### PR TITLE
feat(backup): encrypt Qdrant snapshots; history migration script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ docs/actions/user/*.md
 !docs/actions/README.md
 data/genesis.db
 *.jsonl
+.config/

--- a/docs/reference/backup-history-migration.md
+++ b/docs/reference/backup-history-migration.md
@@ -1,0 +1,130 @@
+# Backup History Migration
+
+## Why
+
+Before PR #48 (merged 2026-04-16), `scripts/backup.sh` stored SQLite dumps,
+CC transcripts, and auto-memory files as plaintext in the `genesis-backups`
+git repo. Only `secrets.env` was encrypted.
+
+Post-PR #48, all PII-bearing payloads are GPG-encrypted before push.
+However, **git history retains the old plaintext commits** indefinitely.
+The backup repo is private, but plaintext PII in git history is still a
+liability — especially since the memory system stores credentials by design.
+
+This migration removes those plaintext payloads from all history, leaving
+encrypted (`.gpg`) versions and everything else intact.
+
+## When to run
+
+**Once**, after you've confirmed that a few encrypted backup cycles have
+landed successfully (check `~/.genesis/backup_status.json` — look for
+`secrets_encrypted: true` and non-zero `qdrant_collections`).
+
+**Skip entirely** if your Genesis install was set up after PR #48 — your
+backup history never contained plaintext payloads.
+
+## Prerequisites
+
+Install `git-filter-repo`:
+
+```bash
+# pip (works everywhere)
+pip install git-filter-repo
+
+# Ubuntu 22.04+
+sudo apt install git-filter-repo
+
+# macOS
+brew install git-filter-repo
+```
+
+## Step-by-step
+
+### 1. Update your backup repo
+
+```bash
+cd ~/backups/genesis-backups
+git pull
+```
+
+### 2. Preview (dry-run)
+
+```bash
+~/genesis/scripts/migrate-backup-history.sh --dry-run
+```
+
+This shows what would be removed without making changes.
+
+### 3. Run the migration
+
+```bash
+~/genesis/scripts/migrate-backup-history.sh --yes
+```
+
+The script:
+- Removes `data/genesis.sql`, `data/genesis.db`, `transcripts/*.jsonl`,
+  and `memory/**/*.{md,json}` from ALL commits in history
+- Preserves all `.gpg` files, Qdrant snapshots, config overlays, and
+  secrets
+- Runs `git gc --aggressive --prune=now` to reclaim disk space
+- Reports size before and after
+
+### 4. Force-push
+
+The script prints the exact commands but does NOT push automatically:
+
+```bash
+cd ~/backups/genesis-backups
+git push --force --all origin
+git push --force --tags origin
+```
+
+### 5. Verify
+
+```bash
+# Should return no results:
+git log --all --oneline -- data/genesis.sql
+git log --all --oneline -- 'transcripts/*.jsonl'
+
+# Should still show encrypted history:
+git log --all --oneline -- data/genesis.sql.gpg
+```
+
+## Risks
+
+- **Force-push rewrites remote history.** Any other clone of the backup
+  repo (e.g., on another machine) must re-clone. Since the backup repo is
+  per-install, this is usually just one machine.
+
+- **Commit SHAs change.** If you have external references to specific
+  backup commits (unlikely), they become dangling.
+
+- **Irreversible locally.** After the rewrite + gc, the old plaintext is
+  gone from the local clone. The force-push removes it from the remote.
+  If you're nervous, clone the backup repo to a scratch directory first
+  and run there:
+  ```bash
+  git clone ~/backups/genesis-backups /tmp/migration-test
+  ~/genesis/scripts/migrate-backup-history.sh --backup-dir /tmp/migration-test
+  ```
+
+## Manual fallback
+
+If you prefer not to use the script:
+
+```bash
+cd ~/backups/genesis-backups
+
+git filter-repo \
+  --invert-paths \
+  --path data/genesis.sql \
+  --path data/genesis.db \
+  --path-glob 'transcripts/*.jsonl' \
+  --path-glob 'memory/*.md' \
+  --path-glob 'memory/**/*.md' \
+  --path-glob 'memory/**/*.json' \
+  --force
+
+git gc --aggressive --prune=now
+git push --force --all origin
+```

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -8,6 +8,9 @@
 #
 # Restore via scripts/restore.sh or `python -m genesis restore`.
 #
+# To scrub pre-encryption plaintext payloads from the backup repo's git
+# history, run scripts/migrate-backup-history.sh (one-shot, user-invoked).
+#
 # Environment variables (all optional unless noted):
 #   GENESIS_BACKUP_REPO        — Git URL for backup repo (auto-detected from existing clone)
 #   GENESIS_BACKUP_PASSPHRASE  — GPG passphrase (REQUIRED for secrets + encrypted payloads)
@@ -129,9 +132,13 @@ else
     log "WARNING: genesis.db not found at $DB_FILE"
 fi
 
-# --- 2. Qdrant snapshots ---
+# --- 2. Qdrant snapshots (encrypted — snapshots contain embedding vectors
+#       and payloads derived from memory/DB content) ---
 log "Backing up Qdrant collections..."
 mkdir -p data/qdrant
+# Purge any pre-encryption plaintext snapshots so they don't persist
+# alongside the new encrypted form.
+find data/qdrant -maxdepth 1 -name '*.snapshot' -type f -delete 2>/dev/null || true
 for collection in episodic_memory knowledge_base; do
     # Create snapshot via Qdrant API
     snapshot_resp=$(curl -sf -X POST "$QDRANT_URL/collections/$collection/snapshots" 2>/dev/null) || {
@@ -148,8 +155,20 @@ for collection in episodic_memory knowledge_base; do
         log "WARNING: Could not download snapshot for $collection"
         continue
     }
-    _QDRANT_COUNT=$(( _QDRANT_COUNT + 1 ))
-    log "Qdrant: $collection snapshot saved ($(du -sh "data/qdrant/${collection}.snapshot" | cut -f1))"
+
+    # Encrypt. Refuse plaintext if no passphrase — Qdrant snapshots are
+    # not opaque enough to ship plaintext to the backup repo.
+    if ! $_ENCRYPT_READY; then
+        log "WARNING: GENESIS_BACKUP_PASSPHRASE not set — skipping Qdrant snapshot for $collection (refusing plaintext)"
+        rm -f "data/qdrant/${collection}.snapshot"
+    elif encrypt_file "data/qdrant/${collection}.snapshot" "data/qdrant/${collection}.snapshot.gpg"; then
+        rm -f "data/qdrant/${collection}.snapshot"
+        _QDRANT_COUNT=$(( _QDRANT_COUNT + 1 ))
+        log "Qdrant: $collection ($(du -sh "data/qdrant/${collection}.snapshot.gpg" | cut -f1), encrypted)"
+    else
+        log "WARNING: Qdrant encryption failed for $collection"
+        rm -f "data/qdrant/${collection}.snapshot"
+    fi
 
     # Clean up snapshot from Qdrant server
     curl -sf -X DELETE "$QDRANT_URL/collections/$collection/snapshots/$snapshot_name" >/dev/null 2>&1 || true

--- a/scripts/migrate-backup-history.sh
+++ b/scripts/migrate-backup-history.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Strip pre-encryption plaintext payloads from genesis-backups git history.
+#
+# After PR#48 (2026-04-16), backup.sh encrypts SQLite dumps, transcripts,
+# memory files, and Qdrant snapshots before pushing. But git history still
+# contains older commits with those same payloads in plaintext. This script
+# removes those plaintext files from ALL history, leaving encrypted (.gpg)
+# versions and everything else intact.
+#
+# REMOVES from history:
+#   data/genesis.sql         — plaintext SQLite dump
+#   data/genesis.db          — raw DB fallback
+#   transcripts/*.jsonl      — plaintext CC transcripts
+#   memory/*.md, **/*.md     — plaintext auto-memory
+#   memory/*.json, **/*.json — plaintext auto-memory metadata
+#
+# PRESERVES:
+#   *.gpg                    — encrypted payloads
+#   data/qdrant/             — Qdrant snapshots (now encrypted too)
+#   config_overrides/        — local config overlays
+#   cc-memory/               — in-repo CC memory backup
+#   secrets/                 — already encrypted pre-PR#48
+#
+# REQUIREMENTS:
+#   - git-filter-repo (pip install git-filter-repo, or distro package)
+#   - Clean working tree in the target backup repo
+#   - You must manually force-push afterward; this script does NOT push
+#
+# Usage:
+#   scripts/migrate-backup-history.sh [--backup-dir <path>] [--dry-run] [--yes]
+set -euo pipefail
+
+# ── Args ─────────────────────────────────────────────────────────────
+BACKUP_DIR="${HOME:-}/backups/genesis-backups"
+DRY_RUN=false
+AUTO_YES=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --backup-dir) BACKUP_DIR="$2"; shift 2 ;;
+        --dry-run)    DRY_RUN=true; shift ;;
+        --yes)        AUTO_YES=true; shift ;;
+        -h|--help)
+            grep -E '^#( |$)' "$0" | sed 's/^# //; s/^#//'
+            exit 0 ;;
+        *)
+            echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[migrate-backup-history] $*"; }
+die() { log "FATAL: $*"; exit 1; }
+
+# ── Preflight checks ────────────────────────────────────────────────
+if ! command -v git-filter-repo >/dev/null 2>&1; then
+    die "git-filter-repo not found. Install it:
+  pip install git-filter-repo
+  # or: apt install git-filter-repo  (Ubuntu 22.04+)
+  # or: brew install git-filter-repo (macOS)"
+fi
+
+[ -d "$BACKUP_DIR/.git" ] || die "Not a git repo: $BACKUP_DIR"
+
+cd "$BACKUP_DIR"
+
+if [ -n "$(git status --porcelain)" ]; then
+    die "Working tree is dirty. Commit or stash changes first."
+fi
+
+# ── Check if there's anything to strip ──────────────────────────────
+_has_plaintext=false
+for pattern in data/genesis.sql data/genesis.db; do
+    if git log --all --oneline -- "$pattern" 2>/dev/null | head -1 | grep -q .; then
+        _has_plaintext=true
+        break
+    fi
+done
+if ! $_has_plaintext; then
+    # Check glob patterns
+    for glob_pat in 'transcripts/*.jsonl' 'memory/*.md' 'memory/**/*.md' 'memory/**/*.json'; do
+        if git log --all --oneline --diff-filter=A -- "$glob_pat" 2>/dev/null | head -1 | grep -q .; then
+            _has_plaintext=true
+            break
+        fi
+    done
+fi
+
+if ! $_has_plaintext; then
+    log "No pre-encryption plaintext payloads found in history. Nothing to do."
+    exit 0
+fi
+
+# ── Show plan ────────────────────────────────────────────────────────
+SIZE_BEFORE=$(du -sh .git | cut -f1)
+COMMIT_COUNT=$(git rev-list --all --count)
+
+log ""
+log "Backup repo: $BACKUP_DIR"
+log "Commits: $COMMIT_COUNT"
+log ".git size before: $SIZE_BEFORE"
+log ""
+log "Paths to REMOVE from ALL history:"
+log "  data/genesis.sql, data/genesis.db"
+log "  transcripts/*.jsonl"
+log "  memory/*.md, memory/**/*.md, memory/**/*.json"
+log ""
+log "Everything else is PRESERVED (*.gpg, data/qdrant/, config_overrides/, cc-memory/, secrets/)"
+log ""
+
+if $DRY_RUN; then
+    log "[dry-run] Would rewrite $COMMIT_COUNT commits. No changes made."
+    exit 0
+fi
+
+# ── Confirm ──────────────────────────────────────────────────────────
+if ! $AUTO_YES; then
+    read -r -p "Rewrite history in $BACKUP_DIR? This is irreversible locally. [y/N] " reply
+    if ! [[ "$reply" =~ ^[yY]([eE][sS])?$ ]]; then
+        log "Aborted."
+        exit 0
+    fi
+fi
+
+# ── Run filter-repo ─────────────────────────────────────────────────
+log "Rewriting history..."
+git filter-repo \
+    --invert-paths \
+    --path data/genesis.sql \
+    --path data/genesis.db \
+    --path-glob 'transcripts/*.jsonl' \
+    --path-glob 'memory/*.md' \
+    --path-glob 'memory/**/*.md' \
+    --path-glob 'memory/**/*.json' \
+    --force
+
+# ── GC ───────────────────────────────────────────────────────────────
+log "Running garbage collection..."
+git gc --aggressive --prune=now 2>/dev/null
+
+SIZE_AFTER=$(du -sh .git | cut -f1)
+
+log ""
+log "Done."
+log ".git size: $SIZE_BEFORE → $SIZE_AFTER"
+log ""
+log "To propagate, run:"
+log "  cd $BACKUP_DIR"
+log "  git push --force --all origin"
+log "  git push --force --tags origin"
+log ""
+log "WARNING: force-push rewrites remote history. Any other clones of"
+log "this repo must re-clone after the push."

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -144,7 +144,7 @@ _has_encrypted=false
 for candidate in "$BACKUP_DIR"/data/genesis.sql.gpg "$BACKUP_DIR"/secrets/secrets.env.gpg; do
     [ -f "$candidate" ] && _has_encrypted=true
 done
-if find "$BACKUP_DIR"/transcripts "$BACKUP_DIR"/memory -name '*.gpg' -print -quit 2>/dev/null | grep -q .; then
+if find "$BACKUP_DIR"/transcripts "$BACKUP_DIR"/memory "$BACKUP_DIR"/data/qdrant -name '*.gpg' -print -quit 2>/dev/null | grep -q .; then
     _has_encrypted=true
 fi
 if $_has_encrypted && [ -z "$_BACKUP_PASSPHRASE" ]; then
@@ -207,8 +207,26 @@ if [ -d "$BACKUP_DIR/data/qdrant" ]; then
     if ! curl -sf "$QDRANT_URL/" >/dev/null; then
         warn "Qdrant at $QDRANT_URL not reachable — skipping collection restore"
     else
+        # Build a dedup'd collection → source map. When both .snapshot and
+        # .snapshot.gpg exist for the same collection, prefer the encrypted
+        # form (the plaintext is stale from a pre-encryption backup).
+        declare -A _SNAPSHOTS
         while IFS= read -r -d '' snap; do
-            coll=$(basename "$snap" .snapshot)
+            name=$(basename "$snap")
+            case "$name" in
+                *.snapshot.gpg) coll="${name%.snapshot.gpg}" ;;
+                *.snapshot)     coll="${name%.snapshot}" ;;
+                *) continue ;;
+            esac
+            existing="${_SNAPSHOTS[$coll]:-}"
+            if [ -z "$existing" ] || [[ "$snap" == *.gpg ]]; then
+                _SNAPSHOTS[$coll]="$snap"
+            fi
+        done < <(find "$BACKUP_DIR/data/qdrant" -maxdepth 1 \
+            \( -name '*.snapshot' -o -name '*.snapshot.gpg' \) -print0 2>/dev/null)
+
+        for coll in "${!_SNAPSHOTS[@]}"; do
+            snap="${_SNAPSHOTS[$coll]}"
             # If the collection already exists with points, don't clobber.
             existing_count=$(curl -sf "$QDRANT_URL/collections/$coll" 2>/dev/null \
                 | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('result',{}).get('points_count',0))" 2>/dev/null \
@@ -226,12 +244,33 @@ if [ -d "$BACKUP_DIR/data/qdrant" ]; then
                 log "Qdrant: '$coll' skipped (user declined)"
                 continue
             fi
+
+            # Decrypt to tempfile if encrypted — curl -F needs a real fs path.
+            upload_src="$snap"
+            _QDRANT_TMP=""
+            if [[ "$snap" == *.gpg ]]; then
+                if [ -z "$_BACKUP_PASSPHRASE" ]; then
+                    warn "Qdrant: '$coll' is encrypted but GENESIS_BACKUP_PASSPHRASE unset — skipping"
+                    continue
+                fi
+                _QDRANT_TMP=$(mktemp --suffix=.snapshot)
+                if ! decrypt_file "$snap" "$_QDRANT_TMP"; then
+                    warn "Qdrant: decrypt failed for '$coll'"
+                    rm -f "$_QDRANT_TMP"
+                    continue
+                fi
+                upload_src="$_QDRANT_TMP"
+            fi
+
             log "Qdrant: uploading '$coll' snapshot..."
             resp=$(curl -sf -X POST "$QDRANT_URL/collections/$coll/snapshots/upload?priority=snapshot" \
-                -F "snapshot=@$snap" 2>/dev/null) || {
+                -F "snapshot=@$upload_src" 2>/dev/null) || {
                 warn "Qdrant: upload failed for '$coll'"
+                [ -n "$_QDRANT_TMP" ] && rm -f "$_QDRANT_TMP"
                 continue
             }
+            [ -n "$_QDRANT_TMP" ] && rm -f "$_QDRANT_TMP"
+
             ok=$(echo "$resp" | python3 -c "import sys,json;print(json.load(sys.stdin).get('result',False))" 2>/dev/null || echo false)
             if [ "$ok" = "True" ]; then
                 _QDRANT_RESTORED=$(( _QDRANT_RESTORED + 1 ))
@@ -241,7 +280,7 @@ if [ -d "$BACKUP_DIR/data/qdrant" ]; then
             else
                 warn "Qdrant: upload returned non-ok for '$coll': $resp"
             fi
-        done < <(find "$BACKUP_DIR/data/qdrant" -maxdepth 1 -name '*.snapshot' -print0 2>/dev/null)
+        done
     fi
 else
     log "Qdrant: no snapshots in backup"


### PR DESCRIPTION
## Summary

- **Encrypt Qdrant snapshots** in `backup.sh` — the last PII-bearing payload that was still plaintext. Uses the same `GENESIS_BACKUP_PASSPHRASE` and `encrypt_file` helper as SQLite/transcripts/memory (PR #48). Refuse plaintext when passphrase is unset.
- **Decrypt on restore** in `restore.sh` — builds a dedup'd collection map handling both `.snapshot.gpg` (preferred) and legacy `.snapshot` (backward compat). Decrypts to tempfile before multipart Qdrant upload. Extended fail-fast encrypted-payload check.
- **History migration script** `scripts/migrate-backup-history.sh` — one-shot `git-filter-repo` wrapper to strip pre-encryption plaintext from the genesis-backups repo history. Never auto-runs, never pushes. Includes dry-run and confirmation gate.
- **Migration doc** at `docs/reference/backup-history-migration.md` — when to run, prerequisites, step-by-step, risks, manual fallback.
- **Gitignore `.config/`** — prevents accidental commit of repo-local gh auth tokens.

## Verification

- E2E backup+restore round-trip: both Qdrant collections (`episodic_memory` 3316pts, `knowledge_base` 0pts) encrypted → deleted → restored successfully
- Wrong passphrase: clear per-collection warnings, no partial restore
- Legacy plaintext backward compat: mixed `.snapshot` + `.snapshot.gpg` restore handled correctly
- Tempfile cleanup: zero leaks across success and failure paths
- Migration script: dry-run + live rewrite on scratch repo — plaintext stripped from history, encrypted files preserved, `.git` size reduced
- ruff check: clean (pre-existing `az_plugins/` error only)
- pytest: all tests pass (pre-existing `test_watchdog_az.py` import error excluded)

## Test plan

- [ ] CI checks pass (lint, tests, CodeQL, portability scan)
- [ ] Verify no private-repo references leaked in commit messages or diff
- [ ] Squash-merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)