### PR TITLE
fix: backup passphrase, cost attribution, dashboard UX, file browser

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -54,6 +54,14 @@ SECRETS_FILE="${SECRETS_PATH:-$GENESIS_DIR/secrets.env}"
 QDRANT_URL="${QDRANT_URL:-http://localhost:6333}"
 LOG_PREFIX="[genesis-backup]"
 
+# Source secrets for backup passphrase (cron doesn't inherit shell env)
+if [ -f "$SECRETS_FILE" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$SECRETS_FILE"
+    set +a
+fi
+
 log() { echo "$LOG_PREFIX $(date -Iseconds) $*"; }
 
 die() { _FAILURE_REASON="$*"; log "FATAL: $*"; exit 1; }
@@ -310,5 +318,9 @@ else
     log "Backup committed and pushed"
 fi
 
-_SUCCESS=true
-log "Backup complete"
+if [ "$_SQLITE_LINES" -gt 0 ]; then
+    _SUCCESS=true
+else
+    log "WARNING: No SQLite data backed up — marking as failure"
+fi
+log "Backup complete (success=$_SUCCESS)"

--- a/scripts/migrate_reference_data.py
+++ b/scripts/migrate_reference_data.py
@@ -447,8 +447,8 @@ async def main(args: argparse.Namespace) -> None:
         for name, entries in sources:
             for e in entries:
                 logger.info(
-                    "  [%s] %-18s %s → %s",
-                    name, e.kind, e.identifier[:50], e.value[:60],
+                    "  [%s] %-18s %s",
+                    name, e.kind, e.identifier[:30] + "..." if len(e.identifier) > 30 else e.identifier,
                 )
         logger.info("Dry run complete. Re-run without --dry-run to ingest.")
         return
@@ -485,13 +485,13 @@ async def main(args: argparse.Namespace) -> None:
                 try:
                     unit_id, _ = await _ingest_entry(entry, store=store, db=db)
                     logger.info(
-                        "  [%s] upserted %s → unit_id=%s",
-                        name, entry.identifier[:60], unit_id[:12],
+                        "  [%s] upserted kind=%s → unit_id=%s",
+                        name, entry.kind, unit_id[:12],
                     )
                     succeeded += 1
                 except Exception:
                     logger.exception(
-                        "  [%s] failed to ingest %s", name, entry.identifier,
+                        "  [%s] failed to ingest kind=%s", name, entry.kind,
                     )
                     failed += 1
 

--- a/src/genesis/dashboard/routes/files.py
+++ b/src/genesis/dashboard/routes/files.py
@@ -78,7 +78,10 @@ def file_list():
     raw_path = request.args.get("path", str(_HOME / "genesis"))
     target = Path(raw_path).resolve()
 
-    if not _is_allowed(target):
+    # Allow listing the home directory for navigation between roots,
+    # but do NOT add _HOME to _ALLOWED_ROOTS (that would expose ~/.ssh etc.
+    # to read/write/delete endpoints). Only file_list gets this exception.
+    if target != _HOME.resolve() and not _is_allowed(target):
         return jsonify({"error": "Path not allowed"}), 403
 
     if not target.is_dir():
@@ -91,7 +94,7 @@ def file_list():
 
     items = []
     for entry in entries:
-        # Skip hidden files in top-level listing for cleanliness
+        # Skip hidden files except known safe directories
         if entry.name.startswith(".") and entry.name not in (".claude", ".genesis"):
             continue
         if entry.name.lower() in _BLOCKED_NAMES:
@@ -100,7 +103,7 @@ def file_list():
 
     return jsonify({
         "path": str(target),
-        "parent": str(target.parent) if target != target.parent else None,
+        "parent": str(target.parent) if target != target.parent and target.resolve() != _HOME.resolve() else None,
         "entries": items,
     })
 

--- a/src/genesis/dashboard/routes/state.py
+++ b/src/genesis/dashboard/routes/state.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json as _json
+import logging
 from datetime import UTC, datetime
 from pathlib import Path
 
 from flask import jsonify, request
 
 from genesis.dashboard._blueprint import _async_route, blueprint
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_approval_rows(rows: list[dict]) -> list[dict]:
@@ -272,7 +275,8 @@ def essential_knowledge_endpoint():
         mtime = datetime.fromtimestamp(ek_path.stat().st_mtime, tz=UTC).isoformat()
         return jsonify({"content": content, "updated_at": mtime})
     except OSError as e:
-        return jsonify({"content": None, "error": str(e)})
+        logger.warning("Failed to read essential knowledge: %s", e)
+        return jsonify({"content": None, "error": "Failed to read essential knowledge file"})
 
 
 
@@ -327,7 +331,8 @@ async def settings_timezone():
             os.unlink(tmp_path)
             raise
     except Exception as exc:
-        return jsonify({"error": f"Failed to write config: {exc}"}), 500
+        logger.error("Failed to write timezone config: %s", exc, exc_info=True)
+        return jsonify({"error": "Failed to write config"}), 500
 
     # Invalidate caches
     from genesis.env import _invalidate_local_config

--- a/src/genesis/dashboard/routes/updates.py
+++ b/src/genesis/dashboard/routes/updates.py
@@ -145,7 +145,8 @@ def update_check():
     # (tag conflicts from history rewrites should not block the check).
     branch_out, branch_err = _git_result("fetch", "origin", "main", timeout=30)
     if branch_out is None:
-        return jsonify({"error": f"git fetch failed: {branch_err}"}), 502
+        logger.error("git fetch failed: %s", branch_err)
+        return jsonify({"error": "git fetch failed"}), 502
 
     # Best-effort tag sync — force to handle rewritten history
     if _git("fetch", "origin", "--tags", "--force", timeout=15) is None:
@@ -234,7 +235,7 @@ def _apply_direct(pid_file: Path) -> tuple:
         return jsonify({"status": "triggered", "pid": proc.pid, "supervised": False})
     except Exception as exc:
         logger.error("Failed to trigger update: %s", exc, exc_info=True)
-        return jsonify({"error": str(exc)}), 500
+        return jsonify({"error": "Failed to trigger update"}), 500
 
 
 # ── Three-tier CC update prompts ─────────────────────────────────────

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -135,6 +135,7 @@
           fileWritable: false,
           fileDirty: false,
           saving: false,
+          sidebarCollapsed: false,
         },
 
         // ── Tasks tab state ────────────────────────────────────────
@@ -859,7 +860,7 @@
               if (domain === "autonomous_cli_policy") {
                 this.fetchAutonomousCliPolicy();
               }
-              if (d.needs_restart) { this.settingsRestartMessage = "Settings saved. Restart to apply changes."; }
+              if (d.needs_restart) { this.settingsRestartMessage = "Settings saved. Changes take effect after server restart."; }
             } else {
               const err = await resp.json().catch(() => ({}));
               alert("Save failed: " + (err.details ? err.details.join(", ") : err.error || "Unknown error"));
@@ -896,7 +897,7 @@
             if (resp.ok) {
               this.secretsEditing = {...this.secretsEditing, [keyName]: false};
               delete this.secretsValues[keyName];
-              this.secretsMessage = {type: 'restart', text: `${keyName} saved. Restart to apply changes.`};
+              this.secretsMessage = {type: 'restart', text: `${keyName} saved. Changes take effect after server restart.`};
               this.fetchSecrets();
             } else {
               this.secretsMessage = {type: 'error', text: d.error || 'Save failed'};
@@ -5147,7 +5148,7 @@
                   </div>
                   <div style="display:flex; gap:0.5rem; align-items:center;">
                     <template x-if="domain.needs_restart">
-                      <span style="font-size:0.65rem; background:#fff3cd; color:#856404; padding:2px 6px; border-radius:3px;" title="Changes to this setting require a genesis-server restart to take effect">restart to apply</span>
+                      <span style="font-size:0.65rem; background:#fff3cd; color:#856404; padding:2px 6px; border-radius:3px;" title="Changes to this setting require a genesis-server restart to take effect">requires restart</span>
                     </template>
                     <template x-if="$store.genesisDashboard.settingsEditing !== domain.name">
                       <button style="font-size:0.75rem; padding:2px 10px;" @click="$store.genesisDashboard.startEditSettings(domain.name)">Edit</button>
@@ -5305,7 +5306,7 @@
                           <span style="font-size:0.65rem; background:var(--color-bg-tertiary); padding:2px 6px; border-radius:3px;">locked</span>
                         </template>
                         <template x-if="domain.needs_restart && !domain.readonly">
-                          <span style="font-size:0.65rem; background:#fff3cd; color:#856404; padding:2px 6px; border-radius:3px;" title="Changes require a genesis-server restart to take effect">restart to apply</span>
+                          <span style="font-size:0.65rem; background:#fff3cd; color:#856404; padding:2px 6px; border-radius:3px;" title="Changes require a genesis-server restart to take effect">requires restart</span>
                         </template>
                         <template x-if="!domain.readonly && !domain.needs_restart">
                           <span style="font-size:0.65rem; background:#d4edda; color:#155724; padding:2px 6px; border-radius:3px;">hot-reload</span>
@@ -6134,11 +6135,16 @@
           </template>
           <span style="color:var(--color-text-secondary); font-family:monospace; word-break:break-all;"
                 x-text="$store.genesisDashboard.fileBrowser.path || 'Loading...'"></span>
+          <button @click="$store.genesisDashboard.fileBrowser.sidebarCollapsed = !$store.genesisDashboard.fileBrowser.sidebarCollapsed"
+                  style="cursor:pointer; background:rgba(255,255,255,0.05); color:var(--color-text-secondary); border:1px solid var(--color-border);
+                         padding:0.15rem 0.5rem; border-radius:3px; font-size:0.65rem; margin-left:auto;"
+                  x-text="$store.genesisDashboard.fileBrowser.sidebarCollapsed ? 'Show Files' : 'Hide Files'"></button>
         </div>
 
         <div style="display:flex; gap:1rem;">
           <!-- Directory listing -->
-          <div style="flex:0 0 45%; max-height:calc(100vh - 280px); overflow-y:auto; border-right:1px solid var(--color-border); padding-right:0.75rem;">
+          <div x-show="!$store.genesisDashboard.fileBrowser.sidebarCollapsed"
+               style="flex:0 0 30%; max-height:calc(100vh - 280px); overflow-y:auto; border-right:1px solid var(--color-border); padding-right:0.75rem;">
             <template x-if="$store.genesisDashboard.fileBrowser.loading">
               <div style="color:var(--color-text-secondary); font-size:0.75rem; padding:1rem;">Loading...</div>
             </template>

--- a/src/genesis/memory/knowledge_ingest.py
+++ b/src/genesis/memory/knowledge_ingest.py
@@ -123,8 +123,8 @@ async def ingest_knowledge_unit(
     )
 
     logger.info(
-        "Knowledge unit %s: %s (project=%s, domain=%s)",
+        "Knowledge unit %s (project=%s, domain=%s)",
         "ingested" if inserted else "updated",
-        actual_id, project, domain,
+        project, domain,
     )
     return actual_id

--- a/src/genesis/memory/reference_extraction.py
+++ b/src/genesis/memory/reference_extraction.py
@@ -329,14 +329,14 @@ async def ingest_reference_from_extraction(
         )
     except Exception:
         logger.warning(
-            "reference extractor ingest failed for kind=%s identifier=%s",
-            kind, identifier, exc_info=True,
+            "reference extractor ingest failed for kind=%s identifier=<redacted>",
+            kind, exc_info=True,
         )
         return None
 
     logger.info(
-        "Auto-captured reference: kind=%s identifier=%s session=%s",
-        kind, identifier, source_session_id or "unknown",
+        "Auto-captured reference: kind=%s identifier=<redacted> session=%s",
+        kind, source_session_id or "unknown",
     )
     return unit_id
 

--- a/src/genesis/routing/litellm_delegate.py
+++ b/src/genesis/routing/litellm_delegate.py
@@ -92,17 +92,21 @@ class LiteLLMDelegate:
             )
             content = response.choices[0].message.content
             usage = getattr(response, "usage", None)
-            cost_known = True
-            try:
-                cost = litellm.completion_cost(completion_response=response)
-            except Exception:
+            if cfg.is_free:
                 cost = 0.0
-                cost_known = False
-                if _should_log_failure(provider):
-                    logger.warning(
-                        "Cost calculation failed for %s/%s — recording as $0.00",
-                        provider, model_string, exc_info=True,
-                    )
+                cost_known = True
+            else:
+                cost_known = True
+                try:
+                    cost = litellm.completion_cost(completion_response=response)
+                except Exception:
+                    cost = 0.0
+                    cost_known = False
+                    if _should_log_failure(provider):
+                        logger.warning(
+                            "Cost calculation failed for %s/%s — recording as $0.00",
+                            provider, model_string, exc_info=True,
+                        )
             return CallResult(
                 success=True,
                 content=content,

--- a/tests/test_routing/test_litellm_delegate.py
+++ b/tests/test_routing/test_litellm_delegate.py
@@ -20,6 +20,7 @@ def _config(
     provider_type="groq",
     model_id="llama-3.3-70b-versatile",
     base_url=None,
+    is_free=True,
 ) -> RoutingConfig:
     """Minimal config with one provider."""
     return RoutingConfig(
@@ -28,7 +29,7 @@ def _config(
                 name="test-provider",
                 provider_type=provider_type,
                 model_id=model_id,
-                is_free=True,
+                is_free=is_free,
                 rpm_limit=30,
                 open_duration_s=120,
                 base_url=base_url,
@@ -104,7 +105,7 @@ def test_resolve_api_key_not_found():
 
 
 async def test_call_success():
-    config = _config()
+    config = _config(is_free=False)
     delegate = LiteLLMDelegate(config)
     mock_resp = _mock_response(content="Test output", prompt_tokens=15, completion_tokens=8)
 
@@ -122,6 +123,27 @@ async def test_call_success():
     assert result.input_tokens == 15
     assert result.output_tokens == 8
     assert result.cost_usd == 0.0003
+
+
+async def test_free_provider_always_zero_cost():
+    """Free providers should always report cost=0.0 without calling litellm.completion_cost."""
+    config = _config(is_free=True)
+    delegate = LiteLLMDelegate(config)
+    mock_resp = _mock_response(content="Free output", prompt_tokens=10, completion_tokens=5)
+
+    with patch("genesis.routing.litellm_delegate.litellm") as mock_litellm:
+        mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+
+        result = await delegate.call(
+            "test-provider", "llama-3.3-70b-versatile",
+            [{"role": "user", "content": "Hello"}],
+        )
+
+    assert result.success is True
+    assert result.cost_usd == 0.0
+    assert result.cost_known is True
+    # completion_cost should never be called for free providers
+    mock_litellm.completion_cost.assert_not_called()
 
 
 async def test_call_passes_model_string():
@@ -284,8 +306,8 @@ async def test_call_generic_error():
 
 
 async def test_call_cost_extraction_fallback():
-    """If completion_cost raises, cost_usd should be 0.0 not an exception."""
-    config = _config()
+    """If completion_cost raises on a paid provider, cost_usd should be 0.0 and cost_known False."""
+    config = _config(is_free=False)
     delegate = LiteLLMDelegate(config)
     mock_resp = _mock_response()
 
@@ -300,6 +322,7 @@ async def test_call_cost_extraction_fallback():
 
     assert result.success is True
     assert result.cost_usd == 0.0
+    assert result.cost_known is False
 
 
 # ── Provider failure logging ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Cherry-pick of the bug-fix work from PR #54 onto current main (the old branch had 142-commit divergence with 55 merge conflicts).

- **backup.sh**: Source secrets.env in cron context for backup passphrase; conditional success flag when no SQLite data backed up
- **litellm_delegate.py**: Free providers (`cfg.is_free`) always report cost=0.0 without calling `litellm.completion_cost()`
- **files.py**: Allow listing home directory for navigation between roots (listing-only; read/write/delete still restricted); suppress Up button at home boundary
- **genesis_dashboard.html**: "restart to apply" → "requires restart" badge text; directory listing 45% → 30% width with collapse toggle
- **test_litellm_delegate.py**: Add is_free parameter, new free-provider test, fix vacuous cost-fallback test

Supersedes #54 (will close after merge).

## Test plan
- [ ] `bash ~/genesis/scripts/backup.sh` succeeds with encrypted secrets
- [ ] Free provider LLM calls show $0.00 cost
- [ ] Dashboard config page says "requires restart"
- [ ] Files tab: navigate Up from ~/genesis to home, browse .claude/.genesis, no Up at home boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)