### PR TITLE
feat(ego): causal intervention journal for proposal lifecycle tracking

### DIFF
--- a/src/genesis/dashboard/routes/comms.py
+++ b/src/genesis/dashboard/routes/comms.py
@@ -194,6 +194,6 @@ async def comms_resolve_proposal(proposal_id: str):
             user_response=user_response or None,
         )
     except Exception:
-        pass  # Non-critical
+        logger.warning("Journal resolve failed for proposal %s", proposal_id)
 
     return jsonify({"id": proposal_id, "status": status})

--- a/src/genesis/dashboard/routes/comms.py
+++ b/src/genesis/dashboard/routes/comms.py
@@ -185,4 +185,15 @@ async def comms_resolve_proposal(proposal_id: str):
     if not ok:
         return jsonify({"error": "Proposal not found or already resolved"}), 404
 
+    try:
+        from genesis.db.crud import intervention_journal as journal_crud
+        await journal_crud.resolve(
+            rt.db, proposal_id,
+            outcome_status=status,
+            actual_outcome=f"Dashboard: user {status}",
+            user_response=user_response or None,
+        )
+    except Exception:
+        pass  # Non-critical
+
     return jsonify({"id": proposal_id, "status": status})

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -228,7 +228,8 @@ async def ego_proposal_resolve(proposal_id: str):
             user_response=user_response or None,
         )
     except Exception:
-        pass  # Non-critical
+        import logging
+        logging.getLogger(__name__).warning("Journal resolve failed for %s", proposal_id)
 
     return jsonify({"ok": True, "id": proposal_id, "status": status})
 

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -219,6 +219,17 @@ async def ego_proposal_resolve(proposal_id: str):
     if not updated:
         return jsonify({"ok": False, "error": "proposal not found or not pending"}), 404
 
+    try:
+        from genesis.db.crud import intervention_journal as journal_crud
+        await journal_crud.resolve(
+            rt._db, proposal_id,
+            outcome_status=status,
+            actual_outcome=f"Dashboard: user {status}",
+            user_response=user_response or None,
+        )
+    except Exception:
+        pass  # Non-critical
+
     return jsonify({"ok": True, "id": proposal_id, "status": status})
 
 

--- a/src/genesis/db/crud/intervention_journal.py
+++ b/src/genesis/db/crud/intervention_journal.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import aiosqlite
 
@@ -91,7 +91,7 @@ async def recent_resolved(
     limit: int = 10,
 ) -> list[dict]:
     """Return recently resolved entries for ego context display."""
-    cutoff = (datetime.now(UTC) - __import__("datetime").timedelta(days=days)).isoformat()
+    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
     cur = await db.execute(
         """SELECT action_type, action_summary, expected_outcome,
                   actual_outcome, outcome_status, user_response,

--- a/src/genesis/db/crud/intervention_journal.py
+++ b/src/genesis/db/crud/intervention_journal.py
@@ -1,0 +1,141 @@
+"""CRUD operations for the intervention journal.
+
+Tracks ego proposals from creation through resolution, recording
+expected vs actual outcomes for metacognitive feedback.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+async def create(
+    db: aiosqlite.Connection,
+    *,
+    ego_source: str,
+    proposal_id: str,
+    cycle_id: str,
+    action_type: str,
+    action_summary: str,
+    expected_outcome: str = "",
+    confidence: float = 0.0,
+    created_at: str | None = None,
+) -> str:
+    """Create a journal entry when a proposal is born."""
+    jid = uuid.uuid4().hex[:16]
+    created_at = created_at or datetime.now(UTC).isoformat()
+    await db.execute(
+        """INSERT INTO intervention_journal
+           (id, ego_source, proposal_id, cycle_id, action_type,
+            action_summary, expected_outcome, confidence, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (jid, ego_source, proposal_id, cycle_id, action_type,
+         action_summary, expected_outcome, confidence, created_at),
+    )
+    await db.commit()
+    return jid
+
+
+async def resolve(
+    db: aiosqlite.Connection,
+    proposal_id: str,
+    *,
+    outcome_status: str,
+    actual_outcome: str | None = None,
+    user_response: str | None = None,
+    resolved_at: str | None = None,
+) -> bool:
+    """Update a pending journal entry when its proposal resolves.
+
+    Returns True if a row was updated, False if no pending entry found.
+    """
+    resolved_at = resolved_at or datetime.now(UTC).isoformat()
+    cur = await db.execute(
+        """UPDATE intervention_journal
+           SET outcome_status = ?, actual_outcome = ?,
+               user_response = ?, resolved_at = ?
+           WHERE proposal_id = ? AND outcome_status = 'pending'""",
+        (outcome_status, actual_outcome, user_response,
+         resolved_at, proposal_id),
+    )
+    await db.commit()
+    return cur.rowcount > 0
+
+
+async def get_by_proposal(
+    db: aiosqlite.Connection,
+    proposal_id: str,
+) -> dict | None:
+    """Fetch the journal entry for a given proposal."""
+    cur = await db.execute(
+        "SELECT * FROM intervention_journal WHERE proposal_id = ?",
+        (proposal_id,),
+    )
+    row = await cur.fetchone()
+    if row is None:
+        return None
+    cols = [d[0] for d in cur.description]
+    return dict(zip(cols, row, strict=False))
+
+
+async def recent_resolved(
+    db: aiosqlite.Connection,
+    *,
+    days: int = 7,
+    limit: int = 10,
+) -> list[dict]:
+    """Return recently resolved entries for ego context display."""
+    cutoff = (datetime.now(UTC) - __import__("datetime").timedelta(days=days)).isoformat()
+    cur = await db.execute(
+        """SELECT action_type, action_summary, expected_outcome,
+                  actual_outcome, outcome_status, user_response,
+                  confidence, resolved_at
+           FROM intervention_journal
+           WHERE outcome_status != 'pending' AND resolved_at >= ?
+           ORDER BY resolved_at DESC
+           LIMIT ?""",
+        (cutoff, limit),
+    )
+    rows = await cur.fetchall()
+    cols = [d[0] for d in cur.description]
+    return [dict(zip(cols, r, strict=False)) for r in rows]
+
+
+async def unresolved_count(db: aiosqlite.Connection) -> int:
+    """Count pending (unresolved) journal entries."""
+    cur = await db.execute(
+        "SELECT COUNT(*) FROM intervention_journal WHERE outcome_status = 'pending'"
+    )
+    row = await cur.fetchone()
+    return row[0] if row else 0
+
+
+async def aggregate_by_type(db: aiosqlite.Connection) -> list[dict]:
+    """Aggregate outcomes by action_type for capability map input.
+
+    Returns rows with: action_type, total, approved, rejected, executed,
+    failed, avg_confidence.
+    """
+    cur = await db.execute(
+        """SELECT
+               action_type,
+               COUNT(*) as total,
+               SUM(CASE WHEN outcome_status = 'approved' THEN 1 ELSE 0 END) as approved,
+               SUM(CASE WHEN outcome_status = 'rejected' THEN 1 ELSE 0 END) as rejected,
+               SUM(CASE WHEN outcome_status = 'executed' THEN 1 ELSE 0 END) as executed,
+               SUM(CASE WHEN outcome_status = 'failed' THEN 1 ELSE 0 END) as failed,
+               ROUND(AVG(confidence), 2) as avg_confidence
+           FROM intervention_journal
+           WHERE outcome_status != 'pending'
+           GROUP BY action_type
+           ORDER BY total DESC"""
+    )
+    rows = await cur.fetchall()
+    cols = [d[0] for d in cur.description]
+    return [dict(zip(cols, r, strict=False)) for r in rows]

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -777,6 +777,26 @@ TABLES = {
             updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
         )
     """,
+    # ── Intervention Journal ────────────────────────────────────────────────
+    "intervention_journal": """
+        CREATE TABLE IF NOT EXISTS intervention_journal (
+            id              TEXT PRIMARY KEY,
+            ego_source      TEXT NOT NULL,               -- 'user_ego_cycle' or 'genesis_ego_cycle'
+            proposal_id     TEXT,                        -- FK to ego_proposals.id
+            cycle_id        TEXT,                        -- FK to ego_cycles.id
+            action_type     TEXT NOT NULL,               -- from proposal.action_type
+            action_summary  TEXT NOT NULL,               -- from proposal.content (truncated)
+            expected_outcome TEXT NOT NULL DEFAULT '',   -- from proposal.rationale
+            actual_outcome  TEXT,                        -- filled on resolution
+            outcome_status  TEXT NOT NULL DEFAULT 'pending'
+                CHECK (outcome_status IN ('pending', 'approved', 'rejected',
+                       'executed', 'failed', 'tabled', 'withdrawn', 'expired')),
+            user_response   TEXT,                        -- user feedback on resolve
+            confidence      REAL DEFAULT 0.0,            -- from proposal.confidence
+            created_at      TEXT NOT NULL,
+            resolved_at     TEXT
+        )
+    """,
     # ── Behavioral Immune System (BIS) ───────────────────────────────────────
     # GROUNDWORK(bis): Tables for graduated behavioral correction.
     # See docs/plans/2026-03-27-behavioral-immune-system-design.md
@@ -1118,6 +1138,11 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_ego_proposals_batch ON ego_proposals(batch_id)",
     "CREATE INDEX IF NOT EXISTS idx_ego_proposals_expires ON ego_proposals(expires_at)",
     "CREATE INDEX IF NOT EXISTS idx_ego_proposals_rank ON ego_proposals(status, rank)",
+    # intervention journal
+    "CREATE INDEX IF NOT EXISTS idx_intervention_journal_status ON intervention_journal(outcome_status)",
+    "CREATE INDEX IF NOT EXISTS idx_intervention_journal_proposal ON intervention_journal(proposal_id)",
+    "CREATE INDEX IF NOT EXISTS idx_intervention_journal_created ON intervention_journal(created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_intervention_journal_source ON intervention_journal(ego_source)",
     # behavioral immune system (BIS)
     "CREATE INDEX IF NOT EXISTS idx_bis_corrections_theme ON behavioral_corrections(theme_id)",
     "CREATE INDEX IF NOT EXISTS idx_bis_corrections_created ON behavioral_corrections(created_at)",

--- a/src/genesis/ego/context.py
+++ b/src/genesis/ego/context.py
@@ -56,6 +56,7 @@ class EgoContextBuilder:
         sections.append(await self._follow_ups_section())
         sections.append(await self._cost_section())
         sections.append(await self._proposal_history_section())
+        sections.append(await self._intervention_history_section())
         sections.append(await self._user_corrections_section())
         sections.append(await self._output_contract_section())
 
@@ -368,6 +369,39 @@ class EgoContextBuilder:
             )
 
         lines.append("")
+        return "\n".join(lines)
+
+    async def _intervention_history_section(self) -> str:
+        """Recent intervention outcomes — what happened after proposals resolved."""
+        lines = ["## Intervention History (7d)\n"]
+
+        try:
+            from genesis.db.crud import intervention_journal as journal_crud
+
+            resolved = await journal_crud.recent_resolved(self._db, days=7, limit=10)
+            pending = await journal_crud.unresolved_count(self._db)
+        except Exception:
+            lines.append("*No intervention data available.*\n")
+            return "\n".join(lines)
+
+        if not resolved and not pending:
+            lines.append("*No interventions recorded yet.*\n")
+            return "\n".join(lines)
+
+        if resolved:
+            lines.append("| Action | Expected | Outcome | Status |")
+            lines.append("|--------|----------|---------|--------|")
+            for entry in resolved:
+                action = entry["action_type"]
+                expected = (entry["expected_outcome"] or "—")[:60].replace("\n", " ").replace("|", "/")
+                actual = (entry["actual_outcome"] or "—")[:60].replace("\n", " ").replace("|", "/")
+                status = entry["outcome_status"]
+                lines.append(f"| {action} | {expected} | {actual} | {status} |")
+            lines.append("")
+
+        if pending:
+            lines.append(f"*{pending} proposals pending resolution.*\n")
+
         return "\n".join(lines)
 
     async def _user_corrections_section(self) -> str:

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -291,6 +291,17 @@ class ProposalWorkflow:
                     confidence=prop.get("confidence"),
                     action_type=prop.get("action_type"),
                 )
+                # Intervention journal: record resolution
+                try:
+                    from genesis.db.crud import intervention_journal as journal_crud
+                    await journal_crud.resolve(
+                        self._db, prop["id"],
+                        outcome_status=status,
+                        actual_outcome=f"User {status}" + (f": {reason}" if reason else ""),
+                        user_response=reason,
+                    )
+                except Exception:
+                    logger.warning("Failed to update intervention journal for %s", prop["id"])
                 # Auto-store correction memory on rejection with reason
                 if (
                     status == ProposalStatus.REJECTED

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -612,6 +612,12 @@ class EgoSession:
                         status="failed",
                         user_response="dispatch failed",
                     )
+                except Exception:
+                    logger.error(
+                        "Failed to mark proposal %s as failed",
+                        proposal_id, exc_info=True,
+                    )
+                try:
                     from genesis.db.crud import intervention_journal as journal_crud
                     await journal_crud.resolve(
                         self._db, proposal_id,
@@ -619,10 +625,7 @@ class EgoSession:
                         actual_outcome="Dispatch failed",
                     )
                 except Exception:
-                    logger.error(
-                        "Failed to mark proposal %s as failed",
-                        proposal_id, exc_info=True,
-                    )
+                    logger.warning("Journal resolve failed for %s", proposal_id)
 
     async def _process_escalations(
         self,

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -309,6 +309,13 @@ class EgoSession:
                         ok = await ego_crud.table_proposal(self._db, pid)
                         if ok:
                             logger.info("Proposal %s tabled by ego", pid)
+                            try:
+                                from genesis.db.crud import intervention_journal as journal_crud
+                                await journal_crud.resolve(
+                                    self._db, pid, outcome_status="tabled",
+                                )
+                            except Exception:
+                                pass
 
             withdrawn_ids = parsed.get("withdrawn", [])
             if isinstance(withdrawn_ids, list):
@@ -317,6 +324,13 @@ class EgoSession:
                         ok = await ego_crud.withdraw_proposal(self._db, pid)
                         if ok:
                             logger.info("Proposal %s withdrawn by ego", pid)
+                            try:
+                                from genesis.db.crud import intervention_journal as journal_crud
+                                await journal_crud.resolve(
+                                    self._db, pid, outcome_status="withdrawn",
+                                )
+                            except Exception:
+                                pass
 
             # 9c. Process execution briefs (ego-as-executor)
             execution_briefs = parsed.get("execution_briefs", [])
@@ -469,6 +483,25 @@ class EgoSession:
                 batch_id, len(ids),
             )
 
+            # Record intervention journal entries (fire-and-forget)
+            try:
+                from genesis.db.crud import intervention_journal as journal_crud
+                now = datetime.now(UTC).isoformat()
+                for pid, prop in zip(ids, proposals, strict=False):
+                    await journal_crud.create(
+                        self._db,
+                        ego_source=self._source_tag,
+                        proposal_id=pid,
+                        cycle_id=cycle_id,
+                        action_type=prop.get("action_type", "unknown"),
+                        action_summary=prop.get("content", "")[:500],
+                        expected_outcome=prop.get("rationale", ""),
+                        confidence=prop.get("confidence", 0.0),
+                        created_at=now,
+                    )
+            except Exception:
+                logger.warning("Failed to create intervention journal entries", exc_info=True)
+
             # Structural validation — annotates digest, doesn't block
             validation_issues = await self._proposals.validate_batch(proposals)
             if validation_issues:
@@ -555,6 +588,15 @@ class EgoSession:
                     status="executed",
                     user_response=f"session:{session_id}",
                 )
+                try:
+                    from genesis.db.crud import intervention_journal as journal_crud
+                    await journal_crud.resolve(
+                        self._db, proposal_id,
+                        outcome_status="executed",
+                        actual_outcome=f"Dispatched as session:{session_id}",
+                    )
+                except Exception:
+                    logger.warning("Journal resolve failed for %s", proposal_id)
                 logger.info(
                     "Dispatched proposal %s → session %s",
                     proposal_id, session_id,
@@ -569,6 +611,12 @@ class EgoSession:
                         self._db, proposal_id,
                         status="failed",
                         user_response="dispatch failed",
+                    )
+                    from genesis.db.crud import intervention_journal as journal_crud
+                    await journal_crud.resolve(
+                        self._db, proposal_id,
+                        outcome_status="failed",
+                        actual_outcome="Dispatch failed",
                     )
                 except Exception:
                     logger.error(

--- a/tests/test_db/test_intervention_journal.py
+++ b/tests/test_db/test_intervention_journal.py
@@ -1,0 +1,207 @@
+"""Tests for intervention_journal CRUD operations."""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import intervention_journal as journal_crud
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """In-memory DB with intervention_journal table."""
+    db_path = str(tmp_path / "test.db")
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.execute("""
+            CREATE TABLE intervention_journal (
+                id              TEXT PRIMARY KEY,
+                ego_source      TEXT NOT NULL,
+                proposal_id     TEXT,
+                cycle_id        TEXT,
+                action_type     TEXT NOT NULL,
+                action_summary  TEXT NOT NULL,
+                expected_outcome TEXT NOT NULL DEFAULT '',
+                actual_outcome  TEXT,
+                outcome_status  TEXT NOT NULL DEFAULT 'pending',
+                user_response   TEXT,
+                confidence      REAL DEFAULT 0.0,
+                created_at      TEXT NOT NULL,
+                resolved_at     TEXT
+            )
+        """)
+        await conn.commit()
+        yield conn
+
+
+class TestCreate:
+    @pytest.mark.asyncio
+    async def test_create_returns_id(self, db):
+        jid = await journal_crud.create(
+            db,
+            ego_source="user_ego_cycle",
+            proposal_id="prop-1",
+            cycle_id="cycle-1",
+            action_type="investigate",
+            action_summary="Look into memory usage",
+            expected_outcome="Identify memory leaks",
+            confidence=0.8,
+        )
+        assert isinstance(jid, str)
+        assert len(jid) == 16
+
+    @pytest.mark.asyncio
+    async def test_create_stores_fields(self, db):
+        await journal_crud.create(
+            db,
+            ego_source="genesis_ego_cycle",
+            proposal_id="prop-2",
+            cycle_id="cycle-2",
+            action_type="outreach",
+            action_summary="Send morning report",
+            expected_outcome="User sees daily update",
+            confidence=0.9,
+        )
+        entry = await journal_crud.get_by_proposal(db, "prop-2")
+        assert entry is not None
+        assert entry["ego_source"] == "genesis_ego_cycle"
+        assert entry["action_type"] == "outreach"
+        assert entry["outcome_status"] == "pending"
+        assert entry["confidence"] == 0.9
+
+
+class TestResolve:
+    @pytest.mark.asyncio
+    async def test_resolve_updates_pending(self, db):
+        await journal_crud.create(
+            db,
+            ego_source="user_ego_cycle",
+            proposal_id="prop-3",
+            cycle_id="cycle-3",
+            action_type="investigate",
+            action_summary="Check logs",
+        )
+        ok = await journal_crud.resolve(
+            db, "prop-3",
+            outcome_status="approved",
+            actual_outcome="User approved investigation",
+            user_response="yes, go ahead",
+        )
+        assert ok is True
+
+        entry = await journal_crud.get_by_proposal(db, "prop-3")
+        assert entry["outcome_status"] == "approved"
+        assert entry["actual_outcome"] == "User approved investigation"
+        assert entry["user_response"] == "yes, go ahead"
+        assert entry["resolved_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_false_for_unknown_proposal(self, db):
+        ok = await journal_crud.resolve(
+            db, "nonexistent",
+            outcome_status="approved",
+        )
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_resolve_only_updates_pending(self, db):
+        await journal_crud.create(
+            db,
+            ego_source="user_ego_cycle",
+            proposal_id="prop-4",
+            cycle_id="cycle-4",
+            action_type="investigate",
+            action_summary="Check memory",
+        )
+        # Resolve once
+        await journal_crud.resolve(db, "prop-4", outcome_status="approved")
+        # Try to resolve again — should return False
+        ok = await journal_crud.resolve(db, "prop-4", outcome_status="rejected")
+        assert ok is False
+        # Status should still be approved
+        entry = await journal_crud.get_by_proposal(db, "prop-4")
+        assert entry["outcome_status"] == "approved"
+
+
+class TestQueries:
+    @pytest.mark.asyncio
+    async def test_recent_resolved(self, db):
+        # Create and resolve 2 entries
+        await journal_crud.create(
+            db, ego_source="user_ego_cycle", proposal_id="p1",
+            cycle_id="c1", action_type="investigate",
+            action_summary="Check A",
+        )
+        await journal_crud.create(
+            db, ego_source="user_ego_cycle", proposal_id="p2",
+            cycle_id="c2", action_type="outreach",
+            action_summary="Send B",
+        )
+        await journal_crud.resolve(db, "p1", outcome_status="approved")
+        await journal_crud.resolve(db, "p2", outcome_status="rejected")
+
+        resolved = await journal_crud.recent_resolved(db, days=7, limit=10)
+        assert len(resolved) == 2
+        # Newest first
+        assert resolved[0]["action_type"] in ("investigate", "outreach")
+
+    @pytest.mark.asyncio
+    async def test_recent_resolved_excludes_pending(self, db):
+        await journal_crud.create(
+            db, ego_source="user_ego_cycle", proposal_id="p3",
+            cycle_id="c3", action_type="investigate",
+            action_summary="Check C",
+        )
+        # Don't resolve — should not appear
+        resolved = await journal_crud.recent_resolved(db)
+        assert len(resolved) == 0
+
+    @pytest.mark.asyncio
+    async def test_unresolved_count(self, db):
+        await journal_crud.create(
+            db, ego_source="user_ego_cycle", proposal_id="p4",
+            cycle_id="c4", action_type="investigate",
+            action_summary="Check D",
+        )
+        await journal_crud.create(
+            db, ego_source="user_ego_cycle", proposal_id="p5",
+            cycle_id="c5", action_type="investigate",
+            action_summary="Check E",
+        )
+        assert await journal_crud.unresolved_count(db) == 2
+
+        await journal_crud.resolve(db, "p4", outcome_status="approved")
+        assert await journal_crud.unresolved_count(db) == 1
+
+    @pytest.mark.asyncio
+    async def test_aggregate_by_type(self, db):
+        # Create several entries of different types
+        for i, (atype, status) in enumerate([
+            ("investigate", "approved"),
+            ("investigate", "rejected"),
+            ("investigate", "executed"),
+            ("outreach", "approved"),
+            ("outreach", "approved"),
+        ]):
+            await journal_crud.create(
+                db, ego_source="user_ego_cycle",
+                proposal_id=f"agg-{i}", cycle_id=f"c-{i}",
+                action_type=atype, action_summary=f"Test {i}",
+                confidence=0.7,
+            )
+            await journal_crud.resolve(
+                db, f"agg-{i}", outcome_status=status,
+            )
+
+        aggs = await journal_crud.aggregate_by_type(db)
+        assert len(aggs) == 2
+
+        investigate = next(a for a in aggs if a["action_type"] == "investigate")
+        assert investigate["total"] == 3
+        assert investigate["approved"] == 1
+        assert investigate["rejected"] == 1
+        assert investigate["executed"] == 1
+
+        outreach = next(a for a in aggs if a["action_type"] == "outreach")
+        assert outreach["total"] == 2
+        assert outreach["approved"] == 2

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -78,7 +78,7 @@ async def test_no_unexpected_tables(db):
         "knowledge_fts_content", "knowledge_fts_docsize", "knowledge_fts_config",
         "call_site_last_run", "resolved_errors", "job_health",
         "processed_emails", "task_steps",
-        "ego_cycles", "ego_proposals", "ego_state",
+        "ego_cycles", "ego_proposals", "ego_state", "intervention_journal",
         "behavioral_corrections", "behavioral_themes", "behavioral_treatments",
         "memory_metadata",
         "code_modules", "code_symbols", "code_imports",


### PR DESCRIPTION
## Summary
- New `intervention_journal` table that records every ego proposal at creation (with rationale as expected outcome) and updates it when the proposal resolves
- CRUD module with create, resolve, get_by_proposal, recent_resolved, unresolved_count, aggregate_by_type
- Write path in `_process_proposals()` creates journal entries after batch creation (fire-and-forget)
- Resolution hooks at 6 sites: proposals.resolve_proposals (Telegram), session.py execute/table/withdraw, and both dashboard routes
- New "Intervention History (7d)" ego context section showing action/expected/outcome/status table
- Foundation for Phase 0 AGI: capability map (PR-3) will aggregate this data

## Test plan
- [x] 9 new CRUD tests: create, resolve, idempotency, recent_resolved, unresolved_count, aggregate_by_type
- [x] 32 total tests pass (schema + journal)
- [x] `ruff check` clean on all changed files
- [x] Code review: fixed `__import__` hack, separated try/except in failure path, added logging to dashboard hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)