### PR TITLE
chore: backfill procedure embeddings + fix stale search docs

### DIFF
--- a/.claude/agents/genesis-researcher.md
+++ b/.claude/agents/genesis-researcher.md
@@ -9,7 +9,7 @@ You are a research agent for Genesis with access to powerful web and code intell
 ## Web Tools (MCP — use these, NOT CC WebFetch/WebSearch)
 
 - **`web_fetch(url)`** — Fetch any URL with smart anti-bot bypass. Scrapling TLS impersonation → Crawl4AI JS rendering → httpx. Returns structured content.
-- **`web_search(query)`** — Search the web via SearXNG (unlimited, self-hosted) → Brave fallback. For specialized search: `backend="tavily"` (AI-optimized), `backend="exa"` (semantic), `backend="perplexity"` (synthesized answer).
+- **`web_search(query)`** — Search the web via TinyFish (primary) → SearXNG (self-hosted fallback) → Brave. For specialized search: `backend="tavily"` (AI-optimized), `backend="exa"` (semantic), `backend="perplexity"` (synthesized answer).
 - **CC WebFetch** — ONLY if you specifically need an AI-processed summary of content. Otherwise use `web_fetch`.
 - **CC WebSearch** — ONLY for trivial general lookups. Otherwise use `web_search`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ one matches.
 
 **MCP tools (canonical — work in ALL session types):**
 - `web_fetch(url)` — fetch any URL with anti-bot bypass (Scrapling→Crawl4AI→httpx)
-- `web_search(query)` — search web (SearXNG→Brave, or explicit tavily/exa/perplexity)
+- `web_search(query)` — search web (TinyFish→SearXNG→Brave, or explicit tavily/exa/perplexity)
 
 **CC built-in tools (foreground convenience):**
 - CC `WebFetch` — AI-processed summary (use when you need a summary, not raw content)

--- a/scripts/backfill_procedure_embeddings.py
+++ b/scripts/backfill_procedure_embeddings.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""One-time backfill: embed procedural_memory principles that are missing embeddings.
+
+The proactive procedure hook (PR #321) uses cosine similarity on
+principle_embedding to surface relevant procedures. Rows with NULL embedding
+are invisible to that hook.
+
+Usage:
+    source ~/genesis/.venv/bin/activate
+    python scripts/backfill_procedure_embeddings.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+logger = logging.getLogger("backfill_procedure_embeddings")
+
+
+async def main(dry_run: bool = False) -> None:
+    import aiosqlite
+
+    from genesis.env import genesis_db_path
+    from genesis.learning.procedural.embedding import pack_embedding
+    from genesis.memory.embeddings import EmbeddingProvider
+
+    db_path = genesis_db_path()
+    db = await aiosqlite.connect(str(db_path))
+    db.row_factory = aiosqlite.Row
+
+    embedding = EmbeddingProvider()
+
+    # Select all procedures with NULL principle_embedding
+    cursor = await db.execute(
+        "SELECT id, task_type, principle FROM procedural_memory "
+        "WHERE principle_embedding IS NULL "
+        "ORDER BY created_at ASC",
+    )
+    rows = [dict(row) for row in await cursor.fetchall()]
+    logger.info("Found %d procedures with missing embeddings", len(rows))
+
+    if not rows:
+        logger.info("Nothing to backfill. Exiting.")
+        await db.close()
+        return
+
+    if dry_run:
+        logger.info("DRY RUN — would embed %d procedures:", len(rows))
+        for row in rows:
+            logger.info(
+                "  [%s] %s: %s",
+                row["id"][:8], row["task_type"], row["principle"][:80],
+            )
+        await db.close()
+        return
+
+    succeeded = 0
+    failed = 0
+    for i, row in enumerate(rows):
+        proc_id = row["id"]
+        principle = row["principle"]
+        try:
+            vector = await embedding.embed(principle)
+            blob = pack_embedding(vector)
+            await db.execute(
+                "UPDATE procedural_memory SET principle_embedding = ? WHERE id = ?",
+                (blob, proc_id),
+            )
+            await db.commit()
+            succeeded += 1
+            logger.info(
+                "  [%d/%d] Embedded %s (%s)",
+                i + 1, len(rows), proc_id[:8], row["task_type"],
+            )
+        except Exception:
+            failed += 1
+            logger.warning(
+                "  [%d/%d] FAILED %s (%s)",
+                i + 1, len(rows), proc_id[:8], row["task_type"],
+                exc_info=True,
+            )
+
+    logger.info(
+        "Backfill complete: %d succeeded, %d failed out of %d",
+        succeeded, failed, len(rows),
+    )
+    await db.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Backfill missing principle_embedding in procedural_memory",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be done without writing")
+    args = parser.parse_args()
+    asyncio.run(main(dry_run=args.dry_run))

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -89,6 +89,7 @@ async def test_no_unexpected_tables(db):
         "eval_events", "eval_snapshots",
         "memory_events",
         "user_goals", "user_contacts",
+        "tool_call_outcomes",
     }
     for table in tables:
         assert table in known, f"Unexpected table: {table}"

--- a/tests/test_mcp/test_web_tools.py
+++ b/tests/test_mcp/test_web_tools.py
@@ -88,21 +88,23 @@ class TestWebFetch:
             title="",
             status_code=403,
         )
-        with patch("genesis.mcp.health.web_tools._get_fetcher") as mock_fetcher:
+        with (
+            patch("genesis.mcp.health.web_tools._get_fetcher") as mock_fetcher,
+            patch("genesis.mcp.health.web_tools._try_ladder_fetch", return_value=None),
+            patch("genesis.mcp.health.web_tools._try_crawl4ai") as mock_crawl,
+        ):
             mock_fetcher.return_value.fetch = AsyncMock(return_value=challenge_result)
-            with patch("genesis.mcp.health.web_tools._try_ladder_fetch", return_value=None):
-                with patch("genesis.mcp.health.web_tools._try_crawl4ai") as mock_crawl:
-                    mock_crawl.return_value = {
-                        "url": "https://protected.com",
-                        "title": "Real Page",
-                        "content": "JS rendered content",
-                        "backend_used": "crawl4ai",
-                        "status_code": 200,
-                        "truncated": False,
-                        "error": None,
-                        "latency_ms": 2000.0,
-                    }
-                    result = await _impl_web_fetch("https://protected.com", "auto", 50000)
+            mock_crawl.return_value = {
+                "url": "https://protected.com",
+                "title": "Real Page",
+                "content": "JS rendered content",
+                "backend_used": "crawl4ai",
+                "status_code": 200,
+                "truncated": False,
+                "error": None,
+                "latency_ms": 2000.0,
+            }
+            result = await _impl_web_fetch("https://protected.com", "auto", 50000)
 
         assert result["backend_used"] == "crawl4ai"
         assert result["content"] == "JS rendered content"


### PR DESCRIPTION
## Summary
- Add `scripts/backfill_procedure_embeddings.py` — one-off script to embed all `procedural_memory` rows with NULL `principle_embedding` via Ollama. 21 procedures were invisible to the proactive procedure hook (PR #321, cosine similarity matching).
- Fix stale search provider chain in CLAUDE.md and genesis-researcher.md: `SearXNG→Brave` → `TinyFish→SearXNG→Brave` (TinyFish became primary in PR #292).

## Verification
- Script ran successfully: 21/21 embedded, 0 failures
- `SELECT COUNT(*) FROM procedural_memory WHERE principle_embedding IS NULL` → 0
- Re-run is idempotent (finds 0, exits cleanly)
- `ruff check` passes

## From
Handoff tasks #5 and #10 from genesis-followup-handoff.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)