### PR TITLE
fix(eval): route J9 batch through router instead of hardcoded litellm

### DIFF
--- a/src/genesis/eval/j9_batch.py
+++ b/src/genesis/eval/j9_batch.py
@@ -4,7 +4,8 @@ Runs as a surplus task. For each recall_fired event from the past 24h,
 asks a cheap model to judge whether each recalled memory was relevant
 to the query. Stores recall_relevance events.
 
-Cost: ~50K tokens/day at Haiku ≈ $0.04/day.
+Routes through the Genesis LLM router (call site "judge") to use whatever
+provider is available — no hardcoded model dependency.
 """
 
 from __future__ import annotations
@@ -14,18 +15,15 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
-import litellm
-
 from genesis.db.crud import j9_eval
 from genesis.surplus.types import ExecutorResult, SurplusTask
 
 if TYPE_CHECKING:
     import aiosqlite
 
-logger = logging.getLogger(__name__)
+    from genesis.routing.router import LLMRouter
 
-# Model for relevance judgments — cheap and fast
-_JUDGE_MODEL = "claude-haiku-4-5-20251001"
+logger = logging.getLogger(__name__)
 
 def _text_overlap(memory_text: str, reference_text: str, min_phrases: int = 2) -> bool:
     """Check if memory content appears in reference text via trigram overlap.
@@ -64,8 +62,14 @@ class J9EvalBatchExecutor:
     Scores memory recall relevance for the past 24 hours.
     """
 
-    def __init__(self, *, db: aiosqlite.Connection | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        db: aiosqlite.Connection | None = None,
+        router: LLMRouter | None = None,
+    ) -> None:
         self._db = db
+        self._router = router
 
     async def execute(self, task: SurplusTask) -> ExecutorResult:
         if self._db is None:
@@ -116,7 +120,7 @@ class J9EvalBatchExecutor:
                             "memory_id": mid,
                             "relevance": relevance,
                             "judge_rationale": rationale,
-                            "judge_model": _JUDGE_MODEL,
+                            "judge_model": "router:judge",
                         },
                     )
                     scored += 1
@@ -137,7 +141,7 @@ class J9EvalBatchExecutor:
             insights=[{
                 "content": content,
                 "source_task_type": task.task_type,
-                "generating_model": _JUDGE_MODEL,
+                "generating_model": "router:judge",
                 "drive_alignment": "competence",
                 "confidence": 0.8 if errors == 0 else 0.6,
             }],
@@ -237,19 +241,24 @@ class J9EvalBatchExecutor:
     async def _judge_relevance(
         self, query: str, memory_content: str,
     ) -> tuple[float | None, str]:
-        """Ask the judge model to score relevance."""
+        """Ask the judge model to score relevance via the router."""
+        if self._router is None:
+            return (None, "no router configured")
+
         prompt = _RELEVANCE_PROMPT.format(
             query=query[:500],
             memory_content=memory_content[:1000],
         )
         try:
-            response = await litellm.acompletion(
-                model=_JUDGE_MODEL,
+            result = await self._router.route_call(
+                call_site_id="judge",
                 messages=[{"role": "user", "content": prompt}],
-                max_tokens=150,
                 temperature=0.0,
             )
-            text = response.choices[0].message.content or ""
+            if not result.success:
+                logger.debug("J9 relevance routing failed: %s", result.error)
+                return (None, result.error or "routing failed")
+            text = result.content or ""
             # Parse JSON response
             parsed = json.loads(text.strip())
             relevance = float(parsed.get("relevance", 0.0))

--- a/src/genesis/eval/j9_batch.py
+++ b/src/genesis/eval/j9_batch.py
@@ -21,7 +21,7 @@ from genesis.surplus.types import ExecutorResult, SurplusTask
 if TYPE_CHECKING:
     import aiosqlite
 
-    from genesis.routing.router import LLMRouter
+    from genesis.routing.router import Router
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class J9EvalBatchExecutor:
         self,
         *,
         db: aiosqlite.Connection | None = None,
-        router: LLMRouter | None = None,
+        router: Router | None = None,
     ) -> None:
         self._db = db
         self._router = router
@@ -107,7 +107,7 @@ class J9EvalBatchExecutor:
                 if not content:
                     continue
 
-                relevance, rationale = await self._judge_relevance(query, content)
+                relevance, rationale, model_used = await self._judge_relevance(query, content)
                 if relevance is not None:
                     await j9_eval.insert_event(
                         self._db,
@@ -120,7 +120,7 @@ class J9EvalBatchExecutor:
                             "memory_id": mid,
                             "relevance": relevance,
                             "judge_rationale": rationale,
-                            "judge_model": "router:judge",
+                            "judge_model": model_used,
                         },
                     )
                     scored += 1
@@ -240,10 +240,13 @@ class J9EvalBatchExecutor:
 
     async def _judge_relevance(
         self, query: str, memory_content: str,
-    ) -> tuple[float | None, str]:
-        """Ask the judge model to score relevance via the router."""
+    ) -> tuple[float | None, str, str]:
+        """Ask the judge model to score relevance via the router.
+
+        Returns (relevance_score, rationale_or_error, model_used).
+        """
         if self._router is None:
-            return (None, "no router configured")
+            return (None, "no router configured", "none")
 
         prompt = _RELEVANCE_PROMPT.format(
             query=query[:500],
@@ -254,19 +257,21 @@ class J9EvalBatchExecutor:
                 call_site_id="judge",
                 messages=[{"role": "user", "content": prompt}],
                 temperature=0.0,
+                max_tokens=150,
             )
+            model_used = result.model_id or result.provider_used or "router:judge"
             if not result.success:
                 logger.debug("J9 relevance routing failed: %s", result.error)
-                return (None, result.error or "routing failed")
+                return (None, result.error or "routing failed", model_used)
             text = result.content or ""
             # Parse JSON response
             parsed = json.loads(text.strip())
             relevance = float(parsed.get("relevance", 0.0))
             rationale = parsed.get("rationale", "")
-            return (max(0.0, min(1.0, relevance)), rationale)
+            return (max(0.0, min(1.0, relevance)), rationale, model_used)
         except (json.JSONDecodeError, KeyError, ValueError) as exc:
             logger.debug("J9 relevance parse error: %s", exc)
-            return (None, str(exc))
+            return (None, str(exc), "router:judge")
         except Exception as exc:
             logger.debug("J9 relevance LLM error: %s", exc)
-            return (None, str(exc))
+            return (None, str(exc), "router:judge")

--- a/src/genesis/modules/external/adapter.py
+++ b/src/genesis/modules/external/adapter.py
@@ -136,6 +136,8 @@ class ExternalProgramAdapter:
         The program's API decides how to handle it. If no specific endpoint
         is configured, this is a no-op.
         """
+        if not self._enabled:
+            return None
         if not self._healthy:
             logger.debug("Skipping opportunity for unhealthy module '%s'", self.name)
             return None
@@ -154,6 +156,8 @@ class ExternalProgramAdapter:
 
     async def record_outcome(self, outcome: dict) -> None:
         """Forward outcome to the external program if it has an outcome endpoint."""
+        if not self._enabled:
+            return
         if not self._healthy:
             return
         try:

--- a/src/genesis/runtime/init/surplus.py
+++ b/src/genesis/runtime/init/surplus.py
@@ -190,7 +190,7 @@ async def init(rt: GenesisRuntime) -> None:
         # J-9 eval batch executor (daily memory relevance scoring)
         try:
             from genesis.eval.j9_batch import J9EvalBatchExecutor
-            j9_executor = J9EvalBatchExecutor(db=rt._db)
+            j9_executor = J9EvalBatchExecutor(db=rt._db, router=rt._router)
             rt._surplus_scheduler.set_j9_eval_batch_executor(j9_executor)
             logger.info("J9EvalBatchExecutor wired to surplus scheduler")
         except (ImportError, AttributeError):


### PR DESCRIPTION
## Summary
- J9EvalBatchExecutor was calling `litellm.acompletion(model="claude-haiku-4-5-20251001")` directly — no API key configured, so every relevance judgment silently failed (268+ errors per batch at DEBUG level)
- Tasks were marked successful with 0 actual results (12 enqueues, 1 eval_run in 4+ days)
- Fix: route through the Genesis router via the existing `"judge"` call site
- Removes `litellm` dependency and `_JUDGE_MODEL` constant from this module

## Test plan
- [x] `pytest tests/test_eval/ -v` — 95 passed
- [x] `ruff check` — clean
- [ ] CI passes
- [ ] After server restart: verify eval_snapshots table gets new entries from J9 batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)