### PR TITLE
fix(web_tools): correct TinyFish cost_events event_type

### DIFF
--- a/src/genesis/mcp/health/web_tools.py
+++ b/src/genesis/mcp/health/web_tools.py
@@ -583,7 +583,7 @@ async def web_agent(
                     await cost_events.create(
                         db,
                         id=str(uuid.uuid4()),
-                        event_type="tinyfish_agent",
+                        event_type="api_call",
                         provider="tinyfish",
                         cost_usd=cost_usd,
                         cost_known=True,


### PR DESCRIPTION
## Summary

- One-line fix: `event_type="tinyfish_agent"` → `event_type="api_call"` in `web_tools.py:586`
- The `cost_events` table has a CHECK constraint limiting `event_type` to `llm_call|api_call|tool_use|sub_agent`. The invalid value would throw `IntegrityError` on any TinyFish agent invocation that tries to record cost.

## Test plan

- [x] `ruff check` passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)