### PR TITLE
fix(inbox): normalize content hash + strengthen YouTube fallback

### DIFF
--- a/src/genesis/identity/INBOX_EVALUATE.md
+++ b/src/genesis/identity/INBOX_EVALUATE.md
@@ -103,6 +103,13 @@ You MUST address every single one:
 
 ## Environment Constraints & Workarounds
 
+- **Before reporting ANY URL as unfetchable**, call `procedure_recall` (via the
+  genesis-memory MCP server) with the URL's domain or content type (e.g.,
+  "youtube transcript fetch", "linkedin video transcript", "paywalled article").
+  The procedure store contains proven workarounds with exact commands. You MUST
+  check procedures before giving up on a URL — reporting "cannot fetch" without
+  checking procedures is a failure.
+
 - **YouTube SSL errors**: This container cannot verify YouTube's SSL certificate
   chain. WebFetch will fail on all YouTube URLs with SSL errors. A PreToolUse
   hook blocks WebFetch for YouTube and provides instructions, but if you reach
@@ -123,6 +130,11 @@ You MUST address every single one:
   curl -sk <youtube_url>
   ```
   Extract `"title":"..."` and `"shortDescription":"..."` from the HTML JSON.
+
+- **You MUST attempt yt-dlp via Bash for ANY YouTube URL before reporting it
+  as unfetchable.** WebFetch will always fail on YouTube in this container.
+  That is expected. The real tool is yt-dlp. If you report a YouTube video
+  as unfetchable without running yt-dlp, you have failed the evaluation.
 
 - **NEVER tell the user to do something you haven't attempted yourself.**
   If WebFetch fails, try yt-dlp. If yt-dlp fails, try curl -k. Only after

--- a/src/genesis/inbox/scanner.py
+++ b/src/genesis/inbox/scanner.py
@@ -41,10 +41,19 @@ def scan_folder(
 
 
 def compute_hash(file_path: Path) -> str:
-    """Compute SHA-256 hex digest of file content."""
-    h = hashlib.sha256()
-    h.update(file_path.read_bytes())
-    return h.hexdigest()
+    """Compute SHA-256 of normalized content (whitespace/encoding-invariant).
+
+    Normalises before hashing so that sync-tool artefacts (BOM changes,
+    CRLF↔LF conversion, trailing-whitespace cleanup) do not trigger
+    spurious re-evaluations.
+    """
+    raw = file_path.read_bytes()
+    if raw.startswith(b"\xef\xbb\xbf"):
+        raw = raw[3:]  # strip UTF-8 BOM
+    text = raw.decode("utf-8", errors="replace")
+    text = text.replace("\r\n", "\n")
+    normalized = "\n".join(line.rstrip() for line in text.split("\n"))
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
 
 
 def read_content(file_path: Path, max_bytes: int = 50_000) -> str:


### PR DESCRIPTION
## Summary
- `compute_hash()` now normalizes content before hashing (strips BOM, CRLF→LF, trailing whitespace) — prevents Obsidian sync from triggering spurious re-evaluations
- `INBOX_EVALUATE.md` strengthened: procedure_recall instruction for all unfetchable URLs + explicit MUST directive for yt-dlp on YouTube

## Context
Inbox evaluation session failed to fetch a YouTube transcript despite having yt-dlp and Bash access. The LLM ignored fallback instructions. Adding procedure_recall gives background sessions access to proven workarounds. Hash normalization prevents sync-tool whitespace changes from triggering duplicate evaluations.

## Test plan
- [x] Hash normalization verified: BOM, CRLF, trailing whitespace all produce same hash; content changes produce different hash
- [ ] Next inbox cycle with YouTube URL confirms transcript is fetched
- [ ] Obsidian sync no longer triggers re-evaluation of unchanged files

🤖 Generated with [Claude Code](https://claude.com/claude-code)