### PR TITLE
fix(inbox): startup wake delay for event loop bootstrap

### DIFF
--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -178,9 +178,9 @@ class InboxMonitor:
     def set_autonomous_dispatcher(self, dispatcher: object) -> None:
         self._autonomous_dispatcher = dispatcher
         # Now that the approval gate is wired, check for items that were
-        # approved while the server was down.  Must happen AFTER the
-        # dispatcher is set so the approval_manager is available.
-        self.wake()
+        # approved while the server was down.  Use a short delay so the
+        # event loop has time to finish bootstrap before the job fires.
+        self.wake(delay_seconds=10)
 
     async def start(self) -> None:
         """Start the inbox monitor scheduler."""
@@ -198,18 +198,23 @@ class InboxMonitor:
             self._config.watch_path,
         )
 
-    def wake(self) -> None:
-        """Schedule an immediate inbox check (one-shot).
+    def wake(self, *, delay_seconds: int = 0) -> None:
+        """Schedule an inbox check (one-shot).
 
         Called after an approval is resolved so the monitor picks up
         the approved item without waiting for the next interval tick.
+        *delay_seconds* adds a short offset — useful at startup so the
+        event loop can finish bootstrap before the job fires.
         """
+        from datetime import timedelta
+
         from apscheduler.triggers.date import DateTrigger
 
+        run_at = datetime.now(UTC) + timedelta(seconds=delay_seconds)
         try:
             self._scheduler.add_job(
                 self._check_inbox,
-                DateTrigger(run_date=datetime.now(UTC)),
+                DateTrigger(run_date=run_at),
                 id="inbox_monitor_wake",
                 max_instances=1,
                 replace_existing=True,


### PR DESCRIPTION
## Summary

- Adds a 10-second delay to the startup wake job so the APScheduler event loop finishes bootstrap before the inbox check fires.
- `wake()` now accepts `delay_seconds` — 0 for Telegram button wakes (instant), 10 for startup recovery.

## Test plan

- [x] `tests/test_inbox/` — 176 passed
- [x] `tests/test_outreach/test_callback_handler.py` — 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)