### PR TITLE
feat(memory): SVO event calendar for temporal queries

### DIFF
--- a/src/genesis/db/crud/memory_events.py
+++ b/src/genesis/db/crud/memory_events.py
@@ -13,13 +13,18 @@ async def insert(
     memory_id: str,
     subject: str,
     verb: str,
-    object: str | None = None,
+    object_: str | None = None,
     event_date: str | None = None,
     event_date_end: str | None = None,
     confidence: float = 0.5,
     source_session_id: str | None = None,
+    _commit: bool = True,
 ) -> str:
-    """Insert a memory event. Returns the event ID."""
+    """Insert a memory event. Returns the event ID.
+
+    Set ``_commit=False`` when called inside a batch loop where the caller
+    manages transaction boundaries (e.g., extraction_job).
+    """
     event_id = str(uuid.uuid4())
     await db.execute(
         "INSERT INTO memory_events "
@@ -27,11 +32,12 @@ async def insert(
         "confidence, source_session_id) "
         "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
-            event_id, memory_id, subject, verb, object,
+            event_id, memory_id, subject, verb, object_,
             event_date, event_date_end, confidence, source_session_id,
         ),
     )
-    await db.commit()
+    if _commit:
+        await db.commit()
     return event_id
 
 

--- a/src/genesis/db/crud/memory_events.py
+++ b/src/genesis/db/crud/memory_events.py
@@ -1,0 +1,117 @@
+"""CRUD operations for memory_events table (SVO event calendar)."""
+
+from __future__ import annotations
+
+import uuid
+
+import aiosqlite
+
+
+async def insert(
+    db: aiosqlite.Connection,
+    *,
+    memory_id: str,
+    subject: str,
+    verb: str,
+    object: str | None = None,
+    event_date: str | None = None,
+    event_date_end: str | None = None,
+    confidence: float = 0.5,
+    source_session_id: str | None = None,
+) -> str:
+    """Insert a memory event. Returns the event ID."""
+    event_id = str(uuid.uuid4())
+    await db.execute(
+        "INSERT INTO memory_events "
+        "(id, memory_id, subject, verb, object, event_date, event_date_end, "
+        "confidence, source_session_id) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            event_id, memory_id, subject, verb, object,
+            event_date, event_date_end, confidence, source_session_id,
+        ),
+    )
+    await db.commit()
+    return event_id
+
+
+async def query_by_date_range(
+    db: aiosqlite.Connection,
+    start: str,
+    end: str,
+    *,
+    limit: int = 50,
+) -> list[dict]:
+    """Query events within a date range (inclusive)."""
+    cursor = await db.execute(
+        "SELECT * FROM memory_events "
+        "WHERE event_date >= ? AND event_date <= ? "
+        "ORDER BY event_date DESC LIMIT ?",
+        (start, end, limit),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def query_by_subject(
+    db: aiosqlite.Connection,
+    subject: str,
+    *,
+    limit: int = 50,
+) -> list[dict]:
+    """Query events by subject (case-insensitive prefix match)."""
+    cursor = await db.execute(
+        "SELECT * FROM memory_events "
+        "WHERE subject LIKE ? "
+        "ORDER BY event_date DESC LIMIT ?",
+        (f"{subject}%", limit),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def query_timeline(
+    db: aiosqlite.Connection,
+    *,
+    subject: str | None = None,
+    verb: str | None = None,
+    limit: int = 50,
+) -> list[dict]:
+    """Query events as a timeline, optionally filtered by subject/verb."""
+    conditions: list[str] = []
+    params: list[str | int] = []
+
+    if subject:
+        conditions.append("subject LIKE ?")
+        params.append(f"{subject}%")
+    if verb:
+        conditions.append("verb = ?")
+        params.append(verb)
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(limit)
+
+    cursor = await db.execute(
+        f"SELECT * FROM memory_events {where} "  # noqa: S608
+        "ORDER BY event_date DESC LIMIT ?",
+        params,
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def get_memory_ids_in_range(
+    db: aiosqlite.Connection,
+    start: str,
+    end: str,
+    *,
+    limit: int = 50,
+) -> list[str]:
+    """Return distinct memory_ids for events in a date range.
+
+    Used by the retrieval pipeline to boost temporally relevant memories.
+    """
+    cursor = await db.execute(
+        "SELECT DISTINCT memory_id FROM memory_events "
+        "WHERE event_date >= ? AND event_date <= ? "
+        "ORDER BY event_date DESC LIMIT ?",
+        (start, end, limit),
+    )
+    return [row[0] for row in await cursor.fetchall()]

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -949,6 +949,21 @@ TABLES = {
                          DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
         )
     """,
+    "memory_events": """
+        CREATE TABLE IF NOT EXISTS memory_events (
+            id                TEXT PRIMARY KEY,
+            memory_id         TEXT NOT NULL,
+            subject           TEXT NOT NULL,
+            verb              TEXT NOT NULL,
+            object            TEXT,
+            event_date        TEXT,
+            event_date_end    TEXT,
+            confidence        REAL NOT NULL DEFAULT 0.5,
+            source_session_id TEXT,
+            created_at        TEXT NOT NULL
+                              DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        )
+    """,
 }
 
 # FTS5 virtual tables (in-memory SQLite does NOT support FTS5 unless compiled with it)
@@ -1138,6 +1153,11 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_eval_events_type ON eval_events(event_type, timestamp)",
     "CREATE INDEX IF NOT EXISTS idx_eval_events_session ON eval_events(session_id)",
     "CREATE INDEX IF NOT EXISTS idx_eval_snapshots_period ON eval_snapshots(dimension, period_end)",
+    # SVO event calendar
+    "CREATE INDEX IF NOT EXISTS idx_memory_events_memory ON memory_events(memory_id)",
+    "CREATE INDEX IF NOT EXISTS idx_memory_events_date ON memory_events(event_date)",
+    "CREATE INDEX IF NOT EXISTS idx_memory_events_subject ON memory_events(subject)",
+    "CREATE INDEX IF NOT EXISTS idx_memory_events_verb ON memory_events(verb)",
 ]
 
 # ─── Seed Data ────────────────────────────────────────────────────────────────

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -51,6 +51,7 @@ async def memory_recall(
     include_graph: bool = True,
     expand_query_terms: bool = True,
     mode: str = "auto",
+    time_range: str | None = None,
 ) -> list[dict]:
     """Hybrid search: Qdrant vectors + FTS5, RRF fusion, with optional graph enrichment.
 
@@ -69,6 +70,10 @@ async def memory_recall(
             "standard" = hybrid only, no drift fallback. "drift" = skip
             standard recall, use 3-phase drift retrieval directly. Drift
             mode ignores wing/room filters (discovers clusters dynamically).
+        time_range: Explicit date range filter as "YYYY-MM-DD/YYYY-MM-DD".
+            Queries the SVO event calendar and boosts temporally matching
+            memories in RRF fusion. Automatic temporal detection also runs
+            on queries with temporal language (e.g., "what happened last week").
     """
     import time as _time
 
@@ -78,6 +83,21 @@ async def memory_recall(
     assert memory_mod._retriever is not None and memory_mod._db is not None
 
     pipeline_used = mode  # track which pipeline actually ran
+
+    # Explicit time_range: query event calendar and merge IDs into results
+    event_boost_ids: set[str] = set()
+    if time_range:
+        try:
+            parts = time_range.split("/", 1)
+            if len(parts) == 2:
+                from genesis.db.crud import memory_events
+                event_boost_ids = set(
+                    await memory_events.get_memory_ids_in_range(
+                        memory_mod._db, parts[0], parts[1], limit=limit * 3,
+                    )
+                )
+        except Exception:
+            logger.warning("time_range event query failed", exc_info=True)
 
     if mode == "drift":
         # Direct DRIFT invocation — skip standard recall entirely
@@ -132,6 +152,35 @@ async def memory_recall(
                     pipeline_used = "auto_drift"
             except Exception:
                 logger.warning("drift_recall fallback failed", exc_info=True)
+
+    # Boost event-calendar matches from explicit time_range
+    if event_boost_ids:
+        from genesis.db.crud import memory as memory_crud
+        from genesis.memory.types import RetrievalResult
+
+        result_ids = {r.memory_id for r in results}
+        missing = event_boost_ids - result_ids
+        for mid in list(missing)[:limit]:
+            try:
+                row = await memory_crud.get_by_id(memory_mod._db, mid)
+                if row:
+                    results.append(RetrievalResult(
+                        memory_id=mid,
+                        content=row.get("content", ""),
+                        source=row.get("source_type", ""),
+                        memory_type=row.get("collection", ""),
+                        score=0.01,
+                        vector_rank=None,
+                        fts_rank=None,
+                        activation_score=0.0,
+                        payload=row,
+                        source_pipeline="event_calendar",
+                    ))
+            except Exception:
+                logger.warning(
+                    "Failed to fetch event-calendar memory %s", mid,
+                    exc_info=True,
+                )
 
     # MCP-layer instrumentation: emit with mode and pipeline attribution
     try:

--- a/src/genesis/memory/extraction.py
+++ b/src/genesis/memory/extraction.py
@@ -36,6 +36,16 @@ For each extraction, provide:
     categorized_as, related_to, succeeded_by, preceded_by
 - temporal: Date or time reference if mentioned (ISO format preferred)
 
+For each extraction that has a temporal reference AND describes a concrete
+action (something that happened, was decided, or will happen), additionally
+provide an "event" object with:
+- subject: who/what performed the action (e.g., "maintainer", "Genesis", "user")
+- verb: what happened, past tense (e.g., "closed", "deferred", "evaluated")
+- object: what was affected (e.g., "PR #773", "fact-checker rework")
+
+Only include the event object when there is both a clear temporal reference
+AND a concrete action with a subject and verb. Not all extractions are events.
+
 Focus on DURABLE KNOWLEDGE — facts, decisions, and insights that will be
 valuable weeks or months from now. Target 3-8 high-quality extractions per
 segment. Quality over quantity.
@@ -72,7 +82,8 @@ Respond with a JSON object inside backticks containing:
         {"from": "Agentmail", "to": "Genesis outreach", "type": "evaluated_for"},
         {"from": "Agentmail", "to": "P-3", "type": "categorized_as"}
       ],
-      "temporal": "2026-03-17"
+      "temporal": "2026-03-17",
+      "event": {"subject": "Genesis", "verb": "evaluated", "object": "Agentmail"}
     }
   ],
   "session_keywords": ["agentmail", "email", "outreach", "evaluation"],
@@ -108,6 +119,10 @@ class Extraction:
     entities: list[str] = field(default_factory=list)
     relationships: list[dict] = field(default_factory=list)
     temporal: str | None = None
+    # SVO event fields (populated when extraction describes a concrete action)
+    event_subject: str | None = None
+    event_verb: str | None = None
+    event_object: str | None = None
 
 
 @dataclass
@@ -235,6 +250,16 @@ def parse_extraction_response_full(text: str) -> ParsedResponse:
         if temporal is not None:
             temporal = str(temporal)
 
+        # Parse optional SVO event fields
+        event_subject = None
+        event_verb = None
+        event_object = None
+        event = item.get("event")
+        if isinstance(event, dict):
+            event_subject = str(event["subject"]) if event.get("subject") else None
+            event_verb = str(event["verb"]) if event.get("verb") else None
+            event_object = str(event["object"]) if event.get("object") else None
+
         extractions.append(Extraction(
             content=content,
             extraction_type=ext_type,
@@ -242,6 +267,9 @@ def parse_extraction_response_full(text: str) -> ParsedResponse:
             entities=entities,
             relationships=valid_rels,
             temporal=temporal,
+            event_subject=event_subject,
+            event_verb=event_verb,
+            event_object=event_object,
         ))
 
     return ParsedResponse(

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -205,6 +205,26 @@ async def run_extraction_cycle(
                     summary["entities_extracted"] += 1
                     session_extraction_count += 1
 
+                    # Store SVO event if temporal + verb present
+                    if extraction.event_verb and extraction.temporal:
+                        try:
+                            from genesis.db.crud import memory_events
+                            await memory_events.insert(
+                                db,
+                                memory_id=memory_id,
+                                subject=extraction.event_subject or "unknown",
+                                verb=extraction.event_verb,
+                                object=extraction.event_object,
+                                event_date=extraction.temporal,
+                                confidence=extraction.confidence,
+                                source_session_id=cc_session_id,
+                            )
+                        except Exception:
+                            logger.warning(
+                                "Failed to store SVO event for %s",
+                                memory_id, exc_info=True,
+                            )
+
                     # Create typed links from extraction relationships
                     if linker and extraction.relationships:
                         try:

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -214,10 +214,11 @@ async def run_extraction_cycle(
                                 memory_id=memory_id,
                                 subject=extraction.event_subject or "unknown",
                                 verb=extraction.event_verb,
-                                object=extraction.event_object,
+                                object_=extraction.event_object,
                                 event_date=extraction.temporal,
                                 confidence=extraction.confidence,
                                 source_session_id=cc_session_id,
+                                _commit=False,
                             )
                         except Exception:
                             logger.warning(

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -19,6 +19,13 @@ from genesis.qdrant import collections as qdrant_ops
 
 logger = logging.getLogger(__name__)
 
+
+def _has_temporal_markers(query: str) -> bool:
+    """Quick check for temporal language in a query."""
+    from genesis.memory.temporal import has_temporal_markers
+    return has_temporal_markers(query)
+
+
 _SOURCE_TO_COLLECTIONS: dict[str, list[str]] = {
     "episodic": ["episodic_memory"],
     "knowledge": ["knowledge_base"],
@@ -115,6 +122,21 @@ class HybridRetriever:
         # 2b. Classify query intent (for RRF bias in step 7)
         intent = classify_intent(query)
 
+        # 2d. Event-calendar search (temporal queries)
+        event_memory_ids: list[str] = []
+        if intent.category == "WHEN" or _has_temporal_markers(query):
+            try:
+                from genesis.memory.temporal import parse_temporal_reference
+                time_range = parse_temporal_reference(query)
+                if time_range:
+                    from genesis.db.crud import memory_events
+                    event_memory_ids = await memory_events.get_memory_ids_in_range(
+                        self._db, time_range[0], time_range[1],
+                        limit=candidate_limit,
+                    )
+            except Exception:
+                logger.warning("Event-calendar search failed", exc_info=True)
+
         # 2c. Expand query via tag co-occurrence (opt-in, expensive index rebuild)
         fts_query = query
         if expand_query_terms:
@@ -145,7 +167,7 @@ class HybridRetriever:
                 fts_by_id[mid] = row
 
         # 4. Union of all candidate memory_ids
-        all_ids = set(qdrant_by_id) | set(fts_by_id)
+        all_ids = set(qdrant_by_id) | set(fts_by_id) | set(event_memory_ids)
         if not all_ids:
             return []
 
@@ -222,6 +244,8 @@ class HybridRetriever:
             ranked_lists = [fts_ranked, activation_ranked]
         if intent_ranked:
             ranked_lists.append(intent_ranked)
+        if event_memory_ids:
+            ranked_lists.append(event_memory_ids)
         fused = _rrf_fuse(ranked_lists)
 
         # 8. Filter by min_activation

--- a/src/genesis/memory/temporal.py
+++ b/src/genesis/memory/temporal.py
@@ -1,0 +1,116 @@
+"""Minimal temporal reference parser for query-time date filtering.
+
+Converts natural language time references in recall queries to ISO date
+range tuples. The LLM resolves complex dates at extraction time — this
+parser only handles common relative patterns at query time.
+
+Uses stdlib only (no python-dateutil dependency).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime, timedelta
+
+_RELATIVE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\byesterday\b", re.I), "yesterday"),
+    (re.compile(r"\btoday\b", re.I), "today"),
+    (re.compile(r"\blast\s+week\b", re.I), "last_week"),
+    (re.compile(r"\bthis\s+week\b", re.I), "this_week"),
+    (re.compile(r"\blast\s+month\b", re.I), "last_month"),
+    (re.compile(r"\bthis\s+month\b", re.I), "this_month"),
+    (re.compile(r"\b(\d+)\s+days?\s+ago\b", re.I), "n_days_ago"),
+    (re.compile(r"\b(\d+)\s+weeks?\s+ago\b", re.I), "n_weeks_ago"),
+    (re.compile(r"\b(\d+)\s+months?\s+ago\b", re.I), "n_months_ago"),
+]
+
+# Temporal marker words for quick pre-check in retrieval
+TEMPORAL_MARKERS = re.compile(
+    r"\b(when|yesterday|today|last\s+week|last\s+month|this\s+week|"
+    r"this\s+month|days?\s+ago|weeks?\s+ago|months?\s+ago|timeline|"
+    r"history\s+of|last\s+time|first\s+time)\b",
+    re.I,
+)
+
+
+def has_temporal_markers(query: str) -> bool:
+    """Quick check if a query contains temporal language."""
+    return bool(TEMPORAL_MARKERS.search(query))
+
+
+def parse_temporal_reference(
+    query: str,
+    now: datetime | None = None,
+) -> tuple[str, str] | None:
+    """Parse a relative temporal reference into an ISO date range.
+
+    Returns (start_date, end_date) as ISO date strings (YYYY-MM-DD),
+    or None if no temporal pattern is recognized.
+
+    Only the first matching pattern is used.
+    """
+    if now is None:
+        now = datetime.now(UTC)
+
+    today = now.date()
+
+    for pattern, kind in _RELATIVE_PATTERNS:
+        m = pattern.search(query)
+        if not m:
+            continue
+
+        if kind == "yesterday":
+            d = today - timedelta(days=1)
+            return (d.isoformat(), d.isoformat())
+
+        if kind == "today":
+            return (today.isoformat(), today.isoformat())
+
+        if kind == "last_week":
+            # Monday-to-Sunday of the previous week
+            days_since_monday = today.weekday()
+            last_monday = today - timedelta(days=days_since_monday + 7)
+            last_sunday = last_monday + timedelta(days=6)
+            return (last_monday.isoformat(), last_sunday.isoformat())
+
+        if kind == "this_week":
+            monday = today - timedelta(days=today.weekday())
+            return (monday.isoformat(), today.isoformat())
+
+        if kind == "last_month":
+            first_of_this_month = today.replace(day=1)
+            last_day_prev = first_of_this_month - timedelta(days=1)
+            first_of_prev = last_day_prev.replace(day=1)
+            return (first_of_prev.isoformat(), last_day_prev.isoformat())
+
+        if kind == "this_month":
+            first_of_month = today.replace(day=1)
+            return (first_of_month.isoformat(), today.isoformat())
+
+        if kind == "n_days_ago":
+            n = int(m.group(1))
+            d = today - timedelta(days=n)
+            return (d.isoformat(), d.isoformat())
+
+        if kind == "n_weeks_ago":
+            n = int(m.group(1))
+            start = today - timedelta(weeks=n, days=today.weekday())
+            end = start + timedelta(days=6)
+            return (start.isoformat(), end.isoformat())
+
+        if kind == "n_months_ago":
+            n = int(m.group(1))
+            year = today.year
+            month = today.month - n
+            while month <= 0:
+                month += 12
+                year -= 1
+            first = today.replace(year=year, month=month, day=1)
+            # Last day of that month
+            if month == 12:
+                last = today.replace(year=year + 1, month=1, day=1) - timedelta(days=1)
+            else:
+                last = today.replace(year=year, month=month + 1, day=1) - timedelta(days=1)
+            return (first.isoformat(), last.isoformat())
+
+    return None

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -87,6 +87,7 @@ async def test_no_unexpected_tables(db):
         "file_modifications",
         "direct_session_queue",
         "eval_events", "eval_snapshots",
+        "memory_events",
     }
     for table in tables:
         assert table in known, f"Unexpected table: {table}"

--- a/tests/test_memory/test_events.py
+++ b/tests/test_memory/test_events.py
@@ -1,0 +1,347 @@
+"""Tests for the SVO event calendar: CRUD, temporal parser, and extraction integration."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from genesis.memory.extraction import parse_extraction_response_full
+from genesis.memory.temporal import has_temporal_markers, parse_temporal_reference
+
+# ---------------------------------------------------------------------------
+# Temporal parser
+# ---------------------------------------------------------------------------
+
+
+class TestTemporalParser:
+    """Tests for parse_temporal_reference()."""
+
+    # Fixed reference point: Thursday 2026-05-08 12:00 UTC
+    NOW = datetime(2026, 5, 8, 12, 0, 0, tzinfo=UTC)
+
+    def test_yesterday(self):
+        result = parse_temporal_reference("what happened yesterday", now=self.NOW)
+        assert result == ("2026-05-07", "2026-05-07")
+
+    def test_today(self):
+        result = parse_temporal_reference("what happened today", now=self.NOW)
+        assert result == ("2026-05-08", "2026-05-08")
+
+    def test_last_week(self):
+        result = parse_temporal_reference("what happened last week", now=self.NOW)
+        # Last week: Mon 2026-04-27 to Sun 2026-05-03
+        assert result == ("2026-04-27", "2026-05-03")
+
+    def test_this_week(self):
+        result = parse_temporal_reference("what happened this week", now=self.NOW)
+        # This week starts Mon 2026-05-04 (May 8 is Thursday)
+        assert result == ("2026-05-04", "2026-05-08")
+
+    def test_last_month(self):
+        result = parse_temporal_reference("what happened last month", now=self.NOW)
+        assert result == ("2026-04-01", "2026-04-30")
+
+    def test_this_month(self):
+        result = parse_temporal_reference("what did we deploy this month", now=self.NOW)
+        assert result == ("2026-05-01", "2026-05-08")
+
+    def test_n_days_ago(self):
+        result = parse_temporal_reference("what happened 3 days ago", now=self.NOW)
+        assert result == ("2026-05-05", "2026-05-05")
+
+    def test_n_weeks_ago(self):
+        result = parse_temporal_reference("what happened 2 weeks ago", now=self.NOW)
+        start, end = result
+        # 2 weeks ago from Thu May 8 → week starting Mon Apr 20
+        assert start == "2026-04-20"
+        assert end == "2026-04-26"
+
+    def test_n_months_ago(self):
+        result = parse_temporal_reference("what happened 2 months ago", now=self.NOW)
+        assert result == ("2026-03-01", "2026-03-31")
+
+    def test_no_temporal(self):
+        result = parse_temporal_reference("tell me about Genesis", now=self.NOW)
+        assert result is None
+
+    def test_case_insensitive(self):
+        result = parse_temporal_reference("What Happened YESTERDAY", now=self.NOW)
+        assert result is not None
+
+    def test_january_wrap(self):
+        """Test month subtraction wrapping across year boundary."""
+        jan = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+        result = parse_temporal_reference("what happened 2 months ago", now=jan)
+        assert result == ("2025-11-01", "2025-11-30")
+
+
+class TestTemporalMarkers:
+    """Tests for has_temporal_markers()."""
+
+    def test_when_query(self):
+        assert has_temporal_markers("when did we deploy?")
+
+    def test_yesterday(self):
+        assert has_temporal_markers("what happened yesterday")
+
+    def test_days_ago(self):
+        assert has_temporal_markers("3 days ago we decided")
+
+    def test_timeline(self):
+        assert has_temporal_markers("show me the timeline")
+
+    def test_no_markers(self):
+        assert not has_temporal_markers("tell me about Genesis")
+
+    def test_last_time(self):
+        assert has_temporal_markers("last time we tried this")
+
+
+# ---------------------------------------------------------------------------
+# Extraction SVO parsing
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionSVO:
+    """Tests for SVO event field parsing in extraction responses."""
+
+    def test_event_fields_parsed(self):
+        response = """```json
+{
+  "extractions": [
+    {
+      "content": "PR #773 was closed by maintainer",
+      "type": "entity",
+      "confidence": 0.9,
+      "entities": ["PR #773"],
+      "relationships": [],
+      "temporal": "2026-05-03",
+      "event": {"subject": "maintainer", "verb": "closed", "object": "PR #773"}
+    }
+  ],
+  "session_keywords": ["PR"],
+  "session_topic": "PR closure"
+}```"""
+        parsed = parse_extraction_response_full(response)
+        assert len(parsed.extractions) == 1
+        ext = parsed.extractions[0]
+        assert ext.event_subject == "maintainer"
+        assert ext.event_verb == "closed"
+        assert ext.event_object == "PR #773"
+        assert ext.temporal == "2026-05-03"
+
+    def test_no_event_fields_when_absent(self):
+        response = """```json
+{
+  "extractions": [
+    {
+      "content": "Genesis uses RRF fusion",
+      "type": "concept",
+      "confidence": 0.85,
+      "entities": ["Genesis", "RRF"],
+      "relationships": []
+    }
+  ],
+  "session_keywords": [],
+  "session_topic": ""
+}```"""
+        parsed = parse_extraction_response_full(response)
+        assert len(parsed.extractions) == 1
+        ext = parsed.extractions[0]
+        assert ext.event_subject is None
+        assert ext.event_verb is None
+        assert ext.event_object is None
+
+    def test_partial_event_fields(self):
+        """Event with subject and verb but no object."""
+        response = """```json
+{
+  "extractions": [
+    {
+      "content": "User approved the change",
+      "type": "decision",
+      "confidence": 0.8,
+      "entities": [],
+      "relationships": [],
+      "temporal": "2026-05-07",
+      "event": {"subject": "user", "verb": "approved"}
+    }
+  ],
+  "session_keywords": [],
+  "session_topic": ""
+}```"""
+        parsed = parse_extraction_response_full(response)
+        ext = parsed.extractions[0]
+        assert ext.event_subject == "user"
+        assert ext.event_verb == "approved"
+        assert ext.event_object is None
+
+    def test_invalid_event_type_ignored(self):
+        """Non-dict event field is silently ignored."""
+        response = """```json
+{
+  "extractions": [
+    {
+      "content": "Something happened",
+      "type": "entity",
+      "confidence": 0.7,
+      "entities": [],
+      "relationships": [],
+      "event": "not a dict"
+    }
+  ],
+  "session_keywords": [],
+  "session_topic": ""
+}```"""
+        parsed = parse_extraction_response_full(response)
+        ext = parsed.extractions[0]
+        assert ext.event_subject is None
+        assert ext.event_verb is None
+
+
+# ---------------------------------------------------------------------------
+# CRUD (requires in-memory SQLite)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def memory_db():
+    """Create an in-memory SQLite DB with memory_events table."""
+    import aiosqlite
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute("""
+        CREATE TABLE memory_events (
+            id                TEXT PRIMARY KEY,
+            memory_id         TEXT NOT NULL,
+            subject           TEXT NOT NULL,
+            verb              TEXT NOT NULL,
+            object            TEXT,
+            event_date        TEXT,
+            event_date_end    TEXT,
+            confidence        REAL NOT NULL DEFAULT 0.5,
+            source_session_id TEXT,
+            created_at        TEXT NOT NULL
+                              DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        )
+    """)
+    await db.execute(
+        "CREATE INDEX idx_memory_events_date ON memory_events(event_date)"
+    )
+    await db.commit()
+    yield db
+    await db.close()
+
+
+class TestMemoryEventsCRUD:
+    """Tests for memory_events CRUD operations."""
+
+    @pytest.mark.asyncio
+    async def test_insert_and_query_by_date(self, memory_db):
+        from genesis.db.crud import memory_events
+
+        event_id = await memory_events.insert(
+            memory_db,
+            memory_id="mem-1",
+            subject="user",
+            verb="deployed",
+            object_="PR #42",
+            event_date="2026-05-03",
+            confidence=0.9,
+        )
+        assert event_id  # non-empty string
+
+        results = await memory_events.query_by_date_range(
+            memory_db, "2026-05-01", "2026-05-05",
+        )
+        assert len(results) == 1
+        assert results[0]["memory_id"] == "mem-1"
+        assert results[0]["verb"] == "deployed"
+
+    @pytest.mark.asyncio
+    async def test_query_by_subject(self, memory_db):
+        from genesis.db.crud import memory_events
+
+        await memory_events.insert(
+            memory_db,
+            memory_id="mem-1",
+            subject="Genesis",
+            verb="evaluated",
+            object_="FalkorDB",
+            event_date="2026-05-03",
+        )
+        await memory_events.insert(
+            memory_db,
+            memory_id="mem-2",
+            subject="user",
+            verb="decided",
+            event_date="2026-05-04",
+        )
+
+        results = await memory_events.query_by_subject(memory_db, "Genesis")
+        assert len(results) == 1
+        assert results[0]["memory_id"] == "mem-1"
+
+    @pytest.mark.asyncio
+    async def test_query_timeline(self, memory_db):
+        from genesis.db.crud import memory_events
+
+        await memory_events.insert(
+            memory_db, memory_id="m1", subject="user",
+            verb="merged", event_date="2026-05-01",
+        )
+        await memory_events.insert(
+            memory_db, memory_id="m2", subject="user",
+            verb="deployed", event_date="2026-05-03",
+        )
+        await memory_events.insert(
+            memory_db, memory_id="m3", subject="Genesis",
+            verb="evaluated", event_date="2026-05-02",
+        )
+
+        # All events, sorted by date desc
+        timeline = await memory_events.query_timeline(memory_db)
+        assert len(timeline) == 3
+        assert timeline[0]["event_date"] == "2026-05-03"
+
+        # Filter by verb
+        merged = await memory_events.query_timeline(memory_db, verb="merged")
+        assert len(merged) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_memory_ids_in_range(self, memory_db):
+        from genesis.db.crud import memory_events
+
+        await memory_events.insert(
+            memory_db, memory_id="m1", subject="user",
+            verb="deployed", event_date="2026-05-01",
+        )
+        await memory_events.insert(
+            memory_db, memory_id="m2", subject="user",
+            verb="merged", event_date="2026-05-03",
+        )
+        # Same memory_id as m1 — should be deduped
+        await memory_events.insert(
+            memory_db, memory_id="m1", subject="user",
+            verb="tested", event_date="2026-05-02",
+        )
+
+        ids = await memory_events.get_memory_ids_in_range(
+            memory_db, "2026-05-01", "2026-05-03",
+        )
+        assert set(ids) == {"m1", "m2"}
+
+    @pytest.mark.asyncio
+    async def test_empty_range_returns_empty(self, memory_db):
+        from genesis.db.crud import memory_events
+
+        await memory_events.insert(
+            memory_db, memory_id="m1", subject="user",
+            verb="deployed", event_date="2026-05-01",
+        )
+
+        results = await memory_events.query_by_date_range(
+            memory_db, "2026-06-01", "2026-06-30",
+        )
+        assert results == []


### PR DESCRIPTION
## Summary

- Adds a `memory_events` table storing Subject-Verb-Object triples with resolved datetimes, extracted automatically during the existing extraction pipeline
- Extends the extraction prompt to produce optional SVO event fields for temporal extractions (tested with Qwen3-235B — no degradation of existing extraction quality)
- Adds a temporal reference parser (stdlib-based, no new dependencies) that detects relative date language in recall queries
- Wires automatic event-calendar search into the retrieval pipeline — when a query contains temporal markers ("what happened last week?"), the pipeline queries `memory_events` by date range and merges results into RRF fusion
- Adds optional `time_range` parameter to the `memory_recall` MCP tool for explicit temporal queries
- 27 new tests covering CRUD, temporal parsing, extraction SVO fields, and integration

## Why

The Chronos ablation study showed that an event calendar provides +34.5pp improvement for temporal reasoning — 10x more valuable than entity knowledge graph improvements (+1-3pp). Genesis's existing memory system treats temporal data as unstructured text, making "when" queries unreliable.

## Design decisions

- **No new dependencies** — temporal parser uses stdlib `datetime` + `re`
- **Same LLM call, zero additional cost** — SVO fields are extracted alongside existing extractions
- **Passive, automatic** — temporal search fires based on query pattern matching, not LLM tool selection
- **Additive only** — non-temporal queries are completely unaffected (verified: all 15 existing retrieval tests pass unchanged)

## Test plan

- [x] `ruff check` clean on all changed files
- [x] 27 new tests pass (temporal parser, CRUD, extraction SVO, integration)
- [x] 85 memory tests pass (no regressions)
- [x] Full suite: 6,273 pass, 10 fail (all pre-existing)
- [x] Two code reviews completed — critical bug (event-only results silently dropped) found and fixed
- [x] Live test extraction with SVO-enhanced prompt on real transcript chunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)