### PR TITLE
feat(mcp): web intelligence tools — external world discoverability

### DIFF
--- a/.claude/agents/genesis-researcher.md
+++ b/.claude/agents/genesis-researcher.md
@@ -1,0 +1,45 @@
+---
+name: genesis-researcher
+description: Deep research agent with full web + code intelligence. Use for any task requiring web fetching, searching, codebase exploration, or multi-source synthesis. Prefer this over generic Explore agents for research tasks.
+model: sonnet
+---
+
+You are a research agent for Genesis with access to powerful web and code intelligence tools via MCP.
+
+## Web Tools (MCP — use these, NOT CC WebFetch/WebSearch)
+
+- **`web_fetch(url)`** — Fetch any URL with smart anti-bot bypass. Scrapling TLS impersonation → Crawl4AI JS rendering → httpx. Returns structured content.
+- **`web_search(query)`** — Search the web via SearXNG (unlimited, self-hosted) → Brave fallback. For specialized search: `backend="tavily"` (AI-optimized), `backend="exa"` (semantic), `backend="perplexity"` (synthesized answer).
+- **CC WebFetch** — ONLY if you specifically need an AI-processed summary of content. Otherwise use `web_fetch`.
+- **CC WebSearch** — ONLY for trivial general lookups. Otherwise use `web_search`.
+
+## Code Intelligence (use these, NOT raw Grep for discovery)
+
+- **CBM `search_graph(name_pattern="...")`** — Find functions/classes/symbols by name pattern
+- **CBM `trace_path(function_name="...")`** — Trace call chains through the codebase
+- **CBM `get_architecture(aspects=["overview"])`** — High-level architecture view
+- **Serena `find_symbol`** — LSP-powered exact symbol lookup
+- **Serena `find_referencing_symbols`** — Find all callers/references to a symbol
+- **GitNexus `impact(target="...")`** — Blast radius of changing a symbol
+- **GitNexus `context(name="...")`** — 360° view of a symbol's relationships
+- **Grep/Read** — ONLY for text content search (configs, docs, string literals, non-code)
+
+## Decision Guide
+
+| Need | Tool |
+|------|------|
+| Fetch a webpage | `web_fetch(url)` |
+| Search the internet | `web_search(query)` |
+| Find a function/class | CBM `search_graph` or Serena `find_symbol` |
+| Who calls this? | Serena `find_referencing_symbols` |
+| Call chain trace | CBM `trace_path` |
+| Impact of changing X | GitNexus `impact` |
+| Config/doc content | Grep/Read directly |
+
+## Principles
+
+- Start with structured tools, fall back to text search only if they don't find what you need
+- Return findings in structured format with source URLs or file paths
+- Cite where information came from
+- For web content: prefer `web_fetch` over `web_search` if you already have the URL
+- For code: prefer CBM/Serena over reading files manually when discovering symbols

--- a/.claude/docs/web-tools-guide.md
+++ b/.claude/docs/web-tools-guide.md
@@ -2,6 +2,26 @@
 
 Genesis has multiple web tools across two execution contexts.
 
+
+## Canonical Interface (MCP — all session types)
+
+These are the PRIMARY tools. Use them by default in all contexts.
+
+| Need | Tool | Notes |
+|------|------|-------|
+| Fetch URL content | `web_fetch(url)` | Anti-bot, JS fallback, structured output |
+| Search the web | `web_search(query)` | SearXNG unlimited, structured results |
+| AI-summarized fetch | CC `WebFetch` | Foreground only — when you need AI summary |
+| Quick general lookup | CC `WebSearch` | Foreground only — simple questions |
+| JS-heavy SPA | `web_fetch(url, backend="crawl4ai")` | Playwright rendering |
+| Semantic search | `web_search(query, backend="exa")` | Find similar by meaning |
+| Synthesized answer | `web_search(query, backend="perplexity")` | Multi-source synthesis |
+| Page interaction | `browser_navigate` + `browser_click` | Login, forms, visual |
+
+**Default rule:** `web_fetch`/`web_search` first. CC tools for AI summaries only.
+Browser for interaction. ATS APIs for job listings.
+
+---
 ## Search — "I need to find something"
 
 | Tool | Context | Use when... | Free tier |

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -221,6 +221,26 @@
                         "command": "echo \"$CLAUDE_TOOL_INPUT\" | ${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook behavioral_linter.py"
                     }
                 ]
+            },
+            {
+                "matcher": "WebFetch|WebSearch",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/web_tools_gate.py",
+                        "timeout": 2000
+                    }
+                ]
+            },
+            {
+                "matcher": "Agent",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/agent_tool_guidance.py",
+                        "timeout": 2000
+                    }
+                ]
             }
         ],
         "Stop": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,18 @@ one matches.
 
 ## Web Tools
 
-CC WebSearch for general lookups, SearXNG for structured/bulk queries,
-Crawl4AI for JS-rendered pages, ATS APIs for job listings.
+**MCP tools (canonical — work in ALL session types):**
+- `web_fetch(url)` — fetch any URL with anti-bot bypass (Scrapling→Crawl4AI→httpx)
+- `web_search(query)` — search web (SearXNG→Brave, or explicit tavily/exa/perplexity)
+
+**CC built-in tools (foreground convenience):**
+- CC `WebFetch` — AI-processed summary (use when you need a summary, not raw content)
+- CC `WebSearch` — quick general lookups (fine for simple questions)
+
+**Default to MCP tools.** They handle anti-bot, work in background sessions,
+and return structured data. Use CC tools only when AI summarization is the goal.
+
+Browser tools for interactive pages. ATS APIs for job listings.
 Full decision guide: `.claude/docs/web-tools-guide.md`
 
 ## Background Sessions

--- a/scripts/hooks/agent_tool_guidance.py
+++ b/scripts/hooks/agent_tool_guidance.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""PreToolUse hook (Agent): nudge caller to include tool guidance in agent prompts.
+
+When dispatching subagents for research or exploration, the caller often
+forgets to tell the agent about Genesis's web and code intelligence tools.
+This hook provides a soft reminder to include tool guidance.
+
+Smart filtering: only nudges when the prompt contains research/web/explore
+keywords. Nudges once per session via sentinel. Never blocks (exit 0).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tempfile
+
+_SENTINEL_PREFIX = "genesis_agent_guidance_"
+
+# Keywords that suggest the agent will need web or code discovery tools
+_RESEARCH_KEYWORDS = re.compile(
+    r"\b(fetch|search|web|url|http|research|explore|find|discover|investigate"
+    r"|codebase|architecture|symbol|function|class|import|call.?chain)\b",
+    re.IGNORECASE,
+)
+
+
+def _session_sentinel_path() -> str:
+    session_id = os.environ.get("CLAUDE_SESSION_ID", "unknown")
+    return os.path.join(tempfile.gettempdir(), f"{_SENTINEL_PREFIX}{session_id}")
+
+
+def main() -> int:
+    # Only nudge once per session
+    sentinel = _session_sentinel_path()
+    if os.path.exists(sentinel):
+        return 0
+
+    try:
+        raw = os.environ.get("CLAUDE_TOOL_INPUT", "")
+        if not raw:
+            return 0
+
+        data = json.loads(raw)
+        prompt = data.get("prompt", "")
+
+        # Only nudge for research/exploration-type prompts
+        if not _RESEARCH_KEYWORDS.search(prompt):
+            return 0
+
+        # Create sentinel
+        try:
+            with open(sentinel, "w") as f:
+                f.write("1")
+        except OSError:
+            pass
+
+        nudge = (
+            "When dispatching agents for research or exploration, include tool guidance:\n"
+            "- Web: use web_fetch(url) and web_search(query) MCP tools (anti-bot, JS rendering)\n"
+            "- Code: use CBM search_graph/trace_path, Serena find_symbol/find_referencing_symbols\n"
+            "- These MCP tools are available to the agent. Prefer them over CC WebFetch/WebSearch and raw Grep."
+        )
+        print(json.dumps({"additionalContext": nudge}))
+
+    except (json.JSONDecodeError, KeyError):
+        pass  # Fail-open
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hooks/web_tools_gate.py
+++ b/scripts/hooks/web_tools_gate.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""PreToolUse hook (WebFetch|WebSearch): soft nudge toward MCP web tools.
+
+Fires when CC's built-in WebFetch or WebSearch is invoked. Suggests the
+Genesis MCP web_fetch/web_search tools which provide anti-bot bypass,
+JS rendering, and work in all session types (including background).
+
+Never blocks (exit 0 always). Nudges once per session via sentinel file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+
+_SENTINEL_PREFIX = "genesis_web_nudge_"
+
+
+def _session_sentinel_path() -> str:
+    """Path to a sentinel file that tracks whether we've nudged this session."""
+    session_id = os.environ.get("CLAUDE_SESSION_ID", "unknown")
+    return os.path.join(tempfile.gettempdir(), f"{_SENTINEL_PREFIX}{session_id}")
+
+
+def main() -> int:
+    # Only nudge once per session
+    sentinel = _session_sentinel_path()
+    if os.path.exists(sentinel):
+        return 0
+
+    try:
+        raw = os.environ.get("CLAUDE_TOOL_INPUT", "")
+        if not raw:
+            return 0
+
+        # Create sentinel — we've nudged
+        try:
+            with open(sentinel, "w") as f:
+                f.write("1")
+        except OSError:
+            pass  # Non-critical
+
+        # Output soft nudge as additionalContext
+        nudge = (
+            "Genesis MCP web tools (web_fetch, web_search) provide anti-bot bypass "
+            "(Scrapling TLS impersonation), JS rendering (Crawl4AI), and work in ALL "
+            "session types including background. Consider using them instead.\n"
+            "- web_fetch(url) — structured content with smart fallback chain\n"
+            "- web_search(query) — SearXNG (unlimited) with Brave/Tavily/Exa/Perplexity options\n"
+            "CC WebFetch is best when you specifically need an AI-processed summary."
+        )
+        print(json.dumps({"additionalContext": nudge}))
+
+    except (json.JSONDecodeError, KeyError):
+        pass  # Fail-open
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -70,6 +70,7 @@ from genesis.mcp.health import settings as _settings  # noqa: E402
 from genesis.mcp.health import status as _status  # noqa: E402
 from genesis.mcp.health import task_tools as _task_tools  # noqa: E402
 from genesis.mcp.health import update_history as _update_history  # noqa: E402
+from genesis.mcp.health import web_tools as _web_tools  # noqa: E402
 
 codebase = _codebase
 db_schema = _db_schema

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -70,7 +70,7 @@ from genesis.mcp.health import settings as _settings  # noqa: E402
 from genesis.mcp.health import status as _status  # noqa: E402
 from genesis.mcp.health import task_tools as _task_tools  # noqa: E402
 from genesis.mcp.health import update_history as _update_history  # noqa: E402
-from genesis.mcp.health import web_tools as _web_tools  # noqa: E402
+from genesis.mcp.health import web_tools as _web_tools  # noqa: E402, F401
 
 codebase = _codebase
 db_schema = _db_schema

--- a/src/genesis/mcp/health/web_tools.py
+++ b/src/genesis/mcp/health/web_tools.py
@@ -41,7 +41,14 @@ def _get_searcher():
 
 
 def _is_challenge_response(text: str, status_code: int) -> bool:
-    """Detect anti-bot challenge responses that need JS rendering."""
+    """Detect anti-bot challenge responses that need JS rendering.
+
+    Intentional trade-off: only checks markers in short pages (<500 chars).
+    Most Cloudflare challenges return 403/503 (caught by status check).
+    Rare 200+challenge pages that exceed 500 chars will not trigger escalation
+    — acceptable because large pages with challenge markers mixed into real
+    content would cause false positives on legitimate pages.
+    """
     if status_code in (403, 429, 503):
         return True
     if not text or len(text) < 500:
@@ -113,7 +120,7 @@ async def _impl_web_fetch(
             "url": result.url,
             "title": result.title,
             "content": result.text,
-            "backend_used": "scrapling" if result.text else "httpx",
+            "backend_used": "scrapling" if not result.error else "httpx",
             "status_code": result.status_code,
             "truncated": result.truncated,
             "error": result.error,

--- a/src/genesis/mcp/health/web_tools.py
+++ b/src/genesis/mcp/health/web_tools.py
@@ -1,0 +1,334 @@
+"""Web intelligence MCP tools — external world discoverability.
+
+Exposes Genesis's web infrastructure (Scrapling, Crawl4AI, SearXNG, Brave,
+Tavily, Exa, Perplexity) as MCP tools accessible from all session types.
+
+Smart fallback chains — callers say what they want, the tool figures out how.
+Parallel to code intelligence tools (CBM, Serena, GitNexus) for internal
+discoverability.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+# Lazy singletons — avoids import-time overhead for Playwright/httpx
+_fetcher = None
+_searcher = None
+
+
+def _get_fetcher():
+    global _fetcher
+    if _fetcher is None:
+        from genesis.web.fetch import WebFetcher
+
+        _fetcher = WebFetcher()
+    return _fetcher
+
+
+def _get_searcher():
+    global _searcher
+    if _searcher is None:
+        from genesis.web.search import WebSearcher
+
+        _searcher = WebSearcher()
+    return _searcher
+
+
+def _is_challenge_response(text: str, status_code: int) -> bool:
+    """Detect anti-bot challenge responses that need JS rendering."""
+    if status_code in (403, 429, 503):
+        return True
+    if not text or len(text) < 500:
+        lower = text.lower() if text else ""
+        challenge_markers = ("captcha", "cloudflare", "challenge", "verify you are human")
+        return any(m in lower for m in challenge_markers)
+    return False
+
+
+async def _try_crawl4ai(url: str, max_chars: int) -> dict | None:
+    """Attempt Crawl4AI fetch. Returns result dict or None on failure."""
+    try:
+        from crawl4ai import AsyncWebCrawler
+
+        start = time.monotonic()
+        async with AsyncWebCrawler() as crawler:
+            result = await crawler.arun(url=url)
+        latency = (time.monotonic() - start) * 1000
+
+        if result and result.markdown:
+            content = result.markdown[:max_chars]
+            return {
+                "url": url,
+                "title": result.metadata.get("title", "") if result.metadata else "",
+                "content": content,
+                "backend_used": "crawl4ai",
+                "status_code": 200,
+                "truncated": len(result.markdown) > max_chars,
+                "error": None,
+                "latency_ms": round(latency, 1),
+            }
+    except ImportError:
+        logger.debug("Crawl4AI not available for fallback")
+    except Exception as exc:
+        logger.warning("Crawl4AI fallback failed for %s: %s", url, exc)
+    return None
+
+
+async def _impl_web_fetch(
+    url: str,
+    backend: str = "auto",
+    max_chars: int = 50000,
+) -> dict:
+    """Fetch a URL and return clean text content."""
+    if not url or not url.strip():
+        return {"error": "url is required"}
+
+    url = url.strip()
+    if not url.startswith(("http://", "https://")):
+        url = "https://" + url
+
+    start = time.monotonic()
+    fetcher = _get_fetcher()
+
+    if backend == "auto":
+        # Primary: Scrapling/httpx via WebFetcher
+        result = await fetcher.fetch(url, max_chars=max_chars)
+        latency = (time.monotonic() - start) * 1000
+
+        # If challenge detected, escalate to Crawl4AI
+        if _is_challenge_response(result.text, result.status_code):
+            logger.info("Challenge detected for %s, escalating to Crawl4AI", url)
+            crawl_result = await _try_crawl4ai(url, max_chars)
+            if crawl_result:
+                return crawl_result
+
+        # Return WebFetcher result (even if partial)
+        return {
+            "url": result.url,
+            "title": result.title,
+            "content": result.text,
+            "backend_used": "scrapling" if result.text else "httpx",
+            "status_code": result.status_code,
+            "truncated": result.truncated,
+            "error": result.error,
+            "latency_ms": round(latency, 1),
+        }
+
+    elif backend == "crawl4ai":
+        crawl_result = await _try_crawl4ai(url, max_chars)
+        if crawl_result:
+            return crawl_result
+        return {"url": url, "error": "Crawl4AI failed or unavailable", "backend_used": "crawl4ai"}
+
+    elif backend in ("scrapling", "httpx"):
+        # Force WebFetcher (which uses scrapling if available, else httpx)
+        result = await fetcher.fetch(url, max_chars=max_chars)
+        latency = (time.monotonic() - start) * 1000
+        return {
+            "url": result.url,
+            "title": result.title,
+            "content": result.text,
+            "backend_used": backend,
+            "status_code": result.status_code,
+            "truncated": result.truncated,
+            "error": result.error,
+            "latency_ms": round(latency, 1),
+        }
+
+    else:
+        return {"error": f"Unknown backend '{backend}'. Use: auto, scrapling, crawl4ai, httpx"}
+
+
+async def _impl_web_search(
+    query: str,
+    backend: str = "auto",
+    max_results: int = 10,
+) -> dict:
+    """Search the web and return structured results."""
+    if not query or not query.strip():
+        return {"error": "query is required"}
+
+    query = query.strip()
+    max_results = min(max(1, max_results), 20)
+    start = time.monotonic()
+
+    if backend in ("auto", "searxng", "brave"):
+        # Use WebSearcher (SearXNG primary, Brave fallback)
+        searcher = _get_searcher()
+        response = await searcher.search(query, max_results=max_results)
+        latency = (time.monotonic() - start) * 1000
+
+        results = [
+            {"title": r.title, "url": r.url, "snippet": r.snippet, "score": r.score}
+            for r in response.results
+        ]
+        return {
+            "query": response.query,
+            "results": results,
+            "backend_used": response.backend_used.value if response.backend_used else "unknown",
+            "fallback_used": response.fallback_used,
+            "answer": None,
+            "error": response.error,
+            "latency_ms": round(latency, 1),
+        }
+
+    elif backend == "tavily":
+        try:
+            from genesis.providers.tavily_adapter import TavilyAdapter
+
+            adapter = TavilyAdapter()
+            result = await adapter.invoke({
+                "query": query,
+                "max_results": max_results,
+                "include_answer": True,
+            })
+            latency = (time.monotonic() - start) * 1000
+
+            if not result.success:
+                return {"query": query, "error": result.error or "Tavily search failed", "backend_used": "tavily"}
+
+            data = result.data or {}
+            results = [
+                {"title": r.get("title", ""), "url": r.get("url", ""), "snippet": r.get("content", ""), "score": r.get("score", 0)}
+                for r in data.get("results", [])
+            ]
+            return {
+                "query": query,
+                "results": results,
+                "backend_used": "tavily",
+                "fallback_used": False,
+                "answer": data.get("answer"),
+                "error": None,
+                "latency_ms": round(latency, 1),
+            }
+        except (ImportError, ValueError) as exc:
+            return {"query": query, "error": f"Tavily unavailable: {exc}", "backend_used": "tavily"}
+
+    elif backend == "exa":
+        try:
+            from genesis.providers.exa_adapter import ExaAdapter
+
+            adapter = ExaAdapter()
+            result = await adapter.invoke({
+                "query": query,
+                "num_results": max_results,
+            })
+            latency = (time.monotonic() - start) * 1000
+
+            if not result.success:
+                return {"query": query, "error": result.error or "Exa search failed", "backend_used": "exa"}
+
+            data = result.data or {}
+            results = [
+                {"title": r.get("title", ""), "url": r.get("url", ""), "snippet": r.get("text", "")[:300], "score": r.get("score", 0)}
+                for r in data.get("results", [])
+            ]
+            return {
+                "query": query,
+                "results": results,
+                "backend_used": "exa",
+                "fallback_used": False,
+                "answer": None,
+                "error": None,
+                "latency_ms": round(latency, 1),
+            }
+        except (ImportError, ValueError) as exc:
+            return {"query": query, "error": f"Exa unavailable: {exc}", "backend_used": "exa"}
+
+    elif backend == "perplexity":
+        try:
+            from genesis.research.perplexity import PerplexityAdapter
+
+            adapter = PerplexityAdapter()
+            result = await adapter.invoke({"query": query})
+            latency = (time.monotonic() - start) * 1000
+
+            if not result.success:
+                return {"query": query, "error": result.error or "Perplexity failed", "backend_used": "perplexity"}
+
+            return {
+                "query": query,
+                "results": [],
+                "backend_used": "perplexity",
+                "fallback_used": False,
+                "answer": result.data if isinstance(result.data, str) else str(result.data),
+                "error": None,
+                "latency_ms": round(latency, 1),
+            }
+        except (ImportError, ValueError) as exc:
+            return {"query": query, "error": f"Perplexity unavailable: {exc}", "backend_used": "perplexity"}
+
+    else:
+        return {"error": f"Unknown backend '{backend}'. Use: auto, searxng, brave, tavily, exa, perplexity"}
+
+
+@mcp.tool()
+async def web_fetch(
+    url: str,
+    backend: str = "auto",
+    max_chars: int = 50000,
+) -> dict:
+    """Fetch a URL and return clean text content.
+
+    Smart fallback chain: Scrapling (TLS impersonation, fast) → Crawl4AI
+    (JS rendering, handles SPAs) → httpx (plain, last resort). The tool
+    decides the best backend unless overridden.
+
+    Args:
+        url: The URL to fetch.
+        backend: "auto" (smart fallback), "scrapling" (fast, anti-bot TLS),
+                 "crawl4ai" (JS-rendered markdown), or "httpx" (plain HTTP).
+        max_chars: Maximum characters to return (default 50000 ≈ 12k tokens).
+
+    Returns dict with: url, title, content, backend_used, status_code,
+    truncated, error, latency_ms.
+
+    Use this instead of CC WebFetch for:
+    - Anti-bot protected sites (Scrapling's TLS fingerprinting)
+    - JS-heavy SPAs (Crawl4AI's Playwright rendering)
+    - Background sessions (no Bash available)
+    - Consistent structured output (no AI summarization)
+
+    Use CC WebFetch when you specifically need AI-processed summaries.
+    Use browser_navigate when you need to interact with the page.
+    """
+    return await _impl_web_fetch(url, backend, max_chars)
+
+
+@mcp.tool()
+async def web_search(
+    query: str,
+    backend: str = "auto",
+    max_results: int = 10,
+) -> dict:
+    """Search the web and return structured results.
+
+    Smart fallback chain: SearXNG (self-hosted, unlimited) → Brave (API).
+    Paid backends (tavily, exa, perplexity) available via explicit backend param.
+
+    Args:
+        query: Search query string. Supports site: filters with SearXNG.
+        backend: "auto" (SearXNG→Brave), "searxng", "brave", "tavily"
+                 (AI-optimized), "exa" (semantic), or "perplexity" (synthesized).
+        max_results: Maximum results (default 10, max 20).
+
+    Returns dict with: query, results (list of title/url/snippet/score),
+    backend_used, fallback_used, answer (for tavily/perplexity), error, latency_ms.
+
+    Use this instead of CC WebSearch for:
+    - site: filters and structured JSON (SearXNG)
+    - Background sessions (no Bash available)
+    - Bulk queries (SearXNG is unlimited, self-hosted)
+    - Agent pipelines needing structured data
+
+    Use CC WebSearch for quick general lookups in foreground sessions.
+    Use "perplexity" backend when you need a synthesized multi-source answer.
+    Use "exa" backend for conceptual/semantic discovery.
+    """
+    return await _impl_web_search(query, backend, max_results)

--- a/tests/test_mcp/test_web_tools.py
+++ b/tests/test_mcp/test_web_tools.py
@@ -1,0 +1,190 @@
+"""Tests for web intelligence MCP tools — web_fetch and web_search."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from genesis.mcp.health.web_tools import (
+    _impl_web_fetch,
+    _impl_web_search,
+    _is_challenge_response,
+)
+from genesis.web.types import FetchResult, SearchBackend, SearchResponse, SearchResult
+
+
+class TestIsChallenge:
+    def test_403_is_challenge(self):
+        assert _is_challenge_response("Forbidden", 403) is True
+
+    def test_429_is_challenge(self):
+        assert _is_challenge_response("Rate limited", 429) is True
+
+    def test_503_is_challenge(self):
+        assert _is_challenge_response("", 503) is True
+
+    def test_short_cloudflare_text(self):
+        assert _is_challenge_response("Please verify you are human cloudflare", 200) is True
+
+    def test_normal_200_not_challenge(self):
+        assert _is_challenge_response("A" * 1000, 200) is False
+
+    def test_empty_body_200_not_challenge(self):
+        # Empty body with 200 is ambiguous — no markers means not a challenge
+        assert _is_challenge_response("", 200) is False
+
+    def test_empty_body_403_is_challenge(self):
+        assert _is_challenge_response("", 403) is True
+
+
+class TestWebFetch:
+    @pytest.mark.asyncio
+    async def test_missing_url(self):
+        result = await _impl_web_fetch("", "auto", 50000)
+        assert "error" in result
+        assert "required" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_auto_adds_https(self):
+        """URLs without scheme get https:// prepended."""
+        mock_result = FetchResult(
+            url="https://example.com",
+            text="Hello world",
+            title="Example",
+            status_code=200,
+        )
+        with patch("genesis.mcp.health.web_tools._get_fetcher") as mock:
+            mock.return_value.fetch = AsyncMock(return_value=mock_result)
+            result = await _impl_web_fetch("example.com", "auto", 50000)
+        assert result["content"] == "Hello world"
+        assert result["backend_used"] == "scrapling"
+
+    @pytest.mark.asyncio
+    async def test_auto_returns_scrapling_result(self):
+        mock_result = FetchResult(
+            url="https://example.com",
+            text="Page content here",
+            title="Test Page",
+            status_code=200,
+        )
+        with patch("genesis.mcp.health.web_tools._get_fetcher") as mock:
+            mock.return_value.fetch = AsyncMock(return_value=mock_result)
+            result = await _impl_web_fetch("https://example.com", "auto", 50000)
+
+        assert result["url"] == "https://example.com"
+        assert result["title"] == "Test Page"
+        assert result["content"] == "Page content here"
+        assert result["backend_used"] == "scrapling"
+        assert result["status_code"] == 200
+        assert result["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_auto_escalates_to_crawl4ai_on_challenge(self):
+        """When Scrapling gets a 403, should try Crawl4AI."""
+        challenge_result = FetchResult(
+            url="https://protected.com",
+            text="cloudflare challenge",
+            title="",
+            status_code=403,
+        )
+        with patch("genesis.mcp.health.web_tools._get_fetcher") as mock_fetcher:
+            mock_fetcher.return_value.fetch = AsyncMock(return_value=challenge_result)
+            with patch("genesis.mcp.health.web_tools._try_crawl4ai") as mock_crawl:
+                mock_crawl.return_value = {
+                    "url": "https://protected.com",
+                    "title": "Real Page",
+                    "content": "JS rendered content",
+                    "backend_used": "crawl4ai",
+                    "status_code": 200,
+                    "truncated": False,
+                    "error": None,
+                    "latency_ms": 2000.0,
+                }
+                result = await _impl_web_fetch("https://protected.com", "auto", 50000)
+
+        assert result["backend_used"] == "crawl4ai"
+        assert result["content"] == "JS rendered content"
+
+    @pytest.mark.asyncio
+    async def test_explicit_crawl4ai_backend(self):
+        with patch("genesis.mcp.health.web_tools._try_crawl4ai") as mock:
+            mock.return_value = {
+                "url": "https://spa.com",
+                "title": "SPA",
+                "content": "Rendered markdown",
+                "backend_used": "crawl4ai",
+                "status_code": 200,
+                "truncated": False,
+                "error": None,
+                "latency_ms": 3000.0,
+            }
+            result = await _impl_web_fetch("https://spa.com", "crawl4ai", 50000)
+        assert result["backend_used"] == "crawl4ai"
+        assert result["content"] == "Rendered markdown"
+
+    @pytest.mark.asyncio
+    async def test_unknown_backend_error(self):
+        result = await _impl_web_fetch("https://example.com", "nosuchbackend", 50000)
+        assert "error" in result
+        assert "Unknown backend" in result["error"]
+
+
+class TestWebSearch:
+    @pytest.mark.asyncio
+    async def test_missing_query(self):
+        result = await _impl_web_search("", "auto", 10)
+        assert "error" in result
+        assert "required" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_auto_uses_searxng(self):
+        mock_response = SearchResponse(
+            query="test query",
+            results=[
+                SearchResult(title="Result 1", url="https://r1.com", snippet="Snippet 1", backend=SearchBackend.SEARXNG),
+                SearchResult(title="Result 2", url="https://r2.com", snippet="Snippet 2", backend=SearchBackend.SEARXNG),
+            ],
+            backend_used=SearchBackend.SEARXNG,
+        )
+        with patch("genesis.mcp.health.web_tools._get_searcher") as mock:
+            mock.return_value.search = AsyncMock(return_value=mock_response)
+            result = await _impl_web_search("test query", "auto", 10)
+
+        assert result["query"] == "test query"
+        assert result["backend_used"] == "searxng"
+        assert len(result["results"]) == 2
+        assert result["results"][0]["title"] == "Result 1"
+        assert result["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_max_results_capped_at_20(self):
+        mock_response = SearchResponse(query="q", results=[], backend_used=SearchBackend.SEARXNG)
+        with patch("genesis.mcp.health.web_tools._get_searcher") as mock:
+            mock.return_value.search = AsyncMock(return_value=mock_response)
+            await _impl_web_search("q", "auto", 100)
+            # Verify max_results was capped
+            mock.return_value.search.assert_awaited_once_with("q", max_results=20)
+
+    @pytest.mark.asyncio
+    async def test_tavily_backend(self):
+        with patch("genesis.providers.tavily_adapter.TavilyAdapter") as MockAdapter:
+            from genesis.providers.types import ProviderResult
+
+            mock_instance = MockAdapter.return_value
+            mock_instance.invoke = AsyncMock(return_value=ProviderResult(
+                success=True,
+                data={"results": [{"title": "T", "url": "U", "content": "C", "score": 0.9}], "answer": "The answer"},
+                provider_name="tavily",
+            ))
+            result = await _impl_web_search("AI agents", "tavily", 5)
+
+        assert result["backend_used"] == "tavily"
+        assert result["answer"] == "The answer"
+        assert len(result["results"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_unknown_backend_error(self):
+        result = await _impl_web_search("query", "nosuchbackend", 10)
+        assert "error" in result
+        assert "Unknown backend" in result["error"]


### PR DESCRIPTION
## Summary
- Add `web_fetch` and `web_search` MCP tools to genesis-health, exposing Genesis's full web stack to ALL session types (foreground, background, ego, subagents)
- Add behavioral injection: PreToolUse hooks nudge sessions toward MCP tools when they reach for CC's weaker WebFetch/WebSearch
- Add `genesis-researcher` custom agent with web + code intelligence guidance baked in
- Update CLAUDE.md and web-tools-guide.md with MCP-first defaults

## What this solves
Sessions (especially background/ego/subagents) default to CC's weak WebFetch/WebSearch because they don't know Genesis has Scrapling (anti-bot TLS), Crawl4AI (JS rendering), SearXNG (unlimited self-hosted search), or Tavily/Exa/Perplexity. Same discoverability problem code intelligence already solved.

## Architecture
- `web_fetch(url)`: Scrapling → Crawl4AI (on challenge) → httpx fallback
- `web_search(query)`: SearXNG → Brave fallback. Explicit `tavily`/`exa`/`perplexity` backends.
- PreToolUse:WebFetch|WebSearch → soft nudge (once per session)
- PreToolUse:Agent → reminds caller to include tool guidance (keyword-filtered)
- `.claude/agents/genesis-researcher.md` → custom agent with full tool awareness

## Test plan
- [x] 18 unit tests covering both tools, challenge detection, fallback chains
- [x] 22 existing web tests still pass (zero regressions)
- [x] Functional smoke test: web_fetch on httpbin.org → Scrapling success
- [x] Functional smoke test: web_search → SearXNG returns structured results
- [x] Verified: tools registered in FastMCP tool manager
- [x] Verified: subagents DO have MCP tool access (tested with health_status)
- [x] Note: tools visible to new sessions only (MCP server restart required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)