### PR TITLE
feat(surplus): intelligence intake pipeline — atomize, score, route

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -426,6 +426,16 @@ call_sites:
     - gemini-free
     default_paid: true
     description: Pre-mortem failure analysis before committing to execution
+  45_intelligence_intake:
+    chain:
+    - cerebras-qwen
+    - gemini-free
+    - groq-free
+    - mistral-large-free
+    - openrouter-free
+    never_pays: true
+    retry_profile: background
+    description: "Intelligence intake — score uncurated recon findings for relevance and quality"
   35_content_draft:
     chain:
     - gemini-free

--- a/docs/superpowers/specs/2026-05-14-intelligence-intake-pipeline-design.md
+++ b/docs/superpowers/specs/2026-05-14-intelligence-intake-pipeline-design.md
@@ -1,0 +1,272 @@
+# Intelligence Intake Pipeline — Design Spec
+
+**Date:** 2026-05-14
+**Status:** Draft
+**Scope:** Surplus insight routing, recon pipeline redesign, Deep reflection changes, code intelligence hook, web search capture
+
+## Context
+
+Genesis has two intelligence-gathering systems — surplus (anticipatory research, brainstorms, code audits) and recon (GitHub monitoring, email scanning, model intelligence) — that both produce findings but route them through disconnected, broken, or nonexistent pipelines.
+
+**Current problems:**
+- Surplus insights stage in `surplus_insights` table waiting for Deep reflection to promote/discard. Deep runs every 48h and reviews max 20 items. Backlog: 206 pending, 2.7% lifetime promotion rate.
+- Multi-finding surplus outputs (e.g., 3 separate topics from anticipatory research) are stored as single blobs. If promoted, they become one low-quality observation mixing unrelated topics.
+- Recon has 6 scheduled jobs but only 3 have implementations. `web_monitoring` and `source_discovery` are ghost schedules with no code. `model_intelligence` has code but is not wired to fire.
+- `github_landscape` is a firehose — 204 raw release note dumps with no quality filter.
+- `email_recon` works well but output sits in observations without reaching the knowledge base.
+- Web search results from foreground/background sessions evaporate after the session ends. No systematic capture.
+- The code intelligence PreToolUse hook fires once per session then goes silent, providing no ongoing guidance.
+
+**Design principle:** Triage is an intake function (fast, cheap, immediate), not a cognitive function (slow, expensive, batched). Don't re-triage what's already been triaged.
+
+## Architecture
+
+```
+Surplus tasks ──┐
+                │
+Recon jobs ─────┤──→ [ Atomize ] ──→ [ Score (conditional) ] ──→ [ Route ]
+                │     (always,        (only for uncurated         ├─→ Knowledge base
+Web search ─────┘      programmatic)   sources; LLM for recon,    ├─→ Observation
+                                       skip for surplus/sessions)  └─→ Discard
+```
+
+Input pipelines maintain their own scheduling and query generation. They converge at a shared intake module that handles atomization, scoring, and routing.
+
+## Item D: Code Intelligence Hook Fix
+
+**File:** `~/.claude/hooks/cbm-code-discovery-gate`
+
+**Changes:**
+- Counter-based: fires advisory reminder every 3rd qualifying call (not every call, not just once)
+- Path-aware: only counts calls targeting `src/genesis/` or `.py` files under the project root. Calls to config, docs, YAML, markdown — no counter increment, no reminder
+- Reads tool input JSON from stdin to extract target path
+- Counter resets per session (PPID-based gate file, same mechanism as current)
+- Always exit 0 (never blocks)
+
+## Item A: Atomization
+
+**New function:** `atomize(content: str, source_task_type: str) -> list[AtomicFinding]`
+
+**Location:** `src/genesis/surplus/intake.py`
+
+**Approach:** Control format at the source. For task types that produce multi-finding outputs (anticipatory_research, code_audit, gap_clustering), modify surplus task prompts to require structured JSON output:
+
+```json
+{
+  "findings": [
+    {
+      "title": "...",
+      "content": "...",
+      "sources": ["https://..."],
+      "relevance": "Why this matters to Genesis"
+    }
+  ]
+}
+```
+
+Atomization then iterates the array — no regex, no markdown parsing.
+
+**Fallback chain:**
+1. Parse as JSON with `findings` array — ideal path
+2. JSON but no `findings` key — treat whole output as single item
+3. Not valid JSON — attempt markdown split (best effort: numbered items, heading-delimited sections)
+4. Markdown split fails or uncertain — treat as single item, don't force a bad split
+
+**Observability:** Log which fallback path was taken per intake. Track structured output success rate by model.
+
+Task types that produce single narrative outputs (brainstorm_self, self_unblock) skip atomization — flow through as single items.
+
+## Item C: Intake Pipeline
+
+**New module:** `src/genesis/surplus/intake.py`
+
+Three functions called in sequence:
+
+```python
+atomize(content, source_task_type) -> list[AtomicFinding]
+score(finding, source_type) -> ScoredFinding    # conditional
+route(scored_finding) -> "knowledge" | "observation" | "discard"
+```
+
+### Scoring — conditional by source
+
+Sources with existing LLM curation skip the scoring step and inherit confidence from their source tier:
+
+| Source | Skip scoring? | Confidence | Rationale |
+|--------|--------------|------------|-----------|
+| User-directed ingestion | Yes | 0.9 | Explicit "store this" |
+| Foreground web research | Yes | 0.75 | User-directed, specific |
+| Background task research | Yes | 0.7 | Explicit Sonnet call for research |
+| Anticipatory research (surplus) | Yes | 0.6 | LLM-curated, context-aware |
+| model_intelligence recon | TBD | 0.6 | Structured API data, check if LLM-curated |
+| email_recon | Yes | 0.65 | Two-layer Gemini + CC triage |
+| github_landscape | LLM score | 0.5 | Mechanical scrape, no quality filter |
+| web_monitoring | LLM score | 0.5 | Automated URL change detection |
+| free_model_inventory | LLM score | 0.5 | Mechanical API scan |
+| source_discovery | LLM score | 0.4 | Speculative, needs approval |
+
+### Routing thresholds
+
+- Score >= 0.5 → knowledge base via `knowledge_ingest`
+- Score >= 0.7 AND pattern-level insight → also create observation
+- Score 0.4-0.5 → store to knowledge at low confidence, no observation
+- Score < 0.4 → discard silently
+
+### Call site
+
+`45_intelligence_intake` in the router. Free-tier, Haiku-class. Only invoked for sources that need LLM scoring.
+
+### Integration points
+
+- **Surplus executor:** After task completion, before current `surplus_insights` write. For sources that skip scoring, findings go straight to knowledge. No staging table needed.
+- **Recon pipeline:** After findings generation, replaces direct observation storage with intake routing.
+
+### Fallback
+
+If the intake LLM call fails (free-tier unavailable), write to `surplus_insights` as pending with current behavior. Deep can still pick it up. Graceful degradation.
+
+### Observability
+
+Log each intake decision to events: source, atomization path, score, route destination, model used. This is how we verify the pipeline is working.
+
+## Item B: Deep Reflection Changes
+
+### Remove surplus review
+
+- Remove `SURPLUS_REVIEW` from `DeepReflectionJob` enum
+- Remove `surplus_decisions` output section from `REFLECTION_DEEP.md`
+- Remove `_route_surplus_decision()` from `output_router.py`
+- Remove `SurplusDecision` dataclass from `types.py`
+
+### Replace with intelligence digest
+
+Context gatherer replaces `surplus.list_pending(db, limit=20)` with a summary query:
+- Count of items triaged since last Deep cycle
+- Breakdown by source type
+- Top themes/topics
+
+Deep can reference this for pattern recognition, contradiction detection, and strategic thinking — but does not make individual promote/discard decisions.
+
+### Reduce cadence
+
+Update `depth_thresholds` table:
+- `floor_seconds`: 172800 (48h) → **86400 (24h)**
+- `ceiling_window_seconds`: 86400 (24h) → **86400 (24h)** (unchanged)
+
+Deep runs daily instead of every two days. With surplus review removed, cycles are lighter and faster.
+
+## Recon Pipeline Redesign
+
+### 1. github_landscape — Tone down noise, add intake routing
+
+**Pre-LLM noise reduction:**
+- Skip pre-releases: filter on GitHub API `prerelease` boolean field. OpenClaw betas, Cognee dev releases — all gone.
+- Reduce `_RELEASES_PER_PROJECT` from 5 to 2.
+- Timestamp gate: only process releases published after last successful gather. No re-checking old releases.
+
+**Post-filter:** Remaining releases route through intake pipeline. Confidence 0.5 (automated scan, no prior LLM curation).
+
+### 2. model_intelligence — Wire to scheduler
+
+**Problem:** `ModelIntelligenceJob` class exists with good code but is not dispatched by the scheduler. Only callable via MCP tool.
+
+**Fix:** Add a dedicated scheduler job (like `run_recon_gather`) that instantiates and runs `ModelIntelligenceJob` on the Sunday 6am cron schedule. Wire profile_registry and surplus_queue dependencies.
+
+**Output:** Through intake pipeline. Confidence 0.6 (structured API data, directly actionable for router).
+
+### 3. free_model_inventory — Debug and wire
+
+**Problem:** Cache file shows 0 free models despite running May 12. Either OpenRouter API response format changed or `pricing.prompt == 0` check is failing on string vs float comparison.
+
+**Fix:**
+1. Debug the OpenRouter API response — check actual `pricing.prompt` field type
+2. Fix the parsing if needed
+3. Wire as dedicated daily job (currently only runs as part of model_intelligence)
+
+**Output:** New free models create follow-ups for MODEL_EVAL surplus tasks (logic exists). Through intake pipeline, confidence 0.5.
+
+### 4. email_recon — Route through intake
+
+**Status:** Working well. Quality is excellent (two-layer Gemini + CC triage).
+
+**Change:** Route output through intake pipeline instead of directly to observations. Confidence 0.65 (LLM-curated, authoritative newsletter sources).
+
+No other changes needed.
+
+### 5. web_monitoring — Build infrastructure (empty source list)
+
+**Purpose:** Monitor non-GitHub web sources for content changes. Blog posts, documentation pages, API changelogs, competitor sites.
+
+**Implementation:**
+- URL watcher: fetch URL → compute content hash → compare against last fetch → if changed, extract key changes
+- Change extraction via intake pipeline LLM scoring step
+- Source list managed via `recon_sources` MCP tool or dashboard
+- Ships with empty source list — user adds sources when ready
+
+**Cadence:** Weekly (Fridays), per existing schedule.
+**Confidence:** 0.5 (automated scan, LLM-summarized changes)
+
+### 6. source_discovery — Build infrastructure (disabled by default)
+
+**Purpose:** Expand the watchlist. Find new repos, tools, blogs relevant to Genesis's domain.
+
+**Implementation:**
+- LLM-driven (Haiku via intake call site): prompt with current watchlist + recent cognitive state
+- Web search to verify suggestions exist and are active
+- Output: proposed new sources as findings, surfaced for user/ego approval
+- Never auto-adds to watchlist
+
+**Cadence:** Monthly (1st), per existing schedule. Ships disabled or with first run deferred.
+**Confidence:** 0.4 (speculative, requires approval)
+
+## Web Search Capture
+
+**New utility:** `intake.capture_web_result(url, content_summary, query_context, session_type)`
+
+Sessions (foreground, background, surplus) call this when a web search/fetch returns useful results. Not automatic for every fetch — the session decides what's worth capturing based on relevance to the query.
+
+**Confidence by session type:**
+- Foreground: 0.75
+- Background task: 0.7
+- Surplus: 0.6
+
+**Implementation:** Lightweight function that calls into the intake pipeline. Modified session prompts instruct: "For significant web findings, call `capture_web_result()` with URL, key facts, and relevance."
+
+**Contradictory findings:** Both sides stored with source attribution. The consuming session resolves in context. "Source A says X, Source B says Y" is more honest than a triage layer picking a winner.
+
+## Files to Modify
+
+### New files
+- `src/genesis/surplus/intake.py` — atomize, score, route functions + AtomicFinding/ScoredFinding types
+
+### Modified files
+- `~/.claude/hooks/cbm-code-discovery-gate` — counter-based, path-aware hook
+- `src/genesis/surplus/executor.py` — call intake after task completion instead of writing to surplus_insights
+- `src/genesis/recon/gatherer.py` — skip pre-releases, reduce releases per project, timestamp gate, route through intake
+- `src/genesis/recon/model_intelligence.py` — debug free model parsing
+- `src/genesis/surplus/scheduler.py` — add model_intelligence and free_model_inventory as dedicated jobs
+- `src/genesis/reflection/context_gatherer.py` — replace surplus.list_pending with intelligence digest
+- `src/genesis/identity/REFLECTION_DEEP.md` — remove surplus_decisions section
+- `src/genesis/reflection/output_router.py` — remove _route_surplus_decision
+- `src/genesis/reflection/types.py` — remove SURPLUS_REVIEW job, SurplusDecision dataclass
+- `src/genesis/mail/monitor.py` — route email_recon findings through intake
+- `config/model_routing.yaml` — add call site 45_intelligence_intake
+- Surplus task prompts — add structured JSON output requirement for multi-finding task types
+- `depth_thresholds` table — update Deep floor_seconds to 86400
+
+### New infrastructure (empty, built but not populated)
+- Web monitoring URL watcher in recon module
+- Source discovery prompt and search mechanism in recon module
+
+## Verification
+
+1. **Hook:** Grep inside `src/genesis/` 3+ times, verify reminder fires on 3rd call but not on config/doc reads
+2. **Atomization:** Run anticipatory_research surplus task, verify output splits into separate findings
+3. **Intake routing:** Verify findings reach knowledge base with correct confidence, not surplus_insights staging
+4. **github_landscape:** Verify pre-releases are filtered, remaining releases route through intake
+5. **model_intelligence:** Trigger via MCP tool, verify findings stored with correct category
+6. **free_model_inventory:** Debug OpenRouter response, verify free models detected and follow-ups created
+7. **Deep reflection:** Trigger a cycle, verify no surplus_decisions in output, verify intelligence digest in context
+8. **Deep cadence:** Verify floor_seconds is 86400 in depth_thresholds table
+9. **Web capture:** In a foreground session, do a web search, call capture_web_result, verify it reaches knowledge base
+10. **Fallback:** Kill free-tier provider, verify surplus insight falls back to staging table for Deep pickup

--- a/src/genesis/cc/reflection_bridge.py
+++ b/src/genesis/cc/reflection_bridge.py
@@ -273,11 +273,11 @@ class CCReflectionBridge:
             pending = await self._context_gatherer.detect_pending_work(db)
             logger.info(
                 "Deep reflection pending work: has_any=%s, jobs=%s "
-                "(obs=%d, surplus=%d, skills=%d, cog_stale=%s)",
+                "(obs=%d, intake=%d, skills=%d, cog_stale=%s)",
                 pending.has_any_work,
                 [j.value for j in pending.active_jobs],
                 pending.observation_backlog,
-                pending.surplus_pending,
+                pending.intake_items_since_last,
                 pending.skills_needing_review,
                 pending.cognitive_regeneration,
             )

--- a/src/genesis/cc/reflection_bridge.py
+++ b/src/genesis/cc/reflection_bridge.py
@@ -608,14 +608,9 @@ class CCReflectionBridge:
             ], indent=2)
             parts.append(f"\n## Recent Observations (for consolidation)\n```json\n{obs_summary}\n```")
 
-        # Surplus staging items
-        if bundle.surplus_staging_items:
-            surplus_summary = json.dumps([
-                {"id": s.get("id", ""), "content": s.get("content", "")[:200],
-                 "confidence": s.get("confidence", 0), "drive": s.get("drive_alignment", "")}
-                for s in bundle.surplus_staging_items[:10]
-            ], indent=2)
-            parts.append(f"\n## Pending Surplus Items (decide: promote or discard)\n```json\n{surplus_summary}\n```")
+        # Intelligence digest (replaces old surplus staging items section)
+        if bundle.intelligence_digest:
+            parts.append(f"\n## Intelligence Digest (since last Deep cycle)\n{bundle.intelligence_digest}")
 
         # Procedure stats
         stats = bundle.procedure_stats

--- a/src/genesis/cc/reflection_bridge/_prompts.py
+++ b/src/genesis/cc/reflection_bridge/_prompts.py
@@ -370,14 +370,8 @@ async def build_enriched_prompt(
         obs_summary = _format_observations_grouped(bundle.recent_observations)
         parts.append(f"\n## Recent Observations (for consolidation)\n{obs_summary}")
 
-    if bundle.surplus_staging_items:
-        _surplus_limit = max(200, _OBS_TOTAL_CHAR_BUDGET // max(len(bundle.surplus_staging_items), 1))
-        surplus_summary = json.dumps([
-            {"id": s.get("id", ""), "content": s.get("content", "")[:_surplus_limit],
-             "confidence": s.get("confidence", 0), "drive": s.get("drive_alignment", "")}
-            for s in bundle.surplus_staging_items[:10]
-        ], indent=2)
-        parts.append(f"\n## Pending Surplus Items (decide: promote or discard)\n```json\n{surplus_summary}\n```")
+    if bundle.intelligence_digest:
+        parts.append(f"\n## Intelligence Digest (since last Deep cycle)\n{bundle.intelligence_digest}")
 
     stats = bundle.procedure_stats
     if stats.total_active > 0:

--- a/src/genesis/db/migrations/0017_deep_floor_24h.py
+++ b/src/genesis/db/migrations/0017_deep_floor_24h.py
@@ -1,0 +1,29 @@
+"""Reduce Deep reflection floor from 48h to 24h.
+
+With surplus review removed from Deep (intake pipeline handles triage),
+Deep cycles are lighter and faster. Reducing cadence from 48h to 24h
+ensures patterns and contradictions are caught more promptly.
+
+Idempotent — uses UPDATE with WHERE clause.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # Verify the table exists (fresh installs may not have it yet)
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='depth_thresholds'"
+    )
+    if not await cursor.fetchone():
+        return
+
+    # Update Deep floor from 172800 (48h) to 86400 (24h)
+    await db.execute(
+        "UPDATE depth_thresholds SET floor_seconds = 86400 "
+        "WHERE depth_name = 'Deep' AND floor_seconds = 172800"
+    )
+    await db.commit()

--- a/src/genesis/identity/REFLECTION_DEEP.md
+++ b/src/genesis/identity/REFLECTION_DEEP.md
@@ -78,13 +78,12 @@ For each operation, specify the target observation IDs and a brief reason.
 **IMPORTANT:** Use exact observation IDs from the provided data. Do not fabricate
 or guess IDs. Operations referencing non-existent IDs will be skipped.
 
-### Surplus Review (if staging items are provided)
+### Intelligence Digest Review
 
-For each pending surplus insight, decide:
-- **Promote**: the insight is valuable and should become a permanent observation
-- **Discard**: the insight is low-quality, redundant, or no longer relevant
-
-Provide the item_id, action ("promote" or "discard"), and a brief reason.
+The intake pipeline now handles triage of surplus and recon findings automatically.
+You receive a digest of what was processed since your last cycle — use this for
+pattern recognition, contradiction detection, and strategic thinking. You do NOT
+make individual promote/discard decisions.
 
 ### Skill Review (if skill reports are provided)
 
@@ -210,10 +209,6 @@ the next deep reflection fires.
     {"operation": "merge", "target_ids": ["obs-id-3", "obs-id-4"], "reason": "complementary", "merged_content": "combined insight..."},
     {"operation": "prune", "target_ids": ["obs-id-5"], "reason": "no longer relevant"},
     {"operation": "flag_contradiction", "target_ids": ["obs-id-6", "obs-id-7"], "reason": "conflicting claims about X"}
-  ],
-  "surplus_decisions": [
-    {"item_id": "surplus-id-1", "action": "promote", "reason": "valuable insight"},
-    {"item_id": "surplus-id-2", "action": "discard", "reason": "redundant"}
   ],
   "surplus_task_requests": [
     {"task_type": "memory_audit", "reason": "50+ unresolved observations older than 72h", "priority": 0.7, "drive_alignment": "competence"}

--- a/src/genesis/mail/monitor.py
+++ b/src/genesis/mail/monitor.py
@@ -628,8 +628,7 @@ class MailMonitor:
         decision: dict,
         batch_id: str,
     ) -> None:
-        """Store a single KEEP decision as a recon observation."""
-        now = datetime.now(UTC).isoformat()
+        """Store a single KEEP decision via intake pipeline."""
         content_hash = hashlib.sha256(
             f"email_recon:{email.message_id}".encode(),
         ).hexdigest()[:16]
@@ -649,17 +648,29 @@ class MailMonitor:
             f"Judge rationale: {rationale}"
         )
 
-        await observations.create(
-            self._db,
-            id=str(uuid.uuid4()),
-            source="recon",
-            type="finding",
-            category="email_recon",
-            content=content,
-            priority="medium",
-            created_at=now,
-            content_hash=content_hash,
-        )
+        try:
+            from genesis.surplus.intake import IntakeSource, run_intake
+            await run_intake(
+                content=content,
+                source=IntakeSource.EMAIL_RECON,
+                source_task_type="email_recon",
+                db=self._db,
+            )
+        except Exception:
+            # Fallback: store as observation directly (old behavior)
+            logger.warning("Intake failed for email_recon finding — falling back to direct observation", exc_info=True)
+            now = datetime.now(UTC).isoformat()
+            await observations.create(
+                self._db,
+                id=str(uuid.uuid4()),
+                source="recon",
+                type="finding",
+                category="email_recon",
+                content=content,
+                priority="medium",
+                created_at=now,
+                content_hash=content_hash,
+            )
 
     def _build_judge_prompt(self, briefs: list[EmailBrief]) -> str:
         """Build the Layer 2 judge prompt from paralegal briefs."""

--- a/src/genesis/recon/gatherer.py
+++ b/src/genesis/recon/gatherer.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 _CONFIG_DIR = Path(__file__).resolve().parents[3] / "config"
 _WATCHLIST_PATH = _CONFIG_DIR / "recon_watchlist.yaml"
 _GH_TIMEOUT = 15  # seconds — network calls are slower than local git
-_RELEASES_PER_PROJECT = 5
+_RELEASES_PER_PROJECT = 2
 _MAX_BODY_CHARS = 1000
 
 
@@ -219,7 +219,13 @@ class ReconGatherer:
         return None
 
     async def _check_releases(self, project: dict) -> int:
-        """Check a single project for new releases. Returns count of new findings."""
+        """Check a single project for new releases. Returns count of new findings.
+
+        Noise reduction:
+        - Pre-releases are skipped (filter on GitHub API prerelease field)
+        - Only the last _RELEASES_PER_PROJECT releases are checked
+        - Timestamp gate: only releases published after the last gather are processed
+        """
         repo = project.get("repo", "")
         if not repo:
             logger.warning("Watchlist project %s has no repo", project.get("name"))
@@ -228,7 +234,7 @@ class ReconGatherer:
         raw = await self._run_gh(
             "gh", "api",
             f"repos/{repo}/releases",
-            "--jq", f".[0:{_RELEASES_PER_PROJECT}]",
+            "--jq", f".[0:{_RELEASES_PER_PROJECT * 3}]",  # Fetch extra to filter pre-releases
         )
         if not raw:
             logger.warning("No release data from gh for %s", repo)
@@ -244,13 +250,31 @@ class ReconGatherer:
             logger.warning("Unexpected release format for %s: %s", repo, type(releases))
             return 0
 
+        # Get timestamp gate: last recorded release for this project
+        last_published = await self._get_last_release_timestamp(project.get("name", repo))
+
         new_count = 0
+        processed = 0
         for release in releases:
             if not isinstance(release, dict):
                 continue
 
+            # Skip pre-releases
+            if release.get("prerelease", False):
+                continue
+
+            # Limit to _RELEASES_PER_PROJECT stable releases
+            if processed >= _RELEASES_PER_PROJECT:
+                break
+            processed += 1
+
             tag_name = release.get("tag_name", "")
             if not tag_name:
+                continue
+
+            # Timestamp gate: skip releases published before last gather
+            published = release.get("published_at", "")
+            if last_published and published and published <= last_published:
                 continue
 
             content_hash = _release_hash(repo, tag_name)
@@ -260,9 +284,8 @@ class ReconGatherer:
             ):
                 continue
 
-            # New release — store it
+            # New release — route through intake pipeline
             name = release.get("name", tag_name)
-            published = release.get("published_at", "")
             body = release.get("body", "") or ""
             html_url = release.get("html_url", "")
 
@@ -273,23 +296,55 @@ class ReconGatherer:
             if html_url:
                 content += f"\n\nSource: {html_url}"
 
-            priority = project.get("priority", "medium")
-            now = datetime.now(UTC).isoformat()
-
-            await observations.create(
-                self._db,
-                id=str(uuid.uuid4()),
-                source="recon",
-                type="finding",
-                category="github_releases",
-                content=content,
-                priority=priority,
-                created_at=now,
-                content_hash=content_hash,
-            )
+            try:
+                from genesis.surplus.intake import IntakeSource, run_intake
+                await run_intake(
+                    content=content,
+                    source=IntakeSource.GITHUB_LANDSCAPE,
+                    source_task_type="github_releases",
+                    db=self._db,
+                )
+            except Exception:
+                # Fallback: store as observation directly (old behavior)
+                logger.warning("Intake failed for release %s — falling back to direct observation", tag_name, exc_info=True)
+                now = datetime.now(UTC).isoformat()
+                await observations.create(
+                    self._db,
+                    id=str(uuid.uuid4()),
+                    source="recon",
+                    type="finding",
+                    category="github_releases",
+                    content=content,
+                    priority=project.get("priority", "medium"),
+                    created_at=now,
+                    content_hash=content_hash,
+                )
             new_count += 1
 
         return new_count
+
+    async def _get_last_release_timestamp(self, project_name: str) -> str | None:
+        """Get the most recent release timestamp for a project from observations."""
+        try:
+            cursor = await self._db.execute(
+                "SELECT content FROM observations "
+                "WHERE source IN ('recon', 'intake:github_landscape') "
+                "AND category = 'github_releases' "
+                "AND content LIKE ? "
+                "ORDER BY created_at DESC LIMIT 1",
+                (f"{project_name} %",),
+            )
+            row = await cursor.fetchone()
+            if not row:
+                return None
+            # Extract "Released: 2026-05-10T..." from content
+            text = row[0] if isinstance(row, tuple) else row["content"]
+            for line in text.split("\n"):
+                if line.startswith("Released: "):
+                    return line[len("Released: "):].strip()
+        except Exception:
+            logger.debug("Could not get last release timestamp for %s", project_name, exc_info=True)
+        return None
 
     async def _run_gh(self, *args: str) -> str:
         """Run gh CLI command with timeout. Returns stdout or empty on failure."""

--- a/src/genesis/recon/model_intelligence.py
+++ b/src/genesis/recon/model_intelligence.py
@@ -377,7 +377,7 @@ class ModelIntelligenceJob:
         return findings
 
     async def _store_finding(self, finding: dict) -> str:
-        """Store a model intelligence finding in observations."""
+        """Store a model intelligence finding via intake pipeline."""
         import uuid
 
         finding_id = str(uuid.uuid4())
@@ -397,21 +397,31 @@ class ModelIntelligenceJob:
             "detected_at": now,
         })
 
-        _MEDIUM_TYPES = ("pricing_change", "new_model", "new_free_model", "free_model_removed")
-        priority = "medium" if finding_type in _MEDIUM_TYPES else "low"
+        try:
+            from genesis.surplus.intake import IntakeSource, run_intake
+            await run_intake(
+                content=content,
+                source=IntakeSource.MODEL_INTELLIGENCE,
+                source_task_type="model_intelligence",
+                db=self._db,
+            )
+        except Exception:
+            # Fallback: store as observation directly (old behavior)
+            logger.warning("Intake failed for model_intelligence finding — falling back to direct observation", exc_info=True)
+            _MEDIUM_TYPES = ("pricing_change", "new_model", "new_free_model", "free_model_removed")
+            priority = "medium" if finding_type in _MEDIUM_TYPES else "low"
 
-        from genesis.db.crud import observations
-
-        await observations.create(
-            self._db,
-            id=finding_id,
-            source="recon",
-            type="finding",
-            content=content,
-            priority=priority,
-            created_at=now,
-            category="model_intelligence",
-        )
+            from genesis.db.crud import observations
+            await observations.create(
+                self._db,
+                id=finding_id,
+                source="recon",
+                type="finding",
+                content=content,
+                priority=priority,
+                created_at=now,
+                category="model_intelligence",
+            )
         return finding_id
 
     async def _create_benchmark_follow_up(

--- a/src/genesis/recon/source_discovery.py
+++ b/src/genesis/recon/source_discovery.py
@@ -1,0 +1,59 @@
+"""Source discovery — find new repos, tools, and blogs to monitor.
+
+LLM-driven: prompts with current watchlist and cognitive state, then
+verifies suggestions via web search. Output is surfaced as findings for
+user/ego approval — never auto-adds to watchlist.
+
+Cadence: monthly (1st), per config/recon_schedules.yaml.
+Ships disabled: first run deferred until user enables.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+class SourceDiscoveryJob:
+    """Discovers new intelligence sources for the recon pipeline."""
+
+    def __init__(
+        self,
+        *,
+        db: aiosqlite.Connection,
+        enabled: bool = False,
+    ) -> None:
+        self._db = db
+        self._enabled = enabled
+
+    async def run(self) -> dict:
+        """Run a discovery cycle. Returns summary dict.
+
+        Currently a stub — ships disabled. When enabled, will:
+        1. Gather current watchlist + recent cognitive state
+        2. Prompt LLM (via intake call site) for new source suggestions
+        3. Verify suggestions exist via web search
+        4. Route verified suggestions through intake (confidence 0.4)
+        """
+        if not self._enabled:
+            logger.info("Source discovery: disabled — skipping")
+            return {"enabled": False, "suggestions": 0}
+
+        # TODO: Implement when user enables source discovery.
+        # The infrastructure is in place:
+        # - IntakeSource.SOURCE_DISCOVERY (confidence 0.4)
+        # - 45_intelligence_intake call site for LLM scoring
+        # - Web search via genesis providers
+        #
+        # Implementation outline:
+        # 1. Load current watchlist from config/recon_watchlist.yaml
+        # 2. Load recent cognitive state (active projects, interests)
+        # 3. Build prompt asking for new sources to monitor
+        # 4. Route LLM call through 45_intelligence_intake
+        # 5. For each suggestion, verify via web search
+        # 6. Route verified suggestions through run_intake()
+        logger.info("Source discovery: enabled but not yet implemented")
+        return {"enabled": True, "suggestions": 0, "status": "not_implemented"}

--- a/src/genesis/recon/web_monitoring.py
+++ b/src/genesis/recon/web_monitoring.py
@@ -1,0 +1,179 @@
+"""Web monitoring — watches non-GitHub URLs for content changes.
+
+Monitors blog posts, documentation pages, API changelogs, and competitor
+sites for meaningful changes. Ships with an empty source list — user adds
+sources via recon_sources MCP tool or dashboard when ready.
+
+Cadence: weekly (Fridays), per config/recon_schedules.yaml.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+_SOURCES_PATH = Path.home() / ".genesis" / "web_monitoring_sources.json"
+
+
+class WebMonitoringJob:
+    """Monitors URLs for content changes and routes findings through intake."""
+
+    def __init__(self, *, db: aiosqlite.Connection) -> None:
+        self._db = db
+
+    async def run(self) -> dict:
+        """Run a monitoring cycle. Returns summary dict."""
+        sources = self._load_sources()
+        if not sources:
+            logger.info("Web monitoring: no sources configured — skipping")
+            return {"checked": 0, "changes": 0, "sources_count": 0}
+
+        checked = 0
+        changes = 0
+        errors = 0
+
+        for source in sources:
+            try:
+                changed = await self._check_source(source)
+                checked += 1
+                if changed:
+                    changes += 1
+            except Exception:
+                errors += 1
+                logger.error(
+                    "Web monitoring failed for %s",
+                    source.get("url", "unknown"),
+                    exc_info=True,
+                )
+
+        logger.info(
+            "Web monitoring: checked=%d, changes=%d, errors=%d",
+            checked, changes, errors,
+        )
+        return {
+            "checked": checked,
+            "changes": changes,
+            "errors": errors,
+            "sources_count": len(sources),
+        }
+
+    async def _check_source(self, source: dict) -> bool:
+        """Check a single URL for changes. Returns True if changed."""
+        import httpx
+
+        url = source.get("url", "")
+        if not url:
+            return False
+
+        try:
+            async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
+                resp = await client.get(url)
+                if resp.status_code != 200:
+                    logger.warning("Web monitoring: %s returned %d", url, resp.status_code)
+                    return False
+                body = resp.text
+        except Exception:
+            logger.warning("Web monitoring: failed to fetch %s", url, exc_info=True)
+            return False
+
+        # Compute content hash.
+        content_hash = hashlib.sha256(body.encode()).hexdigest()[:32]
+
+        # Check against last known hash.
+        last_hash = await self._get_last_hash(url)
+        if last_hash == content_hash:
+            return False  # No change
+
+        # Content changed — store the new hash and route through intake.
+        await self._store_hash(url, content_hash)
+
+        # Only route if we had a previous hash (skip first-time baseline).
+        if last_hash is not None:
+            await self._route_change(source, body, url)
+
+        return last_hash is not None
+
+    async def _get_last_hash(self, url: str) -> str | None:
+        """Get last content hash for a URL from the DB."""
+        try:
+            cursor = await self._db.execute(
+                "SELECT content_hash FROM web_monitoring_hashes WHERE url = ?",
+                (url,),
+            )
+            row = await cursor.fetchone()
+            return row[0] if row else None
+        except Exception:
+            # Table might not exist yet — create it.
+            await self._ensure_table()
+            return None
+
+    async def _store_hash(self, url: str, content_hash: str) -> None:
+        """Store or update the content hash for a URL."""
+        await self._ensure_table()
+        now = datetime.now(UTC).isoformat()
+        await self._db.execute(
+            "INSERT INTO web_monitoring_hashes (url, content_hash, checked_at) "
+            "VALUES (?, ?, ?) "
+            "ON CONFLICT(url) DO UPDATE SET content_hash = excluded.content_hash, "
+            "checked_at = excluded.checked_at",
+            (url, content_hash, now),
+        )
+        await self._db.commit()
+
+    async def _ensure_table(self) -> None:
+        """Create the hash tracking table if it doesn't exist."""
+        await self._db.execute(
+            "CREATE TABLE IF NOT EXISTS web_monitoring_hashes ("
+            "  url TEXT PRIMARY KEY,"
+            "  content_hash TEXT NOT NULL,"
+            "  checked_at TEXT NOT NULL"
+            ")"
+        )
+        await self._db.commit()
+
+    async def _route_change(self, source: dict, body: str, url: str) -> None:
+        """Route a detected change through the intake pipeline."""
+        label = source.get("label", url)
+        # Extract a content summary (first 500 chars of body, cleaned).
+        summary = body[:500].strip()
+        content = (
+            f"Content change detected: {label}\n"
+            f"URL: {url}\n\n"
+            f"Content preview:\n{summary}"
+        )
+
+        try:
+            from genesis.surplus.intake import IntakeSource, run_intake
+            await run_intake(
+                content=content,
+                source=IntakeSource.WEB_MONITORING,
+                source_task_type="web_monitoring",
+                db=self._db,
+            )
+        except Exception:
+            logger.warning(
+                "Intake failed for web monitoring change at %s", url,
+                exc_info=True,
+            )
+
+    @staticmethod
+    def _load_sources() -> list[dict]:
+        """Load monitored URL sources.
+
+        Format: [{"url": "https://...", "label": "Blog Name", "category": "blog"}]
+        """
+        if not _SOURCES_PATH.exists():
+            return []
+        try:
+            data = json.loads(_SOURCES_PATH.read_text())
+            return data if isinstance(data, list) else []
+        except (json.JSONDecodeError, OSError):
+            logger.error("Failed to load web monitoring sources", exc_info=True)
+            return []

--- a/src/genesis/reflection/context_gatherer.py
+++ b/src/genesis/reflection/context_gatherer.py
@@ -11,7 +11,6 @@ from genesis.db.crud import (
     cognitive_state,
     cost_events,
     observations,
-    surplus,
 )
 from genesis.reflection.types import (
     ContextBundle,
@@ -25,7 +24,6 @@ logger = logging.getLogger(__name__)
 # Thresholds for "pending work" detection
 _MIN_OBSERVATIONS_FOR_CONSOLIDATION = 10
 _COGNITIVE_STATE_STALE_HOURS = 24
-_SURPLUS_BACKLOG_WARNING_THRESHOLD = 500
 
 
 class ContextGatherer:
@@ -42,7 +40,7 @@ class ContextGatherer:
         cog_state = await cognitive_state.render(db)
         recent_obs = await self._recent_observations(db)
         proc_stats = await self._procedure_stats(db)
-        surplus_items = await surplus.list_pending(db, limit=20)
+        intel_digest = await self._intelligence_digest(db)
         cost = await self._cost_summary(db)
         pending = await self.detect_pending_work(db)
         conversations = self._recent_conversation_turns()
@@ -52,7 +50,7 @@ class ContextGatherer:
             cognitive_state=cog_state,
             recent_observations=recent_obs,
             procedure_stats=proc_stats,
-            surplus_staging_items=surplus_items,
+            intelligence_digest=intel_digest,
             cost_summary=cost,
             pending_work=pending,
             recent_conversations=conversations,
@@ -67,15 +65,6 @@ class ContextGatherer:
         unresolved = await observations.query(db, resolved=False, limit=200)
         obs_backlog = len(unresolved)
         has_memory_work = obs_backlog >= _MIN_OBSERVATIONS_FOR_CONSOLIDATION
-
-        # Surplus review: pending staging items (real count, not capped)
-        surplus_count = await surplus.count_pending(db)
-        if surplus_count >= _SURPLUS_BACKLOG_WARNING_THRESHOLD:
-            logger.warning(
-                "Surplus backlog at %d items (threshold: %d) — "
-                "drain rate may be insufficient",
-                surplus_count, _SURPLUS_BACKLOG_WARNING_THRESHOLD,
-            )
 
         # Cognitive state staleness
         current_cog = await cognitive_state.get_current(db, "active_context")
@@ -104,16 +93,18 @@ class ContextGatherer:
         except Exception:
             logger.warning("Skill analysis failed in context_gatherer", exc_info=True)
 
+        # Intake pipeline items since last Deep cycle (for digest awareness)
+        intake_count = await self._intake_items_since_last_deep(db)
+
         return PendingWorkSummary(
             memory_consolidation=has_memory_work,
-            surplus_review=surplus_count > 0,
             skill_review=skills_needing_review > 0,
             cost_reconciliation=True,  # Always include cost summary
             lessons_extraction=has_lessons,
             cognitive_regeneration=cog_stale,
             observation_backlog=obs_backlog,
-            surplus_pending=surplus_count,
             skills_needing_review=skills_needing_review,
+            intake_items_since_last=intake_count,
         )
 
     async def gather_for_assessment(self, db: aiosqlite.Connection) -> dict:
@@ -148,11 +139,8 @@ class ContextGatherer:
             if two_weeks_ago <= o.get("created_at", "") < week_ago
         ]
 
-        # Dimension 5: Resource efficiency
-        surplus_items = await surplus.list_pending(db, limit=100)
-        # Count promoted/discarded this week
-        promoted_count = await self._surplus_status_count(db, "promoted", since=week_ago)
-        discarded_count = await self._surplus_status_count(db, "discarded", since=week_ago)
+        # Dimension 5: Resource efficiency — intake pipeline stats
+        intake_count = await self._intake_items_since_last_deep(db)
 
         # Dimension 6: Blind spots — topic distribution
         topic_dist = {}
@@ -178,9 +166,7 @@ class ContextGatherer:
                 "observations_last_week": len(last_week_obs),
             },
             "resource_efficiency": {
-                "surplus_pending": len(surplus_items),
-                "promoted_this_week": promoted_count,
-                "discarded_this_week": discarded_count,
+                "intake_items_this_cycle": intake_count,
             },
             "blind_spots": {
                 "topic_distribution": topic_dist,
@@ -351,16 +337,65 @@ class ContextGatherer:
         except Exception:
             return {}
 
-    async def _surplus_status_count(
-        self, db: aiosqlite.Connection, status: str, *, since: str
-    ) -> int:
-        """Count surplus items with a given promotion_status since a date."""
+    async def _intelligence_digest(self, db: aiosqlite.Connection) -> str:
+        """Build a summary of intelligence intake since last Deep cycle.
+
+        Replaces the old surplus.list_pending() call. Deep gets a digest
+        for pattern recognition, not individual promote/discard decisions.
+        """
+        # Get last Deep reflection timestamp
+        last_deep = await observations.query(
+            db, source="cc_reflection_deep", limit=1,
+        )
+        since = ""
+        if last_deep:
+            since = last_deep[0].get("created_at", "")
+
+        # Count knowledge units ingested since last Deep
         try:
-            cursor = await db.execute(
-                "SELECT COUNT(*) FROM surplus_insights "
-                "WHERE promotion_status = ? AND created_at >= ?",
-                (status, since),
+            query = (
+                "SELECT authority, COUNT(*) as cnt FROM knowledge_units "
+                "WHERE created_at > ? GROUP BY authority ORDER BY cnt DESC"
+            ) if since else (
+                "SELECT authority, COUNT(*) as cnt FROM knowledge_units "
+                "WHERE created_at > datetime('now', '-2 days') "
+                "GROUP BY authority ORDER BY cnt DESC"
             )
+            params = (since,) if since else ()
+            cursor = await db.execute(query, params)
+            rows = await cursor.fetchall()
+        except Exception:
+            logger.debug("knowledge_units query failed in digest", exc_info=True)
+            rows = []
+
+        if not rows:
+            return "No intelligence items ingested since last Deep cycle."
+
+        total = sum(r[1] for r in rows)
+        parts = [f"**{total} intelligence items** triaged since last Deep cycle:"]
+        for row in rows:
+            parts.append(f"- {row[0]}: {row[1]} items")
+
+        return "\n".join(parts)
+
+    async def _intake_items_since_last_deep(self, db: aiosqlite.Connection) -> int:
+        """Count intake items since last Deep reflection."""
+        last_deep = await observations.query(
+            db, source="cc_reflection_deep", limit=1,
+        )
+        since = ""
+        if last_deep:
+            since = last_deep[0].get("created_at", "")
+
+        try:
+            query = (
+                "SELECT COUNT(*) FROM knowledge_units WHERE created_at > ?"
+            ) if since else (
+                "SELECT COUNT(*) FROM knowledge_units "
+                "WHERE created_at > datetime('now', '-2 days')"
+            )
+            params = (since,) if since else ()
+            cursor = await db.execute(query, params)
             row = await cursor.fetchone()
             return row[0] if row else 0
         except Exception:

--- a/src/genesis/reflection/output_router.py
+++ b/src/genesis/reflection/output_router.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from genesis.db.crud import cognitive_state, observations, procedural, surplus
+from genesis.db.crud import cognitive_state, observations, procedural
 from genesis.perception.confidence import load_config as load_confidence_config
 from genesis.perception.confidence import should_gate
 from genesis.reflection.types import (
@@ -18,7 +18,6 @@ from genesis.reflection.types import (
     DimensionScore,
     MemoryOperation,
     QualityCalibrationOutput,
-    SurplusDecision,
     SurplusTaskRequest,
     UserQuestion,
     WeeklyAssessmentOutput,
@@ -70,16 +69,6 @@ def parse_deep_reflection_output(raw_json: str) -> DeepReflectionOutput:
                 merged_content=op.get("merged_content"),
             ))
 
-    # Parse surplus decisions
-    surplus_decisions = []
-    for sd in data.get("surplus_decisions", []):
-        if isinstance(sd, dict):
-            surplus_decisions.append(SurplusDecision(
-                item_id=sd.get("item_id", ""),
-                action=sd.get("action", "discard"),
-                reason=sd.get("reason", ""),
-            ))
-
     # Parse surplus_task_requests
     task_requests = []
     for req in data.get("surplus_task_requests", []):
@@ -106,7 +95,6 @@ def parse_deep_reflection_output(raw_json: str) -> DeepReflectionOutput:
         observations=data.get("observations", []),
         cognitive_state_update=data.get("cognitive_state_update"),
         memory_operations=mem_ops,
-        surplus_decisions=surplus_decisions,
         surplus_task_requests=task_requests,
         user_question=user_question,
         skill_triggers=data.get("skill_triggers", []),
@@ -228,7 +216,7 @@ class OutputRouter:
         summary: dict = {
             "observations_written": 0,
             "cognitive_state_updated": False,
-            "surplus_decisions": 0,
+            # surplus_decisions removed — intake pipeline handles triage now
             "memory_operations": 0,
             "quarantines": 0,
             "contradictions": 0,
@@ -253,7 +241,6 @@ class OutputRouter:
             output.observations
             or output.cognitive_state_update
             or output.memory_operations
-            or output.surplus_decisions
             or output.learnings
             or output.focus_next
             or output.skill_triggers
@@ -356,12 +343,7 @@ class OutputRouter:
             )
             summary["focus_next_stored"] = True
 
-        # 4. Surplus decisions
-        for decision in output.surplus_decisions:
-            await self._route_surplus_decision(db, decision)
-            summary["surplus_decisions"] += 1
-
-        # 4b. Surplus task requests (deep reflection dispatching new tasks)
+        # 4. Surplus task requests (deep reflection dispatching new tasks)
         if self._surplus_queue and output.surplus_task_requests:
             from genesis.surplus.types import ComputeTier, TaskType
             for req in output.surplus_task_requests:
@@ -745,48 +727,6 @@ class OutputRouter:
             skip_if_duplicate=True,
         )
         return obs_id
-
-    async def _route_surplus_decision(
-        self, db: aiosqlite.Connection, decision: SurplusDecision,
-    ) -> None:
-        """Apply a surplus promotion/discard decision.
-
-        On promote: fetch the insight, create an observation from its content,
-        then mark the surplus insight as promoted.
-        """
-        if not decision.item_id:
-            return
-        if decision.action == "promote":
-            # Verify the insight exists and isn't already promoted
-            insight = await surplus.get_by_id(db, decision.item_id)
-            if not insight:
-                logger.warning(
-                    "Surplus promote references non-existent ID: %s",
-                    decision.item_id,
-                )
-                return
-            if insight.get("promotion_status") == "promoted":
-                return  # Already promoted — idempotent
-            # Promote first, then create observation (avoids duplicate
-            # observations if promote succeeds but observation creation
-            # is retried by the awareness loop).
-            await surplus.promote(db, decision.item_id, promoted_to="observation")
-            try:
-                await self._write_observation(
-                    db,
-                    source="surplus_promotion",
-                    type=insight.get("source_task_type", "unknown"),
-                    content=insight.get("content", ""),
-                    priority="low",
-                )
-            except Exception:
-                logger.error(
-                    "Failed to create observation for promoted surplus %s",
-                    decision.item_id,
-                    exc_info=True,
-                )
-        elif decision.action == "discard":
-            await surplus.discard(db, decision.item_id)
 
     def _write_reflection_markdown(
         self, label: str, content: str, score: float | None = None,

--- a/src/genesis/reflection/types.py
+++ b/src/genesis/reflection/types.py
@@ -10,7 +10,6 @@ class DeepReflectionJob(StrEnum):
     """Jobs that a deep reflection cycle can perform."""
 
     MEMORY_CONSOLIDATION = "memory_consolidation"
-    SURPLUS_REVIEW = "surplus_review"
     SKILL_REVIEW = "skill_review"
     COST_RECONCILIATION = "cost_reconciliation"
     LESSONS_EXTRACTION = "lessons_extraction"
@@ -33,7 +32,6 @@ class PendingWorkSummary:
     """Summarises which deep reflection jobs have pending work."""
 
     memory_consolidation: bool = False
-    surplus_review: bool = False
     skill_review: bool = False
     cost_reconciliation: bool = False
     lessons_extraction: bool = False
@@ -41,8 +39,9 @@ class PendingWorkSummary:
 
     # Data counts for prompt assembly (only include sections with data)
     observation_backlog: int = 0
-    surplus_pending: int = 0
     skills_needing_review: int = 0
+    # Intelligence digest for intake pipeline awareness
+    intake_items_since_last: int = 0
 
     @property
     def has_any_work(self) -> bool:
@@ -54,7 +53,6 @@ class PendingWorkSummary:
         """
         return any([
             self.memory_consolidation,
-            self.surplus_review,
             self.skill_review,
             self.lessons_extraction,
             self.cognitive_regeneration,
@@ -65,8 +63,6 @@ class PendingWorkSummary:
         jobs = []
         if self.memory_consolidation:
             jobs.append(DeepReflectionJob.MEMORY_CONSOLIDATION)
-        if self.surplus_review:
-            jobs.append(DeepReflectionJob.SURPLUS_REVIEW)
         if self.skill_review:
             jobs.append(DeepReflectionJob.SKILL_REVIEW)
         if self.cost_reconciliation:
@@ -107,7 +103,7 @@ class ContextBundle:
     cognitive_state: str = ""
     recent_observations: list[dict] = field(default_factory=list)
     procedure_stats: ProcedureStats = field(default_factory=ProcedureStats)
-    surplus_staging_items: list[dict] = field(default_factory=list)
+    intelligence_digest: str = ""
     skill_reports: list[dict] = field(default_factory=list)
     cost_summary: CostSummary = field(default_factory=CostSummary)
     pending_work: PendingWorkSummary = field(default_factory=PendingWorkSummary)
@@ -128,15 +124,6 @@ class MemoryOperation:
     target_ids: list[str] = field(default_factory=list)
     reason: str = ""
     merged_content: str | None = None
-
-
-@dataclass(frozen=True)
-class SurplusDecision:
-    """Decision on a surplus staging item."""
-
-    item_id: str
-    action: str  # "promote" or "discard"
-    reason: str = ""
 
 
 @dataclass(frozen=True)
@@ -166,7 +153,6 @@ class DeepReflectionOutput:
     observations: list[str] = field(default_factory=list)
     cognitive_state_update: str | None = None
     memory_operations: list[MemoryOperation] = field(default_factory=list)
-    surplus_decisions: list[SurplusDecision] = field(default_factory=list)
     skill_triggers: list[str] = field(default_factory=list)
     procedure_quarantines: list[dict] = field(default_factory=list)
     contradictions: list[dict] = field(default_factory=list)

--- a/src/genesis/runtime/init/surplus.py
+++ b/src/genesis/runtime/init/surplus.py
@@ -93,6 +93,22 @@ async def init(rt: GenesisRuntime) -> None:
             logger.error("Unexpected error wiring ReconGatherer", exc_info=True)
             await _degraded(rt, "ReconGatherer")
 
+        try:
+            from genesis.recon.model_intelligence import ModelIntelligenceJob
+            mi_job = ModelIntelligenceJob(
+                db=rt._db,
+                profile_registry=getattr(rt, "_profile_registry", None),
+                surplus_queue=getattr(rt, "_surplus_queue", None),
+            )
+            rt._surplus_scheduler.set_model_intelligence_job(mi_job)
+            logger.info("ModelIntelligenceJob wired to surplus scheduler")
+        except (ImportError, AttributeError):
+            logger.error("Failed to wire ModelIntelligenceJob", exc_info=True)
+            await _degraded(rt, "ModelIntelligenceJob")
+        except Exception:
+            logger.error("Unexpected error wiring ModelIntelligenceJob", exc_info=True)
+            await _degraded(rt, "ModelIntelligenceJob")
+
         await rt._surplus_scheduler.start()
         logger.info("Genesis surplus scheduler started")
 

--- a/src/genesis/surplus/brainstorm.py
+++ b/src/genesis/surplus/brainstorm.py
@@ -114,23 +114,38 @@ class BrainstormRunner:
 
         from datetime import timedelta
         now = self._clock()
-        ttl = (now + timedelta(days=7)).isoformat()
         now_iso = now.isoformat()
         staging_id = str(uuid.uuid4())
 
-        # Write to surplus_insights staging
         insight = result.insights[0] if result.insights else {}
-        await surplus_crud.create(
-            self._db,
-            id=staging_id,
-            content=result.content or "",
-            source_task_type=str(task_type),
-            generating_model=insight.get("generating_model", "stub"),
-            drive_alignment=drive_alignment,
-            confidence=insight.get("confidence", 0.0),
-            created_at=now_iso,
-            ttl=ttl,
-        )
+        content = result.content or ""
+
+        # Route through intake pipeline (atomize → score → knowledge base)
+        try:
+            from genesis.surplus.intake import run_intake, source_for_task_type
+            source = source_for_task_type(str(task_type))
+            await run_intake(
+                content=content,
+                source=source,
+                source_task_type=str(task_type),
+                generating_model=insight.get("generating_model", "stub"),
+                db=self._db,
+            )
+        except Exception:
+            # Fallback: write to surplus_insights staging (old behavior)
+            logger.warning("Intake pipeline failed in brainstorm — falling back to staging", exc_info=True)
+            ttl = (now + timedelta(days=7)).isoformat()
+            await surplus_crud.create(
+                self._db,
+                id=staging_id,
+                content=content,
+                source_task_type=str(task_type),
+                generating_model=insight.get("generating_model", "stub"),
+                drive_alignment=drive_alignment,
+                confidence=insight.get("confidence", 0.0),
+                created_at=now_iso,
+                ttl=ttl,
+            )
 
         # Write to brainstorm_log
         session_type = _SESSION_TYPE_MAP.get(task_type, str(task_type))

--- a/src/genesis/surplus/executor.py
+++ b/src/genesis/surplus/executor.py
@@ -242,7 +242,19 @@ _TASK_PROMPTS: dict[TaskType, str] = {
         "Generate 2-3 concrete, actionable ideas for how the system could "
         "better serve the user based on the system context and user profile "
         "above.  Each idea should be specific enough to act on.\n\n"
-        "Respond in plain text with numbered ideas."
+        "Respond with ONLY a JSON object in this exact format:\n"
+        '```json\n'
+        '{{\n'
+        '  "findings": [\n'
+        '    {{\n'
+        '      "title": "Short idea title",\n'
+        '      "content": "Detailed description of the idea",\n'
+        '      "sources": [],\n'
+        '      "relevance": "Why this would create value"\n'
+        '    }}\n'
+        '  ]\n'
+        '}}\n'
+        '```\n'
     ),
     TaskType.BRAINSTORM_SELF: (
         "You are brainstorming ways to improve your own capabilities.\n\n"
@@ -251,7 +263,19 @@ _TASK_PROMPTS: dict[TaskType, str] = {
         "Identify 2-3 concrete improvements to your own processes, skills, "
         "or knowledge that would make you more effective.  Focus on gaps "
         "exposed by recent work.\n\n"
-        "Respond in plain text with numbered ideas."
+        "Respond with ONLY a JSON object in this exact format:\n"
+        '```json\n'
+        '{{\n'
+        '  "findings": [\n'
+        '    {{\n'
+        '      "title": "Short improvement title",\n'
+        '      "content": "What to improve and how",\n'
+        '      "sources": [],\n'
+        '      "relevance": "Why this improvement matters"\n'
+        '    }}\n'
+        '  ]\n'
+        '}}\n'
+        '```\n'
     ),
     TaskType.META_BRAINSTORM: (
         "You are reviewing the quality of recent brainstorm outputs.\n\n"
@@ -284,7 +308,19 @@ _TASK_PROMPTS: dict[TaskType, str] = {
         "Cluster recent unresolved observations into themes.  Identify "
         "recurring patterns that suggest systemic issues rather than "
         "one-off events.\n\n"
-        "Respond in plain text with grouped findings."
+        "Respond with ONLY a JSON object in this exact format:\n"
+        '```json\n'
+        '{{\n'
+        '  "findings": [\n'
+        '    {{\n'
+        '      "title": "Theme/pattern name",\n'
+        '      "content": "Description of the pattern and evidence",\n'
+        '      "sources": [],\n'
+        '      "relevance": "Why this pattern matters"\n'
+        '    }}\n'
+        '  ]\n'
+        '}}\n'
+        '```\n'
     ),
     TaskType.SELF_UNBLOCK: (
         "You are helping an autonomous AI system get unstuck.\n\n"
@@ -316,13 +352,21 @@ _TASK_PROMPTS: dict[TaskType, str] = {
         "{context}\n\n"
         "## Task\n"
         "Synthesize the search results above into 1-3 actionable findings.\n\n"
-        "For each finding:\n"
-        "- State the insight clearly\n"
-        "- Cite the source URL(s)\n"
-        "- Explain why this matters for the user or system\n\n"
-        "If no useful search results were found, state that clearly and "
-        "suggest better search queries for next time.\n\n"
-        "Respond in plain text with numbered findings."
+        "If no useful search results were found, respond with a plain text "
+        "message explaining that and suggesting better queries.\n\n"
+        "Otherwise, respond with ONLY a JSON object in this exact format:\n"
+        '```json\n'
+        '{{\n'
+        '  "findings": [\n'
+        '    {{\n'
+        '      "title": "Short descriptive title",\n'
+        '      "content": "The insight, explained clearly",\n'
+        '      "sources": ["https://..."],\n'
+        '      "relevance": "Why this matters for the user or system"\n'
+        '    }}\n'
+        '  ]\n'
+        '}}\n'
+        '```\n'
     ),
     TaskType.PROMPT_REVIEW_CATALOG: (
         "You are cataloging LLM call site activity for an autonomous AI.\n\n"

--- a/src/genesis/surplus/findings_bridge.py
+++ b/src/genesis/surplus/findings_bridge.py
@@ -1,9 +1,7 @@
-"""Bridge code audit findings to surplus_insights staging table.
+"""Bridge code audit findings to the intelligence intake pipeline.
 
-Findings are staged for Genesis proper (via reflection) to review and
-promote/discard. They do NOT go to the observations table directly —
-free-model output must pass through Genesis proper before influencing
-reasoning or reaching the user.
+Findings are routed through intake (atomize → score → knowledge base).
+Falls back to surplus_insights staging if the intake pipeline is unavailable.
 """
 
 from __future__ import annotations
@@ -11,8 +9,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import uuid
-from datetime import UTC, datetime, timedelta
 
 from genesis.db.crud import surplus
 
@@ -22,21 +18,19 @@ logger = logging.getLogger(__name__)
 # likely generic/speculative and not worth persisting.
 _MIN_CONFIDENCE = 0.7
 
-_TTL_DAYS = 7
-
 
 class FindingsBridge:
-    """Writes code audit findings to surplus_insights for Genesis proper to review.
+    """Routes code audit findings through the intake pipeline.
 
-    Findings are staged with promotion_status='pending'. Deep reflection
-    reads surplus.list_pending() and decides whether to promote or discard.
+    Findings that pass the confidence gate are routed to the knowledge base
+    via intake. If intake fails, falls back to surplus_insights staging.
     """
 
     def __init__(self, db) -> None:
         self._db = db
 
     async def bridge_findings(self, insights: list[dict]) -> int:
-        """Write findings to surplus_insights table. Returns count of new findings written."""
+        """Route findings through intake. Returns count of findings processed."""
         written = 0
         for insight in insights:
             try:
@@ -62,7 +56,7 @@ class FindingsBridge:
             )
             return 0
 
-        # Hash only semantically meaningful fields for dedup
+        # Hash for dedup check
         hash_keys = {
             k: insight.get(k) for k in ("file", "line", "severity", "suggestion")
         }
@@ -70,7 +64,7 @@ class FindingsBridge:
             json.dumps(hash_keys, sort_keys=True).encode()
         ).hexdigest()[:16]
 
-        # Dedup: use content_hash as id prefix, check with exact prefix match
+        # Dedup: check surplus_insights for already-processed findings
         id_prefix = f"audit-{content_hash}"
         cursor = await self._db.execute(
             "SELECT 1 FROM surplus_insights WHERE id = ? OR id GLOB ?",
@@ -80,19 +74,34 @@ class FindingsBridge:
             logger.debug("Duplicate finding skipped: %s", content_hash)
             return 0
 
-        now = datetime.now(UTC)
-        ttl = (now + timedelta(days=_TTL_DAYS)).isoformat()
-
-        await surplus.create(
-            self._db,
-            id=f"{id_prefix}-{uuid.uuid4().hex[:8]}",
-            content=json.dumps(insight),
-            source_task_type="code_audit",
-            generating_model=insight.get("model", "unknown"),
-            drive_alignment="competence",
-            confidence=confidence,
-            created_at=now.isoformat(),
-            ttl=ttl,
-        )
+        # Route through intake pipeline
+        content = json.dumps(insight)
+        try:
+            from genesis.surplus.intake import IntakeSource, run_intake
+            await run_intake(
+                content=content,
+                source=IntakeSource.ANTICIPATORY_RESEARCH,
+                source_task_type="code_audit",
+                generating_model=insight.get("model", "unknown"),
+                db=self._db,
+            )
+        except Exception:
+            # Fallback: write to surplus_insights staging (old behavior)
+            logger.warning("Intake failed for code audit finding — falling back to staging", exc_info=True)
+            import uuid
+            from datetime import UTC, datetime, timedelta
+            now = datetime.now(UTC)
+            ttl = (now + timedelta(days=7)).isoformat()
+            await surplus.create(
+                self._db,
+                id=f"{id_prefix}-{uuid.uuid4().hex[:8]}",
+                content=content,
+                source_task_type="code_audit",
+                generating_model=insight.get("model", "unknown"),
+                drive_alignment="competence",
+                confidence=confidence,
+                created_at=now.isoformat(),
+                ttl=ttl,
+            )
 
         return 1

--- a/src/genesis/surplus/intake.py
+++ b/src/genesis/surplus/intake.py
@@ -1,0 +1,657 @@
+"""Intelligence intake pipeline — atomize, score, route.
+
+Converges surplus insights, recon findings, and web search results into a
+unified pipeline.  Design spec:
+  docs/superpowers/specs/2026-05-14-intelligence-intake-pipeline-design.md
+
+Three-step pipeline:
+  1. atomize(content, source_task_type) -> list[AtomicFinding]
+  2. score(finding, source_type) -> ScoredFinding  (conditional — skipped for curated sources)
+  3. route(scored_finding) -> "knowledge" | "observation" | "discard"
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+    from genesis.memory.store import MemoryStore
+    from genesis.routing.router import Router
+
+logger = logging.getLogger(__name__)
+
+
+# ── Types ────────────────────────────────────────────────────────────────
+
+
+class IntakeSource(StrEnum):
+    """Source categories with pre-assigned confidence tiers."""
+
+    USER_DIRECTED = "user_directed"              # 0.9
+    FOREGROUND_WEB = "foreground_web"            # 0.75
+    BACKGROUND_TASK = "background_task"          # 0.7
+    EMAIL_RECON = "email_recon"                  # 0.65
+    ANTICIPATORY_RESEARCH = "anticipatory_research"  # 0.6
+    MODEL_INTELLIGENCE = "model_intelligence"    # 0.6
+    GITHUB_LANDSCAPE = "github_landscape"        # 0.5 — needs LLM scoring
+    WEB_MONITORING = "web_monitoring"            # 0.5 — needs LLM scoring
+    FREE_MODEL_INVENTORY = "free_model_inventory"  # 0.5 — needs LLM scoring
+    SOURCE_DISCOVERY = "source_discovery"        # 0.4 — needs LLM scoring
+
+
+# Sources that skip LLM scoring — already curated by an LLM upstream.
+_CURATED_SOURCES: dict[IntakeSource, float] = {
+    IntakeSource.USER_DIRECTED: 0.9,
+    IntakeSource.FOREGROUND_WEB: 0.75,
+    IntakeSource.BACKGROUND_TASK: 0.7,
+    IntakeSource.EMAIL_RECON: 0.65,
+    IntakeSource.ANTICIPATORY_RESEARCH: 0.6,
+    IntakeSource.MODEL_INTELLIGENCE: 0.6,
+}
+
+# Sources that require LLM scoring.
+_UNCURATED_SOURCES: dict[IntakeSource, float] = {
+    IntakeSource.GITHUB_LANDSCAPE: 0.5,
+    IntakeSource.WEB_MONITORING: 0.5,
+    IntakeSource.FREE_MODEL_INVENTORY: 0.5,
+    IntakeSource.SOURCE_DISCOVERY: 0.4,
+}
+
+# Map surplus TaskType strings to IntakeSource.
+_TASK_TYPE_TO_SOURCE: dict[str, IntakeSource] = {
+    "anticipatory_research": IntakeSource.ANTICIPATORY_RESEARCH,
+    "brainstorm_user": IntakeSource.ANTICIPATORY_RESEARCH,
+    "brainstorm_self": IntakeSource.ANTICIPATORY_RESEARCH,
+    "code_audit": IntakeSource.ANTICIPATORY_RESEARCH,
+    "gap_clustering": IntakeSource.ANTICIPATORY_RESEARCH,
+    "meta_brainstorm": IntakeSource.ANTICIPATORY_RESEARCH,
+    "memory_audit": IntakeSource.ANTICIPATORY_RESEARCH,
+    "procedure_audit": IntakeSource.ANTICIPATORY_RESEARCH,
+    "prompt_effectiveness_review": IntakeSource.ANTICIPATORY_RESEARCH,
+}
+
+# Task types that typically produce multiple findings and should be atomized.
+_MULTI_FINDING_TASK_TYPES = frozenset({
+    "anticipatory_research",
+    "code_audit",
+    "gap_clustering",
+    "brainstorm_user",
+    "brainstorm_self",
+})
+
+
+@dataclass(frozen=True)
+class AtomicFinding:
+    """A single, self-contained finding."""
+
+    title: str
+    content: str
+    sources: list[str] = field(default_factory=list)
+    relevance: str = ""
+
+
+@dataclass(frozen=True)
+class ScoredFinding:
+    """An atomic finding with a confidence score and routing metadata."""
+
+    finding: AtomicFinding
+    confidence: float
+    source: IntakeSource
+    source_task_type: str = ""
+    generating_model: str = ""
+    is_pattern_insight: bool = False
+
+
+class IntakeResult(StrEnum):
+    """Routing decision."""
+
+    KNOWLEDGE = "knowledge"
+    OBSERVATION = "observation"
+    DISCARD = "discard"
+
+
+@dataclass
+class IntakeStats:
+    """Observability counters for a single intake run."""
+
+    source: str = ""
+    atomization_path: str = ""  # "json_findings", "json_single", "markdown_split", "single_item"
+    findings_count: int = 0
+    routed_knowledge: int = 0
+    routed_observation: int = 0
+    routed_discard: int = 0
+    scoring_skipped: bool = False
+    scoring_model: str = ""
+    errors: list[str] = field(default_factory=list)
+
+
+# ── Atomization ──────────────────────────────────────────────────────────
+
+
+def atomize(content: str, source_task_type: str) -> tuple[list[AtomicFinding], str]:
+    """Split content into atomic findings.
+
+    Returns (findings, atomization_path) where path is one of:
+    - "json_findings": parsed JSON with findings array
+    - "json_single": valid JSON but no findings key
+    - "markdown_split": split on markdown headings/numbered items
+    - "single_item": treated as one finding (fallback or single-output type)
+    """
+    if not content or not content.strip():
+        return [], "empty"
+
+    # Single-output task types skip atomization entirely.
+    if source_task_type not in _MULTI_FINDING_TASK_TYPES:
+        return [AtomicFinding(
+            title=source_task_type.replace("_", " ").title(),
+            content=content.strip(),
+        )], "single_item"
+
+    # Attempt 1: Parse as JSON with findings array.
+    try:
+        data = json.loads(content)
+        if isinstance(data, dict) and "findings" in data:
+            findings_raw = data["findings"]
+            if isinstance(findings_raw, list) and findings_raw:
+                findings = []
+                for item in findings_raw:
+                    if isinstance(item, dict):
+                        findings.append(AtomicFinding(
+                            title=str(item.get("title", ""))[:200],
+                            content=str(item.get("content", "")),
+                            sources=[str(s) for s in item.get("sources", [])
+                                     if isinstance(s, str)],
+                            relevance=str(item.get("relevance", "")),
+                        ))
+                    elif isinstance(item, str):
+                        findings.append(AtomicFinding(
+                            title=item[:200],
+                            content=item,
+                        ))
+                if findings:
+                    return findings, "json_findings"
+        # Valid JSON but no findings key — treat as single item.
+        if isinstance(data, dict):
+            return [AtomicFinding(
+                title=str(data.get("title", source_task_type.replace("_", " ").title()))[:200],
+                content=json.dumps(data, indent=2) if not isinstance(data, str) else data,
+            )], "json_single"
+    except (json.JSONDecodeError, ValueError, TypeError):
+        pass
+
+    # Attempt 2: Markdown split on headings or numbered items.
+    findings = _markdown_split(content)
+    if findings and len(findings) > 1:
+        return findings, "markdown_split"
+
+    # Attempt 3: Fall back to single item.
+    return [AtomicFinding(
+        title=source_task_type.replace("_", " ").title(),
+        content=content.strip(),
+    )], "single_item"
+
+
+# Markdown heading pattern: ## Title or ### Title
+_HEADING_RE = re.compile(r"^#{2,3}\s+(.+)", re.MULTILINE)
+# Numbered list: 1. / 1) or **1.** / **1)** (bold numbered items)
+_NUMBERED_RE = re.compile(r"^(?:\*{2})?\d+[.)]\*{0,2}\s+(.+?)(?:\n|$)", re.MULTILINE)
+
+
+def _markdown_split(content: str) -> list[AtomicFinding]:
+    """Best-effort split on markdown structure."""
+    # Try heading-delimited sections first.
+    headings = list(_HEADING_RE.finditer(content))
+    if len(headings) >= 2:
+        findings = []
+        for i, match in enumerate(headings):
+            title = match.group(1).strip()
+            start = match.end()
+            end = headings[i + 1].start() if i + 1 < len(headings) else len(content)
+            body = content[start:end].strip()
+            if body:
+                findings.append(AtomicFinding(title=title[:200], content=body))
+        return findings
+
+    # Try numbered items.
+    numbered = list(_NUMBERED_RE.finditer(content))
+    if len(numbered) >= 2:
+        findings = []
+        for i, match in enumerate(numbered):
+            start = match.start()
+            end = numbered[i + 1].start() if i + 1 < len(numbered) else len(content)
+            chunk = content[start:end].strip()
+            # Use the first line as title.
+            lines = chunk.split("\n", 1)
+            title = re.sub(r"^(?:\*{2})?\d+[.)]\*{0,2}\s*", "", lines[0]).strip()
+            body = lines[1].strip() if len(lines) > 1 else title
+            if title:
+                findings.append(AtomicFinding(title=title[:200], content=body or title))
+        return findings
+
+    return []
+
+
+# ── Scoring ──────────────────────────────────────────────────────────────
+
+
+def score_finding(
+    finding: AtomicFinding,
+    source: IntakeSource,
+    source_task_type: str = "",
+    generating_model: str = "",
+) -> ScoredFinding:
+    """Assign confidence from source tier (curated sources skip LLM scoring).
+
+    For uncurated sources, the caller must run LLM scoring via score_batch_llm().
+    This function provides the non-LLM fast path.
+    """
+    confidence = _CURATED_SOURCES.get(source, _UNCURATED_SOURCES.get(source, 0.5))
+    return ScoredFinding(
+        finding=finding,
+        confidence=confidence,
+        source=source,
+        source_task_type=source_task_type,
+        generating_model=generating_model,
+    )
+
+
+def needs_llm_scoring(source: IntakeSource) -> bool:
+    """Return True if this source needs LLM scoring."""
+    return source in _UNCURATED_SOURCES
+
+
+_INTAKE_SCORE_PROMPT = """\
+You are scoring intelligence findings for relevance and quality.
+
+For each finding below, assign a score from 0.0 to 1.0 based on:
+- Relevance to the user's projects and interests
+- Actionability — can something be done with this information?
+- Novelty — is this new information or already known?
+- Quality — is this well-sourced and specific?
+
+Also mark if the finding represents a pattern-level insight (recurring theme,
+systemic issue, cross-domain connection) vs a single data point.
+
+Respond with ONLY a JSON array:
+```json
+[
+  {{"index": 0, "score": 0.7, "is_pattern": false, "reason": "..."}},
+  {{"index": 1, "score": 0.3, "is_pattern": false, "reason": "..."}}
+]
+```
+
+## Findings to score:
+
+{findings_text}
+"""
+
+
+async def score_batch_llm(
+    findings: list[AtomicFinding],
+    source: IntakeSource,
+    router: Router,
+    source_task_type: str = "",
+    generating_model: str = "",
+) -> list[ScoredFinding]:
+    """Score a batch of findings via LLM (for uncurated sources).
+
+    Falls back to default source confidence if the LLM call fails.
+    """
+    if not findings:
+        return []
+
+    default_confidence = _UNCURATED_SOURCES.get(source, 0.5)
+
+    # Build the findings text for the prompt.
+    parts = []
+    for i, f in enumerate(findings):
+        parts.append(f"### Finding {i}: {f.title}\n{f.content[:500]}")
+    findings_text = "\n\n".join(parts)
+
+    prompt = _INTAKE_SCORE_PROMPT.format(findings_text=findings_text)
+
+    try:
+        result = await router.route(
+            call_site_id="45_intelligence_intake",
+            system="You are an intelligence quality scorer.",
+            prompt=prompt,
+            temperature=0.1,
+        )
+        if not result.success or not result.content:
+            logger.warning("Intake LLM scoring returned empty — using defaults")
+            return [
+                ScoredFinding(
+                    finding=f, confidence=default_confidence,
+                    source=source, source_task_type=source_task_type,
+                    generating_model=generating_model,
+                )
+                for f in findings
+            ]
+
+        # Parse LLM scores.
+        scores = _parse_score_response(result.content)
+        scored = []
+        for i, f in enumerate(findings):
+            score_data = scores.get(i, {})
+            scored.append(ScoredFinding(
+                finding=f,
+                confidence=float(score_data.get("score", default_confidence)),
+                source=source,
+                source_task_type=source_task_type,
+                generating_model=generating_model,
+                is_pattern_insight=bool(score_data.get("is_pattern", False)),
+            ))
+        return scored
+
+    except Exception:
+        logger.warning("Intake LLM scoring failed — using default confidence", exc_info=True)
+        return [
+            ScoredFinding(
+                finding=f, confidence=default_confidence,
+                source=source, source_task_type=source_task_type,
+                generating_model=generating_model,
+            )
+            for f in findings
+        ]
+
+
+def _parse_score_response(content: str) -> dict[int, dict]:
+    """Parse LLM scoring response into {index: {score, is_pattern, reason}}."""
+    # Strip markdown code fences.
+    content = re.sub(r"```(?:json)?\s*", "", content)
+    content = content.strip()
+
+    try:
+        data = json.loads(content)
+        if isinstance(data, list):
+            return {
+                item.get("index", i): item
+                for i, item in enumerate(data)
+                if isinstance(item, dict)
+            }
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return {}
+
+
+# ── Routing ──────────────────────────────────────────────────────────────
+
+
+def route(scored: ScoredFinding) -> IntakeResult:
+    """Determine where a scored finding goes.
+
+    Thresholds:
+    - >= 0.5 → knowledge base
+    - >= 0.7 AND pattern insight → also create observation
+    - 0.4–0.5 → knowledge at low confidence
+    - < 0.4 → discard
+    """
+    if scored.confidence >= 0.7 and scored.is_pattern_insight:
+        return IntakeResult.OBSERVATION
+    if scored.confidence >= 0.4:
+        return IntakeResult.KNOWLEDGE
+    return IntakeResult.DISCARD
+
+
+# ── Pipeline orchestration ───────────────────────────────────────────────
+
+
+async def run_intake(
+    content: str,
+    source: IntakeSource,
+    source_task_type: str = "",
+    generating_model: str = "",
+    *,
+    db: aiosqlite.Connection,
+    store: MemoryStore | None = None,
+    router: Router | None = None,
+) -> IntakeStats:
+    """Run the full intake pipeline: atomize → score → route.
+
+    For curated sources (surplus, email_recon, etc.), scoring is skipped
+    and findings go directly to the knowledge base at source-tier confidence.
+
+    For uncurated sources (github_landscape, web_monitoring), LLM scoring
+    is applied via the 45_intelligence_intake call site.
+
+    Args:
+        content: Raw content to process.
+        source: The IntakeSource category.
+        source_task_type: Original task type string.
+        generating_model: Model that generated the content.
+        db: Database connection.
+        store: MemoryStore for knowledge ingestion (resolved from runtime if None).
+        router: Router for LLM scoring (only needed for uncurated sources).
+
+    Returns:
+        IntakeStats with observability counters.
+    """
+    stats = IntakeStats(source=source.value)
+
+    # Step 1: Atomize.
+    findings, atom_path = atomize(content, source_task_type)
+    stats.atomization_path = atom_path
+    stats.findings_count = len(findings)
+
+    if not findings:
+        return stats
+
+    # Step 2: Score (conditional).
+    if needs_llm_scoring(source):
+        if router is not None:
+            scored_findings = await score_batch_llm(
+                findings, source, router,
+                source_task_type=source_task_type,
+                generating_model=generating_model,
+            )
+            stats.scoring_skipped = False
+        else:
+            logger.warning("No router available for LLM scoring — using defaults")
+            scored_findings = [
+                score_finding(f, source, source_task_type, generating_model)
+                for f in findings
+            ]
+            stats.scoring_skipped = True
+    else:
+        scored_findings = [
+            score_finding(f, source, source_task_type, generating_model)
+            for f in findings
+        ]
+        stats.scoring_skipped = True
+
+    # Step 3: Route each finding.
+    for scored in scored_findings:
+        destination = route(scored)
+        try:
+            if destination == IntakeResult.KNOWLEDGE:
+                await _route_to_knowledge(scored, db=db, store=store)
+                stats.routed_knowledge += 1
+            elif destination == IntakeResult.OBSERVATION:
+                await _route_to_knowledge(scored, db=db, store=store)
+                await _route_to_observation(scored, db=db)
+                stats.routed_knowledge += 1
+                stats.routed_observation += 1
+            else:
+                stats.routed_discard += 1
+        except Exception as exc:
+            logger.error(
+                "Intake routing failed for finding '%s': %s",
+                scored.finding.title[:50], exc, exc_info=True,
+            )
+            stats.errors.append(f"{scored.finding.title[:50]}: {exc}")
+
+    # Log intake event for observability.
+    logger.info(
+        "Intake: source=%s, atomization=%s, findings=%d, "
+        "knowledge=%d, observation=%d, discard=%d, scoring_skipped=%s",
+        stats.source, stats.atomization_path, stats.findings_count,
+        stats.routed_knowledge, stats.routed_observation,
+        stats.routed_discard, stats.scoring_skipped,
+    )
+
+    return stats
+
+
+async def _route_to_knowledge(
+    scored: ScoredFinding,
+    *,
+    db: aiosqlite.Connection,
+    store: MemoryStore | None = None,
+) -> None:
+    """Store finding in the knowledge base."""
+    # Resolve MemoryStore from runtime if not provided.
+    if store is None:
+        try:
+            from genesis.runtime import GenesisRuntime
+            rt = GenesisRuntime.instance()
+            store = rt._memory_store
+        except Exception:
+            logger.warning("Cannot resolve MemoryStore — falling back to memory_store MCP")
+            store = None
+
+    if store is None:
+        logger.warning("No MemoryStore available — skipping knowledge ingestion")
+        return
+
+    from genesis.memory.knowledge_ingest import ingest_knowledge_unit
+
+    # Build provenance.
+    provenance = {
+        "source_doc": f"intake:{scored.source.value}",
+        "ingested_at": datetime.now(UTC).isoformat(),
+    }
+    if scored.generating_model:
+        provenance["generating_model"] = scored.generating_model
+
+    # Determine domain from source.
+    domain = _domain_for_source(scored.source, scored.source_task_type)
+
+    sources_str = ""
+    if scored.finding.sources:
+        sources_str = "\n\nSources: " + ", ".join(scored.finding.sources)
+
+    content_for_kb = (
+        f"{scored.finding.title}\n\n"
+        f"{scored.finding.content}"
+        f"{sources_str}"
+    )
+    if scored.finding.relevance:
+        content_for_kb += f"\n\nRelevance: {scored.finding.relevance}"
+
+    await ingest_knowledge_unit(
+        store=store,
+        db=db,
+        content=content_for_kb,
+        project="genesis",
+        domain=domain,
+        authority=scored.source.value,
+        provenance=provenance,
+        memory_class="fact",
+    )
+
+
+async def _route_to_observation(
+    scored: ScoredFinding,
+    *,
+    db: aiosqlite.Connection,
+) -> None:
+    """Create an observation for pattern-level insights."""
+    from genesis.db.crud import observations
+
+    obs_id = str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+    content = (
+        f"{scored.finding.title}\n\n"
+        f"{scored.finding.content}"
+    )
+    if scored.finding.relevance:
+        content += f"\n\nRelevance: {scored.finding.relevance}"
+
+    await observations.create(
+        db,
+        id=obs_id,
+        source=f"intake:{scored.source.value}",
+        type=scored.source_task_type or "intelligence_finding",
+        content=content[:2000],
+        priority="medium",
+        created_at=now,
+    )
+
+
+def _domain_for_source(source: IntakeSource, task_type: str) -> str:
+    """Map source/task_type to a knowledge domain string."""
+    domain_map = {
+        IntakeSource.EMAIL_RECON: "intelligence.email",
+        IntakeSource.GITHUB_LANDSCAPE: "intelligence.github",
+        IntakeSource.MODEL_INTELLIGENCE: "intelligence.models",
+        IntakeSource.FREE_MODEL_INVENTORY: "intelligence.models",
+        IntakeSource.WEB_MONITORING: "intelligence.web",
+        IntakeSource.SOURCE_DISCOVERY: "intelligence.sources",
+        IntakeSource.FOREGROUND_WEB: "research.web",
+        IntakeSource.BACKGROUND_TASK: "research.background",
+        IntakeSource.USER_DIRECTED: "research.user",
+    }
+    if source in domain_map:
+        return domain_map[source]
+    # Fall back based on task type.
+    if "code" in task_type:
+        return "intelligence.code"
+    return "intelligence.surplus"
+
+
+# ── Web search capture ───────────────────────────────────────────────────
+
+
+async def capture_web_result(
+    url: str,
+    content_summary: str,
+    query_context: str,
+    session_type: str = "foreground",
+    *,
+    db: aiosqlite.Connection,
+    store: MemoryStore | None = None,
+) -> IntakeStats:
+    """Capture a web search result through the intake pipeline.
+
+    Called by sessions when a web search/fetch returns useful results.
+    Not automatic — the session decides what's worth capturing.
+
+    session_type: "foreground" (0.75), "background" (0.7), "surplus" (0.6)
+    """
+    source_map = {
+        "foreground": IntakeSource.FOREGROUND_WEB,
+        "background": IntakeSource.BACKGROUND_TASK,
+        "surplus": IntakeSource.ANTICIPATORY_RESEARCH,
+    }
+    source = source_map.get(session_type, IntakeSource.FOREGROUND_WEB)
+
+    content = (
+        f"Web result: {url}\n\n"
+        f"Query: {query_context}\n\n"
+        f"{content_summary}"
+    )
+
+    return await run_intake(
+        content=content,
+        source=source,
+        source_task_type="web_capture",
+        db=db,
+        store=store,
+    )
+
+
+# ── Helpers for callers ──────────────────────────────────────────────────
+
+
+def source_for_task_type(task_type: str) -> IntakeSource:
+    """Map a surplus task type string to its IntakeSource."""
+    return _TASK_TYPE_TO_SOURCE.get(task_type, IntakeSource.ANTICIPATORY_RESEARCH)

--- a/src/genesis/surplus/intake.py
+++ b/src/genesis/surplus/intake.py
@@ -498,6 +498,15 @@ async def run_intake(
         stats.routed_discard, stats.scoring_skipped,
     )
 
+    # If ALL non-discard findings failed routing, raise so caller can fall back.
+    expected_routes = stats.findings_count - stats.routed_discard
+    actual_routes = stats.routed_knowledge + stats.routed_observation
+    if expected_routes > 0 and actual_routes == 0 and stats.errors:
+        raise RuntimeError(
+            f"Intake routing failed for all {expected_routes} findings: "
+            f"{stats.errors[0]}"
+        )
+
     return stats
 
 
@@ -519,8 +528,7 @@ async def _route_to_knowledge(
             store = None
 
     if store is None:
-        logger.warning("No MemoryStore available — skipping knowledge ingestion")
-        return
+        raise RuntimeError("No MemoryStore available for knowledge ingestion")
 
     from genesis.memory.knowledge_ingest import ingest_knowledge_unit
 

--- a/src/genesis/surplus/intake.py
+++ b/src/genesis/surplus/intake.py
@@ -320,10 +320,12 @@ async def score_batch_llm(
     prompt = _INTAKE_SCORE_PROMPT.format(findings_text=findings_text)
 
     try:
-        result = await router.route(
-            call_site_id="45_intelligence_intake",
-            system="You are an intelligence quality scorer.",
-            prompt=prompt,
+        result = await router.route_call(
+            "45_intelligence_intake",
+            messages=[
+                {"role": "system", "content": "You are an intelligence quality scorer."},
+                {"role": "user", "content": prompt},
+            ],
             temperature=0.1,
         )
         if not result.success or not result.content:

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -715,7 +715,7 @@ class SurplusScheduler:
             await self._maybe_observe_failure(task, result.error or "unknown")
             return False
 
-        # 6. Write to staging (with content-hash dedup + quality gate)
+        # 6. Route through intake pipeline (atomize → score → route to knowledge)
         staging_id = None
         if result.insights:
             insight = result.insights[0]
@@ -727,22 +727,52 @@ class SurplusScheduler:
                     len(content.strip()), task.id[:8],
                 )
             else:
-                content_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
-                staging_id = f"{task.task_type.value}-{content_hash}"
-                now = self._clock()
-                ttl = (now + timedelta(days=7)).isoformat()
-                now_iso = now.isoformat()
-                await surplus_crud.upsert(
-                    self._db,
-                    id=staging_id,
-                    content=content,
-                    source_task_type=str(task.task_type),
-                    generating_model=insight.get("generating_model", "unknown"),
-                    drive_alignment=task.drive_alignment,
-                    confidence=insight.get("confidence", 0.0),
-                    created_at=now_iso,
-                    ttl=ttl,
-                )
+                try:
+                    from genesis.surplus.intake import (
+                        run_intake,
+                        source_for_task_type,
+                    )
+                    source = source_for_task_type(str(task.task_type))
+                    intake_stats = await run_intake(
+                        content=content,
+                        source=source,
+                        source_task_type=str(task.task_type),
+                        generating_model=insight.get("generating_model", "unknown"),
+                        db=self._db,
+                    )
+                    logger.info(
+                        "Intake routed %d findings (k=%d, o=%d, d=%d) for task %s",
+                        intake_stats.findings_count,
+                        intake_stats.routed_knowledge,
+                        intake_stats.routed_observation,
+                        intake_stats.routed_discard,
+                        task.id[:8],
+                    )
+                    # Use a synthetic staging_id for tracking
+                    content_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
+                    staging_id = f"{task.task_type.value}-{content_hash}"
+                except Exception:
+                    # Fallback: write to surplus_insights staging (old behavior)
+                    logger.warning(
+                        "Intake pipeline failed — falling back to surplus_insights staging",
+                        exc_info=True,
+                    )
+                    content_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
+                    staging_id = f"{task.task_type.value}-{content_hash}"
+                    now = self._clock()
+                    ttl = (now + timedelta(days=7)).isoformat()
+                    now_iso = now.isoformat()
+                    await surplus_crud.upsert(
+                        self._db,
+                        id=staging_id,
+                        content=content,
+                        source_task_type=str(task.task_type),
+                        generating_model=insight.get("generating_model", "unknown"),
+                        drive_alignment=task.drive_alignment,
+                        confidence=insight.get("confidence", 0.0),
+                        created_at=now_iso,
+                        ttl=ttl,
+                    )
 
         await self._queue.mark_completed(task.id, staging_id=staging_id)
 

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -93,6 +93,7 @@ class SurplusScheduler:
         self._dead_letter_replay_executor: SurplusExecutor | None = None
         self._db_maintenance_executor: SurplusExecutor | None = None
         self._recon_gatherer: ReconGatherer | None = None
+        self._model_intelligence_job = None  # Set via set_model_intelligence_job()
         self._extraction_store: MemoryStore | None = None
         self._extraction_router: Router | None = None
         self._follow_up_dispatcher = None  # Set via set_follow_up_dispatcher()
@@ -154,6 +155,10 @@ class SurplusScheduler:
     def set_recon_gatherer(self, gatherer: ReconGatherer) -> None:
         """Set the recon gatherer for scheduled release checking."""
         self._recon_gatherer = gatherer
+
+    def set_model_intelligence_job(self, job) -> None:
+        """Set the ModelIntelligenceJob for scheduled model landscape scanning."""
+        self._model_intelligence_job = job
 
     def set_extraction_deps(
         self,
@@ -222,6 +227,16 @@ class SurplusScheduler:
             max_instances=1,
             misfire_grace_time=300,
         )
+        # Model intelligence: weekly Sunday 6am (per config/recon_schedules.yaml)
+        if self._model_intelligence_job is not None:
+            from apscheduler.triggers.cron import CronTrigger
+            self._scheduler.add_job(
+                self.run_model_intelligence,
+                CronTrigger(day_of_week="sun", hour=6),
+                id="model_intelligence",
+                max_instances=1,
+                misfire_grace_time=3600,
+            )
         self._scheduler.add_job(
             self.schedule_maintenance,
             IntervalTrigger(hours=self._maintenance_hours),
@@ -560,6 +575,45 @@ class SurplusScheduler:
             try:
                 from genesis.runtime import GenesisRuntime
                 GenesisRuntime.instance().record_job_failure("recon_gather", str(exc))
+            except Exception:
+                pass
+
+    async def run_model_intelligence(self) -> None:
+        """Run model intelligence scan (weekly)."""
+        if self._model_intelligence_job is None:
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_failure(
+                    "model_intelligence", "job not wired",
+                )
+            except Exception:
+                pass
+            return
+        try:
+            result = await self._model_intelligence_job.run()
+            total = result.get("total_findings", 0)
+            logger.info("Model intelligence scan: %d findings", total)
+            if self._event_bus:
+                await self._event_bus.emit(
+                    Subsystem.RECON, Severity.DEBUG,
+                    "heartbeat", "model_intelligence completed",
+                )
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_success("model_intelligence")
+            except Exception:
+                pass
+        except Exception as exc:
+            logger.exception("Model intelligence scan failed")
+            if self._event_bus:
+                await self._event_bus.emit(
+                    Subsystem.RECON, Severity.ERROR,
+                    "model_intelligence.failed",
+                    "Model intelligence scan failed",
+                )
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_failure("model_intelligence", str(exc))
             except Exception:
                 pass
 

--- a/tests/test_cc/test_reflection_bridge.py
+++ b/tests/test_cc/test_reflection_bridge.py
@@ -323,7 +323,7 @@ async def test_strategic_enriched_path_includes_observations_and_pointers(db, mo
             {"id": "obs-1", "type": "test", "source": "test", "priority": "medium",
              "content": "Observation content here", "created_at": "2026-04-02T12:00:00"},
         ],
-        surplus_staging_items=[],
+        intelligence_digest="",
         pending_work=PendingWorkSummary(memory_consolidation=False),
         procedure_stats=ProcedureStats(total_active=0, total_quarantined=0, avg_success_rate=0, low_performers=[]),
         cost_summary=CostSummary(daily_usd=0.0, weekly_usd=0.0, monthly_usd=0.0,

--- a/tests/test_reflection/test_bridge_overhaul.py
+++ b/tests/test_reflection/test_bridge_overhaul.py
@@ -270,7 +270,7 @@ class TestPromptFiles:
         path = Path(__file__).resolve().parent.parent.parent / "src" / "genesis" / "identity" / "REFLECTION_DEEP.md"
         content = path.read_text()
         assert "Memory Consolidation" in content
-        assert "Surplus Review" in content
+        assert "Intelligence Digest" in content
         assert "Skill Review" in content
         assert "Cognitive State Regeneration" in content
         assert "memory_operations" in content

--- a/tests/test_reflection/test_context_gatherer.py
+++ b/tests/test_reflection/test_context_gatherer.py
@@ -29,7 +29,6 @@ class TestDetectPendingWork:
     async def test_no_pending_work_empty_db(self, db, gatherer):
         pending = await gatherer.detect_pending_work(db)
         assert not pending.memory_consolidation
-        assert not pending.surplus_review
         assert pending.cost_reconciliation  # always true
         assert not pending.has_any_work or pending.cost_reconciliation
 
@@ -62,23 +61,6 @@ class TestDetectPendingWork:
         pending = await gatherer.detect_pending_work(db)
         assert pending.memory_consolidation
         assert pending.observation_backlog == 12
-
-    @pytest.mark.asyncio
-    async def test_surplus_review_pending(self, db, gatherer):
-        """Pending surplus items → surplus review needed."""
-        now = datetime.now(UTC).isoformat()
-        ttl = (datetime.now(UTC) + timedelta(days=3)).isoformat()
-        await db.execute(
-            "INSERT INTO surplus_insights "
-            "(id, content, source_task_type, generating_model, drive_alignment, "
-            "confidence, created_at, ttl) VALUES (?, 'test', 'brainstorm', "
-            "'model', 'curiosity', 0.5, ?, ?)",
-            (str(uuid.uuid4()), now, ttl),
-        )
-        await db.commit()
-        pending = await gatherer.detect_pending_work(db)
-        assert pending.surplus_review
-        assert pending.surplus_pending == 1
 
     @pytest.mark.asyncio
     async def test_cognitive_state_stale(self, db, gatherer):
@@ -125,7 +107,7 @@ class TestGather:
     async def test_gather_empty_db(self, db, gatherer):
         bundle = await gatherer.gather(db)
         assert bundle.recent_observations == []
-        assert bundle.surplus_staging_items == []
+        assert bundle.intelligence_digest != ""  # always has a message
         assert isinstance(bundle.cost_summary.daily_usd, float)
 
     @pytest.mark.asyncio

--- a/tests/test_reflection/test_output_router.py
+++ b/tests/test_reflection/test_output_router.py
@@ -16,7 +16,6 @@ from genesis.reflection.output_router import (
 from genesis.reflection.types import (
     DeepReflectionOutput,
     QualityCalibrationOutput,
-    SurplusDecision,
     WeeklyAssessmentOutput,
 )
 
@@ -70,16 +69,16 @@ class TestParseDeepReflectionOutput:
         assert len(out.memory_operations) == 1
         assert out.memory_operations[0].operation == "dedup"
 
-    def test_surplus_decisions_parsed(self):
+    def test_surplus_decisions_ignored(self):
+        """Old outputs with surplus_decisions should parse without error."""
         raw = json.dumps({
             "surplus_decisions": [
                 {"item_id": "s1", "action": "promote", "reason": "good"},
-                {"item_id": "s2", "action": "discard"},
             ],
         })
         out = parse_deep_reflection_output(raw)
-        assert len(out.surplus_decisions) == 2
-        assert out.surplus_decisions[0].action == "promote"
+        # surplus_decisions field no longer exists on output
+        assert not hasattr(out, "surplus_decisions")
 
     def test_missing_fields_get_defaults(self):
         raw = json.dumps({"observations": ["only this"]})
@@ -181,78 +180,6 @@ class TestRouteDeepReflection:
         row = await cursor.fetchone()
         assert row is not None
         assert dict(row)["content"] == "new active context"
-
-    @pytest.mark.asyncio
-    async def test_routes_surplus_promote(self, db, router):
-        # Insert a pending surplus item
-        now = datetime.now(UTC).isoformat()
-        ttl = (datetime.now(UTC) + timedelta(days=3)).isoformat()
-        await db.execute(
-            "INSERT INTO surplus_insights "
-            "(id, content, source_task_type, generating_model, drive_alignment, "
-            "confidence, created_at, ttl) VALUES ('s1', 'test', 'brainstorm', "
-            "'model', 'curiosity', 0.5, ?, ?)",
-            (now, ttl),
-        )
-        await db.commit()
-
-        output = DeepReflectionOutput(
-            surplus_decisions=[SurplusDecision(item_id="s1", action="promote", reason="good")]
-        )
-        summary = await router.route(output, db)
-        assert summary["surplus_decisions"] == 1
-
-        cursor = await db.execute("SELECT promotion_status FROM surplus_insights WHERE id = 's1'")
-        row = await cursor.fetchone()
-        assert row[0] == "promoted"
-
-        # Verify an observation was also created from the promoted insight
-        cursor = await db.execute(
-            "SELECT * FROM observations WHERE source = 'surplus_promotion'"
-        )
-        obs_rows = await cursor.fetchall()
-        assert len(obs_rows) == 1
-        obs = dict(obs_rows[0])
-        assert obs["type"] == "brainstorm"
-        assert obs["content"] == "test"
-
-    @pytest.mark.asyncio
-    async def test_promote_nonexistent_id_is_noop(self, db, router):
-        """Promoting a non-existent surplus ID logs warning and does nothing."""
-        output = DeepReflectionOutput(
-            surplus_decisions=[SurplusDecision(item_id="nonexistent", action="promote", reason="test")]
-        )
-        summary = await router.route(output, db)
-        assert summary["surplus_decisions"] == 1
-
-        # No observation should be created
-        cursor = await db.execute(
-            "SELECT COUNT(*) FROM observations WHERE source = 'surplus_promotion'"
-        )
-        row = await cursor.fetchone()
-        assert row[0] == 0
-
-    @pytest.mark.asyncio
-    async def test_routes_surplus_discard(self, db, router):
-        now = datetime.now(UTC).isoformat()
-        ttl = (datetime.now(UTC) + timedelta(days=3)).isoformat()
-        await db.execute(
-            "INSERT INTO surplus_insights "
-            "(id, content, source_task_type, generating_model, drive_alignment, "
-            "confidence, created_at, ttl) VALUES ('s2', 'test', 'brainstorm', "
-            "'model', 'curiosity', 0.5, ?, ?)",
-            (now, ttl),
-        )
-        await db.commit()
-
-        output = DeepReflectionOutput(
-            surplus_decisions=[SurplusDecision(item_id="s2", action="discard")]
-        )
-        await router.route(output, db)
-
-        cursor = await db.execute("SELECT promotion_status FROM surplus_insights WHERE id = 's2'")
-        row = await cursor.fetchone()
-        assert row[0] == "discarded"
 
     @pytest.mark.asyncio
     async def test_routes_quarantines(self, db, router):

--- a/tests/test_reflection/test_output_router.py
+++ b/tests/test_reflection/test_output_router.py
@@ -1,7 +1,6 @@
 """Tests for genesis.reflection.output_router — parsing and routing."""
 
 import json
-from datetime import UTC, datetime, timedelta
 
 import aiosqlite
 import pytest

--- a/tests/test_reflection/test_types.py
+++ b/tests/test_reflection/test_types.py
@@ -14,7 +14,6 @@ from genesis.reflection.types import (
     ProcedureStats,
     ProcedureTrend,
     QualityCalibrationOutput,
-    SurplusDecision,
     WeeklyAssessmentOutput,
 )
 
@@ -22,14 +21,16 @@ from genesis.reflection.types import (
 class TestDeepReflectionJob:
     def test_enum_values(self):
         assert DeepReflectionJob.MEMORY_CONSOLIDATION == "memory_consolidation"
-        assert DeepReflectionJob.SURPLUS_REVIEW == "surplus_review"
         assert DeepReflectionJob.SKILL_REVIEW == "skill_review"
         assert DeepReflectionJob.COST_RECONCILIATION == "cost_reconciliation"
         assert DeepReflectionJob.LESSONS_EXTRACTION == "lessons_extraction"
         assert DeepReflectionJob.COGNITIVE_REGENERATION == "cognitive_regeneration"
 
     def test_all_values(self):
-        assert len(DeepReflectionJob) == 6
+        assert len(DeepReflectionJob) == 5
+
+    def test_surplus_review_removed(self):
+        assert "surplus_review" not in [j.value for j in DeepReflectionJob]
 
 
 class TestAssessmentDimension:
@@ -44,22 +45,25 @@ class TestPendingWorkSummary:
         assert p.active_jobs == []
 
     def test_single_job(self):
-        p = PendingWorkSummary(surplus_review=True, surplus_pending=3)
+        p = PendingWorkSummary(memory_consolidation=True, observation_backlog=15)
         assert p.has_any_work
-        assert p.active_jobs == [DeepReflectionJob.SURPLUS_REVIEW]
+        assert p.active_jobs == [DeepReflectionJob.MEMORY_CONSOLIDATION]
 
     def test_multiple_jobs(self):
         p = PendingWorkSummary(
             memory_consolidation=True,
-            surplus_review=True,
             cognitive_regeneration=True,
         )
-        assert len(p.active_jobs) == 3
+        assert len(p.active_jobs) == 2
 
     def test_frozen(self):
         p = PendingWorkSummary()
         with pytest.raises(AttributeError):
-            p.surplus_review = True  # type: ignore[misc]
+            p.memory_consolidation = True  # type: ignore[misc]
+
+    def test_intake_items_field(self):
+        p = PendingWorkSummary(intake_items_since_last=42)
+        assert p.intake_items_since_last == 42
 
 
 class TestProcedureStats:
@@ -89,22 +93,16 @@ class TestContextBundle:
         assert cb.recent_observations == []
         assert isinstance(cb.pending_work, PendingWorkSummary)
 
+    def test_intelligence_digest(self):
+        cb = ContextBundle(intelligence_digest="5 items triaged")
+        assert cb.intelligence_digest == "5 items triaged"
+
 
 class TestMemoryOperation:
     def test_construction(self):
         op = MemoryOperation(operation="dedup", target_ids=["a", "b"], reason="similar")
         assert op.operation == "dedup"
         assert len(op.target_ids) == 2
-
-
-class TestSurplusDecision:
-    def test_promote(self):
-        sd = SurplusDecision(item_id="s1", action="promote", reason="valuable")
-        assert sd.action == "promote"
-
-    def test_discard(self):
-        sd = SurplusDecision(item_id="s2", action="discard")
-        assert sd.action == "discard"
 
 
 class TestDeepReflectionOutput:
@@ -117,10 +115,9 @@ class TestDeepReflectionOutput:
     def test_with_data(self):
         out = DeepReflectionOutput(
             observations=["obs1"],
-            surplus_decisions=[SurplusDecision(item_id="x", action="promote")],
             confidence=0.9,
         )
-        assert len(out.surplus_decisions) == 1
+        assert len(out.observations) == 1
 
 
 class TestDimensionScore:

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -133,7 +133,8 @@ def test_load_full_yaml(monkeypatch):
     # 2026-05-10: 44 → 43 after net change (judge added by #304, 2_triage +
     # 7_task_retrospective removed by this PR).
     # 2026-05-12: 43 → 44 after 44_task_premortem added by #334.
-    assert len(cfg.call_sites) == 44
+    # 2026-05-14: 44 → 45 after 45_intelligence_intake added by #349.
+    assert len(cfg.call_sites) == 45
     assert "2_triage" not in cfg.call_sites  # removed 2026-05-10
     assert "7_task_retrospective" not in cfg.call_sites  # removed 2026-05-10 (duplicate; live one is 43_task_retrospective)
     assert "background" in cfg.retry_profiles


### PR DESCRIPTION
## Summary

Comprehensive redesign of how Genesis processes intelligence findings. Replaces the bottlenecked Deep reflection surplus review (20 items per 48h cycle, 2.7% promotion rate) with a unified intake pipeline that processes findings immediately.

**Three-step pipeline:** atomize → conditional score → route
- Curated sources (surplus, email_recon) skip LLM scoring and go straight to knowledge base
- Uncurated sources (github_landscape, web_monitoring) get scored via new `45_intelligence_intake` free-tier call site
- Graceful fallback: all callers fall back to surplus_insights staging if intake fails

### Changes by area

**New intake module** (`src/genesis/surplus/intake.py`)
- `atomize()`: JSON-first with markdown fallback chain
- `score_finding()` / `score_batch_llm()`: conditional scoring by source tier
- `route()`: threshold-based routing to knowledge base, observations, or discard
- `capture_web_result()`: utility for sessions to capture web search findings
- Confidence tiering: user-directed 0.9 → source_discovery 0.4

**Surplus prompts**: multi-finding types (anticipatory_research, brainstorm_user, brainstorm_self, gap_clustering) now request structured JSON output for reliable atomization

**Surplus wiring**: scheduler, brainstorm, findings_bridge all route through intake with fallback

**Recon fixes (4 pipelines)**:
- `github_landscape`: skip pre-releases, reduce to 2/project, timestamp gate
- `model_intelligence`: wired to scheduler via CronTrigger (Sun 6am)
- `free_model_inventory`: cache refreshed (29 free models, was 0 from stale cache)
- `email_recon`: routed through intake (confidence 0.65)

**New recon infrastructure**: web_monitoring URL watcher (empty source list), source_discovery stub (disabled)

**Deep reflection changes**:
- Removed: SURPLUS_REVIEW job, SurplusDecision type, surplus_decisions output, _route_surplus_decision
- Added: intelligence digest (counts by source since last cycle)
- Deep floor reduced from 48h to 24h (migration 0017)

**Code intelligence hook**: rewritten to fire every 3rd qualifying call (path-aware, counter-based)

## Test plan

- [x] Hook: tested counter behavior (fires on 3rd call, skips non-code targets)
- [x] Lint: `ruff check` passes on all modified files
- [x] Reflection tests: 178 passed (updated for SURPLUS_REVIEW removal)
- [x] Surplus tests: 165 passed (fallback to staging works when MemoryStore unavailable)
- [x] Recon tests: 84 passed
- [x] Mail tests: 34 passed
- [x] Code review: two critical bugs caught and fixed (router API, dangling field reference)
- [ ] CI: awaiting

🤖 Generated with [Claude Code](https://claude.com/claude-code)