### PR TITLE
fix(routing): move DeepSeek V4 Flash to end of distillation chain

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -448,12 +448,12 @@ call_sites:
     description: "Proactive infrastructure monitoring \u2014 trend detection and forecasting"
   40_knowledge_distillation:
     chain:
-    - openrouter-deepseek-v4-flash
     - cerebras-qwen
     - groq-free
     - gemini-free
     - mistral-large-free
     - openrouter-free
+    - openrouter-deepseek-v4-flash
     default_paid: true
     retry_profile: background
     description: "Knowledge pipeline — distill raw content into structured knowledge units"


### PR DESCRIPTION
## Summary

- Move `openrouter-deepseek-v4-flash` from first to last in call site 40 chain
- Free providers tried first, paid DeepSeek as fallback only

## Test plan

- [x] Chain order verified in YAML
- [x] No code changes needed (chain_offset rotation works regardless of order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)