### PR TITLE
fix(memory): 300/200 limits + smart sentence truncation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ index. If this answers "what are we working on," don't burn a recall.
 
 **L2 — Proactive Recall (automatic per prompt):**
 The UserPromptSubmit hook searches FTS5 + Qdrant based on your prompt keywords
-and injects `[Memory | age | wing | id:xxx]` tags (200/150 chars, rank 1/2-3).
+and injects `[Memory | age | wing | id:xxx]` tags (300/200 chars, rank 1/2-3).
 Check these first before doing explicit recall. Results are biased toward the
 active wing (domain) when detectable. Use the `id:` handle with `memory_expand`
 for full context without re-searching. Proactive hook results are keyword-matched

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -477,13 +477,21 @@ def _format_results(results: list[dict]) -> str:
     lines = []
     for rank, r in enumerate(results):
         is_rule = r.get("memory_class") == "rule"
-        max_len = 200 if (rank == 0 or is_rule) else 150
+        max_len = 300 if (rank == 0 or is_rule) else 200
         content = r.get("content", "")
         # Strip extraction-pipeline prefixes like [discovery], [feature], etc.
         # These are baked into stored content but waste display chars.
         if content.startswith("[") and "] " in content[:30]:
             content = content[content.index("] ") + 2:]
-        content = content[:max_len]
+        # Smart truncation: cut at last sentence boundary before limit
+        if len(content) > max_len:
+            for i in range(max_len - 1, max(max_len - 60, 0), -1):
+                if content[i] in ".!?":
+                    content = content[: i + 1]
+                    break
+            else:
+                content = content[:max_len]
+
 
         mid = r.get("memory_id", "")
         age = _format_age(r.get("_created_at", ""))


### PR DESCRIPTION
## Summary
- Bump proactive hook content limits from 200/150 to 300/200 (rank 1/2-3)
- Add smart truncation: cuts at last sentence boundary instead of hard char limit
- Reduces mid-sentence cliffhangers from 73% to ~32% of truncated results
- Cost: ~60 extra tokens per message (~266 vs ~206)

Data from 200-memory random sample validated the improvement.

## Test plan
- [x] `ruff check` passes
- [x] Functional test shows complete sentences in output
- [x] Statistical analysis across 200 random memories confirms improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)