### PR TITLE
fix(sentinel): auto-clear when pending alarm resolves

### DIFF
--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -2398,7 +2398,7 @@
           if (probe?.status) return map[probe.status] || "#666";
           // Disk: derive status from free_pct
           if (probe?.free_pct != null) {
-            if (probe.free_pct > 20) return "#4caf50";
+            if (probe.free_pct >= 20) return "#4caf50";
             if (probe.free_pct > 10) return "#f0ad4e";
             return "#d9534f";
           }

--- a/src/genesis/learning/signals/genesis_version.py
+++ b/src/genesis/learning/signals/genesis_version.py
@@ -155,6 +155,7 @@ class GenesisVersionCollector:
             try:
                 await self._store_version_change(last_known, current_head)
                 await self._resolve_pending_update_available(current_head)
+                await self._resolve_pending_update_failed(current_head)
             except Exception:
                 logger.error(
                     "Failed to store Genesis version change %s -> %s",
@@ -412,6 +413,26 @@ class GenesisVersionCollector:
             "  AND type = 'genesis_update_available' "
             "  AND resolved = 0",
             (now, f"resolved by local update to {current_head}"),
+        )
+        await self._db.commit()
+
+    async def _resolve_pending_update_failed(self, current_head: str) -> None:
+        """Resolve any unresolved genesis_update_failed observations.
+
+        Called when the local HEAD changes (an update was applied).
+        If Genesis successfully updates past a previously failed version,
+        the failure observation is no longer relevant — resolve it so the
+        alert clears and the sentinel can auto-unstick.
+        """
+        now = datetime.now(UTC).isoformat()
+        await self._db.execute(
+            "UPDATE observations "
+            "SET resolved = 1, resolved_at = ?, "
+            "    resolution_notes = ? "
+            "WHERE source = 'genesis_version' "
+            "  AND type = 'genesis_update_failed' "
+            "  AND resolved = 0",
+            (now, f"resolved by successful update to {current_head}"),
         )
         await self._db.commit()
 

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -1342,26 +1342,43 @@ class SentinelDispatcher:
         # if empty, an empty set is data that confirms absence).
         self._recent_alarm_sets.append(current_ids)
 
-        # If alarms have cleared while we're waiting for approval, cancel
-        # the pending approval and go back to HEALTHY.
-        if not alarms and self._state.state in (
+        # If the specific alarm(s) that triggered this dispatch have cleared
+        # while we're waiting for approval, cancel the pending approval and
+        # go back to HEALTHY.  We check the *pending* alarm IDs specifically
+        # (not all system alarms) so an unrelated WARNING doesn't keep the
+        # sentinel stuck on a resolved CRITICAL.
+        if self._state.state in (
             SentinelState.AWAITING_DISPATCH_APPROVAL,
             SentinelState.AWAITING_ACTION_APPROVAL,
         ):
-            request_id = self._state.pending_request_id
-            if request_id and self._approval_gate is not None:
+            pending_ids = set()
+            if self._state.pending_request_json:
                 try:
-                    await self._approval_gate.resolve_request(
-                        request_id, decision="cancelled", resolved_by="alarm_cleared",
-                    )
-                except Exception:
-                    logger.warning("Failed to cancel sentinel approval %s", request_id, exc_info=True)
-            logger.info("Alarms cleared — cancelling pending sentinel approval %s", request_id)
-            async with self._lock:
-                self._state.clear_pending()
-                self._state.transition(SentinelState.HEALTHY, reason="alarms cleared while awaiting approval")
-                save_state(self._state)
-            return None
+                    import json
+                    req = json.loads(self._state.pending_request_json)
+                    pending_ids = {a.get("alert_id", "") for a in req.get("alarms", [])}
+                    pending_ids.discard("")
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            # Fall back to pending_pattern (single alarm ID) if no list
+            if not pending_ids and self._state.pending_pattern:
+                pending_ids = {self._state.pending_pattern}
+
+            if pending_ids and not (pending_ids & current_ids):
+                request_id = self._state.pending_request_id
+                if request_id and self._approval_gate is not None:
+                    try:
+                        await self._approval_gate.resolve_request(
+                            request_id, decision="cancelled", resolved_by="alarm_cleared",
+                        )
+                    except Exception:
+                        logger.warning("Failed to cancel sentinel approval %s", request_id, exc_info=True)
+                logger.info("Pending alarms %s cleared — cancelling sentinel approval %s", pending_ids, request_id)
+                async with self._lock:
+                    self._state.clear_pending()
+                    self._state.transition(SentinelState.HEALTHY, reason="pending alarms cleared while awaiting approval")
+                    save_state(self._state)
+                return None
 
         if not alarms:
             return None


### PR DESCRIPTION
## Summary
- Auto-resolve `genesis_update_failed` observations when Genesis updates past a failed version, preventing stale alerts from persisting for 30 days
- Fix sentinel auto-clear to check the *specific pending alarm* rather than requiring all system alarms to be zero — an unrelated WARNING no longer keeps sentinel stuck on a resolved CRITICAL
- Fix tmpfs dashboard threshold boundary (`>` → `>=` at 20%) for consistency with alert threshold

## Test plan
- [x] Resolved stale observation, verified `genesis:update_failed` alert cleared
- [x] Verified sentinel transitioned to HEALTHY with reason "pending alarms cleared while awaiting approval"
- [x] Dashboard confirmed: Services HEALTHY, Sentinel green, active alerts dropped from 2 to 1
- [x] `ruff check` passes on both modified Python files

🤖 Generated with [Claude Code](https://claude.com/claude-code)