### PR TITLE
fix: extraction quality, dashboard thresholds, code index priority

### DIFF
--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1986,9 +1986,15 @@
               || (queues.deferred_stuck || 0) > 0 || (queues.failed_embeddings || 0) > 0) {
             return { state: "error", reason: "stuck/failed items or dead letters require attention" };
           }
-          if ((queues.deferred_work || 0) > 0 || (queues.pending_embeddings || 0) > 0
-              || (queues.deferred_processing || 0) > 0) {
-            return { state: "degraded", reason: "work is backing up in deferred or embedding queues" };
+          if ((queues.deferred_work || 0) > 0 || (queues.deferred_processing || 0) > 0) {
+            return { state: "degraded", reason: "work is backing up in deferred queues" };
+          }
+          const pe = queues.pending_embeddings || 0;
+          if (pe > 2000) {
+            return { state: "error", reason: `embedding queue critically backed up (${pe} pending)` };
+          }
+          if (pe > 500) {
+            return { state: "degraded", reason: `embedding queue backed up (${pe} pending)` };
           }
           if (Array.isArray(queues.errors) && queues.errors.length > 0) {
             return { state: "unknown", reason: "some queue counters could not be collected" };

--- a/src/genesis/memory/extraction.py
+++ b/src/genesis/memory/extraction.py
@@ -36,12 +36,23 @@ For each extraction, provide:
     categorized_as, related_to, succeeded_by, preceded_by
 - temporal: Date or time reference if mentioned (ISO format preferred)
 
-Focus on SUBSTANCE — what was discussed, decided, evaluated, or planned.
-Skip: greetings, filler, acknowledgments.
-DO extract: tool/project names discussed, opinions expressed, decisions made,
-action items created, evaluations of external things, errors encountered,
-file paths mentioned, technical concepts introduced.
-Extract generously — 5-15 facts per conversation segment is normal.
+Focus on DURABLE KNOWLEDGE — facts, decisions, and insights that will be
+valuable weeks or months from now. Target 3-8 high-quality extractions per
+segment. Quality over quantity.
+
+DO extract: architectural decisions, design rationale, bug root causes,
+tool/project evaluations, user preferences, external concepts introduced,
+lessons learned, non-obvious technical insights.
+
+DO NOT extract:
+- Session narration ("merged to main", "committed changes", "pushed to remote")
+- Test/build status ("67 tests passed", "all checks green", "batch 3 committed")
+- Point-in-time metrics (memory %, budget numbers, CPU usage, queue depths)
+- Investigation play-by-play ("[investigation] checked X", "searched for Y")
+- Model/session configuration ("Opus set for session", "effort set to high")
+- File path inventories without context ("Files to modify: src/a.py, src/b.py")
+- Git operations (commit hashes, merge descriptions, branch operations)
+- Routine procedural decisions ("decided to create new commit instead of amending")
 
 Respond with a JSON object inside backticks containing:
 1. "extractions" — array of extracted facts

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -186,15 +186,6 @@ async def run_extraction_cycle(
                 # episodic memory rows that already exist from prior cycles.
                 continue
 
-            # Check per-session cap before storing more extractions
-            if session_extraction_count >= max_extractions_per_session:
-                logger.info(
-                    "Hit per-session extraction cap (%d) for session %s, "
-                    "skipping remaining chunks",
-                    max_extractions_per_session, session_id,
-                )
-                break
-
             # Store each extraction with provenance
             for extraction in result.extractions:
                 kwargs = extractions_to_store_kwargs(
@@ -231,6 +222,15 @@ async def run_extraction_cycle(
                         "Failed to store extraction from session %s",
                         session_id, exc_info=True,
                     )
+
+            # Check per-session cap after storing this chunk's extractions
+            if session_extraction_count >= max_extractions_per_session:
+                logger.info(
+                    "Hit per-session extraction cap (%d) for session %s, "
+                    "skipping remaining chunks",
+                    max_extractions_per_session, session_id,
+                )
+                break
 
         # Update watermark + session keywords/topic
         # Skip both in reference_only_mode so the history mining run leaves

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -60,6 +60,7 @@ async def run_extraction_cycle(
     reference_only_mode: bool = False,
     start_line_override: int | None = None,
     session_filter: set[str] | None = None,
+    max_extractions_per_session: int = 30,
 ) -> dict:
     """Run one extraction cycle across all eligible sessions.
 
@@ -118,6 +119,7 @@ async def run_extraction_cycle(
         max_line = last_line
         all_keywords: set[str] = set()
         latest_topic = ""
+        session_extraction_count = 0
 
         for chunk in chunks:
             chunk_start = chunk[0].line_number
@@ -184,6 +186,15 @@ async def run_extraction_cycle(
                 # episodic memory rows that already exist from prior cycles.
                 continue
 
+            # Check per-session cap before storing more extractions
+            if session_extraction_count >= max_extractions_per_session:
+                logger.info(
+                    "Hit per-session extraction cap (%d) for session %s, "
+                    "skipping remaining chunks",
+                    max_extractions_per_session, session_id,
+                )
+                break
+
             # Store each extraction with provenance
             for extraction in result.extractions:
                 kwargs = extractions_to_store_kwargs(
@@ -201,6 +212,7 @@ async def run_extraction_cycle(
                         **kwargs, force_fts5_only=True,
                     )
                     summary["entities_extracted"] += 1
+                    session_extraction_count += 1
 
                     # Create typed links from extraction relationships
                     if linker and extraction.relationships:

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -297,7 +297,7 @@ class SurplusScheduler:
             pending = await self._queue.pending_by_type(TaskType.CODE_INDEX)
             if pending == 0:
                 await self._queue.enqueue(
-                    TaskType.CODE_INDEX, ComputeTier.LOCAL_30B, 0.3, "competence"
+                    TaskType.CODE_INDEX, ComputeTier.LOCAL_30B, 0.6, "competence"
                 )
             try:
                 from genesis.runtime import GenesisRuntime


### PR DESCRIPTION
## Summary

- **Extraction prompt tightened**: Focus on durable knowledge (3-8 extractions/segment), explicit exclusion list for session narration, test counts, metrics, investigation play-by-play, git operations
- **Per-session extraction cap**: 30 extractions/session to prevent runaway cycles (previous: unlimited, produced 100+/session)
- **Dashboard queue thresholds**: `pending_embeddings` separated from `deferred_work`; now uses >500 (degraded) / >2000 (error) instead of >0 which caused persistent false degraded status
- **Code index priority**: 0.3 → 0.6 to prevent priority starvation (was never dispatched)

### DB maintenance performed (not in this diff):
- Purged 11,756 noisy extraction memories from Apr 17-18 (extraction ran through 187-session backlog, creating 10,603 memories in one day vs ~50-100/day baseline)
- Purged 10,152 orphaned Qdrant vectors
- Manually populated code index (635 modules, 3,876 symbols)
- FTS5 integrity verified after purge

## Test plan

- [x] `ruff check` passes on all changed Python files
- [x] 417 tests pass (4 deselected — pre-existing failures in `test_reference_extraction.py` on main)
- [x] FTS5 integrity check passed after memory purge
- [x] Memory metadata (2,109) matches FTS content count
- [x] Qdrant points (2,088) align with metadata
- [x] Code index populated: 635 modules, 3,876 symbols
- [ ] Dashboard shows healthy after merge + server restart
- [ ] Next extraction cycle produces reasonable volume with tighter prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)