### PR TITLE
fix(memory): per-collection FTS5 + intent-driven default source

### DIFF
--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -42,7 +42,7 @@ def _increment_retrieved(qdrant, results) -> None:
 @mcp.tool()
 async def memory_recall(
     query: str,
-    source: str = "both",
+    source: str | None = None,
     limit: int = 10,
     min_activation: float = 0.0,
     compact: bool = False,
@@ -56,6 +56,10 @@ async def memory_recall(
     """Hybrid search: Qdrant vectors + FTS5, RRF fusion, with optional graph enrichment.
 
     Args:
+        source: 'episodic' | 'knowledge' | 'both' | None. When None
+            (default), classify_intent() routes the query to the best
+            pool: WHY/WHEN/WHERE/STATUS → episodic; WHAT/HOW/GENERAL
+            → both. Pass an explicit value to force a specific pool.
         compact: If True, return lightweight previews only (memory_id, preview,
             score, wing, room, memory_class, source). Use memory_expand to
             fetch full content for specific IDs. Saves tokens and ~500ms.
@@ -81,6 +85,15 @@ async def memory_recall(
     memory_mod = _memory_mod()
     memory_mod._require_init()
     assert memory_mod._retriever is not None and memory_mod._db is not None
+
+    # Resolve source=None to the intent-recommended pool here, before
+    # dispatching to retriever or drift_recall. Both consumers expect a
+    # concrete string; HybridRetriever.recall accepts None but the drift
+    # path uses dict.get(source, [...]) which would silently return the
+    # default branch for None.
+    if source is None:
+        from genesis.memory.intent import classify_intent
+        source = classify_intent(query).recommended_source
 
     pipeline_used = mode  # track which pipeline actually ran
 

--- a/src/genesis/memory/intent.py
+++ b/src/genesis/memory/intent.py
@@ -30,6 +30,29 @@ class QueryIntent:
     category: str  # WHAT, WHY, HOW, WHEN, WHERE, STATUS, GENERAL
     confidence: float  # 0.0-1.0
     matched_pattern: str  # pattern that triggered (debug/logging)
+    # 'episodic' | 'knowledge' | 'both'. Defaults to 'both' so existing
+    # tests / call sites that construct QueryIntent without specifying
+    # source continue to work; classify_intent() sets it explicitly per
+    # category via _INTENT_TO_SOURCE.
+    recommended_source: str = "both"
+
+
+# Map intent categories to the recall source that's most likely to ground
+# the query. Internal lookups (WHY/WHEN/WHERE/STATUS) almost always live
+# in episodic memory — past decisions, timelines, current state. WHAT and
+# HOW can go either way: "what is X" might be a knowledge_base entry,
+# but "what did we decide about X" is episodic. We default WHAT/HOW to
+# "both" rather than guess wrong, and let RRF + activation sort it out.
+# GENERAL queries have no signal — keep "both".
+_INTENT_TO_SOURCE: dict[str, str] = {
+    "WHY": "episodic",
+    "WHEN": "episodic",
+    "WHERE": "episodic",
+    "STATUS": "episodic",
+    "WHAT": "both",
+    "HOW": "both",
+    "GENERAL": "both",
+}
 
 
 @dataclass(frozen=True)
@@ -108,11 +131,18 @@ INTENT_PROFILES: dict[str, IntentProfile] = {
 def classify_intent(query: str) -> QueryIntent:
     """Classify query intent using compiled regex patterns.
 
-    Returns GENERAL with confidence 0.0 if no pattern matches.
+    Returns GENERAL with confidence 0.0 if no pattern matches. The
+    ``recommended_source`` field is derived from the category via
+    ``_INTENT_TO_SOURCE`` — callers that defer to intent (passing
+    ``source=None`` to ``HybridRetriever.recall``) use this to route
+    the query toward the right pool.
     """
     cleaned = query.strip()
     if not cleaned:
-        return QueryIntent(category="GENERAL", confidence=0.0, matched_pattern="")
+        return QueryIntent(
+            category="GENERAL", confidence=0.0, matched_pattern="",
+            recommended_source=_INTENT_TO_SOURCE["GENERAL"],
+        )
 
     for category, pattern, confidence in _INTENT_PATTERNS:
         match = pattern.search(cleaned)
@@ -121,9 +151,13 @@ def classify_intent(query: str) -> QueryIntent:
                 category=category,
                 confidence=confidence,
                 matched_pattern=match.group(0),
+                recommended_source=_INTENT_TO_SOURCE[category],
             )
 
-    return QueryIntent(category="GENERAL", confidence=0.0, matched_pattern="")
+    return QueryIntent(
+        category="GENERAL", confidence=0.0, matched_pattern="",
+        recommended_source=_INTENT_TO_SOURCE["GENERAL"],
+    )
 
 
 def compute_intent_affinity(

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -64,15 +64,35 @@ class HybridRetriever:
         self,
         query: str,
         *,
-        source: str = "both",
+        source: str | None = None,
         limit: int = 10,
         min_activation: float = 0.0,
         expand_query_terms: bool = True,
         wing: str | None = None,
         room: str | None = None,
     ) -> list[RetrievalResult]:
-        """Hybrid retrieval: Qdrant + FTS5 + activation, fused via RRF."""
+        """Hybrid retrieval: Qdrant + FTS5 + activation, fused via RRF.
+
+        Source selection:
+            - ``source=None`` (default): classify the query's intent and
+              use ``intent.recommended_source``. WHY/WHEN/WHERE/STATUS
+              route to episodic; WHAT/HOW/GENERAL route to ``both`` and
+              let RRF + activation sort the candidates.
+            - ``source='episodic' | 'knowledge' | 'both'``: explicit
+              override; intent inference is skipped for the source
+              decision but still informs RRF biasing.
+
+            Callers that want to force ``both`` regardless of intent
+            should pass ``source='both'`` explicitly.
+        """
         _t0 = time.monotonic()
+
+        # Classify intent up-front — used for both source-selection
+        # (when source is None) and RRF bias (always, downstream).
+        intent = classify_intent(query)
+
+        if source is None:
+            source = intent.recommended_source
         if source not in _SOURCE_TO_COLLECTIONS:
             msg = f"source must be one of {list(_SOURCE_TO_COLLECTIONS)}, got {source!r}"
             raise ValueError(msg)
@@ -119,8 +139,9 @@ class HybridRetriever:
                 if mid not in qdrant_by_id:
                     qdrant_by_id[mid] = hit
 
-        # 2b. Classify query intent (for RRF bias in step 7)
-        intent = classify_intent(query)
+        # 2b. (Intent was classified up-front for source selection;
+        #     it's reused here for RRF bias in step 7 + event-calendar
+        #     temporal filtering below.)
 
         # 2d. Event-calendar search (temporal queries)
         event_memory_ids: list[str] = []
@@ -148,14 +169,18 @@ class HybridRetriever:
                 logger.warning("Query expansion failed, using original", exc_info=True)
 
         # 3. FTS5 text search (using expanded query)
-        # Search all of memory_fts (no collection filter) so that references
-        # and knowledge entries surface even when source="episodic". The RRF
-        # fusion handles ranking across collections.
+        # FTS5 respects the caller's source choice — searching the wrong
+        # pool here is how knowledge_base entries flood episodic recall
+        # results purely by candidate volume. When source="both" we pass
+        # None so FTS5 sees every row; for a single-collection source we
+        # filter at the SQL level so the candidate set matches Qdrant's
+        # filtered search and RRF fuses comparable lists.
         fts_is_boolean = fts_query != query  # expansion produced boolean syntax
+        fts_collection = collections[0] if len(collections) == 1 else None
         fts_results = await memory_crud.search_ranked(
             self._db,
             query=fts_query,
-            collection=None,
+            collection=fts_collection,
             limit=candidate_limit,
             boolean=fts_is_boolean,
         )

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -139,11 +139,9 @@ class HybridRetriever:
                 if mid not in qdrant_by_id:
                     qdrant_by_id[mid] = hit
 
-        # 2b. (Intent was classified up-front for source selection;
-        #     it's reused here for RRF bias in step 7 + event-calendar
-        #     temporal filtering below.)
-
-        # 2d. Event-calendar search (temporal queries)
+        # 2b. Event-calendar search (temporal queries)
+        # (Intent classified at the top of recall(); reused below for
+        # RRF bias in step 7 and for the temporal-marker check here.)
         event_memory_ids: list[str] = []
         if intent.category == "WHEN" or _has_temporal_markers(query):
             try:

--- a/tests/test_memory/test_intent.py
+++ b/tests/test_memory/test_intent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from genesis.memory.intent import (
+    _INTENT_TO_SOURCE,
     QueryIntent,
     TagCooccurrenceIndex,
     _tokenize_query,
@@ -10,6 +11,65 @@ from genesis.memory.intent import (
     compute_intent_affinity,
     rank_by_intent,
 )
+
+
+class TestRecommendedSource:
+    """recommended_source field on QueryIntent — used by recall() to
+    decide which collection to query when no explicit source is passed."""
+
+    def test_episodic_routed_intents(self):
+        # WHY/WHEN/WHERE/STATUS should all route to episodic — these are
+        # internal lookups (past reasoning, timelines, current state).
+        for q, expected_cat in [
+            ("why did we choose X?", "WHY"),
+            ("when did the migration run?", "WHEN"),
+            ("where is the runtime config?", "WHERE"),
+            ("status of the cc_relay rollout", "STATUS"),
+        ]:
+            intent = classify_intent(q)
+            assert intent.category == expected_cat
+            assert intent.recommended_source == "episodic", (
+                f"Expected episodic for {expected_cat}, got "
+                f"{intent.recommended_source!r}"
+            )
+
+    def test_both_routed_intents(self):
+        # WHAT/HOW/GENERAL should default to both — either pool could
+        # ground them, let RRF + activation decide.
+        for q in [
+            "what is the extraction pipeline?",
+            "how do I run the bridge?",
+            "the brainstorm queue",  # GENERAL
+        ]:
+            intent = classify_intent(q)
+            assert intent.recommended_source == "both", (
+                f"Expected both for {q!r}, got "
+                f"{intent.recommended_source!r}"
+            )
+
+    def test_empty_query_falls_back_to_both(self):
+        intent = classify_intent("")
+        assert intent.category == "GENERAL"
+        assert intent.recommended_source == "both"
+
+    def test_intent_to_source_covers_all_categories(self):
+        # Guard against adding a new intent category without wiring its
+        # recommended_source. Every category in QueryIntent's docstring
+        # must have an entry in _INTENT_TO_SOURCE.
+        for cat in ["WHAT", "WHY", "HOW", "WHEN", "WHERE", "STATUS", "GENERAL"]:
+            assert cat in _INTENT_TO_SOURCE, (
+                f"Category {cat!r} missing from _INTENT_TO_SOURCE — every "
+                f"intent category must have a recommended_source mapping."
+            )
+            assert _INTENT_TO_SOURCE[cat] in ("episodic", "knowledge", "both")
+
+    def test_query_intent_default_source_is_both(self):
+        # Tests/external callers that construct QueryIntent without
+        # passing recommended_source get the safe baseline of 'both'.
+        intent = QueryIntent(
+            category="GENERAL", confidence=0.0, matched_pattern="",
+        )
+        assert intent.recommended_source == "both"
 
 # ---------------------------------------------------------------------------
 # Intent classification

--- a/tests/test_memory/test_retrieval.py
+++ b/tests/test_memory/test_retrieval.py
@@ -311,6 +311,18 @@ async def test_explicit_source_overrides_intent(
 @patch("genesis.memory.retrieval.memory_links")
 @patch("genesis.memory.retrieval.memory_crud")
 @patch("genesis.memory.retrieval.qdrant_ops")
+async def test_unknown_source_raises(mock_qdrant, mock_crud, mock_links, _):
+    """Unknown source string still rejected after the source=None handling."""
+    retriever, _, _, _ = _build_retriever()
+    with pytest.raises(ValueError, match="source must be one of"):
+        await retriever.recall("anything", source="bogus", limit=5)
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
 async def test_recall_min_activation_filters(mock_qdrant, mock_crud, mock_links, _):
     retriever, _, _, _ = _build_retriever()
 

--- a/tests/test_memory/test_retrieval.py
+++ b/tests/test_memory/test_retrieval.py
@@ -177,6 +177,140 @@ async def test_recall_both_sources(mock_qdrant, mock_crud, mock_links, _):
 @patch("genesis.memory.retrieval.memory_links")
 @patch("genesis.memory.retrieval.memory_crud")
 @patch("genesis.memory.retrieval.qdrant_ops")
+async def test_fts5_collection_filter_matches_source_episodic(
+    mock_qdrant, mock_crud, mock_links, _,
+):
+    """FTS5 must filter to the source collection when source is single
+    — regression guard for the bug where collection=None was hardcoded
+    and knowledge_base entries leaked into episodic recall."""
+    retriever, _, _, _ = _build_retriever()
+
+    mock_qdrant.search.return_value = []
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    mock_links.count_links = AsyncMock(return_value=0)
+
+    await retriever.recall("test", source="episodic", limit=5)
+
+    mock_crud.search_ranked.assert_called_once()
+    assert mock_crud.search_ranked.call_args.kwargs["collection"] == "episodic_memory"
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_fts5_collection_filter_matches_source_knowledge(
+    mock_qdrant, mock_crud, mock_links, _,
+):
+    retriever, _, _, _ = _build_retriever()
+
+    mock_qdrant.search.return_value = []
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    mock_links.count_links = AsyncMock(return_value=0)
+
+    await retriever.recall("test", source="knowledge", limit=5)
+
+    mock_crud.search_ranked.assert_called_once()
+    assert mock_crud.search_ranked.call_args.kwargs["collection"] == "knowledge_base"
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_fts5_collection_filter_both_searches_all(
+    mock_qdrant, mock_crud, mock_links, _,
+):
+    """When source='both', FTS5 still searches everything (None) — RRF
+    fuses the union with Qdrant's two-collection result."""
+    retriever, _, _, _ = _build_retriever()
+
+    mock_qdrant.search.return_value = []
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    mock_links.count_links = AsyncMock(return_value=0)
+
+    await retriever.recall("test", source="both", limit=5)
+
+    mock_crud.search_ranked.assert_called_once()
+    assert mock_crud.search_ranked.call_args.kwargs["collection"] is None
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="why decided x")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_source_none_routes_by_intent_episodic(
+    mock_qdrant, mock_crud, mock_links, _,
+):
+    """When source=None (default), WHY queries route to episodic only."""
+    retriever, _, _, _ = _build_retriever()
+
+    mock_qdrant.search.return_value = []
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    mock_links.count_links = AsyncMock(return_value=0)
+
+    # WHY intent → recommended_source = 'episodic'
+    await retriever.recall("why did we decide x?", limit=5)
+
+    assert mock_qdrant.search.call_count == 1
+    assert mock_qdrant.search.call_args.kwargs["collection"] == "episodic_memory"
+    assert mock_crud.search_ranked.call_args.kwargs["collection"] == "episodic_memory"
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="what is x")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_source_none_routes_by_intent_both(
+    mock_qdrant, mock_crud, mock_links, _,
+):
+    """WHAT queries route to both via intent default."""
+    retriever, _, _, _ = _build_retriever()
+
+    mock_qdrant.search.return_value = []
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    mock_links.count_links = AsyncMock(return_value=0)
+
+    await retriever.recall("what is the cc_relay?", limit=5)
+
+    # Both collections searched in Qdrant; FTS5 collection=None
+    assert mock_qdrant.search.call_count == 2
+    assert mock_crud.search_ranked.call_args.kwargs["collection"] is None
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="general query")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_explicit_source_overrides_intent(
+    mock_qdrant, mock_crud, mock_links, _,
+):
+    """Caller passing source='knowledge' on a WHY query gets knowledge,
+    not the WHY-recommended episodic. Explicit beats inferred."""
+    retriever, _, _, _ = _build_retriever()
+
+    mock_qdrant.search.return_value = []
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    mock_links.count_links = AsyncMock(return_value=0)
+
+    # WHY intent would route episodic, but caller forces knowledge
+    await retriever.recall("why did we decide x?", source="knowledge", limit=5)
+
+    assert mock_qdrant.search.call_count == 1
+    assert mock_qdrant.search.call_args.kwargs["collection"] == "knowledge_base"
+    assert mock_crud.search_ranked.call_args.kwargs["collection"] == "knowledge_base"
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
 async def test_recall_min_activation_filters(mock_qdrant, mock_crud, mock_links, _):
     retriever, _, _, _ = _build_retriever()
 


### PR DESCRIPTION
## Summary

Two coupled fixes to the hybrid memory recall pipeline, surfaced as regressions by Phase 1 calibration of the `memory_recall_grounding` rubric (69.7% agreement; many disagreements traced to knowledge_base entries leaking into episodic-flavored recalls).

- **FTS5 collection filter respects `source`.** `retrieval.py:158` previously hardcoded `collection=None` (regression from PR #261), so `source='episodic'` still pulled candidate matches from knowledge_base. RRF fused asymmetric lists and surfaced knowledge_base entries in nominally-episodic recalls. Under recon-firehose ingestion this would only get worse. The fix derives the FTS5 collection filter from the resolved `source`.
- **Intent-driven default source.** `HybridRetriever.recall(source=...)` and `memory_recall` MCP both default to `None`. `None` → classify the query and use `intent.recommended_source`. WHY/WHEN/WHERE/STATUS → `episodic`; WHAT/HOW/GENERAL → `both`. Explicit `source=` still wins, so existing callers in `resume_review.py`, `cc/context_injector.py`, `autonomy/executor/resources.py`, and `mcp/memory/knowledge.py` are unchanged.
- **MCP-layer source resolution.** `memory_recall` resolves `None` to a concrete source before dispatching to either `HybridRetriever.recall` or `drift_recall`, because `drift_recall` uses `dict.get(source, [...])` which would silently default-branch on None.

Per the plan (`Phase 1.5a` in `wise-sprouting-wadler.md`), this lands before re-grading the calibration golden set — the existing set is contaminated by exactly the recall noise this PR fixes.

## Deferred (filed as 1.5a-followup)

- WHAT-IS sub-classifier (factual definitions → `knowledge`) and ambiguity damping factor. Plan note added: a regex-only sub-classifier would miss too many cases; a small LLM call once 1.5d picks a judge model is the more promising path.

## Test plan

- [x] `ruff check src/genesis/ tests/test_memory/ tests/test_mcp/` — clean
- [x] `pytest tests/test_memory/ tests/test_mcp/test_memory_mcp.py` — 427 passing, 19 new
- [x] superpowers code-reviewer pass — 1 important issue caught (MCP layer wasn't wired through) and fixed in commit 183e452
- [ ] **Post-merge runtime verification:** restart genesis-server, run `memory_recall` MCP with WHY/WHEN queries, confirm results no longer include knowledge_base candidate pollution

🤖 Generated with [Claude Code](https://claude.com/claude-code)