### PR TITLE
fix(ego): show clear FAILED/OK outcome in proposal context table

### DIFF
--- a/src/genesis/ego/context.py
+++ b/src/genesis/ego/context.py
@@ -364,14 +364,23 @@ class EgoContextBuilder:
             lines.append("*No proposals in last 7 days.*\n")
             return "\n".join(lines)
 
-        lines.append("| Action | Category | Status | Response |")
-        lines.append("|--------|----------|--------|----------|")
+        lines.append("| Action | Category | Status | Outcome | Content |")
+        lines.append("|--------|----------|--------|---------|---------|")
         for action_type, category, content, status, response, _created in rows:
-            short = content[:80] + "..." if len(content) > 80 else content
+            short = content[:60] + "..." if len(content) > 60 else content
             short = short.replace("\n", " ").replace("|", "/")
-            resp = (response or "—")[:50]
+            # Parse outcome from user_response: "session:xxx|failed:reason"
+            resp = response or ""
+            if "|failed:" in resp:
+                outcome = "FAILED: " + resp.split("|failed:", 1)[1][:60]
+            elif "|completed:" in resp:
+                outcome = "OK: " + resp.split("|completed:", 1)[1][:60]
+            elif status == "executed" and resp and not resp.startswith("dispatching"):
+                outcome = "dispatched"
+            else:
+                outcome = "—"
             lines.append(
-                f"| {action_type} | {category} | {status} | {resp} |"
+                f"| {action_type} | {category} | {status} | {outcome} | {short} |"
             )
 
         lines.append("")

--- a/src/genesis/ego/context.py
+++ b/src/genesis/ego/context.py
@@ -379,6 +379,7 @@ class EgoContextBuilder:
                 outcome = "dispatched"
             else:
                 outcome = "—"
+            outcome = outcome.replace("|", "/").replace("\n", " ")
             lines.append(
                 f"| {action_type} | {category} | {status} | {outcome} | {short} |"
             )


### PR DESCRIPTION
## Summary

- The ego context builder truncated `user_response` to 50 chars, hiding the `|failed:` suffix that indicates dispatch failure
- Ego saw `session:uuid|fail` and couldn't distinguish success from failure — kept proposing social posts "for 3 published Medium articles" when no article was ever published
- Now parses `|failed:` and `|completed:` into a clear Outcome column: `FAILED: Session timed out (900s)...`

## Root cause

PR #365 added outcome feedback (`|failed:reason` appended to `user_response`), but the context builder only showed the first 50 chars — the failure message was always truncated away.

## Test plan

- [x] 5 ego tests pass
- [x] Ruff lint clean
- [ ] CI
- [ ] Live: ego sees `FAILED:` in its context and proposes publish retry instead of social posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)