### PR TITLE
fix(contribution): give --force-with-lease an explicit expected SHA

### DIFF
--- a/src/genesis/contribution/pr_opener.py
+++ b/src/genesis/contribution/pr_opener.py
@@ -446,8 +446,14 @@ def _prepare_and_push_branch(
             capture_output=True, text=True,
             cwd=str(wt_dir), timeout=30, check=False,
         )
+        if ls_proc.returncode != 0:
+            # Auth failure, network blip, DNS, rate limit. Surface
+            # cleanly instead of falling through to an empty lease
+            # that would then produce a confusing "stale info" error
+            # on the push if the branch happens to exist.
+            return False, f"ls-remote failed: {ls_proc.stderr.strip()}"
         expected_sha = ""
-        if ls_proc.returncode == 0 and ls_proc.stdout.strip():
+        if ls_proc.stdout.strip():
             expected_sha = ls_proc.stdout.split()[0]
         lease_arg = f"--force-with-lease=refs/heads/{branch}:{expected_sha}"
         proc = subprocess.run(

--- a/src/genesis/contribution/pr_opener.py
+++ b/src/genesis/contribution/pr_opener.py
@@ -433,9 +433,26 @@ def _prepare_and_push_branch(
         # (same install_id + same source_sha → same branch name) by
         # overwriting our own stale branch but refusing to stomp on
         # concurrent updates from another machine.
+        #
+        # We push to a URL (not a configured remote), so git has no
+        # remote-tracking ref to derive the lease's expected SHA from.
+        # On modern git, an implicit lease in that situation fails with
+        # "stale info" rather than falling back to no-protection. So we
+        # query the fork ourselves via `git ls-remote` and pass the
+        # explicit `=<ref>:<expected>` form. An empty `<expected>` is
+        # the canonical "ref must not exist on remote" lease.
+        ls_proc = subprocess.run(
+            ["git", "ls-remote", fork_url, f"refs/heads/{branch}"],
+            capture_output=True, text=True,
+            cwd=str(wt_dir), timeout=30, check=False,
+        )
+        expected_sha = ""
+        if ls_proc.returncode == 0 and ls_proc.stdout.strip():
+            expected_sha = ls_proc.stdout.split()[0]
+        lease_arg = f"--force-with-lease=refs/heads/{branch}:{expected_sha}"
         proc = subprocess.run(
             [
-                "git", "push", "--force-with-lease",
+                "git", "push", lease_arg,
                 fork_url, f"HEAD:refs/heads/{branch}",
             ],
             capture_output=True, text=True,


### PR DESCRIPTION
## Summary

Fixes a deterministic failure in `_prepare_and_push_branch()` that surfaces as a flake in CI but is actually a real bug affecting every contribution re-run.

## Root cause

The contribution flow pushes to the user's fork via URL (not a configured remote). `git push --force-with-lease` without an explicit lease value derives the expected SHA from the remote-tracking ref — but URL-based pushes have no remote-tracking ref. On modern git, this fails deterministically with `(stale info)` rather than falling back to no-protection.

Symptom: `test_prepare_and_push_branch_idempotent_rerun` fails identically on CI for every PR, passes locally only because dev environments happen to have stale remote-tracking refs from prior runs. Same failure mode would hit any real contribution re-run in production.

## Fix

Query the fork via `git ls-remote` to get the actual current SHA of the target branch, then pass an explicit `--force-with-lease=<ref>:<expected_sha>` form. Empty `<expected>` (when the branch doesn't exist yet) is the canonical "ref must not exist on remote" lease.

## Test plan

- [x] All 27 tests in `tests/test_contribution/test_pr_opener.py` pass locally, including the previously-failing `test_prepare_and_push_branch_idempotent_rerun`
- [x] Lint clean

## Falsifiability

Re-running `genesis contribute <sha>` twice in a row should now succeed instead of failing on the second push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)