### PR TITLE
chore(eval): rubric v1.1.0 — tighten memory_recall_grounding to relevance-only

### DIFF
--- a/src/genesis/eval/rubrics/memory_recall_grounding.py
+++ b/src/genesis/eval/rubrics/memory_recall_grounding.py
@@ -18,14 +18,29 @@ from __future__ import annotations
 from genesis.eval.rubrics import Rubric, register_rubric
 
 _PROMPT = """\
-You are grading whether a recalled memory grounds the answer to a query.
+You are grading the *topical relevance* of a recalled memory to a query.
+You are NOT grading the memory's truthfulness, its overall quality, its
+freshness, or whether it should exist — only whether it is topically
+related enough to the query that a downstream consumer (a human or
+another LLM) COULD draw on it while responding.
 
-A memory grounds an answer when it provides on-topic, useful information
-that a downstream consumer could weave into their response — facts,
-context, relevant background, prior decisions. A memory does NOT ground
-an answer when it is off-topic, redundant with what the query already
-states, generic boilerplate, or merely shares keywords without
-substantive overlap.
+Three rules, applied in order:
+
+1. **Topic overlap is the bar, not keyword overlap.** A memory that
+   shares the query's topic counts as relevant even if the wording
+   differs. A memory that shares only surface keywords (same noun, same
+   tool name) without addressing the query's actual subject is NOT
+   relevant.
+
+2. **You do not assess truth.** If the memory makes a claim that is
+   wrong, biased, outdated, or self-contradictory, that does NOT make
+   it irrelevant. A wrong-but-on-topic memory still scores as relevant.
+   Memory hygiene is a separate concern handled elsewhere.
+
+3. **Procedural / investigation / decision memories count as relevant**
+   if they record activity or reasoning about the query's topic. They
+   do not need to *answer* the query to be relevant; they need to
+   provide on-topic context.
 
 Query the user asked:
 {query}
@@ -33,12 +48,13 @@ Query the user asked:
 Memory that was recalled:
 {actual}
 
-User's hand-graded label (for reference only — your job is to judge the
-memory against the query, not to agree with the label):
+Reference label (FYI only — describes the memory's recall position and
+collection; do not let this bias your judgment):
 {expected}
 
-Score the memory's grounding from 0.0 (irrelevant / unhelpful) to 1.0
-(directly grounds the answer). Brief rationale required.
+Score the topical relevance from 0.0 (off-topic / unrelated) through
+0.5 (tangential but on-topic) to 1.0 (directly on-topic, clearly
+related). Brief rationale required.
 
 Respond with ONLY a JSON object, no markdown fences, no prose:
 {{"score": <float 0.0-1.0>, "rationale": "<one sentence>"}}"""
@@ -46,10 +62,13 @@ Respond with ONLY a JSON object, no markdown fences, no prose:
 
 MEMORY_RECALL_GROUNDING = Rubric(
     name="memory_recall_grounding",
-    version="1.0.0",
+    version="1.1.0",
     description=(
-        "Grades whether a recalled memory grounds the answer to a query. "
-        "Foundation rubric for Phase 2 CRAG borderline grading."
+        "Grades topical relevance of a recalled memory to a query. "
+        "Foundation rubric for Phase 2 CRAG borderline grading. "
+        "v1.1.0: tightened to relevance-only after 1.0.0 calibration "
+        "exposed user grading on truth+usefulness while the rubric only "
+        "asked about relevance."
     ),
     prompt_template=_PROMPT,
     pass_threshold=0.6,

--- a/tests/test_eval/test_rubrics.py
+++ b/tests/test_eval/test_rubrics.py
@@ -26,7 +26,7 @@ def test_first_party_rubrics_are_registered():
     """Importing the package auto-registers built-in rubrics."""
     rubric = get_rubric("memory_recall_grounding")
     assert rubric.name == "memory_recall_grounding"
-    assert rubric.version == "1.0.0"
+    assert rubric.version == "1.1.0"
     assert "{actual}" in rubric.prompt_template
     assert "{query}" in rubric.prompt_template
     assert "query" in rubric.extra_placeholders


### PR DESCRIPTION
## Summary

Phase 1 calibration ran the v1.0.0 `memory_recall_grounding` rubric at **69.7% agreement** against a hand-graded 33-case golden set (target: ≥80%). Disagreements split:

- **Half** came from the user implicitly grading on truth + usefulness + ego-pollution principle, while the rubric only asked about relevance.
- **Half** came from the judge falling back to literal term-overlap when the v1.0.0 prompt's "useful information" phrasing left "relevance" ambiguous.

v1.1.0 tightens the prompt to relevance-only — three explicit rules, plus an explicit "you do not assess truth" guard.

## What changed

- `src/genesis/eval/rubrics/memory_recall_grounding.py` — version bump to v1.1.0, prompt rewrite. Three rules in order:
  1. Topic overlap is the bar, not keyword overlap.
  2. Do not assess truth (wrong-but-on-topic is still relevant).
  3. Procedural / investigation / decision memories count as relevant if on-topic.
- `tests/test_eval/test_rubrics.py` — version assertion bumped 1.0.0 → 1.1.0.

## What does NOT change

- Registry contract — no `Rubric` dataclass changes.
- Scorer behavior — `LLMJudgeScorer` unchanged.
- Calibration job — `run_calibration` unchanged.
- Pass threshold — still 0.6.

## Why this lands before recalibration

The plan (`wise-sprouting-wadler.md` Phase 1.5) sequences Phase 1.5a (recall architecture fixes, PR #309, merged) and Phase 1.5b (subsystem source tagging) before re-grading the golden set against the cleaner recall path. Rubric v1.1.0 is independent of those — it ships when ready and is in place by the time re-grading happens, so the v1.1.0 prompt is what the user grades against the next time.

## Test plan

- [x] `ruff check src/genesis/eval/ tests/test_eval/` clean
- [x] `pytest tests/test_eval/test_rubrics.py -v` — 6/6 passing
- [ ] Recalibration: deferred until after Phase 1.5a + 1.5b land and golden set is regenerated. v1.1.0 will be the prompt under test then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)