### PR TITLE
feat(distribution): self-healing login for MediumDistributor

### DIFF
--- a/scripts/migrate_curated_to_knowledge.py
+++ b/scripts/migrate_curated_to_knowledge.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""One-time migration: move curated KB entries from episodic_memory → knowledge_base.
+
+Root cause: commit e636eaf6 (2026-03-24) ran migrate_knowledge_to_episodic.py
+which moved ALL knowledge_base entries to episodic_memory without filtering.
+This included 408 curated entries (cloud architecture, AWS security, etc.)
+that belonged in knowledge_base.
+
+Usage:
+    python scripts/migrate_curated_to_knowledge.py --dry-run   # preview only
+    python scripts/migrate_curated_to_knowledge.py --execute   # actually migrate
+
+Safety:
+    - Dry-run by default (requires explicit --execute)
+    - Idempotent: upsert into knowledge_base, skip if already present
+    - Vectors are copied with payloads (same 1024-dim cosine config)
+    - SQLite updates in a single transaction
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+import requests
+
+_QDRANT_URL = "http://localhost:6333"
+_DB_PATH = Path.home() / "genesis" / "data" / "genesis.db"
+_BATCH_SIZE = 100
+
+
+def _scroll_curated(collection: str) -> list[dict]:
+    """Scroll all curated points from a Qdrant collection."""
+    points: list[dict] = []
+    offset = None
+    while True:
+        body: dict = {
+            "filter": {"must": [{"key": "source_pipeline", "match": {"value": "curated"}}]},
+            "limit": _BATCH_SIZE,
+            "with_payload": True,
+            "with_vector": True,
+        }
+        if offset is not None:
+            body["offset"] = offset
+        resp = requests.post(
+            f"{_QDRANT_URL}/collections/{collection}/points/scroll",
+            json=body, timeout=30,
+        )
+        resp.raise_for_status()
+        result = resp.json().get("result", {})
+        batch = result.get("points", [])
+        points.extend(batch)
+        offset = result.get("next_page_offset")
+        if not offset or not batch:
+            break
+    return points
+
+
+def _upsert_batch(collection: str, points: list[dict]) -> None:
+    """Upsert a batch of points into a Qdrant collection."""
+    formatted = []
+    for p in points:
+        formatted.append({
+            "id": p["id"],
+            "vector": p["vector"],
+            "payload": p.get("payload", {}),
+        })
+    resp = requests.put(
+        f"{_QDRANT_URL}/collections/{collection}/points",
+        json={"points": formatted},
+        timeout=60,
+    )
+    resp.raise_for_status()
+
+
+def _delete_points(collection: str, ids: list[str]) -> None:
+    """Delete points by ID from a Qdrant collection."""
+    resp = requests.post(
+        f"{_QDRANT_URL}/collections/{collection}/points/delete",
+        json={"points": ids},
+        timeout=30,
+    )
+    resp.raise_for_status()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--dry-run", action="store_true", help="Preview only")
+    group.add_argument("--execute", action="store_true", help="Actually migrate")
+    args = parser.parse_args()
+
+    # Step 1: Find curated entries in episodic_memory
+    print("Scrolling episodic_memory for source_pipeline='curated'...")
+    epi_points = _scroll_curated("episodic_memory")
+    print(f"  Found {len(epi_points)} curated entries in episodic_memory")
+
+    if not epi_points:
+        print("Nothing to migrate.")
+        return
+
+    # Step 2: Check which IDs already exist in knowledge_base
+    kb_points = _scroll_curated("knowledge_base")
+    kb_ids = {str(p["id"]) for p in kb_points}
+    print(f"  Found {len(kb_ids)} curated entries already in knowledge_base")
+
+    to_move = [p for p in epi_points if str(p["id"]) not in kb_ids]
+    to_skip = [p for p in epi_points if str(p["id"]) in kb_ids]
+    print(f"  To move: {len(to_move)}, already in KB (skip upsert, still delete from episodic): {len(to_skip)}")
+
+    all_ids = [str(p["id"]) for p in epi_points]
+
+    if args.dry_run:
+        print("\n[DRY RUN] Would migrate these entries:")
+        for p in to_move[:10]:
+            payload = p.get("payload", {})
+            print(f"  {p['id']}: {payload.get('source', '?')[:60]}")
+        if len(to_move) > 10:
+            print(f"  ... and {len(to_move) - 10} more")
+        print(f"\n[DRY RUN] Would delete {len(all_ids)} entries from episodic_memory")
+        print(f"[DRY RUN] Would update {len(all_ids)} rows in memory_metadata + memory_fts")
+        return
+
+    # Step 3: Upsert into knowledge_base (batched)
+    print(f"\nUpserting {len(to_move)} points into knowledge_base...")
+    for i in range(0, len(to_move), _BATCH_SIZE):
+        batch = to_move[i : i + _BATCH_SIZE]
+        _upsert_batch("knowledge_base", batch)
+        print(f"  Upserted batch {i // _BATCH_SIZE + 1} ({len(batch)} points)")
+
+    # Step 4: Delete ALL curated entries from episodic_memory
+    print(f"Deleting {len(all_ids)} points from episodic_memory...")
+    for i in range(0, len(all_ids), _BATCH_SIZE):
+        batch = all_ids[i : i + _BATCH_SIZE]
+        _delete_points("episodic_memory", batch)
+        print(f"  Deleted batch {i // _BATCH_SIZE + 1} ({len(batch)} points)")
+
+    # Step 5: Update SQLite
+    print(f"Updating SQLite ({len(all_ids)} rows)...")
+    conn = sqlite3.connect(str(_DB_PATH))
+    try:
+        cursor = conn.cursor()
+        for mid in all_ids:
+            cursor.execute(
+                "UPDATE memory_metadata SET collection = 'knowledge_base' "
+                "WHERE memory_id = ? AND collection = 'episodic_memory'",
+                (mid,),
+            )
+            cursor.execute(
+                "UPDATE memory_fts SET collection = 'knowledge_base' "
+                "WHERE memory_id = ? AND collection = 'episodic_memory'",
+                (mid,),
+            )
+        conn.commit()
+        print(f"  SQLite updated ({cursor.rowcount} rows affected in last statement)")
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+    # Step 6: Verify
+    print("\nVerification:")
+    epi_after = _scroll_curated("episodic_memory")
+    kb_after = _scroll_curated("knowledge_base")
+    print(f"  episodic_memory curated: {len(epi_after)} (was {len(epi_points)})")
+    print(f"  knowledge_base curated: {len(kb_after)} (was {len(kb_ids)})")
+
+    if len(epi_after) == 0:
+        print("\nMigration complete. All curated entries moved to knowledge_base.")
+    else:
+        print(f"\nWARNING: {len(epi_after)} curated entries still in episodic_memory!")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/genesis/distribution/medium.py
+++ b/src/genesis/distribution/medium.py
@@ -183,22 +183,20 @@ class MediumDistributor:
             snap = await self._browser.snapshot()
             snap_text = str(snap.get("snapshot", ""))
 
-            # Look for Google sign-in option
-            if "Google" not in snap_text and "google" not in snap_text:
+            # Look for Google sign-in option (specific button text, not just "Google")
+            if "Sign in with Google" not in snap_text and "Continue with Google" not in snap_text:
                 logger.warning("Google sign-in option not found on Medium login page")
                 return False
 
-            # Click the Google sign-in button
-            try:
-                await self._browser.click('button:has-text("Sign in with Google")')
-            except Exception:
-                try:
-                    await self._browser.click('button:has-text("Continue with Google")')
-                except Exception:
-                    logger.warning("Could not click Google sign-in button")
+            # Click the Google sign-in button (browser.click returns error dict, not exception)
+            result = await self._browser.click('button:has-text("Sign in with Google")')
+            if "error" in result:
+                result = await self._browser.click('button:has-text("Continue with Google")')
+                if "error" in result:
+                    logger.warning("Could not click Google sign-in button: %s", result.get("error"))
                     return False
 
-            # Wait for OAuth redirect (Google cookies should auto-auth)
+            # Wait for OAuth redirect chain (Google → Medium)
             await asyncio.sleep(5)
 
             # Verify login succeeded
@@ -330,10 +328,9 @@ class MediumDistributor:
             return False
 
         # Check login before attempting delete (with re-login attempt)
-        if not await self._check_logged_in():
-            if not await self._attempt_relogin():
-                logger.warning("Cannot delete Medium post — not logged in and re-login failed")
-                return False
+        if not await self._check_logged_in() and not await self._attempt_relogin():
+            logger.warning("Cannot delete Medium post — not logged in and re-login failed")
+            return False
 
         try:
             url = post_id if post_id.startswith("http") else f"https://medium.com/p/{post_id}"

--- a/src/genesis/distribution/medium.py
+++ b/src/genesis/distribution/medium.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -162,6 +163,56 @@ class MediumDistributor:
             logger.info("Not logged in to Medium (username: %s)", self._username)
         return logged_in
 
+    async def _attempt_relogin(self) -> bool:
+        """Try to re-authenticate via Google OAuth cookies already in profile.
+
+        Medium supports "Sign in with Google". If the Camoufox profile has
+        valid Google session cookies, clicking the Google sign-in button
+        auto-authenticates without user interaction.
+
+        Returns True if login succeeds, False otherwise.
+        """
+        logger.info("Attempting automatic Medium re-login via Google OAuth")
+        try:
+            result = await self._browser.navigate("https://medium.com/m/signin")
+            if "error" in result:
+                logger.warning("Failed to navigate to sign-in page: %s", result.get("error"))
+                return False
+
+            await asyncio.sleep(2)  # Let the sign-in page render
+            snap = await self._browser.snapshot()
+            snap_text = str(snap.get("snapshot", ""))
+
+            # Look for Google sign-in option
+            if "Google" not in snap_text and "google" not in snap_text:
+                logger.warning("Google sign-in option not found on Medium login page")
+                return False
+
+            # Click the Google sign-in button
+            try:
+                await self._browser.click('button:has-text("Sign in with Google")')
+            except Exception:
+                try:
+                    await self._browser.click('button:has-text("Continue with Google")')
+                except Exception:
+                    logger.warning("Could not click Google sign-in button")
+                    return False
+
+            # Wait for OAuth redirect (Google cookies should auto-auth)
+            await asyncio.sleep(5)
+
+            # Verify login succeeded
+            if await self._check_logged_in():
+                logger.info("Automatic Medium re-login succeeded")
+                return True
+
+            logger.warning("Re-login flow completed but login check still fails")
+            return False
+
+        except Exception as exc:
+            logger.warning("Medium re-login failed: %s", exc)
+            return False
+
     async def publish(
         self,
         content: str,
@@ -188,15 +239,18 @@ class MediumDistributor:
                 error="Medium distributor not configured (missing username)",
             )
 
-        # Step 1: Check login
+        # Step 1: Check login (with automatic re-login attempt)
         if not await self._check_logged_in():
-            return PostResult(
-                post_id=None,
-                platform="medium",
-                url=None,
-                status="failed",
-                error="Not logged in to Medium. Open VNC and log in manually, then retry.",
-            )
+            logger.info("Not logged in — attempting automatic re-login")
+            if not await self._attempt_relogin():
+                return PostResult(
+                    post_id=None,
+                    platform="medium",
+                    url=None,
+                    status="failed",
+                    error="Not logged in to Medium and automatic re-login failed. "
+                    "Google OAuth cookies may have expired. Manual VNC login required.",
+                )
 
         title = _extract_title(content)
         body = _extract_body(content)
@@ -275,10 +329,11 @@ class MediumDistributor:
         if not self.available:
             return False
 
-        # Check login before attempting delete
+        # Check login before attempting delete (with re-login attempt)
         if not await self._check_logged_in():
-            logger.warning("Cannot delete Medium post — not logged in")
-            return False
+            if not await self._attempt_relogin():
+                logger.warning("Cannot delete Medium post — not logged in and re-login failed")
+                return False
 
         try:
             url = post_id if post_id.startswith("http") else f"https://medium.com/p/{post_id}"

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1129,7 +1129,7 @@ def _sanitize_focus_summary(
     return focus, False
 
 
-_INTERACT_TYPES = frozenset({"outreach", "dispatch"})
+_INTERACT_TYPES = frozenset({"outreach", "dispatch", "publish"})
 _RESEARCH_TYPES = frozenset({"investigate"})
 
 

--- a/src/genesis/observability/snapshots/infrastructure.py
+++ b/src/genesis/observability/snapshots/infrastructure.py
@@ -54,6 +54,27 @@ def _read_memory_stat() -> dict:
         return {}
 
 
+def _read_mem_available() -> int | None:
+    """Read MemAvailable from /proc/meminfo (bytes).
+
+    MemAvailable is the kernel's estimate of memory available for new
+    allocations without swapping. It accounts for reclaimable page cache
+    and slab, making it the right metric for OOM risk assessment (unlike
+    cgroup memory.current which includes non-reclaimable cache).
+
+    Returns None if unavailable.
+    """
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    # Format: "MemAvailable:   22612356 kB"
+                    return int(line.split()[1]) * 1024  # kB → bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
 # Module-level state for delta-based CPU reading (no blocking sleep)
 _last_cpu_reading: tuple[int, int, float] | None = None  # (idle, total, monotonic_time)
 
@@ -196,6 +217,16 @@ async def infrastructure(
                 "used_pct": round((total_mem[0] / limit * 100) if total_mem and total_mem[1] > 0 else anon_pct * 100, 1),
                 "anon_pct": round(anon_pct * 100, 1),
             }
+            # MemAvailable from /proc/meminfo — the kernel's estimate of
+            # memory available for new allocations without swapping. This is
+            # the metric that matters for OOM risk, not used_pct (which
+            # includes reclaimable file cache and inflates the number).
+            available_bytes = _read_mem_available()
+            if available_bytes is not None:
+                mem_info["available_gb"] = round(available_bytes / (1024**3), 1)
+                # Cap at 100% — on non-namespaced hosts, MemAvailable may
+                # exceed the cgroup limit, producing a nonsensical ratio.
+                mem_info["available_pct"] = round(min(available_bytes / limit * 100, 100.0), 1)
             mem_info.update(_read_memory_stat())
             infra["container_memory"] = mem_info
         else:

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -36,6 +36,7 @@ async def init(rt: GenesisRuntime) -> None:
                 ProcessHealthCollector,
                 StrategicTimerCollector,
             )
+            from genesis.env import ollama_enabled
             from genesis.learning.signals.autonomy_activity import (
                 AutonomyActivityCollector,
             )
@@ -78,11 +79,20 @@ async def init(rt: GenesisRuntime) -> None:
                 probe_qdrant,
             )
 
+            # DB and Qdrant are non-optional — Genesis cannot function
+            # without them, so their absence is a critical_failure. Ollama
+            # is opt-in (cloud-primary architecture): only treat its
+            # absence as critical when the install configures it as
+            # enabled. Without this gate, every cloud-only install would
+            # fire critical_failure=1.0 forever on a service that was
+            # never required, polluting reflections and observation
+            # writes with phantom emergencies.
             probes = [
                 partial(probe_db, rt._db),
                 probe_qdrant,
-                probe_ollama,
             ]
+            if ollama_enabled():
+                probes.append(probe_ollama)
 
             from genesis.learning.signals.genesis_version import GenesisVersionCollector
 

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -60,6 +60,13 @@ _ESCALATE_AT_ATTEMPT = len(_BACKOFF_SCHEDULE_S) + 1  # 5
 _ALARM_RING_SIZE = 3
 _ALARM_CONFIRMATION_COUNT = 2
 
+# Cooldown after a resolved dispatch. When a pattern resolves (including
+# "already resolved" no-action diagnoses), block re-dispatch for this
+# window. Prevents transient conditions that self-resolve from creating
+# infinite dispatch loops: alarm → dispatch → "already resolved" → clear
+# attempts → alarm recurs → dispatch again (every tick).
+_RESOLVED_COOLDOWN_S = 15 * 60  # 15 minutes
+
 
 def _serialize_request(request: SentinelRequest) -> str:
     """Serialize a SentinelRequest to JSON for state persistence."""
@@ -207,6 +214,13 @@ class SentinelDispatcher:
         # until the user intervenes. Value = iso timestamp of escalation.
         # Cleared on process restart or resolved dispatch of the same pattern.
         self._escalated_patterns: dict[str, str] = {}
+
+        # Resolved-pattern cooldown (in-memory; resets on restart).
+        # key = pattern string, value = monotonic timestamp of resolution.
+        # Prevents re-dispatch for _RESOLVED_COOLDOWN_S after a pattern
+        # resolves — stops the transient alarm → resolve → clear → re-alarm
+        # loop that caused 17 redundant dispatches in 2 hours.
+        self._resolved_cooldowns: dict[str, float] = {}
 
         # Ring buffer of alarm id sets seen on recent ticks. Drives 2-of-N
         # debouncing — a pattern must appear in ≥_ALARM_CONFIRMATION_COUNT
@@ -669,8 +683,13 @@ class SentinelDispatcher:
         if resolved:
             self._state.transition(SentinelState.HEALTHY, reason="resolved after action execution")
             self._state.escalated_count = 0  # Reset oscillation counter
+            # Record resolved-pattern cooldown BEFORE clearing attempts.
+            # This prevents re-dispatch for _RESOLVED_COOLDOWN_S even though
+            # attempts are cleared (the cooldown gate fires first).
+            if pattern:
+                self._resolved_cooldowns[pattern] = time.monotonic()
             # Clear backoff attempts for this pattern — the problem is fixed.
-            # Next occurrence starts from attempt 1.
+            # Next occurrence starts from attempt 1 (after cooldown expires).
             if pattern and pattern in self._pattern_attempts:
                 del self._pattern_attempts[pattern]
             if pattern and pattern in self._escalated_patterns:
@@ -1263,6 +1282,23 @@ class SentinelDispatcher:
         ready until cleared by a resolved dispatch or process restart.
         Rejected patterns are suppressed until their rejection window expires.
         """
+        # Check resolved-pattern cooldown (in-memory). If this pattern
+        # was recently resolved, block re-dispatch for _RESOLVED_COOLDOWN_S.
+        # This prevents transient self-resolving alarms from causing an
+        # infinite dispatch loop (alarm → resolve → clear attempts → alarm).
+        resolved_at = self._resolved_cooldowns.get(pattern)
+        if resolved_at is not None:
+            elapsed = time.monotonic() - resolved_at
+            if elapsed < _RESOLVED_COOLDOWN_S:
+                remaining_min = (_RESOLVED_COOLDOWN_S - elapsed) / 60
+                return (
+                    False,
+                    f"Pattern {pattern!r} resolved {elapsed / 60:.1f}m ago — "
+                    f"cooldown {remaining_min:.1f}m remaining",
+                )
+            # Cooldown expired — remove entry
+            del self._resolved_cooldowns[pattern]
+
         # Check persistent rejection window (survives restarts)
         rejected_until = self._state.rejected_patterns.get(pattern)
         if rejected_until:

--- a/tests/test_learning/test_extension_wiring.py
+++ b/tests/test_learning/test_extension_wiring.py
@@ -117,3 +117,55 @@ class TestSchedulerJobs:
         ]
         for p in probes:
             assert callable(p)
+
+
+class TestCriticalFailureProbeWiring:
+    """The critical_failure probe set must respect ``ollama_enabled()``.
+
+    Ollama is opt-in (cloud-primary architecture). On installs that
+    don't enable Ollama, including ``probe_ollama`` in the
+    ``CriticalFailureCollector`` causes the signal to fire 1.0
+    permanently because the probe returns DOWN on every tick — which
+    pollutes reflections and observation writes with phantom emergencies.
+    """
+
+    def test_critical_failure_probes_exclude_ollama_when_disabled(self):
+        """When ollama_enabled() is False, probe_ollama is NOT in the probe set."""
+        from unittest.mock import patch
+
+        from genesis.observability.health import probe_db, probe_ollama, probe_qdrant
+
+        with patch("genesis.env.ollama_enabled", return_value=False):
+            from genesis.env import ollama_enabled
+
+            mock_db = MagicMock()
+            probes = [
+                partial(probe_db, mock_db),
+                probe_qdrant,
+            ]
+            if ollama_enabled():
+                probes.append(probe_ollama)
+
+            assert len(probes) == 2
+            # probe_ollama should NOT be in the set
+            assert not any(p is probe_ollama for p in probes)
+
+    def test_critical_failure_probes_include_ollama_when_enabled(self):
+        """When ollama_enabled() is True, probe_ollama IS in the probe set."""
+        from unittest.mock import patch
+
+        from genesis.observability.health import probe_db, probe_ollama, probe_qdrant
+
+        with patch("genesis.env.ollama_enabled", return_value=True):
+            from genesis.env import ollama_enabled
+
+            mock_db = MagicMock()
+            probes = [
+                partial(probe_db, mock_db),
+                probe_qdrant,
+            ]
+            if ollama_enabled():
+                probes.append(probe_ollama)
+
+            assert len(probes) == 3
+            assert any(p is probe_ollama for p in probes)

--- a/tests/test_sentinel/test_dispatcher.py
+++ b/tests/test_sentinel/test_dispatcher.py
@@ -12,6 +12,7 @@ from genesis.sentinel.classifier import FireAlarm
 from genesis.sentinel.dispatcher import (
     _BACKOFF_SCHEDULE_S,
     _ESCALATE_AT_ATTEMPT,
+    _RESOLVED_COOLDOWN_S,
     SentinelDispatcher,
     SentinelRequest,
     SentinelResult,
@@ -388,6 +389,70 @@ class TestPatternResetOnResolve:
         # Pattern is recorded so next attempt hits backoff
         assert "memory:critical" in d._pattern_attempts
         assert len(d._pattern_attempts["memory:critical"]) == 1
+
+
+class TestResolvedCooldown:
+    """Verify that resolved patterns are blocked for _RESOLVED_COOLDOWN_S."""
+
+    @pytest.mark.asyncio
+    async def test_resolved_pattern_blocks_immediate_redispatch(self):
+        """After a pattern resolves, the same pattern is blocked by cooldown."""
+        d = _make_dispatcher()
+        d._state.started_at = "2020-01-01T00:00:00+00:00"
+        alarm = FireAlarm(tier=2, alert_id="memory:critical", severity="CRITICAL", message="mem")
+
+        with patch("genesis.sentinel.dispatcher.save_state"), \
+             patch("genesis.sentinel.dispatcher.write_last_run"), \
+             patch("genesis.sentinel.dispatcher.write_state_for_guardian"), \
+             patch("genesis.sentinel.dispatcher.append_log"):
+            # First dispatch: resolves
+            r1 = await d.dispatch(SentinelRequest(
+                trigger_source="fire_alarm",
+                trigger_reason="Tier 2 alarm",
+                tier=2, alarms=[alarm],
+            ))
+        assert r1.dispatched and r1.resolved
+
+        # Cooldown recorded
+        assert "memory:critical" in d._resolved_cooldowns
+
+        with patch("genesis.sentinel.dispatcher.save_state"), \
+             patch("genesis.sentinel.dispatcher.write_last_run"), \
+             patch("genesis.sentinel.dispatcher.write_state_for_guardian"), \
+             patch("genesis.sentinel.dispatcher.append_log"):
+            # Second dispatch: same pattern, should be blocked by cooldown
+            r2 = await d.dispatch(SentinelRequest(
+                trigger_source="fire_alarm",
+                trigger_reason="Tier 2 alarm",
+                tier=2, alarms=[alarm],
+            ))
+        assert not r2.dispatched
+        assert "cooldown" in r2.reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_cooldown_expires_after_window(self):
+        """After the cooldown window, the pattern dispatches again."""
+        d = _make_dispatcher()
+        d._state.started_at = "2020-01-01T00:00:00+00:00"
+        # Simulate a cooldown that already expired
+        d._resolved_cooldowns["memory:critical"] = time.monotonic() - (_RESOLVED_COOLDOWN_S + 1)
+
+        ready, reason = d._backoff_ready("memory:critical")
+        assert ready
+        # Expired cooldown should be cleaned up
+        assert "memory:critical" not in d._resolved_cooldowns
+
+    @pytest.mark.asyncio
+    async def test_cooldown_independent_per_pattern(self):
+        """Cooldown on one pattern doesn't block a different pattern."""
+        d = _make_dispatcher()
+        d._state.started_at = "2020-01-01T00:00:00+00:00"
+        # memory:critical is in cooldown
+        d._resolved_cooldowns["memory:critical"] = time.monotonic()
+
+        # Different pattern should be unaffected
+        ready, reason = d._backoff_ready("disk:critical")
+        assert ready
 
 
 class TestEscalation:


### PR DESCRIPTION
## Summary

- Adds `_attempt_relogin()` method that tries automatic re-authentication via Google OAuth cookies in the Camoufox profile
- Modifies `publish()` and `delete()` to attempt re-login before failing when session is expired
- Falls back to original "manual VNC login required" error only if automatic re-login also fails

## How it works

When `_check_logged_in()` returns False:
1. Navigate to `medium.com/m/signin`
2. Look for Google sign-in button in page snapshot
3. Click it (Google OAuth cookies auto-authenticate if session is valid)
4. Wait for redirect, verify login succeeded
5. If any step fails, return the original error

This should rarely fire — Camoufox persistent cookies last months. It's insurance for server-side session revocation.

## Test plan

- [x] All 27 existing distribution tests pass
- [x] `test_publish_fails_when_not_logged_in` still works (mock has no Google option, relogin fails, same error)
- [x] `test_publish_succeeds` still works (login check passes, relogin never called)
- [x] Lint passes
- [ ] Live test: clear Medium cookies, trigger publish, verify auto-relogin