### PR TITLE
fix(outreach): exempt approval requests from dedup

### DIFF
--- a/src/genesis/outreach/governance.py
+++ b/src/genesis/outreach/governance.py
@@ -41,6 +41,7 @@ _DEDUP_WINDOWS: dict[str, int] = {
     "surplus_insight": 24,
     "surplus_opportunity": 24,
     "content_review": 1,  # Short window — distinct content pieces may share topics
+    "cli_approval": 0,  # Never dedup — every approval request must be delivered
 }
 _DEFAULT_DEDUP_HOURS = 24
 

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -159,7 +159,7 @@ class OutreachPipeline:
         # Wrapped in try/except: submit_raw must stay reliable even if DB is down.
         try:
             if await self._governance.is_duplicate(request):
-                logger.info(
+                logger.warning(
                     "submit_raw dedup suppressed: signal=%s topic=%r",
                     request.signal_type, request.topic,
                 )


### PR DESCRIPTION
## Summary

- Approval requests (`cli_approval` signal type) now bypass the outreach dedup check entirely
- Dedup suppression log elevated from INFO to WARNING for visibility

## Root Cause

The ego was deadlocked for 12 hours because the second approval request was silently rejected by the 24-hour default dedup window. The `cli_approval` signal type had no explicit entry in `_DEDUP_WINDOWS`, so it fell through to the 24h default. The first approval (delivered 2 hours earlier) matched, and the second was suppressed — created in DB but never sent to Telegram.

## Test plan

- [x] 108 outreach tests pass
- [x] Lint clean
- [ ] After merge: verify ego approval requests always deliver to Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)