### PR TITLE
feat(dashboard): consolidate tabs — 10→9, unified Work + Chat comms

### DIFF
--- a/src/genesis/dashboard/routes/__init__.py
+++ b/src/genesis/dashboard/routes/__init__.py
@@ -6,6 +6,7 @@ from genesis.dashboard.routes import (
     activity,
     backup,
     budget,
+    comms,
     config,
     errors,
     events,
@@ -33,12 +34,14 @@ from genesis.dashboard.routes import (
     ui_data,
     updates,
     vitals,
+    work,
 )
 
 __all__ = [
     "activity",
     "backup",
     "budget",
+    "comms",
     "config",
     "errors",
     "events",
@@ -66,4 +69,5 @@ __all__ = [
     "ui_data",
     "updates",
     "vitals",
+    "work",
 ]

--- a/src/genesis/dashboard/routes/comms.py
+++ b/src/genesis/dashboard/routes/comms.py
@@ -1,0 +1,134 @@
+"""Unified Communications route — aggregates outreach, ego proposals, and approvals."""
+
+from __future__ import annotations
+
+import logging
+
+from flask import jsonify, request
+
+from genesis.dashboard._blueprint import _async_route, blueprint
+
+logger = logging.getLogger(__name__)
+
+
+@blueprint.route("/api/genesis/comms")
+@_async_route
+async def unified_comms():
+    """Return unified communications data: outreach, proposals, and approvals.
+
+    Query params:
+        view  – 'pending' (default) or 'all'
+        limit – max items per source (default 30, capped at 100)
+    """
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({
+            "outreach": [], "proposals": [], "pending_approvals": [],
+            "counts": {},
+        })
+
+    view = request.args.get("view", "pending")
+    limit = max(1, min(request.args.get("limit", 30, type=int), 100))
+
+    outreach: list[dict] = []
+    proposals: list[dict] = []
+    pending_approvals: list[dict] = []
+    counts: dict = {}
+
+    # --- Outreach messages ---
+    try:
+        cursor = await rt.db.execute(
+            """SELECT id, category, signal_type, topic, channel, message_content,
+                      delivered_at, engagement_outcome, user_response, created_at
+               FROM outreach_history
+               ORDER BY created_at DESC LIMIT ?""",
+            (limit,),
+        )
+        cols = [d[0] for d in cursor.description]
+        rows = await cursor.fetchall()
+        outreach = [dict(zip(cols, r, strict=False)) for r in rows]
+
+        count_cursor = await rt.db.execute("SELECT COUNT(*) FROM outreach_history")
+        counts["outreach_total"] = (await count_cursor.fetchone())[0]
+    except Exception:
+        logger.error("Failed to fetch outreach for comms view", exc_info=True)
+        counts["outreach_total"] = 0
+
+    # --- Ego proposals ---
+    try:
+        from genesis.db.crud import ego
+
+        if view == "pending":
+            proposals = await ego.list_pending_proposals(rt.db)
+        else:
+            proposals = await ego.list_proposals(rt.db, limit=limit)
+
+        pending_count_cursor = await rt.db.execute(
+            "SELECT COUNT(*) FROM ego_proposals WHERE status = 'pending'"
+        )
+        counts["proposals_pending"] = (await pending_count_cursor.fetchone())[0]
+
+        total_count_cursor = await rt.db.execute(
+            "SELECT COUNT(*) FROM ego_proposals"
+        )
+        counts["proposals_total"] = (await total_count_cursor.fetchone())[0]
+    except Exception:
+        # Ego tables may be empty if ego hasn't run — that's fine
+        logger.debug("Ego proposals unavailable for comms view", exc_info=True)
+        counts["proposals_pending"] = 0
+        counts["proposals_total"] = 0
+
+    # --- Pending approvals ---
+    try:
+        from genesis.db.crud import approval_requests
+
+        raw_pending = await approval_requests.list_pending(rt.db)
+        # Normalize rows — list_pending may return Row objects
+        for row in raw_pending:
+            if hasattr(row, "keys"):
+                pending_approvals.append(dict(row))
+            elif isinstance(row, dict):
+                pending_approvals.append(row)
+        counts["pending_approvals"] = len(pending_approvals)
+    except Exception:
+        logger.error("Failed to fetch approvals for comms view", exc_info=True)
+        counts["pending_approvals"] = 0
+
+    return jsonify({
+        "outreach": outreach,
+        "proposals": proposals,
+        "pending_approvals": pending_approvals,
+        "counts": counts,
+    })
+
+
+@blueprint.route("/api/genesis/comms/proposals/<proposal_id>/resolve", methods=["POST"])
+@_async_route
+async def comms_resolve_proposal(proposal_id: str):
+    """Approve or reject an ego proposal from the Chat/Comms tab."""
+    from genesis.db.crud import ego
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"error": "Not bootstrapped"}), 503
+
+    data = request.get_json(silent=True) or {}
+    status = str(data.get("status", "")).strip().lower()
+    if status not in ("approved", "rejected"):
+        return jsonify({"error": "status must be 'approved' or 'rejected'"}), 400
+
+    user_response = data.get("user_response", "")
+
+    ok = await ego.resolve_proposal(
+        rt.db,
+        proposal_id,
+        status=status,
+        user_response=user_response or None,
+    )
+    if not ok:
+        return jsonify({"error": "Proposal not found or already resolved"}), 404
+
+    return jsonify({"id": proposal_id, "status": status})

--- a/src/genesis/dashboard/routes/work.py
+++ b/src/genesis/dashboard/routes/work.py
@@ -1,0 +1,162 @@
+"""Unified Work tab route — aggregates tasks, follow-ups, and background sessions."""
+
+from __future__ import annotations
+
+import logging
+
+from flask import jsonify, request
+
+from genesis.dashboard._blueprint import _async_route, blueprint
+
+logger = logging.getLogger(__name__)
+
+
+@blueprint.route("/api/genesis/work")
+@_async_route
+async def unified_work():
+    """Return a unified work view aggregating tasks, follow-ups, and bg sessions.
+
+    Query params:
+        view  – 'active' (default) or 'history'
+        type  – optional filter: 'task', 'follow_up', 'session'
+        limit – max items per source (default 50, capped at 200)
+    """
+    from genesis.db.crud import follow_ups, task_states
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"items": [], "counts": {}})
+
+    view = request.args.get("view", "active")
+    type_filter = request.args.get("type") or None
+    limit = max(1, min(request.args.get("limit", 50, type=int), 200))
+
+    items: list[dict] = []
+    counts: dict = {}
+
+    # --- Tasks ---
+    if type_filter in (None, "task"):
+        try:
+            if view == "active":
+                tasks = await task_states.list_active(rt.db)
+            else:
+                tasks = await task_states.list_all_recent(rt.db, limit=limit)
+            for t in tasks:
+                items.append({
+                    "id": t["task_id"],
+                    "type": "task",
+                    "status": t.get("current_phase", "unknown"),
+                    "description": t.get("description", ""),
+                    "created_at": t.get("created_at", ""),
+                    "updated_at": t.get("updated_at", ""),
+                    "source": t.get("source_session_id", ""),
+                    "raw": t,
+                })
+            active_tasks = await task_states.list_active(rt.db)
+            completed = await _count_tasks_by_phase(rt.db, "completed")
+            failed = await _count_tasks_by_phase(rt.db, "failed")
+            counts["tasks"] = {
+                "active": len(active_tasks),
+                "completed": completed,
+                "failed": failed,
+            }
+        except Exception:
+            logger.error("Failed to fetch tasks for work view", exc_info=True)
+            counts["tasks"] = {"active": 0, "completed": 0, "failed": 0}
+
+    # --- Follow-ups ---
+    if type_filter in (None, "follow_up"):
+        try:
+            if view == "active":
+                fups = await follow_ups.get_by_status(rt.db, "pending")
+                fups += await follow_ups.get_by_status(rt.db, "in_progress")
+                fups += await follow_ups.get_by_status(rt.db, "blocked")
+            else:
+                fups = await follow_ups.get_recent(rt.db, limit=limit)
+            for f in fups:
+                items.append({
+                    "id": f["id"],
+                    "type": "follow_up",
+                    "status": f.get("status", "pending"),
+                    "description": f.get("content", ""),
+                    "created_at": f.get("created_at", ""),
+                    "updated_at": f.get("completed_at") or f.get("created_at", ""),
+                    "priority": f.get("priority", "medium"),
+                    "strategy": f.get("strategy", ""),
+                    "source": f.get("source", ""),
+                    "reason": f.get("reason", ""),
+                    "resolution_notes": f.get("resolution_notes", ""),
+                    "blocked_reason": f.get("blocked_reason", ""),
+                    "raw": f,
+                })
+            fu_counts = await follow_ups.get_summary_counts(rt.db)
+            counts["follow_ups"] = fu_counts
+        except Exception:
+            logger.error("Failed to fetch follow-ups for work view", exc_info=True)
+            counts["follow_ups"] = {}
+
+    # --- Background sessions ---
+    if type_filter in (None, "session"):
+        try:
+            if view == "active":
+                cursor = await rt.db.execute(
+                    """SELECT id, session_type, model, status, source_tag, channel,
+                              cost_usd, started_at, last_activity_at
+                       FROM cc_sessions
+                       WHERE session_type != 'foreground' AND status = 'active'
+                       ORDER BY started_at DESC LIMIT ?""",
+                    (limit,),
+                )
+            else:
+                cursor = await rt.db.execute(
+                    """SELECT id, session_type, model, status, source_tag, channel,
+                              cost_usd, started_at, last_activity_at
+                       FROM cc_sessions
+                       WHERE session_type != 'foreground'
+                       ORDER BY started_at DESC LIMIT ?""",
+                    (limit,),
+                )
+            cols = [d[0] for d in cursor.description]
+            rows = await cursor.fetchall()
+            for r in rows:
+                sess = dict(zip(cols, r, strict=False))
+                items.append({
+                    "id": sess["id"],
+                    "type": "session",
+                    "status": sess.get("status", "unknown"),
+                    "description": sess.get("source_tag") or sess.get("channel") or "background session",
+                    "created_at": sess.get("started_at", ""),
+                    "updated_at": sess.get("last_activity_at") or sess.get("started_at", ""),
+                    "session_type": sess.get("session_type", ""),
+                    "model": sess.get("model", ""),
+                    "cost_usd": sess.get("cost_usd"),
+                    "raw": sess,
+                })
+            # Count active bg sessions
+            count_cursor = await rt.db.execute(
+                "SELECT COUNT(*) FROM cc_sessions WHERE session_type != 'foreground' AND status = 'active'"
+            )
+            active_bg = (await count_cursor.fetchone())[0]
+            counts["sessions"] = {"active_bg": active_bg}
+        except Exception:
+            logger.error("Failed to fetch sessions for work view", exc_info=True)
+            counts["sessions"] = {"active_bg": 0}
+
+    # Sort all items by most recent activity
+    items.sort(key=lambda x: x.get("updated_at") or x.get("created_at") or "", reverse=True)
+
+    return jsonify({
+        "items": items[:limit],
+        "counts": counts,
+    })
+
+
+async def _count_tasks_by_phase(db, phase: str) -> int:
+    """Count tasks in a specific phase."""
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM task_states WHERE current_phase = ?",
+        (phase,),
+    )
+    row = await cursor.fetchone()
+    return row[0] if row else 0

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -6049,7 +6049,7 @@
           <div>
             <!-- Tab bar -->
             <div style="display: flex; gap: 0; border-bottom: 1px solid var(--color-border); margin-bottom: 1rem;">
-              <template x-for="t in [{id:'overview',label:'Overview'},{id:'proposals',label:'Proposals'},{id:'cycles',label:'Cycles'},{id:'followups',label:'Follow-ups'}]" :key="t.id">
+              <template x-for="t in [{id:'overview',label:'Overview'},{id:'cycles',label:'Cycles'}]" :key="t.id">
                 <button style="padding: 0.4rem 1rem; font-size: 0.78rem; border: none; background: none; cursor: pointer; border-bottom: 2px solid transparent; color: var(--color-text-secondary);"
                         :style="$store.genesisDashboard.egoModal.tab === t.id ? 'border-bottom-color: #c084fc; color: #c084fc; font-weight: 600;' : ''"
                         @click="$store.genesisDashboard.egoModal.tab = t.id"
@@ -6139,9 +6139,16 @@
                   </div>
                 </div>
               </template>
+              <!-- Quick navigation links -->
+              <div style="margin-top:1rem; display:flex; gap:0.5rem;">
+                <button style="font-size:0.72rem; padding:0.3rem 0.8rem; border-radius:4px; cursor:pointer; background:rgba(192,132,252,0.1); color:#c084fc; border:1px solid rgba(192,132,252,0.2);"
+                        @click="$store.genesisDashboard.egoModal.open = false; location.hash = 'chat'; $store.genesisDashboard.commsTab = 'proposals'">View Proposals</button>
+                <button style="font-size:0.72rem; padding:0.3rem 0.8rem; border-radius:4px; cursor:pointer; background:rgba(156,39,176,0.1); color:#ce93d8; border:1px solid rgba(156,39,176,0.2);"
+                        @click="$store.genesisDashboard.egoModal.open = false; location.hash = 'work'; $store.genesisDashboard.workTypeFilter = 'follow_up'">View Follow-ups</button>
+              </div>
             </div>
 
-            <!-- ═══ Tab: Proposals ═══ -->
+            <!-- ═══ Tab: Proposals (deprecated — now in Chat tab) ═══ -->
             <div x-show="$store.genesisDashboard.egoModal.tab === 'proposals'">
               <!-- Filter pills -->
               <div style="display: flex; gap: 0.4rem; margin-bottom: 0.8rem; flex-wrap: wrap;">

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -21,7 +21,7 @@
       Alpine.store("genesisDashboard", {
         // Tab state
         activeTab: "overview",
-        _tabInitialized: { overview: false, chat: false, internals: false, sessions: false, config: false, files: false, tasks: false, memory: false, knowledge: false, backup: false },
+        _tabInitialized: { overview: false, chat: false, internals: false, config: false, files: false, work: false, memory: false, knowledge: false, backup: false },
 
         // State
         health: {},
@@ -152,12 +152,29 @@
         },
         fileUpload: { dragging: false, uploading: false, error: null },
 
-        // ── Tasks tab state ────────────────────────────────────────
+        // ── Work tab state (tasks + follow-ups + bg sessions) ──────
         taskList: [],
         taskActive: {},
         taskExpanded: null,
         taskDetail: null,
         taskDetailSteps: [],
+        workItems: [],
+        workCounts: {},
+        workView: 'active',
+        workTypeFilter: null,
+        workExpanded: null,
+
+        // ── Comms state (on Chat tab) ────────────────────────────
+        commsOutreach: [],
+        commsProposals: [],
+        commsPendingApprovals: [],
+        commsCounts: {},
+        commsView: 'pending',
+        commsTab: 'outreach',
+        commsProposalFilter: null,
+        commsCategoryFilter: null,
+        commsRejectingId: null,
+        commsRejectReason: '',
 
         // ── Memory tab state ──────────────────────────────────────
         memorySearch: { query: "", results: [], loading: false },
@@ -252,16 +269,17 @@
         _awarenessInterval: null,
         _jobHealthInterval: null,
         _tasksInterval: null,
+        _workInterval: null,
+        _commsInterval: null,
 
         // Tab management
         _TAB_INTERVALS: {
           overview:  ["_cognitiveInterval", "_ekInterval", "_modulesInterval", "_approvalsInterval"],
-          chat:      [],
-          internals: ["_awarenessInterval", "_routingInterval", "_jobHealthInterval"],
-          sessions:  ["_activityInterval", "_sessionsInterval"],
+          chat:      ["_commsInterval"],
+          internals: ["_awarenessInterval", "_routingInterval", "_jobHealthInterval", "_activityInterval", "_sessionsInterval"],
           config:    [],
           files:     [],
-          tasks:     ["_tasksInterval"],
+          work:      ["_workInterval"],
           memory:    [],
           knowledge: [],
           backup:    [],
@@ -269,7 +287,7 @@
 
         initTab() {
           const hash = location.hash.replace("#", "") || "overview";
-          const valid = ["overview", "chat", "internals", "sessions", "config", "files", "tasks", "memory", "knowledge", "backup"];
+          const valid = ["overview", "chat", "internals", "config", "files", "work", "memory", "knowledge", "backup"];
           this.activeTab = valid.includes(hash) ? hash : "overview";
           window.addEventListener("hashchange", () => {
             const h = location.hash.replace("#", "");
@@ -303,13 +321,10 @@
               this._approvalsInterval = setInterval(() => this.fetchApprovals(), 15000);
               break;
             case "internals":
-              if (first) { this.fetchAwarenessSignals(); this.fetchOperationalVitals(); this.fetchAutonomyConfig(); this.fetchAutonomousCliPolicy(); this.fetchRoutingConfig(); this.fetchJobHealth(); this.fetchApprovals(); }
+              if (first) { this.fetchAwarenessSignals(); this.fetchOperationalVitals(); this.fetchAutonomyConfig(); this.fetchAutonomousCliPolicy(); this.fetchRoutingConfig(); this.fetchJobHealth(); this.fetchApprovals(); this.fetchActivity(); this.fetchSessions(); }
               this._awarenessInterval = setInterval(() => this.fetchAwarenessSignals(), 30000);
               this._routingInterval = setInterval(() => this.fetchRoutingConfig(), 15000);
               this._jobHealthInterval = setInterval(() => this.fetchJobHealth(), 60000);
-              break;
-            case "sessions":
-              if (first) { this.fetchActivity(); this.fetchSessions(); }
               this._activityInterval = setInterval(() => this.fetchActivity(), 10000);
               this._sessionsInterval = setInterval(() => this.fetchSessions(), 30000);
               break;
@@ -319,13 +334,15 @@
             case "chat":
               // Re-fit terminal on tab re-entry
               if (!first && this._xterm && this._fitAddon) { this._fitAddon.fit(); }
+              if (first) { this.fetchComms(); }
+              this._commsInterval = setInterval(() => this.fetchComms(), 15000);
               break;
             case "files":
               if (first) { this.fetchFiles(); }
               break;
-            case "tasks":
-              if (first) { this.fetchTasks(); }
-              this._tasksInterval = setInterval(() => this.fetchTasks(), 5000);
+            case "work":
+              if (first) { this.fetchWork(); this.fetchTasks(); }
+              this._workInterval = setInterval(() => this.fetchWork(), 5000);
               break;
             case "memory":
               if (first) { this.fetchMemoryRecent(); this.fetchMemoryStats(); }
@@ -387,7 +404,7 @@
 
         cleanup() {
           if (this._healthInterval) clearInterval(this._healthInterval);
-          for (const tab of ["overview", "internals", "sessions", "config"]) {
+          for (const tab of ["overview", "chat", "internals", "config", "work"]) {
             this._stopTabIntervals(tab);
           }
           // Terminal runs in its own window — no cleanup needed here
@@ -679,6 +696,44 @@
             await this.fetchTasks();
             if (this.taskExpanded === taskId) await this.fetchTaskDetail(taskId);
           } catch (e) { console.warn(`Task ${action} failed:`, e); }
+        },
+
+        // ── Work tab fetches ──────────────────────────────────────
+        async fetchWork() {
+          try {
+            const resp = await fetchApi(`/api/genesis/work?view=${this.workView}&limit=50`);
+            if (resp && resp.ok) {
+              const data = await resp.json();
+              this.workItems = data.items || [];
+              this.workCounts = data.counts || {};
+            }
+          } catch (e) { console.warn("Work fetch failed:", e); }
+        },
+
+        // ── Comms fetches (on Chat tab) ──────────────────────────
+        async fetchComms() {
+          try {
+            const resp = await fetchApi(`/api/genesis/comms?view=${this.commsView}&limit=30`);
+            if (resp && resp.ok) {
+              const data = await resp.json();
+              this.commsOutreach = data.outreach || [];
+              this.commsProposals = data.proposals || [];
+              this.commsPendingApprovals = data.pending_approvals || [];
+              this.commsCounts = data.counts || {};
+            }
+          } catch (e) { console.warn("Comms fetch failed:", e); }
+        },
+        async resolveCommsProposal(proposalId, status, userResponse) {
+          try {
+            await fetchApi(`/api/genesis/comms/proposals/${proposalId}/resolve`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ status, user_response: userResponse || "" }),
+            });
+            this.commsRejectingId = null;
+            this.commsRejectReason = '';
+            await this.fetchComms();
+          } catch (e) { console.warn("Proposal resolve failed:", e); }
         },
 
         // ── Memory tab fetches ────────────────────────────────────
@@ -3329,14 +3384,12 @@
               @click="location.hash = 'chat'">Chat</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'internals' }"
               @click="location.hash = 'internals'">Internals</button>
-      <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'sessions' }"
-              @click="location.hash = 'sessions'">Sessions & Activity</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'config' }"
               @click="location.hash = 'config'">Configuration</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'files' }"
               @click="location.hash = 'files'">Files</button>
-      <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'tasks' }"
-              @click="location.hash = 'tasks'">Tasks</button>
+      <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'work' }"
+              @click="location.hash = 'work'">Work</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'memory' }"
               @click="location.hash = 'memory'">Memory</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'knowledge' }"
@@ -3946,7 +3999,7 @@
 
           <!-- Outreach Stats -->
           <div class="health-card" title="7-day outreach metrics. Click to view messages."
-               style="cursor: pointer;" @click="$store.genesisDashboard.outreachModal.open = true; $store.genesisDashboard.fetchOutreachMessages()">
+               style="cursor: pointer;" @click="location.hash = 'chat'; $store.genesisDashboard.commsTab = 'outreach'">
             <div class="health-card-header">
               <div class="health-card-title">Outreach (7d) <span style="font-size: 0.6rem; opacity: 0.5;">click for details</span></div>
               <span class="status-chip"
@@ -4659,7 +4712,7 @@
 
 
     <!-- Panel: CC Sessions [Tab: sessions] -->
-    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'sessions'">
+    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'internals'">
       <div class="panel-header">
         <span class="material-symbols-outlined">terminal</span>
         CC Sessions
@@ -4733,7 +4786,7 @@
     </div>
 
     <!-- Panel: Activity Feed [Tab: sessions] -->
-    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'sessions'">
+    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'internals'">
       <div class="panel-header">
         <span class="material-symbols-outlined">timeline</span>
         Activity Feed
@@ -6246,9 +6299,9 @@
     </div>
   </div>
 
-  <!-- Outreach Messages Modal -->
-  <div class="config-modal-overlay" x-show="$store.genesisDashboard.outreachModal.open"
-       @click.self="$store.genesisDashboard.outreachModal.open = false" x-transition>
+  <!-- Outreach Messages Modal (deprecated — moved to Chat tab Communication panel) -->
+  <div class="config-modal-overlay" x-show="false"
+       x-transition>
     <div class="config-modal" style="max-width: 800px; max-height: 85vh;">
       <div class="config-modal-header">
         <span>Outreach Messages</span>
@@ -6750,18 +6803,232 @@
         Genesis / Claude Code Terminal
       </div>
       <div class="panel-body">
-        <div style="padding:3rem; text-align:center;">
-          <span class="material-symbols-outlined" style="font-size:3rem; color:#555; display:block; margin-bottom:1rem;">terminal</span>
+        <div style="padding:2rem; text-align:center;">
+          <span class="material-symbols-outlined" style="font-size:2.5rem; color:#555; display:block; margin-bottom:0.75rem;">terminal</span>
           <div style="margin-bottom:0.5rem; color:var(--color-text-secondary); font-size:0.85rem;">
             Open a shell in the Genesis project directory.
-          </div>
-          <div style="margin-bottom:1.5rem; color:#888; font-size:0.75rem;">
-            Opens in a new window with a full-screen terminal.
           </div>
           <button @click="$store.genesisDashboard.openTerminal()"
                   style="font-size:0.8rem; padding:0.5rem 1.5rem; border-radius:4px; cursor:pointer;
                          background:rgba(33,150,243,0.15); color:#2196F3; border:1px solid rgba(33,150,243,0.3);
                          font-weight:500;">Open Terminal</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Communication: Outreach + Proposals [Tab: chat] ─── -->
+    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'chat'">
+      <div class="panel-header">
+        <span class="material-symbols-outlined">forum</span>
+        Communication
+        <span class="panel-status">
+          <span style="font-size:0.72rem; opacity:0.7;"
+                x-text="(() => {
+                  const c = $store.genesisDashboard.commsCounts;
+                  const parts = [];
+                  if (c.proposals_pending) parts.push(c.proposals_pending + ' proposal' + (c.proposals_pending > 1 ? 's' : ''));
+                  if (c.pending_approvals) parts.push(c.pending_approvals + ' approval' + (c.pending_approvals > 1 ? 's' : ''));
+                  return parts.length ? parts.join(' · ') : '';
+                })()"></span>
+        </span>
+      </div>
+      <div class="panel-body">
+        <!-- Sub-tabs -->
+        <div style="display:flex; gap:0.25rem; margin-bottom:0.75rem;">
+          <button style="font-size:0.72rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer;"
+                  :style="$store.genesisDashboard.commsTab === 'outreach' ? 'background:#2196F333; border:1px solid #2196F3; color:#2196F3; font-weight:600;' : 'background:transparent; border:1px solid #666; color:#aaa;'"
+                  @click="$store.genesisDashboard.commsTab = 'outreach'">Outreach</button>
+          <button style="font-size:0.72rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer;"
+                  :style="$store.genesisDashboard.commsTab === 'proposals' ? 'background:#ce93d833; border:1px solid #ce93d8; color:#ce93d8; font-weight:600;' : 'background:transparent; border:1px solid #666; color:#aaa;'"
+                  @click="$store.genesisDashboard.commsTab = 'proposals'">
+            Proposals
+            <template x-if="$store.genesisDashboard.commsCounts.proposals_pending > 0">
+              <span style="background:#ce93d8; color:#000; font-size:0.6rem; padding:0.05rem 0.25rem; border-radius:8px; margin-left:0.25rem;"
+                    x-text="$store.genesisDashboard.commsCounts.proposals_pending"></span>
+            </template>
+          </button>
+        </div>
+
+        <!-- View toggle -->
+        <div style="display:flex; gap:0.25rem; margin-bottom:0.75rem;">
+          <button style="font-size:0.68rem; padding:0.15rem 0.5rem; border-radius:3px; cursor:pointer;"
+                  :style="$store.genesisDashboard.commsView === 'pending' ? 'background:#ffffff15; border:1px solid #888; color:#fff;' : 'background:transparent; border:1px solid #555; color:#888;'"
+                  @click="$store.genesisDashboard.commsView = 'pending'; $store.genesisDashboard.fetchComms()">Pending</button>
+          <button style="font-size:0.68rem; padding:0.15rem 0.5rem; border-radius:3px; cursor:pointer;"
+                  :style="$store.genesisDashboard.commsView === 'all' ? 'background:#ffffff15; border:1px solid #888; color:#fff;' : 'background:transparent; border:1px solid #555; color:#888;'"
+                  @click="$store.genesisDashboard.commsView = 'all'; $store.genesisDashboard.fetchComms()">All</button>
+        </div>
+
+        <!-- Pending approvals banner -->
+        <template x-if="$store.genesisDashboard.commsPendingApprovals.length > 0">
+          <div style="background:#d9534f1a; border:1px solid #d9534f44; border-radius:6px; padding:0.6rem 0.75rem; margin-bottom:0.75rem;">
+            <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:0.3rem;">
+              <span style="font-weight:600; font-size:0.82rem; color:#d9534f;">
+                Action Required
+                <span style="background:#d9534f; color:white; font-size:0.65rem; padding:0.1rem 0.35rem; border-radius:10px; margin-left:0.3rem;"
+                      x-text="$store.genesisDashboard.commsPendingApprovals.length"></span>
+              </span>
+              <button style="font-size:0.68rem; padding:0.2rem 0.5rem; border:1px solid #4caf50; color:#4caf50; border-radius:3px; cursor:pointer; background:transparent;"
+                      @click="$store.genesisDashboard.approveAllPending()">Approve All</button>
+            </div>
+            <template x-for="a in $store.genesisDashboard.commsPendingApprovals" :key="a.id">
+              <div style="display:flex; justify-content:space-between; align-items:center; padding:0.25rem 0; border-top:1px solid #d9534f22;">
+                <div>
+                  <span style="font-size:0.75rem;" x-text="a.description || a.action_type"></span>
+                  <span style="font-size:0.62rem; color:#888; margin-left:0.3rem;" x-text="$store.genesisDashboard.formatDateTime(a.created_at)"></span>
+                </div>
+                <div style="display:flex; gap:0.25rem;">
+                  <button style="font-size:0.65rem; padding:0.15rem 0.4rem; border:1px solid #4caf50; color:#4caf50; border-radius:3px; cursor:pointer; background:transparent;"
+                          @click="$store.genesisDashboard.resolveApproval(a.id, 'approved')">Approve</button>
+                  <button style="font-size:0.65rem; padding:0.15rem 0.4rem; border:1px solid #d9534f; color:#d9534f; border-radius:3px; cursor:pointer; background:transparent;"
+                          @click="$store.genesisDashboard.resolveApproval(a.id, 'rejected')">Deny</button>
+                </div>
+              </div>
+            </template>
+          </div>
+        </template>
+
+        <!-- ── Outreach messages ──────────────────────────── -->
+        <div x-show="$store.genesisDashboard.commsTab === 'outreach'">
+          <!-- Category filters -->
+          <div style="display:flex; gap:0.4rem; margin-bottom:0.75rem; flex-wrap:wrap;">
+            <template x-for="cat in [null, 'alert', 'digest', 'surplus', 'blocker']" :key="cat || 'all'">
+              <button style="font-size:0.72rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer; transition:opacity 0.15s;"
+                      :style="`border:1px solid ${cat ? '#888' : '#4caf50'}; background:${$store.genesisDashboard.commsCategoryFilter === cat ? (cat ? '#88888833' : '#4caf5033') : 'transparent'}; color:${$store.genesisDashboard.commsCategoryFilter === cat ? '#fff' : '#aaa'}; opacity:${$store.genesisDashboard.commsCategoryFilter === cat || $store.genesisDashboard.commsCategoryFilter === null && cat === null ? '1' : '0.6'}`"
+                      @click="$store.genesisDashboard.commsCategoryFilter = cat"
+                      x-text="cat ? cat.charAt(0).toUpperCase() + cat.slice(1) : 'All'"></button>
+            </template>
+          </div>
+          <template x-if="$store.genesisDashboard.commsOutreach.length === 0">
+            <div style="color:var(--color-text-secondary); text-align:center; padding:2rem; font-size:0.75rem;">No outreach messages found.</div>
+          </template>
+          <template x-for="msg in $store.genesisDashboard.commsOutreach.filter(m => !$store.genesisDashboard.commsCategoryFilter || m.category === $store.genesisDashboard.commsCategoryFilter)" :key="msg.id">
+            <div style="border:1px solid var(--color-border); border-radius:6px; padding:0.75rem; margin-bottom:0.5rem;">
+              <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:0.3rem;">
+                <div>
+                  <span style="font-weight:600; font-size:0.85rem;" x-text="msg.topic || msg.signal_type || 'Untitled'"></span>
+                  <span style="font-size:0.68rem; padding:0.1rem 0.3rem; border-radius:3px; margin-left:0.3rem;"
+                        :style="`background:${(msg.category === 'blocker' || msg.category === 'approval') ? '#d9534f33' : msg.category === 'alert' ? '#f0ad4e33' : msg.category === 'digest' ? '#2196F333' : '#4caf5033'}; color:${(msg.category === 'blocker' || msg.category === 'approval') ? '#d9534f' : msg.category === 'alert' ? '#f0ad4e' : msg.category === 'digest' ? '#2196F3' : '#4caf50'}`"
+                        x-text="msg.category"></span>
+                </div>
+                <span style="font-size:0.68rem; color:var(--color-text-secondary);"
+                      x-text="msg.channel + ' · ' + $store.genesisDashboard.formatDateTime(msg.created_at)"></span>
+              </div>
+              <div style="font-size:0.8rem; white-space:pre-wrap; max-height:150px; overflow-y:auto; padding:0.4rem; background:var(--color-background); border-radius:4px; margin-bottom:0.3rem;"
+                   x-text="msg.message_content || '(no content)'"></div>
+              <!-- Engagement buttons -->
+              <div style="display:flex; gap:0.3rem; align-items:center;">
+                <template x-if="msg.category === 'blocker' || msg.category === 'approval'">
+                  <div style="display:flex; gap:0.3rem;">
+                    <template x-for="btn in [{value:'approved',label:'Approve',color:'#4caf50'},{value:'rejected',label:'Deny',color:'#d9534f'}]" :key="btn.value">
+                      <button style="font-size:0.68rem; padding:0.2rem 0.5rem; border-radius:3px; cursor:pointer;"
+                              :style="`border:1px solid ${btn.color}; color:${btn.color}; background:${msg.user_response === (btn.value === 'approved' ? 'approve' : 'deny') ? btn.color + '33' : 'transparent'};`"
+                              @click="$store.genesisDashboard.engageOutreach(msg.id, btn.value === 'approved' ? 'useful' : 'not_useful', btn.value === 'approved' ? 'approve' : 'deny')"
+                              x-text="btn.label"></button>
+                    </template>
+                  </div>
+                </template>
+                <template x-if="msg.category === 'alert'">
+                  <button style="font-size:0.68rem; padding:0.2rem 0.5rem; border-radius:3px; cursor:pointer;"
+                          :style="`border:1px solid #f0ad4e; color:#f0ad4e; background:${msg.engagement_outcome === 'useful' ? '#f0ad4e33' : 'transparent'};`"
+                          @click="$store.genesisDashboard.engageOutreach(msg.id, 'useful')"
+                          x-text="msg.engagement_outcome === 'useful' ? 'Acknowledged' : 'Acknowledge'"></button>
+                </template>
+                <template x-if="msg.category !== 'blocker' && msg.category !== 'alert' && msg.category !== 'approval'">
+                  <div style="display:flex; gap:0.3rem;">
+                    <template x-for="btn in [{value:'useful',label:'Useful',color:'#4caf50'},{value:'not_useful',label:'Not Useful',color:'#d9534f'},{value:'ambivalent',label:'Ambivalent',color:'#888'}]" :key="btn.value">
+                      <button style="font-size:0.68rem; padding:0.2rem 0.5rem; border-radius:3px; cursor:pointer;"
+                              :style="`border:1px solid ${btn.color}; color:${btn.color}; background:${msg.engagement_outcome === btn.value ? btn.color + '33' : 'transparent'}; opacity:${!msg.engagement_outcome || msg.engagement_outcome === btn.value ? '1' : '0.4'};`"
+                              @click="$store.genesisDashboard.engageOutreach(msg.id, btn.value)"
+                              x-text="btn.label"></button>
+                    </template>
+                  </div>
+                </template>
+              </div>
+            </div>
+          </template>
+        </div>
+
+        <!-- ── Ego Proposals ──────────────────────────────── -->
+        <div x-show="$store.genesisDashboard.commsTab === 'proposals'">
+          <!-- Status filter pills -->
+          <div style="display:flex; gap:0.4rem; margin-bottom:0.75rem; flex-wrap:wrap;">
+            <template x-for="[val, label] in [[null, 'All'], ['pending', 'Pending'], ['approved', 'Approved'], ['rejected', 'Rejected'], ['expired', 'Expired']]" :key="val || 'all'">
+              <button style="font-size:0.72rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer;"
+                      :style="$store.genesisDashboard.commsProposalFilter === val ? 'background:#ffffff15; border:1px solid #888; color:#fff;' : 'background:transparent; border:1px solid #555; color:#888;'"
+                      @click="$store.genesisDashboard.commsProposalFilter = val"
+                      x-text="label"></button>
+            </template>
+          </div>
+          <template x-if="$store.genesisDashboard.commsProposals.length === 0">
+            <div style="color:var(--color-text-secondary); text-align:center; padding:2rem; font-size:0.75rem;">No proposals. The ego hasn't produced any proposals yet.</div>
+          </template>
+          <template x-for="p in $store.genesisDashboard.commsProposals.filter(p => !$store.genesisDashboard.commsProposalFilter || p.status === $store.genesisDashboard.commsProposalFilter)" :key="p.id">
+            <div style="border:1px solid var(--color-border); border-radius:6px; padding:0.75rem; margin-bottom:0.5rem;">
+              <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:0.3rem;">
+                <div style="display:flex; gap:0.3rem; align-items:center;">
+                  <span style="font-size:0.65rem; padding:0.08rem 0.35rem; border-radius:3px; font-weight:600; text-transform:uppercase;"
+                        :style="{
+                          'pending':  'background:rgba(255,167,38,0.15); color:#ffa726;',
+                          'approved': 'background:rgba(102,187,106,0.15); color:#66bb6a;',
+                          'rejected': 'background:rgba(239,154,154,0.15); color:#ef9a9a;',
+                          'expired':  'background:rgba(158,158,158,0.15); color:#9e9e9e;',
+                          'executed': 'background:rgba(33,150,243,0.15); color:#2196F3;',
+                        }[p.status] || 'background:rgba(158,158,158,0.15); color:#9e9e9e;'"
+                        x-text="p.status"></span>
+                  <span x-show="p.action_type" style="font-size:0.65rem; padding:0.08rem 0.35rem; border-radius:3px; background:rgba(33,150,243,0.1); color:#64b5f6;"
+                        x-text="p.action_type"></span>
+                  <span x-show="p.urgency && p.urgency !== 'normal'" style="font-size:0.65rem; padding:0.08rem 0.35rem; border-radius:3px;"
+                        :style="p.urgency === 'high' || p.urgency === 'critical' ? 'background:rgba(239,154,154,0.15); color:#ef9a9a;' : ''"
+                        x-text="p.urgency"></span>
+                </div>
+                <span style="font-size:0.65rem; color:var(--color-text-secondary);"
+                      x-text="$store.genesisDashboard.formatDateTime(p.created_at)"></span>
+              </div>
+              <!-- Confidence bar -->
+              <template x-if="p.confidence != null">
+                <div style="margin-bottom:0.3rem;">
+                  <div style="display:flex; align-items:center; gap:0.3rem;">
+                    <div style="flex:1; height:4px; background:rgba(255,255,255,0.1); border-radius:2px; overflow:hidden;">
+                      <div style="height:100%; border-radius:2px; transition:width 0.3s;"
+                           :style="`width:${(p.confidence * 100)}%; background:${p.confidence > 0.7 ? '#66bb6a' : p.confidence > 0.4 ? '#ffa726' : '#ef9a9a'};`"></div>
+                    </div>
+                    <span style="font-size:0.6rem; color:var(--color-text-secondary);" x-text="(p.confidence * 100).toFixed(0) + '%'"></span>
+                  </div>
+                </div>
+              </template>
+              <div style="font-size:0.8rem; margin-bottom:0.3rem; line-height:1.4;" x-text="p.content"></div>
+              <template x-if="p.rationale">
+                <div style="font-size:0.7rem; color:var(--color-text-secondary); margin-bottom:0.3rem;" x-text="'Rationale: ' + p.rationale"></div>
+              </template>
+              <template x-if="p.user_response">
+                <div style="font-size:0.7rem; color:var(--color-text-secondary); margin-top:0.2rem;">
+                  <strong>Response:</strong> <span x-text="p.user_response"></span>
+                </div>
+              </template>
+              <!-- Approve/Reject for pending -->
+              <template x-if="p.status === 'pending'">
+                <div style="display:flex; gap:0.3rem; margin-top:0.4rem;">
+                  <button style="font-size:0.68rem; padding:0.2rem 0.5rem; border-radius:3px; cursor:pointer; border:1px solid #4caf50; color:#4caf50; background:transparent;"
+                          @click="$store.genesisDashboard.resolveCommsProposal(p.id, 'approved')">Approve</button>
+                  <template x-if="$store.genesisDashboard.commsRejectingId !== p.id">
+                    <button style="font-size:0.68rem; padding:0.2rem 0.5rem; border-radius:3px; cursor:pointer; border:1px solid #d9534f; color:#d9534f; background:transparent;"
+                            @click="$store.genesisDashboard.commsRejectingId = p.id">Reject</button>
+                  </template>
+                  <template x-if="$store.genesisDashboard.commsRejectingId === p.id">
+                    <div style="display:flex; gap:0.25rem; flex:1;">
+                      <input type="text" x-model="$store.genesisDashboard.commsRejectReason" placeholder="Reason (optional)"
+                             style="flex:1; font-size:0.68rem; padding:0.2rem 0.4rem; background:var(--color-background); border:1px solid var(--color-border); color:var(--color-text); border-radius:3px;">
+                      <button style="font-size:0.68rem; padding:0.2rem 0.5rem; border-radius:3px; cursor:pointer; border:1px solid #d9534f; color:#d9534f; background:#d9534f22;"
+                              @click="$store.genesisDashboard.resolveCommsProposal(p.id, 'rejected', $store.genesisDashboard.commsRejectReason)">Confirm</button>
+                      <button style="font-size:0.68rem; padding:0.2rem 0.5rem; border-radius:3px; cursor:pointer; border:1px solid #666; color:#888; background:transparent;"
+                              @click="$store.genesisDashboard.commsRejectingId = null; $store.genesisDashboard.commsRejectReason = ''">Cancel</button>
+                    </div>
+                  </template>
+                </div>
+              </template>
+            </div>
+          </template>
         </div>
       </div>
     </div>
@@ -6880,9 +7147,149 @@
     </div>
 
     <!-- ═══════════════════════════════════════════════════════════════
-         Panel: Task Execution Viewer [Tab: tasks]
+         Panel: Work [Tab: work] — Tasks + Follow-ups + Background Sessions
          ═══════════════════════════════════════════════════════════════ -->
-    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'tasks'">
+
+    <!-- Work: Unified view -->
+    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'work'">
+      <div class="panel-header">
+        <span class="material-symbols-outlined">work</span>
+        Work
+        <span class="panel-status">
+          <span style="font-size:0.72rem; opacity:0.7;"
+                x-text="(() => {
+                  const c = $store.genesisDashboard.workCounts;
+                  const parts = [];
+                  if (c.tasks?.active) parts.push(c.tasks.active + ' task' + (c.tasks.active > 1 ? 's' : ''));
+                  if (c.follow_ups?.pending) parts.push(c.follow_ups.pending + ' follow-up' + (c.follow_ups.pending > 1 ? 's' : ''));
+                  if (c.sessions?.active_bg) parts.push(c.sessions.active_bg + ' bg');
+                  return parts.length ? parts.join(' · ') : '';
+                })()"></span>
+        </span>
+      </div>
+      <div class="panel-body">
+        <!-- View toggle + type filter -->
+        <div style="display:flex; gap:0.5rem; margin-bottom:0.75rem; align-items:center; flex-wrap:wrap;">
+          <div style="display:flex; gap:0.25rem;">
+            <button style="font-size:0.72rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer; transition:all 0.15s;"
+                    :style="$store.genesisDashboard.workView === 'active' ? 'background:#4caf5033; border:1px solid #4caf50; color:#4caf50; font-weight:600;' : 'background:transparent; border:1px solid #666; color:#aaa;'"
+                    @click="$store.genesisDashboard.workView = 'active'; $store.genesisDashboard.fetchWork()">Active</button>
+            <button style="font-size:0.72rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer; transition:all 0.15s;"
+                    :style="$store.genesisDashboard.workView === 'history' ? 'background:#2196F333; border:1px solid #2196F3; color:#2196F3; font-weight:600;' : 'background:transparent; border:1px solid #666; color:#aaa;'"
+                    @click="$store.genesisDashboard.workView = 'history'; $store.genesisDashboard.fetchWork()">History</button>
+          </div>
+          <div style="display:flex; gap:0.25rem; margin-left:0.5rem;">
+            <template x-for="[filterVal, label] in [[null, 'All'], ['task', 'Tasks'], ['follow_up', 'Follow-ups'], ['session', 'Sessions']]" :key="filterVal || 'all'">
+              <button style="font-size:0.68rem; padding:0.15rem 0.5rem; border-radius:3px; cursor:pointer;"
+                      :style="$store.genesisDashboard.workTypeFilter === filterVal ? 'background:#ffffff15; border:1px solid #888; color:#fff;' : 'background:transparent; border:1px solid #555; color:#888;'"
+                      @click="$store.genesisDashboard.workTypeFilter = filterVal"
+                      x-text="label"></button>
+            </template>
+          </div>
+        </div>
+
+        <!-- Counts bar -->
+        <div style="display:flex; gap:0.75rem; margin-bottom:0.75rem; font-size:0.72rem; color:var(--color-text-secondary);">
+          <span x-show="$store.genesisDashboard.workCounts.tasks" x-text="'Tasks: ' + ($store.genesisDashboard.workCounts.tasks?.active || 0) + ' active / ' + ($store.genesisDashboard.workCounts.tasks?.completed || 0) + ' done'"></span>
+          <span x-show="$store.genesisDashboard.workCounts.follow_ups" x-text="'Follow-ups: ' + ($store.genesisDashboard.workCounts.follow_ups?.pending || 0) + ' pending'"></span>
+          <span x-show="$store.genesisDashboard.workCounts.sessions" x-text="'BG Sessions: ' + ($store.genesisDashboard.workCounts.sessions?.active_bg || 0) + ' active'"></span>
+        </div>
+
+        <!-- Unified item list -->
+        <template x-if="$store.genesisDashboard.workItems.filter(i => !$store.genesisDashboard.workTypeFilter || i.type === $store.genesisDashboard.workTypeFilter).length === 0">
+          <div style="padding:1.5rem; text-align:center; color:var(--color-text-secondary); font-size:0.75rem;">
+            No work items found.
+          </div>
+        </template>
+        <div class="activity-feed">
+          <template x-for="item in $store.genesisDashboard.workItems.filter(i => !$store.genesisDashboard.workTypeFilter || i.type === $store.genesisDashboard.workTypeFilter)" :key="item.id">
+            <div>
+              <div class="activity-row" style="cursor:pointer; display:flex; align-items:center; gap:0.5rem;"
+                   @click="if (item.type === 'task') { $store.genesisDashboard.fetchTaskDetail(item.id); } else { $store.genesisDashboard.workExpanded = $store.genesisDashboard.workExpanded === item.id ? null : item.id; }">
+                <!-- Type badge -->
+                <span style="font-size:0.6rem; padding:0.08rem 0.35rem; border-radius:3px; font-weight:600; text-transform:uppercase; flex-shrink:0;"
+                      :style="{
+                        'task':      'background:rgba(33,150,243,0.15); color:#2196F3;',
+                        'follow_up': 'background:rgba(156,39,176,0.15); color:#ce93d8;',
+                        'session':   'background:rgba(0,150,136,0.15); color:#80cbc4;',
+                      }[item.type] || 'background:rgba(158,158,158,0.15); color:#9e9e9e;'"
+                      x-text="item.type === 'follow_up' ? 'follow-up' : item.type"></span>
+                <!-- Status badge -->
+                <span style="font-size:0.6rem; padding:0.08rem 0.35rem; border-radius:3px; font-weight:600; text-transform:uppercase; flex-shrink:0;"
+                      :style="{
+                        'executing':   'background:rgba(33,150,243,0.15); color:#2196F3;',
+                        'completed':   'background:rgba(102,187,106,0.15); color:#66bb6a;',
+                        'failed':      'background:rgba(239,154,154,0.15); color:#ef9a9a;',
+                        'cancelled':   'background:rgba(158,158,158,0.15); color:#9e9e9e;',
+                        'paused':      'background:rgba(255,167,38,0.15); color:#ffa726;',
+                        'blocked':     'background:rgba(255,167,38,0.15); color:#ffa726;',
+                        'pending':     'background:rgba(158,158,158,0.15); color:#9e9e9e;',
+                        'in_progress': 'background:rgba(33,150,243,0.15); color:#2196F3;',
+                        'active':      'background:rgba(102,187,106,0.15); color:#66bb6a;',
+                      }[item.status?.toLowerCase()] || 'background:rgba(158,158,158,0.15); color:#9e9e9e;'"
+                      x-text="item.status"></span>
+                <!-- Priority badge (follow-ups only) -->
+                <template x-if="item.type === 'follow_up' && item.priority && item.priority !== 'medium'">
+                  <span style="font-size:0.6rem; padding:0.08rem 0.3rem; border-radius:3px; flex-shrink:0;"
+                        :style="item.priority === 'high' || item.priority === 'critical' ? 'background:rgba(239,154,154,0.15); color:#ef9a9a;' : 'background:rgba(158,158,158,0.1); color:#9e9e9e;'"
+                        x-text="item.priority"></span>
+                </template>
+                <!-- Description -->
+                <span style="flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-size:0.73rem;"
+                      x-text="item.description || item.id"></span>
+                <!-- Timestamp -->
+                <span style="color:var(--color-text-secondary); font-size:0.65rem; flex-shrink:0;"
+                      x-text="$store.genesisDashboard.formatTime(item.created_at)"></span>
+                <!-- Expand arrow -->
+                <span class="material-symbols-outlined" style="font-size:0.9rem; color:var(--color-text-secondary); transition:transform 0.15s;"
+                      :style="($store.genesisDashboard.taskExpanded === item.id || $store.genesisDashboard.workExpanded === item.id) ? 'transform:rotate(90deg)' : ''">chevron_right</span>
+              </div>
+
+              <!-- Expanded: follow-up detail -->
+              <template x-if="item.type === 'follow_up' && $store.genesisDashboard.workExpanded === item.id">
+                <div style="padding:0.5rem 0.75rem; background:rgba(0,0,0,0.15); border-radius:4px; margin:0.25rem 0 0.5rem 0; font-size:0.72rem;">
+                  <div style="margin-bottom:0.4rem; line-height:1.5;" x-text="item.description"></div>
+                  <template x-if="item.reason">
+                    <div style="margin-bottom:0.3rem; color:var(--color-text-secondary); font-size:0.7rem;">
+                      <strong>Reason:</strong> <span x-text="item.reason"></span>
+                    </div>
+                  </template>
+                  <div style="display:flex; gap:0.5rem; font-size:0.65rem; color:var(--color-text-secondary);">
+                    <span x-text="'Strategy: ' + (item.strategy || 'unknown')"></span>
+                    <span x-text="'Source: ' + (item.source || 'unknown')"></span>
+                  </div>
+                  <template x-if="item.resolution_notes">
+                    <div style="margin-top:0.3rem; padding:0.2rem 0.4rem; background:rgba(0,0,0,0.2); border-radius:3px; font-size:0.65rem; color:var(--color-text-secondary);">
+                      <strong>Resolution:</strong> <span x-text="item.resolution_notes"></span>
+                    </div>
+                  </template>
+                  <template x-if="item.blocked_reason">
+                    <div style="margin-top:0.3rem; padding:0.2rem 0.4rem; background:rgba(255,167,38,0.08); border-radius:3px; border:1px solid rgba(255,167,38,0.15); font-size:0.65rem;">
+                      <strong style="color:#ffa726;">Blocked:</strong> <span x-text="item.blocked_reason"></span>
+                    </div>
+                  </template>
+                </div>
+              </template>
+
+              <!-- Expanded: session detail -->
+              <template x-if="item.type === 'session' && $store.genesisDashboard.workExpanded === item.id">
+                <div style="padding:0.5rem 0.75rem; background:rgba(0,0,0,0.15); border-radius:4px; margin:0.25rem 0 0.5rem 0; font-size:0.72rem;">
+                  <div style="display:flex; gap:1rem; flex-wrap:wrap; color:var(--color-text-secondary); font-size:0.7rem;">
+                    <span x-text="'Type: ' + (item.session_type || 'unknown')"></span>
+                    <span x-text="'Model: ' + (item.model || 'unknown')"></span>
+                    <span x-show="item.cost_usd != null" x-text="'Cost: $' + (item.cost_usd || 0).toFixed(4)"></span>
+                    <span x-text="'Started: ' + $store.genesisDashboard.formatTime(item.created_at)"></span>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </template>
+        </div>
+      </div>
+    </div>
+
+    <!-- Work: Task Execution Detail (preserved from original) -->
+    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'work'">
       <div class="panel-header">
         <span class="material-symbols-outlined">task_alt</span>
         Task Execution


### PR DESCRIPTION
## Summary

Dashboard tab consolidation reducing from 10 to 9 tabs with better information density:

- **Tasks → Work** — unified tab showing tasks, follow-ups, and background sessions with active/history views and type filtering
- **Sessions & Activity → merged into Internals** — CC sessions and activity feed panels now live under Internals
- **Chat tab expanded** — now includes Communication panel with outreach messages and ego proposals (with approve/reject controls)
- **Outreach modal deprecated** — functionality moved to Chat tab, Overview health card updated to navigate there
- **Ego modal simplified** — removed proposals and follow-ups tabs (now in Chat and Work), added navigation links

### New API endpoints
- `GET /api/genesis/work` — unified work view (tasks + follow-ups + bg sessions)
- `GET /api/genesis/comms` — unified comms view (outreach + proposals + approvals)
- `POST /api/genesis/comms/proposals/<id>/resolve` — approve/reject proposals

### Tab layout (before → after)
| Before (10) | After (9) |
|-------------|-----------|
| Overview | Overview |
| Chat | Chat (+ Communication panel) |
| Internals | Internals (+ Sessions & Activity) |
| Sessions & Activity | *removed* |
| Configuration | Configuration |
| Files | Files |
| Tasks | Work (tasks + follow-ups + bg sessions) |
| Memory | Memory |
| Knowledge | Knowledge |
| Backup & Updates | Backup & Updates |

## Test plan
- [ ] Load dashboard — verify 9 tabs render
- [ ] Work tab: check active view shows tasks + follow-ups + bg sessions
- [ ] Work tab: toggle to History view, verify completed items appear
- [ ] Work tab: test type filter pills (All/Tasks/Follow-ups/Sessions)
- [ ] Chat tab: verify terminal launcher still works
- [ ] Chat tab: check outreach messages display with category filters
- [ ] Chat tab: check proposals display with approve/reject controls
- [ ] Internals tab: verify CC Sessions and Activity Feed panels appear
- [ ] Overview: outreach health card navigates to Chat tab (not modal)
- [ ] Ego modal: "View Proposals" and "View Follow-ups" buttons navigate correctly
- [ ] `curl /api/genesis/work` returns data
- [ ] `curl /api/genesis/comms` returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)