### PR TITLE
feat(ego): realist gate + cross-ego isolation + capability map + reactive cycles + model tiering (Layers 3-6)

### DIFF
--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -1027,11 +1027,18 @@ async def _try_bare_proposal_resolution(ctx: HandlerContext, msg) -> bool:
                 reason,
             )
         else:
-            # Get most recent pending proposals to find their batch
-            pending = await ego_crud.list_pending_proposals(ctx.db)
+            # Get most recent pending proposals — prefer user ego to avoid
+            # cross-ego conflation (bare replies are from the user).
+            pending = await ego_crud.list_pending_proposals(
+                ctx.db, ego_source="user_ego_cycle",
+            )
+            if not pending:
+                # Fall back to any pending (handles pre-migration NULL ego_source)
+                pending = await ego_crud.list_pending_proposals(ctx.db)
             if not pending:
                 return False
-            batch_id = pending[0].get("batch_id")
+            # Use the MOST RECENT batch (user sees latest digest at top)
+            batch_id = pending[-1].get("batch_id")
             if not batch_id:
                 return False
 

--- a/src/genesis/db/crud/capability_map.py
+++ b/src/genesis/db/crud/capability_map.py
@@ -16,6 +16,9 @@ import aiosqlite
 logger = logging.getLogger(__name__)
 
 
+_TREND_THRESHOLD = 0.05  # 5% change threshold for trend detection
+
+
 async def upsert(
     db: aiosqlite.Connection,
     *,
@@ -25,20 +28,46 @@ async def upsert(
     trend: str = "stable",
     evidence_summary: str = "",
 ) -> str:
-    """Insert or update a capability map entry for a domain."""
+    """Insert or update a capability map entry for a domain.
+
+    Automatically computes trend by comparing new confidence against
+    the existing score (>5% change = improving/declining).
+    """
     now = datetime.now(UTC).isoformat()
     cid = uuid.uuid4().hex[:16]
+
+    # Read current confidence for trend detection
+    cur = await db.execute(
+        "SELECT confidence FROM capability_map WHERE domain = ?",
+        (domain,),
+    )
+    row = await cur.fetchone()
+    previous_confidence = row[0] if row else None
+
+    # Compute trend from delta (only when we have previous data + enough samples)
+    if previous_confidence is not None and sample_size >= 3:
+        delta = confidence - previous_confidence
+        if delta > _TREND_THRESHOLD:
+            trend = "improving"
+        elif delta < -_TREND_THRESHOLD:
+            trend = "declining"
+        else:
+            trend = "stable"
+
     await db.execute(
         """INSERT INTO capability_map
-           (id, domain, confidence, sample_size, trend, evidence_summary, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?)
+           (id, domain, confidence, sample_size, trend, evidence_summary,
+            updated_at, previous_confidence)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(domain) DO UPDATE SET
+             previous_confidence = capability_map.confidence,
              confidence = excluded.confidence,
              sample_size = excluded.sample_size,
              trend = excluded.trend,
              evidence_summary = excluded.evidence_summary,
              updated_at = excluded.updated_at""",
-        (cid, domain, confidence, sample_size, trend, evidence_summary, now),
+        (cid, domain, confidence, sample_size, trend, evidence_summary,
+         now, previous_confidence),
     )
     await db.commit()
     return cid

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -224,6 +224,9 @@ async def create_proposal(
     execution_plan: str | None = None,
     recurring: bool = False,
     memory_basis: str = "",
+    realist_verdict: str | None = None,
+    realist_reasoning: str | None = None,
+    ego_source: str | None = None,
 ) -> str:
     """Insert a new ego proposal. Returns the id."""
     if created_at is None:
@@ -233,8 +236,9 @@ async def create_proposal(
            (id, action_type, action_category, content, rationale,
             confidence, urgency, alternatives, status, cycle_id,
             batch_id, created_at, expires_at, rank, execution_plan,
-            recurring, memory_basis)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            recurring, memory_basis, realist_verdict, realist_reasoning,
+            ego_source)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             id,
             action_type,
@@ -253,6 +257,9 @@ async def create_proposal(
             execution_plan,
             1 if recurring else 0,
             memory_basis,
+            realist_verdict,
+            realist_reasoning,
+            ego_source,
         ),
     )
     await db.commit()
@@ -281,11 +288,27 @@ async def list_proposals_by_batch(
     return [dict(r) for r in await cursor.fetchall()]
 
 
-async def list_pending_proposals(db: aiosqlite.Connection) -> list[dict]:
-    """All pending proposals, oldest first."""
-    cursor = await db.execute(
-        "SELECT * FROM ego_proposals WHERE status = 'pending' ORDER BY created_at ASC",
-    )
+async def list_pending_proposals(
+    db: aiosqlite.Connection,
+    *,
+    ego_source: str | None = None,
+) -> list[dict]:
+    """All pending proposals, oldest first.
+
+    If ``ego_source`` is provided, only returns proposals from that ego.
+    NULL ego_source proposals (pre-migration) match any filter.
+    """
+    if ego_source:
+        cursor = await db.execute(
+            "SELECT * FROM ego_proposals "
+            "WHERE status = 'pending' AND (ego_source = ? OR ego_source IS NULL) "
+            "ORDER BY created_at ASC",
+            (ego_source,),
+        )
+    else:
+        cursor = await db.execute(
+            "SELECT * FROM ego_proposals WHERE status = 'pending' ORDER BY created_at ASC",
+        )
     return [dict(r) for r in await cursor.fetchall()]
 
 

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1091,6 +1091,24 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
     # lack rows. Without backfill, the "recent" dashboard view is empty.
     await _migrate_backfill_memory_metadata(db)
 
+    # Ego proposals: realist gate annotations (dreamer/realist architecture).
+    await _try_alter(db,
+        "ALTER TABLE ego_proposals ADD COLUMN realist_verdict TEXT",
+        "ego_proposals.realist_verdict")
+    await _try_alter(db,
+        "ALTER TABLE ego_proposals ADD COLUMN realist_reasoning TEXT",
+        "ego_proposals.realist_reasoning")
+
+    # Ego proposals: ego_source for cross-ego isolation.
+    await _try_alter(db,
+        "ALTER TABLE ego_proposals ADD COLUMN ego_source TEXT",
+        "ego_proposals.ego_source")
+
+    # Capability map: previous_confidence for trend detection.
+    await _try_alter(db,
+        "ALTER TABLE capability_map ADD COLUMN previous_confidence REAL",
+        "capability_map.previous_confidence")
+
     # World model tables: user goals and contacts for ego world model.
     await _migrate_world_model_tables(db)
 

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -770,7 +770,10 @@ TABLES = {
             rank            INTEGER,                  -- board position (lower = higher priority)
             execution_plan  TEXT,                     -- dispatch instructions for approved proposals
             recurring       INTEGER DEFAULT 0,        -- 1 if ongoing/recurring commitment
-            memory_basis    TEXT DEFAULT ''            -- non-obvious memory attribution
+            memory_basis    TEXT DEFAULT '',           -- non-obvious memory attribution
+            realist_verdict  TEXT,                     -- realist gate: pass/amend/reject
+            realist_reasoning TEXT,                    -- realist gate: explanation
+            ego_source       TEXT                     -- which ego created this (user_ego_cycle / genesis_ego_cycle)
         )
     """,
     "ego_state": """
@@ -810,7 +813,8 @@ TABLES = {
             trend           TEXT DEFAULT 'stable'
                 CHECK (trend IN ('improving', 'stable', 'declining')),
             evidence_summary TEXT,                        -- brief rationale
-            updated_at      TEXT NOT NULL
+            updated_at      TEXT NOT NULL,
+            previous_confidence REAL                      -- last refresh score for trend detection
         )
     """,
     # ── Behavioral Immune System (BIS) ───────────────────────────────────────

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -85,6 +85,19 @@ class EgoCadenceManager:
         # Prevent concurrent cycles (interval + morning could overlap)
         self._lock = asyncio.Lock()
 
+        # Deep-think counter: every Nth proactive cycle uses Opus instead
+        # of the ego's base model. Only meaningful for egos that run Sonnet
+        # by default (Genesis ego). User ego already runs Opus proactive.
+        self._deep_think_interval = 5
+        self._proactive_cycle_count = 0
+
+        # Reactive event queue: events push here, debounce loop drains
+        self._reactive_queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=100)
+        self._reactive_task: asyncio.Task | None = None
+        self._reactive_debounce_s = 300  # 5 minutes
+        self._reactive_max_per_hour = 3
+        self._reactive_timestamps: list[datetime] = []
+
     # -- Lifecycle ---------------------------------------------------------
 
     async def start(self) -> None:
@@ -119,6 +132,9 @@ class EgoCadenceManager:
             misfire_grace_time=300,
         )
         self._scheduler.start()
+        self._reactive_task = asyncio.create_task(
+            self._reactive_loop(), name=f"ego_reactive_{id(self)}",
+        )
         self._running = True
         morning_str = (
             f", morning={self._config.morning_report_hour:02d}:"
@@ -128,13 +144,16 @@ class EgoCadenceManager:
             else ", morning=disabled"
         )
         logger.info(
-            "Ego cadence started (interval=%dm%s)",
+            "Ego cadence started (interval=%dm%s, reactive=enabled)",
             self._current_interval,
             morning_str,
         )
 
     async def stop(self) -> None:
-        """Shut down APScheduler."""
+        """Shut down APScheduler and reactive loop."""
+        if self._reactive_task is not None:
+            self._reactive_task.cancel()
+            self._reactive_task = None
         if self._scheduler.running:
             self._scheduler.shutdown(wait=False)
         self._running = False
@@ -166,10 +185,104 @@ class EgoCadenceManager:
     def consecutive_failures(self) -> int:
         return self._consecutive_failures
 
+    # -- Reactive event queue -----------------------------------------------
+
+    def push_reactive_event(self, event: dict) -> None:
+        """Push an event that may trigger a reactive ego cycle.
+
+        Events are debounced: the reactive loop waits 5 minutes after the
+        first event before running a cycle (batching concurrent events).
+        Rate-limited to 3 reactive cycles per hour.
+
+        event keys: {"type": str, "summary": str, "priority": str?, "source": str?}
+        """
+        if not self._running or self._paused:
+            return
+        try:
+            self._reactive_queue.put_nowait(event)
+            logger.debug("Reactive event queued: %s", event.get("type", "?"))
+        except asyncio.QueueFull:
+            logger.warning("Reactive queue full — dropping event")
+
+    async def _reactive_loop(self) -> None:
+        """Background task: drain reactive queue with debounce, run cycle."""
+        while True:
+            try:
+                # Block until first event arrives
+                first_event = await self._reactive_queue.get()
+                events = [first_event]
+
+                # Debounce: wait, then drain anything that arrived meanwhile
+                await asyncio.sleep(self._reactive_debounce_s)
+                while not self._reactive_queue.empty():
+                    try:
+                        events.append(self._reactive_queue.get_nowait())
+                    except asyncio.QueueEmpty:
+                        break
+
+                # Rate limit: max N reactive cycles per hour
+                now = datetime.now(UTC)
+                cutoff = now - timedelta(hours=1)
+                self._reactive_timestamps = [
+                    ts for ts in self._reactive_timestamps if ts > cutoff
+                ]
+                if len(self._reactive_timestamps) >= self._reactive_max_per_hour:
+                    logger.info(
+                        "Reactive rate limit: %d/%d in last hour, skipping %d event(s)",
+                        len(self._reactive_timestamps),
+                        self._reactive_max_per_hour,
+                        len(events),
+                    )
+                    continue
+
+                # Run reactive cycle
+                event_summary = "; ".join(
+                    e.get("summary", e.get("type", "?"))[:80] for e in events[:5]
+                )
+                logger.info(
+                    "Reactive cycle triggered by %d event(s): %s",
+                    len(events),
+                    event_summary,
+                )
+
+                async with self._lock:
+                    if not self._should_run(skip_idle_check=True):
+                        continue
+
+                    try:
+                        from genesis.ego.types import CycleType
+
+                        cycle = await self._session.run_cycle(
+                            cycle_type=CycleType.REACTIVE,
+                        )
+                    except (BudgetExceededError, CycleBlockedError) as exc:
+                        logger.info("Reactive cycle gated: %s", exc)
+                        continue
+                    except Exception:
+                        logger.error("Reactive cycle failed", exc_info=True)
+                        self._record_failure("reactive cycle failed")
+                        continue
+
+                    if cycle is not None:
+                        self._record_success()
+                        self._reactive_timestamps.append(datetime.now(UTC))
+                        logger.info(
+                            "Reactive cycle %s completed (cost=$%.4f)",
+                            cycle.id,
+                            cycle.cost_usd,
+                        )
+
+            except asyncio.CancelledError:
+                logger.debug("Reactive loop cancelled")
+                return
+            except Exception:
+                logger.error("Reactive loop error", exc_info=True)
+                await asyncio.sleep(60)  # Back off on unexpected errors
+
     # -- Sweep helpers -----------------------------------------------------
 
     async def _sweep_with_expiry(self) -> None:
-        """Expire stale proposals, then dispatch approved ones."""
+        """Expire stale proposals, dispatch approved, check deadlines."""
         try:
             from genesis.db.crud import ego as ego_crud
 
@@ -181,6 +294,35 @@ class EgoCadenceManager:
 
         await self._session.sweep_approved_proposals()
 
+        # Deadline scanner: push reactive events for approaching deadlines
+        await self._check_approaching_deadlines()
+
+    async def _check_approaching_deadlines(self) -> None:
+        """Push reactive events for events approaching within 48h."""
+        try:
+            from genesis.db.crud import memory_events
+
+            events = await memory_events.approaching_deadlines(
+                self._session._db, days=2, limit=5,
+            )
+            if not events:
+                return
+
+            for evt in events:
+                subj = evt.get("subject", "?")
+                verb = evt.get("verb", "?")
+                obj = evt.get("object", "")
+                date = evt.get("event_date", "")[:10]
+                self.push_reactive_event({
+                    "type": "deadline_approaching",
+                    "summary": f"{subj} {verb} {obj} on {date}",
+                    "priority": "high",
+                    "source": "deadline_scanner",
+                })
+            logger.debug("Deadline scanner found %d approaching event(s)", len(events))
+        except Exception:
+            logger.debug("Deadline scanner failed", exc_info=True)
+
     # -- Tick handlers -----------------------------------------------------
 
     async def _on_tick(self) -> None:
@@ -190,8 +332,25 @@ class EgoCadenceManager:
             if not self._should_run(skip_idle_check=False):
                 return
 
+            # Deep-think: every Nth proactive cycle upgrades to Opus.
+            # Only effective for egos that normally run Sonnet (Genesis ego).
+            self._proactive_cycle_count += 1
+            model_override = None
+            if (
+                self._deep_think_interval > 0
+                and self._proactive_cycle_count % self._deep_think_interval == 0
+                and self._config.model != "opus"
+            ):
+                model_override = "opus"
+                logger.info(
+                    "Deep-think cycle %d — upgrading to Opus",
+                    self._proactive_cycle_count,
+                )
+
             try:
-                cycle = await self._session.run_cycle()
+                cycle = await self._session.run_cycle(
+                    model_override=model_override,
+                )
             except BudgetExceededError:
                 # Budget exhaustion is intentional, not a failure.
                 # Don't trip the circuit breaker.

--- a/src/genesis/ego/capability_aggregator.py
+++ b/src/genesis/ego/capability_aggregator.py
@@ -22,15 +22,19 @@ async def compute_capability_map(db: aiosqlite.Connection) -> list[dict]:
     domains: dict[str, _DomainAccumulator] = {}
 
     # 1. Intervention journal — proposal outcome rates by action_type
+    # Excludes withdrawn/tabled from denominator — these are lifecycle
+    # events, not user decisions on proposal quality.
     try:
         from genesis.db.crud import intervention_journal as journal_crud
         aggs = await journal_crud.aggregate_by_type(db)
         for row in aggs:
             domain = row["action_type"]
-            total = row["total"]
+            # Only count terminal user-decision states in denominator
+            success = row.get("approved", 0) + row.get("executed", 0)
+            rejected = row.get("rejected", 0) + row.get("failed", 0)
+            total = success + rejected
             if total == 0:
                 continue
-            success = row.get("approved", 0) + row.get("executed", 0)
             rate = success / total
             acc = domains.setdefault(domain, _DomainAccumulator(domain))
             acc.add_signal("journal", rate, total)
@@ -38,17 +42,20 @@ async def compute_capability_map(db: aiosqlite.Connection) -> list[dict]:
         logger.debug("Capability aggregation: intervention_journal unavailable")
 
     # 2. Ego proposals — approval rates by action_type (30d)
+    # Excludes withdrawn/tabled/expired from denominator — only count
+    # proposals that reached a terminal user-decision state.
     try:
         cur = await db.execute(
             """SELECT action_type,
-                      COUNT(*) as total,
-                      SUM(CASE WHEN status IN ('approved', 'executed') THEN 1 ELSE 0 END) as success
+                      SUM(CASE WHEN status IN ('approved', 'executed') THEN 1 ELSE 0 END) as success,
+                      SUM(CASE WHEN status IN ('rejected', 'failed') THEN 1 ELSE 0 END) as rejected
                FROM ego_proposals
                WHERE created_at >= datetime('now', '-30 days')
-                 AND status != 'pending'
+                 AND status IN ('approved', 'executed', 'rejected', 'failed')
                GROUP BY action_type"""
         )
-        for action_type, total, success in await cur.fetchall():
+        for action_type, success, rejected in await cur.fetchall():
+            total = success + rejected
             if total == 0:
                 continue
             rate = success / total

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -59,6 +59,7 @@ class GenesisEgoContextBuilder:
         sections.append(await self._proposal_history_section())
         sections.append(await self._proposal_board_section())
         sections.append(await self._execution_outcomes_section())
+        sections.append(await self._capability_performance_section())
         sections.append(await self._autonomy_readiness_section())
         sections.append(self._output_contract_section())
 
@@ -472,6 +473,42 @@ class GenesisEgoContextBuilder:
             lines.append(f"- [{ts}] [{priority}] {short}")
 
         lines.append("")
+        return "\n".join(lines)
+
+    async def _capability_performance_section(self) -> str:
+        """System capability performance — domain confidence from multiple sources."""
+        lines = ["## Capability Performance\n"]
+
+        try:
+            from genesis.db.crud import capability_map as cap_crud
+
+            entries = await cap_crud.get_all(self._db)
+        except Exception:
+            return ""
+
+        if not entries:
+            lines.append("*No performance data yet.*\n")
+            return "\n".join(lines)
+
+        _TREND_ICONS = {"improving": "+", "declining": "-", "stable": "="}
+
+        lines.append("| Domain | Confidence | Trend | Samples | Evidence |")
+        lines.append("|--------|-----------|-------|---------|----------|")
+        for e in entries[:15]:
+            domain = e.get("domain", "?")
+            conf = e.get("confidence", 0.0)
+            trend = e.get("trend", "stable")
+            samples = e.get("sample_size", 0)
+            evidence = (e.get("evidence_summary") or "")[:80].replace("|", "/")
+            icon = _TREND_ICONS.get(trend, "=")
+            lines.append(
+                f"| {domain} | {conf:.0%} | {icon} | {samples} | {evidence} |"
+            )
+
+        lines.append(
+            "\nDeclining domains may need investigation. Improving domains "
+            "indicate effective maintenance patterns.\n"
+        )
         return "\n".join(lines)
 
     async def _autonomy_readiness_section(self) -> str:

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -135,6 +135,7 @@ class ProposalWorkflow:
         proposals: list[dict],
         *,
         cycle_id: str | None = None,
+        ego_source: str | None = None,
     ) -> tuple[str, list[str]]:
         """Create a batch of proposals from ego output dicts.
 
@@ -169,6 +170,9 @@ class ProposalWorkflow:
                 execution_plan=p.get("execution_plan"),
                 recurring=bool(p.get("recurring", False)),
                 memory_basis=p.get("memory_basis", ""),
+                realist_verdict=p.get("_realist_verdict"),
+                realist_reasoning=p.get("_realist_reasoning"),
+                ego_source=ego_source,
             )
             ids.append(pid)
 
@@ -220,6 +224,7 @@ class ProposalWorkflow:
         batch_id: str,
         *,
         validation_warnings: list[str] | None = None,
+        ego_source: str | None = None,
     ) -> str | None:
         """Send the batch digest to Telegram. Returns delivery_id or None.
 
@@ -244,9 +249,11 @@ class ProposalWorkflow:
             warn_lines = "\n".join(f"  - {w}" for w in validation_warnings)
             digest_html = f"\u26a0\ufe0f <b>Validation:</b>\n{warn_lines}\n\n{digest_html}"
 
-        # Show pending count from other batches for visibility
+        # Show pending count from other batches (same ego only) for visibility
         try:
-            all_pending = await ego_crud.list_pending_proposals(self._db)
+            all_pending = await ego_crud.list_pending_proposals(
+                self._db, ego_source=ego_source,
+            )
             other_pending = [p for p in all_pending if p.get("batch_id") != batch_id]
             if other_pending:
                 digest_html = (

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -12,6 +12,7 @@ Durable knowledge lives in the memory system (memory_store/recall).
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import re
@@ -28,7 +29,13 @@ from genesis.cc.types import (
     background_session_dir,
 )
 from genesis.db.crud import ego as ego_crud
-from genesis.ego.types import CYCLE_TYPE_DEFAULTS, CycleType, EgoConfig, EgoCycle
+from genesis.ego.types import (
+    CYCLE_TYPE_DEFAULTS,
+    NEUTRAL_STATUS,
+    CycleType,
+    EgoConfig,
+    EgoCycle,
+)
 from genesis.observability.session_context import set_session_id as _set_obs_session
 
 if TYPE_CHECKING:
@@ -112,6 +119,7 @@ class EgoSession:
         self._focus_summary_key = focus_summary_key or _DEFAULT_FOCUS_SUMMARY_KEY
         self._source_tag = source_tag or "ego_cycle"
         self._sweep_lock = asyncio.Lock()
+        self._last_realist_cost_usd = 0.0  # accumulated by _filter_proposals
         # Cache the static system prompt (read once, not every cycle)
         actual_prompt_path = prompt_path or _DEFAULT_PROMPT_PATH
         if actual_prompt_path.exists():
@@ -133,6 +141,7 @@ class EgoSession:
         *,
         is_morning_report: bool = False,
         cycle_type: CycleType | None = None,
+        model_override: str | None = None,
     ) -> EgoCycle | None:
         """Execute one ego thinking cycle.
 
@@ -144,6 +153,9 @@ class EgoSession:
         cycle_type:
             Determines model and effort for this cycle. If None,
             inferred from ``is_morning_report``.
+        model_override:
+            Override model selection (e.g., "opus" for deep-think cycles).
+            Takes precedence over both config and cycle_type defaults.
 
         Returns the stored EgoCycle, or None if the cycle failed (CC error).
 
@@ -161,6 +173,10 @@ class EgoSession:
         cycle_model, cycle_effort = CYCLE_TYPE_DEFAULTS.get(cycle_type, (None, None))
         model = CCModel(cycle_model or self._config.model)
         effort = EffortLevel(cycle_effort or self._config.default_effort)
+
+        # model_override takes precedence (e.g., deep-think Opus cycle)
+        if model_override:
+            model = CCModel(model_override)
 
         # 1. Budget check — raises BudgetExceededError (not a failure)
         if not await self._check_budget():
@@ -265,7 +281,8 @@ class EgoSession:
             if prev and not _BEHAVIORAL_FOCUS_RE.search(prev):
                 parsed["focus_summary"] = prev
 
-        # 7. Store cycle
+        # 7. Store cycle (realist cost added below after _filter_proposals)
+        self._last_realist_cost_usd = 0.0
         focus = parsed.get("focus_summary", "") if parsed else ""
         proposals_json = json.dumps(parsed.get("proposals", [])) if parsed else "[]"
         cycle = EgoCycle(
@@ -309,10 +326,16 @@ class EgoSession:
             proposals = parsed.get("proposals", [])
             comm_decision = parsed.get("communication_decision", "send_digest")
             if proposals:
-                # Light feasibility filter — only blocks clearly impossible
-                # proposals. The ego dreams freely; this filter catches
-                # proposals that reference nonexistent capabilities.
+                # Realist gate — LLM evaluates proposals against history
                 proposals = await self._filter_proposals(proposals)
+                # Log realist cost for observability (cycle dataclass is frozen,
+                # so cost is tracked via logging; negligible vs ego cycle cost)
+                if self._last_realist_cost_usd > 0:
+                    logger.info(
+                        "Realist cost: $%.4f (ego cycle: $%.4f)",
+                        self._last_realist_cost_usd,
+                        cycle.cost_usd,
+                    )
                 if proposals:
                     await self._process_proposals(
                         proposals,
@@ -522,28 +545,90 @@ class EgoSession:
         self,
         proposals: list[dict],
     ) -> list[dict]:
-        """Light feasibility filter — only block clearly impossible proposals.
+        """Realist gate — LLM evaluates proposals against recent history.
 
-        The ego proposes freely based on its world model ("dream first").
-        This filter catches proposals that reference capabilities Genesis
-        genuinely doesn't have. Questionable proposals pass through — the
-        user can reject them.
+        The dreamer proposes freely; the realist catches:
+        1. Read-only investigations disguised as proposals (investigate is free)
+        2. Zombie proposals (same topic proposed + withdrawn/tabled/expired)
+        3. Infeasible proposals (requires capabilities Genesis doesn't have)
+        4. Vague proposals that need amendment with concrete steps
 
-        The ego NEVER sees filter results. No per-proposal feedback.
+        Annotations are stored on proposals that pass (via _realist_verdict
+        and _realist_reasoning keys). The ego sees these in its next cycle's
+        proposal history context, forming the outer dreamer→realist loop.
+
+        Gracefully degrades to pass-through on ANY failure (DB, CC, parse).
         """
         if not proposals:
             return proposals
 
-        # Currently a pass-through: the architecture is in place for future
-        # capability-based filtering as the system matures. Starts fully
-        # permissive — better to let a questionable proposal through than
-        # suppress a creative one.
-        #
-        # Future filter criteria (when data supports it):
-        # - action_type references a capability domain that doesn't exist
-        # - content suggests a tool Genesis genuinely lacks
-        # - a known hard blocker (service down, API revoked)
-        return proposals
+        # Fetch recent history for zombie/duplicate detection
+        try:
+            cursor = await self._db.execute(
+                "SELECT action_type, content, status, created_at "
+                "FROM ego_proposals "
+                "WHERE created_at >= datetime('now', '-2 days') "
+                "ORDER BY created_at DESC LIMIT 20",
+            )
+            recent = [dict(r) for r in await cursor.fetchall()]
+        except Exception:
+            logger.warning("Realist: failed to fetch history, passing through")
+            return proposals
+
+        prompt = _build_realist_prompt(proposals, recent)
+
+        try:
+            invocation = CCInvocation(
+                prompt=prompt,
+                model=CCModel.SONNET,
+                effort=EffortLevel.LOW,
+                skip_permissions=True,
+                working_dir=background_session_dir(),
+            )
+            output = await self._invoker.run(invocation)
+            # Track realist cost for cycle accounting
+            self._last_realist_cost_usd = output.cost_usd
+            if output.is_error:
+                logger.warning("Realist CC call failed: %s", output.error_message)
+                return proposals
+
+            verdicts = _parse_realist_response(output.text, len(proposals))
+
+            filtered = []
+            rejected_count = 0
+            amended_count = 0
+            for i, prop in enumerate(proposals):
+                verdict = verdicts.get(i, {"verdict": "pass", "reasoning": ""})
+                prop["_realist_verdict"] = verdict["verdict"]
+                prop["_realist_reasoning"] = verdict.get("reasoning", "")
+
+                if verdict["verdict"] == "amend" and verdict.get("amended_content"):
+                    prop["content"] = verdict["amended_content"]
+                    amended_count += 1
+
+                if verdict["verdict"] != "reject":
+                    filtered.append(prop)
+                else:
+                    rejected_count += 1
+                    logger.info(
+                        "Realist rejected: %s — %s",
+                        prop.get("content", "")[:80],
+                        verdict.get("reasoning", "")[:100],
+                    )
+
+            if rejected_count or amended_count:
+                logger.info(
+                    "Realist: %d/%d passed (%d rejected, %d amended)",
+                    len(filtered),
+                    len(proposals),
+                    rejected_count,
+                    amended_count,
+                )
+
+            return filtered
+        except Exception:
+            logger.warning("Realist filter failed, passing through", exc_info=True)
+            return proposals
 
     async def _process_proposals(
         self,
@@ -562,6 +647,7 @@ class EgoSession:
             batch_id, ids = await self._proposals.create_batch(
                 proposals,
                 cycle_id=cycle_id,
+                ego_source=self._source_tag,
             )
             logger.info(
                 "Created proposal batch %s with %d proposals",
@@ -602,6 +688,7 @@ class EgoSession:
                 delivery = await self._proposals.send_digest(
                     batch_id,
                     validation_warnings=validation_issues or None,
+                    ego_source=self._source_tag,
                 )
                 if delivery:
                     logger.info("Ego digest sent (delivery_id=%s)", delivery)
@@ -1049,6 +1136,140 @@ class EgoSession:
         return True
 
 
+# -- Realist prompt & parser -----------------------------------------------
+
+_NEUTRAL_STATUS = NEUTRAL_STATUS  # re-export for backwards compat
+
+
+def _build_realist_prompt(
+    proposals: list[dict],
+    recent_history: list[dict],
+) -> str:
+    """Build the realist evaluation prompt.
+
+    Kept as small as possible — the realist prompt is ~2-3K input tokens
+    vs the ego's 50-80K, so cost is modest even at Opus pricing.
+    """
+    history_lines = []
+    if recent_history:
+        history_lines.append("| Type | Topic | Outcome | When |")
+        history_lines.append("|------|-------|---------|------|")
+        for h in recent_history:
+            action = h.get("action_type", "?")
+            content = (h.get("content") or "")[:100].replace("\n", " ").replace("|", "/")
+            status = _NEUTRAL_STATUS.get(h.get("status", ""), h.get("status", "?"))
+            created = (h.get("created_at") or "")[:16]
+            history_lines.append(f"| {action} | {content} | {status} | {created} |")
+    else:
+        history_lines.append("*No recent proposals.*")
+
+    proposal_lines = []
+    for i, p in enumerate(proposals):
+        content = (p.get("content") or "")[:300].replace("\n", " ")
+        action = p.get("action_type", "?")
+        conf = p.get("confidence", 0.0)
+        proposal_lines.append(f"{i}. [{action}] (confidence: {conf:.2f}) {content}")
+
+    return f"""You are the Realist — a quality gate for ego proposals. Evaluate each
+proposal and return a JSON array of verdicts.
+
+## Rules
+
+1. **Read operations are NOT proposals.** Investigating, researching, reading,
+   profiling, querying, checking, monitoring — these are things the ego should
+   do during its normal cycle without asking permission. If a proposal is
+   purely investigative with no write/action/outreach component, REJECT it:
+   "Read operation — do this during your cycle, don't propose it."
+
+2. **Check for zombies.** If a proposal covers substantially the same topic
+   as a recent proposal that was recycled/withdrawn/deferred/expired, and
+   nothing has changed in the circumstances, REJECT: "Zombie — proposed
+   before with no change in circumstances."
+
+3. **Check feasibility.** If a proposal requires a capability Genesis
+   genuinely doesn't have, AMEND with a feasible alternative.
+
+4. **Check actionability.** If the proposal is too vague to execute,
+   AMEND with concrete steps.
+
+5. **Err on the side of passing.** When in doubt, PASS. The user is the
+   final gate. Your job is to catch clear issues, not second-guess
+   creative proposals.
+
+## Recent Proposal History (48h)
+{chr(10).join(history_lines)}
+
+## New Proposals to Evaluate
+{chr(10).join(proposal_lines)}
+
+## Output Format
+Return ONLY a JSON array, one entry per proposal (same order as input):
+[{{"index": 0, "verdict": "pass|amend|reject", "reasoning": "brief explanation", "amended_content": "only if verdict is amend"}}]"""
+
+
+def _parse_realist_response(
+    raw_text: str,
+    num_proposals: int,
+) -> dict[int, dict]:
+    """Parse the realist's JSON response into per-proposal verdicts.
+
+    Returns {index: {"verdict": str, "reasoning": str, "amended_content": str?}}.
+    On parse failure, returns empty dict (all proposals pass through).
+    """
+    if not raw_text or not raw_text.strip():
+        return {}
+
+    text = raw_text.strip()
+
+    # Try direct parse
+    parsed = None
+    with contextlib.suppress(json.JSONDecodeError):
+        parsed = json.loads(text)
+
+    # Try markdown code block
+    if parsed is None:
+        match = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", text)
+        if match:
+            with contextlib.suppress(json.JSONDecodeError):
+                parsed = json.loads(match.group(1).strip())
+
+    # Try bracket extraction
+    if parsed is None:
+        first = text.find("[")
+        last = text.rfind("]")
+        if first != -1 and last > first:
+            with contextlib.suppress(json.JSONDecodeError):
+                parsed = json.loads(text[first : last + 1])
+
+    if not isinstance(parsed, list):
+        logger.warning("Realist response is not a JSON array: %.200s", text)
+        return {}
+
+    verdicts: dict[int, dict] = {}
+    for entry in parsed:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            idx = int(entry.get("index", -1))
+        except (ValueError, TypeError):
+            continue
+        if idx < 0 or idx >= num_proposals:
+            continue
+
+        verdict = entry.get("verdict", "pass")
+        if verdict not in ("pass", "amend", "reject"):
+            verdict = "pass"
+
+        verdicts[idx] = {
+            "verdict": verdict,
+            "reasoning": str(entry.get("reasoning", ""))[:500],
+        }
+        if verdict == "amend" and entry.get("amended_content"):
+            verdicts[idx]["amended_content"] = str(entry["amended_content"])[:2000]
+
+    return verdicts
+
+
 _VALID_URGENCIES = frozenset({"low", "normal", "high", "critical"})
 _VALID_NOTEPAD_ACTIONS = frozenset({"add", "update", "remove"})
 
@@ -1203,6 +1424,7 @@ _CAP_PATTERN = re.compile(r"_\(max (\d+) items?\)_")
 _NOTEPAD_SECTIONS = [
     "Active Projects & Priorities",
     "Interests & Expertise",
+    "Proposal Context Journal",
     "Open Questions",
 ]
 

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -18,12 +18,13 @@ class CycleType(StrEnum):
 
 
 # Per-cycle-type model/effort OVERRIDES.  Only cycle types listed here
-# bypass the ego's config.model / config.default_effort.  PROACTIVE and
-# REACTIVE are intentionally absent — they respect the per-ego config so
-# genesis ego can run Sonnet while user ego runs Opus.
+# bypass the ego's config.model / config.default_effort.  PROACTIVE is
+# intentionally absent — it respects the per-ego config so genesis ego
+# can run Sonnet while user ego runs Opus.
 CYCLE_TYPE_DEFAULTS: dict[CycleType, tuple[str, str]] = {
     CycleType.MORNING_REPORT: ("sonnet", "low"),
     CycleType.ESCALATION: ("sonnet", "medium"),
+    CycleType.REACTIVE: ("opus", "high"),  # fires need the best model
 }
 
 
@@ -38,6 +39,21 @@ class ProposalStatus(StrEnum):
     FAILED = "failed"
     TABLED = "tabled"
     WITHDRAWN = "withdrawn"
+
+
+# Neutral status labels — factual lifecycle terms without judgment language.
+# Used in ego context to avoid LLM deference bias from loaded outcomes.
+NEUTRAL_STATUS: dict[str, str] = {
+    "pending": "pending",
+    "approved": "approved",
+    "rejected": "passed on",
+    "expired": "expired",
+    "tabled": "deferred",
+    "withdrawn": "recycled",
+    "executed": "completed",
+    "failed": "attempted",
+    "cancelled": "cancelled",
+}
 
 
 class ProposalUrgency(StrEnum):

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -19,6 +19,8 @@ from typing import Any
 
 import aiosqlite
 
+from genesis.ego.types import NEUTRAL_STATUS
+
 logger = logging.getLogger(__name__)
 
 # Observation categories that represent user-world signals.
@@ -81,6 +83,7 @@ class UserEgoContextBuilder:
         sections.append(await self._proposal_history_section())
         sections.append(await self._proposal_board_section())
         sections.append(await self._execution_outcomes_section())
+        sections.append(await self._capability_performance_section())
         sections.append(await self._autonomy_readiness_section())
         sections.append(await self._recurring_patterns_section())
         sections.append(self._output_contract_section())
@@ -624,23 +627,26 @@ class UserEgoContextBuilder:
         lines.append("")
         return "\n".join(lines)
 
-    async def _proposal_history_section(self) -> str:
-        """Recent proposal topics for duplicate avoidance.
+    _NEUTRAL_STATUS = NEUTRAL_STATUS  # single source of truth in ego.types
 
-        Shows WHAT was proposed (to prevent re-proposing the same idea),
-        but NOT status/response — engagement metrics trigger LLM deference
-        bias and self-suppression.  Intervention history (separate section)
-        provides outcome learning for executed proposals.
+    async def _proposal_history_section(self) -> str:
+        """Recent proposal topics with neutral status for context.
+
+        Shows WHAT was proposed and its lifecycle outcome using neutral
+        labels (no judgment language). Also shows realist annotations
+        when available. No aggregate scores, no user_response text —
+        those trigger deference bias.
         """
         lines = ["## Recent Proposals (last 7 days)\n"]
 
         try:
             cursor = await self._db.execute(
-                "SELECT action_type, content, created_at "
+                "SELECT action_type, content, status, realist_verdict, "
+                "realist_reasoning, created_at "
                 "FROM ego_proposals "
                 "WHERE created_at >= datetime('now', '-7 days') "
                 "ORDER BY created_at DESC "
-                "LIMIT 15"
+                "LIMIT 15",
             )
             rows = await cursor.fetchall()
         except Exception:
@@ -653,12 +659,22 @@ class UserEgoContextBuilder:
 
         lines.append(f"**{len(rows)} proposals** in last 7 days:\n")
 
-        lines.append("| Action | Topic |")
-        lines.append("|--------|-------|")
-        for action_type, content, _created in rows:
+        lines.append("| Action | Topic | Outcome | Realist |")
+        lines.append("|--------|-------|---------|---------|")
+        for row in rows:
+            action_type = row["action_type"]
+            content = row["content"]
             short = content[:100] + "..." if len(content) > 100 else content
             short = short.replace("\n", " ").replace("|", "/")
-            lines.append(f"| {action_type} | {short} |")
+            status = self._NEUTRAL_STATUS.get(row["status"], row["status"])
+            realist = ""
+            if row["realist_verdict"]:
+                realist = row["realist_verdict"]
+                if row["realist_reasoning"]:
+                    reason_short = row["realist_reasoning"][:60]
+                    reason_short = reason_short.replace("|", "/")
+                    realist = f"{realist}: {reason_short}"
+            lines.append(f"| {action_type} | {short} | {status} | {realist} |")
 
         lines.append("")
         return "\n".join(lines)
@@ -711,6 +727,28 @@ class UserEgoContextBuilder:
         else:
             lines.append("\n*No approved proposals awaiting execution.*\n")
 
+        # Deferred (tabled) proposals — ego can resurface or withdraw
+        try:
+            tabled = await ego_crud.get_tabled(self._db)
+        except Exception:
+            tabled = []
+
+        if tabled:
+            shown = tabled[:8]
+            lines.append(f"\n**Deferred ({len(tabled)} tabled)**:\n")
+            for p in shown:
+                content = (p.get("content") or "")[:120]
+                content = content.replace("\n", " ")
+                lines.append(
+                    f"- (id:{p['id']}) **{p.get('action_type', '?')}**: {content}"
+                )
+            if len(tabled) > 8:
+                lines.append(f"- ... and {len(tabled) - 8} more")
+            lines.append(
+                "\nReview deferred items each cycle. Withdraw if stale, "
+                "resurface if conditions changed.\n"
+            )
+
         lines.append("")
         return "\n".join(lines)
 
@@ -742,6 +780,44 @@ class UserEgoContextBuilder:
             lines.append(f"- [{ts}] [{priority}] {short}")
 
         lines.append("")
+        return "\n".join(lines)
+
+    async def _capability_performance_section(self) -> str:
+        """Your track record — domain confidence from multiple data sources.
+
+        Framed as context for better proposals, NOT as a limiter.
+        The realist gate handles feasibility; this informs confidence calibration.
+        """
+        lines = ["## Your Track Record\n"]
+
+        try:
+            from genesis.db.crud import capability_map as cap_crud
+
+            entries = await cap_crud.get_all(self._db)
+        except Exception:
+            return ""
+
+        if not entries:
+            lines.append("*No performance data yet.*\n")
+            return "\n".join(lines)
+
+        _TREND_ICONS = {"improving": "+", "declining": "-", "stable": "="}
+
+        lines.append("| Domain | Confidence | Trend | Evidence |")
+        lines.append("|--------|-----------|-------|----------|")
+        for e in entries[:12]:
+            domain = e.get("domain", "?")
+            conf = e.get("confidence", 0.0)
+            trend = e.get("trend", "stable")
+            evidence = (e.get("evidence_summary") or "")[:80].replace("|", "/")
+            icon = _TREND_ICONS.get(trend, "=")
+            lines.append(f"| {domain} | {conf:.0%} | {icon} | {evidence} |")
+
+        lines.append(
+            "\nUse this to calibrate confidence on proposals. High-confidence "
+            "domains deserve ambitious proposals. Low-confidence domains may "
+            "benefit from smaller, incremental actions.\n"
+        )
         return "\n".join(lines)
 
     async def _autonomy_readiness_section(self) -> str:

--- a/src/genesis/ego/world_snapshot.py
+++ b/src/genesis/ego/world_snapshot.py
@@ -65,8 +65,8 @@ class WorldSnapshot:
                 verb = evt.get("verb", "?")
                 obj = evt.get("object", "")
 
-                # Urgency marker
-                urgency = ""
+                # Relative time annotation
+                relative = ""
                 try:
                     evt_date = datetime.fromisoformat(
                         evt.get("event_date", "")
@@ -74,17 +74,24 @@ class WorldSnapshot:
                     if evt_date.tzinfo is None:
                         evt_date = evt_date.replace(tzinfo=UTC)
                     days_until = (evt_date - now).days
-                    if days_until < 0:
-                        urgency = " **OVERDUE**"
-                    elif days_until <= 2:
-                        urgency = " **IMMINENT**"
+                    if days_until < -1:
+                        relative = f" **OVERDUE** ({abs(days_until)} days ago)"
+                    elif days_until == -1:
+                        relative = " **OVERDUE** (yesterday)"
+                    elif days_until == 0:
+                        relative = " **TODAY**"
+                    elif days_until == 1:
+                        relative = " **TOMORROW**"
                     elif days_until <= 7:
-                        urgency = " *APPROACHING*"
+                        relative = f" **in {days_until} days**"
+                    elif days_until <= 14:
+                        relative = f" (in {days_until} days)"
+                    # >14 days: no annotation, just the date
                 except (ValueError, TypeError):
                     pass
 
                 parts.append(
-                    f"- [{date_str}] {subj} {verb} {obj}{urgency}"
+                    f"- [{date_str}] {subj} {verb} {obj}{relative}"
                 )
             parts.append("")
 

--- a/src/genesis/identity/EGO_NOTEPAD.md.example
+++ b/src/genesis/identity/EGO_NOTEPAD.md.example
@@ -9,5 +9,8 @@ _(max 8 items)_
 ## Interests & Expertise
 _(max 12 items)_
 
+## Proposal Context Journal
+_(max 15 items)_
+
 ## Open Questions
 _(max 5 items)_

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -128,6 +128,33 @@ Every brainstorming cycle:
 Stale detection is YOUR job, not time-based. There is no automatic expiry.
 You judge relevance each cycle based on current signals.
 
+## Investigate Is Free
+
+Read operations do not need proposals. If you want to investigate,
+research, query, profile, or check something — just do it during your
+cycle using your MCP tools. Proposals are a **write permission gate**,
+not a read permission gate. Only propose actions that change state:
+sending messages, creating content, modifying configurations, dispatching
+background sessions.
+
+If you find yourself proposing "investigate X" or "research Y", stop.
+Just do the investigation right now, in this cycle. Use what you learn
+to inform better proposals.
+
+## Realist Gate
+
+Your proposals pass through a realist evaluation before delivery. The
+realist catches:
+- Read-only investigations that should be done in-cycle (not proposed)
+- Zombie proposals — same topic re-proposed after being recycled/deferred
+- Infeasible proposals — capabilities Genesis doesn't have
+- Vague proposals that need concrete steps
+
+The realist's annotations appear in your proposal history (the "Realist"
+column). Use this feedback to improve your next cycle's proposals. If the
+realist flagged something, address the concern — don't just re-propose
+the same thing.
+
 ## Pattern Recognition
 
 Before generating proposals, review the "Recurring Patterns" section in
@@ -136,9 +163,10 @@ your context. When you see a pattern appearing 3+ times:
 - Consider whether automation or a systematic response would help
 - Propose with action_type "recurring_pattern"
 - Be specific: "Recurring: [what]. Proposed: [specific automation]. Approve?"
-- If you proposed this pattern before and it was rejected, do NOT
+- If you proposed this pattern before and it was passed on, do NOT
   re-propose unless circumstances changed. Cross-reference your
-  proposal history.
+  proposal history — the "Outcome" and "Realist" columns show what
+  happened to previous proposals.
 
 Pattern proposals are regular proposals — same digest, same approval flow.
 
@@ -146,8 +174,8 @@ Pattern proposals are regular proposals — same digest, same approval flow.
 
 Focus on making every proposal worth the user's attention:
 
-1. Every cycle, review your pending proposals. Withdraw anything that's
-   no longer your best thinking. Supersede with better ideas.
+1. Every cycle, review your pending and deferred proposals. Withdraw
+   anything that's no longer your best thinking. Supersede with better ideas.
 2. Three high-confidence proposals are better than ten speculative ones.
    Depth over breadth.
 3. Proposals are for brainstorming cycles only. Morning reports, health

--- a/src/genesis/runtime/init/ego.py
+++ b/src/genesis/runtime/init/ego.py
@@ -262,6 +262,54 @@ async def init(rt: GenesisRuntime) -> None:
             rt._session_manager.add_on_end(_ego_dispatch_on_end)
             logger.info("Ego dispatch outcome hook registered")
 
+        # ================================================================
+        # REACTIVE EVENT WIRING — EventBus → ego reactive queue
+        # ================================================================
+        if rt._event_bus is not None:
+            from genesis.observability.types import Severity
+
+            # Route by subsystem — reliable field on every GenesisEvent.
+            # User-facing subsystems trigger user ego; system subsystems
+            # trigger Genesis ego.
+            _USER_SUBSYSTEMS = frozenset({
+                "outreach", "inbox", "mail", "recon",
+            })
+            _SYSTEM_SUBSYSTEMS = frozenset({
+                "health", "routing", "providers", "guardian",
+                "awareness", "surplus", "learning",
+            })
+
+            async def _on_high_severity_event(event) -> None:
+                """Route high-severity events to the appropriate ego's reactive queue."""
+                # Only react to WARNING+ events with actionable types
+                if event.event_type in ("heartbeat", "metric"):
+                    return
+
+                subsystem = str(getattr(event, "subsystem", ""))
+
+                reactive_event = {
+                    "type": event.event_type,
+                    "summary": str(event.message)[:200],
+                    "priority": event.severity.name if hasattr(event, "severity") else "high",
+                    "source": subsystem,
+                }
+
+                # Route by subsystem (reliable field on every event)
+                if subsystem in _USER_SUBSYSTEMS:
+                    user_ego_cadence.push_reactive_event(reactive_event)
+                elif subsystem in _SYSTEM_SUBSYSTEMS:
+                    genesis_ego_cadence.push_reactive_event(reactive_event)
+                else:
+                    # ego, perception, memory, etc. — route to Genesis ego
+                    # (system-internal concerns)
+                    genesis_ego_cadence.push_reactive_event(reactive_event)
+
+            rt._event_bus.subscribe(
+                _on_high_severity_event,
+                min_severity=Severity.WARNING,
+            )
+            logger.info("Ego reactive event subscriber registered")
+
     except ImportError:
         logger.warning("genesis.ego not available")
     except Exception:

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -126,7 +126,9 @@ class TestCadenceTick:
     ):
         mock_idle_detector.is_idle.return_value = True
         await cadence._on_tick()
-        mock_session.run_cycle.assert_called_once_with()
+        mock_session.run_cycle.assert_called_once()
+        # model_override is None for normal proactive cycles
+        assert mock_session.run_cycle.call_args.kwargs.get("model_override") is None
 
     async def test_tick_skips_when_active(
         self, cadence, mock_session, mock_idle_detector,

--- a/tests/ego/test_knowledge_notepad.py
+++ b/tests/ego/test_knowledge_notepad.py
@@ -129,14 +129,15 @@ class TestRebuildNotepad:
         pos_interests = result.index("Interests & Expertise")
         pos_questions = result.index("Open Questions")
         assert pos_projects < pos_interests < pos_questions
-        # Removed sections (Interaction Patterns, Proposal Context Journal)
-        # are treated as extras and appended after defined sections.
+        # Proposal Context Journal is a defined section, ordered before Open Questions.
+        if "Proposal Context Journal" in result:
+            pos_journal = result.index("Proposal Context Journal")
+            assert pos_interests < pos_journal < pos_questions
+        # Removed sections (Interaction Patterns) are treated as extras
+        # and appended after defined sections.
         if "Interaction Patterns" in result:
             pos_patterns = result.index("Interaction Patterns")
             assert pos_patterns > pos_questions
-        if "Proposal Context Journal" in result:
-            pos_journal = result.index("Proposal Context Journal")
-            assert pos_journal > pos_questions
 
 
 # -- _apply_knowledge_updates (integration via EgoSession) -------------------

--- a/tests/ego/test_realist.py
+++ b/tests/ego/test_realist.py
@@ -1,0 +1,465 @@
+"""Tests for the ego realist gate (dreamer/realist architecture)."""
+
+import json
+
+import pytest
+
+from genesis.db.crud import ego as ego_crud
+from genesis.ego.session import (
+    _build_realist_prompt,
+    _parse_realist_response,
+)
+from genesis.ego.types import NEUTRAL_STATUS
+
+# -- Realist prompt construction tests --
+
+
+class TestBuildRealistPrompt:
+    def test_basic_prompt_structure(self):
+        """Prompt contains rules, history, and proposals."""
+        proposals = [
+            {"action_type": "dispatch", "content": "Send report", "confidence": 0.8},
+        ]
+        history = [
+            {
+                "action_type": "investigate",
+                "content": "Check drift",
+                "status": "withdrawn",
+                "created_at": "2026-05-13T10:00:00",
+            },
+        ]
+        prompt = _build_realist_prompt(proposals, history)
+        assert "Realist" in prompt
+        assert "Read operations are NOT proposals" in prompt
+        assert "zombies" in prompt.lower()
+        assert "Send report" in prompt
+        assert "Check drift" in prompt
+
+    def test_empty_history(self):
+        """Prompt handles no recent history."""
+        proposals = [{"action_type": "dispatch", "content": "Test", "confidence": 0.5}]
+        prompt = _build_realist_prompt(proposals, [])
+        assert "No recent proposals" in prompt
+        assert "Test" in prompt
+
+    def test_history_status_uses_neutral_labels(self):
+        """History table uses neutral status labels."""
+        proposals = [{"action_type": "dispatch", "content": "Test", "confidence": 0.5}]
+        history = [
+            {
+                "action_type": "investigate",
+                "content": "Old proposal",
+                "status": "withdrawn",
+                "created_at": "2026-05-13T10:00:00",
+            },
+        ]
+        prompt = _build_realist_prompt(proposals, history)
+        assert "recycled" in prompt  # neutral label for withdrawn
+
+    def test_multiple_proposals_indexed(self):
+        """Each proposal gets a 0-based index."""
+        proposals = [
+            {"action_type": "dispatch", "content": "First", "confidence": 0.8},
+            {"action_type": "investigate", "content": "Second", "confidence": 0.6},
+        ]
+        prompt = _build_realist_prompt(proposals, [])
+        assert "0. [dispatch]" in prompt
+        assert "1. [investigate]" in prompt
+
+    def test_long_content_truncated(self):
+        """Content longer than 300 chars is truncated in the prompt."""
+        proposals = [
+            {"action_type": "dispatch", "content": "X" * 500, "confidence": 0.5},
+        ]
+        prompt = _build_realist_prompt(proposals, [])
+        # Prompt should contain truncated content, not the full 500 chars
+        assert "X" * 300 in prompt
+        assert "X" * 500 not in prompt
+
+
+# -- Realist response parsing tests --
+
+
+class TestParseRealistResponse:
+    def test_parse_valid_json_array(self):
+        """Parses a clean JSON array response."""
+        response = json.dumps([
+            {"index": 0, "verdict": "pass", "reasoning": "Good proposal"},
+            {"index": 1, "verdict": "reject", "reasoning": "Zombie"},
+        ])
+        result = _parse_realist_response(response, 2)
+        assert result[0]["verdict"] == "pass"
+        assert result[1]["verdict"] == "reject"
+        assert result[1]["reasoning"] == "Zombie"
+
+    def test_parse_markdown_code_block(self):
+        """Parses JSON inside a markdown code block."""
+        response = """Here's my evaluation:
+```json
+[{"index": 0, "verdict": "amend", "reasoning": "Too vague", "amended_content": "Specific version"}]
+```"""
+        result = _parse_realist_response(response, 1)
+        assert result[0]["verdict"] == "amend"
+        assert result[0]["amended_content"] == "Specific version"
+
+    def test_parse_bracket_extraction(self):
+        """Falls back to bracket extraction."""
+        response = "My analysis: [" + json.dumps(
+            {"index": 0, "verdict": "pass", "reasoning": "OK"}
+        ) + "]"
+        result = _parse_realist_response(response, 1)
+        assert result[0]["verdict"] == "pass"
+
+    def test_parse_empty_response(self):
+        """Returns empty dict on empty response (pass-through)."""
+        assert _parse_realist_response("", 1) == {}
+        assert _parse_realist_response("   ", 1) == {}
+
+    def test_parse_invalid_json(self):
+        """Returns empty dict on unparseable response (pass-through)."""
+        assert _parse_realist_response("not json at all", 1) == {}
+
+    def test_parse_invalid_verdict_defaults_pass(self):
+        """Unknown verdict defaults to 'pass'."""
+        response = json.dumps([
+            {"index": 0, "verdict": "maybe", "reasoning": "Unsure"},
+        ])
+        result = _parse_realist_response(response, 1)
+        assert result[0]["verdict"] == "pass"
+
+    def test_parse_out_of_range_index(self):
+        """Ignores verdicts with out-of-range indices."""
+        response = json.dumps([
+            {"index": 0, "verdict": "pass", "reasoning": "OK"},
+            {"index": 5, "verdict": "reject", "reasoning": "Bad"},
+        ])
+        result = _parse_realist_response(response, 2)
+        assert 0 in result
+        assert 5 not in result
+
+    def test_parse_truncates_long_reasoning(self):
+        """Reasoning is capped at 500 chars."""
+        response = json.dumps([
+            {"index": 0, "verdict": "pass", "reasoning": "R" * 1000},
+        ])
+        result = _parse_realist_response(response, 1)
+        assert len(result[0]["reasoning"]) == 500
+
+    def test_default_verdict_for_missing_index(self):
+        """Proposals without a verdict default to pass in the filter logic."""
+        # Simulate: realist only returns verdict for index 0, but there are 2 proposals
+        response = json.dumps([
+            {"index": 0, "verdict": "reject", "reasoning": "Bad"},
+        ])
+        result = _parse_realist_response(response, 2)
+        assert 0 in result
+        assert 1 not in result  # Missing = pass (handled by filter logic)
+
+
+# -- Neutral status labels tests --
+
+
+class TestNeutralStatus:
+    def test_all_statuses_have_labels(self):
+        """Every known proposal status has a neutral label."""
+        expected_statuses = {
+            "pending", "approved", "rejected", "expired",
+            "tabled", "withdrawn", "executed", "failed", "cancelled",
+        }
+        for status in expected_statuses:
+            assert status in NEUTRAL_STATUS, f"Missing label for status: {status}"
+
+    def test_neutral_labels_no_judgment(self):
+        """Labels avoid judgment language."""
+        assert NEUTRAL_STATUS["rejected"] == "passed on"
+        assert NEUTRAL_STATUS["withdrawn"] == "recycled"
+        assert NEUTRAL_STATUS["tabled"] == "deferred"
+        assert NEUTRAL_STATUS["failed"] == "attempted"
+
+    def test_positive_labels_unchanged(self):
+        """Approved/executed/pending are unchanged."""
+        assert NEUTRAL_STATUS["approved"] == "approved"
+        assert NEUTRAL_STATUS["executed"] == "completed"
+        assert NEUTRAL_STATUS["pending"] == "pending"
+
+
+# -- Context visibility tests --
+
+
+class TestProposalHistoryContext:
+    @pytest.mark.asyncio
+    async def test_history_shows_status_and_realist(self, db):
+        """Proposal history includes neutral status and realist columns."""
+        from genesis.ego.user_context import UserEgoContextBuilder
+
+        await ego_crud.create_proposal(
+            db,
+            id="ctx1",
+            action_type="dispatch",
+            content="Test proposal",
+            realist_verdict="pass",
+            realist_reasoning="Looks good",
+        )
+
+        builder = UserEgoContextBuilder(db=db)
+        section = await builder._proposal_history_section()
+        assert "Outcome" in section  # column header
+        assert "Realist" in section  # column header
+        assert "pending" in section  # neutral status
+        assert "pass" in section  # realist verdict
+        assert "Looks good" in section  # realist reasoning
+
+    @pytest.mark.asyncio
+    async def test_history_without_realist_annotations(self, db):
+        """Proposals without realist annotations show empty realist column."""
+        from genesis.ego.user_context import UserEgoContextBuilder
+
+        await ego_crud.create_proposal(
+            db,
+            id="ctx2",
+            action_type="investigate",
+            content="Pre-realist proposal",
+        )
+
+        builder = UserEgoContextBuilder(db=db)
+        section = await builder._proposal_history_section()
+        assert "Pre-realist proposal" in section
+        # No realist annotation in the row
+        assert "| investigate |" in section
+
+
+class TestTabledProposalBoard:
+    @pytest.mark.asyncio
+    async def test_board_shows_tabled(self, db):
+        """Board section includes deferred (tabled) proposals."""
+        from genesis.ego.user_context import UserEgoContextBuilder
+
+        await ego_crud.create_proposal(
+            db,
+            id="tbl1",
+            action_type="maintenance",
+            content="Tabled proposal",
+        )
+        await ego_crud.table_proposal(db, "tbl1")
+
+        builder = UserEgoContextBuilder(db=db)
+        section = await builder._proposal_board_section()
+        assert "Deferred" in section
+        assert "Tabled proposal" in section
+        assert "tbl1" in section
+
+    @pytest.mark.asyncio
+    async def test_board_caps_tabled_at_8(self, db):
+        """Board caps tabled proposals at 8."""
+        from genesis.ego.user_context import UserEgoContextBuilder
+
+        for i in range(10):
+            await ego_crud.create_proposal(
+                db,
+                id=f"tbl_{i:02d}",
+                action_type="maintenance",
+                content=f"Tabled proposal {i}",
+            )
+            await ego_crud.table_proposal(db, f"tbl_{i:02d}")
+
+        builder = UserEgoContextBuilder(db=db)
+        section = await builder._proposal_board_section()
+        assert "Deferred (10 tabled)" in section
+        assert "and 2 more" in section
+
+
+# -- Capability map aggregator fix tests --
+
+
+class TestCapabilityMapFix:
+    @pytest.mark.asyncio
+    async def test_withdrawn_excluded_from_denominator(self, db):
+        """Withdrawn/tabled proposals don't inflate failure rate."""
+        from genesis.ego.capability_aggregator import compute_capability_map
+
+        # Create proposals: 1 approved, 1 rejected, 3 withdrawn
+        await ego_crud.create_proposal(
+            db, id="cap1", action_type="maintenance", content="Approved"
+        )
+        await ego_crud.resolve_proposal(db, "cap1", status="approved")
+
+        await ego_crud.create_proposal(
+            db, id="cap2", action_type="maintenance", content="Rejected"
+        )
+        await ego_crud.resolve_proposal(db, "cap2", status="rejected")
+
+        for i in range(3):
+            await ego_crud.create_proposal(
+                db, id=f"cap_w{i}", action_type="maintenance", content=f"Withdrawn {i}"
+            )
+            await ego_crud.withdraw_proposal(db, f"cap_w{i}")
+
+        results = await compute_capability_map(db)
+        maint = [r for r in results if r["domain"] == "maintenance"]
+
+        # Without fix: 1/5 = 20%. With fix: 1/2 = 50%.
+        if maint:
+            assert maint[0]["confidence"] >= 0.4, (
+                f"Expected >= 0.4 (withdrawn excluded), got {maint[0]['confidence']}"
+            )
+
+
+# -- Realist filter integration tests --
+
+
+class TestRealistFilterIntegration:
+    @pytest.mark.asyncio
+    async def test_filter_passthrough_on_empty(self):
+        """Empty proposals list passes through."""
+        from genesis.ego.session import EgoSession
+
+        session = object.__new__(EgoSession)
+        result = await session._filter_proposals([])
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_annotations_stored_on_proposals(self, db):
+        """Realist annotations persist through create_batch to DB."""
+        from genesis.ego.proposals import ProposalWorkflow
+
+        proposals = [
+            {
+                "action_type": "dispatch",
+                "content": "Test proposal",
+                "confidence": 0.8,
+                "_realist_verdict": "pass",
+                "_realist_reasoning": "Looks actionable",
+            },
+        ]
+
+        workflow = ProposalWorkflow(db=db)
+        batch_id, ids = await workflow.create_batch(proposals)
+
+        prop = await ego_crud.get_proposal(db, ids[0])
+        assert prop["realist_verdict"] == "pass"
+        assert prop["realist_reasoning"] == "Looks actionable"
+
+    @pytest.mark.asyncio
+    async def test_annotations_absent_by_default(self, db):
+        """Proposals without realist annotations have NULL columns."""
+        from genesis.ego.proposals import ProposalWorkflow
+
+        proposals = [
+            {
+                "action_type": "dispatch",
+                "content": "No realist",
+                "confidence": 0.5,
+            },
+        ]
+
+        workflow = ProposalWorkflow(db=db)
+        batch_id, ids = await workflow.create_batch(proposals)
+
+        prop = await ego_crud.get_proposal(db, ids[0])
+        assert prop["realist_verdict"] is None
+        assert prop["realist_reasoning"] is None
+
+
+# -- Cross-ego isolation tests --
+
+
+class TestEgoSourceIsolation:
+    @pytest.mark.asyncio
+    async def test_ego_source_stored_on_proposal(self, db):
+        """ego_source is persisted when creating proposals via batch."""
+        from genesis.ego.proposals import ProposalWorkflow
+
+        proposals = [{"action_type": "dispatch", "content": "Test", "confidence": 0.8}]
+        workflow = ProposalWorkflow(db=db)
+        _, ids = await workflow.create_batch(
+            proposals, ego_source="user_ego_cycle",
+        )
+        prop = await ego_crud.get_proposal(db, ids[0])
+        assert prop["ego_source"] == "user_ego_cycle"
+
+    @pytest.mark.asyncio
+    async def test_ego_source_null_by_default(self, db):
+        """Proposals created without ego_source have NULL (backwards compat)."""
+        from genesis.ego.proposals import ProposalWorkflow
+
+        proposals = [{"action_type": "dispatch", "content": "Old", "confidence": 0.5}]
+        workflow = ProposalWorkflow(db=db)
+        _, ids = await workflow.create_batch(proposals)
+        prop = await ego_crud.get_proposal(db, ids[0])
+        assert prop["ego_source"] is None
+
+    @pytest.mark.asyncio
+    async def test_list_pending_filtered_by_ego(self, db):
+        """list_pending_proposals with ego_source filters correctly."""
+        await ego_crud.create_proposal(
+            db, id="user1", action_type="dispatch", content="User proposal",
+            ego_source="user_ego_cycle",
+        )
+        await ego_crud.create_proposal(
+            db, id="gen1", action_type="maintenance", content="Genesis proposal",
+            ego_source="genesis_ego_cycle",
+        )
+
+        user_pending = await ego_crud.list_pending_proposals(
+            db, ego_source="user_ego_cycle",
+        )
+        assert len(user_pending) == 1
+        assert user_pending[0]["id"] == "user1"
+
+        gen_pending = await ego_crud.list_pending_proposals(
+            db, ego_source="genesis_ego_cycle",
+        )
+        assert len(gen_pending) == 1
+        assert gen_pending[0]["id"] == "gen1"
+
+        # No filter returns both
+        all_pending = await ego_crud.list_pending_proposals(db)
+        assert len(all_pending) == 2
+
+    @pytest.mark.asyncio
+    async def test_null_ego_source_matches_any_filter(self, db):
+        """Pre-migration proposals (NULL ego_source) match any filter."""
+        await ego_crud.create_proposal(
+            db, id="old1", action_type="dispatch", content="Old proposal",
+            # No ego_source — simulates pre-migration row
+        )
+
+        user_pending = await ego_crud.list_pending_proposals(
+            db, ego_source="user_ego_cycle",
+        )
+        assert len(user_pending) == 1  # NULL matches
+
+    @pytest.mark.asyncio
+    async def test_digest_pending_count_filtered(self, db):
+        """send_digest pending count only shows same-ego proposals."""
+        from unittest.mock import AsyncMock
+
+        from genesis.ego.proposals import ProposalWorkflow
+
+        # Create user ego proposal (the batch being sent)
+        await ego_crud.create_proposal(
+            db, id="u_new", action_type="dispatch", content="New user",
+            batch_id="user_batch", ego_source="user_ego_cycle",
+        )
+        # Create another user ego pending from old batch
+        await ego_crud.create_proposal(
+            db, id="u_old", action_type="dispatch", content="Old user",
+            batch_id="old_user_batch", ego_source="user_ego_cycle",
+        )
+        # Create genesis ego pending (should NOT appear in count)
+        await ego_crud.create_proposal(
+            db, id="g1", action_type="maintenance", content="Genesis",
+            batch_id="gen_batch", ego_source="genesis_ego_cycle",
+        )
+
+        mock_tm = AsyncMock()
+        mock_tm.send_to_category = AsyncMock(return_value="delivery123")
+        workflow = ProposalWorkflow(db=db, topic_manager=mock_tm)
+
+        await workflow.send_digest(
+            "user_batch", ego_source="user_ego_cycle",
+        )
+
+        sent_html = mock_tm.send_to_category.call_args[0][1]
+        # Should show 1 pending from old user batch, not 2 (which would include genesis)
+        assert "1 proposal(s) pending" in sent_html

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -161,7 +161,8 @@ class TestEgoSession:
         assert cycle.cost_usd == 0.15
         assert cycle.model_used == "opus"
         assert cycle.focus_summary == "investigating backlog growth"
-        mock_invoker.run.assert_called_once()
+        # Invoker called for ego cycle + realist filter (2 calls when proposals exist)
+        assert mock_invoker.run.call_count >= 1
 
         # Focus summary stored in ego_state
         focus = await ego_crud.get_state(db, "ego_focus_summary")
@@ -192,7 +193,7 @@ class TestEgoSession:
         """Morning report flag appears in the user prompt."""
         await ego_session.run_cycle(is_morning_report=True)
 
-        call_args = mock_invoker.run.call_args[0][0]
+        call_args = mock_invoker.run.call_args_list[0][0][0]
         assert "MORNING REPORT" in call_args.prompt
 
     async def test_run_cycle_budget_exceeded(
@@ -245,7 +246,8 @@ class TestEgoSession:
         """Verify CCInvocation has correct model, effort, append mode."""
         await ego_session.run_cycle()
 
-        invocation = mock_invoker.run.call_args[0][0]
+        # First call is the ego cycle; subsequent calls are realist filter
+        invocation = mock_invoker.run.call_args_list[0][0][0]
         assert invocation.model.value == "opus"
         assert invocation.effort.value == "high"  # default from EgoConfig
         assert invocation.append_system_prompt is True
@@ -277,7 +279,8 @@ class TestEgoSession:
     async def test_ephemeral_no_resume(self, ego_session, mock_invoker):
         """Every cycle is ephemeral — resume_session_id is always None."""
         await ego_session.run_cycle()
-        invocation = mock_invoker.run.call_args[0][0]
+        # First call is the ego cycle
+        invocation = mock_invoker.run.call_args_list[0][0][0]
         assert invocation.resume_session_id is None
 
     async def test_ephemeral_consecutive_cycles(self, ego_session, mock_invoker):
@@ -286,41 +289,42 @@ class TestEgoSession:
         mock_invoker.run.reset_mock()
 
         await ego_session.run_cycle()
-        invocation = mock_invoker.run.call_args[0][0]
+        # First call after reset is the ego cycle
+        invocation = mock_invoker.run.call_args_list[0][0][0]
         assert invocation.resume_session_id is None
 
     async def test_morning_report_uses_sonnet_low(self, ego_session, mock_invoker):
         """Morning report cycle uses Sonnet/Low per cycle type defaults."""
         await ego_session.run_cycle(is_morning_report=True)
-        invocation = mock_invoker.run.call_args[0][0]
+        invocation = mock_invoker.run.call_args_list[0][0][0]
         assert invocation.model.value == "sonnet"
         assert invocation.effort.value == "low"
 
     async def test_cycle_type_proactive(self, ego_session, mock_invoker):
         """Proactive cycle type uses Opus/High."""
         await ego_session.run_cycle(cycle_type=CycleType.PROACTIVE)
-        invocation = mock_invoker.run.call_args[0][0]
+        invocation = mock_invoker.run.call_args_list[0][0][0]
         assert invocation.model.value == "opus"
         assert invocation.effort.value == "high"
 
     async def test_cycle_type_escalation(self, ego_session, mock_invoker):
         """Escalation cycle type uses Sonnet/Medium."""
         await ego_session.run_cycle(cycle_type=CycleType.ESCALATION)
-        invocation = mock_invoker.run.call_args[0][0]
+        invocation = mock_invoker.run.call_args_list[0][0][0]
         assert invocation.model.value == "sonnet"
         assert invocation.effort.value == "medium"
 
     async def test_system_prompt_is_static(self, ego_session, mock_invoker):
         """System prompt is the static identity — no dynamic content."""
         await ego_session.run_cycle()
-        invocation = mock_invoker.run.call_args[0][0]
+        invocation = mock_invoker.run.call_args_list[0][0][0]
         # System prompt should be the cached static prompt
         assert invocation.system_prompt == ego_session._static_prompt
 
     async def test_dynamic_context_in_user_message(self, ego_session, mock_invoker):
         """Operational context appears in the user message, not system prompt."""
         await ego_session.run_cycle()
-        invocation = mock_invoker.run.call_args[0][0]
+        invocation = mock_invoker.run.call_args_list[0][0][0]
         assert "Test operational context" in invocation.prompt
 
 

--- a/tests/test_db/test_capability_map.py
+++ b/tests/test_db/test_capability_map.py
@@ -21,6 +21,7 @@ async def db(tmp_path):
                 sample_size     INTEGER NOT NULL DEFAULT 0,
                 trend           TEXT DEFAULT 'stable',
                 evidence_summary TEXT,
+                previous_confidence REAL,
                 updated_at      TEXT NOT NULL
             )
         """)


### PR DESCRIPTION
## Summary

- **Realist gate**: LLM-powered quality filter evaluates proposals against 48h history before delivery. Catches read-only investigations ("investigate is free"), zombie proposals (same topic re-proposed), infeasible proposals, and vague proposals needing amendment. Gracefully degrades to pass-through on any failure.
- **Context visibility**: Neutral status labels (recycled, deferred, passed on) + realist annotations in proposal history. Tabled proposals visible on board. Prevents deference bias while giving ego context to avoid re-proposing.
- **Capability map fix**: Withdrawn/tabled excluded from success rate denominator — only terminal user-decision states count.
- **Delivery improvements (Layers 4-5)**: Auto-expiry, cross-batch approval, cancel/revoke during grace period, pending count header, sweep lock.

## Architecture

Dreamer/Realist outer loop: ego (dreamer) proposes freely → realist evaluates via Sonnet/LOW CC call (~$0.01-0.02) → annotations stored on `ego_proposals` → visible in next cycle's context → ego adapts.

## Changes

| File | What |
|------|------|
| `ego/session.py` | Realist in `_filter_proposals()`, prompt builder, response parser |
| `ego/types.py` | `NEUTRAL_STATUS` dict (single source of truth) |
| `ego/user_context.py` | Neutral status + realist column + tabled board |
| `ego/capability_aggregator.py` | Fix denominator (exclude withdrawn/tabled) |
| `ego/proposals.py` | Write realist annotations in `create_batch()`, cross-batch ops, cancel/revoke |
| `ego/cadence.py` | Sweep with expiry |
| `db/crud/ego.py` | New columns, expire/revoke/table/withdraw CRUD |
| `db/schema/` | Migration + table def for realist columns |
| `identity/USER_EGO_SESSION.md` | "Investigate Is Free" + "Realist Gate" sections |
| `identity/EGO_NOTEPAD.md.example` | Proposal Context Journal section |

## Test plan

- [x] 25 new realist tests (prompt, parsing, context, annotations, capability map)
- [x] 23 delivery/execution tests (expiry, cross-batch, cancel/revoke)
- [x] 114 existing session tests updated for dual invocation
- [x] 487/487 ego tests pass
- [ ] Monitor realist effectiveness for 3 days (follow-up 2026-05-16)
- [ ] Verify zombie rate drops below 15%

🤖 Generated with [Claude Code](https://claude.com/claude-code)