### PR TITLE
fix(readme): explicit anchors for roadmap + get-involved links

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,8 @@ All phases complete. See [`docs/journey/`](docs/journey/) for the build story.
 
 ---
 
+<a id="where-its-headed"></a>
+
 ## Where it's headed 🗺️
 
 V3 is the foundation — complete, tested, running in production. What comes next is where it gets ambitious enough to need a community behind it.
@@ -558,6 +560,8 @@ The complete design lives in [`docs/architecture/`](docs/architecture/):
 - [`genesis-v3-resilience-architecture.md`](docs/architecture/genesis-v3-resilience-architecture.md) — Resilience layer design
 
 ---
+
+<a id="get-involved"></a>
 
 ## Get involved 🤝
 


### PR DESCRIPTION
## Summary

The \`[roadmap](#where-its-headed)\` and \`[come build with us](#get-involved)\` links near the top of the README silently bounce to the top of the page because the target headings contain trailing emoji (🗺️, 🤝). GitHub's slugger includes the emoji codepoints in the generated anchor ids, so \`#where-its-headed\` and \`#get-involved\` don't resolve.

Adds explicit \`<a id="...">\` anchors immediately before each heading. The existing link text and the heading content are unchanged.

## Test plan
- [ ] Click \`[roadmap](#where-its-headed)\` in the first paragraphs → jumps to "Where it's headed 🗺️"
- [ ] Click \`[come build with us](#get-involved)\` → jumps to "Get involved 🤝"
- [ ] Click the "Contributors Welcome" badge → jumps to "Get involved 🤝"