### PR TITLE
fix(executor): expand tilde in task plan paths

### DIFF
--- a/src/genesis/autonomy/dispatcher.py
+++ b/src/genesis/autonomy/dispatcher.py
@@ -42,7 +42,7 @@ def _validate_plan_path(path_str: str) -> Path:
     Raises ValueError for paths outside allowed directories.
     Raises FileNotFoundError if the plan file does not exist.
     """
-    resolved = Path(path_str).resolve()
+    resolved = Path(path_str).expanduser().resolve()
     if not any(resolved.is_relative_to(d) for d in _ALLOWED_PLAN_DIRS):
         raise ValueError(
             f"Plan path outside allowed directories: {path_str}. "

--- a/src/genesis/mcp/health/task_tools.py
+++ b/src/genesis/mcp/health/task_tools.py
@@ -93,7 +93,7 @@ async def _impl_task_submit(plan_path: str, description: str) -> dict:
 
     # MCP fallback: validate + create DB row, server picks up via dispatch_cycle
     try:
-        resolved = Path(plan_path).resolve()
+        resolved = Path(plan_path).expanduser().resolve()
         if not any(resolved.is_relative_to(d) for d in _ALLOWED_PLAN_DIRS):
             return {
                 "error": f"Plan path outside allowed directories: {plan_path}. "


### PR DESCRIPTION
## Summary
- `Path("~/.genesis/plans/...").resolve()` treats `~` as a literal directory name, causing all MCP-submitted tasks to fail path validation
- Added `.expanduser()` before `.resolve()` in both the MCP fallback path (`task_tools.py`) and the in-server dispatcher (`dispatcher.py`)
- The MCP tool description explicitly tells callers to use `~/...` paths, so every task submission was guaranteed to fail

## Test plan
- [x] Reproduced bug locally — confirmed "Plan path outside allowed directories" error
- [x] Verified fix produces correct path (`/home/ubuntu/.genesis/plans/...`)
- [x] Successfully submitted 3 tasks via fixed code path
- [x] `ruff check` passes
- [x] `pytest -k task` — 131 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)