### PR TITLE
fix(ego,health): fix ego proposals schema + remove stale tmpfs probe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,8 @@ reflection) → Services (routing, memory, outreach, autonomy, surplus) → Data
   hooks and MCP servers require inherited API keys (DeepInfra, Qwen, etc.).
 - **Setup**: `./scripts/bootstrap.sh` (venv, config, services, memory)
 - **Temp files**: `~/tmp/` for transient downloads (media, audio, exports).
-  NEVER use `/tmp/` — it is a 512MB tmpfs shared across all CC sessions.
-  Clean up after use.
+  NEVER use `/tmp/` — it shares the root filesystem and competes with all
+  CC sessions.  Clean up after use.
 
 ## Process Management
 

--- a/config/guardian-claude.md
+++ b/config/guardian-claude.md
@@ -31,7 +31,7 @@ data and signal history. DO NOT stop at that data — investigate:
 - `incus exec genesis -- su - ubuntu -c "journalctl --user -n 200 --no-pager"` — Read logs
 - `incus exec genesis -- su - ubuntu -c "ps aux --sort=-%mem | head -20"` — Top processes
 - `incus exec genesis -- su - ubuntu -c "df -h"` — Disk usage
-- `incus exec genesis -- su - ubuntu -c "df -h /tmp"` — /tmp usage (512MB tmpfs)
+- `incus exec genesis -- su - ubuntu -c "df -h /tmp"` — /tmp usage (on root filesystem)
 - `incus exec genesis -- su - ubuntu -c "cat /sys/fs/cgroup/memory.current"` — Memory
 - `incus exec genesis -- su - ubuntu -c "cd ~/genesis && git log --oneline -5"` — Recent commits
 - `incus info genesis` — Container status

--- a/config/outreach.yaml
+++ b/config/outreach.yaml
@@ -59,7 +59,6 @@ health_alerts:
   # NOTE: service:bridge_down is intentionally absent — if the bridge is dead,
   # the Telegram adapter is also dead, so the alert can never be delivered.
   immediate_escalation:
-    - "infra:tmpfs_low"
     - "infra:disk_low"
     - "infra:container_memory_high"
     - "cc:quota_exhausted"

--- a/docs/architecture/genesis-v3-self-healing-design.md
+++ b/docs/architecture/genesis-v3-self-healing-design.md
@@ -265,7 +265,7 @@ genesis-watchdog.timer (systemd, 60s)
 ```
 Awareness tick fires
   → Run health probes: probe_db(), probe_qdrant(), probe_ollama(), probe_scheduler()
-  → Run filesystem probes: probe_tmp(), probe_disk()
+  → Run filesystem probes: probe_disk()
   → StatusFileWriter.write()              # Existing: updates status.json
   → RemediationRegistry.check_and_remediate(probe_results)
     → For each registered action:
@@ -284,28 +284,6 @@ Awareness tick fires
 ### 4.4 New Health Probes
 
 Two new probes to be added to `src/genesis/observability/health.py`:
-
-**`probe_tmp()`** — Filesystem probe for `/tmp` (512M tmpfs).
-
-```python
-async def probe_tmp(
-    path: str = "/tmp",
-    threshold_pct: float = 80.0,
-    *,
-    clock=None,
-) -> ProbeResult:
-    """Probe /tmp filesystem usage via os.statvfs()."""
-    stat = os.statvfs(path)
-    used_pct = (1 - stat.f_bavail / stat.f_blocks) * 100
-    status = ProbeStatus.HEALTHY if used_pct < threshold_pct else ProbeStatus.DEGRADED
-    return ProbeResult(
-        name="tmp_fs",
-        status=status,
-        latency_ms=0.0,
-        message=f"{used_pct:.0f}% used",
-        details={"used_pct": round(used_pct, 1), "path": path},
-    )
-```
 
 **`probe_disk()`** — Root filesystem probe.
 

--- a/src/genesis/autonomy/remediation.py
+++ b/src/genesis/autonomy/remediation.py
@@ -356,19 +356,6 @@ DEFAULT_REMEDIATIONS: list[RemediationAction] = [
         max_attempts=3,
     ),
     RemediationAction(
-        name="tmp_cleanup",
-        probe_name="tmp_usage",
-        condition="/tmp usage exceeds 80%",
-        command=[
-            "bash", "-c",
-            'find /tmp -maxdepth 1 -type f \\( -name "claude-*" -o -name ".claude-*" \\) -mmin +60 -delete',
-        ],
-        governance_level=2,
-        reversible=True,
-        cooldown_s=600,
-        max_attempts=5,
-    ),
-    RemediationAction(
         name="awareness_restart",
         probe_name="awareness_tick",
         condition="Awareness loop heartbeat stale >15min",

--- a/src/genesis/db/migrations/0011_j9_eval_tables.py
+++ b/src/genesis/db/migrations/0011_j9_eval_tables.py
@@ -66,4 +66,4 @@ async def up(db: aiosqlite.Connection) -> None:
         "ON eval_snapshots(dimension, period_end)"
     )
 
-    await db.commit()
+    # Runner manages the transaction — do not call db.commit() here.

--- a/src/genesis/db/migrations/0012_ego_proposals_status_check.py
+++ b/src/genesis/db/migrations/0012_ego_proposals_status_check.py
@@ -1,0 +1,105 @@
+"""Fix ego_proposals CHECK constraint — add 'tabled' and 'withdrawn' statuses.
+
+Migration 0007 was supposed to add these values but was short-circuited by the
+_migrate_add_columns() function which added the 'rank' column first via ALTER
+TABLE, causing 0007's idempotency check (``if 'rank' in cols: return``) to skip
+the table rebuild.  The CHECK constraint on status never got updated.
+
+SQLite cannot ALTER CHECK constraints — requires full table rebuild.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # Idempotency: check if the fix is already applied
+    cursor = await db.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='ego_proposals'"
+    )
+    row = await cursor.fetchone()
+    if not row:
+        return  # Table doesn't exist (fresh install creates it correctly)
+
+    ddl = row[0] or ""
+    if "'tabled'" in ddl and "'withdrawn'" in ddl:
+        return  # Already has the expanded constraint
+
+    # Clean up orphaned temp table from a prior failed attempt
+    await db.execute("DROP TABLE IF EXISTS ego_proposals_new")
+
+    await db.execute("""
+        CREATE TABLE ego_proposals_new (
+            id              TEXT PRIMARY KEY,
+            action_type     TEXT NOT NULL,
+            action_category TEXT NOT NULL DEFAULT '',
+            content         TEXT NOT NULL,
+            rationale       TEXT NOT NULL DEFAULT '',
+            confidence      REAL NOT NULL DEFAULT 0.0,
+            urgency         TEXT NOT NULL DEFAULT 'normal'
+                CHECK (urgency IN ('low', 'normal', 'high', 'critical')),
+            alternatives    TEXT NOT NULL DEFAULT '',
+            status          TEXT NOT NULL DEFAULT 'pending'
+                CHECK (status IN ('pending', 'approved', 'rejected',
+                                  'expired', 'executed', 'failed',
+                                  'tabled', 'withdrawn')),
+            user_response   TEXT,
+            cycle_id        TEXT,
+            batch_id        TEXT,
+            created_at      TEXT NOT NULL,
+            resolved_at     TEXT,
+            expires_at      TEXT,
+            rank            INTEGER,
+            execution_plan  TEXT,
+            recurring       INTEGER DEFAULT 0,
+            memory_basis    TEXT DEFAULT ''
+        )
+    """)
+
+    await db.execute("""
+        INSERT INTO ego_proposals_new
+            (id, action_type, action_category, content, rationale,
+             confidence, urgency, alternatives, status, user_response,
+             cycle_id, batch_id, created_at, resolved_at, expires_at,
+             rank, execution_plan, recurring, memory_basis)
+        SELECT
+            id, action_type, action_category, content, rationale,
+            confidence, urgency, alternatives, status, user_response,
+            cycle_id, batch_id, created_at, resolved_at, expires_at,
+            rank, execution_plan, recurring, memory_basis
+        FROM ego_proposals
+    """)
+
+    await db.execute("DROP TABLE ego_proposals")
+    await db.execute("ALTER TABLE ego_proposals_new RENAME TO ego_proposals")
+
+    # Recreate all indexes
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ego_proposals_status "
+        "ON ego_proposals(status)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ego_proposals_created "
+        "ON ego_proposals(created_at)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ego_proposals_cycle "
+        "ON ego_proposals(cycle_id)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ego_proposals_category "
+        "ON ego_proposals(action_category, status)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ego_proposals_batch "
+        "ON ego_proposals(batch_id)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ego_proposals_expires "
+        "ON ego_proposals(expires_at)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ego_proposals_rank "
+        "ON ego_proposals(status, rank)"
+    )

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1033,6 +1033,13 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE ego_proposals ADD COLUMN memory_basis TEXT DEFAULT ''",
         "ego_proposals.memory_basis")
 
+    # Ego proposals: fix CHECK constraint to include 'tabled'/'withdrawn'.
+    # Migration 0007 was bypassed because the column additions above ran first,
+    # causing 0007's idempotency check (``if 'rank' in cols``) to skip the
+    # table rebuild.  This defensive path ensures the constraint is correct
+    # even if the versioned migration (0012) hasn't run yet.
+    await _migrate_ego_proposals_status_check(db)
+
     # Phase 1.5: backfill memory_metadata from Qdrant + pending_embeddings.
     # New memories write metadata at store time, but pre-existing memories
     # lack rows. Without backfill, the "recent" dashboard view is empty.
@@ -1088,6 +1095,87 @@ async def _migrate_cognitive_state_check(db: aiosqlite.Connection) -> None:
         with contextlib.suppress(Exception):
             await db.execute("DROP TABLE IF EXISTS cognitive_state_new")
         logger.error("cognitive_state CHECK constraint migration failed", exc_info=True)
+
+
+async def _migrate_ego_proposals_status_check(db: aiosqlite.Connection) -> None:
+    """Rebuild ego_proposals if CHECK constraint lacks 'tabled'/'withdrawn'.
+
+    SQLite doesn't support ALTER CHECK — must rebuild the table.
+    Idempotent: skips if the constraint already includes the new statuses.
+    """
+    try:
+        cursor = await db.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='ego_proposals'"
+        )
+        row = await cursor.fetchone()
+        if not row:
+            return  # Table doesn't exist yet (fresh install)
+        ddl = row[0] or ""
+        if "'tabled'" in ddl and "'withdrawn'" in ddl:
+            return  # Already up to date
+
+        await db.execute("DROP TABLE IF EXISTS ego_proposals_rebuild")
+        await db.execute("""
+            CREATE TABLE ego_proposals_rebuild (
+                id              TEXT PRIMARY KEY,
+                action_type     TEXT NOT NULL,
+                action_category TEXT NOT NULL DEFAULT '',
+                content         TEXT NOT NULL,
+                rationale       TEXT NOT NULL DEFAULT '',
+                confidence      REAL NOT NULL DEFAULT 0.0,
+                urgency         TEXT NOT NULL DEFAULT 'normal'
+                    CHECK (urgency IN ('low', 'normal', 'high', 'critical')),
+                alternatives    TEXT NOT NULL DEFAULT '',
+                status          TEXT NOT NULL DEFAULT 'pending'
+                    CHECK (status IN ('pending', 'approved', 'rejected',
+                                      'expired', 'executed', 'failed',
+                                      'tabled', 'withdrawn')),
+                user_response   TEXT,
+                cycle_id        TEXT,
+                batch_id        TEXT,
+                created_at      TEXT NOT NULL,
+                resolved_at     TEXT,
+                expires_at      TEXT,
+                rank            INTEGER,
+                execution_plan  TEXT,
+                recurring       INTEGER DEFAULT 0,
+                memory_basis    TEXT DEFAULT ''
+            )
+        """)
+        await db.execute("""
+            INSERT INTO ego_proposals_rebuild
+                (id, action_type, action_category, content, rationale,
+                 confidence, urgency, alternatives, status, user_response,
+                 cycle_id, batch_id, created_at, resolved_at, expires_at,
+                 rank, execution_plan, recurring, memory_basis)
+            SELECT
+                id, action_type, action_category, content, rationale,
+                confidence, urgency, alternatives, status, user_response,
+                cycle_id, batch_id, created_at, resolved_at, expires_at,
+                rank, execution_plan, recurring, memory_basis
+            FROM ego_proposals
+        """)
+        await db.execute("DROP TABLE ego_proposals")
+        await db.execute(
+            "ALTER TABLE ego_proposals_rebuild RENAME TO ego_proposals"
+        )
+        # Recreate indexes
+        for idx_sql in [
+            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_status ON ego_proposals(status)",
+            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_created ON ego_proposals(created_at)",
+            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_cycle ON ego_proposals(cycle_id)",
+            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_category ON ego_proposals(action_category, status)",
+            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_batch ON ego_proposals(batch_id)",
+            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_expires ON ego_proposals(expires_at)",
+            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_rank ON ego_proposals(status, rank)",
+        ]:
+            await db.execute(idx_sql)
+        await db.commit()
+        logger.info("ego_proposals table rebuilt with 'tabled'/'withdrawn' statuses")
+    except Exception:
+        with contextlib.suppress(Exception):
+            await db.execute("DROP TABLE IF EXISTS ego_proposals_rebuild")
+        logger.error("ego_proposals CHECK constraint migration failed", exc_info=True)
 
 
 async def _migrate_backfill_memory_metadata(db: aiosqlite.Connection) -> None:

--- a/src/genesis/guardian/briefing.py
+++ b/src/genesis/guardian/briefing.py
@@ -264,7 +264,7 @@ def _build_default_briefing() -> BriefingContent:
             "Awareness loop ticks every 5 minutes — heartbeat canary is tied to it.",
             "Python venv at ~/genesis/.venv. Config at ~/genesis/config/.",
             "Database at ~/genesis/data/genesis.db (SQLite, 60+ tables).",
-            "/tmp is 512MB tmpfs — fills up under heavy logging or temp file use.",
+            "/tmp shares the root filesystem — avoid large temp file accumulation.",
             "Cgroup memory limit is 24GiB. OOM kills target heaviest process.",
         ],
     )

--- a/src/genesis/guardian/diagnosis.py
+++ b/src/genesis/guardian/diagnosis.py
@@ -174,8 +174,8 @@ can cause catastrophic damage:
   to the worktree path and crashes the bridge.
 - **Always validate pgid > 1 before `os.killpg()`** — `int(AsyncMock().pid)`
   returns 1 in Python 3.12. Sending a signal to pgid 1 kills ALL processes.
-- **/tmp inside the container is a 512MB tmpfs** — filling it kills CC's shell
-  across ALL sessions. Use `~/tmp/` for transient files.
+- **/tmp shares the root filesystem** — avoid accumulating large temp files.
+  Use `~/tmp/` for transient files.
 - **Never kill the genesis-server process directly** — always use
   `systemctl --user restart genesis-server`. Direct kills leave the lock file.
 - **Server management is systemd only** — never use `nohup` or bare
@@ -205,7 +205,7 @@ Run these via Bash:
 - `incus exec {container_name} -- su - ubuntu -c "journalctl --user -n 200 --no-pager"` — Read recent logs
 - `incus exec {container_name} -- su - ubuntu -c "cat /sys/fs/cgroup/memory.current"` — Check memory
 - `incus exec {container_name} -- su - ubuntu -c "df -h"` — Check disk
-- `incus exec {container_name} -- su - ubuntu -c "df -h /tmp"` — Check /tmp (512MB tmpfs)
+- `incus exec {container_name} -- su - ubuntu -c "df -h /tmp"` — Check /tmp usage
 - `incus exec {container_name} -- su - ubuntu -c "ps aux --sort=-%mem | head -20"` — Top processes
 - `incus exec {container_name} -- su - ubuntu -c "cd ~/genesis && git log --oneline -5"` — Recent commits
 - `incus exec {container_name} -- su - ubuntu -c "cd ~/genesis && git diff --stat"` — Uncommitted changes

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -285,17 +285,6 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
         })
         current_ids.add(alert_id)
 
-    tmpfs = snap.get("infrastructure", {}).get("tmpfs", {})
-    tmp_free_pct = tmpfs.get("free_pct")
-    if tmp_free_pct is not None and tmp_free_pct < 20:
-        alert_id = "infra:tmpfs_low"
-        alerts.append({
-            "id": alert_id,
-            "severity": "CRITICAL" if tmp_free_pct < 10 else "WARNING",
-            "message": f"/tmp tmpfs low: {tmp_free_pct}% free ({tmpfs.get('free_mb', '?')}MB) — filling /tmp kills CC sessions",
-        })
-        current_ids.add(alert_id)
-
     container_mem = snap.get("infrastructure", {}).get("container_memory", {})
     # Use anon_pct (non-reclaimable memory) for alerts, not used_pct
     # (total cgroup including reclaimable page cache).

--- a/src/genesis/observability/health.py
+++ b/src/genesis/observability/health.py
@@ -228,61 +228,6 @@ async def probe_scheduler(
         )
 
 
-async def probe_tmp(
-    tmp_path: str = "/tmp",
-    *,
-    warn_pct: float = 80.0,
-    critical_pct: float = 90.0,
-    clock=None,
-) -> ProbeResult:
-    """Probe /tmp filesystem usage.
-
-    /tmp is a 512M tmpfs in this container -- filling it kills CC's shell.
-    Returns ProbeResult with details={"pct_used": float, "used_mb": float, "total_mb": float}.
-    """
-    _clock = clock or (lambda: datetime.now(UTC))
-    start = time.monotonic()
-    try:
-        st = os.statvfs(tmp_path)
-        total = st.f_blocks * st.f_frsize
-        free = st.f_bavail * st.f_frsize
-        used = total - free
-        pct = (used / total * 100) if total > 0 else 0.0
-        latency = (time.monotonic() - start) * 1000
-
-        if pct >= critical_pct:
-            status = ProbeStatus.DOWN
-            msg = f"/tmp at {pct:.1f}% ({used / (1024*1024):.0f}/{total / (1024*1024):.0f} MB)"
-        elif pct >= warn_pct:
-            status = ProbeStatus.DEGRADED
-            msg = f"/tmp at {pct:.1f}%"
-        else:
-            status = ProbeStatus.HEALTHY
-            msg = ""
-
-        return ProbeResult(
-            name="tmp_usage",
-            status=status,
-            latency_ms=round(latency, 2),
-            message=msg,
-            checked_at=_clock().isoformat(),
-            details={
-                "pct_used": round(pct, 1),
-                "used_mb": round(used / (1024 * 1024), 1),
-                "total_mb": round(total / (1024 * 1024), 1),
-            },
-        )
-    except OSError as exc:
-        latency = (time.monotonic() - start) * 1000
-        return ProbeResult(
-            name="tmp_usage",
-            status=ProbeStatus.DOWN,
-            latency_ms=round(latency, 2),
-            message=f"Cannot stat {tmp_path}: {exc}",
-            checked_at=_clock().isoformat(),
-        )
-
-
 async def probe_disk(
     mount_path: str = "/",
     *,
@@ -531,7 +476,6 @@ async def collect_probe_results(
     tasks = [
         _safe("qdrant", probe_qdrant()),
         *([] if not ollama_enabled() else [_safe("ollama", probe_ollama())]),
-        _safe("tmp_usage", probe_tmp()),
         _safe("disk", probe_disk()),
         _safe("guardian", probe_guardian(guardian_remote=guardian_remote)),
         _safe("browser_processes", probe_browser_processes()),

--- a/src/genesis/observability/service_status.py
+++ b/src/genesis/observability/service_status.py
@@ -305,18 +305,3 @@ def collect_cc_tmp_usage() -> dict:
     except (json.JSONDecodeError, OSError):
         return {"status": "error", "error": "cannot read watchgod state"}
 
-
-def collect_tmpfs_usage() -> dict:
-    """Check /tmp tmpfs usage. Returns dict with size, used, free, free_pct."""
-    import shutil
-
-    try:
-        usage = shutil.disk_usage("/tmp")
-        free_pct = round(usage.free / usage.total * 100, 1)
-        return {
-            "total_mb": round(usage.total / (1024**2), 1),
-            "free_mb": round(usage.free / (1024**2), 1),
-            "free_pct": free_pct,
-        }
-    except Exception:
-        return {"status": "unknown"}

--- a/src/genesis/observability/snapshots/infrastructure.py
+++ b/src/genesis/observability/snapshots/infrastructure.py
@@ -164,13 +164,6 @@ async def infrastructure(
         infra["disk"] = {"status": "error", "error": str(exc)}
 
     try:
-        from genesis.observability.service_status import collect_tmpfs_usage
-
-        infra["tmpfs"] = collect_tmpfs_usage()
-    except (ImportError, OSError) as exc:
-        infra["tmpfs"] = {"status": "error", "error": str(exc)}
-
-    try:
         from genesis.observability.service_status import collect_cc_tmp_usage
 
         infra["cc_tmp"] = collect_cc_tmp_usage()

--- a/src/genesis/outreach/config.py
+++ b/src/genesis/outreach/config.py
@@ -31,7 +31,6 @@ class OutreachConfig:
     engagement_timeout_hours: int
     engagement_poll_minutes: int
     immediate_escalation_alerts: tuple[str, ...] = (
-        "infra:tmpfs_low",
         "infra:disk_low",
         "infra:container_memory_high",
         "cc:quota_exhausted",
@@ -61,7 +60,6 @@ _DEFAULTS = OutreachConfig(
     engagement_timeout_hours=24,
     engagement_poll_minutes=60,
     immediate_escalation_alerts=(
-        "infra:tmpfs_low",
         "infra:disk_low",
         "infra:container_memory_high",
         "cc:quota_exhausted",

--- a/src/genesis/sentinel/classifier.py
+++ b/src/genesis/sentinel/classifier.py
@@ -42,7 +42,6 @@ _TIER1_PATTERNS = {
 _TIER2_PATTERNS = {
     "memory:critical",
     "disk:critical",
-    "tmpfs:critical",
     "embedding:unreachable",
     "qdrant:unreachable",
     "qdrant:collections_missing",

--- a/tests/test_autonomy/test_remediation.py
+++ b/tests/test_autonomy/test_remediation.py
@@ -101,7 +101,6 @@ class TestRegistration:
         assert len(reg.actions) == len(DEFAULT_REMEDIATIONS)
         names = {a.name for a in reg.actions}
         assert "qdrant_restart" in names
-        assert "tmp_cleanup" in names
         assert "awareness_restart" in names
         assert "ollama_alert" in names
         assert "disk_cleanup" in names

--- a/tests/test_health_mcp.py
+++ b/tests/test_health_mcp.py
@@ -32,7 +32,6 @@ _HEALTHY_DEFAULTS = {
     },
     "infrastructure": {
         "disk": {"free_pct": 80, "free_gb": 100, "total_gb": 140},
-        "tmpfs": {"free_pct": 90, "free_mb": 460, "total_mb": 512},
         "qdrant_collections": {"status": "healthy", "missing": []},
     },
 }

--- a/tests/test_observability/test_health.py
+++ b/tests/test_observability/test_health.py
@@ -11,7 +11,6 @@ from genesis.observability.health import (
     probe_ollama,
     probe_qdrant,
     probe_scheduler,
-    probe_tmp,
 )
 from genesis.observability.types import ProbeStatus
 
@@ -110,39 +109,6 @@ def _fake_statvfs(total_blocks, free_blocks, frsize=4096):
     result.f_bavail = free_blocks
     result.f_frsize = frsize
     return result
-
-
-class TestProbeTmp:
-    @pytest.mark.asyncio
-    async def test_healthy_low_usage(self):
-        # 30% used: 300 of 1000 blocks used
-        with patch("os.statvfs", return_value=_fake_statvfs(1000, 700)):
-            result = await probe_tmp(clock=FROZEN_CLOCK)
-        assert result.status == ProbeStatus.HEALTHY
-        assert result.name == "tmp_usage"
-        assert result.details["pct_used"] == 30.0
-
-    @pytest.mark.asyncio
-    async def test_degraded_at_warn(self):
-        # 85% used (between warn=80% and critical=90%)
-        with patch("os.statvfs", return_value=_fake_statvfs(1000, 150)):
-            result = await probe_tmp(clock=FROZEN_CLOCK)
-        assert result.status == ProbeStatus.DEGRADED
-
-    @pytest.mark.asyncio
-    async def test_down_at_critical(self):
-        # 90% used
-        with patch("os.statvfs", return_value=_fake_statvfs(1000, 100)):
-            result = await probe_tmp(clock=FROZEN_CLOCK)
-        assert result.status == ProbeStatus.DOWN
-        assert "/tmp" in result.message
-
-    @pytest.mark.asyncio
-    async def test_oserror_returns_down(self):
-        with patch("os.statvfs", side_effect=OSError("no such")):
-            result = await probe_tmp(clock=FROZEN_CLOCK)
-        assert result.status == ProbeStatus.DOWN
-        assert "Cannot stat" in result.message
 
 
 class TestProbeDisk:

--- a/tests/test_observability/test_health_data.py
+++ b/tests/test_observability/test_health_data.py
@@ -63,12 +63,6 @@ class TestSnapshot:
         snap = asyncio.run(svc.snapshot())
         assert "services" in snap
 
-    def test_infrastructure_includes_tmpfs(self, mock_db):
-        svc = HealthDataService(db=mock_db)
-        snap = asyncio.run(svc.snapshot())
-        infra = snap["infrastructure"]
-        assert "tmpfs" in infra
-
     def test_no_db_returns_unknown(self):
         svc = HealthDataService()
         snap = asyncio.run(svc.snapshot())

--- a/tests/test_observability/test_service_status.py
+++ b/tests/test_observability/test_service_status.py
@@ -11,7 +11,6 @@ import pytest
 from genesis.observability.service_status import (
     _load_watchdog_state,
     collect_service_status,
-    collect_tmpfs_usage,
     compute_uptime_seconds,
     parse_systemd_timestamp,
     probe_qdrant_collections,
@@ -121,14 +120,6 @@ class TestCollectServiceStatus:
             result = collect_service_status()
         assert result["watchdog"]["in_backoff"] is True
         assert result["watchdog"]["consecutive_failures"] == 2
-
-
-class TestCollectTmpfsUsage:
-    def test_returns_free_pct(self):
-        result = collect_tmpfs_usage()
-        assert "free_pct" in result
-        assert isinstance(result["free_pct"], float)
-        assert 0 <= result["free_pct"] <= 100
 
 
 class TestProbeQdrantCollections:

--- a/tests/test_sentinel/test_classifier.py
+++ b/tests/test_sentinel/test_classifier.py
@@ -79,7 +79,6 @@ class TestClassifyAlerts:
             "guardian:heartbeat_stale",             # Tier 1 (Part 8)
             "awareness:tick_overdue",               # Tier 1 (explicit — defense mechanism)
             "infra:disk_low",                       # Tier 2 (via blanket)
-            "infra:tmpfs_low",                      # Tier 2 (via blanket)
             "infra:container_memory_high",          # Tier 2 (via blanket)
             "infra:qdrant_collections_missing",     # Tier 2 (via blanket)
             "provider:embedding_failing",           # Tier 2 (via blanket)


### PR DESCRIPTION
## Summary

- **Ego proposals CHECK constraint fix**: Migration 0012 rebuilds the `ego_proposals` table to add `'tabled'` and `'withdrawn'` to the status CHECK constraint. Migration 0007 was silently bypassed because `_migrate_add_columns()` added the `rank` column first, causing 0007's idempotency check to exit early. 8 proposals were stuck as `pending` because board cleanup operations failed silently at the DB layer.

- **Defensive rebuild in `_migrate_add_columns()`**: Follows the existing pattern (cognitive_state, outreach_history, tool_registry) to ensure the constraint is fixed even without the versioned migration running.

- **Remove tmpfs probe**: `/tmp` is not a tmpfs mount on this container — it shares the root filesystem. The `probe_tmp` / `collect_tmpfs_usage` probe was redundantly reporting root filesystem usage (already covered by the disk probe), causing a misleading yellow status on the dashboard. The `cc_tmp` watchgod probe correctly handles `/tmp` monitoring regardless of filesystem type. Cleaned up related alert generator, remediation action, outreach escalation config, and docs.

## Test plan

- [x] Targeted tests: 259 passed (observability, health MCP, outreach, sentinel, guardian)
- [x] Full test suite: 3 background runs all passed (exit code 0)
- [x] Migration verified against copy of real database — tabling a proposal succeeds
- [x] Lint clean on all changed files
- [x] No regressions in guardian health signals (38 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)