### PR TITLE
fix(dashboard): restore mouse wheel scrolling on all pages

### DIFF
--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -2680,8 +2680,11 @@
   <style>
     :root { --color-text-secondary: var(--color-text-muted, #d4d4d4e4); }
 
-    /* Override AZ's body overflow:hidden + position:fixed so dashboard can scroll */
+    /* Override AZ's body overflow:hidden + position:fixed so dashboard can scroll.
+       overscroll-behavior:auto counters index.css body{overscroll-behavior:none}
+       which blocks wheel-event scroll chaining from body→html viewport. */
     html, body { overflow: auto !important; position: static !important; height: auto !important; }
+    body { overscroll-behavior: auto !important; }
 
     /* Error banner */
     .error-banner {

--- a/src/genesis/dashboard/templates/genesis_errors.html
+++ b/src/genesis/dashboard/templates/genesis_errors.html
@@ -252,6 +252,7 @@
   <style>
     :root { --color-text-secondary: var(--color-text-muted, #d4d4d4e4); }
     html, body { overflow: auto !important; position: static !important; height: auto !important; }
+    body { overscroll-behavior: auto !important; }
 
     .error-banner {
       background: rgba(217,83,79,0.1);

--- a/src/genesis/dashboard/templates/genesis_logs.html
+++ b/src/genesis/dashboard/templates/genesis_logs.html
@@ -241,6 +241,7 @@
   <style>
     :root { --color-text-secondary: var(--color-text-muted, #d4d4d4e4); }
     html, body { overflow: auto !important; position: static !important; height: auto !important; }
+    body { overscroll-behavior: auto !important; }
 
     .error-banner {
       background: rgba(217,83,79,0.1);

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -9,6 +9,7 @@
 <style>
 :root { --color-text-secondary: var(--color-text-muted, #d4d4d4e4); }
 html, body { overflow: auto !important; position: static !important; height: auto !important; }
+body { overscroll-behavior: auto !important; }
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body {
     background: var(--color-background, #0f172a);


### PR DESCRIPTION
## Summary

- Override `overscroll-behavior: none` (from AZ framework's `index.css`) to `auto` on body in all 4 dashboard templates
- Root cause: body has `overflow: auto` but `height: auto` makes it expand to fit content (no internal overflow). Wheel events hit body's scroll boundary immediately, and `overscroll-behavior: none` blocks chaining to the html viewport — the actual scroll container
- Regression introduced by d51c785d (2026-04-05) which added `index.css` with `body { overscroll-behavior: none }` after the scroll override was written
- Knowledge tab was unaffected because it has its own `overflow-y: auto` container

## Test plan

- [ ] Mouse wheel scrolling on Overview, Internals, Sessions, Config, Memory tabs
- [ ] Knowledge tab still scrolls within its panel
- [ ] Scrollbar clicking still works on all tabs
- [ ] Event Log, Error Log, Neural Monitor pages — wheel scroll works
- [ ] Kill Switch footer stays fixed at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)