### PR TITLE
feat(events): session_id ContextVar for automatic event bus tracing

### DIFF
--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -36,6 +36,7 @@ from genesis.cc.types import (
     StreamEvent,
     background_session_dir,
 )
+from genesis.observability.session_context import set_session_id as _set_obs_session
 from genesis.util.tasks import tracked_task
 
 if TYPE_CHECKING:
@@ -255,6 +256,7 @@ class DirectSessionRunner:
         session_id: str,
     ) -> DirectSessionResult:
         """Execute a single CC session. Called inside tracked_task."""
+        _set_obs_session(session_id)
         telemetry: list[dict] = []
         start = time.monotonic()
 

--- a/src/genesis/cc/reflection_bridge/_bridge.py
+++ b/src/genesis/cc/reflection_bridge/_bridge.py
@@ -479,6 +479,7 @@ class CCReflectionBridge:
                 source_tag="weekly_assessment",
                 skill_tags=["self-assessment"],
             )
+            _set_obs_session(sess["id"])
         except Exception:
             logger.exception("Failed to create assessment session")
             return ReflectionResult(success=False, reason="Session creation failed")
@@ -554,6 +555,7 @@ class CCReflectionBridge:
                 source_tag="quality_calibration",
                 skill_tags=["strategic-reflection"],
             )
+            _set_obs_session(sess["id"])
         except Exception:
             logger.exception("Failed to create calibration session")
             return ReflectionResult(success=False, reason="Session creation failed")

--- a/src/genesis/cc/reflection_bridge/_bridge.py
+++ b/src/genesis/cc/reflection_bridge/_bridge.py
@@ -32,6 +32,7 @@ from genesis.cc.reflection_bridge._prompts import (
 from genesis.cc.types import CCInvocation, CCModel, EffortLevel, SessionType, background_session_dir
 from genesis.db.crud import cc_sessions as cc_sessions_crud
 from genesis.observability.call_site_recorder import record_last_run
+from genesis.observability.session_context import set_session_id as _set_obs_session
 from genesis.perception.types import ReflectionResult
 
 if TYPE_CHECKING:
@@ -301,6 +302,7 @@ class CCReflectionBridge:
                     dispatch_mode="cli",
                 )
                 session_id = sess["id"]
+                _set_obs_session(session_id)
             except Exception:
                 logger.exception("Failed to create background session for %s", depth.value)
                 return ReflectionResult(success=False, reason="Session creation failed")

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -28,6 +28,7 @@ from genesis.cc.types import (
 )
 from genesis.db.crud import ego as ego_crud
 from genesis.ego.types import CYCLE_TYPE_DEFAULTS, CycleType, EgoConfig, EgoCycle
+from genesis.observability.session_context import set_session_id as _set_obs_session
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -230,6 +231,7 @@ class EgoSession:
                     source_tag=self._source_tag,
                 )
                 session_id = sess["id"]
+                _set_obs_session(session_id)
             except Exception:
                 logger.error("Failed to create ego background session", exc_info=True)
                 return None

--- a/src/genesis/observability/events.py
+++ b/src/genesis/observability/events.py
@@ -147,8 +147,8 @@ class GenesisEventBus:
                     "message": message,
                     "details": details or None,
                     "session_id": (
-                        details.get("session_id")
-                        or _get_context_session_id()
+                        sid if (sid := details.get("session_id")) is not None
+                        else _get_context_session_id()
                     ) if details else _get_context_session_id(),
                 })
             except asyncio.QueueFull:

--- a/src/genesis/observability/events.py
+++ b/src/genesis/observability/events.py
@@ -10,6 +10,7 @@ from collections import deque
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 
+from genesis.observability.session_context import get_session_id as _get_context_session_id
 from genesis.observability.types import GenesisEvent, Severity, Subsystem
 
 logger = logging.getLogger(__name__)
@@ -145,7 +146,10 @@ class GenesisEventBus:
                     "event_type": event_type,
                     "message": message,
                     "details": details or None,
-                    "session_id": details.get("session_id") if details else None,
+                    "session_id": (
+                        details.get("session_id")
+                        or _get_context_session_id()
+                    ) if details else _get_context_session_id(),
                 })
             except asyncio.QueueFull:
                 logger.warning("Event write queue full — dropping event: %s/%s", event_type, message[:80])

--- a/src/genesis/observability/session_context.py
+++ b/src/genesis/observability/session_context.py
@@ -1,0 +1,40 @@
+"""ContextVar-based session tracking for event bus observability.
+
+Provides implicit session_id propagation to emit() calls without
+requiring every call site to pass session_id explicitly.  Set the
+session_id at entry points (ego cycles, direct sessions, reflection
+bridges) and all downstream emit() calls inherit it automatically.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+_current_session_id: ContextVar[str | None] = ContextVar(
+    "genesis_session_id", default=None
+)
+
+
+def get_session_id() -> str | None:
+    """Return the current session_id, or None if not in a session scope."""
+    return _current_session_id.get()
+
+
+def set_session_id(session_id: str | None) -> None:
+    """Set the current session_id for the running context."""
+    _current_session_id.set(session_id)
+
+
+@contextmanager
+def session_scope(session_id: str) -> Generator[None]:
+    """Context manager that sets session_id for the duration of a block.
+
+    Restores the previous value on exit (supports nesting).
+    """
+    token = _current_session_id.set(session_id)
+    try:
+        yield
+    finally:
+        _current_session_id.reset(token)

--- a/tests/test_observability/test_session_context.py
+++ b/tests/test_observability/test_session_context.py
@@ -68,6 +68,28 @@ class TestAsyncPropagation:
             set_session_id(None)
 
 
+    @pytest.mark.asyncio
+    async def test_sibling_tasks_are_isolated(self):
+        """Setting session_id in one task must not affect a sibling task."""
+        results: dict[str, str | None] = {}
+
+        async def task_a():
+            set_session_id("task-a")
+            await asyncio.sleep(0.01)
+            results["a"] = get_session_id()
+
+        async def task_b():
+            await asyncio.sleep(0.01)
+            results["b"] = get_session_id()
+
+        await asyncio.gather(
+            asyncio.create_task(task_a()),
+            asyncio.create_task(task_b()),
+        )
+        assert results["a"] == "task-a"
+        assert results["b"] is None
+
+
 class TestEmitIntegration:
     @pytest.mark.asyncio
     async def test_emit_uses_contextvar_when_no_explicit_session_id(self):

--- a/tests/test_observability/test_session_context.py
+++ b/tests/test_observability/test_session_context.py
@@ -1,0 +1,131 @@
+"""Tests for session_context ContextVar-based session tracking."""
+
+import asyncio
+
+import pytest
+
+from genesis.observability.session_context import (
+    get_session_id,
+    session_scope,
+    set_session_id,
+)
+
+
+class TestGetSet:
+    def test_default_is_none(self):
+        assert get_session_id() is None
+
+    def test_set_and_get(self):
+        set_session_id("sess-abc")
+        try:
+            assert get_session_id() == "sess-abc"
+        finally:
+            set_session_id(None)
+
+    def test_set_none_clears(self):
+        set_session_id("sess-123")
+        set_session_id(None)
+        assert get_session_id() is None
+
+
+class TestSessionScope:
+    def test_scope_sets_and_restores(self):
+        assert get_session_id() is None
+        with session_scope("sess-xyz"):
+            assert get_session_id() == "sess-xyz"
+        assert get_session_id() is None
+
+    def test_nested_scopes(self):
+        with session_scope("outer"):
+            assert get_session_id() == "outer"
+            with session_scope("inner"):
+                assert get_session_id() == "inner"
+            assert get_session_id() == "outer"
+        assert get_session_id() is None
+
+    def test_scope_restores_on_exception(self):
+        with pytest.raises(ValueError), session_scope("will-fail"):
+            assert get_session_id() == "will-fail"
+            raise ValueError("boom")
+        assert get_session_id() is None
+
+
+class TestAsyncPropagation:
+    @pytest.mark.asyncio
+    async def test_contextvar_propagates_to_asyncio_task(self):
+        """ContextVar should propagate to asyncio.create_task children."""
+        captured = []
+
+        async def child():
+            captured.append(get_session_id())
+
+        set_session_id("parent-sess")
+        try:
+            task = asyncio.create_task(child())
+            await task
+            assert captured == ["parent-sess"]
+        finally:
+            set_session_id(None)
+
+
+class TestEmitIntegration:
+    @pytest.mark.asyncio
+    async def test_emit_uses_contextvar_when_no_explicit_session_id(self):
+        """emit() should auto-populate session_id from ContextVar."""
+        from datetime import UTC, datetime
+
+        from genesis.observability.events import GenesisEventBus
+        from genesis.observability.types import Severity, Subsystem
+
+        bus = GenesisEventBus(clock=lambda: datetime(2026, 1, 1, tzinfo=UTC))
+
+        # Enable persistence to capture the dict that would be written
+        original_queue = asyncio.Queue(maxsize=500)
+        bus._write_queue = original_queue
+
+        with session_scope("ctx-sess-001"):
+            await bus.emit(
+                Subsystem.ROUTING, Severity.INFO, "test.event", "hello",
+            )
+
+        # The dict queued for DB write should have our session_id
+        item = original_queue.get_nowait()
+        assert item["session_id"] == "ctx-sess-001"
+
+    @pytest.mark.asyncio
+    async def test_explicit_session_id_takes_precedence(self):
+        """Explicit session_id in details should override ContextVar."""
+        from datetime import UTC, datetime
+
+        from genesis.observability.events import GenesisEventBus
+        from genesis.observability.types import Severity, Subsystem
+
+        bus = GenesisEventBus(clock=lambda: datetime(2026, 1, 1, tzinfo=UTC))
+        bus._write_queue = asyncio.Queue(maxsize=500)
+
+        with session_scope("ctx-sess"):
+            await bus.emit(
+                Subsystem.ROUTING, Severity.INFO, "test.event", "hello",
+                session_id="explicit-sess",
+            )
+
+        item = bus._write_queue.get_nowait()
+        assert item["session_id"] == "explicit-sess"
+
+    @pytest.mark.asyncio
+    async def test_no_session_produces_none(self):
+        """Without ContextVar or explicit session_id, should be None."""
+        from datetime import UTC, datetime
+
+        from genesis.observability.events import GenesisEventBus
+        from genesis.observability.types import Severity, Subsystem
+
+        bus = GenesisEventBus(clock=lambda: datetime(2026, 1, 1, tzinfo=UTC))
+        bus._write_queue = asyncio.Queue(maxsize=500)
+
+        await bus.emit(
+            Subsystem.ROUTING, Severity.INFO, "test.event", "hello",
+        )
+
+        item = bus._write_queue.get_nowait()
+        assert item["session_id"] is None


### PR DESCRIPTION
## Summary
- Add `ContextVar`-based session tracking so `emit()` calls automatically inherit `session_id` without requiring every call site to pass it explicitly
- New module `observability/session_context.py` with `get_session_id()`, `set_session_id()`, and `session_scope()` context manager
- `emit()` falls back to ContextVar when no explicit `session_id` is passed in `**details`; explicit values take precedence (using `is not None`, not `or`)
- Wired at 5 entry points: ego session, direct session, reflection bridge (reflect + weekly assessment + quality calibration)

## Scope
**Wired entry points:** ego cycles, direct sessions, all 3 reflection bridge methods  
**Not wired (follow-up):** sentinel, inbox monitor, conversation — these run in isolated async contexts and currently emit with `session_id=None` (unchanged behavior)

## Test plan
- [x] 11 new tests: get/set, scoping, nested scopes, exception safety, async propagation, sibling-task isolation, emit integration (ContextVar fallback, explicit override, no-session None)
- [x] 11 existing event bus tests pass (zero regressions)
- [x] `ruff check` clean on all changed files
- [x] Code review: addressed `or` vs `is not None` bug, wired 2 additional bridge entry points, added isolation test

🤖 Generated with [Claude Code](https://claude.com/claude-code)