### PR TITLE
fix(update): timeout extension, dirty-tree guard, better merge failure messages

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -132,11 +132,16 @@ fi
 if [[ "$POST_MERGE" == "false" ]]; then
     DIRTY_FILES=$(git -C "$GENESIS_ROOT" status --porcelain 2>/dev/null | grep -v "^??")
     if [[ -n "$DIRTY_FILES" ]]; then
-        echo "ERROR: Working tree has uncommitted changes. Commit or stash them first:"
+        echo "ERROR: Working tree has uncommitted changes. Clean them up first:"
         echo "$DIRTY_FILES"
         echo ""
-        echo "  git stash        # to save and restore after update"
-        echo "  git add -p && git commit -m 'chore: save local changes'  # to commit"
+        # Mid-merge state (UU/AA entries) needs abort, not stash/commit
+        if git -C "$GENESIS_ROOT" rev-parse --verify MERGE_HEAD &>/dev/null; then
+            echo "  Repo is mid-merge. Run: git merge --abort"
+        else
+            echo "  git stash        # save and restore after update"
+            echo "  git add -p && git commit -m 'chore: save local changes'  # commit"
+        fi
         exit 1
     fi
 fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -125,6 +125,22 @@ if [ -x "$GENESIS_ROOT/scripts/backup.sh" ]; then
     echo ""
 fi
 
+# ── Dirty-tree guard ─────────────────────────────────────
+# Abort before touching anything if tracked files are modified.
+# Untracked files (^??) are excluded — merge/reset never touches them.
+# git reset --hard in _do_rollback would silently discard uncommitted work.
+if [[ "$POST_MERGE" == "false" ]]; then
+    DIRTY_FILES=$(git -C "$GENESIS_ROOT" status --porcelain 2>/dev/null | grep -v "^??")
+    if [[ -n "$DIRTY_FILES" ]]; then
+        echo "ERROR: Working tree has uncommitted changes. Commit or stash them first:"
+        echo "$DIRTY_FILES"
+        echo ""
+        echo "  git stash        # to save and restore after update"
+        echo "  git add -p && git commit -m 'chore: save local changes'  # to commit"
+        exit 1
+    fi
+fi
+
 # ── Rollback tag ─────────────────────────────────────────
 ROLLBACK_TAG="pre-update-$(date +%Y%m%d-%H%M%S)"
 if [[ "$POST_MERGE" == "true" ]] && [ -f "$STATE_FILE" ]; then
@@ -489,9 +505,12 @@ CEOF
         trap - ERR
         exit 2
     else
-        # Not a conflict — some other merge error. Let ERR trap handle rollback.
+        # Not a conflict — some other merge error. Call rollback directly so the
+        # DB gets a meaningful reason instead of "command failed (exit 1): false".
         echo "  Merge failed: $MERGE_OUTPUT"
-        false  # triggers ERR trap → rollback
+        trap - ERR
+        _do_rollback "git merge failed: $(echo "$MERGE_OUTPUT" | head -3 | tr '\n' ' ')"
+        exit 1
     fi
 fi
 

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1209,10 +1209,10 @@
                 }
               }
             } catch (e) { /* server may be restarting, keep polling */ }
-            if (Date.now() - start > 300000) {
+            if (Date.now() - start > 900000) {
               clearInterval(poll);
               this._updating = false;
-              alert("Update did not complete after 5 minutes.\nCheck server logs for status.");
+              alert("Update did not complete after 15 minutes.\nCheck server logs for status.");
               await this.fetchUpdateStatus();
             }
           }, 5000);
@@ -1242,7 +1242,7 @@
             } catch (e) { /* keep polling */ }
           }, 5000);
           // Safety timeout
-          setTimeout(() => { clearInterval(poll); this._resolvingConflicts = false; }, 600000);
+          setTimeout(() => { clearInterval(poll); this._resolvingConflicts = false; }, 900000);
         },
 
         async dismissUpdate() {

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1241,8 +1241,13 @@
               }
             } catch (e) { /* keep polling */ }
           }, 5000);
-          // Safety timeout
-          setTimeout(() => { clearInterval(poll); this._resolvingConflicts = false; }, 900000);
+          // Safety timeout — alert and refresh status so user isn't left with a blank UI
+          setTimeout(async () => {
+            clearInterval(poll);
+            this._resolvingConflicts = false;
+            alert("Conflict resolution did not complete after 15 minutes.\nCheck server logs for status.");
+            await this.fetchUpdateStatus();
+          }, 900000);
         },
 
         async dismissUpdate() {


### PR DESCRIPTION
## Summary

- **Frontend polling timeout 5 min → 15 min** — the 3-tier CC pipeline (Haiku → Sonnet escalation) routinely exceeds 5 minutes; the dashboard was firing an alert before the backend finished. Both `applyUpdate()` and `resolveConflicts()` timeouts updated to 900s. `resolveConflicts()` timeout now emits an alert and refreshes status instead of silently resetting the UI.
- **update.sh: early dirty-tree guard** — aborts before creating any rollback tag or touching the DB if tracked files are modified. Prevents rollback from silently discarding uncommitted local work. Untracked files (`data/`, etc.) are excluded — merge never touches them. Detects mid-merge state (MERGE_HEAD) and emits `git merge --abort` guidance instead of misleading stash/commit instructions.
- **update.sh: descriptive merge failure reason** — replaces bare `false` ERR-trap trigger with a direct `_do_rollback` call so the DB `failure_reason` reads `"git merge failed: <output>"` instead of the opaque `"command failed (exit 1): false"`.

## Test plan

- [ ] `pytest tests/test_dashboard/test_update_template.py -v` passes (verified locally)
- [ ] Introduce a tracked file modification, run `bash scripts/update.sh` — should exit immediately with "uncommitted changes" message, no rollback tag created, no DB entry written
- [ ] Introduce an untracked file only — guard should not fire, update proceeds normally
- [ ] Confirm `grep -n "900000" src/genesis/dashboard/templates/genesis_dashboard.html` shows both timeout sites and no `300000`/`600000` remain in the update flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)