### PR TITLE
fix(telegram): refuse to start with invalid/empty TELEGRAM_ALLOWED_USERS

### DIFF
--- a/secrets.env.example
+++ b/secrets.env.example
@@ -8,6 +8,10 @@
 
 # ─── Telegram ────────────────────────────────────────────────────────────
 # Required for the Telegram bridge. Create a bot via @BotFather.
+# TELEGRAM_BOT_TOKEN: paste the token from BotFather (format: 123456:ABC-DEF...)
+# TELEGRAM_ALLOWED_USERS: comma-separated numeric user IDs (NOT the bot token).
+#   Get your ID: message @userinfobot on Telegram.
+# TELEGRAM_FORUM_CHAT_ID: optional supergroup chat ID for topic routing (negative number)
 
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_ALLOWED_USERS=

--- a/src/genesis/channels/bridge.py
+++ b/src/genesis/channels/bridge.py
@@ -65,6 +65,14 @@ def _load_bridge_config() -> dict | None:
             elif uid:
                 log.warning("Invalid UID in TELEGRAM_ALLOWED_USERS: %r", uid)
 
+    if not allowed_users:
+        log.error(
+            "TELEGRAM_ALLOWED_USERS is empty or has no valid user IDs — "
+            "Telegram will not start. Set numeric user IDs "
+            "(get yours from @userinfobot on Telegram)"
+        )
+        return None
+
     # Optional forum chat ID for per-session topics
     forum_raw = secrets.get("TELEGRAM_FORUM_CHAT_ID", "")
     forum_chat_id = int(forum_raw) if forum_raw.strip().lstrip("-").isdigit() else None

--- a/src/genesis/dashboard/routes/secrets.py
+++ b/src/genesis/dashboard/routes/secrets.py
@@ -222,6 +222,25 @@ def secrets_update():
             errors.append(f"Value for {key} too long (max 500 chars)")
         if "\n" in val or "\x00" in val:
             errors.append(f"Value for {key} contains invalid characters")
+        # Telegram-specific: ALLOWED_USERS must be numeric IDs
+        if key == "TELEGRAM_ALLOWED_USERS":
+            for uid in val.split(","):
+                uid = uid.strip()
+                if not uid:
+                    continue
+                if ":" in uid:
+                    errors.append(
+                        "TELEGRAM_ALLOWED_USERS looks like a bot token — "
+                        "this field needs numeric user IDs "
+                        "(get yours from @userinfobot on Telegram)"
+                    )
+                    break
+                if not uid.isdigit():
+                    errors.append(
+                        f"TELEGRAM_ALLOWED_USERS: '{uid}' is not a valid "
+                        f"numeric user ID (get yours from @userinfobot)"
+                    )
+                    break
     if errors:
         return jsonify({"error": "Validation failed", "details": errors}), 422
 

--- a/tests/test_channels/test_bridge_wiring.py
+++ b/tests/test_channels/test_bridge_wiring.py
@@ -29,12 +29,27 @@ def test_load_bridge_config_parses_values(secrets_file):
 
 
 def test_load_bridge_config_defaults(secrets_file):
-    secrets_file.write_text('TELEGRAM_BOT_TOKEN=tok\n')
+    secrets_file.write_text('TELEGRAM_BOT_TOKEN=tok\nTELEGRAM_ALLOWED_USERS=123\n')
     config = _load_bridge_config()
     assert config["token"] == "tok"
-    assert config["allowed_users"] == set()
+    assert config["allowed_users"] == {123}
     assert config["whisper_model"] == "whisper-large-v3"
     assert config["day_boundary_hour"] == 0
+
+
+def test_load_bridge_config_empty_users_returns_none(secrets_file):
+    """Token set but no allowed users → None (refuses to start)."""
+    secrets_file.write_text('TELEGRAM_BOT_TOKEN=tok\n')
+    assert _load_bridge_config() is None
+
+
+def test_load_bridge_config_invalid_uids_returns_none(secrets_file):
+    """Token set but allowed_users contains non-numeric values → None."""
+    secrets_file.write_text(
+        'TELEGRAM_BOT_TOKEN=tok\n'
+        'TELEGRAM_ALLOWED_USERS=123456:ABC-token\n'
+    )
+    assert _load_bridge_config() is None
 
 
 def test_load_bridge_config_missing_token_returns_none(secrets_file):


### PR DESCRIPTION
## Summary

- **Refuse to start** Telegram adapter when `TELEGRAM_ALLOWED_USERS` is empty or contains no valid numeric IDs — previously the bot would start silently and allow messages from _all_ users (security issue)
- **Dashboard validation** rejects `TELEGRAM_ALLOWED_USERS` values that look like a bot token (contain `:`) or aren't numeric, with a clear error pointing to `@userinfobot`
- **secrets.env.example** now documents the expected format for each Telegram field

## Background

A user configured `TELEGRAM_BOT_TOKEN` correctly but accidentally put the bot token value into `TELEGRAM_ALLOWED_USERS`. The system logged a quiet WARNING and started the bot with zero allowed users. Empty `allowed_users` in `_handler_context.py` means allow-all — so the bot was effectively open to anyone.

## Test plan

- [ ] `pytest tests/test_channels/test_bridge_wiring.py -v` — 7 tests pass (2 new: empty users → None, invalid UIDs → None)
- [ ] Dashboard PUT `/api/genesis/secrets` with `TELEGRAM_ALLOWED_USERS=123:abc` returns 422
- [ ] Server started with token but no allowed users logs ERROR and skips Telegram (dashboard-only mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)