### PR TITLE
chore: VNC port 5999 in setup script + GitHub search in researcher agent

### DIFF
--- a/.claude/agents/genesis-researcher.md
+++ b/.claude/agents/genesis-researcher.md
@@ -13,6 +13,17 @@ You are a research agent for Genesis with access to powerful web and code intell
 - **CC WebFetch** — ONLY if you specifically need an AI-processed summary of content. Otherwise use `web_fetch`.
 - **CC WebSearch** — ONLY for trivial general lookups. Otherwise use `web_search`.
 
+## GitHub Search (use for open-source research)
+
+When searching for repos, libraries, or implementation patterns on GitHub:
+
+- **`gh search repos "query" --limit 10`** — Find repos by topic/description. Via Bash.
+- **`gh search code "query" --limit 10`** — Search code across all public repos. Via Bash.
+- **`web_fetch("https://grep.app/search?q=QUERY")`** — Semantic code search across GitHub. Better than GitHub native search for finding implementation patterns.
+- **`gh api search/repositories?q=QUERY`** — Structured JSON results. Via Bash.
+
+**When to use:** Any time the prompt asks to "search GitHub," "find repos," "look for libraries," or "how do other projects handle X." These are FAR more targeted than web search for code discovery.
+
 ## Code Intelligence (use these, NOT raw Grep for discovery)
 
 - **CBM `search_graph(name_pattern="...")`** — Find functions/classes/symbols by name pattern
@@ -30,6 +41,8 @@ You are a research agent for Genesis with access to powerful web and code intell
 |------|------|
 | Fetch a webpage | `web_fetch(url)` |
 | Search the internet | `web_search(query)` |
+| Search GitHub repos | `gh search repos "query"` via Bash |
+| Search GitHub code | `gh search code "query"` or grep.app via `web_fetch` |
 | Find a function/class | CBM `search_graph` or Serena `find_symbol` |
 | Who calls this? | Serena `find_referencing_symbols` |
 | Call chain trace | CBM `trace_path` |

--- a/.claude/docs/web-tools-guide.md
+++ b/.claude/docs/web-tools-guide.md
@@ -38,6 +38,27 @@ Bash for structured JSON / `site:` filtering. Tavily for AI-optimized
 agent search (free tier). Exa for semantic/conceptual discovery. Perplexity
 when synthesis from multiple sources justifies the cost.
 
+## GitHub Search — "I need to find repos, code, or libraries"
+
+When searching for open-source projects, implementation patterns, or
+libraries on GitHub, use these INSTEAD of generic web search:
+
+| Tool | Context | Use when... |
+|------|---------|-------------|
+| **`gh search repos "query"`** | Both (via Bash) | Find repos by topic, description, language |
+| **`gh search code "query"`** | Both (via Bash) | Search code across all public repos |
+| **grep.app** | Both | `web_fetch("https://grep.app/search?q=QUERY")` — semantic code search, better than GitHub native |
+| **`gh api search/repositories?q=QUERY`** | Both | Structured JSON results with star counts, dates |
+| **Exa** with GitHub filter | Both | `web_search(query, backend="exa")` with `include_domains: ["github.com"]` |
+
+**When to use:** Any task involving "search GitHub," "find a library,"
+"how do other projects handle X," or "what open-source tools exist for Y."
+Generic web search returns blog posts ABOUT GitHub projects; these tools
+search GitHub directly. grep.app is especially valuable for finding
+implementation patterns across repos.
+
+---
+
 ## Fetch — "I have a URL, get the content"
 
 | Tool | Context | Use when... |

--- a/scripts/setup-vnc.sh
+++ b/scripts/setup-vnc.sh
@@ -81,7 +81,7 @@ Requires=genesis-xvfb.service
 [Service]
 Type=simple
 Environment=DISPLAY=:99
-ExecStart=/usr/bin/x11vnc -display :99 -forever -shared -rfbauth %h/.genesis/vnc_passwd -rfbport 5900 -xdamage -threads
+ExecStart=/usr/bin/x11vnc -display :99 -forever -shared -rfbauth %h/.genesis/vnc_passwd -rfbport 5999 -xdamage -threads
 Restart=on-failure
 RestartSec=3
 
@@ -98,7 +98,7 @@ Requires=genesis-vnc.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/websockify --web=/usr/share/novnc/ 6080 localhost:5900
+ExecStart=/usr/bin/websockify --web=/usr/share/novnc/ 6080 localhost:5999
 Restart=on-failure
 RestartSec=3
 
@@ -136,10 +136,10 @@ else
     OK=false
 fi
 
-if ss -tlnp | grep -q ':5900'; then
-    echo "✓ VNC server listening on port 5900"
+if ss -tlnp | grep -q ':5999'; then
+    echo "✓ VNC server listening on port 5999"
 else
-    echo "✗ VNC server not listening on port 5900"
+    echo "✗ VNC server not listening on port 5999"
     OK=false
 fi
 


### PR DESCRIPTION
## Summary

- **setup-vnc.sh** — port 5900→5999 for fresh installs. Matches systemd services (updated in PR #426) and proven Turnstile bypass procedure.
- **genesis-researcher agent** — added GitHub Search section with `gh search repos`, `gh search code`, grep.app, and GitHub API. Research agents previously used generic web search for GitHub-specific queries, missing targeted tools.

## Test plan

- [x] Verified setup-vnc.sh references 5999 throughout
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)