### PR TITLE
feat(recon): weekly models.md synthesis pipeline

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -546,6 +546,12 @@ call_sites:
     - gemini-free
     default_paid: true
     description: Analyze CC version changes for impact on Genesis
+  models_md_synthesis:
+    chain:
+    - claude-sonnet
+    default_paid: true
+    retry_profile: background
+    description: "Weekly models.md synthesis \u2014 updates model catalog from recon findings"
   outreach_email_triage:
     chain:
     - gemini-free

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -1,7 +1,8 @@
 <!-- This file is the model catalog — what's available and what each model is good at.
      For which model is assigned to which call site, see the Model Routing Registry:
      docs/architecture/genesis-v3-model-routing-registry.md
-     Read by the task decomposer and routing registry. Reviewed weekly by the dream cycle. -->
+     Read by the task decomposer and routing registry.
+     Updated weekly by ModelsMdSynthesisJob (Sunday 8am UTC, after model intelligence recon). -->
 
 # Model Pool
 

--- a/src/genesis/recon/models_md_synthesis.py
+++ b/src/genesis/recon/models_md_synthesis.py
@@ -1,0 +1,255 @@
+"""Weekly models.md synthesis — updates the model catalog from recon findings.
+
+Reads recent model intelligence findings from knowledge_units, feeds them
+alongside the current docs/reference/models.md to Sonnet, and writes
+back the updated file with a git commit.
+
+Scheduled via SurplusScheduler: Sunday 8am UTC, 2h after model intelligence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from genesis.env import repo_root
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+    from genesis.routing.router import Router
+
+logger = logging.getLogger(__name__)
+
+# Finding types that are actionable for models.md updates.
+# Excludes 'new_model' (bulk catalog of ALL 100k+ context models)
+# and 'benchmark_unmatched' (unknown models with benchmark data).
+_ACTIONABLE_TYPES = frozenset({
+    "pricing_change",
+    "benchmark_enrichment",
+    "new_free_model",
+    "free_model_removed",
+    "free_model_inventory",
+    "stale_profile",
+})
+
+# Structural markers that must be present in the output to pass validation.
+_REQUIRED_MARKERS = (
+    "## THE HEAVY LIFTERS",
+    "## THE ALL-ROUNDERS",
+    "## THE SPECIALISTS",
+)
+
+_SYSTEM_PROMPT = """\
+You maintain a model catalog (models.md) for an AI agent system called Genesis.
+You receive the current file and recent model intelligence findings. Your job:
+
+1. UPDATE structured fields when findings provide new data:
+   - Pricing (the **Cost:** line)
+   - Benchmark scores (SWE-Bench fields, benchmark comparison table)
+   - Free tier status and terms
+   - Context window sizes
+2. ADD genuinely notable NEW models to the "Pending Evaluation" section ONLY.
+   Do NOT promote new models into a capability tier. Most findings are from a
+   broad automated scan — only add models that fill a real gap in the current
+   roster or represent a notable new capability from a major provider.
+3. APPEND a dated changelog entry to the "Last Reviewed" section at the bottom
+   summarizing what was updated. Use the format: **YYYY-MM-DD** — description.
+4. PRESERVE all existing editorial voice, structure, and commentary. Do NOT
+   rewrite Best At / Worst For bullets, Selection Cheat Sheet entries, or
+   Genesis-specific notes. Do NOT reorder sections.
+5. Do NOT change: Effort Level Assignments, routing recommendations, the HTML
+   comment header at the top of the file.
+6. Return the COMPLETE updated file contents. Do not truncate or summarize.
+   If nothing material changed, return the file unchanged except for updating
+   the Last Reviewed date.
+"""
+
+
+class ModelsMdSynthesisJob:
+    """Weekly job: synthesize recon findings into docs/reference/models.md."""
+
+    def __init__(self, *, db: aiosqlite.Connection, router: Router):
+        self._db = db
+        self._router = router
+
+    async def run(self) -> dict:
+        """Run the synthesis. Returns a summary dict."""
+        # 1. Query recent findings
+        findings = await self._query_findings()
+        if not findings:
+            logger.info("Models.md synthesis: no actionable findings in last 7 days")
+            return {"skipped": True, "reason": "no_findings"}
+
+        # 2. Read current models.md
+        models_md_path = repo_root() / "docs" / "reference" / "models.md"
+        if not models_md_path.exists():
+            logger.error("Models.md not found at %s", models_md_path)
+            return {"skipped": True, "reason": "file_not_found"}
+        current_content = models_md_path.read_text(encoding="utf-8")
+
+        # 3. Build LLM prompt
+        serialized = self._serialize_findings(findings)
+        user_prompt = (
+            f"## Recent Intelligence Findings (last 7 days)\n\n"
+            f"{serialized}\n\n"
+            f"## Current models.md\n\n"
+            f"{current_content}"
+        )
+
+        # 4. Call Sonnet via router
+        messages = [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ]
+        result = await self._router.route_call(
+            "models_md_synthesis", messages, max_tokens=16384,
+        )
+        if not result.success:
+            logger.error(
+                "Models.md synthesis LLM call failed: %s", result.error,
+            )
+            raise RuntimeError(f"LLM call failed: {result.error}")
+
+        updated_content = (result.content or "").strip()
+
+        # 5. Validate output
+        validation_error = self._validate_output(updated_content, current_content)
+        if validation_error:
+            logger.warning(
+                "Models.md synthesis validation failed: %s", validation_error,
+            )
+            return {"skipped": True, "reason": f"validation_failed: {validation_error}"}
+
+        # 6. Check for meaningful changes
+        if updated_content.strip() == current_content.strip():
+            logger.info("Models.md synthesis: no changes detected")
+            return {"skipped": True, "reason": "no_changes"}
+
+        # 7. Write file
+        models_md_path.write_text(updated_content + "\n", encoding="utf-8")
+        logger.info("Models.md updated (%d -> %d bytes)", len(current_content), len(updated_content))
+
+        # 8. Git commit
+        committed = await self._git_commit(models_md_path)
+
+        return {
+            "findings_count": len(findings),
+            "updated": True,
+            "committed": committed,
+            "input_tokens": result.input_tokens,
+            "output_tokens": result.output_tokens,
+            "cost_usd": result.cost_usd,
+        }
+
+    async def _query_findings(self) -> list[dict]:
+        """Query actionable findings from knowledge_units."""
+        cutoff = (datetime.now(UTC) - timedelta(days=7)).isoformat()
+        cursor = await self._db.execute(
+            """
+            SELECT concept, body, ingested_at
+            FROM knowledge_units
+            WHERE domain = 'intelligence.models'
+              AND ingested_at > ?
+            ORDER BY ingested_at DESC
+            LIMIT 200
+            """,
+            (cutoff,),
+        )
+        rows = await cursor.fetchall()
+
+        findings = []
+        for _concept, body, _ingested_at in rows:
+            parsed = self._parse_body(body)
+            if parsed and parsed.get("type") in _ACTIONABLE_TYPES:
+                findings.append(parsed)
+        return findings
+
+    @staticmethod
+    def _parse_body(body: str) -> dict | None:
+        """Extract JSON from finding body (prefix + JSON format)."""
+        match = re.search(r"\{.*\}", body, re.DOTALL)
+        if not match:
+            return None
+        try:
+            return json.loads(match.group())
+        except (json.JSONDecodeError, ValueError):
+            return None
+
+    @staticmethod
+    def _serialize_findings(findings: list[dict]) -> str:
+        """Render findings as compact text blocks for the LLM prompt."""
+        parts = []
+        for f in findings:
+            ftype = f.get("type", "unknown")
+            title = f.get("title", ftype)
+            # Remove the "Model intelligence: " prefix for readability
+            title = title.replace("Model intelligence: ", "")
+            details = json.dumps(
+                {k: v for k, v in f.items() if k not in ("title", "type")},
+                indent=2,
+                default=str,
+            )
+            parts.append(f"### {title} ({ftype})\n```json\n{details}\n```")
+        return "\n\n".join(parts)
+
+    @staticmethod
+    def _validate_output(output: str, original: str) -> str | None:
+        """Validate LLM output before writing. Returns error string or None."""
+        if not output:
+            return "empty output"
+
+        for marker in _REQUIRED_MARKERS:
+            if marker not in output:
+                return f"missing structural marker: {marker}"
+
+        orig_len = len(original)
+        out_len = len(output)
+        if out_len < orig_len * 0.5:
+            return f"too short ({out_len} vs {orig_len} original, <50%)"
+        if out_len > orig_len * 2.0:
+            return f"too long ({out_len} vs {orig_len} original, >200%)"
+
+        return None
+
+    @staticmethod
+    async def _git_commit(file_path: Path) -> bool:
+        """Stage and commit the updated file. Returns True if committed."""
+        repo = repo_root()
+        try:
+            # git add — uses create_subprocess_exec (no shell injection risk)
+            proc = await asyncio.create_subprocess_exec(
+                "git", "add", str(file_path.relative_to(repo)),
+                cwd=str(repo),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await proc.wait()
+
+            # git commit
+            proc = await asyncio.create_subprocess_exec(
+                "git", "commit", "-m",
+                "docs(models): weekly synthesis update\n\n"
+                "Auto-generated from model intelligence recon findings.",
+                cwd=str(repo),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await proc.communicate()
+            if proc.returncode != 0:
+                msg = stderr.decode(errors="replace").strip()
+                if "nothing to commit" in msg:
+                    logger.info("Models.md commit: no changes to commit")
+                else:
+                    logger.warning("Models.md commit failed: %s", msg)
+                return False
+            logger.info("Models.md committed to git")
+            return True
+        except Exception:
+            logger.exception("Failed to git commit models.md update")
+            return False

--- a/src/genesis/runtime/init/surplus.py
+++ b/src/genesis/runtime/init/surplus.py
@@ -110,6 +110,21 @@ async def init(rt: GenesisRuntime) -> None:
             logger.error("Unexpected error wiring ModelIntelligenceJob", exc_info=True)
             await _degraded(rt, "ModelIntelligenceJob")
 
+        try:
+            from genesis.recon.models_md_synthesis import ModelsMdSynthesisJob
+            if rt._router is not None:
+                synthesis_job = ModelsMdSynthesisJob(db=rt._db, router=rt._router)
+                rt._surplus_scheduler.set_models_md_synthesis_job(synthesis_job)
+                logger.info("ModelsMdSynthesisJob wired to surplus scheduler")
+            else:
+                logger.warning("ModelsMdSynthesisJob skipped — router not available")
+        except (ImportError, AttributeError):
+            logger.error("Failed to wire ModelsMdSynthesisJob", exc_info=True)
+            await _degraded(rt, "ModelsMdSynthesisJob")
+        except Exception:
+            logger.error("Unexpected error wiring ModelsMdSynthesisJob", exc_info=True)
+            await _degraded(rt, "ModelsMdSynthesisJob")
+
         await rt._surplus_scheduler.start()
         logger.info("Genesis surplus scheduler started")
 

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -97,6 +97,7 @@ class SurplusScheduler:
         self._db_maintenance_executor: SurplusExecutor | None = None
         self._recon_gatherer: ReconGatherer | None = None
         self._model_intelligence_job = None  # Set via set_model_intelligence_job()
+        self._models_md_synthesis_job = None  # Set via set_models_md_synthesis_job()
         self._extraction_store: MemoryStore | None = None
         self._extraction_router: Router | None = None
         self._follow_up_dispatcher = None  # Set via set_follow_up_dispatcher()
@@ -162,6 +163,10 @@ class SurplusScheduler:
     def set_model_intelligence_job(self, job) -> None:
         """Set the ModelIntelligenceJob for scheduled model landscape scanning."""
         self._model_intelligence_job = job
+
+    def set_models_md_synthesis_job(self, job) -> None:
+        """Set the ModelsMdSynthesisJob for weekly models.md updates."""
+        self._models_md_synthesis_job = job
 
     def set_extraction_deps(
         self,
@@ -237,6 +242,16 @@ class SurplusScheduler:
                 self.run_model_intelligence,
                 CronTrigger(day_of_week="sun", hour=6),
                 id="model_intelligence",
+                max_instances=1,
+                misfire_grace_time=3600,
+            )
+        # Models.md synthesis: weekly Sunday 8am — updates model catalog from recon
+        if self._models_md_synthesis_job is not None:
+            from apscheduler.triggers.cron import CronTrigger
+            self._scheduler.add_job(
+                self.run_models_md_synthesis,
+                CronTrigger(day_of_week="sun", hour=8),
+                id="models_md_synthesis",
                 max_instances=1,
                 misfire_grace_time=3600,
             )
@@ -745,6 +760,59 @@ class SurplusScheduler:
             try:
                 from genesis.runtime import GenesisRuntime
                 GenesisRuntime.instance().record_job_failure("model_intelligence", str(exc))
+            except Exception:
+                pass
+
+    async def run_models_md_synthesis(self) -> None:
+        """Run weekly models.md synthesis (Sunday 8am UTC)."""
+        try:
+            from genesis.runtime import GenesisRuntime
+            if GenesisRuntime.instance().paused:
+                logger.debug("Models.md synthesis skipped (Genesis paused)")
+                return
+        except Exception:
+            pass
+        if self._models_md_synthesis_job is None:
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_failure(
+                    "models_md_synthesis", "job not wired",
+                )
+            except Exception:
+                pass
+            return
+        try:
+            result = await self._models_md_synthesis_job.run()
+            skipped = result.get("skipped", False)
+            if skipped:
+                logger.info("Models.md synthesis skipped: %s", result.get("reason"))
+            else:
+                logger.info(
+                    "Models.md synthesis: %d findings applied (cost $%.4f)",
+                    result.get("findings_count", 0),
+                    result.get("cost_usd", 0),
+                )
+            if self._event_bus:
+                await self._event_bus.emit(
+                    Subsystem.RECON, Severity.DEBUG,
+                    "heartbeat", "models_md_synthesis completed",
+                )
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_success("models_md_synthesis")
+            except Exception:
+                pass
+        except Exception as exc:
+            logger.exception("Models.md synthesis failed")
+            if self._event_bus:
+                await self._event_bus.emit(
+                    Subsystem.RECON, Severity.ERROR,
+                    "models_md_synthesis.failed",
+                    "Models.md synthesis failed",
+                )
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_failure("models_md_synthesis", str(exc))
             except Exception:
                 pass
 

--- a/tests/test_recon/test_models_md_synthesis.py
+++ b/tests/test_recon/test_models_md_synthesis.py
@@ -1,0 +1,117 @@
+"""Tests for ModelsMdSynthesisJob — weekly models.md synthesis."""
+
+import pytest
+
+from genesis.recon.models_md_synthesis import ModelsMdSynthesisJob
+
+
+class TestParseBody:
+    """Test finding body parsing (prefix + JSON format)."""
+
+    def test_standard_body(self):
+        body = 'Model Intelligence\n\n{"type": "pricing_change", "model": "test"}'
+        result = ModelsMdSynthesisJob._parse_body(body)
+        assert result == {"type": "pricing_change", "model": "test"}
+
+    def test_json_only(self):
+        body = '{"type": "new_free_model", "api_id": "test/model"}'
+        result = ModelsMdSynthesisJob._parse_body(body)
+        assert result == {"type": "new_free_model", "api_id": "test/model"}
+
+    def test_no_json(self):
+        assert ModelsMdSynthesisJob._parse_body("plain text no json") is None
+
+    def test_invalid_json(self):
+        assert ModelsMdSynthesisJob._parse_body("{invalid json}") is None
+
+
+class TestSerializeFindings:
+    """Test finding serialization for LLM prompt."""
+
+    def test_compact_output(self):
+        findings = [
+            {"type": "pricing_change", "title": "Model intelligence: pricing_change — gpt-5", "model": "gpt-5"},
+        ]
+        result = ModelsMdSynthesisJob._serialize_findings(findings)
+        assert "pricing_change — gpt-5 (pricing_change)" in result
+        assert "```json" in result
+        assert '"model": "gpt-5"' in result
+
+    def test_strips_prefix(self):
+        findings = [{"type": "new_free_model", "title": "Model intelligence: new — test"}]
+        result = ModelsMdSynthesisJob._serialize_findings(findings)
+        assert "Model intelligence: " not in result
+        assert "new — test" in result
+
+    def test_empty_findings(self):
+        assert ModelsMdSynthesisJob._serialize_findings([]) == ""
+
+
+class TestValidateOutput:
+    """Test output validation gates."""
+
+    MINIMAL_VALID = (
+        "<!-- header -->\n"
+        "## THE HEAVY LIFTERS\nContent\n"
+        "## THE ALL-ROUNDERS\nContent\n"
+        "## THE SPECIALISTS\nContent\n"
+    )
+
+    def test_valid_output(self):
+        original = self.MINIMAL_VALID
+        # Same-ish length output with all markers
+        assert ModelsMdSynthesisJob._validate_output(original, original) is None
+
+    def test_empty_output(self):
+        assert ModelsMdSynthesisJob._validate_output("", "original") == "empty output"
+
+    def test_missing_marker(self):
+        output = "## THE HEAVY LIFTERS\n## THE ALL-ROUNDERS\n"
+        err = ModelsMdSynthesisJob._validate_output(output, self.MINIMAL_VALID)
+        assert err is not None
+        assert "THE SPECIALISTS" in err
+
+    def test_too_short(self):
+        output = self.MINIMAL_VALID
+        # Original is 3x longer
+        original = self.MINIMAL_VALID * 3
+        err = ModelsMdSynthesisJob._validate_output(output, original)
+        assert err is not None
+        assert "<50%" in err
+
+    def test_too_long(self):
+        output = self.MINIMAL_VALID * 5
+        original = self.MINIMAL_VALID
+        err = ModelsMdSynthesisJob._validate_output(output, original)
+        assert err is not None
+        assert ">200%" in err
+
+
+class TestQueryFindings:
+    """Test finding query and type filtering."""
+
+    @pytest.mark.asyncio
+    async def test_filters_to_actionable_types(self):
+        """Only actionable finding types should be returned."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        # Mock DB with mixed finding types
+        findings_data = [
+            ("concept1", 'prefix\n\n{"type": "pricing_change", "model": "test"}', "2026-05-22"),
+            ("concept2", 'prefix\n\n{"type": "new_model", "api_id": "test/bulk"}', "2026-05-22"),
+            ("concept3", 'prefix\n\n{"type": "new_free_model", "api_id": "test/free"}', "2026-05-22"),
+            ("concept4", 'prefix\n\n{"type": "benchmark_unmatched", "source": "aa"}', "2026-05-22"),
+        ]
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall = AsyncMock(return_value=findings_data)
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock(return_value=mock_cursor)
+
+        job = ModelsMdSynthesisJob(db=mock_db, router=AsyncMock())
+        findings = await job._query_findings()
+
+        # Should include pricing_change and new_free_model, exclude new_model and benchmark_unmatched
+        types = {f["type"] for f in findings}
+        assert types == {"pricing_change", "new_free_model"}
+        assert len(findings) == 2

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -135,7 +135,8 @@ def test_load_full_yaml(monkeypatch):
     # 2026-05-12: 43 → 44 after 44_task_premortem added by #334.
     # 2026-05-14: 44 → 45 after 45_intelligence_intake added by #349.
     # 2026-05-15: 45 → 46 after dream_cycle_synthesis added by #359.
-    assert len(cfg.call_sites) == 46
+    # 2026-05-22: 46 → 47 after models_md_synthesis added by #410.
+    assert len(cfg.call_sites) == 47
     assert "2_triage" not in cfg.call_sites  # removed 2026-05-10
     assert "7_task_retrospective" not in cfg.call_sites  # removed 2026-05-10 (duplicate; live one is 43_task_retrospective)
     assert "background" in cfg.retry_profiles


### PR DESCRIPTION
## Summary

- Adds `ModelsMdSynthesisJob` — weekly job (Sunday 8am UTC) that reads model intelligence findings from `knowledge_units` and uses Sonnet to update `docs/reference/models.md`
- Filters to actionable finding types only (pricing_change, benchmark_enrichment, new_free_model, etc.) — skips bulk catalog noise
- Validation gates prevent file corruption: structural markers check + 50-200% length bounds
- Wired into SurplusScheduler alongside model_intelligence (runs 2h later)
- Fixes false "dream cycle" comment in models.md header

## Files changed

| File | Change |
|------|--------|
| `src/genesis/recon/models_md_synthesis.py` | **NEW** — Core job class |
| `config/model_routing.yaml` | Added `models_md_synthesis` call site (Sonnet) |
| `src/genesis/surplus/scheduler.py` | Setter, executor, CronTrigger registration |
| `src/genesis/runtime/init/surplus.py` | Job wiring |
| `docs/reference/models.md` | Header comment fix |
| `tests/test_recon/test_models_md_synthesis.py` | **NEW** — 13 unit tests |

## Test plan

- [x] 13 unit tests passing (parse, serialize, validate, query filtering)
- [x] Lint clean (ruff check)
- [ ] CI passes
- [ ] After merge: verify job registers via `job_health` table
- [ ] First manual trigger to verify end-to-end (diff review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)