### PR TITLE
fix(surplus): add Telegram delivery for surplus reflections

### DIFF
--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -736,8 +736,14 @@ class AwarenessLoop:
                         f"{f' | Tags: {tags_str}' if tags_str else ''}</i>"
                     )
                     await self._topic_manager.send_to_category("reflection_micro", text)
+                    logger.info(
+                        "Posted micro reflection to Telegram (tick=%s, salience=%.2f)",
+                        tick_id[:8], micro.salience,
+                    )
                 except Exception:
                     logger.warning("Failed to post micro reflection to topic", exc_info=True)
+            elif ref_result and ref_result.success and ref_result.output and not self._topic_manager:
+                logger.warning("Micro reflection completed but topic_manager not set")
 
             if (ref_result is None or not ref_result.success) and self._deferred_queue:
                 try:

--- a/src/genesis/channels/bridge.py
+++ b/src/genesis/channels/bridge.py
@@ -261,6 +261,10 @@ async def main():
         if runtime.awareness_loop:
             runtime.awareness_loop.set_topic_manager(topic_manager)
 
+        # Wire into surplus scheduler for surplus reflection posting
+        if runtime.surplus_scheduler:
+            runtime.surplus_scheduler.set_topic_manager(topic_manager)
+
         # One-shot: close orphaned per-session topics from old code (March 24-27).
         # Checks DB for a sentinel category to avoid re-running on every restart.
         if topic_manager.get_thread_id("_orphan_cleanup_done") is None:

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -469,6 +469,8 @@ class StandaloneAdapter:
                     rt.outreach_pipeline.set_forum_chat_id(config["forum_chat_id"])
                 if rt.awareness_loop:
                     rt.awareness_loop.set_topic_manager(topic_manager)
+                if rt.surplus_scheduler:
+                    rt.surplus_scheduler.set_topic_manager(topic_manager)
 
                 logger.info(
                     "Forum topics enabled (chat_id=%s) — %d categories",

--- a/src/genesis/surplus/executor.py
+++ b/src/genesis/surplus/executor.py
@@ -129,6 +129,11 @@ class ReflectionBasedSurplusExecutor:
     def __init__(self, engine: ReflectionEngine, *, db: aiosqlite.Connection) -> None:
         self._engine = engine
         self._db = db
+        self._topic_manager = None
+
+    def set_topic_manager(self, manager) -> None:
+        """Set TopicManager for posting surplus reflections to Telegram."""
+        self._topic_manager = manager
 
     async def execute(self, task: SurplusTask) -> ExecutorResult:
         depth = _DEPTH_MAP.get(task.task_type, Depth.LIGHT)
@@ -174,6 +179,10 @@ class ReflectionBasedSurplusExecutor:
         if not result.success:
             return ExecutorResult(success=False, error=result.reason)
 
+        # Post to Telegram topic (mirrors awareness loop delivery path)
+        if result.output and self._topic_manager:
+            await self._post_to_telegram(result.output, depth, task)
+
         content = _extract_content(result)
         confidence = getattr(result.output, "confidence", 0.5) if result.output else 0.3
         model = "reflection_engine"
@@ -194,3 +203,47 @@ class ReflectionBasedSurplusExecutor:
                 logger.warning("Failed to mark prior findings as influenced", exc_info=True)
 
         return ExecutorResult(success=True, content=content, insights=insights)
+
+    async def _post_to_telegram(self, output, depth: Depth, task: SurplusTask) -> None:
+        """Format and send reflection output to the appropriate Telegram topic."""
+        try:
+            from html import escape
+
+            from genesis.perception.types import LightOutput, MicroOutput
+
+            if isinstance(output, MicroOutput):
+                anomaly_flag = " [ANOMALY]" if output.anomaly else ""
+                tags_str = ", ".join(output.tags[:5]) if output.tags else ""
+                summary = escape(output.summary)
+                text = (
+                    f"<b>Micro Reflection</b> [surplus]{anomaly_flag}\n\n"
+                    f"{summary}\n\n"
+                    f"<i>Salience: {output.salience:.2f}"
+                    f"{f' | Tags: {tags_str}' if tags_str else ''}</i>"
+                )
+                category = "reflection_micro"
+
+            elif isinstance(output, LightOutput):
+                assessment = escape(output.assessment[:2000])
+                recs = ""
+                if output.recommendations:
+                    items = [escape(r if isinstance(r, str) else str(r)) for r in output.recommendations]
+                    recs = "\n\n<b>Recommendations:</b>\n" + "\n".join(f"• {r}" for r in items)
+                text = (
+                    f"<b>Light Reflection</b> [surplus]\n\n"
+                    f"{assessment}{recs}\n\n"
+                    f"<i>Focus: {escape(output.focus_area)} | "
+                    f"Confidence: {output.confidence:.2f}</i>"
+                )
+                category = "reflection_light"
+
+            else:
+                return
+
+            await self._topic_manager.send_to_category(category, text)
+            logger.info(
+                "Posted surplus %s reflection to Telegram (task=%s)",
+                depth.value, task.task_type,
+            )
+        except Exception:
+            logger.warning("Failed to post surplus reflection to Telegram", exc_info=True)

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -92,12 +92,22 @@ class SurplusScheduler:
         self._extraction_store: MemoryStore | None = None
         self._extraction_router: Router | None = None
         self._follow_up_dispatcher = None  # Set via set_follow_up_dispatcher()
+        self._topic_manager = None
         self._scheduler = AsyncIOScheduler()
+
+    def set_topic_manager(self, manager) -> None:
+        """Set TopicManager for routing surplus reflections to Telegram topics."""
+        self._topic_manager = manager
+        if hasattr(self._executor, "set_topic_manager"):
+            self._executor.set_topic_manager(manager)
 
     def set_executor(self, executor) -> None:
         """Replace the current executor (e.g., swap StubExecutor for a real one)."""
         self._executor = executor
         self._brainstorm_runner._executor = executor
+        # Propagate topic_manager to the new executor
+        if self._topic_manager and hasattr(executor, "set_topic_manager"):
+            executor.set_topic_manager(self._topic_manager)
 
     def set_code_audit_executor(self, executor) -> None:
         """Set a dedicated executor for CODE_AUDIT tasks."""


### PR DESCRIPTION
## Summary

- Surplus micro/light reflections were silently lost — `ReflectionBasedSurplusExecutor` calls `ReflectionEngine.reflect()` directly, bypassing the awareness loop's Telegram delivery. This was the primary cause of missing micro-reflections since April 18 (~60% of all micro-reflections come from surplus).
- Adds `topic_manager` to the surplus executor with a `_post_to_telegram()` method that formats and sends to the correct topic category
- Wires `topic_manager` through `SurplusScheduler` with propagation via `set_executor()` to handle init ordering
- Adds `[surplus]` tag and HTML escaping for LLM content
- Adds diagnostic logging to the awareness loop's normal micro-reflection delivery path

## Test plan

- [x] `ruff check .` passes
- [x] `pytest` — 1460 passed, 0 new failures (1 pre-existing dashboard test failure unrelated)
- [x] Code review passed (HTML escaping recommendation addressed)
- [ ] After merge + server restart: verify surplus micro-reflections appear in Telegram `reflection_micro` topic with `[surplus]` tag
- [ ] Check logs for `"Posted surplus Micro reflection to Telegram"` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)