### PR TITLE
fix(routing): keep call sites visible when chain has no API keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,24 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   off automatically, in line with the existing rules for non-critical
   background work.
 
+### Fixed
+
+- **Call sites with no API key stay visible on the dashboard.**
+  Previously, a call site whose entire provider chain had no API key
+  configured was silently dropped from `cfg.call_sites` at startup,
+  making it invisible everywhere (dashboard, routing API, health
+  snapshot). On a partially-configured install (some keys set, some
+  empty) you couldn't tell which call sites were unreachable or what
+  you needed to add. Keyless providers now stay registered with
+  `has_api_key=False`; the router skips them at routing time exactly
+  the way it skips a tripped circuit breaker, and the neural monitor
+  shows the call site with a red **NO API KEY CONFIGURED** badge plus
+  a banner naming the env vars (`API_KEY_<TYPE>`) that would enable
+  it. Partial API-key configuration is the normal install state, not
+  a bug --- it should be discoverable. Sentinel does not alert on
+  these sites (existing filter for `wired:False`/`disabled`/no
+  `last_run_at` covers it).
+
 ### Migrations
 
 - **0014_eval_results_metadata** --- adds a `metadata_json` TEXT

--- a/docs/reference/call-site-audit.md
+++ b/docs/reference/call-site-audit.md
@@ -3,7 +3,7 @@
 Comprehensive audit of all 44 neural monitor call sites. Verified against
 live code traces, routing config, and last_run database records.
 
-**2026-05-1X update:** Silent-drop fix for keyless call sites.
+**2026-05-10 update:** Silent-drop fix for keyless call sites.
 - Partial API-key configuration is now treated as a first-class normal state, not a load-time filter condition. Previously, the config loader auto-disabled any provider whose API key env var was unset/empty AND filtered those providers out of every chain. Sites whose entire chain was keyless were dropped from `cfg.call_sites` entirely — invisible everywhere downstream (neural monitor, routing API, health snapshot). On a partially-configured install (the normal install state), this masked which sites were unreachable and what env vars would unblock them.
 - New behaviour: keyless providers stay registered in `cfg.providers` with `has_api_key=False`. The router skips them in chain walk the same way it skips a tripped breaker — no LiteLLM call, no failure record, no CB trip. The snapshot surfaces `has_api_key=False` + `missing_env_var` on each chain entry; when every entry in a chain is keyless, the site cascades to `status="disabled"` with `status_reason="NO_API_KEYS"`, rendered as a red badge in the neural monitor with a banner naming the env vars (`API_KEY_<TYPE>`) that would enable it.
 - `ProviderConfig` gains a `has_api_key: bool = True` field, set at parse time. The `_provider_health()` snapshot helper returns `"disabled"` for `has_api_key=False` (defense-in-depth alongside the existing `probe_status="not_configured"` path that fires once probes have run).

--- a/docs/reference/call-site-audit.md
+++ b/docs/reference/call-site-audit.md
@@ -3,6 +3,12 @@
 Comprehensive audit of all 44 neural monitor call sites. Verified against
 live code traces, routing config, and last_run database records.
 
+**2026-05-1X update:** Silent-drop fix for keyless call sites.
+- Partial API-key configuration is now treated as a first-class normal state, not a load-time filter condition. Previously, the config loader auto-disabled any provider whose API key env var was unset/empty AND filtered those providers out of every chain. Sites whose entire chain was keyless were dropped from `cfg.call_sites` entirely — invisible everywhere downstream (neural monitor, routing API, health snapshot). On a partially-configured install (the normal install state), this masked which sites were unreachable and what env vars would unblock them.
+- New behaviour: keyless providers stay registered in `cfg.providers` with `has_api_key=False`. The router skips them in chain walk the same way it skips a tripped breaker — no LiteLLM call, no failure record, no CB trip. The snapshot surfaces `has_api_key=False` + `missing_env_var` on each chain entry; when every entry in a chain is keyless, the site cascades to `status="disabled"` with `status_reason="NO_API_KEYS"`, rendered as a red badge in the neural monitor with a banner naming the env vars (`API_KEY_<TYPE>`) that would enable it.
+- `ProviderConfig` gains a `has_api_key: bool = True` field, set at parse time. The `_provider_health()` snapshot helper returns `"disabled"` for `has_api_key=False` (defense-in-depth alongside the existing `probe_status="not_configured"` path that fires once probes have run).
+- Sentinel does NOT alert on `NO_API_KEYS` sites — the existing Tier 1 filter for `wired:False / disabled / no last_run` covers it.
+
 **2026-05-10 update:** Routing-config cleanup pass.
 - Removed `2_triage` from YAML (awareness loop's `classify_depth()` superseded it; meta entry retained as historical reference).
 - Removed `7_task_retrospective` from YAML — confirmed duplicate; the executor went live with `43_task_retrospective` and `7_*` was forgotten.

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -926,13 +926,25 @@ function showDetail(item) {
                 ul.style.cssText = 'margin:4px 0 0 0;padding-left:18px;';
                 missing.forEach(c => {
                     const li = el('li', null);
-                    li.innerHTML = '<code style="color:#fde68a">' + c.missing_env_var + '</code>'
-                        + ' — ' + (c.provider || '') + ' (' + (c.type || '') + ')';
+                    const code = el('code', null, c.missing_env_var || '');
+                    code.style.color = '#fde68a';
+                    li.appendChild(code);
+                    li.appendChild(document.createTextNode(
+                        ' — ' + (c.provider || '') + ' (' + (c.type || '') + ')',
+                    ));
                     ul.appendChild(li);
                 });
                 list.appendChild(ul);
-                const note = el('div', null,
-                    'Genesis also accepts <code>&lt;TYPE&gt;_API_KEY</code> or <code>&lt;TYPE&gt;_API_TOKEN</code> if your install uses a different convention.');
+                const note = el('div', null);
+                note.appendChild(document.createTextNode('Genesis also accepts '));
+                const alt1 = el('code', null, '<TYPE>_API_KEY');
+                note.appendChild(alt1);
+                note.appendChild(document.createTextNode(' or '));
+                const alt2 = el('code', null, '<TYPE>_API_TOKEN');
+                note.appendChild(alt2);
+                note.appendChild(document.createTextNode(
+                    ' if your install uses a different convention.',
+                ));
                 note.style.cssText = 'margin-top:6px;color:#a8a29e;font-size:10px;';
                 list.appendChild(note);
                 banner.appendChild(list);

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -871,7 +871,7 @@ function showDetail(item) {
             SUPERSEDED: 'SUPERSEDED',
             TEMP_DISABLED: 'TEMPORARILY DISABLED',
             REPLACED_BY_AWARENESS_LOOP: 'REPLACED BY AWARENESS LOOP',
-            NO_API_KEYS: 'NO API KEY CONFIGURED',
+            NO_API_KEYS: 'NO API KEY CONFIGURED',  // pragma: allowlist secret
         };
         const REASON_CLASS = {
             WIRED: 'badge-normal',
@@ -882,7 +882,7 @@ function showDetail(item) {
             SUPERSEDED: 'badge-disabled',
             TEMP_DISABLED: 'badge-warning',
             REPLACED_BY_AWARENESS_LOOP: 'badge-disabled',
-            NO_API_KEYS: 'badge-critical',
+            NO_API_KEYS: 'badge-critical',  // pragma: allowlist secret
         };
         const reasonWrap = el('div', 'detail-status-reason');
         const reasonBadge = el('span', 'badge ' + (REASON_CLASS[statusReason] || 'badge'),

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -871,6 +871,7 @@ function showDetail(item) {
             SUPERSEDED: 'SUPERSEDED',
             TEMP_DISABLED: 'TEMPORARILY DISABLED',
             REPLACED_BY_AWARENESS_LOOP: 'REPLACED BY AWARENESS LOOP',
+            NO_API_KEYS: 'NO API KEY CONFIGURED',
         };
         const REASON_CLASS = {
             WIRED: 'badge-normal',
@@ -881,6 +882,7 @@ function showDetail(item) {
             SUPERSEDED: 'badge-disabled',
             TEMP_DISABLED: 'badge-warning',
             REPLACED_BY_AWARENESS_LOOP: 'badge-disabled',
+            NO_API_KEYS: 'badge-critical',
         };
         const reasonWrap = el('div', 'detail-status-reason');
         const reasonBadge = el('span', 'badge ' + (REASON_CLASS[statusReason] || 'badge'),
@@ -907,11 +909,37 @@ function showDetail(item) {
         banner.style.cssText = 'background:rgba(136,136,136,0.15);color:#888;padding:6px 10px;border-radius:4px;font-size:11px;margin:8px 0;';
         content.appendChild(banner);
     } else if (item.status === 'disabled') {
-        const reason = item.data.disabled_reason === 'no_api_keys_configured'
-            ? 'No API key configured for any provider in this chain. This is a deployment-time config state, not an outage. Add the relevant API keys to secrets.env to enable.'
-            : 'This call site is disabled.';
-        const banner = el('div', null, reason);
-        banner.style.cssText = 'background:rgba(136,136,136,0.15);color:#888;padding:6px 10px;border-radius:4px;font-size:11px;margin:8px 0;';
+        const banner = el('div', null);
+        banner.style.cssText = 'background:rgba(153,27,27,0.15);color:#fca5a5;padding:8px 10px;border-radius:4px;font-size:11px;margin:8px 0;line-height:1.5;';
+        if (item.data.disabled_reason === 'no_api_keys_configured') {
+            const intro = el('div', null,
+                'No API key configured for any provider in this chain. This is a deployment-time config state, not an outage — partial API-key configuration is the normal install state.');
+            banner.appendChild(intro);
+            // Enumerate missing env vars from chain_health
+            const chain = item.data.chain_health || [];
+            const missing = chain.filter(c => c.missing_env_var);
+            if (missing.length > 0) {
+                const list = el('div', null);
+                list.style.cssText = 'margin-top:6px;';
+                list.appendChild(el('div', null, 'Configure one of these in secrets.env to enable:'));
+                const ul = el('ul', null);
+                ul.style.cssText = 'margin:4px 0 0 0;padding-left:18px;';
+                missing.forEach(c => {
+                    const li = el('li', null);
+                    li.innerHTML = '<code style="color:#fde68a">' + c.missing_env_var + '</code>'
+                        + ' — ' + (c.provider || '') + ' (' + (c.type || '') + ')';
+                    ul.appendChild(li);
+                });
+                list.appendChild(ul);
+                const note = el('div', null,
+                    'Genesis also accepts <code>&lt;TYPE&gt;_API_KEY</code> or <code>&lt;TYPE&gt;_API_TOKEN</code> if your install uses a different convention.');
+                note.style.cssText = 'margin-top:6px;color:#a8a29e;font-size:10px;';
+                list.appendChild(note);
+                banner.appendChild(list);
+            }
+        } else {
+            banner.textContent = 'This call site is disabled.';
+        }
         content.appendChild(banner);
     }
     // Warning/failure details

--- a/src/genesis/eval/cli.py
+++ b/src/genesis/eval/cli.py
@@ -202,6 +202,7 @@ async def _cmd_benchmark(args: argparse.Namespace) -> int:
         providers = [
             name for name, cfg in sorted(config.providers.items())
             if getattr(cfg, "enabled", True)  # skip explicitly disabled
+            and getattr(cfg, "has_api_key", True)  # skip keyless — eval would 401
             and (args.include_paid or cfg.is_free)
         ]
 

--- a/src/genesis/eval/runner.py
+++ b/src/genesis/eval/runner.py
@@ -97,6 +97,13 @@ async def run_eval(
         )
 
     provider_cfg = config.providers[provider_name]
+    if not provider_cfg.has_api_key:
+        raise ValueError(
+            f"provider '{provider_name}' has no API key configured — "
+            f"set API_KEY_{provider_cfg.provider_type.upper()} (or "
+            f"{provider_cfg.provider_type.upper()}_API_KEY / "
+            f"{provider_cfg.provider_type.upper()}_API_TOKEN) in secrets.env"
+        )
     delegate = LiteLLMDelegate(config)
 
     # Set up rate gate if provider has an RPM limit

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -14,8 +14,13 @@ Fields:
   model_tier:     What class of model this needs (embedding/slm/mid/frontier/cc)
   status_reason:  Machine-readable status (WIRED, WIRED_DIFFERENT_MECHANISM,
                   PARTIALLY_WIRED, V4_PLACEHOLDER, DEPRECATED_REMOVED,
-                  SUPERSEDED, TEMP_DISABLED, REPLACED_BY_AWARENESS_LOOP).
+                  SUPERSEDED, TEMP_DISABLED, REPLACED_BY_AWARENESS_LOOP,
+                  NO_API_KEYS [runtime overlay, install-specific]).
                   Renders as a colored badge in the neural monitor.
+                  NO_API_KEYS is set at snapshot time by call_sites.py
+                  when every provider in a site's chain has has_api_key=False;
+                  intrinsic statuses defined in _CALL_SITE_META take
+                  precedence (setdefault).
   see_also:       Sibling call-site IDs to cross-reference. Populated for
                   confusable-vocabulary families. Rendered as clickable
                   links in the neural monitor detail panel.

--- a/src/genesis/observability/snapshots/call_sites.py
+++ b/src/genesis/observability/snapshots/call_sites.py
@@ -101,6 +101,17 @@ async def call_sites(
             if pcfg:
                 entry["type"] = pcfg.provider_type
                 entry["model"] = pcfg.model_id
+                # Surface "no API key" as a first-class chain entry state so
+                # the dashboard can render a dimmed chip with a tooltip
+                # naming the env var that would enable it. has_api_key is a
+                # load-time check; works on cold start before any probe
+                # has run. Probes (provider_health.py) overlay the same
+                # state via probe_status="not_configured" once they execute.
+                if not pcfg.has_api_key:
+                    entry["has_api_key"] = False
+                    entry["missing_env_var"] = (
+                        f"API_KEY_{pcfg.provider_type.upper()}"
+                    )
             chain_health.append(entry)
 
             if state not in (ProviderState.OPEN, ProviderState.HALF_OPEN):
@@ -283,6 +294,11 @@ async def call_sites(
             # deployment-time config state, NOT an infrastructure alert.
             site_data["status"] = "disabled"
             site_data["disabled_reason"] = "no_api_keys_configured"
+            # Machine-readable status for the neural monitor badge.
+            # Preserve any pre-existing status_reason from _CALL_SITE_META
+            # (e.g., V4_PLACEHOLDER) — that's intrinsic to the call site,
+            # NO_API_KEYS is a runtime overlay specific to this install.
+            site_data.setdefault("status_reason", "NO_API_KEYS")
             continue
 
         prev_status = site_data.get("status")
@@ -316,6 +332,12 @@ def _provider_health(entry: dict) -> str:
     it crashed. Callers should filter disabled providers out of routing
     decisions rather than treating them as failures.
     """
+    # Load-time has_api_key check (set by config loader). Works on cold
+    # start before any probe runs. Probe overlay (probe_status) catches
+    # the same case once probes execute — having both gives belt-and-
+    # suspenders coverage.
+    if entry.get("has_api_key") is False:
+        return "disabled"
     # Probe says "no API key" — provider is disabled by config, not broken
     ps = entry.get("probe_status")
     if ps == "not_configured":

--- a/src/genesis/routing/config.py
+++ b/src/genesis/routing/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import dataclasses
 import logging
 import os
 import re
@@ -218,13 +219,19 @@ def _parse(raw: dict, *, check_api_keys: bool = True) -> RoutingConfig:
             profile=p.get("profile"),
         )
 
-        # Auto-disable providers with no API key configured.  Local
-        # providers (ollama, lmstudio) don't need keys.
+        # Keyless providers stay registered with has_api_key=False. The
+        # router treats them as down (same code path as a tripped
+        # breaker), and the snapshot surfaces them as "disabled" so the
+        # dashboard can show "NO API KEY CONFIGURED". Partial API-key
+        # configuration is the normal install state, not an error — call
+        # sites whose chain depends on keyless providers stay visible so
+        # users can see what they need to enable.
         if check_api_keys and not has_api_key(cfg):
-            disabled_providers.add(name)
-            disabled_provider_types[name] = cfg.provider_type
-            logger.info("Provider '%s' disabled: no API key configured", name)
-            continue
+            cfg = dataclasses.replace(cfg, has_api_key=False)
+            logger.info(
+                "Provider '%s' has no API key configured — staying registered as down",
+                name,
+            )
 
         providers[name] = cfg
 
@@ -232,7 +239,11 @@ def _parse(raw: dict, *, check_api_keys: bool = True) -> RoutingConfig:
     call_sites: dict[str, CallSiteConfig] = {}
     for name, cs in (raw.get("call_sites") or {}).items():
         chain = cs["chain"]
-        # Filter out disabled providers from chain
+        # Chains stay intact — keyless providers are NOT filtered. The
+        # router skips them at routing time (treats them as down).
+        # disabled_providers is still filtered (explicit `enabled: false`
+        # in YAML is a deliberate user choice; chains referencing those
+        # providers would fail validation otherwise).
         chain = [p for p in chain if p not in disabled_providers]
         dispatch = _normalize_dispatch(cs.get("dispatch"), call_site_name=name)
 
@@ -241,7 +252,8 @@ def _parse(raw: dict, *, check_api_keys: bool = True) -> RoutingConfig:
             # spawn CC sessions directly.  An empty chain is valid for them.
             if dispatch != "cli":
                 logger.warning(
-                    "Call site '%s' has no enabled providers — all were disabled", name,
+                    "Call site '%s' has empty chain after `enabled: false` filter — dropping",
+                    name,
                 )
                 continue
             logger.info(

--- a/src/genesis/routing/router.py
+++ b/src/genesis/routing/router.py
@@ -199,6 +199,14 @@ class Router:
         for provider_name in chain:
             provider_cfg = self.config.providers[provider_name]
 
+            # Skip providers with no API key — treat as down-by-config.
+            # Same effect as a tripped CB: no LiteLLM call, no failure
+            # record, no CB trip. Partial API-key configuration is the
+            # normal install state on freshly-installed systems.
+            if not provider_cfg.has_api_key:
+                failed_providers.append(provider_name)
+                continue
+
             # Skip if circuit breaker is open
             cb = self.breakers.get(provider_name)
             if not cb.is_available():

--- a/src/genesis/routing/types.py
+++ b/src/genesis/routing/types.py
@@ -47,6 +47,12 @@ class ProviderConfig:
     keep_alive: str | int | None = None
     enabled: bool = True
     profile: str | None = None
+    # False when no API key env var is configured for this provider.
+    # Set by the config loader at parse time. Router treats False as
+    # down-by-config (skip in chain walk, no LiteLLM call, no CB trip),
+    # mirroring the behaviour for a tripped breaker. Snapshot surfaces
+    # this so partially-configured installs see the state on the dashboard.
+    has_api_key: bool = True
 
 
 @dataclass(frozen=True)

--- a/tests/test_health_data.py
+++ b/tests/test_health_data.py
@@ -394,6 +394,123 @@ class TestDisabledChainSemantics:
         assert chain[0]["probe_status"] == "not_configured"
         assert chain[0]["probe_reason"] == "no_api_key"
 
+    @pytest.mark.asyncio
+    async def test_keyless_provider_surfaces_in_chain_health(self):
+        """Load-time has_api_key=False must surface as has_api_key field +
+        missing_env_var in the chain entry. Works WITHOUT probe data
+        (cold start, no probe has run yet).
+        """
+        import dataclasses
+
+        from genesis.observability.snapshots.call_sites import call_sites
+
+        providers = {
+            "claude-sonnet": dataclasses.replace(
+                _make_provider("claude-sonnet"),
+                provider_type="anthropic",
+                has_api_key=False,
+            ),
+        }
+        config = _make_config(providers, {
+            "test_site": CallSiteConfig(id="test_site", chain=["claude-sonnet"]),
+        })
+        breakers = _mock_registry({
+            "claude-sonnet": _mock_breaker(ProviderState.CLOSED),
+        })
+        # No probe_results — cold-start condition
+        result = await call_sites(
+            db=None, routing_config=config, breakers=breakers,
+            probe_results=None,
+        )
+        chain = result["test_site"]["chain_health"]
+        assert chain[0]["has_api_key"] is False
+        assert chain[0]["missing_env_var"] == "API_KEY_ANTHROPIC"
+
+    @pytest.mark.asyncio
+    async def test_keyless_chain_cascades_to_disabled_no_probes(self):
+        """Cold-start (no probe data) with all-keyless chain → site status
+        cascades to 'disabled' with status_reason='NO_API_KEYS'.
+
+        Uses a synthetic site ID NOT in _CALL_SITE_META so meta overlay
+        doesn't interfere — sites with wired=False in meta are forced to
+        'idle' before the unified chain walk runs, which is correct
+        behavior for groundwork sites but masks the no-keys cascade.
+        """
+        import dataclasses
+
+        from genesis.observability.snapshots.call_sites import call_sites
+
+        providers = {
+            "p_zenmux": dataclasses.replace(
+                _make_provider("p_zenmux"), provider_type="zenmux", has_api_key=False,
+            ),
+            "p_anthropic": dataclasses.replace(
+                _make_provider("p_anthropic"), provider_type="anthropic", has_api_key=False,
+            ),
+        }
+        config = _make_config(providers, {
+            "active_site_with_no_keys": CallSiteConfig(
+                id="active_site_with_no_keys", chain=["p_zenmux", "p_anthropic"],
+            ),
+        })
+        breakers = _mock_registry({
+            "p_zenmux": _mock_breaker(ProviderState.CLOSED),
+            "p_anthropic": _mock_breaker(ProviderState.CLOSED),
+        })
+        result = await call_sites(
+            db=None, routing_config=config, breakers=breakers,
+            probe_results=None,
+        )
+        site = result["active_site_with_no_keys"]
+        assert site["status"] == "disabled"
+        assert site["disabled_reason"] == "no_api_keys_configured"
+        assert site["status_reason"] == "NO_API_KEYS"
+        # Both chain entries must surface their missing env var
+        env_vars = {c["missing_env_var"] for c in site["chain_health"]}
+        assert env_vars == {"API_KEY_ZENMUX", "API_KEY_ANTHROPIC"}
+
+    @pytest.mark.asyncio
+    async def test_intrinsic_status_reason_wins_over_no_api_keys(self):
+        """If _CALL_SITE_META declares an intrinsic status_reason (e.g.,
+        V4_PLACEHOLDER), the NO_API_KEYS runtime overlay must NOT
+        clobber it. Intrinsic state takes precedence — V4_PLACEHOLDER
+        means the site isn't supposed to fire yet regardless of keys.
+        """
+        import dataclasses
+        from unittest.mock import patch
+
+        from genesis.observability.snapshots.call_sites import call_sites
+
+        providers = {
+            "claude-sonnet": dataclasses.replace(
+                _make_provider("claude-sonnet"),
+                provider_type="anthropic", has_api_key=False,
+            ),
+        }
+        config = _make_config(providers, {
+            "future_site": CallSiteConfig(
+                id="future_site", chain=["claude-sonnet"],
+            ),
+        })
+        breakers = _mock_registry({
+            "claude-sonnet": _mock_breaker(ProviderState.CLOSED),
+        })
+        # Inject intrinsic meta entry. wired=True so idle override
+        # doesn't short-circuit the chain walk before NO_API_KEYS would
+        # be considered.
+        meta_override = {
+            "future_site": {"status_reason": "V4_PLACEHOLDER", "wired": True},
+        }
+        with patch(
+            "genesis.observability.snapshots.call_sites._CALL_SITE_META",
+            meta_override,
+        ):
+            result = await call_sites(
+                db=None, routing_config=config, breakers=breakers,
+                probe_results=None,
+            )
+        assert result["future_site"]["status_reason"] == "V4_PLACEHOLDER"
+
 
 class TestCallSiteTripCount:
     """Verify trip_count is exposed in chain_health entries."""

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -315,6 +315,50 @@ call_sites:
     assert cfg.call_sites["site"].chain == ["keyless", "keyed"]
 
 
+def test_mixed_disabled_and_keyless_chain():
+    """A chain mixing `enabled: false` (filtered out) + keyless (kept as
+    down) must keep the chain reference for the keyless provider while
+    dropping the explicitly-disabled one. This is the only regression
+    path where the two filters could interact incorrectly.
+    """
+    from unittest.mock import patch
+
+    def _has_key(cfg):
+        return cfg.provider_type == "ollama"
+
+    with patch(
+        "genesis.observability.snapshots.api_keys.has_api_key",
+        side_effect=_has_key,
+    ):
+        cfg = load_config_from_string("""\
+providers:
+  off:
+    type: anthropic
+    model: m
+    free: false
+    enabled: false
+  keyless:
+    type: zenmux
+    model: m
+    free: false
+  keyed:
+    type: ollama
+    model: m
+    free: true
+call_sites:
+  s:
+    chain: [off, keyless, keyed]
+""", check_api_keys=True)
+
+    # `off` is removed from cfg.providers (explicit enabled:false)
+    assert "off" not in cfg.providers
+    # keyless stays registered with has_api_key=False
+    assert cfg.providers["keyless"].has_api_key is False
+    assert cfg.providers["keyed"].has_api_key is True
+    # Chain has `off` filtered out, keyless preserved
+    assert cfg.call_sites["s"].chain == ["keyless", "keyed"]
+
+
 def test_keyless_chain_preserves_site():
     """When a site's whole chain is keyless, the site stays visible —
     no silent drop. The snapshot will mark it 'disabled' so the user

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -264,6 +264,87 @@ call_sites:
 
 
 # ---------------------------------------------------------------------------
+# Keyless providers stay registered as down (2026-05-10).
+# ---------------------------------------------------------------------------
+
+
+def test_keyless_provider_stays_registered_as_down(monkeypatch):
+    """A provider whose API key env var is unset must stay in cfg.providers
+    with has_api_key=False, NOT get filtered out at load time. The call
+    site that references it must also remain visible in cfg.call_sites
+    with its full chain intact.
+
+    This is the normal install state for partial API-key configuration —
+    the router treats keyless providers as down (same as a tripped CB),
+    and the snapshot surfaces them on the neural monitor so the user can
+    see what they need to add to enable the call site.
+    """
+    # Override the conftest autouse patch that forces has_api_key=True.
+    # We want the real check to run so we can verify the load-time
+    # marking. Local types (ollama) bypass the env check entirely.
+    from unittest.mock import patch
+
+    def _real_has_api_key(cfg):
+        return cfg.provider_type in {"ollama", "lmstudio"}
+
+    with patch(
+        "genesis.observability.snapshots.api_keys.has_api_key",
+        side_effect=_real_has_api_key,
+    ):
+        cfg = load_config_from_string("""\
+providers:
+  keyless:
+    type: anthropic
+    model: claude-haiku
+    free: false
+  keyed:
+    type: ollama
+    model: qwen2.5:3b
+    free: true
+call_sites:
+  site:
+    chain: [keyless, keyed]
+""", check_api_keys=True)
+
+    assert "keyless" in cfg.providers
+    assert cfg.providers["keyless"].has_api_key is False
+    # Local providers always have keys
+    assert cfg.providers["keyed"].has_api_key is True
+    # Call site stays visible with full chain
+    assert "site" in cfg.call_sites
+    assert cfg.call_sites["site"].chain == ["keyless", "keyed"]
+
+
+def test_keyless_chain_preserves_site():
+    """When a site's whole chain is keyless, the site stays visible —
+    no silent drop. The snapshot will mark it 'disabled' so the user
+    knows it's not running, but it's reachable in the dashboard.
+    """
+    from unittest.mock import patch
+
+    # All providers come back as keyless
+    with patch("genesis.observability.snapshots.api_keys.has_api_key", return_value=False):
+        cfg = load_config_from_string("""\
+providers:
+  p1:
+    type: anthropic
+    model: claude-sonnet
+    free: false
+  p2:
+    type: zenmux
+    model: glm-4.5
+    free: false
+call_sites:
+  only_keyless:
+    chain: [p1, p2]
+""", check_api_keys=True)
+
+    assert "only_keyless" in cfg.call_sites
+    assert cfg.call_sites["only_keyless"].chain == ["p1", "p2"]
+    assert all(not cfg.providers[p].has_api_key for p in ["p1", "p2"])
+
+
+# ---------------------------------------------------------------------------
 # F1: ``dispatch`` field parsing on CallSiteConfig.
 # ---------------------------------------------------------------------------
 

--- a/tests/test_routing/test_router.py
+++ b/tests/test_routing/test_router.py
@@ -150,6 +150,84 @@ async def test_skips_open_breaker(sample_config, breakers, cost_tracker, degrada
 
 
 @pytest.mark.asyncio
+async def test_skips_keyless_provider(
+    sample_providers, breakers, cost_tracker, degradation,
+):
+    """A provider with has_api_key=False must be skipped without ever
+    calling the delegate — same effect as a tripped breaker, but driven
+    by config rather than runtime state. No CB trip, no failure record.
+    """
+    import dataclasses
+
+    from genesis.routing.types import CallSiteConfig, RetryPolicy, RoutingConfig
+
+    # Mark free-1 as keyless
+    providers = dict(sample_providers)
+    providers["free-1"] = dataclasses.replace(providers["free-1"], has_api_key=False)
+
+    config = RoutingConfig(
+        providers=providers,
+        call_sites={
+            "test_keyless": CallSiteConfig(id="test_keyless", chain=["free-1", "free-2"]),
+        },
+        retry_profiles={"default": RetryPolicy(max_retries=1, base_delay_ms=10, jitter_pct=0.0)},
+    )
+
+    delegate = MockDelegate()
+    router = Router(
+        config=config, breakers=breakers, cost_tracker=cost_tracker,
+        degradation=degradation, delegate=delegate,
+    )
+    result = await router.route_call("test_keyless", [{"role": "user", "content": "hi"}])
+
+    # Successful routing — free-2 handled it
+    assert result.success is True
+    assert result.provider_used == "free-2"
+    # free-1 must never have been called
+    assert all(c["provider"] != "free-1" for c in delegate.calls)
+    # free-1's CB must NOT have tripped — we never tried, never failed
+    assert breakers.get("free-1").consecutive_failures == 0
+    assert breakers.get("free-1").trip_count == 0
+
+
+@pytest.mark.asyncio
+async def test_all_keyless_chain_returns_exhausted(
+    sample_providers, breakers, cost_tracker, degradation,
+):
+    """If every provider in the chain is keyless, routing fails with the
+    standard exhausted-chain error — no LiteLLM calls, no CB trips.
+    """
+    import dataclasses
+
+    from genesis.routing.types import CallSiteConfig, RetryPolicy, RoutingConfig
+
+    providers = {
+        name: dataclasses.replace(cfg, has_api_key=False)
+        for name, cfg in sample_providers.items()
+    }
+    config = RoutingConfig(
+        providers=providers,
+        call_sites={
+            "all_keyless": CallSiteConfig(id="all_keyless", chain=["free-1", "free-2"]),
+        },
+        retry_profiles={"default": RetryPolicy(max_retries=1, base_delay_ms=10, jitter_pct=0.0)},
+    )
+    delegate = MockDelegate()
+    router = Router(
+        config=config, breakers=breakers, cost_tracker=cost_tracker,
+        degradation=degradation, delegate=delegate,
+    )
+    result = await router.route_call("all_keyless", [{"role": "user", "content": "hi"}])
+
+    assert result.success is False
+    # No CB trips on any provider
+    for name in providers:
+        assert breakers.get(name).trip_count == 0
+    # Delegate was never called
+    assert len(delegate.calls) == 0
+
+
+@pytest.mark.asyncio
 async def test_degradation_skips_call_site(sample_config, breakers, cost_tracker, degradation):
     """At L2 degradation, surplus call sites are skipped."""
     degradation.update(DegradationLevel.REDUCED)


### PR DESCRIPTION
## Summary

- Partial API-key configuration is a first-class normal state, not a silent-drop condition. Keyless providers stay registered with new `has_api_key=False`; router skips them in chain walk the same way it skips a tripped breaker (no LiteLLM call, no failure record, no CB trip).
- Neural monitor shows previously-invisible call sites with a red **NO API KEY CONFIGURED** badge plus a banner enumerating the env vars (`API_KEY_<TYPE>` + alternate conventions) that would enable them.
- Existing site-level cascade (`disabled_reason="no_api_keys_configured"`) drives a new `status_reason="NO_API_KEYS"`. Intrinsic statuses from `_CALL_SITE_META` (`V4_PLACEHOLDER`, etc.) take precedence over the runtime overlay.

Before: on a partially-configured install, every call site whose chain depended on an unconfigured provider type vanished from the dashboard, routing API, and health snapshot. Users had no way to discover what was unreachable or how to fix it.

After: same call sites stay visible, marked disabled, with a list of the env vars to add. Sentinel does not alert on these sites (existing `wired:False`/`disabled`/no-`last_run` filter covers it).

## Test plan

- [x] `pytest tests/test_routing/ tests/test_health_data.py tests/test_eval/` — 350 tests pass
- [x] `ruff check .` clean
- [x] New tests: `test_keyless_provider_stays_registered_as_down`, `test_keyless_chain_preserves_site`, `test_mixed_disabled_and_keyless_chain`, `test_skips_keyless_provider`, `test_all_keyless_chain_returns_exhausted`, `test_keyless_provider_surfaces_in_chain_health`, `test_keyless_chain_cascades_to_disabled_no_probes`, `test_intrinsic_status_reason_wins_over_no_api_keys`
- [x] Loader smoke test: with current secrets.env, `len(cfg.providers) == 28`, `len(cfg.call_sites) == 43`, 7 keyless providers correctly marked
- [x] Router skip verified: no CB trip on keyless providers
- [ ] Live dashboard restart + visual confirmation that previously-invisible call sites appear with the red badge + env-var banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)