### PR TITLE
fix(dashboard): auto-resolve stale update-available banner after successful update

### DIFF
--- a/src/genesis/dashboard/routes/updates.py
+++ b/src/genesis/dashboard/routes/updates.py
@@ -9,6 +9,7 @@ import os
 import sqlite3
 import subprocess
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
 
 from flask import jsonify, request
@@ -66,6 +67,20 @@ def _query_db(sql: str, params: tuple = ()) -> list[dict]:
         return []
 
 
+def _execute_db(sql: str, params: tuple = ()) -> bool:
+    """Run a write query against genesis.db. Returns True on success."""
+    if not _DB_PATH.is_file():
+        return False
+    try:
+        conn = sqlite3.connect(str(_DB_PATH), timeout=5)
+        conn.execute(sql, params)
+        conn.commit()
+        conn.close()
+        return True
+    except (sqlite3.Error, OSError):
+        return False
+
+
 @blueprint.route("/api/genesis/updates/status")
 def update_status():
     """Current version, update availability, and last update result."""
@@ -92,6 +107,21 @@ def update_status():
             }
         except (json.JSONDecodeError, KeyError):
             pass
+
+    # Reconcile: if target_commit is already in HEAD, the update has been
+    # applied but GenesisVersionCollector hasn't run yet — auto-resolve.
+    if (
+        update_available
+        and update_available.get("target_commit")
+        and _git("merge-base", "--is-ancestor", update_available["target_commit"], "HEAD") is not None
+    ):
+        _execute_db(
+            "UPDATE observations SET resolved = 1, resolved_at = ?, "
+            "resolution_notes = 'auto-resolved: target_commit is ancestor of HEAD' "
+            "WHERE type = 'genesis_update_available' AND resolved = 0",
+            (datetime.now(UTC).isoformat(),),
+        )
+        update_available = None
 
     # Last update attempt
     last_update = None

--- a/src/genesis/dashboard/routes/updates.py
+++ b/src/genesis/dashboard/routes/updates.py
@@ -71,14 +71,17 @@ def _execute_db(sql: str, params: tuple = ()) -> bool:
     """Run a write query against genesis.db. Returns True on success."""
     if not _DB_PATH.is_file():
         return False
+    conn = None
     try:
         conn = sqlite3.connect(str(_DB_PATH), timeout=5)
         conn.execute(sql, params)
         conn.commit()
-        conn.close()
         return True
     except (sqlite3.Error, OSError):
         return False
+    finally:
+        if conn:
+            conn.close()
 
 
 @blueprint.route("/api/genesis/updates/status")


### PR DESCRIPTION
## Summary

- After a successful update, the \"Update Available\" banner persisted on the dashboard until the user manually clicked \"Check for Updates\"
- Root cause: `/api/genesis/updates/status` returned stale `update_available` data from an unresolved DB observation; the observation was only resolved by `GenesisVersionCollector` on its next tick (up to 6h later)
- Fix: added inline reconciliation to the status endpoint — if `target_commit` is already an ancestor of HEAD, auto-resolve the observation and return `null`; same pattern already used for `last_update` reconciliation in the same function

## Changes

- `src/genesis/dashboard/routes/updates.py`: added `_execute_db` write helper, `datetime` import, and reconciliation block in `update_status()`; also fixed connection not closed on exception in `_execute_db`

## Test plan

- [ ] `ruff check && pytest` clean (2 pre-existing failures unrelated to this change)
- [ ] After next update completes, confirm banner clears on dashboard refresh without clicking \"Check for Updates\"
- [ ] Synthetic: insert a fake unresolved `genesis_update_available` observation with a `target_commit` already in HEAD, call `GET /api/genesis/updates/status`, confirm `update_available: null` and DB row is `resolved = 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)