### PR TITLE
fix(perception): reduce repetitive micro reflections

### DIFF
--- a/src/genesis/awareness/scorer.py
+++ b/src/genesis/awareness/scorer.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 # ─── Staleness decay ────────────────────────────────────────────────────────
 _DECAY_BASE = 0.5   # halve contribution each unchanged tick
-_DECAY_FLOOR = 0.25  # never decay below 25% (was 5%, too aggressive — nullified PR #65 scoring overhaul)
+_DECAY_FLOOR = 0.10  # never decay below 10% (was 25%, stuck signals triggered micro every ~30min; was 5%, too aggressive)
 _EPSILON = 0.001     # float comparison tolerance for 0-1 normalized signals
 
 # Module-level state: consecutive-unchanged count per signal.

--- a/src/genesis/awareness/scorer.py
+++ b/src/genesis/awareness/scorer.py
@@ -6,7 +6,7 @@ Staleness decay: signals whose value hasn't changed since the previous tick
 get exponentially reduced weight contribution. This prevents permanently-stuck
 signals (e.g. critical_failure=1.0 for hours) from triggering reflections
 every tick. First occurrence = full weight; each consecutive unchanged tick
-halves the contribution, flooring at 25%.
+halves the contribution, flooring at 10%.
 """
 
 from __future__ import annotations

--- a/src/genesis/awareness/signals.py
+++ b/src/genesis/awareness/signals.py
@@ -254,6 +254,7 @@ class StrategicTimerCollector:
             value=round(value, 3),
             source="clock",
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note="Time since last strategic reflection. 0.0=recent, 1.0=15+ days overdue",
         )
 
 
@@ -283,6 +284,7 @@ class ContainerMemoryCollector:
             normal_max=0.80,
             warning_threshold=0.85,
             critical_threshold=0.90,
+            baseline_note="Includes page cache; 70-80% is normal for containerized workloads",
         )
 
 
@@ -319,6 +321,7 @@ class ProcessHealthCollector:
                 name=self.signal_name, value=value, source="process",
                 collected_at=datetime.now(UTC).isoformat(),
                 warning_threshold=0.3, critical_threshold=0.5,
+                baseline_note="0=no browsers (normal idle). 1-2 during active browsing is expected",
             )
         except Exception:
             logger.error("ProcessHealthCollector failed", exc_info=True)
@@ -376,6 +379,7 @@ class JobHealthCollector:
             value=round(value, 3),
             source="runtime",
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note="0.0=all jobs healthy. Brief spikes normal after restart",
         )
 
 
@@ -439,6 +443,7 @@ class SchedulerLivenessCollector:
             return SignalReading(
                 name=self.signal_name, value=0.0, source="runtime",
                 collected_at=now.isoformat(),
+                baseline_note="0.0=scheduler active. Rises if surplus jobs stop running",
             )
 
         return SignalReading(

--- a/src/genesis/awareness/types.py
+++ b/src/genesis/awareness/types.py
@@ -28,6 +28,7 @@ class SignalReading:
     normal_max: float | None = None  # values at or below this are normal
     warning_threshold: float | None = None  # values at or above this warrant attention
     critical_threshold: float | None = None  # values at or above this are critical
+    baseline_note: str | None = None  # human-readable "what's normal" for LLM context
 
 
 @dataclass(frozen=True)

--- a/src/genesis/cc/reflection_bridge/_prompts.py
+++ b/src/genesis/cc/reflection_bridge/_prompts.py
@@ -38,6 +38,8 @@ def _format_signal(s: SignalReading, *, unchanged_ticks: int = 0) -> str:
             else "normal"
         )
         base += f" [{status}]"
+    if s.baseline_note:
+        base += f" -- baseline: {s.baseline_note}"
     if unchanged_ticks >= 2:
         hours = unchanged_ticks * _TICK_INTERVAL_MINUTES / 60
         base += f" (persistent ~{hours:.1f}h)"

--- a/src/genesis/learning/signals/autonomy_activity.py
+++ b/src/genesis/learning/signals/autonomy_activity.py
@@ -74,4 +74,5 @@ class AutonomyActivityCollector:
             value=value,
             source=source,
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note="0.0=stable autonomy (normal). 0.3=corrections accumulating, 0.7=near regression, 1.0=active regression",
         )

--- a/src/genesis/learning/signals/budget.py
+++ b/src/genesis/learning/signals/budget.py
@@ -34,4 +34,5 @@ class BudgetCollector:
             value=value,
             source="cost_events",
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note="Daily budget consumption fraction. 0.0-0.5 normal for first half of day",
         )

--- a/src/genesis/learning/signals/cc_version.py
+++ b/src/genesis/learning/signals/cc_version.py
@@ -93,6 +93,7 @@ class CCVersionCollector:
                 value=1.0,
                 source="cc_version",
                 collected_at=now,
+                baseline_note="1.0=CC version just changed (event signal, resets to 0.0 next tick)",
             )
 
         # No local change — check if a newer version is available on npm.
@@ -106,6 +107,7 @@ class CCVersionCollector:
             value=0.0,
             source="cc_version",
             collected_at=now,
+            baseline_note="0.0=no version change (normal). 1.0=CC just updated",
         )
 
     async def _get_cc_version(self) -> str:

--- a/src/genesis/learning/signals/conversation.py
+++ b/src/genesis/learning/signals/conversation.py
@@ -51,6 +51,7 @@ class ConversationCollector:
             value=round(value, 3),
             source="cc_sessions",
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note="0.0=no conversations since last reflection (normal off-hours). 0.3-0.5=typical active period",
         )
 
     def _count_jsonl_turns(self, cutoff: str) -> int:

--- a/src/genesis/learning/signals/critical_failure.py
+++ b/src/genesis/learning/signals/critical_failure.py
@@ -42,4 +42,5 @@ class CriticalFailureCollector:
             value=value,
             source="health_probes",
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note="0.0=all providers reachable (healthy). 0.5=degraded, 1.0=provider down",
         )

--- a/src/genesis/learning/signals/error_spike.py
+++ b/src/genesis/learning/signals/error_spike.py
@@ -56,4 +56,5 @@ class ErrorSpikeCollector:
             value=value,
             source="observations",
             collected_at=now.isoformat(),
+            baseline_note="0.0=no error spike (normal). Fires when hourly errors exceed 3x daily baseline",
         )

--- a/src/genesis/learning/signals/genesis_version.py
+++ b/src/genesis/learning/signals/genesis_version.py
@@ -164,6 +164,7 @@ class GenesisVersionCollector:
             return SignalReading(
                 name=self.signal_name, value=1.0,
                 source="genesis_version", collected_at=now_iso,
+                baseline_note="1.0=Genesis version just changed or upstream update available",
             )
 
         # ── Self-throttled remote check ──────────────────────────────
@@ -187,6 +188,7 @@ class GenesisVersionCollector:
                     return SignalReading(
                         name=self.signal_name, value=1.0,
                         source="genesis_version", collected_at=now_iso,
+                        baseline_note="1.0=upstream update available",
                     )
             except Exception:
                 logger.error("Upstream check failed", exc_info=True)
@@ -195,6 +197,7 @@ class GenesisVersionCollector:
         return SignalReading(
             name=self.signal_name, value=0.0,
             source="genesis_version", collected_at=now_iso,
+            baseline_note="0.0=up to date (normal). 1.0=update available or just applied",
         )
 
     # ── Git operations ────────────────────────────────────────────────

--- a/src/genesis/learning/signals/guardian_activity.py
+++ b/src/genesis/learning/signals/guardian_activity.py
@@ -73,4 +73,5 @@ class GuardianActivityCollector:
             value=value,
             source=source,
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note="0.0=heartbeat fresh <5min (healthy). 0.5=stale 5-30min, 1.0=very stale >30min",
         )

--- a/src/genesis/learning/signals/light_cascade.py
+++ b/src/genesis/learning/signals/light_cascade.py
@@ -59,4 +59,5 @@ class LightCascadeCollector:
             value=round(value, 3),
             source="awareness_ticks",
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note="Light ticks since last Deep. 0.0=Deep just ran, 1.0=3+ light ticks without deep",
         )

--- a/src/genesis/learning/signals/memory_backlog.py
+++ b/src/genesis/learning/signals/memory_backlog.py
@@ -33,4 +33,5 @@ class MemoryBacklogCollector:
             value=value,
             source="observations",
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note="Unprocessed observations from last 7 days. Low values normal; rises if retrieval pipeline stalls",
         )

--- a/src/genesis/learning/signals/micro_cascade.py
+++ b/src/genesis/learning/signals/micro_cascade.py
@@ -56,4 +56,5 @@ class MicroCascadeCollector:
             value=round(value, 3),
             source="awareness_ticks",
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note="Micro ticks since last Light. 0.0=Light just ran, 1.0=5+ micro ticks without light",
         )

--- a/src/genesis/learning/signals/outreach_engagement.py
+++ b/src/genesis/learning/signals/outreach_engagement.py
@@ -25,12 +25,14 @@ class OutreachEngagementCollector:
             "GROUP BY engagement_outcome"
         )
         rows = await cursor.fetchall()
+        note = "Engagement ratio from last 7 days of outreach. 0.0=no outreach or no engagement"
         if not rows:
             return SignalReading(
                 name=self.signal_name,
                 value=0.0,
                 source="outreach_history",
                 collected_at=datetime.now(UTC).isoformat(),
+                baseline_note=note,
             )
         total = sum(r[1] for r in rows)
         engaged = sum(r[1] for r in rows if r[0] == "engaged")
@@ -40,4 +42,5 @@ class OutreachEngagementCollector:
             value=value,
             source="outreach_history",
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note=note,
         )

--- a/src/genesis/learning/signals/pending_items.py
+++ b/src/genesis/learning/signals/pending_items.py
@@ -82,4 +82,5 @@ class PendingItemCollector:
             value=value,
             source=source,
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note="0.0=no stale pending items. Rises when follow-ups/tasks age past 3 days without resolution",
         )

--- a/src/genesis/learning/signals/recon_findings.py
+++ b/src/genesis/learning/signals/recon_findings.py
@@ -31,4 +31,5 @@ class ReconFindingsCollector:
             value=value,
             source="observations",
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note="Unresolved recon findings. 0.0=none pending (normal). Normalized against ceiling of 10",
         )

--- a/src/genesis/learning/signals/sentinel_activity.py
+++ b/src/genesis/learning/signals/sentinel_activity.py
@@ -48,4 +48,5 @@ class SentinelActivityCollector:
             value=value,
             source="sentinel_state",
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note="0.0=healthy (normal). 0.3=investigating, 0.7=remediating, 1.0=escalated",
         )

--- a/src/genesis/learning/signals/surplus_activity.py
+++ b/src/genesis/learning/signals/surplus_activity.py
@@ -79,4 +79,5 @@ class SurplusActivityCollector:
             value=value,
             source=source,
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note="0.0=idle or healthy (normal). 0.5=concerning failure rate, 0.8=stuck task, 1.0=broken",
         )

--- a/src/genesis/learning/signals/task_quality.py
+++ b/src/genesis/learning/signals/task_quality.py
@@ -41,4 +41,5 @@ class TaskQualityCollector:
             value=value,
             source="execution_traces",
             collected_at=datetime.now(UTC).isoformat(),
+            baseline_note="0.0=no failures in last 24h (or no tasks ran). Failure rate of recent task executions",
         )

--- a/src/genesis/perception/context.py
+++ b/src/genesis/perception/context.py
@@ -422,6 +422,8 @@ class ContextAssembler:
                     f" [{status}; normal<={s.normal_max},"
                     f" warn>={s.warning_threshold}, crit>={s.critical_threshold}]"
                 )
+            if s.baseline_note:
+                line += f" -- baseline: {s.baseline_note}"
             unchanged = staleness.get(s.name, 0)
             if unchanged >= 2:
                 hours = unchanged * tick_interval_min / 60

--- a/src/genesis/perception/templates/micro/analyst.txt
+++ b/src/genesis/perception/templates/micro/analyst.txt
@@ -6,6 +6,8 @@ You are a signal classifier for an autonomous AI system. Classify these signals.
 ## Task
 Classify these signals. Focus on what has CHANGED — new anomalies, trend shifts, or signals crossing thresholds. If all signals are stable and unchanged from typical baseline, respond with salience 0.0 and an empty tags list. Do NOT repeat observations about stable, expected states. Look for cross-signal patterns that individual thresholds wouldn't catch.
 
+Signals marked "-- baseline:" include what's normal for this system. A signal within its baseline range that hasn't changed is NOT noteworthy — skip it.
+
 Assess overall salience (0.0-1.0). Flag any anomalies.
 
 Respond in JSON:

--- a/src/genesis/perception/templates/micro/contrarian.txt
+++ b/src/genesis/perception/templates/micro/contrarian.txt
@@ -6,6 +6,8 @@ You are a signal classifier for an autonomous AI system. Assume these signals ar
 ## Task
 Look for anything that deviates from expected patterns. What would a careful observer notice that a casual one would miss? Focus on what has CHANGED — if everything truly is normal and unchanged, respond with salience 0.0 and an empty tags list rather than restating known-stable conditions. Look for cross-signal relationships that suggest something individual thresholds wouldn't catch.
 
+Signals marked "-- baseline:" include what's normal for this system. A signal within its baseline range that hasn't changed is NOT noteworthy — skip it.
+
 Respond in JSON:
 {{
   "tags": ["tag1", "tag2"],

--- a/src/genesis/perception/templates/micro/curiosity.txt
+++ b/src/genesis/perception/templates/micro/curiosity.txt
@@ -6,6 +6,8 @@ You are a signal classifier for an autonomous AI system. What is the most intere
 ## Task
 Look for patterns, connections, or implications that aren't obvious at first glance. Focus on what is NEW or CHANGING — not what is stable. If nothing novel stands out, respond with salience 0.0 and an empty tags list. Focus on cross-signal relationships — what combinations of changes might indicate something that individual thresholds wouldn't catch?
 
+Signals marked "-- baseline:" include what's normal for this system. A signal within its baseline range that hasn't changed is NOT noteworthy — skip it.
+
 Respond in JSON:
 {{
   "tags": ["tag1", "tag2"],

--- a/src/genesis/perception/writer.py
+++ b/src/genesis/perception/writer.py
@@ -99,12 +99,11 @@ class ResultWriter:
 
         # Cooldown gate: skip if a micro_reflection was created within the last
         # 20 minutes. Anomalies bypass — same pattern as light reflections (30 min).
-        if not output.anomaly:
-            if await observations.exists_recent_by_type(
-                db, source="reflection", type="micro_reflection", window_minutes=20,
-            ):
-                logger.debug("Micro reflection cooldown: skipping (recent exists within 20m)")
-                return False
+        if not output.anomaly and await observations.exists_recent_by_type(
+            db, source="reflection", type="micro_reflection", window_minutes=20,
+        ):
+            logger.debug("Micro reflection cooldown: skipping (recent exists within 20m)")
+            return False
 
         content = json.dumps({
             "tags": output.tags,

--- a/src/genesis/perception/writer.py
+++ b/src/genesis/perception/writer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
@@ -47,6 +48,17 @@ class ResultWriter:
         """SHA-256 hash for observation dedup."""
         return hashlib.sha256(content.encode()).hexdigest()
 
+    @staticmethod
+    def _normalize_for_dedup(summary: str) -> str:
+        """Strip numbers and normalize whitespace for fuzzy micro dedup.
+
+        "memory at 78% is fine" and "memory at 79% is fine" → same string.
+        """
+        text = summary.lower()
+        text = re.sub(r"-?\d+\.?\d*%?", "N", text)
+        text = re.sub(r"\s+", " ", text).strip()
+        return text
+
     async def write(
         self,
         output: MicroOutput | LightOutput,
@@ -85,6 +97,15 @@ class ResultWriter:
             logger.debug("Micro observation below salience threshold (%.2f), skipping", output.salience)
             return False
 
+        # Cooldown gate: skip if a micro_reflection was created within the last
+        # 20 minutes. Anomalies bypass — same pattern as light reflections (30 min).
+        if not output.anomaly:
+            if await observations.exists_recent_by_type(
+                db, source="reflection", type="micro_reflection", window_minutes=20,
+            ):
+                logger.debug("Micro reflection cooldown: skipping (recent exists within 20m)")
+                return False
+
         content = json.dumps({
             "tags": output.tags,
             "salience": output.salience,
@@ -93,10 +114,17 @@ class ResultWriter:
             "signals_examined": output.signals_examined,
         }, sort_keys=True)
         category = "anomaly" if output.anomaly else "routine"
-        chash = self._content_hash(content)
+
+        # Normalized hash: strips numeric variation from the summary so
+        # "memory at 78% is fine" and "memory at 79% is fine" dedup correctly.
+        # Signal names + anomaly flag are included to preserve structural uniqueness.
+        norm_summary = self._normalize_for_dedup(output.summary)
+        signal_names = ",".join(sorted(s.name for s in tick.signals))
+        norm_key = f"micro:{norm_summary}|{signal_names}|{output.anomaly}"
+        chash = self._content_hash(norm_key)
 
         if await observations.exists_by_hash(db, source="reflection", content_hash=chash, unresolved_only=True):
-            logger.debug("Micro observation dedup: skipping duplicate (hash=%s)", chash[:12])
+            logger.debug("Micro observation dedup: skipping near-duplicate (hash=%s)", chash[:12])
             return False
 
         await observations.create(

--- a/tests/test_awareness/test_scorer.py
+++ b/tests/test_awareness/test_scorer.py
@@ -173,13 +173,13 @@ def test_update_staleness_new_signal():
 
 
 def test_update_staleness_decay_floor():
-    """Decay should not go below the floor (0.25)."""
+    """Decay should not go below the floor (0.10)."""
     _signal_unchanged_counts.clear()
     _signal_unchanged_counts["sig_a"] = 10  # very stale
     current = {"sig_a": 1.0}
     prev = {"sig_a": 1.0}
     factors = _update_staleness(current, prev)
-    assert factors["sig_a"] == 0.25  # floored at 25%
+    assert factors["sig_a"] == 0.10  # floored at 10%
 
 
 def test_get_staleness_context_returns_copy():

--- a/tests/test_perception/test_writer.py
+++ b/tests/test_perception/test_writer.py
@@ -420,3 +420,114 @@ async def test_micro_boundary_salience_stored(db):
 
     rows = await observations.query(db, source="reflection", type="micro_reflection")
     assert len(rows) == 1
+
+
+# ── Normalized dedup tests ───────────────────────────────────────────────
+
+
+def test_normalize_for_dedup_strips_numbers():
+    """Numeric variation should be collapsed."""
+    from genesis.perception.writer import ResultWriter
+
+    n = ResultWriter._normalize_for_dedup
+    assert n("memory at 78% is fine") == n("memory at 79% is fine")
+    assert n("CPU 0.45 stable") == n("CPU 0.83 stable")
+    assert n("3 of 5 signals healthy") == n("2 of 5 signals healthy")
+
+
+def test_normalize_for_dedup_preserves_structure():
+    """Structurally different summaries should NOT collapse."""
+    from genesis.perception.writer import ResultWriter
+
+    n = ResultWriter._normalize_for_dedup
+    assert n("memory is fine") != n("cpu is fine")
+    assert n("all systems nominal") != n("anomaly detected in network")
+
+
+async def test_micro_normalized_dedup_catches_near_duplicate(db):
+    """Near-identical summaries differing only in numbers should dedup."""
+    from genesis.db.crud import observations
+    from genesis.perception.writer import ResultWriter
+
+    writer = ResultWriter()
+    tick = _make_tick()
+    output1 = MicroOutput(
+        tags=["stable"], salience=0.6, anomaly=False,
+        summary="Memory usage at 78% is within normal range.",
+        signals_examined=5,
+    )
+    output2 = MicroOutput(
+        tags=["stable"], salience=0.62, anomaly=False,
+        summary="Memory usage at 79% is within normal range.",
+        signals_examined=5,
+    )
+
+    await writer.write(output1, Depth.MICRO, tick, db=db)
+    stored = await writer.write(output2, Depth.MICRO, tick, db=db)
+
+    rows = await observations.query(db, source="reflection", type="micro_reflection")
+    assert len(rows) == 1, "Near-duplicate should be caught by normalized hash"
+    assert not stored
+
+
+async def test_micro_cooldown_blocks_rapid_non_anomaly(db):
+    """Non-anomaly micro within 20 min of a recent one should be blocked."""
+    from datetime import UTC, datetime
+
+    from genesis.db.crud import observations
+    from genesis.perception.writer import ResultWriter
+
+    writer = ResultWriter()
+
+    # Insert a recent micro_reflection with current timestamp
+    now = datetime.now(UTC).isoformat()
+    await observations.create(
+        db,
+        id="recent-micro",
+        source="reflection",
+        type="micro_reflection",
+        content='{"summary": "prior"}',
+        priority="low",
+        created_at=now,
+    )
+
+    output = MicroOutput(
+        tags=["stable"], salience=0.6, anomaly=False,
+        summary="Different wording but same state.",
+        signals_examined=5,
+    )
+    stored = await writer.write(output, Depth.MICRO, _make_tick(), db=db)
+
+    assert not stored, "Cooldown should block non-anomaly within 20 min"
+
+
+async def test_micro_cooldown_allows_anomaly(db):
+    """Anomaly bypasses cooldown even if recent micro exists."""
+    from datetime import UTC, datetime
+
+    from genesis.db.crud import observations
+    from genesis.perception.writer import ResultWriter
+
+    writer = ResultWriter()
+
+    now = datetime.now(UTC).isoformat()
+    await observations.create(
+        db,
+        id="recent-micro",
+        source="reflection",
+        type="micro_reflection",
+        content='{"summary": "prior"}',
+        priority="low",
+        created_at=now,
+    )
+
+    output = MicroOutput(
+        tags=["anomaly"], salience=0.8, anomaly=True,
+        summary="Critical failure detected.",
+        signals_examined=5,
+    )
+    stored = await writer.write(output, Depth.MICRO, _make_tick(), db=db)
+
+    assert stored, "Anomaly should bypass cooldown"
+    rows = await observations.query(db, source="reflection", type="micro_reflection")
+    assert len(rows) == 2  # both the prior and the anomaly


### PR DESCRIPTION
## Summary

Three interventions to reduce repetitive micro reflections (7-19x/day of the
same signals being restated with slightly different wording):

- **Staleness decay floor 0.25→0.10**: Stuck signals can no longer trigger micro
  reflections on their own. Three mid-weight stuck signals now contribute 0.145
  (below 0.30 threshold), vs 0.36 at the old floor.
- **20-min cooldown + normalized hash dedup**: Micro reflections now have a
  cooldown gate (like light already has at 30 min). Normalized hash strips
  numbers from summaries so "memory at 78%" and "memory at 79%" dedup correctly.
  Anomalies bypass both gates.
- **Baseline notes on all signals**: Every signal collector now includes a
  `baseline_note` describing what's normal. LLM sees these inline and the micro
  templates instruct it to skip signals within baseline range.

## Test plan

- [x] All 1474 tests pass (1 pre-existing failure in `test_pr_opener` unrelated)
- [x] Ruff lint clean
- [x] New tests: `_normalize_for_dedup`, near-duplicate dedup, cooldown blocking,
  cooldown anomaly bypass (5 tests added)
- [x] Scorer floor test updated (0.25→0.10)
- [x] Code review: no bugs, no GROUNDWORK deletions, no security concerns
- [ ] Monitor micro reflection count/day for 24-48h post-deploy (target: <5/day)
- [ ] Verify anomaly detection still works via manual trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)