### PR TITLE
feat(dashboard): surface eval metrics + J-9 dimensions

### DIFF
--- a/src/genesis/dashboard/routes/surplus.py
+++ b/src/genesis/dashboard/routes/surplus.py
@@ -169,6 +169,25 @@ async def surplus_config():
     # Eval staleness
     eval_data = await eval_staleness(db)
 
+    # Eval metrics — per-run scores + J-9 dimension snapshots
+    eval_metrics = {"runs": [], "j9": []}
+    if db is not None:
+        try:
+            cursor = await db.execute("""
+                SELECT model_id, dataset, aggregate_score, passed_cases,
+                       failed_cases, skipped_cases, duration_s, created_at
+                FROM eval_runs ORDER BY created_at DESC LIMIT 20
+            """)
+            eval_metrics["runs"] = [dict(r) for r in await cursor.fetchall()]
+
+            cursor = await db.execute("""
+                SELECT dimension, metrics_json, sample_count, created_at
+                FROM eval_snapshots ORDER BY created_at DESC LIMIT 10
+            """)
+            eval_metrics["j9"] = [dict(r) for r in await cursor.fetchall()]
+        except Exception:
+            logger.debug("eval_metrics query failed (tables may not exist yet)")
+
     # Queue stats
     stats = {}
     if db is not None:
@@ -187,6 +206,7 @@ async def surplus_config():
         "catalog": catalog,
         "drives": drives,
         "eval_staleness": eval_data,
+        "eval_metrics": eval_metrics,
         "stats": stats,
     })
 

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -1751,8 +1751,10 @@ async function loadSurplusDetail(container) {
                     const row = el('div', 'surplus-task-row');
                     row.appendChild(el('span', 'task-type', `${run.model_id} / ${run.dataset}`));
                     const score = run.aggregate_score != null ? Math.round(run.aggregate_score * 100) + '%' : '?';
-                    const scoreColor = run.aggregate_score >= 0.8 ? '#4ade80' : run.aggregate_score >= 0.6 ? '#fbbf24' : '#ef4444';
-                    const scoreEl = el('span', 'task-time', `${score} (${run.passed_cases}/${run.passed_cases + run.failed_cases})`);
+                    const scoreColor = run.aggregate_score == null ? '#94a3b8' : run.aggregate_score >= 0.8 ? '#4ade80' : run.aggregate_score >= 0.6 ? '#fbbf24' : '#ef4444';
+                    const passed = run.passed_cases || 0;
+                    const failed = run.failed_cases || 0;
+                    const scoreEl = el('span', 'task-time', `${score} (${passed}/${passed + failed})`);
                     scoreEl.style.color = scoreColor;
                     row.appendChild(scoreEl);
                     evalSection.appendChild(row);

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -1714,12 +1714,18 @@ async function loadSurplusDetail(container) {
             container.appendChild(driveSection);
         }
 
-        // Section 3: Eval Staleness
+        // Section 3: Eval Metrics
         const evalData = data.eval_staleness || {};
+        const evalMetrics = data.eval_metrics || {};
         const providers = evalData.providers || [];
-        if (providers.length > 0) {
+        const evalRuns = evalMetrics.runs || [];
+        const j9Snaps = evalMetrics.j9 || [];
+
+        if (providers.length > 0 || evalRuns.length > 0 || j9Snaps.length > 0) {
             const evalSection = el('div', 'detail-section');
-            evalSection.appendChild(el('h4', null, 'Eval Freshness'));
+            evalSection.appendChild(el('h4', null, 'Eval & Assessment'));
+
+            // Provider freshness
             for (const p of providers) {
                 const row = el('div', 'surplus-task-row');
                 row.appendChild(el('span', 'task-type', p.provider));
@@ -1734,6 +1740,42 @@ async function loadSurplusDetail(container) {
                 }
                 evalSection.appendChild(row);
             }
+
+            // Recent eval run scores
+            if (evalRuns.length > 0) {
+                const runsHeader = el('div', null, '');
+                runsHeader.style.cssText = 'margin-top:8px;font-size:11px;color:#94a3b8;';
+                runsHeader.textContent = 'Recent Runs';
+                evalSection.appendChild(runsHeader);
+                for (const run of evalRuns.slice(0, 5)) {
+                    const row = el('div', 'surplus-task-row');
+                    row.appendChild(el('span', 'task-type', `${run.model_id} / ${run.dataset}`));
+                    const score = run.aggregate_score != null ? Math.round(run.aggregate_score * 100) + '%' : '?';
+                    const scoreColor = run.aggregate_score >= 0.8 ? '#4ade80' : run.aggregate_score >= 0.6 ? '#fbbf24' : '#ef4444';
+                    const scoreEl = el('span', 'task-time', `${score} (${run.passed_cases}/${run.passed_cases + run.failed_cases})`);
+                    scoreEl.style.color = scoreColor;
+                    row.appendChild(scoreEl);
+                    evalSection.appendChild(row);
+                }
+            }
+
+            // J-9 dimension scores
+            if (j9Snaps.length > 0) {
+                const j9Header = el('div', null, '');
+                j9Header.style.cssText = 'margin-top:8px;font-size:11px;color:#94a3b8;';
+                j9Header.textContent = 'J-9 Dimensions';
+                evalSection.appendChild(j9Header);
+                for (const snap of j9Snaps) {
+                    if (snap.dimension === 'composite') continue;
+                    const row = el('div', 'surplus-task-row');
+                    row.appendChild(el('span', 'task-type', snap.dimension));
+                    const samples = el('span', 'task-time', `${snap.sample_count} samples`);
+                    samples.style.color = snap.sample_count > 0 ? '#94a3b8' : '#ef4444';
+                    row.appendChild(samples);
+                    evalSection.appendChild(row);
+                }
+            }
+
             container.appendChild(evalSection);
         }
 


### PR DESCRIPTION
## Summary
- Extends `/api/genesis/surplus/config` with `eval_metrics` key containing recent eval runs + J-9 dimension snapshots
- Enhances neural_monitor eval section: provider scores with color coding (green >80%, yellow 60-80%, red <60%) and J-9 dimension sample counts
- Data already existed in DB (PR #372) but was invisible — this surfaces it

## Test plan
- [x] Ruff passes
- [x] Queries verified against live DB (1 eval run, 6 J-9 snapshots returned correctly)
- [ ] Visual: restart server, check neural_monitor surplus panel shows eval card with scores
- [ ] Verify no regression in existing surplus panel functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)