### PR TITLE
fix(dashboard): add 30-min backstop timeout for update polling

### DIFF
--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1222,6 +1222,13 @@
                 }
               }
             } catch (e) { /* server may be restarting, keep polling */ }
+            // Backstop: if server is completely dead, stop after 30 min
+            if (Date.now() - start > 1800000) {
+              clearInterval(poll);
+              this._updating = false;
+              alert("Update polling timed out after 30 minutes.\nCheck server status manually.");
+              return;
+            }
           }, 5000);
         },
         async resolveConflicts() {


### PR DESCRIPTION
## Summary

PR #394 replaced the 15-min wall-clock timeout with state-based silent-death detection, but left no upper bound for the case where the server itself is completely dead. The polling loop would run forever. Adds a 30-min backstop.

## Test plan

- [x] Dashboard template compiles
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)