### PR TITLE
fix(test): quiet hours collision + anti-rationalization tables

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -116,6 +116,26 @@ Full syntax, Cypher examples, and decision matrix:
   fires. Use `CronTrigger` for anything longer than a few hours.
   Bit us with `user_model_evolution` (48h interval, daily restarts).
 
+### Anti-Rationalization
+
+These are excuses sessions use to skip discipline. If you catch yourself
+thinking any of these, STOP — you are rationalizing a shortcut.
+
+| Rationalization | Why it's wrong |
+|---|---|
+| "This is just a simple fix, no tests needed" | Simple fixes break complex systems. The Qdrant regression was a "simple fix." Write the test. |
+| "I already know what this function does" | You haven't read the implementation. Docstrings lie. Read the actual code. |
+| "Tests pass, so we're done" | Tests verify what they cover, not the outcome. Verify actual end-to-end behavior. |
+| "I'll clean this up in the next commit" | Next commit never comes in autonomous sessions. Do it now or create a follow-up. |
+| "This file is too large to read fully" | Read the relevant section. Partial reads lead to partial understanding and wrong fixes. |
+| "The linter is happy, ship it" | Linters catch syntax, not logic. Clean lint with broken behavior is worse than a warning with correct behavior. |
+| "This change is low-risk, no impact analysis needed" | Your confidence is based on what you know. Impact analysis reveals what you don't. Run gitnexus impact. |
+| "I can skip the worktree, I'll be quick" | Concurrent session safety exists because "quick" commits have destroyed work before. Always worktree. |
+| "The error is transient, retry will fix it" | Diagnose first. Retrying a misdiagnosed error wastes tokens and masks root causes. |
+| "I'll add the follow-up later" | Follow-ups not created in-session are lost. Create it now while context is fresh. |
+| "I don't need a skill for this" | If a skill exists, use it. The using-superpowers Red Flags table exists for this exact rationalization. |
+| "I can read the summary instead of the source" | Summaries lose context. If you're about to change code, read the code, not the description of it. |
+
 ### Code Discovery
 
 Use the right tool for how you're exploring:

--- a/src/genesis/identity/SOUL.md
+++ b/src/genesis/identity/SOUL.md
@@ -120,6 +120,14 @@ You are overconfident. You compensate with null hypothesis defaults.
 You are sycophantic. You compensate by being explicitly instructed to challenge,
 and by tracking whether your challenges are evidence-based.
 
+You rationalize shortcuts. When a step feels unnecessary, you generate
+plausible-sounding reasons to skip it — "just a simple fix", "I already
+know what this does", "tests pass so we're done", "I'll add the follow-up
+later." These are rationalizations, not reasoning. The moment you catch
+yourself justifying why a step can be skipped, that is the signal to slow
+down and do it properly. Detailed anti-rationalization tables exist in
+domain-specific skills (e.g., genesis-development) — read them.
+
 Being honest about these weaknesses — and having architectural compensations for
 them — is what separates you from a chatbot running on the same LLM.
 

--- a/tests/test_outreach/test_governance.py
+++ b/tests/test_outreach/test_governance.py
@@ -32,8 +32,10 @@ def config():
     )
 
 
-# Narrow quiet window that won't interfere with test execution.
-_NO_QUIET_HOURS = QuietHours(start="02:00", end="02:30")
+# Quiet window that cannot interfere with test execution regardless of
+# timezone.  The 1-minute window at 23:58-23:59 avoids the 02:00-02:30
+# collision that broke CI (GitHub Actions runs at ~02:18 UTC).
+_NO_QUIET_HOURS = QuietHours(start="23:58", end="23:59")
 
 
 def _cfg_no_quiet(**overrides):

--- a/tests/test_outreach/test_pipeline.py
+++ b/tests/test_outreach/test_pipeline.py
@@ -20,7 +20,7 @@ from genesis.outreach.types import (
 @pytest.fixture
 def config():
     return OutreachConfig(
-        quiet_hours=QuietHours(start="02:00", end="02:30"),
+        quiet_hours=QuietHours(start="23:58", end="23:59"),
         channel_preferences={"default": "telegram"},
         thresholds={"blocker": 0.0, "alert": 0.3, "surplus": 0.7, "digest": 0.0},
         max_daily=5,


### PR DESCRIPTION
## Summary
- **Outreach test fix**: Quiet hours window `02:00-02:30` collided with CI runs at ~02:18 UTC, causing 9 governance/pipeline test failures. Changed to `23:58-23:59` (1-minute window that's effectively never active).
- **Anti-rationalization**: Added 12-row lookup table to genesis-development SKILL.md and compact principle to SOUL.md (from inbox evaluation of agent-skills project).

## Root cause
`_in_quiet_hours()` uses `user_timezone()` which returns UTC on GitHub Actions. The "no quiet hours" test config used `02:00-02:30` — exactly when CI runs. Tests expecting `ALLOW` got `DENY` because governance correctly enforced quiet hours.

## Test plan
- [x] All 30 outreach tests pass locally
- [ ] CI passes (this should fix all 9 outreach failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)