### PR TITLE
docs(modules): clarify domain framing — observers of Genesis are also valid

### DIFF
--- a/src/genesis/modules/base.py
+++ b/src/genesis/modules/base.py
@@ -7,12 +7,20 @@ from typing import Any, Protocol, runtime_checkable
 
 @runtime_checkable
 class CapabilityModule(Protocol):
-    """A pluggable external capability for Genesis.
+    """A pluggable capability for Genesis.
 
-    Modules are external domain capabilities (crypto trading, prediction markets,
-    prospecting, etc.) that leverage Genesis's cognitive services without modifying
-    core. They are "hands, not brain" — they can be plugged in and unplugged
-    without affecting Genesis identity, reflection, or learning.
+    Modules are pluggable capabilities that operate on a domain. The domain is
+    typically external (crypto trading, prediction markets, prospecting, etc.),
+    but the same plug-and-unplug contract also covers components whose target
+    of inspection is Genesis itself — auditors, monitors, and other observers
+    that don't participate in Genesis's cognitive operations.
+
+    The unifying property is "hands, not brain" — modules can be plugged in
+    and unplugged without affecting Genesis identity, reflection, or learning.
+    A module may *observe* Genesis's state, but it does not *think with* it:
+    no memory writes, no reflection contribution, no ego role. Components that
+    participate in Genesis's cognitive operations belong elsewhere (memory,
+    reflection, ego, sentinel) — not in modules.
 
     ## Implementing a Native Module
 


### PR DESCRIPTION
## Summary
- Sharpens the `CapabilityModule` docstring in `src/genesis/modules/base.py`
- The original framing — "external domain capabilities" — excluded a legitimate use case: modules whose target of inspection is Genesis itself (auditors, monitors, observers)
- Updated framing keeps the "hands, not brain" boundary intact: a module may *observe* Genesis's state but does not *think with* it (no memory writes, no reflection contribution, no ego role)
- Pure docs change. No code touched.

## Why
The principle wasn't wrong — it just under-described the boundary. Future contributors may reasonably want to add a module that watches Genesis's own state (job-health auditor, schema linter, etc.). The original wording would have made them feel like that violates the principle, when it actually doesn't.

## Test plan
- [x] No code changed; nothing to test
- [ ] Reviewer reads the new wording and confirms it doesn't loosen the principle in ways that would let a "brain" component sneak in as a module

🤖 Generated with [Claude Code](https://claude.com/claude-code)