### PR TITLE
fix(ego): split proposal context + settings hot-reload + cadence diagnostics

### DIFF
--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -328,7 +328,7 @@ class EgoCadenceManager:
     async def _on_tick(self) -> None:
         """Interval trigger handler. Checks all gates then runs cycle."""
         self._emit_heartbeat("tick")
-        logger.info(
+        logger.debug(
             "Ego tick fired (current_interval=%dm, config_cadence=%dm)",
             self._current_interval,
             self._config.cadence_minutes,

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -328,6 +328,11 @@ class EgoCadenceManager:
     async def _on_tick(self) -> None:
         """Interval trigger handler. Checks all gates then runs cycle."""
         self._emit_heartbeat("tick")
+        logger.info(
+            "Ego tick fired (current_interval=%dm, config_cadence=%dm)",
+            self._current_interval,
+            self._config.cadence_minutes,
+        )
         async with self._lock:
             if not self._should_run(skip_idle_check=False):
                 return
@@ -552,7 +557,23 @@ class EgoCadenceManager:
         - Idle cycle (no proposals): multiply by backoff_multiplier
         - Productive cycle: reset to base cadence_minutes
         - Max interval adapts to user recency (longer absence → higher cap)
+        - Hot-reloads config from disk so dashboard changes take effect
         """
+        # Hot-reload config from disk (allows dashboard changes without restart)
+        try:
+            from genesis.ego.config import load_ego_config
+
+            fresh = load_ego_config()
+            if fresh.cadence_minutes != self._config.cadence_minutes:
+                logger.info(
+                    "Ego config hot-reload: cadence %d → %d",
+                    self._config.cadence_minutes,
+                    fresh.cadence_minutes,
+                )
+            self._config = fresh
+        except Exception:
+            logger.debug("Config hot-reload failed, using cached", exc_info=True)
+
         recency_max = await self._recency_max_interval()
 
         if had_proposals:
@@ -563,6 +584,13 @@ class EgoCadenceManager:
                 recency_max,
             )
 
+        logger.info(
+            "Ego interval calc: new=%dm, current=%dm, had_proposals=%s, recency_max=%dm",
+            new_interval,
+            self._current_interval,
+            had_proposals,
+            recency_max,
+        )
         if new_interval != self._current_interval:
             old_interval = self._current_interval
             self._current_interval = new_interval

--- a/src/genesis/ego/context.py
+++ b/src/genesis/ego/context.py
@@ -405,7 +405,7 @@ class EgoContextBuilder:
                 "user_response, created_at "
                 "FROM ego_proposals "
                 "WHERE created_at >= datetime('now', '-7 days') "
-                "AND status IN ('withdrawn', 'tabled', 'rejected', 'failed') "
+                "AND status IN ('withdrawn', 'tabled', 'rejected', 'failed', 'expired') "
                 "ORDER BY created_at DESC "
                 "LIMIT 10"
             )

--- a/src/genesis/ego/context.py
+++ b/src/genesis/ego/context.py
@@ -341,50 +341,87 @@ class EgoContextBuilder:
         lines.append("")
         return "\n".join(lines)
 
+    def _format_proposal_row(
+        self,
+        action_type: str,
+        category: str,
+        content: str,
+        status: str,
+        response: str | None,
+    ) -> str:
+        """Format a single proposal row for the context table."""
+        short = content[:60] + "..." if len(content) > 60 else content
+        short = short.replace("\n", " ").replace("|", "/")
+        # Parse outcome from user_response: "session:xxx|failed:reason"
+        resp = response or ""
+        if "|failed:" in resp:
+            outcome = "FAILED: " + resp.split("|failed:", 1)[1][:60]
+        elif "|completed:" in resp:
+            outcome = "OK: " + resp.split("|completed:", 1)[1][:60]
+        elif status == "executed" and resp and not resp.startswith("dispatching"):
+            outcome = "dispatched"
+        else:
+            outcome = "—"
+        outcome = outcome.replace("|", "/").replace("\n", " ")
+        return f"| {action_type} | {category} | {status} | {outcome} | {short} |"
+
     async def _proposal_history_section(self) -> str:
-        """Recent proposal outcomes for calibration."""
-        lines = ["## Recent Proposals (last 7 days)\n"]
+        """Recent proposal outcomes for calibration.
+
+        Split into two sections so active proposals are always visible
+        regardless of how many withdrawn/tabled proposals exist.
+        """
+        lines = ["## Active Proposals\n"]
+        table_header = (
+            "| Action | Category | Status | Outcome | Content |\n"
+            "|--------|----------|--------|---------|---------|"
+        )
 
         try:
+            # Section 1: Active proposals (pending, approved, executed)
             cursor = await self._db.execute(
                 "SELECT action_type, action_category, content, status, "
                 "user_response, created_at "
                 "FROM ego_proposals "
                 "WHERE created_at >= datetime('now', '-7 days') "
+                "AND status IN ('pending', 'approved', 'executed') "
                 "ORDER BY created_at DESC "
                 "LIMIT 15"
             )
-            rows = await cursor.fetchall()
-        except Exception:
-            # Table may not exist yet
-            lines.append("*No proposal history available.*\n")
-            return "\n".join(lines)
+            active_rows = await cursor.fetchall()
 
-        if not rows:
-            lines.append("*No proposals in last 7 days.*\n")
-            return "\n".join(lines)
-
-        lines.append("| Action | Category | Status | Outcome | Content |")
-        lines.append("|--------|----------|--------|---------|---------|")
-        for action_type, category, content, status, response, _created in rows:
-            short = content[:60] + "..." if len(content) > 60 else content
-            short = short.replace("\n", " ").replace("|", "/")
-            # Parse outcome from user_response: "session:xxx|failed:reason"
-            resp = response or ""
-            if "|failed:" in resp:
-                outcome = "FAILED: " + resp.split("|failed:", 1)[1][:60]
-            elif "|completed:" in resp:
-                outcome = "OK: " + resp.split("|completed:", 1)[1][:60]
-            elif status == "executed" and resp and not resp.startswith("dispatching"):
-                outcome = "dispatched"
+            if not active_rows:
+                lines.append("*No active proposals.*\n")
             else:
-                outcome = "—"
-            outcome = outcome.replace("|", "/").replace("\n", " ")
-            lines.append(
-                f"| {action_type} | {category} | {status} | {outcome} | {short} |"
-            )
+                lines.append(table_header)
+                for row in active_rows:
+                    lines.append(self._format_proposal_row(*row[:5]))
+                lines.append("")
 
-        lines.append("")
+            # Section 2: Recently tried (withdrawn, tabled, rejected, failed)
+            lines.append("## Recently Tried (do not re-propose)\n")
+            cursor2 = await self._db.execute(
+                "SELECT action_type, action_category, content, status, "
+                "user_response, created_at "
+                "FROM ego_proposals "
+                "WHERE created_at >= datetime('now', '-7 days') "
+                "AND status IN ('withdrawn', 'tabled', 'rejected', 'failed') "
+                "ORDER BY created_at DESC "
+                "LIMIT 10"
+            )
+            tried_rows = await cursor2.fetchall()
+
+            if not tried_rows:
+                lines.append("*No recently tried proposals.*\n")
+            else:
+                lines.append(table_header)
+                for row in tried_rows:
+                    lines.append(self._format_proposal_row(*row[:5]))
+                lines.append("")
+
+        except Exception:
+            lines.append("*No proposal history available.*\n")
+
         return "\n".join(lines)
 
     async def _intervention_history_section(self) -> str:

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -351,45 +351,72 @@ class GenesisEgoContextBuilder:
         return "\n".join(lines)
 
     async def _proposal_history_section(self) -> str:
-        """Recent proposal outcomes for self-calibration."""
-        lines = ["## Recent Proposals (last 7 days)\n"]
+        """Recent proposal outcomes for self-calibration.
+
+        Split into Active (pending/approved/executed) and Recently Tried
+        (withdrawn/tabled/rejected/failed/expired) so active proposals
+        are always visible regardless of withdrawn noise volume.
+        """
+        lines = ["## Active Proposals\n"]
+        table_header = (
+            "| Action | Content | Status | Response |\n"
+            "|--------|---------|--------|----------|"
+        )
 
         try:
+            # Section 1: Active proposals
             cursor = await self._db.execute(
                 "SELECT action_type, content, status, "
                 "user_response, created_at "
                 "FROM ego_proposals "
                 "WHERE created_at >= datetime('now', '-7 days') "
+                "AND status IN ('pending', 'approved', 'executed') "
                 "ORDER BY created_at DESC "
                 "LIMIT 15"
             )
-            rows = await cursor.fetchall()
+            active_rows = await cursor.fetchall()
+
+            if not active_rows:
+                lines.append("*No active proposals.*\n")
+            else:
+                lines.append(table_header)
+                for action_type, content, status, response, _created in active_rows:
+                    short = content[:80] + "..." if len(content) > 80 else content
+                    short = short.replace("\n", " ").replace("|", "/")
+                    resp = (response or "\u2014")[:50]
+                    lines.append(
+                        f"| {action_type} | {short} | {status} | {resp} |"
+                    )
+                lines.append("")
+
+            # Section 2: Recently tried
+            lines.append("## Recently Tried (do not re-propose)\n")
+            cursor2 = await self._db.execute(
+                "SELECT action_type, content, status, "
+                "user_response, created_at "
+                "FROM ego_proposals "
+                "WHERE created_at >= datetime('now', '-7 days') "
+                "AND status IN ('withdrawn', 'tabled', 'rejected', 'failed', 'expired') "
+                "ORDER BY created_at DESC "
+                "LIMIT 10"
+            )
+            tried_rows = await cursor2.fetchall()
+
+            if not tried_rows:
+                lines.append("*No recently tried proposals.*\n")
+            else:
+                lines.append(table_header)
+                for action_type, content, status, response, _created in tried_rows:
+                    short = content[:80] + "..." if len(content) > 80 else content
+                    short = short.replace("\n", " ").replace("|", "/")
+                    resp = (response or "\u2014")[:50]
+                    lines.append(
+                        f"| {action_type} | {short} | {status} | {resp} |"
+                    )
+                lines.append("")
+
         except Exception:
             lines.append("*No proposal history available.*\n")
-            return "\n".join(lines)
-
-        if not rows:
-            lines.append("*No proposals in last 7 days.*\n")
-            return "\n".join(lines)
-
-        # Summary line for quick calibration
-        from collections import Counter
-        status_counts = Counter(r[2] for r in rows)
-        parts = [f"{status_counts[s]} {s}" for s in
-                 ("approved", "rejected", "executed", "pending", "failed",
-                  "expired", "tabled", "withdrawn")
-                 if status_counts.get(s)]
-        lines.append(f"**{len(rows)} proposals**: {', '.join(parts)}\n")
-
-        lines.append("| Action | Content | Status | Response |")
-        lines.append("|--------|---------|--------|----------|")
-        for action_type, content, status, response, _created in rows:
-            short = content[:80] + "..." if len(content) > 80 else content
-            short = short.replace("\n", " ").replace("|", "/")
-            resp = (response or "\u2014")[:50]
-            lines.append(
-                f"| {action_type} | {short} | {status} | {resp} |"
-            )
 
         lines.append("")
         return "\n".join(lines)

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -614,36 +614,19 @@ class UserEgoContextBuilder:
     async def _proposal_history_section(self) -> str:
         """Recent proposal topics with neutral status for context.
 
-        Shows WHAT was proposed and its lifecycle outcome using neutral
-        labels (no judgment language). Also shows realist annotations
+        Split into Active and Recently Tried so active proposals are always
+        visible. Shows WHAT was proposed and its lifecycle outcome using
+        neutral labels (no judgment language). Also shows realist annotations
         when available. No aggregate scores, no user_response text —
         those trigger deference bias.
         """
-        lines = ["## Recent Proposals (last 7 days)\n"]
+        lines = ["## Active Proposals\n"]
+        table_header = (
+            "| Action | Topic | Outcome | Realist |\n"
+            "|--------|-------|---------|---------|"
+        )
 
-        try:
-            cursor = await self._db.execute(
-                "SELECT action_type, content, status, realist_verdict, "
-                "realist_reasoning, created_at "
-                "FROM ego_proposals "
-                "WHERE created_at >= datetime('now', '-7 days') "
-                "ORDER BY created_at DESC "
-                "LIMIT 15",
-            )
-            rows = await cursor.fetchall()
-        except Exception:
-            lines.append("*No proposal history available.*\n")
-            return "\n".join(lines)
-
-        if not rows:
-            lines.append("*No proposals in last 7 days.*\n")
-            return "\n".join(lines)
-
-        lines.append(f"**{len(rows)} proposals** in last 7 days:\n")
-
-        lines.append("| Action | Topic | Outcome | Realist |")
-        lines.append("|--------|-------|---------|---------|")
-        for row in rows:
+        def _format_row(row) -> str:
             action_type = row["action_type"]
             content = row["content"]
             short = content[:100] + "..." if len(content) > 100 else content
@@ -656,9 +639,53 @@ class UserEgoContextBuilder:
                     reason_short = row["realist_reasoning"][:60]
                     reason_short = reason_short.replace("|", "/")
                     realist = f"{realist}: {reason_short}"
-            lines.append(f"| {action_type} | {short} | {status} | {realist} |")
+            return f"| {action_type} | {short} | {status} | {realist} |"
 
-        lines.append("")
+        try:
+            # Section 1: Active proposals
+            cursor = await self._db.execute(
+                "SELECT action_type, content, status, realist_verdict, "
+                "realist_reasoning, created_at "
+                "FROM ego_proposals "
+                "WHERE created_at >= datetime('now', '-7 days') "
+                "AND status IN ('pending', 'approved', 'executed') "
+                "ORDER BY created_at DESC "
+                "LIMIT 15",
+            )
+            active_rows = await cursor.fetchall()
+
+            if not active_rows:
+                lines.append("*No active proposals.*\n")
+            else:
+                lines.append(table_header)
+                for row in active_rows:
+                    lines.append(_format_row(row))
+                lines.append("")
+
+            # Section 2: Recently tried
+            lines.append("## Recently Tried (do not re-propose)\n")
+            cursor2 = await self._db.execute(
+                "SELECT action_type, content, status, realist_verdict, "
+                "realist_reasoning, created_at "
+                "FROM ego_proposals "
+                "WHERE created_at >= datetime('now', '-7 days') "
+                "AND status IN ('withdrawn', 'tabled', 'rejected', 'failed', 'expired') "
+                "ORDER BY created_at DESC "
+                "LIMIT 10",
+            )
+            tried_rows = await cursor2.fetchall()
+
+            if not tried_rows:
+                lines.append("*No recently tried proposals.*\n")
+            else:
+                lines.append(table_header)
+                for row in tried_rows:
+                    lines.append(_format_row(row))
+                lines.append("")
+
+        except Exception:
+            lines.append("*No proposal history available.*\n")
+
         return "\n".join(lines)
 
     async def _proposal_board_section(self) -> str:

--- a/tests/ego/test_context.py
+++ b/tests/ego/test_context.py
@@ -238,7 +238,7 @@ class TestEgoContextBuilder:
             db=db, health_data=mock_health_data, capabilities=capabilities,
         )
         result = await builder.build()
-        assert "Recent Proposals" in result
+        assert "Active Proposals" in result
         assert "investigate" in result
         assert "approved" in result
 

--- a/tests/ego/test_genesis_context.py
+++ b/tests/ego/test_genesis_context.py
@@ -483,7 +483,7 @@ class TestGenesisEgoContextBuilder:
             "## Unresolved Observations",
             "## Maintenance Follow-ups",
             "## Cost Status",
-            "## Recent Proposals",
+            "## Active Proposals",
             "## Output Contract",
         ]
         for section in expected_sections:
@@ -532,7 +532,7 @@ class TestGenesisEgoContextBuilder:
             db=db, health_data=mock_health_data, capabilities=capabilities,
         )
         result = await builder.build()
-        assert "Recent Proposals" in result
+        assert "Active Proposals" in result
         assert "outreach" in result
         assert "Post update on LinkedIn" in result
         assert "approved" in result
@@ -545,7 +545,7 @@ class TestGenesisEgoContextBuilder:
             db=db, health_data=mock_health_data, capabilities=capabilities,
         )
         result = await builder.build()
-        assert "No proposals in last 7 days" in result
+        assert "No active proposals" in result
 
     @pytest.mark.asyncio
     async def test_proposal_history_truncates_long_content(
@@ -564,7 +564,7 @@ class TestGenesisEgoContextBuilder:
             db=db, health_data=mock_health_data, capabilities=capabilities,
         )
         result = await builder.build()
-        proposals_section = result.split("## Recent Proposals")[1].split("##")[0]
+        proposals_section = result.split("## Active Proposals")[1].split("##")[0]
         assert "..." in proposals_section
         assert "Z" * 200 not in proposals_section
 

--- a/tests/ego/test_user_context.py
+++ b/tests/ego/test_user_context.py
@@ -466,7 +466,7 @@ class TestUserEgoContextBuilder:
             "## Genesis Ego Escalations",
             "## Genesis Capabilities",
             "## Open Threads",
-            "## Recent Proposals",
+            "## Active Proposals",
             "## Recurring Patterns (72h)",
             "## Goal Progress (7d)",
             "## Output Contract",


### PR DESCRIPTION
## Summary

- **Split proposal context**: Active proposals (pending/approved/executed, LIMIT 15) and Recently Tried (withdrawn/tabled/rejected/failed, LIMIT 10) shown in separate sections. Ensures the ego always sees failed dispatches and knows what it already tried.
- **Settings hot-reload**: `_update_interval()` re-reads `ego.local.yaml` each cycle. Dashboard settings changes now take effect without server restart.
- **Cadence diagnostic logging**: `_on_tick` logs `current_interval` vs `config_cadence` on every fire. `_update_interval` logs the full calculation. Will reveal why ego cycles at 30min despite 60min config.

## Root cause

The ego generated 59 proposals in 7 days (mostly withdrawn noise). The `LIMIT 15` query showed only the newest, pushing the failed Medium publish proposal out of view. The ego couldn't see its own failures and kept proposing social media posts for articles it thought were published.

## Test plan

- [x] 5 ego capability tests pass
- [x] 114 ego session tests pass  
- [x] Ruff lint clean
- [ ] CI full suite
- [ ] Live: verify ego context shows Active + Recently Tried sections
- [ ] Live: change cadence on dashboard → verify next cycle uses new value
- [ ] Live: check journalctl logs for cadence diagnostic output

🤖 Generated with [Claude Code](https://claude.com/claude-code)