### PR TITLE
fix(channels): address code review findings

### DIFF
--- a/src/genesis/channels/bridge.py
+++ b/src/genesis/channels/bridge.py
@@ -15,14 +15,12 @@ import os
 import signal
 import sys
 import time
-from pathlib import Path
-
-import yaml
 
 from genesis.cc.conversation import ConversationLoop
 from genesis.cc.system_prompt import SystemPromptAssembler
 from genesis.cc.types import CCModel, EffortLevel
 from genesis.env import secrets_path
+from genesis.mcp.health.settings import _load_yaml_merged
 from genesis.runtime import GenesisRuntime
 
 logging.basicConfig(
@@ -90,31 +88,30 @@ def _load_bridge_config() -> dict | None:
     }
 
 
-_CONFIG_DIR = Path(__file__).resolve().parents[3] / "config"
-
-
 def _load_channel_defaults() -> tuple[CCModel, EffortLevel]:
     """Load default model/effort for Telegram from channels.yaml."""
-    model_map = {"opus": CCModel.OPUS, "sonnet": CCModel.SONNET, "haiku": CCModel.HAIKU}
-    effort_map = {
-        "low": EffortLevel.LOW, "medium": EffortLevel.MEDIUM,
-        "high": EffortLevel.HIGH, "max": EffortLevel.MAX,
-    }
-    data: dict = {}
-    for fname in ("channels.yaml", "channels.local.yaml"):
-        path = _CONFIG_DIR / fname
-        if path.is_file():
-            try:
-                with open(path) as f:
-                    loaded = yaml.safe_load(f) or {}
-                tg = loaded.get("telegram", {})
-                if isinstance(tg, dict):
-                    data.update(tg)
-            except Exception:
-                log.warning("Failed to read %s", path, exc_info=True)
+    data = _load_yaml_merged("channels.yaml")
+    tg = data.get("telegram", {})
+    if not isinstance(tg, dict):
+        tg = {}
 
-    model = model_map.get(data.get("default_model", ""), CCModel.SONNET)
-    effort = effort_map.get(data.get("default_effort", ""), EffortLevel.MEDIUM)
+    raw_model = tg.get("default_model", "")
+    raw_effort = tg.get("default_effort", "")
+
+    try:
+        model = CCModel(raw_model)
+    except ValueError:
+        if raw_model:
+            log.warning("Unknown default_model %r in channels config, falling back to sonnet", raw_model)
+        model = CCModel.SONNET
+
+    try:
+        effort = EffortLevel(raw_effort)
+    except ValueError:
+        if raw_effort:
+            log.warning("Unknown default_effort %r in channels config, falling back to medium", raw_effort)
+        effort = EffortLevel.MEDIUM
+
     log.info("Channel defaults: model=%s, effort=%s", model.value, effort.value)
     return model, effort
 

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1320,6 +1320,9 @@
           interval_hours: 'Check Interval (hours)',
           auto_apply: 'Auto Apply', allowed_impacts: 'Allowed Impacts',
           backup_before_update: 'Backup Before Update',
+          // Channels
+          telegram: 'Telegram',
+          default_model: 'Default Model', default_effort: 'Default Effort',
         },
         _SETTING_DESCS: {
           // Autonomous CLI Policy
@@ -1362,9 +1365,6 @@
           batch_size: 'Maximum files to process per scan cycle (1\u201310)',
           effort: 'Processing depth: low (fast), medium (balanced), or high (thorough)',
           timeout_s: 'Max seconds per inbox item processing before timeout',
-          // Channels
-          telegram: 'Telegram',
-          default_model: 'Default Model', default_effort: 'Default Effort',
           // Outreach
           start: 'Quiet hours start \u2014 no outreach before this time (e.g., 22:00)',
           end: 'Quiet hours end \u2014 outreach resumes after this time (e.g., 07:00)',

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -517,8 +517,13 @@ def _validate_ego(changes: dict) -> list[str]:
 def _validate_channels(changes: dict) -> list[str]:
     """Validate channel defaults config changes."""
     errors: list[str] = []
+    valid_top_keys = {"telegram"}
     valid_models = {"opus", "sonnet", "haiku"}
     valid_efforts = {"low", "medium", "high", "max"}
+
+    for key in changes:
+        if key not in valid_top_keys:
+            errors.append(f"Unknown key '{key}'. Valid: {', '.join(sorted(valid_top_keys))}")
 
     tg = changes.get("telegram", {})
     if not isinstance(tg, dict):


### PR DESCRIPTION
## Summary
Follow-up to PR #250 — fixes bugs caught during code review:
- Labels were in the wrong JS map (`_SETTING_DESCS` instead of `_SETTING_LABELS`)
- Validator accepted arbitrary top-level keys (e.g., `discord`) without error
- Bridge duplicated YAML merge logic instead of reusing `_load_yaml_merged`
- Invalid config values caused silent fallback with no warning log

## Test plan
- [x] `ruff check .` passes
- [x] 70 conversation tests + 45 settings tests pass
- [ ] Dashboard: Channels settings show correct labels and tooltips

🤖 Generated with [Claude Code](https://claude.com/claude-code)