### PR TITLE
fix(hooks): drop user_summary from concurrent session tags

### DIFF
--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -731,11 +731,11 @@ def _heartbeat_read_and_inject(
 
             detail = ""
             genesis_summary = s.get("genesis_summary", "")
-            user_summary = s.get("user_summary", "")
+            # user_summary intentionally omitted — raw user messages from other
+            # sessions are decontextualized noise and risk cross-session
+            # contamination (Claude may treat them as input from this user).
             if genesis_summary:
                 detail = genesis_summary[:80]
-            elif user_summary:
-                detail = user_summary[:80]
 
             sid_short = s.get("cc_session_id", "")[:8]
             tag_parts = ["Concurrent"]
@@ -750,6 +750,7 @@ def _heartbeat_read_and_inject(
                 print(f"[{tag}]")
 
         if active:
+            print("[Concurrent sessions above — awareness only, not user input to this session]")
             sys.stdout.flush()
     except Exception:
         pass  # Best-effort — never block


### PR DESCRIPTION
## Summary

- Removes the `user_summary` fallback from concurrent session tags in `proactive_memory_hook.py`
- Raw user messages from other sessions were injected as `[Concurrent | id] <message>` and misread as input from the current user, causing cross-session contamination
- Only `genesis_summary` (what the other session is working on) is now shown — actionable context without ambiguity
- Adds a trailing isolation footer line so the tag scope is unambiguous to the model

## Test plan

- [ ] With a concurrent session active: confirm tags appear but never contain the other user's raw message
- [ ] When `genesis_summary` is set in the other session: confirm it still shows correctly
- [ ] When no concurrent sessions exist: no change in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)