### PR TITLE
fix(autonomy): overhaul approval system — 6 fixes

### DIFF
--- a/config/autonomy.yaml
+++ b/config/autonomy.yaml
@@ -23,11 +23,11 @@ approval_policy:
   irreversible: "propose"      # Ask user first (always, no exceptions in V3)
 
 # Approval timeout (seconds) per action type
-# Expired = rejected, never auto-approved.
-# null = wait forever (no timeout).
+# All human-action approvals wait forever (no timeout).
+# Timeouts on human-action approvals are effectively auto-rejections.
 approval_timeouts:
-  outreach: 3600         # 60 minutes
-  task_proposal: 86400   # 24 hours
+  outreach: null
+  task_proposal: null
   irreversible: null     # Wait forever
 
 # Regression policy

--- a/src/genesis/autonomy/approval_gate.py
+++ b/src/genesis/autonomy/approval_gate.py
@@ -375,17 +375,25 @@ class AutonomousCliApprovalGate:
             return request_id
         return None
 
-    async def approve_all_pending(self, *, resolved_by: str) -> int:
+    async def approve_all_pending(
+        self, *, resolved_by: str, subsystem: str | None = None,
+    ) -> int:
         """Approve all pending CLI-fallback approval requests. Returns count.
 
-        Scoped to ``autonomous_cli_fallback`` action type only — does NOT
-        touch approval requests from other subsystems (ego, modules, etc.).
+        Scoped to ``autonomous_cli_fallback`` action type only.  When
+        *subsystem* is provided, further restricts to requests whose
+        context matches that subsystem (e.g. only inbox, only ego).
+        Pass ``None`` for the dashboard "approve everything" path.
         """
         pending = await self._approval_manager.get_pending()
         count = 0
         for req in pending:
             if req.get("action_type") != "autonomous_cli_fallback":
                 continue
+            if subsystem is not None:
+                ctx = _json_loads(req.get("context"))
+                if ctx.get("subsystem") != subsystem:
+                    continue
             ok = await self._approval_manager.resolve(
                 req["id"], status="approved", resolved_by=resolved_by,
             )
@@ -399,6 +407,14 @@ class AutonomousCliApprovalGate:
         return await self._approval_manager.resolve(
             request_id, status=decision, resolved_by=resolved_by,
         )
+
+    async def get_request_subsystem(self, request_id: str) -> str | None:
+        """Return the subsystem from a request's context, or ``None``."""
+        row = await self._approval_manager.get_by_id(request_id)
+        if not row:
+            return None
+        context = _json_loads(row.get("context"))
+        return context.get("subsystem")
 
     async def _find_existing(
         self, approval_key: str,
@@ -647,9 +663,14 @@ class AutonomousCliApprovalGate:
                     "✅ Approve",
                     callback_data=f"cli_approve:{request_id}",
                 )]]
-                if pending_count >= 2:
+                if pending_count >= 1:
+                    btn_label = (
+                        f"Approve all {pending_count} pending"
+                        if pending_count > 1
+                        else "Approve all pending"
+                    )
                     rows.append([InlineKeyboardButton(
-                        f"✅✅ Approve all {pending_count} pending",
+                        f"✅✅ {btn_label}",
                         callback_data=f"cli_approve_all:{request_id}",
                     )])
                 keyboard = InlineKeyboardMarkup(rows)

--- a/src/genesis/autonomy/classification.py
+++ b/src/genesis/autonomy/classification.py
@@ -39,11 +39,11 @@ _DEFAULT_APPROVAL_POLICY: dict[str, str] = {
 }
 
 _DEFAULT_APPROVAL_TIMEOUTS: dict[str, int | None] = {
-    "outreach": 3600,
-    "task_proposal": 86400,
-    "autonomous_cli_fallback": 3600,    # 1h — ego/reflection/sentinel cycles
-    "sentinel_dispatch": 7200,           # 2h — sentinel needs more response time
-    "sentinel_action": 7200,
+    "outreach": None,
+    "task_proposal": None,
+    "autonomous_cli_fallback": None,
+    "sentinel_dispatch": None,
+    "sentinel_action": None,
     "irreversible": None,
 }
 

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -987,6 +987,22 @@ async def handle_text(ctx: HandlerContext, update: Update, context: ContextTypes
         await _handle_text_inner(ctx, msg, user, tid)
 
 
+async def _resolution_label(gate, request_id: str) -> str:
+    """Look up actual approval status to show a meaningful label."""
+    try:
+        row = await gate.approval_manager.get_by_id(request_id)
+        actual = row.get("status") if row else "unknown"
+    except Exception:
+        actual = "unknown"
+    if actual == "expired":
+        return "⏰ Expired"
+    if actual == "approved":
+        return "✅ Already approved"
+    if actual == "cancelled":
+        return "🚫 Cancelled"
+    return f"⚠️ Already resolved ({actual})"
+
+
 async def handle_callback_query(ctx: HandlerContext, update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Handle inline keyboard button presses (approval flows).
 
@@ -1042,20 +1058,7 @@ async def handle_callback_query(ctx: HandlerContext, update: Update, context: Co
         if ok:
             label = "✅ Approved"
         else:
-            # Look up actual status for a meaningful label
-            try:
-                _row = await ctx.autonomous_cli_gate.approval_manager.get_by_id(key)
-                _actual = _row.get("status") if _row else "unknown"
-            except Exception:
-                _actual = "unknown"
-            if _actual == "expired":
-                label = "⏰ Expired"
-            elif _actual == "approved":
-                label = "✅ Already approved"
-            elif _actual == "cancelled":
-                label = "🚫 Cancelled"
-            else:
-                label = f"⚠️ Already resolved ({_actual})"
+            label = await _resolution_label(ctx.autonomous_cli_gate, key)
         log.info("cli_approve %s → %s (user %s)", key, label, user.id)
         try:
             original = query.message.text_html or query.message.text or ""
@@ -1084,12 +1087,23 @@ async def handle_callback_query(ctx: HandlerContext, update: Update, context: Co
                 key, decision="approved",
                 resolved_by=f"telegram:batch:{user.id}",
             )
-            # Scope batch to same subsystem as the triggering request
+            # Scope batch to same subsystem as the triggering request.
+            # If subsystem lookup fails (request gone), skip batch to avoid
+            # accidentally approving all subsystems (the single approve
+            # above already resolved the triggering request).
             _subsystem = await ctx.autonomous_cli_gate.get_request_subsystem(key)
-            batch_count = await ctx.autonomous_cli_gate.approve_all_pending(
-                resolved_by=f"telegram:batch:{user.id}",
-                subsystem=_subsystem,
-            )
+            if _subsystem is not None:
+                batch_count = await ctx.autonomous_cli_gate.approve_all_pending(
+                    resolved_by=f"telegram:batch:{user.id}",
+                    subsystem=_subsystem,
+                )
+            else:
+                log.warning(
+                    "cli_approve_all: subsystem lookup failed for %s — "
+                    "skipping batch to avoid cross-subsystem approve",
+                    key,
+                )
+                batch_count = 0
         except Exception:
             log.error(
                 "Failed to resolve cli_approve_all for %s", key, exc_info=True,
@@ -1099,19 +1113,7 @@ async def handle_callback_query(ctx: HandlerContext, update: Update, context: Co
         if total:
             label = f"✅ Approved ({total} total)"
         else:
-            try:
-                _row = await ctx.autonomous_cli_gate.approval_manager.get_by_id(key)
-                _actual = _row.get("status") if _row else "unknown"
-            except Exception:
-                _actual = "unknown"
-            if _actual == "expired":
-                label = "⏰ Expired"
-            elif _actual == "approved":
-                label = "✅ Already approved"
-            elif _actual == "cancelled":
-                label = "🚫 Cancelled"
-            else:
-                label = f"⚠️ Already resolved ({_actual})"
+            label = await _resolution_label(ctx.autonomous_cli_gate, key)
         log.info(
             "cli_approve_all triggered by %s: triggered=%s batch=%d total=%d (user %s)",
             key, triggered_ok, batch_count, total, user.id,

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -1039,7 +1039,23 @@ async def handle_callback_query(ctx: HandlerContext, update: Update, context: Co
                 "Failed to resolve cli_approve for request %s", key, exc_info=True,
             )
             return
-        label = "✅ Approved" if ok else "⚠️ Already resolved"
+        if ok:
+            label = "✅ Approved"
+        else:
+            # Look up actual status for a meaningful label
+            try:
+                _row = await ctx.autonomous_cli_gate.approval_manager.get_by_id(key)
+                _actual = _row.get("status") if _row else "unknown"
+            except Exception:
+                _actual = "unknown"
+            if _actual == "expired":
+                label = "⏰ Expired"
+            elif _actual == "approved":
+                label = "✅ Already approved"
+            elif _actual == "cancelled":
+                label = "🚫 Cancelled"
+            else:
+                label = f"⚠️ Already resolved ({_actual})"
         log.info("cli_approve %s → %s (user %s)", key, label, user.id)
         try:
             original = query.message.text_html or query.message.text or ""
@@ -1068,8 +1084,11 @@ async def handle_callback_query(ctx: HandlerContext, update: Update, context: Co
                 key, decision="approved",
                 resolved_by=f"telegram:batch:{user.id}",
             )
+            # Scope batch to same subsystem as the triggering request
+            _subsystem = await ctx.autonomous_cli_gate.get_request_subsystem(key)
             batch_count = await ctx.autonomous_cli_gate.approve_all_pending(
                 resolved_by=f"telegram:batch:{user.id}",
+                subsystem=_subsystem,
             )
         except Exception:
             log.error(
@@ -1077,7 +1096,22 @@ async def handle_callback_query(ctx: HandlerContext, update: Update, context: Co
             )
             return
         total = batch_count + (1 if triggered_ok else 0)
-        label = f"✅ Approved ({total} total)" if total else "⚠️ Already resolved"
+        if total:
+            label = f"✅ Approved ({total} total)"
+        else:
+            try:
+                _row = await ctx.autonomous_cli_gate.approval_manager.get_by_id(key)
+                _actual = _row.get("status") if _row else "unknown"
+            except Exception:
+                _actual = "unknown"
+            if _actual == "expired":
+                label = "⏰ Expired"
+            elif _actual == "approved":
+                label = "✅ Already approved"
+            elif _actual == "cancelled":
+                label = "🚫 Cancelled"
+            else:
+                label = f"⚠️ Already resolved ({_actual})"
         log.info(
             "cli_approve_all triggered by %s: triggered=%s batch=%d total=%d (user %s)",
             key, triggered_ok, batch_count, total, user.id,

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -446,6 +446,26 @@ class InboxMonitor:
     # Phase 2: Detect new/modified files
     # =================================================================
 
+    async def _scan_and_dedup(
+        self, watch: Path, resumed_paths: set[str],
+    ) -> tuple[list[Path], list[Path]]:
+        """Scan for new/modified files and dedup against resumed paths."""
+        from genesis.db.crud import inbox_items
+
+        known = await inbox_items.get_all_known(
+            self._db, max_retries=self._config.max_retries,
+        )
+        new_files, modified_files = detect_changes(
+            watch, known, self._config.response_dir,
+            recursive=self._config.recursive,
+        )
+        if resumed_paths:
+            new_files = [f for f in new_files if str(f) not in resumed_paths]
+            modified_files = [
+                f for f in modified_files if str(f) not in resumed_paths
+            ]
+        return new_files, modified_files
+
     async def _phase_detect_changes(
         self,
         watch: Path,
@@ -453,12 +473,15 @@ class InboxMonitor:
     ) -> tuple[list[Path], list[Path]]:
         """Detect new and modified files in the inbox folder.
 
-        Returns ``(new_files, modified_files)``.  Skips detection
-        entirely if a call-site approval is pending.
+        Returns ``(new_files, modified_files)``.  When a call-site
+        approval is pending, still scans for new files.  If new content
+        arrives, cancels the stale approval so a fresh one reflecting
+        the updated inbox state can be created.
         """
         from genesis.db.crud import inbox_items
 
-        # Call-site gating pre-check: skip detection if approval pending.
+        # Call-site gating pre-check: check if approval is pending.
+        pending = None
         if self._autonomous_dispatcher is not None:
             try:
                 pending = await (
@@ -472,32 +495,67 @@ class InboxMonitor:
                     "proceeding without pre-check",
                     exc_info=True,
                 )
-                pending = None
-            if pending is not None:
+
+        if pending is not None:
+            # Approval pending — scan anyway to detect new content.
+            new_files, modified_files = await self._scan_and_dedup(
+                watch, resumed_paths,
+            )
+            if not new_files and not modified_files:
                 logger.info(
-                    "Inbox new/modified file detection skipped — "
-                    "call site blocked on approval %s",
+                    "Inbox detection skipped — approval %s pending, "
+                    "no new files",
                     pending.get("id"),
                 )
                 return [], []
 
-        known = await inbox_items.get_all_known(
-            self._db, max_retries=self._config.max_retries,
-        )
+            # New content while approval pending — cancel the stale
+            # approval so a fresh one with updated content is created.
+            pending_id = pending.get("id")
+            logger.info(
+                "New inbox files detected while approval %s pending — "
+                "cancelling stale approval to refresh",
+                pending_id,
+            )
+            try:
+                gate = self._autonomous_dispatcher.approval_gate
+                await gate.approval_manager.cancel(pending_id)
+            except Exception:
+                logger.warning(
+                    "Failed to cancel stale inbox approval %s; "
+                    "proceeding with new detection anyway",
+                    pending_id,
+                    exc_info=True,
+                )
 
-        new_files, modified_files = detect_changes(
-            watch, known, self._config.response_dir,
-            recursive=self._config.recursive,
-        )
+            # Invalidate inbox_items parked on the cancelled approval.
+            try:
+                awaiting = await inbox_items.get_awaiting_approval(self._db)
+                for row in awaiting:
+                    marker = str(row.get("error_message") or "")
+                    if marker == (
+                        f"{inbox_items.AWAITING_APPROVAL_PREFIX}{pending_id}"
+                    ):
+                        await inbox_items.update_status(
+                            self._db, str(row["id"]),
+                            status="failed",
+                            error_message=(
+                                f"{inbox_items.APPROVAL_INVALIDATED_PREFIX}"
+                                "superseded by new inbox scan"
+                            ),
+                            processed_at=self._clock().isoformat(),
+                        )
+            except Exception:
+                logger.warning(
+                    "Failed to invalidate parked inbox items for %s",
+                    pending_id,
+                    exc_info=True,
+                )
 
-        # Dedup resumed paths out of new/modified lists (TOCTOU guard).
-        if resumed_paths:
-            new_files = [f for f in new_files if str(f) not in resumed_paths]
-            modified_files = [
-                f for f in modified_files if str(f) not in resumed_paths
-            ]
+            return new_files, modified_files
 
-        return new_files, modified_files
+        # Normal path: no approval pending.
+        return await self._scan_and_dedup(watch, resumed_paths)
 
     # =================================================================
     # Phase 3: Create DB records for changed files

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -773,11 +773,75 @@ class SentinelDispatcher:
                     )
                 return await self._phase2_cc_and_actions(request, pattern=pattern)
             if policy_id == "sentinel_action":
-                # No re-verification here — actions are tied to a specific CC
-                # diagnosis, not to alarm state.  The CC session already ran
-                # and proposed actions; even if the original alarm cleared,
-                # the proposed fix may still be needed.
                 logger.info("Resuming sentinel actions after approval %s", request_id)
+
+                # Intelligent staleness guard: if original alarms cleared,
+                # check whether the system self-healed or the root cause
+                # shifted before executing potentially stale actions.
+                alarms_still_active = await self._re_verify_alarms(request)
+                if not alarms_still_active:
+                    try:
+                        from genesis.mcp.health_mcp import _impl_health_alerts
+                        current_alerts = await _impl_health_alerts(active_only=True)
+                    except Exception:
+                        logger.warning(
+                            "Cannot verify system health for stale sentinel "
+                            "action — proceeding with actions",
+                            exc_info=True,
+                        )
+                        current_alerts = None
+
+                    if current_alerts is not None and not current_alerts:
+                        # System healthy — self-healed, skip stale actions
+                        logger.info(
+                            "Sentinel actions cancelled — original alarms "
+                            "cleared and system is healthy (self-healed "
+                            "during action approval wait)",
+                        )
+                        self._state.clear_pending()
+                        self._state.transition(
+                            SentinelState.HEALTHY,
+                            reason="self-healed during action approval wait",
+                        )
+                        save_state(self._state)
+                        return SentinelResult(
+                            dispatched=False,
+                            reason=(
+                                "System self-healed — original alarms "
+                                "cleared, no current alerts"
+                            ),
+                        )
+                    elif current_alerts:
+                        # Different alarms — root cause shifted
+                        logger.warning(
+                            "Sentinel actions stale — original alarms "
+                            "cleared but new alerts present: %s. "
+                            "Cancelling stale actions, will re-investigate.",
+                            [
+                                a.get("alert_id", "?")
+                                if isinstance(a, dict) else getattr(a, "alert_id", "?")
+                                for a in current_alerts[:5]
+                            ],
+                        )
+                        self._state.clear_pending()
+                        self._state.transition(
+                            SentinelState.ALARM_DETECTED,
+                            reason=(
+                                "root cause shifted during action approval "
+                                "wait — re-investigating"
+                            ),
+                        )
+                        save_state(self._state)
+                        return SentinelResult(
+                            dispatched=False,
+                            reason=(
+                                "Root cause shifted — new alarms present, "
+                                "re-investigating"
+                            ),
+                        )
+                    # current_alerts is None (health check failed) — proceed
+                    # with actions (fail-open)
+
                 cc_result = _deserialize_result(self._state.pending_cc_result_json)
                 if cc_result is None:
                     logger.error("Sentinel resume: failed to deserialize CC result")

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -825,7 +825,7 @@ class SentinelDispatcher:
                         )
                         self._state.clear_pending()
                         self._state.transition(
-                            SentinelState.ALARM_DETECTED,
+                            SentinelState.INVESTIGATING,
                             reason=(
                                 "root cause shifted during action approval "
                                 "wait — re-investigating"

--- a/tests/test_autonomy/test_autonomous_dispatch.py
+++ b/tests/test_autonomy/test_autonomous_dispatch.py
@@ -651,13 +651,17 @@ async def test_send_request_builds_batch_button_when_two_pending(
     assert len(runtime.pipeline.sent) == 2
     first_markup = runtime.pipeline.sent[0][2]
     second_markup = runtime.pipeline.sent[1][2]
-    # First send had pending_count=1 → single row only
-    assert len(first_markup.inline_keyboard) == 1
-    # Second send had pending_count=2 → two rows (single + batch)
+    # Both sends include batch button (always shown when pending_count >= 1)
+    assert len(first_markup.inline_keyboard) == 2
     assert len(second_markup.inline_keyboard) == 2
-    # The second row is the batch button with the "Approve all" callback prefix
-    batch_button = second_markup.inline_keyboard[1][0]
-    assert batch_button.callback_data.startswith("cli_approve_all:")
+    # First send: singular label ("Approve all pending")
+    first_batch = first_markup.inline_keyboard[1][0]
+    assert first_batch.callback_data.startswith("cli_approve_all:")
+    assert "Approve all pending" in first_batch.text
+    # Second send: plural label ("Approve all 2 pending")
+    second_batch = second_markup.inline_keyboard[1][0]
+    assert second_batch.callback_data.startswith("cli_approve_all:")
+    assert "Approve all 2 pending" in second_batch.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_autonomy/test_classification.py
+++ b/tests/test_autonomy/test_classification.py
@@ -63,11 +63,11 @@ class TestGetTimeout:
 
     def test_outreach_timeout(self) -> None:
         c = self._make_classifier()
-        assert c.get_timeout("outreach") == 3600
+        assert c.get_timeout("outreach") is None
 
     def test_task_proposal_timeout(self) -> None:
         c = self._make_classifier()
-        assert c.get_timeout("task_proposal") == 86400
+        assert c.get_timeout("task_proposal") is None
 
     def test_irreversible_timeout_none(self) -> None:
         c = self._make_classifier()
@@ -79,15 +79,15 @@ class TestGetTimeout:
 
     def test_autonomous_cli_fallback_timeout(self) -> None:
         c = self._make_classifier()
-        assert c.get_timeout("autonomous_cli_fallback") == 3600
+        assert c.get_timeout("autonomous_cli_fallback") is None
 
     def test_sentinel_dispatch_timeout(self) -> None:
         c = self._make_classifier()
-        assert c.get_timeout("sentinel_dispatch") == 7200
+        assert c.get_timeout("sentinel_dispatch") is None
 
     def test_sentinel_action_timeout(self) -> None:
         c = self._make_classifier()
-        assert c.get_timeout("sentinel_action") == 7200
+        assert c.get_timeout("sentinel_action") is None
 
 
 # ---------------------------------------------------------------------------
@@ -121,7 +121,7 @@ class TestConfigLoading:
         # Should still produce V3 defaults
         assert c.classify(ActionClass.REVERSIBLE, 1) is ApprovalDecision.ACT
         assert c.classify(ActionClass.COSTLY_REVERSIBLE, 1) is ApprovalDecision.PROPOSE
-        assert c.get_timeout("outreach") == 3600
+        assert c.get_timeout("outreach") is None
 
     def test_malformed_yaml_uses_defaults(self, tmp_path) -> None:
         cfg = tmp_path / "autonomy.yaml"
@@ -129,7 +129,7 @@ class TestConfigLoading:
         c = ActionClassifier(config_path=cfg, rules_path=tmp_path / "no_rules.yaml")
         # Falls back to V3 defaults
         assert c.classify(ActionClass.IRREVERSIBLE, 1) is ApprovalDecision.PROPOSE
-        assert c.get_timeout("task_proposal") == 86400
+        assert c.get_timeout("task_proposal") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_inbox/test_monitor.py
+++ b/tests/test_inbox/test_monitor.py
@@ -1030,7 +1030,10 @@ def _make_wired_dispatcher(
     async def _get_by_id(request_id: str):
         return approval_by_id.get(request_id)
 
-    approval_manager = SimpleNamespace(get_by_id=_get_by_id)
+    async def _cancel(request_id: str):
+        return True
+
+    approval_manager = SimpleNamespace(get_by_id=_get_by_id, cancel=_cancel)
     # Use the PUBLIC accessor names: the resume pass walks
     # dispatcher.approval_gate.approval_manager via public properties
     # so wrappers/test doubles that only mirror the public API still
@@ -1046,13 +1049,11 @@ def _make_wired_dispatcher(
 
 
 @pytest.mark.asyncio
-async def test_precheck_skips_detection_when_site_blocked(
+async def test_precheck_skips_detection_when_site_blocked_no_new_files(
     monitor, inbox_dir, mock_invoker, db,
 ):
-    """When an inbox_evaluation approval is already pending, detection
-    of new files must be skipped entirely — no new inbox_items rows,
-    no new Telegram prompt, no dispatch calls for the new file."""
-    # Simulate a pending approval for the inbox call site
+    """When an inbox_evaluation approval is already pending and no new
+    files were added, detection still short-circuits — no dispatch."""
     pending_site_row = {
         "id": "req-already-pending",
         "status": "pending",
@@ -1071,21 +1072,56 @@ async def test_precheck_skips_detection_when_site_blocked(
         pending_sites=[pending_site_row],
     )
 
-    # Drop a NEW file — normally this would create a row and dispatch
-    (inbox_dir / "new-while-blocked.md").write_text("fresh content")
+    # No new files — just run check
     result = await monitor.check_once()
 
-    # No row was created for the new file — creation was skipped entirely
-    rows = [dict(r) for r in (await (await db.execute(
-        "SELECT * FROM inbox_items WHERE file_path LIKE '%new-while-blocked%'",
-    )).fetchall())]
-    assert len(rows) == 0, (
-        f"pre-check should have skipped row creation, got: {rows}"
-    )
-    # No dispatch happened (no resume items, detect_changes was skipped)
+    # No dispatch happened
     monitor._autonomous_dispatcher.route.assert_not_called()
     assert result.batches_dispatched == 0
     mock_invoker.run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_precheck_refreshes_when_new_files_added_while_blocked(
+    monitor, inbox_dir, mock_invoker, db,
+):
+    """When an inbox_evaluation approval is pending but new files arrive,
+    the stale approval is cancelled and files are detected so a fresh
+    approval reflecting the current inbox state can be created."""
+    pending_site_row = {
+        "id": "req-already-pending",
+        "status": "pending",
+        "action_type": "autonomous_cli_fallback",
+        "_context": {
+            "subsystem": "inbox",
+            "policy_id": "inbox_evaluation",
+        },
+    }
+    # After the stale approval is cancelled, the dispatch will create
+    # a new approval request (blocked again with a new request id).
+    decision = AutonomousDispatchDecision(
+        mode="blocked", reason="approval requested",
+        approval_request_id="req-fresh",
+    )
+    monitor._autonomous_dispatcher = _make_wired_dispatcher(
+        decision=decision,
+        pending_sites=[pending_site_row],
+    )
+
+    # Drop a NEW file while approval is pending
+    (inbox_dir / "new-while-blocked.md").write_text("fresh content")
+    await monitor.check_once()
+
+    # The new file WAS detected and a row was created
+    rows = [dict(r) for r in (await (await db.execute(
+        "SELECT * FROM inbox_items WHERE file_path LIKE '%new-while-blocked%'",
+    )).fetchall())]
+    assert len(rows) == 1, (
+        f"new file should have been detected after stale approval cancel, "
+        f"got: {rows}"
+    )
+    # Dispatch was attempted (creating a fresh approval)
+    monitor._autonomous_dispatcher.route.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_outreach/test_callback_handler.py
+++ b/tests/test_outreach/test_callback_handler.py
@@ -130,6 +130,11 @@ def _make_gate_ctx(*, allowed_users=None, resolve_ok=True, batch_count=0):
     gate = MagicMock()
     gate.resolve_request = AsyncMock(return_value=resolve_ok)
     gate.approve_all_pending = AsyncMock(return_value=batch_count)
+    gate.get_request_subsystem = AsyncMock(return_value="test_subsystem")
+    # For Fix 2 status-aware labels when resolve_ok=False
+    approval_mgr = MagicMock()
+    approval_mgr.get_by_id = AsyncMock(return_value={"status": "approved"})
+    gate.approval_manager = approval_mgr
     ctx.autonomous_cli_gate = gate
     return ctx, gate
 
@@ -194,7 +199,7 @@ async def test_cli_approve_double_click_is_graceful():
     # Message edit still happens, with "Already resolved" marker
     update.callback_query.edit_message_text.assert_awaited_once()
     edit_text = update.callback_query.edit_message_text.call_args.kwargs["text"]
-    assert "Already resolved" in edit_text
+    assert "Already approved" in edit_text
 
 
 @pytest.mark.asyncio

--- a/tests/test_sentinel/test_dispatcher.py
+++ b/tests/test_sentinel/test_dispatcher.py
@@ -14,6 +14,7 @@ from genesis.sentinel.dispatcher import (
     _ESCALATE_AT_ATTEMPT,
     SentinelDispatcher,
     SentinelRequest,
+    SentinelResult,
     _extract_pattern,
 )
 from genesis.sentinel.state import SentinelState, SentinelStateData
@@ -672,3 +673,123 @@ class TestRejectionWindow:
 
         assert "memory:critical" in loaded.rejected_patterns
         assert loaded.rejected_patterns["memory:critical"] == expiry
+
+
+# ---------------------------------------------------------------------------
+# TestSentinelActionStalenessGuard — resume_from_approval for sentinel_action
+# ---------------------------------------------------------------------------
+
+
+def _setup_pending_action(dispatcher, *, request_id="req-action-1", alarm_id="test:alarm"):
+    """Set up dispatcher state as if waiting for sentinel_action approval."""
+    import json
+    request_data = {
+        "trigger_source": "fire_alarm",
+        "trigger_reason": "test alarm",
+        "tier": 2,
+        "alarms": [{"alert_id": alarm_id, "tier": 2, "severity": "critical", "message": "test alarm"}],
+        "context": {},
+    }
+    cc_result_data = {
+        "dispatched": True,
+        "session_id": "sess-1",
+        "diagnosis": "test diagnosis",
+        "actions_taken": [],
+        "proposed_actions": [{"command": "systemctl restart test", "description": "restart", "safe": True}],
+        "resolved": False,
+        "observation_id": "",
+        "reason": "",
+        "duration_s": 10.0,
+    }
+    dispatcher._state.pending_request_id = request_id
+    dispatcher._state.pending_policy_id = "sentinel_action"
+    dispatcher._state.pending_pattern = alarm_id
+    dispatcher._state.pending_request_json = json.dumps(request_data)
+    dispatcher._state.pending_cc_result_json = json.dumps(cc_result_data)
+    dispatcher._state.transition(
+        SentinelState.AWAITING_ACTION_APPROVAL,
+        reason="test setup",
+    )
+
+
+class TestSentinelActionStalenessGuard:
+    """Tests for the intelligent staleness guard on sentinel_action resume."""
+
+    @pytest.mark.asyncio
+    async def test_alarms_still_active_proceeds(self):
+        """When original alarms are still active, actions execute normally."""
+        d = _make_dispatcher()
+        _setup_pending_action(d)
+
+        mock_execute = AsyncMock(return_value=[])
+        with patch.object(d, "_re_verify_alarms", new_callable=AsyncMock, return_value=True), \
+             patch.object(d, "_execute_approved_actions", mock_execute), \
+             patch.object(d, "_finalize_dispatch", new_callable=AsyncMock, return_value=SentinelResult(dispatched=True)), \
+             patch("genesis.sentinel.dispatcher.save_state"):
+            result = await d.resume_from_approval("req-action-1", "approved")
+
+        assert result is not None
+        assert result.dispatched is True
+        mock_execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_self_healed_skips_actions(self):
+        """When original alarms cleared and system is healthy, skip stale actions."""
+        d = _make_dispatcher()
+        _setup_pending_action(d)
+
+        with patch.object(d, "_re_verify_alarms", new_callable=AsyncMock, return_value=False), \
+             patch("genesis.mcp.health_mcp._impl_health_alerts", new_callable=AsyncMock, return_value=[]), \
+             patch("genesis.sentinel.dispatcher.save_state"):
+            result = await d.resume_from_approval("req-action-1", "approved")
+
+        assert result is not None
+        assert result.dispatched is False
+        assert "self-healed" in result.reason.lower()
+        assert d._state.state == SentinelState.HEALTHY
+
+    @pytest.mark.asyncio
+    async def test_root_cause_shifted_reinvestigates(self):
+        """When original alarms cleared but new alerts exist, transition to ALARM_DETECTED."""
+        d = _make_dispatcher()
+        _setup_pending_action(d)
+
+        new_alerts = [{"alert_id": "different:alarm", "tier": 1}]
+
+        with patch.object(d, "_re_verify_alarms", new_callable=AsyncMock, return_value=False), \
+             patch("genesis.mcp.health_mcp._impl_health_alerts", new_callable=AsyncMock, return_value=new_alerts), \
+             patch("genesis.sentinel.dispatcher.save_state"):
+            result = await d.resume_from_approval("req-action-1", "approved")
+
+        assert result is not None
+        assert result.dispatched is False
+        assert "shifted" in result.reason.lower() or "re-investigating" in result.reason.lower()
+        assert d._state.state == SentinelState.INVESTIGATING
+
+    @pytest.mark.asyncio
+    async def test_health_check_fails_proceeds_failopen(self):
+        """When health check fails (can't verify), proceed with actions (fail-open)."""
+        d = _make_dispatcher()
+        _setup_pending_action(d)
+
+        mock_execute = AsyncMock(return_value=[])
+        with patch.object(d, "_re_verify_alarms", new_callable=AsyncMock, return_value=False), \
+             patch("genesis.mcp.health_mcp._impl_health_alerts", new_callable=AsyncMock, side_effect=Exception("health unavailable")), \
+             patch.object(d, "_execute_approved_actions", mock_execute), \
+             patch.object(d, "_finalize_dispatch", new_callable=AsyncMock, return_value=SentinelResult(dispatched=True)), \
+             patch("genesis.sentinel.dispatcher.save_state"):
+            result = await d.resume_from_approval("req-action-1", "approved")
+
+        assert result is not None
+        mock_execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_mismatched_request_id_skips(self):
+        """Resume with wrong request_id returns None (stale resume)."""
+        d = _make_dispatcher()
+        _setup_pending_action(d, request_id="req-action-1")
+
+        with patch("genesis.sentinel.dispatcher.save_state"):
+            result = await d.resume_from_approval("req-wrong-id", "approved")
+
+        assert result is None


### PR DESCRIPTION
## Summary

Six fixes to the Telegram approval system, addressing user-reported issues with ghost approvals, missing UI elements, stale inbox approvals, and approval timeouts that effectively auto-reject.

- **Remove all approval timeouts** — human-action approvals now wait forever instead of auto-expiring after 1-2 hours
- **Status-aware resolution labels** — shows "Expired" / "Already approved" / "Cancelled" instead of generic "Already resolved"
- **Always show "approve all" button** — threshold lowered from ≥2 to ≥1 pending requests
- **Scope "approve all" by subsystem** — batch approve on an inbox message only approves other inbox requests, not ego/reflections
- **Refresh inbox approval on new files** — cancels stale approval when new files arrive in ~/inbox/ and creates a fresh one
- **Sentinel action staleness guard** — re-verifies alarms before executing approved actions; skips if self-healed, re-investigates if root cause shifted

## Test plan

- [x] `ruff check .` — all lint clean
- [x] `pytest tests/test_autonomy/test_classification.py` — 23 passed (timeout tests updated)
- [x] `pytest tests/test_autonomy/test_autonomous_dispatch.py` — batch button test updated
- [x] `pytest tests/test_outreach/test_callback_handler.py` — 11 passed (mock fixtures updated)
- [x] `pytest tests/test_inbox/test_monitor.py` — 57 passed (precheck test split into no-new-files + refresh cases)
- [x] `pytest tests/test_sentinel/` — 74 passed
- [x] All 204 targeted tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)