### PR TITLE
feat(browser): CDP remote backend — drive user's real Chrome over Tailscale

### DIFF
--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -41,6 +41,13 @@ _stealth_browser = None
 _stealth_page = None
 _active_page = None  # Tracks whichever page was last navigated (standard or stealth)
 
+# Layer 3: CDP remote browser (user's real Chrome over Tailscale)
+_remote_pw = None  # Separate Playwright instance (independent lifecycle from _playwright)
+_remote_browser = None  # CDP Browser connection
+_remote_page = None  # Active page on user's remote Chrome
+_remote_cdp_url: str | None = None  # e.g. "http://100.x.y.z:9222"
+_remote_last_url: str | None = None  # URL at last Genesis action (drift detection)
+
 # Collaborative mode — when True, browser launches headed on virtual display :99.
 # User watches/interacts via noVNC at http://<tailscale-ip>:6080/vnc.html
 _collaborate_mode = False
@@ -93,6 +100,9 @@ async def async_cleanup():
             await _idle_task
         _idle_task = None
     _last_used = 0.0
+
+    # Remote CDP: disconnect (does NOT close user's Chrome)
+    await _cleanup_remote_cdp()
 
     if _context is not None:
         try:
@@ -156,6 +166,7 @@ async def _ensure_browser():
             persistent_context=True,
             user_data_dir=str(_PROFILE_DIR),
             humanize=2.5,  # Native Camoufox cursor humanization (Bézier curves, max 2.5s)
+            window=(1920, 1080),  # Fill VNC display (Xvfb :99 is 1920x1080x24)
             firefox_user_prefs={
                 # Camoufox disables session history (max_entries=0) for
                 # anti-detection.  Re-enable it so back/forward navigation
@@ -210,6 +221,112 @@ async def _ensure_chromium_fallback():
         return _page
 
 
+def _on_remote_disconnected() -> None:
+    """Callback when CDP connection drops (Chrome closed, machine asleep)."""
+    global _remote_browser, _remote_page, _active_page
+    logger.warning("Remote CDP disconnected (Chrome closed or network lost)")
+    _remote_browser = None
+    if _active_page is _remote_page:
+        _active_page = None
+    _remote_page = None
+    # Preserve _remote_cdp_url so reconnection works on next call
+
+
+async def _cleanup_remote_cdp() -> None:
+    """Disconnect from remote Chrome. Does NOT close the user's browser.
+
+    Playwright's browser.close() on a CDP connection is a disconnect only —
+    it does NOT terminate the remote Chrome process.
+    """
+    global _remote_pw, _remote_browser, _remote_page, _remote_last_url
+
+    if _remote_browser is not None:
+        try:
+            await asyncio.wait_for(_remote_browser.close(), timeout=10.0)
+        except TimeoutError:
+            logger.warning("Remote CDP disconnect timed out (10s)")
+        except Exception:
+            logger.debug("Remote CDP cleanup failed", exc_info=True)
+        _remote_browser = None
+        _remote_page = None
+
+    if _remote_pw is not None:
+        try:
+            await asyncio.wait_for(_remote_pw.stop(), timeout=10.0)
+        except TimeoutError:
+            logger.warning("Remote Playwright stop timed out (10s)")
+        except Exception:
+            logger.debug("Remote Playwright cleanup failed", exc_info=True)
+        _remote_pw = None
+
+    _remote_last_url = None
+
+
+async def _ensure_remote_cdp(cdp_url: str | None = None):
+    """Connect to the user's Chrome via CDP over Tailscale.
+
+    Returns the active remote page. The user must have Chrome running with
+    ``--remote-debugging-port=9222``. Connection is via Tailscale IP.
+
+    Does NOT launch Chrome. Does NOT close the user's existing tabs.
+    On disconnect, clears state — next call gets a clear error.
+    """
+    global _remote_pw, _remote_browser, _remote_page, _remote_cdp_url
+
+    async with _browser_lock:
+        # Already connected and alive — reuse
+        if _remote_page is not None and _remote_browser is not None:
+            if _remote_browser.is_connected() and _is_page_alive(_remote_page):
+                return _remote_page
+            logger.warning("Remote CDP connection stale — cleaning up")
+            await _cleanup_remote_cdp()
+
+        # Resolve CDP URL: explicit > env > stored
+        url = cdp_url or os.environ.get("GENESIS_CDP_URL") or _remote_cdp_url
+        if not url:
+            raise ConnectionError(
+                "No CDP URL configured. Pass cdp_url parameter or set "
+                "GENESIS_CDP_URL in secrets.env.\n\n"
+                "User setup: Launch Chrome on your machine with:\n"
+                "  chrome.exe --remote-debugging-port=9222 "
+                "--user-data-dir=%USERPROFILE%\\chrome-genesis"
+            )
+
+        from playwright.async_api import async_playwright
+
+        _remote_pw = await async_playwright().start()
+        try:
+            _remote_browser = await _remote_pw.chromium.connect_over_cdp(url)
+        except Exception as e:
+            await _remote_pw.stop()
+            _remote_pw = None
+            raise ConnectionError(
+                f"Cannot connect to Chrome at {url}. Error: {e}\n\n"
+                "Check:\n"
+                "  1. Chrome is running with --remote-debugging-port=9222\n"
+                "  2. Tailscale is connected on both machines\n"
+                "  3. Windows firewall allows port 9222 from Tailscale"
+            ) from e
+
+        _remote_cdp_url = url
+        _remote_browser.on("disconnected", lambda: _on_remote_disconnected())
+
+        # Use existing tab or create new one — never close user's tabs
+        contexts = _remote_browser.contexts
+        if contexts and contexts[0].pages:
+            _remote_page = contexts[0].pages[-1]
+            logger.info("CDP remote connected — using existing tab: %s", _remote_page.url)
+        elif contexts:
+            _remote_page = await contexts[0].new_page()
+            logger.info("CDP remote connected — created new tab")
+        else:
+            ctx = await _remote_browser.new_context()
+            _remote_page = await ctx.new_page()
+            logger.info("CDP remote connected — created new context and tab")
+
+        return _remote_page
+
+
 def _touch():
     """Record browser activity timestamp for idle timeout tracking."""
     global _last_used
@@ -245,18 +362,27 @@ def _start_idle_watcher():
         )
 
 
-async def _get_page(stealth: bool = False):
+async def _get_page(
+    stealth: bool = False,
+    remote: bool = False,
+    cdp_url: str | None = None,
+):
     """Get the appropriate browser page based on mode.
 
     Default (stealth=False): Camoufox (anti-detection, primary).
     Fallback (stealth=True): Chromium (for Camoufox-incompatible sites).
-    Note: 'stealth' param is inverted from its old meaning for API compat.
+    Remote (remote=True): User's real Chrome via CDP over Tailscale.
 
     Sets _active_page so subsequent interaction tools (click, fill, etc.)
     use whichever browser was last navigated.
     """
     global _active_page
-    _active_page = await _ensure_chromium_fallback() if stealth else await _ensure_browser()
+    if remote:
+        _active_page = await _ensure_remote_cdp(cdp_url)
+    elif stealth:
+        _active_page = await _ensure_chromium_fallback()
+    else:
+        _active_page = await _ensure_browser()
     _touch()
     _start_idle_watcher()
     return _active_page
@@ -285,18 +411,74 @@ def _is_camoufox_active() -> bool:
     return _stealth_cm is not None and _active_page is _stealth_page
 
 
+def _is_remote_active() -> bool:
+    """True when the active browser is the remote CDP connection."""
+    return _remote_page is not None and _active_page is _remote_page
+
+
+def _remote_browser_connected() -> bool:
+    """Quick check if CDP remote is still connected."""
+    return _remote_browser is not None and _remote_browser.is_connected()
+
+
+def _check_remote_health() -> dict | None:
+    """Returns error dict if remote is active but disconnected. None if OK."""
+    if not _is_remote_active():
+        return None
+    if not _remote_browser_connected():
+        global _active_page, _remote_page
+        _active_page = None
+        _remote_page = None
+        return {
+            "error": (
+                "Remote Chrome connection lost. "
+                "Ask the user to restart Chrome with --remote-debugging-port=9222, "
+                "then call browser_navigate(url, remote=True) to reconnect."
+            )
+        }
+    return None
+
+
+def _check_page_drift(page) -> dict | None:
+    """Check if the remote page URL changed since Genesis last touched it.
+
+    Returns None if no drift, or a dict describing the change.
+    Non-async — uses only the synchronous page.url property.
+    """
+    if _remote_last_url is None:
+        return None
+    try:
+        current_url = page.url
+    except Exception:
+        return {
+            "drift": "page_inaccessible",
+            "detail": "Cannot read page URL — tab may have been closed",
+        }
+    if current_url != _remote_last_url:
+        return {
+            "drift": "url_changed",
+            "expected": _remote_last_url,
+            "actual": current_url,
+            "detail": (
+                f"Page URL changed from {_remote_last_url} to {current_url} "
+                "since last Genesis action"
+            ),
+        }
+    return None
+
+
 async def _human_delay() -> None:
     """Random delay mimicking human interaction timing.
 
-    Only fires when Camoufox (anti-detection browser) is active.
-    Playwright/Chromium mode skips delays entirely — that's for dev/test.
-
-    Background (default): 1.0–15.0s, log-normal distribution.
-    Stealth priority — nobody watching, look maximally human.
-
-    Collaborate mode (VNC): 0.5–2.0s, uniform.
-    Human watching — keep it responsive but not instant.
+    Remote CDP: always collaborate timing (user watching their own screen).
+    Camoufox background: 1.0–15.0s, log-normal distribution.
+    Camoufox collaborate (VNC): 0.5–2.0s, uniform.
+    Chromium: no delay (dev/test).
     """
+    if _is_remote_active():
+        # Remote CDP: user is literally watching their own screen
+        await asyncio.sleep(random.uniform(0.5, 2.0))
+        return
     if not _is_camoufox_active():
         return
     if _collaborate_mode:
@@ -585,27 +767,48 @@ async def _wait_for_turnstile(page, timeout_ms: int = 15000) -> dict | None:
 # ---------------------------------------------------------------------------
 
 
-async def _impl_browser_navigate(url: str, stealth: bool = False) -> dict:
+async def _impl_browser_navigate(
+    url: str,
+    stealth: bool = False,
+    remote: bool = False,
+    cdp_url: str | None = None,
+) -> dict:
     """Navigate to a URL and return the page snapshot."""
+    global _collaborate_mode, _remote_last_url
     _touch()
+
+    # Auto-enable collaborate timing for remote CDP (user watching their screen)
+    if remote and not _collaborate_mode:
+        _collaborate_mode = True
+        logger.info("Auto-enabled collaborate timing for remote CDP session")
+
     try:
-        page = await _get_page(stealth)
+        page = await _get_page(stealth, remote=remote, cdp_url=cdp_url)
+    except ConnectionError as e:
+        return {"error": str(e)}
     except ImportError as e:
         return {"error": f"Browser not available: {e}. Install with: pip install playwright"}
 
     try:
         await page.goto(url, wait_until="domcontentloaded", timeout=30000)
 
-        # Detect and handle Cloudflare Turnstile if present
+        # Turnstile detection only for Camoufox (real Chrome won't trigger it)
         turnstile_result = None
         if _is_camoufox_active():
             turnstile_result = await _wait_for_turnstile(page)
+
+        # Track URL for drift detection on remote sessions
+        if remote:
+            _remote_last_url = page.url
 
         snapshot = await _snapshot_page(page)
         result = {
             "url": page.url,
             "title": await page.title(),
             "snapshot": snapshot,
+            "layer": "remote_cdp" if _is_remote_active() else (
+                "camoufox" if _is_camoufox_active() else "chromium"
+            ),
         }
         if turnstile_result:
             result["turnstile"] = turnstile_result
@@ -616,6 +819,16 @@ async def _impl_browser_navigate(url: str, stealth: bool = False) -> dict:
                 )
         return result
     except Exception as e:
+        if remote and not _remote_browser_connected():
+            return {
+                "error": (
+                    "Remote Chrome disconnected during navigation. "
+                    "The user may have closed Chrome or the machine went to sleep. "
+                    "Ask the user to restart Chrome with --remote-debugging-port=9222, "
+                    "then retry."
+                ),
+                "url": url,
+            }
         logger.error("browser_navigate failed: %s", e, exc_info=True)
         return {"error": str(e), "url": url}
 
@@ -625,6 +838,16 @@ async def _impl_browser_click(selector: str) -> dict:
     _touch()
     if _active_page is None:
         return {"error": "No page open. Call browser_navigate first."}
+    health = _check_remote_health()
+    if health:
+        return health
+    drift = _check_page_drift(_active_page) if _is_remote_active() else None
+    if drift:
+        return {
+            "advisory": "Page state changed since last Genesis action.",
+            **drift,
+            "recommendation": "Call browser_snapshot() to see current page state before acting.",
+        }
     try:
         await _human_delay()
         await _stealth_click(_active_page, selector)
@@ -639,6 +862,16 @@ async def _impl_browser_fill(selector: str, value: str) -> dict:
     _touch()
     if _active_page is None:
         return {"error": "No page open. Call browser_navigate first."}
+    health = _check_remote_health()
+    if health:
+        return health
+    drift = _check_page_drift(_active_page) if _is_remote_active() else None
+    if drift:
+        return {
+            "advisory": "Page state changed since last Genesis action.",
+            **drift,
+            "recommendation": "Call browser_snapshot() to see current page state before acting.",
+        }
     try:
         await _human_delay()
         await _human_type(_active_page, selector, value)
@@ -651,6 +884,9 @@ async def _impl_browser_upload(selector: str, file_path: str) -> dict:
     """Upload a file to a file input element on the current page."""
     if _active_page is None:
         return {"error": "No page open. Call browser_navigate first."}
+    health = _check_remote_health()
+    if health:
+        return health
     p = Path(file_path)
     if not p.is_file():
         return {"error": f"File not found or not a regular file: {file_path}"}
@@ -667,6 +903,9 @@ async def _impl_browser_screenshot() -> dict:
     _touch()
     if _active_page is None:
         return {"error": "No page open. Call browser_navigate first."}
+    health = _check_remote_health()
+    if health:
+        return health
     try:
         _SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
         screenshot_path = _SCREENSHOT_DIR / "genesis_browser_screenshot.png"
@@ -685,6 +924,9 @@ async def _impl_browser_snapshot() -> dict:
     _touch()
     if _active_page is None:
         return {"error": "No page open. Call browser_navigate first."}
+    health = _check_remote_health()
+    if health:
+        return health
     try:
         snapshot = await _snapshot_page(_active_page)
         return {"url": _active_page.url, "title": await _active_page.title(), "snapshot": snapshot}
@@ -701,6 +943,9 @@ async def _impl_browser_run_js(expression: str) -> dict:
     _touch()
     if _active_page is None:
         return {"error": "No page open. Call browser_navigate first."}
+    health = _check_remote_health()
+    if health:
+        return health
     try:
         logger.info("browser_run_js: %s", expression[:200])
         result = await _active_page.evaluate(expression)
@@ -750,6 +995,9 @@ async def _impl_browser_press_key(key: str, count: int = 1) -> dict:
     _touch()
     if _active_page is None:
         return {"error": "No page open. Call browser_navigate first."}
+    health = _check_remote_health()
+    if health:
+        return health
     count = max(1, min(count, 50))
     try:
         for i in range(count):
@@ -767,7 +1015,12 @@ async def _impl_browser_press_key(key: str, count: int = 1) -> dict:
 
 
 @mcp.tool()
-async def browser_navigate(url: str, stealth: bool = False) -> dict:
+async def browser_navigate(
+    url: str,
+    stealth: bool = False,
+    remote: bool = False,
+    cdp_url: str | None = None,
+) -> dict:
     """Navigate to a URL and return an accessibility tree snapshot.
 
     Uses Camoufox (anti-detection Firefox) by default with a persistent profile
@@ -780,12 +1033,19 @@ async def browser_navigate(url: str, stealth: bool = False) -> dict:
     Set stealth=True to use Chromium fallback for sites incompatible with
     Camoufox (rare). Chromium uses a separate profile at ~/.genesis/browser-profile/.
 
-    NOTE: If Cloudflare Turnstile is detected, this call may block for up to
-    ~5 minutes while waiting for human resolution via VNC. A Telegram alert
-    is sent automatically. The response will include a 'turnstile' field with
-    the resolution status.
+    Set remote=True to drive the user's real Chrome over CDP/Tailscale.
+    This connects to Chrome running on the user's machine with
+    --remote-debugging-port=9222. Real browser = real fingerprint = no detection.
+    Collaborate timing is auto-enabled. Use for ATS submissions with aggressive
+    anti-bot detection (Ashby, Greenhouse with reCAPTCHA v3).
+
+    cdp_url: Override the CDP endpoint. Default: GENESIS_CDP_URL env var.
+    Example: browser_navigate("https://jobs.ashbyhq.com/...", remote=True)
+
+    NOTE: If Cloudflare Turnstile is detected (Camoufox only), this call may
+    block for up to ~5 minutes while waiting for human resolution via VNC.
     """
-    return await _impl_browser_navigate(url, stealth)
+    return await _impl_browser_navigate(url, stealth, remote=remote, cdp_url=cdp_url)
 
 
 @mcp.tool()
@@ -943,12 +1203,18 @@ async def browser_collaborate(enable: bool = True) -> dict:
     _collaborate_mode = enable
 
     vnc_url = _get_vnc_url()
-    return {
+    result = {
         "mode": "collaborate" if enable else "background",
         "timing": "fast (0.5-2s)" if enable else "stealth (1-15s)",
         "vnc_url": vnc_url,
         "note": "Browser is always headed on VNC. Open the URL above to watch/interact.",
     }
+    if _is_remote_active():
+        result["remote_note"] = (
+            "Remote CDP session active — collaborate timing is always used "
+            "regardless of this setting (user watching their own screen)."
+        )
+    return result
 
 
 def _get_vnc_url() -> str:

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -439,6 +439,16 @@ def _check_remote_health() -> dict | None:
     return None
 
 
+def _update_remote_url() -> None:
+    """Update drift tracking URL after a successful action that may navigate."""
+    global _remote_last_url
+    if _is_remote_active() and _active_page is not None:
+        try:
+            _remote_last_url = _active_page.url
+        except Exception:
+            pass
+
+
 def _check_page_drift(page) -> dict | None:
     """Check if the remote page URL changed since Genesis last touched it.
 
@@ -851,6 +861,7 @@ async def _impl_browser_click(selector: str) -> dict:
     try:
         await _human_delay()
         await _stealth_click(_active_page, selector)
+        _update_remote_url()  # Click may cause navigation (form submit, link)
         snapshot = await _snapshot_page(_active_page)
         return {"clicked": selector, "url": _active_page.url, "snapshot": snapshot}
     except Exception as e:
@@ -875,6 +886,7 @@ async def _impl_browser_fill(selector: str, value: str) -> dict:
     try:
         await _human_delay()
         await _human_type(_active_page, selector, value)
+        _update_remote_url()  # Fill + Enter may cause navigation
         return {"filled": selector, "url": _active_page.url}
     except Exception as e:
         return {"error": f"Fill failed on '{selector}': {e}"}
@@ -949,6 +961,7 @@ async def _impl_browser_run_js(expression: str) -> dict:
     try:
         logger.info("browser_run_js: %s", expression[:200])
         result = await _active_page.evaluate(expression)
+        _update_remote_url()  # JS may cause navigation
         return {"result": result, "url": _active_page.url}
     except Exception as e:
         return {"error": f"JS execution failed: {e}"}

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -893,12 +893,24 @@ async def _impl_browser_fill(selector: str, value: str) -> dict:
 
 
 async def _impl_browser_upload(selector: str, file_path: str) -> dict:
-    """Upload a file to a file input element on the current page."""
+    """Upload a file to a file input element on the current page.
+
+    For remote CDP: file must exist on the Genesis container (Playwright sends
+    the file contents over the wire to the remote browser).
+    """
+    _touch()
     if _active_page is None:
         return {"error": "No page open. Call browser_navigate first."}
     health = _check_remote_health()
     if health:
         return health
+    drift = _check_page_drift(_active_page) if _is_remote_active() else None
+    if drift:
+        return {
+            "advisory": "Page state changed since last Genesis action.",
+            **drift,
+            "recommendation": "Call browser_snapshot() to see current page state before acting.",
+        }
     p = Path(file_path)
     if not p.is_file():
         return {"error": f"File not found or not a regular file: {file_path}"}

--- a/src/genesis/skills/browser-automation/SKILL.md
+++ b/src/genesis/skills/browser-automation/SKILL.md
@@ -47,12 +47,26 @@ that can accomplish the task. **Token cost increases with each layer.**
   VNC — no mode switch or restart needed. Use when a human is actively
   watching to speed up interaction. Disabling restores stealth timing.
 
-### Layer 3: On-Demand MCP (heavy sessions — activate when needed)
+### Layer 3: Remote CDP (user's real Chrome over Tailscale)
+- Tool: `browser_navigate(url, remote=True)` — built into genesis-health MCP
+- Connects to user's Chrome via `playwright.chromium.connect_over_cdp()`
+- **Real browser, real fingerprint** — nothing to detect. Bulletproof for
+  ATS submissions with reCAPTCHA v3 or aggressive anti-bot detection.
+- Collaborate timing auto-enabled (user watching their own screen)
+- Drift detection: warns if user navigated away since last Genesis action
+- **User setup**: Launch Chrome with `--remote-debugging-port=9222
+  --user-data-dir=%USERPROFILE%\chrome-genesis` (Windows batch file)
+- Set `GENESIS_CDP_URL=http://<tailscale-ip>:9222` in `secrets.env`, or
+  pass `cdp_url=` parameter directly
+- Graceful errors when Chrome is offline — no retry storms
+- Camoufox stays default for non-adversarial browsing
+
+### Layer 3b: On-Demand MCP (network inspection — activate when needed)
 - Tools: Chrome DevTools MCP (29 tools) or Playwright MCP
 - Activate: `/activate-browser` → adds to `.mcp.json` → restart session
 - Deactivate when done to reclaim ~17k tokens of context budget
-- **Remote mode**: `--browserUrl http://127.0.0.1:9222` connects to user's
-  Chrome via CDP-over-SSH tunnel (uses user's logged-in sessions)
+- Use when you need network inspection, Lighthouse, or performance tracing
+  beyond what the built-in Genesis browser tools provide
 
 ### Layer 4: Computer Use (visual fallback — V4)
 - Claude Computer Use API (screenshot-based interaction)
@@ -67,9 +81,10 @@ that can accomplish the task. **Token cost increases with each layer.**
 | Fill a form on agent's account | Genesis Browser | Persistent login |
 | Site blocks automation | Genesis Browser (stealth) | Anti-detection |
 | CAPTCHA / payment / 2FA step | Genesis Browser (collaborate) | User takes VNC control |
+| ATS with reCAPTCHA v3 / Ashby | Remote CDP | Real Chrome fingerprint |
+| Submit on user's logged-in site | Remote CDP | User's sessions |
 | Network inspection / Lighthouse | On-Demand MCP | Chrome DevTools |
-| Check user's Gmail | On-Demand MCP (remote) | CDP-over-SSH |
-| Take action in user's banking app | On-Demand MCP (remote) | MUST confirm |
+| Take action in user's banking app | Remote CDP | MUST confirm |
 
 ## When to Use
 

--- a/tests/test_mcp/test_browser_tools.py
+++ b/tests/test_mcp/test_browser_tools.py
@@ -837,3 +837,24 @@ class TestRemoteHelpers:
         assert browser._remote_browser is None
         assert browser._remote_page is None
         assert browser._active_page is None
+
+    def test_update_remote_url_tracks_after_action(self):
+        """_update_remote_url syncs drift tracking after click/fill/js."""
+        page = MagicMock()
+        page.url = "https://new-page-after-submit.com"
+        browser._remote_page = page
+        browser._active_page = page
+        browser._remote_last_url = "https://old-form-page.com"
+
+        browser._update_remote_url()
+
+        assert browser._remote_last_url == "https://new-page-after-submit.com"
+
+    def test_update_remote_url_noop_when_not_remote(self):
+        """_update_remote_url does nothing when not in remote mode."""
+        browser._active_page = MagicMock()
+        browser._remote_last_url = "https://old.com"
+
+        browser._update_remote_url()
+
+        assert browser._remote_last_url == "https://old.com"  # unchanged

--- a/tests/test_mcp/test_browser_tools.py
+++ b/tests/test_mcp/test_browser_tools.py
@@ -10,28 +10,31 @@ import pytest
 from genesis.mcp.health import browser
 
 
+def _clear_all_browser_state():
+    """Clear all module-level browser state."""
+    browser._stealth_cm = None
+    browser._stealth_browser = None
+    browser._stealth_page = None
+    browser._playwright = None
+    browser._context = None
+    browser._page = None
+    browser._active_page = None
+    browser._collaborate_mode = False
+    browser._browser_lock = asyncio.Lock()
+    # Remote CDP state
+    browser._remote_pw = None
+    browser._remote_browser = None
+    browser._remote_page = None
+    browser._remote_cdp_url = None
+    browser._remote_last_url = None
+
+
 @pytest.fixture(autouse=True)
 def _reset_browser_state():
     """Reset module-level browser state before and after each test."""
-    browser._stealth_cm = None
-    browser._stealth_browser = None
-    browser._stealth_page = None
-    browser._playwright = None
-    browser._context = None
-    browser._page = None
-    browser._active_page = None
-    browser._collaborate_mode = False
-    browser._browser_lock = asyncio.Lock()
+    _clear_all_browser_state()
     yield
-    browser._stealth_cm = None
-    browser._stealth_browser = None
-    browser._stealth_page = None
-    browser._playwright = None
-    browser._context = None
-    browser._page = None
-    browser._active_page = None
-    browser._collaborate_mode = False
-    browser._browser_lock = asyncio.Lock()
+    _clear_all_browser_state()
 
 
 class TestIsPageAlive:
@@ -386,3 +389,451 @@ class TestPressKey:
         result = await browser._impl_browser_press_key("Foo")
         assert "error" in result
         assert "Foo" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# CDP Remote Browser Tests (Layer 3)
+# ---------------------------------------------------------------------------
+
+
+def _mock_remote_browser(pages=None, connected=True):
+    """Create a mock CDP browser with optional pages."""
+    mock_browser = MagicMock()
+    mock_browser.is_connected.return_value = connected
+    mock_browser.close = AsyncMock()
+    mock_browser.on = MagicMock()
+    ctx = MagicMock()
+    ctx.pages = pages or []
+    ctx.new_page = AsyncMock(return_value=MagicMock())
+    mock_browser.contexts = [ctx]
+    mock_browser.new_context = AsyncMock(return_value=ctx)
+    return mock_browser
+
+
+class TestEnsureRemoteCdp:
+    """Verify _ensure_remote_cdp connection lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_returns_alive_page_without_reconnect(self):
+        """Already-connected, alive page is reused."""
+        page = MagicMock()
+        page.is_closed.return_value = False
+        page.url = "https://example.com"
+        mock_br = _mock_remote_browser(connected=True)
+
+        browser._remote_page = page
+        browser._remote_browser = mock_br
+
+        result = await browser._ensure_remote_cdp("http://100.1.2.3:9222")
+        assert result is page
+
+    @pytest.mark.asyncio
+    async def test_reconnects_after_disconnect(self):
+        """Stale connection is cleaned up and re-established."""
+        dead_browser = _mock_remote_browser(connected=False)
+        browser._remote_browser = dead_browser
+        browser._remote_page = MagicMock()
+
+        new_page = MagicMock()
+        new_browser = _mock_remote_browser(pages=[new_page])
+
+        mock_pw = AsyncMock()
+        mock_pw.chromium.connect_over_cdp = AsyncMock(return_value=new_browser)
+        mock_pw.stop = AsyncMock()
+
+        with patch("playwright.async_api.async_playwright") as mock_apw:
+            mock_starter = AsyncMock()
+            mock_starter.start = AsyncMock(return_value=mock_pw)
+            mock_apw.return_value = mock_starter
+            result = await browser._ensure_remote_cdp("http://100.1.2.3:9222")
+
+        assert result is new_page
+        assert browser._remote_cdp_url == "http://100.1.2.3:9222"
+
+    @pytest.mark.asyncio
+    async def test_raises_connection_error_no_url(self):
+        """No CDP URL configured — clear error with setup instructions."""
+        with pytest.raises(ConnectionError, match="No CDP URL configured"):
+            await browser._ensure_remote_cdp(None)
+
+    @pytest.mark.asyncio
+    async def test_raises_connection_error_chrome_not_running(self):
+        """Chrome not running — clear error with troubleshooting."""
+        mock_pw = AsyncMock()
+        mock_pw.chromium.connect_over_cdp = AsyncMock(
+            side_effect=Exception("Connection refused")
+        )
+        mock_pw.stop = AsyncMock()
+
+        with patch("playwright.async_api.async_playwright") as mock_apw:
+            mock_starter = AsyncMock()
+            mock_starter.start = AsyncMock(return_value=mock_pw)
+            mock_apw.return_value = mock_starter
+            with pytest.raises(ConnectionError, match="Cannot connect"):
+                await browser._ensure_remote_cdp("http://100.1.2.3:9222")
+
+        # Playwright instance must be cleaned up
+        mock_pw.stop.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_uses_existing_tab(self):
+        """Picks up existing tab (last page) instead of creating new."""
+        existing_page = MagicMock()
+        existing_page.url = "https://already-open.com"
+        new_browser = _mock_remote_browser(pages=[MagicMock(), existing_page])
+
+        mock_pw = AsyncMock()
+        mock_pw.chromium.connect_over_cdp = AsyncMock(return_value=new_browser)
+
+        with patch("playwright.async_api.async_playwright") as mock_apw:
+            mock_starter = AsyncMock()
+            mock_starter.start = AsyncMock(return_value=mock_pw)
+            mock_apw.return_value = mock_starter
+            result = await browser._ensure_remote_cdp("http://100.1.2.3:9222")
+
+        assert result is existing_page  # Last tab, not first
+
+    @pytest.mark.asyncio
+    async def test_creates_new_tab_when_no_pages(self):
+        """Context exists but no pages — creates new tab."""
+        new_browser = _mock_remote_browser(pages=[])
+        created_page = MagicMock()
+        new_browser.contexts[0].new_page = AsyncMock(return_value=created_page)
+
+        mock_pw = AsyncMock()
+        mock_pw.chromium.connect_over_cdp = AsyncMock(return_value=new_browser)
+
+        with patch("playwright.async_api.async_playwright") as mock_apw:
+            mock_starter = AsyncMock()
+            mock_starter.start = AsyncMock(return_value=mock_pw)
+            mock_apw.return_value = mock_starter
+            result = await browser._ensure_remote_cdp("http://100.1.2.3:9222")
+
+        assert result is created_page
+        new_browser.contexts[0].new_page.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_resolves_url_from_env(self):
+        """Falls back to GENESIS_CDP_URL env var when no explicit URL."""
+        new_page = MagicMock()
+        new_browser = _mock_remote_browser(pages=[new_page])
+
+        mock_pw = AsyncMock()
+        mock_pw.chromium.connect_over_cdp = AsyncMock(return_value=new_browser)
+
+        with patch("playwright.async_api.async_playwright") as mock_apw, \
+             patch.dict("os.environ", {"GENESIS_CDP_URL": "http://env.url:9222"}):
+            mock_starter = AsyncMock()
+            mock_starter.start = AsyncMock(return_value=mock_pw)
+            mock_apw.return_value = mock_starter
+            await browser._ensure_remote_cdp(None)
+
+        mock_pw.chromium.connect_over_cdp.assert_awaited_once_with("http://env.url:9222")
+
+
+class TestRemotePageDrift:
+    """Verify _check_page_drift detects URL changes."""
+
+    def test_no_drift_when_url_unchanged(self):
+        page = MagicMock()
+        page.url = "https://example.com/form"
+        browser._remote_last_url = "https://example.com/form"
+
+        assert browser._check_page_drift(page) is None
+
+    def test_drift_detected_on_url_change(self):
+        page = MagicMock()
+        page.url = "https://example.com/other"
+        browser._remote_last_url = "https://example.com/form"
+
+        drift = browser._check_page_drift(page)
+        assert drift is not None
+        assert drift["drift"] == "url_changed"
+        assert drift["expected"] == "https://example.com/form"
+        assert drift["actual"] == "https://example.com/other"
+
+    def test_no_drift_when_no_previous_url(self):
+        page = MagicMock()
+        page.url = "https://example.com"
+        browser._remote_last_url = None
+
+        assert browser._check_page_drift(page) is None
+
+    def test_drift_on_inaccessible_page(self):
+        page = MagicMock()
+        type(page).url = property(lambda self: (_ for _ in ()).throw(Exception("tab closed")))
+        browser._remote_last_url = "https://example.com"
+
+        drift = browser._check_page_drift(page)
+        assert drift is not None
+        assert drift["drift"] == "page_inaccessible"
+
+
+class TestRemoteCleanup:
+    """Verify _cleanup_remote_cdp disconnects safely."""
+
+    @pytest.mark.asyncio
+    async def test_cleanup_disconnects_without_closing_chrome(self):
+        """browser.close() on CDP = disconnect, verified via mock."""
+        mock_br = _mock_remote_browser()
+        mock_pw = AsyncMock()
+        mock_pw.stop = AsyncMock()
+
+        browser._remote_browser = mock_br
+        browser._remote_page = MagicMock()
+        browser._remote_pw = mock_pw
+        browser._remote_last_url = "https://example.com"
+
+        await browser._cleanup_remote_cdp()
+
+        mock_br.close.assert_awaited_once()
+        mock_pw.stop.assert_awaited_once()
+        assert browser._remote_browser is None
+        assert browser._remote_page is None
+        assert browser._remote_pw is None
+        assert browser._remote_last_url is None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_safe_on_dead_connection(self):
+        """Cleanup doesn't raise when browser.close() fails."""
+        mock_br = _mock_remote_browser()
+        mock_br.close = AsyncMock(side_effect=Exception("already gone"))
+        mock_pw = AsyncMock()
+        mock_pw.stop = AsyncMock()
+
+        browser._remote_browser = mock_br
+        browser._remote_page = MagicMock()
+        browser._remote_pw = mock_pw
+
+        await browser._cleanup_remote_cdp()  # should not raise
+
+        assert browser._remote_browser is None
+        assert browser._remote_pw is None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_resets_all_globals(self):
+        browser._remote_browser = MagicMock()
+        browser._remote_page = MagicMock()
+        browser._remote_pw = AsyncMock()
+        browser._remote_pw.stop = AsyncMock()
+        browser._remote_browser.close = AsyncMock()
+        browser._remote_last_url = "https://test.com"
+
+        await browser._cleanup_remote_cdp()
+
+        assert browser._remote_browser is None
+        assert browser._remote_page is None
+        assert browser._remote_pw is None
+        assert browser._remote_last_url is None
+        # cdp_url preserved for reconnection
+        # (not set in this test, but verify it's not touched)
+
+
+class TestRemoteNavigate:
+    """Verify _impl_browser_navigate with remote=True."""
+
+    @pytest.mark.asyncio
+    async def test_navigate_remote_auto_enables_collaborate(self):
+        page = MagicMock()
+        page.url = "https://example.com"
+        page.title = AsyncMock(return_value="Example")
+        page.goto = AsyncMock()
+        page.is_closed.return_value = False
+        locator = MagicMock()
+        locator.aria_snapshot = AsyncMock(return_value="- heading: Example")
+        page.locator.return_value = locator
+
+        assert browser._collaborate_mode is False
+        # _ensure_remote_cdp normally sets _remote_page; mock must too
+        browser._remote_page = page
+
+        with patch.object(browser, "_ensure_remote_cdp", new_callable=AsyncMock, return_value=page):
+            result = await browser._impl_browser_navigate(
+                "https://example.com", remote=True, cdp_url="http://x:9222"
+            )
+
+        assert browser._collaborate_mode is True
+        assert result.get("layer") == "remote_cdp"
+
+    @pytest.mark.asyncio
+    async def test_navigate_remote_skips_turnstile(self):
+        page = MagicMock()
+        page.url = "https://example.com"
+        page.title = AsyncMock(return_value="Example")
+        page.goto = AsyncMock()
+        page.is_closed.return_value = False
+        locator = MagicMock()
+        locator.aria_snapshot = AsyncMock(return_value="- heading: Example")
+        page.locator.return_value = locator
+        browser._remote_page = page
+
+        with patch.object(browser, "_ensure_remote_cdp", new_callable=AsyncMock, return_value=page), \
+             patch.object(browser, "_wait_for_turnstile") as mock_turnstile:
+            await browser._impl_browser_navigate(
+                "https://example.com", remote=True, cdp_url="http://x:9222"
+            )
+
+        mock_turnstile.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_navigate_remote_connection_error(self):
+        with patch.object(
+            browser, "_ensure_remote_cdp", new_callable=AsyncMock,
+            side_effect=ConnectionError("No CDP URL configured"),
+        ):
+            result = await browser._impl_browser_navigate(
+                "https://example.com", remote=True
+            )
+
+        assert "error" in result
+        assert "No CDP URL" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_navigate_remote_tracks_url_for_drift(self):
+        page = MagicMock()
+        page.url = "https://jobs.ashbyhq.com/apply"
+        page.title = AsyncMock(return_value="Apply")
+        page.goto = AsyncMock()
+        page.is_closed.return_value = False
+        locator = MagicMock()
+        locator.aria_snapshot = AsyncMock(return_value="- heading: Apply")
+        page.locator.return_value = locator
+
+        browser._remote_page = page
+
+        with patch.object(browser, "_ensure_remote_cdp", new_callable=AsyncMock, return_value=page):
+            browser._active_page = page
+            await browser._impl_browser_navigate(
+                "https://jobs.ashbyhq.com/apply", remote=True, cdp_url="http://x:9222"
+            )
+
+        assert browser._remote_last_url == "https://jobs.ashbyhq.com/apply"
+
+
+class TestRemoteInteraction:
+    """Verify interaction tools handle remote CDP state."""
+
+    @pytest.mark.asyncio
+    async def test_click_with_drift_returns_advisory(self):
+        """When user navigated away, click returns advisory instead of acting."""
+        page = MagicMock()
+        page.url = "https://other-page.com"
+        page.is_closed.return_value = False
+        browser._active_page = page
+        browser._remote_page = page
+        browser._remote_browser = _mock_remote_browser(connected=True)
+        browser._remote_last_url = "https://original-page.com"
+
+        result = await browser._impl_browser_click("#submit")
+        assert "advisory" in result
+        assert result["drift"] == "url_changed"
+
+    @pytest.mark.asyncio
+    async def test_click_with_disconnected_remote_returns_error(self):
+        page = MagicMock()
+        browser._active_page = page
+        browser._remote_page = page
+        browser._remote_browser = _mock_remote_browser(connected=False)
+
+        result = await browser._impl_browser_click("#submit")
+        assert "error" in result
+        assert "connection lost" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_human_delay_uses_collaborate_timing_for_remote(self):
+        """Remote CDP always uses fast 0.5-2.0s timing."""
+        page = MagicMock()
+        browser._active_page = page
+        browser._remote_page = page
+
+        with patch("genesis.mcp.health.browser.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await browser._human_delay()
+
+        mock_sleep.assert_awaited_once()
+        delay = mock_sleep.call_args[0][0]
+        assert 0.5 <= delay <= 2.0
+
+    @pytest.mark.asyncio
+    async def test_fill_with_drift_returns_advisory(self):
+        page = MagicMock()
+        page.url = "https://other.com"
+        page.is_closed.return_value = False
+        browser._active_page = page
+        browser._remote_page = page
+        browser._remote_browser = _mock_remote_browser(connected=True)
+        browser._remote_last_url = "https://original.com"
+
+        result = await browser._impl_browser_fill("#email", "test@test.com")
+        assert "advisory" in result
+
+    @pytest.mark.asyncio
+    async def test_press_key_with_disconnected_returns_error(self):
+        page = MagicMock()
+        browser._active_page = page
+        browser._remote_page = page
+        browser._remote_browser = _mock_remote_browser(connected=False)
+
+        result = await browser._impl_browser_press_key("Tab")
+        assert "error" in result
+        assert "connection lost" in result["error"].lower()
+
+
+class TestRemoteHelpers:
+    """Verify remote state helper functions."""
+
+    def test_is_remote_active_true(self):
+        page = MagicMock()
+        browser._remote_page = page
+        browser._active_page = page
+        assert browser._is_remote_active() is True
+
+    def test_is_remote_active_false_no_remote(self):
+        assert browser._is_remote_active() is False
+
+    def test_is_remote_active_false_different_page(self):
+        browser._remote_page = MagicMock()
+        browser._active_page = MagicMock()  # different object
+        assert browser._is_remote_active() is False
+
+    def test_remote_browser_connected(self):
+        browser._remote_browser = MagicMock()
+        browser._remote_browser.is_connected.return_value = True
+        assert browser._remote_browser_connected() is True
+
+    def test_remote_browser_not_connected(self):
+        browser._remote_browser = MagicMock()
+        browser._remote_browser.is_connected.return_value = False
+        assert browser._remote_browser_connected() is False
+
+    def test_remote_browser_none(self):
+        assert browser._remote_browser_connected() is False
+
+    def test_check_remote_health_ok(self):
+        """Non-remote page — returns None."""
+        browser._active_page = MagicMock()
+        assert browser._check_remote_health() is None
+
+    def test_check_remote_health_disconnected(self):
+        page = MagicMock()
+        browser._active_page = page
+        browser._remote_page = page
+        browser._remote_browser = MagicMock()
+        browser._remote_browser.is_connected.return_value = False
+
+        result = browser._check_remote_health()
+        assert result is not None
+        assert "error" in result
+        assert browser._active_page is None
+        assert browser._remote_page is None
+
+    def test_on_remote_disconnected_clears_state(self):
+        page = MagicMock()
+        browser._remote_browser = MagicMock()
+        browser._remote_page = page
+        browser._active_page = page
+
+        browser._on_remote_disconnected()
+
+        assert browser._remote_browser is None
+        assert browser._remote_page is None
+        assert browser._active_page is None


### PR DESCRIPTION
## Summary

- **CDP remote browser backend (Layer 3):** `browser_navigate(url, remote=True)` connects to user's real Windows Chrome via `playwright.chromium.connect_over_cdp()` over Tailscale. Real browser = real fingerprint = undetectable by reCAPTCHA v3.
- **Page-state drift detection:** warns when user navigated away mid-session instead of blindly acting on wrong page
- **Camoufox viewport fix:** `window=(1920, 1080)` fills the VNC display — no more cut-off page bottoms

### What's in the PR

| Area | Changes |
|------|---------|
| `browser.py` | New globals, `_ensure_remote_cdp()`, `_cleanup_remote_cdp()`, disconnect callback, drift detection, health guards on all interaction tools, `_human_delay` remote path, auto-collaborate for CDP |
| Tests | 32 new tests (58 total) across 7 test classes: connection lifecycle, drift, cleanup, navigate, interaction, helpers |
| SKILL.md | Layer 3 remote CDP docs, updated selection guide |

### Design decisions

- Separate Playwright instance for CDP (independent lifecycle from Chromium fallback)
- `browser.close()` on CDP = disconnect only — never closes user's Chrome
- No auto-reconnect — clear error with setup instructions when Chrome offline
- Drift detection returns advisory, not error (user may have intentionally navigated)
- Collaborate timing always auto-enabled for remote (user watching their own screen)

## Test plan

- [x] All 58 browser tool tests pass
- [x] Full suite: 5761 passed, 5 skipped, 0 failed
- [x] Lint clean (pre-existing az_plugins error only)
- [ ] Manual smoke: connect to user's Windows Chrome via CDP over Tailscale
- [ ] Manual smoke: verify Camoufox viewport fills VNC display
- [ ] Manual smoke: verify drift detection when user navigates away

🤖 Generated with [Claude Code](https://claude.com/claude-code)