### PR TITLE
feat(db): add since + proposal_type filters to evolution_proposals.list_pending

### DIFF
--- a/src/genesis/db/crud/evolution_proposals.py
+++ b/src/genesis/db/crud/evolution_proposals.py
@@ -63,14 +63,26 @@ async def list_pending(
     db: aiosqlite.Connection,
     *,
     limit: int = 10,
+    since: str | None = None,
+    proposal_type: str | None = None,
 ) -> list[dict]:
-    """List pending proposals, newest first."""
-    cursor = await db.execute(
-        """SELECT * FROM evolution_proposals
-           WHERE status = 'pending'
-           ORDER BY created_at DESC LIMIT ?""",
-        (limit,),
-    )
+    """List pending proposals, newest first.
+
+    Optional filters (both backward-compatible — None = no filter):
+    - ``since``: ISO-8601 timestamp; only proposals created at or after.
+    - ``proposal_type``: restrict to a single proposal_type value.
+    """
+    sql = "SELECT * FROM evolution_proposals WHERE status = 'pending'"
+    params: list = []
+    if since is not None:
+        sql += " AND created_at >= ?"
+        params.append(since)
+    if proposal_type is not None:
+        sql += " AND proposal_type = ?"
+        params.append(proposal_type)
+    sql += " ORDER BY created_at DESC LIMIT ?"
+    params.append(limit)
+    cursor = await db.execute(sql, params)
     rows = await cursor.fetchall()
     columns = [desc[0] for desc in cursor.description]
     return [dict(zip(columns, row, strict=False)) for row in rows]

--- a/tests/test_db/test_knowledge_crud.py
+++ b/tests/test_db/test_knowledge_crud.py
@@ -361,3 +361,39 @@ async def test_proposal_list_pending(db):
     pending = await evolution_proposals.list_pending(db)
     assert len(pending) == 1
     assert pending[0]["proposal_type"] == "a"
+
+
+async def test_proposal_list_pending_filters(db):
+    """`since` and `proposal_type` filters narrow the pending list."""
+    pid_a = await evolution_proposals.create(
+        db, proposal_type="alpha", current_content="x",
+        proposed_change="y", rationale="z",
+    )
+    pid_b = await evolution_proposals.create(
+        db, proposal_type="beta", current_content="x",
+        proposed_change="y", rationale="z",
+    )
+
+    # proposal_type filter
+    alphas = await evolution_proposals.list_pending(db, proposal_type="alpha")
+    assert len(alphas) == 1
+    assert alphas[0]["id"] == pid_a
+
+    betas = await evolution_proposals.list_pending(db, proposal_type="beta")
+    assert len(betas) == 1
+    assert betas[0]["id"] == pid_b
+
+    # since filter — far-future timestamp filters everything out
+    none = await evolution_proposals.list_pending(db, since="9999-01-01T00:00:00+00:00")
+    assert none == []
+
+    # since filter — far-past returns all pending
+    all_pending = await evolution_proposals.list_pending(db, since="1970-01-01T00:00:00+00:00")
+    assert len(all_pending) == 2
+
+    # combined filters
+    only_alpha = await evolution_proposals.list_pending(
+        db, since="1970-01-01T00:00:00+00:00", proposal_type="alpha",
+    )
+    assert len(only_alpha) == 1
+    assert only_alpha[0]["id"] == pid_a


### PR DESCRIPTION
## Summary
- Adds optional `since` and `proposal_type` keyword args to `evolution_proposals.list_pending()`
- Both default to `None` — fully backward-compatible
- New test `test_proposal_list_pending_filters` covers all branches; existing test still passes

## Why
The existing `list_pending()` returns every pending proposal, forcing callers that need to scope by date or type to filter in Python after fetching — wasteful when the proposal table grows. These two filters are the obvious narrowings; doing them in SQL is one branch each.

## Test plan
- [x] `pytest tests/test_db/test_knowledge_crud.py -v -k list_pending` — passes (existing + new test)
- [x] Manual: confirm signature is backward-compatible (no positional args added; both new args keyword-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)