### PR TITLE
feat(ego): enforce jurisdiction separation between user and genesis egos

### DIFF
--- a/src/genesis/cc/session_config.py
+++ b/src/genesis/cc/session_config.py
@@ -32,6 +32,7 @@ _READONLY_DISALLOWED = [
 # Module-level constant (immutable intent), consistent with _READONLY_DISALLOWED.
 _MCP_PROFILES: dict[str, list[str]] = {
     "reflection": ["genesis-health", "genesis-memory"],
+    "user_reflection": ["genesis-memory"],  # User ego: memory only, no health tools
     "sentinel": ["genesis-health", "genesis-memory", "genesis-outreach"],
     "interop": ["genesis-health", "genesis-memory"],
 }

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -2,7 +2,8 @@
 
 The user ego sees the world through the user's eyes: their conversations,
 their interests, their pending work, and what Genesis can do for them.
-Genesis-internal details are compressed to a one-line status.
+Genesis infrastructure is intentionally excluded — system issues reach
+the user ego ONLY via genesis ego escalations.
 
 This is an automated prompt generator — it builds the prompt the user
 WOULD give if they were sitting here. The quality of this prompt
@@ -30,6 +31,25 @@ _USER_WORLD_CATEGORIES = frozenset({
     "contribution", "user_model_delta",
 })
 
+# Keywords indicating a session is about Genesis internals (not user-world).
+# Used to annotate conversation transcripts so the user ego knows which
+# sessions fall under the Genesis ego's jurisdiction.
+_GENESIS_INTERNAL_KEYWORDS = frozenset({
+    "surplus", "dream cycle", "dream_cycle", "genesis runtime",
+    "routing config", "circuit breaker", "guardian", "sentinel", "qdrant",
+    "awareness loop", "health check", "dead letter", "model_routing",
+    "worktree", "genesis-development", "dashboard fix", "ego cycle",
+    "model eval", "surplus_task", "provider fallback", "watchdog",
+    "systemd", "genesis server", "eval batch", "j9 eval",
+    "runtime init", "embedding chain", "embedding fallback",
+})
+
+
+def _is_genesis_internal(topic: str) -> bool:
+    """Check if a session topic is about Genesis internals."""
+    topic_lower = topic.lower()
+    return any(kw in topic_lower for kw in _GENESIS_INTERNAL_KEYWORDS)
+
 
 class UserEgoContextBuilder:
     """Builds the user-focused operational briefing for the user ego.
@@ -44,19 +64,21 @@ class UserEgoContextBuilder:
     4. User-world observations — email, inbox, findings
     5. Genesis ego escalations — things Genesis can't resolve alone
     6. Capabilities — what Genesis CAN do but ISN'T doing
-    7. Minimal system status — one-line health summary
-    8. Open threads — pending follow-ups
+    7. Open threads — pending follow-ups
+
+    NOTE: System health is intentionally EXCLUDED. The user ego has no
+    jurisdiction over Genesis infrastructure. System issues reach it ONLY
+    via genesis ego escalations (source 5 above).
     """
 
     def __init__(
         self,
         *,
         db: aiosqlite.Connection,
-        health_data: Any | None = None,
+        health_data: Any | None = None,  # Retained for API compat; unused
         capabilities: dict[str, str] | None = None,
     ) -> None:
         self._db = db
-        self._health_data = health_data
         self._capabilities = capabilities or {}
 
     async def build(self) -> str:
@@ -78,7 +100,8 @@ class UserEgoContextBuilder:
         sections.append(await self._backlog_summary_section())
         sections.append(await self._genesis_escalations_section())
         sections.append(await self._capabilities_section())
-        sections.append(await self._system_status_section())
+        # System status removed — user ego has no jurisdiction over Genesis
+        # health.  System issues reach it ONLY via genesis ego escalations.
         sections.append(await self._follow_ups_section())
         sections.append(await self._proposal_history_section())
         sections.append(await self._proposal_board_section())
@@ -389,11 +412,12 @@ class UserEgoContextBuilder:
             short_topic = topic[:200] + "..." if len(topic) > 200 else topic
             short_topic = short_topic.replace("\n", " ")
             ts = started_at[:16] if started_at else "?"
-            lines.append(f"- [{ts}] ({model}) {short_topic}")
+            domain = " [Genesis internal]" if _is_genesis_internal(short_topic) else ""
+            lines.append(f"- [{ts}] ({model}) {short_topic}{domain}")
 
         lines.append(
-            "\nThese show what the user is actively working on. "
-            "Unfinished threads are opportunities to help.\n"
+            "\nSessions marked [Genesis internal] are system development work — "
+            "the Genesis ego's domain. Focus on user-facing threads only.\n"
         )
         return "\n".join(lines)
 
@@ -530,50 +554,6 @@ class UserEgoContextBuilder:
             "\nThink about which capabilities could serve the user "
             "that aren't being used enough.\n"
         )
-        return "\n".join(lines)
-
-    async def _system_status_section(self) -> str:
-        """Compressed one-liner — only RED items matter to the user ego."""
-        lines = ["## System Status (summary)\n"]
-
-        if not self._health_data:
-            lines.append("*Health data not available.*\n")
-            return "\n".join(lines)
-
-        try:
-            snap = await self._health_data.snapshot()
-        except Exception:
-            lines.append("*Health snapshot failed.*\n")
-            return "\n".join(lines)
-
-        resilience = snap.get("resilience", "unknown")
-        infra = snap.get("infrastructure", {})
-
-        # Only surface degraded/down items
-        problems = []
-        for key, val in sorted(infra.items()):
-            if isinstance(val, dict):
-                status = val.get("status", "?")
-                if status not in ("ok", "healthy"):
-                    problems.append(f"{key}: {status}")
-            elif isinstance(val, str) and val not in ("ok", "healthy"):
-                problems.append(f"{key}: {val}")
-
-        if problems:
-            lines.append(f"**State**: {resilience} — issues: {', '.join(problems)}")
-        else:
-            lines.append(f"**State**: {resilience} — all systems nominal.")
-
-        lines.append(
-            "\nGenesis ego handles infrastructure. Only act on system "
-            "issues if they directly impact the user.\n"
-        )
-
-        # Cost tracking is NOT the user ego's domain — it belongs to the
-        # Genesis ego (see genesis_context.py) or the dashboard.  Removed
-        # per audit: user ego was creating cost-focused follow-ups.
-
-        lines.append("")
         return "\n".join(lines)
 
     async def _follow_ups_section(self) -> str:

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -120,6 +120,31 @@ Add an escalation when:
   escalate the operational issue only. The user ego decides what matters
   to the user. You fix what's broken.
 
+### Signal Threshold — What Deserves Your Attention
+
+Not all system changes are worth your cognitive budget. Apply these filters:
+
+**Act on (propose fix or escalate):**
+- Actual failures: something that worked yesterday is broken today
+- Trend toward failure: a metric growing linearly toward a hard limit
+- Cascading degradation: one failure causing others
+- User-impacting: something the user will notice in their experience
+
+**Ignore (noise, not signal):**
+- Normal fluctuations: memory usage varying by 5-10% is not news
+- Single data points without trend: one timeout, one retry, one fallback
+- Metrics that self-heal: circuit breaker cycling is designed behavior
+- Dashboard cosmetics: widgets showing yellow with no user impact
+
+A metric changing is not news. A metric BREAKING is news. Don't report
+observations — report decisions and actions.
+
+### No Autonomous Code Execution
+
+Do NOT propose dispatching autonomous code fixes. You may diagnose issues and
+recommend the user address them in a foreground session, but autonomous code
+execution is a future capability. Your role is diagnosis and recommendation.
+
 ## Persistent Memory
 
 Store findings via memory_store:

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -256,6 +256,35 @@ These are hard limits on what you think about:
   Do not position Genesis capabilities as solutions to the user's
   personal career goals.
 
+### Genesis Internals Are Not Your Domain
+
+When foreground sessions show the user working on Genesis itself — fixing bugs,
+debugging infrastructure, reviewing surplus/eval/routing/memory code — this is
+NOT your concern. The user sometimes works on Genesis as a developer. That work
+falls under the Genesis ego's jurisdiction.
+
+Do NOT:
+- Investigate system health, infrastructure metrics, or Genesis operational
+  state. You do not have health tools — this is by design.
+- Adopt Genesis development topics from conversation transcripts as your focus.
+  If the user spent 2 hours fixing the dream cycle, that does not make dream
+  cycle YOUR priority.
+- Report on anything that belongs to the Genesis ego (surplus status, eval
+  metrics, provider failures, container resources, scheduling).
+
+DO:
+- Note that the user has been deep in technical work and think about what they
+  might be neglecting (career, relationships, goals, rest).
+- Think about what Genesis could do FOR the user, not what's broken IN Genesis.
+- If Genesis has an issue that impacts the user's experience, you'll see it as
+  a Genesis ego escalation — that's the ONLY path for system issues to reach you.
+
+### No Autonomous Code Execution
+
+Do NOT propose dispatching code fixes, refactors, or feature work. Autonomous
+code execution is a future capability. You may recommend the user address
+something in a foreground session, but you cannot dispatch coding work.
+
 ## Constraints
 
 You are in **proposal mode**. New actions require user approval via

--- a/src/genesis/runtime/init/ego.py
+++ b/src/genesis/runtime/init/ego.py
@@ -60,9 +60,13 @@ async def init(rt: GenesisRuntime) -> None:
             logger.info("Ego disabled by config — skipping")
             return
 
-        # MCP config: reflection profile (genesis-health + genesis-memory)
+        # MCP configs: user ego gets memory-only, genesis ego gets full health+memory.
+        # User ego has no need for health tools — its jurisdiction is the user's
+        # world, not Genesis infrastructure. System issues reach it only via
+        # genesis ego escalations.
         config_builder = SessionConfigBuilder()
-        mcp_config_path = config_builder.build_mcp_config("reflection")
+        user_ego_mcp_path = config_builder.build_mcp_config("user_reflection")
+        genesis_ego_mcp_path = config_builder.build_mcp_config("reflection")
 
         # -- Shared components --
         # ProposalWorkflow is shared — both egos create proposals that go
@@ -109,7 +113,7 @@ async def init(rt: GenesisRuntime) -> None:
             db=rt._db,
             event_bus=rt._event_bus,
             direct_session_runner=rt._direct_session_runner,
-            mcp_config_path=mcp_config_path,
+            mcp_config_path=user_ego_mcp_path,
             prompt_path=_IDENTITY_DIR / "USER_EGO_SESSION.md",
             call_site="7_user_ego_cycle",
             session_id_key="user_ego_cc_session_id",
@@ -182,7 +186,7 @@ async def init(rt: GenesisRuntime) -> None:
             db=rt._db,
             event_bus=rt._event_bus,
             direct_session_runner=rt._direct_session_runner,
-            mcp_config_path=mcp_config_path,
+            mcp_config_path=genesis_ego_mcp_path,
             prompt_path=_IDENTITY_DIR / "GENESIS_EGO_SESSION.md",
             call_site="7_genesis_ego_cycle",
             session_id_key="genesis_ego_cc_session_id",

--- a/tests/ego/test_user_context.py
+++ b/tests/ego/test_user_context.py
@@ -417,52 +417,20 @@ class TestUserEgoContextBuilder:
         result = await builder.build()
         assert "No capabilities registered" in result
 
-    # ── System Status ───────────────────────────────────────────────────
+    # ── System Status (removed from user ego) ─────────────────────────
 
     @pytest.mark.asyncio
-    async def test_system_status_healthy(self, db, mock_health_data, capabilities):
+    async def test_no_system_status_section(self, db, mock_health_data, capabilities):
+        """System status is intentionally excluded from user ego context.
+
+        User ego has no jurisdiction over Genesis health — system issues
+        reach it only via genesis ego escalations.
+        """
         builder = UserEgoContextBuilder(
             db=db, health_data=mock_health_data, capabilities=capabilities,
         )
         result = await builder.build()
-        assert "## System Status" in result
-        assert "all systems nominal" in result
-
-    @pytest.mark.asyncio
-    async def test_system_status_degraded(self, db, capabilities):
-        hd = AsyncMock()
-        hd.snapshot.return_value = {
-            "infrastructure": {
-                "genesis.db": {"status": "healthy", "latency_ms": 0.5},
-                "qdrant": {"status": "degraded", "latency_ms": 5000.0},
-                "ollama": {"status": "down", "latency_ms": None},
-            },
-            "resilience": "degraded",
-        }
-        builder = UserEgoContextBuilder(
-            db=db, health_data=hd, capabilities=capabilities,
-        )
-        result = await builder.build()
-        assert "qdrant: degraded" in result
-        assert "ollama: down" in result
-
-    @pytest.mark.asyncio
-    async def test_system_status_no_health_data(self, db, capabilities):
-        builder = UserEgoContextBuilder(
-            db=db, health_data=None, capabilities=capabilities,
-        )
-        result = await builder.build()
-        assert "Health data not available" in result
-
-    @pytest.mark.asyncio
-    async def test_system_status_snapshot_failure(self, db, capabilities):
-        hd = AsyncMock()
-        hd.snapshot.side_effect = RuntimeError("DB locked")
-        builder = UserEgoContextBuilder(
-            db=db, health_data=hd, capabilities=capabilities,
-        )
-        result = await builder.build()
-        assert "Health snapshot failed" in result
+        assert "## System Status" not in result
 
     # ── Output Contract ─────────────────────────────────────────────────
 
@@ -496,7 +464,6 @@ class TestUserEgoContextBuilder:
             "## Backlogs",
             "## Genesis Ego Escalations",
             "## Genesis Capabilities",
-            "## System Status",
             "## Open Threads",
             "## Recent Proposals",
             "## Recurring Patterns (72h)",


### PR DESCRIPTION
## Summary

- **MCP profile split**: User ego gets `genesis-memory` only (no health tools). Genesis ego retains full `genesis-health` + `genesis-memory`. Prevents user ego from investigating system health.
- **System status removed**: User ego context no longer includes system health section. System issues reach it ONLY via genesis ego escalations.
- **Session domain annotations**: Foreground conversation transcripts are tagged `[Genesis internal]` via keyword matching, so user ego knows which sessions are outside its jurisdiction.
- **Prompt hardening**: Both ego identity prompts updated with explicit jurisdiction rules, signal thresholds, and no-autonomous-code-execution gates.

## Why

User ego was reporting on Genesis internals (dream cycle failures, surplus failure rates, container memory). Root cause: shared MCP profile gave it health tools + system_status section triggered investigation. Fix enforces the principle that each ego lives in its own curated world.

## Test plan

- [x] `pytest tests/ego/ tests/test_ego/` — 490 passed
- [x] `ruff check` — clean
- [x] MCP config generation verified: `user_reflection` produces genesis-memory only
- [x] Keyword false-positive review (removed bare "eval", "runtime", "embedding")
- [ ] After merge + server restart: verify user ego cycle focus excludes Genesis internals
- [ ] Verify genesis ego still has full health tool access