### PR TITLE
fix(memory): reliable KB tagging in proactive hook

### DIFF
--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -595,6 +595,7 @@ async def _search_qdrant(
                         "memory_class": payload.get("memory_class", "fact"),
                         "_retrieved_count": payload.get("retrieved_count", 0),
                         "_wing": payload.get("wing"),
+                        "collection": collection,
                     })
                 return results
     except Exception as exc:


### PR DESCRIPTION
## Summary

- Add `collection` field to `_search_qdrant()` result dicts in the proactive hook, set from the Qdrant collection parameter (the authoritative source)
- Previously, `[KB | ...]` tagging depended on `_enrich_with_metadata` succeeding, which silently catches all exceptions — if it failed, KB entries would display as `[Memory | ...]`

One-line fix from code review of PR #324.

## Test plan

- [x] `ruff check scripts/proactive_memory_hook.py` — clean
- [x] CI will verify full suite