### PR TITLE
feat(ego,memory): ego integrity gates + recall quality instrumentation

### DIFF
--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -28,6 +28,8 @@ async def create_cycle(
     output_tokens: int = 0,
     duration_ms: int = 0,
     created_at: str | None = None,
+    output_hash: str | None = None,
+    output_size: int | None = None,
 ) -> str:
     """Insert a new ego cycle record. Returns the id."""
     if created_at is None:
@@ -36,8 +38,8 @@ async def create_cycle(
         """INSERT INTO ego_cycles
            (id, output_text, proposals_json, focus_summary,
             model_used, cost_usd, input_tokens, output_tokens,
-            duration_ms, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            duration_ms, created_at, output_hash, output_size)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             id,
             output_text,
@@ -49,6 +51,8 @@ async def create_cycle(
             output_tokens,
             duration_ms,
             created_at,
+            output_hash,
+            output_size,
         ),
     )
     await db.commit()
@@ -228,6 +232,8 @@ async def create_proposal(
     realist_reasoning: str | None = None,
     ego_source: str | None = None,
     goal_id: str | None = None,
+    content_hash: str | None = None,
+    original_content: str | None = None,
 ) -> str:
     """Insert a new ego proposal. Returns the id."""
     if created_at is None:
@@ -238,8 +244,8 @@ async def create_proposal(
             confidence, urgency, alternatives, status, cycle_id,
             batch_id, created_at, expires_at, rank, execution_plan,
             recurring, memory_basis, realist_verdict, realist_reasoning,
-            ego_source, goal_id)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ego_source, goal_id, content_hash, original_content)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             id,
             action_type,
@@ -262,6 +268,8 @@ async def create_proposal(
             realist_reasoning,
             ego_source,
             goal_id,
+            content_hash,
+            original_content,
         ),
     )
     await db.commit()

--- a/src/genesis/db/migrations/0021_ego_integrity_tracking.py
+++ b/src/genesis/db/migrations/0021_ego_integrity_tracking.py
@@ -1,0 +1,86 @@
+"""Add integrity tracking columns to ego_cycles and ego_proposals.
+
+ego_cycles: output_hash, output_size for audit trail on raw ego output.
+ego_proposals: content_hash for creation-time fingerprint,
+              original_content to preserve pre-realist-amendment text.
+
+Idempotent — column adds guarded by PRAGMA table_info.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # -- ego_cycles --
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='ego_cycles'"
+    )
+    if await cursor.fetchone():
+        cursor = await db.execute("PRAGMA table_info(ego_cycles)")
+        cols = {row[1] for row in await cursor.fetchall()}
+
+        if "output_hash" not in cols:
+            await db.execute(
+                "ALTER TABLE ego_cycles ADD COLUMN output_hash TEXT"
+            )
+        if "output_size" not in cols:
+            await db.execute(
+                "ALTER TABLE ego_cycles ADD COLUMN output_size INTEGER"
+            )
+
+    # -- ego_proposals --
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='ego_proposals'"
+    )
+    if await cursor.fetchone():
+        cursor = await db.execute("PRAGMA table_info(ego_proposals)")
+        cols = {row[1] for row in await cursor.fetchall()}
+
+        if "content_hash" not in cols:
+            await db.execute(
+                "ALTER TABLE ego_proposals ADD COLUMN content_hash TEXT"
+            )
+        if "original_content" not in cols:
+            await db.execute(
+                "ALTER TABLE ego_proposals ADD COLUMN original_content TEXT"
+            )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    # ego_cycles
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='ego_cycles'"
+    )
+    if await cursor.fetchone():
+        cursor = await db.execute("PRAGMA table_info(ego_cycles)")
+        cols = {row[1] for row in await cursor.fetchall()}
+        if "output_hash" in cols:
+            await db.execute(
+                "ALTER TABLE ego_cycles DROP COLUMN output_hash"
+            )
+        if "output_size" in cols:
+            await db.execute(
+                "ALTER TABLE ego_cycles DROP COLUMN output_size"
+            )
+
+    # ego_proposals
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='ego_proposals'"
+    )
+    if await cursor.fetchone():
+        cursor = await db.execute("PRAGMA table_info(ego_proposals)")
+        cols = {row[1] for row in await cursor.fetchall()}
+        if "content_hash" in cols:
+            await db.execute(
+                "ALTER TABLE ego_proposals DROP COLUMN content_hash"
+            )
+        if "original_content" in cols:
+            await db.execute(
+                "ALTER TABLE ego_proposals DROP COLUMN original_content"
+            )

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -749,7 +749,9 @@ TABLES = {
             output_tokens   INTEGER NOT NULL DEFAULT 0,
             duration_ms     INTEGER NOT NULL DEFAULT 0,
             created_at      TEXT NOT NULL,
-            compacted_into  TEXT                     -- set when folded into compacted summary
+            compacted_into  TEXT,                    -- set when folded into compacted summary
+            output_hash     TEXT,                    -- SHA-256 of output_text for audit trail
+            output_size     INTEGER                  -- byte count of output_text
         )
     """,
     "ego_proposals": """
@@ -776,7 +778,9 @@ TABLES = {
             realist_verdict  TEXT,                     -- realist gate: pass/amend/reject
             realist_reasoning TEXT,                    -- realist gate: explanation
             ego_source       TEXT,                    -- which ego created this (user_ego_cycle / genesis_ego_cycle)
-            goal_id          TEXT                     -- FK to user_goals.id (nullable — not all proposals serve a goal)
+            goal_id          TEXT,                    -- FK to user_goals.id (nullable — not all proposals serve a goal)
+            content_hash     TEXT,                    -- SHA-256 of content at creation time
+            original_content TEXT                     -- pre-realist-amendment content (NULL if not amended)
         )
     """,
     "ego_state": """

--- a/src/genesis/ego/compaction.py
+++ b/src/genesis/ego/compaction.py
@@ -69,6 +69,8 @@ class CompactionEngine:
         Returns the cycle id. Cycles are stored for audit logging,
         cost tracking, and historical analysis.
         """
+        from genesis.ego.integrity import content_hash, content_size
+
         return await ego_crud.create_cycle(
             self._db,
             id=cycle.id,
@@ -81,6 +83,8 @@ class CompactionEngine:
             output_tokens=cycle.output_tokens,
             duration_ms=cycle.duration_ms,
             created_at=cycle.created_at,
+            output_hash=content_hash(cycle.output_text),
+            output_size=content_size(cycle.output_text),
         )
 
     async def assemble_context(

--- a/src/genesis/ego/integrity.py
+++ b/src/genesis/ego/integrity.py
@@ -1,0 +1,19 @@
+"""Content integrity utilities for ego pipeline audit tracking.
+
+Provides lightweight hash and size computation for tracking content
+mutations through the ego cycle → realist gate → proposal pipeline.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def content_hash(text: str) -> str:
+    """SHA-256 hex digest of UTF-8 encoded text."""
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def content_size(text: str) -> int:
+    """Byte count of UTF-8 encoded text."""
+    return len(text.encode())

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -166,6 +166,8 @@ class ProposalWorkflow:
                     exc_info=True,
                 )
 
+        from genesis.ego.integrity import content_hash as _content_hash
+
         ids: list[str] = []
         for p in proposals:
             pid = uuid.uuid4().hex[:16]
@@ -189,12 +191,13 @@ class ProposalWorkflow:
             else:
                 goal_id = raw_goal_id
 
+            proposal_content = p.get("content", "")
             await ego_crud.create_proposal(
                 self._db,
                 id=pid,
                 action_type=p.get("action_type", "unknown"),
                 action_category=p.get("action_category", ""),
-                content=p.get("content", ""),
+                content=proposal_content,
                 rationale=p.get("rationale", ""),
                 confidence=float(p.get("confidence", 0.0)),
                 urgency=p.get("urgency", "normal"),
@@ -210,6 +213,8 @@ class ProposalWorkflow:
                 realist_reasoning=p.get("_realist_reasoning"),
                 ego_source=ego_source,
                 goal_id=goal_id,
+                content_hash=_content_hash(proposal_content),
+                original_content=p.get("_original_content"),
             )
             ids.append(pid)
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -623,6 +623,7 @@ class EgoSession:
                 prop["_realist_reasoning"] = verdict.get("reasoning", "")
 
                 if verdict["verdict"] == "amend" and verdict.get("amended_content"):
+                    prop["_original_content"] = prop["content"]
                     prop["content"] = verdict["amended_content"]
                     amended_count += 1
 

--- a/src/genesis/eval/j9_hooks.py
+++ b/src/genesis/eval/j9_hooks.py
@@ -29,8 +29,11 @@ async def emit_recall_fired(
     mode: str | None = None,
     pipeline_used: str | None = None,
     intent_category: str | None = None,
-) -> None:
-    """Log a memory recall() invocation as an eval event."""
+) -> str | None:
+    """Log a memory recall() invocation as an eval event.
+
+    Returns the event id so callers can link diagnostics events.
+    """
     try:
         metrics: dict = {
             "query": query[:500],
@@ -46,7 +49,7 @@ async def emit_recall_fired(
             metrics["pipeline_used"] = pipeline_used
         if intent_category:
             metrics["intent_category"] = intent_category
-        await j9_eval.insert_event(
+        return await j9_eval.insert_event(
             db,
             dimension="memory",
             event_type="recall_fired",
@@ -55,6 +58,7 @@ async def emit_recall_fired(
         )
     except Exception:
         logger.debug("eval: failed to emit recall_fired", exc_info=True)
+        return None
 
 
 async def emit_proposal_resolved(
@@ -128,3 +132,75 @@ async def emit_procedure_outcome(
         )
     except Exception:
         logger.debug("eval: failed to emit procedure_outcome", exc_info=True)
+
+
+async def emit_recall_diagnostics(
+    db: aiosqlite.Connection,
+    *,
+    recall_event_id: str | None,
+    qdrant_pool_size: int,
+    fts_pool_size: int,
+    event_pool_size: int,
+    total_candidates: int,
+    overlap_count: int,
+    score_spread: float | None,
+    embedding_available: bool,
+    intent_category: str,
+    intent_confidence: float,
+    query_expanded: bool,
+) -> None:
+    """Log intermediate retrieval pipeline diagnostics for a recall.
+
+    Captures source pool sizes, overlap statistics, and RRF score
+    distribution — data that exists in local variables during recall()
+    but otherwise goes out of scope.
+    """
+    try:
+        await j9_eval.insert_event(
+            db,
+            dimension="memory",
+            event_type="recall_diagnostics",
+            subject_id=recall_event_id,
+            metrics={
+                "qdrant_pool": qdrant_pool_size,
+                "fts_pool": fts_pool_size,
+                "event_pool": event_pool_size,
+                "total_candidates": total_candidates,
+                "overlap": overlap_count,
+                "score_spread": score_spread,
+                "embedding_available": embedding_available,
+                "intent": intent_category,
+                "intent_confidence": round(intent_confidence, 3),
+                "query_expanded": query_expanded,
+            },
+        )
+    except Exception:
+        logger.debug("eval: failed to emit recall_diagnostics", exc_info=True)
+
+
+async def emit_recall_used(
+    db: aiosqlite.Connection,
+    *,
+    memory_ids: list[str],
+    source: str = "memory_expand",
+) -> None:
+    """Log that specific memories were accessed/used downstream.
+
+    This provides the implicit relevance signal that
+    _compute_memory_quality() in j9_aggregator expects from
+    'recall_used' events.
+    """
+    try:
+        await j9_eval.insert_event(
+            db,
+            dimension="memory",
+            event_type="recall_used",
+            metrics={
+                "memory_ids": memory_ids[:20],
+                "source": source,
+                "used": True,
+                "count": len(memory_ids),
+            },
+        )
+    except Exception:
+        logger.debug("eval: failed to emit recall_used", exc_info=True)

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -302,6 +302,19 @@ async def memory_expand(
     found_ids = {str(p.id) for p in points}
     not_found = [mid for mid in memory_ids if mid not in found_ids]
 
+    # J-9 eval: implicit relevance signal — expanded memories are "used"
+    if found_ids:
+        try:
+            from genesis.eval.j9_hooks import emit_recall_used
+
+            await emit_recall_used(
+                memory_mod._db,
+                memory_ids=list(found_ids),
+                source="memory_expand",
+            )
+        except Exception:
+            logger.debug("eval: recall_used emit failed", exc_info=True)
+
     results = []
     for point in points:
         mid = str(point.id)

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -570,8 +570,12 @@ class HybridRetriever:
             )
 
         # J-9 eval: log recall event for memory retrieval quality measurement
-        from genesis.eval.j9_hooks import emit_recall_fired
-        await emit_recall_fired(
+        from genesis.eval.j9_hooks import (
+            emit_recall_diagnostics,
+            emit_recall_fired,
+        )
+
+        recall_event_id = await emit_recall_fired(
             self._db,
             query=query,
             result_count=len(results),
@@ -579,6 +583,25 @@ class HybridRetriever:
             memory_ids=[r.memory_id for r in results[:10]],
             latency_ms=(time.monotonic() - _t0) * 1000,
             source=source,
+            intent_category=intent.category,
+        )
+
+        # Recall diagnostics: capture intermediate pipeline metrics
+        _overlap = len(set(qdrant_by_id) & set(fts_by_id))
+        _scores = [r.score for r in results]
+        await emit_recall_diagnostics(
+            self._db,
+            recall_event_id=recall_event_id,
+            qdrant_pool_size=len(qdrant_by_id),
+            fts_pool_size=len(fts_by_id),
+            event_pool_size=len(event_memory_ids),
+            total_candidates=len(all_ids),
+            overlap_count=_overlap,
+            score_spread=round(max(_scores) - min(_scores), 4) if _scores else None,
+            embedding_available=embedding_available,
+            intent_category=intent.category,
+            intent_confidence=intent.confidence,
+            query_expanded=fts_query != query,
         )
 
         return results

--- a/tests/test_ego/test_integrity.py
+++ b/tests/test_ego/test_integrity.py
@@ -1,0 +1,158 @@
+"""Tests for ego pipeline integrity tracking.
+
+Covers: integrity utility, CRUD columns, realist gate original_content
+preservation, and cycle storage with hash/size.
+"""
+
+from __future__ import annotations
+
+from genesis.db.crud import ego as ego_crud
+from genesis.ego.integrity import content_hash, content_size
+
+# ── Utility ─────────────────────────────────────────────────────────────────
+
+
+def test_content_hash_deterministic():
+    text = "Propose investigating memory drift"
+    assert content_hash(text) == content_hash(text)
+
+
+def test_content_hash_different_input():
+    assert content_hash("alpha") != content_hash("beta")
+
+
+def test_content_hash_is_sha256_hex():
+    h = content_hash("test")
+    assert len(h) == 64  # SHA-256 hex digest length
+    assert all(c in "0123456789abcdef" for c in h)
+
+
+def test_content_size_ascii():
+    assert content_size("hello") == 5
+
+
+def test_content_size_utf8():
+    # Japanese characters are 3 bytes each in UTF-8
+    assert content_size("日本") == 6
+
+
+def test_content_size_empty():
+    assert content_size("") == 0
+
+
+# ── CRUD: ego_cycles with integrity columns ─────────────────────────────────
+
+
+async def test_create_cycle_with_integrity(db):
+    text = "Full ego output text here"
+    cid = await ego_crud.create_cycle(
+        db,
+        id="cycle-int-1",
+        output_text=text,
+        output_hash=content_hash(text),
+        output_size=content_size(text),
+    )
+    row = await ego_crud.get_cycle(db, cid)
+    assert row is not None
+    assert row["output_hash"] == content_hash(text)
+    assert row["output_size"] == content_size(text)
+
+
+async def test_create_cycle_without_integrity(db):
+    """Backward compatibility — omitting integrity params still works."""
+    cid = await ego_crud.create_cycle(
+        db,
+        id="cycle-compat-1",
+        output_text="no hash",
+    )
+    row = await ego_crud.get_cycle(db, cid)
+    assert row is not None
+    assert row["output_hash"] is None
+    assert row["output_size"] is None
+
+
+# ── CRUD: ego_proposals with integrity columns ──────────────────────────────
+
+
+async def test_create_proposal_with_hash(db):
+    content = "Investigate memory drift patterns"
+    pid = await ego_crud.create_proposal(
+        db,
+        id="prop-hash-1",
+        action_type="investigate",
+        content=content,
+        content_hash=content_hash(content),
+    )
+    row = await ego_crud.get_proposal(db, pid)
+    assert row is not None
+    assert row["content_hash"] == content_hash(content)
+    assert row["original_content"] is None  # not amended
+
+
+async def test_create_proposal_with_original_content(db):
+    """When realist gate amends, original_content preserves pre-amendment."""
+    original = "Draft outreach to AI community"
+    amended = "Draft targeted outreach to AI agent builders"
+
+    pid = await ego_crud.create_proposal(
+        db,
+        id="prop-amend-1",
+        action_type="outreach",
+        content=amended,
+        content_hash=content_hash(amended),
+        original_content=original,
+    )
+    row = await ego_crud.get_proposal(db, pid)
+    assert row is not None
+    assert row["content"] == amended
+    assert row["original_content"] == original
+    assert row["content_hash"] == content_hash(amended)
+
+
+async def test_create_proposal_without_integrity(db):
+    """Backward compatibility — omitting integrity params still works."""
+    pid = await ego_crud.create_proposal(
+        db,
+        id="prop-compat-1",
+        action_type="investigate",
+        content="no hash provided",
+    )
+    row = await ego_crud.get_proposal(db, pid)
+    assert row is not None
+    assert row["content_hash"] is None
+    assert row["original_content"] is None
+
+
+# ── Realist gate: _original_content propagation ─────────────────────────────
+
+
+def test_realist_amendment_sets_original_content():
+    """Simulate the realist gate mutation to verify _original_content is set."""
+    prop = {
+        "content": "Investigate X",
+        "action_type": "investigate",
+    }
+    verdict = {"verdict": "amend", "amended_content": "Investigate X (narrowed scope)"}
+
+    # Simulate session.py _filter_proposals logic
+    if verdict["verdict"] == "amend" and verdict.get("amended_content"):
+        prop["_original_content"] = prop["content"]
+        prop["content"] = verdict["amended_content"]
+
+    assert prop["_original_content"] == "Investigate X"
+    assert prop["content"] == "Investigate X (narrowed scope)"
+
+
+def test_realist_pass_no_original_content():
+    """When realist passes without amendment, no _original_content key."""
+    prop = {
+        "content": "Investigate X",
+        "action_type": "investigate",
+    }
+    verdict = {"verdict": "pass", "reasoning": "looks good"}
+
+    if verdict["verdict"] == "amend" and verdict.get("amended_content"):
+        prop["_original_content"] = prop["content"]
+        prop["content"] = verdict["amended_content"]
+
+    assert "_original_content" not in prop

--- a/tests/test_eval/test_recall_instrumentation.py
+++ b/tests/test_eval/test_recall_instrumentation.py
@@ -1,0 +1,168 @@
+"""Tests for memory recall quality instrumentation.
+
+Covers: recall_diagnostics emitter, recall_used emitter,
+emit_recall_fired return value, and fire-and-forget safety.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from genesis.db.crud import j9_eval
+from genesis.eval.j9_hooks import (
+    emit_recall_diagnostics,
+    emit_recall_fired,
+    emit_recall_used,
+)
+
+# ── emit_recall_fired returns event_id ──────────────────────────────────────
+
+
+async def test_emit_recall_fired_returns_event_id(db):
+    event_id = await emit_recall_fired(
+        db,
+        query="test query",
+        result_count=5,
+        top_scores=[0.8, 0.7, 0.6],
+        memory_ids=["m1", "m2"],
+        latency_ms=42.0,
+        source="both",
+    )
+    assert event_id is not None
+    assert isinstance(event_id, str)
+    assert len(event_id) > 0
+
+
+async def test_emit_recall_fired_returns_none_on_error():
+    """Fire-and-forget: returns None on failure, does not raise."""
+    bad_db = AsyncMock()
+    bad_db.execute = AsyncMock(side_effect=RuntimeError("db gone"))
+
+    result = await emit_recall_fired(
+        bad_db,
+        query="test",
+        result_count=0,
+        top_scores=[],
+        memory_ids=[],
+        latency_ms=0,
+        source="both",
+    )
+    assert result is None
+
+
+# ── emit_recall_diagnostics ─────────────────────────────────────────────────
+
+
+async def test_emit_recall_diagnostics_stores_event(db):
+    await emit_recall_diagnostics(
+        db,
+        recall_event_id="evt-123",
+        qdrant_pool_size=42,
+        fts_pool_size=35,
+        event_pool_size=0,
+        total_candidates=60,
+        overlap_count=17,
+        score_spread=0.0234,
+        embedding_available=True,
+        intent_category="WHAT",
+        intent_confidence=0.85,
+        query_expanded=True,
+    )
+
+    events = await j9_eval.get_events(db, event_type="recall_diagnostics")
+    assert len(events) == 1
+
+    m = events[0]["metrics"]
+    assert m["qdrant_pool"] == 42
+    assert m["fts_pool"] == 35
+    assert m["event_pool"] == 0
+    assert m["total_candidates"] == 60
+    assert m["overlap"] == 17
+    assert m["score_spread"] == 0.0234
+    assert m["embedding_available"] is True
+    assert m["intent"] == "WHAT"
+    assert m["intent_confidence"] == 0.85
+    assert m["query_expanded"] is True
+    assert events[0]["subject_id"] == "evt-123"
+
+
+async def test_emit_recall_diagnostics_fire_and_forget():
+    """Should not propagate errors."""
+    bad_db = AsyncMock()
+    bad_db.execute = AsyncMock(side_effect=RuntimeError("db gone"))
+
+    # Should not raise
+    await emit_recall_diagnostics(
+        bad_db,
+        recall_event_id=None,
+        qdrant_pool_size=0,
+        fts_pool_size=0,
+        event_pool_size=0,
+        total_candidates=0,
+        overlap_count=0,
+        score_spread=None,
+        embedding_available=False,
+        intent_category="GENERAL",
+        intent_confidence=0.5,
+        query_expanded=False,
+    )
+
+
+async def test_emit_recall_diagnostics_null_score_spread(db):
+    """score_spread is None when no results."""
+    await emit_recall_diagnostics(
+        db,
+        recall_event_id=None,
+        qdrant_pool_size=0,
+        fts_pool_size=0,
+        event_pool_size=0,
+        total_candidates=0,
+        overlap_count=0,
+        score_spread=None,
+        embedding_available=False,
+        intent_category="GENERAL",
+        intent_confidence=0.5,
+        query_expanded=False,
+    )
+
+    events = await j9_eval.get_events(db, event_type="recall_diagnostics")
+    assert len(events) == 1
+    assert events[0]["metrics"]["score_spread"] is None
+
+
+# ── emit_recall_used ────────────────────────────────────────────────────────
+
+
+async def test_emit_recall_used_stores_event(db):
+    await emit_recall_used(
+        db,
+        memory_ids=["mem-1", "mem-2", "mem-3"],
+        source="memory_expand",
+    )
+
+    events = await j9_eval.get_events(db, event_type="recall_used")
+    assert len(events) == 1
+
+    m = events[0]["metrics"]
+    assert m["memory_ids"] == ["mem-1", "mem-2", "mem-3"]
+    assert m["source"] == "memory_expand"
+    assert m["used"] is True
+    assert m["count"] == 3
+
+
+async def test_emit_recall_used_truncates_long_list(db):
+    """Memory IDs are capped at 20."""
+    ids = [f"mem-{i}" for i in range(30)]
+    await emit_recall_used(db, memory_ids=ids)
+
+    events = await j9_eval.get_events(db, event_type="recall_used")
+    assert len(events[0]["metrics"]["memory_ids"]) == 20
+
+
+async def test_emit_recall_used_fire_and_forget():
+    """Should not propagate errors."""
+    bad_db = AsyncMock()
+    bad_db.execute = AsyncMock(side_effect=RuntimeError("db gone"))
+
+    # Should not raise
+    await emit_recall_used(bad_db, memory_ids=["mem-1"])


### PR DESCRIPTION
## Summary
- **Ego integrity gates**: Track content hash/size at cycle storage and proposal creation. Preserve original content before realist gate amendment (new `output_hash`/`output_size` on `ego_cycles`, `content_hash`/`original_content` on `ego_proposals`). Migration 0021.
- **Memory recall instrumentation**: Emit `recall_diagnostics` (source pool sizes, overlap, score spread) and `recall_used` (implicit relevance from `memory_expand`) events for J-9 quality aggregation. `emit_recall_fired` now returns event_id for linking.

## Motivation
- Microsoft Research found 25-50% content corruption in multi-step LLM workflows. Ego is live — this adds cheap, passive integrity tracking.
- 22K+ memories with fixed RRF fusion weights and no way to measure recall quality. This provides the instrumentation needed for future auto-tuning.

## Test plan
- [x] 21 new tests (13 integrity, 8 instrumentation) — all passing
- [x] 121 total tests in ego + eval suites — zero regressions
- [x] Full lint clean (`ruff check`)
- [x] Code reviewer agent: 0 critical, 0 important after fixes
- [ ] CI passes
- [ ] Verify migration applies on server restart
- [ ] Verify recall_diagnostics events appear in eval_events after memory_recall

🤖 Generated with [Claude Code](https://claude.com/claude-code)