### PR TITLE
feat(infra): email outbound, star tracking, outreach metric fix

### DIFF
--- a/config/recon_watchlist.yaml
+++ b/config/recon_watchlist.yaml
@@ -14,6 +14,14 @@
 
 projects:
 
+  - name: GENesis-AGI
+    repo: WingedGuardian/GENesis-AGI
+    track: [stars]
+    priority: high
+    notes: >
+      Genesis public repo. Star count is the primary growth metric for the
+      marketing campaign. Track changes to measure outreach effectiveness.
+
   - name: Claude Code
     repo: anthropics/claude-code
     track: [releases, commits, discussions]

--- a/src/genesis/channels/email_adapter.py
+++ b/src/genesis/channels/email_adapter.py
@@ -1,0 +1,98 @@
+"""Email channel adapter — sends outreach via Gmail SMTP."""
+
+from __future__ import annotations
+
+import email.message
+import logging
+import smtplib
+from typing import Any
+
+from genesis.channels.base import ChannelAdapter
+
+logger = logging.getLogger(__name__)
+
+
+class EmailAdapter(ChannelAdapter):
+    """SMTP-based email adapter for the outreach pipeline.
+
+    Uses Gmail app passwords (same credential type as the IMAP mail monitor).
+    Each send opens a fresh SMTP_SSL connection — stateless, no persistent
+    connection to manage.
+    """
+
+    def __init__(
+        self,
+        smtp_host: str,
+        smtp_port: int,
+        username: str,
+        password: str,
+        from_address: str,
+        *,
+        from_name: str = "Genesis",
+    ) -> None:
+        self._host = smtp_host
+        self._port = smtp_port
+        self._username = username
+        self._password = password
+        self._from_address = from_address
+        self._from_name = from_name
+
+    async def start(self) -> None:
+        """No-op — SMTP is stateless per-send."""
+
+    async def stop(self) -> None:
+        """No-op — no persistent connection."""
+
+    async def send_message(
+        self,
+        channel_id: str,
+        text: str,
+        *,
+        message_thread_id: int | None = None,
+        **kwargs: Any,
+    ) -> str:
+        """Send an email. Returns the Message-ID as delivery ID.
+
+        Args:
+            channel_id: Recipient email address.
+            text: Message body (plain text).
+            message_thread_id: Ignored for email.
+            **kwargs: Optional 'subject' (str) for the email subject line.
+        """
+        subject = kwargs.get("subject", "Message from Genesis")
+        recipient = channel_id
+
+        msg = email.message.EmailMessage()
+        msg["From"] = f"{self._from_name} <{self._from_address}>"
+        msg["To"] = recipient
+        msg["Subject"] = subject
+        msg.set_content(text)
+
+        try:
+            with smtplib.SMTP_SSL(self._host, self._port, timeout=30) as smtp:
+                smtp.login(self._username, self._password)
+                smtp.send_message(msg)
+        except smtplib.SMTPException:
+            logger.exception("Failed to send email to %s", recipient)
+            raise
+
+        message_id = msg["Message-ID"] or f"email-{id(msg)}"
+        logger.info("Email sent to %s (Message-ID: %s)", recipient, message_id)
+        return message_id
+
+    async def send_typing(self, channel_id: str) -> None:
+        """No-op — email has no typing indicator."""
+
+    def get_capabilities(self) -> dict:
+        return {
+            "markdown": False,
+            "buttons": False,
+            "reactions": False,
+            "voice": False,
+            "documents": True,
+            "max_length": 50_000,
+        }
+
+    async def get_engagement_signals(self, delivery_id: str) -> dict:
+        """Email has no built-in read receipts — always returns neutral."""
+        return {"signal": "neutral", "details": {}}

--- a/src/genesis/channels/email_adapter.py
+++ b/src/genesis/channels/email_adapter.py
@@ -89,7 +89,7 @@ class EmailAdapter(ChannelAdapter):
             "buttons": False,
             "reactions": False,
             "voice": False,
-            "documents": True,
+            "documents": False,
             "max_length": 50_000,
         }
 

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -2010,7 +2010,7 @@ function updateSubsystemGrid(data) {
             const o = data.outreach_stats || {};
             if (o.total !== undefined) { enrichment.appendChild(sectionRow('Sent (7d)', String(o.total))); hasEnrichment = true; }
             if (o.delivery_rate != null) { enrichment.appendChild(sectionRow('Delivery', Math.round(o.delivery_rate * 100) + '%')); hasEnrichment = true; }
-            if (o.open_rate != null) { enrichment.appendChild(sectionRow('Open Rate', Math.round(o.open_rate * 100) + '%')); hasEnrichment = true; }
+            if (o.response_rate != null) { enrichment.appendChild(sectionRow('Response Rate', Math.round(o.response_rate * 100) + '%')); hasEnrichment = true; }
         }
         if (key === 'contingency') {
             const cc = data.cc_sessions || {};

--- a/src/genesis/observability/snapshots/outreach.py
+++ b/src/genesis/observability/snapshots/outreach.py
@@ -20,7 +20,7 @@ async def outreach_stats(db: aiosqlite.Connection | None) -> dict:
             """SELECT
                 COUNT(*) as total,
                 COUNT(delivered_at) as delivered,
-                COUNT(opened_at) as opened,
+                SUM(CASE WHEN engagement_signal = 'user_reply' THEN 1 ELSE 0 END) as responded,
                 SUM(CASE WHEN engagement_outcome IN ('useful', 'engaged') THEN 1 ELSE 0 END) as engaged
             FROM outreach_history
             WHERE created_at >= datetime('now', '-7 days')
@@ -29,14 +29,14 @@ async def outreach_stats(db: aiosqlite.Connection | None) -> dict:
         row = await cursor.fetchone()
         total = row["total"] if row else 0
         delivered = row["delivered"] if row else 0
-        opened = row["opened"] if row else 0
+        responded = row["responded"] if row else 0
         engaged = row["engaged"] if row else 0
 
         return {
             "window": "7d",
             "total": total,
             "delivery_rate": round(delivered / total, 3) if total > 0 else None,
-            "open_rate": round(opened / delivered, 3) if delivered > 0 else None,
+            "response_rate": round(responded / delivered, 3) if delivered > 0 else None,
             "engagement_rate": round(engaged / delivered, 3) if delivered > 0 else None,
         }
     except Exception:

--- a/src/genesis/recon/gatherer.py
+++ b/src/genesis/recon/gatherer.py
@@ -1,4 +1,4 @@
-"""ReconGatherer — checks watchlist projects for new GitHub releases via gh CLI."""
+"""ReconGatherer — checks watchlist projects for GitHub releases and stars via gh CLI."""
 
 from __future__ import annotations
 
@@ -38,6 +38,11 @@ class GatherResult:
 def _release_hash(repo: str, tag_name: str) -> str:
     """Deterministic content hash for a release — used for dedup."""
     return hashlib.sha256(f"{repo}:{tag_name}".encode()).hexdigest()[:16]
+
+
+def _stars_hash(repo: str, count: int) -> str:
+    """Deterministic content hash for a star count — deduplicates unchanged counts."""
+    return hashlib.sha256(f"{repo}:stars:{count}".encode()).hexdigest()[:16]
 
 
 class ReconGatherer:
@@ -97,6 +102,120 @@ class ReconGatherer:
             result.errors,
         )
         return result
+
+    async def gather_stars(self) -> GatherResult:
+        """Check star counts for watchlist projects. Store changes as findings."""
+        projects = self._load_watchlist()
+        star_projects = [
+            p for p in projects if "stars" in p.get("track", [])
+        ]
+
+        if not star_projects:
+            return GatherResult(details=["No projects track stars"])
+
+        checked = 0
+        new_total = 0
+        errors = 0
+        details: list[str] = []
+
+        for project in star_projects:
+            try:
+                stored = await self._check_stars(project)
+                checked += 1
+                if stored:
+                    new_total += 1
+                    details.append(stored)
+            except Exception:
+                errors += 1
+                details.append(f"{project['name']}: error checking stars")
+                logger.error(
+                    "Failed to check stars for %s",
+                    project.get("name", "unknown"),
+                    exc_info=True,
+                )
+
+        result = GatherResult(
+            checked=checked, new_findings=new_total,
+            errors=errors, details=details,
+        )
+        logger.info(
+            "Star gather: checked=%d, new=%d, errors=%d",
+            result.checked, result.new_findings, result.errors,
+        )
+        return result
+
+    async def _check_stars(self, project: dict) -> str | None:
+        """Check a single project's star count. Returns detail string if changed."""
+        repo = project.get("repo", "")
+        if not repo:
+            return None
+
+        raw = await self._run_gh(
+            "gh", "api", f"repos/{repo}", "--jq", ".stargazers_count",
+        )
+        if not raw:
+            return None
+
+        try:
+            count = int(raw)
+        except ValueError:
+            logger.warning("Non-integer star count for %s: %s", repo, raw)
+            return None
+
+        content_hash = _stars_hash(repo, count)
+
+        if await observations.exists_by_hash(
+            self._db, source="recon", content_hash=content_hash
+        ):
+            return None  # Count unchanged
+
+        # Get previous count for delta
+        prev_count = await self._get_previous_star_count(repo)
+        delta = count - prev_count if prev_count is not None else None
+
+        name = project.get("name", repo)
+        delta_str = f" ({'+' if delta > 0 else ''}{delta} since last check)" if delta is not None else ""
+        content = f"{name}: {count} stars{delta_str}"
+
+        now = datetime.now(UTC).isoformat()
+        await observations.create(
+            self._db,
+            id=str(uuid.uuid4()),
+            source="recon",
+            type="finding",
+            category="github_stars",
+            content=content,
+            priority=project.get("priority", "medium"),
+            created_at=now,
+            content_hash=content_hash,
+        )
+
+        detail = f"{name}: {count} stars{delta_str}"
+        logger.info("Star count recorded: %s", detail)
+        return detail
+
+    async def _get_previous_star_count(self, repo: str) -> int | None:
+        """Get the most recent star count for a repo from observations."""
+        try:
+            cursor = await self._db.execute(
+                "SELECT content FROM observations "
+                "WHERE source = 'recon' AND category = 'github_stars' "
+                "AND content LIKE ? "
+                "ORDER BY created_at DESC LIMIT 1",
+                (f"%{repo.split('/')[-1]}%",),
+            )
+            row = await cursor.fetchone()
+            if not row:
+                return None
+            # Content format: "Name: 30 stars (+5 since last check)"
+            text = row[0] if isinstance(row, tuple) else row["content"]
+            # Extract the number before " stars"
+            parts = text.split(" stars")[0].rsplit(": ", 1)
+            if len(parts) == 2:
+                return int(parts[1])
+        except (ValueError, IndexError, Exception):
+            pass
+        return None
 
     async def _check_releases(self, project: dict) -> int:
         """Check a single project for new releases. Returns count of new findings."""

--- a/src/genesis/recon/gatherer.py
+++ b/src/genesis/recon/gatherer.py
@@ -162,6 +162,7 @@ class ReconGatherer:
             logger.warning("Non-integer star count for %s: %s", repo, raw)
             return None
 
+        name = project.get("name", repo)
         content_hash = _stars_hash(repo, count)
 
         if await observations.exists_by_hash(
@@ -170,10 +171,8 @@ class ReconGatherer:
             return None  # Count unchanged
 
         # Get previous count for delta
-        prev_count = await self._get_previous_star_count(repo)
+        prev_count = await self._get_previous_star_count(name)
         delta = count - prev_count if prev_count is not None else None
-
-        name = project.get("name", repo)
         delta_str = f" ({'+' if delta > 0 else ''}{delta} since last check)" if delta is not None else ""
         content = f"{name}: {count} stars{delta_str}"
 
@@ -190,19 +189,21 @@ class ReconGatherer:
             content_hash=content_hash,
         )
 
-        detail = f"{name}: {count} stars{delta_str}"
-        logger.info("Star count recorded: %s", detail)
-        return detail
+        logger.info("Star count recorded: %s", content)
+        return content
 
-    async def _get_previous_star_count(self, repo: str) -> int | None:
-        """Get the most recent star count for a repo from observations."""
+    async def _get_previous_star_count(self, name: str) -> int | None:
+        """Get the most recent star count for a project from observations.
+
+        Content format: "Name: 30 stars (+5 since last check)"
+        """
         try:
             cursor = await self._db.execute(
                 "SELECT content FROM observations "
                 "WHERE source = 'recon' AND category = 'github_stars' "
                 "AND content LIKE ? "
                 "ORDER BY created_at DESC LIMIT 1",
-                (f"%{repo.split('/')[-1]}%",),
+                (f"{name}: %",),
             )
             row = await cursor.fetchone()
             if not row:
@@ -213,8 +214,8 @@ class ReconGatherer:
             parts = text.split(" stars")[0].rsplit(": ", 1)
             if len(parts) == 2:
                 return int(parts[1])
-        except (ValueError, IndexError, Exception):
-            pass
+        except Exception:
+            logger.debug("Could not parse previous star count for %s", name, exc_info=True)
         return None
 
     async def _check_releases(self, project: dict) -> int:

--- a/src/genesis/runtime/init/outreach.py
+++ b/src/genesis/runtime/init/outreach.py
@@ -51,6 +51,23 @@ async def init(rt: GenesisRuntime) -> None:
             if tg_users:
                 recipients["telegram"] = tg_users.split(",")[0].strip()
 
+        # Wire email adapter if Gmail credentials exist
+        gmail_addr = os.environ.get("GENESIS_GMAIL_ADDRESS")
+        gmail_pass = os.environ.get("GENESIS_GMAIL_APP_PASSWORD")
+        if gmail_addr and gmail_pass:
+            from genesis.channels.email_adapter import EmailAdapter
+
+            channels["email"] = EmailAdapter(
+                smtp_host="smtp.gmail.com",
+                smtp_port=465,
+                username=gmail_addr,
+                password=gmail_pass,
+                from_address=gmail_addr,
+            )
+            if "email" not in recipients:
+                recipients["email"] = gmail_addr
+            logger.info("Email channel adapter registered (from: %s)", gmail_addr)
+
         rt._outreach_pipeline = _Pipeline(
             governance=governance,
             drafter=drafter,

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -479,7 +479,7 @@ class SurplusScheduler:
                 pass
 
     async def run_recon_gather(self) -> None:
-        """Check watchlist projects for new GitHub releases."""
+        """Check watchlist projects for new GitHub releases and star counts."""
         if self._recon_gatherer is None:
             try:
                 from genesis.runtime import GenesisRuntime
@@ -493,6 +493,12 @@ class SurplusScheduler:
                 logger.info(
                     "Recon gather found %d new release(s): %s",
                     result.new_findings, "; ".join(result.details),
+                )
+            star_result = await self._recon_gatherer.gather_stars()
+            if star_result.new_findings > 0:
+                logger.info(
+                    "Star gather found %d change(s): %s",
+                    star_result.new_findings, "; ".join(star_result.details),
                 )
             if self._event_bus:
                 await self._event_bus.emit(

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -494,12 +494,15 @@ class SurplusScheduler:
                     "Recon gather found %d new release(s): %s",
                     result.new_findings, "; ".join(result.details),
                 )
-            star_result = await self._recon_gatherer.gather_stars()
-            if star_result.new_findings > 0:
-                logger.info(
-                    "Star gather found %d change(s): %s",
-                    star_result.new_findings, "; ".join(star_result.details),
-                )
+            try:
+                star_result = await self._recon_gatherer.gather_stars()
+                if star_result.new_findings > 0:
+                    logger.info(
+                        "Star gather found %d change(s): %s",
+                        star_result.new_findings, "; ".join(star_result.details),
+                    )
+            except Exception:
+                logger.exception("Star gather failed (releases unaffected)")
             if self._event_bus:
                 await self._event_bus.emit(
                     Subsystem.RECON, Severity.DEBUG,

--- a/tests/test_channels/test_email_adapter.py
+++ b/tests/test_channels/test_email_adapter.py
@@ -26,7 +26,7 @@ class TestEmailAdapter:
         assert caps["markdown"] is False
         assert caps["buttons"] is False
         assert caps["voice"] is False
-        assert caps["documents"] is True
+        assert caps["documents"] is False
         assert caps["max_length"] == 50_000
 
     @pytest.mark.anyio

--- a/tests/test_channels/test_email_adapter.py
+++ b/tests/test_channels/test_email_adapter.py
@@ -1,0 +1,78 @@
+"""Tests for the email channel adapter."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from genesis.channels.email_adapter import EmailAdapter
+
+
+@pytest.fixture
+def adapter() -> EmailAdapter:
+    return EmailAdapter(
+        smtp_host="smtp.gmail.com",
+        smtp_port=465,
+        username="test@gmail.com",
+        password="app-password",
+        from_address="test@gmail.com",
+    )
+
+
+class TestEmailAdapter:
+    def test_capabilities(self, adapter: EmailAdapter) -> None:
+        caps = adapter.get_capabilities()
+        assert caps["markdown"] is False
+        assert caps["buttons"] is False
+        assert caps["voice"] is False
+        assert caps["documents"] is True
+        assert caps["max_length"] == 50_000
+
+    @pytest.mark.anyio
+    async def test_send_message(self, adapter: EmailAdapter) -> None:
+        mock_smtp = MagicMock()
+        with patch("genesis.channels.email_adapter.smtplib.SMTP_SSL") as smtp_cls:
+            smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_smtp)
+            smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            delivery_id = await adapter.send_message(
+                "recipient@example.com",
+                "Hello from Genesis",
+                subject="Test Subject",
+            )
+
+            mock_smtp.login.assert_called_once_with("test@gmail.com", "app-password")
+            mock_smtp.send_message.assert_called_once()
+
+            sent_msg = mock_smtp.send_message.call_args[0][0]
+            assert sent_msg["To"] == "recipient@example.com"
+            assert sent_msg["Subject"] == "Test Subject"
+            assert "Genesis" in sent_msg["From"]
+            assert delivery_id  # non-empty string
+
+    @pytest.mark.anyio
+    async def test_send_message_default_subject(self, adapter: EmailAdapter) -> None:
+        mock_smtp = MagicMock()
+        with patch("genesis.channels.email_adapter.smtplib.SMTP_SSL") as smtp_cls:
+            smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_smtp)
+            smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            await adapter.send_message("recipient@example.com", "body")
+
+            sent_msg = mock_smtp.send_message.call_args[0][0]
+            assert sent_msg["Subject"] == "Message from Genesis"
+
+    @pytest.mark.anyio
+    async def test_engagement_signals_neutral(self, adapter: EmailAdapter) -> None:
+        result = await adapter.get_engagement_signals("any-id")
+        assert result["signal"] == "neutral"
+
+    @pytest.mark.anyio
+    async def test_start_stop_noop(self, adapter: EmailAdapter) -> None:
+        await adapter.start()
+        await adapter.stop()
+
+    @pytest.mark.anyio
+    async def test_send_typing_noop(self, adapter: EmailAdapter) -> None:
+        await adapter.send_typing("any-channel")

--- a/tests/test_recon/test_gatherer.py
+++ b/tests/test_recon/test_gatherer.py
@@ -11,7 +11,7 @@ import pytest
 
 from genesis.db import schema
 from genesis.db.crud import observations
-from genesis.recon.gatherer import GatherResult, ReconGatherer, _release_hash
+from genesis.recon.gatherer import GatherResult, ReconGatherer, _release_hash, _stars_hash
 
 # ── fixtures ────────────────────────────────────────────────────────────────
 
@@ -396,3 +396,146 @@ class TestBodyTruncation:
         assert "... (truncated)" in content
         # Content should be bounded — body was 2000 chars, truncated to ~1000
         assert len(content) < 1500
+
+
+# ── star tracking tests ──────────────────────────────────────────────────────
+
+_STAR_WATCHLIST = [
+    {
+        "name": "GENesis-AGI",
+        "repo": "WingedGuardian/GENesis-AGI",
+        "track": ["stars"],
+        "priority": "high",
+    },
+    {
+        "name": "NoStars",
+        "repo": "example/no-stars",
+        "track": ["releases"],
+        "priority": "low",
+    },
+]
+
+
+class TestStarsHash:
+    def test_deterministic(self):
+        h1 = _stars_hash("WingedGuardian/GENesis-AGI", 30)
+        h2 = _stars_hash("WingedGuardian/GENesis-AGI", 30)
+        assert h1 == h2
+
+    def test_different_for_different_counts(self):
+        h1 = _stars_hash("WingedGuardian/GENesis-AGI", 30)
+        h2 = _stars_hash("WingedGuardian/GENesis-AGI", 31)
+        assert h1 != h2
+
+    def test_length(self):
+        h = _stars_hash("WingedGuardian/GENesis-AGI", 30)
+        assert len(h) == 16
+
+
+class TestGatherStars:
+    @pytest.mark.asyncio
+    async def test_stores_star_count(self, db):
+        gatherer = ReconGatherer(db)
+
+        with (
+            patch.object(ReconGatherer, "_load_watchlist", return_value=_STAR_WATCHLIST),
+            patch.object(ReconGatherer, "_run_gh", return_value="30"),
+        ):
+            result = await gatherer.gather_stars()
+
+        assert result.checked == 1  # Only GENesis-AGI tracks stars
+        assert result.new_findings == 1
+        assert result.errors == 0
+
+        rows = await observations.query(
+            db, source="recon", type="finding", category="github_stars"
+        )
+        assert len(rows) == 1
+        assert "30 stars" in rows[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_dedup_same_count(self, db):
+        gatherer = ReconGatherer(db)
+
+        with (
+            patch.object(ReconGatherer, "_load_watchlist", return_value=_STAR_WATCHLIST),
+            patch.object(ReconGatherer, "_run_gh", return_value="30"),
+        ):
+            r1 = await gatherer.gather_stars()
+            r2 = await gatherer.gather_stars()
+
+        assert r1.new_findings == 1
+        assert r2.new_findings == 0  # Same count, deduped
+
+    @pytest.mark.asyncio
+    async def test_records_delta(self, db):
+        gatherer = ReconGatherer(db)
+
+        with (
+            patch.object(ReconGatherer, "_load_watchlist", return_value=_STAR_WATCHLIST),
+            patch.object(ReconGatherer, "_run_gh", return_value="30"),
+        ):
+            await gatherer.gather_stars()
+
+        with (
+            patch.object(ReconGatherer, "_load_watchlist", return_value=_STAR_WATCHLIST),
+            patch.object(ReconGatherer, "_run_gh", return_value="35"),
+        ):
+            result = await gatherer.gather_stars()
+
+        assert result.new_findings == 1
+        rows = await observations.query(
+            db, source="recon", type="finding", category="github_stars"
+        )
+        assert len(rows) == 2
+        latest = sorted(rows, key=lambda r: r["created_at"])[-1]
+        assert "+5" in latest["content"]
+
+    @pytest.mark.asyncio
+    async def test_filters_by_track(self, db):
+        gatherer = ReconGatherer(db)
+
+        with (
+            patch.object(ReconGatherer, "_load_watchlist", return_value=_STAR_WATCHLIST),
+            patch.object(ReconGatherer, "_run_gh", return_value="30"),
+        ):
+            result = await gatherer.gather_stars()
+
+        # NoStars project should be skipped (only tracks releases)
+        assert result.checked == 1
+
+    @pytest.mark.asyncio
+    async def test_handles_empty_response(self, db):
+        gatherer = ReconGatherer(db)
+
+        with (
+            patch.object(ReconGatherer, "_load_watchlist", return_value=_STAR_WATCHLIST),
+            patch.object(ReconGatherer, "_run_gh", return_value=""),
+        ):
+            result = await gatherer.gather_stars()
+
+        assert result.checked == 1
+        assert result.new_findings == 0
+
+    @pytest.mark.asyncio
+    async def test_handles_non_integer(self, db):
+        gatherer = ReconGatherer(db)
+
+        with (
+            patch.object(ReconGatherer, "_load_watchlist", return_value=_STAR_WATCHLIST),
+            patch.object(ReconGatherer, "_run_gh", return_value="not a number"),
+        ):
+            result = await gatherer.gather_stars()
+
+        assert result.new_findings == 0
+
+    @pytest.mark.asyncio
+    async def test_no_star_projects(self, db):
+        gatherer = ReconGatherer(db)
+        no_stars = [p for p in _STAR_WATCHLIST if "stars" not in p.get("track", [])]
+
+        with patch.object(ReconGatherer, "_load_watchlist", return_value=no_stars):
+            result = await gatherer.gather_stars()
+
+        assert result.checked == 0
+        assert "No projects track stars" in result.details


### PR DESCRIPTION
## Summary

- **Email outbound**: New `EmailAdapter` channel using Gmail SMTP (reuses existing app password credentials). Wired into runtime alongside Telegram — outreach can now send via `channel="email"`.
- **Outreach metric fix**: Replaced unmeasurable `open_rate` (Telegram has no read receipts, `opened_at` was never populated) with `response_rate` tracking actual user replies.
- **GitHub star tracking**: Added `gather_stars()` to `ReconGatherer` with delta tracking and content-hash dedup. GENesis-AGI added to watchlist. Runs alongside existing release checks.
- **Chinese platform follow-ups**: Created ego-visible follow-ups for Zhihu account creation and CSDN content translation pipeline.

## Files Changed

| File | Change |
|------|--------|
| `src/genesis/channels/email_adapter.py` | NEW — SMTP email channel adapter |
| `src/genesis/runtime/init/outreach.py` | Wire email adapter if Gmail creds exist |
| `src/genesis/observability/snapshots/outreach.py` | `open_rate` → `response_rate` |
| `src/genesis/dashboard/templates/neural_monitor.html` | Update dashboard label |
| `src/genesis/recon/gatherer.py` | Add `gather_stars()` + `_check_stars()` + delta tracking |
| `src/genesis/surplus/scheduler.py` | Wire star gathering into `run_recon_gather()` |
| `config/recon_watchlist.yaml` | Add GENesis-AGI with `track: [stars]` |
| `tests/test_channels/test_email_adapter.py` | NEW — 6 tests |
| `tests/test_recon/test_gatherer.py` | 10 new star tracking tests |

## Test plan

- [x] 37 tests pass (6 email + 31 gatherer including 10 new star tests)
- [x] `ruff check` clean on all changed files
- [ ] After merge: verify `outreach_send(channel="email")` delivers to Gmail
- [ ] After merge: verify `recon_findings(job_type="github_stars")` shows GENesis-AGI count
- [ ] After merge: verify dashboard shows "Response Rate" instead of "Open Rate"