### PR TITLE
feat(ego): delivery + execution improvements (Layers 4 & 5)

### DIFF
--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
 from pathlib import Path
@@ -811,18 +812,34 @@ async def _try_bare_approval_resolution(
     return True
 
 
+_SWEEP_GRACE_SECONDS = 300  # 5-minute grace period before dispatching
+
+
+async def _delayed_sweep() -> None:
+    """Wait 5 minutes then sweep — gives user time to change their mind."""
+    import asyncio
+
+    await asyncio.sleep(_SWEEP_GRACE_SECONDS)
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if rt.ego_session is not None:
+        await rt.ego_session.sweep_approved_proposals()
+
+
 def _trigger_immediate_sweep() -> None:
-    """Fire-and-forget sweep of approved proposals after user approval."""
+    """Schedule a sweep after a 5-minute grace period.
+
+    The grace window lets the user revoke approval before dispatch
+    starts.  The 30-min interval sweep remains as fallback.
+    """
     try:
-        from genesis.runtime import GenesisRuntime
         from genesis.util.tasks import tracked_task
 
-        rt = GenesisRuntime.instance()
-        if rt.ego_session is not None:
-            tracked_task(
-                rt.ego_session.sweep_approved_proposals(),
-                name="immediate_proposal_sweep",
-            )
+        tracked_task(
+            _delayed_sweep(),
+            name="delayed_proposal_sweep",
+        )
     except Exception:
         pass  # Sweep will catch it on next 30-min interval
 
@@ -949,6 +966,40 @@ async def _try_bare_proposal_resolution(ctx: HandlerContext, msg) -> bool:
     decisions = parse_proposal_decisions(msg.text)
     if not decisions:
         return False
+
+    # Handle cancel/revoke (approved → rejected)
+    has_cancel = any(s == "cancelled" for s, _ in decisions.values())
+    if has_cancel:
+        try:
+            from genesis.db.crud import ego as ego_crud
+
+            pending = await ego_crud.list_pending_proposals(ctx.db)
+            # Find the most recent batch (could be pending or approved)
+            approved = await ego_crud.list_proposals(ctx.db, status="approved", limit=10)
+            if not approved:
+                with contextlib.suppress(Exception):
+                    await msg.reply_text("No approved proposals to cancel.")
+                return True
+
+            batch_id = approved[0].get("batch_id")
+            if 0 in decisions:
+                # "cancel all" — revoke all approved in this batch
+                revoked = await ctx.proposal_workflow.revoke_approved_proposals(batch_id)
+            else:
+                # "cancel N" — revoke specific indices
+                indices = [idx for idx, (s, _) in decisions.items() if s == "cancelled"]
+                revoked = await ctx.proposal_workflow.revoke_approved_proposals(
+                    batch_id,
+                    proposal_indices=indices,
+                )
+            try:
+                await msg.reply_text(f"\u2705 Cancelled: {revoked} proposal(s) revoked")
+            except Exception:
+                log.debug("Failed to send cancel ack", exc_info=True)
+            return True
+        except Exception:
+            log.warning("Proposal cancel failed", exc_info=True)
+            return False
 
     # Resolve proposals
     try:

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -817,8 +817,6 @@ _SWEEP_GRACE_SECONDS = 300  # 5-minute grace period before dispatching
 
 async def _delayed_sweep() -> None:
     """Wait 5 minutes then sweep — gives user time to change their mind."""
-    import asyncio
-
     await asyncio.sleep(_SWEEP_GRACE_SECONDS)
     from genesis.runtime import GenesisRuntime
 
@@ -862,6 +860,24 @@ async def _try_proposal_resolution(ctx: HandlerContext, msg, reply_to_id: str) -
         decisions = parse_proposal_decisions(msg.text)
         if not decisions:
             return False  # Unparseable — fall through to correction store
+
+        # Cancel/revoke approved proposals (works on approved, not pending)
+        has_cancel = any(s == "cancelled" for s, _ in decisions.values())
+        if has_cancel:
+            proposals = await ego_crud.list_proposals_by_batch(ctx.db, batch_id)
+            if 0 in decisions:
+                revoked = await ctx.proposal_workflow.revoke_approved_proposals(batch_id)
+            else:
+                indices = [idx for idx, (s, _) in decisions.items() if s == "cancelled"]
+                revoked = await ctx.proposal_workflow.revoke_approved_proposals(
+                    batch_id,
+                    proposal_indices=indices,
+                )
+            try:
+                await msg.reply_text(f"✅ Cancelled: {revoked} proposal(s) revoked")
+            except Exception:
+                log.debug("Failed to send cancel ack", exc_info=True)
+            return True
 
         # Cross-batch resolution (sentinel -1): resolve all pending
         if -1 in decisions:
@@ -973,8 +989,6 @@ async def _try_bare_proposal_resolution(ctx: HandlerContext, msg) -> bool:
         try:
             from genesis.db.crud import ego as ego_crud
 
-            pending = await ego_crud.list_pending_proposals(ctx.db)
-            # Find the most recent batch (could be pending or approved)
             approved = await ego_crud.list_proposals(ctx.db, status="approved", limit=10)
             if not approved:
                 with contextlib.suppress(Exception):

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -699,6 +699,22 @@ async def _try_bare_approval_resolution(
 
 
 
+def _trigger_immediate_sweep() -> None:
+    """Fire-and-forget sweep of approved proposals after user approval."""
+    try:
+        from genesis.runtime import GenesisRuntime
+        from genesis.util.tasks import tracked_task
+
+        rt = GenesisRuntime.instance()
+        if rt.ego_session is not None:
+            tracked_task(
+                rt.ego_session.sweep_approved_proposals(),
+                name="immediate_proposal_sweep",
+            )
+    except Exception:
+        pass  # Sweep will catch it on next 30-min interval
+
+
 async def _try_proposal_resolution(ctx: HandlerContext, msg, reply_to_id: str) -> bool:
     """Resolve a proposal batch from a quote-reply to an ego digest.
 
@@ -717,6 +733,28 @@ async def _try_proposal_resolution(ctx: HandlerContext, msg, reply_to_id: str) -
         decisions = parse_proposal_decisions(msg.text)
         if not decisions:
             return False  # Unparseable — fall through to correction store
+
+        # Cross-batch resolution (sentinel -1): resolve all pending
+        if -1 in decisions:
+            status, reason = decisions[-1]
+            results = await ctx.proposal_workflow.resolve_all_pending_proposals(
+                status, reason,
+            )
+            approved = sum(1 for s in results.values() if s == "approved")
+            rejected = sum(1 for s in results.values() if s == "rejected")
+            parts = []
+            if approved:
+                parts.append(f"{approved} approved")
+            if rejected:
+                parts.append(f"{rejected} rejected")
+            summary = ", ".join(parts) or "no changes"
+            try:
+                await msg.reply_text(f"✅ Resolved: {summary}")
+            except Exception:
+                log.debug("Failed to send proposal resolution ack", exc_info=True)
+            if approved > 0:
+                _trigger_immediate_sweep()
+            return True
 
         # Handle "approve all" / "reject all" (sentinel key 0)
         if 0 in decisions:
@@ -750,6 +788,11 @@ async def _try_proposal_resolution(ctx: HandlerContext, msg, reply_to_id: str) -
             await msg.reply_text(f"✅ Resolved: {summary}")
         except Exception:
             log.debug("Failed to send proposal resolution ack", exc_info=True)
+
+        # Trigger immediate sweep if any proposals were approved
+        if approved > 0:
+            _trigger_immediate_sweep()
+
         return True
     except Exception:
         log.warning("Proposal resolution failed", exc_info=True)
@@ -794,32 +837,44 @@ async def _try_bare_proposal_resolution(ctx: HandlerContext, msg) -> bool:
     if not decisions:
         return False
 
-    # Find the most recent unresolved batch
+    # Resolve proposals
     try:
         from genesis.db.crud import ego as ego_crud
 
-        # Get most recent pending proposals to find their batch
-        pending = await ego_crud.list_pending_proposals(ctx.db)
-        if not pending:
-            return False
-        # All pending proposals share a batch_id
-        batch_id = pending[0].get("batch_id")
-        if not batch_id:
-            return False
-
-        # Handle "approve all" / "reject all" (sentinel key 0)
-        if 0 in decisions:
-            status, reason = decisions[0]
-            all_decisions = {
-                i + 1: (status, reason) for i in range(len(pending))
-            }
-            results = await ctx.proposal_workflow.resolve_proposals(
-                batch_id, all_decisions,
+        # Cross-batch resolution: sentinel -1 resolves ALL pending
+        if -1 in decisions:
+            status, reason = decisions[-1]
+            results = await ctx.proposal_workflow.resolve_all_pending_proposals(
+                status, reason,
             )
         else:
-            results = await ctx.proposal_workflow.resolve_proposals(
-                batch_id, decisions,
-            )
+            # Get most recent pending proposals to find their batch
+            pending = await ego_crud.list_pending_proposals(ctx.db)
+            if not pending:
+                return False
+            batch_id = pending[0].get("batch_id")
+            if not batch_id:
+                return False
+
+            # Handle "approve all" / "reject all" (sentinel key 0)
+            if 0 in decisions:
+                status, reason = decisions[0]
+                # Use full batch for correct 1-based indexing — resolve_proposal
+                # skips already-resolved proposals via WHERE status='pending'.
+                full_batch = await ego_crud.list_proposals_by_batch(
+                    ctx.db, batch_id,
+                )
+                all_decisions = {
+                    i + 1: (status, reason)
+                    for i in range(len(full_batch))
+                }
+                results = await ctx.proposal_workflow.resolve_proposals(
+                    batch_id, all_decisions,
+                )
+            else:
+                results = await ctx.proposal_workflow.resolve_proposals(
+                    batch_id, decisions,
+                )
 
         approved = sum(1 for s in results.values() if s == "approved")
         rejected = sum(1 for s in results.values() if s == "rejected")
@@ -833,6 +888,11 @@ async def _try_bare_proposal_resolution(ctx: HandlerContext, msg) -> bool:
             await msg.reply_text(f"\u2705 Resolved: {summary}")
         except Exception:
             log.debug("Failed to send bare proposal resolution ack", exc_info=True)
+
+        # Trigger immediate sweep if any proposals were approved
+        if approved > 0:
+            _trigger_immediate_sweep()
+
         return True
     except Exception:
         log.warning("Bare proposal resolution failed", exc_info=True)

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -1,4 +1,5 @@
 """Message handlers for V2 Telegram handlers."""
+
 from __future__ import annotations
 
 import asyncio
@@ -29,21 +30,29 @@ _MAX_VOICE_BYTES = 20 * 1024 * 1024
 _MAX_MEDIA_BYTES = 20 * 1024 * 1024  # Telegram getFile() limit
 _MEDIA_DIR = Path.home() / "tmp" / "tg_media"
 _READABLE_MIMES = (
-    "image/jpeg", "image/png", "image/gif", "image/webp",
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/webp",
     "application/pdf",
 )
 
 
 async def _persist_tg_message(
     ctx: HandlerContext,
-    chat_id: int, message_id: int, sender: str, content: str,
-    thread_id: str | None = None, reply_to: int | None = None,
+    chat_id: int,
+    message_id: int,
+    sender: str,
+    content: str,
+    thread_id: str | None = None,
+    reply_to: int | None = None,
     direction: str = "inbound",
 ) -> None:
     if ctx.db is None:
         return
     try:
         from genesis.db.crud.telegram_messages import store
+
         await store(
             ctx.db,
             chat_id=chat_id,
@@ -76,14 +85,19 @@ async def _apply_pending_settings(ctx: HandlerContext, user_id: int, tid: str | 
         return
     try:
         from genesis.db.crud import cc_sessions
+
         sess = await cc_sessions.get_active_foreground(
-            ctx.loop._db, user_id=f"tg-{user_id}",
-            channel=str(ChannelType.TELEGRAM), thread_id=tid,
+            ctx.loop._db,
+            user_id=f"tg-{user_id}",
+            channel=str(ChannelType.TELEGRAM),
+            thread_id=tid,
         )
         if sess:
             await cc_sessions.update_model_effort(
-                ctx.loop._db, sess["id"],
-                model=pending.get("model"), effort=pending.get("effort"),
+                ctx.loop._db,
+                sess["id"],
+                model=pending.get("model"),
+                effort=pending.get("effort"),
             )
         else:
             log.warning("Pending settings for user %s discarded — no active session", user_id)
@@ -104,7 +118,8 @@ async def _make_streamer(ctx: HandlerContext, msg, user, tid) -> DraftStreamer |
     """
     if not (
         ctx.draft_streaming_enabled
-        and ctx.adapter and ctx.adapter._app
+        and ctx.adapter
+        and ctx.adapter._app
         and msg.chat.type == "private"
     ):
         return None
@@ -129,6 +144,7 @@ async def _make_streamer(ctx: HandlerContext, msg, user, tid) -> DraftStreamer |
                 show_prefix = True
             else:
                 from datetime import UTC, datetime
+
                 prev_ts = datetime.fromisoformat(prev[0])
                 now = datetime.now(UTC)
                 # Handle naive timestamps
@@ -190,6 +206,7 @@ async def _handle_text_inner(ctx: HandlerContext, msg, user, tid):
                     log.debug("Status snapshot send failed", exc_info=True)
 
     from genesis.util.tasks import tracked_task
+
     status_task = tracked_task(_status_snapshot(), name="status-snapshot")
 
     try:
@@ -238,8 +255,13 @@ async def _handle_text_inner(ctx: HandlerContext, msg, user, tid):
         if response:
             out_id = sent_msg.message_id if sent_msg else msg.message_id
             await _persist_tg_message(
-                ctx, msg.chat.id, out_id, "genesis", response,
-                thread_id=tid, direction="outbound",
+                ctx,
+                msg.chat.id,
+                out_id,
+                "genesis",
+                response,
+                thread_id=tid,
+                direction="outbound",
             )
 
     except CCError as e:
@@ -248,8 +270,13 @@ async def _handle_text_inner(ctx: HandlerContext, msg, user, tid):
         try:
             sent = await msg.reply_text(error_text)
             await _persist_tg_message(
-                ctx, msg.chat.id, sent.message_id, "genesis", error_text,
-                thread_id=tid, direction="outbound",
+                ctx,
+                msg.chat.id,
+                sent.message_id,
+                "genesis",
+                error_text,
+                thread_id=tid,
+                direction="outbound",
             )
         except Exception:
             log.error("Failed to send error reply to user %s", user.id, exc_info=True)
@@ -257,20 +284,26 @@ async def _handle_text_inner(ctx: HandlerContext, msg, user, tid):
         if streamer and streamer.accumulated_text:
             log.warning(
                 "Connection error for user %s after streaming %d chars — delivering accumulated text",
-                user.id, len(streamer.accumulated_text),
+                user.id,
+                len(streamer.accumulated_text),
             )
             try:
                 sent = await _reply_formatted(msg, streamer.accumulated_text)
                 if sent:
                     await _persist_tg_message(
-                        ctx, msg.chat.id, sent.message_id, "genesis",
+                        ctx,
+                        msg.chat.id,
+                        sent.message_id,
+                        "genesis",
                         streamer.accumulated_text,
-                        thread_id=tid, direction="outbound",
+                        thread_id=tid,
+                        direction="outbound",
                     )
             except Exception:
                 log.error(
                     "Failed to deliver accumulated text after connection error for user %s",
-                    user.id, exc_info=True,
+                    user.id,
+                    exc_info=True,
                 )
         else:
             error_text = "Connection issue reaching Genesis."
@@ -278,19 +311,31 @@ async def _handle_text_inner(ctx: HandlerContext, msg, user, tid):
             try:
                 sent = await msg.reply_text(error_text)
                 await _persist_tg_message(
-                    ctx, msg.chat.id, sent.message_id, "genesis", error_text,
-                    thread_id=tid, direction="outbound",
+                    ctx,
+                    msg.chat.id,
+                    sent.message_id,
+                    "genesis",
+                    error_text,
+                    thread_id=tid,
+                    direction="outbound",
                 )
             except Exception:
-                log.error("Failed to send connection-error reply for user %s", user.id, exc_info=True)
+                log.error(
+                    "Failed to send connection-error reply for user %s", user.id, exc_info=True
+                )
     except Exception as e:
         log.exception("CC request failed for user %s", user.id)
         error_text = _format_error(e)
         try:
             sent = await msg.reply_text(error_text)
             await _persist_tg_message(
-                ctx, msg.chat.id, sent.message_id, "genesis", error_text,
-                thread_id=tid, direction="outbound",
+                ctx,
+                msg.chat.id,
+                sent.message_id,
+                "genesis",
+                error_text,
+                thread_id=tid,
+                direction="outbound",
             )
         except Exception:
             log.error("Failed to send error reply to user %s", user.id, exc_info=True)
@@ -325,6 +370,7 @@ async def _handle_voice_inner(ctx: HandlerContext, msg, user, voice, context, wh
                     log.debug("Status snapshot send failed", exc_info=True)
 
     from genesis.util.tasks import tracked_task
+
     status_task = tracked_task(_status_snapshot(), name="voice-status-snapshot")
 
     try:
@@ -339,7 +385,11 @@ async def _handle_voice_inner(ctx: HandlerContext, msg, user, voice, context, wh
             return
 
         await _persist_tg_message(
-            ctx, msg.chat.id, msg.message_id, "user", f"[voice] {text}",
+            ctx,
+            msg.chat.id,
+            msg.message_id,
+            "user",
+            f"[voice] {text}",
             thread_id=tid,
         )
 
@@ -393,8 +443,13 @@ async def _handle_voice_inner(ctx: HandlerContext, msg, user, voice, context, wh
         if response:
             out_id = sent_msg.message_id if sent_msg else msg.message_id
             await _persist_tg_message(
-                ctx, msg.chat.id, out_id, "genesis", response,
-                thread_id=tid, direction="outbound",
+                ctx,
+                msg.chat.id,
+                out_id,
+                "genesis",
+                response,
+                thread_id=tid,
+                direction="outbound",
             )
 
     except CCError as e:
@@ -403,8 +458,13 @@ async def _handle_voice_inner(ctx: HandlerContext, msg, user, voice, context, wh
         try:
             sent = await msg.reply_text(error_text)
             await _persist_tg_message(
-                ctx, msg.chat.id, sent.message_id, "genesis", error_text,
-                thread_id=tid, direction="outbound",
+                ctx,
+                msg.chat.id,
+                sent.message_id,
+                "genesis",
+                error_text,
+                thread_id=tid,
+                direction="outbound",
             )
         except Exception:
             log.error("Failed to send error reply to voice user %s", user.id, exc_info=True)
@@ -412,20 +472,26 @@ async def _handle_voice_inner(ctx: HandlerContext, msg, user, voice, context, wh
         if streamer and streamer.accumulated_text:
             log.warning(
                 "Connection error for voice %s after streaming %d chars — delivering accumulated text",
-                user.id, len(streamer.accumulated_text),
+                user.id,
+                len(streamer.accumulated_text),
             )
             try:
                 sent = await _reply_formatted(msg, streamer.accumulated_text)
                 if sent:
                     await _persist_tg_message(
-                        ctx, msg.chat.id, sent.message_id, "genesis",
+                        ctx,
+                        msg.chat.id,
+                        sent.message_id,
+                        "genesis",
                         streamer.accumulated_text,
-                        thread_id=tid, direction="outbound",
+                        thread_id=tid,
+                        direction="outbound",
                     )
             except Exception:
                 log.error(
                     "Failed to deliver accumulated text after connection error for voice %s",
-                    user.id, exc_info=True,
+                    user.id,
+                    exc_info=True,
                 )
         else:
             error_text = "Connection issue processing your voice message."
@@ -433,13 +499,19 @@ async def _handle_voice_inner(ctx: HandlerContext, msg, user, voice, context, wh
             try:
                 sent = await msg.reply_text(error_text)
                 await _persist_tg_message(
-                    ctx, msg.chat.id, sent.message_id, "genesis", error_text,
-                    thread_id=tid, direction="outbound",
+                    ctx,
+                    msg.chat.id,
+                    sent.message_id,
+                    "genesis",
+                    error_text,
+                    thread_id=tid,
+                    direction="outbound",
                 )
             except Exception:
                 log.error(
                     "Failed to send connection-error reply to voice %s",
-                    user.id, exc_info=True,
+                    user.id,
+                    exc_info=True,
                 )
     except Exception as e:
         log.exception("Voice handling failed for user %s", user.id)
@@ -447,8 +519,13 @@ async def _handle_voice_inner(ctx: HandlerContext, msg, user, voice, context, wh
         try:
             sent = await msg.reply_text(error_text)
             await _persist_tg_message(
-                ctx, msg.chat.id, sent.message_id, "genesis", error_text,
-                thread_id=tid, direction="outbound",
+                ctx,
+                msg.chat.id,
+                sent.message_id,
+                "genesis",
+                error_text,
+                thread_id=tid,
+                direction="outbound",
             )
         except Exception:
             log.error("Failed to send error reply to voice user %s", user.id, exc_info=True)
@@ -459,8 +536,12 @@ async def _handle_voice_inner(ctx: HandlerContext, msg, user, voice, context, wh
 
 
 async def _handle_media_inner(
-    ctx: HandlerContext, msg, user, file_path: Path,
-    caption: str | None, context: ContextTypes.DEFAULT_TYPE,
+    ctx: HandlerContext,
+    msg,
+    user,
+    file_path: Path,
+    caption: str | None,
+    context: ContextTypes.DEFAULT_TYPE,
 ) -> None:
     """Process a downloaded media file through CC."""
     from genesis.channels.telegram._handler_helpers import _TypingKeepAliveV2
@@ -485,6 +566,7 @@ async def _handle_media_inner(
                     log.debug("Status snapshot send failed", exc_info=True)
 
     from genesis.util.tasks import tracked_task
+
     status_task = tracked_task(_status_snapshot(), name="media-status-snapshot")
 
     # Build prompt — CC's Read tool will open the file (images, PDFs)
@@ -529,8 +611,13 @@ async def _handle_media_inner(
         if response:
             out_id = sent_msg.message_id if sent_msg else msg.message_id
             await _persist_tg_message(
-                ctx, msg.chat.id, out_id, "genesis", response,
-                thread_id=tid, direction="outbound",
+                ctx,
+                msg.chat.id,
+                out_id,
+                "genesis",
+                response,
+                thread_id=tid,
+                direction="outbound",
             )
 
     except CCError as e:
@@ -539,8 +626,13 @@ async def _handle_media_inner(
         try:
             sent = await msg.reply_text(error_text)
             await _persist_tg_message(
-                ctx, msg.chat.id, sent.message_id, "genesis", error_text,
-                thread_id=tid, direction="outbound",
+                ctx,
+                msg.chat.id,
+                sent.message_id,
+                "genesis",
+                error_text,
+                thread_id=tid,
+                direction="outbound",
             )
         except Exception:
             log.error("Failed to send error reply to media user %s", user.id, exc_info=True)
@@ -548,20 +640,26 @@ async def _handle_media_inner(
         if streamer and streamer.accumulated_text:
             log.warning(
                 "Connection error for media %s after streaming %d chars — delivering accumulated text",
-                user.id, len(streamer.accumulated_text),
+                user.id,
+                len(streamer.accumulated_text),
             )
             try:
                 sent = await _reply_formatted(msg, streamer.accumulated_text)
                 if sent:
                     await _persist_tg_message(
-                        ctx, msg.chat.id, sent.message_id, "genesis",
+                        ctx,
+                        msg.chat.id,
+                        sent.message_id,
+                        "genesis",
                         streamer.accumulated_text,
-                        thread_id=tid, direction="outbound",
+                        thread_id=tid,
+                        direction="outbound",
                     )
             except Exception:
                 log.error(
                     "Failed to deliver accumulated text after connection error for media %s",
-                    user.id, exc_info=True,
+                    user.id,
+                    exc_info=True,
                 )
         else:
             error_text = "Connection issue processing your file."
@@ -569,13 +667,19 @@ async def _handle_media_inner(
             try:
                 sent = await msg.reply_text(error_text)
                 await _persist_tg_message(
-                    ctx, msg.chat.id, sent.message_id, "genesis", error_text,
-                    thread_id=tid, direction="outbound",
+                    ctx,
+                    msg.chat.id,
+                    sent.message_id,
+                    "genesis",
+                    error_text,
+                    thread_id=tid,
+                    direction="outbound",
                 )
             except Exception:
                 log.error(
                     "Failed to send connection-error reply to media %s",
-                    user.id, exc_info=True,
+                    user.id,
+                    exc_info=True,
                 )
     except Exception as e:
         log.exception("Media handling failed for user %s", user.id)
@@ -583,8 +687,13 @@ async def _handle_media_inner(
         try:
             sent = await msg.reply_text(error_text)
             await _persist_tg_message(
-                ctx, msg.chat.id, sent.message_id, "genesis", error_text,
-                thread_id=tid, direction="outbound",
+                ctx,
+                msg.chat.id,
+                sent.message_id,
+                "genesis",
+                error_text,
+                thread_id=tid,
+                direction="outbound",
             )
         except Exception:
             log.error("Failed to send error reply to media user %s", user.id, exc_info=True)
@@ -611,6 +720,7 @@ def _bare_decision(text: str) -> str | None:
         return None
     # Allow optional trailing punctuation on a single token.
     import re
+
     cleaned = re.sub(r"[^\w]", "", stripped) if " " not in stripped else stripped
     if " " in cleaned:
         return None
@@ -622,7 +732,9 @@ def _bare_decision(text: str) -> str | None:
 
 
 async def _try_bare_approval_resolution(
-    ctx: HandlerContext, msg, user,
+    ctx: HandlerContext,
+    msg,
+    user,
 ) -> bool:
     """Resolve a bare 'approve'/'reject' typed into the Approvals topic.
 
@@ -687,16 +799,16 @@ async def _try_bare_approval_resolution(
         return False
     log.info(
         "Bare %s in Approvals topic resolved request %s (user %s)",
-        decision, resolved_id, user.id,
+        decision,
+        resolved_id,
+        user.id,
     )
     try:
         ack = "✅ Approved" if decision == "approved" else "❌ Rejected"
-        await msg.reply_text(f"{ack} request <code>{resolved_id}</code>",
-                             parse_mode="HTML")
+        await msg.reply_text(f"{ack} request <code>{resolved_id}</code>", parse_mode="HTML")
     except Exception:
         log.debug("Failed to ack bare approval", exc_info=True)
     return True
-
 
 
 def _trigger_immediate_sweep() -> None:
@@ -738,7 +850,8 @@ async def _try_proposal_resolution(ctx: HandlerContext, msg, reply_to_id: str) -
         if -1 in decisions:
             status, reason = decisions[-1]
             results = await ctx.proposal_workflow.resolve_all_pending_proposals(
-                status, reason,
+                status,
+                reason,
             )
             approved = sum(1 for s in results.values() if s == "approved")
             rejected = sum(1 for s in results.values() if s == "rejected")
@@ -761,15 +874,15 @@ async def _try_proposal_resolution(ctx: HandlerContext, msg, reply_to_id: str) -
             status, reason = decisions[0]
             # Get all proposals in this batch and resolve them all
             proposals = await ego_crud.list_proposals_by_batch(ctx.db, batch_id)
-            all_decisions = {
-                i + 1: (status, reason) for i in range(len(proposals))
-            }
+            all_decisions = {i + 1: (status, reason) for i in range(len(proposals))}
             results = await ctx.proposal_workflow.resolve_proposals(
-                batch_id, all_decisions,
+                batch_id,
+                all_decisions,
             )
         else:
             results = await ctx.proposal_workflow.resolve_proposals(
-                batch_id, decisions,
+                batch_id,
+                decisions,
             )
 
         # Send confirmation
@@ -845,7 +958,8 @@ async def _try_bare_proposal_resolution(ctx: HandlerContext, msg) -> bool:
         if -1 in decisions:
             status, reason = decisions[-1]
             results = await ctx.proposal_workflow.resolve_all_pending_proposals(
-                status, reason,
+                status,
+                reason,
             )
         else:
             # Get most recent pending proposals to find their batch
@@ -862,18 +976,18 @@ async def _try_bare_proposal_resolution(ctx: HandlerContext, msg) -> bool:
                 # Use full batch for correct 1-based indexing — resolve_proposal
                 # skips already-resolved proposals via WHERE status='pending'.
                 full_batch = await ego_crud.list_proposals_by_batch(
-                    ctx.db, batch_id,
+                    ctx.db,
+                    batch_id,
                 )
-                all_decisions = {
-                    i + 1: (status, reason)
-                    for i in range(len(full_batch))
-                }
+                all_decisions = {i + 1: (status, reason) for i in range(len(full_batch))}
                 results = await ctx.proposal_workflow.resolve_proposals(
-                    batch_id, all_decisions,
+                    batch_id,
+                    all_decisions,
                 )
             else:
                 results = await ctx.proposal_workflow.resolve_proposals(
-                    batch_id, decisions,
+                    batch_id,
+                    decisions,
                 )
 
         approved = sum(1 for s in results.values() if s == "approved")
@@ -964,7 +1078,11 @@ async def handle_text(ctx: HandlerContext, update: Update, context: ContextTypes
     log.info("Text from %s (%d chars)", user.id, len(msg.text))
 
     await _persist_tg_message(
-        ctx, msg.chat.id, msg.message_id, "user", msg.text,
+        ctx,
+        msg.chat.id,
+        msg.message_id,
+        "user",
+        msg.text,
         thread_id=ctx.thread_id(update),
         reply_to=msg.reply_to_message.message_id if msg.reply_to_message else None,
     )
@@ -1006,10 +1124,12 @@ async def handle_text(ctx: HandlerContext, update: Update, context: ContextTypes
         if ctx.engagement_tracker and ctx.db:
             try:
                 from genesis.db.crud.outreach import find_by_delivery_id
+
                 outreach_record = await find_by_delivery_id(ctx.db, reply_to_id)
                 if outreach_record:
                     await ctx.engagement_tracker.record_reply(
-                        outreach_record["id"], msg.text,
+                        outreach_record["id"],
+                        msg.text,
                     )
                     log.info("Engagement recorded for outreach %s", outreach_record["id"])
             except Exception:
@@ -1028,6 +1148,7 @@ async def handle_text(ctx: HandlerContext, update: Update, context: ContextTypes
     if ctx.engagement_tracker and ctx.db:
         try:
             from genesis.db.crud.outreach import find_recent_unengaged
+
             recent = await find_recent_unengaged(ctx.db)
             for rec in recent:
                 await ctx.engagement_tracker.record_implicit_engagement(rec["id"])
@@ -1041,7 +1162,8 @@ async def handle_text(ctx: HandlerContext, update: Update, context: ContextTypes
 
     chat_lock = (
         ctx.adapter.get_chat_lock(msg.chat.id, msg.message_thread_id)
-        if ctx.adapter else asyncio.Lock()
+        if ctx.adapter
+        else asyncio.Lock()
     )
     async with chat_lock:
         await _handle_text_inner(ctx, msg, user, tid)
@@ -1063,7 +1185,9 @@ async def _resolution_label(gate, request_id: str) -> str:
     return f"⚠️ Already resolved ({actual})"
 
 
-async def handle_callback_query(ctx: HandlerContext, update: Update, context: ContextTypes.DEFAULT_TYPE):
+async def handle_callback_query(
+    ctx: HandlerContext, update: Update, context: ContextTypes.DEFAULT_TYPE
+):
     """Handle inline keyboard button presses (approval flows).
 
     Recognized callback_data prefixes:
@@ -1108,11 +1232,15 @@ async def handle_callback_query(ctx: HandlerContext, update: Update, context: Co
             return
         try:
             ok = await ctx.autonomous_cli_gate.resolve_request(
-                key, decision="approved", resolved_by=f"telegram:button:{user.id}",
+                key,
+                decision="approved",
+                resolved_by=f"telegram:button:{user.id}",
             )
         except Exception:
             log.error(
-                "Failed to resolve cli_approve for request %s", key, exc_info=True,
+                "Failed to resolve cli_approve for request %s",
+                key,
+                exc_info=True,
             )
             return
         if ok:
@@ -1144,7 +1272,8 @@ async def handle_callback_query(ctx: HandlerContext, update: Update, context: Co
             # reflects the click, even if approve_all_pending re-resolves
             # it as part of the batch sweep.
             triggered_ok = await ctx.autonomous_cli_gate.resolve_request(
-                key, decision="approved",
+                key,
+                decision="approved",
                 resolved_by=f"telegram:batch:{user.id}",
             )
             # Scope batch to same subsystem as the triggering request.
@@ -1166,7 +1295,9 @@ async def handle_callback_query(ctx: HandlerContext, update: Update, context: Co
                 batch_count = 0
         except Exception:
             log.error(
-                "Failed to resolve cli_approve_all for %s", key, exc_info=True,
+                "Failed to resolve cli_approve_all for %s",
+                key,
+                exc_info=True,
             )
             return
         total = batch_count + (1 if triggered_ok else 0)
@@ -1176,7 +1307,11 @@ async def handle_callback_query(ctx: HandlerContext, update: Update, context: Co
             label = await _resolution_label(ctx.autonomous_cli_gate, key)
         log.info(
             "cli_approve_all triggered by %s: triggered=%s batch=%d total=%d (user %s)",
-            key, triggered_ok, batch_count, total, user.id,
+            key,
+            triggered_ok,
+            batch_count,
+            total,
+            user.id,
         )
         try:
             original = query.message.text_html or query.message.text or ""
@@ -1212,7 +1347,9 @@ async def handle_callback_query(ctx: HandlerContext, update: Update, context: Co
             decision_label = "Approved" if action == "approve" else "Rejected"
             log.info(
                 "Callback for expired/processed waiter %s: %s (user %s)",
-                key, decision_label, user.id,
+                key,
+                decision_label,
+                user.id,
             )
             try:
                 original = query.message.text_html or query.message.text or ""
@@ -1238,8 +1375,8 @@ async def handle_voice(ctx: HandlerContext, update: Update, context: ContextType
 
     if voice.file_size and voice.file_size > _MAX_VOICE_BYTES:
         await msg.reply_text(
-            f"Voice file too large ({voice.file_size // (1024*1024)}MB). "
-            f"Maximum is {_MAX_VOICE_BYTES // (1024*1024)}MB."
+            f"Voice file too large ({voice.file_size // (1024 * 1024)}MB). "
+            f"Maximum is {_MAX_VOICE_BYTES // (1024 * 1024)}MB."
         )
         return
 
@@ -1250,11 +1387,17 @@ async def handle_voice(ctx: HandlerContext, update: Update, context: ContextType
 
     chat_lock = (
         ctx.adapter.get_chat_lock(msg.chat.id, msg.message_thread_id)
-        if ctx.adapter else asyncio.Lock()
+        if ctx.adapter
+        else asyncio.Lock()
     )
     async with chat_lock:
         await _handle_voice_inner(
-            ctx, msg, user, voice, context, ctx.whisper_model,
+            ctx,
+            msg,
+            user,
+            voice,
+            context,
+            ctx.whisper_model,
         )
 
 
@@ -1295,7 +1438,8 @@ async def handle_photo(ctx: HandlerContext, update: Update, context: ContextType
 
     chat_lock = (
         ctx.adapter.get_chat_lock(msg.chat.id, msg.message_thread_id)
-        if ctx.adapter else asyncio.Lock()
+        if ctx.adapter
+        else asyncio.Lock()
     )
     try:
         async with chat_lock:
@@ -1357,7 +1501,8 @@ async def handle_document(ctx: HandlerContext, update: Update, context: ContextT
 
     chat_lock = (
         ctx.adapter.get_chat_lock(msg.chat.id, msg.message_thread_id)
-        if ctx.adapter else asyncio.Lock()
+        if ctx.adapter
+        else asyncio.Lock()
     )
     try:
         async with chat_lock:

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -385,6 +385,46 @@ async def get_tabled(db: aiosqlite.Connection) -> list[dict]:
     return [dict(r) for r in await cursor.fetchall()]
 
 
+async def expire_stale_proposals(db: aiosqlite.Connection) -> int:
+    """Expire pending proposals past their expires_at.
+
+    Also expires corresponding intervention_journal entries to keep the
+    journal in sync (avoids orphaned 'pending' entries inflating ego context).
+
+    Returns count of expired proposals.
+    """
+    now = datetime.now(UTC).isoformat()
+    # Get IDs first so we can update journal too
+    cursor = await db.execute(
+        "SELECT id FROM ego_proposals "
+        "WHERE status = 'pending' AND expires_at IS NOT NULL AND expires_at < ?",
+        (now,),
+    )
+    rows = await cursor.fetchall()
+    if not rows:
+        return 0
+
+    ids = [r[0] for r in rows]
+    # Expire proposals
+    await db.execute(
+        "UPDATE ego_proposals SET status = 'expired', resolved_at = ? "
+        "WHERE status = 'pending' AND expires_at IS NOT NULL AND expires_at < ?",
+        (now, now),
+    )
+    # Expire matching journal entries
+    placeholders = ",".join("?" * len(ids))
+    await db.execute(
+        f"UPDATE intervention_journal SET outcome_status = 'expired', "
+        f"resolved_at = ? WHERE proposal_id IN ({placeholders}) "
+        f"AND outcome_status = 'pending'",
+        (now, *ids),
+    )
+    await db.commit()
+    if ids:
+        logger.info("Expired %d stale proposal(s)", len(ids))
+    return len(ids)
+
+
 async def get_batch_for_delivery(
     db: aiosqlite.Connection,
     delivery_id: str,

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -407,6 +407,26 @@ async def get_tabled(db: aiosqlite.Connection) -> list[dict]:
     return [dict(r) for r in await cursor.fetchall()]
 
 
+async def revoke_proposal(
+    db: aiosqlite.Connection,
+    id: str,
+    *,
+    user_response: str | None = None,
+) -> bool:
+    """Revoke an approved proposal (approved → rejected).
+
+    Used during the grace period between approval and dispatch.
+    Returns True if a row was updated.
+    """
+    cursor = await db.execute(
+        "UPDATE ego_proposals SET status = 'rejected', user_response = ?, "
+        "resolved_at = ? WHERE id = ? AND status = 'approved'",
+        (user_response or "revoked by user", datetime.now(UTC).isoformat(), id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
 async def expire_stale_proposals(db: aiosqlite.Connection) -> int:
     """Expire pending proposals past their expires_at.
 

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -38,9 +38,18 @@ async def create_cycle(
             model_used, cost_usd, input_tokens, output_tokens,
             duration_ms, created_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        (id, output_text, proposals_json, focus_summary,
-         model_used, cost_usd, input_tokens, output_tokens,
-         duration_ms, created_at),
+        (
+            id,
+            output_text,
+            proposals_json,
+            focus_summary,
+            model_used,
+            cost_usd,
+            input_tokens,
+            output_tokens,
+            duration_ms,
+            created_at,
+        ),
     )
     await db.commit()
     return id
@@ -49,7 +58,8 @@ async def create_cycle(
 async def get_cycle(db: aiosqlite.Connection, id: str) -> dict | None:
     """Fetch a single cycle by id. Returns None if not found."""
     cursor = await db.execute(
-        "SELECT * FROM ego_cycles WHERE id = ?", (id,),
+        "SELECT * FROM ego_cycles WHERE id = ?",
+        (id,),
     )
     row = await cursor.fetchone()
     if row is None:
@@ -132,7 +142,8 @@ async def count_uncompacted(db: aiosqlite.Connection) -> int:
 async def get_state(db: aiosqlite.Connection, key: str) -> str | None:
     """Get a value from ego_state. Returns None if key not found."""
     cursor = await db.execute(
-        "SELECT value FROM ego_state WHERE key = ?", (key,),
+        "SELECT value FROM ego_state WHERE key = ?",
+        (key,),
     )
     row = await cursor.fetchone()
     return row[0] if row else None
@@ -224,10 +235,25 @@ async def create_proposal(
             batch_id, created_at, expires_at, rank, execution_plan,
             recurring, memory_basis)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        (id, action_type, action_category, content, rationale,
-         confidence, urgency, alternatives, status, cycle_id,
-         batch_id, created_at, expires_at, rank, execution_plan,
-         1 if recurring else 0, memory_basis),
+        (
+            id,
+            action_type,
+            action_category,
+            content,
+            rationale,
+            confidence,
+            urgency,
+            alternatives,
+            status,
+            cycle_id,
+            batch_id,
+            created_at,
+            expires_at,
+            rank,
+            execution_plan,
+            1 if recurring else 0,
+            memory_basis,
+        ),
     )
     await db.commit()
     return id
@@ -236,7 +262,8 @@ async def create_proposal(
 async def get_proposal(db: aiosqlite.Connection, id: str) -> dict | None:
     """Fetch a single proposal by id."""
     cursor = await db.execute(
-        "SELECT * FROM ego_proposals WHERE id = ?", (id,),
+        "SELECT * FROM ego_proposals WHERE id = ?",
+        (id,),
     )
     row = await cursor.fetchone()
     return dict(row) if row else None
@@ -257,8 +284,7 @@ async def list_proposals_by_batch(
 async def list_pending_proposals(db: aiosqlite.Connection) -> list[dict]:
     """All pending proposals, oldest first."""
     cursor = await db.execute(
-        "SELECT * FROM ego_proposals WHERE status = 'pending' "
-        "ORDER BY created_at ASC",
+        "SELECT * FROM ego_proposals WHERE status = 'pending' ORDER BY created_at ASC",
     )
     return [dict(r) for r in await cursor.fetchall()]
 
@@ -272,8 +298,7 @@ async def list_proposals(
     """All proposals, optionally filtered by status, newest first."""
     if status:
         cursor = await db.execute(
-            "SELECT * FROM ego_proposals WHERE status = ? "
-            "ORDER BY created_at DESC LIMIT ?",
+            "SELECT * FROM ego_proposals WHERE status = ? ORDER BY created_at DESC LIMIT ?",
             (status, limit),
         )
     else:
@@ -317,9 +342,7 @@ async def execute_proposal(
     resolve_proposal (which operates on 'pending').
     """
     if status not in ("executed", "failed"):
-        raise ValueError(
-            f"execute_proposal status must be 'executed' or 'failed', got {status!r}"
-        )
+        raise ValueError(f"execute_proposal status must be 'executed' or 'failed', got {status!r}")
     cursor = await db.execute(
         "UPDATE ego_proposals SET status = ?, user_response = ?, resolved_at = ? "
         "WHERE id = ? AND status = 'approved'",
@@ -379,8 +402,7 @@ async def get_board(
 async def get_tabled(db: aiosqlite.Connection) -> list[dict]:
     """All tabled proposals, newest first."""
     cursor = await db.execute(
-        "SELECT * FROM ego_proposals WHERE status = 'tabled' "
-        "ORDER BY resolved_at DESC",
+        "SELECT * FROM ego_proposals WHERE status = 'tabled' ORDER BY resolved_at DESC",
     )
     return [dict(r) for r in await cursor.fetchall()]
 
@@ -437,6 +459,7 @@ def _next_date(date_str: str) -> str:
     """Return the next day as YYYY-MM-DD."""
     from datetime import date as dt_date
     from datetime import timedelta
+
     d = dt_date.fromisoformat(date_str)
     return (d + timedelta(days=1)).isoformat()
 
@@ -457,6 +480,7 @@ async def daily_ego_cost(
     """
     if date is None:
         from datetime import UTC, datetime
+
         date = datetime.now(UTC).strftime("%Y-%m-%d")
     async with db.execute(
         "SELECT COALESCE(SUM(cost_usd), 0.0) FROM ego_cycles "

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -109,10 +109,10 @@ class EgoCadenceManager:
                 max_instances=1,
                 misfire_grace_time=600,
             )
-        # Mechanical sweep: dispatch approved proposals every 30 min,
-        # independent of ego LLM cycles.
+        # Mechanical sweep: expire stale proposals then dispatch approved
+        # proposals every 30 min, independent of ego LLM cycles.
         self._scheduler.add_job(
-            self._session.sweep_approved_proposals,
+            self._sweep_with_expiry,
             IntervalTrigger(minutes=30),
             id="ego_sweep_approved",
             max_instances=1,
@@ -165,6 +165,21 @@ class EgoCadenceManager:
     @property
     def consecutive_failures(self) -> int:
         return self._consecutive_failures
+
+    # -- Sweep helpers -----------------------------------------------------
+
+    async def _sweep_with_expiry(self) -> None:
+        """Expire stale proposals, then dispatch approved ones."""
+        try:
+            from genesis.db.crud import ego as ego_crud
+
+            expired = await ego_crud.expire_stale_proposals(self._session._db)
+            if expired:
+                logger.info("Pre-sweep expiry: %d proposal(s) expired", expired)
+        except Exception:
+            logger.warning("Pre-sweep expiry failed", exc_info=True)
+
+        await self._session.sweep_approved_proposals()
 
     # -- Tick handlers -----------------------------------------------------
 

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -35,11 +35,11 @@ logger = logging.getLogger(__name__)
 # When the user hasn't had a foreground session in a while, the ego
 # naturally winds down — through the cadence system, not self-suppression.
 _RECENCY_TIERS: list[tuple[timedelta | None, int]] = [
-    (timedelta(hours=24), 240),    # <24h:   current max (~6x/day)
-    (timedelta(days=3),   480),    # 1-3d:   ~3x/day
-    (timedelta(days=7),   1440),   # 3-7d:   ~1x/day
-    (timedelta(days=14),  2880),   # 7-14d:  every other day
-    (None,                4320),   # 14+d:   every 3 days
+    (timedelta(hours=24), 240),  # <24h:   current max (~6x/day)
+    (timedelta(days=3), 480),  # 1-3d:   ~3x/day
+    (timedelta(days=7), 1440),  # 3-7d:   ~1x/day
+    (timedelta(days=14), 2880),  # 7-14d:  every other day
+    (None, 4320),  # 14+d:   every 3 days
 ]
 
 
@@ -273,6 +273,7 @@ class EgoCadenceManager:
         # Check global Genesis pause
         try:
             from genesis.runtime import GenesisRuntime
+
             if GenesisRuntime.instance().paused:
                 logger.debug("Ego cycle skipped — Genesis paused")
                 return False
@@ -318,6 +319,7 @@ class EgoCadenceManager:
 
         try:
             from genesis.runtime import GenesisRuntime
+
             GenesisRuntime.instance().record_job_success("ego_cycle")
         except ImportError:
             pass
@@ -333,14 +335,14 @@ class EgoCadenceManager:
                 minutes=self._config.failure_backoff_minutes,
             )
             logger.warning(
-                "Ego circuit breaker OPEN — %d consecutive failures, "
-                "pausing for %d minutes",
+                "Ego circuit breaker OPEN — %d consecutive failures, pausing for %d minutes",
                 self._consecutive_failures,
                 self._config.failure_backoff_minutes,
             )
 
         try:
             from genesis.runtime import GenesisRuntime
+
             GenesisRuntime.instance().record_job_failure("ego_cycle", error)
         except ImportError:
             pass
@@ -412,11 +414,14 @@ class EgoCadenceManager:
                 )
                 logger.info(
                     "Ego interval adjusted: %dm → %dm (recency_max=%dm)",
-                    old_interval, new_interval, recency_max,
+                    old_interval,
+                    new_interval,
+                    recency_max,
                 )
             except Exception:
                 logger.warning(
-                    "Failed to reschedule ego interval", exc_info=True,
+                    "Failed to reschedule ego interval",
+                    exc_info=True,
                 )
 
     # -- Observability -----------------------------------------------------

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -38,10 +38,13 @@ _URGENCY_TAGS = {"critical": "[CRITICAL] ", "high": "[HIGH] "}
 
 def _sort_proposals(proposals: list[dict]) -> list[dict]:
     """Sort proposals by urgency (critical first) then confidence (desc)."""
-    return sorted(proposals, key=lambda p: (
-        _URGENCY_ORDER.get(p.get("urgency", "normal"), 2),
-        -float(p.get("confidence", 0)),
-    ))
+    return sorted(
+        proposals,
+        key=lambda p: (
+            _URGENCY_ORDER.get(p.get("urgency", "normal"), 2),
+            -float(p.get("confidence", 0)),
+        ),
+    )
 
 
 def _format_digest(
@@ -77,10 +80,7 @@ def _format_digest(
                 memory_basis = memory_basis[:500] + "\u2026"
             lines.append(f"<i>{_ESC(memory_basis)}</i>")
         confidence = p.get("confidence", 0.0)
-        lines.append(
-            f"<i>Confidence:</i> {confidence:.2f} | "
-            f"<i>Urgency:</i> {urgency}"
-        )
+        lines.append(f"<i>Confidence:</i> {confidence:.2f} | <i>Urgency:</i> {urgency}")
         alts = p.get("alternatives", "")
         if alts:
             if len(alts) > 300:
@@ -174,7 +174,8 @@ class ProposalWorkflow:
 
         logger.info(
             "Created ego proposal batch %s with %d proposals",
-            batch_id, len(ids),
+            batch_id,
+            len(ids),
         )
         return batch_id, ids
 
@@ -250,14 +251,14 @@ class ProposalWorkflow:
             if other_pending:
                 digest_html = (
                     f"<i>{len(other_pending)} proposal(s) pending from previous "
-                    f"batches. Reply 'approve all pending' to resolve all.</i>\n\n"
-                    + digest_html
+                    f"batches. Reply 'approve all pending' to resolve all.</i>\n\n" + digest_html
                 )
         except Exception:
             pass  # Non-critical; skip header on error
 
         delivery_id = await self._topic_manager.send_to_category(
-            TOPIC_CATEGORY, digest_html,
+            TOPIC_CATEGORY,
+            digest_html,
         )
 
         if delivery_id is None:
@@ -266,15 +267,21 @@ class ProposalWorkflow:
 
         # Store bidirectional mapping for reply resolution.
         await ego_crud.set_state(
-            self._db, key=f"delivery_batch:{delivery_id}", value=batch_id,
+            self._db,
+            key=f"delivery_batch:{delivery_id}",
+            value=batch_id,
         )
         await ego_crud.set_state(
-            self._db, key=f"batch_delivery:{batch_id}", value=delivery_id,
+            self._db,
+            key=f"batch_delivery:{batch_id}",
+            value=delivery_id,
         )
 
         logger.info(
             "Sent ego digest for batch %s (delivery_id=%s, %d proposals)",
-            batch_id, delivery_id, len(proposals),
+            batch_id,
+            delivery_id,
+            len(proposals),
         )
         return str(delivery_id)
 
@@ -301,17 +308,22 @@ class ProposalWorkflow:
                 continue
             prop = proposals[idx - 1]
             updated = await ego_crud.resolve_proposal(
-                self._db, prop["id"], status=status, user_response=reason,
+                self._db,
+                prop["id"],
+                status=status,
+                user_response=reason,
             )
             if updated:
                 results[prop["id"]] = status
                 logger.info(
                     "Proposal %s → %s%s",
-                    prop["id"], status,
+                    prop["id"],
+                    status,
                     f" ({reason})" if reason else "",
                 )
                 # J-9 eval: log proposal resolution for ego quality tracking
                 from genesis.eval.j9_hooks import emit_proposal_resolved
+
                 await emit_proposal_resolved(
                     self._db,
                     proposal_id=prop["id"],
@@ -322,8 +334,10 @@ class ProposalWorkflow:
                 # Intervention journal: record resolution
                 try:
                     from genesis.db.crud import intervention_journal as journal_crud
+
                     await journal_crud.resolve(
-                        self._db, prop["id"],
+                        self._db,
+                        prop["id"],
                         outcome_status=status,
                         actual_outcome=f"User {status}" + (f": {reason}" if reason else ""),
                         user_response=reason,
@@ -331,15 +345,12 @@ class ProposalWorkflow:
                 except Exception:
                     logger.warning("Failed to update intervention journal for %s", prop["id"])
                 # Auto-store correction memory on rejection with reason
-                if (
-                    status == ProposalStatus.REJECTED
-                    and reason
-                    and self._memory_store
-                ):
+                if status == ProposalStatus.REJECTED and reason and self._memory_store:
                     await self._store_correction(prop, reason)
             else:
                 logger.warning(
-                    "Proposal %s not updated (already resolved?)", prop["id"],
+                    "Proposal %s not updated (already resolved?)",
+                    prop["id"],
                 )
 
         return results
@@ -354,8 +365,7 @@ class ProposalWorkflow:
         action_category = proposal.get("action_category", "")
         content_snippet = proposal.get("content", "")[:200]
         correction_text = (
-            f"User rejected [{action_type}]: {content_snippet}. "
-            f"Reason: {reason}. Do not repeat."
+            f"User rejected [{action_type}]: {content_snippet}. Reason: {reason}. Do not repeat."
         )
         tags = ["ego_correction"]
         if action_category:
@@ -408,19 +418,20 @@ class ProposalWorkflow:
         for batch_id in batch_ids:
             # Get full batch to find correct 1-based positions
             full_batch = await ego_crud.list_proposals_by_batch(
-                self._db, batch_id,
+                self._db,
+                batch_id,
             )
             # Create decisions for ALL positions — resolve_proposal's
             # WHERE status='pending' clause skips already-resolved ones.
-            decisions = {
-                i + 1: (status, reason) for i in range(len(full_batch))
-            }
+            decisions = {i + 1: (status, reason) for i in range(len(full_batch))}
             results = await self.resolve_proposals(batch_id, decisions)
             all_results.update(results)
 
         logger.info(
             "Cross-batch resolve: %d proposals → %s across %d batch(es)",
-            len(all_results), status, len(batch_ids),
+            len(all_results),
+            status,
+            len(batch_ids),
         )
         return all_results
 
@@ -464,13 +475,17 @@ def parse_proposal_decisions(text: str) -> dict[int, tuple[str, str | None]]:
 
     # Cross-batch bulk operations (all pending across batches)
     if stripped in (
-        "approve all pending", "approved all pending",
-        "accept all pending", "yes all pending",
+        "approve all pending",
+        "approved all pending",
+        "accept all pending",
+        "yes all pending",
     ):
         return {-1: ("approved", None)}  # -1 = sentinel for cross-batch
     if stripped in (
-        "reject all pending", "rejected all pending",
-        "deny all pending", "no all pending",
+        "reject all pending",
+        "rejected all pending",
+        "deny all pending",
+        "no all pending",
     ):
         return {-1: ("rejected", None)}
 

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -451,7 +451,7 @@ class ProposalWorkflow:
         proposals = await ego_crud.list_proposals_by_batch(self._db, batch_id)
         revoked = 0
         for i, prop in enumerate(proposals, 1):
-            if proposal_indices and i not in proposal_indices:
+            if proposal_indices is not None and i not in proposal_indices:
                 continue
             if prop["status"] != "approved":
                 continue

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -32,15 +32,30 @@ TOPIC_CATEGORY = "ego_proposals"
 
 _ESC = html.escape
 
+_URGENCY_ORDER = {"critical": 0, "high": 1, "normal": 2, "low": 3}
+_URGENCY_TAGS = {"critical": "[CRITICAL] ", "high": "[HIGH] "}
+
+
+def _sort_proposals(proposals: list[dict]) -> list[dict]:
+    """Sort proposals by urgency (critical first) then confidence (desc)."""
+    return sorted(proposals, key=lambda p: (
+        _URGENCY_ORDER.get(p.get("urgency", "normal"), 2),
+        -float(p.get("confidence", 0)),
+    ))
+
 
 def _format_digest(
     proposals: list[dict],
     batch_id: str,
 ) -> str:
-    """Format proposals as an HTML numbered digest for Telegram."""
+    """Format proposals as an HTML numbered digest for Telegram.
+
+    Proposals are sorted by urgency x confidence before numbering.
+    """
+    sorted_proposals = _sort_proposals(proposals)
     lines = [f"<b>Ego Proposals</b> \u2014 Batch {_ESC(batch_id[:8])}\n"]
 
-    for i, p in enumerate(proposals, 1):
+    for i, p in enumerate(sorted_proposals, 1):
         content = p.get("content", "")
         if len(content) > 800:
             content = content[:800] + "\u2026"
@@ -48,8 +63,10 @@ def _format_digest(
         if len(rationale) > 500:
             rationale = rationale[:500] + "\u2026"
 
+        urgency = p.get("urgency", "normal")
+        urgency_tag = _URGENCY_TAGS.get(urgency, "")
         lines.append(
-            f"<b>{i}.</b> <b>[{_ESC(p.get('action_type', '?'))}]</b> "
+            f"<b>{i}.</b> {_ESC(urgency_tag)}<b>[{_ESC(p.get('action_type', '?'))}]</b> "
             f"{_ESC(content)}"
         )
         if rationale:
@@ -60,7 +77,6 @@ def _format_digest(
                 memory_basis = memory_basis[:500] + "\u2026"
             lines.append(f"<i>{_ESC(memory_basis)}</i>")
         confidence = p.get("confidence", 0.0)
-        urgency = p.get("urgency", "normal")
         lines.append(
             f"<i>Confidence:</i> {confidence:.2f} | "
             f"<i>Urgency:</i> {urgency}"
@@ -71,7 +87,6 @@ def _format_digest(
                 alts = alts[:300] + "\u2026"
             lines.append(f"<i>Alternatives:</i> {_ESC(alts)}")
         lines.append("")
-
 
     return "\n".join(lines)
 
@@ -228,6 +243,19 @@ class ProposalWorkflow:
             warn_lines = "\n".join(f"  - {w}" for w in validation_warnings)
             digest_html = f"\u26a0\ufe0f <b>Validation:</b>\n{warn_lines}\n\n{digest_html}"
 
+        # Show pending count from other batches for visibility
+        try:
+            all_pending = await ego_crud.list_pending_proposals(self._db)
+            other_pending = [p for p in all_pending if p.get("batch_id") != batch_id]
+            if other_pending:
+                digest_html = (
+                    f"<i>{len(other_pending)} proposal(s) pending from previous "
+                    f"batches. Reply 'approve all pending' to resolve all.</i>\n\n"
+                    + digest_html
+                )
+        except Exception:
+            pass  # Non-critical; skip header on error
+
         delivery_id = await self._topic_manager.send_to_category(
             TOPIC_CATEGORY, digest_html,
         )
@@ -351,6 +379,51 @@ class ProposalWorkflow:
                 exc_info=True,
             )
 
+    # -- Cross-batch approval ------------------------------------------------
+
+    async def resolve_all_pending_proposals(
+        self,
+        status: str,
+        reason: str | None = None,
+    ) -> dict[str, str]:
+        """Resolve ALL pending proposals across all batches.
+
+        Loops per-batch to preserve intervention_journal, J-9 eval,
+        and correction memory lifecycle.  Returns {proposal_id: status}.
+
+        Uses full batch lists for correct 1-based indexing — resolve_proposals
+        indexes into list_proposals_by_batch (ALL proposals, not just pending).
+        """
+        pending = await ego_crud.list_pending_proposals(self._db)
+        if not pending:
+            return {}
+
+        # Group by batch_id
+        batch_ids: set[str] = set()
+        for p in pending:
+            bid = p.get("batch_id") or "unknown"
+            batch_ids.add(bid)
+
+        all_results: dict[str, str] = {}
+        for batch_id in batch_ids:
+            # Get full batch to find correct 1-based positions
+            full_batch = await ego_crud.list_proposals_by_batch(
+                self._db, batch_id,
+            )
+            # Create decisions for ALL positions — resolve_proposal's
+            # WHERE status='pending' clause skips already-resolved ones.
+            decisions = {
+                i + 1: (status, reason) for i in range(len(full_batch))
+            }
+            results = await self.resolve_proposals(batch_id, decisions)
+            all_results.update(results)
+
+        logger.info(
+            "Cross-batch resolve: %d proposals → %s across %d batch(es)",
+            len(all_results), status, len(batch_ids),
+        )
+        return all_results
+
     # -- Late-binding for memory store (wired in init/ego.py) ----------------
 
     def set_memory_store(self, store: MemoryStore) -> None:
@@ -389,9 +462,21 @@ def parse_proposal_decisions(text: str) -> dict[int, tuple[str, str | None]]:
     """
     stripped = text.strip().lower()
 
-    # Bulk operations
+    # Cross-batch bulk operations (all pending across batches)
+    if stripped in (
+        "approve all pending", "approved all pending",
+        "accept all pending", "yes all pending",
+    ):
+        return {-1: ("approved", None)}  # -1 = sentinel for cross-batch
+    if stripped in (
+        "reject all pending", "rejected all pending",
+        "deny all pending", "no all pending",
+    ):
+        return {-1: ("rejected", None)}
+
+    # Batch-scoped bulk operations
     if stripped in ("approve all", "approved all", "accept all", "yes all", "go ahead"):
-        return {0: ("approved", None)}  # 0 = sentinel for "all"
+        return {0: ("approved", None)}  # 0 = sentinel for "all in batch"
     if stripped in ("reject all", "rejected all", "deny all", "no all"):
         return {0: ("rejected", None)}
 

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -435,6 +435,50 @@ class ProposalWorkflow:
         )
         return all_results
 
+    # -- Revoke (cancel approved proposals) -----------------------------------
+
+    async def revoke_approved_proposals(
+        self,
+        batch_id: str,
+        proposal_indices: list[int] | None = None,
+        reason: str | None = None,
+    ) -> int:
+        """Revoke approved proposals in a batch (approved → rejected).
+
+        If proposal_indices is None, revokes all approved in the batch.
+        Returns count of revoked proposals.
+        """
+        proposals = await ego_crud.list_proposals_by_batch(self._db, batch_id)
+        revoked = 0
+        for i, prop in enumerate(proposals, 1):
+            if proposal_indices and i not in proposal_indices:
+                continue
+            if prop["status"] != "approved":
+                continue
+            ok = await ego_crud.revoke_proposal(
+                self._db,
+                prop["id"],
+                user_response=reason or "revoked by user",
+            )
+            if ok:
+                revoked += 1
+                # Update intervention journal
+                try:
+                    from genesis.db.crud import intervention_journal as journal_crud
+
+                    await journal_crud.resolve(
+                        self._db,
+                        prop["id"],
+                        outcome_status="rejected",
+                        actual_outcome="User revoked approval" + (f": {reason}" if reason else ""),
+                        user_response=reason,
+                    )
+                except Exception:
+                    logger.warning("Failed to update journal for revoked proposal %s", prop["id"])
+        if revoked:
+            logger.info("Revoked %d approved proposal(s) in batch %s", revoked, batch_id)
+        return revoked
+
     # -- Late-binding for memory store (wired in init/ego.py) ----------------
 
     def set_memory_store(self, store: MemoryStore) -> None:
@@ -448,6 +492,7 @@ class ProposalWorkflow:
 
 _APPROVE_WORDS = {"approve", "approved", "yes", "accept", "go", "ok", "okay"}
 _REJECT_WORDS = {"reject", "rejected", "no", "deny", "denied", "skip", "nope"}
+_CANCEL_WORDS = {"cancel", "cancelled", "revoke", "revoked", "stop", "undo"}
 
 # Pattern: "1 approve" or "approve 1" or "1 yes" or "reject 2: reason"
 _NUMBERED_PATTERN = re.compile(
@@ -489,6 +534,10 @@ def parse_proposal_decisions(text: str) -> dict[int, tuple[str, str | None]]:
     ):
         return {-1: ("rejected", None)}
 
+    # Cancel/revoke (works on approved proposals during grace period)
+    if stripped in ("cancel all", "revoke all", "stop all", "undo all"):
+        return {0: ("cancelled", None)}  # 0 = sentinel, "cancelled" triggers revoke path
+
     # Batch-scoped bulk operations
     if stripped in ("approve all", "approved all", "accept all", "yes all", "go ahead"):
         return {0: ("approved", None)}  # 0 = sentinel for "all in batch"
@@ -529,6 +578,8 @@ def parse_proposal_decisions(text: str) -> dict[int, tuple[str, str | None]]:
             decisions[idx] = ("approved", reason.strip() if reason else None)
         elif word in _REJECT_WORDS:
             decisions[idx] = ("rejected", reason.strip() if reason else None)
+        elif word in _CANCEL_WORDS:
+            decisions[idx] = ("cancelled", reason.strip() if reason else None)
         # Unknown word → skip this part (don't fail the whole parse)
 
     return decisions

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -11,6 +11,7 @@ Durable knowledge lives in the memory system (memory_store/recall).
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -110,6 +111,7 @@ class EgoSession:
         self._call_site = call_site or _DEFAULT_CALL_SITE
         self._focus_summary_key = focus_summary_key or _DEFAULT_FOCUS_SUMMARY_KEY
         self._source_tag = source_tag or "ego_cycle"
+        self._sweep_lock = asyncio.Lock()
         # Cache the static system prompt (read once, not every cycle)
         actual_prompt_path = prompt_path or _DEFAULT_PROMPT_PATH
         if actual_prompt_path.exists():
@@ -832,12 +834,17 @@ class EgoSession:
     async def sweep_approved_proposals(self) -> list[str]:
         """Mechanically dispatch approved proposals via DirectSessionRunner.
 
-        Called on a fixed 30-minute interval by EgoCadenceManager,
-        independent of ego LLM cycles. This ensures approved work gets
-        dispatched even when the ego is in stay_quiet mode.
+        Called on a fixed 30-minute interval by EgoCadenceManager AND
+        immediately after user approval via Telegram.  The sweep lock
+        prevents concurrent execution (double-dispatch guard).
 
         Returns list of dispatched proposal IDs.
         """
+        async with self._sweep_lock:
+            return await self._sweep_approved_inner()
+
+    async def _sweep_approved_inner(self) -> list[str]:
+        """Inner sweep logic — must be called under self._sweep_lock."""
         if self._direct_session_runner is None:
             return []
 
@@ -864,12 +871,7 @@ class EgoSession:
             except (KeyError, TypeError, ValueError):
                 continue
 
-            prompt = (
-                f"Execute this approved proposal:\n\n"
-                f"{prop['content']}\n\n"
-                f"Execution plan: {prop.get('execution_plan') or 'N/A'}\n\n"
-                f"Context: {prop.get('rationale') or ''}"
-            )
+            prompt = await self._build_dispatch_prompt(prop)
             profile = _infer_profile(prop.get("action_type", ""))
 
             try:
@@ -894,6 +896,8 @@ class EgoSession:
                         "Sweep dispatched proposal %s → session %s",
                         prop["id"], session_id,
                     )
+                    # Send execution notification to ego_proposals topic
+                    await self._notify_execution(prop, session_id)
             except Exception:
                 logger.error(
                     "Sweep failed to dispatch proposal %s",
@@ -914,6 +918,73 @@ class EgoSession:
         if dispatched:
             logger.info("Sweep dispatched %d approved proposal(s)", len(dispatched))
         return dispatched
+
+    async def _build_dispatch_prompt(self, prop: dict) -> str:
+        """Build enriched dispatch prompt with world model context."""
+        parts = [
+            f"Execute this approved proposal:\n\n{prop['content']}",
+            f"\nExecution plan: {prop.get('execution_plan') or 'N/A'}",
+            f"\nRationale: {prop.get('rationale') or ''}",
+        ]
+
+        # World model context — each section degrades independently
+        try:
+            from genesis.db.crud import user_goals
+            goals = await user_goals.list_active(self._db)
+            if goals:
+                goal_lines = [
+                    f"- {g['title']} ({g['category']}, {g['priority']})"
+                    for g in goals[:5]
+                ]
+                parts.append(
+                    "\n\nUser's active goals:\n" + "\n".join(goal_lines)
+                )
+        except Exception:
+            pass
+
+        try:
+            from genesis.db.crud import user_contacts
+            contacts = await user_contacts.recently_active(self._db, days=14)
+            if contacts:
+                contact_lines = [
+                    f"- {c['name']} ({c.get('relationship', 'contact')})"
+                    for c in contacts[:5]
+                ]
+                parts.append("\nRelevant contacts:\n" + "\n".join(contact_lines))
+        except Exception:
+            pass
+
+        try:
+            from genesis.db.crud import memory_events
+            events = await memory_events.upcoming_user_events(self._db, days=14)
+            if events:
+                event_lines = [
+                    f"- {e['object']} ({e.get('event_date', 'TBD')})"
+                    for e in events[:5]
+                ]
+                parts.append("\nUpcoming events:\n" + "\n".join(event_lines))
+        except Exception:
+            pass
+
+        return "\n".join(parts)
+
+    async def _notify_execution(self, prop: dict, session_id: str) -> None:
+        """Send structured notification to ego_proposals topic."""
+        try:
+            import html as html_mod
+
+            tm = self._proposals._topic_manager
+            if tm is None:
+                return
+            content = html_mod.escape(prop.get("content", "")[:200])
+            action = html_mod.escape(prop.get("action_type", "unknown"))
+            msg = (
+                f"<b>Dispatched</b> [{action}]: {content}\n"
+                f"<i>Session:</i> {session_id}"
+            )
+            await tm.send_to_category("ego_proposals", msg)
+        except Exception:
+            logger.debug("Failed to send execution notification", exc_info=True)
 
     async def _check_budget(self) -> bool:
         """True if daily ego thinking spend is under the budget cap."""

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -153,10 +153,7 @@ class EgoSession:
         """
         # Resolve cycle type
         if cycle_type is None:
-            cycle_type = (
-                CycleType.MORNING_REPORT if is_morning_report
-                else CycleType.PROACTIVE
-            )
+            cycle_type = CycleType.MORNING_REPORT if is_morning_report else CycleType.PROACTIVE
         is_morning_report = cycle_type == CycleType.MORNING_REPORT
 
         # Select model + effort: config is the base, cycle type overrides
@@ -168,8 +165,7 @@ class EgoSession:
         # 1. Budget check — raises BudgetExceededError (not a failure)
         if not await self._check_budget():
             raise BudgetExceededError(
-                f"Daily ego thinking spend exceeds cap "
-                f"${self._config.ego_thinking_budget_usd}"
+                f"Daily ego thinking spend exceeds cap ${self._config.ego_thinking_budget_usd}"
             )
 
         # 2. Assemble operational context (previous focus + fresh context)
@@ -263,7 +259,8 @@ class EgoSession:
         # 6b. If focus was sanitized, try previous legitimate focus as fallback
         if parsed and parsed.get("_focus_violation"):
             prev = await ego_crud.get_state(
-                self._db, self._focus_summary_key,
+                self._db,
+                self._focus_summary_key,
             )
             if prev and not _BEHAVIORAL_FOCUS_RE.search(prev):
                 parsed["focus_summary"] = prev
@@ -294,9 +291,12 @@ class EgoSession:
             # 8. Record last run for neural monitor
             try:
                 from genesis.observability.call_site_recorder import record_last_run
+
                 await record_last_run(
-                    self._db, self._call_site,
-                    provider="cc", model_id=output.model_used or model.value,
+                    self._db,
+                    self._call_site,
+                    provider="cc",
+                    model_id=output.model_used or model.value,
                     response_text=output.text[:500] if output.text else "",
                     input_tokens=output.input_tokens,
                     output_tokens=output.output_tokens,
@@ -315,7 +315,9 @@ class EgoSession:
                 proposals = await self._filter_proposals(proposals)
                 if proposals:
                     await self._process_proposals(
-                        proposals, cycle.id, communication_decision=comm_decision,
+                        proposals,
+                        cycle.id,
+                        communication_decision=comm_decision,
                     )
 
             # 9b. Process tabled/withdrawn proposal IDs
@@ -328,8 +330,11 @@ class EgoSession:
                             logger.info("Proposal %s tabled by ego", pid)
                             try:
                                 from genesis.db.crud import intervention_journal as journal_crud
+
                                 await journal_crud.resolve(
-                                    self._db, pid, outcome_status="tabled",
+                                    self._db,
+                                    pid,
+                                    outcome_status="tabled",
                                 )
                             except Exception:
                                 pass
@@ -343,8 +348,11 @@ class EgoSession:
                             logger.info("Proposal %s withdrawn by ego", pid)
                             try:
                                 from genesis.db.crud import intervention_journal as journal_crud
+
                                 await journal_crud.resolve(
-                                    self._db, pid, outcome_status="withdrawn",
+                                    self._db,
+                                    pid,
+                                    outcome_status="withdrawn",
                                 )
                             except Exception:
                                 pass
@@ -363,7 +371,8 @@ class EgoSession:
             resolved_follow_ups = parsed.get("resolved_follow_ups", [])
             if isinstance(resolved_follow_ups, list) and resolved_follow_ups:
                 await self._dispatcher.resolve_follow_ups(
-                    resolved_follow_ups, cycle.id,
+                    resolved_follow_ups,
+                    cycle.id,
                 )
 
             # 10c. Process knowledge notepad updates (user ego only)
@@ -374,7 +383,9 @@ class EgoSession:
             # 11. Store focus summary for reflection injection
             if focus:
                 await ego_crud.set_state(
-                    self._db, key=self._focus_summary_key, value=focus,
+                    self._db,
+                    key=self._focus_summary_key,
+                    value=focus,
                 )
 
             # 11b. Record violation if focus was behavioral self-assignment
@@ -492,7 +503,7 @@ class EgoSession:
         last_brace = text.rfind("}")
         if first_brace != -1 and last_brace > first_brace:
             try:
-                result = json.loads(text[first_brace:last_brace + 1])
+                result = json.loads(text[first_brace : last_brace + 1])
                 if isinstance(result, dict):
                     return _validate_output(result)
             except json.JSONDecodeError:
@@ -500,7 +511,8 @@ class EgoSession:
 
         logger.error(
             "Failed to parse ego output (length=%d): %.200s...",
-            len(text), text,
+            len(text),
+            text,
         )
         return None
 
@@ -548,16 +560,19 @@ class EgoSession:
         """
         try:
             batch_id, ids = await self._proposals.create_batch(
-                proposals, cycle_id=cycle_id,
+                proposals,
+                cycle_id=cycle_id,
             )
             logger.info(
                 "Created proposal batch %s with %d proposals",
-                batch_id, len(ids),
+                batch_id,
+                len(ids),
             )
 
             # Record intervention journal entries (fire-and-forget)
             try:
                 from genesis.db.crud import intervention_journal as journal_crud
+
                 now = datetime.now(UTC).isoformat()
                 for pid, prop in zip(ids, proposals, strict=False):
                     await journal_crud.create(
@@ -579,7 +594,8 @@ class EgoSession:
             if validation_issues:
                 logger.warning(
                     "Proposal validation issues in batch %s: %s",
-                    batch_id, "; ".join(validation_issues),
+                    batch_id,
+                    "; ".join(validation_issues),
                 )
 
             if communication_decision in ("send_digest", "urgent_notify"):
@@ -591,7 +607,8 @@ class EgoSession:
                     logger.info("Ego digest sent (delivery_id=%s)", delivery)
             else:
                 logger.info(
-                    "Ego decided stay_quiet — batch %s stored only", batch_id,
+                    "Ego decided stay_quiet — batch %s stored only",
+                    batch_id,
                 )
         except Exception:
             logger.error("Failed to process ego proposals", exc_info=True)
@@ -656,14 +673,17 @@ class EgoSession:
                 )
                 session_id = await self._direct_session_runner.spawn(request)
                 await ego_crud.execute_proposal(
-                    self._db, proposal_id,
+                    self._db,
+                    proposal_id,
                     status="executed",
                     user_response=f"session:{session_id}",
                 )
                 try:
                     from genesis.db.crud import intervention_journal as journal_crud
+
                     await journal_crud.resolve(
-                        self._db, proposal_id,
+                        self._db,
+                        proposal_id,
                         outcome_status="executed",
                         actual_outcome=f"Dispatched as session:{session_id}",
                     )
@@ -671,28 +691,34 @@ class EgoSession:
                     logger.warning("Journal resolve failed for %s", proposal_id)
                 logger.info(
                     "Dispatched proposal %s → session %s",
-                    proposal_id, session_id,
+                    proposal_id,
+                    session_id,
                 )
             except Exception:
                 logger.error(
-                    "Failed to dispatch proposal %s", proposal_id,
+                    "Failed to dispatch proposal %s",
+                    proposal_id,
                     exc_info=True,
                 )
                 try:
                     await ego_crud.execute_proposal(
-                        self._db, proposal_id,
+                        self._db,
+                        proposal_id,
                         status="failed",
                         user_response="dispatch failed",
                     )
                 except Exception:
                     logger.error(
                         "Failed to mark proposal %s as failed",
-                        proposal_id, exc_info=True,
+                        proposal_id,
+                        exc_info=True,
                     )
                 try:
                     from genesis.db.crud import intervention_journal as journal_crud
+
                     await journal_crud.resolve(
-                        self._db, proposal_id,
+                        self._db,
+                        proposal_id,
                         outcome_status="failed",
                         actual_outcome="Dispatch failed",
                     )
@@ -739,13 +765,15 @@ class EgoSession:
             except Exception:
                 logger.error(
                     "Failed to write escalation from cycle %s",
-                    cycle_id, exc_info=True,
+                    cycle_id,
+                    exc_info=True,
                 )
 
         if escalations:
             logger.info(
                 "Genesis ego cycle %s produced %d escalation(s)",
-                cycle_id, len(escalations),
+                cycle_id,
+                len(escalations),
             )
 
     # -- Knowledge notepad --------------------------------------------------
@@ -824,7 +852,9 @@ class EgoSession:
             result = _rebuild_notepad(sections, today)
             self._NOTEPAD_PATH.write_text(result)
             logger.info(
-                "Ego notepad: applied %d/%d updates", applied, len(updates),
+                "Ego notepad: applied %d/%d updates",
+                applied,
+                len(updates),
             )
         except Exception:
             logger.error("Failed to apply ego notepad updates", exc_info=True)
@@ -855,7 +885,9 @@ class EgoSession:
         from genesis.cc.direct_session import DirectSessionRequest
 
         approved = await ego_crud.list_proposals(
-            self._db, status="approved", limit=5,
+            self._db,
+            status="approved",
+            limit=5,
         )
         if not approved:
             return []
@@ -886,7 +918,8 @@ class EgoSession:
                 )
                 session_id = await self._direct_session_runner.spawn(request)
                 ok = await ego_crud.execute_proposal(
-                    self._db, prop["id"],
+                    self._db,
+                    prop["id"],
                     status="executed",
                     user_response=f"session:{session_id}",
                 )
@@ -894,25 +927,29 @@ class EgoSession:
                     dispatched.append(prop["id"])
                     logger.info(
                         "Sweep dispatched proposal %s → session %s",
-                        prop["id"], session_id,
+                        prop["id"],
+                        session_id,
                     )
                     # Send execution notification to ego_proposals topic
                     await self._notify_execution(prop, session_id)
             except Exception:
                 logger.error(
                     "Sweep failed to dispatch proposal %s",
-                    prop["id"], exc_info=True,
+                    prop["id"],
+                    exc_info=True,
                 )
                 try:
                     await ego_crud.execute_proposal(
-                        self._db, prop["id"],
+                        self._db,
+                        prop["id"],
                         status="failed",
                         user_response="sweep_dispatch_error",
                     )
                 except Exception:
                     logger.error(
                         "Failed to mark proposal %s as failed",
-                        prop["id"], exc_info=True,
+                        prop["id"],
+                        exc_info=True,
                     )
 
         if dispatched:
@@ -930,25 +967,23 @@ class EgoSession:
         # World model context — each section degrades independently
         try:
             from genesis.db.crud import user_goals
+
             goals = await user_goals.list_active(self._db)
             if goals:
                 goal_lines = [
-                    f"- {g['title']} ({g['category']}, {g['priority']})"
-                    for g in goals[:5]
+                    f"- {g['title']} ({g['category']}, {g['priority']})" for g in goals[:5]
                 ]
-                parts.append(
-                    "\n\nUser's active goals:\n" + "\n".join(goal_lines)
-                )
+                parts.append("\n\nUser's active goals:\n" + "\n".join(goal_lines))
         except Exception:
             pass
 
         try:
             from genesis.db.crud import user_contacts
+
             contacts = await user_contacts.recently_active(self._db, days=14)
             if contacts:
                 contact_lines = [
-                    f"- {c['name']} ({c.get('relationship', 'contact')})"
-                    for c in contacts[:5]
+                    f"- {c['name']} ({c.get('relationship', 'contact')})" for c in contacts[:5]
                 ]
                 parts.append("\nRelevant contacts:\n" + "\n".join(contact_lines))
         except Exception:
@@ -956,11 +991,11 @@ class EgoSession:
 
         try:
             from genesis.db.crud import memory_events
+
             events = await memory_events.upcoming_user_events(self._db, days=14)
             if events:
                 event_lines = [
-                    f"- {e['object']} ({e.get('event_date', 'TBD')})"
-                    for e in events[:5]
+                    f"- {e['object']} ({e.get('event_date', 'TBD')})" for e in events[:5]
                 ]
                 parts.append("\nUpcoming events:\n" + "\n".join(event_lines))
         except Exception:
@@ -978,10 +1013,7 @@ class EgoSession:
                 return
             content = html_mod.escape(prop.get("content", "")[:200])
             action = html_mod.escape(prop.get("action_type", "unknown"))
-            msg = (
-                f"<b>Dispatched</b> [{action}]: {content}\n"
-                f"<i>Session:</i> {session_id}"
-            )
+            msg = f"<b>Dispatched</b> [{action}]: {content}\n<i>Session:</i> {session_id}"
             await tm.send_to_category("ego_proposals", msg)
         except Exception:
             logger.debug("Failed to send execution notification", exc_info=True)
@@ -993,7 +1025,8 @@ class EgoSession:
             if daily >= self._config.ego_thinking_budget_usd:
                 logger.warning(
                     "Ego thinking spend $%.2f exceeds cap $%.2f",
-                    daily, self._config.ego_thinking_budget_usd,
+                    daily,
+                    self._config.ego_thinking_budget_usd,
                 )
                 return False
         except Exception:
@@ -1007,7 +1040,8 @@ class EgoSession:
             if daily >= self._config.ego_dispatch_budget_usd:
                 logger.warning(
                     "Ego dispatch spend $%.2f exceeds cap $%.2f",
-                    daily, self._config.ego_dispatch_budget_usd,
+                    daily,
+                    self._config.ego_dispatch_budget_usd,
                 )
                 return False
         except Exception:
@@ -1075,8 +1109,7 @@ def _sanitize_focus_summary(
     if _BEHAVIORAL_FOCUS_RE.search(focus):
         fallback = previous_focus or "general system awareness"
         logger.warning(
-            "Ego focus_summary contains behavioral self-assignment: %r — "
-            "replacing with %r",
+            "Ego focus_summary contains behavioral self-assignment: %r — replacing with %r",
             focus[:120],
             fallback,
         )
@@ -1087,8 +1120,7 @@ def _sanitize_focus_summary(
     cleaned = _ENGAGEMENT_SUPPRESSION_RE.sub("", focus).strip().rstrip(";,")
     if cleaned != focus:
         logger.warning(
-            "Ego focus_summary contains engagement-suppression clause: %r — "
-            "stripped to %r",
+            "Ego focus_summary contains engagement-suppression clause: %r — stripped to %r",
             focus[:120],
             cleaned[:120],
         )
@@ -1152,7 +1184,8 @@ def _validate_output(data: dict) -> dict | None:
             data["knowledge_updates"] = []
         else:
             data["knowledge_updates"] = [
-                u for u in raw
+                u
+                for u in raw
                 if isinstance(u, dict)
                 and isinstance(u.get("section"), str)
                 and u.get("action") in _VALID_NOTEPAD_ACTIONS

--- a/tests/ego/test_delivery_execution.py
+++ b/tests/ego/test_delivery_execution.py
@@ -1,0 +1,293 @@
+"""Tests for ego Layers 4 (Delivery) and 5 (Execution) improvements."""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genesis.db.crud import ego as ego_crud
+from genesis.ego.proposals import (
+    ProposalWorkflow,
+    _sort_proposals,
+    parse_proposal_decisions,
+)
+
+
+# -- Layer 4: Delivery tests --
+
+
+class TestProposalExpiry:
+    @pytest.mark.asyncio
+    async def test_expire_stale_proposals(self, db):
+        """Proposals past expires_at are marked expired."""
+        past = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+        await ego_crud.create_proposal(
+            db, id="exp1", action_type="investigate",
+            content="Old proposal", expires_at=past,
+        )
+        expired = await ego_crud.expire_stale_proposals(db)
+        assert expired == 1
+        prop = await ego_crud.get_proposal(db, "exp1")
+        assert prop["status"] == "expired"
+        assert prop["resolved_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_expire_skips_unexpired(self, db):
+        """Proposals with future expires_at are not expired."""
+        future = (datetime.now(UTC) + timedelta(hours=2)).isoformat()
+        await ego_crud.create_proposal(
+            db, id="fut1", action_type="investigate",
+            content="Future proposal", expires_at=future,
+        )
+        expired = await ego_crud.expire_stale_proposals(db)
+        assert expired == 0
+        prop = await ego_crud.get_proposal(db, "fut1")
+        assert prop["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_expire_updates_journal(self, db):
+        """Expiry also updates matching intervention_journal entries."""
+        from genesis.db.crud import intervention_journal as journal_crud
+
+        past = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+        await ego_crud.create_proposal(
+            db, id="exp_j", action_type="dispatch",
+            content="Journal test", expires_at=past,
+        )
+        # Create matching journal entry
+        await journal_crud.create(
+            db, ego_source="user_ego_cycle", proposal_id="exp_j",
+            cycle_id="cycle1", action_type="dispatch",
+            action_summary="Journal test",
+        )
+        expired = await ego_crud.expire_stale_proposals(db)
+        assert expired == 1
+
+        journal = await journal_crud.get_by_proposal(db, "exp_j")
+        assert journal is not None
+        assert journal["outcome_status"] == "expired"
+
+
+class TestPrioritySorting:
+    def test_urgency_ordering(self):
+        """Critical proposals sort before normal ones."""
+        proposals = [
+            {"urgency": "normal", "confidence": 0.9, "content": "normal"},
+            {"urgency": "critical", "confidence": 0.5, "content": "critical"},
+            {"urgency": "high", "confidence": 0.7, "content": "high"},
+        ]
+        sorted_p = _sort_proposals(proposals)
+        assert sorted_p[0]["urgency"] == "critical"
+        assert sorted_p[1]["urgency"] == "high"
+        assert sorted_p[2]["urgency"] == "normal"
+
+    def test_confidence_within_urgency(self):
+        """Within same urgency, higher confidence sorts first."""
+        proposals = [
+            {"urgency": "high", "confidence": 0.5, "content": "low conf"},
+            {"urgency": "high", "confidence": 0.9, "content": "high conf"},
+        ]
+        sorted_p = _sort_proposals(proposals)
+        assert sorted_p[0]["confidence"] == 0.9
+        assert sorted_p[1]["confidence"] == 0.5
+
+
+class TestCrossBatchParser:
+    def test_approve_all_pending(self):
+        """'approve all pending' returns cross-batch sentinel -1."""
+        result = parse_proposal_decisions("approve all pending")
+        assert -1 in result
+        assert result[-1] == ("approved", None)
+
+    def test_reject_all_pending(self):
+        """'reject all pending' returns cross-batch sentinel -1."""
+        result = parse_proposal_decisions("reject all pending")
+        assert -1 in result
+        assert result[-1] == ("rejected", None)
+
+    def test_approve_all_still_works(self):
+        """'approve all' (batch-scoped) still returns sentinel 0."""
+        result = parse_proposal_decisions("approve all")
+        assert 0 in result
+        assert result[0] == ("approved", None)
+        assert -1 not in result
+
+    def test_numbered_still_works(self):
+        """'1 approve, 2 reject' still works as before."""
+        result = parse_proposal_decisions("1 approve, 2 reject: bad idea")
+        assert result[1] == ("approved", None)
+        assert result[2] == ("rejected", "bad idea")
+
+
+class TestCrossBatchApproval:
+    @pytest.mark.asyncio
+    async def test_resolve_all_pending_across_batches(self, db):
+        """resolve_all_pending_proposals resolves proposals in multiple batches."""
+        # Create two batches
+        await ego_crud.create_proposal(
+            db, id="b1p1", action_type="dispatch",
+            content="Batch 1 proposal 1", batch_id="batch_a",
+        )
+        await ego_crud.create_proposal(
+            db, id="b2p1", action_type="investigate",
+            content="Batch 2 proposal 1", batch_id="batch_b",
+        )
+
+        workflow = ProposalWorkflow(db=db)
+        results = await workflow.resolve_all_pending_proposals("approved")
+
+        assert len(results) == 2
+        assert results["b1p1"] == "approved"
+        assert results["b2p1"] == "approved"
+
+        # Verify in DB
+        p1 = await ego_crud.get_proposal(db, "b1p1")
+        p2 = await ego_crud.get_proposal(db, "b2p1")
+        assert p1["status"] == "approved"
+        assert p2["status"] == "approved"
+
+    @pytest.mark.asyncio
+    async def test_resolve_all_with_partially_resolved_batch(self, db):
+        """Cross-batch approval works when a batch has some already-resolved proposals."""
+        # Create batch with 3 proposals, resolve #1 first
+        await ego_crud.create_proposal(
+            db, id="mix_a1", action_type="dispatch",
+            content="Already resolved", batch_id="mixed_batch",
+        )
+        await ego_crud.create_proposal(
+            db, id="mix_a2", action_type="investigate",
+            content="Still pending 1", batch_id="mixed_batch",
+        )
+        await ego_crud.create_proposal(
+            db, id="mix_a3", action_type="dispatch",
+            content="Still pending 2", batch_id="mixed_batch",
+        )
+        # Resolve the first one manually
+        await ego_crud.resolve_proposal(db, "mix_a1", status="rejected")
+
+        workflow = ProposalWorkflow(db=db)
+        results = await workflow.resolve_all_pending_proposals("approved")
+
+        # Only the 2 pending proposals should be resolved
+        assert len(results) == 2
+        assert "mix_a2" in results
+        assert "mix_a3" in results
+        assert "mix_a1" not in results  # was already rejected
+
+        # Verify DB state
+        p1 = await ego_crud.get_proposal(db, "mix_a1")
+        p2 = await ego_crud.get_proposal(db, "mix_a2")
+        p3 = await ego_crud.get_proposal(db, "mix_a3")
+        assert p1["status"] == "rejected"  # unchanged
+        assert p2["status"] == "approved"
+        assert p3["status"] == "approved"
+
+    @pytest.mark.asyncio
+    async def test_resolve_all_empty(self, db):
+        """resolve_all_pending_proposals returns empty dict when no pending."""
+        workflow = ProposalWorkflow(db=db)
+        results = await workflow.resolve_all_pending_proposals("approved")
+        assert results == {}
+
+
+class TestPendingCountHeader:
+    @pytest.mark.asyncio
+    async def test_send_digest_shows_pending_count(self, db):
+        """send_digest includes pending count from other batches."""
+        # Create pending proposals in another batch
+        await ego_crud.create_proposal(
+            db, id="old1", action_type="investigate",
+            content="Old pending", batch_id="old_batch",
+        )
+        # Create the batch we're sending
+        await ego_crud.create_proposal(
+            db, id="new1", action_type="dispatch",
+            content="New proposal", batch_id="new_batch",
+        )
+
+        mock_tm = AsyncMock()
+        mock_tm.send_to_category = AsyncMock(return_value="delivery123")
+
+        workflow = ProposalWorkflow(db=db, topic_manager=mock_tm)
+        delivery_id = await workflow.send_digest("new_batch")
+
+        assert delivery_id is not None
+        # Check that the sent HTML contains the pending count
+        sent_html = mock_tm.send_to_category.call_args[0][1]
+        assert "1 proposal(s) pending from previous batches" in sent_html
+        assert "approve all pending" in sent_html
+
+
+# -- Layer 5: Execution tests --
+
+
+class TestSweepLock:
+    @pytest.mark.asyncio
+    async def test_sweep_serialized(self):
+        """Concurrent sweep calls are serialized by the lock."""
+        from genesis.ego.session import EgoSession
+
+        # Create a minimal EgoSession mock with the lock
+        session = object.__new__(EgoSession)
+        session._sweep_lock = asyncio.Lock()
+        session._direct_session_runner = None
+
+        # Both calls should complete (runner is None → early return)
+        results = await asyncio.gather(
+            session.sweep_approved_proposals(),
+            session.sweep_approved_proposals(),
+        )
+        assert results == [[], []]
+
+
+class TestBuildDispatchPrompt:
+    @pytest.mark.asyncio
+    async def test_basic_prompt(self, db):
+        """Dispatch prompt includes proposal content, plan, and rationale."""
+        from genesis.ego.session import EgoSession
+
+        session = object.__new__(EgoSession)
+        session._db = db
+
+        prop = {
+            "content": "Research AGI safety standards",
+            "execution_plan": "Step 1: Search literature",
+            "rationale": "User interested in safety",
+        }
+        prompt = await session._build_dispatch_prompt(prop)
+        assert "Research AGI safety standards" in prompt
+        assert "Step 1: Search literature" in prompt
+        assert "User interested in safety" in prompt
+
+    @pytest.mark.asyncio
+    async def test_prompt_includes_goals(self, db):
+        """Dispatch prompt includes active goals when available."""
+        from genesis.db.crud import user_goals
+        from genesis.ego.session import EgoSession
+
+        await user_goals.create(
+            db, title="Build thought leadership", category="career",
+            priority="high",
+        )
+
+        session = object.__new__(EgoSession)
+        session._db = db
+
+        prop = {"content": "Test proposal", "execution_plan": None, "rationale": ""}
+        prompt = await session._build_dispatch_prompt(prop)
+        assert "Build thought leadership" in prompt
+        assert "active goals" in prompt.lower()
+
+    @pytest.mark.asyncio
+    async def test_prompt_degrades_gracefully(self, db):
+        """Dispatch prompt works even when world model tables are empty."""
+        from genesis.ego.session import EgoSession
+
+        session = object.__new__(EgoSession)
+        session._db = db
+
+        prop = {"content": "Basic proposal"}
+        prompt = await session._build_dispatch_prompt(prop)
+        assert "Basic proposal" in prompt
+        # Should not crash even with no goals/contacts/events

--- a/tests/ego/test_delivery_execution.py
+++ b/tests/ego/test_delivery_execution.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -12,7 +12,6 @@ from genesis.ego.proposals import (
     _sort_proposals,
     parse_proposal_decisions,
 )
-
 
 # -- Layer 4: Delivery tests --
 

--- a/tests/ego/test_delivery_execution.py
+++ b/tests/ego/test_delivery_execution.py
@@ -23,8 +23,11 @@ class TestProposalExpiry:
         """Proposals past expires_at are marked expired."""
         past = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
         await ego_crud.create_proposal(
-            db, id="exp1", action_type="investigate",
-            content="Old proposal", expires_at=past,
+            db,
+            id="exp1",
+            action_type="investigate",
+            content="Old proposal",
+            expires_at=past,
         )
         expired = await ego_crud.expire_stale_proposals(db)
         assert expired == 1
@@ -37,8 +40,11 @@ class TestProposalExpiry:
         """Proposals with future expires_at are not expired."""
         future = (datetime.now(UTC) + timedelta(hours=2)).isoformat()
         await ego_crud.create_proposal(
-            db, id="fut1", action_type="investigate",
-            content="Future proposal", expires_at=future,
+            db,
+            id="fut1",
+            action_type="investigate",
+            content="Future proposal",
+            expires_at=future,
         )
         expired = await ego_crud.expire_stale_proposals(db)
         assert expired == 0
@@ -52,13 +58,19 @@ class TestProposalExpiry:
 
         past = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
         await ego_crud.create_proposal(
-            db, id="exp_j", action_type="dispatch",
-            content="Journal test", expires_at=past,
+            db,
+            id="exp_j",
+            action_type="dispatch",
+            content="Journal test",
+            expires_at=past,
         )
         # Create matching journal entry
         await journal_crud.create(
-            db, ego_source="user_ego_cycle", proposal_id="exp_j",
-            cycle_id="cycle1", action_type="dispatch",
+            db,
+            ego_source="user_ego_cycle",
+            proposal_id="exp_j",
+            cycle_id="cycle1",
+            action_type="dispatch",
             action_summary="Journal test",
         )
         expired = await ego_crud.expire_stale_proposals(db)
@@ -126,12 +138,18 @@ class TestCrossBatchApproval:
         """resolve_all_pending_proposals resolves proposals in multiple batches."""
         # Create two batches
         await ego_crud.create_proposal(
-            db, id="b1p1", action_type="dispatch",
-            content="Batch 1 proposal 1", batch_id="batch_a",
+            db,
+            id="b1p1",
+            action_type="dispatch",
+            content="Batch 1 proposal 1",
+            batch_id="batch_a",
         )
         await ego_crud.create_proposal(
-            db, id="b2p1", action_type="investigate",
-            content="Batch 2 proposal 1", batch_id="batch_b",
+            db,
+            id="b2p1",
+            action_type="investigate",
+            content="Batch 2 proposal 1",
+            batch_id="batch_b",
         )
 
         workflow = ProposalWorkflow(db=db)
@@ -152,16 +170,25 @@ class TestCrossBatchApproval:
         """Cross-batch approval works when a batch has some already-resolved proposals."""
         # Create batch with 3 proposals, resolve #1 first
         await ego_crud.create_proposal(
-            db, id="mix_a1", action_type="dispatch",
-            content="Already resolved", batch_id="mixed_batch",
+            db,
+            id="mix_a1",
+            action_type="dispatch",
+            content="Already resolved",
+            batch_id="mixed_batch",
         )
         await ego_crud.create_proposal(
-            db, id="mix_a2", action_type="investigate",
-            content="Still pending 1", batch_id="mixed_batch",
+            db,
+            id="mix_a2",
+            action_type="investigate",
+            content="Still pending 1",
+            batch_id="mixed_batch",
         )
         await ego_crud.create_proposal(
-            db, id="mix_a3", action_type="dispatch",
-            content="Still pending 2", batch_id="mixed_batch",
+            db,
+            id="mix_a3",
+            action_type="dispatch",
+            content="Still pending 2",
+            batch_id="mixed_batch",
         )
         # Resolve the first one manually
         await ego_crud.resolve_proposal(db, "mix_a1", status="rejected")
@@ -197,13 +224,19 @@ class TestPendingCountHeader:
         """send_digest includes pending count from other batches."""
         # Create pending proposals in another batch
         await ego_crud.create_proposal(
-            db, id="old1", action_type="investigate",
-            content="Old pending", batch_id="old_batch",
+            db,
+            id="old1",
+            action_type="investigate",
+            content="Old pending",
+            batch_id="old_batch",
         )
         # Create the batch we're sending
         await ego_crud.create_proposal(
-            db, id="new1", action_type="dispatch",
-            content="New proposal", batch_id="new_batch",
+            db,
+            id="new1",
+            action_type="dispatch",
+            content="New proposal",
+            batch_id="new_batch",
         )
 
         mock_tm = AsyncMock()
@@ -267,7 +300,9 @@ class TestBuildDispatchPrompt:
         from genesis.ego.session import EgoSession
 
         await user_goals.create(
-            db, title="Build thought leadership", category="career",
+            db,
+            title="Build thought leadership",
+            category="career",
             priority="high",
         )
 

--- a/tests/ego/test_delivery_execution.py
+++ b/tests/ego/test_delivery_execution.py
@@ -217,6 +217,82 @@ class TestCrossBatchApproval:
         assert results == {}
 
 
+class TestCancelRevoke:
+    def test_cancel_all_parser(self):
+        """'cancel all' returns sentinel 0 with 'cancelled' status."""
+        result = parse_proposal_decisions("cancel all")
+        assert 0 in result
+        assert result[0] == ("cancelled", None)
+
+    def test_cancel_numbered(self):
+        """'cancel 1' returns numbered entry with 'cancelled' status."""
+        result = parse_proposal_decisions("cancel 1")
+        assert result[1] == ("cancelled", None)
+
+    def test_revoke_word(self):
+        """'revoke 2' works as cancel."""
+        result = parse_proposal_decisions("revoke 2")
+        assert result[2] == ("cancelled", None)
+
+    @pytest.mark.asyncio
+    async def test_revoke_approved_proposal(self, db):
+        """revoke_proposal transitions approved -> rejected."""
+        await ego_crud.create_proposal(
+            db,
+            id="rev1",
+            action_type="dispatch",
+            content="Will be revoked",
+        )
+        await ego_crud.resolve_proposal(db, "rev1", status="approved")
+        ok = await ego_crud.revoke_proposal(db, "rev1")
+        assert ok
+        p = await ego_crud.get_proposal(db, "rev1")
+        assert p["status"] == "rejected"
+        assert p["user_response"] == "revoked by user"
+
+    @pytest.mark.asyncio
+    async def test_revoke_only_works_on_approved(self, db):
+        """revoke_proposal does nothing on pending proposals."""
+        await ego_crud.create_proposal(
+            db,
+            id="rev2",
+            action_type="investigate",
+            content="Still pending",
+        )
+        ok = await ego_crud.revoke_proposal(db, "rev2")
+        assert not ok
+        p = await ego_crud.get_proposal(db, "rev2")
+        assert p["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_revoke_via_workflow(self, db):
+        """ProposalWorkflow.revoke_approved_proposals revokes correct proposals."""
+        await ego_crud.create_proposal(
+            db,
+            id="rw1",
+            action_type="dispatch",
+            content="Approved proposal",
+            batch_id="rev_batch",
+        )
+        await ego_crud.create_proposal(
+            db,
+            id="rw2",
+            action_type="investigate",
+            content="Pending proposal",
+            batch_id="rev_batch",
+        )
+        await ego_crud.resolve_proposal(db, "rw1", status="approved")
+
+        workflow = ProposalWorkflow(db=db)
+        revoked = await workflow.revoke_approved_proposals("rev_batch")
+        assert revoked == 1
+
+        p1 = await ego_crud.get_proposal(db, "rw1")
+        p2 = await ego_crud.get_proposal(db, "rw2")
+        assert p1["status"] == "rejected"
+        assert p2["status"] == "pending"  # unchanged
+
+
 class TestPendingCountHeader:
     @pytest.mark.asyncio
     async def test_send_digest_shows_pending_count(self, db):


### PR DESCRIPTION
## Summary
- **Layer 4 (Delivery)**: Auto-expire stale proposals, priority-sort digests by urgency x confidence, show pending accumulation count, cross-batch "approve all pending" with proper journal lifecycle
- **Layer 5 (Execution)**: Immediate dispatch after Telegram approval (not 30-min wait), sweep lock for concurrency safety, world model context in dispatch prompts (goals, contacts, events), structured execution notifications
- **Bug fix**: Corrected 1-based indexing in bare "approve all" handler to prevent silent failures on partially-resolved batches

Builds on PRs #331 (trigger removal) and #333 (world model Layer 1).

## Test plan
- [x] 17 new tests: expiry (with journal sync), priority sorting, cross-batch parser, cross-batch approval (including partially-resolved batches), pending count header, sweep lock, dispatch prompt enrichment
- [x] 456 existing ego tests pass (0 regressions)
- [x] ruff clean
- [x] Code review completed — all critical/important findings addressed
- [ ] CI passes
- [ ] Verify priority sorting in live ego digest after deploy
- [ ] Verify immediate dispatch after Telegram approval
- [ ] Verify expiry logged in server output

🤖 Generated with [Claude Code](https://claude.com/claude-code)