### PR TITLE
feat(browser): collaborative mode + fix broken executable_path

### DIFF
--- a/scripts/browser.py
+++ b/scripts/browser.py
@@ -30,7 +30,6 @@ def _launch(pw):
     context = pw.chromium.launch_persistent_context(
         user_data_dir=str(USER_DATA_DIR),
         headless=True,
-        executable_path="/usr/bin/google-chrome",
         args=["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
     )
     page = context.pages[0] if context.pages else context.new_page()

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -35,6 +35,7 @@ _active_page = None  # Tracks whichever page was last navigated (standard or ste
 # Collaborative mode — when True, browser launches headed on virtual display :99.
 # User watches/interacts via noVNC at http://<tailscale-ip>:6080/vnc.html
 _collaborate_mode = False
+_original_display: str | None = None  # Saved DISPLAY before collaborate override
 
 _SCREENSHOT_DIR = Path.home() / "tmp"
 _VNC_DISPLAY = ":99"
@@ -82,9 +83,15 @@ async def _ensure_browser():
 
     _PROFILE_DIR.mkdir(parents=True, exist_ok=True)
 
+    global _original_display
     headed = _collaborate_mode
     if headed:
+        _original_display = os.environ.get("DISPLAY")
         os.environ["DISPLAY"] = _VNC_DISPLAY
+    elif _original_display is not None:
+        os.environ["DISPLAY"] = _original_display
+    elif "DISPLAY" in os.environ:
+        del os.environ["DISPLAY"]
 
     _playwright = await async_playwright().start()
     _context = await _playwright.chromium.launch_persistent_context(
@@ -378,6 +385,15 @@ async def browser_collaborate(enable: bool = True) -> dict:
     _collaborate_mode = enable
     await async_cleanup()  # Force browser restart on next tool call
 
+    if enable and not Path(f"/tmp/.X{_VNC_DISPLAY[1:]}-lock").exists():
+        return {
+            "mode": "collaborate",
+            "changed": True,
+            "vnc_url": None,
+            "warning": f"Virtual display {_VNC_DISPLAY} not running. "
+            "Start with: systemctl --user start genesis-xvfb genesis-vnc genesis-novnc",
+        }
+
     return {
         "mode": "collaborate" if enable else "headless",
         "changed": True,
@@ -395,7 +411,7 @@ def _get_vnc_url() -> str:
             ["tailscale", "ip", "-4"],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=2,
         )
         if result.returncode == 0 and result.stdout.strip():
             ip = result.stdout.strip().split("\n")[0]

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -14,6 +14,7 @@ of raw DOM or screenshots by default.
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 
 from genesis.mcp.health import mcp
@@ -31,7 +32,12 @@ _stealth_browser = None
 _stealth_page = None
 _active_page = None  # Tracks whichever page was last navigated (standard or stealth)
 
+# Collaborative mode — when True, browser launches headed on virtual display :99.
+# User watches/interacts via noVNC at http://<tailscale-ip>:6080/vnc.html
+_collaborate_mode = False
+
 _SCREENSHOT_DIR = Path.home() / "tmp"
+_VNC_DISPLAY = ":99"
 
 
 async def async_cleanup():
@@ -65,6 +71,7 @@ async def _ensure_browser():
     """Lazily initialize the Playwright browser with persistent profile.
 
     Returns the active page. Raises ImportError if playwright is not installed.
+    In collaborate mode, launches headed on virtual display :99 for VNC sharing.
     """
     global _playwright, _context, _page
 
@@ -75,15 +82,21 @@ async def _ensure_browser():
 
     _PROFILE_DIR.mkdir(parents=True, exist_ok=True)
 
+    headed = _collaborate_mode
+    if headed:
+        os.environ["DISPLAY"] = _VNC_DISPLAY
+
     _playwright = await async_playwright().start()
     _context = await _playwright.chromium.launch_persistent_context(
         user_data_dir=str(_PROFILE_DIR),
-        headless=True,
-        executable_path="/usr/bin/google-chrome",
-        args=["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
+        headless=not headed,
+        args=["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"]
+        + (["--start-maximized"] if headed else []),
+        viewport={"width": 1920, "height": 1080} if headed else None,
     )
     _page = _context.pages[0] if _context.pages else await _context.new_page()
-    logger.info("Browser launched with persistent profile at %s", _PROFILE_DIR)
+    mode_str = "headed (collaborate)" if headed else "headless"
+    logger.info("Browser launched %s with persistent profile at %s", mode_str, _PROFILE_DIR)
     return _page
 
 
@@ -340,3 +353,53 @@ async def browser_clear_domain(domain: str) -> dict:
     Example: browser_clear_domain('github.com')
     """
     return await _impl_browser_clear_domain(domain)
+
+
+@mcp.tool()
+async def browser_collaborate(enable: bool = True) -> dict:
+    """Toggle collaborative browser mode (headed + VNC).
+
+    When enabled, the browser runs visibly on a virtual display.
+    The user can watch and interact via noVNC in their browser.
+    Useful for tasks requiring human input (captchas, payments, 2FA).
+
+    When disabled, reverts to headless mode for faster automation.
+    Toggling restarts the browser — existing page state is lost.
+    """
+    global _collaborate_mode
+
+    if _collaborate_mode == enable:
+        return {
+            "mode": "collaborate" if enable else "headless",
+            "changed": False,
+            "vnc_url": _get_vnc_url() if enable else None,
+        }
+
+    _collaborate_mode = enable
+    await async_cleanup()  # Force browser restart on next tool call
+
+    return {
+        "mode": "collaborate" if enable else "headless",
+        "changed": True,
+        "vnc_url": _get_vnc_url() if enable else None,
+        "note": "Browser will relaunch in new mode on next navigation.",
+    }
+
+
+def _get_vnc_url() -> str:
+    """Derive the noVNC URL from Tailscale IP or fall back to localhost."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["tailscale", "ip", "-4"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            ip = result.stdout.strip().split("\n")[0]
+            return f"http://{ip}:6080/vnc.html"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return "http://localhost:6080/vnc.html"

--- a/src/genesis/skills/browser-automation/SKILL.md
+++ b/src/genesis/skills/browser-automation/SKILL.md
@@ -39,6 +39,11 @@ that can accomplish the task. **Token cost increases with each layer.**
   Separate profile at `~/.genesis/camoufox-profile/`.
 - **Agent-owned accounts**: log into accounts created FOR the agent, never the
   user's personal accounts. Treat the agent like a new employee.
+- **Collaborate mode**: `browser_collaborate(enable=True)` switches to headed
+  mode on a virtual display. The user watches and interacts via noVNC in their
+  browser (URL returned by the tool). Use for tasks requiring human input:
+  captchas, payments, 2FA, OAuth flows. Genesis drives automation; user takes
+  VNC control when needed. Toggling mode restarts the browser.
 
 ### Layer 3: On-Demand MCP (heavy sessions — activate when needed)
 - Tools: Chrome DevTools MCP (29 tools) or Playwright MCP
@@ -59,6 +64,7 @@ that can accomplish the task. **Token cost increases with each layer.**
 | Search the web | Fetch | API-based, fast |
 | Fill a form on agent's account | Genesis Browser | Persistent login |
 | Site blocks automation | Genesis Browser (stealth) | Anti-detection |
+| CAPTCHA / payment / 2FA step | Genesis Browser (collaborate) | User takes VNC control |
 | Network inspection / Lighthouse | On-Demand MCP | Chrome DevTools |
 | Check user's Gmail | On-Demand MCP (remote) | CDP-over-SSH |
 | Take action in user's banking app | On-Demand MCP (remote) | MUST confirm |
@@ -111,7 +117,7 @@ button:has-text("Add to Cart")
 | Element not found | 1. Try alternative selector 2. Try visible text 3. Scroll page 4. Wait for dynamic load |
 | Page timeout | 1. Retry navigation 2. Check if URL redirected 3. Verify network connectivity |
 | Login required | Inform user. Ask for credentials. Never guess passwords. |
-| CAPTCHA | Cannot solve. Inform user. Suggest manual completion. |
+| CAPTCHA | Switch to collaborate mode. User solves via VNC. Resume automation after. |
 | Pop-up / modal | Click dismiss/close button. Look for `[aria-label="Close"]` or `.modal-close` |
 | Cookie consent | Click "Accept" or dismiss. Look for `#cookie-accept` or text="Accept All" |
 | Rate limited | Wait 30 seconds. Retry once. If still limited, back off exponentially. |
@@ -179,7 +185,7 @@ result: <task outcome description>
 
 - Genesis browser MCP tools: `browser_navigate`, `browser_click`, `browser_fill`,
   `browser_screenshot`, `browser_snapshot`, `browser_run_js`, `browser_sessions`,
-  `browser_clear_domain` (via genesis-health MCP)
+  `browser_clear_domain`, `browser_collaborate` (via genesis-health MCP)
 - `src/genesis/mcp/health/browser.py` — MCP tool implementations
 - `src/genesis/browser/profile.py` — BrowserProfileManager (cookie DB, sessions)
 - `scripts/browser.py` — Standalone CLI (opens/closes per command, for one-off use)


### PR DESCRIPTION
## Summary

- **Bug fix**: Remove non-existent `/usr/bin/google-chrome` executable_path from browser.py and scripts/browser.py — Playwright now uses its bundled Chromium (which actually exists)
- **Feature**: Add `browser_collaborate` MCP tool that toggles between headless and headed mode on virtual display :99, enabling shared browser control via noVNC
- **Docs**: Update browser-automation skill doc with collaborate mode, VNC workflow, updated layer table

## How it works

1. User calls `browser_collaborate(enable=True)` 
2. Browser relaunches headed on Xvfb virtual display :99
3. Tool returns noVNC URL (derived from Tailscale IP dynamically)
4. User opens URL in their browser — watches Genesis automate
5. User takes VNC control for captchas/payments/2FA
6. Genesis resumes automation after user is done

## Infrastructure (local, not in PR)

- Xvfb, x11vnc, noVNC/websockify installed and running as systemd user units
- VNC password-protected, exposed only via Tailscale (not internet-accessible)
- Services: genesis-xvfb, genesis-vnc, genesis-novnc

## Test plan

- [x] Verified /usr/bin/google-chrome doesn't exist (confirmed bug)
- [x] Verified Playwright launches without executable_path (uses bundled chromium)
- [x] Verified headed mode works on Xvfb :99
- [x] Verified full VNC stack (x11vnc + websockify + noVNC) — ports 5900/6080 listening
- [x] End-to-end test: collaborate on → navigate → screenshot → collaborate off → navigate headless
- [x] DISPLAY env var properly saved/restored on mode toggle
- [x] Xvfb lock file check returns helpful error when display not available
- [x] VNC URL correctly derives from tailscale ip -4
- [x] scripts/browser.py CLI works after fix
- [x] All 273 browser + MCP tests pass
- [x] Full lint passes (ruff check)
- [x] Code review completed (3 findings addressed in commit 87cdca1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)