### PR TITLE
feat(ego): expand interact profile for content publishing dispatch

### DIFF
--- a/.claude/docs/background-sessions.md
+++ b/.claude/docs/background-sessions.md
@@ -19,15 +19,17 @@ the next few minutes → sub-agent.
 
 ## Profiles
 
-| Profile | Browser | memory_store | outreach_send | Web search |
-|---|---|---|---|---|
-| `observe` | ✗ | ✗ | ✗ | ✓ |
-| `interact` | ✓ | ✓ | ✗ | ✓ |
-| `research` | ✓ | ✓ | ✓ | ✓ |
+| Profile | Browser click/fill | memory_store | outreach_send | follow_up_create | Web search |
+|---|---|---|---|---|---|
+| `observe` | ✗ | ✗ | ✗ | ✗ | ✓ |
+| `research` | ✗ | ✓ | ✗ | ✓ | ✓ |
+| `interact` | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 All profiles block: Bash, Edit, Write, task_submit, settings_update,
-direct_session_run. The `code` profile is intentionally disabled — background
-sessions do not write code.
+direct_session_run. Use `interact` for workflows that operate external
+platforms (publishing, form filling) and need to communicate with the user.
+Use `research` for data gathering that writes to memory. Use `observe` for
+read-only investigation.
 
 ## Key Parameters
 

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -61,9 +61,12 @@ _UNIVERSAL_DISALLOW = [
     "mcp__genesis-health__task_submit",
     "mcp__genesis-health__settings_update",
     "mcp__genesis-health__direct_session_run",  # No recursive spawn
+    "mcp__genesis-health__module_call",
+]
+
+_NO_OUTREACH_SEND = [
     "mcp__genesis-outreach__outreach_send",
     "mcp__genesis-outreach__outreach_send_and_wait",
-    "mcp__genesis-health__module_call",
 ]
 
 # Composable building blocks for profile disallow lists
@@ -107,15 +110,16 @@ _NO_RECON_WRITES = [
 
 PROFILES: dict[str, list[str]] = {
     "observe": (
-        _UNIVERSAL_DISALLOW + _NO_BROWSER_INTERACTION + _NO_MEMORY_WRITES
-        + _NO_FOLLOW_UPS + _NO_OUTREACH_ENGAGEMENT + _NO_RECON_WRITES
+        _UNIVERSAL_DISALLOW + _NO_OUTREACH_SEND + _NO_BROWSER_INTERACTION
+        + _NO_MEMORY_WRITES + _NO_FOLLOW_UPS + _NO_OUTREACH_ENGAGEMENT
+        + _NO_RECON_WRITES
     ),
     "interact": (
-        _UNIVERSAL_DISALLOW + _NO_MEMORY_WRITES
-        + _NO_FOLLOW_UPS + _NO_OUTREACH_ENGAGEMENT + _NO_RECON_WRITES
+        _UNIVERSAL_DISALLOW + _NO_OUTREACH_ENGAGEMENT + _NO_RECON_WRITES
+        + ["mcp__genesis-memory__evolution_propose"]
     ),
     "research": (
-        _UNIVERSAL_DISALLOW + _NO_BROWSER_INTERACTION
+        _UNIVERSAL_DISALLOW + _NO_OUTREACH_SEND + _NO_BROWSER_INTERACTION
     ),
 }
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -483,7 +483,7 @@ class EgoSession:
             logger.warning("Dispatch budget exceeded — skipping execution briefs")
             return
 
-        from genesis.cc.direct_session import DirectSessionRequest
+        from genesis.cc.direct_session import VALID_PROFILES, DirectSessionRequest
         from genesis.cc.types import CCModel, EffortLevel
 
         for brief in briefs:
@@ -506,7 +506,7 @@ class EgoSession:
 
             # Map profile and model from brief
             profile = brief.get("profile", "observe")
-            if profile not in ("observe", "research"):
+            if profile not in VALID_PROFILES:
                 profile = "observe"
             model_str = brief.get("model", "sonnet")
             model = CCModel.SONNET if model_str != "haiku" else CCModel.HAIKU

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -181,8 +181,8 @@ EGO_OUTPUT_SCHEMA = {
                     },
                     "profile": {
                         "type": "string",
-                        "enum": ["observe", "research"],
-                        "description": "Session profile (default: observe)",
+                        "enum": ["observe", "research", "interact"],
+                        "description": "Session profile (default: observe). Use interact for browser + memory + outreach.",
                     },
                     "model": {
                         "type": "string",

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -80,7 +80,7 @@ To dispatch an approved proposal, output an `execution_briefs` entry:
 
 - `proposal_id` — the approved proposal's ID (must match an approved proposal)
 - `prompt` — detailed dispatch instructions for the background session
-- `profile` — "observe" (read-only) or "research" (can write). Default: observe.
+- `profile` — "observe" (read-only), "research" (can write memory), or "interact" (browser + memory + outreach). Default: observe.
 - `model` — "sonnet" (default) or "haiku"
 
 You control whether proposals are sent for review via `communication_decision`:

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -50,6 +50,26 @@ You have MCP tools. Use them before producing your output:
 Do NOT trust pre-assembled context blindly. Observations can be stale.
 Verify anything you're about to act on.
 
+## Skills & Execution Capabilities
+
+Genesis has a skill library at `~/.claude/skills/` — markdown files that
+define step-by-step workflows for complex tasks (content publishing,
+research, browser automation, etc.). Background sessions you dispatch can
+discover and invoke these skills via the `Skill` tool.
+
+When proposing actions that involve multi-step workflows:
+- Search for existing skills with `memory_recall` or mention the skill
+  by name in your dispatch prompt (e.g., "Use the content-publish skill
+  to write and publish a Medium post about X")
+- The dispatched session will find the skill, load it, and follow the
+  workflow
+- If no skill exists for a capability you need, that's worth noting —
+  skills can be created for recurring workflows
+
+Strategic plans (like the master marketing plan) are stored in memory
+and at `~/.genesis/output/`. Use `memory_recall` to find them when
+making proposals that should align with long-term strategy.
+
 ## Proposal Quality
 
 - **Propose actions for the user, not about Genesis.** "Investigate
@@ -119,7 +139,10 @@ To dispatch an approved proposal, output an `execution_briefs` entry:
 
 - `proposal_id` — the approved proposal's ID (must match an approved proposal)
 - `prompt` — detailed dispatch instructions for the background session
-- `profile` — "observe" (read-only) or "research" (can write). Default: observe.
+- `profile` — choose the minimum that covers the task:
+  - `"observe"` — read-only. No browser interaction, no memory writes, no outreach. Default.
+  - `"research"` — can write memory, create follow-ups. No browser interaction.
+  - `"interact"` — full browser interaction + memory writes + can message user via Telegram. Use for workflows that need to operate external platforms (publishing, form filling) AND communicate results.
 - `model` — "sonnet" (default) or "haiku"
 
 You control whether proposals are sent to the user via `communication_decision`:

--- a/src/genesis/mcp/health/direct_session_tools.py
+++ b/src/genesis/mcp/health/direct_session_tools.py
@@ -279,10 +279,11 @@ async def direct_session_run(
 
     Profiles control what the session can do:
     - observe: Read everything, change nothing. Browser viewing, memory reads, web search.
-    - interact: Observe + browser clicks/fills. For social media, web tasks.
-    - research: Observe + memory/observation writes. Stores findings for future use.
+    - research: Observe + memory/observation writes + follow-ups. Stores findings for future use.
+    - interact: Full browser interaction + memory writes + outreach_send + follow-ups.
+      Use for workflows that operate external platforms and communicate with the user.
 
-    All profiles block: Bash, Edit, Write, outreach_send, task_submit, settings_update.
+    All profiles block: Bash, Edit, Write, task_submit, settings_update.
 
     Args:
         prompt: The full instructions for the background session

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -472,6 +472,17 @@ class TestProcessExecutionBriefs:
         req = mock_direct_runner.spawn.call_args[0][0]
         assert req.profile == "observe"
 
+    async def test_interact_profile_accepted(self, ego_with_runner, mock_direct_runner, db):
+        """Interact profile is valid and passes through to the request."""
+        await self._insert_proposal(db, "prop_009")
+
+        briefs = [{"proposal_id": "prop_009", "prompt": "Publish a Medium post",
+                    "profile": "interact", "model": "sonnet"}]
+        await ego_with_runner._process_execution_briefs(briefs)
+
+        req = mock_direct_runner.spawn.call_args[0][0]
+        assert req.profile == "interact"
+
     async def test_empty_brief_skipped(self, ego_with_runner, mock_direct_runner, db):
         """Brief missing proposal_id or prompt is silently skipped."""
         briefs = [

--- a/tests/test_cc/test_direct_session_profiles.py
+++ b/tests/test_cc/test_direct_session_profiles.py
@@ -1,0 +1,147 @@
+"""Tests for direct session profile definitions and tool restrictions.
+
+Validates that profile changes don't accidentally grant or revoke tool access.
+"""
+
+from genesis.cc.direct_session import (
+    PROFILES,
+    VALID_PROFILES,
+)
+
+# --- Profile existence ---
+
+def test_valid_profiles_matches_profiles_dict():
+    """VALID_PROFILES frozenset must match PROFILES keys."""
+    assert frozenset(PROFILES.keys()) == VALID_PROFILES
+
+
+def test_all_expected_profiles_exist():
+    assert "observe" in PROFILES
+    assert "interact" in PROFILES
+    assert "research" in PROFILES
+
+
+# --- Universal safety blocks (all profiles) ---
+
+_UNIVERSAL_BLOCKED = {
+    "Bash", "Edit", "Write", "NotebookEdit",
+    "mcp__genesis-health__task_submit",
+    "mcp__genesis-health__settings_update",
+    "mcp__genesis-health__direct_session_run",
+    "mcp__genesis-health__module_call",
+}
+
+
+def test_observe_blocks_universal():
+    for tool in _UNIVERSAL_BLOCKED:
+        assert tool in PROFILES["observe"], f"observe should block {tool}"
+
+
+def test_interact_blocks_universal():
+    for tool in _UNIVERSAL_BLOCKED:
+        assert tool in PROFILES["interact"], f"interact should block {tool}"
+
+
+def test_research_blocks_universal():
+    for tool in _UNIVERSAL_BLOCKED:
+        assert tool in PROFILES["research"], f"research should block {tool}"
+
+
+# --- Observe: most restrictive ---
+
+def test_observe_blocks_browser_interaction():
+    assert "mcp__genesis-health__browser_click" in PROFILES["observe"]
+    assert "mcp__genesis-health__browser_fill" in PROFILES["observe"]
+    assert "mcp__genesis-health__browser_run_js" in PROFILES["observe"]
+
+
+def test_observe_blocks_memory_writes():
+    assert "mcp__genesis-memory__memory_store" in PROFILES["observe"]
+    assert "mcp__genesis-memory__observation_write" in PROFILES["observe"]
+    assert "mcp__genesis-memory__procedure_store" in PROFILES["observe"]
+
+
+def test_observe_blocks_outreach_send():
+    assert "mcp__genesis-outreach__outreach_send" in PROFILES["observe"]
+    assert "mcp__genesis-outreach__outreach_send_and_wait" in PROFILES["observe"]
+
+
+def test_observe_blocks_follow_ups():
+    assert "mcp__genesis-health__follow_up_create" in PROFILES["observe"]
+
+
+# --- Research: memory writes + follow-ups, no browser interaction ---
+
+def test_research_allows_memory_writes():
+    assert "mcp__genesis-memory__memory_store" not in PROFILES["research"]
+    assert "mcp__genesis-memory__observation_write" not in PROFILES["research"]
+    assert "mcp__genesis-memory__procedure_store" not in PROFILES["research"]
+
+
+def test_research_allows_follow_ups():
+    assert "mcp__genesis-health__follow_up_create" not in PROFILES["research"]
+
+
+def test_research_blocks_browser_interaction():
+    assert "mcp__genesis-health__browser_click" in PROFILES["research"]
+    assert "mcp__genesis-health__browser_fill" in PROFILES["research"]
+    assert "mcp__genesis-health__browser_run_js" in PROFILES["research"]
+
+
+def test_research_blocks_outreach_send():
+    assert "mcp__genesis-outreach__outreach_send" in PROFILES["research"]
+    assert "mcp__genesis-outreach__outreach_send_and_wait" in PROFILES["research"]
+
+
+# --- Interact: most permissive — browser + memory + outreach ---
+
+def test_interact_allows_browser_interaction():
+    assert "mcp__genesis-health__browser_click" not in PROFILES["interact"]
+    assert "mcp__genesis-health__browser_fill" not in PROFILES["interact"]
+    assert "mcp__genesis-health__browser_run_js" not in PROFILES["interact"]
+
+
+def test_interact_allows_memory_writes():
+    assert "mcp__genesis-memory__memory_store" not in PROFILES["interact"]
+    assert "mcp__genesis-memory__observation_write" not in PROFILES["interact"]
+    assert "mcp__genesis-memory__procedure_store" not in PROFILES["interact"]
+
+
+def test_interact_allows_outreach_send():
+    assert "mcp__genesis-outreach__outreach_send" not in PROFILES["interact"]
+    assert "mcp__genesis-outreach__outreach_send_and_wait" not in PROFILES["interact"]
+
+
+def test_interact_allows_follow_ups():
+    assert "mcp__genesis-health__follow_up_create" not in PROFILES["interact"]
+
+
+def test_interact_blocks_outreach_engagement():
+    """Interact should not allow modifying outreach preferences/engagement."""
+    assert "mcp__genesis-outreach__outreach_engagement" in PROFILES["interact"]
+    assert "mcp__genesis-outreach__outreach_preferences" in PROFILES["interact"]
+
+
+def test_interact_blocks_recon_writes():
+    assert "mcp__genesis-recon__recon_store_finding" in PROFILES["interact"]
+
+
+def test_interact_blocks_evolution_propose():
+    """Publishing sessions should not propose evolution changes."""
+    assert "mcp__genesis-memory__evolution_propose" in PROFILES["interact"]
+
+
+# --- Profile shape assertions ---
+
+def test_observe_is_most_restrictive():
+    """Observe should block the most tools."""
+    assert len(PROFILES["observe"]) >= len(PROFILES["research"])
+    assert len(PROFILES["observe"]) >= len(PROFILES["interact"])
+
+
+def test_interact_and_research_share_universal_base():
+    """Both interact and research include all universal blocks."""
+    interact_set = set(PROFILES["interact"])
+    research_set = set(PROFILES["research"])
+    assert _UNIVERSAL_BLOCKED.issubset(interact_set)
+    assert _UNIVERSAL_BLOCKED.issubset(research_set)


### PR DESCRIPTION
## Summary
- Extract `outreach_send` from `_UNIVERSAL_DISALLOW` into composable `_NO_OUTREACH_SEND` list, preserving existing `observe`/`research` behavior
- Expand `interact` profile to allow browser interaction + memory writes + outreach_send + follow-ups, enabling ego-dispatched content publishing with two-layer approval
- Add `interact` to ego execution_briefs schema; use `VALID_PROFILES` import instead of hardcoded tuple in session guard
- Update identity docs (both egos), background-sessions guide, and MCP tool docstring
- 22 new profile regression tests + 1 ego session test

## Context
The ego needs to dispatch sessions that execute the content-publish skill (Medium publishing via browser MCP tools). No existing profile covered the full workflow: `interact` had browser but no memory/outreach, `research` had memory but no browser. Since `interact` had zero call sites, expanding it is safe and avoids a new profile.

## Test plan
- [x] 22 profile tests verify tool grants/denials for all three profiles
- [x] `test_interact_profile_accepted` verifies ego dispatch accepts the new profile
- [x] Full suite: 1982 passed (1 pre-existing migration failure unrelated)
- [x] Lint clean on all changed files
- [ ] E2E: ego cycle dispatches with `profile: "interact"` after merge + restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)