### PR TITLE
fix(vnc): remove -ncache flag that distorted noVNC local scaling

### DIFF
--- a/scripts/setup-vnc.sh
+++ b/scripts/setup-vnc.sh
@@ -68,7 +68,9 @@ EOF
 # Flags:
 #   -xdamage   — use X DAMAGE extension to only send changed regions (was -noxdamage)
 #   -threads   — multi-threaded encoding for better FPS
-#   -ncache 10 — client-side pixel caching for faster scrolling/tab switching
+#   NOTE: -ncache was removed — it creates a hidden pixel cache below the
+#   visible screen that makes the framebuffer ~11x taller, causing noVNC
+#   local scaling to produce a stretched/distorted view.
 #   xclip required for clipboard sync (installed above)
 cat > "$SYSTEMD_DIR/genesis-vnc.service" << EOF
 [Unit]
@@ -79,7 +81,7 @@ Requires=genesis-xvfb.service
 [Service]
 Type=simple
 Environment=DISPLAY=:99
-ExecStart=/usr/bin/x11vnc -display :99 -forever -shared -rfbauth %h/.genesis/vnc_passwd -rfbport 5900 -xdamage -threads -ncache 10
+ExecStart=/usr/bin/x11vnc -display :99 -forever -shared -rfbauth %h/.genesis/vnc_passwd -rfbport 5900 -xdamage -threads
 Restart=on-failure
 RestartSec=3
 
@@ -110,7 +112,7 @@ echo "Systemd units written to $SYSTEMD_DIR"
 # vnc_scaled.html forces scaleViewport=true so the display fits the browser
 # window without clipping. Stock vnc.html defaults to no scaling (off-center
 # logo, bottom-right cut off on displays wider than the browser window).
-cp "$SCRIPT_DIR/vnc_scaled.html" /usr/share/novnc/vnc_scaled.html
+sudo cp "$SCRIPT_DIR/vnc_scaled.html" /usr/share/novnc/vnc_scaled.html
 echo "✓ Deployed scripts/vnc_scaled.html → /usr/share/novnc/vnc_scaled.html"
 
 # ── 4. Enable and start ──────────────────────────────────


### PR DESCRIPTION
## Summary
- Removed `-ncache 10` from x11vnc flags — it creates a hidden pixel cache 10x screen height below the visible area (1920x11880 framebuffer), causing noVNC local scaling to produce a stretched/distorted view
- Added `sudo` for `vnc_scaled.html` deploy (writes to `/usr/share/novnc/`)

## Test plan
- [x] Verified fix live — noVNC local scaling now shows correct 1920x1080 proportions

🤖 Generated with [Claude Code](https://claude.com/claude-code)