### PR TITLE
feat(dashboard): parallelization indicator badge

### DIFF
--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -4530,6 +4530,9 @@
                     <template x-if="$store.genesisDashboard.routingConfig.call_sites[siteId].retry_profile">
                       <span style="font-size:0.65rem; padding:0.08rem 0.32rem; border-radius:3px; background:rgba(255,255,255,0.07); color:var(--color-text-secondary);" x-text="$store.genesisDashboard.routingConfig.call_sites[siteId].retry_profile"></span>
                     </template>
+                    <template x-if="site.parallelized">
+                      <span style="font-size:0.65rem; padding:0.08rem 0.32rem; border-radius:3px; background:rgba(156,39,176,0.16); color:#9c27ac;">parallelized</span>
+                    </template>
                   </div>
                 </template>
                 <template x-if="site.chain_health">

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -303,6 +303,13 @@ _CALL_SITE_META: dict[str, dict] = {
         "frequency": "On outreach failure",
         "model_tier": "slm",
     },
+    "40_knowledge_distillation": {
+        "description": "Distills ingested knowledge sources into atomic units. Parallelized across provider chain via chain_offset.",
+        "category": "processing",
+        "frequency": "Per ingestion",
+        "model_tier": "slm",
+        "parallelized": True,
+    },
     "autonomous_executor_reasoning": {
         "description": "Non-tooling reasoning for autonomous executor steps (research/analysis/synthesis). API-first via AutonomousDispatchRouter.",
         "category": "reasoning",


### PR DESCRIPTION
## Summary

- Add `40_knowledge_distillation` entry to `_CALL_SITE_META` with `parallelized: True`
- Add purple "parallelized" badge in dashboard call site cards (reads from health snapshot `site.parallelized`)
- Call site 40 uses `chain_offset` to rotate chunks across providers concurrently — this makes that visible

## Test plan

- [x] `ruff check` passes
- [x] 218 routing tests pass
- [ ] Restart server, verify badge appears on call site 40 card
- [ ] Verify no badge on other call sites