### PR TITLE
fix(perception): decouple micro Telegram delivery from observation storage

### DIFF
--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -813,6 +813,13 @@ class AwarenessLoop:
                 except Exception:
                     logger.warning("Failed to emit reflection heartbeat", exc_info=True)
 
+            # Mark tick as dispatched on success (mirrors Light/Deep path)
+            if ref_result and ref_result.success:
+                try:
+                    await awareness_ticks.mark_dispatched(db, tick_id)
+                except Exception:
+                    logger.warning("Failed to mark tick %s dispatched", tick_id[:8])
+
             # Post micro reflection to supergroup topic
             if ref_result and ref_result.success and ref_result.output and self._topic_manager:
                 micro = ref_result.output

--- a/src/genesis/perception/engine.py
+++ b/src/genesis/perception/engine.py
@@ -120,4 +120,6 @@ class ReflectionEngine:
         # 5. Write results (returns False if gated by salience/dedup)
         stored = await self._writer.write(parsed.output, depth, tick, db=db)
 
-        return ReflectionResult(success=True, output=parsed.output if stored else None)
+        # Always return the parsed output — Telegram delivery should not
+        # be coupled to observation storage gates (PR #101 rule).
+        return ReflectionResult(success=True, output=parsed.output, stored=stored)

--- a/src/genesis/perception/types.py
+++ b/src/genesis/perception/types.py
@@ -55,6 +55,7 @@ class ReflectionResult:
     success: bool
     output: MicroOutput | LightOutput | None = None
     reason: str | None = None
+    stored: bool = False
 
 
 @dataclass(frozen=True)

--- a/tests/test_perception/test_engine.py
+++ b/tests/test_perception/test_engine.py
@@ -148,6 +148,45 @@ async def test_reflect_retry_on_parse_failure(db):
     assert caller.call.call_count == 2
 
 
+async def test_reflect_output_preserved_when_writer_gates(db):
+    """Output must survive writer gating — Telegram delivery is decoupled from storage."""
+    from genesis.perception.engine import ReflectionEngine
+
+    assembler = AsyncMock()
+    assembler.assemble = AsyncMock(return_value=PromptContext(
+        depth="Micro", identity="Genesis", signals_text="cpu: 0.3",
+        tick_number=1,
+    ))
+    builder = MagicMock()
+    builder.build = MagicMock(return_value="Test prompt")
+    caller = AsyncMock()
+    caller.call = AsyncMock(return_value=LLMResponse(
+        text='{"tags":["idle"],"salience":0.1,"anomaly":false,"summary":"Normal.","signals_examined":1}',
+        model="groq-free", input_tokens=100, output_tokens=50,
+        cost_usd=0.0, latency_ms=200,
+    ))
+    parser = MagicMock()
+    parser.parse = MagicMock(return_value=ParseResult(
+        success=True, output=_micro_output(),
+    ))
+    writer = AsyncMock()
+    writer.write = AsyncMock(return_value=False)  # Writer gates storage
+
+    engine = ReflectionEngine(
+        context_assembler=assembler,
+        prompt_builder=builder,
+        llm_caller=caller,
+        output_parser=parser,
+        result_writer=writer,
+    )
+
+    result = await engine.reflect(Depth.MICRO, _make_tick(), db=db)
+
+    assert result.success is True
+    assert result.output is not None  # Output preserved despite gating
+    assert result.stored is False     # But flagged as not stored
+
+
 async def test_reflect_max_retries_exceeded(db):
     from genesis.perception.engine import ReflectionEngine
 

--- a/tests/test_perception/test_engine.py
+++ b/tests/test_perception/test_engine.py
@@ -52,7 +52,7 @@ async def test_reflect_success(db):
         success=True, output=_micro_output(),
     ))
     writer = AsyncMock()
-    writer.write = AsyncMock()
+    writer.write = AsyncMock(return_value=True)
 
     engine = ReflectionEngine(
         context_assembler=assembler,
@@ -66,6 +66,7 @@ async def test_reflect_success(db):
 
     assert result.success is True
     assert result.output is not None
+    assert result.stored is True
     assembler.assemble.assert_called_once()
     builder.build.assert_called_once()
     caller.call.assert_called_once()


### PR DESCRIPTION
## Summary

- **Decouple Telegram delivery from writer storage gates** — `engine.py` now always returns `parsed.output` regardless of whether the writer stored the observation. Adds `stored: bool` field to `ReflectionResult` for callers that need to distinguish.
- **Add missing `mark_dispatched()` for micro ticks** — Light/Deep/Strategic had it since PR #331; micro was overlooked. 10 micro ticks since May 20 accumulated as undispatched.

### Root Cause

PR #101 (Apr 19) removed the salience gate on micro Telegram delivery. PR #28 (Apr 27) reintroduced the same suppression at the engine level by returning `output=None` when the writer rejected storage. Combined with tightened dedup gates (PRs #246/#248, May 7), virtually all micro reflections were silently dropped before reaching Telegram.

## Test plan

- [x] `pytest tests/test_perception/test_engine.py -v` — 5/5 pass (includes new `test_reflect_output_preserved_when_writer_gates`)
- [x] `pytest tests/test_db/test_awareness_ticks.py -v` — 12/12 pass
- [x] `pytest tests/test_cc/test_reflection_bridge.py tests/test_cc/test_reflection_bridge_resilience.py -v` — 29/29 pass
- [x] `ruff check` clean on all changed files
- [ ] After deploy: verify "Posted micro reflection to Telegram" in logs on next micro tick (~5 min)
- [ ] After deploy: verify `SELECT dispatched FROM awareness_ticks WHERE classified_depth='Micro' ORDER BY created_at DESC LIMIT 5` shows `dispatched=1`