### PR TITLE
feat(memory): dream cycle — retroactive episodic memory consolidation

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -352,6 +352,14 @@ call_sites:
     - mistral-small-free
     - groq-free
     - openrouter-free
+  # Dream cycle: cluster-merge synthesis for episodic memory consolidation.
+  # Free-tier only. Separate from 22_tagging (entity extraction).
+  dream_cycle_synthesis:
+    chain:
+    - groq-free
+    - mistral-small-free
+    - openrouter-free
+    retry_profile: background
   27_pre_execution_assessment:
     chain:
     - glm51

--- a/docs/superpowers/specs/2026-05-14-dream-cycle-design.md
+++ b/docs/superpowers/specs/2026-05-14-dream-cycle-design.md
@@ -1,0 +1,536 @@
+# Dream Cycle — Retroactive Memory Consolidation Design
+
+**Date:** 2026-05-14
+**Status:** Draft
+**Scope:** Episodic memory consolidation, weak link pruning, dead letter cleanup,
+transcript archival, entity enrichment (22_tagging)
+**Prerequisite:** PR #352 (memory lifecycle bug fixes) merged
+
+## Context
+
+Genesis episodic memory grows monotonically. 19K+ memories, ~734/day. The
+extraction pipeline uses exact-content dedup only (FTS5 length + substring match)
+with no semantic similarity check before storing. The LLM's quality filter is the
+only gate, so near-duplicates accumulate. Nothing consolidates, prunes, or
+synthesizes after ingest.
+
+The brain analogy: episodic memories consolidate during sleep. Genesis does the
+same on a cron schedule — a "dream cycle."
+
+**Design principles:**
+- No time-based confidence decay. Confidence changes on evidence only
+  (contradictions, corrections, corroboration). Not because time passed.
+- Episodic only. Knowledge base excluded (low volume, upsert handles dedup).
+- Observations already healthy (TTL system + daily 2AM sweep). Leave alone.
+- Deep reflection is NOT for consolidation. Reflection = strategic thinking.
+  Dream cycle = separate infrastructure.
+- `deprecated` supplements `invalid_at`. They are independent dimensions:
+  `invalid_at` = "fact no longer true in the world." `deprecated` = "memory
+  consolidated into a synthesis." A memory must pass both filters to surface.
+
+## Three-Tier Architecture
+
+```
+Tier 1 — Mechanical          Tier 2 — 22_tagging           Tier 3 — Dream Cycle
+(schedule_maintenance,        (free-tier LLM,               (LLM synthesis,
+ no LLM, every 6h)            entity enrichment,             cluster-merge,
+                               weekly, up to 200)             weekly Sunday 3am)
+┌─────────────────────┐    ┌─────────────────────┐    ┌─────────────────────────┐
+│ Weak link pruning   │    │ Entity extraction    │    │ Group by wing/room      │
+│ Dead letter cleanup  │    │ (people, projects,   │    │ Cluster by cosine >=0.87│
+│ Transcript archival  │    │  tech, decisions)    │    │ Union-find components   │
+│ (no LLM needed)     │    │ Feed typed links     │    │ LLM synthesis per clust │
+│                     │    │ to NetworkX graph    │    │ Soft-delete originals   │
+└─────────────────────┘    └─────────────────────┘    └─────────────────────────┘
+      ↓ ships first              ↓ ships last               ↓ ships second
+```
+
+**Build order:** Tier 1 first (mechanical, zero risk), then Tier 3 (dream cycle
+synthesis — the core value), then Tier 2 (22_tagging enrichment — lower priority,
+builds on Tier 3 infrastructure).
+
+---
+
+## Tier 1: Mechanical Maintenance
+
+Runs inside `schedule_maintenance()` in `src/genesis/surplus/scheduler.py`.
+No LLM. Direct DB operations. Each wrapped in its own try/except (fixing the
+sequential-failure gap identified in PR #352 review).
+
+### 1A. Weak Link Pruning
+
+**Criteria:** `strength < 0.3 AND created_at < (now - 30d)`
+
+Weak links in the NetworkX graph that have never been reinforced. These are
+noise from auto-linking that didn't prove useful.
+
+**Implementation:**
+```python
+# In schedule_maintenance(), after existing GC calls
+from genesis.db.crud import memory_links
+pruned = await memory_links.prune_weak(
+    rt.db, max_strength=0.3, min_age_days=30,
+)
+```
+
+**New function:** `memory_links.prune_weak(db, max_strength, min_age_days) -> int`
+
+**File:** `src/genesis/db/crud/memory_links.py`
+
+**Safety:** Only prunes links, never memories. NetworkX cache invalidated after
+prune via existing `_invalidate_graph_cache()`.
+
+### 1B. Dead Letter Cleanup
+
+**Target:** `chain_exhausted:3_micro_reflection` entries older than 72h.
+
+These are 59% of the dead letter queue — expected noise from 5-minute awareness
+ticks hitting free provider rate limits. The existing 72h auto-expire handles
+generic entries, but categorized bulk cleanup is cleaner.
+
+**Implementation:** Already handled by existing `purge_expired()` in dead letter
+module. Verify the 72h TTL is functioning and add monitoring if not.
+
+### 1C. Transcript Archival
+
+**Target:** `.jsonl` files in `~/.genesis/background-sessions/` older than 90 days.
+
+**Action:** gzip in-place (`.jsonl` -> `.jsonl.gz`). Not deletion.
+
+**Implementation:**
+```python
+# In schedule_maintenance()
+from genesis.surplus.maintenance import archive_old_transcripts
+archived = await archive_old_transcripts(
+    base_dir=Path.home() / ".genesis" / "background-sessions",
+    older_than_days=90,
+)
+```
+
+**New function:** `archive_old_transcripts(base_dir, older_than_days) -> int`
+
+**File:** `src/genesis/surplus/maintenance.py`
+
+**Safety:** gzip is lossless and reversible. Original `.jsonl` deleted only after
+successful gzip write + size verification.
+
+---
+
+## Tier 3: Dream Cycle Synthesis
+
+The core consolidation engine. Finds clusters of semantically near-duplicate
+episodic memories, synthesizes each cluster into a single canonical memory via
+LLM, and soft-deletes the originals.
+
+### Algorithm
+
+#### Phase 1 — Scroll and Group
+
+Pull all episodic_memory point IDs + payloads from Qdrant via `scroll()`.
+Group into `(wing, room)` buckets. This constrains pairwise comparisons to
+semantically coherent domains and prevents cross-wing false-positive clusters.
+
+```python
+# Batched scroll, 1000 points/page
+points = await qdrant_scroll_all("episodic_memory")
+buckets = defaultdict(list)
+for point in points:
+    wing = point.payload.get("wing", "general")
+    room = point.payload.get("room", "uncategorized")
+    buckets[(wing, room)].append(point)
+```
+
+**Skip deprecated memories:** Filter `deprecated == True` from scroll results
+before clustering (don't re-cluster already-merged memories).
+
+#### Phase 2 — Cluster Within Each Bucket
+
+For each `(wing, room)` bucket:
+
+1. For each point, call `qdrant.search(vector=point.vector, limit=20,
+   score_threshold=0.87)` restricted to the same wing/room via filter.
+2. Build a graph: nodes = memory IDs, edges = pairs above threshold.
+3. Extract connected components via union-find. Each component with >= 2
+   nodes is a candidate cluster.
+
+**Similarity threshold:** 0.87 (configurable)
+- Below the potential 0.90 ingest-time near-dup check (catches things that
+  would slip through)
+- High enough to avoid merging conceptually distinct memories that share
+  domain vocabulary
+
+**Performance:** At ~19K points grouped by wing/room, buckets are dozens to
+hundreds of points. Pairwise search is fine. Revisit if any bucket exceeds
+~2K points (log a warning).
+
+#### Phase 3 — LLM Synthesis Per Cluster
+
+For each cluster (capped at 100 clusters per run):
+
+1. Pull full content of all memories in the cluster.
+2. Send to LLM via router chain `dream_cycle_synthesis`.
+3. Receive: synthesized content, merged tags, confidence, recommended
+   wing/room, synthesis notes.
+4. Store via `MemoryStore.store()` with:
+   - `source="dream_cycle"`
+   - `source_pipeline="dream_cycle"`
+   - `confidence=max(original confidences)`
+   - `tags` including `"synthesized"` + merged originals' tags
+   - `wing`/`room` as returned by LLM (may reclassify)
+
+**Why not `memory_synthesize` MCP tool?** It stores with fixed confidence 0.8
+and `source_pipeline="synthesis"`. Dream cycle needs `source_pipeline="dream_cycle"`
+for provenance tracking and `dream_cycle_run_id` for rollback. Using
+`MemoryStore.store()` directly gives full control. The linking step from
+`memory_synthesize` (creates `extends` typed links) should be extracted into a
+reusable helper and called with link type `consolidated_from`.
+
+#### Phase 4 — Soft-Delete Originals
+
+For each original in the merged cluster:
+
+1. **Qdrant:** `set_payload()` — add `deprecated: True` and
+   `synthesized_into: <new_memory_id>`.
+2. **SQLite:** `UPDATE memory_metadata SET deprecated = 1,
+   dream_cycle_run_id = ? WHERE memory_id = ?`.
+3. **Do NOT hard-delete.** Keep for audit trail and rollback.
+
+**On the new synthesized memory's Qdrant payload:**
+- `synthesized_from: list[str]` — IDs of all original memories in the cluster
+
+### Synthesis Prompt
+
+```
+You are synthesizing a cluster of related memories into a single canonical record.
+
+These memories are all tagged wing={wing}, room={room}. They share high semantic
+similarity (cosine >= 0.87). Your job is to produce ONE memory that is strictly
+more informative than any individual original, preserving all unique facts while
+eliminating redundancy.
+
+Input memories ({n} total):
+{for each: "--- Memory {i} (confidence {c}, source {source}, created {date}) ---\n{content}\n"}
+
+Output JSON:
+{
+  "content": "<synthesized content — complete, self-contained, no references to 'the above'>",
+  "tags": ["<merged relevant tags — deduplicated>"],
+  "confidence": <float 0-1, max of inputs as baseline>,
+  "memory_class": "<fact|reference|procedure|insight>",
+  "wing": "<wing — may differ from inputs if reclassification is warranted>",
+  "room": "<room>",
+  "synthesis_notes": "<why these were merged, what was dropped>"
+}
+
+Rules:
+- Never invent facts not present in the inputs
+- Preserve all unique details — err on the side of keeping too much
+- If memories contradict, note the contradiction explicitly in content
+- If memories represent temporal evolution (X was true, then Y), preserve the timeline
+- If one memory has much higher confidence, it likely supersedes the others — note this
+```
+
+### Routing Chain
+
+**New chain in `config/model_routing.yaml`:**
+```yaml
+dream_cycle_synthesis:
+  chain:
+  - groq-free
+  - mistral-small-free
+  - openrouter-free
+  retry_profile: background
+```
+
+Free-tier only. The 22_tagging chain is reserved for entity extraction (different
+prompt, different purpose). Dream cycle synthesis needs its own chain.
+
+**Call site metadata in `_call_site_meta.py`:**
+```python
+"dream_cycle_synthesis": {
+    "description": "Dream cycle cluster-merge synthesis. Consolidates near-duplicate episodic memories into canonical records.",
+    "category": "consolidation",
+    "frequency": "Weekly batch (Sunday 3am)",
+    "model_tier": "slm",
+    "wired": True,
+    "status_reason": "ACTIVE",
+},
+```
+
+### Clusters > 10 Memories
+
+Flag for manual review instead of auto-merging. Write an observation with the
+cluster details but don't synthesize. This prevents catastrophic loss from
+merging a large, potentially heterogeneous cluster.
+
+```python
+if len(cluster) > MAX_CLUSTER_SIZE:  # default 10
+    await observation_write(
+        source="dream_cycle",
+        type="large_cluster_detected",
+        content=f"Cluster of {len(cluster)} memories in {wing}/{room} — skipped auto-merge",
+        priority="medium",
+    )
+    continue
+```
+
+### Scheduling
+
+**CronTrigger:** `day_of_week="sun", hour=3` — Sunday 3am weekly.
+
+Register in surplus scheduler `start()` method, following the `model_intelligence`
+pattern at `src/genesis/surplus/scheduler.py:230-239`:
+
+```python
+from apscheduler.triggers.cron import CronTrigger
+self._scheduler.add_job(
+    self.run_dream_cycle,
+    CronTrigger(day_of_week="sun", hour=3),
+    id="dream_cycle",
+    max_instances=1,
+    misfire_grace_time=3600,
+)
+```
+
+### Run Cap
+
+Max 100 cluster merges per run to bound LLM cost. If the queue exceeds the cap,
+prioritize clusters with the most originals (highest redundancy reduction per
+synthesis call).
+
+**Cost estimate:** At 19K points with ~5% mergeable pairs: ~950 clusters.
+Capped at 100/run. At free-tier models, cost is $0/run. Even paid fallback
+would be well under $1/run.
+
+---
+
+## Schema Changes
+
+### SQLite — Migration 0018
+
+**File:** `src/genesis/db/migrations/0018_dream_cycle.py`
+
+```python
+async def up(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute("PRAGMA table_info(memory_metadata)")
+    cols = {row[1] for row in await cursor.fetchall()}
+
+    if "deprecated" not in cols:
+        await db.execute(
+            "ALTER TABLE memory_metadata "
+            "ADD COLUMN deprecated INTEGER NOT NULL DEFAULT 0"
+        )
+    if "dream_cycle_run_id" not in cols:
+        await db.execute(
+            "ALTER TABLE memory_metadata "
+            "ADD COLUMN dream_cycle_run_id TEXT"
+        )
+
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_meta_deprecated "
+        "ON memory_metadata(deprecated)"
+    )
+
+    # Bonus: index on knowledge_units.qdrant_id (deferred from PR #352)
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='knowledge_units'"
+    )
+    if await cursor.fetchone():
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_knowledge_units_qdrant_id "
+            "ON knowledge_units(qdrant_id)"
+        )
+```
+
+**Also update schema definition in `src/genesis/db/schema/_tables.py`** —
+add `deprecated` and `dream_cycle_run_id` columns to `memory_metadata` CREATE
+TABLE statement (after `source_subsystem`).
+
+### Qdrant (schemaless — no migration)
+
+On original memories after merge:
+- `deprecated: true` — payload field via `set_payload()`
+- `synthesized_into: str` — ID of the new synthesis
+
+On new synthesized memory:
+- `synthesized_from: list[str]` — IDs of originals
+
+### Retrieval Filter Changes
+
+**Qdrant filter:** `src/genesis/qdrant/collections.py:117-123`
+
+Add to `must_not_conditions` list (always-on, like subsystem exclusion):
+```python
+# Always exclude deprecated memories (dream cycle soft-delete)
+must_not_conditions.append(
+    FieldCondition(key="deprecated", match=MatchValue(value=True))
+)
+```
+
+**FTS5 filter:** `src/genesis/db/crud/memory.py:196`
+
+Add after the bitemporal `invalid_at` filter:
+```python
+# Dream cycle deprecation filter
+sql += (
+    " AND (memory_metadata.deprecated IS NULL "
+    "OR memory_metadata.deprecated = 0)"
+)
+```
+
+---
+
+## Safety
+
+### Dry-Run Mode (Default)
+
+`dry_run: bool = True` parameter on the dream cycle runner. In dry-run:
+- Compute clusters and log them
+- Write an observation with the cluster report (what would have been merged,
+  how many clusters, size distribution)
+- Do NOT write any new memories or deprecate anything
+
+**Ship dry-run first.** Run manually, review the cluster report, then enable
+live mode via config toggle.
+
+### Rollback
+
+Every dream cycle run generates a UUID `run_id`. Each deprecated original gets
+`dream_cycle_run_id = run_id`. Each synthesized memory gets tagged
+`dream_cycle_run_id:{run_id}`.
+
+Rollback function:
+```python
+async def rollback(run_id: str) -> dict:
+    """Reverse a dream cycle run.
+
+    1. Find all memories deprecated by this run_id
+    2. Clear their deprecated flag
+    3. Find the synthesized memories created by this run
+    4. Hard-delete the syntheses (they're derived, not original data)
+    """
+```
+
+### What NOT to Merge
+
+- **knowledge_base collection** — excluded entirely (different collection,
+  authoritative references)
+- **Contradictory memories** — merge with explicit contradiction note in content;
+  do not pick a winner
+- **Temporal sequences** — if memories document evolving state over time, preserve
+  the timeline rather than collapsing to latest
+- **Clusters > 10** — flag for review, don't auto-merge
+- **Already-deprecated memories** — skip during scroll phase
+
+---
+
+## Tier 2: 22_tagging Entity Enrichment (Lower Priority)
+
+**Ships after Tier 1 + Tier 3.** Depends on dream cycle infrastructure being
+proven.
+
+### Purpose
+
+Batch-enrich memories lacking entity tags. Extract structured entities (people,
+projects, technologies, decisions) and feed typed links into the NetworkX graph.
+
+### Approach
+
+- Bring the `22_tagging` call site online (currently V4_PLACEHOLDER, wired=False)
+- Use existing chain: `mistral-small-free → groq-free → openrouter-free`
+- Weekly schedule, up to 200 memories per run
+- Target: memories with no entity-type tags (no `entity:*` in tags list)
+- Output: entity tags added to Qdrant payload + typed links created
+
+### Design Deferred
+
+Full design for Tier 2 deferred to implementation time. The 22_tagging chain
+and call site infrastructure are ready. The entity extraction prompt and link
+type mapping need design work.
+
+---
+
+## Files to Create/Modify
+
+| File | Action | Tier |
+|------|--------|------|
+| `src/genesis/memory/dream_cycle.py` | Create — main consolidation logic | 3 |
+| `src/genesis/db/migrations/0018_dream_cycle.py` | Create — schema migration | 3 |
+| `src/genesis/db/crud/memory_links.py` | Modify — add `prune_weak()` | 1 |
+| `src/genesis/surplus/maintenance.py` | Modify — add `archive_old_transcripts()` | 1 |
+| `src/genesis/surplus/scheduler.py` | Modify — register CronTrigger, add maintenance calls | 1+3 |
+| `src/genesis/qdrant/collections.py` | Modify — add deprecated filter | 3 |
+| `src/genesis/db/crud/memory.py` | Modify — add deprecated filter to FTS5 | 3 |
+| `src/genesis/db/schema/_tables.py` | Modify — update memory_metadata schema | 3 |
+| `src/genesis/memory/retrieval.py` | Verify — deprecated filter cascades correctly | 3 |
+| `src/genesis/observability/_call_site_meta.py` | Modify — add dream_cycle_synthesis | 3 |
+| `config/model_routing.yaml` | Modify — add dream_cycle_synthesis chain | 3 |
+| `tests/test_memory/test_dream_cycle.py` | Create — unit tests | 3 |
+| `tests/test_db/test_memory_links_crud.py` | Create/modify — prune_weak tests | 1 |
+
+---
+
+## Verification Plan
+
+### Tier 1 Verification
+1. `pytest tests/test_db/test_memory_links_crud.py -v` — weak link pruning
+2. Manual: create old weak links, run prune, verify count
+3. Manual: create old `.jsonl` files, run archival, verify `.gz` created
+
+### Tier 3 Verification
+1. `pytest tests/test_memory/test_dream_cycle.py -v` — unit tests
+2. **Dry-run against live data:** Run dream cycle in dry-run mode against the
+   production episodic_memory collection. Review cluster report:
+   - How many clusters found?
+   - Size distribution (2-3 vs 4-10 vs 10+)?
+   - Sample cluster contents — do they actually belong together?
+3. **Single live merge (supervised):** Enable live mode, cap at 1 cluster.
+   Verify: synthesis stored correctly, originals deprecated, retrieval filters
+   working, rollback works.
+4. **Full run:** Enable with cap=100. Review observation report next morning.
+5. **Rollback test:** Pick one run_id, execute rollback, verify originals
+   un-deprecated and synthesis deleted.
+
+### Regression Checks
+- Memory recall still returns results (deprecated filter not over-filtering)
+- Proactive hook still surfaces memories
+- Essential knowledge generation still works
+- FTS5 search still returns results
+- `memory_synthesize` MCP tool still works independently
+
+---
+
+## Open Questions for Implementation
+
+1. **Linking helper extraction:** `memory_synthesize` MCP tool creates `extends`
+   links to source memories. Should dream cycle reuse this exact linking, or
+   create a different link type (e.g., `consolidated_from`)? Leaning toward
+   `consolidated_from` for semantic clarity.
+
+2. **Wing/room reclassification:** If the LLM synthesis recommends a different
+   wing/room than the originals, store with the recommended classification and
+   add tag `"reclassified_by:dream_cycle"`. Tentative yes.
+
+3. **Proactive hook interaction:** After consolidation, synthesized memories
+   should surface preferentially. This happens naturally since deprecated
+   originals are filtered out and the synthesis contains all their information.
+
+4. **GC wrapping in schedule_maintenance:** The PR #352 review identified that
+   GC calls run sequentially without individual try/except. Implement this
+   wrapping as part of Tier 1 work (it's the right scope).
+
+---
+
+## Key Numbers (snapshot 2026-05-14)
+
+| Metric | Value |
+|---|---|
+| episodic_memory points | ~19,000 |
+| Daily growth rate | ~734/day |
+| memory_links | 54,631 |
+| Estimated mergeable pairs (5%) | ~950 clusters |
+| Run cap | 100 clusters/run |
+| Estimated weeks to steady state | ~10 (at 100/week) |
+| Cost per run (free-tier) | $0 |
+| Cost per run (paid fallback) | < $1 |

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -194,6 +194,12 @@ async def search_ranked(
         "OR memory_metadata.invalid_at > ?)"
     )
     params.append(as_of)
+    # Always-on dream cycle deprecation filter: exclude consolidated memories.
+    # NULL deprecated (legacy rows pre-migration) = not deprecated.
+    sql += (
+        " AND (memory_metadata.deprecated IS NULL "
+        "OR memory_metadata.deprecated = 0)"
+    )
     if exclude_subsystems:
         placeholders = ",".join("?" * len(exclude_subsystems))
         sql += (

--- a/src/genesis/db/crud/memory_links.py
+++ b/src/genesis/db/crud/memory_links.py
@@ -92,4 +92,11 @@ async def prune_weak(
         (max_strength, cutoff),
     )
     await db.commit()
-    return cursor.rowcount
+    pruned = cursor.rowcount
+    if pruned:
+        try:
+            from genesis.memory.graph import invalidate_graph_cache
+            invalidate_graph_cache()
+        except ImportError:
+            pass
+    return pruned

--- a/src/genesis/db/crud/memory_links.py
+++ b/src/genesis/db/crud/memory_links.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import aiosqlite
 
 
@@ -68,6 +70,26 @@ async def delete_by_memory(db: aiosqlite.Connection, *, memory_id: str) -> int:
     cursor = await db.execute(
         "DELETE FROM memory_links WHERE source_id = ? OR target_id = ?",
         (memory_id, memory_id),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
+async def prune_weak(
+    db: aiosqlite.Connection,
+    *,
+    max_strength: float = 0.3,
+    min_age_days: int = 30,
+) -> int:
+    """Delete weak, old links that were never reinforced.
+
+    Criteria: strength <= *max_strength* AND created_at older than
+    *min_age_days*. Returns count deleted.
+    """
+    cutoff = (datetime.now(UTC) - timedelta(days=min_age_days)).isoformat()
+    cursor = await db.execute(
+        "DELETE FROM memory_links WHERE strength <= ? AND created_at < ?",
+        (max_strength, cutoff),
     )
     await db.commit()
     return cursor.rowcount

--- a/src/genesis/db/migrations/0018_dream_cycle.py
+++ b/src/genesis/db/migrations/0018_dream_cycle.py
@@ -1,0 +1,81 @@
+"""Add dream cycle columns to memory_metadata + qdrant_id index on knowledge_units.
+
+Schema changes:
+- memory_metadata.deprecated INTEGER DEFAULT 0 — soft-delete flag for
+  memories consolidated by the dream cycle. Independent of bi-temporal
+  invalid_at (which tracks real-world fact validity).
+- memory_metadata.dream_cycle_run_id TEXT — provenance tracking for
+  rollback. Each dream cycle run stamps its UUID on deprecated originals.
+- idx_memory_meta_deprecated on memory_metadata(deprecated) — filter
+  performance for recall queries that exclude deprecated memories.
+- idx_knowledge_units_qdrant_id on knowledge_units(qdrant_id) — deferred
+  from PR #352; prevents full table scan on retrieved_count increment.
+
+Idempotent — column adds guarded by PRAGMA table_info.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # Guard: table may not exist on fresh DBs before schema bootstrap
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='memory_metadata'"
+    )
+    has_metadata = await cursor.fetchone() is not None
+
+    if has_metadata:
+        cursor = await db.execute("PRAGMA table_info(memory_metadata)")
+        cols = {row[1] for row in await cursor.fetchall()}
+
+        if "deprecated" not in cols:
+            await db.execute(
+                "ALTER TABLE memory_metadata "
+                "ADD COLUMN deprecated INTEGER NOT NULL DEFAULT 0"
+            )
+        if "dream_cycle_run_id" not in cols:
+            await db.execute(
+                "ALTER TABLE memory_metadata "
+                "ADD COLUMN dream_cycle_run_id TEXT"
+            )
+
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_memory_meta_deprecated "
+            "ON memory_metadata(deprecated)"
+        )
+
+    # Bonus: index on knowledge_units.qdrant_id (deferred from PR #352).
+    # Without this, increment_retrieved_batch() does a full table scan.
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='knowledge_units'"
+    )
+    if await cursor.fetchone():
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_knowledge_units_qdrant_id "
+            "ON knowledge_units(qdrant_id)"
+        )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    await db.execute("DROP INDEX IF EXISTS idx_memory_meta_deprecated")
+    await db.execute("DROP INDEX IF EXISTS idx_knowledge_units_qdrant_id")
+
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='memory_metadata'"
+    )
+    if await cursor.fetchone():
+        cursor = await db.execute("PRAGMA table_info(memory_metadata)")
+        cols = {row[1] for row in await cursor.fetchall()}
+        if "deprecated" in cols:
+            await db.execute(
+                "ALTER TABLE memory_metadata DROP COLUMN deprecated"
+            )
+        if "dream_cycle_run_id" in cols:
+            await db.execute(
+                "ALTER TABLE memory_metadata DROP COLUMN dream_cycle_run_id"
+            )

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -869,7 +869,9 @@ TABLES = {
             room             TEXT,
             valid_at         TEXT,
             invalid_at       TEXT,
-            source_subsystem TEXT
+            source_subsystem TEXT,
+            deprecated       INTEGER NOT NULL DEFAULT 0,
+            dream_cycle_run_id TEXT
         )
     """,
     "code_modules": """

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1229,6 +1229,9 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_memory_metadata_collection ON memory_metadata(collection)",
     "CREATE INDEX IF NOT EXISTS idx_memory_meta_valid_at ON memory_metadata(valid_at)",
     "CREATE INDEX IF NOT EXISTS idx_memory_meta_invalid_at ON memory_metadata(invalid_at)",
+    "CREATE INDEX IF NOT EXISTS idx_memory_meta_deprecated ON memory_metadata(deprecated)",
+    # knowledge_units
+    "CREATE INDEX IF NOT EXISTS idx_knowledge_units_qdrant_id ON knowledge_units(qdrant_id)",
     # codebase index
     "CREATE INDEX IF NOT EXISTS idx_code_symbols_module ON code_symbols(module_path)",
     "CREATE INDEX IF NOT EXISTS idx_code_symbols_name ON code_symbols(name)",

--- a/src/genesis/memory/dream_cycle.py
+++ b/src/genesis/memory/dream_cycle.py
@@ -1,0 +1,656 @@
+"""Dream cycle — retroactive episodic memory consolidation.
+
+Sweeps the episodic_memory Qdrant collection on a schedule, identifies
+clusters of semantically near-duplicate memories, synthesizes each
+cluster into a single canonical memory via LLM, and soft-deletes the
+originals.  Analogy: the brain consolidates episodic memories during
+sleep.
+
+**Key design decisions:**
+- Episodic only — knowledge_base excluded (low volume, upsert handles dedup)
+- No time-based confidence decay — evidence-based changes only
+- deprecated supplements invalid_at (independent dimensions)
+- Dry-run mode is the default until manually reviewed
+- Max 100 cluster merges per run (configurable)
+- Clusters > 10 memories flagged for manual review, not auto-merged
+
+Spec: docs/superpowers/specs/2026-05-14-dream-cycle-design.md
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from collections import defaultdict
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import aiosqlite
+    from qdrant_client import QdrantClient
+
+    from genesis.memory.store import MemoryStore
+    from genesis.routing.router import Router
+
+logger = logging.getLogger(__name__)
+
+# ── Configuration ────────────────────────────────────────────────────────
+
+SIMILARITY_THRESHOLD: float = 0.87
+MAX_CLUSTER_SIZE: int = 10
+MAX_MERGES_PER_RUN: int = 100
+CALL_SITE_ID: str = "dream_cycle_synthesis"
+COLLECTION: str = "episodic_memory"
+
+# ── Union-Find ───────────────────────────────────────────────────────────
+
+
+class _UnionFind:
+    """Disjoint-set (union-find) with path compression and union by rank."""
+
+    def __init__(self) -> None:
+        self._parent: dict[str, str] = {}
+        self._rank: dict[str, int] = {}
+
+    def find(self, x: str) -> str:
+        if x not in self._parent:
+            self._parent[x] = x
+            self._rank[x] = 0
+        if self._parent[x] != x:
+            self._parent[x] = self.find(self._parent[x])
+        return self._parent[x]
+
+    def union(self, x: str, y: str) -> None:
+        rx, ry = self.find(x), self.find(y)
+        if rx == ry:
+            return
+        if self._rank[rx] < self._rank[ry]:
+            rx, ry = ry, rx
+        self._parent[ry] = rx
+        if self._rank[rx] == self._rank[ry]:
+            self._rank[rx] += 1
+
+    def components(self) -> dict[str, list[str]]:
+        """Return {root: [members]} for all groups."""
+        groups: dict[str, list[str]] = defaultdict(list)
+        for x in self._parent:
+            groups[self.find(x)].append(x)
+        return groups
+
+
+# ── Core ─────────────────────────────────────────────────────────────────
+
+
+async def run(
+    *,
+    qdrant: QdrantClient,
+    db: aiosqlite.Connection,
+    router: Router,
+    store: MemoryStore,
+    dry_run: bool = True,
+    similarity_threshold: float = SIMILARITY_THRESHOLD,
+    max_merges: int = MAX_MERGES_PER_RUN,
+    max_cluster_size: int = MAX_CLUSTER_SIZE,
+) -> dict[str, Any]:
+    """Execute one dream cycle run.
+
+    Returns a report dict with cluster counts, merge stats, and any
+    errors encountered.
+    """
+    run_id = str(uuid.uuid4())
+    report: dict[str, Any] = {
+        "run_id": run_id,
+        "dry_run": dry_run,
+        "threshold": similarity_threshold,
+        "clusters_found": 0,
+        "clusters_merged": 0,
+        "clusters_skipped_large": 0,
+        "memories_deprecated": 0,
+        "errors": [],
+    }
+
+    # Phase 1 — Scroll and group by (wing, room)
+    buckets = await _scroll_and_group(qdrant)
+    total_points = sum(len(pts) for pts in buckets.values())
+    report["total_points"] = total_points
+    report["buckets"] = len(buckets)
+    logger.info(
+        "Dream cycle %s: %d points across %d (wing,room) buckets",
+        run_id[:8], total_points, len(buckets),
+    )
+
+    # Phase 2 — Cluster within each bucket
+    all_clusters: list[list[dict]] = []
+    for (wing, room), points in buckets.items():
+        if len(points) < 2:
+            continue
+        if len(points) > 2000:
+            logger.warning(
+                "Bucket (%s, %s) has %d points — may be slow",
+                wing, room, len(points),
+            )
+        clusters = await _cluster_bucket(
+            qdrant, points, wing, room,
+            threshold=similarity_threshold,
+        )
+        all_clusters.extend(clusters)
+
+    report["clusters_found"] = len(all_clusters)
+    logger.info("Dream cycle %s: found %d clusters", run_id[:8], len(all_clusters))
+
+    if dry_run:
+        report["cluster_sizes"] = _size_distribution(all_clusters)
+        report["sample_clusters"] = _sample_clusters(all_clusters, n=5)
+        logger.info("Dream cycle %s: DRY RUN — no changes written", run_id[:8])
+        return report
+
+    # Phase 3+4 — Synthesize and deprecate (live mode)
+    # Sort by descending size so highest-redundancy clusters merge first
+    all_clusters.sort(key=len, reverse=True)
+    merged = 0
+
+    for cluster in all_clusters:
+        if merged >= max_merges:
+            break
+
+        if len(cluster) > max_cluster_size:
+            report["clusters_skipped_large"] += 1
+            logger.info(
+                "Dream cycle %s: skipping cluster of %d in %s/%s (too large)",
+                run_id[:8], len(cluster),
+                cluster[0].get("wing", "?"), cluster[0].get("room", "?"),
+            )
+            continue
+
+        try:
+            result = await _synthesize_and_deprecate(
+                cluster=cluster,
+                run_id=run_id,
+                qdrant=qdrant,
+                db=db,
+                router=router,
+                store=store,
+            )
+            merged += 1
+            report["memories_deprecated"] += result["deprecated_count"]
+        except Exception as exc:
+            report["errors"].append({
+                "cluster_size": len(cluster),
+                "error": str(exc),
+            })
+            logger.warning(
+                "Dream cycle %s: synthesis failed for cluster of %d: %s",
+                run_id[:8], len(cluster), exc, exc_info=True,
+            )
+
+    report["clusters_merged"] = merged
+    logger.info(
+        "Dream cycle %s: merged %d clusters, deprecated %d memories, %d errors",
+        run_id[:8], merged, report["memories_deprecated"], len(report["errors"]),
+    )
+    return report
+
+
+# ── Phase 1: Scroll and Group ────────────────────────────────────────────
+
+
+async def _scroll_and_group(
+    qdrant: QdrantClient,
+) -> dict[tuple[str, str], list[dict]]:
+    """Scroll all episodic_memory points, group by (wing, room).
+
+    Skips already-deprecated points.
+    """
+    from genesis.qdrant.collections import scroll_points
+
+    buckets: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    offset: str | None = None
+
+    while True:
+        points, next_offset = scroll_points(
+            qdrant, collection=COLLECTION, limit=1000, offset=offset,
+        )
+        for point in points:
+            payload = point.get("payload", {})
+            # Skip already-deprecated memories
+            if payload.get("deprecated") is True:
+                continue
+            wing = payload.get("wing") or "general"
+            room = payload.get("room") or "uncategorized"
+            buckets[(wing, room)].append({
+                "id": point["id"],
+                "payload": payload,
+            })
+
+        if next_offset is None or not points:
+            break
+        offset = next_offset
+
+    return buckets
+
+
+# ── Phase 2: Cluster ────────────────────────────────────────────────────
+
+
+async def _cluster_bucket(
+    qdrant: QdrantClient,
+    points: list[dict],
+    wing: str,
+    room: str,
+    *,
+    threshold: float,
+) -> list[list[dict]]:
+    """Find connected components of similar memories within a (wing, room) bucket.
+
+    For each point, searches Qdrant for neighbors above threshold,
+    then extracts connected components via union-find.
+    """
+    from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+    from genesis.qdrant.collections import search
+
+    uf = _UnionFind()
+    point_map = {p["id"]: p for p in points}
+
+    # Build similarity graph
+    for point in points:
+        pid = point["id"]
+        # We need the vector to search — retrieve it from Qdrant
+        try:
+            neighbors = search(
+                qdrant,
+                collection=COLLECTION,
+                query_vector=_get_vector(qdrant, pid),
+                limit=20,
+                wing=wing,
+                room=room,
+            )
+        except Exception:
+            logger.debug("Could not search neighbors for %s", pid)
+            continue
+
+        for neighbor in neighbors:
+            nid = neighbor["id"]
+            score = neighbor["score"]
+            if nid == pid:
+                continue
+            if nid not in point_map:
+                continue  # Different bucket or deprecated
+            if score >= threshold:
+                uf.union(pid, nid)
+
+    # Extract components with >= 2 members
+    clusters: list[list[dict]] = []
+    for _root, members in uf.components().items():
+        if len(members) >= 2:
+            cluster = [point_map[m] for m in members if m in point_map]
+            if len(cluster) >= 2:
+                # Tag wing/room for downstream use
+                for item in cluster:
+                    item["wing"] = wing
+                    item["room"] = room
+                clusters.append(cluster)
+
+    return clusters
+
+
+def _get_vector(qdrant: QdrantClient, point_id: str) -> list[float]:
+    """Retrieve a point's vector from Qdrant."""
+    result = qdrant.retrieve(
+        collection_name=COLLECTION,
+        ids=[point_id],
+        with_vectors=True,
+    )
+    if not result:
+        raise ValueError(f"Point {point_id} not found in {COLLECTION}")
+    return result[0].vector
+
+
+# ── Phase 3+4: Synthesize and Deprecate ──────────────────────────────────
+
+
+async def _synthesize_and_deprecate(
+    *,
+    cluster: list[dict],
+    run_id: str,
+    qdrant: QdrantClient,
+    db: aiosqlite.Connection,
+    router: Router,
+    store: MemoryStore,
+) -> dict[str, Any]:
+    """Synthesize a cluster into one canonical memory, deprecate originals."""
+    wing = cluster[0]["wing"]
+    room = cluster[0]["room"]
+    original_ids = [item["id"] for item in cluster]
+
+    # Build synthesis prompt
+    prompt = _build_synthesis_prompt(cluster, wing, room)
+    messages = [{"role": "user", "content": prompt}]
+
+    # LLM synthesis via router
+    result = await router.route_call(CALL_SITE_ID, messages)
+    if not result.success:
+        raise RuntimeError(f"LLM synthesis failed: {result.error}")
+
+    synthesis = _parse_synthesis_response(result.content, wing, room)
+
+    # Merge tags from originals + synthesis
+    all_tags = set()
+    for item in cluster:
+        for tag in item["payload"].get("tags", []):
+            if tag != "deprecated":
+                all_tags.add(tag)
+    for tag in synthesis.get("tags", []):
+        all_tags.add(tag)
+    all_tags.add("synthesized")
+    all_tags.add(f"dream_cycle_run_id:{run_id}")
+
+    # Store synthesized memory via MemoryStore
+    max_confidence = max(
+        item["payload"].get("confidence", 0.5)
+        for item in cluster
+    )
+    new_memory_id = await store.store(
+        synthesis["content"],
+        source="dream_cycle",
+        memory_type="episodic",
+        tags=sorted(all_tags),
+        confidence=max(max_confidence, synthesis.get("confidence", 0.8)),
+        source_pipeline="dream_cycle",
+        wing=synthesis.get("wing", wing),
+        room=synthesis.get("room", room),
+    )
+
+    # Set synthesized_from on the new memory's Qdrant payload
+    from genesis.qdrant.collections import update_payload
+    update_payload(
+        qdrant,
+        collection=COLLECTION,
+        point_id=new_memory_id,
+        payload={"synthesized_from": original_ids},
+    )
+
+    # Deprecate originals
+    deprecated_count = 0
+    for original_id in original_ids:
+        try:
+            # Qdrant: mark as deprecated
+            update_payload(
+                qdrant,
+                collection=COLLECTION,
+                point_id=original_id,
+                payload={
+                    "deprecated": True,
+                    "synthesized_into": new_memory_id,
+                },
+            )
+            # SQLite: mark as deprecated
+            await db.execute(
+                "UPDATE memory_metadata SET deprecated = 1, "
+                "dream_cycle_run_id = ? WHERE memory_id = ?",
+                (run_id, original_id),
+            )
+            deprecated_count += 1
+        except Exception:
+            logger.warning(
+                "Failed to deprecate memory %s", original_id, exc_info=True,
+            )
+    await db.commit()
+
+    # Create links from synthesis to originals
+    if store.linker:
+        for original_id in original_ids:
+            try:
+                from genesis.db.crud import memory_links as links_crud
+                now_iso = datetime.now(UTC).isoformat()
+                await links_crud.create(
+                    db,
+                    source_id=new_memory_id,
+                    target_id=original_id,
+                    link_type="extends",
+                    strength=1.0,
+                    created_at=now_iso,
+                )
+            except Exception:
+                pass  # Best-effort linking
+
+    logger.info(
+        "Dream cycle: synthesized %d memories into %s (%s/%s)",
+        len(cluster), new_memory_id[:8], wing, room,
+    )
+
+    return {
+        "new_memory_id": new_memory_id,
+        "deprecated_count": deprecated_count,
+        "original_ids": original_ids,
+    }
+
+
+# ── Rollback ─────────────────────────────────────────────────────────────
+
+
+async def rollback(
+    run_id: str,
+    *,
+    qdrant: QdrantClient,
+    db: aiosqlite.Connection,
+) -> dict[str, Any]:
+    """Reverse a dream cycle run.
+
+    1. Find all memories deprecated by this run_id
+    2. Clear their deprecated flag (Qdrant + SQLite)
+    3. Find synthesized memories created by this run (by tag)
+    4. Hard-delete the syntheses (they're derived, not original data)
+    """
+    from genesis.qdrant.collections import update_payload
+
+    report: dict[str, Any] = {
+        "run_id": run_id,
+        "restored": 0,
+        "syntheses_deleted": 0,
+        "errors": [],
+    }
+
+    # 1. Restore deprecated originals in SQLite
+    cursor = await db.execute(
+        "SELECT memory_id FROM memory_metadata "
+        "WHERE dream_cycle_run_id = ? AND deprecated = 1",
+        (run_id,),
+    )
+    deprecated_ids = [row[0] for row in await cursor.fetchall()]
+
+    for mid in deprecated_ids:
+        try:
+            await db.execute(
+                "UPDATE memory_metadata SET deprecated = 0, "
+                "dream_cycle_run_id = NULL WHERE memory_id = ?",
+                (mid,),
+            )
+            update_payload(
+                qdrant,
+                collection=COLLECTION,
+                point_id=mid,
+                payload={"deprecated": False, "synthesized_into": None},
+            )
+            report["restored"] += 1
+        except Exception as exc:
+            report["errors"].append({"memory_id": mid, "error": str(exc)})
+
+    await db.commit()
+
+    # 2. Delete synthesized memories created by this run
+    # They carry the tag "dream_cycle_run_id:{run_id}"
+    tag_marker = f"dream_cycle_run_id:{run_id}"
+    cursor = await db.execute(
+        "SELECT memory_id FROM memory_fts WHERE tags LIKE ?",
+        (f"%{tag_marker}%",),
+    )
+    synthesis_ids = [row[0] for row in await cursor.fetchall()]
+
+    for sid in synthesis_ids:
+        try:
+            from genesis.qdrant.collections import delete_point
+            delete_point(qdrant, collection=COLLECTION, point_id=sid)
+            await db.execute(
+                "DELETE FROM memory_metadata WHERE memory_id = ?", (sid,),
+            )
+            await db.execute(
+                "DELETE FROM memory_fts WHERE memory_id = ?", (sid,),
+            )
+            await db.execute(
+                "DELETE FROM memory_links WHERE source_id = ? OR target_id = ?",
+                (sid, sid),
+            )
+            report["syntheses_deleted"] += 1
+        except Exception as exc:
+            report["errors"].append({"synthesis_id": sid, "error": str(exc)})
+
+    await db.commit()
+
+    logger.info(
+        "Dream cycle rollback %s: restored %d, deleted %d syntheses, %d errors",
+        run_id[:8], report["restored"], report["syntheses_deleted"],
+        len(report["errors"]),
+    )
+    return report
+
+
+# ── Prompt and Parsing ───────────────────────────────────────────────────
+
+_SYNTHESIS_PROMPT = """\
+You are synthesizing a cluster of related memories into a single canonical record.
+
+These memories are all tagged wing={wing}, room={room}. They share high semantic \
+similarity (cosine >= 0.87). Your job is to produce ONE memory that is strictly \
+more informative than any individual original, preserving all unique facts while \
+eliminating redundancy.
+
+Input memories ({n} total):
+{memories}
+
+Output JSON (no markdown fences, just raw JSON):
+{{
+  "content": "<synthesized content — complete, self-contained>",
+  "tags": ["<merged relevant tags — deduplicated>"],
+  "confidence": <float 0-1, max of inputs as baseline>,
+  "memory_class": "<fact|reference|procedure|insight>",
+  "wing": "<wing>",
+  "room": "<room>",
+  "synthesis_notes": "<why these were merged, what was dropped>"
+}}
+
+Rules:
+- Never invent facts not present in the inputs
+- Preserve all unique details — err on the side of keeping too much
+- If memories contradict, note the contradiction explicitly in content
+- If memories represent temporal evolution (X was true, then Y), preserve the timeline
+- If one memory has much higher confidence, it likely supersedes the others — note this\
+"""
+
+
+def _build_synthesis_prompt(
+    cluster: list[dict], wing: str, room: str,
+) -> str:
+    """Build the synthesis prompt from cluster memories."""
+    memory_blocks = []
+    for i, item in enumerate(cluster, 1):
+        payload = item["payload"]
+        confidence = payload.get("confidence", 0.5)
+        source = payload.get("source", "unknown")
+        created = payload.get("created_at", "unknown")
+        content = payload.get("content", "")
+        memory_blocks.append(
+            f"--- Memory {i} (confidence {confidence}, source {source}, "
+            f"created {created}) ---\n{content}"
+        )
+    return _SYNTHESIS_PROMPT.format(
+        wing=wing,
+        room=room,
+        n=len(cluster),
+        memories="\n\n".join(memory_blocks),
+    )
+
+
+def _parse_synthesis_response(
+    response: str, default_wing: str, default_room: str,
+) -> dict[str, Any]:
+    """Parse the LLM's JSON synthesis response.
+
+    Falls back gracefully if the response isn't valid JSON — uses the
+    raw response as content with defaults for other fields.
+    """
+    # Strip markdown fences if present
+    text = response.strip()
+    if text.startswith("```"):
+        lines = text.split("\n")
+        # Remove first and last fence lines
+        if lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        text = "\n".join(lines).strip()
+
+    try:
+        data = json.loads(text)
+        # Validate required fields
+        if "content" not in data or not data["content"]:
+            raise ValueError("Missing 'content' field")
+        return {
+            "content": data["content"],
+            "tags": data.get("tags", []),
+            "confidence": data.get("confidence", 0.8),
+            "memory_class": data.get("memory_class", "fact"),
+            "wing": data.get("wing", default_wing),
+            "room": data.get("room", default_room),
+            "synthesis_notes": data.get("synthesis_notes", ""),
+        }
+    except (json.JSONDecodeError, ValueError) as exc:
+        logger.warning("Failed to parse synthesis JSON: %s", exc)
+        # Fallback: use raw response as content
+        return {
+            "content": response,
+            "tags": [],
+            "confidence": 0.8,
+            "memory_class": "fact",
+            "wing": default_wing,
+            "room": default_room,
+            "synthesis_notes": f"JSON parse failed: {exc}",
+        }
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _size_distribution(clusters: list[list[dict]]) -> dict[str, int]:
+    """Categorize clusters by size for dry-run reporting."""
+    dist: dict[str, int] = {"2-3": 0, "4-5": 0, "6-10": 0, "11+": 0}
+    for c in clusters:
+        n = len(c)
+        if n <= 3:
+            dist["2-3"] += 1
+        elif n <= 5:
+            dist["4-5"] += 1
+        elif n <= 10:
+            dist["6-10"] += 1
+        else:
+            dist["11+"] += 1
+    return dist
+
+
+def _sample_clusters(
+    clusters: list[list[dict]], *, n: int = 5,
+) -> list[dict]:
+    """Return summaries of the first N clusters for dry-run review."""
+    samples = []
+    for cluster in clusters[:n]:
+        samples.append({
+            "size": len(cluster),
+            "wing": cluster[0].get("wing", "?"),
+            "room": cluster[0].get("room", "?"),
+            "sample_content": [
+                item["payload"].get("content", "")[:100]
+                for item in cluster[:3]
+            ],
+        })
+    return samples

--- a/src/genesis/memory/dream_cycle.py
+++ b/src/genesis/memory/dream_cycle.py
@@ -251,15 +251,21 @@ async def _cluster_bucket(
     uf = _UnionFind()
     point_map = {p["id"]: p for p in points}
 
+    # Batch-retrieve all vectors for this bucket in one call
+    # (avoids N sync blocking calls to Qdrant)
+    vector_map = _batch_get_vectors(qdrant, [p["id"] for p in points])
+
     # Build similarity graph
     for point in points:
         pid = point["id"]
-        # We need the vector to search — retrieve it from Qdrant
+        vec = vector_map.get(pid)
+        if vec is None:
+            continue
         try:
             neighbors = search(
                 qdrant,
                 collection=COLLECTION,
-                query_vector=_get_vector(qdrant, pid),
+                query_vector=vec,
                 limit=20,
                 wing=wing,
                 room=room,
@@ -293,8 +299,36 @@ async def _cluster_bucket(
     return clusters
 
 
+def _batch_get_vectors(
+    qdrant: QdrantClient, point_ids: list[str],
+) -> dict[str, list[float]]:
+    """Batch-retrieve vectors for all points in one Qdrant call.
+
+    Returns {point_id: vector}. Missing points are silently omitted.
+    Batches in chunks of 100 to avoid oversized requests.
+    """
+    vector_map: dict[str, list[float]] = {}
+    batch_size = 100
+    for i in range(0, len(point_ids), batch_size):
+        batch_ids = point_ids[i:i + batch_size]
+        try:
+            results = qdrant.retrieve(
+                collection_name=COLLECTION,
+                ids=batch_ids,
+                with_vectors=True,
+            )
+            for r in results:
+                vector_map[str(r.id)] = r.vector
+        except Exception:
+            logger.warning(
+                "Failed to retrieve vectors for batch %d-%d",
+                i, i + len(batch_ids), exc_info=True,
+            )
+    return vector_map
+
+
 def _get_vector(qdrant: QdrantClient, point_id: str) -> list[float]:
-    """Retrieve a point's vector from Qdrant."""
+    """Retrieve a single point's vector from Qdrant (used by tests)."""
     result = qdrant.retrieve(
         collection_name=COLLECTION,
         ids=[point_id],
@@ -358,6 +392,7 @@ async def _synthesize_and_deprecate(
         source_pipeline="dream_cycle",
         wing=synthesis.get("wing", wing),
         room=synthesis.get("room", room),
+        auto_link=False,  # We create provenance links explicitly below
     )
 
     # Set synthesized_from on the new memory's Qdrant payload
@@ -367,6 +402,13 @@ async def _synthesize_and_deprecate(
         collection=COLLECTION,
         point_id=new_memory_id,
         payload={"synthesized_from": original_ids},
+    )
+
+    # Stamp synthesis memory with run_id for rollback (prefixed to
+    # distinguish from deprecated originals in the same column)
+    await db.execute(
+        "UPDATE memory_metadata SET dream_cycle_run_id = ? WHERE memory_id = ?",
+        (f"synthesis:{run_id}", new_memory_id),
     )
 
     # Deprecate originals
@@ -411,7 +453,10 @@ async def _synthesize_and_deprecate(
                     created_at=now_iso,
                 )
             except Exception:
-                pass  # Best-effort linking
+                logger.debug(
+                    "Dream cycle: link %s → %s failed",
+                    new_memory_id, original_id, exc_info=True,
+                )
 
     logger.info(
         "Dream cycle: synthesized %d memories into %s (%s/%s)",
@@ -478,11 +523,10 @@ async def rollback(
     await db.commit()
 
     # 2. Delete synthesized memories created by this run
-    # They carry the tag "dream_cycle_run_id:{run_id}"
-    tag_marker = f"dream_cycle_run_id:{run_id}"
+    # Syntheses are stamped with "synthesis:{run_id}" in dream_cycle_run_id
     cursor = await db.execute(
-        "SELECT memory_id FROM memory_fts WHERE tags LIKE ?",
-        (f"%{tag_marker}%",),
+        "SELECT memory_id FROM memory_metadata WHERE dream_cycle_run_id = ?",
+        (f"synthesis:{run_id}",),
     )
     synthesis_ids = [row[0] for row in await cursor.fetchall()]
 
@@ -505,6 +549,14 @@ async def rollback(
             report["errors"].append({"synthesis_id": sid, "error": str(exc)})
 
     await db.commit()
+
+    # Invalidate graph cache since we deleted links
+    if report["syntheses_deleted"] > 0:
+        try:
+            from genesis.memory.graph import invalidate_graph_cache
+            invalidate_graph_cache()
+        except ImportError:
+            pass
 
     logger.info(
         "Dream cycle rollback %s: restored %d, deleted %d syntheses, %d errors",

--- a/src/genesis/memory/dream_cycle.py
+++ b/src/genesis/memory/dream_cycle.py
@@ -246,8 +246,6 @@ async def _cluster_bucket(
     For each point, searches Qdrant for neighbors above threshold,
     then extracts connected components via union-find.
     """
-    from qdrant_client.models import FieldCondition, Filter, MatchValue
-
     from genesis.qdrant.collections import search
 
     uf = _UnionFind()

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -424,6 +424,13 @@ _CALL_SITE_META: dict[str, dict] = {
         "wired": False,
         "status_reason": "V4_PLACEHOLDER",
     },
+    "dream_cycle_synthesis": {
+        "description": "Dream cycle cluster-merge synthesis. Consolidates near-duplicate episodic memories into canonical records. Weekly Sunday 3am via CronTrigger.",
+        "category": "consolidation",
+        "frequency": "Weekly batch (Sunday 3am, max 100 clusters/run)",
+        "model_tier": "slm",
+        "wired": True,
+    },
     "28_observation_sweep": {
         "description": "Functionally replaced by awareness loop's signal collection (awareness/loop.py:perform_tick). Kept as historical reference; no live consumers route through this call site.",
         "category": "processing",

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -168,7 +168,7 @@ _CALL_SITE_META: dict[str, dict] = {
         "model_tier": "cc",
     },
     "8_ego_compaction": {
-        "description": "Ego-internal rolling summary compactor. Folds old ego_cycles outputs into a single compacted_summary in ego_state so long-running ego memory stays bounded. NOT Genesis-wide memory consolidation — that pipeline (dream cycle) is not yet built. Only caller: ego/compaction.py:54 (inert until ego sessions go live). Note: 8_user_ego_compaction and 8_genesis_ego_compaction are observability labels (NOT routing IDs) — see runtime/init/ego.py:86,157.",
+        "description": "Ego-internal rolling summary compactor. Folds old ego_cycles outputs into a single compacted_summary in ego_state so long-running ego memory stays bounded. NOT Genesis-wide memory consolidation — that is the dream cycle (call site: dream_cycle_synthesis, weekly Sunday 3am). Only caller: ego/compaction.py:54. Note: 8_user_ego_compaction and 8_genesis_ego_compaction are observability labels (NOT routing IDs) — see runtime/init/ego.py:86,157.",
         "category": "processing",
         "frequency": "Daily",
         "model_tier": "slm",

--- a/src/genesis/qdrant/collections.py
+++ b/src/genesis/qdrant/collections.py
@@ -87,48 +87,48 @@ def search(
     points missing the key (legacy data without the tag) are preserved.
     Includes use ``must`` — only points whose key matches are returned.
     """
+    from qdrant_client.models import FieldCondition, Filter, MatchAny, MatchValue
+
     conditions: list = []
     must_not_conditions: list = []
-    if (
-        source_type or wing or room
-        or exclude_subsystems or include_only_subsystems
-    ):
-        from qdrant_client.models import FieldCondition, Filter, MatchAny, MatchValue
 
-        if source_type:
-            conditions.append(
-                FieldCondition(key="source_type", match=MatchValue(value=source_type))
-            )
-        if wing:
-            conditions.append(
-                FieldCondition(key="wing", match=MatchValue(value=wing))
-            )
-        if room:
-            conditions.append(
-                FieldCondition(key="room", match=MatchValue(value=room))
-            )
-        if include_only_subsystems:
-            conditions.append(
-                FieldCondition(
-                    key="source_subsystem",
-                    match=MatchAny(any=list(include_only_subsystems)),
-                )
-            )
-        if exclude_subsystems:
-            must_not_conditions.append(
-                FieldCondition(
-                    key="source_subsystem",
-                    match=MatchAny(any=list(exclude_subsystems)),
-                )
-            )
-    query_filter = None
-    if conditions or must_not_conditions:
-        from qdrant_client.models import Filter
+    # Always exclude deprecated memories (dream cycle soft-delete).
+    # Points without the field (legacy data) are preserved — Qdrant's
+    # must_not only excludes points where the field exists AND matches.
+    must_not_conditions.append(
+        FieldCondition(key="deprecated", match=MatchValue(value=True))
+    )
 
-        query_filter = Filter(
-            must=conditions or None,
-            must_not=must_not_conditions or None,
+    if source_type:
+        conditions.append(
+            FieldCondition(key="source_type", match=MatchValue(value=source_type))
         )
+    if wing:
+        conditions.append(
+            FieldCondition(key="wing", match=MatchValue(value=wing))
+        )
+    if room:
+        conditions.append(
+            FieldCondition(key="room", match=MatchValue(value=room))
+        )
+    if include_only_subsystems:
+        conditions.append(
+            FieldCondition(
+                key="source_subsystem",
+                match=MatchAny(any=list(include_only_subsystems)),
+            )
+        )
+    if exclude_subsystems:
+        must_not_conditions.append(
+            FieldCondition(
+                key="source_subsystem",
+                match=MatchAny(any=list(exclude_subsystems)),
+            )
+        )
+    query_filter = Filter(
+        must=conditions or None,
+        must_not=must_not_conditions or None,
+    )
     results = client.query_points(
         collection_name=collection,
         query=query_vector,

--- a/src/genesis/surplus/maintenance.py
+++ b/src/genesis/surplus/maintenance.py
@@ -324,6 +324,60 @@ class DbMaintenanceExecutor:
         )
 
 
+# ─── Transcript Archival ────────────────────────────────────────────────
+
+
+async def archive_old_transcripts(
+    base_dir: Path,
+    *,
+    older_than_days: int = 90,
+) -> int:
+    """Gzip .jsonl transcript files older than *older_than_days*.
+
+    Lossless and reversible — originals are deleted only after a
+    successful gzip write with size verification. Returns count of
+    files archived.
+    """
+    import gzip
+
+    cutoff = datetime.now(UTC) - timedelta(days=older_than_days)
+    archived = 0
+
+    if not base_dir.is_dir():
+        return 0
+
+    for f in base_dir.glob("*.jsonl"):
+        if not f.is_file():
+            continue
+        try:
+            mtime = datetime.fromtimestamp(f.stat().st_mtime, tz=UTC)
+            if mtime >= cutoff:
+                continue
+
+            gz_path = f.with_suffix(".jsonl.gz")
+            original_size = f.stat().st_size
+
+            # Write compressed
+            with f.open("rb") as src, gzip.open(gz_path, "wb") as dst:
+                while chunk := src.read(65536):
+                    dst.write(chunk)
+
+            # Verify gzip wrote something reasonable
+            if gz_path.stat().st_size == 0 and original_size > 0:
+                gz_path.unlink(missing_ok=True)
+                logger.warning("Gzip produced empty file for %s — skipped", f.name)
+                continue
+
+            # Safe to remove original
+            f.unlink()
+            archived += 1
+        except OSError:
+            logger.warning("Failed to archive %s", f.name, exc_info=True)
+            continue
+
+    return archived
+
+
 # ─── Helpers ─────────────────────────────────────────────────────────────
 
 def _fmt_bytes(n: int) -> str:

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -722,7 +722,8 @@ class SurplusScheduler:
 
             # Write observation with the report
             try:
-                import uuid as _uuid
+                import uuid as _uuid  # noqa: PLC0415
+
                 from genesis.db.crud import observations as obs_crud
                 await obs_crud.create(
                     rt.db,

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -238,6 +238,15 @@ class SurplusScheduler:
                 max_instances=1,
                 misfire_grace_time=3600,
             )
+        # Dream cycle: weekly Sunday 3am — episodic memory consolidation
+        from apscheduler.triggers.cron import CronTrigger
+        self._scheduler.add_job(
+            self.run_dream_cycle,
+            CronTrigger(day_of_week="sun", hour=3),
+            id="dream_cycle",
+            max_instances=1,
+            misfire_grace_time=3600,
+        )
         self._scheduler.add_job(
             self.schedule_maintenance,
             IntervalTrigger(hours=self._maintenance_hours),
@@ -666,6 +675,81 @@ class SurplusScheduler:
             try:
                 from genesis.runtime import GenesisRuntime
                 GenesisRuntime.instance().record_job_failure("model_intelligence", str(exc))
+            except Exception:
+                pass
+
+    async def run_dream_cycle(self) -> None:
+        """Run weekly episodic memory consolidation (dream cycle).
+
+        Dry-run by default — set ``dream_cycle_live`` in Genesis config
+        to enable live merges after reviewing a dry-run report.
+        """
+        try:
+            from genesis.runtime import GenesisRuntime
+            if GenesisRuntime.instance().paused:
+                logger.debug("Dream cycle skipped (Genesis paused)")
+                return
+        except Exception:
+            logger.warning("Pause check failed — skipping dream cycle", exc_info=True)
+            return
+
+        try:
+            from genesis.memory import dream_cycle
+            from genesis.runtime import GenesisRuntime
+
+            rt = GenesisRuntime.instance()
+            if rt.db is None or rt.qdrant is None or rt.router is None:
+                logger.warning("Dream cycle skipped — missing runtime dependencies")
+                return
+
+            # Default dry-run until user enables live mode.
+            # Set GENESIS_DREAM_CYCLE_LIVE=1 to enable actual merges.
+            import os
+            dry_run = os.environ.get("GENESIS_DREAM_CYCLE_LIVE", "") not in ("1", "true")
+
+            store = getattr(rt, "_memory_store", None)
+            if store is None:
+                logger.warning("Dream cycle skipped — MemoryStore not initialized")
+                return
+
+            report = await dream_cycle.run(
+                qdrant=rt.qdrant,
+                db=rt.db,
+                router=rt.router,
+                store=store,
+                dry_run=dry_run,
+            )
+
+            # Write observation with the report
+            try:
+                import uuid as _uuid
+                from genesis.db.crud import observations as obs_crud
+                await obs_crud.create(
+                    rt.db,
+                    id=str(_uuid.uuid4()),
+                    source="dream_cycle",
+                    type="dream_cycle_report",
+                    content=(
+                        f"Dream cycle {'DRY RUN' if dry_run else 'LIVE'}: "
+                        f"{report.get('clusters_found', 0)} clusters found, "
+                        f"{report.get('clusters_merged', 0)} merged, "
+                        f"{report.get('memories_deprecated', 0)} deprecated, "
+                        f"{len(report.get('errors', []))} errors"
+                    ),
+                    priority="low",
+                    created_at=datetime.now(UTC).isoformat(),
+                )
+            except Exception:
+                pass
+
+            logger.info("Dream cycle complete: %s", report)
+            with contextlib.suppress(Exception):
+                GenesisRuntime.instance().record_job_success("dream_cycle")
+        except Exception as exc:
+            logger.exception("Dream cycle failed")
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_failure("dream_cycle", str(exc))
             except Exception:
                 pass
 

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -6,6 +6,7 @@ import contextlib
 import hashlib
 import logging
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import aiosqlite
@@ -413,28 +414,64 @@ class SurplusScheduler:
                         task_type, ComputeTier.FREE_API, priority, drive,
                     )
 
-            # Purge expired surplus insights (TTL enforcement)
+            # ── GC operations ──────────────────────────────────────────
+            # Each wrapped individually so one failure doesn't skip the rest.
             from genesis.runtime import GenesisRuntime
             rt = GenesisRuntime.instance()
             if rt.db is not None:
-                purged = await surplus_crud.purge_expired(rt.db)
-                if purged:
-                    logger.info("Purged %d expired surplus insights", purged)
+                # Purge expired surplus insights (TTL enforcement)
+                try:
+                    purged = await surplus_crud.purge_expired(rt.db)
+                    if purged:
+                        logger.info("Purged %d expired surplus insights", purged)
+                except Exception:
+                    logger.warning("GC: surplus insights purge failed", exc_info=True)
 
                 # GC: remove completed/failed pending_embeddings older than 30 days
-                from genesis.db.crud import pending_embeddings as pe_crud
-                pe_purged = await pe_crud.purge_completed(rt.db, older_than_days=30)
-                if pe_purged:
-                    logger.info("Purged %d completed pending_embeddings", pe_purged)
+                try:
+                    from genesis.db.crud import pending_embeddings as pe_crud
+                    pe_purged = await pe_crud.purge_completed(rt.db, older_than_days=30)
+                    if pe_purged:
+                        logger.info("Purged %d completed pending_embeddings", pe_purged)
+                except Exception:
+                    logger.warning("GC: pending_embeddings purge failed", exc_info=True)
 
                 # GC: rotate heartbeat events older than 7 days
-                from genesis.db.crud import events as events_crud
-                hb_cutoff = (datetime.now(UTC) - timedelta(days=7)).isoformat()
-                hb_purged = await events_crud.prune(
-                    rt.db, older_than=hb_cutoff, event_type="heartbeat",
-                )
-                if hb_purged:
-                    logger.info("Pruned %d heartbeat events older than 7d", hb_purged)
+                try:
+                    from genesis.db.crud import events as events_crud
+                    hb_cutoff = (datetime.now(UTC) - timedelta(days=7)).isoformat()
+                    hb_purged = await events_crud.prune(
+                        rt.db, older_than=hb_cutoff, event_type="heartbeat",
+                    )
+                    if hb_purged:
+                        logger.info("Pruned %d heartbeat events older than 7d", hb_purged)
+                except Exception:
+                    logger.warning("GC: heartbeat event rotation failed", exc_info=True)
+
+                # GC: prune weak memory links (strength <= 0.3, older than 30d)
+                try:
+                    from genesis.db.crud import memory_links as links_crud
+                    links_pruned = await links_crud.prune_weak(
+                        rt.db, max_strength=0.3, min_age_days=30,
+                    )
+                    if links_pruned:
+                        logger.info("Pruned %d weak memory links", links_pruned)
+                except Exception:
+                    logger.warning("GC: weak link pruning failed", exc_info=True)
+
+                # GC: archive old transcript files (gzip .jsonl > 90 days)
+                try:
+                    from genesis.surplus.maintenance import archive_old_transcripts
+                    transcripts_archived = await archive_old_transcripts(
+                        Path.home() / ".genesis" / "background-sessions",
+                        older_than_days=90,
+                    )
+                    if transcripts_archived:
+                        logger.info(
+                            "Archived %d old transcript files", transcripts_archived,
+                        )
+                except Exception:
+                    logger.warning("GC: transcript archival failed", exc_info=True)
 
             with contextlib.suppress(Exception):
                 GenesisRuntime.instance().record_job_success("schedule_maintenance")

--- a/tests/test_db/test_memory_links_prune.py
+++ b/tests/test_db/test_memory_links_prune.py
@@ -1,0 +1,84 @@
+"""Tests for memory_links.prune_weak()."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from genesis.db.crud import memory_links
+from genesis.db.schema import create_all_tables
+
+
+@pytest.fixture
+async def db():
+    import aiosqlite
+
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = None
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+def _old_date(days_ago: int = 60) -> str:
+    return (datetime.now(UTC) - timedelta(days=days_ago)).isoformat()
+
+
+def _recent_date() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@pytest.mark.asyncio
+async def test_prune_weak_deletes_old_weak_links(db):
+    """Links with strength <= 0.3 and age > 30d are pruned."""
+    await memory_links.create(
+        db, source_id="a", target_id="b",
+        link_type="related_to", strength=0.2,
+        created_at=_old_date(60),
+    )
+    pruned = await memory_links.prune_weak(db, max_strength=0.3, min_age_days=30)
+    assert pruned == 1
+
+
+@pytest.mark.asyncio
+async def test_prune_weak_spares_strong_links(db):
+    """Links with strength > 0.3 are kept regardless of age."""
+    await memory_links.create(
+        db, source_id="a", target_id="b",
+        link_type="supports", strength=0.8,
+        created_at=_old_date(60),
+    )
+    pruned = await memory_links.prune_weak(db, max_strength=0.3, min_age_days=30)
+    assert pruned == 0
+
+
+@pytest.mark.asyncio
+async def test_prune_weak_spares_recent_weak_links(db):
+    """Weak links younger than min_age_days are kept."""
+    await memory_links.create(
+        db, source_id="a", target_id="b",
+        link_type="related_to", strength=0.1,
+        created_at=_recent_date(),
+    )
+    pruned = await memory_links.prune_weak(db, max_strength=0.3, min_age_days=30)
+    assert pruned == 0
+
+
+@pytest.mark.asyncio
+async def test_prune_weak_returns_zero_on_empty(db):
+    """No links to prune returns 0."""
+    pruned = await memory_links.prune_weak(db)
+    assert pruned == 0
+
+
+@pytest.mark.asyncio
+async def test_prune_weak_boundary_strength(db):
+    """Links at exactly max_strength are pruned (<=, not <)."""
+    await memory_links.create(
+        db, source_id="a", target_id="b",
+        link_type="related_to", strength=0.3,
+        created_at=_old_date(60),
+    )
+    pruned = await memory_links.prune_weak(db, max_strength=0.3, min_age_days=30)
+    assert pruned == 1

--- a/tests/test_db/test_search_ranked_invalid_at.py
+++ b/tests/test_db/test_search_ranked_invalid_at.py
@@ -22,7 +22,9 @@ async def _build_db(path: str) -> aiosqlite.Connection:
             room TEXT,
             valid_at TEXT,
             invalid_at TEXT,
-            source_subsystem TEXT
+            source_subsystem TEXT,
+            deprecated INTEGER NOT NULL DEFAULT 0,
+            dream_cycle_run_id TEXT
         )
     """)
     await conn.execute("""

--- a/tests/test_db/test_search_ranked_subsystem.py
+++ b/tests/test_db/test_search_ranked_subsystem.py
@@ -22,7 +22,9 @@ async def _build_db(path: str) -> aiosqlite.Connection:
             room TEXT,
             valid_at TEXT,
             invalid_at TEXT,
-            source_subsystem TEXT
+            source_subsystem TEXT,
+            deprecated INTEGER NOT NULL DEFAULT 0,
+            dream_cycle_run_id TEXT
         )
     """)
     await conn.execute("""

--- a/tests/test_memory/test_dream_cycle.py
+++ b/tests/test_memory/test_dream_cycle.py
@@ -22,7 +22,7 @@ _SCROLL = "genesis.qdrant.collections.scroll_points"
 _SEARCH = "genesis.qdrant.collections.search"
 _UPDATE = "genesis.qdrant.collections.update_payload"
 _DELETE = "genesis.qdrant.collections.delete_point"
-_GET_VEC = "genesis.memory.dream_cycle._get_vector"
+_BATCH_VEC = "genesis.memory.dream_cycle._batch_get_vectors"
 
 
 # ── Union-Find ───────────────────────────────────────────────────────────
@@ -158,7 +158,7 @@ class TestDryRun:
 
         with patch(_SCROLL) as mock_scroll, \
              patch(_SEARCH) as mock_search, \
-             patch(_GET_VEC) as mock_vec:
+             patch(_BATCH_VEC) as mock_vec:
             mock_scroll.return_value = (
                 [
                     {"id": "p1", "payload": {"wing": "memory", "room": "store", "content": "fact A", "confidence": 0.9}},
@@ -169,7 +169,7 @@ class TestDryRun:
             mock_search.return_value = [
                 {"id": "p2", "score": 0.92, "payload": {}},
             ]
-            mock_vec.return_value = [0.1] * 768
+            mock_vec.return_value = {"p1": [0.1] * 768, "p2": [0.1] * 768}
 
             report = await run(
                 qdrant=mock_qdrant,
@@ -214,7 +214,7 @@ class TestLiveRun:
 
         with patch(_SCROLL) as mock_scroll, \
              patch(_SEARCH) as mock_search, \
-             patch(_GET_VEC) as mock_vec, \
+             patch(_BATCH_VEC) as mock_vec, \
              patch(_UPDATE) as mock_update:
             mock_scroll.return_value = (
                 [
@@ -226,7 +226,7 @@ class TestLiveRun:
             mock_search.return_value = [
                 {"id": "p2", "score": 0.92, "payload": {}},
             ]
-            mock_vec.return_value = [0.1] * 768
+            mock_vec.return_value = {"p1": [0.1] * 768, "p2": [0.1] * 768}
 
             report = await run(
                 qdrant=mock_qdrant,
@@ -260,13 +260,15 @@ class TestLiveRun:
 
         with patch(_SCROLL) as mock_scroll, \
              patch(_SEARCH) as mock_search, \
-             patch(_GET_VEC) as mock_vec:
+             patch(_BATCH_VEC) as mock_vec:
             mock_scroll.return_value = (large_cluster_points, None)
             mock_search.side_effect = lambda *a, **kw: [
                 {"id": p["id"], "score": 0.95, "payload": {}}
                 for p in large_cluster_points
             ]
-            mock_vec.return_value = [0.1] * 768
+            mock_vec.return_value = {
+                p["id"]: [0.1] * 768 for p in large_cluster_points
+            }
 
             report = await run(
                 qdrant=mock_qdrant,

--- a/tests/test_memory/test_dream_cycle.py
+++ b/tests/test_memory/test_dream_cycle.py
@@ -1,0 +1,322 @@
+"""Tests for dream cycle consolidation engine."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genesis.memory.dream_cycle import (
+    MAX_CLUSTER_SIZE,
+    _UnionFind,
+    _build_synthesis_prompt,
+    _parse_synthesis_response,
+    _size_distribution,
+    run,
+)
+
+# All Qdrant functions are imported inside function bodies, so we patch
+# at the source (genesis.qdrant.collections.*) not at dream_cycle.*.
+_SCROLL = "genesis.qdrant.collections.scroll_points"
+_SEARCH = "genesis.qdrant.collections.search"
+_UPDATE = "genesis.qdrant.collections.update_payload"
+_DELETE = "genesis.qdrant.collections.delete_point"
+_GET_VEC = "genesis.memory.dream_cycle._get_vector"
+
+
+# ── Union-Find ───────────────────────────────────────────────────────────
+
+
+class TestUnionFind:
+    def test_singleton(self):
+        uf = _UnionFind()
+        assert uf.find("a") == "a"
+
+    def test_union_two(self):
+        uf = _UnionFind()
+        uf.union("a", "b")
+        assert uf.find("a") == uf.find("b")
+
+    def test_union_chain(self):
+        uf = _UnionFind()
+        uf.union("a", "b")
+        uf.union("b", "c")
+        assert uf.find("a") == uf.find("c")
+
+    def test_components(self):
+        uf = _UnionFind()
+        uf.union("a", "b")
+        uf.union("c", "d")
+        comps = uf.components()
+        roots = list(comps.keys())
+        assert len(roots) == 2
+        sizes = sorted(len(v) for v in comps.values())
+        assert sizes == [2, 2]
+
+    def test_no_false_merge(self):
+        uf = _UnionFind()
+        uf.find("a")
+        uf.find("b")
+        assert uf.find("a") != uf.find("b")
+
+
+# ── Prompt Building ──────────────────────────────────────────────────────
+
+
+class TestBuildSynthesisPrompt:
+    def test_includes_all_memories(self):
+        cluster = [
+            {"id": "m1", "payload": {"content": "fact A", "confidence": 0.9, "source": "s1", "created_at": "2026-01-01"}},
+            {"id": "m2", "payload": {"content": "fact B", "confidence": 0.7, "source": "s2", "created_at": "2026-01-02"}},
+        ]
+        prompt = _build_synthesis_prompt(cluster, "memory", "retrieval")
+        assert "fact A" in prompt
+        assert "fact B" in prompt
+        assert "wing=memory" in prompt
+        assert "room=retrieval" in prompt
+        assert "2 total" in prompt
+
+    def test_handles_missing_fields(self):
+        cluster = [
+            {"id": "m1", "payload": {"content": "x"}},
+            {"id": "m2", "payload": {"content": "y"}},
+        ]
+        prompt = _build_synthesis_prompt(cluster, "general", "uncategorized")
+        assert "x" in prompt
+        assert "y" in prompt
+
+
+# ── Response Parsing ─────────────────────────────────────────────────────
+
+
+class TestParseSynthesisResponse:
+    def test_valid_json(self):
+        response = json.dumps({
+            "content": "merged content",
+            "tags": ["a", "b"],
+            "confidence": 0.95,
+            "memory_class": "fact",
+            "wing": "memory",
+            "room": "store",
+            "synthesis_notes": "combined A and B",
+        })
+        result = _parse_synthesis_response(response, "default_wing", "default_room")
+        assert result["content"] == "merged content"
+        assert result["confidence"] == 0.95
+        assert result["wing"] == "memory"
+
+    def test_json_with_markdown_fences(self):
+        response = '```json\n{"content": "test", "tags": []}\n```'
+        result = _parse_synthesis_response(response, "w", "r")
+        assert result["content"] == "test"
+
+    def test_invalid_json_fallback(self):
+        response = "This is not JSON at all"
+        result = _parse_synthesis_response(response, "w", "r")
+        assert result["content"] == response
+        assert result["wing"] == "w"
+        assert result["room"] == "r"
+
+    def test_missing_content_field(self):
+        response = json.dumps({"tags": ["a"]})
+        result = _parse_synthesis_response(response, "w", "r")
+        # Falls back to raw response
+        assert "tags" in result["content"]
+
+
+# ── Size Distribution ────────────────────────────────────────────────────
+
+
+class TestSizeDistribution:
+    def test_categorizes_correctly(self):
+        clusters = [
+            [{"id": "1"}, {"id": "2"}],
+            [{"id": "1"}, {"id": "2"}, {"id": "3"}],
+            [{"id": str(i)} for i in range(5)],
+            [{"id": str(i)} for i in range(8)],
+            [{"id": str(i)} for i in range(15)],
+        ]
+        dist = _size_distribution(clusters)
+        assert dist["2-3"] == 2
+        assert dist["4-5"] == 1
+        assert dist["6-10"] == 1
+        assert dist["11+"] == 1
+
+
+# ── Dry-Run Integration ─────────────────────────────────────────────────
+
+
+class TestDryRun:
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_report_without_changes(self):
+        """Dry run computes clusters but doesn't write anything."""
+        mock_qdrant = MagicMock()
+        mock_db = AsyncMock()
+        mock_router = AsyncMock()
+        mock_store = AsyncMock()
+
+        with patch(_SCROLL) as mock_scroll, \
+             patch(_SEARCH) as mock_search, \
+             patch(_GET_VEC) as mock_vec:
+            mock_scroll.return_value = (
+                [
+                    {"id": "p1", "payload": {"wing": "memory", "room": "store", "content": "fact A", "confidence": 0.9}},
+                    {"id": "p2", "payload": {"wing": "memory", "room": "store", "content": "fact A rephrased", "confidence": 0.8}},
+                ],
+                None,
+            )
+            mock_search.return_value = [
+                {"id": "p2", "score": 0.92, "payload": {}},
+            ]
+            mock_vec.return_value = [0.1] * 768
+
+            report = await run(
+                qdrant=mock_qdrant,
+                db=mock_db,
+                router=mock_router,
+                store=mock_store,
+                dry_run=True,
+            )
+
+        assert report["dry_run"] is True
+        assert report["clusters_found"] >= 1
+        assert report["clusters_merged"] == 0
+        mock_store.store.assert_not_called()
+        mock_db.execute.assert_not_called()
+
+
+class TestLiveRun:
+    @pytest.mark.asyncio
+    async def test_live_run_synthesizes_and_deprecates(self):
+        """Live run calls LLM, stores synthesis, deprecates originals."""
+        mock_qdrant = MagicMock()
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock()
+        mock_db.commit = AsyncMock()
+        mock_router = AsyncMock()
+        mock_store = AsyncMock()
+        mock_store.store = AsyncMock(return_value="new-synth-id")
+        mock_store.linker = None
+
+        synthesis_json = json.dumps({
+            "content": "Merged fact A+B",
+            "tags": ["test"],
+            "confidence": 0.9,
+            "memory_class": "fact",
+            "wing": "memory",
+            "room": "store",
+            "synthesis_notes": "combined",
+        })
+        mock_router.route_call = AsyncMock(
+            return_value=MagicMock(success=True, content=synthesis_json),
+        )
+
+        with patch(_SCROLL) as mock_scroll, \
+             patch(_SEARCH) as mock_search, \
+             patch(_GET_VEC) as mock_vec, \
+             patch(_UPDATE) as mock_update:
+            mock_scroll.return_value = (
+                [
+                    {"id": "p1", "payload": {"wing": "memory", "room": "store", "content": "fact A", "confidence": 0.9}},
+                    {"id": "p2", "payload": {"wing": "memory", "room": "store", "content": "fact A v2", "confidence": 0.8}},
+                ],
+                None,
+            )
+            mock_search.return_value = [
+                {"id": "p2", "score": 0.92, "payload": {}},
+            ]
+            mock_vec.return_value = [0.1] * 768
+
+            report = await run(
+                qdrant=mock_qdrant,
+                db=mock_db,
+                router=mock_router,
+                store=mock_store,
+                dry_run=False,
+            )
+
+        assert report["dry_run"] is False
+        assert report["clusters_merged"] >= 1
+        assert report["memories_deprecated"] >= 2
+        mock_store.store.assert_called_once()
+        assert mock_store.store.call_args[1]["source_pipeline"] == "dream_cycle"
+        # 1 for synthesized_from + 2 for deprecated originals
+        assert mock_update.call_count >= 3
+
+    @pytest.mark.asyncio
+    async def test_skips_large_clusters(self):
+        """Clusters > MAX_CLUSTER_SIZE are skipped."""
+        mock_qdrant = MagicMock()
+        mock_db = AsyncMock()
+        mock_router = AsyncMock()
+        mock_store = AsyncMock()
+        mock_store.linker = None
+
+        large_cluster_points = [
+            {"id": f"p{i}", "payload": {"wing": "memory", "room": "store", "content": f"fact {i}", "confidence": 0.5}}
+            for i in range(MAX_CLUSTER_SIZE + 5)
+        ]
+
+        with patch(_SCROLL) as mock_scroll, \
+             patch(_SEARCH) as mock_search, \
+             patch(_GET_VEC) as mock_vec:
+            mock_scroll.return_value = (large_cluster_points, None)
+            mock_search.side_effect = lambda *a, **kw: [
+                {"id": p["id"], "score": 0.95, "payload": {}}
+                for p in large_cluster_points
+            ]
+            mock_vec.return_value = [0.1] * 768
+
+            report = await run(
+                qdrant=mock_qdrant,
+                db=mock_db,
+                router=mock_router,
+                store=mock_store,
+                dry_run=False,
+            )
+
+        assert report["clusters_skipped_large"] >= 1
+        assert report["clusters_merged"] == 0
+        mock_store.store.assert_not_called()
+
+
+# ── Rollback ─────────────────────────────────────────────────────────────
+
+
+class TestRollback:
+    @pytest.mark.asyncio
+    async def test_rollback_restores_and_deletes(self):
+        """Rollback restores deprecated originals and deletes syntheses."""
+        from genesis.memory.dream_cycle import rollback
+
+        mock_qdrant = MagicMock()
+        mock_db = AsyncMock()
+
+        deprecated_cursor = AsyncMock()
+        deprecated_cursor.fetchall = AsyncMock(return_value=[("orig-1",), ("orig-2",)])
+
+        synthesis_cursor = AsyncMock()
+        synthesis_cursor.fetchall = AsyncMock(return_value=[("synth-1",)])
+
+        mock_db.execute = AsyncMock(side_effect=[
+            deprecated_cursor,   # SELECT deprecated
+            AsyncMock(),         # UPDATE orig-1
+            AsyncMock(),         # UPDATE orig-2
+            synthesis_cursor,    # SELECT synthesis
+            AsyncMock(),         # DELETE metadata
+            AsyncMock(),         # DELETE fts
+            AsyncMock(),         # DELETE links
+        ])
+        mock_db.commit = AsyncMock()
+
+        with patch(_UPDATE), patch(_DELETE):
+            report = await rollback(
+                "test-run-id",
+                qdrant=mock_qdrant,
+                db=mock_db,
+            )
+
+        assert report["restored"] == 2
+        assert report["syntheses_deleted"] == 1
+        assert len(report["errors"]) == 0

--- a/tests/test_memory/test_dream_cycle.py
+++ b/tests/test_memory/test_dream_cycle.py
@@ -9,10 +9,10 @@ import pytest
 
 from genesis.memory.dream_cycle import (
     MAX_CLUSTER_SIZE,
-    _UnionFind,
     _build_synthesis_prompt,
     _parse_synthesis_response,
     _size_distribution,
+    _UnionFind,
     run,
 )
 

--- a/tests/test_memory/test_transcript_archival.py
+++ b/tests/test_memory/test_transcript_archival.py
@@ -1,0 +1,82 @@
+"""Tests for transcript archival (gzip old .jsonl files)."""
+
+from __future__ import annotations
+
+import gzip
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from genesis.surplus.maintenance import archive_old_transcripts
+
+
+@pytest.fixture
+def tmp_sessions(tmp_path: Path) -> Path:
+    """Create a temp directory simulating background-sessions/."""
+    return tmp_path
+
+
+def _create_file(base: Path, name: str, content: str, age_days: int) -> Path:
+    """Create a file with a given mtime age."""
+    import os
+    f = base / name
+    f.write_text(content)
+    mtime = (datetime.now(UTC) - timedelta(days=age_days)).timestamp()
+    os.utime(f, (mtime, mtime))
+    return f
+
+
+@pytest.mark.asyncio
+async def test_archives_old_files(tmp_sessions):
+    """Files older than threshold are gzipped."""
+    _create_file(tmp_sessions, "old.jsonl", '{"a":1}\n', age_days=120)
+    count = await archive_old_transcripts(tmp_sessions, older_than_days=90)
+    assert count == 1
+    assert (tmp_sessions / "old.jsonl.gz").exists()
+    assert not (tmp_sessions / "old.jsonl").exists()
+
+    # Verify contents
+    with gzip.open(tmp_sessions / "old.jsonl.gz", "rt") as f:
+        assert f.read() == '{"a":1}\n'
+
+
+@pytest.mark.asyncio
+async def test_spares_recent_files(tmp_sessions):
+    """Files younger than threshold are left alone."""
+    _create_file(tmp_sessions, "recent.jsonl", '{"b":2}\n', age_days=30)
+    count = await archive_old_transcripts(tmp_sessions, older_than_days=90)
+    assert count == 0
+    assert (tmp_sessions / "recent.jsonl").exists()
+
+
+@pytest.mark.asyncio
+async def test_skips_nonexistent_directory(tmp_path):
+    """Missing directory returns 0 without error."""
+    count = await archive_old_transcripts(
+        tmp_path / "nonexistent", older_than_days=90,
+    )
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_ignores_non_jsonl_files(tmp_sessions):
+    """Only .jsonl files are targeted."""
+    _create_file(tmp_sessions, "old.log", "log content\n", age_days=120)
+    count = await archive_old_transcripts(tmp_sessions, older_than_days=90)
+    assert count == 0
+    assert (tmp_sessions / "old.log").exists()
+
+
+@pytest.mark.asyncio
+async def test_skips_already_compressed(tmp_sessions):
+    """Already-compressed .jsonl.gz files are not touched."""
+    gz_path = tmp_sessions / "already.jsonl.gz"
+    with gzip.open(gz_path, "wt") as f:
+        f.write("compressed\n")
+    import os
+    mtime = (datetime.now(UTC) - timedelta(days=120)).timestamp()
+    os.utime(gz_path, (mtime, mtime))
+
+    count = await archive_old_transcripts(tmp_sessions, older_than_days=90)
+    assert count == 0  # .gz files don't match *.jsonl glob

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -134,7 +134,8 @@ def test_load_full_yaml(monkeypatch):
     # 7_task_retrospective removed by this PR).
     # 2026-05-12: 43 → 44 after 44_task_premortem added by #334.
     # 2026-05-14: 44 → 45 after 45_intelligence_intake added by #349.
-    assert len(cfg.call_sites) == 45
+    # 2026-05-15: 45 → 46 after dream_cycle_synthesis added by #359.
+    assert len(cfg.call_sites) == 46
     assert "2_triage" not in cfg.call_sites  # removed 2026-05-10
     assert "7_task_retrospective" not in cfg.call_sites  # removed 2026-05-10 (duplicate; live one is 43_task_retrospective)
     assert "background" in cfg.retry_profiles


### PR DESCRIPTION
## Summary

- **Dream cycle engine** — weekly background job that finds clusters of near-duplicate episodic memories (cosine >= 0.87), LLM-synthesizes each cluster into a canonical record, and soft-deletes the originals
- **Tier 1 mechanical maintenance** — weak link pruning (strength <= 0.3, age > 30d), transcript archival (gzip .jsonl > 90d), GC try/except wrapping
- **Schema + retrieval filters** — `deprecated` column on memory_metadata + Qdrant payload, always-on exclusion filters in both search paths
- **Design spec** at `docs/superpowers/specs/2026-05-14-dream-cycle-design.md`

## Key Design Decisions

- Ships in **dry-run mode** by default (set `GENESIS_DREAM_CYCLE_LIVE=1` to enable)
- **CronTrigger Sunday 3am** — uses CronTrigger, not IntervalTrigger
- `deprecated` supplements `invalid_at` (independent dimensions)
- Max 100 cluster merges per run; clusters > 10 flagged for manual review
- Rollback via `dream_cycle_run_id` on both deprecated originals and syntheses
- `auto_link=False` on synthesis store (prevents spurious links to about-to-be-deprecated originals)
- Batch vector retrieval per bucket (1 Qdrant call vs N)
- Graph cache invalidated after link pruning and rollback

## Architecture Review Fixes

Genesis-architect review found 6 important issues, all fixed:
1. Bare `except: pass` on link creation → now logs with exc_info
2. `store.store()` auto_link race → disabled with `auto_link=False`
3. `prune_weak()` missing graph cache invalidation → added
4. Rollback FTS5 LIKE fragility → now uses indexed memory_metadata column
5. N sync Qdrant calls → batch retrieval
6. Rollback missing graph cache invalidation → added

## Test plan

- [x] 26 new tests (dream cycle phases, link pruning, transcript archival)
- [x] 64 existing affected tests pass (no regressions)
- [x] ruff lint clean
- [ ] CI (lint, test, CodeQL, leak-detector, migration-check)
- [ ] Dry-run against live episodic_memory collection (post-merge)
- [ ] Supervised single-cluster live merge (after dry-run review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)