### PR TITLE
feat(memory): safe FTS5 query expansion with boolean support

### DIFF
--- a/src/genesis/db/crud/knowledge.py
+++ b/src/genesis/db/crud/knowledge.py
@@ -9,12 +9,17 @@ from datetime import UTC, datetime
 import aiosqlite
 
 
-def _escape_fts5(query: str) -> str | None:
-    """Escape FTS5 special characters to prevent syntax errors from user input.
+def _prepare_fts5(query: str) -> str | None:
+    """Prepare a query string for FTS5 MATCH.
+
+    Lowercases the query to neutralize accidental FTS5 boolean operators —
+    uppercase OR/AND are interpreted as operators by FTS5, but lowercase
+    or/and are plain search terms. FTS5 content matching is case-insensitive,
+    so lowercasing doesn't affect result quality.
 
     Returns None if the query is empty after escaping (caller should return []).
     """
-    cleaned = re.sub(r'[^\w\s]', " ", query, flags=re.UNICODE).strip()
+    cleaned = re.sub(r'[^\w\s]', " ", query.lower(), flags=re.UNICODE).strip()
     return cleaned or None
 
 
@@ -235,7 +240,7 @@ async def search_fts(
     JOINs back to knowledge_units to include source_pipeline for authority
     boosting in the recall merge step.
     """
-    escaped = _escape_fts5(query)
+    escaped = _prepare_fts5(query)
     if not escaped:
         return []
     sql = (

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -11,22 +11,34 @@ import re
 import aiosqlite
 
 
-def _escape_fts5(query: str) -> str | None:
-    """Escape FTS5 special characters to prevent syntax errors from user input.
+def _prepare_fts5(query: str, *, boolean: bool = False) -> str | None:
+    """Prepare a query string for FTS5 MATCH.
 
-    Preserves FTS5 boolean operators (OR, AND) and parentheses when present,
-    allowing callers to pass pre-constructed boolean queries. Plain queries
-    without operators are treated as implicit AND (FTS5 default).
+    Args:
+        query: Raw query text.
+        boolean: If True, preserve FTS5 boolean operators (OR, AND) and
+            parentheses. Use ONLY for queries constructed by expand_query
+            (controlled vocabulary). Never for raw user input.
+
+    Default path (boolean=False): lowercases the query to neutralize
+    accidental FTS5 boolean operators — uppercase OR/AND are interpreted
+    as operators by FTS5, but lowercase or/and are plain search terms.
+    FTS5 content matching is case-insensitive, so lowercasing doesn't
+    affect result quality.
 
     Returns None if the query is empty after escaping (caller should return []).
     """
-    # Check if query contains boolean operators (from expand_query)
-    has_boolean = bool(re.search(r'\bOR\b|\bAND\b', query))
-    if has_boolean:
-        # Preserve OR/AND keywords and parentheses, escape everything else
-        cleaned = re.sub(r'[^\w\s()"]', " ", query, flags=re.UNICODE).strip()
+    if boolean:
+        # Preserve OR/AND keywords and parentheses for structured queries.
+        # Strip everything else that could cause FTS5 syntax errors.
+        cleaned = re.sub(r'[^\w\s()]', " ", query, flags=re.UNICODE).strip()
+        # Safety: strip unbalanced parentheses rather than crash FTS5
+        if cleaned.count("(") != cleaned.count(")"):
+            cleaned = cleaned.replace("(", " ").replace(")", " ").strip()
     else:
-        cleaned = re.sub(r'[^\w\s]', " ", query, flags=re.UNICODE).strip()
+        # Lowercase neutralizes accidental boolean operators (OR/AND).
+        # Strip all non-alphanumeric to prevent FTS5 syntax errors.
+        cleaned = re.sub(r'[^\w\s]', " ", query.lower(), flags=re.UNICODE).strip()
     return cleaned or None
 
 
@@ -110,7 +122,7 @@ async def search(
     limit: int = 10,
 ) -> list[dict]:
     """Full-text search on memory content. Returns matching rows."""
-    escaped = _escape_fts5(query)
+    escaped = _prepare_fts5(query)
     if not escaped:
         return []
     sql = "SELECT memory_id, content, source_type, collection FROM memory_fts WHERE memory_fts MATCH ?"
@@ -137,9 +149,10 @@ async def search_ranked(
     query: str,
     collection: str | None = None,
     limit: int = 30,
+    boolean: bool = False,
 ) -> list[dict]:
     """FTS5 search returning rank scores for RRF fusion."""
-    escaped = _escape_fts5(query)
+    escaped = _prepare_fts5(query, boolean=boolean)
     if not escaped:
         return []
     sql = (

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -14,9 +14,19 @@ import aiosqlite
 def _escape_fts5(query: str) -> str | None:
     """Escape FTS5 special characters to prevent syntax errors from user input.
 
+    Preserves FTS5 boolean operators (OR, AND) and parentheses when present,
+    allowing callers to pass pre-constructed boolean queries. Plain queries
+    without operators are treated as implicit AND (FTS5 default).
+
     Returns None if the query is empty after escaping (caller should return []).
     """
-    cleaned = re.sub(r'[^\w\s]', " ", query, flags=re.UNICODE).strip()
+    # Check if query contains boolean operators (from expand_query)
+    has_boolean = bool(re.search(r'\bOR\b|\bAND\b', query))
+    if has_boolean:
+        # Preserve OR/AND keywords and parentheses, escape everything else
+        cleaned = re.sub(r'[^\w\s()"]', " ", query, flags=re.UNICODE).strip()
+    else:
+        cleaned = re.sub(r'[^\w\s]', " ", query, flags=re.UNICODE).strip()
     return cleaned or None
 
 

--- a/src/genesis/memory/intent.py
+++ b/src/genesis/memory/intent.py
@@ -355,8 +355,13 @@ async def expand_query(
         if not expansions:
             return query
 
-        # Append expansion terms to original query
-        expanded = query + " " + " ".join(expansions)
+        # Build boolean FTS5 query: original terms AND'd, expansions OR'd
+        # e.g. "configure routing" + expansions [setup, deploy] →
+        #   "(configure AND routing) OR setup OR deploy"
+        # This broadens recall without losing the original intent.
+        original_and = " AND ".join(keywords)
+        parts = [f"({original_and})"] + expansions
+        expanded = " OR ".join(parts)
         logger.debug("Query expanded: %r → %r", query, expanded)
         return expanded
 

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -121,11 +121,13 @@ class HybridRetriever:
 
         # 3. FTS5 text search (using expanded query)
         fts_collection = collections[0] if len(collections) == 1 else None
+        fts_is_boolean = fts_query != query  # expansion produced boolean syntax
         fts_results = await memory_crud.search_ranked(
             self._db,
             query=fts_query,
             collection=fts_collection,
             limit=candidate_limit,
+            boolean=fts_is_boolean,
         )
 
         fts_by_id: dict[str, dict] = {}

--- a/tests/test_channels/test_transport.py
+++ b/tests/test_channels/test_transport.py
@@ -264,38 +264,79 @@ class TestDraftStreamer:
 
 # ---- FTS5 Escape Fix ----
 
-class TestFTS5Escape:
+class TestFTS5Prepare:
+    """Tests for _prepare_fts5 — the FTS5 query sanitizer."""
+
     def test_commas_escaped(self):
-        from genesis.db.crud.memory import _escape_fts5
-        result = _escape_fts5("hello, world, test")
+        from genesis.db.crud.memory import _prepare_fts5
+        result = _prepare_fts5("hello, world, test")
         assert "," not in result
         assert result is not None
 
     def test_natural_language(self):
-        from genesis.db.crud.memory import _escape_fts5
-        result = _escape_fts5("What's the weather like today?")
+        from genesis.db.crud.memory import _prepare_fts5
+        result = _prepare_fts5("What's the weather like today?")
         assert result is not None
-        # No special chars should remain
         assert "?" not in result
         assert "'" not in result
 
     def test_parentheses_escaped(self):
-        from genesis.db.crud.knowledge import _escape_fts5
-        result = _escape_fts5("function(arg1, arg2)")
+        from genesis.db.crud.knowledge import _prepare_fts5
+        result = _prepare_fts5("function(arg1, arg2)")
         assert "(" not in result
         assert ")" not in result
         assert "," not in result
 
     def test_empty_after_escape_returns_none(self):
-        from genesis.db.crud.memory import _escape_fts5
-        result = _escape_fts5("!!!")
+        from genesis.db.crud.memory import _prepare_fts5
+        result = _prepare_fts5("!!!")
         assert result is None
 
     def test_unicode_preserved(self):
-        from genesis.db.crud.memory import _escape_fts5
-        result = _escape_fts5("café résumé naïve")
+        from genesis.db.crud.memory import _prepare_fts5
+        result = _prepare_fts5("café résumé naïve")
         assert result is not None
         assert "café" in result
+
+    def test_uppercase_or_and_neutralized(self):
+        """Uppercase OR/AND in user queries must not become FTS5 operators."""
+        from genesis.db.crud.memory import _prepare_fts5
+        result = _prepare_fts5("FTS5 boolean OR AND query")
+        assert result is not None
+        # Lowercased — or/and are plain search terms, not FTS5 operators
+        assert "OR" not in result
+        assert "AND" not in result
+        assert "or" in result
+        assert "and" in result
+
+    def test_boolean_mode_preserves_operators(self):
+        """Boolean mode preserves OR/AND/parens for expand_query output."""
+        from genesis.db.crud.memory import _prepare_fts5
+        result = _prepare_fts5(
+            "(configure AND routing) OR setup OR deploy", boolean=True,
+        )
+        assert result is not None
+        assert "OR" in result
+        assert "AND" in result
+        assert "(" in result
+        assert ")" in result
+
+    def test_boolean_mode_unbalanced_parens_stripped(self):
+        """Unbalanced parentheses in boolean mode are safely stripped."""
+        from genesis.db.crud.memory import _prepare_fts5
+        result = _prepare_fts5("(test AND query", boolean=True)
+        assert result is not None
+        assert "(" not in result  # parens stripped due to imbalance
+        assert ")" not in result
+
+    def test_boolean_mode_strips_special_chars(self):
+        """Boolean mode still strips non-operator special chars."""
+        from genesis.db.crud.memory import _prepare_fts5
+        result = _prepare_fts5(
+            '(test AND "query") OR setup*', boolean=True,
+        )
+        assert '"' not in result
+        assert "*" not in result
 
 
 # ---- Adapter offset persistence debounce ----


### PR DESCRIPTION
## Summary
- Replaces `_escape_fts5` with `_prepare_fts5(query, boolean=False)` — explicit opt-in for boolean FTS5 syntax
- **Fixes latent bug**: user queries containing uppercase "OR"/"AND" could trigger FTS5 syntax errors (lowercasing neutralizes this)
- **Enables query expansion**: `expand_query` builds boolean FTS5 queries that broaden recall through the `boolean=True` path
- Includes paren balance safety check — unbalanced parens stripped rather than crashing
- Updates duplicate in `knowledge.py` with same approach

## Due diligence
- Initial approach (content-sniffing for OR/AND) was wrong — replaced with explicit parameter
- Verified FTS5 boolean syntax on live DB (330+ hits with expansion vs 146 without)
- Confirmed crash case fixed: `"FTS5 boolean OR AND query"` → 0 hits instead of crash
- Expansion tags always lowercased (intent.py:227) — no accidental boolean operators

## Test plan
- [x] 9/9 FTS5Prepare tests passed (5 updated + 4 new)
- [x] 321/321 memory tests passed
- [x] 2304/2305 full suite (1 pre-existing hook failure)
- [x] ruff clean (1 pre-existing unrelated error)
- [x] Live DB verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)