### PR TITLE
fix(knowledge): add transaction safety to _store_units batch commit

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -435,7 +435,7 @@ call_sites:
     description: "Proactive infrastructure monitoring \u2014 trend detection and forecasting"
   40_knowledge_distillation:
     chain:
-    - openrouter-haiku
+    # - openrouter-haiku  # credits exhausted 2026-05-08
     - mistral-large-free
     - groq-free
     - gemini-free

--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -130,10 +130,19 @@ class KnowledgeOrchestrator:
             )
 
         # 7. Store each unit
-        unit_ids = await self._store_units(
-            units, project_type=project_type, source=source,
-            content=content, purpose=purpose,
-        )
+        try:
+            unit_ids = await self._store_units(
+                units, project_type=project_type, source=source,
+                content=content, purpose=purpose,
+            )
+        except Exception as exc:
+            logger.error("Storage failed for %s: %s", source, exc)
+            return IngestResult(
+                source=source,
+                source_type=content.source_type,
+                units_created=0,
+                error=f"Storage failed: {exc}",
+            )
 
         # 8. Update manifest
         self._manifest.add_source(
@@ -284,8 +293,8 @@ class KnowledgeOrchestrator:
 
         except Exception:
             logger.error(
-                "Batch storage failed after %d/%d units from %s — rolling back",
-                len(unit_ids), len(units), source,
+                "Batch storage failed after %d/%d units (%d qdrant vectors) from %s — rolling back",
+                len(unit_ids), len(units), len(qdrant_ids), source,
                 exc_info=True,
             )
             # Roll back SQLite to release the write lock immediately

--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -210,7 +210,12 @@ class KnowledgeOrchestrator:
         content: ProcessedContent,
         purpose: list[str] | None,
     ) -> list[str]:
-        """Store knowledge units via the existing knowledge_ingest MCP internals."""
+        """Store knowledge units via the existing knowledge_ingest MCP internals.
+
+        Uses a batch SQLite transaction with Qdrant compensation on failure:
+        if anything fails mid-batch, SQLite is rolled back and any Qdrant
+        vectors written so far are deleted to prevent orphaned state.
+        """
         # Import the memory module to access the store + CRUD
         import genesis.mcp.memory_mcp as memory_mod
 
@@ -221,55 +226,86 @@ class KnowledgeOrchestrator:
         import uuid
         from datetime import UTC, datetime
 
+        from genesis.qdrant.collections import delete_point
+
         unit_ids: list[str] = []
+        qdrant_ids: list[str] = []  # Track for compensation on failure
         purpose_json = json.dumps(purpose) if purpose else None
         now_iso = datetime.now(UTC).isoformat()
         embedding_model = getattr(
             memory_mod._store._embeddings, "model_name", "unknown"
         )
 
-        for unit in units:
-            unit_id = str(uuid.uuid4())
+        try:
+            for unit in units:
+                unit_id = str(uuid.uuid4())
 
-            # Store to Qdrant via MemoryStore
-            qdrant_id = await memory_mod._store.store(
-                unit.body,
-                f"knowledge:{project_type}/{unit.domain}",
-                memory_type="knowledge",
-                collection="knowledge_base",
-                tags=unit.tags + [unit.domain, project_type],
-                confidence=unit.confidence,
-                auto_link=False,
-                source_pipeline="curated",
+                # Store to Qdrant via MemoryStore (non-transactional, immediate)
+                qdrant_id = await memory_mod._store.store(
+                    unit.body,
+                    f"knowledge:{project_type}/{unit.domain}",
+                    memory_type="knowledge",
+                    collection="knowledge_base",
+                    tags=unit.tags + [unit.domain, project_type],
+                    confidence=unit.confidence,
+                    auto_link=False,
+                    source_pipeline="curated",
+                )
+                qdrant_ids.append(qdrant_id)
+
+                # Store to SQLite via CRUD (_commit=False for batch transaction)
+                await memory_mod.knowledge.insert(
+                    memory_mod._db,
+                    id=unit_id,
+                    project_type=project_type,
+                    domain=unit.domain,
+                    source_doc=source,
+                    concept=unit.concept,
+                    body=unit.body,
+                    relationships=json.dumps(unit.relationships) if unit.relationships else None,
+                    caveats=json.dumps(unit.caveats) if unit.caveats else None,
+                    tags=json.dumps(unit.tags) if unit.tags else None,
+                    confidence=unit.confidence,
+                    ingested_at=now_iso,
+                    qdrant_id=qdrant_id,
+                    section_title=unit.section_title,
+                    source_date=unit.source_date,
+                    embedding_model=embedding_model,
+                    source_pipeline="curated",
+                    purpose=purpose_json,
+                    ingestion_source=source,
+                    _commit=False,
+                )
+
+                unit_ids.append(unit_id)
+
+            # Single commit for all units in the batch
+            await memory_mod._db.commit()
+
+        except Exception:
+            logger.error(
+                "Batch storage failed after %d/%d units from %s — rolling back",
+                len(unit_ids), len(units), source,
+                exc_info=True,
             )
+            # Roll back SQLite to release the write lock immediately
+            try:
+                await memory_mod._db.rollback()
+            except Exception:
+                logger.warning("SQLite rollback failed", exc_info=True)
 
-            # Store to SQLite via CRUD (_commit=False for batch transaction)
-            await memory_mod.knowledge.insert(
-                memory_mod._db,
-                id=unit_id,
-                project_type=project_type,
-                domain=unit.domain,
-                source_doc=source,
-                concept=unit.concept,
-                body=unit.body,
-                relationships=json.dumps(unit.relationships) if unit.relationships else None,
-                caveats=json.dumps(unit.caveats) if unit.caveats else None,
-                tags=json.dumps(unit.tags) if unit.tags else None,
-                confidence=unit.confidence,
-                ingested_at=now_iso,
-                qdrant_id=qdrant_id,
-                section_title=unit.section_title,
-                source_date=unit.source_date,
-                embedding_model=embedding_model,
-                source_pipeline="curated",
-                purpose=purpose_json,
-                ingestion_source=source,
-                _commit=False,
-            )
+            # Compensate: delete orphaned Qdrant vectors
+            for qid in qdrant_ids:
+                try:
+                    delete_point(
+                        memory_mod._store._qdrant,
+                        collection="knowledge_base",
+                        point_id=qid,
+                    )
+                except Exception:
+                    logger.warning("Qdrant compensation delete failed for %s", qid)
 
-            unit_ids.append(unit_id)
+            raise
 
-        # Single commit for all units in the batch
-        await memory_mod._db.commit()
         logger.info("Stored %d knowledge units from %s", len(unit_ids), source)
         return unit_ids

--- a/tests/test_knowledge/test_orchestrator.py
+++ b/tests/test_knowledge/test_orchestrator.py
@@ -116,3 +116,55 @@ async def test_thin_extraction_quality_flag(tmp_path: Path):
         result = await orch.ingest_source(str(file), project_type="test")
         assert result.units_created == 1
         assert "thin_extraction" in result.quality_flags
+
+
+async def test_store_units_rollback_on_failure(tmp_path: Path):
+    """When _store_units fails mid-batch, SQLite is rolled back and Qdrant vectors are cleaned up."""
+    units = [
+        KnowledgeUnit(
+            domain="test", concept=f"concept_{i}", body=f"body {i}",
+            tags=["t"], confidence=0.9,
+        )
+        for i in range(3)
+    ]
+    orch = _make_orchestrator(tmp_path, mock_distill_result=units)
+
+    # Mock the memory module internals that _store_units uses
+    mock_db = AsyncMock()
+    mock_store = MagicMock()
+    # store() succeeds for first 2 calls, then the 3rd SQLite insert fails
+    mock_store.store = AsyncMock(side_effect=["qid-0", "qid-1", "qid-2"])
+    mock_store._qdrant = MagicMock()
+    mock_store._embeddings = MagicMock(model_name="test-model")
+
+    mock_knowledge = MagicMock()
+    # SQLite insert succeeds twice, then raises on the 3rd
+    mock_knowledge.insert = AsyncMock(
+        side_effect=[None, None, Exception("DB locked")]
+    )
+
+    with patch("genesis.mcp.memory_mcp._require_init"), \
+         patch("genesis.mcp.memory_mcp._store", mock_store), \
+         patch("genesis.mcp.memory_mcp._db", mock_db), \
+         patch("genesis.mcp.memory_mcp.knowledge", mock_knowledge), \
+         patch("genesis.qdrant.collections.delete_point") as mock_delete_point:
+
+        file = tmp_path / "test.txt"
+        file.write_text("some content")
+
+        result = await orch.ingest_source(str(file), project_type="test")
+
+        # Storage failed — should return error result (S2 fix)
+        assert result.error is not None
+        assert "Storage failed" in result.error
+        assert result.units_created == 0
+
+        # SQLite should have been rolled back
+        mock_db.rollback.assert_awaited_once()
+        # commit should NOT have been called (failed before reaching it)
+        mock_db.commit.assert_not_awaited()
+
+        # All 3 Qdrant vectors should be compensation-deleted
+        assert mock_delete_point.call_count == 3
+        deleted_ids = [call.kwargs["point_id"] for call in mock_delete_point.call_args_list]
+        assert deleted_ids == ["qid-0", "qid-1", "qid-2"]


### PR DESCRIPTION
## Summary

- Wrap `_store_units` storage loop in `try/except` with SQLite rollback + Qdrant compensation delete on failure
- Track Qdrant IDs during batch for orphan cleanup if anything fails mid-loop
- Comment out `openrouter-haiku` from distillation chain (credits exhausted)

**Root cause of 2026-05-08 DB lock incident:** The method had no error handling — a failed knowledge ingest left an uncommitted SQLite transaction holding the WAL write lock for 40+ minutes, causing 862 DB lock errors, awareness loop down, and sentinel unable to dispatch. Every resilience mechanism failed because they all depend on DB writes.

## Files changed

- `src/genesis/knowledge/orchestrator.py` — `_store_units` method: try/except/rollback/compensation
- `config/model_routing.yaml` — comment out exhausted openrouter-haiku

## Test plan

- [x] `ruff check` passes on changed file
- [x] 118 knowledge-related tests pass
- [x] 541/547 tests pass (6 pre-existing failures in migration runner + schema)
- [x] Import and assertion checks verify fix is structurally correct
- [ ] After merge: re-ingest AWS WAF PDF to verify end-to-end pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)