### PR TITLE
feat(cc): add xhigh effort tier support

### DIFF
--- a/config/ego.yaml
+++ b/config/ego.yaml
@@ -14,7 +14,7 @@ backoff_multiplier: 2.0      # interval doubles on idle cycles
 model: opus                  # default model for ego cycles
 
 # Effort
-default_effort: high         # effort for regular cycles (low/medium/high/max)
+default_effort: high         # effort for regular cycles (low/medium/high/xhigh/max)
 morning_report_effort: low   # effort for morning reports
 
 # Proposals

--- a/src/genesis/cc/intent.py
+++ b/src/genesis/cc/intent.py
@@ -15,7 +15,7 @@ from genesis.cc.types import CCModel, EffortLevel, IntentResult
 
 class IntentParser:
     _SLASH_MODEL = re.compile(r"/model\s+(sonnet|opus|haiku)", re.IGNORECASE)
-    _SLASH_EFFORT = re.compile(r"/effort\s+(low|medium|high|max)", re.IGNORECASE)
+    _SLASH_EFFORT = re.compile(r"/effort\s+(low|medium|high|xhigh|max)", re.IGNORECASE)
     _SLASH_RESUME = re.compile(r"/resume(?:\s+(\S+))?", re.IGNORECASE)
     _SLASH_TASK = re.compile(r"/task(?:\s+(.*))?", re.IGNORECASE)
 

--- a/src/genesis/cc/terminal.py
+++ b/src/genesis/cc/terminal.py
@@ -16,7 +16,7 @@ from genesis.runtime import GenesisRuntime
 
 _BANNER = """\
 Genesis Terminal — type your message, press Enter.
-Commands: /model <sonnet|opus|haiku>, /effort <low|medium|high>
+Commands: /model <sonnet|opus|haiku>, /effort <low|medium|high|xhigh|max>
 Type 'exit' or 'quit' to leave. Ctrl+D or Ctrl+C also works.
 """
 

--- a/src/genesis/cc/types.py
+++ b/src/genesis/cc/types.py
@@ -76,6 +76,7 @@ class EffortLevel(StrEnum):
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
+    XHIGH = "xhigh"
     MAX = "max"
 
 

--- a/src/genesis/channels/telegram/_handler_commands.py
+++ b/src/genesis/channels/telegram/_handler_commands.py
@@ -27,7 +27,7 @@ async def cmd_start(ctx: HandlerContext, update: Update, context: ContextTypes.D
         "/stop — stop current generation\n"
         "/status — show current session info\n"
         "/model sonnet|opus|haiku — switch model\n"
-        "/effort low|medium|high — change thinking effort\n"
+        "/effort low|medium|high|xhigh|max — change thinking effort\n"
         "/pause [on|off] — pause/resume all background activity\n"
         f"{tts_line}"
     )
@@ -115,7 +115,7 @@ async def cmd_effort(ctx: HandlerContext, update: Update, context: ContextTypes.
         return
 
     if not context.args:
-        await update.message.reply_text("Usage: /effort low|medium|high|max")
+        await update.message.reply_text("Usage: /effort low|medium|high|xhigh|max")
         return
 
     effort_str = context.args[0].lower().strip()
@@ -123,11 +123,12 @@ async def cmd_effort(ctx: HandlerContext, update: Update, context: ContextTypes.
         "low": EffortLevel.LOW,
         "medium": EffortLevel.MEDIUM,
         "high": EffortLevel.HIGH,
+        "xhigh": EffortLevel.XHIGH,
         "max": EffortLevel.MAX,
     }
     if effort_str not in effort_map:
         await update.message.reply_text(
-            f"Unknown effort '{effort_str}'. Use: low, medium, high, max"
+            f"Unknown effort '{effort_str}'. Use: low, medium, high, xhigh, max"
         )
         return
 

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -145,7 +145,8 @@ async def _make_streamer(ctx: HandlerContext, msg, user, tid) -> DraftStreamer |
                 )
                 if session:
                     model = (session.get("model") or "sonnet").title()
-                    effort = session.get("effort") or "medium"
+                    effort_raw = session.get("effort") or "medium"
+                    effort = "xHigh" if effort_raw == "xhigh" else effort_raw.title()
                     prefix = f"[{model} / {effort}]"
         except Exception:
             log.debug("Could not resolve model/effort prefix", exc_info=True)

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1363,7 +1363,7 @@
           response_dir: 'Subdirectory pattern where responses are written (excluded from scanning)',
           check_interval_seconds: 'How often (in seconds) to scan the inbox directory for new files',
           batch_size: 'Maximum files to process per scan cycle (1\u201310)',
-          effort: 'Processing depth: low (fast), medium (balanced), or high (thorough)',
+          effort: 'Processing depth: low (fast), medium (balanced), high (thorough), xhigh (Opus 4.7 only), or max',
           timeout_s: 'Max seconds per inbox item processing before timeout',
           // Outreach
           start: 'Quiet hours start \u2014 no outreach before this time (e.g., 22:00)',
@@ -6137,7 +6137,7 @@
                   </div>
                   <select style="margin-left: auto; background: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-border); border-radius: 4px; padding: 0.3rem 0.5rem; font-size: 0.82rem;"
                           @change="fetchApi('/api/genesis/settings/ego', { method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({default_effort: $event.target.value}) })">
-                    <!-- MAX intentionally excluded per user decision -->
+                    <!-- MAX and XHIGH intentionally excluded per user decision (defaults stay at high; xhigh is Opus 4.7 only and reachable via session_set_effort) -->
                     <template x-for="e in ['low', 'medium', 'high']" :key="e">
                       <option :value="e" x-text="e.charAt(0).toUpperCase() + e.slice(1)"
                               :selected="e === ($store.genesisDashboard.egoStatus?.default_effort || 'high')"></option>

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1417,7 +1417,7 @@
         _SETTING_CHOICES: {
           provider: ['elevenlabs', 'fish_audio', 'cartesia'],
           model: ['opus', 'sonnet', 'haiku'],
-          effort: ['low', 'medium', 'high', 'max'],
+          effort: ['low', 'medium', 'high', 'xhigh', 'max'],
           approval_channel: ['telegram', 'email', 'dashboard'],
           default: ['telegram', 'email', 'dashboard'],
           blocker: ['telegram', 'email', 'dashboard'],
@@ -1425,7 +1425,7 @@
           surplus: ['telegram', 'email', 'dashboard'],
           digest: ['telegram', 'email', 'dashboard'],
           default_model: ['opus', 'sonnet', 'haiku'],
-          default_effort: ['low', 'medium', 'high', 'max'],
+          default_effort: ['low', 'medium', 'high', 'xhigh', 'max'],
         },
         // Display order for settings domains — most important first
         _DOMAIN_ORDER: [

--- a/src/genesis/ego/config.py
+++ b/src/genesis/ego/config.py
@@ -122,7 +122,7 @@ def validate_ego_config(changes: dict) -> list[str]:
         v = changes["morning_report_minute"]
         if not isinstance(v, int) or not (0 <= v <= 59):
             errors.append("morning_report_minute must be 0-59")
-    _VALID_EFFORTS = {"low", "medium", "high", "max"}
+    _VALID_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
     if "default_effort" in changes and changes["default_effort"] not in _VALID_EFFORTS:
         errors.append(f"default_effort must be one of {_VALID_EFFORTS}")
     if "morning_report_effort" in changes and changes["morning_report_effort"] not in _VALID_EFFORTS:

--- a/src/genesis/mcp/health/direct_session_tools.py
+++ b/src/genesis/mcp/health/direct_session_tools.py
@@ -80,7 +80,7 @@ async def _impl_direct_session_run(
     try:
         EffortLevel(effort_lower)
     except ValueError:
-        return {"error": f"Invalid effort '{effort}'. Must be one of: low, medium, high, max"}
+        return {"error": f"Invalid effort '{effort}'. Must be one of: low, medium, high, xhigh, max"}
 
     try:
         from genesis.db.crud import direct_session_queue as dsq
@@ -289,7 +289,7 @@ async def direct_session_run(
         prompt: The full instructions for the background session
         profile: Safety profile (observe, interact, research)
         model: LLM model (sonnet, opus, haiku)
-        effort: Effort level (low, medium, high, max)
+        effort: Effort level (low, medium, high, xhigh, max)
         timeout_minutes: Max runtime in minutes (default 15, max 60)
         notify: Send Telegram notification on completion/failure
     """

--- a/src/genesis/mcp/health/session_control.py
+++ b/src/genesis/mcp/health/session_control.py
@@ -10,7 +10,7 @@ from genesis.mcp.health import mcp  # noqa: E402
 logger = logging.getLogger(__name__)
 
 _VALID_MODELS = {"sonnet", "opus", "haiku"}
-_VALID_EFFORTS = {"low", "medium", "high", "max"}
+_VALID_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
 
 
 async def _impl_session_set_model(session_id: str, model: str) -> dict:
@@ -85,7 +85,7 @@ async def session_set_effort(session_id: str, effort: str) -> dict:
 
     Call this when the user asks to change thinking effort, e.g. 'use high
     thinking', 'think harder', 'low effort', 'max effort'. Valid levels:
-    low, medium, high, max. Pass the Session ID from your system configuration.
+    low, medium, high, xhigh, max. Pass the Session ID from your system configuration.
     The change takes effect on the next response.
     """
     return await _impl_session_set_effort(session_id, effort)

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -361,7 +361,7 @@ def _validate_inbox_monitor(changes: dict) -> list[str]:
             f"got '{section['model']}'"
         )
 
-    valid_efforts = {"low", "medium", "high", "max"}
+    valid_efforts = {"low", "medium", "high", "xhigh", "max"}
     if "effort" in section and section["effort"] not in valid_efforts:
         errors.append(
             f"inbox_monitor.effort must be one of {sorted(valid_efforts)}, "
@@ -519,7 +519,7 @@ def _validate_channels(changes: dict) -> list[str]:
     errors: list[str] = []
     valid_top_keys = {"telegram"}
     valid_models = {"opus", "sonnet", "haiku"}
-    valid_efforts = {"low", "medium", "high", "max"}
+    valid_efforts = {"low", "medium", "high", "xhigh", "max"}
 
     for key in changes:
         if key not in valid_top_keys:

--- a/tests/test_cc/test_intent.py
+++ b/tests/test_cc/test_intent.py
@@ -18,6 +18,19 @@ def test_slash_effort_high():
     assert r.cleaned_text == "can you help?"
 
 
+def test_slash_effort_xhigh():
+    """Opus 4.7 xhigh tier (CC 2.1.111+) must parse correctly."""
+    r = parser.parse("/effort xhigh investigate this thoroughly")
+    assert r.effort_override == EffortLevel.XHIGH
+    assert r.cleaned_text == "investigate this thoroughly"
+
+
+def test_slash_effort_max():
+    r = parser.parse("/effort max push hard")
+    assert r.effort_override == EffortLevel.MAX
+    assert r.cleaned_text == "push hard"
+
+
 def test_slash_resume():
     r = parser.parse("/resume")
     assert r.resume_requested is True

--- a/tests/test_cc/test_types.py
+++ b/tests/test_cc/test_types.py
@@ -21,6 +21,14 @@ def test_enums_have_expected_values():
     assert MessageType.QUESTION == "question"
     assert CCModel.OPUS == "opus"
     assert EffortLevel.HIGH == "high"
+    assert EffortLevel.XHIGH == "xhigh"
+    assert EffortLevel.MAX == "max"
+
+
+def test_effort_level_xhigh_constructible_from_string():
+    """Round-trip: 'xhigh' string -> enum -> 'xhigh' string."""
+    assert EffortLevel("xhigh") is EffortLevel.XHIGH
+    assert str(EffortLevel.XHIGH) == "xhigh"
 
 
 def test_cc_invocation_defaults():


### PR DESCRIPTION
## Summary
- Claude Code 2.1.111 introduced the **xhigh** effort tier (between `high` and `max`, Opus 4.7 only)
- Genesis was built before xhigh existed and rejected it everywhere — `EffortLevel` enum lacked it, 5 validator sets rejected it, the `/effort` regex didn't match it, and the Telegram session prefix mislabeled it
- This PR adds full xhigh support across the codebase

## Changes
- `EffortLevel` enum: add `XHIGH = "xhigh"`
- 5 `_VALID_EFFORTS` validation sets in `session_control.py`, `ego/config.py`, `mcp/health/settings.py` (×2)
- `/effort` regex in `cc/intent.py`
- Effort mapping dict in Telegram handler
- Dashboard `_SETTING_CHOICES` (effort + default_effort)
- Help text, error messages, docstrings (8 strings)
- Telegram session-prefix formatter: `[Sonnet / xhigh]` → `[Sonnet / xHigh]` (with proper case for the awkward x prefix)
- ego.yaml comment

Also fixes pre-existing bugs where the CC banner and Telegram `/help` text said `low|medium|high` only, omitting `max`.

## Test plan
- [x] All 82 effort/Telegram-handler tests pass
- [x] All 70 settings/effort/session_control tests pass
- [x] `ruff check` passes on all 9 modified Python files
- [x] GitNexus impact analysis: LOW risk (additive enum value, no breaking upstream callers)
- [ ] After merge + restart: verify xhigh works via `session_set_effort` MCP tool
- [ ] After merge + restart: verify Telegram session prefix renders \"xHigh\" not \"xhigh\"

## Defaults unchanged
Per user direction, this PR adds xhigh as an option but does NOT change any defaults. ego stays at `high`, telegram stays at `high`. Users opt into xhigh via `session_set_effort` or `--effort xhigh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)