### PR TITLE
fix(tz): respect user timezone across outreach, alerts, and follow-ups

### DIFF
--- a/config/outreach.yaml
+++ b/config/outreach.yaml
@@ -3,7 +3,7 @@
 quiet_hours:
   start: "22:00"
   end: "07:00"
-  timezone: "UTC"
+  # timezone omitted — inherits from central genesis.yaml / USER_TIMEZONE
 
 channel_preferences:
   default: telegram
@@ -30,7 +30,7 @@ rate_limits:
 
 morning_report:
   trigger_time: "07:00"
-  timezone: "UTC"
+  # timezone omitted — inherits from central genesis.yaml / USER_TIMEZONE
 
 engagement:
   timeout_hours: 24

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -16,6 +16,15 @@ def _new_id() -> str:
     return uuid.uuid4().hex
 
 
+def _normalize_scheduled_at(iso_str: str | None) -> str | None:
+    """Normalize a scheduled_at ISO timestamp to UTC for safe DB comparison."""
+    if not iso_str:
+        return iso_str
+    dt = datetime.fromisoformat(iso_str)
+    dt = dt.astimezone(UTC) if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+    return dt.isoformat()
+
+
 async def create(
     db: aiosqlite.Connection,
     *,
@@ -36,7 +45,7 @@ async def create(
             scheduled_at, status, priority, created_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)""",
         (fid, source, source_session, content, reason, strategy,
-         scheduled_at, priority, _now_iso()),
+         _normalize_scheduled_at(scheduled_at), priority, _now_iso()),
     )
     await db.commit()
     return fid
@@ -101,7 +110,7 @@ async def get_scheduled_due(db: aiosqlite.Connection) -> list[dict]:
         "SELECT * FROM follow_ups "
         "WHERE strategy = 'scheduled_task' AND status = 'pending' "
         "AND scheduled_at IS NOT NULL "
-        "AND scheduled_at <= strftime('%Y-%m-%dT%H:%M:%S+00:00', 'now') "
+        "AND datetime(scheduled_at) <= datetime('now') "
         "ORDER BY scheduled_at ASC",
     )
     return [dict(row) for row in await cursor.fetchall()]

--- a/src/genesis/db/migrations/__main__.py
+++ b/src/genesis/db/migrations/__main__.py
@@ -30,6 +30,7 @@ async def _run(args: argparse.Namespace) -> int:
 
     async with aiosqlite.connect(str(db_path)) as db:
         await db.execute("PRAGMA journal_mode=WAL")
+        await db.execute("PRAGMA busy_timeout=5000")  # Match connection.BUSY_TIMEOUT_MS
         runner = MigrationRunner(db)
 
         if args.status:

--- a/src/genesis/eval/cli.py
+++ b/src/genesis/eval/cli.py
@@ -145,6 +145,7 @@ async def _cmd_run(args: argparse.Namespace) -> int:
 
             from genesis.env import genesis_db_path
             db = await aiosqlite.connect(str(genesis_db_path()))
+            await db.execute("PRAGMA busy_timeout=5000")  # Match connection.BUSY_TIMEOUT_MS
         except Exception as e:
             print(f"warning: could not open DB ({e}), results won't be stored")
 
@@ -213,6 +214,7 @@ async def _cmd_benchmark(args: argparse.Namespace) -> int:
             import aiosqlite  # noqa: I001
             from genesis.env import genesis_db_path
             db = await aiosqlite.connect(str(genesis_db_path()))
+            await db.execute("PRAGMA busy_timeout=5000")  # Match connection.BUSY_TIMEOUT_MS
         except Exception as e:
             print(f"warning: could not open DB ({e}), results won't be stored")
 
@@ -270,6 +272,7 @@ async def _cmd_results(args: argparse.Namespace) -> int:
         from genesis.eval.db import get_runs
 
         async with aiosqlite.connect(str(genesis_db_path())) as db:
+            await db.execute("PRAGMA busy_timeout=5000")  # Match connection.BUSY_TIMEOUT_MS
             runs = await get_runs(
                 db, model_id=args.model, dataset=args.dataset, limit=args.last,
             )
@@ -310,6 +313,7 @@ async def _cmd_compare(args: argparse.Namespace) -> int:
         results: dict[str, dict[str, tuple[int, int, int]]] = {}
 
         async with aiosqlite.connect(str(genesis_db_path())) as db:
+            await db.execute("PRAGMA busy_timeout=5000")  # Match connection.BUSY_TIMEOUT_MS
             for ds_name in datasets:
                 # Fetch enough rows so each provider can contribute up to args.last runs.
                 # We don't know the provider count upfront, so over-fetch generously.
@@ -362,6 +366,7 @@ async def _cmd_export(args: argparse.Namespace) -> int:
         provider_notes: dict[str, str] = {}
 
         async with aiosqlite.connect(str(genesis_db_path())) as db:
+            await db.execute("PRAGMA busy_timeout=5000")  # Match connection.BUSY_TIMEOUT_MS
             for ds_name in datasets:
                 runs = await get_runs(db, dataset=ds_name, limit=500)
                 seen: set[str] = set()

--- a/src/genesis/outreach/config.py
+++ b/src/genesis/outreach/config.py
@@ -49,14 +49,23 @@ class OutreachConfig:
             object.__setattr__(self, "delivery_routing", {"default": "supergroup"})
 
 
+def _default_tz() -> str:
+    """Resolve default timezone at call time, not import time."""
+    try:
+        from genesis.env import user_timezone
+        return user_timezone()
+    except Exception:
+        return os.environ.get("USER_TIMEZONE", "UTC")
+
+
 _DEFAULTS = OutreachConfig(
-    quiet_hours=QuietHours(start="22:00", end="07:00", timezone=os.environ.get("USER_TIMEZONE", "UTC")),
+    quiet_hours=QuietHours(start="22:00", end="07:00", timezone="UTC"),
     channel_preferences={"default": "telegram"},
     thresholds={"blocker": 0.0, "alert": 0.3, "surplus": 0.7, "digest": 0.0},
     max_daily=5,
     surplus_daily=1,
     morning_report_time="07:00",
-    morning_report_timezone=os.environ.get("USER_TIMEZONE", "UTC"),
+    morning_report_timezone="UTC",
     engagement_timeout_hours=24,
     engagement_poll_minutes=60,
     immediate_escalation_alerts=(
@@ -179,18 +188,19 @@ def load_outreach_config(path: Path | None = None) -> OutreachConfig:
     with open(path) as f:
         raw = yaml.safe_load(f) or {}
     qh = raw.get("quiet_hours", {})
+    tz = _default_tz()
     return OutreachConfig(
         quiet_hours=QuietHours(
             start=qh.get("start", "22:00"),
             end=qh.get("end", "07:00"),
-            timezone=qh.get("timezone", os.environ.get("USER_TIMEZONE", "UTC")),
+            timezone=qh.get("timezone") or tz,
         ),
         channel_preferences=raw.get("channel_preferences", {"default": "telegram"}),
         thresholds=raw.get("thresholds", _DEFAULTS.thresholds),
         max_daily=raw.get("rate_limits", {}).get("max_daily", 5),
         surplus_daily=raw.get("rate_limits", {}).get("surplus_daily", 1),
         morning_report_time=raw.get("morning_report", {}).get("trigger_time", "07:00"),
-        morning_report_timezone=raw.get("morning_report", {}).get("timezone", os.environ.get("USER_TIMEZONE", "UTC")),
+        morning_report_timezone=raw.get("morning_report", {}).get("timezone") or tz,
         engagement_timeout_hours=raw.get("engagement", {}).get("timeout_hours", 24),
         engagement_poll_minutes=raw.get("engagement", {}).get("poll_interval_minutes", 60),
         immediate_escalation_alerts=tuple(

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -233,7 +233,7 @@ class OutreachScheduler:
         report, awareness signals). Multiple alerts are batched into one message.
         """
         try:
-            from datetime import UTC, datetime
+            from datetime import datetime
 
             from genesis.outreach.health_outreach import HealthOutreachBridge
 
@@ -252,9 +252,18 @@ class OutreachScheduler:
             for req in requests:
                 lines.append(f"\U0001f534 {req.context}")
             lines.append("")
+            from datetime import UTC
+            from zoneinfo import ZoneInfo
+
+            from genesis.env import user_timezone
+
+            try:
+                _alert_tz = ZoneInfo(user_timezone())
+            except Exception:
+                _alert_tz = UTC
             lines.append(
                 f"({len(requests)} critical alert(s) at "
-                f"{datetime.now(UTC).strftime('%H:%M UTC')})"
+                f"{datetime.now(_alert_tz).strftime('%H:%M %Z')})"
             )
             batched_text = "\n".join(lines)
 


### PR DESCRIPTION
## Summary

- Outreach config YAML hardcoded `timezone: "UTC"`, overriding the user's `America/New_York` setting from `genesis.yaml`. Config loader now falls through to `user_timezone()` when YAML key is absent.
- Health alerts showed UTC ("03:48 UTC") instead of local time ("23:48 EDT"). Now uses `user_timezone()` with fallback.
- Follow-up `scheduled_at` comparison used lexicographic string compare, which gives wrong results with mixed timezone offsets. Now uses SQLite `datetime()` for proper normalization. Also normalizes `scheduled_at` to UTC on write.
- Added `PRAGMA busy_timeout=5000` to migration runner and eval CLI (6 connection sites).

## Test plan

- [x] `ruff check` passes on all 6 modified files
- [x] 667/668 tests pass (1 pre-existing failure in callback handler, unrelated)
- [x] `load_outreach_config()` resolves to `America/New_York` for both `quiet_hours.timezone` and `morning_report_timezone`
- [x] `save_outreach_config` round-trips correctly (preserves `America/New_York`)
- [x] `_normalize_scheduled_at("2026-04-20T10:00:00-04:00")` returns `2026-04-20T14:00:00+00:00`
- [x] SQLite `datetime()` comparison correctly handles mixed offsets (verified: string compare gives wrong result, `datetime()` gives correct result)
- [ ] Restart server, confirm outreach scheduler fires at local time

🤖 Generated with [Claude Code](https://claude.com/claude-code)