### PR TITLE
feat(voice): wire outbound voice adapter with HA credentials

### DIFF
--- a/secrets.env.example
+++ b/secrets.env.example
@@ -215,6 +215,14 @@ DAY_BOUNDARY_HOUR=0
 # Set to a strong random token for production use.
 GENESIS_MCP_HTTP_TOKEN=
 
+# Home Assistant (outbound voice TTS)
+# Used by: VoiceChannelAdapter — Genesis speaking through HA speakers.
+# HA_URL: Home Assistant base URL reachable from the Genesis container.
+# HA_LONG_LIVED_TOKEN: Generated via HA UI (Profile → Security → Long-lived access tokens)
+#   or via WebSocket API. Required for outbound TTS calls.
+HA_URL=
+HA_LONG_LIVED_TOKEN=
+
 # User preferences
 USER_TIMEZONE=UTC
 GENESIS_BACKUP_PASSPHRASE=

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import threading
 import time
 from pathlib import Path
@@ -231,6 +232,7 @@ class StandaloneAdapter:
             return
 
         try:
+            from genesis.channels.voice.adapter import VoiceChannelAdapter
             from genesis.channels.voice.handler import VoiceConversationHandler
             from genesis.channels.voice.sessions import VoiceSessionManager
 
@@ -243,6 +245,18 @@ class StandaloneAdapter:
 
             self._app.config["VOICE_HANDLER"] = handler
             logger.info("Voice conversation handler initialized")
+
+            # Outbound voice adapter — Genesis speaking through HA speakers
+            ha_url = os.environ.get("HA_URL", "")
+            ha_token = os.environ.get("HA_LONG_LIVED_TOKEN", "")
+            if ha_url and ha_token:
+                voice_adapter = VoiceChannelAdapter(
+                    ha_url=ha_url, ha_token=ha_token,
+                )
+                self._app.config["VOICE_ADAPTER"] = voice_adapter
+                logger.info("Voice adapter initialized (outbound TTS via HA)")
+            else:
+                logger.info("Voice adapter skipped — HA_URL or HA_LONG_LIVED_TOKEN not set")
         except Exception:
             logger.exception("Failed to initialize voice handler")
 


### PR DESCRIPTION
## Summary
- Reads `HA_URL` and `HA_LONG_LIVED_TOKEN` from `secrets.env` to instantiate `VoiceChannelAdapter` for outbound TTS through Home Assistant speakers
- Registers both env vars in `secrets.env.example` so the dashboard's Provider Keys panel shows their status
- Adapter stored in Flask `app.config["VOICE_ADAPTER"]` for access from routes

## Context
Follow-up to #422 (voice channel). The conversation handler (inbound) was wired but the adapter (outbound TTS) was not connected to credentials.

## Test plan
- [x] 25 voice tests pass locally
- [x] Server restart shows "Voice adapter initialized (outbound TTS via HA)" in logs
- [x] Voice endpoint still responds correctly after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)