### PR TITLE
feat(surplus): pipeline infrastructure + infra monitor removal

### DIFF
--- a/config/surplus.yaml
+++ b/config/surplus.yaml
@@ -12,7 +12,6 @@ jobs:
   brainstorm_check_hours: 12
   code_audit_hours: 12
   code_index_hours: 4
-  infra_monitor_hours: 2
   recon_gather_hours: 84       # ~3.5 days
   maintenance_hours: 6
   analytical_hours: 24            # gap_clustering, anticipatory_research, prompt_effectiveness

--- a/src/genesis/runtime/init/surplus.py
+++ b/src/genesis/runtime/init/surplus.py
@@ -73,7 +73,6 @@ async def init(rt: GenesisRuntime) -> None:
             task_expiry_hours=int(dispatch.get("task_expiry_hours", 72)),
             code_audit_hours=int(jobs.get("code_audit_hours", 12)),
             code_index_hours=int(jobs.get("code_index_hours", 4)),
-            infra_monitor_hours=int(jobs.get("infra_monitor_hours", 2)),
             recon_gather_hours=int(jobs.get("recon_gather_hours", 84)),
             maintenance_hours=int(jobs.get("maintenance_hours", 6)),
             analytical_hours=int(jobs.get("analytical_hours", 24)),

--- a/src/genesis/sentinel/prompts/SENTINEL.md
+++ b/src/genesis/sentinel/prompts/SENTINEL.md
@@ -67,6 +67,16 @@ Common infrastructure failures and their fixes:
 | Guardian heartbeat stale | Check `~/.genesis/guardian_heartbeat.json` age | SSH probe to verify Guardian is alive vs heartbeat delivery broken |
 | Auth blocking health probes | Check dashboard auth config | Verify /api/ routes are exempted from auth |
 
+## Grounding Rules
+
+- ONLY propose commands from the Failure Inventory above, or commands you
+  have VERIFIED exist by running `which <command>`, `systemctl --user
+  list-units`, or `ls <path>` first.
+- NEVER invent service names, log paths, or configuration files. If you
+  are unsure whether something exists, use Bash to check before proposing.
+- If you cannot find the right command, set `proposed_actions` to `[]`
+  and explain what you need in `recommendation`.
+
 ## Output Format
 
 Output a JSON block with your diagnosis and proposed actions. The dispatcher

--- a/src/genesis/surplus/executor.py
+++ b/src/genesis/surplus/executor.py
@@ -234,6 +234,20 @@ class SurplusLLMExecutor:
 
         context = await self._gather_context(task)
 
+        # Inject previous pipeline step output into context if present
+        if task.payload:
+            try:
+                import json as _json
+                payload_data = _json.loads(task.payload)
+                prev = payload_data.get("previous_output")
+                if prev:
+                    context = (
+                        f"## Previous Step Output\n{prev}\n\n"
+                        f"## Additional Context\n{context}"
+                    )
+            except (ValueError, TypeError):
+                pass
+
         if task.task_type == TaskType.INFRASTRUCTURE_MONITOR:
             return template.format(signals=context)
         return template.format(context=context)

--- a/src/genesis/surplus/executor.py
+++ b/src/genesis/surplus/executor.py
@@ -237,8 +237,7 @@ class SurplusLLMExecutor:
         # Inject previous pipeline step output into context if present
         if task.payload:
             try:
-                import json as _json
-                payload_data = _json.loads(task.payload)
+                payload_data = json.loads(task.payload)
                 prev = payload_data.get("previous_output")
                 if prev:
                     context = (

--- a/src/genesis/surplus/executor.py
+++ b/src/genesis/surplus/executor.py
@@ -76,7 +76,10 @@ _TASK_PROMPTS: dict[TaskType, str] = {
         "patterns, or trends that could become problems.\n\n"
         "If everything is operating normally with no concerns, respond with "
         "exactly the word NOMINAL and nothing else.\n\n"
-        "Respond in plain text (2-4 sentences for concerns, or just NOMINAL)."
+        "Respond in plain text (2-4 sentences for concerns, or just NOMINAL).\n\n"
+        "Do not reference specific system commands, service names, or file "
+        "paths unless you have verified they exist.  Report what you observe, "
+        "not what you assume the fix would be."
     ),
     TaskType.BRAINSTORM_USER: (
         "You are brainstorming ways to create value for your user.\n\n"

--- a/src/genesis/surplus/pipelines.py
+++ b/src/genesis/surplus/pipelines.py
@@ -1,0 +1,103 @@
+"""Surplus pipeline definitions — deterministic multi-step task chains.
+
+A pipeline is a sequence of steps, each executed as a surplus task.
+The dispatcher mechanically advances steps — the LLM never decides
+whether the next step happens. Think factory conveyor belt: the worker
+at station 1 doesn't decide if the part goes to station 2.
+
+Pipeline state travels in the existing `payload` JSON field on
+surplus_tasks (no schema migration needed).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+
+from genesis.surplus.types import ComputeTier, TaskType
+
+logger = logging.getLogger(__name__)
+
+# ── Payload key used to identify pipeline tasks ──────────────────────
+PIPELINE_KEY = "pipeline"
+
+
+@dataclass(frozen=True)
+class PipelineStep:
+    """One step in a surplus pipeline."""
+
+    task_type: TaskType
+    compute_tier: ComputeTier
+    prompt_key: str  # Key into the executor's _TASK_PROMPTS or a custom template
+    priority: float = 0.5
+
+
+@dataclass(frozen=True)
+class PipelineDefinition:
+    """A named, deterministic sequence of surplus task steps."""
+
+    name: str
+    steps: tuple[PipelineStep, ...]
+    drive_alignment: str
+    description: str
+
+
+# ── Pipeline registry ────────────────────────────────────────────────
+# Add pipelines here as they are built. Each pipeline is a code-level
+# definition — no DB config, no YAML. Adding a pipeline = adding an
+# entry to this dict.
+
+PIPELINES: dict[str, PipelineDefinition] = {}
+
+
+# ── Payload helpers ──────────────────────────────────────────────────
+
+def is_pipeline_task(payload: str | None) -> bool:
+    """Return True if this task's payload marks it as a pipeline step."""
+    if not payload:
+        return False
+    try:
+        data = json.loads(payload)
+        return PIPELINE_KEY in data
+    except (json.JSONDecodeError, TypeError):
+        return False
+
+
+def parse_pipeline_payload(payload: str) -> dict:
+    """Parse pipeline metadata from a task payload.
+
+    Returns dict with keys: pipeline, pipeline_run_id, step, total_steps,
+    and optionally previous_output.
+    """
+    return json.loads(payload)
+
+
+def build_initial_payload(pipeline_name: str, total_steps: int) -> str:
+    """Build the payload JSON for step 1 of a pipeline."""
+    return json.dumps({
+        PIPELINE_KEY: pipeline_name,
+        "pipeline_run_id": str(uuid.uuid4()),
+        "step": 1,
+        "total_steps": total_steps,
+    })
+
+
+def build_next_step_payload(
+    current_payload: dict,
+    step_output: str,
+) -> str:
+    """Build the payload for the next step, carrying forward the previous output."""
+    return json.dumps({
+        PIPELINE_KEY: current_payload[PIPELINE_KEY],
+        "pipeline_run_id": current_payload["pipeline_run_id"],
+        "step": current_payload["step"] + 1,
+        "total_steps": current_payload["total_steps"],
+        "previous_output": step_output[:8000],  # Cap to prevent payload bloat
+    })
+
+
+def get_pipeline(name: str) -> PipelineDefinition | None:
+    """Look up a pipeline definition by name."""
+    return PIPELINES.get(name)

--- a/src/genesis/surplus/pipelines.py
+++ b/src/genesis/surplus/pipelines.py
@@ -30,7 +30,6 @@ class PipelineStep:
 
     task_type: TaskType
     compute_tier: ComputeTier
-    prompt_key: str  # Key into the executor's _TASK_PROMPTS or a custom template
     priority: float = 0.5
 
 

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -239,7 +239,7 @@ class SurplusScheduler:
         self._scheduler.start()
         # Run brainstorm check immediately on startup
         await self.brainstorm_check()
-        # Also run infra monitor and recon gather immediately —
+        # Run remaining jobs immediately on startup —
         # otherwise they only fire after their IntervalTrigger elapses.
         if self._enable_code_audits:
             await self.schedule_code_audit()
@@ -683,7 +683,12 @@ class SurplusScheduler:
 
         await self._queue.mark_completed(task.id, staging_id=staging_id)
 
-        # Pipeline chaining — enqueue next step if this was a pipeline task
+        # Pipeline chaining — enqueue next step if this was a pipeline task.
+        # Note: if a step returns NOMINAL (empty content), chaining still
+        # proceeds — the next step gets empty previous_output.  This is
+        # intentional: pipeline steps are deterministic, not conditional.
+        # If a pipeline should skip remaining steps on NOMINAL, that logic
+        # belongs in the pipeline definition, not the generic chainer.
         if result.success and task.payload:
             from genesis.surplus.pipelines import (
                 build_next_step_payload,

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -379,13 +379,8 @@ class SurplusScheduler:
 
             analytical_tasks = [
                 (TaskType.GAP_CLUSTERING, 0.4, "competence"),
-                # DEACTIVATED: anticipatory_research has no web search — pure
-                # LLM speculation.  Redesign as CC session task with tool access.
-                # (TaskType.ANTICIPATORY_RESEARCH, 0.3, "curiosity"),
-                # DEACTIVATED: prompt_effectiveness_review reviews outputs, not
-                # prompts.  Redesign to actually analyze prompt templates vs
-                # output quality.
-                # (TaskType.PROMPT_EFFECTIVENESS_REVIEW, 0.3, "competence"),
+                # anticipatory_research and prompt_effectiveness_review return
+                # as multi-step pipelines — see pipelines.py.
             ]
             for task_type, priority, drive in analytical_tasks:
                 pending = await self._queue.pending_by_type(task_type)
@@ -405,6 +400,38 @@ class SurplusScheduler:
                 GenesisRuntime.instance().record_job_failure("schedule_analytical", str(exc))
             except Exception:
                 pass
+
+    async def schedule_pipeline(self, pipeline_name: str) -> str | None:
+        """Enqueue step 1 of a named pipeline if not already running.
+
+        Returns the task ID of the enqueued step, or None if skipped
+        (pipeline unknown, or step 1 task type already pending).
+        """
+        from genesis.surplus.pipelines import build_initial_payload, get_pipeline
+
+        defn = get_pipeline(pipeline_name)
+        if defn is None:
+            logger.warning("Unknown pipeline: %s", pipeline_name)
+            return None
+
+        step1 = defn.steps[0]
+        # Prevent re-enqueue if step 1's task type is already pending.
+        # This is imprecise (blocks if ANY task of this type is pending,
+        # not just pipeline tasks), but safe — false negatives only mean
+        # the pipeline waits one more cycle.
+        if await self._queue.pending_by_type(step1.task_type) > 0:
+            return None
+
+        payload = build_initial_payload(pipeline_name, len(defn.steps))
+        task_id = await self._queue.enqueue(
+            step1.task_type,
+            step1.compute_tier,
+            step1.priority,
+            defn.drive_alignment,
+            payload=payload,
+        )
+        logger.info("Pipeline %s: enqueued step 1 (task=%s)", pipeline_name, task_id[:8])
+        return task_id
 
     async def dispatch_follow_ups(self) -> None:
         """Run the follow-up dispatcher cycle (always-on, not idle-gated)."""
@@ -655,6 +682,51 @@ class SurplusScheduler:
                 )
 
         await self._queue.mark_completed(task.id, staging_id=staging_id)
+
+        # Pipeline chaining — enqueue next step if this was a pipeline task
+        if result.success and task.payload:
+            from genesis.surplus.pipelines import (
+                build_next_step_payload,
+                get_pipeline,
+                is_pipeline_task,
+                parse_pipeline_payload,
+            )
+            if is_pipeline_task(task.payload):
+                try:
+                    meta = parse_pipeline_payload(task.payload)
+                    step = meta.get("step", 1)
+                    total = meta.get("total_steps", 1)
+                    pipeline_name = meta.get("pipeline", "")
+                    if step < total:
+                        defn = get_pipeline(pipeline_name)
+                        if defn and step < len(defn.steps):
+                            next_step = defn.steps[step]  # 0-indexed, step is 1-based
+                            next_payload = build_next_step_payload(
+                                meta, result.content or "",
+                            )
+                            await self._queue.enqueue(
+                                next_step.task_type,
+                                next_step.compute_tier,
+                                next_step.priority,
+                                defn.drive_alignment,
+                                payload=next_payload,
+                            )
+                            logger.info(
+                                "Pipeline %s: step %d/%d complete, enqueued step %d",
+                                pipeline_name, step, total, step + 1,
+                            )
+                        else:
+                            logger.warning(
+                                "Pipeline %s: step %d references missing definition",
+                                pipeline_name, step + 1,
+                            )
+                    else:
+                        logger.info(
+                            "Pipeline %s: final step %d/%d complete",
+                            pipeline_name, step, total,
+                        )
+                except Exception:
+                    logger.error("Pipeline chaining failed", exc_info=True)
 
         # Bridge code audit findings to recon observations
         if task.task_type == _TT.CODE_AUDIT and result.insights:

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -50,7 +50,6 @@ class SurplusScheduler:
         task_expiry_hours: int = 72,
         code_audit_hours: int = 12,
         code_index_hours: int = 4,
-        infra_monitor_hours: int = 2,
         recon_gather_hours: int = 84,
         maintenance_hours: int = 6,
         analytical_hours: int = 24,
@@ -75,7 +74,6 @@ class SurplusScheduler:
         self._task_expiry_hours = task_expiry_hours
         self._code_audit_hours = code_audit_hours
         self._code_index_hours = code_index_hours
-        self._infra_monitor_hours = infra_monitor_hours
         self._recon_gather_hours = recon_gather_hours
         self._maintenance_hours = maintenance_hours
         self._analytical_hours = analytical_hours
@@ -210,13 +208,6 @@ class SurplusScheduler:
             misfire_grace_time=300,
         )
         self._scheduler.add_job(
-            self.schedule_infra_monitor,
-            IntervalTrigger(hours=self._infra_monitor_hours),
-            id="schedule_infra_monitor",
-            max_instances=1,
-            misfire_grace_time=300,
-        )
-        self._scheduler.add_job(
             self.run_recon_gather,
             IntervalTrigger(hours=self._recon_gather_hours),
             id="recon_gather",
@@ -253,7 +244,6 @@ class SurplusScheduler:
         if self._enable_code_audits:
             await self.schedule_code_audit()
         await self.schedule_code_index()
-        await self.schedule_infra_monitor()
         await self.run_recon_gather()
         await self.schedule_maintenance()
         await self.schedule_analytical()
@@ -343,29 +333,6 @@ class SurplusScheduler:
             try:
                 from genesis.runtime import GenesisRuntime
                 GenesisRuntime.instance().record_job_failure("schedule_code_index", str(exc))
-            except Exception:
-                pass
-
-    async def schedule_infra_monitor(self) -> None:
-        """Enqueue an infrastructure monitor task if none pending/running."""
-        try:
-            from genesis.surplus.types import ComputeTier, TaskType
-
-            pending = await self._queue.pending_by_type(TaskType.INFRASTRUCTURE_MONITOR)
-            if pending == 0:
-                await self._queue.enqueue(
-                    TaskType.INFRASTRUCTURE_MONITOR, ComputeTier.FREE_API, 0.6, "preservation"
-                )
-            try:
-                from genesis.runtime import GenesisRuntime
-                GenesisRuntime.instance().record_job_success("schedule_infra_monitor")
-            except Exception:
-                pass
-        except Exception as exc:
-            logger.exception("Infrastructure monitor scheduling failed")
-            try:
-                from genesis.runtime import GenesisRuntime
-                GenesisRuntime.instance().record_job_failure("schedule_infra_monitor", str(exc))
             except Exception:
                 pass
 

--- a/tests/test_surplus/test_pipelines.py
+++ b/tests/test_surplus/test_pipelines.py
@@ -28,13 +28,11 @@ _TEST_PIPELINE = PipelineDefinition(
         PipelineStep(
             task_type=TaskType.GAP_CLUSTERING,
             compute_tier=ComputeTier.FREE_API,
-            prompt_key="gap_clustering",
             priority=0.4,
         ),
         PipelineStep(
             task_type=TaskType.BRAINSTORM_SELF,
             compute_tier=ComputeTier.FREE_API,
-            prompt_key="brainstorm_self",
             priority=0.5,
         ),
     ),

--- a/tests/test_surplus/test_pipelines.py
+++ b/tests/test_surplus/test_pipelines.py
@@ -1,0 +1,364 @@
+"""Tests for surplus pipeline infrastructure — registry, payload helpers, chaining."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from genesis.surplus.pipelines import (
+    PIPELINE_KEY,
+    PIPELINES,
+    PipelineDefinition,
+    PipelineStep,
+    build_initial_payload,
+    build_next_step_payload,
+    get_pipeline,
+    is_pipeline_task,
+    parse_pipeline_payload,
+)
+from genesis.surplus.types import ComputeTier, TaskType
+
+# ── Test pipeline definition for tests only ─────────────────────────
+
+_TEST_PIPELINE = PipelineDefinition(
+    name="_test_two_step",
+    steps=(
+        PipelineStep(
+            task_type=TaskType.GAP_CLUSTERING,
+            compute_tier=ComputeTier.FREE_API,
+            prompt_key="gap_clustering",
+            priority=0.4,
+        ),
+        PipelineStep(
+            task_type=TaskType.BRAINSTORM_SELF,
+            compute_tier=ComputeTier.FREE_API,
+            prompt_key="brainstorm_self",
+            priority=0.5,
+        ),
+    ),
+    drive_alignment="competence",
+    description="Test pipeline with two steps",
+)
+
+
+@pytest.fixture(autouse=True)
+def _register_test_pipeline():
+    """Register test pipeline for the duration of each test."""
+    PIPELINES["_test_two_step"] = _TEST_PIPELINE
+    yield
+    PIPELINES.pop("_test_two_step", None)
+
+
+# ── Registry tests ──────────────────────────────────────────────────
+
+def test_get_pipeline_found():
+    assert get_pipeline("_test_two_step") is _TEST_PIPELINE
+
+
+def test_get_pipeline_missing():
+    assert get_pipeline("nonexistent") is None
+
+
+# ── Payload helper tests ────────────────────────────────────────────
+
+def test_is_pipeline_task_true():
+    payload = json.dumps({PIPELINE_KEY: "test", "step": 1})
+    assert is_pipeline_task(payload) is True
+
+
+def test_is_pipeline_task_false_no_key():
+    payload = json.dumps({"source": "follow_up"})
+    assert is_pipeline_task(payload) is False
+
+
+def test_is_pipeline_task_none():
+    assert is_pipeline_task(None) is False
+
+
+def test_is_pipeline_task_empty_string():
+    assert is_pipeline_task("") is False
+
+
+def test_is_pipeline_task_invalid_json():
+    assert is_pipeline_task("not json") is False
+
+
+def test_build_initial_payload():
+    payload = build_initial_payload("_test_two_step", 2)
+    data = json.loads(payload)
+    assert data[PIPELINE_KEY] == "_test_two_step"
+    assert data["step"] == 1
+    assert data["total_steps"] == 2
+    assert "pipeline_run_id" in data
+
+
+def test_build_next_step_payload():
+    current = {
+        PIPELINE_KEY: "_test_two_step",
+        "pipeline_run_id": "abc-123",
+        "step": 1,
+        "total_steps": 2,
+    }
+    payload = build_next_step_payload(current, "step 1 output text")
+    data = json.loads(payload)
+    assert data[PIPELINE_KEY] == "_test_two_step"
+    assert data["pipeline_run_id"] == "abc-123"
+    assert data["step"] == 2
+    assert data["total_steps"] == 2
+    assert data["previous_output"] == "step 1 output text"
+
+
+def test_build_next_step_payload_caps_output():
+    """Previous output should be capped to prevent payload bloat."""
+    current = {
+        PIPELINE_KEY: "_test_two_step",
+        "pipeline_run_id": "abc-123",
+        "step": 1,
+        "total_steps": 3,
+    }
+    long_output = "x" * 10000
+    payload = build_next_step_payload(current, long_output)
+    data = json.loads(payload)
+    assert len(data["previous_output"]) == 8000
+
+
+def test_parse_pipeline_payload():
+    payload = json.dumps({
+        PIPELINE_KEY: "test",
+        "step": 2,
+        "total_steps": 3,
+        "previous_output": "hello",
+    })
+    data = parse_pipeline_payload(payload)
+    assert data["step"] == 2
+    assert data["previous_output"] == "hello"
+
+
+# ── Integration: chaining in dispatch_once ──────────────────────────
+# Uses the global `db` fixture from conftest.py (in-memory SQLite with
+# all tables created and seeded).
+
+
+async def test_pipeline_chaining_enqueues_next_step(db):
+    """When step 1 of a 2-step pipeline completes, step 2 is enqueued."""
+    from genesis.surplus.queue import SurplusQueue
+    from genesis.surplus.scheduler import SurplusScheduler
+    from genesis.surplus.types import ExecutorResult
+
+    queue = SurplusQueue(db=db)
+
+    # Create a mock executor that returns success
+    mock_executor = AsyncMock()
+    mock_executor.execute.return_value = ExecutorResult(
+        success=True,
+        content="Step 1 analysis results here.",
+        insights=[{"generating_model": "test", "confidence": 0.5}],
+    )
+
+    sched = SurplusScheduler(
+        db=db,
+        queue=queue,
+        idle_detector=AsyncMock(),
+        compute_availability=AsyncMock(),
+        executor=mock_executor,
+    )
+    # Make idle detector say we're idle
+    sched._idle_detector.is_idle = lambda **kwargs: True
+
+    # Enqueue step 1 of test pipeline
+    payload = build_initial_payload("_test_two_step", 2)
+    await queue.enqueue(
+        TaskType.GAP_CLUSTERING, ComputeTier.FREE_API,
+        0.4, "competence", payload=payload,
+    )
+
+    # Mock compute availability to return FREE_API
+    with patch.object(sched._compute, "get_available_tiers", new_callable=AsyncMock, return_value=[ComputeTier.FREE_API]):
+        dispatched = await sched.dispatch_once()
+
+    assert dispatched is True
+
+    # Step 2 should now be pending
+    pending = await queue.pending_by_type(TaskType.BRAINSTORM_SELF)
+    assert pending == 1
+
+    # Verify step 2 payload contains previous output
+    task2 = await queue.next_task([ComputeTier.FREE_API])
+    assert task2 is not None
+    data = json.loads(task2.payload)
+    assert data["step"] == 2
+    assert data["total_steps"] == 2
+    assert "Step 1 analysis results" in data["previous_output"]
+
+
+async def test_pipeline_final_step_no_enqueue(db):
+    """Final step of a pipeline does NOT enqueue another step."""
+    from genesis.surplus.queue import SurplusQueue
+    from genesis.surplus.scheduler import SurplusScheduler
+    from genesis.surplus.types import ExecutorResult
+
+    queue = SurplusQueue(db=db)
+    mock_executor = AsyncMock()
+    mock_executor.execute.return_value = ExecutorResult(
+        success=True,
+        content="Final step output.",
+        insights=[{"generating_model": "test", "confidence": 0.5}],
+    )
+
+    sched = SurplusScheduler(
+        db=db, queue=queue,
+        idle_detector=AsyncMock(),
+        compute_availability=AsyncMock(),
+        executor=mock_executor,
+    )
+    sched._idle_detector.is_idle = lambda **kwargs: True
+
+    # Enqueue step 2 of 2 (final step)
+    payload = json.dumps({
+        PIPELINE_KEY: "_test_two_step",
+        "pipeline_run_id": "run-final",
+        "step": 2,
+        "total_steps": 2,
+        "previous_output": "step 1 output",
+    })
+    await queue.enqueue(
+        TaskType.BRAINSTORM_SELF, ComputeTier.FREE_API,
+        0.5, "competence", payload=payload,
+    )
+
+    with patch.object(sched._compute, "get_available_tiers", new_callable=AsyncMock, return_value=[ComputeTier.FREE_API]):
+        await sched.dispatch_once()
+
+    # No new tasks should be pending
+    total = await queue.pending_count()
+    assert total == 0
+
+
+async def test_non_pipeline_task_no_chaining(db):
+    """Regular (non-pipeline) tasks don't trigger chaining."""
+    from genesis.surplus.queue import SurplusQueue
+    from genesis.surplus.scheduler import SurplusScheduler
+    from genesis.surplus.types import ExecutorResult
+
+    queue = SurplusQueue(db=db)
+    mock_executor = AsyncMock()
+    mock_executor.execute.return_value = ExecutorResult(
+        success=True,
+        content="Regular task output that is long enough to pass quality gate easily.",
+        insights=[{"generating_model": "test", "confidence": 0.5}],
+    )
+
+    sched = SurplusScheduler(
+        db=db, queue=queue,
+        idle_detector=AsyncMock(),
+        compute_availability=AsyncMock(),
+        executor=mock_executor,
+    )
+    sched._idle_detector.is_idle = lambda **kwargs: True
+
+    # Enqueue a regular task (no pipeline payload)
+    await queue.enqueue(
+        TaskType.GAP_CLUSTERING, ComputeTier.FREE_API,
+        0.4, "competence",
+    )
+
+    with patch.object(sched._compute, "get_available_tiers", new_callable=AsyncMock, return_value=[ComputeTier.FREE_API]):
+        await sched.dispatch_once()
+
+    # No chained tasks
+    total = await queue.pending_count()
+    assert total == 0
+
+
+async def test_malformed_pipeline_payload_no_crash(db):
+    """Malformed pipeline payload doesn't crash the dispatcher."""
+    from genesis.surplus.queue import SurplusQueue
+    from genesis.surplus.scheduler import SurplusScheduler
+    from genesis.surplus.types import ExecutorResult
+
+    queue = SurplusQueue(db=db)
+    mock_executor = AsyncMock()
+    mock_executor.execute.return_value = ExecutorResult(
+        success=True,
+        content="Output from task with bad payload that is long enough to pass.",
+        insights=[{"generating_model": "test", "confidence": 0.5}],
+    )
+
+    sched = SurplusScheduler(
+        db=db, queue=queue,
+        idle_detector=AsyncMock(),
+        compute_availability=AsyncMock(),
+        executor=mock_executor,
+    )
+    sched._idle_detector.is_idle = lambda **kwargs: True
+
+    # Enqueue task with malformed pipeline payload
+    await queue.enqueue(
+        TaskType.GAP_CLUSTERING, ComputeTier.FREE_API,
+        0.4, "competence",
+        payload=json.dumps({PIPELINE_KEY: "nonexistent", "step": 1, "total_steps": 2}),
+    )
+
+    with patch.object(sched._compute, "get_available_tiers", new_callable=AsyncMock, return_value=[ComputeTier.FREE_API]):
+        # Should not raise
+        dispatched = await sched.dispatch_once()
+
+    assert dispatched is True
+
+
+async def test_schedule_pipeline(db):
+    """schedule_pipeline enqueues step 1 and returns task ID."""
+    from genesis.surplus.queue import SurplusQueue
+    from genesis.surplus.scheduler import SurplusScheduler
+
+    queue = SurplusQueue(db=db)
+    sched = SurplusScheduler(
+        db=db, queue=queue,
+        idle_detector=AsyncMock(),
+        compute_availability=AsyncMock(),
+    )
+
+    task_id = await sched.schedule_pipeline("_test_two_step")
+    assert task_id is not None
+
+    # Step 1 task type should be pending
+    pending = await queue.pending_by_type(TaskType.GAP_CLUSTERING)
+    assert pending == 1
+
+
+async def test_schedule_pipeline_skips_if_pending(db):
+    """schedule_pipeline skips if step 1 task type already pending."""
+    from genesis.surplus.queue import SurplusQueue
+    from genesis.surplus.scheduler import SurplusScheduler
+
+    queue = SurplusQueue(db=db)
+    sched = SurplusScheduler(
+        db=db, queue=queue,
+        idle_detector=AsyncMock(),
+        compute_availability=AsyncMock(),
+    )
+
+    # First call succeeds
+    await sched.schedule_pipeline("_test_two_step")
+    # Second call returns None (already pending)
+    result = await sched.schedule_pipeline("_test_two_step")
+    assert result is None
+
+    # Only 1 task pending, not 2
+    pending = await queue.pending_by_type(TaskType.GAP_CLUSTERING)
+    assert pending == 1
+
+
+async def test_schedule_pipeline_unknown():
+    """schedule_pipeline returns None for unknown pipeline name."""
+    from genesis.surplus.scheduler import SurplusScheduler
+
+    sched = SurplusScheduler(
+        db=AsyncMock(), queue=AsyncMock(),
+        idle_detector=AsyncMock(),
+        compute_availability=AsyncMock(),
+    )
+    result = await sched.schedule_pipeline("nonexistent_pipeline")
+    assert result is None

--- a/tests/test_surplus/test_scheduler.py
+++ b/tests/test_surplus/test_scheduler.py
@@ -118,10 +118,10 @@ async def test_start_and_stop(db):
     assert sched._scheduler.get_job("surplus_brainstorm_check") is not None
     assert sched._scheduler.get_job("surplus_dispatch") is not None
     assert sched._scheduler.get_job("schedule_code_audit") is not None
-    # Brainstorm (2) + code audit (1) + code index (1) + infra monitor (1)
-    # + maintenance (4) + analytical (1: gap_clustering) = 10
-    # (anticipatory_research and prompt_effectiveness_review deactivated)
-    assert await sched._queue.pending_count() == 10
+    # Brainstorm (2) + code audit (1) + code index (1)
+    # + maintenance (4) + analytical (1: gap_clustering) = 9
+    # (infra_monitor removed, anticipatory/prompt_effectiveness deactivated)
+    assert await sched._queue.pending_count() == 9
     # Stop should not raise
     await sched.stop()
 
@@ -133,9 +133,9 @@ async def test_start_without_code_audits(db):
     assert sched._scheduler.running is True
     # Code audit job should NOT be registered
     assert sched._scheduler.get_job("schedule_code_audit") is None
-    # Brainstorm (2) + code index (1) + infra monitor (1)
-    # + maintenance (4) + analytical (1: gap_clustering) = 9
-    assert await sched._queue.pending_count() == 9
+    # Brainstorm (2) + code index (1)
+    # + maintenance (4) + analytical (1: gap_clustering) = 8
+    assert await sched._queue.pending_count() == 8
     await sched.stop()
 
 


### PR DESCRIPTION
## Summary
- Adds deterministic multi-step pipeline infrastructure to the surplus scheduler — assembly line pattern where the LLM does its piece at each step, the dispatcher mechanically advances to the next (conveyor belt model)
- Removes infrastructure monitor cron scheduling (459 insights, 1 promotion, 389 pending — noise without value). TaskType + prompt kept for future pipeline reuse
- Adds grounding rules to Sentinel and infra monitor prompts to prevent LLM confabulation of fake commands

## Pipeline Design
- Pipeline definitions are code-level (registry dict in `pipelines.py`), not DB or YAML
- State travels in the existing `payload` JSON field on surplus_tasks — zero schema migration
- Chaining logic in `dispatch_once()` completion handler: reads pipeline metadata, enqueues next step on success
- `schedule_pipeline()` method on SurplusScheduler with dedup check
- Executor injects `previous_output` from payload into prompt context
- Non-pipeline tasks completely unaffected (no `"pipeline"` key in payload = current behavior)

## Data Behind Decisions
```
infrastructure_monitor: 459 total | 389 pending | 1 promoted | avg conf 0.74
anticipatory_research:   53 total |  52 pending | 0 promoted
prompt_effectiveness:    44 total |  44 pending | 0 promoted
```
Infra monitor's purpose (trajectory analysis, "monitor the monitors") is valid but current implementation adds nothing the awareness loop + Sentinel + Guardian don't already cover. Returns as a pipeline task.

## Test plan
- [x] 18 new pipeline tests (registry, payloads, chaining integration, edge cases)
- [x] 12 surplus scheduler tests pass (counts updated for infra monitor removal)
- [x] 131 total surplus tests pass
- [x] Full suite: 5839 passed, 0 failures
- [x] Lint clean on all changed files
- [x] Import chain verified (no circular deps)
- [x] GROUNDWORK code preserved (verified via git diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)