### PR TITLE
feat(ego): add mechanical sweep for approved proposal dispatch

### DIFF
--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -98,6 +98,15 @@ class EgoCadenceManager:
                 max_instances=1,
                 misfire_grace_time=600,
             )
+        # Mechanical sweep: dispatch approved proposals every 30 min,
+        # independent of ego LLM cycles.
+        self._scheduler.add_job(
+            self._session.sweep_approved_proposals,
+            IntervalTrigger(minutes=30),
+            id="ego_sweep_approved",
+            max_instances=1,
+            misfire_grace_time=300,
+        )
         self._scheduler.start()
         self._running = True
         morning_str = (

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -706,6 +706,94 @@ class EgoSession:
         except Exception:
             logger.error("Failed to apply ego notepad updates", exc_info=True)
 
+    # -- Approved proposal sweep --------------------------------------------
+
+    async def sweep_approved_proposals(self) -> list[str]:
+        """Mechanically dispatch approved proposals via DirectSessionRunner.
+
+        Called on a fixed 30-minute interval by EgoCadenceManager,
+        independent of ego LLM cycles. This ensures approved work gets
+        dispatched even when the ego is in stay_quiet mode.
+
+        Returns list of dispatched proposal IDs.
+        """
+        if self._direct_session_runner is None:
+            return []
+
+        if not await self._check_dispatch_budget():
+            logger.info("Sweep skipped — dispatch budget exceeded")
+            return []
+
+        from genesis.cc.direct_session import DirectSessionRequest
+
+        approved = await ego_crud.list_proposals(
+            self._db, status="approved", limit=5,
+        )
+        if not approved:
+            return []
+
+        dispatched: list[str] = []
+        for prop in approved:
+            # Staleness guard — skip proposals approved more than 48h ago.
+            # resolved_at is set by resolve_proposal() at approval time.
+            try:
+                approved_at = datetime.fromisoformat(prop["resolved_at"])
+                if datetime.now(UTC) - approved_at > timedelta(hours=48):
+                    continue
+            except (KeyError, TypeError, ValueError):
+                continue
+
+            prompt = (
+                f"Execute this approved proposal:\n\n"
+                f"{prop['content']}\n\n"
+                f"Execution plan: {prop.get('execution_plan') or 'N/A'}\n\n"
+                f"Context: {prop.get('rationale') or ''}"
+            )
+            profile = _infer_profile(prop.get("action_type", ""))
+
+            try:
+                request = DirectSessionRequest(
+                    prompt=prompt,
+                    profile=profile,
+                    model=CCModel.SONNET,
+                    effort=EffortLevel.HIGH,
+                    notify=True,
+                    source_tag="ego_dispatch",
+                    caller_context=f"ego_proposal:{prop['id']}",
+                )
+                session_id = await self._direct_session_runner.spawn(request)
+                ok = await ego_crud.execute_proposal(
+                    self._db, prop["id"],
+                    status="executed",
+                    user_response=f"session:{session_id}",
+                )
+                if ok:
+                    dispatched.append(prop["id"])
+                    logger.info(
+                        "Sweep dispatched proposal %s → session %s",
+                        prop["id"], session_id,
+                    )
+            except Exception:
+                logger.error(
+                    "Sweep failed to dispatch proposal %s",
+                    prop["id"], exc_info=True,
+                )
+                try:
+                    await ego_crud.execute_proposal(
+                        self._db, prop["id"],
+                        status="failed",
+                        user_response="sweep_dispatch_error",
+                    )
+                except Exception:
+                    logger.error(
+                        "Failed to mark proposal %s as failed",
+                        prop["id"], exc_info=True,
+                    )
+
+        if dispatched:
+            logger.info("Sweep dispatched %d approved proposal(s)", len(dispatched))
+        return dispatched
+
     async def _check_budget(self) -> bool:
         """True if daily ego thinking spend is under the budget cap."""
         try:
@@ -737,6 +825,18 @@ class EgoSession:
 
 _VALID_URGENCIES = frozenset({"low", "normal", "high", "critical"})
 _VALID_NOTEPAD_ACTIONS = frozenset({"add", "update", "remove"})
+
+_INTERACT_TYPES = frozenset({"outreach", "dispatch"})
+_RESEARCH_TYPES = frozenset({"investigate"})
+
+
+def _infer_profile(action_type: str) -> str:
+    """Map proposal action_type to a DirectSession profile."""
+    if action_type in _INTERACT_TYPES:
+        return "interact"
+    if action_type in _RESEARCH_TYPES:
+        return "research"
+    return "observe"
 
 
 def _validate_output(data: dict) -> dict | None:

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -142,7 +142,8 @@ These principles prevent you from overwhelming the user:
 1. Check your pending proposal board before proposing new items. If you
    have 3+ unreviewed proposals, table new ones unless genuinely urgent.
 2. If the user hasn't engaged with your last two digests, scale back.
-   They're busy. Table things. Wait for a signal.
+   They're busy. Use `stay_quiet` more often — continue creating
+   proposals, but don't send digests until engagement resumes.
 3. You're measured by proposal quality and user approval rate, not by
    volume. Three approved proposals per week is better than twenty
    ignored ones.
@@ -229,9 +230,14 @@ These are hard limits on what you think about:
 
 ## Constraints
 
-You are in **proposal mode**. ALL actions require user approval via
+You are in **proposal mode**. New actions require user approval via
 Telegram. Your proposals are sent as a batch digest; the user approves
 or rejects each one.
+
+**Already-approved proposals are different.** When you see approved
+proposals on the Proposal Board, generate `execution_briefs` for them.
+The user already said yes — dispatching approved work is not an
+interruption.
 
 Recording follow_ups (your open threads for next cycle) is always
 allowed — these are internal bookkeeping.


### PR DESCRIPTION
## Summary

- **Prompt calibration**: ego self-regulation no longer goes fully dark when user is busy — uses `stay_quiet` instead of tabling everything, and constraints now distinguish new actions (need approval) from approved proposals (dispatch immediately)
- **Mechanical sweep**: 30-minute `IntervalTrigger` queries approved proposals and dispatches them via `DirectSessionRunner`, independent of ego LLM cycles — ensures approved work executes even when the ego is in stay_quiet mode
- **Safety guards**: 48h staleness on `resolved_at`, dispatch budget check, atomic `WHERE status='approved'` prevents double-dispatch between sweep and ego execution briefs

## Test plan

- [x] 330 ego tests pass
- [x] 6266 full suite tests pass (5 pre-existing failures on main)
- [x] ruff clean
- [ ] After server restart: ego creates proposals (even with `stay_quiet`) within 3 cycles
- [ ] After server restart: approved proposal dispatched by sweep within 30 min
- [ ] Monitor outcome hook (`_ego_dispatch_on_end`) observations for dispatch results

🤖 Generated with [Claude Code](https://claude.com/claude-code)