### PR TITLE
fix(dashboard): allow horizontal textarea resize in files tab

### DIFF
--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -7365,7 +7365,7 @@
                           style="width:100%; height:calc(100vh - 320px); min-height:300px; font-family:monospace;
                                  font-size:0.75rem; line-height:1.5; background:rgba(0,0,0,0.3); color:var(--color-text);
                                  border:1px solid var(--color-border); border-radius:4px; padding:0.5rem;
-                                 resize:vertical; tab-size:4;"></textarea>
+                                 resize:both; tab-size:4;"></textarea>
               </div>
             </template>
             <template x-if="!$store.genesisDashboard.fileBrowser.selectedFile">


### PR DESCRIPTION
## Summary
- Change `resize:vertical` to `resize:both` on the file content textarea in the Files tab
- Users can now drag the bottom-right grip to resize both horizontally and vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)