### PR TITLE
feat(observability): file modification audit trail

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -167,6 +167,16 @@
         ]
       },
       {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook file_modification_audit_hook.py",
+            "timeout": 500
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -143,22 +143,18 @@ gotcha has changed, flag to user before acting on stale assumptions.
 
 ## Public Repo & Release Workflow
 
-Genesis uses a dual-repo model. The public repo (`GENesis-AGI`) is
-primary. Key differences from a standard single-repo workflow:
+The public repo (`GENesis-AGI`) is the primary development repo.
+Standard open-source workflow: PRs go directly to the public repo.
 
 - **Squash merges only** — merge commits are disabled on the public repo.
   Always `git pull --rebase origin main` after merging a PR before
   committing locally, or push will be rejected (non-fast-forward).
-- **Release pipeline** — `prepare-public-release.sh` strips user-specific
-  content (IPs, voice data, research profiles), then
-  `push-public-release.sh --version vX.Y` creates a PR on the public
-  repo. Merge the PR, then create the GitHub release with `gh release
-  create`. The release script has safety gates (voice data, secret scan,
-  portability scan) — fix failures, don't bypass them.
 - **README is public-authoritative** — the public repo's `README.md` is
-  hand-crafted and must NEVER be overwritten by the private repo version.
-  The release script preserves it automatically.
+  hand-crafted and must NEVER be overwritten.
 - **CHANGELOG audience is users** — only include entries a user updating
   their install would care about. No internal refactors, README changes,
   CI tweaks, or process artifacts. Lead with the user-visible effect, not
   the implementation technique.
+- **No sensitive data in commits** — voice data, research profiles, IPs,
+  and secrets must never enter the repo. User data lives in overlays
+  outside the repo (e.g., `~/.claude/skills/*/`, `~/.genesis/`).

--- a/scripts/file_modification_audit_hook.py
+++ b/scripts/file_modification_audit_hook.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: audit trail for file modifications.
+
+Records Write and Edit tool uses to the file_modifications table in
+genesis.db, enabling fast diagnosis of "what session modified this file?"
+
+Fires on Write|Edit tool completions. Reads stdin JSON per the
+PostToolUse contract. Uses sync sqlite3 (not aiosqlite) since hooks
+run as standalone processes outside the async runtime.
+
+Zero tokens — pure shell/DB operation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+# genesis.db location — same as genesis.env.genesis_db_path()
+_DB_PATH = Path.home() / "genesis" / "data" / "genesis.db"
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return
+        data = json.loads(raw)
+        _process(data)
+    except Exception:
+        # Hooks must never crash
+        return
+
+
+def _process(data: dict) -> None:
+    session_id = data.get("session_id", "")
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input") or {}
+
+    if not isinstance(tool_input, dict):
+        return
+
+    file_path = tool_input.get("file_path")
+    if not file_path:
+        return
+
+    # Determine action
+    if tool_name == "Write":
+        action = "write"
+    elif tool_name == "Edit":
+        action = "edit"
+    else:
+        return
+
+    # Compute hash of file after modification (if it exists)
+    file_hash = None
+    try:
+        p = Path(file_path)
+        if p.exists() and p.is_file():
+            file_hash = hashlib.sha256(p.read_bytes()).hexdigest()[:16]
+    except (OSError, PermissionError):
+        pass
+
+    # Insert into DB (sync sqlite3)
+    if not _DB_PATH.exists():
+        return
+
+    try:
+        conn = sqlite3.connect(str(_DB_PATH), timeout=2)
+        conn.execute(
+            """INSERT INTO file_modifications
+               (session_id, file_path, action, tool_name, file_hash, timestamp)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                session_id or None,
+                file_path,
+                action,
+                tool_name,
+                file_hash,
+                datetime.now(UTC).isoformat(),
+            ),
+        )
+        conn.commit()
+        conn.close()
+    except sqlite3.OperationalError:
+        # Table might not exist yet (pre-migration). Silent fail.
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/genesis/db/crud/file_modifications.py
+++ b/src/genesis/db/crud/file_modifications.py
@@ -1,0 +1,87 @@
+"""CRUD operations for the file_modifications audit trail.
+
+Records which CC sessions modify which files, enabling fast diagnosis of
+unexpected file changes ("what session touched this file?").
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+async def record(
+    db: aiosqlite.Connection,
+    *,
+    session_id: str | None,
+    file_path: str,
+    action: str,
+    tool_name: str | None = None,
+    file_hash: str | None = None,
+    timestamp: str | None = None,
+) -> int:
+    """Insert a file modification record. Returns the row id."""
+    ts = timestamp or datetime.now(UTC).isoformat()
+    cursor = await db.execute(
+        """INSERT INTO file_modifications
+           (session_id, file_path, action, tool_name, file_hash, timestamp)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (session_id, file_path, action, tool_name, file_hash, ts),
+    )
+    await db.commit()
+    return cursor.lastrowid  # type: ignore[return-value]
+
+
+async def query_by_file(
+    db: aiosqlite.Connection,
+    file_path: str,
+    *,
+    limit: int = 20,
+) -> list[dict]:
+    """Return recent modifications to a specific file path."""
+    cursor = await db.execute(
+        """SELECT * FROM file_modifications
+           WHERE file_path = ?
+           ORDER BY timestamp DESC
+           LIMIT ?""",
+        (file_path, limit),
+    )
+    rows = await cursor.fetchall()
+    return [dict(row) for row in rows]
+
+
+async def query_by_session(
+    db: aiosqlite.Connection,
+    session_id: str,
+) -> list[dict]:
+    """Return all files modified by a specific session."""
+    cursor = await db.execute(
+        """SELECT * FROM file_modifications
+           WHERE session_id = ?
+           ORDER BY timestamp""",
+        (session_id,),
+    )
+    rows = await cursor.fetchall()
+    return [dict(row) for row in rows]
+
+
+async def prune_older_than(
+    db: aiosqlite.Connection,
+    days: int = 90,
+) -> int:
+    """Delete records older than N days. Returns count deleted."""
+    cutoff = datetime.now(UTC).isoformat()
+    # Compute cutoff by subtracting days (ISO format comparison works)
+    from datetime import timedelta
+
+    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+    cursor = await db.execute(
+        "DELETE FROM file_modifications WHERE timestamp < ?",
+        (cutoff,),
+    )
+    await db.commit()
+    return cursor.rowcount  # type: ignore[return-value]

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -871,6 +871,17 @@ TABLES = {
             verification_notes TEXT
         )
     """,
+    "file_modifications": """
+        CREATE TABLE IF NOT EXISTS file_modifications (
+            id               INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id       TEXT,
+            file_path        TEXT NOT NULL,
+            action           TEXT NOT NULL,
+            tool_name        TEXT,
+            file_hash        TEXT,
+            timestamp        TEXT NOT NULL
+        )
+    """,
 }
 
 # FTS5 virtual tables (in-memory SQLite does NOT support FTS5 unless compiled with it)
@@ -1046,6 +1057,10 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_follow_ups_scheduled ON follow_ups(scheduled_at)",
     "CREATE INDEX IF NOT EXISTS idx_follow_ups_source ON follow_ups(source)",
     "CREATE INDEX IF NOT EXISTS idx_follow_ups_linked_task ON follow_ups(linked_task_id)",
+    # file modification audit trail
+    "CREATE INDEX IF NOT EXISTS idx_file_mod_path ON file_modifications(file_path)",
+    "CREATE INDEX IF NOT EXISTS idx_file_mod_session ON file_modifications(session_id)",
+    "CREATE INDEX IF NOT EXISTS idx_file_mod_ts ON file_modifications(timestamp)",
 ]
 
 # ─── Seed Data ────────────────────────────────────────────────────────────────

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -83,6 +83,7 @@ async def test_no_unexpected_tables(db):
         "code_modules", "code_symbols", "code_imports",
         "follow_ups", "surplus_tasks", "surplus_insights",
         "knowledge_uploads",
+        "file_modifications",
     }
     for table in tables:
         assert table in known, f"Unexpected table: {table}"


### PR DESCRIPTION
## Summary
- Add `file_modifications` DB table + PostToolUse hook that records Write/Edit operations with session ID, file path, action, and file hash
- Enables instant diagnosis of "what session modified this file?" — replaces 12-minute transcript archaeology with a single SQL query
- Zero token cost — pure shell/SQLite hook, no LLM calls
- Remove stale dual-repo release pipeline docs from genesis-development skill (public repo is now primary with standard OSS workflow)

## Context
During voice-master skill deployment, discovered that a prior release session had silently overwritten calibrated voice exemplars with empty templates. Diagnosing this required grepping through JSONL transcripts — the audit trail would have made it a one-line query.

## Test plan
- [ ] Hook fires on Write/Edit tool use and inserts row into `file_modifications`
- [ ] `query_by_file()` returns correct session and timestamp for a given path
- [ ] `query_by_session()` returns all files modified by a session
- [ ] Hook runs in <100ms (pure sqlite3 insert)
- [ ] Pre-existing test suite passes (1434 passed, 1 pre-existing failure in unrelated dashboard template test)
- [ ] Lint clean (`ruff check` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)