### PR TITLE
fix(ssh): add PATH for claude in SSH RemoteCommand context

### DIFF
--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -9,6 +9,9 @@
 
 set -euo pipefail
 
+# SSH RemoteCommand doesn't source .bashrc (interactive guard) — set PATH explicitly
+export PATH="$HOME/.n/bin:$HOME/.bun/bin:$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"
+
 GENESIS_ROOT="${HOME}/genesis"
 SESSION_PREFIX="cc"
 


### PR DESCRIPTION
## Summary

- SSH `RemoteCommand` runs non-interactively, so `.bashrc` is skipped (standard Ubuntu interactive guard: `case $- in *i*) ;; *) return;; esac`)
- `~/.npm-global/bin` (where `claude` is installed) is never added to PATH
- `exec claude` fails silently, tmux session exits immediately, user sees `[exited]`
- Fix: explicitly set PATH at the top of `cc-slot.sh` to include the user's custom bin directories

## Test plan

- [ ] `ssh genesis-1-1` from Windows PowerShell enters tmux with Claude running
- [ ] Existing tmux sessions unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)