### PR TITLE
fix(security): prevent stack trace exposure in files API

### DIFF
--- a/src/genesis/dashboard/routes/files.py
+++ b/src/genesis/dashboard/routes/files.py
@@ -277,8 +277,9 @@ def file_rename():
 
     try:
         source.rename(dest)
-    except Exception as exc:
-        return jsonify({"error": str(exc)}), 500
+    except Exception:
+        logger.exception("Failed to rename %s", source)
+        return jsonify({"error": "Rename failed"}), 500
 
     return jsonify({"status": "ok", "old_path": str(source), "new_path": str(dest)})
 
@@ -303,8 +304,9 @@ def file_delete():
 
     try:
         target.unlink()
-    except Exception as exc:
-        return jsonify({"error": str(exc)}), 500
+    except Exception:
+        logger.exception("Failed to delete %s", target)
+        return jsonify({"error": "Delete failed"}), 500
 
     return jsonify({"status": "ok", "path": str(raw_path)})
 


### PR DESCRIPTION
## Summary
- Replace `str(exc)` in HTTP 500 responses with generic error messages in file rename and delete endpoints
- Exception details now go to server logs only, not the client
- Also dismisses 5 CodeQL false positives (taint from server-controlled DB paths, extracted safe fields)

## Test plan
- [ ] Lint passes
- [ ] File delete/rename errors return generic message, not exception text
- [ ] CodeQL alert #98 resolves after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)