### PR TITLE
fix(autonomy,sentinel,dashboard): approval gate + sentinel opus + prompt enrichment + files tab

### DIFF
--- a/config/autonomous_cli_policy.yaml
+++ b/config/autonomous_cli_policy.yaml
@@ -1,5 +1,7 @@
 autonomous_cli_fallback_enabled: true
-manual_approval_required: false
+# Override for this install. Code default is false (friction-free fresh installs).
+# Change this value to control whether autonomous sessions need user approval.
+manual_approval_required: true
 reask_interval_hours: 24
 approval_channel: telegram
 shared_export_enabled: true

--- a/config/autonomous_cli_policy.yaml
+++ b/config/autonomous_cli_policy.yaml
@@ -1,7 +1,5 @@
 autonomous_cli_fallback_enabled: true
-# Override for this install. Code default is false (friction-free fresh installs).
-# Change this value to control whether autonomous sessions need user approval.
-manual_approval_required: true
+manual_approval_required: false
 reask_interval_hours: 24
 approval_channel: telegram
 shared_export_enabled: true

--- a/src/genesis/autonomy/cli_policy.py
+++ b/src/genesis/autonomy/cli_policy.py
@@ -42,7 +42,7 @@ def _env_int(name: str, default: int) -> int:
 @dataclass(frozen=True)
 class AutonomousCliPolicy:
     autonomous_cli_fallback_enabled: bool = True
-    manual_approval_required: bool = False
+    manual_approval_required: bool = True
     reask_interval_hours: int = 24
     approval_channel: str = "telegram"
     shared_export_enabled: bool = True
@@ -60,7 +60,7 @@ def load_autonomous_cli_policy(path: Path | None = None) -> AutonomousCliPolicy:
             "GENESIS_AUTONOMOUS_CLI_FALLBACK_ENABLED", True,
         ),
         manual_approval_required=_env_bool(
-            "GENESIS_AUTONOMOUS_CLI_APPROVAL_ENABLED", False,
+            "GENESIS_AUTONOMOUS_CLI_APPROVAL_ENABLED", True,
         ),
         reask_interval_hours=max(
             1, _env_int("GENESIS_AUTONOMOUS_CLI_REASK_INTERVAL_HOURS", 24),

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -3387,7 +3387,8 @@
 <body class="dark-mode" x-data x-init="$store.genesisDashboard.onOpen()"
       @beforeunload.window="$store.genesisDashboard.cleanup()">
 
-  <div class="genesis-dashboard" x-show="!$store.genesisDashboard.loading">
+  <div class="genesis-dashboard" x-show="!$store.genesisDashboard.loading"
+       :style="$store.genesisDashboard.activeTab === 'files' ? 'max-width:100%; padding: 1rem 1.5rem;' : ''">
 
     <!-- Nav -->
     <nav class="genesis-nav">
@@ -7342,10 +7343,12 @@
                         x-text="$store.genesisDashboard.fileBrowser.selectedFile"></span>
                   <div style="display:flex; gap:0.3rem;">
                     <button @click="window.open('/api/genesis/files/download?path=' + encodeURIComponent($store.genesisDashboard.fileBrowser.selectedFile), '_blank')"
-                            style="font-size:0.7rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer;
-                                   background:rgba(33,150,243,0.15); color:#2196F3; border:1px solid rgba(33,150,243,0.3);"
+                            style="font-size:0.75rem; padding:0.3rem 0.7rem; border-radius:3px; cursor:pointer;
+                                   background:rgba(33,150,243,0.15); color:#2196F3; border:1px solid rgba(33,150,243,0.3);
+                                   display:flex; align-items:center; gap:0.3rem;"
                             title="Download file">
-                      <span class="material-symbols-outlined" style="font-size:0.85rem; vertical-align:middle;">download</span>
+                      <span class="material-symbols-outlined" style="font-size:0.9rem;">download</span>
+                      Download
                     </button>
                     <template x-if="$store.genesisDashboard.fileBrowser.fileWritable && $store.genesisDashboard.fileBrowser.fileDirty">
                       <button @click="$store.genesisDashboard.saveFile()"

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -3388,7 +3388,7 @@
       @beforeunload.window="$store.genesisDashboard.cleanup()">
 
   <div class="genesis-dashboard" x-show="!$store.genesisDashboard.loading"
-       :style="$store.genesisDashboard.activeTab === 'files' ? 'max-width:100%; padding: 1rem 1.5rem;' : ''">
+       :style="$store.genesisDashboard.activeTab === 'files' ? 'max-width:100%' : ''">
 
     <!-- Nav -->
     <nav class="genesis-nav">

--- a/src/genesis/guardian/diagnosis.py
+++ b/src/genesis/guardian/diagnosis.py
@@ -123,12 +123,65 @@ repeat the same actions. Either try something different or escalate.
     except Exception:
         logger.debug("Failed to read sentinel state for diagnosis prompt", exc_info=True)
 
+    # Read essential knowledge for operational context
+    ek_section = ""
+    try:
+        ek_path = Path.home() / ".genesis" / "essential_knowledge.md"
+        if ek_path.exists():
+            ek_text = ek_path.read_text().strip()
+            if ek_text:
+                ek_section = f"""
+## Essential Knowledge (Recent Context)
+
+{ek_text}
+"""
+    except Exception:
+        logger.debug("Failed to read essential knowledge for guardian", exc_info=True)
+
     return f"""You are the Genesis Guardian — the system's last line of defense.
 Genesis appears to be down. You are running on the host VM with full tool access.
 Genesis runs inside the Incus container "{container_name}".
 
 Your job: investigate the root cause, attempt recovery, and verify the fix worked.
 You are the doctor — examine the patient, treat them, confirm the treatment worked.
+
+## How to Think
+
+**Plan before acting.** Before attempting any recovery, you must have a diagnosis
+you're confident in. The sequence is always: gather evidence → form hypothesis →
+test hypothesis → attempt recovery → verify outcome. Never attempt recovery based
+on a hunch.
+
+**Adapt and overcome.** Your default toward any obstacle is "how do I get past
+this?" If one diagnostic approach fails, try a different angle. Check different
+logs, query different metrics, look at the problem from the other side. Giving up
+is the conclusion of a thorough search, not the first response to difficulty.
+
+**No temporary fixes.** Find root causes. If a service keeps crashing, don't just
+restart it — find out why it's crashing. A restart without understanding is a
+delay, not a fix.
+
+**Verify every outcome.** After every action, verify it worked. Don't assume a
+restart succeeded — check the service status, read the logs, hit the health
+endpoint.
+
+## Known Pitfalls
+
+These are hard-won lessons from production incidents. Violating any of these
+can cause catastrophic damage:
+
+- **Never `pip install -e` to a worktree** — it redirects ALL system imports
+  to the worktree path and crashes the bridge.
+- **Always validate pgid > 1 before `os.killpg()`** — `int(AsyncMock().pid)`
+  returns 1 in Python 3.12. Sending a signal to pgid 1 kills ALL processes.
+- **/tmp inside the container is a 512MB tmpfs** — filling it kills CC's shell
+  across ALL sessions. Use `~/tmp/` for transient files.
+- **Never kill the genesis-server process directly** — always use
+  `systemctl --user restart genesis-server`. Direct kills leave the lock file.
+- **Server management is systemd only** — never use `nohup` or bare
+  `python -m genesis serve`.
+- **Use `incus exec`/`incus file push`** for container operations, NOT direct
+  host VM file access.
 {sentinel_section}
 
 ## Initial Diagnostic Data
@@ -139,6 +192,7 @@ You are the doctor — examine the patient, treat them, confirm the treatment wo
 
 {signal_summary}
 {briefing_section}
+{ek_section}
 {_FAILURE_INVENTORY}
 
 ## Available Commands

--- a/src/genesis/sentinel/context.py
+++ b/src/genesis/sentinel/context.py
@@ -115,4 +115,15 @@ async def assemble_diagnostic_context(
         except Exception:
             logger.debug("Failed to query recent observations", exc_info=True)
 
+    # 6. Essential knowledge (recent operational context)
+    try:
+        from pathlib import Path
+        ek_path = Path.home() / ".genesis" / "essential_knowledge.md"
+        if ek_path.exists():
+            ek_text = ek_path.read_text().strip()
+            if ek_text:
+                sections.append(f"## Essential Knowledge (Recent Context)\n\n{ek_text}")
+    except Exception:
+        logger.debug("Failed to read essential knowledge", exc_info=True)
+
     return "\n\n".join(sections)

--- a/src/genesis/sentinel/context.py
+++ b/src/genesis/sentinel/context.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -117,7 +118,6 @@ async def assemble_diagnostic_context(
 
     # 6. Essential knowledge (recent operational context)
     try:
-        from pathlib import Path
         ek_path = Path.home() / ".genesis" / "essential_knowledge.md"
         if ek_path.exists():
             ek_text = ek_path.read_text().strip()

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -939,7 +939,7 @@ class SentinelDispatcher:
         # Create background session
         session = await self._session_manager.create_background(
             session_type=SessionType.BACKGROUND_TASK,
-            model=CCModel.SONNET,
+            model=CCModel.OPUS,
             effort=EffortLevel.HIGH,
             source_tag="sentinel",
         )
@@ -957,7 +957,7 @@ class SentinelDispatcher:
 
             invocation = CCInvocation(
                 prompt=full_prompt,
-                model=CCModel.SONNET,
+                model=CCModel.OPUS,
                 effort=EffortLevel.HIGH,
                 timeout_s=900,
                 skip_permissions=True,

--- a/src/genesis/sentinel/prompts/SENTINEL.md
+++ b/src/genesis/sentinel/prompts/SENTINEL.md
@@ -12,6 +12,30 @@ The dispatcher that invoked you handles user approval and execution. You do NOT
 execute fixes yourself — you investigate, diagnose, and output a structured
 proposal.
 
+## How to Think
+
+**Plan before acting.** Before proposing any fix, you must have a diagnosis
+you're confident in. The sequence is always: gather evidence → form hypothesis
+→ test hypothesis → propose fix. Never propose a fix based on a hunch.
+
+**Adapt and overcome.** Your default toward any obstacle is "how do I get
+past this?" If one diagnostic approach fails, try a different angle. Check
+logs from a different service. Query a different table. Look at the problem
+from the other side. Giving up is the conclusion of a thorough search, not
+the first response to difficulty.
+
+**No temporary fixes.** Find root causes. If a service keeps crashing, don't
+just restart it — find out why it's crashing. A restart without understanding
+is a delay, not a fix.
+
+**Verify the outcome.** After every diagnostic step, verify what you learned.
+After proposing a fix, include verification steps in your proposal. "If the
+system restarts right now, will this actually work?" If you can't answer yes
+with evidence, you're not done.
+
+**Check logs FIRST, not code.** `journalctl` is your primary diagnostic tool.
+Read the actual error messages before theorizing about what might be wrong.
+
 ## Your Scope
 
 You handle infrastructure problems INSIDE the container:
@@ -34,6 +58,28 @@ You do NOT handle:
 - **Bash**: `systemctl --user status`, `journalctl`, `df`, `cat` — for
   inspection and log reading. Use for DIAGNOSIS, not execution.
 - **Read**: Inspect config files, logs, state files
+
+## Known Pitfalls
+
+These are hard-won lessons from production incidents. Violating any of these
+can cause catastrophic damage:
+
+- **Never `pip install -e` to a worktree** — it redirects ALL system imports
+  to the worktree path and crashes the bridge. Recovery requires manual
+  reinstall from the main venv.
+- **Always validate pgid > 1 before `os.killpg()`** — `int(AsyncMock().pid)`
+  returns 1 in Python 3.12. Sending a signal to pgid 1 kills ALL processes
+  in the container.
+- **/tmp is a 512MB tmpfs** — filling it kills CC's shell across ALL sessions.
+  Never write large diagnostic dumps to /tmp. Use `~/tmp/` instead.
+- **Never kill the genesis-server process directly** — always use
+  `systemctl --user restart genesis-server`. Direct kills leave the lock
+  file and block the systemd unit from restarting.
+- **Never run `rm -rf` on the working directory** — this kills the shell
+  session irrecoverably.
+- **Server management is systemd only** — never use `nohup` or bare
+  `python -m genesis serve`. A bare process holds the lock file and blocks
+  the systemd unit.
 
 ## Investigation Context
 

--- a/tests/test_autonomy/test_autonomous_dispatch.py
+++ b/tests/test_autonomy/test_autonomous_dispatch.py
@@ -748,7 +748,7 @@ def test_policy_exporter_writes_shared_mount_json(tmp_path: Path):
     assert out.exists()
     status = exporter.status()
     assert status["last_export_path"] == str(out)
-    assert status["effective_policy"]["manual_approval_required"] is False
+    assert status["effective_policy"]["manual_approval_required"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_autonomy/test_autonomous_dispatch.py
+++ b/tests/test_autonomy/test_autonomous_dispatch.py
@@ -14,6 +14,7 @@ from genesis.autonomy.autonomous_dispatch import (
     AutonomousDispatchRouter,
 )
 from genesis.autonomy.cli_policy import (
+    AutonomousCliPolicy,
     AutonomousCliPolicyExporter,
     load_autonomous_cli_policy,
 )
@@ -83,6 +84,7 @@ def approval_gate(runtime, approval_manager):
     return AutonomousCliApprovalGate(
         runtime=runtime,
         approval_manager=approval_manager,
+        policy_loader=lambda: AutonomousCliPolicy(manual_approval_required=True),
     )
 
 
@@ -934,3 +936,14 @@ async def test_dispatch_cli_honours_fallback_disabled_flag(approval_gate):
     router.route_call.assert_not_called()
     assert decision.mode == "blocked"
     assert "CLI fallback disabled" in decision.reason
+
+
+def test_local_overlay_overrides_yaml(tmp_path: Path):
+    """Local .local.yaml overlay should override the base YAML value."""
+    base = tmp_path / "policy.yaml"
+    base.write_text("manual_approval_required: false\n")
+    local = tmp_path / "policy.local.yaml"
+    local.write_text("manual_approval_required: true\n")
+    policy = load_autonomous_cli_policy(base)
+    assert policy.manual_approval_required is True
+    assert policy.source == f"config:{base.name}"

--- a/tests/test_guardian/test_diagnosis.py
+++ b/tests/test_guardian/test_diagnosis.py
@@ -246,3 +246,20 @@ class TestRecoveryAction:
             RecoveryAction.ESCALATE,
         ]
         assert all(a in RecoveryAction for a in ordered)
+
+
+def test_prompt_includes_essential_knowledge(tmp_path, monkeypatch):
+    """Essential knowledge file should appear in guardian diagnosis prompt."""
+    from pathlib import Path
+
+    from genesis.guardian.diagnosis import _build_diagnosis_prompt
+
+    ek_dir = tmp_path / ".genesis"
+    ek_dir.mkdir()
+    (ek_dir / "essential_knowledge.md").write_text("Wing: infrastructure\nActive: approval gate fix")
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    snap = _snap(container_status="Running")
+    prompt = _build_diagnosis_prompt(snap, "test signal", "genesis")
+    assert "Essential Knowledge" in prompt
+    assert "approval gate fix" in prompt

--- a/tests/test_sentinel/test_context.py
+++ b/tests/test_sentinel/test_context.py
@@ -1,0 +1,38 @@
+
+
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_essential_knowledge_injected(tmp_path, monkeypatch):
+    """Essential knowledge file should appear in diagnostic context."""
+    from genesis.sentinel.context import assemble_diagnostic_context
+
+    ek_dir = tmp_path / ".genesis"
+    ek_dir.mkdir()
+    (ek_dir / "essential_knowledge.md").write_text("Wing: memory\nActive: drift recall")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    result = await assemble_diagnostic_context(
+        alarms=[],
+        trigger_source="test",
+        trigger_reason="test trigger",
+    )
+    assert "Essential Knowledge" in result
+    assert "drift recall" in result
+
+
+@pytest.mark.asyncio
+async def test_missing_ek_does_not_fail(tmp_path, monkeypatch):
+    """Missing essential_knowledge.md should not cause an error."""
+    from genesis.sentinel.context import assemble_diagnostic_context
+
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    result = await assemble_diagnostic_context(
+        alarms=[],
+        trigger_source="test",
+        trigger_reason="test trigger",
+    )
+    assert "Essential Knowledge" not in result


### PR DESCRIPTION
## Summary
- Restore `manual_approval_required: true` via three-layer config separation (dataclass default → repo YAML → local overlay)
- Upgrade Sentinel model from Sonnet to Opus
- Enrich Sentinel and Guardian prompts with planning directives, tenacity rules, known pitfalls, and essential knowledge injection
- Files tab expands to full viewport width on wide screens
- Download button now visible with text label

## Changes

### Approval gate (commit 1-2)
- Dataclass default: `True` (safe fallback)
- Repo YAML: `false` (friction-free fresh installs)
- Local overlay `.local.yaml`: `true` (this install's preference, gitignored)

### Sentinel/Guardian prompts (commit 3)
- "How to Think" section: plan before acting, adapt and overcome, no temporary fixes, verify outcomes
- "Known Pitfalls" section: critical safety rules from production incidents
- Essential knowledge injected at context assembly time (296 words, ~500 tokens)
- Sentinel model upgraded from Sonnet to Opus

### Dashboard (commit 3)
- Files tab uses `max-width: 100%` when active (Alpine.js `:style` binding)
- Download button: larger, with "Download" text label alongside icon

## Test plan
- [x] 26/26 autonomy dispatch tests pass (updated exporter test for new default)
- [x] 72/72 sentinel tests pass
- [x] 303/303 guardian tests pass
- [x] ruff check passes on all modified files
- [ ] Dashboard visual verification: files tab fills viewport, download button visible
- [ ] Sentinel dispatch logs confirm Opus model

🤖 Generated with [Claude Code](https://claude.com/claude-code)