### PR TITLE
feat(memory): proactive procedure recall hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   Prevents the table from filling with paraphrases of the same insight
   as SUCCESS-path extraction broadens the trigger surface. Fail-open
   when the embedding stack is unavailable.
+- **Proactive procedure recall hook.** Procedures now surface
+  automatically on every CC prompt — same UserPromptSubmit pathway as
+  the proactive memory hook. The hook reuses the prompt embedding the
+  memory hook already computes, compares it against `principle_embedding`
+  BLOBs stored on each procedure row, and emits a single
+  `[Procedure | task_type | id:xxx]` line when the top match's cosine
+  ≥ 0.7. Top-1 only — most prompts won't surface a procedure. New
+  `principle_embedding` column on `procedural_memory` (forward-only;
+  pre-existing rows store NULL and are skipped until they're
+  re-extracted or re-taught). Effectively replaces the manual
+  `procedure_recall`-before-multi-step-tasks reminder in CLAUDE.md.
 - **Foreground recall excludes automated-subsystem content by
   default.** Memory writes from ego corrections, triage signals, and
   reflection observations are now tagged with a new

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,9 +339,11 @@ To send the user a future Telegram reminder, use `mcp__genesis-outreach__outreac
 - **Conventional commit prefixes**: `feat:`, `fix:`, `refactor:`, `docs:`,
   `test:`, `chore:`. Scope is optional: `feat(ego): add cadence manager`.
   Keep subject line under 72 characters. Dominant category wins if mixed.
-- **Check procedures before multi-step tasks**: use `procedure_recall` if relevant.
-  Applies when a task involves external services, has failed before, or
-  requires multi-step tool use.
+- **Procedure recall is automatic.** The proactive procedure hook surfaces
+  the single most relevant stored procedure (cosine ≥ 0.7) as a
+  `[Procedure | task_type | id:xxx]` tag on every prompt, when one applies.
+  No manual `procedure_recall` call needed for routine work — use it only
+  when you want broader matches or wider context.
 - **Store procedures when you discover them.** When you find a non-obvious
   reusable workflow (multi-step, hard-won, capability that took effort to
   learn), call `procedure_store` immediately — don't defer.

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -410,6 +410,57 @@ def _search_fts5(db_path: Path, keywords: list[str]) -> list[dict]:
         return []
 
 
+_PROCEDURE_SURFACE_THRESHOLD = 0.7  # Cosine threshold for the procedure hook.
+# "Recommend a procedure" carries higher risk of being a false positive than
+# "recommend a memory" (procedures are workflow assertions), so use a stricter
+# cosine cutoff. Top-1 only: most prompts have no relevant procedure.
+
+
+def _search_procedures(
+    db_path: Path, prompt_vector: list[float],
+) -> tuple[str, str, str] | None:
+    """Return (procedure_id, task_type, principle_snippet) if a procedure's
+    principle embedding clears the cosine threshold, else None.
+
+    Best-effort: catches every failure mode and returns None so the parent
+    hook (memory recall) is never blocked by this addition.
+    """
+    try:
+        from genesis.learning.procedural.embedding import (
+            cosine_similarity,
+            unpack_embedding,
+        )
+
+        conn = sqlite3.connect(str(db_path), timeout=2)
+        try:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT id, task_type, principle, principle_embedding "
+                "FROM procedural_memory "
+                "WHERE deprecated = 0 AND quarantined = 0 "
+                "AND principle_embedding IS NOT NULL "
+                "ORDER BY confidence DESC LIMIT 100"
+            ).fetchall()
+        finally:
+            conn.close()
+
+        best: tuple[float, str, str, str] | None = None
+        for row in rows:
+            existing_vec = unpack_embedding(row["principle_embedding"])
+            if existing_vec is None:
+                continue
+            sim = cosine_similarity(prompt_vector, existing_vec)
+            if best is None or sim > best[0]:
+                best = (sim, row["id"], row["task_type"] or "", row["principle"] or "")
+
+        if best is None or best[0] < _PROCEDURE_SURFACE_THRESHOLD:
+            return None
+        _sim, proc_id, task_type, principle = best
+        return proc_id, task_type, principle[:200]
+    except Exception:
+        return None  # Never block the memory hook
+
+
 async def _embed_text(text: str) -> list[float] | None:
     """Get embedding from the configured backend chain (cloud-first).
 
@@ -1087,6 +1138,20 @@ async def _run(prompt: str, session_id: str = "") -> None:
         if output:
             print(output)
             sys.stdout.flush()
+
+    # Procedure surfacing — reuses the already-computed prompt embedding
+    # so there's no extra cloud call. Top-1 only, cosine >= 0.7. Wrapped in
+    # a broad try/except so a bad procedure read can't crash the memory hook.
+    if vector:
+        try:
+            proc = _search_procedures(_DB_PATH, vector)
+            if proc is not None:
+                proc_id, task_type, principle = proc
+                tag = f"Procedure | {task_type} | id:{proc_id[:8]}" if task_type else f"Procedure | id:{proc_id[:8]}"
+                print(f"[{tag}] {principle}")
+                sys.stdout.flush()
+        except Exception as proc_exc:
+            print(f"Procedure surfacing skipped: {proc_exc}", file=sys.stderr)
 
     # Print deferred metadata AFTER memory results (memories are more
     # actionable and should appear first in the injection block).

--- a/src/genesis/autonomy/executor/trace.py
+++ b/src/genesis/autonomy/executor/trace.py
@@ -392,6 +392,23 @@ class ExecutionTracer:
 
         from genesis.learning.procedural.operations import store_procedure
 
+        # Best-effort principle embedding for the proactive procedure hook.
+        # Stored as NULL if the embedding stack is unavailable — the hook
+        # simply skips rows without an embedding.
+        principle_blob: bytes | None = None
+        try:
+            from genesis.learning.procedural.embedding import pack_embedding
+            from genesis.memory.embeddings import EmbeddingProvider
+
+            embedder = EmbeddingProvider()
+            vec = await embedder.embed(proc_data["principle"])
+            principle_blob = pack_embedding(vec)
+        except Exception:
+            logger.debug(
+                "Retrospective: principle embedding failed; storing without",
+                exc_info=True,
+            )
+
         proc_id = await store_procedure(
             self._db,
             task_type=proc_data["task_type"],
@@ -401,6 +418,7 @@ class ExecutionTracer:
             context_tags=proc_data["context_tags"],
             activation_tier="L4",
             speculative=1,
+            principle_embedding=principle_blob,
         )
 
         trace.procedural_extractions.append(proc_id)

--- a/src/genesis/db/crud/procedural.py
+++ b/src/genesis/db/crud/procedural.py
@@ -27,20 +27,22 @@ async def create(
     confidence: float = 0.0,
     source: str | None = None,
     promotion_history: str | None = None,
+    principle_embedding: bytes | None = None,
 ) -> str:
     await db.execute(
         """INSERT INTO procedural_memory
            (id, person_id, task_type, principle, steps, tools_used, context_tags,
             speculative, attempted_workarounds, version, created_at,
             activation_tier, tool_trigger, success_count, confidence,
-            source, promotion_history)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            source, promotion_history, principle_embedding)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (id, person_id, task_type, principle, json.dumps(steps), json.dumps(tools_used),
          json.dumps(context_tags), speculative,
          json.dumps(attempted_workarounds) if attempted_workarounds else None,
          version, created_at, activation_tier,
          json.dumps(tool_trigger) if tool_trigger else None,
-         success_count, confidence, source, promotion_history),
+         success_count, confidence, source, promotion_history,
+         principle_embedding),
     )
     await db.commit()
     return id

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -994,6 +994,15 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE procedural_memory ADD COLUMN promotion_history TEXT",
         "procedural_memory.promotion_history")
 
+    # Proactive procedure hook: BLOB of the principle embedding (qwen3-embedding
+    # 1024 floats packed as little-endian float32 = 4096 bytes). Read at hook
+    # fire time to compute cosine similarity vs the prompt embedding without
+    # re-embedding stored principles. Forward-only — existing rows stay NULL
+    # until re-extracted; the hook skips NULL rows.
+    await _try_alter(db,
+        "ALTER TABLE procedural_memory ADD COLUMN principle_embedding BLOB",
+        "procedural_memory.principle_embedding")
+
     # Rebuild cognitive_state table if CHECK constraint lacks resilience_degradation.
     # SQLite can't ALTER CHECK constraints — requires table rebuild.
     await _migrate_cognitive_state_check(db)

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -33,7 +33,8 @@ TABLES = {
             activation_tier   TEXT NOT NULL DEFAULT 'L4',  -- L1/L2/L3/L4 promotion tier
             tool_trigger      TEXT,                        -- JSON array of tool names for L1 matching
             source            TEXT,                        -- JSON: {type, session_id?, observation_id?, triage_outcome?}
-            promotion_history TEXT                         -- JSON array: [{from_tier, to_tier, at, reason}]
+            promotion_history TEXT,                        -- JSON array: [{from_tier, to_tier, at, reason}]
+            principle_embedding BLOB                       -- qwen3-embedding(1024 float32) of `principle`, little-endian; read by proactive procedure hook
         )
     """,
     "observations": """

--- a/src/genesis/learning/procedural/embedding.py
+++ b/src/genesis/learning/procedural/embedding.py
@@ -1,0 +1,59 @@
+"""Procedure principle embedding — pack/unpack + cosine helpers.
+
+Procedures store `principle_embedding` as a BLOB of 1024 little-endian
+float32 values (4096 bytes). Storing the embedding avoids re-embedding
+existing principles on every proactive-hook firing.
+
+The hook reads the BLOB, unpacks to a vector, computes cosine vs the
+already-embedded prompt vector, and surfaces a procedure when the max
+cosine across all procedures crosses the activation threshold.
+"""
+
+from __future__ import annotations
+
+import math
+import struct
+
+# qwen3-embedding output dimensionality. Matches genesis.memory.embeddings.
+EMBEDDING_DIM = 1024
+
+
+def pack_embedding(vector: list[float]) -> bytes:
+    """Pack a float vector into a little-endian float32 BLOB.
+
+    Raises ValueError if the vector dimensionality is unexpected — store
+    sites should treat that as "skip embedding" rather than corrupting the
+    column.
+    """
+    if len(vector) != EMBEDDING_DIM:
+        raise ValueError(
+            f"Embedding dimension mismatch: got {len(vector)}, expected {EMBEDDING_DIM}"
+        )
+    return struct.pack(f"<{EMBEDDING_DIM}f", *vector)
+
+
+def unpack_embedding(blob: bytes | None) -> list[float] | None:
+    """Inverse of pack_embedding. Returns None on any failure (bad length,
+    corrupted bytes, NULL) so the hook can skip the row instead of crashing.
+    """
+    if not blob or len(blob) != EMBEDDING_DIM * 4:
+        return None
+    try:
+        return list(struct.unpack(f"<{EMBEDDING_DIM}f", blob))
+    except struct.error:
+        return None
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Cosine similarity of two equal-length vectors. Returns 0.0 on any
+    edge case (length mismatch, zero norm) so callers can treat the value
+    as a relevance score without separate error handling.
+    """
+    if len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)

--- a/src/genesis/learning/procedural/extractor.py
+++ b/src/genesis/learning/procedural/extractor.py
@@ -72,15 +72,20 @@ async def _principle_is_novel(
     task_type: str,
     new_principle: str,
     embedder: EmbeddingProvider | None,
-) -> tuple[bool, float]:
-    """Return (is_novel, max_similarity_seen).
+) -> tuple[bool, float, list[float] | None]:
+    """Return (is_novel, max_similarity_seen, new_principle_vector).
+
+    `new_principle_vector` is the embedding of `new_principle` (or None if
+    the embedder is unavailable or embedding fails). Callers that want to
+    store the embedding alongside the procedure can reuse this vector
+    instead of re-embedding.
 
     Fail-open: if embedding fails or no embedder is configured, treat as
     novel so we don't silently drop extractions when the embedding stack is
     degraded.
     """
     if embedder is None:
-        return True, 0.0
+        return True, 0.0, None
 
     try:
         from genesis.db.crud.procedural import list_by_task_type
@@ -94,13 +99,21 @@ async def _principle_is_novel(
         logger.warning(
             "Procedure novelty lookup failed; allowing storage", exc_info=True,
         )
-        return True, 0.0
-
-    if not existing:
-        return True, 0.0
+        return True, 0.0, None
 
     try:
         new_emb = await embedder.embed(new_principle)
+    except Exception:
+        logger.warning(
+            "Failed to embed new principle; allowing storage without novelty check",
+            exc_info=True,
+        )
+        return True, 0.0, None
+
+    if not existing:
+        return True, 0.0, new_emb
+
+    try:
         max_sim = 0.0
         for row in existing:
             existing_principle = (
@@ -112,13 +125,13 @@ async def _principle_is_novel(
             sim = _cosine_similarity(new_emb, existing_emb)
             if sim > max_sim:
                 max_sim = sim
-        return max_sim < NOVELTY_THRESHOLD, max_sim
+        return max_sim < NOVELTY_THRESHOLD, max_sim, new_emb
     except Exception:
         logger.warning(
             "Embedding/cosine failed in novelty gate; allowing storage",
             exc_info=True,
         )
-        return True, 0.0
+        return True, 0.0, new_emb
 
 # 38_procedure_extraction — extracts reusable procedures from interaction outcomes.
 # Currently in the learning-pipeline-only path (partially wired per _call_site_meta.py).
@@ -214,7 +227,7 @@ async def extract_procedure(
     # Novelty gate: skip if a near-duplicate principle already exists for
     # this task_type. Fail-open when embeddings are unavailable.
     embedder = embedding_provider if embedding_provider is not None else _get_embedding_provider()
-    is_novel, max_sim = await _principle_is_novel(
+    is_novel, max_sim, principle_vec = await _principle_is_novel(
         db,
         task_type=data["task_type"],
         new_principle=data["principle"],
@@ -226,6 +239,20 @@ async def extract_procedure(
             data["task_type"], max_sim, NOVELTY_THRESHOLD,
         )
         return None
+
+    # Pack the principle embedding for the proactive procedure hook.
+    # NULL is acceptable — the hook skips rows without an embedding.
+    principle_blob: bytes | None = None
+    if principle_vec is not None:
+        try:
+            from genesis.learning.procedural.embedding import pack_embedding
+
+            principle_blob = pack_embedding(principle_vec)
+        except Exception:
+            logger.warning(
+                "Failed to pack principle embedding; storing without it",
+                exc_info=True,
+            )
 
     try:
         proc_id = await store_procedure(
@@ -239,6 +266,7 @@ async def extract_procedure(
             activation_tier="L4",
             speculative=1,
             source={"type": "auto_extracted", "triage_outcome": outcome},
+            principle_embedding=principle_blob,
         )
         logger.info("Extracted procedure %s: %s", proc_id, data["task_type"])
         return proc_id

--- a/src/genesis/learning/procedural/operations.py
+++ b/src/genesis/learning/procedural/operations.py
@@ -39,6 +39,7 @@ async def store_procedure(
     success_count: int = 0,
     confidence: float = 0.0,
     source: dict | None = None,
+    principle_embedding: bytes | None = None,
 ) -> str:
     """Create a new procedure and return its ID.
 
@@ -47,6 +48,10 @@ async def store_procedure(
     user-driven `procedure_store` MCP writes — should pass non-default
     values to seed the procedure as already-trusted (speculative=0,
     success_count>=1, confidence via Laplace).
+
+    `principle_embedding` is the packed BLOB returned by
+    `procedural.embedding.pack_embedding`. Optional — when None, the
+    proactive procedure hook skips this row.
     """
     proc_id = str(uuid.uuid4())
     now = datetime.now(UTC).isoformat()
@@ -65,6 +70,7 @@ async def store_procedure(
         success_count=success_count,
         confidence=confidence,
         source=json.dumps(source) if source else None,
+        principle_embedding=principle_embedding,
     )
     return proc_id
 
@@ -83,6 +89,7 @@ async def store_procedure_checked(
     success_count: int = 1,
     confidence: float = 2 / 3,
     source: dict | None = None,
+    principle_embedding: bytes | None = None,
 ) -> StoreResult:
     """Store a procedure with conflict detection.
 
@@ -154,6 +161,7 @@ async def store_procedure_checked(
         success_count=success_count,
         confidence=confidence,
         source=source,
+        principle_embedding=principle_embedding,
     )
 
     if warnings:

--- a/src/genesis/mcp/memory/procedural.py
+++ b/src/genesis/mcp/memory/procedural.py
@@ -2,17 +2,40 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import asdict as _asdict
 
 from genesis.learning.procedural.matcher import find_best_match, find_relevant
 
 from ..memory import mcp
 
+logger = logging.getLogger(__name__)
+
 
 def _memory_mod():
     import genesis.mcp.memory_mcp as memory_mod
 
     return memory_mod
+
+
+async def _embed_principle_for_hook(principle: str) -> bytes | None:
+    """Best-effort: compute principle embedding for the proactive procedure
+    hook. Returns None on any failure — the hook simply skips rows without
+    an embedding rather than failing the whole store.
+    """
+    try:
+        from genesis.learning.procedural.embedding import pack_embedding
+        from genesis.memory.embeddings import EmbeddingProvider
+
+        embedder = EmbeddingProvider()
+        vec = await embedder.embed(principle)
+        return pack_embedding(vec)
+    except Exception:
+        logger.warning(
+            "procedure_store: principle embedding failed, storing without it",
+            exc_info=True,
+        )
+        return None
 
 
 @mcp.tool()
@@ -34,6 +57,10 @@ async def procedure_store(
     successes/failures via `record_success`/`record_failure` continue to
     update the row via Laplace smoothing.
 
+    Computes a principle embedding for the proactive procedure hook. If the
+    embedding stack is unavailable, the procedure stores without it and the
+    hook skips that row.
+
     The auto-extraction path (`learning.procedural.extractor`) keeps its
     speculative=1 / success_count=0 / confidence=0.0 / L4 defaults — those
     procedures are LLM-hypothesized and must earn trust.
@@ -42,6 +69,8 @@ async def procedure_store(
     memory_mod._require_init()
     assert memory_mod._db is not None
     from genesis.learning.procedural.operations import store_procedure_checked
+
+    principle_blob = await _embed_principle_for_hook(principle)
 
     result = await store_procedure_checked(
         memory_mod._db,
@@ -56,6 +85,7 @@ async def procedure_store(
         success_count=1,
         confidence=2 / 3,
         source={"type": "explicit_teach"},
+        principle_embedding=principle_blob,
     )
 
     response = result.procedure_id

--- a/tests/test_learning/test_extractor.py
+++ b/tests/test_learning/test_extractor.py
@@ -76,10 +76,18 @@ def test_cosine_similarity_basic():
 
 @pytest.mark.asyncio
 async def test_extract_stores_when_table_empty(db):
-    """No existing procedures => stores regardless of embedder."""
+    """No existing procedures => stores; embeds the new principle once.
+
+    The new principle is embedded so it can be packed into the
+    `principle_embedding` BLOB for the proactive procedure hook. No
+    existing-principle comparisons fire when the table is empty for this
+    task_type.
+    """
     payload = _valid_payload()
     router = _router_returning(payload)
-    embedder = _embedder({})  # No principles needed; table is empty
+    embedder = _embedder({
+        "always verify before deploy": [1.0, 0.0, 0.0],
+    })
 
     proc_id = await extract_procedure(
         db,
@@ -89,8 +97,10 @@ async def test_extract_stores_when_table_empty(db):
         embedding_provider=embedder,
     )
     assert proc_id is not None
-    # Embedder shouldn't be called when the same-task_type list is empty.
-    embedder.embed.assert_not_called()
+    # Embed is called exactly once — for the new principle. The dim-mismatch
+    # in the test vector triggers a graceful "stored without embedding" path
+    # (logged), but the procedure still lands in the DB.
+    assert embedder.embed.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_learning/test_procedure_embedding.py
+++ b/tests/test_learning/test_procedure_embedding.py
@@ -1,0 +1,108 @@
+"""Tests for the procedure principle embedding helper + write path."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from genesis.db.crud.procedural import get_by_id
+from genesis.learning.procedural.embedding import (
+    EMBEDDING_DIM,
+    cosine_similarity,
+    pack_embedding,
+    unpack_embedding,
+)
+from genesis.learning.procedural.operations import store_procedure
+
+
+def test_pack_unpack_roundtrip():
+    vec = [float(i) / 1000.0 for i in range(EMBEDDING_DIM)]
+    blob = pack_embedding(vec)
+    assert len(blob) == EMBEDDING_DIM * 4
+    out = unpack_embedding(blob)
+    assert out is not None
+    assert len(out) == EMBEDDING_DIM
+    # Float32 precision — exact equality won't hold across the full vector,
+    # but close-enough is the contract we care about.
+    for a, b in zip(vec, out, strict=True):
+        assert abs(a - b) < 1e-6
+
+
+def test_pack_rejects_wrong_dim():
+    with pytest.raises(ValueError):
+        pack_embedding([0.0, 1.0, 2.0])
+
+
+def test_unpack_handles_none():
+    assert unpack_embedding(None) is None
+
+
+def test_unpack_handles_corrupted_length():
+    # Wrong byte count — function should return None, not raise
+    assert unpack_embedding(b"\x00\x00") is None
+
+
+def test_unpack_handles_corrupted_bytes():
+    # Right byte count but unparseable would be hard to trigger with struct
+    # — corrupted-length already covers the common failure mode.
+    bad = bytes(EMBEDDING_DIM * 4 + 1)  # off by one
+    assert unpack_embedding(bad) is None
+
+
+def test_cosine_basic():
+    assert cosine_similarity([1.0, 0.0], [1.0, 0.0]) == pytest.approx(1.0)
+    assert cosine_similarity([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+    # length mismatch returns 0
+    assert cosine_similarity([1.0], [1.0, 0.0]) == 0.0
+    # zero vectors return 0
+    assert cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_store_procedure_persists_embedding(db):
+    """store_procedure should persist principle_embedding when provided."""
+    vec = [0.5] * EMBEDDING_DIM
+    blob = pack_embedding(vec)
+    proc_id = await store_procedure(
+        db,
+        task_type="t",
+        principle="p",
+        steps=["a"],
+        tools_used=["x"],
+        context_tags=["y"],
+        principle_embedding=blob,
+    )
+
+    row = await get_by_id(db, proc_id)
+    assert row is not None
+    stored = row.get("principle_embedding")
+    assert stored is not None
+    assert len(stored) == EMBEDDING_DIM * 4
+    # Round-trip preserves the vector
+    out = unpack_embedding(stored)
+    assert out is not None
+    for a, b in zip(vec, out, strict=True):
+        assert abs(a - b) < 1e-6
+
+
+@pytest.mark.asyncio
+async def test_store_procedure_persists_none_when_not_provided(db):
+    """Backwards-compat: callers that don't supply an embedding still work."""
+    proc_id = await store_procedure(
+        db,
+        task_type="t2",
+        principle="p2",
+        steps=["a"],
+        tools_used=["x"],
+        context_tags=["y"],
+    )
+    row = await get_by_id(db, proc_id)
+    assert row is not None
+    assert row.get("principle_embedding") is None
+
+
+def test_pack_layout_is_little_endian_float32():
+    """Locks the on-disk format so future readers don't drift from writers."""
+    expected = struct.pack("<1f", 1.0)
+    assert expected == b"\x00\x00\x80?"


### PR DESCRIPTION
## Summary

Surfaces a single relevant procedure on every CC prompt — same UserPromptSubmit pathway as the proactive memory hook, but top-1 only. Replaces the manual `procedure_recall`-before-multi-step-tasks reminder. Most prompts will surface nothing; the hook is silent unless a procedure's `principle` embedding has cosine ≥ 0.7 to the prompt.

> Stacked on top of #319. Will need rebase if #319 doesn't merge first; targets `feat/procedure-extraction-revival` for clean diff review.

## Architecture

- New BLOB column `procedural_memory.principle_embedding` stores the qwen3-embedding(1024 float32) of each procedure's principle. Packed little-endian. Backwards-compatible NULL — pre-existing rows and rows written without an embedder are skipped by the hook.
- Embedding is computed at write time in three paths:
  - `learning/procedural/extractor.py` (auto-extraction) — reuses the vector already embedded for the novelty gate, so this adds **zero new LLM calls**.
  - `autonomy/executor/trace.py` (retrospective auto-extraction) — best-effort wrapper.
  - `mcp/memory/procedural.py::procedure_store` (explicit teach) — best-effort wrapper.
- `scripts/proactive_memory_hook.py` reuses the prompt vector it already embedded for the memory recall path, so the procedure surfacing also adds **zero new embedding calls**. Reads procedure rows (capped at 100, ordered by confidence DESC), computes cosines, prints `[Procedure | task_type | id:xxx] {principle}` when the top match clears the threshold.
- All write paths use try/except wrappers — if the embedding stack is degraded, procedures still store, just without the embedding column. The hook skips NULL rows.
- The proactive hook addition is wrapped in a broad try/except so a bad procedure row can never crash the memory hook.

## Why

PR #319 revives procedure extraction (SUCCESS path on autonomous channels). Recall was the matching half — relying on CC sessions to remember to call `procedure_recall` before multi-step tasks is fragile, the same reason the memory recall hook exists. With this PR procedures are surfaced mechanically.

## Test plan

- [x] `tests/test_learning/test_procedure_embedding.py` (new): pack/unpack roundtrip, dim mismatch raises, corrupted-length handling, cosine basic, store_procedure persistence, NULL preservation, format byte-layout lock
- [x] `tests/test_learning/test_extractor.py`: updated to reflect that the new principle is now embedded even when the same-task_type set is empty
- [x] Full learning + autonomy executor suites: 652 pass, 3 skipped
- [x] `ruff check .` clean

## Follow-ups

- Subprocess integration test for `proactive_memory_hook.py` end-to-end procedure surfacing (the hook has env-gated `sys.exit`/`load_dotenv` side effects that complicate in-process pytest)
- Optional: `CREATE INDEX idx_procedural_confidence` partial index if the procedural_memory table grows beyond a few hundred rows
- Backfill principle_embedding for pre-existing speculative=0 procedures (the 6 explicit-teach rows are currently NULL); recommend a maintenance script rather than a migration since embedding requires the cloud chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)