### PR TITLE
feat(channels): configurable default model and effort for Telegram

### DIFF
--- a/config/channels.yaml
+++ b/config/channels.yaml
@@ -1,0 +1,6 @@
+# Channel defaults — model and effort for new sessions by channel.
+# Override locally in channels.local.yaml (never edit this file).
+
+telegram:
+  default_model: sonnet
+  default_effort: medium

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -50,6 +50,8 @@ class ConversationLoop:
         session_manager: SessionManager | None = None,
         contingency: CCContingencyDispatcher | None = None,
         failure_detector: object | None = None,
+        default_model: CCModel = CCModel.SONNET,
+        default_effort: EffortLevel = EffortLevel.MEDIUM,
     ):
         self._db = db
         self._invoker = invoker
@@ -64,6 +66,8 @@ class ConversationLoop:
         self._context_injector = context_injector
         self._contingency = contingency
         self._failure_detector = failure_detector
+        self._default_model = default_model
+        self._default_effort = default_effort
         self._session_locks: dict[str, asyncio.Lock] = {}
 
     async def interrupt(self) -> None:
@@ -135,12 +139,12 @@ class ConversationLoop:
             await self._session_mgr.complete(session["id"])
             session = None
 
-        # Resolve model/effort: explicit override > session stored > default
+        # Resolve model/effort: explicit override > session stored > config default
         model = intent.model_override or (
-            CCModel(session["model"]) if session and session.get("model") else CCModel.SONNET
+            CCModel(session["model"]) if session and session.get("model") else self._default_model
         )
         effort = intent.effort_override or (
-            EffortLevel(session["effort"]) if session and session.get("effort") else EffortLevel.MEDIUM
+            EffortLevel(session["effort"]) if session and session.get("effort") else self._default_effort
         )
 
         # Get or create session, persist any model/effort changes
@@ -327,10 +331,10 @@ class ConversationLoop:
             session = None
 
         model = intent.model_override or (
-            CCModel(session["model"]) if session and session.get("model") else CCModel.SONNET
+            CCModel(session["model"]) if session and session.get("model") else self._default_model
         )
         effort = intent.effort_override or (
-            EffortLevel(session["effort"]) if session and session.get("effort") else EffortLevel.MEDIUM
+            EffortLevel(session["effort"]) if session and session.get("effort") else self._default_effort
         )
 
         session = await self._session_mgr.get_or_create_foreground(

--- a/src/genesis/channels/bridge.py
+++ b/src/genesis/channels/bridge.py
@@ -15,9 +15,13 @@ import os
 import signal
 import sys
 import time
+from pathlib import Path
+
+import yaml
 
 from genesis.cc.conversation import ConversationLoop
 from genesis.cc.system_prompt import SystemPromptAssembler
+from genesis.cc.types import CCModel, EffortLevel
 from genesis.env import secrets_path
 from genesis.runtime import GenesisRuntime
 
@@ -86,6 +90,35 @@ def _load_bridge_config() -> dict | None:
     }
 
 
+_CONFIG_DIR = Path(__file__).resolve().parents[3] / "config"
+
+
+def _load_channel_defaults() -> tuple[CCModel, EffortLevel]:
+    """Load default model/effort for Telegram from channels.yaml."""
+    model_map = {"opus": CCModel.OPUS, "sonnet": CCModel.SONNET, "haiku": CCModel.HAIKU}
+    effort_map = {
+        "low": EffortLevel.LOW, "medium": EffortLevel.MEDIUM,
+        "high": EffortLevel.HIGH, "max": EffortLevel.MAX,
+    }
+    data: dict = {}
+    for fname in ("channels.yaml", "channels.local.yaml"):
+        path = _CONFIG_DIR / fname
+        if path.is_file():
+            try:
+                with open(path) as f:
+                    loaded = yaml.safe_load(f) or {}
+                tg = loaded.get("telegram", {})
+                if isinstance(tg, dict):
+                    data.update(tg)
+            except Exception:
+                log.warning("Failed to read %s", path, exc_info=True)
+
+    model = model_map.get(data.get("default_model", ""), CCModel.SONNET)
+    effort = effort_map.get(data.get("default_effort", ""), EffortLevel.MEDIUM)
+    log.info("Channel defaults: model=%s, effort=%s", model.value, effort.value)
+    return model, effort
+
+
 async def _run_headless(runtime: GenesisRuntime) -> None:
     """Keep the bridge process alive without Telegram.
 
@@ -134,6 +167,8 @@ async def main():
     except Exception:
         log.warning("Failed to initialize failure detector", exc_info=True)
 
+    default_model, default_effort = _load_channel_defaults()
+
     conversation_loop = ConversationLoop(
         db=runtime.db,
         invoker=runtime.cc_invoker,
@@ -144,6 +179,8 @@ async def main():
         session_manager=runtime.session_manager,
         contingency=runtime.contingency_dispatcher,
         failure_detector=failure_detector,
+        default_model=default_model,
+        default_effort=default_effort,
     )
 
     # Resolve TTS provider (first available, if any)

--- a/src/genesis/dashboard/routes/settings.py
+++ b/src/genesis/dashboard/routes/settings.py
@@ -94,5 +94,5 @@ async def settings_update(domain_name: str):
 # Domains that get dedicated form UI on the dashboard
 _FORM_DOMAINS = frozenset({
     "tts", "ego", "inbox_monitor", "outreach", "autonomous_cli_policy",
-    "surplus", "resilience", "confidence_gates", "updates",
+    "surplus", "resilience", "confidence_gates", "updates", "channels",
 })

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1362,6 +1362,9 @@
           batch_size: 'Maximum files to process per scan cycle (1\u201310)',
           effort: 'Processing depth: low (fast), medium (balanced), or high (thorough)',
           timeout_s: 'Max seconds per inbox item processing before timeout',
+          // Channels
+          telegram: 'Telegram',
+          default_model: 'Default Model', default_effort: 'Default Effort',
           // Outreach
           start: 'Quiet hours start \u2014 no outreach before this time (e.g., 22:00)',
           end: 'Quiet hours end \u2014 outreach resumes after this time (e.g., 07:00)',
@@ -1407,6 +1410,9 @@
           auto_apply: 'Automatically apply safe updates without approval',
           allowed_impacts: 'Impact levels eligible for auto-apply',
           backup_before_update: 'Run backup before applying any update',
+          // Channels
+          default_model: 'Model for new Telegram sessions (opus = highest quality, haiku = fastest)',
+          default_effort: 'Effort level for new Telegram sessions (higher = more thorough)',
         },
         _SETTING_CHOICES: {
           provider: ['elevenlabs', 'fish_audio', 'cartesia'],
@@ -1418,10 +1424,12 @@
           alert: ['telegram', 'email', 'dashboard'],
           surplus: ['telegram', 'email', 'dashboard'],
           digest: ['telegram', 'email', 'dashboard'],
+          default_model: ['opus', 'sonnet', 'haiku'],
+          default_effort: ['low', 'medium', 'high', 'max'],
         },
         // Display order for settings domains — most important first
         _DOMAIN_ORDER: [
-          'autonomous_cli_policy', 'ego', 'outreach', 'tts',
+          'channels', 'autonomous_cli_policy', 'ego', 'outreach', 'tts',
           'inbox_monitor', 'surplus', 'resilience', 'confidence_gates',
           'updates', 'recon_schedules', 'recon_watchlist', 'recon_sources',
           'autonomy', 'autonomy_rules', 'guardian',
@@ -1439,6 +1447,7 @@
           guardian: 'Guardian', model_profiles: 'Model Profiles',
           model_routing: 'Model Routing',
           content_sanitization: 'Content Sanitization',
+          channels: 'Channels',
         },
         _sortedDomains(domains) {
           const order = this._DOMAIN_ORDER;

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -178,6 +178,13 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=True,
     ),
+    "channels": SettingsDomain(
+        name="channels",
+        description="Channel defaults (model and effort for new Telegram sessions)",
+        config_filename="channels.yaml",
+        readonly=False,
+        needs_restart=True,
+    ),
 }
 
 
@@ -507,6 +514,36 @@ def _validate_ego(changes: dict) -> list[str]:
     return validate_ego_config(changes)
 
 
+def _validate_channels(changes: dict) -> list[str]:
+    """Validate channel defaults config changes."""
+    errors: list[str] = []
+    valid_models = {"opus", "sonnet", "haiku"}
+    valid_efforts = {"low", "medium", "high", "max"}
+
+    tg = changes.get("telegram", {})
+    if not isinstance(tg, dict):
+        errors.append("telegram must be a mapping")
+        return errors
+
+    for key in tg:
+        if key not in ("default_model", "default_effort"):
+            errors.append(f"Unknown key 'telegram.{key}'. Valid: default_model, default_effort")
+
+    if "default_model" in tg and tg["default_model"] not in valid_models:
+        errors.append(
+            f"telegram.default_model must be one of {sorted(valid_models)}, "
+            f"got '{tg['default_model']}'"
+        )
+
+    if "default_effort" in tg and tg["default_effort"] not in valid_efforts:
+        errors.append(
+            f"telegram.default_effort must be one of {sorted(valid_efforts)}, "
+            f"got '{tg['default_effort']}'"
+        )
+
+    return errors
+
+
 _DOMAIN_VALIDATORS: dict[str, Any] = {
     "tts": _validate_tts,
     "resilience": _validate_resilience,
@@ -515,6 +552,7 @@ _DOMAIN_VALIDATORS: dict[str, Any] = {
     "updates": _validate_updates,
     "surplus": _validate_surplus,
     "ego": _validate_ego,
+    "channels": _validate_channels,
 }
 
 


### PR DESCRIPTION
## Summary
- Adds a `channels` settings domain so the default model/effort for new Telegram sessions can be changed from the dashboard settings panel
- Resolution chain: `/model` command > session stored > config default > hardcoded fallback
- New `config/channels.yaml` with `.local.yaml` overlay support for user customization

## Changes
- `config/channels.yaml` — base config (sonnet/medium defaults)
- `src/genesis/mcp/health/settings.py` — register domain + validator
- `src/genesis/cc/conversation.py` — accept configurable defaults via constructor
- `src/genesis/channels/bridge.py` — load channel config at startup
- `src/genesis/dashboard/` — settings panel UI (labels, descriptions, dropdowns)

## Test plan
- [x] `ruff check .` passes
- [x] 70 conversation tests pass
- [x] 45 settings tests pass
- [ ] Set `default_model: opus` in `channels.local.yaml`, restart server, verify new Telegram session starts with Opus
- [ ] Dashboard: Settings > Channels shows model/effort dropdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)