### PR TITLE
feat(modules): external module dispatch awareness + enabled guard fix

### DIFF
--- a/src/genesis/identity/CONVERSATION.md
+++ b/src/genesis/identity/CONVERSATION.md
@@ -34,6 +34,55 @@ WebSearch) plus Genesis MCP tools across four servers: genesis-health,
 genesis-memory, genesis-outreach, and genesis-recon. The SessionStart hook
 injects the full tool list — refer to it for specifics.
 
+## External Module Dispatch
+
+Genesis has external modules — programs running on other machines that you
+can invoke via `module_call` MCP tool. Use `module_list` to see what's
+available and whether each module is enabled.
+
+When the user asks about a domain covered by an external module, dispatch
+to that module rather than answering from general knowledge. The module has
+specialized context, skills, and data that you don't.
+
+**Before dispatching:** Check the module is enabled via `module_list`. If
+disabled, tell the user ("Career Ops is disabled — I can answer from what
+I know, or you can re-enable it on the dashboard"). If the module returns
+an error (unhealthy, unreachable), fall back to answering from Genesis
+context and mention the module was unavailable.
+
+### Career Domain
+
+Two career modules handle different aspects:
+
+**Career Ops** (SSH CC dispatch) — the cognitive service:
+- JD evaluation, interview prep, strategy coaching, CV generation
+- Has its own profile data, skills, and evaluation framework
+- Use: `module_call("Career Ops", "dispatch", {"prompt": "..."})`
+- Dedicated JD eval: `module_call("Career Ops", "eval_jd", {"prompt": "..."})`
+
+**Career Agent** (HTTP API) — the data service:
+- Job pipeline, listings, company details, activity feeds
+- Use: `module_call("Career Agent", "list_jobs")`, `pipeline`, `activity`, etc.
+
+**Routing rule:**
+- Analysis, strategy, coaching, evaluation → Career Ops (`dispatch`/`eval_jd`)
+- Data, status, listings, pipeline → Career Agent (HTTP operations)
+
+**Prompt formulation for Career Ops dispatch:**
+Include enough context for the remote session to act independently. Restate
+the user's question, include artifacts (JD text, company name, role), and
+specify what output you need. The remote session has CareerOps' full context
+(profile, skills, working directory) but not this conversation's history.
+
+**Present results naturally** — summarize or reformat verbose responses.
+Note the source transparently when relevant ("From your CareerOps profile:
+...") but don't make it feel like a separate system.
+
+**Cost awareness:** Each Career Ops dispatch spawns a remote Claude Code
+session (~30-60s, variable cost). Don't dispatch trivial questions you can
+answer from Genesis memory. Do dispatch anything requiring CareerOps'
+specialized context.
+
 ## Task Recognition
 
 When the user's message contains an implicit task — something with a verifiable

--- a/src/genesis/mcp/health/module_ops.py
+++ b/src/genesis/mcp/health/module_ops.py
@@ -115,6 +115,9 @@ async def _impl_module_call(
             },
         }
 
+    if not adapter.enabled:
+        return {"error": f"Module '{module_name}' is disabled"}
+
     await _ensure_adapter_started(adapter)
     return await adapter.execute_operation(operation.strip(), params)
 

--- a/src/genesis/modules/external/adapter.py
+++ b/src/genesis/modules/external/adapter.py
@@ -196,6 +196,9 @@ class ExternalProgramAdapter:
             available = list(ops.keys())
             return {"error": f"Unknown operation '{operation_name}'", "available": available}
 
+        if not self._enabled:
+            return {"error": f"Module '{self.name}' is disabled"}
+
         if not self._healthy:
             return {"error": f"Module '{self.name}' is not healthy"}
 

--- a/tests/test_modules/test_external_adapter.py
+++ b/tests/test_modules/test_external_adapter.py
@@ -306,6 +306,39 @@ class TestExternalProgramAdapter:
         assert await adapter.check_health() is True
         assert adapter.healthy is True
 
+    @pytest.mark.asyncio
+    async def test_execute_operation_disabled(self):
+        adapter = self._make_adapter(
+            enabled=False,
+            operations={"status": {"method": "SHELL", "command": "echo ok"}},
+        )
+        adapter._healthy = True
+        result = await adapter.execute_operation("status")
+        assert "error" in result
+        assert "disabled" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_execute_operation_unhealthy(self):
+        adapter = self._make_adapter(
+            enabled=True,
+            operations={"status": {"method": "SHELL", "command": "echo ok"}},
+        )
+        adapter._healthy = False
+        result = await adapter.execute_operation("status")
+        assert "error" in result
+        assert "not healthy" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_execute_operation_unknown(self):
+        adapter = self._make_adapter(
+            enabled=True,
+            operations={"status": {"method": "SHELL", "command": "echo ok"}},
+        )
+        adapter._healthy = True
+        result = await adapter.execute_operation("nonexistent")
+        assert "error" in result
+        assert "Unknown operation" in result["error"]
+
 
 # ---------------------------------------------------------------------------
 # YAML auto-discovery integration


### PR DESCRIPTION
## Summary

- **Fix:** `execute_operation()` now checks the `enabled` flag before executing operations. Previously, disabled modules could still execute via `module_call` since only `_healthy` was checked.
- **Feature:** Added external module dispatch awareness to CONVERSATION.md. Genesis conversation mode now knows how to route career-domain questions to Career Ops (SSH CC dispatch for analysis/strategy) and Career Agent (HTTP API for data/pipeline).
- Includes prompt formulation guidance, error handling for disabled/unhealthy modules, and cost awareness.

## Test plan

- [x] 3 new tests for execute_operation guards (disabled, unhealthy, unknown operation)
- [x] 243 module tests pass (240 existing + 3 new)
- [x] Lint passes on all changed files
- [ ] Manual verification: disable Career Ops on dashboard, call module_call, verify error
- [ ] Manual verification: in new conversation, ask career question, verify dispatch