### PR TITLE
fix(ego): tighten observation TTLs for infra types + add age annotations

### DIFF
--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -83,6 +83,8 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     "dead_letter_replay": timedelta(days=3),
     "light_reflection_candidate": timedelta(days=3),
     "process_reaper_kill": timedelta(days=3),
+    "operational_alert": timedelta(days=3),
+    "strategic_reflection": timedelta(days=3),
     # ── 1-day (transient) ──────────────────────────────────────────────
     "light_escalation_resolved": timedelta(days=1),
     "light_escalation_pending": timedelta(days=1),
@@ -91,11 +93,9 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     # ── 7-day (version tracking, operational) ──────────────────────────
     "genesis_version_change": timedelta(days=7),
     "memory_index": timedelta(days=7),
-    "operational_alert": timedelta(days=7),
     "db_maintenance": timedelta(days=7),
     "backup_verification": timedelta(days=7),
     "scheduled_review": timedelta(days=7),
-    "strategic_reflection": timedelta(days=7),
     "micro_reflection": timedelta(days=7),
     "deep_reflection": timedelta(days=7),
     "reflection_observation": timedelta(days=7),
@@ -106,6 +106,9 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     "question_response": timedelta(days=7),
     "init_degradation": timedelta(days=7),
     "procedure_quarantined": timedelta(days=7),
+    "escalation_to_user_ego": timedelta(days=7),
+    "sentinel_escalated": timedelta(days=7),
+    "guardian_diagnosis": timedelta(days=7),
     # ── 14-day (learning artifacts & assessments — also the DEFAULT) ───
     "build_state": timedelta(days=14),
     "project_context": timedelta(days=14),
@@ -121,12 +124,10 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     "quality_calibration": timedelta(days=14),
     "user_model_delta": timedelta(days=14),
     "capability_improvement": timedelta(days=14),
-    "escalation_to_user_ego": timedelta(days=14),
     "strategic_analysis": timedelta(days=14),
     # ── 30-day (intake signals, need processing time) ──────────────────
     "finding": timedelta(days=30),
     "bugfix_committed": timedelta(days=30),
-    "sentinel_escalated": timedelta(days=30),
     "user_signal": timedelta(days=30),
     "user_model_gap": timedelta(days=30),
     "reference_pointer": timedelta(days=30),
@@ -134,7 +135,6 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     "test_isolation_gap": timedelta(days=30),
     "operational_gap": timedelta(days=30),
     "interaction_theme": timedelta(days=30),
-    "guardian_diagnosis": timedelta(days=30),
     # ── 60-day (action-required, real issues) ──────────────────────────
     "bug_identified": timedelta(days=60),
     "tech_debt": timedelta(days=60),

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -631,10 +631,11 @@ class UserEgoContextBuilder:
             return "\n".join(lines)
 
         lines.append(f"**{len(rows)} escalations** needing your attention:\n")
-        for _source, content, priority, _created_at in rows:
+        for _source, content, priority, created_at in rows:
+            age = self._days_ago(created_at) or "?"
             short = content[:300] + "..." if len(content) > 300 else content
             short = short.replace("\n", " ")
-            lines.append(f"- [{priority}] {short}")
+            lines.append(f"- [{age}] [{priority}] {short}")
 
         lines.append(
             "\nThese are issues the Genesis ego couldn't resolve alone. "


### PR DESCRIPTION
## Summary

- Recalibrate TTLs for infrastructure observation types that were too generous for ephemeral system state:
  - `sentinel_escalated`: 30d → 7d
  - `guardian_diagnosis`: 30d → 7d
  - `escalation_to_user_ego`: 14d → 7d
  - `operational_alert`: 7d → 3d
  - `strategic_reflection`: 7d → 3d
- Add age annotation (`[today]`, `[2d ago]`) to ego escalation context so the ego can see how old escalations are
- `finding` type (30d) intentionally NOT changed — dual-use for recon signals that legitimately need processing time

## Context

Root cause fix for the stale-belief incident (May 20) where the ego
downgraded its Medium article proposal because 5-day-old observations
said the pipeline was broken (it had been fixed by PRs #348/#390 days
earlier). The behavioral guard ("verify before assuming broken") was
deployed in PR #403; this PR addresses the structural calibration.

## Post-merge action

Backfill `expires_at` on production DB for existing observations of
affected types so the next 2 AM sweep resolves stale entries:

```sql
UPDATE observations SET expires_at = datetime(created_at, '+7 days')
WHERE type IN ('sentinel_escalated', 'guardian_diagnosis', 'escalation_to_user_ego')
  AND resolved = 0;

UPDATE observations SET expires_at = datetime(created_at, '+3 days')
WHERE type IN ('operational_alert', 'strategic_reflection')
  AND resolved = 0;
```

## Test plan

- [x] `ruff check` passes
- [x] `pytest tests/ -k observation` — 157 tests pass
- [x] `pytest tests/test_ego/` — 18 tests pass
- [x] `_compute_ttl()` returns correct values for all changed types
- [ ] After merge + backfill: verify unresolved count drops at next sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)