### PR TITLE
fix(executor): persist worktree paths across server restarts

### DIFF
--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -194,10 +194,12 @@ class CCSessionExecutor:
                         step_results.append(sr)
                         completed_indices.add(row["step_idx"])
 
-                # Create worktree if needed
+                # Recover or create worktree for code tasks
                 has_code = any(s.get("type") == "code" for s in steps)
                 if has_code:
-                    await self._create_worktree(task_id)
+                    recovered = await self._recover_worktree(task_id, task)
+                    if not recovered:
+                        await self._create_worktree(task_id)
 
                 # Filter to only pending/failed steps
                 remaining_steps = [
@@ -589,7 +591,57 @@ class CCSessionExecutor:
             task_id, _REPO_ROOT, _WORKTREE_BASE,
         )
         self._worktree_paths[task_id] = wt_path
+        await self._set_output(task_id, "worktree_path", str(wt_path))
         return wt_path
+
+    async def _recover_worktree(
+        self, task_id: str, task: dict,
+    ) -> bool:
+        """Recover a worktree from persisted state.
+
+        Returns True if a valid worktree was found or recreated.
+        Falls back to False so the caller can create a fresh one.
+        """
+        raw_outputs = task.get("outputs") or ""
+        try:
+            parsed = json.loads(raw_outputs)
+            wt_path_str = (
+                parsed.get("worktree_path")
+                if isinstance(parsed, dict)
+                else None
+            )
+        except (json.JSONDecodeError, ValueError):
+            wt_path_str = None
+
+        if not wt_path_str:
+            return False
+
+        wt_path = Path(wt_path_str)
+        if await _worktree.verify_worktree(wt_path):
+            self._worktree_paths[task_id] = wt_path
+            logger.info(
+                "Recovered existing worktree at %s for task %s",
+                wt_path, task_id,
+            )
+            return True
+
+        # Worktree gone but branch might still exist — recreate
+        try:
+            wt_path = await _worktree.create_worktree(
+                task_id, _REPO_ROOT, _WORKTREE_BASE,
+            )
+            self._worktree_paths[task_id] = wt_path
+            await self._set_output(task_id, "worktree_path", str(wt_path))
+            logger.info(
+                "Recreated worktree at %s for task %s (branch recovered)",
+                wt_path, task_id,
+            )
+            return True
+        except RuntimeError:
+            logger.warning(
+                "Worktree recovery failed for task %s", task_id,
+            )
+            return False
 
     async def _cleanup_worktree(self, task_id: str) -> None:
         """Remove worktree if one was created for this task."""
@@ -597,6 +649,8 @@ class CCSessionExecutor:
         if wt_path is None:
             return
         await _worktree.cleanup_worktree(wt_path, _REPO_ROOT)
+        with contextlib.suppress(Exception):
+            await self._set_output(task_id, "worktree_path", "")
 
     # =================================================================
     # Notification

--- a/src/genesis/autonomy/executor/worktree_mgr.py
+++ b/src/genesis/autonomy/executor/worktree_mgr.py
@@ -83,6 +83,13 @@ async def create_worktree(
     if wt_path.exists():
         logger.info("Stale worktree dir %s exists, cleaning up", wt_path)
         await cleanup_worktree(wt_path, repo_root)
+        # If cleanup failed (logged as warning), force-remove the directory
+        # so git worktree add doesn't fail on an existing path.
+        if wt_path.exists():
+            import shutil
+
+            shutil.rmtree(wt_path, ignore_errors=True)
+            logger.warning("Force-removed stale worktree dir at %s", wt_path)
     else:
         # No dir but branch might linger from a prior crash
         await _prune_worktrees(repo_root)

--- a/src/genesis/autonomy/executor/worktree_mgr.py
+++ b/src/genesis/autonomy/executor/worktree_mgr.py
@@ -71,6 +71,8 @@ async def create_worktree(
 
     Cleans up stale state from previous runs before creating.
     Returns the worktree path on success.
+    Handles the case where the task branch already exists (e.g., resume
+    after restart) by checking it out instead of creating a new branch.
     Raises RuntimeError if worktree creation fails.
     """
     short_id = task_id[:8]
@@ -92,14 +94,46 @@ async def create_worktree(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    stdout, stderr = await proc.communicate()
+    _, stderr = await proc.communicate()
     if proc.returncode != 0:
         err = stderr.decode(errors="replace")
-        logger.error("Failed to create worktree: %s", err)
-        raise RuntimeError(f"Worktree creation failed: {err}")
+        if "already exists" in err:
+            # Branch exists from previous run — check it out
+            proc = await asyncio.create_subprocess_exec(
+                "git", "worktree", "add", str(wt_path), branch,
+                cwd=str(repo_root),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await proc.communicate()
+            if proc.returncode != 0:
+                err2 = stderr.decode(errors="replace")
+                logger.error("Failed to create worktree: %s", err2)
+                raise RuntimeError(f"Worktree creation failed: {err2}")
+            logger.info(
+                "Created worktree at %s (existing branch %s)", wt_path, branch,
+            )
+        else:
+            logger.error("Failed to create worktree: %s", err)
+            raise RuntimeError(f"Worktree creation failed: {err}")
+    else:
+        logger.info("Created worktree at %s (branch %s)", wt_path, branch)
 
-    logger.info("Created worktree at %s (branch %s)", wt_path, branch)
     return wt_path
+
+
+async def verify_worktree(wt_path: Path) -> bool:
+    """Check if a path is a valid git worktree."""
+    if not wt_path.exists():
+        return False
+    proc = await asyncio.create_subprocess_exec(
+        "git", "rev-parse", "--git-dir",
+        cwd=str(wt_path),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await proc.communicate()
+    return proc.returncode == 0
 
 
 async def cleanup_worktree(


### PR DESCRIPTION
## Summary
- Worktree paths were stored in-memory only (`_worktree_paths` dict), lost on server restart
- On task resume, the engine created a fresh worktree from HEAD instead of reconnecting to the task's branch
- This caused adversarial verification to check main branch code instead of the task's actual changes (root cause of mac refactor task's false-negative review failure)

**Fix:**
- Persist `worktree_path` in `task_states.outputs` JSON via existing `_set_output()` pattern
- On resume, `_recover_worktree()` checks if the persisted worktree still exists on disk — reuses it if valid, recreates on same branch if not
- `create_worktree()` now handles existing branches gracefully (falls back from `git worktree add -b` to `git worktree add` when branch already exists)
- Clear persisted path on worktree cleanup

No schema changes — uses existing outputs JSON column.

## Test plan
- [x] `ruff check` passes on both modified files
- [x] All 156 executor tests pass
- [x] Verified git "already exists" error message format matches string check
- [ ] Smoke test: submit task → verify worktree_path in DB → restart → resume → verify recovery log message

🤖 Generated with [Claude Code](https://claude.com/claude-code)