### PR TITLE
feat(web): integrate TinyFish search, fetch, and agent APIs

### DIFF
--- a/src/genesis/mcp/health/web_tools.py
+++ b/src/genesis/mcp/health/web_tools.py
@@ -84,6 +84,7 @@ async def _try_tinyfish_fetch(url: str, max_chars: int) -> dict | None:
                 "error": None,
                 "latency_ms": round(item.get("latency_ms", 0), 1),
             }
+        logger.debug("TinyFish returned empty results for %s", url)
     except Exception as exc:
         logger.debug("TinyFish fetch failed for %s: %s", url, exc)
     return None
@@ -105,7 +106,7 @@ async def _try_tinyfish_search(query: str, max_results: int) -> dict | None:
                 "title": r.get("title", ""),
                 "url": r.get("url", ""),
                 "snippet": r.get("snippet", ""),
-                "score": 1.0 - (r.get("position", 1) - 1) * 0.1,
+                "score": max(0.0, 1.0 - (r.get("position", 1) - 1) * 0.1),
             }
             for r in raw_results
         ]
@@ -532,6 +533,23 @@ async def web_agent(
 
     if not os.environ.get("API_KEY_TINYFISH"):
         return {"error": "web_agent requires API_KEY_TINYFISH"}
+
+    # Budget check before execution — agent calls cost $0.015/step
+    try:
+        import aiosqlite
+
+        from genesis.env import genesis_db_path
+        from genesis.routing.cost_tracker import CostTracker
+
+        async with aiosqlite.connect(genesis_db_path()) as db:
+            tracker = CostTracker(db)
+            status = await tracker.check_budget()
+            if hasattr(status, "value"):
+                status = status.value
+            if status == "EXCEEDED":
+                return {"error": "Daily budget exceeded. web_agent costs ~$0.015/step."}
+    except Exception as exc:
+        logger.debug("Budget check skipped: %s", exc)
 
     start = time.monotonic()
     try:

--- a/src/genesis/mcp/health/web_tools.py
+++ b/src/genesis/mcp/health/web_tools.py
@@ -1,7 +1,7 @@
 """Web intelligence MCP tools — external world discoverability.
 
-Exposes Genesis's web infrastructure (Scrapling, Crawl4AI, SearXNG, Brave,
-Tavily, Exa, Perplexity) as MCP tools accessible from all session types.
+Exposes Genesis's web infrastructure (TinyFish, Scrapling, Crawl4AI, SearXNG,
+Brave, Tavily, Exa, Perplexity) as MCP tools accessible from all session types.
 
 Smart fallback chains — callers say what they want, the tool figures out how.
 Parallel to code intelligence tools (CBM, Serena, GitNexus) for internal
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import time
+from datetime import UTC
 
 from genesis.mcp.health import mcp
 
@@ -56,6 +57,69 @@ def _is_challenge_response(text: str, status_code: int) -> bool:
         challenge_markers = ("captcha", "cloudflare", "challenge", "verify you are human")
         return any(m in lower for m in challenge_markers)
     return False
+
+
+async def _try_tinyfish_fetch(url: str, max_chars: int) -> dict | None:
+    """Attempt TinyFish fetch. Returns result dict or None on failure."""
+    import os
+
+    if not os.environ.get("API_KEY_TINYFISH"):
+        return None
+    try:
+        from genesis.providers import tinyfish_client
+
+        response = await tinyfish_client.fetch([url])
+        results = response.get("results", [])
+        if results:
+            item = results[0]
+            text = item.get("text", "")
+            content = text[:max_chars]
+            return {
+                "url": item.get("url", url),
+                "title": item.get("title", ""),
+                "content": content,
+                "backend_used": "tinyfish",
+                "status_code": 200,
+                "truncated": len(text) > max_chars,
+                "error": None,
+                "latency_ms": round(item.get("latency_ms", 0), 1),
+            }
+    except Exception as exc:
+        logger.debug("TinyFish fetch failed for %s: %s", url, exc)
+    return None
+
+
+async def _try_tinyfish_search(query: str, max_results: int) -> dict | None:
+    """Attempt TinyFish search. Returns result dict or None on failure."""
+    import os
+
+    if not os.environ.get("API_KEY_TINYFISH"):
+        return None
+    try:
+        from genesis.providers import tinyfish_client
+
+        response = await tinyfish_client.search(query)
+        raw_results = response.get("results", [])[:max_results]
+        results = [
+            {
+                "title": r.get("title", ""),
+                "url": r.get("url", ""),
+                "snippet": r.get("snippet", ""),
+                "score": 1.0 - (r.get("position", 1) - 1) * 0.1,
+            }
+            for r in raw_results
+        ]
+        return {
+            "query": query,
+            "results": results,
+            "backend_used": "tinyfish",
+            "fallback_used": False,
+            "answer": None,
+            "error": None,
+        }
+    except Exception as exc:
+        logger.debug("TinyFish search failed: %s", exc)
+    return None
 
 
 async def _try_crawl4ai(url: str, max_chars: int) -> dict | None:
@@ -104,7 +168,12 @@ async def _impl_web_fetch(
     fetcher = _get_fetcher()
 
     if backend == "auto":
-        # Primary: Scrapling/httpx via WebFetcher
+        # Primary: TinyFish (free, server-side anti-bot, JS rendering)
+        tf_result = await _try_tinyfish_fetch(url, max_chars)
+        if tf_result:
+            return tf_result
+
+        # Fallback: Scrapling/httpx via WebFetcher
         result = await fetcher.fetch(url, max_chars=max_chars)
         latency = (time.monotonic() - start) * 1000
 
@@ -126,6 +195,12 @@ async def _impl_web_fetch(
             "error": result.error,
             "latency_ms": round(latency, 1),
         }
+
+    elif backend == "tinyfish":
+        tf_result = await _try_tinyfish_fetch(url, max_chars)
+        if tf_result:
+            return tf_result
+        return {"url": url, "error": "TinyFish fetch failed or unavailable", "backend_used": "tinyfish"}
 
     elif backend == "crawl4ai":
         crawl_result = await _try_crawl4ai(url, max_chars)
@@ -149,7 +224,49 @@ async def _impl_web_fetch(
         }
 
     else:
-        return {"error": f"Unknown backend '{backend}'. Use: auto, scrapling, crawl4ai, httpx"}
+        return {"error": f"Unknown backend '{backend}'. Use: auto, tinyfish, scrapling, crawl4ai, httpx"}
+
+
+async def _impl_web_fetch_multi(
+    urls: list[str],
+    max_chars: int = 50000,
+) -> dict:
+    """Fetch multiple URLs in parallel via TinyFish."""
+    import os
+
+    if not os.environ.get("API_KEY_TINYFISH"):
+        return {"error": "Multi-URL fetch requires API_KEY_TINYFISH"}
+
+    clean_urls = []
+    for u in urls[:10]:
+        u = u.strip()
+        if not u.startswith(("http://", "https://")):
+            u = "https://" + u
+        clean_urls.append(u)
+
+    start = time.monotonic()
+    try:
+        from genesis.providers import tinyfish_client
+
+        response = await tinyfish_client.fetch(clean_urls)
+        for item in response.get("results", []):
+            text = item.get("text", "")
+            if len(text) > max_chars:
+                item["text"] = text[:max_chars]
+                item["truncated"] = True
+            else:
+                item["truncated"] = False
+
+        latency = round((time.monotonic() - start) * 1000, 1)
+        return {
+            "results": response.get("results", []),
+            "errors": response.get("errors", []),
+            "backend_used": "tinyfish",
+            "latency_ms": latency,
+        }
+    except Exception as exc:
+        latency = round((time.monotonic() - start) * 1000, 1)
+        return {"error": f"TinyFish multi-fetch failed: {exc}", "backend_used": "tinyfish", "latency_ms": latency}
 
 
 async def _impl_web_search(
@@ -165,8 +282,35 @@ async def _impl_web_search(
     max_results = min(max(1, max_results), 20)
     start = time.monotonic()
 
-    if backend in ("auto", "searxng", "brave"):
-        # Use WebSearcher (SearXNG primary, Brave fallback)
+    if backend == "auto":
+        # Primary: TinyFish (free, faster, better quality)
+        tf_result = await _try_tinyfish_search(query, max_results)
+        if tf_result:
+            latency = (time.monotonic() - start) * 1000
+            tf_result["latency_ms"] = round(latency, 1)
+            return tf_result
+
+        # Fallback: SearXNG → Brave
+        searcher = _get_searcher()
+        response = await searcher.search(query, max_results=max_results)
+        latency = (time.monotonic() - start) * 1000
+
+        results = [
+            {"title": r.title, "url": r.url, "snippet": r.snippet, "score": r.score}
+            for r in response.results
+        ]
+        return {
+            "query": response.query,
+            "results": results,
+            "backend_used": response.backend_used.value if response.backend_used else "unknown",
+            "fallback_used": True,
+            "answer": None,
+            "error": response.error,
+            "latency_ms": round(latency, 1),
+        }
+
+    elif backend in ("searxng", "brave"):
+        # Explicit SearXNG/Brave selection
         searcher = _get_searcher()
         response = await searcher.search(query, max_results=max_results)
         latency = (time.monotonic() - start) * 1000
@@ -184,6 +328,14 @@ async def _impl_web_search(
             "error": response.error,
             "latency_ms": round(latency, 1),
         }
+
+    elif backend == "tinyfish":
+        tf_result = await _try_tinyfish_search(query, max_results)
+        if tf_result:
+            latency = (time.monotonic() - start) * 1000
+            tf_result["latency_ms"] = round(latency, 1)
+            return tf_result
+        return {"query": query, "error": "TinyFish search failed or unavailable", "backend_used": "tinyfish"}
 
     elif backend == "tavily":
         try:
@@ -272,39 +424,42 @@ async def _impl_web_search(
             return {"query": query, "error": f"Perplexity unavailable: {exc}", "backend_used": "perplexity"}
 
     else:
-        return {"error": f"Unknown backend '{backend}'. Use: auto, searxng, brave, tavily, exa, perplexity"}
+        return {"error": f"Unknown backend '{backend}'. Use: auto, tinyfish, searxng, brave, tavily, exa, perplexity"}
 
 
 @mcp.tool()
 async def web_fetch(
-    url: str,
+    url: str = "",
+    urls: list[str] | None = None,
     backend: str = "auto",
     max_chars: int = 50000,
 ) -> dict:
-    """Fetch a URL and return clean text content.
+    """Fetch URL(s) and return clean text content.
 
-    Smart fallback chain: Scrapling (TLS impersonation, fast) → Crawl4AI
-    (JS rendering, handles SPAs) → httpx (plain, last resort). The tool
-    decides the best backend unless overridden.
+    Smart fallback chain: TinyFish (anti-bot, JS rendering) → Scrapling
+    (TLS impersonation) → Crawl4AI (local Playwright) → httpx (plain).
 
     Args:
-        url: The URL to fetch.
-        backend: "auto" (smart fallback), "scrapling" (fast, anti-bot TLS),
-                 "crawl4ai" (JS-rendered markdown), or "httpx" (plain HTTP).
-        max_chars: Maximum characters to return (default 50000 ≈ 12k tokens).
+        url: Single URL to fetch.
+        urls: Multiple URLs (1-10) for parallel fetch via TinyFish.
+        backend: "auto" (smart fallback), "tinyfish" (cloud anti-bot),
+                 "scrapling" (fast, TLS), "crawl4ai" (JS-rendered), "httpx".
+        max_chars: Maximum characters per URL (default 50000 ≈ 12k tokens).
 
     Returns dict with: url, title, content, backend_used, status_code,
-    truncated, error, latency_ms.
+    truncated, error, latency_ms. For multi-URL: results[] array.
 
     Use this instead of CC WebFetch for:
-    - Anti-bot protected sites (Scrapling's TLS fingerprinting)
-    - JS-heavy SPAs (Crawl4AI's Playwright rendering)
+    - Anti-bot protected sites (TinyFish's server-side bypass)
+    - JS-heavy SPAs (TinyFish or Crawl4AI rendering)
+    - Parallel multi-URL fetching (urls parameter)
     - Background sessions (no Bash available)
-    - Consistent structured output (no AI summarization)
 
     Use CC WebFetch when you specifically need AI-processed summaries.
     Use browser_navigate when you need to interact with the page.
     """
+    if urls:
+        return await _impl_web_fetch_multi(urls, max_chars)
     return await _impl_web_fetch(url, backend, max_chars)
 
 
@@ -316,22 +471,21 @@ async def web_search(
 ) -> dict:
     """Search the web and return structured results.
 
-    Smart fallback chain: SearXNG (self-hosted, unlimited) → Brave (API).
+    Smart fallback chain: TinyFish (fast, free) → SearXNG (self-hosted) → Brave.
     Paid backends (tavily, exa, perplexity) available via explicit backend param.
 
     Args:
         query: Search query string. Supports site: filters with SearXNG.
-        backend: "auto" (SearXNG→Brave), "searxng", "brave", "tavily"
-                 (AI-optimized), "exa" (semantic), or "perplexity" (synthesized).
+        backend: "auto" (TinyFish→SearXNG→Brave), "tinyfish", "searxng",
+                 "brave", "tavily", "exa", or "perplexity".
         max_results: Maximum results (default 10, max 20).
 
     Returns dict with: query, results (list of title/url/snippet/score),
     backend_used, fallback_used, answer (for tavily/perplexity), error, latency_ms.
 
     Use this instead of CC WebSearch for:
-    - site: filters and structured JSON (SearXNG)
+    - Structured JSON results
     - Background sessions (no Bash available)
-    - Bulk queries (SearXNG is unlimited, self-hosted)
     - Agent pipelines needing structured data
 
     Use CC WebSearch for quick general lookups in foreground sessions.
@@ -339,3 +493,100 @@ async def web_search(
     Use "exa" backend for conceptual/semantic discovery.
     """
     return await _impl_web_search(query, backend, max_results)
+
+
+@mcp.tool()
+async def web_agent(
+    url: str,
+    goal: str,
+    output_schema: dict | None = None,
+    browser_profile: str = "stealth",
+    max_steps: int = 100,
+) -> dict:
+    """Run a goal-based browser automation and return structured results.
+
+    Uses TinyFish's AI agent to achieve a natural language goal on a web page.
+    The agent navigates, clicks, fills forms, and extracts data autonomously.
+
+    PAID: ~$0.015 per step. Budget-checked before execution.
+
+    Args:
+        url: Target URL to automate.
+        goal: Natural language description of what to achieve. Include the
+              desired JSON structure for extraction tasks.
+        output_schema: Optional JSON Schema for structured output validation.
+        browser_profile: "stealth" (anti-bot) or "lite" (fast).
+        max_steps: Maximum agent steps, 1-500 (default 100).
+
+    Returns dict with: run_id, status, result, num_of_steps, cost_usd,
+    latency_ms, error.
+
+    Use this when:
+    - Local Camoufox can't pass anti-bot detection
+    - You need structured data extraction from complex pages
+    - Step-by-step browser_navigate would be too many tool calls
+
+    Don't use for simple page reads — use web_fetch instead.
+    """
+    import os
+
+    if not os.environ.get("API_KEY_TINYFISH"):
+        return {"error": "web_agent requires API_KEY_TINYFISH"}
+
+    start = time.monotonic()
+    try:
+        from genesis.providers.tinyfish_agent import COST_PER_STEP_USD, TinyFishAgentAdapter
+
+        adapter = TinyFishAgentAdapter()
+        result = await adapter.invoke({
+            "url": url,
+            "goal": goal,
+            "output_schema": output_schema,
+            "browser_profile": browser_profile,
+            "max_steps": max_steps,
+        })
+        latency = round((time.monotonic() - start) * 1000, 1)
+
+        if result.success:
+            data = result.data or {}
+            # Record cost
+            try:
+                import uuid
+                from datetime import datetime
+
+                import aiosqlite
+
+                from genesis.db.crud import cost_events
+                from genesis.env import genesis_db_path
+
+                num_steps = data.get("num_of_steps", 0)
+                cost_usd = round(num_steps * COST_PER_STEP_USD, 4)
+                async with aiosqlite.connect(genesis_db_path()) as db:
+                    await cost_events.create(
+                        db,
+                        id=str(uuid.uuid4()),
+                        event_type="tinyfish_agent",
+                        provider="tinyfish",
+                        cost_usd=cost_usd,
+                        cost_known=True,
+                        metadata={"run_id": data.get("run_id"), "goal": goal, "url": url, "steps": num_steps},
+                        created_at=datetime.now(UTC).isoformat(),
+                    )
+            except Exception as exc:
+                logger.warning("Failed to record TinyFish agent cost: %s", exc)
+
+            return {
+                "run_id": data.get("run_id"),
+                "status": data.get("status"),
+                "result": data.get("result"),
+                "num_of_steps": data.get("num_of_steps", 0),
+                "cost_usd": data.get("cost_usd", 0),
+                "error": data.get("error"),
+                "latency_ms": latency,
+            }
+        else:
+            return {"error": result.error or "TinyFish agent failed", "latency_ms": latency}
+
+    except Exception as exc:
+        latency = round((time.monotonic() - start) * 1000, 1)
+        return {"error": f"web_agent failed: {exc}", "latency_ms": latency}

--- a/src/genesis/providers/tinyfish_agent.py
+++ b/src/genesis/providers/tinyfish_agent.py
@@ -1,0 +1,105 @@
+"""ToolProvider adapter for TinyFish Agent — NL browser automation.
+
+Runs a goal-based browser automation and returns structured results.
+Paid: $0.015 per agent step. 500 one-time free credits on signup.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from genesis.providers.types import (
+    CostTier,
+    ProviderCapability,
+    ProviderCategory,
+    ProviderResult,
+    ProviderStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+COST_PER_STEP_USD = 0.015
+
+
+class TinyFishAgentAdapter:
+    """TinyFish Agent — NL goal-based web automation with structured output."""
+
+    name = "tinyfish_agent"
+    capability = ProviderCapability(
+        content_types=("web_page", "structured_data"),
+        categories=(ProviderCategory.WEB, ProviderCategory.EXTRACTION),
+        cost_tier=CostTier.MODERATE,
+        description="TinyFish — NL browser automation, $0.015/step",
+    )
+
+    async def check_health(self) -> ProviderStatus:
+        try:
+            from genesis.providers.tinyfish_client import _get_key
+
+            _get_key()
+            return ProviderStatus.AVAILABLE
+        except ValueError:
+            return ProviderStatus.UNAVAILABLE
+
+    async def invoke(self, request: dict) -> ProviderResult:
+        """Run agent automation via TinyFish.
+
+        Request keys:
+            url (str): Target URL (required).
+            goal (str): NL goal description (required).
+            output_schema (dict): JSON Schema for structured output (optional).
+            browser_profile (str): "stealth" or "lite" (default "stealth").
+            max_steps (int): Max steps, 1-500 (default 100).
+        """
+        start = time.monotonic()
+
+        url = request.get("url", "")
+        goal = request.get("goal", "")
+        if not url or not goal:
+            return ProviderResult(
+                success=False,
+                error="'url' and 'goal' are required",
+                latency_ms=round((time.monotonic() - start) * 1000, 2),
+                provider_name=self.name,
+            )
+
+        try:
+            from genesis.providers import tinyfish_client
+
+            response = await tinyfish_client.agent_run(
+                url=url,
+                goal=goal,
+                output_schema=request.get("output_schema"),
+                browser_profile=request.get("browser_profile", "stealth"),
+                max_steps=request.get("max_steps", 100),
+            )
+
+            num_steps = response.get("num_of_steps", 0)
+            cost_usd = round(num_steps * COST_PER_STEP_USD, 4)
+            response["cost_usd"] = cost_usd
+
+            latency = round((time.monotonic() - start) * 1000, 2)
+            return ProviderResult(
+                success=response.get("status") == "COMPLETED",
+                data=response,
+                latency_ms=latency,
+                provider_name=self.name,
+            )
+        except ValueError as exc:
+            latency = round((time.monotonic() - start) * 1000, 2)
+            return ProviderResult(
+                success=False,
+                error=str(exc),
+                latency_ms=latency,
+                provider_name=self.name,
+            )
+        except Exception as exc:
+            latency = round((time.monotonic() - start) * 1000, 2)
+            logger.error("TinyFish agent failed", exc_info=True)
+            return ProviderResult(
+                success=False,
+                error=str(exc),
+                latency_ms=latency,
+                provider_name=self.name,
+            )

--- a/src/genesis/providers/tinyfish_client.py
+++ b/src/genesis/providers/tinyfish_client.py
@@ -1,7 +1,7 @@
 """Async HTTP client for TinyFish APIs (search, fetch, agent, browser).
 
-Shared by all TinyFish adapters. Uses httpx with connection pooling.
-Auth: X-API-Key header. No CLI subprocess overhead.
+Shared by all TinyFish adapters. Lazy singleton httpx clients for
+connection pooling. Auth: X-API-Key header. No CLI subprocess overhead.
 
 API endpoints:
   Search: GET  https://api.search.tinyfish.ai/?query=...
@@ -24,6 +24,11 @@ _FETCH_URL = "https://api.fetch.tinyfish.ai/"
 _AGENT_URL = "https://agent.tinyfish.ai/v1/automation/run"
 _BROWSER_URL = "https://api.browser.tinyfish.ai/"
 
+# Lazy singleton clients — reused across calls for connection pooling
+_search_client: httpx.AsyncClient | None = None
+_fetch_client: httpx.AsyncClient | None = None
+_agent_client: httpx.AsyncClient | None = None
+
 
 def _get_key() -> str:
     key = os.environ.get("API_KEY_TINYFISH", "")
@@ -39,6 +44,27 @@ def _headers() -> dict[str, str]:
     }
 
 
+def _get_search_client() -> httpx.AsyncClient:
+    global _search_client
+    if _search_client is None:
+        _search_client = httpx.AsyncClient(timeout=10.0)
+    return _search_client
+
+
+def _get_fetch_client() -> httpx.AsyncClient:
+    global _fetch_client
+    if _fetch_client is None:
+        _fetch_client = httpx.AsyncClient(timeout=30.0)
+    return _fetch_client
+
+
+def _get_agent_client() -> httpx.AsyncClient:
+    global _agent_client
+    if _agent_client is None:
+        _agent_client = httpx.AsyncClient(timeout=600.0)
+    return _agent_client
+
+
 async def search(
     query: str,
     *,
@@ -52,10 +78,10 @@ async def search(
     if language:
         params["language"] = language
 
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        resp = await client.get(_SEARCH_URL, params=params, headers=_headers())
-        resp.raise_for_status()
-        return resp.json()
+    client = _get_search_client()
+    resp = await client.get(_SEARCH_URL, params=params, headers=_headers())
+    resp.raise_for_status()
+    return resp.json()
 
 
 async def fetch(
@@ -72,10 +98,10 @@ async def fetch(
     if image_links:
         body["image_links"] = True
 
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(_FETCH_URL, json=body, headers=_headers())
-        resp.raise_for_status()
-        return resp.json()
+    client = _get_fetch_client()
+    resp = await client.post(_FETCH_URL, json=body, headers=_headers())
+    resp.raise_for_status()
+    return resp.json()
 
 
 async def agent_run(
@@ -96,8 +122,7 @@ async def agent_run(
     if output_schema:
         body["output_schema"] = output_schema
 
-    # Agent calls can be slow (30s-5min)
-    async with httpx.AsyncClient(timeout=600.0) as client:
-        resp = await client.post(_AGENT_URL, json=body, headers=_headers())
-        resp.raise_for_status()
-        return resp.json()
+    client = _get_agent_client()
+    resp = await client.post(_AGENT_URL, json=body, headers=_headers())
+    resp.raise_for_status()
+    return resp.json()

--- a/src/genesis/providers/tinyfish_client.py
+++ b/src/genesis/providers/tinyfish_client.py
@@ -1,0 +1,103 @@
+"""Async HTTP client for TinyFish APIs (search, fetch, agent, browser).
+
+Shared by all TinyFish adapters. Uses httpx with connection pooling.
+Auth: X-API-Key header. No CLI subprocess overhead.
+
+API endpoints:
+  Search: GET  https://api.search.tinyfish.ai/?query=...
+  Fetch:  POST https://api.fetch.tinyfish.ai/  {urls, format}
+  Agent:  POST https://agent.tinyfish.ai/v1/automation/run  {url, goal}
+  Browser: POST https://api.browser.tinyfish.ai/  {url}
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_SEARCH_URL = "https://api.search.tinyfish.ai/"
+_FETCH_URL = "https://api.fetch.tinyfish.ai/"
+_AGENT_URL = "https://agent.tinyfish.ai/v1/automation/run"
+_BROWSER_URL = "https://api.browser.tinyfish.ai/"
+
+
+def _get_key() -> str:
+    key = os.environ.get("API_KEY_TINYFISH", "")
+    if not key:
+        raise ValueError("API_KEY_TINYFISH required")
+    return key
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "X-API-Key": _get_key(),
+        "Content-Type": "application/json",
+    }
+
+
+async def search(
+    query: str,
+    *,
+    location: str | None = None,
+    language: str | None = None,
+) -> dict:
+    """Web search. Free, no credits consumed."""
+    params: dict[str, str] = {"query": query}
+    if location:
+        params["location"] = location
+    if language:
+        params["language"] = language
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.get(_SEARCH_URL, params=params, headers=_headers())
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def fetch(
+    urls: list[str],
+    *,
+    fmt: str = "markdown",
+    links: bool = False,
+    image_links: bool = False,
+) -> dict:
+    """Fetch content from 1-10 URLs in parallel. Free, no credits consumed."""
+    body: dict = {"urls": urls, "format": fmt}
+    if links:
+        body["links"] = True
+    if image_links:
+        body["image_links"] = True
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(_FETCH_URL, json=body, headers=_headers())
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def agent_run(
+    url: str,
+    goal: str,
+    *,
+    output_schema: dict | None = None,
+    browser_profile: str = "stealth",
+    max_steps: int = 100,
+) -> dict:
+    """Run NL browser automation. Paid: $0.015 per step."""
+    body: dict = {
+        "url": url,
+        "goal": goal,
+        "browser_profile": browser_profile,
+        "agent_config": {"max_steps": min(max(1, max_steps), 500)},
+    }
+    if output_schema:
+        body["output_schema"] = output_schema
+
+    # Agent calls can be slow (30s-5min)
+    async with httpx.AsyncClient(timeout=600.0) as client:
+        resp = await client.post(_AGENT_URL, json=body, headers=_headers())
+        resp.raise_for_status()
+        return resp.json()

--- a/src/genesis/providers/tinyfish_fetch.py
+++ b/src/genesis/providers/tinyfish_fetch.py
@@ -1,0 +1,110 @@
+"""ToolProvider adapter for TinyFish Fetch — free content extraction.
+
+Fetches 1-10 URLs in parallel, returns clean markdown with metadata.
+Server-side anti-bot and JS rendering. Free and unlimited.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from genesis.providers.types import (
+    CostTier,
+    ProviderCapability,
+    ProviderCategory,
+    ProviderResult,
+    ProviderStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TinyFishFetchAdapter:
+    """TinyFish Fetch — parallel multi-URL content extraction."""
+
+    name = "tinyfish_fetch"
+    capability = ProviderCapability(
+        content_types=("web_page", "markdown"),
+        categories=(ProviderCategory.WEB,),
+        cost_tier=CostTier.FREE,
+        description="TinyFish — free parallel URL fetch with anti-bot bypass",
+    )
+
+    async def check_health(self) -> ProviderStatus:
+        try:
+            from genesis.providers.tinyfish_client import _get_key
+
+            _get_key()
+            return ProviderStatus.AVAILABLE
+        except ValueError:
+            return ProviderStatus.UNAVAILABLE
+
+    async def invoke(self, request: dict) -> ProviderResult:
+        """Fetch via TinyFish.
+
+        Request keys:
+            url (str): Single URL to fetch.
+            urls (list[str]): Multiple URLs (1-10) for parallel fetch.
+            format (str): "markdown" (default), "html", or "json".
+            max_chars (int): Truncate per-URL content (default 50000).
+        """
+        start = time.monotonic()
+
+        url = request.get("url", "")
+        urls = request.get("urls", [])
+        if not url and not urls:
+            return ProviderResult(
+                success=False,
+                error="'url' or 'urls' is required in request",
+                latency_ms=round((time.monotonic() - start) * 1000, 2),
+                provider_name=self.name,
+            )
+
+        fetch_urls = urls if urls else [url]
+        if len(fetch_urls) > 10:
+            fetch_urls = fetch_urls[:10]
+
+        max_chars = request.get("max_chars", 50000)
+
+        try:
+            from genesis.providers import tinyfish_client
+
+            response = await tinyfish_client.fetch(
+                fetch_urls,
+                fmt=request.get("format", "markdown"),
+            )
+
+            # Truncate per-URL content
+            for item in response.get("results", []):
+                text = item.get("text", "")
+                if len(text) > max_chars:
+                    item["text"] = text[:max_chars]
+                    item["truncated"] = True
+                else:
+                    item["truncated"] = False
+
+            latency = round((time.monotonic() - start) * 1000, 2)
+            return ProviderResult(
+                success=True,
+                data=response,
+                latency_ms=latency,
+                provider_name=self.name,
+            )
+        except ValueError as exc:
+            latency = round((time.monotonic() - start) * 1000, 2)
+            return ProviderResult(
+                success=False,
+                error=str(exc),
+                latency_ms=latency,
+                provider_name=self.name,
+            )
+        except Exception as exc:
+            latency = round((time.monotonic() - start) * 1000, 2)
+            logger.error("TinyFish fetch failed", exc_info=True)
+            return ProviderResult(
+                success=False,
+                error=str(exc),
+                latency_ms=latency,
+                provider_name=self.name,
+            )

--- a/src/genesis/providers/tinyfish_search.py
+++ b/src/genesis/providers/tinyfish_search.py
@@ -1,0 +1,95 @@
+"""ToolProvider adapter for TinyFish Search — free web search.
+
+Returns structured results with titles, snippets, and URLs.
+Free and unlimited on all plans.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from genesis.providers.types import (
+    CostTier,
+    ProviderCapability,
+    ProviderCategory,
+    ProviderResult,
+    ProviderStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TinyFishSearchAdapter:
+    """TinyFish Search — fast web search with structured results."""
+
+    name = "tinyfish_search"
+    capability = ProviderCapability(
+        content_types=("search_results",),
+        categories=(ProviderCategory.SEARCH,),
+        cost_tier=CostTier.FREE,
+        description="TinyFish — free web search, 2x faster than SearXNG",
+    )
+
+    async def check_health(self) -> ProviderStatus:
+        try:
+            from genesis.providers.tinyfish_client import _get_key
+
+            _get_key()
+            return ProviderStatus.AVAILABLE
+        except ValueError:
+            return ProviderStatus.UNAVAILABLE
+
+    async def invoke(self, request: dict) -> ProviderResult:
+        """Search via TinyFish.
+
+        Request keys:
+            query (str): Search query (required).
+            max_results (int): Ignored (TinyFish returns 10 results).
+            location (str): Country code hint (optional).
+            language (str): Language code hint (optional).
+        """
+        start = time.monotonic()
+
+        query = request.get("query", "")
+        if not query:
+            return ProviderResult(
+                success=False,
+                error="'query' is required in request",
+                latency_ms=round((time.monotonic() - start) * 1000, 2),
+                provider_name=self.name,
+            )
+
+        try:
+            from genesis.providers import tinyfish_client
+
+            response = await tinyfish_client.search(
+                query,
+                location=request.get("location"),
+                language=request.get("language"),
+            )
+
+            latency = round((time.monotonic() - start) * 1000, 2)
+            return ProviderResult(
+                success=True,
+                data=response,
+                latency_ms=latency,
+                provider_name=self.name,
+            )
+        except ValueError as exc:
+            latency = round((time.monotonic() - start) * 1000, 2)
+            return ProviderResult(
+                success=False,
+                error=str(exc),
+                latency_ms=latency,
+                provider_name=self.name,
+            )
+        except Exception as exc:
+            latency = round((time.monotonic() - start) * 1000, 2)
+            logger.error("TinyFish search failed", exc_info=True)
+            return ProviderResult(
+                success=False,
+                error=str(exc),
+                latency_ms=latency,
+                provider_name=self.name,
+            )

--- a/src/genesis/runtime/init/providers.py
+++ b/src/genesis/runtime/init/providers.py
@@ -77,6 +77,15 @@ def init(rt: GenesisRuntime) -> None:
         except ImportError:
             pass  # crawl4ai not installed — skip silently
 
+        if os.environ.get("API_KEY_TINYFISH"):
+            from genesis.providers.tinyfish_agent import TinyFishAgentAdapter
+            from genesis.providers.tinyfish_fetch import TinyFishFetchAdapter
+            from genesis.providers.tinyfish_search import TinyFishSearchAdapter
+
+            rt._provider_registry.register(TinyFishSearchAdapter())
+            rt._provider_registry.register(TinyFishFetchAdapter())
+            rt._provider_registry.register(TinyFishAgentAdapter())
+
         if os.environ.get("API_KEY_PERPLEXITY"):
             from genesis.research.perplexity import PerplexityAdapter
 

--- a/tests/test_providers/test_tinyfish.py
+++ b/tests/test_providers/test_tinyfish.py
@@ -1,0 +1,393 @@
+"""Tests for TinyFish adapters (search, fetch, agent) and MCP tool wiring."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from genesis.providers.protocol import ToolProvider
+from genesis.providers.tinyfish_agent import COST_PER_STEP_USD, TinyFishAgentAdapter
+from genesis.providers.tinyfish_fetch import TinyFishFetchAdapter
+from genesis.providers.tinyfish_search import TinyFishSearchAdapter
+from genesis.providers.types import (
+    CostTier,
+    ProviderCategory,
+    ProviderResult,
+    ProviderStatus,
+)
+
+ENV = {"API_KEY_TINYFISH": "sk-tinyfish-test-key"}
+
+
+# ── Search adapter ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def search_adapter():
+    return TinyFishSearchAdapter()
+
+
+class TestSearchProtocol:
+    def test_implements_tool_provider(self, search_adapter):
+        assert isinstance(search_adapter, ToolProvider)
+
+    def test_name(self, search_adapter):
+        assert search_adapter.name == "tinyfish_search"
+
+    def test_capability_categories(self, search_adapter):
+        assert ProviderCategory.SEARCH in search_adapter.capability.categories
+
+    def test_capability_cost_tier(self, search_adapter):
+        assert search_adapter.capability.cost_tier == CostTier.FREE
+
+
+class TestSearchHealth:
+    @pytest.mark.asyncio
+    async def test_available_when_configured(self, search_adapter):
+        with patch.dict("os.environ", ENV):
+            status = await search_adapter.check_health()
+        assert status == ProviderStatus.AVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_unavailable_when_no_key(self, search_adapter):
+        with patch.dict("os.environ", {}, clear=True):
+            status = await search_adapter.check_health()
+        assert status == ProviderStatus.UNAVAILABLE
+
+
+class TestSearchInvoke:
+    @pytest.mark.asyncio
+    async def test_missing_query(self, search_adapter):
+        with patch.dict("os.environ", ENV):
+            result = await search_adapter.invoke({})
+        assert result.success is False
+        assert "query" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_missing_key(self, search_adapter):
+        with patch.dict("os.environ", {}, clear=True):
+            result = await search_adapter.invoke({"query": "test"})
+        assert result.success is False
+        assert "required" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_success(self, search_adapter):
+        mock_response = {
+            "query": "test",
+            "results": [
+                {"position": 1, "title": "Result 1", "url": "https://example.com", "snippet": "text"}
+            ],
+            "total_results": 1,
+        }
+        with patch.dict("os.environ", ENV), \
+             patch("genesis.providers.tinyfish_client.search", new_callable=AsyncMock, return_value=mock_response):
+            result = await search_adapter.invoke({"query": "test"})
+
+        assert isinstance(result, ProviderResult)
+        assert result.success is True
+        assert result.data["total_results"] == 1
+        assert result.provider_name == "tinyfish_search"
+        assert result.latency_ms >= 0
+
+    @pytest.mark.asyncio
+    async def test_api_error(self, search_adapter):
+        with patch.dict("os.environ", ENV), \
+             patch("genesis.providers.tinyfish_client.search", new_callable=AsyncMock, side_effect=RuntimeError("timeout")):
+            result = await search_adapter.invoke({"query": "test"})
+
+        assert result.success is False
+        assert "timeout" in result.error
+
+
+# ── Fetch adapter ───────────────────────────────────────────────
+
+
+@pytest.fixture
+def fetch_adapter():
+    return TinyFishFetchAdapter()
+
+
+class TestFetchProtocol:
+    def test_implements_tool_provider(self, fetch_adapter):
+        assert isinstance(fetch_adapter, ToolProvider)
+
+    def test_name(self, fetch_adapter):
+        assert fetch_adapter.name == "tinyfish_fetch"
+
+    def test_capability_categories(self, fetch_adapter):
+        assert ProviderCategory.WEB in fetch_adapter.capability.categories
+
+    def test_capability_cost_tier(self, fetch_adapter):
+        assert fetch_adapter.capability.cost_tier == CostTier.FREE
+
+
+class TestFetchInvoke:
+    @pytest.mark.asyncio
+    async def test_missing_url(self, fetch_adapter):
+        with patch.dict("os.environ", ENV):
+            result = await fetch_adapter.invoke({})
+        assert result.success is False
+        assert "url" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_single_url(self, fetch_adapter):
+        mock_response = {
+            "results": [
+                {"url": "https://example.com", "text": "Hello world", "title": "Example", "latency_ms": 500}
+            ],
+            "errors": [],
+        }
+        with patch.dict("os.environ", ENV), \
+             patch("genesis.providers.tinyfish_client.fetch", new_callable=AsyncMock, return_value=mock_response):
+            result = await fetch_adapter.invoke({"url": "https://example.com"})
+
+        assert result.success is True
+        assert len(result.data["results"]) == 1
+        assert result.data["results"][0]["truncated"] is False
+
+    @pytest.mark.asyncio
+    async def test_multi_url(self, fetch_adapter):
+        mock_response = {
+            "results": [
+                {"url": "https://a.com", "text": "A", "title": "A", "latency_ms": 100},
+                {"url": "https://b.com", "text": "B", "title": "B", "latency_ms": 200},
+            ],
+            "errors": [],
+        }
+        with patch.dict("os.environ", ENV), \
+             patch("genesis.providers.tinyfish_client.fetch", new_callable=AsyncMock, return_value=mock_response):
+            result = await fetch_adapter.invoke({"urls": ["https://a.com", "https://b.com"]})
+
+        assert result.success is True
+        assert len(result.data["results"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_truncation(self, fetch_adapter):
+        long_text = "x" * 60000
+        mock_response = {
+            "results": [{"url": "https://example.com", "text": long_text, "title": "Big"}],
+            "errors": [],
+        }
+        with patch.dict("os.environ", ENV), \
+             patch("genesis.providers.tinyfish_client.fetch", new_callable=AsyncMock, return_value=mock_response):
+            result = await fetch_adapter.invoke({"url": "https://example.com", "max_chars": 1000})
+
+        assert result.data["results"][0]["truncated"] is True
+        assert len(result.data["results"][0]["text"]) == 1000
+
+    @pytest.mark.asyncio
+    async def test_urls_capped_at_10(self, fetch_adapter):
+        urls = [f"https://example{i}.com" for i in range(15)]
+        with patch.dict("os.environ", ENV), \
+             patch("genesis.providers.tinyfish_client.fetch", new_callable=AsyncMock, return_value={"results": [], "errors": []}) as mock:
+            await fetch_adapter.invoke({"urls": urls})
+
+        called_urls = mock.call_args[0][0]
+        assert len(called_urls) == 10
+
+
+# ── Agent adapter ───────────────────────────────────────────────
+
+
+@pytest.fixture
+def agent_adapter():
+    return TinyFishAgentAdapter()
+
+
+class TestAgentProtocol:
+    def test_implements_tool_provider(self, agent_adapter):
+        assert isinstance(agent_adapter, ToolProvider)
+
+    def test_name(self, agent_adapter):
+        assert agent_adapter.name == "tinyfish_agent"
+
+    def test_capability_categories(self, agent_adapter):
+        assert ProviderCategory.WEB in agent_adapter.capability.categories
+        assert ProviderCategory.EXTRACTION in agent_adapter.capability.categories
+
+    def test_capability_cost_tier(self, agent_adapter):
+        assert agent_adapter.capability.cost_tier == CostTier.MODERATE
+
+
+class TestAgentInvoke:
+    @pytest.mark.asyncio
+    async def test_missing_url_and_goal(self, agent_adapter):
+        with patch.dict("os.environ", ENV):
+            result = await agent_adapter.invoke({})
+        assert result.success is False
+        assert "required" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_success(self, agent_adapter):
+        mock_response = {
+            "run_id": "abc-123",
+            "status": "COMPLETED",
+            "result": {"data": [1, 2, 3]},
+            "num_of_steps": 3,
+        }
+        with patch.dict("os.environ", ENV), \
+             patch("genesis.providers.tinyfish_client.agent_run", new_callable=AsyncMock, return_value=mock_response):
+            result = await agent_adapter.invoke({"url": "https://example.com", "goal": "extract data"})
+
+        assert result.success is True
+        assert result.data["num_of_steps"] == 3
+        assert result.data["cost_usd"] == round(3 * COST_PER_STEP_USD, 4)
+
+    @pytest.mark.asyncio
+    async def test_failed_status(self, agent_adapter):
+        mock_response = {
+            "run_id": "abc-123",
+            "status": "FAILED",
+            "result": None,
+            "error": "Page not found",
+            "num_of_steps": 1,
+        }
+        with patch.dict("os.environ", ENV), \
+             patch("genesis.providers.tinyfish_client.agent_run", new_callable=AsyncMock, return_value=mock_response):
+            result = await agent_adapter.invoke({"url": "https://example.com", "goal": "extract data"})
+
+        assert result.success is False
+
+
+# ── MCP tool wiring ─────────────────────────────────────────────
+
+
+class TestWebSearchAutoChain:
+    """Verify TinyFish is first in the auto search chain."""
+
+    @pytest.mark.asyncio
+    async def test_auto_uses_tinyfish_when_available(self):
+        from genesis.mcp.health.web_tools import _impl_web_search
+
+        mock_response = {
+            "results": [{"position": 1, "title": "TF Result", "url": "https://tf.com", "snippet": "found it"}],
+            "total_results": 1,
+        }
+        with patch.dict("os.environ", ENV), \
+             patch("genesis.providers.tinyfish_client.search", new_callable=AsyncMock, return_value=mock_response):
+            result = await _impl_web_search("test query", "auto", 10)
+
+        assert result["backend_used"] == "tinyfish"
+        assert len(result["results"]) == 1
+        assert result["results"][0]["title"] == "TF Result"
+
+    @pytest.mark.asyncio
+    async def test_auto_falls_back_when_tinyfish_unavailable(self):
+        from genesis.mcp.health.web_tools import _impl_web_search
+
+        with patch.dict("os.environ", {}, clear=False), \
+             patch("genesis.mcp.health.web_tools._get_searcher") as mock_searcher:
+            # Remove TINYFISH key so it falls through
+            import os
+            old_key = os.environ.pop("API_KEY_TINYFISH", None)
+            try:
+                mock_response = type("R", (), {
+                    "query": "test",
+                    "results": [],
+                    "backend_used": type("B", (), {"value": "searxng"})(),
+                    "fallback_used": False,
+                    "error": None,
+                })()
+                mock_searcher.return_value.search = AsyncMock(return_value=mock_response)
+                result = await _impl_web_search("test query", "auto", 10)
+            finally:
+                if old_key:
+                    os.environ["API_KEY_TINYFISH"] = old_key
+
+        assert result["backend_used"] == "searxng"
+
+    @pytest.mark.asyncio
+    async def test_score_never_negative(self):
+        from genesis.mcp.health.web_tools import _try_tinyfish_search
+
+        mock_response = {
+            "results": [{"position": i, "title": f"R{i}", "url": f"https://r{i}.com", "snippet": ""} for i in range(1, 21)],
+        }
+        with patch.dict("os.environ", ENV), \
+             patch("genesis.providers.tinyfish_client.search", new_callable=AsyncMock, return_value=mock_response):
+            result = await _try_tinyfish_search("test", 20)
+
+        assert result is not None
+        for r in result["results"]:
+            assert r["score"] >= 0.0
+
+
+class TestWebFetchAutoChain:
+    """Verify TinyFish is first in the auto fetch chain."""
+
+    @pytest.mark.asyncio
+    async def test_auto_uses_tinyfish_when_available(self):
+        from genesis.mcp.health.web_tools import _impl_web_fetch
+
+        mock_response = {
+            "results": [{"url": "https://example.com", "text": "content here", "title": "Example", "latency_ms": 500}],
+            "errors": [],
+        }
+        with patch.dict("os.environ", ENV), \
+             patch("genesis.providers.tinyfish_client.fetch", new_callable=AsyncMock, return_value=mock_response):
+            result = await _impl_web_fetch("https://example.com", "auto", 50000)
+
+        assert result["backend_used"] == "tinyfish"
+        assert result["content"] == "content here"
+
+    @pytest.mark.asyncio
+    async def test_auto_falls_back_to_scrapling(self):
+        import os
+
+        from genesis.mcp.health.web_tools import _impl_web_fetch
+        old_key = os.environ.pop("API_KEY_TINYFISH", None)
+        try:
+            mock_result = type("R", (), {
+                "url": "https://example.com",
+                "title": "Example",
+                "text": "scrapling content",
+                "status_code": 200,
+                "truncated": False,
+                "error": None,
+            })()
+            with patch("genesis.mcp.health.web_tools._get_fetcher") as mock_fetcher:
+                mock_fetcher.return_value.fetch = AsyncMock(return_value=mock_result)
+                result = await _impl_web_fetch("https://example.com", "auto", 50000)
+        finally:
+            if old_key:
+                os.environ["API_KEY_TINYFISH"] = old_key
+
+        assert result["backend_used"] == "scrapling"
+
+
+class TestWebFetchMulti:
+    """Test multi-URL parallel fetch via urls parameter."""
+
+    @pytest.mark.asyncio
+    async def test_multi_url_fetch(self):
+        from genesis.mcp.health.web_tools import _impl_web_fetch_multi
+
+        mock_response = {
+            "results": [
+                {"url": "https://a.com", "text": "A content", "title": "A", "latency_ms": 100},
+                {"url": "https://b.com", "text": "B content", "title": "B", "latency_ms": 200},
+            ],
+            "errors": [],
+        }
+        with patch.dict("os.environ", ENV), \
+             patch("genesis.providers.tinyfish_client.fetch", new_callable=AsyncMock, return_value=mock_response):
+            result = await _impl_web_fetch_multi(["https://a.com", "https://b.com"])
+
+        assert result["backend_used"] == "tinyfish"
+        assert len(result["results"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_multi_url_requires_key(self):
+        import os
+
+        from genesis.mcp.health.web_tools import _impl_web_fetch_multi
+        old_key = os.environ.pop("API_KEY_TINYFISH", None)
+        try:
+            result = await _impl_web_fetch_multi(["https://a.com"])
+        finally:
+            if old_key:
+                os.environ["API_KEY_TINYFISH"] = old_key
+
+        assert "error" in result
+        assert "API_KEY_TINYFISH" in result["error"]


### PR DESCRIPTION
## Summary

- Add TinyFish (tinyfish.ai) as a new web tools provider with three tiers: search (free), fetch (free, parallel multi-URL), and agent (paid, NL browser automation)
- Wire TinyFish as primary in both web_search and web_fetch auto chains with existing backends (SearXNG/Brave, Scrapling/Crawl4AI) as fallbacks
- Add new `web_agent` MCP tool for goal-based browser automation with budget checking and cost tracking
- Add `urls` parameter to `web_fetch` for parallel multi-URL fetching (1-10 URLs)
- 33 tests covering all adapters, protocol compliance, auto chain wiring, and edge cases

## New files
- `src/genesis/providers/tinyfish_client.py` — shared async HTTP client with connection pooling
- `src/genesis/providers/tinyfish_search.py` — search adapter (FREE, SEARCH category)
- `src/genesis/providers/tinyfish_fetch.py` — fetch adapter (FREE, WEB category)
- `src/genesis/providers/tinyfish_agent.py` — agent adapter (MODERATE, WEB+EXTRACTION)
- `tests/test_providers/test_tinyfish.py` — 33 tests

## Modified files
- `src/genesis/runtime/init/providers.py` — register 3 adapters gated on `API_KEY_TINYFISH`
- `src/genesis/mcp/health/web_tools.py` — auto chain wiring, new `web_agent` tool

## Test plan
- [x] All 33 TinyFish-specific tests pass
- [x] All 202 provider + web_tools tests pass (0 regressions)
- [x] Ruff lint clean on all changed files
- [x] Code review completed — budget check, connection pooling, score clamping fixed
- [ ] Live verification after merge (web_search/web_fetch auto chain, web_agent)