### PR TITLE
chore(surplus): deactivate broken analytical tasks

### DIFF
--- a/src/genesis/follow_ups/dispatcher.py
+++ b/src/genesis/follow_ups/dispatcher.py
@@ -163,8 +163,10 @@ class FollowUpDispatcher:
 
         if "benchmark" in content or "eval" in content:
             return TaskType.MODEL_EVAL, ComputeTier.FREE_API, {"source": "follow_up", "follow_up_id": fu["id"]}
+        # DEACTIVATED: anticipatory_research has no web search — route to
+        # brainstorm_self until redesigned as CC session task.
         if "research" in content:
-            return TaskType.ANTICIPATORY_RESEARCH, ComputeTier.FREE_API, {"source": "follow_up", "follow_up_id": fu["id"]}
+            return TaskType.BRAINSTORM_SELF, ComputeTier.FREE_API, {"source": "follow_up", "follow_up_id": fu["id"]}
         if "brainstorm" in content:
             return TaskType.BRAINSTORM_SELF, ComputeTier.FREE_API, {"source": "follow_up", "follow_up_id": fu["id"]}
         if "cleanup" in content or "disk" in content:

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -412,8 +412,13 @@ class SurplusScheduler:
 
             analytical_tasks = [
                 (TaskType.GAP_CLUSTERING, 0.4, "competence"),
-                (TaskType.ANTICIPATORY_RESEARCH, 0.3, "curiosity"),
-                (TaskType.PROMPT_EFFECTIVENESS_REVIEW, 0.3, "competence"),
+                # DEACTIVATED: anticipatory_research has no web search — pure
+                # LLM speculation.  Redesign as CC session task with tool access.
+                # (TaskType.ANTICIPATORY_RESEARCH, 0.3, "curiosity"),
+                # DEACTIVATED: prompt_effectiveness_review reviews outputs, not
+                # prompts.  Redesign to actually analyze prompt templates vs
+                # output quality.
+                # (TaskType.PROMPT_EFFECTIVENESS_REVIEW, 0.3, "competence"),
             ]
             for task_type, priority, drive in analytical_tasks:
                 pending = await self._queue.pending_by_type(task_type)

--- a/tests/test_surplus/test_scheduler.py
+++ b/tests/test_surplus/test_scheduler.py
@@ -118,8 +118,10 @@ async def test_start_and_stop(db):
     assert sched._scheduler.get_job("surplus_brainstorm_check") is not None
     assert sched._scheduler.get_job("surplus_dispatch") is not None
     assert sched._scheduler.get_job("schedule_code_audit") is not None
-    # Brainstorm (2) + code audit (1) + code index (1) + infra monitor (1) + maintenance (7) = 12
-    assert await sched._queue.pending_count() == 12
+    # Brainstorm (2) + code audit (1) + code index (1) + infra monitor (1)
+    # + maintenance (4) + analytical (1: gap_clustering) = 10
+    # (anticipatory_research and prompt_effectiveness_review deactivated)
+    assert await sched._queue.pending_count() == 10
     # Stop should not raise
     await sched.stop()
 
@@ -131,8 +133,9 @@ async def test_start_without_code_audits(db):
     assert sched._scheduler.running is True
     # Code audit job should NOT be registered
     assert sched._scheduler.get_job("schedule_code_audit") is None
-    # Brainstorm (2) + code index (1) + infra monitor (1) + maintenance (7) = 11
-    assert await sched._queue.pending_count() == 11
+    # Brainstorm (2) + code index (1) + infra monitor (1)
+    # + maintenance (4) + analytical (1: gap_clustering) = 9
+    assert await sched._queue.pending_count() == 9
     await sched.stop()
 
 


### PR DESCRIPTION
## Summary
- Deactivates `anticipatory_research` and `prompt_effectiveness_review` from `schedule_analytical`
- Both tasks are generating noise without producing value:
  - **anticipatory_research**: 52 pending, 0 promoted — pure LLM speculation without web search or tool access
  - **prompt_effectiveness_review**: 44 pending, 0 promoted — reviews outputs not prompts, misaligned with its stated purpose
- `gap_clustering` remains active
- Code and task types preserved for future proper redesign with CC session access

## Data
```
anticipatory_research:  53 total | 52 pending | 0 promoted | avg conf 0.69
prompt_effectiveness:   44 total | 44 pending | 0 promoted | avg conf 0.50
```

## Test plan
- [x] `pytest tests/test_surplus/test_scheduler.py -v` — 12/12 pass
- [x] Full suite — 5776 passed, 0 failures
- [x] Lint clean (pre-existing B008 in az_plugins excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)