### PR TITLE
fix(health): raise disk alert threshold from 10% to 15% free

### DIFF
--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -276,7 +276,7 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
 
     disk = snap.get("infrastructure", {}).get("disk", {})
     free_pct = disk.get("free_pct")
-    if free_pct is not None and free_pct < 10:
+    if free_pct is not None and free_pct < 15:
         alert_id = "infra:disk_low"
         alerts.append({
             "id": alert_id,


### PR DESCRIPTION
## Summary
- Health alerts only fired at <10% free disk space (CRITICAL), leaving a blind spot between `probe_disk` DEGRADED at 20% free and the alert
- Now fires WARNING at <15% free, CRITICAL at <10% — closes the gap
- One-line change in `mcp/health/errors.py`

## Test plan
- [x] `ruff check` passes
- [ ] Verify via `health_alerts` MCP tool with current disk at ~21% free (should show no alert — above 15%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)