### PR TITLE
fix(executor): verify in worktree + enrich fixup context

### DIFF
--- a/src/genesis/autonomy/executor/dispatch.py
+++ b/src/genesis/autonomy/executor/dispatch.py
@@ -156,29 +156,49 @@ def dominant_step_type(steps: list[dict]) -> str:
     return max(set(types), key=types.count)
 
 
-def create_fixup_step(verify, idx: int) -> dict:
-    """Create a fixup step from review feedback."""
+def create_fixup_step(
+    verify,
+    idx: int,
+    plan_content: str = "",
+) -> dict:
+    """Create a fixup step from review feedback.
+
+    *plan_content*: the original task plan, included so the fixup CC
+    session can reference the success criteria and requirements.
+    """
+    _FEEDBACK_LIMIT = 2000
+
     feedback_parts = []
     if verify.fresh_eyes_feedback:
         feedback_parts.append(
-            f"Fresh-eyes feedback: {verify.fresh_eyes_feedback[:500]}"
+            f"Fresh-eyes feedback:\n{verify.fresh_eyes_feedback[:_FEEDBACK_LIMIT]}"
         )
     if verify.adversarial_feedback:
         feedback_parts.append(
-            f"Adversarial feedback: {verify.adversarial_feedback[:500]}"
+            f"Adversarial feedback:\n{verify.adversarial_feedback[:_FEEDBACK_LIMIT]}"
         )
     if verify.programmatic_issues:
         feedback_parts.append(
             "Programmatic issues: " + "; ".join(verify.programmatic_issues)
         )
 
+    description_parts = [
+        "Address review feedback and fix identified issues:",
+        "",
+        *feedback_parts,
+    ]
+
+    if plan_content:
+        description_parts.extend([
+            "",
+            "## Original Plan (for reference — especially success criteria)",
+            plan_content[:4000],
+        ])
+
     return {
         "idx": idx,
         "type": "code",
-        "description": (
-            "Address review feedback and fix identified issues:\n"
-            + "\n".join(feedback_parts)
-        ),
+        "description": "\n".join(description_parts),
         "required_tools": [],
         "complexity": "medium",
         "dependencies": [],

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -322,6 +322,7 @@ class CCSessionExecutor:
                     plan_content,
                     task_type=_dispatch.dominant_step_type(steps),
                     iteration=iteration,
+                    worktree_path=self._worktree_paths.get(task_id),
                 )
                 last_verify = verify
 
@@ -342,6 +343,7 @@ class CCSessionExecutor:
                     await self._transition(task_id, TaskPhase.EXECUTING)
                     fixup = _dispatch.create_fixup_step(
                         verify, len(steps) + iteration,
+                        plan_content=plan_content,
                     )
                     fixup_result = await self._step_dispatcher.execute_step(
                         task_id, fixup, step_results,

--- a/src/genesis/autonomy/executor/review.py
+++ b/src/genesis/autonomy/executor/review.py
@@ -19,6 +19,7 @@ import logging
 import re
 import shutil
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
@@ -169,6 +170,7 @@ class TaskReviewer:
         *,
         task_type: str = "code",
         iteration: int = 0,
+        worktree_path: Path | None = None,
     ) -> VerifyResult:
         """Post-execution verification with tool-capable adversarial gate.
 
@@ -179,6 +181,10 @@ class TaskReviewer:
 
         If programmatic checks fail, LLM gates are skipped.
         If both LLM routes fail, delivers with a warning (Amendment #5).
+
+        *worktree_path*: When the task executed in a git worktree, pass the
+        path so tool-capable reviewers (Codex, CC invoker) can inspect the
+        actual changed files rather than the repo root / main branch.
         """
         # Gate 1 -- programmatic checks
         issues = self._programmatic_checks(deliverable, task_type)
@@ -195,7 +201,9 @@ class TaskReviewer:
         )
 
         # Gate 3 -- adversarial verification (tool-capable chain)
-        adversarial = await self._tool_capable_review(deliverable, requirements)
+        adversarial = await self._tool_capable_review(
+            deliverable, requirements, worktree_path=worktree_path,
+        )
 
         # Amendment #5: both routing fail -> deliver with warning
         if fresh_eyes is None and adversarial is None:
@@ -226,6 +234,8 @@ class TaskReviewer:
         self,
         deliverable: str,
         requirements: str,
+        *,
+        worktree_path: Path | None = None,
     ) -> str | None:
         """Run the tool-capable adversarial verification chain.
 
@@ -236,18 +246,25 @@ class TaskReviewer:
 
         Returns verdict text or ``None`` on total chain failure.
 
+        *worktree_path*: passed to Codex (as ``cwd``) and CC invoker
+        (as ``working_dir``) so they inspect the worktree, not repo root.
+
         # GROUNDWORK(per-step-verify): This method is extracted so future
         # per-step verification can reuse the same chain.  The follow-up
         # PR will call it from the step execution loop for steps where
         # ``StepType.verify_step`` is True.
         """
         # Link 1: Codex (cross-vendor, tool-capable)
-        verdict = await self._verify_via_codex(deliverable, requirements)
+        verdict = await self._verify_via_codex(
+            deliverable, requirements, worktree_path=worktree_path,
+        )
         if verdict is not None:
             return verdict
 
         # Link 2: CC invoker (Sonnet, tool-capable fallback)
-        verdict = await self._verify_via_invoker(deliverable, requirements)
+        verdict = await self._verify_via_invoker(
+            deliverable, requirements, worktree_path=worktree_path,
+        )
         if verdict is not None:
             return verdict
 
@@ -260,17 +277,25 @@ class TaskReviewer:
         self,
         deliverable: str,
         requirements: str,
+        *,
+        worktree_path: Path | None = None,
     ) -> str | None:
         """Run adversarial verification via ``codex exec`` subprocess.
 
         Returns verdict text or ``None`` if Codex is not installed or fails.
         Uses ``asyncio.create_subprocess_exec`` since review.py is async.
+
+        *worktree_path*: when set, Codex runs with ``cwd`` pointing to the
+        worktree so it can read the actual changed files rather than main.
         """
         if shutil.which("codex") is None:
             logger.info("review: codex not on PATH -- skipping codex link")
             return None
 
         prompt = self._build_active_verify_prompt(deliverable, requirements)
+
+        # Resolve cwd: prefer worktree so Codex sees the changed files
+        cwd = str(worktree_path) if worktree_path else None
 
         try:
             # Sandbox bypass required: bubblewrap namespace creation
@@ -286,6 +311,7 @@ class TaskReviewer:
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
             )
             stdout_bytes, stderr_bytes = await proc.communicate(
                 input=prompt.encode("utf-8"),
@@ -332,10 +358,15 @@ class TaskReviewer:
         self,
         deliverable: str,
         requirements: str,
+        *,
+        worktree_path: Path | None = None,
     ) -> str | None:
         """Run adversarial verification via CC invoker (Sonnet).
 
         Returns verdict text or ``None`` if invoker is unavailable or fails.
+
+        *worktree_path*: when set, the CC session runs in the worktree
+        directory so it can inspect the actual changed files.
         """
         if self._invoker is None:
             return None
@@ -350,6 +381,7 @@ class TaskReviewer:
                 model=CCModel.SONNET,
                 effort=EffortLevel.HIGH,
                 skip_permissions=True,
+                working_dir=str(worktree_path) if worktree_path else None,
             )
             output = await self._invoker.run(invocation)
             if output.is_error:


### PR DESCRIPTION
## Summary

- **Verification worktree fix**: Adversarial reviewers (Codex, CC invoker) now execute in the task's worktree directory. Previously they inherited the server's working directory (repo root / main branch) and couldn't see the actual changed files. This caused false-negative verification failures — e.g., the mac refactor task failed review despite all files being correctly refactored.
- **Fixup context enrichment**: Fixup steps now receive the original plan content (success criteria, requirements) and review feedback limit raised from 500 → 2000 chars. The fixup CC session can now reference what it should be fixing against.

## Test plan
- [x] Lint clean (`ruff check` on all 3 files)
- [x] 461 relevant tests pass, 0 failures
- [x] Codex adversarial review: pass, zero issues
- [ ] E2E: re-run mac refactor verification — should pass now that Codex sees the worktree

## Files changed
| File | Change |
|------|--------|
| `src/genesis/autonomy/executor/review.py` | Thread `worktree_path` through verify chain; add `cwd=` to Codex, `working_dir=` to CC invoker |
| `src/genesis/autonomy/executor/engine.py` | Pass `worktree_path` and `plan_content` to verify/fixup calls |
| `src/genesis/autonomy/executor/dispatch.py` | Enrich `create_fixup_step` with plan_content, raise feedback limit |

🤖 Generated with [Claude Code](https://claude.com/claude-code)