### PR TITLE
fix(memory): route memory_type=knowledge to knowledge_base collection

### DIFF
--- a/.claude/docs/background-sessions.md
+++ b/.claude/docs/background-sessions.md
@@ -79,6 +79,22 @@ Failure modes:
 - **Rate limit during wait** → countdown expires → same as timeout
 - **Crash** → Telegram notification, same recovery path
 
+## Memory Storage for Research Sessions
+
+The core philosophy: **internal → episodic, external → knowledge base.**
+
+**External research** (web sources, online data, third-party information):
+- `memory_type`: `"knowledge"` (routes to `knowledge_base` collection)
+- `confidence`: `0.5` (default — not vetted yet)
+- After human review, promote via `knowledge_ingest` (0.85 confidence boost + dedup)
+
+**Internal research** (about Genesis itself, codebase analysis, architecture):
+- `memory_type`: `"episodic"` (routes to `episodic_memory` collection)
+- This is Genesis reflecting on itself — internal context, not external facts
+
+For both types, include a descriptive `source` tag (e.g. `"research_session"`,
+`"podcast_research"`) and topic `tags` for recall.
+
 ## MCP Tool
 
 ```

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -237,6 +237,7 @@ async def memory_store(
     memory_class: str | None = None,
     wing: str | None = None,
     room: str | None = None,
+    collection: str | None = None,
 ) -> str:
     """Store memory with source metadata and type tag. Returns memory_id.
 
@@ -245,6 +246,8 @@ async def memory_store(
             Auto-classified from content if not provided.
         wing: Structural domain (auto-classified if not provided).
         room: Topic within the wing (auto-classified if not provided).
+        collection: Explicit Qdrant collection override. Bypasses the default
+            collection routing when provided (e.g. "knowledge_base").
     """
     memory_mod = _memory_mod()
     memory_mod._require_init()
@@ -252,7 +255,7 @@ async def memory_store(
     return await memory_mod._store.store(
         content, source, memory_type=memory_type, tags=tags, confidence=confidence,
         memory_class=memory_class, source_pipeline="conversation",
-        wing=wing, room=room,
+        wing=wing, room=room, collection=collection,
     )
 
 

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 _COLLECTION_MAP = {
     "episodic": "episodic_memory",
-    "knowledge": "episodic_memory",  # Internal knowledge lives with episodic
+    "knowledge": "knowledge_base",  # External knowledge → knowledge_base
 }
 
 

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -92,9 +92,8 @@ class MemoryStore:
 
         Args:
             collection: Explicit Qdrant collection override. If provided, bypasses
-                ``_COLLECTION_MAP`` lookup. Used by ``knowledge_ingest`` and pipeline
-                orchestrator to route domain data to ``knowledge_base`` while the
-                default map routes all internal knowledge to ``episodic_memory``.
+                ``_COLLECTION_MAP`` lookup. Default routing: ``episodic`` types →
+                ``episodic_memory``, ``knowledge`` types → ``knowledge_base``.
         """
         # Dedup: skip if exact content already stored (any collection)
         try:

--- a/tests/test_memory/test_mcp_integration.py
+++ b/tests/test_memory/test_mcp_integration.py
@@ -72,7 +72,7 @@ async def test_memory_store_delegates(mock_deps, tools):
     memory_mcp._store.store.assert_awaited_once_with(
         "hello", "test", memory_type="episodic", tags=None, confidence=0.5,
         memory_class=None, source_pipeline="conversation",
-        wing=None, room=None,
+        wing=None, room=None, collection=None,
     )
 
 

--- a/tests/test_memory/test_store.py
+++ b/tests/test_memory/test_store.py
@@ -173,8 +173,8 @@ async def test_store_collection_override_bypasses_map(store):
 
 
 @pytest.mark.asyncio()
-async def test_store_knowledge_type_defaults_to_episodic(store):
-    """memory_type='knowledge' without collection override routes to episodic_memory."""
+async def test_store_knowledge_type_defaults_to_knowledge_base(store):
+    """memory_type='knowledge' without collection override routes to knowledge_base."""
     with patch("genesis.memory.store.upsert_point") as mock_upsert, \
          patch("genesis.memory.store.memory_crud") as mock_mem:
         mock_mem.upsert = AsyncMock(return_value="id")
@@ -183,7 +183,7 @@ async def test_store_knowledge_type_defaults_to_episodic(store):
         await store.store("internal fact", "session_extraction", memory_type="knowledge")
 
     call_kwargs = mock_upsert.call_args
-    assert call_kwargs.kwargs["collection"] == "episodic_memory"
+    assert call_kwargs.kwargs["collection"] == "knowledge_base"
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## Summary
- Fix `_COLLECTION_MAP["knowledge"]` routing from `episodic_memory` to `knowledge_base` — external research findings were incorrectly landing in the episodic collection
- Add `collection` parameter to `memory_store` MCP tool for explicit collection override
- Add storage guidance to background session docs (internal→episodic, external→knowledge_base)

All existing `memory_type="knowledge"` callers (`ingest_knowledge_unit`, `KnowledgeOrchestrator._store_units`) already use explicit `collection="knowledge_base"` override, so only the default routing path (used by `memory_store` MCP) is affected.

## Follow-ups
- `memory_expand` only queries `episodic_memory` — knowledge_base memories invisible to expand (pre-existing, now more impactful)
- `memory_core_facts` only queries `episodic_memory` — same pattern
- Migrate ~17 mislabeled research session memories from episodic → KB (separate step, needs manual review)

## Test plan
- [x] `pytest tests/test_memory/test_store.py` — 13/13 passed
- [x] `pytest tests/test_memory/test_mcp_integration.py::test_memory_store_delegates` — passed
- [x] `ruff check` — clean on all modified files
- [x] Code review via superpowers:code-reviewer — stale docstring fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)