### PR TITLE
fix(db): migration 0010 handles missing memory_metadata table

### DIFF
--- a/src/genesis/db/migrations/0010_bitemporal_memory.py
+++ b/src/genesis/db/migrations/0010_bitemporal_memory.py
@@ -20,6 +20,14 @@ import aiosqlite
 
 
 async def up(db: aiosqlite.Connection) -> None:
+    # Skip if memory_metadata doesn't exist yet (fresh DB without DDL schema).
+    # The DDL schema creates the table with these columns already.
+    tables = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='memory_metadata'"
+    )
+    if not await tables.fetchone():
+        return  # Table doesn't exist — DDL will create it with columns included
+
     # Add bi-temporal columns (idempotent — column may already exist from DDL)
     cursor = await db.execute("PRAGMA table_info(memory_metadata)")
     existing = {row[1] for row in await cursor.fetchall()}


### PR DESCRIPTION
## Summary
- Migration 0010 (bi-temporal memory) now skips gracefully when `memory_metadata` table doesn't exist
- Fixes 5 test failures in `test_migrations_runner.py` that run against empty DBs

## Context
The migration fixture creates a fresh DB without DDL schema. Migration 0010 assumed the table existed. Fresh installs get the columns from DDL directly — migration only applies to existing installs with the table already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)