### PR TITLE
chore(scripts): auto-upgrade gitnexus on bootstrap, pin to 1.6.4

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -315,16 +315,16 @@ if command -v codebase-memory-mcp &>/dev/null; then
 fi
 
 # GitNexus (blast radius, impact analysis, execution flows)
-# Pinned to ~1.6 (>=1.6.0 <1.7.0). Re-evaluate before bumping past 1.7
-# — earlier 1.7 prereleases had FTS read-blocking issues that need to be
-# verified fixed.
+# Exact pin to 1.6.4 — only ship versions we've actually verified.
+# Bumping to 1.6.5+ or 1.7+ is an explicit decision in a follow-up PR
+# (1.7 prereleases had FTS read-blocking issues that need re-verification).
 if _node_version_ok; then
     if ! command -v gitnexus &>/dev/null; then
         echo "  GitNexus not found — installing..."
-        npm install -g 'gitnexus@~1.6' 2>/dev/null || echo "  WARNING: GitNexus install failed (non-critical)"
+        npm install -g gitnexus@1.6.4 2>/dev/null || echo "  WARNING: GitNexus install failed (non-critical)"
     else
-        echo "  GitNexus: upgrading..."
-        npm install -g 'gitnexus@~1.6' 2>/dev/null || echo "  WARNING: GitNexus upgrade failed (non-critical)"
+        echo "  GitNexus: ensuring pin..."
+        npm install -g gitnexus@1.6.4 2>/dev/null || echo "  WARNING: GitNexus upgrade failed (non-critical)"
     fi
     if command -v gitnexus &>/dev/null; then
         echo "  GitNexus: $(gitnexus --version 2>/dev/null)"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -315,10 +315,16 @@ if command -v codebase-memory-mcp &>/dev/null; then
 fi
 
 # GitNexus (blast radius, impact analysis, execution flows)
+# Pinned to ~1.6 (>=1.6.0 <1.7.0). Re-evaluate before bumping past 1.7
+# — earlier 1.7 prereleases had FTS read-blocking issues that need to be
+# verified fixed.
 if _node_version_ok; then
     if ! command -v gitnexus &>/dev/null; then
         echo "  GitNexus not found — installing..."
-        npm install -g gitnexus@latest 2>/dev/null || echo "  WARNING: GitNexus install failed (non-critical)"
+        npm install -g 'gitnexus@~1.6' 2>/dev/null || echo "  WARNING: GitNexus install failed (non-critical)"
+    else
+        echo "  GitNexus: upgrading..."
+        npm install -g 'gitnexus@~1.6' 2>/dev/null || echo "  WARNING: GitNexus upgrade failed (non-critical)"
     fi
     if command -v gitnexus &>/dev/null; then
         echo "  GitNexus: $(gitnexus --version 2>/dev/null)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -605,10 +605,17 @@ curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/i
     || echo "    NOTE: codebase-memory-mcp unavailable (optional)"
 
 if _node_version_ok; then
+    # Pinned to ~1.6 (>=1.6.0 <1.7.0). Re-evaluate before bumping past
+    # 1.7 — earlier 1.7 prereleases had FTS read-blocking issues that
+    # need to be verified fixed.
     if ! command -v gitnexus &>/dev/null; then
-        npm install -g gitnexus@latest 2>/dev/null \
+        npm install -g 'gitnexus@~1.6' 2>/dev/null \
             && echo "    + GitNexus installed ($(gitnexus --version 2>/dev/null))" \
             || echo "    NOTE: GitNexus unavailable (optional)"
+    else
+        npm install -g 'gitnexus@~1.6' 2>/dev/null \
+            && echo "    + GitNexus upgraded ($(gitnexus --version 2>/dev/null))" \
+            || echo "    NOTE: GitNexus upgrade skipped (already current or failed)"
     fi
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -605,17 +605,18 @@ curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/i
     || echo "    NOTE: codebase-memory-mcp unavailable (optional)"
 
 if _node_version_ok; then
-    # Pinned to ~1.6 (>=1.6.0 <1.7.0). Re-evaluate before bumping past
-    # 1.7 — earlier 1.7 prereleases had FTS read-blocking issues that
-    # need to be verified fixed.
+    # Exact pin to 1.6.4 — only ship versions we've actually verified.
+    # Bumping to 1.6.5+ or 1.7+ is an explicit decision in a follow-up
+    # PR (1.7 prereleases had FTS read-blocking issues that need
+    # re-verification).
     if ! command -v gitnexus &>/dev/null; then
-        npm install -g 'gitnexus@~1.6' 2>/dev/null \
+        npm install -g gitnexus@1.6.4 2>/dev/null \
             && echo "    + GitNexus installed ($(gitnexus --version 2>/dev/null))" \
             || echo "    NOTE: GitNexus unavailable (optional)"
     else
-        npm install -g 'gitnexus@~1.6' 2>/dev/null \
-            && echo "    + GitNexus upgraded ($(gitnexus --version 2>/dev/null))" \
-            || echo "    NOTE: GitNexus upgrade skipped (already current or failed)"
+        npm install -g gitnexus@1.6.4 2>/dev/null \
+            && echo "    + GitNexus pin enforced ($(gitnexus --version 2>/dev/null))" \
+            || echo "    NOTE: GitNexus pin enforcement skipped (already at 1.6.4 or failed)"
     fi
 fi
 


### PR DESCRIPTION
## Summary

#299 added auto-upgrade for codebase-memory-mcp and serena but
explicitly skipped GitNexus because it was on a prerelease channel.
GitNexus `1.6.4` stable shipped on 2026-05-10, so the same pattern
now applies — install if missing, upgrade unconditionally otherwise,
so existing installs pick up new releases without manual intervention.

## Why exact `1.6.4` pin?

Only ship versions we've actually verified in production. A range
pin (e.g. `~1.6`) would auto-pull 1.6.5-rc.* and future 1.6.5 stable
as soon as published, bypassing the verification step. Exact 1.6.4
makes any future bump an explicit decision in a follow-up PR, not
an automatic side-effect of running bootstrap.

Bumping past 1.7 specifically also requires re-verifying the FTS
read-blocking issues earlier 1.7 prereleases had.

## Files

- `scripts/bootstrap.sh` — install gitnexus if missing, enforce the
  pin otherwise.
- `scripts/install.sh` — same change for the fresh-install path.

## Test plan

- [x] `bash -n scripts/bootstrap.sh` — syntax OK
- [x] `bash -n scripts/install.sh` — syntax OK
- [x] Verified locally: `npm install -g gitnexus@1.6.4` upgrades
      `1.6.4-rc.21` → `1.6.4` cleanly, and `gitnexus analyze --force`
      then indexes correctly (37,105 nodes / 58,975 edges,
      indexed_commit matches current).

🤖 Generated with [Claude Code](https://claude.com/claude-code)