### PR TITLE
fix(memory): GC for pending_embeddings + events rotation + knowledge retrieved_count

### DIFF
--- a/src/genesis/db/crud/events.py
+++ b/src/genesis/db/crud/events.py
@@ -134,12 +134,22 @@ async def prune(
     db: aiosqlite.Connection,
     *,
     older_than: str,
+    event_type: str | None = None,
 ) -> int:
-    """Delete events older than the given ISO timestamp. Returns count deleted."""
-    cursor = await db.execute(
-        "DELETE FROM events WHERE timestamp < ?",
-        (older_than,),
-    )
+    """Delete events older than the given ISO timestamp. Returns count deleted.
+
+    If *event_type* is provided, only events of that type are pruned.
+    """
+    if event_type is not None:
+        cursor = await db.execute(
+            "DELETE FROM events WHERE event_type = ? AND timestamp < ?",
+            (event_type, older_than),
+        )
+    else:
+        cursor = await db.execute(
+            "DELETE FROM events WHERE timestamp < ?",
+            (older_than,),
+        )
     await db.commit()
     return cursor.rowcount
 

--- a/src/genesis/db/crud/knowledge.py
+++ b/src/genesis/db/crud/knowledge.py
@@ -350,6 +350,28 @@ async def list_by_domain(
     return result
 
 
+async def increment_retrieved_batch(
+    db: aiosqlite.Connection,
+    qdrant_ids: list[str],
+) -> int:
+    """Increment retrieved_count for knowledge units matched by Qdrant point IDs.
+
+    Qdrant point IDs map to knowledge_units.qdrant_id (not .id) because
+    ingest_knowledge_unit stores the memory_metadata ID as qdrant_id.
+    Returns count of rows updated.
+    """
+    if not qdrant_ids:
+        return 0
+    placeholders = ",".join("?" for _ in qdrant_ids)
+    cursor = await db.execute(
+        f"UPDATE knowledge_units SET retrieved_count = retrieved_count + 1 "
+        f"WHERE qdrant_id IN ({placeholders})",
+        qdrant_ids,
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
 async def delete(db: aiosqlite.Connection, unit_id: str) -> bool:
     """Delete a knowledge unit from both knowledge_units and knowledge_fts."""
     cursor = await db.execute(

--- a/src/genesis/db/crud/pending_embeddings.py
+++ b/src/genesis/db/crud/pending_embeddings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import aiosqlite
 
 
@@ -120,6 +122,22 @@ async def delete_by_memory(db: aiosqlite.Connection, *, memory_id: str) -> int:
     cursor = await db.execute(
         "DELETE FROM pending_embeddings WHERE memory_id = ?",
         (memory_id,),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
+async def purge_completed(
+    db: aiosqlite.Connection,
+    *,
+    older_than_days: int = 30,
+) -> int:
+    """Delete embedded/failed rows older than *older_than_days*. Returns count deleted."""
+    cutoff = (datetime.now(UTC) - timedelta(days=older_than_days)).isoformat()
+    cursor = await db.execute(
+        "DELETE FROM pending_embeddings "
+        "WHERE status IN ('embedded', 'failed') AND created_at < ?",
+        (cutoff,),
     )
     await db.commit()
     return cursor.rowcount

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -485,6 +485,31 @@ class HybridRetriever:
                     len(obs_ids), exc_info=True,
                 )
 
+        # 11c. Sync knowledge_units retrieved_count in SQLite
+        #       Match via qdrant_id (Qdrant point ID == knowledge_units.qdrant_id)
+        ku_qdrant_ids: list[str] = []
+        for mid in top:
+            qdrant_hit = qdrant_by_id.get(mid)
+            if qdrant_hit:
+                if qdrant_hit.get("_collection") == "knowledge_base":
+                    ku_qdrant_ids.append(mid)
+            else:
+                # FTS5-only hit — check collection tag
+                fts_hit = fts_by_id.get(mid)
+                if fts_hit and fts_hit.get("collection") == "knowledge_base":
+                    ku_qdrant_ids.append(mid)
+        if ku_qdrant_ids:
+            try:
+                from genesis.db.crud import knowledge as knowledge_crud
+                await knowledge_crud.increment_retrieved_batch(
+                    self._db, ku_qdrant_ids,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to sync knowledge retrieved_count for %d units",
+                    len(ku_qdrant_ids), exc_info=True,
+                )
+
         # 12. Build RetrievalResult objects
         results: list[RetrievalResult] = []
         for mid in top:

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -421,6 +421,21 @@ class SurplusScheduler:
                 if purged:
                     logger.info("Purged %d expired surplus insights", purged)
 
+                # GC: remove completed/failed pending_embeddings older than 30 days
+                from genesis.db.crud import pending_embeddings as pe_crud
+                pe_purged = await pe_crud.purge_completed(rt.db, older_than_days=30)
+                if pe_purged:
+                    logger.info("Purged %d completed pending_embeddings", pe_purged)
+
+                # GC: rotate heartbeat events older than 7 days
+                from genesis.db.crud import events as events_crud
+                hb_cutoff = (datetime.now(UTC) - timedelta(days=7)).isoformat()
+                hb_purged = await events_crud.prune(
+                    rt.db, older_than=hb_cutoff, event_type="heartbeat",
+                )
+                if hb_purged:
+                    logger.info("Pruned %d heartbeat events older than 7d", hb_purged)
+
             with contextlib.suppress(Exception):
                 GenesisRuntime.instance().record_job_success("schedule_maintenance")
         except Exception as exc:

--- a/tests/test_db/test_events_extended.py
+++ b/tests/test_db/test_events_extended.py
@@ -119,6 +119,65 @@ class TestQueryPaginated:
 # ── count_filtered ───────────────────────────────────────────────────────
 
 
+class TestPrune:
+    @pytest.mark.asyncio
+    async def test_prune_all_types(self, db):
+        """Without event_type filter, prune deletes all old events."""
+        await crud.insert(
+            db, subsystem="awareness", severity="info",
+            event_type="heartbeat", message="alive",
+            timestamp="2026-01-01T00:00:00",
+        )
+        await crud.insert(
+            db, subsystem="routing", severity="error",
+            event_type="breaker.tripped", message="down",
+            timestamp="2026-01-01T00:00:00",
+        )
+        pruned = await crud.prune(db, older_than="2026-06-01T00:00:00")
+        assert pruned == 2
+
+    @pytest.mark.asyncio
+    async def test_prune_by_event_type(self, db):
+        """With event_type filter, only matching events are pruned."""
+        await crud.insert(
+            db, subsystem="awareness", severity="info",
+            event_type="heartbeat", message="alive",
+            timestamp="2026-01-01T00:00:00",
+        )
+        await crud.insert(
+            db, subsystem="routing", severity="error",
+            event_type="breaker.tripped", message="down",
+            timestamp="2026-01-01T00:00:00",
+        )
+        pruned = await crud.prune(
+            db, older_than="2026-06-01T00:00:00", event_type="heartbeat",
+        )
+        assert pruned == 1
+        # The error event should remain
+        remaining = await crud.count(db)
+        assert remaining == 1
+
+    @pytest.mark.asyncio
+    async def test_prune_respects_timestamp(self, db):
+        """Events newer than cutoff are kept."""
+        await crud.insert(
+            db, subsystem="awareness", severity="info",
+            event_type="heartbeat", message="old",
+            timestamp="2026-01-01T00:00:00",
+        )
+        await crud.insert(
+            db, subsystem="awareness", severity="info",
+            event_type="heartbeat", message="new",
+            timestamp="2026-12-01T00:00:00",
+        )
+        pruned = await crud.prune(
+            db, older_than="2026-06-01T00:00:00", event_type="heartbeat",
+        )
+        assert pruned == 1
+        remaining = await crud.count(db)
+        assert remaining == 1
+
+
 class TestCountFiltered:
     @pytest.mark.asyncio
     async def test_total_count(self, db):

--- a/tests/test_db/test_knowledge_crud.py
+++ b/tests/test_db/test_knowledge_crud.py
@@ -174,6 +174,47 @@ async def test_stats_filtered_by_project(db):
     assert s["total"] == 1
 
 
+# ─── knowledge.increment_retrieved_batch ─────────────────────────────────────
+
+
+async def test_increment_retrieved_batch_by_qdrant_id(db):
+    """Incrementing by qdrant_id (not id) bumps retrieved_count."""
+    uid = await knowledge.insert(
+        db, project_type="cloud", domain="aws", source_doc="m1",
+        concept="VPC", body="vpc", qdrant_id="qdrant-point-1",
+    )
+    count = await knowledge.increment_retrieved_batch(db, ["qdrant-point-1"])
+    assert count == 1
+    row = await knowledge.get(db, uid)
+    assert row["retrieved_count"] == 1
+
+
+async def test_increment_retrieved_batch_multiple(db):
+    """Batch increment touches all matching rows."""
+    await knowledge.insert(
+        db, project_type="cloud", domain="aws", source_doc="m1",
+        concept="VPC", body="vpc", qdrant_id="qp-1",
+    )
+    await knowledge.insert(
+        db, project_type="cloud", domain="gcp", source_doc="m2",
+        concept="GKE", body="gke", qdrant_id="qp-2",
+    )
+    count = await knowledge.increment_retrieved_batch(db, ["qp-1", "qp-2"])
+    assert count == 2
+
+
+async def test_increment_retrieved_batch_empty_list(db):
+    """Empty list returns 0 without errors."""
+    count = await knowledge.increment_retrieved_batch(db, [])
+    assert count == 0
+
+
+async def test_increment_retrieved_batch_nonexistent_id(db):
+    """Non-matching qdrant_ids are silently skipped."""
+    count = await knowledge.increment_retrieved_batch(db, ["no-such-id"])
+    assert count == 0
+
+
 # ─── knowledge.delete ────────────────────────────────────────────────────────
 
 

--- a/tests/test_db/test_pending_embeddings_crud.py
+++ b/tests/test_db/test_pending_embeddings_crud.py
@@ -134,6 +134,58 @@ class TestResetFailedToPending:
         assert items[0]["error_message"] is None
 
 
+class TestPurgeCompleted:
+    @pytest.mark.asyncio
+    async def test_purges_old_embedded(self, db):
+        """Embedded rows older than threshold are deleted."""
+        await crud.create(
+            db, id="pe-1", memory_id="mem-1", content="old",
+            memory_type="episodic", collection="episodic_memory",
+            created_at="2025-01-01T00:00:00",  # very old
+        )
+        await crud.mark_embedded(db, "pe-1", embedded_at="2025-01-01T00:01:00")
+        purged = await crud.purge_completed(db, older_than_days=30)
+        assert purged == 1
+
+    @pytest.mark.asyncio
+    async def test_purges_old_failed(self, db):
+        """Failed rows older than threshold are deleted."""
+        await crud.create(
+            db, id="pe-1", memory_id="mem-1", content="old",
+            memory_type="episodic", collection="episodic_memory",
+            created_at="2025-01-01T00:00:00",
+        )
+        await crud.mark_failed(db, "pe-1", error_message="some error")
+        purged = await crud.purge_completed(db, older_than_days=30)
+        assert purged == 1
+
+    @pytest.mark.asyncio
+    async def test_spares_pending_rows(self, db):
+        """Pending rows are never deleted regardless of age."""
+        await crud.create(
+            db, id="pe-1", memory_id="mem-1", content="old pending",
+            memory_type="episodic", collection="episodic_memory",
+            created_at="2025-01-01T00:00:00",
+        )
+        purged = await crud.purge_completed(db, older_than_days=30)
+        assert purged == 0
+        assert await crud.count_pending(db) == 1
+
+    @pytest.mark.asyncio
+    async def test_spares_recent_embedded(self, db):
+        """Recently embedded rows within threshold are kept."""
+        from datetime import UTC, datetime
+        now = datetime.now(UTC).isoformat()
+        await crud.create(
+            db, id="pe-1", memory_id="mem-1", content="recent",
+            memory_type="episodic", collection="episodic_memory",
+            created_at=now,
+        )
+        await crud.mark_embedded(db, "pe-1", embedded_at=now)
+        purged = await crud.purge_completed(db, older_than_days=30)
+        assert purged == 0
+
+
 class TestCountPending:
     @pytest.mark.asyncio
     async def test_count_empty(self, db):


### PR DESCRIPTION
## Summary

Three memory lifecycle bug fixes from the Phase 1 audit:

- **BF1**: `pending_embeddings` GC — `purge_completed()` deletes embedded/failed rows older than 30 days, wired into the existing maintenance cycle. Clears 7,897 stale rows.
- **BF2**: Events heartbeat rotation — adds `event_type` filter to `prune()` so only heartbeat events are rotated (7-day cutoff). **Critical safety fix**: without the filter, `prune()` would delete ALL events including error history.
- **BF3**: `knowledge_units.retrieved_count` wiring — the column existed but was never incremented in SQLite (only Qdrant payload was updated). Wired into `retrieval.py` recall for both Qdrant and FTS5-only hits. Keyed on `qdrant_id` (not `id`). Foundational for dream cycle quality scoring.

### Design decisions
- Direct DB calls in `schedule_maintenance()` (not executor pattern) — matches existing `purge_expired` pattern. GC doesn't need idle-gating or intake routing.
- `events.prune()` backwards-compatible — `event_type` defaults to `None`, preserving original behavior.
- Knowledge increment matches on `qdrant_id` because Qdrant point ID == `memory_metadata.id` == `knowledge_units.qdrant_id` (not `.id`).

## Test plan

- [x] 4 new tests for `purge_completed()` (old embedded, old failed, spare pending, spare recent)
- [x] 3 new tests for `prune()` event_type filter (all types, by type, timestamp cutoff)
- [x] 4 new tests for `increment_retrieved_batch()` (by qdrant_id, multiple, empty, nonexistent)
- [x] All 79 targeted tests pass (CRUD + DRIFT retrieval + maintenance)
- [x] `ruff check` clean on all modified files
- [x] Architecture review + code review passed