### PR TITLE
feat(cc): AgentProvider protocol enforcement + LiteLLM proxy support

### DIFF
--- a/src/genesis/autonomy/decomposer.py
+++ b/src/genesis/autonomy/decomposer.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
-    from genesis.cc.invoker import CCInvoker
+    from genesis.cc import AgentProvider
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class TaskDecomposer:
         self,
         *,
         router: _Router,
-        invoker: CCInvoker | None = None,
+        invoker: AgentProvider | None = None,
         db: Any | None = None,
         memory_store: Any | None = None,
         retriever: Any | None = None,

--- a/src/genesis/autonomy/executor/review.py
+++ b/src/genesis/autonomy/executor/review.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
-    from genesis.cc.invoker import CCInvoker
+    from genesis.cc import AgentProvider
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +120,7 @@ class TaskReviewer:
         self,
         *,
         router: _Router,
-        invoker: CCInvoker | None = None,
+        invoker: AgentProvider | None = None,
     ) -> None:
         self._router = router
         self._invoker = invoker

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -40,7 +40,7 @@ from genesis.observability.session_context import set_session_id as _set_obs_ses
 from genesis.util.tasks import tracked_task
 
 if TYPE_CHECKING:
-    from genesis.cc.invoker import CCInvoker
+    from genesis.cc import AgentProvider
     from genesis.cc.session_config import SessionConfigBuilder
     from genesis.cc.session_manager import SessionManager
 
@@ -214,7 +214,7 @@ class DirectSessionRunner:
     def __init__(
         self,
         *,
-        invoker: CCInvoker,
+        invoker: AgentProvider,
         session_manager: SessionManager,
         config_builder: SessionConfigBuilder,
         runtime: object,

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -131,6 +131,8 @@ class CCInvoker:
             env["CLAUDE_STREAM_IDLE_TIMEOUT_MS"] = str(inv.stream_idle_timeout_ms)
         if inv and inv.anthropic_base_url:
             env["ANTHROPIC_BASE_URL"] = inv.anthropic_base_url
+        else:
+            env.pop("ANTHROPIC_BASE_URL", None)
         # Move CC's Bash sandbox off /tmp (512MB tmpfs) onto persistent disk.
         # CC reads CLAUDE_CODE_TMPDIR to choose where it creates
         # /claude-<uid>/<cwd>/<session-id>/ for each Bash invocation.

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -129,6 +129,8 @@ class CCInvoker:
         env["GENESIS_CC_SESSION"] = "1"
         if inv and inv.stream_idle_timeout_ms is not None:
             env["CLAUDE_STREAM_IDLE_TIMEOUT_MS"] = str(inv.stream_idle_timeout_ms)
+        if inv and inv.anthropic_base_url:
+            env["ANTHROPIC_BASE_URL"] = inv.anthropic_base_url
         # Move CC's Bash sandbox off /tmp (512MB tmpfs) onto persistent disk.
         # CC reads CLAUDE_CODE_TMPDIR to choose where it creates
         # /claude-<uid>/<cwd>/<session-id>/ for each Bash invocation.
@@ -548,6 +550,7 @@ class CCInvoker:
             duration_ms=elapsed,
             exit_code=proc.returncode or 0,
             model_requested=str(invocation.model),
+            via_proxy=bool(invocation.anthropic_base_url),
         )
         await self._fire_downgrade_callback(output)
         return output
@@ -589,6 +592,7 @@ class CCInvoker:
             is_error=result_data.get("is_error", False),
             model_requested=str(inv.model),
             downgraded=downgraded,
+            via_proxy=bool(inv.anthropic_base_url),
         )
 
     def _parse_output(self, raw: str, inv: CCInvocation, elapsed_ms: int) -> CCOutput:
@@ -643,4 +647,5 @@ class CCInvoker:
             duration_ms=elapsed_ms,
             exit_code=0,
             model_requested=str(inv.model),
+            via_proxy=bool(inv.anthropic_base_url),
         )

--- a/src/genesis/cc/protocol.py
+++ b/src/genesis/cc/protocol.py
@@ -1,7 +1,7 @@
 """AgentProvider protocol — abstract interface for agent invocation.
 
-CCInvoker implements this today. SDK/ACP backends can be added in V5
-(see docs/plans/v5-hybrid-agent-protocol.md).
+CCInvoker implements this today. Alternative backends (Codex CLI, Pi)
+can implement this protocol to become swappable agent providers.
 """
 
 from __future__ import annotations

--- a/src/genesis/cc/types.py
+++ b/src/genesis/cc/types.py
@@ -98,6 +98,7 @@ class CCInvocation:
     bare: bool = False
     append_system_prompt: bool = False
     stream_idle_timeout_ms: int | None = None
+    anthropic_base_url: str | None = None  # Proxy URL override (ANTHROPIC_BASE_URL)
     on_spawn: Callable[[int], Awaitable[None]] | None = field(
         default=None, compare=False, repr=False,
     )
@@ -135,6 +136,7 @@ class CCOutput:
     error_message: str | None = None
     model_requested: str = ""
     downgraded: bool = False
+    via_proxy: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/genesis/mail/monitor.py
+++ b/src/genesis/mail/monitor.py
@@ -26,7 +26,7 @@ from genesis.security.sanitizer import ContentSanitizer, ContentSource
 if TYPE_CHECKING:
     import aiosqlite
 
-    from genesis.cc.invoker import CCInvoker
+    from genesis.cc import AgentProvider
     from genesis.cc.session_manager import SessionManager
     from genesis.mail.imap_client import IMAPClient
     from genesis.observability.events import GenesisEventBus
@@ -47,7 +47,7 @@ class MailMonitor:
         config: MailConfig,
         imap_client: IMAPClient,
         router: Router,
-        invoker: CCInvoker,
+        invoker: AgentProvider,
         session_manager: SessionManager,
         event_bus: GenesisEventBus | None = None,
         triage_pipeline=None,

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -23,9 +23,9 @@ if TYPE_CHECKING:
     import aiosqlite
 
     from genesis.awareness.loop import AwarenessLoop
+    from genesis.cc import AgentProvider
     from genesis.cc.checkpoint import CheckpointManager
     from genesis.cc.context_injector import ContextInjector
-    from genesis.cc.invoker import CCInvoker
     from genesis.cc.reflection_bridge import CCReflectionBridge
     from genesis.cc.session_manager import SessionManager
     from genesis.inbox.monitor import InboxMonitor
@@ -175,7 +175,7 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
         self._awareness_loop: AwarenessLoop | None = None
         self._router: Router | None = None
         self._reflection_engine: object | None = None
-        self._cc_invoker: CCInvoker | None = None
+        self._cc_invoker: AgentProvider | None = None
         self._session_manager: SessionManager | None = None
         self._checkpoint_manager: CheckpointManager | None = None
         self._cc_reflection_bridge: CCReflectionBridge | None = None

--- a/src/genesis/runtime/_properties.py
+++ b/src/genesis/runtime/_properties.py
@@ -28,9 +28,9 @@ if TYPE_CHECKING:
     import aiosqlite
 
     from genesis.awareness.loop import AwarenessLoop
+    from genesis.cc import AgentProvider
     from genesis.cc.checkpoint import CheckpointManager
     from genesis.cc.context_injector import ContextInjector
-    from genesis.cc.invoker import CCInvoker
     from genesis.cc.reflection_bridge import CCReflectionBridge
     from genesis.cc.session_manager import SessionManager
     from genesis.inbox.monitor import InboxMonitor
@@ -81,7 +81,7 @@ class _RuntimeProperties:
         return self._reflection_engine
 
     @property
-    def cc_invoker(self) -> CCInvoker | None:
+    def cc_invoker(self) -> AgentProvider | None:
         return self._cc_invoker
 
     @property

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -33,7 +33,7 @@ from genesis.sentinel.state import (
 
 if TYPE_CHECKING:
     from genesis.autonomy.remediation import RemediationRegistry
-    from genesis.cc.invoker import CCInvoker
+    from genesis.cc import AgentProvider
     from genesis.cc.session_manager import SessionManager
     from genesis.observability.events import GenesisEventBus
     from genesis.observability.health_data import HealthDataService
@@ -185,7 +185,7 @@ class SentinelDispatcher:
         self,
         *,
         session_manager: SessionManager | None = None,
-        invoker: CCInvoker | None = None,
+        invoker: AgentProvider | None = None,
         remediation_registry: RemediationRegistry | None = None,
         db=None,
         event_bus: GenesisEventBus | None = None,

--- a/tests/test_cc/test_invoker.py
+++ b/tests/test_cc/test_invoker.py
@@ -68,6 +68,22 @@ def test_build_env_strips_claudecode(invoker):
         assert env["HOME"] == "/home/test"
 
 
+def test_build_env_sets_anthropic_base_url(invoker):
+    inv = CCInvocation(prompt="hello", anthropic_base_url="http://localhost:8100")
+    env = invoker._build_env(inv)
+    assert env["ANTHROPIC_BASE_URL"] == "http://localhost:8100"
+
+
+def test_build_env_omits_anthropic_base_url_when_none(invoker):
+    inv = CCInvocation(prompt="hello")
+    with patch.dict("os.environ", {}, clear=False):
+        # Ensure no ANTHROPIC_BASE_URL leaks from parent env
+        import os
+        os.environ.pop("ANTHROPIC_BASE_URL", None)
+        env = invoker._build_env(inv)
+        assert "ANTHROPIC_BASE_URL" not in env
+
+
 @pytest.mark.asyncio
 async def test_run_success(invoker):
     # Match real CLI JSON shape (verified 2026-03-08)
@@ -109,6 +125,38 @@ async def test_run_success(invoker):
     assert output.model_used == "claude-sonnet-4-6"
     assert output.exit_code == 0
     assert not output.is_error
+    assert not output.via_proxy
+
+
+@pytest.mark.asyncio
+async def test_run_via_proxy_sets_flag(invoker):
+    """When anthropic_base_url is set, output.via_proxy should be True."""
+    result_line = json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": False,
+            "result": "proxied response",
+            "session_id": "sess-proxy-1",
+            "total_cost_usd": 0.05,
+            "duration_ms": 1000,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "modelUsage": {"claude-sonnet-4-6": {}},
+        }
+    )
+    mock_proc = AsyncMock()
+    mock_proc.communicate = AsyncMock(return_value=(result_line.encode(), b""))
+    mock_proc.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        output = await invoker.run(
+            CCInvocation(
+                prompt="hello",
+                anthropic_base_url="http://localhost:8100",
+            )
+        )
+    assert output.via_proxy is True
+    assert output.text == "proxied response"
 
 
 @pytest.mark.asyncio

--- a/tests/test_cc/test_invoker.py
+++ b/tests/test_cc/test_invoker.py
@@ -77,9 +77,16 @@ def test_build_env_sets_anthropic_base_url(invoker):
 def test_build_env_omits_anthropic_base_url_when_none(invoker):
     inv = CCInvocation(prompt="hello")
     with patch.dict("os.environ", {}, clear=False):
-        # Ensure no ANTHROPIC_BASE_URL leaks from parent env
         import os
         os.environ.pop("ANTHROPIC_BASE_URL", None)
+        env = invoker._build_env(inv)
+        assert "ANTHROPIC_BASE_URL" not in env
+
+
+def test_build_env_strips_parent_anthropic_base_url(invoker):
+    """Parent env ANTHROPIC_BASE_URL must not leak when field is None."""
+    inv = CCInvocation(prompt="hello")
+    with patch.dict("os.environ", {"ANTHROPIC_BASE_URL": "http://leaked:8100"}):
         env = invoker._build_env(inv)
         assert "ANTHROPIC_BASE_URL" not in env
 

--- a/tests/test_cc/test_protocol.py
+++ b/tests/test_cc/test_protocol.py
@@ -1,0 +1,53 @@
+"""Tests for AgentProvider protocol conformance."""
+
+from __future__ import annotations
+
+import inspect
+
+from genesis.cc.invoker import CCInvoker
+from genesis.cc.protocol import AgentProvider
+from genesis.cc.types import CCInvocation, CCOutput, StreamEvent
+
+
+def test_ccinvoker_is_agent_provider():
+    """CCInvoker must satisfy the AgentProvider runtime-checkable protocol."""
+    invoker = CCInvoker(claude_path="/usr/bin/claude")
+    assert isinstance(invoker, AgentProvider)
+
+
+def test_protocol_has_three_methods():
+    """AgentProvider protocol defines exactly run, run_streaming, interrupt."""
+    protocol_methods = {
+        name
+        for name, _ in inspect.getmembers(AgentProvider, predicate=inspect.isfunction)
+        if not name.startswith("_")
+    }
+    assert protocol_methods == {"run", "run_streaming", "interrupt"}
+
+
+def test_run_signature_matches():
+    """CCInvoker.run() signature matches AgentProvider.run()."""
+    proto_sig = inspect.signature(AgentProvider.run)
+    impl_sig = inspect.signature(CCInvoker.run)
+    # Both should accept (self, invocation: CCInvocation) -> CCOutput
+    proto_params = list(proto_sig.parameters.keys())
+    impl_params = list(impl_sig.parameters.keys())
+    assert proto_params == impl_params
+
+
+def test_run_streaming_signature_matches():
+    """CCInvoker.run_streaming() signature matches AgentProvider.run_streaming()."""
+    proto_sig = inspect.signature(AgentProvider.run_streaming)
+    impl_sig = inspect.signature(CCInvoker.run_streaming)
+    proto_params = list(proto_sig.parameters.keys())
+    impl_params = list(impl_sig.parameters.keys())
+    assert proto_params == impl_params
+
+
+def test_interrupt_signature_matches():
+    """CCInvoker.interrupt() signature matches AgentProvider.interrupt()."""
+    proto_sig = inspect.signature(AgentProvider.interrupt)
+    impl_sig = inspect.signature(CCInvoker.interrupt)
+    proto_params = list(proto_sig.parameters.keys())
+    impl_params = list(impl_sig.parameters.keys())
+    assert proto_params == impl_params

--- a/tests/test_cc/test_protocol.py
+++ b/tests/test_cc/test_protocol.py
@@ -6,7 +6,6 @@ import inspect
 
 from genesis.cc.invoker import CCInvoker
 from genesis.cc.protocol import AgentProvider
-from genesis.cc.types import CCInvocation, CCOutput, StreamEvent
 
 
 def test_ccinvoker_is_agent_provider():


### PR DESCRIPTION
## Summary

- **Phase 3 (LiteLLM Proxy):** Add `anthropic_base_url` field to `CCInvocation` and wire it into `_build_env()`. When set, the CC subprocess gets `ANTHROPIC_BASE_URL` in its environment, routing API calls through a LiteLLM proxy. `CCOutput` gains a `via_proxy` flag for future cost reconciliation. Parent env `ANTHROPIC_BASE_URL` is explicitly stripped when the field is not set, preventing silent proxy leak.
- **Phase 2 (AgentProvider Protocol):** Migrate 7 call site files from importing `CCInvoker` directly to depending on the `AgentProvider` protocol. `CCInvoker` imports now exist only in 3 `runtime/init/` files that instantiate the concrete class. Adding a future `CodexProvider` or `PiProvider` means implementing one class, not touching 7+ files.
- **Protocol conformance tests:** 5 tests verify CCInvoker satisfies AgentProvider (isinstance, method set, signature parity).

## Test plan

- [x] `pytest tests/test_cc/test_invoker.py` — 58 tests pass (4 new: env var set/omit/parent-leak, via_proxy flag)
- [x] `pytest tests/test_cc/test_protocol.py` — 5 tests pass (new: conformance)
- [x] `pytest tests/test_cc/` — 307 passed, 2 skipped
- [x] `pytest tests/test_sentinel/ tests/test_autonomy/ tests/test_mail/` — 772 passed
- [x] `ruff check` — all clean
- [x] No `isinstance(*, CCInvoker)` checks in codebase
- [x] `CCInvoker` imports only in `runtime/init/` (3 files)
- [x] All `CCOutput(...)` construction sites include `via_proxy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)