### PR TITLE
fix(guardian): health API depth check + 503 retry

### DIFF
--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -39,6 +39,7 @@ class SuspiciousChecksConfig:
     tick_history_count: int = 10
     error_spike_window_min: int = 30
     error_spike_threshold: int = 50
+    db_latency_warning_ms: float = 5000.0  # Normal is <100ms; 5s = serious degradation
 
 
 @dataclass

--- a/src/genesis/guardian/health_signals.py
+++ b/src/genesis/guardian/health_signals.py
@@ -247,12 +247,21 @@ async def probe_icmp_reachable(config: GuardianConfig) -> SignalResult:
 
 
 async def probe_health_api(config: GuardianConfig) -> SignalResult:
-    """Check Flask health API responds with 200."""
+    """Check Flask health API responds with 200.
+
+    Retries once on 503 (often transient during DB lock or bootstrap).
+    """
     name = "health_api"
     t0 = datetime.now(UTC)
     try:
         url = f"{config.health_url}/api/genesis/health"
         status, body = await _http_get_async(url, timeout=config.probes.http_timeout_s)
+
+        # 503 is often transient (DB lock, bootstrap race). Retry once.
+        if status == 503:
+            await asyncio.sleep(5)
+            status, body = await _http_get_async(url, timeout=config.probes.http_timeout_s)
+
         latency = (datetime.now(UTC) - t0).total_seconds() * 1000
         alive = status == 200
         detail = "healthy" if alive else f"status={status} body={body[:200]}"
@@ -587,6 +596,58 @@ async def check_error_spike(config: GuardianConfig) -> SuspiciousResult:
         )
 
 
+async def check_health_api_depth(config: GuardianConfig) -> SuspiciousResult:
+    """Parse health API response body for degraded infrastructure metrics.
+
+    Runs only when all probes pass (health API already returned 200).
+    Checks DB latency, scheduler status, and Qdrant status against thresholds.
+    """
+    name = "health_api_depth"
+    t0 = datetime.now(UTC)
+    try:
+        url = f"{config.health_url}/api/genesis/health"
+        status, body = await _http_get_async(url, timeout=config.probes.http_timeout_s)
+        if status != 200:
+            return SuspiciousResult(
+                name=name, ok=True, detail=f"skipped (status={status})",
+                collected_at=t0.isoformat(),
+            )
+
+        data = json.loads(body)
+        infra = data.get("infrastructure", {})
+
+        warnings: list[str] = []
+
+        # DB latency
+        db = infra.get("genesis.db", {})
+        db_latency = db.get("latency_ms", 0)
+        if isinstance(db_latency, (int, float)) and db_latency > config.suspicious.db_latency_warning_ms:
+            warnings.append(f"db_latency={db_latency:.0f}ms")
+
+        # Scheduler
+        sched = infra.get("scheduler", {})
+        sched_status = sched.get("status", "unknown")
+        if sched_status not in ("healthy", "unknown"):
+            warnings.append(f"scheduler={sched_status}")
+
+        # Qdrant
+        qdrant = infra.get("qdrant", {})
+        qdrant_status = qdrant.get("status", "unknown")
+        if qdrant_status not in ("healthy", "unknown"):
+            warnings.append(f"qdrant={qdrant_status}")
+
+        ok = len(warnings) == 0
+        detail = ", ".join(warnings) if warnings else "all metrics healthy"
+        return SuspiciousResult(
+            name=name, ok=ok, detail=detail, collected_at=t0.isoformat(),
+        )
+    except Exception as exc:
+        return SuspiciousResult(
+            name=name, ok=True, detail=f"exception: {exc}",
+            collected_at=t0.isoformat(),
+        )
+
+
 async def check_pause_state(config: GuardianConfig) -> PauseState:
     """Read Genesis pause state from the container."""
     try:
@@ -660,6 +721,7 @@ async def collect_all_signals(config: GuardianConfig) -> HealthSnapshot:
             check_cc_tmp_usage(config),
             check_restart_count(config),
             check_error_spike(config),
+            check_health_api_depth(config),
             return_exceptions=True,
         )
         for result in suspicious_results:

--- a/src/genesis/guardian/health_signals.py
+++ b/src/genesis/guardian/health_signals.py
@@ -7,7 +7,7 @@ asyncio.gather.
 Probes:
   1. Container exists     — incus info genesis → "Status: RUNNING"
   2. ICMP reachable       — ping -c1 -W3 {container_ip}
-  3. Health API           — HTTP GET :5000/api/genesis/health
+  3. Health API           — HTTP GET :5000/api/genesis/health (retries once on 503)
   4. Heartbeat canary     — HTTP GET :5000/api/genesis/heartbeat
   5. Log freshness        — incus exec journalctl last line timestamp
 
@@ -18,7 +18,7 @@ Suspicious checks (run when all 5 probes pass):
   4. CC tmp usage         — watchgod_state.json tier check
   5. Restart count        — systemctl NRestarts
   6. Error spike          — journalctl error count in window
-  7. Pause state          — /api/genesis/pause or paused.json
+  7. Health API depth     — parse response body for degraded metrics
 """
 
 from __future__ import annotations
@@ -250,6 +250,7 @@ async def probe_health_api(config: GuardianConfig) -> SignalResult:
     """Check Flask health API responds with 200.
 
     Retries once on 503 (often transient during DB lock or bootstrap).
+    Reported latency reflects the successful call, not the retry wait.
     """
     name = "health_api"
     t0 = datetime.now(UTC)
@@ -260,6 +261,7 @@ async def probe_health_api(config: GuardianConfig) -> SignalResult:
         # 503 is often transient (DB lock, bootstrap race). Retry once.
         if status == 503:
             await asyncio.sleep(5)
+            t0 = datetime.now(UTC)  # Reset — report latency of the successful call
             status, body = await _http_get_async(url, timeout=config.probes.http_timeout_s)
 
         latency = (datetime.now(UTC) - t0).total_seconds() * 1000

--- a/tests/test_guardian/test_health_signals.py
+++ b/tests/test_guardian/test_health_signals.py
@@ -16,6 +16,7 @@ from genesis.guardian.health_signals import (
     SignalResult,
     SuspiciousResult,
     check_error_spike,
+    check_health_api_depth,
     check_memory_pressure,
     check_pause_state,
     check_restart_count,
@@ -187,12 +188,34 @@ class TestProbeHealthApi:
 
     @pytest.mark.asyncio
     async def test_unhealthy(self, config: GuardianConfig) -> None:
-        with patch(
-            "genesis.guardian.health_signals._http_get_async",
-            _mock_http(503, '{"status": "unhealthy"}'),
+        with (
+            patch(
+                "genesis.guardian.health_signals._http_get_async",
+                _mock_http(503, '{"status": "unhealthy"}'),
+            ),
+            patch("genesis.guardian.health_signals.asyncio.sleep", return_value=None),
         ):
             result = await probe_health_api(config)
         assert result.alive is False
+
+    @pytest.mark.asyncio
+    async def test_503_retry_succeeds(self, config: GuardianConfig) -> None:
+        """503 followed by 200 should report alive=True."""
+        call_count = [0]
+
+        async def mock_retry(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return (503, '{"status": "unhealthy"}')
+            return (200, '{"status": "healthy"}')
+
+        with (
+            patch("genesis.guardian.health_signals._http_get_async", mock_retry),
+            patch("genesis.guardian.health_signals.asyncio.sleep", return_value=None),
+        ):
+            result = await probe_health_api(config)
+        assert result.alive is True
+        assert call_count[0] == 2
 
     @pytest.mark.asyncio
     async def test_connection_refused(self, config: GuardianConfig) -> None:
@@ -442,6 +465,85 @@ class TestCheckErrorSpike:
         ):
             result = await check_error_spike(config)
         assert result.ok is False
+
+
+class TestCheckHealthApiDepth:
+
+    @pytest.mark.asyncio
+    async def test_all_healthy(self, config: GuardianConfig) -> None:
+        body = '{"infrastructure": {"genesis.db": {"status": "healthy", "latency_ms": 5}, "scheduler": {"status": "healthy"}, "qdrant": {"status": "healthy"}}}'
+        with patch(
+            "genesis.guardian.health_signals._http_get_async",
+            _mock_http(200, body),
+        ):
+            result = await check_health_api_depth(config)
+        assert result.ok is True
+        assert "all metrics healthy" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_high_db_latency(self, config: GuardianConfig) -> None:
+        body = '{"infrastructure": {"genesis.db": {"status": "healthy", "latency_ms": 8000}, "scheduler": {"status": "healthy"}, "qdrant": {"status": "healthy"}}}'
+        with patch(
+            "genesis.guardian.health_signals._http_get_async",
+            _mock_http(200, body),
+        ):
+            result = await check_health_api_depth(config)
+        assert result.ok is False
+        assert "db_latency=8000ms" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_degraded_scheduler(self, config: GuardianConfig) -> None:
+        body = '{"infrastructure": {"genesis.db": {"status": "healthy", "latency_ms": 10}, "scheduler": {"status": "degraded"}, "qdrant": {"status": "healthy"}}}'
+        with patch(
+            "genesis.guardian.health_signals._http_get_async",
+            _mock_http(200, body),
+        ):
+            result = await check_health_api_depth(config)
+        assert result.ok is False
+        assert "scheduler=degraded" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_qdrant_down(self, config: GuardianConfig) -> None:
+        body = '{"infrastructure": {"genesis.db": {"status": "healthy", "latency_ms": 10}, "scheduler": {"status": "healthy"}, "qdrant": {"status": "down"}}}'
+        with patch(
+            "genesis.guardian.health_signals._http_get_async",
+            _mock_http(200, body),
+        ):
+            result = await check_health_api_depth(config)
+        assert result.ok is False
+        assert "qdrant=down" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_multiple_warnings(self, config: GuardianConfig) -> None:
+        body = '{"infrastructure": {"genesis.db": {"status": "healthy", "latency_ms": 9000}, "scheduler": {"status": "error"}, "qdrant": {"status": "down"}}}'
+        with patch(
+            "genesis.guardian.health_signals._http_get_async",
+            _mock_http(200, body),
+        ):
+            result = await check_health_api_depth(config)
+        assert result.ok is False
+        assert "db_latency=9000ms" in result.detail
+        assert "scheduler=error" in result.detail
+        assert "qdrant=down" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_non_200_skipped(self, config: GuardianConfig) -> None:
+        with patch(
+            "genesis.guardian.health_signals._http_get_async",
+            _mock_http(503, '{"status": "unhealthy"}'),
+        ):
+            result = await check_health_api_depth(config)
+        assert result.ok is True
+        assert "skipped" in result.detail
+
+    @pytest.mark.asyncio
+    async def test_malformed_body(self, config: GuardianConfig) -> None:
+        with patch(
+            "genesis.guardian.health_signals._http_get_async",
+            _mock_http(200, "not json"),
+        ):
+            result = await check_health_api_depth(config)
+        assert result.ok is True  # Errors fall safe
 
 
 class TestCheckPauseState:

--- a/tests/test_guardian/test_health_signals.py
+++ b/tests/test_guardian/test_health_signals.py
@@ -542,13 +542,14 @@ class TestCollectAllSignals:
             patch("genesis.guardian.health_signals.check_cc_tmp_usage", return_value=SuspiciousResult("cc_tmp_usage", True, "ok", "t")),
             patch("genesis.guardian.health_signals.check_restart_count", return_value=SuspiciousResult("restart_count", True, "ok", "t")),
             patch("genesis.guardian.health_signals.check_error_spike", return_value=SuspiciousResult("error_spike", True, "ok", "t")),
+            patch("genesis.guardian.health_signals.check_health_api_depth", return_value=SuspiciousResult("health_api_depth", True, "all metrics healthy", "t")),
         ):
             snapshot = await collect_all_signals(config)
 
         assert snapshot.all_alive is True
         assert len(snapshot.signals) == 5
-        # Suspicious checks run when all alive
-        assert len(snapshot.suspicious) == 6
+        # Suspicious checks run when all alive (7 checks: 6 original + health_api_depth)
+        assert len(snapshot.suspicious) == 7
 
     @pytest.mark.asyncio
     async def test_partial_failure_skips_suspicious(self, config: GuardianConfig) -> None:


### PR DESCRIPTION
## Summary
- Guardian now retries once on 503 from health API (absorbs transient DB lock)
- New `check_health_api_depth` suspicious check parses the health API response body for degraded metrics (DB latency >5000ms, scheduler/qdrant not healthy)
- Uses existing suspicious check architecture — no state machine changes

**Root cause:** During 2026-05-08 DB lock incident, a single 503 triggered the full confirmation cascade. Guardian also never parsed the response body which contains rich infrastructure data (DB latency, scheduler state, Qdrant status) — it only checked HTTP 200 vs non-200.

## Test plan
- [x] Ruff check passes
- [x] All 304 guardian tests pass
- [x] Import chain verified (`check_health_api_depth` importable, config default loads)
- [ ] Manual: `python -m genesis.guardian --check-only` shows `health_api_depth` in output
- [ ] Integration: 503 retry verified during next DB lock event (or simulated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)