### PR TITLE
fix(modules): MCP tool reads local config overlay, document process management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,55 @@ Genesis v3 is an autonomous AI agent system.
 - **Env scrub**: `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` is NOT used — Genesis
   hooks and MCP servers require inherited API keys (DeepInfra, Qwen, etc.).
 
+## Process Management
+
+All Genesis services are **systemd user units**. NEVER start services with
+`nohup`, `&`, or bare `python -m genesis serve`. NEVER `kill` a service
+process directly — use `systemctl --user stop`. The server has a process lock
+(`~/.genesis/genesis-server.lock`); a bare process blocks the systemd unit.
+
+| Unit | Purpose | Expected State |
+|------|---------|----------------|
+| `genesis-server.service` | Main server (port 5000) | `active (running)` |
+| `genesis-bridge.service` | Telegram CC conversation relay | `inactive` (start on demand) |
+| `genesis-tmp-watchgod.service` | /tmp filesystem protection | `active (running)` |
+| `genesis-watchdog.timer` | Periodic health check | `active (waiting)` |
+
+```bash
+systemctl --user status genesis-server           # Check server
+systemctl --user restart genesis-server          # Restart server
+systemctl --user stop genesis-server             # Stop server
+journalctl --user -u genesis-server -n 50        # Recent logs
+systemctl --user list-units 'genesis-*' --all    # All Genesis units
+```
+
+The server loads `secrets.env` via `EnvironmentFile=`. It depends on
+`qdrant.service` (system unit). Exit code 200 = lock held by another
+instance (won't auto-restart). Exit code 2 = missing config (won't
+auto-restart).
+
+## MCP Server Lifecycle
+
+Genesis has 4 MCP servers: `genesis-health`, `genesis-memory`,
+`genesis-outreach`, `genesis-recon`. They are **Claude Code child
+processes** — started automatically when CC needs them, NOT systemd
+services.
+
+- MCP servers cache state per-process (e.g., module adapter cache).
+- Code changes to MCP tools take effect on **next CC session start**.
+- MCP servers read module configs from both `config/modules/` (repo)
+  and `~/.genesis/config/modules/` (local overlay). Local wins on
+  same filename.
+
+## Config Layering
+
+Module YAML configs and other settings use a two-directory overlay:
+- **Repo defaults**: `~/genesis/config/modules/*.yaml`
+- **Local overrides**: `~/.genesis/config/modules/*.yaml`
+
+Local takes precedence on same filename. The Career Agent config lives
+in the local overlay (install-specific, not committed to repo).
+
 ## New Machine Setup
 
 ```bash
@@ -35,8 +84,8 @@ cd ~/genesis && ruff check .                      # Lint all Python
 cd ~/genesis && pytest -v                         # Run tests
 cd ~/genesis && ruff check . && pytest -v         # Both (do before committing)
 curl -s http://localhost:6333/collections | jq .  # Verify Qdrant
-python -m genesis serve                           # Standalone server (port 5000)
-python -m genesis serve --port 5001               # Custom port
+systemctl --user restart genesis-server           # Restart server (NEVER nohup)
+systemctl --user status genesis-server            # Verify server running
 ```
 
 ## Serena — Semantic Code Analysis

--- a/src/genesis/mcp/health/module_ops.py
+++ b/src/genesis/mcp/health/module_ops.py
@@ -18,6 +18,7 @@ from genesis.mcp.health import mcp
 logger = logging.getLogger(__name__)
 
 _MODULES_DIR = Path(__file__).resolve().parents[4] / "config" / "modules"
+_LOCAL_MODULES_DIR = Path.home() / ".genesis" / "config" / "modules"
 
 # Cache of loaded configs + IPC adapters (lazy, per-process lifetime)
 _adapters: dict | None = None
@@ -50,10 +51,16 @@ def _get_adapters() -> dict:
     from genesis.modules.external.config import ProgramConfig
 
     _adapters = {}
-    if not _MODULES_DIR.is_dir():
-        return _adapters
 
-    for yaml_path in sorted(_MODULES_DIR.glob("*.yaml")):
+    # Collect configs: repo defaults first, local overlay wins on same filename
+    # (mirrors genesis.runtime.init.modules._load_modules_from_yaml)
+    config_files: dict[str, Path] = {}
+    for d in (_MODULES_DIR, _LOCAL_MODULES_DIR):
+        if d.is_dir():
+            for p in sorted(d.glob("*.yaml")):
+                config_files[p.name] = p
+
+    for yaml_path in sorted(config_files.values(), key=lambda p: p.name):
         try:
             data = yaml.safe_load(yaml_path.read_text())
             if not data or data.get("type") != "external":


### PR DESCRIPTION
## Summary
- MCP module tools (`module_call`, `module_list`) now check both `config/modules/` (repo) and `~/.genesis/config/modules/` (local overlay), matching the runtime init behavior. Fixes Career Agent module not being discoverable via MCP.
- Added Process Management, MCP Server Lifecycle, and Config Layering sections to CLAUDE.md — operational self-knowledge to prevent recurring nohup/systemd mistakes.

## Test plan
- [x] `ruff check src/genesis/mcp/health/module_ops.py` passes
- [x] 228 module-related tests pass
- [x] Direct Python verification: adapter loads Career Agent from local overlay
- [x] Genesis server running under systemd with Career Agent enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)