### PR TITLE
fix(sentinel): detect and report stale heartbeat on dashboard

### DIFF
--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -2435,6 +2435,9 @@
           // paints the card red, an in-flight investigation paints it degraded.
           const sentinel = services?.sentinel;
           if (sentinel?.enabled) {
+            if (sentinel.is_stale) {
+              return { state: "degraded", reason: `sentinel stale — last heartbeat ${Math.round((sentinel.staleness_s || 0) / 60)}m ago` };
+            }
             if (sentinel.current_state === "escalated") {
               return { state: "error", reason: "sentinel escalated — CC diagnosis failed" };
             }
@@ -4079,7 +4082,8 @@
                          const s = $store.genesisDashboard.health.services?.sentinel;
                          if (!s || !s.enabled) return 'Sentinel: unavailable';
                          let tip = 'Sentinel: ' + s.current_state;
-                         if (s.is_active) tip += ' (running)';
+                         if (s.is_stale) tip += ` (stale ${Math.round((s.staleness_s || 0) / 60)}m)`;
+                         else if (s.is_active) tip += ' (running)';
                          if (s.last_trigger_reason) tip += ' — last: ' + s.last_trigger_reason;
                          return tip;
                        })()">
@@ -4087,6 +4091,7 @@
                           :style="`background: ${(() => {
                             const s = $store.genesisDashboard.health.services?.sentinel;
                             if (!s || !s.enabled) return '#666';
+                            if (s.is_stale || s.current_state === 'stale') return '#ff9800';
                             if (s.current_state === 'healthy') return '#4caf50';
                             if (s.current_state === 'escalated') return '#d9534f';
                             if (['investigating', 'remediating', 'awaiting_dispatch_approval', 'awaiting_action_approval'].includes(s.current_state)) return '#f0ad4e';
@@ -4097,6 +4102,7 @@
                           x-text="(() => {
                             const s = $store.genesisDashboard.health.services?.sentinel;
                             if (!s || !s.enabled) return '';
+                            if (s.is_stale) return '(stale)';
                             if (s.is_active) return '(running)';
                             if (s.current_state.startsWith('awaiting')) return '(awaiting approval)';
                             if (s.current_state !== 'healthy') return '(' + s.current_state + ')';

--- a/src/genesis/observability/snapshots/services.py
+++ b/src/genesis/observability/snapshots/services.py
@@ -57,7 +57,7 @@ def services() -> dict:
         else:
             state = sentinel.state
             # Compute heartbeat staleness (stale = >10 min since last tick)
-            heartbeat = state.last_heartbeat_at
+            heartbeat = getattr(state, "last_heartbeat_at", "")
             if heartbeat:
                 try:
                     age_s = (datetime.now(UTC) - datetime.fromisoformat(heartbeat)).total_seconds()
@@ -67,9 +67,15 @@ def services() -> dict:
                 age_s = 9999  # No heartbeat recorded yet — treat as stale
             is_stale = age_s > 600  # 10 min = 2x awareness loop interval
 
+            # Only override to "stale" when sentinel reports healthy — active
+            # states (investigating, escalated) are more informative than stale.
+            reported_state = state.current_state
+            if is_stale and reported_state == "healthy":
+                reported_state = "stale"
+
             result["sentinel"] = {
                 "enabled": True,
-                "current_state": "stale" if is_stale else state.current_state,
+                "current_state": reported_state,
                 "is_active": bool(sentinel.is_active),
                 "last_trigger_source": state.last_trigger_source or "",
                 "last_trigger_reason": state.last_trigger_reason or "",

--- a/src/genesis/observability/snapshots/services.py
+++ b/src/genesis/observability/snapshots/services.py
@@ -6,6 +6,7 @@ import asyncio as _aio
 import importlib
 import json
 import logging
+from datetime import UTC, datetime
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -55,14 +56,27 @@ def services() -> dict:
             result["sentinel"] = _sentinel_unavailable()
         else:
             state = sentinel.state
+            # Compute heartbeat staleness (stale = >10 min since last tick)
+            heartbeat = state.last_heartbeat_at
+            if heartbeat:
+                try:
+                    age_s = (datetime.now(UTC) - datetime.fromisoformat(heartbeat)).total_seconds()
+                except (ValueError, TypeError):
+                    age_s = 9999
+            else:
+                age_s = 9999  # No heartbeat recorded yet — treat as stale
+            is_stale = age_s > 600  # 10 min = 2x awareness loop interval
+
             result["sentinel"] = {
                 "enabled": True,
-                "current_state": state.current_state,
+                "current_state": "stale" if is_stale else state.current_state,
                 "is_active": bool(sentinel.is_active),
                 "last_trigger_source": state.last_trigger_source or "",
                 "last_trigger_reason": state.last_trigger_reason or "",
                 "last_dispatch_at": state.last_cc_dispatch_at or "",
                 "escalated_count": int(state.escalated_count),
+                "staleness_s": int(age_s),
+                "is_stale": is_stale,
             }
     except ImportError:
         # In production this import should always succeed; failure here means

--- a/src/genesis/observability/snapshots/services.py
+++ b/src/genesis/observability/snapshots/services.py
@@ -105,6 +105,8 @@ def _sentinel_unavailable() -> dict:
         "last_trigger_reason": "",
         "last_dispatch_at": "",
         "escalated_count": 0,
+        "staleness_s": 0,
+        "is_stale": False,
     }
 
 

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -1427,6 +1427,10 @@ class SentinelDispatcher:
         appeared in ≥_ALARM_CONFIRMATION_COUNT of the last _ALARM_RING_SIZE
         ticks. Single-tick flaps never wake the Sentinel.
         """
+        # Record heartbeat on every tick so staleness can be detected.
+        self._state.record_heartbeat()
+        save_state(self._state)
+
         # Auto-reset ESCALATED on every tick (not just on new dispatches).
         # Without this, the sentinel stays red forever if no new alarms fire.
         self._try_auto_reset_escalated()

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -1427,10 +1427,6 @@ class SentinelDispatcher:
         appeared in ≥_ALARM_CONFIRMATION_COUNT of the last _ALARM_RING_SIZE
         ticks. Single-tick flaps never wake the Sentinel.
         """
-        # Record heartbeat on every tick so staleness can be detected.
-        self._state.record_heartbeat()
-        save_state(self._state)
-
         # Auto-reset ESCALATED on every tick (not just on new dispatches).
         # Without this, the sentinel stays red forever if no new alarms fire.
         self._try_auto_reset_escalated()
@@ -1444,6 +1440,12 @@ class SentinelDispatcher:
         except Exception:
             logger.debug("Failed to query health alerts for fire alarm check", exc_info=True)
             return None
+
+        # Record heartbeat AFTER the health query succeeds. This certifies
+        # "sentinel checked the system this tick." If the query above fails
+        # or health_data is None, no heartbeat is stamped → staleness detected.
+        self._state.record_heartbeat()
+        save_state(self._state)
 
         alarms = classify_alerts(alerts or [])
         current_ids = {a.alert_id for a in alarms}

--- a/src/genesis/sentinel/state.py
+++ b/src/genesis/sentinel/state.py
@@ -72,6 +72,10 @@ class SentinelStateData:
     pending_request_json: str = ""  # JSON-serialized SentinelRequest fields
     pending_cc_result_json: str = ""  # JSON-serialized CC result (for action phase)
 
+    # Heartbeat — updated every awareness tick via check_fire_alarms().
+    # If this goes stale (>10 min), dashboard reports sentinel as "stale".
+    last_heartbeat_at: str = ""
+
     # Bootstrap grace
     bootstrap_grace_s: int = 240
     started_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
@@ -100,6 +104,10 @@ class SentinelStateData:
             return elapsed < self.bootstrap_grace_s
         except (ValueError, TypeError):
             return False
+
+    def record_heartbeat(self) -> None:
+        """Stamp the heartbeat. Called every awareness tick."""
+        self.last_heartbeat_at = datetime.now(UTC).isoformat()
 
     def record_cc_dispatch(self) -> None:
         """Stamp the last dispatch time. Used for observability only."""

--- a/tests/test_observability/test_services_snapshot.py
+++ b/tests/test_observability/test_services_snapshot.py
@@ -21,12 +21,14 @@ from genesis.runtime._core import GenesisRuntime
 
 
 def _fake_sentinel(current_state="healthy", is_active=False, **kw):
+    from datetime import UTC, datetime
     state = SimpleNamespace(
         current_state=current_state,
         last_trigger_source=kw.get("last_trigger_source", ""),
         last_trigger_reason=kw.get("last_trigger_reason", ""),
         last_cc_dispatch_at=kw.get("last_cc_dispatch_at", ""),
         escalated_count=kw.get("escalated_count", 0),
+        last_heartbeat_at=kw.get("last_heartbeat_at", datetime.now(UTC).isoformat()),
     )
     return SimpleNamespace(state=state, is_active=is_active)
 


### PR DESCRIPTION
## Summary
- Sentinel now records `last_heartbeat_at` on every awareness tick (5 min)
- Services snapshot computes staleness: if heartbeat >10 min old → reports `is_stale: true`
- Dashboard renders stale sentinel as orange dot instead of green
- Guardian card shows degraded state with human-readable staleness ("last heartbeat Xm ago")

**Root cause:** During the 2026-05-08 DB lock incident, dashboard showed sentinel green while it was silently failing to dispatch. The state file only updated on state transitions, so "healthy" persisted indefinitely.

## Test plan
- [ ] Ruff check passes (verified)
- [ ] State roundtrip: save/load preserves `last_heartbeat_at` (verified)
- [ ] Backwards compat: old state file without field loads as stale (verified)
- [ ] Edge cases: empty/malformed heartbeat → treated as stale (verified)
- [ ] After deploy: sentinel dot shows green with staleness_s < 600
- [ ] After server stop (>10 min): sentinel dot shows orange "stale"

🤖 Generated with [Claude Code](https://claude.com/claude-code)