### PR TITLE
fix(tests): resolve 30 pre-existing CI failures

### DIFF
--- a/scripts/pending_reminders_hook.py
+++ b/scripts/pending_reminders_hook.py
@@ -40,7 +40,7 @@ import json
 import os
 import sys
 import traceback
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 
@@ -50,7 +50,7 @@ def _pending_dir() -> Path:
 
 
 def _now() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 def _parse_fire_at(raw: str) -> datetime | None:
@@ -61,7 +61,7 @@ def _parse_fire_at(raw: str) -> datetime | None:
         return None
     if dt.tzinfo is None:
         return None
-    return dt.astimezone(timezone.utc)
+    return dt.astimezone(UTC)
 
 
 def _iter_markers(d: Path) -> list[Path]:

--- a/src/genesis/web/fetch.py
+++ b/src/genesis/web/fetch.py
@@ -22,6 +22,7 @@ try:
 
     _HAS_SCRAPLING = True
 except ImportError:
+    _ScraplingFetcher = None  # type: ignore[misc,assignment]
     _HAS_SCRAPLING = False
 
 

--- a/tests/test_autonomy/test_remediation.py
+++ b/tests/test_autonomy/test_remediation.py
@@ -96,7 +96,8 @@ class TestRegistration:
 
     def test_register_defaults(self):
         reg = RemediationRegistry()
-        register_defaults(reg)
+        with patch("genesis.env.ollama_enabled", return_value=True):
+            register_defaults(reg)
         assert len(reg.actions) == len(DEFAULT_REMEDIATIONS)
         names = {a.name for a in reg.actions}
         assert "qdrant_restart" in names

--- a/tests/test_dashboard/test_api.py
+++ b/tests/test_dashboard/test_api.py
@@ -455,6 +455,7 @@ def test_set_budget_rejects_invalid_budget_type(client):
 def test_routing_config_read_includes_call_sites(client):
     """Routing config read exposes configured call sites for the dashboard editor."""
     mock_cfg = SimpleNamespace()
+    mock_cfg.disabled_providers = {}
     mock_cfg.providers = {
         "claude-sonnet": SimpleNamespace(
             name="claude-sonnet",

--- a/tests/test_learning/test_triage.py
+++ b/tests/test_learning/test_triage.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
+
 from genesis.cc.types import CCOutput
 from genesis.learning.triage.classifier import TriageClassifier
 from genesis.learning.triage.prefilter import should_skip
@@ -251,37 +253,33 @@ class TestClassifier:
 # ── Calibration file ─────────────────────────────────────────────────────────
 
 
-class TestCalibrationFile:
-    def test_file_exists(self):
-        path = (
-            Path(__file__).resolve().parents[2]
-            / "src"
-            / "genesis"
-            / "identity"
-            / "TRIAGE_CALIBRATION.md"
-        )
-        assert path.exists(), f"Missing {path}"
+_CALIBRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "genesis"
+    / "identity"
+    / "TRIAGE_CALIBRATION.md"
+)
 
+_skip_no_calibration = pytest.mark.skipif(
+    not _CALIBRATION_PATH.exists(),
+    reason="TRIAGE_CALIBRATION.md is runtime-generated and gitignored",
+)
+
+
+class TestCalibrationFile:
+    @_skip_no_calibration
+    def test_file_exists(self):
+        assert _CALIBRATION_PATH.exists(), f"Missing {_CALIBRATION_PATH}"
+
+    @_skip_no_calibration
     def test_has_frontmatter(self):
-        path = (
-            Path(__file__).resolve().parents[2]
-            / "src"
-            / "genesis"
-            / "identity"
-            / "TRIAGE_CALIBRATION.md"
-        )
-        text = path.read_text()
+        text = _CALIBRATION_PATH.read_text()
         assert text.startswith("---")
         assert "version:" in text
 
+    @_skip_no_calibration
     def test_has_examples_and_rules_section(self):
-        path = (
-            Path(__file__).resolve().parents[2]
-            / "src"
-            / "genesis"
-            / "identity"
-            / "TRIAGE_CALIBRATION.md"
-        )
-        text = path.read_text()
+        text = _CALIBRATION_PATH.read_text()
         assert "## Few-Shot Examples" in text
         assert "## Calibration Rules" in text

--- a/tests/test_providers/test_crawl4ai.py
+++ b/tests/test_providers/test_crawl4ai.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+pytest.importorskip("crawl4ai")
+
 from genesis.providers.crawl4ai_adapter import Crawl4AIAdapter
 from genesis.providers.protocol import ToolProvider
 from genesis.providers.types import (

--- a/tests/test_providers/test_exa.py
+++ b/tests/test_providers/test_exa.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+pytest.importorskip("exa_py")
+
 from genesis.providers.exa_adapter import ExaAdapter
 from genesis.providers.protocol import ToolProvider
 from genesis.providers.types import (

--- a/tests/test_providers/test_tavily.py
+++ b/tests/test_providers/test_tavily.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+pytest.importorskip("tavily")
+
 from genesis.providers.protocol import ToolProvider
 from genesis.providers.tavily_adapter import TavilyAdapter
 from genesis.providers.types import (

--- a/tests/test_routing/test_integration.py
+++ b/tests/test_routing/test_integration.py
@@ -59,7 +59,7 @@ async def test_full_stack_success(real_config, breakers, cost_tracker, degradati
 
 @pytest.mark.asyncio
 async def test_full_stack_fallback_chain(real_config, breakers, cost_tracker, degradation):
-    """mistral-small-free fails, should fallback to groq-free for 3_micro_reflection."""
+    """mistral-small-free fails, should fallback to openrouter-free for 3_micro_reflection."""
     delegate = MockDelegate(responses={
         "mistral-small-free": CallResult(success=False, error="rate limited", status_code=429),
     })
@@ -69,7 +69,7 @@ async def test_full_stack_fallback_chain(real_config, breakers, cost_tracker, de
     )
     result = await router.route_call("3_micro_reflection", [{"role": "user", "content": "reflect"}])
     assert result.success is True
-    assert result.provider_used == "groq-free"
+    assert result.provider_used == "openrouter-free"
     assert result.fallback_used is True
 
 
@@ -108,7 +108,7 @@ async def test_dead_letter_queue_lifecycle(dlq):
 
 @pytest.mark.asyncio
 async def test_circuit_breaker_affects_routing(real_config, breakers, cost_tracker, degradation):
-    """Trip mistral-small-free breaker, route 3_micro_reflection — should use groq-free."""
+    """Trip mistral-small-free breaker, route 3_micro_reflection — should use openrouter-free."""
     cb = breakers.get("mistral-small-free")
     for _ in range(3):
         cb.record_failure(ErrorCategory.TRANSIENT)
@@ -121,5 +121,5 @@ async def test_circuit_breaker_affects_routing(real_config, breakers, cost_track
     )
     result = await router.route_call("3_micro_reflection", [{"role": "user", "content": "reflect"}])
     assert result.success is True
-    assert result.provider_used == "groq-free"
+    assert result.provider_used == "openrouter-free"
     assert all(c["provider"] != "mistral-small-free" for c in delegate.calls)


### PR DESCRIPTION
## Summary
- Skip optional provider tests (crawl4ai, exa, tavily) via `pytest.importorskip` when deps absent in CI
- Add `_ScraplingFetcher = None` sentinel so scrapling tests can patch the target without the package installed
- Skip `TRIAGE_CALIBRATION.md` validation tests in CI (file is runtime-generated and gitignored)
- Mock `ollama_enabled` in remediation defaults test (Ollama not available in CI)
- Add missing `disabled_providers` attribute to routing config mock
- Update routing fallback assertions to match current chain order (`openrouter-free` is now #2 in `3_micro_reflection`)
- Fix `datetime.timezone.utc` → `datetime.UTC` lint errors (ruff UP017)

## Test plan
- [ ] `ruff check` passes (0 errors)
- [ ] All 30 previously-failing tests now pass or skip appropriately
- [ ] Full test suite: 5650+ passed, 0 failures
- [ ] No behavioral changes to production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)