### PR TITLE
fix(test): update assertions for eval tables and routing config

### DIFF
--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -86,6 +86,7 @@ async def test_no_unexpected_tables(db):
         "knowledge_uploads",
         "file_modifications",
         "direct_session_queue",
+        "eval_events", "eval_snapshots",
     }
     for table in tables:
         assert table in known, f"Unexpected table: {table}"

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -122,9 +122,9 @@ def test_load_full_yaml(monkeypatch):
     path = Path(__file__).resolve().parents[2] / "config" / "model_routing.yaml"
     cfg = load_config(path)
     # lmstudio-30b, github-o3mini, openrouter-deepseek-r1 disabled → 27 enabled providers
-    # (30 total - 3 disabled; added openrouter-deepseek-v4, openrouter-gpt55 for
+    # (32 total - 4 disabled; added openrouter-deepseek-v4, openrouter-gpt55 for
     # executor review gates)
-    assert len(cfg.providers) == 27
+    assert len(cfg.providers) == 28
     assert "lmstudio-30b" not in cfg.providers
     assert "github-o3mini" not in cfg.providers
     assert "openrouter-deepseek-r1" not in cfg.providers
@@ -145,7 +145,7 @@ def test_load_full_yaml(monkeypatch):
     # lmstudio-30b filtered out, only mistral-large-free remains
     assert cfg.call_sites["30_triage_calibration"].chain == ["mistral-large-free"]
     assert cfg.call_sites["31_outcome_classification"].chain == [
-        "glm5", "mistral-large-free",
+        "glm51", "mistral-large-free",
     ]
 
     # mistral-large-free provider (consolidated from mistral-free + mistral-large)


### PR DESCRIPTION
## Summary

- Add `eval_events` and `eval_snapshots` to known tables in test_schema (from migration 0011)
- Update provider count 27→28 in test_config (deepseek-v4-flash added, deepseek-chat disabled)
- Rename `glm5`→`glm51` in chain assertion (renamed in #274)

Fixes 7 pre-existing test failures (6 migration runner + 1 schema).
Migration runner tests now pass because the `db.commit()` in migration 0011
was already fixed with a comment.

## Test plan

- [x] `test_no_unexpected_tables` passes
- [x] `test_load_full_yaml` passes
- [x] All 5 migration runner tests pass
- [x] 30/30 tests in test_db + test_config pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)