### PR TITLE
chore(scripts): auto-upgrade codebase-memory-mcp and serena on bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **MCP code-intelligence tools auto-upgrade on install/bootstrap**
+  --- `scripts/bootstrap.sh` and `scripts/install.sh` now re-run the
+  codebase-memory-mcp installer unconditionally (it is idempotent and
+  pulls the latest release) and call `uv tool upgrade serena-agent`
+  when Serena is already present. Existing installs get the latest
+  versions on the next bootstrap; fresh installs are unchanged.
+  GitNexus is unaffected (deliberately pinned to a prerelease
+  channel).
+
+---
+
 ## [v3.0b7] - 2026-05-09
 
 Ego gets two new self-awareness features, references move into the

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -305,11 +305,11 @@ echo
 echo "--- Installing code intelligence tools ---"
 
 # codebase-memory-mcp (code graph — 66 languages)
-if ! command -v codebase-memory-mcp &>/dev/null; then
-    echo "  codebase-memory-mcp not found — installing..."
-    curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash -s -- --ui \
-        || echo "  WARNING: codebase-memory-mcp install failed (non-critical)"
-fi
+# Always re-runs the upstream installer: it is idempotent and pulls the latest
+# release, so existing installs are upgraded in place.
+echo "  codebase-memory-mcp: installing/upgrading..."
+curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash -s -- --ui \
+    || echo "  WARNING: codebase-memory-mcp install/upgrade failed (non-critical)"
 if command -v codebase-memory-mcp &>/dev/null; then
     echo "  codebase-memory-mcp: $(codebase-memory-mcp --version 2>/dev/null || echo 'installed')"
 fi
@@ -332,9 +332,14 @@ if ! command -v uv &>/dev/null; then
         || echo "  WARNING: uv install failed (non-critical)"
     export PATH="$HOME/.local/bin:$PATH"
 fi
-if command -v uv &>/dev/null && ! command -v serena &>/dev/null; then
-    echo "  Serena not found — installing..."
-    uv tool install serena-agent 2>/dev/null || echo "  WARNING: Serena install failed (non-critical)"
+if command -v uv &>/dev/null; then
+    if ! command -v serena &>/dev/null; then
+        echo "  Serena not found — installing..."
+        uv tool install serena-agent 2>/dev/null || echo "  WARNING: Serena install failed (non-critical)"
+    else
+        echo "  Serena: upgrading..."
+        uv tool upgrade serena-agent 2>/dev/null || echo "  WARNING: Serena upgrade failed (non-critical)"
+    fi
 fi
 if command -v serena &>/dev/null; then
     echo "  Serena: $(serena --version 2>/dev/null || echo 'installed')"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -598,11 +598,11 @@ done
 # Code intelligence tools (optional — enhance Claude Code sessions)
 echo "    Installing code intelligence tools..."
 
-if ! command -v codebase-memory-mcp &>/dev/null; then
-    curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash -s -- --ui 2>/dev/null \
-        && echo "    + codebase-memory-mcp installed" \
-        || echo "    NOTE: codebase-memory-mcp unavailable (optional)"
-fi
+# Always re-runs the upstream installer: it is idempotent and pulls the latest
+# release, so existing installs are upgraded in place.
+curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/install.sh | bash -s -- --ui 2>/dev/null \
+    && echo "    + codebase-memory-mcp installed/upgraded" \
+    || echo "    NOTE: codebase-memory-mcp unavailable (optional)"
 
 if _node_version_ok; then
     if ! command -v gitnexus &>/dev/null; then
@@ -616,10 +616,16 @@ if ! command -v uv &>/dev/null; then
     curl -LsSf https://astral.sh/uv/install.sh 2>/dev/null | sh 2>/dev/null || true
     export PATH="$HOME/.local/bin:$PATH"
 fi
-if command -v uv &>/dev/null && ! command -v serena &>/dev/null; then
-    uv tool install serena-agent 2>/dev/null \
-        && echo "    + Serena installed" \
-        || echo "    NOTE: Serena unavailable (optional)"
+if command -v uv &>/dev/null; then
+    if ! command -v serena &>/dev/null; then
+        uv tool install serena-agent 2>/dev/null \
+            && echo "    + Serena installed" \
+            || echo "    NOTE: Serena unavailable (optional)"
+    else
+        uv tool upgrade serena-agent 2>/dev/null \
+            && echo "    + Serena upgraded" \
+            || echo "    NOTE: Serena upgrade skipped (already current or failed)"
+    fi
 fi
 
 # Python venv — prefer python3.12 for venv creation


### PR DESCRIPTION
## Summary

- Re-run the upstream `codebase-memory-mcp` installer unconditionally on bootstrap/install (it is idempotent and pulls the latest release).
- Call `uv tool upgrade serena-agent` when Serena is already installed; first-time installs are unchanged.
- Existing Genesis installs now pick up new releases of these MCP tools without manual intervention.

GitNexus is intentionally left alone — it is pinned to a prerelease channel.

## Test plan

- [ ] Run `scripts/bootstrap.sh` on a host with both tools already installed and confirm both upgrade in place.
- [ ] Run `scripts/install.sh` (CI bootstrap path) on a fresh container and confirm latest versions are installed end-to-end.
- [ ] Verify shellcheck/ruff still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)