### PR TITLE
fix(dashboard,config): make settings panel functional, fix Knowledge tab

### DIFF
--- a/src/genesis/_config_overlay.py
+++ b/src/genesis/_config_overlay.py
@@ -1,0 +1,55 @@
+"""Shared helper for merging .local.yaml config overlays.
+
+The dashboard settings system writes user customizations to
+``config/{name}.local.yaml``. Each subsystem config loader calls
+:func:`merge_local_overlay` after reading the base YAML to pick up
+those overrides.
+
+This module is intentionally dependency-free (only stdlib + yaml)
+to avoid circular imports from any config loader.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def merge_local_overlay(base: dict, base_path: Path) -> dict:
+    """Deep-merge a ``.local.yaml`` overlay into *base* if it exists.
+
+    *base_path* is the path to the base YAML file (e.g.
+    ``config/inbox_monitor.yaml``).  The overlay path is derived by
+    inserting ``.local`` before the ``.yaml`` suffix.
+
+    Returns *base* unchanged when no overlay file exists.
+    """
+    local_path = base_path.with_suffix(".local.yaml")
+    if not local_path.exists():
+        return base
+    try:
+        local = yaml.safe_load(local_path.read_text()) or {}
+    except Exception:
+        return base
+    return _deep_merge(base, local)
+
+
+def local_overlay_mtime(base_path: Path) -> float:
+    """Return the mtime of the ``.local.yaml`` overlay, or ``0.0``."""
+    local_path = base_path.with_suffix(".local.yaml")
+    try:
+        return local_path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _deep_merge(base: dict, overlay: dict) -> dict:
+    """Recursively merge *overlay* into *base*.  Lists are replaced."""
+    merged = dict(base)
+    for key, val in overlay.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(val, dict):
+            merged[key] = _deep_merge(merged[key], val)
+        else:
+            merged[key] = val
+    return merged

--- a/src/genesis/autonomy/cli_policy.py
+++ b/src/genesis/autonomy/cli_policy.py
@@ -79,7 +79,10 @@ def load_autonomous_cli_policy(path: Path | None = None) -> AutonomousCliPolicy:
         return defaults
 
     try:
+        from genesis._config_overlay import merge_local_overlay
+
         raw = yaml.safe_load(cfg_path.read_text()) or {}
+        raw = merge_local_overlay(raw, cfg_path)
     except Exception:
         logger.warning(
             "Failed to load autonomous CLI policy from %s; using env defaults",

--- a/src/genesis/channels/tts_config.py
+++ b/src/genesis/channels/tts_config.py
@@ -85,7 +85,9 @@ class TTSConfigLoader:
             return self._cached
 
         try:
-            mtime = self._path.stat().st_mtime
+            from genesis._config_overlay import local_overlay_mtime
+
+            mtime = self._path.stat().st_mtime + local_overlay_mtime(self._path)
         except OSError:
             if self._cached is None:
                 self._cached = _config_from_env()
@@ -109,8 +111,11 @@ class TTSConfigLoader:
 
 def _load_from_yaml(path: Path) -> TTSConfig:
     """Parse YAML into TTSConfig, falling back to env vars for empty fields."""
+    from genesis._config_overlay import merge_local_overlay
+
     with open(path) as f:
         raw = yaml.safe_load(f) or {}
+    raw = merge_local_overlay(raw, path)
 
     el_raw = raw.get("elevenlabs", {}) or {}
     fish_raw = raw.get("fish_audio", {}) or {}

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1011,7 +1011,7 @@
               if (domain === "autonomous_cli_policy") {
                 this.fetchAutonomousCliPolicy();
               }
-              if (d.needs_restart) { this.settingsRestartMessage = "Settings saved. Changes take effect after server restart."; }
+              if (d.needs_restart) { this.settingsRestartMessage = "Settings saved. Restart Genesis server to apply."; }
             } else {
               const err = await resp.json().catch(() => ({}));
               alert("Save failed: " + (err.details ? err.details.join(", ") : err.error || "Unknown error"));
@@ -1213,7 +1213,7 @@
         _SETTING_CHOICES: {
           provider: ['elevenlabs', 'fish_audio', 'cartesia'],
           model: ['opus', 'sonnet', 'haiku'],
-          effort: ['low', 'medium', 'high'],
+          effort: ['low', 'medium', 'high', 'max'],
           approval_channel: ['telegram', 'email', 'dashboard'],
           default: ['telegram', 'email', 'dashboard'],
           blocker: ['telegram', 'email', 'dashboard'],
@@ -5243,7 +5243,7 @@
                   </div>
                   <div style="display:flex; gap:0.5rem; align-items:center;">
                     <template x-if="domain.needs_restart">
-                      <span style="font-size:0.65rem; background:#fff3cd; color:#856404; padding:2px 6px; border-radius:3px;" title="Changes to this setting require a genesis-server restart to take effect">requires restart</span>
+                      <span style="font-size:0.65rem; background:#fff3cd; color:#856404; padding:2px 6px; border-radius:3px;" title="Changes to this setting require a genesis-server restart to take effect">Restart Genesis server to apply</span>
                     </template>
                     <template x-if="$store.genesisDashboard.settingsEditing !== domain.name">
                       <button style="font-size:0.75rem; padding:2px 10px;" @click="$store.genesisDashboard.startEditSettings(domain.name)">Edit</button>
@@ -5401,7 +5401,7 @@
                           <span style="font-size:0.65rem; background:var(--color-bg-tertiary); padding:2px 6px; border-radius:3px;">locked</span>
                         </template>
                         <template x-if="domain.needs_restart && !domain.readonly">
-                          <span style="font-size:0.65rem; background:#fff3cd; color:#856404; padding:2px 6px; border-radius:3px;" title="Changes require a genesis-server restart to take effect">requires restart</span>
+                          <span style="font-size:0.65rem; background:#fff3cd; color:#856404; padding:2px 6px; border-radius:3px;" title="Changes require a genesis-server restart to take effect">Restart Genesis server to apply</span>
                         </template>
                         <template x-if="!domain.readonly && !domain.needs_restart">
                           <span style="font-size:0.65rem; background:#d4edda; color:#155724; padding:2px 6px; border-radius:3px;">hot-reload</span>
@@ -6538,11 +6538,12 @@
     <!-- ═══════════════════════════════════════════════════════════
          Panel: Knowledge Base [Tab: knowledge]
          ═══════════════════════════════════════════════════════════ -->
-    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'knowledge'">
+    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'knowledge'" style="overflow: visible;">
       <div class="panel-header">
         <span class="material-symbols-outlined">school</span>
         Knowledge Base
       </div>
+      <div style="padding: 1rem;">
 
       <!-- ── Upload Zone ─────────────────────────────────────── -->
       <div style="margin-bottom: 1.5rem;">
@@ -6645,22 +6646,22 @@
       </template>
 
       <!-- Stats Cards -->
-      <div class="stat-row" style="margin-bottom: 1.5rem;">
-        <div class="stat-card">
-          <div class="stat-value" x-text="$store.genesisDashboard.knowledgeStats?.total ?? '—'"></div>
-          <div class="stat-label">Total Units</div>
+      <div style="display: flex; gap: 1rem; margin-bottom: 1.5rem; flex-wrap: wrap;">
+        <div style="flex: 1; min-width: 100px; background: var(--color-bg-tertiary); border-radius: 6px; padding: .75rem; text-align: center;">
+          <div style="font-size: 1.4rem; font-weight: 700;" x-text="$store.genesisDashboard.knowledgeStats?.total ?? '—'"></div>
+          <div style="font-size: .75rem; color: var(--color-text-secondary);">Total Units</div>
         </div>
-        <div class="stat-card">
-          <div class="stat-value" x-text="$store.genesisDashboard.knowledgeStats?.qdrant_vectors ?? '—'"></div>
-          <div class="stat-label">Qdrant Vectors</div>
+        <div style="flex: 1; min-width: 100px; background: var(--color-bg-tertiary); border-radius: 6px; padding: .75rem; text-align: center;">
+          <div style="font-size: 1.4rem; font-weight: 700;" x-text="$store.genesisDashboard.knowledgeStats?.qdrant_vectors ?? '—'"></div>
+          <div style="font-size: .75rem; color: var(--color-text-secondary);">Qdrant Vectors</div>
         </div>
-        <div class="stat-card">
-          <div class="stat-value" x-text="Object.keys($store.genesisDashboard.knowledgeStats?.by_domain ?? {}).length"></div>
-          <div class="stat-label">Domains</div>
+        <div style="flex: 1; min-width: 100px; background: var(--color-bg-tertiary); border-radius: 6px; padding: .75rem; text-align: center;">
+          <div style="font-size: 1.4rem; font-weight: 700;" x-text="Object.keys($store.genesisDashboard.knowledgeStats?.by_domain ?? {}).length"></div>
+          <div style="font-size: .75rem; color: var(--color-text-secondary);">Domains</div>
         </div>
-        <div class="stat-card">
-          <div class="stat-value" x-text="$store.genesisDashboard.knowledgeStats?.by_tier?.curated ?? 0"></div>
-          <div class="stat-label">Curated</div>
+        <div style="flex: 1; min-width: 100px; background: var(--color-bg-tertiary); border-radius: 6px; padding: .75rem; text-align: center;">
+          <div style="font-size: 1.4rem; font-weight: 700;" x-text="$store.genesisDashboard.knowledgeStats?.by_tier?.curated ?? 0"></div>
+          <div style="font-size: .75rem; color: var(--color-text-secondary);">Curated</div>
         </div>
       </div>
 
@@ -6688,7 +6689,7 @@
       <div style="margin-bottom: 1rem; display: flex; gap: .5rem;">
         <input type="text" x-model="$store.genesisDashboard.knowledgeQuery" placeholder="Search knowledge base..."
                @keyup.enter="$store.genesisDashboard.searchKnowledge()"
-               style="flex: 1; padding: .5rem; background: var(--bg-tertiary); border: 1px solid var(--border); color: var(--text); border-radius: 4px;">
+               style="flex: 1; padding: .5rem; background: var(--color-bg-tertiary); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
         <button @click="$store.genesisDashboard.searchKnowledge()" class="btn-sm">Search</button>
       </div>
 
@@ -6696,38 +6697,48 @@
       <template x-if="$store.genesisDashboard.knowledgeSearchResults.length > 0">
         <div style="margin-bottom: 1.5rem;">
           <h4 style="margin-bottom: .5rem;">Search Results</h4>
-          <template x-for="item in $store.genesisDashboard.knowledgeSearchResults" :key="item.unit_id">
-            <div class="card" style="margin-bottom: .5rem; cursor: pointer;" @click="$store.genesisDashboard.viewKnowledgeDetail(item.unit_id)">
-              <strong x-text="item.concept || item.unit_id"></strong>
-              <div style="font-size: .85em; color: var(--text-dim);">
-                <span x-text="item.domain"></span> |
-                <span x-text="item.source_pipeline || 'unknown'"></span>
+          <div style="display: flex; flex-direction: column; gap: .5rem;">
+            <template x-for="item in $store.genesisDashboard.knowledgeSearchResults" :key="item.unit_id">
+              <div style="background: var(--color-bg-tertiary); border: 1px solid var(--color-border); border-radius: 6px; padding: .75rem; cursor: pointer;"
+                   @click="$store.genesisDashboard.viewKnowledgeDetail(item.unit_id)">
+                <div style="display: flex; justify-content: space-between; align-items: center;">
+                  <strong x-text="item.concept || item.unit_id" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 70%;"></strong>
+                  <span class="badge" x-text="item.domain"></span>
+                </div>
+                <div style="font-size: .85em; color: var(--color-text-secondary); margin-top: .25rem;">
+                  <span x-text="item.source_pipeline || 'unknown'"></span>
+                </div>
+                <div style="font-size: .85em; margin-top: .25rem; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;"
+                     x-text="(item.body || item.content || '').substring(0, 200)"></div>
               </div>
-              <div style="font-size: .85em; margin-top: .25rem;" x-text="(item.body || item.content || '').substring(0, 200) + '...'"></div>
-            </div>
-          </template>
+            </template>
+          </div>
         </div>
       </template>
 
       <!-- Recent Units -->
       <h4 style="margin-bottom: .5rem;">Recent Knowledge Units</h4>
       <template x-if="$store.genesisDashboard.knowledgeRecent.length === 0">
-        <p style="color: var(--text-dim);">No knowledge units ingested yet.</p>
+        <p style="color: var(--color-text-secondary);">No knowledge units ingested yet.</p>
       </template>
-      <template x-for="unit in $store.genesisDashboard.knowledgeRecent" :key="unit.id">
-        <div class="card" style="margin-bottom: .5rem; cursor: pointer;" @click="$store.genesisDashboard.viewKnowledgeDetail(unit.id)">
-          <div style="display: flex; justify-content: space-between; align-items: center;">
-            <strong x-text="unit.concept || unit.id"></strong>
-            <span class="badge" x-text="unit.source_pipeline || 'unknown'"></span>
+      <div style="display: flex; flex-direction: column; gap: .5rem;">
+        <template x-for="unit in $store.genesisDashboard.knowledgeRecent" :key="unit.id">
+          <div style="background: var(--color-bg-tertiary); border: 1px solid var(--color-border); border-radius: 6px; padding: .75rem; cursor: pointer;"
+               @click="$store.genesisDashboard.viewKnowledgeDetail(unit.id)">
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+              <strong x-text="unit.concept || unit.id" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 70%;"></strong>
+              <span class="badge" x-text="unit.source_pipeline || 'unknown'"></span>
+            </div>
+            <div style="font-size: .85em; color: var(--color-text-secondary);">
+              <span x-text="unit.domain"></span> |
+              <span x-text="unit.project_type"></span> |
+              <span x-text="unit.ingested_at?.substring(0, 10)"></span>
+            </div>
+            <div style="font-size: .85em; margin-top: .25rem; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;"
+                 x-text="(unit.body || '').substring(0, 200)"></div>
           </div>
-          <div style="font-size: .85em; color: var(--text-dim);">
-            <span x-text="unit.domain"></span> |
-            <span x-text="unit.project_type"></span> |
-            <span x-text="unit.ingested_at?.substring(0, 10)"></span>
-          </div>
-          <div style="font-size: .85em; margin-top: .25rem;" x-text="(unit.body || '').substring(0, 200) + '...'"></div>
-        </div>
-      </template>
+        </template>
+      </div>
 
       <!-- Detail Modal -->
       <template x-if="$store.genesisDashboard.knowledgeDetail">
@@ -6756,6 +6767,7 @@
           </div>
         </div>
       </template>
+      </div><!-- /panel-body padding -->
     </div>
 
     <!-- ═══════════════════════════════════════════════════════════

--- a/src/genesis/ego/config.py
+++ b/src/genesis/ego/config.py
@@ -33,8 +33,11 @@ def load_ego_config(path: Path | None = None) -> EgoConfig:
         return EgoConfig()
 
     try:
+        from genesis._config_overlay import merge_local_overlay
+
         with open(path) as f:
             raw = yaml.safe_load(f) or {}
+        raw = merge_local_overlay(raw, path)
     except Exception:
         logger.error("Failed to read ego config from %s", path, exc_info=True)
         return EgoConfig()

--- a/src/genesis/inbox/config.py
+++ b/src/genesis/inbox/config.py
@@ -12,9 +12,17 @@ from genesis.inbox.types import InboxConfig
 
 
 def load_inbox_config(path: str | Path) -> InboxConfig:
-    """Load inbox config from a YAML file path."""
-    text = Path(path).read_text()
-    return load_inbox_config_from_string(text)
+    """Load inbox config from a YAML file path.
+
+    Merges ``config/inbox_monitor.local.yaml`` overlay (written by the
+    dashboard settings panel) on top of the base file when present.
+    """
+    from genesis._config_overlay import merge_local_overlay
+
+    base_path = Path(path)
+    raw = yaml.safe_load(base_path.read_text()) or {}
+    raw = merge_local_overlay(raw, base_path)
+    return _parse(raw)
 
 
 def load_inbox_config_from_string(text: str) -> InboxConfig:

--- a/src/genesis/learning/signals/genesis_version.py
+++ b/src/genesis/learning/signals/genesis_version.py
@@ -42,8 +42,11 @@ def _load_updates_config() -> dict:
     """Load config/updates.yaml. Returns defaults if missing."""
     path = _CONFIG_DIR / "updates.yaml"
     if path.is_file():
+        from genesis._config_overlay import merge_local_overlay
+
         with open(path) as f:
-            return yaml.safe_load(f) or {}
+            raw = yaml.safe_load(f) or {}
+        return merge_local_overlay(raw, path)
     return {"check": {"enabled": True, "interval_hours": 6}}
 
 

--- a/src/genesis/outreach/config.py
+++ b/src/genesis/outreach/config.py
@@ -176,8 +176,11 @@ def load_outreach_config(path: Path | None = None) -> OutreachConfig:
     if not path.exists():
         logger.warning("Outreach config not found at %s — using UTC defaults", path)
         return _DEFAULTS
+    from genesis._config_overlay import merge_local_overlay
+
     with open(path) as f:
         raw = yaml.safe_load(f) or {}
+    raw = merge_local_overlay(raw, path)
     qh = raw.get("quiet_hours", {})
     return OutreachConfig(
         quiet_hours=QuietHours(

--- a/src/genesis/perception/confidence.py
+++ b/src/genesis/perception/confidence.py
@@ -68,8 +68,11 @@ def load_config(path: Path | None = None) -> ConfidenceGatesConfig:
         result = ConfidenceGatesConfig()
     else:
         try:
+            from genesis._config_overlay import merge_local_overlay
+
             with open(config_path) as f:
                 raw = yaml.safe_load(f) or {}
+            raw = merge_local_overlay(raw, config_path)
             result = ConfidenceGatesConfig(
                 observation_write=GateConfig(**raw.get("observation_write", {})),
                 memory_upsertion=GateConfig(**raw.get("memory_upsertion", {})),

--- a/src/genesis/perception/confidence.py
+++ b/src/genesis/perception/confidence.py
@@ -16,9 +16,11 @@ logger = logging.getLogger(__name__)
 
 _CONFIG_PATH = Path(__file__).resolve().parents[3] / "config" / "confidence_gates.yaml"
 
-# Module-level cache with TTL — avoids re-reading YAML on every gate call
+# Module-level cache — avoids re-reading YAML on every gate call.
+# Invalidates on TTL expiry OR file mtime change (whichever comes first).
 _cached_config: ConfidenceGatesConfig | None = None
 _cache_ts: float = 0.0
+_cached_mtime: float = 0.0
 _CACHE_TTL = 60.0  # seconds
 
 
@@ -55,15 +57,23 @@ def load_config(path: Path | None = None) -> ConfidenceGatesConfig:
     call (multiple gates fire per awareness tick). Cache is bypassed when an
     explicit path is provided (e.g., in tests).
     """
-    global _cached_config, _cache_ts  # noqa: PLW0603
+    global _cached_config, _cache_ts, _cached_mtime  # noqa: PLW0603
 
     import time
 
-    now = time.monotonic()
-    if path is None and _cached_config is not None and (now - _cache_ts) < _CACHE_TTL:
-        return _cached_config
+    from genesis._config_overlay import local_overlay_mtime
 
+    now = time.monotonic()
     config_path = path or _CONFIG_PATH
+
+    # Invalidate cache if file changed (mtime check) even within TTL window
+    if path is None and _cached_config is not None:
+        try:
+            cur_mtime = config_path.stat().st_mtime + local_overlay_mtime(config_path)
+        except OSError:
+            cur_mtime = 0.0
+        if cur_mtime == _cached_mtime and (now - _cache_ts) < _CACHE_TTL:
+            return _cached_config
     if not config_path.exists():
         result = ConfidenceGatesConfig()
     else:
@@ -85,6 +95,10 @@ def load_config(path: Path | None = None) -> ConfidenceGatesConfig:
     if path is None:
         _cached_config = result
         _cache_ts = now
+        try:
+            _cached_mtime = config_path.stat().st_mtime + local_overlay_mtime(config_path)
+        except OSError:
+            _cached_mtime = 0.0
     return result
 
 

--- a/src/genesis/resilience/config.py
+++ b/src/genesis/resilience/config.py
@@ -63,8 +63,11 @@ def load_config(path: Path | None = None) -> ResilienceConfig:
         logger.info("Resilience config not found at %s, using defaults", config_path)
         return ResilienceConfig()
 
+    from genesis._config_overlay import merge_local_overlay
+
     with open(config_path) as f:
         raw = yaml.safe_load(f) or {}
+    raw = merge_local_overlay(raw, config_path)
 
     return ResilienceConfig(
         flapping=FlappingConfig(**raw.get("flapping", {})),


### PR DESCRIPTION
## Summary

- **Settings panel was entirely cosmetic** — all 11 writable config domains wrote user changes to `.local.yaml` overlay files, but no subsystem config loader read them. Changes were silently lost on every restart.
- Added shared `_config_overlay.py` module with `merge_local_overlay()` and wired it into 8 config loaders: inbox_monitor, ego, outreach, resilience, autonomous_cli_policy, confidence_gates, tts, updates
- TTS and confidence_gates loaders also get `.local.yaml` mtime awareness for their hot-reload caches
- "requires restart" labels → "Restart Genesis server to apply" (3 places)
- Added missing "max" effort option to inbox effort dropdown
- Fixed Knowledge tab layout: stats cards in flex row, recent units stack vertically instead of overflowing off-screen, proper panel padding and text overflow handling

## Test plan

- [x] `ruff check .` — all changed files pass
- [x] `pytest` — 5627 passed, 0 failed
- [ ] Change inbox_monitor effort via dashboard → restart → verify new value loaded
- [ ] Screenshot Knowledge tab to verify visual layout fix
- [ ] Verify each config loader picks up `.local.yaml` overlay after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)