### PR TITLE
fix(approval): remove micro-reflection salience gate, populate approval_request_id

### DIFF
--- a/src/genesis/autonomy/autonomous_dispatch.py
+++ b/src/genesis/autonomy/autonomous_dispatch.py
@@ -955,6 +955,7 @@ class AutonomousDispatchRouter:
                 api_error=api_error,
             )
 
+        request_id: str | None = None
         if request.approval_required_for_cli:
             status, request_id, reason = await self._approval_gate.ensure_approval(
                 subsystem=request.subsystem,
@@ -980,5 +981,6 @@ class AutonomousDispatchRouter:
         return AutonomousDispatchDecision(
             mode="cli_approved",
             reason="CLI fallback approved",
+            approval_request_id=request_id,
             api_error=api_error,
         )

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -723,22 +723,21 @@ class AwarenessLoop:
                 except Exception:
                     logger.warning("Failed to emit reflection heartbeat", exc_info=True)
 
-            # Post micro reflection to supergroup topic (respect salience gate)
+            # Post micro reflection to supergroup topic
             if ref_result and ref_result.success and ref_result.output and self._topic_manager:
                 micro = ref_result.output
-                if micro.salience >= 0.45 or micro.anomaly:
-                    try:
-                        anomaly_flag = " [ANOMALY]" if micro.anomaly else ""
-                        tags_str = ", ".join(micro.tags[:5]) if micro.tags else ""
-                        text = (
-                            f"<b>Micro Reflection</b>{anomaly_flag}\n\n"
-                            f"{micro.summary}\n\n"
-                            f"<i>Salience: {micro.salience:.2f}"
-                            f"{f' | Tags: {tags_str}' if tags_str else ''}</i>"
-                        )
-                        await self._topic_manager.send_to_category("reflection_micro", text)
-                    except Exception:
-                        logger.warning("Failed to post micro reflection to topic", exc_info=True)
+                try:
+                    anomaly_flag = " [ANOMALY]" if micro.anomaly else ""
+                    tags_str = ", ".join(micro.tags[:5]) if micro.tags else ""
+                    text = (
+                        f"<b>Micro Reflection</b>{anomaly_flag}\n\n"
+                        f"{micro.summary}\n\n"
+                        f"<i>Salience: {micro.salience:.2f}"
+                        f"{f' | Tags: {tags_str}' if tags_str else ''}</i>"
+                    )
+                    await self._topic_manager.send_to_category("reflection_micro", text)
+                except Exception:
+                    logger.warning("Failed to post micro reflection to topic", exc_info=True)
 
             if (ref_result is None or not ref_result.success) and self._deferred_queue:
                 try:


### PR DESCRIPTION
## Summary

- Remove salience gate (>= 0.45) on micro-reflection Telegram delivery — all completed micro-reflections now reach the supergroup topic instead of being silently filtered
- Populate `approval_request_id` on `cli_approved` dispatch decisions so callers can track which approval was consumed (fixes inbox monitor pending-detection at line 759)

Phase 1 of the approval system overhaul (plan: `~/.claude/plans/fizzy-splashing-toast.md`).

## Test plan

- [x] `ruff check` passes on both changed files
- [x] 602 tests pass in `tests/test_awareness/` and `tests/test_autonomy/`
- [ ] Verify next micro-reflection appears in Telegram `reflection_micro` topic
- [ ] Verify no NameError when `approval_required_for_cli=False` path is taken

🤖 Generated with [Claude Code](https://claude.com/claude-code)