### PR TITLE
feat(db): apply pending migrations at server startup

### DIFF
--- a/src/genesis/runtime/init/db.py
+++ b/src/genesis/runtime/init/db.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("genesis.runtime")
 
 
 async def init(rt: GenesisRuntime) -> None:
-    """Initialize the SQLite database."""
+    """Initialize the SQLite database and apply pending schema migrations."""
     try:
         from genesis.db.connection import init_db
 
@@ -21,8 +21,46 @@ async def init(rt: GenesisRuntime) -> None:
         logger.info("Genesis DB initialized")
     except sqlite3.Error:
         logger.exception("DB error during initialization")
+        return
     except Exception:
         logger.exception("Failed to initialize Genesis DB")
+        return
+
+    # Apply pending schema migrations before any other init step touches DB
+    # data. runtime/_core._run_init_step_async runs init steps sequentially,
+    # so no other coroutine holds rt._db here. SerializedConnection releases
+    # its lock per-call, so the runner's BEGIN IMMEDIATE / COMMIT envelope
+    # only stays atomic while this is the sole DB user. Do NOT move this
+    # past the next init step.
+    try:
+        from genesis.db.migrations.runner import MigrationRunner
+
+        runner = MigrationRunner(rt._db)
+        results = await runner.run_pending()
+        failed = [r for r in results if not r.success]
+        if failed:
+            for r in failed:
+                logger.critical(
+                    "Migration %s failed (%dms): %s",
+                    r.name, r.duration_ms, r.error,
+                )
+            raise RuntimeError(
+                f"{len(failed)} schema migration(s) failed at startup; "
+                f"DB is in inconsistent state. See logs for details."
+            )
+        applied = [r for r in results if r.success]
+        if applied:
+            logger.info(
+                "Applied %d schema migration(s) at startup: %s",
+                len(applied), ", ".join(r.name for r in applied),
+            )
+    except Exception:
+        try:
+            await rt._db.close()
+        except Exception:
+            logger.exception("Failed to close DB after migration failure")
+        rt._db = None
+        raise
 
 
 async def init_tool_registry(rt: GenesisRuntime) -> None:

--- a/tests/test_db/test_migrations_runner.py
+++ b/tests/test_db/test_migrations_runner.py
@@ -447,3 +447,32 @@ class TestStatus:
         status_after = await runner.status()
         assert status_after["pending_count"] == 0
         assert status_after["applied_count"] >= 1
+
+
+class TestSerializedConnectionCompat:
+    """The runtime path passes a SerializedConnection (not raw aiosqlite),
+    so the runner and its proxy must work through that wrapper."""
+
+    @pytest.mark.asyncio
+    async def test_run_pending_through_serialized_connection(
+        self, tmp_path,
+    ) -> None:
+        from genesis.db.connection import SerializedConnection
+
+        db_path = tmp_path / "serialized.db"
+        async with aiosqlite.connect(str(db_path)) as raw_conn:
+            await raw_conn.execute("PRAGMA journal_mode=WAL")
+            wrapped = SerializedConnection(raw_conn)
+
+            runner = MigrationRunner(wrapped)
+            results = await runner.run_pending()
+
+            assert len(results) >= 1, "expected at least one migration to apply"
+            assert all(r.success for r in results), (
+                f"migration failed via SerializedConnection: "
+                f"{[r.error for r in results if not r.success]}"
+            )
+
+            # Re-run is a no-op (idempotence holds through the wrapper)
+            second = await runner.run_pending()
+            assert second == []


### PR DESCRIPTION
## Summary

Wires `MigrationRunner.run_pending()` into `runtime/init/db.py` so
pending schema migrations apply automatically after the DB connection
opens, before any other init step touches DB data.

Previously the runner only ran via the CLI
(`python -m genesis.db.migrations --apply`). Migrations could sit
pending while the runtime kept running because
`db/schema/_tables.py` recreates tables idempotently at boot, masking
the gap. Data migrations and ALTER statements never ran automatically,
leading to silently inconsistent schemas across installs.

## Behavior

- Successful migrations log `Applied N schema migration(s) at startup: <names>`.
- Failed migrations log `CRITICAL` per-migration, close the DB
  connection, set `rt._db = None`, and raise. The exception propagates
  to `_run_init_step_async` which marks the `db` bootstrap step
  `failed: <exc>`, preventing downstream init steps from running
  against a partial schema.
- No-op when no migrations pending (silent fast path).

## Concurrency

`init_db()` returns a `SerializedConnection` (asyncio.Lock per-call),
not a raw `aiosqlite.Connection`. The runner's `BEGIN IMMEDIATE` /
`COMMIT` envelope only stays atomic while the runner is the sole DB
user. Init runs sequentially, so the wire-in **must** remain inside
`_init_db`; an in-code comment warns future refactors not to move it
past the next init step.

## Test plan

- [x] All 29 migration runner tests pass — including new
  `TestSerializedConnectionCompat::test_run_pending_through_serialized_connection`
  that locks in the duck-typing contract between `MigrationRunner`
  and `SerializedConnection`.
- [x] All 38 `tests/test_runtime/` tests pass.
- [x] Full `tests/test_db/` suite (527 tests) passes.
- [x] `ruff check` clean.

## Companion PR

Bundles cleanly with #301 (`fix(db): remove db.commit() from migration
0013`). Order doesn't matter for shipping — this PR's failure-mode
handling correctly surfaces 0013's bug to the manifest if 0013 still
has the `db.commit()` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)