### PR TITLE
feat(autonomy): sequential task execution + skip per-step approval

### DIFF
--- a/.claude/commands/task.md
+++ b/.claude/commands/task.md
@@ -1,0 +1,54 @@
+---
+name: task
+description: >
+  Guided task intake — interviews the user, writes a plan following
+  TASK_INTAKE.md format, validates structure, then submits to the
+  autonomous task executor.
+---
+
+# Task Submission — Guided Intake
+
+You are conducting a task intake interview following the TASK_INTAKE.md
+format (`src/genesis/identity/TASK_INTAKE.md`).
+
+## Process
+
+1. Read the user's request: $ARGUMENTS
+2. **Triage first**: Is this multi-step, time-consuming, background-appropriate?
+   If not, handle inline — say so and do it directly.
+3. Gather requirements (one question at a time, don't over-interview):
+   - Desired outcome and success criteria (specific + testable)
+   - LLM provider preference (OpenAI/Anthropic/other) with SDK + env var + model
+   - Risks and failure modes (specific, not vague)
+   - Deliverable format and where output goes
+   - Any URLs, file paths, API details, or credentials the executor needs
+4. Enter plan mode and write the plan to `~/.genesis/plans/`
+5. Plan structure — `task_submit` **enforces** these four sections (rejects if missing):
+   - `## Requirements`
+   - `## Steps` (from executor CC session's perspective)
+   - `## Success Criteria` (testable by the executor)
+   - `## Risks and Failure Modes` (specific)
+
+   Also include these sections (best practice, caught by the LLM plan reviewer):
+   - `## Context`
+   - `## Deliverable Format`
+   - `## Quality Checks` (achievable in the executor's environment)
+   - `## Constraints`
+6. After user approves the plan, submit via `task_submit` MCP tool
+
+## Critical Rules
+
+- **Steps are for the EXECUTOR** — what the background CC session will DO,
+  not what the user does. Write from the executor's perspective.
+- **Success criteria must be executor-testable** — if the executor can't verify
+  it (e.g., browser testing without a display server), explicitly note it as
+  "deferred to user" and provide criteria the executor CAN check.
+- **Concrete references only** — include actual URLs, file paths, API details.
+  Never say "study the repo" — say "read https://github.com/org/repo/tree/main/path".
+- **Quality Checks must not contradict environment constraints** — don't require
+  "run the app and test manually" when the executor runs headless in a container.
+- **Specify LLM provider explicitly** — SDK name, env var name, model name.
+  Don't say "use an LLM" — say "use the `openai` SDK, `OPENAI_API_KEY`, model `gpt-4o-mini`".
+- **Validation is enforced** — `task_submit` will reject plans missing
+  `## Requirements`, `## Steps`, `## Success Criteria`, or
+  `## Risks and Failure Modes`. Get it right before submitting.

--- a/src/genesis/autonomy/dispatcher.py
+++ b/src/genesis/autonomy/dispatcher.py
@@ -28,6 +28,14 @@ _ALLOWED_PLAN_DIRS = [
     Path.home() / ".claude" / "plans",
 ]
 
+# Required sections in plan files (must match TASK_INTAKE.md plan format)
+REQUIRED_PLAN_SECTIONS = [
+    "## Requirements",
+    "## Steps",
+    "## Success Criteria",
+    "## Risks and Failure Modes",
+]
+
 # Terminal phases that should not be re-dispatched
 _TERMINAL_PHASES = frozenset({
     TaskPhase.COMPLETED.value,
@@ -51,6 +59,20 @@ def _validate_plan_path(path_str: str) -> Path:
     if not resolved.exists():
         raise FileNotFoundError(f"Plan file not found: {path_str}")
     return resolved
+
+
+def _validate_plan_content(path: Path) -> None:
+    """Check plan file contains required TASK_INTAKE.md sections.
+
+    Raises ValueError listing any missing sections.
+    """
+    lines = set(path.read_text().splitlines())
+    missing = [s for s in REQUIRED_PLAN_SECTIONS if s not in lines]
+    if missing:
+        raise ValueError(
+            f"Plan file missing required sections: {', '.join(missing)}. "
+            "See TASK_INTAKE.md format. Use /task for guided intake."
+        )
 
 
 class TaskDispatcher:
@@ -88,6 +110,7 @@ class TaskDispatcher:
 
         # Amendment #9: path validation
         resolved_path = _validate_plan_path(plan_path)
+        _validate_plan_content(resolved_path)
 
         task_id = f"t-{uuid.uuid4().hex[:12]}"
         now = datetime.now(UTC).isoformat()

--- a/src/genesis/autonomy/dispatcher.py
+++ b/src/genesis/autonomy/dispatcher.py
@@ -12,6 +12,7 @@ Implements:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from datetime import UTC, datetime
@@ -84,11 +85,20 @@ class TaskDispatcher:
         db: Any,
         executor: Any,
         event_bus: Any | None = None,
+        exec_semaphore: asyncio.Semaphore | None = None,
     ) -> None:
         self._db = db
         self._executor = executor
         self._event_bus = event_bus
+        self._exec_semaphore = exec_semaphore
         self._dispatched: set[str] = set()  # in-memory dedup guard
+
+    async def _guarded_execute(self, task_id: str) -> bool:
+        """Execute a task, serialized through the semaphore if present."""
+        if self._exec_semaphore:
+            async with self._exec_semaphore:
+                return await self._executor.execute(task_id)
+        return await self._executor.execute(task_id)
 
     async def submit(
         self,
@@ -131,7 +141,7 @@ class TaskDispatcher:
 
         # Dispatch immediately via tracked_task (Amendment #2)
         tracked_task(
-            self._executor.execute(task_id),
+            self._guarded_execute(task_id),
             name=f"task-{task_id}",
         )
 
@@ -209,7 +219,7 @@ class TaskDispatcher:
 
             self._dispatched.add(task_id)
             tracked_task(
-                self._executor.execute(task_id),
+                self._guarded_execute(task_id),
                 name=f"task-{task_id}",
             )
             dispatched += 1
@@ -247,7 +257,7 @@ class TaskDispatcher:
             )
             self._dispatched.add(task_id)
             tracked_task(
-                self._executor.execute(task_id),
+                self._guarded_execute(task_id),
                 name=f"task-{task_id}-resume",
             )
             dispatched += 1
@@ -336,6 +346,19 @@ class TaskDispatcher:
             if task_id in self._dispatched:
                 continue
 
+            if phase == TaskPhase.PAUSED.value:
+                # Recover as paused — pre-set pause flag so checkpoint
+                # pauses immediately after first step
+                logger.info("Recovering paused task %s", task_id)
+                self._executor._paused_tasks.add(task_id)
+                self._dispatched.add(task_id)
+                tracked_task(
+                    self._guarded_execute(task_id),
+                    name=f"task-paused-{task_id}",
+                )
+                recovered += 1
+                continue
+
             if phase == TaskPhase.BLOCKED.value:
                 # Check if there's an approved-but-unconsumed approval
                 try:
@@ -362,7 +385,7 @@ class TaskDispatcher:
                     )
                     self._dispatched.add(task_id)
                     tracked_task(
-                        self._executor.execute(task_id),
+                        self._guarded_execute(task_id),
                         name=f"task-resume-{task_id}",
                     )
                     recovered += 1
@@ -379,7 +402,7 @@ class TaskDispatcher:
             )
             self._dispatched.add(task_id)
             tracked_task(
-                self._executor.execute(task_id),
+                self._guarded_execute(task_id),
                 name=f"task-recover-{task_id}",
             )
             recovered += 1

--- a/src/genesis/autonomy/dispatcher.py
+++ b/src/genesis/autonomy/dispatcher.py
@@ -94,11 +94,25 @@ class TaskDispatcher:
         self._dispatched: set[str] = set()  # in-memory dedup guard
 
     async def _guarded_execute(self, task_id: str) -> bool:
-        """Execute a task, serialized through the semaphore if present."""
-        if self._exec_semaphore:
-            async with self._exec_semaphore:
-                return await self._executor.execute(task_id)
-        return await self._executor.execute(task_id)
+        """Execute a task, serialized through the semaphore if present.
+
+        Uses explicit acquire/release instead of ``async with`` because
+        the engine may release the semaphore during a pause (to let
+        another task run).  On cancel-during-pause the engine signals
+        via ``_semaphore_released`` that it already released, so we
+        must NOT release again here.
+        """
+        if self._exec_semaphore is None:
+            return await self._executor.execute(task_id)
+        await self._exec_semaphore.acquire()
+        try:
+            return await self._executor.execute(task_id)
+        finally:
+            # Only release if engine didn't already release during pause
+            if task_id not in self._executor._semaphore_released:
+                self._exec_semaphore.release()
+            else:
+                self._executor._semaphore_released.discard(task_id)
 
     async def submit(
         self,

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -59,6 +59,7 @@ class CCSessionExecutor:
         event_bus: Any | None = None,
         runtime: Any | None = None,
         autonomous_dispatcher: Any | None = None,
+        exec_semaphore: asyncio.Semaphore | None = None,
     ) -> None:
         self._db = db
         self._invoker = invoker
@@ -69,6 +70,7 @@ class CCSessionExecutor:
         self._event_bus = event_bus
         self._runtime = runtime
         self._autonomous_dispatcher = autonomous_dispatcher
+        self._exec_semaphore = exec_semaphore
 
         # Step dispatch (extracted to StepDispatcher)
         self._step_dispatcher = StepDispatcher(
@@ -534,6 +536,11 @@ class CCSessionExecutor:
         )
         if should_pause:
             await self._transition(task_id, TaskPhase.PAUSED)
+
+            # Release execution semaphore so another task can run
+            if self._exec_semaphore:
+                self._exec_semaphore.release()
+
             pause_event = asyncio.Event()
             self._pause_events[task_id] = pause_event
 
@@ -544,6 +551,10 @@ class CCSessionExecutor:
                         await self._transition(task_id, TaskPhase.CANCELLED)
                     return False
                 await asyncio.sleep(0.1)
+
+            # Reacquire semaphore before resuming
+            if self._exec_semaphore:
+                await self._exec_semaphore.acquire()
 
             self._paused_tasks.discard(task_id)
             await self._transition(task_id, TaskPhase.EXECUTING)

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -86,6 +86,7 @@ class CCSessionExecutor:
         self._pause_events: dict[str, asyncio.Event] = {}
         self._paused_tasks: set[str] = set()
         self._worktree_paths: dict[str, Path] = {}
+        self._semaphore_released: set[str] = set()  # tracks tasks whose semaphore was released during pause
 
     # =================================================================
     # Main lifecycle
@@ -540,6 +541,7 @@ class CCSessionExecutor:
             # Release execution semaphore so another task can run
             if self._exec_semaphore:
                 self._exec_semaphore.release()
+                self._semaphore_released.add(task_id)
 
             pause_event = asyncio.Event()
             self._pause_events[task_id] = pause_event
@@ -549,12 +551,15 @@ class CCSessionExecutor:
                 if cancel and cancel.is_set():
                     with contextlib.suppress(InvalidTransitionError):
                         await self._transition(task_id, TaskPhase.CANCELLED)
+                    # semaphore_released stays set — dispatcher will
+                    # skip release in _guarded_execute finally block
                     return False
                 await asyncio.sleep(0.1)
 
             # Reacquire semaphore before resuming
             if self._exec_semaphore:
                 await self._exec_semaphore.acquire()
+                self._semaphore_released.discard(task_id)
 
             self._paused_tasks.discard(task_id)
             await self._transition(task_id, TaskPhase.EXECUTING)

--- a/src/genesis/autonomy/executor/step_dispatcher.py
+++ b/src/genesis/autonomy/executor/step_dispatcher.py
@@ -233,7 +233,7 @@ class StepDispatcher:
                     cli_invocation=invocation,
                     api_call_site_id=api_call_site_id,
                     cli_fallback_allowed=True,
-                    approval_required_for_cli=True,
+                    approval_required_for_cli=False,  # task submission = approval
                     context={
                         "task_id": task_id,
                         "step_idx": step_idx,

--- a/src/genesis/autonomy/executor/worktree_mgr.py
+++ b/src/genesis/autonomy/executor/worktree_mgr.py
@@ -14,6 +14,54 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _branch_from_wt_path(wt_path: Path) -> str | None:
+    """Derive branch name from worktree path: task-XXXX → task/XXXX."""
+    name = wt_path.name
+    if name.startswith("task-"):
+        return f"task/{name[5:]}"
+    return None
+
+
+async def _delete_branch(branch: str, repo_root: Path) -> None:
+    """Delete a local git branch. Logs result, never raises."""
+    proc = await asyncio.create_subprocess_exec(
+        "git", "branch", "-D", branch,
+        cwd=str(repo_root),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    _, stderr = await proc.communicate()
+    if proc.returncode == 0:
+        logger.info("Deleted branch %s", branch)
+    else:
+        # Branch may not exist — that's fine
+        logger.debug(
+            "Branch %s not deleted (may not exist): %s",
+            branch, stderr.decode(errors="replace").strip(),
+        )
+
+
+async def _prune_worktrees(repo_root: Path) -> None:
+    """Run git worktree prune to clean orphaned entries."""
+    proc = await asyncio.create_subprocess_exec(
+        "git", "worktree", "prune",
+        cwd=str(repo_root),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await proc.communicate()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
 async def create_worktree(
     task_id: str,
     repo_root: Path,
@@ -21,12 +69,22 @@ async def create_worktree(
 ) -> Path:
     """Create a git worktree for code task isolation.
 
+    Cleans up stale state from previous runs before creating.
     Returns the worktree path on success.
     Raises RuntimeError if worktree creation fails.
     """
     short_id = task_id[:8]
     branch = f"task/{short_id}"
     wt_path = worktree_base / f"task-{short_id}"
+
+    # Clean up stale state from previous runs of this task
+    if wt_path.exists():
+        logger.info("Stale worktree dir %s exists, cleaning up", wt_path)
+        await cleanup_worktree(wt_path, repo_root)
+    else:
+        # No dir but branch might linger from a prior crash
+        await _prune_worktrees(repo_root)
+        await _delete_branch(branch, repo_root)
 
     proc = await asyncio.create_subprocess_exec(
         "git", "worktree", "add", "-b", branch, str(wt_path),
@@ -48,8 +106,16 @@ async def cleanup_worktree(
     wt_path: Path,
     repo_root: Path,
 ) -> None:
-    """Remove a worktree. NO --force per CLAUDE.md worktree rules."""
+    """Remove a worktree and its associated branch.
+
+    NO --force per CLAUDE.md worktree rules.
+    """
+    branch = _branch_from_wt_path(wt_path)
+
     if not wt_path.exists():
+        # Worktree dir gone but branch might linger
+        if branch:
+            await _delete_branch(branch, repo_root)
         return
 
     proc = await asyncio.create_subprocess_exec(
@@ -66,3 +132,7 @@ async def cleanup_worktree(
         )
     else:
         logger.info("Cleaned up worktree at %s", wt_path)
+
+    # Delete the branch (even if worktree removal failed, try anyway)
+    if branch:
+        await _delete_branch(branch, repo_root)

--- a/src/genesis/db/crud/procedural.py
+++ b/src/genesis/db/crud/procedural.py
@@ -25,19 +25,22 @@ async def create(
     tool_trigger: list[str] | None = None,
     success_count: int = 0,
     confidence: float = 0.0,
+    source: str | None = None,
+    promotion_history: str | None = None,
 ) -> str:
     await db.execute(
         """INSERT INTO procedural_memory
            (id, person_id, task_type, principle, steps, tools_used, context_tags,
             speculative, attempted_workarounds, version, created_at,
-            activation_tier, tool_trigger, success_count, confidence)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            activation_tier, tool_trigger, success_count, confidence,
+            source, promotion_history)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (id, person_id, task_type, principle, json.dumps(steps), json.dumps(tools_used),
          json.dumps(context_tags), speculative,
          json.dumps(attempted_workarounds) if attempted_workarounds else None,
          version, created_at, activation_tier,
          json.dumps(tool_trigger) if tool_trigger else None,
-         success_count, confidence),
+         success_count, confidence, source, promotion_history),
     )
     await db.commit()
     return id
@@ -61,6 +64,8 @@ async def upsert(
     tool_trigger: list[str] | None = None,
     success_count: int = 0,
     confidence: float = 0.0,
+    source: str | None = None,
+    promotion_history: str | None = None,
 ) -> str:
     """Idempotent write: insert or update on conflict.
 
@@ -74,8 +79,9 @@ async def upsert(
         """INSERT INTO procedural_memory
            (id, person_id, task_type, principle, steps, tools_used, context_tags,
             speculative, attempted_workarounds, version, created_at,
-            activation_tier, tool_trigger, success_count, confidence)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            activation_tier, tool_trigger, success_count, confidence,
+            source, promotion_history)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(id) DO UPDATE SET
              person_id = excluded.person_id,
              task_type = excluded.task_type, principle = excluded.principle,
@@ -86,13 +92,15 @@ async def upsert(
              activation_tier = excluded.activation_tier,
              tool_trigger = excluded.tool_trigger,
              success_count = excluded.success_count,
-             confidence = excluded.confidence""",
+             confidence = excluded.confidence,
+             source = COALESCE(procedural_memory.source, excluded.source),
+             promotion_history = COALESCE(procedural_memory.promotion_history, excluded.promotion_history)""",
         (id, person_id, task_type, principle, json.dumps(steps), json.dumps(tools_used),
          json.dumps(context_tags), speculative,
          json.dumps(attempted_workarounds) if attempted_workarounds else None,
          version, created_at, activation_tier,
          json.dumps(tool_trigger) if tool_trigger else None,
-         success_count, confidence),
+         success_count, confidence, source, promotion_history),
     )
     await db.commit()
     return id
@@ -104,6 +112,59 @@ async def get_by_id(db: aiosqlite.Connection, id: str) -> dict | None:
     if row is None:
         return None
     return dict(row)
+
+
+async def find_by_task_type(
+    db: aiosqlite.Connection,
+    task_type: str,
+) -> dict | None:
+    """Find the best active procedure with an exact task_type match.
+
+    Returns the highest-confidence non-deprecated, non-quarantined row,
+    or None. Used by conflict detection before store.
+    """
+    cursor = await db.execute(
+        """SELECT * FROM procedural_memory
+           WHERE task_type = ? AND deprecated = 0 AND quarantined = 0
+           ORDER BY confidence DESC LIMIT 1""",
+        (task_type,),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def find_by_context_overlap(
+    db: aiosqlite.Connection,
+    context_tags: list[str],
+    *,
+    jaccard_threshold: float = 0.7,
+    exclude_id: str | None = None,
+    limit: int = 5,
+) -> list[dict]:
+    """Find active procedures with high context_tag Jaccard overlap.
+
+    Loads active procedures and filters in Python (SQLite lacks native
+    JSON set operations). Returns rows with overlap >= threshold.
+    """
+    query_tags = set(context_tags)
+    if not query_tags:
+        return []
+
+    rows = await list_active(db, limit=200)
+    scored = []
+    for row in rows:
+        if exclude_id and row["id"] == exclude_id:
+            continue
+        raw = row.get("context_tags", "[]")
+        row_tags = set(json.loads(raw) if isinstance(raw, str) else raw)
+        union = query_tags | row_tags
+        if not union:
+            continue
+        jaccard = len(query_tags & row_tags) / len(union)
+        if jaccard >= jaccard_threshold:
+            scored.append((jaccard, row))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [row for _, row in scored[:limit]]
 
 
 async def list_by_task_type(
@@ -162,9 +223,11 @@ async def update(db: aiosqlite.Connection, id: str, **fields) -> bool:
         return False
     # Serialize JSON fields
     for key in ("steps", "tools_used", "context_tags", "failure_modes",
-                 "attempted_workarounds", "tool_trigger"):
+                 "attempted_workarounds", "tool_trigger", "promotion_history"):
         if key in fields and isinstance(fields[key], list):
             fields[key] = json.dumps(fields[key])
+    if "source" in fields and isinstance(fields["source"], dict):
+        fields["source"] = json.dumps(fields["source"])
     set_clause = ", ".join(f"{k} = ?" for k in fields)
     values = list(fields.values()) + [id]
     cursor = await db.execute(

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -951,6 +951,14 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE follow_ups ADD COLUMN verification_notes TEXT",
         "follow_ups.verification_notes")
 
+    # Procedure provenance tracking
+    await _try_alter(db,
+        "ALTER TABLE procedural_memory ADD COLUMN source TEXT",
+        "procedural_memory.source")
+    await _try_alter(db,
+        "ALTER TABLE procedural_memory ADD COLUMN promotion_history TEXT",
+        "procedural_memory.promotion_history")
+
     # Rebuild cognitive_state table if CHECK constraint lacks resilience_degradation.
     # SQLite can't ALTER CHECK constraints — requires table rebuild.
     await _migrate_cognitive_state_check(db)

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -31,7 +31,9 @@ TABLES = {
             version           INTEGER NOT NULL DEFAULT 1,
             created_at        TEXT NOT NULL,
             activation_tier   TEXT NOT NULL DEFAULT 'L4',  -- L1/L2/L3/L4 promotion tier
-            tool_trigger      TEXT                         -- JSON array of tool names for L1 matching
+            tool_trigger      TEXT,                        -- JSON array of tool names for L1 matching
+            source            TEXT,                        -- JSON: {type, session_id?, observation_id?, triage_outcome?}
+            promotion_history TEXT                         -- JSON array: [{from_tier, to_tier, at, reason}]
         )
     """,
     "observations": """

--- a/src/genesis/learning/procedural/extractor.py
+++ b/src/genesis/learning/procedural/extractor.py
@@ -89,6 +89,20 @@ async def extract_procedure(
         logger.warning("Procedure extraction: missing required fields in %s", list(data.keys()))
         return None
 
+    # Skip if an explicit-teach procedure already covers this task_type
+    try:
+        from genesis.db.crud.procedural import find_by_task_type
+
+        existing = await find_by_task_type(db, data["task_type"])
+        if existing and existing.get("speculative") == 0:
+            logger.info(
+                "Skipped extraction for %s: explicit-teach %s exists",
+                data["task_type"], existing["id"],
+            )
+            return None
+    except Exception:
+        pass  # Non-critical guard — continue with extraction if check fails
+
     try:
         proc_id = await store_procedure(
             db,
@@ -100,6 +114,7 @@ async def extract_procedure(
             tool_trigger=data.get("tool_trigger"),
             activation_tier="L4",
             speculative=1,
+            source={"type": "auto_extracted", "triage_outcome": outcome},
         )
         logger.info("Extracted procedure %s: %s", proc_id, data["task_type"])
         return proc_id

--- a/src/genesis/learning/procedural/operations.py
+++ b/src/genesis/learning/procedural/operations.py
@@ -3,12 +3,26 @@
 from __future__ import annotations
 
 import json
+import logging
 import uuid
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
 import aiosqlite
 
 from genesis.db.crud import procedural
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StoreResult:
+    """Result of a conflict-checked procedure store."""
+
+    procedure_id: str
+    action: str  # "created" | "updated" | "skipped"
+    warnings: list[str] = field(default_factory=list)
+    conflicting_ids: list[str] = field(default_factory=list)
 
 
 async def store_procedure(
@@ -24,6 +38,7 @@ async def store_procedure(
     speculative: int = 1,
     success_count: int = 0,
     confidence: float = 0.0,
+    source: dict | None = None,
 ) -> str:
     """Create a new procedure and return its ID.
 
@@ -49,8 +64,107 @@ async def store_procedure(
         speculative=speculative,
         success_count=success_count,
         confidence=confidence,
+        source=json.dumps(source) if source else None,
     )
     return proc_id
+
+
+async def store_procedure_checked(
+    db: aiosqlite.Connection,
+    *,
+    task_type: str,
+    principle: str,
+    steps: list[str],
+    tools_used: list[str],
+    context_tags: list[str],
+    activation_tier: str = "L3",
+    tool_trigger: list[str] | None = None,
+    speculative: int = 0,
+    success_count: int = 1,
+    confidence: float = 2 / 3,
+    source: dict | None = None,
+) -> StoreResult:
+    """Store a procedure with conflict detection.
+
+    Defaults match the explicit-teach path (speculative=0, success_count=1).
+
+    Conflict resolution:
+    - Exact task_type match, incoming is auto-extracted but existing is
+      explicit-teach → skip (don't overwrite human-taught).
+    - Exact task_type match, same source type → upsert (update content,
+      preserve operational history, bump version).
+    - High context_tag overlap with different task_type → warn but still create.
+    """
+    existing = await procedural.find_by_task_type(db, task_type)
+
+    if existing:
+        # Auto-extracted should never overwrite explicit-teach
+        if speculative == 1 and existing.get("speculative") == 0:
+            logger.info(
+                "Skipped auto-extracted procedure for %s: explicit-teach %s exists",
+                task_type, existing["id"],
+            )
+            return StoreResult(
+                procedure_id=existing["id"],
+                action="skipped",
+                warnings=["Auto-extracted procedure skipped: explicit-teach already exists"],
+                conflicting_ids=[existing["id"]],
+            )
+
+        # Upsert: update content, preserve operational history (counts, confidence)
+        new_version = existing.get("version", 1) + 1
+        await procedural.update(
+            db,
+            existing["id"],
+            principle=principle,
+            steps=steps,
+            tools_used=tools_used,
+            context_tags=context_tags,
+            tool_trigger=tool_trigger,
+            version=new_version,
+            source=json.dumps(source) if source else existing.get("source"),
+        )
+        logger.info("Updated procedure %s (v%d): %s", existing["id"], new_version, task_type)
+        return StoreResult(
+            procedure_id=existing["id"],
+            action="updated",
+        )
+
+    # Check for high context_tag overlap with different task_types
+    warnings: list[str] = []
+    conflicting_ids: list[str] = []
+    overlapping = await procedural.find_by_context_overlap(db, context_tags)
+    for row in overlapping:
+        warnings.append(
+            f"High context overlap with '{row['task_type']}' (id={row['id']})"
+        )
+        conflicting_ids.append(row["id"])
+
+    # Create new procedure
+    proc_id = await store_procedure(
+        db,
+        task_type=task_type,
+        principle=principle,
+        steps=steps,
+        tools_used=tools_used,
+        context_tags=context_tags,
+        activation_tier=activation_tier,
+        tool_trigger=tool_trigger,
+        speculative=speculative,
+        success_count=success_count,
+        confidence=confidence,
+        source=source,
+    )
+
+    if warnings:
+        logger.info("Procedure %s created with %d overlap warnings", proc_id, len(warnings))
+
+    return StoreResult(
+        procedure_id=proc_id,
+        action="created",
+        warnings=warnings,
+        conflicting_ids=conflicting_ids,
+    )
 
 
 async def record_success(db: aiosqlite.Connection, procedure_id: str) -> bool:

--- a/src/genesis/learning/procedural/promoter.py
+++ b/src/genesis/learning/procedural/promoter.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import UTC, datetime
 
 import aiosqlite
 
@@ -95,6 +96,14 @@ async def promote_and_demote(db: aiosqlite.Connection) -> dict:
 
         # Quarantine check
         if row["confidence"] < 0.3 and row["success_count"] + row["failure_count"] >= 3:
+            history = json.loads(row.get("promotion_history") or "[]")
+            history.append({
+                "from_tier": current_tier,
+                "to_tier": "quarantined",
+                "at": datetime.now(UTC).isoformat(),
+                "reason": "low_confidence_quarantine",
+            })
+            await procedural.update(db, proc_id, promotion_history=json.dumps(history))
             await procedural.quarantine(db, proc_id)
             quarantined += 1
             logger.info("Quarantined procedure %s (conf=%.2f)", row["task_type"], row["confidence"])
@@ -110,9 +119,23 @@ async def promote_and_demote(db: aiosqlite.Connection) -> dict:
                 target_tier = _RANK_TIER[current_rank - 1]
 
         if target_tier != current_tier:
-            await procedural.update(db, proc_id, activation_tier=target_tier)
             target_rank = _TIER_RANK.get(target_tier, 1)
             current_rank = _TIER_RANK.get(current_tier, 1)
+            reason = "metrics_promotion" if target_rank > current_rank else "failure_demotion"
+
+            history = json.loads(row.get("promotion_history") or "[]")
+            history.append({
+                "from_tier": current_tier,
+                "to_tier": target_tier,
+                "at": datetime.now(UTC).isoformat(),
+                "reason": reason,
+            })
+            await procedural.update(
+                db, proc_id,
+                activation_tier=target_tier,
+                promotion_history=json.dumps(history),
+            )
+
             if target_rank > current_rank:
                 promotions += 1
                 logger.info("Promoted %s: %s → %s", row["task_type"], current_tier, target_tier)

--- a/src/genesis/mcp/health/task_tools.py
+++ b/src/genesis/mcp/health/task_tools.py
@@ -40,6 +40,23 @@ _ALLOWED_PLAN_DIRS = [
     Path.home() / ".claude" / "plans",
 ]
 
+# Required sections in plan files (must match dispatcher.py)
+REQUIRED_PLAN_SECTIONS = [
+    "## Requirements",
+    "## Steps",
+    "## Success Criteria",
+    "## Risks and Failure Modes",
+]
+
+
+def _validate_plan_content(path: Path) -> list[str]:
+    """Check plan file contains required TASK_INTAKE.md sections.
+
+    Returns list of missing section headers (empty if valid).
+    """
+    lines = set(path.read_text().splitlines())
+    return [s for s in REQUIRED_PLAN_SECTIONS if s not in lines]
+
 
 def init_task_tools(dispatcher, executor, *, db=None) -> None:
     """Wire dispatcher and executor references. Called from runtime init."""
@@ -84,7 +101,7 @@ async def _impl_task_submit(plan_path: str, description: str) -> dict:
             task_id = await _dispatcher.submit(plan_path, description)
             return {"task_id": task_id, "status": "dispatched"}
         except ValueError as exc:
-            return {"error": f"Invalid plan path: {exc}"}
+            return {"error": str(exc)}
         except FileNotFoundError as exc:
             return {"error": f"Plan file not found: {exc}"}
         except Exception as exc:
@@ -103,6 +120,14 @@ async def _impl_task_submit(plan_path: str, description: str) -> dict:
             return {"error": f"Plan file not found: {plan_path}"}
     except Exception as exc:
         return {"error": f"Invalid plan path: {exc}"}
+
+    # Content validation: check required sections
+    missing = _validate_plan_content(resolved)
+    if missing:
+        return {
+            "error": f"Plan file missing required sections: {', '.join(missing)}. "
+            "See TASK_INTAKE.md format. Use /task for guided intake.",
+        }
 
     task_id = f"t-{uuid.uuid4().hex[:12]}"
     now = datetime.now(UTC).isoformat()

--- a/src/genesis/mcp/memory/procedural.py
+++ b/src/genesis/mcp/memory/procedural.py
@@ -41,9 +41,9 @@ async def procedure_store(
     memory_mod = _memory_mod()
     memory_mod._require_init()
     assert memory_mod._db is not None
-    from genesis.learning.procedural.operations import store_procedure
+    from genesis.learning.procedural.operations import store_procedure_checked
 
-    return await store_procedure(
+    result = await store_procedure_checked(
         memory_mod._db,
         task_type=task_type,
         principle=principle,
@@ -55,7 +55,17 @@ async def procedure_store(
         speculative=0,
         success_count=1,
         confidence=2 / 3,
+        source={"type": "explicit_teach"},
     )
+
+    response = result.procedure_id
+    if result.action == "updated":
+        response = f"Updated existing procedure {result.procedure_id} (version bumped)"
+    elif result.action == "skipped":
+        response = f"Skipped: procedure {result.conflicting_ids[0]} already covers this task_type"
+    if result.warnings:
+        response += "\n\nWarnings:\n" + "\n".join(f"- {w}" for w in result.warnings)
+    return response
 
 
 @mcp.tool()

--- a/src/genesis/runtime/init/tasks.py
+++ b/src/genesis/runtime/init/tasks.py
@@ -46,6 +46,11 @@ async def init(rt: GenesisRuntime) -> None:
             memory_store=getattr(rt, "_memory_store", None),
         )
 
+        # Single-task execution: semaphore ensures only one task runs
+        # at a time.  Shared between executor (pause releases it) and
+        # dispatcher (guarded_execute acquires it).
+        exec_semaphore = asyncio.Semaphore(1)
+
         executor = CCSessionExecutor(
             db=rt._db,
             invoker=rt._cc_invoker,
@@ -57,12 +62,14 @@ async def init(rt: GenesisRuntime) -> None:
             event_bus=rt._event_bus,
             runtime=rt,
             autonomous_dispatcher=getattr(rt, "_autonomous_dispatcher", None),
+            exec_semaphore=exec_semaphore,
         )
 
         dispatcher = TaskDispatcher(
             db=rt._db,
             executor=executor,
             event_bus=rt._event_bus,
+            exec_semaphore=exec_semaphore,
         )
 
         rt._task_executor = executor

--- a/tests/test_autonomy/test_executor/test_dispatcher.py
+++ b/tests/test_autonomy/test_executor/test_dispatcher.py
@@ -7,7 +7,20 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from genesis.autonomy.dispatcher import TaskDispatcher, _validate_plan_path
+from genesis.autonomy.dispatcher import (
+    TaskDispatcher,
+    _validate_plan_content,
+    _validate_plan_path,
+)
+
+# Minimal plan content satisfying REQUIRED_PLAN_SECTIONS validation
+VALID_PLAN = (
+    "# Plan\n"
+    "## Requirements\nBuild it\n"
+    "## Steps\n1. Do thing\n"
+    "## Success Criteria\nIt works\n"
+    "## Risks and Failure Modes\nNone significant\n"
+)
 
 # ---------------------------------------------------------------------------
 # Path validation tests
@@ -42,6 +55,32 @@ class TestPathValidation:
             _validate_plan_path(str(Path.home() / "nonexistent_plan_xyz.md"))
 
 
+class TestPlanContentValidation:
+    def test_rejects_missing_sections(self, tmp_path: Path) -> None:
+        plan = tmp_path / "bad-plan.md"
+        plan.write_text("# Plan\n## Steps\n1. Do thing\n")
+        with pytest.raises(ValueError, match="missing required sections"):
+            _validate_plan_content(plan)
+
+    def test_lists_all_missing_sections(self, tmp_path: Path) -> None:
+        plan = tmp_path / "minimal.md"
+        plan.write_text("# Plan\nJust a title\n")
+        with pytest.raises(ValueError, match="Requirements") as exc_info:
+            _validate_plan_content(plan)
+        msg = str(exc_info.value)
+        assert "## Requirements" in msg
+        assert "## Steps" in msg
+        assert "## Success Criteria" in msg
+        assert "## Risks and Failure Modes" in msg
+
+    def test_accepts_complete_plan(self, tmp_path: Path) -> None:
+        plan = tmp_path / "good-plan.md"
+        plan.write_text(VALID_PLAN)
+        # Should not raise
+        _validate_plan_content(plan)
+
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -74,7 +113,7 @@ class TestSubmit:
         self, dispatcher: TaskDispatcher, tmp_path: Path,
     ) -> None:
         plan = tmp_path / "plan.md"
-        plan.write_text("# Plan\n## Steps\n1. Do thing")
+        plan.write_text(VALID_PLAN)
 
         with (
             patch("genesis.autonomy.dispatcher._ALLOWED_PLAN_DIRS", [tmp_path]),
@@ -102,6 +141,19 @@ class TestSubmit:
                 str(tmp_path / "gone.md"), "Missing plan",
             )
 
+    async def test_submit_rejects_incomplete_plan(
+        self, dispatcher: TaskDispatcher, tmp_path: Path,
+    ) -> None:
+        """Content validation fires through submit() for in-server path."""
+        plan = tmp_path / "incomplete.md"
+        plan.write_text("# Plan\n## Steps\n1. Do thing\n")
+
+        with (
+            patch("genesis.autonomy.dispatcher._ALLOWED_PLAN_DIRS", [tmp_path]),
+            pytest.raises(ValueError, match="missing required sections"),
+        ):
+            await dispatcher.submit(str(plan), "Bad task")
+
     async def test_submit_with_event_bus(
         self, mock_executor: AsyncMock, tmp_path: Path,
     ) -> None:
@@ -110,7 +162,7 @@ class TestSubmit:
         d = TaskDispatcher(db=AsyncMock(), executor=mock_executor, event_bus=event_bus)
 
         plan = tmp_path / "plan.md"
-        plan.write_text("# Plan")
+        plan.write_text(VALID_PLAN)
 
         with (
             patch("genesis.autonomy.dispatcher._ALLOWED_PLAN_DIRS", [tmp_path]),
@@ -133,7 +185,7 @@ class TestDispatchCycle:
         self, dispatcher: TaskDispatcher, tmp_path: Path,
     ) -> None:
         plan = tmp_path / "plan.md"
-        plan.write_text("# Plan")
+        plan.write_text(VALID_PLAN)
 
         obs = {
             "id": "obs-1",
@@ -157,6 +209,8 @@ class TestDispatchCycle:
     async def test_dedup_skips_active_tasks(
         self, dispatcher: TaskDispatcher,
     ) -> None:
+        # content-match dedup fires before path/content validation —
+        # this path never reaches submit()
         obs = {
             "id": "obs-2",
             "content": "Already running",

--- a/tests/test_autonomy/test_executor/test_task_tools.py
+++ b/tests/test_autonomy/test_executor/test_task_tools.py
@@ -9,6 +9,15 @@ import pytest
 
 from genesis.mcp.health import task_tools
 
+# Minimal plan content satisfying REQUIRED_PLAN_SECTIONS validation
+VALID_PLAN = (
+    "# Test Plan\n"
+    "## Requirements\nBuild it\n"
+    "## Steps\n1. Do thing\n"
+    "## Success Criteria\nIt works\n"
+    "## Risks and Failure Modes\nNone significant\n"
+)
+
 
 @pytest.fixture(autouse=True)
 def _reset_task_tools():
@@ -43,7 +52,7 @@ class TestTaskSubmit:
     async def test_mcp_fallback_creates_db_row(self, tmp_path: Path) -> None:
         """Without dispatcher, MCP fallback creates DB row directly."""
         plan = tmp_path / "test-plan.md"
-        plan.write_text("# Test Plan\n")
+        plan.write_text(VALID_PLAN)
 
         # Temporarily allow the tmp dir
         original_dirs = task_tools._ALLOWED_PLAN_DIRS[:]
@@ -87,7 +96,46 @@ class TestTaskSubmit:
 
         result = await task_tools._impl_task_submit("/bad/path", "task")
         assert "error" in result
-        assert "Invalid" in result["error"]
+        assert "bad path" in result["error"]
+
+    async def test_mcp_fallback_rejects_missing_sections(self, tmp_path: Path) -> None:
+        """MCP fallback validates plan content after path checks pass."""
+        plan = tmp_path / "incomplete.md"
+        plan.write_text("# Plan\n## Steps\n1. Do thing\n")
+
+        original_dirs = task_tools._ALLOWED_PLAN_DIRS[:]
+        task_tools._ALLOWED_PLAN_DIRS.append(tmp_path)
+
+        result = await task_tools._impl_task_submit(str(plan), "Bad task")
+
+        task_tools._ALLOWED_PLAN_DIRS[:] = original_dirs
+
+        assert "error" in result
+        assert "missing required sections" in result["error"]
+        assert "## Requirements" in result["error"]
+        assert "## Success Criteria" in result["error"]
+
+    async def test_mcp_fallback_accepts_valid_plan(self, tmp_path: Path) -> None:
+        """MCP fallback passes content validation for well-formed plans."""
+        plan = tmp_path / "good.md"
+        plan.write_text(VALID_PLAN)
+
+        original_dirs = task_tools._ALLOWED_PLAN_DIRS[:]
+        task_tools._ALLOWED_PLAN_DIRS.append(tmp_path)
+
+        mock_db = AsyncMock()
+        mock_db.close = AsyncMock()
+
+        with (
+            patch.object(task_tools, "_get_db", new_callable=AsyncMock, return_value=mock_db),
+            patch("genesis.db.crud.task_states.create", new_callable=AsyncMock),
+        ):
+            result = await task_tools._impl_task_submit(str(plan), "Good task")
+
+        task_tools._ALLOWED_PLAN_DIRS[:] = original_dirs
+
+        assert "task_id" in result
+        assert result["status"] == "pending"
 
 
 @pytest.mark.asyncio

--- a/tests/test_learning/test_procedural.py
+++ b/tests/test_learning/test_procedural.py
@@ -13,6 +13,7 @@ from genesis.learning.procedural.operations import (
     record_success,
     record_workaround,
     store_procedure,
+    store_procedure_checked,
     update_confidence,
 )
 from genesis.learning.types import MaturityStage
@@ -357,3 +358,162 @@ async def test_find_relevant_still_hides_speculative_extractor_writes(db):
     )
     matches = await find_relevant(db, ["extracted", "hypothesis"], limit=3)
     assert all(m.task_type != "auto-extracted-task" for m in matches)
+
+
+# ─── Conflict Detection ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_store_checked_exact_match_upserts(db):
+    """Same task_type → update existing, preserve counts, bump version."""
+    proc_id = await store_procedure(
+        db, task_type="deploy-safety", principle="original",
+        steps=["step-a"], tools_used=["Bash"], context_tags=["deploy"],
+        speculative=0, success_count=3, confidence=0.8,
+    )
+    result = await store_procedure_checked(
+        db, task_type="deploy-safety", principle="updated principle",
+        steps=["step-b", "step-c"], tools_used=["Bash"],
+        context_tags=["deploy", "safety"],
+    )
+    assert result.action == "updated"
+    assert result.procedure_id == proc_id
+    # Read back and verify
+    from genesis.db.crud.procedural import get_by_id
+    row = await get_by_id(db, proc_id)
+    assert row["principle"] == "updated principle"
+    assert json.loads(row["steps"]) == ["step-b", "step-c"]
+    assert row["version"] == 2  # bumped
+    assert row["success_count"] == 3  # preserved
+    assert row["confidence"] == 0.8  # preserved
+
+
+@pytest.mark.asyncio
+async def test_store_checked_auto_skips_explicit(db):
+    """Auto-extracted should not overwrite explicit-teach."""
+    proc_id = await store_procedure(
+        db, task_type="manual-task", principle="human taught",
+        steps=["do-this"], tools_used=["Bash"], context_tags=["manual"],
+        speculative=0, success_count=1, confidence=2 / 3,
+    )
+    result = await store_procedure_checked(
+        db, task_type="manual-task", principle="auto extracted",
+        steps=["maybe-this"], tools_used=["Bash"],
+        context_tags=["manual"], speculative=1, confidence=0.0,
+    )
+    assert result.action == "skipped"
+    assert proc_id in result.conflicting_ids
+    # Original unchanged
+    from genesis.db.crud.procedural import get_by_id
+    row = await get_by_id(db, proc_id)
+    assert row["principle"] == "human taught"
+
+
+@pytest.mark.asyncio
+async def test_store_checked_context_overlap_warns(db):
+    """High Jaccard overlap with different task_type → warn but create."""
+    await store_procedure(
+        db, task_type="youtube-fetch", principle="fetch youtube",
+        steps=["s1"], tools_used=["WebFetch"],
+        context_tags=["youtube", "video", "transcript"],
+        speculative=0, success_count=1, confidence=2 / 3,
+    )
+    # Jaccard: 3/4 = 0.75 >= 0.7 threshold
+    result = await store_procedure_checked(
+        db, task_type="youtube-download", principle="download youtube",
+        steps=["s2"], tools_used=["Bash"],
+        context_tags=["youtube", "video", "transcript", "download"],
+    )
+    assert result.action == "created"
+    assert len(result.warnings) > 0
+    assert "youtube-fetch" in result.warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_store_checked_clean_insert(db):
+    """No conflicts → clean create, no warnings."""
+    result = await store_procedure_checked(
+        db, task_type="unique-task", principle="unique",
+        steps=["s1"], tools_used=["Grep"],
+        context_tags=["unique", "new"],
+    )
+    assert result.action == "created"
+    assert result.warnings == []
+    assert result.conflicting_ids == []
+
+
+# ─── Provenance Tracking ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_source_persisted(db):
+    """Source provenance round-trips through store/read."""
+    proc_id = await store_procedure(
+        db, task_type="sourced-task", principle="test",
+        steps=["s1"], tools_used=["Bash"], context_tags=["test"],
+        source={"type": "explicit_teach"},
+    )
+    from genesis.db.crud.procedural import get_by_id
+    row = await get_by_id(db, proc_id)
+    source = json.loads(row["source"])
+    assert source["type"] == "explicit_teach"
+
+
+@pytest.mark.asyncio
+async def test_auto_extracted_source_persisted(db):
+    """Auto-extracted procedures record triage outcome in source."""
+    proc_id = await store_procedure(
+        db, task_type="extracted-task", principle="test",
+        steps=["s1"], tools_used=["Bash"], context_tags=["test"],
+        source={"type": "auto_extracted", "triage_outcome": "approach_failure"},
+    )
+    from genesis.db.crud.procedural import get_by_id
+    row = await get_by_id(db, proc_id)
+    source = json.loads(row["source"])
+    assert source["type"] == "auto_extracted"
+    assert source["triage_outcome"] == "approach_failure"
+
+
+@pytest.mark.asyncio
+async def test_null_provenance_backward_compat(db):
+    """Old rows with NULL source/promotion_history still work."""
+    # Insert row without new columns (simulating pre-migration data)
+    await db.execute(
+        "INSERT INTO procedural_memory "
+        "(id, task_type, principle, steps, tools_used, context_tags, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("old-row", "old-task", "p", "[]", "[]", '["old"]', "2026-01-01"),
+    )
+    await db.commit()
+
+    # All existing operations should work
+    from genesis.db.crud.procedural import get_by_id
+    row = await get_by_id(db, "old-row")
+    assert row["source"] is None
+    assert row["promotion_history"] is None
+
+    # record_success should work on rows without provenance
+    result = await record_success(db, "old-row")
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_promoter_records_promotion_history(db):
+    """Promotion appends to promotion_history JSON."""
+    from genesis.learning.procedural.promoter import promote_and_demote
+
+    proc_id = await store_procedure(
+        db, task_type="promotable", principle="test",
+        steps=["s1"], tools_used=["Bash"], context_tags=["test"],
+        speculative=0, success_count=5, confidence=0.78,
+        activation_tier="L4",
+    )
+    result = await promote_and_demote(db)
+    assert result["promotions"] >= 1
+
+    from genesis.db.crud.procedural import get_by_id
+    row = await get_by_id(db, proc_id)
+    history = json.loads(row["promotion_history"])
+    assert len(history) >= 1
+    assert history[0]["from_tier"] == "L4"
+    assert history[0]["reason"] == "metrics_promotion"

--- a/tests/test_learning/test_procedural.py
+++ b/tests/test_learning/test_procedural.py
@@ -500,6 +500,8 @@ async def test_null_provenance_backward_compat(db):
 @pytest.mark.asyncio
 async def test_promoter_records_promotion_history(db):
     """Promotion appends to promotion_history JSON."""
+    from unittest.mock import AsyncMock, patch
+
     from genesis.learning.procedural.promoter import promote_and_demote
 
     proc_id = await store_procedure(
@@ -508,7 +510,9 @@ async def test_promoter_records_promotion_history(db):
         speculative=0, success_count=5, confidence=0.78,
         activation_tier="L4",
     )
-    result = await promote_and_demote(db)
+    # Mock regenerate to avoid clobbering the filesystem trigger cache
+    with patch("genesis.learning.procedural.promoter.regenerate", new_callable=AsyncMock):
+        result = await promote_and_demote(db)
     assert result["promotions"] >= 1
 
     from genesis.db.crud.procedural import get_by_id


### PR DESCRIPTION
## Summary

- **Skip per-step approval**: Task executor steps no longer require individual Telegram approval — task submission is the approval
- **Sequential execution**: `asyncio.Semaphore(1)` enforces one task at a time, preventing racy concurrent dict mutations
- **Task switching**: Pausing a task releases the semaphore so another queued task can run
- **DB-persisted pause**: PAUSED state survives server restarts via `recover_incomplete()`
- **Semaphore safety**: Explicit acquire/release with `_semaphore_released` tracking prevents overflow on cancel-during-pause

## Files changed

- `src/genesis/autonomy/executor/step_dispatcher.py` — `approval_required_for_cli=False`
- `src/genesis/autonomy/executor/engine.py` — Semaphore param, release/acquire in `_checkpoint()`, `_semaphore_released` tracking
- `src/genesis/autonomy/dispatcher.py` — `_guarded_execute()`, PAUSED recovery in `recover_incomplete()`
- `src/genesis/runtime/init/tasks.py` — Create and wire `asyncio.Semaphore(1)`

## Test plan

- [x] `ruff check` clean on all changed files
- [x] 161/162 executor tests pass (1 pre-existing `/tmp` watchdog race)
- [x] Full suite passed (exit code 0)
- [x] Architecture review: critical semaphore overflow bug found and fixed
- [x] Code audit: cancel-during-pause path verified safe after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)