### PR TITLE
fix(learning): outcome classifier sentinel + parse-fail bug + chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Changed
 
+- **Procedure extraction routes to stronger models.** The
+  `38_procedure_extraction` call site chain is now
+  `cerebras-qwen` (Qwen 3 235B, free) →
+  `openrouter-deepseek-v4` (V4 Pro, paid) →
+  `groq-free` (Llama 3.3 70B). Mistral Large and Gemini Flash are
+  dropped — Mistral underperformed for this synthesis task and Gemini
+  Flash is too small. DeepSeek V4 Pro is enabled via `default_paid:
+  true`; at the realistic event-driven frequency of this call site,
+  the spend is negligible.
 - **`judge` call site is in the L2 / tmp-pressure-high skip lists**
   --- when Genesis is degraded or disk-pressured, judge calls back
   off automatically, in line with the existing rules for non-critical
@@ -60,6 +69,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Outcome classifier no longer silently claims SUCCESS on parse
+  failure.** When the LLM response was unparseable, the classifier
+  previously returned `OutcomeClass.SUCCESS`, which let bad runs
+  silently update autonomy weights and skip procedure extraction.
+  Failed classifications now return a dedicated `CLASSIFICATION_FAILED`
+  sentinel; the learning pipeline detects it after the classifier call
+  and skips downstream learning (delta assessment, attribution
+  routing, procedure extraction, steering rule capture) instead of
+  proceeding with phantom success. The sentinel renames the internal
+  `OutcomeClass.UNKNOWN` value to make its role as an error marker
+  explicit (it was never a real 6th outcome category, just a fallback
+  bucket).
 - **Call sites with no API key stay visible on the dashboard.**
   Previously, a call site whose entire provider chain had no API key
   configured was silently dropped from `cfg.call_sites` at startup,

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -407,9 +407,10 @@ call_sites:
     description: Synthesize research results into concise summaries
   38_procedure_extraction:
     chain:
+    - cerebras-qwen
+    - openrouter-deepseek-v4
     - groq-free
-    - mistral-large-free
-    - gemini-free
+    default_paid: true
     description: Extract reusable procedures from interaction outcomes
   43_task_retrospective:
     chain:

--- a/src/genesis/learning/classification/attribution.py
+++ b/src/genesis/learning/classification/attribution.py
@@ -109,7 +109,7 @@ async def route_learning_signals(
             actions["user_revised_scope"] = "tracked"
 
     # Create speculative claims for low-confidence patterns (hypothesis for later validation)
-    if delta.evidence and outcome not in (OutcomeClass.SUCCESS, OutcomeClass.UNKNOWN):
+    if delta.evidence and outcome not in (OutcomeClass.SUCCESS, OutcomeClass.CLASSIFICATION_FAILED):
         try:
             from datetime import timedelta
 

--- a/src/genesis/learning/classification/outcome.py
+++ b/src/genesis/learning/classification/outcome.py
@@ -35,7 +35,7 @@ class OutcomeClassifier:
         result = await self._router.route_call(_CALL_SITE, messages)
 
         if not result.success or not result.content:
-            return OutcomeClass.UNKNOWN
+            return OutcomeClass.CLASSIFICATION_FAILED
 
         return self._parse_response(result.content)
 
@@ -92,4 +92,7 @@ class OutcomeClassifier:
             with contextlib.suppress(ValueError):
                 return OutcomeClass(outcome_str)
 
-        return OutcomeClass.SUCCESS
+        # Parse failed: response was non-empty but unusable. This is an error
+        # state, not a success — returning SUCCESS here previously caused silent
+        # false-positive autonomy updates and procedure-extraction skips.
+        return OutcomeClass.CLASSIFICATION_FAILED

--- a/src/genesis/learning/pipeline.py
+++ b/src/genesis/learning/pipeline.py
@@ -86,7 +86,15 @@ def build_triage_pipeline(
         delta = None
         if triage.depth >= TriageDepth.WORTH_THINKING:
             outcome = await outcome_classifier.classify(summary)
-            delta = await delta_assessor.assess(summary)
+            if outcome == OutcomeClass.CLASSIFICATION_FAILED:
+                logger.warning(
+                    "Outcome classification failed for session %s; "
+                    "skipping downstream learning (delta, attribution, extraction).",
+                    summary.session_id or "unknown",
+                )
+                outcome = None
+            else:
+                delta = await delta_assessor.assess(summary)
 
             # Log prediction for calibration (fire-and-forget)
             if outcome and runtime is not None:

--- a/src/genesis/learning/pipeline.py
+++ b/src/genesis/learning/pipeline.py
@@ -87,6 +87,11 @@ def build_triage_pipeline(
         if triage.depth >= TriageDepth.WORTH_THINKING:
             outcome = await outcome_classifier.classify(summary)
             if outcome == OutcomeClass.CLASSIFICATION_FAILED:
+                # CLASSIFICATION_FAILED is an error sentinel, not a real
+                # outcome. The execution_traces.outcome_class CHECK constraint
+                # does not allow this value — by setting outcome to None here,
+                # all downstream guards short-circuit and nothing tries to
+                # serialize the sentinel to the DB.
                 logger.warning(
                     "Outcome classification failed for session %s; "
                     "skipping downstream learning (delta, attribution, extraction).",

--- a/src/genesis/learning/types.py
+++ b/src/genesis/learning/types.py
@@ -18,7 +18,9 @@ class OutcomeClass(StrEnum):
     CAPABILITY_GAP = "capability_gap"
     EXTERNAL_BLOCKER = "external_blocker"
     WORKAROUND_SUCCESS = "workaround_success"
-    UNKNOWN = "unknown"
+    # Sentinel for classifier errors (router failure, parse failure). NOT a
+    # 6th outcome category — downstream pipeline treats this as a skip signal.
+    CLASSIFICATION_FAILED = "classification_failed"
 
 
 class TriageDepth(IntEnum):

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -329,10 +329,10 @@ _CALL_SITE_META: dict[str, dict] = {
         "model_tier": "slm",
     },
     "38_procedure_extraction": {
-        "description": "Extracts reusable procedures from successful interaction patterns. Part of the learning pipeline.",
+        "description": "Extracts reusable procedures from interaction outcomes (success path + failures). Part of the learning pipeline.",
         "category": "content",
         "frequency": "On demand",
-        "model_tier": "slm",
+        "model_tier": "mid",
     },
     "contingency_foreground": {
         "description": "API-based foreground conversation fallback when CC is rate-limited or unavailable.",

--- a/tests/test_learning/test_classification.py
+++ b/tests/test_learning/test_classification.py
@@ -103,13 +103,15 @@ class TestOutcomeClassifier:
     async def test_classify_fallback_on_failure(self):
         router = _mock_router("", success=False)
         result = await OutcomeClassifier(router).classify(_make_summary())
-        assert result == OutcomeClass.UNKNOWN
+        assert result == OutcomeClass.CLASSIFICATION_FAILED
 
     @pytest.mark.asyncio
     async def test_classify_fallback_on_bad_json(self):
         router = _mock_router("not json at all")
         result = await OutcomeClassifier(router).classify(_make_summary())
-        assert result == OutcomeClass.SUCCESS
+        # Parse failure is an error state, not silent SUCCESS — previously this
+        # asserted SUCCESS, which masked real classification failures.
+        assert result == OutcomeClass.CLASSIFICATION_FAILED
 
     @pytest.mark.asyncio
     async def test_classify_extracts_json_from_markdown(self):
@@ -124,8 +126,8 @@ class TestOutcomeClassifier:
         await c.classify(_make_summary())
         prompt = router.route_call.call_args[0][1][0]["content"]
         for cls in OutcomeClass:
-            if cls == OutcomeClass.UNKNOWN:
-                continue  # UNKNOWN is an internal sentinel, not a valid LLM classification
+            if cls == OutcomeClass.CLASSIFICATION_FAILED:
+                continue  # Internal sentinel, never returned by the LLM
             assert cls.value in prompt
 
     @pytest.mark.asyncio

--- a/tests/test_learning/test_pipeline.py
+++ b/tests/test_learning/test_pipeline.py
@@ -133,6 +133,43 @@ class TestTriagePipeline:
         da.assess.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_classification_failed_skips_downstream(self, db):
+        """When the classifier returns CLASSIFICATION_FAILED, the pipeline must
+        skip delta assessment, attribution routing, autonomy adaptation, and
+        procedure extraction — but still run debrief parsing (which is
+        classification-independent).
+        """
+        oc = _make_outcome_classifier(OutcomeClass.CLASSIFICATION_FAILED)
+        da = _make_delta_assessor()
+        ow = MagicMock()
+        ow.write = AsyncMock(return_value="obs-1")
+        router = MagicMock()
+        router.route_call = AsyncMock()
+        pipeline = build_triage_pipeline(
+            db=db,
+            triage_classifier=_make_triage_classifier(TriageDepth.FULL_ANALYSIS),
+            outcome_classifier=oc,
+            delta_assessor=da,
+            observation_writer=ow,
+            router=router,
+        )
+        text_with_learnings = (
+            "response\n## Learnings\n- something\n- else"
+        )
+        await pipeline(FakeCCOutput(text=text_with_learnings), "q", "terminal")
+
+        oc.classify.assert_awaited_once()
+        # Delta assessment must NOT fire — classifier failed
+        da.assess.assert_not_awaited()
+        # Procedure extraction routes through router — must NOT fire
+        router.route_call.assert_not_awaited()
+        # Debrief parsing is independent — should still write learnings
+        learning_calls = [
+            c for c in ow.write.call_args_list if c[1].get("source") == "cc_debrief"
+        ]
+        assert len(learning_calls) == 2
+
+    @pytest.mark.asyncio
     async def test_writes_observation_at_full_analysis(self, db):
         """Pipeline writes observation at depth >= FULL_ANALYSIS."""
         ow = MagicMock()

--- a/tests/test_learning/test_types.py
+++ b/tests/test_learning/test_types.py
@@ -25,7 +25,17 @@ from genesis.learning.types import (
 def test_outcome_class_values():
     assert OutcomeClass.SUCCESS == "success"
     assert OutcomeClass.WORKAROUND_SUCCESS == "workaround_success"
+    assert OutcomeClass.CLASSIFICATION_FAILED == "classification_failed"
+    # 5 real outcomes + 1 error sentinel = 6
     assert len(OutcomeClass) == 6
+    real_outcomes = {
+        OutcomeClass.SUCCESS,
+        OutcomeClass.APPROACH_FAILURE,
+        OutcomeClass.CAPABILITY_GAP,
+        OutcomeClass.EXTERNAL_BLOCKER,
+        OutcomeClass.WORKAROUND_SUCCESS,
+    }
+    assert OutcomeClass.CLASSIFICATION_FAILED not in real_outcomes
 
 
 def test_triage_depth_ordering():


### PR DESCRIPTION
## Summary

- Renames `OutcomeClass.UNKNOWN` → `OutcomeClass.CLASSIFICATION_FAILED` to make the sentinel's role as an error marker explicit. It was never a real 6th outcome category — just a fallback bucket used when the LLM call failed.
- Fixes a real bug in `outcome.py:95`: when the LLM response was non-empty but unparseable JSON, the classifier returned `SUCCESS`, silently letting phantom autonomy updates proceed and skipping procedure extraction. Now returns `CLASSIFICATION_FAILED`.
- Adds an early-skip in `pipeline.py`: when the classifier returns `CLASSIFICATION_FAILED`, the pipeline logs a warning and skips `delta_assessor`, attribution routing, autonomy adaptation, and procedure extraction rather than running them on bogus inputs. Debrief parsing (classification-independent) still runs.
- Re-orders `38_procedure_extraction` chain to `cerebras-qwen → openrouter-deepseek-v4 → groq-free` with `default_paid: true`. Drops `mistral-large-free` (underperforms for this synthesis task) and `gemini-free` (too small).
- Fixes `model_tier` label from `slm` to `mid` (chain is mid-tier now, not SLM).

## Why

The parse-fail-returns-SUCCESS path was producing silent false positives in the learning system — autonomy weights were being nudged upward and procedure extraction was being skipped because the system thought classification succeeded with outcome=success. The sentinel rename makes the error semantics explicit so it's harder to misuse.

The chain change reflects current model availability and quality. Cerebras Qwen 3 235B is free for now; DeepSeek V4 Pro is the paid quality backstop and will become primary when Cerebras drops (separate follow-up). The 70B Groq Llama remains as the free emergency fallback.

## Test plan

- [x] `tests/test_learning/test_classification.py` — 24 tests, including updated `test_classify_fallback_on_failure` and `test_classify_fallback_on_bad_json` (the latter previously asserted the bug)
- [x] `tests/test_learning/test_pipeline.py::test_classification_failed_skips_downstream` — new test asserting delta/attribution/extraction don't fire and debrief parsing still does
- [x] `tests/test_learning/test_types.py::test_outcome_class_values` — pins the sentinel, asserts it's distinct from the 5 real outcomes
- [x] Full learning test suite (429 pass, 3 skipped)
- [x] Routing + observability suites (356 pass)
- [x] `ruff check .` clean
- [x] `config/model_routing.yaml` validates as YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)