### PR TITLE
feat(eval): J-9 cognitive architecture eval infrastructure

### DIFF
--- a/src/genesis/db/crud/j9_eval.py
+++ b/src/genesis/db/crud/j9_eval.py
@@ -1,0 +1,192 @@
+"""CRUD operations for J-9 eval infrastructure (eval_events + eval_snapshots)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+
+import aiosqlite
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def _new_id() -> str:
+    return uuid.uuid4().hex[:16]
+
+
+# ── eval_events ──────────────────────────────────────────────────────────────
+
+
+async def insert_event(
+    db: aiosqlite.Connection,
+    *,
+    dimension: str,
+    event_type: str,
+    metrics: dict,
+    subject_id: str | None = None,
+    session_id: str | None = None,
+    timestamp: str | None = None,
+) -> str:
+    """Append an eval event. Returns the event id."""
+    eid = _new_id()
+    ts = timestamp or _now_iso()
+    await db.execute(
+        """INSERT INTO eval_events
+           (id, timestamp, dimension, event_type, subject_id,
+            session_id, metrics_json, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (eid, ts, dimension, event_type, subject_id,
+         session_id, json.dumps(metrics), ts),
+    )
+    await db.commit()
+    return eid
+
+
+async def get_events(
+    db: aiosqlite.Connection,
+    *,
+    dimension: str | None = None,
+    event_type: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    session_id: str | None = None,
+    limit: int = 500,
+) -> list[dict]:
+    """Query eval events with optional filters."""
+    sql = "SELECT * FROM eval_events WHERE 1=1"
+    params: list = []
+    if dimension:
+        sql += " AND dimension = ?"
+        params.append(dimension)
+    if event_type:
+        sql += " AND event_type = ?"
+        params.append(event_type)
+    if since:
+        sql += " AND timestamp >= ?"
+        params.append(since)
+    if until:
+        sql += " AND timestamp < ?"
+        params.append(until)
+    if session_id:
+        sql += " AND session_id = ?"
+        params.append(session_id)
+    sql += " ORDER BY timestamp DESC LIMIT ?"
+    params.append(limit)
+    cursor = await db.execute(sql, params)
+    rows = await cursor.fetchall()
+    result = []
+    for r in rows:
+        d = dict(r)
+        if d.get("metrics_json"):
+            d["metrics"] = json.loads(d["metrics_json"])
+        result.append(d)
+    return result
+
+
+async def count_events(
+    db: aiosqlite.Connection,
+    *,
+    dimension: str | None = None,
+    event_type: str | None = None,
+    since: str | None = None,
+) -> int:
+    """Count eval events with optional filters."""
+    sql = "SELECT COUNT(*) as cnt FROM eval_events WHERE 1=1"
+    params: list = []
+    if dimension:
+        sql += " AND dimension = ?"
+        params.append(dimension)
+    if event_type:
+        sql += " AND event_type = ?"
+        params.append(event_type)
+    if since:
+        sql += " AND timestamp >= ?"
+        params.append(since)
+    cursor = await db.execute(sql, params)
+    row = await cursor.fetchone()
+    return row["cnt"] if row else 0
+
+
+# ── eval_snapshots ───────────────────────────────────────────────────────────
+
+
+async def insert_snapshot(
+    db: aiosqlite.Connection,
+    *,
+    period_start: str,
+    period_end: str,
+    period_type: str,
+    dimension: str,
+    metrics: dict,
+    sample_count: int,
+) -> str:
+    """Insert a periodic aggregation snapshot. Returns the snapshot id."""
+    sid = _new_id()
+    await db.execute(
+        """INSERT INTO eval_snapshots
+           (id, period_start, period_end, period_type, dimension,
+            metrics_json, sample_count, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (sid, period_start, period_end, period_type, dimension,
+         json.dumps(metrics), sample_count, _now_iso()),
+    )
+    await db.commit()
+    return sid
+
+
+async def get_snapshots(
+    db: aiosqlite.Connection,
+    *,
+    dimension: str | None = None,
+    period_type: str | None = None,
+    since: str | None = None,
+    limit: int = 52,
+) -> list[dict]:
+    """Query snapshots, most recent first."""
+    sql = "SELECT * FROM eval_snapshots WHERE 1=1"
+    params: list = []
+    if dimension:
+        sql += " AND dimension = ?"
+        params.append(dimension)
+    if period_type:
+        sql += " AND period_type = ?"
+        params.append(period_type)
+    if since:
+        sql += " AND period_end >= ?"
+        params.append(since)
+    sql += " ORDER BY period_end DESC LIMIT ?"
+    params.append(limit)
+    cursor = await db.execute(sql, params)
+    rows = await cursor.fetchall()
+    result = []
+    for r in rows:
+        d = dict(r)
+        if d.get("metrics_json"):
+            d["metrics"] = json.loads(d["metrics_json"])
+        result.append(d)
+    return result
+
+
+async def get_latest_snapshot(
+    db: aiosqlite.Connection,
+    *,
+    dimension: str,
+    period_type: str = "weekly",
+) -> dict | None:
+    """Get the most recent snapshot for a dimension."""
+    cursor = await db.execute(
+        """SELECT * FROM eval_snapshots
+           WHERE dimension = ? AND period_type = ?
+           ORDER BY period_end DESC LIMIT 1""",
+        (dimension, period_type),
+    )
+    row = await cursor.fetchone()
+    if not row:
+        return None
+    d = dict(row)
+    if d.get("metrics_json"):
+        d["metrics"] = json.loads(d["metrics_json"])
+    return d

--- a/src/genesis/db/migrations/0011_j9_eval_tables.py
+++ b/src/genesis/db/migrations/0011_j9_eval_tables.py
@@ -1,0 +1,69 @@
+"""Add J-9 eval infrastructure tables.
+
+Supports the cognitive architecture paper's 5 eval dimensions:
+1. Memory retrieval quality (precision@K, MRR, hit rate)
+2. System improvement over time (composite metric)
+3. Ego proposal quality trajectory
+4. Cognitive loop value (recall vs no-recall)
+5. Procedural learning effectiveness
+
+Two tables:
+- eval_events: append-only event log for all measurable eval signals
+- eval_snapshots: periodic (daily/weekly) aggregated metrics
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute("""
+        CREATE TABLE IF NOT EXISTS eval_events (
+            id          TEXT PRIMARY KEY,
+            timestamp   TEXT NOT NULL,
+            dimension   TEXT NOT NULL
+                        CHECK (dimension IN (
+                            'memory', 'ego', 'procedure', 'cognitive', 'system'
+                        )),
+            event_type  TEXT NOT NULL,
+            subject_id  TEXT,
+            session_id  TEXT,
+            metrics_json TEXT NOT NULL,
+            created_at  TEXT NOT NULL
+                        DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        )
+    """)
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_eval_events_dimension "
+        "ON eval_events(dimension, timestamp)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_eval_events_type "
+        "ON eval_events(event_type, timestamp)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_eval_events_session "
+        "ON eval_events(session_id)"
+    )
+
+    await db.execute("""
+        CREATE TABLE IF NOT EXISTS eval_snapshots (
+            id           TEXT PRIMARY KEY,
+            period_start TEXT NOT NULL,
+            period_end   TEXT NOT NULL,
+            period_type  TEXT NOT NULL
+                         CHECK (period_type IN ('daily', 'weekly')),
+            dimension    TEXT NOT NULL,
+            metrics_json TEXT NOT NULL,
+            sample_count INTEGER NOT NULL,
+            created_at   TEXT NOT NULL
+                         DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        )
+    """)
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_eval_snapshots_period "
+        "ON eval_snapshots(dimension, period_end)"
+    )
+
+    await db.commit()

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -919,6 +919,36 @@ TABLES = {
             dispatched_at   TEXT
         )
     """,
+    "eval_events": """
+        CREATE TABLE IF NOT EXISTS eval_events (
+            id           TEXT PRIMARY KEY,
+            timestamp    TEXT NOT NULL,
+            dimension    TEXT NOT NULL
+                         CHECK (dimension IN (
+                             'memory', 'ego', 'procedure', 'cognitive', 'system'
+                         )),
+            event_type   TEXT NOT NULL,
+            subject_id   TEXT,
+            session_id   TEXT,
+            metrics_json TEXT NOT NULL,
+            created_at   TEXT NOT NULL
+                         DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        )
+    """,
+    "eval_snapshots": """
+        CREATE TABLE IF NOT EXISTS eval_snapshots (
+            id           TEXT PRIMARY KEY,
+            period_start TEXT NOT NULL,
+            period_end   TEXT NOT NULL,
+            period_type  TEXT NOT NULL
+                         CHECK (period_type IN ('daily', 'weekly')),
+            dimension    TEXT NOT NULL,
+            metrics_json TEXT NOT NULL,
+            sample_count INTEGER NOT NULL,
+            created_at   TEXT NOT NULL
+                         DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        )
+    """,
 }
 
 # FTS5 virtual tables (in-memory SQLite does NOT support FTS5 unless compiled with it)
@@ -1103,6 +1133,11 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_file_mod_ts ON file_modifications(timestamp)",
     # direct session queue
     "CREATE INDEX IF NOT EXISTS idx_dsq_status_created ON direct_session_queue(status, created_at)",
+    # J-9 eval infrastructure
+    "CREATE INDEX IF NOT EXISTS idx_eval_events_dimension ON eval_events(dimension, timestamp)",
+    "CREATE INDEX IF NOT EXISTS idx_eval_events_type ON eval_events(event_type, timestamp)",
+    "CREATE INDEX IF NOT EXISTS idx_eval_events_session ON eval_events(session_id)",
+    "CREATE INDEX IF NOT EXISTS idx_eval_snapshots_period ON eval_snapshots(dimension, period_end)",
 ]
 
 # ─── Seed Data ────────────────────────────────────────────────────────────────

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -282,6 +282,15 @@ class ProposalWorkflow:
                     prop["id"], status,
                     f" ({reason})" if reason else "",
                 )
+                # J-9 eval: log proposal resolution for ego quality tracking
+                from genesis.eval.j9_hooks import emit_proposal_resolved
+                await emit_proposal_resolved(
+                    self._db,
+                    proposal_id=prop["id"],
+                    status=status,
+                    confidence=prop.get("confidence"),
+                    action_type=prop.get("action_type"),
+                )
                 # Auto-store correction memory on rejection with reason
                 if (
                     status == ProposalStatus.REJECTED

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -1,0 +1,481 @@
+"""J-9 weekly eval aggregator — computes snapshots for all 5 dimensions.
+
+Runs on a weekly CronTrigger. Reads eval_events and existing DB tables
+to compute metrics for each dimension, stores results in eval_snapshots.
+
+Dimensions:
+1. Memory retrieval quality (precision@5, hit rate, MRR, usage rate)
+2. System improvement composite (session success, ego acceptance, etc.)
+3. Ego proposal quality (approval rate, confidence calibration)
+4. Cognitive loop value (recall vs no-recall session comparison)
+5. Procedural learning effectiveness (invocation rate, success rate)
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from genesis.db.crud import j9_eval
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+async def run_weekly_aggregation(db: aiosqlite.Connection) -> dict[str, dict]:
+    """Compute and store weekly snapshots for all 5 eval dimensions.
+
+    Returns dict of {dimension: metrics} for logging/inspection.
+    """
+    now = datetime.now(UTC)
+    period_end = now.isoformat()
+    period_start = (now - timedelta(days=7)).isoformat()
+
+    results: dict[str, dict] = {}
+
+    for name, fn in [
+        ("memory", _compute_memory_quality),
+        ("system", _compute_system_composite),
+        ("ego", _compute_ego_quality),
+        ("cognitive", _compute_cognitive_loop),
+        ("procedure", _compute_procedural_effectiveness),
+    ]:
+        try:
+            metrics, sample_count = await fn(db, period_start, period_end)
+            await j9_eval.insert_snapshot(
+                db,
+                period_start=period_start,
+                period_end=period_end,
+                period_type="weekly",
+                dimension=name,
+                metrics=metrics,
+                sample_count=sample_count,
+            )
+            results[name] = metrics
+            logger.info("J9 weekly %s: %d samples", name, sample_count)
+        except Exception:
+            logger.warning("J9 weekly %s aggregation failed", name, exc_info=True)
+
+    # Composite: trend analysis across prior weeks
+    try:
+        composite = await _compute_composite_trends(db)
+        await j9_eval.insert_snapshot(
+            db,
+            period_start=period_start,
+            period_end=period_end,
+            period_type="weekly",
+            dimension="composite",
+            metrics=composite,
+            sample_count=len(results),
+        )
+        results["composite"] = composite
+    except Exception:
+        logger.warning("J9 weekly composite failed", exc_info=True)
+
+    return results
+
+
+# ── Dimension 1: Memory Retrieval Quality ────────────────────────────────────
+
+
+async def _compute_memory_quality(
+    db: aiosqlite.Connection, since: str, until: str,
+) -> tuple[dict, int]:
+    """Precision@5, hit rate, MRR from recall_relevance events."""
+    relevance_events = await j9_eval.get_events(
+        db, dimension="memory", event_type="recall_relevance",
+        since=since, until=until, limit=5000,
+    )
+
+    if not relevance_events:
+        return {"precision_at_5": None, "hit_rate": None, "mrr": None,
+                "usage_rate": None, "total_recalls": 0}, 0
+
+    # Group by recall_event_id
+    by_recall: dict[str, list[dict]] = defaultdict(list)
+    for ev in relevance_events:
+        m = ev.get("metrics", {})
+        rid = m.get("recall_event_id", "")
+        if rid:
+            by_recall[rid].append(m)
+
+    # Compute per-recall metrics
+    precisions = []
+    mrrs = []
+    hits = 0
+    total_recalls = len(by_recall)
+
+    for _rid, memories in by_recall.items():
+        # Sort by original position (memory_ids order in recall_fired)
+        relevant_count = sum(1 for m in memories if m.get("relevance", 0) >= 0.5)
+        precisions.append(relevant_count / max(len(memories), 1))
+
+        # MRR: rank of first relevant result
+        found_relevant = False
+        for rank, m in enumerate(memories, 1):
+            if m.get("relevance", 0) >= 0.5:
+                mrrs.append(1.0 / rank)
+                found_relevant = True
+                hits += 1
+                break
+        if not found_relevant:
+            mrrs.append(0.0)
+
+    # Also check recall_used events for usage rate
+    used_events = await j9_eval.get_events(
+        db, dimension="memory", event_type="recall_used",
+        since=since, until=until, limit=5000,
+    )
+    total_used = sum(1 for ev in used_events if ev.get("metrics", {}).get("used"))
+    total_usage_checked = len(used_events)
+
+    metrics = {
+        "precision_at_5": round(sum(precisions) / len(precisions), 4) if precisions else None,
+        "hit_rate": round(hits / total_recalls, 4) if total_recalls else None,
+        "mrr": round(sum(mrrs) / len(mrrs), 4) if mrrs else None,
+        "usage_rate": round(total_used / total_usage_checked, 4) if total_usage_checked else None,
+        "total_recalls": total_recalls,
+        "total_memories_judged": len(relevance_events),
+    }
+    return metrics, total_recalls
+
+
+# ── Dimension 2: System Improvement Composite ────────────────────────────────
+
+
+async def _compute_system_composite(
+    db: aiosqlite.Connection, since: str, until: str,
+) -> tuple[dict, int]:
+    """Aggregate signals from cc_sessions, ego_proposals, observations, procedures."""
+    # Session success rate
+    cursor = await db.execute(
+        """SELECT
+            COUNT(*) as total,
+            SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
+            SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as failed
+        FROM cc_sessions
+        WHERE started_at >= ? AND started_at < ?""",
+        (since, until),
+    )
+    row = await cursor.fetchone()
+    session_total = row["total"] if row else 0
+    session_completed = row["completed"] if row else 0
+    session_success_pct = round(session_completed / session_total, 4) if session_total else None
+
+    # Ego acceptance rate
+    cursor = await db.execute(
+        """SELECT
+            COUNT(*) as total,
+            SUM(CASE WHEN status = 'approved' OR status = 'executed' THEN 1 ELSE 0 END) as accepted
+        FROM ego_proposals
+        WHERE created_at >= ? AND created_at < ?
+        AND status NOT IN ('pending', 'expired')""",
+        (since, until),
+    )
+    row = await cursor.fetchone()
+    ego_total = row["total"] if row else 0
+    ego_accepted = row["accepted"] if row else 0
+    ego_acceptance_pct = round(ego_accepted / ego_total, 4) if ego_total else None
+
+    # Observation influence rate
+    cursor = await db.execute(
+        """SELECT
+            COUNT(*) as total,
+            SUM(influenced_action) as influenced
+        FROM observations
+        WHERE created_at >= ? AND created_at < ?""",
+        (since, until),
+    )
+    row = await cursor.fetchone()
+    obs_total = row["total"] if row else 0
+    obs_influenced = row["influenced"] if row else 0
+    obs_influence_pct = round(obs_influenced / obs_total, 4) if obs_total else None
+
+    # Procedure mean confidence
+    cursor = await db.execute(
+        "SELECT AVG(confidence) as avg_conf FROM procedural_memory WHERE deprecated = 0",
+    )
+    row = await cursor.fetchone()
+    proc_mean_conf = round(row["avg_conf"], 4) if row and row["avg_conf"] else None
+
+    # Get memory precision from this week's snapshot (if computed already)
+    mem_snapshot = await j9_eval.get_latest_snapshot(db, dimension="memory")
+    mem_precision = mem_snapshot["metrics"].get("precision_at_5") if mem_snapshot else None
+
+    # Composite: simple average of available signals (weighted equally)
+    signals = [v for v in [session_success_pct, ego_acceptance_pct,
+                            obs_influence_pct, proc_mean_conf, mem_precision]
+               if v is not None]
+    composite = round(sum(signals) / len(signals), 4) if signals else None
+
+    sample_count = session_total + ego_total + obs_total
+
+    metrics = {
+        "session_success_pct": session_success_pct,
+        "session_total": session_total,
+        "ego_acceptance_pct": ego_acceptance_pct,
+        "ego_total": ego_total,
+        "observation_influence_pct": obs_influence_pct,
+        "observation_total": obs_total,
+        "procedure_mean_confidence": proc_mean_conf,
+        "memory_precision_at5": mem_precision,
+        "composite_score": composite,
+    }
+    return metrics, sample_count
+
+
+# ── Dimension 3: Ego Proposal Quality ────────────────────────────────────────
+
+
+async def _compute_ego_quality(
+    db: aiosqlite.Connection, since: str, until: str,
+) -> tuple[dict, int]:
+    """Approval rate, execution success, confidence calibration."""
+    cursor = await db.execute(
+        """SELECT id, status, confidence, action_type
+        FROM ego_proposals
+        WHERE created_at >= ? AND created_at < ?""",
+        (since, until),
+    )
+    proposals = [dict(r) for r in await cursor.fetchall()]
+    total = len(proposals)
+
+    if not total:
+        return {"approval_rate": None, "execution_success_rate": None,
+                "confidence_calibration": {}, "total_proposals": 0}, 0
+
+    # Approval rate (resolved proposals only)
+    resolved = [p for p in proposals if p["status"] not in ("pending", "expired")]
+    approved = [p for p in resolved if p["status"] in ("approved", "executed")]
+    approval_rate = round(len(approved) / len(resolved), 4) if resolved else None
+
+    # Execution success rate
+    executed = [p for p in proposals if p["status"] == "executed"]
+    failed = [p for p in proposals if p["status"] == "failed"]
+    exec_total = len(executed) + len(failed)
+    exec_success = round(len(executed) / exec_total, 4) if exec_total else None
+
+    # Confidence calibration: bin by confidence decile
+    calibration: dict[str, dict] = {}
+    for bucket_low in [0.0, 0.2, 0.4, 0.6, 0.8]:
+        bucket_high = bucket_low + 0.2
+        label = f"{bucket_low:.1f}-{bucket_high:.1f}"
+        in_bucket = [p for p in resolved
+                     if p.get("confidence") is not None
+                     and bucket_low <= p["confidence"] < bucket_high]
+        if in_bucket:
+            bucket_approved = [p for p in in_bucket
+                               if p["status"] in ("approved", "executed")]
+            calibration[label] = {
+                "count": len(in_bucket),
+                "success_rate": round(len(bucket_approved) / len(in_bucket), 4),
+            }
+
+    metrics = {
+        "approval_rate": approval_rate,
+        "execution_success_rate": exec_success,
+        "confidence_calibration": calibration,
+        "total_proposals": total,
+        "total_resolved": len(resolved),
+    }
+    return metrics, total
+
+
+# ── Dimension 4: Cognitive Loop Value ────────────────────────────────────────
+
+
+async def _compute_cognitive_loop(
+    db: aiosqlite.Connection, since: str, until: str,
+) -> tuple[dict, int]:
+    """Compare sessions with proactive recall vs without."""
+    # Get all sessions in the window
+    cursor = await db.execute(
+        """SELECT id, status, started_at, completed_at
+        FROM cc_sessions
+        WHERE started_at >= ? AND started_at < ?""",
+        (since, until),
+    )
+    sessions = [dict(r) for r in await cursor.fetchall()]
+
+    if not sessions:
+        return {"sessions_with_recall": 0, "sessions_without_recall": 0,
+                "success_rate_with": None, "success_rate_without": None,
+                "delta": None}, 0
+
+    # Find which sessions had recall_fired events
+    recall_events = await j9_eval.get_events(
+        db, dimension="memory", event_type="recall_fired",
+        since=since, until=until, limit=5000,
+    )
+    sessions_with_recall = {ev.get("session_id") for ev in recall_events
+                            if ev.get("session_id")}
+
+    with_recall = [s for s in sessions if s["id"] in sessions_with_recall]
+    without_recall = [s for s in sessions if s["id"] not in sessions_with_recall]
+
+    def _success_rate(session_list: list[dict]) -> float | None:
+        if not session_list:
+            return None
+        completed = sum(1 for s in session_list if s["status"] == "completed")
+        return round(completed / len(session_list), 4)
+
+    rate_with = _success_rate(with_recall)
+    rate_without = _success_rate(without_recall)
+
+    delta = None
+    if rate_with is not None and rate_without is not None:
+        delta = round(rate_with - rate_without, 4)
+
+    metrics = {
+        "sessions_with_recall": len(with_recall),
+        "sessions_without_recall": len(without_recall),
+        "success_rate_with": rate_with,
+        "success_rate_without": rate_without,
+        "delta": delta,
+    }
+    return metrics, len(sessions)
+
+
+# ── Dimension 5: Procedural Learning Effectiveness ───────────────────────────
+
+
+async def _compute_procedural_effectiveness(
+    db: aiosqlite.Connection, since: str, until: str,
+) -> tuple[dict, int]:
+    """Invocation frequency, success rate, confidence calibration."""
+    # Invocation events
+    invocations = await j9_eval.get_events(
+        db, dimension="procedure", event_type="procedure_invoked",
+        since=since, until=until, limit=1000,
+    )
+    invocation_count = len(invocations)
+
+    # Outcome events
+    outcomes = await j9_eval.get_events(
+        db, dimension="procedure", event_type="procedure_outcome",
+        since=since, until=until, limit=1000,
+    )
+    successes = sum(1 for o in outcomes if o.get("metrics", {}).get("success"))
+    outcome_total = len(outcomes)
+    success_rate = round(successes / outcome_total, 4) if outcome_total else None
+
+    # Overall procedure stats
+    cursor = await db.execute(
+        """SELECT COUNT(*) as total, AVG(confidence) as avg_conf
+        FROM procedural_memory WHERE deprecated = 0""",
+    )
+    row = await cursor.fetchone()
+    total_procedures = row["total"] if row else 0
+    mean_confidence = round(row["avg_conf"], 4) if row and row["avg_conf"] else None
+
+    # Tier distribution
+    cursor = await db.execute(
+        """SELECT activation_tier, COUNT(*) as cnt
+        FROM procedural_memory WHERE deprecated = 0
+        GROUP BY activation_tier""",
+    )
+    tiers = {r["activation_tier"]: r["cnt"] for r in await cursor.fetchall()}
+
+    # Confidence calibration from outcome events
+    calibration: dict[str, dict] = {}
+    for o in outcomes:
+        m = o.get("metrics", {})
+        conf = m.get("confidence_after")
+        success = m.get("success", False)
+        if conf is not None:
+            bucket = f"{int(conf * 10) / 10:.1f}"
+            if bucket not in calibration:
+                calibration[bucket] = {"total": 0, "success": 0}
+            calibration[bucket]["total"] += 1
+            if success:
+                calibration[bucket]["success"] += 1
+    for bucket in calibration:
+        calibration[bucket]["rate"] = round(
+            calibration[bucket]["success"] / calibration[bucket]["total"], 4,
+        )
+
+    metrics = {
+        "invocation_count": invocation_count,
+        "outcome_count": outcome_total,
+        "success_rate": success_rate,
+        "mean_confidence": mean_confidence,
+        "total_procedures": total_procedures,
+        "tier_distribution": tiers,
+        "confidence_calibration": calibration,
+    }
+    return metrics, invocation_count + outcome_total
+
+
+# ── Composite Trends ─────────────────────────────────────────────────────────
+
+
+async def _compute_composite_trends(db: aiosqlite.Connection) -> dict:
+    """Compute slopes across prior weekly snapshots for GO/NO-GO criteria."""
+    # Get up to 12 weeks of history per dimension
+    dimensions = ["memory", "system", "ego", "cognitive", "procedure"]
+    trends: dict[str, list[float]] = {}
+
+    for dim in dimensions:
+        snapshots = await j9_eval.get_snapshots(
+            db, dimension=dim, period_type="weekly", limit=12,
+        )
+        snapshots.reverse()  # oldest first
+        trends[dim] = _extract_trend_values(dim, snapshots)
+
+    # Compute slopes via simple linear regression
+    slopes: dict[str, float | None] = {}
+    for dim, values in trends.items():
+        slopes[f"{dim}_slope"] = _simple_slope(values) if len(values) >= 2 else None
+
+    # GO/NO-GO criteria check
+    go_count = 0
+    if slopes.get("memory_slope") is not None and slopes["memory_slope"] > 0:
+        go_count += 1
+    if slopes.get("system_slope") is not None and slopes["system_slope"] > 0:
+        go_count += 1
+    if slopes.get("ego_slope") is not None and slopes["ego_slope"] > 0:
+        go_count += 1
+    if slopes.get("cognitive_slope") is not None and slopes["cognitive_slope"] > 0:
+        go_count += 1
+
+    return {
+        **slopes,
+        "weeks_of_data": max(len(v) for v in trends.values()) if trends else 0,
+        "go_criteria_met": go_count,
+        "go_ready": go_count >= 2,
+    }
+
+
+def _extract_trend_values(dimension: str, snapshots: list[dict]) -> list[float]:
+    """Extract the key metric for trend tracking from each snapshot."""
+    key_metric = {
+        "memory": "precision_at_5",
+        "system": "composite_score",
+        "ego": "approval_rate",
+        "cognitive": "delta",
+        "procedure": "success_rate",
+    }.get(dimension, "composite_score")
+
+    values = []
+    for s in snapshots:
+        m = s.get("metrics", {})
+        v = m.get(key_metric)
+        if v is not None:
+            values.append(float(v))
+    return values
+
+
+def _simple_slope(values: list[float]) -> float | None:
+    """Simple linear regression slope over equally-spaced values."""
+    n = len(values)
+    if n < 2:
+        return None
+    x_mean = (n - 1) / 2.0
+    y_mean = sum(values) / n
+    numerator = sum((i - x_mean) * (v - y_mean) for i, v in enumerate(values))
+    denominator = sum((i - x_mean) ** 2 for i in range(n))
+    return round(numerator / denominator, 6) if denominator else None

--- a/src/genesis/eval/j9_batch.py
+++ b/src/genesis/eval/j9_batch.py
@@ -1,0 +1,164 @@
+"""J-9 daily eval batch — LLM-judged memory relevance scoring.
+
+Runs as a surplus task. For each recall_fired event from the past 24h,
+asks a cheap model to judge whether each recalled memory was relevant
+to the query. Stores recall_relevance events.
+
+Cost: ~50K tokens/day at Haiku ≈ $0.04/day.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import litellm
+
+from genesis.db.crud import j9_eval
+from genesis.surplus.types import ExecutorResult, SurplusTask
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+# Model for relevance judgments — cheap and fast
+_JUDGE_MODEL = "claude-haiku-4-5-20251001"
+
+_RELEVANCE_PROMPT = """\
+You are judging whether a recalled memory is relevant to a query.
+
+Query: {query}
+
+Memory content: {memory_content}
+
+Rate the relevance from 0.0 (completely irrelevant) to 1.0 (highly relevant).
+A memory is relevant if it provides useful context, background, or information
+that would help someone respond to the query.
+
+Respond with ONLY a JSON object: {{"relevance": <float>, "rationale": "<brief reason>"}}"""
+
+
+class J9EvalBatchExecutor:
+    """Surplus executor for J9_EVAL_BATCH tasks.
+
+    Scores memory recall relevance for the past 24 hours.
+    """
+
+    def __init__(self, *, db: aiosqlite.Connection | None = None) -> None:
+        self._db = db
+
+    async def execute(self, task: SurplusTask) -> ExecutorResult:
+        if self._db is None:
+            return ExecutorResult(success=False, error="no db connection")
+
+        since = (datetime.now(UTC) - timedelta(hours=24)).isoformat()
+        recall_events = await j9_eval.get_events(
+            self._db,
+            dimension="memory",
+            event_type="recall_fired",
+            since=since,
+            limit=200,
+        )
+
+        if not recall_events:
+            return ExecutorResult(
+                success=True,
+                content="J9 eval batch: no recall events in past 24h",
+            )
+
+        scored = 0
+        errors = 0
+
+        for event in recall_events:
+            metrics = event.get("metrics", {})
+            query = metrics.get("query", "")
+            memory_ids = metrics.get("memory_ids", [])
+
+            if not query or not memory_ids:
+                continue
+
+            # Fetch memory content for each recalled memory
+            for mid in memory_ids[:5]:  # Cap at top-5 per recall
+                content = await self._get_memory_content(mid)
+                if not content:
+                    continue
+
+                relevance, rationale = await self._judge_relevance(query, content)
+                if relevance is not None:
+                    await j9_eval.insert_event(
+                        self._db,
+                        dimension="memory",
+                        event_type="recall_relevance",
+                        subject_id=mid,
+                        session_id=event.get("session_id"),
+                        metrics={
+                            "recall_event_id": event["id"],
+                            "memory_id": mid,
+                            "relevance": relevance,
+                            "judge_rationale": rationale,
+                            "judge_model": _JUDGE_MODEL,
+                        },
+                    )
+                    scored += 1
+                else:
+                    errors += 1
+
+        content = f"J9 eval batch: scored {scored} memory-query pairs ({errors} errors)"
+        return ExecutorResult(
+            success=True,
+            content=content,
+            insights=[{
+                "content": content,
+                "source_task_type": task.task_type,
+                "generating_model": _JUDGE_MODEL,
+                "drive_alignment": "competence",
+                "confidence": 0.8 if errors == 0 else 0.6,
+            }],
+        )
+
+    async def _get_memory_content(self, memory_id: str) -> str | None:
+        """Fetch memory content from Qdrant payload or FTS5."""
+        if self._db is None:
+            return None
+        try:
+            cursor = await self._db.execute(
+                "SELECT content FROM memory_fts WHERE memory_id = ? LIMIT 1",
+                (memory_id,),
+            )
+            row = await cursor.fetchone()
+            if row:
+                return row[0] if isinstance(row, tuple) else row["content"]
+        except Exception:
+            logger.debug("Failed to fetch memory %s from FTS5", memory_id)
+        return None
+
+    async def _judge_relevance(
+        self, query: str, memory_content: str,
+    ) -> tuple[float | None, str]:
+        """Ask the judge model to score relevance."""
+        prompt = _RELEVANCE_PROMPT.format(
+            query=query[:500],
+            memory_content=memory_content[:1000],
+        )
+        try:
+            response = await litellm.acompletion(
+                model=_JUDGE_MODEL,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=150,
+                temperature=0.0,
+            )
+            text = response.choices[0].message.content or ""
+            # Parse JSON response
+            parsed = json.loads(text.strip())
+            relevance = float(parsed.get("relevance", 0.0))
+            rationale = parsed.get("rationale", "")
+            return (max(0.0, min(1.0, relevance)), rationale)
+        except (json.JSONDecodeError, KeyError, ValueError) as exc:
+            logger.debug("J9 relevance parse error: %s", exc)
+            return (None, str(exc))
+        except Exception as exc:
+            logger.debug("J9 relevance LLM error: %s", exc)
+            return (None, str(exc))

--- a/src/genesis/eval/j9_hooks.py
+++ b/src/genesis/eval/j9_hooks.py
@@ -1,0 +1,120 @@
+"""Lightweight eval event emitters for J-9 instrumentation.
+
+Each function is fire-and-forget — errors are logged but never propagate
+to the caller. This ensures eval instrumentation cannot break production
+code paths.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import aiosqlite
+
+from genesis.db.crud import j9_eval
+
+logger = logging.getLogger(__name__)
+
+
+async def emit_recall_fired(
+    db: aiosqlite.Connection,
+    *,
+    query: str,
+    result_count: int,
+    top_scores: list[float],
+    memory_ids: list[str],
+    latency_ms: float,
+    source: str,
+    session_id: str | None = None,
+) -> None:
+    """Log a memory recall() invocation as an eval event."""
+    try:
+        await j9_eval.insert_event(
+            db,
+            dimension="memory",
+            event_type="recall_fired",
+            session_id=session_id,
+            metrics={
+                "query": query[:500],
+                "result_count": result_count,
+                "top_scores": top_scores[:10],
+                "memory_ids": memory_ids[:10],
+                "latency_ms": round(latency_ms, 1),
+                "source": source,
+            },
+        )
+    except Exception:
+        logger.debug("eval: failed to emit recall_fired", exc_info=True)
+
+
+async def emit_proposal_resolved(
+    db: aiosqlite.Connection,
+    *,
+    proposal_id: str,
+    status: str,
+    confidence: float | None = None,
+    action_type: str | None = None,
+) -> None:
+    """Log an ego proposal resolution (approved/rejected/etc)."""
+    try:
+        await j9_eval.insert_event(
+            db,
+            dimension="ego",
+            event_type="proposal_resolved",
+            subject_id=proposal_id,
+            metrics={
+                "status": status,
+                "confidence": confidence,
+                "action_type": action_type,
+            },
+        )
+    except Exception:
+        logger.debug("eval: failed to emit proposal_resolved", exc_info=True)
+
+
+async def emit_procedure_invoked(
+    db: aiosqlite.Connection,
+    *,
+    procedure_id: str,
+    confidence: float,
+    matched_tags: list[str],
+    session_id: str | None = None,
+) -> None:
+    """Log a procedure recall invocation."""
+    try:
+        await j9_eval.insert_event(
+            db,
+            dimension="procedure",
+            event_type="procedure_invoked",
+            subject_id=procedure_id,
+            session_id=session_id,
+            metrics={
+                "confidence_at_invoke": confidence,
+                "matched_tags": matched_tags[:10],
+            },
+        )
+    except Exception:
+        logger.debug("eval: failed to emit procedure_invoked", exc_info=True)
+
+
+async def emit_procedure_outcome(
+    db: aiosqlite.Connection,
+    *,
+    procedure_id: str,
+    success: bool,
+    confidence_after: float,
+) -> None:
+    """Log a procedure success/failure outcome."""
+    try:
+        await j9_eval.insert_event(
+            db,
+            dimension="procedure",
+            event_type="procedure_outcome",
+            subject_id=procedure_id,
+            metrics={
+                "success": success,
+                "confidence_after": confidence_after,
+            },
+        )
+    except Exception:
+        logger.debug("eval: failed to emit procedure_outcome", exc_info=True)

--- a/src/genesis/learning/procedural/operations.py
+++ b/src/genesis/learning/procedural/operations.py
@@ -176,12 +176,20 @@ async def record_success(db: aiosqlite.Connection, procedure_id: str) -> bool:
     f = row["failure_count"]
     confidence = (s + 1) / (s + f + 2)
     now = datetime.now(UTC).isoformat()
-    return await procedural.update(
+    result = await procedural.update(
         db, procedure_id,
         success_count=s,
         confidence=confidence,
         last_used=now,
     )
+    # J-9 eval: log procedure outcome
+    if result:
+        from genesis.eval.j9_hooks import emit_procedure_outcome
+        await emit_procedure_outcome(
+            db, procedure_id=procedure_id, success=True,
+            confidence_after=confidence,
+        )
+    return result
 
 
 async def record_failure(
@@ -212,13 +220,21 @@ async def record_failure(
             "transient": transient,
         })
 
-    return await procedural.update(
+    result = await procedural.update(
         db, procedure_id,
         failure_count=f,
         failure_modes=modes,
         confidence=confidence,
         last_used=datetime.now(UTC).isoformat(),
     )
+    # J-9 eval: log procedure outcome
+    if result:
+        from genesis.eval.j9_hooks import emit_procedure_outcome
+        await emit_procedure_outcome(
+            db, procedure_id=procedure_id, success=False,
+            confidence_after=confidence,
+        )
+    return result
 
 
 async def record_workaround(

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -62,6 +62,7 @@ from genesis.mcp.health import db_schema as _db_schema  # noqa: E402
 from genesis.mcp.health import direct_session_tools as _direct_session_tools  # noqa: E402
 from genesis.mcp.health import errors as _errors  # noqa: E402
 from genesis.mcp.health import follow_up_tools as _follow_up_tools  # noqa: E402
+from genesis.mcp.health import j9_eval as _j9_eval  # noqa: E402, F401
 from genesis.mcp.health import manifest as _manifest  # noqa: E402
 from genesis.mcp.health import module_ops as _module_ops  # noqa: E402
 from genesis.mcp.health import provider as _provider  # noqa: E402

--- a/src/genesis/mcp/health/j9_eval.py
+++ b/src/genesis/mcp/health/j9_eval.py
@@ -1,0 +1,64 @@
+"""J-9 eval status MCP tool — quick overview of eval data collection progress."""
+
+from __future__ import annotations
+
+import logging
+
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+
+async def _impl_j9_eval_status() -> dict:
+    """Get J-9 eval collection status across all 5 dimensions."""
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    _service = health_mcp_mod._service
+    if _service is None or _service._db is None:
+        return {"status": "unavailable", "message": "DB not initialized"}
+
+    db = _service._db
+
+    from genesis.db.crud import j9_eval
+
+    # Count events by dimension
+    dimensions = ["memory", "ego", "procedure", "cognitive", "system"]
+    event_counts: dict[str, int] = {}
+    for dim in dimensions:
+        event_counts[dim] = await j9_eval.count_events(db, dimension=dim)
+
+    # Get latest snapshot per dimension
+    latest_snapshots: dict[str, dict | None] = {}
+    for dim in [*dimensions, "composite"]:
+        snap = await j9_eval.get_latest_snapshot(db, dimension=dim)
+        if snap:
+            latest_snapshots[dim] = {
+                "period_end": snap["period_end"],
+                "sample_count": snap["sample_count"],
+                "metrics": snap.get("metrics", {}),
+            }
+        else:
+            latest_snapshots[dim] = None
+
+    # GO/NO-GO status from composite
+    composite = latest_snapshots.get("composite")
+    go_status = None
+    if composite and composite.get("metrics"):
+        go_status = {
+            "criteria_met": composite["metrics"].get("go_criteria_met", 0),
+            "go_ready": composite["metrics"].get("go_ready", False),
+            "weeks_of_data": composite["metrics"].get("weeks_of_data", 0),
+        }
+
+    return {
+        "event_counts": event_counts,
+        "total_events": sum(event_counts.values()),
+        "latest_snapshots": latest_snapshots,
+        "go_status": go_status,
+    }
+
+
+@mcp.tool()
+async def j9_eval_status() -> dict:
+    """J-9 paper eval progress: event counts, latest snapshots, GO/NO-GO status."""
+    return await _impl_j9_eval_status()

--- a/src/genesis/mcp/memory/procedural.py
+++ b/src/genesis/mcp/memory/procedural.py
@@ -93,4 +93,15 @@ async def procedure_recall(
         if len(results) >= 3:
             break
 
+    # J-9 eval: log procedure invocations for learning effectiveness tracking
+    if results:
+        from genesis.eval.j9_hooks import emit_procedure_invoked
+        for r in results:
+            await emit_procedure_invoked(
+                memory_mod._db,
+                procedure_id=r.get("procedure_id", ""),
+                confidence=r.get("confidence", 0.0),
+                matched_tags=tags[:10] if tags else [],
+            )
+
     return results

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from datetime import UTC, datetime
 
 import aiosqlite
@@ -64,6 +65,7 @@ class HybridRetriever:
         room: str | None = None,
     ) -> list[RetrievalResult]:
         """Hybrid retrieval: Qdrant + FTS5 + activation, fused via RRF."""
+        _t0 = time.monotonic()
         if source not in _SOURCE_TO_COLLECTIONS:
             msg = f"source must be one of {list(_SOURCE_TO_COLLECTIONS)}, got {source!r}"
             raise ValueError(msg)
@@ -343,5 +345,17 @@ class HybridRetriever:
                     intent_confidence=intent.confidence,
                 ),
             )
+
+        # J-9 eval: log recall event for memory retrieval quality measurement
+        from genesis.eval.j9_hooks import emit_recall_fired
+        await emit_recall_fired(
+            self._db,
+            query=query,
+            result_count=len(results),
+            top_scores=[r.score for r in results[:5]],
+            memory_ids=[r.memory_id for r in results[:10]],
+            latency_ms=(time.monotonic() - _t0) * 1000,
+            source=source,
+        )
 
         return results

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -703,6 +703,26 @@ async def init(rt: GenesisRuntime) -> None:
             misfire_grace_time=3600,
         )
 
+        # J-9 eval weekly aggregation (Sundays 5am — after skill evolution)
+        async def _run_j9_eval_aggregation():
+            try:
+                from genesis.eval.j9_aggregator import run_weekly_aggregation
+                results = await run_weekly_aggregation(rt._db)
+                dims_computed = len(results)
+                logger.info("J9 weekly aggregation: %d dimensions computed", dims_computed)
+                rt.record_job_success("j9_eval_aggregation")
+            except Exception as exc:
+                rt.record_job_failure("j9_eval_aggregation", str(exc))
+                logger.exception("J9 weekly aggregation failed")
+
+        rt._learning_scheduler.add_job(
+            _run_j9_eval_aggregation,
+            CronTrigger(day_of_week="sun", hour=5, minute=0),
+            id="j9_eval_aggregation",
+            max_instances=1,
+            misfire_grace_time=3600,
+        )
+
         rt._learning_scheduler.start()
         logger.info("Genesis learning scheduler started")
 

--- a/src/genesis/runtime/init/surplus.py
+++ b/src/genesis/runtime/init/surplus.py
@@ -169,6 +169,19 @@ async def init(rt: GenesisRuntime) -> None:
             logger.error("Unexpected error wiring ModelEvalExecutor", exc_info=True)
             await _degraded(rt, "ModelEvalExecutor")
 
+        # J-9 eval batch executor (daily memory relevance scoring)
+        try:
+            from genesis.eval.j9_batch import J9EvalBatchExecutor
+            j9_executor = J9EvalBatchExecutor(db=rt._db)
+            rt._surplus_scheduler.set_j9_eval_batch_executor(j9_executor)
+            logger.info("J9EvalBatchExecutor wired to surplus scheduler")
+        except (ImportError, AttributeError):
+            logger.error("Failed to wire J9EvalBatchExecutor", exc_info=True)
+            await _degraded(rt, "J9EvalBatchExecutor")
+        except Exception:
+            logger.error("Unexpected error wiring J9EvalBatchExecutor", exc_info=True)
+            await _degraded(rt, "J9EvalBatchExecutor")
+
         try:
             from genesis.surplus.maintenance import (
                 BackupVerificationExecutor,

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -85,6 +85,7 @@ class SurplusScheduler:
         self._code_index_executor: SurplusExecutor | None = None
         self._bookmark_enrichment_executor: SurplusExecutor | None = None
         self._model_eval_executor: SurplusExecutor | None = None
+        self._j9_eval_batch_executor: SurplusExecutor | None = None
         self._disk_cleanup_executor: SurplusExecutor | None = None
         self._backup_verification_executor: SurplusExecutor | None = None
         self._dead_letter_replay_executor: SurplusExecutor | None = None
@@ -125,6 +126,10 @@ class SurplusScheduler:
     def set_model_eval_executor(self, executor: SurplusExecutor) -> None:
         """Set a dedicated executor for MODEL_EVAL tasks."""
         self._model_eval_executor = executor
+
+    def set_j9_eval_batch_executor(self, executor: SurplusExecutor) -> None:
+        """Set executor for J9_EVAL_BATCH tasks (daily memory relevance scoring)."""
+        self._j9_eval_batch_executor = executor
 
     def set_maintenance_executors(
         self,
@@ -616,6 +621,8 @@ class SurplusScheduler:
             executor = self._dead_letter_replay_executor
         elif task.task_type == _TT.DB_MAINTENANCE and self._db_maintenance_executor is not None:
             executor = self._db_maintenance_executor
+        elif task.task_type == _TT.J9_EVAL_BATCH and self._j9_eval_batch_executor is not None:
+            executor = self._j9_eval_batch_executor
 
         try:
             result = await executor.execute(task)

--- a/src/genesis/surplus/types.py
+++ b/src/genesis/surplus/types.py
@@ -31,6 +31,8 @@ class TaskType(StrEnum):
     DB_MAINTENANCE = "db_maintenance"
     DEAD_LETTER_REPLAY = "dead_letter_replay"
     BACKUP_VERIFICATION = "backup_verification"
+    # J-9 paper eval infrastructure
+    J9_EVAL_BATCH = "j9_eval_batch"
 
 
 class ComputeTier(StrEnum):


### PR DESCRIPTION
## Summary
- Adds eval infrastructure for the J-9 arXiv paper on cognitive architecture
- Two new tables (`eval_events`, `eval_snapshots`) for longitudinal measurement
- Runtime hooks at 4 integration points: memory recall, ego proposals, procedure invocations, procedure outcomes
- Daily Haiku batch (surplus executor) scores memory relevance (~$0.04/day)
- Weekly aggregation computes 5 eval dimensions + composite trends with GO/NO-GO criteria
- MCP tool (`j9_eval_status`) for checking collection progress

## Eval Dimensions
1. **Memory retrieval quality** — precision@5, hit rate, MRR from LLM-judged relevance
2. **System improvement** — composite from session success, ego acceptance, observation influence
3. **Ego proposal quality** — approval rate, execution success, confidence calibration
4. **Cognitive loop value** — session success delta (recall vs no-recall)
5. **Procedural learning** — invocation frequency, success rate, tier distribution

## Cost Profile
- Runtime: ~2ms added to memory recall path (SQLite insert on 500ms path)
- Daily batch: ~50K tokens/day Haiku (~$0.04/day = $1.20/month)
- Zero new real-time LLM call sites

## Test plan
- [x] `ruff check` passes on all modified files
- [x] `pytest` passes (291/291 eval+surplus tests, 399/400 full suite — 1 pre-existing failure)
- [ ] Run migration on production DB
- [ ] Verify eval_events appear after memory recall
- [ ] Verify weekly aggregation produces snapshots
- [ ] Verify `j9_eval_status` MCP tool returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)