### PR TITLE
fix(dashboard): portability — genericize tz examples in docstring

### DIFF
--- a/src/genesis/dashboard/routes/state.py
+++ b/src/genesis/dashboard/routes/state.py
@@ -265,8 +265,9 @@ async def autonomy_config():
 async def settings_timezone():
     """Get or set the user's display timezone.
 
-    GET: returns {"timezone": "America/New_York"}
-    POST: {"timezone": "US/Eastern"} → validates, writes to genesis.yaml,
+    GET: returns {"timezone": <IANA tz name>} — whatever the user configured
+         (defaults to "UTC" if unset).
+    POST: {"timezone": <IANA tz name>} → validates, writes to genesis.yaml,
           invalidates caches. Takes effect immediately for display;
           scheduler CronTrigger timezone updates on next restart.
     """


### PR DESCRIPTION
## Summary

Commit 91359dd introduced hardcoded \`\"America/New_York\"\` and
\`\"US/Eastern\"\` in a docstring example for the settings_timezone
endpoint. The portability scan in \`.github/workflows/ci.yml\` explicitly
rejects \`America/New_York\` as user-specific content, blocking all PRs
against origin/main.

The actual function behavior is correct — \`user_timezone()\` reads from
\`USER_TIMEZONE\` env → local config → \`\"UTC\"\` (no Eastern-Time
default). Only the docstring needed genericization.

## Change

\`{\"timezone\": \"America/New_York\"}\` → \`{\"timezone\": <IANA tz name>}\`

Added the \`\"UTC\"\` default note so readers know what the GET returns
when the user hasn't configured anything.

## Test plan

- [x] Local run of CI's portability scan (with same \`SCAN_EXCLUDES\`):
      **CLEAN** after fix, flagged state.py:268 before fix
- [x] \`user_timezone()\` behavior unchanged (docstring-only edit)

Unblocks #43 and #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)