### PR TITLE
fix(browser): deploy scaled noVNC viewer — fixes off-center logo and clipping

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -481,6 +481,14 @@ if [[ -f "$WATCHGOD_SRC" ]]; then
     systemctl --user enable --now genesis-tmp-watchgod.service 2>/dev/null && \
         echo "  genesis-tmp-watchgod.service enabled + started" || true
 fi
+
+# --- VNC stack (collaborative browser mode) ---
+echo "--- Setting up VNC stack ---"
+if bash "$GENESIS_ROOT/scripts/setup-vnc.sh" 2>&1 | sed 's/^/  /'; then
+    echo "  VNC stack ready"
+else
+    echo "  VNC setup failed (non-fatal — run scripts/setup-vnc.sh manually)"
+fi
 echo
 
 # --- Memory restore ---

--- a/scripts/setup-vnc.sh
+++ b/scripts/setup-vnc.sh
@@ -106,6 +106,13 @@ EOF
 
 echo "Systemd units written to $SYSTEMD_DIR"
 
+# ── 3b. Deploy scaled noVNC viewer ────────────────────────
+# vnc_scaled.html forces scaleViewport=true so the display fits the browser
+# window without clipping. Stock vnc.html defaults to no scaling (off-center
+# logo, bottom-right cut off on displays wider than the browser window).
+cp "$SCRIPT_DIR/vnc_scaled.html" /usr/share/novnc/vnc_scaled.html
+echo "✓ Deployed scripts/vnc_scaled.html → /usr/share/novnc/vnc_scaled.html"
+
 # ── 4. Enable and start ──────────────────────────────────
 # Ensure user session bus is available
 export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
@@ -146,9 +153,9 @@ if $OK; then
     # Try to get Tailscale IP for the access URL
     TS_IP=$(tailscale ip -4 2>/dev/null || echo "")
     if [ -n "$TS_IP" ]; then
-        echo "Access noVNC at: http://$TS_IP:6080/vnc.html"
+        echo "Access noVNC at: http://$TS_IP:6080/vnc_scaled.html"
     else
-        echo "Access noVNC at: http://localhost:6080/vnc.html"
+        echo "Access noVNC at: http://localhost:6080/vnc_scaled.html"
     fi
     echo "VNC password: whatever you set (default: genesis)"
     echo ""

--- a/scripts/vnc_scaled.html
+++ b/scripts/vnc_scaled.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!--
+    noVNC: scaled viewer for Genesis remote display.
+    Based on vnc_lite.html from noVNC 1.3.0.
+    Forces scaleViewport=true with a robust flexbox layout that
+    constrains the container size independently of canvas content.
+
+    Usage:
+        http://HOST:6080/vnc_scaled.html?password=PASS
+        http://HOST:6080/vnc_scaled.html  (will prompt for password)
+    -->
+    <title>Genesis Remote Display</title>
+    <meta charset="utf-8">
+    <style>
+        * { box-sizing: border-box; }
+        html, body {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;          /* prevent body scrollbars */
+            background-color: #1a1a2e;
+        }
+        body {
+            display: flex;
+            flex-direction: column;
+        }
+        #top_bar {
+            background-color: #16213e;
+            color: #e2e2e2;
+            font: bold 12px Helvetica, Arial, sans-serif;
+            padding: 6px 10px 4px 10px;
+            border-bottom: 1px solid #0f3460;
+            flex-shrink: 0;            /* never collapse the bar */
+        }
+        #status {
+            text-align: center;
+        }
+        #sendCtrlAltDelButton {
+            position: fixed;
+            top: 0px;
+            right: 0px;
+            border: 1px outset;
+            padding: 5px 8px 4px 8px;
+            cursor: pointer;
+            background: #0f3460;
+            color: #e2e2e2;
+            font-size: 11px;
+            z-index: 10;
+        }
+        #sendCtrlAltDelButton:hover {
+            background: #533483;
+        }
+        /*
+         * This is the critical layout fix:
+         * - position:absolute fills the remaining space below the top bar
+         *   without depending on height:100% inheritance
+         * - overflow:hidden prevents the canvas from expanding this container
+         * - The container size is determined by the viewport, NOT by its children
+         */
+        #screen {
+            position: absolute;
+            top: 28px;                 /* height of top_bar */
+            left: 0;
+            right: 0;
+            bottom: 0;
+            overflow: hidden;
+        }
+    </style>
+
+    <script type="module" crossorigin="anonymous">
+        import RFB from './core/rfb.js';
+
+        let rfb;
+        let desktopName;
+
+        function connectedToServer(e) {
+            status("Connected to " + desktopName);
+        }
+
+        function disconnectedFromServer(e) {
+            if (e.detail.clean) {
+                status("Disconnected");
+            } else {
+                status("Connection lost");
+            }
+        }
+
+        function credentialsAreRequired(e) {
+            const password = prompt("VNC Password:");
+            rfb.sendCredentials({ password: password });
+        }
+
+        function updateDesktopName(e) {
+            desktopName = e.detail.name;
+        }
+
+        function sendCtrlAltDel() {
+            rfb.sendCtrlAltDel();
+            return false;
+        }
+
+        function status(text) {
+            document.getElementById('status').textContent = text;
+        }
+
+        function readQueryVariable(name, defaultValue) {
+            const re = new RegExp('.*[?&]' + name + '=([^&#]*)'),
+                  match = ''.concat(document.location.href, window.location.hash).match(re);
+            if (match) {
+                return decodeURIComponent(match[1]);
+            }
+            return defaultValue;
+        }
+
+        document.getElementById('sendCtrlAltDelButton')
+            .onclick = sendCtrlAltDel;
+
+        const host = readQueryVariable('host', window.location.hostname);
+        let port = readQueryVariable('port', window.location.port);
+        const password = readQueryVariable('password');
+        const path = readQueryVariable('path', 'websockify');
+
+        status("Connecting");
+
+        let url;
+        if (window.location.protocol === "https:") {
+            url = 'wss';
+        } else {
+            url = 'ws';
+        }
+        url += '://' + host;
+        if (port) {
+            url += ':' + port;
+        }
+        url += '/' + path;
+
+        rfb = new RFB(document.getElementById('screen'), url,
+                      { credentials: { password: password } });
+
+        rfb.addEventListener("connect",  connectedToServer);
+        rfb.addEventListener("disconnect", disconnectedFromServer);
+        rfb.addEventListener("credentialsrequired", credentialsAreRequired);
+        rfb.addEventListener("desktopname", updateDesktopName);
+
+        rfb.viewOnly = readQueryVariable('view_only', false);
+
+        // Force scaling ON -- this is the whole point of this page
+        rfb.scaleViewport = true;
+    </script>
+</head>
+
+<body>
+    <div id="top_bar">
+        <div id="status">Loading</div>
+        <div id="sendCtrlAltDelButton">Send CtrlAltDel</div>
+    </div>
+    <div id="screen">
+        <!-- RFB attaches the canvas here -->
+    </div>
+</body>
+</html>

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -801,7 +801,7 @@ def _get_vnc_url() -> str:
         )
         if result.returncode == 0 and result.stdout.strip():
             ip = result.stdout.strip().split("\n")[0]
-            return f"http://{ip}:6080/vnc.html"
+            return f"http://{ip}:6080/vnc_scaled.html"
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
-    return "http://localhost:6080/vnc.html"
+    return "http://localhost:6080/vnc_scaled.html"


### PR DESCRIPTION
## Problem

Stock \`vnc.html\` defaults to no scaling. When the Xvfb virtual display (1920x1080) is wider than the browser window, the canvas overflows — the content appears off-center and the bottom-right is clipped.

This fix was applied locally but was never committed to the repo, so the other Genesis machine still shows the broken view.

## Changes

- **\`scripts/vnc_scaled.html\`** — Custom noVNC viewer that forces \`scaleViewport = true\`. Dark Genesis theme. Uses position:absolute screen div for correct flex layout independent of canvas content.
- **\`scripts/setup-vnc.sh\`** — Step 3b deploys \`vnc_scaled.html\` to \`/usr/share/novnc/\` during VNC stack setup. Updates access URL in output to point to the scaled viewer.
- **\`browser.py\` \`_get_vnc_url()\`** — Links to \`vnc_scaled.html\` instead of stock \`vnc.html\`.

## Test plan

- [ ] Run \`setup-vnc.sh\` on the other machine — confirms deployment step runs without error
- [ ] Open \`http://<ip>:6080/vnc_scaled.html\` — display fills the browser window with no clipping
- [ ] VNC session shows browser content correctly scaled

Generated with [Claude Code](https://claude.com/claude-code)