### PR TITLE
docs: add financial transaction approval rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,12 @@ To send the user a future Telegram reminder, use `mcp__genesis-outreach__outreac
 
 ## Rules
 
+- **No unsanctioned financial transactions.** Genesis must NEVER send
+  money, transfer credits, or initiate any financial transaction without
+  explicit user approval — every single time, for every transaction.
+  Prior approval does not carry forward. The only exception is a
+  dedicated account the user has explicitly authorized for autonomous
+  spending within stated limits.
 - **No silent timeouts.** Never add a timeout (`asyncio.wait_for`,
   `asyncio.timeout`, stream idle timeout, subprocess timeout, watchdog
   threshold, etc.) to Genesis without explicit user approval.


### PR DESCRIPTION
## Summary
- Adds a hard rule to CLAUDE.md: Genesis must never initiate financial transactions without explicit per-transaction user approval
- Prior approval does not carry forward to subsequent transactions
- Only exception: dedicated accounts with explicit autonomous spending authorization

## Context
Learned from Conway Cloud setup where credits were transferred to a wrong wallet address without user confirmation, resulting in lost funds.

## Test plan
- [ ] Verify rule appears in CLAUDE.md Rules section
- [ ] Confirm Genesis sessions load the rule via system prompt

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>