### PR TITLE
fix(eval): wire J-9 eval batch scheduling into surplus dispatcher

### DIFF
--- a/config/surplus.yaml
+++ b/config/surplus.yaml
@@ -17,6 +17,7 @@ jobs:
   analytical_hours: 0             # DISABLED — gap_clustering + prompt_effectiveness are self-referential (0 = off)
   follow_up_dispatch_minutes: 5
   memory_extraction_hours: 2
+  j9_eval_batch_hours: 24
 
 task_defaults:
   code_audit:                { priority: 0.5, drive: competence,   tier: free_api }
@@ -29,3 +30,4 @@ task_defaults:
   gap_clustering:            { priority: 0.4, drive: competence,   tier: free_api }
   anticipatory_research:     { priority: 0.3, drive: curiosity,    tier: free_api }
   prompt_effectiveness:      { priority: 0.3, drive: competence,   tier: free_api }
+  j9_eval_batch:             { priority: 0.3, drive: competence,   tier: free_api }

--- a/src/genesis/runtime/init/surplus.py
+++ b/src/genesis/runtime/init/surplus.py
@@ -78,6 +78,7 @@ async def init(rt: GenesisRuntime) -> None:
             analytical_hours=int(jobs.get("analytical_hours", 24)),
             follow_up_dispatch_minutes=int(jobs.get("follow_up_dispatch_minutes", 5)),
             memory_extraction_hours=int(jobs.get("memory_extraction_hours", 2)),
+            j9_eval_batch_hours=int(jobs.get("j9_eval_batch_hours", 24)),
         )
 
         try:

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -56,6 +56,7 @@ class SurplusScheduler:
         analytical_hours: int = 24,
         follow_up_dispatch_minutes: int | None = None,
         memory_extraction_hours: int = 2,
+        j9_eval_batch_hours: int = 24,
         clock=None,
         event_bus: GenesisEventBus | None = None,
         enable_code_audits: bool = True,
@@ -80,6 +81,7 @@ class SurplusScheduler:
         self._analytical_hours = analytical_hours
         self._follow_up_dispatch_minutes = follow_up_dispatch_minutes or dispatch_interval_minutes
         self._memory_extraction_hours = memory_extraction_hours
+        self._j9_eval_batch_hours = j9_eval_batch_hours
         self._clock = clock or (lambda: datetime.now(UTC))
         self._code_audit_executor: SurplusExecutor | None = None
         self._code_index_executor: SurplusExecutor | None = None
@@ -235,6 +237,14 @@ class SurplusScheduler:
                 max_instances=1,
                 misfire_grace_time=300,
             )
+        if self._j9_eval_batch_hours > 0:
+            self._scheduler.add_job(
+                self.schedule_j9_eval_batch,
+                IntervalTrigger(hours=self._j9_eval_batch_hours),
+                id="schedule_j9_eval_batch",
+                max_instances=1,
+                misfire_grace_time=300,
+            )
         if self._follow_up_dispatcher is not None:
             self._scheduler.add_job(
                 self.dispatch_follow_ups,
@@ -253,6 +263,8 @@ class SurplusScheduler:
         await self.schedule_code_index()
         await self.run_recon_gather()
         await self.schedule_maintenance()
+        if self._j9_eval_batch_hours > 0:
+            await self.schedule_j9_eval_batch()
         if self._analytical_hours > 0:
             await self.schedule_analytical()
         logger.info(
@@ -341,6 +353,29 @@ class SurplusScheduler:
             try:
                 from genesis.runtime import GenesisRuntime
                 GenesisRuntime.instance().record_job_failure("schedule_code_index", str(exc))
+            except Exception:
+                pass
+
+    async def schedule_j9_eval_batch(self) -> None:
+        """Enqueue a J9 eval batch task if none pending/running."""
+        try:
+            from genesis.surplus.types import ComputeTier, TaskType
+
+            active = await self._queue.active_by_type(TaskType.J9_EVAL_BATCH)
+            if active == 0:
+                await self._queue.enqueue(
+                    TaskType.J9_EVAL_BATCH, ComputeTier.FREE_API, 0.3, "competence"
+                )
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_success("schedule_j9_eval_batch")
+            except Exception:
+                pass
+        except Exception as exc:
+            logger.exception("J9 eval batch scheduling failed")
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_failure("schedule_j9_eval_batch", str(exc))
             except Exception:
                 pass
 

--- a/tests/test_surplus/test_scheduler.py
+++ b/tests/test_surplus/test_scheduler.py
@@ -119,9 +119,9 @@ async def test_start_and_stop(db):
     assert sched._scheduler.get_job("surplus_dispatch") is not None
     assert sched._scheduler.get_job("schedule_code_audit") is not None
     # Brainstorm (2) + code audit (1) + code index (1)
-    # + maintenance (4) + analytical (1: gap_clustering)
-    # + pipeline (1: prompt_effectiveness step 1) = 10
-    assert await sched._queue.pending_count() == 10
+    # + maintenance (4) + j9_eval_batch (1) + analytical (1: gap_clustering)
+    # + pipeline (1: prompt_effectiveness step 1) = 11
+    assert await sched._queue.pending_count() == 11
     # Stop should not raise
     await sched.stop()
 
@@ -134,9 +134,9 @@ async def test_start_without_code_audits(db):
     # Code audit job should NOT be registered
     assert sched._scheduler.get_job("schedule_code_audit") is None
     # Brainstorm (2) + code index (1)
-    # + maintenance (4) + analytical (1: gap_clustering)
-    # + pipeline (1: prompt_effectiveness step 1) = 9
-    assert await sched._queue.pending_count() == 9
+    # + maintenance (4) + j9_eval_batch (1) + analytical (1: gap_clustering)
+    # + pipeline (1: prompt_effectiveness step 1) = 10
+    assert await sched._queue.pending_count() == 10
     await sched.stop()
 
 


### PR DESCRIPTION
## Summary
- The `J9EvalBatchExecutor` was wired to the surplus scheduler but no `schedule_j9_eval_batch()` method existed — tasks were never enqueued, so the J-9 eval pipeline produced no data (0 snapshots, 6 events total over weeks of runtime)
- Adds `schedule_j9_eval_batch()` following the existing `schedule_code_audit` pattern with 24h interval + immediate startup call
- Adds config entry `j9_eval_batch_hours: 24` to `surplus.yaml`

## Test plan
- [x] All 196 surplus + eval tests pass (including updated startup queue counts)
- [x] `ruff check` passes on all modified files
- [ ] After merge + restart: verify `SELECT COUNT(*) FROM surplus_tasks WHERE task_type='j9_eval_batch'` returns ≥ 1
- [ ] After 1-2 weeks: verify `eval_events` and `eval_snapshots` tables accumulate data

🤖 Generated with [Claude Code](https://claude.com/claude-code)