### PR TITLE
fix(learning): 5 structural fixes for procedural learning pipeline

### DIFF
--- a/src/genesis/learning/classification/outcome.py
+++ b/src/genesis/learning/classification/outcome.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import re
 from typing import Any, Protocol
 
 from genesis.learning.types import InteractionSummary, OutcomeClass
+
+logger = logging.getLogger(__name__)
 
 
 class _Router(Protocol):
@@ -47,13 +50,21 @@ class OutcomeClassifier:
             "Classify the following interaction into exactly one outcome class.",
             "",
             "## Outcome Classes",
-            "- success: task completed as requested",
+            "- success: ALL requested goals were achieved",
             "- approach_failure: wrong approach used, could have done better",
             "- capability_gap: Genesis lacks the ability to complete the task."
             " REQUIRES exhaustion evidence — must have tried alternatives and failed.",
             "- external_blocker: an external system prevented completion."
             " REQUIRES exhaustion evidence — must have tried alternatives and failed.",
             "- workaround_success: primary approach failed but an alternative worked",
+            "",
+            "## Goal Validation",
+            "Before classifying, explicitly identify:",
+            "1. What specific outcomes did the user request? (list each discrete goal)",
+            "2. Which goals were achieved? Which were NOT achieved?",
+            "3. If ANY requested goal was not achieved, the outcome CANNOT be 'success'.",
+            "   Partial completion (e.g. 3/4 URLs fetched) → 'approach_failure' or",
+            "   'workaround_success', never 'success'.",
             "",
         ]
 
@@ -70,7 +81,12 @@ class OutcomeClassifier:
             f"User: {summary.user_text}",
             f"Response: {summary.response_text}",
             "",
-            'Respond with JSON: {"outcome": "<class_name>", "rationale": "<brief reason>"}',
+            "Respond with JSON:",
+            '{"goals_identified": ["goal1", "goal2"],'
+            ' "goals_achieved": ["goal1"],'
+            ' "goals_failed": ["goal2"],'
+            ' "outcome": "<class_name>",'
+            ' "rationale": "<brief reason>"}',
         ])
 
         return "\n".join(parts)
@@ -89,6 +105,19 @@ class OutcomeClassifier:
 
         if data is not None:
             outcome_str = str(data.get("outcome", "")).lower().strip()
+
+            # Hard gate: if the LLM identified failed goals but still
+            # classified as "success", override.  Partial completion is
+            # approach_failure, never success.
+            goals_failed = data.get("goals_failed")
+            if goals_failed and outcome_str == "success":
+                logger.warning(
+                    "Outcome hard gate: %d goal(s) failed but classified "
+                    "as success — overriding to approach_failure",
+                    len(goals_failed),
+                )
+                return OutcomeClass.APPROACH_FAILURE
+
             with contextlib.suppress(ValueError):
                 return OutcomeClass(outcome_str)
 

--- a/src/genesis/learning/procedural/extractor.py
+++ b/src/genesis/learning/procedural/extractor.py
@@ -2,13 +2,24 @@
 
 When the triage pipeline classifies an interaction as APPROACH_FAILURE,
 WORKAROUND_SUCCESS, or (on autonomous channels) SUCCESS, this module extracts
-a reusable procedure and stores it. New procedures start at L4
-(advisory-only) with speculative=1 until confirmed.
+a reusable procedure and stores it. New procedures start at L3 with
+speculative=1 and confidence=0.5 — immediately visible to session injection
+and proactive surfacing.
 
-Novelty gate: before storing, compute the cosine similarity of the new
-procedure's principle embedding against existing procedures of the same
-task_type. Skip storage if max similarity >= NOVELTY_THRESHOLD to prevent
-the table from filling with paraphrases of the same insight.
+Quality gate: the extraction prompt includes criteria for the LLM to
+self-assess whether the procedure codifies correct behavior and is
+genuinely reusable.  A ``skip`` flag or low ``reusability_score`` aborts.
+
+Novelty gate: cosine similarity of the new procedure's principle embedding
+against existing procedures of the same task_type.  Skip storage if max
+similarity >= NOVELTY_THRESHOLD to prevent paraphrased duplicates.
+
+Cross-type contradiction check: after the same-type novelty gate passes,
+check for trusted procedures with overlapping context_tags across all
+task_types.  Blocks cross-type duplicates and warns on contradictions.
+
+Fail-open rate limiter: when embedding is unavailable, a per-task-type
+cooldown prevents flooding the table with unchecked near-duplicates.
 """
 
 from __future__ import annotations
@@ -16,6 +27,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import time
 from typing import TYPE_CHECKING, Any, Protocol
 
 from genesis.learning.procedural.operations import store_procedure
@@ -32,6 +44,12 @@ logger = logging.getLogger(__name__)
 # calibrated by hand; see follow-up to retune from similarity-score histogram
 # after 30 days of extraction data.
 NOVELTY_THRESHOLD = 0.85
+
+# Fail-open rate limiter: when the embedder is unavailable, at most one
+# procedure per task_type per cooldown window is stored without novelty
+# filtering.  Prevents table flooding during extended embedding outages.
+_FAIL_OPEN_COOLDOWN_SECS = 3600  # 1 hour
+_fail_open_timestamps: dict[str, float] = {}
 
 _EMBEDDING_PROVIDER: EmbeddingProvider | None = None
 
@@ -72,34 +90,25 @@ async def _principle_is_novel(
     task_type: str,
     new_principle: str,
     embedder: EmbeddingProvider | None,
-) -> tuple[bool, float, list[float] | None]:
-    """Return (is_novel, max_similarity_seen, new_principle_vector).
+) -> tuple[bool, float, list[float] | None, bool]:
+    """Return (is_novel, max_similarity_seen, new_principle_vector, fell_open).
 
-    `new_principle_vector` is the embedding of `new_principle` (or None if
-    the embedder is unavailable or embedding fails). Callers that want to
-    store the embedding alongside the procedure can reuse this vector
-    instead of re-embedding.
-
-    Fail-open: if embedding fails or no embedder is configured, treat as
-    novel so we don't silently drop extractions when the embedding stack is
-    degraded.
+    ``fell_open`` is True when the novelty gate could not perform a real
+    check (embedder unavailable, lookup failed, etc.) and defaulted to
+    "novel".  Callers use this to apply the fail-open rate limiter.
     """
     if embedder is None:
-        return True, 0.0, None
+        return True, 0.0, None, True
 
     try:
         from genesis.db.crud.procedural import list_by_task_type
 
-        # list_by_task_type defaults to limit=50, ordered by confidence DESC.
-        # The default cap is load-bearing here — it bounds the per-extraction
-        # cost at 50 embedding lookups (cached) + 50 cosines. If the cap
-        # changes, revisit the latency budget for this hot path.
         existing = await list_by_task_type(db, task_type)
     except Exception:
         logger.warning(
             "Procedure novelty lookup failed; allowing storage", exc_info=True,
         )
-        return True, 0.0, None
+        return True, 0.0, None, True
 
     try:
         new_emb = await embedder.embed(new_principle)
@@ -108,10 +117,10 @@ async def _principle_is_novel(
             "Failed to embed new principle; allowing storage without novelty check",
             exc_info=True,
         )
-        return True, 0.0, None
+        return True, 0.0, None, True
 
     if not existing:
-        return True, 0.0, new_emb
+        return True, 0.0, new_emb, False
 
     try:
         max_sim = 0.0
@@ -125,13 +134,13 @@ async def _principle_is_novel(
             sim = _cosine_similarity(new_emb, existing_emb)
             if sim > max_sim:
                 max_sim = sim
-        return max_sim < NOVELTY_THRESHOLD, max_sim, new_emb
+        return max_sim < NOVELTY_THRESHOLD, max_sim, new_emb, False
     except Exception:
         logger.warning(
             "Embedding/cosine failed in novelty gate; allowing storage",
             exc_info=True,
         )
-        return True, 0.0, new_emb
+        return True, 0.0, new_emb, True
 
 # 38_procedure_extraction — extracts reusable procedures from interaction outcomes.
 # Currently in the learning-pipeline-only path (partially wired per _call_site_meta.py).
@@ -147,6 +156,17 @@ the same failure or capture the successful workaround for future use.
 ## Outcome
 {outcome}
 
+## Quality Gate
+Before returning a procedure, validate:
+1. Does this codify the CORRECT approach, or a workaround for a problem that
+   has a proper solution?  (e.g., "search for metadata" when the real tool
+   works is a BAD procedure — it codifies giving up.)
+2. Is this genuinely reusable across multiple future tasks, or is it specific
+   to this one interaction?
+3. Would an expert endorse this specific approach?
+
+If any answer is "no", return {{"skip": true, "reason": "..."}} instead.
+
 ## Instructions
 Return a JSON object with these fields:
 - "task_type": short kebab-case identifier (e.g., "youtube-content-fetch")
@@ -155,6 +175,7 @@ Return a JSON object with these fields:
 - "tools_used": array of tool names involved (e.g., ["Bash", "WebFetch"])
 - "context_tags": array of tags for matching (e.g., ["youtube", "ssl", "video"])
 - "tool_trigger": array of CC tool names that should trigger this procedure, or null
+- "reusability_score": float 0.0-1.0 (how likely is this to help future tasks?)
 
 Return ONLY the JSON object, no markdown fences or explanation.
 """
@@ -204,6 +225,24 @@ async def extract_procedure(
         logger.error("Procedure extraction: failed to parse LLM response: %s", result.content[:200])
         return None
 
+    # ── Quality gate (FM3): LLM self-assessment ──────────────────────────
+    # Check skip/reusability BEFORE required-fields validation — when the
+    # LLM returns {"skip": true, ...} the procedure fields are absent.
+    if data.get("skip"):
+        logger.info(
+            "Extraction quality gate: skipped — %s",
+            data.get("reason", "no reason"),
+        )
+        return None
+
+    reusability = data.get("reusability_score")
+    if reusability is not None and isinstance(reusability, (int, float)) and reusability < 0.5:
+        logger.info(
+            "Extraction quality gate: low reusability score (%.2f)",
+            reusability,
+        )
+        return None
+
     # Validate required fields
     required = ("task_type", "principle", "steps", "tools_used", "context_tags")
     if not all(k in data and data[k] for k in required):
@@ -224,10 +263,11 @@ async def extract_procedure(
     except Exception:
         pass  # Non-critical guard — continue with extraction if check fails
 
-    # Novelty gate: skip if a near-duplicate principle already exists for
-    # this task_type. Fail-open when embeddings are unavailable.
+    # ── Same-type novelty gate ───────────────────────────────────────────
+    # Skip if a near-duplicate principle already exists for this task_type.
+    # Fail-open when embeddings are unavailable (rate-limited below).
     embedder = embedding_provider if embedding_provider is not None else _get_embedding_provider()
-    is_novel, max_sim, principle_vec = await _principle_is_novel(
+    is_novel, max_sim, principle_vec, fell_open = await _principle_is_novel(
         db,
         task_type=data["task_type"],
         new_principle=data["principle"],
@@ -240,8 +280,60 @@ async def extract_procedure(
         )
         return None
 
-    # Pack the principle embedding for the proactive procedure hook.
-    # NULL is acceptable — the hook skips rows without an embedding.
+    # ── Fail-open rate limiter (FM5) ─────────────────────────────────────
+    # When the embedder was unavailable, limit to one store per task_type
+    # per cooldown window to prevent flooding during extended outages.
+    if fell_open:
+        now = time.monotonic()
+        last = _fail_open_timestamps.get(data["task_type"], 0.0)
+        if now - last < _FAIL_OPEN_COOLDOWN_SECS:
+            logger.warning(
+                "Fail-open rate limited for %s: cooldown active",
+                data["task_type"],
+            )
+            return None
+        _fail_open_timestamps[data["task_type"]] = now
+
+    # ── Cross-type contradiction check (FM2) ─────────────────────────────
+    # After same-type novelty passes, check for trusted procedures with
+    # overlapping context_tags across ALL task_types.
+    # Jaccard threshold 0.5 (vs the CRUD default of 0.7) intentionally casts
+    # a wider net — cross-type duplicates share domain but differ in name.
+    try:
+        from genesis.db.crud.procedural import find_by_context_overlap
+
+        overlapping = await find_by_context_overlap(
+            db, data["context_tags"], jaccard_threshold=0.5, limit=5,
+        )
+        for ov in overlapping:
+            if (
+                ov.get("confidence", 0) >= 0.5
+                and ov.get("speculative") == 0
+                and principle_vec is not None
+                and embedder is not None
+            ):
+                try:
+                    ov_emb = await embedder.embed(ov["principle"])
+                    sim = _cosine_similarity(principle_vec, ov_emb)
+                    if sim >= NOVELTY_THRESHOLD:
+                        logger.info(
+                            "Cross-type duplicate: '%s' vs existing '%s' "
+                            "(cosine=%.3f)",
+                            data["task_type"], ov["task_type"], sim,
+                        )
+                        return None
+                    if sim < 0.3:
+                        logger.warning(
+                            "Potential cross-type contradiction: '%s' vs "
+                            "'%s' (cosine=%.3f)",
+                            data["task_type"], ov["task_type"], sim,
+                        )
+                except Exception:
+                    pass  # Best-effort embedding comparison
+    except Exception:
+        pass  # Best-effort cross-check, never block extraction
+
+    # ── Pack embedding & store ───────────────────────────────────────────
     principle_blob: bytes | None = None
     if principle_vec is not None:
         try:
@@ -263,8 +355,9 @@ async def extract_procedure(
             tools_used=data["tools_used"],
             context_tags=data["context_tags"],
             tool_trigger=data.get("tool_trigger"),
-            activation_tier="L4",
+            activation_tier="L3",
             speculative=1,
+            confidence=0.5,
             source={"type": "auto_extracted", "triage_outcome": outcome},
             principle_embedding=principle_blob,
         )

--- a/src/genesis/learning/procedural/extractor.py
+++ b/src/genesis/learning/procedural/extractor.py
@@ -285,14 +285,14 @@ async def extract_procedure(
     # per cooldown window to prevent flooding during extended outages.
     if fell_open:
         now = time.monotonic()
-        last = _fail_open_timestamps.get(data["task_type"], 0.0)
-        if now - last < _FAIL_OPEN_COOLDOWN_SECS:
+        task_type_key = data["task_type"]
+        if task_type_key in _fail_open_timestamps and now - _fail_open_timestamps[task_type_key] < _FAIL_OPEN_COOLDOWN_SECS:
             logger.warning(
                 "Fail-open rate limited for %s: cooldown active",
-                data["task_type"],
+                task_type_key,
             )
             return None
-        _fail_open_timestamps[data["task_type"]] = now
+        _fail_open_timestamps[task_type_key] = now
 
     # ── Cross-type contradiction check (FM2) ─────────────────────────────
     # After same-type novelty passes, check for trusted procedures with

--- a/src/genesis/learning/procedural/promoter.py
+++ b/src/genesis/learning/procedural/promoter.py
@@ -4,7 +4,7 @@ Evaluates all active procedures for tier changes based on confidence and
 success/failure history. Runs as a scheduled background job (hourly).
 
 Promotion thresholds:
-  L4 → L3: success_count >= 3 AND confidence >= 0.65 AND speculative = 0
+  L4 → L3: success_count >= 3 AND confidence >= 0.65
   L3 → L2: success_count >= 5 AND confidence >= 0.75
   L2 → L1: success_count >= 8 AND confidence >= 0.85 AND tool_trigger set
 
@@ -53,7 +53,6 @@ def _compute_tier(row: dict) -> str:
     """
     s = row["success_count"]
     conf = row["confidence"]
-    spec = row.get("speculative", 1)
     has_trigger = bool(row.get("tool_trigger"))
     current = row.get("activation_tier") or "L4"
 
@@ -62,7 +61,7 @@ def _compute_tier(row: dict) -> str:
         qualified = "L1"
     elif s >= 5 and conf >= 0.75:
         qualified = "L2"
-    elif s >= 3 and conf >= 0.65 and spec == 0:
+    elif s >= 3 and conf >= 0.65:
         qualified = "L3"
 
     # Promote-only: never demote via metrics drift.

--- a/tests/test_learning/test_classification.py
+++ b/tests/test_learning/test_classification.py
@@ -138,6 +138,52 @@ class TestOutcomeClassifier:
         prompt = router.route_call.call_args[0][1][0]["content"]
         assert "retried 3 times" in prompt
 
+    @pytest.mark.asyncio
+    async def test_hard_gate_overrides_success_when_goals_failed(self):
+        """FM1: partial completion classified as success → forced to approach_failure."""
+        response = json.dumps({
+            "goals_identified": ["fetch URL A", "fetch URL B"],
+            "goals_achieved": ["fetch URL A"],
+            "goals_failed": ["fetch URL B"],
+            "outcome": "success",
+            "rationale": "mostly worked",
+        })
+        router = _mock_router(response)
+        result = await OutcomeClassifier(router).classify(_make_summary())
+        assert result == OutcomeClass.APPROACH_FAILURE
+
+    @pytest.mark.asyncio
+    async def test_hard_gate_allows_success_when_no_goals_failed(self):
+        """FM1: all goals achieved → success is preserved."""
+        response = json.dumps({
+            "goals_identified": ["deploy widget"],
+            "goals_achieved": ["deploy widget"],
+            "goals_failed": [],
+            "outcome": "success",
+            "rationale": "all done",
+        })
+        router = _mock_router(response)
+        result = await OutcomeClassifier(router).classify(_make_summary())
+        assert result == OutcomeClass.SUCCESS
+
+    @pytest.mark.asyncio
+    async def test_hard_gate_ignores_missing_goals_fields(self):
+        """FM1: old-format response without goals fields still works."""
+        response = json.dumps({"outcome": "success", "rationale": "ok"})
+        router = _mock_router(response)
+        result = await OutcomeClassifier(router).classify(_make_summary())
+        assert result == OutcomeClass.SUCCESS
+
+    @pytest.mark.asyncio
+    async def test_prompt_includes_goal_validation_section(self):
+        """FM1: the prompt asks for structured goal validation."""
+        router = _mock_router(json.dumps({"outcome": "success"}))
+        c = OutcomeClassifier(router)
+        await c.classify(_make_summary())
+        prompt = router.route_call.call_args[0][1][0]["content"]
+        assert "Goal Validation" in prompt
+        assert "goals_failed" in prompt
+
 
 # ─── DeltaAssessor ───────────────────────────────────────────────────────────
 

--- a/tests/test_learning/test_extractor.py
+++ b/tests/test_learning/test_extractor.py
@@ -18,14 +18,13 @@ from genesis.learning.procedural.operations import store_procedure
 
 
 @pytest.fixture(autouse=True)
-def _reset_embedding_provider_singleton():
-    """Reset the module-level embedder cache between tests so state from one
-    test (or a real EmbeddingProvider built on first use) can't leak into the
-    next.
-    """
+def _reset_module_state():
+    """Reset module-level singletons between tests so state can't leak."""
     extractor_mod._EMBEDDING_PROVIDER = None
+    extractor_mod._fail_open_timestamps.clear()
     yield
     extractor_mod._EMBEDDING_PROVIDER = None
+    extractor_mod._fail_open_timestamps.clear()
 
 
 @dataclass
@@ -196,3 +195,230 @@ async def test_extract_fails_open_when_embedder_is_none(db):
     # (Note: if a backend IS available in the test env, this test would still
     # pass because the principles are very different.)
     assert proc_id is not None
+
+
+# ─── FM3: Quality gate ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_extract_skips_when_quality_gate_returns_skip(db):
+    """LLM says skip => extraction aborted before required-fields check."""
+    router = _router_returning({"skip": True, "reason": "not reusable"})
+    proc_id = await extract_procedure(
+        db,
+        summary_text="did a thing",
+        outcome="success",
+        router=router,
+        embedding_provider=_embedder({}),
+    )
+    assert proc_id is None
+
+
+@pytest.mark.asyncio
+async def test_extract_skips_when_reusability_score_low(db):
+    """Low reusability_score => extraction aborted."""
+    payload = _valid_payload()
+    payload["reusability_score"] = 0.3
+    router = _router_returning(payload)
+    proc_id = await extract_procedure(
+        db,
+        summary_text="did a thing",
+        outcome="success",
+        router=router,
+        embedding_provider=_embedder({"always verify before deploy": [1.0, 0.0, 0.0]}),
+    )
+    assert proc_id is None
+
+
+@pytest.mark.asyncio
+async def test_extract_stores_when_reusability_score_high(db):
+    """High reusability_score => extraction proceeds normally."""
+    payload = _valid_payload()
+    payload["reusability_score"] = 0.8
+    router = _router_returning(payload)
+    proc_id = await extract_procedure(
+        db,
+        summary_text="did a thing",
+        outcome="success",
+        router=router,
+        embedding_provider=_embedder({"always verify before deploy": [1.0, 0.0, 0.0]}),
+    )
+    assert proc_id is not None
+
+
+# ─── FM2: Cross-type contradiction check ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cross_type_duplicate_blocked(db):
+    """Trusted procedure with overlapping tags + similar principle blocks extraction."""
+    # Seed a trusted (explicit-teach) procedure with overlapping context tags
+    await store_procedure(
+        db,
+        task_type="youtube-content-fetch",
+        principle="use yt-dlp to download youtube transcripts",
+        steps=["run yt-dlp"],
+        tools_used=["Bash"],
+        context_tags=["youtube", "video", "transcript"],
+        speculative=0,
+        confidence=0.7,
+    )
+
+    # New extraction with different task_type but overlapping tags + similar principle
+    same_vector = [1.0, 0.0, 0.0]
+    payload = _valid_payload(
+        task_type="youtube-fallback",
+        principle="use yt-dlp for youtube video transcripts",
+    )
+    payload["context_tags"] = ["youtube", "video", "fallback"]
+    embedder = _embedder({
+        "use yt-dlp for youtube video transcripts": same_vector,
+        "use yt-dlp to download youtube transcripts": same_vector,
+    })
+    router = _router_returning(payload)
+
+    proc_id = await extract_procedure(
+        db,
+        summary_text="fetched youtube transcript",
+        outcome="success",
+        router=router,
+        embedding_provider=embedder,
+    )
+    assert proc_id is None  # Blocked by cross-type duplicate check
+
+
+@pytest.mark.asyncio
+async def test_cross_type_check_allows_different_principles(db):
+    """Different principles with overlapping tags are allowed (not duplicates)."""
+    await store_procedure(
+        db,
+        task_type="youtube-content-fetch",
+        principle="use yt-dlp to download youtube transcripts",
+        steps=["run yt-dlp"],
+        tools_used=["Bash"],
+        context_tags=["youtube", "video", "transcript"],
+        speculative=0,
+        confidence=0.7,
+    )
+
+    # Different principle (orthogonal vectors = cosine 0)
+    payload = _valid_payload(
+        task_type="youtube-metadata",
+        principle="use youtube API for video metadata",
+    )
+    payload["context_tags"] = ["youtube", "video", "metadata"]
+    embedder = _embedder({
+        "use youtube API for video metadata": [1.0, 0.0, 0.0],
+        "use yt-dlp to download youtube transcripts": [0.0, 1.0, 0.0],
+    })
+    router = _router_returning(payload)
+
+    proc_id = await extract_procedure(
+        db,
+        summary_text="fetched youtube metadata",
+        outcome="success",
+        router=router,
+        embedding_provider=embedder,
+    )
+    assert proc_id is not None  # Allowed — different principles
+
+
+# ─── FM4: Auto-extracted procedures start at L3 ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_auto_extracted_starts_at_l3_with_baseline_confidence(db):
+    """Auto-extracted procedures start at L3/0.5, not L4/0.0."""
+    payload = _valid_payload()
+    router = _router_returning(payload)
+    proc_id = await extract_procedure(
+        db,
+        summary_text="deployed service",
+        outcome="success",
+        router=router,
+        embedding_provider=_embedder({"always verify before deploy": [1.0, 0.0, 0.0]}),
+    )
+    assert proc_id is not None
+
+    cursor = await db.execute(
+        "SELECT activation_tier, confidence, speculative FROM procedural_memory WHERE id = ?",
+        (proc_id,),
+    )
+    rows = await cursor.fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == "L3"
+    assert rows[0][1] == pytest.approx(0.5)
+    assert rows[0][2] == 1  # still marked speculative (provenance only)
+
+
+# ─── FM5: Fail-open rate limiter ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fail_open_rate_limiter_allows_first_store(db):
+    """First fail-open extraction for a task_type is allowed."""
+    payload = _valid_payload()
+    router = _router_returning(payload)
+
+    proc_id = await extract_procedure(
+        db,
+        summary_text="x",
+        outcome="success",
+        router=router,
+        embedding_provider=None,
+    )
+    assert proc_id is not None
+
+
+@pytest.mark.asyncio
+async def test_fail_open_rate_limiter_blocks_rapid_second(db):
+    """Second fail-open extraction for same task_type within cooldown => blocked."""
+    payload = _valid_payload()
+
+    # First extraction succeeds (fail-open, first in cooldown window)
+    router1 = _router_returning(payload)
+    proc_id1 = await extract_procedure(
+        db,
+        summary_text="x",
+        outcome="success",
+        router=router1,
+        embedding_provider=None,
+    )
+    assert proc_id1 is not None
+
+    # Second extraction with same task_type => rate limited
+    router2 = _router_returning(payload)
+    proc_id2 = await extract_procedure(
+        db,
+        summary_text="y",
+        outcome="success",
+        router=router2,
+        embedding_provider=None,
+    )
+    assert proc_id2 is None
+
+
+@pytest.mark.asyncio
+async def test_fail_open_rate_limiter_allows_different_task_type(db):
+    """Fail-open rate limit is per-task-type, not global."""
+    # First extraction: task_type = "deploy-service"
+    router1 = _router_returning(_valid_payload())
+    await extract_procedure(
+        db,
+        summary_text="x",
+        outcome="success",
+        router=router1,
+        embedding_provider=None,
+    )
+
+    # Second extraction: different task_type => allowed
+    payload2 = _valid_payload(task_type="build-service", principle="always build first")
+    router2 = _router_returning(payload2)
+    proc_id2 = await extract_procedure(
+        db,
+        summary_text="y",
+        outcome="success",
+        router=router2,
+        embedding_provider=None,
+    )
+    assert proc_id2 is not None

--- a/tests/test_learning/test_promoter.py
+++ b/tests/test_learning/test_promoter.py
@@ -130,14 +130,14 @@ def test_compute_tier_l1_with_drift_stays_at_l1():
     assert _compute_tier(row) == "L1"
 
 
-def test_compute_tier_speculative_procedure_blocked_from_l3():
-    """Speculative procedures cannot be auto-promoted to L3."""
+def test_compute_tier_speculative_procedure_can_promote_to_l3():
+    """Speculative procedures can promote to L3 if they meet thresholds."""
     row = {
         "success_count": 5, "confidence": 0.7, "speculative": 1,
         "tool_trigger": None, "activation_tier": "L4",
     }
-    # L3 requires speculative=0; L2 requires conf>=0.75; falls back to current.
-    assert _compute_tier(row) == "L4"
+    # speculative flag is provenance metadata, not a promotion gate.
+    assert _compute_tier(row) == "L3"
 
 
 # ─── _check_demotion ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes 5 structural failure modes in the procedural learning pipeline, discovered during the inbox YouTube incident where the system extracted a **bad** procedure (codifying wrong behavior) while the correct procedure already existed.

- **FM1**: Outcome classifier now requires structured goal validation — partial completion can no longer classify as "success" (hard gate override)
- **FM3**: Extraction prompt includes quality criteria — LLM self-assesses correctness and reusability before extraction proceeds
- **FM4**: Auto-extracted procedures start at L3/confidence=0.5 (immediately visible) instead of L4/0.0 (permanently invisible dead code). Removed `speculative=0` gate from promotion
- **FM2**: Cross-task-type contradiction check blocks duplicates across different `task_type` values using context_tag overlap + principle cosine similarity
- **FM5**: Fail-open rate limiter prevents table flooding when embedding backend is unavailable (per-task-type 1h cooldown)

### Files changed
- `src/genesis/learning/classification/outcome.py` — goal validation prompt + hard gate
- `src/genesis/learning/procedural/extractor.py` — quality filter, cross-type check, rate limiter, L3/0.5 storage
- `src/genesis/learning/procedural/promoter.py` — removed `speculative=0` promotion gate
- 3 test files — 13 new tests, 1 updated test

## Test plan
- [x] All 106 learning tests pass (54 core + 52 pipeline/procedural/embedding)
- [x] 28 executor trace tests pass (no ripple effects from `store_procedure` change)
- [x] Lint clean (ruff)
- [x] Code review completed — 3 review findings addressed
- [ ] Verify next inbox evaluation with YouTube URL fetches transcript correctly (requires inbox cycle)
- [ ] Monitor extraction logs for quality gate + cross-type check firing rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)