### PR TITLE
feat(ego): add user-recency tiers to cadence max interval

### DIFF
--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -31,6 +31,17 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# User-recency tiers: (elapsed_threshold, max_interval_minutes).
+# When the user hasn't had a foreground session in a while, the ego
+# naturally winds down — through the cadence system, not self-suppression.
+_RECENCY_TIERS: list[tuple[timedelta | None, int]] = [
+    (timedelta(hours=24), 240),    # <24h:   current max (~6x/day)
+    (timedelta(days=3),   480),    # 1-3d:   ~3x/day
+    (timedelta(days=7),   1440),   # 3-7d:   ~1x/day
+    (timedelta(days=14),  2880),   # 7-14d:  every other day
+    (None,                4320),   # 14+d:   every 3 days
+]
+
 
 class EgoCadenceManager:
     """Manages when the ego runs.
@@ -201,7 +212,7 @@ class EgoCadenceManager:
                 return
 
             self._record_success()
-            self._update_interval(had_proposals=bool(proposals))
+            await self._update_interval(had_proposals=bool(proposals))
 
     async def _on_morning_report(self) -> None:
         """Cron trigger handler. Morning report cycle (skips idle check)."""
@@ -228,7 +239,7 @@ class EgoCadenceManager:
 
             self._record_success()
             # Morning report always resets interval to base
-            self._update_interval(had_proposals=True)
+            await self._update_interval(had_proposals=True)
 
     # -- Gate logic --------------------------------------------------------
 
@@ -323,29 +334,71 @@ class EgoCadenceManager:
 
     # -- Adaptive interval -------------------------------------------------
 
-    def _update_interval(self, *, had_proposals: bool) -> None:
-        """Adjust cycle interval based on productivity.
+    async def _recency_max_interval(self) -> int:
+        """Dynamic max_interval based on last foreground session.
+
+        Returns a ceiling that adapts to how recently the user was active.
+        Falls back to the static config max if no foreground data is
+        available.
+        """
+        try:
+            cursor = await self._db.execute(
+                "SELECT last_activity_at FROM cc_sessions "
+                "WHERE source_tag = 'foreground' "
+                "AND status IN ('active', 'completed', 'checkpointed') "
+                "ORDER BY last_activity_at DESC LIMIT 1",
+            )
+            row = await cursor.fetchone()
+        except Exception:
+            return self._config.max_interval_minutes
+
+        if not row or not row[0]:
+            return self._config.max_interval_minutes
+
+        try:
+            last_active = datetime.fromisoformat(row[0])
+            if last_active.tzinfo is None:
+                last_active = last_active.replace(tzinfo=UTC)
+        except (ValueError, TypeError):
+            return self._config.max_interval_minutes
+
+        elapsed = datetime.now(UTC) - last_active
+
+        for threshold, max_mins in _RECENCY_TIERS:
+            if threshold is None or elapsed < threshold:
+                return max_mins
+
+        return self._config.max_interval_minutes
+
+    async def _update_interval(self, *, had_proposals: bool) -> None:
+        """Adjust cycle interval based on productivity and user recency.
 
         - Idle cycle (no proposals): multiply by backoff_multiplier
         - Productive cycle: reset to base cadence_minutes
-        - Never exceed max_interval_minutes
+        - Max interval adapts to user recency (longer absence → higher cap)
         """
+        recency_max = await self._recency_max_interval()
+
         if had_proposals:
             new_interval = self._config.cadence_minutes
         else:
             new_interval = min(
                 int(self._current_interval * self._config.backoff_multiplier),
-                self._config.max_interval_minutes,
+                recency_max,
             )
 
         if new_interval != self._current_interval:
+            old_interval = self._current_interval
             self._current_interval = new_interval
             try:
                 self._scheduler.reschedule_job(
                     "ego_cycle",
                     trigger=IntervalTrigger(minutes=new_interval),
                 )
-                logger.info("Ego interval adjusted to %d minutes", new_interval)
+                logger.info(
+                    "Ego interval adjusted: %dm → %dm (recency_max=%dm)",
+                    old_interval, new_interval, recency_max,
+                )
             except Exception:
                 logger.warning(
                     "Failed to reschedule ego interval", exc_info=True,

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -11,7 +11,7 @@ import aiosqlite
 import pytest
 
 from genesis.db.schema import TABLES
-from genesis.ego.cadence import EgoCadenceManager
+from genesis.ego.cadence import _RECENCY_TIERS, EgoCadenceManager
 from genesis.ego.session import CycleBlockedError
 from genesis.ego.types import EgoConfig, EgoCycle
 
@@ -24,7 +24,7 @@ from genesis.ego.types import EgoConfig, EgoCycle
 async def db():
     async with aiosqlite.connect(":memory:") as conn:
         conn.row_factory = aiosqlite.Row
-        for table in ("ego_cycles", "ego_state"):
+        for table in ("ego_cycles", "ego_state", "cc_sessions"):
             await conn.execute(TABLES[table])
         yield conn
 
@@ -285,3 +285,154 @@ class TestAdaptiveInterval:
         for _ in range(10):
             await cadence._on_tick()
         assert cadence.current_interval_minutes <= config.max_interval_minutes
+
+
+# ---------------------------------------------------------------------------
+# User-recency tiers
+# ---------------------------------------------------------------------------
+
+
+async def _insert_foreground_session(
+    db: aiosqlite.Connection, *, last_activity_at: str,
+) -> None:
+    """Insert a foreground session with the given last_activity_at."""
+    await db.execute(
+        "INSERT INTO cc_sessions "
+        "(id, session_type, model, status, started_at, last_activity_at, source_tag) "
+        "VALUES (?, 'foreground', 'opus', 'completed', ?, ?, 'foreground')",
+        (f"sess_{last_activity_at}", last_activity_at, last_activity_at),
+    )
+    await db.commit()
+
+
+class TestRecencyMaxInterval:
+    """_recency_max_interval returns tier-appropriate max based on user activity."""
+
+    async def test_recent_activity_returns_base_max(self, cadence, db):
+        """Activity < 24h ago → 240 min max."""
+        recent = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+        await _insert_foreground_session(db, last_activity_at=recent)
+        result = await cadence._recency_max_interval()
+        assert result == 240
+
+    async def test_1_to_3_days_returns_480(self, cadence, db):
+        """Activity 1-3 days ago → 480 min max."""
+        ts = (datetime.now(UTC) - timedelta(days=2)).isoformat()
+        await _insert_foreground_session(db, last_activity_at=ts)
+        result = await cadence._recency_max_interval()
+        assert result == 480
+
+    async def test_3_to_7_days_returns_1440(self, cadence, db):
+        """Activity 3-7 days ago → 1440 min max."""
+        ts = (datetime.now(UTC) - timedelta(days=5)).isoformat()
+        await _insert_foreground_session(db, last_activity_at=ts)
+        result = await cadence._recency_max_interval()
+        assert result == 1440
+
+    async def test_7_to_14_days_returns_2880(self, cadence, db):
+        """Activity 7-14 days ago → 2880 min max."""
+        ts = (datetime.now(UTC) - timedelta(days=10)).isoformat()
+        await _insert_foreground_session(db, last_activity_at=ts)
+        result = await cadence._recency_max_interval()
+        assert result == 2880
+
+    async def test_14_plus_days_returns_4320(self, cadence, db):
+        """Activity > 14 days ago → 4320 min max."""
+        ts = (datetime.now(UTC) - timedelta(days=20)).isoformat()
+        await _insert_foreground_session(db, last_activity_at=ts)
+        result = await cadence._recency_max_interval()
+        assert result == 4320
+
+    async def test_no_foreground_sessions_returns_config_max(self, cadence):
+        """No foreground sessions → fallback to config max."""
+        result = await cadence._recency_max_interval()
+        assert result == cadence._config.max_interval_minutes
+
+    async def test_uses_most_recent_session(self, cadence, db):
+        """Multiple sessions → uses most recent."""
+        old = (datetime.now(UTC) - timedelta(days=10)).isoformat()
+        recent = (datetime.now(UTC) - timedelta(hours=6)).isoformat()
+        await _insert_foreground_session(db, last_activity_at=old)
+        await _insert_foreground_session(db, last_activity_at=recent)
+        result = await cadence._recency_max_interval()
+        assert result == 240  # <24h tier
+
+    async def test_ignores_background_sessions(self, cadence, db):
+        """Background sessions don't count as user presence."""
+        recent = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        await db.execute(
+            "INSERT INTO cc_sessions "
+            "(id, session_type, model, status, started_at, last_activity_at, source_tag) "
+            "VALUES ('bg1', 'background_reflection', 'sonnet', 'completed', ?, ?, 'reflection')",
+            (recent, recent),
+        )
+        await db.commit()
+        result = await cadence._recency_max_interval()
+        assert result == cadence._config.max_interval_minutes  # no foreground → fallback
+
+
+class TestRecencyAwareBackoff:
+    """_update_interval respects recency-adjusted max."""
+
+    async def test_backoff_respects_recency_tier(self, cadence, mock_session, db):
+        """When user was active 2 days ago, backoff caps at 480 (not 240)."""
+        ts = (datetime.now(UTC) - timedelta(days=2)).isoformat()
+        await _insert_foreground_session(db, last_activity_at=ts)
+
+        mock_session.run_cycle.return_value = EgoCycle(
+            output_text="quiet", proposals_json="[]", focus_summary="idle",
+        )
+        # Run enough idle cycles to hit the cap
+        for _ in range(10):
+            await cadence._on_tick()
+
+        assert cadence.current_interval_minutes <= 480
+        # Should have backed off beyond the old 240 cap
+        assert cadence.current_interval_minutes > 240
+
+    async def test_user_return_resets_to_base(self, cadence, mock_session, db):
+        """After a productive cycle, interval resets to base regardless of tier."""
+        # Start in a high tier
+        old_ts = (datetime.now(UTC) - timedelta(days=10)).isoformat()
+        await _insert_foreground_session(db, last_activity_at=old_ts)
+
+        mock_session.run_cycle.return_value = EgoCycle(
+            output_text="quiet", proposals_json="[]", focus_summary="idle",
+        )
+        for _ in range(5):
+            await cadence._on_tick()
+        assert cadence.current_interval_minutes > cadence._config.cadence_minutes
+
+        # Productive cycle → reset to base
+        mock_session.run_cycle.return_value = EgoCycle(
+            output_text="active",
+            proposals_json=json.dumps([{"action_type": "test"}]),
+            focus_summary="active",
+        )
+        await cadence._on_tick()
+        assert cadence.current_interval_minutes == cadence._config.cadence_minutes
+
+
+class TestRecencyTiersConstant:
+    """Validate the _RECENCY_TIERS constant is well-formed."""
+
+    def test_tiers_ordered(self):
+        """Thresholds must be in ascending order, with None last."""
+        for i in range(len(_RECENCY_TIERS) - 1):
+            threshold, _ = _RECENCY_TIERS[i]
+            assert threshold is not None, "Only the last tier should have None threshold"
+            if i + 1 < len(_RECENCY_TIERS) - 1:
+                next_threshold, _ = _RECENCY_TIERS[i + 1]
+                assert next_threshold is not None
+                assert threshold < next_threshold
+
+    def test_last_tier_is_catchall(self):
+        """Last tier must have None threshold (catchall)."""
+        assert _RECENCY_TIERS[-1][0] is None
+
+    def test_max_intervals_increase(self):
+        """Max intervals should increase with each tier."""
+        for i in range(len(_RECENCY_TIERS) - 1):
+            _, max_a = _RECENCY_TIERS[i]
+            _, max_b = _RECENCY_TIERS[i + 1]
+            assert max_b > max_a


### PR DESCRIPTION
## Summary

- Added 5-tier user-recency system to ego cadence: max interval adapts based on last foreground session (<24h → 240m, 1-3d → 480m, 3-7d → 1440m, 7-14d → 2880m, 14+d → 4320m)
- Converted `_update_interval()` from sync to async to support DB queries
- Queries `cc_sessions.last_activity_at` with `source_tag='foreground'` filter (indexed)

## Context

Complements PR #283 (ego holdback fix). The ego should naturally wind down when the user is absent — but through the system-controlled cadence, not through qualitative self-suppression. The adaptive backoff still operates within each tier; only the ceiling changes. User return → fresh foreground session → cadence resets to base (60 min).

## Test plan

- [x] 13 new tests: all 5 tier boundaries, no-session fallback, most-recent-wins, background-sessions-ignored, backoff integration, user-return reset, constant validation
- [x] All 343 ego tests pass (19 existing cadence + 13 new)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)