### PR TITLE
refactor(channels): move load_channel_defaults to proper module

### DIFF
--- a/src/genesis/channels/bridge.py
+++ b/src/genesis/channels/bridge.py
@@ -18,9 +18,8 @@ import time
 
 from genesis.cc.conversation import ConversationLoop
 from genesis.cc.system_prompt import SystemPromptAssembler
-from genesis.cc.types import CCModel, EffortLevel
+from genesis.channels.config import load_channel_defaults as _load_channel_defaults  # noqa: F401
 from genesis.env import secrets_path
-from genesis.mcp.health.settings import _load_yaml_merged
 from genesis.runtime import GenesisRuntime
 
 logging.basicConfig(
@@ -88,32 +87,9 @@ def _load_bridge_config() -> dict | None:
     }
 
 
-def _load_channel_defaults() -> tuple[CCModel, EffortLevel]:
-    """Load default model/effort for Telegram from channels.yaml."""
-    data = _load_yaml_merged("channels.yaml")
-    tg = data.get("telegram", {})
-    if not isinstance(tg, dict):
-        tg = {}
 
-    raw_model = tg.get("default_model", "")
-    raw_effort = tg.get("default_effort", "")
-
-    try:
-        model = CCModel(raw_model)
-    except ValueError:
-        if raw_model:
-            log.warning("Unknown default_model %r in channels config, falling back to sonnet", raw_model)
-        model = CCModel.SONNET
-
-    try:
-        effort = EffortLevel(raw_effort)
-    except ValueError:
-        if raw_effort:
-            log.warning("Unknown default_effort %r in channels config, falling back to medium", raw_effort)
-        effort = EffortLevel.MEDIUM
-
-    log.info("Channel defaults: model=%s, effort=%s", model.value, effort.value)
-    return model, effort
+# _load_channel_defaults is imported from genesis.channels.config above
+# and re-exported for backwards compatibility with standalone.py.
 
 
 async def _run_headless(runtime: GenesisRuntime) -> None:

--- a/src/genesis/channels/config.py
+++ b/src/genesis/channels/config.py
@@ -1,0 +1,44 @@
+"""Channel configuration — loads channel defaults from channels.yaml."""
+
+from __future__ import annotations
+
+import logging
+
+from genesis.cc.types import CCModel, EffortLevel
+from genesis.mcp.health.settings import _load_yaml_merged
+
+logger = logging.getLogger(__name__)
+
+
+def load_channel_defaults() -> tuple[CCModel, EffortLevel]:
+    """Load default model/effort for Telegram from channels.yaml."""
+    data = _load_yaml_merged("channels.yaml")
+    tg = data.get("telegram", {})
+    if not isinstance(tg, dict):
+        tg = {}
+
+    raw_model = tg.get("default_model", "")
+    raw_effort = tg.get("default_effort", "")
+
+    try:
+        model = CCModel(raw_model)
+    except ValueError:
+        if raw_model:
+            logger.warning(
+                "Unknown default_model %r in channels config, falling back to sonnet",
+                raw_model,
+            )
+        model = CCModel.SONNET
+
+    try:
+        effort = EffortLevel(raw_effort)
+    except ValueError:
+        if raw_effort:
+            logger.warning(
+                "Unknown default_effort %r in channels config, falling back to medium",
+                raw_effort,
+            )
+        effort = EffortLevel.MEDIUM
+
+    logger.info("Channel defaults: model=%s, effort=%s", model.value, effort.value)
+    return model, effort

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -194,6 +194,8 @@ class StandaloneAdapter:
             except Exception:
                 logger.warning("Failed to init failure detector for OpenClaw", exc_info=True)
 
+            # OpenClaw callers set model/effort per-request via the completions API.
+            # Channel-level defaults (channels.yaml) are intentionally not applied here.
             conversation_loop = ConversationLoop(
                 db=rt.db,
                 invoker=rt.cc_invoker,
@@ -337,7 +339,8 @@ class StandaloneAdapter:
         wiring for forum topic routing (reflection, outreach, awareness).
         """
         try:
-            from genesis.channels.bridge import _load_bridge_config, _load_channel_defaults
+            from genesis.channels.bridge import _load_bridge_config
+            from genesis.channels.config import load_channel_defaults
 
             config = _load_bridge_config()
             if config is None:
@@ -358,7 +361,7 @@ class StandaloneAdapter:
                 logger.warning("Failed to init failure detector", exc_info=True)
 
             rt = self._runtime
-            default_model, default_effort = _load_channel_defaults()
+            default_model, default_effort = load_channel_defaults()
 
             conversation_loop = ConversationLoop(
                 db=rt.db,


### PR DESCRIPTION
## Summary
- Extracts `load_channel_defaults` from `bridge.py` (deprecated Agent Zero entry point) to `genesis.channels.config` (proper library module)
- Logger now correctly reports as `genesis.channels.config` instead of `genesis.bridge`
- Documents why OpenClaw intentionally skips channel defaults
- Re-exports from bridge.py for backwards compat

Follow-up to PRs #250, #251, #252.

## Test plan
- [x] `ruff check` passes
- [x] 70 conversation + 45 settings tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)