### PR TITLE
fix(routing,dashboard): restore Anthropic providers, fix false alerts, UI polish

### DIFF
--- a/src/genesis/dashboard/routes/settings.py
+++ b/src/genesis/dashboard/routes/settings.py
@@ -31,6 +31,7 @@ async def settings_index():
             "name": domain.name,
             "description": domain.description,
             "readonly": domain.readonly,
+            "readonly_reason": domain.readonly_reason,
             "needs_restart": domain.needs_restart,
             "dedicated_tool": domain.dedicated_tool,
             "has_form": domain.name in _FORM_DOMAINS,

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1274,7 +1274,9 @@
           return m[d] || '#6b7280';
         },
         _tierColor(t) {
-          return {curated:'#fbbf24', validated:'#4ade80', raw:'#6b7280', promoted:'#60a5fa'}[t] || '#6b7280';
+          return {curated:'#fbbf24', validated:'#4ade80', raw:'#6b7280', promoted:'#60a5fa',
+                  extraction_job:'#38bdf8', recon:'#f59e0b', manual:'#a78bfa',
+                  ingestion:'#34d399', conversation:'#f472b6', unknown:'#6b7280'}[t] || '#6b7280';
         },
         _memoryTypeColor(t) {
           const m = {episodic_memory:'#60a5fa', semantic_memory:'#4ade80', procedural:'#f59e0b',
@@ -5428,12 +5430,15 @@
                           <span title="Say this to Genesis in conversation to change these settings" style="cursor:help;">Chat: <em x-text="'&quot;update ' + domain.name.replace(/_/g, ' ') + ' settings&quot;'"></em></span>
                         </template>
                         <template x-if="domain.readonly">
-                          <span style="color:var(--color-text-secondary);">Read-only</span>
+                          <span style="color:var(--color-text-secondary); cursor:help;"
+                                :title="domain.readonly_reason || 'This setting cannot be edited from the dashboard'"
+                                x-text="domain.readonly_reason || 'Read-only'"></span>
                         </template>
                       </td>
                       <td style="padding:4px 8px;">
                         <template x-if="domain.readonly">
-                          <span style="font-size:0.65rem; background:var(--color-bg-tertiary); padding:2px 6px; border-radius:3px;">locked</span>
+                          <span style="font-size:0.65rem; background:var(--color-bg-tertiary); padding:2px 6px; border-radius:3px; cursor:help;"
+                                :title="domain.readonly_reason || 'Not editable from the dashboard'">view only</span>
                         </template>
                         <template x-if="domain.needs_restart && !domain.readonly">
                           <span style="font-size:0.65rem; background:#fff3cd; color:#856404; padding:2px 6px; border-radius:3px;" title="Changes require a genesis-server restart to take effect">Changing these settings requires a restart to apply</span>
@@ -6275,7 +6280,7 @@
           <!-- Directory listing -->
           <div x-show="!$store.genesisDashboard.fileBrowser.sidebarCollapsed"
                x-ref="fileBrowserSidebar"
-               style="flex:0 0 260px; max-height:calc(100vh - 280px); overflow-y:auto; padding-right:0.5rem;">
+               style="flex:0 0 28%; max-height:calc(100vh - 280px); overflow-y:auto; padding-right:0.5rem;">
             <template x-if="$store.genesisDashboard.fileBrowser.loading">
               <div style="color:var(--color-text-secondary); font-size:0.75rem; padding:1rem;">Loading...</div>
             </template>
@@ -6299,11 +6304,14 @@
 
           <!-- Resize handle -->
           <div x-show="!$store.genesisDashboard.fileBrowser.sidebarCollapsed"
-               style="flex:0 0 4px; cursor:col-resize; background:var(--color-border); border-radius:2px;
-                      transition:background .15s; position:relative; z-index:5; margin:0 2px;"
-               @mouseenter="$el.style.background='var(--color-accent)'"
-               @mouseleave="if(!$store.genesisDashboard.fileBrowser._resizing) $el.style.background='var(--color-border)'"
+               style="flex:0 0 8px; cursor:col-resize; background:var(--color-bg-tertiary);
+                      display:flex; align-items:center; justify-content:center;
+                      border-left:1px solid var(--color-border); border-right:1px solid var(--color-border);
+                      transition:background .15s; position:relative; z-index:5;"
+               @mouseenter="$el.style.background='rgba(99,102,241,0.25)'"
+               @mouseleave="if(!$store.genesisDashboard.fileBrowser._resizing) $el.style.background='var(--color-bg-tertiary)'"
                @mousedown.prevent="$store.genesisDashboard._startFileBrowserResize($event, $refs.fileBrowserSidebar)">
+            <span style="color:var(--color-text-secondary); font-size:0.55rem; pointer-events:none; opacity:0.6;">&#x22EE;</span>
           </div>
 
           <!-- File viewer -->
@@ -6787,8 +6795,8 @@
             <div style="display: flex; justify-content: space-between; align-items: center;">
               <strong x-text="unit.concept || unit.id" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 55%;"></strong>
               <div style="display:flex; gap:.35rem; align-items:center;">
-                <span :style="`font-size:.65rem; padding:1px 6px; border-radius:3px; background:${$store.genesisDashboard._tierColor(unit.tier)}22; color:${$store.genesisDashboard._tierColor(unit.tier)};`"
-                      x-text="unit.tier || 'raw'"></span>
+                <span :style="`font-size:.65rem; padding:1px 6px; border-radius:3px; background:${$store.genesisDashboard._tierColor(unit.source_pipeline)}22; color:${$store.genesisDashboard._tierColor(unit.source_pipeline)};`"
+                      x-text="unit.source_pipeline || 'unknown'"></span>
                 <span :style="`font-size:.65rem; padding:1px 6px; border-radius:3px; background:${$store.genesisDashboard._domainColor(unit.domain)}22; color:${$store.genesisDashboard._domainColor(unit.domain)};`"
                       x-text="unit.domain"></span>
               </div>

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -598,6 +598,11 @@ function infraStatusClass(probe) {
     if (status === 'healthy' || status === 'active') return 'status-healthy';
     if (status === 'degraded' || status === 'warning') return 'status-degraded';
     if (status === 'down') return 'status-down';
+    // cc_tmp uses tier (green/orange/red) instead of status
+    const tier = probe?.tier || probe?.cc_tier;
+    if (tier === 'green') return 'status-healthy';
+    if (tier === 'orange') return 'status-degraded';
+    if (tier === 'red') return 'status-down';
     if (probe?.free_pct != null) {
         if (probe.free_pct > 20) return 'status-healthy';
         if (probe.free_pct > 10) return 'status-degraded';

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -178,7 +178,16 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
             current_ids.add(alert_id)
 
     queues = snap.get("queues", {})
+    # Only check fields that represent actual queue depths — exclude
+    # cumulative counters (embedded_total), timestamps, error messages, etc.
+    _QUEUE_DEPTH_FIELDS = {
+        "pending_embeddings", "dead_letters", "deferred_work",
+        "deferred_processing", "deferred_stuck", "failed_embeddings",
+        "discarded_count",
+    }
     for queue_name, depth in queues.items():
+        if queue_name not in _QUEUE_DEPTH_FIELDS:
+            continue
         if isinstance(depth, int) and depth > 100:
             alert_id = f"queue:{queue_name}"
             alerts.append({

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -37,6 +37,7 @@ class SettingsDomain:
     readonly: bool
     needs_restart: bool
     dedicated_tool: str | None = None
+    readonly_reason: str = ""
 
 
 _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
@@ -63,45 +64,51 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
     ),
     "autonomy": SettingsDomain(
         name="autonomy",
-        description="Autonomy levels, ceilings, approval policy, watchdog (read-only — CRITICAL)",
+        description="Autonomy levels, ceilings, approval policy, watchdog",
         config_filename="autonomy.yaml",
         readonly=True,
         needs_restart=True,
+        readonly_reason="Controls autonomous action limits and approval requirements. Ask Genesis to review and adjust.",
     ),
     "guardian": SettingsDomain(
         name="guardian",
-        description="Host VM guardian health monitoring thresholds (read-only — host-side)",
+        description="Host VM guardian health monitoring thresholds",
         config_filename="guardian.yaml",
         readonly=True,
         needs_restart=True,
+        readonly_reason="Configured on the host VM during Guardian installation. Not editable from the container.",
     ),
     "autonomy_rules": SettingsDomain(
         name="autonomy_rules",
-        description="Data-driven autonomy decision rules (read-only — evaluated by RuleEngine)",
+        description="Data-driven autonomy decision rules evaluated by RuleEngine",
         config_filename="autonomy_rules.yaml",
         readonly=True,
         needs_restart=False,
+        readonly_reason="Decision rules that gate autonomous actions. Ask Genesis to review changes.",
     ),
     "content_sanitization": SettingsDomain(
         name="content_sanitization",
-        description="Content sanitization injection detection patterns (read-only)",
+        description="Content sanitization and injection detection patterns",
         config_filename="content_sanitization.yaml",
         readonly=True,
         needs_restart=True,
+        readonly_reason="Security filters for prompt injection detection. Changes require careful review — ask Genesis.",
     ),
     "model_profiles": SettingsDomain(
         name="model_profiles",
-        description="Model intelligence tiers, costs, and capabilities (read-only)",
+        description="Model intelligence tiers, costs, and capabilities",
         config_filename="model_profiles.yaml",
         readonly=True,
         needs_restart=False,
+        readonly_reason="System reference data — model capabilities, costs, and intelligence tiers.",
     ),
     "model_routing": SettingsDomain(
         name="model_routing",
-        description="Model routing call sites, provider chains, retry profiles (read-only — use dashboard for edits)",
+        description="Model routing call sites, provider chains, retry profiles",
         config_filename="model_routing.yaml",
         readonly=True,
         needs_restart=False,
+        readonly_reason="Managed in the Routing panel on the Internals tab.",
     ),
     "outreach": SettingsDomain(
         name="outreach",
@@ -121,11 +128,12 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
     ),
     "recon_watchlist": SettingsDomain(
         name="recon_watchlist",
-        description="Recon project watchlist (read-only)",
+        description="Recon project watchlist",
         config_filename="recon_watchlist.yaml",
         readonly=True,
         needs_restart=False,
         dedicated_tool="recon_watchlist",
+        readonly_reason="Editable via the watchlist tool — ask Genesis to add or remove items.",
     ),
     "recon_sources": SettingsDomain(
         name="recon_sources",
@@ -552,6 +560,7 @@ async def _impl_settings_list() -> list[dict]:
             "domain": d.name,
             "description": d.description,
             "readonly": d.readonly,
+            "readonly_reason": d.readonly_reason,
             "needs_restart": d.needs_restart,
             "dedicated_tool": d.dedicated_tool,
         }

--- a/src/genesis/observability/snapshots/api_keys.py
+++ b/src/genesis/observability/snapshots/api_keys.py
@@ -31,6 +31,8 @@ def has_api_key(provider_cfg) -> bool:
     ptype = provider_cfg.provider_type
     if ptype in _LOCAL_TYPES:
         return True
+    if ptype in _CC_MANAGED_TYPES:
+        return True  # CC handles auth — no API key needed
     service = ptype.upper()
     for pattern in [f"API_KEY_{service}", f"{service}_API_KEY", f"{service}_API_TOKEN"]:
         val = os.environ.get(pattern)
@@ -95,6 +97,13 @@ def api_key_health(routing_config: RoutingConfig | None) -> dict:
             else:
                 entry["status"] = "configured"
         results[name] = entry
+
+    # Include providers that were disabled at config load (no API key, etc.)
+    # so they still appear in the dashboard as "not configured".
+    for name, ptype in getattr(routing_config, "disabled_providers", {}).items():
+        if name not in results:
+            results[name] = {"status": "missing", "provider_type": ptype}
+
     return results
 
 

--- a/src/genesis/routing/config.py
+++ b/src/genesis/routing/config.py
@@ -190,6 +190,7 @@ def _parse(raw: dict, *, check_api_keys: bool = True) -> RoutingConfig:
 
     providers: dict[str, ProviderConfig] = {}
     disabled_providers: set[str] = set()
+    disabled_provider_types: dict[str, str] = {}  # name → provider_type
     for name, p in (raw.get("providers") or {}).items():
         # Parse enabled field — supports bool, string from env var expansion
         enabled_raw = p.get("enabled", True)
@@ -200,6 +201,7 @@ def _parse(raw: dict, *, check_api_keys: bool = True) -> RoutingConfig:
 
         if not enabled:
             disabled_providers.add(name)
+            disabled_provider_types[name] = p.get("type", "unknown")
             logger.info("Provider '%s' disabled via config", name)
             continue
 
@@ -220,6 +222,7 @@ def _parse(raw: dict, *, check_api_keys: bool = True) -> RoutingConfig:
         # providers (ollama, lmstudio) don't need keys.
         if check_api_keys and not has_api_key(cfg):
             disabled_providers.add(name)
+            disabled_provider_types[name] = cfg.provider_type
             logger.info("Provider '%s' disabled: no API key configured", name)
             continue
 
@@ -265,6 +268,7 @@ def _parse(raw: dict, *, check_api_keys: bool = True) -> RoutingConfig:
         providers=providers,
         call_sites=call_sites,
         retry_profiles=retry_profiles,
+        disabled_providers=disabled_provider_types,
     )
 
 

--- a/src/genesis/routing/types.py
+++ b/src/genesis/routing/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Protocol
 
@@ -113,6 +113,9 @@ class RoutingConfig:
     providers: dict[str, ProviderConfig]
     call_sites: dict[str, CallSiteConfig]
     retry_profiles: dict[str, RetryPolicy]
+    # Provider name → provider_type for providers disabled at config load
+    # (e.g., no API key). Stored for the API keys dashboard display.
+    disabled_providers: dict[str, str] = field(default_factory=dict)
 
 
 class CallDelegate(Protocol):


### PR DESCRIPTION
## Summary

Fixes regressions from PR #85 and polish from PR #86:

- **Anthropic providers restored**: `has_api_key()` now returns True for CC-managed providers — CC handles its own auth, `ANTHROPIC_API_KEY` is irrelevant for CLI-dispatched call sites
- **Disabled providers visible**: API keys panel shows providers disabled at config load as "missing" instead of hiding them entirely
- **Knowledge tab fixed**: `unit.tier` (nonexistent field) → `unit.source_pipeline` (actual DB column). Colored badges now render correctly.
- **File browser resize handle visible**: 8px wide with grip indicator and hover highlight (was 4px invisible). Default sidebar width restored to 28% (was 260px).
- **Neural monitor CC temp fixed**: `infraStatusClass()` now handles the `tier` field used by cc_tmp watchdog data
- **Readonly settings explained**: Each readonly domain now has a `readonly_reason` tooltip explaining why and what to do
- **False queue depth alert fixed**: Health alerts now whitelist actual depth fields — `embedded_total` (success counter) no longer triggers false alarms

## Test plan

- [x] `ruff check` — all checks passed
- [x] `pytest tests/test_routing/ tests/test_observability/` — 332 passed
- [x] Code review passed (superpowers:code-reviewer)
- [ ] Dashboard API keys panel shows Anthropic as "cc_managed" and disabled providers as "missing"
- [ ] Neural monitor shows strategic reflection chain includes claude-opus
- [ ] Knowledge tab shows colored source_pipeline badges
- [ ] File browser has visible resize handle between sidebar and viewer
- [ ] Neural monitor CC temp shows green (not gray)
- [ ] Config page readonly domains show explanatory tooltip on hover
- [ ] No false "embedded_total" alert in health alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)