### PR TITLE
feat(surplus): prompt effectiveness pipeline — first 3-step pipeline

### DIFF
--- a/src/genesis/db/crud/surplus_tasks.py
+++ b/src/genesis/db/crud/surplus_tasks.py
@@ -176,6 +176,17 @@ async def count_pending_by_type(db: aiosqlite.Connection, task_type: str) -> int
     return row[0]
 
 
+async def count_active_by_type(db: aiosqlite.Connection, task_type: str) -> int:
+    """Count tasks that are pending OR running for a given type."""
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM surplus_tasks "
+        "WHERE status IN ('pending', 'running') AND task_type = ?",
+        (task_type,),
+    )
+    row = await cursor.fetchone()
+    return row[0]
+
+
 async def delete(db: aiosqlite.Connection, id: str) -> bool:
     cursor = await db.execute("DELETE FROM surplus_tasks WHERE id = ?", (id,))
     await db.commit()

--- a/src/genesis/surplus/executor.py
+++ b/src/genesis/surplus/executor.py
@@ -149,14 +149,50 @@ _TASK_PROMPTS: dict[TaskType, str] = {
         "research directions.\n\n"
         "Respond in plain text with numbered suggestions."
     ),
-    TaskType.PROMPT_EFFECTIVENESS_REVIEW: (
-        "You are reviewing prompt effectiveness for an autonomous AI.\n\n"
+    TaskType.PROMPT_REVIEW_CATALOG: (
+        "You are cataloging LLM call site activity for an autonomous AI.\n\n"
         "{context}\n\n"
         "## Task\n"
-        "Assess whether recent LLM outputs have been high-quality and "
-        "on-target.  Identify prompts or call sites that consistently "
-        "produce poor results and suggest improvements.\n\n"
-        "Respond in plain text with bullet points."
+        "Review the call site activity data above.  For each active call "
+        "site, summarize: what it does, how often it fires, which model it "
+        "uses, its cost efficiency (tokens in vs out), and success rate.\n\n"
+        "Flag any concerning patterns: silent sites (not firing when they "
+        "should), expensive sites (high token usage for low value), or "
+        "failing sites (low success rate).\n\n"
+        "If no call site data is available, state that no data was found "
+        "and produce no findings.\n\n"
+        "Respond in plain text with a numbered list of call sites and a "
+        "summary section for flagged concerns."
+    ),
+    TaskType.PROMPT_REVIEW_SAMPLE: (
+        "You are sampling and scoring recent LLM outputs for an "
+        "autonomous AI.\n\n"
+        "{context}\n\n"
+        "## Task\n"
+        "Review the recent LLM outputs above.  For each task type or call "
+        "site represented, score the outputs on three dimensions:\n"
+        "- **Relevance**: Does the output address the intended purpose?\n"
+        "- **Actionability**: Are recommendations specific enough to act on?\n"
+        "- **Specificity**: Does it reference real data, or is it generic?\n\n"
+        "Use a simple Low/Medium/High scale.  Identify which task types "
+        "produce consistently good vs poor results.\n\n"
+        "Respond in plain text with a scored summary per task type."
+    ),
+    TaskType.PROMPT_EFFECTIVENESS_REVIEW: (
+        "You are synthesizing a prompt effectiveness review for an "
+        "autonomous AI.\n\n"
+        "{context}\n\n"
+        "## Task\n"
+        "Using the call site activity catalog and output quality scores "
+        "in '## Previous Step Output' above (if present), identify the "
+        "2-3 highest-leverage improvements to LLM prompts or call sites.\n\n"
+        "For each recommendation:\n"
+        "1. Name the call site or task type\n"
+        "2. Describe the failure pattern (low relevance, generic output, etc.)\n"
+        "3. Suggest a concrete prompt improvement\n\n"
+        "If no prior analysis is present, assess general prompt quality "
+        "from the context above.\n\n"
+        "Respond in plain text with numbered recommendations."
     ),
 }
 
@@ -269,6 +305,101 @@ class SurplusLLMExecutor:
             except Exception:
                 parts.append("(Signal data unavailable)")
             return "\n".join(parts) if parts else "(No recent signals)"
+
+        # Pipeline step 1: call site activity + cost aggregation
+        if task.task_type == TaskType.PROMPT_REVIEW_CATALOG:
+            try:
+                cursor = await self._db.execute(
+                    "SELECT call_site_id, last_run_at, provider_used, "
+                    "model_id, input_tokens, output_tokens, success "
+                    "FROM call_site_last_run "
+                    "ORDER BY last_run_at DESC LIMIT 20"
+                )
+                rows = await cursor.fetchall()
+                if rows:
+                    parts.append("## Call Site Activity (most recent run per site)")
+                    for r in rows:
+                        cs = r[0] or "?"
+                        last = (r[1] or "?")[:19]
+                        provider = r[2] or "?"
+                        model = r[3] or "?"
+                        in_tok = r[4] or 0
+                        out_tok = r[5] or 0
+                        ok = "OK" if r[6] else "FAIL"
+                        parts.append(
+                            f"- {cs}: {last} | {provider}/{model} | "
+                            f"in={in_tok} out={out_tok} | {ok}"
+                        )
+            except Exception:
+                logger.warning(
+                    "_gather_context failed for %s (call_site_last_run)",
+                    task.task_type, exc_info=True,
+                )
+                parts.append("(Call site activity data unavailable)")
+
+            try:
+                cursor = await self._db.execute(
+                    "SELECT json_extract(metadata, '$.call_site') as call_site, "
+                    "COUNT(*) as cnt, SUM(cost_usd) as total_cost, "
+                    "AVG(input_tokens) as avg_in, AVG(output_tokens) as avg_out "
+                    "FROM cost_events "
+                    "WHERE created_at > datetime('now', '-7 days') "
+                    "AND json_extract(metadata, '$.call_site') IS NOT NULL "
+                    "GROUP BY json_extract(metadata, '$.call_site') "
+                    "ORDER BY cnt DESC LIMIT 15"
+                )
+                rows = await cursor.fetchall()
+                if rows:
+                    parts.append("\n## Cost Summary (last 7 days, by call site)")
+                    for r in rows:
+                        cs = r[0] or "?"
+                        cnt = r[1]
+                        cost = r[2] or 0.0
+                        avg_in = int(r[3] or 0)
+                        avg_out = int(r[4] or 0)
+                        parts.append(
+                            f"- {cs}: {cnt} calls, ${cost:.4f}, "
+                            f"avg_in={avg_in}, avg_out={avg_out}"
+                        )
+            except Exception:
+                logger.warning(
+                    "_gather_context failed for %s (cost_events)",
+                    task.task_type, exc_info=True,
+                )
+                parts.append("(Cost data unavailable)")
+
+            return "\n".join(parts) if parts else "(No call site data available)"
+
+        # Pipeline step 2: recent surplus insight samples
+        if task.task_type == TaskType.PROMPT_REVIEW_SAMPLE:
+            try:
+                cursor = await self._db.execute(
+                    "SELECT source_task_type, content, generating_model, "
+                    "confidence, promotion_status, created_at "
+                    "FROM surplus_insights "
+                    "WHERE created_at > datetime('now', '-7 days') "
+                    "ORDER BY created_at DESC LIMIT 15"
+                )
+                rows = await cursor.fetchall()
+                if rows:
+                    parts.append("## Recent Surplus Outputs (last 7 days)")
+                    for r in rows:
+                        task_type = r[0] or "?"
+                        content = (r[1] or "")[:300]
+                        model = r[2] or "?"
+                        conf = r[3] or 0.0
+                        status = r[4] or "?"
+                        parts.append(
+                            f"- [{task_type}] model={model} conf={conf:.2f} "
+                            f"status={status}\n  {content}"
+                        )
+            except Exception:
+                logger.warning(
+                    "_gather_context failed for %s (surplus_insights)",
+                    task.task_type, exc_info=True,
+                )
+                parts.append("(Surplus output data unavailable)")
+            # Fall through to also gather standard observations below
 
         # For analytical tasks: recent observations + basic stats
         try:

--- a/src/genesis/surplus/pipelines.py
+++ b/src/genesis/surplus/pipelines.py
@@ -48,7 +48,34 @@ class PipelineDefinition:
 # definition — no DB config, no YAML. Adding a pipeline = adding an
 # entry to this dict.
 
-PIPELINES: dict[str, PipelineDefinition] = {}
+PIPELINES: dict[str, PipelineDefinition] = {
+    "prompt_effectiveness": PipelineDefinition(
+        name="prompt_effectiveness",
+        steps=(
+            PipelineStep(
+                task_type=TaskType.PROMPT_REVIEW_CATALOG,
+                compute_tier=ComputeTier.FREE_API,
+                priority=0.4,
+            ),
+            PipelineStep(
+                task_type=TaskType.PROMPT_REVIEW_SAMPLE,
+                compute_tier=ComputeTier.FREE_API,
+                priority=0.4,
+            ),
+            PipelineStep(
+                task_type=TaskType.PROMPT_EFFECTIVENESS_REVIEW,
+                compute_tier=ComputeTier.FREE_API,
+                priority=0.5,
+            ),
+        ),
+        drive_alignment="competence",
+        description=(
+            "Three-step prompt effectiveness review: "
+            "catalog active call sites, sample recent outputs, "
+            "evaluate gaps and recommend improvements"
+        ),
+    ),
+}
 
 
 # ── Payload helpers ──────────────────────────────────────────────────

--- a/src/genesis/surplus/queue.py
+++ b/src/genesis/surplus/queue.py
@@ -100,6 +100,10 @@ class SurplusQueue:
     async def pending_by_type(self, task_type: TaskType | str) -> int:
         return await surplus_tasks.count_pending_by_type(self._db, str(task_type))
 
+    async def active_by_type(self, task_type: TaskType | str) -> int:
+        """Count tasks that are pending OR running for a given type."""
+        return await surplus_tasks.count_active_by_type(self._db, str(task_type))
+
     async def _apply_drive_weight(self, base_priority: float, drive: str) -> float:
         """Multiply base priority by the drive's current weight."""
         cursor = await self._db.execute(

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -379,8 +379,7 @@ class SurplusScheduler:
 
             analytical_tasks = [
                 (TaskType.GAP_CLUSTERING, 0.4, "competence"),
-                # anticipatory_research and prompt_effectiveness_review return
-                # as multi-step pipelines — see pipelines.py.
+                # anticipatory_research returns as a pipeline — see pipelines.py.
             ]
             for task_type, priority, drive in analytical_tasks:
                 pending = await self._queue.pending_by_type(task_type)
@@ -388,6 +387,8 @@ class SurplusScheduler:
                     await self._queue.enqueue(
                         task_type, ComputeTier.FREE_API, priority, drive,
                     )
+            # prompt_effectiveness runs as a 3-step pipeline.
+            await self.schedule_pipeline("prompt_effectiveness")
             try:
                 from genesis.runtime import GenesisRuntime
                 GenesisRuntime.instance().record_job_success("schedule_analytical")
@@ -415,11 +416,10 @@ class SurplusScheduler:
             return None
 
         step1 = defn.steps[0]
-        # Prevent re-enqueue if step 1's task type is already pending.
-        # This is imprecise (blocks if ANY task of this type is pending,
-        # not just pipeline tasks), but safe — false negatives only mean
-        # the pipeline waits one more cycle.
-        if await self._queue.pending_by_type(step1.task_type) > 0:
+        # Prevent re-enqueue if step 1's task type is already pending or
+        # running.  Checks RUNNING too — otherwise a slow pipeline step
+        # could allow a duplicate enqueue on the next scheduled cycle.
+        if await self._queue.active_by_type(step1.task_type) > 0:
             return None
 
         payload = build_initial_payload(pipeline_name, len(defn.steps))

--- a/src/genesis/surplus/types.py
+++ b/src/genesis/surplus/types.py
@@ -18,6 +18,9 @@ class TaskType(StrEnum):
     SELF_UNBLOCK = "self_unblock"
     ANTICIPATORY_RESEARCH = "anticipatory_research"
     PROMPT_EFFECTIVENESS_REVIEW = "prompt_effectiveness_review"
+    # Pipeline intermediate steps (prompt_effectiveness pipeline)
+    PROMPT_REVIEW_CATALOG = "prompt_review_catalog"
+    PROMPT_REVIEW_SAMPLE = "prompt_review_sample"
     CODE_AUDIT = "code_audit"
     INFRASTRUCTURE_MONITOR = "infrastructure_monitor"
     BOOKMARK_ENRICHMENT = "bookmark_enrichment"

--- a/tests/test_surplus/test_pipelines.py
+++ b/tests/test_surplus/test_pipelines.py
@@ -360,3 +360,156 @@ async def test_schedule_pipeline_unknown():
     )
     result = await sched.schedule_pipeline("nonexistent_pipeline")
     assert result is None
+
+
+# ── Prompt effectiveness pipeline tests ───────────────────────────
+
+
+def test_prompt_effectiveness_pipeline_registered():
+    """prompt_effectiveness pipeline is registered in the PIPELINES dict."""
+    defn = get_pipeline("prompt_effectiveness")
+    assert defn is not None
+    assert defn.name == "prompt_effectiveness"
+
+
+def test_prompt_effectiveness_has_three_steps():
+    """prompt_effectiveness pipeline has exactly 3 steps."""
+    defn = get_pipeline("prompt_effectiveness")
+    assert defn is not None
+    assert len(defn.steps) == 3
+
+
+def test_prompt_effectiveness_step_types():
+    """Steps use the correct task types in order."""
+    defn = get_pipeline("prompt_effectiveness")
+    assert defn is not None
+    assert defn.steps[0].task_type == TaskType.PROMPT_REVIEW_CATALOG
+    assert defn.steps[1].task_type == TaskType.PROMPT_REVIEW_SAMPLE
+    assert defn.steps[2].task_type == TaskType.PROMPT_EFFECTIVENESS_REVIEW
+
+
+def test_prompt_effectiveness_all_free_tier():
+    """All steps use FREE_API compute tier."""
+    defn = get_pipeline("prompt_effectiveness")
+    assert defn is not None
+    for step in defn.steps:
+        assert step.compute_tier == ComputeTier.FREE_API
+
+
+async def test_prompt_effectiveness_three_step_chaining(db):
+    """Full 3-step pipeline chains correctly through all steps."""
+    from genesis.surplus.queue import SurplusQueue
+    from genesis.surplus.scheduler import SurplusScheduler
+    from genesis.surplus.types import ExecutorResult
+
+    queue = SurplusQueue(db=db)
+    step_outputs = [
+        "Step 1: Call site catalog — 12_surplus_brainstorm active, 37_infra disabled.",
+        "Step 2: Quality scores — brainstorm=Medium, gap_clustering=Low.",
+        "Step 3: Recommendations — improve gap_clustering prompt specificity.",
+    ]
+    call_count = 0
+
+    async def mock_execute(task):
+        nonlocal call_count
+        output = step_outputs[min(call_count, len(step_outputs) - 1)]
+        call_count += 1
+        return ExecutorResult(
+            success=True,
+            content=output,
+            insights=[{"generating_model": "test", "confidence": 0.5}],
+        )
+
+    mock_executor = AsyncMock()
+    mock_executor.execute = mock_execute
+
+    sched = SurplusScheduler(
+        db=db, queue=queue,
+        idle_detector=AsyncMock(),
+        compute_availability=AsyncMock(),
+        executor=mock_executor,
+    )
+    sched._idle_detector.is_idle = lambda **kwargs: True
+
+    # Enqueue step 1
+    payload = build_initial_payload("prompt_effectiveness", 3)
+    await queue.enqueue(
+        TaskType.PROMPT_REVIEW_CATALOG, ComputeTier.FREE_API,
+        0.4, "competence", payload=payload,
+    )
+
+    # Dispatch step 1 → should chain to step 2
+    with patch.object(sched._compute, "get_available_tiers", new_callable=AsyncMock, return_value=[ComputeTier.FREE_API]):
+        dispatched = await sched.dispatch_once()
+    assert dispatched is True
+
+    # Step 2 should be pending
+    pending = await queue.pending_by_type(TaskType.PROMPT_REVIEW_SAMPLE)
+    assert pending == 1
+
+    # Dispatch step 2 → should chain to step 3
+    with patch.object(sched._compute, "get_available_tiers", new_callable=AsyncMock, return_value=[ComputeTier.FREE_API]):
+        dispatched = await sched.dispatch_once()
+    assert dispatched is True
+
+    # Step 3 should be pending
+    pending = await queue.pending_by_type(TaskType.PROMPT_EFFECTIVENESS_REVIEW)
+    assert pending == 1
+
+    # Dispatch step 3 → final step, no more chaining
+    with patch.object(sched._compute, "get_available_tiers", new_callable=AsyncMock, return_value=[ComputeTier.FREE_API]):
+        dispatched = await sched.dispatch_once()
+    assert dispatched is True
+
+    # No more tasks pending
+    total = await queue.pending_count()
+    assert total == 0
+    assert call_count == 3
+
+
+async def test_active_by_type_includes_running(db):
+    """active_by_type counts both pending and running tasks."""
+    from genesis.surplus.queue import SurplusQueue
+
+    queue = SurplusQueue(db=db)
+
+    # Enqueue a task
+    task_id = await queue.enqueue(
+        TaskType.PROMPT_REVIEW_CATALOG, ComputeTier.FREE_API,
+        0.4, "competence",
+    )
+
+    # Pending: active_by_type should count it
+    assert await queue.active_by_type(TaskType.PROMPT_REVIEW_CATALOG) == 1
+
+    # Mark running: active_by_type should still count it
+    await queue.mark_running(task_id)
+    assert await queue.active_by_type(TaskType.PROMPT_REVIEW_CATALOG) == 1
+    # But pending_by_type should NOT count it
+    assert await queue.pending_by_type(TaskType.PROMPT_REVIEW_CATALOG) == 0
+
+    # Mark completed: active_by_type should NOT count it
+    await queue.mark_completed(task_id)
+    assert await queue.active_by_type(TaskType.PROMPT_REVIEW_CATALOG) == 0
+
+
+async def test_schedule_pipeline_blocks_on_running(db):
+    """schedule_pipeline returns None if step 1 type is running (not just pending)."""
+    from genesis.surplus.queue import SurplusQueue
+    from genesis.surplus.scheduler import SurplusScheduler
+
+    queue = SurplusQueue(db=db)
+    sched = SurplusScheduler(
+        db=db, queue=queue,
+        idle_detector=AsyncMock(),
+        compute_availability=AsyncMock(),
+    )
+
+    # Enqueue step 1 and mark it running
+    task_id = await sched.schedule_pipeline("prompt_effectiveness")
+    assert task_id is not None
+    await queue.mark_running(task_id)
+
+    # Second schedule attempt should still be blocked (task is RUNNING)
+    result = await sched.schedule_pipeline("prompt_effectiveness")
+    assert result is None

--- a/tests/test_surplus/test_scheduler.py
+++ b/tests/test_surplus/test_scheduler.py
@@ -119,9 +119,9 @@ async def test_start_and_stop(db):
     assert sched._scheduler.get_job("surplus_dispatch") is not None
     assert sched._scheduler.get_job("schedule_code_audit") is not None
     # Brainstorm (2) + code audit (1) + code index (1)
-    # + maintenance (4) + analytical (1: gap_clustering) = 9
-    # (infra_monitor removed, anticipatory/prompt_effectiveness deactivated)
-    assert await sched._queue.pending_count() == 9
+    # + maintenance (4) + analytical (1: gap_clustering)
+    # + pipeline (1: prompt_effectiveness step 1) = 10
+    assert await sched._queue.pending_count() == 10
     # Stop should not raise
     await sched.stop()
 
@@ -134,8 +134,9 @@ async def test_start_without_code_audits(db):
     # Code audit job should NOT be registered
     assert sched._scheduler.get_job("schedule_code_audit") is None
     # Brainstorm (2) + code index (1)
-    # + maintenance (4) + analytical (1: gap_clustering) = 8
-    assert await sched._queue.pending_count() == 8
+    # + maintenance (4) + analytical (1: gap_clustering)
+    # + pipeline (1: prompt_effectiveness step 1) = 9
+    assert await sched._queue.pending_count() == 9
     await sched.stop()
 
 


### PR DESCRIPTION
## Summary

- First real pipeline on the surplus pipeline infrastructure (PR #147)
- 3-step assembly line: catalog call sites → sample outputs → evaluate gaps
- Fixes dedup race in `schedule_pipeline` (check pending+running, not just pending)

## What changed

- **2 new TaskTypes**: `PROMPT_REVIEW_CATALOG`, `PROMPT_REVIEW_SAMPLE` (pipeline intermediate steps)
- **Pipeline registered**: `prompt_effectiveness` in `PIPELINES` dict (3 steps, all FREE_API)
- **Context gathering**: Step 1 queries `call_site_last_run` + `cost_events` (json_extract for per-site breakdown). Step 2 queries `surplus_insights` + observations.
- **Dedup fix**: `schedule_pipeline` now uses `active_by_type` (pending OR running) to prevent double pipeline runs on slow execution
- **Scheduling**: `schedule_analytical()` calls `schedule_pipeline("prompt_effectiveness")` on its 24h cadence
- **7 new tests**: registration, step types, 3-step chaining, active_by_type, running-state dedup

## Data verification

All SQL queries verified against production DB:
- `call_site_last_run`: 26 rows, all columns confirmed
- `cost_events`: 2,574 rows, all have `call_site` in metadata JSON
- `surplus_insights`: 814 total, 280 in last 7d

## Test plan

- [x] 25 pipeline tests pass (18 existing + 7 new)
- [x] 138 surplus tests pass (full suite)
- [x] 5,846 full test suite passes
- [x] ruff check clean (pre-existing error in az_plugins only)
- [x] Architecture review: no blockers
- [x] Code review: approved, no critical issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)