### PR TITLE
docs: add background session decision guide

### DIFF
--- a/.claude/docs/background-sessions.md
+++ b/.claude/docs/background-sessions.md
@@ -1,0 +1,90 @@
+# Background Sessions — Decision Guide
+
+Genesis can run background CC sessions via the `direct_session_run` MCP tool.
+Read this guide any time you're considering a background session or sub-agent.
+
+## Background Session vs Sub-agent
+
+| Situation | Use |
+|---|---|
+| Task > 20 minutes | Background session |
+| Needs `memory_store` writes that must persist across sessions | Background session |
+| Needs browser automation with a persistent profile | Background session |
+| Quick research returning results to this conversation | Sub-agent |
+| Parallel analysis with no memory writes needed | Sub-agent |
+
+**Default heuristic:** If you'd need to resume it later, or if results need to
+outlive this conversation → background session. If you just need an answer in
+the next few minutes → sub-agent.
+
+## Profiles
+
+| Profile | Browser | memory_store | outreach_send | Web search |
+|---|---|---|---|---|
+| `observe` | ✗ | ✗ | ✗ | ✓ |
+| `interact` | ✓ | ✓ | ✗ | ✓ |
+| `research` | ✓ | ✓ | ✓ | ✓ |
+
+All profiles block: Bash, Edit, Write, task_submit, settings_update,
+direct_session_run. The `code` profile is intentionally disabled — background
+sessions do not write code.
+
+## Key Parameters
+
+- **`timeout_s`** — default 900 (15min). Use 3600 for research tasks. The clock
+  runs the entire time, including during rate limit waits.
+- **`model` / `effort`** — default Sonnet/High. Haiku for cheap bulk tasks.
+- **`profile`** — see table above. Choose the minimum profile that covers the task.
+
+## Always Write Progress Incrementally
+
+**Rule: instruct every background session to write findings to memory as it
+discovers them, not as a final batch at the end.**
+
+Why: Background sessions are fragile and cannot be resumed. The timeout clock
+runs continuously — including during rate limit waits. Any write committed
+before a failure is preserved; any uncommitted work is lost permanently.
+
+**Pattern to use in every prompt:**
+> "Write each [finding/target/result] to memory as you find it, not all at the end."
+
+Design your prompt around this constraint. A session that writes 15 of 20 targets
+and then times out has delivered value. A session that batches and times out
+delivers nothing.
+
+## Rate Limits Are Shared
+
+Background sessions share your account's Claude API rate limit with your
+foreground session.
+
+- Rate limit hits don't just block the background session — they block you too
+- Rate limit wait time counts against `timeout_s` — 5 min waiting = 5 min less work
+- Sessions that exhaust timeout during a wait fail with a Telegram failure notification
+- Memory writes committed before failure are preserved
+
+**Implication:** Don't run heavy background sessions during active foreground
+work. Schedule long research sessions for idle periods.
+
+## Failure Recovery
+
+There is no resume path for failed background sessions. If a session fails:
+1. Check memory for partial results (writes before failure are preserved)
+2. Relaunch with a prompt that says: "Check memory for existing progress first,
+   then continue from where it left off."
+
+Failure modes:
+- **Timeout** → Telegram notification + any committed memory writes preserved
+- **Rate limit during wait** → countdown expires → same as timeout
+- **Crash** → Telegram notification, same recovery path
+
+## MCP Tool
+
+```
+direct_session_run(
+    prompt="...",
+    profile="research",      # observe | interact | research
+    timeout_s=3600,          # 900 default, 3600 for long research
+    model="claude-sonnet-4-6",
+    effort="high",
+)
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,19 @@ CC WebSearch for general lookups, SearXNG for structured/bulk queries,
 Crawl4AI for JS-rendered pages, ATS APIs for job listings.
 Full decision guide: `.claude/docs/web-tools-guide.md`
 
+## Background Sessions
+
+**When to use a background session vs sub-agent:**
+- Task > 20 min OR needs persistent `memory_store` writes → **background session**
+- Quick research returning results to this conversation → **sub-agent**
+
+Always instruct background sessions to write progress incrementally — never batch at the end.
+
+Profiles: `observe` · `interact` · `research` — use the minimum that covers the task.
+
+**Always read the full guide before dispatching a background session:**
+`.claude/docs/background-sessions.md`
+
 ## Genesis Development Work
 
 When the task involves modifying Genesis itself — fixing bugs, implementing


### PR DESCRIPTION
## Summary
- Adds `.claude/docs/background-sessions.md` — full operational guide covering when to use background sessions vs sub-agents, profiles, incremental write rule, rate limit behavior, and failure recovery
- Updates `CLAUDE.md` with inline decision logic (bg session vs sub-agent) and a mandatory read pointer to the guide

## Why
Genesis sessions in fresh contexts lacked clear guidance on background session mechanics — when to use them, which profile to pick, and the critical rule that sessions must write progress incrementally (sessions are fragile: no resume, timeout clock runs during rate limit waits, uncommitted writes lost on failure).

## Test plan
- [ ] Read `.claude/docs/background-sessions.md` and verify it matches the design agreed in session
- [ ] Read `CLAUDE.md` Background Sessions section and verify decision logic is correct and concise

🤖 Generated with [Claude Code](https://claude.com/claude-code)