### PR TITLE
fix(executor): unblock approved tasks in step dispatcher

### DIFF
--- a/src/genesis/autonomy/executor/step_dispatcher.py
+++ b/src/genesis/autonomy/executor/step_dispatcher.py
@@ -177,19 +177,51 @@ class StepDispatcher:
                 )
                 pending = None
             if pending is not None:
-                blocker = (
-                    f"awaiting approval {pending.get('id')} for "
-                    f"{step_type.value} step"
-                )
+                # Check whether this pending request has already been
+                # approved but not yet consumed.  Without this, the
+                # pre-check blocks indefinitely even after the user
+                # grants approval — route() never gets the chance to
+                # consume the approved request.
+                try:
+                    approved = await (
+                        self._autonomous_dispatcher
+                        .approval_gate
+                        .find_recently_approved(
+                            subsystem="task_executor",
+                            policy_id=executor_policy_id,
+                        )
+                    )
+                except Exception:
+                    logger.warning(
+                        "find_recently_approved failed for %s; "
+                        "treating as still pending",
+                        executor_policy_id, exc_info=True,
+                    )
+                    approved = None
+
+                if approved is None:
+                    # Genuinely pending — no approval yet.
+                    blocker = (
+                        f"awaiting approval {pending.get('id')} for "
+                        f"{step_type.value} step"
+                    )
+                    logger.info(
+                        "Task %s step %d skipped — call site blocked "
+                        "on approval %s",
+                        task_id, step_idx, pending.get("id"),
+                    )
+                    return StepResult(
+                        idx=step_idx,
+                        status="blocked",
+                        result=blocker,
+                        blocker_description=blocker,
+                    )
+                # Approved but unconsumed — fall through to route()
+                # which will consume it atomically.
                 logger.info(
-                    "Task %s step %d skipped — call site blocked on approval %s",
-                    task_id, step_idx, pending.get("id"),
-                )
-                return StepResult(
-                    idx=step_idx,
-                    status="blocked",
-                    result=blocker,
-                    blocker_description=blocker,
+                    "Task %s step %d has approved request %s — "
+                    "proceeding to route()",
+                    task_id, step_idx, approved.get("id"),
                 )
 
             decision = await self._autonomous_dispatcher.route(

--- a/tests/test_autonomy/test_executor/test_step_dispatcher.py
+++ b/tests/test_autonomy/test_executor/test_step_dispatcher.py
@@ -1,0 +1,254 @@
+"""Tests for genesis.autonomy.executor.step_dispatcher.StepDispatcher.
+
+Focuses on the approval-gate pre-check logic in ``dispatch_step`` —
+specifically the interaction between ``find_site_pending`` and
+``find_recently_approved`` that prevents approved requests from being
+permanently blocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.autonomy.autonomous_dispatch import AutonomousDispatchDecision
+from genesis.autonomy.executor.step_dispatcher import StepDispatcher
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_step(idx: int = 0, step_type: str = "code") -> dict:
+    return {
+        "idx": idx,
+        "type": step_type,
+        "description": "test step",
+    }
+
+
+def _make_dispatcher(
+    *,
+    autonomous_dispatcher: AsyncMock | None = None,
+) -> StepDispatcher:
+    return StepDispatcher(
+        db=AsyncMock(),
+        invoker=AsyncMock(),
+        autonomous_dispatcher=autonomous_dispatcher,
+    )
+
+
+def _mock_autonomous_dispatcher(
+    *,
+    pending: dict | None = None,
+    approved: dict | None = None,
+    route_decision: AutonomousDispatchDecision | None = None,
+    find_pending_exc: Exception | None = None,
+    find_approved_exc: Exception | None = None,
+) -> AsyncMock:
+    """Build a mock AutonomousDispatchRouter with configurable gate behavior."""
+    gate = AsyncMock()
+    if find_pending_exc:
+        gate.find_site_pending = AsyncMock(side_effect=find_pending_exc)
+    else:
+        gate.find_site_pending = AsyncMock(return_value=pending)
+
+    if find_approved_exc:
+        gate.find_recently_approved = AsyncMock(side_effect=find_approved_exc)
+    else:
+        gate.find_recently_approved = AsyncMock(return_value=approved)
+
+    router = AsyncMock()
+    router.approval_gate = gate
+    if route_decision is not None:
+        router.route = AsyncMock(return_value=route_decision)
+    else:
+        router.route = AsyncMock(
+            return_value=AutonomousDispatchDecision(
+                mode="cli_approved",
+                reason="approved for CLI",
+            ),
+        )
+    return router
+
+
+# ---------------------------------------------------------------------------
+# Approval-gate pre-check tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestApprovalGatePreCheck:
+    """Test the pre-check logic that gates step dispatch on approval state."""
+
+    async def test_pending_no_approval_blocks(self) -> None:
+        """When there is a pending request and no approval, step is blocked."""
+        pending_row = {"id": "req-1", "status": "pending"}
+        ad = _mock_autonomous_dispatcher(pending=pending_row, approved=None)
+        sd = _make_dispatcher(autonomous_dispatcher=ad)
+
+        result = await sd.dispatch_step("t-1", _make_step(), [])
+
+        assert result.status == "blocked"
+        assert "awaiting approval req-1" in result.result
+        ad.approval_gate.find_site_pending.assert_awaited_once()
+        ad.approval_gate.find_recently_approved.assert_awaited_once()
+        # route() should NOT have been called — we blocked early.
+        ad.route.assert_not_awaited()
+
+    async def test_pending_with_approval_falls_through_to_route(self) -> None:
+        """When pending exists but approval is granted, fall through to route()."""
+        pending_row = {"id": "req-1", "status": "pending"}
+        approved_row = {"id": "req-1", "status": "approved"}
+        decision = AutonomousDispatchDecision(
+            mode="cli_approved",
+            reason="CLI fallback approved",
+        )
+        ad = _mock_autonomous_dispatcher(
+            pending=pending_row,
+            approved=approved_row,
+            route_decision=decision,
+        )
+        sd = _make_dispatcher(autonomous_dispatcher=ad)
+
+        result = await sd.dispatch_step("t-1", _make_step(), [])
+
+        # Should NOT be blocked — route() should have been called.
+        ad.route.assert_awaited_once()
+        # Result depends on route() returning cli_approved, which
+        # means the invoker runs. Since our invoker is a mock, we
+        # just verify we didn't get "blocked".
+        # (cli_approved without invoker mock output will go to the
+        #  invoker.run path, which is mocked.)
+        assert result.status != "blocked" or "awaiting approval" not in result.result
+
+    async def test_no_pending_goes_straight_to_route(self) -> None:
+        """When there is no pending approval, go straight to route()."""
+        decision = AutonomousDispatchDecision(
+            mode="cli_approved",
+            reason="approved",
+        )
+        ad = _mock_autonomous_dispatcher(pending=None, route_decision=decision)
+        sd = _make_dispatcher(autonomous_dispatcher=ad)
+
+        await sd.dispatch_step("t-1", _make_step(), [])
+
+        ad.approval_gate.find_site_pending.assert_awaited_once()
+        # find_recently_approved should NOT be called when there's no pending.
+        ad.approval_gate.find_recently_approved.assert_not_awaited()
+        ad.route.assert_awaited_once()
+
+    async def test_find_pending_exception_proceeds_to_route(self) -> None:
+        """If find_site_pending raises, proceed to route() (fail-open)."""
+        decision = AutonomousDispatchDecision(
+            mode="cli_approved",
+            reason="approved",
+        )
+        ad = _mock_autonomous_dispatcher(
+            find_pending_exc=RuntimeError("db error"),
+            route_decision=decision,
+        )
+        sd = _make_dispatcher(autonomous_dispatcher=ad)
+
+        await sd.dispatch_step("t-1", _make_step(), [])
+
+        ad.route.assert_awaited_once()
+
+    async def test_find_approved_exception_treats_as_pending(self) -> None:
+        """If find_recently_approved raises, treat as still pending (fail-safe)."""
+        pending_row = {"id": "req-2", "status": "pending"}
+        ad = _mock_autonomous_dispatcher(
+            pending=pending_row,
+            find_approved_exc=RuntimeError("db error"),
+        )
+        sd = _make_dispatcher(autonomous_dispatcher=ad)
+
+        step_result = await sd.dispatch_step("t-1", _make_step(), [])
+
+        assert step_result.status == "blocked"
+        assert "awaiting approval req-2" in step_result.result
+        ad.route.assert_not_awaited()
+
+    async def test_route_blocked_returns_blocked(self) -> None:
+        """When route() returns blocked, the step result is blocked."""
+        decision = AutonomousDispatchDecision(
+            mode="blocked",
+            reason="CLI fallback disabled",
+        )
+        ad = _mock_autonomous_dispatcher(pending=None, route_decision=decision)
+        sd = _make_dispatcher(autonomous_dispatcher=ad)
+
+        result = await sd.dispatch_step("t-1", _make_step(), [])
+
+        assert result.status == "blocked"
+        assert result.blocker_description == "CLI fallback disabled"
+
+    async def test_policy_id_uses_step_type(self) -> None:
+        """Verify policy_id is constructed from step type."""
+        pending_row = {"id": "req-3", "status": "pending"}
+        ad = _mock_autonomous_dispatcher(pending=pending_row, approved=None)
+        sd = _make_dispatcher(autonomous_dispatcher=ad)
+
+        await sd.dispatch_step("t-1", _make_step(step_type="research"), [])
+
+        # Should have queried with policy_id "executor_research"
+        ad.approval_gate.find_site_pending.assert_awaited_once_with(
+            subsystem="task_executor",
+            policy_id="executor_research",
+        )
+        ad.approval_gate.find_recently_approved.assert_awaited_once_with(
+            subsystem="task_executor",
+            policy_id="executor_research",
+        )
+
+
+# ---------------------------------------------------------------------------
+# No autonomous dispatcher (direct invoker path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestNoAutonomousDispatcher:
+    """When autonomous_dispatcher is None, steps go directly to invoker."""
+
+    async def test_direct_invoker_success(self) -> None:
+        invoker = AsyncMock()
+        invoker.run = AsyncMock(return_value=MagicMock(
+            is_error=False,
+            text='{"status": "completed", "result": "done"}',
+            cost_usd=0.01,
+            session_id="sess-1",
+            model_used="sonnet",
+        ))
+        sd = StepDispatcher(
+            db=AsyncMock(),
+            invoker=invoker,
+            autonomous_dispatcher=None,
+        )
+
+        result = await sd.dispatch_step("t-1", _make_step(), [])
+
+        assert result.status == "completed"
+        invoker.run.assert_awaited_once()
+
+    async def test_direct_invoker_error(self) -> None:
+        invoker = AsyncMock()
+        invoker.run = AsyncMock(return_value=MagicMock(
+            is_error=True,
+            error_message="session crashed",
+            text="",
+            cost_usd=0.0,
+            session_id="sess-2",
+            model_used="sonnet",
+        ))
+        sd = StepDispatcher(
+            db=AsyncMock(),
+            invoker=invoker,
+            autonomous_dispatcher=None,
+        )
+
+        result = await sd.dispatch_step("t-1", _make_step(), [])
+
+        assert result.status == "failed"
+        assert "session crashed" in result.result


### PR DESCRIPTION
## Summary
- Fix approval gate loop where `find_site_pending()` blocked indefinitely even after user approval
- Step dispatcher now checks `find_recently_approved()` before blocking, letting `route()` consume approved requests
- 9 new tests covering all approval gate pre-check paths (pending/approved/exception/fallthrough)

## Problem
When the executor reached EXECUTING phase, the pre-check in `dispatch_step()` called `find_site_pending()` and immediately returned "blocked" if a pending approval existed — without checking whether that request had already been approved. This created a loop:
1. Executor requests CC session approval
2. User approves
3. Pre-check finds the (still unconsumed) pending row → blocks again
4. `route()` never gets the chance to consume the approved request

## Fix
After `find_site_pending()` returns a pending row, now also calls `find_recently_approved()`:
- If approved request exists → fall through to `route()` which atomically consumes it
- If no approval yet → block as before (original behavior preserved)
- If `find_recently_approved()` fails → fail-safe, treat as still pending

## Test plan
- [x] `test_pending_no_approval_blocks` — original blocking behavior preserved
- [x] `test_pending_with_approval_falls_through_to_route` — approved requests proceed
- [x] `test_no_pending_goes_straight_to_route` — no pre-check when nothing pending
- [x] `test_find_pending_exception_proceeds_to_route` — fail-open on pending check error
- [x] `test_find_approved_exception_treats_as_pending` — fail-safe on approval check error
- [x] `test_route_blocked_returns_blocked` — route() blocked propagates correctly
- [x] `test_policy_id_uses_step_type` — policy ID constructed from step type
- [x] `test_direct_invoker_success/error` — no-dispatcher path unchanged
- [x] Full suite: 5633 passed, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)