### PR TITLE
fix(db): remove db.commit() from migration 0013

### DIFF
--- a/src/genesis/db/migrations/0013_migrate_refs_to_episodic.py
+++ b/src/genesis/db/migrations/0013_migrate_refs_to_episodic.py
@@ -45,5 +45,3 @@ async def up(db: aiosqlite.Connection) -> None:
           )
         """
     )
-
-    await db.commit()


### PR DESCRIPTION
## Summary

Migration 0013 calls `await db.commit()` from inside `up()`, which the
`MigrationRunner` connection proxy explicitly forbids and raises
`RuntimeError` on. This makes 0013 fail for every install attempting
to apply it.

The runner manages the transaction explicitly via `BEGIN IMMEDIATE` /
`COMMIT` around each migration body. A `db.commit()` inside `up()`
breaks atomicity between the migration body and the
`schema_migrations` tracking row, and re-opens the DDL-rollback bug
the proxy exists to prevent.

Fix: drop the `await db.commit()` call. The runner commits.

## Test plan

- [x] All 28 migration runner tests pass (`pytest tests/test_db/test_migrations_runner.py -v`)
- [x] `ruff check` clean
- [x] Migration 0013 applies cleanly via `python -m genesis.db.migrations --apply`

🤖 Generated with [Claude Code](https://claude.com/claude-code)