### PR TITLE
fix(install): unbound UBUNTU_UID in timezone seed

### DIFF
--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -637,10 +637,12 @@ echo "  + Timezone: $_final_tz (host + container)"
 # Pre-seed timezone in container's secrets.env so install.sh doesn't re-detect.
 # install.sh checks USER_TIMEZONE in secrets.env first (lines 1206-1208) and
 # skips its own timezone prompt if present.
-incus exec "$CONTAINER_NAME" --user "$UBUNTU_UID" --env "HOME=/home/ubuntu" -- \
+# Run as root (UBUNTU_UID not yet resolved), then chown so install.sh (as ubuntu) can write
+incus exec "$CONTAINER_NAME" -- \
     bash -c "mkdir -p /home/ubuntu/genesis && f=/home/ubuntu/genesis/secrets.env && \
     grep -q '^USER_TIMEZONE=' \"\$f\" 2>/dev/null || \
-    { echo 'USER_TIMEZONE=$_final_tz' >> \"\$f\" && chmod 600 \"\$f\"; }" 2>/dev/null || true
+    { echo 'USER_TIMEZONE=$_final_tz' >> \"\$f\" && chmod 600 \"\$f\"; }; \
+    chown -R ubuntu:ubuntu /home/ubuntu/genesis 2>/dev/null" 2>/dev/null || true
 
 # ── Set up user inside container ─────────────────────────────
 echo "  Setting up user inside container..."


### PR DESCRIPTION
## Summary

The secrets.env timezone seed (from PR #50) used `--user "$UBUNTU_UID"` but that variable is set later in the script. With `set -u`, this causes an immediate fatal error on fresh installs.

Fix: run as root (no `--user` flag needed for file creation), then `chown` to ubuntu so install.sh can write to it later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)