### PR TITLE
fix(routing): route knowledge distillation via OpenRouter Haiku

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -51,6 +51,13 @@ providers:
     free: true
     rpm_limit: 20
     open_duration_s: 120
+  openrouter-haiku:
+    type: openrouter
+    model: anthropic/claude-haiku-4.5
+    profile: claude-haiku-4.5
+    free: false
+    rpm_limit: 20
+    open_duration_s: 120
   # ── Phase 2 providers (gated on eval before chain promotion) ──
   cerebras-qwen:
     type: cerebras
@@ -428,7 +435,7 @@ call_sites:
     description: "Proactive infrastructure monitoring \u2014 trend detection and forecasting"
   40_knowledge_distillation:
     chain:
-    - claude-haiku
+    - openrouter-haiku
     - mistral-large-free
     - groq-free
     - gemini-free


### PR DESCRIPTION
## Summary

- No `ANTHROPIC_API_KEY` configured — direct `claude-haiku` provider fails auth
- Add `openrouter-haiku` provider using existing OpenRouter credentials
- Route `40_knowledge_distillation` through it (verified: `anthropic/claude-haiku-4.5` works)
- Other call sites using `claude-haiku` (e.g., `8_ego_compaction`) are NOT changed

## Test plan

- [x] Verified `openrouter/anthropic/claude-haiku-4.5` returns successful completions
- [x] Only `40_knowledge_distillation` chain changed