### PR TITLE
fix(migration): remove db.commit() from 0017

### DIFF
--- a/src/genesis/db/migrations/0017_deep_floor_24h.py
+++ b/src/genesis/db/migrations/0017_deep_floor_24h.py
@@ -26,4 +26,3 @@ async def up(db: aiosqlite.Connection) -> None:
         "UPDATE depth_thresholds SET floor_seconds = 86400 "
         "WHERE depth_name = 'Deep' AND floor_seconds = 172800"
     )
-    await db.commit()


### PR DESCRIPTION
One-line fix: migration runner manages transactions, calling db.commit() inside up() is prohibited.