### PR TITLE
fix(autonomy): approval staleness guard + infra monitor disable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,9 +282,9 @@ To send the user a future Telegram reminder, use `mcp__genesis-outreach__outreac
 
 ## Traps
 
-- **Ego** (`src/genesis/ego/`) — Live autonomous decision-making cycle.
-  Wired via `genesis.runtime`. Don't add new call sites without reviewing
-  the cadence manager and budget controls.
+- **Ego** (`src/genesis/ego/`) — Live. Two egos: user (CEO/Opus) and
+  Genesis (COO/Sonnet). Review cadence manager and budget controls
+  before adding call sites.
 - **GROUNDWORK tags** — `# GROUNDWORK(id): why` is intentional. Never delete.
 - **IntervalTrigger** — Resets on restart. Use `CronTrigger` for intervals >1h.
 

--- a/src/genesis/autonomy/approval_gate.py
+++ b/src/genesis/autonomy/approval_gate.py
@@ -418,6 +418,18 @@ class AutonomousCliApprovalGate:
                     continue
                 if status_str == "approved" and row.get("consumed_at"):
                     continue
+                # Staleness guard: don't recycle approvals resolved >24h ago.
+                # Prevents historical backlogs from silently bypassing the gate.
+                if status_str == "approved":
+                    resolved_at_str = row.get("resolved_at", "")
+                    if resolved_at_str:
+                        try:
+                            resolved_dt = datetime.fromisoformat(resolved_at_str)
+                            age_hours = (datetime.now(UTC) - resolved_dt).total_seconds() / 3600
+                            if age_hours > 24:
+                                continue
+                        except (ValueError, TypeError):
+                            pass
                 return row
         # Pass 2: race-safety fallback — pending rows for the same site.
         # Sentinel retains this because alarm-based triggers should dedup.

--- a/src/genesis/db/crud/approval_requests.py
+++ b/src/genesis/db/crud/approval_requests.py
@@ -159,6 +159,7 @@ async def find_approved_unconsumed(
              AND consumed_at IS NULL
              AND json_extract(context, '$.subsystem') = ?
              AND json_extract(context, '$.policy_id') = ?
+             AND resolved_at > datetime('now', '-24 hours')
            ORDER BY resolved_at DESC
            LIMIT 1""",
         (subsystem, policy_id),

--- a/src/genesis/identity/REFLECTION_DEEP.md
+++ b/src/genesis/identity/REFLECTION_DEEP.md
@@ -252,7 +252,7 @@ Example:
 
 You can dispatch surplus tasks for investigation that benefits from free compute.
 Surplus tasks run on free APIs — use them for exploration, auditing, and analysis.
-Valid task types: code_audit, memory_audit, procedure_audit, infrastructure_monitor,
+Valid task types: code_audit, memory_audit, procedure_audit,
 brainstorm_user, brainstorm_self, meta_brainstorm, gap_clustering, self_unblock,
 anticipatory_research, prompt_effectiveness_review.
 Only dispatch when you identify specific work that needs doing. Don't dispatch

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -291,9 +291,9 @@ _CALL_SITE_META: dict[str, dict] = {
         "wired": False,
     },
     "37_infrastructure_monitor": {
-        "description": "Disabled. Surplus-scheduled infrastructure trend detection. Probes built but not wired to surplus scheduler.",
+        "description": "Disabled. Deep reflections may enqueue infra monitor surplus tasks but output quality is low (generic signal summaries from free models). Not independently scheduled.",
         "category": "surplus",
-        "frequency": "Periodic (surplus scheduler)",
+        "frequency": "On deep reflection dispatch only",
         "model_tier": "slm",
         "wired": False,
     },


### PR DESCRIPTION
## Summary

- Add 24h staleness guard to both approval recycling paths (`_find_existing` and `find_approved_unconsumed` SQL) — prevents old approved-but-unconsumed requests from silently bypassing the approval gate
- Disable infrastructure monitor surplus task dispatching from deep reflection prompt (output was low-value free-model signal summaries)
- Update CLAUDE.md ego trap from INERT to ACTIVE (live since v3.0a11)
- Update call site metadata for `37_infrastructure_monitor` to accurately reflect current state

## Context

Telegram audit found inbox sessions firing without approval requests. Root cause was twofold:
1. Server hadn't been restarted in 35h, so PR #198's Pass 3 deletion was never deployed
2. 31 stale unconsumed approvals from April 10-18 were being recycled by `_find_existing()`

Server was restarted and stale approvals consumed via SQL. The code changes here are defense-in-depth to prevent recurrence.

## Test plan

- [x] `ruff check` passes on all changed files
- [x] 576 autonomy tests pass
- [x] 6054/6057 full suite pass (3 pre-existing migration failures on main)
- [x] Verified post-restart: ego creates NEW approval request (not recycled)
- [x] Verified post-restart: micro reflection posted to Telegram at 11:43
- [x] Verified post-restart: light reflection completed at 11:39
- [x] Code review by superpowers:code-reviewer — all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)