### PR TITLE
fix(ego,perception): observation dedup + ego domain boundaries + CC watcher + ubuntu portability

### DIFF
--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -49,6 +49,7 @@ fi
 
 # ── Defaults ─────────────────────────────────────────────────
 CONTAINER_NAME="genesis"
+CONTAINER_IMAGE="${GENESIS_CONTAINER_IMAGE:-images:ubuntu/noble}"
 RAM="24GiB"
 DISK="30GB"
 CPUS="8"
@@ -487,9 +488,10 @@ if ! incus info "$CONTAINER_NAME" &>/dev/null; then
         echo "  + Guardian state reset (stale from previous container)"
     fi
 
-    echo "  Creating container '$CONTAINER_NAME'..."
-    # images:ubuntu/noble — the images: remote is always available after incus admin init
-    incus launch images:ubuntu/noble "$CONTAINER_NAME"
+    echo "  Creating container '$CONTAINER_NAME' from $CONTAINER_IMAGE..."
+    # Override with GENESIS_CONTAINER_IMAGE env var for non-Ubuntu distros.
+    # Default: images:ubuntu/noble (the images: remote is always available).
+    incus launch "$CONTAINER_IMAGE" "$CONTAINER_NAME"
     echo "  + Container created"
 
     # Apply resource limits
@@ -664,7 +666,7 @@ incus exec "$CONTAINER_NAME" -- bash -c '
         git curl sudo \
         python3 python3-pip \
         nodejs npm || { echo "  FATAL: package install failed"; exit 1; }
-    # Install venv — try version-specific first (noble = 3.12), then generic
+    # Install venv — try version-specific first, then generic fallback
     apt-get install -y -q python3.12-venv 2>/dev/null || \
         apt-get install -y -q python3-venv || \
         { echo "  FATAL: could not install python3-venv"; exit 1; }

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -540,19 +540,8 @@ class UserEgoContextBuilder:
             "issues if they directly impact the user.\n"
         )
 
-        # Cost status (brief)
-        try:
-            today = datetime.now(UTC).strftime("%Y-%m-%d")
-            cursor = await self._db.execute(
-                "SELECT COALESCE(SUM(cost_usd), 0.0) FROM cost_events "
-                "WHERE created_at >= ?",
-                (today,),
-            )
-            row = await cursor.fetchone()
-            daily_spend = row[0] if row else 0.0
-            lines.append(f"**Today's spend**: ${daily_spend:.2f}")
-        except Exception:
-            pass
+        # Cost tracking is NOT the user ego's domain — it belongs to the
+        # Genesis ego (infrastructure) or the dashboard.  Removed per audit.
 
         lines.append("")
         return "\n".join(lines)

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -541,7 +541,8 @@ class UserEgoContextBuilder:
         )
 
         # Cost tracking is NOT the user ego's domain — it belongs to the
-        # Genesis ego (infrastructure) or the dashboard.  Removed per audit.
+        # Genesis ego (see genesis_context.py) or the dashboard.  Removed
+        # per audit: user ego was creating cost-focused follow-ups.
 
         lines.append("")
         return "\n".join(lines)

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -107,6 +107,19 @@ Add an escalation when:
 - Something requires a decision only the user can make
 - A cost threshold might be exceeded
 
+## Domain Boundaries
+
+- **Do NOT opine on config values.** Approval gates, cadence intervals,
+  budget caps, model choices — these are user decisions. You proceed
+  however you're authorized. If a config value is causing operational
+  problems, state the problem factually in an escalation. Never argue
+  for or against a specific setting.
+
+- **Do NOT position Genesis capabilities as solutions to user goals.**
+  When you see user career goals or personal interests in escalations,
+  escalate the operational issue only. The user ego decides what matters
+  to the user. You fix what's broken.
+
 ## Persistent Memory
 
 Store findings via memory_store:

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -205,6 +205,28 @@ Write in Genesis's conversational tone. Direct, no filler, no performed
 enthusiasm. Cite memory naturally ("the freelance goal from March") not
 mechanically. When uncertain, say so plainly. See VOICE.md for full reference.
 
+## Domain Boundaries
+
+These are hard limits on what you think about:
+
+- **Do NOT track operational costs.** Daily spend, budget utilization,
+  and cost optimization are the Genesis ego's domain. If a proposal has
+  a cost implication (e.g., "this dispatch would cost ~$0.50"), state it
+  factually in the execution_plan — but never propose actions motivated
+  by "keeping costs down." Cost management is not your job.
+
+- **Do NOT opine on config values.** Approval gates, budget caps,
+  cadence intervals, effort levels, model choices — these are user
+  decisions. You proceed however you're authorized. If you believe a
+  config value is causing problems, state the problem factually and let
+  the user decide the fix. Never argue for or against a specific setting.
+
+- **User goals and Genesis goals are independent.** The user's career
+  targets, job search, and professional positioning are separate from
+  Genesis's own marketing and distribution goals. Do not conflate them.
+  Do not position Genesis capabilities as solutions to the user's
+  personal career goals.
+
 ## Constraints
 
 You are in **proposal mode**. ALL actions require user approval via

--- a/src/genesis/learning/signals/__init__.py
+++ b/src/genesis/learning/signals/__init__.py
@@ -8,7 +8,6 @@ implementations exported here.
 
 from genesis.learning.signals.autonomy_activity import AutonomyActivityCollector
 from genesis.learning.signals.budget import BudgetCollector
-from genesis.learning.signals.cc_version import CCVersionCollector
 from genesis.learning.signals.conversation import ConversationCollector
 from genesis.learning.signals.critical_failure import CriticalFailureCollector
 from genesis.learning.signals.error_spike import ErrorSpikeCollector
@@ -22,7 +21,6 @@ from genesis.learning.signals.task_quality import TaskQualityCollector
 __all__ = [
     "AutonomyActivityCollector",
     "BudgetCollector",
-    "CCVersionCollector",
     "ConversationCollector",
     "CriticalFailureCollector",
     "ErrorSpikeCollector",

--- a/src/genesis/learning/signals/user_goal_staleness.py
+++ b/src/genesis/learning/signals/user_goal_staleness.py
@@ -57,9 +57,10 @@ class UserGoalStalenessCollector:
             source="follow_ups+user_model",
             collected_at=now.isoformat(),
             baseline_note=(
-                "0.0=all user goals fresh or none tracked. "
-                "0.5=goals aging 7+ days without engagement. "
-                "1.0=14+ days stale."
+                "0.0=fresh or none tracked. 0.5=7+ days stale. "
+                "1.0=14+ days stale (EXPECTED when old follow-ups "
+                "exist — not a system anomaly, not noteworthy unless "
+                "it changed sharply from a prior tick)."
             ),
         )
 

--- a/src/genesis/perception/writer.py
+++ b/src/genesis/perception/writer.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import re
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
@@ -76,17 +75,6 @@ class ResultWriter:
         if has_user:
             return "user"
         return "genesis"
-
-    @staticmethod
-    def _normalize_for_dedup(summary: str) -> str:
-        """Strip numbers and normalize whitespace for fuzzy micro dedup.
-
-        "memory at 78% is fine" and "memory at 79% is fine" → same string.
-        """
-        text = summary.lower()
-        text = re.sub(r"-?\d+\.?\d*%?", "N", text)
-        text = re.sub(r"\s+", " ", text).strip()
-        return text
 
     async def write(
         self,

--- a/src/genesis/perception/writer.py
+++ b/src/genesis/perception/writer.py
@@ -145,12 +145,13 @@ class ResultWriter:
         relevance = self._relevance_from_signals(tick)
         category = f"{base_category}:{relevance}"
 
-        # Normalized hash: strips numeric variation from the summary so
-        # "memory at 78% is fine" and "memory at 79% is fine" dedup correctly.
-        # Signal names + anomaly flag are included to preserve structural uniqueness.
-        norm_summary = self._normalize_for_dedup(output.summary)
+        # Structural dedup: hash on tags + salience band + anomaly flag +
+        # signal names.  LLM-generated summaries vary too much per tick to
+        # be useful as dedup keys — even after number normalization, the
+        # sentence structure changes and the hash never collides.
         signal_names = ",".join(sorted(s.name for s in tick.signals))
-        norm_key = f"micro:{norm_summary}|{signal_names}|{output.anomaly}"
+        salience_band = round(output.salience, 1)
+        norm_key = f"micro:{','.join(sorted(output.tags))}|{salience_band}|{output.anomaly}|{signal_names}"
         chash = self._content_hash(norm_key)
 
         if await observations.exists_by_hash(db, source="reflection", content_hash=chash, unresolved_only=True):

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -84,7 +84,6 @@ async def init(rt: GenesisRuntime) -> None:
                 probe_ollama,
             ]
 
-            from genesis.learning.signals.cc_version import CCVersionCollector
             from genesis.learning.signals.genesis_version import GenesisVersionCollector
 
             collectors = [
@@ -104,11 +103,6 @@ async def init(rt: GenesisRuntime) -> None:
                 GuardianActivityCollector(),
                 SurplusActivityCollector(rt._db),
                 AutonomyActivityCollector(rt._db),
-                CCVersionCollector(
-                    rt._db, router=rt._router,
-                    pipeline_getter=lambda: rt._outreach_pipeline,
-                    memory_store_getter=lambda: rt._memory_store,
-                ),
                 GenesisVersionCollector(
                     rt._db,
                     pipeline_getter=lambda: rt._outreach_pipeline,

--- a/tests/test_perception/test_writer.py
+++ b/tests/test_perception/test_writer.py
@@ -531,3 +531,59 @@ async def test_micro_cooldown_allows_anomaly(db):
     assert stored, "Anomaly should bypass cooldown"
     rows = await observations.query(db, source="reflection", type="micro_reflection")
     assert len(rows) == 2  # both the prior and the anomaly
+
+
+async def test_write_micro_dedup_same_structure(db):
+    """Two micro outputs with same tags/anomaly/signals but different summaries should dedup."""
+    from genesis.db.crud import observations
+    from genesis.perception.writer import ResultWriter
+
+    writer = ResultWriter()
+    output1 = MicroOutput(
+        tags=["anomaly_detected", "staleness"],
+        salience=0.7,
+        anomaly=True,
+        summary="Significant anomaly in user_goal_staleness signal at 1.0",
+        signals_examined=21,
+    )
+    output2 = MicroOutput(
+        tags=["anomaly_detected", "staleness"],
+        salience=0.7,
+        anomaly=True,
+        summary="The combination of signals indicates user_goal_staleness anomaly",
+        signals_examined=22,
+    )
+    tick = _make_tick()
+    await writer.write(output1, Depth.MICRO, tick, db=db)
+    await writer.write(output2, Depth.MICRO, tick, db=db)
+
+    obs = await observations.query(db, source="reflection")
+    assert len(obs) == 1, f"Expected 1 observation (dedup), got {len(obs)}"
+
+
+async def test_write_micro_different_structure_not_deduped(db):
+    """Micro outputs with different tags should NOT dedup."""
+    from genesis.db.crud import observations
+    from genesis.perception.writer import ResultWriter
+
+    writer = ResultWriter()
+    output1 = MicroOutput(
+        tags=["anomaly_detected"],
+        salience=0.7,
+        anomaly=True,
+        summary="CPU spike detected.",
+        signals_examined=5,
+    )
+    output2 = MicroOutput(
+        tags=["idle", "resource_normal"],
+        salience=0.6,
+        anomaly=False,
+        summary="All systems normal.",
+        signals_examined=5,
+    )
+    tick = _make_tick()
+    await writer.write(output1, Depth.MICRO, tick, db=db)
+    await writer.write(output2, Depth.MICRO, tick, db=db)
+
+    obs = await observations.query(db, source="reflection")
+    assert len(obs) == 2, f"Expected 2 observations (different structure), got {len(obs)}"

--- a/tests/test_perception/test_writer.py
+++ b/tests/test_perception/test_writer.py
@@ -422,30 +422,11 @@ async def test_micro_boundary_salience_stored(db):
     assert len(rows) == 1
 
 
-# ── Normalized dedup tests ───────────────────────────────────────────────
+# ── Structural dedup tests ────────────────────────────────────────────────
 
 
-def test_normalize_for_dedup_strips_numbers():
-    """Numeric variation should be collapsed."""
-    from genesis.perception.writer import ResultWriter
-
-    n = ResultWriter._normalize_for_dedup
-    assert n("memory at 78% is fine") == n("memory at 79% is fine")
-    assert n("CPU 0.45 stable") == n("CPU 0.83 stable")
-    assert n("3 of 5 signals healthy") == n("2 of 5 signals healthy")
-
-
-def test_normalize_for_dedup_preserves_structure():
-    """Structurally different summaries should NOT collapse."""
-    from genesis.perception.writer import ResultWriter
-
-    n = ResultWriter._normalize_for_dedup
-    assert n("memory is fine") != n("cpu is fine")
-    assert n("all systems nominal") != n("anomaly detected in network")
-
-
-async def test_micro_normalized_dedup_catches_near_duplicate(db):
-    """Near-identical summaries differing only in numbers should dedup."""
+async def test_micro_structural_dedup_catches_near_duplicate(db):
+    """Same tags + salience band + anomaly should dedup regardless of summary text."""
     from genesis.db.crud import observations
     from genesis.perception.writer import ResultWriter
 


### PR DESCRIPTION
## Summary
- Fix micro-reflection observation spam: dedup hash now uses structural properties (tags, salience band, anomaly, signal names) instead of volatile LLM-generated summary text
- Add domain boundary rules to both ego prompts: no cost tracking by User Ego, no config opinions, career goals ≠ Genesis marketing
- Deactivate CCVersionCollector (noisy CC update signal)
- Remove cost query from User Ego context builder
- Add GENESIS_CONTAINER_IMAGE env var for distro-portable container setup
- Resolve 5 stale follow-ups (LinkedIn automation, ego gate, Docling, approval gate, Telegram health)

## Changes

### Observation dedup fix (highest impact)
The micro-reflection dedup hash included `norm_summary` (LLM-generated text) which varied each tick despite identical signals. 21+ duplicate `user_goal_staleness=1.0` observations accumulated. Fix: hash on `tags|salience_band|anomaly|signal_names` only. Also updated baseline_note to clarify 1.0 is expected, not anomalous.

### Ego domain boundaries
- USER_EGO_SESSION.md: added "Domain Boundaries" section — no cost tracking, no config opinions, career ≠ marketing
- GENESIS_EGO_SESSION.md: added "Domain Boundaries" section — no config opinions, don't position capabilities as user goal solutions
- Removed `cost_events` query from `user_context.py:_system_status_section()` — cost tracking stays in Genesis Ego (`genesis_context.py`)

### CC version checker
Removed `CCVersionCollector` from `runtime/init/learning.py` and `signals/__init__.py`. `GenesisVersionCollector` (upstream update detection) stays active.

### Ubuntu/noble portability
`scripts/host-setup.sh`: Added `CONTAINER_IMAGE` variable (default: `images:ubuntu/noble`, overridable via `GENESIS_CONTAINER_IMAGE` env var)

## Test plan
- [x] 24/24 perception writer tests pass (including 2 new dedup tests)
- [x] 328/328 combined perception + ego tests pass
- [x] ruff check passes on all modified files
- [x] Code review completed — dead code removed, export hygiene fixed
- [ ] Verify: next awareness tick produces no duplicate staleness observations
- [ ] Verify: User Ego context no longer includes daily spend

🤖 Generated with [Claude Code](https://claude.com/claude-code)