### PR TITLE
chore: community health files, CI, templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,35 @@
+name: Bug Report
+description: Report a bug in Genesis
+labels: ["bug", "needs-triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, install method, etc.
+      placeholder: |
+        - OS: Ubuntu 24.04 (Incus container)
+        - Python: 3.12
+        - Genesis version: v3.0a2
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste any error messages or log output
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature Request
+description: Suggest a feature or improvement
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem does this solve? Why do you want it?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should it work? Include examples if possible.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Memory
+        - Dashboard
+        - Runtime
+        - Guardian
+        - Autonomy
+        - Channels (Telegram, Gmail, etc.)
+        - Install / Setup
+        - Other

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+<!-- What does this PR do? Keep it brief. -->
+
+## Changes
+
+<!-- Bullet the key changes. -->
+
+## Testing
+
+<!-- How did you verify this works? -->
+
+- [ ] `ruff check .` passes
+- [ ] `pytest -v` passes
+- [ ] Tested end-to-end (describe how)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install ruff
+        run: pip install ruff
+      - name: Lint
+        run: ruff check .
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]" 2>/dev/null || pip install -e .
+          pip install pytest pytest-asyncio pytest-timeout
+      - name: Run tests
+        run: pytest -v --timeout=30 -x
+        env:
+          GENESIS_TESTING: "1"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# Code of Conduct
+
+## Our pledge
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our standards
+
+**Examples of behavior that contributes to a positive environment:**
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+**Examples of unacceptable behavior:**
+
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting the maintainer directly. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to Genesis
+
+Thanks for your interest in Genesis. This guide covers everything you need to get started.
+
+## Quick start
+
+Genesis runs inside an Incus container. The fastest way to get a dev environment:
+
+```bash
+# On a fresh Linux VM (Ubuntu 22.04+, Debian 13+)
+git clone https://github.com/WingedGuardian/GENesis-AGI.git ~/genesis-setup
+cd ~/genesis-setup
+./scripts/host-setup.sh
+
+# Inside the container
+incus exec genesis --user 1000 --env HOME=/home/ubuntu -- bash
+cd ~/genesis
+source .venv/bin/activate
+```
+
+## Development workflow
+
+```bash
+# Activate the venv (required for all Python work)
+source ~/genesis/.venv/bin/activate
+
+# Lint
+ruff check .
+
+# Run tests
+pytest -v
+
+# Both (run before every commit)
+ruff check . && pytest -v
+```
+
+## Making changes
+
+1. **Fork the repo** and clone your fork
+2. **Create a branch**: `git checkout -b <scope>/<description>` (e.g., `fix/memory-recall-timeout`)
+3. **Make your changes** — target ~600 LOC per file, hard cap 1000
+4. **Run lint + tests**: `ruff check . && pytest -v`
+5. **Commit** with a conventional prefix: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`
+6. **Open a PR** against `main`
+
+## Commit conventions
+
+```
+feat(memory): add semantic deduplication to recall
+fix(dashboard): uptime counter timezone offset
+refactor(routing): extract fallback chain logic
+docs: update install instructions for Debian 13
+test(guardian): add probe timeout coverage
+chore: pin wsproto dependency
+```
+
+Keep the subject line under 72 characters. Scope is optional but helpful.
+
+## Code style
+
+- **Python 3.12** — use modern syntax (type unions with `|`, etc.)
+- **Ruff** for linting and formatting — config is in `pyproject.toml`
+- **No unnecessary abstractions** — three similar lines > a premature helper
+- **Catch specific exceptions** before generic `except Exception`
+- **Log at appropriate levels** — ERROR for operational failures, DEBUG for tracing
+
+## Architecture
+
+The architecture docs in [`docs/architecture/`](docs/architecture/) are the primary reference:
+
+- [`genesis-v3-vision.md`](docs/architecture/genesis-v3-vision.md) — Core philosophy
+- [`genesis-v3-autonomous-behavior-design.md`](docs/architecture/genesis-v3-autonomous-behavior-design.md) — Primary design reference
+- [`genesis-v3-build-phases.md`](docs/architecture/genesis-v3-build-phases.md) — Build plan and phase history
+
+## What to work on
+
+- Issues labeled [`good first issue`](https://github.com/WingedGuardian/GENesis-AGI/labels/good%20first%20issue) are scoped for new contributors
+- Issues labeled [`help wanted`](https://github.com/WingedGuardian/GENesis-AGI/labels/help%20wanted) are open for community contribution
+- Check [Discussions](https://github.com/WingedGuardian/GENesis-AGI/discussions) for ideas and design conversations
+
+## Questions?
+
+Open a [Discussion](https://github.com/WingedGuardian/GENesis-AGI/discussions) — that's the best place for questions, ideas, and design conversations. Issues are for bugs and concrete feature requests.


### PR DESCRIPTION
## Summary

Adds the standard community health files for an open-source project:

- **CONTRIBUTING.md** — dev setup, workflow, commit conventions, code style
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1
- **CI workflow** — `ruff check .` + `pytest -v` on push and PR
- **Issue templates** — bug report and feature request (YAML forms)
- **PR template** — summary, changes, testing checklist

Community health score should jump from 57% to ~85%+.