### PR TITLE
test: fix 15 pre-existing baseline failures on main

### DIFF
--- a/tests/test_channels/test_bridge.py
+++ b/tests/test_channels/test_bridge.py
@@ -18,6 +18,7 @@ class TestLoadBridgeConfig:
     def test_forum_chat_id_parsed(self, monkeypatch):
         path = _write_secrets(
             'TELEGRAM_BOT_TOKEN=testtoken\n'
+            'TELEGRAM_ALLOWED_USERS=12345\n'
             'TELEGRAM_FORUM_CHAT_ID=-100123456\n'
         )
         monkeypatch.setattr(
@@ -28,7 +29,10 @@ class TestLoadBridgeConfig:
         os.unlink(path)
 
     def test_forum_chat_id_absent(self, monkeypatch):
-        path = _write_secrets('TELEGRAM_BOT_TOKEN=testtoken\n')
+        path = _write_secrets(
+            'TELEGRAM_BOT_TOKEN=testtoken\n'
+            'TELEGRAM_ALLOWED_USERS=12345\n'
+        )
         monkeypatch.setattr(
             "genesis.channels.bridge.secrets_path", lambda: path,
         )
@@ -39,6 +43,7 @@ class TestLoadBridgeConfig:
     def test_forum_chat_id_empty_string(self, monkeypatch):
         path = _write_secrets(
             'TELEGRAM_BOT_TOKEN=testtoken\n'
+            'TELEGRAM_ALLOWED_USERS=12345\n'
             'TELEGRAM_FORUM_CHAT_ID=\n'
         )
         monkeypatch.setattr(
@@ -51,6 +56,7 @@ class TestLoadBridgeConfig:
     def test_forum_chat_id_positive(self, monkeypatch):
         path = _write_secrets(
             'TELEGRAM_BOT_TOKEN=testtoken\n'
+            'TELEGRAM_ALLOWED_USERS=12345\n'
             'TELEGRAM_FORUM_CHAT_ID=999\n'
         )
         monkeypatch.setattr(

--- a/tests/test_qdrant/test_collections.py
+++ b/tests/test_qdrant/test_collections.py
@@ -35,11 +35,17 @@ def _random_vector():
 
 @pytest.fixture(scope="module")
 def qdrant():
-    client = get_client()
-    client.create_collection(
-        collection_name=TEST_COLLECTION,
-        vectors_config=VectorParams(size=VECTOR_DIM, distance=Distance.COSINE),
-    )
+    # Qdrant isn't guaranteed to be running in every environment (e.g., CI
+    # without a Qdrant service). Skip the whole module gracefully instead of
+    # failing with a connection error.
+    try:
+        client = get_client()
+        client.create_collection(
+            collection_name=TEST_COLLECTION,
+            vectors_config=VectorParams(size=VECTOR_DIM, distance=Distance.COSINE),
+        )
+    except Exception as exc:
+        pytest.skip(f"Qdrant unavailable: {exc}")
     yield client
     client.delete_collection(TEST_COLLECTION)
 

--- a/tests/test_routing/test_model_profiles.py
+++ b/tests/test_routing/test_model_profiles.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import textwrap
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -13,6 +14,13 @@ from genesis.routing.model_profiles import (
     TIER_SCORES,
     ModelProfileRegistry,
 )
+
+# Reference date used by staleness fixtures below.
+# model-a and model-c set last_reviewed = REFERENCE_DATE (fresh);
+# model-b sets last_reviewed = "2026-01-01" (stale).
+# TestStaleness tests patch datetime.now() to return this date so the
+# asserts don't break as real time passes.
+REFERENCE_DATE = datetime(2026, 3, 14, tzinfo=UTC)
 
 
 @pytest.fixture()
@@ -261,16 +269,42 @@ class TestMatcher:
         assert len(results) >= 1
 
 
+class _FrozenDatetime(datetime):
+    """datetime subclass whose now() returns REFERENCE_DATE, for deterministic
+    staleness tests. Subclass rather than monkeypatching a specific method so
+    ``isinstance(x, datetime)`` still holds everywhere."""
+
+    @classmethod
+    def now(cls, tz=None):  # type: ignore[override]
+        if tz is None:
+            return REFERENCE_DATE.replace(tzinfo=None)
+        return REFERENCE_DATE.astimezone(tz)
+
+
+@pytest.fixture()
+def _freeze_now(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Freeze datetime.now() in the model_profiles module to REFERENCE_DATE
+    so that fixture dates (which assume 'today' is 2026-03-14) stay valid
+    regardless of when the tests run."""
+    monkeypatch.setattr(
+        "genesis.routing.model_profiles.datetime", _FrozenDatetime,
+    )
+
+
 class TestStaleness:
     """Stale profile detection."""
 
-    def test_stale_detected(self, registry: ModelProfileRegistry) -> None:
+    def test_stale_detected(
+        self, registry: ModelProfileRegistry, _freeze_now: None,
+    ) -> None:
         # model-b last reviewed 2026-01-01 — over 30 days ago from 2026-03-14
         stale = registry.stale_profiles(days=30)
         names = [p.name for p in stale]
         assert "model-b" in names
 
-    def test_fresh_not_stale(self, registry: ModelProfileRegistry) -> None:
+    def test_fresh_not_stale(
+        self, registry: ModelProfileRegistry, _freeze_now: None,
+    ) -> None:
         # model-a and model-c reviewed 2026-03-14 — fresh
         stale = registry.stale_profiles(days=30)
         names = [p.name for p in stale]


### PR DESCRIPTION
## Summary

Origin/main's CI test job has been failing for days due to three distinct issues, all unrelated to any one PR:

| Issue | Tests | Root cause | Fix |
|-------|-------|------------|-----|
| 1 | 4 FAILED in \`test_bridge.py\` | Telegram validation fix made \`_load_bridge_config()\` return None with empty \`TELEGRAM_ALLOWED_USERS\`, but forum_chat_id tests didn't set it | Add \`TELEGRAM_ALLOWED_USERS=12345\` to all 4 fixtures |
| 2 | 1 FAILED in \`test_model_profiles.py::TestStaleness::test_fresh_not_stale\` | Fixture uses \`last_reviewed="2026-03-14"\`; test uses real \`datetime.now()\`. Broke after 30 days elapsed. | Freeze \`datetime.now()\` in routing module via \`_freeze_now\` fixture |
| 3 | 10 ERRORS in \`test_qdrant/test_collections.py\` | CI has no Qdrant service → Connection refused | Wrap fixture in try/except, \`pytest.skip()\` when Qdrant unavailable (still runs locally) |

## Verification
- [x] All 4 telegram tests pass
- [x] All 3 staleness tests pass (incl. previously-failing \`fresh_not_stale\`)
- [x] All 10 qdrant tests pass when Qdrant running; skip cleanly when not
- [x] \`ruff check\` passes on modified files

## Impact

Unblocks PRs #34, #37, #41 which currently can't merge through normal channels because of these baseline failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)