### PR TITLE
feat(ego): user directives + rich goal context + goal/directive MCP tools

### DIFF
--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -584,3 +584,80 @@ async def daily_dispatch_cost(
     except Exception:
         logger.warning("daily_dispatch_cost query failed", exc_info=True)
         return 0.0
+
+
+# ---------------------------------------------------------------------------
+# ego_directives
+# ---------------------------------------------------------------------------
+
+
+async def create_directive(
+    db: aiosqlite.Connection,
+    *,
+    content: str,
+    priority: str = "normal",
+    ego_target: str = "user_ego",
+    source: str = "user",
+) -> str:
+    """Insert a new ego directive. Returns the id."""
+    import uuid
+
+    directive_id = uuid.uuid4().hex[:16]
+    created_at = datetime.now(UTC).isoformat()
+    await db.execute(
+        """INSERT INTO ego_directives
+           (id, content, priority, source, ego_target, status, created_at)
+           VALUES (?, ?, ?, ?, ?, 'active', ?)""",
+        (directive_id, content, priority, source, ego_target, created_at),
+    )
+    await db.commit()
+    return directive_id
+
+
+async def list_active_directives(
+    db: aiosqlite.Connection,
+    ego_target: str = "user_ego",
+    limit: int = 5,
+) -> list[dict]:
+    """Active directives for a given ego target, newest first."""
+    cursor = await db.execute(
+        "SELECT * FROM ego_directives "
+        "WHERE status = 'active' AND ego_target = ? "
+        "ORDER BY created_at DESC LIMIT ?",
+        (ego_target, limit),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def resolve_directive(
+    db: aiosqlite.Connection,
+    directive_id: str,
+    *,
+    status: str = "completed",
+    resolution: str = "",
+) -> bool:
+    """Mark a directive as completed/cancelled. Returns True if updated."""
+    resolved_at = datetime.now(UTC).isoformat()
+    cursor = await db.execute(
+        "UPDATE ego_directives SET status = ?, resolved_at = ?, resolution = ? "
+        "WHERE id = ? AND status = 'active'",
+        (status, resolved_at, resolution, directive_id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def get_goal_proposal_summary(
+    db: aiosqlite.Connection,
+    goal_id: str,
+) -> dict[str, int]:
+    """Count proposals by status for a given goal_id."""
+    try:
+        cursor = await db.execute(
+            "SELECT status, count(*) FROM ego_proposals "
+            "WHERE goal_id = ? GROUP BY status",
+            (goal_id,),
+        )
+        return dict(await cursor.fetchall())
+    except Exception:
+        return {}

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1389,7 +1389,7 @@ async def _migrate_world_model_tables(db: aiosqlite.Connection) -> None:
     """
     from genesis.db.schema._tables import TABLES
 
-    for table_name in ("user_goals", "user_contacts"):
+    for table_name in ("user_goals", "user_contacts", "ego_directives"):
         ddl = TABLES.get(table_name)
         if ddl:
             try:

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -786,6 +786,22 @@ TABLES = {
             updated_at      TEXT NOT NULL DEFAULT (datetime('now'))
         )
     """,
+    # ── Ego Directives ─────────────────────────────────────────────────────
+    "ego_directives": """
+        CREATE TABLE IF NOT EXISTS ego_directives (
+            id          TEXT PRIMARY KEY,
+            content     TEXT NOT NULL,
+            priority    TEXT NOT NULL DEFAULT 'normal'
+                CHECK (priority IN ('low', 'normal', 'high', 'critical')),
+            source      TEXT NOT NULL DEFAULT 'user',
+            ego_target  TEXT NOT NULL DEFAULT 'user_ego',
+            status      TEXT NOT NULL DEFAULT 'active'
+                CHECK (status IN ('active', 'completed', 'cancelled')),
+            created_at  TEXT NOT NULL,
+            resolved_at TEXT,
+            resolution  TEXT
+        )
+    """,
     # ── Intervention Journal ────────────────────────────────────────────────
     "intervention_journal": """
         CREATE TABLE IF NOT EXISTS intervention_journal (
@@ -1224,6 +1240,9 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_ego_proposals_expires ON ego_proposals(expires_at)",
     "CREATE INDEX IF NOT EXISTS idx_ego_proposals_rank ON ego_proposals(status, rank)",
     "CREATE INDEX IF NOT EXISTS idx_ego_proposals_goal ON ego_proposals(goal_id)",
+    # ego directives
+    "CREATE INDEX IF NOT EXISTS idx_ego_directives_status ON ego_directives(status)",
+    "CREATE INDEX IF NOT EXISTS idx_ego_directives_created ON ego_directives(created_at)",
     # intervention journal
     "CREATE INDEX IF NOT EXISTS idx_intervention_journal_status ON intervention_journal(outcome_status)",
     "CREATE INDEX IF NOT EXISTS idx_intervention_journal_proposal ON intervention_journal(proposal_id)",

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -398,7 +398,27 @@ class EgoSession:
                     cycle.id,
                 )
 
-            # 10c. Process knowledge notepad updates (user ego only)
+            # 10c. Resolve directives the ego addressed
+            resolved_directives = parsed.get("resolved_directives", [])
+            if isinstance(resolved_directives, list):
+                for rd in resolved_directives:
+                    if isinstance(rd, dict) and "id" in rd:
+                        try:
+                            await ego_crud.resolve_directive(
+                                self._db, rd["id"],
+                                status="completed",
+                                resolution=rd.get("resolution", ""),
+                            )
+                            logger.info(
+                                "Directive %s resolved by ego", rd["id"],
+                            )
+                        except Exception:
+                            logger.debug(
+                                "Failed to resolve directive %s",
+                                rd.get("id"), exc_info=True,
+                            )
+
+            # 10d. Process knowledge notepad updates (user ego only)
             knowledge_updates = parsed.get("knowledge_updates", [])
             if knowledge_updates and self._source_tag == "user_ego_cycle":
                 await self._apply_knowledge_updates(knowledge_updates)
@@ -1442,6 +1462,20 @@ def _validate_output(data: dict) -> dict | None:
                 and isinstance(u.get("section"), str)
                 and u.get("action") in _VALID_NOTEPAD_ACTIONS
                 and isinstance(u.get("content"), str)
+            ]
+
+    # Sanitize resolved_directives — filter malformed entries.
+    if "resolved_directives" in data:
+        raw = data["resolved_directives"]
+        if not isinstance(raw, list):
+            data["resolved_directives"] = []
+        else:
+            data["resolved_directives"] = [
+                r
+                for r in raw
+                if isinstance(r, dict)
+                and isinstance(r.get("id"), str)
+                and r["id"]
             ]
 
     return data

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -94,6 +94,7 @@ class UserEgoContextBuilder:
         sections.append(await self._user_model_section())
         sections.append(self._ego_notepad_section())
         sections.append(await self._user_goals_section())
+        sections.append(await self._user_directives_section())
         sections.append(await self._world_snapshot_section())
         sections.append(await self._user_activity_pulse_section())
         sections.append(await self._recent_conversations_section())
@@ -241,17 +242,118 @@ class UserEgoContextBuilder:
             )
             return "\n".join(lines)
 
+        from datetime import UTC, datetime
+
+        from genesis.db.crud import ego as ego_crud
+
+        now = datetime.now(UTC)
+
         for g in goals:
             goal_id = g.get("id", "?")
             priority = g.get("priority", "medium")
             title = g.get("title", "?")[:120]
             category = g.get("category", "")
-            timeline = g.get("timeline") or ""
-            timeline_str = f" — {timeline}" if timeline else ""
-            conf = g.get("confidence", 0.5)
-            lines.append(
+
+            # Staleness: days since updated_at
+            updated_at = g.get("updated_at") or g.get("created_at") or ""
+            stale_str = ""
+            if updated_at:
+                try:
+                    updated = datetime.fromisoformat(updated_at)
+                    days_since = (now - updated).days
+                    if days_since >= 7:
+                        stale_str = f" STALE ({days_since}d)"
+                except (ValueError, TypeError):
+                    pass
+
+            # Latest progress note
+            progress_str = ""
+            progress_notes_raw = g.get("progress_notes", "[]")
+            try:
+                import json
+                notes = json.loads(progress_notes_raw) if isinstance(progress_notes_raw, str) else progress_notes_raw
+                if notes and isinstance(notes, list):
+                    latest = notes[-1]
+                    note_text = latest.get("note", str(latest)) if isinstance(latest, dict) else str(latest)
+                    progress_str = f' | Last: "{note_text[:60]}"'
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+            # Proposal outcome summary
+            proposal_str = ""
+            try:
+                summary = await ego_crud.get_goal_proposal_summary(self._db, goal_id)
+                if summary:
+                    parts = [f"{count} {status}" for status, count in summary.items()]
+                    proposal_str = f" | Proposals: {', '.join(parts)}"
+            except Exception:
+                pass
+
+            # Render
+            header = (
                 f"- [{priority.upper()}] **{title}** "
-                f"(id={goal_id}, {category}{timeline_str}, conf={conf:.0%})"
+                f"(id={goal_id}, {category})"
+            )
+            detail_parts = [p for p in [stale_str, progress_str, proposal_str] if p]
+            if detail_parts:
+                detail = "".join(detail_parts).lstrip(" |")
+                lines.append(f"{header}\n  {detail}")
+            else:
+                lines.append(header)
+
+        lines.append("")
+        return "\n".join(lines)
+
+    async def _user_directives_section(self) -> str:
+        """User directives — explicit user instructions for the ego.
+
+        Only rendered if there are active directives. Returns empty string
+        otherwise to avoid polluting context with empty sections.
+        """
+        try:
+            from genesis.db.crud import ego as ego_crud
+
+            directives = await ego_crud.list_active_directives(
+                self._db, ego_target="user_ego", limit=5,
+            )
+        except Exception:
+            logger.debug("Failed to query ego directives", exc_info=True)
+            return ""
+
+        if not directives:
+            return ""
+
+        lines = ["## User Directives\n"]
+        lines.append(
+            "*The user flagged these as important. Factor them into your "
+            "thinking — but you decide what to propose.*\n"
+        )
+
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC)
+        for d in directives:
+            priority = d.get("priority", "normal").upper()
+            content = d.get("content", "?")[:200]
+            directive_id = d.get("id", "?")
+            created_at = d.get("created_at", "")
+            # Compute age
+            age_str = ""
+            if created_at:
+                try:
+                    created = datetime.fromisoformat(created_at)
+                    delta = now - created
+                    if delta.days > 0:
+                        age_str = f"{delta.days}d ago"
+                    else:
+                        hours = int(delta.total_seconds() / 3600)
+                        age_str = f"{hours}h ago" if hours > 0 else "just now"
+                except (ValueError, TypeError):
+                    pass
+            age_part = f", {age_str}" if age_str else ""
+            lines.append(
+                f"- [{priority}] {content}\n"
+                f"  (id={directive_id}{age_part})"
             )
 
         lines.append("")

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -22,6 +22,9 @@ Think like this, in this order:
 
 1. **What do the user's goals need right now?** Look at their active goals
    and what would advance them. The best proposals are goal-connected.
+   When a goal shows failed proposals or stale progress (7+ days), check
+   what went wrong. If the infrastructure issue was fixed, propose a retry
+   with a different approach — don't repeat the exact same action.
 
 2. **What's approaching?** Check upcoming events and deadlines. Time-
    sensitive opportunities are higher value than open-ended ones.
@@ -322,6 +325,15 @@ To mark an existing follow-up as resolved, output it in a
 This is how you close your own open threads without relying on external
 cleanup.
 
+## User Directives
+
+Your context may include user directives — things the user explicitly
+flagged as important. These are input to your thinking, not orders.
+
+Factor them into your reasoning. If you act on one, resolve it in your
+output. If you disagree with one, explain why in your reasoning and
+resolve it with your rationale. Never ignore a directive silently.
+
 ## Morning Report
 
 When indicated as a morning report cycle, include the `morning_report`
@@ -403,6 +415,9 @@ Use MCP tools to verify beliefs first, then output valid JSON:
   ],
   "resolved_follow_ups": [
     {"id": "follow_up_id", "resolution": "Why it's resolved"}
+  ],
+  "resolved_directives": [
+    {"id": "directive_id", "resolution": "What you decided and why"}
   ],
   "knowledge_updates": [
     {"section": "Interaction Patterns", "action": "add", "content": "Prefers bundled PRs during shipping sprints"},

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -1,7 +1,9 @@
-"""MCP tool for resetting ego focus state.
+"""MCP tools for ego management — focus reset, directives, goal CRUD.
 
-Allows a foreground CC session to clear behavioral self-assignments
-from the ego's focus_summary, breaking self-reinforcing holdback loops.
+Allows foreground CC sessions to interact with the ego system:
+- Reset focus (break holdback loops)
+- Create directives (flag things as important for the ego)
+- Manage goals (create, list, update, achieve, abandon)
 """
 
 from __future__ import annotations
@@ -92,3 +94,178 @@ async def ego_focus_reset(
     awareness'. Regenerates essential_knowledge.md after the reset.
     """
     return await _impl_ego_focus_reset(new_focus or None)
+
+
+@mcp.tool()
+async def ego_directive(
+    content: str,
+    priority: str = "normal",
+    ego_target: str = "user_ego",
+) -> dict:
+    """Create a directive for the ego — flags something as important for
+    the ego's next thinking cycle.
+
+    Directives are context, not commands. The ego considers them as input
+    to its reasoning but decides what to propose. Use this when you want
+    the ego to pay attention to something specific.
+
+    Args:
+        content: What you want the ego to consider (e.g., "Retry the
+            Medium article publish — VNC bypass is fixed now")
+        priority: low, normal, high, or critical
+        ego_target: user_ego (default) or genesis_ego
+    """
+    import aiosqlite
+
+    from genesis.db.crud import ego as ego_crud
+
+    db_path = _get_db_path()
+    async with aiosqlite.connect(str(db_path)) as db:
+        db.row_factory = aiosqlite.Row
+        directive_id = await ego_crud.create_directive(
+            db,
+            content=content,
+            priority=priority,
+            ego_target=ego_target,
+            source="user",
+        )
+
+    return {
+        "status": "created",
+        "directive_id": directive_id,
+        "content": content[:100],
+        "priority": priority,
+        "ego_target": ego_target,
+        "note": "The ego will see this in its next thinking cycle.",
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+
+
+@mcp.tool()
+async def ego_goal_create(
+    title: str,
+    category: str = "project",
+    priority: str = "medium",
+    description: str = "",
+    timeline: str = "",
+) -> dict:
+    """Create a new user goal for the ego system.
+
+    Goals are visible to the ego in its thinking cycles. The ego considers
+    goals when deciding what to propose.
+
+    Args:
+        title: Goal title (concise, actionable)
+        category: career, project, learning, relationship, financial, other
+        priority: low, medium, high, or critical
+        description: Detailed description of the goal
+        timeline: Expected timeline (e.g., "Q2 2026")
+    """
+    import aiosqlite
+
+    from genesis.db.crud import user_goals
+
+    db_path = _get_db_path()
+    async with aiosqlite.connect(str(db_path)) as db:
+        db.row_factory = aiosqlite.Row
+        goal_id = await user_goals.create(
+            db,
+            title=title,
+            category=category,
+            priority=priority,
+            description=description,
+            timeline=timeline or None,
+            confidence=0.9,
+        )
+
+    return {
+        "status": "created",
+        "goal_id": goal_id,
+        "title": title,
+        "category": category,
+        "priority": priority,
+    }
+
+
+@mcp.tool()
+async def ego_goal_list() -> dict:
+    """List all active user goals in the ego system."""
+    import aiosqlite
+
+    from genesis.db.crud import user_goals
+
+    db_path = _get_db_path()
+    async with aiosqlite.connect(str(db_path)) as db:
+        db.row_factory = aiosqlite.Row
+        goals = await user_goals.list_active(db, limit=20)
+
+    return {
+        "status": "ok",
+        "count": len(goals),
+        "goals": [
+            {
+                "id": g["id"],
+                "title": g["title"][:100],
+                "category": g.get("category", ""),
+                "priority": g.get("priority", "medium"),
+                "status": g.get("status", "active"),
+            }
+            for g in goals
+        ],
+    }
+
+
+@mcp.tool()
+async def ego_goal_update(
+    goal_id: str,
+    title: str = "",
+    category: str = "",
+    priority: str = "",
+    description: str = "",
+    timeline: str = "",
+    status: str = "",
+) -> dict:
+    """Update an existing user goal, or mark it as achieved/abandoned.
+
+    Pass only the fields you want to change. Empty strings are ignored.
+
+    Args:
+        goal_id: The goal ID to update
+        title: New title (optional)
+        category: New category (optional)
+        priority: New priority (optional)
+        description: New description (optional)
+        timeline: New timeline (optional)
+        status: Set to 'achieved' or 'abandoned' to close the goal (optional)
+    """
+    import aiosqlite
+
+    from genesis.db.crud import user_goals
+
+    db_path = _get_db_path()
+    async with aiosqlite.connect(str(db_path)) as db:
+        db.row_factory = aiosqlite.Row
+
+        if status == "achieved":
+            await user_goals.mark_achieved(db, goal_id)
+            return {"status": "achieved", "goal_id": goal_id}
+        if status == "abandoned":
+            await user_goals.mark_abandoned(db, goal_id)
+            return {"status": "abandoned", "goal_id": goal_id}
+
+        fields: dict = {}
+        if title:
+            fields["title"] = title
+        if description:
+            fields["description"] = description
+        if category:
+            fields["category"] = category
+        if priority:
+            fields["priority"] = priority
+        if timeline:
+            fields["timeline"] = timeline
+        if not fields:
+            return {"status": "error", "reason": "no fields to update"}
+
+        await user_goals.update(db, goal_id, **fields)
+        return {"status": "updated", "goal_id": goal_id, "fields": list(fields.keys())}

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -88,7 +88,7 @@ async def test_no_unexpected_tables(db):
         "direct_session_queue",
         "eval_events", "eval_snapshots",
         "memory_events",
-        "user_goals", "user_contacts",
+        "user_goals", "user_contacts", "ego_directives",
         "tool_call_outcomes",
     }
     for table in tables:


### PR DESCRIPTION
## Summary
- **User directives**: New `ego_directives` table + CRUD + context injection + output parsing + MCP tool. Directives are user-flagged priorities that persist to the ego's next thinking cycle. Framed as context (not commands) — the ego decides what to propose.
- **Rich goal context**: Goals now show staleness markers (STALE 7d+), latest progress notes, and proposal outcome summaries per goal. Gives the ego enough information to decide what to retry.
- **Goal MCP tools**: `ego_goal_create`, `ego_goal_list`, `ego_goal_update` — per-operation tools (not CRUD-in-one) following codebase convention.
- **Prompt additions**: 3 targeted additions to USER_EGO_SESSION.md — directive awareness, resolved_directives output format, goal staleness guidance. No rewrites.

## Architecture Review Findings Addressed
- Removed dead `acknowledged` status (no code path could produce it)
- Added `resolved_directives` sanitization in `_validate_output` (prevents silent data corruption on malformed LLM output)
- Split `ego_goal` into per-operation tools (matches `settings_get`/`settings_update` convention)
- `logger.debug` for directive query failures (fresh install safe)

## Deferred
- Telegram → directive creation path (follow-up PR after testing)
- Auto-expiry of directives (add if pile-up observed)
- Dashboard goal management UI

## Test plan
- [x] `ruff check` on all modified files — clean
- [x] `pytest tests/ego/ tests/test_db/test_schema.py` — 518 passed
- [x] Architecture review (genesis-architect agent) — 7 findings, all addressed
- [ ] Verify `ego_directives` table created after server restart
- [ ] Create directive via MCP tool → verify in ego context next cycle
- [ ] Create goal via MCP tool → verify in ego context
- [ ] End-to-end: directive "retry Medium article" → ego acknowledges

🤖 Generated with [Claude Code](https://claude.com/claude-code)