### PR TITLE
feat(autonomy): deep research + exit gate for task executor blocker resolution

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -479,6 +479,14 @@ call_sites:
     default_paid: true
     retry_profile: background
     description: Autonomous executor non-tooling reasoning via API
+  failure_exit_gate:
+    chain:
+    - claude-sonnet
+    - openrouter-qwen36plus
+    default_paid: true
+    retry_profile: background
+    description: Adversarial exit gate — challenges task failures before allowing
+      surrender
   cc_update_analysis:
     chain:
     - mistral-large-free

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -54,6 +54,8 @@ class CCSessionExecutor:
         decomposer: Any,
         reviewer: Any,
         workaround_searcher: Any | None = None,
+        research_searcher: Any | None = None,
+        router: Any | None = None,
         tracer: Any | None = None,
         outreach_pipeline: Any | None = None,
         event_bus: Any | None = None,
@@ -65,6 +67,7 @@ class CCSessionExecutor:
         self._invoker = invoker
         self._decomposer = decomposer
         self._reviewer = reviewer
+        self._router = router
         self._tracer = tracer
         self._outreach = outreach_pipeline
         self._event_bus = event_bus
@@ -78,6 +81,7 @@ class CCSessionExecutor:
             invoker=invoker,
             autonomous_dispatcher=autonomous_dispatcher,
             workaround_searcher=workaround_searcher,
+            research_searcher=research_searcher,
         )
 
         # In-memory state
@@ -298,22 +302,94 @@ class CCSessionExecutor:
                     )
                     return False
 
-                # Handle failed step -- try workaround
+                # Handle failed step -- layered recovery
                 if result.status == "failed":
+                    wt_path = self._worktree_paths.get(task_id)
+
+                    # Layer 1: procedural memory workaround
                     recovered = await self._step_dispatcher.try_workaround(
                         task_id, step, result, step_results,
-                        worktree_path=self._worktree_paths.get(task_id),
+                        worktree_path=wt_path,
                     )
                     if recovered is not None:
                         step_results[-1] = recovered
                         if trace:
                             self._tracer.record_step(trace, recovered)
-                    else:
-                        await self._fail_task(
-                            task_id,
-                            f"Step {step['idx']} failed: {result.result[:300]}",
+                        continue
+
+                    # Layer 2: inline due diligence (quick web+memory)
+                    dd_context = await self._step_dispatcher.try_due_diligence(
+                        step, result,
+                    )
+                    if dd_context:
+                        dd_retry = await self._step_dispatcher.execute_step(
+                            task_id, step, step_results,
+                            workaround=dd_context,
+                            worktree_path=wt_path,
                         )
-                        return False
+                        if dd_retry.status == "completed":
+                            step_results[-1] = dd_retry
+                            if trace:
+                                self._tracer.record_step(trace, dd_retry)
+                            continue
+
+                    # Layer 3: full research session
+                    researched, research_result = (
+                        await self._step_dispatcher.try_research(
+                            task_id, step, result, step_results,
+                            due_diligence_results=dd_context,
+                            worktree_path=wt_path,
+                        )
+                    )
+                    if researched is not None:
+                        step_results[-1] = researched
+                        if trace:
+                            self._tracer.record_step(trace, researched)
+                        continue
+
+                    # Layer 4: exit gate loop (cap 10 — safety net only)
+                    exit_decision = None
+                    prior_rejections: list[dict] = []
+                    for _gate_cycle in range(10):
+                        exit_decision = await self._challenge_failure(
+                            task_id, step, result, research_result,
+                            prior_rejections,
+                        )
+                        if exit_decision.get("verdict") == "accept":
+                            break
+                        # Exit gate rejected — try its suggestion
+                        prior_rejections.append(exit_decision)
+                        suggested = exit_decision.get("suggested_approach", "")
+                        if suggested:
+                            retry = await self._step_dispatcher.execute_step(
+                                task_id, step, step_results,
+                                workaround=suggested,
+                                worktree_path=wt_path,
+                            )
+                            if retry.status == "completed":
+                                step_results[-1] = retry
+                                if trace:
+                                    self._tracer.record_step(trace, retry)
+                                break
+                    else:
+                        # Hit cap 10 — force accept (safety net)
+                        logger.warning(
+                            "Exit gate cap reached for task %s step %d",
+                            task_id, step["idx"],
+                        )
+
+                    if step_results[-1].status == "completed":
+                        continue  # one of the gate retries worked
+
+                    # All recovery exhausted. Record challenge + fail.
+                    await self._record_challenge(
+                        task_id, step, result, research_result, exit_decision,
+                    )
+                    await self._fail_task(
+                        task_id,
+                        f"Step {step['idx']} failed: {result.result[:300]}",
+                    )
+                    return False
 
             # --- VERIFYING (review loop, Amendment #4) ---
             deliverable = _dispatch.synthesize_deliverable(step_results)
@@ -473,6 +549,173 @@ class CCSessionExecutor:
             self._db, task_id, blockers=reason,
         )
         await self._notify(task_id, f"Task failed: {reason}", "alert")
+
+    # =================================================================
+    # Exit gate + challenge recording
+    # =================================================================
+
+    async def _challenge_failure(
+        self,
+        task_id: str,
+        step: dict,
+        result: StepResult,
+        research_result: Any,
+        prior_rejections: list[dict],
+    ) -> dict:
+        """Adversarial exit gate — challenges the failure before accepting it."""
+        if not self._router:
+            # No router → can't run exit gate → accept by default
+            return {"verdict": "accept", "confirmed_blockers": ["No exit gate available"]}
+
+        from pathlib import Path as _Path
+
+        prompt_path = _Path(__file__).resolve().parent / "prompts" / "exit_gate.md"
+        try:
+            template = prompt_path.read_text()
+        except FileNotFoundError:
+            return {"verdict": "accept", "confirmed_blockers": ["Exit gate prompt missing"]}
+
+        desc = step.get("description", step.get("title", "unknown step"))
+        research_conclusion = ""
+        concrete_blockers_text = "None identified"
+        if research_result:
+            research_conclusion = research_result.clues or "No clues found"
+            if research_result.concrete_blockers:
+                concrete_blockers_text = "\n".join(
+                    f"- {b}" for b in research_result.concrete_blockers
+                )
+
+        rejections_text = "None (first attempt)"
+        if prior_rejections:
+            rejections_text = "\n".join(
+                f"- Attempt {i+1}: {r.get('reason', '?')}"
+                for i, r in enumerate(prior_rejections)
+            )
+
+        prompt = (
+            template
+            .replace("{{step_description}}", desc)
+            .replace("{{error_text}}", result.result[:2000])
+            .replace("{{research_conclusion}}", research_conclusion)
+            .replace("{{concrete_blockers}}", concrete_blockers_text)
+            .replace("{{prior_rejections}}", rejections_text)
+        )
+
+        try:
+            llm_result = await self._router.route_call(
+                "failure_exit_gate",
+                [{"role": "user", "content": prompt}],
+            )
+            text = llm_result.content if hasattr(llm_result, "content") else str(llm_result)
+            # Parse JSON from response
+            parsed = self._parse_gate_response(text)
+            if parsed:
+                return parsed
+        except Exception:
+            logger.exception("Exit gate LLM call failed for task %s", task_id)
+
+        # On failure, default to accept (don't infinite loop)
+        return {"verdict": "accept", "confirmed_blockers": ["Exit gate call failed"]}
+
+    @staticmethod
+    def _parse_gate_response(text: str) -> dict | None:
+        """Extract JSON verdict from exit gate response."""
+        import re
+
+        json_block = re.search(r"```json\s*\n(.*?)\n\s*```", text, re.DOTALL)
+        if json_block:
+            try:
+                parsed = json.loads(json_block.group(1))
+                if "verdict" in parsed:
+                    return parsed
+            except json.JSONDecodeError:
+                pass
+
+        # Try bare JSON object
+        for i in range(len(text) - 1, -1, -1):
+            if text[i] == "}":
+                depth = 0
+                for j in range(i, -1, -1):
+                    if text[j] == "}":
+                        depth += 1
+                    elif text[j] == "{":
+                        depth -= 1
+                    if depth == 0:
+                        try:
+                            parsed = json.loads(text[j : i + 1])
+                            if "verdict" in parsed:
+                                return parsed
+                        except json.JSONDecodeError:
+                            break
+                break
+        return None
+
+    async def _record_challenge(
+        self,
+        task_id: str,
+        step: dict,
+        result: StepResult,
+        research_result: Any,
+        exit_decision: dict | None,
+    ) -> None:
+        """Record a permanent execution_challenge observation + follow-up."""
+        desc = step.get("description", step.get("title", "unknown step"))
+
+        # Build challenge content
+        blockers = []
+        clues = None
+        what_needs_to_change = None
+        if research_result:
+            blockers = research_result.concrete_blockers or []
+            clues = research_result.clues
+        if exit_decision and exit_decision.get("verdict") == "accept":
+            what_needs_to_change = exit_decision.get("what_needs_to_change")
+            confirmed = exit_decision.get("confirmed_blockers", [])
+            if confirmed:
+                blockers = confirmed
+
+        content = json.dumps({
+            "task_id": task_id,
+            "step_description": desc,
+            "error": result.result[:1000],
+            "concrete_blockers": blockers,
+            "clues": clues,
+            "what_needs_to_change": what_needs_to_change,
+            "research_session_id": getattr(research_result, "session_id", None),
+        })
+
+        # Create permanent observation
+        try:
+            from genesis.db.crud import observations
+
+            await observations.create(
+                self._db,
+                source="task_executor",
+                obs_type="execution_challenge",
+                content=content,
+                priority="high",
+            )
+            logger.info(
+                "Recorded execution_challenge observation for task %s step %s",
+                task_id, step.get("idx", "?"),
+            )
+        except Exception:
+            logger.exception("Failed to record execution challenge observation")
+
+        # Create follow-up for ego evaluation
+        try:
+            from genesis.db.crud import follow_ups
+
+            await follow_ups.create(
+                self._db,
+                content=f"Execution challenge: step '{desc}' failed after deep research. "
+                f"Blockers: {', '.join(blockers) if blockers else 'unknown'}",
+                source="task_executor",
+                strategy="ego_judgment",
+                reason=content,
+            )
+        except Exception:
+            logger.exception("Failed to create challenge follow-up")
 
     # =================================================================
     # Blocker persistence (Amendment #1)

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -606,7 +606,7 @@ class CCSessionExecutor:
                 "failure_exit_gate",
                 [{"role": "user", "content": prompt}],
             )
-            text = llm_result.content if hasattr(llm_result, "content") else str(llm_result)
+            text = (llm_result.content if hasattr(llm_result, "content") else str(llm_result)) or ""
             # Parse JSON from response
             parsed = self._parse_gate_response(text)
             if parsed:
@@ -686,14 +686,18 @@ class CCSessionExecutor:
 
         # Create permanent observation
         try:
+            import uuid
+
             from genesis.db.crud import observations
 
             await observations.create(
                 self._db,
+                id=str(uuid.uuid4()),
                 source="task_executor",
-                obs_type="execution_challenge",
+                type="execution_challenge",
                 content=content,
                 priority="high",
+                created_at=datetime.now(UTC).isoformat(),
             )
             logger.info(
                 "Recorded execution_challenge observation for task %s step %s",

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -332,6 +332,14 @@ class CCSessionExecutor:
                             if trace:
                                 self._tracer.record_step(trace, dd_retry)
                             continue
+                        if dd_retry.status == "blocked":
+                            await self._persist_blocker(
+                                task_id,
+                                dd_retry.blocker_description or "Blocked during due diligence retry",
+                                TaskPhase.EXECUTING,
+                                step_idx=step["idx"],
+                            )
+                            return False
 
                     # Layer 3: full research session
                     researched, research_result = (
@@ -371,6 +379,16 @@ class CCSessionExecutor:
                                 if trace:
                                     self._tracer.record_step(trace, retry)
                                 break
+                            if retry.status == "blocked":
+                                await self._persist_blocker(
+                                    task_id,
+                                    retry.blocker_description or "Blocked during exit gate retry",
+                                    TaskPhase.EXECUTING,
+                                    step_idx=step["idx"],
+                                )
+                                return False
+                            # Update result for next gate cycle so it judges fresh evidence
+                            result = retry
                     else:
                         # Hit cap 10 — force accept (safety net)
                         logger.warning(

--- a/src/genesis/autonomy/executor/prompts/exit_gate.md
+++ b/src/genesis/autonomy/executor/prompts/exit_gate.md
@@ -1,0 +1,54 @@
+# Failure Exit Gate
+
+A task step failed and a dedicated research session has concluded it cannot
+be resolved with current capabilities.
+
+## Step that failed
+
+{{step_description}}
+
+## Error
+
+```
+{{error_text}}
+```
+
+## Research session conclusion
+
+{{research_conclusion}}
+
+## Claimed concrete blockers
+
+{{concrete_blockers}}
+
+## Prior exit gate attempts
+
+{{prior_rejections}}
+
+## Your job
+
+You are the adversarial exit gate. The task system is trying to give up.
+Challenge it rigorously but reasonably.
+
+Evaluate the claimed blockers:
+
+1. Are they ACTUALLY specific? "Need clicking capabilities" when the system
+   HAS clicking capabilities = REJECT.
+2. Are they genuinely unsolvable right now? Or just hard?
+3. Did the research session actually exhaust reasonable angles?
+4. Could reframing the problem yield a different approach?
+
+You must be a hard judge, but never unreasonable. If the blockers are
+genuinely specific, verified, and the research was thorough — accept.
+
+Respond with a single JSON block:
+
+If rejecting (blockers are vague, incomplete, or there's an untried approach):
+```json
+{"verdict": "reject", "reason": "Why the failure claim is insufficient", "suggested_approach": "Specific alternative to try next"}
+```
+
+If accepting (blockers are genuinely specific and verified):
+```json
+{"verdict": "accept", "confirmed_blockers": ["Verified specific blockers"], "what_needs_to_change": "Summary of what would need to be built/acquired/changed"}
+```

--- a/src/genesis/autonomy/executor/prompts/research_session.md
+++ b/src/genesis/autonomy/executor/prompts/research_session.md
@@ -1,0 +1,67 @@
+# Research Session — Blocker Investigation
+
+You are investigating a blocker that prevented a task step from completing.
+Your job is to find a solution or, failing that, document EXACTLY what would
+need to change for this to become solvable.
+
+## The Blocker
+
+**Step:** {{step_description}}
+
+**Error:**
+```
+{{error_text}}
+```
+
+## What Was Already Tried
+
+{{prior_attempts}}
+
+## Initial Research (due diligence results)
+
+{{due_diligence_results}}
+
+## Instructions
+
+1. Start by understanding the problem deeply. What exactly failed and why?
+2. Search for solutions — try multiple angles, different query formulations.
+3. Read relevant results fully. Don't just skim snippets.
+4. If promising leads emerge, dig deeper. Follow links, read docs, check examples.
+5. If extensive searching turns up nothing relevant, wrap up.
+
+## Adaptive Effort
+
+- Promising results: dig deeper, fetch full pages, try refined searches
+- Dry results: conclude sooner, document what you tried
+
+## Required Output
+
+End your session with a JSON block (fenced in triple backticks with json tag):
+
+```json
+{
+  "found": true,
+  "approach": "Concrete step-by-step approach to resolve the blocker",
+  "sources": ["URLs or references consulted"],
+  "clues": null,
+  "concrete_blockers": []
+}
+```
+
+OR if you cannot find a solution:
+
+```json
+{
+  "found": false,
+  "approach": null,
+  "sources": ["URLs or references consulted"],
+  "clues": "Partial findings, leads worth exploring later",
+  "concrete_blockers": ["SPECIFIC things that would need to change"]
+}
+```
+
+The `concrete_blockers` field is CRITICAL when found=false. You MUST articulate
+specifically what capability, tool, access, or change would be needed. Not "need
+better tools" — but "need a CAPTCHA solving API like 2captcha" or "need Chrome
+CDP access to shadow DOM elements" or "need OAuth credentials for service X."
+Be specific enough that someone reading this knows exactly what to build or acquire.

--- a/src/genesis/autonomy/executor/research.py
+++ b/src/genesis/autonomy/executor/research.py
@@ -1,0 +1,333 @@
+"""Deep research module for task executor blocker resolution.
+
+Provides two layers of investigation when a task step fails:
+
+1. **Inline due diligence** — quick parallel web search + memory recall.
+   The "pull out your phone" step: fast, lightweight, direct API calls.
+   Returns context string if relevant results found, None otherwise.
+
+2. **Research session** — full CC session invocation with research profile.
+   Iterates on the problem with web search, memory, documentation reading.
+   Returns a ResearchResult with either an approach or concrete blockers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from genesis.autonomy.executor.types import ResearchResult
+from genesis.cc.types import CCInvocation, CCModel, CCOutput, EffortLevel
+
+logger = logging.getLogger(__name__)
+
+_PROMPT_DIR = Path(__file__).resolve().parent / "prompts"
+_RESEARCH_PROMPT = _PROMPT_DIR / "research_session.md"
+
+# Call site for the due diligence triage LLM call
+_DD_CALL_SITE = "autonomous_executor_reasoning"
+
+
+class DeepResearcherImpl:
+    """Two-layer research: inline due diligence + full CC research session."""
+
+    def __init__(
+        self,
+        *,
+        db: Any,
+        retriever: Any | None = None,
+        router: Any | None = None,
+        invoker: Any | None = None,
+        event_bus: Any | None = None,
+        web_searcher: Any | None = None,
+    ) -> None:
+        self._db = db
+        self._retriever = retriever
+        self._router = router
+        self._invoker = invoker
+        self._event_bus = event_bus
+        self._web_searcher = web_searcher
+
+    # ─── Layer 1: Inline Due Diligence ───────────────────��──────────────────
+
+    async def inline_due_diligence(self, step: dict, error: str) -> str | None:
+        """Quick web+memory check. Returns context string or None.
+
+        This is the 'pull out your phone' step ��� fast, lightweight,
+        runs BEFORE dispatching a full research session.
+        """
+        if not self._router:
+            logger.debug("Due diligence skipped: no router available")
+            return None
+
+        query = self._build_search_query(step, error)
+        if not query:
+            return None
+
+        # Parallel: web search + memory recall
+        web_task = self._web_search(query)
+        memory_task = self._memory_recall(query)
+        web_results, memory_results = await asyncio.gather(
+            web_task, memory_task, return_exceptions=True,
+        )
+
+        # Collect whatever succeeded
+        context_parts: list[str] = []
+
+        if isinstance(web_results, str) and web_results:
+            context_parts.append(f"**Web search results:**\n{web_results}")
+        elif isinstance(web_results, BaseException):
+            logger.debug("Due diligence web search failed: %s", web_results)
+
+        if isinstance(memory_results, str) and memory_results:
+            context_parts.append(f"**Memory recall:**\n{memory_results}")
+        elif isinstance(memory_results, BaseException):
+            logger.debug("Due diligence memory recall failed: %s", memory_results)
+
+        if not context_parts:
+            return None
+
+        # Triage: ask LLM if any of these results are relevant
+        combined = "\n\n".join(context_parts)
+        triage_result = await self._triage_relevance(step, error, combined)
+        return triage_result
+
+    # ─── Layer 2: Full Research Session ────────────────���────────────────────
+
+    async def research(
+        self,
+        step: dict,
+        error: str,
+        prior_attempts: list[str],
+        due_diligence_results: str | None = None,
+    ) -> ResearchResult | None:
+        """Dispatch a full research CC session.
+
+        Uses CCInvoker.run() (synchronous subprocess) so the executor
+        blocks until research completes. The research session has web
+        search and memory tools but cannot execute code.
+        """
+        if not self._invoker:
+            logger.warning("Research skipped: no CC invoker available")
+            return None
+
+        prompt = self._build_research_prompt(step, error, prior_attempts, due_diligence_results)
+
+        invocation = CCInvocation(
+            prompt=prompt,
+            model=CCModel.SONNET,
+            effort=EffortLevel.HIGH,
+            system_prompt=None,  # Uses default SOUL.md identity
+            append_system_prompt=True,
+            timeout_s=1800,  # 30 min max for research
+            skip_permissions=True,
+            disallowed_tools=[
+                "Bash", "Edit", "Write", "NotebookEdit",
+                "mcp__genesis-health__task_submit",
+                "mcp__genesis-health__settings_update",
+                "mcp__genesis-health__direct_session_run",
+                "mcp__genesis-outreach__outreach_send",
+                "mcp__genesis-outreach__outreach_send_and_wait",
+                "mcp__genesis-health__module_call",
+            ],
+        )
+
+        logger.info(
+            "Research session dispatching for step %s (error: %s...)",
+            step.get("idx", "?"), error[:80],
+        )
+
+        try:
+            output: CCOutput = await self._invoker.run(invocation)
+        except Exception:
+            logger.exception("Research session failed")
+            return ResearchResult(
+                found=False,
+                clues="Research session crashed before producing results",
+                concrete_blockers=["Research infrastructure failure"],
+            )
+
+        return self._parse_research_output(output)
+
+    # ─── Private Helpers ───────────────────────────────────────��────────────
+
+    def _build_search_query(self, step: dict, error: str) -> str:
+        """Build a concise search query from step context and error."""
+        parts: list[str] = []
+        desc = step.get("description", step.get("title", ""))
+        if desc:
+            parts.append(desc[:100])
+
+        # Extract the most informative part of the error
+        error_lines = error.strip().splitlines()
+        if error_lines:
+            # Use last meaningful line (usually the actual error message)
+            for line in reversed(error_lines):
+                stripped = line.strip()
+                if stripped and len(stripped) > 10:
+                    parts.append(stripped[:150])
+                    break
+
+        return " ".join(parts)[:250] if parts else ""
+
+    async def _web_search(self, query: str) -> str:
+        """Run web search and format results."""
+        if not self._web_searcher:
+            return ""
+
+        try:
+            response = await self._web_searcher.search(query, max_results=5)
+            if response.error or not response.results:
+                return ""
+            lines = []
+            for r in response.results[:5]:
+                lines.append(f"- [{r.title}]({r.url}): {r.snippet[:200]}")
+            return "\n".join(lines)
+        except Exception as exc:
+            logger.debug("Web search error in due diligence: %s", exc)
+            return ""
+
+    async def _memory_recall(self, query: str) -> str:
+        """Run memory recall and format results."""
+        if not self._retriever:
+            return ""
+
+        try:
+            results = await self._retriever.recall(
+                query, limit=5, wing="learning",
+            )
+            if not results:
+                return ""
+            lines = []
+            for r in results[:5]:
+                content = r.content[:200] if hasattr(r, "content") else str(r)[:200]
+                lines.append(f"- {content}")
+            return "\n".join(lines)
+        except Exception as exc:
+            logger.debug("Memory recall error in due diligence: %s", exc)
+            return ""
+
+    async def _triage_relevance(
+        self, step: dict, error: str, combined_results: str,
+    ) -> str | None:
+        """Ask the LLM: are these search results relevant to this error?"""
+        desc = step.get("description", step.get("title", "unknown step"))
+        prompt = (
+            f"A task step failed. Step: {desc}\n"
+            f"Error: {error[:500]}\n\n"
+            f"The following information was found via quick search:\n\n"
+            f"{combined_results}\n\n"
+            f"Are any of these results relevant to resolving this error? "
+            f"If yes, summarize the key insight in 2-3 sentences that would "
+            f"help resolve the error. If nothing is relevant, respond with "
+            f"exactly: NOT_RELEVANT"
+        )
+
+        try:
+            result = await self._router.route_call(
+                _DD_CALL_SITE,
+                [{"role": "user", "content": prompt}],
+            )
+            text = result.content if hasattr(result, "content") else str(result)
+            if "NOT_RELEVANT" in text:
+                return None
+            return text.strip()[:2000]
+        except Exception:
+            logger.exception("Due diligence triage LLM call failed")
+            return None
+
+    def _build_research_prompt(
+        self,
+        step: dict,
+        error: str,
+        prior_attempts: list[str],
+        due_diligence_results: str | None,
+    ) -> str:
+        """Build the full research session prompt from template."""
+        try:
+            template = _RESEARCH_PROMPT.read_text()
+        except FileNotFoundError:
+            template = (
+                "Investigate this blocker and produce a JSON result.\n"
+                "Step: {{step_description}}\nError: {{error_text}}\n"
+                "Prior attempts: {{prior_attempts}}\n"
+                "Due diligence: {{due_diligence_results}}"
+            )
+
+        desc = step.get("description", step.get("title", "unknown step"))
+        attempts_text = "\n".join(
+            f"- {a}" for a in prior_attempts
+        ) if prior_attempts else "None"
+        dd_text = due_diligence_results or "No prior research results"
+
+        return (
+            template
+            .replace("{{step_description}}", desc)
+            .replace("{{error_text}}", error[:3000])
+            .replace("{{prior_attempts}}", attempts_text)
+            .replace("{{due_diligence_results}}", dd_text)
+        )
+
+    def _parse_research_output(self, output: CCOutput) -> ResearchResult:
+        """Parse CC session output into a ResearchResult."""
+        text = output.text if hasattr(output, "text") else ""
+        if not text:
+            text = output.result if hasattr(output, "result") else str(output)
+
+        session_id = getattr(output, "session_id", None)
+
+        # Try to find JSON block in output
+        parsed = self._extract_json_from_text(text)
+        if parsed:
+            return ResearchResult(
+                found=bool(parsed.get("found", False)),
+                approach=parsed.get("approach"),
+                sources=parsed.get("sources", []),
+                clues=parsed.get("clues"),
+                concrete_blockers=parsed.get("concrete_blockers", []),
+                session_id=session_id,
+            )
+
+        # Fallback: treat entire output as clues
+        logger.warning("Research session did not produce parseable JSON output")
+        return ResearchResult(
+            found=False,
+            clues=text[:2000],
+            concrete_blockers=["Research session output was not parseable"],
+            session_id=session_id,
+        )
+
+    @staticmethod
+    def _extract_json_from_text(text: str) -> dict | None:
+        """Extract JSON object from text, searching for ```json blocks first."""
+        # Try fenced JSON block
+        import re
+
+        json_block = re.search(r"```json\s*\n(.*?)\n\s*```", text, re.DOTALL)
+        if json_block:
+            try:
+                return json.loads(json_block.group(1))
+            except json.JSONDecodeError:
+                pass
+
+        # Try reverse search for last JSON object
+        for i in range(len(text) - 1, -1, -1):
+            if text[i] == "}":
+                # Find matching opening brace
+                depth = 0
+                for j in range(i, -1, -1):
+                    if text[j] == "}":
+                        depth += 1
+                    elif text[j] == "{":
+                        depth -= 1
+                    if depth == 0:
+                        try:
+                            return json.loads(text[j : i + 1])
+                        except json.JSONDecodeError:
+                            break
+                break
+
+        return None

--- a/src/genesis/autonomy/executor/research.py
+++ b/src/genesis/autonomy/executor/research.py
@@ -116,12 +116,17 @@ class DeepResearcherImpl:
 
         prompt = self._build_research_prompt(step, error, prior_attempts, due_diligence_results)
 
+        # Build MCP config so the research session has access to Genesis
+        # MCP servers (memory recall, web search tools).
+        mcp_config = self._build_mcp_config()
+
         invocation = CCInvocation(
             prompt=prompt,
             model=CCModel.SONNET,
             effort=EffortLevel.HIGH,
             system_prompt=None,  # Uses default SOUL.md identity
             append_system_prompt=True,
+            mcp_config=mcp_config,
             timeout_s=1800,  # 30 min max for research
             skip_permissions=True,
             disallowed_tools=[
@@ -151,6 +156,17 @@ class DeepResearcherImpl:
             )
 
         return self._parse_research_output(output)
+
+    def _build_mcp_config(self) -> str | None:
+        """Build MCP config for research sessions (reflection profile)."""
+        try:
+            from genesis.cc.session_config import SessionConfigBuilder
+
+            builder = SessionConfigBuilder()
+            return builder.build_mcp_config(profile="reflection")
+        except Exception:
+            logger.debug("Could not build MCP config, session will use project defaults")
+            return None
 
     # ─── Private Helpers ───────────────────────────────────────��────────────
 

--- a/src/genesis/autonomy/executor/research.py
+++ b/src/genesis/autonomy/executor/research.py
@@ -231,8 +231,8 @@ class DeepResearcherImpl:
                 _DD_CALL_SITE,
                 [{"role": "user", "content": prompt}],
             )
-            text = result.content if hasattr(result, "content") else str(result)
-            if "NOT_RELEVANT" in text:
+            text = (result.content if hasattr(result, "content") else str(result)) or ""
+            if not text or "NOT_RELEVANT" in text:
                 return None
             return text.strip()[:2000]
         except Exception:

--- a/src/genesis/autonomy/executor/step_dispatcher.py
+++ b/src/genesis/autonomy/executor/step_dispatcher.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from genesis.autonomy.autonomous_dispatch import AutonomousDispatchRequest
 from genesis.autonomy.executor import dispatch as _dispatch
-from genesis.autonomy.executor.types import StepResult, StepType
+from genesis.autonomy.executor.types import ResearchResult, StepResult, StepType
 
 logger = logging.getLogger(__name__)
 
@@ -39,11 +39,13 @@ class StepDispatcher:
         invoker: Any,
         autonomous_dispatcher: Any | None = None,
         workaround_searcher: Any | None = None,
+        research_searcher: Any | None = None,
     ) -> None:
         self._db = db
         self._invoker = invoker
         self._autonomous_dispatcher = autonomous_dispatcher
         self._workaround = workaround_searcher
+        self._research = research_searcher
 
     async def execute_step(
         self,
@@ -337,3 +339,66 @@ class StepDispatcher:
             worktree_path=worktree_path,
         )
         return retry if retry.status == "completed" else None
+
+    async def try_due_diligence(
+        self,
+        step: dict,
+        failed_result: StepResult,
+    ) -> str | None:
+        """Quick inline research. Returns context string or None."""
+        if not self._research:
+            return None
+
+        try:
+            return await self._research.inline_due_diligence(
+                step, failed_result.result,
+            )
+        except Exception:
+            logger.error(
+                "Due diligence failed for step %d",
+                step.get("idx", "?"), exc_info=True,
+            )
+            return None
+
+    async def try_research(
+        self,
+        task_id: str,
+        step: dict,
+        failed_result: StepResult,
+        step_results: list[StepResult],
+        due_diligence_results: str | None = None,
+        *,
+        worktree_path: Path | None = None,
+    ) -> tuple[StepResult | None, ResearchResult | None]:
+        """Dispatch research session. Returns (retry_result, research_result).
+
+        If research finds an approach, retries the step with that context.
+        Returns (successful_retry, research_result) or (None, research_result).
+        """
+        if not self._research:
+            return None, None
+
+        try:
+            research_result = await self._research.research(
+                step, failed_result.result, [],
+                due_diligence_results=due_diligence_results,
+            )
+        except Exception:
+            logger.error(
+                "Research session failed for step %d",
+                step.get("idx", "?"), exc_info=True,
+            )
+            return None, None
+
+        if research_result is None or not research_result.found:
+            return None, research_result
+
+        # Retry with research-derived approach
+        retry = await self.execute_step(
+            task_id, step, step_results,
+            workaround=research_result.approach,
+            worktree_path=worktree_path,
+        )
+        if retry.status == "completed":
+            return retry, research_result
+        return None, research_result

--- a/src/genesis/autonomy/executor/trace.py
+++ b/src/genesis/autonomy/executor/trace.py
@@ -184,17 +184,21 @@ class ExecutionTracer:
             )
             return
 
-        # Skip retrospective for trivial traces (single-step fallbacks, all failed)
         completed = sum(1 for s in trace.step_results if s.status == "completed")
-        if completed == 0:
-            logger.info(
-                "Retrospective skipped for task %s: no completed steps",
-                trace.task_id,
-            )
-            return
 
         try:
             prompt = await self._build_retrospective_prompt(trace, summary)
+
+            # Inject failure-mode guidance when all steps failed
+            if completed == 0:
+                prompt += (
+                    "\n\n## ALL-FAILED TRACE\n\n"
+                    "This task produced no completed steps. Focus on:\n"
+                    "- What went wrong and why (root cause, not symptoms)\n"
+                    "- Whether failures are transient or permanent\n"
+                    "- Use procedure_updates with outcome='failure' to document anti-patterns\n"
+                    "- DO NOT create new_procedures from failure (no 'how to fail' procedures)\n"
+                )
             result = await self._router.route_call(
                 _CALL_SITE,
                 [{"role": "user", "content": prompt}],

--- a/src/genesis/autonomy/executor/types.py
+++ b/src/genesis/autonomy/executor/types.py
@@ -221,6 +221,32 @@ class WorkaroundResult:
     approach: str | None = None
 
 
+@dataclass(frozen=True)
+class ResearchResult:
+    """Result of a deep research session investigating a blocker."""
+
+    found: bool
+    approach: str | None = None  # actionable approach if found=True
+    sources: list[str] = field(default_factory=list)
+    clues: str | None = None  # partial findings even when found=False
+    concrete_blockers: list[str] = field(default_factory=list)  # what needs to change
+    session_id: str | None = None  # research session ID for traceability
+
+
+@runtime_checkable
+class ResearchSearcher(Protocol):
+    """Protocol for deep research dispatch (implemented in research.py)."""
+
+    async def inline_due_diligence(
+        self, step: dict, error: str,
+    ) -> str | None: ...
+
+    async def research(
+        self, step: dict, error: str, prior_attempts: list[str],
+        due_diligence_results: str | None = None,
+    ) -> ResearchResult | None: ...
+
+
 @runtime_checkable
 class ExecutionTracerProto(Protocol):
     """Protocol for execution trace recording (implemented in trace.py)."""

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -15,6 +15,7 @@ _PERMANENT_TYPES: frozenset[str] = frozenset({
     "feedback_rule",             # Learned behavioral rules
     "genesis_version_baseline",  # Single reference point, replaced on next version
     "cc_version_baseline",       # Single reference point, replaced on next version
+    "execution_challenge",       # Task failure post-mortem — resolved manually
 })
 
 # Default TTL for types not explicitly listed. Any new type that appears without

--- a/src/genesis/identity/TASK_RETROSPECTIVE.md
+++ b/src/genesis/identity/TASK_RETROSPECTIVE.md
@@ -78,3 +78,12 @@ Return ONLY a JSON object:
   flag when X") not vague ("be careful with Y").
 - Think about what would help if this exact task type came up again next
   week. What would you want to know?
+
+## Handling Failures
+
+If the trace shows failed steps:
+- Document failure patterns as procedure_updates with `outcome: "failure"`
+- Include `failure_condition` with the specific technical root cause
+- Include `workaround` if a workaround was attempted (even if it failed)
+- For ALL-failed traces: focus entirely on documenting what went wrong and why
+- Never create a `new_procedure` from failure — only update existing ones

--- a/src/genesis/runtime/init/tasks.py
+++ b/src/genesis/runtime/init/tasks.py
@@ -22,6 +22,7 @@ async def init(rt: GenesisRuntime) -> None:
         from genesis.autonomy.decomposer import TaskDecomposer
         from genesis.autonomy.dispatcher import TaskDispatcher
         from genesis.autonomy.executor.engine import CCSessionExecutor
+        from genesis.autonomy.executor.research import DeepResearcherImpl
         from genesis.autonomy.executor.review import TaskReviewer
         from genesis.autonomy.executor.trace import ExecutionTracer
         from genesis.autonomy.executor.workaround import WorkaroundSearcherImpl
@@ -47,6 +48,14 @@ async def init(rt: GenesisRuntime) -> None:
             invoker=rt._cc_invoker,
         )
         workaround = WorkaroundSearcherImpl(db=rt._db)
+        researcher = DeepResearcherImpl(
+            db=rt._db,
+            retriever=getattr(rt, "_hybrid_retriever", None),
+            router=rt._router,
+            invoker=rt._cc_invoker,
+            event_bus=rt._event_bus,
+            web_searcher=getattr(rt, "_web_searcher", None),
+        )
         tracer = ExecutionTracer(
             db=rt._db,
             memory_store=getattr(rt, "_memory_store", None),
@@ -64,6 +73,8 @@ async def init(rt: GenesisRuntime) -> None:
             decomposer=decomposer,
             reviewer=reviewer,
             workaround_searcher=workaround,
+            research_searcher=researcher,
+            router=rt._router,
             tracer=tracer,
             outreach_pipeline=getattr(rt, "_outreach_pipeline", None),
             event_bus=rt._event_bus,

--- a/src/genesis/runtime/init/tasks.py
+++ b/src/genesis/runtime/init/tasks.py
@@ -54,6 +54,8 @@ async def init(rt: GenesisRuntime) -> None:
             router=rt._router,
             invoker=rt._cc_invoker,
             event_bus=rt._event_bus,
+            # GROUNDWORK(web-dd): web_searcher not yet on runtime; due diligence
+            # degrades to memory-only until WebSearcher is wired as a service.
             web_searcher=getattr(rt, "_web_searcher", None),
         )
         tracer = ExecutionTracer(

--- a/tests/test_autonomy/test_executor/test_research.py
+++ b/tests/test_autonomy/test_executor/test_research.py
@@ -446,8 +446,10 @@ class TestRecordChallenge:
             # Observation was created
             mock_obs.assert_called_once()
             obs_call = mock_obs.call_args
-            assert obs_call.kwargs["obs_type"] == "execution_challenge"
+            assert obs_call.kwargs["type"] == "execution_challenge"
             assert obs_call.kwargs["priority"] == "high"
+            assert "id" in obs_call.kwargs
+            assert "created_at" in obs_call.kwargs
 
             # Follow-up was created
             mock_fu.assert_called_once()

--- a/tests/test_autonomy/test_executor/test_research.py
+++ b/tests/test_autonomy/test_executor/test_research.py
@@ -1,0 +1,490 @@
+"""Tests for genesis.autonomy.executor.research.DeepResearcherImpl."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from genesis.autonomy.executor.research import DeepResearcherImpl
+from genesis.autonomy.executor.types import ResearchResult
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class FakeSearchResponse:
+    query: str = ""
+    results: list = field(default_factory=list)
+    error: str | None = None
+
+
+@dataclass
+class FakeSearchResult:
+    title: str = "Test Result"
+    url: str = "https://example.com"
+    snippet: str = "This is a relevant snippet about the solution"
+
+
+@dataclass
+class FakeRetrievalResult:
+    content: str = "Previously solved: use --flag to fix this"
+    score: float = 0.8
+
+
+@dataclass
+class FakeRouterResult:
+    success: bool = True
+    content: str = "The key insight is to use X instead of Y"
+
+
+@dataclass
+class FakeCCOutput:
+    text: str = ""
+    session_id: str = "ses-research-001"
+    cost_usd: float = 0.01
+    model_used: str = "sonnet"
+    result: str = ""
+
+
+# ─── Due Diligence Tests ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestInlineDueDiligence:
+    async def test_no_router_returns_none(self) -> None:
+        researcher = DeepResearcherImpl(db=AsyncMock(), router=None)
+        result = await researcher.inline_due_diligence(
+            {"idx": 1, "description": "Fix the API call"},
+            "ConnectionError: timeout",
+        )
+        assert result is None
+
+    async def test_web_finds_relevant_result(self) -> None:
+        web_searcher = AsyncMock()
+        web_searcher.search.return_value = FakeSearchResponse(
+            results=[FakeSearchResult(
+                title="How to fix timeout errors",
+                snippet="Set the timeout to 30s and add retry logic",
+            )],
+        )
+
+        router = AsyncMock()
+        router.route_call.return_value = FakeRouterResult(
+            content="The solution is to increase the timeout to 30s and add retry logic.",
+        )
+
+        researcher = DeepResearcherImpl(
+            db=AsyncMock(),
+            router=router,
+            web_searcher=web_searcher,
+        )
+        result = await researcher.inline_due_diligence(
+            {"idx": 1, "description": "Call external API"},
+            "ConnectionError: timed out after 10s",
+        )
+        assert result is not None
+        assert "timeout" in result.lower() or "30s" in result
+
+    async def test_web_returns_nothing(self) -> None:
+        web_searcher = AsyncMock()
+        web_searcher.search.return_value = FakeSearchResponse(results=[])
+
+        router = AsyncMock()
+        router.route_call.return_value = FakeRouterResult(content="NOT_RELEVANT")
+
+        researcher = DeepResearcherImpl(
+            db=AsyncMock(),
+            router=router,
+            web_searcher=web_searcher,
+        )
+        result = await researcher.inline_due_diligence(
+            {"idx": 1, "description": "Do something"},
+            "SomeError: unknown",
+        )
+        assert result is None
+
+    async def test_memory_provides_context(self) -> None:
+        retriever = AsyncMock()
+        retriever.recall.return_value = [
+            FakeRetrievalResult(content="Use --no-cache flag to bypass this"),
+        ]
+
+        router = AsyncMock()
+        router.route_call.return_value = FakeRouterResult(
+            content="Based on memory: use --no-cache flag to bypass the issue.",
+        )
+
+        researcher = DeepResearcherImpl(
+            db=AsyncMock(),
+            router=router,
+            retriever=retriever,
+            web_searcher=AsyncMock(search=AsyncMock(return_value=FakeSearchResponse())),
+        )
+        result = await researcher.inline_due_diligence(
+            {"idx": 2, "description": "Build the project"},
+            "CacheError: stale cache entry",
+        )
+        assert result is not None
+        assert "cache" in result.lower()
+
+    async def test_both_sources_fail_gracefully(self) -> None:
+        web_searcher = AsyncMock()
+        web_searcher.search.side_effect = Exception("network error")
+
+        retriever = AsyncMock()
+        retriever.recall.side_effect = Exception("qdrant down")
+
+        router = AsyncMock()
+
+        researcher = DeepResearcherImpl(
+            db=AsyncMock(),
+            router=router,
+            web_searcher=web_searcher,
+            retriever=retriever,
+        )
+        result = await researcher.inline_due_diligence(
+            {"idx": 1, "description": "Do thing"},
+            "Error happened",
+        )
+        assert result is None
+
+
+# ─── Research Session Tests ──────────────────────────────────────���───────────
+
+
+@pytest.mark.asyncio
+class TestResearchSession:
+    async def test_no_invoker_returns_none(self) -> None:
+        researcher = DeepResearcherImpl(db=AsyncMock(), invoker=None)
+        result = await researcher.research(
+            {"idx": 1, "description": "Fix bug"},
+            "Error",
+            [],
+        )
+        assert result is None
+
+    async def test_session_finds_approach(self) -> None:
+        output = FakeCCOutput(
+            text='Some analysis...\n```json\n{"found": true, "approach": "Use library X version 2.0 which fixes this bug", "sources": ["https://github.com/lib/issues/123"], "clues": null, "concrete_blockers": []}\n```',
+        )
+        invoker = AsyncMock()
+        invoker.run.return_value = output
+
+        researcher = DeepResearcherImpl(
+            db=AsyncMock(),
+            invoker=invoker,
+        )
+        result = await researcher.research(
+            {"idx": 1, "description": "Fix dependency issue"},
+            "ImportError: incompatible version",
+            ["Tried upgrading to latest"],
+        )
+        assert result is not None
+        assert result.found is True
+        assert "library X" in result.approach
+        assert result.session_id == "ses-research-001"
+
+    async def test_session_finds_nothing_with_blockers(self) -> None:
+        output = FakeCCOutput(
+            text='After extensive search...\n```json\n{"found": false, "approach": null, "sources": ["https://docs.example.com"], "clues": "The API requires OAuth2 but we have no credentials", "concrete_blockers": ["Need OAuth2 client credentials for service X"]}\n```',
+        )
+        invoker = AsyncMock()
+        invoker.run.return_value = output
+
+        researcher = DeepResearcherImpl(
+            db=AsyncMock(),
+            invoker=invoker,
+        )
+        result = await researcher.research(
+            {"idx": 2, "description": "Authenticate with service"},
+            "401 Unauthorized",
+            [],
+        )
+        assert result is not None
+        assert result.found is False
+        assert "OAuth2" in result.concrete_blockers[0]
+        assert result.clues is not None
+
+    async def test_session_crash_returns_failure_result(self) -> None:
+        invoker = AsyncMock()
+        invoker.run.side_effect = RuntimeError("subprocess killed")
+
+        researcher = DeepResearcherImpl(
+            db=AsyncMock(),
+            invoker=invoker,
+        )
+        result = await researcher.research(
+            {"idx": 1, "description": "Do thing"},
+            "Error",
+            [],
+        )
+        assert result is not None
+        assert result.found is False
+        assert "crashed" in result.clues.lower()
+
+    async def test_unparseable_output_falls_back(self) -> None:
+        output = FakeCCOutput(
+            text="I searched a lot but here is what I found: the API is broken and needs a fix.",
+        )
+        invoker = AsyncMock()
+        invoker.run.return_value = output
+
+        researcher = DeepResearcherImpl(
+            db=AsyncMock(),
+            invoker=invoker,
+        )
+        result = await researcher.research(
+            {"idx": 1, "description": "Fix API"},
+            "Error",
+            [],
+        )
+        assert result is not None
+        assert result.found is False
+        assert "API is broken" in result.clues
+
+
+# ─── Exit Gate Tests (via engine) ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestExitGate:
+    async def test_rejects_vague_blockers(self) -> None:
+        from genesis.autonomy.executor.engine import CCSessionExecutor
+
+        router = AsyncMock()
+        router.route_call.return_value = FakeRouterResult(
+            content='```json\n{"verdict": "reject", "reason": "Blocker is too vague", "suggested_approach": "Try using the --force flag"}\n```',
+        )
+
+        engine = CCSessionExecutor(
+            db=AsyncMock(),
+            invoker=AsyncMock(),
+            decomposer=AsyncMock(),
+            reviewer=AsyncMock(),
+            router=router,
+        )
+
+        from genesis.autonomy.executor.types import StepResult
+
+        research_result = ResearchResult(
+            found=False,
+            concrete_blockers=["Need better tools"],
+        )
+
+        decision = await engine._challenge_failure(
+            "task-1",
+            {"idx": 1, "description": "Do complex thing"},
+            StepResult(idx=1, status="failed", result="It didn't work"),
+            research_result,
+            [],
+        )
+        assert decision["verdict"] == "reject"
+        assert "suggested_approach" in decision
+
+    async def test_accepts_concrete_blockers(self) -> None:
+        from genesis.autonomy.executor.engine import CCSessionExecutor
+
+        router = AsyncMock()
+        router.route_call.return_value = FakeRouterResult(
+            content='```json\n{"verdict": "accept", "confirmed_blockers": ["Need OAuth2 credentials for service X"], "what_needs_to_change": "Acquire OAuth2 client_id and client_secret from service X admin panel"}\n```',
+        )
+
+        engine = CCSessionExecutor(
+            db=AsyncMock(),
+            invoker=AsyncMock(),
+            decomposer=AsyncMock(),
+            reviewer=AsyncMock(),
+            router=router,
+        )
+
+        from genesis.autonomy.executor.types import StepResult
+
+        research_result = ResearchResult(
+            found=False,
+            concrete_blockers=["Need OAuth2 credentials for service X"],
+        )
+
+        decision = await engine._challenge_failure(
+            "task-1",
+            {"idx": 1, "description": "Authenticate"},
+            StepResult(idx=1, status="failed", result="401 Unauthorized"),
+            research_result,
+            [],
+        )
+        assert decision["verdict"] == "accept"
+        assert "OAuth2" in decision["confirmed_blockers"][0]
+
+    async def test_no_router_defaults_to_accept(self) -> None:
+        from genesis.autonomy.executor.engine import CCSessionExecutor
+
+        engine = CCSessionExecutor(
+            db=AsyncMock(),
+            invoker=AsyncMock(),
+            decomposer=AsyncMock(),
+            reviewer=AsyncMock(),
+            router=None,
+        )
+
+        from genesis.autonomy.executor.types import StepResult
+
+        decision = await engine._challenge_failure(
+            "task-1",
+            {"idx": 1, "description": "Thing"},
+            StepResult(idx=1, status="failed", result="Error"),
+            None,
+            [],
+        )
+        assert decision["verdict"] == "accept"
+
+    async def test_llm_failure_defaults_to_accept(self) -> None:
+        from genesis.autonomy.executor.engine import CCSessionExecutor
+
+        router = AsyncMock()
+        router.route_call.side_effect = Exception("LLM unavailable")
+
+        engine = CCSessionExecutor(
+            db=AsyncMock(),
+            invoker=AsyncMock(),
+            decomposer=AsyncMock(),
+            reviewer=AsyncMock(),
+            router=router,
+        )
+
+        from genesis.autonomy.executor.types import StepResult
+
+        decision = await engine._challenge_failure(
+            "task-1",
+            {"idx": 1, "description": "Thing"},
+            StepResult(idx=1, status="failed", result="Error"),
+            None,
+            [],
+        )
+        assert decision["verdict"] == "accept"
+
+    async def test_prior_rejections_passed_in_prompt(self) -> None:
+        from genesis.autonomy.executor.engine import CCSessionExecutor
+
+        router = AsyncMock()
+        router.route_call.return_value = FakeRouterResult(
+            content='```json\n{"verdict": "accept", "confirmed_blockers": ["Real blocker"], "what_needs_to_change": "Fix X"}\n```',
+        )
+
+        engine = CCSessionExecutor(
+            db=AsyncMock(),
+            invoker=AsyncMock(),
+            decomposer=AsyncMock(),
+            reviewer=AsyncMock(),
+            router=router,
+        )
+
+        from genesis.autonomy.executor.types import StepResult
+
+        prior = [
+            {"verdict": "reject", "reason": "Try harder", "suggested_approach": "Do X"},
+            {"verdict": "reject", "reason": "Still vague", "suggested_approach": "Do Y"},
+        ]
+
+        await engine._challenge_failure(
+            "task-1",
+            {"idx": 1, "description": "Thing"},
+            StepResult(idx=1, status="failed", result="Error"),
+            ResearchResult(found=False, concrete_blockers=["Specific blocker"]),
+            prior,
+        )
+        # Verify router was called with prior rejections in the prompt
+        call_args = router.route_call.call_args
+        prompt_content = call_args[0][1][0]["content"]
+        assert "Try harder" in prompt_content
+        assert "Still vague" in prompt_content
+
+
+# ─── Challenge Recording Tests ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestRecordChallenge:
+    async def test_creates_observation_and_follow_up(self) -> None:
+        from genesis.autonomy.executor.engine import CCSessionExecutor
+        from genesis.autonomy.executor.types import StepResult
+
+        db = AsyncMock()
+
+        engine = CCSessionExecutor(
+            db=db,
+            invoker=AsyncMock(),
+            decomposer=AsyncMock(),
+            reviewer=AsyncMock(),
+        )
+
+        research_result = ResearchResult(
+            found=False,
+            clues="Partial findings about the issue",
+            concrete_blockers=["Need credential X"],
+            session_id="ses-123",
+        )
+
+        exit_decision = {
+            "verdict": "accept",
+            "confirmed_blockers": ["Need credential X"],
+            "what_needs_to_change": "Acquire X from admin panel",
+        }
+
+        with (
+            patch("genesis.db.crud.observations.create", new_callable=AsyncMock) as mock_obs,
+            patch("genesis.db.crud.follow_ups.create", new_callable=AsyncMock) as mock_fu,
+        ):
+            await engine._record_challenge(
+                "task-1",
+                {"idx": 1, "description": "Authenticate with service"},
+                StepResult(idx=1, status="failed", result="401 Unauthorized"),
+                research_result,
+                exit_decision,
+            )
+
+            # Observation was created
+            mock_obs.assert_called_once()
+            obs_call = mock_obs.call_args
+            assert obs_call.kwargs["obs_type"] == "execution_challenge"
+            assert obs_call.kwargs["priority"] == "high"
+
+            # Follow-up was created
+            mock_fu.assert_called_once()
+            fu_call = mock_fu.call_args
+            assert fu_call.kwargs["strategy"] == "ego_judgment"
+            assert "Authenticate with service" in fu_call.kwargs["content"]
+
+
+# ─── JSON Parsing Tests ──────────────────────────────────────────────────────
+
+
+class TestJsonParsing:
+    def test_parse_fenced_json(self) -> None:
+        text = "Here is my analysis:\n```json\n{\"found\": true, \"approach\": \"Do X\"}\n```\nDone."
+        result = DeepResearcherImpl._extract_json_from_text(text)
+        assert result == {"found": True, "approach": "Do X"}
+
+    def test_parse_bare_json(self) -> None:
+        text = 'After analysis, the result is {"found": false, "clues": "nothing"}'
+        result = DeepResearcherImpl._extract_json_from_text(text)
+        assert result == {"found": False, "clues": "nothing"}
+
+    def test_parse_no_json(self) -> None:
+        text = "No JSON here, just plain text."
+        result = DeepResearcherImpl._extract_json_from_text(text)
+        assert result is None
+
+    def test_parse_gate_response_fenced(self) -> None:
+        from genesis.autonomy.executor.engine import CCSessionExecutor
+
+        text = '```json\n{"verdict": "reject", "reason": "vague"}\n```'
+        result = CCSessionExecutor._parse_gate_response(text)
+        assert result == {"verdict": "reject", "reason": "vague"}
+
+    def test_parse_gate_response_bare(self) -> None:
+        from genesis.autonomy.executor.engine import CCSessionExecutor
+
+        text = 'I think: {"verdict": "accept", "confirmed_blockers": ["X"]}'
+        result = CCSessionExecutor._parse_gate_response(text)
+        assert result["verdict"] == "accept"

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -130,7 +130,7 @@ def test_load_full_yaml(monkeypatch):
     assert "openrouter-deepseek-r1" not in cfg.providers
     # Call sites evolve — assert actual count matches config, and lock in
     # a few load-bearing ids rather than chasing the total on every edit.
-    assert len(cfg.call_sites) == 43
+    assert len(cfg.call_sites) == 44
     assert "background" in cfg.retry_profiles
     assert cfg.call_sites["12_surplus_brainstorm"].never_pays is True
     assert cfg.call_sites["5_deep_reflection"].default_paid is True


### PR DESCRIPTION
## Summary
- Adds layered recovery strategy when task steps fail: workaround → due diligence → research session → exit gate
- Research sessions use CCInvoker.run() (synchronous) with disallowed tools for safety
- Exit gate adversarially challenges failures before allowing them (cap 10 safety net)
- execution_challenge observations are PERMANENT (never TTL-expire)
- Failure retrospectives now run on all-failed traces with specialized guidance

## Architecture

```
Step fails → try_workaround (procedural memory)
  → try_due_diligence (quick web+memory, LLM triage)
    → try_research (full CC session, research profile)
      → exit gate loop (adversarial challenge, retry with suggestions)
        → _record_challenge (permanent observation + follow-up)
```

## Files changed (12)
- `types.py` — ResearchResult + ResearchSearcher protocol
- `research.py` — DeepResearcherImpl (due diligence + session dispatch)
- `prompts/` — research_session.md + exit_gate.md templates
- `engine.py` — Layered failed-step handler + _challenge_failure + _record_challenge
- `step_dispatcher.py` — try_due_diligence + try_research methods
- `trace.py` — Remove completed==0 skip, add failure-mode guidance
- `observations.py` — execution_challenge in _PERMANENT_TYPES
- `model_routing.yaml` — failure_exit_gate call site
- `tasks.py` — Wire DeepResearcherImpl into runtime construction
- `TASK_RETROSPECTIVE.md` — Failure handling guidance

## Test plan
- [x] 21 new unit tests (test_research.py) covering all layers
- [x] 207 total executor tests pass (zero regressions)
- [x] 17 observations tests pass
- [x] ruff check passes on all changed files
- [x] Code review completed, critical bug (observations.create kwargs) fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)