### PR TITLE
fix(health+surplus): MCP error reporting, code_index dispatch, extraction metric

### DIFF
--- a/config/surplus.yaml
+++ b/config/surplus.yaml
@@ -21,7 +21,7 @@ jobs:
 
 task_defaults:
   code_audit:                { priority: 0.5, drive: competence,   tier: free_api }
-  code_index:                { priority: 0.3, drive: competence,   tier: local_30b }
+  code_index:                { priority: 0.3, drive: competence,   tier: free_api }
   infrastructure_monitor:    { priority: 0.6, drive: preservation, tier: free_api }
   disk_cleanup:              { priority: 0.4, drive: preservation, tier: free_api }
   backup_verification:       { priority: 0.7, drive: preservation, tier: free_api }

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -75,11 +75,11 @@ async def _impl_health_errors(
 
             db_rows = await events_crud.query(
                 _service._db,
-                severity="WARNING",
+                severity="warning",
                 since=cutoff,
                 limit=50,
             )
-            for sev in ("ERROR", "CRITICAL"):
+            for sev in ("error", "critical"):
                 db_rows.extend(await events_crud.query(
                     _service._db,
                     severity=sev,

--- a/src/genesis/observability/snapshots/memory_health.py
+++ b/src/genesis/observability/snapshots/memory_health.py
@@ -80,12 +80,22 @@ async def _link_distribution(db: aiosqlite.Connection) -> dict:
 
 
 async def _extraction_coverage(db: aiosqlite.Connection) -> dict:
-    """Session extraction pipeline coverage."""
+    """Session extraction pipeline coverage.
+
+    Only counts sessions with extractable source_tags (foreground, inbox)
+    since other session types (reflections, ego cycles, etc.) are
+    intentionally excluded from extraction.
+    """
     try:
-        cursor = await db.execute("SELECT COUNT(*) FROM cc_sessions")
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM cc_sessions "
+            "WHERE source_tag IN ('foreground', 'inbox')"
+        )
         total = (await cursor.fetchone())[0]
         cursor = await db.execute(
-            "SELECT COUNT(*) FROM cc_sessions WHERE last_extracted_line > 0"
+            "SELECT COUNT(*) FROM cc_sessions "
+            "WHERE source_tag IN ('foreground', 'inbox') "
+            "AND last_extracted_line > 0"
         )
         extracted = (await cursor.fetchone())[0]
         pct = round(extracted / total * 100, 1) if total else 0.0

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -366,7 +366,7 @@ class SurplusScheduler:
             active = await self._queue.active_by_type(TaskType.CODE_INDEX)
             if active == 0:
                 await self._queue.enqueue(
-                    TaskType.CODE_INDEX, ComputeTier.LOCAL_30B, 0.6, "competence"
+                    TaskType.CODE_INDEX, ComputeTier.FREE_API, 0.6, "competence"
                 )
             try:
                 from genesis.runtime import GenesisRuntime


### PR DESCRIPTION
## Summary

- **health_errors MCP tool** was returning empty because it queried with uppercase severity strings (`"WARNING"`) while the DB stores lowercase (`"warning"`). Dashboard uses a different code path (`query_grouped_errors`) that worked correctly. Fixed by lowercasing the query strings.
- **code_index surplus task** was stuck pending forever because it was enqueued with `LOCAL_30B` compute tier, but no LM Studio is available. The executor does pure AST parsing (no LLM needed), so changed to `FREE_API`.
- **Extraction coverage metric** counted all 1224 cc_sessions as denominator, but only `foreground`/`inbox` sessions (~625) are extractable by design. Dashboard showed misleading 49.5% when actual pipeline coverage is ~97%.
- Cleaned up 4 dead `model_eval` tasks (keyword routing bug already fixed in PR #291) and 1 stuck `code_index` task.

## Test plan
- [x] `test_health_transport_smoke::health_errors` passes
- [x] `test_surplus/test_scheduler.py` all 12 tests pass
- [x] `ruff check` clean on all changed files
- [ ] After deploy: verify `health_errors(window_minutes=60, pattern_group=True)` returns the embedding fallback group
- [ ] After deploy: verify dashboard extraction shows ~97% instead of 49.5%
- [ ] After next surplus cycle: verify code_index task gets picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)