### PR TITLE
chore(gitnexus): refresh tooling drift

### DIFF
--- a/.claude/hooks/cbm-discovery-gate.sh
+++ b/.claude/hooks/cbm-discovery-gate.sh
@@ -6,29 +6,15 @@
 # docs, and non-code files.
 #
 # NEVER blocks (always exit 0). Uses additionalContext for soft tips.
-# Nudges once per session via sentinel file.
+# Fires every time a non-skipped code-file Read/Grep/Glob happens —
+# no session-once suppression, since the nudge has value on each
+# code-discovery action. Configs, docs, and plans are skipped by the
+# path/extension filter below.
 #
 # Replaces the global ~/.claude/hooks/cbm-code-discovery-gate which
 # hard-blocked (exit 2) every Read/Grep call regardless of file type.
 
 set -u
-
-# ── Session-once gate ──────────────────────────────────────────────────
-# CC spawns each hook as a new bash process, so $$ and $PPID differ per
-# invocation. Use $CLAUDE_SESSION_ID (set by CC) when available, else
-# fall back to a project-dir + date hash for once-per-day-per-project.
-if [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
-    GATE_KEY="$CLAUDE_SESSION_ID"
-else
-    GATE_KEY="$(echo "${PWD:-unknown}-$(date +%Y%m%d)" | md5sum | cut -c1-16)"
-fi
-GATE="/tmp/cbm-discovery-gate-${GATE_KEY}"
-if [[ -f "$GATE" ]]; then
-    exit 0  # already nudged this session
-fi
-
-# Clean up old gate files (>1 day)
-find /tmp -maxdepth 1 -name 'cbm-discovery-gate-*' -mtime +1 -delete 2>/dev/null || true
 
 # ── Parse stdin to determine the target file ───────────────────────────
 INPUT=$(cat)
@@ -60,10 +46,6 @@ if [[ -n "$FILE_PATH" ]]; then
             ;;
     esac
 fi
-
-# If Grep with no path (searching whole repo), or Read on a code file,
-# or Glob searching for code patterns — nudge once.
-touch "$GATE"
 
 # Emit soft tip via additionalContext (never blocks)
 cat << 'TIPJSON'

--- a/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
+++ b/.claude/skills/gitnexus/gitnexus-cli/SKILL.md
@@ -23,7 +23,7 @@ Run from the project root. This parses all source files, builds the knowledge gr
 | `--embeddings` | Enable embedding generation for semantic search (off by default) |
 | `--drop-embeddings` | Drop existing embeddings on rebuild. By default, an `analyze` without `--embeddings` preserves them. |
 
-**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook runs `analyze` automatically after `git commit` and `git merge`, preserving embeddings if previously generated.
+**When to run:** First time in a project, after major code changes, or when `gitnexus://repo/{name}/context` reports the index is stale. In Claude Code, a PostToolUse hook detects staleness after `git commit` and `git merge` and notifies the agent to run `analyze` — the hook does not run analyze itself, to avoid blocking the agent for up to 120s and risking KuzuDB corruption on timeout.
 
 ### status — Check index freshness
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **GENesis-AGI** (35247 symbols, 51942 relationships, 185 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **GENesis-AGI** (37105 symbols, 58975 relationships, 285 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 


### PR DESCRIPTION
## Summary

Three small, independent tooling drifts from gitnexus auto-updates and a hook behavior change. None affects Genesis runtime behavior; all three are tooling-adjacent.

- **`AGENTS.md` stats refresh** — 35247 → 37105 symbols, 51942 → 58975 relationships, 185 → 285 execution flows. Auto-updated by gitnexus between the existing `<!-- gitnexus:start --> ... <!-- gitnexus:end -->` sentinels.
- **`gitnexus-cli/SKILL.md` doc accuracy** — the post-commit hook *detects* index staleness and notifies the agent; it does NOT run `gitnexus analyze` itself. The earlier doc claimed it ran analyze automatically, which would risk 120s blocks and KuzuDB corruption on timeout.
- **`cbm-discovery-gate.sh`** — removed the session-once gate. The hook now fires every code-file Read/Grep/Glob. The per-extension / per-path exclusions (`.md`, `.yaml`, `*/plans/*`, `*/.claude/*`, etc.) are unchanged, so doc/config reads still pass through silently. Trade-off is more nudges during long sessions in exchange for higher safety on long-running sessions where the per-session suppression could mask a genuine code-discovery mistake.

CLAUDE.md was *not* included even though gitnexus auto-injected the same `<!-- gitnexus:start --> ... <!-- gitnexus:end -->` block at the bottom — it duplicates content already in the "Code Intelligence" section higher up.

## Test plan

- [x] `bash -n .claude/hooks/cbm-discovery-gate.sh` — syntax OK
- [ ] In-session verification that the hook still suppresses on `.md` / `.yaml` / `*/plans/*` reads (per-extension filter unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)