### PR TITLE
fix(cc): isolate background session transcripts from resume picker

### DIFF
--- a/src/genesis/autonomy/executor/research.py
+++ b/src/genesis/autonomy/executor/research.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from genesis.autonomy.executor.types import ResearchResult
-from genesis.cc.types import CCInvocation, CCModel, CCOutput, EffortLevel
+from genesis.cc.types import CCInvocation, CCModel, CCOutput, EffortLevel, background_session_dir
 
 logger = logging.getLogger(__name__)
 
@@ -128,6 +128,7 @@ class DeepResearcherImpl:
             append_system_prompt=True,
             mcp_config=mcp_config,
             timeout_s=1800,  # 30 min max for research
+            working_dir=background_session_dir(),
             skip_permissions=True,
             disallowed_tools=[
                 "Bash", "Edit", "Write", "NotebookEdit",

--- a/src/genesis/autonomy/executor/review.py
+++ b/src/genesis/autonomy/executor/review.py
@@ -143,13 +143,14 @@ class TaskReviewer:
 
     async def _review_plan_via_invoker(self, prompt: str) -> str | None:
         """Run plan review via CC invoker (Opus). Returns text or None."""
-        from genesis.cc.types import CCInvocation, CCModel, EffortLevel
+        from genesis.cc.types import CCInvocation, CCModel, EffortLevel, background_session_dir
 
         invocation = CCInvocation(
             prompt=prompt,
             model=CCModel.OPUS,
             effort=EffortLevel.HIGH,
             timeout_s=600,
+            working_dir=background_session_dir(),
             skip_permissions=True,
         )
         output = await self._invoker.run(invocation)
@@ -374,14 +375,14 @@ class TaskReviewer:
         prompt = self._build_active_verify_prompt(deliverable, requirements)
 
         try:
-            from genesis.cc.types import CCInvocation, CCModel, EffortLevel
+            from genesis.cc.types import CCInvocation, CCModel, EffortLevel, background_session_dir
 
             invocation = CCInvocation(
                 prompt=prompt,
                 model=CCModel.SONNET,
                 effort=EffortLevel.HIGH,
                 skip_permissions=True,
-                working_dir=str(worktree_path) if worktree_path else None,
+                working_dir=str(worktree_path) if worktree_path else background_session_dir(),
             )
             output = await self._invoker.run(invocation)
             if output.is_error:

--- a/src/genesis/autonomy/executor/step_dispatcher.py
+++ b/src/genesis/autonomy/executor/step_dispatcher.py
@@ -124,7 +124,7 @@ class StepDispatcher:
         All V3 steps use CC sessions. Multi-model router dispatch
         for research/analysis steps is deferred to V4.
         """
-        from genesis.cc.types import CCInvocation, CCModel, EffortLevel
+        from genesis.cc.types import CCInvocation, CCModel, EffortLevel, background_session_dir
 
         step_idx = step["idx"]
         step_type_str = step.get("type", "code")
@@ -150,6 +150,8 @@ class StepDispatcher:
         working_dir: str | None = None
         if worktree_path and step_type == StepType.CODE:
             working_dir = str(worktree_path)
+        else:
+            working_dir = background_session_dir()
 
         # Effort: HIGH for code/verification, MEDIUM otherwise
         effort = (

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -905,7 +905,13 @@ class SentinelDispatcher:
 
     async def _dispatch_cc_session(self, request: SentinelRequest) -> SentinelResult:
         """Dispatch the actual CC background session."""
-        from genesis.cc.types import CCInvocation, CCModel, EffortLevel, SessionType
+        from genesis.cc.types import (
+            CCInvocation,
+            CCModel,
+            EffortLevel,
+            SessionType,
+            background_session_dir,
+        )
 
         # Assemble diagnostic context
         health_snapshot = None
@@ -965,6 +971,7 @@ class SentinelDispatcher:
                 append_system_prompt=True,
                 output_format="text",
                 mcp_config=mcp_path,
+                working_dir=background_session_dir(),
             )
 
             output = await self._invoker.run(invocation)


### PR DESCRIPTION
## Summary
- Add `working_dir=background_session_dir()` to 4 CC session call sites that were missing it
- Affected: autonomy research executor, autonomy plan reviewer, sentinel dispatcher, step dispatcher (non-CODE steps)
- These sessions were creating transcripts in the main project directory, polluting the `/resume` picker with background noise

## Test plan
- [x] `ruff check` passes on all 4 files
- [x] `pytest tests/test_autonomy/` — 606 passed (3 pre-existing failures unrelated)
- [ ] After deploy: `/resume` no longer shows autonomy/sentinel background sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)