### PR TITLE
fix(browser): per-keystroke typing for CDP remote sessions

### DIFF
--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -727,17 +727,17 @@ async def _click_in_shadow_dom(page, selector: str) -> bool:
 async def _human_type(page, selector: str, value: str) -> None:
     """Type text character-by-character with human-like timing.
 
-    Camoufox mode: clears field via fill(""), then types per-keystroke
-    with randomized inter-key intervals.  This fires the full
-    keydown → keypress/input → keyup event chain per character that
-    behavioral detection systems expect from real users.
+    Camoufox and CDP remote: clears field via fill(""), then types
+    per-keystroke with randomized inter-key intervals.  This fires
+    the full keydown → keypress/input → keyup event chain per character
+    that behavioral detection systems expect from real users.
 
     Uses per-character randomization via keyboard.type() for true IKI
     jitter (Playwright's page.type delay= is fixed across all chars).
 
-    Non-Camoufox: falls back to atomic page.fill() (no delay overhead).
+    Chromium fallback (dev/test): atomic page.fill() (no delay overhead).
     """
-    if not _is_camoufox_active():
+    if not _is_camoufox_active() and not _is_remote_active():
         await page.fill(selector, value, timeout=10000)
         return
 
@@ -1210,8 +1210,9 @@ async def browser_fill(selector: str, value: str) -> dict:
 
     Examples: browser_fill('#email', 'user@example.com')
 
-    Per-keystroke typing is active for Camoufox — long strings take
-    proportionally longer. The tool timeout scales with string length.
+    Per-keystroke typing is active for Camoufox and CDP remote — long
+    strings take proportionally longer. The tool timeout scales with
+    string length.
     """
     timeout = min(max(60.0, len(value) * 0.25), 300.0)
     return await _with_tool_timeout(

--- a/tests/test_mcp/test_browser_tools.py
+++ b/tests/test_mcp/test_browser_tools.py
@@ -836,6 +836,36 @@ class TestRemoteInteraction:
         assert 0.5 <= delay <= 2.0
 
     @pytest.mark.asyncio
+    async def test_human_type_uses_per_keystroke_for_remote(self):
+        """Remote CDP fires per-keystroke typing, not atomic fill."""
+        page = AsyncMock()
+        browser._active_page = page
+        browser._remote_page = page
+        browser._stealth_cm = None  # not Camoufox
+
+        with patch("genesis.mcp.health.browser.asyncio.sleep", new_callable=AsyncMock):
+            await browser._human_type(page, "#email", "hi")
+
+        # Should clear field, click to focus, then type per-character
+        page.fill.assert_awaited_once_with("#email", "", timeout=10000)
+        page.click.assert_awaited_once_with("#email", timeout=10000)
+        assert page.keyboard.type.await_count == 2  # 'h', 'i'
+
+    @pytest.mark.asyncio
+    async def test_human_type_uses_atomic_fill_for_chromium(self):
+        """Plain Chromium (dev/test) uses atomic fill, no per-keystroke."""
+        page = AsyncMock()
+        browser._active_page = page
+        browser._remote_page = None  # not remote
+        browser._stealth_cm = None  # not Camoufox
+
+        await browser._human_type(page, "#email", "hi")
+
+        # Should use atomic fill with the full value
+        page.fill.assert_awaited_once_with("#email", "hi", timeout=10000)
+        page.keyboard.type.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_fill_with_drift_returns_advisory(self):
         page = MagicMock()
         page.url = "https://other.com"


### PR DESCRIPTION
## Summary

- `_human_type` was guarded by `_is_camoufox_active()` only, causing CDP remote sessions to fall through to atomic `page.fill()`. Extended the guard so per-keystroke IKI-jittered typing fires for both Camoufox and CDP remote. Chromium fallback (dev/test) keeps atomic fill.

## Test plan

- [x] New test: CDP remote fires per-keystroke typing path
- [x] New test: Chromium fallback uses atomic fill
- [x] Full browser test suite: 67/67 passed
- [x] Ruff lint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)