### PR TITLE
fix: outreach pipeline — approval reuse, alert routing, surplus topic, staleness decay

### DIFF
--- a/src/genesis/autonomy/autonomous_dispatch.py
+++ b/src/genesis/autonomy/autonomous_dispatch.py
@@ -408,6 +408,9 @@ class AutonomousCliApprovalGate:
                 context.get("kind") == "autonomous_cli_fallback"
                 and context.get("approval_key") == approval_key
             ):
+                # Don't reuse consumed approvals — each dispatch needs its own.
+                if str(row.get("status") or "") == "approved" and row.get("consumed_at"):
+                    continue
                 return row
         # Pass 2: race-safety fallback — pending rows for the same site.
         if subsystem is None or policy_id is None:
@@ -422,13 +425,12 @@ class AutonomousCliApprovalGate:
                 and context.get("policy_id") == policy_id
             ):
                 return row
-        # Pass 3: resume fallback — approved rows for the same site.
-        # When a user approves a reflection/Sentinel dispatch and the
-        # resume path re-enters ensure_approval with different tick data,
-        # the approval_key won't match Pass 1. This pass picks up the
-        # approved row so the action can proceed without a second approval.
+        # Pass 3: resume fallback — unconsumed approved rows for the same site.
         for row in recent:
             if str(row.get("status") or "") != "approved":
+                continue
+            # Don't reuse consumed approvals — each dispatch needs its own.
+            if row.get("consumed_at"):
                 continue
             context = _json_loads(row.get("context"))
             if (
@@ -973,6 +975,16 @@ class AutonomousDispatchRouter:
                     approval_request_id=request_id,
                     api_error=api_error,
                 )
+            # Atomically consume — each dispatch needs its own approval.
+            if request_id:
+                consumed = await self._approval_gate.mark_consumed(request_id)
+                if not consumed:
+                    return AutonomousDispatchDecision(
+                        mode="blocked",
+                        reason="approval already consumed by concurrent dispatch",
+                        approval_request_id=request_id,
+                        api_error=api_error,
+                    )
 
         logger.info(
             "Autonomous dispatch %s approved for CLI fallback",

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -849,13 +849,17 @@ class AwarenessLoop:
                 )
                 if not approved:
                     continue
+                # Atomic consume — prevents double-dispatch across ticks.
+                # Must happen HERE, not inside route(), because skip_approval
+                # bypasses the approval gate (and its mark_consumed call).
+                consumed = await gate.mark_consumed(approved["id"])
+                if not consumed:
+                    continue  # Another tick already consumed it
                 depth = Depth.DEEP if depth_name == "deep" else Depth.STRATEGIC
                 logger.info(
                     "Resuming %s reflection from approved request %s",
                     depth_name, approved["id"][:8],
                 )
-                # skip_approval=True: the approval was already granted and
-                # will be consumed inside _cli_fallback_decision via route().
                 await self._cc_reflection_bridge.reflect(
                     depth, tick, db=self._db, skip_approval=True,
                 )

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -849,17 +849,15 @@ class AwarenessLoop:
                 )
                 if not approved:
                     continue
-                # Atomic consume — prevents double-dispatch across ticks
-                consumed = await gate.mark_consumed(approved["id"])
-                if not consumed:
-                    continue  # Another tick already consumed it
                 depth = Depth.DEEP if depth_name == "deep" else Depth.STRATEGIC
                 logger.info(
                     "Resuming %s reflection from approved request %s",
                     depth_name, approved["id"][:8],
                 )
+                # skip_approval=True: the approval was already granted and
+                # will be consumed inside _cli_fallback_decision via route().
                 await self._cc_reflection_bridge.reflect(
-                    depth, tick, db=self._db,
+                    depth, tick, db=self._db, skip_approval=True,
                 )
             except Exception:
                 logger.error(

--- a/src/genesis/awareness/scorer.py
+++ b/src/genesis/awareness/scorer.py
@@ -6,7 +6,7 @@ Staleness decay: signals whose value hasn't changed since the previous tick
 get exponentially reduced weight contribution. This prevents permanently-stuck
 signals (e.g. critical_failure=1.0 for hours) from triggering reflections
 every tick. First occurrence = full weight; each consecutive unchanged tick
-halves the contribution, flooring at 5%.
+halves the contribution, flooring at 25%.
 """
 
 from __future__ import annotations

--- a/src/genesis/awareness/scorer.py
+++ b/src/genesis/awareness/scorer.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 # ─── Staleness decay ────────────────────────────────────────────────────────
 _DECAY_BASE = 0.5   # halve contribution each unchanged tick
-_DECAY_FLOOR = 0.05  # never decay below 5%
+_DECAY_FLOOR = 0.25  # never decay below 25% (was 5%, too aggressive — nullified PR #65 scoring overhaul)
 _EPSILON = 0.001     # float comparison tolerance for 0-1 normalized signals
 
 # Module-level state: consecutive-unchanged count per signal.

--- a/src/genesis/cc/reflection_bridge/_bridge.py
+++ b/src/genesis/cc/reflection_bridge/_bridge.py
@@ -197,6 +197,7 @@ class CCReflectionBridge:
     async def reflect(
         self, depth: Depth, tick, *, db,
         escalation_source: str | None = None,
+        skip_approval: bool = False,
     ) -> ReflectionResult:
         """Run Deep or Strategic reflection via CC background session."""
         # Check CC budget before proceeding
@@ -263,34 +264,33 @@ class CCReflectionBridge:
         used_cli = True
         session_id = f"api:{depth.value.lower()}"
         if self._autonomous_dispatcher is not None:
-            # Call-site gating pre-check: if a reflection of this depth
-            # is already pending approval, skip scheduling a new one.
-            # Different depths are independently gated (deep/light/
-            # strategic each have their own policy_id), so light
-            # reflection continues even if deep is blocked.
             reflection_policy_id = f"reflection_{depth.value.lower()}"
-            try:
-                pending = await (
-                    self._autonomous_dispatcher.approval_gate.find_site_pending(
-                        subsystem="reflection",
-                        policy_id=reflection_policy_id,
+            if not skip_approval:
+                # Call-site gating pre-check: if a reflection of this depth
+                # is already pending approval, skip scheduling a new one.
+                # Skipped when skip_approval=True (resume path — already approved).
+                try:
+                    pending = await (
+                        self._autonomous_dispatcher.approval_gate.find_site_pending(
+                            subsystem="reflection",
+                            policy_id=reflection_policy_id,
+                        )
                     )
-                )
-            except Exception:
-                logger.warning(
-                    "find_site_pending failed for %s; proceeding without pre-check",
-                    reflection_policy_id, exc_info=True,
-                )
-                pending = None
-            if pending is not None:
-                logger.info(
-                    "%s reflection skipped — call site blocked on approval %s",
-                    depth.value.title(), pending.get("id"),
-                )
-                return ReflectionResult(
-                    success=False,
-                    reason=f"awaiting approval {pending.get('id')} for {depth.value} reflection",
-                )
+                except Exception:
+                    logger.warning(
+                        "find_site_pending failed for %s; proceeding without pre-check",
+                        reflection_policy_id, exc_info=True,
+                    )
+                    pending = None
+                if pending is not None:
+                    logger.info(
+                        "%s reflection skipped — call site blocked on approval %s",
+                        depth.value.title(), pending.get("id"),
+                    )
+                    return ReflectionResult(
+                        success=False,
+                        reason=f"awaiting approval {pending.get('id')} for {depth.value} reflection",
+                    )
 
             decision = await self._autonomous_dispatcher.route(
                 request=AutonomousDispatchRequest(
@@ -304,7 +304,7 @@ class CCReflectionBridge:
                     cli_invocation=invocation,
                     api_call_site_id=_DEPTH_CALL_SITE.get(depth),
                     cli_fallback_allowed=True,
-                    approval_required_for_cli=True,
+                    approval_required_for_cli=not skip_approval,
                     context={"depth": depth.value},
                 ),
             )

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -777,6 +777,16 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
             row,
         )
 
+    # Fix: stale_pending_items was INSERT OR IGNORE'd above but the row already
+    # existed from an earlier migration with ["Deep"]/0.45. UPDATE to the
+    # intended ["Micro"]/0.35 values from the PR #65 scoring overhaul.
+    await db.execute(
+        "UPDATE signal_weights "
+        "SET feeds_depths = '[\"Micro\"]', current_weight = 0.35, initial_weight = 0.35, "
+        "    source_mcp = 'cognitive_state' "
+        "WHERE signal_name = 'stale_pending_items'"
+    )
+
     # Cross-session awareness: heartbeat table for real-time session tracking.
     # Separate from cc_sessions because hooks need simple fast UPSERT and
     # cc_sessions rows may not exist for direct user CC sessions.

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -135,7 +135,7 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
     _alert_history = health_mcp_mod._alert_history
 
     if _service is None:
-        return [{"severity": "CRITICAL", "message": "HealthDataService not initialized"}]
+        return [{"id": "service:health_data_uninitialized", "severity": "CRITICAL", "message": "HealthDataService not initialized"}]
 
     snap = await _service.snapshot()
     alerts: list[dict] = []

--- a/src/genesis/outreach/config.py
+++ b/src/genesis/outreach/config.py
@@ -38,6 +38,7 @@ class OutreachConfig:
         "provider:embedding_failing",
         "provider:qdrant_unreachable",
         "awareness:tick_overdue",
+        "service:health_data_uninitialized",
     )
     # Delivery routing: per-category target — "supergroup", "dm", or "both".
     # Falls back to "default" key, then "supergroup" if unset.
@@ -76,6 +77,7 @@ _DEFAULTS = OutreachConfig(
         "provider:embedding_failing",
         "provider:qdrant_unreachable",
         "awareness:tick_overdue",
+        "service:health_data_uninitialized",
     ),
     delivery_routing={"default": "supergroup"},
 )

--- a/src/genesis/surplus/executor.py
+++ b/src/genesis/surplus/executor.py
@@ -55,19 +55,21 @@ _CALL_SITE_OVERRIDE: dict[TaskType, str] = {
     TaskType.INFRASTRUCTURE_MONITOR: "37_infrastructure_monitor",
 }
 
-# Task type → reflection depth mapping
+# Task type → reflection depth mapping.
+# Micro = signal triage / baseline change detection (cheap, fast).
+# Light = structured assessment with recommendations (deeper analysis).
 _DEPTH_MAP: dict[TaskType, Depth] = {
+    TaskType.INFRASTRUCTURE_MONITOR: Depth.MICRO,
     TaskType.BRAINSTORM_USER: Depth.LIGHT,
     TaskType.BRAINSTORM_SELF: Depth.LIGHT,
     TaskType.META_BRAINSTORM: Depth.LIGHT,
-    TaskType.MEMORY_AUDIT: Depth.MICRO,
-    TaskType.PROCEDURE_AUDIT: Depth.MICRO,
+    TaskType.MEMORY_AUDIT: Depth.LIGHT,
+    TaskType.PROCEDURE_AUDIT: Depth.LIGHT,
     TaskType.GAP_CLUSTERING: Depth.LIGHT,
     TaskType.SELF_UNBLOCK: Depth.LIGHT,
     TaskType.ANTICIPATORY_RESEARCH: Depth.LIGHT,
-    TaskType.PROMPT_EFFECTIVENESS_REVIEW: Depth.MICRO,
+    TaskType.PROMPT_EFFECTIVENESS_REVIEW: Depth.LIGHT,
     TaskType.CODE_AUDIT: Depth.LIGHT,
-    TaskType.INFRASTRUCTURE_MONITOR: Depth.LIGHT,
 }
 
 
@@ -221,7 +223,7 @@ class ReflectionBasedSurplusExecutor:
                     f"<i>Salience: {output.salience:.2f}"
                     f"{f' | Tags: {tags_str}' if tags_str else ''}</i>"
                 )
-                category = "reflection_micro"
+                category = "surplus"
 
             elif isinstance(output, LightOutput):
                 assessment = escape(output.assessment[:2000])
@@ -235,7 +237,7 @@ class ReflectionBasedSurplusExecutor:
                     f"<i>Focus: {escape(output.focus_area)} | "
                     f"Confidence: {output.confidence:.2f}</i>"
                 )
-                category = "reflection_light"
+                category = "surplus"
 
             else:
                 return

--- a/tests/test_awareness/test_scorer.py
+++ b/tests/test_awareness/test_scorer.py
@@ -173,13 +173,13 @@ def test_update_staleness_new_signal():
 
 
 def test_update_staleness_decay_floor():
-    """Decay should not go below the floor (0.05)."""
+    """Decay should not go below the floor (0.25)."""
     _signal_unchanged_counts.clear()
     _signal_unchanged_counts["sig_a"] = 10  # very stale
     current = {"sig_a": 1.0}
     prev = {"sig_a": 1.0}
     factors = _update_staleness(current, prev)
-    assert factors["sig_a"] == 0.05  # floored at 5%
+    assert factors["sig_a"] == 0.25  # floored at 25%
 
 
 def test_get_staleness_context_returns_copy():

--- a/tests/test_db/test_cognitive_state.py
+++ b/tests/test_db/test_cognitive_state.py
@@ -259,10 +259,11 @@ async def test_render_includes_stored_sections_and_focus(db):
     assert "Fix memory retrieval." in rendered
 
 
-async def test_render_empty_returns_bootstrap(db):
+async def test_render_empty_returns_bootstrap(db, tmp_path):
     from genesis.db.crud import cognitive_state
 
-    rendered = await cognitive_state.render(db)
+    # Use a non-existent patches file so production session data doesn't leak in
+    rendered = await cognitive_state.render(db, patches_file=tmp_path / "empty.json")
     assert "No cognitive state yet" in rendered
 
 

--- a/tests/test_perception/test_context.py
+++ b/tests/test_perception/test_context.py
@@ -104,6 +104,8 @@ async def test_light_context_includes_user_and_cognitive_state(db, identity_dir)
 
 
 async def test_light_context_empty_cognitive_state_uses_bootstrap(db, identity_dir):
+    from unittest.mock import patch
+
     from genesis.identity.loader import IdentityLoader
     from genesis.perception.context import ContextAssembler
 
@@ -111,7 +113,9 @@ async def test_light_context_empty_cognitive_state_uses_bootstrap(db, identity_d
     assembler = ContextAssembler(identity_loader=loader)
     tick = _make_tick(depth=Depth.LIGHT)
 
-    ctx = await assembler.assemble(Depth.LIGHT, tick, db=db)
+    # Mock out session patches so production data doesn't leak into the test
+    with patch("genesis.db.crud.cognitive_state.load_session_patches", return_value=[]):
+        ctx = await assembler.assemble(Depth.LIGHT, tick, db=db)
 
     assert ctx.cognitive_state is not None
     assert "No cognitive state yet" in ctx.cognitive_state


### PR DESCRIPTION
## Summary

Four fixes for notification subsystems degraded since ~April 17:

- **Approval reuse**: `_find_existing()` now skips consumed approvals (consumed_at guard). `_cli_fallback_decision()` atomically consumes on dispatch. Each dispatch requires its own approval — no reuse, no blanket passes.
- **Health alert ID**: Early-return alert in `_impl_health_alerts()` now includes `id="service:health_data_uninitialized"` + added to escalation whitelist, so it reaches Telegram instead of being suppressed as internal-only.
- **Surplus Telegram routing**: Surplus reflections now post to the `surplus` topic instead of `reflection_micro`/`reflection_light`. Depth map adjusted: infrastructure_monitor→Micro, memory_audit/procedure_audit/prompt_effectiveness_review→Light.
- **Staleness decay floor**: Raised `_DECAY_FLOOR` from 0.05 to 0.25 — the 5% floor nullified the PR #65 scoring overhaul by decaying all signals to near-zero within 10 minutes. DB migration fixes `stale_pending_items` INSERT OR IGNORE gap.
- **Test fix**: Two flaky cognitive state tests now isolate from production session patches.

## Test plan

- [ ] `ruff check . && pytest -v` passes (5665 passed, 0 failures)
- [ ] After server restart: awareness ticks show `classified_depth != None` within 1-2 hours
- [ ] Surplus reflections appear in `surplus` Telegram topic, not `reflection_light`
- [ ] New inbox evaluation creates fresh approval request (not reusing old)
- [ ] Health outreach logs show reduced suppression count

🤖 Generated with [Claude Code](https://claude.com/claude-code)