### PR TITLE
feat(ego): wire publish action type for interact profile

### DIFF
--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1129,7 +1129,7 @@ def _sanitize_focus_summary(
     return focus, False
 
 
-_INTERACT_TYPES = frozenset({"outreach", "dispatch"})
+_INTERACT_TYPES = frozenset({"outreach", "dispatch", "publish"})
 _RESEARCH_TYPES = frozenset({"investigate"})
 
 


### PR DESCRIPTION
## Summary

- Adds `"publish"` to `_INTERACT_TYPES` in ego session dispatch so proposals with `action_type="publish"` get the `interact` profile (browser tools + outreach + memory writes) instead of defaulting to `observe` (read-only)
- Enables the user ego to autonomously dispatch content publishing tasks via background sessions with browser automation access
- Part of wiring the autonomous Medium publishing pipeline per master marketing plan

## Context

The user ego can already propose publishing actions, but the profile inference defaulted to `observe` for unknown action types. This meant dispatched sessions couldn't use browser tools needed by the content-publish skill.

One-line change: `frozenset({"outreach", "dispatch"})` → `frozenset({"outreach", "dispatch", "publish"})`.

## Test plan

- [x] `_infer_profile("publish")` returns `"interact"` (verified inline)
- [x] Existing action types unchanged: outreach→interact, dispatch→interact, investigate→research, unknown→observe
- [x] Lint passes (`ruff check`)
- [ ] User ego proposes publishing after seeing `article_ready` observation
- [ ] Dispatched session gets `interact` profile with browser tools