### PR TITLE
feat(mcp): add evolution_propose_review tool for proposal triage

### DIFF
--- a/docs/architecture/genesis-v3-autonomous-behavior-design.md
+++ b/docs/architecture/genesis-v3-autonomous-behavior-design.md
@@ -862,6 +862,7 @@ more than an aggressive question asked five times in a week.
 - `observation_query` — Query by type/priority/source
 - `observation_resolve` — Mark resolved with notes
 - `evolution_propose` — Write identity evolution proposal (for SOUL.md / identity file changes)
+- `evolution_propose_review` — Transition a proposal out of pending (approved / rejected / withdrawn)
 
 **Knowledge base tools (post-v3 feature, groundwork laid in v3):**
 - `knowledge_recall` — Hybrid search scoped by project/domain, authority-tagged results

--- a/src/genesis/mcp/memory/identity.py
+++ b/src/genesis/mcp/memory/identity.py
@@ -15,6 +15,9 @@ def _memory_mod():
 logger = logging.getLogger(__name__)
 
 
+_REVIEW_STATUSES = ("approved", "rejected", "withdrawn")
+
+
 @mcp.tool()
 async def evolution_propose(
     proposal_type: str,
@@ -37,3 +40,26 @@ async def evolution_propose(
     )
     logger.info("Evolution proposal created: %s (type=%s)", proposal_id, proposal_type)
     return proposal_id
+
+
+@mcp.tool()
+async def evolution_propose_review(proposal_id: str, status: str) -> dict:
+    """Transition an evolution proposal out of pending.
+
+    status must be one of: approved, rejected, withdrawn.
+    Returns the updated row, or {"error": ...} on invalid status / missing id.
+    Triage rationale belongs in a paired observation_write, not in this call.
+    """
+    if status not in _REVIEW_STATUSES:
+        return {"error": f"invalid status {status!r}; must be one of {_REVIEW_STATUSES}"}
+    memory_mod = _memory_mod()
+    memory_mod._require_init()
+    assert memory_mod._db is not None
+    updated = await memory_mod.evolution_proposals.update_status(
+        memory_mod._db, proposal_id, status
+    )
+    if not updated:
+        return {"error": f"proposal {proposal_id!r} not found"}
+    row = await memory_mod.evolution_proposals.get(memory_mod._db, proposal_id)
+    logger.info("Evolution proposal reviewed: %s → %s", proposal_id, status)
+    return row or {"error": "proposal vanished after update"}

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -17,7 +17,7 @@ async def test_all_tools_registered():
         "memory_recall", "memory_store", "memory_extract", "memory_proactive",
         "memory_core_facts", "memory_stats",
         "observation_write", "observation_query", "observation_resolve",
-        "evolution_propose",
+        "evolution_propose", "evolution_propose_review",
         "conversation_history",
         "knowledge_recall", "knowledge_ingest", "knowledge_status",
         "reference_store", "reference_lookup", "reference_delete",
@@ -942,6 +942,92 @@ async def test_evolution_propose_stores_pending():
             call_kwargs = mock_evo.create.call_args[1]
             assert call_kwargs["proposal_type"] == "soul_update"
             assert call_kwargs["rationale"] == "clarity"
+    finally:
+        mod._store = old_store
+        mod._db = old_db
+        mod._retriever = old_retriever
+
+
+# ─── evolution_propose_review tests ────────────────────────────────────────
+
+
+async def test_evolution_propose_review_requires_init():
+    tools = await _get_tools()
+    with pytest.raises(RuntimeError, match="not initialized"):
+        await tools["evolution_propose_review"].fn(
+            proposal_id="abc", status="approved"
+        )
+
+
+async def test_evolution_propose_review_rejects_invalid_status():
+    """Invalid status returns error dict without touching the DB."""
+    import genesis.mcp.memory_mcp as mod
+
+    old_store, old_db, old_retriever = mod._store, mod._db, mod._retriever
+    try:
+        mod._store = AsyncMock()
+        mod._db = AsyncMock()
+        mod._retriever = AsyncMock()
+        with patch("genesis.mcp.memory_mcp.evolution_proposals") as mock_evo:
+            tools = await _get_tools()
+            result = await tools["evolution_propose_review"].fn(
+                proposal_id="any", status="bogus"
+            )
+            assert "error" in result
+            assert "bogus" in result["error"]
+            mock_evo.update_status.assert_not_called()
+    finally:
+        mod._store = old_store
+        mod._db = old_db
+        mod._retriever = old_retriever
+
+
+async def test_evolution_propose_review_missing_proposal():
+    """Returns error when proposal_id doesn't exist."""
+    import genesis.mcp.memory_mcp as mod
+
+    old_store, old_db, old_retriever = mod._store, mod._db, mod._retriever
+    try:
+        mod._store = AsyncMock()
+        mod._db = AsyncMock()
+        mod._retriever = AsyncMock()
+        with patch("genesis.mcp.memory_mcp.evolution_proposals") as mock_evo:
+            mock_evo.update_status = AsyncMock(return_value=False)
+            tools = await _get_tools()
+            result = await tools["evolution_propose_review"].fn(
+                proposal_id="missing-id", status="rejected"
+            )
+            assert "error" in result
+            assert "not found" in result["error"]
+            mock_evo.get.assert_not_called()
+    finally:
+        mod._store = old_store
+        mod._db = old_db
+        mod._retriever = old_retriever
+
+
+async def test_evolution_propose_review_updates_and_returns_row():
+    """Happy path: status transitions and updated row returned."""
+    import genesis.mcp.memory_mcp as mod
+
+    old_store, old_db, old_retriever = mod._store, mod._db, mod._retriever
+    try:
+        mod._store = AsyncMock()
+        mod._db = AsyncMock()
+        mod._retriever = AsyncMock()
+        with patch("genesis.mcp.memory_mcp.evolution_proposals") as mock_evo:
+            mock_evo.update_status = AsyncMock(return_value=True)
+            mock_evo.get = AsyncMock(return_value={
+                "id": "p-1", "status": "approved", "reviewed_at": "2026-05-10T21:00:00+00:00",
+            })
+            tools = await _get_tools()
+            result = await tools["evolution_propose_review"].fn(
+                proposal_id="p-1", status="approved"
+            )
+            assert result["id"] == "p-1"
+            assert result["status"] == "approved"
+            mock_evo.update_status.assert_called_once_with(mod._db, "p-1", "approved")
+            mock_evo.get.assert_called_once_with(mod._db, "p-1")
     finally:
         mod._store = old_store
         mod._db = old_db


### PR DESCRIPTION
## Summary

- Adds `evolution_propose_review(proposal_id, status)` MCP tool that wraps the existing `evolution_proposals.update_status()` CRUD function. Validates `status ∈ {approved, rejected, withdrawn}`, returns the updated row dict (with refreshed `reviewed_at`), or `{"error": ...}` on invalid status / missing id.
- The CRUD function existed but had no MCP surface — only `create` and `list_pending` were exposed. Triage cycles had to drop to direct sqlite, which made the workflow fragile.
- Updates the v3 autonomous-behavior design doc tool list to mention the new surface.

## Test plan

- [x] 4 new tests cover registration, init guard, invalid status, missing proposal, happy path
- [x] All 42 tests in `tests/test_mcp/test_memory_mcp.py` pass (no regressions)
- [x] `ruff check` clean across worktree
- [x] Inline code review: no blockers; ship-it verdict
- [ ] First end-to-end use: next architect triage cycle (tool registers on next CC session start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)