### PR TITLE
feat(infra): unified code intelligence guide + soft discovery hooks

### DIFF
--- a/.claude/docs/code-intelligence-guide.md
+++ b/.claude/docs/code-intelligence-guide.md
@@ -1,7 +1,7 @@
-# Code Intelligence — Decision Guide
+# Code Intelligence — Deep Reference
 
-Three tools for code understanding. Each has a sweet spot — use the
-lightest tool that answers the question.
+Detailed reference for Serena, GitNexus, and codebase-memory-mcp.
+For the quick decision matrix, see: `.claude/docs/code-intelligence.md`
 
 ## When to Use Which
 

--- a/.claude/docs/code-intelligence.md
+++ b/.claude/docs/code-intelligence.md
@@ -58,3 +58,8 @@ run `index_repository` manually.
 
 **Grep/Glob/Read** — Always available, zero overhead. Preferred for config
 files, markdown, YAML, JSON, shell scripts, SQL, and any non-code content.
+
+---
+
+For deep GitNexus reference (Cypher syntax, edge types, MCP resources,
+graph schema): `.claude/docs/code-intelligence-guide.md`

--- a/.claude/docs/code-intelligence.md
+++ b/.claude/docs/code-intelligence.md
@@ -1,0 +1,60 @@
+# Code Intelligence — Decision Guide
+
+Four tool layers for code search and analysis, lightest to richest.
+Use the lightest layer that answers your question.
+
+## Tool Layers
+
+| Layer | Tools | Scope | Best for |
+|-------|-------|-------|----------|
+| **1. Text search** | Grep, Glob, Read | All files | String patterns, config, docs, non-code, known file paths |
+| **2. Serena** | `mcp__serena__*` | Python only | Symbol definitions, references, type hierarchies, safe rename/refactor |
+| **3. codebase-memory-mcp** | `mcp__codebase-memory-mcp__*` | 66 languages | Code graph, architecture overview, call tracing, cross-language search |
+| **4. GitNexus** | `mcp__gitnexus__*` | Git + graph | Blast radius, impact analysis, execution flows, rename across codebase |
+
+## Decision Matrix
+
+| Question | Tool | Call |
+|----------|------|------|
+| "Where is this config value set?" | Grep | `Grep(pattern, glob="*.yaml")` |
+| "What files match this name?" | Glob | `Glob(pattern)` |
+| "Read this specific file" | Read | `Read(file_path)` |
+| "Where is class X defined?" | Serena | `find_symbol(name_path="X", include_body=True)` |
+| "What methods does class X have?" | Serena | `find_symbol(name_path="X", depth=1)` |
+| "Who calls function Y?" | Serena | `find_referencing_symbols(name_path="Y")` |
+| "What's the project architecture?" | CBM | `get_architecture(aspects=["overview"])` |
+| "Find all functions related to Z" | CBM | `search_graph(name_pattern="Z")` |
+| "Trace the call chain from A to B" | CBM | `trace_path(function_name="A")` |
+| "What would break if I change file F?" | GitNexus | `impact(path="F")` |
+| "Show execution flow through endpoint" | GitNexus | `route_map(path="src/...")` |
+| "Rename symbol across the codebase" | Serena (Python) / GitNexus (any) | `rename_symbol` / `rename` |
+
+## When Tools Overlap
+
+- **Finding Python callers**: Serena `find_referencing_symbols` (LSP-precise)
+  vs CBM `trace_path` (graph-based, cross-language). Serena is more precise
+  for Python; CBM works across languages and shows the full chain.
+- **Symbol lookup**: Serena `find_symbol` (type signatures, containing class)
+  vs CBM `search_graph` (label/pattern-based, all languages). Use Serena
+  for Python type info; CBM for broader structural search.
+- **Rename**: Serena `rename_symbol` (LSP-safe, Python only) vs GitNexus
+  `rename` (git-aware, any language). Serena for Python refactors;
+  GitNexus when you need blast-radius awareness.
+
+## Per-Tool Notes
+
+**Serena** — 1-2s LSP init on first call per session, then fast. Config:
+`.serena/project.yml`. Python-only (Pyright). Does not follow mock patterns
+in tests. Use Grep for non-Python files.
+
+**codebase-memory-mcp** — Tree-sitter code graph, SQLite index (~48MB for
+Genesis). Supports 66 languages. 3D visualization at `localhost:9749`.
+Index rebuilds automatically on each commit (post-commit hook). If stale,
+run `index_repository` manually.
+
+**GitNexus** — LadybugDB graph. `query` tool (FTS) is broken on Linux
+(known issue). Other tools (`impact`, `route_map`, `api_impact`, `rename`,
+`context`) work fine. Auto-reindexes on commit.
+
+**Grep/Glob/Read** — Always available, zero overhead. Preferred for config
+files, markdown, YAML, JSON, shell scripts, SQL, and any non-code content.

--- a/.claude/docs/serena-guide.md
+++ b/.claude/docs/serena-guide.md
@@ -1,33 +1,4 @@
 # Serena — Decision Guide
 
-Serena is an MCP server providing LSP-powered code intelligence via Pyright.
-Available as `mcp__serena__*` tools. Complements Grep, does not replace it.
-
-## When to Use Serena
-
-- "Where is this class/function wired in?" → `find_referencing_symbols`
-- "What's the definition and signature?" → `find_symbol` with `include_body`
-- "What methods does this class have?" → `find_symbol` with `depth=1`
-- Architectural traversal — dependency injection patterns, type hierarchies
-- Safe refactoring — `rename_symbol`, `replace_symbol_body`
-
-## When to Use Grep Instead
-
-- String patterns, comments, config files, migrations, YAML/JSON
-- Test files using mocks (Pyright doesn't follow mock patterns)
-- Anything outside Python semantics (shell scripts, HTML templates, SQL)
-
-## When to Use the AST Code Index
-
-Tables: `code_modules` / `code_symbols`
-
-- Lightweight structural queries (module counts, symbol stats)
-- Proactive hook enrichment (runs every prompt — must be fast)
-- Package-level summaries
-
-## Key Behaviors
-
-- 1-2s one-time LSP init per session, then fast
-- Returns semantic context (symbol kind, type signatures, containing class)
-- Distinguishes `TYPE_CHECKING` imports from runtime imports
-- Config: `.serena/project.yml`
+Serena guidance is now part of the unified code intelligence guide.
+See: `.claude/docs/code-intelligence.md`

--- a/.claude/hooks/cbm-discovery-gate.sh
+++ b/.claude/hooks/cbm-discovery-gate.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Code intelligence discovery gate — soft nudge for code exploration.
+#
+# Fires on PreToolUse for Read/Grep/Glob. Suggests codebase-memory-mcp,
+# Serena, or GitNexus for code files. Silently passes through for config,
+# docs, and non-code files.
+#
+# NEVER blocks (always exit 0). Uses additionalContext for soft tips.
+# Nudges once per session via sentinel file.
+#
+# Replaces the global ~/.claude/hooks/cbm-code-discovery-gate which
+# hard-blocked (exit 2) every Read/Grep call regardless of file type.
+
+set -u
+
+# ── Session-once gate ──────────────────────────────────────────────────
+# CC spawns each hook as a new bash process, so $$ and $PPID differ per
+# invocation. Use $CLAUDE_SESSION_ID (set by CC) when available, else
+# fall back to a project-dir + date hash for once-per-day-per-project.
+if [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
+    GATE_KEY="$CLAUDE_SESSION_ID"
+else
+    GATE_KEY="$(echo "${PWD:-unknown}-$(date +%Y%m%d)" | md5sum | cut -c1-16)"
+fi
+GATE="/tmp/cbm-discovery-gate-${GATE_KEY}"
+if [[ -f "$GATE" ]]; then
+    exit 0  # already nudged this session
+fi
+
+# Clean up old gate files (>1 day)
+find /tmp -maxdepth 1 -name 'cbm-discovery-gate-*' -mtime +1 -delete 2>/dev/null || true
+
+# ── Parse stdin to determine the target file ───────────────────────────
+INPUT=$(cat)
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)
+FILE_PATH=""
+
+case "$TOOL_NAME" in
+    Read)
+        FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)
+        ;;
+    Grep)
+        FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.path // empty' 2>/dev/null || true)
+        ;;
+    Glob)
+        FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.path // empty' 2>/dev/null || true)
+        ;;
+esac
+
+# ── Skip nudge for non-code files ─────────────────────────────────────
+# Config, docs, markdown, JSON, YAML, shell, text, TOML, env files
+# are best handled by Grep/Read directly — no nudge needed.
+if [[ -n "$FILE_PATH" ]]; then
+    case "$FILE_PATH" in
+        *.md|*.json|*.yaml|*.yml|*.toml|*.txt|*.sh|*.bash|*.env|*.cfg|*.ini|*.conf|*.csv|*.lock|*.sql)
+            exit 0  # non-code file, pass through silently
+            ;;
+        */plans/*|*/.claude/*|*/settings*|*/config/*|*/CLAUDE.md|*/.serena/*|*/.gitnexus/*)
+            exit 0  # known config/meta paths, pass through silently
+            ;;
+    esac
+fi
+
+# If Grep with no path (searching whole repo), or Read on a code file,
+# or Glob searching for code patterns — nudge once.
+touch "$GATE"
+
+# Emit soft tip via additionalContext (never blocks)
+cat << 'TIPJSON'
+{"additionalContext": "Tip: For code exploration, consider using code intelligence tools — Serena (Python symbols), codebase-memory-mcp (code graph, architecture), or GitNexus (impact analysis). See .claude/docs/code-intelligence.md for the full decision matrix."}
+TIPJSON
+
+exit 0

--- a/.claude/hooks/cbm-session-reminder.sh
+++ b/.claude/hooks/cbm-session-reminder.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Code intelligence session reminder — lists available tool layers.
+#
+# Fires on SessionStart (startup/resume/clear/compact).
+# Informational only, points to the full decision guide.
+
+cat << 'REMINDER'
+Code intelligence tools available:
+1. Grep/Glob/Read — text search, file patterns, configs, docs
+2. Serena (mcp__serena__*) — Python LSP: symbols, references, rename
+3. codebase-memory-mcp — 66-language code graph: search_graph, trace_path, get_architecture
+4. GitNexus (mcp__gitnexus__*) — blast radius, impact analysis, execution flows
+Decision guide: .claude/docs/code-intelligence.md
+REMINDER

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,46 @@
             "timeout": 5000
           }
         ]
+      },
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_DIR}/.claude/hooks/cbm-session-reminder.sh",
+            "timeout": 2000
+          }
+        ]
+      },
+      {
+        "matcher": "resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_DIR}/.claude/hooks/cbm-session-reminder.sh",
+            "timeout": 2000
+          }
+        ]
+      },
+      {
+        "matcher": "clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_DIR}/.claude/hooks/cbm-session-reminder.sh",
+            "timeout": 2000
+          }
+        ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_DIR}/.claude/hooks/cbm-session-reminder.sh",
+            "timeout": 2000
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [
@@ -77,6 +117,16 @@
           {
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook procedure_advisor.py",
+            "timeout": 2000
+          }
+        ]
+      },
+      {
+        "matcher": "Read|Grep|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_DIR}/.claude/hooks/cbm-discovery-gate.sh",
             "timeout": 2000
           }
         ]

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -114,6 +114,18 @@ Full syntax, Cypher examples, and decision matrix:
   fires. Use `CronTrigger` for anything longer than a few hours.
   Bit us with `user_model_evolution` (48h interval, daily restarts).
 
+### Code Discovery
+
+Use the right tool for how you're exploring:
+
+- **Architecture overview** — CBM `get_architecture(aspects=["overview"])`
+- **Finding symbols** — CBM `search_graph(name_pattern="...")` or Serena `find_symbol`
+- **Call tracing** — CBM `trace_path(function_name="...")` or Serena `find_referencing_symbols`
+- **Impact before changes** — GitNexus `impact(path="...")`
+- **Config/doc/non-code files** — Grep/Read directly
+
+Full decision matrix: `.claude/docs/code-intelligence.md`
+
 ## Adaptive Review Protocol
 
 Choose the review level proportional to the change:
@@ -162,6 +174,7 @@ references on every trigger.
 | V3 state, build order, GROUNDWORK, architecture docs | `references/architecture.md` |
 | Phase 6 contribution pipeline, sanitizer | `references/contribution.md` |
 | Pending work, active incidents, subsystem status | `references/build-state.md` |
+| Which code tool to use (CBM vs Serena vs GitNexus vs Grep) | `.claude/docs/code-intelligence.md` |
 
 **Freshness rule:** On first read of `codebase-map.md` in a session,
 verify structural claims against current code. If a package status or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,14 +61,13 @@ systemctl --user status genesis-server            # Verify server running
 
 ## Code Intelligence
 
-Three tools — use the lightest that answers the question:
+Four tool layers for code search and analysis, lightest to richest:
 
-- **Grep/Glob** — text patterns, any file type. Always available.
-- **Serena** (LSP/Pyright) — Python: definitions, references, type
-  hierarchies, safe rename. `mcp__serena__*` tools.
-- **GitNexus** (knowledge graph) — structural: impact analysis, execution
-  flows, community detection, route/tool mapping, change detection.
-  CLI: `gitnexus <command>`. ~34K nodes, ~51K edges.
+1. **Grep/Glob/Read** — text search, file patterns, direct reads. Configs, docs, non-code.
+2. **Serena** (`mcp__serena__*`) — Python LSP. Symbol lookup, references, type hierarchies, safe rename.
+3. **codebase-memory-mcp** (`mcp__codebase-memory-mcp__*`) — 66-language code graph. search_graph, trace_path, get_architecture.
+4. **GitNexus** (`mcp__gitnexus__*`) — blast radius, impact analysis, execution flows, rename.
+   CLI: `gitnexus <command>`. ~34K nodes, ~51K edges.
 
 **When to reach for GitNexus (all session types):**
 - Before editing code: `gitnexus impact <symbol>` for blast radius
@@ -88,8 +87,7 @@ Three tools — use the lightest that answers the question:
 **Known limitation:** FTS text search is broken on Linux
 (LadybugDB/ladybug#430). Use Grep/Serena for text search.
 
-Full syntax, Cypher examples, edge types, and decision matrix:
-`.claude/docs/code-intelligence-guide.md`
+Full decision matrix: `.claude/docs/code-intelligence.md`
 
 ## Skill Library
 


### PR DESCRIPTION
## Summary

- **Created `.claude/docs/code-intelligence.md`** — unified decision guide covering all 4 tool layers (Grep/Glob/Read, Serena, codebase-memory-mcp, GitNexus) with decision matrix and overlap notes
- **Replaced `.claude/docs/serena-guide.md`** with pointer to the unified guide
- **Updated `CLAUDE.md`** — "Serena" section → "Code Intelligence" section listing all 4 layers
- **Updated `genesis-development` SKILL.md** — added Reference Router row + Code Discovery section with per-tool recommendations
- **Created `.claude/hooks/cbm-discovery-gate.sh`** — soft nudge (never blocks) for code file exploration, skips non-code files (.md, .json, .yaml, etc.), once per session
- **Created `.claude/hooks/cbm-session-reminder.sh`** — informational session start message listing all 4 tool layers
- **Registered both hooks** in project-level `.claude/settings.json`

Replaces the aggressive global CBM hooks (installed by `codebase-memory-mcp` installer) that hard-blocked every Read/Grep/Glob call regardless of file type. Global hooks have been removed from this install; the new project-level hooks are version-controlled and go to the public repo.

## Test plan

- [ ] Read a `.md` file — succeeds without nudge
- [ ] Read a `.py` file — succeeds with soft "Tip:" in additionalContext (never blocks)
- [ ] Second code file read — succeeds silently (gate already fired)
- [ ] Session start text lists all 4 tool layers
- [ ] CLAUDE.md shows "Code Intelligence" with all 4 layers
- [ ] genesis-development skill has Code Discovery section

🤖 Generated with [Claude Code](https://claude.com/claude-code)