### PR TITLE
fix(db): missing ego_proposals migrations + proactive activity context

### DIFF
--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -920,6 +920,15 @@ async def _run(prompt: str, session_id: str = "") -> None:
     except Exception:
         pass  # Intent trail must never block the hook
 
+    # ── Recent tool activity (self-awareness for post-compaction context) ─
+    try:
+        activity = _extract_genesis_summary(session_id)
+        if activity:
+            print(f"[Recent activity] {activity}")
+            sys.stdout.flush()
+    except Exception:
+        pass  # Never block
+
     # Augment keywords with file-context from PostToolUse tracking
     recent_files = _load_recent_files(session_id)
     if recent_files:

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -938,6 +938,18 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE knowledge_uploads ADD COLUMN chunks_done INTEGER DEFAULT 0",
         "knowledge_uploads.chunks_done")
 
+    # Ego proposals: rank, execution_plan, recurring columns added to
+    # schema definition but missing migrations for existing tables.
+    await _try_alter(db,
+        "ALTER TABLE ego_proposals ADD COLUMN rank INTEGER",
+        "ego_proposals.rank")
+    await _try_alter(db,
+        "ALTER TABLE ego_proposals ADD COLUMN execution_plan TEXT",
+        "ego_proposals.execution_plan")
+    await _try_alter(db,
+        "ALTER TABLE ego_proposals ADD COLUMN recurring INTEGER DEFAULT 0",
+        "ego_proposals.recurring")
+
     # Approval resume tracking — atomic consumed_at column
     await _try_alter(db,
         "ALTER TABLE approval_requests ADD COLUMN consumed_at TEXT",


### PR DESCRIPTION
## Summary
- **Critical fix:** Add missing `ALTER TABLE` migrations for `ego_proposals.rank`, `execution_plan`, and `recurring` columns. These were in the schema definition but had no migration, causing server startup to crash with `sqlite3.OperationalError: no such column: rank` when creating `idx_ego_proposals_rank`.
- **Enhancement:** Surface recent tool activity as `[Recent activity]` context in the proactive memory hook. Reuses the existing `_extract_genesis_summary()` function (previously only used for cross-session heartbeats) to give the current session awareness of its own recent tool use — especially useful after context compaction.

## Test plan
- [x] `ruff check` passes on both modified files
- [x] All 483 DB tests pass (`pytest tests/test_db/ -v`)
- [x] Manually verified migration runs idempotently (columns already exist → no-op)
- [x] Manually verified `_extract_genesis_summary()` returns correct output for active session
- [x] Server starts successfully after fix
- [ ] Verify `[Recent activity]` line appears in hook output on next prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)