### PR TITLE
fix(executor): expand tilde in plan path before reading

### DIFF
--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -123,7 +123,7 @@ class CCSessionExecutor:
             return False
 
         try:
-            plan_content = Path(plan_path).read_text(encoding="utf-8")
+            plan_content = Path(plan_path).expanduser().read_text(encoding="utf-8")
         except OSError:
             logger.error("Cannot read plan at %s", plan_path, exc_info=True)
             await self._fail_task(task_id, f"Cannot read plan: {plan_path}")


### PR DESCRIPTION
## Summary

- `Path('~/.genesis/plans/...').read_text()` raises `FileNotFoundError` because Python's `Path` doesn't automatically expand `~`
- Added `.expanduser()` before `.read_text()` in `CCSessionExecutor.execute()`
- This bug caused the mac-refactor task (`t-3575f95040bc`) to fail immediately on startup with "Cannot read plan" even though the file existed

## Test plan
- [ ] Submit a task with a `~/.genesis/plans/...` path — executor should read it correctly
- [ ] Existing plan paths (absolute) unaffected by `.expanduser()` (it's a no-op on absolute paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)