### PR TITLE
feat(modules): SSH IPC adapter for remote CC dispatch

### DIFF
--- a/src/genesis/mcp/health/module_ops.py
+++ b/src/genesis/mcp/health/module_ops.py
@@ -75,13 +75,17 @@ def _get_adapters() -> dict:
 
 
 async def _ensure_adapter_started(adapter) -> None:
-    """Start the IPC adapter and mark healthy if not already running."""
-    if adapter.ipc._client is None:
+    """Start the IPC adapter and mark healthy if not already running.
+
+    Each adapter type owns its readiness semantics via ``needs_start``:
+    HTTP needs a client, stdio needs a process, SSH is always ready.
+    """
+    if adapter.ipc.needs_start:
         await adapter.ipc.start()
-        # In standalone MCP context, register() never ran. Mark healthy
-        # if health check passes so execute_operation doesn't reject.
-        if not adapter.healthy:
-            await adapter.check_health()
+    # In standalone MCP context, register() never ran. Mark healthy
+    # if health check passes so execute_operation doesn't reject.
+    if not adapter.healthy:
+        await adapter.check_health()
 
 
 async def _impl_module_call(
@@ -121,15 +125,20 @@ async def _impl_module_list() -> dict:
     result = {}
     for name, adapter in adapters.items():
         ops = adapter.list_operations()
-        result[name] = {
+        ipc = adapter.config.ipc
+        entry: dict = {
             "description": adapter.config.description,
             "enabled": adapter.enabled,
-            "ipc_method": adapter.config.ipc.method,
-            "ipc_url": adapter.config.ipc.url,
+            "ipc_method": ipc.method,
             "operations": {
                 op_name: op.get("description", "") for op_name, op in ops.items()
             },
         }
+        if ipc.method == "ssh":
+            entry["ipc_host"] = ipc.ssh_host
+        else:
+            entry["ipc_url"] = ipc.url
+        result[name] = entry
     return result
 
 
@@ -142,15 +151,19 @@ async def module_call(
     """Execute an operation on an external module.
 
     Looks up the module by name, finds the operation in its manifest,
-    and executes via IPC (HTTP or stdio). Pass params as a dict for
-    query parameters or request body fields.
+    and executes via IPC (HTTP, stdio, or SSH). Pass params as a dict
+    for query parameters, request body fields, or SSH dispatch options.
 
     Call with just module_name (no operation) to see available operations.
 
     Examples:
-        module_call("Career Agent", "list_jobs", {"min_score": 80})
-        module_call("Career Agent", "pipeline")
-        module_call("Career Agent", "trigger_discovery")
+        module_call("My Module", "list_items", {"min_score": 80})
+        module_call("My Module", "status")
+        module_call("Remote Agent", "dispatch", {
+            "prompt": "Analyze the latest data",
+            "model": "sonnet", "effort": "high"
+        })
+        module_call("Remote Agent", "version")
     """
     return await _impl_module_call(module_name, operation, params)
 

--- a/src/genesis/modules/external/adapter.py
+++ b/src/genesis/modules/external/adapter.py
@@ -154,7 +154,8 @@ class ExternalProgramAdapter:
         """Execute a named operation from the manifest via IPC.
 
         Translates manifest entries (method, path, params) to IPC calls.
-        Path parameters like {id} are substituted from params.
+        HTTP operations substitute path parameters like {id} from params.
+        CC/SHELL operations pass params directly to the SSH adapter.
         """
         ops = self._config.operations
         if operation_name not in ops:
@@ -169,16 +170,20 @@ class ExternalProgramAdapter:
         path = op.get("path", "/")
         request_params = dict(params or {})
 
-        # Substitute path parameters like /api/jobs/{id}
-        import re
-        path_params = re.findall(r"\{(\w+)\}", path)
-        for pp in path_params:
-            if pp in request_params:
-                path = path.replace(f"{{{pp}}}", str(request_params.pop(pp)))
-            else:
-                return {"error": f"Missing required path parameter: {pp}"}
-
         try:
+            # SSH-based operations: pass params directly to adapter
+            if method.upper() in ("CC", "SHELL"):
+                return await self._ipc.send(path, data=request_params or None, method=method)
+
+            # HTTP operations: substitute path parameters like /api/jobs/{id}
+            import re
+            path_params = re.findall(r"\{(\w+)\}", path)
+            for pp in path_params:
+                if pp in request_params:
+                    path = path.replace(f"{{{pp}}}", str(request_params.pop(pp)))
+                else:
+                    return {"error": f"Missing required path parameter: {pp}"}
+
             result = await self._ipc.send(
                 path,
                 data=request_params if request_params else None,

--- a/src/genesis/modules/external/config.py
+++ b/src/genesis/modules/external/config.py
@@ -23,13 +23,19 @@ class HealthCheckConfig:
 class IPCConfig:
     """Inter-process communication configuration."""
 
-    method: Literal["http", "stdio"] = "http"
+    method: Literal["http", "stdio", "ssh"] = "http"
     url: str | None = None
     timeout: int = 30
     # stdio-specific
     command: list[str] = field(default_factory=list)
     working_dir: Path | None = None
     env: dict[str, str] = field(default_factory=dict)
+    # ssh-specific
+    ssh_host: str | None = None  # user@host
+    ssh_key: str | None = None  # path to identity file
+    ssh_connect_timeout: int = 10
+    remote_working_dir: str | None = None  # cd here before running
+    remote_claude_path: str = "claude"  # claude CLI path on remote
 
 
 @dataclass
@@ -89,6 +95,11 @@ class ProgramConfig:
             command=ipc_data.get("command", []),
             working_dir=Path(ipc_data["working_dir"]) if ipc_data.get("working_dir") else None,
             env=ipc_data.get("env", {}),
+            ssh_host=ipc_data.get("ssh_host"),
+            ssh_key=ipc_data.get("ssh_key"),
+            ssh_connect_timeout=ipc_data.get("ssh_connect_timeout", 10),
+            remote_working_dir=ipc_data.get("remote_working_dir"),
+            remote_claude_path=ipc_data.get("remote_claude_path", "claude"),
         )
 
         hc_data = data.get("health_check")

--- a/src/genesis/modules/external/ipc.py
+++ b/src/genesis/modules/external/ipc.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import os
+from pathlib import Path
 from typing import Protocol
 
 import httpx
@@ -18,6 +19,8 @@ logger = logging.getLogger(__name__)
 class IPCAdapter(Protocol):
     """Protocol for IPC communication with external programs."""
 
+    @property
+    def needs_start(self) -> bool: ...
     async def start(self) -> None: ...
     async def stop(self) -> None: ...
     async def send(self, path: str, data: dict | None = None, method: str = "GET") -> dict: ...
@@ -33,6 +36,10 @@ class HttpIPCAdapter:
         self._url = config.url.rstrip("/")
         self._timeout = config.timeout
         self._client: httpx.AsyncClient | None = None
+
+    @property
+    def needs_start(self) -> bool:
+        return self._client is None
 
     async def start(self) -> None:
         self._client = httpx.AsyncClient(
@@ -94,6 +101,10 @@ class StdioIPCAdapter:
         self._timeout = config.timeout
         self._process: asyncio.subprocess.Process | None = None
 
+    @property
+    def needs_start(self) -> bool:
+        return self._process is None or self._process.returncode is not None
+
     async def start(self) -> None:
         self._process = await asyncio.create_subprocess_exec(
             *self._command,
@@ -145,10 +156,189 @@ class StdioIPCAdapter:
             return False
 
 
-def create_ipc_adapter(config: IPCConfig) -> HttpIPCAdapter | StdioIPCAdapter:
+class SshIPCAdapter:
+    """Communicates with a remote Claude Code instance via SSH.
+
+    Two operation modes based on the method passed to send():
+    - CC: Runs ``claude -p`` on the remote machine with the prompt from
+      data["prompt"]. Returns structured JSON output.
+    - SHELL: Runs a raw command on the remote machine. Returns stdout + exit code.
+
+    Uses OpenSSH CLI (not paramiko) following the Guardian SSH pattern.
+    """
+
+    def __init__(self, config: IPCConfig) -> None:
+        if not config.ssh_host:
+            raise ValueError("SSH IPC requires ssh_host in config")
+        self._ssh_host = config.ssh_host
+        self._ssh_key = str(Path(config.ssh_key).expanduser()) if config.ssh_key else None
+        self._ssh_connect_timeout = config.ssh_connect_timeout
+        self._remote_working_dir = config.remote_working_dir
+        self._remote_claude_path = config.remote_claude_path
+        self._timeout = config.timeout
+
+    @property
+    def needs_start(self) -> bool:
+        return False  # connectionless — each send() opens its own SSH session
+
+    async def start(self) -> None:
+        pass  # no persistent connection
+
+    async def stop(self) -> None:
+        pass  # nothing to tear down
+
+    def _build_ssh_args(self, remote_command: str) -> list[str]:
+        """Build the SSH command array following the Guardian pattern."""
+        cmd = [
+            "ssh",
+            "-o", "StrictHostKeyChecking=accept-new",
+            "-o", f"ConnectTimeout={self._ssh_connect_timeout}",
+            "-o", "BatchMode=yes",
+        ]
+        if self._ssh_key:
+            cmd.extend(["-i", self._ssh_key])
+        cmd.extend([self._ssh_host, remote_command])
+        return cmd
+
+    async def send(self, path: str, data: dict | None = None, method: str = "GET") -> dict:
+        method_upper = method.upper()
+        if method_upper == "CC":
+            return await self._send_cc(data or {})
+        if method_upper == "SHELL":
+            return await self._send_shell(path)
+        return {"error": f"SSH adapter does not support method '{method}'. Use CC or SHELL."}
+
+    async def _send_cc(self, data: dict) -> dict:
+        """Dispatch a prompt to remote Claude Code and return structured output."""
+        prompt = data.get("prompt", "")
+        if not prompt:
+            return {"error": "CC dispatch requires a 'prompt' in params"}
+
+        model = data.get("model", "sonnet")
+        effort = data.get("effort", "high")
+        timeout_s = data.get("timeout_s", self._timeout)
+
+        # Build remote command: cd to working dir, run claude -p
+        parts = []
+        if self._remote_working_dir:
+            parts.append(f"cd {self._remote_working_dir} &&")
+        parts.append(
+            f"{self._remote_claude_path} -p"
+            f" --model {model}"
+            f" --output-format json"
+            f" --effort {effort}"
+            f" --max-turns 25"
+            f" --dangerously-skip-permissions"
+        )
+        remote_cmd = " ".join(parts)
+        ssh_args = self._build_ssh_args(remote_cmd)
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *ssh_args,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(input=prompt.encode()),
+                timeout=timeout_s,
+            )
+        except TimeoutError:
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
+            return {"error": f"SSH CC dispatch timed out after {timeout_s}s"}
+        except OSError as exc:
+            return {"error": f"SSH connection failed: {exc}"}
+
+        stdout = stdout_bytes.decode()
+        stderr = stderr_bytes.decode()
+
+        if proc.returncode != 0:
+            return {
+                "error": f"Remote claude exited {proc.returncode}",
+                "stderr": stderr[:2000],
+                "stdout": stdout[:2000],
+            }
+
+        return self._parse_cc_output(stdout)
+
+    async def _send_shell(self, command: str) -> dict:
+        """Run a raw shell command on the remote machine."""
+        ssh_args = self._build_ssh_args(command)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *ssh_args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=30,
+            )
+        except TimeoutError:
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
+            return {"error": "SSH shell command timed out"}
+        except OSError as exc:
+            return {"error": f"SSH connection failed: {exc}"}
+
+        return {
+            "output": stdout_bytes.decode().strip(),
+            "stderr": stderr_bytes.decode().strip() or None,
+            "exit_code": proc.returncode,
+        }
+
+    @staticmethod
+    def _parse_cc_output(raw: str) -> dict:
+        """Parse claude -p JSON output into a structured dict.
+
+        Scans lines in reverse for {"type": "result", ...} — same approach
+        as CCInvoker._parse_output().
+        """
+        for line in reversed(raw.strip().splitlines()):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+                if isinstance(parsed, dict) and parsed.get("type") == "result":
+                    usage = parsed.get("usage", {})
+                    return {
+                        "text": parsed.get("result", ""),
+                        "session_id": parsed.get("session_id", ""),
+                        "cost_usd": parsed.get("total_cost_usd", 0.0),
+                        "input_tokens": usage.get("input_tokens", 0),
+                        "output_tokens": usage.get("output_tokens", 0),
+                        "duration_ms": parsed.get("duration_ms", 0),
+                        "is_error": parsed.get("is_error", False),
+                        "model_used": next(iter(parsed.get("modelUsage", {})), ""),
+                    }
+            except json.JSONDecodeError:
+                continue
+        # Fallback: no structured output found
+        return {"text": raw.strip(), "is_error": False, "parse_fallback": True}
+
+    async def health_check(self, endpoint: str, expected_status: int) -> bool:
+        """Check remote connectivity by running a simple SSH command."""
+        result = await self._send_shell(f"{self._remote_claude_path} --version")
+        return result.get("exit_code") == 0
+
+
+def create_ipc_adapter(
+    config: IPCConfig,
+) -> HttpIPCAdapter | StdioIPCAdapter | SshIPCAdapter:
     """Factory: create the right IPC adapter from config."""
     if config.method == "http":
         return HttpIPCAdapter(config)
     if config.method == "stdio":
         return StdioIPCAdapter(config)
+    if config.method == "ssh":
+        return SshIPCAdapter(config)
     raise ValueError(f"Unknown IPC method: {config.method}")

--- a/tests/test_modules/test_ssh_ipc.py
+++ b/tests/test_modules/test_ssh_ipc.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/test_modules/test_ssh_ipc.py
+++ b/tests/test_modules/test_ssh_ipc.py
@@ -1,0 +1,260 @@
+"""Tests for SshIPCAdapter — SSH-based IPC for remote Claude Code dispatch."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genesis.modules.external.config import IPCConfig
+from genesis.modules.external.ipc import SshIPCAdapter, create_ipc_adapter
+
+
+class TestSshIPCAdapterInit:
+    def test_requires_ssh_host(self):
+        config = IPCConfig(method="ssh")
+        with pytest.raises(ValueError, match="ssh_host"):
+            SshIPCAdapter(config)
+
+    def test_creates_with_valid_config(self):
+        config = IPCConfig(
+            method="ssh",
+            ssh_host="user@host",
+            ssh_key="~/.ssh/id_rsa",
+            remote_working_dir="/home/user/project",
+            remote_claude_path="/usr/local/bin/claude",
+        )
+        adapter = SshIPCAdapter(config)
+        assert adapter.needs_start is False
+
+    @pytest.mark.asyncio
+    async def test_start_stop_are_noops(self):
+        config = IPCConfig(method="ssh", ssh_host="user@host")
+        adapter = SshIPCAdapter(config)
+        # Should not raise
+        await adapter.start()
+        await adapter.stop()
+
+
+class TestSshIPCAdapterBuildArgs:
+    def test_build_ssh_args_with_key(self):
+        config = IPCConfig(
+            method="ssh",
+            ssh_host="user@host",
+            ssh_key="/home/test/.ssh/key",
+            ssh_connect_timeout=15,
+        )
+        adapter = SshIPCAdapter(config)
+        args = adapter._build_ssh_args("echo hello")
+        assert args == [
+            "ssh",
+            "-o", "StrictHostKeyChecking=accept-new",
+            "-o", "ConnectTimeout=15",
+            "-o", "BatchMode=yes",
+            "-i", "/home/test/.ssh/key",
+            "user@host",
+            "echo hello",
+        ]
+
+    def test_build_ssh_args_without_key(self):
+        config = IPCConfig(method="ssh", ssh_host="user@host")
+        adapter = SshIPCAdapter(config)
+        args = adapter._build_ssh_args("ls")
+        assert "-i" not in args
+        assert "user@host" in args
+        assert args[-1] == "ls"
+
+
+class TestSshIPCAdapterSend:
+    @pytest.mark.asyncio
+    async def test_send_cc_dispatch(self):
+        config = IPCConfig(
+            method="ssh",
+            ssh_host="user@host",
+            ssh_key="/tmp/key",
+            remote_working_dir="/home/user/project",
+            remote_claude_path="/usr/local/bin/claude",
+            timeout=300,
+        )
+        adapter = SshIPCAdapter(config)
+
+        cc_output = json.dumps({
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": "Hello from remote",
+            "session_id": "abc-123",
+            "total_cost_usd": 0.05,
+            "duration_ms": 2000,
+            "usage": {"input_tokens": 10, "output_tokens": 20},
+            "modelUsage": {"claude-sonnet-4-6": {}},
+        })
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (cc_output.encode(), b"")
+        mock_proc.returncode = 0
+
+        with patch("genesis.modules.external.ipc.asyncio.create_subprocess_exec",
+                    return_value=mock_proc) as mock_exec:
+            result = await adapter.send("dispatch", data={"prompt": "say hello"}, method="CC")
+
+        assert result["text"] == "Hello from remote"
+        assert result["session_id"] == "abc-123"
+        assert result["cost_usd"] == 0.05
+        assert result["input_tokens"] == 10
+        assert result["output_tokens"] == 20
+        assert result["model_used"] == "claude-sonnet-4-6"
+        assert result["is_error"] is False
+
+        # Verify SSH command was constructed correctly
+        call_args = mock_exec.call_args[0]
+        assert call_args[0] == "ssh"
+        # Verify prompt was piped to stdin
+        mock_proc.communicate.assert_awaited_once()
+        stdin_data = mock_proc.communicate.call_args[1]["input"]
+        assert stdin_data == b"say hello"
+
+    @pytest.mark.asyncio
+    async def test_send_cc_requires_prompt(self):
+        config = IPCConfig(method="ssh", ssh_host="user@host")
+        adapter = SshIPCAdapter(config)
+        result = await adapter.send("dispatch", data={}, method="CC")
+        assert "error" in result
+        assert "prompt" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_send_cc_timeout(self):
+        config = IPCConfig(method="ssh", ssh_host="user@host", timeout=1)
+        adapter = SshIPCAdapter(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.side_effect = TimeoutError()
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock()
+
+        with patch("genesis.modules.external.ipc.asyncio.create_subprocess_exec",
+                    return_value=mock_proc):
+            result = await adapter.send(
+                "dispatch",
+                data={"prompt": "slow task", "timeout_s": 1},
+                method="CC",
+            )
+
+        assert "error" in result
+        assert "timed out" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_send_cc_nonzero_exit(self):
+        config = IPCConfig(method="ssh", ssh_host="user@host")
+        adapter = SshIPCAdapter(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"", b"Permission denied")
+        mock_proc.returncode = 1
+
+        with patch("genesis.modules.external.ipc.asyncio.create_subprocess_exec",
+                    return_value=mock_proc):
+            result = await adapter.send("dispatch", data={"prompt": "test"}, method="CC")
+
+        assert "error" in result
+        assert "exited 1" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_send_shell_command(self):
+        config = IPCConfig(method="ssh", ssh_host="user@host", ssh_key="/tmp/key")
+        adapter = SshIPCAdapter(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"2.1.126 (Claude Code)\n", b"")
+        mock_proc.returncode = 0
+
+        with patch("genesis.modules.external.ipc.asyncio.create_subprocess_exec",
+                    return_value=mock_proc):
+            result = await adapter.send("claude --version", method="SHELL")
+
+        assert result["output"] == "2.1.126 (Claude Code)"
+        assert result["exit_code"] == 0
+
+    @pytest.mark.asyncio
+    async def test_send_unsupported_method(self):
+        config = IPCConfig(method="ssh", ssh_host="user@host")
+        adapter = SshIPCAdapter(config)
+        result = await adapter.send("/api/foo", method="GET")
+        assert "error" in result
+        assert "does not support" in result["error"]
+
+
+class TestSshIPCAdapterParseCCOutput:
+    def test_parse_valid_result(self):
+        output = json.dumps({
+            "type": "result",
+            "result": "hello",
+            "session_id": "s1",
+            "total_cost_usd": 0.1,
+            "duration_ms": 1000,
+            "usage": {"input_tokens": 5, "output_tokens": 10},
+            "modelUsage": {"claude-sonnet-4-6": {}},
+            "is_error": False,
+        })
+        result = SshIPCAdapter._parse_cc_output(output)
+        assert result["text"] == "hello"
+        assert result["cost_usd"] == 0.1
+        assert result["model_used"] == "claude-sonnet-4-6"
+
+    def test_parse_multiline_with_noise(self):
+        """Non-JSON lines before the result should be ignored."""
+        raw = "some debug output\nwarning: something\n" + json.dumps({
+            "type": "result", "result": "ok", "session_id": "s2",
+            "total_cost_usd": 0.0, "duration_ms": 100,
+            "usage": {}, "modelUsage": {}, "is_error": False,
+        })
+        result = SshIPCAdapter._parse_cc_output(raw)
+        assert result["text"] == "ok"
+
+    def test_parse_fallback_no_json(self):
+        result = SshIPCAdapter._parse_cc_output("just plain text output")
+        assert result["text"] == "just plain text output"
+        assert result["parse_fallback"] is True
+
+
+class TestSshIPCAdapterHealthCheck:
+    @pytest.mark.asyncio
+    async def test_health_check_success(self):
+        config = IPCConfig(
+            method="ssh", ssh_host="user@host",
+            remote_claude_path="/usr/local/bin/claude",
+        )
+        adapter = SshIPCAdapter(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"2.1.126\n", b"")
+        mock_proc.returncode = 0
+
+        with patch("genesis.modules.external.ipc.asyncio.create_subprocess_exec",
+                    return_value=mock_proc):
+            assert await adapter.health_check("/version", 200) is True
+
+    @pytest.mark.asyncio
+    async def test_health_check_failure(self):
+        config = IPCConfig(
+            method="ssh", ssh_host="user@host",
+            remote_claude_path="/usr/local/bin/claude",
+        )
+        adapter = SshIPCAdapter(config)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"", b"command not found")
+        mock_proc.returncode = 127
+
+        with patch("genesis.modules.external.ipc.asyncio.create_subprocess_exec",
+                    return_value=mock_proc):
+            assert await adapter.health_check("/version", 200) is False
+
+
+class TestIPCFactory:
+    def test_create_ssh_adapter(self):
+        config = IPCConfig(method="ssh", ssh_host="user@host")
+        adapter = create_ipc_adapter(config)
+        assert isinstance(adapter, SshIPCAdapter)


### PR DESCRIPTION
## Summary

- Adds `SshIPCAdapter` as a third IPC method (alongside HTTP and stdio) for the external module system
- Two operation modes: `CC` (dispatch prompt to remote `claude -p`, parse JSON result) and `SHELL` (run raw commands for health/lifecycle)
- Follows Guardian SSH pattern (OpenSSH CLI, BatchMode, timeout wrapping)
- Adds `needs_start` property to all IPC adapters so `_ensure_adapter_started` doesn't hardcode HTTP internals
- Updates `execute_operation()` to route CC/SHELL methods directly to SSH adapter

## Test plan

- [x] 17 new unit tests for SshIPCAdapter (init, args, CC dispatch, shell, timeout, parse, health, factory)
- [x] 29 existing external adapter tests still pass (46/46 total)
- [x] 223/223 module tests pass
- [x] Ruff lint clean on all changed files
- [ ] After merge: smoke test `module_call("Career Ops", "version")` end-to-end
- [ ] After merge: full CC dispatch `module_call("Career Ops", "dispatch", {"prompt": "..."})`

🤖 Generated with [Claude Code](https://claude.com/claude-code)