### PR TITLE
fix(knowledge): merge PDF sections into full-size chunks

### DIFF
--- a/src/genesis/knowledge/distillation.py
+++ b/src/genesis/knowledge/distillation.py
@@ -184,7 +184,8 @@ class DistillationPipeline:
 
         # Use sections if available, otherwise chunk the full text
         if content.sections and len(content.sections) > 1:
-            chunks = content.sections
+            # Merge small sections into properly-sized chunks for efficiency
+            chunks = _chunk_text("\n\n".join(content.sections))
         else:
             chunks = _chunk_text(content.text)
 


### PR DESCRIPTION
## Summary

- PDF processor returns one section per page (~1,900 chars avg)
- Distillation was sending each page as a separate LLM call
- Now merges sections into 40K-char chunks before distillation
- AWS Well-Architected Framework: 1,002 calls → 50 calls (95% reduction)

## Test plan

- [x] All 54 knowledge tests pass
- [x] Lint clean
- [ ] Run full AWS WAF ingestion to validate