### PR TITLE
fix(dashboard): state-based silent-death detection for update polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Changed
+
+- **Update polling** --- replaced 15-minute wall-clock timeout in the
+  dashboard update flow with state-based silent-death detection. The
+  poller now tracks whether the update process was ever seen alive
+  (`seenInProgress`) and alerts within one 5-second poll cycle if the
+  process ends without leaving a summary, escalation, or conflict
+  record. A 30-second startup grace period prevents false positives
+  during the brief PID-write window at launch.
+
 ---
 
 ## [v3.0b10] - 2026-05-15

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1212,7 +1212,7 @@
                 }
               }
               // Silent-death detection: process ended without leaving any state
-              if (!prog.in_progress && !prog.summary && !prog.escalation && !prog.conflicts) {
+              if (!prog.in_progress && !prog.summary && !prog.escalation && !(prog.conflicts && prog.conflicts.length)) {
                 if (seenInProgress || Date.now() - start > 30000) {
                   clearInterval(poll);
                   this._updating = false;

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1170,11 +1170,13 @@
             });
           } catch (e) { /* expected — server may restart */ }
           const start = Date.now();
+          let seenInProgress = false;
           const poll = setInterval(async () => {
             try {
               await this.fetchUpdateProgress();
               const prog = this.updateProgress;
               if (!prog) return;
+              if (prog.in_progress) seenInProgress = true;
               // Conflicts detected — stop polling, show resolve UI
               if (prog.escalation && (prog.escalation.includes("tier3_needed") || prog.escalation.includes("tier2_needed"))
                   && !prog.in_progress) {
@@ -1206,15 +1208,20 @@
                   this._updating = false;
                   await this.fetchUpdateStatus();
                   await this.fetchHealth();
+                  return;
+                }
+              }
+              // Silent-death detection: process ended without leaving any state
+              if (!prog.in_progress && !prog.summary && !prog.escalation && !prog.conflicts) {
+                if (seenInProgress || Date.now() - start > 30000) {
+                  clearInterval(poll);
+                  this._updating = false;
+                  alert("Update process ended without completing.\nCheck server logs for status.");
+                  await this.fetchUpdateStatus();
+                  return;
                 }
               }
             } catch (e) { /* server may be restarting, keep polling */ }
-            if (Date.now() - start > 900000) {
-              clearInterval(poll);
-              this._updating = false;
-              alert("Update did not complete after 15 minutes.\nCheck server logs for status.");
-              await this.fetchUpdateStatus();
-            }
           }, 5000);
         },
         async resolveConflicts() {


### PR DESCRIPTION
## Summary

- Replaces the 15-minute wall-clock timeout in `applyUpdate()` with a `seenInProgress` flag that detects when the update process exits without leaving any state
- A 30-second startup grace period prevents false positives during the brief PID-write window between process launch and the orchestrator writing its PID
- Adds `return` to the health-fallback OK branch to prevent double-firing into the silent-death alert
- Guards the silent-death condition against `conflicts: []` — `![]` is `false` in JS, which would have caused infinite polling if the conflicts file existed but was empty

## Behavior

| Scenario | Before | After |
|---|---|---|
| Success | spinner clears | unchanged |
| Conflict / failed | escalation UI / error | unchanged |
| Server restarting | keep polling | keep polling |
| Process died, server healthy | health fallback clears spinner (no alert) | unchanged |
| Process died, server degraded | poll for 15 min, then alert | alert within one 5s cycle after death |
| Process never started | poll for 15 min, then alert | 30s grace, then alert |

## Test plan

- [ ] Template compiles: `pytest tests/test_dashboard/test_update_template.py -v`
- [ ] Grep confirms no `900000` remains in the update polling block
- [ ] Normal update flow completes without triggering the silent-death alert
- [ ] (Manual) Kill orchestrator PID mid-update → alert fires within 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)