### PR TITLE
feat(knowledge): improve distillation quality with proportional extraction

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -428,11 +428,13 @@ call_sites:
     description: "Proactive infrastructure monitoring \u2014 trend detection and forecasting"
   40_knowledge_distillation:
     chain:
+    - claude-haiku
     - mistral-large-free
     - groq-free
     - gemini-free
     - cerebras-qwen
     - openrouter-free
+    default_paid: true
     retry_profile: background
     description: "Knowledge pipeline — distill raw content into structured knowledge units"
   41_resume_review_pass1:

--- a/src/genesis/knowledge/distillation.py
+++ b/src/genesis/knowledge/distillation.py
@@ -18,23 +18,33 @@ logger = logging.getLogger(__name__)
 
 _CALL_SITE = "40_knowledge_distillation"
 
-# Max characters per chunk sent to the LLM for distillation
-_MAX_CHUNK_CHARS = 12000
+# Max characters per chunk sent to the LLM for distillation.
+# Sized for Haiku (200K context) / Mistral Large (128K) — ~10K tokens per chunk.
+_MAX_CHUNK_CHARS = 40_000
 
 # Max concurrent LLM calls for parallel chunk processing
 _MAX_CONCURRENT_CHUNKS = 4
 
+# Minimum extraction ratio (output chars / input chars). Below this, flag as thin.
+_MIN_EXTRACTION_RATIO = 0.10
+
 _DISTILLATION_SYSTEM_PROMPT = """\
 You are a knowledge distillation engine. Your job is to extract structured
-knowledge units from raw content.
+knowledge units from raw content, preserving the depth and nuance of the
+source material.
 
-For each meaningful concept, fact, or insight in the content, produce a
-knowledge unit. Each unit should capture UNDERSTANDING, not reproduction
-— distill the material into what someone would need to know.
+For each meaningful concept, principle, pattern, best practice, or insight
+in the content, produce a knowledge unit. Each unit should capture
+UNDERSTANDING — distill the material into what a senior practitioner would
+need to know, including specifics, examples, and operational detail.
 
 Output a JSON array of objects with these fields:
 - concept: Short title (max 200 chars) — what this unit is about
-- body: The distilled knowledge (1-3 paragraphs)
+- body: The distilled knowledge — be as thorough as the source warrants.
+  For reference material, frameworks, and technical guides, include
+  specific details, thresholds, configuration values, and actionable
+  guidance. A 1-paragraph body is fine for a simple fact; a multi-paragraph
+  body is expected for a rich topic.
 - domain: Knowledge domain (e.g., "aws", "python", "leadership", "resume-advice")
 - relationships: JSON array of related concepts (strings)
 - caveats: JSON array of limitations or qualifications
@@ -44,7 +54,12 @@ Output a JSON array of objects with these fields:
 Rules:
 - Extract UNDERSTANDING, not quotes. Paraphrase and synthesize.
 - Each unit should stand alone — readable without the source.
-- Skip trivial or redundant content.
+- Be THOROUGH. Extract every distinct concept, pattern, and practice.
+  Err on the side of extracting more units rather than fewer.
+  A comprehensive framework document should produce many units.
+- Preserve operational specifics: numbers, thresholds, configuration
+  values, command examples, decision criteria. These are the details
+  that make knowledge actionable.
 - If the content is poorly structured or unclear, set confidence < 0.5.
 - Return an empty array if there's nothing meaningful to extract.
 - These are machine-extracted summaries, not authoritative facts. Include
@@ -139,6 +154,7 @@ class DistillationPipeline:
 
     def __init__(self, router: object) -> None:
         self._router = router
+        self._last_extraction_ratio: float = 0.0
 
     async def distill(
         self,
@@ -161,13 +177,18 @@ class DistillationPipeline:
                 called after each chunk completes. Used for progress tracking.
         """
         if not content.text.strip():
+            self._last_extraction_ratio = 0.0
             return []
+
+        total_chars = len(content.text)
 
         # Use sections if available, otherwise chunk the full text
         if content.sections and len(content.sections) > 1:
             chunks = content.sections
         else:
             chunks = _chunk_text(content.text)
+
+        total_chunks = len(chunks)
 
         # Process chunks in parallel with concurrency limit
         sem = asyncio.Semaphore(_MAX_CONCURRENT_CHUNKS)
@@ -176,6 +197,8 @@ class DistillationPipeline:
             async with sem:
                 raw_units = await self._distill_chunk(
                     chunk, content, project_type, domain, user_context,
+                    chunk_index=i, total_chunks=total_chunks,
+                    total_chars=total_chars,
                 )
                 units = []
                 for raw in raw_units:
@@ -237,9 +260,21 @@ class DistillationPipeline:
             if isinstance(r, Exception):
                 logger.warning("Chunk distillation failed: %s", r)
 
+        # Track extraction ratio for quality monitoring
+        output_chars = sum(len(u.body) for u in all_units)
+        self._last_extraction_ratio = output_chars / total_chars if total_chars > 0 else 0.0
+
+        if self._last_extraction_ratio < _MIN_EXTRACTION_RATIO and all_units:
+            logger.warning(
+                "Thin extraction: %.1f%% ratio (%d output chars / %d input chars, %d units) from %s",
+                self._last_extraction_ratio * 100, output_chars, total_chars,
+                len(all_units), content.source_path,
+            )
+
         logger.info(
-            "Distilled %d knowledge units from %s (%d chunks, %d concurrent)",
+            "Distilled %d knowledge units from %s (%d chunks, %d concurrent, %.1f%% extraction ratio)",
             len(all_units), content.source_path, len(chunks), _MAX_CONCURRENT_CHUNKS,
+            self._last_extraction_ratio * 100,
         )
         return all_units
 
@@ -250,9 +285,23 @@ class DistillationPipeline:
         project_type: str,
         domain: str,
         user_context: str | None = None,
+        *,
+        chunk_index: int = 0,
+        total_chunks: int = 1,
+        total_chars: int = 0,
     ) -> list[dict]:
         """Send a single chunk through the LLM for distillation."""
         context_hint = ""
+
+        # Document scale — helps the LLM calibrate extraction depth
+        if total_chars > 0:
+            context_hint += f"\nDocument: {total_chars:,} characters total"
+            context_hint += f", chunk {chunk_index + 1} of {total_chunks}"
+        if content.metadata.get("page_count"):
+            context_hint += f" ({content.metadata['page_count']} pages)"
+        if content.metadata.get("duration"):
+            mins = int(content.metadata["duration"]) // 60
+            context_hint += f" ({mins} min video)"
 
         # Include user-provided context about the document
         if user_context:

--- a/src/genesis/knowledge/distillation.py
+++ b/src/genesis/knowledge/distillation.py
@@ -26,7 +26,7 @@ _MAX_CHUNK_CHARS = 40_000
 _MAX_CONCURRENT_CHUNKS = 4
 
 # Minimum extraction ratio (output chars / input chars). Below this, flag as thin.
-_MIN_EXTRACTION_RATIO = 0.10
+MIN_EXTRACTION_RATIO = 0.10
 
 _DISTILLATION_SYSTEM_PROMPT = """\
 You are a knowledge distillation engine. Your job is to extract structured
@@ -154,7 +154,7 @@ class DistillationPipeline:
 
     def __init__(self, router: object) -> None:
         self._router = router
-        self._last_extraction_ratio: float = 0.0
+        self.last_extraction_ratio: float = 0.0
 
     async def distill(
         self,
@@ -177,7 +177,7 @@ class DistillationPipeline:
                 called after each chunk completes. Used for progress tracking.
         """
         if not content.text.strip():
-            self._last_extraction_ratio = 0.0
+            self.last_extraction_ratio = 0.0
             return []
 
         total_chars = len(content.text)
@@ -262,19 +262,19 @@ class DistillationPipeline:
 
         # Track extraction ratio for quality monitoring
         output_chars = sum(len(u.body) for u in all_units)
-        self._last_extraction_ratio = output_chars / total_chars if total_chars > 0 else 0.0
+        self.last_extraction_ratio = output_chars / total_chars if total_chars > 0 else 0.0
 
-        if self._last_extraction_ratio < _MIN_EXTRACTION_RATIO and all_units:
+        if self.last_extraction_ratio < MIN_EXTRACTION_RATIO and all_units:
             logger.warning(
                 "Thin extraction: %.1f%% ratio (%d output chars / %d input chars, %d units) from %s",
-                self._last_extraction_ratio * 100, output_chars, total_chars,
+                self.last_extraction_ratio * 100, output_chars, total_chars,
                 len(all_units), content.source_path,
             )
 
         logger.info(
             "Distilled %d knowledge units from %s (%d chunks, %d concurrent, %.1f%% extraction ratio)",
             len(all_units), content.source_path, len(chunks), _MAX_CONCURRENT_CHUNKS,
-            self._last_extraction_ratio * 100,
+            self.last_extraction_ratio * 100,
         )
         return all_units
 

--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -12,7 +12,7 @@ import typing
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from genesis.knowledge.distillation import DistillationPipeline
+from genesis.knowledge.distillation import _MIN_EXTRACTION_RATIO, DistillationPipeline
 from genesis.knowledge.manifest import ManifestManager
 from genesis.knowledge.processors.base import ProcessedContent
 from genesis.knowledge.processors.registry import ContentProcessorRegistry
@@ -148,6 +148,11 @@ class KnowledgeOrchestrator:
         low_conf = [u for u in units if u.confidence < 0.5]
         if low_conf:
             quality_flags.append(f"{len(low_conf)}_low_confidence_units")
+
+        # Flag thin extraction (output much smaller than input)
+        ratio = self._distillation._last_extraction_ratio
+        if ratio < _MIN_EXTRACTION_RATIO and units:
+            quality_flags.append("thin_extraction")
 
         return IngestResult(
             source=source,

--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -12,7 +12,7 @@ import typing
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from genesis.knowledge.distillation import _MIN_EXTRACTION_RATIO, DistillationPipeline
+from genesis.knowledge.distillation import MIN_EXTRACTION_RATIO, DistillationPipeline
 from genesis.knowledge.manifest import ManifestManager
 from genesis.knowledge.processors.base import ProcessedContent
 from genesis.knowledge.processors.registry import ContentProcessorRegistry
@@ -150,8 +150,8 @@ class KnowledgeOrchestrator:
             quality_flags.append(f"{len(low_conf)}_low_confidence_units")
 
         # Flag thin extraction (output much smaller than input)
-        ratio = self._distillation._last_extraction_ratio
-        if ratio < _MIN_EXTRACTION_RATIO and units:
+        ratio = self._distillation.last_extraction_ratio
+        if ratio < MIN_EXTRACTION_RATIO and units:
             quality_flags.append("thin_extraction")
 
         return IngestResult(

--- a/tests/test_knowledge/test_distillation.py
+++ b/tests/test_knowledge/test_distillation.py
@@ -142,3 +142,109 @@ async def test_distill_llm_failure():
 
     units = await pipeline.distill(content, project_type="test")
     assert units == []
+
+
+# ─── New tests: chunk size, doc stats, extraction ratio ────────────────────
+
+
+def test_max_chunk_chars_default():
+    """Default chunk size should be 40K (upgraded from 12K)."""
+    from genesis.knowledge.distillation import _MAX_CHUNK_CHARS
+    assert _MAX_CHUNK_CHARS == 40_000
+
+
+def test_min_extraction_ratio_default():
+    """Minimum extraction ratio should be 10%."""
+    from genesis.knowledge.distillation import _MIN_EXTRACTION_RATIO
+    assert _MIN_EXTRACTION_RATIO == 0.10
+
+
+async def test_distill_passes_doc_stats():
+    """LLM user message should include document scale information."""
+    mock_router = MagicMock()
+    mock_result = MagicMock()
+    mock_result.success = True
+    mock_result.content = json.dumps([
+        {
+            "concept": "Test Concept",
+            "body": "Test body content.",
+            "domain": "test",
+            "confidence": 0.9,
+        },
+    ])
+    mock_router.route_call = AsyncMock(return_value=mock_result)
+
+    pipeline = DistillationPipeline(router=mock_router)
+    content = ProcessedContent(
+        text="A" * 500,
+        source_type="text",
+        source_path="/test.txt",
+    )
+
+    await pipeline.distill(content, project_type="test", domain="test")
+
+    # Verify route_call was called and user message contains doc stats
+    assert mock_router.route_call.called
+    call_args = mock_router.route_call.call_args
+    messages = call_args[0][1]  # Second positional arg
+    user_msg = messages[1]["content"]
+    assert "500 characters total" in user_msg
+    assert "chunk 1 of 1" in user_msg
+
+
+async def test_distill_passes_page_count():
+    """LLM user message should include page count from metadata."""
+    mock_router = MagicMock()
+    mock_result = MagicMock()
+    mock_result.success = True
+    mock_result.content = json.dumps([
+        {"concept": "Test", "body": "Body.", "domain": "test", "confidence": 0.9},
+    ])
+    mock_router.route_call = AsyncMock(return_value=mock_result)
+
+    pipeline = DistillationPipeline(router=mock_router)
+    content = ProcessedContent(
+        text="Some PDF content here.",
+        source_type="pdf",
+        source_path="/test.pdf",
+        metadata={"page_count": 42},
+    )
+
+    await pipeline.distill(content, project_type="test", domain="test")
+
+    user_msg = mock_router.route_call.call_args[0][1][1]["content"]
+    assert "42 pages" in user_msg
+
+
+async def test_extraction_ratio_tracked():
+    """Pipeline should track extraction ratio after distillation."""
+    mock_router = MagicMock()
+    mock_result = MagicMock()
+    mock_result.success = True
+    # 100 chars input, body is ~20 chars → ~20% ratio
+    mock_result.content = json.dumps([
+        {"concept": "Test", "body": "A" * 20, "domain": "test", "confidence": 0.9},
+    ])
+    mock_router.route_call = AsyncMock(return_value=mock_result)
+
+    pipeline = DistillationPipeline(router=mock_router)
+    content = ProcessedContent(
+        text="B" * 100,
+        source_type="text",
+        source_path="/test.txt",
+    )
+
+    units = await pipeline.distill(content, project_type="test")
+    assert len(units) == 1
+    assert pipeline._last_extraction_ratio > 0
+    assert abs(pipeline._last_extraction_ratio - 0.20) < 0.01
+
+
+async def test_extraction_ratio_zero_on_empty():
+    """Extraction ratio should be 0 when no content."""
+    mock_router = MagicMock()
+    pipeline = DistillationPipeline(router=mock_router)
+    content = ProcessedContent(text="   ", source_type="text", source_path="empty.txt")
+
+    await pipeline.distill(content, project_type="test")
+    assert pipeline._last_extraction_ratio == 0.0

--- a/tests/test_knowledge/test_distillation.py
+++ b/tests/test_knowledge/test_distillation.py
@@ -155,8 +155,8 @@ def test_max_chunk_chars_default():
 
 def test_min_extraction_ratio_default():
     """Minimum extraction ratio should be 10%."""
-    from genesis.knowledge.distillation import _MIN_EXTRACTION_RATIO
-    assert _MIN_EXTRACTION_RATIO == 0.10
+    from genesis.knowledge.distillation import MIN_EXTRACTION_RATIO
+    assert MIN_EXTRACTION_RATIO == 0.10
 
 
 async def test_distill_passes_doc_stats():
@@ -236,8 +236,8 @@ async def test_extraction_ratio_tracked():
 
     units = await pipeline.distill(content, project_type="test")
     assert len(units) == 1
-    assert pipeline._last_extraction_ratio > 0
-    assert abs(pipeline._last_extraction_ratio - 0.20) < 0.01
+    assert pipeline.last_extraction_ratio > 0
+    assert abs(pipeline.last_extraction_ratio - 0.20) < 0.01
 
 
 async def test_extraction_ratio_zero_on_empty():
@@ -247,4 +247,4 @@ async def test_extraction_ratio_zero_on_empty():
     content = ProcessedContent(text="   ", source_type="text", source_path="empty.txt")
 
     await pipeline.distill(content, project_type="test")
-    assert pipeline._last_extraction_ratio == 0.0
+    assert pipeline.last_extraction_ratio == 0.0

--- a/tests/test_knowledge/test_orchestrator.py
+++ b/tests/test_knowledge/test_orchestrator.py
@@ -98,3 +98,21 @@ async def test_batch_ingest(tmp_path: Path):
     results = await orch.ingest_batch(str(tmp_path), project_type="test")
     # Should process a.txt and b.md but skip c.xyz
     assert len(results) == 2
+
+
+async def test_thin_extraction_quality_flag(tmp_path: Path):
+    """Thin extraction should produce a quality flag."""
+    units = [KnowledgeUnit(concept="Thin", body="Short.", domain="test")]
+    orch = _make_orchestrator(tmp_path, mock_distill_result=units)
+
+    # Simulate a low extraction ratio on the distillation pipeline
+    orch._distillation._last_extraction_ratio = 0.02  # 2% — below 10% floor
+
+    with patch("genesis.knowledge.orchestrator.KnowledgeOrchestrator._store_units",
+               new_callable=AsyncMock, return_value=["unit-1"]):
+        file = tmp_path / "big_doc.txt"
+        file.write_text("A" * 10000)  # Large input
+
+        result = await orch.ingest_source(str(file), project_type="test")
+        assert result.units_created == 1
+        assert "thin_extraction" in result.quality_flags

--- a/tests/test_knowledge/test_orchestrator.py
+++ b/tests/test_knowledge/test_orchestrator.py
@@ -106,7 +106,7 @@ async def test_thin_extraction_quality_flag(tmp_path: Path):
     orch = _make_orchestrator(tmp_path, mock_distill_result=units)
 
     # Simulate a low extraction ratio on the distillation pipeline
-    orch._distillation._last_extraction_ratio = 0.02  # 2% — below 10% floor
+    orch._distillation.last_extraction_ratio = 0.02  # 2% — below 10% floor
 
     with patch("genesis.knowledge.orchestrator.KnowledgeOrchestrator._store_units",
                new_callable=AsyncMock, return_value=["unit-1"]):


### PR DESCRIPTION
## Summary

- Upgrade knowledge distillation from free-tier models to Claude Haiku primary (free fallback preserved)
- Increase chunk size from 12K → 40K chars to use model capacity properly
- Rewrite distillation prompt: thorough extraction, preserve operational specifics, no artificial compression ceiling
- Pass document scale stats (total chars, chunk position, page count) so the LLM can calibrate extraction depth
- Track extraction ratio with 10% quality floor and `thin_extraction` quality flag

## Context

The AWS Well-Architected Framework (100+ page document) was distilled into a single 7KB knowledge unit. The DR Architecture doc retained 42KB from a comparable source. Root cause: tiny chunks, compression-encouraging prompt, no proportionality awareness, and free-tier model for permanent storage.

## Test plan

- [x] All 54 knowledge tests pass (47 existing + 7 new)
- [x] Lint clean on all changed files
- [x] GitNexus impact analysis: LOW risk on all symbols
- [ ] Re-ingest AWS Well-Architected Framework and verify substantially richer output
- [ ] Monitor `40_knowledge_distillation` call site cost after first few ingestions