### PR TITLE
fix(dashboard,routing,observations): morning report issues

### DIFF
--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -47,7 +47,7 @@ max_sessions=$ram_cap
 [[ $max_sessions -gt $CPU_CAP ]] && max_sessions=$CPU_CAP
 
 existing=$(tmux list-sessions -F '#{session_name}' 2>/dev/null \
-           | grep -c "^${SESSION_PREFIX}-" || echo 0)
+           | grep -c "^${SESSION_PREFIX}-" || true)
 
 # Reattaching to existing session — always allow
 if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -352,6 +352,7 @@ class AwarenessLoop:
         self._tick_count: int = 0
         self._last_tick_at: str | None = None
         self._last_tick_result: TickResult | None = None
+        self._last_degradation_level: DegradationLevel | None = None
 
     def request_stop(self) -> None:
         """Signal that shutdown is imminent — skip deferred retries.
@@ -375,6 +376,37 @@ class AwarenessLoop:
     def set_circuit_breakers(self, breakers: CircuitBreakerRegistry) -> None:
         """Inject circuit breaker registry for resilience state updates."""
         self._circuit_breakers = breakers
+
+    async def _update_resilience_cognitive_state(self, level: DegradationLevel) -> None:
+        """Write or clear cognitive state when resilience level changes."""
+        try:
+            from genesis.db.crud import cognitive_state
+
+            now = datetime.now(UTC).isoformat()
+            if level == DegradationLevel.NORMAL:
+                content = "All providers normal — no degradation."
+            else:
+                # Identify which providers are down
+                down = []
+                if self._circuit_breakers:
+                    down = [
+                        name for name, cb in self._circuit_breakers._breakers.items()
+                        if not cb.is_available()
+                    ]
+                detail = f"Providers down: {', '.join(sorted(down))}" if down else ""
+                content = f"Resilience {level.value}: {detail}"
+
+            await cognitive_state.replace_section(
+                self._db,
+                section="resilience_degradation",
+                id=str(uuid.uuid4()),
+                content=content,
+                generated_by="awareness_loop",
+                created_at=now,
+            )
+            logger.info("Resilience cognitive state updated: %s → %s", self._last_degradation_level, level)
+        except Exception:
+            logger.warning("Failed to update resilience cognitive state", exc_info=True)
 
     async def start(self) -> None:
         """Start the scheduler with the tick job.
@@ -537,6 +569,11 @@ class AwarenessLoop:
                         logger.warning("Unknown degradation level %s, defaulting to OFFLINE", level)
                         cloud = CloudStatus.OFFLINE
                     self._resilience_state_machine.update_cloud(cloud)
+
+                    # Track degradation transitions in cognitive state
+                    if level != self._last_degradation_level:
+                        await self._update_resilience_cognitive_state(level)
+                        self._last_degradation_level = level
                 except Exception:
                     logger.warning("Resilience state update failed", exc_info=True)
 

--- a/src/genesis/cc/reflection_bridge/_output.py
+++ b/src/genesis/cc/reflection_bridge/_output.py
@@ -51,31 +51,40 @@ async def store_reflection_output(depth, tick, output, *, db) -> None:
     now = datetime.now(UTC).isoformat()
     source = f"cc_reflection_{depth.value.lower()}"
 
-    # Primary reflection output (with dedup)
-    content = json.dumps({
-        "tick_id": tick.tick_id,
-        "depth": depth.value,
-        "cc_output": output.text[:2000],
-        "model_used": output.model_used,
-        "cost_usd": output.cost_usd,
-        "input_tokens": output.input_tokens,
-        "output_tokens": output.output_tokens,
-    }, sort_keys=True)
-    content_hash = hashlib.sha256(content.encode()).hexdigest()
-    if not await observations.exists_by_hash(
-        db, source=source, content_hash=content_hash, unresolved_only=True,
-    ):
-        await observations.create(
-            db,
-            id=str(uuid.uuid4()),
-            source=source,
-            type="reflection_output",
-            content=content,
-            priority="high" if depth == Depth.STRATEGIC else "medium",
-            created_at=now,
-            content_hash=content_hash,
-            skip_if_duplicate=True,
-        )
+    # Cooldown gate: skip primary observation if one of the same type+source
+    # was created within the last 30 minutes.  Still process sub-outputs
+    # (light escalations, deltas, surplus) and strategic focus.
+    skip_primary = await observations.exists_recent_by_type(
+        db, source=source, type="reflection_output", window_minutes=30,
+    )
+    if skip_primary:
+        logger.debug("Reflection output cooldown: skipping (recent %s exists within 30m)", source)
+    else:
+        # Primary reflection output (with dedup)
+        content = json.dumps({
+            "tick_id": tick.tick_id,
+            "depth": depth.value,
+            "cc_output": output.text[:2000],
+            "model_used": output.model_used,
+            "cost_usd": output.cost_usd,
+            "input_tokens": output.input_tokens,
+            "output_tokens": output.output_tokens,
+        }, sort_keys=True)
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+        if not await observations.exists_by_hash(
+            db, source=source, content_hash=content_hash, unresolved_only=True,
+        ):
+            await observations.create(
+                db,
+                id=str(uuid.uuid4()),
+                source=source,
+                type="reflection_output",
+                content=content,
+                priority="high" if depth == Depth.STRATEGIC else "medium",
+                created_at=now,
+                content_hash=content_hash,
+                skip_if_duplicate=True,
+            )
 
     # Light: parse JSON for escalation, user_model_deltas, surplus_candidates
     if depth == Depth.LIGHT:
@@ -260,6 +269,13 @@ async def _store_reflection_summary(output, *, source: str, now: str, db) -> Non
         if output.text.strip():
             summary_parts.append(output.text[:2000])
     if summary_parts:
+        # Cooldown: skip if a reflection_summary from this source exists
+        # within the last 30 minutes.
+        if await observations.exists_recent_by_type(
+            db, source=source, type="reflection_summary", window_minutes=30,
+        ):
+            logger.debug("Reflection summary cooldown: skipping (recent exists within 30m)")
+            return
         summary_text = "\n\n".join(summary_parts)[:4000]
         summary_hash = hashlib.sha256(summary_text.encode()).hexdigest()
         if not await observations.exists_by_hash(

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -3199,9 +3199,9 @@
         </div>
       </template>
       <!-- Resilience degradation banner -->
-      <template x-if="$store.genesisDashboard.health.resilience && $store.genesisDashboard.health.resilience !== 'L0' && $store.genesisDashboard.health.resilience !== 'not configured'">
-        <div :style="`background: ${['L3', 'L4', 'L5', 'error'].includes($store.genesisDashboard.health.resilience) ? '#d9534f' : '#f0ad4e'}; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center;`"
-             x-text="'Resilience: ' + $store.genesisDashboard.health.resilience + ' — system is operating in degraded mode'">
+      <template x-if="$store.genesisDashboard.health.resilience?.level && $store.genesisDashboard.health.resilience.level !== 'L0' && $store.genesisDashboard.health.resilience.level !== 'not configured'">
+        <div :style="`background: ${['L3', 'L4', 'L5', 'error'].includes($store.genesisDashboard.health.resilience.level) ? '#d9534f' : '#f0ad4e'}; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center;`"
+             x-text="'Resilience: ' + $store.genesisDashboard.health.resilience.level + ' — ' + ($store.genesisDashboard.health.resilience.summary || 'system is operating in degraded mode')">
         </div>
       </template>
       <div class="panel-body">

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -2247,7 +2247,7 @@ function updateHeaderBadges(data) {
     const hbRes = document.getElementById('hb-resilience');
     if (hbRes) {
         const resObj = data.resilience || {};
-        const res = resObj.level || resObj || 'unknown';
+        const res = (typeof resObj === 'object' ? resObj.level : resObj) || 'unknown';
         const isOk = res === 'L0' || res === 'normal' || res === 'not configured';
         hbRes.style.display = 'inline-flex';
         hbRes.style.background = isOk ? 'rgba(22,101,52,0.5)' : 'rgba(133,77,14,0.5)';

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -1640,9 +1640,12 @@ function updateSidePanel(data) {
     const resEl = document.getElementById('resilience-content');
     if (resEl) {
         resEl.replaceChildren();
-        const resState = data.resilience || 'not configured';
+        const resObj = data.resilience || {};
+        const resState = resObj.level || resObj || 'not configured';
+        const resSummary = resObj.summary || '';
         const rColor = (resState === 'L0' || resState === 'normal') ? 'color:#4ade80' : resState === 'not configured' ? 'color:#6b7280' : 'color:#ffe600';
-        resEl.appendChild(sectionRow('State', String(resState), rColor + ';font-weight:600'));
+        const resLabel = resSummary ? `${resState} — ${resSummary}` : String(resState);
+        resEl.appendChild(sectionRow('State', resLabel, rColor + ';font-weight:600'));
 
         // Provider summary: X/Y call sites healthy
         // Excludes idle (groundwork) and disabled (no API key) sites — these
@@ -2243,7 +2246,8 @@ function updateHeaderBadges(data) {
     // Resilience badge
     const hbRes = document.getElementById('hb-resilience');
     if (hbRes) {
-        const res = data.resilience || 'unknown';
+        const resObj = data.resilience || {};
+        const res = resObj.level || resObj || 'unknown';
         const isOk = res === 'L0' || res === 'normal' || res === 'not configured';
         hbRes.style.display = 'inline-flex';
         hbRes.style.background = isOk ? 'rgba(22,101,52,0.5)' : 'rgba(133,77,14,0.5)';

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -309,6 +309,51 @@ async def resolve_expired(db: aiosqlite.Connection) -> int:
     return cursor.rowcount
 
 
+async def resolve_stale_persistent(
+    db: aiosqlite.Connection,
+    *,
+    max_age_days: int = 60,
+) -> int:
+    """Resolve unresolved persistent observations older than *max_age_days*.
+
+    Only targets low/medium priority.  High/critical persist until manually
+    resolved so they remain visible for human review.
+    """
+    now = datetime.now(UTC).isoformat()
+    cutoff = (datetime.now(UTC) - timedelta(days=max_age_days)).isoformat()
+    cursor = await db.execute(
+        "UPDATE observations SET resolved = 1, resolved_at = ?, "
+        "resolution_notes = 'auto-resolved (stale persistent)' "
+        "WHERE resolved = 0 AND expires_at IS NULL "
+        "AND created_at < ? AND priority IN ('low', 'medium')",
+        (now, cutoff),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
+async def exists_recent_by_type(
+    db: aiosqlite.Connection,
+    *,
+    source: str,
+    type: str,
+    window_minutes: int = 30,
+) -> bool:
+    """Check if an unresolved observation of this source+type was created recently.
+
+    Used as a cooldown gate to prevent near-duplicate observations from
+    LLM reflections that produce different wording for the same system state.
+    """
+    cursor = await db.execute(
+        "SELECT 1 FROM observations "
+        "WHERE source = ? AND type = ? AND resolved = 0 "
+        "AND created_at > datetime('now', ? || ' minutes') "
+        "LIMIT 1",
+        (source, type, str(-window_minutes)),
+    )
+    return (await cursor.fetchone()) is not None
+
+
 async def delete(db: aiosqlite.Connection, id: str) -> bool:
     cursor = await db.execute("DELETE FROM observations WHERE id = ?", (id,))
     await db.commit()

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -343,13 +343,17 @@ async def exists_recent_by_type(
 
     Used as a cooldown gate to prevent near-duplicate observations from
     LLM reflections that produce different wording for the same system state.
+
+    Uses Python-side ISO cutoff (not SQLite ``datetime('now')``) so the
+    comparison works correctly with ISO 8601 timestamps stored in created_at.
     """
+    cutoff = (datetime.now(UTC) - timedelta(minutes=window_minutes)).isoformat()
     cursor = await db.execute(
         "SELECT 1 FROM observations "
         "WHERE source = ? AND type = ? AND resolved = 0 "
-        "AND created_at > datetime('now', ? || ' minutes') "
+        "AND created_at > ? "
         "LIMIT 1",
-        (source, type, str(-window_minutes)),
+        (source, type, cutoff),
     )
     return (await cursor.fetchone()) is not None
 

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -637,6 +637,68 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
     except Exception:
         logger.warning("Expired observation sweep skipped", exc_info=True)
 
+    # 2026-04-18: Backfill expires_at on pre-TTL observations that have no
+    # expiry despite belonging to a TTL-governed type, then resolve any whose
+    # computed expiry is already past.  Also resolve stale persistent
+    # observations (>60 days, low/medium priority).  Idempotent.
+    try:
+        from datetime import UTC, datetime, timedelta
+
+        from genesis.db.crud.observations import _TTL_BY_TYPE, _TTL_PREFIX
+
+        now = datetime.now(UTC)
+        now_iso = now.isoformat()
+
+        # Phase 1: backfill expires_at per type
+        backfilled = 0
+        for obs_type, ttl in _TTL_BY_TYPE.items():
+            secs = int(ttl.total_seconds())
+            cursor = await db.execute(
+                "UPDATE observations SET expires_at = datetime(created_at, ? || ' seconds') "
+                "WHERE resolved = 0 AND expires_at IS NULL AND type = ?",
+                (str(secs), obs_type),
+            )
+            backfilled += cursor.rowcount
+        for prefix, ttl in _TTL_PREFIX:
+            secs = int(ttl.total_seconds())
+            cursor = await db.execute(
+                "UPDATE observations SET expires_at = datetime(created_at, ? || ' seconds') "
+                "WHERE resolved = 0 AND expires_at IS NULL AND type LIKE ?",
+                (str(secs), f"{prefix}%"),
+            )
+            backfilled += cursor.rowcount
+        if backfilled:
+            await db.commit()
+            logger.info("Backfilled expires_at on %d pre-TTL observations", backfilled)
+
+        # Phase 2: resolve any that are now past their backfilled expiry
+        cursor = await db.execute(
+            "UPDATE observations SET resolved = 1, resolved_at = ?, "
+            "resolution_notes = 'auto-expired (TTL backfill)' "
+            "WHERE resolved = 0 AND expires_at IS NOT NULL AND expires_at < ?",
+            (now_iso, now_iso),
+        )
+        newly_expired = cursor.rowcount
+        if newly_expired:
+            await db.commit()
+            logger.info("Resolved %d observations past backfilled TTL", newly_expired)
+
+        # Phase 3: resolve stale persistent-type observations (>60 days, low/medium)
+        stale_cutoff = (now - timedelta(days=60)).isoformat()
+        cursor = await db.execute(
+            "UPDATE observations SET resolved = 1, resolved_at = ?, "
+            "resolution_notes = 'auto-resolved (stale persistent, >60 days)' "
+            "WHERE resolved = 0 AND expires_at IS NULL "
+            "AND created_at < ? AND priority IN ('low', 'medium')",
+            (now_iso, stale_cutoff),
+        )
+        stale_resolved = cursor.rowcount
+        if stale_resolved:
+            await db.commit()
+            logger.info("Resolved %d stale persistent observations (>60d)", stale_resolved)
+    except Exception:
+        logger.warning("Observation TTL backfill migration skipped", exc_info=True)
+
     # Memory rebalance: purge orphaned memory_links whose source/target
     # memories were deleted but links were never cascade-cleaned.  MemoryStore
     # .delete() now cascades, but ~1,600 stale links accumulated before that.

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -928,6 +928,7 @@ INDEXES = [
     # GROUNDWORK(multi-person)
     "CREATE INDEX IF NOT EXISTS idx_observations_person ON observations(person_id)",
     "CREATE INDEX IF NOT EXISTS idx_observations_content_hash ON observations(source, content_hash)",
+    "CREATE INDEX IF NOT EXISTS idx_observations_type_source_created ON observations(type, source, created_at)",
     "CREATE INDEX IF NOT EXISTS idx_outreach_person ON outreach_history(person_id)",
     "CREATE INDEX IF NOT EXISTS idx_autonomy_person ON autonomy_state(person_id)",
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_autonomy_category ON autonomy_state(category)",

--- a/src/genesis/observability/health_data.py
+++ b/src/genesis/observability/health_data.py
@@ -144,11 +144,11 @@ class HealthDataService:
             for name, r in self._provider_health.results.items()
         }
 
-    def _resilience_state(self) -> str:
-        """Compute resilience state from circuit breaker registry."""
-        from genesis.observability.snapshots.infrastructure import resilience_state
+    def _resilience_state(self) -> dict:
+        """Compute resilience state with detail from circuit breaker registry."""
+        from genesis.observability.snapshots.infrastructure import resilience_state_detail
 
-        return resilience_state(self._breakers, self._state_machine)
+        return resilience_state_detail(self._breakers, self._state_machine)
 
     async def validate_api_keys(self) -> None:
         """Test each provider's API key with a lightweight call. Cache results."""

--- a/src/genesis/observability/snapshots/__init__.py
+++ b/src/genesis/observability/snapshots/__init__.py
@@ -16,6 +16,7 @@ from genesis.observability.snapshots.eval_staleness import eval_staleness
 from genesis.observability.snapshots.infrastructure import (
     infrastructure,
     resilience_state,
+    resilience_state_detail,
 )
 from genesis.observability.snapshots.memory_health import memory_health
 from genesis.observability.snapshots.outreach import outreach_stats
@@ -41,6 +42,7 @@ __all__ = [
     "provider_activity",
     "queues",
     "resilience_state",
+    "resilience_state_detail",
     "services",
     "surplus_status",
     "validate_api_keys",

--- a/src/genesis/observability/snapshots/api_keys.py
+++ b/src/genesis/observability/snapshots/api_keys.py
@@ -21,6 +21,24 @@ _CC_MANAGED_TYPES = frozenset({"anthropic"})
 _api_validation_cache: dict[str, dict] = {}
 
 
+def has_api_key(provider_cfg) -> bool:
+    """Check if a provider has a non-empty API key in the environment.
+
+    Local providers (ollama, lmstudio) always return True — they don't
+    need cloud API keys.  Used by the config loader to auto-disable
+    providers that have no credentials configured.
+    """
+    ptype = provider_cfg.provider_type
+    if ptype in _LOCAL_TYPES:
+        return True
+    service = ptype.upper()
+    for pattern in [f"API_KEY_{service}", f"{service}_API_KEY", f"{service}_API_TOKEN"]:
+        val = os.environ.get(pattern)
+        if val and val not in ("None", "NA", ""):
+            return True
+    return False
+
+
 def api_key_health(routing_config: RoutingConfig | None) -> dict:
     """Check which configured providers have API keys present + validation status."""
     if not routing_config:

--- a/src/genesis/observability/snapshots/infrastructure.py
+++ b/src/genesis/observability/snapshots/infrastructure.py
@@ -263,6 +263,26 @@ def resilience_state(
         return "error"
 
 
+def resilience_state_detail(
+    breakers,  # CircuitBreakerRegistry | None
+    state_machine,  # ResilienceStateMachine | None
+) -> dict:
+    """Compute resilience state with human-readable detail."""
+    level = resilience_state(breakers, state_machine)
+    summary = ""
+    if breakers:
+        try:
+            down = [
+                name for name, cb in breakers._breakers.items()
+                if not cb.is_available()
+            ]
+            if down:
+                summary = f"Providers down: {', '.join(sorted(down))}"
+        except Exception:
+            pass
+    return {"level": level, "summary": summary}
+
+
 def _update_cloud_axis(state_machine, level: DegradationLevel) -> None:
     if state_machine is None:
         return

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -206,6 +206,9 @@ class MorningReportGenerator:
             f"- Awareness: ticks_24h={awareness.get('ticks_24h', '?')}",
             f"- CC Sessions: foreground={cc.get('foreground_active', 0)}, background={cc.get('background_active', 0)}, failed_24h={cc.get('failed_24h', 0)}",
         ]
+        pending_embed = queues.get('pending_embeddings', 0)
+        if pending_embed and pending_embed > 100:
+            lines.append(f"- **Embedding queue elevated**: {pending_embed} pending")
         return "\n".join(lines)
 
     async def _get_activity_summary(self) -> str:

--- a/src/genesis/perception/writer.py
+++ b/src/genesis/perception/writer.py
@@ -131,6 +131,16 @@ class ResultWriter:
         if gated:
             return
 
+        # Cooldown gate: skip if a light_reflection from this source was
+        # created within the last 30 minutes.  Prevents near-duplicate
+        # observations where the LLM generates different wording for the
+        # same system state.
+        if await observations.exists_recent_by_type(
+            db, source="reflection", type="light_reflection", window_minutes=30,
+        ):
+            logger.debug("Light reflection cooldown: skipping (recent exists within 30m)")
+            return
+
         content = json.dumps({
             "assessment": output.assessment,
             "patterns": output.patterns,

--- a/src/genesis/routing/config.py
+++ b/src/genesis/routing/config.py
@@ -186,6 +186,8 @@ def _parse(raw: dict) -> RoutingConfig:
         retry_profiles["default"] = RetryPolicy()
 
     # --- Providers ---
+    from genesis.observability.snapshots.api_keys import has_api_key
+
     providers: dict[str, ProviderConfig] = {}
     disabled_providers: set[str] = set()
     for name, p in (raw.get("providers") or {}).items():
@@ -201,7 +203,7 @@ def _parse(raw: dict) -> RoutingConfig:
             logger.info("Provider '%s' disabled via config", name)
             continue
 
-        providers[name] = ProviderConfig(
+        cfg = ProviderConfig(
             name=name,
             provider_type=p["type"],
             model_id=p["model"],
@@ -213,6 +215,15 @@ def _parse(raw: dict) -> RoutingConfig:
             enabled=True,
             profile=p.get("profile"),
         )
+
+        # Auto-disable providers with no API key configured.  Local
+        # providers (ollama, lmstudio) don't need keys.
+        if not has_api_key(cfg):
+            disabled_providers.add(name)
+            logger.info("Provider '%s' disabled: no API key configured", name)
+            continue
+
+        providers[name] = cfg
 
     # --- Call sites ---
     call_sites: dict[str, CallSiteConfig] = {}

--- a/src/genesis/routing/config.py
+++ b/src/genesis/routing/config.py
@@ -128,7 +128,7 @@ def _sanitize_local_overlay(base_raw: dict, local_raw: dict) -> dict:
     return result
 
 
-def load_config(path: str | Path) -> RoutingConfig:
+def load_config(path: str | Path, *, check_api_keys: bool = True) -> RoutingConfig:
     """Load routing config from a YAML file path.
 
     Checks for a ``{stem}.local.yaml`` overlay in the same directory and
@@ -145,13 +145,13 @@ def load_config(path: str | Path) -> RoutingConfig:
         if local_raw:
             base_raw = _deep_merge(base_raw, local_raw)
 
-    return _parse(base_raw)
+    return _parse(base_raw, check_api_keys=check_api_keys)
 
 
-def load_config_from_string(text: str) -> RoutingConfig:
+def load_config_from_string(text: str, *, check_api_keys: bool = True) -> RoutingConfig:
     """Load routing config from a YAML string (no overlay support)."""
     raw = yaml.safe_load(_expand_env_vars(text))
-    return _parse(raw)
+    return _parse(raw, check_api_keys=check_api_keys)
 
 
 def _expand_env_vars(text: str) -> str:
@@ -165,7 +165,7 @@ def _expand_env_vars(text: str) -> str:
     return _ENV_PATTERN.sub(repl, text)
 
 
-def _parse(raw: dict) -> RoutingConfig:
+def _parse(raw: dict, *, check_api_keys: bool = True) -> RoutingConfig:
     """Parse raw YAML dict into a validated RoutingConfig."""
     if not isinstance(raw, dict):
         msg = "Config must be a YAML mapping"
@@ -218,7 +218,7 @@ def _parse(raw: dict) -> RoutingConfig:
 
         # Auto-disable providers with no API key configured.  Local
         # providers (ollama, lmstudio) don't need keys.
-        if not has_api_key(cfg):
+        if check_api_keys and not has_api_key(cfg):
             disabled_providers.add(name)
             logger.info("Provider '%s' disabled: no API key configured", name)
             continue

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -252,9 +252,13 @@ async def init(rt: GenesisRuntime) -> None:
         async def _observation_expiry_sweep() -> None:
             try:
                 count = await observations.resolve_expired(rt._db)
+                stale = await observations.resolve_stale_persistent(rt._db, max_age_days=60)
                 rt.record_job_success("observation_expiry_sweep")
-                if count:
-                    logger.info("Observation expiry sweep: resolved %d expired observations", count)
+                if count or stale:
+                    logger.info(
+                        "Observation expiry sweep: resolved %d expired, %d stale persistent",
+                        count, stale,
+                    )
             except Exception as exc:
                 rt.record_job_failure("observation_expiry_sweep", str(exc))
                 logger.exception("Observation expiry sweep failed")

--- a/tests/test_routing/conftest.py
+++ b/tests/test_routing/conftest.py
@@ -1,5 +1,7 @@
 """Shared fixtures for routing tests."""
 
+from unittest.mock import patch
+
 import pytest
 
 from genesis.routing.types import (
@@ -9,6 +11,13 @@ from genesis.routing.types import (
     RetryPolicy,
     RoutingConfig,
 )
+
+
+@pytest.fixture(autouse=True)
+def _skip_api_key_check():
+    """Tests don't have real API keys — bypass the check in config loading."""
+    with patch("genesis.observability.snapshots.api_keys.has_api_key", return_value=True):
+        yield
 
 
 class MockDelegate:


### PR DESCRIPTION
## Summary
- **Observation debt**: TTL backfill migration resolves ~1,100+ pre-TTL observations; daily sweep catches stale persistent ones (>60 days, low/medium priority)
- **Reflection dedup**: 30-minute cooldown gates prevent near-duplicate observations from light reflections generating different wording for the same system state
- **Resilience accuracy**: Auto-disable providers with no API key at config load, preventing false L1 banner from breaker cycling on unconfigured providers (claude-opus, claude-sonnet, qwen-plus)
- **Dashboard banner**: Resilience degradation banner now shows reason ("Providers down: ...") alongside level code
- **Cognitive state**: Resilience transitions write to cognitive state for essential knowledge visibility
- **Morning report**: Embedding queue warning when pending_embeddings > 100
- **tmux SSH**: Fix grep -c double-output bug in cc-slot.sh that broke first connection

## Test plan
- [x] `ruff check` passes on all modified files
- [x] 221 relevant tests pass (test_db, test_routing, test_awareness)
- [x] Full test suite passes (1075 passed)
- [x] Code review completed — datetime format mismatch fixed
- [ ] Verify dashboard banner disappears after restart (keyless providers filtered)
- [ ] Verify `ssh genesis-1-1` works from Windows PowerShell
- [ ] Verify observation count drops after migration runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)