### PR TITLE
fix(cleanup): unpack 4 columns from memory_metadata SELECT

### DIFF
--- a/scripts/cleanup_subsystem_qdrant.py
+++ b/scripts/cleanup_subsystem_qdrant.py
@@ -95,7 +95,7 @@ async def main(apply: bool = False) -> None:
                 logger.warning("Pre-cleanup count failed for %s: %s", coll, exc)
 
         deleted_count = 0
-        for memory_id, collection, _invalid_at in rows:
+        for memory_id, _subsystem, collection, _invalid_at in rows:
             # Try the recorded collection first, then the other as a
             # defensive fallback (the collection column is mostly reliable
             # but historical inserts pre-#311 sometimes drifted).


### PR DESCRIPTION
## Summary

One-line typo fix in `scripts/cleanup_subsystem_qdrant.py` shipped in #317.

The SELECT returns `(memory_id, source_subsystem, collection, invalid_at)` (4 columns) but the iteration unpacks only 3 values, crashing on the dry-run before any work happens:

```
ValueError: too many values to unpack (expected 3)
```

## Fix

Add `_subsystem` placeholder to the unpacking — the value isn't needed in the loop body since the WHERE clause already filters to subsystem rows.

## Test plan

- [x] Lint clean
- [x] Inline iteration test confirms unpack with mock rows
- [ ] Will validate end-to-end against the prod DB once merged (the dry-run that surfaced the bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)