### PR TITLE
feat(ego): bidirectional proposals, outcome feedback, staleness fix

### DIFF
--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -705,13 +705,27 @@ class ConversationLoop:
 
             lines.append(
                 "\n### To resolve a proposal:\n"
-                "Run this SQL (replace the proposal ID):\n"
-                "```sql\n"
-                "UPDATE ego_proposals SET status = 'approved', "
-                "resolved_at = datetime('now') WHERE id = '<proposal_id>' "
-                "AND status = 'pending';\n"
+                "Use Bash to run the genesis CLI:\n"
+                "```bash\n"
+                "source ~/genesis/.venv/bin/activate && python -c \"\n"
+                "import asyncio, aiosqlite\n"
+                "async def go():\n"
+                "    async with aiosqlite.connect("
+                "'$HOME/genesis/data/genesis.db') as db:\n"
+                "        await db.execute(\n"
+                "            'UPDATE ego_proposals SET status=?, "
+                "resolved_at=datetime(\"now\") WHERE id=? AND status=\"pending\"',\n"
+                "            ('approved', '<PROPOSAL_ID>'),\n"
+                "        )\n"
+                "        await db.commit()\n"
+                "asyncio.run(go())\n"
+                "\"\n"
                 "```\n"
-                "For rejection: SET status = 'rejected' instead.\n"
+                "For rejection: use 'rejected' instead of 'approved'.\n"
+                "\n### Important:\n"
+                "- If the user gives guidance or corrections (not just approve/reject),\n"
+                "  store it via `memory_store` MCP so the ego sees it in future cycles.\n"
+                "- Always confirm what you did: 'Approved proposal 1: [content]'\n"
             )
             return "\n".join(lines)
         except Exception:

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -403,6 +403,13 @@ class ConversationLoop:
                         "\n\n## Recent conversation (session recovered)\n"
                         + recovery_context
                     )
+
+                # Topic-aware context: inject proposal board when in ego_proposals
+                if thread_id:
+                    topic_ctx = await self._build_topic_context(thread_id)
+                    if topic_ctx:
+                        system_prompt += topic_ctx
+
                 resume_id = None
 
             invocation = CCInvocation(
@@ -652,6 +659,64 @@ class ConversationLoop:
                 "Session %s updated: model=%s effort=%s",
                 session["id"][:8], model, effort,
             )
+
+    async def _build_topic_context(self, thread_id: str) -> str | None:
+        """Build topic-specific context for the conversation system prompt.
+
+        When the user is messaging in the ego_proposals topic, inject the
+        pending proposal board so the CC session can discuss and resolve them.
+        """
+        if self._db is None:
+            return None
+        try:
+            # Look up which topic this thread_id belongs to
+            async with self._db.execute(
+                "SELECT category FROM telegram_topics WHERE thread_id = ?",
+                (int(thread_id),),
+            ) as cur:
+                row = await cur.fetchone()
+            if not row or row[0] != "ego_proposals":
+                return None
+
+            # Fetch pending proposals
+            from genesis.db.crud import ego as ego_crud
+
+            pending = await ego_crud.list_proposals(
+                self._db, status="pending", limit=10,
+            )
+            if not pending:
+                return "\n\n## Ego Proposals Topic\n\nNo pending proposals.\n"
+
+            lines = ["\n\n## You Are in the Ego Proposals Topic\n"]
+            lines.append(
+                "The user communicates with you here to review, approve, reject, "
+                "or discuss ego proposals. When the user indicates approval "
+                "(e.g., 'do it', 'yes', 'go ahead', 'approve 1'), resolve the "
+                "proposal. When they reject, mark it rejected with their reason. "
+                "When unclear, ask for clarification.\n"
+            )
+            lines.append("### Pending Proposals:\n")
+            for i, p in enumerate(pending, 1):
+                cat = p.get("action_category", "unknown")
+                content = (p.get("content") or "")[:120]
+                pid = p["id"]
+                lines.append(f"{i}. **[{cat}]** {content}")
+                lines.append(f"   ID: `{pid}`\n")
+
+            lines.append(
+                "\n### To resolve a proposal:\n"
+                "Run this SQL (replace the proposal ID):\n"
+                "```sql\n"
+                "UPDATE ego_proposals SET status = 'approved', "
+                "resolved_at = datetime('now') WHERE id = '<proposal_id>' "
+                "AND status = 'pending';\n"
+                "```\n"
+                "For rejection: SET status = 'rejected' instead.\n"
+            )
+            return "\n".join(lines)
+        except Exception:
+            logger.debug("Failed to build topic context", exc_info=True)
+            return None
 
     async def _enrich_with_context(
         self, system_prompt: str | None, query: str,

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -371,19 +371,18 @@ class DirectSessionRunner:
             # On failure: create observation so ego sees it next cycle
             if not result.success:
                 try:
-                    from genesis.memory.store import get_store
-
-                    store = get_store()
-                    await store.store(
-                        content=(
-                            f"Ego dispatch FAILED for proposal {proposal_id}: {summary}"
-                        ),
-                        source="ego_dispatch_outcome",
-                        tags=["ego", "dispatch_failure"],
-                        memory_type="episodic",
-                        wing="autonomy",
-                        room="ego",
-                    )
+                    store = getattr(self._rt, "_memory_store", None)
+                    if store is not None:
+                        await store.store(
+                            content=(
+                                f"Ego dispatch FAILED for proposal {proposal_id}: {summary}"
+                            ),
+                            source="ego_dispatch_outcome",
+                            tags=["ego", "dispatch_failure"],
+                            memory_type="episodic",
+                            wing="autonomy",
+                            room="ego",
+                        )
                 except Exception:
                     logger.debug("Failed to store failure observation", exc_info=True)
         except Exception:

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -295,6 +295,9 @@ class DirectSessionRunner:
             # Persist result in session metadata (merge, don't overwrite)
             await self._store_result(session_id, request, result)
 
+            # Feed outcome back to ego proposal if this was a proposal dispatch
+            await self._record_proposal_outcome(request, result)
+
             await self._session_manager.complete(
                 session_id,
                 cost_usd=output.cost_usd,
@@ -321,6 +324,7 @@ class DirectSessionRunner:
             # Best-effort: persist failure and notify
             try:
                 await self._store_result(session_id, request, error_result)
+                await self._record_proposal_outcome(request, error_result)
                 await self._session_manager.fail(
                     session_id, reason=str(exc)[:500],
                 )
@@ -344,6 +348,50 @@ class DirectSessionRunner:
                 session_id[:8], elapsed, exc,
             )
             raise
+
+    async def _record_proposal_outcome(
+        self,
+        request: DirectSessionRequest,
+        result: DirectSessionResult,
+    ) -> None:
+        """Feed session outcome back to ego proposal for feedback loop."""
+        if not request.caller_context or not request.caller_context.startswith("ego_proposal:"):
+            return
+        proposal_id = request.caller_context.split(":", 1)[1]
+        try:
+            from genesis.db.crud.ego import update_proposal_outcome
+
+            db = getattr(self._rt, "_db", None)
+            if db is None:
+                return
+            summary = (result.output_text or result.error or "")[:200]
+            await update_proposal_outcome(
+                db, proposal_id, success=result.success, summary=summary,
+            )
+            # On failure: create observation so ego sees it next cycle
+            if not result.success:
+                try:
+                    from genesis.memory.store import get_store
+
+                    store = get_store()
+                    await store.store(
+                        content=(
+                            f"Ego dispatch FAILED for proposal {proposal_id}: {summary}"
+                        ),
+                        source="ego_dispatch_outcome",
+                        tags=["ego", "dispatch_failure"],
+                        memory_type="episodic",
+                        wing="autonomy",
+                        room="ego",
+                    )
+                except Exception:
+                    logger.debug("Failed to store failure observation", exc_info=True)
+        except Exception:
+            logger.warning(
+                "Failed to record proposal outcome for %s",
+                proposal_id,
+                exc_info=True,
+            )
 
     def _build_invocation(self, request: DirectSessionRequest) -> CCInvocation:
         system_prompt = request.system_prompt

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -1181,11 +1181,11 @@ async def handle_text(ctx: HandlerContext, update: Update, context: ContextTypes
     if not msg.reply_to_message and await _try_bare_proposal_resolution(ctx, msg):
         return
 
-    # Messages in the ego_proposals topic (that aren't quote-replies to
-    # proposals and weren't parsed as decisions) get stored as
-    # user corrections for the ego's next cycle.
-    if not msg.reply_to_message and await _try_ego_correction_store(ctx, msg):
-        return
+    # Messages in the ego_proposals topic that aren't parseable as decisions
+    # fall through to the conversation handler below, which now has
+    # topic-aware context injection (pending proposals + resolution
+    # instructions). The CC session can discuss and resolve proposals
+    # conversationally.
 
     if msg.reply_to_message:
         reply_to_id = str(msg.reply_to_message.message_id)

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -389,7 +389,7 @@ async def update_proposal_outcome(
     """
     suffix = f"|{'completed' if success else 'failed'}:{summary[:200]}"
     cursor = await db.execute(
-        "UPDATE ego_proposals SET user_response = user_response || ? "
+        "UPDATE ego_proposals SET user_response = COALESCE(user_response, '') || ? "
         "WHERE id = ? AND status = 'executed'",
         (suffix, proposal_id),
     )

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -375,6 +375,28 @@ async def execute_proposal(
     return cursor.rowcount > 0
 
 
+async def update_proposal_outcome(
+    db: aiosqlite.Connection,
+    proposal_id: str,
+    *,
+    success: bool,
+    summary: str,
+) -> bool:
+    """Append session outcome to an executed proposal's user_response.
+
+    Called after the dispatched session completes, so the ego knows whether
+    the action actually succeeded or failed.
+    """
+    suffix = f"|{'completed' if success else 'failed'}:{summary[:200]}"
+    cursor = await db.execute(
+        "UPDATE ego_proposals SET user_response = user_response || ? "
+        "WHERE id = ? AND status = 'executed'",
+        (suffix, proposal_id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
 async def table_proposal(
     db: aiosqlite.Connection,
     id: str,

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -989,11 +989,12 @@ class EgoSession:
 
         dispatched: list[str] = []
         for prop in approved:
-            # Staleness guard — skip proposals approved more than 48h ago.
-            # resolved_at is set by resolve_proposal() at approval time.
+            # Staleness guard — skip proposals approved more than 7 days ago.
+            # Proposals go stale by clock only as a safety net; semantic
+            # staleness (premise invalid) is the ego's job to evaluate.
             try:
                 approved_at = datetime.fromisoformat(prop["resolved_at"])
-                if datetime.now(UTC) - approved_at > timedelta(hours=48):
+                if datetime.now(UTC) - approved_at > timedelta(days=7):
                     continue
             except (KeyError, TypeError, ValueError):
                 continue


### PR DESCRIPTION
## Summary

Three fixes for ego autonomous operation:

- **Bidirectional proposals topic**: Messages in the ego proposals Telegram topic that don't match regex now fall through to a full CC conversation session with topic-aware context (pending proposals injected into system prompt). Replaces the old silent "Noted — ego will see this next cycle" intercept.
- **Session outcome feedback**: When a dispatched ego session completes or fails, the outcome is written back to the proposal record. On failure, creates an observation so the ego knows and can propose a retry.
- **Staleness 48h → 7 days**: Proposals should only go stale for semantic reasons. 48h was killing valid proposals that were just waiting for approval.

## Root cause

The user said "Ok do it" in the ego proposals topic. The regex parser didn't match (only accepts "approve 1", "approve all", "go ahead"). The message was intercepted by `_try_ego_correction_store` which stored it as a "correction" and replied "Noted." The actual conversation handler — which already exists and already routes to a full CC session — never got the message.

Meanwhile, the ego thought the Medium article was published because it marks proposals "executed" at dispatch time and never checks whether the session actually succeeded or failed.

## Test plan

- [x] 17 ego + telegram topics tests pass
- [x] 25 direct session tests pass
- [x] Ruff lint clean on all files
- [ ] CI full suite
- [ ] Live: send "do it" in ego proposals topic → session resolves proposal
- [ ] Live: dispatch fails → proposal shows `|failed:...` in user_response

🤖 Generated with [Claude Code](https://claude.com/claude-code)