### PR TITLE
fix(resilience): memory metric, tmp pressure axis, phantom L2

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -302,10 +302,14 @@ call_sites:
     chain:
     - claude-opus
     default_paid: true
+    dispatch: cli
+    cc_model: Opus
   16_quality_calibration:
     chain:
-    - claude-opus
+    - claude-sonnet
     default_paid: true
+    dispatch: cli
+    cc_model: Sonnet
   17_fresh_eyes_review:
     chain:
     - openrouter-deepseek-v4
@@ -335,13 +339,18 @@ call_sites:
     - groq-free
   27_pre_execution_assessment:
     chain:
-    - claude-sonnet
-    - claude-haiku
+    - minimax-m25
+    - deepseek-chat
+    - glm5
     default_paid: true
     retry_profile: user_facing
   28_observation_sweep:
     chain:
-    - claude-sonnet
+    - minimax-m25
+    - deepseek-chat
+    - glm5
+    - groq-free
+    - gemini-free
     default_paid: true
   29_retrospective_triage:
     chain:

--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -44,8 +44,22 @@ dir_usage_mb() {
 }
 
 tmp_usage_pct() {
-    # Percentage of /tmp filesystem used
-    df --output=pcent /tmp 2>/dev/null | tail -1 | tr -d ' %' || echo 0
+    if df -T /tmp 2>/dev/null | grep -q tmpfs; then
+        # tmpfs: filesystem percentage is meaningful
+        df --output=pcent /tmp 2>/dev/null | tail -1 | tr -d ' %' || echo 0
+    else
+        # Not tmpfs (/tmp on root disk): use absolute free space thresholds.
+        # Danger is the same regardless of disk size — CC sessions need ~60MB
+        # each, sacred ground is 150MB.  Percentage-based thresholds are
+        # meaningless when measuring the whole root filesystem.
+        local free_mb
+        free_mb=$(df -BM --output=avail /tmp 2>/dev/null | tail -1 | tr -d ' M' || echo 9999)
+        if (( free_mb > 2048 )); then echo 0       # >2GB free  → green
+        elif (( free_mb > 1024 )); then echo 60     # 1-2GB free → yellow
+        elif (( free_mb > 500 )); then echo 75      # 500M-1GB  → orange
+        else echo 90                                 # <500MB    → red
+        fi
+    fi
 }
 
 fs_free_mb() {

--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -262,26 +262,26 @@ class WatchdogChecker:
     def _check_memory_pressure(self) -> None:
         """Proactive memory check — reclaim page cache if approaching limit.
 
-        Runs every watchdog cycle (60s). Prevents the OOM cascade where ghost
-        page cache from killed sessions accumulates and triggers increasingly
-        rapid OOM kills.
+        Runs every watchdog cycle (60s). Uses anon+kernel memory (non-reclaimable)
+        for threshold decisions. Total cgroup usage (memory.current) includes
+        reclaimable page cache, which inflates the metric and causes false alarms.
         """
-        mem = get_container_memory()
+        mem = get_container_anon_memory()
         if mem is None or mem[1] == 0:
             return  # Can't read or no limit set
 
-        current, limit = mem
-        pct = (current / limit) * 100
+        anon_kernel, limit = mem
+        pct = (anon_kernel / limit) * 100
         if pct >= 90:
             logger.error(
-                "Container memory CRITICAL: %.0f%% (%.1f/%.1f GiB) — reclaiming cache",
-                pct, current / (1024**3), limit / (1024**3),
+                "Container memory CRITICAL: %.0f%% anon+kernel (%.1f/%.1f GiB) — reclaiming cache",
+                pct, anon_kernel / (1024**3), limit / (1024**3),
             )
             reclaim_page_cache("256M")
         elif pct >= 80:
             logger.warning(
-                "Container memory HIGH: %.0f%% (%.1f/%.1f GiB) — reclaiming cache",
-                pct, current / (1024**3), limit / (1024**3),
+                "Container memory HIGH: %.0f%% anon+kernel (%.1f/%.1f GiB) — reclaiming cache",
+                pct, anon_kernel / (1024**3), limit / (1024**3),
             )
             reclaim_page_cache("128M")
 
@@ -489,6 +489,32 @@ def get_container_memory() -> tuple[int, int] | None:
         max_raw = Path("/sys/fs/cgroup/memory.max").read_text().strip()
         max_bytes = int(max_raw) if max_raw != "max" else 0
         return current, max_bytes
+    except (OSError, ValueError):
+        return None
+
+
+def get_container_anon_memory() -> tuple[int, int] | None:
+    """Read non-reclaimable container memory (anon + kernel) and limit.
+
+    Unlike ``get_container_memory()`` which reads ``memory.current`` (includes
+    reclaimable page cache), this reads ``memory.stat`` for anon + kernel
+    bytes — the memory that actually matters for OOM risk.
+
+    Returns (anon_plus_kernel_bytes, max_bytes) or None if unavailable.
+    """
+    try:
+        stats: dict[str, int] = {}
+        with open("/sys/fs/cgroup/memory.stat") as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) == 2 and parts[0] in ("anon", "kernel"):
+                    stats[parts[0]] = int(parts[1])
+        if not stats:
+            return None
+        anon_kernel = stats.get("anon", 0) + stats.get("kernel", 0)
+        max_raw = Path("/sys/fs/cgroup/memory.max").read_text().strip()
+        max_bytes = int(max_raw) if max_raw != "max" else 0
+        return anon_kernel, max_bytes
     except (OSError, ValueError):
         return None
 

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -577,6 +577,26 @@ class AwarenessLoop:
                 except Exception:
                     logger.warning("Resilience state update failed", exc_info=True)
 
+            # Update resilience tmp_pressure axis from watchgod state
+            if self._resilience_state_machine:
+                try:
+                    from genesis.observability.service_status import collect_cc_tmp_usage
+                    from genesis.resilience.state import TmpPressureStatus
+
+                    _TIER_TO_TMP = {
+                        "green": TmpPressureStatus.NORMAL,
+                        "yellow": TmpPressureStatus.MODERATE,
+                        "orange": TmpPressureStatus.HIGH,
+                        "red": TmpPressureStatus.CRITICAL,
+                    }
+                    cc_tmp = collect_cc_tmp_usage()
+                    tier = cc_tmp.get("cc_tier", "unknown")
+                    tmp_status = _TIER_TO_TMP.get(tier)
+                    if tmp_status is not None:
+                        self._resilience_state_machine.update_tmp_pressure(tmp_status)
+                except Exception:
+                    logger.debug("tmp_pressure axis update failed", exc_info=True)
+
             # Status file writes are handled by a dedicated loop in
             # runtime/init/memory.py (status-writer-loop). Decoupled from
             # the awareness tick so a slow tick (e.g. long Light reflection)

--- a/src/genesis/awareness/signals.py
+++ b/src/genesis/awareness/signals.py
@@ -258,23 +258,25 @@ class StrategicTimerCollector:
 
 
 class ContainerMemoryCollector:
-    """Reports container memory usage as a percentage of cgroup limit.
+    """Reports non-reclaimable container memory (anon+kernel) as fraction of limit.
 
-    Reads /sys/fs/cgroup/memory.current and memory.max. Returns 0.0–1.0
-    where 1.0 = at the cgroup limit. Returns 0.0 if cgroup info unavailable.
+    Reads anon and kernel from /sys/fs/cgroup/memory.stat + memory.max.
+    Returns 0.0–1.0 where 1.0 = at the cgroup limit. This excludes
+    reclaimable page cache, which inflates memory.current and causes
+    false pressure signals.
     """
 
     signal_name = "container_memory_pct"
 
     async def collect(self) -> SignalReading:
-        from genesis.autonomy.watchdog import get_container_memory
+        from genesis.autonomy.watchdog import get_container_anon_memory
 
-        mem = get_container_memory()
+        mem = get_container_anon_memory()
         if mem is None or mem[1] == 0:
             return _bootstrap_placeholder_reading(self.signal_name, "cgroup")
 
-        current, limit = mem
-        pct = current / limit  # 0.0–1.0
+        anon_kernel, limit = mem
+        pct = anon_kernel / limit  # 0.0–1.0
         return SignalReading(
             name=self.signal_name,
             value=round(pct, 3),

--- a/src/genesis/dashboard/routes/resources.py
+++ b/src/genesis/dashboard/routes/resources.py
@@ -26,19 +26,22 @@ def system_resources():
         logger.error("CPU probe failed", exc_info=True)
         result["cpu"] = {"status": "unavailable", "used_pct": None}
 
-    # Container memory — cgroup-based
+    # Container memory — anon+kernel (non-reclaimable) for status decisions
     try:
-        from genesis.autonomy.watchdog import get_container_memory
+        from genesis.autonomy.watchdog import get_container_anon_memory, get_container_memory
 
-        mem = get_container_memory()
-        if mem and mem[1] > 0:
-            current, limit = mem
-            pct = round(current / limit * 100, 1)
+        anon_mem = get_container_anon_memory()
+        total_mem = get_container_memory()
+        if anon_mem and anon_mem[1] > 0:
+            anon_kernel, limit = anon_mem
+            anon_pct = round(anon_kernel / limit * 100, 1)
+            total_pct = round(total_mem[0] / limit * 100, 1) if total_mem and total_mem[1] > 0 else anon_pct
             result["memory"] = {
-                "status": "healthy" if pct < 85 else ("degraded" if pct < 95 else "critical"),
-                "used_gb": round(current / (1024**3), 1),
+                "status": "healthy" if anon_pct < 85 else ("degraded" if anon_pct < 95 else "critical"),
+                "used_gb": round((total_mem[0] if total_mem else anon_kernel) / (1024**3), 1),
                 "total_gb": round(limit / (1024**3), 1),
-                "used_pct": pct,
+                "used_pct": total_pct,
+                "anon_pct": anon_pct,
             }
         else:
             result["memory"] = {"status": "unavailable"}

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -3461,6 +3461,8 @@
                              ? name + ': ' + probe.free_gb?.toFixed(1) + ' GB free (' + probe.free_pct?.toFixed(0) + '% of ' + probe.total_gb?.toFixed(0) + ' GB)'
                              : probe.total_points != null
                                ? name + ': ' + probe.total_points + ' total points across ' + (probe.collections?.length || 0) + ' collections'
+                             : probe.cc_tier != null
+                               ? name + ': CC ' + probe.cc_tier + ' (' + probe.cc_used_mb + '/' + probe.cc_budget_mb + 'MB)' + (probe.sys_tier ? ', /tmp ' + probe.sys_tier + ' (' + probe.sys_used_pct + '%)' : '')
                              : name + ': ' + (probe.status || 'unknown')">
                     <span class="status-dot"
                           :style="`background: ${$store.genesisDashboard.probeStatusColor(probe)}`"></span>

--- a/src/genesis/guardian/health_signals.py
+++ b/src/genesis/guardian/health_signals.py
@@ -394,21 +394,32 @@ async def check_tick_regularity(config: GuardianConfig) -> SuspiciousResult:
 
 
 async def check_memory_pressure(config: GuardianConfig) -> SuspiciousResult:
-    """Check container memory usage via cgroup v2."""
+    """Check container memory usage via cgroup v2.
+
+    Uses anon+kernel from memory.stat (non-reclaimable) for threshold
+    decisions instead of memory.current (which includes reclaimable page cache).
+    """
     name = "memory_pressure"
     t0 = datetime.now(UTC)
     try:
+        # Read memory.stat for anon+kernel (non-reclaimable memory)
         rc, stdout, stderr = await _run_subprocess(
             "incus", "exec", config.container_name, "--",
-            "cat", "/sys/fs/cgroup/memory.current",
+            "cat", "/sys/fs/cgroup/memory.stat",
             timeout=config.probes.probe_timeout_s,
         )
         if rc != 0:
             return SuspiciousResult(
-                name=name, ok=True, detail=f"cgroup read failed: {stderr[:200]}",
+                name=name, ok=True, detail=f"cgroup stat read failed: {stderr[:200]}",
                 collected_at=t0.isoformat(),
             )
-        current = int(stdout.strip())
+        # Parse anon and kernel values from memory.stat
+        stats: dict[str, int] = {}
+        for line in stdout.splitlines():
+            parts = line.split()
+            if len(parts) == 2 and parts[0] in ("anon", "kernel"):
+                stats[parts[0]] = int(parts[1])
+        anon_kernel = stats.get("anon", 0) + stats.get("kernel", 0)
 
         rc2, stdout2, stderr2 = await _run_subprocess(
             "incus", "exec", config.container_name, "--",
@@ -429,9 +440,9 @@ async def check_memory_pressure(config: GuardianConfig) -> SuspiciousResult:
             )
 
         max_bytes = int(max_mem)
-        pct = (current / max_bytes) * 100 if max_bytes > 0 else 0
+        pct = (anon_kernel / max_bytes) * 100 if max_bytes > 0 else 0
         ok = pct < config.suspicious.memory_warning_pct
-        detail = f"{pct:.1f}% ({current // (1024*1024)}M / {max_bytes // (1024*1024)}M)"
+        detail = f"{pct:.1f}% anon+kernel ({anon_kernel // (1024*1024)}M / {max_bytes // (1024*1024)}M)"
         return SuspiciousResult(
             name=name, ok=ok, detail=detail, collected_at=t0.isoformat(),
         )

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -297,13 +297,15 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
         current_ids.add(alert_id)
 
     container_mem = snap.get("infrastructure", {}).get("container_memory", {})
-    used_pct = container_mem.get("used_pct", 0)
-    if used_pct > 85:
+    # Use anon_pct (non-reclaimable memory) for alerts, not used_pct
+    # (total cgroup including reclaimable page cache).
+    anon_pct = container_mem.get("anon_pct", container_mem.get("used_pct", 0))
+    if anon_pct > 85:
         alert_id = "infra:container_memory_high"
         alerts.append({
             "id": alert_id,
-            "severity": "CRITICAL" if used_pct > 90 else "WARNING",
-            "message": f"Container memory at {used_pct}% ({container_mem.get('current_gb', '?')}/{container_mem.get('limit_gb', '?')}GB)",
+            "severity": "CRITICAL" if anon_pct > 90 else "WARNING",
+            "message": f"Container memory at {anon_pct}% anon+kernel ({container_mem.get('current_gb', '?')}/{container_mem.get('limit_gb', '?')}GB total)",
         })
         current_ids.add(alert_id)
 

--- a/src/genesis/observability/snapshots/api_keys.py
+++ b/src/genesis/observability/snapshots/api_keys.py
@@ -15,7 +15,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _LOCAL_TYPES = frozenset({"ollama", "lmstudio"})
-_CC_MANAGED_TYPES = frozenset({"anthropic"})
+# Anthropic providers require ANTHROPIC_API_KEY when configured as direct
+# API providers (via LiteLLM).  CC-dispatched call sites (dispatch=cli)
+# bypass the provider chain entirely and work regardless.  Previously
+# "anthropic" was exempted here, which caused phantom circuit-breaker
+# failures: providers registered without keys, failed every API call,
+# and counted as "down" — triggering false L2 resilience state.
+_CC_MANAGED_TYPES: frozenset[str] = frozenset()
 
 
 _api_validation_cache: dict[str, dict] = {}

--- a/src/genesis/observability/snapshots/infrastructure.py
+++ b/src/genesis/observability/snapshots/infrastructure.py
@@ -185,20 +185,24 @@ async def infrastructure(
         infra["qdrant_collections"] = {"status": "error", "error": str(exc)}
 
     try:
-        from genesis.autonomy.watchdog import get_container_memory
+        from genesis.autonomy.watchdog import get_container_anon_memory, get_container_memory
 
-        mem = get_container_memory()
-        if mem and mem[1] > 0:
-            current, limit = mem
-            pct = current / limit
+        anon_mem = get_container_anon_memory()
+        total_mem = get_container_memory()
+        if anon_mem and anon_mem[1] > 0:
+            anon_kernel, limit = anon_mem
+            anon_pct = anon_kernel / limit
+            # Status thresholds use anon+kernel (non-reclaimable).
+            # Total cgroup usage (memory.current) is shown for reference
+            # but not used for health decisions — it includes reclaimable
+            # page cache that inflates the metric.
             mem_info: dict = {
-                "status": "healthy" if pct < 0.85 else ("degraded" if pct < 0.95 else "down"),
-                "current_gb": round(current / (1024**3), 1),
+                "status": "healthy" if anon_pct < 0.85 else ("degraded" if anon_pct < 0.95 else "down"),
+                "current_gb": round((total_mem[0] if total_mem else anon_kernel) / (1024**3), 1),
                 "limit_gb": round(limit / (1024**3), 1),
-                "used_pct": round(pct * 100, 1),
+                "used_pct": round((total_mem[0] / limit * 100) if total_mem and total_mem[1] > 0 else anon_pct * 100, 1),
+                "anon_pct": round(anon_pct * 100, 1),
             }
-            # Decompose into anon/file/kernel — "83% memory" is meaningless
-            # without knowing what's reclaimable (incident 2026-04-08)
             mem_info.update(_read_memory_stat())
             infra["container_memory"] = mem_info
         else:

--- a/src/genesis/resilience/state.py
+++ b/src/genesis/resilience/state.py
@@ -47,6 +47,19 @@ class CCStatus(IntEnum):
     NORMAL = 3
 
 
+class TmpPressureStatus(IntEnum):
+    """CC temp directory pressure from watchgod tiers.
+
+    Mapped from watchgod cc_tmp tier (green/yellow/orange/red).
+    Budget is configurable per-install (~/.genesis/config/watchgod.conf),
+    so tiers are relative to the configured budget, not absolute sizes.
+    """
+    CRITICAL = 0   # Red:   >90% or sacred ground breached
+    HIGH = 1       # Orange: 75-90%
+    MODERATE = 2   # Yellow: 50-75%
+    NORMAL = 3     # Green:  <50%
+
+
 # ── Transition record ────────────────────────────────────────────────────────
 
 @dataclass(frozen=True)
@@ -68,6 +81,7 @@ class ResilienceState:
     memory: MemoryStatus = MemoryStatus.NORMAL
     embedding: EmbeddingStatus = EmbeddingStatus.NORMAL
     cc: CCStatus = CCStatus.NORMAL
+    tmp_pressure: TmpPressureStatus = TmpPressureStatus.NORMAL
     timestamp: str = ""
     transitions: list[StateTransition] = field(default_factory=list)
 
@@ -90,6 +104,14 @@ class ResilienceState:
         # Embedding unavailability overrides if worse
         if self.embedding in (EmbeddingStatus.QUEUED, EmbeddingStatus.UNAVAILABLE) and level < DegradationLevel.LOCAL_COMPUTE_DOWN:
             level = DegradationLevel.LOCAL_COMPUTE_DOWN
+
+        # Tmp pressure — CRITICAL maps to L3, HIGH to L2, MODERATE to L1
+        if self.tmp_pressure == TmpPressureStatus.CRITICAL and level < DegradationLevel.ESSENTIAL:
+            level = DegradationLevel.ESSENTIAL
+        elif self.tmp_pressure == TmpPressureStatus.HIGH and level < DegradationLevel.REDUCED:
+            level = DegradationLevel.REDUCED
+        elif self.tmp_pressure == TmpPressureStatus.MODERATE and level < DegradationLevel.FALLBACK:
+            level = DegradationLevel.FALLBACK
 
         return level
 
@@ -122,6 +144,7 @@ class ResilienceStateMachine:
             "memory": _AxisFlap(),
             "embedding": _AxisFlap(),
             "cc": _AxisFlap(),
+            "tmp_pressure": _AxisFlap(),
         }
 
     @property
@@ -135,6 +158,7 @@ class ResilienceStateMachine:
             or self._state.memory != MemoryStatus.NORMAL
             or self._state.embedding != EmbeddingStatus.NORMAL
             or self._state.cc != CCStatus.NORMAL
+            or self._state.tmp_pressure != TmpPressureStatus.NORMAL
         )
 
     def update_cloud(self, status: CloudStatus) -> list[StateTransition]:
@@ -156,6 +180,9 @@ class ResilienceStateMachine:
         # .claude/plans/fluttering-humming-bentley.md for the false-alarm
         # incident that motivated this.)
         return self._update("cc", status, apply_flapping_protection=False)
+
+    def update_tmp_pressure(self, status: TmpPressureStatus) -> list[StateTransition]:
+        return self._update("tmp_pressure", status)
 
     def _update(
         self,

--- a/src/genesis/routing/config.py
+++ b/src/genesis/routing/config.py
@@ -234,11 +234,19 @@ def _parse(raw: dict, *, check_api_keys: bool = True) -> RoutingConfig:
         chain = cs["chain"]
         # Filter out disabled providers from chain
         chain = [p for p in chain if p not in disabled_providers]
+        dispatch = _normalize_dispatch(cs.get("dispatch"), call_site_name=name)
+
         if not chain:
-            logger.warning(
-                "Call site '%s' has no enabled providers — all were disabled", name,
+            # CLI-dispatch call sites don't use the provider chain — they
+            # spawn CC sessions directly.  An empty chain is valid for them.
+            if dispatch != "cli":
+                logger.warning(
+                    "Call site '%s' has no enabled providers — all were disabled", name,
+                )
+                continue
+            logger.info(
+                "Call site '%s' has no API providers but dispatch=cli — keeping", name,
             )
-            continue
         # Validate remaining providers exist
         for provider in chain:
             if provider not in providers:
@@ -252,8 +260,6 @@ def _parse(raw: dict, *, check_api_keys: bool = True) -> RoutingConfig:
                 f"retry profile '{retry_profile}'"
             )
             raise ValueError(msg)
-
-        dispatch = _normalize_dispatch(cs.get("dispatch"), call_site_name=name)
 
         call_sites[name] = CallSiteConfig(
             id=name,

--- a/src/genesis/routing/degradation.py
+++ b/src/genesis/routing/degradation.py
@@ -15,6 +15,17 @@ _L2_SKIP = {"12_surplus_brainstorm", "13_morning_report"}
 # L3 (Essential) only keeps these call sites
 _L3_KEEP = {"2_triage", "3_micro_reflection", "21_embeddings", "22_tagging"}
 
+# Tmp pressure skip lists — separate from cloud degradation because disk
+# pressure requires different shedding than provider outages.
+# MODERATE (yellow): suppress surplus + morning report (same as cloud L2)
+_TMP_MODERATE_SKIP = {"12_surplus_brainstorm", "13_morning_report"}
+# HIGH (orange): also suppress background reflections, ego, calibration, sweeps
+_TMP_HIGH_SKIP = _TMP_MODERATE_SKIP | {
+    "5_deep_reflection", "6_strategic_reflection", "7_ego_cycle",
+    "14_weekly_self_assessment", "16_quality_calibration",
+    "28_observation_sweep",
+}
+
 
 def should_skip_call_site(call_site_id: str, level: DegradationLevel) -> bool:
     """Return True if call_site_id should be skipped at the given degradation level."""
@@ -47,4 +58,17 @@ class DegradationTracker:
         self._level = self._resilience_state.current.to_legacy_degradation_level()
 
     def should_skip(self, call_site_id: str) -> bool:
-        return should_skip_call_site(call_site_id, self._level)
+        # Check cloud/provider-based degradation first
+        if should_skip_call_site(call_site_id, self._level):
+            return True
+        # Check tmp_pressure axis independently
+        if self._resilience_state is not None:
+            from genesis.resilience.state import TmpPressureStatus
+            tmp = self._resilience_state.current.tmp_pressure
+            if tmp == TmpPressureStatus.CRITICAL:
+                return call_site_id not in _L3_KEEP
+            if tmp == TmpPressureStatus.HIGH:
+                return call_site_id in _TMP_HIGH_SKIP
+            if tmp == TmpPressureStatus.MODERATE:
+                return call_site_id in _TMP_MODERATE_SKIP
+        return False

--- a/src/genesis/runtime/init/router.py
+++ b/src/genesis/runtime/init/router.py
@@ -32,7 +32,13 @@ def init(rt: GenesisRuntime) -> None:
         delegate = LiteLLMDelegate(config)
         breakers = CircuitBreakerRegistry(config.providers)
         cost_tracker = CostTracker(db=rt._db, event_bus=rt._event_bus)
-        degradation = DegradationTracker()
+
+        from genesis.resilience.state import ResilienceStateMachine
+
+        rt._resilience_state_machine = ResilienceStateMachine()
+        logger.info("Resilience state machine created")
+
+        degradation = DegradationTracker(resilience_state=rt._resilience_state_machine)
 
         from genesis.routing.dead_letter import DeadLetterQueue
 
@@ -62,11 +68,6 @@ def init(rt: GenesisRuntime) -> None:
         rt._deferred_work_queue = DeferredWorkQueue(
             db=rt._db, event_bus=rt._event_bus,
         )
-
-        from genesis.resilience.state import ResilienceStateMachine
-
-        rt._resilience_state_machine = ResilienceStateMachine()
-        logger.info("Resilience state machine created")
 
         if rt._awareness_loop is not None:
             rt._awareness_loop.set_deferred_queue(rt._deferred_work_queue)

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -378,7 +378,7 @@ class TestMemoryPressureCheck:
     def test_reclaims_at_80_percent(self, tmp_path: Path, fresh_status: Path):
         checker = _make_checker(tmp_path, fresh_status)
         with (
-            patch("genesis.autonomy.watchdog.get_container_memory",
+            patch("genesis.autonomy.watchdog.get_container_anon_memory",
                   return_value=(20_000_000_000, 24_000_000_000)),  # 83%
             patch("genesis.autonomy.watchdog.reclaim_page_cache") as mock_reclaim,
         ):
@@ -388,7 +388,7 @@ class TestMemoryPressureCheck:
     def test_reclaims_256m_at_90_percent(self, tmp_path: Path, fresh_status: Path):
         checker = _make_checker(tmp_path, fresh_status)
         with (
-            patch("genesis.autonomy.watchdog.get_container_memory",
+            patch("genesis.autonomy.watchdog.get_container_anon_memory",
                   return_value=(22_000_000_000, 24_000_000_000)),  # 91%
             patch("genesis.autonomy.watchdog.reclaim_page_cache") as mock_reclaim,
         ):
@@ -398,7 +398,7 @@ class TestMemoryPressureCheck:
     def test_no_reclaim_below_80_percent(self, tmp_path: Path, fresh_status: Path):
         checker = _make_checker(tmp_path, fresh_status)
         with (
-            patch("genesis.autonomy.watchdog.get_container_memory",
+            patch("genesis.autonomy.watchdog.get_container_anon_memory",
                   return_value=(15_000_000_000, 24_000_000_000)),  # 62%
             patch("genesis.autonomy.watchdog.reclaim_page_cache") as mock_reclaim,
         ):
@@ -407,5 +407,5 @@ class TestMemoryPressureCheck:
 
     def test_handles_no_memory_info(self, tmp_path: Path, fresh_status: Path):
         checker = _make_checker(tmp_path, fresh_status)
-        with patch("genesis.autonomy.watchdog.get_container_memory", return_value=None):
+        with patch("genesis.autonomy.watchdog.get_container_anon_memory", return_value=None):
             checker._check_memory_pressure()  # Should not raise

--- a/tests/test_guardian/test_health_signals.py
+++ b/tests/test_guardian/test_health_signals.py
@@ -336,12 +336,13 @@ class TestCheckMemoryPressure:
 
     @pytest.mark.asyncio
     async def test_normal_memory(self, config: GuardianConfig) -> None:
-        # 50% memory usage
+        # 50% memory usage (anon + kernel)
+        stat_output = f"anon 10737418240\nfile 5368709120\nkernel 2147483648\n"
         with patch(
             "genesis.guardian.health_signals._run_subprocess",
             side_effect=[
-                (0, str(12 * 1024**3), ""),  # 12 GiB current
-                (0, str(24 * 1024**3), ""),  # 24 GiB max
+                (0, stat_output, ""),         # memory.stat
+                (0, str(24 * 1024**3), ""),   # 24 GiB max
             ],
         ):
             result = await check_memory_pressure(config)
@@ -350,12 +351,13 @@ class TestCheckMemoryPressure:
 
     @pytest.mark.asyncio
     async def test_high_memory(self, config: GuardianConfig) -> None:
-        # 90% memory usage
+        # 90% memory usage (anon + kernel)
+        stat_output = f"anon 21045339750\nfile 1073741824\nkernel 2147483648\n"
         with patch(
             "genesis.guardian.health_signals._run_subprocess",
             side_effect=[
-                (0, str(int(21.6 * 1024**3)), ""),  # 21.6 GiB current
-                (0, str(24 * 1024**3), ""),           # 24 GiB max
+                (0, stat_output, ""),         # memory.stat
+                (0, str(24 * 1024**3), ""),   # 24 GiB max
             ],
         ):
             result = await check_memory_pressure(config)
@@ -364,10 +366,11 @@ class TestCheckMemoryPressure:
 
     @pytest.mark.asyncio
     async def test_no_limit(self, config: GuardianConfig) -> None:
+        stat_output = f"anon {10 * 1024**3}\nkernel {2 * 1024**3}\n"
         with patch(
             "genesis.guardian.health_signals._run_subprocess",
             side_effect=[
-                (0, str(12 * 1024**3), ""),
+                (0, stat_output, ""),
                 (0, "max", ""),
             ],
         ):


### PR DESCRIPTION
## Summary

- **Memory metric fix**: All health thresholds now use anon+kernel memory (non-reclaimable) instead of total cgroup usage (which includes ~15GB reclaimable page cache). Eliminates false "88% memory" alerts when actual process memory is ~23%.
- **cc_tmp resilience axis**: New `TmpPressureStatus` axis in the resilience state machine, driven by watchgod tiers. Yellow suppresses surplus, orange sheds background work, red blocks non-essential call sites. Budget-relative thresholds adapt to any install size.
- **Phantom L2 fix**: Anthropic API providers without `ANTHROPIC_API_KEY` no longer register in the circuit breaker as "down." Four broken call sites get working provider chains or switch to CC dispatch.

## Changes

| File | Change |
|---|---|
| `src/genesis/observability/snapshots/api_keys.py` | Remove anthropic from `_CC_MANAGED_TYPES` |
| `src/genesis/routing/config.py` | Keep cli-dispatch call sites with empty chains |
| `config/model_routing.yaml` | Fix 4 call site chains (27, 28 → cheap paid; 14, 16 → cli) |
| `src/genesis/autonomy/watchdog.py` | Add `get_container_anon_memory()`, update pressure check |
| `src/genesis/awareness/signals.py` | `ContainerMemoryCollector` uses anon+kernel |
| `src/genesis/observability/snapshots/infrastructure.py` | Add `anon_pct`, use for status |
| `src/genesis/mcp/health/errors.py` | Alert threshold uses `anon_pct` |
| `src/genesis/dashboard/routes/resources.py` | Dashboard API uses anon+kernel for status |
| `src/genesis/guardian/health_signals.py` | Host-side check parses `memory.stat` |
| `src/genesis/resilience/state.py` | Add `TmpPressureStatus` enum + axis |
| `src/genesis/routing/degradation.py` | Tmp-specific call site skip lists |
| `src/genesis/awareness/loop.py` | Wire watchgod tier → tmp_pressure axis per tick |
| `src/genesis/runtime/init/router.py` | Wire RSM into DegradationTracker |

## Test plan

- [x] 332 targeted tests pass (routing, resilience, watchdog)
- [x] 5961 full suite pass, 0 new failures
- [x] Ruff clean (0 new lint errors)
- [ ] Verify dashboard shows `anon_pct` after server restart
- [ ] Verify resilience level clears from L2 after server restart
- [ ] Verify tmp_pressure axis appears in resilience state

🤖 Generated with [Claude Code](https://claude.com/claude-code)