### PR TITLE
feat(ego): approval gate fix, reflection rebalancing, context enrichment

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -96,8 +96,10 @@ Full syntax, Cypher examples, and decision matrix:
 
 ### Common Traps
 
-- **Ego sessions are inert.** `src/genesis/ego/` exists but has zero
-  production callers. Don't wire them; don't treat them as broken.
+- **Ego sessions are ACTIVE.** `src/genesis/ego/` is live (v3.0a11).
+  Two egos: user ego (CEO, Opus) and Genesis ego (COO, Sonnet). Both
+  run on adaptive cadence via the awareness loop. Changes here are
+  production changes.
 - **DB path confusion.** `genesis.db` is at `~/genesis/data/genesis.db`,
   NOT `~/genesis/genesis.db`. Use `genesis.env.genesis_db_path()`.
 - **Column names.** Use `db_schema` MCP before assuming column names.

--- a/.claude/skills/genesis-development/references/architecture.md
+++ b/.claude/skills/genesis-development/references/architecture.md
@@ -5,8 +5,9 @@
 Genesis core is feature-complete. Preparing for V4 work (meta-prompting,
 adaptive weights, channel learning, L5+ autonomy).
 
-**Ego sessions** (`src/genesis/ego/`) are built but **inert until beta**.
-Not registered in bootstrap; disabled by default.
+**Ego sessions** (`src/genesis/ego/`) are **ACTIVE** (v3.0a11, PRs #26/#27).
+Two egos: user ego (CEO, Opus) and Genesis ego (COO, Sonnet). Registered
+in bootstrap, running on adaptive cadence via the awareness loop.
 
 ## Groundwork Code Protection
 

--- a/.claude/skills/genesis-development/references/codebase-map.md
+++ b/.claude/skills/genesis-development/references/codebase-map.md
@@ -21,7 +21,7 @@ things, and what trips developers up repeatedly.
 | `outreach/` | Governance gate, draft/deliver pipeline, engagement tracker, scheduler | ACTIVE |
 | `autonomy/` | Levels L1-L4, action classifier, approval flow, task verifier | ACTIVE |
 | `skills/` | 20+ internal skills (evaluate, research, osint, forecasting, etc.) | ACTIVE |
-| `ego/` | Ego sessions, adaptive backoff, circuit breaker | **INERT** |
+| `ego/` | Ego sessions (user ego + genesis ego), adaptive cadence, proposals, dispatch | **ACTIVE** |
 | `providers/` | Provider registry (web search, STT, TTS, embeddings, health) | ACTIVE |
 | `research/` | Web search + URL fetch via SearXNG+Brave, Gemini YouTube routing | ACTIVE |
 | `mail/` | Gmail monitor (weekly poll), two-layer triage (Gemini + CC) | ACTIVE |

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ scripts/cops_interop.sh
 # Stealth browser skill + research (private — lives at ~/.genesis/skills/)
 src/genesis/skills/stealth-browser/
 .gitnexus
+
+# Personal skills (user-level data, lives at ~/.claude/skills/)
+.claude/skills/code-voice/

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -354,7 +354,7 @@ class GenesisEgoContextBuilder:
 
         try:
             cursor = await self._db.execute(
-                "SELECT action_type, action_category, content, status, "
+                "SELECT action_type, content, status, "
                 "user_response, created_at "
                 "FROM ego_proposals "
                 "WHERE created_at >= datetime('now', '-7 days') "
@@ -370,9 +370,18 @@ class GenesisEgoContextBuilder:
             lines.append("*No proposals in last 7 days.*\n")
             return "\n".join(lines)
 
+        # Summary line for quick calibration
+        from collections import Counter
+        status_counts = Counter(r[2] for r in rows)
+        parts = [f"{status_counts[s]} {s}" for s in
+                 ("approved", "rejected", "executed", "pending", "failed",
+                  "expired", "tabled", "withdrawn")
+                 if status_counts.get(s)]
+        lines.append(f"**{len(rows)} proposals**: {', '.join(parts)}\n")
+
         lines.append("| Action | Content | Status | Response |")
         lines.append("|--------|---------|--------|----------|")
-        for action_type, _category, content, status, response, _created in rows:
+        for action_type, content, status, response, _created in rows:
             short = content[:80] + "..." if len(content) > 80 else content
             short = short.replace("\n", " ").replace("|", "/")
             resp = (response or "\u2014")[:50]

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -127,57 +127,94 @@ class GenesisEgoContextBuilder:
         return "\n".join(lines)
 
     async def _signals_section(self) -> str:
-        """Recent awareness loop signal values."""
+        """Recent awareness loop signal values with trend indicators."""
         lines = ["## Awareness Signals (latest tick)\n"]
 
         try:
             cursor = await self._db.execute(
                 "SELECT signals_json, classified_depth, created_at "
                 "FROM awareness_ticks "
-                "ORDER BY created_at DESC LIMIT 1"
+                "ORDER BY created_at DESC LIMIT 3"
             )
-            row = await cursor.fetchone()
+            rows = await cursor.fetchall()
         except Exception:
             logger.error("Failed to query awareness_ticks", exc_info=True)
             lines.append("*No awareness data available.*\n")
             return "\n".join(lines)
 
-        if not row:
+        if not rows:
             lines.append("*No awareness ticks recorded.*\n")
             return "\n".join(lines)
 
-        signals_json, depth, created_at = row
+        # Parse signals from the most recent tick (display) and previous
+        # tick (trend comparison).
+        current_row = rows[0]
+        signals_json, depth, created_at = current_row
         lines.append(f"**Last tick**: {created_at} (depth: {depth})\n")
 
-        try:
-            signals = json.loads(signals_json) if signals_json else {}
-        except (json.JSONDecodeError, TypeError):
-            signals = {}
+        signals = self._parse_signals_json(signals_json)
 
-        # signals_json is stored as a list of {name, value, source} dicts,
-        # not a dict keyed by name. Normalize to dict for display.
-        if isinstance(signals, list):
-            signals = {
-                s["name"]: s
-                for s in signals
-                if isinstance(s, dict) and "name" in s
-            }
+        # Build previous tick's signal values for trend comparison
+        prev_values: dict[str, float] = {}
+        if len(rows) >= 2:
+            prev_signals = self._parse_signals_json(rows[1][0])
+            for name, info in prev_signals.items():
+                if isinstance(info, dict):
+                    v = info.get("value")
+                    if isinstance(v, (int, float)):
+                        prev_values[name] = float(v)
 
         if signals:
-            lines.append("| Signal | Value | Source |")
-            lines.append("|--------|-------|--------|")
+            lines.append("| Signal | Value | Trend | Source |")
+            lines.append("|--------|-------|-------|--------|")
             for sig_name, sig_info in sorted(signals.items()):
                 if isinstance(sig_info, dict):
                     val = sig_info.get("value", "?")
                     src = sig_info.get("source", "?")
+                    trend = self._signal_trend(sig_name, val, prev_values)
                     if isinstance(val, float):
                         val = f"{val:.3f}"
-                    lines.append(f"| {sig_name} | {val} | {src} |")
+                    lines.append(
+                        f"| {sig_name} | {val} | {trend} | {src} |"
+                    )
                 else:
-                    lines.append(f"| {sig_name} | {sig_info} | ? |")
+                    lines.append(f"| {sig_name} | {sig_info} | \u2192 | ? |")
 
         lines.append("")
         return "\n".join(lines)
+
+    @staticmethod
+    def _parse_signals_json(signals_json: str | None) -> dict:
+        """Parse signals_json (list or dict format) into a name-keyed dict."""
+        try:
+            signals = json.loads(signals_json) if signals_json else {}
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        if isinstance(signals, list):
+            return {
+                s["name"]: s
+                for s in signals
+                if isinstance(s, dict) and "name" in s
+            }
+        return signals if isinstance(signals, dict) else {}
+
+    @staticmethod
+    def _signal_trend(
+        name: str,
+        current_value: object,
+        prev_values: dict[str, float],
+    ) -> str:
+        """Compute trend arrow: \u2191 (up), \u2193 (down), \u2192 (stable/new)."""
+        if not isinstance(current_value, (int, float)):
+            return "\u2192"
+        curr = float(current_value)
+        prev = prev_values.get(name)
+        if prev is None:
+            return "\u2192"  # New signal, no history
+        delta = curr - prev
+        if abs(delta) < 0.01:  # Within noise threshold
+            return "\u2192"
+        return "\u2191" if delta > 0 else "\u2193"
 
     async def _observations_section(self) -> str:
         """Genesis-internal observations — system issues needing attention."""

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -56,6 +56,7 @@ class GenesisEgoContextBuilder:
         sections.append(await self._observations_section())
         sections.append(await self._follow_ups_section())
         sections.append(await self._cost_section())
+        sections.append(await self._proposal_history_section())
         sections.append(await self._proposal_board_section())
         sections.append(await self._execution_outcomes_section())
         sections.append(self._output_contract_section())
@@ -306,6 +307,41 @@ class GenesisEgoContextBuilder:
             lines.append(f"- **Ego spend today**: ${ego_spend:.4f}")
         except Exception:
             pass
+
+        lines.append("")
+        return "\n".join(lines)
+
+    async def _proposal_history_section(self) -> str:
+        """Recent proposal outcomes for self-calibration."""
+        lines = ["## Recent Proposals (last 7 days)\n"]
+
+        try:
+            cursor = await self._db.execute(
+                "SELECT action_type, action_category, content, status, "
+                "user_response, created_at "
+                "FROM ego_proposals "
+                "WHERE created_at >= datetime('now', '-7 days') "
+                "ORDER BY created_at DESC "
+                "LIMIT 15"
+            )
+            rows = await cursor.fetchall()
+        except Exception:
+            lines.append("*No proposal history available.*\n")
+            return "\n".join(lines)
+
+        if not rows:
+            lines.append("*No proposals in last 7 days.*\n")
+            return "\n".join(lines)
+
+        lines.append("| Action | Content | Status | Response |")
+        lines.append("|--------|---------|--------|----------|")
+        for action_type, _category, content, status, response, _created in rows:
+            short = content[:80] + "..." if len(content) > 80 else content
+            short = short.replace("\n", " ").replace("|", "/")
+            resp = (response or "\u2014")[:50]
+            lines.append(
+                f"| {action_type} | {short} | {status} | {resp} |"
+            )
 
         lines.append("")
         return "\n".join(lines)

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -69,6 +69,7 @@ class UserEgoContextBuilder:
         sections.append(await self._user_activity_pulse_section())
         sections.append(await self._recent_conversations_section())
         sections.append(await self._user_world_observations_section())
+        sections.append(await self._backlog_summary_section())
         sections.append(await self._genesis_escalations_section())
         sections.append(await self._capabilities_section())
         sections.append(await self._system_status_section())
@@ -362,6 +363,78 @@ class UserEgoContextBuilder:
 
         lines.append("")
         return "\n".join(lines)
+
+    async def _backlog_summary_section(self) -> str:
+        """Inbox, recon, and pending item backlogs."""
+        lines = ["## Backlogs\n"]
+
+        counts: list[tuple[str, int, str | None]] = []  # (label, count, oldest)
+
+        # Inbox: pending/processing items
+        try:
+            cursor = await self._db.execute(
+                "SELECT COUNT(*), MIN(created_at) FROM inbox_items "
+                "WHERE status NOT IN ('completed', 'failed')"
+            )
+            row = await cursor.fetchone()
+            if row and row[0] > 0:
+                age = self._days_ago(row[1])
+                counts.append(("Inbox", row[0], age))
+        except Exception:
+            pass  # Table may not exist
+
+        # Recon findings: unresolved
+        try:
+            cursor = await self._db.execute(
+                "SELECT COUNT(*), MIN(created_at) FROM observations "
+                "WHERE type = 'finding' AND resolved = 0"
+            )
+            row = await cursor.fetchone()
+            if row and row[0] > 0:
+                age = self._days_ago(row[1])
+                counts.append(("Recon findings", row[0], age))
+        except Exception:
+            pass
+
+        # Follow-ups awaiting user input
+        try:
+            cursor = await self._db.execute(
+                "SELECT COUNT(*), MIN(created_at) FROM follow_ups "
+                "WHERE status = 'pending' "
+                "AND strategy = 'user_input_needed'"
+            )
+            row = await cursor.fetchone()
+            if row and row[0] > 0:
+                age = self._days_ago(row[1])
+                counts.append(("Awaiting user input", row[0], age))
+        except Exception:
+            pass
+
+        if not counts:
+            lines.append("*All backlogs clear.*\n")
+        else:
+            for label, count, oldest in counts:
+                age_str = f" (oldest: {oldest})" if oldest else ""
+                lines.append(f"- **{label}**: {count} pending{age_str}")
+
+        lines.append("")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _days_ago(iso_timestamp: str | None) -> str | None:
+        """Convert ISO timestamp to 'Xd ago' string."""
+        if not iso_timestamp:
+            return None
+        try:
+            dt = datetime.fromisoformat(iso_timestamp)
+            days = (datetime.now(UTC) - dt).days
+            if days == 0:
+                return "today"
+            if days == 1:
+                return "1d ago"
+            return f"{days}d ago"
+        except (ValueError, TypeError):
+            return None
 
     async def _genesis_escalations_section(self) -> str:
         """Escalations from the Genesis ego that need user ego attention."""

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -112,6 +112,8 @@ class UserEgoContextBuilder:
         # relative to recent conversation activity.
         try:
             synth_dt = datetime.fromisoformat(synthesized_at)
+            if synth_dt.tzinfo is None:
+                synth_dt = synth_dt.replace(tzinfo=UTC)
             age_days = (datetime.now(UTC) - synth_dt).days
             cursor = await self._db.execute(
                 "SELECT COUNT(*) FROM cc_sessions "
@@ -427,6 +429,8 @@ class UserEgoContextBuilder:
             return None
         try:
             dt = datetime.fromisoformat(iso_timestamp)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=UTC)
             days = (datetime.now(UTC) - dt).days
             if days == 0:
                 return "today"
@@ -608,7 +612,7 @@ class UserEgoContextBuilder:
 
         try:
             cursor = await self._db.execute(
-                "SELECT action_type, action_category, content, status, "
+                "SELECT action_type, content, status, "
                 "user_response, created_at "
                 "FROM ego_proposals "
                 "WHERE created_at >= datetime('now', '-7 days') "
@@ -624,9 +628,18 @@ class UserEgoContextBuilder:
             lines.append("*No proposals in last 7 days.*\n")
             return "\n".join(lines)
 
+        # Summary line for quick calibration
+        from collections import Counter
+        status_counts = Counter(r[2] for r in rows)
+        parts = [f"{status_counts[s]} {s}" for s in
+                 ("approved", "rejected", "executed", "pending", "failed",
+                  "expired", "tabled", "withdrawn")
+                 if status_counts.get(s)]
+        lines.append(f"**{len(rows)} proposals**: {', '.join(parts)}\n")
+
         lines.append("| Action | Content | Status | Response |")
         lines.append("|--------|---------|--------|----------|")
-        for action_type, _category, content, status, response, _created in rows:
+        for action_type, content, status, response, _created in rows:
             short = content[:80] + "..." if len(content) > 80 else content
             short = short.replace("\n", " ").replace("|", "/")
             resp = (response or "\u2014")[:50]

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -35,12 +35,13 @@ class UserEgoContextBuilder:
 
     Data sources (ordered by signal value):
     1. User model — who the user is, what they care about
-    2. Recent conversations — what the user is working on
-    3. User-world observations — email, inbox, findings
-    4. Genesis ego escalations — things Genesis can't resolve alone
-    5. Capabilities — what Genesis CAN do but ISN'T doing
-    6. Minimal system status — one-line health summary
-    7. Open threads — pending follow-ups
+    2. User activity pulse — user-facing awareness signals
+    3. Recent conversations — what the user is working on
+    4. User-world observations — email, inbox, findings
+    5. Genesis ego escalations — things Genesis can't resolve alone
+    6. Capabilities — what Genesis CAN do but ISN'T doing
+    7. Minimal system status — one-line health summary
+    8. Open threads — pending follow-ups
     """
 
     def __init__(
@@ -65,6 +66,7 @@ class UserEgoContextBuilder:
         )
 
         sections.append(await self._user_model_section())
+        sections.append(await self._user_activity_pulse_section())
         sections.append(await self._recent_conversations_section())
         sections.append(await self._user_world_observations_section())
         sections.append(await self._genesis_escalations_section())
@@ -104,6 +106,27 @@ class UserEgoContextBuilder:
             f"last synthesized {synthesized_at[:10]}*\n"
         )
 
+        # 3d: Model freshness warning — flag when model is stale
+        # relative to recent conversation activity.
+        try:
+            synth_dt = datetime.fromisoformat(synthesized_at)
+            age_days = (datetime.now(UTC) - synth_dt).days
+            cursor = await self._db.execute(
+                "SELECT COUNT(*) FROM cc_sessions "
+                "WHERE source_tag = 'foreground' "
+                "AND started_at > ?",
+                (synthesized_at,),
+            )
+            freshness_row = await cursor.fetchone()
+            sessions_since = freshness_row[0] if freshness_row else 0
+            if age_days >= 3 and sessions_since >= 3:
+                lines.append(
+                    f"**Warning: Model may be stale**: {age_days}d old, "
+                    f"{sessions_since} conversations since last synthesis\n"
+                )
+        except Exception:
+            pass  # Non-critical enrichment
+
         try:
             model = json.loads(model_json) if model_json else {}
         except (json.JSONDecodeError, TypeError):
@@ -140,6 +163,115 @@ class UserEgoContextBuilder:
             lines.append(
                 f"\n*{remaining} more fields available via memory_recall.*"
             )
+
+        lines.append("")
+        return "\n".join(lines)
+
+    # Signals that track user activity — used to filter awareness tick
+    # signals for the user ego's activity pulse section.
+    _USER_FACING_SIGNALS = frozenset({
+        "conversations_since_reflection",
+        "task_completion_quality",
+        "recon_findings_pending",
+        "stale_pending_items",
+        "user_goal_staleness",
+        "user_session_pattern",
+    })
+
+    # Human-readable interpretations for user-facing signal ranges.
+    _SIGNAL_INTERPRETATIONS: dict[str, list[tuple[float, str]]] = {
+        "user_goal_staleness": [
+            (0.7, "oldest pending goal is significantly stale (14+ days)"),
+            (0.3, "oldest pending goal is moderately stale (7-14 days)"),
+            (0.0, "pending goals are relatively fresh"),
+        ],
+        "user_session_pattern": [
+            (0.7, "user activity is significantly below their baseline"),
+            (0.3, "user activity is somewhat below their baseline"),
+            (0.0, "user activity is near their normal pattern"),
+        ],
+        "stale_pending_items": [
+            (0.7, "several pending items are aging (3+ days)"),
+            (0.3, "some pending items are aging"),
+            (0.0, "pending items are fresh"),
+        ],
+    }
+
+    @classmethod
+    def _interpret_signal(cls, name: str, value: float) -> str | None:
+        """Return a human-readable interpretation, or None to skip."""
+        thresholds = cls._SIGNAL_INTERPRETATIONS.get(name)
+        if thresholds:
+            for threshold, text in thresholds:
+                if value >= threshold:
+                    return text
+            return None
+        # Default: just show the raw value for known user-facing signals
+        if isinstance(value, float):
+            return f"{value:.2f}"
+        return str(value)
+
+    async def _user_activity_pulse_section(self) -> str:
+        """User activity signals — interpreted for ego decision-making.
+
+        Queries the latest awareness tick and surfaces user-facing signal
+        values as prose. Signals at 0.0 are skipped (nothing noteworthy).
+        """
+        lines = ["## User Activity Pulse\n"]
+
+        try:
+            cursor = await self._db.execute(
+                "SELECT signals_json, created_at "
+                "FROM awareness_ticks "
+                "ORDER BY created_at DESC LIMIT 1"
+            )
+            row = await cursor.fetchone()
+        except Exception:
+            logger.error("Failed to query awareness_ticks", exc_info=True)
+            lines.append("*No awareness data available.*\n")
+            return "\n".join(lines)
+
+        if not row:
+            lines.append("*No awareness ticks recorded.*\n")
+            return "\n".join(lines)
+
+        signals_json, created_at = row
+
+        try:
+            signals = json.loads(signals_json) if signals_json else {}
+        except (json.JSONDecodeError, TypeError):
+            signals = {}
+
+        # Normalize list format to dict (same as genesis_context.py)
+        if isinstance(signals, list):
+            signals = {
+                s["name"]: s
+                for s in signals
+                if isinstance(s, dict) and "name" in s
+            }
+
+        # Filter to user-facing signals with non-zero values
+        pulse_items: list[str] = []
+        for sig_name in sorted(self._USER_FACING_SIGNALS):
+            sig_info = signals.get(sig_name)
+            if not sig_info:
+                continue
+            value = sig_info.get("value", 0.0) if isinstance(sig_info, dict) else sig_info
+            if not isinstance(value, (int, float)) or value == 0.0:
+                continue
+            interpretation = self._interpret_signal(sig_name, float(value))
+            if interpretation:
+                label = sig_name.replace("_", " ").title()
+                pulse_items.append(
+                    f"- **{label}**: {interpretation} (signal: {value:.2f})"
+                )
+
+        if not pulse_items:
+            lines.append("*All user activity signals nominal.*\n")
+        else:
+            ts = created_at[:16] if created_at else "?"
+            lines.append(f"*From latest awareness tick ({ts}):*\n")
+            lines.extend(pulse_items)
 
         lines.append("")
         return "\n".join(lines)

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -73,6 +73,7 @@ class UserEgoContextBuilder:
         sections.append(await self._capabilities_section())
         sections.append(await self._system_status_section())
         sections.append(await self._follow_ups_section())
+        sections.append(await self._proposal_history_section())
         sections.append(await self._proposal_board_section())
         sections.append(await self._execution_outcomes_section())
         sections.append(self._output_contract_section())
@@ -524,6 +525,41 @@ class UserEgoContextBuilder:
             if blocked:
                 line += f" — BLOCKED: {blocked[:100]}"
             lines.append(line)
+
+        lines.append("")
+        return "\n".join(lines)
+
+    async def _proposal_history_section(self) -> str:
+        """Recent proposal outcomes for self-calibration."""
+        lines = ["## Recent Proposals (last 7 days)\n"]
+
+        try:
+            cursor = await self._db.execute(
+                "SELECT action_type, action_category, content, status, "
+                "user_response, created_at "
+                "FROM ego_proposals "
+                "WHERE created_at >= datetime('now', '-7 days') "
+                "ORDER BY created_at DESC "
+                "LIMIT 15"
+            )
+            rows = await cursor.fetchall()
+        except Exception:
+            lines.append("*No proposal history available.*\n")
+            return "\n".join(lines)
+
+        if not rows:
+            lines.append("*No proposals in last 7 days.*\n")
+            return "\n".join(lines)
+
+        lines.append("| Action | Content | Status | Response |")
+        lines.append("|--------|---------|--------|----------|")
+        for action_type, _category, content, status, response, _created in rows:
+            short = content[:80] + "..." if len(content) > 80 else content
+            short = short.replace("\n", " ").replace("|", "/")
+            resp = (response or "\u2014")[:50]
+            lines.append(
+                f"| {action_type} | {short} | {status} | {resp} |"
+            )
 
         lines.append("")
         return "\n".join(lines)

--- a/tests/ego/test_genesis_context.py
+++ b/tests/ego/test_genesis_context.py
@@ -443,6 +443,7 @@ class TestGenesisEgoContextBuilder:
             "## Unresolved Observations",
             "## Maintenance Follow-ups",
             "## Cost Status",
+            "## Recent Proposals",
             "## Output Contract",
         ]
         for section in expected_sections:
@@ -467,3 +468,80 @@ class TestGenesisEgoContextBuilder:
         assert "Content for interest" not in result
         assert "Content for interests" not in result
         assert "Content for finding" not in result
+
+    # ── Proposal History (3b) ──────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_proposal_history_section(self, db, mock_health_data, capabilities):
+        """Proposal history displays recent proposals in a table."""
+        await db.execute(
+            "INSERT INTO ego_proposals "
+            "(id, action_type, action_category, content, status, "
+            "user_response, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, datetime('now'))",
+            ("p1", "outreach", "linkedin", "Post update on LinkedIn", "approved", None),
+        )
+        await db.execute(
+            "INSERT INTO ego_proposals "
+            "(id, action_type, action_category, content, status, "
+            "user_response, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, datetime('now'))",
+            ("p2", "investigate", "recon", "Check competitor repos", "rejected", "not now"),
+        )
+        builder = GenesisEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        assert "Recent Proposals" in result
+        assert "outreach" in result
+        assert "Post update on LinkedIn" in result
+        assert "approved" in result
+        assert "rejected" in result
+        assert "not now" in result
+
+    @pytest.mark.asyncio
+    async def test_proposal_history_empty(self, db, mock_health_data, capabilities):
+        builder = GenesisEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        assert "No proposals in last 7 days" in result
+
+    @pytest.mark.asyncio
+    async def test_proposal_history_truncates_long_content(
+        self, db, mock_health_data, capabilities,
+    ):
+        """Long content in proposal history table is truncated to 80 chars."""
+        long_content = "Z" * 200
+        await db.execute(
+            "INSERT INTO ego_proposals "
+            "(id, action_type, action_category, content, status, "
+            "user_response, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, datetime('now'))",
+            ("p3", "investigate", "recon", long_content, "pending", None),
+        )
+        builder = GenesisEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        proposals_section = result.split("## Recent Proposals")[1].split("##")[0]
+        assert "..." in proposals_section
+        assert "Z" * 200 not in proposals_section
+
+    @pytest.mark.asyncio
+    async def test_proposal_history_pipes_escaped(
+        self, db, mock_health_data, capabilities,
+    ):
+        """Pipe chars in content are escaped to not break markdown table."""
+        await db.execute(
+            "INSERT INTO ego_proposals "
+            "(id, action_type, action_category, content, status, "
+            "user_response, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, datetime('now'))",
+            ("p4", "investigate", "recon", "repo|branch|status", "pending", None),
+        )
+        builder = GenesisEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        assert "repo/branch/status" in result

--- a/tests/ego/test_genesis_context.py
+++ b/tests/ego/test_genesis_context.py
@@ -232,6 +232,45 @@ class TestGenesisEgoContextBuilder:
         assert "software_error_spike" in result
         assert "budget_pct_consumed" in result
         assert "Micro" in result
+        # Single tick → all trends should be stable (→)
+        assert "Trend" in result
+        assert "\u2192" in result  # → symbol
+
+    @pytest.mark.asyncio
+    async def test_signals_trend_arrows(self, db, mock_health_data, capabilities):
+        """Signal trends show up/down/stable arrows based on previous tick."""
+        # Previous tick: error_spike=0.0, budget=0.50
+        prev_data = json.dumps([
+            {"name": "software_error_spike", "value": 0.0, "source": "circuit_breakers"},
+            {"name": "budget_pct_consumed", "value": 0.50, "source": "cost_events"},
+            {"name": "container_memory_pct", "value": 0.60, "source": "cgroup"},
+        ])
+        await db.execute(
+            "INSERT INTO awareness_ticks "
+            "(id, source, signals_json, scores_json, signal_data, classified_depth, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("t_prev", "scheduled", prev_data, "{}", "{}", "Micro", "2026-04-24T09:50:00+00:00"),
+        )
+        # Current tick: error_spike=0.3 (↑), budget=0.25 (↓), memory=0.60 (→)
+        curr_data = json.dumps([
+            {"name": "software_error_spike", "value": 0.3, "source": "circuit_breakers"},
+            {"name": "budget_pct_consumed", "value": 0.25, "source": "cost_events"},
+            {"name": "container_memory_pct", "value": 0.60, "source": "cgroup"},
+        ])
+        await db.execute(
+            "INSERT INTO awareness_ticks "
+            "(id, source, signals_json, scores_json, signal_data, classified_depth, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("t_curr", "scheduled", curr_data, "{}", "{}", "Micro", "2026-04-24T09:55:00+00:00"),
+        )
+        builder = GenesisEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        # Check that all three trend arrows appear
+        assert "\u2191" in result  # ↑ for error_spike going up
+        assert "\u2193" in result  # ↓ for budget going down
+        assert "\u2192" in result  # → for memory staying the same
 
     @pytest.mark.asyncio
     async def test_signals_section_no_data(self, db, mock_health_data, capabilities):

--- a/tests/ego/test_user_context.py
+++ b/tests/ego/test_user_context.py
@@ -1,6 +1,7 @@
 """Tests for genesis.ego.user_context — UserEgoContextBuilder."""
 
 import json
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
 import aiosqlite
@@ -104,6 +105,16 @@ async def db():
                 cost_usd         REAL NOT NULL DEFAULT 0.0,
                 metadata         TEXT,
                 created_at       TEXT NOT NULL
+            )
+        """)
+        await conn.execute("""
+            CREATE TABLE awareness_ticks (
+                id              TEXT PRIMARY KEY,
+                signals_json    TEXT,
+                scores_json     TEXT,
+                classified_depth TEXT,
+                trigger_reason  TEXT,
+                created_at      TEXT NOT NULL
             )
         """)
         await conn.execute("""
@@ -469,6 +480,7 @@ class TestUserEgoContextBuilder:
         result = await builder.build()
         expected_sections = [
             "## User Profile",
+            "## User Activity Pulse",
             "## Recent Conversations",
             "## User-World Signals",
             "## Genesis Ego Escalations",
@@ -522,3 +534,156 @@ class TestUserEgoContextBuilder:
         crit_pos = result.index("CRITICAL_ITEM")
         low_pos = result.index("LOW_ITEM")
         assert crit_pos < low_pos, "Critical items should appear before low-priority items"
+
+    # ── User Activity Pulse (3a) ───────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_activity_pulse_with_signals(self, db, mock_health_data, capabilities):
+        """Non-zero user-facing signals are surfaced as prose."""
+        signals = json.dumps([
+            {"name": "user_goal_staleness", "value": 0.5, "source": "follow_ups+user_model"},
+            {"name": "user_session_pattern", "value": 0.8, "source": "cc_sessions"},
+            {"name": "conversations_since_reflection", "value": 3.0, "source": "cc_sessions"},
+            {"name": "software_error_spike", "value": 0.1, "source": "circuit_breakers"},
+        ])
+        await db.execute(
+            "INSERT INTO awareness_ticks "
+            "(id, signals_json, classified_depth, created_at) "
+            "VALUES (?, ?, ?, datetime('now'))",
+            ("tick1", signals, "Micro", ),
+        )
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        assert "## User Activity Pulse" in result
+        # User-facing signals present
+        assert "User Goal Staleness" in result
+        assert "moderately stale" in result
+        assert "User Session Pattern" in result
+        assert "significantly below" in result
+        assert "Conversations Since Reflection" in result
+        # Genesis-internal signal excluded
+        assert "Software Error Spike" not in result
+        assert "circuit_breakers" not in result
+
+    @pytest.mark.asyncio
+    async def test_activity_pulse_all_zero(self, db, mock_health_data, capabilities):
+        """All user-facing signals at 0.0 → nominal message."""
+        signals = json.dumps([
+            {"name": "user_goal_staleness", "value": 0.0, "source": "follow_ups"},
+            {"name": "user_session_pattern", "value": 0.0, "source": "cc_sessions"},
+        ])
+        await db.execute(
+            "INSERT INTO awareness_ticks "
+            "(id, signals_json, classified_depth, created_at) "
+            "VALUES (?, ?, ?, datetime('now'))",
+            ("tick2", signals, "Micro", ),
+        )
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        assert "All user activity signals nominal" in result
+
+    @pytest.mark.asyncio
+    async def test_activity_pulse_no_ticks(self, db, mock_health_data, capabilities):
+        """No awareness ticks recorded → graceful fallback."""
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        assert "No awareness ticks recorded" in result
+
+    @pytest.mark.asyncio
+    async def test_activity_pulse_dict_format(self, db, mock_health_data, capabilities):
+        """signals_json stored as dict (legacy format) still works."""
+        signals = json.dumps({
+            "user_goal_staleness": {"name": "user_goal_staleness", "value": 0.9, "source": "follow_ups"},
+        })
+        await db.execute(
+            "INSERT INTO awareness_ticks "
+            "(id, signals_json, classified_depth, created_at) "
+            "VALUES (?, ?, ?, datetime('now'))",
+            ("tick3", signals, "Micro", ),
+        )
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        assert "User Goal Staleness" in result
+        assert "significantly stale" in result
+
+    # ── Model Freshness Warning (3d) ───────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_model_freshness_warning_shown(self, db, mock_health_data, capabilities):
+        """Stale model + recent activity → warning shown."""
+        # Model synthesized 5 days ago
+        old_date = (datetime.now(UTC) - timedelta(days=5)).isoformat()
+        model_data = json.dumps({"active_projects": ["Genesis v3"]})
+        await db.execute(
+            "INSERT INTO user_model_cache "
+            "(id, model_json, version, synthesized_at, synthesized_by, evidence_count) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("current", model_data, 3, old_date, "reflection", 42),
+        )
+        # 5 foreground sessions since synthesis
+        for i in range(5):
+            await db.execute(
+                "INSERT INTO cc_sessions "
+                "(id, session_type, model, started_at, last_activity_at, source_tag, topic) "
+                "VALUES (?, ?, ?, datetime('now'), datetime('now'), ?, ?)",
+                (f"s{i}", "foreground", "opus-4", "foreground", f"Session {i}"),
+            )
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        assert "Model may be stale" in result
+        assert "5d old" in result
+        assert "5 conversations since" in result
+
+    @pytest.mark.asyncio
+    async def test_model_freshness_no_warning_when_fresh(
+        self, db, mock_health_data, capabilities,
+    ):
+        """Recent model → no warning."""
+        model_data = json.dumps({"active_projects": ["Genesis v3"]})
+        await db.execute(
+            "INSERT INTO user_model_cache "
+            "(id, model_json, version, synthesized_at, synthesized_by, evidence_count) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("current", model_data, 3, datetime.now(UTC).isoformat(), "reflection", 42),
+        )
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        assert "Model may be stale" not in result
+
+    @pytest.mark.asyncio
+    async def test_model_freshness_no_warning_few_sessions(
+        self, db, mock_health_data, capabilities,
+    ):
+        """Old model but few sessions since → no warning (not enough signal)."""
+        old_date = (datetime.now(UTC) - timedelta(days=10)).isoformat()
+        model_data = json.dumps({"active_projects": ["Genesis v3"]})
+        await db.execute(
+            "INSERT INTO user_model_cache "
+            "(id, model_json, version, synthesized_at, synthesized_by, evidence_count) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("current", model_data, 3, old_date, "reflection", 42),
+        )
+        # Only 1 session since (below threshold of 3)
+        await db.execute(
+            "INSERT INTO cc_sessions "
+            "(id, session_type, model, started_at, last_activity_at, source_tag, topic) "
+            "VALUES (?, ?, ?, datetime('now'), datetime('now'), ?, ?)",
+            ("s1", "foreground", "opus-4", "foreground", "One session"),
+        )
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        assert "Model may be stale" not in result

--- a/tests/ego/test_user_context.py
+++ b/tests/ego/test_user_context.py
@@ -487,6 +487,7 @@ class TestUserEgoContextBuilder:
             "## Genesis Capabilities",
             "## System Status",
             "## Open Threads",
+            "## Recent Proposals",
             "## Output Contract",
         ]
         for section in expected_sections:

--- a/tests/ego/test_user_context.py
+++ b/tests/ego/test_user_context.py
@@ -108,6 +108,21 @@ async def db():
             )
         """)
         await conn.execute("""
+            CREATE TABLE inbox_items (
+                id             TEXT PRIMARY KEY,
+                file_path      TEXT NOT NULL,
+                content_hash   TEXT NOT NULL,
+                status         TEXT NOT NULL DEFAULT 'pending',
+                batch_id       TEXT,
+                response_path  TEXT,
+                created_at     TEXT NOT NULL,
+                processed_at   TEXT,
+                error_message  TEXT,
+                retry_count    INTEGER NOT NULL DEFAULT 0,
+                evaluated_content TEXT
+            )
+        """)
+        await conn.execute("""
             CREATE TABLE awareness_ticks (
                 id              TEXT PRIMARY KEY,
                 signals_json    TEXT,
@@ -483,6 +498,7 @@ class TestUserEgoContextBuilder:
             "## User Activity Pulse",
             "## Recent Conversations",
             "## User-World Signals",
+            "## Backlogs",
             "## Genesis Ego Escalations",
             "## Genesis Capabilities",
             "## System Status",
@@ -688,3 +704,67 @@ class TestUserEgoContextBuilder:
         )
         result = await builder.build()
         assert "Model may be stale" not in result
+
+    # ── Backlog Summary (3c) ──────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_backlog_with_items(self, db, mock_health_data, capabilities):
+        """Backlogs section shows counts and oldest ages."""
+        old_date = (datetime.now(UTC) - timedelta(days=6)).isoformat()
+        await db.execute(
+            "INSERT INTO inbox_items "
+            "(id, file_path, content_hash, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("i1", "/inbox/test.md", "abc", "pending", old_date),
+        )
+        await db.execute(
+            "INSERT INTO inbox_items "
+            "(id, file_path, content_hash, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("i2", "/inbox/test2.md", "def", "processing", datetime.now(UTC).isoformat()),
+        )
+        await db.execute(
+            "INSERT INTO observations "
+            "(id, source, type, category, content, priority, resolved, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("f1", "recon", "finding", "finding", "Interesting article", "medium", 0, old_date),
+        )
+        await db.execute(
+            "INSERT INTO follow_ups "
+            "(id, source, content, strategy, status, priority, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("fu1", "ego", "Review draft", "user_input_needed", "pending", "high", old_date),
+        )
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        assert "## Backlogs" in result
+        assert "**Inbox**: 2 pending" in result
+        assert "6d ago" in result
+        assert "**Recon findings**: 1 pending" in result
+        assert "**Awaiting user input**: 1 pending" in result
+
+    @pytest.mark.asyncio
+    async def test_backlog_all_clear(self, db, mock_health_data, capabilities):
+        """Empty backlogs show 'all clear' message."""
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        assert "All backlogs clear" in result
+
+    @pytest.mark.asyncio
+    async def test_backlog_excludes_completed(self, db, mock_health_data, capabilities):
+        """Completed inbox items don't count."""
+        await db.execute(
+            "INSERT INTO inbox_items "
+            "(id, file_path, content_hash, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("i3", "/inbox/done.md", "ghi", "completed", datetime.now(UTC).isoformat()),
+        )
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder.build()
+        assert "All backlogs clear" in result


### PR DESCRIPTION
## Summary

- **Approval gate fix**: Stable approval keys for recurring dispatches (ego cycles, inbox eval), delete Pass 3 stale reuse, fix genesis ego signals crash (`signals.items()` on list)
- **Reflection rebalancing (Phase 2.5a+b)**: Relevance tags (`:user`/`:genesis`/`:both`) on reflection outputs, two new user-facing signal collectors (`user_goal_staleness`, `user_session_pattern`)
- **Ego context enrichment (Phase 3)**: User activity pulse section, model freshness warning, proposal self-calibration for both egos, backlog visibility, genesis ego signal trend arrows
- **Docs**: Ego sessions marked ACTIVE in genesis-development skill, code-voice gitignored

## Test plan

- [x] `ruff check .` clean
- [x] `pytest -v` — 6027 passed, 0 failed
- [x] Code review completed (timezone safety, proposal stats fix)
- [ ] Post-merge: verify user ego context includes activity pulse with real signals
- [ ] Post-merge: verify genesis ego shows trend arrows across ticks
- [ ] Post-merge: verify proposal history section shows real ego_proposals data
- [ ] Post-merge: verify backlog counts match direct SQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)