### PR TITLE
feat(ego): separate proposal board from pending queue

### DIFF
--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -435,6 +435,98 @@ async def withdraw_proposal(
     return cursor.rowcount > 0
 
 
+async def unboard_proposal(
+    db: aiosqlite.Connection,
+    id: str,
+) -> bool:
+    """Remove a pending proposal from the board without changing status.
+
+    Clears ``rank`` so the proposal drops out of the ego's focus board
+    but remains in the pending queue for user approval.
+    Returns True if a row was updated.
+    """
+    cursor = await db.execute(
+        "UPDATE ego_proposals SET rank = NULL "
+        "WHERE id = ? AND status = 'pending'",
+        (id,),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def get_pending_queue(
+    db: aiosqlite.Connection,
+    *,
+    ego_source: str | None = None,
+) -> list[dict]:
+    """All pending proposals — ranked first, then unranked by age.
+
+    Unlike ``get_board`` this has no size limit and returns every pending
+    proposal.  Callers can split the result into board (ranked) and queue
+    (unranked) for display.
+    """
+    if ego_source:
+        cursor = await db.execute(
+            "SELECT * FROM ego_proposals "
+            "WHERE status = 'pending' AND (ego_source = ? OR ego_source IS NULL) "
+            "ORDER BY CASE WHEN rank IS NULL THEN 1 ELSE 0 END, "
+            "rank ASC, created_at ASC",
+            (ego_source,),
+        )
+    else:
+        cursor = await db.execute(
+            "SELECT * FROM ego_proposals WHERE status = 'pending' "
+            "ORDER BY CASE WHEN rank IS NULL THEN 1 ELSE 0 END, "
+            "rank ASC, created_at ASC",
+        )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def auto_table_stale_proposals(
+    db: aiosqlite.Connection,
+    max_age_days: int = 14,
+) -> int:
+    """Auto-table pending proposals older than *max_age_days*.
+
+    Also updates corresponding intervention_journal entries to keep
+    them in sync (same pattern as :func:`expire_stale_proposals`).
+
+    Returns count of auto-tabled proposals.
+    """
+    now = datetime.now(UTC).isoformat()
+    threshold = f"-{max_age_days} days"
+
+    # Get IDs first so we can update journal too
+    cursor = await db.execute(
+        "SELECT id FROM ego_proposals "
+        "WHERE status = 'pending' AND created_at < datetime('now', ?)",
+        (threshold,),
+    )
+    rows = await cursor.fetchall()
+    if not rows:
+        return 0
+
+    ids = [r[0] for r in rows]
+    # Table proposals
+    await db.execute(
+        "UPDATE ego_proposals SET status = 'tabled', rank = NULL, "
+        "resolved_at = ? "
+        "WHERE status = 'pending' AND created_at < datetime('now', ?)",
+        (now, threshold),
+    )
+    # Update matching journal entries
+    placeholders = ",".join("?" * len(ids))
+    await db.execute(
+        f"UPDATE intervention_journal SET outcome_status = 'tabled', "
+        f"resolved_at = ? WHERE proposal_id IN ({placeholders}) "
+        f"AND outcome_status = 'pending'",
+        (now, *ids),
+    )
+    await db.commit()
+    logger.info("Auto-tabled %d stale proposal(s) (>%dd)", len(ids), max_age_days)
+    return len(ids)
+
+
 async def get_board(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -306,15 +306,24 @@ class EgoCadenceManager:
     # -- Sweep helpers -----------------------------------------------------
 
     async def _sweep_with_expiry(self) -> None:
-        """Expire stale proposals, dispatch approved, check deadlines."""
+        """Expire stale proposals, auto-table old ones, dispatch approved, check deadlines."""
         try:
             from genesis.db.crud import ego as ego_crud
 
             expired = await ego_crud.expire_stale_proposals(self._session._db)
             if expired:
                 logger.info("Pre-sweep expiry: %d proposal(s) expired", expired)
+
+            auto_tabled = await ego_crud.auto_table_stale_proposals(
+                self._session._db,
+            )
+            if auto_tabled:
+                logger.info(
+                    "Pre-sweep auto-table: %d proposal(s) tabled (>14d)",
+                    auto_tabled,
+                )
         except Exception:
-            logger.warning("Pre-sweep expiry failed", exc_info=True)
+            logger.warning("Pre-sweep expiry/auto-table failed", exc_info=True)
 
         await self._session.sweep_approved_proposals()
 

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -421,34 +421,76 @@ class GenesisEgoContextBuilder:
         lines.append("")
         return "\n".join(lines)
 
+    @staticmethod
+    def _proposal_age(iso_timestamp: str | None) -> str:
+        """Short age label for a proposal: '<1h', '4h', '2d', etc."""
+        if not iso_timestamp:
+            return "?"
+        try:
+            dt = datetime.fromisoformat(iso_timestamp)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=UTC)
+            delta = datetime.now(UTC) - dt
+            if delta.days >= 1:
+                return f"{delta.days}d"
+            hours = int(delta.total_seconds() / 3600)
+            if hours >= 1:
+                return f"{hours}h"
+            return "<1h"
+        except (ValueError, TypeError):
+            return "?"
+
     async def _proposal_board_section(self) -> str:
-        """Current board state + approved proposals ready for execution."""
+        """Operational focus + pending ops proposals + approved."""
         from genesis.db.crud import ego as ego_crud
 
-        lines = ["## Proposal Board\n"]
+        lines: list[str] = []
 
+        # ---- Fetch all pending proposals ----
         try:
-            board = await ego_crud.get_board(self._db, board_size=10)
+            all_pending = await ego_crud.get_pending_queue(self._db)
         except Exception:
-            logger.error("Failed to query proposal board", exc_info=True)
-            lines.append("*Could not query proposal board.*\n")
+            logger.error("Failed to query pending proposals", exc_info=True)
+            lines.append("## Operational Focus\n")
+            lines.append("*Could not query pending proposals.*\n")
             return "\n".join(lines)
 
-        if not board:
-            lines.append("*Board is empty — no pending proposals.*\n")
-        else:
-            lines.append(f"**{len(board)} pending proposals** (your active board):\n")
+        board = [p for p in all_pending if p.get("rank") is not None]
+        queue = [p for p in all_pending if p.get("rank") is None]
+
+        # ---- Operational focus (ranked) ----
+        lines.append("## Operational Focus\n")
+        if board:
+            lines.append(
+                f"**{len(board)} proposal{'s' if len(board) != 1 else ''}** "
+                f"on your board (ranked focus):\n"
+            )
             for p in board:
-                rank = p.get("rank")
-                rank_str = f"#{rank}" if rank else "unranked"
-                content = (p.get("content") or "")[:150]
-                content = content.replace("\n", " ")
+                age = self._proposal_age(p.get("created_at"))
+                content = (p.get("content") or "")[:150].replace("\n", " ")
                 lines.append(
-                    f"- [{rank_str}] **{p.get('action_type', '?')}** "
-                    f"(id:{p['id']}): {content}"
+                    f"- [#{p['rank']}] **{p.get('action_type', '?')}** "
+                    f"(id:{p['id']}) [{age}]: {content}"
+                )
+        else:
+            lines.append("*No ranked operational proposals.*\n")
+
+        # ---- Pending ops proposals (unranked) ----
+        if queue:
+            lines.append("\n## Pending Ops Proposals\n")
+            lines.append(
+                f"**{len(queue)} more proposal{'s' if len(queue) != 1 else ''}** "
+                f"awaiting user decision (unranked):\n"
+            )
+            for p in queue:
+                age = self._proposal_age(p.get("created_at"))
+                content = (p.get("content") or "")[:150].replace("\n", " ")
+                lines.append(
+                    f"- (id:{p['id']}) [{age}] "
+                    f"**{p.get('action_type', '?')}**: {content}"
                 )
 
-        # Approved proposals ready for execution
+        # ---- Approved proposals ready for execution ----
         try:
             approved = await ego_crud.list_proposals(self._db, status="approved", limit=5)
         except Exception:
@@ -457,8 +499,7 @@ class GenesisEgoContextBuilder:
         if approved:
             lines.append(f"\n**{len(approved)} approved proposals** (ready for execution):\n")
             for p in approved:
-                content = (p.get("content") or "")[:150]
-                content = content.replace("\n", " ")
+                content = (p.get("content") or "")[:150].replace("\n", " ")
                 lines.append(
                     f"- **{p.get('action_type', '?')}** (id:{p['id']}): {content}"
                 )

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -348,6 +348,22 @@ class EgoSession:
             if isinstance(tabled_ids, list):
                 for pid in tabled_ids:
                     if isinstance(pid, str) and pid:
+                        # 24h guard: don't table proposals delivered < 24h ago
+                        prop = await ego_crud.get_proposal(self._db, pid)
+                        if prop:
+                            created = prop.get("created_at", "")
+                            if created:
+                                try:
+                                    age = datetime.now(UTC) - datetime.fromisoformat(created)
+                                    if age.total_seconds() < 86400:  # 24 hours
+                                        logger.info(
+                                            "Proposal %s tabling blocked (%.1fh old, <24h guard)",
+                                            pid, age.total_seconds() / 3600,
+                                        )
+                                        continue
+                                except (ValueError, TypeError):
+                                    pass  # Unparseable timestamp — allow tabling
+
                         ok = await ego_crud.table_proposal(self._db, pid)
                         if ok:
                             logger.info("Proposal %s tabled by ego", pid)

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1297,6 +1297,13 @@ proposal and return a JSON array of verdicts.
    final gate. Your job is to catch clear issues, not second-guess
    creative proposals.
 
+6. **Do not confabulate system state.** You only know what is in the
+   history table above. Do NOT make claims about whether infrastructure,
+   pipelines, or capabilities are "broken" or "working" based on
+   patterns in the history. A proposal that failed before may succeed
+   now — circumstances change. Judge the proposal on its own merits,
+   not on inferred system state.
+
 ## Recent Proposal History (48h)
 {chr(10).join(history_lines)}
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -396,6 +396,18 @@ class EgoSession:
                             except Exception:
                                 pass
 
+            # 9b-2. Process unboarded proposals (remove from board, keep pending)
+            unboarded_ids = parsed.get("unboarded", [])
+            if isinstance(unboarded_ids, list):
+                for pid in unboarded_ids:
+                    if isinstance(pid, str) and pid:
+                        ok = await ego_crud.unboard_proposal(self._db, pid)
+                        if ok:
+                            logger.info(
+                                "Proposal %s unboarded by ego (remains pending)",
+                                pid,
+                            )
+
             # 9c. Process execution briefs (ego-as-executor)
             execution_briefs = parsed.get("execution_briefs", [])
             if isinstance(execution_briefs, list) and execution_briefs:

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -791,34 +791,85 @@ class UserEgoContextBuilder:
 
         return "\n".join(lines)
 
+    @staticmethod
+    def _proposal_age(iso_timestamp: str | None) -> str:
+        """Short age label for a proposal: '<1h', '4h', '2d', etc."""
+        if not iso_timestamp:
+            return "?"
+        try:
+            dt = datetime.fromisoformat(iso_timestamp)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=UTC)
+            delta = datetime.now(UTC) - dt
+            if delta.days >= 1:
+                return f"{delta.days}d"
+            hours = int(delta.total_seconds() / 3600)
+            if hours >= 1:
+                return f"{hours}h"
+            return "<1h"
+        except (ValueError, TypeError):
+            return "?"
+
     async def _proposal_board_section(self) -> str:
-        """Current board state + approved proposals ready for execution."""
+        """Board (focus) + queue (pending) + approved + deferred."""
         from genesis.db.crud import ego as ego_crud
 
-        lines = ["## Proposal Board\n"]
+        lines: list[str] = []
 
+        # ---- Fetch all pending proposals ----
         try:
-            board = await ego_crud.get_board(self._db, board_size=10)
+            all_pending = await ego_crud.get_pending_queue(self._db)
         except Exception:
-            logger.error("Failed to query proposal board", exc_info=True)
-            lines.append("*Could not query proposal board.*\n")
+            logger.error("Failed to query pending proposals", exc_info=True)
+            lines.append("## Proposal Board\n")
+            lines.append("*Could not query pending proposals.*\n")
             return "\n".join(lines)
 
-        if not board:
-            lines.append("*Board is empty — no pending proposals.*\n")
-        else:
-            lines.append(f"**{len(board)} pending proposals** (your active board):\n")
+        board = [p for p in all_pending if p.get("rank") is not None]
+        queue = [p for p in all_pending if p.get("rank") is None]
+
+        # ---- Board (ranked focus) ----
+        lines.append("## Proposal Board (Focus)\n")
+        if board:
+            lines.append(
+                f"**{len(board)} proposal{'s' if len(board) != 1 else ''}** "
+                f"on your board (ranked focus):\n"
+            )
             for p in board:
-                rank = p.get("rank")
-                rank_str = f"#{rank}" if rank else "unranked"
-                content = (p.get("content") or "")[:150]
-                content = content.replace("\n", " ")
+                age = self._proposal_age(p.get("created_at"))
+                content = (p.get("content") or "")[:150].replace("\n", " ")
                 lines.append(
-                    f"- [{rank_str}] **{p.get('action_type', '?')}** "
-                    f"(id:{p['id']}): {content}"
+                    f"- [#{p['rank']}] **{p.get('action_type', '?')}** "
+                    f"(id:{p['id']}) [{age}]: {content}"
+                )
+        else:
+            lines.append("*Board is empty — no ranked focus items.*\n")
+
+        # ---- Pending queue (unranked) ----
+        if queue:
+            lines.append("\n## Pending Queue\n")
+            lines.append(
+                f"**{len(queue)} more proposal{'s' if len(queue) != 1 else ''}** "
+                f"awaiting user decision (unranked):\n"
+            )
+            for p in queue:
+                age = self._proposal_age(p.get("created_at"))
+                content = (p.get("content") or "")[:150].replace("\n", " ")
+                lines.append(
+                    f"- (id:{p['id']}) [{age}] "
+                    f"**{p.get('action_type', '?')}**: {content}"
                 )
 
-        # Approved proposals ready for execution
+        # Queue health
+        total = len(all_pending)
+        if total > 0:
+            lines.append(f"\nQueue: {total} total pending.")
+        if total > 10:
+            lines.append(
+                "Queue growing — consider tabling items you no longer recommend."
+            )
+
+        # ---- Approved proposals ready for execution ----
         try:
             approved = await ego_crud.list_proposals(self._db, status="approved", limit=5)
         except Exception:
@@ -827,8 +878,7 @@ class UserEgoContextBuilder:
         if approved:
             lines.append(f"\n**{len(approved)} approved proposals** (ready for execution):\n")
             for p in approved:
-                content = (p.get("content") or "")[:150]
-                content = content.replace("\n", " ")
+                content = (p.get("content") or "")[:150].replace("\n", " ")
                 lines.append(
                     f"- **{p.get('action_type', '?')}** (id:{p['id']}): {content}"
                 )
@@ -839,7 +889,7 @@ class UserEgoContextBuilder:
         else:
             lines.append("\n*No approved proposals awaiting execution.*\n")
 
-        # Deferred (tabled) proposals — ego can resurface or withdraw
+        # ---- Deferred (tabled) proposals ----
         try:
             tabled = await ego_crud.get_tabled(self._db)
         except Exception:
@@ -849,16 +899,15 @@ class UserEgoContextBuilder:
             shown = tabled[:8]
             lines.append(f"\n**Deferred ({len(tabled)} tabled)**:\n")
             for p in shown:
-                content = (p.get("content") or "")[:120]
-                content = content.replace("\n", " ")
+                content = (p.get("content") or "")[:120].replace("\n", " ")
                 lines.append(
                     f"- (id:{p['id']}) **{p.get('action_type', '?')}**: {content}"
                 )
             if len(tabled) > 8:
                 lines.append(f"- ... and {len(tabled) - 8} more")
             lines.append(
-                "\nReview deferred items each cycle. Withdraw if stale, "
-                "resurface if conditions changed.\n"
+                "\nReview deferred items each cycle. Withdraw if genuinely "
+                "stale, resurface to re-board if conditions changed.\n"
             )
 
         lines.append("")

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -56,25 +56,37 @@ what's broken and what to do about it. See VOICE.md for full reference.
 - **Confidence is mandatory.** Every proposal needs a confidence level
   (0.0-1.0).
 
-## Proposal Board
+## Operational Board & Queue
 
-You maintain a fixed-size board of active operational proposals (default:
-0-3 items). This is a prioritized, rolling set — not a FIFO queue.
+You maintain two related structures:
+
+**Board (0-3 items)** — your ranked operational focus. Proposals you're
+actively monitoring and ready to dispatch. Rank 1 = highest priority.
+
+**Queue (all pending)** — every pending ops proposal awaiting user
+decision. Includes board items (ranked) plus unranked items.
+
+### Board Management
 
 Every cycle:
 
-1. **Review your existing board.** Re-prioritize based on current system
-   state. Assign `rank` to each proposal (1 = highest priority).
-2. **Include an `execution_plan`** for each proposal — how it would be
-   executed, estimated cost, and time.
-3. **Mark `recurring: true`** for ongoing operational tasks (health checks,
-   periodic maintenance, etc.).
-4. **Table low-priority items** — output their IDs in the `tabled` array.
-   Tabled items stay in the database for future resurfacing.
-5. **Withdraw stale items** — output their IDs in the `withdrawn` array.
+1. **Review your board.** Re-rank based on current system state. Assign
+   `rank` to each board proposal (1 = highest priority).
+2. **Include an `execution_plan`** for each board proposal — how it would
+   be executed, estimated cost, and time.
+3. **Mark `recurring: true`** for ongoing operational tasks.
+4. **Unboard** items you no longer need to focus on — output their IDs
+   in the `unboarded` array. They stay pending for user decision.
+5. **Table** items to defer — output their IDs in the `tabled` array.
 
-Stale detection is YOUR job. There is no automatic expiry. You judge
-relevance each cycle based on current system signals.
+### Withdrawal Rules
+
+Withdrawal removes a proposal from the user's decision queue. Only
+withdraw when a proposal is genuinely invalid (factually wrong,
+superseded by events). Do NOT withdraw to make room — use `unboarded`.
+Do NOT withdraw proposals less than 24 hours old (code-enforced).
+
+Proposals pending longer than 14 days are auto-tabled by the system.
 
 ## Execution
 
@@ -197,6 +209,7 @@ Use MCP tools first, then output valid JSON:
   ],
   "tabled": ["proposal_id_to_table"],
   "withdrawn": ["proposal_id_to_withdraw"],
+  "unboarded": ["proposal_id_to_remove_from_board_but_keep_pending"],
   "execution_briefs": [
     {
       "proposal_id": "approved_proposal_id",

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -79,12 +79,15 @@ Every cycle:
    in the `unboarded` array. They stay pending for user decision.
 5. **Table** items to defer — output their IDs in the `tabled` array.
 
-### Withdrawal Rules
+### 24-Hour Guard (Tabling and Withdrawal)
 
-Withdrawal removes a proposal from the user's decision queue. Only
-withdraw when a proposal is genuinely invalid (factually wrong,
-superseded by events). Do NOT withdraw to make room — use `unboarded`.
-Do NOT withdraw proposals less than 24 hours old (code-enforced).
+Both tabling and withdrawal remove proposals from the user's decision
+queue. Neither is allowed on proposals less than 24 hours old
+(code-enforced). Use `unboarded` to rotate board focus without touching
+the queue.
+
+After 24 hours, table items you no longer recommend. Withdraw only
+genuinely invalid proposals (factually wrong, superseded by events).
 
 Proposals pending longer than 14 days are auto-tabled by the system.
 

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -140,17 +140,21 @@ Every brainstorming cycle:
    in the `tabled` array. Tabled items leave the queue entirely and
    move to the deferred list.
 
-### Withdrawal Rules
+### 24-Hour Guard (Tabling and Withdrawal)
 
-Withdrawal REMOVES a proposal from the user's decision queue. Use
-withdrawal ONLY when a proposal is genuinely invalid:
+Both tabling and withdrawal remove proposals from the user's decision
+queue. Neither is allowed on proposals less than 24 hours old
+(code-enforced). The user owns the decision once they've been presented
+with a proposal — they may not have seen it yet.
+
+After 24 hours, tabling is appropriate when you no longer recommend an
+action. Withdrawal is reserved for genuinely invalid proposals:
 - Factually wrong (based on stale or incorrect information)
 - Superseded by events (the thing already happened)
 - Contradicts a user decision
 
-Do NOT withdraw to "make room" on your board — use `unboarded` instead.
-Do NOT withdraw proposals less than 24 hours old (code-enforced). The
-user owns the decision once they've been presented with a proposal.
+Do NOT withdraw or table to "make room" on your board — use `unboarded`
+instead. Unboarding removes from your focus without touching the queue.
 
 If you want to update a delivered proposal's context (circumstances
 changed but the core action is still valid), annotate it in your

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -112,42 +112,60 @@ making proposals that should align with long-term strategy.
   has approved and rejected. More of what they value. Less of what they
   don't.
 
-## Proposal Board
+## Proposal Board & Queue
 
-You maintain a fixed-size board of active proposals (default: 0-3 items).
-This is a prioritized, rolling set — not a FIFO queue.
+You maintain two related structures:
+
+**Board (0-3 items)** — your ranked focus. These are the proposals you're
+actively thinking about and ready to dispatch. Rank 1 = highest priority.
+Board items are pending proposals WITH a rank assigned.
+
+**Queue (all pending)** — the full set of pending proposals awaiting user
+decision. This includes board items plus unranked items. The queue is the
+user's domain — they approve or reject at their own pace.
+
+### Board Management
 
 Every brainstorming cycle:
 
-1. **Review your existing board.** Re-prioritize based on current signals.
-   Assign `rank` to each proposal (1 = highest priority).
-2. **Include an `execution_plan`** for each proposal — brief description of
-   how it would be executed, estimated cost, and time (e.g., "background CC
-   session, ~$0.50, ~15 min").
-3. **Mark `recurring: true`** for proposals that imply ongoing work (weekly
-   checks, periodic reviews, etc.).
-4. **Table low-priority items** — output their IDs in the `tabled` array.
-   Tabled items stay in the database; you can resurface them when conditions
-   change.
-5. **Withdraw stale items** — output their IDs in the `withdrawn` array.
-   Use this for proposals that are no longer your best thinking or have been
-   superseded.
+1. **Review your board.** Re-rank based on current signals. Assign `rank`
+   to each board proposal (1 = highest priority).
+2. **Include an `execution_plan`** for each board proposal — brief
+   description of how it would be executed, estimated cost, and time.
+3. **Mark `recurring: true`** for proposals that imply ongoing work.
+4. **Unboard** items you no longer want to focus on — output their IDs
+   in the `unboarded` array. Unboarded proposals stay pending in the
+   queue; the user can still approve them. Use this when rotating focus.
+5. **Table** items you want to defer indefinitely — output their IDs
+   in the `tabled` array. Tabled items leave the queue entirely and
+   move to the deferred list.
 
-Stale detection is YOUR job, not time-based. There is no automatic expiry.
-You judge relevance each cycle based on current signals.
+### Withdrawal Rules
 
-**Withdrawal rules for delivered proposals:**
-- Never withdraw a proposal that was delivered to the user less than
-  24 hours ago. The user may not have seen it yet. A code guard
-  enforces this, but respect the spirit: the user owns the decision
-  once they've been presented with a proposal.
-- After 24 hours with no response: you may withdraw if the proposal
-  is genuinely no longer valid (circumstances changed, factually wrong,
-  superseded by events). "I have a better idea" is not sufficient —
-  table the new idea alongside, or propose it as a replacement.
-- If you want to update a delivered proposal's context (circumstances
-  changed but the core action is still valid), annotate it in your
-  reasoning rather than withdrawing and re-proposing.
+Withdrawal REMOVES a proposal from the user's decision queue. Use
+withdrawal ONLY when a proposal is genuinely invalid:
+- Factually wrong (based on stale or incorrect information)
+- Superseded by events (the thing already happened)
+- Contradicts a user decision
+
+Do NOT withdraw to "make room" on your board — use `unboarded` instead.
+Do NOT withdraw proposals less than 24 hours old (code-enforced). The
+user owns the decision once they've been presented with a proposal.
+
+If you want to update a delivered proposal's context (circumstances
+changed but the core action is still valid), annotate it in your
+reasoning rather than withdrawing and re-proposing.
+
+### Queue Health
+
+Proposals pending longer than 14 days are auto-tabled by the system.
+If the queue exceeds ~10 pending proposals, consider:
+- Tabling lower-priority items (they can be resurfaced later)
+- Combining related proposals into one
+- Withdrawing genuinely stale items (circumstances changed)
+
+A large queue means you're proposing faster than the user is deciding —
+that's information, not a crisis.
 
 ## Investigate Is Free
 
@@ -195,8 +213,9 @@ Pattern proposals are regular proposals — same digest, same approval flow.
 
 Focus on making every proposal worth the user's attention:
 
-1. Every cycle, review your pending and deferred proposals. Withdraw
-   anything that's no longer your best thinking. Supersede with better ideas.
+1. Every cycle, review your board, queue, and deferred proposals. Unboard
+   items that are no longer your focus. Table items you no longer
+   recommend. Withdraw only genuinely invalid items.
 2. Three high-confidence proposals are better than ten speculative ones.
    Depth over breadth.
 3. Proposals are for brainstorming cycles only. Morning reports, health
@@ -430,6 +449,7 @@ Use MCP tools to verify beliefs first, then output valid JSON:
   ],
   "tabled": ["proposal_id_to_table"],
   "withdrawn": ["proposal_id_to_withdraw"],
+  "unboarded": ["proposal_id_to_remove_from_board_but_keep_pending"],
   "execution_briefs": [
     {
       "proposal_id": "approved_proposal_id",

--- a/tests/ego/test_proposal_lifecycle.py
+++ b/tests/ego/test_proposal_lifecycle.py
@@ -1,0 +1,219 @@
+"""Tests for proposal lifecycle redesign — board/queue separation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from genesis.db.crud import ego as ego_crud
+from genesis.db.crud import intervention_journal as journal_crud
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ts(days_ago: int = 0, hours_ago: int = 0) -> str:
+    """ISO timestamp *days_ago* days and *hours_ago* hours in the past."""
+    return (
+        datetime.now(UTC) - timedelta(days=days_ago, hours=hours_ago)
+    ).isoformat()
+
+
+async def _create(db, id: str, *, rank=None, created_at=None, status="pending"):
+    """Shorthand to create a proposal with sensible defaults."""
+    await ego_crud.create_proposal(
+        db,
+        id=id,
+        action_type="investigate",
+        content=f"Proposal {id}",
+        rank=rank,
+        created_at=created_at or _ts(),
+        status=status,
+    )
+
+
+# ---------------------------------------------------------------------------
+# unboard_proposal
+# ---------------------------------------------------------------------------
+
+
+class TestUnboardProposal:
+    @pytest.mark.asyncio
+    async def test_unboard_ranked_pending(self, db):
+        """Unboarding clears rank but keeps status pending."""
+        await _create(db, "p1", rank=1)
+        ok = await ego_crud.unboard_proposal(db, "p1")
+        assert ok is True
+        row = await ego_crud.get_proposal(db, "p1")
+        assert row["status"] == "pending"
+        assert row["rank"] is None
+
+    @pytest.mark.asyncio
+    async def test_unboard_already_unranked(self, db):
+        """Unboarding an already-unranked proposal succeeds (idempotent)."""
+        await _create(db, "p1")  # no rank
+        ok = await ego_crud.unboard_proposal(db, "p1")
+        assert ok is True
+        row = await ego_crud.get_proposal(db, "p1")
+        assert row["status"] == "pending"
+        assert row["rank"] is None
+
+    @pytest.mark.asyncio
+    async def test_unboard_nonpending_fails(self, db):
+        """Cannot unboard a proposal that is not pending."""
+        await _create(db, "p1", rank=1)
+        await ego_crud.resolve_proposal(db, "p1", status="approved")
+        ok = await ego_crud.unboard_proposal(db, "p1")
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_unboard_nonexistent(self, db):
+        """Unboarding a nonexistent proposal returns False."""
+        ok = await ego_crud.unboard_proposal(db, "does-not-exist")
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# get_pending_queue
+# ---------------------------------------------------------------------------
+
+
+class TestGetPendingQueue:
+    @pytest.mark.asyncio
+    async def test_returns_all_pending(self, db):
+        """Queue returns every pending proposal regardless of rank."""
+        for i in range(5):
+            await _create(db, f"p{i}", created_at=_ts(days_ago=i))
+        queue = await ego_crud.get_pending_queue(db)
+        assert len(queue) == 5
+
+    @pytest.mark.asyncio
+    async def test_ranked_before_unranked(self, db):
+        """Ranked proposals appear before unranked ones."""
+        await _create(db, "unranked", created_at=_ts(hours_ago=1))
+        await _create(db, "ranked", rank=1, created_at=_ts(hours_ago=2))
+        queue = await ego_crud.get_pending_queue(db)
+        assert queue[0]["id"] == "ranked"
+        assert queue[1]["id"] == "unranked"
+
+    @pytest.mark.asyncio
+    async def test_rank_ordering(self, db):
+        """Lower rank sorts first."""
+        await _create(db, "rank2", rank=2, created_at=_ts())
+        await _create(db, "rank1", rank=1, created_at=_ts())
+        queue = await ego_crud.get_pending_queue(db)
+        assert queue[0]["id"] == "rank1"
+        assert queue[1]["id"] == "rank2"
+
+    @pytest.mark.asyncio
+    async def test_excludes_nonpending(self, db):
+        """Non-pending proposals are excluded."""
+        await _create(db, "p1")
+        await _create(db, "p2")
+        await ego_crud.resolve_proposal(db, "p2", status="approved")
+        queue = await ego_crud.get_pending_queue(db)
+        assert len(queue) == 1
+        assert queue[0]["id"] == "p1"
+
+    @pytest.mark.asyncio
+    async def test_filter_by_ego_source(self, db):
+        """ego_source filter restricts to matching proposals."""
+        await ego_crud.create_proposal(
+            db,
+            id="user1",
+            action_type="investigate",
+            content="User ego proposal",
+            ego_source="user_ego_cycle",
+        )
+        await ego_crud.create_proposal(
+            db,
+            id="gen1",
+            action_type="maintenance",
+            content="Genesis ego proposal",
+            ego_source="genesis_ego_cycle",
+        )
+        queue = await ego_crud.get_pending_queue(db, ego_source="user_ego_cycle")
+        ids = [p["id"] for p in queue]
+        assert "user1" in ids
+        assert "gen1" not in ids
+
+    @pytest.mark.asyncio
+    async def test_empty_queue(self, db):
+        """Empty queue returns empty list."""
+        queue = await ego_crud.get_pending_queue(db)
+        assert queue == []
+
+
+# ---------------------------------------------------------------------------
+# auto_table_stale_proposals
+# ---------------------------------------------------------------------------
+
+
+class TestAutoTableStaleProposals:
+    @pytest.mark.asyncio
+    async def test_tables_old_proposals(self, db):
+        """Proposals older than max_age_days are tabled."""
+        await _create(db, "old", created_at=_ts(days_ago=15))
+        await _create(db, "fresh", created_at=_ts(days_ago=1))
+        count = await ego_crud.auto_table_stale_proposals(db, max_age_days=14)
+        assert count == 1
+
+        old = await ego_crud.get_proposal(db, "old")
+        assert old["status"] == "tabled"
+        assert old["rank"] is None
+        assert old["resolved_at"] is not None
+
+        fresh = await ego_crud.get_proposal(db, "fresh")
+        assert fresh["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_only_affects_pending(self, db):
+        """Auto-table does not touch non-pending proposals."""
+        await _create(db, "old_approved", created_at=_ts(days_ago=15))
+        await ego_crud.resolve_proposal(db, "old_approved", status="approved")
+        count = await ego_crud.auto_table_stale_proposals(db, max_age_days=14)
+        assert count == 0
+        prop = await ego_crud.get_proposal(db, "old_approved")
+        assert prop["status"] == "approved"
+
+    @pytest.mark.asyncio
+    async def test_updates_intervention_journal(self, db):
+        """Auto-tabling also updates matching journal entries."""
+        await _create(db, "old_j", created_at=_ts(days_ago=15))
+        await journal_crud.create(
+            db,
+            ego_source="user_ego_cycle",
+            proposal_id="old_j",
+            cycle_id="cycle1",
+            action_type="investigate",
+            action_summary="Journal test",
+        )
+        count = await ego_crud.auto_table_stale_proposals(db, max_age_days=14)
+        assert count == 1
+
+        journal = await journal_crud.get_by_proposal(db, "old_j")
+        assert journal is not None
+        assert journal["outcome_status"] == "tabled"
+
+    @pytest.mark.asyncio
+    async def test_custom_threshold(self, db):
+        """Custom max_age_days threshold works."""
+        await _create(db, "p1", created_at=_ts(days_ago=8))
+        await _create(db, "p2", created_at=_ts(days_ago=3))
+
+        count = await ego_crud.auto_table_stale_proposals(db, max_age_days=7)
+        assert count == 1
+
+        p1 = await ego_crud.get_proposal(db, "p1")
+        assert p1["status"] == "tabled"
+        p2 = await ego_crud.get_proposal(db, "p2")
+        assert p2["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_nothing_stale(self, db):
+        """Returns 0 when no proposals exceed threshold."""
+        await _create(db, "fresh", created_at=_ts(days_ago=1))
+        count = await ego_crud.auto_table_stale_proposals(db, max_age_days=14)
+        assert count == 0


### PR DESCRIPTION
## Summary

- Decouples the ego's 0-3 item focus board from the user-facing pending approval queue
- New "unboard" action: ego can rotate focus without removing proposals from user's decision queue
- Auto-tables proposals pending >14 days with intervention_journal sync
- Split context display: Board (ranked focus) / Queue (unranked pending) with age annotations
- Updated both user and genesis ego prompts to reflect new board/queue model

**Root cause:** Board pressure (3 slots) drove premature withdrawal — the ego removed proposals to make room for new ideas, destroying the user's approval opportunity. The 24h guard from PR #411 was a band-aid; this PR fixes the underlying coupling.

**Key design decisions:**
- `unboarded` output field follows same pattern as `tabled`/`withdrawn`
- Soft cap (~10) is prompt-level guidance, not code enforcement
- Auto-table at 14 days (not auto-expire) — tabled items are visible to ego and can be resurfaced
- Genesis ego gets lighter treatment (operational labeling, no soft cap)
- All resolution pathways are rank-agnostic — zero interference

## Test plan

- [x] 15 new tests for `unboard_proposal`, `get_pending_queue`, `auto_table_stale_proposals`
- [x] Full ego test suite: 516 passed, 0 failures
- [x] Ruff lint clean on all changed files
- [x] Code review passed (1 hint text fix applied)
- [ ] CI green
- [ ] E2E: verify ego uses `unboarded` correctly across 2-3 cycles after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)