### PR TITLE
fix(sentinel+observability): alarm flapping cooldown + MemAvailable metric

### DIFF
--- a/src/genesis/observability/snapshots/infrastructure.py
+++ b/src/genesis/observability/snapshots/infrastructure.py
@@ -54,6 +54,27 @@ def _read_memory_stat() -> dict:
         return {}
 
 
+def _read_mem_available() -> int | None:
+    """Read MemAvailable from /proc/meminfo (bytes).
+
+    MemAvailable is the kernel's estimate of memory available for new
+    allocations without swapping. It accounts for reclaimable page cache
+    and slab, making it the right metric for OOM risk assessment (unlike
+    cgroup memory.current which includes non-reclaimable cache).
+
+    Returns None if unavailable.
+    """
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    # Format: "MemAvailable:   22612356 kB"
+                    return int(line.split()[1]) * 1024  # kB → bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
 # Module-level state for delta-based CPU reading (no blocking sleep)
 _last_cpu_reading: tuple[int, int, float] | None = None  # (idle, total, monotonic_time)
 
@@ -196,6 +217,14 @@ async def infrastructure(
                 "used_pct": round((total_mem[0] / limit * 100) if total_mem and total_mem[1] > 0 else anon_pct * 100, 1),
                 "anon_pct": round(anon_pct * 100, 1),
             }
+            # MemAvailable from /proc/meminfo — the kernel's estimate of
+            # memory available for new allocations without swapping. This is
+            # the metric that matters for OOM risk, not used_pct (which
+            # includes reclaimable file cache and inflates the number).
+            available_bytes = _read_mem_available()
+            if available_bytes is not None:
+                mem_info["available_gb"] = round(available_bytes / (1024**3), 1)
+                mem_info["available_pct"] = round(available_bytes / limit * 100, 1)
             mem_info.update(_read_memory_stat())
             infra["container_memory"] = mem_info
         else:

--- a/src/genesis/observability/snapshots/infrastructure.py
+++ b/src/genesis/observability/snapshots/infrastructure.py
@@ -224,7 +224,9 @@ async def infrastructure(
             available_bytes = _read_mem_available()
             if available_bytes is not None:
                 mem_info["available_gb"] = round(available_bytes / (1024**3), 1)
-                mem_info["available_pct"] = round(available_bytes / limit * 100, 1)
+                # Cap at 100% — on non-namespaced hosts, MemAvailable may
+                # exceed the cgroup limit, producing a nonsensical ratio.
+                mem_info["available_pct"] = round(min(available_bytes / limit * 100, 100.0), 1)
             mem_info.update(_read_memory_stat())
             infra["container_memory"] = mem_info
         else:

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -60,6 +60,13 @@ _ESCALATE_AT_ATTEMPT = len(_BACKOFF_SCHEDULE_S) + 1  # 5
 _ALARM_RING_SIZE = 3
 _ALARM_CONFIRMATION_COUNT = 2
 
+# Cooldown after a resolved dispatch. When a pattern resolves (including
+# "already resolved" no-action diagnoses), block re-dispatch for this
+# window. Prevents transient conditions that self-resolve from creating
+# infinite dispatch loops: alarm → dispatch → "already resolved" → clear
+# attempts → alarm recurs → dispatch again (every tick).
+_RESOLVED_COOLDOWN_S = 15 * 60  # 15 minutes
+
 
 def _serialize_request(request: SentinelRequest) -> str:
     """Serialize a SentinelRequest to JSON for state persistence."""
@@ -207,6 +214,13 @@ class SentinelDispatcher:
         # until the user intervenes. Value = iso timestamp of escalation.
         # Cleared on process restart or resolved dispatch of the same pattern.
         self._escalated_patterns: dict[str, str] = {}
+
+        # Resolved-pattern cooldown (in-memory; resets on restart).
+        # key = pattern string, value = monotonic timestamp of resolution.
+        # Prevents re-dispatch for _RESOLVED_COOLDOWN_S after a pattern
+        # resolves — stops the transient alarm → resolve → clear → re-alarm
+        # loop that caused 17 redundant dispatches in 2 hours.
+        self._resolved_cooldowns: dict[str, float] = {}
 
         # Ring buffer of alarm id sets seen on recent ticks. Drives 2-of-N
         # debouncing — a pattern must appear in ≥_ALARM_CONFIRMATION_COUNT
@@ -669,8 +683,13 @@ class SentinelDispatcher:
         if resolved:
             self._state.transition(SentinelState.HEALTHY, reason="resolved after action execution")
             self._state.escalated_count = 0  # Reset oscillation counter
+            # Record resolved-pattern cooldown BEFORE clearing attempts.
+            # This prevents re-dispatch for _RESOLVED_COOLDOWN_S even though
+            # attempts are cleared (the cooldown gate fires first).
+            if pattern:
+                self._resolved_cooldowns[pattern] = time.monotonic()
             # Clear backoff attempts for this pattern — the problem is fixed.
-            # Next occurrence starts from attempt 1.
+            # Next occurrence starts from attempt 1 (after cooldown expires).
             if pattern and pattern in self._pattern_attempts:
                 del self._pattern_attempts[pattern]
             if pattern and pattern in self._escalated_patterns:
@@ -1263,6 +1282,23 @@ class SentinelDispatcher:
         ready until cleared by a resolved dispatch or process restart.
         Rejected patterns are suppressed until their rejection window expires.
         """
+        # Check resolved-pattern cooldown (in-memory). If this pattern
+        # was recently resolved, block re-dispatch for _RESOLVED_COOLDOWN_S.
+        # This prevents transient self-resolving alarms from causing an
+        # infinite dispatch loop (alarm → resolve → clear attempts → alarm).
+        resolved_at = self._resolved_cooldowns.get(pattern)
+        if resolved_at is not None:
+            elapsed = time.monotonic() - resolved_at
+            if elapsed < _RESOLVED_COOLDOWN_S:
+                remaining_min = (_RESOLVED_COOLDOWN_S - elapsed) / 60
+                return (
+                    False,
+                    f"Pattern {pattern!r} resolved {elapsed / 60:.1f}m ago — "
+                    f"cooldown {remaining_min:.1f}m remaining",
+                )
+            # Cooldown expired — remove entry
+            del self._resolved_cooldowns[pattern]
+
         # Check persistent rejection window (survives restarts)
         rejected_until = self._state.rejected_patterns.get(pattern)
         if rejected_until:

--- a/tests/test_sentinel/test_dispatcher.py
+++ b/tests/test_sentinel/test_dispatcher.py
@@ -12,6 +12,7 @@ from genesis.sentinel.classifier import FireAlarm
 from genesis.sentinel.dispatcher import (
     _BACKOFF_SCHEDULE_S,
     _ESCALATE_AT_ATTEMPT,
+    _RESOLVED_COOLDOWN_S,
     SentinelDispatcher,
     SentinelRequest,
     SentinelResult,
@@ -388,6 +389,70 @@ class TestPatternResetOnResolve:
         # Pattern is recorded so next attempt hits backoff
         assert "memory:critical" in d._pattern_attempts
         assert len(d._pattern_attempts["memory:critical"]) == 1
+
+
+class TestResolvedCooldown:
+    """Verify that resolved patterns are blocked for _RESOLVED_COOLDOWN_S."""
+
+    @pytest.mark.asyncio
+    async def test_resolved_pattern_blocks_immediate_redispatch(self):
+        """After a pattern resolves, the same pattern is blocked by cooldown."""
+        d = _make_dispatcher()
+        d._state.started_at = "2020-01-01T00:00:00+00:00"
+        alarm = FireAlarm(tier=2, alert_id="memory:critical", severity="CRITICAL", message="mem")
+
+        with patch("genesis.sentinel.dispatcher.save_state"), \
+             patch("genesis.sentinel.dispatcher.write_last_run"), \
+             patch("genesis.sentinel.dispatcher.write_state_for_guardian"), \
+             patch("genesis.sentinel.dispatcher.append_log"):
+            # First dispatch: resolves
+            r1 = await d.dispatch(SentinelRequest(
+                trigger_source="fire_alarm",
+                trigger_reason="Tier 2 alarm",
+                tier=2, alarms=[alarm],
+            ))
+        assert r1.dispatched and r1.resolved
+
+        # Cooldown recorded
+        assert "memory:critical" in d._resolved_cooldowns
+
+        with patch("genesis.sentinel.dispatcher.save_state"), \
+             patch("genesis.sentinel.dispatcher.write_last_run"), \
+             patch("genesis.sentinel.dispatcher.write_state_for_guardian"), \
+             patch("genesis.sentinel.dispatcher.append_log"):
+            # Second dispatch: same pattern, should be blocked by cooldown
+            r2 = await d.dispatch(SentinelRequest(
+                trigger_source="fire_alarm",
+                trigger_reason="Tier 2 alarm",
+                tier=2, alarms=[alarm],
+            ))
+        assert not r2.dispatched
+        assert "cooldown" in r2.reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_cooldown_expires_after_window(self):
+        """After the cooldown window, the pattern dispatches again."""
+        d = _make_dispatcher()
+        d._state.started_at = "2020-01-01T00:00:00+00:00"
+        # Simulate a cooldown that already expired
+        d._resolved_cooldowns["memory:critical"] = time.monotonic() - (_RESOLVED_COOLDOWN_S + 1)
+
+        ready, reason = d._backoff_ready("memory:critical")
+        assert ready
+        # Expired cooldown should be cleaned up
+        assert "memory:critical" not in d._resolved_cooldowns
+
+    @pytest.mark.asyncio
+    async def test_cooldown_independent_per_pattern(self):
+        """Cooldown on one pattern doesn't block a different pattern."""
+        d = _make_dispatcher()
+        d._state.started_at = "2020-01-01T00:00:00+00:00"
+        # memory:critical is in cooldown
+        d._resolved_cooldowns["memory:critical"] = time.monotonic()
+
+        # Different pattern should be unaffected
+        ready, reason = d._backoff_ready("disk:critical")
+        assert ready
 
 
 class TestEscalation:


### PR DESCRIPTION
## Summary
- **Sentinel flapping fix**: Adds a 15-minute resolved-pattern cooldown to prevent infinite dispatch loops on transient self-resolving alarms (e.g., free-tier provider exhaustion). The root cause was `_finalize_dispatch()` clearing `_pattern_attempts` on resolve, allowing the same alarm to immediately re-trigger at attempt 0. Cost: ~$4.25/incident × 17 incidents = ~$72 wasted overnight.
- **MemAvailable metric**: Adds `available_gb` and `available_pct` fields to the infrastructure snapshot from `/proc/meminfo` MemAvailable. This is the kernel's actual estimate of memory available without swapping — unlike `used_pct` (memory.current/memory.max) which includes reclaimable file cache and reads ~89% when actual availability is ~65%. Additive change, no existing field removals.
- **available_pct cap**: Caps `available_pct` at 100% for non-namespaced hosts where MemAvailable may exceed the cgroup limit.

## Test plan
- [x] 48/48 tests pass (45 existing + 3 new cooldown tests)
- [x] `TestResolvedCooldown` covers: immediate re-dispatch blocked, cooldown expiry allows dispatch, independent per-pattern cooldown
- [x] Lint clean (ruff check)
- [x] Blast radius verified: dashboard (9 refs), health_alerts, ego context, watchdog — all untouched
- [ ] Verify `available_gb`/`available_pct` appear in `health_status` MCP after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)