### PR TITLE
fix: memory_expand multi-collection + inbox coherence platform names

### DIFF
--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -129,13 +129,19 @@ def _passes_coherence_check(evaluation: str, source_content: str) -> bool:
     if "# Inbox Evaluation" not in evaluation:
         return False
 
-    # Source URLs should appear in evaluation (domain-level check)
+    # Source URLs should appear in evaluation (domain or platform name)
     urls = re.findall(r"https?://([^\s/]+)", source_content)
     if urls:
         eval_lower = evaluation.lower()
-        url_hits = sum(1 for u in urls if u.lower() in eval_lower)
+        url_hits = 0
+        for u in urls:
+            domain = u.lower().removeprefix("www.")
+            # Check raw domain OR platform name (e.g., "github.com" → "github")
+            platform_name = domain.split(".")[0]
+            if domain in eval_lower or platform_name in eval_lower:
+                url_hits += 1
         if url_hits == 0:
-            return False  # Evaluation doesn't reference ANY source URLs
+            return False  # Evaluation doesn't reference ANY source URLs/platforms
 
     return True
 

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -284,15 +284,19 @@ async def memory_expand(
     memory_mod._require_init()
     assert memory_mod._qdrant is not None and memory_mod._db is not None
 
-    # Batch retrieve all IDs in a single Qdrant call
-    try:
-        points = memory_mod._qdrant.retrieve(
-            collection_name="episodic_memory",
-            ids=memory_ids,
-            with_payload=True,
-        )
-    except Exception:
-        logger.warning("Qdrant batch retrieve failed", exc_info=True)
+    # Batch retrieve from all collections (episodic_memory + knowledge_base)
+    points: list = []
+    for coll in ("episodic_memory", "knowledge_base"):
+        try:
+            points.extend(memory_mod._qdrant.retrieve(
+                collection_name=coll,
+                ids=memory_ids,
+                with_payload=True,
+            ))
+        except Exception:
+            logger.warning("Qdrant retrieve from %s failed", coll, exc_info=True)
+
+    if not points:
         return []
 
     found_ids = {str(p.id) for p in points}


### PR DESCRIPTION
## Summary
- `memory_expand` MCP tool now queries both `episodic_memory` and `knowledge_base` Qdrant collections (was hardcoded to only `episodic_memory`, causing 225 knowledge_base memories to silently return as "not_found")
- Inbox coherence check now matches platform names (e.g., "github", "linkedin") not just raw domains — fixes false positive warnings on well-written evaluations

## Test plan
- [ ] Verify `memory_expand` with a knowledge_base memory ID returns full content
- [ ] Verify inbox evaluation referencing "GitHub" (not "github.com") passes coherence check
- [ ] Ruff check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)