### PR TITLE
feat(skills): publish stealth-browser skill with VNC trusted input

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -327,6 +327,16 @@
                 ]
             },
             {
+                "matcher": "browser_navigate",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/stealth_skill_nudge.py",
+                        "timeout": 500
+                    }
+                ]
+            },
+            {
                 "matcher": ".*",
                 "hooks": [
                     {

--- a/.gitignore
+++ b/.gitignore
@@ -84,8 +84,6 @@ docs/content/
 config/interop_system_prompt.md
 scripts/cops_interop.sh
 
-# Stealth browser skill + research (private — lives at ~/.genesis/skills/)
-src/genesis/skills/stealth-browser/
 .gitnexus
 
 # Personal skills (user-level data, lives at ~/.claude/skills/)

--- a/scripts/hooks/stealth_skill_nudge.py
+++ b/scripts/hooks/stealth_skill_nudge.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""PostToolUse hook (browser_navigate): nudge stealth-browser skill.
+
+Fires after browser_navigate is called with Camoufox (the default).
+Reminds the session to load the stealth-browser skill for anti-detection
+behavioral rules and the VNC trusted input technique.
+
+Never blocks (exit 0 always). Nudges once per session via sentinel file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+
+_SENTINEL_PREFIX = "genesis_stealth_nudge_"
+
+
+def _session_sentinel_path() -> str:
+    """Path to a sentinel file that tracks whether we've nudged this session."""
+    session_id = os.environ.get("CLAUDE_SESSION_ID", "unknown")
+    return os.path.join(tempfile.gettempdir(), f"{_SENTINEL_PREFIX}{session_id}")
+
+
+def main() -> int:
+    # Only nudge once per session
+    sentinel = _session_sentinel_path()
+    if os.path.exists(sentinel):
+        return 0
+
+    try:
+        raw = os.environ.get("CLAUDE_TOOL_USE_RESULT", "")
+        if not raw:
+            return 0
+
+        result = json.loads(raw)
+        layer = result.get("layer", "")
+
+        # Only nudge for Camoufox (stealth) sessions, not Playwright/Chromium
+        if layer != "camoufox":
+            return 0
+
+        # Create sentinel — we've nudged
+        try:
+            with open(sentinel, "w") as f:
+                f.write("1")
+        except OSError:
+            pass  # Non-critical
+
+        nudge = (
+            "Camoufox stealth browser is active. Load the stealth-browser skill "
+            "(`src/genesis/skills/stealth-browser/SKILL.md`) for anti-detection "
+            "behavioral rules: page warm-up, honeypot detection, form fill order, "
+            "timing profiles, and the VNC trusted input technique for bypassing "
+            "Cloudflare Turnstile checkboxes."
+        )
+        print(json.dumps({"additionalContext": nudge}))
+
+    except (json.JSONDecodeError, KeyError):
+        pass  # Fail-open
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/genesis/skills/stealth-browser/SKILL.md
+++ b/src/genesis/skills/stealth-browser/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: stealth-browser
+description: Anti-detection behavioral rules for stealth browser automation
+consumer: cc_any
+phase: execution
+---
+
+# Stealth Browser Skill
+
+Tool-agnostic anti-detection behavioral rules for browser automation.
+Applies regardless of browser engine (Camoufox, Playwright, future tools).
+
+**Load this skill when:** The `browser_navigate` tool is used with the
+default Camoufox (anti-detection) mode. The tool's docstring directs you here.
+
+## Core Principle
+
+Bot detection systems look for **behavioral signals**, not just
+fingerprints. A perfect fingerprint with robotic behavior is still
+detectable. The browser engine handles fingerprinting. This skill
+handles behavior.
+
+---
+
+## Always-Headed Mode
+
+Camoufox always launches headed on VNC display :99. This means:
+- Human can always observe the browser via noVNC
+- CAPTCHA/Turnstile escalation doesn't require browser restart
+- `browser_collaborate(True)` speeds up timing (human watching)
+- `browser_collaborate(False)` restores stealth timing (nobody watching)
+
+---
+
+## Layer 1: Current Infrastructure (use now)
+
+These rules work with the existing browser tools. The tools already
+implement human-like delays automatically — this section covers what
+YOU (the LLM session) must do on top.
+
+### Profile Pre-Warming
+
+Before navigating to a target form (especially ATS job applications),
+browse the company's public careers page first. This builds browsing
+history and cookie trail in the persistent profile. A cold browser going
+straight to an application form is a bot signal.
+
+### Page Load Warm-Up
+
+After `browser_navigate`, wait before interacting. Read the page snapshot,
+plan your actions. Do NOT immediately call `browser_fill` or `browser_click`.
+A human would look at the page first. 1-3 seconds minimum.
+
+### Honeypot Detection
+
+Before filling ANY form field, check the accessibility snapshot for hidden
+fields. Do NOT fill fields that appear to be:
+- `display: none` or `visibility: hidden` in the snapshot
+- Zero-dimension elements
+- Fields with names like `url`, `website`, `fax` that aren't expected
+  for the form type (common honeypot names)
+- Fields positioned off-screen
+
+Filling a honeypot = instant bot detection. When in doubt, skip the field.
+
+### Form Filling Order
+
+Fill fields in visual top-to-bottom order, matching how a human would
+tab through the form. Do NOT fill them in an arbitrary order.
+
+### Pre-Submit Validation
+
+Before clicking submit:
+1. Take a `browser_screenshot()`
+2. Review the screenshot to verify all fields are filled correctly
+3. Only then click submit
+4. Take another screenshot after submit to capture confirmation
+
+### Error Recovery
+
+If a form fill or click fails:
+- Do NOT immediately retry — wait 2-5 seconds
+- Take a screenshot to understand the current state
+- Try an alternative selector
+- If the page has changed (redirect, modal), re-read the snapshot
+
+### Per-Site Escalation
+
+Before engaging high-detection sites, check `references/per-site/` for
+site-specific rules. High-detection sites include:
+- **ATS systems**: Ashby, Greenhouse, Lever
+- **Social platforms**: Reddit, X/Twitter, LinkedIn
+- **Search engines**: Google
+- **Tech communities**: Hacker News, Stack Overflow
+
+If no per-site reference exists, conduct a research pass first to
+understand the site's detection patterns before automating.
+
+---
+
+## Layer 2: Active Infrastructure
+
+These features are now implemented in the browser tools.
+
+### Per-Keystroke Typing (active)
+
+`browser_fill` now types character-by-character with randomized inter-key
+intervals (50-200ms) when Camoufox is active. This fires the full
+keydown→keypress/input→keyup event chain per character. Atomic `fill()`
+only fires a single `input` event — trivially detectable.
+
+**Note for phone fields with input masks:** The per-keystroke typing
+interacts with auto-formatting. If a phone field adds characters mid-type
+(e.g., "(123) 456-..."), let the field format naturally — the typing
+engine handles this. If the result looks wrong, retry with `browser_fill`
+after clearing the field manually.
+
+### Stealth Click (active)
+
+`browser_click` now uses hover→mousemove trail→position jitter→realistic
+mousedown/mouseup gap when Camoufox is active. Clicks land within the
+central 60% of elements, not dead center. The Camoufox `humanize=2.5`
+setting provides native Bézier cursor movement at the browser level.
+
+### Turnstile/CAPTCHA Auto-Escalation (active)
+
+After `browser_navigate`, Turnstile is automatically detected. If it
+doesn't auto-resolve in 15 seconds, try the Layer 3 VNC trusted input
+technique (below) before escalating to human. If VNC click also fails,
+a Telegram alert is sent and the system polls for human resolution via
+VNC for up to 5 minutes. No browser restart needed — always headed.
+
+---
+
+## Layer 3: VNC Trusted Input Bridge
+
+When Turnstile or other anti-bot checkboxes won't auto-resolve, use the
+VNC protocol to inject real input events. This bypasses detection of
+synthetic events (XTest, CDP, Playwright mouse).
+
+### Why It Works
+
+x11vnc converts VNC protocol mouse/keyboard events into real X11 input
+device events. These are indistinguishable from physical hardware input.
+By contrast, xdotool uses the XTest extension, and Playwright uses CDP
+protocol — both produce synthetic events that Cloudflare fingerprints.
+
+### When to Use
+
+- Turnstile checkbox doesn't auto-resolve after 15 seconds
+- reCAPTCHA v2 checkbox needs a human-like click
+- Any anti-bot system that rejects automated clicks
+
+### Prerequisites
+
+- `genesis-vnc.service` running (x11vnc on port 5900, systemd auto-start)
+- `vncdotool` installed (`pip install vncdotool`)
+- If the VNC service uses password auth, start a temporary no-auth
+  instance for programmatic use:
+  `x11vnc -display :99 -forever -nopw -quiet -bg -rfbport 5999`
+
+### Steps
+
+1. **Find the element** — use `browser_run_js` to get the target
+   element's bounding rect:
+   ```javascript
+   document.querySelector('[style*="display: grid"]').getBoundingClientRect()
+   ```
+
+2. **Get window geometry** — the browser window position on the Xvfb display:
+   ```bash
+   DISPLAY=:99 xdotool getwindowgeometry $(DISPLAY=:99 xdotool search --name "Camoufox")
+   ```
+
+3. **Calculate screen coordinates**:
+   - `screen_x = window_x + page_element_x`
+   - `screen_y = window_y + browser_chrome_height + page_element_y`
+   - Chrome height is ~34px for Camoufox (viewport = window - 34)
+
+4. **Send human-like mouse movement** — move through 1-2 intermediate
+   points with 200-300ms pauses, then click:
+   ```bash
+   vncdo -s localhost::5999 move {start_x} {start_y}
+   # pause 300ms
+   vncdo -s localhost::5999 move {mid_x} {mid_y}
+   # pause 200ms
+   vncdo -s localhost::5999 move {target_x} {target_y} click 1
+   ```
+
+5. **Wait and verify** — allow 5-8 seconds for server-side verification,
+   then check if the page title changed from "Just a moment..." to the
+   actual page title.
+
+### Notes
+
+- The `cf_clearance` cookie persists for days/weeks after clearing
+  Turnstile. Subsequent page loads won't trigger the challenge.
+- If verification fails (checkbox reappears), wait 10 seconds and retry
+  once. Cloudflare rate-limits rapid attempts.
+- This technique works for ANY browser on Xvfb, not just Camoufox.
+
+---
+
+## Timing Profiles
+
+The browser tools implement automatic delays. These are the profiles:
+
+| Context | Inter-action delay | Notes |
+|---------|-------------------|-------|
+| Background (Camoufox, default) | 1-15s log-normal | Stealth priority. Mostly 2-5s, occasional long pauses |
+| Collaborate (Camoufox + VNC) | 0.5-2s uniform | Human watching. Responsive but not instant |
+| Playwright/Chromium (dev/test) | None | Speed priority. No stealth needed |
+
+The delay fires automatically before `browser_fill`, `browser_click`,
+and `browser_upload`. You do NOT need to add manual sleeps.
+
+---
+
+## Anti-Detection Services
+
+See `references/services.md` for external services that supplement
+the browser's built-in anti-detection:
+- **2Captcha**: Programmatic CAPTCHA solving ($0.00145/solve)
+- **Browserbase**: Cloud browser with real hardware ($0.002/session)
+- **Residential proxies**: IP reputation improvement
+
+---
+
+## What This Skill Does NOT Cover
+
+- Browser fingerprinting (handled by Camoufox at C++ level)
+- Proxy/IP management (see references/services.md)
+- Account management (login sessions, credential storage)

--- a/src/genesis/skills/stealth-browser/SKILL.md
+++ b/src/genesis/skills/stealth-browser/SKILL.md
@@ -140,10 +140,12 @@ synthetic events (XTest, CDP, Playwright mouse).
 
 ### Why It Works
 
-x11vnc converts VNC protocol mouse/keyboard events into real X11 input
-device events. These are indistinguishable from physical hardware input.
-By contrast, xdotool uses the XTest extension, and Playwright uses CDP
-protocol — both produce synthetic events that Cloudflare fingerprints.
+x11vnc injects input through the VNC protocol, adding network-realistic
+timing and event sequencing patterns. While the underlying X11 mechanism
+is similar to xdotool, the VNC protocol layer produces timing closer to
+real human input (variable latency, natural event gaps). Playwright uses
+CDP protocol which Cloudflare directly fingerprints. The practical result:
+VNC-injected clicks pass Turnstile where xdotool and Playwright fail.
 
 ### When to Use
 

--- a/src/genesis/skills/stealth-browser/references/anti-detection-research.md
+++ b/src/genesis/skills/stealth-browser/references/anti-detection-research.md
@@ -1,0 +1,79 @@
+# Anti-Detection Research Summary
+
+Compiled: 2026-04-22. Source: web research + bot detection literature.
+
+## Fingerprinting (browser engine handles this)
+
+Modern anti-detection browsers (Camoufox, Patchright) handle:
+- Navigator/screen/WebGL/canvas/audio fingerprinting
+- Font enumeration spoofing
+- Playwright sandboxing removal
+- Headless mode masking
+- HTTP header normalization
+- WebRTC IP leak prevention
+- BrowserForge statistical fingerprint generation
+
+**Known gaps (as of 2026-04):**
+- Camoufox has a maintenance gap — base Firefox version slightly outdated
+- Cannot masquerade as Chrome (SpiderMonkey vs V8 is unfakeable)
+- Canvas spoofing quality has degraded in recent versions
+
+## Behavioral Signals (our responsibility)
+
+### Timing
+- Human inter-keystroke interval: 239ms mean, 112ms SD (Aalto 136M study)
+- Common bigrams 40% faster, uncommon 30% slower
+- Gradual fatigue: ~0.05% slower per character
+- Page load to first interaction: 1.5-6 seconds (immediate = bot)
+- Pre-submit think time: 1.5-4 seconds
+- Form field to field: 2-8 seconds (log-normal, not uniform)
+
+### Mouse Movement
+- Humans generate hundreds of mousemove events per movement
+- Bots generate 0-10 events (or none)
+- 65% of fast movements overshoot by 3-12% then correct
+- Zero acceleration between points = bot
+- Bézier curves with noise > linear interpolation
+
+### Focus/Blur Events
+- `page.fill()` skips focus/blur events
+- Real browsers ALWAYS fire them
+- Critical for form detection systems
+- Must fire: click → focus → input → blur sequence
+
+### Scroll Patterns
+- Human scroll delta variance: 20-100px
+- Bot scroll delta variance: <5px
+- Humans pause to read, occasionally scroll back up
+- Jump-to-element (no scroll) = bot signal
+
+### Paste Detection
+- `element.fill()` doesn't fire paste/clipboard events
+- Some detection systems check if content was "typed" or "pasted"
+- For realistic behavior: simulate Ctrl+V event chain for pasted content
+
+### Honeypot Fields
+- Hidden fields with CSS: `display:none`, `visibility:hidden`, `opacity:0`
+- Zero-dimension or off-screen positioned fields
+- Common names: `url`, `website`, `fax`, `phone2`
+- Filling ANY honeypot = instant bot flag
+- Must check computed CSS before filling
+
+## Detection Systems by Platform
+
+| Platform | Detection | Primary signals |
+|----------|-----------|----------------|
+| Cloudflare Turnstile | Browser environment, NOT typing/mouse | Fingerprint, JS challenges |
+| DataDome | Behavioral + fingerprint | Mouse, timing, request patterns |
+| reCAPTCHA v3 | Risk score from page interaction | Engagement depth, timing |
+| Ashby (ATS) | Cloudflare Turnstile + form validation | Fingerprint, honeypots |
+| Greenhouse (ATS) | reCAPTCHA v2/v3 | Challenge-based |
+| Lever (ATS) | Basic rate limiting | Request frequency |
+| Reddit | Proprietary CQS + biometric verification | Account behavior, IP, burst patterns |
+
+## IP Reputation
+
+- Datacenter IPs: instant flag on Reddit, high risk on Cloudflare
+- Residential proxies: necessary for high-detection sites
+- GeoIP must align with timezone/locale headers
+- IP stability matters: rotating too fast = suspicious

--- a/src/genesis/skills/stealth-browser/references/per-site/ats-ashby.md
+++ b/src/genesis/skills/stealth-browser/references/per-site/ats-ashby.md
@@ -1,0 +1,118 @@
+# ATS: Ashby, Greenhouse, Lever
+
+## Ashby (Medium-High detection)
+
+**CORRECTION (2026-04-22):** Ashby does NOT use Cloudflare Turnstile on
+application forms. Previous research was incorrect.
+
+**UPDATE (2026-04-23):** Ashby DOES use Google reCAPTCHA v3 (invisible).
+Confirmed by live test — user filled form entirely manually via VNC through
+Camoufox, still flagged as spam. Error message explicitly states "we use
+Google's reCAPTCHA technology." The reCAPTCHA scores the browser environment
+throughout the session, not just at submit. Camoufox fingerprint alone
+triggers a low score regardless of human-like behavior.
+
+### Actual Detection Stack
+
+Ashby uses **six layers of detection** (reCAPTCHA is pre-submission, rest mostly post):
+
+0. **Google reCAPTCHA v3** (pre-submission, invisible): Scores the browser
+   session continuously. Camoufox triggers a low score based on fingerprint
+   alone — confirmed by manual VNC test (2026-04-23). Error message lists:
+   VPN/proxy, ad blockers, shared networks, "unusual browser settings."
+
+1. **Application Rate Limits** (pre-submission): per-email frequency caps.
+   Employer-configurable "max X applications in Y days." A new email resets.
+
+2. **Auto-Reject Rules** (at submission): based solely on form answer values
+   (yes/no, dropdown). Does NOT use email, IP, or behavioral signals.
+
+3. **Built-in Fraud Detection** (post-submission, automatic, Sept 2025):
+   Runs on ALL applicants. Analyzes: IP/geolocation, email validity, phone
+   risk, device/browser fingerprint, connection method, location mismatches,
+   synthetic identity patterns. Provides **signals, not verdicts** — the
+   application goes through and recruiters see flags alongside it.
+   **Candidates never know they've been flagged.**
+
+4. **Third-Party Verification** (optional): Socure, Incode, Persona
+   integrations. Auto-run on submission if employer enables them.
+
+5. **AI Application Review** (content analysis): evaluates resume vs. JD.
+   Not auto-reject — evaluation signals only.
+
+### What Triggers Fraud Flags
+
+- Datacenter/VPN IP (biggest signal)
+- Disposable email (mailinator, guerrillamail, etc.)
+- Invalid phone number
+- IP geolocation doesn't match stated location
+- Synthetic identity patterns (AI-optimized resume text)
+- White/invisible text in resume PDF
+- Same IP + different identities in rapid succession
+
+### What Does NOT Trigger Issues
+
+- Real personal email with history
+- Residential IP matching stated location
+- Genuine resume content
+- Reasonable application frequency
+- Standard browser with proper fingerprint (Camoufox handles this)
+
+### Form Architecture
+
+- Iframe embed: `<div id="ashby_embed">` + script from `jobs.ashbyhq.com`
+- API: `POST api.ashbyhq.com/applicationForm.submit`
+- No honeypot fields (confirmed)
+- No CAPTCHA of any kind on the form itself
+- Submit-time validation only (not per-field)
+- File upload via standard `<input type="file">`
+
+### Strategy
+
+- Use real identity data (name, email, phone, LinkedIn)
+- Ensure IP geolocation matches resume location
+- Residential proxy if submitting from datacenter
+- Per-keystroke typing for device fingerprint legitimacy
+- Pre-warm by browsing company's public page first
+- Screenshot before/after submit for audit trail
+- Space applications 5+ minutes apart from same identity
+
+### "Flagged as Spam" = Not a Rejection
+
+Applications flagged by fraud detection **still go through**. Recruiters
+see fraud signals alongside the application. There is no auto-rejection.
+There is no candidate-facing notification of being flagged. If the
+application content is strong, the recruiter may ignore the fraud flag.
+
+---
+
+## Greenhouse (Medium detection)
+
+- Uses **reCAPTCHA v2 or v3** depending on employer config
+- Form hosted at `boards.greenhouse.io`
+- Standard field layout with optional custom questions
+- Multi-page forms (some employers split into steps)
+- File upload for resume, optional cover letter
+- **reCAPTCHA v3**: invisible, scores interaction quality
+- **reCAPTCHA v2**: checkbox challenge, may need VNC collaborate mode
+
+### Strategy
+- reCAPTCHA v3: ensure sufficient page interaction before submit
+- reCAPTCHA v2: if checkbox appears, try clicking it; if image
+  challenge triggers, fall back to VNC (always available)
+- Fill all visible fields, skip honeypots
+- Multi-page: navigate each page, fill, screenshot, next
+
+## Lever (Medium-Low detection)
+
+- Basic rate limiting, no advanced bot detection
+- Form hosted at `jobs.lever.co`
+- Simple single-page form
+- File upload for resume
+- Optional fields: cover letter text, LinkedIn, website
+
+### Strategy
+- Lowest detection risk of the three
+- Standard human-like timing is sufficient
+- Rate limit: don't submit multiple applications in quick succession
+  from the same IP (space 5+ minutes apart)

--- a/src/genesis/skills/stealth-browser/references/per-site/reddit.md
+++ b/src/genesis/skills/stealth-browser/references/per-site/reddit.md
@@ -1,0 +1,60 @@
+# Reddit
+
+## Detection System (as of 2026-04)
+
+Reddit uses **proprietary internal detection**, not an external WAF.
+
+### Contributor Quality Score (CQS)
+Invisible 5-tier score based on:
+- Account age
+- IP stability
+- Karma (post + comment)
+- Engagement quality (replies, upvotes received)
+- Rule adherence (reports, removals)
+
+Low CQS = content auto-removed before any human sees it.
+
+### Biometric Verification (March 2026)
+- Flagged accounts must verify via passkeys, biometrics, or government ID
+- **Cannot be automated** — this is the hard wall
+- Prevention (never getting flagged) is the only strategy
+
+### ~100,000 bot accounts removed daily
+
+## What Gets You Caught (ranked by risk)
+
+1. Standard Playwright/Selenium without stealth patches (instant)
+2. Datacenter IPs (instant)
+3. Burst activity patterns — most bans from bursts, not total volume
+4. Same content across multiple subreddits (shadowban)
+5. AI-generated polished content (detected faster than casual writing)
+6. New accounts acting too quickly without karma/age
+
+## Rate Limits
+
+| Action | New account | Established |
+|--------|------------|-------------|
+| Comments | 2-3/day | Higher, varies |
+| Posts | None for ~2 weeks | Varies by subreddit |
+| Subreddit with low karma | 1 per 10 min | Normal |
+| API (OAuth) | 100 req/min | 100 req/min |
+| API (unauth) | 10 req/min | 10 req/min |
+| Browser scraping | ~50 pages before flagged | Similar |
+| DMs | <15 per 5 min | <15 per 5 min |
+
+## Strategy
+
+- **Residential proxy mandatory** — datacenter IPs are instant flags
+- **Account age matters** — don't use new accounts for automation
+- **No burst patterns** — space actions over hours, not minutes
+- **Content quality** — casual, human-like. Overly polished = suspicious
+- **IP stability** — don't rotate IPs within a session
+- **GeoIP alignment** — IP location must match account's typical location
+- **Self-service API keys eliminated** (Nov 2025) — all OAuth requires
+  manual Reddit pre-approval
+
+## Bottom Line
+
+Reddit automation is HIGH RISK. The biometric verification wall means
+there's no recovery from being flagged. Every interaction must be
+designed to never trigger the first flag. Use with extreme caution.

--- a/src/genesis/skills/stealth-browser/references/services.md
+++ b/src/genesis/skills/stealth-browser/references/services.md
@@ -1,0 +1,199 @@
+# Anti-Detection Services
+
+External services that supplement the browser's built-in anti-detection.
+Use when the built-in stealth isn't sufficient for a target site.
+
+---
+
+## 2Captcha — CAPTCHA Solving
+
+Solves Cloudflare Turnstile, reCAPTCHA v2/v3, hCaptcha programmatically.
+
+- **Cost:** $1.45/1000 solves (~$0.00145 each)
+- **Speed:** 10-30s per challenge
+- **API:** REST + Python SDK
+
+```python
+from twocaptcha import TwoCaptcha
+solver = TwoCaptcha('API_KEY')
+
+# Solve Turnstile
+result = solver.turnstile(sitekey='0x4AAAAAAAxx', url='https://target.com/')
+# result['code'] is the token — inject as cf-turnstile-response input value
+
+# Solve reCAPTCHA v2
+result = solver.recaptcha(sitekey='6Lc...', url='https://target.com/')
+```
+
+**When to use:** Sites with Turnstile/reCAPTCHA that don't auto-resolve
+and human VNC intervention isn't available. Alternative to the built-in
+Telegram → VNC → human escalation flow.
+
+**Install:** `pip install 2captcha-python`
+
+---
+
+## Browserbase — Cloud Browser
+
+Cloud-hosted Chromium with real hardware, residential IP, auto CAPTCHA
+solving. Eliminates container fingerprint issues entirely.
+
+- **Cost:** $99/mo startup (500 browser hours) or x402 at $0.12/hr
+- **Connection:** WebSocket CDP endpoint for Playwright
+
+```python
+from browserbase import Browserbase
+from playwright.async_api import async_playwright
+
+client = Browserbase(api_key="...")
+session = client.sessions.create(project_id="...")
+
+async with async_playwright() as p:
+    browser = await p.chromium.connect_over_cdp(session.connect_url)
+    page = browser.contexts[0].pages[0]
+    await page.goto("https://target.com")
+```
+
+**When to use:** Fallback when Camoufox in the container gets detected
+(container fingerprint leaks, no GPU for WebGL). Cloud browser runs on
+real hardware with genuine GPU, full font set, residential IP.
+
+**Install:** `pip install browserbase`
+
+---
+
+## Residential Proxies — IP Reputation
+
+Datacenter IPs are scored low by fraud detection systems. Residential
+proxies route through real ISP connections.
+
+### Providers
+
+| Provider | Cost | Notes |
+|----------|------|-------|
+| PROXIES.SX | $4/GB shared | x402 (USDC) compatible, no signup |
+| Bright Data | $8-15/GB | Largest network, enterprise |
+| Oxylabs | $8-12/GB | Good API, ISP proxies |
+| Webshare | $5/GB | Budget option |
+
+**Note:** Agent Camo (agentcamo.com) is defunct — domain parked.
+
+### Integration with Camoufox
+
+```python
+from camoufox.async_api import AsyncCamoufox
+
+async with AsyncCamoufox(
+    proxy={"server": "http://proxy.example.com:8080",
+           "username": "user", "password": "pass"},
+    geoip=True,  # Auto-set timezone/locale from proxy IP
+) as browser:
+    page = await browser.new_page()
+```
+
+**When to use:** Target site scores IP reputation heavily (Ashby,
+Cloudflare-protected sites). Especially important when submitting
+from a datacenter/VPS where the IP geolocates to a hosting provider.
+
+---
+
+## x402 Protocol (Coinbase)
+
+HTTP 402 Payment Required protocol for agent micropayments. Some services
+above support x402 for account-free, pay-per-use access via USDC on Base.
+
+```python
+pip install "x402[httpx]"
+# Requires EVM wallet + USDC on Base chain
+# Auto-handles 402 responses with payment signatures
+```
+
+Not required for most services — traditional API keys are simpler.
+Consider x402 when you want no-account, pay-per-use access.
+
+---
+
+## GPU Passthrough (Hardware)
+
+Container environments lack real GPUs, causing WebGL fingerprint
+inconsistencies (software rendering vs. claimed GPU). Options:
+
+1. **Camoufox C++ spoofing** (default, no change needed): handles 95%
+   of sites by patching WebGL parameters at the engine level
+2. **virtio-gpu**: Add `vga: virtio` to Proxmox VM config, pass
+   `/dev/dri/` into Incus container. Mesa virgl rendering.
+3. **Intel GVT-g**: If host has 6th-10th gen Intel iGPU. Virtual GPU
+   with real Intel identifiers.
+4. **PCIe passthrough**: Dedicated GPU card ($25-30 for GT 710).
+   Perfect fingerprints.
+
+See `references/gpu-passthrough.md` for setup instructions.
+
+---
+
+## CDP Remote Browser — Drive User's Real Chrome
+
+The most reliable anti-detection approach: Genesis drives the user's actual
+browser via Chrome DevTools Protocol over an SSH tunnel. Real browser = real
+fingerprint = nothing to detect.
+
+### Setup
+```bash
+# On user's machine: launch Chrome with debug port
+google-chrome --remote-debugging-port=9222
+
+# SSH tunnel (from Genesis container to user's machine)
+ssh -L 9222:127.0.0.1:9222 user@machine
+```
+
+### Playwright connection
+```python
+from playwright.async_api import async_playwright
+
+async with async_playwright() as p:
+    browser = await p.chromium.connect_over_cdp("http://127.0.0.1:9222")
+    page = browser.contexts[0].pages[0]  # Use existing tab
+    # or: page = await browser.contexts[0].new_page()
+```
+
+**When to use:** ATS submissions with aggressive detection (Ashby, Mercor,
+any site with reCAPTCHA v3 or Fingerprint.com integration). Camoufox is
+fine for non-adversarial browsing.
+
+**Status:** Not yet integrated into browser.py. Planned as Step 2 of
+stealth Layer 3.
+
+---
+
+## Anti-Detection Landscape (researched 2026-04-23)
+
+### Camoufox limitations (confirmed)
+- 100% detected by reCAPTCHA v3 (GitHub Issue #284)
+- Detected by Akamai (Issue #555), Google (Issue #388)
+- Container detection (Issue #311) — not just containers, bare metal too
+- Viewport mismatch bug: JS reports 1920px while Playwright is 1280px
+- Maintenance stalled ~1 year, forks exist but degraded
+
+### No open-source tool bypasses reCAPTCHA v3
+A benchmark (techinz/browsers-benchmark) tested ALL major tools — they
+ALL score 0.9 on test sites (including stock Playwright). Production
+sites use additional signals beyond v3 scoring.
+
+Community consensus: use external CAPTCHA solvers when challenges appear,
+don't try to bypass the scoring itself.
+
+### Tools evaluated (April 2026)
+| Tool | Verdict |
+|------|---------|
+| CloakBrowser | Unverified 0.9 claim (single screenshot). Worth testing. |
+| Pydoll | WebDriver-free CDP. No reCAPTCHA claims. Behavioral only. |
+| Browser Use | LLM agent framework. Zero anti-detection. Cloud version adds stealth ($). |
+| Stagehand | TypeScript, Browserbase-oriented. Not useful for Genesis. |
+| rebrowser-patches | Fixes CDP leak only. Doesn't address reCAPTCHA. |
+| undetected-chromedriver | Still detected by v3 invisible (Issue #2280, Nov 2025). |
+
+### What actually matters for detection
+1. **IP reputation** (residential > datacenter) — #1 signal
+2. **Browser fingerprint** (real browser > any patched browser)
+3. **Behavioral realism** (we already have this via Layer 2)
+4. **CAPTCHA solver as safety net** (CapSolver ~$1/1K solves)

--- a/src/genesis/skills/stealth-browser/references/services.md
+++ b/src/genesis/skills/stealth-browser/references/services.md
@@ -85,7 +85,7 @@ from camoufox.async_api import AsyncCamoufox
 
 async with AsyncCamoufox(
     proxy={"server": "http://proxy.example.com:8080",
-           "username": "user", "password": "pass"},
+           "username": "user", "password": "***"},  # noqa: placeholder
     geoip=True,  # Auto-set timezone/locale from proxy IP
 ) as browser:
     page = await browser.new_page()

--- a/src/genesis/skills/stealth-browser/references/services.md
+++ b/src/genesis/skills/stealth-browser/references/services.md
@@ -127,7 +127,8 @@ inconsistencies (software rendering vs. claimed GPU). Options:
 4. **PCIe passthrough**: Dedicated GPU card ($25-30 for GT 710).
    Perfect fingerprints.
 
-See `references/gpu-passthrough.md` for setup instructions.
+GPU passthrough setup is host-specific — consult Proxmox/Incus docs for
+your hardware configuration.
 
 ---
 


### PR DESCRIPTION
## Summary

- Moves stealth-browser skill from private `~/.genesis/skills/` to the public repo (`src/genesis/skills/stealth-browser/`)
- Adds Layer 3 (VNC trusted input bridge) technique for bypassing Cloudflare Turnstile and other anti-bot checkboxes
- Adds PostToolUse hook that nudges sessions to load the stealth skill when Camoufox browser is active
- Removes the gitignore exclusion for stealth-browser

## Test plan

- [ ] Verify stealth-browser appears in skill catalog after `python scripts/generate_skill_catalog.py`
- [ ] Verify `browser_navigate` with Camoufox triggers the stealth skill nudge (PostToolUse hook)
- [ ] Verify VNC trusted input technique works against Cloudflare Turnstile (tested live during development)