### PR TITLE
feat(observability): cache token tracking + error message storage

### DIFF
--- a/src/genesis/db/crud/cost_events.py
+++ b/src/genesis/db/crud/cost_events.py
@@ -21,16 +21,19 @@ async def create(
     person_id: str | None = None,
     input_tokens: int | None = None,
     output_tokens: int | None = None,
+    cache_read_tokens: int | None = None,
     cost_known: bool = True,
     metadata: dict | None = None,
 ) -> str:
     await db.execute(
         """INSERT INTO cost_events
            (id, event_type, model, provider, engine, task_id, person_id,
-            input_tokens, output_tokens, cost_usd, cost_known, metadata, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            input_tokens, output_tokens, cache_read_tokens,
+            cost_usd, cost_known, metadata, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (id, event_type, model, provider, engine, task_id, person_id,
-         input_tokens, output_tokens, cost_usd, int(cost_known),
+         input_tokens, output_tokens, cache_read_tokens, cost_usd,
+         int(cost_known),
          json.dumps(metadata) if metadata else None, created_at),
     )
     await db.commit()
@@ -51,6 +54,7 @@ async def upsert(
     person_id: str | None = None,
     input_tokens: int | None = None,
     output_tokens: int | None = None,
+    cache_read_tokens: int | None = None,
     cost_known: bool = True,
     metadata: dict | None = None,
 ) -> str:
@@ -58,17 +62,20 @@ async def upsert(
     await db.execute(
         """INSERT INTO cost_events
            (id, event_type, model, provider, engine, task_id, person_id,
-            input_tokens, output_tokens, cost_usd, cost_known, metadata, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            input_tokens, output_tokens, cache_read_tokens,
+            cost_usd, cost_known, metadata, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(id) DO UPDATE SET
              event_type = excluded.event_type, model = excluded.model,
              provider = excluded.provider, engine = excluded.engine,
              task_id = excluded.task_id, person_id = excluded.person_id,
              input_tokens = excluded.input_tokens, output_tokens = excluded.output_tokens,
+             cache_read_tokens = excluded.cache_read_tokens,
              cost_usd = excluded.cost_usd, cost_known = excluded.cost_known,
              metadata = excluded.metadata""",
         (id, event_type, model, provider, engine, task_id, person_id,
-         input_tokens, output_tokens, cost_usd, int(cost_known),
+         input_tokens, output_tokens, cache_read_tokens, cost_usd,
+         int(cost_known),
          json.dumps(metadata) if metadata else None, created_at),
     )
     await db.commit()

--- a/src/genesis/db/migrations/0019_cache_and_errors.py
+++ b/src/genesis/db/migrations/0019_cache_and_errors.py
@@ -1,0 +1,39 @@
+"""Add cache_read_tokens to cost_events and error_message to activity_log.
+
+cache_read_tokens: Provider-level prompt cache hits (e.g., Anthropic,
+Cerebras). Distinct from the system-level cache_hit boolean in activity_log.
+
+error_message: Raw error string from failed LLM calls. Complements the
+binary success flag for post-mortem diagnostics.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # Guard: tables may not exist on fresh DBs before schema bootstrap
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='cost_events'"
+    )
+    if await cursor.fetchone():
+        cursor = await db.execute("PRAGMA table_info(cost_events)")
+        cols = {row[1] for row in await cursor.fetchall()}
+        if "cache_read_tokens" not in cols:
+            await db.execute(
+                "ALTER TABLE cost_events ADD COLUMN cache_read_tokens INTEGER"
+            )
+
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='activity_log'"
+    )
+    if await cursor.fetchone():
+        cursor = await db.execute("PRAGMA table_info(activity_log)")
+        cols = {row[1] for row in await cursor.fetchall()}
+        if "error_message" not in cols:
+            await db.execute(
+                "ALTER TABLE activity_log ADD COLUMN error_message TEXT"
+            )

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -265,6 +265,7 @@ TABLES = {
             person_id        TEXT,               -- GROUNDWORK(multi-person)
             input_tokens     INTEGER,
             output_tokens    INTEGER,
+            cache_read_tokens INTEGER,
             cost_usd         REAL NOT NULL DEFAULT 0.0,
             cost_known       INTEGER NOT NULL DEFAULT 1,  -- 0 if litellm couldn't price
             metadata         TEXT,               -- JSON
@@ -709,12 +710,13 @@ TABLES = {
     """,
     "activity_log": """
         CREATE TABLE IF NOT EXISTS activity_log (
-            id          INTEGER PRIMARY KEY AUTOINCREMENT,
-            provider    TEXT NOT NULL,
-            latency_ms  REAL NOT NULL,
-            success     INTEGER NOT NULL DEFAULT 1,
-            cache_hit   INTEGER NOT NULL DEFAULT 0,
-            created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            provider      TEXT NOT NULL,
+            latency_ms    REAL NOT NULL,
+            success       INTEGER NOT NULL DEFAULT 1,
+            cache_hit     INTEGER NOT NULL DEFAULT 0,
+            error_message TEXT,
+            created_at    TEXT NOT NULL DEFAULT (datetime('now'))
         )
     """,
     "module_config": """

--- a/src/genesis/observability/provider_activity.py
+++ b/src/genesis/observability/provider_activity.py
@@ -42,7 +42,7 @@ class ProviderActivityTracker:
         self._calls: dict[str, deque[CallRecord]] = defaultdict(deque)
         self._db: aiosqlite.Connection | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
-        self._write_batch: list[tuple[str, float, bool, bool]] = []
+        self._write_batch: list[tuple[str, float, bool, bool, str | None]] = []
         self._flush_task: asyncio.Task | None = None
 
     def set_db(self, db: aiosqlite.Connection) -> None:
@@ -60,6 +60,7 @@ class ProviderActivityTracker:
         latency_ms: float,
         success: bool,
         cache_hit: bool = False,
+        error_message: str | None = None,
     ) -> None:
         """Record a single call. Auto-evicts entries older than window."""
         self._calls[provider].append(
@@ -74,7 +75,9 @@ class ProviderActivityTracker:
 
         # Queue for DB persistence (fire-and-forget)
         if self._db is not None:
-            self._write_batch.append((provider, latency_ms, success, cache_hit))
+            self._write_batch.append(
+                (provider, latency_ms, success, cache_hit, error_message),
+            )
             self._schedule_flush()
 
     def _schedule_flush(self) -> None:
@@ -113,9 +116,13 @@ class ProviderActivityTracker:
         now = datetime.now(UTC).isoformat()
         try:
             await self._db.executemany(
-                "INSERT INTO activity_log (provider, latency_ms, success, cache_hit, created_at) "
-                "VALUES (?, ?, ?, ?, ?)",
-                [(p, lat, int(s), int(c), now) for p, lat, s, c in batch],
+                "INSERT INTO activity_log "
+                "(provider, latency_ms, success, cache_hit, error_message, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                [
+                    (p, lat, int(s), int(c), err, now)
+                    for p, lat, s, c, err in batch
+                ],
             )
             await self._db.commit()
         except Exception:

--- a/src/genesis/routing/cost_tracker.py
+++ b/src/genesis/routing/cost_tracker.py
@@ -41,6 +41,7 @@ class CostTracker:
             provider=provider,
             input_tokens=result.input_tokens,
             output_tokens=result.output_tokens,
+            cache_read_tokens=result.cache_read_tokens or None,
             cost_usd=result.cost_usd,
             cost_known=cost_known,
             metadata={"call_site": call_site_id},

--- a/src/genesis/routing/litellm_delegate.py
+++ b/src/genesis/routing/litellm_delegate.py
@@ -92,6 +92,12 @@ class LiteLLMDelegate:
             )
             content = response.choices[0].message.content
             usage = getattr(response, "usage", None)
+            # Extract provider-level prompt cache info when available
+            cache_read = 0
+            if usage:
+                details = getattr(usage, "prompt_tokens_details", None)
+                if details:
+                    cache_read = getattr(details, "cached_tokens", 0) or 0
             if cfg.is_free:
                 cost = 0.0
                 cost_known = True
@@ -112,6 +118,7 @@ class LiteLLMDelegate:
                 content=content,
                 input_tokens=usage.prompt_tokens if usage else 0,
                 output_tokens=usage.completion_tokens if usage else 0,
+                cache_read_tokens=cache_read,
                 cost_usd=cost,
                 cost_known=cost_known,
             )

--- a/src/genesis/routing/router.py
+++ b/src/genesis/routing/router.py
@@ -240,6 +240,7 @@ class Router:
                         f"llm.{provider_name}",
                         latency_ms=latency_ms,
                         success=result.success,
+                        error_message=result.error if not result.success else None,
                     )
                 except Exception:
                     logger.warning(

--- a/src/genesis/routing/router.py
+++ b/src/genesis/routing/router.py
@@ -240,7 +240,7 @@ class Router:
                         f"llm.{provider_name}",
                         latency_ms=latency_ms,
                         success=result.success,
-                        error_message=result.error if not result.success else None,
+                        error_message=(result.error or "")[:1024] if not result.success else None,
                     )
                 except Exception:
                     logger.warning(

--- a/src/genesis/routing/types.py
+++ b/src/genesis/routing/types.py
@@ -92,6 +92,7 @@ class CallResult:
     status_code: int | None = None
     input_tokens: int = 0
     output_tokens: int = 0
+    cache_read_tokens: int = 0
     cost_usd: float = 0.0
     cost_known: bool = True
     retry_after_s: float | None = None


### PR DESCRIPTION
## Summary

- Thread provider-level `cache_read_tokens` through the cost tracking pipeline (litellm response → `CallResult` → `CostTracker` → `cost_events` table). Providers like Anthropic and Cerebras serve cached prompt tokens at reduced cost; Genesis now tracks this.
- Add `error_message` to `activity_log` for post-mortem diagnostics. When LLM calls fail, the raw error string is now stored alongside the binary success flag.
- Migration 0019 adds both columns (idempotent, guarded).

Both gaps identified during the Arize Phoenix instrumentation experiment.

## Files changed

| File | Change |
|------|--------|
| `routing/types.py` | Add `cache_read_tokens` field to `CallResult` |
| `routing/litellm_delegate.py` | Extract `usage.prompt_tokens_details.cached_tokens` |
| `routing/cost_tracker.py` | Pass `cache_read_tokens` to CRUD |
| `db/crud/cost_events.py` | Add `cache_read_tokens` param to `create()` and `upsert()` |
| `observability/provider_activity.py` | Add `error_message` param to `record()` + flush |
| `routing/router.py` | Pass `error_message` on failed calls |
| `db/schema/_tables.py` | Update `cost_events` and `activity_log` CREATE TABLE |
| `db/migrations/0019_cache_and_errors.py` | New migration (idempotent) |

## Test plan

- [x] `ruff check` — all files pass
- [x] `pytest tests/test_routing/` — 223 passed
- [x] `pytest tests/test_db/test_migrations_runner.py` — 29 passed
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)