### PR TITLE
feat(awareness): scoring overhaul — signal redistribution, subsystem signals, citations

### DIFF
--- a/src/genesis/awareness/signals.py
+++ b/src/genesis/awareness/signals.py
@@ -129,6 +129,51 @@ class BudgetCollector:
         return _bootstrap_placeholder_reading(self.signal_name, "health_mcp")
 
 
+# GROUNDWORK(signal-bootstrap): pre-swap placeholder. Replaced at runtime
+# by genesis.learning.signals.light_cascade.LightCascadeCollector.
+class LightCascadeCollector:
+    signal_name = "light_count_since_deep"
+
+    async def collect(self) -> SignalReading:
+        return _bootstrap_placeholder_reading(self.signal_name, "awareness_loop")
+
+
+# GROUNDWORK(signal-bootstrap): pre-swap placeholder. Replaced at runtime
+# by genesis.learning.signals.sentinel_activity.SentinelActivityCollector.
+class SentinelActivityCollector:
+    signal_name = "sentinel_activity"
+
+    async def collect(self) -> SignalReading:
+        return _bootstrap_placeholder_reading(self.signal_name, "sentinel")
+
+
+# GROUNDWORK(signal-bootstrap): pre-swap placeholder. Replaced at runtime
+# by genesis.learning.signals.guardian_activity.GuardianActivityCollector.
+class GuardianActivityCollector:
+    signal_name = "guardian_activity"
+
+    async def collect(self) -> SignalReading:
+        return _bootstrap_placeholder_reading(self.signal_name, "guardian")
+
+
+# GROUNDWORK(signal-bootstrap): pre-swap placeholder. Replaced at runtime
+# by genesis.learning.signals.surplus_activity.SurplusActivityCollector.
+class SurplusActivityCollector:
+    signal_name = "surplus_activity"
+
+    async def collect(self) -> SignalReading:
+        return _bootstrap_placeholder_reading(self.signal_name, "surplus")
+
+
+# GROUNDWORK(signal-bootstrap): pre-swap placeholder. Replaced at runtime
+# by genesis.learning.signals.autonomy_activity.AutonomyActivityCollector.
+class AutonomyActivityCollector:
+    signal_name = "autonomy_activity"
+
+    async def collect(self) -> SignalReading:
+        return _bootstrap_placeholder_reading(self.signal_name, "autonomy")
+
+
 class ErrorSpikeCollector:
     signal_name = "software_error_spike"
 

--- a/src/genesis/cc/reflection_bridge/_prompts.py
+++ b/src/genesis/cc/reflection_bridge/_prompts.py
@@ -116,6 +116,67 @@ def _format_observations_json(observations: list[dict], *, max_count: int = _OBS
     ], indent=2)
 
 
+# Source category mapping — mirrors perception/context.py categories.
+# Acceptable duplication (10 lines) to avoid cross-module coupling.
+_SOURCE_CATEGORIES: dict[str, str] = {
+    "sentinel": "Sentinel", "sentinel_dispatch": "Sentinel",
+    "guardian": "Guardian", "guardian_watchdog": "Guardian",
+    "recon": "Recon", "recon_pipeline": "Recon", "recon_mcp": "Recon",
+    "surplus_promotion": "Surplus", "surplus": "Surplus", "surplus_scheduler": "Surplus",
+    "reflection": "Reflections", "light_reflection": "Reflections",
+    "deep_reflection": "Reflections", "cc_reflection_deep": "Reflections",
+    "cc_reflection_light": "Reflections", "cc_reflection_strategic": "Reflections",
+    "strategic_reflection": "Reflections",
+    "conversation": "Conversation", "conversation_intent": "Conversation",
+    "conversation_analysis": "Conversation", "conversation_followup": "Conversation",
+    "inbox_evaluation": "Inbox",
+}
+_CATEGORY_ORDER = [
+    "Sentinel", "Guardian", "Recon", "Reflections",
+    "Surplus", "Conversation", "Inbox", "Other",
+]
+
+
+def _format_observations_grouped(
+    observations: list[dict],
+    *,
+    max_count: int = _OBS_MAX_COUNT,
+) -> str:
+    """Format observations grouped by source subsystem with citation anchors.
+
+    Replaces flat JSON rendering for Deep/Strategic prompts with structured
+    markdown that makes subsystem provenance clear at a glance.
+    """
+    obs = observations[:max_count]
+    if not obs:
+        return ""
+
+    per_item = max(_OBS_MIN_PER_ITEM, _OBS_TOTAL_CHAR_BUDGET // len(obs))
+
+    # Group by category
+    groups: dict[str, list[dict]] = {}
+    for o in obs:
+        cat = _SOURCE_CATEGORIES.get(o.get("source", ""), "Other")
+        groups.setdefault(cat, []).append(o)
+
+    lines: list[str] = []
+    for cat in _CATEGORY_ORDER:
+        if cat not in groups:
+            continue
+        lines.append(f"### {cat}")
+        for o in groups[cat]:
+            oid = o.get("id", "?")
+            short_id = oid[:8] if len(oid) > 8 else oid
+            priority = o.get("priority", "?")
+            obs_type = o.get("type", "?")
+            content = o.get("content", "")[:per_item]
+            created = o.get("created_at", "?")
+            lines.append(f"- [#{short_id}] [{priority}] {obs_type} ({created}): {content}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
 # ── Data pointers ────────────────────────────────────────────────────
 
 
@@ -244,8 +305,8 @@ async def build_strategic_prompt_enriched(
     ]
 
     if bundle.recent_observations:
-        obs_summary = _format_observations_json(bundle.recent_observations)
-        parts.append(f"\n## Recent Observations\n```json\n{obs_summary}\n```")
+        obs_summary = _format_observations_grouped(bundle.recent_observations)
+        parts.append(f"\n## Recent Observations\n{obs_summary}")
 
     cost = bundle.cost_summary
     parts.append(
@@ -301,8 +362,8 @@ async def build_enriched_prompt(
         parts.append("\n## Active Jobs\n" + ", ".join(j.value for j in jobs))
 
     if bundle.recent_observations and bundle.pending_work.memory_consolidation:
-        obs_summary = _format_observations_json(bundle.recent_observations)
-        parts.append(f"\n## Recent Observations (for consolidation)\n```json\n{obs_summary}\n```")
+        obs_summary = _format_observations_grouped(bundle.recent_observations)
+        parts.append(f"\n## Recent Observations (for consolidation)\n{obs_summary}")
 
     if bundle.surplus_staging_items:
         _surplus_limit = max(200, _OBS_TOTAL_CHAR_BUDGET // max(len(bundle.surplus_staging_items), 1))

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -689,6 +689,31 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "WHERE depth_name = 'Light' AND floor_seconds = 21600"
     )
 
+    # 2026-04-17: Signal redistribution — cc_version_changed to Micro-only.
+    # (critical_failure and software_error_spike already migrated above.)
+    await db.execute(
+        "UPDATE signal_weights SET feeds_depths = '[\"Micro\"]', "
+        "current_weight = 0.50, initial_weight = 0.50 "
+        "WHERE signal_name = 'cc_version_changed'"
+    )
+
+    # 2026-04-17: New signals — cascade bridge + subsystem activity + ghost activation.
+    # INSERT OR IGNORE so re-running is idempotent.
+    _new_signals = [
+        ("light_count_since_deep", "awareness_loop", 0.50, 0.50, 0.0, 1.0, '["Deep"]'),
+        ("sentinel_activity", "sentinel", 0.60, 0.60, 0.0, 1.0, '["Micro"]'),
+        ("guardian_activity", "guardian", 0.50, 0.50, 0.0, 1.0, '["Micro"]'),
+        ("surplus_activity", "surplus", 0.45, 0.45, 0.0, 1.0, '["Micro"]'),
+        ("autonomy_activity", "autonomy", 0.60, 0.60, 0.0, 1.0, '["Micro"]'),
+        ("stale_pending_items", "cognitive_state", 0.35, 0.35, 0.0, 1.0, '["Micro"]'),
+    ]
+    for row in _new_signals:
+        await db.execute(
+            "INSERT OR IGNORE INTO signal_weights "
+            "(signal_name, source_mcp, current_weight, initial_weight, min_weight, max_weight, feeds_depths) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            row,
+        )
 
     # Phase 1.5: backfill memory_metadata from Qdrant + pending_embeddings.
     # New memories write metadata at store time, but pre-existing memories

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1035,12 +1035,22 @@ SIGNAL_WEIGHTS_SEED = [
     # Signal collectors and cognitive-state flag removed in the same sweep.
     # Existing rows cleaned up by _migrate_add_columns() on next boot.
     ("budget_pct_consumed", "health_mcp", 0.40, 0.40, 0.0, 1.0, '["Light","Deep"]'),
-    ("software_error_spike", "health_mcp", 0.70, 0.70, 0.0, 1.0, '["Micro","Light"]'),
-    ("critical_failure", "health_mcp", 0.90, 0.90, 0.0, 1.0, '["Light"]'),
+    # 2026-04-17: health delta signals moved to Micro-only — they matter when
+    # they flip state, not as persistent conditions driving Light reflections.
+    ("software_error_spike", "health_mcp", 0.70, 0.70, 0.0, 1.0, '["Micro"]'),
+    ("critical_failure", "health_mcp", 0.70, 0.70, 0.0, 1.0, '["Micro"]'),
     ("time_since_last_strategic", "clock", 0.50, 0.50, 0.0, 1.0, '["Strategic"]'),
     ("micro_count_since_light", "awareness_loop", 0.50, 0.50, 0.0, 1.0, '["Light"]'),
-    ("cc_version_changed", "awareness_loop", 0.60, 0.60, 0.0, 1.0, '["Light"]'),
-    ("stale_pending_items", "genesis", 0.45, 0.45, 0.0, 1.0, '["Deep"]'),
+    ("cc_version_changed", "awareness_loop", 0.50, 0.50, 0.0, 1.0, '["Micro"]'),
+    # 2026-04-17: cascade bridge — Light accumulation triggers Deep
+    ("light_count_since_deep", "awareness_loop", 0.50, 0.50, 0.0, 1.0, '["Deep"]'),
+    # 2026-04-17: subsystem activity signals — Micro delta detection
+    ("sentinel_activity", "sentinel", 0.60, 0.60, 0.0, 1.0, '["Micro"]'),
+    ("guardian_activity", "guardian", 0.50, 0.50, 0.0, 1.0, '["Micro"]'),
+    ("surplus_activity", "surplus", 0.45, 0.45, 0.0, 1.0, '["Micro"]'),
+    ("autonomy_activity", "autonomy", 0.60, 0.60, 0.0, 1.0, '["Micro"]'),
+    # 2026-04-17: ghost signal activation — collector already exists, just needs weight
+    ("stale_pending_items", "cognitive_state", 0.35, 0.35, 0.0, 1.0, '["Micro"]'),
 ]
 
 DEPTH_THRESHOLDS_SEED = [

--- a/src/genesis/learning/signals/__init__.py
+++ b/src/genesis/learning/signals/__init__.py
@@ -6,20 +6,30 @@ bootstrap contract: awareness init registers placeholder collectors from
 implementations exported here.
 """
 
+from genesis.learning.signals.autonomy_activity import AutonomyActivityCollector
 from genesis.learning.signals.budget import BudgetCollector
 from genesis.learning.signals.cc_version import CCVersionCollector
 from genesis.learning.signals.conversation import ConversationCollector
 from genesis.learning.signals.critical_failure import CriticalFailureCollector
 from genesis.learning.signals.error_spike import ErrorSpikeCollector
 from genesis.learning.signals.genesis_version import GenesisVersionCollector
+from genesis.learning.signals.guardian_activity import GuardianActivityCollector
+from genesis.learning.signals.light_cascade import LightCascadeCollector
+from genesis.learning.signals.sentinel_activity import SentinelActivityCollector
+from genesis.learning.signals.surplus_activity import SurplusActivityCollector
 from genesis.learning.signals.task_quality import TaskQualityCollector
 
 __all__ = [
+    "AutonomyActivityCollector",
     "BudgetCollector",
     "CCVersionCollector",
-    "GenesisVersionCollector",
     "ConversationCollector",
     "CriticalFailureCollector",
     "ErrorSpikeCollector",
+    "GenesisVersionCollector",
+    "GuardianActivityCollector",
+    "LightCascadeCollector",
+    "SentinelActivityCollector",
+    "SurplusActivityCollector",
     "TaskQualityCollector",
 ]

--- a/src/genesis/learning/signals/autonomy_activity.py
+++ b/src/genesis/learning/signals/autonomy_activity.py
@@ -1,0 +1,77 @@
+"""AutonomyActivityCollector — reports autonomy state transitions as awareness signal."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+import aiosqlite
+
+from genesis.awareness.types import SignalReading
+from genesis.db.crud import autonomy
+
+logger = logging.getLogger(__name__)
+
+
+class AutonomyActivityCollector:
+    """Reports autonomy transition state as a 0.0–1.0 signal.
+
+    | Condition                                      | Signal Value |
+    |-----------------------------------------------|-------------|
+    | Stable (no corrections, no level gaps)        | 0.0         |
+    | Corrections accumulating (consecutive > 0)    | 0.3         |
+    | Near regression (consecutive >= threshold-1)  | 0.7         |
+    | Regression active (current < earned level)    | 1.0         |
+
+    Checks ALL autonomy categories — the worst state drives the signal.
+    """
+
+    signal_name = "autonomy_activity"
+    _REGRESSION_THRESHOLD = 3  # consecutive corrections before regression likely
+
+    def __init__(self, db: aiosqlite.Connection) -> None:
+        self._db = db
+
+    async def collect(self) -> SignalReading:
+        try:
+            categories = await autonomy.list_all(self._db)
+        except Exception:
+            logger.error("AutonomyActivityCollector DB query failed", exc_info=True)
+            return self._reading(0.0, "db_error")
+
+        if not categories:
+            return self._reading(0.0, "no_categories")
+
+        worst_value = 0.0
+        worst_source = "stable"
+
+        for cat in categories:
+            current_level = cat.get("current_level", 1)
+            earned_level = cat.get("earned_level", 1)
+            consecutive = cat.get("consecutive_corrections", 0)
+            category_name = cat.get("category", "unknown")
+
+            if current_level < earned_level:
+                # Active regression — strongest signal
+                if worst_value < 1.0:
+                    worst_value = 1.0
+                    worst_source = f"regression_{category_name}"
+            elif consecutive >= self._REGRESSION_THRESHOLD - 1:
+                # Near regression threshold
+                if worst_value < 0.7:
+                    worst_value = 0.7
+                    worst_source = f"near_regression_{category_name}"
+            elif consecutive > 0 and worst_value < 0.3:
+                # Corrections accumulating
+                worst_value = 0.3
+                worst_source = f"corrections_{category_name}"
+
+        return self._reading(worst_value, worst_source)
+
+    def _reading(self, value: float, source: str) -> SignalReading:
+        return SignalReading(
+            name=self.signal_name,
+            value=value,
+            source=source,
+            collected_at=datetime.now(UTC).isoformat(),
+        )

--- a/src/genesis/learning/signals/guardian_activity.py
+++ b/src/genesis/learning/signals/guardian_activity.py
@@ -1,0 +1,76 @@
+"""GuardianActivityCollector — reports Guardian heartbeat freshness."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from genesis.awareness.types import SignalReading
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_HEARTBEAT_PATH = Path.home() / ".genesis" / "guardian_heartbeat.json"
+
+# Staleness thresholds in seconds.
+_STALE_THRESHOLD_S = 300     # 5 minutes — Guardian may be delayed
+_VERY_STALE_THRESHOLD_S = 1800  # 30 minutes — Guardian likely dead
+
+
+class GuardianActivityCollector:
+    """Reports Guardian heartbeat freshness as a 0.0–1.0 signal.
+
+    Reads ~/.genesis/guardian_heartbeat.json (written by Guardian on host VM
+    via SSH into container).
+
+    | Heartbeat Age | Signal Value |
+    |--------------|-------------|
+    | < 5 min      | 0.0         |
+    | 5-30 min     | 0.5         |
+    | > 30 min     | 1.0         |
+    | File missing | 0.0         |
+    | Corrupt JSON | 0.5         |
+
+    FileNotFoundError → 0.0 is intentional: no heartbeat file means Guardian
+    was never configured, which is a valid state (not an alarm).
+    """
+
+    signal_name = "guardian_activity"
+
+    def __init__(self, *, heartbeat_path: Path | None = None) -> None:
+        self._path = heartbeat_path or _DEFAULT_HEARTBEAT_PATH
+
+    async def collect(self) -> SignalReading:
+        try:
+            raw = self._path.read_text()
+        except FileNotFoundError:
+            # Guardian never ran — not an alarm condition
+            return self._reading(0.0, "no_heartbeat_file")
+        except OSError:
+            logger.warning("GuardianActivityCollector: cannot read heartbeat file", exc_info=True)
+            return self._reading(0.5, "read_error")
+
+        try:
+            data = json.loads(raw)
+            timestamp_str = data.get("timestamp", "")
+            hb_time = datetime.fromisoformat(timestamp_str)
+            age_s = (datetime.now(UTC) - hb_time).total_seconds()
+        except (json.JSONDecodeError, ValueError, TypeError):
+            # Corrupt JSON — treat as stale
+            return self._reading(0.5, "corrupt_heartbeat")
+
+        if age_s < _STALE_THRESHOLD_S:
+            return self._reading(0.0, f"fresh_{age_s:.0f}s")
+        elif age_s < _VERY_STALE_THRESHOLD_S:
+            return self._reading(0.5, f"stale_{age_s:.0f}s")
+        else:
+            return self._reading(1.0, f"very_stale_{age_s:.0f}s")
+
+    def _reading(self, value: float, source: str) -> SignalReading:
+        return SignalReading(
+            name=self.signal_name,
+            value=value,
+            source=source,
+            collected_at=datetime.now(UTC).isoformat(),
+        )

--- a/src/genesis/learning/signals/light_cascade.py
+++ b/src/genesis/learning/signals/light_cascade.py
@@ -1,0 +1,62 @@
+"""LightCascadeCollector — counts Light ticks since last Deep reflection."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+
+from genesis.awareness.types import SignalReading
+from genesis.db.crud import awareness_ticks
+
+logger = logging.getLogger(__name__)
+
+
+class LightCascadeCollector:
+    """Counts Light-depth ticks since last Deep-depth tick.
+
+    Implements the Light -> Deep escalation bridge.
+    Normalizes: 0 lights = 0.0, 3+ lights = 1.0.
+
+    Threshold is 3 (vs micro_cascade's 5) because Light ticks are rarer
+    and each carries more synthesized content.
+    """
+
+    signal_name = "light_count_since_deep"
+
+    def __init__(self, db: aiosqlite.Connection) -> None:
+        self._db = db
+
+    async def collect(self) -> SignalReading:
+        last_deep = await awareness_ticks.last_at_depth(self._db, "Deep")
+
+        if last_deep:
+            cutoff = last_deep["created_at"]
+        else:
+            # No Deep tick ever — count recent Lights (last 7 days)
+            cutoff_dt = datetime.now(UTC) - timedelta(days=7)
+            cutoff = cutoff_dt.isoformat()
+
+        # Count Light ticks since cutoff
+        try:
+            cursor = await self._db.execute(
+                """SELECT COUNT(*) FROM awareness_ticks
+                   WHERE classified_depth = 'Light'
+                   AND created_at > ?""",
+                (cutoff,),
+            )
+            row = await cursor.fetchone()
+            count = row[0] if row else 0
+        except Exception:
+            logger.error("LightCascadeCollector DB query failed", exc_info=True)
+            count = 0
+
+        value = min(1.0, count / 3.0)
+
+        return SignalReading(
+            name=self.signal_name,
+            value=round(value, 3),
+            source="awareness_ticks",
+            collected_at=datetime.now(UTC).isoformat(),
+        )

--- a/src/genesis/learning/signals/sentinel_activity.py
+++ b/src/genesis/learning/signals/sentinel_activity.py
@@ -1,0 +1,51 @@
+"""SentinelActivityCollector — reports Sentinel state as awareness signal."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from genesis.awareness.types import SignalReading
+
+logger = logging.getLogger(__name__)
+
+# Sentinel state → signal value mapping.
+# Higher values = more concerning states that warrant Micro attention.
+_STATE_VALUES = {
+    "healthy": 0.0,
+    "investigating": 0.3,
+    "remediating": 0.7,
+    "escalated": 1.0,
+}
+
+
+class SentinelActivityCollector:
+    """Reports current Sentinel state as a 0.0–1.0 signal.
+
+    Reads the persistent state file written by the Sentinel dispatcher.
+    Uses the existing load_state() function which handles missing/corrupt
+    files gracefully (returns HEALTHY default).
+    """
+
+    signal_name = "sentinel_activity"
+
+    def __init__(self, *, state_path: Path | None = None) -> None:
+        self._state_path = state_path
+
+    async def collect(self) -> SignalReading:
+        try:
+            from genesis.sentinel.state import load_state
+
+            state_data = load_state(path=self._state_path)
+            value = _STATE_VALUES.get(state_data.current_state, 0.0)
+        except Exception:
+            logger.error("SentinelActivityCollector failed", exc_info=True)
+            value = 0.0
+
+        return SignalReading(
+            name=self.signal_name,
+            value=value,
+            source="sentinel_state",
+            collected_at=datetime.now(UTC).isoformat(),
+        )

--- a/src/genesis/learning/signals/surplus_activity.py
+++ b/src/genesis/learning/signals/surplus_activity.py
@@ -1,0 +1,82 @@
+"""SurplusActivityCollector — reports surplus task health as awareness signal."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+
+from genesis.awareness.types import SignalReading
+
+logger = logging.getLogger(__name__)
+
+
+class SurplusActivityCollector:
+    """Reports surplus task health over the last 24 hours.
+
+    | Condition                          | Signal Value |
+    |-----------------------------------|-------------|
+    | Idle or healthy (>80% success)    | 0.0         |
+    | Concerning (20-50% failure rate)  | 0.5         |
+    | Stuck tasks (running > 2h)        | 0.8         |
+    | Broken (>50% failure rate)        | 1.0         |
+    """
+
+    signal_name = "surplus_activity"
+
+    def __init__(self, db: aiosqlite.Connection) -> None:
+        self._db = db
+
+    async def collect(self) -> SignalReading:
+        now = datetime.now(UTC)
+        cutoff = (now - timedelta(hours=24)).isoformat()
+
+        try:
+            # Count completed and failed tasks in last 24h
+            cursor = await self._db.execute(
+                "SELECT status, COUNT(*) FROM surplus_tasks "
+                "WHERE created_at >= ? AND status IN ('completed', 'failed') "
+                "GROUP BY status",
+                (cutoff,),
+            )
+            counts = dict(await cursor.fetchall())
+            completed = counts.get("completed", 0)
+            failed = counts.get("failed", 0)
+
+            # Count stuck tasks (running > 2h)
+            stuck_cutoff = (now - timedelta(hours=2)).isoformat()
+            cursor = await self._db.execute(
+                "SELECT COUNT(*) FROM surplus_tasks "
+                "WHERE status = 'running' AND started_at < ?",
+                (stuck_cutoff,),
+            )
+            stuck = (await cursor.fetchone())[0]
+        except Exception:
+            logger.error("SurplusActivityCollector DB query failed", exc_info=True)
+            return self._reading(0.0, "db_error")
+
+        total = completed + failed
+        if total == 0 and stuck == 0:
+            return self._reading(0.0, "idle")
+
+        # Stuck tasks are a stronger signal than failure rate
+        if stuck > 0:
+            return self._reading(0.8, f"stuck_{stuck}")
+
+        failure_rate = failed / total if total > 0 else 0.0
+
+        if failure_rate > 0.5:
+            return self._reading(1.0, f"broken_{failed}/{total}")
+        elif failure_rate > 0.2:
+            return self._reading(0.5, f"concerning_{failed}/{total}")
+        else:
+            return self._reading(0.0, f"healthy_{failed}/{total}")
+
+    def _reading(self, value: float, source: str) -> SignalReading:
+        return SignalReading(
+            name=self.signal_name,
+            value=value,
+            source=source,
+            collected_at=datetime.now(UTC).isoformat(),
+        )

--- a/src/genesis/perception/context.py
+++ b/src/genesis/perception/context.py
@@ -24,6 +24,91 @@ _AGE_GUARD_HOURS: dict = {
     "strategic": 168,  # 7 days
 }
 
+# ── Source category mapping for citation-grouped rendering ──────────────
+
+_SOURCE_CATEGORIES: dict[str, str] = {
+    "sentinel": "Sentinel",
+    "sentinel_dispatch": "Sentinel",
+    "guardian": "Guardian",
+    "guardian_watchdog": "Guardian",
+    "recon": "Recon",
+    "recon_pipeline": "Recon",
+    "recon_mcp": "Recon",
+    "surplus_promotion": "Surplus",
+    "surplus": "Surplus",
+    "surplus_scheduler": "Surplus",
+    "reflection": "Reflections",
+    "light_reflection": "Reflections",
+    "deep_reflection": "Reflections",
+    "cc_reflection_deep": "Reflections",
+    "cc_reflection_light": "Reflections",
+    "cc_reflection_strategic": "Reflections",
+    "strategic_reflection": "Reflections",
+    "conversation": "Conversation",
+    "conversation_intent": "Conversation",
+    "conversation_analysis": "Conversation",
+    "conversation_followup": "Conversation",
+    "inbox_evaluation": "Inbox",
+}
+
+_CATEGORY_ORDER = [
+    "Sentinel", "Guardian", "Recon", "Reflections",
+    "Surplus", "Conversation", "Inbox", "Other",
+]
+
+
+def _categorize_source(source: str) -> str:
+    """Map an observation source to its display category."""
+    return _SOURCE_CATEGORIES.get(source, "Other")
+
+
+def _relative_age(created_at: str) -> str:
+    """Return a human-readable relative time string."""
+    try:
+        created = datetime.fromisoformat(created_at)
+        delta = datetime.now(UTC) - created
+        hours = delta.total_seconds() / 3600
+        if hours < 1:
+            return f"{int(delta.total_seconds() / 60)}m ago"
+        if hours < 24:
+            return f"{hours:.0f}h ago"
+        return f"{hours / 24:.0f}d ago"
+    except (ValueError, TypeError):
+        return ""
+
+
+def _format_observations_grouped(obs_list: list[dict]) -> list[str]:
+    """Group observations by source subsystem with citation anchors.
+
+    Returns formatted lines ready for prompt injection.
+    """
+    if not obs_list:
+        return []
+
+    # Group by category
+    groups: dict[str, list[dict]] = {}
+    for obs in obs_list:
+        cat = _categorize_source(obs.get("source", ""))
+        groups.setdefault(cat, []).append(obs)
+
+    lines: list[str] = ["## Subsystem Activity"]
+    for cat in _CATEGORY_ORDER:
+        if cat not in groups:
+            continue
+        lines.append(f"### {cat}")
+        for obs in groups[cat]:
+            oid = obs.get("id", "?")
+            short_id = oid[:8] if len(oid) > 8 else oid
+            priority = obs.get("priority", "?")
+            obs_type = obs.get("type", "?")
+            content = obs.get("content", "")
+            age = _relative_age(obs.get("created_at", ""))
+            age_suffix = f" ({age})" if age else ""
+            lines.append(f"- [#{short_id}] [{priority}] {obs_type}: {content}{age_suffix}")
+        lines.append("")  # blank line between groups
+
+    return lines
+
 
 class ContextAssembler:
     """Assembles context for prompt rendering based on depth.
@@ -181,16 +266,10 @@ class ContextAssembler:
         priority_order = {"high": 0, "medium": 1, "low": 2}
         merged.sort(key=lambda o: priority_order.get(o.get("priority", "low"), 3))
 
-        lines: list[str] = []
-        obs_ids: list[str] = []
-        for obs in merged:
-            oid = obs.get("id", "?")
-            obs_ids.append(oid)
-            priority = obs.get("priority", "?")
-            obs_type = obs.get("type", "?")
-            content = obs.get("content", "")
-            created = obs.get("created_at", "?")
-            lines.append(f"- [{priority}] {obs_type} ({created}): {content}")
+        obs_ids: list[str] = [obs.get("id", "") for obs in merged if obs.get("id")]
+
+        # Group by source subsystem for structured rendering
+        lines = _format_observations_grouped(merged)
 
         # Track retrieval and influence (displayed in prompt = influenced awareness)
         if obs_ids:

--- a/src/genesis/runtime/init/awareness.py
+++ b/src/genesis/runtime/init/awareness.py
@@ -16,15 +16,20 @@ async def init(rt: GenesisRuntime) -> None:
     try:
         from genesis.awareness.loop import AwarenessLoop
         from genesis.awareness.signals import (
+            AutonomyActivityCollector,
             BudgetCollector,
             ContainerMemoryCollector,
             ConversationCollector,
             CriticalFailureCollector,
             ErrorSpikeCollector,
+            GuardianActivityCollector,
             JobHealthCollector,
+            LightCascadeCollector,
             OutreachEngagementCollector,
             ReconFindingsCollector,
+            SentinelActivityCollector,
             StrategicTimerCollector,
+            SurplusActivityCollector,
             TaskQualityCollector,
         )
 
@@ -39,6 +44,11 @@ async def init(rt: GenesisRuntime) -> None:
             StrategicTimerCollector(),
             ContainerMemoryCollector(),
             JobHealthCollector(runtime=rt),
+            LightCascadeCollector(),
+            SentinelActivityCollector(),
+            GuardianActivityCollector(),
+            SurplusActivityCollector(),
+            AutonomyActivityCollector(),
         ]
 
         rt._awareness_loop = AwarenessLoop(

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -35,12 +35,19 @@ async def init(rt: GenesisRuntime) -> None:
                 ContainerMemoryCollector,
                 StrategicTimerCollector,
             )
+            from genesis.learning.signals.autonomy_activity import (
+                AutonomyActivityCollector,
+            )
             from genesis.learning.signals.budget import BudgetCollector
             from genesis.learning.signals.conversation import ConversationCollector
             from genesis.learning.signals.critical_failure import (
                 CriticalFailureCollector,
             )
             from genesis.learning.signals.error_spike import ErrorSpikeCollector
+            from genesis.learning.signals.guardian_activity import (
+                GuardianActivityCollector,
+            )
+            from genesis.learning.signals.light_cascade import LightCascadeCollector
             from genesis.learning.signals.micro_cascade import MicroCascadeCollector
             from genesis.learning.signals.outreach_engagement import (
                 OutreachEngagementCollector,
@@ -50,6 +57,12 @@ async def init(rt: GenesisRuntime) -> None:
             )
             from genesis.learning.signals.recon_findings import (
                 ReconFindingsCollector,
+            )
+            from genesis.learning.signals.sentinel_activity import (
+                SentinelActivityCollector,
+            )
+            from genesis.learning.signals.surplus_activity import (
+                SurplusActivityCollector,
             )
             from genesis.learning.signals.task_quality import TaskQualityCollector
             from genesis.observability.health import (
@@ -79,6 +92,11 @@ async def init(rt: GenesisRuntime) -> None:
                 ContainerMemoryCollector(),
                 PendingItemCollector(rt._db),
                 MicroCascadeCollector(rt._db),
+                LightCascadeCollector(rt._db),
+                SentinelActivityCollector(),
+                GuardianActivityCollector(),
+                SurplusActivityCollector(rt._db),
+                AutonomyActivityCollector(rt._db),
                 CCVersionCollector(
                     rt._db, router=rt._router,
                     pipeline_getter=lambda: rt._outreach_pipeline,

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -493,7 +493,7 @@ class SentinelDispatcher:
                 prompt=full_prompt,
                 model=CCModel.SONNET,
                 effort=EffortLevel.HIGH,
-                timeout_s=600,
+                timeout_s=900,
                 skip_permissions=True,
                 system_prompt=system_prompt,
                 append_system_prompt=True,

--- a/src/genesis/sentinel/prompts/SENTINEL.md
+++ b/src/genesis/sentinel/prompts/SENTINEL.md
@@ -35,6 +35,23 @@ You do NOT handle:
   inspection and log reading. Use for DIAGNOSIS, not execution.
 - **Read**: Inspect config files, logs, state files
 
+## Investigation Context
+
+Before proposing fixes, gather context from Genesis's awareness system:
+
+- **Recent signals**: Query `awareness_ticks` table for the last few ticks'
+  `signals_json` — these show what the awareness loop has been seeing
+  (e.g., error spikes, memory trends, surplus failures)
+- **Related observations**: Query `observations` table filtered by relevant
+  source (e.g., `source='surplus'`, `source='recon'`) for recent unresolved
+  findings that may be related to the current fire alarm
+- **Subsystem health**: Use `health_status` and `subsystem_heartbeats` MCP
+  tools for a live snapshot
+
+This context helps you distinguish "isolated incident" from "part of a
+broader pattern" — and avoids proposing fixes that address symptoms while
+missing the root cause.
+
 ## Failure Inventory
 
 Common infrastructure failures and their fixes:

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -92,8 +92,9 @@ async def test_no_unexpected_tables(db):
 async def test_signal_weights_seeded(db):
     cursor = await db.execute("SELECT COUNT(*) FROM signal_weights")
     count = (await cursor.fetchone())[0]
-    # 11 → 10 on 2026-04-11 after unprocessed_memory_backlog removal.
-    assert count == 10
+    # 10 → 16 on 2026-04-17: +6 new signals (light_cascade, sentinel,
+    # guardian, surplus, autonomy activity, stale_pending_items).
+    assert count == 16
 
 
 async def test_signal_weights_values(db):
@@ -103,9 +104,10 @@ async def test_signal_weights_values(db):
     )
     row = await cursor.fetchone()
     assert row is not None
-    assert row[1] == 0.90
+    # 2026-04-17: critical_failure moved to Micro-only at weight 0.70
+    assert row[1] == 0.70
     depths = json.loads(row[2])
-    assert "Light" in depths
+    assert "Micro" in depths
 
 
 async def test_unprocessed_memory_backlog_migration_removes_existing_row(db):
@@ -295,8 +297,8 @@ async def test_seed_is_idempotent(db):
     await seed_data(db)
     await db.commit()
     cursor = await db.execute("SELECT COUNT(*) FROM signal_weights")
-    # 11 → 10 on 2026-04-11 after unprocessed_memory_backlog removal.
-    assert (await cursor.fetchone())[0] == 10
+    # 10 → 16 on 2026-04-17: +6 new signals (awareness scoring overhaul).
+    assert (await cursor.fetchone())[0] == 16
     cursor = await db.execute("SELECT COUNT(*) FROM drive_weights")
     assert (await cursor.fetchone())[0] == 4
 

--- a/tests/test_db/test_signal_weights.py
+++ b/tests/test_db/test_signal_weights.py
@@ -1,12 +1,12 @@
-"""Tests for signal_weights CRUD (uses seed data: 10 rows)."""
+"""Tests for signal_weights CRUD (uses seed data: 16 rows)."""
 
 from genesis.db.crud import signal_weights
 
 
 async def test_list_all(db):
     rows = await signal_weights.list_all(db)
-    # 11 → 10 on 2026-04-11 after unprocessed_memory_backlog removal.
-    assert len(rows) == 10
+    # 10 → 16 on 2026-04-17: +6 new signals (awareness scoring overhaul).
+    assert len(rows) == 16
 
 
 async def test_get_existing(db):
@@ -22,8 +22,8 @@ async def test_get_nonexistent(db):
 async def test_list_by_depth(db):
     rows = await signal_weights.list_by_depth(db, "Light")
     assert len(rows) > 0
-    # critical_failure feeds Light
-    assert any(r["signal_name"] == "critical_failure" for r in rows)
+    # micro_count_since_light feeds Light
+    assert any(r["signal_name"] == "micro_count_since_light" for r in rows)
 
 
 async def test_list_by_depth_empty(db):

--- a/tests/test_learning/test_new_signals.py
+++ b/tests/test_learning/test_new_signals.py
@@ -1,0 +1,478 @@
+"""Tests for the awareness scoring overhaul signal collectors.
+
+Covers: LightCascadeCollector, SentinelActivityCollector,
+        GuardianActivityCollector, SurplusActivityCollector,
+        AutonomyActivityCollector, and SEED weight validation.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from genesis.awareness.signals import SignalCollector
+from genesis.db.schema import create_all_tables
+
+
+@pytest.fixture
+async def db():
+    async with aiosqlite.connect(":memory:") as conn:
+        conn.row_factory = aiosqlite.Row
+        await create_all_tables(conn)
+        yield conn
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+# ── LightCascadeCollector ──────────────────────────────────────────────
+
+
+class TestLightCascadeCollector:
+    async def test_no_ticks_returns_zero(self, db):
+        from genesis.learning.signals.light_cascade import LightCascadeCollector
+
+        r = await LightCascadeCollector(db).collect()
+        assert r.name == "light_count_since_deep"
+        assert r.value == 0.0
+
+    async def test_one_light_tick(self, db):
+        from genesis.learning.signals.light_cascade import LightCascadeCollector
+
+        await db.execute(
+            "INSERT INTO awareness_ticks (id, source, classified_depth, signals_json, scores_json, created_at) "
+            "VALUES (?, 'scheduled', 'Light', '[]', '[]', ?)",
+            (_uid(), _now_iso()),
+        )
+        await db.commit()
+        r = await LightCascadeCollector(db).collect()
+        assert r.value == pytest.approx(1 / 3, abs=0.01)
+
+    async def test_three_light_ticks_caps_at_one(self, db):
+        from genesis.learning.signals.light_cascade import LightCascadeCollector
+
+        for _ in range(3):
+            await db.execute(
+                "INSERT INTO awareness_ticks (id, source, classified_depth, signals_json, scores_json, created_at) "
+                "VALUES (?, 'scheduled', 'Light', '[]', '[]', ?)",
+                (_uid(), _now_iso()),
+            )
+        await db.commit()
+        r = await LightCascadeCollector(db).collect()
+        assert r.value == 1.0
+
+    async def test_deep_tick_resets_count(self, db):
+        from genesis.learning.signals.light_cascade import LightCascadeCollector
+
+        # Insert some Light ticks
+        old = (datetime.now(UTC) - timedelta(hours=6)).isoformat()
+        for _ in range(5):
+            await db.execute(
+                "INSERT INTO awareness_ticks (id, source, classified_depth, signals_json, scores_json, created_at) "
+                "VALUES (?, 'scheduled', 'Light', '[]', '[]', ?)",
+                (_uid(), old),
+            )
+        # Insert a Deep tick after them
+        await db.execute(
+            "INSERT INTO awareness_ticks (id, source, classified_depth, signals_json, scores_json, created_at) "
+            "VALUES (?, 'scheduled', 'Deep', '[]', '[]', ?)",
+            (_uid(), _now_iso()),
+        )
+        await db.commit()
+        r = await LightCascadeCollector(db).collect()
+        # No Light ticks after the Deep tick
+        assert r.value == 0.0
+
+    async def test_isinstance_protocol(self, db):
+        from genesis.learning.signals.light_cascade import LightCascadeCollector
+
+        assert isinstance(LightCascadeCollector(db), SignalCollector)
+
+
+# ── SentinelActivityCollector ──────────────────────────────────────────
+
+
+class TestSentinelActivityCollector:
+    def _write_state(self, tmp_path: Path, state: str) -> Path:
+        state_path = tmp_path / "sentinel_state.json"
+        state_path.write_text(json.dumps({
+            "current_state": state,
+            "entered_at": _now_iso(),
+        }))
+        return state_path
+
+    async def test_healthy_returns_zero(self, tmp_path):
+        from genesis.learning.signals.sentinel_activity import SentinelActivityCollector
+
+        path = self._write_state(tmp_path, "healthy")
+        r = await SentinelActivityCollector(state_path=path).collect()
+        assert r.name == "sentinel_activity"
+        assert r.value == 0.0
+
+    async def test_investigating_returns_03(self, tmp_path):
+        from genesis.learning.signals.sentinel_activity import SentinelActivityCollector
+
+        path = self._write_state(tmp_path, "investigating")
+        r = await SentinelActivityCollector(state_path=path).collect()
+        assert r.value == 0.3
+
+    async def test_remediating_returns_07(self, tmp_path):
+        from genesis.learning.signals.sentinel_activity import SentinelActivityCollector
+
+        path = self._write_state(tmp_path, "remediating")
+        r = await SentinelActivityCollector(state_path=path).collect()
+        assert r.value == 0.7
+
+    async def test_escalated_returns_10(self, tmp_path):
+        from genesis.learning.signals.sentinel_activity import SentinelActivityCollector
+
+        path = self._write_state(tmp_path, "escalated")
+        r = await SentinelActivityCollector(state_path=path).collect()
+        assert r.value == 1.0
+
+    async def test_missing_file_returns_zero(self, tmp_path):
+        from genesis.learning.signals.sentinel_activity import SentinelActivityCollector
+
+        path = tmp_path / "nonexistent.json"
+        r = await SentinelActivityCollector(state_path=path).collect()
+        assert r.value == 0.0  # load_state returns HEALTHY default
+
+    async def test_isinstance_protocol(self, tmp_path):
+        from genesis.learning.signals.sentinel_activity import SentinelActivityCollector
+
+        assert isinstance(SentinelActivityCollector(), SignalCollector)
+
+
+# ── GuardianActivityCollector ──────────────────────────────────────────
+
+
+class TestGuardianActivityCollector:
+    async def test_fresh_heartbeat(self, tmp_path):
+        from genesis.learning.signals.guardian_activity import GuardianActivityCollector
+
+        hb = tmp_path / "guardian_heartbeat.json"
+        hb.write_text(json.dumps({
+            "guardian_alive": True,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "uptime_s": 100,
+        }))
+        r = await GuardianActivityCollector(heartbeat_path=hb).collect()
+        assert r.name == "guardian_activity"
+        assert r.value == 0.0
+
+    async def test_stale_heartbeat(self, tmp_path):
+        from genesis.learning.signals.guardian_activity import GuardianActivityCollector
+
+        hb = tmp_path / "guardian_heartbeat.json"
+        stale = (datetime.now(UTC) - timedelta(minutes=10)).isoformat()
+        hb.write_text(json.dumps({
+            "guardian_alive": True,
+            "timestamp": stale,
+            "uptime_s": 600,
+        }))
+        r = await GuardianActivityCollector(heartbeat_path=hb).collect()
+        assert r.value == 0.5
+
+    async def test_very_stale_heartbeat(self, tmp_path):
+        from genesis.learning.signals.guardian_activity import GuardianActivityCollector
+
+        hb = tmp_path / "guardian_heartbeat.json"
+        old = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+        hb.write_text(json.dumps({
+            "guardian_alive": True,
+            "timestamp": old,
+            "uptime_s": 7200,
+        }))
+        r = await GuardianActivityCollector(heartbeat_path=hb).collect()
+        assert r.value == 1.0
+
+    async def test_missing_file_returns_zero(self, tmp_path):
+        from genesis.learning.signals.guardian_activity import GuardianActivityCollector
+
+        hb = tmp_path / "nonexistent.json"
+        r = await GuardianActivityCollector(heartbeat_path=hb).collect()
+        assert r.value == 0.0
+
+    async def test_corrupt_json_returns_05(self, tmp_path):
+        from genesis.learning.signals.guardian_activity import GuardianActivityCollector
+
+        hb = tmp_path / "guardian_heartbeat.json"
+        hb.write_text("not valid json{{{")
+        r = await GuardianActivityCollector(heartbeat_path=hb).collect()
+        assert r.value == 0.5
+
+    async def test_isinstance_protocol(self, tmp_path):
+        from genesis.learning.signals.guardian_activity import GuardianActivityCollector
+
+        assert isinstance(GuardianActivityCollector(), SignalCollector)
+
+
+# ── SurplusActivityCollector ───────────────────────────────────────────
+
+
+class TestSurplusActivityCollector:
+    async def _insert_task(self, db, status: str, *, hours_ago: float = 0, started_hours_ago: float | None = None):
+        created = (datetime.now(UTC) - timedelta(hours=hours_ago)).isoformat()
+        started = (datetime.now(UTC) - timedelta(hours=started_hours_ago)).isoformat() if started_hours_ago is not None else None
+        await db.execute(
+            "INSERT INTO surplus_tasks (id, task_type, compute_tier, priority, drive_alignment, "
+            "status, created_at, started_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (_uid(), "brainstorm", "micro", 0.5, "curiosity", status, created, started),
+        )
+        await db.commit()
+
+    async def test_idle_returns_zero(self, db):
+        from genesis.learning.signals.surplus_activity import SurplusActivityCollector
+
+        r = await SurplusActivityCollector(db).collect()
+        assert r.name == "surplus_activity"
+        assert r.value == 0.0
+
+    async def test_healthy_tasks(self, db):
+        from genesis.learning.signals.surplus_activity import SurplusActivityCollector
+
+        for _ in range(8):
+            await self._insert_task(db, "completed")
+        await self._insert_task(db, "failed")
+        r = await SurplusActivityCollector(db).collect()
+        # 1/9 = 11% failure < 20% → healthy
+        assert r.value == 0.0
+
+    async def test_concerning_failure_rate(self, db):
+        from genesis.learning.signals.surplus_activity import SurplusActivityCollector
+
+        for _ in range(6):
+            await self._insert_task(db, "completed")
+        for _ in range(3):
+            await self._insert_task(db, "failed")
+        r = await SurplusActivityCollector(db).collect()
+        # 3/9 = 33% → concerning
+        assert r.value == 0.5
+
+    async def test_broken_failure_rate(self, db):
+        from genesis.learning.signals.surplus_activity import SurplusActivityCollector
+
+        await self._insert_task(db, "completed")
+        for _ in range(3):
+            await self._insert_task(db, "failed")
+        r = await SurplusActivityCollector(db).collect()
+        # 3/4 = 75% → broken
+        assert r.value == 1.0
+
+    async def test_stuck_tasks(self, db):
+        from genesis.learning.signals.surplus_activity import SurplusActivityCollector
+
+        await self._insert_task(db, "running", started_hours_ago=3)
+        r = await SurplusActivityCollector(db).collect()
+        assert r.value == 0.8
+
+    async def test_old_tasks_excluded(self, db):
+        from genesis.learning.signals.surplus_activity import SurplusActivityCollector
+
+        # 48h old completed tasks — outside 24h window
+        for _ in range(5):
+            await self._insert_task(db, "failed", hours_ago=48)
+        r = await SurplusActivityCollector(db).collect()
+        assert r.value == 0.0
+
+    async def test_isinstance_protocol(self, db):
+        from genesis.learning.signals.surplus_activity import SurplusActivityCollector
+
+        assert isinstance(SurplusActivityCollector(db), SignalCollector)
+
+
+# ── AutonomyActivityCollector ──────────────────────────────────────────
+
+
+class TestAutonomyActivityCollector:
+    async def _insert_autonomy_state(
+        self, db, category: str, *,
+        current_level: int = 4,
+        earned_level: int = 4,
+        consecutive_corrections: int = 0,
+    ):
+        await db.execute(
+            "INSERT INTO autonomy_state (id, category, current_level, earned_level, "
+            "consecutive_corrections, total_successes, total_corrections, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, 10, 0, ?)",
+            (_uid(), category, current_level, earned_level, consecutive_corrections, _now_iso()),
+        )
+        await db.commit()
+
+    async def test_no_categories_returns_zero(self, db):
+        from genesis.learning.signals.autonomy_activity import AutonomyActivityCollector
+
+        r = await AutonomyActivityCollector(db).collect()
+        assert r.name == "autonomy_activity"
+        assert r.value == 0.0
+
+    async def test_stable_returns_zero(self, db):
+        from genesis.learning.signals.autonomy_activity import AutonomyActivityCollector
+
+        await self._insert_autonomy_state(db, "background_cognitive")
+        r = await AutonomyActivityCollector(db).collect()
+        assert r.value == 0.0
+
+    async def test_corrections_accumulating(self, db):
+        from genesis.learning.signals.autonomy_activity import AutonomyActivityCollector
+
+        await self._insert_autonomy_state(db, "background_cognitive", consecutive_corrections=1)
+        r = await AutonomyActivityCollector(db).collect()
+        assert r.value == 0.3
+
+    async def test_near_regression(self, db):
+        from genesis.learning.signals.autonomy_activity import AutonomyActivityCollector
+
+        # _REGRESSION_THRESHOLD is 3, so threshold-1 = 2
+        await self._insert_autonomy_state(db, "background_cognitive", consecutive_corrections=2)
+        r = await AutonomyActivityCollector(db).collect()
+        assert r.value == 0.7
+
+    async def test_active_regression(self, db):
+        from genesis.learning.signals.autonomy_activity import AutonomyActivityCollector
+
+        await self._insert_autonomy_state(
+            db, "background_cognitive",
+            current_level=2, earned_level=4,
+        )
+        r = await AutonomyActivityCollector(db).collect()
+        assert r.value == 1.0
+
+    async def test_worst_category_wins(self, db):
+        from genesis.learning.signals.autonomy_activity import AutonomyActivityCollector
+
+        await self._insert_autonomy_state(db, "background_cognitive")  # stable
+        await self._insert_autonomy_state(
+            db, "outreach",
+            current_level=2, earned_level=4,
+        )  # regression
+        r = await AutonomyActivityCollector(db).collect()
+        assert r.value == 1.0
+
+    async def test_isinstance_protocol(self, db):
+        from genesis.learning.signals.autonomy_activity import AutonomyActivityCollector
+
+        assert isinstance(AutonomyActivityCollector(db), SignalCollector)
+
+
+# ── SEED Weight Validation ─────────────────────────────────────────────
+
+
+class TestSeedWeights:
+    def test_critical_failure_micro_only(self):
+        from genesis.db.schema._tables import SIGNAL_WEIGHTS_SEED
+
+        for row in SIGNAL_WEIGHTS_SEED:
+            if row[0] == "critical_failure":
+                assert json.loads(row[6]) == ["Micro"]
+                assert row[2] == 0.70  # current_weight
+                break
+        else:
+            pytest.fail("critical_failure not in SEED")
+
+    def test_software_error_spike_micro_only(self):
+        from genesis.db.schema._tables import SIGNAL_WEIGHTS_SEED
+
+        for row in SIGNAL_WEIGHTS_SEED:
+            if row[0] == "software_error_spike":
+                assert json.loads(row[6]) == ["Micro"]
+                break
+        else:
+            pytest.fail("software_error_spike not in SEED")
+
+    def test_cc_version_changed_micro_only(self):
+        from genesis.db.schema._tables import SIGNAL_WEIGHTS_SEED
+
+        for row in SIGNAL_WEIGHTS_SEED:
+            if row[0] == "cc_version_changed":
+                assert json.loads(row[6]) == ["Micro"]
+                assert row[2] == 0.50
+                break
+        else:
+            pytest.fail("cc_version_changed not in SEED")
+
+    def test_new_signals_present(self):
+        from genesis.db.schema._tables import SIGNAL_WEIGHTS_SEED
+
+        names = {row[0] for row in SIGNAL_WEIGHTS_SEED}
+        expected = {
+            "light_count_since_deep",
+            "sentinel_activity",
+            "guardian_activity",
+            "surplus_activity",
+            "autonomy_activity",
+            "stale_pending_items",
+        }
+        assert expected.issubset(names), f"Missing: {expected - names}"
+
+    def test_light_count_feeds_deep(self):
+        from genesis.db.schema._tables import SIGNAL_WEIGHTS_SEED
+
+        for row in SIGNAL_WEIGHTS_SEED:
+            if row[0] == "light_count_since_deep":
+                assert json.loads(row[6]) == ["Deep"]
+                break
+        else:
+            pytest.fail("light_count_since_deep not in SEED")
+
+
+# ── Citation Formatting ────────────────────────────────────────────────
+
+
+class TestCitationFormatting:
+    def test_format_observations_grouped_basic(self):
+        from genesis.perception.context import _format_observations_grouped
+
+        obs = [
+            {"id": "abc12345-full-id", "source": "sentinel", "type": "alert",
+             "priority": "high", "content": "circuit breaker open",
+             "created_at": _now_iso()},
+            {"id": "def67890-full-id", "source": "recon", "type": "finding",
+             "priority": "medium", "content": "SDK update",
+             "created_at": _now_iso()},
+        ]
+        lines = _format_observations_grouped(obs)
+        text = "\n".join(lines)
+        assert "### Sentinel" in text
+        assert "### Recon" in text
+        assert "[#abc12345]" in text
+        assert "[#def67890]" in text
+
+    def test_format_observations_grouped_empty(self):
+        from genesis.perception.context import _format_observations_grouped
+
+        assert _format_observations_grouped([]) == []
+
+    def test_unknown_source_goes_to_other(self):
+        from genesis.perception.context import _format_observations_grouped
+
+        obs = [
+            {"id": "xyz", "source": "unknown_source", "type": "event",
+             "priority": "low", "content": "test",
+             "created_at": _now_iso()},
+        ]
+        lines = _format_observations_grouped(obs)
+        text = "\n".join(lines)
+        assert "### Other" in text
+
+    def test_prompts_format_observations_grouped(self):
+        from genesis.cc.reflection_bridge._prompts import _format_observations_grouped
+
+        obs = [
+            {"id": "abc12345-full", "source": "sentinel", "type": "alert",
+             "priority": "high", "content": "test",
+             "created_at": _now_iso()},
+        ]
+        result = _format_observations_grouped(obs)
+        assert "### Sentinel" in result
+        assert "[#abc12345]" in result


### PR DESCRIPTION
## Summary
Cherry-pick of #59 onto current main (old branch diverged 154 commits).

- 5 new subsystem signals (autonomy, guardian, sentinel, surplus, light_cascade)
- Signal weight redistribution across Deep/Light/Awareness scorers
- Citation formatting in reflection prompts
- DB migration for signal_weights_seed

Supersedes #59.

## Test plan
- [ ] `pytest tests/test_learning/test_new_signals.py` passes
- [ ] `pytest tests/test_db/test_signal_weights.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)