### PR TITLE
fix: surplus routing, watchgod /tmp protection, scoring collapse

### DIFF
--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -212,16 +212,16 @@ check_cc_tmp() {
 
 clean_sys_yellow() {
     log INFO "Zone B YELLOW — cleaning /tmp files not accessed in 7+ days"
-    find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -name "*.sock" \
+    find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
         -atime +7 -delete 2>/dev/null || true
-    find /tmp -mindepth 1 -type d -empty -not -path "*/tmux-*" -not -path "*/pytest-*" \
+    find /tmp -mindepth 1 -type d -empty -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" \
         -delete 2>/dev/null || true
 }
 
 clean_sys_orange() {
     clean_sys_yellow
     log WARN "Zone B ORANGE — cleaning /tmp files not accessed in 3+ days"
-    find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -name "*.sock" \
+    find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
         -atime +3 -delete 2>/dev/null || true
     mkdir -p "$ALERT_DIR"
     touch "$ALERT_DIR/tmp_warning"
@@ -230,14 +230,14 @@ clean_sys_orange() {
 clean_sys_red() {
     log WARN "Zone B RED — aggressive /tmp cleanup"
     # Files not accessed in 1+ day
-    find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -name "*.sock" \
+    find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
         -atime +1 -delete 2>/dev/null || true
 
-    # If still critical, remove all regular files except last 1h, sockets, tmux, pytest
+    # If still critical, remove all regular files except last 1h, sockets, tmux, pytest, claude
     local pct_after
     pct_after=$(tmp_usage_pct)
     if (( pct_after > 85 )); then
-        find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -name "*.sock" \
+        find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
             -mmin +60 -delete 2>/dev/null || true
     fi
 

--- a/src/genesis/awareness/scorer.py
+++ b/src/genesis/awareness/scorer.py
@@ -60,12 +60,12 @@ def _update_staleness(current_signals: dict[str, float], prev_signals: dict[str,
 
 _TIME_CURVES: dict[Depth, list[tuple[int, float]]] = {
     Depth.MICRO: [
-        (0, 0.3),       # just happened
+        (0, 0.5),       # softened from 0.3 — counter reset already suppresses
         (1800, 1.0),    # 30min — floor
         (3600, 2.5),    # 60min — overdue
     ],
     Depth.LIGHT: [
-        (0, 0.5),
+        (0, 0.8),       # softened from 0.5 — counter reset already suppresses
         (10800, 1.0),   # 3h
         (21600, 1.5),   # 6h — floor
         (43200, 3.0),   # 12h — alarm

--- a/src/genesis/follow_ups/dispatcher.py
+++ b/src/genesis/follow_ups/dispatcher.py
@@ -161,8 +161,11 @@ class FollowUpDispatcher:
         # 2. Fall back to keyword matching on content
         content = fu.get("content", "").lower()
 
+        # Don't route to MODEL_EVAL via keyword — it requires model_id in
+        # payload which keyword matching can't provide.  Legitimate MODEL_EVAL
+        # follow-ups arrive via structured routing (recon pipeline) above.
         if "benchmark" in content or "eval" in content:
-            return TaskType.MODEL_EVAL, ComputeTier.FREE_API, {"source": "follow_up", "follow_up_id": fu["id"]}
+            return TaskType.BRAINSTORM_SELF, ComputeTier.FREE_API, {"source": "follow_up", "follow_up_id": fu["id"]}
         # DEACTIVATED: anticipatory_research has no web search — route to
         # brainstorm_self until redesigned as CC session task.
         if "research" in content:

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -202,11 +202,19 @@ async def follow_up_create(
     Args:
         content: What needs to happen (actionable description)
         reason: Why this follow-up exists (context for future sessions/ego)
-        strategy: How to handle it:
-            - scheduled_task: Run at scheduled_at time via surplus
-            - surplus_task: Run ASAP via surplus scheduler
-            - ego_judgment: Needs ego evaluation in next cycle
-            - user_input_needed: Requires user decision, surfaced in morning report
+        strategy: How to handle it — choose based on what kind of work this requires:
+            - user_input_needed: Park this for a future interactive session. No
+              automation touches it. Use for anything requiring real CC sessions:
+              coding, plan execution, Genesis development, file edits. Surfaces in
+              morning report so the user can trigger a session when ready.
+            - surplus_task: Enqueue to the free-model surplus system. Runs on idle
+              compute using lightweight free-tier models. ONLY for pure analysis,
+              summarization, or data processing. NOT for code changes, file edits,
+              or anything requiring an interactive CC session.
+            - scheduled_task: Same as surplus_task but triggered at a specific time.
+              Same constraints — free model only, no interactive work.
+            - ego_judgment: Hand to ego for evaluation in its next cycle. Ego decides
+              whether to act, defer, or escalate. Not auto-executed.
         scheduled_at: ISO datetime for scheduled_task strategy (required if strategy is scheduled_task)
         priority: low | medium | high | critical
         pinned: If true, ego can see this follow-up but cannot auto-resolve it.

--- a/tests/test_awareness/test_scorer.py
+++ b/tests/test_awareness/test_scorer.py
@@ -17,7 +17,7 @@ from genesis.db.crud import awareness_ticks
 
 def test_micro_multiplier_at_zero():
     """Micro: 0.3x at 0 minutes elapsed."""
-    assert compute_time_multiplier(Depth.MICRO, elapsed_seconds=0) == 0.3
+    assert compute_time_multiplier(Depth.MICRO, elapsed_seconds=0) == 0.5
 
 
 def test_micro_multiplier_at_floor():
@@ -31,13 +31,13 @@ def test_micro_multiplier_at_overdue():
 
 
 def test_micro_multiplier_interpolated():
-    """Micro: halfway between 0min (0.3) and 30min (1.0) should be ~0.65."""
+    """Micro: halfway between 0min (0.5) and 30min (1.0) should be ~0.75."""
     result = compute_time_multiplier(Depth.MICRO, elapsed_seconds=900)
-    assert abs(result - 0.65) < 0.01
+    assert abs(result - 0.75) < 0.01
 
 
 def test_light_multiplier_at_zero():
-    assert compute_time_multiplier(Depth.LIGHT, elapsed_seconds=0) == 0.5
+    assert compute_time_multiplier(Depth.LIGHT, elapsed_seconds=0) == 0.8
 
 
 def test_light_multiplier_at_3h():

--- a/tests/test_follow_ups/test_dispatcher.py
+++ b/tests/test_follow_ups/test_dispatcher.py
@@ -190,6 +190,7 @@ class TestFollowUpDispatcher:
 
         fu = await follow_ups.get_by_id(db, fid)
         task = await surplus_tasks.get_by_id(db, fu["linked_task_id"])
-        # Falls back to keyword "benchmark" → MODEL_EVAL
+        # Falls back to keyword "benchmark" → BRAINSTORM_SELF (not MODEL_EVAL,
+        # which requires model_id that keyword matching can't provide)
         from genesis.surplus.types import TaskType
-        assert task["task_type"] == str(TaskType.MODEL_EVAL)
+        assert task["task_type"] == str(TaskType.BRAINSTORM_SELF)


### PR DESCRIPTION
## Summary
- **Surplus routing fix**: Keyword fallback (eval/benchmark) now routes to BRAINSTORM_SELF instead of MODEL_EVAL (which requires model_id that keyword matching can't provide). Structured routing from recon pipeline unchanged.
- **Watchgod Zone B fix**: All `/tmp` cleanup commands now exclude `*/claude-*` paths to protect interactive CC session temp dirs during pressure events.
- **Scoring collapse fix**: Softened post-reflection time multiplier curves (Micro 0.3→0.5, Light 0.5→0.8) to prevent 9h silence after deep reflections. Counter signals already suppress redundant ticks.
- **Follow-up strategy docs**: Clarified MCP tool descriptions for strategy field.

## Test plan
- [x] `tests/test_follow_ups/test_dispatcher.py` — 9 tests pass (including updated fallback assertion)
- [x] `tests/test_awareness/test_scorer.py` — 26 tests pass (updated multiplier values)
- [x] Watchgod changes verified via bash syntax check

🤖 Generated with [Claude Code](https://claude.com/claude-code)