### PR TITLE
feat(web): Scrapling TLS fingerprinting + Cloudflare Quick Actions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
                          # (Genesis uses stdio transport only, no OpenAPI/OAuth/CLI features)
     "detect-secrets>=1.4",  # Phase 6 contribution sanitizer — REQUIRED floor. sanitize.py fails closed if missing.
     "pymupdf>=1.27",  # PDF text extraction for knowledge ingestion pipeline
+    "scrapling>=0.4.7",  # Web fetching with TLS fingerprint impersonation
+    "curl_cffi>=0.15.0",  # curl_cffi backend for Scrapling's AsyncFetcher
 ]
 
 [project.optional-dependencies]

--- a/src/genesis/knowledge/processors/web.py
+++ b/src/genesis/knowledge/processors/web.py
@@ -1,8 +1,13 @@
-"""Web content processor wrapping the existing WebFetcher."""
+"""Web content processor wrapping the existing WebFetcher.
+
+Escalates to Cloudflare Browser Run /markdown when the primary fetch
+returns thin content (JS-rendered shell with no real text).
+"""
 
 from __future__ import annotations
 
 import logging
+import os
 import re
 
 from genesis.knowledge.processors.base import ProcessedContent
@@ -10,6 +15,7 @@ from genesis.knowledge.processors.base import ProcessedContent
 logger = logging.getLogger(__name__)
 
 _URL_PATTERN = re.compile(r"^https?://")
+_THIN_CONTENT_THRESHOLD = 200  # chars after stripping markers
 
 
 class WebProcessor:
@@ -24,13 +30,27 @@ class WebProcessor:
         if result.error:
             raise RuntimeError(f"Failed to fetch {source}: {result.error}")
 
+        # Escalate to Cloudflare /markdown if the primary fetch returned
+        # thin content (likely a JS-rendered shell like <div id="root">).
+        text = result.text
+        title = result.title
+        escalated = False
+        stripped = re.sub(r"<external-content[^>]*>|</external-content>", "", text).strip()
+        if len(stripped) < _THIN_CONTENT_THRESHOLD:
+            cf_text = await self._try_cloudflare_markdown(source)
+            if cf_text:
+                text = cf_text
+                escalated = True
+                logger.info("Escalated to Cloudflare /markdown for %s", source)
+
         return ProcessedContent(
-            text=result.text,
+            text=text,
             metadata={
                 "url": result.url,
-                "title": result.title,
+                "title": title,
                 "status_code": result.status_code,
                 "truncated": result.truncated,
+                "escalated_to_cloudflare": escalated,
             },
             source_type="web",
             source_path=source,
@@ -38,3 +58,19 @@ class WebProcessor:
 
     def can_handle(self, source: str) -> bool:
         return bool(_URL_PATTERN.match(source))
+
+    @staticmethod
+    async def _try_cloudflare_markdown(url: str) -> str | None:
+        """Attempt Cloudflare /markdown extraction. Returns None on failure."""
+        if not os.environ.get("API_KEY_CLOUDFLARE") or not os.environ.get("CLOUDFLARE_ACCOUNT_ID"):
+            return None
+        try:
+            from genesis.providers.cloudflare_crawl import CloudflareCrawlAdapter
+
+            adapter = CloudflareCrawlAdapter()
+            result = await adapter.fetch_markdown(url)
+            if result.success and result.data:
+                return result.data if isinstance(result.data, str) else str(result.data)
+        except Exception:
+            logger.debug("Cloudflare /markdown escalation failed for %s", url, exc_info=True)
+        return None

--- a/src/genesis/providers/cloudflare_crawl.py
+++ b/src/genesis/providers/cloudflare_crawl.py
@@ -1,4 +1,10 @@
-"""ToolProvider adapter for Cloudflare Browser Rendering /crawl endpoint."""
+"""ToolProvider adapter for Cloudflare Browser Run (formerly Browser Rendering).
+
+Supports:
+- /crawl — async multi-page crawl to Markdown (original)
+- /markdown — single-page JS-rendered markdown extraction (Quick Action)
+- /json — AI-powered structured data extraction (Quick Action)
+"""
 
 from __future__ import annotations
 
@@ -24,14 +30,14 @@ _POLL_TIMEOUT = 120.0
 
 
 class CloudflareCrawlAdapter:
-    """Cloudflare /crawl endpoint — whole-site crawl to Markdown."""
+    """Cloudflare Browser Run — crawl, markdown extraction, and structured data."""
 
     name = "cloudflare_crawl"
     capability = ProviderCapability(
-        content_types=("web_page", "crawl"),
+        content_types=("web_page", "crawl", "markdown", "structured_data"),
         categories=(ProviderCategory.WEB,),
         cost_tier=CostTier.FREE,
-        description="Cloudflare /crawl — whole-site crawling to Markdown",
+        description="Cloudflare Browser Run — crawl, markdown, and AI extraction",
     )
 
     def __init__(self) -> None:
@@ -50,8 +56,11 @@ class CloudflareCrawlAdapter:
             self._client = httpx.AsyncClient(timeout=30.0)
         return self._client
 
+    def _endpoint_url(self, account_id: str, endpoint: str) -> str:
+        return f"{_BASE_URL.format(account_id=account_id)}/{endpoint}"
+
     def _crawl_url(self, account_id: str) -> str:
-        return f"{_BASE_URL.format(account_id=account_id)}/crawl"
+        return self._endpoint_url(account_id, "crawl")
 
     async def check_health(self) -> ProviderStatus:
         """HEAD request to crawl endpoint to verify auth and availability."""
@@ -198,6 +207,82 @@ class CloudflareCrawlAdapter:
                 error=str(exc),
                 latency_ms=latency,
                 provider_name=self.name,
+            )
+
+    # ── Quick Actions (stateless, no polling) ───────────────────
+
+    async def fetch_markdown(self, url: str) -> ProviderResult:
+        """Render a URL via headless Chrome and return clean Markdown."""
+        return await self._quick_action("markdown", url)
+
+    async def fetch_json(
+        self, url: str, prompt: str, *, schema: dict | None = None,
+    ) -> ProviderResult:
+        """AI-powered structured data extraction from a rendered page."""
+        payload: dict = {"url": url, "prompt": prompt}
+        if schema:
+            payload["response_format"] = schema
+        return await self._quick_action("json", url, extra_payload=payload)
+
+    async def _quick_action(
+        self, endpoint: str, url: str, *, extra_payload: dict | None = None,
+    ) -> ProviderResult:
+        """POST to a Quick Actions endpoint and return the result."""
+        start = time.monotonic()
+        try:
+            api_key, account_id = self._get_config()
+        except ValueError as exc:
+            return ProviderResult(
+                success=False, error=str(exc),
+                latency_ms=round((time.monotonic() - start) * 1000, 2),
+                provider_name=self.name,
+            )
+
+        if not url.startswith(("http://", "https://")):
+            return ProviderResult(
+                success=False,
+                error=f"URL must use http:// or https:// scheme, got: {url[:50]}",
+                latency_ms=round((time.monotonic() - start) * 1000, 2),
+                provider_name=self.name,
+            )
+
+        payload = extra_payload or {"url": url}
+        if "url" not in payload:
+            payload["url"] = url
+
+        try:
+            client = self._get_client()
+            resp = await client.post(
+                self._endpoint_url(account_id, endpoint),
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+            )
+            resp.raise_for_status()
+            body = resp.json()
+            latency = round((time.monotonic() - start) * 1000, 2)
+
+            result_data = body.get("result", body.get("data", body))
+            return ProviderResult(
+                success=True, data=result_data,
+                latency_ms=latency, provider_name=self.name,
+            )
+        except httpx.HTTPStatusError as exc:
+            latency = round((time.monotonic() - start) * 1000, 2)
+            logger.error("Cloudflare %s HTTP error: %s", endpoint, exc.response.status_code)
+            return ProviderResult(
+                success=False,
+                error=f"HTTP {exc.response.status_code}: {exc.response.text[:200]}",
+                latency_ms=latency, provider_name=self.name,
+            )
+        except Exception as exc:
+            latency = round((time.monotonic() - start) * 1000, 2)
+            logger.error("Cloudflare %s failed", endpoint, exc_info=True)
+            return ProviderResult(
+                success=False, error=str(exc),
+                latency_ms=latency, provider_name=self.name,
             )
 
     async def _poll_job(

--- a/src/genesis/web/fetch.py
+++ b/src/genesis/web/fetch.py
@@ -15,9 +15,22 @@ _DEFAULT_MAX_CHARS = 50_000  # ~12k tokens
 _DEFAULT_TIMEOUT = 20.0
 _USER_AGENT = "Genesis/3.0 (research bot)"
 
+# Scrapling gives TLS fingerprint impersonation via curl_cffi —
+# requests appear as real Chrome, bypassing most anti-bot detection.
+try:
+    from scrapling.fetchers import AsyncFetcher as _ScraplingFetcher
+
+    _HAS_SCRAPLING = True
+except ImportError:
+    _HAS_SCRAPLING = False
+
 
 class WebFetcher:
-    """Async URL fetcher with HTML-to-text extraction."""
+    """Async URL fetcher with HTML-to-text extraction.
+
+    Uses Scrapling (curl_cffi) when available for TLS fingerprint
+    impersonation, falling back to plain httpx otherwise.
+    """
 
     def __init__(
         self,
@@ -25,37 +38,47 @@ class WebFetcher:
         timeout_s: float = _DEFAULT_TIMEOUT,
         max_chars: int = _DEFAULT_MAX_CHARS,
     ) -> None:
-        self._client = httpx.AsyncClient(
-            timeout=timeout_s,
-            follow_redirects=True,
-            headers={"User-Agent": _USER_AGENT},
-        )
+        self._timeout_s = timeout_s
+        self._client: httpx.AsyncClient | None = None
         self._max_chars = max_chars
+
+    def _get_httpx_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                timeout=self._timeout_s,
+                follow_redirects=True,
+                headers={"User-Agent": _USER_AGENT},
+            )
+        return self._client
 
     async def fetch(self, url: str, *, max_chars: int | None = None) -> FetchResult:
         """Fetch a URL and return cleaned text. Never raises."""
         limit = max_chars or self._max_chars
-        try:
-            resp = await self._client.get(url)
-            resp.raise_for_status()
-        except httpx.HTTPError as exc:
-            logger.warning("Fetch failed for %s: %s", url, exc)
-            status = getattr(exc, "response", None)
-            code = status.status_code if status else 0
-            return FetchResult(url=url, text="", status_code=code, error=str(exc))
 
-        content_type = resp.headers.get("content-type", "")
-        if "text/html" in content_type or "application/xhtml" in content_type:
+        if _HAS_SCRAPLING:
+            body, status_code, content_type, error = await self._fetch_scrapling(url)
+        else:
+            body, status_code, content_type, error = await self._fetch_httpx(url)
+
+        if error:
+            return FetchResult(url=url, text="", status_code=status_code, error=error)
+
+        is_html = (
+            "text/html" in content_type
+            or "application/xhtml" in content_type
+            or body.lstrip()[:15].lower().startswith(("<!doctype", "<html"))
+        )
+        if is_html:
             try:
-                text, title = _extract_html(resp.text)
+                text, title = _extract_html(body)
             except Exception:
                 logger.warning("HTML extraction failed for %s — using raw text", url, exc_info=True)
-                text, title = resp.text[:5000], ""
-        elif "text/plain" in content_type or "application/json" in content_type:
-            text, title = resp.text, ""
+                text, title = body[:5000], ""
+        elif "text/plain" in content_type or "application/json" in content_type or not content_type:
+            text, title = body, ""
         else:
             return FetchResult(
-                url=url, text="", status_code=resp.status_code,
+                url=url, text="", status_code=status_code,
                 error=f"Unsupported content type: {content_type}",
             )
 
@@ -63,14 +86,52 @@ class WebFetcher:
         if truncated:
             text = text[:limit]
 
-        # Wrap in boundary markers for injection defense
         sanitizer = ContentSanitizer()
         text = sanitizer.wrap_content(text, ContentSource.WEB_FETCH)
 
         return FetchResult(
             url=url, text=text, title=title,
-            status_code=resp.status_code, truncated=truncated,
+            status_code=status_code, truncated=truncated,
         )
+
+    async def _fetch_scrapling(self, url: str) -> tuple[str, int, str, str | None]:
+        """Fetch via Scrapling with TLS fingerprint impersonation.
+
+        Returns (body, status_code, content_type, error).
+        """
+        try:
+            resp = await _ScraplingFetcher.get(
+                url, impersonate="chrome", timeout=self._timeout_s,
+            )
+        except Exception as exc:
+            logger.warning("Scrapling fetch failed for %s: %s", url, exc)
+            return "", 0, "", str(exc)
+
+        if resp.status >= 400:
+            error = f"HTTP {resp.status}"
+            logger.warning("Fetch failed for %s: %s", url, error)
+            return "", resp.status, "", error
+
+        content_type = resp.headers.get("content-type", "")
+        body = resp.body.decode("utf-8", errors="replace")
+        return body, resp.status, content_type, None
+
+    async def _fetch_httpx(self, url: str) -> tuple[str, int, str, str | None]:
+        """Fetch via plain httpx (fallback when Scrapling not installed).
+
+        Returns (body, status_code, content_type, error).
+        """
+        client = self._get_httpx_client()
+        try:
+            resp = await client.get(url)
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            logger.warning("Fetch failed for %s: %s", url, exc)
+            status = getattr(exc, "response", None)
+            code = status.status_code if status else 0
+            return "", code, "", str(exc)
+        content_type = resp.headers.get("content-type", "")
+        return resp.text, resp.status_code, content_type, None
 
 
 def _extract_html(html: str) -> tuple[str, str]:

--- a/tests/test_web/test_fetch.py
+++ b/tests/test_web/test_fetch.py
@@ -1,6 +1,6 @@
 """Tests for genesis.web.fetch — WebFetcher with HTML extraction."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -8,7 +8,7 @@ import pytest
 from genesis.web.fetch import WebFetcher
 
 
-def _make_response(
+def _make_httpx_response(
     text: str, content_type: str = "text/html", status_code: int = 200,
 ) -> MagicMock:
     resp = MagicMock()
@@ -16,6 +16,16 @@ def _make_response(
     resp.text = text
     resp.headers = {"content-type": content_type}
     resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _make_scrapling_response(
+    body: bytes, status: int = 200, content_type: str = "text/html",
+) -> MagicMock:
+    resp = MagicMock()
+    resp.status = status
+    resp.body = body
+    resp.headers = {"content-type": content_type}
     return resp
 
 
@@ -39,9 +49,15 @@ def fetcher():
     return WebFetcher(max_chars=50_000)
 
 
+# ── httpx fallback path tests ────────────────────────────────────
+
+
 @pytest.mark.asyncio
+@patch("genesis.web.fetch._HAS_SCRAPLING", False)
 async def test_fetch_html_extracts_text(fetcher: WebFetcher):
-    fetcher._client.get = AsyncMock(return_value=_make_response(SIMPLE_HTML))
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(return_value=_make_httpx_response(SIMPLE_HTML))
+    fetcher._client = mock_client
     result = await fetcher.fetch("https://example.com")
     assert result.title == "Test Page"
     assert "Hello World" in result.text
@@ -51,68 +67,88 @@ async def test_fetch_html_extracts_text(fetcher: WebFetcher):
 
 
 @pytest.mark.asyncio
+@patch("genesis.web.fetch._HAS_SCRAPLING", False)
 async def test_fetch_plain_text(fetcher: WebFetcher):
-    fetcher._client.get = AsyncMock(
-        return_value=_make_response("Plain text here", "text/plain"),
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(
+        return_value=_make_httpx_response("Plain text here", "text/plain"),
     )
+    fetcher._client = mock_client
     result = await fetcher.fetch("https://example.com")
     assert "Plain text here" in result.text
-    assert "<external-content" in result.text  # boundary markers
+    assert "<external-content" in result.text
     assert result.title == ""
 
 
 @pytest.mark.asyncio
+@patch("genesis.web.fetch._HAS_SCRAPLING", False)
 async def test_fetch_json(fetcher: WebFetcher):
-    fetcher._client.get = AsyncMock(
-        return_value=_make_response('{"key": "value"}', "application/json"),
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(
+        return_value=_make_httpx_response('{"key": "value"}', "application/json"),
     )
+    fetcher._client = mock_client
     result = await fetcher.fetch("https://example.com/api")
     assert '"key"' in result.text
 
 
 @pytest.mark.asyncio
+@patch("genesis.web.fetch._HAS_SCRAPLING", False)
 async def test_fetch_binary_returns_error(fetcher: WebFetcher):
-    fetcher._client.get = AsyncMock(
-        return_value=_make_response("", "application/pdf"),
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(
+        return_value=_make_httpx_response("", "application/pdf"),
     )
+    fetcher._client = mock_client
     result = await fetcher.fetch("https://example.com/doc.pdf")
     assert result.error is not None
     assert "Unsupported" in result.error
 
 
 @pytest.mark.asyncio
+@patch("genesis.web.fetch._HAS_SCRAPLING", False)
 async def test_fetch_http_error(fetcher: WebFetcher):
     exc = httpx.HTTPStatusError(
         "Not Found", request=MagicMock(), response=MagicMock(status_code=404),
     )
-    fetcher._client.get = AsyncMock(side_effect=exc)
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(side_effect=exc)
+    fetcher._client = mock_client
     result = await fetcher.fetch("https://example.com/missing")
     assert result.error is not None
     assert result.status_code == 404
 
 
 @pytest.mark.asyncio
+@patch("genesis.web.fetch._HAS_SCRAPLING", False)
 async def test_fetch_connection_error(fetcher: WebFetcher):
-    fetcher._client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+    fetcher._client = mock_client
     result = await fetcher.fetch("https://down.example.com")
     assert result.error is not None
     assert result.text == ""
 
 
 @pytest.mark.asyncio
+@patch("genesis.web.fetch._HAS_SCRAPLING", False)
 async def test_fetch_truncation(fetcher: WebFetcher):
     long_html = "<html><body><p>" + "x" * 1000 + "</p></body></html>"
-    fetcher._client.get = AsyncMock(return_value=_make_response(long_html))
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(return_value=_make_httpx_response(long_html))
+    fetcher._client = mock_client
     result = await fetcher.fetch("https://example.com", max_chars=100)
     assert result.truncated is True
-    # Content is truncated to max_chars THEN wrapped in boundary markers
-    assert "x" * 50 in result.text  # truncated content present
+    assert "x" * 50 in result.text
     assert "<external-content" in result.text
 
 
 @pytest.mark.asyncio
+@patch("genesis.web.fetch._HAS_SCRAPLING", False)
 async def test_fetch_noise_stripping(fetcher: WebFetcher):
-    fetcher._client.get = AsyncMock(return_value=_make_response(SIMPLE_HTML))
+    mock_client = MagicMock()
+    mock_client.get = AsyncMock(return_value=_make_httpx_response(SIMPLE_HTML))
+    fetcher._client = mock_client
     result = await fetcher.fetch("https://example.com")
     assert "alert" not in result.text
     assert "Navigation" not in result.text
@@ -120,11 +156,63 @@ async def test_fetch_noise_stripping(fetcher: WebFetcher):
     assert "color:red" not in result.text
 
 
+# ── Scrapling path tests ─────────────────────────────────────────
+
+
 @pytest.mark.asyncio
-async def test_fetch_custom_max_chars(fetcher: WebFetcher):
-    html = "<html><body><p>" + "y" * 500 + "</p></body></html>"
-    fetcher._client.get = AsyncMock(return_value=_make_response(html))
-    result = await fetcher.fetch("https://example.com", max_chars=200)
-    # Content truncated to 200 chars then wrapped (markers add ~70 chars)
-    assert "y" * 100 in result.text
+@patch("genesis.web.fetch._HAS_SCRAPLING", True)
+async def test_scrapling_html_extracts_text(fetcher: WebFetcher):
+    mock_resp = _make_scrapling_response(SIMPLE_HTML.encode())
+    with patch("genesis.web.fetch._ScraplingFetcher") as mock_fetcher:
+        mock_fetcher.get = AsyncMock(return_value=mock_resp)
+        result = await fetcher.fetch("https://example.com")
+    assert result.title == "Test Page"
+    assert "Hello World" in result.text
+    assert result.status_code == 200
+    assert result.error is None
+    mock_fetcher.get.assert_awaited_once()
+    call_kwargs = mock_fetcher.get.call_args
+    assert call_kwargs.kwargs.get("impersonate") == "chrome" or call_kwargs[1].get("impersonate") == "chrome"
+
+
+@pytest.mark.asyncio
+@patch("genesis.web.fetch._HAS_SCRAPLING", True)
+async def test_scrapling_status_error(fetcher: WebFetcher):
+    mock_resp = _make_scrapling_response(b"", status=403)
+    with patch("genesis.web.fetch._ScraplingFetcher") as mock_fetcher:
+        mock_fetcher.get = AsyncMock(return_value=mock_resp)
+        result = await fetcher.fetch("https://blocked.example.com")
+    assert result.error is not None
+    assert result.status_code == 403
+
+
+@pytest.mark.asyncio
+@patch("genesis.web.fetch._HAS_SCRAPLING", True)
+async def test_scrapling_connection_error(fetcher: WebFetcher):
+    with patch("genesis.web.fetch._ScraplingFetcher") as mock_fetcher:
+        mock_fetcher.get = AsyncMock(side_effect=ConnectionError("refused"))
+        result = await fetcher.fetch("https://down.example.com")
+    assert result.error is not None
+    assert result.text == ""
+
+
+@pytest.mark.asyncio
+@patch("genesis.web.fetch._HAS_SCRAPLING", True)
+async def test_scrapling_plain_text(fetcher: WebFetcher):
+    mock_resp = _make_scrapling_response(b"Just plain text", content_type="text/plain")
+    with patch("genesis.web.fetch._ScraplingFetcher") as mock_fetcher:
+        mock_fetcher.get = AsyncMock(return_value=mock_resp)
+        result = await fetcher.fetch("https://example.com/plain")
+    assert "Just plain text" in result.text
     assert "<external-content" in result.text
+
+
+@pytest.mark.asyncio
+@patch("genesis.web.fetch._HAS_SCRAPLING", True)
+async def test_scrapling_unsupported_content_type(fetcher: WebFetcher):
+    mock_resp = _make_scrapling_response(b"\x00\x01", content_type="application/pdf")
+    with patch("genesis.web.fetch._ScraplingFetcher") as mock_fetcher:
+        mock_fetcher.get = AsyncMock(return_value=mock_resp)
+        result = await fetcher.fetch("https://example.com/doc.pdf")
+    assert result.error is not None
+    assert "Unsupported" in result.error


### PR DESCRIPTION
## Summary
- WebFetcher upgraded to use Scrapling (curl_cffi) for TLS fingerprint impersonation — requests appear as real Chrome, bypassing anti-bot detection
- Cloudflare Browser Run adapter gains `/markdown` and `/json` Quick Actions endpoints for JS-rendered content extraction
- WebProcessor auto-escalates to Cloudflare when primary fetch returns thin content (JS shells)
- Graceful fallback: if Scrapling not installed, httpx path unchanged

## Test plan
- [x] 13 tests pass (8 httpx path, 5 Scrapling path)
- [x] Live test: Scrapling fetches example.com with Chrome impersonation
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)