### PR TITLE
fix: opencode wrapper silent exit when no stale sessions exist

### DIFF
--- a/scripts/opencode-wrapper.sh
+++ b/scripts/opencode-wrapper.sh
@@ -11,7 +11,7 @@ OPENCODE_BIN="${HOME}/.npm-global/bin/opencode"
 
 kill_opencode() {
     local count
-    count=$(pgrep -f opencode-ai 2>/dev/null | wc -l)
+    count=$(pgrep -fc opencode-ai 2>/dev/null || true)
     if [ "$count" -gt 0 ]; then
         echo "[opencode-wrapper] Killing $count existing opencode process(es)..."
         pkill -f opencode-ai 2>/dev/null || true


### PR DESCRIPTION
## Summary
- `pgrep -f opencode-ai | wc -l` with `set -euo pipefail` exits the wrapper when no processes match (pgrep returns 1, pipefail propagates it, set -e kills script)
- This broke when the process reaper started cleaning stale sessions — no stale processes = pgrep always fails = wrapper never reaches `exec`
- Fix: `pgrep -fc opencode-ai 2>/dev/null || true` (count flag, no pipe, safe fallback)

## Test plan
- [x] `bash -x scripts/opencode-wrapper.sh --version` → executes through to `exec`, prints `1.3.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)