### PR TITLE
fix(resilience): DB-fault-tolerant awareness tick + connection recovery + alert dedup

### DIFF
--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -664,7 +664,8 @@ class AwarenessLoop:
             # SQLite WAL checkpoint — prevent unbounded WAL growth from
             # external scripts or concurrent writers. PASSIVE is non-blocking.
             # (SQLite-specific; remove when migrating to PostgreSQL.)
-            _sqlite_wal_checkpoint(self._db)
+            if result is not None and result.db_available:
+                _sqlite_wal_checkpoint(self._db)
 
             # Status file writes are handled by a dedicated loop in
             # runtime/init/memory.py (status-writer-loop). Decoupled from

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -38,6 +38,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _sqlite_wal_checkpoint(db) -> None:
+    """Attempt a non-blocking WAL checkpoint. SQLite-specific."""
+    try:
+        import sqlite3
+        # Access the raw connection for synchronous PRAGMA
+        if hasattr(db, '_conn') and hasattr(db._conn, '_conn'):
+            raw = db._conn._conn
+            if isinstance(raw, sqlite3.Connection):
+                raw.execute("PRAGMA wal_checkpoint(PASSIVE)")
+    except Exception:
+        pass  # Best-effort; failure is harmless
+
+
 # Maps circuit-breaker degradation levels to resilience cloud axis states.
 _DEGRADATION_TO_CLOUD: dict[DegradationLevel, CloudStatus] = {
     DegradationLevel.NORMAL: CloudStatus.NORMAL,
@@ -63,106 +77,171 @@ async def perform_tick(
     """Execute one awareness tick. Testable without the scheduler."""
     now = datetime.now(UTC).isoformat()
     tick_id = str(uuid.uuid4())
-    escalation_source: str | None = None
 
-    # 1. Collect signals
+    # 1. Collect signals (DB-independent — always succeeds)
     signals = await collect_all(collectors)
 
-    # 2. Score urgency per depth
-    scores = await compute_scores(db, signals, now=now)
-
-    # 3. Classify depth
-    bypass = source == "critical_bypass"
-    decision = await classify_depth(db, scores, bypass_ceiling=bypass)
-
-    classified_depth = decision.depth if decision else None
-    trigger_reason = decision.reason if decision else reason
-
-    # 3b. Check for pending light→deep escalation
+    # 2-5. DB-dependent operations — wrapped for fault tolerance.
+    # If the DB is locked/unavailable, the tick still "succeeds" as degraded:
+    # signals are collected, _last_tick_at updates, but scoring/classification
+    # are skipped and the resilience memory axis is set to DOWN.
+    scores: list = []
+    decision = None
+    classified_depth = None
+    trigger_reason = reason
+    escalation_source: str | None = None
     escalation_pending_id: str | None = None
-    if cc_reflection_bridge is not None:
-        try:
-            # Fix 3A: expire stale escalations (>8h) before checking
-            _STALE_ESCALATION_HOURS = 8
-            all_pending = await observations.query(
-                db, type="light_escalation_pending", resolved=False, limit=10,
-            )
-            for stale in all_pending:
-                stale_created = stale.get("created_at", "")
-                try:
-                    stale_age = (
-                        datetime.now(UTC) - datetime.fromisoformat(stale_created)
-                    ).total_seconds() / 3600
-                except (ValueError, TypeError):
-                    stale_age = 999
-                if stale_age >= _STALE_ESCALATION_HOURS:
-                    await observations.resolve(
-                        db, stale["id"],
-                        resolved_at=now,
-                        resolution_notes=f"Expired (age {stale_age:.1f}h > {_STALE_ESCALATION_HOURS}h TTL)",
-                    )
-                    logger.info("Auto-resolved stale escalation %s (%.1fh old)", stale["id"], stale_age)
+    db_available = True
 
-            # Re-query after cleanup
-            pending_escalations = await observations.query(
-                db, type="light_escalation_pending", resolved=False, limit=1,
-            )
-            if pending_escalations:
-                esc_created = pending_escalations[0].get("created_at", "")
-                try:
-                    esc_age_hours = (
-                        datetime.now(UTC) - datetime.fromisoformat(esc_created)
-                    ).total_seconds() / 3600
-                except (ValueError, TypeError):
-                    esc_age_hours = 999  # treat unparseable as expired
+    try:
+        # 2. Score urgency per depth
+        scores = await compute_scores(db, signals, now=now)
 
-                if esc_age_hours < _STALE_ESCALATION_HOURS:
-                    # Fix 2A: daily escalation budget (max 2 per 24h)
-                    _ESCALATION_BUDGET_PER_DAY = 2
-                    resolved_recent = await observations.query(
-                        db, type="light_escalation_resolved", limit=20,
-                    )
-                    resolved_24h_count = 0
-                    resolved_2h_count = 0
-                    for r in resolved_recent:
-                        r_created = r.get("created_at", "")
-                        try:
-                            r_age = (
-                                datetime.now(UTC) - datetime.fromisoformat(r_created)
-                            ).total_seconds() / 3600
-                            if r_age < 2:
-                                resolved_2h_count += 1
-                            if r_age < 24:
-                                resolved_24h_count += 1
-                        except (ValueError, TypeError):
-                            pass
+        # 3. Classify depth
+        bypass = source == "critical_bypass"
+        decision = await classify_depth(db, scores, bypass_ceiling=bypass)
 
-                    # Check emergency bypass — critical signals override budget
-                    esc_content = pending_escalations[0].get("content", "").lower()
-                    is_emergency = any(kw in esc_content for kw in (
-                        "critical_failure", "data_loss", "security_breach",
-                        "all providers", "container memory critical",
-                    ))
+        classified_depth = decision.depth if decision else None
+        trigger_reason = decision.reason if decision else reason
 
-                    if resolved_2h_count >= 1 and not is_emergency:
-                        logger.info("Light escalation cooldown active (2h), skipping")
-                    elif resolved_24h_count >= _ESCALATION_BUDGET_PER_DAY and not is_emergency:
-                        logger.info(
-                            "Escalation budget exhausted (%d/%d in 24h), skipping",
-                            resolved_24h_count, _ESCALATION_BUDGET_PER_DAY,
+        # 3b. Check for pending light->deep escalation
+        if cc_reflection_bridge is not None:
+            try:
+                # Fix 3A: expire stale escalations (>8h) before checking
+                _STALE_ESCALATION_HOURS = 8
+                all_pending = await observations.query(
+                    db, type="light_escalation_pending", resolved=False, limit=10,
+                )
+                for stale in all_pending:
+                    stale_created = stale.get("created_at", "")
+                    try:
+                        stale_age = (
+                            datetime.now(UTC) - datetime.fromisoformat(stale_created)
+                        ).total_seconds() / 3600
+                    except (ValueError, TypeError):
+                        stale_age = 999
+                    if stale_age >= _STALE_ESCALATION_HOURS:
+                        await observations.resolve(
+                            db, stale["id"],
+                            resolved_at=now,
+                            resolution_notes=f"Expired (age {stale_age:.1f}h > {_STALE_ESCALATION_HOURS}h TTL)",
                         )
-                    else:
-                        if is_emergency:
-                            logger.warning("Emergency escalation bypassing budget: %s", esc_content[:100])
-                        classified_depth = Depth.DEEP
-                        escalation_source = "light_escalation"
-                        trigger_reason = f"light escalation: {pending_escalations[0].get('content', 'unknown')}"
-                        logger.info("Forcing DEEP reflection due to light escalation")
+                        logger.info("Auto-resolved stale escalation %s (%.1fh old)", stale["id"], stale_age)
 
-                        # Fix 3B: defer resolution until after successful dispatch
-                        escalation_pending_id = pending_escalations[0]["id"]
-        except Exception:
-            logger.warning("Failed to check light escalation state", exc_info=True)
+                # Re-query after cleanup
+                pending_escalations = await observations.query(
+                    db, type="light_escalation_pending", resolved=False, limit=1,
+                )
+                if pending_escalations:
+                    esc_created = pending_escalations[0].get("created_at", "")
+                    try:
+                        esc_age_hours = (
+                            datetime.now(UTC) - datetime.fromisoformat(esc_created)
+                        ).total_seconds() / 3600
+                    except (ValueError, TypeError):
+                        esc_age_hours = 999  # treat unparseable as expired
+
+                    if esc_age_hours < _STALE_ESCALATION_HOURS:
+                        # Fix 2A: daily escalation budget (max 2 per 24h)
+                        _ESCALATION_BUDGET_PER_DAY = 2
+                        resolved_recent = await observations.query(
+                            db, type="light_escalation_resolved", limit=20,
+                        )
+                        resolved_24h_count = 0
+                        resolved_2h_count = 0
+                        for r in resolved_recent:
+                            r_created = r.get("created_at", "")
+                            try:
+                                r_age = (
+                                    datetime.now(UTC) - datetime.fromisoformat(r_created)
+                                ).total_seconds() / 3600
+                                if r_age < 2:
+                                    resolved_2h_count += 1
+                                if r_age < 24:
+                                    resolved_24h_count += 1
+                            except (ValueError, TypeError):
+                                pass
+
+                        # Check emergency bypass -- critical signals override budget
+                        esc_content = pending_escalations[0].get("content", "").lower()
+                        is_emergency = any(kw in esc_content for kw in (
+                            "critical_failure", "data_loss", "security_breach",
+                            "all providers", "container memory critical",
+                        ))
+
+                        if resolved_2h_count >= 1 and not is_emergency:
+                            logger.info("Light escalation cooldown active (2h), skipping")
+                        elif resolved_24h_count >= _ESCALATION_BUDGET_PER_DAY and not is_emergency:
+                            logger.info(
+                                "Escalation budget exhausted (%d/%d in 24h), skipping",
+                                resolved_24h_count, _ESCALATION_BUDGET_PER_DAY,
+                            )
+                        else:
+                            if is_emergency:
+                                logger.warning("Emergency escalation bypassing budget: %s", esc_content[:100])
+                            classified_depth = Depth.DEEP
+                            escalation_source = "light_escalation"
+                            trigger_reason = f"light escalation: {pending_escalations[0].get('content', 'unknown')}"
+                            logger.info("Forcing DEEP reflection due to light escalation")
+
+                            # Fix 3B: defer resolution until after successful dispatch
+                            escalation_pending_id = pending_escalations[0]["id"]
+            except Exception:
+                logger.warning("Failed to check light escalation state", exc_info=True)
+
+        # 4. Store tick result
+        await awareness_ticks.create(
+            db,
+            id=tick_id,
+            source=source,
+            signals_json=json.dumps([
+                {"name": s.name, "value": s.value, "source": s.source,
+                 "collected_at": s.collected_at}
+                for s in signals
+            ]),
+            scores_json=json.dumps([
+                {"depth": s.depth.value, "raw_score": s.raw_score,
+                 "time_multiplier": s.time_multiplier, "final_score": s.final_score,
+                 "threshold": s.threshold, "triggered": s.triggered}
+                for s in scores
+            ]),
+            classified_depth=classified_depth.value if classified_depth else None,
+            trigger_reason=trigger_reason,
+            created_at=now,
+        )
+
+        # 5. If triggered, also create an observation (with content-hash dedup)
+        if decision is not None:
+            obs_content = json.dumps({
+                "tick_id": tick_id,
+                "depth": classified_depth.value,
+                "reason": trigger_reason,
+                "scores": {s.depth.value: s.final_score for s in scores},
+            }, sort_keys=True)
+            content_hash = hashlib.sha256(obs_content.encode()).hexdigest()
+            is_dup = await observations.exists_by_hash(
+                db, source="awareness_loop", content_hash=content_hash, unresolved_only=True,
+            )
+            if not is_dup:
+                obs_id = str(uuid.uuid4())
+                await observations.create(
+                    db,
+                    id=obs_id,
+                    source="awareness_loop",
+                    type="awareness_tick",
+                    content=obs_content,
+                    priority="high" if classified_depth in (Depth.DEEP, Depth.STRATEGIC) else "medium",
+                    created_at=now,
+                    content_hash=content_hash,
+                    skip_if_duplicate=True,
+                )
+
+    except Exception as db_exc:
+        db_available = False
+        logger.warning(
+            "Tick DB operations failed — degraded tick (signals collected, "
+            "scoring/persistence skipped): %s", db_exc,
+        )
 
     result = TickResult(
         tick_id=tick_id,
@@ -172,57 +251,11 @@ async def perform_tick(
         scores=scores,
         classified_depth=classified_depth,
         trigger_reason=trigger_reason,
-        escalation_source=escalation_source,
-        escalation_pending_id=escalation_pending_id,
+        escalation_source=escalation_source if db_available else None,
+        escalation_pending_id=escalation_pending_id if db_available else None,
         signal_staleness=get_staleness_context(),
+        db_available=db_available,
     )
-
-    # 4. Store tick result
-    await awareness_ticks.create(
-        db,
-        id=tick_id,
-        source=source,
-        signals_json=json.dumps([
-            {"name": s.name, "value": s.value, "source": s.source,
-             "collected_at": s.collected_at}
-            for s in signals
-        ]),
-        scores_json=json.dumps([
-            {"depth": s.depth.value, "raw_score": s.raw_score,
-             "time_multiplier": s.time_multiplier, "final_score": s.final_score,
-             "threshold": s.threshold, "triggered": s.triggered}
-            for s in scores
-        ]),
-        classified_depth=classified_depth.value if classified_depth else None,
-        trigger_reason=trigger_reason,
-        created_at=now,
-    )
-
-    # 5. If triggered, also create an observation (with content-hash dedup)
-    if decision is not None:
-        obs_content = json.dumps({
-            "tick_id": tick_id,
-            "depth": classified_depth.value,
-            "reason": trigger_reason,
-            "scores": {s.depth.value: s.final_score for s in scores},
-        }, sort_keys=True)
-        content_hash = hashlib.sha256(obs_content.encode()).hexdigest()
-        is_dup = await observations.exists_by_hash(
-            db, source="awareness_loop", content_hash=content_hash, unresolved_only=True,
-        )
-        if not is_dup:
-            obs_id = str(uuid.uuid4())
-            await observations.create(
-                db,
-                id=obs_id,
-                source="awareness_loop",
-                type="awareness_tick",
-                content=obs_content,
-                priority="high" if classified_depth in (Depth.DEEP, Depth.STRATEGIC) else "medium",
-                created_at=now,
-                content_hash=content_hash,
-                skip_if_duplicate=True,
-            )
 
     if not dispatch_reflection:
         return result
@@ -525,29 +558,13 @@ class AwarenessLoop:
                     deferred_queue=self._deferred_queue,
                     dispatch_reflection=False,
                 )
-                self._tick_count += 1
-                self._last_tick_at = datetime.now(UTC).isoformat()
-                self._last_tick_result = result
-                if result.classified_depth:
-                    logger.info(
-                        "Tick triggered %s: %s",
-                        result.classified_depth.value, result.trigger_reason,
-                    )
-                # Heartbeat — lets health MCP detect silent death
-                if self._event_bus:
-                    await self._event_bus.emit(
-                        Subsystem.AWARENESS, Severity.DEBUG,
-                        "heartbeat", "awareness_loop tick completed",
-                    )
-                try:
-                    from genesis.runtime import GenesisRuntime
-                    GenesisRuntime.instance().record_job_success("awareness_tick")
-                except Exception:
-                    pass  # Runtime may not be available in tests
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                logger.exception("Awareness tick failed")
+                # perform_tick itself shouldn't raise (it has internal
+                # try/except for DB ops), but guard against unexpected
+                # failures in signal collection or other non-DB code.
+                logger.exception("Awareness tick failed unexpectedly")
                 if self._event_bus:
                     await self._event_bus.emit(
                         Subsystem.AWARENESS, Severity.ERROR,
@@ -559,6 +576,53 @@ class AwarenessLoop:
                     GenesisRuntime.instance().record_job_failure("awareness_tick", str(exc))
                 except Exception:
                     pass
+                # Even on unexpected failure, don't leave _last_tick_at stale
+                self._last_tick_at = datetime.now(UTC).isoformat()
+
+            if result is not None:
+                # Always update tick tracking — even degraded ticks count
+                # as "alive" to prevent false overdue alerts.
+                self._tick_count += 1
+                self._last_tick_at = datetime.now(UTC).isoformat()
+                self._last_tick_result = result
+
+                if result.classified_depth:
+                    logger.info(
+                        "Tick triggered %s: %s",
+                        result.classified_depth.value, result.trigger_reason,
+                    )
+
+                if not result.db_available:
+                    logger.warning(
+                        "Tick %d completed DEGRADED (DB unavailable)",
+                        self._tick_count,
+                    )
+
+                # Heartbeat — lets health MCP detect silent death
+                if self._event_bus:
+                    await self._event_bus.emit(
+                        Subsystem.AWARENESS, Severity.DEBUG,
+                        "heartbeat",
+                        "awareness_loop tick completed"
+                        + (" (degraded)" if not result.db_available else ""),
+                    )
+                try:
+                    from genesis.runtime import GenesisRuntime
+                    if result.db_available:
+                        GenesisRuntime.instance().record_job_success("awareness_tick")
+                    else:
+                        GenesisRuntime.instance().record_job_failure(
+                            "awareness_tick", "DB unavailable (degraded tick)")
+                except Exception:
+                    pass  # Runtime may not be available in tests
+
+            # Update resilience memory axis based on DB availability
+            if self._resilience_state_machine and result is not None:
+                from genesis.resilience.state import MemoryStatus
+                if result.db_available:
+                    self._resilience_state_machine.update_memory(MemoryStatus.NORMAL)
+                else:
+                    self._resilience_state_machine.update_memory(MemoryStatus.DOWN)
 
             # Update resilience cloud axis from circuit breaker state
             if self._resilience_state_machine and self._circuit_breakers:
@@ -596,6 +660,11 @@ class AwarenessLoop:
                         self._resilience_state_machine.update_tmp_pressure(tmp_status)
                 except Exception:
                     logger.debug("tmp_pressure axis update failed", exc_info=True)
+
+            # SQLite WAL checkpoint — prevent unbounded WAL growth from
+            # external scripts or concurrent writers. PASSIVE is non-blocking.
+            # (SQLite-specific; remove when migrating to PostgreSQL.)
+            _sqlite_wal_checkpoint(self._db)
 
             # Status file writes are handled by a dedicated loop in
             # runtime/init/memory.py (status-writer-loop). Decoupled from

--- a/src/genesis/awareness/types.py
+++ b/src/genesis/awareness/types.py
@@ -57,3 +57,4 @@ class TickResult:
     escalation_source: str | None = None
     escalation_pending_id: str | None = None  # observation ID to resolve after dispatch
     signal_staleness: dict[str, int] | None = None  # signal_name → consecutive unchanged ticks
+    db_available: bool = True  # False when DB operations failed (degraded tick)

--- a/src/genesis/db/connection.py
+++ b/src/genesis/db/connection.py
@@ -8,7 +8,9 @@ coroutines from interleaving execute+commit and locking the connection.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
+import logging
+import sqlite3
+from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +18,8 @@ import aiosqlite
 from aiosqlite.context import Result
 
 from genesis.env import genesis_db_path
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_DB_PATH = genesis_db_path()
 
@@ -51,11 +55,24 @@ class SerializedConnection:
     """
 
     # Attributes that live on the proxy itself, not the wrapped connection.
-    _OWN_ATTRS = frozenset({"_conn", "_lock"})
+    _OWN_ATTRS = frozenset({
+        "_conn", "_lock", "_reconnect_fn",
+        "_consecutive_errors", "_max_errors",
+    })
 
-    def __init__(self, conn: aiosqlite.Connection) -> None:
+    _MAX_LOCK_ERRORS = 5
+
+    def __init__(
+        self,
+        conn: aiosqlite.Connection,
+        *,
+        reconnect_fn: Callable[[], aiosqlite.Connection] | None = None,
+    ) -> None:
         object.__setattr__(self, "_conn", conn)
         object.__setattr__(self, "_lock", asyncio.Lock())
+        object.__setattr__(self, "_reconnect_fn", reconnect_fn)
+        object.__setattr__(self, "_consecutive_errors", 0)
+        object.__setattr__(self, "_max_errors", self._MAX_LOCK_ERRORS)
 
     # -- Attribute passthrough (e.g. row_factory, in_transaction) ----------
 
@@ -68,6 +85,34 @@ class SerializedConnection:
         else:
             setattr(self._conn, name, value)
 
+    # -- Error tracking and recovery ----------------------------------------
+
+    def _reset_error_count(self) -> None:
+        object.__setattr__(self, "_consecutive_errors", 0)
+
+    async def _handle_lock_error(self, exc: Exception) -> None:
+        """Track lock errors and attempt reconnection after threshold."""
+        count = self._consecutive_errors + 1
+        object.__setattr__(self, "_consecutive_errors", count)
+        if count >= self._max_errors and self._reconnect_fn is not None:
+            logger.warning(
+                "DB lock error %d/%d — attempting reconnection",
+                count, self._max_errors,
+            )
+            try:
+                old_conn = self._conn
+                try:
+                    await old_conn.close()
+                except Exception:
+                    logger.debug("Old connection close failed", exc_info=True)
+                new_conn = await self._reconnect_fn()
+                object.__setattr__(self, "_conn", new_conn)
+                object.__setattr__(self, "_consecutive_errors", 0)
+                logger.info("DB connection recovered after %d lock errors", count)
+            except Exception:
+                logger.error("DB reconnection failed", exc_info=True)
+        raise exc
+
     # -- Operations that return Result (support both await and async with) --
 
     def execute(
@@ -75,7 +120,14 @@ class SerializedConnection:
     ) -> Result:
         async def _locked() -> aiosqlite.Cursor:
             async with self._lock:
-                return await self._conn.execute(sql, parameters)
+                try:
+                    result = await self._conn.execute(sql, parameters)
+                    self._reset_error_count()
+                    return result
+                except sqlite3.OperationalError as e:
+                    if "locked" in str(e):
+                        await self._handle_lock_error(e)
+                    raise
         return Result(_locked())
 
     def executemany(
@@ -83,7 +135,14 @@ class SerializedConnection:
     ) -> Result:
         async def _locked() -> aiosqlite.Cursor:
             async with self._lock:
-                return await self._conn.executemany(sql, parameters)
+                try:
+                    result = await self._conn.executemany(sql, parameters)
+                    self._reset_error_count()
+                    return result
+                except sqlite3.OperationalError as e:
+                    if "locked" in str(e):
+                        await self._handle_lock_error(e)
+                    raise
         return Result(_locked())
 
     def execute_fetchall(
@@ -91,7 +150,14 @@ class SerializedConnection:
     ) -> Result:
         async def _locked() -> list[aiosqlite.Row]:
             async with self._lock:
-                return await self._conn.execute_fetchall(sql, parameters)
+                try:
+                    result = await self._conn.execute_fetchall(sql, parameters)
+                    self._reset_error_count()
+                    return result
+                except sqlite3.OperationalError as e:
+                    if "locked" in str(e):
+                        await self._handle_lock_error(e)
+                    raise
         return Result(_locked())
 
     def execute_insert(
@@ -99,20 +165,40 @@ class SerializedConnection:
     ) -> Result:
         async def _locked() -> tuple | None:
             async with self._lock:
-                return await self._conn.execute_insert(sql, parameters)
+                try:
+                    result = await self._conn.execute_insert(sql, parameters)
+                    self._reset_error_count()
+                    return result
+                except sqlite3.OperationalError as e:
+                    if "locked" in str(e):
+                        await self._handle_lock_error(e)
+                    raise
         return Result(_locked())
 
     def executescript(self, sql: str) -> Result:
         async def _locked() -> aiosqlite.Cursor:
             async with self._lock:
-                return await self._conn.executescript(sql)
+                try:
+                    result = await self._conn.executescript(sql)
+                    self._reset_error_count()
+                    return result
+                except sqlite3.OperationalError as e:
+                    if "locked" in str(e):
+                        await self._handle_lock_error(e)
+                    raise
         return Result(_locked())
 
     # -- Simple async operations -------------------------------------------
 
     async def commit(self) -> None:
         async with self._lock:
-            await self._conn.commit()
+            try:
+                await self._conn.commit()
+                self._reset_error_count()
+            except sqlite3.OperationalError as e:
+                if "locked" in str(e):
+                    await self._handle_lock_error(e)
+                raise
 
     async def rollback(self) -> None:
         async with self._lock:
@@ -150,7 +236,17 @@ async def get_db(path: str | Path = DEFAULT_DB_PATH) -> SerializedConnection:
     await db.execute("PRAGMA journal_mode=WAL")
     await db.execute("PRAGMA foreign_keys=ON")
     await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
-    return SerializedConnection(db)
+
+    # Build reconnect closure (SQLite-specific; replace for PostgreSQL)
+    async def _reconnect() -> aiosqlite.Connection:
+        conn = await aiosqlite.connect(str(path))
+        conn.row_factory = aiosqlite.Row
+        await conn.execute("PRAGMA journal_mode=WAL")
+        await conn.execute("PRAGMA foreign_keys=ON")
+        await conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+        return conn
+
+    return SerializedConnection(db, reconnect_fn=_reconnect)
 
 
 async def init_db(path: str | Path = DEFAULT_DB_PATH) -> SerializedConnection:

--- a/src/genesis/db/connection.py
+++ b/src/genesis/db/connection.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
-from collections.abc import Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from pathlib import Path
 from typing import Any
 
@@ -66,7 +66,7 @@ class SerializedConnection:
         self,
         conn: aiosqlite.Connection,
         *,
-        reconnect_fn: Callable[[], aiosqlite.Connection] | None = None,
+        reconnect_fn: Callable[[], Awaitable[aiosqlite.Connection]] | None = None,
     ) -> None:
         object.__setattr__(self, "_conn", conn)
         object.__setattr__(self, "_lock", asyncio.Lock())

--- a/src/genesis/knowledge/distillation.py
+++ b/src/genesis/knowledge/distillation.py
@@ -325,7 +325,7 @@ class DistillationPipeline:
         ]
 
         try:
-            result = await self._router.route_call(_CALL_SITE, messages)
+            result = await self._router.route_call(_CALL_SITE, messages, chain_offset=chunk_index)
             if not result.success or not result.content:
                 logger.warning("Distillation LLM call failed for chunk: %s",
                                result.error or "empty response")

--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -6,6 +6,7 @@ distillation -> knowledge units -> storage (SQLite + Qdrant).
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import typing
@@ -45,6 +46,7 @@ class KnowledgeOrchestrator:
         self._registry = registry
         self._distillation = distillation
         self._manifest = manifest
+        self._store_lock = asyncio.Lock()
 
     async def ingest_source(
         self,
@@ -131,10 +133,11 @@ class KnowledgeOrchestrator:
 
         # 7. Store each unit
         try:
-            unit_ids = await self._store_units(
-                units, project_type=project_type, source=source,
-                content=content, purpose=purpose,
-            )
+            async with self._store_lock:
+                unit_ids = await self._store_units(
+                    units, project_type=project_type, source=source,
+                    content=content, purpose=purpose,
+                )
         except Exception as exc:
             logger.error("Storage failed for %s: %s", source, exc)
             return IngestResult(

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -41,6 +41,11 @@ class OutreachScheduler:
         self._curve_computer = curve_computer
         self._event_bus = event_bus
         self._scheduler: AsyncIOScheduler | None = None
+        # In-memory alert dedup — DB-independent fallback.
+        # When DB is locked, the outreach_history dedup query fails silently
+        # (returns empty set), causing repeated alerts. This dict survives
+        # across health check cycles as a reliable dedup layer.
+        self._alert_last_sent: dict[str, float] = {}  # alert_id → monotonic time
 
     @property
     def is_running(self) -> bool:
@@ -235,10 +240,10 @@ class OutreachScheduler:
         report, awareness signals). Multiple alerts are batched into one message.
         """
         try:
+            import time
             from datetime import datetime
 
             from genesis.outreach.health_outreach import HealthOutreachBridge
-
             escalation_ids = frozenset(
                 self._config.immediate_escalation_alerts
             )
@@ -248,6 +253,28 @@ class OutreachScheduler:
             if not requests:
                 await self._record_job_result("health_check")
                 return
+
+            # In-memory dedup — filter out alerts sent recently.
+            # This is the primary dedup layer; the DB query in
+            # HealthOutreachBridge is the secondary (cross-restart) layer.
+            from genesis.outreach.health_outreach import _DEDUP_HOURS
+            dedup_window_s = _DEDUP_HOURS * 3600
+            now_mono = time.monotonic()
+            deduped = []
+            for req in requests:
+                aid = req.source_id or ""
+                last = self._alert_last_sent.get(aid)
+                if last is not None and (now_mono - last) < dedup_window_s:
+                    continue
+                deduped.append(req)
+            if not deduped:
+                logger.info(
+                    "Health outreach: %d alert(s) suppressed by in-memory dedup",
+                    len(requests),
+                )
+                await self._record_job_result("health_check")
+                return
+            requests = deduped
 
             # Batch all immediate alerts into one Telegram message
             lines = ["\u26a0\ufe0f INFRASTRUCTURE ALERT", ""]
@@ -284,6 +311,11 @@ class OutreachScheduler:
                 "Health outreach (batched %d alert(s)): %s",
                 len(requests), result.status.value,
             )
+            # Record send time in memory — regardless of whether DB
+            # write succeeded. This prevents re-send on next cycle.
+            for req in requests:
+                if req.source_id:
+                    self._alert_last_sent[req.source_id] = now_mono
             await self._record_job_result("health_check")
         except Exception as exc:
             logger.exception("Health check outreach job failed")

--- a/src/genesis/routing/router.py
+++ b/src/genesis/routing/router.py
@@ -150,6 +150,7 @@ class Router:
         *,
         budget_override: bool = False,
         suppress_dead_letter: bool = False,
+        chain_offset: int = 0,
         **kwargs,
     ) -> RoutingResult:
         """Route a call through the provider chain for the given call site."""
@@ -174,8 +175,17 @@ class Router:
         if policy is None:
             policy = self.config.retry_profiles["default"]
 
-        # 3. Filter chain
+        # 3. Filter chain (and rotate for parallelization)
         chain = self._filter_chain(site)
+        if not chain:
+            return RoutingResult(
+                success=False,
+                call_site_id=call_site_id,
+                error="No providers available in chain after filtering",
+            )
+        if chain_offset:
+            n = chain_offset % len(chain)
+            chain = chain[n:] + chain[:n]
         if not chain:
             return RoutingResult(
                 success=False,

--- a/src/genesis/routing/router.py
+++ b/src/genesis/routing/router.py
@@ -186,12 +186,6 @@ class Router:
         if chain_offset:
             n = chain_offset % len(chain)
             chain = chain[n:] + chain[:n]
-        if not chain:
-            return RoutingResult(
-                success=False,
-                call_site_id=call_site_id,
-                error="No providers available in chain after filtering",
-            )
 
         # 4. Check budget once (shared across providers)
         budget_status = BudgetStatus.UNDER_LIMIT

--- a/tests/test_awareness/test_db_resilience.py
+++ b/tests/test_awareness/test_db_resilience.py
@@ -1,0 +1,53 @@
+"""Tests for DB-fault-tolerant awareness tick (A1).
+
+Verifies that when DB operations fail, the tick degrades gracefully:
+- Signals still collected
+- db_available=False in result
+- No exception propagated
+"""
+
+from unittest.mock import patch
+
+from genesis.awareness.loop import perform_tick
+from genesis.awareness.signals import ConversationCollector
+from genesis.awareness.types import TickResult
+
+
+async def test_degraded_tick_on_db_failure(db):
+    """When DB ops raise, tick returns degraded result with db_available=False."""
+    collectors = [ConversationCollector()]
+
+    # Make compute_scores raise (simulating DB lock)
+    with patch(
+        "genesis.awareness.loop.compute_scores",
+        side_effect=Exception("database is locked"),
+    ):
+        result = await perform_tick(db, collectors, source="scheduled")
+
+    assert isinstance(result, TickResult)
+    assert result.db_available is False
+    assert result.classified_depth is None
+    assert result.scores == []
+    assert len(result.signals) > 0  # signals still collected
+
+
+async def test_normal_tick_has_db_available_true(db):
+    """Normal tick sets db_available=True."""
+    collectors = [ConversationCollector()]
+    result = await perform_tick(db, collectors, source="scheduled")
+
+    assert result.db_available is True
+
+
+async def test_degraded_tick_clears_escalation(db):
+    """Degraded tick should not carry escalation state."""
+    collectors = [ConversationCollector()]
+
+    with patch(
+        "genesis.awareness.loop.compute_scores",
+        side_effect=Exception("database is locked"),
+    ):
+        result = await perform_tick(db, collectors, source="scheduled")
+
+    assert result.escalation_source is None
+    assert result.escalation_pending_id is None

--- a/tests/test_db/test_connection_recovery.py
+++ b/tests/test_db/test_connection_recovery.py
@@ -1,0 +1,115 @@
+"""Tests for SerializedConnection lock error tracking and recovery (A3)."""
+
+import sqlite3
+
+import aiosqlite
+import pytest
+
+from genesis.db.connection import SerializedConnection
+
+
+@pytest.fixture
+async def recovery_conn(tmp_path):
+    """SerializedConnection with reconnect_fn for testing."""
+    db_path = tmp_path / "test.db"
+    conn = await aiosqlite.connect(str(db_path))
+    conn.row_factory = aiosqlite.Row
+    await conn.execute("PRAGMA journal_mode=WAL")
+    await conn.execute("CREATE TABLE t(x)")
+    await conn.commit()
+
+    async def _reconnect():
+        c = await aiosqlite.connect(str(db_path))
+        c.row_factory = aiosqlite.Row
+        await c.execute("PRAGMA journal_mode=WAL")
+        return c
+
+    sc = SerializedConnection(conn, reconnect_fn=_reconnect)
+    yield sc
+    import contextlib
+    with contextlib.suppress(Exception):
+        await sc.close()
+
+
+async def test_error_counter_resets_on_success(recovery_conn):
+    """Successful operations reset the consecutive error counter."""
+    await recovery_conn.execute("INSERT INTO t VALUES (1)")
+    await recovery_conn.commit()
+    assert recovery_conn._consecutive_errors == 0
+
+
+async def test_error_counter_increments_on_lock(recovery_conn):
+    """Lock errors increment the counter and re-raise."""
+    # Patch the underlying execute to simulate lock error
+    original = recovery_conn._conn.execute
+
+    call_count = 0
+
+    async def fake_execute(sql, params=None):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise sqlite3.OperationalError("database is locked")
+        return await original(sql, params)
+
+    recovery_conn._conn.execute = fake_execute
+
+    with pytest.raises(sqlite3.OperationalError, match="locked"):
+        await recovery_conn.execute("SELECT 1")
+
+    assert recovery_conn._consecutive_errors == 1
+
+    with pytest.raises(sqlite3.OperationalError, match="locked"):
+        await recovery_conn.execute("SELECT 1")
+
+    assert recovery_conn._consecutive_errors == 2
+
+
+async def test_reconnect_after_threshold(recovery_conn):
+    """After _MAX_LOCK_ERRORS consecutive failures, reconnection is attempted."""
+    recovery_conn._max_errors = 3  # Lower threshold for testing
+    original_conn = recovery_conn._conn
+
+    fail_count = 0
+
+    async def always_fail(sql, params=None):
+        nonlocal fail_count
+        fail_count += 1
+        raise sqlite3.OperationalError("database is locked")
+
+    recovery_conn._conn.execute = always_fail
+
+    # First 2 failures — just increment counter
+    for _ in range(2):
+        with pytest.raises(sqlite3.OperationalError):
+            await recovery_conn.execute("SELECT 1")
+
+    assert recovery_conn._consecutive_errors == 2
+
+    # 3rd failure — triggers reconnect
+    with pytest.raises(sqlite3.OperationalError):
+        await recovery_conn.execute("SELECT 1")
+
+    # After reconnect, counter resets and conn is new
+    assert recovery_conn._consecutive_errors == 0
+    assert recovery_conn._conn is not original_conn
+
+
+async def test_no_reconnect_without_fn():
+    """Without reconnect_fn, lock errors just increment and re-raise."""
+    conn = await aiosqlite.connect(":memory:")
+    sc = SerializedConnection(conn)  # No reconnect_fn
+
+
+    async def fake_fail(sql, params=None):
+        raise sqlite3.OperationalError("database is locked")
+
+    conn.execute = fake_fail
+
+    for _ in range(10):
+        with pytest.raises(sqlite3.OperationalError):
+            await sc.execute("SELECT 1")
+
+    # Counter goes up but no crash
+    assert sc._consecutive_errors == 10
+    await sc.close()

--- a/tests/test_routing/test_chain_offset.py
+++ b/tests/test_routing/test_chain_offset.py
@@ -1,0 +1,59 @@
+"""Tests for chain_offset rotation logic (B1).
+
+Tests the rotation math directly rather than constructing a full Router,
+since chain rotation is a simple list operation applied inside route_call.
+"""
+
+
+
+def _rotate_chain(chain: list[str], offset: int) -> list[str]:
+    """Reproduce the rotation logic from Router.route_call."""
+    if not chain or not offset:
+        return list(chain)
+    n = offset % len(chain)
+    return chain[n:] + chain[:n]
+
+
+def test_offset_zero_unchanged():
+    """chain_offset=0 returns original order."""
+    assert _rotate_chain(["A", "B", "C"], 0) == ["A", "B", "C"]
+
+
+def test_offset_one():
+    """chain_offset=1 starts at the 2nd provider."""
+    assert _rotate_chain(["A", "B", "C", "D", "E"], 1) == ["B", "C", "D", "E", "A"]
+
+
+def test_offset_two():
+    """chain_offset=2 starts at the 3rd provider."""
+    assert _rotate_chain(["A", "B", "C", "D", "E"], 2) == ["C", "D", "E", "A", "B"]
+
+
+def test_offset_wraps_modulo():
+    """chain_offset > len(chain) wraps correctly."""
+    assert _rotate_chain(["A", "B", "C"], 7) == ["B", "C", "A"]  # 7 % 3 = 1
+
+
+def test_offset_equal_to_length():
+    """chain_offset == len(chain) is equivalent to offset=0."""
+    assert _rotate_chain(["A", "B", "C"], 3) == ["A", "B", "C"]
+
+
+def test_single_provider_unaffected():
+    """Single-provider chain is unaffected by any offset."""
+    for offset in [0, 1, 5, 100]:
+        assert _rotate_chain(["A"], offset) == ["A"]
+
+
+def test_distillation_round_robin():
+    """Simulate 10 chunks across 5 providers — each gets 2 chunks."""
+    providers = ["cerebras", "groq", "gemini", "mistral", "deepseek"]
+    assignments = {}
+    for chunk_idx in range(10):
+        rotated = _rotate_chain(providers, chunk_idx)
+        primary = rotated[0]
+        assignments.setdefault(primary, []).append(chunk_idx)
+
+    # Each provider should be primary for exactly 2 chunks
+    for p in providers:
+        assert len(assignments[p]) == 2, f"{p} got {assignments[p]}"


### PR DESCRIPTION
## Summary

- **A1: DB-fault-tolerant awareness tick** — `perform_tick` wraps DB operations in try/except. Signal collection always succeeds. On DB failure, tick returns degraded result with `db_available=False`. `_on_tick` ALWAYS updates `_last_tick_at` (preventing false overdue alerts) and sets resilience memory axis to DOWN (L4 MEMORY_IMPAIRED).

- **A2: In-memory alert dedup** — `OutreachScheduler` adds `_alert_last_sent` dict checked BEFORE the DB-dependent bridge query. Updated after Telegram send, not after DB write. Prevents alert spam when DB is locked (Telegram sends before DB record write, so DB dedup layer is bypassed).

- **A3: Connection recovery** — `SerializedConnection` tracks consecutive lock errors. After 5 failures, closes and reopens connection via `reconnect_fn` closure. Engine-agnostic pattern (replace closure for PostgreSQL).

- **A4: WAL checkpoint** — Periodic `PRAGMA wal_checkpoint(PASSIVE)` in awareness tick handler. Prevents unbounded WAL growth from external scripts. SQLite-specific, clearly scoped.

- **B1: chain_offset** — `Router.route_call()` gains `chain_offset` parameter. Rotates provider chain for parallelized distillation (chunk N starts at provider N % chain_length).

- **B2: Storage lock** — `asyncio.Lock` around `_store_units` for concurrent chunk safety.

## Context

Two DB lock incidents in one session exposed a systemic failure: every resilience mechanism depends on the DB. When the DB locks (67MB WAL from external batch scripts), the awareness loop "fails" every tick, `_last_tick_at` goes stale, the overdue alert fires repeatedly (dedup query fails → returns empty set, Telegram sends before DB write → no record persists), and the connection never recovers without manual restart.

## Test plan

- [x] `test_degraded_tick_on_db_failure` — tick returns db_available=False, signals collected
- [x] `test_normal_tick_has_db_available_true` — normal path unchanged  
- [x] `test_degraded_tick_clears_escalation` — no escalation state on degraded tick
- [x] `test_error_counter_resets_on_success` — counter resets after successful operation
- [x] `test_error_counter_increments_on_lock` — counter tracks consecutive failures
- [x] `test_reconnect_after_threshold` — reconnection triggered at threshold
- [x] `test_no_reconnect_without_fn` — graceful degradation without reconnect_fn
- [x] `test_offset_*` — rotation math for all edge cases including round-robin distribution
- [x] 98 pre-existing awareness tests pass
- [x] ruff check clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)