### PR TITLE
feat(memory): add 4 user-work wings to the taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   pre-existing rows store NULL and are skipped until they're
   re-extracted or re-taught). Effectively replaces the manual
   `procedure_recall`-before-multi-step-tasks reminder in CLAUDE.md.
+- **Four user-work wings added to the memory taxonomy:** `dev_workflow`,
+  `research`, `integrations`, and `career`. Previously the taxonomy only
+  modelled Genesis-internal subsystems (memory, learning, routing,
+  infrastructure, channels, autonomy), so all user-domain memories
+  (git/PR/CI activity, paper reading, third-party API integrations,
+  career and job-search work) collapsed into `general/uncategorized`.
+  New keyword and tag rules route the obvious cases; the long tail
+  will still land in `general` until reclassified. The Genesis-internal
+  `provider` tag still routes to `routing`, not `integrations` —
+  user-work integrations come in via specific service names (minimax,
+  abacus, litellm, etc.).
 - **Foreground recall excludes automated-subsystem content by
   default.** Memory writes from ego corrections, triage signals, and
   reflection observations are now tagged with a new

--- a/src/genesis/memory/taxonomy.py
+++ b/src/genesis/memory/taxonomy.py
@@ -196,19 +196,17 @@ _KEYWORD_MAP: dict[str, tuple[str, str]] = {
     "approval gate": ("autonomy", "approval"),
     "protected path": ("autonomy", "protected_paths"),
     "adversarial review": ("autonomy", "adversarial_review"),
-    # dev_workflow wing (git ops, CI, PRs, worktrees, merges)
+    # dev_workflow wing (PRs, worktrees, CI, code review tooling). Kept
+    # narrow on purpose: bare "git commit"/"git push" etc. appear too often
+    # in operational memories (autonomy, infrastructure) and would steal
+    # those classifications via the earliest-position rule. The terms below
+    # are dev-workflow-specific.
     "pull request": ("dev_workflow", "pull_request"),
     "worktree": ("dev_workflow", "worktree"),
-    "merge conflict": ("dev_workflow", "git"),
-    "git commit": ("dev_workflow", "git"),
-    "git push": ("dev_workflow", "git"),
-    "git rebase": ("dev_workflow", "git"),
-    "git branch": ("dev_workflow", "git"),
     "github actions": ("dev_workflow", "ci"),
     "code review": ("dev_workflow", "review"),
     "ruff check": ("dev_workflow", "ci"),
     "greptile": ("dev_workflow", "review"),
-    "codex": ("dev_workflow", "review"),
     "ultrareview": ("dev_workflow", "review"),
     # research wing (external content, system reading, paper notes)
     "vllm": ("research", "external_systems"),
@@ -219,17 +217,20 @@ _KEYWORD_MAP: dict[str, tuple[str, str]] = {
     "research paper": ("research", "papers"),
     "arxiv": ("research", "papers"),
     "api documentation": ("research", "api_docs"),
-    # integrations wing (third-party providers, APIs we wire into)
+    # integrations wing (specific third-party services the user is wiring
+    # into projects). Deliberately omits "openai api" / "anthropic api"
+    # because those phrases overlap heavily with Genesis-internal routing
+    # provider discussions — those memories should stay in `routing`.
     "minimax": ("integrations", "providers"),
     "abacus ai": ("integrations", "providers"),
     "litellm": ("integrations", "providers"),
     "openrouter": ("integrations", "providers"),
-    "anthropic api": ("integrations", "providers"),
-    "openai api": ("integrations", "providers"),
     "conway": ("integrations", "third_party_apis"),
     "composio": ("integrations", "third_party_apis"),
-    # career wing (job search, profile, applications)
-    "resume": ("career", "applications"),
+    # career wing. "resume" intentionally omitted as a content keyword —
+    # it collides with "resume the session", "resume crawling", etc. —
+    # career classifications via this word should come through the
+    # `resume` tag instead (handled in _TAG_WING_MAP below).
     "cv revision": ("career", "applications"),
     "profile.yml": ("career", "profile"),
     "job application": ("career", "applications"),

--- a/src/genesis/memory/taxonomy.py
+++ b/src/genesis/memory/taxonomy.py
@@ -17,12 +17,20 @@ from dataclasses import dataclass
 # ---------------------------------------------------------------------------
 
 WINGS = frozenset({
+    # Genesis-internal subsystems
     "memory",
     "learning",
     "routing",
     "infrastructure",
     "channels",
     "autonomy",
+    # User-work domains (added 2026-05-11 from cluster analysis of the
+    # 1,964-row general/uncategorized pile). About what the user works on,
+    # not Genesis subsystem internals.
+    "dev_workflow",
+    "research",
+    "integrations",
+    "career",
     "general",
 })
 
@@ -50,6 +58,18 @@ ROOMS: dict[str, list[str]] = {
     "autonomy": [
         "tasks", "permissions", "approval", "protected_paths",
         "adversarial_review",
+    ],
+    "dev_workflow": [
+        "git", "ci", "pull_request", "review", "worktree",
+    ],
+    "research": [
+        "papers", "external_systems", "newsletters", "api_docs",
+    ],
+    "integrations": [
+        "providers", "third_party_apis", "tools", "models",
+    ],
+    "career": [
+        "applications", "profile", "research", "outreach",
     ],
     "general": ["uncategorized"],
 }
@@ -176,6 +196,47 @@ _KEYWORD_MAP: dict[str, tuple[str, str]] = {
     "approval gate": ("autonomy", "approval"),
     "protected path": ("autonomy", "protected_paths"),
     "adversarial review": ("autonomy", "adversarial_review"),
+    # dev_workflow wing (git ops, CI, PRs, worktrees, merges)
+    "pull request": ("dev_workflow", "pull_request"),
+    "worktree": ("dev_workflow", "worktree"),
+    "merge conflict": ("dev_workflow", "git"),
+    "git commit": ("dev_workflow", "git"),
+    "git push": ("dev_workflow", "git"),
+    "git rebase": ("dev_workflow", "git"),
+    "git branch": ("dev_workflow", "git"),
+    "github actions": ("dev_workflow", "ci"),
+    "code review": ("dev_workflow", "review"),
+    "ruff check": ("dev_workflow", "ci"),
+    "greptile": ("dev_workflow", "review"),
+    "codex": ("dev_workflow", "review"),
+    "ultrareview": ("dev_workflow", "review"),
+    # research wing (external content, system reading, paper notes)
+    "vllm": ("research", "external_systems"),
+    "honcho": ("research", "external_systems"),
+    "agent zero": ("research", "external_systems"),
+    "latent space": ("research", "newsletters"),
+    "newsletter": ("research", "newsletters"),
+    "research paper": ("research", "papers"),
+    "arxiv": ("research", "papers"),
+    "api documentation": ("research", "api_docs"),
+    # integrations wing (third-party providers, APIs we wire into)
+    "minimax": ("integrations", "providers"),
+    "abacus ai": ("integrations", "providers"),
+    "litellm": ("integrations", "providers"),
+    "openrouter": ("integrations", "providers"),
+    "anthropic api": ("integrations", "providers"),
+    "openai api": ("integrations", "providers"),
+    "conway": ("integrations", "third_party_apis"),
+    "composio": ("integrations", "third_party_apis"),
+    # career wing (job search, profile, applications)
+    "resume": ("career", "applications"),
+    "cv revision": ("career", "applications"),
+    "profile.yml": ("career", "profile"),
+    "job application": ("career", "applications"),
+    "ats integration": ("career", "outreach"),
+    "recruiter": ("career", "outreach"),
+    "careerops": ("career", "applications"),
+    "jerbs": ("career", "applications"),
 }
 
 # ---------------------------------------------------------------------------
@@ -212,6 +273,28 @@ _TAG_WING_MAP: dict[str, str] = {
     "autonomy": "autonomy",
     "task": "autonomy",
     "permission": "autonomy",
+    # dev_workflow tag map
+    "git": "dev_workflow",
+    "worktree": "dev_workflow",
+    "pr": "dev_workflow",
+    "pull_request": "dev_workflow",
+    "ci": "dev_workflow",
+    "code_review": "dev_workflow",
+    # research tag map
+    "newsletter": "research",
+    "external_system": "research",
+    "research_paper": "research",
+    # integrations tag map. NOTE: "provider" deliberately stays mapped to
+    # "routing" above (Genesis-internal model providers). User-work
+    # integrations come in via keyword classification on specific service
+    # names (minimax, abacus, litellm, etc.).
+    "third_party_api": "integrations",
+    "integration": "integrations",
+    # career tag map
+    "career": "career",
+    "job_search": "career",
+    "resume": "career",
+    "ats": "career",
 }
 
 

--- a/tests/test_memory/test_taxonomy.py
+++ b/tests/test_memory/test_taxonomy.py
@@ -1,11 +1,73 @@
 """Tests for memory taxonomy classifier."""
 
+import pytest
+
 from genesis.memory.taxonomy import (
     ROOMS,
     WINGS,
     classify,
     detect_wing_from_prompt,
 )
+
+
+class TestUserWorkWings:
+    """The 4 user-work wings added 2026-05-11. Verify classification works
+    for the cluster categories that previously polluted general/uncategorized.
+    """
+
+    @pytest.mark.parametrize(
+        ("content", "expected_wing"),
+        [
+            # dev_workflow
+            ("Opened a pull request to upstream", "dev_workflow"),
+            ("Cleaning up the worktree after merge", "dev_workflow"),
+            ("GitHub Actions failing on macOS runner", "dev_workflow"),
+            ("Ran ruff check and fixed lint issues", "dev_workflow"),
+            ("Greptile review surfaced two findings", "dev_workflow"),
+            # research
+            ("Reading the vLLM paper on continuous batching", "research"),
+            ("Latent Space newsletter on AI engineering", "research"),
+            ("Skimmed the latest agent zero release notes", "research"),
+            ("Honcho session memory benchmark", "research"),
+            # integrations
+            ("Wiring MiniMax video API into the pipeline", "integrations"),
+            ("Abacus AI training run failed", "integrations"),
+            ("Switched to LiteLLM for fallback routing", "integrations"),
+            # career
+            ("Tweaked profile.yml for the new role", "career"),
+            ("Drafted job application cover letter", "career"),
+            ("CareerOps pipeline broken on the conduit", "career"),
+        ],
+    )
+    def test_new_wing_classification(self, content: str, expected_wing: str):
+        result = classify(content)
+        assert result.wing == expected_wing, (
+            f"Expected {expected_wing!r} for {content!r}, got {result.wing!r}/{result.room!r}"
+        )
+
+    def test_new_wings_registered(self):
+        for wing in ("dev_workflow", "research", "integrations", "career"):
+            assert wing in WINGS, f"{wing} missing from WINGS frozenset"
+            assert wing in ROOMS, f"{wing} missing from ROOMS dict"
+            assert ROOMS[wing], f"{wing} has empty room list"
+
+    def test_provider_tag_still_routes_to_routing(self):
+        """Regression guard: adding the integrations wing must not steal the
+        'provider' tag from the routing wing — Genesis-internal model
+        providers should still route to `routing`.
+        """
+        result = classify(
+            "config tweak", tags=["provider", "deepinfra"], source_pipeline="",
+        )
+        assert result.wing == "routing"
+
+    def test_detect_wing_dev_workflow_from_prompt(self):
+        wing = detect_wing_from_prompt("I'm working on a pull request review")
+        assert wing == "dev_workflow"
+
+    def test_detect_wing_career_from_prompt(self):
+        wing = detect_wing_from_prompt("Update my CareerOps profile and ATS integration")
+        assert wing == "career"
 
 
 class TestClassify:


### PR DESCRIPTION
## Summary

Adds four user-work wings (`dev_workflow`, `research`, `integrations`, `career`) to the memory taxonomy alongside the existing Genesis-internal wings (memory, learning, routing, infrastructure, channels, autonomy). Routes git/PR/CI activity, paper reading, third-party API work, and career/job-search content out of `general/uncategorized` and into structured wings.

## Why

The taxonomy was designed around Genesis-internal subsystems, so all user-domain memories collapsed into the catch-all bucket. On this install, 13.8% of the memory store (1,964 of 14,247 rows) had `wing='general'` AND `room='uncategorized'` with zero diversity — an evenly-distributed sample of 40 revealed clear clusters: dev workflow (~30%), investigation/debugging (~25%), research/external content (~15%), integrations (~15%), career (~5%, recent only). The four added wings cover the obvious clusters; the long tail will still land in `general` until reclassified.

## Design notes

- Wing names are deliberately user-domain neutral, not Genesis-internal — these are about what the user works on, not what Genesis does.
- The existing `provider` tag stays mapped to `routing` (Genesis-internal model providers). The integrations wing classifies via specific service names (minimax, abacus, litellm, openrouter, anthropic-api, etc.) instead. Test guards this.
- Earliest-position-in-content rule still wins on overlap, so "Drafted profile.yml" → career but "Updated profile.yml" → infrastructure (because "update" matches first). Tightening that rule is out of scope.

## Test plan

- [x] `tests/test_memory/test_taxonomy.py::TestUserWorkWings` — new test class covering classification for each new wing, registration in WINGS/ROOMS, provider-tag regression guard, and prompt-based wing detection
- [x] All 39 memory taxonomy tests pass (was 20 before this PR)
- [x] Full `tests/test_memory/` suite: 434 pass
- [x] `ruff check .` clean

## Follow-ups

- The original plan included a `wing_audit` surplus task that samples recent `general/uncategorized` rows twice a week and surfaces proposed clusters via Telegram. Filing as a separate follow-up to keep this PR scoped to the structural change.
- One-off reclassification job to apply the new taxonomy retroactively to the ~1,964 existing `general/uncategorized` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)