### PR TITLE
feat: knowledge dashboard UX overhaul

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -255,6 +255,7 @@ call_sites:
     default_paid: true
   8_ego_compaction:
     chain:
+    - cerebras-qwen
     - mistral-large-free
     - groq-free
     - gemini-free
@@ -264,6 +265,7 @@ call_sites:
     - mistral-large-free
     - groq-free
     - gemini-free
+    - cerebras-qwen
     - openrouter-free
   10_cognitive_state:
     chain:
@@ -279,6 +281,7 @@ call_sites:
     retry_profile: background
   12_surplus_brainstorm:
     chain:
+    - cerebras-qwen
     - gemini-free
     - mistral-large-free
     - groq-free
@@ -406,6 +409,7 @@ call_sites:
     - mistral-large-free
     - groq-free
     - gemini-free
+    - cerebras-qwen
     - openrouter-free
     retry_profile: background
     description: "Knowledge pipeline — distill raw content into structured knowledge units"
@@ -414,11 +418,13 @@ call_sites:
     - mistral-large-free
     - gemini-free
     - groq-free
+    - cerebras-qwen
     - openrouter-free
     retry_profile: background
     description: "Resume review Pass 1 — native LLM structural analysis"
   42_resume_review_pass2:
     chain:
+    - cerebras-qwen
     - mistral-large-free
     - gemini-free
     - groq-free

--- a/src/genesis/dashboard/routes/files.py
+++ b/src/genesis/dashboard/routes/files.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import stat
 from pathlib import Path
 
@@ -35,6 +36,36 @@ _BLOCKED_NAMES = frozenset({
 })
 
 _MAX_FILE_SIZE = 2 * 1024 * 1024  # 2 MB read/write limit
+_MAX_UPLOAD_SIZE = 50 * 1024 * 1024  # 50 MB upload limit
+_UPLOAD_DIR = _HOME / ".genesis" / "uploads"
+
+# Sanitize filenames: allow alphanumeric, dots, hyphens, underscores, spaces.
+_SAFE_FILENAME_RE = re.compile(r"[^a-zA-Z0-9._\- ]")
+_MAX_FILENAME_LEN = 255
+
+
+def _sanitize_filename(name: str) -> str:
+    """Sanitize an uploaded filename to prevent path traversal."""
+    name = Path(name).name
+    name = _SAFE_FILENAME_RE.sub("_", name)
+    name = name.strip(". ")
+    if len(name) > _MAX_FILENAME_LEN:
+        stem = Path(name).stem[: _MAX_FILENAME_LEN - len(Path(name).suffix) - 1]
+        name = stem + Path(name).suffix
+    return name or "unnamed"
+
+
+def _deduplicate_filename(directory: Path, name: str) -> str:
+    """If *name* already exists in *directory*, append -1, -2, etc."""
+    dest = directory / name
+    if not dest.exists():
+        return name
+    stem = Path(name).stem
+    suffix = Path(name).suffix
+    counter = 1
+    while (directory / f"{stem}-{counter}{suffix}").exists():
+        counter += 1
+    return f"{stem}-{counter}{suffix}"
 
 
 def _is_allowed(path: Path) -> bool:
@@ -276,3 +307,46 @@ def file_delete():
         return jsonify({"error": str(exc)}), 500
 
     return jsonify({"status": "ok", "path": str(raw_path)})
+
+
+@blueprint.route("/api/genesis/files/upload", methods=["POST"])
+def file_upload():
+    """Upload a file to ~/.genesis/uploads/ via multipart form.
+
+    No processing or knowledge base involvement — just filesystem storage.
+    """
+    if "file" not in request.files:
+        return jsonify({"error": "No file provided"}), 400
+
+    file = request.files["file"]
+    if not file.filename:
+        return jsonify({"error": "Empty filename"}), 400
+
+    safe_name = _sanitize_filename(file.filename)
+
+    # Ensure uploads directory exists
+    _UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Deduplicate filename
+    safe_name = _deduplicate_filename(_UPLOAD_DIR, safe_name)
+    dest = _UPLOAD_DIR / safe_name
+
+    # Security check
+    if not _is_allowed(dest):
+        return jsonify({"error": "Path not allowed"}), 403
+
+    # Save and check size
+    file.save(str(dest))
+    file_size = dest.stat().st_size
+
+    if file_size > _MAX_UPLOAD_SIZE:
+        dest.unlink()
+        return jsonify({"error": f"File too large (>{_MAX_UPLOAD_SIZE // (1024 * 1024)}MB)"}), 413
+
+    logger.info("File uploaded: %s (%d bytes)", safe_name, file_size)
+
+    return jsonify({
+        "path": str(dest),
+        "filename": safe_name,
+        "size": file_size,
+    })

--- a/src/genesis/dashboard/routes/files.py
+++ b/src/genesis/dashboard/routes/files.py
@@ -322,6 +322,10 @@ def file_upload():
     if not file.filename:
         return jsonify({"error": "Empty filename"}), 400
 
+    # Pre-check content length before saving to disk
+    if request.content_length and request.content_length > _MAX_UPLOAD_SIZE:
+        return jsonify({"error": f"File too large (>{_MAX_UPLOAD_SIZE // (1024 * 1024)}MB)"}), 413
+
     safe_name = _sanitize_filename(file.filename)
 
     # Ensure uploads directory exists
@@ -335,7 +339,7 @@ def file_upload():
     if not _is_allowed(dest):
         return jsonify({"error": "Path not allowed"}), 403
 
-    # Save and check size
+    # Save and verify size (content_length can be spoofed, so double-check)
     file.save(str(dest))
     file_size = dest.stat().st_size
 

--- a/src/genesis/dashboard/routes/knowledge_upload.py
+++ b/src/genesis/dashboard/routes/knowledge_upload.py
@@ -117,6 +117,9 @@ async def knowledge_ingest_upload():
     if not upload_id or not project_type:
         return jsonify({"error": "upload_id and project_type required"}), 400
 
+    if mode not in ("extract", "store"):
+        return jsonify({"error": "mode must be 'extract' or 'store'"}), 400
+
     # Atomic status transition: uploaded -> processing (prevents double-ingestion)
     purpose_list = [p.strip() for p in purpose.split(",")] if purpose else None
     transitioned = await knowledge_uploads.atomic_transition(

--- a/src/genesis/dashboard/routes/knowledge_upload.py
+++ b/src/genesis/dashboard/routes/knowledge_upload.py
@@ -111,6 +111,8 @@ async def knowledge_ingest_upload():
     project_type = data.get("project_type")
     domain = data.get("domain", "auto")
     purpose = data.get("purpose")
+    context = data.get("context", "")  # User-provided document context
+    mode = data.get("mode", "extract")  # "extract" or "store"
 
     if not upload_id or not project_type:
         return jsonify({"error": "upload_id and project_type required"}), 400
@@ -138,13 +140,27 @@ async def knowledge_ingest_upload():
     event_loop = current_app.config.get("GENESIS_EVENT_LOOP")
     if event_loop and event_loop.is_running():
         asyncio.run_coroutine_threadsafe(
-            run_ingest(upload_id, project_type=project_type, domain=domain, purpose=purpose_list),
+            run_ingest(
+                upload_id,
+                project_type=project_type,
+                domain=domain,
+                purpose=purpose_list,
+                context=context,
+                mode=mode,
+            ),
             event_loop,
         )
     else:
         # Fallback: run in current request's event loop (blocks until done)
         logger.warning("Main event loop unavailable — running ingest synchronously")
-        await run_ingest(upload_id, project_type=project_type, domain=domain, purpose=purpose_list)
+        await run_ingest(
+            upload_id,
+            project_type=project_type,
+            domain=domain,
+            purpose=purpose_list,
+            context=context,
+            mode=mode,
+        )
 
     return jsonify({
         "upload_id": upload_id,

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -136,6 +136,7 @@
           sidebarCollapsed: false,
           _resizing: false,
         },
+        fileUpload: { dragging: false, uploading: false, error: null },
 
         // ── Tasks tab state ────────────────────────────────────────
         taskList: [],
@@ -164,11 +165,16 @@
           projectType: "",
           domain: "",
           purpose: "",
+          context: "",
+          mode: "extract",
           error: null,
         },
         knowledgeUploads: [],
         knowledgeTaxonomy: { project_types: [], domains: [] },
         _uploadPollInterval: null,
+
+        // ── Confirm modal state ──────────────────────────────────
+        confirmModal: { show: false, title: '', message: '', _resolve: null },
 
         // ── Backup tab state ──────────────────────────────────────
         backupStatus: null,
@@ -588,6 +594,27 @@
           } catch (e) { alert("Save failed: " + e.message); }
           this.fileBrowser.saving = false;
         },
+        async uploadFile(event) {
+          event.preventDefault();
+          this.fileUpload.dragging = false;
+          this.fileUpload.error = null;
+          const files = event.dataTransfer?.files || event.target?.files;
+          if (!files || files.length === 0) return;
+          this.fileUpload.uploading = true;
+          try {
+            const form = new FormData();
+            form.append("file", files[0]);
+            const resp = await fetchApi("/api/genesis/files/upload", { method: "POST", body: form });
+            if (resp && resp.ok) {
+              const data = await resp.json();
+              this.fetchFiles(data.path.substring(0, data.path.lastIndexOf("/")));
+            } else {
+              const err = resp ? await resp.json() : {};
+              this.fileUpload.error = err.error || "Upload failed";
+            }
+          } catch (e) { this.fileUpload.error = "Upload failed: " + e.message; }
+          this.fileUpload.uploading = false;
+        },
         _startFileBrowserResize(e, sidebar) {
           this.fileBrowser._resizing = true;
           const startX = e.clientX;
@@ -679,7 +706,6 @@
           } catch (e) { console.warn("Memory detail failed:", e); }
         },
         async deleteMemory(memId) {
-          if (!confirm("Delete this memory from all layers?")) return;
           try {
             await fetchApi(`/api/genesis/memory/${memId}`, { method: "DELETE" });
             this.memoryDetail = null;
@@ -724,7 +750,6 @@
           } catch (e) { console.warn("Knowledge detail failed:", e); }
         },
         async deleteKnowledge(unitId) {
-          if (!confirm("Delete this knowledge unit?")) return;
           try {
             await fetchApi(`/api/genesis/knowledge/${unitId}`, { method: "DELETE" });
             this.knowledgeDetail = null;
@@ -783,6 +808,8 @@
                 project_type: u.projectType.trim(),
                 domain: u.domain.trim() || "auto",
                 purpose: u.purpose.trim() || null,
+                context: u.context.trim() || "",
+                mode: u.mode || "extract",
               }),
             });
             if (!resp.ok) {
@@ -800,7 +827,7 @@
           const uploadId = this.knowledgeUpload.uploadId;
           this.knowledgeUpload = {
             dragging: false, file: null, uploading: false, confirm: false,
-            uploadId: null, projectType: "", domain: "", purpose: "", error: null,
+            uploadId: null, projectType: "", domain: "", purpose: "", context: "", mode: "extract", error: null,
           };
           // Clean up server-side file + DB record
           if (uploadId) {
@@ -836,6 +863,17 @@
           if (bytes < 1024) return bytes + " B";
           if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
           return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+        },
+
+        // ── Confirm modal ─────────────────────────────────────
+        showConfirm(title, message) {
+          return new Promise(resolve => {
+            this.confirmModal = { show: true, title, message, _resolve: resolve };
+          });
+        },
+        _confirmModalResolve(result) {
+          if (this.confirmModal._resolve) this.confirmModal._resolve(result);
+          this.confirmModal = { show: false, title: '', message: '', _resolve: null };
         },
 
         // ── Backup tab fetches ───────────────────────────────────
@@ -907,7 +945,7 @@
         },
         async applyUpdate() {
           const msg = "Apply Genesis update?\n\nA background session will:\n\u2022 Back up data\n\u2022 Merge latest code\n\u2022 Resolve trivial conflicts automatically\n\u2022 Run migrations & restart services\n\u2022 Verify health\n\nContinue?";
-          if (!confirm(msg)) return;
+          if (!(await this.showConfirm("Apply Update", msg))) return;
           this._updating = true;
           try {
             await fetchApi("/api/genesis/updates/apply", {
@@ -965,7 +1003,7 @@
           }, 5000);
         },
         async resolveConflicts() {
-          if (!confirm("Spawn an Opus session to resolve deep merge conflicts?\n\nThis may take a few minutes.")) return;
+          if (!(await this.showConfirm("Resolve Conflicts", "Spawn an Opus session to resolve deep merge conflicts?\n\nThis may take a few minutes."))) return;
           this._resolvingConflicts = true;
           try {
             const resp = await fetchApi("/api/genesis/updates/resolve", { method: "POST" });
@@ -1432,7 +1470,7 @@
           const action = newState ? "Pause" : "Resume";
           const pauseMsg = "Pause Genesis?\n\nThis will stop ALL background activity:\n• Reflections\n• Surplus tasks\n• Outreach\n• Inbox monitoring\n\nConversations still work but without background enrichment.\nYou must manually resume via this button or /pause off in Telegram.";
           const resumeMsg = "Resume Genesis?\n\nAll background activity will restart\n(reflections, surplus tasks, outreach, inbox monitoring).";
-          if (!confirm(newState ? pauseMsg : resumeMsg)) return;
+          if (!(await this.showConfirm(action + " Genesis", newState ? pauseMsg : resumeMsg))) return;
           this.pauseState.toggling = true;
           try {
             const resp = await fetchApi("/api/genesis/pause", {
@@ -1450,7 +1488,7 @@
         // Service restarts
         async restartBridge() {
           const label = this.health.services?.bridge?.service_label || "Genesis";
-          if (!confirm(`Restart Genesis ${label}?`)) return;
+          if (!(await this.showConfirm("Restart", `Restart Genesis ${label}?`))) return;
           this._restartingBridge = true;
           try {
             const resp = await fetchApi("/api/genesis/restart/bridge", { method: "POST" });
@@ -1475,7 +1513,7 @@
 
         async restartHostFramework() {
           const name = this.health.services?.host_framework?.name || "host framework";
-          if (!confirm(`Restart ${name}? The dashboard will reload.`)) return;
+          if (!(await this.showConfirm("Restart", `Restart ${name}? The dashboard will reload.`))) return;
           this._restartingHF = true;
           try {
             fetchApi("/api/genesis/restart/host-framework", { method: "POST" });
@@ -1782,7 +1820,7 @@
 
         async deleteConfigFile() {
           if (!this.configModal.deletable) return;
-          if (!confirm(`Delete ${this.configModal.name}? This cannot be undone.`)) return;
+          if (!(await this.showConfirm("Delete File", `Delete ${this.configModal.name}? This cannot be undone.`))) return;
           try {
             const resp = await fetchApi(
               `/api/genesis/config-files/${this.configModal.name.split('/').map(encodeURIComponent).join('/')}`,
@@ -1800,8 +1838,8 @@
           }
         },
 
-        closeConfigModal() {
-          if (this.configModal.dirty && !confirm("You have unsaved changes. Discard?")) return;
+        async closeConfigModal() {
+          if (this.configModal.dirty && !(await this.showConfirm("Discard Changes", "You have unsaved changes. Discard?"))) return;
           if (this._configEditor) { this._configEditor.destroy(); this._configEditor = null; }
           this.configModal.open = false;
           this.configModal.dirty = false;
@@ -6308,6 +6346,19 @@
         File Browser
       </div>
       <div class="panel-body">
+        <!-- File upload drop zone -->
+        <div @dragover.prevent="$store.genesisDashboard.fileUpload.dragging = true"
+             @dragleave.prevent="$store.genesisDashboard.fileUpload.dragging = false"
+             @drop.prevent="$store.genesisDashboard.uploadFile($event)"
+             @click="$refs.fileUploadInput.click()"
+             :style="`border: 1px dashed ${$store.genesisDashboard.fileUpload.dragging ? 'var(--color-accent)' : 'var(--color-border)'}; border-radius: 6px; padding: 0.6rem 1rem; text-align: center; cursor: pointer; margin-bottom: 0.75rem; transition: border-color .2s; background: ${$store.genesisDashboard.fileUpload.dragging ? 'rgba(99,102,241,.06)' : 'transparent'};`">
+          <span style="font-size: .8rem; color: var(--color-text-secondary);"
+                x-text="$store.genesisDashboard.fileUpload.uploading ? 'Uploading...' : 'Drop files here to upload — no processing, just storage'"></span>
+          <input type="file" x-ref="fileUploadInput" style="display:none" @change="$store.genesisDashboard.uploadFile($event)">
+        </div>
+        <template x-if="$store.genesisDashboard.fileUpload.error">
+          <div style="color: var(--color-error-text); font-size: .8rem; margin-bottom: .5rem;" x-text="$store.genesisDashboard.fileUpload.error"></div>
+        </template>
         <!-- Breadcrumb / path bar -->
         <div style="display:flex; gap:0.3rem; align-items:center; margin-bottom:0.75rem; font-size:0.75rem; flex-wrap:wrap;">
           <template x-if="$store.genesisDashboard.fileBrowser.parent">
@@ -6603,7 +6654,7 @@
           <div class="card" style="margin-bottom:1rem; border:1px solid var(--color-accent);">
             <div style="padding:0.75rem; display:flex; justify-content:space-between; align-items:center;">
               <span style="font-size:0.8rem; color:var(--color-accent);" x-text="'ID: ' + $store.genesisDashboard.memoryDetail.memory_id"></span>
-              <div style="display:flex; gap:0.5rem;">
+              <div style="display:flex; gap:0.5rem; justify-content:space-between;">
                 <button @click="$store.genesisDashboard.deleteMemory($store.genesisDashboard.memoryDetail.memory_id)"
                         style="background:rgba(239,154,154,0.2); color:#ef9a9a; border:1px solid rgba(239,154,154,0.3); padding:0.25rem 0.5rem; border-radius:4px; cursor:pointer; font-size:0.75rem;">Delete</button>
                 <button @click="$store.genesisDashboard.memoryDetail = null"
@@ -6668,6 +6719,7 @@
           <span class="material-symbols-outlined" style="font-size: 2rem; color: var(--color-text-secondary);">upload_file</span>
           <div style="margin-top: .5rem; color: var(--color-text-secondary);" x-text="$store.genesisDashboard.knowledgeUpload.uploading ? 'Uploading...' : 'Drop files here or click to browse'"></div>
           <div style="font-size: .8em; color: var(--color-text-secondary); margin-top: .25rem;">PDF, text, audio, video — up to 500 MB</div>
+          <div style="font-size: .7em; color: var(--color-text-secondary); margin-top: .15rem; opacity: .7;">Stores to knowledge base for long-term recall. For simple file sharing, use the Files tab.</div>
           <input type="file" x-ref="knowledgeFileInput" style="display:none"
                  @change="$store.genesisDashboard.handleKnowledgeFileDrop($event)">
         </div>
@@ -6683,6 +6735,26 @@
               <span x-text="$store.genesisDashboard.knowledgeUpload.file?.name"></span>
               (<span x-text="$store.genesisDashboard._formatFileSize($store.genesisDashboard.knowledgeUpload.file?.size)"></span>)
             </div>
+            <!-- Context message -->
+            <div style="margin-bottom: .75rem;">
+              <label style="font-size: .8em; color: var(--color-text-secondary);">Context</label>
+              <textarea x-model="$store.genesisDashboard.knowledgeUpload.context" rows="3"
+                        placeholder="Tell Genesis about this document — what is it, how should it be understood? (optional)"
+                        style="width: 100%; padding: .4rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px; font-size: .85rem; resize: vertical;"></textarea>
+            </div>
+            <!-- Processing mode -->
+            <div style="margin-bottom: .75rem; display: flex; gap: 1rem;">
+              <label style="font-size: .8em; cursor: pointer; display: flex; align-items: center; gap: .3rem;">
+                <input type="radio" value="extract" x-model="$store.genesisDashboard.knowledgeUpload.mode">
+                <span style="color: var(--color-text-secondary);">Extract &amp; distill</span>
+                <span style="font-size: .7em; color: var(--color-text-secondary); opacity: .7;">— AI breaks into searchable concepts</span>
+              </label>
+              <label style="font-size: .8em; cursor: pointer; display: flex; align-items: center; gap: .3rem;">
+                <input type="radio" value="store" x-model="$store.genesisDashboard.knowledgeUpload.mode">
+                <span style="color: var(--color-text-secondary);">Store as-is</span>
+                <span style="font-size: .7em; color: var(--color-text-secondary); opacity: .7;">— full document, one unit, instant</span>
+              </label>
+            </div>
             <div style="display: flex; gap: .5rem; margin-bottom: .75rem;">
               <div style="flex: 1;">
                 <label style="font-size: .8em; color: var(--color-text-secondary);">Project Type *</label>
@@ -6693,6 +6765,7 @@
                     <option :value="pt"></option>
                   </template>
                 </datalist>
+                <div style="font-size: .65em; color: var(--color-text-secondary); margin-top: 2px; opacity: .7;">Workspace scope (e.g., 'genesis', 'career')</div>
               </div>
               <div style="flex: 1;">
                 <label style="font-size: .8em; color: var(--color-text-secondary);">Domain</label>
@@ -6703,12 +6776,14 @@
                     <option :value="d"></option>
                   </template>
                 </datalist>
+                <div style="font-size: .65em; color: var(--color-text-secondary); margin-top: 2px; opacity: .7;">Topic filter. Leave 'auto' for AI detection.</div>
               </div>
             </div>
             <div style="margin-bottom: .75rem;">
               <label style="font-size: .8em; color: var(--color-text-secondary);">Purpose (optional, comma-separated)</label>
               <input type="text" x-model="$store.genesisDashboard.knowledgeUpload.purpose"
                      placeholder="e.g. resume-prep, cloud-eng" style="width: 100%; padding: .4rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
+              <div style="font-size: .65em; color: var(--color-text-secondary); margin-top: 2px; opacity: .7;">Usage tags (e.g., 'planning', 'reference')</div>
             </div>
             <template x-if="$store.genesisDashboard.knowledgeUpload.error">
               <div style="color: var(--color-error-text); margin-bottom: .5rem; font-size: .9em;" x-text="$store.genesisDashboard.knowledgeUpload.error"></div>
@@ -6739,7 +6814,8 @@
               </div>
               <div style="display: flex; align-items: center; gap: .5rem;">
                 <template x-if="upload.status === 'processing'">
-                  <span class="badge" style="background: var(--color-warning-text); color: #000;">processing</span>
+                  <span class="badge" style="background: var(--color-warning-text); color: #000;"
+                        x-text="upload.chunks_total ? 'processing ' + (upload.chunks_done || 0) + '/' + upload.chunks_total : 'processing'"></span>
                 </template>
                 <template x-if="upload.status === 'completed'">
                   <span class="badge" style="background: var(--color-primary); color: #fff;" x-text="'completed (' + (JSON.parse(upload.unit_ids || '[]')).length + ' units)'"></span>
@@ -6883,7 +6959,7 @@
             </template>
             <div style="white-space: pre-wrap; font-family: monospace; font-size: .85em; background: var(--color-background); padding: 1rem; border-radius: 4px; margin: .75rem 0;"
                  x-text="$store.genesisDashboard.knowledgeDetail.body"></div>
-            <div style="display: flex; gap: .5rem; justify-content: flex-end; margin-top: 1rem;">
+            <div style="display: flex; gap: .5rem; justify-content: space-between; margin-top: 1rem;">
               <button class="btn-sm btn-danger" @click="$store.genesisDashboard.deleteKnowledge($store.genesisDashboard.knowledgeDetail.id)">Delete</button>
               <button class="btn-sm" @click="$store.genesisDashboard.knowledgeDetail = null">Close</button>
             </div>
@@ -7132,6 +7208,24 @@
         </template>
       </div>
     </div>
+
+    <!-- ═══════════════════════════════════════════════════════════════
+         Confirm Modal (replaces window.confirm)
+         ═══════════════════════════════════════════════════════════════ -->
+    <template x-if="$store.genesisDashboard.confirmModal.show">
+      <div style="position:fixed; inset:0; z-index:9999; display:flex; align-items:center; justify-content:center; background:rgba(0,0,0,0.6);"
+           @click.self="$store.genesisDashboard._confirmModalResolve(false)">
+        <div style="background:var(--color-bg-secondary); border:1px solid var(--color-border); border-radius:8px; padding:1.5rem; max-width:420px; width:90%; box-shadow:0 8px 32px rgba(0,0,0,0.4);">
+          <h3 style="margin:0 0 0.75rem 0; font-size:1rem;" x-text="$store.genesisDashboard.confirmModal.title"></h3>
+          <p style="color:var(--color-text-secondary); font-size:0.85rem; white-space:pre-line; margin:0 0 1.25rem 0; line-height:1.5;"
+             x-text="$store.genesisDashboard.confirmModal.message"></p>
+          <div style="display:flex; gap:0.5rem; justify-content:flex-end;">
+            <button class="btn-sm" style="opacity:.7;" @click="$store.genesisDashboard._confirmModalResolve(false)">Cancel</button>
+            <button class="btn-sm" style="background:var(--color-accent); color:#fff;" @click="$store.genesisDashboard._confirmModalResolve(true)">Confirm</button>
+          </div>
+        </div>
+      </div>
+    </template>
 
   <!-- Extra bottom padding so content isn't hidden behind the fixed footer -->
   <div style="height: 50px;"></div>

--- a/src/genesis/db/crud/knowledge_uploads.py
+++ b/src/genesis/db/crud/knowledge_uploads.py
@@ -153,6 +153,36 @@ async def atomic_transition(
     return cursor.rowcount > 0
 
 
+async def update_chunk_progress(
+    db: aiosqlite.Connection,
+    upload_id: str,
+    *,
+    chunks_total: int | None = None,
+) -> None:
+    """Increment chunk completion count for a processing upload.
+
+    Called once per chunk from parallel callbacks — uses atomic increment
+    so completion order doesn't matter. Commits immediately; must not be
+    called during a _commit=False batch on the same connection.
+    """
+    if chunks_total is not None:
+        await db.execute(
+            """UPDATE knowledge_uploads
+               SET chunks_done = COALESCE(chunks_done, 0) + 1,
+                   chunks_total = ?
+               WHERE id = ?""",
+            (chunks_total, upload_id),
+        )
+    else:
+        await db.execute(
+            """UPDATE knowledge_uploads
+               SET chunks_done = COALESCE(chunks_done, 0) + 1
+               WHERE id = ?""",
+            (upload_id,),
+        )
+    await db.commit()
+
+
 async def list_processing_before(
     db: aiosqlite.Connection,
     cutoff_iso: str,

--- a/src/genesis/db/crud/knowledge_uploads.py
+++ b/src/genesis/db/crud/knowledge_uploads.py
@@ -153,6 +153,20 @@ async def atomic_transition(
     return cursor.rowcount > 0
 
 
+async def list_processing_before(
+    db: aiosqlite.Connection,
+    cutoff_iso: str,
+) -> list[dict]:
+    """List uploads stuck in 'processing' since before *cutoff_iso*."""
+    cursor = await db.execute(
+        "SELECT * FROM knowledge_uploads WHERE status = 'processing' AND created_at < ?",
+        (cutoff_iso,),
+    )
+    rows = await cursor.fetchall()
+    columns = [desc[0] for desc in cursor.description]
+    return [dict(zip(columns, row, strict=False)) for row in rows]
+
+
 async def delete(db: aiosqlite.Connection, upload_id: str) -> bool:
     """Delete an upload record."""
     cursor = await db.execute(

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -827,6 +827,14 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         )
     """)
 
+    # Knowledge upload chunk progress tracking
+    await _try_alter(db,
+        "ALTER TABLE knowledge_uploads ADD COLUMN chunks_total INTEGER",
+        "knowledge_uploads.chunks_total")
+    await _try_alter(db,
+        "ALTER TABLE knowledge_uploads ADD COLUMN chunks_done INTEGER DEFAULT 0",
+        "knowledge_uploads.chunks_done")
+
     # Approval resume tracking — atomic consumed_at column
     await _try_alter(db,
         "ALTER TABLE approval_requests ADD COLUMN consumed_at TEXT",

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -639,6 +639,8 @@ TABLES = {
                           CHECK (status IN ('uploaded', 'processing', 'completed', 'failed')),
             error_message TEXT,
             unit_ids      TEXT,
+            chunks_total  INTEGER,
+            chunks_done   INTEGER DEFAULT 0,
             created_at    TEXT NOT NULL,
             completed_at  TEXT
         )

--- a/src/genesis/knowledge/distillation.py
+++ b/src/genesis/knowledge/distillation.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import typing
 from dataclasses import dataclass, field
 
 from genesis.knowledge.processors.base import ProcessedContent
@@ -146,7 +147,7 @@ class DistillationPipeline:
         project_type: str,
         domain: str = "auto",
         user_context: str | None = None,
-        on_chunk_done: object | None = None,
+        on_chunk_done: typing.Callable | None = None,
     ) -> list[KnowledgeUnit]:
         """Distill processed content into knowledge units.
 

--- a/src/genesis/knowledge/distillation.py
+++ b/src/genesis/knowledge/distillation.py
@@ -6,6 +6,7 @@ knowledge units suitable for storage in the knowledge base.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from dataclasses import dataclass, field
@@ -18,6 +19,9 @@ _CALL_SITE = "40_knowledge_distillation"
 
 # Max characters per chunk sent to the LLM for distillation
 _MAX_CHUNK_CHARS = 12000
+
+# Max concurrent LLM calls for parallel chunk processing
+_MAX_CONCURRENT_CHUNKS = 4
 
 _DISTILLATION_SYSTEM_PROMPT = """\
 You are a knowledge distillation engine. Your job is to extract structured
@@ -42,6 +46,8 @@ Rules:
 - Skip trivial or redundant content.
 - If the content is poorly structured or unclear, set confidence < 0.5.
 - Return an empty array if there's nothing meaningful to extract.
+- These are machine-extracted summaries, not authoritative facts. Include
+  appropriate caveats noting the source and extraction context.
 
 Output ONLY the JSON array, no markdown fences, no explanation."""
 
@@ -59,6 +65,14 @@ class KnowledgeUnit:
     confidence: float = 0.85
     section_title: str | None = None
     source_date: str | None = None
+
+
+@dataclass
+class ChunkResult:
+    """Result of distilling a single chunk."""
+
+    index: int
+    units: list[KnowledgeUnit]
 
 
 def _chunk_text(text: str, max_chars: int = _MAX_CHUNK_CHARS) -> list[str]:
@@ -131,8 +145,20 @@ class DistillationPipeline:
         *,
         project_type: str,
         domain: str = "auto",
+        user_context: str | None = None,
+        on_chunk_done: object | None = None,
     ) -> list[KnowledgeUnit]:
-        """Distill processed content into knowledge units."""
+        """Distill processed content into knowledge units.
+
+        Args:
+            content: Processed source content.
+            project_type: Project classification for the knowledge.
+            domain: Knowledge domain (or "auto" for LLM detection).
+            user_context: Optional user-provided context about the document
+                (e.g., "This is a proposed plan, not established fact").
+            on_chunk_done: Optional async callback(chunk_index, units) called
+                after each chunk completes. Used for checkpoint progress.
+        """
         if not content.text.strip():
             return []
 
@@ -142,37 +168,78 @@ class DistillationPipeline:
         else:
             chunks = _chunk_text(content.text)
 
-        all_units: list[KnowledgeUnit] = []
+        # Process chunks in parallel with concurrency limit
+        sem = asyncio.Semaphore(_MAX_CONCURRENT_CHUNKS)
 
-        for i, chunk in enumerate(chunks):
-            if not chunk.strip():
-                continue
-
-            raw_units = await self._distill_chunk(chunk, content, project_type, domain)
-
-            for raw in raw_units:
-                confidence = raw.get("confidence", 0.85)
-                if confidence < 0.3:
-                    logger.info("Skipping low-confidence unit: %s (%.2f)",
-                                raw.get("concept", "?")[:60], confidence)
-                    continue
-
-                unit = KnowledgeUnit(
-                    concept=str(raw.get("concept", ""))[:200],
-                    body=str(raw.get("body", "")),
-                    domain=str(raw.get("domain", domain)),
-                    relationships=raw.get("relationships", []) or [],
-                    caveats=raw.get("caveats", []) or [],
-                    tags=raw.get("tags", []) or [],
-                    confidence=confidence,
-                    section_title=f"Section {i + 1}" if len(chunks) > 1 else None,
-                    source_date=content.metadata.get("source_date")
-                    or content.metadata.get("upload_date"),
+        async def _process_one(i: int, chunk: str) -> ChunkResult:
+            async with sem:
+                raw_units = await self._distill_chunk(
+                    chunk, content, project_type, domain, user_context,
                 )
-                all_units.append(unit)
+                units = []
+                for raw in raw_units:
+                    confidence = raw.get("confidence", 0.85)
+                    if confidence < 0.3:
+                        logger.info(
+                            "Skipping low-confidence unit: %s (%.2f)",
+                            raw.get("concept", "?")[:60], confidence,
+                        )
+                        continue
 
-        logger.info("Distilled %d knowledge units from %s (%d chunks)",
-                     len(all_units), content.source_path, len(chunks))
+                    # Include user context in caveats if provided
+                    caveats = raw.get("caveats", []) or []
+                    if user_context:
+                        caveats.append(f"User context: {user_context[:200]}")
+
+                    unit = KnowledgeUnit(
+                        concept=str(raw.get("concept", ""))[:200],
+                        body=str(raw.get("body", "")),
+                        domain=str(raw.get("domain", domain)),
+                        relationships=raw.get("relationships", []) or [],
+                        caveats=caveats,
+                        tags=raw.get("tags", []) or [],
+                        confidence=confidence,
+                        section_title=f"Section {i + 1}" if len(chunks) > 1 else None,
+                        source_date=content.metadata.get("source_date")
+                        or content.metadata.get("upload_date"),
+                    )
+                    units.append(unit)
+
+                result = ChunkResult(index=i, units=units)
+
+                # Notify caller of chunk completion (for checkpointing)
+                if on_chunk_done is not None:
+                    try:
+                        await on_chunk_done(i, units)
+                    except Exception:
+                        logger.warning("on_chunk_done callback failed for chunk %d", i, exc_info=True)
+
+                return result
+
+        tasks = [
+            _process_one(i, chunk)
+            for i, chunk in enumerate(chunks)
+            if chunk.strip()
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Collect units in chunk order
+        all_units: list[KnowledgeUnit] = []
+        for r in sorted(
+            (r for r in results if isinstance(r, ChunkResult)),
+            key=lambda cr: cr.index,
+        ):
+            all_units.extend(r.units)
+
+        # Log any chunk-level exceptions
+        for r in results:
+            if isinstance(r, Exception):
+                logger.warning("Chunk distillation failed: %s", r)
+
+        logger.info(
+            "Distilled %d knowledge units from %s (%d chunks, %d concurrent)",
+            len(all_units), content.source_path, len(chunks), _MAX_CONCURRENT_CHUNKS,
+        )
         return all_units
 
     async def _distill_chunk(
@@ -181,9 +248,15 @@ class DistillationPipeline:
         content: ProcessedContent,
         project_type: str,
         domain: str,
+        user_context: str | None = None,
     ) -> list[dict]:
         """Send a single chunk through the LLM for distillation."""
         context_hint = ""
+
+        # Include user-provided context about the document
+        if user_context:
+            context_hint += f"\nUser context about this document: {user_context}"
+
         if content.metadata.get("title"):
             context_hint += f"\nSource title: {content.metadata['title']}"
         if content.metadata.get("channel"):

--- a/src/genesis/knowledge/distillation.py
+++ b/src/genesis/knowledge/distillation.py
@@ -157,8 +157,8 @@ class DistillationPipeline:
             domain: Knowledge domain (or "auto" for LLM detection).
             user_context: Optional user-provided context about the document
                 (e.g., "This is a proposed plan, not established fact").
-            on_chunk_done: Optional async callback(chunk_index, units) called
-                after each chunk completes. Used for checkpoint progress.
+            on_chunk_done: Optional async callback(chunk_index, total_chunks, units)
+                called after each chunk completes. Used for progress tracking.
         """
         if not content.text.strip():
             return []
@@ -211,7 +211,7 @@ class DistillationPipeline:
                 # Notify caller of chunk completion (for checkpointing)
                 if on_chunk_done is not None:
                     try:
-                        await on_chunk_done(i, units)
+                        await on_chunk_done(i, len(chunks), units)
                     except Exception:
                         logger.warning("on_chunk_done callback failed for chunk %d", i, exc_info=True)
 

--- a/src/genesis/knowledge/ingest_upload.py
+++ b/src/genesis/knowledge/ingest_upload.py
@@ -194,9 +194,22 @@ async def _extract_with_pipeline(
     context: str,
 ) -> list[str]:
     """Run the full extraction pipeline with context injection."""
+    from genesis.db.crud import knowledge_uploads
     from genesis.mcp.memory.knowledge import _get_orchestrator
+    from genesis.runtime import GenesisRuntime
 
+    rt = GenesisRuntime.instance()
     orchestrator = _get_orchestrator()
+
+    async def _on_chunk_done(
+        chunk_index: int, total_chunks: int, units: list,
+    ) -> None:
+        """Update chunk progress in DB after each chunk completes."""
+        if rt.db is not None:
+            await knowledge_uploads.update_chunk_progress(
+                rt.db, upload_id,
+                chunks_total=total_chunks,
+            )
 
     result = await orchestrator.ingest_source(
         file_path,
@@ -204,6 +217,7 @@ async def _extract_with_pipeline(
         domain=domain,
         purpose=purpose,
         user_context=context if context else None,
+        on_chunk_done=_on_chunk_done,
     )
 
     if result.error:

--- a/src/genesis/knowledge/ingest_upload.py
+++ b/src/genesis/knowledge/ingest_upload.py
@@ -3,10 +3,15 @@
 Thin bridge: updates DB status → calls KnowledgeOrchestrator.ingest_source →
 updates DB status with results. Called via run_coroutine_threadsafe from the
 upload route handler.
+
+Supports two modes:
+- "extract": Full distillation pipeline (chunk → LLM → knowledge units)
+- "store": Store file content as a single knowledge unit (no LLM, instant)
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import shutil
 from pathlib import Path
@@ -22,14 +27,15 @@ async def run_ingest(
     project_type: str,
     domain: str = "auto",
     purpose: list[str] | None = None,
+    context: str = "",
+    mode: str = "extract",
 ) -> None:
-    """Run the full ingestion pipeline for an uploaded file.
+    """Run the ingestion pipeline for an uploaded file.
 
     Updates the knowledge_uploads row with results on completion or failure.
     Moves the file to the completed directory on success.
     """
     from genesis.db.crud import knowledge_uploads
-    from genesis.mcp.memory.knowledge import _get_orchestrator
     from genesis.runtime import GenesisRuntime
 
     rt = GenesisRuntime.instance()
@@ -47,22 +53,22 @@ async def run_ingest(
     filename = upload["filename"]
 
     try:
-        orchestrator = _get_orchestrator()
-        result = await orchestrator.ingest_source(
-            file_path,
-            project_type=project_type,
-            domain=domain,
-            purpose=purpose,
-        )
-
-        if result.error:
-            await knowledge_uploads.update_status(
-                rt.db, upload_id,
-                status="failed",
-                error_message=result.error,
+        if mode == "store":
+            unit_ids = await _store_as_is(
+                file_path, filename,
+                project_type=project_type,
+                domain=domain,
+                purpose=purpose,
+                context=context,
             )
-            logger.warning("Ingest failed for %s: %s", filename, result.error)
-            return
+        else:
+            unit_ids = await _extract_with_pipeline(
+                upload_id, file_path,
+                project_type=project_type,
+                domain=domain,
+                purpose=purpose,
+                context=context,
+            )
 
         # Move file to completed directory
         _move_to_completed(file_path, upload_id)
@@ -70,12 +76,12 @@ async def run_ingest(
         await knowledge_uploads.update_status(
             rt.db, upload_id,
             status="completed",
-            unit_ids=result.unit_ids,
+            unit_ids=unit_ids,
         )
 
         logger.info(
-            "Ingest completed for %s: %d units created",
-            filename, result.units_created,
+            "Ingest completed for %s: %d units created (mode=%s)",
+            filename, len(unit_ids), mode,
         )
 
     except Exception:
@@ -88,6 +94,126 @@ async def run_ingest(
             )
         except Exception:
             logger.exception("Failed to update upload status after error")
+
+
+async def _store_as_is(
+    file_path: str,
+    filename: str,
+    *,
+    project_type: str,
+    domain: str,
+    purpose: list[str] | None,
+    context: str,
+) -> list[str]:
+    """Store file content as a single knowledge unit — no LLM, instant."""
+    import uuid
+    from datetime import UTC, datetime
+
+    import genesis.mcp.memory_mcp as memory_mod
+
+    memory_mod._require_init()
+    assert memory_mod._store is not None
+    assert memory_mod._db is not None
+
+    from genesis.db.crud import knowledge as knowledge_crud
+
+    # Read file content
+    path = Path(file_path)
+    file_content = path.read_text(encoding="utf-8", errors="replace")
+
+    # Use context or filename as concept
+    concept = context[:200] if context else filename
+
+    # Determine domain
+    effective_domain = domain if domain != "auto" else "general"
+
+    unit_id = str(uuid.uuid4())
+    now_iso = datetime.now(UTC).isoformat()
+    purpose_json = json.dumps(purpose) if purpose else None
+    embedding_model = getattr(
+        memory_mod._store._embeddings, "model_name", "unknown"
+    )
+
+    # Build tags
+    tags = [effective_domain, project_type, "stored-as-is"]
+    if context:
+        tags.append("user-context")
+
+    # Store to Qdrant
+    qdrant_id = await memory_mod._store.store(
+        file_content,
+        f"knowledge:{project_type}/{effective_domain}",
+        memory_type="knowledge",
+        collection="knowledge_base",
+        tags=tags,
+        confidence=0.95,
+        auto_link=False,
+        source_pipeline="curated",
+    )
+
+    # Store to SQLite
+    await knowledge_crud.insert(
+        memory_mod._db,
+        id=unit_id,
+        project_type=project_type,
+        domain=effective_domain,
+        source_doc=file_path,
+        concept=concept,
+        body=file_content,
+        relationships=None,
+        caveats=json.dumps([f"User context: {context}"]) if context else None,
+        tags=json.dumps(tags),
+        confidence=0.95,
+        ingested_at=now_iso,
+        qdrant_id=qdrant_id,
+        section_title=None,
+        source_date=None,
+        embedding_model=embedding_model,
+        source_pipeline="curated",
+        purpose=purpose_json,
+        ingestion_source=file_path,
+        _commit=True,
+    )
+
+    logger.info("Stored %s as single unit %s (store-as-is mode)", filename, unit_id)
+    return [unit_id]
+
+
+async def _extract_with_pipeline(
+    upload_id: str,
+    file_path: str,
+    *,
+    project_type: str,
+    domain: str,
+    purpose: list[str] | None,
+    context: str,
+) -> list[str]:
+    """Run the full extraction pipeline with context injection."""
+    from genesis.db.crud import knowledge_uploads
+    from genesis.mcp.memory.knowledge import _get_orchestrator
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+
+    orchestrator = _get_orchestrator()
+
+    result = await orchestrator.ingest_source(
+        file_path,
+        project_type=project_type,
+        domain=domain,
+        purpose=purpose,
+        user_context=context if context else None,
+    )
+
+    if result.error:
+        await knowledge_uploads.update_status(
+            rt.db, upload_id,
+            status="failed",
+            error_message=result.error,
+        )
+        raise RuntimeError(f"Extraction failed: {result.error}")
+
+    return result.unit_ids
 
 
 def _move_to_completed(file_path: str, upload_id: str) -> str:
@@ -107,3 +233,39 @@ def _move_to_completed(file_path: str, upload_id: str) -> str:
         inbox_dir.rmdir()
 
     return str(dest)
+
+
+async def recover_stale_processing() -> int:
+    """Mark uploads stuck in 'processing' as failed.
+
+    Called on server startup to recover from crashes during extraction.
+    Returns the number of recovered uploads.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from genesis.db.crud import knowledge_uploads
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if rt.db is None:
+        return 0
+
+    stale_cutoff = (datetime.now(UTC) - timedelta(minutes=30)).isoformat()
+    stale = await knowledge_uploads.list_processing_before(rt.db, stale_cutoff)
+
+    count = 0
+    for upload in stale:
+        await knowledge_uploads.update_status(
+            rt.db, upload["id"],
+            status="failed",
+            error_message="Interrupted by server restart",
+        )
+        logger.warning(
+            "Recovered stale upload %s (%s) — marked as failed",
+            upload["id"], upload.get("filename", "?"),
+        )
+        count += 1
+
+    if count:
+        logger.info("Recovered %d stale processing uploads", count)
+    return count

--- a/src/genesis/knowledge/ingest_upload.py
+++ b/src/genesis/knowledge/ingest_upload.py
@@ -84,13 +84,13 @@ async def run_ingest(
             filename, len(unit_ids), mode,
         )
 
-    except Exception:
+    except Exception as exc:
         logger.exception("Ingest worker failed for upload %s", upload_id)
         try:
             await knowledge_uploads.update_status(
                 rt.db, upload_id,
                 status="failed",
-                error_message="Internal error during ingestion",
+                error_message=str(exc) or "Internal error during ingestion",
             )
         except Exception:
             logger.exception("Failed to update upload status after error")
@@ -117,8 +117,13 @@ async def _store_as_is(
 
     from genesis.db.crud import knowledge as knowledge_crud
 
-    # Read file content
+    # Read file content (cap at 2MB for single-unit storage)
     path = Path(file_path)
+    if path.stat().st_size > 2 * 1024 * 1024:
+        raise RuntimeError(
+            "File too large for store-as-is mode (>2MB). "
+            "Use 'Extract & distill' for large documents."
+        )
     file_content = path.read_text(encoding="utf-8", errors="replace")
 
     # Use context or filename as concept
@@ -189,11 +194,7 @@ async def _extract_with_pipeline(
     context: str,
 ) -> list[str]:
     """Run the full extraction pipeline with context injection."""
-    from genesis.db.crud import knowledge_uploads
     from genesis.mcp.memory.knowledge import _get_orchestrator
-    from genesis.runtime import GenesisRuntime
-
-    rt = GenesisRuntime.instance()
 
     orchestrator = _get_orchestrator()
 
@@ -206,12 +207,7 @@ async def _extract_with_pipeline(
     )
 
     if result.error:
-        await knowledge_uploads.update_status(
-            rt.db, upload_id,
-            status="failed",
-            error_message=result.error,
-        )
-        raise RuntimeError(f"Extraction failed: {result.error}")
+        raise RuntimeError(result.error)
 
     return result.unit_ids
 

--- a/src/genesis/knowledge/ingest_upload.py
+++ b/src/genesis/knowledge/ingest_upload.py
@@ -90,7 +90,7 @@ async def run_ingest(
             await knowledge_uploads.update_status(
                 rt.db, upload_id,
                 status="failed",
-                error_message=str(exc) or "Internal error during ingestion",
+                error_message=f"Internal error during ingestion: {exc}",
             )
         except Exception:
             logger.exception("Failed to update upload status after error")

--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -52,6 +52,7 @@ class KnowledgeOrchestrator:
         project_type: str,
         domain: str = "auto",
         purpose: list[str] | None = None,
+        user_context: str | None = None,
     ) -> IngestResult:
         """Ingest a single source (file path or URL) into the knowledge base."""
         # 1. Check for duplicate
@@ -107,7 +108,8 @@ class KnowledgeOrchestrator:
 
         # 6. Distill
         units = await self._distillation.distill(
-            content, project_type=project_type, domain=domain
+            content, project_type=project_type, domain=domain,
+            user_context=user_context,
         )
 
         if not units:

--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import typing
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -53,6 +54,7 @@ class KnowledgeOrchestrator:
         domain: str = "auto",
         purpose: list[str] | None = None,
         user_context: str | None = None,
+        on_chunk_done: typing.Callable | None = None,
     ) -> IngestResult:
         """Ingest a single source (file path or URL) into the knowledge base."""
         # 1. Check for duplicate
@@ -110,6 +112,7 @@ class KnowledgeOrchestrator:
         units = await self._distillation.distill(
             content, project_type=project_type, domain=domain,
             user_context=user_context,
+            on_chunk_done=on_chunk_done,
         )
 
         if not units:

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -333,6 +333,16 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
 
         await self._run_init_step_async("memory", self._init_memory)
 
+        # Recover knowledge uploads stuck in 'processing' from prior crash
+        if self._db is not None:
+            try:
+                from genesis.knowledge.ingest_upload import recover_stale_processing
+                recovered = await recover_stale_processing()
+                if recovered:
+                    logger.info("Recovered %d stale knowledge uploads", recovered)
+            except Exception:
+                logger.warning("Knowledge upload recovery failed", exc_info=True)
+
         if _full:
             await self._run_init_step_async("pipeline", self._init_pipeline)
 

--- a/tests/test_knowledge/test_ingest_upload.py
+++ b/tests/test_knowledge/test_ingest_upload.py
@@ -79,7 +79,7 @@ async def test_run_ingest_failure(db, upload_id):
 
     row = await knowledge_uploads.get(db, upload_id)
     assert row["status"] == "failed"
-    assert row["error_message"] == "Bad file"
+    assert "Bad file" in row["error_message"]
 
 
 async def test_run_ingest_exception(db, upload_id):

--- a/tests/test_routing/test_integration.py
+++ b/tests/test_routing/test_integration.py
@@ -77,6 +77,7 @@ async def test_full_stack_fallback_chain(real_config, breakers, cost_tracker, de
 async def test_surplus_never_pays(real_config, breakers, cost_tracker, degradation):
     """12_surplus_brainstorm has never_pays — all free fail, no paid providers called."""
     delegate = MockDelegate(responses={
+        "cerebras-qwen": CallResult(success=False, error="down", status_code=503),
         "mistral-large-free": CallResult(success=False, error="down", status_code=503),
         "groq-free": CallResult(success=False, error="down", status_code=503),
         "gemini-free": CallResult(success=False, error="down", status_code=503),


### PR DESCRIPTION
## Summary
- Replace all 9 `window.confirm()` calls with in-page confirm modal (immune to browser dialog blocking)
- Add Files tab drag-drop upload for simple file sharing (no knowledge base, no processing)
- Add Knowledge tab context message + processing mode toggle (extract vs store-as-is)
- Parallel distillation pipeline (4x concurrent chunks via semaphore)
- Softer extraction epistemology — units include uncertainty caveats
- Add field help text and guidance distinguishing Knowledge vs Files tab
- Promote cerebras-qwen to 6 call site chains (3 as primary, 3 as fallback)
- Crash recovery function for stuck processing uploads
- Fix delete/close button layout (spatial separation, no confirmation for low-risk deletes)
- Clean up 21 orphaned plan units from accidental ingestion

## Test plan
- [ ] Files tab: drop file → appears in `~/.genesis/uploads/` → browsable
- [ ] Knowledge store-as-is: upload → <1s → 1 unit → full content preserved
- [ ] Knowledge extract with context: upload + context message → units reflect framing
- [ ] Parallel processing: verify 4 concurrent chunks via logs
- [ ] Confirm modal: pause/restart Genesis → in-page modal appears (not browser dialog)
- [ ] Delete buttons: Delete far-left, Close far-right, no confirmation
- [ ] Cerebras routing: cerebras-qwen appears in 6 call site chains
- [ ] Blocked dialogs: block site notifications → all dashboard actions still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)