### PR TITLE
fix(dashboard): sentinel yellow indicator for approval states

### DIFF
--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -2132,8 +2132,9 @@
             if (sentinel.current_state === "escalated") {
               return { state: "error", reason: "sentinel escalated — CC diagnosis failed" };
             }
-            if (sentinel.current_state === "investigating" || sentinel.current_state === "remediating") {
-              return { state: "degraded", reason: `sentinel ${sentinel.current_state}` };
+            if (["investigating", "remediating", "awaiting_dispatch_approval", "awaiting_action_approval"].includes(sentinel.current_state)) {
+              const label = sentinel.current_state.startsWith("awaiting") ? "awaiting approval" : sentinel.current_state;
+              return { state: "degraded", reason: `sentinel ${label}` };
             }
           }
           return { state: "healthy", reason: `${svcLabel} and watchdog services are active` };
@@ -3684,7 +3685,7 @@
                             if (!s || !s.enabled) return '#666';
                             if (s.current_state === 'healthy') return '#4caf50';
                             if (s.current_state === 'escalated') return '#d9534f';
-                            if (s.current_state === 'investigating' || s.current_state === 'remediating') return '#f0ad4e';
+                            if (['investigating', 'remediating', 'awaiting_dispatch_approval', 'awaiting_action_approval'].includes(s.current_state)) return '#f0ad4e';
                             return '#666';  // unknown/future state — gray, not yellow
                           })()}`"></span>
                     Sentinel
@@ -3693,6 +3694,7 @@
                             const s = $store.genesisDashboard.health.services?.sentinel;
                             if (!s || !s.enabled) return '';
                             if (s.is_active) return '(running)';
+                            if (s.current_state.startsWith('awaiting')) return '(awaiting approval)';
                             if (s.current_state !== 'healthy') return '(' + s.current_state + ')';
                             return '';
                           })()"></span>

--- a/tests/test_mcp/test_browser_tools.py
+++ b/tests/test_mcp/test_browser_tools.py
@@ -78,6 +78,7 @@ class TestEnsureBrowserRecovery:
     @pytest.mark.asyncio
     async def test_recovers_from_stale_page(self):
         """If page is dead, _ensure_browser cleans up and re-initializes."""
+        pytest.importorskip("camoufox", reason="camoufox not installed")
         dead_page = MagicMock()
         dead_page.is_closed.return_value = True
         browser._stealth_page = dead_page
@@ -125,6 +126,7 @@ class TestEnsureChromiumRecovery:
 
     @pytest.mark.asyncio
     async def test_recovers_from_stale_chromium(self):
+        pytest.importorskip("playwright", reason="playwright not installed")
         dead_page = MagicMock()
         dead_page.is_closed.return_value = True
         browser._page = dead_page


### PR DESCRIPTION
## Summary

- Sentinel dashboard dot now shows yellow for `awaiting_dispatch_approval` and `awaiting_action_approval` states (was falling through to gray)
- Detail text shows "(awaiting approval)" for human-readable context
- Browser tests (`test_recovers_from_stale_page`, `test_recovers_from_stale_chromium`) now skip in CI where camoufox/playwright aren't installed instead of failing

## Test plan

- [x] `ruff check .` passes
- [x] All 10 browser tests pass locally (skip will activate in CI)
- [x] Visual verification: sentinel dot color mapping covers all 6 states

🤖 Generated with [Claude Code](https://claude.com/claude-code)