### PR TITLE
fix(memory): default source_pipeline to 'knowledge_ingest' not 'recon'

### DIFF
--- a/src/genesis/memory/knowledge_ingest.py
+++ b/src/genesis/memory/knowledge_ingest.py
@@ -77,7 +77,7 @@ async def ingest_knowledge_unit(
     unit_id = existing["id"] if existing else str(uuid.uuid4())
     old_qdrant_id = existing.get("qdrant_id") if existing else None
 
-    source_pipeline_val = (provenance or {}).get("source_pipeline", "recon")
+    source_pipeline_val = (provenance or {}).get("source_pipeline", "knowledge_ingest")
     source_session_id = (provenance or {}).get("session_id")
     qdrant_memory_id = await store.store(
         content,


### PR DESCRIPTION
## Summary

- `ingest_knowledge_unit()` defaulted `source_pipeline` to `"recon"` when no provenance was passed, causing explicitly-ingested KB units to appear as recon findings in recall results
- Changed default to `"knowledge_ingest"` — the correct pipeline label for this function
- Patched Qdrant payloads on existing cloud-engineering KB units to retroactively correct the label

## Root cause

`knowledge_ingest.py:80`:
```python
# Before
source_pipeline_val = (provenance or {}).get("source_pipeline", "recon")
# After
source_pipeline_val = (provenance or {}).get("source_pipeline", "knowledge_ingest")
```

The retrieval layer reads `source_pipeline` from the Qdrant payload, not the SQLite column, so both the code default and the existing payloads needed fixing.

## Test plan
- [x] `pytest tests/test_memory/ -k "ingest"` — 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)