### PR TITLE
fix: code review remediation batch 2 — behavioral fixes

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -463,6 +463,14 @@ call_sites:
     never_pays: true
     description: "Email triage \u2014 Gemini-primary light filter for weekly email\
       \ batch"
+  contribution_gate:
+    chain:
+    - claude-haiku
+    - groq-free
+    - gemini-free
+    default_paid: true
+    description: "Contribution pipeline \u2014 evaluates whether a code change is\
+      \ already fixed upstream"
 retry:
   default:
     max_retries: 3

--- a/src/genesis/autonomy/approval_gate.py
+++ b/src/genesis/autonomy/approval_gate.py
@@ -356,9 +356,10 @@ class AutonomousCliApprovalGate:
     ) -> dict[str, Any] | None:
         """Find an existing approval request that matches this call.
 
-        Primary match: content-stable ``approval_key`` (hits any status,
-        preserves "previously rejected" behaviour so a rejected row blocks
-        the dispatch instead of creating a duplicate).
+        Primary match: content-stable ``approval_key``. Skips resolved
+        rows (rejected and consumed-approved) so each approval/rejection
+        is instance-only — only pending or unconsumed-approved rows are
+        reused for dedup.
 
         Race-safety fallback: if no approval_key match and the caller
         provided ``subsystem``/``policy_id``, also match any *pending* row

--- a/src/genesis/autonomy/approval_gate.py
+++ b/src/genesis/autonomy/approval_gate.py
@@ -381,8 +381,11 @@ class AutonomousCliApprovalGate:
                 context.get("kind") == "autonomous_cli_fallback"
                 and context.get("approval_key") == approval_key
             ):
-                # Don't reuse consumed approvals — each dispatch needs its own.
-                if str(row.get("status") or "") == "approved" and row.get("consumed_at"):
+                # Each approval/rejection is instance-only — skip resolved rows.
+                status_str = str(row.get("status") or "")
+                if status_str == "rejected":
+                    continue
+                if status_str == "approved" and row.get("consumed_at"):
                     continue
                 return row
         # Pass 2: race-safety fallback — pending rows for the same site.

--- a/src/genesis/contribution/version_gate.py
+++ b/src/genesis/contribution/version_gate.py
@@ -16,10 +16,10 @@ The model scored 10/10 at all thresholds 60-90. We ship with a
 threshold of 75 as a safety margin against future prompt-change
 hedging.
 
-Model: Claude Haiku 4.5 preferred when ANTHROPIC_API_KEY is available,
-`groq/llama-3.3-70b-versatile` as the validated fallback. Chosen via
-the Genesis router when runtime is available, direct
-`litellm.acompletion()` otherwise (e.g. from hook contexts).
+Model: Reads from ``contribution_gate`` call site in model_routing.yaml.
+Falls back to hardcoded chain (Claude Haiku 4.5 → Groq Llama → Gemini
+Flash) if config is unavailable. Calls litellm directly (not through the
+router) but records results to the neural monitor for visibility.
 """
 from __future__ import annotations
 
@@ -39,13 +39,15 @@ logger = logging.getLogger(__name__)
 # spike. Lower = more cancellations; higher = more duplicate PRs.
 CONFIDENCE_THRESHOLD = 75
 
-# Preferred model chain (first available wins). Production can override
-# by passing `model=...` to `check_version_gate()`.
-_PREFERRED_MODELS = [
+# Fallback model chain when routing config is unavailable.
+# Production can override by passing `model=...` to `check_version_gate()`.
+_FALLBACK_MODELS = [
     ("anthropic/claude-haiku-4-5", "ANTHROPIC_API_KEY"),
     ("groq/llama-3.3-70b-versatile", "GROQ_API_KEY"),
     ("gemini/gemini-2.0-flash", "GEMINI_API_KEY"),
 ]
+
+_CALL_SITE_ID = "contribution_gate"
 
 # Copied VERBATIM from scripts/spike_version_gate_calibrate.py after
 # 10/10 validation. Do NOT re-engineer without re-running the spike.
@@ -281,10 +283,50 @@ def parse_llm_response(text: str) -> tuple[bool, dict]:
     return True, obj
 
 
+def _load_models_from_config() -> list[tuple[str, str]]:
+    """Try to load the contribution_gate chain from model_routing.yaml.
+
+    Returns list of (litellm_model_string, required_env_var) tuples,
+    or empty list if config is unavailable.
+    """
+    try:
+        from genesis.routing.config import load_config
+
+        cfg_path = Path(__file__).resolve().parents[3] / "config" / "model_routing.yaml"
+        config = load_config(cfg_path)
+        site = config.call_sites.get(_CALL_SITE_ID)
+        if site is None:
+            return []
+        # Map provider type to litellm prefix
+        _PREFIX = {"anthropic": "anthropic", "groq": "groq", "google": "gemini"}
+        # Map provider type to conventional env var for API key
+        _ENV = {
+            "anthropic": "ANTHROPIC_API_KEY",
+            "groq": "GROQ_API_KEY",
+            "google": "GEMINI_API_KEY",
+        }
+        result = []
+        for pname in site.chain:
+            pcfg = config.providers.get(pname)
+            if pcfg is None or not pcfg.enabled:
+                continue
+            ptype = pcfg.provider_type
+            prefix = _PREFIX.get(ptype, ptype)
+            model_str = f"{prefix}/{pcfg.model_id}" if prefix else pcfg.model_id
+            env_var = _ENV.get(ptype, f"{ptype.upper()}_API_KEY")
+            result.append((model_str, env_var))
+        return result
+    except Exception:
+        logger.debug("Could not load routing config for contribution_gate", exc_info=True)
+        return []
+
+
 def _select_model(override: str | None) -> str | None:
     if override:
         return override
-    for model, env_var in _PREFERRED_MODELS:
+    # Try routing config first, fall back to hardcoded defaults
+    models = _load_models_from_config() or _FALLBACK_MODELS
+    for model, env_var in models:
         if os.environ.get(env_var):
             return model
     return None
@@ -300,6 +342,29 @@ async def _call_llm(prompt: str, model: str) -> str:
         max_tokens=500,
     )
     return response.choices[0].message.content or ""
+
+
+async def _record_to_monitor(model: str, response_text: str | None, *, success: bool) -> None:
+    """Best-effort recording to neural monitor. Never raises."""
+    try:
+        import aiosqlite
+
+        from genesis.env import genesis_db_path
+        from genesis.observability.call_site_recorder import record_last_run
+
+        # Extract provider prefix from litellm model string (e.g. "anthropic/..." → "anthropic")
+        provider = model.split("/", 1)[0] if "/" in model else model
+        model_id = model.split("/", 1)[1] if "/" in model else model
+
+        async with aiosqlite.connect(str(genesis_db_path())) as db:
+            await record_last_run(
+                db, _CALL_SITE_ID,
+                provider=provider, model_id=model_id,
+                response_text=(response_text or "")[:200],
+                success=success,
+            )
+    except Exception:
+        logger.debug("Failed to record contribution_gate to neural monitor", exc_info=True)
 
 
 async def check_version_gate(
@@ -364,6 +429,7 @@ async def check_version_gate(
         raw = await _call_llm(prompt, chosen_model)
     except Exception as e:  # noqa: BLE001 — fail-open on any litellm error
         logger.error("version_gate: LLM call failed: %s", e, exc_info=True)
+        await _record_to_monitor(chosen_model, None, success=False)
         return VersionGateResult(
             already_fixed=False,
             confidence=0,
@@ -372,6 +438,8 @@ async def check_version_gate(
             parse_ok=False,
             llm_error=str(e),
         )
+
+    await _record_to_monitor(chosen_model, raw[:200], success=True)
 
     ok, parsed = parse_llm_response(raw)
     if not ok:

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -422,13 +422,14 @@ def _remote_browser_connected() -> bool:
 
 
 def _check_remote_health() -> dict | None:
-    """Returns error dict if remote is active but disconnected. None if OK."""
+    """Returns error dict if remote is active but disconnected. None if OK.
+
+    Read-only — does NOT modify global state. Use _detach_dead_remote()
+    when you need to clear globals on disconnection.
+    """
     if not _is_remote_active():
         return None
     if not _remote_browser_connected():
-        global _active_page, _remote_page
-        _active_page = None
-        _remote_page = None
         return {
             "error": (
                 "Remote Chrome connection lost. "
@@ -437,6 +438,20 @@ def _check_remote_health() -> dict | None:
             )
         }
     return None
+
+
+def _detach_dead_remote() -> dict | None:
+    """Check remote health and clear globals if disconnected.
+
+    Returns error dict if remote was disconnected (globals cleared),
+    None if OK or not in remote mode.
+    """
+    err = _check_remote_health()
+    if err is not None:
+        global _active_page, _remote_page
+        _active_page = None
+        _remote_page = None
+    return err
 
 
 def _update_remote_url() -> None:
@@ -906,7 +921,7 @@ async def _impl_browser_click(selector: str) -> dict:
     _touch()
     if _active_page is None:
         return {"error": "No page open. Call browser_navigate first."}
-    health = _check_remote_health()
+    health = _detach_dead_remote()
     if health:
         return health
     drift = _check_page_drift(_active_page) if _is_remote_active() else None
@@ -931,7 +946,7 @@ async def _impl_browser_fill(selector: str, value: str) -> dict:
     _touch()
     if _active_page is None:
         return {"error": "No page open. Call browser_navigate first."}
-    health = _check_remote_health()
+    health = _detach_dead_remote()
     if health:
         return health
     drift = _check_page_drift(_active_page) if _is_remote_active() else None
@@ -959,7 +974,7 @@ async def _impl_browser_upload(selector: str, file_path: str) -> dict:
     _touch()
     if _active_page is None:
         return {"error": "No page open. Call browser_navigate first."}
-    health = _check_remote_health()
+    health = _detach_dead_remote()
     if health:
         return health
     drift = _check_page_drift(_active_page) if _is_remote_active() else None
@@ -985,7 +1000,7 @@ async def _impl_browser_screenshot() -> dict:
     _touch()
     if _active_page is None:
         return {"error": "No page open. Call browser_navigate first."}
-    health = _check_remote_health()
+    health = _detach_dead_remote()
     if health:
         return health
     try:
@@ -1006,7 +1021,7 @@ async def _impl_browser_snapshot() -> dict:
     _touch()
     if _active_page is None:
         return {"error": "No page open. Call browser_navigate first."}
-    health = _check_remote_health()
+    health = _detach_dead_remote()
     if health:
         return health
     try:
@@ -1025,7 +1040,7 @@ async def _impl_browser_run_js(expression: str) -> dict:
     _touch()
     if _active_page is None:
         return {"error": "No page open. Call browser_navigate first."}
-    health = _check_remote_health()
+    health = _detach_dead_remote()
     if health:
         return health
     try:
@@ -1078,7 +1093,7 @@ async def _impl_browser_press_key(key: str, count: int = 1) -> dict:
     _touch()
     if _active_page is None:
         return {"error": "No page open. Call browser_navigate first."}
-    health = _check_remote_health()
+    health = _detach_dead_remote()
     if health:
         return health
     count = max(1, min(count, 50))

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -363,14 +363,14 @@ def _start_idle_watcher():
 
 
 async def _get_page(
-    stealth: bool = False,
+    stealth: bool = True,
     remote: bool = False,
     cdp_url: str | None = None,
 ):
     """Get the appropriate browser page based on mode.
 
-    Default (stealth=False): Camoufox (anti-detection, primary).
-    Fallback (stealth=True): Chromium (for Camoufox-incompatible sites).
+    Default (stealth=True): Camoufox (anti-detection, primary).
+    Plain (stealth=False): Chromium fallback for Camoufox-incompatible sites.
     Remote (remote=True): User's real Chrome via CDP over Tailscale.
 
     Sets _active_page so subsequent interaction tools (click, fill, etc.)
@@ -380,9 +380,9 @@ async def _get_page(
     if remote:
         _active_page = await _ensure_remote_cdp(cdp_url)
     elif stealth:
-        _active_page = await _ensure_chromium_fallback()
-    else:
         _active_page = await _ensure_browser()
+    else:
+        _active_page = await _ensure_chromium_fallback()
     _touch()
     _start_idle_watcher()
     return _active_page
@@ -837,7 +837,7 @@ async def _wait_for_turnstile(page, timeout_ms: int = 15000) -> dict | None:
 
 async def _impl_browser_navigate(
     url: str,
-    stealth: bool = False,
+    stealth: bool = True,
     remote: bool = False,
     cdp_url: str | None = None,
 ) -> dict:
@@ -1100,7 +1100,7 @@ async def _impl_browser_press_key(key: str, count: int = 1) -> dict:
 @mcp.tool()
 async def browser_navigate(
     url: str,
-    stealth: bool = False,
+    stealth: bool = True,
     remote: bool = False,
     cdp_url: str | None = None,
 ) -> dict:
@@ -1113,7 +1113,7 @@ async def browser_navigate(
     stealth-browser skill for anti-detection behavioral rules. The skill covers
     timing, interaction patterns, honeypot avoidance, and per-site guidance.
 
-    Set stealth=True to use Chromium fallback for sites incompatible with
+    Set stealth=False to use Chromium fallback for sites incompatible with
     Camoufox (rare). Chromium uses a separate profile at ~/.genesis/browser-profile/.
 
     Set remote=True to drive the user's real Chrome over CDP/Tailscale.

--- a/src/genesis/observability/snapshots/call_sites.py
+++ b/src/genesis/observability/snapshots/call_sites.py
@@ -162,26 +162,24 @@ async def call_sites(
     if db:
         try:
             cursor = await db.execute(
-                "SELECT call_site_id, last_run_at, provider_used, model_id, response_text, input_tokens, output_tokens FROM call_site_last_run"
+                "SELECT call_site_id, last_run_at, provider_used, model_id,"
+                " response_text, input_tokens, output_tokens, success"
+                " FROM call_site_last_run"
             )
             for row in await cursor.fetchall():
                 sid = row[0]
+                run_data = {
+                    "last_run_at": row[1],
+                    "last_run_provider": row[2],
+                    "last_run_model": row[3],
+                    "last_response": row[4],
+                    "last_run_tokens": (row[5] or 0) + (row[6] or 0),
+                    "last_run_success": bool(row[7]) if row[7] is not None else True,
+                }
                 if sid in result:
-                    result[sid]["last_run_at"] = row[1]
-                    result[sid]["last_run_provider"] = row[2]
-                    result[sid]["last_run_model"] = row[3]
-                    result[sid]["last_response"] = row[4]
-                    result[sid]["last_run_tokens"] = (row[5] or 0) + (row[6] or 0)
+                    result[sid].update(run_data)
                 else:
-                    result[sid] = {
-                        "status": "active",
-                        "routing": False,
-                        "last_run_at": row[1],
-                        "last_run_provider": row[2],
-                        "last_run_model": row[3],
-                        "last_response": row[4],
-                        "last_run_tokens": (row[5] or 0) + (row[6] or 0),
-                    }
+                    result[sid] = {"status": "active", "routing": False, **run_data}
         except sqlite3.Error:
             logger.debug("call_site_last_run query failed", exc_info=True)
 

--- a/src/genesis/routing/router.py
+++ b/src/genesis/routing/router.py
@@ -108,6 +108,18 @@ class Router:
         else:
             logger.info("Routing config reloaded: %d call sites", len(new_sites))
 
+        # Validate hardcoded call site IDs used by the route() wrapper
+        for label, site_id in [
+            ("_FREE_TIER_SITE", self._FREE_TIER_SITE),
+            *((f"_PURPOSE_SITES[{k!r}]", v) for k, v in self._PURPOSE_SITES.items()),
+        ]:
+            if site_id not in new_config.call_sites:
+                logger.error(
+                    "route() wrapper references call site %r (%s) "
+                    "which is missing from routing config",
+                    site_id, label,
+                )
+
     async def scan_dlq_orphans_after_reload(self) -> int:
         """Proactively expire DLQ items whose target_provider was removed.
 
@@ -402,14 +414,14 @@ class Router:
         Used by modules (crypto_ops, prediction_markets, generalization),
         pipeline triage, and bookmark enrichment.
 
-        Currently only tier="free" is supported. Other tiers log a warning
-        and fall through to the free-tier site.
+        Currently only tier="free" is supported. Raises ValueError for
+        other tiers.
         """
         if purpose and purpose in self._PURPOSE_SITES:
             call_site_id = self._PURPOSE_SITES[purpose]
         else:
             if tier != "free":
-                logger.warning("route() called with tier=%r but only 'free' is supported; using free-tier site", tier)
+                raise ValueError(f"route() only supports tier='free', got {tier!r}")
             call_site_id = self._FREE_TIER_SITE
 
         result = await self.route_call(

--- a/src/genesis/routing/router.py
+++ b/src/genesis/routing/router.py
@@ -308,6 +308,14 @@ class Router:
                 attempts=attempts,
             )
 
+        # Record failure for neural monitor visibility
+        if self.cost_tracker and self.cost_tracker.db:
+            await record_last_run(
+                self.cost_tracker.db, call_site_id,
+                provider="(exhausted)", model_id="",
+                response_text=None, success=False,
+            )
+
         dead_lettered = False
         if self._dead_letter and not suppress_dead_letter:
             try:

--- a/src/genesis/skills/browser-automation/SKILL.md
+++ b/src/genesis/skills/browser-automation/SKILL.md
@@ -38,7 +38,7 @@ that can accomplish the task. **Token cost increases with each layer.**
   VNC display :99 — observable via noVNC. Profile at `~/.genesis/camoufox-profile/`.
   Includes humanized cursor movement, per-keystroke typing with IKI jitter,
   and stealth click with hover/jitter.
-- **Chromium fallback**: `browser_navigate(url, stealth=True)` uses Chromium
+- **Chromium fallback**: `browser_navigate(url, stealth=False)` uses Chromium
   for sites incompatible with Camoufox (rare). Profile at `~/.genesis/browser-profile/`.
 - **Agent-owned accounts**: log into accounts created FOR the agent, never the
   user's personal accounts. Treat the agent like a new employee.

--- a/tests/test_mcp/test_browser_tools.py
+++ b/tests/test_mcp/test_browser_tools.py
@@ -892,6 +892,7 @@ class TestRemoteHelpers:
         assert browser._check_remote_health() is None
 
     def test_check_remote_health_disconnected(self):
+        """Read-only check — returns error but does NOT clear globals."""
         page = MagicMock()
         browser._active_page = page
         browser._remote_page = page
@@ -899,6 +900,21 @@ class TestRemoteHelpers:
         browser._remote_browser.is_connected.return_value = False
 
         result = browser._check_remote_health()
+        assert result is not None
+        assert "error" in result
+        # Read-only: globals NOT cleared
+        assert browser._active_page is page
+        assert browser._remote_page is page
+
+    def test_detach_dead_remote_clears_globals(self):
+        """Mutating variant — returns error AND clears globals."""
+        page = MagicMock()
+        browser._active_page = page
+        browser._remote_page = page
+        browser._remote_browser = MagicMock()
+        browser._remote_browser.is_connected.return_value = False
+
+        result = browser._detach_dead_remote()
         assert result is not None
         assert "error" in result
         assert browser._active_page is None

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -131,7 +131,7 @@ def test_load_full_yaml(monkeypatch):
     assert "openrouter-deepseek-r1" not in cfg.providers
     # Call sites evolve — assert actual count matches config, and lock in
     # a few load-bearing ids rather than chasing the total on every edit.
-    assert len(cfg.call_sites) == 41
+    assert len(cfg.call_sites) == 42
     assert "background" in cfg.retry_profiles
     assert cfg.call_sites["12_surplus_brainstorm"].never_pays is True
     assert cfg.call_sites["5_deep_reflection"].default_paid is True


### PR DESCRIPTION
## Summary

Addresses behavioral findings from the external code review (2026-04-25).
Each fix changes runtime behavior and was verified with targeted testing
and code review.

- **AP3**: Rejected approvals no longer permanently block future requests.
  `_find_existing` now skips rejected rows — each approval/rejection is
  instance-only. Fixes permanent deadlock on mistaken rejections.
- **B1**: `stealth=True` now correctly means Camoufox (anti-detection).
  Previously inverted — `stealth=True` used the *less* stealthy Chromium.
  Default behavior unchanged (Camoufox is still the default).
- **R1**: Routing failures now recorded on the neural monitor. Previously
  only successes were written to `call_site_last_run`, leaving the monitor
  blind to failures. Snapshot query now includes `success` field.
- **R2+R3**: `route()` wrapper raises `ValueError` on non-free tier instead
  of silently downgrading. Hardcoded call site IDs validated against config
  at reload time.
- **B4**: Split `_check_remote_health` into read-only check and mutating
  `_detach_dead_remote`. Command-query separation — same runtime behavior,
  clearer intent.
- **H6**: Contribution pipeline model chain now configurable via
  `contribution_gate` call site in `model_routing.yaml`. Version gate reads
  config (falls back to hardcoded defaults), records to neural monitor.

## Test plan

- [x] `pytest tests/test_autonomy/test_approval.py` — 12 passed
- [x] `pytest tests/test_mcp/test_browser_tools.py` — 65 passed (new test for detach)
- [x] `pytest tests/test_routing/` — all passed (including updated call site count)
- [x] Config load verification: `contribution_gate` site loads with correct chain
- [x] Code review: no issues (stale docstring caught and fixed)
- [x] `ruff check` on all changed files — clean
- [x] Full `pytest -v` — 5590 passed (10+1 failures pre-existing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)