### PR TITLE
feat(cc): DB queue for direct session dispatch

### DIFF
--- a/scripts/genesis_mcp_server.py
+++ b/scripts/genesis_mcp_server.py
@@ -112,13 +112,12 @@ def _bootstrap_health() -> None:
             # the Genesis server's poll loop handles dispatch.
             # Ensure queue table exists (standalone doesn't call db.init()).
             try:
-                from genesis.db.schema import TABLES
+                from genesis.db.schema import INDEXES, TABLES
 
                 await db.execute(TABLES["direct_session_queue"])
-                await db.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_dsq_status_created "
-                    "ON direct_session_queue(status, created_at)"
-                )
+                for idx_ddl in INDEXES:
+                    if "direct_session_queue" in idx_ddl:
+                        await db.execute(idx_ddl)
                 await db.commit()
 
                 from genesis.mcp.health.direct_session_tools import (

--- a/scripts/genesis_mcp_server.py
+++ b/scripts/genesis_mcp_server.py
@@ -106,6 +106,32 @@ def _bootstrap_health() -> None:
             tracker = ProviderActivityTracker()
             tracker.set_db(db)
             init_health_mcp(svc, activity_tracker=tracker)
+
+            # Wire direct session tools with DB-only access.
+            # Standalone MCP enqueues to direct_session_queue;
+            # the Genesis server's poll loop handles dispatch.
+            # Ensure queue table exists (standalone doesn't call db.init()).
+            try:
+                from genesis.db.schema import TABLES
+
+                await db.execute(TABLES["direct_session_queue"])
+                await db.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_dsq_status_created "
+                    "ON direct_session_queue(status, created_at)"
+                )
+                await db.commit()
+
+                from genesis.mcp.health.direct_session_tools import (
+                    init_direct_session_tools,
+                )
+
+                init_direct_session_tools(db=db)
+            except Exception:
+                logger.warning(
+                    "Direct session tools not available in standalone MCP",
+                    exc_info=True,
+                )
+
             clear_mcp_crash("health")
             yield
         finally:

--- a/src/genesis/db/crud/direct_session_queue.py
+++ b/src/genesis/db/crud/direct_session_queue.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import aiosqlite
 
@@ -48,27 +48,27 @@ async def enqueue(
 
 
 async def claim_next(db: aiosqlite.Connection) -> dict | None:
-    """Claim the oldest pending queue item. Returns None if queue is empty."""
+    """Atomically claim the oldest pending queue item.
+
+    Uses UPDATE...RETURNING for a single atomic statement (SQLite 3.35+).
+    Returns None if the queue is empty.
+    """
+    now = _now()
     cursor = await db.execute(
-        """SELECT * FROM direct_session_queue
-           WHERE status = 'pending'
-           ORDER BY created_at
-           LIMIT 1""",
+        """UPDATE direct_session_queue
+           SET status = 'claimed', claimed_at = ?
+           WHERE id = (
+               SELECT id FROM direct_session_queue
+               WHERE status = 'pending'
+               ORDER BY created_at
+               LIMIT 1
+           )
+           RETURNING *""",
+        (now,),
     )
     row = await cursor.fetchone()
-    if row is None:
-        return None
-
-    row_dict = dict(row)
-    now = _now()
-    await db.execute(
-        "UPDATE direct_session_queue SET status = 'claimed', claimed_at = ? WHERE id = ?",
-        (now, row_dict["id"]),
-    )
     await db.commit()
-    row_dict["status"] = "claimed"
-    row_dict["claimed_at"] = now
-    return row_dict
+    return dict(row) if row else None
 
 
 async def mark_dispatched(
@@ -118,9 +118,7 @@ async def recover_stale_claims(
 
     Called on server startup to handle items claimed before a crash.
     """
-    cutoff = datetime.now(UTC).timestamp() - max_age_s
-    # SQLite datetime strings are ISO format — compare as strings
-    cutoff_iso = datetime.fromtimestamp(cutoff, tz=UTC).isoformat()
+    cutoff_iso = (datetime.now(UTC) - timedelta(seconds=max_age_s)).isoformat()
     cursor = await db.execute(
         """UPDATE direct_session_queue
            SET status = 'pending', claimed_at = NULL

--- a/src/genesis/db/crud/direct_session_queue.py
+++ b/src/genesis/db/crud/direct_session_queue.py
@@ -1,0 +1,140 @@
+"""CRUD operations for direct_session_queue table."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+
+import aiosqlite
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+async def enqueue(
+    db: aiosqlite.Connection,
+    *,
+    prompt: str,
+    profile: str = "observe",
+    model: str = "sonnet",
+    effort: str = "high",
+    timeout_s: int = 900,
+    notify: bool = True,
+    notify_on_failure_only: bool = False,
+    caller_context: str | None = None,
+) -> str:
+    """Insert a new queue item. Returns the queue_id."""
+    queue_id = f"dsq-{uuid.uuid4().hex[:12]}"
+    payload = {
+        "prompt": prompt,
+        "profile": profile,
+        "model": model,
+        "effort": effort,
+        "timeout_s": timeout_s,
+        "notify": notify,
+        "notify_on_failure_only": notify_on_failure_only,
+        "caller_context": caller_context,
+    }
+    await db.execute(
+        """INSERT INTO direct_session_queue
+           (id, payload_json, status, created_at)
+           VALUES (?, ?, 'pending', ?)""",
+        (queue_id, json.dumps(payload), _now()),
+    )
+    await db.commit()
+    return queue_id
+
+
+async def claim_next(db: aiosqlite.Connection) -> dict | None:
+    """Claim the oldest pending queue item. Returns None if queue is empty."""
+    cursor = await db.execute(
+        """SELECT * FROM direct_session_queue
+           WHERE status = 'pending'
+           ORDER BY created_at
+           LIMIT 1""",
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+
+    row_dict = dict(row)
+    now = _now()
+    await db.execute(
+        "UPDATE direct_session_queue SET status = 'claimed', claimed_at = ? WHERE id = ?",
+        (now, row_dict["id"]),
+    )
+    await db.commit()
+    row_dict["status"] = "claimed"
+    row_dict["claimed_at"] = now
+    return row_dict
+
+
+async def mark_dispatched(
+    db: aiosqlite.Connection,
+    queue_id: str,
+    session_id: str,
+) -> None:
+    """Mark a queue item as dispatched with the spawned session_id."""
+    await db.execute(
+        """UPDATE direct_session_queue
+           SET status = 'dispatched', session_id = ?, dispatched_at = ?
+           WHERE id = ?""",
+        (session_id, _now(), queue_id),
+    )
+    await db.commit()
+
+
+async def mark_failed(
+    db: aiosqlite.Connection,
+    queue_id: str,
+    error: str,
+) -> None:
+    """Mark a queue item as failed."""
+    await db.execute(
+        """UPDATE direct_session_queue
+           SET status = 'failed', error_message = ?
+           WHERE id = ?""",
+        (error, queue_id),
+    )
+    await db.commit()
+
+
+async def get_by_id(db: aiosqlite.Connection, queue_id: str) -> dict | None:
+    """Fetch a queue item by ID."""
+    cursor = await db.execute(
+        "SELECT * FROM direct_session_queue WHERE id = ?", (queue_id,),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def recover_stale_claims(
+    db: aiosqlite.Connection,
+    max_age_s: int = 120,
+) -> int:
+    """Reset claimed items older than max_age_s back to pending.
+
+    Called on server startup to handle items claimed before a crash.
+    """
+    cutoff = datetime.now(UTC).timestamp() - max_age_s
+    # SQLite datetime strings are ISO format — compare as strings
+    cutoff_iso = datetime.fromtimestamp(cutoff, tz=UTC).isoformat()
+    cursor = await db.execute(
+        """UPDATE direct_session_queue
+           SET status = 'pending', claimed_at = NULL
+           WHERE status = 'claimed' AND claimed_at < ?""",
+        (cutoff_iso,),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
+async def count_pending(db: aiosqlite.Connection) -> int:
+    """Count items in pending status."""
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM direct_session_queue WHERE status = 'pending'",
+    )
+    row = await cursor.fetchone()
+    return row[0] if row else 0

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -884,6 +884,19 @@ TABLES = {
             timestamp        TEXT NOT NULL
         )
     """,
+    "direct_session_queue": """
+        CREATE TABLE IF NOT EXISTS direct_session_queue (
+            id              TEXT PRIMARY KEY,
+            payload_json    TEXT NOT NULL,
+            status          TEXT NOT NULL DEFAULT 'pending'
+                            CHECK (status IN ('pending', 'claimed', 'dispatched', 'failed')),
+            session_id      TEXT,
+            error_message   TEXT,
+            created_at      TEXT NOT NULL,
+            claimed_at      TEXT,
+            dispatched_at   TEXT
+        )
+    """,
 }
 
 # FTS5 virtual tables (in-memory SQLite does NOT support FTS5 unless compiled with it)
@@ -1063,6 +1076,8 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_file_mod_path ON file_modifications(file_path)",
     "CREATE INDEX IF NOT EXISTS idx_file_mod_session ON file_modifications(session_id)",
     "CREATE INDEX IF NOT EXISTS idx_file_mod_ts ON file_modifications(timestamp)",
+    # direct session queue
+    "CREATE INDEX IF NOT EXISTS idx_dsq_status_created ON direct_session_queue(status, created_at)",
 ]
 
 # ─── Seed Data ────────────────────────────────────────────────────────────────

--- a/src/genesis/mcp/health/direct_session_tools.py
+++ b/src/genesis/mcp/health/direct_session_tools.py
@@ -3,6 +3,12 @@
 Follows the ``task_tools.py`` pattern: module-level state, init function
 for runtime wiring, ``_impl_*`` functions (testable without FastMCP),
 and ``@mcp.tool()`` decorated public wrappers.
+
+Sessions are dispatched via a DB queue (``direct_session_queue`` table).
+The MCP tool enqueues the request; the Genesis server's poll loop in
+``runtime/init/direct_session.py`` claims and dispatches to
+``DirectSessionRunner.spawn()``.  This decouples the session lifecycle
+from the MCP server process — sessions outlive the calling CC session.
 """
 
 from __future__ import annotations
@@ -17,13 +23,25 @@ logger = logging.getLogger(__name__)
 
 # Module-level state (wired at runtime via init_direct_session_tools)
 _runner = None
+_db = None
 
 
-def init_direct_session_tools(runner) -> None:
-    """Wire the DirectSessionRunner. Called from runtime init."""
-    global _runner
+def init_direct_session_tools(*, db=None, runner=None) -> None:
+    """Wire direct session tools.
+
+    In runtime mode: both db and runner are provided. The poll loop
+    in runtime/init/direct_session.py handles dispatch.
+    In standalone MCP mode: only db is provided. Items are enqueued
+    for the Genesis server's poll loop to pick up.
+    """
+    global _runner, _db
+    _db = db
     _runner = runner
-    logger.info("Direct session MCP tools wired")
+    logger.info(
+        "Direct session MCP tools wired (db=%s, runner=%s)",
+        db is not None,
+        runner is not None,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -39,9 +57,9 @@ async def _impl_direct_session_run(
     timeout_minutes: int = 15,
     notify: bool = True,
 ) -> dict:
-    """Spawn a directed background CC session."""
-    if _runner is None:
-        return {"error": "Direct session runner not initialized"}
+    """Enqueue a directed background CC session for dispatch."""
+    if _db is None:
+        return {"error": "Direct session tools not initialized (no DB)"}
 
     from genesis.cc.direct_session import VALID_PROFILES
     from genesis.cc.types import CCModel, EffortLevel
@@ -54,60 +72,107 @@ async def _impl_direct_session_run(
 
     model_lower = model.lower()
     try:
-        cc_model = CCModel(model_lower)
+        CCModel(model_lower)
     except ValueError:
         return {"error": f"Invalid model '{model}'. Must be one of: sonnet, opus, haiku"}
 
     effort_lower = effort.lower()
     try:
-        cc_effort = EffortLevel(effort_lower)
+        EffortLevel(effort_lower)
     except ValueError:
         return {"error": f"Invalid effort '{effort}'. Must be one of: low, medium, high, max"}
 
     try:
-        from genesis.cc.direct_session import DirectSessionRequest
+        from genesis.db.crud import direct_session_queue as dsq
 
-        request = DirectSessionRequest(
+        queue_id = await dsq.enqueue(
+            _db,
             prompt=prompt,
             profile=profile,
-            model=cc_model,
-            effort=cc_effort,
+            model=model_lower,
+            effort=effort_lower,
             timeout_s=min(timeout_minutes * 60, 3600),  # cap at 1 hour
             notify=notify,
             caller_context="mcp_tool",
         )
-        session_id = await _runner.spawn(request)
         return {
-            "session_id": session_id,
-            "status": "spawned",
+            "queue_id": queue_id,
+            "status": "queued",
             "profile": profile,
             "message": (
-                f"Background session started with '{profile}' profile. "
+                f"Session queued with '{profile}' profile. "
+                "The Genesis server will dispatch it within seconds. "
                 "You'll be notified via Telegram when it completes."
             ),
         }
     except Exception as exc:
         logger.error("direct_session_run failed", exc_info=True)
-        return {"error": f"Failed to spawn session: {exc}"}
+        return {"error": f"Failed to enqueue session: {exc}"}
 
 
-async def _impl_direct_session_status(session_id: str) -> dict:
-    """Check status of a direct session."""
+async def _get_db():
+    """Get a DB connection — prefer module-level, fall back to health service."""
+    if _db is not None:
+        return _db
     import genesis.mcp.health as health_mcp_mod
 
     svc = health_mcp_mod._service
     if svc is None:
-        return {"error": "Health service not available"}
+        return None
+    return getattr(svc, "_db", None)
 
-    db = getattr(svc, "_db", None)
+
+async def _impl_direct_session_status(lookup_id: str) -> dict:
+    """Check status of a direct session by queue_id or session_id."""
+    db = await _get_db()
     if db is None:
         return {"error": "Database not available"}
 
+    # If it looks like a queue_id, look up the queue row first
+    if lookup_id.startswith("dsq-"):
+        from genesis.db.crud import direct_session_queue as dsq
+
+        q_row = await dsq.get_by_id(db, lookup_id)
+        if q_row is None:
+            return {"error": f"Queue item {lookup_id} not found"}
+
+        payload = {}
+        with contextlib.suppress(json.JSONDecodeError, TypeError):
+            payload = json.loads(q_row.get("payload_json", "{}"))
+
+        result = {
+            "queue_id": lookup_id,
+            "queue_status": q_row["status"],
+            "created_at": q_row["created_at"],
+            "profile": payload.get("profile"),
+            "model": payload.get("model"),
+        }
+
+        # If dispatched, also include session details
+        if q_row.get("session_id"):
+            result["session_id"] = q_row["session_id"]
+            session_info = await _lookup_session(db, q_row["session_id"])
+            if session_info:
+                result.update(session_info)
+        elif q_row["status"] == "failed":
+            result["error"] = q_row.get("error_message")
+
+        return result
+
+    # Otherwise treat as session_id (backward compat)
+    session_info = await _lookup_session(db, lookup_id)
+    if session_info is None:
+        return {"error": f"Session {lookup_id} not found"}
+    return {"session_id": lookup_id, **session_info}
+
+
+async def _lookup_session(db, session_id: str) -> dict | None:
+    """Look up session details from cc_sessions."""
     from genesis.db.crud import cc_sessions
 
     row = await cc_sessions.get_by_id(db, session_id)
     if row is None:
-        return {"error": f"Session {session_id} not found"}
+        return None
 
     metadata = {}
     if row.get("metadata"):
@@ -115,7 +180,6 @@ async def _impl_direct_session_status(session_id: str) -> dict:
             metadata = json.loads(row["metadata"])
 
     return {
-        "session_id": session_id,
         "status": row.get("status", "unknown"),
         "source_tag": row.get("source_tag"),
         "model": row.get("model"),
@@ -138,13 +202,7 @@ async def _impl_direct_session_list(
     limit: int = 20,
 ) -> dict:
     """List recent direct sessions."""
-    import genesis.mcp.health as health_mcp_mod
-
-    svc = health_mcp_mod._service
-    if svc is None:
-        return {"error": "Health service not available"}
-
-    db = getattr(svc, "_db", None)
+    db = await _get_db()
     if db is None:
         return {"error": "Database not available"}
 
@@ -183,10 +241,20 @@ async def _impl_direct_session_list(
 
     active_count = _runner.active_count() if _runner else 0
 
+    # Include pending queue items
+    pending_count = 0
+    try:
+        from genesis.db.crud import direct_session_queue as dsq
+
+        pending_count = await dsq.count_pending(db)
+    except Exception:
+        pass
+
     return {
         "sessions": sessions,
         "count": len(sessions),
         "active_now": active_count,
+        "queued": pending_count,
     }
 
 
@@ -206,8 +274,8 @@ async def direct_session_run(
 ) -> dict:
     """Spawn a directed background CC session with profile-based tool restrictions.
 
-    The session runs independently and reports results via Telegram.
-    Returns immediately with a session_id for tracking.
+    The session is queued and dispatched by the Genesis server, so it
+    outlives this MCP session. Results are reported via Telegram.
 
     Profiles control what the session can do:
     - observe: Read everything, change nothing. Browser viewing, memory reads, web search.
@@ -230,15 +298,17 @@ async def direct_session_run(
 
 
 @mcp.tool()
-async def direct_session_status(session_id: str) -> dict:
+async def direct_session_status(lookup_id: str) -> dict:
     """Check the status and results of a direct background session.
 
-    Returns status, cost, duration, output preview, tools used, and any errors.
+    Accepts either a queue_id (dsq-...) from direct_session_run or a
+    session_id. Returns status, cost, duration, output preview, tools
+    used, and any errors.
 
     Args:
-        session_id: Session ID from direct_session_run
+        lookup_id: Queue ID or session ID from direct_session_run
     """
-    return await _impl_direct_session_status(session_id)
+    return await _impl_direct_session_status(lookup_id)
 
 
 @mcp.tool()

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -230,6 +230,7 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
         self._task_dispatcher: object | None = None
         self._task_dispatch_poll: asyncio.Task | None = None
         self._direct_session_runner: object | None = None
+        self._direct_session_poll: asyncio.Task | None = None
 
         # Global pause state — blocks all background dispatches when True.
         self._paused: bool = False

--- a/src/genesis/runtime/init/direct_session.py
+++ b/src/genesis/runtime/init/direct_session.py
@@ -3,29 +3,103 @@
 Creates a dedicated CCInvoker + DirectSessionRunner and wires the MCP
 tools.  Placed after ``cc_relay`` in bootstrap (needs session_manager)
 but accesses ``outreach_pipeline`` lazily via runtime ref.
+
+Also starts a background poll loop that claims items from the
+``direct_session_queue`` table and dispatches them to the runner.
+This decouples session lifecycle from MCP server processes — sessions
+outlive the calling CC session.
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from genesis.cc.direct_session import DirectSessionRunner
     from genesis.runtime._core import GenesisRuntime
 
 logger = logging.getLogger("genesis.runtime")
 
+_POLL_INTERVAL_S = 5
+
+
+async def _direct_session_poll(runner: DirectSessionRunner, db) -> None:
+    """Poll direct_session_queue for pending items, dispatch to runner."""
+    from genesis.cc.direct_session import DirectSessionRequest
+    from genesis.cc.types import CCModel, EffortLevel
+    from genesis.db.crud import direct_session_queue as dsq
+
+    # Crash recovery: reset items that were claimed but never dispatched
+    # before a crash/restart. Items in 'dispatched' status are intentionally
+    # excluded — they have a running session tracked in cc_sessions.
+    try:
+        recovered = await dsq.recover_stale_claims(db)
+        if recovered:
+            logger.info("Recovered %d stale direct session queue claims", recovered)
+    except Exception:
+        logger.error("Direct session stale claim recovery failed", exc_info=True)
+
+    while True:
+        try:
+            await asyncio.sleep(_POLL_INTERVAL_S)
+            row = await dsq.claim_next(db)
+            if row is None:
+                continue
+
+            queue_id = row["id"]
+            try:
+                payload = json.loads(row["payload_json"])
+                request = DirectSessionRequest(
+                    prompt=payload["prompt"],
+                    profile=payload.get("profile", "observe"),
+                    model=CCModel(payload.get("model", "sonnet")),
+                    effort=EffortLevel(payload.get("effort", "high")),
+                    timeout_s=payload.get("timeout_s", 900),
+                    notify=payload.get("notify", True),
+                    notify_on_failure_only=payload.get("notify_on_failure_only", False),
+                    caller_context=payload.get("caller_context"),
+                )
+                session_id = await runner.spawn(request)
+                await dsq.mark_dispatched(db, queue_id, session_id)
+                logger.info(
+                    "Dispatched direct session %s → %s (profile=%s)",
+                    queue_id,
+                    session_id,
+                    request.profile,
+                )
+            except Exception as exc:
+                await dsq.mark_failed(db, queue_id, str(exc))
+                logger.error(
+                    "Failed to dispatch direct session %s: %s",
+                    queue_id,
+                    exc,
+                    exc_info=True,
+                )
+
+        except asyncio.CancelledError:
+            break
+        except Exception:
+            logger.error("Direct session poll loop error", exc_info=True)
+
 
 async def init(rt: GenesisRuntime) -> None:
-    """Initialize the direct session spawner."""
+    """Initialize the direct session spawner and queue poll loop."""
     if rt._session_manager is None:
         logger.warning("Session manager not available — skipping direct session")
+        return
+
+    if rt._db is None:
+        logger.warning("DB not available — skipping direct session")
         return
 
     try:
         from genesis.cc.direct_session import DirectSessionRunner
         from genesis.cc.invoker import CCInvoker
         from genesis.cc.session_config import SessionConfigBuilder
+        from genesis.util.tasks import tracked_task
 
         # Dedicated invoker for the runner — avoids _active_proc race
         # under Semaphore(2) with the shared invoker (architect finding #5).
@@ -44,11 +118,18 @@ async def init(rt: GenesisRuntime) -> None:
         )
         rt._direct_session_runner = runner
 
-        # Wire MCP tools
+        # Wire MCP tools (pass db so they can enqueue, runner for active_count)
         from genesis.mcp.health.direct_session_tools import init_direct_session_tools
-        init_direct_session_tools(runner)
 
-        logger.info("Direct session spawner initialized")
+        init_direct_session_tools(db=rt._db, runner=runner)
+
+        # Start background poll loop to claim and dispatch queued sessions
+        rt._direct_session_poll = tracked_task(
+            _direct_session_poll(runner, rt._db),
+            name="direct-session-poll",
+        )
+
+        logger.info("Direct session spawner initialized (with queue poll loop)")
 
     except Exception:
         logger.exception("Failed to initialize direct session spawner")

--- a/src/genesis/runtime/init/direct_session.py
+++ b/src/genesis/runtime/init/direct_session.py
@@ -45,6 +45,13 @@ async def _direct_session_poll(runner: DirectSessionRunner, db) -> None:
     while True:
         try:
             await asyncio.sleep(_POLL_INTERVAL_S)
+
+            # Don't over-claim: if runner is at capacity, wait for a slot.
+            # spawn() returns immediately but sessions queue behind the
+            # internal Semaphore — claiming more just wastes queue items.
+            if runner.active_count() >= runner._MAX_CONCURRENT:
+                continue
+
             row = await dsq.claim_next(db)
             if row is None:
                 continue

--- a/tests/test_db/test_direct_session_queue.py
+++ b/tests/test_db/test_direct_session_queue.py
@@ -1,0 +1,150 @@
+"""Tests for direct_session_queue CRUD operations."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from genesis.db.crud import direct_session_queue as dsq
+
+
+class TestEnqueue:
+    @pytest.mark.asyncio
+    async def test_enqueue_returns_prefixed_id(self, db):
+        qid = await dsq.enqueue(db, prompt="hello world")
+        assert qid.startswith("dsq-")
+
+    @pytest.mark.asyncio
+    async def test_enqueue_stores_payload(self, db):
+        qid = await dsq.enqueue(
+            db,
+            prompt="investigate post removals",
+            profile="observe",
+            model="sonnet",
+            effort="high",
+            timeout_s=600,
+            notify=True,
+            caller_context="mcp_tool",
+        )
+        row = await dsq.get_by_id(db, qid)
+        assert row is not None
+        assert row["status"] == "pending"
+
+        payload = json.loads(row["payload_json"])
+        assert payload["prompt"] == "investigate post removals"
+        assert payload["profile"] == "observe"
+        assert payload["model"] == "sonnet"
+        assert payload["timeout_s"] == 600
+        assert payload["caller_context"] == "mcp_tool"
+
+    @pytest.mark.asyncio
+    async def test_enqueue_defaults(self, db):
+        qid = await dsq.enqueue(db, prompt="test")
+        row = await dsq.get_by_id(db, qid)
+        payload = json.loads(row["payload_json"])
+        assert payload["profile"] == "observe"
+        assert payload["model"] == "sonnet"
+        assert payload["effort"] == "high"
+        assert payload["timeout_s"] == 900
+        assert payload["notify"] is True
+        assert payload["notify_on_failure_only"] is False
+
+
+class TestClaimNext:
+    @pytest.mark.asyncio
+    async def test_claim_next_empty(self, db):
+        row = await dsq.claim_next(db)
+        assert row is None
+
+    @pytest.mark.asyncio
+    async def test_claim_next_returns_oldest(self, db):
+        q1 = await dsq.enqueue(db, prompt="first")
+        await dsq.enqueue(db, prompt="second")
+        row = await dsq.claim_next(db)
+        assert row is not None
+        assert row["id"] == q1
+        assert row["status"] == "claimed"
+        assert row["claimed_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_claim_next_skips_claimed(self, db):
+        q1 = await dsq.enqueue(db, prompt="first")
+        q2 = await dsq.enqueue(db, prompt="second")
+        await dsq.claim_next(db)  # claims q1
+        row = await dsq.claim_next(db)
+        assert row is not None
+        assert row["id"] == q2
+
+    @pytest.mark.asyncio
+    async def test_claim_next_skips_dispatched(self, db):
+        q1 = await dsq.enqueue(db, prompt="first")
+        row = await dsq.claim_next(db)
+        await dsq.mark_dispatched(db, q1, "sess-123")
+        row = await dsq.claim_next(db)
+        assert row is None
+
+
+class TestMarkDispatched:
+    @pytest.mark.asyncio
+    async def test_mark_dispatched(self, db):
+        qid = await dsq.enqueue(db, prompt="test")
+        await dsq.claim_next(db)
+        await dsq.mark_dispatched(db, qid, "sess-abc")
+
+        row = await dsq.get_by_id(db, qid)
+        assert row["status"] == "dispatched"
+        assert row["session_id"] == "sess-abc"
+        assert row["dispatched_at"] is not None
+
+
+class TestMarkFailed:
+    @pytest.mark.asyncio
+    async def test_mark_failed(self, db):
+        qid = await dsq.enqueue(db, prompt="test")
+        await dsq.claim_next(db)
+        await dsq.mark_failed(db, qid, "spawn error: invoker busy")
+
+        row = await dsq.get_by_id(db, qid)
+        assert row["status"] == "failed"
+        assert row["error_message"] == "spawn error: invoker busy"
+
+
+class TestRecoverStaleClaims:
+    @pytest.mark.asyncio
+    async def test_recover_stale_claims(self, db):
+        qid = await dsq.enqueue(db, prompt="test")
+        await dsq.claim_next(db)
+
+        # With max_age_s=0, everything claimed is "stale"
+        recovered = await dsq.recover_stale_claims(db, max_age_s=0)
+        assert recovered == 1
+
+        row = await dsq.get_by_id(db, qid)
+        assert row["status"] == "pending"
+        assert row["claimed_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_recover_does_not_touch_dispatched(self, db):
+        qid = await dsq.enqueue(db, prompt="test")
+        await dsq.claim_next(db)
+        await dsq.mark_dispatched(db, qid, "sess-123")
+
+        recovered = await dsq.recover_stale_claims(db, max_age_s=0)
+        assert recovered == 0
+
+        row = await dsq.get_by_id(db, qid)
+        assert row["status"] == "dispatched"
+
+
+class TestCountPending:
+    @pytest.mark.asyncio
+    async def test_count_pending(self, db):
+        assert await dsq.count_pending(db) == 0
+        await dsq.enqueue(db, prompt="a")
+        await dsq.enqueue(db, prompt="b")
+        assert await dsq.count_pending(db) == 2
+
+        # Claim one — no longer pending
+        await dsq.claim_next(db)
+        assert await dsq.count_pending(db) == 1

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -84,6 +84,7 @@ async def test_no_unexpected_tables(db):
         "follow_ups", "surplus_tasks", "surplus_insights",
         "knowledge_uploads",
         "file_modifications",
+        "direct_session_queue",
     }
     for table in tables:
         assert table in known, f"Unexpected table: {table}"


### PR DESCRIPTION
## Summary
- Routes `direct_session_run` MCP tool through a DB queue (`direct_session_queue` table) so background CC sessions outlive the calling session
- Server-side poll loop (5s) claims pending items and dispatches to `DirectSessionRunner.spawn()`
- Standalone MCP just needs DB access to enqueue — no runner, no invoker, no session manager
- Fixes the blocking MCP lifecycle issue from PR #118

## Architecture
```
MCP tool → enqueue(db) → pending
                            ↓ (poll loop, ≤5s)
                          claimed → runner.spawn() → dispatched
                                                       ↓
                                      [session lifecycle in cc_sessions]
```

## Changes
- **New table**: `direct_session_queue` (8 cols, 1 index)
- **New CRUD**: `src/genesis/db/crud/direct_session_queue.py` — enqueue, claim, dispatch, recover
- **MCP tools**: write to queue instead of spawning directly; status accepts queue_id or session_id
- **Runtime init**: poll loop + crash recovery (stale claim reset)
- **Standalone MCP**: simplified from 30-line runner bootstrap to `init_direct_session_tools(db=db)`
- **Tests**: 12 CRUD unit tests, schema allowlist updated

## Safety
- Profile enforcement unchanged (runner handles it)
- Crash recovery: stale `claimed` items reset to `pending` on startup; `dispatched` items excluded
- `dsq-` prefix on queue IDs for unambiguous routing in status tool

## Test plan
- [x] 12 CRUD unit tests pass
- [x] Schema test updated and passing
- [x] Full test suite: 5655 passed, 0 new failures
- [x] Architect review: 9 findings, all addressed
- [ ] E2E: call direct_session_run from MCP → session completes after calling CC exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)