### PR TITLE
fix(security): redact identifier in migration dry-run log

### DIFF
--- a/scripts/migrate_reference_data.py
+++ b/scripts/migrate_reference_data.py
@@ -447,8 +447,8 @@ async def main(args: argparse.Namespace) -> None:
         for name, entries in sources:
             for e in entries:
                 logger.info(
-                    "  [%s] %-18s %s",
-                    name, e.kind, e.identifier[:30] + "..." if len(e.identifier) > 30 else e.identifier,
+                    "  [%s] %-18s (identifier redacted)",
+                    name, e.kind,
                 )
         logger.info("Dry run complete. Re-run without --dry-run to ingest.")
         return


### PR DESCRIPTION
## Summary
Last CodeQL clear-text-logging alert. Migration dry-run mode was logging reference identifiers that could contain credentials.

## Test plan
- [x] Verified: all other CodeQL alerts dismissed as false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)