### PR TITLE
fix(inbox): staleness guard for approvals blocking monitor

### DIFF
--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -25,6 +25,11 @@ logger = logging.getLogger(__name__)
 _PROMPT_DIR = Path(__file__).resolve().parent.parent / "identity"
 _SYSTEM_PROMPT_FILE = "INBOX_EVALUATE.md"
 
+# Max age before a pending inbox approval is considered abandoned.
+# Approvals with timeout_at=None wait indefinitely by design, but the
+# inbox monitor shouldn't block forever if the user never responds.
+_MAX_APPROVAL_STALENESS = timedelta(hours=4)
+
 _FALLBACK_SYSTEM_PROMPT = (
     "You are Genesis performing an inbox evaluation. "
     "Use the filename as your first classification signal — like an email subject line. "
@@ -495,6 +500,38 @@ class InboxMonitor:
                     "proceeding without pre-check",
                     exc_info=True,
                 )
+
+        if pending is not None:
+            # Staleness guard: auto-cancel approvals pending longer than
+            # _MAX_APPROVAL_STALENESS.  Without this, an approval with
+            # timeout_at=None blocks the inbox monitor indefinitely when
+            # the user never responds and no new files arrive.
+            created_str = pending.get("created_at", "")
+            if created_str:
+                try:
+                    created_dt = datetime.fromisoformat(created_str)
+                    age = self._clock() - created_dt
+                    if age > _MAX_APPROVAL_STALENESS:
+                        pending_id = pending.get("id")
+                        logger.info(
+                            "Cancelling stale inbox approval %s "
+                            "(%.1fh old, threshold %.1fh)",
+                            pending_id,
+                            age.total_seconds() / 3600,
+                            _MAX_APPROVAL_STALENESS.total_seconds() / 3600,
+                        )
+                        try:
+                            gate = self._autonomous_dispatcher.approval_gate
+                            await gate.approval_manager.cancel(pending_id)
+                        except Exception:
+                            logger.warning(
+                                "Failed to cancel stale approval %s",
+                                pending_id,
+                                exc_info=True,
+                            )
+                        pending = None  # Cleared — proceed normally
+                except (ValueError, TypeError):
+                    pass
 
         if pending is not None:
             # Approval pending — scan anyway to detect new content.

--- a/tests/test_inbox/test_monitor.py
+++ b/tests/test_inbox/test_monitor.py
@@ -1030,10 +1030,9 @@ def _make_wired_dispatcher(
     async def _get_by_id(request_id: str):
         return approval_by_id.get(request_id)
 
-    async def _cancel(request_id: str):
-        return True
-
-    approval_manager = SimpleNamespace(get_by_id=_get_by_id, cancel=_cancel)
+    approval_manager = SimpleNamespace(
+        get_by_id=_get_by_id, cancel=AsyncMock(return_value=True),
+    )
     # Use the PUBLIC accessor names: the resume pass walks
     # dispatcher.approval_gate.approval_manager via public properties
     # so wrappers/test doubles that only mirror the public API still
@@ -1077,6 +1076,83 @@ async def test_precheck_skips_detection_when_site_blocked_no_new_files(
 
     # No dispatch happened
     monitor._autonomous_dispatcher.route.assert_not_called()
+    assert result.batches_dispatched == 0
+    mock_invoker.run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_precheck_cancels_stale_approval_and_proceeds(
+    monitor, inbox_dir, mock_invoker, db, clock,
+):
+    """When a pending inbox approval exceeds _MAX_APPROVAL_STALENESS,
+    the monitor auto-cancels it and proceeds with normal detection
+    instead of blocking indefinitely."""
+    from genesis.inbox.monitor import _MAX_APPROVAL_STALENESS
+
+    # Create an approval that's older than the staleness threshold
+    stale_created = (clock.now - _MAX_APPROVAL_STALENESS - timedelta(hours=1)).isoformat()
+    pending_site_row = {
+        "id": "req-stale",
+        "status": "pending",
+        "action_type": "autonomous_cli_fallback",
+        "created_at": stale_created,
+        "_context": {
+            "subsystem": "inbox",
+            "policy_id": "inbox_evaluation",
+        },
+    }
+    decision = AutonomousDispatchDecision(
+        mode="allowed", reason="auto-approved",
+    )
+    monitor._autonomous_dispatcher = _make_wired_dispatcher(
+        decision=decision,
+        pending_sites=[pending_site_row],
+    )
+
+    # Drop a file — should be detected because the stale approval is cancelled
+    (inbox_dir / "notes.md").write_text("content after stale approval")
+    result = await monitor.check_once()
+
+    # The stale approval was cancelled and dispatch proceeded
+    monitor._autonomous_dispatcher.approval_gate.approval_manager.cancel.assert_called_once_with(
+        "req-stale",
+    )
+    assert result.items_new == 1
+    assert result.batches_dispatched == 1
+
+
+@pytest.mark.asyncio
+async def test_precheck_does_not_cancel_fresh_approval(
+    monitor, inbox_dir, mock_invoker, db, clock,
+):
+    """A pending approval younger than _MAX_APPROVAL_STALENESS is NOT
+    cancelled — the monitor correctly blocks."""
+    from genesis.inbox.monitor import _MAX_APPROVAL_STALENESS
+
+    # Create an approval that's younger than the staleness threshold
+    fresh_created = (clock.now - _MAX_APPROVAL_STALENESS + timedelta(hours=1)).isoformat()
+    pending_site_row = {
+        "id": "req-fresh",
+        "status": "pending",
+        "action_type": "autonomous_cli_fallback",
+        "created_at": fresh_created,
+        "_context": {
+            "subsystem": "inbox",
+            "policy_id": "inbox_evaluation",
+        },
+    }
+    decision = AutonomousDispatchDecision(
+        mode="blocked", reason="approval requested",
+        approval_request_id="req-fresh",
+    )
+    monitor._autonomous_dispatcher = _make_wired_dispatcher(
+        decision=decision,
+        pending_sites=[pending_site_row],
+    )
+
+    # No new files — should block normally
+    result = await monitor.check_once()
+
     assert result.batches_dispatched == 0
     mock_invoker.run.assert_not_called()
 


### PR DESCRIPTION
## Summary
- A pending approval with `timeout_at=None` blocked the inbox monitor for **3 days** — every 30-min scan skipped because `find_site_pending` returned the stale row
- Adds a staleness guard: approvals pending > 4 hours are auto-cancelled so the monitor always recovers
- Also made the test helper's `cancel` an `AsyncMock` for proper call assertion

## Root cause
`autonomous_cli_fallback` approvals use `timeout_at=None` by design (wait indefinitely). When the user never responds and no new files arrive, `_phase_detect_changes` blocks forever — `_is_timed_out` returns False, `expire_timed_out` only handles non-null timeouts.

## Test plan
- [x] `test_precheck_cancels_stale_approval_and_proceeds` — stale approval (>4h) is cancelled, detection proceeds
- [x] `test_precheck_does_not_cancel_fresh_approval` — fresh approval (<4h) correctly blocks
- [x] All 59 inbox monitor tests pass
- [x] Ruff clean