### PR TITLE
docs(CLAUDE.md): update ego trap — module is live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,7 +273,9 @@ To send the user a future Telegram reminder, use `mcp__genesis-outreach__outreac
 
 ## Traps
 
-- **Ego** (`src/genesis/ego/`) — INERT. Zero production callers. Don't wire.
+- **Ego** (`src/genesis/ego/`) — Live autonomous decision-making cycle.
+  Wired via `genesis.runtime`. Don't add new call sites without reviewing
+  the cadence manager and budget controls.
 - **GROUNDWORK tags** — `# GROUNDWORK(id): why` is intentional. Never delete.
 - **IntervalTrigger** — Resets on restart. Use `CronTrigger` for intervals >1h.
 


### PR DESCRIPTION
## Summary
- Updates the ego trap note in CLAUDE.md from "INERT. Zero production callers. Don't wire." to reflect that the module is live with active callers
- Provides accurate guidance: review cadence manager and budget controls before adding call sites

## Test plan
- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)