### PR TITLE
fix(perception): exclude stale signals from micro-reflection scope

### DIFF
--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1028,6 +1028,14 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         END
     """)
 
+    # Fix: user_goal_staleness was seeded with ["Micro","Light"] but is a
+    # strategic-level signal that generates noise at Micro depth (72 identical
+    # anomaly observations in 7 days).  Scope to Light only.
+    await db.execute(
+        "UPDATE signal_weights SET feeds_depths = '[\"Light\"]' "
+        "WHERE signal_name = 'user_goal_staleness'"
+    )
+
     # Ego proposals: memory_basis column for non-obvious memory attribution.
     await _try_alter(db,
         "ALTER TABLE ego_proposals ADD COLUMN memory_basis TEXT DEFAULT ''",

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1169,7 +1169,7 @@ SIGNAL_WEIGHTS_SEED = [
     # 2026-04-17: ghost signal activation — collector already exists, just needs weight
     ("stale_pending_items", "cognitive_state", 0.35, 0.35, 0.0, 1.0, '["Micro"]'),
     # 2026-04-30: user-facing signals for reflection rebalancing (Phase 2.5b)
-    ("user_goal_staleness", "follow_ups+user_model", 0.40, 0.40, 0.0, 1.0, '["Micro","Light"]'),
+    ("user_goal_staleness", "follow_ups+user_model", 0.40, 0.40, 0.0, 1.0, '["Light"]'),
     ("user_session_pattern", "cc_sessions", 0.35, 0.35, 0.0, 1.0, '["Micro","Light"]'),
 ]
 

--- a/src/genesis/perception/context.py
+++ b/src/genesis/perception/context.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime, timedelta
 import aiosqlite
 
 from genesis.awareness.types import Depth, TickResult
-from genesis.db.crud import cognitive_state, observations, predictions
+from genesis.db.crud import cognitive_state, observations, predictions, signal_weights
 from genesis.identity.loader import IdentityLoader
 from genesis.memory.user_model import UserModelEvolver
 from genesis.perception.types import LIGHT_FOCUS_ROTATION, PromptContext
@@ -142,7 +142,25 @@ class ContextAssembler:
         # Micro: no identity (cheap model overwhelmed by SOUL.md — just task instruction).
         # Light+: full identity block (SOUL.md + USER.md + STEERING.md).
         identity = "" if depth == Depth.MICRO else self._identity.identity_block()
-        signals_text = self._format_signals(tick)
+
+        # Micro: exclude signals registered in signal_weights but NOT scoped
+        # to Micro via feeds_depths.  This prevents the LLM from seeing (and
+        # flagging as anomalous) signals like user_goal_staleness that don't
+        # belong at this depth.  Unregistered signals pass through (safe for
+        # tests and future signal collectors not yet in signal_weights).
+        excluded_signals: set[str] | None = None
+        if depth == Depth.MICRO:
+            try:
+                all_rows = await signal_weights.list_all(db)
+                micro_rows = await signal_weights.list_by_depth(db, "Micro")
+                if all_rows:
+                    all_names = {r["signal_name"] for r in all_rows}
+                    micro_names = {r["signal_name"] for r in micro_rows}
+                    excluded_signals = all_names - micro_names or None
+            except Exception:
+                logger.debug("Could not load signal_weights for Micro filtering")
+
+        signals_text = self._format_signals(tick, excluded_signals=excluded_signals)
         tick_number = self._extract_tick_number(tick)
 
         user_profile = None
@@ -406,11 +424,17 @@ class ContextAssembler:
         )
         return header + "\n" + "\n".join(lines)
 
-    def _format_signals(self, tick: TickResult) -> str:
+    def _format_signals(
+        self,
+        tick: TickResult,
+        excluded_signals: set[str] | None = None,
+    ) -> str:
         staleness = tick.signal_staleness or {}
         tick_interval_min = 5  # awareness loop tick interval
         lines = []
         for s in tick.signals:
+            if excluded_signals is not None and s.name in excluded_signals:
+                continue
             line = f"{s.name}: {s.value} (source={s.source})"
             if s.normal_max is not None:
                 status = (

--- a/src/genesis/perception/writer.py
+++ b/src/genesis/perception/writer.py
@@ -153,13 +153,13 @@ class ResultWriter:
         relevance = self._relevance_from_signals(tick)
         category = f"{base_category}:{relevance}"
 
-        # Structural dedup: hash on tags + salience band + anomaly flag +
-        # signal names.  LLM-generated summaries vary too much per tick to
-        # be useful as dedup keys — even after number normalization, the
-        # sentence structure changes and the hash never collides.
+        # Structural dedup: hash on salience band + anomaly flag + signal
+        # names.  Tags are excluded — they are LLM-generated and vary wildly
+        # across ticks even for identical underlying conditions (61 distinct
+        # tag combos for 72 observations in one week of staleness noise).
         signal_names = ",".join(sorted(s.name for s in tick.signals))
         salience_band = round(output.salience, 1)
-        norm_key = f"micro:{','.join(sorted(output.tags))}|{salience_band}|{output.anomaly}|{signal_names}"
+        norm_key = f"micro:|{salience_band}|{output.anomaly}|{signal_names}"
         chash = self._content_hash(norm_key)
 
         if await observations.exists_by_hash(db, source="reflection", content_hash=chash, unresolved_only=True):

--- a/tests/test_perception/test_context.py
+++ b/tests/test_perception/test_context.py
@@ -259,3 +259,84 @@ async def test_light_focus_aware_context_stripping(db, identity_dir):
     assert ctx_anom.user_profile is None
     assert ctx_anom.user_model is None
     assert ctx_anom.memory_hits is not None
+
+
+async def test_micro_excludes_signals_not_scoped_to_micro(db, identity_dir):
+    """Micro context should exclude signals registered in signal_weights
+    but not scoped to Micro via feeds_depths."""
+    from genesis.identity.loader import IdentityLoader
+    from genesis.perception.context import ContextAssembler
+
+    # Seed a signal scoped only to Light (not Micro)
+    await db.execute(
+        "INSERT OR REPLACE INTO signal_weights "
+        "(signal_name, source_mcp, current_weight, initial_weight, feeds_depths) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("light_only_signal", "test", 0.5, 0.5, '["Light"]'),
+    )
+    await db.commit()
+
+    loader = IdentityLoader(identity_dir)
+    assembler = ContextAssembler(identity_loader=loader)
+    tick = TickResult(
+        tick_id="tick-1",
+        timestamp="2026-03-05T10:00:00+00:00",
+        source="scheduled",
+        signals=[
+            SignalReading(
+                name="cpu_usage", value=0.3, source="system",
+                collected_at="2026-03-05T10:00:00+00:00",
+            ),
+            SignalReading(
+                name="light_only_signal", value=1.0, source="test",
+                collected_at="2026-03-05T10:00:00+00:00",
+            ),
+        ],
+        scores=[],
+        classified_depth=Depth.MICRO,
+        trigger_reason="test",
+    )
+
+    ctx = await assembler.assemble(Depth.MICRO, tick, db=db)
+
+    # cpu_usage is not in signal_weights at all → passes through
+    assert "cpu_usage" in ctx.signals_text
+    # light_only_signal is registered but NOT scoped to Micro → excluded
+    assert "light_only_signal" not in ctx.signals_text
+
+
+async def test_light_shows_all_signals_regardless_of_scope(db, identity_dir):
+    """Light context should show all signals — no depth filtering."""
+    from genesis.identity.loader import IdentityLoader
+    from genesis.perception.context import ContextAssembler
+
+    # Seed a signal scoped only to Micro (not Light)
+    await db.execute(
+        "INSERT OR REPLACE INTO signal_weights "
+        "(signal_name, source_mcp, current_weight, initial_weight, feeds_depths) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("micro_only_signal", "test", 0.5, 0.5, '["Micro"]'),
+    )
+    await db.commit()
+
+    loader = IdentityLoader(identity_dir)
+    assembler = ContextAssembler(identity_loader=loader)
+    tick = TickResult(
+        tick_id="tick-1",
+        timestamp="2026-03-05T10:00:00+00:00",
+        source="scheduled",
+        signals=[
+            SignalReading(
+                name="micro_only_signal", value=0.8, source="test",
+                collected_at="2026-03-05T10:00:00+00:00",
+            ),
+        ],
+        scores=[],
+        classified_depth=Depth.LIGHT,
+        trigger_reason="test",
+    )
+
+    ctx = await assembler.assemble(Depth.LIGHT, tick, db=db)
+
+    # Light doesn't filter — all signals visible
+    assert "micro_only_signal" in ctx.signals_text

--- a/tests/test_perception/test_writer.py
+++ b/tests/test_perception/test_writer.py
@@ -606,3 +606,35 @@ async def test_micro_low_info_gate_passes_real_content(db):
     assert stored is True
     obs = await observations.query(db, source="reflection")
     assert len(obs) == 1
+
+
+async def test_write_micro_dedup_ignores_tag_variation(db):
+    """Two micro outputs with DIFFERENT tags but same signals/salience/anomaly should dedup.
+
+    LLM-generated tags vary wildly across ticks (61 distinct combos for 72
+    observations in production).  Tags must not be part of the dedup hash.
+    """
+    from genesis.db.crud import observations
+    from genesis.perception.writer import ResultWriter
+
+    writer = ResultWriter()
+    output1 = MicroOutput(
+        tags=["user_engagement_spike", "strategic_reflection_overdue"],
+        salience=0.7,
+        anomaly=True,
+        summary="User session patterns show an unusual spike.",
+        signals_examined=21,
+    )
+    output2 = MicroOutput(
+        tags=["cross_signal_analysis", "awareness_cycle"],
+        salience=0.7,
+        anomaly=True,
+        summary="The awareness cycle shows a potential imbalance.",
+        signals_examined=21,
+    )
+    tick = _make_tick()
+    await writer.write(output1, Depth.MICRO, tick, db=db)
+    await writer.write(output2, Depth.MICRO, tick, db=db)
+
+    obs = await observations.query(db, source="reflection")
+    assert len(obs) == 1, f"Expected 1 (tag variation should dedup), got {len(obs)}"


### PR DESCRIPTION
## Summary

- Micro-reflections generated 72 near-identical anomaly observations in 7 days (91% about `user_goal_staleness=1.0`) because `_format_signals()` showed ALL signals to the LLM regardless of depth, and anomalies bypass all quality gates
- Context assembler now filters signals by `feeds_depths` for Micro depth — signals registered in `signal_weights` but not scoped to Micro are excluded from the LLM prompt
- Structural dedup hash no longer includes LLM-generated tags (61 distinct combos for 72 observations), using only salience_band + anomaly + signal_names
- Updated `user_goal_staleness` seed data to `["Light"]` scope (live DB already updated)
- Bulk-resolved 39 stale anomaly:both micro_reflection observations

## Test plan

- [x] 37 targeted perception tests pass (34 existing + 3 new)
- [x] Full suite: 6292 passed, 13 pre-existing failures, 0 new failures
- [x] New tests: `test_micro_excludes_signals_not_scoped_to_micro`, `test_light_shows_all_signals_regardless_of_scope`, `test_write_micro_dedup_ignores_tag_variation`
- [ ] Monitor: `SELECT count(*) FROM observations WHERE type='micro_reflection' AND category LIKE 'anomaly%' AND resolved=0` should stay at 0 post-deploy