### PR TITLE
fix(routing): throttle budget exceeded log spam

### DIFF
--- a/src/genesis/routing/cost_tracker.py
+++ b/src/genesis/routing/cost_tracker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import uuid
 from datetime import UTC, datetime, timedelta
 
@@ -22,10 +23,13 @@ _BUDGET_PERIOD = {
 
 
 class CostTracker:
+    _EVENT_THROTTLE_S = 300.0  # 5 min between identical budget events
+
     def __init__(self, db: aiosqlite.Connection, *, clock=None, event_bus: GenesisEventBus | None = None):
         self.db = db
         self._clock = clock or (lambda: datetime.now(UTC))
         self._event_bus = event_bus
+        self._last_event_at: dict[str, float] = {}  # "daily_exceeded" -> monotonic time
 
     async def record(
         self, call_site_id: str, provider: str, result: CallResult,
@@ -74,22 +78,30 @@ class CostTracker:
         limit_usd = budget["limit_usd"]
         warning_pct = budget["warning_pct"]
         if total >= limit_usd:
-            if self._event_bus:
-                await self._event_bus.emit(
-                    Subsystem.ROUTING, Severity.ERROR,
-                    "budget.exceeded",
-                    f"{budget_type} budget exceeded: ${total:.4f} >= ${limit_usd:.4f}",
-                    budget_type=budget_type, total=total, limit=limit_usd,
-                )
+            event_key = f"{budget_type}_exceeded"
+            now_mono = time.monotonic()
+            if now_mono - self._last_event_at.get(event_key, 0) >= self._EVENT_THROTTLE_S:
+                if self._event_bus:
+                    await self._event_bus.emit(
+                        Subsystem.ROUTING, Severity.ERROR,
+                        "budget.exceeded",
+                        f"{budget_type} budget exceeded: ${total:.4f} >= ${limit_usd:.4f}",
+                        budget_type=budget_type, total=total, limit=limit_usd,
+                    )
+                self._last_event_at[event_key] = now_mono
             return BudgetStatus.EXCEEDED
         if total >= limit_usd * warning_pct:
-            if self._event_bus:
-                await self._event_bus.emit(
-                    Subsystem.ROUTING, Severity.WARNING,
-                    "budget.warning",
-                    f"{budget_type} budget warning: ${total:.4f} / ${limit_usd:.4f}",
-                    budget_type=budget_type, total=total, limit=limit_usd,
-                )
+            event_key = f"{budget_type}_warning"
+            now_mono = time.monotonic()
+            if now_mono - self._last_event_at.get(event_key, 0) >= self._EVENT_THROTTLE_S:
+                if self._event_bus:
+                    await self._event_bus.emit(
+                        Subsystem.ROUTING, Severity.WARNING,
+                        "budget.warning",
+                        f"{budget_type} budget warning: ${total:.4f} / ${limit_usd:.4f}",
+                        budget_type=budget_type, total=total, limit=limit_usd,
+                    )
+                self._last_event_at[event_key] = now_mono
             return BudgetStatus.WARNING
         return BudgetStatus.UNDER_LIMIT
 

--- a/tests/test_routing/test_cost_tracker.py
+++ b/tests/test_routing/test_cost_tracker.py
@@ -1,6 +1,7 @@
 """Tests for CostTracker."""
 
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -90,3 +91,71 @@ async def test_period_start_this_month(clock):
     tracker._clock = clock
     start = tracker._period_start("this_month")
     assert start == "2026-03-01T00:00:00+00:00"
+
+
+class TestBudgetEventThrottle:
+    """Verify budget events are throttled but status is always returned."""
+
+    @pytest.mark.asyncio
+    async def test_exceeded_event_emitted_once_on_rapid_calls(self, db, clock):
+        bus = AsyncMock()
+        tracker = CostTracker(db, clock=clock, event_bus=bus)
+
+        # Push past daily budget
+        await tracker.record("2_triage", "anthropic", CallResult(success=True, cost_usd=3.00))
+
+        # Call check_budget 10 times rapidly
+        for _ in range(10):
+            status = await tracker.check_budget()
+            assert status == BudgetStatus.EXCEEDED  # status always returned
+
+        # Event emitted exactly once (first call only)
+        exceeded_calls = [
+            c for c in bus.emit.call_args_list
+            if c.args[2] == "budget.exceeded"
+        ]
+        assert len(exceeded_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_warning_event_emitted_once_on_rapid_calls(self, db, clock):
+        bus = AsyncMock()
+        tracker = CostTracker(db, clock=clock, event_bus=bus)
+
+        # Push into warning zone (daily $2, 80% = $1.60)
+        await tracker.record("2_triage", "anthropic", CallResult(success=True, cost_usd=1.70))
+
+        for _ in range(10):
+            status = await tracker.check_budget()
+            assert status == BudgetStatus.WARNING
+
+        warning_calls = [
+            c for c in bus.emit.call_args_list
+            if c.args[2] == "budget.warning"
+        ]
+        assert len(warning_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_event_re_emits_after_throttle_expires(self, db, clock):
+        bus = AsyncMock()
+        tracker = CostTracker(db, clock=clock, event_bus=bus)
+        tracker._EVENT_THROTTLE_S = 0.0  # disable throttle → every call emits
+
+        await tracker.record("2_triage", "anthropic", CallResult(success=True, cost_usd=3.00))
+
+        await tracker.check_budget()
+        await tracker.check_budget()
+        await tracker.check_budget()
+
+        exceeded_calls = [
+            c for c in bus.emit.call_args_list
+            if c.args[2] == "budget.exceeded"
+        ]
+        assert len(exceeded_calls) == 3  # all emitted with throttle=0
+
+    @pytest.mark.asyncio
+    async def test_no_event_bus_still_returns_status(self, db, clock):
+        """Without event_bus, status still works (no emit, no error)."""
+        tracker = CostTracker(db, clock=clock, event_bus=None)
+        await tracker.record("2_triage", "anthropic", CallResult(success=True, cost_usd=3.00))
+        status = await tracker.check_budget()
+        assert status == BudgetStatus.EXCEEDED


### PR DESCRIPTION
## Summary
- `budget.exceeded` event fired on every routing call when daily budget was exceeded (~6-7 calls/min = 2,857 log entries in 7 hours)
- Added 5-minute per-event-type throttle using `time.monotonic()` — same pattern for `budget.warning`
- `BudgetStatus` return value unchanged on every call — routing decisions are unaffected, only log volume is reduced
- Expected reduction: ~2,857/7hr → ~84/7hr

## Test plan
- [x] 10 rapid `check_budget()` calls → event emitted exactly once
- [x] Same for warning-level events
- [x] With `_EVENT_THROTTLE_S = 0.0` → every call emits (proves re-emit after expiry)
- [x] No event_bus → status still returned without error
- [x] All 12 tests pass, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)