### PR TITLE
fix(ego): output contract + MCP validation + rebuild template columns

### DIFF
--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1229,7 +1229,11 @@ async def _migrate_ego_proposals_status_check(db: aiosqlite.Connection) -> None:
                 rank            INTEGER,
                 execution_plan  TEXT,
                 recurring       INTEGER DEFAULT 0,
-                memory_basis    TEXT DEFAULT ''
+                memory_basis    TEXT DEFAULT '',
+                realist_verdict  TEXT,
+                realist_reasoning TEXT,
+                ego_source       TEXT,
+                goal_id          TEXT
             )
         """)
         await db.execute("""
@@ -1237,12 +1241,14 @@ async def _migrate_ego_proposals_status_check(db: aiosqlite.Connection) -> None:
                 (id, action_type, action_category, content, rationale,
                  confidence, urgency, alternatives, status, user_response,
                  cycle_id, batch_id, created_at, resolved_at, expires_at,
-                 rank, execution_plan, recurring, memory_basis)
+                 rank, execution_plan, recurring, memory_basis,
+                 realist_verdict, realist_reasoning, ego_source, goal_id)
             SELECT
                 id, action_type, action_category, content, rationale,
                 confidence, urgency, alternatives, status, user_response,
                 cycle_id, batch_id, created_at, resolved_at, expires_at,
-                rank, execution_plan, recurring, memory_basis
+                rank, execution_plan, recurring, memory_basis,
+                realist_verdict, realist_reasoning, ego_source, goal_id
             FROM ego_proposals
         """)
         await db.execute("DROP TABLE ego_proposals")
@@ -1258,6 +1264,7 @@ async def _migrate_ego_proposals_status_check(db: aiosqlite.Connection) -> None:
             "CREATE INDEX IF NOT EXISTS idx_ego_proposals_batch ON ego_proposals(batch_id)",
             "CREATE INDEX IF NOT EXISTS idx_ego_proposals_expires ON ego_proposals(expires_at)",
             "CREATE INDEX IF NOT EXISTS idx_ego_proposals_rank ON ego_proposals(status, rank)",
+            "CREATE INDEX IF NOT EXISTS idx_ego_proposals_goal ON ego_proposals(goal_id)",
         ]:
             await db.execute(idx_sql)
         await db.commit()

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -1076,6 +1076,7 @@ class UserEgoContextBuilder:
             '  "focus_summary": "one-line: what you are focused on for the user",\n'
             '  "follow_ups": [],\n'
             '  "resolved_follow_ups": [{"id": "follow_up_id", "resolution": "why resolved"}],\n'
+            '  "resolved_directives": [{"id": "directive_id", "resolution": "what you decided"}],\n'
             '  "morning_report": "only if this is a morning trigger"\n'
             "}\n"
             "```\n\n"

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -15,6 +15,12 @@ from genesis.mcp.health import mcp
 
 logger = logging.getLogger(__name__)
 
+# Validation sets matching DB CHECK constraints
+_VALID_DIRECTIVE_PRIORITIES = frozenset({"low", "normal", "high", "critical"})
+_VALID_EGO_TARGETS = frozenset({"user_ego", "genesis_ego"})
+_VALID_GOAL_CATEGORIES = frozenset({"career", "project", "learning", "relationship", "financial", "other"})
+_VALID_GOAL_PRIORITIES = frozenset({"low", "medium", "high", "critical"})
+
 
 def _get_db_path():
     """Late-import DB path."""
@@ -115,6 +121,11 @@ async def ego_directive(
         priority: low, normal, high, or critical
         ego_target: user_ego (default) or genesis_ego
     """
+    if priority not in _VALID_DIRECTIVE_PRIORITIES:
+        return {"status": "error", "reason": f"Invalid priority: {priority!r}. Must be one of: {sorted(_VALID_DIRECTIVE_PRIORITIES)}"}
+    if ego_target not in _VALID_EGO_TARGETS:
+        return {"status": "error", "reason": f"Invalid ego_target: {ego_target!r}. Must be one of: {sorted(_VALID_EGO_TARGETS)}"}
+
     import aiosqlite
 
     from genesis.db.crud import ego as ego_crud
@@ -161,6 +172,11 @@ async def ego_goal_create(
         description: Detailed description of the goal
         timeline: Expected timeline (e.g., "Q2 2026")
     """
+    if category not in _VALID_GOAL_CATEGORIES:
+        return {"status": "error", "reason": f"Invalid category: {category!r}. Must be one of: {sorted(_VALID_GOAL_CATEGORIES)}"}
+    if priority not in _VALID_GOAL_PRIORITIES:
+        return {"status": "error", "reason": f"Invalid priority: {priority!r}. Must be one of: {sorted(_VALID_GOAL_PRIORITIES)}"}
+
     import aiosqlite
 
     from genesis.db.crud import user_goals
@@ -238,6 +254,13 @@ async def ego_goal_update(
         timeline: New timeline (optional)
         status: Set to 'achieved' or 'abandoned' to close the goal (optional)
     """
+    if category and category not in _VALID_GOAL_CATEGORIES:
+        return {"status": "error", "reason": f"Invalid category: {category!r}. Must be one of: {sorted(_VALID_GOAL_CATEGORIES)}"}
+    if priority and priority not in _VALID_GOAL_PRIORITIES:
+        return {"status": "error", "reason": f"Invalid priority: {priority!r}. Must be one of: {sorted(_VALID_GOAL_PRIORITIES)}"}
+    if status and status not in ("achieved", "abandoned"):
+        return {"status": "error", "reason": f"Invalid status: {status!r}. Must be 'achieved' or 'abandoned'"}
+
     import aiosqlite
 
     from genesis.db.crud import user_goals


### PR DESCRIPTION
## Summary
Addresses 3 code review findings from PR #399:

- **Output contract**: Added `resolved_directives` to the JSON reminder in `_output_contract_section()` — ego might forget the field without the quick-reference
- **MCP input validation**: `ego_directive`, `ego_goal_create`, `ego_goal_update` now validate priority/category/ego_target/status before DB insert — returns error dict instead of `sqlite3.IntegrityError`
- **Rebuild template**: `_migrate_ego_proposals_status_check` now includes all 4 columns added via `_try_alter` (`realist_verdict`, `realist_reasoning`, `ego_source`, `goal_id`) + the `goal_id` index — prevents silent data loss if rebuild fires on an old DB

## Test plan
- [x] `ruff check` — clean
- [x] `pytest tests/ego/test_user_context.py tests/test_db/test_schema.py` — 61 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)