### PR TITLE
fix(dashboard): display anon_pct for memory gauge

### DIFF
--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -3895,15 +3895,15 @@
             </div>
             <div class="health-card-value" style="display:flex; flex-direction:column; gap:0.35rem;">
               <!-- Memory row -->
-              <template x-if="$store.genesisDashboard.health.infrastructure?.container_memory?.used_pct != null">
+              <template x-if="($store.genesisDashboard.health.infrastructure?.container_memory?.anon_pct ?? $store.genesisDashboard.health.infrastructure?.container_memory?.used_pct) != null">
                 <div style="display:flex; align-items:center; gap:0.5rem; font-size:0.8rem;">
                   <span style="width:3.2rem; color:var(--color-text-secondary);">Memory</span>
                   <span style="width:3rem; text-align:right; font-weight:600;"
-                        :style="`color: ${$store.genesisDashboard.health.infrastructure.container_memory.used_pct > 85 ? '#d9534f' : $store.genesisDashboard.health.infrastructure.container_memory.used_pct > 75 ? '#f0ad4e' : '#4caf50'}`"
-                        x-text="$store.genesisDashboard.health.infrastructure.container_memory.used_pct.toFixed(0) + '%'"></span>
+                        :style="(() => { const p = $store.genesisDashboard.health.infrastructure.container_memory.anon_pct ?? $store.genesisDashboard.health.infrastructure.container_memory.used_pct; return `color: ${p > 85 ? '#d9534f' : p > 75 ? '#f0ad4e' : '#4caf50'}`; })()"
+                        x-text="(($store.genesisDashboard.health.infrastructure.container_memory.anon_pct ?? $store.genesisDashboard.health.infrastructure.container_memory.used_pct) || 0).toFixed(0) + '%'"></span>
                   <div style="flex:1; height:6px; background:var(--color-background); border-radius:3px; min-width:40px;">
                     <div style="height:100%; border-radius:3px; transition:width 0.3s;"
-                         :style="'width:' + $store.genesisDashboard.health.infrastructure.container_memory.used_pct + '%; background:' + ($store.genesisDashboard.health.infrastructure.container_memory.used_pct > 85 ? '#d9534f' : $store.genesisDashboard.health.infrastructure.container_memory.used_pct > 75 ? '#f0ad4e' : '#4caf50')"></div>
+                         :style="(() => { const p = $store.genesisDashboard.health.infrastructure.container_memory.anon_pct ?? $store.genesisDashboard.health.infrastructure.container_memory.used_pct ?? 0; return 'width:' + p + '%; background:' + (p > 85 ? '#d9534f' : p > 75 ? '#f0ad4e' : '#4caf50'); })()"></div>
                   </div>
                   <span style="font-size:0.7rem; color:var(--color-text-secondary); white-space:nowrap;"
                         x-text="$store.genesisDashboard.health.infrastructure.container_memory.current_gb?.toFixed(0) + '/' + $store.genesisDashboard.health.infrastructure.container_memory.limit_gb?.toFixed(0) + ' GB'"></span>


### PR DESCRIPTION
## Summary

- Memory gauge and semantic state were reading `used_pct` (total cgroup = 77%) instead of `anon_pct` (non-reclaimable = 21%)
- All references updated with `anon_pct ?? used_pct` fallback for backward compat

Follow-up to PR #201 which added `anon_pct` to the backend but didn't update the frontend display.

## Test plan

- [x] Dashboard loads without JS errors
- [ ] Memory gauge shows ~21% instead of ~77%
- [ ] Memory bar color is green (under 75%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)