### PR TITLE
feat(bootstrap): add code intelligence tool installation

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -301,6 +301,46 @@ CODEXCFG
 fi
 echo
 
+# --- Code Intelligence Tools ---
+echo "--- Installing code intelligence tools ---"
+
+# codebase-memory-mcp (code graph — 66 languages)
+if ! command -v codebase-memory-mcp &>/dev/null; then
+    echo "  codebase-memory-mcp not found — installing..."
+    curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash -s -- --ui \
+        || echo "  WARNING: codebase-memory-mcp install failed (non-critical)"
+fi
+if command -v codebase-memory-mcp &>/dev/null; then
+    echo "  codebase-memory-mcp: $(codebase-memory-mcp --version 2>/dev/null || echo 'installed')"
+fi
+
+# GitNexus (blast radius, impact analysis, execution flows)
+if _node_version_ok; then
+    if ! command -v gitnexus &>/dev/null; then
+        echo "  GitNexus not found — installing..."
+        npm install -g gitnexus@latest 2>/dev/null || echo "  WARNING: GitNexus install failed (non-critical)"
+    fi
+    if command -v gitnexus &>/dev/null; then
+        echo "  GitNexus: $(gitnexus --version 2>/dev/null)"
+    fi
+fi
+
+# Serena (Python LSP — symbols, references, rename)
+if ! command -v uv &>/dev/null; then
+    echo "  uv not found — installing..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null \
+        || echo "  WARNING: uv install failed (non-critical)"
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+if command -v uv &>/dev/null && ! command -v serena &>/dev/null; then
+    echo "  Serena not found — installing..."
+    uv tool install serena-agent 2>/dev/null || echo "  WARNING: Serena install failed (non-critical)"
+fi
+if command -v serena &>/dev/null; then
+    echo "  Serena: $(serena --version 2>/dev/null || echo 'installed')"
+fi
+echo
+
 # --- Python venv ---
 echo "--- Setting up Python venv ---"
 VENV_DIR="$GENESIS_ROOT/.venv"
@@ -398,6 +438,61 @@ if [[ -n "$HOOKS_DST" ]]; then
         done
     fi
 fi
+echo
+
+# --- MCP Server Registration (Code Intelligence) ---
+echo "--- Registering code intelligence MCP servers ---"
+_register_mcp() {
+    local name="$1" scope="$2"
+    shift 2
+    local cmd_args=("$@")
+    if command -v claude &>/dev/null; then
+        if claude mcp list 2>/dev/null | grep -q "^$name:"; then
+            echo "  $name: already registered"
+            return 0
+        fi
+        claude mcp add "$name" -s "$scope" -- "${cmd_args[@]}" 2>/dev/null \
+            && echo "  $name: registered ($scope)" \
+            || echo "  WARNING: Failed to register $name"
+    else
+        echo "  WARNING: 'claude' CLI not found — skipping $name registration"
+    fi
+}
+
+if command -v gitnexus &>/dev/null; then
+    _register_mcp "gitnexus" "user" "gitnexus" "mcp"
+fi
+if command -v codebase-memory-mcp &>/dev/null; then
+    _register_mcp "codebase-memory-mcp" "user" "codebase-memory-mcp"
+fi
+if command -v serena &>/dev/null; then
+    _register_mcp "serena" "project" "serena" "start-mcp-server" "--context" "claude-code" "--project" "$GENESIS_ROOT"
+fi
+echo
+
+# --- Code Intelligence Indexing ---
+echo "--- Triggering code intelligence indexing ---"
+CI_LOG="$HOME/.genesis/code-intelligence-setup.log"
+mkdir -p "$(dirname "$CI_LOG")"
+
+if command -v gitnexus &>/dev/null; then
+    if [[ ! -d "$GENESIS_ROOT/.gitnexus" ]]; then
+        echo "  GitNexus: running initial analysis (background)..."
+        ( cd "$GENESIS_ROOT" && gitnexus analyze --quiet >> "$CI_LOG" 2>&1 ) &
+        disown 2>/dev/null || true
+    else
+        echo "  GitNexus: index exists (use 'gitnexus analyze' to rebuild)"
+    fi
+fi
+
+if command -v codebase-memory-mcp &>/dev/null; then
+    echo "  codebase-memory-mcp: indexing repository (background)..."
+    ( codebase-memory-mcp cli index_repository "{\"repo_path\": \"$GENESIS_ROOT\"}" \
+        >> "$CI_LOG" 2>&1 ) &
+    disown 2>/dev/null || true
+fi
+
+echo "  Log: $CI_LOG"
 echo
 
 # --- Timezone ---

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -595,6 +595,33 @@ for tool in unzip htop tmux tree; do
     fi
 done
 
+# Code intelligence tools (optional — enhance Claude Code sessions)
+echo "    Installing code intelligence tools..."
+
+if ! command -v codebase-memory-mcp &>/dev/null; then
+    curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash -s -- --ui 2>/dev/null \
+        && echo "    + codebase-memory-mcp installed" \
+        || echo "    NOTE: codebase-memory-mcp unavailable (optional)"
+fi
+
+if _node_version_ok; then
+    if ! command -v gitnexus &>/dev/null; then
+        npm install -g gitnexus@latest 2>/dev/null \
+            && echo "    + GitNexus installed ($(gitnexus --version 2>/dev/null))" \
+            || echo "    NOTE: GitNexus unavailable (optional)"
+    fi
+fi
+
+if ! command -v uv &>/dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh 2>/dev/null | sh 2>/dev/null || true
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+if command -v uv &>/dev/null && ! command -v serena &>/dev/null; then
+    uv tool install serena-agent 2>/dev/null \
+        && echo "    + Serena installed" \
+        || echo "    NOTE: Serena unavailable (optional)"
+fi
+
 # Python venv — prefer python3.12 for venv creation
 PYTHON_BIN=$(command -v python3.12 || command -v python3)
 if [ ! -d "$VENV_PATH" ] || [ ! -x "$VENV_PATH/bin/python" ] || [ ! -x "$VENV_PATH/bin/pip" ]; then
@@ -834,6 +861,37 @@ if [ -f "$MCP_TEMPLATE" ]; then
     fi
 else
     echo "    - MCP template not found (skipping)"
+fi
+
+# Register code intelligence tools as MCP servers
+if command -v claude &>/dev/null; then
+    _register_ci_mcp() {
+        local name="$1" scope="$2"; shift 2
+        if ! claude mcp list 2>/dev/null | grep -q "^$name:"; then
+            claude mcp add "$name" -s "$scope" -- "$@" 2>/dev/null \
+                && echo "    + MCP: $name registered ($scope)" || true
+        fi
+    }
+    command -v gitnexus &>/dev/null && \
+        _register_ci_mcp "gitnexus" "user" "gitnexus" "mcp"
+    command -v codebase-memory-mcp &>/dev/null && \
+        _register_ci_mcp "codebase-memory-mcp" "user" "codebase-memory-mcp"
+    command -v serena &>/dev/null && \
+        _register_ci_mcp "serena" "project" "serena" "start-mcp-server" "--context" "claude-code" "--project" "$REPO_DIR"
+fi
+
+# Trigger initial code intelligence indexing (background)
+CI_LOG="$HOME/.genesis/code-intelligence-setup.log"
+mkdir -p "$(dirname "$CI_LOG")"
+if command -v gitnexus &>/dev/null && [ ! -d "$REPO_DIR/.gitnexus" ]; then
+    ( cd "$REPO_DIR" && gitnexus analyze --quiet >> "$CI_LOG" 2>&1 ) &
+    disown 2>/dev/null || true
+    echo "    + GitNexus: initial indexing (background)"
+fi
+if command -v codebase-memory-mcp &>/dev/null; then
+    ( codebase-memory-mcp cli index_repository "{\"repo_path\": \"$REPO_DIR\"}" >> "$CI_LOG" 2>&1 ) &
+    disown 2>/dev/null || true
+    echo "    + codebase-memory-mcp: indexing (background)"
 fi
 
 


### PR DESCRIPTION
## Summary
- Adds automated installation of codebase-memory-mcp, GitNexus, and Serena to both `scripts/bootstrap.sh` (updates) and `scripts/install.sh` (fresh installs)
- Registers all three as MCP servers via `claude mcp add` (with duplicate detection)
- Triggers initial indexing for GitNexus and codebase-memory-mcp (background, non-blocking)

Closes the bootstrap gap where these tools were manually installed on the primary machine but never added to the automated setup flow.

## Test plan
- [ ] Run `./scripts/bootstrap.sh` on a machine with tools already installed — should detect and skip
- [ ] Run on a fresh machine — should install binaries, register MCPs, trigger indexing
- [ ] After bootstrap, start new CC session and verify `mcp__gitnexus__list_repos`, `mcp__serena__get_symbols_overview`, and `mcp__codebase-memory-mcp__index_status` all respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)