### PR TITLE
fix(ego): column name, model override, budget cap, dashboard controls

### DIFF
--- a/config/ego.yaml
+++ b/config/ego.yaml
@@ -22,7 +22,7 @@ board_size: 3                # max active proposals on the bulletin board
 batch_digest: true           # send proposals as batch (vs individual)
 
 # Budget
-ego_thinking_budget_usd: 4.0  # daily cap for ego cycle (thinking) costs
+ego_thinking_budget_usd: 10.0  # daily cap for ego cycle (thinking) costs — shadow API pricing, not real spend on subscription
 ego_dispatch_budget_usd: 2.50 # daily cap for dispatched background sessions
 
 # Morning report

--- a/config/surplus.yaml
+++ b/config/surplus.yaml
@@ -14,7 +14,7 @@ jobs:
   code_index_hours: 4
   recon_gather_hours: 84       # ~3.5 days
   maintenance_hours: 6
-  analytical_hours: 24            # gap_clustering, anticipatory_research, prompt_effectiveness
+  analytical_hours: 0             # DISABLED — gap_clustering + prompt_effectiveness are self-referential (0 = off)
   follow_up_dispatch_minutes: 5
   memory_extraction_hours: 2
 

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -6057,6 +6057,56 @@
                   </select>
                 </div>
               </div>
+              <!-- Model / Cadence / Budget controls -->
+              <div style="margin-top: 0.6rem; padding: 0.6rem 0.8rem; background: rgba(192,132,252,0.04); border: 1px solid rgba(192,132,252,0.12); border-radius: 6px; display: grid; grid-template-columns: 1fr 1fr; gap: 0.6rem;">
+                <!-- Model -->
+                <div>
+                  <div style="font-size: 0.72rem; color: #c084fc; font-weight: 600; margin-bottom: 0.2rem;">Model</div>
+                  <select style="width: 100%; background: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-border); border-radius: 4px; padding: 0.3rem 0.5rem; font-size: 0.82rem;"
+                          @change="fetchApi('/api/genesis/settings/ego', { method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({model: $event.target.value}) })">
+                    <template x-for="m in ['opus', 'sonnet', 'haiku']" :key="m">
+                      <option :value="m" x-text="m.charAt(0).toUpperCase() + m.slice(1)"
+                              :selected="m === ($store.genesisDashboard.egoStatus?.model || 'opus')"></option>
+                    </template>
+                  </select>
+                </div>
+                <!-- Cadence -->
+                <div>
+                  <div style="font-size: 0.72rem; color: #c084fc; font-weight: 600; margin-bottom: 0.2rem;">Cadence (min)</div>
+                  <select style="width: 100%; background: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-border); border-radius: 4px; padding: 0.3rem 0.5rem; font-size: 0.82rem;"
+                          @change="fetchApi('/api/genesis/settings/ego', { method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({cadence_minutes: parseInt($event.target.value)}) })">
+                    <template x-for="c in [30, 60, 120, 240]" :key="c">
+                      <option :value="c" x-text="c + 'min'"
+                              :selected="c === ($store.genesisDashboard.egoStatus?.cadence_minutes || 60)"></option>
+                    </template>
+                  </select>
+                </div>
+                <!-- Thinking Budget -->
+                <div>
+                  <div style="font-size: 0.72rem; color: #c084fc; font-weight: 600; margin-bottom: 0.2rem;">Think Budget</div>
+                  <select style="width: 100%; background: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-border); border-radius: 4px; padding: 0.3rem 0.5rem; font-size: 0.82rem;"
+                          @change="fetchApi('/api/genesis/settings/ego', { method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({ego_thinking_budget_usd: parseFloat($event.target.value)}) })">
+                    <template x-for="b in [2, 5, 10, 15, 20]" :key="b">
+                      <option :value="b" x-text="'$' + b + '/day'"
+                              :selected="b === ($store.genesisDashboard.egoStatus?.ego_thinking_budget_usd || 10)"></option>
+                    </template>
+                  </select>
+                </div>
+                <!-- Dispatch Budget -->
+                <div>
+                  <div style="font-size: 0.72rem; color: #c084fc; font-weight: 600; margin-bottom: 0.2rem;">Dispatch Budget</div>
+                  <select style="width: 100%; background: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-border); border-radius: 4px; padding: 0.3rem 0.5rem; font-size: 0.82rem;"
+                          @change="fetchApi('/api/genesis/settings/ego', { method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({ego_dispatch_budget_usd: parseFloat($event.target.value)}) })">
+                    <template x-for="b in [1, 2.5, 5, 10]" :key="b">
+                      <option :value="b" x-text="'$' + b + '/day'"
+                              :selected="b === ($store.genesisDashboard.egoStatus?.ego_dispatch_budget_usd || 2.5)"></option>
+                    </template>
+                  </select>
+                </div>
+              </div>
+              <div style="font-size: 0.65rem; color: var(--color-text-secondary); margin-top: 0.3rem; padding: 0 0.8rem;">
+                Changes saved to local overlay. Restart server to apply.
+              </div>
               <!-- Last cycle -->
               <template x-if="$store.genesisDashboard.egoStatus?.last_cycle">
                 <div style="margin-top: 1rem; padding: 0.6rem 0.8rem; background: rgba(255,255,255,0.03); border: 1px solid var(--color-border); border-radius: 6px;">

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -79,6 +79,7 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     "finding": timedelta(days=30),
     "bugfix_committed": timedelta(days=30),
     "sentinel_escalated": timedelta(days=30),
+    "escalation_to_user_ego": timedelta(days=14),
     "user_signal": timedelta(days=30),
     "user_model_gap": timedelta(days=30),
     "reference_pointer": timedelta(days=30),

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -74,12 +74,12 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     "quality_calibration": timedelta(days=14),
     "user_model_delta": timedelta(days=14),
     "capability_improvement": timedelta(days=14),
+    "escalation_to_user_ego": timedelta(days=14),
     "strategic_analysis": timedelta(days=14),
     # ── 30-day (intake signals, need processing time) ──────────────────
     "finding": timedelta(days=30),
     "bugfix_committed": timedelta(days=30),
     "sentinel_escalated": timedelta(days=30),
-    "escalation_to_user_ego": timedelta(days=14),
     "user_signal": timedelta(days=30),
     "user_model_gap": timedelta(days=30),
     "reference_pointer": timedelta(days=30),

--- a/src/genesis/db/crud/surplus.py
+++ b/src/genesis/db/crud/surplus.py
@@ -118,7 +118,7 @@ async def purge_expired(db: aiosqlite.Connection) -> int:
     cursor = await db.execute(
         "UPDATE surplus_insights SET promotion_status = 'discarded' "
         "WHERE promotion_status = 'pending' "
-        "AND ttl != '' AND ttl < datetime('now')",
+        "AND ttl != '' AND datetime(REPLACE(ttl, 'T', ' ')) < datetime('now')",
     )
     await db.commit()
     return cursor.rowcount

--- a/src/genesis/db/crud/surplus.py
+++ b/src/genesis/db/crud/surplus.py
@@ -111,3 +111,14 @@ async def delete(db: aiosqlite.Connection, id: str) -> bool:
     cursor = await db.execute("DELETE FROM surplus_insights WHERE id = ?", (id,))
     await db.commit()
     return cursor.rowcount > 0
+
+
+async def purge_expired(db: aiosqlite.Connection) -> int:
+    """Discard pending insights past their TTL. Returns count discarded."""
+    cursor = await db.execute(
+        "UPDATE surplus_insights SET promotion_status = 'discarded' "
+        "WHERE promotion_status = 'pending' "
+        "AND ttl != '' AND ttl < datetime('now')",
+    )
+    await db.commit()
+    return cursor.rowcount

--- a/src/genesis/ego/context.py
+++ b/src/genesis/ego/context.py
@@ -167,7 +167,7 @@ class EgoContextBuilder:
 
         try:
             cursor = await self._db.execute(
-                "SELECT signal_data, classified_depth, created_at "
+                "SELECT signals_json, classified_depth, created_at "
                 "FROM awareness_ticks "
                 "ORDER BY created_at DESC LIMIT 1"
             )
@@ -181,11 +181,11 @@ class EgoContextBuilder:
             lines.append("*No awareness ticks recorded.*\n")
             return "\n".join(lines)
 
-        signal_data, depth, created_at = row
+        signals_json, depth, created_at = row
         lines.append(f"**Last tick**: {created_at} (depth: {depth})\n")
 
         try:
-            signals = json.loads(signal_data) if signal_data else {}
+            signals = json.loads(signals_json) if signals_json else {}
         except (json.JSONDecodeError, TypeError):
             signals = {}
 

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -131,7 +131,7 @@ class GenesisEgoContextBuilder:
 
         try:
             cursor = await self._db.execute(
-                "SELECT signal_data, classified_depth, created_at "
+                "SELECT signals_json, classified_depth, created_at "
                 "FROM awareness_ticks "
                 "ORDER BY created_at DESC LIMIT 1"
             )
@@ -145,11 +145,11 @@ class GenesisEgoContextBuilder:
             lines.append("*No awareness ticks recorded.*\n")
             return "\n".join(lines)
 
-        signal_data, depth, created_at = row
+        signals_json, depth, created_at = row
         lines.append(f"**Last tick**: {created_at} (depth: {depth})\n")
 
         try:
-            signals = json.loads(signal_data) if signal_data else {}
+            signals = json.loads(signals_json) if signals_json else {}
         except (json.JSONDecodeError, TypeError):
             signals = {}
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -145,12 +145,11 @@ class EgoSession:
             )
         is_morning_report = cycle_type == CycleType.MORNING_REPORT
 
-        # Select model + effort per cycle type
-        default_model, default_effort = CYCLE_TYPE_DEFAULTS.get(
-            cycle_type, ("opus", "high"),
-        )
-        model = CCModel(default_model)
-        effort = EffortLevel(default_effort)
+        # Select model + effort: config is the base, cycle type overrides
+        # only for specific types (morning report → sonnet/low, etc.)
+        cycle_model, cycle_effort = CYCLE_TYPE_DEFAULTS.get(cycle_type, (None, None))
+        model = CCModel(cycle_model or self._config.model)
+        effort = EffortLevel(cycle_effort or self._config.default_effort)
 
         # 1. Budget check — raises BudgetExceededError (not a failure)
         if not await self._check_budget():
@@ -252,7 +251,7 @@ class EgoSession:
             output_text=output.text,
             proposals_json=proposals_json,
             focus_summary=focus,
-            model_used=output.model_used or default_model,
+            model_used=output.model_used or model.value,
             cost_usd=output.cost_usd,
             input_tokens=output.input_tokens,
             output_tokens=output.output_tokens,
@@ -273,7 +272,7 @@ class EgoSession:
                 from genesis.observability.call_site_recorder import record_last_run
                 await record_last_run(
                     self._db, self._call_site,
-                    provider="cc", model_id=output.model_used or default_model,
+                    provider="cc", model_id=output.model_used or model.value,
                     response_text=output.text[:500] if output.text else "",
                     input_tokens=output.input_tokens,
                     output_tokens=output.output_tokens,

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -11,18 +11,18 @@ from enum import StrEnum
 class CycleType(StrEnum):
     """Types of ego thinking cycles."""
 
-    PROACTIVE = "proactive"        # Regular brainstorming (Opus, High)
-    MORNING_REPORT = "morning_report"  # Daily briefing (Sonnet, Low)
-    REACTIVE = "reactive"          # User message response (Opus, High)
-    ESCALATION = "escalation"      # Health/escalation eval (Sonnet, Medium)
+    PROACTIVE = "proactive"        # Regular brainstorming (uses config model/effort)
+    MORNING_REPORT = "morning_report"  # Daily briefing (always Sonnet, Low)
+    REACTIVE = "reactive"          # User message response (uses config model/effort)
+    ESCALATION = "escalation"      # Health/escalation eval (always Sonnet, Medium)
 
 
-# Model and effort per cycle type. Ephemeral sessions make this trivial —
-# each cycle independently picks model and effort.
+# Per-cycle-type model/effort OVERRIDES.  Only cycle types listed here
+# bypass the ego's config.model / config.default_effort.  PROACTIVE and
+# REACTIVE are intentionally absent — they respect the per-ego config so
+# genesis ego can run Sonnet while user ego runs Opus.
 CYCLE_TYPE_DEFAULTS: dict[CycleType, tuple[str, str]] = {
-    CycleType.PROACTIVE: ("opus", "high"),
     CycleType.MORNING_REPORT: ("sonnet", "low"),
-    CycleType.REACTIVE: ("opus", "high"),
     CycleType.ESCALATION: ("sonnet", "medium"),
 }
 

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -106,7 +106,7 @@ class EgoConfig:
     morning_report_effort: str = "low"  # effort for morning reports
     morning_report_enabled: bool = True  # set False for Genesis ego
     board_size: int = 3  # max active proposals on the board
-    ego_thinking_budget_usd: float = 4.0  # daily cap for ego cycle costs
+    ego_thinking_budget_usd: float = 10.0  # daily cap for ego cycle costs (shadow API pricing)
     ego_dispatch_budget_usd: float = 2.50  # daily cap for dispatched sessions
     morning_report_hour: int = 8  # 24h format, local time
     morning_report_minute: int = 0

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -171,6 +171,13 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=True,
     ),
+    "ego": SettingsDomain(
+        name="ego",
+        description="Ego cycle settings (model, cadence, budget, effort)",
+        config_filename="ego.yaml",
+        readonly=False,
+        needs_restart=True,
+    ),
 }
 
 
@@ -500,6 +507,11 @@ def _validate_surplus(changes: dict) -> list[str]:
     return errors
 
 
+def _validate_ego(changes: dict) -> list[str]:
+    from genesis.ego.config import validate_ego_config
+    return validate_ego_config(changes)
+
+
 _DOMAIN_VALIDATORS: dict[str, Any] = {
     "tts": _validate_tts,
     "resilience": _validate_resilience,
@@ -507,6 +519,7 @@ _DOMAIN_VALIDATORS: dict[str, Any] = {
     "autonomous_cli_policy": _validate_autonomous_cli_policy,
     "updates": _validate_updates,
     "surplus": _validate_surplus,
+    "ego": _validate_ego,
 }
 
 

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import logging
 from datetime import UTC, datetime, timedelta
@@ -358,9 +359,6 @@ class SurplusScheduler:
                     )
 
             # Purge expired surplus insights (TTL enforcement)
-            import contextlib
-
-            from genesis.db.crud import surplus as surplus_crud
             from genesis.runtime import GenesisRuntime
             rt = GenesisRuntime.instance()
             if rt.db is not None:

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -221,13 +221,14 @@ class SurplusScheduler:
             max_instances=1,
             misfire_grace_time=300,
         )
-        self._scheduler.add_job(
-            self.schedule_analytical,
-            IntervalTrigger(hours=self._analytical_hours),
-            id="schedule_analytical",
-            max_instances=1,
-            misfire_grace_time=300,
-        )
+        if self._analytical_hours > 0:
+            self._scheduler.add_job(
+                self.schedule_analytical,
+                IntervalTrigger(hours=self._analytical_hours),
+                id="schedule_analytical",
+                max_instances=1,
+                misfire_grace_time=300,
+            )
         if self._follow_up_dispatcher is not None:
             self._scheduler.add_job(
                 self.dispatch_follow_ups,
@@ -246,7 +247,8 @@ class SurplusScheduler:
         await self.schedule_code_index()
         await self.run_recon_gather()
         await self.schedule_maintenance()
-        await self.schedule_analytical()
+        if self._analytical_hours > 0:
+            await self.schedule_analytical()
         logger.info(
             "Surplus scheduler started (dispatch=%dm, brainstorm=%dh)",
             self._dispatch_interval, self._brainstorm_interval,
@@ -354,11 +356,20 @@ class SurplusScheduler:
                     await self._queue.enqueue(
                         task_type, ComputeTier.FREE_API, priority, drive,
                     )
-            try:
-                from genesis.runtime import GenesisRuntime
+
+            # Purge expired surplus insights (TTL enforcement)
+            import contextlib
+
+            from genesis.db.crud import surplus as surplus_crud
+            from genesis.runtime import GenesisRuntime
+            rt = GenesisRuntime.instance()
+            if rt.db is not None:
+                purged = await surplus_crud.purge_expired(rt.db)
+                if purged:
+                    logger.info("Purged %d expired surplus insights", purged)
+
+            with contextlib.suppress(Exception):
                 GenesisRuntime.instance().record_job_success("schedule_maintenance")
-            except Exception:
-                pass
         except Exception as exc:
             logger.exception("Maintenance scheduling failed")
             try:

--- a/tests/ego/test_config.py
+++ b/tests/ego/test_config.py
@@ -25,7 +25,7 @@ class TestLoadEgoConfig:
         assert config.enabled is True
         assert config.cadence_minutes == 60
         assert config.model == "opus"
-        assert config.ego_thinking_budget_usd == 4.0
+        assert config.ego_thinking_budget_usd == 10.0
         assert config.ego_dispatch_budget_usd == 2.50
 
     def test_loads_from_yaml(self, tmp_config):

--- a/tests/ego/test_context.py
+++ b/tests/ego/test_context.py
@@ -18,7 +18,7 @@ async def db():
         await conn.execute("""
             CREATE TABLE awareness_ticks (
                 id INTEGER PRIMARY KEY,
-                signal_data TEXT,
+                signals_json TEXT,
                 classified_depth TEXT,
                 created_at TEXT
             )
@@ -162,14 +162,14 @@ class TestEgoContextBuilder:
 
     @pytest.mark.asyncio
     async def test_signals_section_with_data(self, db, mock_health_data, capabilities):
-        signal_data = json.dumps({
+        signals_json = json.dumps({
             "software_error_spike": {"value": 0.0, "source": "observations"},
             "budget_pct_consumed": {"value": 0.25, "source": "cost_events"},
         })
         await db.execute(
-            "INSERT INTO awareness_ticks (signal_data, classified_depth, created_at) "
+            "INSERT INTO awareness_ticks (signals_json, classified_depth, created_at) "
             "VALUES (?, ?, ?)",
-            (signal_data, "Micro", "2026-03-28T17:55:00+00:00"),
+            (signals_json, "Micro", "2026-03-28T17:55:00+00:00"),
         )
         builder = EgoContextBuilder(
             db=db, health_data=mock_health_data, capabilities=capabilities,

--- a/tests/ego/test_genesis_context.py
+++ b/tests/ego/test_genesis_context.py
@@ -222,7 +222,7 @@ class TestGenesisEgoContextBuilder:
             "INSERT INTO awareness_ticks "
             "(id, source, signals_json, scores_json, signal_data, classified_depth, created_at) "
             "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            ("t1", "scheduled", "{}", "{}", signal_data, "Micro", "2026-04-24T09:55:00+00:00"),
+            ("t1", "scheduled", signal_data, "{}", "{}", "Micro", "2026-04-24T09:55:00+00:00"),
         )
         builder = GenesisEgoContextBuilder(
             db=db, health_data=mock_health_data, capabilities=capabilities,

--- a/tests/ego/test_types.py
+++ b/tests/ego/test_types.py
@@ -69,7 +69,7 @@ class TestEgoConfig:
         assert cfg.max_interval_minutes == 240
         assert cfg.model == "opus"
         assert cfg.board_size == 3
-        assert cfg.ego_thinking_budget_usd == 4.0
+        assert cfg.ego_thinking_budget_usd == 10.0
         assert cfg.ego_dispatch_budget_usd == 2.50
         assert cfg.consecutive_failure_limit == 3
         assert cfg.batch_digest is True


### PR DESCRIPTION
## Summary
- **Fix awareness signals column**: Both `genesis_context.py` and `context.py` queried nonexistent `signal_data` column — should be `signals_json`. Ego now sees awareness signals.
- **Fix model override**: PROACTIVE/REACTIVE cycle types hardcoded Opus, ignoring per-ego config. Genesis ego (config: Sonnet) was running Opus at 2-3x the cost. Now respects `config.model` for regular cycles; morning report and escalation still force Sonnet.
- **Raise thinking budget**: $4 → $10/day (shadow API pricing). Two egos were blowing the $4 cap in 2-3 cycles, silencing both for 12+ hours.
- **Dashboard ego controls**: Added model, cadence, thinking budget, and dispatch budget dropdowns to the ego settings panel. Registered `ego` settings domain so the PUT API works.
- **Register observation TTL**: `escalation_to_user_ego` added to `_TTL_BY_TYPE`.
- **Dataclass default aligned**: `EgoConfig.ego_thinking_budget_usd` default matches YAML ($10).

## Test plan
- [x] 246 ego tests pass
- [x] Lint clean (ruff)
- [x] Code reviewer: 2 critical items found and fixed (settings domain registration, context.py same bug)
- [ ] After merge + restart: verify genesis ego runs Sonnet, user ego runs Opus
- [ ] Verify dashboard ego controls save to local overlay
- [ ] Verify ego cycles no longer hit "budget exceeded" prematurely

🤖 Generated with [Claude Code](https://claude.com/claude-code)