### PR TITLE
fix(browser): lock discipline for interaction tools

### DIFF
--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -353,6 +353,12 @@ async def _idle_watcher_loop():
     Polls every 60s. When the browser has been idle for _IDLE_TIMEOUT_S,
     calls async_cleanup() and exits. CancelledError is the normal shutdown
     path (MCP lifespan exit or explicit cleanup).
+
+    Note: does NOT acquire _browser_lock before cleanup. async_cleanup()
+    cancels and awaits _idle_task (this very coroutine), so holding the
+    lock here would self-deadlock. Cleanup is safe without the lock because
+    it sets _active_page = None atomically at entry and is individually
+    guarded throughout.
     """
     try:
         while True:
@@ -933,24 +939,26 @@ async def _impl_browser_navigate(
 async def _impl_browser_click(selector: str) -> dict:
     """Click an element on the current page."""
     _touch()
-    if _active_page is None:
-        return {"error": "No page open. Call browser_navigate first."}
-    health = _detach_dead_remote()
-    if health:
-        return health
-    drift = _check_page_drift(_active_page) if _is_remote_active() else None
-    if drift:
-        return {
-            "advisory": "Page state changed since last Genesis action.",
-            **drift,
-            "recommendation": "Call browser_snapshot() to see current page state before acting.",
-        }
+    async with _browser_lock:
+        if _active_page is None:
+            return {"error": "No page open. Call browser_navigate first."}
+        health = _detach_dead_remote()
+        if health:
+            return health
+        drift = _check_page_drift(_active_page) if _is_remote_active() else None
+        if drift:
+            return {
+                "advisory": "Page state changed since last Genesis action.",
+                **drift,
+                "recommendation": "Call browser_snapshot() to see current page state before acting.",
+            }
+        page = _active_page
     try:
         await _human_delay()
-        await _stealth_click(_active_page, selector)
+        await _stealth_click(page, selector)
         _update_remote_url()  # Click may cause navigation (form submit, link)
-        snapshot = await _snapshot_page(_active_page)
-        return {"clicked": selector, "url": _active_page.url, "snapshot": snapshot}
+        snapshot = await _snapshot_page(page)
+        return {"clicked": selector, "url": page.url, "snapshot": snapshot}
     except Exception as e:
         return {"error": f"Click failed on '{selector}': {e}"}
 
@@ -958,23 +966,25 @@ async def _impl_browser_click(selector: str) -> dict:
 async def _impl_browser_fill(selector: str, value: str) -> dict:
     """Fill a form field on the current page."""
     _touch()
-    if _active_page is None:
-        return {"error": "No page open. Call browser_navigate first."}
-    health = _detach_dead_remote()
-    if health:
-        return health
-    drift = _check_page_drift(_active_page) if _is_remote_active() else None
-    if drift:
-        return {
-            "advisory": "Page state changed since last Genesis action.",
-            **drift,
-            "recommendation": "Call browser_snapshot() to see current page state before acting.",
-        }
+    async with _browser_lock:
+        if _active_page is None:
+            return {"error": "No page open. Call browser_navigate first."}
+        health = _detach_dead_remote()
+        if health:
+            return health
+        drift = _check_page_drift(_active_page) if _is_remote_active() else None
+        if drift:
+            return {
+                "advisory": "Page state changed since last Genesis action.",
+                **drift,
+                "recommendation": "Call browser_snapshot() to see current page state before acting.",
+            }
+        page = _active_page
     try:
         await _human_delay()
-        await _human_type(_active_page, selector, value)
+        await _human_type(page, selector, value)
         _update_remote_url()  # Fill + Enter may cause navigation
-        return {"filled": selector, "url": _active_page.url}
+        return {"filled": selector, "url": page.url}
     except Exception as e:
         return {"error": f"Fill failed on '{selector}': {e}"}
 
@@ -986,25 +996,27 @@ async def _impl_browser_upload(selector: str, file_path: str) -> dict:
     the file contents over the wire to the remote browser).
     """
     _touch()
-    if _active_page is None:
-        return {"error": "No page open. Call browser_navigate first."}
-    health = _detach_dead_remote()
-    if health:
-        return health
-    drift = _check_page_drift(_active_page) if _is_remote_active() else None
-    if drift:
-        return {
-            "advisory": "Page state changed since last Genesis action.",
-            **drift,
-            "recommendation": "Call browser_snapshot() to see current page state before acting.",
-        }
+    async with _browser_lock:
+        if _active_page is None:
+            return {"error": "No page open. Call browser_navigate first."}
+        health = _detach_dead_remote()
+        if health:
+            return health
+        drift = _check_page_drift(_active_page) if _is_remote_active() else None
+        if drift:
+            return {
+                "advisory": "Page state changed since last Genesis action.",
+                **drift,
+                "recommendation": "Call browser_snapshot() to see current page state before acting.",
+            }
+        page = _active_page
     p = Path(file_path)
     if not p.is_file():
         return {"error": f"File not found or not a regular file: {file_path}"}
     try:
         await _human_delay()
-        await _active_page.set_input_files(selector, str(p), timeout=10000)
-        return {"uploaded": p.name, "selector": selector, "url": _active_page.url}
+        await page.set_input_files(selector, str(p), timeout=10000)
+        return {"uploaded": p.name, "selector": selector, "url": page.url}
     except Exception as e:
         return {"error": f"Upload failed on '{selector}': {e}"}
 
@@ -1012,19 +1024,21 @@ async def _impl_browser_upload(selector: str, file_path: str) -> dict:
 async def _impl_browser_screenshot() -> dict:
     """Take a screenshot of the current page."""
     _touch()
-    if _active_page is None:
-        return {"error": "No page open. Call browser_navigate first."}
-    health = _detach_dead_remote()
-    if health:
-        return health
+    async with _browser_lock:
+        if _active_page is None:
+            return {"error": "No page open. Call browser_navigate first."}
+        health = _detach_dead_remote()
+        if health:
+            return health
+        page = _active_page
     try:
         _SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
         screenshot_path = _SCREENSHOT_DIR / "genesis_browser_screenshot.png"
-        await _active_page.screenshot(path=str(screenshot_path))
+        await page.screenshot(path=str(screenshot_path))
         return {
             "path": str(screenshot_path),
-            "url": _active_page.url,
-            "title": await _active_page.title(),
+            "url": page.url,
+            "title": await page.title(),
         }
     except Exception as e:
         return {"error": f"Screenshot failed: {e}"}
@@ -1033,14 +1047,16 @@ async def _impl_browser_screenshot() -> dict:
 async def _impl_browser_snapshot() -> dict:
     """Return the accessibility tree snapshot of the current page."""
     _touch()
-    if _active_page is None:
-        return {"error": "No page open. Call browser_navigate first."}
-    health = _detach_dead_remote()
-    if health:
-        return health
+    async with _browser_lock:
+        if _active_page is None:
+            return {"error": "No page open. Call browser_navigate first."}
+        health = _detach_dead_remote()
+        if health:
+            return health
+        page = _active_page
     try:
-        snapshot = await _snapshot_page(_active_page)
-        return {"url": _active_page.url, "title": await _active_page.title(), "snapshot": snapshot}
+        snapshot = await _snapshot_page(page)
+        return {"url": page.url, "title": await page.title(), "snapshot": snapshot}
     except Exception as e:
         return {"error": f"Snapshot failed: {e}"}
 
@@ -1052,16 +1068,18 @@ async def _impl_browser_run_js(expression: str) -> dict:
     Equivalent to Chrome DevTools console. Expressions are logged for audit.
     """
     _touch()
-    if _active_page is None:
-        return {"error": "No page open. Call browser_navigate first."}
-    health = _detach_dead_remote()
-    if health:
-        return health
+    async with _browser_lock:
+        if _active_page is None:
+            return {"error": "No page open. Call browser_navigate first."}
+        health = _detach_dead_remote()
+        if health:
+            return health
+        page = _active_page
     try:
         logger.info("browser_run_js: %s", expression[:200])
-        result = await _active_page.evaluate(expression)
+        result = await page.evaluate(expression)
         _update_remote_url()  # JS may cause navigation
-        return {"result": result, "url": _active_page.url}
+        return {"result": result, "url": page.url}
     except Exception as e:
         return {"error": f"JS execution failed: {e}"}
 
@@ -1105,18 +1123,20 @@ async def _impl_browser_clear_domain(domain: str) -> dict:
 async def _impl_browser_press_key(key: str, count: int = 1) -> dict:
     """Press a keyboard key on the current page."""
     _touch()
-    if _active_page is None:
-        return {"error": "No page open. Call browser_navigate first."}
-    health = _detach_dead_remote()
-    if health:
-        return health
+    async with _browser_lock:
+        if _active_page is None:
+            return {"error": "No page open. Call browser_navigate first."}
+        health = _detach_dead_remote()
+        if health:
+            return health
+        page = _active_page
     count = max(1, min(count, 50))
     try:
         for i in range(count):
             if i > 0:
                 await asyncio.sleep(random.uniform(0.05, 0.15))
-            await _active_page.keyboard.press(key)
-        return {"pressed": key, "count": count, "url": _active_page.url}
+            await page.keyboard.press(key)
+        return {"pressed": key, "count": count, "url": page.url}
     except Exception as e:
         return {"error": f"Key press failed for '{key}': {e}"}
 

--- a/tests/test_sentinel/test_dispatcher.py
+++ b/tests/test_sentinel/test_dispatcher.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -587,3 +587,88 @@ class TestRingBufferDebounce:
         assert r1 is None
         assert r2 is None
         assert r3 is None
+
+
+class TestRejectionWindow:
+    """Tests for the 24-hour rejection suppression window."""
+
+    def test_rejected_pattern_blocked_during_window(self):
+        """Pattern with active rejection window returns not-ready."""
+        d = _make_dispatcher()
+        expiry = (datetime.now(UTC) + timedelta(hours=23)).isoformat()
+        d._state.rejected_patterns["memory:critical"] = expiry
+        ready, reason = d._backoff_ready("memory:critical")
+        assert ready is False
+        assert "rejected" in reason.lower()
+
+    def test_rejected_pattern_allowed_after_expiry(self):
+        """Pattern with expired rejection window is allowed and entry cleaned."""
+        d = _make_dispatcher()
+        expiry = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        d._state.rejected_patterns["memory:critical"] = expiry
+
+        with patch("genesis.sentinel.dispatcher.save_state"):
+            ready, _ = d._backoff_ready("memory:critical")
+
+        assert ready is True
+        assert "memory:critical" not in d._state.rejected_patterns
+
+    def test_rejection_independent_per_pattern(self):
+        """Rejecting one pattern doesn't block another."""
+        d = _make_dispatcher()
+        expiry = (datetime.now(UTC) + timedelta(hours=23)).isoformat()
+        d._state.rejected_patterns["memory:critical"] = expiry
+        ready, _ = d._backoff_ready("infra:disk_low")
+        assert ready is True
+
+    def test_resolve_clears_rejection(self):
+        """Successful resolve clears the rejection entry for the pattern."""
+        d = _make_dispatcher()
+        d._state.started_at = "2020-01-01T00:00:00+00:00"
+        expiry = (datetime.now(UTC) + timedelta(hours=20)).isoformat()
+        d._state.rejected_patterns["memory:critical"] = expiry
+
+        # Simulate resolve by directly calling the logic from _finalize_dispatch
+        pattern = "memory:critical"
+        if pattern in d._state.rejected_patterns:
+            del d._state.rejected_patterns[pattern]
+
+        assert "memory:critical" not in d._state.rejected_patterns
+
+    @pytest.mark.asyncio
+    async def test_handle_approval_resolution_rejected(self):
+        """handle_approval_resolution('rejected') records 24h window and transitions to HEALTHY."""
+        d = _make_dispatcher()
+        d._state.current_state = "awaiting_dispatch_approval"
+        d._state.pending_request_id = "req-123"
+        d._state.pending_policy_id = "sentinel_dispatch"
+        d._state.pending_pattern = "memory:critical"
+
+        with patch("genesis.sentinel.dispatcher.save_state"), \
+             patch("genesis.sentinel.dispatcher.append_log"):
+            result = await d.handle_approval_resolution("req-123", "rejected")
+
+        assert result is not None
+        assert result.dispatched is False
+        assert "memory:critical" in d._state.rejected_patterns
+        # Verify the expiry is ~24h from now
+        expiry = datetime.fromisoformat(d._state.rejected_patterns["memory:critical"])
+        diff = expiry - datetime.now(UTC)
+        assert timedelta(hours=23) < diff < timedelta(hours=25)
+        # State transitioned to HEALTHY
+        assert d._state.current_state == "healthy"
+
+    def test_rejection_persists_across_save_load(self, tmp_path):
+        """rejected_patterns survives state serialization round-trip."""
+        from genesis.sentinel.state import SentinelStateData, load_state, save_state
+
+        state = SentinelStateData()
+        expiry = (datetime.now(UTC) + timedelta(hours=12)).isoformat()
+        state.rejected_patterns["memory:critical"] = expiry
+
+        state_file = tmp_path / "sentinel_state.json"
+        save_state(state, path=state_file)
+        loaded = load_state(path=state_file)
+
+        assert "memory:critical" in loaded.rejected_patterns
+        assert loaded.rejected_patterns["memory:critical"] == expiry


### PR DESCRIPTION
## Summary

- 7 browser interaction tools (click, fill, upload, screenshot, snapshot, run_js, press_key) now acquire `_browser_lock` before accessing `_active_page` global state
- Prevents TOCTOU races when concurrent sessions (direct_session, background research) call browser tools simultaneously
- Pattern: lock → validate → capture page ref → release → long operation runs unlocked (lock held <1ms)

## Design decisions

- **Early release**: Lock only held for state validation + reference capture. Page operations run outside the lock to avoid contention.
- **Idle watcher NOT locked**: `async_cleanup()` cancels and awaits `_idle_task` (the watcher itself) — locking would self-deadlock. Cleanup is safe without it because it sets `_active_page = None` atomically at entry.
- **`_update_remote_url()` outside lock**: Fire-and-forget URL tracker with suppress(Exception). Worst case: one stale drift URL. Not worth lock contention.

## Verification

- Zero deadlock risk: grep confirms lock acquired in only 3 `_ensure_*` functions — no interaction tool calls any of them
- `ruff check` clean
- All 65 browser tool tests pass
- Architecture review caught idle watcher self-deadlock (fixed before push)

## Test plan

- [x] `pytest tests/test_mcp/test_browser_tools.py -v` — 65 passed
- [x] `ruff check src/genesis/mcp/health/browser.py` — clean
- [x] Static deadlock analysis (grep for all lock acquire sites)
- [x] genesis-architect review completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)