### PR TITLE
fix: update checker uses correct upstream remote

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -35,6 +35,24 @@ echo ""
 echo "  Genesis Update"
 echo "  ──────────────────────────────────────"
 
+# ── Resolve upstream remote ────────────────────────────────
+# Use the remote pointing to github_public_repo (e.g. 'public' for GENesis-AGI).
+# Falls back to 'origin' if detection fails or genesis.env is unavailable.
+_detect_update_remote() {
+    local public_repo
+    public_repo=$(
+        "$VENV_DIR/bin/python" -c \
+        "from genesis.env import github_public_repo; print(github_public_repo())" \
+        2>/dev/null
+    ) || public_repo="GENesis-AGI"
+    local remote
+    remote=$(git -C "$GENESIS_ROOT" remote -v 2>/dev/null \
+        | awk "/$public_repo.*fetch/{print \$1; exit}")
+    echo "${remote:-origin}"
+}
+UPDATE_REMOTE="$(_detect_update_remote)"
+echo "  Update remote: $UPDATE_REMOTE"
+
 # ── Current state ─────────────────────────────────────────
 ORIGINAL_BRANCH=$(git -C "$GENESIS_ROOT" symbolic-ref --short HEAD 2>/dev/null || echo "main")
 OLD_TAG=$(git -C "$GENESIS_ROOT" describe --tags --abbrev=0 2>/dev/null || echo "untagged")
@@ -254,7 +272,7 @@ trap _on_err ERR
 
 # ── Pull ──────────────────────────────────────────────────
 echo "--- Pulling latest ---"
-git -C "$GENESIS_ROOT" pull --rebase origin main
+git -C "$GENESIS_ROOT" pull --rebase "$UPDATE_REMOTE" main
 NEW_TAG=$(git -C "$GENESIS_ROOT" describe --tags --abbrev=0 2>/dev/null || echo "untagged")
 NEW_COMMIT=$(git -C "$GENESIS_ROOT" rev-parse --short HEAD)
 

--- a/src/genesis/dashboard/routes/updates.py
+++ b/src/genesis/dashboard/routes/updates.py
@@ -34,6 +34,24 @@ def _git(*args: str, timeout: int = 10) -> str | None:
         return None
 
 
+def _update_remote() -> str:
+    """Return the git remote that points to the public/primary repo.
+
+    Reads github.public_repo from genesis.env (e.g. 'GENesis-AGI') and finds
+    the matching remote. Falls back to 'origin' if detection fails.
+    """
+    try:
+        from genesis.env import github_public_repo
+        public_repo = github_public_repo()
+        output = _git("remote", "-v") or ""
+        for line in output.splitlines():
+            if public_repo in line and "(fetch)" in line:
+                return line.split()[0]
+    except Exception:
+        pass
+    return "origin"
+
+
 def _query_db(sql: str, params: tuple = ()) -> list[dict]:
     """Run a read-only query against genesis.db. Returns list of row dicts."""
     if not _DB_PATH.is_file():
@@ -104,26 +122,24 @@ def update_status():
 @blueprint.route("/api/genesis/updates/check", methods=["POST"])
 def update_check():
     """Force an upstream check (git fetch + compare)."""
+    remote = _update_remote()
     # git fetch produces no stdout on success; None means the command failed
-    if _git("fetch", "origin", "main", timeout=30) is None:
+    if _git("fetch", remote, "main", timeout=30) is None:
         return jsonify({"error": "git fetch failed"}), 502
 
+    ref = f"{remote}/main"
     # Count commits behind
-    behind_str = _git("rev-list", "--count", "HEAD..origin/main")
+    behind_str = _git("rev-list", "--count", f"HEAD..{ref}")
     commits_behind = int(behind_str) if behind_str and behind_str.isdigit() else 0
 
     target_tag = None
     if commits_behind > 0:
-        target_tag = _git(
-            "describe", "--tags", "--abbrev=0", "origin/main"
-        )
+        target_tag = _git("describe", "--tags", "--abbrev=0", ref)
 
     # Summary of what changed
     summary = None
     if commits_behind > 0:
-        summary = _git(
-            "log", "--oneline", "--no-merges", "HEAD..origin/main",
-        )
+        summary = _git("log", "--oneline", "--no-merges", f"HEAD..{ref}")
 
     return jsonify({
         "commits_behind": commits_behind,

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -691,7 +691,20 @@
           try {
             const resp = await fetchApi("/api/genesis/updates/check", { method: "POST" });
             if (resp && resp.ok) {
+              const data = await resp.json();
+              // Refresh current_version / last_update fields from DB
               await this.fetchUpdateStatus();
+              // Overlay the fresh check result — DB observation may be stale
+              if (this.updateStatus) {
+                this.updateStatus = {
+                  ...this.updateStatus,
+                  update_available: data.commits_behind > 0 ? {
+                    commits_behind: data.commits_behind,
+                    target_tag: data.target_tag,
+                    summary: data.summary,
+                  } : null,
+                };
+              }
             } else {
               alert("Check failed — could not reach upstream");
             }
@@ -6297,8 +6310,10 @@
                         Install Update</button>
                     </template>
                     <button @click="$store.genesisDashboard.checkForUpdates()"
-                            style="background:var(--color-accent); color:#000; border:none; padding:0.4rem 0.8rem; border-radius:4px; cursor:pointer; font-size:0.8rem;">
-                      Check for Updates</button>
+                            :disabled="$store.genesisDashboard._checkingForUpdates"
+                            style="background:var(--color-accent); color:#000; border:none; padding:0.4rem 0.8rem; border-radius:4px; cursor:pointer; font-size:0.8rem;"
+                            :style="$store.genesisDashboard._checkingForUpdates ? 'opacity:0.6;cursor:not-allowed' : ''">
+                      <span x-text="$store.genesisDashboard._checkingForUpdates ? 'Checking...' : 'Check for Updates'"></span></button>
                   </div>
                 </div>
                 <div style="display:flex; gap:1.5rem; flex-wrap:wrap; margin-bottom:0.5rem;">

--- a/src/genesis/learning/signals/genesis_version.py
+++ b/src/genesis/learning/signals/genesis_version.py
@@ -47,6 +47,29 @@ def _load_updates_config() -> dict:
     return {"check": {"enabled": True, "interval_hours": 6}}
 
 
+def _update_remote() -> str:
+    """Return the git remote that points to the public/primary repo.
+
+    Reads github.public_repo from genesis.env and matches it against
+    'git remote -v'. Falls back to 'origin' if detection fails.
+    """
+    import subprocess
+    try:
+        from genesis.env import github_public_repo
+        public_repo = github_public_repo()
+        result = subprocess.run(
+            ["git", "-C", str(_GENESIS_ROOT), "remote", "-v"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                if public_repo in line and "(fetch)" in line:
+                    return line.split()[0]
+    except Exception:
+        pass
+    return "origin"
+
+
 class GenesisVersionCollector:
     """Detects Genesis version changes and available upstream updates.
 
@@ -186,16 +209,17 @@ class GenesisVersionCollector:
         return stdout.decode().strip()
 
     async def _check_upstream(self) -> tuple[int, str]:
-        """Fetch origin/main and return (commits_behind, summary).
+        """Fetch the upstream primary remote and return (commits_behind, summary).
 
-        Returns (0, "") only when origin/main is reachable AND we are
-        up to date. Raises RuntimeError on git failure (network down,
-        auth failure, missing remote) so the caller can log the error
-        properly — silent failures hide broken state.
+        Uses the remote pointing to github_public_repo() (e.g. 'public'),
+        falling back to 'origin'. Raises RuntimeError on git failure.
         """
+        remote = _update_remote()
+        ref = f"{remote}/main"
+
         # Fetch (updates remote refs, doesn't change working tree)
         proc = await asyncio.create_subprocess_exec(
-            "git", "fetch", "origin", "main",
+            "git", "fetch", remote, "main",
             cwd=str(_GENESIS_ROOT),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -204,12 +228,12 @@ class GenesisVersionCollector:
         if proc.returncode != 0:
             stderr_text = stderr.decode(errors="replace").strip()
             raise RuntimeError(
-                f"git fetch origin main failed (exit {proc.returncode}): {stderr_text}"
+                f"git fetch {remote} main failed (exit {proc.returncode}): {stderr_text}"
             )
 
         # Count commits behind
         proc = await asyncio.create_subprocess_exec(
-            "git", "rev-list", "--count", "HEAD..origin/main",
+            "git", "rev-list", "--count", f"HEAD..{ref}",
             cwd=str(_GENESIS_ROOT),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -227,7 +251,7 @@ class GenesisVersionCollector:
 
         # Get summary of what's new
         proc = await asyncio.create_subprocess_exec(
-            "git", "log", "--oneline", "HEAD..origin/main",
+            "git", "log", "--oneline", f"HEAD..{ref}",
             cwd=str(_GENESIS_ROOT),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,


### PR DESCRIPTION
## Summary

- Both the dashboard Check-for-Updates endpoint and the background `GenesisVersionCollector` hardcoded `git fetch origin main`. For installs with a dual-remote setup (e.g. private fork + public remote), `origin` may point to the wrong repo, causing the update checker to always report up-to-date.
- `update.sh` had the same bug — `git pull --rebase origin main` would pull from the wrong remote.
- `checkForUpdates()` in the dashboard discarded the response body and re-read stale DB observations, so the "Install Update" button would never appear even when behind.

## Changes

- Add `_update_remote()` to `updates.py`, `genesis_version.py`, and `update.sh` — detects the remote whose URL matches `github_public_repo()` from `genesis.env`, falls back to `origin`. For standard installs (cloned from GENesis-AGI), `origin` matches and the fallback is a no-op.
- Fix `checkForUpdates()` to overlay `update_available` directly from the fresh check response instead of relying on DB observations.
- Add disabled/loading state to the Check for Updates button while checking.

## Test plan

- [ ] Fresh clone from GENesis-AGI: `origin` matches `GENesis-AGI`, `_update_remote()` returns `origin` — no behaviour change
- [ ] Click "Check for Updates" — button shows "Checking...", disables during request, shows update info after
- [ ] If behind: "Install Update" button appears immediately after check (no longer requires background recon to update DB first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)