### PR TITLE
refactor(reflection): event-driven anomaly focus + delta-only Light prompts

### DIFF
--- a/src/genesis/cc/reflection_bridge/_output.py
+++ b/src/genesis/cc/reflection_bridge/_output.py
@@ -59,6 +59,17 @@ async def store_reflection_output(depth, tick, output, *, db) -> None:
     now = datetime.now(UTC).isoformat()
     source = f"cc_reflection_{depth.value.lower()}"
 
+    # Extract focus_area from Light output JSON for category metadata.
+    focus_area = None
+    if depth == Depth.LIGHT:
+        try:
+            json_match = re.search(r"```json\s*(.*?)\s*```", output.text, re.DOTALL)
+            raw_json = json_match.group(1) if json_match else output.text
+            parsed = json.loads(raw_json)
+            focus_area = (parsed.get("focus_area") or "").strip() or None
+        except (json.JSONDecodeError, AttributeError, TypeError):
+            pass
+
     # Cooldown gate: skip primary observation if one of the same type+source
     # was created within the last 30 minutes.  Still process sub-outputs
     # (light escalations, deltas, surplus) and strategic focus.
@@ -88,6 +99,7 @@ async def store_reflection_output(depth, tick, output, *, db) -> None:
                 source=source,
                 type="reflection_output",
                 content=content,
+                category=focus_area,
                 priority="high" if depth == Depth.STRATEGIC else "medium",
                 created_at=now,
                 content_hash=content_hash,
@@ -105,7 +117,9 @@ async def store_reflection_output(depth, tick, output, *, db) -> None:
     # Store a consolidated reflection summary for embedding.
     # Deep reflections get their summary via OutputRouter.route() — skip here.
     if depth != Depth.DEEP:
-        await _store_reflection_summary(output, source=source, now=now, db=db)
+        await _store_reflection_summary(
+            output, source=source, now=now, db=db, category=focus_area,
+        )
 
 
 async def _process_light_output(output, *, source: str, now: str, db) -> None:
@@ -296,7 +310,9 @@ async def _extract_strategic_focus(output, *, now: str, db) -> None:
         logger.debug("Could not parse focus_next_week from strategic output")
 
 
-async def _store_reflection_summary(output, *, source: str, now: str, db) -> None:
+async def _store_reflection_summary(
+    output, *, source: str, now: str, db, category: str | None = None,
+) -> None:
     """Store a consolidated reflection summary for embedding."""
     from genesis.db.crud import observations
 
@@ -334,6 +350,7 @@ async def _store_reflection_summary(output, *, source: str, now: str, db) -> Non
                 source=source,
                 type="reflection_summary",
                 content=summary_text,
+                category=category,
                 priority="medium",
                 created_at=now,
                 content_hash=summary_hash,

--- a/src/genesis/cc/reflection_bridge/_prompts.py
+++ b/src/genesis/cc/reflection_bridge/_prompts.py
@@ -88,15 +88,38 @@ LIGHT_FOCUS_INSTRUCTIONS: dict[str, str] = {
 }
 
 
+# Anomaly focus is event-driven — only fires when critical operational
+# signals are active.  Continuous-drift signals (container_memory_pct,
+# micro_count_since_light, etc.) always change between ticks, making
+# staleness-based gating ineffective (0% of ticks would be gated).
+_ANOMALY_RELEVANT_SIGNALS = frozenset({"software_error_spike", "critical_failure"})
+_SENTINEL_ANOMALY_THRESHOLD = 0.7
+
+
 def _light_focus_area(tick: TickResult) -> str:
-    """Derive focus area from tick_id, matching perception engine rotation."""
+    """Derive focus area from tick_id.  Anomaly is event-driven — falls back
+    to situation when no critical operational signals are active."""
     import uuid as _uuid
 
     try:
         tick_number = _uuid.UUID(tick.tick_id).int % 10000
     except ValueError:
         tick_number = int.from_bytes(tick.tick_id.encode()[:8], "big") % 10000
-    return LIGHT_FOCUS_ROTATION[tick_number % len(LIGHT_FOCUS_ROTATION)]
+
+    candidate = LIGHT_FOCUS_ROTATION[tick_number % len(LIGHT_FOCUS_ROTATION)]
+
+    if candidate == "anomaly":
+        has_critical = any(
+            s.value > 0 for s in tick.signals
+            if s.name in _ANOMALY_RELEVANT_SIGNALS
+        ) or any(
+            s.value >= _SENTINEL_ANOMALY_THRESHOLD for s in tick.signals
+            if s.name == "sentinel_activity"
+        )
+        if not has_critical:
+            return "situation"
+
+    return candidate
 
 
 # ── Observation formatting ───────────────────────────────────────────

--- a/src/genesis/cc/reflection_bridge/_prompts.py
+++ b/src/genesis/cc/reflection_bridge/_prompts.py
@@ -92,6 +92,7 @@ LIGHT_FOCUS_INSTRUCTIONS: dict[str, str] = {
 # signals are active.  Continuous-drift signals (container_memory_pct,
 # micro_count_since_light, etc.) always change between ticks, making
 # staleness-based gating ineffective (0% of ticks would be gated).
+# NOTE: Must stay in sync with _MICRO_CRITICAL_SIGNALS in awareness/loop.py.
 _ANOMALY_RELEVANT_SIGNALS = frozenset({"software_error_spike", "critical_failure"})
 _SENTINEL_ANOMALY_THRESHOLD = 0.7
 

--- a/src/genesis/identity/REFLECTION_LIGHT.md
+++ b/src/genesis/identity/REFLECTION_LIGHT.md
@@ -71,6 +71,11 @@ or from the cognitive state you were given as context. If a condition was alread
 noted, it does not need noting again unless it has MATERIALLY CHANGED (new data,
 new threshold breach, new symptom). Restating known issues is noise.
 
+**Permission to say "nothing new":** If the signals haven't materially changed
+since the cognitive state was written, the correct response is a short assessment
+("no material change since last cycle") with confidence 0.3 and empty lists.
+This is better output than restating known conditions.
+
 **Verification protocol (MANDATORY):**
 1. For each issue mentioned in Recent Observations below, check: does the
    current signal data confirm this issue RIGHT NOW?

--- a/src/genesis/identity/REFLECTION_LIGHT_HAIKU.md
+++ b/src/genesis/identity/REFLECTION_LIGHT_HAIKU.md
@@ -16,6 +16,8 @@ when it impacts user value.
 2. Decide: escalate to Deep reflection? (yes/no + reason)
 3. Cite specific evidence for every claim
 4. Confidence: below 0.5 when uncertain. Never default to 0.7.
+5. If nothing material changed since the cognitive state: say "no material
+   change" with confidence 0.3. This is better than restating known conditions.
 
 ## Output Format
 Respond with valid JSON matching the focus area. Empty lists for fields

--- a/src/genesis/perception/templates/light/situation.txt
+++ b/src/genesis/perception/templates/light/situation.txt
@@ -19,6 +19,11 @@ You are in situation assessment mode.
 **Grounding rule:** Every claim in your assessment MUST cite a specific signal
 value or observation timestamp. If you cannot cite evidence, do not make the claim.
 
+**Delta-only:** Focus on what has CHANGED since the cognitive state above.
+If nothing material changed, say so — a short "no material change" with
+confidence 0.3 is better than restating known conditions. Persistent issues
+only need mention if they crossed a new threshold or have new evidence.
+
 **Anti-repetition:** If a condition appears in Recent Observations above AND
 Current Signals still confirm it, note "persists" with the current value.
 If signals no longer confirm it, omit it entirely. Silence > stale echoes.

--- a/src/genesis/perception/templates/light/user_impact.txt
+++ b/src/genesis/perception/templates/light/user_impact.txt
@@ -17,6 +17,10 @@ How do current conditions affect the user's goals and work?
 You are in user impact analysis mode. This is the ONLY reflection mode
 that produces user model updates.
 
+**Delta-only:** Only report user impacts that represent a CHANGE from the
+cognitive state above. If the user's situation hasn't shifted, say so —
+a short "no material user impact change" with confidence 0.3 is correct.
+
 **User model updates:** Only propose a delta if:
 1. You have specific signal or observation evidence (cite it)
 2. Confidence >= 0.9

--- a/tests/test_cc/test_light_focus_gate.py
+++ b/tests/test_cc/test_light_focus_gate.py
@@ -1,0 +1,97 @@
+"""Tests for Light reflection focus area gating.
+
+Anomaly focus is event-driven — falls back to situation when no critical
+operational signals are active.
+"""
+
+from genesis.awareness.types import Depth, DepthScore, SignalReading, TickResult
+from genesis.cc.reflection_bridge._prompts import _light_focus_area
+
+
+def _make_tick(signals: list[SignalReading], tick_id: str = "00000000-0000-0000-0000-000000000002") -> TickResult:
+    """Build a TickResult for focus area testing.
+
+    Default tick_id has UUID int % 3 == 2, which maps to 'anomaly' in rotation.
+    """
+    return TickResult(
+        tick_id=tick_id,
+        timestamp="2026-05-22T12:00:00+00:00",
+        source="scheduled",
+        signals=signals,
+        scores=[DepthScore(
+            depth=Depth.LIGHT, raw_score=0.8,
+            time_multiplier=1.0, final_score=0.8,
+            threshold=0.6, triggered=True,
+        )],
+        classified_depth=Depth.LIGHT,
+        trigger_reason="threshold_exceeded",
+    )
+
+
+def test_anomaly_fires_on_error_spike():
+    """Anomaly focus fires when software_error_spike > 0."""
+    tick = _make_tick([
+        SignalReading(name="software_error_spike", value=0.5, source="test",
+                      collected_at="2026-05-22T12:00:00+00:00"),
+    ])
+    assert _light_focus_area(tick) == "anomaly"
+
+
+def test_anomaly_fires_on_critical_failure():
+    """Anomaly focus fires when critical_failure > 0."""
+    tick = _make_tick([
+        SignalReading(name="critical_failure", value=1.0, source="test",
+                      collected_at="2026-05-22T12:00:00+00:00"),
+    ])
+    assert _light_focus_area(tick) == "anomaly"
+
+
+def test_anomaly_fires_on_sentinel_high():
+    """Anomaly focus fires when sentinel_activity >= 0.7."""
+    tick = _make_tick([
+        SignalReading(name="sentinel_activity", value=0.7, source="test",
+                      collected_at="2026-05-22T12:00:00+00:00"),
+    ])
+    assert _light_focus_area(tick) == "anomaly"
+
+
+def test_anomaly_falls_back_on_routine_signals():
+    """Anomaly focus falls back to situation when no critical signals active."""
+    tick = _make_tick([
+        SignalReading(name="autonomy_activity", value=0.3, source="test",
+                      collected_at="2026-05-22T12:00:00+00:00"),
+        SignalReading(name="container_memory_pct", value=0.25, source="test",
+                      collected_at="2026-05-22T12:00:00+00:00"),
+    ])
+    assert _light_focus_area(tick) == "situation"
+
+
+def test_anomaly_falls_back_on_low_sentinel():
+    """Anomaly doesn't fire when sentinel_activity < 0.7."""
+    tick = _make_tick([
+        SignalReading(name="sentinel_activity", value=0.3, source="test",
+                      collected_at="2026-05-22T12:00:00+00:00"),
+    ])
+    assert _light_focus_area(tick) == "situation"
+
+
+def test_situation_focus_unaffected():
+    """Situation focus always fires regardless of signals."""
+    # tick_id with UUID int % 3 == 0 maps to 'situation'
+    tick = _make_tick(
+        [SignalReading(name="autonomy_activity", value=0.3, source="test",
+                       collected_at="2026-05-22T12:00:00+00:00")],
+        tick_id="00000000-0000-0000-0000-000000000000",
+    )
+    assert _light_focus_area(tick) == "situation"
+
+
+def test_user_impact_focus_unaffected():
+    """User impact focus always fires regardless of signals."""
+    # tick_id with UUID int % 3 == 1 maps to 'user_impact'
+    tick = _make_tick(
+        [SignalReading(name="autonomy_activity", value=0.3, source="test",
+                       collected_at="2026-05-22T12:00:00+00:00")],
+        tick_id="00000000-0000-0000-0000-000000000001",
+    )
+    assert _light_focus_area(tick) == "user_impact"

--- a/tests/test_mcp/test_standalone_health.py
+++ b/tests/test_mcp/test_standalone_health.py
@@ -620,7 +620,7 @@ class TestReflectionHeartbeatEmission:
         from unittest.mock import AsyncMock, MagicMock
 
         from genesis.awareness.loop import AwarenessLoop
-        from genesis.awareness.types import Depth, TickResult
+        from genesis.awareness.types import Depth, SignalReading, TickResult
         from genesis.observability.types import Severity, Subsystem
 
         mock_engine = AsyncMock()
@@ -641,6 +641,11 @@ class TestReflectionHeartbeatEmission:
         tick = MagicMock(spec=TickResult)
         tick.classified_depth = Depth.MICRO
         tick.tick_id = "test-tick-123"
+        # Micro is silent by default — needs a critical signal to trigger LLM
+        tick.signals = [
+            SignalReading(name="software_error_spike", value=1.0,
+                          source="test", collected_at="2026-01-01T00:00:00"),
+        ]
 
         await loop._dispatch_reflection(tick)
 
@@ -673,6 +678,7 @@ class TestReflectionHeartbeatEmission:
         tick = MagicMock(spec=TickResult)
         tick.classified_depth = Depth.MICRO
         tick.tick_id = "test-tick-456"
+        tick.signals = []  # micro gate reads tick.signals
 
         await loop._dispatch_reflection(tick)
 

--- a/tests/test_perception/test_prompts.py
+++ b/tests/test_perception/test_prompts.py
@@ -87,13 +87,14 @@ def test_light_suggested_focus_user_impact():
 
 
 def test_light_focus_area_rotation():
-    """30 random UUIDs should produce all 3 focus areas."""
+    """30 random UUIDs should produce situation + user_impact (anomaly is event-driven)."""
     import uuid
 
-    from genesis.awareness.types import Depth, TickResult
+    from genesis.awareness.types import Depth, SignalReading, TickResult
     from genesis.cc.reflection_bridge import _light_focus_area
 
-    results = set()
+    # Without critical signals, anomaly falls back to situation.
+    results_quiet = set()
     for _ in range(30):
         tick = TickResult(
             tick_id=str(uuid.uuid4()),
@@ -101,8 +102,24 @@ def test_light_focus_area_rotation():
             source="scheduled", signals=[], scores=[],
             classified_depth=Depth.LIGHT, trigger_reason="test",
         )
-        results.add(_light_focus_area(tick))
-    assert results == {"situation", "user_impact", "anomaly"}
+        results_quiet.add(_light_focus_area(tick))
+    assert results_quiet == {"situation", "user_impact"}
+
+    # With a critical signal, anomaly can fire.
+    results_critical = set()
+    critical_signal = SignalReading(
+        name="software_error_spike", value=1.0, source="test",
+        collected_at="2026-03-28T12:00:00",
+    )
+    for _ in range(30):
+        tick = TickResult(
+            tick_id=str(uuid.uuid4()),
+            timestamp="2026-03-28T12:00:00",
+            source="scheduled", signals=[critical_signal], scores=[],
+            classified_depth=Depth.LIGHT, trigger_reason="test",
+        )
+        results_critical.add(_light_focus_area(tick))
+    assert results_critical == {"situation", "user_impact", "anomaly"}
 
 
 def test_variable_substitution():


### PR DESCRIPTION
## Summary

- **Event-driven anomaly focus** — Light's anomaly rotation fires only on critical operational signals (same pattern as micro: error spike, critical failure, sentinel >= 0.7). Falls back to situation otherwise. Data showed 0% of Light ticks had fully-stale signals (continuous-drift signals always change), so staleness-based gating was rejected in favor of critical-signal gating.
- **Delta-only prompt instructions** — Situation and user_impact templates now explicitly frame as delta-only. System prompts grant explicit permission to say "no material change" at confidence 0.3 instead of restating known conditions.
- **Store focus_area as category** — Parse focus_area from CC output JSON and store in observations.category column. Previously all 99 recent Light outputs had category=None.

### Why

Analysis of last 20 Light outputs showed 6/8 recent assessments restating the same known conditions ("micro delivery broken", "dream cycle failures"). The model has no prior-output memory, the prompt demands novelty every cycle, and 1/3 of cycles (anomaly focus) ran even when nothing anomalous was happening.

## Test plan

- [x] 7 new tests for focus area gating (critical signal fires, routine falls back, situation/user_impact unaffected)
- [x] 44 existing tests pass (bridge, perception, awareness)
- [x] `ruff check` clean on Python files
- [ ] After deploy: verify anomaly focus falls back to situation in logs when signals are quiet
- [ ] After deploy: verify `category` column populated on new `reflection_output` observations