### PR TITLE
feat(memory): bi-temporal wiring, NetworkX graph, DRIFT mode, recall instrumentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pymupdf>=1.27",  # PDF text extraction for knowledge ingestion pipeline
     "scrapling>=0.4.7",  # Web fetching with TLS fingerprint impersonation
     "curl_cffi>=0.15.0",  # curl_cffi backend for Scrapling's AsyncFetcher
+    "networkx>=3.0",  # In-memory graph for memory_links traversal + algorithms
 ]
 
 [project.optional-dependencies]

--- a/src/genesis/db/crud/knowledge.py
+++ b/src/genesis/db/crud/knowledge.py
@@ -138,6 +138,7 @@ async def upsert(
     source_pipeline: str | None = None,
     purpose: str | None = None,
     ingestion_source: str | None = None,
+    _commit: bool = True,
 ) -> tuple[str, bool]:
     """Insert or update a knowledge unit keyed on (project_type, domain, concept).
 
@@ -223,7 +224,8 @@ async def upsert(
         (actual_id, concept, body, tags or "", domain, project_type),
     )
 
-    await db.commit()
+    if _commit:
+        await db.commit()
     return actual_id, inserted
 
 

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -199,16 +199,43 @@ async def create_metadata(
     memory_class: str = "fact",
     wing: str | None = None,
     room: str | None = None,
+    valid_at: str | None = None,
+    invalid_at: str | None = None,
 ) -> str:
-    """Insert a row into memory_metadata. Returns memory_id."""
+    """Insert a row into memory_metadata. Returns memory_id.
+
+    ``valid_at`` records when the fact became true in the real world
+    (bi-temporal modeling). Defaults to ``created_at`` if not provided.
+    ``invalid_at`` records when the fact stopped being true (NULL = still valid).
+    """
+    resolved_valid_at = valid_at or created_at
     await db.execute(
         "INSERT OR IGNORE INTO memory_metadata "
-        "(memory_id, created_at, collection, confidence, embedding_status, memory_class, wing, room) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-        (memory_id, created_at, collection, confidence, embedding_status, memory_class, wing, room),
+        "(memory_id, created_at, collection, confidence, embedding_status, "
+        "memory_class, wing, room, valid_at, invalid_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (memory_id, created_at, collection, confidence, embedding_status,
+         memory_class, wing, room, resolved_valid_at, invalid_at),
     )
     await db.commit()
     return memory_id
+
+
+async def invalidate_memory(
+    db: aiosqlite.Connection,
+    memory_id: str,
+    invalid_at: str,
+) -> bool:
+    """Mark a memory as no longer valid (bi-temporal invalidation).
+
+    Returns True if the memory was found and updated.
+    """
+    cursor = await db.execute(
+        "UPDATE memory_metadata SET invalid_at = ? WHERE memory_id = ?",
+        (invalid_at, memory_id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
 
 
 async def delete_metadata(db: aiosqlite.Connection, *, memory_id: str) -> bool:

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -251,7 +251,8 @@ async def get_by_id(db: aiosqlite.Connection, memory_id: str) -> dict | None:
     """Get a single memory by ID, joining FTS5 content with metadata."""
     cursor = await db.execute(
         "SELECT f.memory_id, f.content, f.source_type, f.tags, f.collection, "
-        "       m.created_at, m.confidence, m.embedding_status "
+        "       m.created_at, m.confidence, m.embedding_status, "
+        "       m.valid_at, m.invalid_at "
         "FROM memory_fts f "
         "LEFT JOIN memory_metadata m ON f.memory_id = m.memory_id "
         "WHERE f.memory_id = ?",
@@ -269,6 +270,8 @@ async def get_by_id(db: aiosqlite.Connection, memory_id: str) -> dict | None:
         "created_at": row[5],
         "confidence": row[6],
         "embedding_status": row[7],
+        "valid_at": row[8],
+        "invalid_at": row[9],
     }
 
 

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -285,7 +285,8 @@ async def list_recent(
     """List memories ordered by created_at descending (newest first)."""
     sql = (
         "SELECT f.memory_id, f.content, f.source_type, f.collection, "
-        "       m.created_at, m.confidence, m.embedding_status "
+        "       m.created_at, m.confidence, m.embedding_status, "
+        "       m.valid_at, m.invalid_at "
         "FROM memory_metadata m "
         "JOIN memory_fts f ON f.memory_id = m.memory_id "
     )
@@ -306,6 +307,8 @@ async def list_recent(
             "created_at": r[4],
             "confidence": r[5],
             "embedding_status": r[6],
+            "valid_at": r[7],
+            "invalid_at": r[8],
         }
         for r in rows
     ]

--- a/src/genesis/eval/j9_hooks.py
+++ b/src/genesis/eval/j9_hooks.py
@@ -26,22 +26,32 @@ async def emit_recall_fired(
     latency_ms: float,
     source: str,
     session_id: str | None = None,
+    mode: str | None = None,
+    pipeline_used: str | None = None,
+    intent_category: str | None = None,
 ) -> None:
     """Log a memory recall() invocation as an eval event."""
     try:
+        metrics: dict = {
+            "query": query[:500],
+            "result_count": result_count,
+            "top_scores": top_scores[:10],
+            "memory_ids": memory_ids[:10],
+            "latency_ms": round(latency_ms, 1),
+            "source": source,
+        }
+        if mode:
+            metrics["mode"] = mode
+        if pipeline_used:
+            metrics["pipeline_used"] = pipeline_used
+        if intent_category:
+            metrics["intent_category"] = intent_category
         await j9_eval.insert_event(
             db,
             dimension="memory",
             event_type="recall_fired",
             session_id=session_id,
-            metrics={
-                "query": query[:500],
-                "result_count": result_count,
-                "top_scores": top_scores[:10],
-                "memory_ids": memory_ids[:10],
-                "latency_ms": round(latency_ms, 1),
-                "source": source,
-            },
+            metrics=metrics,
         )
     except Exception:
         logger.debug("eval: failed to emit recall_fired", exc_info=True)

--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -250,7 +250,15 @@ class KnowledgeOrchestrator:
 
         try:
             for unit in units:
-                unit_id = str(uuid.uuid4())
+                # Check for existing unit (idempotent re-ingestion)
+                existing = await memory_mod.knowledge.find_by_unique_key(
+                    memory_mod._db,
+                    project_type=project_type,
+                    domain=unit.domain,
+                    concept=unit.concept,
+                )
+                unit_id = existing["id"] if existing else str(uuid.uuid4())
+                old_qdrant_id = existing.get("qdrant_id") if existing else None
 
                 # Store to Qdrant via MemoryStore (non-transactional, immediate)
                 qdrant_id = await memory_mod._store.store(
@@ -265,8 +273,22 @@ class KnowledgeOrchestrator:
                 )
                 qdrant_ids.append(qdrant_id)
 
-                # Store to SQLite via CRUD (_commit=False for batch transaction)
-                await memory_mod.knowledge.insert(
+                # Clean up stale Qdrant point if re-ingesting
+                if old_qdrant_id and old_qdrant_id != qdrant_id:
+                    try:
+                        delete_point(
+                            memory_mod._store._qdrant,
+                            collection="knowledge_base",
+                            point_id=old_qdrant_id,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Failed to clean up stale Qdrant point %s",
+                            old_qdrant_id,
+                        )
+
+                # Upsert to SQLite (_commit=False for batch transaction)
+                actual_id, _inserted = await memory_mod.knowledge.upsert(
                     memory_mod._db,
                     id=unit_id,
                     project_type=project_type,
@@ -289,7 +311,7 @@ class KnowledgeOrchestrator:
                     _commit=False,
                 )
 
-                unit_ids.append(unit_id)
+                unit_ids.append(actual_id)
 
             # Single commit for all units in the batch
             await memory_mod._db.commit()

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -50,6 +50,7 @@ async def memory_recall(
     room: str | None = None,
     include_graph: bool = True,
     expand_query_terms: bool = True,
+    mode: str = "auto",
 ) -> list[dict]:
     """Hybrid search: Qdrant vectors + FTS5, RRF fusion, with optional graph enrichment.
 
@@ -64,50 +65,90 @@ async def memory_recall(
             analysis (~500ms first call, ~10ms cached). Broadens recall for
             ambiguous queries. Default on — catches poor query formulation.
             Note: does not apply to the drift_recall fallback path (if wired).
+        mode: Retrieval mode. "auto" = standard + drift fallback (default).
+            "standard" = hybrid only, no drift fallback. "drift" = skip
+            standard recall, use 3-phase drift retrieval directly. Drift
+            mode ignores wing/room filters (discovers clusters dynamically).
     """
+    import time as _time
+
+    _t0 = _time.monotonic()
     memory_mod = _memory_mod()
     memory_mod._require_init()
     assert memory_mod._retriever is not None and memory_mod._db is not None
-    results = await memory_mod._retriever.recall(
-        query, source=source, limit=limit, min_activation=min_activation,
-        wing=wing, room=room, expand_query_terms=expand_query_terms,
-    )
 
-    # Drift fallback: when standard recall returns sparse results, try the
-    # 3-phase drift retrieval (global scan → cluster drill-down → weighted RRF)
-    # which handles complex/ambiguous queries better.
-    # Skip when wing/room filters are set — drift discovers clusters dynamically
-    # and would silently violate the caller's filter constraints.
-    if (
-        len(results) < min(3, limit)
-        and limit >= 3
-        and not wing
-        and not room
-    ):
-        try:
-            from genesis.memory.drift import drift_recall
+    pipeline_used = mode  # track which pipeline actually ran
 
-            drift_results = await drift_recall(
-                query,
-                db=memory_mod._db,
-                qdrant_client=memory_mod._qdrant,
-                embedding_provider=memory_mod._retriever._embeddings,
-                source=source,
-                limit=limit,
-                min_activation=min_activation,
-            )
-            if len(drift_results) > len(results):
-                logger.info(
-                    "drift_recall fallback: standard=%d → drift=%d results"
-                    " (query=%r)",
-                    len(results), len(drift_results), query[:80],
+    if mode == "drift":
+        # Direct DRIFT invocation — skip standard recall entirely
+        from genesis.memory.drift import drift_recall
+
+        results = await drift_recall(
+            query,
+            db=memory_mod._db,
+            qdrant_client=memory_mod._qdrant,
+            embedding_provider=memory_mod._retriever._embeddings,
+            source=source,
+            limit=limit,
+            min_activation=min_activation,
+        )
+        _increment_retrieved(memory_mod._qdrant, results)
+    else:
+        results = await memory_mod._retriever.recall(
+            query, source=source, limit=limit, min_activation=min_activation,
+            wing=wing, room=room, expand_query_terms=expand_query_terms,
+        )
+        pipeline_used = "standard"
+
+        # Drift fallback (mode="auto" only): when standard recall returns
+        # sparse results, try drift retrieval automatically.
+        if (
+            mode == "auto"
+            and len(results) < min(3, limit)
+            and limit >= 3
+            and not wing
+            and not room
+        ):
+            try:
+                from genesis.memory.drift import drift_recall
+
+                drift_results = await drift_recall(
+                    query,
+                    db=memory_mod._db,
+                    qdrant_client=memory_mod._qdrant,
+                    embedding_provider=memory_mod._retriever._embeddings,
+                    source=source,
+                    limit=limit,
+                    min_activation=min_activation,
                 )
-                results = drift_results
-                # Track drift results as retrieved — HybridRetriever.recall()
-                # handles this internally, but drift_recall does not.
-                _increment_retrieved(memory_mod._qdrant, drift_results)
-        except Exception:
-            logger.warning("drift_recall fallback failed", exc_info=True)
+                if len(drift_results) > len(results):
+                    logger.info(
+                        "drift_recall fallback: standard=%d → drift=%d results"
+                        " (query=%r)",
+                        len(results), len(drift_results), query[:80],
+                    )
+                    results = drift_results
+                    _increment_retrieved(memory_mod._qdrant, drift_results)
+                    pipeline_used = "auto_drift"
+            except Exception:
+                logger.warning("drift_recall fallback failed", exc_info=True)
+
+    # MCP-layer instrumentation: emit with mode and pipeline attribution
+    try:
+        from genesis.eval.j9_hooks import emit_recall_fired
+        await emit_recall_fired(
+            memory_mod._db,
+            query=query,
+            result_count=len(results),
+            top_scores=[r.score for r in results[:5]],
+            memory_ids=[r.memory_id for r in results[:10]],
+            latency_ms=(_time.monotonic() - _t0) * 1000,
+            source=source,
+            mode=mode,
+            pipeline_used=pipeline_used,
+        )
+    except Exception:
+        pass  # instrumentation must never break recall
 
     if compact:
         return [

--- a/src/genesis/memory/extraction.py
+++ b/src/genesis/memory/extraction.py
@@ -281,4 +281,5 @@ def extractions_to_store_kwargs(
         "source_line_range": source_line_range,
         "extraction_timestamp": now_iso,
         "source_pipeline": "harvest",
+        "valid_at": extraction.temporal,
     }

--- a/src/genesis/memory/graph.py
+++ b/src/genesis/memory/graph.py
@@ -276,7 +276,10 @@ async def centrality_scores(
     if G.number_of_nodes() == 0:
         return []
 
-    scores = nx.betweenness_centrality(G)
+    # Use approximate betweenness for large graphs to avoid blocking
+    n_nodes = G.number_of_nodes()
+    k = min(200, n_nodes) if n_nodes > 200 else None
+    scores = nx.betweenness_centrality(G, k=k)
     ranked = sorted(scores.items(), key=lambda x: x[1], reverse=True)
     return ranked[:top_n]
 

--- a/src/genesis/memory/graph.py
+++ b/src/genesis/memory/graph.py
@@ -1,20 +1,32 @@
-"""Knowledge graph traversal using recursive CTEs.
+"""Knowledge graph traversal with NetworkX caching.
 
-Provides graph queries over the memory_links table for exploring
-connected memories, traversing relationship chains, and finding
-clusters of related knowledge.
+Primary path: in-memory NetworkX DiGraph loaded lazily from memory_links.
+Fallback: recursive CTE queries (if NetworkX import fails or cache is cold
+during the first query of a session).
+
+The cache is invalidated via ``invalidate_graph_cache()`` when links are
+created or deleted. The next query triggers a rebuild from SQLite.
 """
 
 from __future__ import annotations
 
 import logging
 import time
+from collections import deque
 from dataclasses import dataclass
 
 import aiosqlite
 
 logger = logging.getLogger(__name__)
 
+try:
+    import networkx as nx
+
+    _NX_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _NX_AVAILABLE = False
+
+# ─── Data structures ──────────────────────────────────────────────────────────
 
 @dataclass
 class GraphNode:
@@ -35,6 +47,111 @@ class TraversalResult:
     query_ms: float
 
 
+# ─── NetworkX cache ───────────────────────────────────────────────────────────
+
+_nx_graph: nx.DiGraph | None = None  # type: ignore[name-defined]
+_nx_dirty: bool = True
+
+
+def invalidate_graph_cache() -> None:
+    """Mark the in-memory graph as stale.
+
+    Called by the linker after link creation/deletion. The next query
+    triggers a full rebuild from memory_links.
+    """
+    global _nx_dirty
+    _nx_dirty = True
+
+
+async def _ensure_graph(db: aiosqlite.Connection) -> nx.DiGraph:  # type: ignore[name-defined]
+    """Lazy-load the graph from memory_links, rebuild if dirty."""
+    global _nx_graph, _nx_dirty
+
+    if _nx_graph is not None and not _nx_dirty:
+        return _nx_graph
+
+    start = time.monotonic()
+    cursor = await db.execute(
+        "SELECT source_id, target_id, link_type, strength FROM memory_links"
+    )
+    rows = await cursor.fetchall()
+
+    G = nx.DiGraph()
+    for source_id, target_id, link_type, strength in rows:
+        G.add_edge(
+            source_id, target_id,
+            link_type=link_type, strength=strength,
+        )
+
+    elapsed_ms = (time.monotonic() - start) * 1000
+    logger.info(
+        "Graph cache rebuilt: %d nodes, %d edges in %.1fms",
+        G.number_of_nodes(), G.number_of_edges(), elapsed_ms,
+    )
+    if G.number_of_edges() > 50_000:
+        logger.warning(
+            "Graph has %d edges — consider FalkorDB migration",
+            G.number_of_edges(),
+        )
+
+    _nx_graph = G
+    _nx_dirty = False
+    return G
+
+
+def _bfs_with_strength(
+    G: nx.DiGraph,  # type: ignore[name-defined]
+    root_id: str,
+    *,
+    max_depth: int,
+    min_strength: float,
+    link_type_filter: str | None = None,
+) -> list[GraphNode]:
+    """BFS traversal with edge-attribute filtering.
+
+    NetworkX's bfs_edges doesn't filter by edge attributes, so we roll
+    a simple BFS that respects min_strength and optional link_type.
+    """
+    if root_id not in G:
+        return []
+
+    visited: set[str] = {root_id}
+    queue: deque[tuple[str, int]] = deque([(root_id, 0)])
+    results: list[GraphNode] = []
+
+    while queue:
+        node, depth = queue.popleft()
+        if depth >= max_depth:
+            continue
+
+        for _, neighbor, data in G.out_edges(node, data=True):
+            if neighbor in visited:
+                continue
+            strength = data.get("strength", 0.0)
+            edge_type = data.get("link_type", "")
+
+            if strength < min_strength:
+                continue
+            if link_type_filter and edge_type != link_type_filter:
+                continue
+
+            visited.add(neighbor)
+            results.append(GraphNode(
+                memory_id=neighbor,
+                link_type=edge_type,
+                depth=depth + 1,
+                strength=strength,
+            ))
+            queue.append((neighbor, depth + 1))
+
+    # Match CTE output order: depth ascending, strength descending
+    results.sort(key=lambda n: (n.depth, -n.strength))
+    return results
+
+
+# ─── Public API ───────────────────────────────────────────────────────────────
+
+
 async def traverse(
     db: aiosqlite.Connection,
     root_id: str,
@@ -42,10 +159,9 @@ async def traverse(
     max_depth: int = 3,
     min_strength: float = 0.0,
 ) -> TraversalResult:
-    """Traverse the memory graph from a root node using recursive CTE.
+    """Traverse the memory graph from a root node.
 
-    Follows outgoing links (source_id → target_id) up to max_depth hops.
-    Filters by minimum link strength. Tracks visited nodes to prevent cycles.
+    Uses NetworkX cache when available, falls back to recursive CTE.
 
     Args:
         db: Database connection.
@@ -58,42 +174,15 @@ async def traverse(
     """
     start = time.monotonic()
 
-    cursor = await db.execute(
-        """
-        WITH RECURSIVE connected(target_id, link_type, depth, strength, path) AS (
-            SELECT target_id, link_type, 1, strength,
-                   source_id || ',' || target_id
-            FROM memory_links
-            WHERE source_id = ?
-              AND strength >= ?
-            UNION ALL
-            SELECT ml.target_id, ml.link_type, c.depth + 1, ml.strength,
-                   c.path || ',' || ml.target_id
-            FROM memory_links ml
-            JOIN connected c ON ml.source_id = c.target_id
-            WHERE c.depth < ?
-              AND ml.strength >= ?
-              AND c.path NOT LIKE '%' || ml.target_id || '%'
+    if _NX_AVAILABLE:
+        G = await _ensure_graph(db)
+        nodes = _bfs_with_strength(
+            G, root_id, max_depth=max_depth, min_strength=min_strength,
         )
-        SELECT DISTINCT target_id, link_type, depth, strength
-        FROM connected
-        ORDER BY depth, strength DESC
-        """,
-        (root_id, min_strength, max_depth, min_strength),
-    )
+    else:
+        nodes = await _traverse_cte(db, root_id, max_depth, min_strength)
 
-    rows = await cursor.fetchall()
     elapsed_ms = (time.monotonic() - start) * 1000
-
-    nodes = [
-        GraphNode(
-            memory_id=row[0],
-            link_type=row[1],
-            depth=row[2],
-            strength=row[3],
-        )
-        for row in rows
-    ]
 
     if elapsed_ms > 100:
         logger.warning(
@@ -119,6 +208,185 @@ async def find_connected_by_type(
     """
     start = time.monotonic()
 
+    if _NX_AVAILABLE:
+        G = await _ensure_graph(db)
+        nodes = _bfs_with_strength(
+            G, root_id, max_depth=max_depth, min_strength=0.0,
+            link_type_filter=link_type,
+        )
+    else:
+        nodes = await _find_connected_by_type_cte(db, root_id, link_type, max_depth)
+
+    elapsed_ms = (time.monotonic() - start) * 1000
+    if elapsed_ms > 100:
+        logger.warning(
+            "Typed traversal (%s) from %s took %.1fms",
+            link_type, root_id, elapsed_ms,
+        )
+
+    return nodes
+
+
+async def get_cluster(
+    db: aiosqlite.Connection,
+    root_id: str,
+    *,
+    max_depth: int = 2,
+    min_strength: float = 0.5,
+) -> list[str]:
+    """Get all memory IDs in a cluster around root_id.
+
+    Follows links in BOTH directions (source->target and target->source)
+    to find the full connected component within depth/strength bounds.
+    """
+    start = time.monotonic()
+
+    if _NX_AVAILABLE:
+        G = await _ensure_graph(db)
+        cluster_ids = _cluster_nx(G, root_id, max_depth, min_strength)
+    else:
+        cluster_ids = await _get_cluster_cte(db, root_id, max_depth, min_strength)
+
+    elapsed_ms = (time.monotonic() - start) * 1000
+    if elapsed_ms > 100:
+        logger.warning(
+            "Cluster query from %s took %.1fms (%d members)",
+            root_id, elapsed_ms, len(cluster_ids),
+        )
+
+    return cluster_ids
+
+
+# ─── New NetworkX-only functions ──────────────────────────────────────────────
+
+
+async def centrality_scores(
+    db: aiosqlite.Connection,
+    top_n: int = 100,
+) -> list[tuple[str, float]]:
+    """Return top-N memories by betweenness centrality.
+
+    Identifies memories that are "bridges" between clusters of knowledge.
+    Requires NetworkX; returns empty list if unavailable.
+    """
+    if not _NX_AVAILABLE:
+        return []
+
+    G = await _ensure_graph(db)
+    if G.number_of_nodes() == 0:
+        return []
+
+    scores = nx.betweenness_centrality(G)
+    ranked = sorted(scores.items(), key=lambda x: x[1], reverse=True)
+    return ranked[:top_n]
+
+
+async def shortest_path(
+    db: aiosqlite.Connection,
+    source_id: str,
+    target_id: str,
+) -> list[str] | None:
+    """Find shortest path between two memories.
+
+    Returns list of memory IDs from source to target, or None if no path.
+    Requires NetworkX; returns None if unavailable.
+    """
+    if not _NX_AVAILABLE:
+        return None
+
+    G = await _ensure_graph(db)
+    try:
+        return nx.shortest_path(G, source_id, target_id)
+    except (nx.NetworkXNoPath, nx.NodeNotFound):
+        return None
+
+
+# ─── NetworkX helpers ─────────────────────────────────────────────────────────
+
+
+def _cluster_nx(
+    G: nx.DiGraph,  # type: ignore[name-defined]
+    root_id: str,
+    max_depth: int,
+    min_strength: float,
+) -> list[str]:
+    """Bidirectional BFS cluster discovery using NetworkX."""
+    if root_id not in G:
+        return []
+
+    visited: set[str] = set()
+    queue: deque[tuple[str, int]] = deque([(root_id, 0)])
+
+    while queue:
+        node, depth = queue.popleft()
+        if node in visited:
+            continue
+        visited.add(node)
+
+        if depth >= max_depth:
+            continue
+
+        # Follow both directions
+        for _, neighbor, data in G.out_edges(node, data=True):
+            if neighbor not in visited and data.get("strength", 0.0) >= min_strength:
+                queue.append((neighbor, depth + 1))
+
+        for predecessor, _, data in G.in_edges(node, data=True):
+            if predecessor not in visited and data.get("strength", 0.0) >= min_strength:
+                queue.append((predecessor, depth + 1))
+
+    # Exclude root from result (matches CTE behavior)
+    visited.discard(root_id)
+    return list(visited)
+
+
+# ─── CTE fallbacks ───────────────────────────────────────────────────────────
+
+
+async def _traverse_cte(
+    db: aiosqlite.Connection,
+    root_id: str,
+    max_depth: int,
+    min_strength: float,
+) -> list[GraphNode]:
+    """Original recursive CTE traversal (fallback)."""
+    cursor = await db.execute(
+        """
+        WITH RECURSIVE connected(target_id, link_type, depth, strength, path) AS (
+            SELECT target_id, link_type, 1, strength,
+                   source_id || ',' || target_id
+            FROM memory_links
+            WHERE source_id = ?
+              AND strength >= ?
+            UNION ALL
+            SELECT ml.target_id, ml.link_type, c.depth + 1, ml.strength,
+                   c.path || ',' || ml.target_id
+            FROM memory_links ml
+            JOIN connected c ON ml.source_id = c.target_id
+            WHERE c.depth < ?
+              AND ml.strength >= ?
+              AND c.path NOT LIKE '%' || ml.target_id || '%'
+        )
+        SELECT DISTINCT target_id, link_type, depth, strength
+        FROM connected
+        ORDER BY depth, strength DESC
+        """,
+        (root_id, min_strength, max_depth, min_strength),
+    )
+    rows = await cursor.fetchall()
+    return [
+        GraphNode(memory_id=row[0], link_type=row[1], depth=row[2], strength=row[3])
+        for row in rows
+    ]
+
+
+async def _find_connected_by_type_cte(
+    db: aiosqlite.Connection,
+    root_id: str,
+    link_type: str,
+    max_depth: int,
+) -> list[GraphNode]:
+    """Original typed CTE traversal (fallback)."""
     cursor = await db.execute(
         """
         WITH RECURSIVE connected(target_id, link_type, depth, strength, path) AS (
@@ -142,41 +410,20 @@ async def find_connected_by_type(
         """,
         (root_id, link_type, max_depth, link_type),
     )
-
     rows = await cursor.fetchall()
-    elapsed_ms = (time.monotonic() - start) * 1000
-
-    if elapsed_ms > 100:
-        logger.warning(
-            "Typed traversal (%s) from %s took %.1fms",
-            link_type, root_id, elapsed_ms,
-        )
-
     return [
-        GraphNode(
-            memory_id=row[0],
-            link_type=row[1],
-            depth=row[2],
-            strength=row[3],
-        )
+        GraphNode(memory_id=row[0], link_type=row[1], depth=row[2], strength=row[3])
         for row in rows
     ]
 
 
-async def get_cluster(
+async def _get_cluster_cte(
     db: aiosqlite.Connection,
     root_id: str,
-    *,
-    max_depth: int = 2,
-    min_strength: float = 0.5,
+    max_depth: int,
+    min_strength: float,
 ) -> list[str]:
-    """Get all memory IDs in a cluster around root_id.
-
-    Follows links in BOTH directions (source→target and target→source)
-    to find the full connected component.
-    """
-    start = time.monotonic()
-
+    """Original bidirectional CTE cluster query (fallback)."""
     cursor = await db.execute(
         """
         WITH RECURSIVE cluster(mem_id, depth, path) AS (
@@ -209,14 +456,5 @@ async def get_cluster(
          root_id, root_id, min_strength,
          max_depth, min_strength),
     )
-
     rows = await cursor.fetchall()
-    elapsed_ms = (time.monotonic() - start) * 1000
-
-    if elapsed_ms > 100:
-        logger.warning(
-            "Cluster query from %s took %.1fms (%d members)",
-            root_id, elapsed_ms, len(rows),
-        )
-
     return [row[0] for row in rows]

--- a/src/genesis/memory/graph.py
+++ b/src/genesis/memory/graph.py
@@ -49,7 +49,7 @@ class TraversalResult:
 
 # ─── NetworkX cache ───────────────────────────────────────────────────────────
 
-_nx_graph: nx.DiGraph | None = None  # type: ignore[name-defined]
+_nx_graph: object | None = None  # nx.DiGraph when _NX_AVAILABLE
 _nx_dirty: bool = True
 
 
@@ -63,7 +63,7 @@ def invalidate_graph_cache() -> None:
     _nx_dirty = True
 
 
-async def _ensure_graph(db: aiosqlite.Connection) -> nx.DiGraph:  # type: ignore[name-defined]
+async def _ensure_graph(db: aiosqlite.Connection) -> object:
     """Lazy-load the graph from memory_links, rebuild if dirty."""
     global _nx_graph, _nx_dirty
 
@@ -100,7 +100,7 @@ async def _ensure_graph(db: aiosqlite.Connection) -> nx.DiGraph:  # type: ignore
 
 
 def _bfs_with_strength(
-    G: nx.DiGraph,  # type: ignore[name-defined]
+    G: object,  # nx.DiGraph
     root_id: str,
     *,
     max_depth: int,
@@ -305,7 +305,7 @@ async def shortest_path(
 
 
 def _cluster_nx(
-    G: nx.DiGraph,  # type: ignore[name-defined]
+    G: object,  # nx.DiGraph
     root_id: str,
     max_depth: int,
     min_strength: float,

--- a/src/genesis/memory/linker.py
+++ b/src/genesis/memory/linker.py
@@ -71,8 +71,6 @@ class MemoryLinker:
                 strength=score,
                 created_at=now,
             )
-            from genesis.memory.graph import invalidate_graph_cache
-            invalidate_graph_cache()
 
             links.append(
                 LinkRecord(
@@ -84,6 +82,9 @@ class MemoryLinker:
                 )
             )
 
+        if links:
+            from genesis.memory.graph import invalidate_graph_cache
+            invalidate_graph_cache()
         return links
 
     async def count_links(self, memory_id: str) -> int:
@@ -148,8 +149,6 @@ class MemoryLinker:
                     strength=0.7,
                     created_at=now,
                 )
-                from genesis.memory.graph import invalidate_graph_cache
-                invalidate_graph_cache()
                 links.append(
                     LinkRecord(
                         source_id=memory_id,
@@ -167,6 +166,9 @@ class MemoryLinker:
                     exc_info=True,
                 )
 
+        if links:
+            from genesis.memory.graph import invalidate_graph_cache
+            invalidate_graph_cache()
         return links
 
     async def _find_entity_by_name(self, entity_name: str) -> str | None:

--- a/src/genesis/memory/linker.py
+++ b/src/genesis/memory/linker.py
@@ -71,6 +71,8 @@ class MemoryLinker:
                 strength=score,
                 created_at=now,
             )
+            from genesis.memory.graph import invalidate_graph_cache
+            invalidate_graph_cache()
 
             links.append(
                 LinkRecord(
@@ -146,6 +148,8 @@ class MemoryLinker:
                     strength=0.7,
                     created_at=now,
                 )
+                from genesis.memory.graph import invalidate_graph_cache
+                invalidate_graph_cache()
                 links.append(
                     LinkRecord(
                         source_id=memory_id,

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -308,6 +308,9 @@ class MemoryStore:
         results["links_deleted"] = await memory_links_crud.delete_by_memory(
             self._db, memory_id=memory_id,
         )
+        if results["links_deleted"]:
+            from genesis.memory.graph import invalidate_graph_cache
+            invalidate_graph_cache()
 
         # 5. Cascade: pending_embeddings
         results["pending_deleted"] = await pending_embeddings.delete_by_memory(

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -87,6 +87,7 @@ class MemoryStore:
         wing: str | None = None,
         room: str | None = None,
         force_fts5_only: bool = False,
+        valid_at: str | None = None,
     ) -> str:
         """Full store pipeline: embed -> Qdrant -> FTS5 -> auto-link. Returns memory_id.
 
@@ -233,6 +234,7 @@ class MemoryStore:
             memory_class=resolved_class,
             wing=wing,
             room=room,
+            valid_at=valid_at,
         )
 
         if not embedding_ok:

--- a/tests/test_knowledge/test_orchestrator.py
+++ b/tests/test_knowledge/test_orchestrator.py
@@ -138,9 +138,11 @@ async def test_store_units_rollback_on_failure(tmp_path: Path):
     mock_store._embeddings = MagicMock(model_name="test-model")
 
     mock_knowledge = MagicMock()
-    # SQLite insert succeeds twice, then raises on the 3rd
-    mock_knowledge.insert = AsyncMock(
-        side_effect=[None, None, Exception("DB locked")]
+    # find_by_unique_key returns None (no existing unit) for all calls
+    mock_knowledge.find_by_unique_key = AsyncMock(return_value=None)
+    # SQLite upsert succeeds twice, then raises on the 3rd
+    mock_knowledge.upsert = AsyncMock(
+        side_effect=[("uid-0", True), ("uid-1", True), Exception("DB locked")]
     )
 
     with patch("genesis.mcp.memory_mcp._require_init"), \

--- a/tests/test_memory/test_bitemporal.py
+++ b/tests/test_memory/test_bitemporal.py
@@ -1,0 +1,154 @@
+"""Tests for bi-temporal memory wiring (valid_at / invalid_at)."""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.memory.extraction import Extraction, extractions_to_store_kwargs
+
+# ---------------------------------------------------------------------------
+# Extraction → valid_at mapping
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionValidAt:
+    """Verify extraction temporal field maps to valid_at in store kwargs."""
+
+    def test_temporal_becomes_valid_at(self):
+        ext = Extraction(
+            content="PR #773 was closed",
+            extraction_type="entity",
+            confidence=0.9,
+            temporal="2026-05-03",
+        )
+        kwargs = extractions_to_store_kwargs(ext)
+        assert kwargs["valid_at"] == "2026-05-03"
+
+    def test_no_temporal_gives_none_valid_at(self):
+        ext = Extraction(
+            content="Genesis uses RRF fusion",
+            extraction_type="concept",
+            confidence=0.8,
+        )
+        kwargs = extractions_to_store_kwargs(ext)
+        assert kwargs["valid_at"] is None
+
+    def test_temporal_still_in_tags(self):
+        """Temporal should appear in BOTH tags and valid_at."""
+        ext = Extraction(
+            content="Something happened",
+            extraction_type="entity",
+            confidence=0.7,
+            temporal="2026-04-15",
+        )
+        kwargs = extractions_to_store_kwargs(ext)
+        assert "2026-04-15" in kwargs["tags"]
+        assert kwargs["valid_at"] == "2026-04-15"
+
+
+# ---------------------------------------------------------------------------
+# CRUD: create_metadata with bi-temporal columns
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def meta_db():
+    """In-memory SQLite with memory_metadata table."""
+    import aiosqlite
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute("""
+        CREATE TABLE memory_metadata (
+            memory_id        TEXT PRIMARY KEY,
+            created_at       TEXT NOT NULL,
+            collection       TEXT NOT NULL DEFAULT 'episodic_memory',
+            confidence       REAL,
+            embedding_status TEXT NOT NULL DEFAULT 'embedded',
+            memory_class     TEXT DEFAULT 'fact',
+            wing             TEXT,
+            room             TEXT,
+            valid_at         TEXT,
+            invalid_at       TEXT
+        )
+    """)
+    await db.commit()
+    yield db
+    await db.close()
+
+
+class TestCreateMetadata:
+    """Tests for create_metadata with bi-temporal columns."""
+
+    @pytest.mark.asyncio
+    async def test_valid_at_defaults_to_created_at(self, meta_db):
+        from genesis.db.crud.memory import create_metadata
+        await create_metadata(
+            meta_db,
+            memory_id="m1",
+            created_at="2026-05-08T12:00:00Z",
+        )
+        cursor = await meta_db.execute(
+            "SELECT valid_at, invalid_at FROM memory_metadata WHERE memory_id = ?",
+            ("m1",),
+        )
+        row = await cursor.fetchone()
+        assert row["valid_at"] == "2026-05-08T12:00:00Z"
+        assert row["invalid_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_explicit_valid_at(self, meta_db):
+        from genesis.db.crud.memory import create_metadata
+        await create_metadata(
+            meta_db,
+            memory_id="m2",
+            created_at="2026-05-08T12:00:00Z",
+            valid_at="2026-04-15",
+        )
+        cursor = await meta_db.execute(
+            "SELECT valid_at FROM memory_metadata WHERE memory_id = ?",
+            ("m2",),
+        )
+        row = await cursor.fetchone()
+        assert row["valid_at"] == "2026-04-15"
+
+    @pytest.mark.asyncio
+    async def test_explicit_invalid_at(self, meta_db):
+        from genesis.db.crud.memory import create_metadata
+        await create_metadata(
+            meta_db,
+            memory_id="m3",
+            created_at="2026-05-08T12:00:00Z",
+            invalid_at="2026-05-07",
+        )
+        cursor = await meta_db.execute(
+            "SELECT invalid_at FROM memory_metadata WHERE memory_id = ?",
+            ("m3",),
+        )
+        row = await cursor.fetchone()
+        assert row["invalid_at"] == "2026-05-07"
+
+
+class TestInvalidateMemory:
+    """Tests for invalidate_memory()."""
+
+    @pytest.mark.asyncio
+    async def test_invalidate_sets_invalid_at(self, meta_db):
+        from genesis.db.crud.memory import create_metadata, invalidate_memory
+        await create_metadata(
+            meta_db, memory_id="m1", created_at="2026-05-08T12:00:00Z",
+        )
+        result = await invalidate_memory(meta_db, "m1", "2026-05-08T15:00:00Z")
+        assert result is True
+
+        cursor = await meta_db.execute(
+            "SELECT invalid_at FROM memory_metadata WHERE memory_id = ?",
+            ("m1",),
+        )
+        row = await cursor.fetchone()
+        assert row["invalid_at"] == "2026-05-08T15:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_invalidate_nonexistent_returns_false(self, meta_db):
+        from genesis.db.crud.memory import invalidate_memory
+        result = await invalidate_memory(meta_db, "nonexistent", "2026-05-08")
+        assert result is False

--- a/tests/test_memory/test_graph.py
+++ b/tests/test_memory/test_graph.py
@@ -6,8 +6,11 @@ import aiosqlite
 import pytest
 
 from genesis.memory.graph import (
+    centrality_scores,
     find_connected_by_type,
     get_cluster,
+    invalidate_graph_cache,
+    shortest_path,
     traverse,
 )
 
@@ -156,3 +159,88 @@ class TestGetCluster:
     async def test_isolated_node(self, graph_db):
         cluster = await get_cluster(graph_db, "Z_isolated")
         assert cluster == []
+
+
+class TestNetworkXCache:
+    """Tests for the NetworkX cache lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_cache_invalidation_triggers_rebuild(self, graph_db):
+        """After invalidation, next query should still return correct results."""
+        result1 = await traverse(graph_db, "A", max_depth=1)
+        ids1 = {n.memory_id for n in result1.nodes}
+
+        # Invalidate and re-query
+        invalidate_graph_cache()
+        result2 = await traverse(graph_db, "A", max_depth=1)
+        ids2 = {n.memory_id for n in result2.nodes}
+
+        assert ids1 == ids2 == {"B", "D"}
+
+    @pytest.mark.asyncio
+    async def test_cache_reflects_new_links(self, graph_db):
+        """After adding a link and invalidating, the new link should appear."""
+        result_before = await traverse(graph_db, "F", max_depth=1)
+        assert result_before.nodes == []
+
+        # Add a new link from F
+        await graph_db.execute(
+            "INSERT INTO memory_links VALUES ('F', 'A', 'related_to', 0.9, '2026-03-23')",
+        )
+        await graph_db.commit()
+        invalidate_graph_cache()
+
+        result_after = await traverse(graph_db, "F", max_depth=1)
+        ids = {n.memory_id for n in result_after.nodes}
+        assert "A" in ids
+
+
+class TestCentrality:
+    """Tests for betweenness centrality scoring."""
+
+    @pytest.mark.asyncio
+    async def test_centrality_returns_scores(self, graph_db):
+        # Ensure cache is built
+        invalidate_graph_cache()
+        scores = await centrality_scores(graph_db, top_n=5)
+        assert len(scores) > 0
+        # Scores are (memory_id, float) tuples
+        assert all(isinstance(s[0], str) and isinstance(s[1], float) for s in scores)
+
+    @pytest.mark.asyncio
+    async def test_centrality_bridge_node_ranks_high(self, graph_db):
+        """B is a bridge between A→C and A→E paths — should rank high."""
+        invalidate_graph_cache()
+        scores = await centrality_scores(graph_db, top_n=10)
+        score_by_id = dict(scores)
+        # B connects to C and E — should have non-zero centrality
+        assert score_by_id.get("B", 0.0) > 0.0
+
+
+class TestShortestPath:
+    """Tests for shortest path finding."""
+
+    @pytest.mark.asyncio
+    async def test_direct_path(self, graph_db):
+        invalidate_graph_cache()
+        path = await shortest_path(graph_db, "A", "B")
+        assert path == ["A", "B"]
+
+    @pytest.mark.asyncio
+    async def test_multi_hop_path(self, graph_db):
+        invalidate_graph_cache()
+        path = await shortest_path(graph_db, "A", "C")
+        assert path == ["A", "B", "C"]
+
+    @pytest.mark.asyncio
+    async def test_no_path(self, graph_db):
+        invalidate_graph_cache()
+        # F has no outgoing edges, can't reach A
+        path = await shortest_path(graph_db, "F", "A")
+        assert path is None
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_node(self, graph_db):
+        invalidate_graph_cache()
+        path = await shortest_path(graph_db, "Z_nonexistent", "A")
+        assert path is None

--- a/tests/test_memory/test_graph.py
+++ b/tests/test_memory/test_graph.py
@@ -57,7 +57,13 @@ async def graph_db(tmp_path):
         )
     await db.commit()
 
+    # Ensure fresh NetworkX cache per test
+    invalidate_graph_cache()
+
     yield db
+
+    # Clean up cache so subsequent test files don't see stale state
+    invalidate_graph_cache()
     await db.close()
 
 

--- a/tests/test_memory/test_mcp_integration.py
+++ b/tests/test_memory/test_mcp_integration.py
@@ -98,7 +98,7 @@ async def test_memory_recall_delegates(mock_deps, tools):
     assert results[0]["memory_id"] == "m1"
     memory_mcp._retriever.recall.assert_awaited_once_with(
         "query", source="both", limit=5, min_activation=0.0,
-        wing=None, room=None,
+        wing=None, room=None, expand_query_terms=True,
     )
 
 


### PR DESCRIPTION
## Summary

- **Bi-temporal wiring:** `valid_at`/`invalid_at` columns on `memory_metadata` were schema-only (migration 0010). Now fully wired — `create_metadata()` accepts and defaults `valid_at` to `created_at`, extraction `temporal` maps to `valid_at`, `get_by_id()`/`list_recent()` return both columns, `invalidate_memory()` helper added
- **NetworkX graph:** Replaces recursive CTE traversals with in-memory NetworkX DiGraph (43K edges, ~5MB). Custom BFS handles edge-attribute filtering. CTE retained as fallback if NetworkX missing. New: `centrality_scores()`, `shortest_path()`. Cache invalidated via `invalidate_graph_cache()` in linker + store delete
- **DRIFT mode:** `memory_recall` MCP tool gains `mode` param — `"auto"` (default), `"standard"`, `"drift"`. Direct DRIFT invocation without waiting for sparse-result fallback
- **Recall instrumentation:** `emit_recall_fired()` extended with `mode`, `pipeline_used`, `intent_category`. MCP layer emits with total wall time and pipeline attribution

## Test plan

- [x] 8 new bi-temporal tests pass (create_metadata defaults, explicit valid_at/invalid_at, invalidation, extraction mapping)
- [x] 20 graph tests pass (12 original + 8 new: cache lifecycle, centrality, shortest path)
- [x] 59 memory tests pass across all affected modules
- [x] Two code reviews completed — critical findings fixed (nx.DiGraph import crash, ghost edges on delete, per-link invalidation, get_by_id missing columns)
- [x] `ruff check` clean on all changed files
- [x] Full suite: 6,281 pass, 5 pre-existing failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)