### PR TITLE
fix(ego): clean goal system — disable auto-extraction, add goal_id migration

### DIFF
--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1104,6 +1104,12 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE ego_proposals ADD COLUMN ego_source TEXT",
         "ego_proposals.ego_source")
 
+    # Ego proposals: goal_id FK to user_goals — enables goal-proposal
+    # linkage and the progress feedback loop in _ego_dispatch_on_end.
+    await _try_alter(db,
+        "ALTER TABLE ego_proposals ADD COLUMN goal_id TEXT",
+        "ego_proposals.goal_id")
+
     # Surplus insights: consumed_at so reflection can mark promoted insights
     # as processed without losing the 'promoted' status.
     await _try_alter(db,

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -244,21 +244,12 @@ async def run_extraction_cycle(
                                 memory_id, exc_info=True,
                             )
 
-                    # Goal signal detection
-                    try:
-                        from genesis.memory.goal_tracker import (
-                            process_extraction as _track_goal,
-                        )
-                        if await _track_goal(
-                            db, extraction,
-                            source_session_id=cc_session_id,
-                        ):
-                            summary["goals_detected"] += 1
-                    except Exception:
-                        logger.debug(
-                            "Goal tracker failed for %s",
-                            memory_id, exc_info=True,
-                        )
+                    # Goal signal detection — DISABLED: keyword matcher
+                    # produced ~95% false positives (277 garbage goals from
+                    # conversation snippets). Replaced by explicit goal
+                    # creation via MCP tool / foreground session.
+                    # See PR for context; re-enable when goal_tracker uses
+                    # LLM classification instead of keyword matching.
 
                     # Contact detection from person entities
                     try:


### PR DESCRIPTION
## Summary
- **Disable broken goal auto-extraction** — keyword matcher in `goal_tracker.py` produced ~95% false positives (277 garbage goals from conversation snippets). Disabled the call site in `extraction_job.py`; re-enable when replaced with LLM classification.
- **Add missing `goal_id` migration** — column existed in table DDL (fresh installs) but was never migrated to existing databases. This broke the entire goal-proposal linkage and the progress feedback loop in `_ego_dispatch_on_end`.
- **Production data cleanup** (applied directly to DB, not in code):
  - Deleted 272 garbage goals, kept 5 legitimate ones
  - Created 3 proper goals: Medium article publish, Discord management, marketing plan execution
  - Withdrew invalid "Re-draft social media posts" proposal that referenced non-existent articles

## Impact
- Ego now sees 8 clean, prioritized goals instead of 277 noise entries
- Goal-proposal linkage unblocked: ego can tag proposals with `goal_id`, dispatch outcomes write progress notes
- No more garbage goals accumulating from extraction pipeline

## Test plan
- [x] `ruff check` on modified files — clean
- [x] `pytest tests/ego/` — 493 passed
- [x] `pytest tests/test_db/test_schema.py` — 25 passed (including `test_migration_creates_all_indexed_columns`)
- [x] `pytest tests/test_memory/ -k extract` — 73 passed
- [ ] Verify `goal_id` column appears on `ego_proposals` after server restart
- [ ] Verify ego sees clean goals in next cycle context

🤖 Generated with [Claude Code](https://claude.com/claude-code)