### PR TITLE
fix(channels): telegram offset persist suppressed on fresh processes

### DIFF
--- a/.claude/skills/genesis-development/references/codebase-map.md
+++ b/.claude/skills/genesis-development/references/codebase-map.md
@@ -152,6 +152,33 @@ outcome -> rule extraction not yet flowing.
 `SurplusScheduler` fires on 12h cadence but `StubExecutor` does nothing.
 Queue fills up; tasks don't execute.
 
+### 13. `time.monotonic()` + `0.0` Sentinel Silently Breaks on Fresh Processes
+
+`time.monotonic()` is **system-wide** on Linux, not process-relative. Its
+epoch is effectively system boot. If you write a debounce/rate-limit like:
+
+```python
+_last_event: float = 0.0  # ← bug
+...
+if (time.monotonic() - _last_event) < INTERVAL_S:
+    return  # suppressed
+```
+
+…then on a fresh VM (CI runner, just-booted container) where system uptime
+< `INTERVAL_S`, `now - 0.0 < INTERVAL_S` holds and the **first event is
+silently suppressed**. Tests on developer machines pass because host uptime
+is huge. Bit twice: `litellm_delegate._should_log_failure` (fixed cf71db2)
+and `telegram/adapter_v2._last_offset_write` (fixed in follow-up).
+
+**Correct patterns:**
+- Use `None` as the "never seen" sentinel and check `last is None or ...`.
+- Or initialize at construction with `time.monotonic()` (only if "just
+  started" should count as "recent event" — opposite semantics, pick
+  carefully).
+
+`learning/failure_detector.py` already uses the None-sentinel pattern
+correctly. When writing a new debounce/throttle, copy that.
+
 ## Debugging Ladder
 
 When Genesis breaks, check in this order:

--- a/src/genesis/channels/telegram/adapter_v2.py
+++ b/src/genesis/channels/telegram/adapter_v2.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import io
 import logging
+import time
 from typing import TYPE_CHECKING
 
 from telegram import Update
@@ -76,7 +77,13 @@ class TelegramAdapterV2(ChannelAdapter):
         self._typing_breaker = TypingCircuitBreaker()
         self._watchdog: PollingWatchdog | None = None
         self._chat_locks: dict[str, asyncio.Lock] = {}
-        self._last_offset_write: float = 0.0
+        # None = never persisted; first call must persist regardless of uptime.
+        # Using 0.0 here would silently suppress the first persist on fresh
+        # processes because time.monotonic() is system-wide: if system uptime
+        # is under _OFFSET_PERSIST_INTERVAL_S, (now - 0.0) < interval holds and
+        # the debounce check would block the first write. Same bug class as
+        # the litellm_delegate._should_log_failure fix (commit cf71db2).
+        self._last_offset_write: float | None = None
 
         if tts_provider:
             from genesis.channels.voice import VoiceDeliveryHelper
@@ -100,12 +107,14 @@ class TelegramAdapterV2(ChannelAdapter):
         Debounced to avoid blocking I/O on every update. Called with
         force=True on stop() to ensure the final offset is persisted.
         """
-        import time
-
         if not self._app or not self._app.updater:
             return
         now = time.monotonic()
-        if not force and (now - self._last_offset_write) < self._OFFSET_PERSIST_INTERVAL_S:
+        if (
+            not force
+            and self._last_offset_write is not None
+            and (now - self._last_offset_write) < self._OFFSET_PERSIST_INTERVAL_S
+        ):
             return
         offset = getattr(self._app.updater, "_last_update_id", 0)
         if offset > 0:

--- a/tests/test_channels/test_transport.py
+++ b/tests/test_channels/test_transport.py
@@ -296,3 +296,99 @@ class TestFTS5Escape:
         result = _escape_fts5("café résumé naïve")
         assert result is not None
         assert "café" in result
+
+
+# ---- Adapter offset persistence debounce ----
+
+
+class TestAdapterOffsetDebounce:
+    """Regression coverage for the None-sentinel fix on _last_offset_write.
+
+    Previously `_last_offset_write: float = 0.0` paired with a 30s debounce
+    meant the first offset persist was suppressed on fresh processes where
+    system uptime (time.monotonic) was under 30 seconds — same bug class as
+    _should_log_failure in litellm_delegate. The fix uses None as the
+    "never persisted" sentinel.
+    """
+
+    def _make_adapter(self):
+        from genesis.channels.telegram.adapter_v2 import TelegramAdapterV2
+        return TelegramAdapterV2(token="t", conversation_loop=AsyncMock())
+
+    def test_sentinel_initialized_to_none(self):
+        adapter = self._make_adapter()
+        assert adapter._last_offset_write is None
+
+    def test_first_persist_not_suppressed_on_fresh_process(self):
+        """With system uptime < _OFFSET_PERSIST_INTERVAL_S (30s), first
+        _persist_offset call must still write — not be debounced away."""
+        adapter = self._make_adapter()
+        # Simulate an _app/updater with a non-zero offset
+        adapter._app = AsyncMock()
+        adapter._app.updater._last_update_id = 42
+        adapter._app.bot.id = 1234
+
+        with (
+            patch("genesis.channels.telegram.adapter_v2.time.monotonic", return_value=5.0),
+            patch("genesis.channels.telegram.adapter_v2.write_offset") as mock_write,
+        ):
+            adapter._persist_offset()
+            # First call must persist even though monotonic=5.0 < interval=30s
+            mock_write.assert_called_once_with("1234", 42)
+            assert adapter._last_offset_write == 5.0
+
+    def test_second_persist_within_interval_is_debounced(self):
+        adapter = self._make_adapter()
+        adapter._app = AsyncMock()
+        adapter._app.updater._last_update_id = 42
+        adapter._app.bot.id = 1234
+
+        with (
+            patch("genesis.channels.telegram.adapter_v2.time.monotonic", return_value=5.0),
+            patch("genesis.channels.telegram.adapter_v2.write_offset") as mock_write,
+        ):
+            adapter._persist_offset()
+            assert mock_write.call_count == 1
+            # Second call at same monotonic time → within debounce window
+            adapter._persist_offset()
+            assert mock_write.call_count == 1  # still 1, suppressed
+
+    def test_persist_after_interval_writes_again(self):
+        adapter = self._make_adapter()
+        adapter._app = AsyncMock()
+        adapter._app.updater._last_update_id = 42
+        adapter._app.bot.id = 1234
+
+        with (
+            patch("genesis.channels.telegram.adapter_v2.time.monotonic", return_value=5.0),
+            patch("genesis.channels.telegram.adapter_v2.write_offset") as mock_write,
+        ):
+            adapter._persist_offset()
+            assert mock_write.call_count == 1
+
+        interval = adapter._OFFSET_PERSIST_INTERVAL_S
+        with (
+            patch(
+                "genesis.channels.telegram.adapter_v2.time.monotonic",
+                return_value=5.0 + interval + 1.0,
+            ),
+            patch("genesis.channels.telegram.adapter_v2.write_offset") as mock_write,
+        ):
+            adapter._persist_offset()
+            assert mock_write.call_count == 1  # second persist after interval
+
+    def test_force_always_persists(self):
+        adapter = self._make_adapter()
+        adapter._app = AsyncMock()
+        adapter._app.updater._last_update_id = 42
+        adapter._app.bot.id = 1234
+
+        with (
+            patch("genesis.channels.telegram.adapter_v2.time.monotonic", return_value=5.0),
+            patch("genesis.channels.telegram.adapter_v2.write_offset") as mock_write,
+        ):
+            adapter._persist_offset(force=True)
+            assert mock_write.call_count == 1
+            # force=True bypasses the debounce check
+            adapter._persist_offset(force=True)
+            assert mock_write.call_count == 2

--- a/tests/test_routing/test_litellm_delegate.py
+++ b/tests/test_routing/test_litellm_delegate.py
@@ -366,6 +366,35 @@ async def test_rate_limit_logs_warning():
     assert "rate-limited" in args[0]
 
 
+def test_should_log_failure_first_call_regardless_of_monotonic_value():
+    """Regression: first _should_log_failure call must log even when
+    time.monotonic() returns a small value (e.g., fresh CI runner with
+    system uptime < _FAILURE_LOG_INTERVAL_S).
+
+    Previously `_last_failure_log.get(provider, 0.0)` meant the check
+    `now - 0.0 >= 300` was False on fresh systems, silently suppressing
+    the first failure log. Fixed by using None as the "never seen" sentinel
+    (commit cf71db2). This test proves the invariant independently of host
+    uptime.
+    """
+    import genesis.routing.litellm_delegate as mod
+
+    mod._last_failure_log.clear()
+
+    with patch("genesis.routing.litellm_delegate.time.monotonic", return_value=10.0):
+        # now=10.0, no entry for "fresh-provider" → last is None → must log
+        assert mod._should_log_failure("fresh-provider") is True
+        # Second call at same "time" — now entry exists, interval not elapsed → suppress
+        assert mod._should_log_failure("fresh-provider") is False
+
+    # After the interval elapses, should log again
+    with patch(
+        "genesis.routing.litellm_delegate.time.monotonic",
+        return_value=10.0 + mod._FAILURE_LOG_INTERVAL_S + 1.0,
+    ):
+        assert mod._should_log_failure("fresh-provider") is True
+
+
 async def test_failure_logging_rate_limited():
     """Second failure within 5 minutes should NOT log."""
     import genesis.routing.litellm_delegate as mod


### PR DESCRIPTION
## Summary

Retroactive follow-up from the code review of cf71db2. Same bug class as
`_should_log_failure`: `_last_offset_write: float = 0.0` paired with the 30s
debounce silently suppresses the first offset persist on fresh processes
because `time.monotonic()` is system-wide on Linux, not process-relative.

On a cold-boot VM with uptime < 30s, `(now - 0.0) < 30` holds and the first
`_persist_offset()` call returns early. The in-memory offset advances but
never hits disk until uptime crosses the 30s threshold. Low severity —
`stop()` forces a final flush and the code self-heals after 30s — but if the
process crashes within the first 30s, already-seen Telegram updates get
reprocessed on restart.

## Changes

- `adapter_v2.py`: `_last_offset_write: float | None = None`, check
  `is not None` before the debounce comparison. Hoist `import time` to
  module scope (trivial; needed for test patching).
- `test_transport.py`: 5 regression tests (`TestAdapterOffsetDebounce`).
  Verified 4/5 fail against the reverted buggy code — the fifth
  (`test_force_always_persists`) correctly passes because `force=True`
  bypasses the debounce.
- `test_litellm_delegate.py`: explicit regression test for
  `_should_log_failure` that mocks `time.monotonic` to a small value.
  Previously the existing tests only happened to pass because developer
  machine uptime is huge — not a mechanical proof.
- `codebase-map.md`: new gotcha #13 documenting the pattern + None-sentinel
  fix + pointer to `learning/failure_detector.py` as reference.

## Test plan

- [x] `pytest tests/test_channels/test_transport.py tests/test_routing/test_litellm_delegate.py` → 65 passed
- [x] `ruff check` on all touched files → clean
- [x] Verified test suite fails against reverted buggy code
- [x] Manual verification: `_persist_offset` called at low monotonic() values now actually writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)