### PR TITLE
feat(ego): proposal approval wiring + kill auto-promote

### DIFF
--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -159,7 +159,7 @@ class CCSessionExecutor:
         # Start trace
         trace: ExecutionTrace | None = None
         if self._tracer:
-            trace = self._tracer.start_trace(task_id, "user", description)
+            trace = self._tracer.start_trace(task_id, "genesis", description)
 
         try:
             if resuming:

--- a/src/genesis/autonomy/state_machine.py
+++ b/src/genesis/autonomy/state_machine.py
@@ -242,6 +242,57 @@ class AutonomyManager:
         )
         return True
 
+    async def promote(
+        self, category: str, to_level: int, *, reason: str = ""
+    ) -> bool:
+        """Explicit promotion — only called on user approval.
+
+        Returns True if promotion succeeded, False if category not found
+        or to_level is not actually a promotion.
+        """
+        state = await self.get_state(category)
+        if state is None:
+            logger.error("Cannot promote — category %s not found in DB", category)
+            return False
+
+        level_before = int(state.current_level)
+        success = await crud.promote(
+            self._db, state.id, to_level=to_level, updated_at=_now_iso()
+        )
+        if success:
+            self._emit_promotion_event(category, level_before, to_level)
+            logger.info(
+                "Autonomy promoted: %s L%d → L%d%s",
+                category, level_before, to_level,
+                f" reason={reason}" if reason else "",
+            )
+        return success
+
+    async def force_regress(
+        self, category: str, to_level: int = 1, *, reason: str = "user_revoked"
+    ) -> bool:
+        """Hard reset — resets BOTH current and earned level.
+
+        Used for user revocation. Unlike Bayesian regression (which only
+        lowers current_level), this resets earned_level too — a full reset.
+        """
+        state = await self.get_state(category)
+        if state is None:
+            logger.error("Cannot force_regress — category %s not found in DB", category)
+            return False
+
+        level_before = int(state.current_level)
+        success = await crud.force_regress(
+            self._db, state.id, to_level=to_level, reason=reason, updated_at=_now_iso()
+        )
+        if success and level_before != to_level:
+            self._emit_regression_event(category, level_before, to_level, _now_iso())
+            logger.warning(
+                "Autonomy force-regressed: %s L%d → L%d (%s)",
+                category, level_before, to_level, reason,
+            )
+        return success
+
     # ------------------------------------------------------------------
     # Correction / success tracking
     # ------------------------------------------------------------------
@@ -285,31 +336,20 @@ class AutonomyManager:
     async def record_success(self, category: str) -> tuple[bool, bool]:
         """Record a successful autonomous action for *category*.
 
-        Returns ``(success, promoted)``.  If a promotion occurred, emits
-        an ``autonomy.promotion`` event via the event bus.
+        Returns ``(success, promoted)``.  Promotion no longer happens
+        automatically — it requires explicit user approval via promote().
+        The second tuple element is always False.
         """
         state = await self.get_state(category)
         if state is None:
             logger.error("Cannot record success — category %s not found", category)
             return False, False
 
-        level_before = int(state.current_level)
         success = await crud.record_success(self._db, state.id, updated_at=_now_iso())
         if not success:
             return False, False
 
-        updated = await self.get_state(category)
-        level_after = int(updated.current_level) if updated else level_before
-        promoted = level_after > level_before
-
-        if promoted:
-            logger.info(
-                "Autonomy promotion for %s: L%d → L%d",
-                category, level_before, level_after,
-            )
-            self._emit_promotion_event(category, level_before, level_after)
-
-        return True, promoted
+        return True, False
 
     # ------------------------------------------------------------------
     # Event emission

--- a/src/genesis/channels/bridge.py
+++ b/src/genesis/channels/bridge.py
@@ -201,6 +201,7 @@ async def main():
         reply_waiter=reply_waiter,
         engagement_tracker=runtime.engagement_tracker,
         autonomous_cli_gate=autonomous_cli_gate,
+        proposal_workflow=runtime._ego_proposal_workflow,
     )
 
     # Register adapter so outreach pipeline can deliver via Telegram

--- a/src/genesis/channels/telegram/_handler_context.py
+++ b/src/genesis/channels/telegram/_handler_context.py
@@ -45,6 +45,9 @@ class HandlerContext:
     # handler only resolves bare approve/reject messages *inside* that
     # topic, not general conversation.  Set alongside autonomous_cli_gate.
     approvals_thread_id: int | None = None
+    # Proposal approval workflow — injected by the channels bridge so
+    # quote-replies to ego proposal digests can resolve proposals inline.
+    proposal_workflow: object | None = None
 
     draft_streaming_enabled: bool = True
     typing_breaker_instance: TypingCircuitBreaker = field(init=False)

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -755,6 +755,89 @@ async def _try_proposal_resolution(ctx: HandlerContext, msg, reply_to_id: str) -
         return False
 
 
+async def _try_bare_proposal_resolution(ctx: HandlerContext, msg) -> bool:
+    """Resolve the most recent pending proposal batch from a bare message.
+
+    Fires for non-reply messages in the ego_proposals topic that parse
+    as proposal decisions. Resolves the most recent unresolved batch.
+    Returns True if resolved, False to fall through to correction store.
+    """
+    if ctx.proposal_workflow is None or ctx.db is None:
+        return False
+
+    thread_id = getattr(msg, "message_thread_id", None)
+    if thread_id is None:
+        return False
+
+    # Check we're in the ego_proposals topic
+    try:
+        from genesis.runtime import GenesisRuntime
+
+        rt = GenesisRuntime.instance()
+        pipeline = rt.outreach_pipeline
+        if pipeline is None:
+            return False
+        topic_manager = pipeline.topic_manager
+        if topic_manager is None:
+            return False
+        ego_thread_id = topic_manager.get_thread_id("ego_proposals")
+        if ego_thread_id is None or ego_thread_id != thread_id:
+            return False
+    except Exception:
+        return False
+
+    # Parse the text — if unparseable, fall through to correction store
+    from genesis.ego.proposals import parse_proposal_decisions
+
+    decisions = parse_proposal_decisions(msg.text)
+    if not decisions:
+        return False
+
+    # Find the most recent unresolved batch
+    try:
+        from genesis.db.crud import ego as ego_crud
+
+        # Get most recent pending proposals to find their batch
+        pending = await ego_crud.list_pending_proposals(ctx.db)
+        if not pending:
+            return False
+        # All pending proposals share a batch_id
+        batch_id = pending[0].get("batch_id")
+        if not batch_id:
+            return False
+
+        # Handle "approve all" / "reject all" (sentinel key 0)
+        if 0 in decisions:
+            status, reason = decisions[0]
+            all_decisions = {
+                i + 1: (status, reason) for i in range(len(pending))
+            }
+            results = await ctx.proposal_workflow.resolve_proposals(
+                batch_id, all_decisions,
+            )
+        else:
+            results = await ctx.proposal_workflow.resolve_proposals(
+                batch_id, decisions,
+            )
+
+        approved = sum(1 for s in results.values() if s == "approved")
+        rejected = sum(1 for s in results.values() if s == "rejected")
+        parts = []
+        if approved:
+            parts.append(f"{approved} approved")
+        if rejected:
+            parts.append(f"{rejected} rejected")
+        summary = ", ".join(parts) or "no changes"
+        try:
+            await msg.reply_text(f"\u2705 Resolved: {summary}")
+        except Exception:
+            log.debug("Failed to send bare proposal resolution ack", exc_info=True)
+        return True
+    except Exception:
+        log.warning("Bare proposal resolution failed", exc_info=True)
+        return False
+
+
 async def _try_ego_correction_store(ctx: HandlerContext, msg) -> bool:
     """Store non-reply messages in the ego_proposals topic as user corrections.
 
@@ -831,8 +914,12 @@ async def handle_text(ctx: HandlerContext, update: Update, context: ContextTypes
     if await _try_bare_approval_resolution(ctx, msg, user):
         return
 
+    # Bare proposal decisions in the ego_proposals topic (no quote-reply needed)
+    if not msg.reply_to_message and await _try_bare_proposal_resolution(ctx, msg):
+        return
+
     # Messages in the ego_proposals topic (that aren't quote-replies to
-    # proposals — those are handled below by ReplyWaiter) get stored as
+    # proposals and weren't parsed as decisions) get stored as
     # user corrections for the ego's next cycle.
     if not msg.reply_to_message and await _try_ego_correction_store(ctx, msg):
         return

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -697,6 +697,64 @@ async def _try_bare_approval_resolution(
     return True
 
 
+
+async def _try_proposal_resolution(ctx: HandlerContext, msg, reply_to_id: str) -> bool:
+    """Resolve a proposal batch from a quote-reply to an ego digest.
+
+    Returns True if resolved (caller should return), False to continue chain.
+    """
+    if ctx.proposal_workflow is None or ctx.db is None:
+        return False
+    try:
+        from genesis.db.crud import ego as ego_crud
+        from genesis.ego.proposals import parse_proposal_decisions
+
+        batch_id = await ego_crud.get_batch_for_delivery(ctx.db, reply_to_id)
+        if batch_id is None:
+            return False
+
+        decisions = parse_proposal_decisions(msg.text)
+        if not decisions:
+            return False  # Unparseable — fall through to correction store
+
+        # Handle "approve all" / "reject all" (sentinel key 0)
+        if 0 in decisions:
+            status, reason = decisions[0]
+            # Get all proposals in this batch and resolve them all
+            proposals = await ego_crud.list_proposals_by_batch(ctx.db, batch_id)
+            all_decisions = {
+                i + 1: (status, reason) for i in range(len(proposals))
+            }
+            results = await ctx.proposal_workflow.resolve_proposals(
+                batch_id, all_decisions,
+            )
+        else:
+            results = await ctx.proposal_workflow.resolve_proposals(
+                batch_id, decisions,
+            )
+
+        # Send confirmation
+        approved = sum(1 for s in results.values() if s == "approved")
+        rejected = sum(1 for s in results.values() if s == "rejected")
+        parts = []
+        if approved:
+            parts.append(f"{approved} approved")
+        if rejected:
+            parts.append(f"{rejected} rejected")
+        already = len(decisions) - len(results) if 0 not in decisions else 0
+        if already > 0:
+            parts.append(f"{already} already resolved")
+        summary = ", ".join(parts) or "no changes"
+        try:
+            await msg.reply_text(f"✅ Resolved: {summary}")
+        except Exception:
+            log.debug("Failed to send proposal resolution ack", exc_info=True)
+        return True
+    except Exception:
+        log.warning("Proposal resolution failed", exc_info=True)
+        return False
+
+
 async def _try_ego_correction_store(ctx: HandlerContext, msg) -> bool:
     """Store non-reply messages in the ego_proposals topic as user corrections.
 
@@ -790,6 +848,11 @@ async def handle_text(ctx: HandlerContext, update: Update, context: ContextTypes
                     return
             except Exception:
                 log.warning("Failed to resolve approval reply", exc_info=True)
+
+        # Resolve proposal batch approvals from quote-reply to ego digest
+        if await _try_proposal_resolution(ctx, msg, reply_to_id):
+            log.info("Proposal batch resolved for delivery %s", reply_to_id)
+            return
 
         # Record engagement if this is a reply to an outreach message
         if ctx.engagement_tracker and ctx.db:

--- a/src/genesis/channels/telegram/adapter_v2.py
+++ b/src/genesis/channels/telegram/adapter_v2.py
@@ -61,6 +61,7 @@ class TelegramAdapterV2(ChannelAdapter):
         reply_waiter: object | None = None,
         engagement_tracker: object | None = None,
         autonomous_cli_gate: object | None = None,
+        proposal_workflow: object | None = None,
     ):
         self.token = token
         self.conversation_loop = conversation_loop
@@ -70,6 +71,7 @@ class TelegramAdapterV2(ChannelAdapter):
         self._reply_waiter = reply_waiter
         self._engagement_tracker = engagement_tracker
         self._autonomous_cli_gate = autonomous_cli_gate
+        self._proposal_workflow = proposal_workflow
         self._app = None
 
         # Transport layer components
@@ -135,6 +137,7 @@ class TelegramAdapterV2(ChannelAdapter):
             typing_breaker=self._typing_breaker,
             dedupe=self._dedupe,
             autonomous_cli_gate=self._autonomous_cli_gate,
+            proposal_workflow=self._proposal_workflow,
         )
 
         self._app = (

--- a/src/genesis/channels/telegram/handlers_v2.py
+++ b/src/genesis/channels/telegram/handlers_v2.py
@@ -62,6 +62,7 @@ def make_handlers_v2(
     typing_breaker: TypingCircuitBreaker | None = None,
     dedupe: TelegramUpdateDedupe | None = None,
     autonomous_cli_gate: object | None = None,
+    proposal_workflow: object | None = None,
 ):
     """Return V2 handler callbacks."""
     draft_streaming_enabled = os.environ.get(
@@ -81,6 +82,7 @@ def make_handlers_v2(
         dedupe=dedupe,
         draft_streaming_enabled=draft_streaming_enabled,
         autonomous_cli_gate=autonomous_cli_gate,
+        proposal_workflow=proposal_workflow,
     )
 
     def _wrap(cmd_fn):

--- a/src/genesis/db/crud/autonomy.py
+++ b/src/genesis/db/crud/autonomy.py
@@ -185,7 +185,7 @@ async def promote(
 ) -> bool:
     """Explicit promotion — only called on user approval."""
     row = await get_by_id(db, id)
-    if not row or to_level < 1 or to_level > 7:
+    if not row or to_level < 1 or to_level > 4:
         return False
     if to_level <= row["current_level"]:
         return False  # Not a promotion
@@ -210,8 +210,10 @@ async def force_regress(
 ) -> bool:
     """Hard reset — resets BOTH current and earned level. For user revocation."""
     row = await get_by_id(db, id)
-    if not row or to_level < 1 or to_level > 7:
+    if not row or to_level < 1 or to_level > 4:
         return False
+    if to_level >= row["current_level"]:
+        return False  # Not a regression
     cursor = await db.execute(
         """UPDATE autonomy_state SET
            current_level = ?, earned_level = ?,

--- a/src/genesis/db/crud/autonomy.py
+++ b/src/genesis/db/crud/autonomy.py
@@ -163,26 +163,61 @@ async def record_correction(
 async def record_success(
     db: aiosqlite.Connection, id: str, *, updated_at: str
 ) -> bool:
-    """Record success. Bayesian promotion: recompute posterior, promote if threshold crossed."""
+    """Record success. Increments counter only — promotion requires explicit approve."""
     row = await get_by_id(db, id)
     if not row:
         return False
     new_successes = row["total_successes"] + 1
 
-    # Bayesian promotion — promote by at most 1 level at a time
-    target = bayesian_level(new_successes, row["total_corrections"])
-    new_level = row["current_level"]
-    new_earned = row["earned_level"]
-    if target > new_level:
-        new_level = min(new_level + 1, target)  # promote by at most 1
-        new_earned = max(new_earned, new_level)
-
     cursor = await db.execute(
         """UPDATE autonomy_state SET
            total_successes = ?, consecutive_corrections = 0,
+           updated_at = ?
+           WHERE id = ?""",
+        (new_successes, updated_at, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def promote(
+    db: aiosqlite.Connection, id: str, *, to_level: int, updated_at: str
+) -> bool:
+    """Explicit promotion — only called on user approval."""
+    row = await get_by_id(db, id)
+    if not row or to_level < 1 or to_level > 7:
+        return False
+    if to_level <= row["current_level"]:
+        return False  # Not a promotion
+    new_earned = max(row["earned_level"], to_level)
+    cursor = await db.execute(
+        """UPDATE autonomy_state SET
            current_level = ?, earned_level = ?, updated_at = ?
            WHERE id = ?""",
-        (new_successes, new_level, new_earned, updated_at, id),
+        (to_level, new_earned, updated_at, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def force_regress(
+    db: aiosqlite.Connection,
+    id: str,
+    *,
+    to_level: int = 1,
+    reason: str = "user_revoked",
+    updated_at: str,
+) -> bool:
+    """Hard reset — resets BOTH current and earned level. For user revocation."""
+    row = await get_by_id(db, id)
+    if not row or to_level < 1 or to_level > 7:
+        return False
+    cursor = await db.execute(
+        """UPDATE autonomy_state SET
+           current_level = ?, earned_level = ?,
+           regression_reason = ?, last_regression_at = ?, updated_at = ?
+           WHERE id = ?""",
+        (to_level, to_level, reason, updated_at, updated_at, id),
     )
     await db.commit()
     return cursor.rowcount > 0

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -59,6 +59,7 @@ class GenesisEgoContextBuilder:
         sections.append(await self._proposal_history_section())
         sections.append(await self._proposal_board_section())
         sections.append(await self._execution_outcomes_section())
+        sections.append(await self._autonomy_readiness_section())
         sections.append(self._output_contract_section())
 
         return "\n".join(sections)
@@ -469,6 +470,40 @@ class GenesisEgoContextBuilder:
             short = (content or "")[:200].replace("\n", " ")
             ts = (created_at or "?")[:16]
             lines.append(f"- [{ts}] [{priority}] {short}")
+
+        lines.append("")
+        return "\n".join(lines)
+
+    async def _autonomy_readiness_section(self) -> str:
+        """Show autonomy posteriors so ego can propose promotion when ready."""
+        from genesis.db.crud import autonomy as autonomy_crud
+        from genesis.db.crud.autonomy import bayesian_level, bayesian_posterior
+
+        try:
+            states = await autonomy_crud.list_all(self._db)
+        except Exception:
+            return ""
+        if not states:
+            return ""
+
+        lines = ["## Autonomy Readiness\n"]
+        for row in states:
+            cat = row["category"]
+            level = row["current_level"]
+            earned = row["earned_level"]
+            successes = row["total_successes"]
+            corrections = row["total_corrections"]
+            posterior = bayesian_posterior(successes, corrections)
+            target = bayesian_level(successes, corrections)
+            status = f"L{level}"
+            if earned > level:
+                status += f" (earned L{earned})"
+            readiness = ""
+            if target > level:
+                readiness = f" — **ready for L{min(level + 1, target)}** (posterior={posterior:.3f})"
+            else:
+                readiness = f" (posterior={posterior:.3f})"
+            lines.append(f"- {cat}: {status}{readiness} [{successes}S/{corrections}C]")
 
         lines.append("")
         return "\n".join(lines)

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import html
 import logging
+import re
 import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -304,8 +305,6 @@ class ProposalWorkflow:
 # ---------------------------------------------------------------------------
 # Reply parser — converts user Telegram text into proposal decisions
 # ---------------------------------------------------------------------------
-
-import re
 
 _APPROVE_WORDS = {"approve", "approved", "yes", "accept", "go", "ok", "okay"}
 _REJECT_WORDS = {"reject", "rejected", "no", "deny", "denied", "skip", "nope"}

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -299,3 +299,81 @@ class ProposalWorkflow:
     def set_memory_store(self, store: MemoryStore) -> None:
         """Attach a MemoryStore for storing correction memories on rejection."""
         self._memory_store = store
+
+
+# ---------------------------------------------------------------------------
+# Reply parser — converts user Telegram text into proposal decisions
+# ---------------------------------------------------------------------------
+
+import re
+
+_APPROVE_WORDS = {"approve", "approved", "yes", "accept", "go", "ok", "okay"}
+_REJECT_WORDS = {"reject", "rejected", "no", "deny", "denied", "skip", "nope"}
+
+# Pattern: "1 approve" or "approve 1" or "1 yes" or "reject 2: reason"
+_NUMBERED_PATTERN = re.compile(
+    r"(?:(\d+)\s*[.:)?\-]?\s*(\w+)|(\w+)\s+(\d+))"
+    r"(?:\s*[:\-]\s*(.+))?",
+    re.IGNORECASE,
+)
+
+
+def parse_proposal_decisions(text: str) -> dict[int, tuple[str, str | None]]:
+    """Parse user reply into proposal decisions.
+
+    Supported formats (case-insensitive, comma/newline separated):
+      "1 approve, 2 reject: reason"
+      "approve 1, reject 2: reason"
+      "approve all" / "reject all"
+
+    Returns {1-based-index: (status, optional_reason)} or empty dict
+    if unparseable.  Empty dict means fall through to correction store.
+
+    IMPORTANT: bare "approve" without "all" or a number does NOT match —
+    it falls through to avoid false positives on conversational replies.
+    """
+    stripped = text.strip().lower()
+
+    # Bulk operations
+    if stripped in ("approve all", "approved all", "accept all", "yes all", "go ahead"):
+        return {0: ("approved", None)}  # 0 = sentinel for "all"
+    if stripped in ("reject all", "rejected all", "deny all", "no all"):
+        return {0: ("rejected", None)}
+
+    # Try numbered decisions (comma or newline separated)
+    decisions: dict[int, tuple[str, str | None]] = {}
+    parts = re.split(r"[,\n]+", text.strip())
+
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+        m = _NUMBERED_PATTERN.match(part)
+        if not m:
+            continue
+
+        # Two capture groups: "1 approve" or "approve 1"
+        if m.group(1) and m.group(2):
+            num_str, word = m.group(1), m.group(2).lower()
+            reason = m.group(5)
+        elif m.group(3) and m.group(4):
+            word, num_str = m.group(3).lower(), m.group(4)
+            reason = m.group(5)
+        else:
+            continue
+
+        try:
+            idx = int(num_str)
+        except ValueError:
+            continue
+
+        if idx < 1:
+            continue
+
+        if word in _APPROVE_WORDS:
+            decisions[idx] = ("approved", reason.strip() if reason else None)
+        elif word in _REJECT_WORDS:
+            decisions[idx] = ("rejected", reason.strip() if reason else None)
+        # Unknown word → skip this part (don't fail the whole parse)
+
+    return decisions

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -77,6 +77,7 @@ class UserEgoContextBuilder:
         sections.append(await self._proposal_history_section())
         sections.append(await self._proposal_board_section())
         sections.append(await self._execution_outcomes_section())
+        sections.append(await self._autonomy_readiness_section())
         sections.append(await self._recurring_patterns_section())
         sections.append(self._output_contract_section())
 
@@ -728,6 +729,40 @@ class UserEgoContextBuilder:
             short = (content or "")[:200].replace("\n", " ")
             ts = (created_at or "?")[:16]
             lines.append(f"- [{ts}] [{priority}] {short}")
+
+        lines.append("")
+        return "\n".join(lines)
+
+    async def _autonomy_readiness_section(self) -> str:
+        """Show autonomy posteriors — informs promotion proposals."""
+        from genesis.db.crud import autonomy as autonomy_crud
+        from genesis.db.crud.autonomy import bayesian_level, bayesian_posterior
+
+        try:
+            states = await autonomy_crud.list_all(self._db)
+        except Exception:
+            return ""
+        if not states:
+            return ""
+
+        lines = ["## Autonomy Readiness\n"]
+        for row in states:
+            cat = row["category"]
+            level = row["current_level"]
+            earned = row["earned_level"]
+            successes = row["total_successes"]
+            corrections = row["total_corrections"]
+            posterior = bayesian_posterior(successes, corrections)
+            target = bayesian_level(successes, corrections)
+            status = f"L{level}"
+            if earned > level:
+                status += f" (earned L{earned})"
+            readiness = ""
+            if target > level:
+                readiness = f" — **ready for L{min(level + 1, target)}** (posterior={posterior:.3f})"
+            else:
+                readiness = f" (posterior={posterior:.3f})"
+            lines.append(f"- {cat}: {status}{readiness} [{successes}S/{corrections}C]")
 
         lines.append("")
         return "\n".join(lines)

--- a/tests/ego/test_proposal_parser.py
+++ b/tests/ego/test_proposal_parser.py
@@ -1,6 +1,5 @@
 """Tests for parse_proposal_decisions() — Telegram reply parser."""
 
-import pytest
 
 from genesis.ego.proposals import parse_proposal_decisions
 

--- a/tests/ego/test_proposal_parser.py
+++ b/tests/ego/test_proposal_parser.py
@@ -1,0 +1,131 @@
+"""Tests for parse_proposal_decisions() — Telegram reply parser."""
+
+import pytest
+
+from genesis.ego.proposals import parse_proposal_decisions
+
+
+class TestBulkOperations:
+    def test_approve_all(self):
+        assert parse_proposal_decisions("approve all") == {0: ("approved", None)}
+
+    def test_approved_all(self):
+        assert parse_proposal_decisions("approved all") == {0: ("approved", None)}
+
+    def test_accept_all(self):
+        assert parse_proposal_decisions("accept all") == {0: ("approved", None)}
+
+    def test_go_ahead(self):
+        assert parse_proposal_decisions("go ahead") == {0: ("approved", None)}
+
+    def test_reject_all(self):
+        assert parse_proposal_decisions("reject all") == {0: ("rejected", None)}
+
+    def test_deny_all(self):
+        assert parse_proposal_decisions("deny all") == {0: ("rejected", None)}
+
+    def test_case_insensitive(self):
+        assert parse_proposal_decisions("APPROVE ALL") == {0: ("approved", None)}
+        assert parse_proposal_decisions("Reject All") == {0: ("rejected", None)}
+
+    def test_whitespace_tolerance(self):
+        assert parse_proposal_decisions("  approve all  ") == {0: ("approved", None)}
+
+
+class TestNumberedDecisions:
+    def test_number_first(self):
+        result = parse_proposal_decisions("1 approve")
+        assert result == {1: ("approved", None)}
+
+    def test_word_first(self):
+        result = parse_proposal_decisions("approve 1")
+        assert result == {1: ("approved", None)}
+
+    def test_reject_with_reason(self):
+        result = parse_proposal_decisions("2 reject: too expensive")
+        assert result == {2: ("rejected", "too expensive")}
+
+    def test_multiple_comma_separated(self):
+        result = parse_proposal_decisions("1 approve, 2 reject: bad idea")
+        assert result == {
+            1: ("approved", None),
+            2: ("rejected", "bad idea"),
+        }
+
+    def test_multiple_newline_separated(self):
+        result = parse_proposal_decisions("1 approve\n2 reject\n3 approve")
+        assert result == {
+            1: ("approved", None),
+            2: ("rejected", None),
+            3: ("approved", None),
+        }
+
+    def test_mixed_formats(self):
+        result = parse_proposal_decisions("approve 1, 2 reject: not now")
+        assert result == {
+            1: ("approved", None),
+            2: ("rejected", "not now"),
+        }
+
+    def test_yes_and_no_synonyms(self):
+        result = parse_proposal_decisions("1 yes, 2 no")
+        assert result == {
+            1: ("approved", None),
+            2: ("rejected", None),
+        }
+
+    def test_ok_synonym(self):
+        result = parse_proposal_decisions("1 ok")
+        assert result == {1: ("approved", None)}
+
+    def test_skip_synonym(self):
+        result = parse_proposal_decisions("1 skip")
+        assert result == {1: ("rejected", None)}
+
+
+class TestFallthrough:
+    """Cases that should return empty dict (fall through to correction store)."""
+
+    def test_bare_approve(self):
+        """Bare 'approve' without 'all' or number must NOT match."""
+        assert parse_proposal_decisions("approve") == {}
+
+    def test_bare_reject(self):
+        assert parse_proposal_decisions("reject") == {}
+
+    def test_conversational_text(self):
+        assert parse_proposal_decisions("sounds good to me") == {}
+
+    def test_empty_string(self):
+        assert parse_proposal_decisions("") == {}
+
+    def test_random_sentence(self):
+        assert parse_proposal_decisions("I think we should reconsider the approach") == {}
+
+    def test_number_without_action(self):
+        """A number alone shouldn't match."""
+        assert parse_proposal_decisions("1") == {}
+
+    def test_partial_match_ignored(self):
+        """Unknown action words are skipped, not treated as failures."""
+        result = parse_proposal_decisions("1 approve, 2 maybe")
+        assert result == {1: ("approved", None)}  # Only valid one parsed
+
+
+class TestEdgeCases:
+    def test_zero_index_ignored(self):
+        """Index 0 is invalid for numbered decisions."""
+        assert parse_proposal_decisions("0 approve") == {}
+
+    def test_negative_index_ignored(self):
+        assert parse_proposal_decisions("-1 approve") == {}
+
+    def test_large_index(self):
+        result = parse_proposal_decisions("99 approve")
+        assert result == {99: ("approved", None)}
+
+    def test_reason_with_colon(self):
+        result = parse_proposal_decisions("1 reject: reason: has colons")
+        assert result[1][0] == "rejected"
+        # Reason captures everything after first colon
+        assert "reason" in result[1][1]

--- a/tests/ego/test_proposal_parser.py
+++ b/tests/ego/test_proposal_parser.py
@@ -1,6 +1,10 @@
 """Tests for parse_proposal_decisions() — Telegram reply parser."""
 
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
 from genesis.ego.proposals import parse_proposal_decisions
 
 
@@ -128,3 +132,130 @@ class TestEdgeCases:
         assert result[1][0] == "rejected"
         # Reason captures everything after first colon
         assert "reason" in result[1][1]
+
+
+# ---------------------------------------------------------------------------
+# Integration test for _try_proposal_resolution handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_try_proposal_resolution_approve_all():
+    """End-to-end: quote-reply 'approve all' resolves entire batch."""
+    from genesis.channels.telegram._handler_messages import _try_proposal_resolution
+
+    # Mock context
+    ctx = MagicMock()
+    ctx.db = AsyncMock()
+
+    # Mock proposal_workflow
+    workflow = AsyncMock()
+    workflow.resolve_proposals = AsyncMock(return_value={
+        "prop-1": "approved",
+        "prop-2": "approved",
+    })
+    ctx.proposal_workflow = workflow
+
+    # Mock message
+    msg = MagicMock()
+    msg.text = "approve all"
+    msg.reply_text = AsyncMock()
+
+    reply_to_id = "12345"
+
+    with patch(
+        "genesis.db.crud.ego.get_batch_for_delivery",
+        new_callable=AsyncMock,
+        return_value="batch-abc",
+    ), patch(
+        "genesis.db.crud.ego.list_proposals_by_batch",
+        new_callable=AsyncMock,
+        return_value=[{"id": "prop-1"}, {"id": "prop-2"}],
+    ):
+        result = await _try_proposal_resolution(ctx, msg, reply_to_id)
+
+    assert result is True
+    workflow.resolve_proposals.assert_called_once()
+    call_args = workflow.resolve_proposals.call_args
+    assert call_args[0][0] == "batch-abc"  # batch_id
+    # All proposals should be approved
+    decisions = call_args[0][1]
+    assert all(s == "approved" for s, _ in decisions.values())
+    msg.reply_text.assert_called_once()
+    assert "2 approved" in msg.reply_text.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_try_proposal_resolution_no_match():
+    """Returns False when delivery_id doesn't match any batch."""
+    from genesis.channels.telegram._handler_messages import _try_proposal_resolution
+
+    ctx = MagicMock()
+    ctx.db = AsyncMock()
+    ctx.proposal_workflow = MagicMock()
+
+    msg = MagicMock()
+    msg.text = "approve all"
+
+    with patch(
+        "genesis.db.crud.ego.get_batch_for_delivery",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        result = await _try_proposal_resolution(ctx, msg, "99999")
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_try_proposal_resolution_unparseable_falls_through():
+    """Unparseable text returns False (falls through to correction store)."""
+    from genesis.channels.telegram._handler_messages import _try_proposal_resolution
+
+    ctx = MagicMock()
+    ctx.db = AsyncMock()
+    ctx.proposal_workflow = MagicMock()
+
+    msg = MagicMock()
+    msg.text = "hmm let me think about this"
+
+    with patch(
+        "genesis.db.crud.ego.get_batch_for_delivery",
+        new_callable=AsyncMock,
+        return_value="batch-xyz",
+    ):
+        result = await _try_proposal_resolution(ctx, msg, "12345")
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_try_proposal_resolution_numbered():
+    """Numbered decisions resolve specific proposals."""
+    from genesis.channels.telegram._handler_messages import _try_proposal_resolution
+
+    ctx = MagicMock()
+    ctx.db = AsyncMock()
+    workflow = AsyncMock()
+    workflow.resolve_proposals = AsyncMock(return_value={
+        "prop-1": "approved",
+        "prop-2": "rejected",
+    })
+    ctx.proposal_workflow = workflow
+
+    msg = MagicMock()
+    msg.text = "1 approve, 2 reject: bad idea"
+    msg.reply_text = AsyncMock()
+
+    with patch(
+        "genesis.db.crud.ego.get_batch_for_delivery",
+        new_callable=AsyncMock,
+        return_value="batch-abc",
+    ):
+        result = await _try_proposal_resolution(ctx, msg, "12345")
+
+    assert result is True
+    call_args = workflow.resolve_proposals.call_args
+    decisions = call_args[0][1]
+    assert decisions[1] == ("approved", None)
+    assert decisions[2] == ("rejected", "bad idea")

--- a/tests/test_autonomy/test_state_machine.py
+++ b/tests/test_autonomy/test_state_machine.py
@@ -323,3 +323,101 @@ class TestCheckCeiling:
     def test_ceiling_check_fails(self, manager):
         """outreach ceiling is 2, required L3 -> False."""
         assert manager.check_ceiling("outreach", 3) is False
+
+
+# ---------------------------------------------------------------------------
+# TestPromote
+# ---------------------------------------------------------------------------
+
+
+class TestPromote:
+    @pytest.mark.asyncio
+    async def test_promote_success(self, manager):
+        """promote() raises level and emits event."""
+        await manager.load_or_create_defaults()
+        ok = await manager.promote("direct_session", 2)
+        assert ok is True
+        state = await manager.get_state("direct_session")
+        assert state is not None
+        assert state.current_level == AutonomyLevel.L2
+        assert state.earned_level == AutonomyLevel.L2
+
+    @pytest.mark.asyncio
+    async def test_promote_emits_event(self, db, config_file):
+        event_bus = MagicMock()
+        event_bus.emit = AsyncMock()
+        mgr = AutonomyManager(db=db, event_bus=event_bus, config_path=config_file)
+        await mgr.load_or_create_defaults()
+        await mgr.promote("direct_session", 3)
+        await asyncio.sleep(0)
+        event_bus.emit.assert_called_once()
+        args = event_bus.emit.call_args
+        assert args[0][2] == "autonomy.promotion"
+        assert args[1]["category"] == "direct_session"
+        assert args[1]["level_before"] == 1
+        assert args[1]["level_after"] == 3
+
+    @pytest.mark.asyncio
+    async def test_promote_rejects_non_promotion(self, manager):
+        """promote() returns False if to_level <= current."""
+        await manager.load_or_create_defaults()
+        await manager.set_level("direct_session", 3)
+        assert await manager.promote("direct_session", 2) is False
+        assert await manager.promote("direct_session", 3) is False
+
+    @pytest.mark.asyncio
+    async def test_promote_missing_category(self, manager):
+        assert await manager.promote("nonexistent", 2) is False
+
+    @pytest.mark.asyncio
+    async def test_record_success_never_promotes(self, manager):
+        """record_success() always returns promoted=False now."""
+        await manager.load_or_create_defaults()
+        # Many successes — still no promotion
+        for _ in range(20):
+            ok, promoted = await manager.record_success("direct_session")
+            assert ok is True
+            assert promoted is False
+        state = await manager.get_state("direct_session")
+        assert state.current_level == AutonomyLevel.L1  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# TestForceRegress
+# ---------------------------------------------------------------------------
+
+
+class TestForceRegress:
+    @pytest.mark.asyncio
+    async def test_force_regress_resets_both_levels(self, manager):
+        """force_regress() resets both current and earned level."""
+        await manager.load_or_create_defaults()
+        await manager.set_level("direct_session", 4)
+        state = await manager.get_state("direct_session")
+        assert state.earned_level == AutonomyLevel.L4
+
+        ok = await manager.force_regress("direct_session", to_level=1, reason="user_revoked")
+        assert ok is True
+        state = await manager.get_state("direct_session")
+        assert state.current_level == AutonomyLevel.L1
+        assert state.earned_level == AutonomyLevel.L1  # earned also reset
+
+    @pytest.mark.asyncio
+    async def test_force_regress_emits_event(self, db, config_file):
+        event_bus = MagicMock()
+        event_bus.emit = AsyncMock()
+        mgr = AutonomyManager(db=db, event_bus=event_bus, config_path=config_file)
+        await mgr.load_or_create_defaults()
+        await mgr.set_level("direct_session", 3)
+        event_bus.reset_mock()
+        await mgr.force_regress("direct_session", to_level=1, reason="test")
+        await asyncio.sleep(0)
+        event_bus.emit.assert_called_once()
+        args = event_bus.emit.call_args
+        assert args[0][2] == "autonomy.regression"
+        assert args[1]["level_before"] == 3
+        assert args[1]["level_after"] == 1
+
+    @pytest.mark.asyncio
+    async def test_force_regress_missing_category(self, manager):
+        assert await manager.force_regress("nonexistent") is False

--- a/tests/test_db/test_autonomy.py
+++ b/tests/test_db/test_autonomy.py
@@ -158,26 +158,77 @@ def test_bayesian_posterior_computation():
     assert abs(bayesian_posterior(50, 2) - 0.944) < 0.01
 
 
-async def test_success_promotes_bayesian(db):
-    """Successes promote level when posterior crosses threshold."""
+async def test_success_does_not_auto_promote(db):
+    """record_success increments counter but does NOT change level."""
     await autonomy.create(db, id="promo1", category="promo1", updated_at="2026-01-01", current_level=1)
-    # Accumulate successes to cross L2 threshold (posterior >= 0.30)
-    # 1S + 0C → 2/3 = 0.667 → bayesian L3, but promote by 1 → L2
+    # Even with high posterior, level stays unchanged
     await autonomy.record_success(db, "promo1", updated_at="t1")
     row = await autonomy.get_by_id(db, "promo1")
-    assert row["current_level"] == 2  # promoted from L1 to L2
-    assert row["earned_level"] == 2
+    assert row["current_level"] == 1  # NOT promoted
+    assert row["earned_level"] == 1
+    assert row["total_successes"] == 1
+    assert row["consecutive_corrections"] == 0
 
 
-async def test_success_promotes_incrementally(db):
-    """Promotion happens one level at a time, even if posterior is much higher."""
+async def test_success_many_does_not_promote(db):
+    """Even many successes do not auto-promote — requires explicit promote()."""
     await autonomy.create(db, id="promo2", category="promo2", updated_at="2026-01-01", current_level=1)
     await db.execute("UPDATE autonomy_state SET total_successes = 49 WHERE id = 'promo2'")
     await db.commit()
-    # 50th success: 50S+0C → 51/52 = 0.98 → bayesian L4, but promote only to L2
     await autonomy.record_success(db, "promo2", updated_at="t1")
     row = await autonomy.get_by_id(db, "promo2")
-    assert row["current_level"] == 2  # only +1 from L1
+    assert row["current_level"] == 1  # Still L1 — no auto-promote
+    assert row["total_successes"] == 50
+
+
+async def test_promote_explicit(db):
+    """promote() explicitly raises level on user approval."""
+    await autonomy.create(db, id="pro1", category="pro1", updated_at="2026-01-01", current_level=1)
+    result = await autonomy.promote(db, "pro1", to_level=2, updated_at="t1")
+    assert result is True
+    row = await autonomy.get_by_id(db, "pro1")
+    assert row["current_level"] == 2
+    assert row["earned_level"] == 2
+
+
+async def test_promote_rejects_non_promotion(db):
+    """promote() returns False if to_level <= current."""
+    await autonomy.create(db, id="pro2", category="pro2", updated_at="2026-01-01", current_level=3)
+    result = await autonomy.promote(db, "pro2", to_level=2, updated_at="t1")
+    assert result is False
+    result = await autonomy.promote(db, "pro2", to_level=3, updated_at="t1")
+    assert result is False
+
+
+async def test_promote_rejects_invalid_level(db):
+    """promote() validates level range 1-7."""
+    await autonomy.create(db, id="pro3", category="pro3", updated_at="2026-01-01", current_level=1)
+    assert await autonomy.promote(db, "pro3", to_level=0, updated_at="t1") is False
+    assert await autonomy.promote(db, "pro3", to_level=8, updated_at="t1") is False
+
+
+async def test_promote_nonexistent(db):
+    """promote() returns False for missing id."""
+    assert await autonomy.promote(db, "ghost", to_level=2, updated_at="t1") is False
+
+
+async def test_force_regress(db):
+    """force_regress() resets BOTH current and earned level."""
+    await autonomy.create(
+        db, id="fr1", category="fr1", updated_at="2026-01-01",
+        current_level=4, earned_level=4,
+    )
+    result = await autonomy.force_regress(db, "fr1", to_level=1, reason="user_revoked", updated_at="t1")
+    assert result is True
+    row = await autonomy.get_by_id(db, "fr1")
+    assert row["current_level"] == 1
+    assert row["earned_level"] == 1  # earned also reset
+    assert row["regression_reason"] == "user_revoked"
+
+
+async def test_force_regress_nonexistent(db):
+    """force_regress() returns False for missing id."""
+    assert await autonomy.force_regress(db, "ghost", updated_at="t1") is False
 
 
 # ─── person_id tests ─────────────────────────────────────────────────────────

--- a/tests/test_db/test_autonomy.py
+++ b/tests/test_db/test_autonomy.py
@@ -201,10 +201,10 @@ async def test_promote_rejects_non_promotion(db):
 
 
 async def test_promote_rejects_invalid_level(db):
-    """promote() validates level range 1-7."""
+    """promote() validates level range 1-4."""
     await autonomy.create(db, id="pro3", category="pro3", updated_at="2026-01-01", current_level=1)
     assert await autonomy.promote(db, "pro3", to_level=0, updated_at="t1") is False
-    assert await autonomy.promote(db, "pro3", to_level=8, updated_at="t1") is False
+    assert await autonomy.promote(db, "pro3", to_level=5, updated_at="t1") is False
 
 
 async def test_promote_nonexistent(db):
@@ -224,6 +224,28 @@ async def test_force_regress(db):
     assert row["current_level"] == 1
     assert row["earned_level"] == 1  # earned also reset
     assert row["regression_reason"] == "user_revoked"
+
+
+async def test_force_regress_rejects_upward(db):
+    """force_regress() rejects 'regression' to a higher level."""
+    await autonomy.create(
+        db, id="fr2", category="fr2", updated_at="2026-01-01",
+        current_level=2, earned_level=2,
+    )
+    result = await autonomy.force_regress(db, "fr2", to_level=3, reason="test", updated_at="t1")
+    assert result is False
+    row = await autonomy.get_by_id(db, "fr2")
+    assert row["current_level"] == 2  # unchanged
+
+
+async def test_force_regress_rejects_same_level(db):
+    """force_regress() rejects 'regression' to same level."""
+    await autonomy.create(
+        db, id="fr3", category="fr3", updated_at="2026-01-01",
+        current_level=2, earned_level=2,
+    )
+    result = await autonomy.force_regress(db, "fr3", to_level=2, reason="test", updated_at="t1")
+    assert result is False
 
 
 async def test_force_regress_nonexistent(db):


### PR DESCRIPTION
## Summary

- **Kill auto-promote**: `record_success()` no longer silently promotes autonomy levels. Promotion now requires explicit user approval via new `promote()` function. `force_regress()` added for user revocation (resets both current + earned).
- **Wire proposal approval**: Quote-replying to an ego proposal digest (or typing a decision bare in the ego_proposals topic) now resolves proposals. Parser supports "approve all", "1 approve, 2 reject: reason", etc.
- **Ego context posteriors**: Both ego contexts now show "ready for L{n}" when Bayesian posterior supports promotion — enables the ego to propose naturally.
- **Executor provenance fix**: Task traces correctly attributed to "genesis" instead of "user".

## Test plan

- [x] 63 autonomy tests pass (CRUD + state machine)
- [x] 141 Telegram handler tests pass
- [x] 32 parser + integration tests pass (28 unit + 4 integration)
- [x] 62 ego context tests pass
- [x] 33 executor tests pass
- [x] 2038/2040 full suite pass (2 pre-existing failures: migrations runner + pr_opener)
- [x] Ruff lint clean on all changed files
- [x] Code review completed — level cap, direction guard, integration tests added

🤖 Generated with [Claude Code](https://claude.com/claude-code)