### PR TITLE
feat(perception): reflection rebalancing -- relevance tags + user signals

### DIFF
--- a/.claude/skills/voice-master/SKILL.md
+++ b/.claude/skills/voice-master/SKILL.md
@@ -9,6 +9,17 @@ description: >
   or any output the user hasn't asked to be written in their voice.
 ---
 
+## Companion Files
+
+This is the **project-level** skill (workflow + AI-tell audit rules). The
+**user-level** companion at `~/.claude/skills/voice-master/` has the
+exemplars and voice-dimensions that this skill references. Always load
+both locations when using this skill:
+
+- **Exemplars:** `~/.claude/skills/voice-master/exemplars/` (index.md,
+  social.md, professional.md, longform.md)
+- **Voice dimensions:** `~/.claude/skills/voice-master/voice-dimensions.md`
+
 ## Overview
 
 Generates content that sounds like the user — not an AI impression of the
@@ -66,6 +77,9 @@ Before delivering, scan the output and eliminate any of the following:
 
 **Banned words and phrases:**
 - delve, leverage, utilize, ensure, robust, seamless, streamline
+- clean (as filler/intensifier, e.g. "clean architecture" — OK for
+  literal cleanliness), smoking gun, landscape, ecosystem (when not
+  literal), holistic, synergy, empower, elevate, harness, foster
 - it's worth noting, it is important to note, it's important to
 - in conclusion, in summary, to summarize
 - cutting-edge, game-changing, transformative, revolutionary
@@ -77,6 +91,15 @@ Before delivering, scan the output and eliminate any of the following:
 - Three-part lists that follow the exact same grammatical structure
 - Passive voice overuse ("it was determined," "it should be noted")
 - Rhetorical questions that aren't genuinely rhetorical
+- Em-dash overuse and wrong format. Two rules, both hard:
+  1. **Format:** `--` with NO spaces on either side. Not `--` with spaces.
+     Not the Unicode `—`. Not ` — `. Just `--` butted up against the words.
+     Wrong: `the memory, the learning loop, the reflection cycles -- Get those`
+     Right: `the memory, the learning loop, the reflection cycles--Get those`
+     Actually: don't write that at all. Use a period instead.
+  2. **Frequency:** Reach for a comma, period, colon, or semicolon first.
+     Every time. Em-dashes are for emphasis or asides where nothing else fits.
+     Max 1-2 per page, not per paragraph. Stacking them is an AI fingerprint.
 - Hedging openers ("It's worth considering that...")
 - Sycophantic acknowledgments before answering
 

--- a/scripts/test_linkedin_post.py
+++ b/scripts/test_linkedin_post.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""End-to-end LinkedIn post verification script.
+
+Verifies that the distribution module (PR #182) can actually publish to
+and delete from LinkedIn via the Composio SDK.
+
+Usage:
+    python scripts/test_linkedin_post.py
+    python scripts/test_linkedin_post.py --delete <post_id>
+    python scripts/test_linkedin_post.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+
+def load_secrets() -> None:
+    """Load secrets.env into the process environment."""
+    secrets_path = Path.home() / "genesis" / "secrets.env"
+    if not secrets_path.exists():
+        print(f"[ERROR] secrets.env not found at {secrets_path}")
+        sys.exit(1)
+
+    with open(secrets_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            # Strip inline comments and quotes
+            value = value.split("#")[0].strip().strip('"').strip("'")
+            if key and value:
+                os.environ.setdefault(key, value)
+
+    print(f"[OK] Loaded secrets from {secrets_path}")
+
+
+TEST_CONTENT = (
+    "Most people think the hard part of building an autonomous agent is the AI. "
+    "It's not. It's the infrastructure underneath it -- the memory, the learning loop, "
+    "the reflection cycles. Get those wrong and the AI has nothing real to think with."
+)
+
+
+async def run_publish(dry_run: bool = False) -> str | None:
+    """Publish a test post and return the post_id."""
+    # Import after secrets are loaded
+    from genesis.distribution.config import load_distribution_config
+    from genesis.distribution.linkedin import LinkedInDistributor
+
+    config = load_distribution_config()
+    li_config = config.linkedin
+
+    print(f"\n--- LinkedIn Config ---")
+    print(f"  connected_account_id : {li_config.connected_account_id or '(empty)'}")
+    print(f"  author_urn           : {li_config.author_urn or '(empty)'}")
+    print(f"  user_id              : {li_config.user_id}")
+    print(f"  COMPOSIO_API_KEY     : {'set' if os.environ.get('COMPOSIO_API_KEY') else 'MISSING'}")
+
+    distributor = LinkedInDistributor(config=li_config)
+
+    if not distributor.available:
+        print("\n[FAIL] Distributor not available. Missing config or COMPOSIO_API_KEY.")
+        print("  Check ~/.genesis/config/distribution.yaml and secrets.env")
+        sys.exit(1)
+
+    print(f"\n[OK] Distributor initialized. Platform: {distributor.platform}")
+
+    if dry_run:
+        print(f"\n[DRY RUN] Would publish with CONNECTIONS visibility:")
+        print(f"  Content: {TEST_CONTENT}")
+        return None
+
+    print(f"\n[...] Publishing to LinkedIn (visibility=CONNECTIONS)...")
+    result = await distributor.publish(TEST_CONTENT, visibility="CONNECTIONS")
+
+    print(f"\n--- PostResult ---")
+    print(f"  status   : {result.status}")
+    print(f"  post_id  : {result.post_id}")
+    print(f"  url      : {result.url}")
+    print(f"  error    : {result.error}")
+
+    if result.status == "published":
+        print(f"\n[SUCCESS] Post published.")
+        print(f"  URL: {result.url}")
+        print(f"  To delete: python scripts/test_linkedin_post.py --delete {result.post_id}")
+        return result.post_id
+    else:
+        print(f"\n[FAIL] Publish failed: {result.error}")
+        return None
+
+
+async def run_delete(post_id: str) -> None:
+    """Delete a post by ID."""
+    from genesis.distribution.config import load_distribution_config
+    from genesis.distribution.linkedin import LinkedInDistributor
+
+    config = load_distribution_config()
+    distributor = LinkedInDistributor(config=config.linkedin)
+
+    if not distributor.available:
+        print("[FAIL] Distributor not available.")
+        sys.exit(1)
+
+    print(f"[...] Deleting post {post_id}...")
+    ok = await distributor.delete(post_id)
+
+    if ok:
+        print(f"[SUCCESS] Post {post_id} deleted.")
+    else:
+        print(f"[FAIL] Could not delete post {post_id}. May need to delete manually.")
+        sys.exit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Test LinkedIn distribution end-to-end")
+    parser.add_argument("--delete", metavar="POST_ID", help="Delete a post by ID instead of publishing")
+    parser.add_argument("--dry-run", action="store_true", help="Show config and exit without posting")
+    args = parser.parse_args()
+
+    # Add venv site-packages to path if needed
+    venv_site = Path.home() / "genesis" / ".venv" / "lib" / "python3.12" / "site-packages"
+    if venv_site.exists() and str(venv_site) not in sys.path:
+        sys.path.insert(0, str(venv_site))
+
+    # Add genesis src to path
+    src_path = Path.home() / "genesis" / "src"
+    if src_path.exists() and str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
+
+    load_secrets()
+
+    if args.delete:
+        asyncio.run(run_delete(args.delete))
+    else:
+        asyncio.run(run_publish(dry_run=args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/genesis/awareness/signals.py
+++ b/src/genesis/awareness/signals.py
@@ -174,6 +174,24 @@ class AutonomyActivityCollector:
         return _bootstrap_placeholder_reading(self.signal_name, "autonomy")
 
 
+# GROUNDWORK(signal-bootstrap): pre-swap placeholder. Replaced at runtime
+# by genesis.learning.signals.user_goal_staleness.UserGoalStalenessCollector.
+class UserGoalStalenessCollector:
+    signal_name = "user_goal_staleness"
+
+    async def collect(self) -> SignalReading:
+        return _bootstrap_placeholder_reading(self.signal_name, "follow_ups+user_model")
+
+
+# GROUNDWORK(signal-bootstrap): pre-swap placeholder. Replaced at runtime
+# by genesis.learning.signals.user_session_pattern.UserSessionPatternCollector.
+class UserSessionPatternCollector:
+    signal_name = "user_session_pattern"
+
+    async def collect(self) -> SignalReading:
+        return _bootstrap_placeholder_reading(self.signal_name, "cc_sessions")
+
+
 class ErrorSpikeCollector:
     signal_name = "software_error_spike"
 

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1115,6 +1115,9 @@ SIGNAL_WEIGHTS_SEED = [
     ("autonomy_activity", "autonomy", 0.60, 0.60, 0.0, 1.0, '["Micro"]'),
     # 2026-04-17: ghost signal activation — collector already exists, just needs weight
     ("stale_pending_items", "cognitive_state", 0.35, 0.35, 0.0, 1.0, '["Micro"]'),
+    # 2026-04-30: user-facing signals for reflection rebalancing (Phase 2.5b)
+    ("user_goal_staleness", "follow_ups+user_model", 0.40, 0.40, 0.0, 1.0, '["Micro","Light"]'),
+    ("user_session_pattern", "cc_sessions", 0.35, 0.35, 0.0, 1.0, '["Micro","Light"]'),
 ]
 
 DEPTH_THRESHOLDS_SEED = [

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -174,7 +174,9 @@ class GenesisEgoContextBuilder:
         lines = ["## Unresolved Observations (last 48h, max 20)\n"]
 
         try:
-            # Exclude user-world categories (imported from user_context)
+            # Exclude user-world categories and user-only relevance tags.
+            # Genesis ego sees: NULL category, :genesis, :both, and anything
+            # not in _USER_WORLD_CATEGORIES that isn't :user tagged.
             exclude_placeholders = ",".join("?" for _ in _USER_WORLD_CATEGORIES)
             cursor = await self._db.execute(
                 f"SELECT source, type, category, content, priority, created_at "
@@ -182,7 +184,8 @@ class GenesisEgoContextBuilder:
                 f"WHERE resolved = 0 "
                 f"AND created_at >= datetime('now', '-48 hours') "
                 f"AND (category IS NULL "
-                f"     OR category NOT IN ({exclude_placeholders})) "
+                f"     OR (category NOT IN ({exclude_placeholders}) "
+                f"         AND category NOT LIKE '%:user')) "
                 f"AND type != 'escalation_to_user_ego' "
                 f"ORDER BY "
                 f"  CASE priority "

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -186,13 +186,16 @@ class UserEgoContextBuilder:
         lines = ["## User-World Signals (last 7 days, max 15)\n"]
 
         try:
-            # Build category filter
+            # Build category filter — match exact user-world categories
+            # plus composite relevance tags ending in :user or :both
             placeholders = ",".join("?" for _ in _USER_WORLD_CATEGORIES)
             cursor = await self._db.execute(
                 f"SELECT source, type, category, content, priority, created_at "
                 f"FROM observations "
                 f"WHERE resolved = 0 "
-                f"AND category IN ({placeholders}) "
+                f"AND (category IN ({placeholders}) "
+                f"     OR category LIKE '%:user' "
+                f"     OR category LIKE '%:both') "
                 f"AND created_at >= datetime('now', '-7 days') "
                 f"ORDER BY "
                 f"  CASE priority "

--- a/src/genesis/learning/signals/user_goal_staleness.py
+++ b/src/genesis/learning/signals/user_goal_staleness.py
@@ -1,0 +1,139 @@
+"""UserGoalStalenessCollector — signal for stale user goals and projects.
+
+Scans follow-ups with strategy='user_input_needed' and user_model_cache
+active_projects for goals that haven't seen progress.
+
+This is observational only — it reports staleness so the ego can decide
+what (if anything) to do. It does NOT recommend action.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+
+import aiosqlite
+
+from genesis.awareness.types import SignalReading
+
+logger = logging.getLogger(__name__)
+
+# Goals older than this are considered stale
+_STALE_THRESHOLD_DAYS = 7
+# Full staleness at this many days
+_MAX_STALE_DAYS = 14
+
+
+class UserGoalStalenessCollector:
+    """Reports how stale the user's most neglected goal/follow-up is.
+
+    Signal value:
+      0.0 = all goals fresh (recent activity or no goals tracked)
+      0.5 = goals aging past 7 days without user engagement
+      1.0 = 14+ days stale
+    """
+
+    signal_name = "user_goal_staleness"
+
+    def __init__(self, db: aiosqlite.Connection) -> None:
+        self._db = db
+
+    async def collect(self) -> SignalReading:
+        now = datetime.now(UTC)
+
+        # Source 1: follow-ups needing user input
+        follow_up_staleness = await self._check_follow_ups(now)
+
+        # Source 2: active_projects from user_model_cache
+        project_staleness = await self._check_active_projects(now)
+
+        # Take the worse (higher) staleness
+        value = max(follow_up_staleness, project_staleness)
+
+        return SignalReading(
+            name=self.signal_name,
+            value=round(value, 3),
+            source="follow_ups+user_model",
+            collected_at=now.isoformat(),
+            baseline_note=(
+                "0.0=all user goals fresh or none tracked. "
+                "0.5=goals aging 7+ days without engagement. "
+                "1.0=14+ days stale."
+            ),
+        )
+
+    async def _check_follow_ups(self, now: datetime) -> float:
+        """Check follow-ups with strategy='user_input_needed' for staleness."""
+        try:
+            cursor = await self._db.execute(
+                "SELECT created_at FROM follow_ups "
+                "WHERE strategy = 'user_input_needed' "
+                "AND status IN ('pending', 'blocked') "
+                "ORDER BY created_at ASC LIMIT 1"
+            )
+            row = await cursor.fetchone()
+        except Exception:
+            logger.debug("UserGoalStalenessCollector: follow_ups query failed", exc_info=True)
+            return 0.0
+
+        if not row:
+            return 0.0
+
+        try:
+            created_at = datetime.fromisoformat(row[0])
+            if created_at.tzinfo is None:
+                created_at = created_at.replace(tzinfo=UTC)
+        except (ValueError, TypeError):
+            return 0.0
+
+        age_days = (now - created_at).total_seconds() / 86400
+        return self._days_to_signal(age_days)
+
+    async def _check_active_projects(self, now: datetime) -> float:
+        """Check user_model_cache for active_projects and their freshness."""
+        try:
+            cursor = await self._db.execute(
+                "SELECT model_json, synthesized_at FROM user_model_cache "
+                "WHERE id = 'current'"
+            )
+            row = await cursor.fetchone()
+        except Exception:
+            logger.debug("UserGoalStalenessCollector: user_model query failed", exc_info=True)
+            return 0.0
+
+        if not row:
+            return 0.0
+
+        model_json, synthesized_at = row
+        try:
+            model = json.loads(model_json) if model_json else {}
+        except (json.JSONDecodeError, TypeError):
+            return 0.0
+
+        projects = model.get("active_projects")
+        if not projects:
+            return 0.0
+
+        # Use synthesized_at as proxy for last model update
+        try:
+            synth_dt = datetime.fromisoformat(synthesized_at)
+            if synth_dt.tzinfo is None:
+                synth_dt = synth_dt.replace(tzinfo=UTC)
+        except (ValueError, TypeError):
+            return 0.0
+
+        age_days = (now - synth_dt).total_seconds() / 86400
+        # Only flag if the model itself is stale — if it was recently
+        # synthesized, the projects are presumably current
+        return self._days_to_signal(age_days)
+
+    @staticmethod
+    def _days_to_signal(age_days: float) -> float:
+        """Convert age in days to 0.0-1.0 signal value."""
+        if age_days < _STALE_THRESHOLD_DAYS:
+            return 0.0
+        if age_days >= _MAX_STALE_DAYS:
+            return 1.0
+        # Linear interpolation between threshold and max
+        return (age_days - _STALE_THRESHOLD_DAYS) / (_MAX_STALE_DAYS - _STALE_THRESHOLD_DAYS)

--- a/src/genesis/learning/signals/user_session_pattern.py
+++ b/src/genesis/learning/signals/user_session_pattern.py
@@ -1,0 +1,130 @@
+"""UserSessionPatternCollector — signal for user activity rhythm deviation.
+
+Tracks the user's typical foreground session pattern from cc_sessions
+and reports how much current activity deviates from their baseline.
+
+Not an alarm — a deviation could mean vacation, schedule change, or just
+a quiet day. The signal provides data; the ego interprets with context.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+
+from genesis.awareness.types import SignalReading
+
+logger = logging.getLogger(__name__)
+
+# How many days of history to use for baseline
+_BASELINE_WINDOW_DAYS = 14
+# How many recent days to compare against baseline
+_RECENT_WINDOW_DAYS = 2
+
+
+class UserSessionPatternCollector:
+    """Reports deviation from the user's typical session activity.
+
+    Signal value:
+      0.0 = activity matches baseline pattern (or no baseline yet)
+      0.5 = noticeably different from typical (e.g., half the usual sessions)
+      1.0 = significantly unusual (absent when normally active, or vice versa)
+    """
+
+    signal_name = "user_session_pattern"
+
+    def __init__(self, db: aiosqlite.Connection) -> None:
+        self._db = db
+
+    async def collect(self) -> SignalReading:
+        now = datetime.now(UTC)
+
+        baseline_avg = await self._baseline_daily_sessions(now)
+        recent_avg = await self._recent_daily_sessions(now)
+
+        if baseline_avg is None:
+            # Not enough history — no deviation to report
+            return SignalReading(
+                name=self.signal_name,
+                value=0.0,
+                source="cc_sessions",
+                collected_at=now.isoformat(),
+                baseline_note=(
+                    "0.0=typical activity or insufficient history. "
+                    "0.5=noticeably different from usual. "
+                    "1.0=significantly unusual activity pattern."
+                ),
+            )
+
+        # Calculate deviation ratio
+        if baseline_avg < 0.1:
+            # User rarely has foreground sessions — any activity is normal
+            deviation = 0.0
+        else:
+            # How far is recent from baseline? Symmetric: both drops and
+            # surges register, but drops matter more for staleness detection.
+            ratio = recent_avg / baseline_avg
+            if 0.5 <= ratio <= 1.5:
+                # Within 50% of normal — low deviation
+                deviation = abs(1.0 - ratio) * 0.5
+            else:
+                # More than 50% off baseline
+                deviation = min(1.0, abs(1.0 - ratio) * 0.7)
+
+        return SignalReading(
+            name=self.signal_name,
+            value=round(deviation, 3),
+            source="cc_sessions",
+            collected_at=now.isoformat(),
+            baseline_note=(
+                f"Baseline: {baseline_avg:.1f} sessions/day "
+                f"(last {_BASELINE_WINDOW_DAYS}d). "
+                f"Recent: {recent_avg:.1f}/day (last {_RECENT_WINDOW_DAYS}d). "
+                "0.0=typical, 1.0=very unusual."
+            ),
+        )
+
+    async def _baseline_daily_sessions(self, now: datetime) -> float | None:
+        """Average daily foreground sessions over the baseline window."""
+        cutoff = (now - timedelta(days=_BASELINE_WINDOW_DAYS)).isoformat()
+        recent_cutoff = (now - timedelta(days=_RECENT_WINDOW_DAYS)).isoformat()
+        try:
+            cursor = await self._db.execute(
+                "SELECT COUNT(*) FROM cc_sessions "
+                "WHERE source_tag = 'foreground' "
+                "AND started_at >= ? "
+                "AND started_at < ?",
+                (cutoff, recent_cutoff),
+            )
+            row = await cursor.fetchone()
+        except Exception:
+            logger.debug("UserSessionPatternCollector: baseline query failed", exc_info=True)
+            return None
+
+        count = row[0] if row else 0
+        window_days = _BASELINE_WINDOW_DAYS - _RECENT_WINDOW_DAYS
+        if window_days <= 0 or count < 3:
+            # Need at least 3 sessions to establish a baseline
+            return None
+
+        return count / window_days
+
+    async def _recent_daily_sessions(self, now: datetime) -> float:
+        """Average daily foreground sessions in the recent window."""
+        cutoff = (now - timedelta(days=_RECENT_WINDOW_DAYS)).isoformat()
+        try:
+            cursor = await self._db.execute(
+                "SELECT COUNT(*) FROM cc_sessions "
+                "WHERE source_tag = 'foreground' "
+                "AND started_at >= ?",
+                (cutoff,),
+            )
+            row = await cursor.fetchone()
+        except Exception:
+            logger.debug("UserSessionPatternCollector: recent query failed", exc_info=True)
+            return 0.0
+
+        count = row[0] if row else 0
+        return count / _RECENT_WINDOW_DAYS

--- a/src/genesis/perception/writer.py
+++ b/src/genesis/perception/writer.py
@@ -25,6 +25,24 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Signals that track user activity/outcomes (vs Genesis infrastructure).
+# Used to determine relevance tagging on micro reflections.
+_USER_FACING_SIGNALS = frozenset({
+    "conversations_since_reflection",
+    "task_completion_quality",
+    "recon_findings_pending",
+    "stale_pending_items",
+    "user_goal_staleness",
+    "user_session_pattern",
+})
+
+# Light reflection focus_area → relevance mapping
+_LIGHT_FOCUS_RELEVANCE: dict[str, str] = {
+    "user_impact": "user",
+    "situation": "both",
+    "anomaly": "genesis",
+}
+
 
 class ResultWriter:
     """Stores reflection outputs to the database and emits events.
@@ -47,6 +65,17 @@ class ResultWriter:
     def _content_hash(content: str) -> str:
         """SHA-256 hash for observation dedup."""
         return hashlib.sha256(content.encode()).hexdigest()
+
+    @staticmethod
+    def _relevance_from_signals(tick: TickResult) -> str:
+        """Determine relevance tag from tick signals: 'user', 'genesis', or 'both'."""
+        has_user = any(s.name in _USER_FACING_SIGNALS for s in tick.signals)
+        has_genesis = any(s.name not in _USER_FACING_SIGNALS for s in tick.signals)
+        if has_user and has_genesis:
+            return "both"
+        if has_user:
+            return "user"
+        return "genesis"
 
     @staticmethod
     def _normalize_for_dedup(summary: str) -> str:
@@ -112,7 +141,9 @@ class ResultWriter:
             "summary": output.summary,
             "signals_examined": output.signals_examined,
         }, sort_keys=True)
-        category = "anomaly" if output.anomaly else "routine"
+        base_category = "anomaly" if output.anomaly else "routine"
+        relevance = self._relevance_from_signals(tick)
+        category = f"{base_category}:{relevance}"
 
         # Normalized hash: strips numeric variation from the summary so
         # "memory at 78% is fine" and "memory at 79% is fine" dedup correctly.
@@ -182,12 +213,16 @@ class ResultWriter:
         }, sort_keys=True)
         chash = self._content_hash(content)
 
+        light_relevance = _LIGHT_FOCUS_RELEVANCE.get(output.focus_area, "both")
+        light_category = f"{output.focus_area}:{light_relevance}"
+
         if not await observations.exists_by_hash(db, source="reflection", content_hash=chash, unresolved_only=True):
             await observations.create(
                 db,
                 id=str(uuid.uuid4()),
                 source="reflection",
                 type="light_reflection",
+                category=light_category,
                 content=content,
                 priority="medium",
                 created_at=tick.timestamp,
@@ -336,6 +371,7 @@ class ResultWriter:
                 id=str(uuid.uuid4()),
                 source="reflection",
                 type="user_model_delta",
+                category="user_model_delta",
                 content=delta_content,
                 priority="medium",
                 created_at=tick.timestamp,

--- a/src/genesis/runtime/init/awareness.py
+++ b/src/genesis/runtime/init/awareness.py
@@ -33,6 +33,8 @@ async def init(rt: GenesisRuntime) -> None:
             StrategicTimerCollector,
             SurplusActivityCollector,
             TaskQualityCollector,
+            UserGoalStalenessCollector,
+            UserSessionPatternCollector,
         )
 
         collectors = [
@@ -53,6 +55,8 @@ async def init(rt: GenesisRuntime) -> None:
             SurplusActivityCollector(),
             AutonomyActivityCollector(),
             ProcessHealthCollector(),
+            UserGoalStalenessCollector(),
+            UserSessionPatternCollector(),
         ]
 
         rt._awareness_loop = AwarenessLoop(

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -66,6 +66,12 @@ async def init(rt: GenesisRuntime) -> None:
                 SurplusActivityCollector,
             )
             from genesis.learning.signals.task_quality import TaskQualityCollector
+            from genesis.learning.signals.user_goal_staleness import (
+                UserGoalStalenessCollector,
+            )
+            from genesis.learning.signals.user_session_pattern import (
+                UserSessionPatternCollector,
+            )
             from genesis.observability.health import (
                 probe_db,
                 probe_ollama,
@@ -108,6 +114,8 @@ async def init(rt: GenesisRuntime) -> None:
                     pipeline_getter=lambda: rt._outreach_pipeline,
                 ),
                 ProcessHealthCollector(),
+                UserGoalStalenessCollector(rt._db),
+                UserSessionPatternCollector(rt._db),
             ]
             rt._awareness_loop.replace_collectors(collectors)
             logger.info("Installed %d signal collectors", len(collectors))

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -96,9 +96,9 @@ async def test_no_unexpected_tables(db):
 async def test_signal_weights_seeded(db):
     cursor = await db.execute("SELECT COUNT(*) FROM signal_weights")
     count = (await cursor.fetchone())[0]
-    # 10 → 16 on 2026-04-17: +6 new signals (light_cascade, sentinel,
-    # guardian, surplus, autonomy activity, stale_pending_items).
-    assert count == 16
+    # 16 → 18 on 2026-04-30: +2 user-facing signals (user_goal_staleness,
+    # user_session_pattern) for reflection rebalancing Phase 2.5b.
+    assert count == 18
 
 
 async def test_signal_weights_values(db):
@@ -301,8 +301,8 @@ async def test_seed_is_idempotent(db):
     await seed_data(db)
     await db.commit()
     cursor = await db.execute("SELECT COUNT(*) FROM signal_weights")
-    # 10 → 16 on 2026-04-17: +6 new signals (awareness scoring overhaul).
-    assert (await cursor.fetchone())[0] == 16
+    # 16 → 18 on 2026-04-30: +2 user-facing signals (Phase 2.5b).
+    assert (await cursor.fetchone())[0] == 18
     cursor = await db.execute("SELECT COUNT(*) FROM drive_weights")
     assert (await cursor.fetchone())[0] == 4
 

--- a/tests/test_db/test_signal_weights.py
+++ b/tests/test_db/test_signal_weights.py
@@ -5,8 +5,8 @@ from genesis.db.crud import signal_weights
 
 async def test_list_all(db):
     rows = await signal_weights.list_all(db)
-    # 10 → 16 on 2026-04-17: +6 new signals (awareness scoring overhaul).
-    assert len(rows) == 16
+    # 16 → 18 on 2026-04-30: +2 user-facing signals (Phase 2.5b).
+    assert len(rows) == 18
 
 
 async def test_get_existing(db):

--- a/tests/test_perception/test_writer.py
+++ b/tests/test_perception/test_writer.py
@@ -61,7 +61,7 @@ async def test_write_micro_anomaly_tags_observation(db):
 
     obs = await observations.query(db, source="reflection")
     assert len(obs) == 1
-    assert obs[0]["category"] == "anomaly"
+    assert obs[0]["category"] == "anomaly:genesis"
 
 
 async def test_write_light_creates_observation(db):


### PR DESCRIPTION
## Summary

- **Phase 2.5a**: Tag every reflection observation with relevance (`user`/`genesis`/`both`) via composite categories (e.g., `routine:genesis`, `user_impact:user`). Ego context queries filter on suffix so each ego sees the right observations. Fixes user_model_delta observations missing category (were silently falling through to genesis ego).
- **Phase 2.5b**: Two new user-facing signal collectors -- `user_goal_staleness` (scans follow-ups + user_model_cache, 7-14 day ramp) and `user_session_pattern` (compares recent 2-day activity against 14-day baseline). Both wired end-to-end: placeholder, awareness init, real impl, learning init, signal weight seed.

Addresses the reflection pipeline imbalance where the User Ego was starved of input (56% of signals were genesis-internal, user-facing data barely reached the user ego).

## Changes

| File | What |
|------|------|
| `perception/writer.py` | `_USER_FACING_SIGNALS` set, `_relevance_from_signals()`, composite categories on micro + light + user_model_delta |
| `ego/user_context.py` | Query now matches `:user` and `:both` suffixed categories |
| `ego/genesis_context.py` | Query now excludes `:user` suffixed categories |
| `awareness/signals.py` | Placeholder classes for both new collectors |
| `runtime/init/awareness.py` | Register placeholders in Phase 1 bootstrap |
| `runtime/init/learning.py` | Register real impls in Phase 2 swap |
| `learning/signals/user_goal_staleness.py` | New collector |
| `learning/signals/user_session_pattern.py` | New collector |
| `db/schema/_tables.py` | Signal weight seeds (16 → 18) |
| 3 test files | Updated assertions for new categories and signal count |

## Test plan

- [x] `ruff check` clean
- [x] 3 previously failing tests fixed and passing (56/56 in targeted run)
- [x] Full suite: 6010 passed, 5 pre-existing failures (dashboard template + browser CDP, unrelated)
- [ ] Observe after deploy: verify micro/light observations get composite categories in production
- [ ] Verify user ego context includes reflection observations tagged `:user`/`:both`

🤖 Generated with [Claude Code](https://claude.com/claude-code)