### PR TITLE
fix(infra): wire heartbeat cleanup and fix surplus dedup consistency

### DIFF
--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -489,12 +489,16 @@ async def init(rt: GenesisRuntime) -> None:
                 return
             try:
                 from genesis.db.crud.cc_sessions import reap_stale
+                from genesis.db.crud.session_heartbeats import cleanup_stale
 
                 cutoff = (datetime.now(UTC) - timedelta(hours=6)).isoformat()
                 reaped = await reap_stale(rt._db, older_than=cutoff)
+                cleaned = await cleanup_stale(rt._db)
                 rt.record_job_success("session_reaper")
                 if reaped:
                     logger.info("Session reaper: marked %d stale sessions as completed", reaped)
+                if cleaned:
+                    logger.info("Session reaper: cleaned %d stale heartbeats", cleaned)
             except Exception as exc:
                 rt.record_job_failure("session_reaper", str(exc))
                 logger.exception("Session reaper failed")

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -303,8 +303,8 @@ class SurplusScheduler:
         try:
             from genesis.surplus.types import ComputeTier, TaskType
 
-            pending = await self._queue.pending_by_type(TaskType.CODE_AUDIT)
-            if pending == 0:
+            active = await self._queue.active_by_type(TaskType.CODE_AUDIT)
+            if active == 0:
                 await self._queue.enqueue(
                     TaskType.CODE_AUDIT, ComputeTier.FREE_API, 0.5, "competence"
                 )
@@ -326,8 +326,8 @@ class SurplusScheduler:
         try:
             from genesis.surplus.types import ComputeTier, TaskType
 
-            pending = await self._queue.pending_by_type(TaskType.CODE_INDEX)
-            if pending == 0:
+            active = await self._queue.active_by_type(TaskType.CODE_INDEX)
+            if active == 0:
                 await self._queue.enqueue(
                     TaskType.CODE_INDEX, ComputeTier.LOCAL_30B, 0.6, "competence"
                 )
@@ -345,7 +345,7 @@ class SurplusScheduler:
                 pass
 
     async def schedule_maintenance(self) -> None:
-        """Enqueue mechanical infrastructure maintenance tasks if none pending."""
+        """Enqueue mechanical infrastructure maintenance tasks if none active."""
         try:
             from genesis.surplus.types import ComputeTier, TaskType
 
@@ -357,8 +357,8 @@ class SurplusScheduler:
                 (TaskType.DB_MAINTENANCE, 0.3, "competence"),
             ]
             for task_type, priority, drive in maintenance_tasks:
-                pending = await self._queue.pending_by_type(task_type)
-                if pending == 0:
+                active = await self._queue.active_by_type(task_type)
+                if active == 0:
                     await self._queue.enqueue(
                         task_type, ComputeTier.FREE_API, priority, drive,
                     )
@@ -382,7 +382,7 @@ class SurplusScheduler:
                 pass
 
     async def schedule_analytical(self) -> None:
-        """Enqueue LLM-based analytical tasks if none pending.
+        """Enqueue LLM-based analytical tasks if none active.
 
         These run on a separate (longer) cadence than mechanical maintenance
         because their inputs change slowly and their free-tier model output
@@ -396,8 +396,8 @@ class SurplusScheduler:
                 # anticipatory_research returns as a pipeline — see pipelines.py.
             ]
             for task_type, priority, drive in analytical_tasks:
-                pending = await self._queue.pending_by_type(task_type)
-                if pending == 0:
+                active = await self._queue.active_by_type(task_type)
+                if active == 0:
                     await self._queue.enqueue(
                         task_type, ComputeTier.FREE_API, priority, drive,
                     )


### PR DESCRIPTION
## Summary
- Wire `session_heartbeats.cleanup_stale()` into the session reaper job so stale heartbeat rows are cleaned alongside stale sessions (every 6h)
- Switch 4 surplus schedulers from `pending_by_type` to `active_by_type` to prevent duplicate enqueues when tasks are slow (`schedule_pipeline` already used `active_by_type` correctly)
- **Dropped I-2** (update script observation resolution) — already fixed by `_resolve_pending_update_failed()` in genesis_version signal collector (PR #97)

## Test plan
- [x] `ruff check` passes on changed files
- [x] 161 tests pass (`test_surplus/` + `test_db/test_schema.py`)
- [x] Code review: APPROVE — stuck-task recovery confirmed, remaining `pending_by_type` callers are intentional (cap-checking, not dedup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)