### PR TITLE
feat(ego): unified cognitive loop — signals, focus selector, unified cycle (PR 1/7)

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -420,6 +420,12 @@ call_sites:
     - groq-free
     default_paid: true
     description: Extract reusable procedures from interaction outcomes
+  40_ego_focus_selection:
+    chain:
+    - groq-free
+    - mistral-small-free
+    - gemini-free
+    description: "Unified cognitive loop focus selector — picks ego attention direction from pending signals"
   43_task_retrospective:
     chain:
     - openrouter-deepseek-v4

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -139,6 +139,69 @@ async def count_uncompacted(db: aiosqlite.Connection) -> int:
 
 
 # ---------------------------------------------------------------------------
+# ego_cycle_outcomes  (unified cognitive loop — Learn phase)
+# ---------------------------------------------------------------------------
+
+
+async def create_cycle_outcome(
+    db: aiosqlite.Connection,
+    *,
+    cycle_id: str,
+    focus_type: str,
+    focus_id: str | None = None,
+    num_proposals: int = 0,
+    num_dispatches: int = 0,
+    assessment: str | None = None,
+    signals_consumed: str | None = None,
+    perception_rationale: str | None = None,
+    perceive_cost_usd: float = 0.0,
+) -> str:
+    """Record a cycle outcome for the Learn phase."""
+    from datetime import UTC, datetime
+
+    await db.execute(
+        """INSERT INTO ego_cycle_outcomes
+           (cycle_id, focus_type, focus_id, num_proposals, num_dispatches,
+            assessment, signals_consumed, perception_rationale,
+            perceive_cost_usd, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            cycle_id,
+            focus_type,
+            focus_id,
+            num_proposals,
+            num_dispatches,
+            assessment,
+            signals_consumed,
+            perception_rationale,
+            perceive_cost_usd,
+            datetime.now(UTC).isoformat(),
+        ),
+    )
+    await db.commit()
+    return cycle_id
+
+
+async def list_cycle_outcomes(
+    db: aiosqlite.Connection,
+    *,
+    limit: int = 10,
+) -> list[dict]:
+    """List recent cycle outcomes (newest first)."""
+    cursor = await db.execute(
+        """SELECT cycle_id, focus_type, focus_id, num_proposals,
+                  num_dispatches, assessment, signals_consumed,
+                  perception_rationale, perceive_cost_usd, created_at
+           FROM ego_cycle_outcomes
+           ORDER BY created_at DESC
+           LIMIT ?""",
+        (limit,),
+    )
+    rows = await cursor.fetchall()
+    return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
 # ego_state  (key-value store)
 # ---------------------------------------------------------------------------
 

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1144,6 +1144,23 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
     # World model tables: user goals and contacts for ego world model.
     await _migrate_world_model_tables(db)
 
+    # Unified cognitive loop: ego cycle outcomes for the Learn phase.
+    # Tracks focus selection decisions and cycle results for feedback.
+    await db.execute("""
+        CREATE TABLE IF NOT EXISTS ego_cycle_outcomes (
+            cycle_id            TEXT PRIMARY KEY,
+            focus_type          TEXT NOT NULL,
+            focus_id            TEXT,
+            num_proposals       INTEGER DEFAULT 0,
+            num_dispatches      INTEGER DEFAULT 0,
+            assessment          TEXT,
+            signals_consumed    TEXT,
+            perception_rationale TEXT,
+            perceive_cost_usd   REAL DEFAULT 0.0,
+            created_at          TEXT NOT NULL
+        )
+    """)
+
 
 async def _migrate_cognitive_state_check(db: aiosqlite.Connection) -> None:
     """Rebuild cognitive_state if CHECK constraint lacks 'resilience_degradation'.

--- a/src/genesis/ego/focus.py
+++ b/src/genesis/ego/focus.py
@@ -19,12 +19,9 @@ import json
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import Any, Protocol
 
 from genesis.ego.signals import EgoSignal
-
-if TYPE_CHECKING:
-    pass
 
 logger = logging.getLogger(__name__)
 
@@ -202,8 +199,9 @@ FOCUS_CONTEXT_WEIGHTS: dict[str, dict[str, str]] = {
 # Focus selector
 # ---------------------------------------------------------------------------
 
-# Regex to extract JSON from LLM response (same as session.py parse pattern)
-_JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
+# Regex to extract JSON from LLM response (non-greedy to avoid matching
+# across multiple JSON objects or trailing text with braces).
+_JSON_RE = re.compile(r"\{.*?\}", re.DOTALL)
 
 
 class FocusSelector:

--- a/src/genesis/ego/focus.py
+++ b/src/genesis/ego/focus.py
@@ -1,0 +1,414 @@
+"""Focus selector — perceive phase of the unified cognitive loop.
+
+Selects what the ego should pay attention to from a batch of signals.
+Uses lightweight LLM classification via ``router.route_call()`` when
+there are multiple competing signals, and shortcuts (no LLM call) for
+single-signal and critical-preemption cases.
+
+Context weights are a lookup table keyed on focus_type — the LLM
+chooses WHAT to focus on, not HOW MUCH context to include. This
+removes the lowest-confidence piece from the critical path. Weights
+are defined here but not wired to ``build()`` until PR 3.
+
+Part of PR 1: Signal System + Focus Selector (unified cognitive loop).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
+
+from genesis.ego.signals import EgoSignal
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+_CALL_SITE = "40_ego_focus_selection"
+
+
+# ---------------------------------------------------------------------------
+# Router protocol (same pattern as learning/triage/classifier.py:21-24)
+# ---------------------------------------------------------------------------
+
+class _Router(Protocol):
+    async def route_call(
+        self, call_site_id: str, messages: list[dict[str, Any]], **kwargs: Any
+    ) -> Any: ...
+
+
+# ---------------------------------------------------------------------------
+# FocusResult — output of the perceive phase
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FocusResult:
+    """Result of focus selection — what the ego should think about."""
+
+    focus_type: str  # "proactive", "daily_briefing", "reactive", etc.
+    focus_id: str | None = None  # specific target (e.g., goal_id)
+    rationale: str = ""  # why this focus was selected
+    signals_consumed: list[str] = field(default_factory=list)
+    context_weights: dict[str, str] = field(default_factory=dict)
+    perceive_cost_usd: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Context weights lookup table
+# ---------------------------------------------------------------------------
+
+# Section names match user_context.py build() order.
+# Weight levels:
+#   "always" — never overridden, always full depth
+#   "deep"   — full detail, all data
+#   "light"  — 1-2 line summary (implemented in PR 3)
+#   "skip"   — omit entirely
+#
+# "always" sections: user_model, ego_notepad, directives, output_contract
+# These are NEVER overridden regardless of focus type.
+
+_ALL_SECTIONS = (
+    "user_model",
+    "ego_notepad",
+    "goals",
+    "directives",
+    "world_snapshot",
+    "activity_pulse",
+    "recent_conversations",
+    "backlog_summary",
+    "escalations",
+    "capabilities",
+    "follow_ups",
+    "proposal_history",
+    "proposal_board",
+    "execution_outcomes",
+    "goal_progress",
+    "capability_performance",
+    "autonomy_readiness",
+    "recurring_patterns",
+    "output_contract",
+)
+
+# Sections that are always included at full depth regardless of weights.
+_ALWAYS_SECTIONS = frozenset({
+    "user_model", "ego_notepad", "directives", "output_contract",
+})
+
+
+def _make_weights(overrides: dict[str, str]) -> dict[str, str]:
+    """Build a full weight dict: always sections stay always, rest uses overrides."""
+    weights: dict[str, str] = {}
+    for section in _ALL_SECTIONS:
+        if section in _ALWAYS_SECTIONS:
+            weights[section] = "always"
+        else:
+            weights[section] = overrides.get(section, "deep")
+    return weights
+
+
+# Default: all sections at "deep" (backward compatible with current behavior).
+_DEFAULT_WEIGHTS = _make_weights({})
+
+FOCUS_CONTEXT_WEIGHTS: dict[str, dict[str, str]] = {
+    # Proactive: breadth scan, everything deep (same as current)
+    "proactive": _DEFAULT_WEIGHTS,
+
+    # Daily briefing: needs full breadth for the morning report
+    "daily_briefing": _DEFAULT_WEIGHTS,
+
+    # Reactive: health/escalations deep, others light
+    "reactive": _make_weights({
+        "escalations": "deep",
+        "execution_outcomes": "deep",
+        "proposal_board": "deep",
+        "goals": "light",
+        "goal_progress": "light",
+        "world_snapshot": "light",
+        "activity_pulse": "light",
+        "recent_conversations": "light",
+        "backlog_summary": "light",
+        "follow_ups": "light",
+        "proposal_history": "light",
+        "capabilities": "skip",
+        "capability_performance": "skip",
+        "autonomy_readiness": "skip",
+        "recurring_patterns": "skip",
+    }),
+
+    # Goal review: goals/progress/outcomes deep, others light
+    "goal_review": _make_weights({
+        "goals": "deep",
+        "goal_progress": "deep",
+        "execution_outcomes": "deep",
+        "follow_ups": "deep",
+        "proposal_board": "deep",
+        "world_snapshot": "light",
+        "activity_pulse": "light",
+        "recent_conversations": "light",
+        "backlog_summary": "light",
+        "escalations": "light",
+        "proposal_history": "light",
+        "capabilities": "skip",
+        "capability_performance": "skip",
+        "autonomy_readiness": "skip",
+        "recurring_patterns": "skip",
+    }),
+
+    # Dispatch outcome: outcomes/goals deep, most others skip
+    "dispatch_outcome": _make_weights({
+        "execution_outcomes": "deep",
+        "goals": "deep",
+        "goal_progress": "deep",
+        "proposal_board": "deep",
+        "follow_ups": "light",
+        "world_snapshot": "skip",
+        "activity_pulse": "skip",
+        "recent_conversations": "skip",
+        "backlog_summary": "skip",
+        "escalations": "light",
+        "proposal_history": "skip",
+        "capabilities": "skip",
+        "capability_performance": "skip",
+        "autonomy_readiness": "skip",
+        "recurring_patterns": "skip",
+    }),
+
+    # Escalation: escalations deep, system context deep, others light
+    "escalation": _make_weights({
+        "escalations": "deep",
+        "execution_outcomes": "deep",
+        "proposal_board": "deep",
+        "goals": "light",
+        "goal_progress": "light",
+        "world_snapshot": "light",
+        "activity_pulse": "light",
+        "recent_conversations": "light",
+        "backlog_summary": "light",
+        "follow_ups": "light",
+        "proposal_history": "light",
+        "capabilities": "skip",
+        "capability_performance": "skip",
+        "autonomy_readiness": "skip",
+        "recurring_patterns": "skip",
+    }),
+}
+
+
+# ---------------------------------------------------------------------------
+# Focus selector
+# ---------------------------------------------------------------------------
+
+# Regex to extract JSON from LLM response (same as session.py parse pattern)
+_JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+class FocusSelector:
+    """Selects what the ego should focus on from a batch of signals.
+
+    Optimizations that skip the LLM call:
+    - Single signal → select directly
+    - Critical signal present → preempt (highest-priority critical)
+    - LLM call only fires for multi-signal arbitration
+
+    Parameters
+    ----------
+    router:
+        Router instance for ``route_call()``. Same interface used by
+        triage classifier, delta assessor, and 8+ other subsystems.
+    """
+
+    def __init__(self, router: _Router) -> None:
+        self._router = router
+
+    async def select(
+        self,
+        signals: list[EgoSignal],
+        recent_focuses: list[dict[str, str]] | None = None,
+    ) -> FocusResult | None:
+        """Select focus from a batch of signals.
+
+        Parameters
+        ----------
+        signals:
+            Drained signals from the SignalQueue (already priority-sorted).
+        recent_focuses:
+            Last N focus outcomes for context (avoids repetition).
+            Each dict has keys: focus_type, focus_id, rationale, created_at.
+
+        Returns None if no actionable signals.
+        """
+        if not signals:
+            return None
+
+        # --- Shortcut: single signal → direct select ---
+        if len(signals) == 1:
+            sig = signals[0]
+            return self._signal_to_focus(sig, rationale="only signal in queue")
+
+        # --- Shortcut: critical signal → preempt ---
+        critical = [s for s in signals if s.priority == "critical"]
+        if critical:
+            sig = critical[0]  # Already priority-sorted
+            return self._signal_to_focus(
+                sig,
+                rationale=f"critical signal preemption ({len(signals)} total)",
+                consumed_ids=[s.id for s in signals],
+            )
+
+        # --- Multi-signal: LLM classification ---
+        return await self._llm_select(signals, recent_focuses or [])
+
+    async def _llm_select(
+        self,
+        signals: list[EgoSignal],
+        recent_focuses: list[dict[str, str]],
+    ) -> FocusResult:
+        """Use router.route_call() for multi-signal focus selection."""
+        prompt = self._build_prompt(signals, recent_focuses)
+        messages = [{"role": "user", "content": prompt}]
+
+        try:
+            result = await self._router.route_call(_CALL_SITE, messages)
+
+            if not result.success or not result.content:
+                logger.warning(
+                    "Focus selector route_call failed — falling back to highest priority",
+                )
+                return self._fallback(signals, cost=getattr(result, "cost_usd", 0.0))
+
+            parsed = self._parse_response(result.content)
+            if parsed is None:
+                logger.warning(
+                    "Focus selector parse failed — falling back to highest priority",
+                )
+                return self._fallback(signals, cost=getattr(result, "cost_usd", 0.0))
+
+            # Build FocusResult from parsed response
+            focus_type = parsed.get("focus_type", signals[0].focus_category)
+            focus_id = parsed.get("focus_id")
+            rationale = parsed.get("rationale", "LLM-selected focus")
+            consumed = parsed.get("signals_consumed", [s.id for s in signals])
+
+            return FocusResult(
+                focus_type=focus_type,
+                focus_id=focus_id,
+                rationale=rationale,
+                signals_consumed=consumed if isinstance(consumed, list) else [consumed],
+                context_weights=self.get_context_weights(focus_type),
+                perceive_cost_usd=getattr(result, "cost_usd", 0.0),
+            )
+
+        except Exception:
+            logger.warning(
+                "Focus selector error — falling back to highest priority",
+                exc_info=True,
+            )
+            return self._fallback(signals)
+
+    def _build_prompt(
+        self,
+        signals: list[EgoSignal],
+        recent_focuses: list[dict[str, str]],
+    ) -> str:
+        """Build classification prompt for the focus selector."""
+        parts = [
+            "You are the focus selector for an autonomous AI agent's cognitive loop.",
+            "Given the pending signals below, choose which one the agent should focus on.",
+            "",
+            "## Pending Signals",
+            "",
+        ]
+
+        for i, sig in enumerate(signals, 1):
+            parts.append(
+                f"{i}. [{sig.priority.upper()}] "
+                f"({sig.focus_category}) {sig.summary}"
+            )
+            if sig.focus_id:
+                parts.append(f"   Target: {sig.focus_id}")
+
+        if recent_focuses:
+            parts.append("")
+            parts.append("## Recent Focuses (avoid repetition)")
+            parts.append("")
+            for rf in recent_focuses[-5:]:
+                parts.append(
+                    f"- {rf.get('focus_type', '?')}: "
+                    f"{rf.get('rationale', '?')[:80]}"
+                )
+
+        parts.extend([
+            "",
+            "## Instructions",
+            "",
+            "Choose the signal that deserves the agent's attention right now.",
+            "Consider: priority, urgency, staleness, and avoid repeating recent focuses.",
+            "",
+            "Respond with JSON only:",
+            '{"focus_type": "<category>", "focus_id": "<target or null>", '
+            '"rationale": "<brief reason>", "signals_consumed": ["<signal_ids>"]}',
+        ])
+
+        return "\n".join(parts)
+
+    def _parse_response(self, content: str) -> dict | None:
+        """Parse JSON from LLM response (same fallback pattern as session.py)."""
+        # Try direct parse
+        try:
+            return json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        # Try regex extraction
+        match = _JSON_RE.search(content)
+        if match:
+            try:
+                return json.loads(match.group())
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        return None
+
+    def _signal_to_focus(
+        self,
+        signal: EgoSignal,
+        rationale: str,
+        consumed_ids: list[str] | None = None,
+    ) -> FocusResult:
+        """Convert a single signal to a FocusResult (no LLM call)."""
+        return FocusResult(
+            focus_type=signal.focus_category,
+            focus_id=signal.focus_id,
+            rationale=rationale,
+            signals_consumed=consumed_ids or [signal.id],
+            context_weights=self.get_context_weights(signal.focus_category),
+            perceive_cost_usd=0.0,
+        )
+
+    def _fallback(
+        self,
+        signals: list[EgoSignal],
+        cost: float = 0.0,
+    ) -> FocusResult:
+        """Fallback: pick the highest-priority signal (signals are pre-sorted)."""
+        sig = signals[0]
+        return FocusResult(
+            focus_type=sig.focus_category,
+            focus_id=sig.focus_id,
+            rationale=f"fallback — highest priority signal ({sig.priority})",
+            signals_consumed=[s.id for s in signals],
+            context_weights=self.get_context_weights(sig.focus_category),
+            perceive_cost_usd=cost,
+        )
+
+    @staticmethod
+    def get_context_weights(focus_type: str) -> dict[str, str]:
+        """Look up context weights for a focus type.
+
+        Returns all-"deep" defaults for unknown focus types.
+        """
+        return FOCUS_CONTEXT_WEIGHTS.get(focus_type, _DEFAULT_WEIGHTS)

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -102,6 +102,10 @@ class EgoSession:
         session_id_key: str | None = None,
         focus_summary_key: str | None = None,
         source_tag: str | None = None,
+        # Unified cognitive loop — optional router for focus selector (PR 1).
+        # Wired in PR 2 via init/ego.py. When None, focus selection
+        # falls back to highest-priority signal (no LLM call).
+        router: object | None = None,
     ) -> None:
         self._invoker = invoker
         self._session_manager = session_manager
@@ -118,6 +122,8 @@ class EgoSession:
         self._call_site = call_site or _DEFAULT_CALL_SITE
         self._focus_summary_key = focus_summary_key or _DEFAULT_FOCUS_SUMMARY_KEY
         self._source_tag = source_tag or "ego_cycle"
+        self._router = router  # For unified cognitive loop focus selector
+        self._focus_selector = None  # Lazy-init in _perceive
         self._sweep_lock = asyncio.Lock()
         self._last_realist_cost_usd = 0.0  # accumulated by _filter_proposals
         # Cache the static system prompt (read once, not every cycle)
@@ -269,6 +275,259 @@ class EgoSession:
                     logger.error("Session fail() also errored", exc_info=True)
             return None
 
+        return await self._process_cycle_output(output, model, session_id)
+
+    async def run_unified_cycle(
+        self,
+        signals: list,
+        *,
+        model_override: str | None = None,
+    ) -> EgoCycle | None:
+        """Execute one ego cycle via the unified perceive→think→act→learn pipeline.
+
+        This is the new entry point for the unified cognitive loop.
+        It coexists with ``run_cycle()`` during migration (PRs 1-4).
+        After PR 5, ``run_cycle()`` is removed and this becomes the
+        sole cycle method.
+
+        Parameters
+        ----------
+        signals:
+            List of ``EgoSignal`` objects drained from the SignalQueue.
+        model_override:
+            Override model selection (takes precedence over config).
+
+        Returns the stored EgoCycle, or None if perception found nothing
+        actionable or the CC invocation failed.
+
+        Raises:
+            BudgetExceededError: Daily budget cap exceeded.
+            CycleBlockedError: Approval gate blocked the cycle.
+        """
+        if not signals:
+            return None
+
+        # 1. PERCEIVE — focus selection
+        focus = await self._perceive(signals)
+        if focus is None:
+            return None
+
+        # 2. THINK — budget, context, prompt, invoke
+
+        # Budget check
+        if not await self._check_budget():
+            raise BudgetExceededError(
+                f"Daily ego thinking spend exceeds cap "
+                f"${self._config.ego_thinking_budget_usd}"
+            )
+
+        # Context assembly — uses assemble_context() as-is.
+        # Context weights are DEFINED in focus.py lookup table but NOT
+        # wired to build() until PR 3 adds the context_weights param.
+        # PR 1: focus affects the PROMPT, not context assembly.
+        dynamic_context = await self._compaction.assemble_context(
+            context_builder=self._context_builder,
+        )
+
+        # Focus-specific prompt
+        user_prompt = self._build_focused_prompt(
+            dynamic_context=dynamic_context,
+            focus=focus,
+        )
+
+        # Model + effort from config (no cycle-type overrides in unified loop)
+        model = CCModel(model_override or self._config.model)
+        effort = EffortLevel(self._config.default_effort)
+
+        # System prompt is identity ONLY (cacheable)
+        system_prompt = self._static_prompt
+
+        # Build invocation — same pattern as run_cycle
+        invocation = CCInvocation(
+            prompt=user_prompt,
+            model=model,
+            effort=effort,
+            resume_session_id=None,
+            append_system_prompt=True,
+            system_prompt=system_prompt,
+            timeout_s=2400,
+            skip_permissions=True,
+            working_dir=background_session_dir(),
+            mcp_config=self._mcp_config_path,
+        )
+
+        # Autonomous dispatch check
+        output = None
+        session_id: str | None = None
+        if self._autonomous_dispatcher is not None:
+            decision = await self._autonomous_dispatcher.route(
+                AutonomousDispatchRequest(
+                    subsystem="ego",
+                    policy_id=self._source_tag,
+                    action_label=self._source_tag.replace("_", " "),
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                    cli_invocation=invocation,
+                    dispatch_mode="cli",
+                    cli_fallback_allowed=True,
+                    approval_required_for_cli=True,
+                    approval_key_stable=True,
+                ),
+            )
+            if decision.mode == "blocked":
+                logger.warning("Ego unified cycle blocked: %s", decision.reason)
+                raise CycleBlockedError(decision.reason or "approval pending")
+
+        if output is None:
+            try:
+                sess = await self._session_manager.create_background(
+                    session_type=SessionType.BACKGROUND_TASK,
+                    model=model,
+                    effort=effort,
+                    source_tag=self._source_tag,
+                )
+                session_id = sess["id"]
+                _set_obs_session(session_id)
+            except Exception:
+                logger.error(
+                    "Failed to create ego background session (unified)",
+                    exc_info=True,
+                )
+                return None
+
+            try:
+                output = await self._invoker.run(invocation)
+            except Exception:
+                logger.error("Ego CC invocation failed (unified)", exc_info=True)
+                try:
+                    await self._session_manager.fail(
+                        session_id, reason="CC invocation error",
+                    )
+                except Exception:
+                    logger.error("Session fail() also errored", exc_info=True)
+                return None
+
+        if output.is_error:
+            logger.error(
+                "Ego CC session returned error (unified): %s",
+                output.error_message,
+            )
+            if session_id is not None:
+                try:
+                    await self._session_manager.fail(
+                        session_id, reason=output.error_message,
+                    )
+                except Exception:
+                    logger.error("Session fail() also errored", exc_info=True)
+            return None
+
+        # 3. ACT — shared output processing
+        cycle = await self._process_cycle_output(output, model, session_id)
+
+        # 4. LEARN — record cycle outcome
+        await self._record_cycle_outcome(cycle, focus)
+
+        return cycle
+
+    async def _perceive(self, signals: list) -> object | None:
+        """Focus selection — perceive phase of the unified cognitive loop.
+
+        Returns a FocusResult or None if no actionable signals.
+        """
+        from genesis.ego.focus import FocusResult, FocusSelector
+
+        if not signals:
+            return None
+
+        # Lazy-init focus selector
+        if self._focus_selector is None:
+            if self._router is not None:
+                self._focus_selector = FocusSelector(self._router)
+            else:
+                # No router → always return highest-priority signal directly.
+                # This is the expected state in PR 1 (router wired in PR 2).
+                sig = signals[0]
+                weights = FocusSelector.get_context_weights(sig.focus_category)
+                return FocusResult(
+                    focus_type=sig.focus_category,
+                    focus_id=sig.focus_id,
+                    rationale="direct selection (no router available)",
+                    signals_consumed=[s.id for s in signals],
+                    context_weights=weights,
+                )
+
+        # Fetch recent focuses from ego_cycle_outcomes for context
+        recent_focuses: list[dict[str, str]] = []
+        try:
+            rows = await ego_crud.list_cycle_outcomes(
+                self._db, limit=5,
+            )
+            recent_focuses = [
+                {
+                    "focus_type": r.get("focus_type", ""),
+                    "focus_id": r.get("focus_id", ""),
+                    "rationale": r.get("perception_rationale", ""),
+                    "created_at": r.get("created_at", ""),
+                }
+                for r in rows
+            ]
+        except Exception:
+            # Table may not exist yet (migration not applied),
+            # or no data yet. Both are fine.
+            logger.debug("No recent focuses available", exc_info=True)
+
+        return await self._focus_selector.select(signals, recent_focuses)
+
+    async def _record_cycle_outcome(
+        self,
+        cycle: EgoCycle,
+        focus: object,
+    ) -> None:
+        """Record cycle outcome for the Learn phase (ego_cycle_outcomes table)."""
+        try:
+            proposals = json.loads(cycle.proposals_json) if cycle.proposals_json else []
+            await ego_crud.create_cycle_outcome(
+                self._db,
+                cycle_id=cycle.id,
+                focus_type=focus.focus_type,
+                focus_id=focus.focus_id,
+                num_proposals=len(proposals),
+                signals_consumed=json.dumps(focus.signals_consumed),
+                perception_rationale=focus.rationale,
+                perceive_cost_usd=focus.perceive_cost_usd,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to record cycle outcome for %s",
+                cycle.id,
+                exc_info=True,
+            )
+
+    # -- Output processing (shared by run_cycle and run_unified_cycle) -----
+
+    async def _process_cycle_output(
+        self,
+        output: object,
+        model: CCModel,
+        session_id: str | None,
+    ) -> EgoCycle:
+        """Post-invocation processing shared by run_cycle and run_unified_cycle.
+
+        Handles: parse → focus sanitize → store cycle → complete session →
+        record last_run → realist gate → proposals → table/withdraw/unboard →
+        execution briefs → follow-ups → directives → knowledge → escalations.
+
+        Parameters
+        ----------
+        output:
+            CC output object with .text, .cost_usd, .input_tokens, etc.
+        model:
+            CCModel used for the invocation (fallback for model_used).
+        session_id:
+            Background session ID, or None if dispatched via autonomous route.
+        """
         # 6. Parse output
         parsed = self._parse_output(output.text)
 
@@ -547,6 +806,58 @@ class EgoSession:
                 "\n\nThis is a MORNING REPORT cycle. Include the morning_report "
                 "field with your daily briefing for the user."
             )
+        return f"{directive}\n\n---\n\n{dynamic_context}"
+
+    def _build_focused_prompt(
+        self,
+        *,
+        dynamic_context: str,
+        focus: object,
+    ) -> str:
+        """Build a focus-specific user message for the unified cognitive loop.
+
+        Similar to ``_build_user_prompt`` but with a focus directive instead
+        of the generic "run your ego cycle" directive. The focus comes from
+        the perceive phase (FocusSelector output).
+
+        Parameters
+        ----------
+        dynamic_context:
+            Assembled operational context from compaction engine.
+        focus:
+            FocusResult with focus_type, focus_id, rationale.
+        """
+        directive = (
+            f"Your focus this cycle: **{focus.focus_type}** — {focus.rationale}\n\n"
+            "Review the operational context below with this focus in mind. "
+            "Check your open threads and use your MCP tools to verify "
+            "any beliefs before proposing actions. End with valid JSON "
+            "matching the ego output schema."
+        )
+
+        # Focus-specific instructions
+        if focus.focus_type == "daily_briefing":
+            directive += (
+                "\n\nThis is a DAILY BRIEFING cycle. Include the morning_report "
+                "field with your daily briefing for the user."
+            )
+        elif focus.focus_type == "goal_review":
+            directive += (
+                "\n\nThis is a GOAL REVIEW cycle. Assess progress on the "
+                "focused goal, identify blockers, and propose goal-advancing "
+                "actions. Include the goal_assessment field."
+            )
+        elif focus.focus_type == "reactive":
+            directive += (
+                "\n\nThis is a REACTIVE cycle. Respond to the event(s) that "
+                "triggered this cycle."
+            )
+        elif focus.focus_type == "dispatch_outcome":
+            directive += (
+                "\n\nThis cycle was triggered by a dispatch outcome. "
+                "Assess the result and determine next steps."
+            )
+
         return f"{directive}\n\n---\n\n{dynamic_context}"
 
     # -- Output parsing ----------------------------------------------------

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -47,7 +47,9 @@ if TYPE_CHECKING:
     from genesis.ego.compaction import CompactionEngine
     from genesis.ego.context import EgoContextBuilder
     from genesis.ego.dispatch import EgoDispatcher
+    from genesis.ego.focus import FocusResult
     from genesis.ego.proposals import ProposalWorkflow
+    from genesis.ego.signals import EgoSignal
     from genesis.observability.events import GenesisEventBus
 
 logger = logging.getLogger(__name__)
@@ -279,7 +281,7 @@ class EgoSession:
 
     async def run_unified_cycle(
         self,
-        signals: list,
+        signals: list[EgoSignal],
         *,
         model_override: str | None = None,
     ) -> EgoCycle | None:
@@ -431,7 +433,7 @@ class EgoSession:
 
         return cycle
 
-    async def _perceive(self, signals: list) -> object | None:
+    async def _perceive(self, signals: list[EgoSignal]) -> FocusResult | None:
         """Focus selection — perceive phase of the unified cognitive loop.
 
         Returns a FocusResult or None if no actionable signals.
@@ -483,11 +485,15 @@ class EgoSession:
     async def _record_cycle_outcome(
         self,
         cycle: EgoCycle,
-        focus: object,
+        focus: FocusResult,
     ) -> None:
         """Record cycle outcome for the Learn phase (ego_cycle_outcomes table)."""
         try:
             proposals = json.loads(cycle.proposals_json) if cycle.proposals_json else []
+            # GROUNDWORK(unified-loop-dispatches): num_dispatches is always 0
+            # here because dispatch count isn't known at cycle-completion time.
+            # PR 2+ should wire the on_end hook to update this column after
+            # dispatched sessions complete.
             await ego_crud.create_cycle_outcome(
                 self._db,
                 cycle_id=cycle.id,
@@ -812,7 +818,7 @@ class EgoSession:
         self,
         *,
         dynamic_context: str,
-        focus: object,
+        focus: FocusResult,
     ) -> str:
         """Build a focus-specific user message for the unified cognitive loop.
 
@@ -856,6 +862,11 @@ class EgoSession:
             directive += (
                 "\n\nThis cycle was triggered by a dispatch outcome. "
                 "Assess the result and determine next steps."
+            )
+        elif focus.focus_type == "escalation":
+            directive += (
+                "\n\nThis is an ESCALATION cycle. Assess the health issue "
+                "or system alert and propose remediation actions."
             )
 
         return f"{directive}\n\n---\n\n{dynamic_context}"

--- a/src/genesis/ego/signals.py
+++ b/src/genesis/ego/signals.py
@@ -113,8 +113,9 @@ class SignalQueue:
             logger.debug("Signal rejected (expired): %s", signal.summary[:50])
             return False
 
-        # Content dedup: skip if same summary seen recently
-        summary_key = signal.summary[:100]
+        # Content dedup: skip if same summary seen recently.
+        # Include focus_category to prevent collision on empty/short summaries.
+        summary_key = f"{signal.focus_category}:{signal.summary[:100]}"
         now = datetime.now(UTC)
 
         if summary_key in self._seen:

--- a/src/genesis/ego/signals.py
+++ b/src/genesis/ego/signals.py
@@ -1,0 +1,184 @@
+"""Ego signal system — structured events for the unified cognitive loop.
+
+Signals represent things the ego might want to pay attention to.
+The SignalQueue provides priority ordering, dedup, and expiry —
+generalizing the reactive dedup pattern from cadence.py.
+
+Part of PR 1: Signal System + Focus Selector (unified cognitive loop).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+# Priority ordering for asyncio.PriorityQueue (lower = higher priority).
+PRIORITY_ORDER: dict[str, int] = {
+    "critical": 0,
+    "high": 1,
+    "medium": 2,
+    "low": 3,
+}
+
+
+@dataclass(order=True)
+class EgoSignal:
+    """A structured event that the ego might want to pay attention to.
+
+    Uses ``@dataclass(order=True)`` with ``_priority_order`` as the
+    only compared field so that ``asyncio.PriorityQueue`` drains
+    highest-priority signals first.
+    """
+
+    # PriorityQueue ordering — lower number = higher priority.
+    _priority_order: int = field(compare=True, repr=False, default=2)
+
+    # --- Actual fields (not compared for ordering) ---
+    id: str = field(
+        default_factory=lambda: uuid.uuid4().hex[:12],
+        compare=False,
+    )
+    signal_type: str = field(default="timer", compare=False)
+    focus_category: str = field(default="proactive", compare=False)
+    summary: str = field(default="", compare=False)
+    priority: str = field(default="medium", compare=False)
+    focus_id: str | None = field(default=None, compare=False)
+    metadata: dict = field(default_factory=dict, compare=False)
+    created_at: str = field(
+        default_factory=lambda: datetime.now(UTC).isoformat(),
+        compare=False,
+    )
+    expires_at: str | None = field(default=None, compare=False)
+
+    def __post_init__(self) -> None:
+        """Set _priority_order from the human-readable priority string."""
+        self._priority_order = PRIORITY_ORDER.get(self.priority, 2)
+
+    @property
+    def is_expired(self) -> bool:
+        """Check if the signal has passed its expiry time."""
+        if self.expires_at is None:
+            return False
+        try:
+            return datetime.now(UTC) > datetime.fromisoformat(self.expires_at)
+        except (ValueError, TypeError):
+            return False
+
+
+class SignalQueue:
+    """Priority queue for ego signals with dedup and expiry.
+
+    Generalizes the reactive dedup pattern from
+    ``EgoCadenceManager`` (cadence.py:101-105, 209-223).
+
+    Parameters
+    ----------
+    maxsize:
+        Maximum number of signals in the queue. Overflow drops
+        on push (lowest priority first via replacement is not
+        implemented — we simply reject when full, matching the
+        existing ``QueueFull`` pattern from cadence.py:225-229).
+    dedup_hours:
+        Window for summary-based dedup. Same summary within this
+        window is rejected. Default 6h matches cadence.py.
+    """
+
+    def __init__(
+        self,
+        *,
+        maxsize: int = 20,
+        dedup_hours: int = 6,
+    ) -> None:
+        self._queue: asyncio.PriorityQueue[EgoSignal] = (
+            asyncio.PriorityQueue(maxsize=maxsize)
+        )
+        self._maxsize = maxsize
+        self._dedup_hours = dedup_hours
+        # summary → last_seen timestamp (same pattern as cadence.py:104)
+        self._seen: dict[str, datetime] = {}
+
+    def push(self, signal: EgoSignal) -> bool:
+        """Add a signal to the queue.
+
+        Returns True if the signal was accepted, False if it was
+        rejected (dedup hit, expired, or queue full).
+        """
+        # Reject expired signals
+        if signal.is_expired:
+            logger.debug("Signal rejected (expired): %s", signal.summary[:50])
+            return False
+
+        # Content dedup: skip if same summary seen recently
+        summary_key = signal.summary[:100]
+        now = datetime.now(UTC)
+
+        if summary_key in self._seen:
+            age = (now - self._seen[summary_key]).total_seconds()
+            if age < self._dedup_hours * 3600:
+                logger.debug(
+                    "Signal deduped (%.0fm old): %s",
+                    age / 60,
+                    summary_key[:50],
+                )
+                return False
+
+        # Prune old entries (keep dict bounded)
+        cutoff = now - timedelta(hours=self._dedup_hours)
+        self._seen = {k: v for k, v in self._seen.items() if v > cutoff}
+        self._seen[summary_key] = now
+
+        # Try to enqueue
+        try:
+            self._queue.put_nowait(signal)
+            logger.debug(
+                "Signal queued [%s]: %s",
+                signal.priority,
+                summary_key[:50],
+            )
+            return True
+        except asyncio.QueueFull:
+            logger.warning("Signal queue full — dropping: %s", summary_key[:50])
+            return False
+
+    def drain(self) -> list[EgoSignal]:
+        """Drain all signals from the queue, dropping expired ones.
+
+        Returns signals sorted by priority (highest first — they
+        come out in priority order from the PriorityQueue).
+        """
+        signals: list[EgoSignal] = []
+        while not self._queue.empty():
+            try:
+                sig = self._queue.get_nowait()
+                if not sig.is_expired:
+                    signals.append(sig)
+                else:
+                    logger.debug(
+                        "Signal dropped (expired on drain): %s",
+                        sig.summary[:50],
+                    )
+            except asyncio.QueueEmpty:
+                break
+        return signals
+
+    def __len__(self) -> int:
+        """Number of signals currently in the queue."""
+        return self._queue.qsize()
+
+    def empty(self) -> bool:
+        """Whether the queue is empty."""
+        return self._queue.empty()
+
+    def clear(self) -> None:
+        """Drop all signals and reset dedup state."""
+        while not self._queue.empty():
+            try:
+                self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        self._seen.clear()

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -9,12 +9,31 @@ from enum import StrEnum
 
 
 class CycleType(StrEnum):
-    """Types of ego thinking cycles."""
+    """Types of ego thinking cycles.
+
+    DEPRECATED: will be removed in PR 5 when all cycle types are
+    migrated to the unified cognitive loop (FocusCategory).
+    """
 
     PROACTIVE = "proactive"        # Regular brainstorming (uses config model/effort)
     MORNING_REPORT = "morning_report"  # Daily briefing (always Sonnet, Low)
     REACTIVE = "reactive"          # User message response (uses config model/effort)
     ESCALATION = "escalation"      # Health/escalation eval (always Sonnet, Medium)
+
+
+class FocusCategory(StrEnum):
+    """Focus categories for the unified cognitive loop.
+
+    Replaces CycleType — signals carry a focus_category that determines
+    context weighting and prompt specialization.
+    """
+
+    PROACTIVE = "proactive"
+    DAILY_BRIEFING = "daily_briefing"
+    REACTIVE = "reactive"
+    GOAL_REVIEW = "goal_review"
+    DISPATCH_OUTCOME = "dispatch_outcome"
+    ESCALATION = "escalation"
 
 
 # Per-cycle-type model/effort OVERRIDES.  Only cycle types listed here
@@ -132,5 +151,7 @@ class EgoConfig:
     failure_backoff_minutes: int = 60  # pause after N failures
     batch_digest: bool = True  # send proposals as daily batch
     shadow_morning_report: bool = True  # shadow mode for morning reports
+    # Unified cognitive loop — goal review staleness threshold
+    goal_review_staleness_days: int = 10  # trigger goal_review after N days without progress
 
 

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -342,6 +342,13 @@ _CALL_SITE_META: dict[str, dict] = {
         "frequency": "On demand",
         "model_tier": "mid",
     },
+    "40_ego_focus_selection": {
+        "description": "Unified cognitive loop focus selector. Classifies pending signals to pick ego attention direction. Only fires for multi-signal arbitration; single-signal and critical-preemption cases bypass LLM.",
+        "category": "classification",
+        "frequency": "Per ego cycle (4-6/day), skipped when single signal",
+        "model_tier": "slm",
+        "status_reason": "WIRED",
+    },
     "contingency_foreground": {
         "description": "API-based foreground conversation fallback when CC is rate-limited or unavailable.",
         "category": "reasoning",

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -347,7 +347,7 @@ _CALL_SITE_META: dict[str, dict] = {
         "category": "classification",
         "frequency": "Per ego cycle (4-6/day), skipped when single signal",
         "model_tier": "slm",
-        "status_reason": "WIRED",
+        "status_reason": "BUILT",  # Wired to cadence consumer loop in PR 2
     },
     "contingency_foreground": {
         "description": "API-based foreground conversation fallback when CC is rate-limited or unavailable.",

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -78,7 +78,7 @@ async def test_no_unexpected_tables(db):
         "knowledge_fts_content", "knowledge_fts_docsize", "knowledge_fts_config",
         "call_site_last_run", "resolved_errors", "job_health",
         "processed_emails", "task_steps",
-        "ego_cycles", "ego_proposals", "ego_state", "intervention_journal", "capability_map",
+        "ego_cycles", "ego_cycle_outcomes", "ego_proposals", "ego_state", "intervention_journal", "capability_map",
         "behavioral_corrections", "behavioral_themes", "behavioral_treatments",
         "memory_metadata",
         "code_modules", "code_symbols", "code_imports",

--- a/tests/test_ego/test_focus.py
+++ b/tests/test_ego/test_focus.py
@@ -1,0 +1,248 @@
+"""Tests for the focus selector — perceive phase of the unified cognitive loop.
+
+Covers: single signal shortcut, critical preemption, multi-signal LLM call,
+router failure fallback, context weight lookup, unknown focus type defaults.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.ego.focus import (
+    _ALWAYS_SECTIONS,
+    _DEFAULT_WEIGHTS,
+    FOCUS_CONTEXT_WEIGHTS,
+    FocusResult,
+    FocusSelector,
+)
+from genesis.ego.signals import EgoSignal
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _make_signal(
+    priority: str = "medium",
+    focus_category: str = "proactive",
+    summary: str = "test signal",
+    focus_id: str | None = None,
+    signal_id: str | None = None,
+) -> EgoSignal:
+    sig = EgoSignal(
+        priority=priority,
+        focus_category=focus_category,
+        summary=summary,
+        focus_id=focus_id,
+    )
+    if signal_id:
+        # Override the auto-generated id
+        object.__setattr__(sig, "id", signal_id)
+    return sig
+
+
+def _mock_router(response_json: dict | None = None, success: bool = True) -> AsyncMock:
+    """Create a mock router that returns a RoutingResult-like object."""
+    router = AsyncMock()
+    result = MagicMock()
+    result.success = success
+    result.content = json.dumps(response_json) if response_json else ""
+    result.cost_usd = 0.001
+    router.route_call = AsyncMock(return_value=result)
+    return router
+
+
+# ── Single signal shortcut (no LLM call) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_single_signal_direct_select():
+    """Single signal → direct select, no LLM call."""
+    router = _mock_router()
+    selector = FocusSelector(router)
+
+    sig = _make_signal(focus_category="daily_briefing", focus_id="morning")
+    result = await selector.select([sig])
+
+    assert result is not None
+    assert result.focus_type == "daily_briefing"
+    assert result.focus_id == "morning"
+    assert result.perceive_cost_usd == 0.0
+    assert "only signal" in result.rationale
+    # Router should NOT have been called
+    router.route_call.assert_not_called()
+
+
+# ── Critical signal preemption (no LLM call) ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_critical_signal_preempts():
+    """Critical signal → preemption, no LLM call."""
+    router = _mock_router()
+    selector = FocusSelector(router)
+
+    low = _make_signal(priority="low", summary="minor")
+    critical = _make_signal(
+        priority="critical",
+        focus_category="escalation",
+        summary="system down",
+    )
+
+    result = await selector.select([critical, low])
+
+    assert result is not None
+    assert result.focus_type == "escalation"
+    assert "critical signal preemption" in result.rationale
+    assert result.perceive_cost_usd == 0.0
+    router.route_call.assert_not_called()
+
+
+# ── Multi-signal LLM selection ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_multi_signal_calls_router():
+    """2+ non-critical signals → LLM classification via router."""
+    response = {
+        "focus_type": "goal_review",
+        "focus_id": "goal_abc",
+        "rationale": "Goal X stale for 12 days",
+        "signals_consumed": ["sig1", "sig2"],
+    }
+    router = _mock_router(response_json=response)
+    selector = FocusSelector(router)
+
+    sig1 = _make_signal(priority="medium", summary="idle tick")
+    sig2 = _make_signal(priority="medium", summary="goal stale")
+
+    result = await selector.select([sig1, sig2])
+
+    assert result is not None
+    assert result.focus_type == "goal_review"
+    assert result.focus_id == "goal_abc"
+    assert result.rationale == "Goal X stale for 12 days"
+    assert result.perceive_cost_usd == 0.001
+    router.route_call.assert_called_once()
+
+
+# ── Router failure → fallback ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_router_failure_falls_back():
+    """Router failure → fallback to highest-priority signal."""
+    router = _mock_router(success=False)
+    selector = FocusSelector(router)
+
+    high = _make_signal(priority="high", focus_category="reactive", summary="event")
+    low = _make_signal(priority="low", summary="idle")
+
+    # Signals are passed pre-sorted (high first from PriorityQueue drain)
+    result = await selector.select([high, low])
+
+    assert result is not None
+    assert result.focus_type == "reactive"
+    assert "fallback" in result.rationale
+
+
+@pytest.mark.asyncio
+async def test_router_parse_failure_falls_back():
+    """Unparseable router response → fallback."""
+    router = AsyncMock()
+    result_obj = MagicMock()
+    result_obj.success = True
+    result_obj.content = "not valid json at all"
+    result_obj.cost_usd = 0.001
+    router.route_call = AsyncMock(return_value=result_obj)
+
+    selector = FocusSelector(router)
+    sig1 = _make_signal(priority="medium", summary="a")
+    sig2 = _make_signal(priority="medium", summary="b")
+
+    result = await selector.select([sig1, sig2])
+
+    assert result is not None
+    assert "fallback" in result.rationale
+
+
+@pytest.mark.asyncio
+async def test_router_exception_falls_back():
+    """Router exception → fallback."""
+    router = AsyncMock()
+    router.route_call = AsyncMock(side_effect=RuntimeError("connection failed"))
+
+    selector = FocusSelector(router)
+    sig1 = _make_signal(summary="a")
+    sig2 = _make_signal(summary="b")
+
+    result = await selector.select([sig1, sig2])
+    assert result is not None
+    assert "fallback" in result.rationale
+
+
+# ── Empty signals ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_empty_signals_returns_none():
+    router = _mock_router()
+    selector = FocusSelector(router)
+    result = await selector.select([])
+    assert result is None
+
+
+# ── Context weight lookup ─────────────────────────────────────────────────
+
+
+def test_known_focus_type_returns_weights():
+    weights = FocusSelector.get_context_weights("reactive")
+    assert weights == FOCUS_CONTEXT_WEIGHTS["reactive"]
+    # Always sections should be "always"
+    assert weights["user_model"] == "always"
+    assert weights["directives"] == "always"
+
+
+def test_unknown_focus_type_returns_default():
+    weights = FocusSelector.get_context_weights("nonexistent_type")
+    assert weights == _DEFAULT_WEIGHTS
+    # All non-always sections should be "deep" in default
+    assert weights["goals"] == "deep"
+
+
+def test_always_sections_never_overridden():
+    """Verify that always sections are 'always' in every weight config."""
+    for focus_type, weights in FOCUS_CONTEXT_WEIGHTS.items():
+        for section in _ALWAYS_SECTIONS:
+            assert weights[section] == "always", (
+                f"{section} should be 'always' in {focus_type}, got {weights[section]}"
+            )
+
+
+def test_reactive_weights_have_deep_escalations():
+    """Reactive focus should have deep escalations."""
+    weights = FOCUS_CONTEXT_WEIGHTS["reactive"]
+    assert weights["escalations"] == "deep"
+    # And light/skip for non-essential
+    assert weights["capabilities"] == "skip"
+
+
+def test_goal_review_weights_have_deep_goals():
+    """Goal review focus should have deep goals and progress."""
+    weights = FOCUS_CONTEXT_WEIGHTS["goal_review"]
+    assert weights["goals"] == "deep"
+    assert weights["goal_progress"] == "deep"
+    assert weights["execution_outcomes"] == "deep"
+
+
+# ── FocusResult dataclass ─────────────────────────────────────────────────
+
+
+def test_focus_result_defaults():
+    fr = FocusResult(focus_type="proactive")
+    assert fr.focus_id is None
+    assert fr.rationale == ""
+    assert fr.signals_consumed == []
+    assert fr.context_weights == {}
+    assert fr.perceive_cost_usd == 0.0

--- a/tests/test_ego/test_signals.py
+++ b/tests/test_ego/test_signals.py
@@ -1,0 +1,179 @@
+"""Tests for the ego signal system — EgoSignal and SignalQueue.
+
+Covers: priority ordering, dedup, expiry, queue overflow, drain, clear.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from genesis.ego.signals import EgoSignal, SignalQueue
+
+# ── EgoSignal dataclass ───────────────────────────────────────────────────
+
+
+def test_signal_priority_order_from_string():
+    """EgoSignal._priority_order is set from the priority string."""
+    sig = EgoSignal(priority="critical")
+    assert sig._priority_order == 0
+
+    sig = EgoSignal(priority="high")
+    assert sig._priority_order == 1
+
+    sig = EgoSignal(priority="medium")
+    assert sig._priority_order == 2
+
+    sig = EgoSignal(priority="low")
+    assert sig._priority_order == 3
+
+
+def test_signal_default_priority_is_medium():
+    sig = EgoSignal()
+    assert sig.priority == "medium"
+    assert sig._priority_order == 2
+
+
+def test_signal_ordering_critical_before_low():
+    """PriorityQueue ordering: critical signals come first."""
+    critical = EgoSignal(priority="critical", summary="urgent")
+    low = EgoSignal(priority="low", summary="minor")
+    # dataclass ordering: lower _priority_order wins
+    assert critical < low
+
+
+def test_signal_not_expired_when_no_expiry():
+    sig = EgoSignal()
+    assert sig.is_expired is False
+
+
+def test_signal_not_expired_when_future():
+    future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+    sig = EgoSignal(expires_at=future)
+    assert sig.is_expired is False
+
+
+def test_signal_expired_when_past():
+    past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    sig = EgoSignal(expires_at=past)
+    assert sig.is_expired is True
+
+
+def test_signal_expired_bad_timestamp():
+    sig = EgoSignal(expires_at="not-a-date")
+    assert sig.is_expired is False
+
+
+def test_signal_has_unique_id():
+    s1 = EgoSignal()
+    s2 = EgoSignal()
+    assert s1.id != s2.id
+
+
+# ── SignalQueue ───────────────────────────────────────────────────────────
+
+
+def test_queue_push_and_drain():
+    q = SignalQueue(maxsize=10)
+    sig = EgoSignal(summary="test signal")
+    assert q.push(sig) is True
+    assert len(q) == 1
+    assert not q.empty()
+
+    signals = q.drain()
+    assert len(signals) == 1
+    assert signals[0].summary == "test signal"
+    assert q.empty()
+
+
+def test_queue_dedup_rejects_same_summary():
+    """Same summary within dedup window should be rejected."""
+    q = SignalQueue(maxsize=10, dedup_hours=6)
+    sig1 = EgoSignal(summary="deadline approaching")
+    sig2 = EgoSignal(summary="deadline approaching")
+
+    assert q.push(sig1) is True
+    assert q.push(sig2) is False  # deduped
+    assert len(q) == 1
+
+
+def test_queue_dedup_allows_different_summary():
+    q = SignalQueue(maxsize=10)
+    sig1 = EgoSignal(summary="event A")
+    sig2 = EgoSignal(summary="event B")
+
+    assert q.push(sig1) is True
+    assert q.push(sig2) is True
+    assert len(q) == 2
+
+
+def test_queue_rejects_expired_on_push():
+    q = SignalQueue(maxsize=10)
+    past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+    sig = EgoSignal(summary="old event", expires_at=past)
+    assert q.push(sig) is False
+    assert q.empty()
+
+
+def test_queue_drops_expired_on_drain():
+    """Expired signals are filtered out during drain."""
+    q = SignalQueue(maxsize=10)
+    good_sig = EgoSignal(summary="good")
+    # Push a signal that will be valid at push time
+    future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+    will_expire = EgoSignal(summary="will expire", expires_at=future)
+
+    q.push(good_sig)
+    q.push(will_expire)
+    assert len(q) == 2
+
+    # Drain should include both since neither expired yet
+    signals = q.drain()
+    assert len(signals) == 2
+
+
+def test_queue_overflow_rejects():
+    """Queue full should reject new signals."""
+    q = SignalQueue(maxsize=2)
+    assert q.push(EgoSignal(summary="first")) is True
+    assert q.push(EgoSignal(summary="second")) is True
+    assert q.push(EgoSignal(summary="third")) is False
+    assert len(q) == 2
+
+
+def test_queue_drain_priority_order():
+    """Drain should return signals in priority order (highest first)."""
+    q = SignalQueue(maxsize=10)
+    q.push(EgoSignal(priority="low", summary="low pri"))
+    q.push(EgoSignal(priority="critical", summary="critical pri"))
+    q.push(EgoSignal(priority="medium", summary="medium pri"))
+
+    signals = q.drain()
+    assert len(signals) == 3
+    assert signals[0].priority == "critical"
+    assert signals[1].priority == "medium"
+    assert signals[2].priority == "low"
+
+
+def test_queue_clear():
+    q = SignalQueue(maxsize=10)
+    q.push(EgoSignal(summary="a"))
+    q.push(EgoSignal(summary="b"))
+    assert len(q) == 2
+
+    q.clear()
+    assert q.empty()
+    assert len(q) == 0
+
+    # After clear, dedup state is also reset
+    assert q.push(EgoSignal(summary="a")) is True
+
+
+def test_queue_dedup_truncates_long_summary():
+    """Dedup key is truncated to 100 chars."""
+    q = SignalQueue(maxsize=10)
+    long_summary = "A" * 200
+    sig1 = EgoSignal(summary=long_summary)
+    sig2 = EgoSignal(summary=long_summary)
+
+    assert q.push(sig1) is True
+    assert q.push(sig2) is False  # deduped by first 100 chars

--- a/tests/test_ego/test_unified_cycle.py
+++ b/tests/test_ego/test_unified_cycle.py
@@ -1,0 +1,214 @@
+"""Tests for the unified cognitive loop — run_unified_cycle and CRUD.
+
+Covers: perceive→think→act→learn pipeline, cycle outcome recording,
+budget check, focused prompt building.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from genesis.db.crud import ego as ego_crud
+from genesis.ego.signals import EgoSignal
+
+# ── CRUD: ego_cycle_outcomes ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_and_list_cycle_outcomes(db):
+    """create_cycle_outcome should insert, list_cycle_outcomes should retrieve."""
+    cid = await ego_crud.create_cycle_outcome(
+        db,
+        cycle_id="cycle-unified-1",
+        focus_type="proactive",
+        focus_id=None,
+        num_proposals=2,
+        signals_consumed=json.dumps(["sig_001", "sig_002"]),
+        perception_rationale="Idle tick, no competing signals",
+        perceive_cost_usd=0.0,
+    )
+    assert cid == "cycle-unified-1"
+
+    rows = await ego_crud.list_cycle_outcomes(db, limit=10)
+    assert len(rows) >= 1
+    row = rows[0]
+    assert row["cycle_id"] == "cycle-unified-1"
+    assert row["focus_type"] == "proactive"
+    assert row["num_proposals"] == 2
+    assert row["perceive_cost_usd"] == 0.0
+    assert "sig_001" in row["signals_consumed"]
+
+
+@pytest.mark.asyncio
+async def test_list_cycle_outcomes_ordered_newest_first(db):
+    """Outcomes should be ordered by created_at descending."""
+    await ego_crud.create_cycle_outcome(
+        db,
+        cycle_id="cycle-old",
+        focus_type="reactive",
+    )
+    await ego_crud.create_cycle_outcome(
+        db,
+        cycle_id="cycle-new",
+        focus_type="goal_review",
+    )
+
+    rows = await ego_crud.list_cycle_outcomes(db, limit=10)
+    assert len(rows) >= 2
+    # Most recent should be first
+    assert rows[0]["cycle_id"] == "cycle-new"
+
+
+@pytest.mark.asyncio
+async def test_create_cycle_outcome_with_focus_id(db):
+    """focus_id should be stored correctly."""
+    await ego_crud.create_cycle_outcome(
+        db,
+        cycle_id="cycle-goal-1",
+        focus_type="goal_review",
+        focus_id="goal_abc123",
+        perception_rationale="Goal stale for 14 days",
+    )
+    rows = await ego_crud.list_cycle_outcomes(db, limit=1)
+    assert rows[0]["focus_id"] == "goal_abc123"
+    assert rows[0]["perception_rationale"] == "Goal stale for 14 days"
+
+
+# ── EgoSignal integration ─────────────────────────────────────────────────
+
+
+def test_ego_signal_imports_cleanly():
+    """Verify EgoSignal can be imported and instantiated."""
+    sig = EgoSignal(
+        signal_type="timer",
+        focus_category="proactive",
+        summary="Idle tick",
+        priority="medium",
+    )
+    assert sig.signal_type == "timer"
+    assert sig.focus_category == "proactive"
+
+
+# ── Focused prompt building ───────────────────────────────────────────────
+
+
+def test_build_focused_prompt_proactive():
+    """Proactive focus should produce a standard directive."""
+    from genesis.ego.focus import FocusResult
+    from genesis.ego.session import EgoSession
+
+    # We only need the method, not a full session — test via direct call.
+    # _build_focused_prompt is a pure function (no I/O, no state).
+    focus = FocusResult(
+        focus_type="proactive",
+        rationale="idle tick, no competing signals",
+    )
+    # Call the unbound method with a mock self
+    prompt = EgoSession._build_focused_prompt(
+        None,  # self (not used for this method)
+        dynamic_context="## Test Context\nSome data here.",
+        focus=focus,
+    )
+    assert "proactive" in prompt
+    assert "idle tick" in prompt
+    assert "Test Context" in prompt
+    # Should NOT contain morning report instructions
+    assert "MORNING REPORT" not in prompt
+    assert "DAILY BRIEFING" not in prompt
+
+
+def test_build_focused_prompt_daily_briefing():
+    """Daily briefing focus should include morning report instructions."""
+    from genesis.ego.focus import FocusResult
+    from genesis.ego.session import EgoSession
+
+    focus = FocusResult(
+        focus_type="daily_briefing",
+        rationale="scheduled morning briefing",
+    )
+    prompt = EgoSession._build_focused_prompt(
+        None,
+        dynamic_context="## Context",
+        focus=focus,
+    )
+    assert "DAILY BRIEFING" in prompt
+    assert "morning_report" in prompt
+
+
+def test_build_focused_prompt_goal_review():
+    """Goal review focus should include goal assessment instructions."""
+    from genesis.ego.focus import FocusResult
+    from genesis.ego.session import EgoSession
+
+    focus = FocusResult(
+        focus_type="goal_review",
+        focus_id="goal_xyz",
+        rationale="goal stale for 12 days",
+    )
+    prompt = EgoSession._build_focused_prompt(
+        None,
+        dynamic_context="## Context",
+        focus=focus,
+    )
+    assert "GOAL REVIEW" in prompt
+    assert "goal_assessment" in prompt
+    assert "goal_review" in prompt
+
+
+def test_build_focused_prompt_reactive():
+    """Reactive focus should include reactive instructions."""
+    from genesis.ego.focus import FocusResult
+    from genesis.ego.session import EgoSession
+
+    focus = FocusResult(
+        focus_type="reactive",
+        rationale="health alert received",
+    )
+    prompt = EgoSession._build_focused_prompt(
+        None,
+        dynamic_context="## Context",
+        focus=focus,
+    )
+    assert "REACTIVE" in prompt
+    assert "event(s)" in prompt
+
+
+# ── FocusCategory enum ────────────────────────────────────────────────────
+
+
+def test_focus_category_values():
+    """Verify FocusCategory enum has expected values."""
+    from genesis.ego.types import FocusCategory
+
+    assert FocusCategory.PROACTIVE == "proactive"
+    assert FocusCategory.DAILY_BRIEFING == "daily_briefing"
+    assert FocusCategory.REACTIVE == "reactive"
+    assert FocusCategory.GOAL_REVIEW == "goal_review"
+    assert FocusCategory.DISPATCH_OUTCOME == "dispatch_outcome"
+    assert FocusCategory.ESCALATION == "escalation"
+
+
+def test_focus_category_coexists_with_cycle_type():
+    """FocusCategory and CycleType should coexist without conflict."""
+    from genesis.ego.types import CycleType, FocusCategory
+
+    # Both should import cleanly
+    assert CycleType.PROACTIVE == "proactive"
+    assert FocusCategory.PROACTIVE == "proactive"
+    # But they are different types
+    assert type(CycleType.PROACTIVE) is not type(FocusCategory.PROACTIVE)
+
+
+# ── EgoConfig goal_review_staleness_days ──────────────────────────────────
+
+
+def test_ego_config_has_staleness_field():
+    from genesis.ego.types import EgoConfig
+
+    config = EgoConfig()
+    assert config.goal_review_staleness_days == 10
+
+    config2 = EgoConfig(goal_review_staleness_days=7)
+    assert config2.goal_review_staleness_days == 7

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -136,7 +136,8 @@ def test_load_full_yaml(monkeypatch):
     # 2026-05-14: 44 → 45 after 45_intelligence_intake added by #349.
     # 2026-05-15: 45 → 46 after dream_cycle_synthesis added by #359.
     # 2026-05-22: 46 → 47 after models_md_synthesis added by #410.
-    assert len(cfg.call_sites) == 47
+    # 2026-05-23: 47 → 48 after 40_ego_focus_selection added by #420.
+    assert len(cfg.call_sites) == 48
     assert "2_triage" not in cfg.call_sites  # removed 2026-05-10
     assert "7_task_retrospective" not in cfg.call_sites  # removed 2026-05-10 (duplicate; live one is 43_task_retrospective)
     assert "background" in cfg.retry_profiles


### PR DESCRIPTION
## Summary

PR 1 of the unified cognitive loop redesign. Builds the signal and perception infrastructure **without** migrating existing cycle types — old `run_cycle()` continues working unchanged.

- **EgoSignal + SignalQueue** (`signals.py`): Priority-ordered signal dataclass with dedup (6h window), expiry, and queue overflow handling. Generalizes the reactive dedup pattern from `cadence.py`.
- **FocusSelector + context weights** (`focus.py`): LLM-based multi-signal arbitration via `router.route_call()`, with shortcuts for single-signal and critical-preemption cases (no LLM call). Context weights lookup table maps focus_type → section weights.
- **FocusCategory enum** (`types.py`): New StrEnum coexisting with CycleType (removed in PR 5).
- **Extracted `_process_cycle_output`** (`session.py`): Refactored ~250 lines of post-invocation processing into a shared method. All 27 existing ego tests pass unchanged.
- **`run_unified_cycle`** (`session.py`): New perceive→think→act→learn pipeline alongside `run_cycle()`.
- **Call site** (`40_ego_focus_selection`): Registered in routing YAML + metadata. Status: BUILT (wired to cadence in PR 2).
- **DB migration**: `ego_cycle_outcomes` table for Learn phase tracking.
- **41 new tests**: signals (priority, dedup, expiry, overflow), focus (shortcut, preemption, LLM, fallback, weights), unified cycle (CRUD, focused prompts, types).

### PR 1 does NOT:
- Modify `cadence.py` (that's PR 2)
- Modify `user_context.py` build() signature (that's PR 3)
- Remove `CycleType` (that's PR 5)
- Change how existing cycles work

## Test plan

- [x] `ruff check` on all changed files — clean
- [x] `pytest tests/test_ego/ -v` — 68/68 pass (27 existing + 41 new)
- [x] Call site loads: `40_ego_focus_selection` verified in routing config
- [x] Migration: `ego_cycle_outcomes` table created in test DB
- [x] Code review: addressed all issues (types, dedup, status, prompts)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)