### PR TITLE
refactor(executor): remove heuristic blocking from OBSERVING phase

### DIFF
--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -231,24 +231,17 @@ class CCSessionExecutor:
             else:
                 # Fresh path: OBSERVING -> REVIEWING -> PLANNING
 
-                # --- OBSERVING ---
+                # --- OBSERVING (annotation-only, never blocks) ---
                 await self._transition(task_id, TaskPhase.OBSERVING)
                 all_tasks = await task_states.list_all_recent(
                     self._db, limit=50,
                 )
                 obs = await _observe.observe(
-                    created_at=task.get("created_at", ""),
+                    updated_at=task.get("updated_at", ""),
                     repo_root=_REPO_ROOT,
                     active_tasks=all_tasks,
                     task_id=task_id,
                 )
-                if not obs.proceed:
-                    await self._persist_blocker(
-                        task_id,
-                        f"Observation blocked: {obs.block_reason}",
-                        TaskPhase.OBSERVING,
-                    )
-                    return False
                 if obs.annotations:
                     ann_text = "\n".join(f"- {a}" for a in obs.annotations)
                     plan_content = (

--- a/src/genesis/autonomy/executor/observe.py
+++ b/src/genesis/autonomy/executor/observe.py
@@ -1,13 +1,17 @@
-"""Pre-execution observation — staleness and context-drift checks.
+"""Pre-execution observation — context annotations for the reviewer.
 
-Deterministic checks run before REVIEWING to detect whether the
-codebase or task context has drifted since the plan was written.
+Deterministic checks run before REVIEWING to provide context about
+whether the task environment has drifted since the plan was written.
 No LLM calls — git commands + in-memory task comparison only.
 
+All checks are annotation-only — they NEVER block execution.
+Annotations are injected into plan_content so the reviewer LLM
+can factor them into its assessment.
+
 Three checks:
-1. Plan age: how old is the task since submission?
-2. Git activity: how many commits landed since task creation?
-3. Task overlap: have other tasks completed since this one was created?
+1. Activity age: time since last task activity (updated_at)
+2. Git activity: commits landed since last task activity
+3. Task overlap: other tasks completed since this one was last active
 """
 
 from __future__ import annotations
@@ -25,10 +29,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 STALE_WARN_HOURS = 48
-STALE_BLOCK_HOURS = 168  # 7 days
-
 COMMIT_WARN_THRESHOLD = 20
-COMMIT_BLOCK_THRESHOLD = 50
 
 # ---------------------------------------------------------------------------
 # Result
@@ -37,11 +38,12 @@ COMMIT_BLOCK_THRESHOLD = 50
 
 @dataclass(frozen=True)
 class ObserveResult:
-    """Outcome of pre-execution observation checks."""
+    """Outcome of pre-execution observation checks.
 
-    proceed: bool  # True = continue to REVIEWING, False = block
+    Annotations only — this phase never blocks execution.
+    """
+
     annotations: list[str] = field(default_factory=list)
-    block_reason: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -51,7 +53,7 @@ class ObserveResult:
 
 async def observe(
     *,
-    created_at: str,
+    updated_at: str,
     repo_root: Path,
     active_tasks: list[dict],
     task_id: str,
@@ -60,8 +62,9 @@ async def observe(
 
     Parameters
     ----------
-    created_at:
-        ISO timestamp of task creation (from task_states.created_at).
+    updated_at:
+        ISO timestamp of last task activity (from task_states.updated_at).
+        Measures time since last meaningful interaction, not submission time.
     repo_root:
         Path to the repository root for git commands.
     active_tasks:
@@ -71,43 +74,27 @@ async def observe(
 
     Returns
     -------
-    ObserveResult with proceed=True/False and annotations/block_reason.
+    ObserveResult with annotations (may be empty if everything is fresh).
     """
     annotations: list[str] = []
 
-    # --- Check 1: Plan age ---
-    age_ann, age_block = _check_plan_age(created_at)
-    if age_block:
-        return ObserveResult(
-            proceed=False,
-            annotations=[age_ann] if age_ann else [],
-            block_reason=age_ann or "Plan is critically stale",
-        )
+    # --- Check 1: Activity age ---
+    age_ann = _check_activity_age(updated_at)
     if age_ann:
         annotations.append(age_ann)
 
     # --- Check 2: Git activity ---
-    commit_count = await _count_commits_since(created_at, repo_root)
-    if commit_count >= COMMIT_BLOCK_THRESHOLD:
-        reason = (
-            f"{commit_count} commits landed since task creation — "
-            f"codebase may have changed significantly"
-        )
-        return ObserveResult(
-            proceed=False,
-            annotations=[reason],
-            block_reason=reason,
-        )
+    commit_count = await _count_commits_since(updated_at, repo_root)
     if commit_count >= COMMIT_WARN_THRESHOLD:
         annotations.append(
-            f"{commit_count} commits landed since task creation"
+            f"{commit_count} commits landed since last task activity"
         )
 
     # --- Check 3: Task overlap ---
-    overlap_annotations = _check_task_overlap(created_at, active_tasks, task_id)
+    overlap_annotations = _check_task_overlap(updated_at, active_tasks, task_id)
     annotations.extend(overlap_annotations)
 
-    return ObserveResult(proceed=True, annotations=annotations)
+    return ObserveResult(annotations=annotations)
 
 
 # ---------------------------------------------------------------------------
@@ -115,46 +102,37 @@ async def observe(
 # ---------------------------------------------------------------------------
 
 
-def _check_plan_age(created_at: str) -> tuple[str | None, bool]:
-    """Check if the task is stale based on creation time.
-
-    Returns (annotation_or_None, should_block).
-    """
-    if not created_at:
-        return None, False
+def _check_activity_age(updated_at: str) -> str | None:
+    """Check time since last task activity. Returns annotation or None."""
+    if not updated_at:
+        return None
 
     try:
-        created = datetime.fromisoformat(created_at)
-        # SQLite datetime('now') produces naive UTC strings
-        if created.tzinfo is None:
-            created = created.replace(tzinfo=UTC)
-        age = datetime.now(UTC) - created
+        updated = datetime.fromisoformat(updated_at)
+        if updated.tzinfo is None:
+            updated = updated.replace(tzinfo=UTC)
+        age = datetime.now(UTC) - updated
         age_hours = age.total_seconds() / 3600
     except (ValueError, TypeError):
-        logger.warning("Cannot parse created_at: %s", created_at)
-        return None, False
-
-    if age_hours >= STALE_BLOCK_HOURS:
-        return (
-            f"Plan is {age.days} days old (>{STALE_BLOCK_HOURS // 24}d threshold)"
-        ), True
+        logger.warning("Cannot parse updated_at: %s", updated_at)
+        return None
 
     if age_hours >= STALE_WARN_HOURS:
-        return (
-            f"Plan is {age_hours:.0f}h old (>{STALE_WARN_HOURS}h warning threshold)"
-        ), False
+        if age.days >= 1:
+            return f"No activity for {age.days} days"
+        return f"No activity for {age_hours:.0f}h"
 
-    return None, False
+    return None
 
 
-async def _count_commits_since(created_at: str, repo_root: Path) -> int:
+async def _count_commits_since(updated_at: str, repo_root: Path) -> int:
     """Count git commits since the given timestamp. Fail-open: returns 0."""
-    if not created_at:
+    if not updated_at:
         return 0
 
     try:
         proc = await asyncio.create_subprocess_exec(
-            "git", "log", "--oneline", f"--since={created_at}",
+            "git", "log", "--oneline", f"--since={updated_at}",
             cwd=str(repo_root),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -166,7 +144,6 @@ async def _count_commits_since(created_at: str, repo_root: Path) -> int:
                 proc.returncode,
             )
             return 0
-        # Count non-empty lines
         lines = [
             ln for ln in stdout.decode(errors="replace").splitlines()
             if ln.strip()
@@ -180,18 +157,18 @@ async def _count_commits_since(created_at: str, repo_root: Path) -> int:
 
 
 def _check_task_overlap(
-    created_at: str,
+    updated_at: str,
     active_tasks: list[dict],
     task_id: str,
 ) -> list[str]:
-    """Check for other tasks that completed since this task was created."""
-    if not created_at or not active_tasks:
+    """Check for other tasks that completed since this task was last active."""
+    if not updated_at or not active_tasks:
         return []
 
     try:
-        created = datetime.fromisoformat(created_at)
-        if created.tzinfo is None:
-            created = created.replace(tzinfo=UTC)
+        updated = datetime.fromisoformat(updated_at)
+        if updated.tzinfo is None:
+            updated = updated.replace(tzinfo=UTC)
     except (ValueError, TypeError):
         return []
 
@@ -202,21 +179,21 @@ def _check_task_overlap(
         phase = t.get("current_phase", "")
         if phase not in ("completed", "failed"):
             continue
-        updated = t.get("updated_at", "")
-        if not updated:
+        t_updated = t.get("updated_at", "")
+        if not t_updated:
             continue
         try:
-            updated_dt = datetime.fromisoformat(updated)
-            if updated_dt.tzinfo is None:
-                updated_dt = updated_dt.replace(tzinfo=UTC)
-            if updated_dt > created:
+            t_updated_dt = datetime.fromisoformat(t_updated)
+            if t_updated_dt.tzinfo is None:
+                t_updated_dt = t_updated_dt.replace(tzinfo=UTC)
+            if t_updated_dt > updated:
                 completed_since.append(t.get("task_id", "unknown")[:8])
         except (ValueError, TypeError):
             continue
 
     if completed_since:
         return [
-            f"{len(completed_since)} other task(s) completed since this "
-            f"task was created ({', '.join(completed_since[:3])})"
+            f"{len(completed_since)} other task(s) completed since last "
+            f"activity ({', '.join(completed_since[:3])})"
         ]
     return []

--- a/src/genesis/autonomy/executor/types.py
+++ b/src/genesis/autonomy/executor/types.py
@@ -41,8 +41,7 @@ class TaskPhase(StrEnum):
 VALID_TRANSITIONS: dict[TaskPhase, set[TaskPhase]] = {
     TaskPhase.PENDING: {TaskPhase.OBSERVING, TaskPhase.FAILED, TaskPhase.CANCELLED},
     TaskPhase.OBSERVING: {
-        TaskPhase.REVIEWING,
-        TaskPhase.BLOCKED,  # stale plan blocks for user review
+        TaskPhase.REVIEWING,  # annotation-only, always proceeds
         TaskPhase.FAILED,
         TaskPhase.CANCELLED,
     },
@@ -91,7 +90,6 @@ VALID_TRANSITIONS: dict[TaskPhase, set[TaskPhase]] = {
         TaskPhase.FAILED,  # retrospective itself fails (non-blocking)
     },
     TaskPhase.BLOCKED: {
-        TaskPhase.OBSERVING,  # resume from observation-phase blocker
         TaskPhase.REVIEWING,  # user responded to review-phase blocker
         TaskPhase.EXECUTING,  # user responded to mid-task blocker
         TaskPhase.VERIFYING,  # recovery resume after verify-phase blocker

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -797,17 +797,17 @@ class TestObservingPhase:
         task = await task_states.get_by_id(db, "t-001")
         assert task["current_phase"] == "completed"
 
-    async def test_stale_task_blocked_by_observing(
+    async def test_stale_task_annotates_plan(
         self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
         mock_subprocess,
     ):
-        """Task created >7 days ago is blocked at OBSERVING."""
+        """Stale task gets annotations but still completes (never blocks)."""
         from datetime import timedelta
 
         old_date = (datetime.now(UTC) - timedelta(days=8)).isoformat()
         await _seed_task(db, plan_path=plan_file)
         await db.execute(
-            "UPDATE task_states SET created_at = ? WHERE task_id = ?",
+            "UPDATE task_states SET updated_at = ? WHERE task_id = ?",
             (old_date, "t-001"),
         )
         await db.commit()
@@ -815,12 +815,12 @@ class TestObservingPhase:
         engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
         result = await engine.execute("t-001")
 
-        assert result is False
-        task = await task_states.get_by_id(db, "t-001")
-        assert task["current_phase"] == "blocked"
-        blocker = json.loads(task["blockers"])
-        assert "Observation blocked" in blocker["description"]
-        assert blocker["resume_phase"] == "observing"
+        # Should complete, not block
+        assert result is True
+        # Plan file should have observation audit with staleness annotation
+        content = Path(plan_file).read_text()
+        assert "## Audit: OBSERVING" in content
+        assert "No activity" in content
 
     async def test_observing_skipped_on_recovery(
         self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
@@ -856,12 +856,12 @@ class TestObservingPhase:
 
 @pytest.mark.asyncio
 class TestPrePlanningBlockerRecovery:
-    async def test_blocked_at_observing_reruns_fresh_path(
+    async def test_blocked_before_planning_reruns_fresh_path(
         self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
         mock_subprocess,
     ):
-        """Task blocked at OBSERVING (no steps) resumes via fresh path."""
-        # Seed as blocked (simulates a prior observation blocker)
+        """Task blocked before PLANNING (no steps) resumes via fresh path."""
+        # Seed as blocked (simulates a prior review blocker)
         await _seed_task(db, plan_path=plan_file, phase="blocked")
         # No steps exist in the DB (blocked before PLANNING)
 
@@ -873,19 +873,6 @@ class TestPrePlanningBlockerRecovery:
         task = await task_states.get_by_id(db, "t-001")
         assert task["current_phase"] == "completed"
         # Review was called (fresh path ran)
-        mock_reviewer.review_plan.assert_called_once()
-
-    async def test_blocked_at_reviewing_reruns_fresh_path(
-        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
-        mock_subprocess,
-    ):
-        """Pre-existing fix: blocked at REVIEWING (no steps) also gets fresh path."""
-        await _seed_task(db, plan_path=plan_file, phase="blocked")
-
-        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
-        result = await engine.execute("t-001")
-
-        assert result is True
         mock_reviewer.review_plan.assert_called_once()
 
 

--- a/tests/test_autonomy/test_executor/test_observe.py
+++ b/tests/test_autonomy/test_executor/test_observe.py
@@ -8,9 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from genesis.autonomy.executor.observe import (
-    COMMIT_BLOCK_THRESHOLD,
     COMMIT_WARN_THRESHOLD,
-    STALE_BLOCK_HOURS,
     STALE_WARN_HOURS,
     observe,
 )
@@ -49,56 +47,55 @@ def _ts(hours_ago: float) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Plan age checks
+# Activity age checks
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-class TestPlanAge:
-    async def test_fresh_task_proceeds(self, monkeypatch, tmp_path):
+class TestActivityAge:
+    async def test_fresh_task_no_annotation(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0)
         result = await observe(
-            created_at=_ts(1), repo_root=tmp_path,
+            updated_at=_ts(1), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
-        assert not any("stale" in a.lower() or "old" in a.lower()
-                       for a in result.annotations)
+        assert not result.annotations
 
-    async def test_48h_task_warns(self, monkeypatch, tmp_path):
+    async def test_48h_stale_annotates(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0)
         result = await observe(
-            created_at=_ts(STALE_WARN_HOURS + 1), repo_root=tmp_path,
+            updated_at=_ts(STALE_WARN_HOURS + 1), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
-        assert any("old" in a.lower() for a in result.annotations)
+        assert any("activity" in a.lower() or "no activity" in a.lower()
+                   for a in result.annotations)
 
-    async def test_7d_task_blocks(self, monkeypatch, tmp_path):
+    async def test_7d_stale_annotates_not_blocks(self, monkeypatch, tmp_path):
+        """Even very stale tasks only get annotated, never blocked."""
         _mock_git(monkeypatch, commit_count=0)
         result = await observe(
-            created_at=_ts(STALE_BLOCK_HOURS + 1), repo_root=tmp_path,
+            updated_at=_ts(170), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is False
-        assert result.block_reason is not None
-        assert "days" in result.block_reason.lower()
+        # Should have an annotation about staleness
+        assert len(result.annotations) > 0
+        assert any("days" in a or "activity" in a.lower() for a in result.annotations)
 
-    async def test_empty_created_at_proceeds(self, monkeypatch, tmp_path):
+    async def test_empty_updated_at_no_annotation(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0)
         result = await observe(
-            created_at="", repo_root=tmp_path,
+            updated_at="", repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
+        assert not result.annotations
 
-    async def test_invalid_created_at_proceeds(self, monkeypatch, tmp_path):
+    async def test_invalid_updated_at_no_annotation(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0)
         result = await observe(
-            created_at="not-a-date", repo_root=tmp_path,
+            updated_at="not-a-date", repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
+        assert not result.annotations
 
 
 # ---------------------------------------------------------------------------
@@ -108,40 +105,38 @@ class TestPlanAge:
 
 @pytest.mark.asyncio
 class TestGitActivity:
-    async def test_low_activity_proceeds(self, monkeypatch, tmp_path):
+    async def test_low_activity_no_annotation(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=5)
         result = await observe(
-            created_at=_ts(1), repo_root=tmp_path,
+            updated_at=_ts(1), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
         assert not any("commit" in a.lower() for a in result.annotations)
 
-    async def test_moderate_activity_warns(self, monkeypatch, tmp_path):
+    async def test_moderate_activity_annotates(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=COMMIT_WARN_THRESHOLD + 1)
         result = await observe(
-            created_at=_ts(1), repo_root=tmp_path,
+            updated_at=_ts(1), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
         assert any("commit" in a.lower() for a in result.annotations)
 
-    async def test_extreme_activity_blocks(self, monkeypatch, tmp_path):
-        _mock_git(monkeypatch, commit_count=COMMIT_BLOCK_THRESHOLD + 1)
+    async def test_high_activity_annotates_not_blocks(self, monkeypatch, tmp_path):
+        """Even 100+ commits only annotates, never blocks."""
+        _mock_git(monkeypatch, commit_count=100)
         result = await observe(
-            created_at=_ts(1), repo_root=tmp_path,
+            updated_at=_ts(1), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is False
-        assert "commit" in result.block_reason.lower()
+        assert any("commit" in a.lower() for a in result.annotations)
 
     async def test_git_failure_is_failopen(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0, fail=True)
         result = await observe(
-            created_at=_ts(1), repo_root=tmp_path,
+            updated_at=_ts(1), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
+        assert not any("commit" in a.lower() for a in result.annotations)
 
 
 # ---------------------------------------------------------------------------
@@ -151,16 +146,15 @@ class TestGitActivity:
 
 @pytest.mark.asyncio
 class TestTaskOverlap:
-    async def test_no_overlap_no_warning(self, monkeypatch, tmp_path):
+    async def test_no_overlap_no_annotation(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0)
         result = await observe(
-            created_at=_ts(1), repo_root=tmp_path,
+            updated_at=_ts(1), repo_root=tmp_path,
             active_tasks=[], task_id="t-001",
         )
-        assert result.proceed is True
         assert not any("other task" in a.lower() for a in result.annotations)
 
-    async def test_completed_task_overlap_warns(self, monkeypatch, tmp_path):
+    async def test_completed_task_overlap_annotates(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0)
         other_tasks = [
             {
@@ -171,24 +165,23 @@ class TestTaskOverlap:
             },
         ]
         result = await observe(
-            created_at=_ts(2), repo_root=tmp_path,
+            updated_at=_ts(2), repo_root=tmp_path,
             active_tasks=other_tasks, task_id="t-001",
         )
-        assert result.proceed is True
         assert any("other task" in a.lower() for a in result.annotations)
 
     async def test_self_excluded_from_overlap(self, monkeypatch, tmp_path):
         _mock_git(monkeypatch, commit_count=0)
         other_tasks = [
             {
-                "task_id": "t-001",  # same task
+                "task_id": "t-001",
                 "current_phase": "completed",
                 "updated_at": datetime.now(UTC).isoformat(),
                 "created_at": _ts(3),
             },
         ]
         result = await observe(
-            created_at=_ts(2), repo_root=tmp_path,
+            updated_at=_ts(2), repo_root=tmp_path,
             active_tasks=other_tasks, task_id="t-001",
         )
         assert not any("other task" in a.lower() for a in result.annotations)
@@ -205,7 +198,7 @@ class TestTaskOverlap:
             },
         ]
         result = await observe(
-            created_at=_ts(2), repo_root=tmp_path,
+            updated_at=_ts(2), repo_root=tmp_path,
             active_tasks=other_tasks, task_id="t-001",
         )
         assert not any("other task" in a.lower() for a in result.annotations)

--- a/tests/test_autonomy/test_executor/test_types.py
+++ b/tests/test_autonomy/test_executor/test_types.py
@@ -37,11 +37,9 @@ class TestTaskPhase:
     def test_observing_can_transition_to_reviewing(self) -> None:
         assert TaskPhase.REVIEWING in VALID_TRANSITIONS[TaskPhase.OBSERVING]
 
-    def test_observing_can_transition_to_blocked(self) -> None:
-        assert TaskPhase.BLOCKED in VALID_TRANSITIONS[TaskPhase.OBSERVING]
-
-    def test_blocked_can_resume_to_observing(self) -> None:
-        assert TaskPhase.OBSERVING in VALID_TRANSITIONS[TaskPhase.BLOCKED]
+    def test_observing_cannot_transition_to_blocked(self) -> None:
+        """OBSERVING is annotation-only, never blocks."""
+        assert TaskPhase.BLOCKED not in VALID_TRANSITIONS[TaskPhase.OBSERVING]
 
     def test_executing_can_loop_to_executing(self) -> None:
         """Executing -> Executing is valid (next step in sequence)."""


### PR DESCRIPTION
## Summary

- OBSERVING phase is now annotation-only — never blocks execution
- Switched from `created_at` to `updated_at` (paused tasks don't get penalized for inactivity)
- Removed blocking thresholds (STALE_BLOCK_HOURS, COMMIT_BLOCK_THRESHOLD)
- Simplified `ObserveResult` (no `proceed`/`block_reason` fields)
- Removed BLOCKED from OBSERVING state transitions (can't block there anymore)

## Rationale

Hard blocks based on heuristics (plan age, commit count) are user-hostile:
- Tasks aren't always code-related
- Tasks can legitimately pause for days waiting on user input
- Commit count in the repo is irrelevant to non-code tasks

The system should provide context to the reviewer LLM, not gatekeep the user.

## Test plan

- [x] 246/246 executor tests pass
- [x] Full repo lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)