### PR TITLE
feat(learning): SUCCESS-path procedure extraction + novelty gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,22 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Procedure auto-extraction now fires on SUCCESS outcomes from
+  autonomous channels.** Previously the triage pipeline only extracted
+  procedures from `APPROACH_FAILURE` and `WORKAROUND_SUCCESS` outcomes,
+  so the procedural_memory table grew only from rare failure patterns.
+  Successful autonomous task completions (`inbox`, `mail`, `reflection`,
+  `surplus` channels) now also drive extraction, giving the system a
+  baseline pattern for the next run of the same task type. Foreground
+  SUCCESS is intentionally NOT auto-extracted — foreground procedures
+  are user-initiated via the `procedure_store` MCP.
+- **Procedure novelty gate.** Auto-extracted procedures are now
+  compared against existing procedures of the same `task_type` via
+  cosine similarity of their `principle` embeddings. If the new
+  principle is ≥0.85 similar to an existing one, storage is skipped.
+  Prevents the table from filling with paraphrases of the same insight
+  as SUCCESS-path extraction broadens the trigger surface. Fail-open
+  when the embedding stack is unavailable.
 - **Foreground recall excludes automated-subsystem content by
   default.** Memory writes from ego corrections, triage signals, and
   reflection observations are now tagged with a new
@@ -114,6 +130,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   `OutcomeClass.UNKNOWN` value to make its role as an error marker
   explicit (it was never a real 6th outcome category, just a fallback
   bucket).
+- **Triage pipeline no longer crashes silently in procedure extraction.**
+  The procedure extraction block referenced `summary.output_text`, which
+  is not a field on `InteractionSummary` — the correct field is
+  `response_text`. The `AttributeError` was caught by the surrounding
+  exception handler, so the bug was invisible at runtime but blocked
+  every auto-extraction. Same fix applied to the behavioral correction
+  recorder (BIS).
 - **Call sites with no API key stay visible on the dashboard.**
   Previously, a call site whose entire provider chain had no API key
   configured was silently dropped from `cfg.call_sites` at startup,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,6 +342,9 @@ To send the user a future Telegram reminder, use `mcp__genesis-outreach__outreac
 - **Check procedures before multi-step tasks**: use `procedure_recall` if relevant.
   Applies when a task involves external services, has failed before, or
   requires multi-step tool use.
+- **Store procedures when you discover them.** When you find a non-obvious
+  reusable workflow (multi-step, hard-won, capability that took effort to
+  learn), call `procedure_store` immediately — don't defer.
 - **Never insert directly into `task_states`.** All task submissions MUST
   go through `task_submit` MCP after completing `/task` intake. Direct DB
   writes are rejected by a SQLite trigger that requires a valid intake

--- a/src/genesis/learning/pipeline.py
+++ b/src/genesis/learning/pipeline.py
@@ -22,6 +22,13 @@ from genesis.observability.types import Severity, Subsystem
 logger = logging.getLogger(__name__)
 
 
+# Channels driven by Genesis's autonomous subsystems rather than direct user
+# input. Used to gate behaviors that should fire only on autonomous activity
+# (e.g., aggressive SUCCESS-path procedure extraction) and to gate behaviors
+# that should fire only on foreground activity (e.g., STEERING.md auto-update).
+_AUTONOMOUS_CHANNELS = {"inbox", "mail", "reflection", "surplus"}
+
+
 def build_triage_pipeline(
     *,
     db: Any,
@@ -155,9 +162,21 @@ def build_triage_pipeline(
                     logger.error("Autonomy calibration failed (non-fatal)", exc_info=True)
 
         # 6.5. Procedure extraction (error-isolated — must not crash pipeline)
-        if outcome in (OutcomeClass.APPROACH_FAILURE, OutcomeClass.WORKAROUND_SUCCESS) and router is not None:
+        #
+        # Triggers by outcome:
+        #  - APPROACH_FAILURE: capture what went wrong, gated by novelty.
+        #  - WORKAROUND_SUCCESS: capture the workaround pattern, gated by novelty.
+        #  - SUCCESS on AUTONOMOUS channels: capture the working pattern so the
+        #    next autonomous run has a baseline. Gated by novelty so this doesn't
+        #    flood the table. Foreground SUCCESS is NOT auto-extracted — the
+        #    user/CC drives that via `procedure_store` calls.
+        is_autonomous = summary.channel in _AUTONOMOUS_CHANNELS
+        if router is not None and (
+            outcome in (OutcomeClass.APPROACH_FAILURE, OutcomeClass.WORKAROUND_SUCCESS)
+            or (outcome == OutcomeClass.SUCCESS and is_autonomous)
+        ):
             try:
-                summary_text = f"User: {summary.user_text}\nOutput: {summary.output_text[:500]}"
+                summary_text = f"User: {summary.user_text}\nOutput: {summary.response_text[:500]}"
                 await extract_procedure(
                     db,
                     summary_text=summary_text,
@@ -170,7 +189,6 @@ def build_triage_pipeline(
         # 6.6. STEERING.md auto-population from user corrections
         # Only extract from foreground user sessions — autonomous pipelines
         # (inbox, mail, reflection) must never write to identity files.
-        _AUTONOMOUS_CHANNELS = {"inbox", "mail", "reflection", "surplus"}
         if (
             outcome == OutcomeClass.APPROACH_FAILURE
             and identity_loader is not None
@@ -248,7 +266,7 @@ def build_triage_pipeline(
         if not user_text.strip():
             return
 
-        context = (summary.output_text or "")[:500]
+        context = (summary.response_text or "")[:500]
         await create_correction(
             db_conn,
             raw_user_text=user_text[:500],

--- a/src/genesis/learning/procedural/extractor.py
+++ b/src/genesis/learning/procedural/extractor.py
@@ -85,6 +85,10 @@ async def _principle_is_novel(
     try:
         from genesis.db.crud.procedural import list_by_task_type
 
+        # list_by_task_type defaults to limit=50, ordered by confidence DESC.
+        # The default cap is load-bearing here — it bounds the per-extraction
+        # cost at 50 embedding lookups (cached) + 50 cosines. If the cap
+        # changes, revisit the latency budget for this hot path.
         existing = await list_by_task_type(db, task_type)
     except Exception:
         logger.warning(

--- a/src/genesis/learning/procedural/extractor.py
+++ b/src/genesis/learning/procedural/extractor.py
@@ -1,14 +1,21 @@
 """Procedure extraction from interaction outcomes.
 
-When the triage pipeline classifies an interaction as APPROACH_FAILURE or
-WORKAROUND_SUCCESS, this module extracts a reusable procedure and stores it.
-New procedures start at L4 (advisory-only) with speculative=1 until confirmed.
+When the triage pipeline classifies an interaction as APPROACH_FAILURE,
+WORKAROUND_SUCCESS, or (on autonomous channels) SUCCESS, this module extracts
+a reusable procedure and stores it. New procedures start at L4
+(advisory-only) with speculative=1 until confirmed.
+
+Novelty gate: before storing, compute the cosine similarity of the new
+procedure's principle embedding against existing procedures of the same
+task_type. Skip storage if max similarity >= NOVELTY_THRESHOLD to prevent
+the table from filling with paraphrases of the same insight.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import math
 from typing import TYPE_CHECKING, Any, Protocol
 
 from genesis.learning.procedural.operations import store_procedure
@@ -16,7 +23,98 @@ from genesis.learning.procedural.operations import store_procedure
 if TYPE_CHECKING:
     import aiosqlite
 
+    from genesis.memory.embeddings import EmbeddingProvider
+
 logger = logging.getLogger(__name__)
+
+# Cosine similarity threshold above which an extracted procedure is treated
+# as a duplicate of an existing same-task_type procedure. Initial value
+# calibrated by hand; see follow-up to retune from similarity-score histogram
+# after 30 days of extraction data.
+NOVELTY_THRESHOLD = 0.85
+
+_EMBEDDING_PROVIDER: EmbeddingProvider | None = None
+
+
+def _get_embedding_provider() -> EmbeddingProvider | None:
+    """Lazy module-level singleton. Returns None if no embedding backend is
+    configured (extractor falls open and stores without novelty filtering).
+    """
+    global _EMBEDDING_PROVIDER
+    if _EMBEDDING_PROVIDER is None:
+        try:
+            from genesis.memory.embeddings import EmbeddingProvider
+
+            _EMBEDDING_PROVIDER = EmbeddingProvider()
+        except Exception:
+            logger.warning(
+                "EmbeddingProvider unavailable; procedure novelty gate disabled",
+                exc_info=True,
+            )
+            return None
+    return _EMBEDDING_PROVIDER
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    if len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+async def _principle_is_novel(
+    db: aiosqlite.Connection,
+    *,
+    task_type: str,
+    new_principle: str,
+    embedder: EmbeddingProvider | None,
+) -> tuple[bool, float]:
+    """Return (is_novel, max_similarity_seen).
+
+    Fail-open: if embedding fails or no embedder is configured, treat as
+    novel so we don't silently drop extractions when the embedding stack is
+    degraded.
+    """
+    if embedder is None:
+        return True, 0.0
+
+    try:
+        from genesis.db.crud.procedural import list_by_task_type
+
+        existing = await list_by_task_type(db, task_type)
+    except Exception:
+        logger.warning(
+            "Procedure novelty lookup failed; allowing storage", exc_info=True,
+        )
+        return True, 0.0
+
+    if not existing:
+        return True, 0.0
+
+    try:
+        new_emb = await embedder.embed(new_principle)
+        max_sim = 0.0
+        for row in existing:
+            existing_principle = (
+                row.get("principle") if isinstance(row, dict) else row["principle"]
+            )
+            if not existing_principle:
+                continue
+            existing_emb = await embedder.embed(existing_principle)
+            sim = _cosine_similarity(new_emb, existing_emb)
+            if sim > max_sim:
+                max_sim = sim
+        return max_sim < NOVELTY_THRESHOLD, max_sim
+    except Exception:
+        logger.warning(
+            "Embedding/cosine failed in novelty gate; allowing storage",
+            exc_info=True,
+        )
+        return True, 0.0
 
 # 38_procedure_extraction — extracts reusable procedures from interaction outcomes.
 # Currently in the learning-pipeline-only path (partially wired per _call_site_meta.py).
@@ -57,12 +155,16 @@ async def extract_procedure(
     summary_text: str,
     outcome: str,
     router: _Router,
+    embedding_provider: EmbeddingProvider | None = None,
 ) -> str | None:
     """Extract a procedure from an interaction summary via LLM.
 
     Returns the procedure ID if successful, None if extraction fails.
     All failures are logged but never raised — this is secondary to the
     main triage pipeline and must not crash it.
+
+    Pass `embedding_provider` to override the default lazy module-level
+    singleton (useful for tests).
     """
     prompt = _PROMPT_TEMPLATE.format(summary_text=summary_text, outcome=outcome)
 
@@ -104,6 +206,22 @@ async def extract_procedure(
             return None
     except Exception:
         pass  # Non-critical guard — continue with extraction if check fails
+
+    # Novelty gate: skip if a near-duplicate principle already exists for
+    # this task_type. Fail-open when embeddings are unavailable.
+    embedder = embedding_provider if embedding_provider is not None else _get_embedding_provider()
+    is_novel, max_sim = await _principle_is_novel(
+        db,
+        task_type=data["task_type"],
+        new_principle=data["principle"],
+        embedder=embedder,
+    )
+    if not is_novel:
+        logger.info(
+            "Skipped extraction for %s: near-duplicate principle (cosine=%.3f >= %.2f)",
+            data["task_type"], max_sim, NOVELTY_THRESHOLD,
+        )
+        return None
 
     try:
         proc_id = await store_procedure(

--- a/tests/test_learning/test_extractor.py
+++ b/tests/test_learning/test_extractor.py
@@ -1,0 +1,176 @@
+"""Tests for the procedure extractor — novelty gate behavior."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.learning.procedural.extractor import (
+    NOVELTY_THRESHOLD,
+    _cosine_similarity,
+    extract_procedure,
+)
+from genesis.learning.procedural.operations import store_procedure
+
+
+@dataclass
+class _FakeRouterResult:
+    success: bool = True
+    content: str = ""
+
+
+def _router_returning(payload: dict) -> MagicMock:
+    router = MagicMock()
+    router.route_call = AsyncMock(
+        return_value=_FakeRouterResult(success=True, content=json.dumps(payload))
+    )
+    return router
+
+
+def _embedder(mapping: dict[str, list[float]]) -> MagicMock:
+    """Build a fake embedder. `mapping` is principle text -> vector."""
+    emb = MagicMock()
+
+    async def _embed(text: str) -> list[float]:
+        # Default to a zero vector for unmapped inputs (cosine = 0).
+        return mapping.get(text, [0.0, 0.0, 0.0])
+
+    emb.embed = AsyncMock(side_effect=_embed)
+    return emb
+
+
+def _valid_payload(task_type: str = "deploy-service", principle: str = "always verify before deploy") -> dict:
+    return {
+        "task_type": task_type,
+        "principle": principle,
+        "steps": ["build", "test", "deploy"],
+        "tools_used": ["docker"],
+        "context_tags": ["prod"],
+        "tool_trigger": None,
+    }
+
+
+def test_cosine_similarity_basic():
+    assert _cosine_similarity([1.0, 0.0], [1.0, 0.0]) == pytest.approx(1.0)
+    assert _cosine_similarity([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+    # Length mismatch returns 0 (defensive)
+    assert _cosine_similarity([1.0], [1.0, 0.0]) == 0.0
+    # Zero vector returns 0
+    assert _cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_extract_stores_when_table_empty(db):
+    """No existing procedures => stores regardless of embedder."""
+    payload = _valid_payload()
+    router = _router_returning(payload)
+    embedder = _embedder({})  # No principles needed; table is empty
+
+    proc_id = await extract_procedure(
+        db,
+        summary_text="ran build, deployed",
+        outcome="success",
+        router=router,
+        embedding_provider=embedder,
+    )
+    assert proc_id is not None
+    # Embedder shouldn't be called when the same-task_type list is empty.
+    embedder.embed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_extract_stores_when_principle_is_novel(db):
+    """Existing procedure of same task_type but dissimilar principle => stores."""
+    # Seed an existing procedure with task_type "deploy-service"
+    await store_procedure(
+        db,
+        task_type="deploy-service",
+        principle="never deploy without rollback plan",
+        steps=["plan", "deploy"],
+        tools_used=["docker"],
+        context_tags=["prod"],
+    )
+
+    payload = _valid_payload(principle="always run integration tests first")
+    embedder = _embedder({
+        "always run integration tests first": [1.0, 0.0, 0.0],
+        "never deploy without rollback plan": [0.0, 1.0, 0.0],
+    })
+    router = _router_returning(payload)
+
+    proc_id = await extract_procedure(
+        db,
+        summary_text="ran integration tests then deployed",
+        outcome="success",
+        router=router,
+        embedding_provider=embedder,
+    )
+    assert proc_id is not None
+
+
+@pytest.mark.asyncio
+async def test_extract_skips_when_near_duplicate(db):
+    """Cosine >= NOVELTY_THRESHOLD against an existing principle => skip store."""
+    await store_procedure(
+        db,
+        task_type="deploy-service",
+        principle="always verify health checks pass before deploy",
+        steps=["check", "deploy"],
+        tools_used=["docker"],
+        context_tags=["prod"],
+    )
+
+    # New principle is intentionally a near-paraphrase; we force the
+    # cosine to be exactly 1.0 by mapping both texts to the same vector.
+    same_vector = [1.0, 0.0, 0.0]
+    payload = _valid_payload(principle="check health then deploy, always")
+    embedder = _embedder({
+        "check health then deploy, always": same_vector,
+        "always verify health checks pass before deploy": same_vector,
+    })
+    router = _router_returning(payload)
+
+    proc_id = await extract_procedure(
+        db,
+        summary_text="deployed after health checks",
+        outcome="success",
+        router=router,
+        embedding_provider=embedder,
+    )
+    assert proc_id is None  # Skipped by novelty gate
+
+    # Verify threshold is the documented constant, not a moved goalpost.
+    assert NOVELTY_THRESHOLD == 0.85
+
+
+@pytest.mark.asyncio
+async def test_extract_fails_open_when_embedder_is_none(db):
+    """Embedder unavailable => store anyway (don't drop extractions silently)."""
+    await store_procedure(
+        db,
+        task_type="deploy-service",
+        principle="some existing principle",
+        steps=["a"],
+        tools_used=["t"],
+        context_tags=["c"],
+    )
+
+    payload = _valid_payload(principle="totally different principle")
+    router = _router_returning(payload)
+
+    proc_id = await extract_procedure(
+        db,
+        summary_text="x",
+        outcome="success",
+        router=router,
+        embedding_provider=None,
+    )
+    # With embedder=None, _get_embedding_provider() is consulted. In test
+    # environments without an embedding backend it returns None and we
+    # fail-open. The procedure should store.
+    # (Note: if a backend IS available in the test env, this test would still
+    # pass because the principles are very different.)
+    assert proc_id is not None

--- a/tests/test_learning/test_extractor.py
+++ b/tests/test_learning/test_extractor.py
@@ -8,12 +8,24 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from genesis.learning.procedural import extractor as extractor_mod
 from genesis.learning.procedural.extractor import (
     NOVELTY_THRESHOLD,
     _cosine_similarity,
     extract_procedure,
 )
 from genesis.learning.procedural.operations import store_procedure
+
+
+@pytest.fixture(autouse=True)
+def _reset_embedding_provider_singleton():
+    """Reset the module-level embedder cache between tests so state from one
+    test (or a real EmbeddingProvider built on first use) can't leak into the
+    next.
+    """
+    extractor_mod._EMBEDDING_PROVIDER = None
+    yield
+    extractor_mod._EMBEDDING_PROVIDER = None
 
 
 @dataclass

--- a/tests/test_learning/test_pipeline.py
+++ b/tests/test_learning/test_pipeline.py
@@ -370,3 +370,88 @@ class TestSteeringRuleExtraction:
         )
         await pipeline(FakeCCOutput(), "don't ever do that", "telegram")
         loader.add_steering_rule.assert_called_once()
+
+
+class TestSuccessExtractionChannelGate:
+    """SUCCESS-path procedure extraction must only fire on autonomous channels.
+
+    Foreground sessions store procedures opportunistically via the
+    `procedure_store` MCP — they should NOT trigger auto-extraction on every
+    successful task, which would flood the table.
+    """
+
+    @pytest.mark.asyncio
+    async def test_success_on_autonomous_channel_triggers_extraction(self, db, monkeypatch):
+        """SUCCESS on 'surplus' (autonomous) should call extract_procedure."""
+        called = {"n": 0}
+
+        async def fake_extract(*_args, **_kwargs):
+            called["n"] += 1
+            return None
+
+        monkeypatch.setattr(
+            "genesis.learning.pipeline.extract_procedure", fake_extract,
+        )
+        router = MagicMock()
+        router.route_call = AsyncMock()
+        pipeline = build_triage_pipeline(
+            db=db,
+            triage_classifier=_make_triage_classifier(TriageDepth.FULL_ANALYSIS),
+            outcome_classifier=_make_outcome_classifier(OutcomeClass.SUCCESS),
+            delta_assessor=_make_delta_assessor(),
+            observation_writer=MagicMock(write=AsyncMock(return_value="o")),
+            router=router,
+        )
+        await pipeline(FakeCCOutput(), "q", "surplus")
+        assert called["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_success_on_foreground_channel_skips_extraction(self, db, monkeypatch):
+        """SUCCESS on 'terminal' (foreground) must NOT call extract_procedure."""
+        called = {"n": 0}
+
+        async def fake_extract(*_args, **_kwargs):
+            called["n"] += 1
+            return None
+
+        monkeypatch.setattr(
+            "genesis.learning.pipeline.extract_procedure", fake_extract,
+        )
+        router = MagicMock()
+        router.route_call = AsyncMock()
+        pipeline = build_triage_pipeline(
+            db=db,
+            triage_classifier=_make_triage_classifier(TriageDepth.FULL_ANALYSIS),
+            outcome_classifier=_make_outcome_classifier(OutcomeClass.SUCCESS),
+            delta_assessor=_make_delta_assessor(),
+            observation_writer=MagicMock(write=AsyncMock(return_value="o")),
+            router=router,
+        )
+        await pipeline(FakeCCOutput(), "q", "terminal")
+        assert called["n"] == 0
+
+    @pytest.mark.asyncio
+    async def test_approach_failure_extracts_regardless_of_channel(self, db, monkeypatch):
+        """APPROACH_FAILURE extraction is channel-agnostic (pre-existing
+        behavior — failures are rare enough to always capture)."""
+        called = {"n": 0}
+
+        async def fake_extract(*_args, **_kwargs):
+            called["n"] += 1
+            return None
+
+        monkeypatch.setattr(
+            "genesis.learning.pipeline.extract_procedure", fake_extract,
+        )
+        router = MagicMock()
+        router.route_call = AsyncMock()
+        pipeline = build_triage_pipeline(
+            db=db,
+            triage_classifier=_make_triage_classifier(TriageDepth.FULL_ANALYSIS),
+            outcome_classifier=_make_outcome_classifier(OutcomeClass.APPROACH_FAILURE),
+            delta_assessor=_make_delta_assessor(),
+            observation_writer=MagicMock(write=AsyncMock(return_value="o")),
+            router=router,
+        )
+        await pipeline(FakeCCOutput(), "q", "terminal")
+        assert called["n"] == 1


### PR DESCRIPTION
## Summary

- Adds SUCCESS-path procedure extraction for autonomous channels (`inbox`, `mail`, `reflection`, `surplus`). Foreground SUCCESS stays opportunistic via `procedure_store`. Previously only `APPROACH_FAILURE` and `WORKAROUND_SUCCESS` triggered extraction, which is why `procedural_memory` has only 6 rows after weeks of operation.
- Adds a cosine-similarity novelty gate to the extractor: skip storage when the new procedure's `principle` embedding is ≥ 0.85 similar to an existing procedure of the same `task_type`. Prevents flooding now that SUCCESS broadens the trigger surface. Fail-open if the embedding stack is unavailable.
- Fixes a latent `AttributeError` where the pipeline accessed `summary.output_text` (correct field is `response_text`). The error was swallowed by the surrounding handler, silently disabling all auto-extraction in production. Same fix applied to the BIS behavioral correction recorder.
- Lifts `_AUTONOMOUS_CHANNELS` to module scope so it gates both SUCCESS extraction and the existing STEERING.md branch.
- Adds a `procedure_store` cue to CLAUDE.md. The companion `procedure_recall` cue stays until the proactive procedure hook lands (PR 2b).

## Why

The procedure system was effectively dormant — auto-extraction was triggering at most a couple times per week, mostly on rare failure patterns. The hidden `output_text` bug meant that every "fire" was silently failing in production. With the bug fixed and SUCCESS path open, autonomous workers will now build a procedural baseline on their working patterns; the novelty gate makes that growth controlled rather than runaway.

## Test plan

- [x] `tests/test_learning/test_extractor.py` (new) — cosine math, empty-table path, novel-principle path, near-duplicate skip, fail-open
- [x] `tests/test_learning/test_pipeline.py::TestSuccessExtractionChannelGate` — SUCCESS fires on `surplus`, does NOT fire on `terminal`, `APPROACH_FAILURE` remains channel-agnostic
- [x] Full learning suite: 436 pass, 3 skipped
- [x] `ruff check .` clean
- [x] Autouse fixture isolates `_EMBEDDING_PROVIDER` between tests

## Follow-ups

- Promote the cosine threshold from a constant to a calibrated value after 30 days of similarity-score histogram data
- Cache `principle_embedding` on procedural_memory rows to avoid re-embedding existing principles on every extraction
- Proactive procedure recall hook (PR 2b) — replaces the manual `procedure_recall` cue in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)