### PR TITLE
feat(eval): activate model assessment framework — scheduler + bug fix

### DIFF
--- a/config/surplus.yaml
+++ b/config/surplus.yaml
@@ -18,6 +18,7 @@ jobs:
   follow_up_dispatch_minutes: 5
   memory_extraction_hours: 2
   j9_eval_batch_hours: 0          # Disabled: 100% error rate, no value
+  model_eval_hours: 24            # Run model quality assessments daily
 
 task_defaults:
   code_audit:                { priority: 0.5, drive: competence,   tier: free_api }

--- a/src/genesis/reflection/output_router.py
+++ b/src/genesis/reflection/output_router.py
@@ -357,12 +357,17 @@ class OutputRouter:
                     logger.warning("Invalid surplus task_type from reflection: %s", req.task_type)
                     continue
                 try:
+                    # Payload must be a JSON string for the queue/executor.
+                    # Reflection output may provide it as any JSON type (parsed).
+                    raw_payload = req.payload
+                    if raw_payload is not None and not isinstance(raw_payload, str):
+                        raw_payload = json.dumps(raw_payload)
                     task_id = await self._surplus_queue.enqueue(
                         task_type=task_type,
                         compute_tier=ComputeTier.FREE_API,
                         priority=req.priority,
                         drive_alignment=req.drive_alignment,
-                        payload=req.payload,
+                        payload=raw_payload,
                     )
                     logger.info("Enqueued surplus task %s (type=%s) from deep reflection", task_id, req.task_type)
                     summary["surplus_tasks_enqueued"] += 1

--- a/src/genesis/runtime/init/surplus.py
+++ b/src/genesis/runtime/init/surplus.py
@@ -79,6 +79,7 @@ async def init(rt: GenesisRuntime) -> None:
             follow_up_dispatch_minutes=int(jobs.get("follow_up_dispatch_minutes", 5)),
             memory_extraction_hours=int(jobs.get("memory_extraction_hours", 2)),
             j9_eval_batch_hours=int(jobs.get("j9_eval_batch_hours", 24)),
+            model_eval_hours=int(jobs.get("model_eval_hours", 24)),
         )
 
         try:

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -58,6 +58,7 @@ class SurplusScheduler:
         follow_up_dispatch_minutes: int | None = None,
         memory_extraction_hours: int = 2,
         j9_eval_batch_hours: int = 24,
+        model_eval_hours: int = 24,
         clock=None,
         event_bus: GenesisEventBus | None = None,
         enable_code_audits: bool = True,
@@ -83,6 +84,7 @@ class SurplusScheduler:
         self._follow_up_dispatch_minutes = follow_up_dispatch_minutes or dispatch_interval_minutes
         self._memory_extraction_hours = memory_extraction_hours
         self._j9_eval_batch_hours = j9_eval_batch_hours
+        self._model_eval_hours = model_eval_hours
         self._clock = clock or (lambda: datetime.now(UTC))
         self._code_audit_executor: SurplusExecutor | None = None
         self._code_index_executor: SurplusExecutor | None = None
@@ -270,6 +272,14 @@ class SurplusScheduler:
                 max_instances=1,
                 misfire_grace_time=300,
             )
+        if self._model_eval_hours > 0:
+            self._scheduler.add_job(
+                self.schedule_model_eval,
+                IntervalTrigger(hours=self._model_eval_hours),
+                id="schedule_model_eval",
+                max_instances=1,
+                misfire_grace_time=300,
+            )
         if self._follow_up_dispatcher is not None:
             self._scheduler.add_job(
                 self.dispatch_follow_ups,
@@ -290,6 +300,8 @@ class SurplusScheduler:
         await self.schedule_maintenance()
         if self._j9_eval_batch_hours > 0:
             await self.schedule_j9_eval_batch()
+        if self._model_eval_hours > 0:
+            await self.schedule_model_eval()
         if self._analytical_hours > 0:
             await self.schedule_analytical()
         logger.info(
@@ -401,6 +413,33 @@ class SurplusScheduler:
             try:
                 from genesis.runtime import GenesisRuntime
                 GenesisRuntime.instance().record_job_failure("schedule_j9_eval_batch", str(exc))
+            except Exception:
+                pass
+
+    async def schedule_model_eval(self) -> None:
+        """Enqueue a MODEL_EVAL task if none pending/running."""
+        try:
+            import json
+
+            from genesis.surplus.types import ComputeTier, TaskType
+
+            active = await self._queue.active_by_type(TaskType.MODEL_EVAL)
+            if active == 0:
+                payload = json.dumps({"model_id": "groq-free"})
+                await self._queue.enqueue(
+                    TaskType.MODEL_EVAL, ComputeTier.FREE_API, 0.4, "competence",
+                    payload=payload,
+                )
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_success("schedule_model_eval")
+            except Exception:
+                pass
+        except Exception as exc:
+            logger.exception("Model eval scheduling failed")
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_failure("schedule_model_eval", str(exc))
             except Exception:
                 pass
 


### PR DESCRIPTION
## Summary

Activates the assessment framework (fully built, never ran) with two changes:

1. **Scheduler job** — `schedule_model_eval()` enqueues MODEL_EVAL tasks every 24h with `groq-free` as target. Follows exact pattern of `schedule_j9_eval_batch()`.

2. **Bug fix** — `reflection/output_router.py` passed payload as dict (parsed JSON) to `queue.enqueue()` which expects `str | None`. This was the root cause of the "missing model_id in payload" failures (tasks 3a510202, 88882472). Fix: serialize any non-string payload with `json.dumps()`.

## Verification

End-to-end test confirmed:
```
groq-free | classification | 12/15 | 80% | stored in eval_runs
```

First assessment run ever recorded in Genesis's database.

## Test plan

- [x] `ruff check` passes on all modified files
- [x] Manual CLI run: `run_eval(provider_name='groq-free', dataset_name='classification')` succeeds
- [x] DB verification: row in `eval_runs` with correct model/dataset/score
- [x] Code review: passed with fixes applied
- [ ] CI
- [ ] After deploy: verify `schedule_model_eval` appears in job health, MODEL_EVAL task completes