### PR TITLE
fix(security): address CodeQL findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/src/genesis/dashboard/routes/routing.py
+++ b/src/genesis/dashboard/routes/routing.py
@@ -114,7 +114,8 @@ async def routing_config_update(call_site_id: str):
             cc_model=cc_model, cc_position=cc_position, dispatch=dispatch,
         )
     except ValueError as e:
-        return jsonify({"error": str(e)}), 400
+        logger.warning("Routing config validation error for %s: %s", call_site_id, e)
+        return jsonify({"error": f"Invalid config: {type(e).__name__}"}), 400
     except Exception as e:
         logger.error(
             "Routing config save failed for %s: %s", call_site_id, e, exc_info=True,
@@ -164,7 +165,8 @@ async def routing_config_reload():
     try:
         new_config = load_config(config_path)
     except Exception as e:
-        return jsonify({"error": f"Config parse failed: {e}"}), 400
+        logger.error("Config parse failed: %s", e, exc_info=True)
+        return jsonify({"error": "Config parse failed"}), 400
 
     rt.router.reload_config(new_config)
     orphans_expired = await rt.router.scan_dlq_orphans_after_reload()

--- a/src/genesis/dashboard/routes/updates.py
+++ b/src/genesis/dashboard/routes/updates.py
@@ -203,7 +203,7 @@ def _apply_direct(pid_file: Path) -> tuple:
         return jsonify({"status": "triggered", "pid": proc.pid, "supervised": False})
     except Exception as exc:
         logger.error("Failed to trigger update: %s", exc, exc_info=True)
-        return jsonify({"error": str(exc)}), 500
+        return jsonify({"error": "Failed to trigger update"}), 500
 
 
 # ── Three-tier CC update prompts ─────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes 6 open CodeQL alerts:

- **#61** `py/stack-trace-exposure` in `updates.py` — `str(exc)` was returned in a 500 response; replaced with generic message
- **#57** `py/stack-trace-exposure` in `routing.py:117` — `str(e)` from ValueError returned in 400; now returns `type(e).__name__` only, with warning logged internally
- **#56** `py/stack-trace-exposure` in `routing.py:167` — exception detail in config parse error; replaced with generic message, error logged internally
- **#51, #53, #60** `actions/missing-workflow-permissions` in `ci.yml` — added workflow-level `permissions: contents: read`

Dismissed as false positives (via API):
- **#58, #55, #54** `py/clear-text-logging-sensitive-data` — Telegram `chat_id` and `user_id` values are public identifiers, not secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)