### PR TITLE
fix(browser): VNC self-repair + remove human escalation

### DIFF
--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -68,6 +68,21 @@ _SCREENSHOT_DIR = Path.home() / "tmp"
 _VNC_DISPLAY = ":99"
 _VNC_PASSWORD = os.environ.get("GENESIS_VNC_PASSWORD", "genesis")
 
+# VNC infrastructure state — verified once per session
+_vnc_verified = False
+
+# Cloudflare challenge detection constants (FlareSolverr-proven)
+_CHALLENGE_TITLES = ["just a moment", "ddos-guard"]
+_CHALLENGE_SELECTORS = [
+    'iframe[src*="challenges.cloudflare.com"]',
+    'input[name="cf-turnstile-response"]',
+    "#cf-challenge-running",
+    "#challenge-spinner",
+    "#turnstile-wrapper",
+    ".ray_id",
+    "#cf-please-wait",
+]
+
 
 def _is_page_alive(page) -> bool:
     """Check if a Playwright page reference is still usable.
@@ -546,6 +561,48 @@ def _start_idle_watcher():
         )
 
 
+async def _ensure_vnc():
+    """Verify x11vnc + websockify are running for local browser VNC access.
+
+    Uses systemd services (genesis-vnc, genesis-novnc) as primary mechanism.
+    Falls back to raw subprocess if systemctl fails.  Checks once per
+    session (module-level ``_vnc_verified`` flag).
+    """
+    global _vnc_verified
+    if _vnc_verified:
+        return
+
+    import subprocess as _sp
+
+    # Check and start x11vnc
+    try:
+        r = _sp.run(
+            ["systemctl", "--user", "is-active", "genesis-vnc"],
+            capture_output=True, text=True, timeout=3,
+        )
+        if r.stdout.strip() != "active":
+            _sp.run(
+                ["systemctl", "--user", "start", "genesis-vnc", "genesis-novnc"],
+                capture_output=True, timeout=5,
+            )
+            logger.info("Started genesis-vnc + genesis-novnc via systemctl")
+    except Exception:
+        # Fallback: start x11vnc directly if systemctl unavailable
+        try:
+            vnc_passwd = Path.home() / ".genesis" / "vnc_passwd"
+            auth_arg = ["-rfbauth", str(vnc_passwd)] if vnc_passwd.exists() else ["-nopw"]
+            _sp.Popen(
+                ["x11vnc", "-display", _VNC_DISPLAY, "-forever", "-shared",
+                 "-rfbport", "5900", "-bg"] + auth_arg,
+                stdout=_sp.DEVNULL, stderr=_sp.DEVNULL,
+            )
+            logger.info("Started x11vnc directly (systemctl fallback)")
+        except FileNotFoundError:
+            logger.debug("x11vnc not installed — VNC click unavailable")
+
+    _vnc_verified = True
+
+
 async def _get_page(
     stealth: bool = True,
     remote: bool = False,
@@ -573,8 +630,10 @@ async def _get_page(
     elif remote:
         _active_page = await _ensure_remote_cdp(cdp_url)
     elif stealth:
+        await _ensure_vnc()
         _active_page = await _ensure_browser()
     else:
+        await _ensure_vnc()
         _active_page = await _ensure_chromium_fallback()
     _touch()
     _start_idle_watcher()
@@ -1095,88 +1154,127 @@ async def _vnc_click_turnstile(page) -> bool:
         return False
 
 
+async def _detect_challenge(page) -> bool:
+    """Detect any Cloudflare challenge (iframe, managed, interstitial).
+
+    Uses FlareSolverr-proven selectors plus page title check.
+    Returns True if a challenge is detected.
+    """
+    # Check DOM selectors (fastest)
+    for selector in _CHALLENGE_SELECTORS:
+        el = await page.query_selector(selector)
+        if el is not None:
+            return True
+
+    # Title-based detection for very early interstitials
+    title = (await page.title()).lower()
+    return any(ct in title for ct in _CHALLENGE_TITLES)
+
+
 async def _wait_for_turnstile(page, timeout_ms: int = 15000) -> dict | None:
-    """Detect and handle Cloudflare Turnstile challenge.
+    """Detect and handle Cloudflare challenge (Turnstile or managed).
 
-    Phase 1 (auto-resolve): Polls for up to ``timeout_ms`` for the Turnstile
-    iframe to produce a ``cf-turnstile-response`` token.  Many challenges
-    auto-resolve for legitimate-looking browsers.
+    Phase 1 (auto-resolve): Polls for up to ``timeout_ms`` for the challenge
+    to resolve automatically.  Trusted browsers on residential IPs typically
+    auto-resolve in 3-5 seconds.
 
-    Phase 2 (VNC trusted input): Sends a real mouse click through the VNC
-    protocol, bypassing Cloudflare's synthetic event detection.  Up to 2
-    attempts with coordinate recalculation between them.
+    Phase 2 (VNC click): Sends a real mouse click through VNC protocol
+    during the checkbox window.  The Turnstile widget cycles between
+    spinner (~10s) and checkbox (~30-60s) phases — clicks must land
+    during the checkbox phase.  Up to 3 attempts.
+
+    Phase 2.5 (reload): If VNC clicks fail, reloads the page.  Research
+    shows this predictably escalates from spinner to interactive checkbox.
 
     Phase 3 (human escalation): Sends a Telegram alert and polls for up to
     5 minutes.  The browser is always headed on :99, so the human can see
-    and interact immediately — no restart needed.
+    and interact immediately.
 
-    Returns None if no Turnstile detected, or a status dict.
+    Returns None if no challenge detected, or a status dict.
     """
     try:
-        # Brief delay for SPA-injected Turnstile iframes/widgets
+        # Brief delay for SPA-injected widgets to load
         await asyncio.sleep(0.8)
 
-        # Detect both iframe-based and managed (inline) Turnstile variants.
-        # Managed challenges embed cf-turnstile-response directly in the page
-        # without an iframe (e.g., Medium's "Just a moment..." interstitial).
-        turnstile = await page.query_selector(
-            'iframe[src*="challenges.cloudflare.com"]'
-        )
-        if turnstile is None:
-            # Check for managed challenge (no iframe, inline widget)
-            managed = await page.query_selector(
-                'input[name="cf-turnstile-response"]'
-            )
-            if managed is None:
-                return None
-            logger.info("Managed Turnstile challenge detected (no iframe)")
+        if not await _detect_challenge(page):
+            return None
 
-        logger.info("Turnstile challenge detected — waiting for auto-resolve")
+        logger.info("Cloudflare challenge detected — waiting for auto-resolve")
 
-        # Phase 1: auto-resolve
+        # Phase 1: auto-resolve (3-5s for trusted browsers, 15s max)
         if await _poll_turnstile_token(page, timeout_ms / 1000, 1.0):
-            logger.info("Turnstile auto-resolved")
+            logger.info("Challenge auto-resolved")
             await asyncio.sleep(random.uniform(1.0, 3.0))
             return {"status": "resolved", "method": "auto"}
 
-        # Phase 2: VNC trusted input click (up to 2 attempts)
+        # Phase 2: VNC click — checkbox-aware with retry
+        # The Turnstile widget cycles: spinner (~10s) → checkbox (~30-60s).
+        # We must click during the checkbox window, not during spinner.
         logger.warning(
-            "Turnstile did NOT auto-resolve in %dms — trying VNC click",
+            "Challenge did NOT auto-resolve in %dms — trying VNC click",
             timeout_ms,
         )
-        for attempt in range(1, 3):
-            if await _vnc_click_turnstile(page):
-                if await _poll_turnstile_token(page, 30, 1.0):
+        for attempt in range(1, 4):  # up to 3 attempts
+            # Wait for spinner to finish (checkbox to appear)
+            for _ in range(10):  # poll every 2s for up to 20s
+                # Check if challenge already resolved (e.g., auto-resolved
+                # during a re-evaluation cycle)
+                if await _poll_turnstile_token(page, 1, 0.5):
                     logger.info(
-                        "Turnstile resolved via VNC click (attempt %d)",
+                        "Challenge resolved during wait (attempt %d)", attempt,
+                    )
+                    await asyncio.sleep(random.uniform(1.0, 3.0))
+                    return {"status": "resolved", "method": "auto_delayed"}
+
+                # Check if we're still on a challenge page
+                if not await _detect_challenge(page):
+                    logger.info("Challenge page gone — resolved externally")
+                    return {"status": "resolved", "method": "external"}
+
+                await asyncio.sleep(2)
+
+            # Attempt VNC click
+            if await _vnc_click_turnstile(page):
+                if await _poll_turnstile_token(page, 15, 1.0):
+                    logger.info(
+                        "Challenge resolved via VNC click (attempt %d)",
                         attempt,
                     )
                     await asyncio.sleep(random.uniform(1.0, 3.0))
                     return {"status": "resolved", "method": "vnc_click"}
                 logger.info(
-                    "VNC click %d sent but Turnstile not yet resolved",
+                    "VNC click %d sent but challenge not yet resolved",
                     attempt,
                 )
             else:
                 logger.warning("VNC click attempt %d failed to send", attempt)
-            if attempt < 2:
-                await asyncio.sleep(random.uniform(1.0, 2.0))
+
+        # Phase 2.5: Reload and retry — triggers different challenge variant
+        logger.info("VNC clicks exhausted — trying page reload")
+        try:
+            await page.reload(wait_until="domcontentloaded", timeout=15000)
+            await asyncio.sleep(2)
+            if await _poll_turnstile_token(page, 15, 1.0):
+                logger.info("Challenge resolved after reload")
+                return {"status": "resolved", "method": "reload"}
+        except Exception:
+            logger.debug("Reload failed", exc_info=True)
 
         # Phase 3: human escalation (last resort)
         logger.warning(
-            "Turnstile NOT resolved via VNC — escalating to human"
+            "Challenge NOT resolved via VNC/reload — escalating to human"
         )
         await _send_turnstile_alert(page.url)
 
         if await _poll_turnstile_token(page, 300, 5.0):  # 5 minutes
-            logger.info("Turnstile resolved by human intervention")
+            logger.info("Challenge resolved by human intervention")
             await asyncio.sleep(random.uniform(1.0, 2.0))
             return {"status": "resolved", "method": "human"}
 
-        logger.warning("Turnstile NOT resolved after 5 min escalation")
+        logger.warning("Challenge NOT resolved after 5 min escalation")
         return {"status": "blocked", "method": "timeout"}
     except Exception as e:
-        logger.debug("Turnstile detection error: %s", e)
+        logger.debug("Challenge detection error: %s", e)
         return None
 
 
@@ -1220,9 +1318,11 @@ async def _impl_browser_navigate(
         if not skip_goto:
             await page.goto(url, wait_until="domcontentloaded", timeout=30000)
 
-        # Turnstile detection only for Camoufox (real Chrome won't trigger it)
+        # Challenge detection for local browsers (Camoufox + Chromium).
+        # Skip for TinyFish (cloud browser, clean IP) and remote CDP
+        # (user watching their own screen — they can handle challenges).
         turnstile_result = None
-        if _is_camoufox_active():
+        if not tinyfish and not remote:
             turnstile_result = await _wait_for_turnstile(page)
 
         # Track URL for drift detection on remote sessions

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -79,8 +79,9 @@ _CHALLENGE_SELECTORS = [
     "#cf-challenge-running",
     "#challenge-spinner",
     "#turnstile-wrapper",
-    ".ray_id",
     "#cf-please-wait",
+    # NOTE: .ray_id excluded — appears on non-challenge Cloudflare error
+    # pages (403, 502, 520) and would cause false-positive blocking.
 ]
 
 
@@ -565,42 +566,67 @@ async def _ensure_vnc():
     """Verify x11vnc + websockify are running for local browser VNC access.
 
     Uses systemd services (genesis-vnc, genesis-novnc) as primary mechanism.
-    Falls back to raw subprocess if systemctl fails.  Checks once per
-    session (module-level ``_vnc_verified`` flag).
+    Falls back to raw subprocess if systemctl fails.  Only marks verified
+    on confirmed success — retries on next call if setup failed.
     """
     global _vnc_verified
     if _vnc_verified:
         return
 
-    import subprocess as _sp
+    started = False
 
-    # Check and start x11vnc
-    try:
-        r = _sp.run(
-            ["systemctl", "--user", "is-active", "genesis-vnc"],
-            capture_output=True, text=True, timeout=3,
-        )
-        if r.stdout.strip() != "active":
+    def _check_and_start():
+        nonlocal started
+        import subprocess as _sp
+
+        try:
+            r = _sp.run(
+                ["systemctl", "--user", "is-active", "genesis-vnc"],
+                capture_output=True, text=True, timeout=3,
+            )
+            if r.stdout.strip() == "active":
+                started = True
+                return
             _sp.run(
                 ["systemctl", "--user", "start", "genesis-vnc", "genesis-novnc"],
                 capture_output=True, timeout=5,
             )
-            logger.info("Started genesis-vnc + genesis-novnc via systemctl")
-    except Exception:
-        # Fallback: start x11vnc directly if systemctl unavailable
-        try:
-            vnc_passwd = Path.home() / ".genesis" / "vnc_passwd"
-            auth_arg = ["-rfbauth", str(vnc_passwd)] if vnc_passwd.exists() else ["-nopw"]
-            _sp.Popen(
-                ["x11vnc", "-display", _VNC_DISPLAY, "-forever", "-shared",
-                 "-rfbport", "5900", "-bg"] + auth_arg,
-                stdout=_sp.DEVNULL, stderr=_sp.DEVNULL,
+            # Verify it actually started
+            r2 = _sp.run(
+                ["systemctl", "--user", "is-active", "genesis-vnc"],
+                capture_output=True, text=True, timeout=3,
             )
-            logger.info("Started x11vnc directly (systemctl fallback)")
-        except FileNotFoundError:
-            logger.debug("x11vnc not installed — VNC click unavailable")
+            if r2.stdout.strip() == "active":
+                started = True
+                logger.info("Started genesis-vnc + genesis-novnc via systemctl")
+        except Exception:
+            # Fallback: start x11vnc directly if systemctl unavailable
+            try:
+                import subprocess as _sp2
 
-    _vnc_verified = True
+                vnc_passwd = Path.home() / ".genesis" / "vnc_passwd"
+                auth_arg = (
+                    ["-rfbauth", str(vnc_passwd)]
+                    if vnc_passwd.exists()
+                    else ["-nopw"]
+                )
+                _sp2.Popen(
+                    ["x11vnc", "-display", _VNC_DISPLAY, "-forever", "-shared",
+                     "-rfbport", "5900", "-bg"] + auth_arg,
+                    stdout=_sp2.DEVNULL, stderr=_sp2.DEVNULL,
+                )
+                started = True
+                logger.info("Started x11vnc directly (systemctl fallback)")
+            except FileNotFoundError:
+                logger.debug("x11vnc not installed — VNC click unavailable")
+
+    # Run blocking subprocess calls off the event loop
+    await asyncio.get_running_loop().run_in_executor(None, _check_and_start)
+
+    if started:
+        _vnc_verified = True
+    else:
+        logger.warning("VNC setup failed — will retry on next browser launch")
 
 
 async def _get_page(
@@ -1133,11 +1159,17 @@ async def _vnc_click_turnstile(page) -> bool:
             logger.warning("VNC Turnstile click: vncdo timed out after 10s")
             return False
         if proc.returncode != 0:
+            global _vnc_verified
+            err_text = stderr.decode()[:200]
             logger.warning(
                 "VNC Turnstile click: vncdo failed (rc=%d): %s",
                 proc.returncode,
-                stderr.decode()[:200],
+                err_text,
             )
+            # Reset VNC verified flag if connection refused — infra may
+            # have died mid-session and needs restart on next attempt.
+            if "Connection refused" in err_text or "Connection was refused" in err_text:
+                _vnc_verified = False
             return False
 
         logger.info("VNC Turnstile click sent at (%d, %d)", click_x, click_y)

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -579,6 +579,31 @@ async def _ensure_vnc():
         nonlocal started
         import subprocess as _sp
 
+        # Kill stale x11vnc processes that hold port 5900 and prevent
+        # the systemd service from starting (common after session restart).
+        try:
+            r = _sp.run(
+                ["fuser", "5900/tcp"],
+                capture_output=True, text=True, timeout=3,
+            )
+            if r.stdout.strip():
+                # Port is held — check if it's the systemd-managed process
+                svc = _sp.run(
+                    ["systemctl", "--user", "is-active", "genesis-vnc"],
+                    capture_output=True, text=True, timeout=3,
+                )
+                if svc.stdout.strip() != "active":
+                    # Stale process — kill it so systemd can bind
+                    _sp.run(
+                        ["fuser", "-k", "5900/tcp"],
+                        capture_output=True, timeout=3,
+                    )
+                    logger.info("Killed stale process holding VNC port 5900")
+                    import time
+                    time.sleep(1)
+        except FileNotFoundError:
+            pass  # fuser not available, proceed anyway
+
         try:
             r = _sp.run(
                 ["systemctl", "--user", "is-active", "genesis-vnc"],
@@ -1206,21 +1231,16 @@ async def _detect_challenge(page) -> bool:
 async def _wait_for_turnstile(page, timeout_ms: int = 15000) -> dict | None:
     """Detect and handle Cloudflare challenge (Turnstile or managed).
 
-    Phase 1 (auto-resolve): Polls for up to ``timeout_ms`` for the challenge
-    to resolve automatically.  Trusted browsers on residential IPs typically
-    auto-resolve in 3-5 seconds.
+    Phase 1 (auto-resolve): Polls for ``timeout_ms`` for automatic resolution.
 
-    Phase 2 (VNC click): Sends a real mouse click through VNC protocol
-    during the checkbox window.  The Turnstile widget cycles between
-    spinner (~10s) and checkbox (~30-60s) phases — clicks must land
-    during the checkbox phase.  Up to 3 attempts.
+    Phase 2 (VNC click): Sends real mouse clicks through VNC during the
+    checkbox window.  If VNC fails (connection refused), repairs VNC infra
+    and retries.  Up to 3 rounds of: wait-for-checkbox → click → poll.
 
-    Phase 2.5 (reload): If VNC clicks fail, reloads the page.  Research
-    shows this predictably escalates from spinner to interactive checkbox.
+    Phase 3 (reload + retry): Reloads the page (triggers different challenge
+    variant) then repeats VNC click.
 
-    Phase 3 (human escalation): Sends a Telegram alert and polls for up to
-    5 minutes.  The browser is always headed on :99, so the human can see
-    and interact immediately.
+    No human escalation — Genesis handles this itself.
 
     Returns None if no challenge detected, or a status dict.
     """
@@ -1239,18 +1259,15 @@ async def _wait_for_turnstile(page, timeout_ms: int = 15000) -> dict | None:
             await asyncio.sleep(random.uniform(1.0, 3.0))
             return {"status": "resolved", "method": "auto"}
 
-        # Phase 2: VNC click — checkbox-aware with retry
-        # The Turnstile widget cycles: spinner (~10s) → checkbox (~30-60s).
-        # We must click during the checkbox window, not during spinner.
+        # Phase 2: VNC click — with self-repair on failure
         logger.warning(
             "Challenge did NOT auto-resolve in %dms — trying VNC click",
             timeout_ms,
         )
+        vnc_failed_count = 0
         for attempt in range(1, 4):  # up to 3 attempts
-            # Wait for spinner to finish (checkbox to appear)
-            for _ in range(10):  # poll every 2s for up to 20s
-                # Check if challenge already resolved (e.g., auto-resolved
-                # during a re-evaluation cycle)
+            # Brief wait for checkbox to appear (spinner → checkbox cycle)
+            for _ in range(5):  # poll every 2s for up to 10s
                 if await _poll_turnstile_token(page, 1, 0.5):
                     logger.info(
                         "Challenge resolved during wait (attempt %d)", attempt,
@@ -1258,15 +1275,16 @@ async def _wait_for_turnstile(page, timeout_ms: int = 15000) -> dict | None:
                     await asyncio.sleep(random.uniform(1.0, 3.0))
                     return {"status": "resolved", "method": "auto_delayed"}
 
-                # Check if we're still on a challenge page
                 if not await _detect_challenge(page):
-                    logger.info("Challenge page gone — resolved externally")
+                    logger.info("Challenge page gone — resolved")
                     return {"status": "resolved", "method": "external"}
 
                 await asyncio.sleep(2)
 
             # Attempt VNC click
-            if await _vnc_click_turnstile(page):
+            click_ok = await _vnc_click_turnstile(page)
+            if click_ok:
+                vnc_failed_count = 0  # reset on success
                 if await _poll_turnstile_token(page, 15, 1.0):
                     logger.info(
                         "Challenge resolved via VNC click (attempt %d)",
@@ -1279,31 +1297,48 @@ async def _wait_for_turnstile(page, timeout_ms: int = 15000) -> dict | None:
                     attempt,
                 )
             else:
-                logger.warning("VNC click attempt %d failed to send", attempt)
+                vnc_failed_count += 1
+                logger.warning(
+                    "VNC click attempt %d failed — repairing VNC infra",
+                    attempt,
+                )
+                # Self-repair: reset VNC verified flag and re-ensure
+                global _vnc_verified
+                _vnc_verified = False
+                await _ensure_vnc()
+                if vnc_failed_count >= 2:
+                    # VNC is persistently broken — skip to reload
+                    logger.warning("VNC persistently failing — skipping to reload")
+                    break
 
-        # Phase 2.5: Reload and retry — triggers different challenge variant
-        logger.info("VNC clicks exhausted — trying page reload")
+        # Phase 3: Reload and retry with fresh VNC clicks
+        logger.info("Trying page reload to trigger different challenge variant")
         try:
             await page.reload(wait_until="domcontentloaded", timeout=15000)
             await asyncio.sleep(2)
             if await _poll_turnstile_token(page, 15, 1.0):
                 logger.info("Challenge resolved after reload")
                 return {"status": "resolved", "method": "reload"}
+
+            # Post-reload VNC click attempts
+            for attempt in range(1, 3):
+                await asyncio.sleep(5)  # let new challenge render
+                if (
+                    await _vnc_click_turnstile(page)
+                    and await _poll_turnstile_token(page, 15, 1.0)
+                ):
+                    logger.info(
+                        "Challenge resolved via VNC click after reload "
+                        "(attempt %d)", attempt,
+                    )
+                    return {"status": "resolved", "method": "vnc_click_reload"}
         except Exception:
             logger.debug("Reload failed", exc_info=True)
 
-        # Phase 3: human escalation (last resort)
-        logger.warning(
-            "Challenge NOT resolved via VNC/reload — escalating to human"
-        )
+        # Final: send a Telegram notification but keep the result as blocked
+        # so the caller knows the challenge was not resolved.
+        logger.warning("Challenge NOT resolved after all attempts")
         await _send_turnstile_alert(page.url)
-
-        if await _poll_turnstile_token(page, 300, 5.0):  # 5 minutes
-            logger.info("Challenge resolved by human intervention")
-            await asyncio.sleep(random.uniform(1.0, 2.0))
-            return {"status": "resolved", "method": "human"}
-
-        logger.warning("Challenge NOT resolved after 5 min escalation")
         return {"status": "blocked", "method": "timeout"}
     except Exception as e:
         logger.debug("Challenge detection error: %s", e)


### PR DESCRIPTION
## Summary

Follow-up to PR #421 (generalized challenge detection).

- **Kill stale x11vnc processes** — `fuser -k 5900/tcp` before systemd start. Prevents crash loop when previous session's x11vnc holds the port.
- **Remove human escalation** — Genesis handles challenges itself. VNC click failures trigger self-repair (reset `_vnc_verified`, re-run `_ensure_vnc()`), not Telegram alerts and 5-minute waits.
- **VNC self-repair loop** — if VNC click fails (connection refused), repair infra and retry. Skip to reload after 2 consecutive VNC failures.
- Telegram notification kept as final status update only.

**Root cause:** After session restart, stale x11vnc held port 5900 → systemd service crash-looped → VNC clicks all failed → challenge handler blocked for 300s doing nothing useful.

## Test plan

- [x] Ruff clean
- [ ] CI green
- [ ] E2E: kill x11vnc → navigate to Cloudflare site → stale process killed → VNC restarted → challenge resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)