### PR TITLE
fix(browser): stale context recovery, session history, VNC environment

### DIFF
--- a/scripts/setup-vnc.sh
+++ b/scripts/setup-vnc.sh
@@ -17,7 +17,7 @@ BRAIN_IMG="$GENESIS_ROOT/docs/images/genesis-brain.png"
 echo "=== Genesis VNC Stack Setup ==="
 
 # ── 1. System packages ────────────────────────────────────
-PKGS=(xvfb x11vnc novnc websockify feh xdotool)
+PKGS=(xvfb x11vnc novnc websockify feh xdotool openbox xclip)
 MISSING=()
 for pkg in "${PKGS[@]}"; do
     if ! dpkg -s "$pkg" &>/dev/null; then
@@ -46,7 +46,7 @@ fi
 # ── 3. Systemd units ─────────────────────────────────────
 mkdir -p "$SYSTEMD_DIR"
 
-# Xvfb — virtual display :99
+# Xvfb — virtual display :99 with openbox window manager
 cat > "$SYSTEMD_DIR/genesis-xvfb.service" << EOF
 [Unit]
 Description=Genesis Virtual Display (Xvfb)
@@ -55,6 +55,7 @@ After=default.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/Xvfb :99 -screen 0 1920x1080x24 -ac
+ExecStartPost=/bin/bash -c 'sleep 1 && DISPLAY=:99 /usr/bin/openbox --sm-disable &'
 ExecStartPost=/bin/bash -c 'sleep 1 && HOME=%h DISPLAY=:99 /usr/bin/feh --bg-center $BRAIN_IMG'
 Restart=on-failure
 RestartSec=3
@@ -64,6 +65,11 @@ WantedBy=default.target
 EOF
 
 # x11vnc — VNC server on display :99
+# Flags:
+#   -xdamage   — use X DAMAGE extension to only send changed regions (was -noxdamage)
+#   -threads   — multi-threaded encoding for better FPS
+#   -ncache 10 — client-side pixel caching for faster scrolling/tab switching
+#   xclip required for clipboard sync (installed above)
 cat > "$SYSTEMD_DIR/genesis-vnc.service" << EOF
 [Unit]
 Description=Genesis VNC Server (x11vnc)
@@ -73,7 +79,7 @@ Requires=genesis-xvfb.service
 [Service]
 Type=simple
 Environment=DISPLAY=:99
-ExecStart=/usr/bin/x11vnc -display :99 -forever -shared -rfbauth %h/.genesis/vnc_passwd -rfbport 5900 -noxdamage
+ExecStart=/usr/bin/x11vnc -display :99 -forever -shared -rfbauth %h/.genesis/vnc_passwd -rfbport 5900 -xdamage -threads -ncache 10
 Restart=on-failure
 RestartSec=3
 

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -26,6 +26,9 @@ from genesis.mcp.health import mcp
 
 logger = logging.getLogger(__name__)
 
+# Prevents concurrent browser init/cleanup races across tool calls.
+_browser_lock = asyncio.Lock()
+
 _PROFILE_DIR = Path.home() / ".genesis" / "camoufox-profile"
 _CHROMIUM_PROFILE_DIR = Path.home() / ".genesis" / "browser-profile"
 
@@ -53,9 +56,22 @@ _SCREENSHOT_DIR = Path.home() / "tmp"
 _VNC_DISPLAY = ":99"
 
 
+def _is_page_alive(page) -> bool:
+    """Check if a Playwright page reference is still usable."""
+    try:
+        if page.is_closed():
+            return False
+        _ = page.url  # raises if connection severed
+        return True
+    except Exception:
+        return False
+
+
 async def async_cleanup():
     """Shut down browser. Called from MCP lifespan, idle timeout, or manually.
 
+    Safe to call when the browser is already dead — all steps are
+    individually guarded so a crashed Camoufox won't hang cleanup.
     Each cleanup step has a 10s timeout (user-approved) to prevent hanging
     if the Playwright Node.js driver or browser process is stuck. Orphaned
     processes that survive timeout are caught by the process reaper (4h cycle).
@@ -110,37 +126,51 @@ async def _ensure_browser():
     Returns the active page. Raises ImportError if camoufox is not installed.
     In collaborate mode, launches headed on virtual display :99 for VNC sharing.
     Uses anti-detection Firefox by default for all browsing.
+
+    Detects stale pages (e.g. browser killed by a concurrent session) and
+    automatically cleans up + re-initializes.
     """
     global _stealth_cm, _stealth_browser, _stealth_page
 
-    if _stealth_page is not None:
+    async with _browser_lock:
+        if _stealth_page is not None:
+            if _is_page_alive(_stealth_page):
+                return _stealth_page
+            logger.warning("Camoufox page is stale — restarting browser")
+            await async_cleanup()
+
+        from camoufox.async_api import AsyncCamoufox
+
+        _PROFILE_DIR.mkdir(parents=True, exist_ok=True)
+
+        global _original_display
+        headed = _collaborate_mode
+        if headed:
+            _original_display = os.environ.get("DISPLAY")
+            os.environ["DISPLAY"] = _VNC_DISPLAY
+        elif _original_display is not None:
+            os.environ["DISPLAY"] = _original_display
+        elif "DISPLAY" in os.environ:
+            del os.environ["DISPLAY"]
+
+        _stealth_cm = AsyncCamoufox(
+            headless=not headed,
+            persistent_context=True,
+            user_data_dir=str(_PROFILE_DIR),
+            firefox_user_prefs={
+                # Camoufox disables session history (max_entries=0) for
+                # anti-detection.  Re-enable it so back/forward navigation
+                # works in collaborate mode.
+                "browser.sessionhistory.max_entries": 10,
+                "browser.sessionhistory.max_total_viewers": -1,
+            },
+        )
+        _stealth_browser = await _stealth_cm.__aenter__()
+        # With persistent_context, browser IS the context
+        _stealth_page = _stealth_browser.pages[0] if _stealth_browser.pages else await _stealth_browser.new_page()
+        mode_str = "headed (collaborate)" if headed else "headless"
+        logger.info("Camoufox browser launched %s with persistent profile at %s", mode_str, _PROFILE_DIR)
         return _stealth_page
-
-    from camoufox.async_api import AsyncCamoufox
-
-    _PROFILE_DIR.mkdir(parents=True, exist_ok=True)
-
-    global _original_display
-    headed = _collaborate_mode
-    if headed:
-        _original_display = os.environ.get("DISPLAY")
-        os.environ["DISPLAY"] = _VNC_DISPLAY
-    elif _original_display is not None:
-        os.environ["DISPLAY"] = _original_display
-    elif "DISPLAY" in os.environ:
-        del os.environ["DISPLAY"]
-
-    _stealth_cm = AsyncCamoufox(
-        headless=not headed,
-        persistent_context=True,
-        user_data_dir=str(_PROFILE_DIR),
-    )
-    _stealth_browser = await _stealth_cm.__aenter__()
-    # With persistent_context, browser IS the context
-    _stealth_page = _stealth_browser.pages[0] if _stealth_browser.pages else await _stealth_browser.new_page()
-    mode_str = "headed (collaborate)" if headed else "headless"
-    logger.info("Camoufox browser launched %s with persistent profile at %s", mode_str, _PROFILE_DIR)
-    return _stealth_page
 
 
 async def _ensure_chromium_fallback():
@@ -148,32 +178,38 @@ async def _ensure_chromium_fallback():
 
     Use only when Camoufox fails on a specific site. Persistent profile at
     ~/.genesis/browser-profile/ (separate from Camoufox profile).
+
+    Detects stale pages and automatically re-initializes.
     """
     global _playwright, _context, _page
 
-    if _page is not None:
+    async with _browser_lock:
+        if _page is not None:
+            if _is_page_alive(_page):
+                return _page
+            logger.warning("Chromium page is stale — restarting browser")
+            await async_cleanup()
+
+        from playwright.async_api import async_playwright
+
+        _CHROMIUM_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
+
+        headed = _collaborate_mode
+        if headed:
+            os.environ["DISPLAY"] = _VNC_DISPLAY
+
+        _playwright = await async_playwright().start()
+        _context = await _playwright.chromium.launch_persistent_context(
+            user_data_dir=str(_CHROMIUM_PROFILE_DIR),
+            headless=not headed,
+            args=["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"]
+            + (["--start-maximized"] if headed else []),
+            viewport={"width": 1280, "height": 720} if headed else None,
+        )
+        _page = _context.pages[0] if _context.pages else await _context.new_page()
+        mode_str = "headed (collaborate)" if headed else "headless"
+        logger.info("Chromium fallback launched %s with profile at %s", mode_str, _CHROMIUM_PROFILE_DIR)
         return _page
-
-    from playwright.async_api import async_playwright
-
-    _CHROMIUM_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
-
-    headed = _collaborate_mode
-    if headed:
-        os.environ["DISPLAY"] = _VNC_DISPLAY
-
-    _playwright = await async_playwright().start()
-    _context = await _playwright.chromium.launch_persistent_context(
-        user_data_dir=str(_CHROMIUM_PROFILE_DIR),
-        headless=not headed,
-        args=["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"]
-        + (["--start-maximized"] if headed else []),
-        viewport={"width": 1280, "height": 720} if headed else None,
-    )
-    _page = _context.pages[0] if _context.pages else await _context.new_page()
-    mode_str = "headed (collaborate)" if headed else "headless"
-    logger.info("Chromium fallback launched %s with profile at %s", mode_str, _CHROMIUM_PROFILE_DIR)
-    return _page
 
 
 def _touch():

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -57,11 +57,17 @@ _VNC_DISPLAY = ":99"
 
 
 def _is_page_alive(page) -> bool:
-    """Check if a Playwright page reference is still usable."""
+    """Check if a Playwright page reference is still usable.
+
+    Synchronous fast-path check.  Catches the most common failure modes
+    (closed pages, disposed objects).  Some stale-page scenarios where the
+    browser process died but the page object has cached state may slip
+    through — those are caught by try/except in the tool implementations.
+    """
     try:
         if page.is_closed():
             return False
-        _ = page.url  # raises if connection severed
+        _ = page.url  # raises on disposed objects
         return True
     except Exception:
         return False
@@ -582,7 +588,8 @@ async def browser_collaborate(enable: bool = True) -> dict:
         }
 
     _collaborate_mode = enable
-    await async_cleanup()  # Force browser restart on next tool call
+    async with _browser_lock:
+        await async_cleanup()  # Force browser restart on next tool call
 
     if enable and not Path(f"/tmp/.X{_VNC_DISPLAY[1:]}-lock").exists():
         return {

--- a/tests/test_mcp/test_browser_tools.py
+++ b/tests/test_mcp/test_browser_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -21,6 +22,7 @@ def _reset_browser_state():
     browser._active_page = None
     browser._collaborate_mode = False
     browser._original_display = None
+    browser._browser_lock = asyncio.Lock()
     yield
     browser._stealth_cm = None
     browser._stealth_browser = None
@@ -31,6 +33,7 @@ def _reset_browser_state():
     browser._active_page = None
     browser._collaborate_mode = False
     browser._original_display = None
+    browser._browser_lock = asyncio.Lock()
 
 
 class TestIsPageAlive:

--- a/tests/test_mcp/test_browser_tools.py
+++ b/tests/test_mcp/test_browser_tools.py
@@ -1,0 +1,143 @@
+"""Tests for browser MCP tool internals (liveness check, recovery)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genesis.mcp.health import browser
+
+
+@pytest.fixture(autouse=True)
+def _reset_browser_state():
+    """Reset module-level browser state before and after each test."""
+    browser._stealth_cm = None
+    browser._stealth_browser = None
+    browser._stealth_page = None
+    browser._playwright = None
+    browser._context = None
+    browser._page = None
+    browser._active_page = None
+    browser._collaborate_mode = False
+    browser._original_display = None
+    yield
+    browser._stealth_cm = None
+    browser._stealth_browser = None
+    browser._stealth_page = None
+    browser._playwright = None
+    browser._context = None
+    browser._page = None
+    browser._active_page = None
+    browser._collaborate_mode = False
+    browser._original_display = None
+
+
+class TestIsPageAlive:
+    def test_alive_page(self):
+        page = MagicMock()
+        page.is_closed.return_value = False
+        page.url = "https://example.com"
+        assert browser._is_page_alive(page) is True
+
+    def test_closed_page(self):
+        page = MagicMock()
+        page.is_closed.return_value = True
+        assert browser._is_page_alive(page) is False
+
+    def test_severed_connection(self):
+        page = MagicMock()
+        page.is_closed.return_value = False
+        type(page).url = property(lambda self: (_ for _ in ()).throw(ConnectionError("pipe broken")))
+        assert browser._is_page_alive(page) is False
+
+    def test_none_page(self):
+        assert browser._is_page_alive(None) is False
+
+    def test_is_closed_throws(self):
+        page = MagicMock()
+        page.is_closed.side_effect = RuntimeError("already disposed")
+        assert browser._is_page_alive(page) is False
+
+
+class TestEnsureBrowserRecovery:
+    @pytest.mark.asyncio
+    async def test_returns_alive_page_without_reinit(self):
+        """If page is alive, _ensure_browser returns it immediately."""
+        page = MagicMock()
+        page.is_closed.return_value = False
+        page.url = "https://example.com"
+        browser._stealth_page = page
+
+        result = await browser._ensure_browser()
+        assert result is page
+
+    @pytest.mark.asyncio
+    async def test_recovers_from_stale_page(self):
+        """If page is dead, _ensure_browser cleans up and re-initializes."""
+        dead_page = MagicMock()
+        dead_page.is_closed.return_value = True
+        browser._stealth_page = dead_page
+
+        new_page = MagicMock()
+        mock_browser = MagicMock()
+        mock_browser.pages = [new_page]
+
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_browser)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("camoufox.async_api.AsyncCamoufox", return_value=mock_cm):
+            result = await browser._ensure_browser()
+
+        assert result is new_page
+        assert browser._stealth_page is new_page
+
+    @pytest.mark.asyncio
+    async def test_cleanup_safe_on_dead_browser(self):
+        """async_cleanup() doesn't raise when browser is already dead."""
+        dead_cm = AsyncMock()
+        dead_cm.__aexit__ = AsyncMock(side_effect=ConnectionError("already gone"))
+        browser._stealth_cm = dead_cm
+        browser._stealth_browser = MagicMock()
+        browser._stealth_page = MagicMock()
+
+        await browser.async_cleanup()
+
+        assert browser._stealth_cm is None
+        assert browser._stealth_browser is None
+        assert browser._stealth_page is None
+
+
+class TestEnsureChromiumRecovery:
+    @pytest.mark.asyncio
+    async def test_returns_alive_page(self):
+        page = MagicMock()
+        page.is_closed.return_value = False
+        page.url = "https://example.com"
+        browser._page = page
+
+        result = await browser._ensure_chromium_fallback()
+        assert result is page
+
+    @pytest.mark.asyncio
+    async def test_recovers_from_stale_chromium(self):
+        dead_page = MagicMock()
+        dead_page.is_closed.return_value = True
+        browser._page = dead_page
+
+        new_page = MagicMock()
+        mock_context = AsyncMock()
+        mock_context.pages = [new_page]
+
+        mock_pw = AsyncMock()
+        mock_pw.chromium.launch_persistent_context = AsyncMock(return_value=mock_context)
+
+        with patch("playwright.async_api.async_playwright") as mock_apw:
+            mock_starter = AsyncMock()
+            mock_starter.start = AsyncMock(return_value=mock_pw)
+            mock_apw.return_value = mock_starter
+            result = await browser._ensure_chromium_fallback()
+
+        assert result is new_page
+        assert browser._page is new_page


### PR DESCRIPTION
## Summary

- **Stale context auto-recovery**: Added `_is_page_alive()` liveness check to `_ensure_browser()` and `_ensure_chromium_fallback()`. When the browser dies (e.g. concurrent sessions fighting over the shared Camoufox profile), the next tool call detects the dead page and automatically cleans up + re-initializes instead of permanently failing with "Target page has been closed."
- **Session history**: Override `browser.sessionhistory.max_entries: 0` (set by camoufox.cfg for anti-detection) via `firefox_user_prefs` so back/forward navigation works in collaborate mode.
- **VNC environment**: Install openbox WM for proper focus/popup handling (fixes vanishing right-click context menus), xclip for clipboard sync (fixes paste from noVNC panel), replace `-noxdamage` with `-xdamage -threads -ncache 10` for better FPS on LAN.
- Added `asyncio.Lock` to prevent concurrent browser init/cleanup races.

## Test plan

- [x] 10 new unit tests for liveness check and recovery paths (all pass)
- [x] 1602/1603 existing tests pass (1 pre-existing failure unrelated)
- [x] Lint clean (`ruff check`)
- [x] VNC stack restarted and verified: openbox running, xclip works, services healthy
- [ ] Manual: navigate 3+ pages in collaborate mode, verify back button works
- [ ] Manual: paste from noVNC clipboard panel, verify Ctrl+V works in browser
- [ ] Manual: right-click in collaborate mode, verify context menu stays open
- [ ] Manual: kill camoufox PID, verify next MCP call auto-recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)