### PR TITLE
fix(memory): dream cycle safety — bucket chunking, memory preflight, async yielding

### DIFF
--- a/docs/superpowers/specs/2026-05-14-dream-cycle-design.md
+++ b/docs/superpowers/specs/2026-05-14-dream-cycle-design.md
@@ -412,6 +412,27 @@ async def rollback(run_id: str) -> dict:
     """
 ```
 
+### Resource Guards (added after VM crash 2026-05-15)
+
+The initial dry-run crashed the VM because the `(general, uncategorized)` bucket
+held ~11,725 points, generating 11,725 Qdrant search calls that saturated I/O
+and exhausted memory. Fixes:
+
+1. **Bucket chunking** (`MAX_BUCKET_SIZE = 500`) — large buckets are shuffled
+   and split into independent chunks. Each chunk gets its own union-find pass.
+   Cross-chunk cluster convergence happens over 2-3 weekly runs via random
+   shuffle rotation.
+
+2. **Async yielding** (`_YIELD_EVERY = 50`) — `await asyncio.sleep(0)` every
+   50 search calls prevents event loop starvation when run inside the server
+   scheduler.
+
+3. **Memory preflight** (`MIN_AVAILABLE_MB = 256`) — reads `/proc/meminfo`
+   before starting; aborts with informative report if available memory is
+   below threshold.
+
+4. **Progress logging** — logs every 100 points per bucket for observability.
+
 ### What NOT to Merge
 
 - **knowledge_base collection** — excluded entirely (different collection,

--- a/src/genesis/memory/dream_cycle.py
+++ b/src/genesis/memory/dream_cycle.py
@@ -19,8 +19,10 @@ Spec: docs/superpowers/specs/2026-05-14-dream-cycle-design.md
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import random
 import uuid
 from collections import defaultdict
 from datetime import UTC, datetime
@@ -40,6 +42,9 @@ logger = logging.getLogger(__name__)
 SIMILARITY_THRESHOLD: float = 0.87
 MAX_CLUSTER_SIZE: int = 10
 MAX_MERGES_PER_RUN: int = 100
+MAX_BUCKET_SIZE: int = 500
+MIN_AVAILABLE_MB: int = 256
+_YIELD_EVERY: int = 50  # yield to event loop every N search calls
 CALL_SITE_ID: str = "dream_cycle_synthesis"
 COLLECTION: str = "episodic_memory"
 
@@ -79,6 +84,22 @@ class _UnionFind:
         return groups
 
 
+def _read_mem_available_mb() -> int | None:
+    """Read MemAvailable from /proc/meminfo in MB.
+
+    Returns None if unavailable (non-Linux).  Inlined to avoid importing
+    the heavy ``genesis.observability.snapshots.infrastructure`` module.
+    """
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) // 1024  # kB → MB
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
 # ── Core ─────────────────────────────────────────────────────────────────
 
 
@@ -110,6 +131,16 @@ async def run(
         "errors": [],
     }
 
+    # Phase 0 — Memory preflight
+    avail_mb = _read_mem_available_mb()
+    if avail_mb is not None and avail_mb < MIN_AVAILABLE_MB:
+        report["aborted"] = f"low_memory ({avail_mb}MB < {MIN_AVAILABLE_MB}MB)"
+        logger.error(
+            "Dream cycle %s: aborting — only %dMB available (need %dMB)",
+            run_id[:8], avail_mb, MIN_AVAILABLE_MB,
+        )
+        return report
+
     # Phase 1 — Scroll and group by (wing, room)
     buckets = await _scroll_and_group(qdrant)
     total_points = sum(len(pts) for pts in buckets.values())
@@ -120,21 +151,37 @@ async def run(
         run_id[:8], total_points, len(buckets),
     )
 
-    # Phase 2 — Cluster within each bucket
+    # Phase 2 — Cluster within each bucket (chunked for safety)
     all_clusters: list[list[dict]] = []
+    bucket_sizes: dict[str, int] = {}
     for (wing, room), points in buckets.items():
+        bucket_sizes[f"{wing}/{room}"] = len(points)
         if len(points) < 2:
             continue
-        if len(points) > 2000:
-            logger.warning(
-                "Bucket (%s, %s) has %d points — may be slow",
+
+        # Chunk large buckets to prevent I/O saturation.
+        # Shuffling rotates chunk boundaries across weekly runs,
+        # giving cross-chunk convergence over 2-3 cycles.
+        if len(points) > MAX_BUCKET_SIZE:
+            logger.info(
+                "Bucket (%s, %s): %d points — splitting into %d chunks of %d",
                 wing, room, len(points),
+                -(-len(points) // MAX_BUCKET_SIZE),  # ceil division
+                MAX_BUCKET_SIZE,
             )
-        clusters = await _cluster_bucket(
-            qdrant, points, wing, room,
-            threshold=similarity_threshold,
-        )
-        all_clusters.extend(clusters)
+            random.shuffle(points)
+
+        for chunk_start in range(0, len(points), MAX_BUCKET_SIZE):
+            chunk = points[chunk_start:chunk_start + MAX_BUCKET_SIZE]
+            if len(chunk) < 2:
+                continue
+            clusters = await _cluster_bucket(
+                qdrant, chunk, wing, room,
+                threshold=similarity_threshold,
+            )
+            all_clusters.extend(clusters)
+
+    report["bucket_sizes"] = bucket_sizes
 
     report["clusters_found"] = len(all_clusters)
     logger.info("Dream cycle %s: found %d clusters", run_id[:8], len(all_clusters))
@@ -256,7 +303,8 @@ async def _cluster_bucket(
     vector_map = _batch_get_vectors(qdrant, [p["id"] for p in points])
 
     # Build similarity graph
-    for point in points:
+    n_points = len(points)
+    for idx, point in enumerate(points):
         pid = point["id"]
         vec = vector_map.get(pid)
         if vec is None:
@@ -283,6 +331,16 @@ async def _cluster_bucket(
                 continue  # Different bucket or deprecated
             if score >= threshold:
                 uf.union(pid, nid)
+
+        # Yield to the event loop periodically so other coroutines
+        # (health probes, scheduler heartbeats) stay alive.
+        if (idx + 1) % _YIELD_EVERY == 0:
+            if (idx + 1) % 100 == 0:
+                logger.info(
+                    "Bucket (%s, %s): searched %d/%d points",
+                    wing, room, idx + 1, n_points,
+                )
+            await asyncio.sleep(0)
 
     # Extract components with >= 2 members
     clusters: list[list[dict]] = []

--- a/tests/test_memory/test_dream_cycle.py
+++ b/tests/test_memory/test_dream_cycle.py
@@ -8,9 +8,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from genesis.memory.dream_cycle import (
+    MAX_BUCKET_SIZE,
     MAX_CLUSTER_SIZE,
     _build_synthesis_prompt,
     _parse_synthesis_response,
+    _read_mem_available_mb,
     _size_distribution,
     _UnionFind,
     run,
@@ -322,3 +324,273 @@ class TestRollback:
         assert report["restored"] == 2
         assert report["syntheses_deleted"] == 1
         assert len(report["errors"]) == 0
+
+
+# ── Bucket Chunking ────────────────────────────────────────────────────
+
+
+class TestBucketChunking:
+    @pytest.mark.asyncio
+    async def test_large_bucket_is_chunked(self):
+        """A bucket exceeding MAX_BUCKET_SIZE gets split into chunks."""
+        mock_qdrant = MagicMock()
+        mock_db = AsyncMock()
+        mock_router = AsyncMock()
+        mock_store = AsyncMock()
+
+        # Create a bucket larger than MAX_BUCKET_SIZE
+        n_points = MAX_BUCKET_SIZE + 200  # 700 points → 2 chunks
+        points = [
+            {
+                "id": f"p{i}",
+                "payload": {
+                    "wing": "memory", "room": "store",
+                    "content": f"fact {i}", "confidence": 0.5,
+                },
+            }
+            for i in range(n_points)
+        ]
+
+        search_call_count = 0
+
+        def mock_search_fn(*args, **kwargs):
+            nonlocal search_call_count
+            search_call_count += 1
+            # Return no neighbors — no clusters formed
+            return []
+
+        with patch(_SCROLL) as mock_scroll, \
+             patch(_SEARCH, side_effect=mock_search_fn), \
+             patch(_BATCH_VEC) as mock_vec:
+            mock_scroll.return_value = (points, None)
+            mock_vec.return_value = {
+                f"p{i}": [0.1] * 768 for i in range(n_points)
+            }
+
+            report = await run(
+                qdrant=mock_qdrant,
+                db=mock_db,
+                router=mock_router,
+                store=mock_store,
+                dry_run=True,
+            )
+
+        # All points should be searched (across chunks)
+        assert search_call_count == n_points
+        assert report["total_points"] == n_points
+        # bucket_sizes should report the full pre-chunk size
+        assert report["bucket_sizes"]["memory/store"] == n_points
+
+    @pytest.mark.asyncio
+    async def test_tail_chunk_of_one_skipped(self):
+        """A bucket of MAX_BUCKET_SIZE+1 splits into 500 + 1; the 1-point tail is skipped."""
+        mock_qdrant = MagicMock()
+        mock_db = AsyncMock()
+        mock_router = AsyncMock()
+        mock_store = AsyncMock()
+
+        n_points = MAX_BUCKET_SIZE + 1  # 501 → chunks of 500 + 1
+        points = [
+            {
+                "id": f"p{i}",
+                "payload": {
+                    "wing": "memory", "room": "store",
+                    "content": f"fact {i}", "confidence": 0.5,
+                },
+            }
+            for i in range(n_points)
+        ]
+
+        search_call_count = 0
+
+        def mock_search_fn(*args, **kwargs):
+            nonlocal search_call_count
+            search_call_count += 1
+            return []
+
+        with patch(_SCROLL) as mock_scroll, \
+             patch(_SEARCH, side_effect=mock_search_fn), \
+             patch(_BATCH_VEC) as mock_vec:
+            mock_scroll.return_value = (points, None)
+            mock_vec.return_value = {
+                f"p{i}": [0.1] * 768 for i in range(n_points)
+            }
+
+            report = await run(
+                qdrant=mock_qdrant,
+                db=mock_db,
+                router=mock_router,
+                store=mock_store,
+                dry_run=True,
+            )
+
+        # Only 500 points searched — tail chunk of 1 skipped
+        assert search_call_count == MAX_BUCKET_SIZE
+
+    @pytest.mark.asyncio
+    async def test_small_bucket_not_chunked(self):
+        """Buckets within MAX_BUCKET_SIZE are processed in one pass."""
+        mock_qdrant = MagicMock()
+        mock_db = AsyncMock()
+        mock_router = AsyncMock()
+        mock_store = AsyncMock()
+
+        points = [
+            {
+                "id": f"p{i}",
+                "payload": {
+                    "wing": "memory", "room": "store",
+                    "content": f"fact {i}", "confidence": 0.5,
+                },
+            }
+            for i in range(10)
+        ]
+
+        with patch(_SCROLL) as mock_scroll, \
+             patch(_SEARCH, return_value=[]), \
+             patch(_BATCH_VEC) as mock_vec:
+            mock_scroll.return_value = (points, None)
+            mock_vec.return_value = {
+                f"p{i}": [0.1] * 768 for i in range(10)
+            }
+
+            report = await run(
+                qdrant=mock_qdrant,
+                db=mock_db,
+                router=mock_router,
+                store=mock_store,
+                dry_run=True,
+            )
+
+        assert report["total_points"] == 10
+        assert report["bucket_sizes"]["memory/store"] == 10
+
+
+# ── Memory Preflight ────────────────────────────────────────────────────
+
+
+class TestMemoryPreflight:
+    @pytest.mark.asyncio
+    async def test_aborts_on_low_memory(self):
+        """Dream cycle aborts early when available memory is too low."""
+        mock_qdrant = MagicMock()
+        mock_db = AsyncMock()
+        mock_router = AsyncMock()
+        mock_store = AsyncMock()
+
+        with patch(
+            "genesis.memory.dream_cycle._read_mem_available_mb",
+            return_value=100,  # 100MB < 256MB threshold
+        ):
+            report = await run(
+                qdrant=mock_qdrant,
+                db=mock_db,
+                router=mock_router,
+                store=mock_store,
+                dry_run=True,
+            )
+
+        assert "aborted" in report
+        assert "low_memory" in report["aborted"]
+        # Should NOT have scrolled Qdrant at all
+        assert "total_points" not in report
+
+    @pytest.mark.asyncio
+    async def test_proceeds_when_memory_ok(self):
+        """Dream cycle proceeds when sufficient memory is available."""
+        mock_qdrant = MagicMock()
+        mock_db = AsyncMock()
+        mock_router = AsyncMock()
+        mock_store = AsyncMock()
+
+        with patch(
+            "genesis.memory.dream_cycle._read_mem_available_mb",
+            return_value=8000,  # 8GB — plenty
+        ), patch(_SCROLL, return_value=([], None)):
+            report = await run(
+                qdrant=mock_qdrant,
+                db=mock_db,
+                router=mock_router,
+                store=mock_store,
+                dry_run=True,
+            )
+
+        assert "aborted" not in report
+        assert report["total_points"] == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_check_on_non_linux(self):
+        """Non-Linux systems (None return) skip preflight, proceed normally."""
+        mock_qdrant = MagicMock()
+        mock_db = AsyncMock()
+        mock_router = AsyncMock()
+        mock_store = AsyncMock()
+
+        with patch(
+            "genesis.memory.dream_cycle._read_mem_available_mb",
+            return_value=None,  # Non-Linux
+        ), patch(_SCROLL, return_value=([], None)):
+            report = await run(
+                qdrant=mock_qdrant,
+                db=mock_db,
+                router=mock_router,
+                store=mock_store,
+                dry_run=True,
+            )
+
+        assert "aborted" not in report
+
+    def test_read_mem_available_returns_int(self):
+        """Smoke test — on Linux this should return an int."""
+        result = _read_mem_available_mb()
+        # We're on Linux, so this should work
+        assert result is not None
+        assert isinstance(result, int)
+        assert result > 0
+
+
+# ── Async Yielding ──────────────────────────────────────────────────────
+
+
+class TestAsyncYielding:
+    @pytest.mark.asyncio
+    async def test_yields_during_search_loop(self):
+        """asyncio.sleep(0) is called periodically during clustering."""
+        mock_qdrant = MagicMock()
+        mock_db = AsyncMock()
+        mock_router = AsyncMock()
+        mock_store = AsyncMock()
+
+        # Create exactly 100 points to trigger 2 yields (at 50 and 100)
+        n_points = 100
+        points = [
+            {
+                "id": f"p{i}",
+                "payload": {
+                    "wing": "memory", "room": "store",
+                    "content": f"fact {i}", "confidence": 0.5,
+                },
+            }
+            for i in range(n_points)
+        ]
+
+        with patch(_SCROLL) as mock_scroll, \
+             patch(_SEARCH, return_value=[]), \
+             patch(_BATCH_VEC) as mock_vec, \
+             patch("genesis.memory.dream_cycle.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            mock_scroll.return_value = (points, None)
+            mock_vec.return_value = {
+                f"p{i}": [0.1] * 768 for i in range(n_points)
+            }
+
+            await run(
+                qdrant=mock_qdrant,
+                db=mock_db,
+                router=mock_router,
+                store=mock_store,
+                dry_run=True,
+            )
+
+        # With 100 points and _YIELD_EVERY=50, sleep(0) called twice
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(0)

--- a/tests/test_memory/test_dream_cycle.py
+++ b/tests/test_memory/test_dream_cycle.py
@@ -416,7 +416,7 @@ class TestBucketChunking:
                 f"p{i}": [0.1] * 768 for i in range(n_points)
             }
 
-            report = await run(
+            await run(
                 qdrant=mock_qdrant,
                 db=mock_db,
                 router=mock_router,


### PR DESCRIPTION
## Summary

The initial dream cycle dry-run (PR #359) crashed the VM because the `(general, uncategorized)` bucket held ~11,725 points, generating 11,725 Qdrant search calls that saturated I/O and exhausted memory.

**Fixes:**
- `MAX_BUCKET_SIZE=500`: large buckets shuffled and split into independent chunks; cross-chunk convergence via random rotation across weekly runs
- `MIN_AVAILABLE_MB=256`: `/proc/meminfo` preflight aborts early if available memory is too low
- `_YIELD_EVERY=50`: `asyncio.sleep(0)` every 50 search calls prevents event loop starvation
- Progress logging every 100 points per bucket for observability

**Verified**: dry-run completed on live data (19,343 points, 197 buckets) in ~40 minutes with 207MB peak memory. Server stayed healthy throughout. Found 590 clusters.

## Test plan
- [x] 24 unit tests pass (16 existing + 8 new)
- [x] Lint clean (`ruff check`)
- [x] Previously-broken test files pass (search_ranked_invalid_at, search_ranked_subsystem, test_config)
- [x] Full dry-run against live Qdrant data — completed without crash
- [x] Server health verified during and after dry-run
- [x] Code review: 0 critical, 0 important findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)