### PR TITLE
chore(infra): README reflow, extraction chain reorder, follow-up retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,6 @@ But what I can tell you is this: Genesis is far closer to AGI than anything else
 
 ---
 
-Day 1 — a strong generalist with full cognitive infrastructure.
-Day 30 — a personalized specialist in every domain you've touched.
-Day 90 — anticipating needs you haven't articulated yet.
-Day 180 — evolving its own architecture to serve you better.
-
----
-
 ## Genesis in 30 seconds
 
 Personal AI does what you tell it. Personal AGI does what you *need*.
@@ -89,6 +82,11 @@ With personal AI, you are the intelligence directing the tool. With personal AGI
 - **Closed-loop learning** — outcome classification, causal attribution, procedure extraction. Laplace-smoothed confidence, not vibes.
 - **Background cognition** — thinks, researches, audits, and communicates on free-tier compute while you sleep.
 - **Earned autonomy** — trust granted per action category through demonstrated competence. The system gets measurably better at its job, and it can show you the receipts.
+
+Day 1 — a strong generalist with full cognitive infrastructure.
+Day 30 — a personalized specialist in every domain you've touched.
+Day 90 — anticipating needs you haven't articulated yet.
+Day 180 — evolving its own architecture to serve you better.
 
 [**Get started →**](#getting-started)
 

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -283,11 +283,11 @@ call_sites:
     default_paid: true
   9_fact_extraction:
     chain:
-    - mistral-large-free
     - groq-free
     - gemini-free
     - cerebras-qwen
-    - openrouter-free
+    - mistral-large-free
+    - openrouter-deepseek-v4-flash
   10_cognitive_state:
     chain:
     - glm51

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import aiosqlite
 
@@ -227,3 +227,25 @@ async def get_recent(
         (limit,),
     )
     return [dict(row) for row in await cursor.fetchall()]
+
+
+async def purge_completed(
+    db: aiosqlite.Connection,
+    *,
+    max_age_days: int = 30,
+) -> int:
+    """Delete completed/failed follow-ups older than *max_age_days*.
+
+    Pinned follow-ups are always preserved regardless of age.
+    Returns the number of records deleted.
+    """
+    cutoff = (datetime.now(UTC) - timedelta(days=max_age_days)).isoformat()
+    cursor = await db.execute(
+        "DELETE FROM follow_ups "
+        "WHERE status IN ('completed', 'failed') "
+        "AND pinned = 0 "
+        "AND completed_at IS NOT NULL AND completed_at < ?",
+        (cutoff,),
+    )
+    await db.commit()
+    return cursor.rowcount

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -275,6 +275,28 @@ async def init(rt: GenesisRuntime) -> None:
             misfire_grace_time=3600,
         )
 
+        async def _follow_up_retention_sweep() -> None:
+            try:
+                from genesis.db.crud import follow_ups
+
+                count = await follow_ups.purge_completed(rt._db)
+                rt.record_job_success("follow_up_retention_sweep")
+                if count:
+                    logger.info(
+                        "Follow-up retention sweep: purged %d old records", count,
+                    )
+            except Exception as exc:
+                rt.record_job_failure("follow_up_retention_sweep", str(exc))
+                logger.exception("Follow-up retention sweep failed")
+
+        rt._learning_scheduler.add_job(
+            _follow_up_retention_sweep,
+            CronTrigger(hour=2, minute=30),
+            id="follow_up_retention_sweep",
+            max_instances=1,
+            misfire_grace_time=3600,
+        )
+
         async def _run_recovery() -> None:
             if rt._recovery_orchestrator is not None:
                 try:

--- a/tests/test_db/test_follow_ups.py
+++ b/tests/test_db/test_follow_ups.py
@@ -1,0 +1,81 @@
+"""Tests for follow_ups CRUD — retention cleanup."""
+
+from genesis.db.crud import follow_ups
+
+_BASE = dict(
+    source="test",
+    content="test follow-up",
+    reason="testing",
+    strategy="ego_judgment",
+    priority="medium",
+)
+
+
+async def test_purge_completed_deletes_old(db):
+    """Old completed follow-ups are deleted."""
+    fid = await follow_ups.create(db, **_BASE)
+    # Mark completed with an old timestamp
+    await db.execute(
+        "UPDATE follow_ups SET status = 'completed', "
+        "completed_at = '2025-01-01T00:00:00+00:00' WHERE id = ?",
+        (fid,),
+    )
+    await db.commit()
+
+    count = await follow_ups.purge_completed(db)
+    assert count == 1
+    row = await follow_ups.get_by_id(db, fid)
+    assert row is None
+
+
+async def test_purge_completed_keeps_recent(db):
+    """Recently completed follow-ups survive."""
+    fid = await follow_ups.create(db, **_BASE)
+    await follow_ups.update_status(db, fid, status="completed",
+                                   resolution_notes="done")
+
+    count = await follow_ups.purge_completed(db)
+    assert count == 0
+    row = await follow_ups.get_by_id(db, fid)
+    assert row is not None
+
+
+async def test_purge_completed_keeps_pinned(db):
+    """Pinned follow-ups are never purged regardless of age."""
+    fid = await follow_ups.create(db, **_BASE)
+    await db.execute(
+        "UPDATE follow_ups SET status = 'completed', pinned = 1, "
+        "completed_at = '2025-01-01T00:00:00+00:00' WHERE id = ?",
+        (fid,),
+    )
+    await db.commit()
+
+    count = await follow_ups.purge_completed(db)
+    assert count == 0
+    row = await follow_ups.get_by_id(db, fid)
+    assert row is not None
+
+
+async def test_purge_completed_keeps_pending(db):
+    """Pending follow-ups are never touched."""
+    fid = await follow_ups.create(db, **_BASE)
+
+    count = await follow_ups.purge_completed(db)
+    assert count == 0
+    row = await follow_ups.get_by_id(db, fid)
+    assert row is not None
+    assert row["status"] == "pending"
+
+
+async def test_purge_failed_old(db):
+    """Old failed follow-ups are also purged."""
+    fid = await follow_ups.create(db, **_BASE)
+    await db.execute(
+        "UPDATE follow_ups SET status = 'failed', "
+        "completed_at = '2025-01-01T00:00:00+00:00' WHERE id = ?",
+        (fid,),
+    )
+    await db.commit()
+
+    count = await follow_ups.purge_completed(db)
+    assert count == 1


### PR DESCRIPTION
## Summary
- **README**: Move Day 1/30/90/180 progression to close the "30 seconds" section (payoff, not unearned claim)
- **Routing**: Reorder `9_fact_extraction` chain — Groq first (10x faster, comparable quality), Mistral demoted, openrouter-free removed, DeepSeek V4 Flash added as paid safety net ($0.14/$0.28/MTok)
- **Follow-up retention**: Add `purge_completed()` — deletes completed/failed follow-ups older than 30 days (pinned exempt). Wired as daily CronTrigger at 02:30 UTC

## Test plan
- [x] Head-to-head extraction test: Groq vs Mistral Large (same prompt, same chunk)
- [x] 5 unit tests for retention cleanup (old deleted, recent kept, pinned kept, pending untouched, failed purged)
- [x] Lint passes (`ruff check`)
- [ ] Verify server restart loads new chain correctly
- [ ] Monitor next extraction cycle routes to groq-free

🤖 Generated with [Claude Code](https://claude.com/claude-code)