### PR TITLE
fix(ego): goal progress hook + Opus dispatch + dispatch quality guidance

### DIFF
--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -756,7 +756,12 @@ class EgoSession:
             if profile not in VALID_PROFILES:
                 profile = "observe"
             model_str = brief.get("model", "sonnet")
-            model = CCModel.SONNET if model_str != "haiku" else CCModel.HAIKU
+            if model_str == "opus":
+                model = CCModel.OPUS
+            elif model_str == "haiku":
+                model = CCModel.HAIKU
+            else:
+                model = CCModel.SONNET
 
             # Atomically claim the proposal BEFORE spawning to prevent
             # double-dispatch (sweep_approved_proposals is a second path).

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -203,9 +203,26 @@ To dispatch an approved proposal, output an `execution_briefs` entry:
 - `prompt` — detailed dispatch instructions for the background session
 - `profile` — choose the minimum that covers the task:
   - `"observe"` — read-only. No browser interaction, no memory writes, no outreach. Default.
-  - `"research"` — can write memory, create follow-ups. No browser interaction.
-  - `"interact"` — full browser interaction + memory writes + can message user via Telegram. Use for workflows that need to operate external platforms (publishing, form filling) AND communicate results.
-- `model` — "sonnet" (default) or "haiku"
+  - `"research"` — can write memory, create follow-ups. No browser interaction. Use for information gathering, analysis, and research that stores findings.
+  - `"interact"` — full browser interaction + memory writes + can message user via Telegram. Use for workflows that need to operate external platforms (publishing, form filling) AND communicate results. **Content creation and publishing ALWAYS requires interact** — the content-publish skill uses browser automation.
+- `model` — "sonnet" (default), "opus" (for complex multi-step workflows, content creation, or anything requiring careful judgment), or "haiku" (simple/fast tasks)
+
+**Dispatch quality checklist:**
+- Reference the relevant skill by name in your prompt (e.g., "Use the
+  content-publish skill"). Dispatched sessions discover and follow skills.
+- Choose `interact` for ANY task involving external platforms, content
+  creation, or publishing. When in doubt, use interact over research.
+- Choose `opus` for multi-step workflows, content drafting, or tasks
+  where following a complex skill matters. Sonnet for simple lookups.
+- Your dispatch prompt IS the session's only instruction. Be specific
+  about the desired outcome, not just the topic.
+
+**Verify before assuming broken.** If your proposal downgrades because
+you believe something is broken, VERIFY in-cycle using your MCP tools.
+Observations age. Failures get fixed. Check `observation_query` for
+resolution status. If you cannot verify, state your uncertainty — don't
+silently deliver a watered-down result. The user approved a specific
+outcome. Deliver that outcome or explain clearly why you can't.
 
 Delivery timing is system-controlled. When you produce proposals, they
 are delivered to the user automatically. The cadence manager ensures

--- a/src/genesis/runtime/init/ego.py
+++ b/src/genesis/runtime/init/ego.py
@@ -237,7 +237,21 @@ async def init(rt: GenesisRuntime) -> None:
 
                     status = session.get("status", "unknown")
                     cost = session.get("cost_usd", 0.0)
-                    caller_ctx = session.get("caller_context", "")
+
+                    # caller_context lives inside the metadata JSON blob,
+                    # not as a top-level column on cc_sessions.
+                    import json as _json
+
+                    _meta_raw = session.get("metadata") or "{}"
+                    try:
+                        _meta = (
+                            _json.loads(_meta_raw)
+                            if isinstance(_meta_raw, str)
+                            else (_meta_raw or {})
+                        )
+                    except (ValueError, TypeError):
+                        _meta = {}
+                    caller_ctx = _meta.get("caller_context", "")
 
                     await obs_crud.create(
                         rt._db,


### PR DESCRIPTION
## Summary
- **Goal progress hook fix**: `caller_context` was read from session row directly but lives inside `metadata` JSON blob. Parsed metadata first — unblocks goal progress notes on ego-dispatched session completion.
- **Opus in execution briefs**: Ego can now dispatch complex tasks with Opus (was limited to sonnet/haiku). Sweep path already auto-selects Opus for interact — this makes execution_briefs consistent.
- **Dispatch quality guidance**: Added to USER_EGO_SESSION.md:
  - "Content creation ALWAYS requires interact" (content-publish skill uses browser)
  - Dispatch quality checklist (skill reference, profile, model selection)
  - Information hygiene: "verify before assuming broken" — ego must check if stale beliefs are still true before downgrading proposals

## Root Cause
Ego proposed "draft to file only (pipeline broken)" for Medium article because 4 unresolved observations from May 15-16 said the pipeline was blocked. Pipeline was actually fixed (PRs #348, #390). Stale observations will be resolved on production DB separately.

## Test plan
- [x] `ruff check` — clean
- [x] `pytest tests/ego/` — 493 passed
- [ ] After merge: resolve stale pipeline observations + create corrective directive
- [ ] Next ego dispatch: verify goal progress notes written, interact profile used

🤖 Generated with [Claude Code](https://claude.com/claude-code)