### PR TITLE
feat: surplus config wiring, Knowledge CSS fix, Sentinel DB-backed approvals

### DIFF
--- a/src/genesis/autonomy/autonomous_dispatch.py
+++ b/src/genesis/autonomy/autonomous_dispatch.py
@@ -41,19 +41,20 @@ def _approval_key(
     subsystem: str,
     policy_id: str,
     action_label: str,
-    invocation: CCInvocation,
+    invocation: CCInvocation | None = None,
     extra: dict[str, Any] | None = None,
 ) -> str:
-    payload = {
+    payload: dict[str, Any] = {
         "subsystem": subsystem,
         "policy_id": policy_id,
         "action_label": action_label,
-        "prompt": invocation.prompt,
-        "model": str(invocation.model),
-        "effort": str(invocation.effort),
-        "system_prompt": invocation.system_prompt or "",
-        "working_dir": invocation.working_dir or "",
     }
+    if invocation is not None:
+        payload["prompt"] = invocation.prompt
+        payload["model"] = str(invocation.model)
+        payload["effort"] = str(invocation.effort)
+        payload["system_prompt"] = invocation.system_prompt or ""
+        payload["working_dir"] = invocation.working_dir or ""
     if extra:
         payload["extra"] = extra
     raw = json.dumps(payload, sort_keys=True)
@@ -169,14 +170,19 @@ class AutonomousCliApprovalGate:
         subsystem: str,
         policy_id: str,
         action_label: str,
-        invocation: CCInvocation,
-        api_call_site_id: str | None,
-        api_error: str | None,
+        invocation: CCInvocation | None = None,
+        api_call_site_id: str | None = None,
+        api_error: str | None = None,
         extra_context: dict[str, Any] | None = None,
+        action_type: str = "autonomous_cli_fallback",
     ) -> tuple[str, str | None, str]:
         """Return ``(status, request_id, reason)`` for CLI fallback.
 
         Status is one of: ``approved``, ``pending``, ``rejected``.
+
+        For sentinel approvals, pass ``action_type="sentinel_dispatch"``
+        or ``"sentinel_action"`` and include sentinel-specific details
+        in ``extra_context``.
         """
         policy = self._policy()
         if not policy.manual_approval_required:
@@ -202,14 +208,14 @@ class AutonomousCliApprovalGate:
                 self._delivery_to_request[str(delivery_id)] = request_id
             if status == "approved":
                 logger.info(
-                    "Autonomous CLI fallback pre-approved for %s (%s)",
-                    policy_id, request_id,
+                    "%s pre-approved for %s (%s)",
+                    action_type, policy_id, request_id,
                 )
                 return ("approved", request_id, "existing approval found")
             if status == "rejected":
                 logger.info(
-                    "Autonomous CLI fallback previously rejected for %s (%s)",
-                    policy_id, request_id,
+                    "%s previously rejected for %s (%s)",
+                    action_type, policy_id, request_id,
                 )
                 return ("rejected", request_id, "existing rejection found")
 
@@ -226,17 +232,22 @@ class AutonomousCliApprovalGate:
                 return ("pending", request_id, "approval pending; reminder sent")
             return ("pending", request_id, "approval pending")
 
-        description = f"Approve autonomous Claude Code fallback for {action_label}?"
+        description = (
+            f"Approve {action_label}?"
+            if action_type.startswith("sentinel_")
+            else f"Approve autonomous Claude Code fallback for {action_label}?"
+        )
         context = {
             "kind": "autonomous_cli_fallback",
             "approval_key": approval_key,
             "subsystem": subsystem,
             "policy_id": policy_id,
             "action_label": action_label,
+            "action_type": action_type,
             "api_call_site_id": api_call_site_id,
             "api_error": api_error,
-            "model": str(invocation.model),
-            "effort": str(invocation.effort),
+            "model": str(invocation.model) if invocation else None,
+            "effort": str(invocation.effort) if invocation else None,
             "channel": policy.approval_channel,
             "delivery_id": None,
             "last_sent_at": None,
@@ -246,7 +257,7 @@ class AutonomousCliApprovalGate:
             context["extra"] = extra_context
 
         request_id = await self._approval_manager.request_approval(
-            action_type="autonomous_cli_fallback",
+            action_type=action_type,
             action_class="costly_reversible",
             description=description,
             context=_context_dump(context),
@@ -485,15 +496,16 @@ class AutonomousCliApprovalGate:
         )
 
     async def get_pending_count(self) -> int:
-        """Return the count of pending autonomous_cli_fallback approvals.
+        """Return the count of pending approvals (CLI fallback + sentinel).
 
         Used by ``_send_request`` to decide whether to include the
         "✅✅ Approve all N pending" batch button in the inline keyboard.
         """
+        _GATED_TYPES = {"autonomous_cli_fallback", "sentinel_dispatch", "sentinel_action"}
         pending = await self._approval_manager.get_pending()
         return sum(
             1 for req in pending
-            if req.get("action_type") == "autonomous_cli_fallback"
+            if req.get("action_type") in _GATED_TYPES
         )
 
     async def _maybe_resend(
@@ -504,7 +516,7 @@ class AutonomousCliApprovalGate:
         subsystem: str,
         policy_id: str,
         action_label: str,
-        invocation: CCInvocation,
+        invocation: CCInvocation | None,
         api_error: str | None,
     ) -> bool:
         next_reask_at = context.get("next_reask_at")
@@ -534,7 +546,7 @@ class AutonomousCliApprovalGate:
         request_id: str,
         context: dict[str, Any],
         action_label: str,
-        invocation: CCInvocation,
+        invocation: CCInvocation | None,
         api_error: str | None,
     ) -> None:
         """Deliver an approval notification via the outreach pipeline.
@@ -587,6 +599,8 @@ class AutonomousCliApprovalGate:
                 invocation=invocation,
                 api_error=api_error,
                 pending_count=pending_count,
+                action_type=context.get("action_type", "autonomous_cli_fallback"),
+                extra_context=context.get("extra"),
             )
 
             # Build inline keyboard — lazy import to keep the module
@@ -673,24 +687,68 @@ class AutonomousCliApprovalGate:
         *,
         request_id: str,
         action_label: str,
-        invocation: CCInvocation,
+        invocation: CCInvocation | None,
         api_error: str | None,
         pending_count: int = 1,
+        action_type: str = "autonomous_cli_fallback",
+        extra_context: dict[str, Any] | None = None,
     ) -> str:
-        lines = [
-            "<b>Approval Needed</b>",
-            "",
-            f"Approve autonomous Claude Code fallback for <b>{action_label}</b>?",
-            f"Request ID: <code>{request_id}</code>",
-            f"Model: <code>{invocation.model}</code>",
-            f"Effort: <code>{invocation.effort}</code>",
-        ]
-        if api_error:
-            lines.extend([
+        extra = extra_context or {}
+
+        # Sentinel-specific message formatting
+        if action_type == "sentinel_dispatch":
+            tier_label = extra.get("tier_label", "Unknown tier")
+            trigger_source = extra.get("trigger_source", "unknown")
+            trigger_reason = extra.get("trigger_reason", "")
+            lines = [
+                "<b>Sentinel Activation Request</b>",
                 "",
-                "<b>Why CLI fallback is being considered</b>",
-                api_error[:500],
-            ])
+                f"The Sentinel detected a <b>{tier_label}</b> fire alarm and "
+                f"wants to investigate and fix the issue.",
+                "",
+                f"<b>Trigger:</b> {trigger_source}",
+                f"<b>Reason:</b> {trigger_reason}",
+                f"Request ID: <code>{request_id}</code>",
+            ]
+        elif action_type == "sentinel_action":
+            diagnosis = extra.get("diagnosis", "")[:200]
+            actions = extra.get("proposed_actions", [])
+            action_lines = []
+            for i, action in enumerate(actions[:5], 1):
+                desc = action.get("description", "Unknown action")
+                cmd = action.get("command", "")
+                safe = "safe" if action.get("safe") else "potentially unsafe"
+                action_lines.append(f"{i}. {desc}\n   <code>{cmd}</code> ({safe})")
+            lines = [
+                "<b>Sentinel Action Approval</b>",
+                "",
+                f"<b>Diagnosis:</b> {diagnosis}",
+                "",
+                "<b>Proposed actions:</b>",
+                *action_lines,
+                "",
+                f"Request ID: <code>{request_id}</code>",
+            ]
+        else:
+            # Default: autonomous CLI fallback message
+            lines = [
+                "<b>Approval Needed</b>",
+                "",
+                f"Approve autonomous Claude Code fallback for <b>{action_label}</b>?",
+                f"Request ID: <code>{request_id}</code>",
+            ]
+            if invocation:
+                lines.extend([
+                    f"Model: <code>{invocation.model}</code>",
+                    f"Effort: <code>{invocation.effort}</code>",
+                ])
+            if api_error:
+                lines.extend([
+                    "",
+                    "<b>Why CLI fallback is being considered</b>",
+                    api_error[:500],
+                ])
+
         lines.extend([
             "",
             "Tap ✅ below, or type <code>approve</code> in the Approvals "

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -687,6 +687,11 @@ class AwarenessLoop:
                 name=f"approval-resume-{result.tick_id[:8]}",
                 subsystem=Subsystem.AWARENESS,
             )
+            tracked_task(
+                self._resume_approved_sentinel_dispatches(),
+                name=f"sentinel-resume-{result.tick_id[:8]}",
+                subsystem=Subsystem.AWARENESS,
+            )
 
     async def _dispatch_reflection(self, result: TickResult) -> None:
         depth = result.classified_depth
@@ -854,6 +859,53 @@ class AwarenessLoop:
             except Exception:
                 logger.error(
                     "Failed to resume %s reflection", depth_name, exc_info=True,
+                )
+
+    async def _resume_approved_sentinel_dispatches(self) -> None:
+        """Resume sentinel dispatches whose approvals were granted.
+
+        Mirrors _resume_approved_reflections: checks for approved-but-
+        unconsumed sentinel approvals and resumes the dispatcher.
+        """
+        if self._sentinel is None:
+            return
+
+        # Access the approval gate via the sentinel dispatcher
+        gate = getattr(self._sentinel, "_approval_gate", None)
+        if gate is None:
+            return
+
+        from genesis.sentinel.state import SentinelState as _SS
+
+        # Only resume if sentinel is actually waiting for an approval
+        state = self._sentinel.state
+        if state.state not in (_SS.AWAITING_DISPATCH_APPROVAL, _SS.AWAITING_ACTION_APPROVAL):
+            return
+
+        for policy_id in ("sentinel_dispatch", "sentinel_action"):
+            try:
+                approved = await gate.find_recently_approved(
+                    subsystem="sentinel",
+                    policy_id=policy_id,
+                )
+                if not approved:
+                    continue
+
+                # Atomic consume — prevents double-dispatch
+                consumed = await gate.mark_consumed(approved["id"])
+                if not consumed:
+                    continue
+
+                logger.info(
+                    "Resuming sentinel %s from approved request %s",
+                    policy_id, approved["id"][:8],
+                )
+                await self._sentinel.resume_from_approval(
+                    approved["id"], "approved",
+                )
+            except Exception:
+                logger.error(
+                    "Failed to resume sentinel %s", policy_id, exc_info=True,
                 )
 
     async def _retry_deferred_reflection(self, current_tick: TickResult) -> None:

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -3679,7 +3679,7 @@
                   <span style="width:3rem; text-align:right; font-weight:600;"
                         :style="`color: ${$store.genesisDashboard.health.infrastructure.container_memory.used_pct > 85 ? '#d9534f' : $store.genesisDashboard.health.infrastructure.container_memory.used_pct > 75 ? '#f0ad4e' : '#4caf50'}`"
                         x-text="$store.genesisDashboard.health.infrastructure.container_memory.used_pct.toFixed(0) + '%'"></span>
-                  <div style="flex:1; height:6px; background:var(--color-bg-tertiary); border-radius:3px; min-width:40px;">
+                  <div style="flex:1; height:6px; background:var(--color-background); border-radius:3px; min-width:40px;">
                     <div style="height:100%; border-radius:3px; transition:width 0.3s;"
                          :style="'width:' + $store.genesisDashboard.health.infrastructure.container_memory.used_pct + '%; background:' + ($store.genesisDashboard.health.infrastructure.container_memory.used_pct > 85 ? '#d9534f' : $store.genesisDashboard.health.infrastructure.container_memory.used_pct > 75 ? '#f0ad4e' : '#4caf50')"></div>
                   </div>
@@ -3700,7 +3700,7 @@
                     <span style="width:3rem; text-align:right; font-size:0.7rem; color:var(--color-text-secondary);">—</span>
                   </template>
                   <template x-if="$store.genesisDashboard.health.infrastructure.cpu.used_pct != null">
-                    <div style="flex:1; height:6px; background:var(--color-bg-tertiary); border-radius:3px; min-width:40px;">
+                    <div style="flex:1; height:6px; background:var(--color-background); border-radius:3px; min-width:40px;">
                       <div style="height:100%; border-radius:3px; transition:width 0.3s;"
                            :style="'width:' + $store.genesisDashboard.health.infrastructure.cpu.used_pct + '%; background:' + ($store.genesisDashboard.health.infrastructure.cpu.used_pct > 85 ? '#d9534f' : $store.genesisDashboard.health.infrastructure.cpu.used_pct > 60 ? '#f0ad4e' : '#4caf50')"></div>
                     </div>
@@ -3719,7 +3719,7 @@
                   <span style="width:3rem; text-align:right; font-weight:600;"
                         :style="`color: ${(100 - $store.genesisDashboard.health.infrastructure.disk.free_pct) > 90 ? '#d9534f' : (100 - $store.genesisDashboard.health.infrastructure.disk.free_pct) > 85 ? '#f0ad4e' : '#4caf50'}`"
                         x-text="(100 - $store.genesisDashboard.health.infrastructure.disk.free_pct).toFixed(0) + '%'"></span>
-                  <div style="flex:1; height:6px; background:var(--color-bg-tertiary); border-radius:3px; min-width:40px;">
+                  <div style="flex:1; height:6px; background:var(--color-background); border-radius:3px; min-width:40px;">
                     <div style="height:100%; border-radius:3px; transition:width 0.3s;"
                          :style="'width:' + (100 - $store.genesisDashboard.health.infrastructure.disk.free_pct) + '%; background:' + ((100 - $store.genesisDashboard.health.infrastructure.disk.free_pct) > 90 ? '#d9534f' : (100 - $store.genesisDashboard.health.infrastructure.disk.free_pct) > 85 ? '#f0ad4e' : '#4caf50')"></div>
                   </div>
@@ -5485,7 +5485,7 @@
                       </td>
                       <td style="padding:4px 8px;">
                         <template x-if="domain.readonly">
-                          <span style="font-size:0.65rem; background:var(--color-bg-tertiary); padding:2px 6px; border-radius:3px; cursor:pointer;"
+                          <span style="font-size:0.65rem; background:var(--color-background); padding:2px 6px; border-radius:3px; cursor:pointer;"
                                 @click.stop="$store.genesisDashboard.viewSettings(domain.name)"
                                 x-text="$store.genesisDashboard.settingsViewing === domain.name ? '\u25BC viewing' : '\u25B6 view'"></span>
                         </template>
@@ -6607,7 +6607,7 @@
                 <button @click="$store.genesisDashboard.deleteMemory($store.genesisDashboard.memoryDetail.memory_id)"
                         style="background:rgba(239,154,154,0.2); color:#ef9a9a; border:1px solid rgba(239,154,154,0.3); padding:0.25rem 0.5rem; border-radius:4px; cursor:pointer; font-size:0.75rem;">Delete</button>
                 <button @click="$store.genesisDashboard.memoryDetail = null"
-                        style="background:var(--color-bg-tertiary); color:var(--color-text-secondary); border:1px solid var(--color-border); padding:0.25rem 0.5rem; border-radius:4px; cursor:pointer; font-size:0.75rem;">Close</button>
+                        style="background:var(--color-background); color:var(--color-text-secondary); border:1px solid var(--color-border); padding:0.25rem 0.5rem; border-radius:4px; cursor:pointer; font-size:0.75rem;">Close</button>
               </div>
             </div>
             <div style="padding:0.75rem; border-top:1px solid var(--color-border);">
@@ -6664,30 +6664,30 @@
              @dragleave.prevent="$store.genesisDashboard.knowledgeUpload.dragging = false"
              @drop.prevent="$store.genesisDashboard.handleKnowledgeFileDrop($event)"
              @click="$refs.knowledgeFileInput.click()"
-             :style="`border: 2px dashed ${$store.genesisDashboard.knowledgeUpload.dragging ? 'var(--accent)' : 'var(--border)'}; border-radius: 8px; padding: 2rem; text-align: center; cursor: pointer; transition: border-color .2s; background: ${$store.genesisDashboard.knowledgeUpload.dragging ? 'rgba(99,102,241,.08)' : 'transparent'};`">
-          <span class="material-symbols-outlined" style="font-size: 2rem; color: var(--text-dim);">upload_file</span>
-          <div style="margin-top: .5rem; color: var(--text-dim);" x-text="$store.genesisDashboard.knowledgeUpload.uploading ? 'Uploading...' : 'Drop files here or click to browse'"></div>
-          <div style="font-size: .8em; color: var(--text-dim); margin-top: .25rem;">PDF, text, audio, video — up to 500 MB</div>
+             :style="`border: 2px dashed ${$store.genesisDashboard.knowledgeUpload.dragging ? 'var(--color-accent)' : 'var(--color-border)'}; border-radius: 8px; padding: 2rem; text-align: center; cursor: pointer; transition: border-color .2s; background: ${$store.genesisDashboard.knowledgeUpload.dragging ? 'rgba(99,102,241,.08)' : 'transparent'};`">
+          <span class="material-symbols-outlined" style="font-size: 2rem; color: var(--color-text-secondary);">upload_file</span>
+          <div style="margin-top: .5rem; color: var(--color-text-secondary);" x-text="$store.genesisDashboard.knowledgeUpload.uploading ? 'Uploading...' : 'Drop files here or click to browse'"></div>
+          <div style="font-size: .8em; color: var(--color-text-secondary); margin-top: .25rem;">PDF, text, audio, video — up to 500 MB</div>
           <input type="file" x-ref="knowledgeFileInput" style="display:none"
                  @change="$store.genesisDashboard.handleKnowledgeFileDrop($event)">
         </div>
 
         <!-- Confirmation Card -->
         <template x-if="$store.genesisDashboard.knowledgeUpload.confirm">
-          <div class="card" style="border: 1px solid var(--accent); padding: 1.25rem;">
+          <div class="card" style="border: 1px solid var(--color-accent); padding: 1.25rem;">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
               <strong>Store to Knowledge Base</strong>
               <span class="badge" x-text="$store.genesisDashboard.knowledgeUpload.file?.mime || 'unknown'"></span>
             </div>
-            <div style="margin-bottom: .75rem; color: var(--text-dim);">
+            <div style="margin-bottom: .75rem; color: var(--color-text-secondary);">
               <span x-text="$store.genesisDashboard.knowledgeUpload.file?.name"></span>
               (<span x-text="$store.genesisDashboard._formatFileSize($store.genesisDashboard.knowledgeUpload.file?.size)"></span>)
             </div>
             <div style="display: flex; gap: .5rem; margin-bottom: .75rem;">
               <div style="flex: 1;">
-                <label style="font-size: .8em; color: var(--text-dim);">Project Type *</label>
+                <label style="font-size: .8em; color: var(--color-text-secondary);">Project Type *</label>
                 <input type="text" list="kb-project-types" x-model="$store.genesisDashboard.knowledgeUpload.projectType"
-                       placeholder="e.g. professional" style="width: 100%; padding: .4rem; background: var(--bg-tertiary); border: 1px solid var(--border); color: var(--text); border-radius: 4px;">
+                       placeholder="e.g. professional" style="width: 100%; padding: .4rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
                 <datalist id="kb-project-types">
                   <template x-for="pt in $store.genesisDashboard.knowledgeTaxonomy.project_types" :key="pt">
                     <option :value="pt"></option>
@@ -6695,9 +6695,9 @@
                 </datalist>
               </div>
               <div style="flex: 1;">
-                <label style="font-size: .8em; color: var(--text-dim);">Domain</label>
+                <label style="font-size: .8em; color: var(--color-text-secondary);">Domain</label>
                 <input type="text" list="kb-domains" x-model="$store.genesisDashboard.knowledgeUpload.domain"
-                       placeholder="auto" style="width: 100%; padding: .4rem; background: var(--bg-tertiary); border: 1px solid var(--border); color: var(--text); border-radius: 4px;">
+                       placeholder="auto" style="width: 100%; padding: .4rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
                 <datalist id="kb-domains">
                   <template x-for="d in $store.genesisDashboard.knowledgeTaxonomy.domains" :key="d">
                     <option :value="d"></option>
@@ -6706,23 +6706,23 @@
               </div>
             </div>
             <div style="margin-bottom: .75rem;">
-              <label style="font-size: .8em; color: var(--text-dim);">Purpose (optional, comma-separated)</label>
+              <label style="font-size: .8em; color: var(--color-text-secondary);">Purpose (optional, comma-separated)</label>
               <input type="text" x-model="$store.genesisDashboard.knowledgeUpload.purpose"
-                     placeholder="e.g. resume-prep, cloud-eng" style="width: 100%; padding: .4rem; background: var(--bg-tertiary); border: 1px solid var(--border); color: var(--text); border-radius: 4px;">
+                     placeholder="e.g. resume-prep, cloud-eng" style="width: 100%; padding: .4rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
             </div>
             <template x-if="$store.genesisDashboard.knowledgeUpload.error">
-              <div style="color: var(--error); margin-bottom: .5rem; font-size: .9em;" x-text="$store.genesisDashboard.knowledgeUpload.error"></div>
+              <div style="color: var(--color-error-text); margin-bottom: .5rem; font-size: .9em;" x-text="$store.genesisDashboard.knowledgeUpload.error"></div>
             </template>
             <div style="display: flex; gap: .5rem; justify-content: flex-end;">
               <button class="btn-sm" style="opacity: .7;" @click="$store.genesisDashboard.cancelKnowledgeUpload()">Cancel</button>
-              <button class="btn-sm" style="background: var(--accent); color: #fff;" @click="$store.genesisDashboard.confirmKnowledgeIngest()">Store</button>
+              <button class="btn-sm" style="background: var(--color-accent); color: #fff;" @click="$store.genesisDashboard.confirmKnowledgeIngest()">Store</button>
             </div>
           </div>
         </template>
 
         <!-- Upload error outside confirmation -->
         <template x-if="$store.genesisDashboard.knowledgeUpload.error && !$store.genesisDashboard.knowledgeUpload.confirm">
-          <div style="color: var(--error); margin-top: .5rem; font-size: .9em;" x-text="$store.genesisDashboard.knowledgeUpload.error"></div>
+          <div style="color: var(--color-error-text); margin-top: .5rem; font-size: .9em;" x-text="$store.genesisDashboard.knowledgeUpload.error"></div>
         </template>
       </div>
 
@@ -6734,18 +6734,18 @@
             <div class="card" style="margin-bottom: .4rem; padding: .6rem .8rem; display: flex; justify-content: space-between; align-items: center;">
               <div>
                 <span x-text="upload.filename" style="font-weight: 500;"></span>
-                <span style="font-size: .8em; color: var(--text-dim); margin-left: .5rem;"
+                <span style="font-size: .8em; color: var(--color-text-secondary); margin-left: .5rem;"
                       x-text="$store.genesisDashboard._formatFileSize(upload.file_size)"></span>
               </div>
               <div style="display: flex; align-items: center; gap: .5rem;">
                 <template x-if="upload.status === 'processing'">
-                  <span class="badge" style="background: var(--warning); color: #000;">processing</span>
+                  <span class="badge" style="background: var(--color-warning-text); color: #000;">processing</span>
                 </template>
                 <template x-if="upload.status === 'completed'">
-                  <span class="badge" style="background: var(--success); color: #fff;" x-text="'completed (' + (JSON.parse(upload.unit_ids || '[]')).length + ' units)'"></span>
+                  <span class="badge" style="background: var(--color-primary); color: #fff;" x-text="'completed (' + (JSON.parse(upload.unit_ids || '[]')).length + ' units)'"></span>
                 </template>
                 <template x-if="upload.status === 'failed'">
-                  <span class="badge" style="background: var(--error); color: #fff;" :title="upload.error_message">failed</span>
+                  <span class="badge" style="background: var(--color-error-text); color: #fff;" :title="upload.error_message">failed</span>
                 </template>
                 <template x-if="upload.status === 'uploaded'">
                   <span class="badge">uploaded</span>
@@ -6758,19 +6758,19 @@
 
       <!-- Stats Cards -->
       <div style="display: flex; gap: 1rem; margin-bottom: 1.5rem; flex-wrap: wrap;">
-        <div style="flex: 1; min-width: 100px; background: var(--color-bg-tertiary); border-radius: 6px; padding: .75rem; text-align: center;">
+        <div style="flex: 1; min-width: 100px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
           <div style="font-size: 1.4rem; font-weight: 700;" x-text="$store.genesisDashboard.knowledgeStats?.total ?? '—'"></div>
           <div style="font-size: .75rem; color: var(--color-text-secondary);">Total Units</div>
         </div>
-        <div style="flex: 1; min-width: 100px; background: var(--color-bg-tertiary); border-radius: 6px; padding: .75rem; text-align: center;">
+        <div style="flex: 1; min-width: 100px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
           <div style="font-size: 1.4rem; font-weight: 700;" x-text="$store.genesisDashboard.knowledgeStats?.qdrant_vectors ?? '—'"></div>
           <div style="font-size: .75rem; color: var(--color-text-secondary);">Qdrant Vectors</div>
         </div>
-        <div style="flex: 1; min-width: 100px; background: var(--color-bg-tertiary); border-radius: 6px; padding: .75rem; text-align: center;">
+        <div style="flex: 1; min-width: 100px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
           <div style="font-size: 1.4rem; font-weight: 700;" x-text="Object.keys($store.genesisDashboard.knowledgeStats?.by_domain ?? {}).length"></div>
           <div style="font-size: .75rem; color: var(--color-text-secondary);">Domains</div>
         </div>
-        <div style="flex: 1; min-width: 100px; background: var(--color-bg-tertiary); border-radius: 6px; padding: .75rem; text-align: center;">
+        <div style="flex: 1; min-width: 100px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
           <div style="font-size: 1.4rem; font-weight: 700;" x-text="$store.genesisDashboard.knowledgeStats?.by_tier?.curated ?? 0"></div>
           <div style="font-size: .75rem; color: var(--color-text-secondary);">Curated</div>
         </div>
@@ -6800,7 +6800,7 @@
       <div style="margin-bottom: 1rem; display: flex; gap: .5rem;">
         <input type="text" x-model="$store.genesisDashboard.knowledgeQuery" placeholder="Search knowledge base..."
                @keyup.enter="$store.genesisDashboard.searchKnowledge()"
-               style="flex: 1; padding: .5rem; background: var(--color-bg-tertiary); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
+               style="flex: 1; padding: .5rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
         <button @click="$store.genesisDashboard.searchKnowledge()" class="btn-sm">Search</button>
       </div>
 
@@ -6810,7 +6810,7 @@
           <h4 style="margin-bottom: .5rem;">Search Results</h4>
           <div style="display: flex; flex-direction: column; gap: .5rem;">
             <template x-for="item in $store.genesisDashboard.knowledgeSearchResults" :key="item.unit_id">
-              <div :style="`background: var(--color-bg-tertiary); border: 1px solid var(--color-border); border-left: 3px solid ${$store.genesisDashboard._domainColor(item.domain)}; border-radius: 6px; padding: .75rem; cursor: pointer; transition: background .15s;`"
+              <div :style="`background: var(--color-background); border: 1px solid var(--color-border); border-left: 3px solid ${$store.genesisDashboard._domainColor(item.domain)}; border-radius: 6px; padding: .75rem; cursor: pointer; transition: background .15s;`"
                    @mouseenter="$el.style.background='rgba(255,255,255,0.06)'"
                    @mouseleave="$el.style.background=''"
                    @click="$store.genesisDashboard.viewKnowledgeDetail(item.unit_id)">
@@ -6837,7 +6837,7 @@
       </template>
       <div style="display: flex; flex-direction: column; gap: .5rem;">
         <template x-for="unit in $store.genesisDashboard.knowledgeRecent" :key="unit.id">
-          <div :style="`background: var(--color-bg-tertiary); border: 1px solid var(--color-border); border-left: 3px solid ${$store.genesisDashboard._domainColor(unit.domain)}; border-radius: 6px; padding: .75rem; cursor: pointer; transition: background .15s;`"
+          <div :style="`background: var(--color-background); border: 1px solid var(--color-border); border-left: 3px solid ${$store.genesisDashboard._domainColor(unit.domain)}; border-radius: 6px; padding: .75rem; cursor: pointer; transition: background .15s;`"
                @mouseenter="$el.style.background='rgba(255,255,255,0.06)'"
                @mouseleave="$el.style.background=''"
                @click="$store.genesisDashboard.viewKnowledgeDetail(unit.id)">
@@ -6867,9 +6867,9 @@
       <template x-if="$store.genesisDashboard.knowledgeDetail">
         <div style="position: fixed; inset: 0; background: rgba(0,0,0,.6); z-index: 100; display: flex; align-items: center; justify-content: center;"
              @click.self="$store.genesisDashboard.knowledgeDetail = null">
-          <div style="background: var(--bg-secondary); border: 1px solid var(--border); border-radius: 8px; padding: 1.5rem; max-width: 700px; width: 90%; max-height: 80vh; overflow-y: auto;">
+          <div style="background: var(--color-panel); border: 1px solid var(--color-border); border-radius: 8px; padding: 1.5rem; max-width: 700px; width: 90%; max-height: 80vh; overflow-y: auto;">
             <h3 x-text="$store.genesisDashboard.knowledgeDetail.concept"></h3>
-            <div style="margin: .75rem 0; font-size: .9em; color: var(--text-dim);">
+            <div style="margin: .75rem 0; font-size: .9em; color: var(--color-text-secondary);">
               <span x-text="'Domain: ' + $store.genesisDashboard.knowledgeDetail.domain"></span> |
               <span x-text="'Project: ' + $store.genesisDashboard.knowledgeDetail.project_type"></span> |
               <span x-text="'Pipeline: ' + ($store.genesisDashboard.knowledgeDetail.source_pipeline || 'unknown')"></span> |
@@ -6881,7 +6881,7 @@
             <template x-if="$store.genesisDashboard.knowledgeDetail.ingestion_source">
               <div style="margin-bottom: .5rem;"><strong>Source:</strong> <span x-text="$store.genesisDashboard.knowledgeDetail.ingestion_source"></span></div>
             </template>
-            <div style="white-space: pre-wrap; font-family: monospace; font-size: .85em; background: var(--bg-tertiary); padding: 1rem; border-radius: 4px; margin: .75rem 0;"
+            <div style="white-space: pre-wrap; font-family: monospace; font-size: .85em; background: var(--color-background); padding: 1rem; border-radius: 4px; margin: .75rem 0;"
                  x-text="$store.genesisDashboard.knowledgeDetail.body"></div>
             <div style="display: flex; gap: .5rem; justify-content: flex-end; margin-top: 1rem;">
               <button class="btn-sm btn-danger" @click="$store.genesisDashboard.deleteKnowledge($store.genesisDashboard.knowledgeDetail.id)">Delete</button>

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -176,7 +176,7 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         description="Surplus compute scheduler (dispatch intervals, job frequencies, task defaults)",
         config_filename="surplus.yaml",
         readonly=False,
-        needs_restart=False,
+        needs_restart=True,
     ),
 }
 

--- a/src/genesis/runtime/init/sentinel.py
+++ b/src/genesis/runtime/init/sentinel.py
@@ -32,6 +32,7 @@ async def init_sentinel(rt) -> None:
         event_bus=getattr(rt, "_event_bus", None),
         health_data=getattr(rt, "_health_data", None),
         outreach_pipeline=getattr(rt, "_outreach_pipeline", None),
+        approval_gate=getattr(rt, "_autonomous_cli_approval_gate", None),
     )
     rt._sentinel = sentinel
 

--- a/src/genesis/runtime/init/surplus.py
+++ b/src/genesis/runtime/init/surplus.py
@@ -10,6 +10,28 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("genesis.runtime")
 
+_CONFIG_DIR = __import__("pathlib").Path(__file__).resolve().parents[3] / "config"
+
+
+def _load_surplus_config() -> dict:
+    """Load surplus config from YAML with .local.yaml overlay."""
+    from pathlib import Path
+
+    import yaml
+
+    from genesis._config_overlay import merge_local_overlay
+
+    config_path = _CONFIG_DIR / "surplus.yaml"
+    if not config_path.exists():
+        logger.info("Surplus config not found at %s — using defaults", config_path)
+        return {}
+    try:
+        raw = yaml.safe_load(Path(config_path).read_text()) or {}
+        return merge_local_overlay(raw, config_path)
+    except Exception:
+        logger.error("Failed to read surplus config from %s", config_path, exc_info=True)
+        return {}
+
 
 async def _degraded(rt: GenesisRuntime, component: str, error: str = "failed to wire") -> None:
     """Record a surplus init degradation."""
@@ -28,6 +50,11 @@ async def init(rt: GenesisRuntime) -> None:
         from genesis.surplus.queue import SurplusQueue
         from genesis.surplus.scheduler import SurplusScheduler
 
+        # Load surplus config (base + .local.yaml overlay from dashboard)
+        cfg = _load_surplus_config()
+        dispatch = cfg.get("dispatch", {})
+        jobs = cfg.get("jobs", {})
+
         queue = SurplusQueue(db=rt._db)
         rt._surplus_queue = queue
         idle_detector = IdleDetector()
@@ -41,6 +68,16 @@ async def init(rt: GenesisRuntime) -> None:
             compute_availability=compute,
             event_bus=rt._event_bus,
             enable_code_audits=False,
+            dispatch_interval_minutes=int(dispatch.get("interval_minutes", 5)),
+            brainstorm_check_hours=int(jobs.get("brainstorm_check_hours", 12)),
+            task_expiry_hours=int(dispatch.get("task_expiry_hours", 72)),
+            code_audit_hours=int(jobs.get("code_audit_hours", 12)),
+            code_index_hours=int(jobs.get("code_index_hours", 4)),
+            infra_monitor_hours=int(jobs.get("infra_monitor_hours", 2)),
+            recon_gather_hours=int(jobs.get("recon_gather_hours", 84)),
+            maintenance_hours=int(jobs.get("maintenance_hours", 6)),
+            follow_up_dispatch_minutes=int(jobs.get("follow_up_dispatch_minutes", 5)),
+            memory_extraction_hours=int(jobs.get("memory_extraction_hours", 2)),
         )
 
         try:
@@ -189,14 +226,15 @@ async def init(rt: GenesisRuntime) -> None:
                 from apscheduler.triggers.interval import (
                     IntervalTrigger as _ExtIvlTrig,
                 )
+                extraction_hours = rt._surplus_scheduler._memory_extraction_hours
                 rt._surplus_scheduler._scheduler.add_job(
                     rt._surplus_scheduler.run_memory_extraction,
-                    _ExtIvlTrig(hours=2),
+                    _ExtIvlTrig(hours=extraction_hours),
                     id="memory_extraction",
                     max_instances=1,
                     misfire_grace_time=300,
                 )
-                logger.info("Memory extraction job wired (2h interval)")
+                logger.info("Memory extraction job wired (%dh interval)", extraction_hours)
         except (ImportError, AttributeError):
             logger.error("Failed to wire memory extraction", exc_info=True)
             await _degraded(rt, "memory_extraction")

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -533,6 +533,11 @@ class SentinelDispatcher:
 
         if status == "rejected":
             self._state.clear_pending()
+            self._state.transition(
+                SentinelState.ESCALATED,
+                reason="user rejected proposed actions",
+            )
+            save_state(self._state)
             append_log({"event": "actions_rejected", "request_id": request_id})
             return SentinelResult(
                 dispatched=True,
@@ -660,28 +665,29 @@ class SentinelDispatcher:
 
         Called by the awareness loop when it finds an approved sentinel
         approval row. Returns None if the state doesn't match (stale resume).
+        All state reads and mutations are lock-protected.
         """
         if status == "rejected":
             return await self.handle_approval_resolution(request_id, "rejected")
 
-        policy_id = self._state.pending_policy_id
-        if not policy_id or self._state.pending_request_id != request_id:
-            logger.warning(
-                "Sentinel resume: request_id %s doesn't match pending %s — skipping",
-                request_id, self._state.pending_request_id,
-            )
-            return None
-
-        pattern = self._state.pending_pattern
-        request = _deserialize_request(self._state.pending_request_json)
-        if request is None:
-            logger.error("Sentinel resume: failed to deserialize pending request")
-            self._state.clear_pending()
-            self._state.transition(SentinelState.HEALTHY, reason="resume failed: bad pending data")
-            save_state(self._state)
-            return None
-
         async with self._lock:
+            policy_id = self._state.pending_policy_id
+            if not policy_id or self._state.pending_request_id != request_id:
+                logger.warning(
+                    "Sentinel resume: request_id %s doesn't match pending %s — skipping",
+                    request_id, self._state.pending_request_id,
+                )
+                return None
+
+            pattern = self._state.pending_pattern
+            request = _deserialize_request(self._state.pending_request_json)
+            if request is None:
+                logger.error("Sentinel resume: failed to deserialize pending request")
+                self._state.clear_pending()
+                self._state.transition(SentinelState.HEALTHY, reason="resume failed: bad pending data")
+                save_state(self._state)
+                return None
+
             if policy_id == "sentinel_dispatch":
                 logger.info("Resuming sentinel dispatch after approval %s", request_id)
                 return await self._phase2_cc_and_actions(request, pattern=pattern)
@@ -712,29 +718,31 @@ class SentinelDispatcher:
         """Handle a rejected or cancelled approval.
 
         Called by the awareness loop or alarm-clearing cancellation.
+        Lock-protected to prevent races with check_fire_alarms.
         """
-        if self._state.pending_request_id != request_id:
-            return None
+        async with self._lock:
+            if self._state.pending_request_id != request_id:
+                return None
 
-        pattern = self._state.pending_pattern
-        policy_id = self._state.pending_policy_id
+            pattern = self._state.pending_pattern
+            policy_id = self._state.pending_policy_id
 
-        if status == "rejected":
-            if pattern:
-                expiry = (datetime.now(UTC) + timedelta(hours=24)).isoformat()
-                self._state.rejected_patterns[pattern] = expiry
-            self._state.clear_pending()
-            self._state.transition(SentinelState.HEALTHY, reason=f"{policy_id} rejected by user")
-            save_state(self._state)
-            append_log({"event": f"{policy_id}_rejected", "request_id": request_id})
-            return SentinelResult(dispatched=False, reason=f"{policy_id} rejected")
+            if status == "rejected":
+                if pattern:
+                    expiry = (datetime.now(UTC) + timedelta(hours=24)).isoformat()
+                    self._state.rejected_patterns[pattern] = expiry
+                self._state.clear_pending()
+                self._state.transition(SentinelState.HEALTHY, reason=f"{policy_id} rejected by user")
+                save_state(self._state)
+                append_log({"event": f"{policy_id}_rejected", "request_id": request_id})
+                return SentinelResult(dispatched=False, reason=f"{policy_id} rejected")
 
-        if status == "cancelled":
-            self._state.clear_pending()
-            self._state.transition(SentinelState.HEALTHY, reason=f"{policy_id} cancelled (alarm cleared)")
-            save_state(self._state)
-            append_log({"event": f"{policy_id}_cancelled", "request_id": request_id})
-            return SentinelResult(dispatched=False, reason=f"{policy_id} cancelled: alarm cleared")
+            if status == "cancelled":
+                self._state.clear_pending()
+                self._state.transition(SentinelState.HEALTHY, reason=f"{policy_id} cancelled (alarm cleared)")
+                save_state(self._state)
+                append_log({"event": f"{policy_id}_cancelled", "request_id": request_id})
+                return SentinelResult(dispatched=False, reason=f"{policy_id} cancelled: alarm cleared")
 
         return None
 
@@ -1259,9 +1267,10 @@ class SentinelDispatcher:
                 except Exception:
                     logger.warning("Failed to cancel sentinel approval %s", request_id, exc_info=True)
             logger.info("Alarms cleared — cancelling pending sentinel approval %s", request_id)
-            self._state.clear_pending()
-            self._state.transition(SentinelState.HEALTHY, reason="alarms cleared while awaiting approval")
-            save_state(self._state)
+            async with self._lock:
+                self._state.clear_pending()
+                self._state.transition(SentinelState.HEALTHY, reason="alarms cleared while awaiting approval")
+                save_state(self._state)
             return None
 
         if not alarms:

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -61,6 +61,70 @@ _ALARM_RING_SIZE = 3
 _ALARM_CONFIRMATION_COUNT = 2
 
 
+def _serialize_request(request: SentinelRequest) -> str:
+    """Serialize a SentinelRequest to JSON for state persistence."""
+    import json
+    return json.dumps({
+        "trigger_source": request.trigger_source,
+        "trigger_reason": request.trigger_reason,
+        "tier": request.tier,
+        "alarms": [asdict(a) for a in request.alarms],
+        "context": request.context,
+    })
+
+
+def _deserialize_request(raw: str) -> SentinelRequest | None:
+    """Deserialize a SentinelRequest from JSON. Returns None on failure."""
+    if not raw:
+        return None
+    try:
+        import json
+        data = json.loads(raw)
+        alarms = [FireAlarm(**a) for a in data.get("alarms", [])]
+        return SentinelRequest(
+            trigger_source=data["trigger_source"],
+            trigger_reason=data["trigger_reason"],
+            tier=data.get("tier"),
+            alarms=alarms,
+            context=data.get("context", {}),
+        )
+    except Exception:
+        logger.error("Failed to deserialize SentinelRequest", exc_info=True)
+        return None
+
+
+def _serialize_result(result: SentinelResult) -> str:
+    """Serialize a SentinelResult to JSON for state persistence."""
+    import json
+    return json.dumps({
+        "dispatched": result.dispatched,
+        "session_id": result.session_id,
+        "diagnosis": result.diagnosis,
+        "actions_taken": result.actions_taken,
+        "proposed_actions": result.proposed_actions,
+        "resolved": result.resolved,
+        "observation_id": result.observation_id,
+        "reason": result.reason,
+        "duration_s": result.duration_s,
+    })
+
+
+def _deserialize_result(raw: str) -> SentinelResult | None:
+    """Deserialize a SentinelResult from JSON. Returns None on failure."""
+    if not raw:
+        return None
+    try:
+        import json
+        data = json.loads(raw)
+        return SentinelResult(**{
+            k: v for k, v in data.items()
+            if k in SentinelResult.__dataclass_fields__
+        })
+    except Exception:
+        logger.error("Failed to deserialize SentinelResult", exc_info=True)
+        return None
+
+
 @dataclass(frozen=True)
 class SentinelRequest:
     """Request to wake the Sentinel."""
@@ -120,6 +184,7 @@ class SentinelDispatcher:
         event_bus: GenesisEventBus | None = None,
         health_data: HealthDataService | None = None,
         outreach_pipeline=None,
+        approval_gate=None,
     ) -> None:
         self._session_manager = session_manager
         self._invoker = invoker
@@ -128,6 +193,7 @@ class SentinelDispatcher:
         self._event_bus = event_bus
         self._health_data = health_data
         self._outreach_pipeline = outreach_pipeline
+        self._approval_gate = approval_gate  # AutonomousCliApprovalGate or None
         self._lock = asyncio.Lock()
         self._active_session_id: str | None = None
         self._state = load_state()
@@ -148,7 +214,7 @@ class SentinelDispatcher:
         # dispatching. Prevents single-tick flaps from waking the Sentinel.
         self._recent_alarm_sets: deque[set[str]] = deque(maxlen=_ALARM_RING_SIZE)
 
-        # Load dispatch approval policy
+        # Load dispatch approval policy (legacy path, used when approval_gate is None)
         try:
             from genesis.autonomy.cli_policy import load_autonomous_cli_policy
             policy = load_autonomous_cli_policy()
@@ -157,6 +223,21 @@ class SentinelDispatcher:
             )
         except Exception:
             self._require_approval = True
+
+        # On startup, clean up stale AWAITING_* states if no matching
+        # approval row exists in the DB. This handles restarts where the
+        # approval was resolved while the process was down.
+        if self._state.state in (
+            SentinelState.AWAITING_DISPATCH_APPROVAL,
+            SentinelState.AWAITING_ACTION_APPROVAL,
+        ) and not self._state.pending_request_id:
+            logger.info(
+                "Clearing stale %s state (no pending request id)",
+                self._state.current_state,
+            )
+            self._state.clear_pending()
+            self._state.transition(SentinelState.HEALTHY, reason="stale pending cleared on startup")
+            save_state(self._state)
 
     async def dispatch(self, request: SentinelRequest) -> SentinelResult:
         """Main entry point. Evaluate request, manage state, dispatch CC if needed.
@@ -188,7 +269,17 @@ class SentinelDispatcher:
                 reason="In bootstrap grace period — skipping",
             )
 
-        # Gate 2: Concurrent limit
+        # Gate 2: Awaiting approval (non-blocking gate)
+        if self._state.state in (
+            SentinelState.AWAITING_DISPATCH_APPROVAL,
+            SentinelState.AWAITING_ACTION_APPROVAL,
+        ):
+            return SentinelResult(
+                dispatched=False,
+                reason=f"Sentinel awaiting approval ({self._state.pending_policy_id})",
+            )
+
+        # Gate 3: Concurrent limit
         if self._active_session_id is not None:
             return SentinelResult(
                 dispatched=False,
@@ -225,15 +316,75 @@ class SentinelDispatcher:
     async def _execute_dispatch(
         self, request: SentinelRequest, *, pattern: str = "",
     ) -> SentinelResult:
-        """Execute the actual CC dispatch with state management."""
+        """Execute the actual CC dispatch with state management.
+
+        Three-phase flow when approval_gate is present:
+          Phase 1: ensure_approval(sentinel_dispatch) → park if pending
+          Phase 2: CC session → get diagnosis + proposed actions
+          Phase 3: ensure_approval(sentinel_action) → park if pending, then execute
+        Legacy path (approval_gate is None): blocking Telegram approval.
+        """
         start = time.monotonic()
 
-        # Dispatch approval — ask user via Telegram before activating CC
-        if self._require_approval and self._outreach_pipeline:
+        # ── Phase 1: Dispatch approval ──────────────────────────────
+        if self._approval_gate is not None:
+            try:
+                status, request_id, reason = await self._approval_gate.ensure_approval(
+                    subsystem="sentinel",
+                    policy_id="sentinel_dispatch",
+                    action_label=f"Sentinel dispatch: {request.trigger_reason[:60]}",
+                    action_type="sentinel_dispatch",
+                    extra_context={
+                        "tier_label": f"Tier {request.tier}" if request.tier else "Unknown tier",
+                        "trigger_source": request.trigger_source,
+                        "trigger_reason": request.trigger_reason,
+                        "alarm_count": len(request.alarms),
+                    },
+                )
+                if status == "pending":
+                    # Park: save context and wait for awareness loop resume
+                    self._state.pending_request_id = request_id or ""
+                    self._state.pending_policy_id = "sentinel_dispatch"
+                    self._state.pending_pattern = pattern
+                    self._state.pending_request_json = _serialize_request(request)
+                    self._state.transition(
+                        SentinelState.AWAITING_DISPATCH_APPROVAL,
+                        reason=f"dispatch approval pending ({request_id})",
+                    )
+                    save_state(self._state)
+                    append_log({"event": "dispatch_approval_pending", "request_id": request_id})
+                    return SentinelResult(
+                        dispatched=False,
+                        reason=f"Dispatch approval pending: {reason}",
+                        duration_s=time.monotonic() - start,
+                    )
+                if status == "rejected":
+                    expiry = (datetime.now(UTC) + timedelta(hours=24)).isoformat()
+                    self._state.rejected_patterns[pattern] = expiry
+                    self._state.clear_pending()
+                    self._state.transition(SentinelState.HEALTHY, reason="dispatch rejected via approval gate")
+                    save_state(self._state)
+                    append_log({"event": "dispatch_rejected", "request_id": request_id})
+                    return SentinelResult(
+                        dispatched=False,
+                        reason="User rejected Sentinel dispatch",
+                        duration_s=time.monotonic() - start,
+                    )
+                # status == "approved" — continue to Phase 2
+                logger.info("Sentinel dispatch approved (%s)", request_id)
+                append_log({"event": "dispatch_approved", "request_id": request_id})
+            except Exception:
+                logger.error("Sentinel dispatch approval failed", exc_info=True)
+                return SentinelResult(
+                    dispatched=False,
+                    reason="Dispatch approval mechanism failed",
+                    duration_s=time.monotonic() - start,
+                )
+        elif self._require_approval and self._outreach_pipeline:
+            # Legacy blocking path
             try:
                 approved = await self._request_dispatch_approval(request)
                 if not approved:
-                    # Record rejection with 24h suppression window
                     expiry = (datetime.now(UTC) + timedelta(hours=24)).isoformat()
                     self._state.rejected_patterns[pattern] = expiry
                     self._state.transition(SentinelState.HEALTHY, reason="dispatch rejected by user")
@@ -251,12 +402,27 @@ class SentinelDispatcher:
                     duration_s=time.monotonic() - start,
                 )
 
+        # ── Phase 2: CC session ─────────────────────────────────────
+        return await self._phase2_cc_and_actions(request, pattern=pattern, start=start)
+
+    async def _phase2_cc_and_actions(
+        self, request: SentinelRequest, *, pattern: str = "", start: float = 0.0,
+    ) -> SentinelResult:
+        """Phase 2-3: Run CC session, then request action approval and execute.
+
+        Split from _execute_dispatch so the awareness loop can resume here
+        after a dispatch approval is granted.
+        """
+        if start == 0.0:
+            start = time.monotonic()
+
         # Transition to INVESTIGATING
         self._state.transition(
             SentinelState.INVESTIGATING,
             reason=f"{request.trigger_source}: {request.trigger_reason}",
         )
         self._state.last_trigger_source = request.trigger_source
+        self._state.clear_pending()
         save_state(self._state)
 
         # Log the dispatch
@@ -290,16 +456,139 @@ class SentinelDispatcher:
                 reason=f"CC dispatch error: {exc}",
             )
 
-        # If CC proposed actions, send them to user for approval and execute
+        # ── Phase 3: Action approval + execution ───────────────────
         if result.dispatched and result.proposed_actions:
-            try:
-                executed = await self._approve_and_execute_actions(result)
-                if executed:
-                    result.resolved = True
-                    result.actions_taken = [a["command"] for a in executed]
-            except Exception:
-                logger.error("Sentinel action approval/execution failed", exc_info=True)
+            if self._approval_gate is not None:
+                try:
+                    action_result = await self._gated_action_approval(result, request, pattern)
+                    if action_result is not None:
+                        # Pending or rejected — return the phase-3 result
+                        action_result.duration_s = time.monotonic() - start
+                        return action_result
+                    # None means approved — continue to execution below
+                except Exception:
+                    logger.error("Sentinel action approval/execution failed", exc_info=True)
+            elif self._outreach_pipeline:
+                # Legacy blocking path
+                try:
+                    executed = await self._approve_and_execute_actions(result)
+                    if executed:
+                        result.resolved = True
+                        result.actions_taken = [a["command"] for a in executed]
+                except Exception:
+                    logger.error("Sentinel action approval/execution failed", exc_info=True)
 
+            # Execute approved actions (gated path)
+            if self._approval_gate is not None and result.proposed_actions and not result.resolved:
+                try:
+                    executed = await self._execute_approved_actions(result.proposed_actions)
+                    if executed:
+                        result.resolved = True
+                        result.actions_taken = [a["command"] for a in executed]
+                except Exception:
+                    logger.error("Sentinel action execution failed", exc_info=True)
+
+        return await self._finalize_dispatch(request, result, pattern=pattern, start=start)
+
+    async def _gated_action_approval(
+        self, result: SentinelResult, request: SentinelRequest, pattern: str,
+    ) -> SentinelResult | None:
+        """Phase 3 approval gate for proposed actions.
+
+        Returns SentinelResult if pending/rejected (caller should return it).
+        Returns None if approved (caller should proceed to execute actions).
+        """
+        status, request_id, reason = await self._approval_gate.ensure_approval(
+            subsystem="sentinel",
+            policy_id="sentinel_action",
+            action_label=f"Sentinel actions: {result.diagnosis[:40]}",
+            action_type="sentinel_action",
+            extra_context={
+                "diagnosis": result.diagnosis,
+                "proposed_actions": result.proposed_actions,
+                "session_id": result.session_id,
+            },
+        )
+
+        if status == "pending":
+            # Park: save CC result for resume
+            self._state.pending_request_id = request_id or ""
+            self._state.pending_policy_id = "sentinel_action"
+            self._state.pending_pattern = pattern
+            self._state.pending_request_json = _serialize_request(request)
+            self._state.pending_cc_result_json = _serialize_result(result)
+            self._state.transition(
+                SentinelState.AWAITING_ACTION_APPROVAL,
+                reason=f"action approval pending ({request_id})",
+            )
+            save_state(self._state)
+            append_log({"event": "action_approval_pending", "request_id": request_id})
+            return SentinelResult(
+                dispatched=True,
+                session_id=result.session_id,
+                diagnosis=result.diagnosis,
+                proposed_actions=result.proposed_actions,
+                reason=f"Action approval pending: {reason}",
+            )
+
+        if status == "rejected":
+            self._state.clear_pending()
+            append_log({"event": "actions_rejected", "request_id": request_id})
+            return SentinelResult(
+                dispatched=True,
+                session_id=result.session_id,
+                diagnosis=result.diagnosis,
+                reason="User rejected Sentinel actions",
+            )
+
+        # Approved — return None so caller executes actions
+        logger.info("Sentinel actions approved (%s)", request_id)
+        append_log({"event": "actions_approved", "request_id": request_id})
+        return None
+
+    async def _execute_approved_actions(self, proposed_actions: list[dict]) -> list[dict]:
+        """Execute a list of approved shell commands."""
+        executed = []
+        for action in proposed_actions:
+            cmd = action.get("command", "")
+            if not cmd:
+                continue
+            try:
+                logger.info("Sentinel executing: %s", cmd)
+                proc = await asyncio.create_subprocess_shell(
+                    cmd,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(), timeout=60.0,
+                )
+                success = proc.returncode == 0
+                action["success"] = success
+                action["stdout"] = stdout.decode("utf-8", errors="replace")[:500]
+                action["stderr"] = stderr.decode("utf-8", errors="replace")[:500]
+                executed.append(action)
+                if success:
+                    logger.info("Sentinel action succeeded: %s", cmd)
+                else:
+                    logger.error(
+                        "Sentinel action failed (rc=%d): %s — %s",
+                        proc.returncode, cmd, stderr.decode("utf-8", errors="replace")[:200],
+                    )
+            except TimeoutError:
+                logger.error("Sentinel action timed out: %s", cmd)
+                action["success"] = False
+                action["stderr"] = "Timed out after 60s"
+                executed.append(action)
+            except OSError as exc:
+                logger.error("Sentinel action OS error: %s — %s", cmd, exc)
+        return executed
+
+    async def _finalize_dispatch(
+        self, request: SentinelRequest, result: SentinelResult,
+        *, pattern: str = "", start: float = 0.0,
+    ) -> SentinelResult:
+        """Common finalization: state transitions, logging, observation creation."""
         duration = time.monotonic() - start
         result.duration_s = duration
 
@@ -320,6 +609,7 @@ class SentinelDispatcher:
         else:
             self._state.transition(SentinelState.ESCALATED, reason=result.reason or "dispatch failed")
 
+        self._state.clear_pending()
         self._state.record_cc_dispatch()
         save_state(self._state)
         write_state_for_guardian(asdict(self._state))
@@ -364,6 +654,89 @@ class SentinelDispatcher:
             )
 
         return result
+
+    async def resume_from_approval(self, request_id: str, status: str) -> SentinelResult | None:
+        """Resume a parked dispatch after the user grants approval.
+
+        Called by the awareness loop when it finds an approved sentinel
+        approval row. Returns None if the state doesn't match (stale resume).
+        """
+        if status == "rejected":
+            return await self.handle_approval_resolution(request_id, "rejected")
+
+        policy_id = self._state.pending_policy_id
+        if not policy_id or self._state.pending_request_id != request_id:
+            logger.warning(
+                "Sentinel resume: request_id %s doesn't match pending %s — skipping",
+                request_id, self._state.pending_request_id,
+            )
+            return None
+
+        pattern = self._state.pending_pattern
+        request = _deserialize_request(self._state.pending_request_json)
+        if request is None:
+            logger.error("Sentinel resume: failed to deserialize pending request")
+            self._state.clear_pending()
+            self._state.transition(SentinelState.HEALTHY, reason="resume failed: bad pending data")
+            save_state(self._state)
+            return None
+
+        async with self._lock:
+            if policy_id == "sentinel_dispatch":
+                logger.info("Resuming sentinel dispatch after approval %s", request_id)
+                return await self._phase2_cc_and_actions(request, pattern=pattern)
+            if policy_id == "sentinel_action":
+                logger.info("Resuming sentinel actions after approval %s", request_id)
+                cc_result = _deserialize_result(self._state.pending_cc_result_json)
+                if cc_result is None:
+                    logger.error("Sentinel resume: failed to deserialize CC result")
+                    self._state.clear_pending()
+                    self._state.transition(SentinelState.HEALTHY, reason="resume failed: bad CC result")
+                    save_state(self._state)
+                    return None
+                # Execute the approved actions
+                try:
+                    executed = await self._execute_approved_actions(cc_result.proposed_actions)
+                    if executed:
+                        cc_result.resolved = True
+                        cc_result.actions_taken = [a["command"] for a in executed]
+                except Exception:
+                    logger.error("Sentinel action execution failed on resume", exc_info=True)
+                return await self._finalize_dispatch(request, cc_result, pattern=pattern)
+
+        return None
+
+    async def handle_approval_resolution(
+        self, request_id: str, status: str,
+    ) -> SentinelResult | None:
+        """Handle a rejected or cancelled approval.
+
+        Called by the awareness loop or alarm-clearing cancellation.
+        """
+        if self._state.pending_request_id != request_id:
+            return None
+
+        pattern = self._state.pending_pattern
+        policy_id = self._state.pending_policy_id
+
+        if status == "rejected":
+            if pattern:
+                expiry = (datetime.now(UTC) + timedelta(hours=24)).isoformat()
+                self._state.rejected_patterns[pattern] = expiry
+            self._state.clear_pending()
+            self._state.transition(SentinelState.HEALTHY, reason=f"{policy_id} rejected by user")
+            save_state(self._state)
+            append_log({"event": f"{policy_id}_rejected", "request_id": request_id})
+            return SentinelResult(dispatched=False, reason=f"{policy_id} rejected")
+
+        if status == "cancelled":
+            self._state.clear_pending()
+            self._state.transition(SentinelState.HEALTHY, reason=f"{policy_id} cancelled (alarm cleared)")
+            save_state(self._state)
+            append_log({"event": f"{policy_id}_cancelled", "request_id": request_id})
+            return SentinelResult(dispatched=False, reason=f"{policy_id} cancelled: alarm cleared")
+
+        return None
 
     async def _request_dispatch_approval(self, request: SentinelRequest) -> bool:
         """Send Telegram approval request with inline buttons and wait.
@@ -870,6 +1243,26 @@ class SentinelDispatcher:
         # Update the ring buffer with this tick's alarm ids (always — even
         # if empty, an empty set is data that confirms absence).
         self._recent_alarm_sets.append(current_ids)
+
+        # If alarms have cleared while we're waiting for approval, cancel
+        # the pending approval and go back to HEALTHY.
+        if not alarms and self._state.state in (
+            SentinelState.AWAITING_DISPATCH_APPROVAL,
+            SentinelState.AWAITING_ACTION_APPROVAL,
+        ):
+            request_id = self._state.pending_request_id
+            if request_id and self._approval_gate is not None:
+                try:
+                    await self._approval_gate.resolve_request(
+                        request_id, decision="cancelled", resolved_by="alarm_cleared",
+                    )
+                except Exception:
+                    logger.warning("Failed to cancel sentinel approval %s", request_id, exc_info=True)
+            logger.info("Alarms cleared — cancelling pending sentinel approval %s", request_id)
+            self._state.clear_pending()
+            self._state.transition(SentinelState.HEALTHY, reason="alarms cleared while awaiting approval")
+            save_state(self._state)
+            return None
 
         if not alarms:
             return None

--- a/src/genesis/sentinel/state.py
+++ b/src/genesis/sentinel/state.py
@@ -1,10 +1,12 @@
-"""Sentinel state machine — 4-state lifecycle for the container-side guardian.
+"""Sentinel state machine — 6-state lifecycle for the container-side guardian.
 
 States:
-  HEALTHY       — No fire alarms, everything normal
-  INVESTIGATING — Fire alarm detected, evaluating conditions and trying reflexes
-  REMEDIATING   — Reflexes failed, CC diagnosis session dispatched
-  ESCALATED     — CC failed, observation created for ego. Auto-resets after timeout.
+  HEALTHY                    — No fire alarms, everything normal
+  INVESTIGATING              — Fire alarm detected, evaluating conditions
+  REMEDIATING                — CC diagnosis session dispatched
+  ESCALATED                  — CC failed, observation created for ego
+  AWAITING_DISPATCH_APPROVAL — Dispatch approval pending (DB-backed)
+  AWAITING_ACTION_APPROVAL   — Action approval pending (DB-backed)
 
 Persistence: atomic JSON write to ~/.genesis/sentinel_state.json
 """

--- a/src/genesis/sentinel/state.py
+++ b/src/genesis/sentinel/state.py
@@ -30,6 +30,8 @@ class SentinelState(Enum):
     INVESTIGATING = "investigating"
     REMEDIATING = "remediating"
     ESCALATED = "escalated"
+    AWAITING_DISPATCH_APPROVAL = "awaiting_dispatch_approval"
+    AWAITING_ACTION_APPROVAL = "awaiting_action_approval"
 
 
 @dataclass
@@ -59,6 +61,14 @@ class SentinelStateData:
     # Rejection tracking — pattern → ISO timestamp when suppression expires.
     # Prevents rejected dispatch patterns from re-triggering within the window.
     rejected_patterns: dict[str, str] = field(default_factory=dict)
+
+    # Pending approval context — serialized so it survives restarts.
+    # Populated when entering AWAITING_DISPATCH_APPROVAL or AWAITING_ACTION_APPROVAL.
+    pending_request_id: str = ""
+    pending_policy_id: str = ""  # "sentinel_dispatch" or "sentinel_action"
+    pending_pattern: str = ""
+    pending_request_json: str = ""  # JSON-serialized SentinelRequest fields
+    pending_cc_result_json: str = ""  # JSON-serialized CC result (for action phase)
 
     # Bootstrap grace
     bootstrap_grace_s: int = 240
@@ -92,6 +102,14 @@ class SentinelStateData:
     def record_cc_dispatch(self) -> None:
         """Stamp the last dispatch time. Used for observability only."""
         self.last_cc_dispatch_at = datetime.now(UTC).isoformat()
+
+    def clear_pending(self) -> None:
+        """Clear all pending approval context fields."""
+        self.pending_request_id = ""
+        self.pending_policy_id = ""
+        self.pending_pattern = ""
+        self.pending_request_json = ""
+        self.pending_cc_result_json = ""
 
     def should_auto_reset_escalated(self) -> bool:
         """Check if ESCALATED state should auto-reset to HEALTHY."""

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -48,6 +48,13 @@ class SurplusScheduler:
         dispatch_interval_minutes: int = 5,
         brainstorm_check_hours: int = 12,
         task_expiry_hours: int = 72,
+        code_audit_hours: int = 12,
+        code_index_hours: int = 4,
+        infra_monitor_hours: int = 2,
+        recon_gather_hours: int = 84,
+        maintenance_hours: int = 6,
+        follow_up_dispatch_minutes: int | None = None,
+        memory_extraction_hours: int = 2,
         clock=None,
         event_bus: GenesisEventBus | None = None,
         enable_code_audits: bool = True,
@@ -65,6 +72,13 @@ class SurplusScheduler:
         self._dispatch_interval = dispatch_interval_minutes
         self._brainstorm_interval = brainstorm_check_hours
         self._task_expiry_hours = task_expiry_hours
+        self._code_audit_hours = code_audit_hours
+        self._code_index_hours = code_index_hours
+        self._infra_monitor_hours = infra_monitor_hours
+        self._recon_gather_hours = recon_gather_hours
+        self._maintenance_hours = maintenance_hours
+        self._follow_up_dispatch_minutes = follow_up_dispatch_minutes or dispatch_interval_minutes
+        self._memory_extraction_hours = memory_extraction_hours
         self._clock = clock or (lambda: datetime.now(UTC))
         self._code_audit_executor: SurplusExecutor | None = None
         self._code_index_executor: SurplusExecutor | None = None
@@ -143,7 +157,7 @@ class SurplusScheduler:
         if self._scheduler.running and not self._scheduler.get_job("follow_up_dispatch"):
             self._scheduler.add_job(
                 self.dispatch_follow_ups,
-                IntervalTrigger(minutes=self._dispatch_interval),
+                IntervalTrigger(minutes=self._follow_up_dispatch_minutes),
                 id="follow_up_dispatch",
                 max_instances=1,
                 misfire_grace_time=60,
@@ -168,7 +182,7 @@ class SurplusScheduler:
         if self._enable_code_audits:
             self._scheduler.add_job(
                 self.schedule_code_audit,
-                IntervalTrigger(hours=12),
+                IntervalTrigger(hours=self._code_audit_hours),
                 id="schedule_code_audit",
                 max_instances=1,
                 misfire_grace_time=300,
@@ -178,28 +192,28 @@ class SurplusScheduler:
             logger.info("Code audits disabled — skipping job registration")
         self._scheduler.add_job(
             self.schedule_code_index,
-            IntervalTrigger(hours=4),
+            IntervalTrigger(hours=self._code_index_hours),
             id="schedule_code_index",
             max_instances=1,
             misfire_grace_time=300,
         )
         self._scheduler.add_job(
             self.schedule_infra_monitor,
-            IntervalTrigger(hours=2),
+            IntervalTrigger(hours=self._infra_monitor_hours),
             id="schedule_infra_monitor",
             max_instances=1,
             misfire_grace_time=300,
         )
         self._scheduler.add_job(
             self.run_recon_gather,
-            IntervalTrigger(hours=84),
+            IntervalTrigger(hours=self._recon_gather_hours),
             id="recon_gather",
             max_instances=1,
             misfire_grace_time=300,
         )
         self._scheduler.add_job(
             self.schedule_maintenance,
-            IntervalTrigger(hours=6),
+            IntervalTrigger(hours=self._maintenance_hours),
             id="schedule_maintenance",
             max_instances=1,
             misfire_grace_time=300,
@@ -207,7 +221,7 @@ class SurplusScheduler:
         if self._follow_up_dispatcher is not None:
             self._scheduler.add_job(
                 self.dispatch_follow_ups,
-                IntervalTrigger(minutes=self._dispatch_interval),
+                IntervalTrigger(minutes=self._follow_up_dispatch_minutes),
                 id="follow_up_dispatch",
                 max_instances=1,
                 misfire_grace_time=60,


### PR DESCRIPTION
## Summary

- **Knowledge panel CSS**: Replace 9 undefined legacy CSS variable names (`--text-dim`, `--accent`, `--border`, etc.) with correct `--color-*` equivalents from `index.css`. These were silently falling back to browser defaults.

- **Surplus config wiring**: `config/surplus.yaml` now actually controls job intervals. Previously, `runtime/init/surplus.py` passed only hardcoded kwargs to `SurplusScheduler.__init__()`, ignoring the YAML file. Now loads via `merge_local_overlay()` and passes all 10 interval values. Dashboard changes to surplus settings take effect on restart.

- **Sentinel migration to DB-backed approvals**: Replace blocking `submit_raw_and_wait()` (300s timeout at two points) with non-blocking `AutonomousCliApprovalGate.ensure_approval()`. This eliminates silent timeouts and enables dashboard-based approval resolution.

  State machine: new `AWAITING_DISPATCH_APPROVAL` / `AWAITING_ACTION_APPROVAL` states with serialized pending context that survives restarts.

  3-phase resumable dispatch:
  1. `ensure_approval(sentinel_dispatch)` → park if pending
  2. CC session → diagnosis + proposed actions
  3. `ensure_approval(sentinel_action)` → park if pending, then execute

  Awareness loop: `_resume_approved_sentinel_dispatches()` picks up approved requests. Alarm-clearing: auto-cancels pending approvals when fire alarms clear.

  Legacy fallback preserved: if `approval_gate is None`, old blocking path still works.

## Test plan

- [x] `ruff check` passes on all changed files (3 pre-existing errors in unrelated files)
- [x] Full test suite: 1356 passed, 1 skipped (pre-existing flaky `test_prepare_and_push_branch_idempotent_rerun`)
- [x] Sentinel tests: 79 passed
- [x] Autonomy/approval tests: 56 passed
- [x] Surplus tests: 32 passed
- [ ] Visual: verify Knowledge tab CSS renders with correct theme colors
- [ ] Surplus: change interval via dashboard → restart → verify logs
- [ ] Sentinel: verify approval flow via Telegram inline buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)