### PR TITLE
refactor(perception): silent micro ticks + critical-signal-only LLM

### DIFF
--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -52,6 +52,11 @@ def _sqlite_wal_checkpoint(db) -> None:
         pass  # Best-effort; failure is harmless
 
 
+# Micro ticks are silent by default (counted for cascade, no LLM call).
+# LLM fires only when these critical operational signals are active.
+_MICRO_CRITICAL_SIGNALS = frozenset({"software_error_spike", "critical_failure"})
+_SENTINEL_ANOMALY_THRESHOLD = 0.7
+
 # Maps circuit-breaker degradation levels to resilience cloud axis states.
 _DEGRADATION_TO_CLOUD: dict[DegradationLevel, CloudStatus] = {
     DegradationLevel.NORMAL: CloudStatus.NORMAL,
@@ -798,63 +803,76 @@ class AwarenessLoop:
         )
 
         if self._reflection_engine is not None and depth == Depth.MICRO:
-            ref_result = None
+            # Check for critical operational signals that warrant LLM analysis.
+            # Routine micro ticks are silent (counted for escalation cascade only).
+            critical_active = any(
+                s.value > 0 for s in result.signals
+                if s.name in _MICRO_CRITICAL_SIGNALS
+            ) or any(
+                s.value >= _SENTINEL_ANOMALY_THRESHOLD for s in result.signals
+                if s.name == "sentinel_activity"
+            )
+
+            if critical_active:
+                # Anomaly path: full LLM reflection for genuine operational events
+                ref_result = None
+                try:
+                    ref_result = await self._reflection_engine.reflect(depth, result, db=db)
+                except Exception:
+                    logger.exception("Micro anomaly reflection crashed for tick %s", tick_id)
+
+                if ref_result and ref_result.success and self._event_bus:
+                    try:
+                        await self._event_bus.emit(
+                            Subsystem.REFLECTION, Severity.DEBUG,
+                            "heartbeat", "micro-reflection completed",
+                        )
+                    except Exception:
+                        logger.warning("Failed to emit reflection heartbeat", exc_info=True)
+
+                if ref_result and ref_result.success and ref_result.output and self._topic_manager:
+                    micro = ref_result.output
+                    try:
+                        anomaly_flag = " [ANOMALY]" if micro.anomaly else ""
+                        tags_str = ", ".join(micro.tags[:5]) if micro.tags else ""
+                        text = (
+                            f"<b>Micro Reflection</b>{anomaly_flag}\n\n"
+                            f"{micro.summary}\n\n"
+                            f"<i>Salience: {micro.salience:.2f}"
+                            f"{f' | Tags: {tags_str}' if tags_str else ''}</i>"
+                        )
+                        await self._topic_manager.send_to_category("reflection_micro", text)
+                        logger.info(
+                            "Posted micro reflection to Telegram (tick=%s, salience=%.2f)",
+                            tick_id[:8], micro.salience,
+                        )
+                    except Exception:
+                        logger.warning("Failed to post micro reflection to topic", exc_info=True)
+
+                if (ref_result is None or not ref_result.success) and self._deferred_queue:
+                    try:
+                        await self._deferred_queue.enqueue(
+                            work_type="reflection",
+                            call_site_id="reflection_micro",
+                            priority=30,
+                            payload=json.dumps({"tick_id": tick_id, "depth": "Micro"}),
+                            reason="reflection_failed",
+                            staleness_policy="ttl",
+                            staleness_ttl_s=RATE_LIMIT_DEFERRAL_TTL_S,
+                        )
+                    except Exception:
+                        logger.warning("Failed to enqueue deferred reflection")
+            else:
+                logger.debug(
+                    "Micro tick %s silent (no critical signals active)",
+                    tick_id[:8],
+                )
+
+            # Always mark dispatched — cascade counting works on ticks
             try:
-                ref_result = await self._reflection_engine.reflect(depth, result, db=db)
+                await awareness_ticks.mark_dispatched(db, tick_id)
             except Exception:
-                logger.exception("Reflection crashed for tick %s", tick_id)
-
-            if ref_result and ref_result.success and self._event_bus:
-                try:
-                    await self._event_bus.emit(
-                        Subsystem.REFLECTION, Severity.DEBUG,
-                        "heartbeat", "micro-reflection completed",
-                    )
-                except Exception:
-                    logger.warning("Failed to emit reflection heartbeat", exc_info=True)
-
-            # Mark tick as dispatched on success (mirrors Light/Deep path)
-            if ref_result and ref_result.success:
-                try:
-                    await awareness_ticks.mark_dispatched(db, tick_id)
-                except Exception:
-                    logger.warning("Failed to mark tick %s dispatched", tick_id[:8])
-
-            # Post micro reflection to supergroup topic
-            if ref_result and ref_result.success and ref_result.output and self._topic_manager:
-                micro = ref_result.output
-                try:
-                    anomaly_flag = " [ANOMALY]" if micro.anomaly else ""
-                    tags_str = ", ".join(micro.tags[:5]) if micro.tags else ""
-                    text = (
-                        f"<b>Micro Reflection</b>{anomaly_flag}\n\n"
-                        f"{micro.summary}\n\n"
-                        f"<i>Salience: {micro.salience:.2f}"
-                        f"{f' | Tags: {tags_str}' if tags_str else ''}</i>"
-                    )
-                    await self._topic_manager.send_to_category("reflection_micro", text)
-                    logger.info(
-                        "Posted micro reflection to Telegram (tick=%s, salience=%.2f)",
-                        tick_id[:8], micro.salience,
-                    )
-                except Exception:
-                    logger.warning("Failed to post micro reflection to topic", exc_info=True)
-            elif ref_result and ref_result.success and ref_result.output and not self._topic_manager:
-                logger.warning("Micro reflection completed but topic_manager not set")
-
-            if (ref_result is None or not ref_result.success) and self._deferred_queue:
-                try:
-                    await self._deferred_queue.enqueue(
-                        work_type="reflection",
-                        call_site_id="reflection_micro",
-                        priority=30,
-                        payload=json.dumps({"tick_id": tick_id, "depth": "Micro"}),
-                        reason="reflection_failed",
-                        staleness_policy="ttl",
-                        staleness_ttl_s=RATE_LIMIT_DEFERRAL_TTL_S,
-                    )
-                except Exception:
-                    logger.warning("Failed to enqueue deferred reflection")
+                logger.warning("Failed to mark tick %s dispatched", tick_id[:8])
             return
 
         if depth == Depth.LIGHT and self._cc_reflection_bridge is None and self._reflection_engine is not None:

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1060,6 +1060,15 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "WHERE signal_name = 'user_goal_staleness'"
     )
 
+    # Fix: user_session_pattern is a behavioral signal that produces noise at
+    # Micro depth (persistent ~0.53 value drives 55% of Micro triggers with
+    # zero actionable insight).  Scope to Light only — Light can reason about
+    # behavioral patterns; Micro should focus on operational health.
+    await db.execute(
+        "UPDATE signal_weights SET feeds_depths = '[\"Light\"]' "
+        "WHERE signal_name = 'user_session_pattern'"
+    )
+
     # Ego proposals: memory_basis column for non-obvious memory attribution.
     await _try_alter(db,
         "ALTER TABLE ego_proposals ADD COLUMN memory_basis TEXT DEFAULT ''",

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1328,7 +1328,7 @@ SIGNAL_WEIGHTS_SEED = [
     ("stale_pending_items", "cognitive_state", 0.35, 0.35, 0.0, 1.0, '["Micro"]'),
     # 2026-04-30: user-facing signals for reflection rebalancing (Phase 2.5b)
     ("user_goal_staleness", "follow_ups+user_model", 0.40, 0.40, 0.0, 1.0, '["Light"]'),
-    ("user_session_pattern", "cc_sessions", 0.35, 0.35, 0.0, 1.0, '["Micro","Light"]'),
+    ("user_session_pattern", "cc_sessions", 0.35, 0.35, 0.0, 1.0, '["Light"]'),
 ]
 
 DEPTH_THRESHOLDS_SEED = [

--- a/src/genesis/ego/context.py
+++ b/src/genesis/ego/context.py
@@ -213,6 +213,7 @@ class EgoContextBuilder:
                 "SELECT source, type, category, content, priority, created_at "
                 "FROM observations "
                 "WHERE resolved = 0 "
+                "AND type NOT IN ('micro_reflection', 'awareness_tick') "
                 "AND created_at >= datetime('now', '-48 hours') "
                 "ORDER BY "
                 "  CASE priority "

--- a/src/genesis/perception/context.py
+++ b/src/genesis/perception/context.py
@@ -250,13 +250,16 @@ class ContextAssembler:
             chain_section = await self._build_light_chain_context(db, depth_value)
 
         try:
-            # Pass 1: reflection-origin observations
+            # Pass 1: reflection-origin observations (exclude micro — low-value
+            # free-model output that adds noise to higher-depth context).
             reflection_obs = await observations.query(
                 db, resolved=False, source_in=_REFLECTION_SOURCES, limit=refl_cap,
+                exclude_types=("micro_reflection",),
             )
             # Pass 2: everything else
             other_obs = await observations.query(
                 db, resolved=False, limit=other_cap,
+                exclude_types=("micro_reflection",),
             )
 
             # Depth-specific age guard — drop observations older than the cutoff

--- a/src/genesis/reflection/context_gatherer.py
+++ b/src/genesis/reflection/context_gatherer.py
@@ -65,7 +65,12 @@ class ContextGatherer:
         now = datetime.now(UTC)
 
         # Memory consolidation: unresolved observations above threshold
-        unresolved = await observations.query(db, resolved=False, limit=200)
+        # Exclude micro_reflection — low-value free-model output that inflates
+        # the backlog count without providing consolidation material.
+        unresolved = await observations.query(
+            db, resolved=False, limit=200,
+            exclude_types=("micro_reflection",),
+        )
         obs_backlog = len(unresolved)
         has_memory_work = obs_backlog >= _MIN_OBSERVATIONS_FOR_CONSOLIDATION
 
@@ -211,14 +216,19 @@ class ContextGatherer:
         last_deep = await observations.query(
             db, source="cc_reflection_deep", limit=1,
         )
+        _micro_excl = ("micro_reflection",)
         if last_deep:
             since = last_deep[0].get("created_at", "")
-            all_obs = await observations.query(db, resolved=False, limit=100)
+            all_obs = await observations.query(
+                db, resolved=False, limit=100, exclude_types=_micro_excl,
+            )
             result = [o for o in all_obs if o.get("created_at", "") > since]
         else:
             # No prior deep reflection — get last 48h
             cutoff = (datetime.now(UTC) - timedelta(hours=48)).isoformat()
-            all_obs = await observations.query(db, resolved=False, limit=100)
+            all_obs = await observations.query(
+                db, resolved=False, limit=100, exclude_types=_micro_excl,
+            )
             result = [o for o in all_obs if o.get("created_at", "") >= cutoff]
 
         # Hard age cap — no observation older than 48h enters deep reflection

--- a/tests/test_awareness/test_loop.py
+++ b/tests/test_awareness/test_loop.py
@@ -4,14 +4,13 @@ Tests the tick pipeline directly (perform_tick) without relying on
 APScheduler timing. Scheduler integration is tested separately.
 """
 
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 from genesis.awareness.loop import AwarenessLoop, perform_tick
 from genesis.awareness.signals import ConversationCollector
 from genesis.awareness.types import Depth, DepthScore, SignalReading, TickResult
 from genesis.db.crud import awareness_ticks, observations
-
-import json
 
 
 async def _persist_tick(db, tick: TickResult) -> None:

--- a/tests/test_awareness/test_loop.py
+++ b/tests/test_awareness/test_loop.py
@@ -4,10 +4,28 @@ Tests the tick pipeline directly (perform_tick) without relying on
 APScheduler timing. Scheduler integration is tested separately.
 """
 
-from genesis.awareness.loop import perform_tick
+from unittest.mock import AsyncMock, MagicMock
+
+from genesis.awareness.loop import AwarenessLoop, perform_tick
 from genesis.awareness.signals import ConversationCollector
-from genesis.awareness.types import SignalReading
+from genesis.awareness.types import Depth, DepthScore, SignalReading, TickResult
 from genesis.db.crud import awareness_ticks, observations
+
+import json
+
+
+async def _persist_tick(db, tick: TickResult) -> None:
+    """Persist a TickResult to the DB so mark_dispatched can find it."""
+    await awareness_ticks.create(
+        db,
+        id=tick.tick_id,
+        source=tick.source,
+        signals_json=json.dumps([{"name": s.name, "value": s.value} for s in tick.signals]),
+        scores_json=json.dumps({}),
+        created_at=tick.timestamp,
+        classified_depth=tick.classified_depth.value if tick.classified_depth else None,
+        trigger_reason=tick.trigger_reason,
+    )
 
 
 async def test_perform_tick_no_trigger(db):
@@ -91,3 +109,104 @@ async def test_replace_collectors(db):
     assert len(loop._collectors) == 2
     assert loop._collectors[0].signal_name == "real_a"
     assert loop._collectors[1].signal_name == "real_b"
+
+
+def _micro_tick(signals: list[SignalReading], tick_id: str = "test-tick") -> TickResult:
+    """Helper: build a TickResult classified as Micro with given signals."""
+    return TickResult(
+        tick_id=tick_id,
+        timestamp="2026-05-21T12:00:00+00:00",
+        source="scheduled",
+        signals=signals,
+        scores=[DepthScore(
+            depth=Depth.MICRO, raw_score=0.5,
+            time_multiplier=1.0, final_score=0.5,
+            threshold=0.3, triggered=True,
+        )],
+        classified_depth=Depth.MICRO,
+        trigger_reason="threshold_exceeded",
+    )
+
+
+async def test_micro_dispatch_silent_on_routine_signals(db):
+    """Micro ticks with only routine signals skip LLM — mark dispatched, no engine call."""
+    engine = AsyncMock()
+    loop = AwarenessLoop(db=db, collectors=[])
+    loop.set_reflection_engine(engine)
+
+    tick = _micro_tick([
+        SignalReading(name="autonomy_activity", value=0.3, source="test",
+                      collected_at="2026-05-21T12:00:00+00:00"),
+        SignalReading(name="surplus_activity", value=0.0, source="test",
+                      collected_at="2026-05-21T12:00:00+00:00"),
+    ])
+
+    # Persist the tick so mark_dispatched can find it
+    await _persist_tick(db, tick)
+
+    await loop._dispatch_reflection(tick)
+
+    # Engine should NOT be called — silent path
+    engine.reflect.assert_not_called()
+
+    # But tick should be marked dispatched (cascade counting)
+    row = await awareness_ticks.get_by_id(db, tick.tick_id)
+    assert row["dispatched"] == 1
+
+
+async def test_micro_dispatch_fires_llm_on_critical_signal(db):
+    """Micro ticks with software_error_spike > 0 fire the LLM."""
+    engine = AsyncMock()
+    engine.reflect = AsyncMock(return_value=MagicMock(success=True, output=None))
+    loop = AwarenessLoop(db=db, collectors=[])
+    loop.set_reflection_engine(engine)
+
+    tick = _micro_tick([
+        SignalReading(name="software_error_spike", value=0.5, source="test",
+                      collected_at="2026-05-21T12:00:00+00:00"),
+        SignalReading(name="autonomy_activity", value=0.0, source="test",
+                      collected_at="2026-05-21T12:00:00+00:00"),
+    ])
+
+    await _persist_tick(db, tick)
+    await loop._dispatch_reflection(tick)
+
+    # Engine SHOULD be called — critical signal active
+    engine.reflect.assert_called_once()
+    row = await awareness_ticks.get_by_id(db, tick.tick_id)
+    assert row["dispatched"] == 1
+
+
+async def test_micro_dispatch_fires_llm_on_sentinel_anomaly(db):
+    """Micro ticks with sentinel_activity >= 0.7 fire the LLM."""
+    engine = AsyncMock()
+    engine.reflect = AsyncMock(return_value=MagicMock(success=True, output=None))
+    loop = AwarenessLoop(db=db, collectors=[])
+    loop.set_reflection_engine(engine)
+
+    tick = _micro_tick([
+        SignalReading(name="sentinel_activity", value=0.7, source="test",
+                      collected_at="2026-05-21T12:00:00+00:00"),
+    ])
+
+    await _persist_tick(db, tick)
+    await loop._dispatch_reflection(tick)
+
+    engine.reflect.assert_called_once()
+
+
+async def test_micro_dispatch_silent_on_low_sentinel(db):
+    """Micro ticks with sentinel_activity < 0.7 do NOT fire LLM."""
+    engine = AsyncMock()
+    loop = AwarenessLoop(db=db, collectors=[])
+    loop.set_reflection_engine(engine)
+
+    tick = _micro_tick([
+        SignalReading(name="sentinel_activity", value=0.3, source="test",
+                      collected_at="2026-05-21T12:00:00+00:00"),
+    ])
+
+    await _persist_tick(db, tick)
+    await loop._dispatch_reflection(tick)
+
+    engine.reflect.assert_not_called()

--- a/tests/test_awareness/test_loop.py
+++ b/tests/test_awareness/test_loop.py
@@ -210,3 +210,21 @@ async def test_micro_dispatch_silent_on_low_sentinel(db):
     await loop._dispatch_reflection(tick)
 
     engine.reflect.assert_not_called()
+
+
+async def test_micro_dispatch_fires_llm_on_critical_failure(db):
+    """Micro ticks with critical_failure > 0 fire the LLM."""
+    engine = AsyncMock()
+    engine.reflect = AsyncMock(return_value=MagicMock(success=True, output=None))
+    loop = AwarenessLoop(db=db, collectors=[])
+    loop.set_reflection_engine(engine)
+
+    tick = _micro_tick([
+        SignalReading(name="critical_failure", value=1.0, source="test",
+                      collected_at="2026-05-21T12:00:00+00:00"),
+    ], tick_id="test-crit-fail")
+
+    await _persist_tick(db, tick)
+    await loop._dispatch_reflection(tick)
+
+    engine.reflect.assert_called_once()


### PR DESCRIPTION
## Summary

- **Silent micro ticks by default** — routine micro ticks skip the LLM call entirely, just count for cascade escalation. ~90% of micro ticks go silent.
- **Critical-signal-only LLM trigger** — fires only on `software_error_spike > 0`, `critical_failure > 0`, or `sentinel_activity >= 0.7`. Score-based thresholds rejected after data analysis showed zero score-quality correlation.
- **`user_session_pattern` scoped to Light-only** — persistent behavioral signal drove 55.6% of Micro triggers with zero actionable insight. Migration + seed update.
- **Downstream quarantine** — filter `micro_reflection` from Light/Deep/Strategic context assembly, Deep pending work detection, and ego observation context.
- **DB cleanup** — resolved 4 remaining unresolved micro_reflection observations.

### Why

Analysis of 310 micro ticks and 178 observations over 30 days revealed:
- ~95% of micro observations were repetitive noise (same persistent conditions restated)
- No correlation between composite score and observation quality
- Micro observations leaked into Light/Deep/Ego context through 4 unfiltered query paths
- Escalation cascade (micro_count_since_light) counts ticks, not observations — unaffected

### What stays unchanged

- Signal collection, scoring, classification (Micro depth still classified)
- Tick creation + dispatching (cascade works on ticks)
- Light/Deep/Strategic reflection paths
- ReflectionEngine (still callable for anomaly ticks)

## Test plan

- [x] 10 awareness loop tests pass (5 existing + 5 new micro dispatch tests)
- [x] 239 total tests pass across awareness/perception/reflection bridge
- [x] `ruff check` clean on all 7 changed files
- [x] Code review: pass (2 pre-existing rough edges noted, both self-correcting)
- [ ] After deploy: verify routine micro ticks log "silent" with no LLM call
- [ ] After deploy: verify `micro_count_since_light` still increments
- [ ] After deploy: verify Light still triggers on schedule