### PR TITLE
feat(dashboard): memory growth sparkline, wing distribution, PWA support

### DIFF
--- a/src/genesis/dashboard/routes/memory.py
+++ b/src/genesis/dashboard/routes/memory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 
+import aiosqlite
 from flask import jsonify, request
 
 from genesis.dashboard._blueprint import _async_route, blueprint
@@ -190,5 +191,33 @@ async def memory_stats():
         stats["pending_embeddings"] = await pending_embeddings.count_pending(rt.db)
     except Exception:
         stats["pending_embeddings"] = None
+
+    # Daily growth — last 30 days
+    try:
+        rt.db.row_factory = aiosqlite.Row
+        rows = await rt.db.execute_fetchall(
+            """SELECT date(created_at) as day, count(*) as count
+               FROM memory_metadata
+               WHERE created_at > datetime('now', '-30 days')
+               GROUP BY day ORDER BY day"""
+        )
+        stats["daily_growth"] = [{"day": r["day"], "count": r["count"]} for r in rows]
+    except Exception:
+        logger.error("Memory growth query failed", exc_info=True)
+        stats["daily_growth"] = []
+
+    # Wing distribution
+    try:
+        rt.db.row_factory = aiosqlite.Row
+        rows = await rt.db.execute_fetchall(
+            """SELECT wing, count(*) as count
+               FROM memory_metadata
+               WHERE wing IS NOT NULL AND wing != ''
+               GROUP BY wing ORDER BY count DESC"""
+        )
+        stats["wings"] = [{"wing": r["wing"], "count": r["count"]} for r in rows]
+    except Exception:
+        logger.error("Wing distribution query failed", exc_info=True)
+        stats["wings"] = []
 
     return jsonify(stats)

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -6,6 +6,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <title>Genesis Dashboard</title>
   <link rel="icon" type="image/svg+xml" href="/public/favicon.svg">
+  <link rel="manifest" href="/manifest.json">
+  <meta name="theme-color" content="#0f1117">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <link rel="stylesheet" href="/index.css">
   <link rel="stylesheet" href="/css/modals.css">
   <link rel="stylesheet" href="/css/buttons.css">
@@ -7604,6 +7608,49 @@
           </template>
         </div>
 
+        <!-- Memory Growth Sparkline -->
+        <template x-if="$store.genesisDashboard.memoryStats.daily_growth && $store.genesisDashboard.memoryStats.daily_growth.length > 1">
+          <div class="card" style="margin-bottom:1rem; padding:0.75rem;">
+            <div style="font-size:0.75rem; color:var(--color-text-secondary); margin-bottom:0.5rem;">Memory Growth (30 days)</div>
+            <svg width="100%" height="48" viewBox="0 0 600 48" preserveAspectRatio="none" style="display:block;" x-data="{
+              get points() {
+                const data = $store.genesisDashboard.memoryStats.daily_growth;
+                if (!data || data.length < 2) return '';
+                const max = Math.max(...data.map(d => d.count));
+                const min = Math.min(...data.map(d => d.count));
+                const range = max - min || 1;
+                const w = 600;
+                const h = 44;
+                return data.map((d, i) => {
+                  const x = (i / (data.length - 1)) * w;
+                  const y = h - ((d.count - min) / range) * (h - 4) - 2;
+                  return `${x},${y}`;
+                }).join(' ');
+              }
+            }">
+              <polyline :points="points" fill="none" stroke="var(--color-accent, #60a5fa)" stroke-width="2" vector-effect="non-scaling-stroke" />
+            </svg>
+            <div style="display:flex; justify-content:space-between; font-size:0.65rem; color:var(--color-text-secondary);">
+              <span x-text="$store.genesisDashboard.memoryStats.daily_growth[0]?.day || ''"></span>
+              <span x-text="'Total: +' + $store.genesisDashboard.memoryStats.daily_growth.reduce((s,d) => s + d.count, 0) + ' memories'"></span>
+              <span x-text="$store.genesisDashboard.memoryStats.daily_growth[$store.genesisDashboard.memoryStats.daily_growth.length - 1]?.day || ''"></span>
+            </div>
+          </div>
+        </template>
+
+        <!-- Wing Distribution -->
+        <template x-if="$store.genesisDashboard.memoryStats.wings && $store.genesisDashboard.memoryStats.wings.length > 0">
+          <div class="card" style="margin-bottom:1rem; padding:0.75rem;">
+            <div style="font-size:0.75rem; color:var(--color-text-secondary); margin-bottom:0.5rem;">Memory by Wing</div>
+            <div style="display:flex; flex-wrap:wrap; gap:0.4rem;">
+              <template x-for="w in $store.genesisDashboard.memoryStats.wings" :key="w.wing">
+                <span class="badge" style="font-size:0.7rem; padding:0.2rem 0.5rem;"
+                      x-text="w.wing + ': ' + w.count.toLocaleString()"></span>
+              </template>
+            </div>
+          </div>
+        </template>
+
         <!-- Search -->
         <div style="display:flex; gap:0.5rem; margin-bottom:1rem;">
           <input type="text" x-model="$store.genesisDashboard.memorySearch.query"
@@ -8224,6 +8271,10 @@
       to { transform: rotate(360deg); }
     }
   </style>
+
+  <script>
+  if ('serviceWorker' in navigator) { navigator.serviceWorker.register('/sw.js').catch(() => {}); }
+  </script>
 
 </body>
 

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -8273,7 +8273,7 @@
   </style>
 
   <script>
-  if ('serviceWorker' in navigator) { navigator.serviceWorker.register('/sw.js').catch(() => {}); }
+  if ('serviceWorker' in navigator) { navigator.serviceWorker.register('/sw.js').catch(e => console.warn('SW:', e)); }
   </script>
 
 </body>

--- a/src/genesis/dashboard/webui/manifest.json
+++ b/src/genesis/dashboard/webui/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "Genesis",
+  "short_name": "Genesis",
+  "description": "Genesis Neural Monitor",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f1117",
+  "theme_color": "#0f1117",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "any",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/src/genesis/dashboard/webui/manifest.json
+++ b/src/genesis/dashboard/webui/manifest.json
@@ -2,15 +2,16 @@
   "name": "Genesis",
   "short_name": "Genesis",
   "description": "Genesis Neural Monitor",
-  "start_url": "/",
+  "start_url": "/genesis",
+  "scope": "/",
   "display": "standalone",
   "background_color": "#0f1117",
   "theme_color": "#0f1117",
   "icons": [
     {
-      "src": "/favicon.ico",
+      "src": "/public/favicon.svg",
       "sizes": "any",
-      "type": "image/x-icon"
+      "type": "image/svg+xml"
     }
   ]
 }

--- a/src/genesis/dashboard/webui/sw.js
+++ b/src/genesis/dashboard/webui/sw.js
@@ -1,6 +1,6 @@
 // Genesis PWA Service Worker — minimal shell cache
 const CACHE = 'genesis-shell-v1';
-const SHELL = ['/', '/vendor/alpine/alpine.min.js', '/js/initFw.js', '/js/api.js', '/index.css'];
+const SHELL = ['/genesis', '/vendor/alpine/alpine.min.js', '/js/initFw.js', '/js/api.js', '/index.css'];
 
 self.addEventListener('install', e => {
   e.waitUntil(caches.open(CACHE).then(c => c.addAll(SHELL)).then(() => self.skipWaiting()));

--- a/src/genesis/dashboard/webui/sw.js
+++ b/src/genesis/dashboard/webui/sw.js
@@ -1,0 +1,16 @@
+// Genesis PWA Service Worker — minimal shell cache
+const CACHE = 'genesis-shell-v1';
+const SHELL = ['/', '/vendor/alpine/alpine.min.js', '/js/initFw.js', '/js/api.js', '/index.css'];
+
+self.addEventListener('install', e => {
+  e.waitUntil(caches.open(CACHE).then(c => c.addAll(SHELL)).then(() => self.skipWaiting()));
+});
+
+self.addEventListener('activate', e => {
+  e.waitUntil(caches.keys().then(ks => Promise.all(ks.filter(k => k !== CACHE).map(k => caches.delete(k)))).then(() => self.clients.claim()));
+});
+
+self.addEventListener('fetch', e => {
+  if (e.request.method !== 'GET') return;
+  e.respondWith(fetch(e.request).catch(() => caches.match(e.request)));
+});


### PR DESCRIPTION
## Summary
- **Memory tab**: adds 30-day growth sparkline (SVG, zero dependencies) and wing distribution badges to the Memory tab stats section
- **PWA**: manifest.json + service worker + meta tags — dashboard is now installable as a standalone mobile app
- **API**: `/api/genesis/memory/stats` extended with `daily_growth` and `wings` data

## Context
Evaluation of external AI tools (Karpathy's Knowledge OS, Hermes GUIs) identified that Genesis's memory system is architecturally ahead but lacks visibility — users can't *see* their knowledge compounding. This closes that gap with a growth trajectory chart and wing breakdown. PWA mode was identified as a low-effort, high-value accessibility improvement for mobile dashboard access.

## Test plan
- [ ] Navigate to dashboard Memory tab — verify sparkline renders with 30-day data
- [ ] Verify wing distribution badges show correct counts
- [ ] Check `/api/genesis/memory/stats` returns `daily_growth` and `wings` arrays
- [ ] On mobile browser, verify "Add to Home Screen" prompt appears
- [ ] Installed PWA opens as standalone app with correct theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)