### PR TITLE
refactor(executor): remove heuristic blocking from OBSERVING phase

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -419,6 +419,13 @@ call_sites:
     - gemini-free
     default_paid: true
     description: Post-execution retrospective learning extraction
+  44_task_premortem:
+    chain:
+    - openrouter-deepseek-v4
+    - mistral-large-free
+    - gemini-free
+    default_paid: true
+    description: Pre-mortem failure analysis before committing to execution
   35_content_draft:
     chain:
     - gemini-free

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -231,24 +231,17 @@ class CCSessionExecutor:
             else:
                 # Fresh path: OBSERVING -> REVIEWING -> PLANNING
 
-                # --- OBSERVING ---
+                # --- OBSERVING (annotation-only, never blocks) ---
                 await self._transition(task_id, TaskPhase.OBSERVING)
                 all_tasks = await task_states.list_all_recent(
                     self._db, limit=50,
                 )
                 obs = await _observe.observe(
-                    created_at=task.get("created_at", ""),
+                    updated_at=task.get("updated_at", ""),
                     repo_root=_REPO_ROOT,
                     active_tasks=all_tasks,
                     task_id=task_id,
                 )
-                if not obs.proceed:
-                    await self._persist_blocker(
-                        task_id,
-                        f"Observation blocked: {obs.block_reason}",
-                        TaskPhase.OBSERVING,
-                    )
-                    return False
                 if obs.annotations:
                     ann_text = "\n".join(f"- {a}" for a in obs.annotations)
                     plan_content = (

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -1205,10 +1205,8 @@ class CCSessionExecutor:
                 "Plan audit append failed (non-blocking)", exc_info=True,
             )
             # Clean up orphaned .tmp if write succeeded but rename failed
-            try:
+            with contextlib.suppress(OSError):
                 Path(plan_path).expanduser().with_suffix(".tmp").unlink(missing_ok=True)
-            except OSError:
-                pass
 
     async def _set_output(self, task_id: str, key: str, value: str) -> None:
         """JSON read-merge-write on the outputs column.

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -233,6 +233,48 @@ class CCSessionExecutor:
                     )
                     return False
 
+                # --- PRE-MORTEM (fail-open) ---
+                pm = await self._reviewer.pre_mortem(plan_content, description)
+                if pm is not None:
+                    from genesis.autonomy.executor.review import (
+                        _PM_BLOCK_THRESHOLD,
+                        _PM_MITIGATE_THRESHOLD,
+                    )
+
+                    if pm.confidence < _PM_BLOCK_THRESHOLD:
+                        modes = "; ".join(pm.failure_modes[:3])
+                        await self._persist_blocker(
+                            task_id,
+                            f"Pre-mortem confidence {pm.confidence}% "
+                            f"(threshold {_PM_BLOCK_THRESHOLD}%): {modes}",
+                            TaskPhase.REVIEWING,
+                        )
+                        return False
+
+                    if pm.confidence < _PM_MITIGATE_THRESHOLD and pm.mitigations:
+                        mitigation_text = "\n".join(
+                            f"- {m}" for m in pm.mitigations
+                        )
+                        plan_content = (
+                            f"{plan_content}\n\n"
+                            f"## Pre-Mortem Mitigations "
+                            f"(confidence: {pm.confidence}%)\n\n"
+                            f"{mitigation_text}\n"
+                        )
+                        logger.info(
+                            "Pre-mortem injected %d mitigations (conf=%d%%)",
+                            len(pm.mitigations), pm.confidence,
+                        )
+
+                    await self._set_output(
+                        task_id, "pre_mortem",
+                        json.dumps({
+                            "confidence": pm.confidence,
+                            "failure_modes": pm.failure_modes,
+                            "mitigations": pm.mitigations,
+                        }),
+                    )
+
                 # --- PLANNING ---
                 await self._transition(task_id, TaskPhase.PLANNING)
                 steps = await self._decomposer.decompose(

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -251,20 +251,26 @@ class CCSessionExecutor:
                         )
                         return False
 
-                    if pm.confidence < _PM_MITIGATE_THRESHOLD and pm.mitigations:
-                        mitigation_text = "\n".join(
-                            f"- {m}" for m in pm.mitigations
-                        )
-                        plan_content = (
-                            f"{plan_content}\n\n"
-                            f"## Pre-Mortem Mitigations "
-                            f"(confidence: {pm.confidence}%)\n\n"
-                            f"{mitigation_text}\n"
-                        )
-                        logger.info(
-                            "Pre-mortem injected %d mitigations (conf=%d%%)",
-                            len(pm.mitigations), pm.confidence,
-                        )
+                    if pm.confidence < _PM_MITIGATE_THRESHOLD:
+                        if pm.mitigations:
+                            mitigation_text = "\n".join(
+                                f"- {m}" for m in pm.mitigations
+                            )
+                            plan_content = (
+                                f"{plan_content}\n\n"
+                                f"## Pre-Mortem Mitigations "
+                                f"(confidence: {pm.confidence}%)\n\n"
+                                f"{mitigation_text}\n"
+                            )
+                            logger.info(
+                                "Pre-mortem injected %d mitigations (conf=%d%%)",
+                                len(pm.mitigations), pm.confidence,
+                            )
+                        else:
+                            logger.info(
+                                "Pre-mortem confidence %d%% (medium) but no mitigations provided",
+                                pm.confidence,
+                            )
 
                     await self._set_output(
                         task_id, "pre_mortem",

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -1,8 +1,9 @@
 """Task executor engine -- state machine for autonomous task execution.
 
 Drives a task through its lifecycle:
-    PENDING -> REVIEWING -> PLANNING -> EXECUTING -> VERIFYING
-    -> SYNTHESIZING -> DELIVERING -> RETROSPECTIVE -> COMPLETED
+    PENDING -> OBSERVING -> REVIEWING -> PLANNING -> EXECUTING
+    -> VERIFYING -> SYNTHESIZING -> DELIVERING -> RETROSPECTIVE
+    -> COMPLETED
 
 Implements:
 - Amendment #1:  Blocker persistence (DB before notification)
@@ -10,7 +11,7 @@ Implements:
 - Amendment #7:  Worktree management for CODE steps
 - Amendment #10: Formal state transitions via validate_transition()
 - Amendment #13: Global pause check at each checkpoint
-- Recovery:      Phase resume — skip REVIEWING/PLANNING on recovery
+- Recovery:      Phase resume — skip OBSERVING/REVIEWING/PLANNING on recovery
 """
 
 from __future__ import annotations
@@ -24,6 +25,7 @@ from pathlib import Path
 from typing import Any
 
 from genesis.autonomy.executor import dispatch as _dispatch
+from genesis.autonomy.executor import observe as _observe
 from genesis.autonomy.executor import worktree_mgr as _worktree
 from genesis.autonomy.executor.step_dispatcher import StepDispatcher
 from genesis.autonomy.executor.types import (
@@ -147,7 +149,7 @@ class CCSessionExecutor:
         if resuming:
             self._active_tasks[task_id] = TaskPhase(db_phase_str)
             logger.info(
-                "Task %s: resuming from %s phase (skipping review/plan)",
+                "Task %s: resuming from %s phase (skipping observe/review/plan)",
                 task_id, db_phase_str,
             )
         else:
@@ -177,6 +179,18 @@ class CCSessionExecutor:
                     for row in existing_rows
                 ]
 
+                if not steps:
+                    # Blocked before PLANNING — no steps exist.
+                    # Re-run from fresh path (covers both OBSERVING
+                    # and REVIEWING blockers).
+                    resuming = False
+                    self._active_tasks[task_id] = TaskPhase.PENDING
+                    logger.info(
+                        "Task %s: pre-planning blocker, re-running fresh path",
+                        task_id,
+                    )
+
+            if resuming:
                 # Reconstruct completed StepResults from persisted data
                 step_results: list[StepResult] = []
                 completed_indices: set[int] = set()
@@ -215,7 +229,36 @@ class CCSessionExecutor:
                     task_id, len(completed_indices), len(remaining_steps),
                 )
             else:
-                # Fresh path: REVIEWING -> PLANNING
+                # Fresh path: OBSERVING -> REVIEWING -> PLANNING
+
+                # --- OBSERVING ---
+                await self._transition(task_id, TaskPhase.OBSERVING)
+                all_tasks = await task_states.list_all_recent(
+                    self._db, limit=50,
+                )
+                obs = await _observe.observe(
+                    created_at=task.get("created_at", ""),
+                    repo_root=_REPO_ROOT,
+                    active_tasks=all_tasks,
+                    task_id=task_id,
+                )
+                if not obs.proceed:
+                    await self._persist_blocker(
+                        task_id,
+                        f"Observation blocked: {obs.block_reason}",
+                        TaskPhase.OBSERVING,
+                    )
+                    return False
+                if obs.annotations:
+                    ann_text = "\n".join(f"- {a}" for a in obs.annotations)
+                    plan_content = (
+                        f"{plan_content}\n\n"
+                        f"## Observation Warnings\n\n{ann_text}\n"
+                    )
+                    self._append_to_plan(
+                        plan_path, "OBSERVING", ann_text,
+                    )
+
                 # --- REVIEWING ---
                 await self._transition(task_id, TaskPhase.REVIEWING)
                 review = await self._reviewer.review_plan(
@@ -226,12 +269,22 @@ class CCSessionExecutor:
                     gap_text = (
                         "; ".join(review.gaps) if review.gaps else "unspecified"
                     )
+                    self._append_to_plan(
+                        plan_path, "REVIEWING",
+                        f"Plan review BLOCKED: {gap_text}",
+                    )
                     await self._persist_blocker(
                         task_id,
                         f"Plan review found gaps: {gap_text}",
                         TaskPhase.REVIEWING,
                     )
                     return False
+
+                self._append_to_plan(
+                    plan_path, "REVIEWING",
+                    f"Plan review passed. Recommendations: "
+                    f"{'; '.join(review.recommendations) if review.recommendations else 'none'}",
+                )
 
                 # --- PRE-MORTEM (fail-open) ---
                 pm = await self._reviewer.pre_mortem(plan_content, description)
@@ -280,6 +333,12 @@ class CCSessionExecutor:
                             "mitigations": pm.mitigations,
                         }),
                     )
+                    self._append_to_plan(
+                        plan_path, "PRE-MORTEM",
+                        f"Confidence: {pm.confidence}%. "
+                        f"Failure modes: {len(pm.failure_modes)}. "
+                        f"Mitigations: {len(pm.mitigations)}.",
+                    )
 
                 # --- PLANNING ---
                 await self._transition(task_id, TaskPhase.PLANNING)
@@ -300,6 +359,12 @@ class CCSessionExecutor:
                 has_code = any(s.get("type") == "code" for s in steps)
                 if has_code:
                     await self._create_worktree(task_id)
+
+                self._append_to_plan(
+                    plan_path, "PLANNING",
+                    f"Decomposed into {len(steps)} steps: "
+                    + ", ".join(s.get("type", "?") for s in steps),
+                )
 
                 await self._notify(
                     task_id,
@@ -514,10 +579,19 @@ class CCSessionExecutor:
                     f"Review failed after {MAX_REVIEW_ITERATIONS} iterations.\n"
                     + "\n".join(feedback_parts)
                 )
+                self._append_to_plan(
+                    plan_path, "VERIFYING",
+                    f"BLOCKED after {MAX_REVIEW_ITERATIONS} iterations.",
+                )
                 await self._persist_blocker(
                     task_id, escalation, TaskPhase.VERIFYING,
                 )
                 return False
+
+            self._append_to_plan(
+                plan_path, "VERIFYING",
+                f"Verification passed (iteration {iteration}).",
+            )
 
             # --- SYNTHESIZING ---
             await self._transition(task_id, TaskPhase.SYNTHESIZING)
@@ -542,6 +616,10 @@ class CCSessionExecutor:
 
             # --- COMPLETED ---
             await self._transition(task_id, TaskPhase.COMPLETED)
+            self._append_to_plan(
+                plan_path, "COMPLETED",
+                f"Task completed. {len(step_results)} steps executed.",
+            )
             await self._notify(
                 task_id, f"Task completed: {description}", "alert",
             )
@@ -1094,6 +1172,43 @@ class CCSessionExecutor:
     _synthesize_deliverable = staticmethod(_dispatch.synthesize_deliverable)
     _dominant_step_type = staticmethod(_dispatch.dominant_step_type)
     _create_fixup_step = staticmethod(_dispatch.create_fixup_step)
+
+    @staticmethod
+    def _append_to_plan(plan_path: str, phase: str, content: str) -> None:
+        """Append a timestamped audit section to the plan file.
+
+        This is audit-only — the in-memory ``plan_content`` string is
+        the executor's working copy.  File appends are for human review
+        and post-mortem analysis.
+
+        Fail-open: errors are logged but never block execution.
+        Uses write-to-temp-then-rename for atomicity.
+        """
+        try:
+            path = Path(plan_path).expanduser()
+            if not path.exists():
+                return
+
+            timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+            section = (
+                f"\n\n---\n"
+                f"## Audit: {phase} ({timestamp})\n\n"
+                f"{content}\n"
+            )
+
+            existing = path.read_text(encoding="utf-8")
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(existing + section, encoding="utf-8")
+            tmp.rename(path)
+        except OSError:
+            logger.warning(
+                "Plan audit append failed (non-blocking)", exc_info=True,
+            )
+            # Clean up orphaned .tmp if write succeeded but rename failed
+            try:
+                Path(plan_path).expanduser().with_suffix(".tmp").unlink(missing_ok=True)
+            except OSError:
+                pass
 
     async def _set_output(self, task_id: str, key: str, value: str) -> None:
         """JSON read-merge-write on the outputs column.

--- a/src/genesis/autonomy/executor/observe.py
+++ b/src/genesis/autonomy/executor/observe.py
@@ -1,0 +1,222 @@
+"""Pre-execution observation — staleness and context-drift checks.
+
+Deterministic checks run before REVIEWING to detect whether the
+codebase or task context has drifted since the plan was written.
+No LLM calls — git commands + in-memory task comparison only.
+
+Three checks:
+1. Plan age: how old is the task since submission?
+2. Git activity: how many commits landed since task creation?
+3. Task overlap: have other tasks completed since this one was created?
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Thresholds (tunable module constants)
+# ---------------------------------------------------------------------------
+
+STALE_WARN_HOURS = 48
+STALE_BLOCK_HOURS = 168  # 7 days
+
+COMMIT_WARN_THRESHOLD = 20
+COMMIT_BLOCK_THRESHOLD = 50
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ObserveResult:
+    """Outcome of pre-execution observation checks."""
+
+    proceed: bool  # True = continue to REVIEWING, False = block
+    annotations: list[str] = field(default_factory=list)
+    block_reason: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def observe(
+    *,
+    created_at: str,
+    repo_root: Path,
+    active_tasks: list[dict],
+    task_id: str,
+) -> ObserveResult:
+    """Run observation checks before committing to execution.
+
+    Parameters
+    ----------
+    created_at:
+        ISO timestamp of task creation (from task_states.created_at).
+    repo_root:
+        Path to the repository root for git commands.
+    active_tasks:
+        Pre-fetched list of recent task dicts (from list_all_recent).
+    task_id:
+        ID of the task being observed (excluded from overlap check).
+
+    Returns
+    -------
+    ObserveResult with proceed=True/False and annotations/block_reason.
+    """
+    annotations: list[str] = []
+
+    # --- Check 1: Plan age ---
+    age_ann, age_block = _check_plan_age(created_at)
+    if age_block:
+        return ObserveResult(
+            proceed=False,
+            annotations=[age_ann] if age_ann else [],
+            block_reason=age_ann or "Plan is critically stale",
+        )
+    if age_ann:
+        annotations.append(age_ann)
+
+    # --- Check 2: Git activity ---
+    commit_count = await _count_commits_since(created_at, repo_root)
+    if commit_count >= COMMIT_BLOCK_THRESHOLD:
+        reason = (
+            f"{commit_count} commits landed since task creation — "
+            f"codebase may have changed significantly"
+        )
+        return ObserveResult(
+            proceed=False,
+            annotations=[reason],
+            block_reason=reason,
+        )
+    if commit_count >= COMMIT_WARN_THRESHOLD:
+        annotations.append(
+            f"{commit_count} commits landed since task creation"
+        )
+
+    # --- Check 3: Task overlap ---
+    overlap_annotations = _check_task_overlap(created_at, active_tasks, task_id)
+    annotations.extend(overlap_annotations)
+
+    return ObserveResult(proceed=True, annotations=annotations)
+
+
+# ---------------------------------------------------------------------------
+# Internal checks
+# ---------------------------------------------------------------------------
+
+
+def _check_plan_age(created_at: str) -> tuple[str | None, bool]:
+    """Check if the task is stale based on creation time.
+
+    Returns (annotation_or_None, should_block).
+    """
+    if not created_at:
+        return None, False
+
+    try:
+        created = datetime.fromisoformat(created_at)
+        # SQLite datetime('now') produces naive UTC strings
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=UTC)
+        age = datetime.now(UTC) - created
+        age_hours = age.total_seconds() / 3600
+    except (ValueError, TypeError):
+        logger.warning("Cannot parse created_at: %s", created_at)
+        return None, False
+
+    if age_hours >= STALE_BLOCK_HOURS:
+        return (
+            f"Plan is {age.days} days old (>{STALE_BLOCK_HOURS // 24}d threshold)"
+        ), True
+
+    if age_hours >= STALE_WARN_HOURS:
+        return (
+            f"Plan is {age_hours:.0f}h old (>{STALE_WARN_HOURS}h warning threshold)"
+        ), False
+
+    return None, False
+
+
+async def _count_commits_since(created_at: str, repo_root: Path) -> int:
+    """Count git commits since the given timestamp. Fail-open: returns 0."""
+    if not created_at:
+        return 0
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git", "log", "--oneline", f"--since={created_at}",
+            cwd=str(repo_root),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await proc.communicate()
+        if proc.returncode != 0:
+            logger.debug(
+                "git log failed (returncode %d), assuming 0 commits",
+                proc.returncode,
+            )
+            return 0
+        # Count non-empty lines
+        lines = [
+            ln for ln in stdout.decode(errors="replace").splitlines()
+            if ln.strip()
+        ]
+        return len(lines)
+    except OSError:
+        logger.warning(
+            "git subprocess failed, assuming 0 commits", exc_info=True,
+        )
+        return 0
+
+
+def _check_task_overlap(
+    created_at: str,
+    active_tasks: list[dict],
+    task_id: str,
+) -> list[str]:
+    """Check for other tasks that completed since this task was created."""
+    if not created_at or not active_tasks:
+        return []
+
+    try:
+        created = datetime.fromisoformat(created_at)
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=UTC)
+    except (ValueError, TypeError):
+        return []
+
+    completed_since = []
+    for t in active_tasks:
+        if t.get("task_id") == task_id:
+            continue
+        phase = t.get("current_phase", "")
+        if phase not in ("completed", "failed"):
+            continue
+        updated = t.get("updated_at", "")
+        if not updated:
+            continue
+        try:
+            updated_dt = datetime.fromisoformat(updated)
+            if updated_dt.tzinfo is None:
+                updated_dt = updated_dt.replace(tzinfo=UTC)
+            if updated_dt > created:
+                completed_since.append(t.get("task_id", "unknown")[:8])
+        except (ValueError, TypeError):
+            continue
+
+    if completed_since:
+        return [
+            f"{len(completed_since)} other task(s) completed since this "
+            f"task was created ({', '.join(completed_since[:3])})"
+        ]
+    return []

--- a/src/genesis/autonomy/executor/observe.py
+++ b/src/genesis/autonomy/executor/observe.py
@@ -1,13 +1,17 @@
-"""Pre-execution observation — staleness and context-drift checks.
+"""Pre-execution observation — context annotations for the reviewer.
 
-Deterministic checks run before REVIEWING to detect whether the
-codebase or task context has drifted since the plan was written.
+Deterministic checks run before REVIEWING to provide context about
+whether the task environment has drifted since the plan was written.
 No LLM calls — git commands + in-memory task comparison only.
 
+All checks are annotation-only — they NEVER block execution.
+Annotations are injected into plan_content so the reviewer LLM
+can factor them into its assessment.
+
 Three checks:
-1. Plan age: how old is the task since submission?
-2. Git activity: how many commits landed since task creation?
-3. Task overlap: have other tasks completed since this one was created?
+1. Activity age: time since last task activity (updated_at)
+2. Git activity: commits landed since last task activity
+3. Task overlap: other tasks completed since this one was last active
 """
 
 from __future__ import annotations
@@ -25,10 +29,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 STALE_WARN_HOURS = 48
-STALE_BLOCK_HOURS = 168  # 7 days
-
 COMMIT_WARN_THRESHOLD = 20
-COMMIT_BLOCK_THRESHOLD = 50
 
 # ---------------------------------------------------------------------------
 # Result
@@ -37,11 +38,12 @@ COMMIT_BLOCK_THRESHOLD = 50
 
 @dataclass(frozen=True)
 class ObserveResult:
-    """Outcome of pre-execution observation checks."""
+    """Outcome of pre-execution observation checks.
 
-    proceed: bool  # True = continue to REVIEWING, False = block
+    Annotations only — this phase never blocks execution.
+    """
+
     annotations: list[str] = field(default_factory=list)
-    block_reason: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -51,7 +53,7 @@ class ObserveResult:
 
 async def observe(
     *,
-    created_at: str,
+    updated_at: str,
     repo_root: Path,
     active_tasks: list[dict],
     task_id: str,
@@ -60,8 +62,9 @@ async def observe(
 
     Parameters
     ----------
-    created_at:
-        ISO timestamp of task creation (from task_states.created_at).
+    updated_at:
+        ISO timestamp of last task activity (from task_states.updated_at).
+        Measures time since last meaningful interaction, not submission time.
     repo_root:
         Path to the repository root for git commands.
     active_tasks:
@@ -71,43 +74,27 @@ async def observe(
 
     Returns
     -------
-    ObserveResult with proceed=True/False and annotations/block_reason.
+    ObserveResult with annotations (may be empty if everything is fresh).
     """
     annotations: list[str] = []
 
-    # --- Check 1: Plan age ---
-    age_ann, age_block = _check_plan_age(created_at)
-    if age_block:
-        return ObserveResult(
-            proceed=False,
-            annotations=[age_ann] if age_ann else [],
-            block_reason=age_ann or "Plan is critically stale",
-        )
+    # --- Check 1: Activity age ---
+    age_ann = _check_activity_age(updated_at)
     if age_ann:
         annotations.append(age_ann)
 
     # --- Check 2: Git activity ---
-    commit_count = await _count_commits_since(created_at, repo_root)
-    if commit_count >= COMMIT_BLOCK_THRESHOLD:
-        reason = (
-            f"{commit_count} commits landed since task creation — "
-            f"codebase may have changed significantly"
-        )
-        return ObserveResult(
-            proceed=False,
-            annotations=[reason],
-            block_reason=reason,
-        )
+    commit_count = await _count_commits_since(updated_at, repo_root)
     if commit_count >= COMMIT_WARN_THRESHOLD:
         annotations.append(
-            f"{commit_count} commits landed since task creation"
+            f"{commit_count} commits landed since last task activity"
         )
 
     # --- Check 3: Task overlap ---
-    overlap_annotations = _check_task_overlap(created_at, active_tasks, task_id)
+    overlap_annotations = _check_task_overlap(updated_at, active_tasks, task_id)
     annotations.extend(overlap_annotations)
 
-    return ObserveResult(proceed=True, annotations=annotations)
+    return ObserveResult(annotations=annotations)
 
 
 # ---------------------------------------------------------------------------
@@ -115,46 +102,37 @@ async def observe(
 # ---------------------------------------------------------------------------
 
 
-def _check_plan_age(created_at: str) -> tuple[str | None, bool]:
-    """Check if the task is stale based on creation time.
-
-    Returns (annotation_or_None, should_block).
-    """
-    if not created_at:
-        return None, False
+def _check_activity_age(updated_at: str) -> str | None:
+    """Check time since last task activity. Returns annotation or None."""
+    if not updated_at:
+        return None
 
     try:
-        created = datetime.fromisoformat(created_at)
-        # SQLite datetime('now') produces naive UTC strings
-        if created.tzinfo is None:
-            created = created.replace(tzinfo=UTC)
-        age = datetime.now(UTC) - created
+        updated = datetime.fromisoformat(updated_at)
+        if updated.tzinfo is None:
+            updated = updated.replace(tzinfo=UTC)
+        age = datetime.now(UTC) - updated
         age_hours = age.total_seconds() / 3600
     except (ValueError, TypeError):
-        logger.warning("Cannot parse created_at: %s", created_at)
-        return None, False
-
-    if age_hours >= STALE_BLOCK_HOURS:
-        return (
-            f"Plan is {age.days} days old (>{STALE_BLOCK_HOURS // 24}d threshold)"
-        ), True
+        logger.warning("Cannot parse updated_at: %s", updated_at)
+        return None
 
     if age_hours >= STALE_WARN_HOURS:
-        return (
-            f"Plan is {age_hours:.0f}h old (>{STALE_WARN_HOURS}h warning threshold)"
-        ), False
+        if age.days >= 1:
+            return f"No activity for {age.days} days"
+        return f"No activity for {age_hours:.0f}h"
 
-    return None, False
+    return None
 
 
-async def _count_commits_since(created_at: str, repo_root: Path) -> int:
+async def _count_commits_since(updated_at: str, repo_root: Path) -> int:
     """Count git commits since the given timestamp. Fail-open: returns 0."""
-    if not created_at:
+    if not updated_at:
         return 0
 
     try:
         proc = await asyncio.create_subprocess_exec(
-            "git", "log", "--oneline", f"--since={created_at}",
+            "git", "log", "--oneline", f"--since={updated_at}",
             cwd=str(repo_root),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -166,7 +144,6 @@ async def _count_commits_since(created_at: str, repo_root: Path) -> int:
                 proc.returncode,
             )
             return 0
-        # Count non-empty lines
         lines = [
             ln for ln in stdout.decode(errors="replace").splitlines()
             if ln.strip()
@@ -180,18 +157,18 @@ async def _count_commits_since(created_at: str, repo_root: Path) -> int:
 
 
 def _check_task_overlap(
-    created_at: str,
+    updated_at: str,
     active_tasks: list[dict],
     task_id: str,
 ) -> list[str]:
-    """Check for other tasks that completed since this task was created."""
-    if not created_at or not active_tasks:
+    """Check for other tasks that completed since this task was last active."""
+    if not updated_at or not active_tasks:
         return []
 
     try:
-        created = datetime.fromisoformat(created_at)
-        if created.tzinfo is None:
-            created = created.replace(tzinfo=UTC)
+        updated = datetime.fromisoformat(updated_at)
+        if updated.tzinfo is None:
+            updated = updated.replace(tzinfo=UTC)
     except (ValueError, TypeError):
         return []
 
@@ -202,21 +179,21 @@ def _check_task_overlap(
         phase = t.get("current_phase", "")
         if phase not in ("completed", "failed"):
             continue
-        updated = t.get("updated_at", "")
-        if not updated:
+        t_updated = t.get("updated_at", "")
+        if not t_updated:
             continue
         try:
-            updated_dt = datetime.fromisoformat(updated)
-            if updated_dt.tzinfo is None:
-                updated_dt = updated_dt.replace(tzinfo=UTC)
-            if updated_dt > created:
+            t_updated_dt = datetime.fromisoformat(t_updated)
+            if t_updated_dt.tzinfo is None:
+                t_updated_dt = t_updated_dt.replace(tzinfo=UTC)
+            if t_updated_dt > updated:
                 completed_since.append(t.get("task_id", "unknown")[:8])
         except (ValueError, TypeError):
             continue
 
     if completed_since:
         return [
-            f"{len(completed_since)} other task(s) completed since this "
-            f"task was created ({', '.join(completed_since[:3])})"
+            f"{len(completed_since)} other task(s) completed since last "
+            f"activity ({', '.join(completed_since[:3])})"
         ]
     return []

--- a/src/genesis/autonomy/executor/review.py
+++ b/src/genesis/autonomy/executor/review.py
@@ -65,6 +65,16 @@ class ReviewResult:
 
 
 @dataclass(frozen=True)
+class PreMortemResult:
+    """Result of pre-mortem failure analysis."""
+
+    confidence: int  # 0-100
+    failure_modes: list[str] = field(default_factory=list)
+    invalid_assumptions: list[str] = field(default_factory=list)
+    mitigations: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
 class VerifyResult:
     """Result of post-execution adversarial verification."""
 
@@ -75,6 +85,20 @@ class VerifyResult:
     skipped_reason: str | None = None
     iteration: int = 0
 
+
+# ---------------------------------------------------------------------------
+# Pre-mortem thresholds (tunable)
+# ---------------------------------------------------------------------------
+
+# Below this confidence, pre-mortem blocks the task (flags for user).
+_PM_BLOCK_THRESHOLD = 50
+
+# Below this confidence (but above block), mitigations are injected into
+# plan context so the decomposer and step executors are aware of risks.
+_PM_MITIGATE_THRESHOLD = 70
+
+# 44_task_premortem — pre-mortem failure analysis before committing to execution.
+_CALL_SITE_PREMORTEM = "44_task_premortem"
 
 # ---------------------------------------------------------------------------
 # Reviewer
@@ -167,6 +191,76 @@ class TaskReviewer:
             )
             return None
         return output.text
+
+    # --- Pre-mortem analysis (between review and planning) ---------------
+
+    async def pre_mortem(
+        self,
+        plan_content: str,
+        task_description: str,
+    ) -> PreMortemResult | None:
+        """Pre-mortem failure analysis: assume the task fails, identify causes.
+
+        Returns ``PreMortemResult`` on success, ``None`` on LLM failure
+        (fail-open — don't block execution because analysis failed).
+        """
+        try:
+            template_path = Path(__file__).resolve().parent.parent.parent / "identity" / "TASK_PREMORTEM.md"
+            template = template_path.read_text(encoding="utf-8")
+        except OSError:
+            logger.warning("TASK_PREMORTEM.md not found, skipping pre-mortem")
+            return None
+
+        prompt = template.replace(
+            "{{plan_content}}", plan_content,
+        ).replace(
+            "{{task_description}}", task_description,
+        )
+
+        messages = [{"role": "user", "content": prompt}]
+        try:
+            result = await self._router.route_call(
+                _CALL_SITE_PREMORTEM, messages,
+            )
+        except Exception:
+            logger.warning(
+                "Pre-mortem LLM call failed, proceeding without",
+                exc_info=True,
+            )
+            return None
+
+        if not result.success or not result.content:
+            logger.warning("Pre-mortem routing failed, proceeding without")
+            return None
+
+        return self._parse_pre_mortem(result.content)
+
+    def _parse_pre_mortem(self, raw: str) -> PreMortemResult | None:
+        """Parse pre-mortem JSON response."""
+        text = raw.strip()
+        # Try JSON block first
+        m = _JSON_BLOCK_RE.search(text)
+        if m:
+            text = m.group(1).strip()
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            logger.warning(
+                "Pre-mortem response not valid JSON: %.200s", raw,
+            )
+            return None
+
+        confidence = data.get("confidence")
+        if not isinstance(confidence, (int, float)):
+            logger.warning("Pre-mortem missing numeric confidence field")
+            return None
+
+        return PreMortemResult(
+            confidence=int(confidence),
+            failure_modes=data.get("failure_modes", []),
+            invalid_assumptions=data.get("invalid_assumptions", []),
+            mitigations=data.get("mitigations", []),
+        )
 
     # --- Deliverable verification (post-execution) ----------------------
 

--- a/src/genesis/autonomy/executor/trace.py
+++ b/src/genesis/autonomy/executor/trace.py
@@ -549,10 +549,12 @@ class ExecutionTracer:
         reason = cal.get("reason", "")
         model_used = cal.get("model_used", "unknown")
         better = cal.get("better_choice", "")
+        step_idx = cal.get("step_idx")
         if not reason:
             return
 
-        content = f"Calibration (task {task_id[:8]}): used {model_used}"
+        step_label = f" step {step_idx}" if step_idx is not None else ""
+        content = f"Calibration (task {task_id[:8]}{step_label}): used {model_used}"
         if better:
             content += f", better choice was {better}"
         content += f". {reason}"

--- a/src/genesis/autonomy/executor/trace.py
+++ b/src/genesis/autonomy/executor/trace.py
@@ -416,8 +416,9 @@ class ExecutionTracer:
             steps=proc_data["steps"],
             tools_used=proc_data["tools_used"],
             context_tags=proc_data["context_tags"],
-            activation_tier="L4",
+            activation_tier="L3",
             speculative=1,
+            confidence=0.5,
             principle_embedding=principle_blob,
         )
 

--- a/src/genesis/autonomy/executor/trace.py
+++ b/src/genesis/autonomy/executor/trace.py
@@ -34,6 +34,9 @@ _RETROSPECTIVE_PROMPT_PATH = (
 _MAX_NEW_PROCEDURES = 3
 _MAX_PROCEDURE_UPDATES = 5
 _MAX_SKILL_OBSERVATIONS = 3
+_MAX_CALIBRATIONS = 2
+_MAX_OPTIMIZATIONS = 2
+_MAX_DRIFT = 2
 
 
 class _Router(Protocol):
@@ -369,6 +372,45 @@ class ExecutionTracer:
                         exc_info=True,
                     )
 
+        # 4. Capability calibrations
+        calibrations = data.get("capability_calibrations", [])
+        if isinstance(calibrations, list):
+            for cal in calibrations[:_MAX_CALIBRATIONS]:
+                if not isinstance(cal, dict):
+                    continue
+                try:
+                    await self._record_calibration(trace.task_id, cal)
+                except Exception:
+                    logger.warning(
+                        "Failed to record calibration", exc_info=True,
+                    )
+
+        # 5. Workflow optimizations
+        optimizations = data.get("workflow_optimizations", [])
+        if isinstance(optimizations, list):
+            for opt in optimizations[:_MAX_OPTIMIZATIONS]:
+                if not isinstance(opt, dict):
+                    continue
+                try:
+                    await self._record_optimization(trace.task_id, opt)
+                except Exception:
+                    logger.warning(
+                        "Failed to record optimization", exc_info=True,
+                    )
+
+        # 6. Context drift
+        drift_items = data.get("context_drift", [])
+        if isinstance(drift_items, list):
+            for drift in drift_items[:_MAX_DRIFT]:
+                if not isinstance(drift, dict):
+                    continue
+                try:
+                    await self._record_drift(trace.task_id, drift)
+                except Exception:
+                    logger.warning(
+                        "Failed to record context drift", exc_info=True,
+                    )
+
         proc_count = len(trace.procedural_extractions)
         if proc_count:
             logger.info(
@@ -498,6 +540,81 @@ class ExecutionTracer:
             confidence=0.5,
         )
         logger.info("Recorded skill observation for '%s'", skill_name)
+
+    async def _record_calibration(self, task_id: str, cal: dict) -> None:
+        """Record a capability calibration observation."""
+        if self._memory_store is None:
+            return
+
+        reason = cal.get("reason", "")
+        model_used = cal.get("model_used", "unknown")
+        better = cal.get("better_choice", "")
+        if not reason:
+            return
+
+        content = f"Calibration (task {task_id[:8]}): used {model_used}"
+        if better:
+            content += f", better choice was {better}"
+        content += f". {reason}"
+
+        await self._memory_store.store(
+            content=content,
+            source="task_retrospective",
+            memory_type="episodic",
+            tags=["learning:calibration", f"task:{task_id[:8]}"],
+            confidence=0.5,
+        )
+        logger.debug("Recorded calibration for task %s", task_id[:8])
+
+    async def _record_optimization(self, task_id: str, opt: dict) -> None:
+        """Record a workflow optimization observation."""
+        if self._memory_store is None:
+            return
+
+        optimization = opt.get("optimization", "")
+        if not optimization:
+            return
+
+        applies_to = opt.get("applies_to", "")
+        content = f"Workflow optimization (task {task_id[:8]}): {optimization}"
+        if applies_to:
+            content += f". Applies to: {applies_to}"
+
+        await self._memory_store.store(
+            content=content,
+            source="task_retrospective",
+            memory_type="episodic",
+            tags=["learning:workflow", f"task:{task_id[:8]}"],
+            confidence=0.5,
+        )
+        logger.debug("Recorded workflow optimization for task %s", task_id[:8])
+
+    async def _record_drift(self, task_id: str, drift: dict) -> None:
+        """Record a context drift observation."""
+        if self._memory_store is None:
+            return
+
+        assumption = drift.get("assumption", "")
+        reality = drift.get("reality", "")
+        if not assumption or not reality:
+            return
+
+        lesson = drift.get("lesson", "")
+        content = (
+            f"Context drift (task {task_id[:8]}): "
+            f"assumed '{assumption}' but reality was '{reality}'"
+        )
+        if lesson:
+            content += f". Lesson: {lesson}"
+
+        await self._memory_store.store(
+            content=content,
+            source="task_retrospective",
+            memory_type="episodic",
+            tags=["learning:drift", f"task:{task_id[:8]}"],
+            confidence=0.5,
+        )
+        logger.debug("Recorded context drift for task %s", task_id[:8])
 
     async def _record_retrospective_failure(
         self,

--- a/src/genesis/autonomy/executor/types.py
+++ b/src/genesis/autonomy/executor/types.py
@@ -41,8 +41,7 @@ class TaskPhase(StrEnum):
 VALID_TRANSITIONS: dict[TaskPhase, set[TaskPhase]] = {
     TaskPhase.PENDING: {TaskPhase.OBSERVING, TaskPhase.FAILED, TaskPhase.CANCELLED},
     TaskPhase.OBSERVING: {
-        TaskPhase.REVIEWING,
-        TaskPhase.BLOCKED,  # stale plan blocks for user review
+        TaskPhase.REVIEWING,  # annotation-only, always proceeds
         TaskPhase.FAILED,
         TaskPhase.CANCELLED,
     },
@@ -91,7 +90,6 @@ VALID_TRANSITIONS: dict[TaskPhase, set[TaskPhase]] = {
         TaskPhase.FAILED,  # retrospective itself fails (non-blocking)
     },
     TaskPhase.BLOCKED: {
-        TaskPhase.OBSERVING,  # resume from observation-phase blocker
         TaskPhase.REVIEWING,  # user responded to review-phase blocker
         TaskPhase.EXECUTING,  # user responded to mid-task blocker
         TaskPhase.VERIFYING,  # recovery resume after verify-phase blocker

--- a/src/genesis/autonomy/executor/types.py
+++ b/src/genesis/autonomy/executor/types.py
@@ -19,6 +19,7 @@ class TaskPhase(StrEnum):
     """Lifecycle phases for a background task."""
 
     PENDING = "pending"
+    OBSERVING = "observing"
     REVIEWING = "reviewing"
     PLANNING = "planning"
     EXECUTING = "executing"
@@ -38,7 +39,13 @@ class TaskPhase(StrEnum):
 # ---------------------------------------------------------------------------
 
 VALID_TRANSITIONS: dict[TaskPhase, set[TaskPhase]] = {
-    TaskPhase.PENDING: {TaskPhase.REVIEWING, TaskPhase.FAILED, TaskPhase.CANCELLED},
+    TaskPhase.PENDING: {TaskPhase.OBSERVING, TaskPhase.FAILED, TaskPhase.CANCELLED},
+    TaskPhase.OBSERVING: {
+        TaskPhase.REVIEWING,
+        TaskPhase.BLOCKED,  # stale plan blocks for user review
+        TaskPhase.FAILED,
+        TaskPhase.CANCELLED,
+    },
     TaskPhase.REVIEWING: {
         TaskPhase.PLANNING,
         TaskPhase.BLOCKED,  # plan has gaps, need user input
@@ -84,6 +91,7 @@ VALID_TRANSITIONS: dict[TaskPhase, set[TaskPhase]] = {
         TaskPhase.FAILED,  # retrospective itself fails (non-blocking)
     },
     TaskPhase.BLOCKED: {
+        TaskPhase.OBSERVING,  # resume from observation-phase blocker
         TaskPhase.REVIEWING,  # user responded to review-phase blocker
         TaskPhase.EXECUTING,  # user responded to mid-task blocker
         TaskPhase.VERIFYING,  # recovery resume after verify-phase blocker

--- a/src/genesis/identity/TASK_PREMORTEM.md
+++ b/src/genesis/identity/TASK_PREMORTEM.md
@@ -1,0 +1,59 @@
+# Genesis --- Task Pre-Mortem Analysis
+
+You are reviewing a task plan. **Assume the task FAILS COMPLETELY.**
+
+Your job: identify what would cause failure BEFORE resources are committed.
+This is not a completeness check — it is a correctness and feasibility check.
+
+## The Plan
+
+{{plan_content}}
+
+## Task Description
+
+{{task_description}}
+
+## Instructions
+
+1. What are the 3 most likely causes of complete failure?
+   Focus on fundamental approach issues, not implementation details.
+
+2. What single assumption in this plan, if wrong, would invalidate the
+   entire approach? (Not "the code might have a bug" — more like
+   "this assumes the API supports batch operations, but it might not.")
+
+3. What concrete mitigations would you add to the plan to address the
+   top risks? Be specific and actionable.
+
+4. Confidence (0-100) that this plan succeeds as written, without
+   modifications. Be honest — most plans have gaps.
+
+## Output Format
+
+Return ONLY a JSON object:
+
+```json
+{
+  "failure_modes": [
+    "Most likely cause of failure",
+    "Second most likely",
+    "Third most likely"
+  ],
+  "invalid_assumptions": [
+    "The critical assumption that could invalidate the approach"
+  ],
+  "mitigations": [
+    "Specific mitigation 1",
+    "Specific mitigation 2"
+  ],
+  "confidence": 72
+}
+```
+
+## Judgment Guidelines
+
+- A confidence of 100 means "this plan cannot fail" — almost never true.
+- A confidence below 50 means "this plan is more likely to fail than succeed."
+- Focus on structural risks, not cosmetic issues.
+- If the plan is straightforward and well-scoped, say so — don't manufacture
+  risks to seem thorough.

--- a/src/genesis/identity/TASK_RETROSPECTIVE.md
+++ b/src/genesis/identity/TASK_RETROSPECTIVE.md
@@ -34,6 +34,18 @@ Analyze the trace and extract:
    a task revealed a reusable pattern and no matching skill exists, note
    that too.
 
+4. **Capability calibrations** --- for each step, was the right model or
+   approach used? Would a different routing have been faster, cheaper, or
+   more effective? Only note cases where calibration clearly matters.
+
+5. **Workflow optimizations** --- could any steps have been parallelized?
+   Were there unnecessary sequential dependencies? Only note actionable
+   improvements that would save meaningful time.
+
+6. **Context drift** --- did any assumptions from the plan change during
+   execution? What was stale by the time the executor reached that step?
+   Only note cases where drift actually impacted execution.
+
 ## Output Format
 
 Return ONLY a JSON object:
@@ -61,6 +73,29 @@ Return ONLY a JSON object:
     {
       "skill_name": "name from catalog",
       "observation": "what should be improved or added"
+    }
+  ],
+  "capability_calibrations": [
+    {
+      "step_idx": 1,
+      "model_used": "opus",
+      "better_choice": "sonnet",
+      "reason": "Simple code formatting task didn't need Opus-level reasoning"
+    }
+  ],
+  "workflow_optimizations": [
+    {
+      "optimization": "Steps 2 and 3 were independent and could run in parallel",
+      "estimated_savings": "50% of step 3 duration",
+      "applies_to": "tasks with independent code + test steps"
+    }
+  ],
+  "context_drift": [
+    {
+      "assumption": "API endpoint at /v2/users was stable",
+      "reality": "Endpoint was modified during execution",
+      "impact": "Step 4 failed, required workaround",
+      "lesson": "Check API stability for tasks spanning >2h"
     }
   ]
 }

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import aiosqlite
@@ -773,3 +775,156 @@ class TestPreMortemIntegration:
         result = await engine.execute("t-001")
 
         assert result is True
+
+
+# ---------------------------------------------------------------------------
+# OBSERVING phase integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestObservingPhase:
+    async def test_fresh_task_passes_observing(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """Fresh task passes OBSERVING without blocking."""
+        await _seed_task(db, plan_path=plan_file)
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+        result = await engine.execute("t-001")
+
+        assert result is True
+        task = await task_states.get_by_id(db, "t-001")
+        assert task["current_phase"] == "completed"
+
+    async def test_stale_task_blocked_by_observing(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """Task created >7 days ago is blocked at OBSERVING."""
+        from datetime import timedelta
+
+        old_date = (datetime.now(UTC) - timedelta(days=8)).isoformat()
+        await _seed_task(db, plan_path=plan_file)
+        await db.execute(
+            "UPDATE task_states SET created_at = ? WHERE task_id = ?",
+            (old_date, "t-001"),
+        )
+        await db.commit()
+
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+        result = await engine.execute("t-001")
+
+        assert result is False
+        task = await task_states.get_by_id(db, "t-001")
+        assert task["current_phase"] == "blocked"
+        blocker = json.loads(task["blockers"])
+        assert "Observation blocked" in blocker["description"]
+        assert blocker["resume_phase"] == "observing"
+
+    async def test_observing_skipped_on_recovery(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """Recovery path skips OBSERVING (resumes from executing)."""
+        await _seed_task(db, plan_path=plan_file, phase="executing")
+        # Add a completed step so recovery has something to work with
+        await task_steps.create_step(
+            db, task_id="t-001", step_idx=0, step_type="research",
+            description="Research",
+        )
+        await db.execute(
+            """UPDATE task_steps SET status = 'completed',
+               result_json = '{"result": "done", "artifacts": []}'
+               WHERE task_id = ? AND step_idx = ?""",
+            ("t-001", 0),
+        )
+        await db.commit()
+
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+        result = await engine.execute("t-001")
+
+        assert result is True
+        # Review was never called (skipped by recovery)
+        mock_reviewer.review_plan.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Pre-planning blocker recovery (Option B fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestPrePlanningBlockerRecovery:
+    async def test_blocked_at_observing_reruns_fresh_path(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """Task blocked at OBSERVING (no steps) resumes via fresh path."""
+        # Seed as blocked (simulates a prior observation blocker)
+        await _seed_task(db, plan_path=plan_file, phase="blocked")
+        # No steps exist in the DB (blocked before PLANNING)
+
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+        result = await engine.execute("t-001")
+
+        # Should re-run through OBSERVING -> REVIEWING -> PLANNING -> ...
+        assert result is True
+        task = await task_states.get_by_id(db, "t-001")
+        assert task["current_phase"] == "completed"
+        # Review was called (fresh path ran)
+        mock_reviewer.review_plan.assert_called_once()
+
+    async def test_blocked_at_reviewing_reruns_fresh_path(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """Pre-existing fix: blocked at REVIEWING (no steps) also gets fresh path."""
+        await _seed_task(db, plan_path=plan_file, phase="blocked")
+
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+        result = await engine.execute("t-001")
+
+        assert result is True
+        mock_reviewer.review_plan.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Living plan audit trail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestLivingPlan:
+    async def test_plan_file_gets_audit_sections(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """Plan file should have audit sections after execution."""
+        await _seed_task(db, plan_path=plan_file)
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+
+        await engine.execute("t-001")
+
+        content = Path(plan_file).read_text()
+        assert "## Audit: REVIEWING" in content
+        assert "## Audit: PLANNING" in content
+        assert "## Audit: COMPLETED" in content
+
+    async def test_plan_append_failopen(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """Unwritable plan file does not block execution."""
+        import os
+
+        await _seed_task(db, plan_path=plan_file)
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+
+        # Make plan file read-only
+        os.chmod(plan_file, 0o444)
+        try:
+            result = await engine.execute("t-001")
+            assert result is True
+        finally:
+            os.chmod(plan_file, 0o644)

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -11,7 +11,7 @@ import aiosqlite
 import pytest
 
 from genesis.autonomy.executor.engine import MAX_REVIEW_ITERATIONS, CCSessionExecutor
-from genesis.autonomy.executor.review import ReviewResult, VerifyResult
+from genesis.autonomy.executor.review import PreMortemResult, ReviewResult, VerifyResult
 from genesis.autonomy.executor.types import (
     StepResult,
     TaskPhase,
@@ -704,3 +704,72 @@ class TestHelpers:
         assert fixup["type"] == "code"
         assert "Fix the imports" in fixup["description"]
         assert "Missing error handling" in fixup["description"]
+
+
+# ---------------------------------------------------------------------------
+# Pre-mortem integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestPreMortemIntegration:
+    async def test_premortem_blocks_low_confidence(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+    ):
+        """Pre-mortem with confidence < 50 blocks the task."""
+        mock_reviewer.pre_mortem = AsyncMock(
+            return_value=PreMortemResult(
+                confidence=30,
+                failure_modes=["Fundamental approach is wrong"],
+                mitigations=["Rethink approach"],
+            ),
+        )
+        await _seed_task(db, plan_path=str(plan_file))
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+        result = await engine.execute("t-001")
+
+        assert result is False
+        task = await task_states.get_by_id(db, "t-001")
+        assert task["current_phase"] == "blocked"
+        blocker = json.loads(task.get("blockers") or "{}")
+        assert "Pre-mortem" in blocker.get("description", "")
+
+    async def test_premortem_injects_mitigations(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+    ):
+        """Pre-mortem with confidence 50-70 injects mitigations and proceeds."""
+        mock_reviewer.pre_mortem = AsyncMock(
+            return_value=PreMortemResult(
+                confidence=60,
+                failure_modes=["Possible edge case"],
+                mitigations=["Handle edge case X", "Add fallback for Y"],
+            ),
+        )
+        await _seed_task(db, plan_path=str(plan_file))
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+        result = await engine.execute("t-001")
+
+        assert result is True
+        # Verify mitigations were stored in outputs
+        task = await task_states.get_by_id(db, "t-001")
+        outputs = json.loads(task.get("outputs", "{}"))
+        pm_data = json.loads(outputs.get("pre_mortem", "{}"))
+        assert pm_data["confidence"] == 60
+        assert len(pm_data["mitigations"]) == 2
+
+    async def test_premortem_high_confidence_proceeds(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+    ):
+        """Pre-mortem with confidence > 70 proceeds normally."""
+        mock_reviewer.pre_mortem = AsyncMock(
+            return_value=PreMortemResult(
+                confidence=85,
+                failure_modes=[],
+                mitigations=[],
+            ),
+        )
+        await _seed_task(db, plan_path=str(plan_file))
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+        result = await engine.execute("t-001")
+
+        assert result is True

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -85,6 +85,7 @@ def mock_decomposer():
 def mock_reviewer():
     r = AsyncMock()
     r.review_plan = AsyncMock(return_value=ReviewResult(passed=True))
+    r.pre_mortem = AsyncMock(return_value=None)  # fail-open by default
     r.verify_deliverable = AsyncMock(return_value=VerifyResult(passed=True))
     return r
 

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -797,17 +797,17 @@ class TestObservingPhase:
         task = await task_states.get_by_id(db, "t-001")
         assert task["current_phase"] == "completed"
 
-    async def test_stale_task_blocked_by_observing(
+    async def test_stale_task_annotates_plan(
         self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
         mock_subprocess,
     ):
-        """Task created >7 days ago is blocked at OBSERVING."""
+        """Stale task gets annotations but still completes (never blocks)."""
         from datetime import timedelta
 
         old_date = (datetime.now(UTC) - timedelta(days=8)).isoformat()
         await _seed_task(db, plan_path=plan_file)
         await db.execute(
-            "UPDATE task_states SET created_at = ? WHERE task_id = ?",
+            "UPDATE task_states SET updated_at = ? WHERE task_id = ?",
             (old_date, "t-001"),
         )
         await db.commit()
@@ -815,12 +815,12 @@ class TestObservingPhase:
         engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
         result = await engine.execute("t-001")
 
-        assert result is False
-        task = await task_states.get_by_id(db, "t-001")
-        assert task["current_phase"] == "blocked"
-        blocker = json.loads(task["blockers"])
-        assert "Observation blocked" in blocker["description"]
-        assert blocker["resume_phase"] == "observing"
+        # Should complete, not block
+        assert result is True
+        # Plan file should have observation audit with staleness annotation
+        content = Path(plan_file).read_text()
+        assert "## Audit: OBSERVING" in content
+        assert "No activity" in content
 
     async def test_observing_skipped_on_recovery(
         self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
@@ -856,12 +856,12 @@ class TestObservingPhase:
 
 @pytest.mark.asyncio
 class TestPrePlanningBlockerRecovery:
-    async def test_blocked_at_observing_reruns_fresh_path(
+    async def test_blocked_before_planning_reruns_fresh_path(
         self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
         mock_subprocess,
     ):
-        """Task blocked at OBSERVING (no steps) resumes via fresh path."""
-        # Seed as blocked (simulates a prior observation blocker)
+        """Task blocked before PLANNING (no steps) resumes via fresh path."""
+        # Seed as blocked (simulates a prior review blocker)
         await _seed_task(db, plan_path=plan_file, phase="blocked")
         # No steps exist in the DB (blocked before PLANNING)
 
@@ -873,19 +873,6 @@ class TestPrePlanningBlockerRecovery:
         task = await task_states.get_by_id(db, "t-001")
         assert task["current_phase"] == "completed"
         # Review was called (fresh path ran)
-        mock_reviewer.review_plan.assert_called_once()
-
-    async def test_blocked_at_reviewing_reruns_fresh_path(
-        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
-        mock_subprocess,
-    ):
-        """Pre-existing fix: blocked at REVIEWING (no steps) also gets fresh path."""
-        await _seed_task(db, plan_path=plan_file, phase="blocked")
-
-        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
-        result = await engine.execute("t-001")
-
-        assert result is True
         mock_reviewer.review_plan.assert_called_once()
 
 

--- a/tests/test_autonomy/test_executor/test_observe.py
+++ b/tests/test_autonomy/test_executor/test_observe.py
@@ -1,0 +1,211 @@
+"""Tests for genesis.autonomy.executor.observe."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+
+from genesis.autonomy.executor.observe import (
+    COMMIT_BLOCK_THRESHOLD,
+    COMMIT_WARN_THRESHOLD,
+    STALE_BLOCK_HOURS,
+    STALE_WARN_HOURS,
+    observe,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_git(monkeypatch, *, commit_count: int, fail: bool = False):
+    """Mock asyncio.create_subprocess_exec for git log."""
+    proc = AsyncMock()
+    if fail:
+        proc.returncode = 1
+        proc.communicate = AsyncMock(return_value=(b"", b"error"))
+    else:
+        if commit_count > 0:
+            lines = "\n".join(
+                f"abc{i:04d} commit {i}" for i in range(commit_count)
+            )
+            stdout = lines.encode()
+        else:
+            stdout = b""
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(stdout, b""))
+
+    monkeypatch.setattr(
+        "genesis.autonomy.executor.observe.asyncio.create_subprocess_exec",
+        AsyncMock(return_value=proc),
+    )
+
+
+def _ts(hours_ago: float) -> str:
+    """Return ISO timestamp for N hours ago."""
+    return (datetime.now(UTC) - timedelta(hours=hours_ago)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Plan age checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestPlanAge:
+    async def test_fresh_task_proceeds(self, monkeypatch, tmp_path):
+        _mock_git(monkeypatch, commit_count=0)
+        result = await observe(
+            created_at=_ts(1), repo_root=tmp_path,
+            active_tasks=[], task_id="t-001",
+        )
+        assert result.proceed is True
+        assert not any("stale" in a.lower() or "old" in a.lower()
+                       for a in result.annotations)
+
+    async def test_48h_task_warns(self, monkeypatch, tmp_path):
+        _mock_git(monkeypatch, commit_count=0)
+        result = await observe(
+            created_at=_ts(STALE_WARN_HOURS + 1), repo_root=tmp_path,
+            active_tasks=[], task_id="t-001",
+        )
+        assert result.proceed is True
+        assert any("old" in a.lower() for a in result.annotations)
+
+    async def test_7d_task_blocks(self, monkeypatch, tmp_path):
+        _mock_git(monkeypatch, commit_count=0)
+        result = await observe(
+            created_at=_ts(STALE_BLOCK_HOURS + 1), repo_root=tmp_path,
+            active_tasks=[], task_id="t-001",
+        )
+        assert result.proceed is False
+        assert result.block_reason is not None
+        assert "days" in result.block_reason.lower()
+
+    async def test_empty_created_at_proceeds(self, monkeypatch, tmp_path):
+        _mock_git(monkeypatch, commit_count=0)
+        result = await observe(
+            created_at="", repo_root=tmp_path,
+            active_tasks=[], task_id="t-001",
+        )
+        assert result.proceed is True
+
+    async def test_invalid_created_at_proceeds(self, monkeypatch, tmp_path):
+        _mock_git(monkeypatch, commit_count=0)
+        result = await observe(
+            created_at="not-a-date", repo_root=tmp_path,
+            active_tasks=[], task_id="t-001",
+        )
+        assert result.proceed is True
+
+
+# ---------------------------------------------------------------------------
+# Git activity checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestGitActivity:
+    async def test_low_activity_proceeds(self, monkeypatch, tmp_path):
+        _mock_git(monkeypatch, commit_count=5)
+        result = await observe(
+            created_at=_ts(1), repo_root=tmp_path,
+            active_tasks=[], task_id="t-001",
+        )
+        assert result.proceed is True
+        assert not any("commit" in a.lower() for a in result.annotations)
+
+    async def test_moderate_activity_warns(self, monkeypatch, tmp_path):
+        _mock_git(monkeypatch, commit_count=COMMIT_WARN_THRESHOLD + 1)
+        result = await observe(
+            created_at=_ts(1), repo_root=tmp_path,
+            active_tasks=[], task_id="t-001",
+        )
+        assert result.proceed is True
+        assert any("commit" in a.lower() for a in result.annotations)
+
+    async def test_extreme_activity_blocks(self, monkeypatch, tmp_path):
+        _mock_git(monkeypatch, commit_count=COMMIT_BLOCK_THRESHOLD + 1)
+        result = await observe(
+            created_at=_ts(1), repo_root=tmp_path,
+            active_tasks=[], task_id="t-001",
+        )
+        assert result.proceed is False
+        assert "commit" in result.block_reason.lower()
+
+    async def test_git_failure_is_failopen(self, monkeypatch, tmp_path):
+        _mock_git(monkeypatch, commit_count=0, fail=True)
+        result = await observe(
+            created_at=_ts(1), repo_root=tmp_path,
+            active_tasks=[], task_id="t-001",
+        )
+        assert result.proceed is True
+
+
+# ---------------------------------------------------------------------------
+# Task overlap checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestTaskOverlap:
+    async def test_no_overlap_no_warning(self, monkeypatch, tmp_path):
+        _mock_git(monkeypatch, commit_count=0)
+        result = await observe(
+            created_at=_ts(1), repo_root=tmp_path,
+            active_tasks=[], task_id="t-001",
+        )
+        assert result.proceed is True
+        assert not any("other task" in a.lower() for a in result.annotations)
+
+    async def test_completed_task_overlap_warns(self, monkeypatch, tmp_path):
+        _mock_git(monkeypatch, commit_count=0)
+        other_tasks = [
+            {
+                "task_id": "t-other",
+                "current_phase": "completed",
+                "updated_at": datetime.now(UTC).isoformat(),
+                "created_at": _ts(3),
+            },
+        ]
+        result = await observe(
+            created_at=_ts(2), repo_root=tmp_path,
+            active_tasks=other_tasks, task_id="t-001",
+        )
+        assert result.proceed is True
+        assert any("other task" in a.lower() for a in result.annotations)
+
+    async def test_self_excluded_from_overlap(self, monkeypatch, tmp_path):
+        _mock_git(monkeypatch, commit_count=0)
+        other_tasks = [
+            {
+                "task_id": "t-001",  # same task
+                "current_phase": "completed",
+                "updated_at": datetime.now(UTC).isoformat(),
+                "created_at": _ts(3),
+            },
+        ]
+        result = await observe(
+            created_at=_ts(2), repo_root=tmp_path,
+            active_tasks=other_tasks, task_id="t-001",
+        )
+        assert not any("other task" in a.lower() for a in result.annotations)
+
+    async def test_active_tasks_not_counted(self, monkeypatch, tmp_path):
+        """Only completed/failed tasks trigger overlap, not active ones."""
+        _mock_git(monkeypatch, commit_count=0)
+        other_tasks = [
+            {
+                "task_id": "t-active",
+                "current_phase": "executing",
+                "updated_at": datetime.now(UTC).isoformat(),
+                "created_at": _ts(3),
+            },
+        ]
+        result = await observe(
+            created_at=_ts(2), repo_root=tmp_path,
+            active_tasks=other_tasks, task_id="t-001",
+        )
+        assert not any("other task" in a.lower() for a in result.annotations)

--- a/tests/test_autonomy/test_executor/test_observe.py
+++ b/tests/test_autonomy/test_executor/test_observe.py
@@ -8,9 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from genesis.autonomy.executor.observe import (
-    COMMIT_BLOCK_THRESHOLD,
     COMMIT_WARN_THRESHOLD,
-    STALE_BLOCK_HOURS,
     STALE_WARN_HOURS,
     observe,
 )
@@ -49,56 +47,55 @@ def _ts(hours_ago: float) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Plan age checks
+# Activity age checks
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-class TestPlanAge:
-    async def test_fresh_task_proceeds(self, monkeypatch, tmp_path):
+class TestActivityAge:
+    async def test_fresh_task_no_annotation(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0)
         result = await observe(
-            created_at=_ts(1), repo_root=tmp_path,
+            updated_at=_ts(1), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
-        assert not any("stale" in a.lower() or "old" in a.lower()
-                       for a in result.annotations)
+        assert not result.annotations
 
-    async def test_48h_task_warns(self, monkeypatch, tmp_path):
+    async def test_48h_stale_annotates(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0)
         result = await observe(
-            created_at=_ts(STALE_WARN_HOURS + 1), repo_root=tmp_path,
+            updated_at=_ts(STALE_WARN_HOURS + 1), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
-        assert any("old" in a.lower() for a in result.annotations)
+        assert any("activity" in a.lower() or "no activity" in a.lower()
+                   for a in result.annotations)
 
-    async def test_7d_task_blocks(self, monkeypatch, tmp_path):
+    async def test_7d_stale_annotates_not_blocks(self, monkeypatch, tmp_path):
+        """Even very stale tasks only get annotated, never blocked."""
         _mock_git(monkeypatch, commit_count=0)
         result = await observe(
-            created_at=_ts(STALE_BLOCK_HOURS + 1), repo_root=tmp_path,
+            updated_at=_ts(170), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is False
-        assert result.block_reason is not None
-        assert "days" in result.block_reason.lower()
+        # Should have an annotation about staleness
+        assert len(result.annotations) > 0
+        assert any("days" in a or "activity" in a.lower() for a in result.annotations)
 
-    async def test_empty_created_at_proceeds(self, monkeypatch, tmp_path):
+    async def test_empty_updated_at_no_annotation(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0)
         result = await observe(
-            created_at="", repo_root=tmp_path,
+            updated_at="", repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
+        assert not result.annotations
 
-    async def test_invalid_created_at_proceeds(self, monkeypatch, tmp_path):
+    async def test_invalid_updated_at_no_annotation(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0)
         result = await observe(
-            created_at="not-a-date", repo_root=tmp_path,
+            updated_at="not-a-date", repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
+        assert not result.annotations
 
 
 # ---------------------------------------------------------------------------
@@ -108,40 +105,38 @@ class TestPlanAge:
 
 @pytest.mark.asyncio
 class TestGitActivity:
-    async def test_low_activity_proceeds(self, monkeypatch, tmp_path):
+    async def test_low_activity_no_annotation(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=5)
         result = await observe(
-            created_at=_ts(1), repo_root=tmp_path,
+            updated_at=_ts(1), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
         assert not any("commit" in a.lower() for a in result.annotations)
 
-    async def test_moderate_activity_warns(self, monkeypatch, tmp_path):
+    async def test_moderate_activity_annotates(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=COMMIT_WARN_THRESHOLD + 1)
         result = await observe(
-            created_at=_ts(1), repo_root=tmp_path,
+            updated_at=_ts(1), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
         assert any("commit" in a.lower() for a in result.annotations)
 
-    async def test_extreme_activity_blocks(self, monkeypatch, tmp_path):
-        _mock_git(monkeypatch, commit_count=COMMIT_BLOCK_THRESHOLD + 1)
+    async def test_high_activity_annotates_not_blocks(self, monkeypatch, tmp_path):
+        """Even 100+ commits only annotates, never blocks."""
+        _mock_git(monkeypatch, commit_count=100)
         result = await observe(
-            created_at=_ts(1), repo_root=tmp_path,
+            updated_at=_ts(1), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is False
-        assert "commit" in result.block_reason.lower()
+        assert any("commit" in a.lower() for a in result.annotations)
 
     async def test_git_failure_is_failopen(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0, fail=True)
         result = await observe(
-            created_at=_ts(1), repo_root=tmp_path,
+            updated_at=_ts(1), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
+        assert not any("commit" in a.lower() for a in result.annotations)
 
 
 # ---------------------------------------------------------------------------
@@ -151,16 +146,15 @@ class TestGitActivity:
 
 @pytest.mark.asyncio
 class TestTaskOverlap:
-    async def test_no_overlap_no_warning(self, monkeypatch, tmp_path):
+    async def test_no_overlap_no_annotation(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0)
         result = await observe(
-            created_at=_ts(1), repo_root=tmp_path,
+            updated_at=_ts(1), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
         assert not any("other task" in a.lower() for a in result.annotations)
 
-    async def test_completed_task_overlap_warns(self, monkeypatch, tmp_path):
+    async def test_completed_task_overlap_annotates(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0)
         other_tasks = [
             {
@@ -171,24 +165,23 @@ class TestTaskOverlap:
             },
         ]
         result = await observe(
-            created_at=_ts(2), repo_root=tmp_path,
+            updated_at=_ts(2), repo_root=tmp_path,
             active_tasks=other_tasks, task_id="t-001",
         )
-        assert result.proceed is True
         assert any("other task" in a.lower() for a in result.annotations)
 
     async def test_self_excluded_from_overlap(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0)
         other_tasks = [
             {
-                "task_id": "t-001",  # same task
+                "task_id": "t-001",
                 "current_phase": "completed",
                 "updated_at": datetime.now(UTC).isoformat(),
                 "created_at": _ts(3),
             },
         ]
         result = await observe(
-            created_at=_ts(2), repo_root=tmp_path,
+            updated_at=_ts(2), repo_root=tmp_path,
             active_tasks=other_tasks, task_id="t-001",
         )
         assert not any("other task" in a.lower() for a in result.annotations)
@@ -205,7 +198,7 @@ class TestTaskOverlap:
             },
         ]
         result = await observe(
-            created_at=_ts(2), repo_root=tmp_path,
+            updated_at=_ts(2), repo_root=tmp_path,
             active_tasks=other_tasks, task_id="t-001",
         )
         assert not any("other task" in a.lower() for a in result.annotations)

--- a/tests/test_autonomy/test_executor/test_review.py
+++ b/tests/test_autonomy/test_executor/test_review.py
@@ -525,3 +525,102 @@ class TestToolCapableReviewChain:
         reviewer = TaskReviewer(router=router, invoker=None)
         result = await reviewer._tool_capable_review("deliverable", "reqs")
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Pre-mortem tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestPreMortem:
+    async def test_high_confidence_returns_result(self) -> None:
+        """Confidence > 70 returns PreMortemResult with all fields."""
+        body = json.dumps({
+            "failure_modes": ["API rate limit", "Schema change"],
+            "invalid_assumptions": ["API is stable"],
+            "mitigations": ["Add retry logic"],
+            "confidence": 85,
+        })
+        reviewer = TaskReviewer(router=_make_router(body))
+        result = await reviewer.pre_mortem("# Plan\nDo X", "Build API")
+
+        assert result is not None
+        assert result.confidence == 85
+        assert len(result.failure_modes) == 2
+        assert len(result.mitigations) == 1
+
+    async def test_low_confidence_returns_result(self) -> None:
+        """Confidence < 50 is returned (engine decides to block)."""
+        body = json.dumps({
+            "failure_modes": ["Fundamental approach wrong"],
+            "invalid_assumptions": ["Assumes non-existent API"],
+            "mitigations": ["Research API first"],
+            "confidence": 30,
+        })
+        reviewer = TaskReviewer(router=_make_router(body))
+        result = await reviewer.pre_mortem("# Bad plan", "Doomed task")
+
+        assert result is not None
+        assert result.confidence == 30
+
+    async def test_medium_confidence_includes_mitigations(self) -> None:
+        """Confidence 50-70 includes mitigations for injection."""
+        body = json.dumps({
+            "failure_modes": ["Partial coverage"],
+            "invalid_assumptions": [],
+            "mitigations": ["Add edge case handling", "Verify assumptions"],
+            "confidence": 60,
+        })
+        reviewer = TaskReviewer(router=_make_router(body))
+        result = await reviewer.pre_mortem("# Plan", "Build X")
+
+        assert result is not None
+        assert result.confidence == 60
+        assert len(result.mitigations) == 2
+
+    async def test_routing_failure_returns_none(self) -> None:
+        """Fail-open: routing failure -> None (don't block execution)."""
+        reviewer = TaskReviewer(router=_make_router(None, success=False))
+        result = await reviewer.pre_mortem("# Plan", "task")
+
+        assert result is None
+
+    async def test_routing_exception_returns_none(self) -> None:
+        """Fail-open: routing exception -> None."""
+        router = AsyncMock()
+        router.route_call = AsyncMock(side_effect=RuntimeError("network"))
+        reviewer = TaskReviewer(router=router)
+        result = await reviewer.pre_mortem("# Plan", "task")
+
+        assert result is None
+
+    async def test_invalid_json_returns_none(self) -> None:
+        """Unparseable response -> None (fail-open)."""
+        reviewer = TaskReviewer(router=_make_router("not json at all"))
+        result = await reviewer.pre_mortem("# Plan", "task")
+
+        assert result is None
+
+    async def test_missing_confidence_returns_none(self) -> None:
+        """JSON without numeric confidence field -> None."""
+        body = json.dumps({"failure_modes": ["x"], "confidence": "high"})
+        reviewer = TaskReviewer(router=_make_router(body))
+        result = await reviewer.pre_mortem("# Plan", "task")
+
+        assert result is None
+
+    async def test_json_in_markdown_block_parsed(self) -> None:
+        """JSON wrapped in markdown code fences is extracted."""
+        inner = json.dumps({
+            "failure_modes": ["risk"],
+            "invalid_assumptions": [],
+            "mitigations": [],
+            "confidence": 75,
+        })
+        body = f"```json\n{inner}\n```"
+        reviewer = TaskReviewer(router=_make_router(body))
+        result = await reviewer.pre_mortem("# Plan", "task")
+
+        assert result is not None
+        assert result.confidence == 75

--- a/tests/test_autonomy/test_executor/test_trace.py
+++ b/tests/test_autonomy/test_executor/test_trace.py
@@ -169,7 +169,8 @@ class TestRetrospective:
         call_kwargs = mock_store.call_args
         # First positional arg is db
         assert call_kwargs.kwargs["task_type"] == "api-endpoint-creation"
-        assert call_kwargs.kwargs["activation_tier"] == "L4"
+        assert call_kwargs.kwargs["activation_tier"] == "L3"
+        assert call_kwargs.kwargs["confidence"] == 0.5
         assert call_kwargs.kwargs["speculative"] == 1
         assert "proc-new-123" in trace.procedural_extractions
 

--- a/tests/test_autonomy/test_executor/test_trace.py
+++ b/tests/test_autonomy/test_executor/test_trace.py
@@ -361,3 +361,167 @@ class TestRetrospective:
                 break
         assert skill_call is not None
         assert "research" in skill_call.kwargs["tags"]
+
+
+# ---------------------------------------------------------------------------
+# Structured learning type tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestStructuredLearningTypes:
+    """Tests for capability calibrations, workflow optimizations, and context drift."""
+
+    def _make_tracer(self):
+        """Build a tracer with mock memory_store and router returning structured data."""
+        memory_store = AsyncMock()
+        memory_store.store = AsyncMock(return_value="mem-learn-001")
+        return memory_store
+
+    async def _run_retro(self, memory_store, retro_data):
+        """Run a retrospective with the given data and return the tracer."""
+        router = AsyncMock()
+        router.route_call = AsyncMock(
+            return_value=FakeRoutingResult(
+                success=True, content=json.dumps(retro_data),
+            ),
+        )
+        tracer = ExecutionTracer(
+            memory_store=memory_store, router=router, db=AsyncMock(),
+        )
+        trace = tracer.start_trace("t-learn", "user", "test task")
+        tracer.record_step(
+            trace,
+            StepResult(idx=0, status="completed", result="done", cost_usd=0.1),
+        )
+
+        with patch(
+            "genesis.learning.procedural.operations.store_procedure",
+            AsyncMock(return_value="proc-ignore"),
+        ):
+            await tracer.finalize(trace)
+        return tracer
+
+    async def test_calibration_stored(self) -> None:
+        """Capability calibration stored with correct tags."""
+        memory_store = self._make_tracer()
+        await self._run_retro(memory_store, {
+            "new_procedures": [],
+            "procedure_updates": [],
+            "skill_observations": [],
+            "capability_calibrations": [{
+                "step_idx": 0,
+                "model_used": "opus",
+                "better_choice": "sonnet",
+                "reason": "Simple formatting task",
+            }],
+        })
+
+        cal_call = None
+        for call in memory_store.store.call_args_list:
+            tags = call.kwargs.get("tags", [])
+            if "learning:calibration" in tags:
+                cal_call = call
+                break
+        assert cal_call is not None
+        assert "opus" in cal_call.kwargs["content"]
+        assert "sonnet" in cal_call.kwargs["content"]
+
+    async def test_optimization_stored(self) -> None:
+        """Workflow optimization stored with correct tags."""
+        memory_store = self._make_tracer()
+        await self._run_retro(memory_store, {
+            "new_procedures": [],
+            "procedure_updates": [],
+            "skill_observations": [],
+            "workflow_optimizations": [{
+                "optimization": "Steps 2 and 3 could run in parallel",
+                "estimated_savings": "50%",
+                "applies_to": "independent code + test steps",
+            }],
+        })
+
+        opt_call = None
+        for call in memory_store.store.call_args_list:
+            tags = call.kwargs.get("tags", [])
+            if "learning:workflow" in tags:
+                opt_call = call
+                break
+        assert opt_call is not None
+        assert "parallel" in opt_call.kwargs["content"]
+
+    async def test_drift_stored(self) -> None:
+        """Context drift stored with correct tags."""
+        memory_store = self._make_tracer()
+        await self._run_retro(memory_store, {
+            "new_procedures": [],
+            "procedure_updates": [],
+            "skill_observations": [],
+            "context_drift": [{
+                "assumption": "API was stable",
+                "reality": "API was deprecated",
+                "impact": "Step 4 failed",
+                "lesson": "Check API stability",
+            }],
+        })
+
+        drift_call = None
+        for call in memory_store.store.call_args_list:
+            tags = call.kwargs.get("tags", [])
+            if "learning:drift" in tags:
+                drift_call = call
+                break
+        assert drift_call is not None
+        assert "API was stable" in drift_call.kwargs["content"]
+        assert "deprecated" in drift_call.kwargs["content"]
+
+    async def test_caps_enforced(self) -> None:
+        """More than 2 entries per type are truncated."""
+        memory_store = self._make_tracer()
+        await self._run_retro(memory_store, {
+            "new_procedures": [],
+            "procedure_updates": [],
+            "skill_observations": [],
+            "capability_calibrations": [
+                {"step_idx": i, "model_used": "opus", "reason": f"reason {i}"}
+                for i in range(5)
+            ],
+        })
+
+        cal_count = sum(
+            1 for call in memory_store.store.call_args_list
+            if "learning:calibration" in call.kwargs.get("tags", [])
+        )
+        assert cal_count == 2  # max cap
+
+    async def test_missing_fields_skipped(self) -> None:
+        """Entries with missing required fields are silently skipped."""
+        memory_store = self._make_tracer()
+        await self._run_retro(memory_store, {
+            "new_procedures": [],
+            "procedure_updates": [],
+            "skill_observations": [],
+            "capability_calibrations": [{"step_idx": 0}],  # missing reason
+            "workflow_optimizations": [{}],  # missing optimization
+            "context_drift": [{"assumption": "x"}],  # missing reality
+        })
+
+        learning_calls = [
+            call for call in memory_store.store.call_args_list
+            if any(
+                t.startswith("learning:")
+                for t in call.kwargs.get("tags", [])
+            )
+        ]
+        assert len(learning_calls) == 0
+
+    async def test_backward_compatible(self) -> None:
+        """Old responses without new fields don't break."""
+        memory_store = self._make_tracer()
+        await self._run_retro(memory_store, {
+            "new_procedures": [],
+            "procedure_updates": [],
+            "skill_observations": [],
+            # No capability_calibrations, workflow_optimizations, context_drift
+        })
+        # Should not raise — .get() defaults to empty list

--- a/tests/test_autonomy/test_executor/test_types.py
+++ b/tests/test_autonomy/test_executor/test_types.py
@@ -27,8 +27,21 @@ class TestTaskPhase:
                 f"Terminal phase {phase} should have no outgoing transitions"
             )
 
-    def test_pending_can_transition_to_reviewing(self) -> None:
-        assert TaskPhase.REVIEWING in VALID_TRANSITIONS[TaskPhase.PENDING]
+    def test_pending_can_transition_to_observing(self) -> None:
+        assert TaskPhase.OBSERVING in VALID_TRANSITIONS[TaskPhase.PENDING]
+
+    def test_pending_cannot_transition_to_reviewing_directly(self) -> None:
+        """PENDING -> REVIEWING is no longer valid; must go through OBSERVING."""
+        assert TaskPhase.REVIEWING not in VALID_TRANSITIONS[TaskPhase.PENDING]
+
+    def test_observing_can_transition_to_reviewing(self) -> None:
+        assert TaskPhase.REVIEWING in VALID_TRANSITIONS[TaskPhase.OBSERVING]
+
+    def test_observing_can_transition_to_blocked(self) -> None:
+        assert TaskPhase.BLOCKED in VALID_TRANSITIONS[TaskPhase.OBSERVING]
+
+    def test_blocked_can_resume_to_observing(self) -> None:
+        assert TaskPhase.OBSERVING in VALID_TRANSITIONS[TaskPhase.BLOCKED]
 
     def test_executing_can_loop_to_executing(self) -> None:
         """Executing -> Executing is valid (next step in sequence)."""
@@ -47,7 +60,7 @@ class TestTaskPhase:
 
 class TestValidateTransition:
     def test_valid_transition_succeeds(self) -> None:
-        validate_transition(TaskPhase.PENDING, TaskPhase.REVIEWING)
+        validate_transition(TaskPhase.PENDING, TaskPhase.OBSERVING)
 
     def test_invalid_transition_raises(self) -> None:
         with pytest.raises(InvalidTransitionError, match="Invalid transition"):

--- a/tests/test_autonomy/test_executor/test_types.py
+++ b/tests/test_autonomy/test_executor/test_types.py
@@ -37,11 +37,9 @@ class TestTaskPhase:
     def test_observing_can_transition_to_reviewing(self) -> None:
         assert TaskPhase.REVIEWING in VALID_TRANSITIONS[TaskPhase.OBSERVING]
 
-    def test_observing_can_transition_to_blocked(self) -> None:
-        assert TaskPhase.BLOCKED in VALID_TRANSITIONS[TaskPhase.OBSERVING]
-
-    def test_blocked_can_resume_to_observing(self) -> None:
-        assert TaskPhase.OBSERVING in VALID_TRANSITIONS[TaskPhase.BLOCKED]
+    def test_observing_cannot_transition_to_blocked(self) -> None:
+        """OBSERVING is annotation-only, never blocks."""
+        assert TaskPhase.BLOCKED not in VALID_TRANSITIONS[TaskPhase.OBSERVING]
 
     def test_executing_can_loop_to_executing(self) -> None:
         """Executing -> Executing is valid (next step in sequence)."""

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -132,7 +132,8 @@ def test_load_full_yaml(monkeypatch):
     # a few load-bearing ids rather than chasing the total on every edit.
     # 2026-05-10: 44 → 43 after net change (judge added by #304, 2_triage +
     # 7_task_retrospective removed by this PR).
-    assert len(cfg.call_sites) == 43
+    # 2026-05-12: 43 → 44 after 44_task_premortem added by #334.
+    assert len(cfg.call_sites) == 44
     assert "2_triage" not in cfg.call_sites  # removed 2026-05-10
     assert "7_task_retrospective" not in cfg.call_sites  # removed 2026-05-10 (duplicate; live one is 43_task_retrospective)
     assert "background" in cfg.retry_profiles


### PR DESCRIPTION
## Summary

- OBSERVING phase is now annotation-only — never blocks execution
- Switched from `created_at` to `updated_at` (paused tasks don't get penalized for inactivity)
- Removed blocking thresholds (STALE_BLOCK_HOURS, COMMIT_BLOCK_THRESHOLD)
- Simplified `ObserveResult` (no `proceed`/`block_reason` fields)
- Removed BLOCKED from OBSERVING state transitions (can't block there anymore)

## Rationale

Hard blocks based on heuristics (plan age, commit count) are user-hostile:
- Tasks aren't always code-related (license renewal, outreach, research)
- Tasks can legitimately pause for days waiting on user input
- Commit count in the repo is irrelevant to non-code tasks
- "Other tasks completed" is noise without knowing if they conflict

The system should provide context to the reviewer LLM, not gatekeep the user.

## Test plan

- [x] 246/246 executor tests pass
- [x] Full repo lint clean
- [x] Stale tasks get annotations but complete successfully
- [x] Recovery path still works for pre-planning blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)