### PR TITLE
feat(memory): expose expand_query_terms in memory_recall MCP tool

### DIFF
--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -30,6 +30,7 @@ async def memory_recall(
     wing: str | None = None,
     room: str | None = None,
     include_graph: bool = True,
+    expand_query_terms: bool = False,
 ) -> list[dict]:
     """Hybrid search: Qdrant vectors + FTS5, RRF fusion, with optional graph enrichment.
 
@@ -40,13 +41,17 @@ async def memory_recall(
         wing: Filter results to this structural domain (e.g., "infrastructure").
         room: Filter results to this topic within a wing.
         include_graph: If False, skip graph traversal (saves ~500ms per call).
+        expand_query_terms: If True, expand the FTS5 query via tag co-occurrence
+            analysis (~500ms first call, ~10ms cached). Broadens recall for
+            ambiguous queries. Default off — opt in when standard search misses.
+            Note: does not apply to the drift_recall fallback path (if wired).
     """
     memory_mod = _memory_mod()
     memory_mod._require_init()
     assert memory_mod._retriever is not None and memory_mod._db is not None
     results = await memory_mod._retriever.recall(
         query, source=source, limit=limit, min_activation=min_activation,
-        wing=wing, room=room,
+        wing=wing, room=room, expand_query_terms=expand_query_terms,
     )
 
     if compact:

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -1058,3 +1058,92 @@ async def test_conversation_history_unknown_channel():
         mod._store = old_store
         mod._db = old_db
         mod._retriever = old_retriever
+
+
+# ─── expand_query_terms pass-through tests ───────────────────────────────────
+
+
+def _make_retrieval_result(mid="a", content="test", score=0.9):
+    """Build a minimal RetrievalResult for mocking."""
+    from genesis.memory.types import RetrievalResult
+
+    return RetrievalResult(
+        memory_id=mid,
+        content=content,
+        source="test",
+        memory_type="episodic",
+        score=score,
+        vector_rank=1,
+        fts_rank=1,
+        activation_score=0.5,
+        payload={"wing": "", "room": ""},
+        memory_class="fact",
+    )
+
+
+async def test_memory_recall_passes_expand_query_terms_true():
+    """When expand_query_terms=True, it reaches retriever.recall()."""
+    import genesis.mcp.memory_mcp as mod
+
+    mock_retriever = AsyncMock()
+    mock_retriever.recall.return_value = [_make_retrieval_result()]
+
+    old_store, old_db, old_retriever, old_qdrant = (
+        mod._store, mod._db, mod._retriever, mod._qdrant,
+    )
+    try:
+        mod._store = MagicMock()
+        mod._db = MagicMock()
+        mod._retriever = mock_retriever
+        mod._qdrant = MagicMock()
+
+        tools = await _get_tools()
+        await tools["memory_recall"].fn(
+            query="configure routing",
+            expand_query_terms=True,
+            include_graph=False,
+        )
+
+        mock_retriever.recall.assert_called_once()
+        call_kwargs = mock_retriever.recall.call_args[1]
+        assert call_kwargs["expand_query_terms"] is True
+    finally:
+        mod._store = old_store
+        mod._db = old_db
+        mod._retriever = old_retriever
+        mod._qdrant = old_qdrant
+
+
+async def test_memory_recall_expand_query_terms_defaults_false():
+    """By default, expand_query_terms is False (no expansion)."""
+    import genesis.mcp.memory_mcp as mod
+
+    mock_retriever = AsyncMock()
+    mock_retriever.recall.return_value = [
+        _make_retrieval_result(),
+        _make_retrieval_result(mid="b"),
+        _make_retrieval_result(mid="c"),
+    ]
+
+    old_store, old_db, old_retriever, old_qdrant = (
+        mod._store, mod._db, mod._retriever, mod._qdrant,
+    )
+    try:
+        mod._store = MagicMock()
+        mod._db = MagicMock()
+        mod._retriever = mock_retriever
+        mod._qdrant = MagicMock()
+
+        tools = await _get_tools()
+        await tools["memory_recall"].fn(
+            query="test query",
+            include_graph=False,
+        )
+
+        call_kwargs = mock_retriever.recall.call_args[1]
+        assert call_kwargs["expand_query_terms"] is False
+    finally:
+        mod._store = old_store
+        mod._db = old_db
+        mod._retriever = old_retriever
+        mod._qdrant = old_qdrant


### PR DESCRIPTION
## Summary

- Threads the existing `expand_query_terms` parameter from `HybridRetriever.recall()` through to the `memory_recall` MCP tool
- Allows CC sessions to opt into tag co-occurrence query expansion for ambiguous searches
- Default off — no behavior change for existing callers

## Details

The `expand_query()` function in `genesis.memory.intent` uses tag co-occurrence analysis to expand FTS5 queries (e.g., "configure routing" → `(configure AND routing) OR setup OR deploy`). This was already built, tested, and wired inside the retriever — but the MCP layer never exposed the parameter, so it was permanently off.

This is a 3-line code change (parameter + docstring + pass-through) plus 2 tests.

## Test plan

- [x] `ruff check` passes
- [x] All 34 `test_memory_mcp.py` tests pass (including 2 new)
- [x] All 30 `test_intent.py` tests pass (no regression)
- [x] End-to-end chain verified: MCP → retriever → expand_query() → FTS5 boolean syntax
- [x] Adversarial code review complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)