### PR TITLE
feat(outreach): observation surfacing via morning report

### DIFF
--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -438,3 +438,72 @@ async def delete(db: aiosqlite.Connection, id: str) -> bool:
     cursor = await db.execute("DELETE FROM observations WHERE id = ?", (id,))
     await db.commit()
     return cursor.rowcount > 0
+
+
+# -- Surfacing ----------------------------------------------------------------
+
+
+async def get_unsurfaced(
+    db: aiosqlite.Connection,
+    *,
+    priority_filter: tuple[str, ...] = ("critical", "high", "medium"),
+    exclude_types: tuple[str, ...] = (),
+    limit: int = 10,
+) -> list[dict]:
+    """Return unsurfaced, unresolved observations for user delivery.
+
+    Results are ordered by priority weight (critical > high > medium)
+    then by creation time descending (newest first).
+    """
+    prio_placeholders = ",".join("?" for _ in priority_filter)
+    sql = (
+        "SELECT id, source, type, category, content, priority, created_at "
+        "FROM observations "
+        f"WHERE surfaced_at IS NULL AND resolved = 0 AND priority IN ({prio_placeholders})"
+    )
+    params: list = list(priority_filter)
+
+    if exclude_types:
+        type_placeholders = ",".join("?" for _ in exclude_types)
+        sql += f" AND type NOT IN ({type_placeholders})"
+        params.extend(exclude_types)
+
+    sql += (
+        " ORDER BY CASE priority "
+        "   WHEN 'critical' THEN 0 WHEN 'high' THEN 1 "
+        "   WHEN 'medium' THEN 2 ELSE 3 END, "
+        " created_at DESC "
+        f"LIMIT {limit}"
+    )
+    cursor = await db.execute(sql, params)
+    rows = await cursor.fetchall()
+    cols = [d[0] for d in cursor.description]
+    return [dict(zip(cols, r, strict=False)) for r in rows]
+
+
+async def mark_surfaced(
+    db: aiosqlite.Connection,
+    ids: list[str],
+    surfaced_at: str,
+) -> int:
+    """Mark observations as surfaced. Returns count updated."""
+    if not ids:
+        return 0
+    placeholders = ",".join("?" for _ in ids)
+    cursor = await db.execute(
+        f"UPDATE observations SET surfaced_at = ? WHERE id IN ({placeholders})",
+        [surfaced_at, *ids],
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
+async def unsurfaced_counts_by_priority(db: aiosqlite.Connection) -> dict[str, int]:
+    """Count unsurfaced, unresolved observations grouped by priority."""
+    cursor = await db.execute(
+        "SELECT priority, COUNT(*) FROM observations "
+        "WHERE surfaced_at IS NULL AND resolved = 0 "
+        "GROUP BY priority"
+    )
+    rows = await cursor.fetchall()
+    return {row[0]: row[1] for row in rows}

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -455,6 +455,8 @@ async def get_unsurfaced(
     Results are ordered by priority weight (critical > high > medium)
     then by creation time descending (newest first).
     """
+    if not priority_filter:
+        return []
     prio_placeholders = ",".join("?" for _ in priority_filter)
     sql = (
         "SELECT id, source, type, category, content, priority, created_at "
@@ -473,7 +475,7 @@ async def get_unsurfaced(
         "   WHEN 'critical' THEN 0 WHEN 'high' THEN 1 "
         "   WHEN 'medium' THEN 2 ELSE 3 END, "
         " created_at DESC "
-        f"LIMIT {limit}"
+        f" LIMIT {limit}"
     )
     cursor = await db.execute(sql, params)
     rows = await cursor.fetchall()

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -95,6 +95,11 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE observations ADD COLUMN content_hash TEXT",
         "observations.content_hash")
 
+    # Observation surfacing: track when observations are delivered to user
+    await _try_alter(db,
+        "ALTER TABLE observations ADD COLUMN surfaced_at TEXT",
+        "observations.surfaced_at")
+
     # Procedure activation: tier + tool trigger for layered procedure surfacing
     await _try_alter(db,
         "ALTER TABLE procedural_memory ADD COLUMN activation_tier TEXT NOT NULL DEFAULT 'L4'",

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1022,6 +1022,7 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_observations_person ON observations(person_id)",
     "CREATE INDEX IF NOT EXISTS idx_observations_content_hash ON observations(source, content_hash)",
     "CREATE INDEX IF NOT EXISTS idx_observations_type_source_created ON observations(type, source, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_observations_surfaced ON observations(surfaced_at)",
     "CREATE INDEX IF NOT EXISTS idx_outreach_person ON outreach_history(person_id)",
     "CREATE INDEX IF NOT EXISTS idx_autonomy_person ON autonomy_state(person_id)",
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_autonomy_category ON autonomy_state(category)",

--- a/src/genesis/ego/context.py
+++ b/src/genesis/ego/context.py
@@ -255,6 +255,22 @@ class EgoContextBuilder:
                 f"{short}"
             )
 
+        # Surfacing awareness: how many observations await morning report delivery
+        try:
+            from genesis.db.crud.observations import unsurfaced_counts_by_priority
+            counts = await unsurfaced_counts_by_priority(self._db)
+            if counts:
+                total = sum(counts.values())
+                breakdown = ", ".join(
+                    f"{c} {p}" for p, c in sorted(
+                        counts.items(),
+                        key=lambda x: {"critical": 0, "high": 1, "medium": 2}.get(x[0], 3),
+                    ) if c > 0
+                )
+                lines.append(f"*Unsurfaced: {total} observations ({breakdown}) awaiting morning report.*\n")
+        except Exception:
+            pass  # surfaced_at column may not exist yet
+
         lines.append("")
         return "\n".join(lines)
 

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -506,6 +506,9 @@ class MorningReportGenerator:
             content = obs["content"][:200].replace("\n", " ")
             lines.append(f"- {badge} **{prio}**: {content}")
 
+        # Mark surfaced during assembly (before delivery confirmation).
+        # Trade-off: if delivery fails, these observations won't re-surface.
+        # Acceptable for v1 — the dashboard can always show them.
         ids = [obs["id"] for obs in observations]
         now = datetime.now(UTC).isoformat()
         await mark_surfaced(self._db, ids, now)

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -173,6 +173,14 @@ class MorningReportGenerator:
             logger.warning("Morning report: critical issues check failed", exc_info=True)
             sections.append(f"## Critical Issues\nFailed to query health alerts: {exc}")
 
+        # 8. What I Noticed (unsurfaced observations worth user attention)
+        try:
+            noticed = await self._get_observation_insights()
+            if noticed:
+                sections.append(f"## What I Noticed\n{noticed}")
+        except Exception:
+            logger.warning("Morning report: observation insights unavailable", exc_info=True)
+
         return "\n\n".join(sections)
 
     async def _emit_warning(self, section: str, message: str) -> None:
@@ -464,5 +472,44 @@ class MorningReportGenerator:
         lines = [f"- {total} messages sent in last 7 days."]
         if pending:
             lines.append(f"- {pending} awaiting engagement signal.")
+
+        return "\n".join(lines)
+
+    async def _get_observation_insights(self) -> str | None:
+        """Surface unsurfaced observations that deserve user attention.
+
+        Returns None if no unsurfaced observations exist. Marks delivered
+        observations as surfaced to prevent re-delivery.
+        """
+        from datetime import UTC, datetime
+
+        from genesis.db.crud.observations import (
+            get_unsurfaced,
+            increment_retrieved_batch,
+            mark_influenced_batch,
+            mark_surfaced,
+        )
+
+        observations = await get_unsurfaced(
+            self._db,
+            priority_filter=("critical", "high", "medium"),
+            exclude_types=_INTERNAL_OBS_TYPES,
+            limit=10,
+        )
+        if not observations:
+            return None
+
+        lines = []
+        for obs in observations:
+            prio = obs["priority"]
+            badge = {"critical": "🔴", "high": "🟠", "medium": "🟡"}.get(prio, "")
+            content = obs["content"][:200].replace("\n", " ")
+            lines.append(f"- {badge} **{prio}**: {content}")
+
+        ids = [obs["id"] for obs in observations]
+        now = datetime.now(UTC).isoformat()
+        await mark_surfaced(self._db, ids, now)
+        await increment_retrieved_batch(self._db, ids)
+        await mark_influenced_batch(self._db, ids)
 
         return "\n".join(lines)

--- a/tests/test_db/test_observation_surfacing.py
+++ b/tests/test_db/test_observation_surfacing.py
@@ -1,0 +1,144 @@
+"""Tests for observation surfacing CRUD functions."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud.observations import (
+    get_unsurfaced,
+    mark_surfaced,
+    unsurfaced_counts_by_priority,
+)
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """In-memory DB with observations table including surfaced_at."""
+    db_path = str(tmp_path / "test.db")
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.execute("""
+            CREATE TABLE observations (
+                id TEXT PRIMARY KEY,
+                person_id TEXT,
+                source TEXT,
+                type TEXT,
+                category TEXT,
+                content TEXT,
+                priority TEXT,
+                speculative INTEGER DEFAULT 0,
+                retrieved_count INTEGER DEFAULT 0,
+                influenced_action INTEGER DEFAULT 0,
+                resolved INTEGER DEFAULT 0,
+                resolved_at TEXT,
+                resolution_notes TEXT,
+                created_at TEXT,
+                expires_at TEXT,
+                content_hash TEXT,
+                surfaced_at TEXT
+            )
+        """)
+        # Seed test data
+        now = datetime.now(UTC).isoformat()
+        rows = [
+            ("obs-1", "sys", "finding", None, "Critical issue found", "critical", 0, now),
+            ("obs-2", "sys", "finding", None, "High priority item", "high", 0, now),
+            ("obs-3", "sys", "finding", None, "Medium finding", "medium", 0, now),
+            ("obs-4", "sys", "finding", None, "Low finding", "low", 0, now),
+            ("obs-5", "sys", "micro_reflection", None, "Internal stuff", "medium", 0, now),
+            ("obs-6", "sys", "finding", None, "Already resolved", "high", 1, now),
+            ("obs-7", "sys", "finding", None, "Already surfaced", "high", 0, now),
+        ]
+        for oid, source, otype, cat, content, prio, resolved, created in rows:
+            await conn.execute(
+                "INSERT INTO observations (id, source, type, category, content, priority, resolved, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (oid, source, otype, cat, content, prio, resolved, created),
+            )
+        # Mark obs-7 as already surfaced
+        await conn.execute(
+            "UPDATE observations SET surfaced_at = ? WHERE id = 'obs-7'",
+            (now,),
+        )
+        await conn.commit()
+        yield conn
+
+
+class TestGetUnsurfaced:
+    @pytest.mark.asyncio
+    async def test_returns_unsurfaced_unresolved(self, db):
+        results = await get_unsurfaced(db)
+        ids = [r["id"] for r in results]
+        # Should include obs-1 (critical), obs-2 (high), obs-3 (medium)
+        assert "obs-1" in ids
+        assert "obs-2" in ids
+        assert "obs-3" in ids
+        # Should NOT include:
+        assert "obs-4" not in ids  # low priority (not in filter)
+        assert "obs-6" not in ids  # resolved
+        assert "obs-7" not in ids  # already surfaced
+
+    @pytest.mark.asyncio
+    async def test_priority_ordering(self, db):
+        results = await get_unsurfaced(db)
+        priorities = [r["priority"] for r in results]
+        # Critical should come first
+        assert priorities[0] == "critical"
+
+    @pytest.mark.asyncio
+    async def test_exclude_types(self, db):
+        results = await get_unsurfaced(
+            db, exclude_types=("micro_reflection",),
+        )
+        ids = [r["id"] for r in results]
+        assert "obs-5" not in ids
+
+    @pytest.mark.asyncio
+    async def test_limit(self, db):
+        results = await get_unsurfaced(db, limit=1)
+        assert len(results) == 1
+
+    @pytest.mark.asyncio
+    async def test_include_low_priority(self, db):
+        results = await get_unsurfaced(
+            db, priority_filter=("critical", "high", "medium", "low"),
+        )
+        ids = [r["id"] for r in results]
+        assert "obs-4" in ids
+
+
+class TestMarkSurfaced:
+    @pytest.mark.asyncio
+    async def test_marks_observations(self, db):
+        now = datetime.now(UTC).isoformat()
+        count = await mark_surfaced(db, ["obs-1", "obs-2"], now)
+        assert count == 2
+
+        # Verify they're now surfaced
+        results = await get_unsurfaced(db)
+        ids = [r["id"] for r in results]
+        assert "obs-1" not in ids
+        assert "obs-2" not in ids
+
+    @pytest.mark.asyncio
+    async def test_empty_list(self, db):
+        count = await mark_surfaced(db, [], datetime.now(UTC).isoformat())
+        assert count == 0
+
+
+class TestUnsurfacedCounts:
+    @pytest.mark.asyncio
+    async def test_counts_by_priority(self, db):
+        counts = await unsurfaced_counts_by_priority(db)
+        assert counts.get("critical") == 1
+        assert counts.get("high") == 1  # obs-2 only (obs-6 resolved, obs-7 surfaced)
+        assert counts.get("medium") == 2  # obs-3 + obs-5
+        assert counts.get("low") == 1
+
+    @pytest.mark.asyncio
+    async def test_counts_decrease_after_surfacing(self, db):
+        await mark_surfaced(db, ["obs-1"], datetime.now(UTC).isoformat())
+        counts = await unsurfaced_counts_by_priority(db)
+        assert counts.get("critical", 0) == 0


### PR DESCRIPTION
## Summary
- Add `surfaced_at` column to observations table with migration + index
- New CRUD functions: `get_unsurfaced()`, `mark_surfaced()`, `unsurfaced_counts_by_priority()`
- Morning report: new "What I Noticed" section (section 8) surfaces top 10 unsurfaced observations by priority, filtered against 37 internal observation types
- Ego context: observations section now shows unsurfaced count breakdown so the ego is aware of the delivery backlog
- Cold-start safe: `limit=10` cap drains the 1,200+ observation backlog at ~10/day, prioritized by severity

## Test plan
- [x] 9 new tests: query filters, priority ordering, type exclusion, limit cap, marking, empty lists, count breakdown
- [x] 23 schema tests pass (zero regressions)
- [x] `ruff check` clean on all changed files
- [x] Code review: fixed empty-tuple guard, spacing before LIMIT, documented mark-before-delivery trade-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)