### PR TITLE
feat(autonomy): activate task executor pipeline

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -93,6 +93,20 @@ providers:
     enabled: false
     rpm_limit: 20
     open_duration_s: 120
+  openrouter-deepseek-v4:
+    type: openrouter
+    model: deepseek/deepseek-v4-pro
+    profile: deepseek-v4-pro
+    free: false
+    rpm_limit: 20
+    open_duration_s: 120
+  openrouter-gpt55:
+    type: openrouter
+    model: openai/gpt-5.5
+    profile: gpt-5.5
+    free: false
+    rpm_limit: 20
+    open_duration_s: 120
   openrouter-mimo:
     type: openrouter
     model: xiaomi/mimo-v2-pro
@@ -144,15 +158,15 @@ providers:
     open_duration_s: 120
   glm5:
     type: zenmux
-    model: z-ai/glm-5-turbo
-    profile: glm-5
+    model: z-ai/glm-5.1-turbo
+    profile: glm-5.1
     base_url: https://zenmux.ai/api/v1
     free: false
     open_duration_s: 120
   minimax-m25:
     type: minimax
-    model: MiniMax-M2.5
-    profile: minimax-m2.5
+    model: MiniMax-M2.7
+    profile: minimax-m2.7
     base_url: https://api.minimaxi.com/v1
     free: false
     open_duration_s: 120
@@ -171,8 +185,8 @@ providers:
     open_duration_s: 120
   kimi-k2.5:
     type: openrouter
-    model: moonshotai/kimi-k2.5
-    profile: kimi-k2.5
+    model: moonshotai/kimi-k2.6
+    profile: kimi-k2.6
     free: false
     rpm_limit: 20
     open_duration_s: 120
@@ -294,8 +308,8 @@ call_sites:
     default_paid: true
   17_fresh_eyes_review:
     chain:
-    - openrouter-free
-    - claude-sonnet
+    - openrouter-deepseek-v4
+    - openrouter-qwen36plus
     default_paid: true
   18_meta_prompting:
     chain:
@@ -303,8 +317,9 @@ call_sites:
     default_paid: true
   20_adversarial_counterargument:
     chain:
-    - openrouter-free
-    - claude-sonnet
+    - openrouter-gpt55
+    - openrouter-deepseek-v4
+    - openrouter-qwen36plus
     default_paid: true
   21_session_observer:
     chain:

--- a/src/genesis/autonomy/dispatcher.py
+++ b/src/genesis/autonomy/dispatcher.py
@@ -137,16 +137,56 @@ class TaskDispatcher:
         return task_id
 
     async def dispatch_cycle(self) -> int:
-        """Poll for task_detected observations and dispatch new tasks.
+        """Poll for pending tasks and task_detected observations.
 
-        Secondary path: picks up tasks from conversation_intent observations
-        that haven't been dispatched yet. Resolves observations after dispatch
-        to prevent duplicates (Amendment #11).
+        Two pickup paths:
+        1. DB scan for PENDING tasks not yet dispatched (picks up tasks
+           created by MCP tool's DB-direct fallback path).
+        2. Observation scan for task_detected observations with plan_path
+           metadata (Amendment #11).
 
         Returns the count of newly dispatched tasks.
         """
         from genesis.db.crud import observations, task_states
+        from genesis.util.tasks import tracked_task
 
+        dispatched = 0
+
+        # Fetch active tasks once — reused by both paths
+        try:
+            active = await task_states.list_active(self._db)
+        except Exception:
+            logger.error("Failed to list active tasks", exc_info=True)
+            active = []
+
+        # --- Path 1: Pick up PENDING tasks from DB (MCP-submitted) ---
+        for task in active:
+            task_id = task["task_id"]
+            phase = task.get("current_phase", "")
+            if phase != TaskPhase.PENDING.value:
+                continue
+            if task_id in self._dispatched:
+                continue
+
+            plan_path = task.get("outputs") or ""
+            if not plan_path:
+                logger.warning(
+                    "Pending task %s has no plan path, skipping", task_id,
+                )
+                continue
+
+            logger.info(
+                "Picking up pending task %s from DB (source=mcp_fallback)",
+                task_id,
+            )
+            self._dispatched.add(task_id)
+            tracked_task(
+                self._executor.execute(task_id),
+                name=f"task-{task_id}",
+            )
+            dispatched += 1
+
+        # --- Path 2: Observation-based task pickup ---
         try:
             pending_obs = await observations.query(
                 self._db,
@@ -156,16 +196,9 @@ class TaskDispatcher:
             )
         except Exception:
             logger.error("Failed to query task observations", exc_info=True)
-            return 0
+            return dispatched
 
-        dispatched = 0
-        # Fetch active tasks once, not per-observation
-        try:
-            existing = await task_states.list_active(self._db)
-        except Exception:
-            logger.error("Failed to list active tasks for dedup", exc_info=True)
-            existing = []
-        active_descriptions = {t.get("description", "") for t in existing}
+        active_descriptions = {t.get("description", "") for t in active}
 
         for obs in pending_obs:
             obs_id = obs["id"]

--- a/src/genesis/autonomy/executor/review.py
+++ b/src/genesis/autonomy/executor/review.py
@@ -17,7 +17,10 @@ import json
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from genesis.cc.invoker import CCInvoker
 
 logger = logging.getLogger(__name__)
 
@@ -74,13 +77,20 @@ _JSON_BLOCK_RE = re.compile(r"```(?:json)?\s*\n?(.*?)\n?```", re.DOTALL)
 class TaskReviewer:
     """Adversarial quality gate using cross-vendor LLM review.
 
-    Plan review uses call site 27.  Post-execution verification uses
+    Plan review uses CC invoker (Opus) when available, falling back to
+    call site 27 via route_call.  Post-execution verification uses
     call sites 17 (fresh eyes) and 20 (adversarial counterargument),
     which are configured for cross-vendor routing.
     """
 
-    def __init__(self, *, router: _Router) -> None:
+    def __init__(
+        self,
+        *,
+        router: _Router,
+        invoker: CCInvoker | None = None,
+    ) -> None:
         self._router = router
+        self._invoker = invoker
 
     # --- Plan review (pre-execution) ------------------------------------
 
@@ -89,14 +99,28 @@ class TaskReviewer:
         plan_content: str,
         task_description: str,
     ) -> ReviewResult:
-        """Pre-execution plan review (call site 27).
+        """Pre-execution plan review via CC invoker (Opus) or call site 27.
 
-        On routing failure, passes the plan through rather than
-        blocking execution on infrastructure problems.
+        Prefers CC invoker for Opus-quality review. Falls back to
+        route_call if invoker unavailable or fails. On total failure,
+        passes the plan through rather than blocking execution.
         """
         prompt = self._build_plan_review_prompt(plan_content, task_description)
-        messages = [{"role": "user", "content": prompt}]
 
+        # Primary path: CC invoker with Opus
+        if self._invoker is not None:
+            try:
+                content = await self._review_plan_via_invoker(prompt)
+                if content is not None:
+                    return self._parse_plan_review(content)
+            except Exception:
+                logger.warning(
+                    "CC invoker plan review failed, falling back to route_call",
+                    exc_info=True,
+                )
+
+        # Fallback: route_call to call site 27
+        messages = [{"role": "user", "content": prompt}]
         try:
             result = await self._router.route_call(_CALL_SITE_PLAN, messages)
         except Exception:
@@ -113,6 +137,26 @@ class TaskReviewer:
             return ReviewResult(passed=True)
 
         return self._parse_plan_review(result.content)
+
+    async def _review_plan_via_invoker(self, prompt: str) -> str | None:
+        """Run plan review via CC invoker (Opus). Returns text or None."""
+        from genesis.cc.types import CCInvocation, CCModel, EffortLevel
+
+        invocation = CCInvocation(
+            prompt=prompt,
+            model=CCModel.OPUS,
+            effort=EffortLevel.HIGH,
+            timeout_s=300,
+            skip_permissions=True,
+        )
+        output = await self._invoker.run(invocation)
+        if output.is_error:
+            logger.warning(
+                "CC invoker plan review returned error: %s",
+                output.error_message or output.text[:200],
+            )
+            return None
+        return output.text
 
     # --- Deliverable verification (post-execution) ----------------------
 

--- a/src/genesis/mcp/health/task_tools.py
+++ b/src/genesis/mcp/health/task_tools.py
@@ -2,21 +2,43 @@
 
 Provides task_submit, task_list, task_detail, and task_control tools
 for the health MCP server.
+
+When running inside the main Genesis server, these tools use the wired
+dispatcher/executor/db references.  When running as a CC child process
+(MCP server), they fall back to direct DB connections for read operations
+and DB-only task creation for submit (the main server's dispatch_cycle
+picks up PENDING tasks).
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
 
+import aiosqlite
+
+from genesis.db.connection import BUSY_TIMEOUT_MS
 from genesis.mcp.health import mcp
 
 logger = logging.getLogger(__name__)
 
-# Module-level state, wired by init_task_tools()
+# Module-level state, wired by init_task_tools() when running in-server.
+# When running as MCP child process, these remain None and we use _get_db().
 _dispatcher = None
 _executor = None
 _db = None
+
+# DB path for fallback connections (matches manifest.py pattern)
+_DB_PATH = Path.home() / "genesis" / "data" / "genesis.db"
+
+# Allowed directories for plan files (must match dispatcher.py)
+_ALLOWED_PLAN_DIRS = [
+    Path.home() / ".genesis" / "plans",
+    Path.home() / ".claude" / "plans",
+]
 
 
 def init_task_tools(dispatcher, executor, *, db=None) -> None:
@@ -28,45 +50,113 @@ def init_task_tools(dispatcher, executor, *, db=None) -> None:
     logger.info("Task MCP tools wired to dispatcher + executor")
 
 
+async def _get_db() -> aiosqlite.Connection:
+    """Open a direct DB connection for MCP fallback reads/writes."""
+    db = await aiosqlite.connect(str(_DB_PATH))
+    db.row_factory = aiosqlite.Row
+    await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+    return db
+
+
 # ---------------------------------------------------------------------------
 # Implementation functions (testable without FastMCP)
 # ---------------------------------------------------------------------------
 
 
 async def _impl_task_submit(plan_path: str, description: str) -> dict:
-    """Submit a task for autonomous execution."""
-    if _dispatcher is None:
-        return {"error": "Task executor not initialized"}
+    """Submit a task for autonomous execution.
 
+    When the dispatcher is wired (in-server), uses it directly.
+    When running as MCP child process, creates the DB row directly
+    and the main server's dispatch_cycle picks it up.
+    """
     if not plan_path or not plan_path.strip():
         return {"error": "plan_path is required"}
     if not description or not description.strip():
         return {"error": "description is required"}
 
+    plan_path = plan_path.strip()
+    description = description.strip()
+
+    # In-server path: use dispatcher directly
+    if _dispatcher is not None:
+        try:
+            task_id = await _dispatcher.submit(plan_path, description)
+            return {"task_id": task_id, "status": "dispatched"}
+        except ValueError as exc:
+            return {"error": f"Invalid plan path: {exc}"}
+        except FileNotFoundError as exc:
+            return {"error": f"Plan file not found: {exc}"}
+        except Exception as exc:
+            logger.error("task_submit failed", exc_info=True)
+            return {"error": f"Failed to submit task: {type(exc).__name__}: {exc}"}
+
+    # MCP fallback: validate + create DB row, server picks up via dispatch_cycle
     try:
-        task_id = await _dispatcher.submit(plan_path.strip(), description.strip())
-        return {"task_id": task_id, "status": "dispatched"}
-    except ValueError as exc:
-        return {"error": f"Invalid plan path: {exc}"}
-    except FileNotFoundError as exc:
-        return {"error": f"Plan file not found: {exc}"}
+        resolved = Path(plan_path).resolve()
+        if not any(resolved.is_relative_to(d) for d in _ALLOWED_PLAN_DIRS):
+            return {
+                "error": f"Plan path outside allowed directories: {plan_path}. "
+                f"Allowed: {[str(d) for d in _ALLOWED_PLAN_DIRS]}",
+            }
+        if not resolved.exists():
+            return {"error": f"Plan file not found: {plan_path}"}
     except Exception as exc:
-        logger.error("task_submit failed", exc_info=True)
+        return {"error": f"Invalid plan path: {exc}"}
+
+    task_id = f"t-{uuid.uuid4().hex[:12]}"
+    now = datetime.now(UTC).isoformat()
+
+    try:
+        from genesis.db.crud import task_states
+
+        db = await _get_db()
+        try:
+            # task_states.create() auto-commits
+            await task_states.create(
+                db,
+                task_id=task_id,
+                description=description,
+                current_phase="pending",
+                decisions=None,
+                blockers=None,
+                outputs=str(resolved),
+                session_id=None,
+                created_at=now,
+            )
+        finally:
+            await db.close()
+
+        return {
+            "task_id": task_id,
+            "status": "pending",
+            "note": "Task created. The server will pick it up on next dispatch cycle (~2 min).",
+        }
+    except Exception as exc:
+        logger.error("task_submit DB fallback failed", exc_info=True)
         return {"error": f"Failed to submit task: {type(exc).__name__}: {exc}"}
 
 
 async def _impl_task_list(include_completed: bool = False) -> dict:
     """List tasks with their current status."""
-    if _dispatcher is None:
-        return {"error": "Task executor not initialized"}
-
     from genesis.db.crud import task_states
+
+    # Use wired DB if available, otherwise open direct connection
+    db = _db
+    own_db = False
+    if db is None:
+        try:
+            db = await _get_db()
+            own_db = True
+        except Exception as exc:
+            logger.error("task_list DB connection failed", exc_info=True)
+            return {"error": f"Database unavailable: {type(exc).__name__}: {exc}"}
 
     try:
         if include_completed:
-            tasks = await task_states.list_all_recent(_db, limit=50)
+            tasks = await task_states.list_all_recent(db, limit=50)
         else:
-            tasks = await task_states.list_active(_db)
+            tasks = await task_states.list_active(db)
 
         return {
             "tasks": [
@@ -83,21 +173,32 @@ async def _impl_task_list(include_completed: bool = False) -> dict:
     except Exception as exc:
         logger.error("task_list failed", exc_info=True)
         return {"error": f"Failed to list tasks: {type(exc).__name__}: {exc}"}
+    finally:
+        if own_db:
+            await db.close()
 
 
 async def _impl_task_detail(task_id: str) -> dict:
     """Get full task state including steps and blockers."""
-    if _dispatcher is None:
-        return {"error": "Task executor not initialized"}
-
     from genesis.db.crud import task_states, task_steps
 
+    # Use wired DB if available, otherwise open direct connection
+    db = _db
+    own_db = False
+    if db is None:
+        try:
+            db = await _get_db()
+            own_db = True
+        except Exception as exc:
+            logger.error("task_detail DB connection failed", exc_info=True)
+            return {"error": f"Database unavailable: {type(exc).__name__}: {exc}"}
+
     try:
-        task = await task_states.get_by_id(_db, task_id)
+        task = await task_states.get_by_id(db, task_id)
         if task is None:
             return {"error": f"Task {task_id} not found"}
 
-        steps = await task_steps.get_steps_for_task(_db, task_id)
+        steps = await task_steps.get_steps_for_task(db, task_id)
 
         # Parse JSON fields safely
         blockers = None
@@ -140,6 +241,9 @@ async def _impl_task_detail(task_id: str) -> dict:
     except Exception as exc:
         logger.error("task_detail failed for %s", task_id, exc_info=True)
         return {"error": f"Failed to get task detail: {type(exc).__name__}: {exc}"}
+    finally:
+        if own_db:
+            await db.close()
 
 
 _TASK_CONTROL_ACTIONS = {
@@ -150,9 +254,16 @@ _TASK_CONTROL_ACTIONS = {
 
 
 async def _impl_task_control(task_id: str, action: str) -> dict:
-    """Pause, resume, or cancel a task."""
+    """Pause, resume, or cancel a task.
+
+    Requires the in-server executor — these operate on in-memory state
+    and cannot be mediated through DB alone.
+    """
     if _executor is None:
-        return {"error": "Task executor not initialized"}
+        return {
+            "error": "Task control requires the main Genesis server. "
+            "Use task_list/task_detail for read-only access from any session.",
+        }
 
     action = action.lower().strip()
     if action not in _TASK_CONTROL_ACTIONS:
@@ -217,5 +328,8 @@ async def task_control(task_id: str, action: str) -> dict:
     - **resume**: Resume a paused task from where it left off.
     - **cancel**: Cancel the task. It will be marked cancelled at next checkpoint
       and any worktree will be cleaned up.
+
+    Note: requires the main Genesis server process. Read-only tools
+    (task_list, task_detail) work from any session.
     """
     return await _impl_task_control(task_id, action)

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -190,10 +190,13 @@ _CALL_SITE_META: dict[str, dict] = {
     },
     # ── PARTIALLY WIRED: code exists, conditions haven't triggered yet ─
     "27_pre_execution_assessment": {
-        "description": "Sanity-checks proposed task execution plans before committing resources. Triggers from autonomous executor.",
+        "description": "Sanity-checks proposed task execution plans before committing resources. Opus via CC invoker, route_call fallback.",
         "category": "reasoning",
         "frequency": "Per task",
-        "model_tier": "frontier",
+        "model_tier": "cc",
+        "dispatch": "cli",
+        "cc_model": "Opus",
+        "wired": True,
     },
     "33_skill_refiner": {
         "description": "Proposes improvements to Genesis's learned skills based on recent outcomes. Part of the learning pipeline.",
@@ -253,11 +256,11 @@ _CALL_SITE_META: dict[str, dict] = {
         "wired": False,
     },
     "17_fresh_eyes_review": {
-        "description": "Cross-vendor quality review of executor deliverables (Gate 2). Wired into executor pipeline. Activates when executor goes live.",
+        "description": "Cross-vendor quality review of executor deliverables (Gate 2). DeepSeek V4 Pro primary, Qwen 3.6+ fallback via OpenRouter.",
         "category": "assessment",
-        "frequency": "Per major decision",
+        "frequency": "Per task verification",
         "model_tier": "frontier",
-        "wired": False,
+        "wired": True,
     },
     "18_meta_prompting": {
         "description": "Disabled. Pre-reflection prompt engineering. Planned for V4 adaptive prompting.",
@@ -267,11 +270,11 @@ _CALL_SITE_META: dict[str, dict] = {
         "wired": False,
     },
     "20_adversarial_counterargument": {
-        "description": "Devil's advocate review of executor deliverables (Gate 3). Wired into executor pipeline. Activates when executor goes live.",
+        "description": "Devil's advocate review of executor deliverables (Gate 3). GPT 5.5 primary, DeepSeek V4 Pro + Qwen 3.6+ fallback via OpenRouter.",
         "category": "assessment",
-        "frequency": "Per major decision",
+        "frequency": "Per task verification",
         "model_tier": "frontier",
-        "wired": False,
+        "wired": True,
     },
     "22_tagging": {
         "description": "Disabled. Entity extraction and metadata tagging. Planned for V4 knowledge graph.",
@@ -301,10 +304,10 @@ _CALL_SITE_META: dict[str, dict] = {
         "model_tier": "slm",
     },
     "autonomous_executor_reasoning": {
-        "description": "Non-tooling reasoning for autonomous executor steps. Wired into executor engine. Activates when executor goes live.",
+        "description": "Non-tooling reasoning for autonomous executor steps (research/analysis/synthesis). API-first via AutonomousDispatchRouter.",
         "category": "reasoning",
         "frequency": "Per executor step",
         "model_tier": "frontier",
-        "wired": False,
+        "wired": True,
     },
 }

--- a/src/genesis/runtime/init/tasks.py
+++ b/src/genesis/runtime/init/tasks.py
@@ -36,7 +36,10 @@ async def init(rt: GenesisRuntime) -> None:
 
         # Build components
         decomposer = TaskDecomposer(router=rt._router)
-        reviewer = TaskReviewer(router=rt._router)
+        reviewer = TaskReviewer(
+            router=rt._router,
+            invoker=rt._cc_invoker,
+        )
         workaround = WorkaroundSearcherImpl(db=rt._db)
         tracer = ExecutionTracer(
             db=rt._db,

--- a/tests/test_autonomy/test_executor/test_task_tools.py
+++ b/tests/test_autonomy/test_executor/test_task_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -24,10 +25,45 @@ def _reset_task_tools():
 
 @pytest.mark.asyncio
 class TestTaskSubmit:
-    async def test_not_initialized(self) -> None:
+    async def test_mcp_fallback_invalid_path(self) -> None:
+        """Without dispatcher, MCP fallback validates plan path."""
         result = await task_tools._impl_task_submit("/path", "desc")
         assert "error" in result
-        assert "not initialized" in result["error"]
+        assert "outside allowed" in result["error"]
+
+    async def test_mcp_fallback_missing_file(self) -> None:
+        """Without dispatcher, MCP fallback checks file existence."""
+        allowed_dir = Path.home() / ".claude" / "plans"
+        result = await task_tools._impl_task_submit(
+            str(allowed_dir / "nonexistent.md"), "desc",
+        )
+        assert "error" in result
+        assert "not found" in result["error"]
+
+    async def test_mcp_fallback_creates_db_row(self, tmp_path: Path) -> None:
+        """Without dispatcher, MCP fallback creates DB row directly."""
+        plan = tmp_path / "test-plan.md"
+        plan.write_text("# Test Plan\n")
+
+        # Temporarily allow the tmp dir
+        original_dirs = task_tools._ALLOWED_PLAN_DIRS[:]
+        task_tools._ALLOWED_PLAN_DIRS.append(tmp_path)
+
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+        mock_db.commit = AsyncMock()
+
+        with (
+            patch.object(task_tools, "_get_db", new_callable=AsyncMock, return_value=mock_db),
+            patch("genesis.db.crud.task_states.create", new_callable=AsyncMock),
+        ):
+            result = await task_tools._impl_task_submit(str(plan), "Test task")
+
+        task_tools._ALLOWED_PLAN_DIRS[:] = original_dirs
+
+        assert "task_id" in result
+        assert result["status"] == "pending"
+        assert "dispatch cycle" in result.get("note", "")
 
     async def test_empty_plan_path(self) -> None:
         task_tools._dispatcher = AsyncMock()
@@ -56,9 +92,37 @@ class TestTaskSubmit:
 
 @pytest.mark.asyncio
 class TestTaskList:
-    async def test_not_initialized(self) -> None:
-        result = await task_tools._impl_task_list()
+    async def test_db_fallback_on_connection_error(self) -> None:
+        """Without wired _db, tries _get_db() fallback."""
+        with patch.object(
+            task_tools, "_get_db",
+            new_callable=AsyncMock,
+            side_effect=Exception("no DB"),
+        ):
+            result = await task_tools._impl_task_list()
         assert "error" in result
+        assert "unavailable" in result["error"].lower()
+
+    async def test_db_fallback_lists_tasks(self) -> None:
+        """Without wired _db, opens own connection and lists."""
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+
+        with (
+            patch.object(task_tools, "_get_db", new_callable=AsyncMock, return_value=mock_db),
+            patch(
+                "genesis.db.crud.task_states.list_active",
+                new_callable=AsyncMock,
+                return_value=[
+                    {"task_id": "t-001", "description": "Task 1", "current_phase": "executing", "created_at": "now"},
+                ],
+            ),
+        ):
+            result = await task_tools._impl_task_list()
+
+        assert result["count"] == 1
+        assert result["tasks"][0]["task_id"] == "t-001"
+        mock_db.close.assert_awaited_once()
 
     async def test_lists_active_tasks(self) -> None:
         task_tools._dispatcher = AsyncMock()
@@ -92,13 +156,44 @@ class TestTaskDetail:
         assert "error" in result
         assert "not found" in result["error"]
 
+    async def test_db_fallback_detail(self) -> None:
+        """Without wired _db, opens own connection for detail."""
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+
+        with (
+            patch.object(task_tools, "_get_db", new_callable=AsyncMock, return_value=mock_db),
+            patch(
+                "genesis.db.crud.task_states.get_by_id",
+                new_callable=AsyncMock,
+                return_value={
+                    "task_id": "t-002",
+                    "description": "Test",
+                    "current_phase": "pending",
+                    "created_at": "now",
+                    "updated_at": "now",
+                    "blockers": None,
+                    "outputs": None,
+                },
+            ),
+            patch(
+                "genesis.db.crud.task_steps.get_steps_for_task",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            result = await task_tools._impl_task_detail("t-002")
+
+        assert result["task_id"] == "t-002"
+        mock_db.close.assert_awaited_once()
+
 
 @pytest.mark.asyncio
 class TestTaskControl:
     async def test_not_initialized(self) -> None:
         result = await task_tools._impl_task_control("t-001", "pause")
         assert "error" in result
-        assert "not initialized" in result["error"]
+        assert "main Genesis server" in result["error"]
 
     async def test_invalid_action(self) -> None:
         task_tools._executor = AsyncMock()

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -121,11 +121,10 @@ def test_load_full_yaml(monkeypatch):
 
     path = Path(__file__).resolve().parents[2] / "config" / "model_routing.yaml"
     cfg = load_config(path)
-    # lmstudio-30b, github-o3mini, openrouter-deepseek-r1 disabled → 24 enabled providers
-    # (27 total - 3 disabled; added cerebras-qwen, github-o3mini (disabled),
-    # openrouter-gemma4, openrouter-qwen3coder, openrouter-deepseek-r1 (disabled — free
-    # endpoint removed from OpenRouter 2026-04-15), openrouter-qwen36plus)
-    assert len(cfg.providers) == 25
+    # lmstudio-30b, github-o3mini, openrouter-deepseek-r1 disabled → 27 enabled providers
+    # (30 total - 3 disabled; added openrouter-deepseek-v4, openrouter-gpt55 for
+    # executor review gates)
+    assert len(cfg.providers) == 27
     assert "lmstudio-30b" not in cfg.providers
     assert "github-o3mini" not in cfg.providers
     assert "openrouter-deepseek-r1" not in cfg.providers


### PR DESCRIPTION
## Summary

- **Routing**: Add `openrouter-deepseek-v4` and `openrouter-gpt55` providers for cross-vendor adversarial review. Rewire call sites 17 (fresh eyes → DeepSeek V4 Pro) and 20 (adversarial → GPT 5.5) with Qwen 3.6+ fallback
- **Plan review**: Route call site 27 through CC invoker (Opus) with `route_call` fallback, giving the orchestrator frontier-quality plan assessment
- **MCP task tools**: `task_submit`, `task_list`, `task_detail` now work from CC child processes via direct DB connections. `dispatch_cycle()` picks up PENDING tasks from DB so MCP-submitted tasks get executed by the main server
- **Metadata**: Call sites 17, 20, 27, and `autonomous_executor_reasoning` marked as wired

## Key design decisions

- Anthropic providers and `_CC_MANAGED_TYPES` bypass **kept intact** — removing them would cascade-break 6+ CC-dispatched call sites (5, 6, 7, 8, 14, 16)
- `task_control` (pause/resume/cancel) returns honest error about needing main server process — these operate on in-memory state that can't be DB-mediated
- Model version bumps for disabled providers (GLM 5.1, MiniMax M2.7, Kimi K2.6) are cosmetic — keys are empty, providers auto-disabled

## Test plan

- [ ] Targeted tests pass (30/30 dispatcher + task_tools, 785/785 autonomy + MCP suite)
- [ ] Config validation: new providers parse, CC-dispatched sites unbroken
- [ ] Verify MCP `task_list` works from CC session after server restart
- [ ] Submit test task via MCP `task_submit` and confirm server picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)