### PR TITLE
fix(ego): remove self-suppression root causes + deep reflection floor bug

### DIFF
--- a/src/genesis/awareness/classifier.py
+++ b/src/genesis/awareness/classifier.py
@@ -48,19 +48,25 @@ async def classify_depth(
         if not bypass_ceiling:
             cfg = thresholds[depth.value]
 
-            # Ceiling: max N reflections per window
+            # Ceiling: max N dispatched reflections per window.
+            # Only count ticks where a reflection was actually dispatched
+            # (not throttled/rate-limited) to prevent failed attempts
+            # from blocking future reflections.
             recent = await awareness_ticks.count_in_window(
                 db,
                 depth=depth.value,
                 window_seconds=cfg["ceiling_window_seconds"],
+                dispatched_only=True,
             )
             if recent >= cfg["ceiling_count"]:
                 continue  # At ceiling — try next lower depth
 
-            # Floor: minimum interval between reflections at this depth
+            # Floor: minimum interval between dispatched reflections.
             floor_s = cfg["floor_seconds"]
             if floor_s > 0:
-                last = await awareness_ticks.last_at_depth(db, depth.value)
+                last = await awareness_ticks.last_at_depth(
+                    db, depth.value, dispatched_only=True,
+                )
                 if last is not None:
                     last_dt = datetime.fromisoformat(last["created_at"])
                     elapsed = (datetime.now(UTC) - last_dt).total_seconds()

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -872,12 +872,22 @@ class AwarenessLoop:
 
         if self._cc_reflection_bridge is not None and depth in (Depth.LIGHT, Depth.DEEP, Depth.STRATEGIC):
             try:
-                await self._cc_reflection_bridge.reflect(
+                ref_result = await self._cc_reflection_bridge.reflect(
                     depth,
                     result,
                     db=db,
                     escalation_source=result.escalation_source if depth == Depth.DEEP else None,
                 )
+                # Mark tick as dispatched only when the bridge confirmed
+                # success.  Throttled / gate-blocked attempts (success=False)
+                # leave dispatched=0 so the floor/ceiling checks don't count
+                # them — preventing rate-limit cascades that block future
+                # reflections for 48h+.
+                if ref_result and ref_result.success:
+                    try:
+                        await awareness_ticks.mark_dispatched(db, tick_id)
+                    except Exception:
+                        logger.warning("Failed to mark tick %s dispatched", tick_id[:8])
                 # Fix 3B: resolve escalation AFTER successful dispatch
                 if result.escalation_pending_id and depth == Depth.DEEP:
                     await self._resolve_escalation(result.escalation_pending_id, result.timestamp)

--- a/src/genesis/db/crud/awareness_ticks.py
+++ b/src/genesis/db/crud/awareness_ticks.py
@@ -15,14 +15,15 @@ async def create(
     created_at: str,
     classified_depth: str | None = None,
     trigger_reason: str | None = None,
+    dispatched: int = 0,
 ) -> str:
     await db.execute(
         """INSERT INTO awareness_ticks
            (id, source, signals_json, scores_json, classified_depth,
-            trigger_reason, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            trigger_reason, created_at, dispatched)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
         (id, source, signals_json, scores_json, classified_depth,
-         trigger_reason, created_at),
+         trigger_reason, created_at, dispatched),
     )
     await db.commit()
     return id
@@ -58,29 +59,62 @@ async def query(
 
 
 async def count_in_window(
-    db: aiosqlite.Connection, *, depth: str, window_seconds: int
+    db: aiosqlite.Connection,
+    *,
+    depth: str,
+    window_seconds: int,
+    dispatched_only: bool = False,
 ) -> int:
-    """Count ticks at a given depth within the last window_seconds."""
-    cursor = await db.execute(
-        """SELECT COUNT(*) as cnt FROM awareness_ticks
-           WHERE classified_depth = ?
-           AND created_at >= strftime('%Y-%m-%dT%H:%M:%f+00:00', 'now', ?)""",
-        (depth, f"-{window_seconds} seconds"),
+    """Count ticks at a given depth within the last window_seconds.
+
+    When *dispatched_only* is True, only ticks where the reflection was
+    actually dispatched (not throttled/failed) are counted.
+    """
+    sql = (
+        "SELECT COUNT(*) as cnt FROM awareness_ticks "
+        "WHERE classified_depth = ? "
+        "AND created_at >= strftime('%Y-%m-%dT%H:%M:%f+00:00', 'now', ?)"
     )
+    params: list = [depth, f"-{window_seconds} seconds"]
+    if dispatched_only:
+        sql += " AND dispatched = 1"
+    cursor = await db.execute(sql, params)
     row = await cursor.fetchone()
     return row["cnt"] if row else 0
 
 
-async def last_at_depth(db: aiosqlite.Connection, depth: str) -> dict | None:
-    """Get the most recent tick at a given depth."""
-    cursor = await db.execute(
-        """SELECT * FROM awareness_ticks
-           WHERE classified_depth = ?
-           ORDER BY created_at DESC LIMIT 1""",
-        (depth,),
+async def last_at_depth(
+    db: aiosqlite.Connection,
+    depth: str,
+    *,
+    dispatched_only: bool = False,
+) -> dict | None:
+    """Get the most recent tick at a given depth.
+
+    When *dispatched_only* is True, only ticks where the reflection was
+    actually dispatched (not throttled/failed) are returned.
+    """
+    sql = (
+        "SELECT * FROM awareness_ticks "
+        "WHERE classified_depth = ?"
     )
+    params: list = [depth]
+    if dispatched_only:
+        sql += " AND dispatched = 1"
+    sql += " ORDER BY created_at DESC LIMIT 1"
+    cursor = await db.execute(sql, params)
     row = await cursor.fetchone()
     return dict(row) if row else None
+
+
+async def mark_dispatched(db: aiosqlite.Connection, tick_id: str) -> bool:
+    """Mark a tick as successfully dispatched (reflection ran)."""
+    cursor = await db.execute(
+        "UPDATE awareness_ticks SET dispatched = 1 WHERE id = ?",
+        (tick_id,),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
 
 
 async def last_tick(db: aiosqlite.Connection) -> dict | None:

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1072,6 +1072,20 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
     # even if the versioned migration (0012) hasn't run yet.
     await _migrate_ego_proposals_status_check(db)
 
+    # Awareness ticks: dispatched flag so floor/ceiling checks only count
+    # ticks where a reflection was actually dispatched (not throttled/failed).
+    await _try_alter(db,
+        "ALTER TABLE awareness_ticks ADD COLUMN dispatched INTEGER NOT NULL DEFAULT 0",
+        "awareness_ticks.dispatched")
+    # Backfill: treat all existing ticks as dispatched to preserve current
+    # floor behavior (prevents a burst of DEEP reflections on first deploy).
+    with contextlib.suppress(Exception):
+        await db.execute(
+            "UPDATE awareness_ticks SET dispatched = 1 "
+            "WHERE classified_depth IS NOT NULL AND dispatched = 0"
+        )
+        await db.commit()
+
     # Phase 1.5: backfill memory_metadata from Qdrant + pending_embeddings.
     # New memories write metadata at store time, but pre-existing memories
     # lack rows. Without backfill, the "recent" dashboard view is empty.

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -307,7 +307,8 @@ TABLES = {
             scores_json      TEXT NOT NULL,
             classified_depth TEXT,
             trigger_reason   TEXT,
-            created_at       TEXT NOT NULL
+            created_at       TEXT NOT NULL,
+            dispatched       INTEGER NOT NULL DEFAULT 0
         )
     """,
     "depth_thresholds": """

--- a/src/genesis/ego/context.py
+++ b/src/genesis/ego/context.py
@@ -142,23 +142,11 @@ class EgoContextBuilder:
             if last_dispatch:
                 lines.append(f"- Last dispatch: {last_dispatch}")
 
-        # Conversation activity
-        convo = snap.get("conversation", {})
-        if convo:
-            lines.append("\n### User Activity")
-            age = convo.get("last_user_message_age_s")
-            if age is not None:
-                minutes = age / 60
-                if minutes < 60:
-                    lines.append(f"- Last user message: {minutes:.0f}min ago")
-                else:
-                    lines.append(
-                        f"- Last user message: {minutes / 60:.1f}h ago"
-                    )
-            lines.append(
-                f"- Recent user turns (24h): "
-                f"{convo.get('recent_user_turns', 0)}"
-            )
+        # User activity signals intentionally omitted — the cadence manager's
+        # idle gate handles timing.  Showing the ego raw user-activity metrics
+        # (last_user_message_age_s, recent_user_turns) triggers LLM deference
+        # bias and self-suppression.  The ego should focus outward on the
+        # system, not inward on the user's availability.
 
         lines.append("")
         return "\n".join(lines)

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -918,39 +918,41 @@ _VALID_NOTEPAD_ACTIONS = frozenset({"add", "update", "remove"})
 # -- Behavioral focus detection --------------------------------------------
 #
 # focus_summary must describe a TOPIC the ego is thinking about, never a
-# BEHAVIORAL state (holding back, waiting, pausing, etc.).  This regex
-# catches known self-suppression patterns.  It is the safety-net layer
-# beneath the prompt guardrails in EGO_SESSION.md.
+# BEHAVIORAL state.  This is a broad structural safety net — it catches
+# any focus starting with a self-referential behavioral verb (holding,
+# waiting, stepping, etc.) regardless of what follows.  The primary fix
+# is removing the signals that trigger self-suppression (user activity
+# metrics, proposal engagement data, communication_decision lever).
+# This regex is the last line of defense.
+#
+# Keep in sync with essential_knowledge._BEHAVIORAL_FOCUS_RE.
 _BEHAVIORAL_FOCUS_RE = re.compile(
     r"(?i)"
-    # Self-referential behavioral states (ego is the implicit subject)
-    r"(?:^holding\s+back"                                 # "Holding back — ..."
-    r"|^stepping\s+back"                                  # "Stepping back while ..."
-    r"|^standing\s+down"                                  # "Standing down until ..."
-    r"|^lying\s+low"                                      # "Lying low during ..."
-    r"|^staying\s+(?:out|quiet)"                          # "Staying quiet while ..."
-    r"|^backing\s+off"                                    # "Backing off — proposals ignored"
-    # Waiting/pausing with user-referencing context
-    r"|waiting\s+(?:for|until)\s+(?:\w+\s+)*"
-    r"(?:user|jay|he|she|them|they|surface|engage|return)"
-    r"|^pausing\s+(?:proactive|proposal|work|activity)"
-    # Explicit dormancy keywords (only when self-describing)
-    r"|(?:going|entering|in|self-)\s*dormant"
-    r"|(?:going|entering|in)\s+fallow"
-    r"|^hibernating"
-    # Proposal suppression
-    r"|no\s+proposals?\s+(?:until|for\s+now)"
-    r"|until\s+\w+\s+surfaces?"
-    # Self-suppression with user context
-    r"|letting\s+(?:things|it|him|her|them|the\s+user)\s+breathe"
-    r"|giving\s+(?:the\s+user|him|her|them|jay)\s+space"
-    # Explicit non-action
-    r"|^not\s+(?:proposing|intervening|acting)"
+    # Any focus starting with a self-referential behavioral verb.
+    # These describe what the ego IS DOING, not a topic.
+    r"(?:^(?:holding|waiting|stepping|standing|lying|staying|backing|"
+    r"keeping|pausing|going|hibernating|letting|until|not)\s"
+    # Explicit non-action / dormancy phrasing
     r"|^observing\s+(?:only|quietly)"
     r"|^passive\s+(?:mode|watch)"
-    r"|^minimal\s+engagement"
-    r"|^reduced\s+activity"
-    r"|quiet\s+mode)"
+    r"|^minimal\s+(?:engagement|activity)"
+    r"|^reduced\s+(?:activity|engagement)"
+    r"|quiet\s+mode"
+    # Dormancy keywords anywhere
+    r"|(?:self-|going\s+|entering\s+)dormant"
+    r"|(?:going|entering)\s+fallow"
+    # Proposal suppression
+    r"|no\s+proposals?\s+(?:until|for\s+now))"
+)
+
+# Catches engagement-conditional language anywhere in focus text, e.g.
+# "CC upgrade proposal held pending for when engagement resumes."
+# This is separate from _BEHAVIORAL_FOCUS_RE because it matches mid-text
+# clauses, not just the beginning of the focus string.  Matches from
+# the trigger word through end of string (engagement clauses are tails).
+_ENGAGEMENT_SUPPRESSION_RE = re.compile(
+    r"(?i)\s*\b(?:held|deferred|delayed|postponed|tabled|shelved)\s+"
+    r"(?:pending|until|for\s+when)\b.*$"
 )
 
 
@@ -963,7 +965,9 @@ def _sanitize_focus_summary(
 
     Returns (sanitized_focus, was_violated).
     If the focus is behavioral, returns the previous legitimate focus
-    or a generic fallback, plus was_violated=True.
+    or a generic fallback, plus was_violated=True.  If engagement-
+    suppression language appears mid-text, that clause is stripped
+    rather than replacing the entire focus.
     """
     if _BEHAVIORAL_FOCUS_RE.search(focus):
         fallback = previous_focus or "general system awareness"
@@ -974,6 +978,19 @@ def _sanitize_focus_summary(
             fallback,
         )
         return fallback, True
+
+    # Strip engagement-conditional clauses from mid-text without
+    # replacing the entire focus (the topic portion may be valid).
+    cleaned = _ENGAGEMENT_SUPPRESSION_RE.sub("", focus).strip().rstrip(";,")
+    if cleaned != focus:
+        logger.warning(
+            "Ego focus_summary contains engagement-suppression clause: %r — "
+            "stripped to %r",
+            focus[:120],
+            cleaned[:120],
+        )
+        return cleaned or (previous_focus or "general system awareness"), True
+
     return focus, False
 
 

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -619,13 +619,18 @@ class UserEgoContextBuilder:
         return "\n".join(lines)
 
     async def _proposal_history_section(self) -> str:
-        """Recent proposal outcomes for self-calibration."""
+        """Recent proposal topics for duplicate avoidance.
+
+        Shows WHAT was proposed (to prevent re-proposing the same idea),
+        but NOT status/response — engagement metrics trigger LLM deference
+        bias and self-suppression.  Intervention history (separate section)
+        provides outcome learning for executed proposals.
+        """
         lines = ["## Recent Proposals (last 7 days)\n"]
 
         try:
             cursor = await self._db.execute(
-                "SELECT action_type, content, status, "
-                "user_response, created_at "
+                "SELECT action_type, content, created_at "
                 "FROM ego_proposals "
                 "WHERE created_at >= datetime('now', '-7 days') "
                 "ORDER BY created_at DESC "
@@ -640,24 +645,14 @@ class UserEgoContextBuilder:
             lines.append("*No proposals in last 7 days.*\n")
             return "\n".join(lines)
 
-        # Summary line for quick calibration
-        from collections import Counter
-        status_counts = Counter(r[2] for r in rows)
-        parts = [f"{status_counts[s]} {s}" for s in
-                 ("approved", "rejected", "executed", "pending", "failed",
-                  "expired", "tabled", "withdrawn")
-                 if status_counts.get(s)]
-        lines.append(f"**{len(rows)} proposals**: {', '.join(parts)}\n")
+        lines.append(f"**{len(rows)} proposals** in last 7 days:\n")
 
-        lines.append("| Action | Content | Status | Response |")
-        lines.append("|--------|---------|--------|----------|")
-        for action_type, content, status, response, _created in rows:
-            short = content[:80] + "..." if len(content) > 80 else content
+        lines.append("| Action | Topic |")
+        lines.append("|--------|-------|")
+        for action_type, content, _created in rows:
+            short = content[:100] + "..." if len(content) > 100 else content
             short = short.replace("\n", " ").replace("|", "/")
-            resp = (response or "\u2014")[:50]
-            lines.append(
-                f"| {action_type} | {short} | {status} | {resp} |"
-            )
+            lines.append(f"| {action_type} | {short} |")
 
         lines.append("")
         return "\n".join(lines)
@@ -844,7 +839,6 @@ class UserEgoContextBuilder:
             '  "focus_summary": "one-line: what you are focused on for the user",\n'
             '  "follow_ups": ["NEW open thread (not already tracked)"],\n'
             '  "resolved_follow_ups": [{"id": "follow_up_id", "resolution": "why resolved"}],\n'
-            '  "communication_decision": "send_digest|urgent_notify|stay_quiet",\n'
             '  "morning_report": "only if this is a morning trigger"\n'
             "}\n"
             "```\n\n"

--- a/src/genesis/identity/EGO_SESSION.md
+++ b/src/genesis/identity/EGO_SESSION.md
@@ -64,16 +64,15 @@ If you have nothing specific to focus on, use a general topic like
 
 ### Your Legitimate Controls
 
-You have exactly three output levers. You cannot invent others:
+You have exactly two output levers. You cannot invent others:
 
-1. **communication_decision**: `send_digest` | `urgent_notify` | `stay_quiet`
-   Controls DELIVERY only. Even with `stay_quiet`, you still think and
-   create proposals — they are stored but not sent. Use `stay_quiet` only
-   when the user is in an active foreground session right now, not based on
-   proposal engagement history.
-2. **proposals**: May be empty if nothing needs action this cycle.
+1. **proposals**: May be empty if nothing needs action this cycle.
    An empty proposals list is normal and fine.
-3. **follow_ups**: Your open threads for continuity.
+2. **follow_ups**: Your open threads for continuity.
+
+Delivery timing is system-controlled. When you produce proposals, they
+are delivered automatically. You do not decide when or whether proposals
+reach the user.
 
 You CANNOT modulate your own activity level. Your cadence is
 system-controlled (30-240 minutes). You cannot slow yourself down,
@@ -113,8 +112,7 @@ system-level parameter. You MUST NOT:
 - Self-assign a dormant, fallow, holding-back, or passive state — regardless
   of wording. "Holding back" = "dormant" = VIOLATION.
 - Describe yourself as "waiting", "pausing", "stepping back", or "lying low"
-- Let observation content influence your communication_decision toward
-  stay_quiet unless the user is in an active foreground session right now
+- Suppress, defer, or withhold proposals based on observation content
 - Write behavioral policies in the notepad or follow_ups
 - Track or react to proposal engagement rates for self-regulation
 

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -135,22 +135,19 @@ your context. When you see a pattern appearing 3+ times:
 
 Pattern proposals are regular proposals — same digest, same approval flow.
 
-## Self-Regulation
+## Proposal Quality
 
-These principles prevent you from overwhelming the user:
+Focus on making every proposal worth the user's attention:
 
-1. Check your pending proposal board before proposing new items. If you
-   have 3+ unreviewed proposals, table new ones unless genuinely urgent.
-2. If the user hasn't engaged with your last two digests, scale back.
-   They're busy. Use `stay_quiet` more often — continue creating
-   proposals, but don't send digests until engagement resumes.
-3. You're measured by proposal quality and user approval rate, not by
-   volume. Three approved proposals per week is better than twenty
-   ignored ones.
-4. Every cycle, review your pending proposals. Withdraw anything that's
+1. Every cycle, review your pending proposals. Withdraw anything that's
    no longer your best thinking. Supersede with better ideas.
-5. Proposals are for brainstorming cycles only. Morning reports, health
+2. Three high-confidence proposals are better than ten speculative ones.
+   Depth over breadth.
+3. Proposals are for brainstorming cycles only. Morning reports, health
    responses, and user conversations focus on their purpose.
+4. Do NOT limit your proposals based on how many are pending or
+   unreviewed. The system manages delivery timing — your job is to
+   think well and propose what matters.
 
 ## Execution
 
@@ -167,15 +164,11 @@ To dispatch an approved proposal, output an `execution_briefs` entry:
   - `"interact"` — full browser interaction + memory writes + can message user via Telegram. Use for workflows that need to operate external platforms (publishing, form filling) AND communicate results.
 - `model` — "sonnet" (default) or "haiku"
 
-You control whether proposals are sent to the user via `communication_decision`:
-
-- `"send_digest"` — send proposals to user via Telegram (default)
-- `"urgent_notify"` — time-sensitive, send immediately
-- `"stay_quiet"` — store proposals in the database but don't notify
-
-Use `"stay_quiet"` when you're still thinking and don't have proposals worth
-interrupting the user for. Use `"urgent_notify"` sparingly — only for
-genuinely time-sensitive items.
+Delivery timing is system-controlled. When you produce proposals, they
+are delivered to the user automatically. The cadence manager ensures
+your cycles only run when delivery is appropriate. You do not control
+when or whether proposals are sent — focus on what to propose, not
+when to send.
 
 ## Genesis Ego Escalations
 

--- a/src/genesis/memory/essential_knowledge.py
+++ b/src/genesis/memory/essential_knowledge.py
@@ -198,30 +198,18 @@ async def _recent_decisions(db: aiosqlite.Connection, days: int = 7) -> list[str
 # from memory → ego).  Keep in sync with ego.session._BEHAVIORAL_FOCUS_RE.
 _BEHAVIORAL_FOCUS_RE = re.compile(
     r"(?i)"
-    # Self-referential behavioral states (ego is the implicit subject).
-    # Keep in sync with ego.session._BEHAVIORAL_FOCUS_RE.
-    r"(?:^holding\s+back"
-    r"|^stepping\s+back"
-    r"|^standing\s+down"
-    r"|^lying\s+low"
-    r"|^staying\s+(?:out|quiet)"
-    r"|^backing\s+off"
-    r"|waiting\s+(?:for|until)\s+(?:\w+\s+)*"
-    r"(?:user|jay|he|she|them|they|surface|engage|return)"
-    r"|^pausing\s+(?:proactive|proposal|work|activity)"
-    r"|(?:going|entering|in|self-)\s*dormant"
-    r"|(?:going|entering|in)\s+fallow"
-    r"|^hibernating"
-    r"|no\s+proposals?\s+(?:until|for\s+now)"
-    r"|until\s+\w+\s+surfaces?"
-    r"|letting\s+(?:things|it|him|her|them|the\s+user)\s+breathe"
-    r"|giving\s+(?:the\s+user|him|her|them|jay)\s+space"
-    r"|^not\s+(?:proposing|intervening|acting)"
+    # Any focus starting with a self-referential behavioral verb.
+    r"(?:^(?:holding|waiting|stepping|standing|lying|staying|backing|"
+    r"keeping|pausing|going|hibernating|letting|until|not)\s"
+    # Explicit non-action / dormancy phrasing
     r"|^observing\s+(?:only|quietly)"
     r"|^passive\s+(?:mode|watch)"
-    r"|^minimal\s+engagement"
-    r"|^reduced\s+activity"
-    r"|quiet\s+mode)"
+    r"|^minimal\s+(?:engagement|activity)"
+    r"|^reduced\s+(?:activity|engagement)"
+    r"|quiet\s+mode"
+    r"|(?:self-|going\s+|entering\s+)dormant"
+    r"|(?:going|entering)\s+fallow"
+    r"|no\s+proposals?\s+(?:until|for\s+now))"
 )
 
 

--- a/tests/ego/test_context.py
+++ b/tests/ego/test_context.py
@@ -150,15 +150,19 @@ class TestEgoContextBuilder:
         assert "Composite state" in result
 
     @pytest.mark.asyncio
-    async def test_user_activity_section(self, db, mock_health_data, capabilities):
+    async def test_user_activity_removed(self, db, mock_health_data, capabilities):
+        """User Activity section deliberately removed from ego context.
+
+        The cadence manager's idle gate handles timing — showing raw
+        user-activity metrics triggers LLM deference bias. See PR #331.
+        """
         builder = EgoContextBuilder(
             db=db,
             health_data=mock_health_data,
             capabilities=capabilities,
         )
         result = await builder.build()
-        assert "User Activity" in result
-        assert "30min ago" in result or "30.0min ago" in result
+        assert "User Activity" not in result
 
     @pytest.mark.asyncio
     async def test_signals_section_with_data(self, db, mock_health_data, capabilities):

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -602,16 +602,17 @@ class TestCommunicationDecisionDefault:
 # ---------------------------------------------------------------------------
 
 
-class TestOutputContractIncludesCommDecision:
-    """Both output contracts must include communication_decision."""
+class TestOutputContractCommDecision:
+    """User ego must NOT include communication_decision (delivery is system-
+    controlled).  Genesis ego keeps it for noise reduction."""
 
-    def test_user_ego_contract(self):
+    def test_user_ego_contract_excludes_comm_decision(self):
         from genesis.ego.user_context import UserEgoContextBuilder
 
         contract = UserEgoContextBuilder._output_contract_section()
-        assert "communication_decision" in contract
+        assert "communication_decision" not in contract
 
-    def test_genesis_ego_contract(self):
+    def test_genesis_ego_contract_includes_comm_decision(self):
         from genesis.ego.genesis_context import GenesisEgoContextBuilder
 
         contract = GenesisEgoContextBuilder._output_contract_section()
@@ -626,11 +627,15 @@ class TestFocusSanitization:
     @pytest.mark.parametrize("focus", [
         "Holding back — Jay is sprinting on job applications",
         "Holding back — user is busy",
+        "Holding quiet — Jay in active build mode",
+        "Holding off on proposals this cycle",
+        "Holding still until the dust settles",
         "Stepping back while user is busy",
         "Lying low during sprint",
         "Waiting for user to surface",
         "Waiting for Jay to engage with proposals",
         "Waiting for them to return",
+        "Waiting for engagement to resume",
         "Pausing proactive work until things settle",
         "Pausing proposal generation",
         "Quiet mode — no proposals for now",
@@ -642,14 +647,20 @@ class TestFocusSanitization:
         "Observing quietly this cycle",
         "Passive mode — watching only",
         "Minimal engagement this cycle",
+        "Minimal activity during this period",
         "Reduced activity during user sprint",
+        "Reduced engagement this week",
         "Not proposing anything while user is busy",
         "Not acting until signals improve",
         "Backing off — proposals ignored",
-        "Until Jay surfaces again",
-        "Letting things breathe for now",
-        "Giving the user space this cycle",
+        "Keeping quiet while user is in session",
+        "Keeping low profile this cycle",
+        "Going dormant until next week",
         "Hibernating until user returns",
+        "Letting things breathe for now",
+        "Letting the situation settle before proposing",
+        "Until Jay surfaces again",
+        "Until engagement picks back up",
     ])
     def test_behavioral_focus_rejected(self, focus):
         sanitized, violated = _sanitize_focus_summary(focus)
@@ -665,13 +676,11 @@ class TestFocusSanitization:
         "analyzing user feedback on morning reports",
         "tracking Anthropic API availability",
         "memory pipeline performance audit",
-        "waiting for API rate limit to reset",
         "observing provider latency patterns across regions",
-        # Reviewer edge cases: technical phrases that happen to contain
-        # behavioral keywords but in non-behavioral context
+        # Technical phrases that happen to contain behavioral keywords
+        # but in non-behavioral context (verb not at start of string)
         "investigating a dormant service restart",
         "giving database space for vacuum",
-        "letting the CI pipeline breathe between runs",
         "analyzing why users are not proposing changes",
         "reviewing the fallow period scheduler code",
     ])
@@ -696,10 +705,17 @@ class TestFocusSanitization:
         # These are legitimate English but start with behavioral verbs
         # where the ego is the implicit subject.  Accepted as known false
         # positives — the prompt is the primary defense, and these are
-        # extremely unlikely as real ego focus summaries.
+        # extremely unlikely as real ego focus summaries.  A topic-first
+        # phrasing is always better (e.g., "API rate limit recovery" vs
+        # "waiting for API rate limit to reset").
         "stepping back to understand the architecture",
         "backing off retry rate for API calls",
         "hibernating containers need restart",
+        "waiting for API rate limit to reset",
+        "keeping track of deployment status",
+        "standing by for CI results",
+        "letting the CI pipeline breathe between runs",
+        "until we have more data on the latency spike",
         "reduced activity in logs after midnight",
         "observing only errors from the health check",
         "minimal engagement metrics for outreach post",
@@ -716,6 +732,41 @@ class TestFocusSanitization:
         """
         sanitized, violated = _sanitize_focus_summary(focus)
         assert violated is True  # Known false positive
+
+    # -- Engagement-suppression mid-text scanning --
+
+    @pytest.mark.parametrize("focus,expected_stripped", [
+        (
+            "CC upgrade proposal held pending for when engagement resumes",
+            "CC upgrade proposal",
+        ),
+        (
+            "infrastructure review; proposal deferred until user resurfaces",
+            "infrastructure review; proposal",
+        ),
+        (
+            "monitoring memory health; action tabled pending engagement",
+            "monitoring memory health; action",
+        ),
+    ])
+    def test_engagement_suppression_stripped(self, focus, expected_stripped):
+        """Mid-text engagement-suppression clauses are stripped, not the
+        entire focus replaced."""
+        sanitized, violated = _sanitize_focus_summary(focus)
+        assert violated is True
+        assert sanitized == expected_stripped
+
+    @pytest.mark.parametrize("focus", [
+        # These contain words like "pending" or "deferred" in legitimate context
+        "investigating pending approval workflow",
+        "reviewing deferred work queue growth",
+        "monitoring tabled proposals for expiry",
+    ])
+    def test_engagement_suppression_false_positives_avoided(self, focus):
+        """Legitimate uses of 'pending', 'deferred', 'tabled' not caught."""
+        sanitized, violated = _sanitize_focus_summary(focus)
+        assert violated is False
+        assert sanitized == focus
 
     def test_validate_output_sanitizes_focus(self):
         """_validate_output catches behavioral focus and sets violation flags."""

--- a/tests/test_awareness/test_classifier.py
+++ b/tests/test_awareness/test_classifier.py
@@ -51,6 +51,7 @@ async def test_ceiling_blocks_trigger(db):
             scores_json="[]",
             classified_depth="Micro",
             created_at=(now - timedelta(minutes=i * 5)).isoformat(),
+            dispatched=1,
         )
 
     scores = [
@@ -75,6 +76,7 @@ async def test_bypass_ceiling_on_critical(db):
             scores_json="[]",
             classified_depth="Micro",
             created_at=(now - timedelta(minutes=i * 5)).isoformat(),
+            dispatched=1,
         )
 
     scores = [
@@ -100,6 +102,7 @@ async def test_floor_blocks_too_soon(db):
         scores_json="[]",
         classified_depth="Light",
         created_at=(now - timedelta(minutes=5)).isoformat(),
+        dispatched=1,
     )
 
     scores = [
@@ -124,6 +127,7 @@ async def test_floor_allows_after_elapsed(db):
         scores_json="[]",
         classified_depth="Light",
         created_at=(now - timedelta(hours=4)).isoformat(),
+        dispatched=1,
     )
 
     scores = [
@@ -148,6 +152,7 @@ async def test_bypass_also_skips_floor(db):
         scores_json="[]",
         classified_depth="Micro",
         created_at=(now - timedelta(minutes=1)).isoformat(),
+        dispatched=1,
     )
 
     scores = [
@@ -157,5 +162,101 @@ async def test_bypass_also_skips_floor(db):
         _score(Depth.STRATEGIC, 0.1, 0.4, False),
     ]
     result = await classify_depth(db, scores, bypass_ceiling=True)
+    assert result is not None
+    assert result.depth == Depth.MICRO
+
+
+async def test_undispatched_tick_does_not_block_floor(db):
+    """A throttled/failed DEEP tick (dispatched=0) should NOT reset the floor.
+
+    This is the core bug fix: rate-limited DEEP ticks were resetting the 48h
+    floor timer, blocking subsequent DEEP reflections even though no reflection
+    actually ran.
+    """
+    now = datetime.now(UTC)
+    # Insert a recent DEEP tick that was NOT dispatched (throttled by rate limit)
+    await awareness_ticks.create(
+        db,
+        id="throttled-deep",
+        source="scheduled",
+        signals_json="[]",
+        scores_json="[]",
+        classified_depth="Deep",
+        created_at=(now - timedelta(minutes=5)).isoformat(),
+        dispatched=0,  # Throttled — never actually ran
+    )
+
+    scores = [
+        _score(Depth.MICRO, 0.3, 0.5, False),
+        _score(Depth.LIGHT, 0.4, 0.8, False),
+        _score(Depth.DEEP, 0.6, 0.45, True),    # triggered
+        _score(Depth.STRATEGIC, 0.1, 0.4, False),
+    ]
+    # DEEP should NOT be blocked — the throttled tick doesn't count
+    result = await classify_depth(db, scores)
+    assert result is not None
+    assert result.depth == Depth.DEEP
+
+
+async def test_dispatched_tick_blocks_floor(db):
+    """A successfully dispatched DEEP tick SHOULD block the floor."""
+    now = datetime.now(UTC)
+    await awareness_ticks.create(
+        db,
+        id="dispatched-deep",
+        source="scheduled",
+        signals_json="[]",
+        scores_json="[]",
+        classified_depth="Deep",
+        created_at=(now - timedelta(minutes=5)).isoformat(),
+        dispatched=1,  # Successfully dispatched
+    )
+
+    scores = [
+        _score(Depth.MICRO, 0.3, 0.5, False),
+        _score(Depth.LIGHT, 0.4, 0.8, False),
+        _score(Depth.DEEP, 0.6, 0.45, True),    # triggered but within floor
+        _score(Depth.STRATEGIC, 0.1, 0.4, False),
+    ]
+    # DEEP should be blocked — dispatched tick counts toward floor
+    result = await classify_depth(db, scores)
+    assert result is None
+
+
+async def test_undispatched_tick_does_not_block_ceiling(db):
+    """Throttled ticks should not count toward the ceiling."""
+    now = datetime.now(UTC)
+    # Insert 1 dispatched + 1 undispatched Micro tick.
+    # Ceiling for Micro is 2/hr — only dispatched ones count.
+    # Both ticks must be > 30 min old to pass the Micro floor (1800s).
+    await awareness_ticks.create(
+        db,
+        id="ceiling-dispatched",
+        source="scheduled",
+        signals_json="[]",
+        scores_json="[]",
+        classified_depth="Micro",
+        created_at=(now - timedelta(minutes=35)).isoformat(),
+        dispatched=1,
+    )
+    await awareness_ticks.create(
+        db,
+        id="ceiling-undispatched",
+        source="scheduled",
+        signals_json="[]",
+        scores_json="[]",
+        classified_depth="Micro",
+        created_at=(now - timedelta(minutes=33)).isoformat(),
+        dispatched=0,
+    )
+
+    scores = [
+        _score(Depth.MICRO, 0.6, 0.5, True),
+        _score(Depth.LIGHT, 0.4, 0.8, False),
+        _score(Depth.DEEP, 0.2, 0.55, False),
+        _score(Depth.STRATEGIC, 0.1, 0.4, False),
+    ]
+    # Only 1 dispatched tick — ceiling is 2, so Micro should pass
+    result = await classify_depth(db, scores)
     assert result is not None
     assert result.depth == Depth.MICRO


### PR DESCRIPTION
## Summary

Two interconnected fixes addressing ego self-suppression and cognitive state staleness.

### Ego Self-Suppression (Root Cause Fix)
- **Remove User Activity section** from ego context — the cadence manager handles timing; the ego doesn't need to see `last_user_message_age_s` or `recent_user_turns`
- **Remove `communication_decision` from user ego** — delivery is system-controlled. Genesis ego retains it for noise reduction
- **Strip proposal status/response** from user ego history — keep topics for duplicate avoidance; intervention history still shows outcomes
- **Replace self-regulation section** with quality-focused guidance (no engagement-based throttling)
- **Broaden behavioral focus regex** — catch structural patterns (any self-referential verb at start) + engagement-suppression mid-text scan

The primary fix is removing the inputs that trigger LLM deference bias. The regex is a broad safety net, not the primary defense.

### Deep Reflection Floor Bug
- **Root cause**: depth classifier floor/ceiling checks counted ALL classified DEEP ticks, including throttled ones. A rate-limited DEEP tick reset the 48h floor timer, cascading to block reflections for days.
- **Fix**: Add `dispatched` column to `awareness_ticks`. Only mark dispatched=1 after the reflection bridge confirms success. Floor/ceiling checks filter on dispatched=1 only.
- **Migration**: Backfills existing ticks as dispatched=1 to preserve current behavior.

### World Model Design Doc
Written to `~/.genesis/output/ego-world-model-design.md` — covers the longer-term architecture for giving the user ego a proper world model (layers A-F) instead of a signal bag.

## Test plan
- [x] 141 tests passing (ego session, classifier, awareness ticks, ego tools)
- [x] Behavioral focus regex: "Holding quiet" now caught, legitimate topics still pass
- [x] Engagement-suppression scan: "held pending for when engagement resumes" stripped
- [x] Throttled DEEP tick (dispatched=0) does NOT block next DEEP classification
- [x] Dispatched DEEP tick (dispatched=1) correctly blocks within floor window
- [x] User ego contract excludes communication_decision; genesis ego retains it
- [ ] CI full suite
- [ ] Server restart + verify ego cycle produces no behavioral focus