### PR TITLE
fix(ego): dispatch pipeline — timeout, double-dispatch, message persistence

### DIFF
--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -141,7 +141,7 @@ class DirectSessionRequest:
     model: CCModel = CCModel.SONNET
     effort: EffortLevel = EffortLevel.HIGH
     system_prompt: str | None = None  # None = SOUL.md identity
-    timeout_s: int = 900  # 15 min default
+    timeout_s: int = 3600  # 1 hour — model decides when to stop
     notify: bool = True
     notify_on_failure_only: bool = False
     source_tag: str = "direct_session"

--- a/src/genesis/channels/telegram/topics.py
+++ b/src/genesis/channels/telegram/topics.py
@@ -223,6 +223,27 @@ class TopicManager:
                     msg = await self._bot.send_message(**kwargs)
                 else:
                     raise
+            # Persist outbound message for audit trail + reply resolution
+            if self._db is not None:
+                try:
+                    from genesis.db.crud.telegram_messages import store
+
+                    await store(
+                        self._db,
+                        chat_id=self._chat_id,
+                        message_id=msg.message_id,
+                        sender="genesis",
+                        content=text,
+                        thread_id=thread_id,
+                        direction="outbound",
+                    )
+                except Exception:
+                    logger.debug(
+                        "Failed to persist topic message %s",
+                        msg.message_id,
+                        exc_info=True,
+                    )
+
             return str(msg.message_id)
         except Exception:
             logger.error(

--- a/src/genesis/db/crud/direct_session_queue.py
+++ b/src/genesis/db/crud/direct_session_queue.py
@@ -20,7 +20,7 @@ async def enqueue(
     profile: str = "observe",
     model: str = "sonnet",
     effort: str = "high",
-    timeout_s: int = 900,
+    timeout_s: int = 3600,
     notify: bool = True,
     notify_on_failure_only: bool = False,
     caller_context: str | None = None,

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -731,22 +731,27 @@ class EgoSession:
             if not proposal_id or not prompt:
                 continue
 
-            # Verify the proposal is actually approved
-            proposal = await ego_crud.get_proposal(self._db, proposal_id)
-            if not proposal or proposal["status"] != "approved":
-                logger.warning(
-                    "Execution brief for proposal %s skipped (status=%s)",
-                    proposal_id,
-                    proposal["status"] if proposal else "not found",
-                )
-                continue
-
             # Map profile and model from brief
             profile = brief.get("profile", "observe")
             if profile not in VALID_PROFILES:
                 profile = "observe"
             model_str = brief.get("model", "sonnet")
             model = CCModel.SONNET if model_str != "haiku" else CCModel.HAIKU
+
+            # Atomically claim the proposal BEFORE spawning to prevent
+            # double-dispatch (sweep_approved_proposals is a second path).
+            ok = await ego_crud.execute_proposal(
+                self._db,
+                proposal_id,
+                status="executed",
+                user_response="dispatching",
+            )
+            if not ok:
+                logger.info(
+                    "Execution brief for proposal %s skipped — already claimed",
+                    proposal_id,
+                )
+                continue
 
             try:
                 request = DirectSessionRequest(
@@ -759,12 +764,12 @@ class EgoSession:
                     caller_context=f"ego_proposal:{proposal_id}",
                 )
                 session_id = await self._direct_session_runner.spawn(request)
-                await ego_crud.execute_proposal(
-                    self._db,
-                    proposal_id,
-                    status="executed",
-                    user_response=f"session:{session_id}",
+                # Update with actual session ID
+                await self._db.execute(
+                    "UPDATE ego_proposals SET user_response = ? WHERE id = ?",
+                    (f"session:{session_id}", proposal_id),
                 )
+                await self._db.commit()
                 try:
                     from genesis.db.crud import intervention_journal as journal_crud
 
@@ -783,20 +788,20 @@ class EgoSession:
                 )
             except Exception:
                 logger.error(
-                    "Failed to dispatch proposal %s",
+                    "Failed to dispatch proposal %s — reverting to approved",
                     proposal_id,
                     exc_info=True,
                 )
                 try:
-                    await ego_crud.execute_proposal(
-                        self._db,
-                        proposal_id,
-                        status="failed",
-                        user_response="dispatch failed",
+                    await self._db.execute(
+                        "UPDATE ego_proposals SET status = 'approved', "
+                        "user_response = NULL WHERE id = ?",
+                        (proposal_id,),
                     )
+                    await self._db.commit()
                 except Exception:
                     logger.error(
-                        "Failed to mark proposal %s as failed",
+                        "Failed to revert proposal %s — stuck at executed",
                         proposal_id,
                         exc_info=True,
                     )
@@ -997,6 +1002,21 @@ class EgoSession:
             # for reliable multi-step workflow execution.
             model = CCModel.OPUS if profile == "interact" else CCModel.SONNET
 
+            # Atomically claim the proposal BEFORE spawning to prevent
+            # double-dispatch (_process_execution_briefs is a second path).
+            ok = await ego_crud.execute_proposal(
+                self._db,
+                prop["id"],
+                status="executed",
+                user_response="dispatching",
+            )
+            if not ok:
+                logger.info(
+                    "Proposal %s already claimed — skipping",
+                    prop["id"],
+                )
+                continue
+
             try:
                 request = DirectSessionRequest(
                     prompt=prompt,
@@ -1008,37 +1028,37 @@ class EgoSession:
                     caller_context=f"ego_proposal:{prop['id']}",
                 )
                 session_id = await self._direct_session_runner.spawn(request)
-                ok = await ego_crud.execute_proposal(
-                    self._db,
-                    prop["id"],
-                    status="executed",
-                    user_response=f"session:{session_id}",
+                # Update with actual session ID
+                await self._db.execute(
+                    "UPDATE ego_proposals SET user_response = ? WHERE id = ?",
+                    (f"session:{session_id}", prop["id"]),
                 )
-                if ok:
-                    dispatched.append(prop["id"])
-                    logger.info(
-                        "Sweep dispatched proposal %s → session %s",
-                        prop["id"],
-                        session_id,
-                    )
-                    # Send execution notification to ego_proposals topic
-                    await self._notify_execution(prop, session_id)
+                await self._db.commit()
+                dispatched.append(prop["id"])
+                logger.info(
+                    "Sweep dispatched proposal %s → session %s",
+                    prop["id"],
+                    session_id,
+                )
+                # Send execution notification to ego_proposals topic
+                await self._notify_execution(prop, session_id)
             except Exception:
                 logger.error(
-                    "Sweep failed to dispatch proposal %s",
+                    "Sweep failed to dispatch proposal %s — reverting to approved",
                     prop["id"],
                     exc_info=True,
                 )
                 try:
-                    await ego_crud.execute_proposal(
-                        self._db,
-                        prop["id"],
-                        status="failed",
-                        user_response="sweep_dispatch_error",
+                    # Revert so sweep can retry on next cycle
+                    await self._db.execute(
+                        "UPDATE ego_proposals SET status = 'approved', "
+                        "user_response = NULL WHERE id = ?",
+                        (prop["id"],),
                     )
+                    await self._db.commit()
                 except Exception:
                     logger.error(
-                        "Failed to mark proposal %s as failed",
+                        "Failed to revert proposal %s — stuck at executed",
                         prop["id"],
                         exc_info=True,
                     )

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -740,13 +740,16 @@ class EgoSession:
 
             # Atomically claim the proposal BEFORE spawning to prevent
             # double-dispatch (sweep_approved_proposals is a second path).
-            ok = await ego_crud.execute_proposal(
-                self._db,
-                proposal_id,
-                status="executed",
-                user_response="dispatching",
+            # Use raw SQL to preserve resolved_at (the approval timestamp
+            # the staleness guard depends on).
+            cursor = await self._db.execute(
+                "UPDATE ego_proposals SET status = 'executed', "
+                "user_response = 'dispatching' "
+                "WHERE id = ? AND status = 'approved'",
+                (proposal_id,),
             )
-            if not ok:
+            await self._db.commit()
+            if cursor.rowcount == 0:
                 logger.info(
                     "Execution brief for proposal %s skipped — already claimed",
                     proposal_id,
@@ -1004,13 +1007,16 @@ class EgoSession:
 
             # Atomically claim the proposal BEFORE spawning to prevent
             # double-dispatch (_process_execution_briefs is a second path).
-            ok = await ego_crud.execute_proposal(
-                self._db,
-                prop["id"],
-                status="executed",
-                user_response="dispatching",
+            # Use raw SQL to preserve resolved_at (the approval timestamp
+            # the staleness guard depends on).
+            cursor = await self._db.execute(
+                "UPDATE ego_proposals SET status = 'executed', "
+                "user_response = 'dispatching' "
+                "WHERE id = ? AND status = 'approved'",
+                (prop["id"],),
             )
-            if not ok:
+            await self._db.commit()
+            if cursor.rowcount == 0:
                 logger.info(
                     "Proposal %s already claimed — skipping",
                     prop["id"],

--- a/src/genesis/inbox/types.py
+++ b/src/genesis/inbox/types.py
@@ -38,7 +38,7 @@ class InboxConfig:
     enabled: bool = True
     model: str = "sonnet"
     effort: str = "high"
-    timeout_s: int = 900
+    timeout_s: int = 3600
     max_retries: int = 3
     recursive: bool = False
     # timezone removed — uses genesis.env.user_timezone()

--- a/src/genesis/runtime/init/direct_session.py
+++ b/src/genesis/runtime/init/direct_session.py
@@ -64,7 +64,7 @@ async def _direct_session_poll(runner: DirectSessionRunner, db) -> None:
                     profile=payload.get("profile", "observe"),
                     model=CCModel(payload.get("model", "sonnet")),
                     effort=EffortLevel(payload.get("effort", "high")),
-                    timeout_s=payload.get("timeout_s", 900),
+                    timeout_s=payload.get("timeout_s", 3600),
                     notify=payload.get("notify", True),
                     notify_on_failure_only=payload.get("notify_on_failure_only", False),
                     caller_context=payload.get("caller_context"),

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -1048,7 +1048,7 @@ class SentinelDispatcher:
                 prompt=full_prompt,
                 model=CCModel.OPUS,
                 effort=EffortLevel.HIGH,
-                timeout_s=900,
+                timeout_s=3600,
                 skip_permissions=True,
                 system_prompt=system_prompt,
                 append_system_prompt=True,

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -418,8 +418,8 @@ class TestProcessExecutionBriefs:
 
         mock_direct_runner.spawn.assert_not_called()
 
-    async def test_spawn_failure_marks_failed(self, ego_with_runner, mock_direct_runner, db):
-        """DirectSessionRunner failure transitions proposal to failed."""
+    async def test_spawn_failure_reverts_to_approved(self, ego_with_runner, mock_direct_runner, db):
+        """DirectSessionRunner failure reverts proposal to approved for retry."""
         await self._insert_proposal(db, "prop_004")
         mock_direct_runner.spawn.side_effect = RuntimeError("spawn failed")
 
@@ -427,7 +427,7 @@ class TestProcessExecutionBriefs:
         await ego_with_runner._process_execution_briefs(briefs)
 
         prop = await ego_crud.get_proposal(db, "prop_004")
-        assert prop["status"] == "failed"
+        assert prop["status"] == "approved"
 
     async def test_no_runner_returns_early(self, ego_session, db):
         """No DirectSessionRunner → log warning and return."""

--- a/tests/test_db/test_direct_session_queue.py
+++ b/tests/test_db/test_direct_session_queue.py
@@ -46,7 +46,7 @@ class TestEnqueue:
         assert payload["profile"] == "observe"
         assert payload["model"] == "sonnet"
         assert payload["effort"] == "high"
-        assert payload["timeout_s"] == 900
+        assert payload["timeout_s"] == 3600
         assert payload["notify"] is True
         assert payload["notify_on_failure_only"] is False
 


### PR DESCRIPTION
## Summary

- **Timeout 900→3600s**: The 900s hardcoded default killed a working browser automation session doing Medium publish (57 tool calls, actively working). Changed all 5 sites to 3600s. The model decides when to stop.
- **Atomic proposal claim**: Two dispatch paths (`_process_execution_briefs` + `sweep_approved_proposals`) both spawned sessions for the same proposal within 1ms. Fix: mark proposal `executed` BEFORE spawning; skip if already claimed. Revert to `approved` on spawn failure.
- **Persist outbound messages**: `TopicManager._send_single()` sent messages to Telegram but never stored them in `telegram_messages`. Now stores with `direction='outbound'` after successful send.

## Root cause analysis

The double-dispatch was not two sweeps racing (the lock works). It was two *different* dispatch paths — the ego cycle itself (`_process_execution_briefs`) and the periodic sweep (`sweep_approved_proposals`) — both reading the same proposal as `approved` and both calling `spawn()` before either called `execute_proposal()`.

## Test plan

- [x] 17 ego + telegram topics tests pass
- [x] Ruff lint clean on all 7 files
- [ ] CI lint + full test suite
- [ ] Live verification: approve proposal → only one session spawns
- [ ] Live verification: interact session completes within 3600s

🤖 Generated with [Claude Code](https://claude.com/claude-code)