### PR TITLE
fix: queue-first extraction, health cache, systemd PATH

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -423,6 +423,9 @@ SERVICES_UPDATED=0
 
 if [[ -d "$SYSTEMD_TEMPLATE_DIR" ]]; then
     mkdir -p "$SYSTEMD_USER_DIR"
+    # Detect Claude Code binary directory for systemd PATH injection
+    CC_BIN_DIR="$(dirname "$(command -v claude 2>/dev/null)" 2>/dev/null || echo "$HOME/.npm-global/bin")"
+
     for template in "$SYSTEMD_TEMPLATE_DIR"/*.service.template "$SYSTEMD_TEMPLATE_DIR"/*.timer.template; do
         [[ -f "$template" ]] || continue
         svc_name=$(basename "$template" .template)
@@ -431,6 +434,7 @@ if [[ -d "$SYSTEMD_TEMPLATE_DIR" ]]; then
         rendered=$(sed -e "s|__HOME__|$HOME|g" \
                        -e "s|__VENV__|$GENESIS_ROOT/.venv|g" \
                        -e "s|__REPO_DIR__|$GENESIS_ROOT|g" \
+                       -e "s|__CC_BIN_DIR__|$CC_BIN_DIR|g" \
                        "$template")
         if [[ -f "$target" ]]; then
             current=$(cat "$target")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -766,6 +766,9 @@ SYSTEMD_TEMPLATE_DIR="$REPO_DIR/scripts/systemd"
 SERVICES_GENERATED=0
 
 if [ -d "$SYSTEMD_TEMPLATE_DIR" ]; then
+    # Detect Claude Code binary directory for systemd PATH injection
+    CC_BIN_DIR="$(dirname "$(command -v claude 2>/dev/null)" 2>/dev/null || echo "$HOME/.npm-global/bin")"
+
     for template in "$SYSTEMD_TEMPLATE_DIR"/*.service.template "$SYSTEMD_TEMPLATE_DIR"/*.timer.template; do
         [ -f "$template" ] || continue
         svc_name=$(basename "$template" .template)
@@ -777,6 +780,7 @@ if [ -d "$SYSTEMD_TEMPLATE_DIR" ]; then
             sed -e "s|__HOME__|$HOME|g" \
                 -e "s|__VENV__|$VENV_PATH|g" \
                 -e "s|__REPO_DIR__|$REPO_DIR|g" \
+                -e "s|__CC_BIN_DIR__|$CC_BIN_DIR|g" \
                 "$template" > "$target"
             echo "    + $svc_name generated"
             SERVICES_GENERATED=1

--- a/scripts/systemd/genesis-bridge.service.template
+++ b/scripts/systemd/genesis-bridge.service.template
@@ -19,7 +19,7 @@ RestartSec=10
 RestartPreventExitStatus=200 2
 
 Environment=TMPDIR=__HOME__/.genesis/cc-tmp
-Environment=PATH=__VENV__/bin:__HOME__/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=__VENV__/bin:__CC_BIN_DIR__:__HOME__/.local/bin:/usr/local/bin:/usr/bin:/bin
 Environment=TG_ADAPTER=v2
 StandardOutput=journal
 StandardError=journal

--- a/scripts/systemd/genesis-server.service.template
+++ b/scripts/systemd/genesis-server.service.template
@@ -19,7 +19,7 @@ RestartSec=10
 RestartPreventExitStatus=200 2
 
 Environment=TMPDIR=__HOME__/.genesis/cc-tmp
-Environment=PATH=__VENV__/bin:__HOME__/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=PATH=__VENV__/bin:__CC_BIN_DIR__:__HOME__/.local/bin:/usr/local/bin:/usr/bin:/bin
 MemoryMax=80%
 LimitNOFILE=65536
 OOMScoreAdjust=-500

--- a/src/genesis/memory/embeddings.py
+++ b/src/genesis/memory/embeddings.py
@@ -65,6 +65,8 @@ class OllamaBackend:
     loading) and retries once on ReadTimeout before propagating the failure.
     """
 
+    _AVAIL_TTL = 120.0  # seconds — cache is_available() result
+
     def __init__(
         self,
         url: str,
@@ -74,6 +76,8 @@ class OllamaBackend:
         self._url = url
         self._model = model
         self._client = client or httpx.AsyncClient(timeout=60.0)
+        self._avail_cache: bool | None = None
+        self._avail_cache_at: float = 0.0
 
     @property
     def name(self) -> str:
@@ -101,13 +105,22 @@ class OllamaBackend:
         raise last_exc  # type: ignore[misc]  # unreachable, but satisfies type checker
 
     async def is_available(self) -> bool:
+        now = time.monotonic()
+        if (
+            self._avail_cache is not None
+            and (now - self._avail_cache_at) < self._AVAIL_TTL
+        ):
+            return self._avail_cache
         try:
             resp = await self._client.get(
                 f"{self._url.rstrip('/')}/api/tags", timeout=5.0,
             )
-            return resp.status_code == 200
+            result = resp.status_code == 200
         except _HTTPX_ERRORS:
-            return False
+            result = False
+        self._avail_cache = result
+        self._avail_cache_at = now
+        return result
 
 
 class DeepInfraBackend:

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -165,6 +165,9 @@ async def run_extraction_cycle(
                     store=store,
                     db=db,
                     source_session_id=cc_session_id,
+                    # Normal: queue for paced embedding; history mining: embed
+                    # inline (one-shot CLI won't have recovery worker running)
+                    force_fts5_only=not reference_only_mode,
                 )
                 summary["references_captured"] += ref_count
             except Exception:
@@ -190,7 +193,13 @@ async def run_extraction_cycle(
                     source_line_range=(chunk_start, chunk_end),
                 )
                 try:
-                    memory_id = await store.store(**kwargs)
+                    # Queue-first: store FTS5-only, queue embedding for
+                    # the recovery worker's paced drain. Prevents the
+                    # extraction cycle from hammering the embedding backend
+                    # with hundreds of sequential calls.
+                    memory_id = await store.store(
+                        **kwargs, force_fts5_only=True,
+                    )
                     summary["entities_extracted"] += 1
 
                     # Create typed links from extraction relationships

--- a/src/genesis/memory/knowledge_ingest.py
+++ b/src/genesis/memory/knowledge_ingest.py
@@ -39,6 +39,7 @@ async def ingest_knowledge_unit(
     memory_class: str | None = None,
     concept: str | None = None,
     tags_json: str | None = None,
+    force_fts5_only: bool = False,
 ) -> str:
     """Ingest or upsert a knowledge unit, returning the stable unit_id.
 
@@ -87,6 +88,7 @@ async def ingest_knowledge_unit(
         source_pipeline=source_pipeline_val,
         memory_class=memory_class,
         source_session_id=source_session_id,
+        force_fts5_only=force_fts5_only,
     )
 
     # If we replaced an existing entry whose Qdrant point ID differs from

--- a/src/genesis/memory/reference_extraction.py
+++ b/src/genesis/memory/reference_extraction.py
@@ -270,6 +270,7 @@ async def ingest_reference_from_extraction(
     store: MemoryStore,
     db: aiosqlite.Connection,
     source_session_id: str | None = None,
+    force_fts5_only: bool = False,
 ) -> str | None:
     """Classify an Extraction and ingest it as a reference entry if matched.
 
@@ -326,6 +327,7 @@ async def ingest_reference_from_extraction(
             memory_class="fact",  # bypass 0.7x auto-reference penalty
             concept=identifier,
             tags_json=tags_json,
+            force_fts5_only=force_fts5_only,
         )
     except Exception:
         logger.warning(
@@ -347,6 +349,7 @@ async def extract_references_from_chunk(
     store: MemoryStore,
     db: aiosqlite.Connection,
     source_session_id: str | None = None,
+    force_fts5_only: bool = False,
 ) -> int:
     """Run the classifier over a chunk of extractions, ingesting references.
 
@@ -361,6 +364,7 @@ async def extract_references_from_chunk(
             store=store,
             db=db,
             source_session_id=source_session_id,
+            force_fts5_only=force_fts5_only,
         )
         if unit_id:
             count += 1

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -86,6 +86,7 @@ class MemoryStore:
         source_pipeline: str | None = None,
         wing: str | None = None,
         room: str | None = None,
+        force_fts5_only: bool = False,
     ) -> str:
         """Full store pipeline: embed -> Qdrant -> FTS5 -> auto-link. Returns memory_id.
 
@@ -112,7 +113,7 @@ class MemoryStore:
         from genesis.perception.confidence import load_config as load_confidence_config
         from genesis.perception.confidence import should_gate
 
-        force_fts5_only = False
+        # force_fts5_only param skips embedding; confidence gate can also set it
         cfg = load_confidence_config()
         gated, gate_msg = should_gate(confidence, cfg.memory_upsertion)
         if gate_msg:

--- a/src/genesis/resilience/embedding_recovery.py
+++ b/src/genesis/resilience/embedding_recovery.py
@@ -112,9 +112,21 @@ class EmbeddingRecoveryWorker:
                             "Auto-link failed for %s, continuing", item["memory_id"],
                         )
 
-                # Mark completed
+                # Mark completed in pending_embeddings + update memory_metadata
                 now = datetime.now(UTC).isoformat()
                 await crud.mark_embedded(self._db, item["id"], embedded_at=now)
+                try:
+                    await self._db.execute(
+                        "UPDATE memory_metadata SET embedding_status = 'embedded' "
+                        "WHERE memory_id = ?",
+                        (item["memory_id"],),
+                    )
+                    await self._db.commit()
+                except Exception:
+                    logger.debug(
+                        "Failed to update embedding_status for %s",
+                        item["memory_id"], exc_info=True,
+                    )
                 processed += 1
 
             except Exception as exc:

--- a/src/genesis/resilience/recovery.py
+++ b/src/genesis/resilience/recovery.py
@@ -109,8 +109,9 @@ class RecoveryOrchestrator:
             except Exception:
                 logger.warning("Failed to reset failed embeddings", exc_info=True)
 
-        # 2. Drain pending embeddings
-        report.embeddings_recovered = await self._embedding_worker.drain_pending(limit=100)
+        # 2. Drain pending embeddings — limit=500 to handle full extraction
+        # cycle output (extraction queues FTS5-only, recovery embeds at pace)
+        report.embeddings_recovered = await self._embedding_worker.drain_pending(limit=500)
 
         # 3. Drain deferred work by priority
         items = await self._deferred_queue.drain_by_priority(limit=50)

--- a/tests/test_resilience/test_recovery.py
+++ b/tests/test_resilience/test_recovery.py
@@ -104,7 +104,7 @@ class TestRunRecovery:
         mocks["embedding_worker"].drain_pending = AsyncMock(return_value=5)
         report = await orchestrator.run_recovery()
         assert report.embeddings_recovered == 5
-        mocks["embedding_worker"].drain_pending.assert_awaited_once_with(limit=100)
+        mocks["embedding_worker"].drain_pending.assert_awaited_once_with(limit=500)
 
     async def test_processes_deferred_work(self, orchestrator, mocks):
         items = [{"id": "a"}, {"id": "b"}]


### PR DESCRIPTION
## Summary

- **Embedding storm fix**: Extraction now stores FTS5-only and queues to `pending_embeddings` for the recovery worker's paced drain (10/min). Eliminates 562 sequential embed calls/hour that were saturating Ollama CPU.
- **Health check cache**: Added 120s TTL cache to `OllamaBackend.is_available()` — was hitting `/api/tags` on every call with no caching.
- **Systemd PATH fix**: Added `__CC_BIN_DIR__` placeholder to server and bridge service templates, detected at install time. Fixes "Claude CLI not found" when binary is at `~/.npm-global/bin/`.
- **Recovery worker fix**: Now updates `memory_metadata.embedding_status` from "pending" to "embedded" after successful processing.

## Architecture

Leverages existing `pending_embeddings` queue + `EmbeddingRecoveryWorker` (already paced at 10/min) rather than building new rate-limiting infrastructure. The extraction job's purpose is extraction, not embedding — this change aligns responsibility correctly.

Phase 2 (batch API for recovery worker) deferred pending observation of Phase 1 impact.

## Test plan

- [x] `ruff check` passes on all modified files
- [x] 5550 tests pass, 0 regressions
- [x] Code review: all findings addressed inline
- [ ] After merge: monitor `pending_embeddings` queue depth for 24-48h
- [ ] After merge: verify Ollama CPU drops from ~70% to baseline
- [ ] After merge: re-render systemd templates via `scripts/bootstrap.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)