### PR TITLE
feat(updates): merge-based update system with three-tier CC escalation

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -19,6 +19,73 @@ echo "=== Genesis Bootstrap ==="
 echo "Genesis root: $GENESIS_ROOT"
 echo
 
+# ── Crash recovery: check for interrupted update ─────────
+UPDATE_STATE="$HOME/.genesis/update_state.json"
+if [ -f "$UPDATE_STATE" ]; then
+    echo "--- Detected interrupted update state file ---"
+    # Read phase and PID from state file
+    STATE_PHASE=$(python3 -c "import json,sys; print(json.load(open('$UPDATE_STATE')).get('phase','unknown'))" 2>/dev/null || echo "unknown")
+    STATE_PID=$(python3 -c "import json,sys; print(json.load(open('$UPDATE_STATE')).get('pid',0))" 2>/dev/null || echo "0")
+
+    # Check if the update process is still alive
+    if [ "$STATE_PID" -gt 1 ] 2>/dev/null && kill -0 "$STATE_PID" 2>/dev/null; then
+        echo "  Update process (pid $STATE_PID) still running in phase '$STATE_PHASE' — not interfering."
+    elif [ "$STATE_PHASE" = "done" ]; then
+        echo "  Update completed successfully — cleaning up state file."
+        rm -f "$UPDATE_STATE"
+    else
+        echo "  Update CRASHED in phase '$STATE_PHASE' (pid $STATE_PID is dead)."
+
+        # Abort any in-progress merge
+        if [ -f "$GENESIS_ROOT/.git/MERGE_HEAD" ]; then
+            echo "  Aborting in-progress merge..."
+            git -C "$GENESIS_ROOT" merge --abort 2>/dev/null || true
+        fi
+
+        # Read rollback tag from state file
+        ROLLBACK_TAG=$(python3 -c "import json,sys; print(json.load(open('$UPDATE_STATE')).get('rollback_tag',''))" 2>/dev/null || echo "")
+
+        if [ -n "$ROLLBACK_TAG" ] && git -C "$GENESIS_ROOT" rev-parse "$ROLLBACK_TAG" >/dev/null 2>&1; then
+            echo "  Rolling back to $ROLLBACK_TAG..."
+            git -C "$GENESIS_ROOT" reset --hard "$ROLLBACK_TAG" 2>&1 || true
+            echo "  Rollback complete."
+        else
+            echo "  No rollback tag found — resetting to HEAD."
+            git -C "$GENESIS_ROOT" reset --hard HEAD 2>&1 || true
+        fi
+
+        # Record crash recovery
+        echo "  Recording crash recovery in update_history..."
+        DB_PATH="$GENESIS_ROOT/data/genesis.db"
+        if [ -f "$DB_PATH" ]; then
+            python3 -c "
+import sqlite3, uuid, json
+from datetime import datetime, timezone
+state = json.load(open('$UPDATE_STATE'))
+try:
+    con = sqlite3.connect('$DB_PATH', timeout=5)
+    con.execute(
+        'INSERT INTO update_history (id, old_tag, new_tag, old_commit, new_commit, status, '
+        'rollback_tag, failure_reason, started_at, completed_at) '
+        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        (str(uuid.uuid4()), state.get('old_tag',''), '', state.get('old_commit',''), '',
+         'crashed_recovered', state.get('rollback_tag',''),
+         f\"Crashed in phase: {state.get('phase','unknown')}\",
+         state.get('started_at',''), datetime.now(timezone.utc).isoformat()))
+    con.commit()
+    con.close()
+except Exception as e:
+    print(f'  WARNING: failed to record crash recovery: {e}')
+" 2>/dev/null || echo "  WARNING: could not record crash in update_history"
+        fi
+
+        rm -f "$UPDATE_STATE"
+        rm -f "$HOME/.genesis/update_in_progress.pid"
+        echo "  Crash recovery complete. Continuing bootstrap with rolled-back code."
+        echo ""
+    fi
+fi
+
 # --- Prerequisites ---
 echo "--- Checking and installing prerequisites ---"
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -122,19 +122,24 @@ if [[ "$POST_MERGE" == "true" ]] && [ -f "$STATE_FILE" ]; then
         git -C "$GENESIS_ROOT" tag "$ROLLBACK_TAG"
         echo "  Post-merge mode: created fallback rollback tag $ROLLBACK_TAG"
     fi
-    # Also recover OLD_TAG / OLD_COMMIT for correct update_history recording
-    OLD_TAG=$(
+    # Also recover OLD_TAG / OLD_COMMIT for correct update_history recording.
+    # Capture to temp vars and only assign if non-empty so that a JSON parse
+    # failure (malformed state file) does not silently blank out the existing
+    # values and corrupt the update_history record.
+    _saved_old_tag=$(
         GH_STATE_FILE="$STATE_FILE" \
         "$VENV_DIR/bin/python" -c \
-        "import json, os; print(json.load(open(os.environ['GH_STATE_FILE'])).get('old_tag','$OLD_TAG'))" \
+        "import json, os; print(json.load(open(os.environ['GH_STATE_FILE'])).get('old_tag',''))" \
         2>/dev/null
     ) || true
-    OLD_COMMIT=$(
+    [ -n "$_saved_old_tag" ] && OLD_TAG="$_saved_old_tag"
+    _saved_old_commit=$(
         GH_STATE_FILE="$STATE_FILE" \
         "$VENV_DIR/bin/python" -c \
-        "import json, os; print(json.load(open(os.environ['GH_STATE_FILE'])).get('old_commit','$OLD_COMMIT'))" \
+        "import json, os; print(json.load(open(os.environ['GH_STATE_FILE'])).get('old_commit',''))" \
         2>/dev/null
     ) || true
+    [ -n "$_saved_old_commit" ] && OLD_COMMIT="$_saved_old_commit"
 else
     git -C "$GENESIS_ROOT" tag "$ROLLBACK_TAG"
     echo "  Rollback tag: $ROLLBACK_TAG"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -12,9 +12,17 @@
 #   - update_history table written on success + failure
 #   - Writes failure context for CC-assisted recovery
 #
-# Usage: ./scripts/update.sh
+# Usage: ./scripts/update.sh [--post-merge]
+#   --post-merge  Skip fetch/merge (code already merged by CC conflict resolution);
+#                 run only bootstrap, migrations, health check, and service restart.
 
 set -euo pipefail
+
+# ── Flag parsing ─────────────────────────────────────────
+POST_MERGE=false
+for _arg in "$@"; do
+    [[ "$_arg" == "--post-merge" ]] && POST_MERGE=true
+done
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 GENESIS_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -96,8 +104,41 @@ fi
 
 # ── Rollback tag ─────────────────────────────────────────
 ROLLBACK_TAG="pre-update-$(date +%Y%m%d-%H%M%S)"
-git -C "$GENESIS_ROOT" tag "$ROLLBACK_TAG"
-echo "  Rollback tag: $ROLLBACK_TAG"
+if [[ "$POST_MERGE" == "true" ]] && [ -f "$STATE_FILE" ]; then
+    # In post-merge mode, the original pre-update rollback tag is in the state
+    # file (written by the initial update.sh run before the merge attempt).
+    # Reusing it ensures rollback still lands on pre-merge code, not merged code.
+    _saved_rt=$(
+        GH_STATE_FILE="$STATE_FILE" \
+        "$VENV_DIR/bin/python" -c \
+        "import json, os; print(json.load(open(os.environ['GH_STATE_FILE'])).get('rollback_tag',''))" \
+        2>/dev/null
+    ) || _saved_rt=""
+    if [ -n "$_saved_rt" ] && git -C "$GENESIS_ROOT" rev-parse "$_saved_rt" >/dev/null 2>&1; then
+        ROLLBACK_TAG="$_saved_rt"
+        echo "  Post-merge mode: reusing rollback tag $ROLLBACK_TAG"
+    else
+        # Original tag missing — tag current (merged) HEAD as fallback
+        git -C "$GENESIS_ROOT" tag "$ROLLBACK_TAG"
+        echo "  Post-merge mode: created fallback rollback tag $ROLLBACK_TAG"
+    fi
+    # Also recover OLD_TAG / OLD_COMMIT for correct update_history recording
+    OLD_TAG=$(
+        GH_STATE_FILE="$STATE_FILE" \
+        "$VENV_DIR/bin/python" -c \
+        "import json, os; print(json.load(open(os.environ['GH_STATE_FILE'])).get('old_tag','$OLD_TAG'))" \
+        2>/dev/null
+    ) || true
+    OLD_COMMIT=$(
+        GH_STATE_FILE="$STATE_FILE" \
+        "$VENV_DIR/bin/python" -c \
+        "import json, os; print(json.load(open(os.environ['GH_STATE_FILE'])).get('old_commit','$OLD_COMMIT'))" \
+        2>/dev/null
+    ) || true
+else
+    git -C "$GENESIS_ROOT" tag "$ROLLBACK_TAG"
+    echo "  Rollback tag: $ROLLBACK_TAG"
+fi
 echo ""
 
 _write_state "fetching"
@@ -131,14 +172,13 @@ _stop_genesis_server() {
 }
 
 _start_genesis_server() {
-    # Try systemctl first
     if systemctl --user start genesis-server.service 2>/dev/null; then
         return 0
     fi
-    # Fallback: start directly
-    nohup "$VENV_DIR/bin/python" -m genesis serve --host 0.0.0.0 --port 5000 \
-        >> /tmp/genesis-server.log 2>&1 &
-    echo "  Started genesis-server (pid $!)"
+    # Genesis is always deployed with systemd — no nohup fallback.
+    echo "  ERROR: systemctl --user start genesis-server.service failed."
+    echo "         Check: systemctl --user status genesis-server.service"
+    return 1
 }
 
 # ── Stop services for update ──────────────────────────────
@@ -314,22 +354,36 @@ _do_rollback() {
     echo "  Reason: $reason"
     [ -n "$degraded" ] && echo "  Degraded subsystems: $degraded"
 
-    # Write failure context for CC to pick up
+    # Write failure context for CC to pick up.
+    # Use Python json.dumps to safely handle special chars in $reason / $BASH_COMMAND.
     mkdir -p "$HOME/.genesis"
-    cat > "$HOME/.genesis/last_update_failure.json" << FAILEOF
-{
-    "old_tag": "$OLD_TAG",
-    "new_tag": "$NEW_TAG",
-    "old_commit": "$OLD_COMMIT",
-    "new_commit": "$NEW_COMMIT",
-    "rollback_tag": "$ROLLBACK_TAG",
-    "reason": "$reason",
-    "degraded_subsystems": "$degraded",
-    "original_branch": "$ORIGINAL_BRANCH",
-    "rollback_complete": $([ "$checkout_ok" = "true" ] && [ "$pip_ok" = "true" ] && echo true || echo false),
-    "timestamp": "$(date -Iseconds)"
+    GH_OLD_TAG="$OLD_TAG" \
+    GH_NEW_TAG="$NEW_TAG" \
+    GH_OLD_COMMIT="$OLD_COMMIT" \
+    GH_NEW_COMMIT="$NEW_COMMIT" \
+    GH_ROLLBACK_TAG="$ROLLBACK_TAG" \
+    GH_REASON="$reason" \
+    GH_DEGRADED="$degraded" \
+    GH_ORIGINAL_BRANCH="$ORIGINAL_BRANCH" \
+    GH_ROLLBACK_COMPLETE="$([ "$checkout_ok" = "true" ] && [ "$pip_ok" = "true" ] && echo true || echo false)" \
+    "$VENV_DIR/bin/python" -c "
+import json, os
+from datetime import datetime, timezone
+data = {
+    'old_tag': os.environ['GH_OLD_TAG'],
+    'new_tag': os.environ['GH_NEW_TAG'],
+    'old_commit': os.environ['GH_OLD_COMMIT'],
+    'new_commit': os.environ['GH_NEW_COMMIT'],
+    'rollback_tag': os.environ['GH_ROLLBACK_TAG'],
+    'reason': os.environ['GH_REASON'],
+    'degraded_subsystems': os.environ['GH_DEGRADED'],
+    'original_branch': os.environ['GH_ORIGINAL_BRANCH'],
+    'rollback_complete': os.environ['GH_ROLLBACK_COMPLETE'] == 'true',
+    'timestamp': datetime.now(timezone.utc).isoformat(),
 }
-FAILEOF
+with open(os.path.expanduser('~/.genesis/last_update_failure.json'), 'w') as _f:
+    json.dump(data, _f, indent=4)
+" 2>/dev/null || echo "  WARNING: failed to write failure context"
 
     echo ""
     echo "  ──────────────────────────────────────"
@@ -346,88 +400,109 @@ _on_err() {
 }
 trap _on_err ERR
 
-_write_state "merging"
+if [[ "$POST_MERGE" == "false" ]]; then
+    _write_state "merging"
 
-# ── Fetch + Merge ────────────────────────────────────────
-echo "--- Fetching latest ---"
-git -C "$GENESIS_ROOT" fetch "$UPDATE_REMOTE" main
+    # ── Fetch + Merge ────────────────────────────────────────
+    echo "--- Fetching latest ---"
+    git -C "$GENESIS_ROOT" fetch "$UPDATE_REMOTE" main
 
-echo "--- Merging $UPDATE_REMOTE/main ---"
-MERGE_OUTPUT=""
-MERGE_RC=0
-MERGE_OUTPUT=$(git -C "$GENESIS_ROOT" merge "$UPDATE_REMOTE/main" --no-edit 2>&1) || MERGE_RC=$?
+    echo "--- Merging $UPDATE_REMOTE/main ---"
+    MERGE_OUTPUT=""
+    MERGE_RC=0
+    MERGE_OUTPUT=$(git -C "$GENESIS_ROOT" merge "$UPDATE_REMOTE/main" --no-edit 2>&1) || MERGE_RC=$?
 
-if [[ $MERGE_RC -ne 0 ]]; then
-    # Check if this is a merge conflict (unmerged paths) vs other error
-    if git -C "$GENESIS_ROOT" diff --name-only --diff-filter=U 2>/dev/null | grep -q .; then
-        CONFLICTED_FILES=$(git -C "$GENESIS_ROOT" diff --name-only --diff-filter=U)
-        echo "  Merge conflicts detected in:"
-        echo "$CONFLICTED_FILES" | sed 's/^/    /'
+    if [[ $MERGE_RC -ne 0 ]]; then
+        # Check if this is a merge conflict (unmerged paths) vs other error
+        if git -C "$GENESIS_ROOT" diff --name-only --diff-filter=U 2>/dev/null | grep -q .; then
+            CONFLICTED_FILES=$(git -C "$GENESIS_ROOT" diff --name-only --diff-filter=U)
+            echo "  Merge conflicts detected in:"
+            echo "$CONFLICTED_FILES" | sed 's/^/    /'
 
-        # Write conflict context for supervising CC session
-        mkdir -p "$HOME/.genesis"
-        # Build JSON array of conflicted files
-        CONFLICT_JSON=$(echo "$CONFLICTED_FILES" | awk '{printf "\"%s\",", $0}' | sed 's/,$//')
-        cat > "$HOME/.genesis/update_conflicts.json" << CEOF
-{
-    "old_tag": "$OLD_TAG",
-    "old_commit": "$OLD_COMMIT",
-    "target_tag": "$(git -C "$GENESIS_ROOT" describe --tags --match 'v*' --abbrev=0 "$UPDATE_REMOTE/main" 2>/dev/null || echo 'untagged')",
-    "target_commit": "$(git -C "$GENESIS_ROOT" rev-parse --short "$UPDATE_REMOTE/main" 2>/dev/null || echo 'unknown')",
-    "conflicted_files": [$CONFLICT_JSON],
-    "merge_output": "$(echo "$MERGE_OUTPUT" | head -20 | sed 's/"/\\"/g')",
-    "timestamp": "$(date -Iseconds)"
+            # Write conflict context for supervising CC session.
+            # Use Python json.dumps to safely handle special chars in filenames
+            # and git output without JSON injection.
+            mkdir -p "$HOME/.genesis"
+            GH_OLD_TAG="$OLD_TAG" \
+            GH_OLD_COMMIT="$OLD_COMMIT" \
+            GH_TARGET_TAG="$(git -C "$GENESIS_ROOT" describe --tags --match 'v*' --abbrev=0 "$UPDATE_REMOTE/main" 2>/dev/null || echo 'untagged')" \
+            GH_TARGET_COMMIT="$(git -C "$GENESIS_ROOT" rev-parse --short "$UPDATE_REMOTE/main" 2>/dev/null || echo 'unknown')" \
+            GH_CONFLICTED_FILES="$CONFLICTED_FILES" \
+            GH_MERGE_OUTPUT="$(echo "$MERGE_OUTPUT" | head -20)" \
+            "$VENV_DIR/bin/python" -c "
+import json, os
+from datetime import datetime, timezone
+data = {
+    'old_tag': os.environ['GH_OLD_TAG'],
+    'old_commit': os.environ['GH_OLD_COMMIT'],
+    'target_tag': os.environ['GH_TARGET_TAG'],
+    'target_commit': os.environ['GH_TARGET_COMMIT'],
+    'conflicted_files': [f for f in os.environ['GH_CONFLICTED_FILES'].split('\n') if f],
+    'merge_output': os.environ['GH_MERGE_OUTPUT'],
+    'timestamp': datetime.now(timezone.utc).isoformat(),
 }
-CEOF
-        echo ""
-        echo "  Conflict context written to ~/.genesis/update_conflicts.json"
+with open(os.path.expanduser('~/.genesis/update_conflicts.json'), 'w') as _f:
+    json.dump(data, _f, indent=4)
+" 2>/dev/null || echo "  WARNING: failed to write conflict context"
 
-        # Abort the merge — don't leave the working tree in a broken state.
-        # CC will resolve conflicts in a worktree, not in the main checkout.
-        echo "  Aborting merge to keep working tree clean..."
-        git -C "$GENESIS_ROOT" merge --abort 2>/dev/null || true
+            echo ""
+            echo "  Conflict context written to ~/.genesis/update_conflicts.json"
 
-        # Restart services with original code so the system stays operational
-        echo "  Restarting services with pre-update code..."
+            # Abort the merge — don't leave the working tree in a broken state.
+            # CC will resolve conflicts in a worktree, not in the main checkout.
+            echo "  Aborting merge to keep working tree clean..."
+            git -C "$GENESIS_ROOT" merge --abort 2>/dev/null || true
+
+            # Restart services with original code so the system stays operational
+            echo "  Restarting services with pre-update code..."
+            for svc in "${WERE_RUNNING[@]}"; do
+                if [ "$svc" = "genesis-server" ]; then
+                    _start_genesis_server || echo "  WARNING: failed to restart genesis-server"
+                else
+                    systemctl --user start "$svc.service" 2>/dev/null || \
+                        echo "  WARNING: failed to restart $svc"
+                fi
+            done
+
+            echo "  System is running on pre-update code."
+            echo "  A CC session will resolve conflicts in a worktree."
+            trap - ERR
+            exit 2
+        else
+            # Not a conflict — some other merge error. Let ERR trap handle rollback.
+            echo "  Merge failed: $MERGE_OUTPUT"
+            false  # triggers ERR trap → rollback
+        fi
+    fi
+
+    NEW_TAG=$(git -C "$GENESIS_ROOT" describe --tags --match 'v*' --abbrev=0 2>/dev/null || echo "untagged")
+    NEW_COMMIT=$(git -C "$GENESIS_ROOT" rev-parse --short HEAD)
+
+    if [[ "$OLD_COMMIT" == "$NEW_COMMIT" ]]; then
+        echo "  Already up to date ($NEW_COMMIT)."
+        # Clean up unnecessary rollback tag and disarm trap
+        trap - ERR
+        git -C "$GENESIS_ROOT" tag -d "$ROLLBACK_TAG" 2>/dev/null || true
+        # Restart services that we stopped (if any)
         for svc in "${WERE_RUNNING[@]}"; do
             if [ "$svc" = "genesis-server" ]; then
-                _start_genesis_server || echo "  WARNING: failed to restart genesis-server"
+                _start_genesis_server || true
             else
-                systemctl --user start "$svc.service" 2>/dev/null || \
-                    echo "  WARNING: failed to restart $svc"
+                systemctl --user start "$svc.service" 2>/dev/null || true
             fi
         done
-
-        echo "  System is running on pre-update code."
-        echo "  A CC session will resolve conflicts in a worktree."
-        trap - ERR
-        exit 2
-    else
-        # Not a conflict — some other merge error. Let ERR trap handle rollback.
-        echo "  Merge failed: $MERGE_OUTPUT"
-        false  # triggers ERR trap → rollback
+        echo ""
+        echo "  Nothing to do."
+        exit 0
     fi
-fi
+fi  # end: [[ "$POST_MERGE" == "false" ]]
 
 NEW_TAG=$(git -C "$GENESIS_ROOT" describe --tags --match 'v*' --abbrev=0 2>/dev/null || echo "untagged")
 NEW_COMMIT=$(git -C "$GENESIS_ROOT" rev-parse --short HEAD)
 
-if [[ "$OLD_COMMIT" == "$NEW_COMMIT" ]]; then
-    echo "  Already up to date ($NEW_COMMIT)."
-    # Clean up unnecessary rollback tag and disarm trap
-    trap - ERR
-    git -C "$GENESIS_ROOT" tag -d "$ROLLBACK_TAG" 2>/dev/null || true
-    # Restart services that we stopped (if any)
-    for svc in "${WERE_RUNNING[@]}"; do
-        if [ "$svc" = "genesis-server" ]; then
-            _start_genesis_server || true
-        else
-            systemctl --user start "$svc.service" 2>/dev/null || true
-        fi
-    done
-    echo ""
-    echo "  Nothing to do."
-    exit 0
+if [[ "$POST_MERGE" == "true" ]]; then
+    echo "--- Post-merge mode: running bootstrap on conflict-resolved code ---"
+    echo "  Merged: $OLD_TAG ($OLD_COMMIT) → $NEW_TAG ($NEW_COMMIT)"
 fi
 echo ""
 
@@ -616,8 +691,9 @@ _write_state "done"
 
 # Clean up state file — successful update, nothing to recover
 rm -f "$STATE_FILE"
-# Clean up PID file
-rm -f "$HOME/.genesis/update_in_progress.pid"
+# Note: update_in_progress.pid is owned by the Python orchestration layer
+# (_spawn_cc in updates.py) and is cleaned up in its finally block.
+# update.sh must not remove it — the CC session that's running us is still live.
 
 # ── Done ──────────────────────────────────────────────────
 echo "  ──────────────────────────────────────"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -20,6 +20,26 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 GENESIS_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 VENV_DIR="$GENESIS_ROOT/.venv"
 STARTED_AT="$(date -Iseconds)"
+STATE_FILE="$HOME/.genesis/update_state.json"
+
+# ── Update state file helper ────────────────────────────
+# Written at each phase boundary so crash recovery knows where we stopped.
+_write_state() {
+    local phase="$1"
+    mkdir -p "$HOME/.genesis"
+    cat > "$STATE_FILE" << SEOF
+{
+    "phase": "$phase",
+    "rollback_tag": "${ROLLBACK_TAG:-}",
+    "old_tag": "${OLD_TAG:-}",
+    "old_commit": "${OLD_COMMIT:-}",
+    "started_at": "$STARTED_AT",
+    "pid": $$,
+    "services_stopped": [$(printf '"%s",' "${WERE_RUNNING[@]:-}" | sed 's/,$//')],
+    "timestamp": "$(date -Iseconds)"
+}
+SEOF
+}
 
 # Refuse to run from a worktree — pip install -e in bootstrap.sh would
 # redirect system-wide imports and cause I/O death spiral.
@@ -55,7 +75,7 @@ echo "  Update remote: $UPDATE_REMOTE"
 
 # ── Current state ─────────────────────────────────────────
 ORIGINAL_BRANCH=$(git -C "$GENESIS_ROOT" symbolic-ref --short HEAD 2>/dev/null || echo "main")
-OLD_TAG=$(git -C "$GENESIS_ROOT" describe --tags --abbrev=0 2>/dev/null || echo "untagged")
+OLD_TAG=$(git -C "$GENESIS_ROOT" describe --tags --match 'v*' --abbrev=0 2>/dev/null || echo "untagged")
 OLD_COMMIT=$(git -C "$GENESIS_ROOT" rev-parse --short HEAD)
 NEW_TAG="$OLD_TAG"
 NEW_COMMIT="$OLD_COMMIT"
@@ -80,15 +100,66 @@ git -C "$GENESIS_ROOT" tag "$ROLLBACK_TAG"
 echo "  Rollback tag: $ROLLBACK_TAG"
 echo ""
 
+_write_state "fetching"
+
+# ── Service stop/start helpers ───────────────────────────
+# Works with both systemd and bare-process environments.
+_stop_genesis_server() {
+    # Try systemctl first (works when D-Bus session bus is available)
+    if systemctl --user is-active --quiet genesis-server.service 2>/dev/null; then
+        systemctl --user stop genesis-server.service 2>/dev/null && return 0
+    fi
+    # Fallback: read PID from fcntl lock file
+    local lock_file="$HOME/.genesis/genesis-server.lock"
+    if [ -f "$lock_file" ]; then
+        local pid
+        pid=$(tr -d '\0' < "$lock_file" 2>/dev/null)
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            kill -TERM "$pid" 2>/dev/null
+            # Wait up to 10s for graceful shutdown
+            for i in $(seq 1 20); do
+                kill -0 "$pid" 2>/dev/null || return 0
+                sleep 0.5
+            done
+            kill -KILL "$pid" 2>/dev/null || true
+            return 0
+        fi
+    fi
+    # Last resort: pkill by command pattern
+    pkill -TERM -f "python -m genesis serve" 2>/dev/null || true
+    sleep 1
+}
+
+_start_genesis_server() {
+    # Try systemctl first
+    if systemctl --user start genesis-server.service 2>/dev/null; then
+        return 0
+    fi
+    # Fallback: start directly
+    nohup "$VENV_DIR/bin/python" -m genesis serve --host 0.0.0.0 --port 5000 \
+        >> /tmp/genesis-server.log 2>&1 &
+    echo "  Started genesis-server (pid $!)"
+}
+
 # ── Stop services for update ──────────────────────────────
 echo "--- Stopping services for update ---"
 WERE_RUNNING=()
-for svc in genesis-server genesis-bridge; do
+
+# Check genesis-server
+if systemctl --user is-active --quiet genesis-server.service 2>/dev/null || \
+   pgrep -f "python -m genesis serve" >/dev/null 2>&1; then
+    _stop_genesis_server
+    WERE_RUNNING+=("genesis-server")
+fi
+
+# Check genesis-bridge
+for svc in genesis-bridge; do
     if systemctl --user is-active --quiet "$svc.service" 2>/dev/null; then
-        systemctl --user stop "$svc.service" || true  # stop failure shouldn't block rollback setup
+        systemctl --user stop "$svc.service" || true
         WERE_RUNNING+=("$svc")
     fi
 done
+
 [[ ${#WERE_RUNNING[@]} -gt 0 ]] && echo "  Stopped: ${WERE_RUNNING[*]}" || echo "  No services were running"
 echo ""
 
@@ -194,7 +265,8 @@ _do_rollback() {
     echo "  Rolling back to $ROLLBACK_TAG..."
 
     # Stop any running services first
-    systemctl --user stop genesis-server genesis-bridge 2>/dev/null || true
+    _stop_genesis_server
+    systemctl --user stop genesis-bridge 2>/dev/null || true
 
     # Restore the original branch, then reset it to the rollback tag.
     # This keeps us on a named branch (not detached HEAD) at the pre-update state.
@@ -219,8 +291,12 @@ _do_rollback() {
 
     # Restart services with old code
     for svc in "${WERE_RUNNING[@]}"; do
-        systemctl --user start "$svc.service" 2>/dev/null || \
-            echo "  CRITICAL: failed to restart $svc"
+        if [ "$svc" = "genesis-server" ]; then
+            _start_genesis_server || echo "  CRITICAL: failed to restart genesis-server"
+        else
+            systemctl --user start "$svc.service" 2>/dev/null || \
+                echo "  CRITICAL: failed to restart $svc"
+        fi
     done
 
     if [ "$checkout_ok" = "true" ] && [ "$pip_ok" = "true" ]; then
@@ -270,10 +346,70 @@ _on_err() {
 }
 trap _on_err ERR
 
-# ── Pull ──────────────────────────────────────────────────
-echo "--- Pulling latest ---"
-git -C "$GENESIS_ROOT" pull --rebase "$UPDATE_REMOTE" main
-NEW_TAG=$(git -C "$GENESIS_ROOT" describe --tags --abbrev=0 2>/dev/null || echo "untagged")
+_write_state "merging"
+
+# ── Fetch + Merge ────────────────────────────────────────
+echo "--- Fetching latest ---"
+git -C "$GENESIS_ROOT" fetch "$UPDATE_REMOTE" main
+
+echo "--- Merging $UPDATE_REMOTE/main ---"
+MERGE_OUTPUT=""
+MERGE_RC=0
+MERGE_OUTPUT=$(git -C "$GENESIS_ROOT" merge "$UPDATE_REMOTE/main" --no-edit 2>&1) || MERGE_RC=$?
+
+if [[ $MERGE_RC -ne 0 ]]; then
+    # Check if this is a merge conflict (unmerged paths) vs other error
+    if git -C "$GENESIS_ROOT" diff --name-only --diff-filter=U 2>/dev/null | grep -q .; then
+        CONFLICTED_FILES=$(git -C "$GENESIS_ROOT" diff --name-only --diff-filter=U)
+        echo "  Merge conflicts detected in:"
+        echo "$CONFLICTED_FILES" | sed 's/^/    /'
+
+        # Write conflict context for supervising CC session
+        mkdir -p "$HOME/.genesis"
+        # Build JSON array of conflicted files
+        CONFLICT_JSON=$(echo "$CONFLICTED_FILES" | awk '{printf "\"%s\",", $0}' | sed 's/,$//')
+        cat > "$HOME/.genesis/update_conflicts.json" << CEOF
+{
+    "old_tag": "$OLD_TAG",
+    "old_commit": "$OLD_COMMIT",
+    "target_tag": "$(git -C "$GENESIS_ROOT" describe --tags --match 'v*' --abbrev=0 "$UPDATE_REMOTE/main" 2>/dev/null || echo 'untagged')",
+    "target_commit": "$(git -C "$GENESIS_ROOT" rev-parse --short "$UPDATE_REMOTE/main" 2>/dev/null || echo 'unknown')",
+    "conflicted_files": [$CONFLICT_JSON],
+    "merge_output": "$(echo "$MERGE_OUTPUT" | head -20 | sed 's/"/\\"/g')",
+    "timestamp": "$(date -Iseconds)"
+}
+CEOF
+        echo ""
+        echo "  Conflict context written to ~/.genesis/update_conflicts.json"
+
+        # Abort the merge — don't leave the working tree in a broken state.
+        # CC will resolve conflicts in a worktree, not in the main checkout.
+        echo "  Aborting merge to keep working tree clean..."
+        git -C "$GENESIS_ROOT" merge --abort 2>/dev/null || true
+
+        # Restart services with original code so the system stays operational
+        echo "  Restarting services with pre-update code..."
+        for svc in "${WERE_RUNNING[@]}"; do
+            if [ "$svc" = "genesis-server" ]; then
+                _start_genesis_server || echo "  WARNING: failed to restart genesis-server"
+            else
+                systemctl --user start "$svc.service" 2>/dev/null || \
+                    echo "  WARNING: failed to restart $svc"
+            fi
+        done
+
+        echo "  System is running on pre-update code."
+        echo "  A CC session will resolve conflicts in a worktree."
+        trap - ERR
+        exit 2
+    else
+        # Not a conflict — some other merge error. Let ERR trap handle rollback.
+        echo "  Merge failed: $MERGE_OUTPUT"
+        false  # triggers ERR trap → rollback
+    fi
+fi
+
+NEW_TAG=$(git -C "$GENESIS_ROOT" describe --tags --match 'v*' --abbrev=0 2>/dev/null || echo "untagged")
 NEW_COMMIT=$(git -C "$GENESIS_ROOT" rev-parse --short HEAD)
 
 if [[ "$OLD_COMMIT" == "$NEW_COMMIT" ]]; then
@@ -283,7 +419,11 @@ if [[ "$OLD_COMMIT" == "$NEW_COMMIT" ]]; then
     git -C "$GENESIS_ROOT" tag -d "$ROLLBACK_TAG" 2>/dev/null || true
     # Restart services that we stopped (if any)
     for svc in "${WERE_RUNNING[@]}"; do
-        systemctl --user start "$svc.service" 2>/dev/null || true
+        if [ "$svc" = "genesis-server" ]; then
+            _start_genesis_server || true
+        else
+            systemctl --user start "$svc.service" 2>/dev/null || true
+        fi
     done
     echo ""
     echo "  Nothing to do."
@@ -295,6 +435,8 @@ echo ""
 echo "--- Changes ---"
 git -C "$GENESIS_ROOT" log "${OLD_COMMIT}..HEAD" --oneline --no-merges | head -20 || true
 echo ""
+
+_write_state "bootstrap"
 
 # ── Run bootstrap (idempotent — handles deps, configs, hooks, systemd) ─
 echo "--- Running bootstrap ---"
@@ -309,6 +451,8 @@ if ! "$VENV_DIR/bin/python" -c "from genesis.runtime import GenesisRuntime" 2>/d
 fi
 echo "  Genesis importable: OK"
 echo ""
+
+_write_state "migrations"
 
 # ── Run migrations (fatal on failure) ─────────────────────
 if "$VENV_DIR/bin/python" -c "import genesis.db.migrations" 2>/dev/null; then
@@ -351,6 +495,8 @@ if p.exists():
     echo ""
 fi
 
+_write_state "health_check"
+
 # ── Restart services ──────────────────────────────────────
 if [[ ${#WERE_RUNNING[@]} -gt 0 ]]; then
     echo "--- Restarting services ---"
@@ -359,7 +505,12 @@ if [[ ${#WERE_RUNNING[@]} -gt 0 ]]; then
     systemctl --user daemon-reload 2>/dev/null || true
 
     for svc in "${WERE_RUNNING[@]}"; do
-        if ! systemctl --user start "$svc.service"; then
+        if [ "$svc" = "genesis-server" ]; then
+            if ! _start_genesis_server; then
+                _do_rollback "failed to start genesis-server after update"
+                exit 1
+            fi
+        elif ! systemctl --user start "$svc.service"; then
             _do_rollback "failed to start $svc after update"
             exit 1
         fi
@@ -460,6 +611,13 @@ fi
 
 # ── Record success in update_history ─────────────────────
 _record_update_history "success" "" ""
+
+_write_state "done"
+
+# Clean up state file — successful update, nothing to recover
+rm -f "$STATE_FILE"
+# Clean up PID file
+rm -f "$HOME/.genesis/update_in_progress.pid"
 
 # ── Done ──────────────────────────────────────────────────
 echo "  ──────────────────────────────────────"

--- a/src/genesis/dashboard/routes/updates.py
+++ b/src/genesis/dashboard/routes/updates.py
@@ -34,24 +34,6 @@ def _git(*args: str, timeout: int = 10) -> str | None:
         return None
 
 
-def _update_remote() -> str:
-    """Return the git remote that points to the public/primary repo.
-
-    Reads github.public_repo from genesis.env (e.g. 'GENesis-AGI') and finds
-    the matching remote. Falls back to 'origin' if detection fails.
-    """
-    try:
-        from genesis.env import github_public_repo
-        public_repo = github_public_repo()
-        output = _git("remote", "-v") or ""
-        for line in output.splitlines():
-            if public_repo in line and "(fetch)" in line:
-                return line.split()[0]
-    except Exception:
-        pass
-    return "origin"
-
-
 def _query_db(sql: str, params: tuple = ()) -> list[dict]:
     """Run a read-only query against genesis.db. Returns list of row dicts."""
     if not _DB_PATH.is_file():
@@ -69,8 +51,8 @@ def _query_db(sql: str, params: tuple = ()) -> list[dict]:
 @blueprint.route("/api/genesis/updates/status")
 def update_status():
     """Current version, update availability, and last update result."""
-    # Current version
-    tag = _git("describe", "--tags", "--always") or "unknown"
+    # Current version — only match release tags (v*), not backup/pre-update tags
+    tag = _git("describe", "--tags", "--match", "v*", "--always") or "unknown"
     commit = _git("rev-parse", "--short", "HEAD") or "unknown"
 
     # Check for unresolved update_available observations
@@ -121,29 +103,46 @@ def update_status():
 
 @blueprint.route("/api/genesis/updates/check", methods=["POST"])
 def update_check():
-    """Force an upstream check (git fetch + compare)."""
-    remote = _update_remote()
-    # git fetch produces no stdout on success; None means the command failed
-    if _git("fetch", remote, "main", timeout=30) is None:
+    """Force an upstream check (git fetch + tag comparison)."""
+    # Fetch with tags so we can compare release versions
+    if _git("fetch", "origin", "main", "--tags", timeout=30) is None:
         return jsonify({"error": "git fetch failed"}), 502
 
-    ref = f"{remote}/main"
-    # Count commits behind
-    behind_str = _git("rev-list", "--count", f"HEAD..{ref}")
-    commits_behind = int(behind_str) if behind_str and behind_str.isdigit() else 0
+    # Compare release tags (robust against squash-merge divergence)
+    local_tag = _git("describe", "--tags", "--match", "v*", "--abbrev=0", "HEAD")
+    origin_tag = _git(
+        "describe", "--tags", "--match", "v*", "--abbrev=0", "origin/main"
+    )
 
-    target_tag = None
-    if commits_behind > 0:
-        target_tag = _git("describe", "--tags", "--abbrev=0", ref)
+    if local_tag and origin_tag and local_tag == origin_tag:
+        # Same release tag — up to date
+        return jsonify({
+            "commits_behind": 0,
+            "local_tag": local_tag,
+            "target_tag": None,
+            "summary": None,
+        })
 
-    # Summary of what changed
+    # Different tags or no tags — count commits and build summary
+    commits_behind = 0
     summary = None
-    if commits_behind > 0:
-        summary = _git("log", "--oneline", "--no-merges", f"HEAD..{ref}")
+
+    if local_tag and origin_tag:
+        # Count between tags (meaningful range, ignores squash noise)
+        behind_str = _git("rev-list", "--count", f"{local_tag}..{origin_tag}")
+        commits_behind = int(behind_str) if behind_str and behind_str.isdigit() else 1
+        summary = _git("log", "--oneline", "--no-merges", f"{local_tag}..{origin_tag}")
+    else:
+        # Fallback to commit-based when tags are missing
+        behind_str = _git("rev-list", "--count", "HEAD..origin/main")
+        commits_behind = int(behind_str) if behind_str and behind_str.isdigit() else 0
+        if commits_behind > 0:
+            summary = _git("log", "--oneline", "--no-merges", "HEAD..origin/main")
 
     return jsonify({
         "commits_behind": commits_behind,
-        "target_tag": target_tag,
+        "local_tag": local_tag or "untagged",
+        "target_tag": origin_tag if local_tag != origin_tag else None,
         "summary": summary,
     })
 
@@ -198,50 +197,159 @@ def _apply_direct(pid_file: Path) -> tuple:
         return jsonify({"error": str(exc)}), 500
 
 
-_UPDATE_PROMPT = """\
-You are managing a Genesis self-update. Run the update script and supervise the outcome.
+# ── Three-tier CC update prompts ─────────────────────────────────────
+
+_TIER1_PROMPT = """\
+You are supervising a Genesis update. Your role is WATCH AND ESCALATE.
 
 1. Run: bash {update_script} 2>&1
-   Capture and review the full output.
+   Capture the FULL output and the exit code.
 
 2. If exit 0 (success):
-   - Verify health endpoint responds: curl -sf http://localhost:5000/api/genesis/health
-   - Verify Genesis is importable: python -c "from genesis.runtime import GenesisRuntime"
-   - Check version changed: git describe --tags --always
-   - If verification passes, report success.
-   - If anything is off, diagnose and fix.
+   - Verify: curl -sf http://localhost:5000/api/genesis/health
+   - Verify: python -c "from genesis.runtime import GenesisRuntime"
+   - Check version: git -C {genesis_root} describe --tags --match 'v*' --always
+   - Write result to {summary_file} (e.g., "success: v3.0a3 -> v3.0a4")
+   - Done.
 
-3. If exit non-zero (failure/rollback):
-   - Read {failure_file} for structured failure context.
-   - Diagnose the root cause.
-   - If it's a targeted fix (missing column, import error, config mismatch),
-     apply the fix and retry the update.
-   - If you can't resolve it confidently, write a clear diagnostic report and stop.
+3. If exit 2 (merge conflicts):
+   - Read {conflict_file} for the list of conflicted files
+   - Write to {summary_file}: "conflicts: <file list>"
+   - Write to {escalation_file}: "tier2_needed"
+   - Done. Do NOT attempt to resolve conflicts yourself.
 
-4. Any fixes you commit should use conventional commit format (fix: ...).
+4. If exit 1 (script error):
+   - Read the error output. If it's a simple retry (network timeout,
+     temp file issue, pip cache), retry ONCE.
+   - If retry succeeds, continue from step 2.
+   - If retry fails or the error is not trivially retryable:
+     Write to {escalation_file}: "tier2_needed"
+     Write error context to {summary_file}
+   - Done. Do NOT attempt code changes.
 
-5. When done, write a one-line summary to {summary_file} with the outcome
-   (e.g., "success: updated v3.0a3 -> v3.0a4" or "failed: <reason>").
-
-Use mechanical judgment: targeted fixes yes, architectural decisions no.
-If in doubt, stop and report rather than guessing.\
+You are a security guard, not an engineer. Press buttons, report status,
+call for backup when needed.\
 """
+
+_TIER2_PROMPT = """\
+You are resolving merge conflicts from a Genesis update.
+
+Read {summary_file} and {conflict_file} for context.
+
+IMPORTANT: The main working tree is CLEAN — the merge was aborted so the
+system stays operational. You must resolve conflicts in a temporary branch.
+
+If MERGE CONFLICTS:
+1. Create a temporary branch: git checkout -b update-merge-resolution
+2. Redo the merge: git merge origin/main --no-edit
+   (This will reproduce the same conflicts)
+3. For each conflicted file, read BOTH sides of every conflict marker
+4. Evaluate: are the changes compatible? (same intent, just different history)
+5. If ALL conflicts in a file are trivially compatible — resolve them:
+   - git checkout --theirs for upstream-only changes
+   - git checkout --ours for user-only changes
+   - Manual merge where both sides add different things
+6. After resolving each file: git add <file>
+7. If ANY conflict is ambiguous or involves genuinely different intents:
+   - git merge --abort to clean up
+   - git checkout main
+   - git branch -D update-merge-resolution
+   - Write to {escalation_file}: "tier3_needed"
+   - Include: which files, what the incompatibility is, your assessment
+   - Done.
+8. If all conflicts resolved:
+   - git commit --no-edit
+   - git checkout main
+   - git merge update-merge-resolution --ff-only
+   - git branch -d update-merge-resolution
+   - Run: bash {update_script} 2>&1
+     (update.sh will see the code is merged and run bootstrap + health)
+
+If SCRIPT ERROR:
+1. Diagnose the root cause from the error output
+2. If fixable (missing dep, config mismatch, import error): fix and retry
+3. If not fixable: write report to {summary_file}, write "tier3_needed"
+   to {escalation_file}, done
+
+Commit any fixes with conventional format (fix: ...).
+Write final outcome to {summary_file}.
+Log every action taken for user review.\
+"""
+
+_TIER3_PROMPT = """\
+You are resolving deep merge conflicts from a Genesis update.
+
+Read {escalation_file} for Sonnet's analysis of what couldn't be resolved.
+
+IMPORTANT: The main working tree is CLEAN. Work on a temporary branch.
+
+1. git checkout -b update-merge-resolution-opus
+2. git merge origin/main --no-edit (reproduces conflicts)
+3. For each conflict, understand the intent of BOTH sides:
+   - LOCAL (ours): user customizations, additions, local config
+   - REMOTE (theirs): upstream bug fixes, features, improvements
+4. Find the resolution that preserves both intents
+5. Where intents genuinely conflict:
+   - Bug fixes and security patches: upstream wins
+   - User identity, config, customizations: user wins
+   - Feature additions: merge both, adapting as needed
+6. After resolving: git add, git commit --no-edit
+7. git checkout main && git merge update-merge-resolution-opus --ff-only
+8. git branch -d update-merge-resolution-opus
+9. Run: bash {update_script} 2>&1
+
+Write a resolution report to {summary_file} explaining each decision.
+Use conventional commit format for any fixes (fix: ...).\
+"""
+
+# Files used for inter-tier communication
+_GENESIS_DIR = _HOME / ".genesis"
+_SUMMARY_FILE = _GENESIS_DIR / "last_update_summary.txt"
+_ESCALATION_FILE = _GENESIS_DIR / "update_escalation.txt"
+_CONFLICT_FILE = _GENESIS_DIR / "update_conflicts.json"
 
 
 def _apply_supervised(pid_file: Path) -> tuple:
-    """Spawn a background CC session to run and supervise the update."""
-    summary_file = _HOME / ".genesis" / "last_update_summary.txt"
-    prompt = _UPDATE_PROMPT.format(
-        update_script=_UPDATE_SCRIPT,
-        failure_file=_FAILURE_FILE,
-        summary_file=summary_file,
-    )
+    """Spawn a three-tier CC update pipeline.
 
+    Tier 1 (Haiku): runs update.sh, watches exit code, escalates if needed.
+    Tier 2 (Sonnet): resolves trivial conflicts or script errors.
+    Tier 3 (Opus): resolves deep merge conflicts requiring judgment.
+
+    Orchestration runs in a background thread so the API returns immediately.
+    Each tier checks for escalation files left by the previous tier.
+    """
+    import threading
+
+    _GENESIS_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Clean up stale escalation/summary files from prior runs
+    for f in (_SUMMARY_FILE, _ESCALATION_FILE):
+        f.unlink(missing_ok=True)
+
+    def _run_tiers():
+        try:
+            _run_tier1(pid_file)
+        except Exception:
+            logger.error("Update orchestrator failed", exc_info=True)
+
+    thread = threading.Thread(target=_run_tiers, daemon=True, name="update-orchestrator")
+    thread.start()
+
+    return jsonify({
+        "status": "triggered",
+        "supervised": True,
+        "tier": 1,
+    })
+
+
+def _spawn_cc(prompt: str, model: str, pid_file: Path) -> int:
+    """Spawn a CC session and wait for it to complete. Returns exit code."""
     try:
         proc = subprocess.Popen(
             [
                 "claude", "-p", prompt,
-                "--model", "sonnet",
+                "--model", model,
                 "--dangerously-skip-permissions",
             ],
             stdout=subprocess.DEVNULL,
@@ -251,14 +359,163 @@ def _apply_supervised(pid_file: Path) -> tuple:
         )
         pid_file.parent.mkdir(parents=True, exist_ok=True)
         pid_file.write_text(str(proc.pid))
-        logger.info("CC-supervised update triggered (pid %d)", proc.pid)
-        return jsonify({
-            "status": "triggered",
-            "pid": proc.pid,
-            "supervised": True,
-        })
+        logger.info("CC %s session started (pid %d)", model, proc.pid)
+        proc.wait()  # Block until CC finishes
+        return proc.returncode
     except Exception as exc:
-        logger.error("Failed to spawn CC update session: %s", exc, exc_info=True)
-        # Fall back to direct update
-        logger.info("Falling back to direct update")
-        return _apply_direct(pid_file)
+        logger.error("Failed to spawn CC session: %s", exc, exc_info=True)
+        return 1
+
+
+def _run_tier1(pid_file: Path) -> None:
+    """Tier 1: Haiku watches update.sh and escalates if needed."""
+    prompt = _TIER1_PROMPT.format(
+        update_script=_UPDATE_SCRIPT,
+        genesis_root=_GENESIS_ROOT,
+        summary_file=_SUMMARY_FILE,
+        escalation_file=_ESCALATION_FILE,
+        conflict_file=_CONFLICT_FILE,
+    )
+
+    rc = _spawn_cc(prompt, "haiku", pid_file)
+    logger.info("Tier 1 (Haiku) completed with rc=%d", rc)
+
+    # Check if escalation is needed
+    if _ESCALATION_FILE.is_file():
+        escalation = _ESCALATION_FILE.read_text().strip()
+        if "tier2_needed" in escalation:
+            logger.info("Tier 1 escalated to Tier 2 (Sonnet)")
+            _ESCALATION_FILE.unlink(missing_ok=True)
+            _run_tier2(pid_file)
+
+
+def _run_tier2(pid_file: Path) -> None:
+    """Tier 2: Sonnet resolves trivial conflicts or script errors."""
+    prompt = _TIER2_PROMPT.format(
+        summary_file=_SUMMARY_FILE,
+        conflict_file=_CONFLICT_FILE,
+        escalation_file=_ESCALATION_FILE,
+        update_script=_UPDATE_SCRIPT,
+    )
+
+    rc = _spawn_cc(prompt, "sonnet", pid_file)
+    logger.info("Tier 2 (Sonnet) completed with rc=%d", rc)
+
+    # Check if further escalation is needed
+    if _ESCALATION_FILE.is_file():
+        escalation = _ESCALATION_FILE.read_text().strip()
+        if "tier3_needed" in escalation:
+            logger.info("Tier 2 escalated to Tier 3 (Opus) — notifying user")
+            _notify_tier3_needed()
+
+
+def _run_tier3(pid_file: Path) -> None:
+    """Tier 3: Opus resolves deep merge conflicts. User-initiated only."""
+    prompt = _TIER3_PROMPT.format(
+        escalation_file=_ESCALATION_FILE,
+        summary_file=_SUMMARY_FILE,
+        update_script=_UPDATE_SCRIPT,
+    )
+
+    rc = _spawn_cc(prompt, "opus", pid_file)
+    logger.info("Tier 3 (Opus) completed with rc=%d", rc)
+
+
+def _notify_tier3_needed() -> None:
+    """Notify user that deep conflicts need Opus-level resolution."""
+    try:
+        # Write a summary for the dashboard to pick up
+        _SUMMARY_FILE.write_text(
+            "conflicts_unresolved: Deep merge conflicts require Opus resolution. "
+            "Use 'Resolve with Opus' from the dashboard."
+        )
+
+        logger.info(
+            "Update has deep conflicts needing Opus resolution. "
+            "User should use dashboard 'Resolve with Opus' button."
+        )
+    except Exception:
+        logger.error("Failed to send tier3 notification", exc_info=True)
+
+
+@blueprint.route("/api/genesis/updates/resolve", methods=["POST"])
+def update_resolve():
+    """User-initiated Tier 3 (Opus) conflict resolution."""
+    if not _ESCALATION_FILE.is_file():
+        return jsonify({"error": "No escalation pending"}), 404
+
+    escalation = _ESCALATION_FILE.read_text().strip()
+    if "tier3_needed" not in escalation:
+        return jsonify({"error": "No Tier 3 escalation pending"}), 404
+
+    pid_file = _HOME / ".genesis" / "update_in_progress.pid"
+
+    # Check if something is already running
+    if pid_file.is_file():
+        try:
+            old_pid = int(pid_file.read_text().strip())
+            result = subprocess.run(["kill", "-0", str(old_pid)],
+                                    capture_output=True, timeout=2)
+            if result.returncode == 0:
+                return jsonify({
+                    "error": "Update session already in progress",
+                    "pid": old_pid,
+                }), 409
+            pid_file.unlink(missing_ok=True)
+        except (ValueError, subprocess.TimeoutExpired, OSError):
+            pid_file.unlink(missing_ok=True)
+
+    import threading
+
+    def _run():
+        try:
+            _run_tier3(pid_file)
+        except Exception:
+            logger.error("Tier 3 (Opus) failed", exc_info=True)
+
+    thread = threading.Thread(target=_run, daemon=True, name="update-tier3")
+    thread.start()
+
+    return jsonify({
+        "status": "triggered",
+        "supervised": True,
+        "tier": 3,
+    })
+
+
+@blueprint.route("/api/genesis/updates/progress")
+def update_progress():
+    """Poll update progress — reads summary and escalation files."""
+    summary = None
+    if _SUMMARY_FILE.is_file():
+        summary = _SUMMARY_FILE.read_text().strip()
+
+    escalation = None
+    if _ESCALATION_FILE.is_file():
+        escalation = _ESCALATION_FILE.read_text().strip()
+
+    conflicts = None
+    if _CONFLICT_FILE.is_file():
+        import contextlib as _ctxlib
+
+        with _ctxlib.suppress(json.JSONDecodeError, OSError):
+            conflicts = json.loads(_CONFLICT_FILE.read_text())
+
+    # Check if an update process is still running
+    pid_file = _HOME / ".genesis" / "update_in_progress.pid"
+    in_progress = False
+    if pid_file.is_file():
+        try:
+            pid = int(pid_file.read_text().strip())
+            result = subprocess.run(["kill", "-0", str(pid)],
+                                    capture_output=True, timeout=2)
+            in_progress = result.returncode == 0
+        except (ValueError, subprocess.TimeoutExpired, OSError):
+            pass
+
+    return jsonify({
+        "in_progress": in_progress,
+        "summary": summary,
+        "escalation": escalation,
+        "conflicts": conflicts,
+    })

--- a/src/genesis/dashboard/routes/updates.py
+++ b/src/genesis/dashboard/routes/updates.py
@@ -7,6 +7,7 @@ import json
 import logging
 import sqlite3
 import subprocess
+import threading
 from pathlib import Path
 
 from flask import jsonify, request
@@ -14,6 +15,14 @@ from flask import jsonify, request
 from genesis.dashboard._blueprint import blueprint
 
 logger = logging.getLogger(__name__)
+
+# ── Orchestrator state ────────────────────────────────────────────────────────
+# Tracks whether a supervised CC update pipeline is currently running in this
+# process. Used by update_progress() to auto-recover Tier 2 escalation after
+# a Flask restart (daemon thread dies but CC subprocess survives; on the next
+# poll, progress endpoint detects tier2_needed + no live orchestrator → spawns).
+_orchestrator_lock = threading.Lock()
+_orchestrator_alive = False
 
 _HOME = Path.home()
 _GENESIS_ROOT = _HOME / "genesis"
@@ -262,8 +271,8 @@ If MERGE CONFLICTS:
    - git checkout main
    - git merge update-merge-resolution --ff-only
    - git branch -d update-merge-resolution
-   - Run: bash {update_script} 2>&1
-     (update.sh will see the code is merged and run bootstrap + health)
+   - Run: bash {update_script} --post-merge 2>&1
+     (skips re-merge, runs bootstrap + migrations + health on resolved code)
 
 If SCRIPT ERROR:
 1. Diagnose the root cause from the error output
@@ -296,7 +305,8 @@ IMPORTANT: The main working tree is CLEAN. Work on a temporary branch.
 6. After resolving: git add, git commit --no-edit
 7. git checkout main && git merge update-merge-resolution-opus --ff-only
 8. git branch -d update-merge-resolution-opus
-9. Run: bash {update_script} 2>&1
+9. Run: bash {update_script} --post-merge 2>&1
+   (skips re-merge, runs bootstrap + migrations + health on resolved code)
 
 Write a resolution report to {summary_file} explaining each decision.
 Use conventional commit format for any fixes (fix: ...).\
@@ -319,7 +329,7 @@ def _apply_supervised(pid_file: Path) -> tuple:
     Orchestration runs in a background thread so the API returns immediately.
     Each tier checks for escalation files left by the previous tier.
     """
-    import threading
+    global _orchestrator_alive
 
     _GENESIS_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -328,10 +338,16 @@ def _apply_supervised(pid_file: Path) -> tuple:
         f.unlink(missing_ok=True)
 
     def _run_tiers():
+        global _orchestrator_alive
+        _orchestrator_alive = True
         try:
             _run_tier1(pid_file)
         except Exception:
             logger.error("Update orchestrator failed", exc_info=True)
+        finally:
+            _orchestrator_alive = False
+            pid_file.unlink(missing_ok=True)
+            logger.info("Update orchestrator finished, PID file cleaned up")
 
     thread = threading.Thread(target=_run_tiers, daemon=True, name="update-orchestrator")
     thread.start()
@@ -360,7 +376,16 @@ def _spawn_cc(prompt: str, model: str, pid_file: Path) -> int:
         pid_file.parent.mkdir(parents=True, exist_ok=True)
         pid_file.write_text(str(proc.pid))
         logger.info("CC %s session started (pid %d)", model, proc.pid)
-        proc.wait()  # Block until CC finishes
+        try:
+            proc.wait(timeout=3600)
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "CC %s session (pid %d) timed out after 3600s — killing",
+                model, proc.pid,
+            )
+            proc.kill()
+            proc.wait(timeout=30)
+            return 1
         return proc.returncode
     except Exception as exc:
         logger.error("Failed to spawn CC session: %s", exc, exc_info=True)
@@ -465,13 +490,19 @@ def update_resolve():
         except (ValueError, subprocess.TimeoutExpired, OSError):
             pid_file.unlink(missing_ok=True)
 
-    import threading
+    global _orchestrator_alive
 
     def _run():
+        global _orchestrator_alive
+        _orchestrator_alive = True
         try:
             _run_tier3(pid_file)
         except Exception:
             logger.error("Tier 3 (Opus) failed", exc_info=True)
+        finally:
+            _orchestrator_alive = False
+            pid_file.unlink(missing_ok=True)
+            logger.info("Tier 3 (Opus) finished, PID file cleaned up")
 
     thread = threading.Thread(target=_run, daemon=True, name="update-tier3")
     thread.start()
@@ -512,6 +543,48 @@ def update_progress():
             in_progress = result.returncode == 0
         except (ValueError, subprocess.TimeoutExpired, OSError):
             pass
+
+    # ── Escalation recovery after Flask restart ───────────────────────────────
+    # If Flask restarted mid-update (genesis-server was stopped/started by
+    # update.sh), the daemon orchestrator thread died. The CC subprocess
+    # survived (start_new_session=True) and may have written tier2_needed.
+    # When Tier 1 CC exits, the PID goes dead → in_progress=False. On the
+    # next poll we detect tier2_needed + no live orchestrator → auto-spawn.
+    # Tier 3 is intentionally NOT auto-spawned (user must confirm via dashboard).
+    if (
+        escalation
+        and "tier2_needed" in escalation
+        and not in_progress
+        and not _orchestrator_alive
+    ):
+        with _orchestrator_lock:
+            # Double-check inside lock to prevent concurrent double-spawn
+            if not _orchestrator_alive:
+                logger.info(
+                    "Escalation recovery: spawning Tier 2 (orchestrator died, "
+                    "tier2_needed in escalation file)"
+                )
+                _ESCALATION_FILE.unlink(missing_ok=True)
+                _recovery_pid = _HOME / ".genesis" / "update_in_progress.pid"
+
+                def _recover_tier2() -> None:
+                    global _orchestrator_alive
+                    _orchestrator_alive = True
+                    try:
+                        _run_tier2(_recovery_pid)
+                    except Exception:
+                        logger.error("Tier 2 escalation recovery failed", exc_info=True)
+                    finally:
+                        _orchestrator_alive = False
+                        _recovery_pid.unlink(missing_ok=True)
+                        logger.info("Tier 2 recovery finished, PID file cleaned up")
+
+                threading.Thread(
+                    target=_recover_tier2,
+                    daemon=True,
+                    name="update-tier2-recovery",
+                ).start()
+                in_progress = True  # reflect spawned state in this response
 
     return jsonify({
         "in_progress": in_progress,

--- a/src/genesis/dashboard/routes/updates.py
+++ b/src/genesis/dashboard/routes/updates.py
@@ -517,6 +517,7 @@ def update_resolve():
 @blueprint.route("/api/genesis/updates/progress")
 def update_progress():
     """Poll update progress — reads summary and escalation files."""
+    global _orchestrator_alive
     summary = None
     if _SUMMARY_FILE.is_file():
         summary = _SUMMARY_FILE.read_text().strip()
@@ -558,8 +559,12 @@ def update_progress():
         and not _orchestrator_alive
     ):
         with _orchestrator_lock:
-            # Double-check inside lock to prevent concurrent double-spawn
+            # Double-check inside lock to prevent concurrent double-spawn.
+            # Set _orchestrator_alive=True here (while lock is held) so that
+            # a second concurrent poll that acquires the lock next sees the
+            # flag already True before the thread has had a chance to run.
             if not _orchestrator_alive:
+                _orchestrator_alive = True
                 logger.info(
                     "Escalation recovery: spawning Tier 2 (orchestrator died, "
                     "tier2_needed in escalation file)"
@@ -569,7 +574,6 @@ def update_progress():
 
                 def _recover_tier2() -> None:
                     global _orchestrator_alive
-                    _orchestrator_alive = True
                     try:
                         _run_tier2(_recovery_pid)
                     except Exception:

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -145,7 +145,6 @@
         // ── Memory tab state ──────────────────────────────────────
         memorySearch: { query: "", results: [], loading: false },
         memoryRecent: { items: [], total: 0, loading: false },
-        memoryCollectionFilter: "",  // "" = all, "episodic_memory", "knowledge_base"
         memoryStats: {},
         memoryDetail: null,
 
@@ -154,9 +153,11 @@
 
         // ── Update state ─────────────────────────────────────────
         updateStatus: null,
+        updateProgress: null,
         _updating: false,
         _updateReconnecting: false,
         _checkingForUpdates: false,
+        _resolvingConflicts: false,
 
         // ── Settings hub state ────────────────────────────────────
         settingsDomains: null,
@@ -286,7 +287,7 @@
               if (first) { this.fetchMemoryRecent(); this.fetchMemoryStats(); }
               break;
             case "backup":
-              if (first) { this.fetchBackupStatus(); this.fetchUpdateStatus(); }
+              if (first) { this.fetchBackupStatus(); this.fetchUpdateStatus(); this.fetchUpdateProgress(); }
               break;
           }
         },
@@ -311,7 +312,7 @@
           // Check auth status (non-blocking, best-effort)
           this.checkAuth();
 
-          // Always fetch: health, errors, pause (needed on all tabs)
+          // Always fetch: health, errors, pause, update status (needed on all tabs)
           await Promise.all([
             this.fetchHealth(),
             this.fetchErrorSummary(),
@@ -614,11 +615,7 @@
         async fetchMemoryRecent() {
           this.memoryRecent.loading = true;
           try {
-            let url = "/api/genesis/memory/recent?limit=50";
-            if (this.memoryCollectionFilter) {
-              url += "&collection=" + encodeURIComponent(this.memoryCollectionFilter);
-            }
-            const resp = await fetchApi(url);
+            const resp = await fetchApi("/api/genesis/memory/recent?limit=50");
             if (resp && resp.ok) {
               const data = await resp.json();
               this.memoryRecent.items = data.memories || [];
@@ -691,19 +688,18 @@
           try {
             const resp = await fetchApi("/api/genesis/updates/check", { method: "POST" });
             if (resp && resp.ok) {
-              const data = await resp.json();
-              // Refresh current_version / last_update fields from DB
-              await this.fetchUpdateStatus();
-              // Overlay the fresh check result — DB observation may be stale
-              if (this.updateStatus) {
-                this.updateStatus = {
-                  ...this.updateStatus,
-                  update_available: data.commits_behind > 0 ? {
-                    commits_behind: data.commits_behind,
-                    target_tag: data.target_tag,
-                    summary: data.summary,
-                  } : null,
+              const check = await resp.json();
+              // Merge check result into updateStatus directly
+              if (!this.updateStatus) await this.fetchUpdateStatus();
+              if (check.commits_behind > 0) {
+                this.updateStatus.update_available = {
+                  commits_behind: check.commits_behind,
+                  target_tag: check.target_tag,
+                  summary: check.summary,
+                  detected_at: new Date().toISOString(),
                 };
+              } else {
+                this.updateStatus.update_available = null;
               }
             } else {
               alert("Check failed — could not reach upstream");
@@ -711,8 +707,14 @@
           } catch (e) { alert("Check failed: " + e.message); }
           this._checkingForUpdates = false;
         },
+        async fetchUpdateProgress() {
+          try {
+            const resp = await fetchApi("/api/genesis/updates/progress");
+            if (resp && resp.ok) { this.updateProgress = await resp.json(); }
+          } catch (e) { /* server may be down during update */ }
+        },
         async applyUpdate() {
-          const msg = "Apply Genesis update?\n\nA background session will:\n• Back up data\n• Pull latest code\n• Run migrations\n• Restart services\n• Verify health\n\nThe dashboard will be briefly unavailable (~30-60s).\nContinue?";
+          const msg = "Apply Genesis update?\n\nA background session will:\n• Back up data\n• Merge latest code\n• Resolve trivial conflicts automatically\n• Run migrations & restart services\n• Verify health\n\nThe dashboard will be briefly unavailable (~30-60s).\nContinue?";
           if (!confirm(msg)) return;
           this._updating = true;
           try {
@@ -721,13 +723,34 @@
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ supervised: true }),
             });
-          } catch (e) { alert("Apply failed: " + e.message); }
+          } catch (e) { /* expected — server may die before response */ }
+          // Poll progress + health
           this._updateReconnecting = true;
           const start = Date.now();
           const poll = setInterval(async () => {
             try {
+              await this.fetchUpdateProgress();
+              const prog = this.updateProgress;
+              // If progress shows conflicts needing Opus, stop polling and show resolve UI
+              if (prog && prog.escalation && prog.escalation.includes("tier3_needed")) {
+                clearInterval(poll);
+                this._updating = false;
+                this._updateReconnecting = false;
+                await this.fetchUpdateStatus();
+                return;
+              }
+              // If progress shows completion (not in progress, has summary)
+              if (prog && !prog.in_progress && prog.summary && prog.summary.startsWith("success")) {
+                clearInterval(poll);
+                this._updating = false;
+                this._updateReconnecting = false;
+                await this.fetchUpdateStatus();
+                await this.fetchHealth();
+                return;
+              }
+              // Fallback: check health endpoint
               const resp = await fetchApi("/api/genesis/health");
-              if (resp && resp.ok) {
+              if (resp && resp.ok && prog && !prog.in_progress) {
                 clearInterval(poll);
                 this._updating = false;
                 this._updateReconnecting = false;
@@ -735,14 +758,41 @@
                 await this.fetchHealth();
               }
             } catch (e) { /* still down, keep polling */ }
-            if (Date.now() - start > 120000) {
+            if (Date.now() - start > 300000) {
               clearInterval(poll);
               this._updating = false;
               this._updateReconnecting = false;
-              alert("Dashboard did not reconnect after 2 minutes.\nCheck server logs for update status.");
+              alert("Update did not complete after 5 minutes.\nCheck server logs for status.");
               await this.fetchUpdateStatus();
             }
           }, 5000);
+        },
+        async resolveConflicts() {
+          if (!confirm("Spawn an Opus session to resolve deep merge conflicts?\n\nThis may take a few minutes.")) return;
+          this._resolvingConflicts = true;
+          try {
+            const resp = await fetchApi("/api/genesis/updates/resolve", { method: "POST" });
+            if (resp && !resp.ok) {
+              const data = await resp.json();
+              alert("Failed: " + (data.error || "unknown error"));
+              this._resolvingConflicts = false;
+              return;
+            }
+          } catch (e) { /* server may restart */ }
+          // Poll for completion
+          const poll = setInterval(async () => {
+            try {
+              await this.fetchUpdateProgress();
+              if (this.updateProgress && !this.updateProgress.in_progress) {
+                clearInterval(poll);
+                this._resolvingConflicts = false;
+                await this.fetchUpdateStatus();
+                await this.fetchHealth();
+              }
+            } catch (e) { /* keep polling */ }
+          }, 5000);
+          // Safety timeout
+          setTimeout(() => { clearInterval(poll); this._resolvingConflicts = false; }, 600000);
         },
 
         // ── Settings hub fetches ─────────────────────────────────
@@ -2195,6 +2245,7 @@
           if (this.costSemantic().state === "degraded") {
             items.push({ level: "warning", title: "Budget pressure rising", detail: this.costSemantic().reason, href: "#budget-controls", tab: "config", anchor: "budget-controls" });
           }
+          // Update availability
           if (this.updateStatus?.update_available) {
             const u = this.updateStatus.update_available;
             const label = u.target_tag || (u.commits_behind + " commit" + (u.commits_behind === 1 ? "" : "s") + " behind");
@@ -6126,12 +6177,6 @@
               <div style="font-size:1.5rem; font-weight:600;" x-text="$store.genesisDashboard.memoryStats.qdrant_episodic_memory"></div>
             </div>
           </template>
-          <template x-if="$store.genesisDashboard.memoryStats.qdrant_knowledge_base != null">
-            <div class="card" style="flex:1; min-width:120px; padding:0.75rem;">
-              <div style="font-size:0.7rem; color:var(--color-text-secondary);">Qdrant Knowledge</div>
-              <div style="font-size:1.5rem; font-weight:600;" x-text="$store.genesisDashboard.memoryStats.qdrant_knowledge_base"></div>
-            </div>
-          </template>
         </div>
 
         <!-- Search -->
@@ -6186,15 +6231,8 @@
 
         <!-- Recent memories -->
         <div class="card">
-          <div style="padding:0.5rem; font-size:0.8rem; color:var(--color-text-secondary); display:flex; justify-content:space-between; align-items:center;">
-            <span>Recent Memories (<span x-text="$store.genesisDashboard.memoryRecent.total"></span> total)</span>
-            <select x-model="$store.genesisDashboard.memoryCollectionFilter"
-                    @change="$store.genesisDashboard.fetchMemoryRecent()"
-                    style="background:var(--color-bg-primary); border:1px solid var(--color-border); color:var(--color-text-secondary); padding:0.2rem 0.4rem; border-radius:4px; font-size:0.7rem; font-family:inherit;">
-              <option value="">All Collections</option>
-              <option value="episodic_memory">Episodic Memory</option>
-              <option value="knowledge_base">Knowledge Base</option>
-            </select>
+          <div style="padding:0.5rem; font-size:0.8rem; color:var(--color-text-secondary);">
+            Recent Memories (<span x-text="$store.genesisDashboard.memoryRecent.total"></span> total)
           </div>
           <template x-if="$store.genesisDashboard.memoryRecent.loading">
             <div style="padding:1rem; text-align:center; color:var(--color-text-secondary);">Loading...</div>
@@ -6214,14 +6252,148 @@
     </div>
 
     <!-- ═══════════════════════════════════════════════════════════
-         Panel: Backup Monitoring [Tab: backup]
+         Panel: Backup & Updates [Tab: backup]
          ═══════════════════════════════════════════════════════════ -->
     <div class="panel" x-show="$store.genesisDashboard.activeTab === 'backup'">
       <div class="panel-header">
-        <span class="material-symbols-outlined">backup</span>
-        Backup Monitoring
+        <span class="material-symbols-outlined">system_update</span>
+        Backup & Updates
       </div>
       <div class="panel-body">
+
+        <!-- ── Update Section ─────────────────────────────────── -->
+        <div id="update-section" style="margin-bottom:1.5rem;">
+
+          <!-- Updating overlay -->
+          <template x-if="$store.genesisDashboard._updating">
+            <div class="card" style="padding:1.5rem; text-align:center;">
+              <div style="font-size:1.5rem; margin-bottom:0.5rem;">&#8987;</div>
+              <div style="font-size:1rem; font-weight:500;" x-text="$store.genesisDashboard._updateReconnecting ? 'Reconnecting to dashboard...' : 'Update in progress...'"></div>
+              <div style="font-size:0.8rem; color:var(--color-text-secondary); margin-top:0.5rem;">A background session is managing the update. This may take a few minutes.</div>
+              <div style="font-size:0.75rem; color:var(--color-text-secondary); margin-top:0.25rem;">Do not close this tab. You may safely refresh &mdash; progress is saved.</div>
+              <template x-if="$store.genesisDashboard.updateProgress?.summary">
+                <div style="font-size:0.8rem; color:var(--color-text-secondary); margin-top:0.5rem; font-family:monospace;"
+                     x-text="$store.genesisDashboard.updateProgress.summary"></div>
+              </template>
+            </div>
+          </template>
+
+          <!-- Resolving conflicts overlay -->
+          <template x-if="$store.genesisDashboard._resolvingConflicts">
+            <div class="card" style="padding:1.5rem; text-align:center;">
+              <div style="font-size:1.5rem; margin-bottom:0.5rem;">&#128295;</div>
+              <div style="font-size:1rem; font-weight:500;">Opus is resolving merge conflicts...</div>
+              <div style="font-size:0.8rem; color:var(--color-text-secondary); margin-top:0.5rem;">This may take several minutes. The page will update when complete.</div>
+            </div>
+          </template>
+
+          <!-- Normal update UI -->
+          <template x-if="!$store.genesisDashboard._updating && !$store.genesisDashboard._resolvingConflicts">
+            <div>
+              <!-- Version + check/apply -->
+              <div class="card" style="padding:1rem; margin-bottom:1rem;">
+                <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:0.75rem;">
+                  <h3 style="margin:0; font-size:1rem;">Genesis Version</h3>
+                  <div style="display:flex; gap:0.5rem;">
+                    <template x-if="$store.genesisDashboard.updateStatus?.update_available">
+                      <button @click="$store.genesisDashboard.applyUpdate()"
+                              style="background:#2196F3; color:#fff; border:none; padding:0.4rem 0.8rem; border-radius:4px; cursor:pointer; font-size:0.8rem;">
+                        Install Update</button>
+                    </template>
+                    <button @click="$store.genesisDashboard.checkForUpdates()"
+                            :disabled="$store.genesisDashboard._checkingForUpdates"
+                            style="background:var(--color-surface-elevated); color:var(--color-text); border:1px solid var(--color-border); padding:0.4rem 0.8rem; border-radius:4px; cursor:pointer; font-size:0.8rem;">
+                      <span x-text="$store.genesisDashboard._checkingForUpdates ? 'Checking...' : 'Check for Updates'"></span>
+                    </button>
+                  </div>
+                </div>
+
+                <!-- Current version -->
+                <div style="display:flex; gap:1.5rem; flex-wrap:wrap; margin-bottom:0.5rem;">
+                  <div>
+                    <span style="font-size:0.7rem; color:var(--color-text-secondary);">Current</span><br>
+                    <span style="font-size:0.9rem;" x-text="($store.genesisDashboard.updateStatus?.current_version || '...') + ' (' + ($store.genesisDashboard.updateStatus?.current_commit || '...') + ')'"></span>
+                  </div>
+                </div>
+
+                <!-- Update available banner -->
+                <template x-if="$store.genesisDashboard.updateStatus?.update_available">
+                  <div style="margin-top:0.75rem; padding:0.75rem; border-radius:4px; background:rgba(33,150,243,0.1); border:1px solid rgba(33,150,243,0.3);">
+                    <div style="font-size:0.85rem; font-weight:500; color:#2196F3;">
+                      Update available
+                      <span x-text="$store.genesisDashboard.updateStatus.update_available.target_tag ? '  ' + $store.genesisDashboard.updateStatus.update_available.target_tag : ''"></span>
+                    </div>
+                    <div style="font-size:0.8rem; color:var(--color-text-secondary); margin-top:0.25rem;"
+                         x-text="($store.genesisDashboard.updateStatus.update_available.commits_behind || '?') + ' commit(s) behind'"></div>
+                    <template x-if="$store.genesisDashboard.updateStatus.update_available.summary">
+                      <pre style="font-size:0.75rem; color:var(--color-text-secondary); margin-top:0.5rem; max-height:6rem; overflow-y:auto; white-space:pre-wrap; background:transparent; border:none; padding:0;"
+                           x-text="$store.genesisDashboard.updateStatus.update_available.summary"></pre>
+                    </template>
+                  </div>
+                </template>
+
+                <!-- Up to date -->
+                <template x-if="$store.genesisDashboard.updateStatus && !$store.genesisDashboard.updateStatus.update_available">
+                  <div style="margin-top:0.5rem; font-size:0.8rem; color:#81c784;">Up to date</div>
+                </template>
+              </div>
+
+              <!-- Conflicts needing resolution -->
+              <template x-if="$store.genesisDashboard.updateProgress?.escalation?.includes('tier3_needed')">
+                <div class="card" style="padding:1rem; margin-bottom:1rem; border:1px solid rgba(255,152,0,0.4);">
+                  <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:0.75rem;">
+                    <h3 style="margin:0; font-size:1rem; color:#ffb74d;">Merge Conflicts</h3>
+                    <button @click="$store.genesisDashboard.resolveConflicts()"
+                            style="background:#ff9800; color:#fff; border:none; padding:0.4rem 0.8rem; border-radius:4px; cursor:pointer; font-size:0.8rem;">
+                      Resolve with Opus</button>
+                  </div>
+                  <div style="font-size:0.8rem; color:var(--color-text-secondary);">
+                    The update has merge conflicts that couldn't be resolved automatically.
+                    Opus can analyze both sides and find the best resolution.
+                  </div>
+                  <template x-if="$store.genesisDashboard.updateProgress?.conflicts?.conflicted_files">
+                    <div style="margin-top:0.5rem;">
+                      <span style="font-size:0.7rem; color:var(--color-text-secondary);">Conflicted files:</span>
+                      <pre style="font-size:0.75rem; color:#ffb74d; margin-top:0.25rem; white-space:pre-wrap; background:transparent; border:none; padding:0;"
+                           x-text="$store.genesisDashboard.updateProgress.conflicts.conflicted_files.join('\n')"></pre>
+                    </div>
+                  </template>
+                </div>
+              </template>
+
+              <!-- Last update result -->
+              <template x-if="$store.genesisDashboard.updateStatus?.last_update">
+                <div class="card" style="padding:1rem; margin-bottom:1rem;">
+                  <h3 style="margin:0 0 0.75rem 0; font-size:1rem;">Last Update</h3>
+                  <div style="display:flex; gap:1.5rem; flex-wrap:wrap;">
+                    <div>
+                      <span style="font-size:0.7rem; color:var(--color-text-secondary);">Status</span><br>
+                      <span style="font-size:0.9rem;"
+                            :style="$store.genesisDashboard.updateStatus.last_update.status === 'success' ? 'color:#81c784' : 'color:#ef9a9a'"
+                            x-text="$store.genesisDashboard.updateStatus.last_update.status"></span>
+                    </div>
+                    <div>
+                      <span style="font-size:0.7rem; color:var(--color-text-secondary);">Version</span><br>
+                      <span style="font-size:0.9rem;" x-text="($store.genesisDashboard.updateStatus.last_update.old_tag || '?') + ' → ' + ($store.genesisDashboard.updateStatus.last_update.new_tag || '?')"></span>
+                    </div>
+                    <div>
+                      <span style="font-size:0.7rem; color:var(--color-text-secondary);">When</span><br>
+                      <span style="font-size:0.9rem;" x-text="$store.genesisDashboard.updateStatus.last_update.completed_at ? new Date($store.genesisDashboard.updateStatus.last_update.completed_at).toLocaleString() : 'in progress'"></span>
+                    </div>
+                  </div>
+                  <template x-if="$store.genesisDashboard.updateStatus.last_update.failure_reason">
+                    <div style="margin-top:0.75rem; padding:0.5rem; border-radius:4px; background:rgba(239,154,154,0.1); border:1px solid rgba(239,154,154,0.3); font-size:0.8rem; color:#ef9a9a;"
+                         x-text="$store.genesisDashboard.updateStatus.last_update.failure_reason"></div>
+                  </template>
+                </div>
+              </template>
+            </div>
+          </template>
+        </div>
+
+        <hr style="border:none; border-top:1px solid var(--color-border); margin-bottom:1.5rem;">
+
+        <!-- ── Backup Section (original) ──────────────────────── -->
         <template x-if="!$store.genesisDashboard.backupStatus">
           <div style="padding:1rem; text-align:center; color:var(--color-text-secondary);">Loading...</div>
         </template>
@@ -6288,86 +6460,6 @@
             </div>
           </div>
         </template>
-
-        <!-- ── Update Section ─────────────────────────────────── -->
-        <div id="update-section" style="margin-bottom:1.5rem;">
-          <template x-if="$store.genesisDashboard._updating">
-            <div class="card" style="padding:1.5rem; text-align:center;">
-              <div style="font-size:1.5rem; margin-bottom:0.5rem;">&#8987;</div>
-              <div style="font-size:1rem; font-weight:500;" x-text="$store.genesisDashboard._updateReconnecting ? 'Reconnecting to dashboard...' : 'Update in progress...'"></div>
-              <div style="font-size:0.8rem; color:var(--color-text-secondary); margin-top:0.5rem;">A background session is managing the update. This may take 1-2 minutes.</div>
-            </div>
-          </template>
-          <template x-if="!$store.genesisDashboard._updating">
-            <div>
-              <div class="card" style="padding:1rem; margin-bottom:1rem;">
-                <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:0.75rem;">
-                  <h3 style="margin:0; font-size:1rem;">Genesis Version</h3>
-                  <div style="display:flex; gap:0.5rem;">
-                    <template x-if="$store.genesisDashboard.updateStatus?.update_available">
-                      <button @click="$store.genesisDashboard.applyUpdate()"
-                              style="background:#2196F3; color:#fff; border:none; padding:0.4rem 0.8rem; border-radius:4px; cursor:pointer; font-size:0.8rem;">
-                        Install Update</button>
-                    </template>
-                    <button @click="$store.genesisDashboard.checkForUpdates()"
-                            :disabled="$store.genesisDashboard._checkingForUpdates"
-                            style="background:var(--color-accent); color:#000; border:none; padding:0.4rem 0.8rem; border-radius:4px; cursor:pointer; font-size:0.8rem;"
-                            :style="$store.genesisDashboard._checkingForUpdates ? 'opacity:0.6;cursor:not-allowed' : ''">
-                      <span x-text="$store.genesisDashboard._checkingForUpdates ? 'Checking...' : 'Check for Updates'"></span></button>
-                  </div>
-                </div>
-                <div style="display:flex; gap:1.5rem; flex-wrap:wrap; margin-bottom:0.5rem;">
-                  <div>
-                    <span style="font-size:0.7rem; color:var(--color-text-secondary);">Current</span><br>
-                    <span style="font-size:0.9rem;" x-text="($store.genesisDashboard.updateStatus?.current_version || '...') + ' (' + ($store.genesisDashboard.updateStatus?.current_commit || '...') + ')'"></span>
-                  </div>
-                </div>
-                <template x-if="$store.genesisDashboard.updateStatus?.update_available">
-                  <div style="margin-top:0.75rem; padding:0.75rem; border-radius:4px; background:rgba(33,150,243,0.1); border:1px solid rgba(33,150,243,0.3);">
-                    <div style="font-size:0.85rem; font-weight:500; color:#2196F3;">
-                      Update available
-                      <span x-text="$store.genesisDashboard.updateStatus.update_available.target_tag ? '  ' + $store.genesisDashboard.updateStatus.update_available.target_tag : ''"></span>
-                    </div>
-                    <div style="font-size:0.8rem; color:var(--color-text-secondary); margin-top:0.25rem;"
-                         x-text="($store.genesisDashboard.updateStatus.update_available.commits_behind || '?') + ' commit(s) behind'"></div>
-                    <template x-if="$store.genesisDashboard.updateStatus.update_available.summary">
-                      <pre style="font-size:0.75rem; color:var(--color-text-secondary); margin-top:0.5rem; max-height:6rem; overflow-y:auto; white-space:pre-wrap; background:transparent; border:none; padding:0;"
-                           x-text="$store.genesisDashboard.updateStatus.update_available.summary"></pre>
-                    </template>
-                  </div>
-                </template>
-                <template x-if="$store.genesisDashboard.updateStatus && !$store.genesisDashboard.updateStatus.update_available">
-                  <div style="margin-top:0.5rem; font-size:0.8rem; color:#81c784;">Up to date</div>
-                </template>
-              </div>
-              <template x-if="$store.genesisDashboard.updateStatus?.last_update">
-                <div class="card" style="padding:1rem; margin-bottom:1rem;">
-                  <h3 style="margin:0 0 0.75rem 0; font-size:1rem;">Last Update</h3>
-                  <div style="display:flex; gap:1.5rem; flex-wrap:wrap;">
-                    <div>
-                      <span style="font-size:0.7rem; color:var(--color-text-secondary);">Status</span><br>
-                      <span style="font-size:0.9rem;"
-                            :style="$store.genesisDashboard.updateStatus.last_update.status === 'success' ? 'color:#81c784' : 'color:#ef9a9a'"
-                            x-text="$store.genesisDashboard.updateStatus.last_update.status"></span>
-                    </div>
-                    <div>
-                      <span style="font-size:0.7rem; color:var(--color-text-secondary);">Version</span><br>
-                      <span style="font-size:0.9rem;" x-text="($store.genesisDashboard.updateStatus.last_update.old_tag || '?') + ' → ' + ($store.genesisDashboard.updateStatus.last_update.new_tag || '?')"></span>
-                    </div>
-                    <div>
-                      <span style="font-size:0.7rem; color:var(--color-text-secondary);">When</span><br>
-                      <span style="font-size:0.9rem;" x-text="$store.genesisDashboard.updateStatus.last_update.completed_at ? new Date($store.genesisDashboard.updateStatus.last_update.completed_at).toLocaleString() : 'in progress'"></span>
-                    </div>
-                  </div>
-                  <template x-if="$store.genesisDashboard.updateStatus.last_update.failure_reason">
-                    <div style="margin-top:0.75rem; padding:0.5rem; border-radius:4px; background:rgba(239,154,154,0.1); border:1px solid rgba(239,154,154,0.3); font-size:0.8rem; color:#ef9a9a;"
-                         x-text="$store.genesisDashboard.updateStatus.last_update.failure_reason"></div>
-                  </template>
-                </div>
-              </template>
-            </div>
-          </template>
-        </div>
       </div>
     </div>
 

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -758,11 +758,11 @@
                 await this.fetchHealth();
               }
             } catch (e) { /* still down, keep polling */ }
-            if (Date.now() - start > 300000) {
+            if (Date.now() - start > 600000) {
               clearInterval(poll);
               this._updating = false;
               this._updateReconnecting = false;
-              alert("Update did not complete after 5 minutes.\nCheck server logs for status.");
+              alert("Update is taking longer than expected.\nIt may still be running — check server logs for status.");
               await this.fetchUpdateStatus();
             }
           }, 5000);

--- a/src/genesis/learning/signals/genesis_version.py
+++ b/src/genesis/learning/signals/genesis_version.py
@@ -208,18 +208,38 @@ class GenesisVersionCollector:
             raise RuntimeError(f"git rev-parse failed: {stderr.decode(errors='replace')}")
         return stdout.decode().strip()
 
+    async def _git_output(self, *args: str, timeout: int = 10) -> str | None:
+        """Run a git command and return stdout, or None on failure."""
+        proc = await asyncio.create_subprocess_exec(
+            "git", *args,
+            cwd=str(_GENESIS_ROOT),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        if proc.returncode != 0:
+            return None
+        return stdout.decode().strip()
+
     async def _check_upstream(self) -> tuple[int, str]:
-        """Fetch the upstream primary remote and return (commits_behind, summary).
+        """Fetch upstream and compare release tags.
 
         Uses the remote pointing to github_public_repo() (e.g. 'public'),
-        falling back to 'origin'. Raises RuntimeError on git failure.
+        falling back to 'origin'. Tag-based comparison is robust against
+        squash-merge divergence — same release tag means same content even
+        if commit SHAs differ.
+
+        Returns (0, "") when tags match (up to date).
+        Returns (N, summary) where N is commits between tags and summary
+        shows what changed in the tag range.
+        Raises RuntimeError on git failure.
         """
         remote = _update_remote()
         ref = f"{remote}/main"
 
-        # Fetch (updates remote refs, doesn't change working tree)
+        # Fetch (updates remote refs + tags, doesn't change working tree)
         proc = await asyncio.create_subprocess_exec(
-            "git", "fetch", remote, "main",
+            "git", "fetch", remote, "main", "--tags",
             cwd=str(_GENESIS_ROOT),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -231,7 +251,61 @@ class GenesisVersionCollector:
                 f"git fetch {remote} main failed (exit {proc.returncode}): {stderr_text}"
             )
 
-        # Count commits behind
+        # Get local and remote release tags
+        local_tag = await self._git_output(
+            "describe", "--tags", "--match", "v*", "--abbrev=0", "HEAD",
+        )
+        origin_tag = await self._git_output(
+            "describe", "--tags", "--match", "v*", "--abbrev=0", ref,
+        )
+
+        # If neither side has tags, fall back to commit-based comparison
+        if not local_tag and not origin_tag:
+            return await self._check_upstream_by_commits()
+
+        # If only one side has tags, there's definitely an update
+        if local_tag != origin_tag:
+            # Count commits in the tag range for a meaningful number
+            behind = 0
+            if local_tag and origin_tag:
+                count_str = await self._git_output(
+                    "rev-list", "--count", f"{local_tag}..{origin_tag}",
+                )
+                behind = int(count_str) if count_str and count_str.isdigit() else 1
+            else:
+                # One side untagged — use commit count as fallback
+                count_str = await self._git_output(
+                    "rev-list", "--count", f"HEAD..{ref}",
+                )
+                behind = int(count_str) if count_str and count_str.isdigit() else 1
+
+            # Summary of what changed between tags
+            summary = ""
+            if local_tag and origin_tag:
+                raw = await self._git_output(
+                    "log", "--oneline", "--no-merges",
+                    f"{local_tag}..{origin_tag}",
+                )
+                summary = raw or ""
+            else:
+                raw = await self._git_output(
+                    "log", "--oneline", "--no-merges", f"HEAD..{ref}",
+                )
+                summary = raw or ""
+
+            # Truncate to first 10 lines
+            lines = summary.split("\n")
+            if len(lines) > 10:
+                summary = "\n".join(lines[:10]) + f"\n... and {len(lines) - 10} more"
+
+            return max(behind, 1), summary
+
+        # Same tag — up to date
+        return 0, ""
+
+    async def _check_upstream_by_commits(self) -> tuple[int, str]:
+        """Fallback: count commits when no release tags exist."""
+        ref = f"{_update_remote()}/main"
         proc = await asyncio.create_subprocess_exec(
             "git", "rev-list", "--count", f"HEAD..{ref}",
             cwd=str(_GENESIS_ROOT),
@@ -249,16 +323,10 @@ class GenesisVersionCollector:
         if behind == 0:
             return 0, ""
 
-        # Get summary of what's new
-        proc = await asyncio.create_subprocess_exec(
-            "git", "log", "--oneline", f"HEAD..{ref}",
-            cwd=str(_GENESIS_ROOT),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+        raw = await self._git_output(
+            "log", "--oneline", "--no-merges", f"HEAD..{ref}",
         )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
-        summary = stdout.decode().strip() if proc.returncode == 0 else ""
-        # Truncate to first 10 lines
+        summary = raw or ""
         lines = summary.split("\n")
         if len(lines) > 10:
             summary = "\n".join(lines[:10]) + f"\n... and {len(lines) - 10} more"
@@ -347,9 +415,10 @@ class GenesisVersionCollector:
         self, current: str, behind: int, summary: str,
     ) -> bool:
         """Store update-available observation. Returns True if new (not deduped)."""
+        ref = f"{_update_remote()}/main"
         # Get target commit for dedup
         proc = await asyncio.create_subprocess_exec(
-            "git", "rev-parse", "--short", "origin/main",
+            "git", "rev-parse", "--short", ref,
             cwd=str(_GENESIS_ROOT),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -372,7 +441,7 @@ class GenesisVersionCollector:
 
         # Get target tag if available
         proc = await asyncio.create_subprocess_exec(
-            "git", "describe", "--tags", "--abbrev=0", "origin/main",
+            "git", "describe", "--tags", "--match", "v*", "--abbrev=0", ref,
             cwd=str(_GENESIS_ROOT),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -423,16 +492,16 @@ class GenesisVersionCollector:
             from genesis.outreach.types import OutreachCategory, OutreachRequest
 
             message = (
-                f"Genesis update available — {behind} commit(s) behind origin/main.\n\n"
-                f"Recent changes:\n{summary}\n\n"
-                f"Run ./scripts/update.sh to update."
+                f"New Genesis version available ({behind} commit(s) behind).\n\n"
+                f"Highlights:\n{summary}\n\n"
+                f"Update from the dashboard when convenient."
             )
 
             await pipeline.submit(OutreachRequest(
-                category=OutreachCategory.ALERT,
+                category=OutreachCategory.DIGEST,
                 topic="Genesis update available",
                 context=message,
-                salience_score=0.6,
+                salience_score=0.4,
                 signal_type="genesis_update",
             ))
         except Exception:


### PR DESCRIPTION
## Summary

Replaces the rebase-based update system with a merge-based approach designed for Genesis's dual-repo reality, where each user's local main diverges from the public repo through customization.

- **Merge instead of rebase**: `git merge` with conflict detection (exit 2) and automatic merge abort to keep the system operational during conflict resolution
- **Tag-based version comparison**: Compares release tags (`v*`) instead of counting commits, which is robust against squash-merge divergence between local and public repos
- **Three-tier CC escalation**: Haiku watches and escalates, Sonnet resolves trivial conflicts on a temporary branch, Opus handles deep incompatibilities (user-initiated from dashboard)
- **Crash recovery**: Update state file tracks phase boundaries; bootstrap.sh detects interrupted updates and rolls back automatically
- **Service management**: Works without systemd D-Bus session bus (reads PID from fcntl lock file)
- **Dashboard UX**: Progress polling, conflict file display, "Resolve with Opus" button, "Do not close this tab" guidance

## Test plan

- [ ] Verify dashboard shows correct version (v* tag, not pre-update-* backup tag)
- [ ] "Check for Updates" detects available updates via tag comparison
- [ ] Clean update (no conflicts): Haiku supervises, reports success
- [ ] Conflicted update: merge aborts cleanly, services restart with old code, conflict context written
- [ ] Verify bootstrap.sh crash recovery detects stale update_state.json
- [ ] Service stop/start works via lock file PID when systemctl is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)