### PR TITLE
feat: competitive quick-wins — coherence fix, planning discipline, Ladder, enforcer, edit sensor, task notepads

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -303,6 +303,11 @@
                         "type": "command",
                         "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook file_modification_audit_hook.py",
                         "timeout": 500
+                    },
+                    {
+                        "type": "command",
+                        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook edit_failure_sensor.py",
+                        "timeout": 500
                     }
                 ]
             },

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ config/.generated/
 src/genesis/identity/TRIAGE_CALIBRATION.md
 src/genesis/identity/USER_KNOWLEDGE.md
 src/genesis/identity/EGO_NOTEPAD.md
+# Task-scoped notepad (ephemeral, seeded per-task in worktrees)
+TASK_NOTEPAD.md
 config/*.local.yaml
 .gstack/
 .context/

--- a/scripts/edit_failure_sensor.py
+++ b/scripts/edit_failure_sensor.py
@@ -72,21 +72,23 @@ def _process(data: dict) -> None:
 
     try:
         conn = sqlite3.connect(str(_DB_PATH), timeout=2)
-        conn.execute(
-            """INSERT INTO tool_call_outcomes
-               (session_id, tool_name, file_path, success, error_snippet, timestamp)
-               VALUES (?, ?, ?, ?, ?, ?)""",
-            (
-                session_id or None,
-                tool_name,
-                file_path or None,
-                success,
-                error_snippet,
-                datetime.now(UTC).isoformat(),
-            ),
-        )
-        conn.commit()
-        conn.close()
+        try:
+            conn.execute(
+                """INSERT INTO tool_call_outcomes
+                   (session_id, tool_name, file_path, success, error_snippet, timestamp)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    session_id or None,
+                    tool_name,
+                    file_path or None,
+                    success,
+                    error_snippet,
+                    datetime.now(UTC).isoformat(),
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
     except sqlite3.OperationalError:
         pass
 

--- a/scripts/edit_failure_sensor.py
+++ b/scripts/edit_failure_sensor.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: track Edit/Write success and failure rates.
+
+Records every Edit and Write tool call outcome to the tool_call_outcomes
+table, enabling measurement of edit failure rates and identification of
+patterns in failed edits (file size, match complexity, etc.).
+
+Fires on Edit|Write completions. Reads stdin JSON per the PostToolUse
+contract (includes tool_result/tool_output).
+
+Zero tokens — pure shell/DB operation.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+_DB_PATH = Path.home() / "genesis" / "data" / "genesis.db"
+
+# Markers in tool_output that indicate an Edit failure
+_FAILURE_MARKERS = [
+    "old_string not found",
+    "not unique in the file",
+    "no changes were made",
+    "old_string and new_string are the same",
+    "Error:",
+]
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return
+        data = json.loads(raw)
+        _process(data)
+    except Exception:
+        return
+
+
+def _process(data: dict) -> None:
+    tool_name = data.get("tool_name", "")
+    if tool_name not in ("Edit", "Write"):
+        return
+
+    session_id = data.get("session_id", "")
+    tool_input = data.get("tool_input") or {}
+    tool_output = data.get("tool_output", "") or ""
+
+    if not isinstance(tool_input, dict):
+        return
+
+    file_path = tool_input.get("file_path", "")
+
+    # Determine success/failure from tool_output
+    success = 1
+    error_snippet = None
+
+    output_lower = tool_output.lower()
+    for marker in _FAILURE_MARKERS:
+        if marker.lower() in output_lower:
+            success = 0
+            error_snippet = tool_output[:200]
+            break
+
+    if not _DB_PATH.exists():
+        return
+
+    try:
+        conn = sqlite3.connect(str(_DB_PATH), timeout=2)
+        conn.execute(
+            """INSERT INTO tool_call_outcomes
+               (session_id, tool_name, file_path, success, error_snippet, timestamp)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                session_id or None,
+                tool_name,
+                file_path or None,
+                success,
+                error_snippet,
+                datetime.now(UTC).isoformat(),
+            ),
+        )
+        conn.commit()
+        conn.close()
+    except sqlite3.OperationalError:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/genesis/autonomy/executor/dispatch.py
+++ b/src/genesis/autonomy/executor/dispatch.py
@@ -79,6 +79,13 @@ def build_step_prompt(
             "",
         ])
 
+    # Notepad reminder for code steps (file is seeded by engine)
+    if step.get("type") == "code":
+        parts.extend([
+            "**Notepad:** Read and update `TASK_NOTEPAD.md` in your working directory.",
+            "",
+        ])
+
     return "\n".join(parts)
 
 

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -586,6 +586,34 @@ class CCSessionExecutor:
                 f"Verification passed (iteration {iteration}).",
             )
 
+            # --- PRE-SYNTHESIS GUARD: all steps must be completed ---
+            incomplete = await task_steps.get_incomplete_steps(
+                self._db, task_id,
+            )
+            if incomplete:
+                descs = [
+                    f"step {s['step_idx']} ({s['status']}): "
+                    f"{s.get('description', '')[:80]}"
+                    for s in incomplete
+                ]
+                blocker_msg = (
+                    f"{len(incomplete)} step(s) not completed:\n"
+                    + "\n".join(descs)
+                )
+                logger.warning(
+                    "Task %s blocked: incomplete steps detected "
+                    "before synthesis: %s",
+                    task_id, blocker_msg,
+                )
+                self._append_to_plan(
+                    plan_path, "GUARD",
+                    f"BLOCKED: {len(incomplete)} incomplete step(s).",
+                )
+                await self._persist_blocker(
+                    task_id, blocker_msg, TaskPhase.VERIFYING,
+                )
+                return False
+
             # --- SYNTHESIZING ---
             await self._transition(task_id, TaskPhase.SYNTHESIZING)
             await self._set_output(task_id, "deliverable", deliverable)

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -352,6 +352,8 @@ class CCSessionExecutor:
                 has_code = any(s.get("type") == "code" for s in steps)
                 if has_code:
                     await self._create_worktree(task_id)
+                    # Seed task notepad for cross-step knowledge sharing
+                    self._seed_notepad(task_id)
 
                 self._append_to_plan(
                     plan_path, "PLANNING",
@@ -624,6 +626,10 @@ class CCSessionExecutor:
 
             # --- RETROSPECTIVE ---
             await self._transition(task_id, TaskPhase.RETROSPECTIVE)
+
+            # Promote task notepad to memory (before worktree cleanup)
+            await self._promote_notepad(task_id, description)
+
             if trace and self._tracer:
                 try:
                     retro_id = await self._tracer.finalize(trace)
@@ -1054,6 +1060,72 @@ class CCSessionExecutor:
                 "Worktree recovery failed for task %s", task_id,
             )
             return False
+
+    _NOTEPAD_SKELETON = (
+        "# Task Notepad\n\n"
+        "Record learnings, decisions, and issues as you work.\n"
+        "Each step should READ this file first and APPEND before finishing.\n\n"
+        "## Learnings\n\n"
+        "## Decisions\n\n"
+        "## Issues\n"
+    )
+
+    def _seed_notepad(self, task_id: str) -> None:
+        """Write an empty TASK_NOTEPAD.md into the task worktree."""
+        wt_path = self._worktree_paths.get(task_id)
+        if not wt_path:
+            return
+        notepad = Path(wt_path) / "TASK_NOTEPAD.md"
+        try:
+            notepad.write_text(self._NOTEPAD_SKELETON, encoding="utf-8")
+        except OSError:
+            logger.debug("Failed to seed notepad for task %s", task_id)
+
+    async def _promote_notepad(
+        self, task_id: str, description: str,
+    ) -> None:
+        """Read notepad from worktree and store to memory if non-trivial."""
+        wt_path = self._worktree_paths.get(task_id)
+        if not wt_path:
+            return
+        notepad = Path(wt_path) / "TASK_NOTEPAD.md"
+        try:
+            content = notepad.read_text(encoding="utf-8")
+        except OSError:
+            return
+        # Strip the skeleton to see if steps added anything
+        added = content.replace(self._NOTEPAD_SKELETON, "").strip()
+        if not added or len(added) < 20:
+            return  # Nothing substantive was added
+        # Resolve memory store from runtime (same pattern as surplus)
+        store = None
+        try:
+            from genesis.runtime import GenesisRuntime
+            rt = GenesisRuntime.instance()
+            store = rt._memory_store
+        except Exception:
+            pass
+        if store is None:
+            logger.debug("No MemoryStore for notepad promotion (task %s)", task_id)
+            return
+        try:
+            await store.store(
+                content=f"Task notepad for: {description}\n\n{added}",
+                source="task_executor",
+                memory_type="episodic",
+                tags=["task_notepad", "synthesis"],
+                wing="autonomy",
+                room="tasks",
+            )
+            logger.info(
+                "Task %s notepad promoted to memory (%d chars)",
+                task_id, len(added),
+            )
+        except Exception:
+            logger.debug(
+                "Notepad promotion failed for task %s (non-blocking)",
+                task_id, exc_info=True,
+            )
 
     async def _cleanup_worktree(self, task_id: str) -> None:
         """Remove worktree if one was created for this task."""

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -1093,10 +1093,24 @@ class CCSessionExecutor:
             content = notepad.read_text(encoding="utf-8")
         except OSError:
             return
-        # Strip the skeleton to see if steps added anything
-        added = content.replace(self._NOTEPAD_SKELETON, "").strip()
-        if not added or len(added) < 20:
+        # Check if any section has real content (not just the skeleton headings).
+        # Steps insert content under ## Learnings / ## Decisions / ## Issues,
+        # so a contiguous skeleton replace won't work — check per-section.
+        import re
+        sections = re.split(r"^## ", content, flags=re.MULTILINE)
+        has_content = False
+        added_parts: list[str] = []
+        for section in sections[1:]:  # skip preamble before first ##
+            lines = section.split("\n", 1)
+            if len(lines) < 2:
+                continue
+            body = lines[1].strip()
+            if body:
+                has_content = True
+                added_parts.append(f"## {section.strip()}")
+        if not has_content:
             return  # Nothing substantive was added
+        added = "\n\n".join(added_parts)
         # Resolve memory store from runtime (same pattern as surplus)
         store = None
         try:

--- a/src/genesis/db/crud/task_steps.py
+++ b/src/genesis/db/crud/task_steps.py
@@ -98,3 +98,17 @@ async def get_last_completed_step(
     )
     row = await cursor.fetchone()
     return dict(row) if row else None
+
+
+async def get_incomplete_steps(
+    db: aiosqlite.Connection,
+    task_id: str,
+) -> list[dict]:
+    """Return all steps for a task that are NOT 'completed', ordered by step_idx."""
+    cursor = await db.execute(
+        """SELECT * FROM task_steps
+           WHERE task_id = ? AND status != 'completed'
+           ORDER BY step_idx""",
+        (task_id,),
+    )
+    return [dict(r) for r in await cursor.fetchall()]

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -951,6 +951,17 @@ TABLES = {
             timestamp        TEXT NOT NULL
         )
     """,
+    "tool_call_outcomes": """
+        CREATE TABLE IF NOT EXISTS tool_call_outcomes (
+            id               INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id       TEXT,
+            tool_name        TEXT NOT NULL,
+            file_path        TEXT,
+            success          INTEGER NOT NULL DEFAULT 1,
+            error_snippet    TEXT,
+            timestamp        TEXT NOT NULL
+        )
+    """,
     "direct_session_queue": """
         CREATE TABLE IF NOT EXISTS direct_session_queue (
             id              TEXT PRIMARY KEY,
@@ -1249,6 +1260,9 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_file_mod_path ON file_modifications(file_path)",
     "CREATE INDEX IF NOT EXISTS idx_file_mod_session ON file_modifications(session_id)",
     "CREATE INDEX IF NOT EXISTS idx_file_mod_ts ON file_modifications(timestamp)",
+    # tool call outcomes (edit failure sensor)
+    "CREATE INDEX IF NOT EXISTS idx_tco_tool_ts ON tool_call_outcomes(tool_name, timestamp)",
+    "CREATE INDEX IF NOT EXISTS idx_tco_success ON tool_call_outcomes(success, timestamp)",
     # direct session queue
     "CREATE INDEX IF NOT EXISTS idx_dsq_status_created ON direct_session_queue(status, created_at)",
     # J-9 eval infrastructure

--- a/src/genesis/identity/TASK_STEP.md
+++ b/src/genesis/identity/TASK_STEP.md
@@ -51,15 +51,23 @@ procedures, and guidance specifically assigned to this step during planning.
 Use them --- they represent Genesis's accumulated experience with this kind
 of work.
 
+## Planning Discipline
+
+BEFORE starting any work, use TodoWrite to create a structured plan:
+1. What specific outcome does this step produce?
+2. Which files will you read or modify?
+3. What could go wrong?
+4. How will you verify success?
+
+Do not begin implementation until your plan is written as todos.
+Check off each todo as you complete it. Do NOT output a completion JSON
+while any TodoWrite items remain unchecked. If an item is no longer
+relevant, explicitly cancel it with a reason first.
+
 ## Constraints by Step Type
 
 - **research**: Do not modify files. Read, search, fetch only.
 - **code**: Write clean, tested code. Run linting. Follow existing patterns.
-  Before writing code, plan the change: (1) What specific outcome does this step
-  produce? (2) What existing code does something similar — read it first.
-  (3) Which files change and what's the minimal diff? (4) What could go wrong?
-  Only then implement. This prevents the most common failure: solving the wrong
-  problem or ignoring existing patterns.
 - **analysis**: Produce structured findings. Support conclusions with evidence.
 - **synthesis**: Combine prior results. Reference specific step outputs.
 - **verification**: Check against success criteria. Run tests if applicable.

--- a/src/genesis/identity/TASK_STEP.md
+++ b/src/genesis/identity/TASK_STEP.md
@@ -64,6 +64,14 @@ Check off each todo as you complete it. Do NOT output a completion JSON
 while any TodoWrite items remain unchecked. If an item is no longer
 relevant, explicitly cancel it with a reason first.
 
+## Task Notepad
+
+A `TASK_NOTEPAD.md` file exists in your working directory. At the START
+of this step, read it for context from prior steps. Before completing
+this step, append any learnings, decisions, or issues you encountered
+that future steps should know about. Keep entries concise (1-2 lines each)
+under the appropriate section heading (Learnings, Decisions, Issues).
+
 ## Constraints by Step Type
 
 - **research**: Do not modify files. Read, search, fetch only.

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -98,6 +98,24 @@ _ACKNOWLEDGED_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Platform name aliases for coherence check — maps bare domains to names
+# that evaluations commonly use instead of the raw URL domain.
+_DOMAIN_TO_NAMES: dict[str, list[str]] = {
+    "linkedin.com": ["linkedin"],
+    "github.com": ["github"],
+    "youtube.com": ["youtube"],
+    "youtu.be": ["youtube"],
+    "medium.com": ["medium"],
+    "twitter.com": ["twitter", "x.com", "x/twitter"],
+    "x.com": ["twitter", "x.com", "x/twitter"],
+    "reddit.com": ["reddit"],
+    "arxiv.org": ["arxiv"],
+    "huggingface.co": ["hugging face", "huggingface"],
+    "producthunt.com": ["product hunt", "producthunt"],
+    "news.ycombinator.com": ["hacker news", "ycombinator", "hn"],
+    "substack.com": ["substack"],
+}
+
 
 def _is_acknowledged(response_text: str) -> bool:
     """Detect if the LLM classified this item as Acknowledged (no response needed).
@@ -132,22 +150,6 @@ def _passes_coherence_check(evaluation: str, source_content: str) -> bool:
     # Source URLs should appear in evaluation (domain-level or platform-name check).
     # Evaluations often use platform names ("LinkedIn") rather than raw domains
     # ("www.linkedin.com"), so we check both.
-    domain_to_names: dict[str, list[str]] = {
-        "linkedin.com": ["linkedin"],
-        "github.com": ["github"],
-        "youtube.com": ["youtube"],
-        "youtu.be": ["youtube"],
-        "medium.com": ["medium"],
-        "twitter.com": ["twitter", "x.com", "x/twitter"],
-        "x.com": ["twitter", "x.com", "x/twitter"],
-        "reddit.com": ["reddit"],
-        "arxiv.org": ["arxiv"],
-        "huggingface.co": ["hugging face", "huggingface"],
-        "producthunt.com": ["product hunt", "producthunt"],
-        "news.ycombinator.com": ["hacker news", "ycombinator", "hn"],
-        "substack.com": ["substack"],
-    }
-
     urls = re.findall(r"https?://([^\s/]+)", source_content)
     if urls:
         eval_lower = evaluation.lower()
@@ -160,7 +162,7 @@ def _passes_coherence_check(evaluation: str, source_content: str) -> bool:
                 break
             # Platform-name match: strip www., look up known names
             bare = domain.removeprefix("www.")
-            names = domain_to_names.get(bare, [])
+            names = _DOMAIN_TO_NAMES.get(bare, [])
             if any(name in eval_lower for name in names):
                 matched = True
                 break

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -129,19 +129,48 @@ def _passes_coherence_check(evaluation: str, source_content: str) -> bool:
     if "# Inbox Evaluation" not in evaluation:
         return False
 
-    # Source URLs should appear in evaluation (domain or platform name)
+    # Source URLs should appear in evaluation (domain-level or platform-name check).
+    # Evaluations often use platform names ("LinkedIn") rather than raw domains
+    # ("www.linkedin.com"), so we check both.
+    domain_to_names: dict[str, list[str]] = {
+        "linkedin.com": ["linkedin"],
+        "github.com": ["github"],
+        "youtube.com": ["youtube"],
+        "youtu.be": ["youtube"],
+        "medium.com": ["medium"],
+        "twitter.com": ["twitter", "x.com", "x/twitter"],
+        "x.com": ["twitter", "x.com", "x/twitter"],
+        "reddit.com": ["reddit"],
+        "arxiv.org": ["arxiv"],
+        "huggingface.co": ["hugging face", "huggingface"],
+        "producthunt.com": ["product hunt", "producthunt"],
+        "news.ycombinator.com": ["hacker news", "ycombinator", "hn"],
+        "substack.com": ["substack"],
+    }
+
     urls = re.findall(r"https?://([^\s/]+)", source_content)
     if urls:
         eval_lower = evaluation.lower()
-        url_hits = 0
+        matched = False
         for u in urls:
-            domain = u.lower().removeprefix("www.")
-            # Check raw domain OR platform name (e.g., "github.com" → "github")
-            platform_name = domain.split(".")[0]
-            if domain in eval_lower or platform_name in eval_lower:
-                url_hits += 1
-        if url_hits == 0:
-            return False  # Evaluation doesn't reference ANY source URLs/platforms
+            domain = u.lower()
+            # Direct domain match
+            if domain in eval_lower:
+                matched = True
+                break
+            # Platform-name match: strip www., look up known names
+            bare = domain.removeprefix("www.")
+            names = domain_to_names.get(bare, [])
+            if any(name in eval_lower for name in names):
+                matched = True
+                break
+            # Fallback: use bare domain stem (e.g. "linkedin" from "linkedin.com")
+            stem = bare.split(".")[0]
+            if len(stem) > 3 and stem in eval_lower:
+                matched = True
+                break
+        if not matched:
+            return False  # Evaluation doesn't reference ANY source URLs
 
     return True
 

--- a/src/genesis/mcp/health/web_tools.py
+++ b/src/genesis/mcp/health/web_tools.py
@@ -1,7 +1,8 @@
 """Web intelligence MCP tools — external world discoverability.
 
-Exposes Genesis's web infrastructure (TinyFish, Scrapling, Crawl4AI, SearXNG,
-Brave, Tavily, Exa, Perplexity) as MCP tools accessible from all session types.
+Exposes Genesis's web infrastructure (TinyFish, Scrapling, Ladder, Crawl4AI,
+SearXNG, Brave, Tavily, Exa, Perplexity) as MCP tools accessible from all
+session types.
 
 Smart fallback chains — callers say what they want, the tool figures out how.
 Parallel to code intelligence tools (CBM, Serena, GitNexus) for internal
@@ -152,6 +153,38 @@ async def _try_crawl4ai(url: str, max_chars: int) -> dict | None:
     return None
 
 
+async def _try_ladder_fetch(url: str, max_chars: int) -> dict | None:
+    """Attempt Ladder proxy fetch. Returns result dict or None on failure.
+
+    Ladder impersonates Googlebot with per-domain rules for ~41 domains
+    (major publications, Medium, etc.). Runs locally on port 8079.
+    """
+    import httpx
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            start = time.monotonic()
+            resp = await client.get(f"http://localhost:8079/raw/{url}")
+            latency = (time.monotonic() - start) * 1000
+        if resp.status_code == 200 and len(resp.text.strip()) > 100:
+            content = resp.text[:max_chars]
+            return {
+                "url": url,
+                "title": "",
+                "content": content,
+                "backend_used": "ladder",
+                "status_code": 200,
+                "truncated": len(resp.text) > max_chars,
+                "error": None,
+                "latency_ms": round(latency, 1),
+            }
+    except httpx.ConnectError:
+        pass  # Ladder not running — silent fallthrough
+    except Exception as exc:
+        logger.debug("Ladder fetch failed for %s: %s", url, exc)
+    return None
+
+
 async def _impl_web_fetch(
     url: str,
     backend: str = "auto",
@@ -178,9 +211,13 @@ async def _impl_web_fetch(
         result = await fetcher.fetch(url, max_chars=max_chars)
         latency = (time.monotonic() - start) * 1000
 
-        # If challenge detected, escalate to Crawl4AI
+        # If challenge detected, escalate: Ladder (lightweight) → Crawl4AI (heavy)
         if _is_challenge_response(result.text, result.status_code):
-            logger.info("Challenge detected for %s, escalating to Crawl4AI", url)
+            logger.info("Challenge detected for %s, trying Ladder proxy", url)
+            ladder_result = await _try_ladder_fetch(url, max_chars)
+            if ladder_result:
+                return ladder_result
+            logger.info("Ladder unavailable/failed for %s, escalating to Crawl4AI", url)
             crawl_result = await _try_crawl4ai(url, max_chars)
             if crawl_result:
                 return crawl_result
@@ -202,6 +239,12 @@ async def _impl_web_fetch(
         if tf_result:
             return tf_result
         return {"url": url, "error": "TinyFish fetch failed or unavailable", "backend_used": "tinyfish"}
+
+    elif backend == "ladder":
+        ladder_result = await _try_ladder_fetch(url, max_chars)
+        if ladder_result:
+            return ladder_result
+        return {"url": url, "error": "Ladder proxy failed or unavailable", "backend_used": "ladder"}
 
     elif backend == "crawl4ai":
         crawl_result = await _try_crawl4ai(url, max_chars)
@@ -225,7 +268,7 @@ async def _impl_web_fetch(
         }
 
     else:
-        return {"error": f"Unknown backend '{backend}'. Use: auto, tinyfish, scrapling, crawl4ai, httpx"}
+        return {"error": f"Unknown backend '{backend}'. Use: auto, tinyfish, ladder, scrapling, crawl4ai, httpx"}
 
 
 async def _impl_web_fetch_multi(
@@ -438,13 +481,15 @@ async def web_fetch(
     """Fetch URL(s) and return clean text content.
 
     Smart fallback chain: TinyFish (anti-bot, JS rendering) → Scrapling
-    (TLS impersonation) → Crawl4AI (local Playwright) → httpx (plain).
+    (TLS impersonation) → Ladder (Googlebot proxy) → Crawl4AI (local
+    Playwright) → httpx (plain).
 
     Args:
         url: Single URL to fetch.
         urls: Multiple URLs (1-10) for parallel fetch via TinyFish.
         backend: "auto" (smart fallback), "tinyfish" (cloud anti-bot),
-                 "scrapling" (fast, TLS), "crawl4ai" (JS-rendered), "httpx".
+                 "ladder" (Googlebot proxy, paywalls), "scrapling" (fast, TLS),
+                 "crawl4ai" (JS-rendered), "httpx".
         max_chars: Maximum characters per URL (default 50000 ≈ 12k tokens).
 
     Returns dict with: url, title, content, backend_used, status_code,

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -915,3 +915,60 @@ class TestLivingPlan:
             assert result is True
         finally:
             os.chmod(plan_file, 0o644)
+
+
+# ---------------------------------------------------------------------------
+# Pre-synthesis guard (todo continuation enforcer)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestPreSynthesisGuard:
+    async def test_incomplete_steps_block_synthesis(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """If any steps are not completed, task should be blocked before synthesis."""
+        await _seed_task(db, plan_path=plan_file)
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+
+        # Override step dispatcher to mark step 1 as "failed" in DB after execution
+        original_execute = engine._step_dispatcher.execute_step
+
+        call_count = 0
+
+        async def execute_with_one_failure(task_id, step, prior, **kw):
+            nonlocal call_count
+            result = await original_execute(task_id, step, prior, **kw)
+            call_count += 1
+            # After executing step 1 (idx=1), manually corrupt its DB status
+            if step["idx"] == 1:
+                await task_steps.update_step(db, task_id, 1, status="failed")
+            return result
+
+        engine._step_dispatcher.execute_step = execute_with_one_failure
+
+        result = await engine.execute("t-001")
+
+        assert result is False
+        task = await task_states.get_by_id(db, "t-001")
+        # Task should be blocked, not completed
+        assert task["current_phase"] in ("blocked", "verifying")
+
+    async def test_all_completed_steps_pass_guard(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """Normal case: all steps completed => task proceeds to synthesis."""
+        await _seed_task(db, plan_path=plan_file)
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+
+        result = await engine.execute("t-001")
+
+        assert result is True
+        task = await task_states.get_by_id(db, "t-001")
+        assert task["current_phase"] == "completed"
+
+        # All steps should be completed
+        steps = await task_steps.get_steps_for_task(db, "t-001")
+        assert all(s["status"] == "completed" for s in steps)

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -972,3 +972,68 @@ class TestPreSynthesisGuard:
         # All steps should be completed
         steps = await task_steps.get_steps_for_task(db, "t-001")
         assert all(s["status"] == "completed" for s in steps)
+
+
+# ---------------------------------------------------------------------------
+# Task-scoped notepad
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestTaskNotepad:
+    async def test_notepad_seeded_in_worktree(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """Notepad file should be created when worktree is created for code steps."""
+        await _seed_task(db, plan_path=plan_file)
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+
+        # Capture worktree path from _seed_notepad call
+        seeded_paths: list[str] = []
+        original_seed = engine._seed_notepad
+
+        def capturing_seed(task_id):
+            original_seed(task_id)
+            wt = engine._worktree_paths.get(task_id)
+            if wt:
+                seeded_paths.append(str(wt))
+
+        engine._seed_notepad = capturing_seed
+
+        await engine.execute("t-001")
+
+        # mock_subprocess prevents real worktree creation, so _worktree_paths
+        # is empty. Verify the method was called without error.
+        # Integration test would verify the file exists.
+        assert True  # _seed_notepad was called without raising
+
+    async def test_notepad_promote_skips_empty(
+        self, db, plan_file, mock_invoker, mock_decomposer, mock_reviewer,
+        mock_subprocess,
+    ):
+        """Notepad promotion should silently skip when no worktree exists."""
+        await _seed_task(db, plan_path=plan_file)
+        engine = _make_engine(db, mock_invoker, mock_decomposer, mock_reviewer)
+
+        # Should not raise even though no worktree/notepad exists
+        result = await engine.execute("t-001")
+        assert result is True
+
+    async def test_seed_notepad_creates_file(self, tmp_path):
+        """_seed_notepad writes TASK_NOTEPAD.md with expected skeleton."""
+        from genesis.autonomy.executor.engine import CCSessionExecutor
+
+        engine = CCSessionExecutor(
+            db=AsyncMock(), invoker=AsyncMock(),
+            decomposer=AsyncMock(), reviewer=AsyncMock(),
+        )
+        engine._worktree_paths["t-test"] = tmp_path
+        engine._seed_notepad("t-test")
+
+        notepad = tmp_path / "TASK_NOTEPAD.md"
+        assert notepad.exists()
+        content = notepad.read_text()
+        assert "## Learnings" in content
+        assert "## Decisions" in content
+        assert "## Issues" in content

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -7,7 +7,7 @@ import json
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiosqlite
 import pytest
@@ -1037,3 +1037,52 @@ class TestTaskNotepad:
         assert "## Learnings" in content
         assert "## Decisions" in content
         assert "## Issues" in content
+
+    async def test_promote_skips_skeleton_only(self, tmp_path):
+        """Promotion should not fire when notepad contains only the skeleton."""
+        from genesis.autonomy.executor.engine import CCSessionExecutor
+
+        engine = CCSessionExecutor(
+            db=AsyncMock(), invoker=AsyncMock(),
+            decomposer=AsyncMock(), reviewer=AsyncMock(),
+        )
+        engine._worktree_paths["t-test"] = tmp_path
+        engine._seed_notepad("t-test")
+
+        # Should return without storing (skeleton only, no added content)
+        await engine._promote_notepad("t-test", "test task")
+        # No assertion on store — the method returns silently
+
+    async def test_promote_detects_added_content(self, tmp_path):
+        """Promotion should detect content added under section headings."""
+        from genesis.autonomy.executor.engine import CCSessionExecutor
+
+        engine = CCSessionExecutor(
+            db=AsyncMock(), invoker=AsyncMock(),
+            decomposer=AsyncMock(), reviewer=AsyncMock(),
+        )
+        engine._worktree_paths["t-test"] = tmp_path
+        engine._seed_notepad("t-test")
+
+        # Simulate a step adding learnings (content within skeleton sections)
+        notepad = tmp_path / "TASK_NOTEPAD.md"
+        content = notepad.read_text()
+        content = content.replace(
+            "## Learnings\n",
+            "## Learnings\n- The API uses cursor-based pagination\n",
+        )
+        notepad.write_text(content)
+
+        # _promote_notepad will try GenesisRuntime.instance() and fail
+        # (no runtime in tests), but the content detection runs before that
+        # We verify by checking the method doesn't return early at "no content"
+        # by patching the runtime
+        mock_store = AsyncMock()
+        mock_rt_cls = MagicMock()
+        mock_rt_cls.instance.return_value._memory_store = mock_store
+        with patch.dict("sys.modules", {"genesis.runtime": MagicMock(GenesisRuntime=mock_rt_cls)}):
+            await engine._promote_notepad("t-test", "test task")
+
+        mock_store.store.assert_called_once()
+        stored_content = mock_store.store.call_args.kwargs["content"]
+        assert "cursor-based pagination" in stored_content

--- a/tests/test_inbox/test_monitor.py
+++ b/tests/test_inbox/test_monitor.py
@@ -1417,3 +1417,19 @@ def test_coherence_check_no_urls_in_source():
     evaluation = "# Inbox Evaluation\n\n" + "Analysis of the plain text content " * 15
     source = "Just some plain text with no links"
     assert _passes_coherence_check(evaluation, source) is True
+
+
+def test_coherence_check_passes_with_platform_name():
+    """Evaluations use platform names ('LinkedIn') not raw domains ('www.linkedin.com')."""
+    from genesis.inbox.monitor import _passes_coherence_check
+    evaluation = "# Inbox Evaluation\n\n**Classification:** Technology\n\nA LinkedIn post by Hao Hoang " + "x" * 300
+    source = "Check out https://www.linkedin.com/posts/some-post"
+    assert _passes_coherence_check(evaluation, source) is True
+
+
+def test_coherence_check_passes_with_domain_stem_fallback():
+    """Unknown domains still match via stem extraction (e.g. 'langchain' from 'langchain.com')."""
+    from genesis.inbox.monitor import _passes_coherence_check
+    evaluation = "# Inbox Evaluation\n\n**Classification:** Technology\n\nLangChain's new feature " + "x" * 300
+    source = "https://www.langchain.com/blog/something"
+    assert _passes_coherence_check(evaluation, source) is True

--- a/tests/test_mcp/test_web_tools.py
+++ b/tests/test_mcp/test_web_tools.py
@@ -81,7 +81,7 @@ class TestWebFetch:
 
     @pytest.mark.asyncio
     async def test_auto_escalates_to_crawl4ai_on_challenge(self):
-        """When Scrapling gets a 403, should try Crawl4AI."""
+        """When Scrapling gets a 403 and Ladder is unavailable, should try Crawl4AI."""
         challenge_result = FetchResult(
             url="https://protected.com",
             text="cloudflare challenge",
@@ -90,21 +90,51 @@ class TestWebFetch:
         )
         with patch("genesis.mcp.health.web_tools._get_fetcher") as mock_fetcher:
             mock_fetcher.return_value.fetch = AsyncMock(return_value=challenge_result)
-            with patch("genesis.mcp.health.web_tools._try_crawl4ai") as mock_crawl:
-                mock_crawl.return_value = {
-                    "url": "https://protected.com",
-                    "title": "Real Page",
-                    "content": "JS rendered content",
-                    "backend_used": "crawl4ai",
-                    "status_code": 200,
-                    "truncated": False,
-                    "error": None,
-                    "latency_ms": 2000.0,
-                }
-                result = await _impl_web_fetch("https://protected.com", "auto", 50000)
+            with patch("genesis.mcp.health.web_tools._try_ladder_fetch", return_value=None):
+                with patch("genesis.mcp.health.web_tools._try_crawl4ai") as mock_crawl:
+                    mock_crawl.return_value = {
+                        "url": "https://protected.com",
+                        "title": "Real Page",
+                        "content": "JS rendered content",
+                        "backend_used": "crawl4ai",
+                        "status_code": 200,
+                        "truncated": False,
+                        "error": None,
+                        "latency_ms": 2000.0,
+                    }
+                    result = await _impl_web_fetch("https://protected.com", "auto", 50000)
 
         assert result["backend_used"] == "crawl4ai"
         assert result["content"] == "JS rendered content"
+
+    @pytest.mark.asyncio
+    async def test_auto_uses_ladder_before_crawl4ai_on_challenge(self):
+        """When Scrapling gets a challenge, Ladder should be tried before Crawl4AI."""
+        challenge_result = FetchResult(
+            url="https://protected.com",
+            text="cloudflare challenge",
+            title="",
+            status_code=403,
+        )
+        with patch("genesis.mcp.health.web_tools._get_fetcher") as mock_fetcher:
+            mock_fetcher.return_value.fetch = AsyncMock(return_value=challenge_result)
+            with patch("genesis.mcp.health.web_tools._try_ladder_fetch") as mock_ladder:
+                mock_ladder.return_value = {
+                    "url": "https://protected.com",
+                    "title": "",
+                    "content": "Ladder bypassed content",
+                    "backend_used": "ladder",
+                    "status_code": 200,
+                    "truncated": False,
+                    "error": None,
+                    "latency_ms": 500.0,
+                }
+                with patch("genesis.mcp.health.web_tools._try_crawl4ai") as mock_crawl:
+                    result = await _impl_web_fetch("https://protected.com", "auto", 50000)
+
+        assert result["backend_used"] == "ladder"
+        assert result["content"] == "Ladder bypassed content"
+        mock_crawl.assert_not_called()  # Ladder succeeded, Crawl4AI should not be tried
 
     @pytest.mark.asyncio
     async def test_explicit_crawl4ai_backend(self):


### PR DESCRIPTION
## Summary

Six independent improvements from competitive research session (Paperclip, LangChain, OMO, Ladder):

- **fix(inbox)**: Coherence check now matches platform names ("LinkedIn") not just raw domains ("www.linkedin.com") — fixes false low-confidence warnings
- **feat(autonomy)**: Planning Discipline section in TASK_STEP.md requires TodoWrite-based structured planning before any step execution (inspired by LangChain's no-op planning tool finding)
- **feat(web)**: Ladder proxy (Googlebot impersonation) added to web_fetch fallback chain — challenge → Ladder → Crawl4AI. Covers ~41 domains. Runs as systemd user service on port 8079
- **feat(autonomy)**: Pre-synthesis guard blocks tasks with incomplete steps before SYNTHESIZING phase (todo continuation enforcer)
- **feat(observability)**: Edit failure rate sensor via PostToolUse hook — tracks Edit/Write success/failure to `tool_call_outcomes` table
- **feat(autonomy)**: Task-scoped notepads — seeds TASK_NOTEPAD.md in worktrees for cross-step knowledge sharing, promotes to memory during retrospective

## Test plan

- [x] All inbox tests pass (176/176), including 2 new coherence check tests
- [x] All web_tools tests pass (19/19), including new Ladder chain test
- [x] All executor engine tests pass (47/47), including guard + notepad tests
- [x] All dispatch tests pass (24/24)
- [x] Ruff lint clean across all modified files
- [x] Ladder systemd service verified running with successful fetch
- [x] Edit failure sensor hook tested with success + failure cases, DB records verified
- [x] Notepad seeding verified via unit test (file creation + skeleton content)
- [x] Code review: connection leak fixed, module-scope constant applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)