### PR TITLE
fix(cc): move Bash sandbox off volatile /tmp via CLAUDE_CODE_TMPDIR

### DIFF
--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -74,7 +74,12 @@ export TMPDIR="$HOME/.genesis/cc-tmp"
 mkdir -p "$TMPDIR"
 chmod 700 "$TMPDIR"
 
+# Move CC's Bash sandbox off volatile /tmp onto persistent disk.
+# CC uses CLAUDE_CODE_TMPDIR for its sandbox root (/claude-<uid>/<cwd>/).
+# Without this, intermittent ENOENT failures on /tmp break the Bash tool.
+export CLAUDE_CODE_TMPDIR="$HOME/.genesis/cc-tmp"
 
 exec tmux new-session -A -s "$SESSION_NAME" \
     -e "GENESIS_SLOT=${SLOT}" \
+    -e "CLAUDE_CODE_TMPDIR=$CLAUDE_CODE_TMPDIR" \
     "cd ${GENESIS_ROOT} && exec claude --dangerously-skip-permissions"

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -10,6 +10,7 @@ import shutil
 import signal
 import time
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 
 from genesis.cc.exceptions import (
     CCError,
@@ -115,6 +116,9 @@ class CCInvoker:
         # prompts safely.
         return args
 
+    # CC's Bash sandbox root — persistent disk, managed by tmp_watchgod.
+    _CC_SANDBOX_TMPDIR = Path.home() / ".genesis" / "cc-tmp"
+
     def _build_env(self, inv: CCInvocation | None = None) -> dict[str, str]:
         env = dict(os.environ)
         env.pop("CLAUDECODE", None)
@@ -125,6 +129,12 @@ class CCInvoker:
         env["GENESIS_CC_SESSION"] = "1"
         if inv and inv.stream_idle_timeout_ms is not None:
             env["CLAUDE_STREAM_IDLE_TIMEOUT_MS"] = str(inv.stream_idle_timeout_ms)
+        # Move CC's Bash sandbox off /tmp (512MB tmpfs) onto persistent disk.
+        # CC reads CLAUDE_CODE_TMPDIR to choose where it creates
+        # /claude-<uid>/<cwd>/<session-id>/ for each Bash invocation.
+        # Without this, the sandbox lives on /tmp where intermittent ENOENT
+        # failures break the Bash tool for entire sessions.
+        env["CLAUDE_CODE_TMPDIR"] = str(self._CC_SANDBOX_TMPDIR)
         return env
 
     async def interrupt(self) -> None:


### PR DESCRIPTION
## Summary

- Set `CLAUDE_CODE_TMPDIR=~/.genesis/cc-tmp` in `CCInvoker._build_env()` (Genesis-dispatched sessions) and `scripts/cc-slot.sh` (interactive tmux sessions)
- Moves CC's Bash sandbox from volatile `/tmp` (512MB tmpfs) to persistent disk under the existing `cc-tmp/` directory managed by `tmp_watchgod`
- Fixes recurring `ENOENT: mkdir '/tmp/claude-1000/-home-ubuntu-genesis/<session-id>'` errors that broke the Bash tool for 7+ sessions since May 3

## Root Cause

CC creates its Bash sandbox at `/tmp/claude-<uid>/<cwd>/<session-id>/`. The parent CWD directory (`-home-ubuntu-genesis/`) is created lazily by the first session and can disappear or fail to be created due to tmpfs volatility. When this happens, every subsequent Bash tool call for that session fails with ENOENT — the session is permanently crippled.

## Verification

Live tested: spawned a CC session with `CLAUDE_CODE_TMPDIR=~/.genesis/cc-tmp`, confirmed sandbox was created at `~/.genesis/cc-tmp/claude-1000/-home-ubuntu-genesis/<session-id>/` and Bash tool worked correctly.

The `tmp_watchgod` service already manages `cc-tmp/claude-*/` paths with tiered cleanup (7-day stale session GC), so no additional cleanup logic is needed.