### PR TITLE
fix(surplus): operational fixes — zombie approvals, backup verification, failure visibility

### DIFF
--- a/config/surplus.yaml
+++ b/config/surplus.yaml
@@ -13,11 +13,11 @@ jobs:
   code_audit_hours: 12
   code_index_hours: 4
   recon_gather_hours: 84       # ~3.5 days
-  maintenance_hours: 6
+  maintenance_hours: 24
   analytical_hours: 12
   follow_up_dispatch_minutes: 5
   memory_extraction_hours: 2
-  j9_eval_batch_hours: 24
+  j9_eval_batch_hours: 0          # Disabled: 100% error rate, no value
 
 task_defaults:
   code_audit:                { priority: 0.5, drive: competence,   tier: free_api }

--- a/src/genesis/autonomy/approval_gate.py
+++ b/src/genesis/autonomy/approval_gate.py
@@ -454,6 +454,8 @@ class AutonomousCliApprovalGate:
                 status_str = str(row.get("status") or "")
                 if status_str == "rejected":
                     continue
+                if status_str in ("cancelled", "expired"):
+                    continue
                 if status_str == "approved" and row.get("consumed_at"):
                     continue
                 # Timeout guard: auto-expire pending requests past timeout_at.

--- a/src/genesis/db/crud/surplus_tasks.py
+++ b/src/genesis/db/crud/surplus_tasks.py
@@ -98,6 +98,30 @@ async def mark_failed(
     return cursor.rowcount > 0
 
 
+async def consecutive_failures(
+    db: aiosqlite.Connection,
+    task_type: str,
+) -> int:
+    """Count consecutive recent failures for a task type.
+
+    Looks at the most recent tasks of this type and counts how many
+    consecutive ones have status='failed', stopping at the first
+    non-failed task.
+    """
+    cursor = await db.execute(
+        "SELECT status FROM surplus_tasks WHERE task_type = ? "
+        "ORDER BY created_at DESC LIMIT 20",
+        (task_type,),
+    )
+    count = 0
+    for row in await cursor.fetchall():
+        if row[0] == "failed":
+            count += 1
+        else:
+            break
+    return count
+
+
 async def recover_stuck(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -312,6 +312,14 @@ _CALL_SITE_META: dict[str, dict] = {
         "frequency": "On provider recovery",
         "model_tier": "embedding",
     },
+    "contribution_gate": {
+        "description": "Evaluates whether a community code fix is already upstream before creating a PR. Part of the contribution pipeline.",
+        "category": "assessment",
+        "frequency": "Per landed fix commit (contribution pipeline)",
+        "cost_policy": "Free primary, paid fallback",
+        "model_tier": "slm",
+        "status_reason": "WIRED",
+    },
     # ── PARTIALLY WIRED: code exists, conditions haven't triggered yet ─
     "27_pre_execution_assessment": {
         "description": "Sanity-checks proposed task execution plans before committing resources. Opus via CC invoker, route_call fallback.",

--- a/src/genesis/surplus/maintenance.py
+++ b/src/genesis/surplus/maintenance.py
@@ -13,6 +13,7 @@ Task types handled:
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -128,20 +129,36 @@ class BackupVerificationExecutor:
         self._max_age_hours = max_age_hours
 
     async def execute(self, task: SurplusTask) -> ExecutorResult:
-        backup_dir = Path.home() / ".genesis" / "backups"
-        marker_file = backup_dir / "last_backup_at"
+        status_file = Path.home() / ".genesis" / "backup_status.json"
         lines: list[str] = ["Backup verification:"]
         stale = False
 
-        if marker_file.exists():
+        if status_file.exists():
             try:
-                ts_str = marker_file.read_text().strip()
+                data = json.loads(status_file.read_text())
+                ts_str = data.get("timestamp", "")
+                success = data.get("success", False)
                 last_backup = datetime.fromisoformat(ts_str)
                 age = datetime.now(UTC) - last_backup
                 age_hours = age.total_seconds() / 3600
-                lines.append(f"  Last backup: {ts_str} ({age_hours:.1f}h ago)")
 
-                if age_hours > self._max_age_hours:
+                lines.append(f"  Last backup: {ts_str} ({age_hours:.1f}h ago)")
+                lines.append(f"  Success: {success}")
+
+                if data.get("duration_s"):
+                    lines.append(f"  Duration: {data['duration_s']}s")
+                if data.get("sqlite_lines"):
+                    lines.append(f"  SQLite rows: {data['sqlite_lines']:,}")
+                if data.get("qdrant_collections") is not None:
+                    lines.append(f"  Qdrant collections: {data['qdrant_collections']}")
+                if data.get("secrets_encrypted") is not None:
+                    lines.append(f"  Secrets encrypted: {data['secrets_encrypted']}")
+
+                if not success:
+                    stale = True
+                    reason = data.get("failure_reason") or "unknown"
+                    lines.append(f"  WARNING: Last backup FAILED — {reason}")
+                elif age_hours > self._max_age_hours:
                     stale = True
                     lines.append(
                         f"  WARNING: Backup is {age_hours:.0f}h old "
@@ -149,29 +166,12 @@ class BackupVerificationExecutor:
                     )
                 else:
                     lines.append("  Status: OK (within retention window)")
-            except (ValueError, OSError) as e:
-                lines.append(f"  Error reading backup marker: {e}")
+            except (ValueError, OSError, json.JSONDecodeError, KeyError) as e:
+                lines.append(f"  Error reading backup status: {e}")
                 stale = True
         else:
-            # Check if backup directory has any recent files
-            if backup_dir.is_dir():
-                latest = _newest_file(backup_dir)
-                if latest:
-                    age = datetime.now(UTC) - datetime.fromtimestamp(
-                        latest.stat().st_mtime, tz=UTC
-                    )
-                    age_hours = age.total_seconds() / 3600
-                    lines.append(
-                        f"  No marker file. Newest backup file: "
-                        f"{latest.name} ({age_hours:.1f}h ago)"
-                    )
-                    stale = age_hours > self._max_age_hours
-                else:
-                    lines.append("  No backup marker and no backup files found.")
-                    stale = True
-            else:
-                lines.append(f"  Backup directory not found: {backup_dir}")
-                stale = True
+            lines.append(f"  Backup status file not found: {status_file}")
+            stale = True
 
         content = "\n".join(lines)
         return ExecutorResult(
@@ -335,19 +335,3 @@ def _fmt_bytes(n: int) -> str:
     if n < 1024 * 1024 * 1024:
         return f"{n / (1024 * 1024):.1f} MB"
     return f"{n / (1024 * 1024 * 1024):.2f} GB"
-
-
-def _newest_file(directory: Path) -> Path | None:
-    """Find the most recently modified file in a directory."""
-    newest = None
-    newest_mtime = 0.0
-    for f in directory.iterdir():
-        if f.is_file():
-            try:
-                mtime = f.stat().st_mtime
-                if mtime > newest_mtime:
-                    newest_mtime = mtime
-                    newest = f
-            except OSError:
-                continue
-    return newest

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -694,6 +694,7 @@ class SurplusScheduler:
                     )
             except Exception:
                 logger.debug("Autonomy correction signal failed (non-fatal)", exc_info=True)
+            await self._maybe_observe_failure(task, "executor_exception")
             return False
 
         if not result.success:
@@ -711,6 +712,7 @@ class SurplusScheduler:
                     )
             except Exception:
                 logger.debug("Autonomy correction signal failed (non-fatal)", exc_info=True)
+            await self._maybe_observe_failure(task, result.error or "unknown")
             return False
 
         # 6. Write to staging (with content-hash dedup + quality gate)
@@ -843,6 +845,36 @@ class SurplusScheduler:
 
         logger.info("Surplus task %s completed (staging=%s)", task.id, staging_id)
         return True
+
+    async def _maybe_observe_failure(self, task, reason: str) -> None:
+        """Create an observation if a task type has 3+ consecutive failures."""
+        try:
+            from genesis.db.crud import observations, surplus_tasks
+
+            count = await surplus_tasks.consecutive_failures(
+                self._db, str(task.task_type),
+            )
+            if count >= 3:
+                obs_id = f"surplus_failing_{task.task_type}"
+                await observations.upsert(
+                    self._db,
+                    id=obs_id,
+                    source="surplus_monitor",
+                    type="surplus_task_failing",
+                    content=(
+                        f"Surplus task {task.task_type} has failed "
+                        f"{count} consecutive times. Last reason: {reason}"
+                    ),
+                    priority="high",
+                    category="infrastructure",
+                    created_at=self._clock().isoformat(),
+                )
+                logger.warning(
+                    "Surplus task %s: %d consecutive failures, observation created",
+                    task.task_type, count,
+                )
+        except Exception:
+            logger.debug("Failed to create failure observation", exc_info=True)
 
     async def _dispatch_loop(self) -> None:
         """Scheduled dispatch callback."""

--- a/tests/test_db/test_surplus_tasks.py
+++ b/tests/test_db/test_surplus_tasks.py
@@ -166,3 +166,32 @@ async def test_delete(db):
     assert await surplus_tasks.delete(db, "st-1") is True
     assert await surplus_tasks.get_by_id(db, "st-1") is None
     assert await surplus_tasks.delete(db, "st-1") is False
+
+
+@pytest.mark.asyncio
+async def test_consecutive_failures(db):
+    """Counts consecutive failed tasks, stopping at first non-failed."""
+    # Create tasks: completed, then 3 failed (newest first by created_at)
+    await surplus_tasks.create(
+        db, id="st-ok", task_type="backup_verification", compute_tier="slm",
+        priority=0.5, drive_alignment="preservation", created_at="2026-03-04T00:00:00Z",
+    )
+    await surplus_tasks.mark_running(db, "st-ok", started_at="2026-03-04T00:01:00Z")
+    await surplus_tasks.mark_completed(db, "st-ok", completed_at="2026-03-04T00:02:00Z")
+
+    for i in range(1, 4):
+        tid = f"st-fail-{i}"
+        await surplus_tasks.create(
+            db, id=tid, task_type="backup_verification", compute_tier="slm",
+            priority=0.5, drive_alignment="preservation",
+            created_at=f"2026-03-04T0{i}:00:00Z",
+        )
+        await surplus_tasks.mark_running(db, tid, started_at=f"2026-03-04T0{i}:01:00Z")
+        await surplus_tasks.mark_failed(db, tid, failure_reason="test failure")
+
+    count = await surplus_tasks.consecutive_failures(db, "backup_verification")
+    assert count == 3
+
+    # Different task type should return 0
+    count = await surplus_tasks.consecutive_failures(db, "brainstorm")
+    assert count == 0

--- a/tests/test_surplus/test_maintenance.py
+++ b/tests/test_surplus/test_maintenance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -90,8 +91,8 @@ class TestDiskCleanup:
 
 class TestBackupVerification:
     @pytest.mark.asyncio
-    async def test_no_backup_dir(self, tmp_path, monkeypatch):
-        """Reports stale when backup dir doesn't exist."""
+    async def test_no_status_file(self, tmp_path, monkeypatch):
+        """Reports stale when backup_status.json doesn't exist."""
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         executor = BackupVerificationExecutor()
         result = await executor.execute(_make_task(TaskType.BACKUP_VERIFICATION))
@@ -99,35 +100,66 @@ class TestBackupVerification:
         assert result.insights[0]["backup_stale"] is True
 
     @pytest.mark.asyncio
-    async def test_fresh_marker(self, tmp_path, monkeypatch):
-        """Reports OK when backup marker is recent."""
+    async def test_fresh_backup(self, tmp_path, monkeypatch):
+        """Reports OK when backup_status.json shows recent success."""
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        backup_dir = tmp_path / ".genesis" / "backups"
-        backup_dir.mkdir(parents=True)
-        marker = backup_dir / "last_backup_at"
-        marker.write_text(datetime.now(UTC).isoformat())
+        genesis_dir = tmp_path / ".genesis"
+        genesis_dir.mkdir(parents=True)
+        status = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "success": True,
+            "duration_s": 120,
+            "sqlite_lines": 300000,
+            "qdrant_collections": 2,
+            "secrets_encrypted": True,
+        }
+        (genesis_dir / "backup_status.json").write_text(json.dumps(status))
 
         executor = BackupVerificationExecutor()
         result = await executor.execute(_make_task(TaskType.BACKUP_VERIFICATION))
         assert result.success is True
         assert result.insights[0]["backup_stale"] is False
         assert "OK" in result.content
+        assert "300,000" in result.content  # sqlite_lines formatted
 
     @pytest.mark.asyncio
-    async def test_stale_marker(self, tmp_path, monkeypatch):
+    async def test_stale_backup(self, tmp_path, monkeypatch):
         """Reports stale when backup is older than threshold."""
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        backup_dir = tmp_path / ".genesis" / "backups"
-        backup_dir.mkdir(parents=True)
-        marker = backup_dir / "last_backup_at"
+        genesis_dir = tmp_path / ".genesis"
+        genesis_dir.mkdir(parents=True)
         old_time = datetime.now(UTC) - timedelta(hours=48)
-        marker.write_text(old_time.isoformat())
+        status = {
+            "timestamp": old_time.isoformat(),
+            "success": True,
+            "duration_s": 120,
+        }
+        (genesis_dir / "backup_status.json").write_text(json.dumps(status))
 
         executor = BackupVerificationExecutor(max_age_hours=24)
         result = await executor.execute(_make_task(TaskType.BACKUP_VERIFICATION))
         assert result.success is True
         assert result.insights[0]["backup_stale"] is True
         assert "WARNING" in result.content
+
+    @pytest.mark.asyncio
+    async def test_failed_backup(self, tmp_path, monkeypatch):
+        """Reports stale when last backup failed."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        genesis_dir = tmp_path / ".genesis"
+        genesis_dir.mkdir(parents=True)
+        status = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "success": False,
+            "failure_reason": "qdrant dump failed",
+        }
+        (genesis_dir / "backup_status.json").write_text(json.dumps(status))
+
+        executor = BackupVerificationExecutor()
+        result = await executor.execute(_make_task(TaskType.BACKUP_VERIFICATION))
+        assert result.success is True
+        assert result.insights[0]["backup_stale"] is True
+        assert "FAILED" in result.content
 
 
 # ── DeadLetterReplayExecutor ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Zombie approval fix**: `_find_existing()` in approval_gate.py now skips `cancelled` and `expired` rows, preventing dead approvals from being resurrected and re-sent to Telegram
- **Backup verification fix**: Reads `~/.genesis/backup_status.json` (written by backup.sh) instead of nonexistent `~/.genesis/backups/last_backup_at` marker — 33 consecutive false failures eliminated
- **J9 eval batch disabled**: Set `j9_eval_batch_hours: 0` — 100% error rate, no value produced
- **Surplus failure visibility**: Creates observations on 3+ consecutive task failures — surfaces in awareness loop, ego context, and dashboard
- **Maintenance cadence reduced**: 6h → 24h for disk_cleanup, db_maintenance, backup_verification, dead_letter_replay
- **Contribution gate metadata**: Added to `_CALL_SITE_META` for neural monitor display

## Test plan

- [x] All 12 approval gate tests pass
- [x] All 13 surplus maintenance tests pass (4 backup verification tests rewritten + new `test_failed_backup`)
- [x] All 12 surplus scheduler tests pass
- [x] All 11 surplus_tasks CRUD tests pass (new `test_consecutive_failures`)
- [x] All 18 sentinel classifier + call site tests pass
- [x] Ruff lint clean on all 8 changed files
- [x] Code review passed (superpowers:code-reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)