### PR TITLE
fix(ego): disable follow-up creation — read/resolve only

### DIFF
--- a/src/genesis/ego/context.py
+++ b/src/genesis/ego/context.py
@@ -298,9 +298,10 @@ class EgoContextBuilder:
             lines.append(line)
 
         lines.append(
-            "\nYou can: create new follow-ups (they persist until resolved), "
-            "mark items completed, or change strategy. Failed items need "
-            "your judgment — retry, promote to task, escalate to user, or dismiss.\n"
+            "\nYou can RESOLVE follow-ups via resolved_follow_ups output. "
+            "You CANNOT create new follow-ups — use proposals for actions "
+            "and observations for noting things. Follow-ups are a user-facing "
+            "tracking mechanism managed by foreground sessions only.\n"
         )
         return "\n".join(lines)
 
@@ -499,7 +500,7 @@ class EgoContextBuilder:
             "    }\n"
             "  ],\n"
             '  "focus_summary": "one-line: what Genesis is focused on",\n'
-            '  "follow_ups": ["open thread 1", "open thread 2"],\n'
+            '  "follow_ups": [],\n'
             '  "morning_report": "only if this is a morning trigger"\n'
             "}\n"
             "```\n\n"

--- a/src/genesis/ego/dispatch.py
+++ b/src/genesis/ego/dispatch.py
@@ -33,45 +33,22 @@ class EgoDispatcher:
         follow_ups: list[str],
         cycle_id: str,
     ) -> int:
-        """Store follow-ups from an ego cycle in the accountability ledger.
+        """No-op: ego follow-up creation is disabled.
 
-        Deduplicates against existing pending follow-ups from ego_cycle
-        source to prevent the accumulation bug where the ego re-outputs
-        follow-ups it already sees in its context.
+        The ego has proposals for action and observations for noting things.
+        Follow-ups are a user-facing tracking mechanism — only foreground
+        sessions should create them. Ego-generated follow-ups accumulated
+        at ~50/month with 84% stale/noise rate (audit 2026-05-16).
 
-        Returns count of genuinely new follow-ups stored.
+        The ego can still READ follow-ups (get_pending_follow_ups) and
+        RESOLVE them (resolve_follow_ups), but cannot create new ones.
         """
-        # Fetch existing pending ego follow-ups for dedup comparison.
-        existing = await follow_up_crud.get_pending(
-            self._db, source="ego_cycle",
-        )
-        existing_contents = {row["content"].strip().lower() for row in existing}
-
-        count = 0
-        for text in follow_ups:
-            if not text or not text.strip():
-                continue
-            normalized = text.strip()
-            if normalized.lower() in existing_contents:
-                logger.debug(
-                    "Skipping duplicate follow-up from cycle %s: %.80s",
-                    cycle_id, normalized,
-                )
-                continue
-            await follow_up_crud.create(
-                self._db,
-                content=normalized,
-                source="ego_cycle",
-                source_session=cycle_id,
-                strategy="ego_judgment",
-                reason=f"Ego cycle {cycle_id} identified this as an open thread",
+        if follow_ups:
+            logger.debug(
+                "Ego cycle %s produced %d follow-ups (creation disabled)",
+                cycle_id, len(follow_ups),
             )
-            # Track the new entry so subsequent items in this batch dedup too.
-            existing_contents.add(normalized.lower())
-            count += 1
-        if count:
-            logger.info("Recorded %d new follow-ups from ego cycle %s", count, cycle_id)
-        return count
+        return 0
 
     async def resolve_follow_ups(
         self,

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -575,7 +575,7 @@ class GenesisEgoContextBuilder:
             "    }\n"
             "  ],\n"
             '  "focus_summary": "one-line: what Genesis is focused on",\n'
-            '  "follow_ups": ["NEW open thread (not already tracked)"],\n'
+            '  "follow_ups": [],\n'
             '  "resolved_follow_ups": [{"id": "follow_up_id", "resolution": "why resolved"}],\n'
             '  "communication_decision": "send_digest|urgent_notify|stay_quiet"\n'
             "}\n"

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -919,7 +919,7 @@ class UserEgoContextBuilder:
             "    }\n"
             "  ],\n"
             '  "focus_summary": "one-line: what you are focused on for the user",\n'
-            '  "follow_ups": ["NEW open thread (not already tracked)"],\n'
+            '  "follow_ups": [],\n'
             '  "resolved_follow_ups": [{"id": "follow_up_id", "resolution": "why resolved"}],\n'
             '  "morning_report": "only if this is a morning trigger"\n'
             "}\n"


### PR DESCRIPTION
## Summary
- Ego cycle follow-up creation disabled (no-op with debug log)
- Ego can still READ follow-ups in context and RESOLVE them
- Output format updated: `follow_ups` field shows empty array
- Context instructions clarify read-only relationship
- Bulk-closed 53 stale/noise ego follow-ups (84% of 62 pending)

**Root cause:** Ego was writing a diary, not a task list. It has proposals for action and observations for noting things — follow-ups are redundant and accumulated unchecked.

## Test plan
- [ ] Ego cycle runs without error (follow_ups field accepted as empty array)
- [ ] Ego context still shows pending follow-ups for awareness
- [ ] Ego can still resolve follow-ups via resolved_follow_ups output
- [ ] No new ego_cycle follow-ups created after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)