### PR TITLE
fix(telegram): polling retry, alert noise, morning report completeness

### DIFF
--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -295,9 +295,6 @@ class DirectSessionRunner:
                 output_tokens=output.output_tokens,
             )
 
-            if request.notify and not request.notify_on_failure_only:
-                await self._notify(request, result, success=True)
-
             logger.info(
                 "Direct session %s completed: %.1fs, $%.4f, %d tools",
                 session_id[:8], elapsed, output.cost_usd, len(telemetry),

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -412,7 +412,16 @@ class DirectSessionRunner:
         *,
         success: bool,
     ) -> None:
-        """Send Telegram notification via outreach pipeline."""
+        """Send Telegram notification via outreach pipeline.
+
+        Only failures are sent — successes are logged to the DB and visible
+        via direct_session_list MCP tool and the dashboard.  Sending success
+        notifications as ALERT was noise: "Direct Session Complete" is not
+        an alert, and in DM-only installs it drowns real alerts.
+        """
+        if success:
+            return
+
         pipeline = getattr(self._rt, "_outreach_pipeline", None)
         if pipeline is None:
             logger.debug("Outreach pipeline not available, skipping notification")
@@ -425,37 +434,23 @@ class DirectSessionRunner:
             )[:8]
         ) or "none"
 
-        if success:
-            title = "Direct Session Complete"
-            preview = result.output_text[:400] if result.output_text else "(no output)"
-            body = (
-                f"<b>{title}</b>\n\n"
-                f"Profile: {request.profile} | "
-                f"Model: {result.model_used or request.model} | "
-                f"Duration: {result.duration_s:.0f}s | "
-                f"Cost: ${result.cost_usd:.4f}\n\n"
-                f"{preview}\n\n"
-                f"Tools: {tools_str}"
-            )
-        else:
-            title = "Direct Session FAILED"
-            body = (
-                f"<b>{title}</b>\n\n"
-                f"Profile: {request.profile} | "
-                f"Model: {request.model} | "
-                f"Duration: {result.duration_s:.0f}s\n\n"
-                f"Error: {result.error or 'unknown'}\n\n"
-                f"Tools before failure: {tools_str}"
-            )
+        body = (
+            f"<b>Direct Session FAILED</b>\n\n"
+            f"Profile: {request.profile} | "
+            f"Model: {request.model} | "
+            f"Duration: {result.duration_s:.0f}s\n\n"
+            f"Error: {result.error or 'unknown'}\n\n"
+            f"Tools before failure: {tools_str}"
+        )
 
         try:
             from genesis.outreach.types import OutreachCategory, OutreachRequest
 
             await pipeline.submit(OutreachRequest(
                 category=OutreachCategory.ALERT,
-                topic=f"direct_session_{'ok' if success else 'fail'}",
+                topic="direct_session_fail",
                 context=body,
-                salience_score=0.9 if not success else 0.7,
+                salience_score=0.9,
             ))
         except Exception:
             logger.error("Outreach submit failed", exc_info=True)

--- a/src/genesis/channels/bridge.py
+++ b/src/genesis/channels/bridge.py
@@ -244,7 +244,7 @@ async def main():
         for cat in (
             "conversation", "morning_report", "alert",
             "reflection_micro", "reflection_light", "reflection_deep", "reflection_strategic",
-            "surplus", "recon", "approvals",
+            "surplus", "recon", "approvals", "ego_proposals",
         ):
             await topic_manager.get_or_create_persistent(cat)
 
@@ -264,6 +264,10 @@ async def main():
         # Wire into surplus scheduler for surplus reflection posting
         if runtime.surplus_scheduler:
             runtime.surplus_scheduler.set_topic_manager(topic_manager)
+
+        # Wire into ego proposal workflow for digest delivery
+        if runtime._ego_proposal_workflow is not None:
+            runtime._ego_proposal_workflow.set_topic_manager(topic_manager)
 
         # One-shot: close orphaned per-session topics from old code (March 24-27).
         # Checks DB for a sentinel category to avoid re-running on every restart.

--- a/src/genesis/channels/telegram/adapter_v2.py
+++ b/src/genesis/channels/telegram/adapter_v2.py
@@ -367,10 +367,23 @@ class TelegramAdapterV2(ChannelAdapter):
         except Exception:
             log.exception("Failed to stop updater — skipping restart")
             return
-        try:
-            await self._app.updater.start_polling(drop_pending_updates=False)
-            log.info("Polling restarted successfully after stall")
-        except Exception:
-            log.exception(
-                "Failed to restart polling — will retry on next stall cycle"
-            )
+        # Try up to 2 attempts with a short delay between them.
+        # Without this, a single TimedOut failure (e.g. on bootstrap_del_webhook)
+        # leaves polling dead for the full stall-backoff period (up to 15 min).
+        for attempt in range(2):
+            try:
+                await self._app.updater.start_polling(drop_pending_updates=False)
+                log.info("Polling restarted successfully after stall")
+                return
+            except Exception:
+                if attempt == 0:
+                    log.warning(
+                        "start_polling attempt 1 failed — retrying in 5s",
+                        exc_info=True,
+                    )
+                    await asyncio.sleep(5)
+                else:
+                    log.exception(
+                        "Failed to restart polling after 2 attempts — "
+                        "will retry on next stall cycle"
+                    )

--- a/src/genesis/identity/MORNING_REPORT.md
+++ b/src/genesis/identity/MORNING_REPORT.md
@@ -71,7 +71,7 @@ delete it.
 - System health — one line if all nominal. Only detail if something is
   actually broken (down, not just degraded).
 - Cost — daily and monthly totals
-- Items requiring user decision — pending approvals, inbox items
+- Items requiring user decision — pending approvals, ego proposals, inbox items
 
 **Omit entirely:**
 - Stable/normal metrics (compress to "All systems nominal")

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -305,6 +305,9 @@ class MorningReportGenerator:
         return header + "\n" + entries
 
     async def _get_pending_items(self) -> str:
+        lines: list[str] = []
+
+        # Message queue items
         cursor = await self._db.execute(
             "SELECT message_type, source, priority, content, created_at "
             "FROM message_queue "
@@ -313,12 +316,54 @@ class MorningReportGenerator:
             "ORDER BY priority, created_at LIMIT 10"
         )
         rows = await cursor.fetchall()
-        if not rows:
-            return "No pending items."
-        return "\n".join(
-            f"- [{r[0]}] priority={r[2]}, from={r[1] or '?'}, created={r[4]}: {r[3][:200]}"
-            for r in rows
-        )
+        for r in rows:
+            lines.append(
+                f"- [{r[0]}] priority={r[2]}, from={r[1] or '?'}, "
+                f"created={r[4]}: {r[3][:200]}"
+            )
+
+        # Pending ego proposals (user needs to approve/reject on dashboard)
+        try:
+            cursor = await self._db.execute(
+                "SELECT id, content, urgency, created_at FROM ego_proposals "
+                "WHERE status = 'pending' ORDER BY created_at DESC LIMIT 5"
+            )
+            proposals = await cursor.fetchall()
+            if proposals:
+                lines.append(
+                    f"- {len(proposals)} pending ego proposal(s) "
+                    "(approve/reject on dashboard):"
+                )
+                for p in proposals:
+                    lines.append(
+                        f"  - {(p[1] or '?')[:150]} "
+                        f"(urgency={p[2] or 'normal'})"
+                    )
+        except Exception:
+            logger.warning(
+                "Morning report: ego proposals query failed", exc_info=True,
+            )
+
+        # Pending approval requests
+        try:
+            cursor = await self._db.execute(
+                "SELECT id, description, created_at FROM approval_requests "
+                "WHERE status = 'pending' ORDER BY created_at DESC LIMIT 5"
+            )
+            approvals = await cursor.fetchall()
+            if approvals:
+                lines.append(
+                    f"- {len(approvals)} pending approval request(s):"
+                )
+                for a in approvals:
+                    lines.append(f"  - {(a[1] or '?')[:150]}")
+        except Exception:
+            logger.warning(
+                "Morning report: approval requests query failed",
+                exc_info=True,
+            )
+
+        return "\n".join(lines) if lines else "No pending items."
 
     async def _get_follow_ups_summary(self) -> str | None:
         """Return follow-ups needing user attention + recently completed."""


### PR DESCRIPTION
## Summary

- **Polling stall restart resilience**: When `start_polling()` fails with `TimedOut` during stall recovery, retry once after 5s instead of waiting the full 15-min backoff cycle. This closes the blind window that dropped approval button presses (observed: consecutive stall #35 left polling dead for 15 min).

- **Alert noise cleanup**: Direct session success notifications ("Direct Session Complete") removed from Telegram ALERT category. Only failures are sent now. Successes are visible via dashboard and `direct_session_list` MCP tool.

- **Morning report surfaces pending items**: Pending ego proposals and approval requests now appear in the Open Items section, giving DM-only users visibility without needing the supergroup.

- **bridge.py bugfix**: Add missing ego proposal wiring and `ego_proposals` topic pre-creation (parity with `standalone.py`).

## Test plan

- [x] `ruff check` on all changed files — passes
- [x] `pytest tests/test_channels/ tests/test_outreach/` — 256 tests pass
- [ ] Verify next polling stall + failed restart logs "attempt 1 failed — retrying in 5s"
- [ ] Verify next morning report includes pending proposals/approvals
- [ ] Verify successful direct sessions no longer send Telegram alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)