### PR TITLE
fix: resolve cognitive state catch-22 and dashboard quality issues

### DIFF
--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -106,8 +106,6 @@
         apiKeysModal: { open: false },
         modules: [],
         providersDetail: [],
-        codeFindings: [],
-        codeAuditStats: null,
         operationalVitals: null,
         autonomousCliPolicy: null,
         cognitiveState: null,
@@ -186,7 +184,6 @@
           sessions: { state: "idle", lastSuccess: null, error: null },
 
           // providerActivity removed — data now in operationalVitals
-          codeQuality: { state: "idle", lastSuccess: null, error: null },
           attention: { state: "idle", lastSuccess: null, error: null },
           budgets: { state: "idle", lastSuccess: null, error: null },
           routing: { state: "idle", lastSuccess: null, error: null },
@@ -205,7 +202,6 @@
         _activityInterval: null,
 
         _sessionsInterval: null,
-        _codeFindingsInterval: null,
         _modulesInterval: null,
         _routingInterval: null,
         _approvalsInterval: null,
@@ -219,7 +215,7 @@
         _TAB_INTERVALS: {
           overview:  ["_cognitiveInterval", "_ekInterval", "_modulesInterval"],
           chat:      [],
-          internals: ["_codeFindingsInterval", "_awarenessInterval", "_routingInterval", "_jobHealthInterval", "_approvalsInterval"],
+          internals: ["_awarenessInterval", "_routingInterval", "_jobHealthInterval", "_approvalsInterval"],
           sessions:  ["_activityInterval", "_sessionsInterval"],
           config:    [],
           files:     [],
@@ -263,8 +259,7 @@
               this._modulesInterval = setInterval(() => { this.fetchModules(); this.fetchProvidersDetail(); }, 30000);
               break;
             case "internals":
-              if (first) { this.fetchCodeFindings(); this.fetchAwarenessSignals(); this.fetchOperationalVitals(); this.fetchAutonomyConfig(); this.fetchAutonomousCliPolicy(); this.fetchRoutingConfig(); this.fetchJobHealth(); this.fetchApprovals(); }
-              this._codeFindingsInterval = setInterval(() => this.fetchCodeFindings(), 60000);
+              if (first) { this.fetchAwarenessSignals(); this.fetchOperationalVitals(); this.fetchAutonomyConfig(); this.fetchAutonomousCliPolicy(); this.fetchRoutingConfig(); this.fetchJobHealth(); this.fetchApprovals(); }
               this._awarenessInterval = setInterval(() => this.fetchAwarenessSignals(), 30000);
               this._routingInterval = setInterval(() => this.fetchRoutingConfig(), 15000);
               this._jobHealthInterval = setInterval(() => this.fetchJobHealth(), 60000);
@@ -467,26 +462,6 @@
           } catch (e) {
             console.error("Providers detail fetch failed:", e);
             this.failFetch("providersDetail", "Providers endpoint unavailable");
-          }
-        },
-
-        async fetchCodeFindings() {
-          this.startFetch("codeQuality");
-          try {
-            const [findingsResp, statsResp] = await Promise.all([
-              fetchApi("/api/genesis/recon/findings?limit=10"),
-              fetchApi("/api/genesis/surplus/activity"),
-            ]);
-            if (findingsResp?.ok) this.codeFindings = await findingsResp.json();
-            if (statsResp?.ok) this.codeAuditStats = await statsResp.json();
-            if (findingsResp?.ok || statsResp?.ok) {
-              this.finishFetch("codeQuality");
-            } else {
-              this.failFetch("codeQuality", "Code quality data unavailable");
-            }
-          } catch (e) {
-            console.error("Code findings fetch failed:", e);
-            this.failFetch("codeQuality", "Code quality data unavailable");
           }
         },
 
@@ -2059,6 +2034,14 @@
             if (probe.free_pct > 10) return "#f0ad4e";
             return "#d9534f";
           }
+          // CC tmp: derive from cc_tier/sys_tier
+          if (probe?.cc_tier != null || probe?.sys_tier != null) {
+            const worst = [probe.cc_tier, probe.sys_tier].includes("red") ? "red"
+              : [probe.cc_tier, probe.sys_tier].includes("orange") ? "orange" : "green";
+            if (worst === "red") return "#d9534f";
+            if (worst === "orange") return "#f0ad4e";
+            return "#4caf50";
+          }
           return "#666";
         },
 
@@ -3054,7 +3037,8 @@
             <div class="health-card-value">
               <template x-if="$store.genesisDashboard.health.infrastructure">
                 <template x-for="(probe, name) in $store.genesisDashboard.health.infrastructure" :key="name">
-                  <div style="margin-bottom: 0.2rem; cursor: default;"
+                  <div x-show="!['container_memory', 'disk', 'cpu'].includes(name)"
+                       style="margin-bottom: 0.2rem; cursor: default;"
                        :title="probe.error
                          ? name + ': ERROR — ' + probe.error
                          : probe.latency_ms != null
@@ -4801,79 +4785,6 @@
             </div>
           </template>
         </div>
-      </div>
-    </div>
-
-    <!-- Panel: Code Quality [Tab: internals] -->
-    <div class="panel" x-data="{ codeQualityOpen: false }" x-show="$store.genesisDashboard.activeTab === 'internals'">
-      <div class="panel-header" style="cursor: pointer;" @click="codeQualityOpen = !codeQualityOpen">
-        <span class="material-symbols-outlined"
-              :style="codeQualityOpen ? 'transform: rotate(90deg)' : ''">
-          chevron_right
-        </span>
-        <span class="material-symbols-outlined">code</span>
-        Code Quality
-        <span class="panel-status">
-          <span class="status-dot" :style="`background:${$store.genesisDashboard.panelStateColor('codeQuality')}`"></span>
-          <span x-text="$store.genesisDashboard.panelStateLabel('codeQuality')"></span>
-        </span>
-        <template x-if="$store.genesisDashboard.codeAuditStats">
-          <span style="margin-left: auto; font-size: 0.75rem; opacity: 0.7;"
-                x-text="(() => {
-                  const s = $store.genesisDashboard.codeAuditStats;
-                  if (!s?.last_audit) return 'no audit data yet';
-                  const open = $store.genesisDashboard.codeFindings.filter(f => !f.resolved).length;
-                  const total = $store.genesisDashboard.codeFindings.length;
-                  return open + ' open / ' + total + ' total findings';
-                })()"></span>
-        </template>
-      </div>
-      <div class="panel-body" x-show="codeQualityOpen" x-transition>
-        <template x-if="$store.genesisDashboard.panelStatusDetail('codeQuality')">
-          <div class="inline-warning" x-text="$store.genesisDashboard.panelStatusDetail('codeQuality')"></div>
-        </template>
-        <!-- Audit stats summary -->
-        <template x-if="$store.genesisDashboard.codeAuditStats">
-          <div style="display: flex; gap: 1rem; margin-bottom: 0.75rem; flex-wrap: wrap;">
-            <div style="font-size: 0.78rem;">
-              <span style="font-weight: 600;">Last Audit:</span>
-              <span x-text="$store.genesisDashboard.codeAuditStats.last_audit ? new Date($store.genesisDashboard.codeAuditStats.last_audit.created_at).toLocaleString() : 'Never'"
-                    :style="$store.genesisDashboard.codeAuditStats.last_audit ? '' : 'color: var(--color-text-secondary)'"></span>
-              <template x-if="$store.genesisDashboard.codeAuditStats.last_audit">
-                <span style="opacity: 0.6; font-size: 0.7rem;"
-                      x-text="'(' + $store.genesisDashboard.codeAuditStats.last_audit.status + ')'"></span>
-              </template>
-            </div>
-            <template x-if="Object.keys($store.genesisDashboard.codeAuditStats.severity_counts || {}).length > 0">
-              <div style="font-size: 0.78rem;">
-                <span style="font-weight: 600;">Severity:</span>
-                <template x-for="(count, sev) in $store.genesisDashboard.codeAuditStats.severity_counts" :key="sev">
-                  <span style="margin-left: 0.4rem; padding: 0.1rem 0.4rem; border-radius: 3px; font-size: 0.72rem;"
-                        :style="sev === 'high' || sev === 'critical' ? 'background: #d9534f; color: white;' : sev === 'medium' ? 'background: #f0ad4e; color: #333;' : 'background: var(--color-border); color: var(--color-text);'"
-                        x-text="sev + ': ' + count"></span>
-                </template>
-              </div>
-            </template>
-          </div>
-        </template>
-        <!-- Findings list -->
-        <template x-if="$store.genesisDashboard.codeFindings.length === 0">
-          <div style="font-size: 0.78rem; color: var(--color-text-secondary); padding: 0.5rem 0;">No code audit findings.</div>
-        </template>
-        <template x-for="f in $store.genesisDashboard.codeFindings" :key="f.id">
-          <div style="font-size: 0.78rem; padding: 0.4rem 0; border-bottom: 1px solid var(--color-border);"
-               :style="f.resolved ? 'opacity: 0.45; text-decoration: line-through;' : ''">
-            <span style="padding: 0.1rem 0.35rem; border-radius: 3px; font-size: 0.68rem; font-weight: 600; margin-right: 0.3rem;"
-                  :style="(f.parsed?.severity === 'high' || f.parsed?.severity === 'critical') ? 'background: #d9534f; color: white;' : f.parsed?.severity === 'medium' ? 'background: #f0ad4e; color: #333;' : 'background: var(--color-border); color: var(--color-text);'"
-                  x-text="(f.parsed?.severity || f.priority || 'info').toUpperCase()"></span>
-            <template x-if="f.resolved">
-              <span style="padding: 0.1rem 0.3rem; border-radius: 3px; font-size: 0.62rem; background: #4caf50; color: white; margin-right: 0.3rem;">RESOLVED</span>
-            </template>
-            <span x-text="f.parsed?.title || f.parsed?.message || f.content?.substring(0, 80) || '(no title)'"></span>
-            <span style="opacity: 0.5; font-size: 0.68rem; margin-left: 0.3rem;"
-                  x-text="f.created_at ? new Date(f.created_at).toLocaleDateString() : ''"></span>
-          </div>
-        </template>
       </div>
     </div>
 

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -120,6 +120,16 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "DELETE FROM signal_weights WHERE signal_name = 'unprocessed_memory_backlog'"
     )
 
+    # Cognitive state catch-22: stale_pending_items signal was collected
+    # but had no weight row, contributing zero to Deep scorer.
+    await db.execute(
+        "INSERT OR IGNORE INTO signal_weights "
+        "(signal_name, source_mcp, current_weight, initial_weight, "
+        "min_weight, max_weight, feeds_depths) "
+        "VALUES ('stale_pending_items', 'genesis', 0.45, 0.45, 0.0, 1.0, "
+        "'[\"Deep\"]')"
+    )
+
     # Reflection starvation fix: tighten strategic ceiling from 7d to 3d
     # Only apply if still at default 604800 to avoid overwriting manual tuning
     await db.execute(

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1040,6 +1040,7 @@ SIGNAL_WEIGHTS_SEED = [
     ("time_since_last_strategic", "clock", 0.50, 0.50, 0.0, 1.0, '["Strategic"]'),
     ("micro_count_since_light", "awareness_loop", 0.50, 0.50, 0.0, 1.0, '["Light"]'),
     ("cc_version_changed", "awareness_loop", 0.60, 0.60, 0.0, 1.0, '["Light"]'),
+    ("stale_pending_items", "genesis", 0.45, 0.45, 0.0, 1.0, '["Deep"]'),
 ]
 
 DEPTH_THRESHOLDS_SEED = [

--- a/src/genesis/learning/signals/pending_items.py
+++ b/src/genesis/learning/signals/pending_items.py
@@ -15,7 +15,8 @@ STALE_THRESHOLD_DAYS = 3
 class PendingItemCollector:
     """Reads cognitive state pending actions, returns stale-item urgency signal.
 
-    Signal value: 0.0 = no stale items, 1.0 = items pending > 7 days.
+    Signal value: 1.0 = missing/error state (triggers deep reflection to generate it),
+    0.0 = no stale items, up to 1.0 = items pending > 7 days.
     Intermediate: linear interpolation between 3-day and 7-day thresholds.
     """
 
@@ -33,10 +34,10 @@ class PendingItemCollector:
             )
             row = await cursor.fetchone()
         except Exception:
-            return self._reading(0.0, "db_error")
+            return self._reading(1.0, "db_error")
 
         if not row:
-            return self._reading(0.0, "no_cognitive_state")
+            return self._reading(1.0, "no_cognitive_state")
 
         content, created_at_str = row
         try:
@@ -44,7 +45,7 @@ class PendingItemCollector:
             if created_at.tzinfo is None:
                 created_at = created_at.replace(tzinfo=UTC)
         except (ValueError, TypeError):
-            return self._reading(0.0, "bad_timestamp")
+            return self._reading(1.0, "bad_timestamp")
 
         age = now - created_at
         age_days = age.total_seconds() / 86400

--- a/src/genesis/memory/essential_knowledge.py
+++ b/src/genesis/memory/essential_knowledge.py
@@ -48,10 +48,10 @@ async def generate_deterministic(db: aiosqlite.Connection) -> str:
         for topic in sessions[:5]:
             parts.append(f"- {topic}")
 
-    # Recent decisions: observations of type 'decision' from last 7 days
+    # Key insights: meaningful observations from last 7 days
     decisions = await _recent_decisions(db, days=7)
     if decisions:
-        parts.append("\n### Recent Decisions (7d)")
+        parts.append("\n### Key Insights (7d)")
         for decision in decisions[:5]:
             parts.append(f"- {decision}")
 
@@ -121,24 +121,46 @@ async def _recent_session_topics(db: aiosqlite.Connection, days: int = 7) -> lis
             (f"-{days} days",),
         )
         rows = await cursor.fetchall()
-        return [row[0][:100] for row in rows if row[0]]
+        return [row[0][:200] for row in rows if row[0]]
     except Exception:
         return []
 
 
 async def _recent_decisions(db: aiosqlite.Connection, days: int = 7) -> list[str]:
-    """Get recent decision observations."""
+    """Get recent meaningful observations (exclusion-based to capture future types)."""
+    # Exclude noisy/mechanical types; everything else surfaces.
+    _EXCLUDED_TYPES = (
+        "awareness_tick",
+        "genesis_version_change",
+        "cc_version_available",
+        "cc_version_baseline",
+        "genesis_update_available",
+        "genesis_version_baseline",
+        "genesis_update_failed",
+        "light_escalation_pending",
+        "light_escalation_resolved",
+        "memory_index",
+        "bugfix_committed",
+        "light_reflection",
+        "micro_reflection",
+        "reflection_output",
+        "user_model_delta",
+        "memory_operation_executed",
+        "memory_operation",
+        "cc_memory_file",
+    )
+    placeholders = ",".join("?" * len(_EXCLUDED_TYPES))
     try:
         cursor = await db.execute(
             "SELECT content FROM observations "
-            "WHERE type IN ('decision', 'architecture_gap', 'learning') "
+            f"WHERE type NOT IN ({placeholders}) "
             "AND resolved = 0 "
             "AND created_at > datetime('now', ?) "
             "ORDER BY created_at DESC LIMIT 10",
-            (f"-{days} days",),
+            (*_EXCLUDED_TYPES, f"-{days} days"),
         )
         rows = await cursor.fetchall()
-        return [row[0][:120] for row in rows if row[0]]
+        return [row[0][:250] for row in rows if row[0]]
     except Exception:
         return []
 

--- a/src/genesis/runtime/init/surplus.py
+++ b/src/genesis/runtime/init/surplus.py
@@ -40,6 +40,7 @@ async def init(rt: GenesisRuntime) -> None:
             idle_detector=idle_detector,
             compute_availability=compute,
             event_bus=rt._event_bus,
+            enable_code_audits=False,
         )
 
         try:

--- a/tests/test_learning/test_signals.py
+++ b/tests/test_learning/test_signals.py
@@ -295,11 +295,11 @@ class TestPendingItemCollector:
         )
         await db.commit()
 
-    async def test_no_state_returns_zero(self, db):
+    async def test_no_state_returns_high_urgency(self, db):
         from genesis.learning.signals.pending_items import PendingItemCollector
         r = await PendingItemCollector(db).collect()
         assert r.name == "stale_pending_items"
-        assert r.value == 0.0
+        assert r.value == 1.0
 
     async def test_recent_items_return_zero(self, db):
         from genesis.learning.signals.pending_items import PendingItemCollector


### PR DESCRIPTION
## Summary
Cherry-pick of #62 onto current main (old branch diverged 153 commits).

- stale_pending_items signal: return 1.0 when cognitive state missing (was 0.0 catch-22)
- CC Temp probe: show green/yellow/red instead of gray
- Dashboard: hide duplicate infra metrics, remove dead Code Quality panel
- Essential knowledge: exclusion-based query instead of phantom 'decision' type filter

Supersedes #62.

## Test plan
- [ ] Dashboard shows no gray dots for cc_tmp probe
- [ ] Essential knowledge section populated with Key Insights

🤖 Generated with [Claude Code](https://claude.com/claude-code)