### PR TITLE
fix(reflection+outreach): light reflection quality + morning report staleness fixes

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -240,9 +240,9 @@ call_sites:
     retry_profile: background
   4_light_reflection:
     chain:
+    - gemini-free
     - groq-free
     - mistral-large-free
-    - gemini-free
     default_paid: false
     never_pays: true
   5_deep_reflection:

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -10,6 +10,7 @@ via DeferredTask, matching AZ's job_loop.py pattern. Phase 1 tests run standalon
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import json
 import logging
@@ -878,6 +879,14 @@ class AwarenessLoop:
         if depth == Depth.LIGHT and self._cc_reflection_bridge is None and self._reflection_engine is not None:
             try:
                 await self._reflection_engine.reflect(depth, result, db=db)
+                # Emit reflection heartbeat so subsystem_heartbeats doesn't
+                # report overdue when only the API path fires.
+                if self._event_bus:
+                    with contextlib.suppress(Exception):
+                        await self._event_bus.emit(
+                            Subsystem.REFLECTION, Severity.DEBUG,
+                            "heartbeat", "light-reflection completed (API)",
+                        )
             except Exception:
                 logger.exception("Light reflection fallback (API) failed for tick %s", tick_id)
                 if self._deferred_queue:
@@ -913,6 +922,16 @@ class AwarenessLoop:
                         await awareness_ticks.mark_dispatched(db, tick_id)
                     except Exception:
                         logger.warning("Failed to mark tick %s dispatched", tick_id[:8])
+                    # Emit reflection heartbeat so subsystem_heartbeats
+                    # tracks Light/Deep/Strategic dispatches, not just
+                    # micro-reflection anomaly ticks and weekly jobs.
+                    if self._event_bus:
+                        with contextlib.suppress(Exception):
+                            await self._event_bus.emit(
+                                Subsystem.REFLECTION, Severity.DEBUG,
+                                "heartbeat",
+                                f"{depth.value.lower()}-reflection completed",
+                            )
                 # Fix 3B: resolve escalation AFTER successful dispatch
                 if result.escalation_pending_id and depth == Depth.DEEP:
                     await self._resolve_escalation(result.escalation_pending_id, result.timestamp)

--- a/src/genesis/cc/reflection_bridge/_bridge.py
+++ b/src/genesis/cc/reflection_bridge/_bridge.py
@@ -46,10 +46,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # ── Signal change detection for Light reflections ─────────────────────
-# Only these signals carry actionable information — changes here mean
-# something actually happened. Continuous-drift noise (container_memory_pct,
-# micro_count_since_light, time_since_last_strategic, light_count_since_deep,
-# budget_pct_consumed, user_session_pattern) is excluded.
+# Signals whose changes indicate something actionable happened.
+# Continuous-drift noise (container_memory_pct, micro_count_since_light,
+# time_since_last_strategic, light_count_since_deep, budget_pct_consumed,
+# user_session_pattern) is excluded.
+# NOTE: software_error_spike and critical_failure primarily drive Micro
+# scoring, but they're included here because if they change 0→1, we want
+# the Light gate to open so the anomaly focus path can fire.
 _MATERIAL_SIGNALS = frozenset({
     "software_error_spike", "critical_failure", "sentinel_activity",
     "guardian_activity", "conversations_since_reflection",

--- a/src/genesis/cc/reflection_bridge/_bridge.py
+++ b/src/genesis/cc/reflection_bridge/_bridge.py
@@ -45,6 +45,38 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# ── Signal change detection for Light reflections ─────────────────────
+# Only these signals carry actionable information — changes here mean
+# something actually happened. Continuous-drift noise (container_memory_pct,
+# micro_count_since_light, time_since_last_strategic, light_count_since_deep,
+# budget_pct_consumed, user_session_pattern) is excluded.
+_MATERIAL_SIGNALS = frozenset({
+    "software_error_spike", "critical_failure", "sentinel_activity",
+    "guardian_activity", "conversations_since_reflection",
+    "stale_browser_processes", "stale_pending_items",
+    "autonomy_activity", "genesis_version_changed",
+})
+
+_last_light_signals: dict[str, float] | None = None
+
+
+def _signals_materially_changed(tick, *, threshold: float = 0.05) -> bool:
+    """Check if any material signal changed since the last light reflection."""
+    global _last_light_signals  # noqa: PLW0603
+    current = {s.name: s.value for s in tick.signals if s.name in _MATERIAL_SIGNALS}
+    if _last_light_signals is None:
+        return True  # first run after restart — always allow
+    return any(
+        abs(current.get(k, 0) - _last_light_signals.get(k, 0)) >= threshold
+        for k in _MATERIAL_SIGNALS
+    )
+
+
+def _update_light_signal_snapshot(tick) -> None:
+    """Update the saved signal snapshot after a successful light dispatch."""
+    global _last_light_signals  # noqa: PLW0603
+    _last_light_signals = {s.name: s.value for s in tick.signals if s.name in _MATERIAL_SIGNALS}
+
 
 _DEPTH_MODEL = {
     Depth.LIGHT: CCModel.HAIKU,
@@ -201,6 +233,11 @@ class CCReflectionBridge:
         skip_approval: bool = False,
     ) -> ReflectionResult:
         """Run Deep or Strategic reflection via CC background session."""
+        # Light reflection: skip if no material signals changed since last dispatch
+        if depth == Depth.LIGHT and not _signals_materially_changed(tick):
+            logger.info("Light reflection skipped — no material signal change")
+            return ReflectionResult(success=True, reason="no_material_change")
+
         # Check CC budget before proceeding
         throttle_result = await self._check_throttle(priority=2, work_type="reflection")
         if throttle_result is not None:
@@ -449,6 +486,10 @@ class CCReflectionBridge:
                 success=False,
                 reason=f"{depth.value} reflection output was unparseable or empty — recorded as failure",
             )
+
+        # Update signal snapshot after successful Light reflection
+        if depth == Depth.LIGHT:
+            _update_light_signal_snapshot(tick)
 
         return ReflectionResult(
             success=True,

--- a/src/genesis/cc/reflection_bridge/_prompts.py
+++ b/src/genesis/cc/reflection_bridge/_prompts.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING
 
 from genesis.awareness.types import Depth, SignalReading, TickResult
 from genesis.cc.types import CCModel
-from genesis.perception.types import LIGHT_FOCUS_ROTATION
 
 if TYPE_CHECKING:
     from genesis.perception.context import ContextAssembler
@@ -46,12 +45,19 @@ def _format_signal(s: SignalReading, *, unchanged_ticks: int = 0) -> str:
     return base
 
 
-def _format_signals_from_tick(tick: TickResult, *, limit: int = 10) -> str:
-    """Format signals with staleness annotations from a TickResult."""
+def _format_signals_from_tick(
+    tick: TickResult, *, limit: int = 10, min_value: float = 0.0,
+) -> str:
+    """Format signals with staleness annotations from a TickResult.
+
+    When min_value > 0, signals at or below that value are excluded.
+    This filters out bootstrap placeholder signals that always return 0.0.
+    """
     staleness = tick.signal_staleness or {}
     parts = [
         _format_signal(s, unchanged_ticks=staleness.get(s.name, 0))
         for s in tick.signals[:limit]
+        if s.value > min_value or min_value == 0.0
     ]
     return ", ".join(parts) if parts else "none"
 
@@ -98,8 +104,23 @@ _SENTINEL_ANOMALY_THRESHOLD = 0.7
 
 
 def _light_focus_area(tick: TickResult) -> str:
-    """Derive focus area from tick_id.  Anomaly is event-driven — falls back
-    to situation when no critical operational signals are active."""
+    """Derive focus area from tick_id.
+
+    Anomaly is event-driven: fires only when critical signals are active.
+    Normal ticks alternate 50/50 between situation and user_impact.
+    """
+    # Event-driven anomaly — only when critical signals are active
+    has_critical = any(
+        s.value > 0 for s in tick.signals
+        if s.name in _ANOMALY_RELEVANT_SIGNALS
+    ) or any(
+        s.value >= _SENTINEL_ANOMALY_THRESHOLD for s in tick.signals
+        if s.name == "sentinel_activity"
+    )
+    if has_critical:
+        return "anomaly"
+
+    # Normal rotation: alternate situation / user_impact
     import uuid as _uuid
 
     try:
@@ -107,20 +128,7 @@ def _light_focus_area(tick: TickResult) -> str:
     except ValueError:
         tick_number = int.from_bytes(tick.tick_id.encode()[:8], "big") % 10000
 
-    candidate = LIGHT_FOCUS_ROTATION[tick_number % len(LIGHT_FOCUS_ROTATION)]
-
-    if candidate == "anomaly":
-        has_critical = any(
-            s.value > 0 for s in tick.signals
-            if s.name in _ANOMALY_RELEVANT_SIGNALS
-        ) or any(
-            s.value >= _SENTINEL_ANOMALY_THRESHOLD for s in tick.signals
-            if s.name == "sentinel_activity"
-        )
-        if not has_critical:
-            return "situation"
-
-    return candidate
+    return ["situation", "user_impact"][tick_number % 2]
 
 
 # ── Observation formatting ───────────────────────────────────────────
@@ -261,7 +269,10 @@ async def build_reflection_prompt(
     # Legacy simple path
     from genesis.db.crud import cognitive_state
 
-    signals_summary = _format_signals_from_tick(tick)
+    # For Light reflections, filter out zero-value bootstrap placeholder signals
+    signals_summary = _format_signals_from_tick(
+        tick, min_value=0.001 if depth == Depth.LIGHT else 0.0,
+    )
 
     scores_summary = ", ".join(
         f"{s.depth.value}={s.final_score:.2f}" for s in tick.scores

--- a/src/genesis/cc/reflection_bridge/_prompts.py
+++ b/src/genesis/cc/reflection_bridge/_prompts.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import uuid as _uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -121,8 +122,6 @@ def _light_focus_area(tick: TickResult) -> str:
         return "anomaly"
 
     # Normal rotation: alternate situation / user_impact
-    import uuid as _uuid
-
     try:
         tick_number = _uuid.UUID(tick.tick_id).int % 10000
     except ValueError:

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -539,16 +539,67 @@ async def mark_surfaced(
     ids: list[str],
     surfaced_at: str,
 ) -> int:
-    """Mark observations as surfaced. Returns count updated."""
+    """Mark observations as surfaced and increment surfaced_count.
+
+    Uses COALESCE to preserve the original surfaced_at timestamp on
+    re-surfacing while always incrementing the count.
+    """
     if not ids:
         return 0
     placeholders = ",".join("?" for _ in ids)
     cursor = await db.execute(
-        f"UPDATE observations SET surfaced_at = ? WHERE id IN ({placeholders})",
+        f"UPDATE observations SET surfaced_at = COALESCE(surfaced_at, ?), "
+        f"surfaced_count = surfaced_count + 1 "
+        f"WHERE id IN ({placeholders})",
         [surfaced_at, *ids],
     )
     await db.commit()
     return cursor.rowcount
+
+
+async def get_standing(
+    db: aiosqlite.Connection,
+    *,
+    priority_filter: tuple[str, ...] = ("critical", "high", "medium"),
+    exclude_types: tuple[str, ...] | frozenset[str] = (),
+    threshold: int = 3,
+    limit: int = 5,
+) -> list[dict]:
+    """Return observations surfaced >= threshold times but still unresolved.
+
+    These are "standing items" — known conditions that have been brought
+    to attention multiple times without being resolved.
+    """
+    prio_placeholders = ",".join("?" for _ in priority_filter)
+    sql = (
+        "SELECT id, source, type, category, content, priority, "
+        "created_at, surfaced_count "
+        f"FROM observations WHERE surfaced_count >= ? AND resolved = 0 "
+        f"AND priority IN ({prio_placeholders})"
+    )
+    params: list = [threshold, *priority_filter]
+    if exclude_types:
+        type_placeholders = ",".join("?" for _ in exclude_types)
+        sql += f" AND type NOT IN ({type_placeholders})"
+        params.extend(exclude_types)
+    sql += (
+        " ORDER BY CASE priority "
+        "  WHEN 'critical' THEN 0 WHEN 'high' THEN 1 "
+        "  WHEN 'medium' THEN 2 ELSE 3 END, "
+        "surfaced_count DESC, created_at DESC "
+        "LIMIT ?"
+    )
+    params.append(limit)
+    cursor = await db.execute(sql, params)
+    rows = await cursor.fetchall()
+    return [
+        {
+            "id": r[0], "source": r[1], "type": r[2], "category": r[3],
+            "content": r[4], "priority": r[5], "created_at": r[6],
+            "surfaced_count": r[7],
+        }
+        for r in rows
+    ]
 
 
 async def unsurfaced_counts_by_priority(db: aiosqlite.Connection) -> dict[str, int]:

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1141,6 +1141,20 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE memory_metadata ADD COLUMN dream_cycle_run_id TEXT",
         "memory_metadata.dream_cycle_run_id")
 
+    # Observation de-escalation: track how many times an observation has
+    # been surfaced (morning report, dashboard, critical alerting).
+    await _try_alter(db,
+        "ALTER TABLE observations ADD COLUMN surfaced_count INTEGER NOT NULL DEFAULT 0",
+        "observations.surfaced_count")
+
+    # Dream cycle fix (PR #385): reset consecutive_failures since the
+    # underlying code bug (rt.qdrant → store.qdrant_client) is fixed.
+    await db.execute(
+        "UPDATE job_health SET consecutive_failures = 0, "
+        "last_error = 'reset: code fix merged (PR #385)' "
+        "WHERE job_name = 'dream_cycle' AND consecutive_failures > 0"
+    )
+
     # World model tables: user goals and contacts for ego world model.
     await _migrate_world_model_tables(db)
 

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -54,7 +54,9 @@ TABLES = {
             resolution_notes TEXT,
             created_at       TEXT NOT NULL,
             expires_at       TEXT,
-            content_hash     TEXT
+            content_hash     TEXT,
+            surfaced_at      TEXT,
+            surfaced_count   INTEGER NOT NULL DEFAULT 0
         )
     """,
     "execution_traces": """

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1149,6 +1149,7 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_observations_content_hash ON observations(source, content_hash)",
     "CREATE INDEX IF NOT EXISTS idx_observations_type_source_created ON observations(type, source, created_at)",
     "CREATE INDEX IF NOT EXISTS idx_observations_surfaced ON observations(surfaced_at)",
+    "CREATE INDEX IF NOT EXISTS idx_observations_surfaced_count ON observations(surfaced_count, resolved)",
     "CREATE INDEX IF NOT EXISTS idx_outreach_person ON outreach_history(person_id)",
     "CREATE INDEX IF NOT EXISTS idx_autonomy_person ON autonomy_state(person_id)",
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_autonomy_category ON autonomy_state(category)",

--- a/src/genesis/identity/MORNING_REPORT.md
+++ b/src/genesis/identity/MORNING_REPORT.md
@@ -92,6 +92,10 @@ Use these sections in order. Skip any that are empty/normal:
    noting. Only include genuinely useful insights.
 4. **System Health** — one line if normal. Detail only if something broke.
 5. **Open Items** — pending items requiring user input (inbox, approvals)
+6. **Standing Items** — only if provided. These are known conditions
+   surfaced 3+ times without being resolved. They are NOT urgent —
+   compress to a brief list. If unchanged since last report, write
+   "N standing items unchanged." Do not lead the report with these.
 
 ## Memory Attribution
 

--- a/src/genesis/identity/REFLECTION_LIGHT_HAIKU.md
+++ b/src/genesis/identity/REFLECTION_LIGHT_HAIKU.md
@@ -7,10 +7,12 @@ You are Genesis performing a Light reflection — a periodic check-in.
 2. Is anything worth escalating to Deep reflection? (yes/no + one-sentence reason)
 3. If your focus is situation: write a context_update summarizing current state.
 
-## Default: Nothing New
-If signals are stable and no anomalies exist, respond with confidence 0.3 and
-assessment "No material change." This is the CORRECT response most of the time.
-Do not restate known conditions — only report what is NEW or CHANGED.
+## Key Rule
+You were triggered because a signal changed. Identify what changed and
+whether it matters. Do not restate known conditions — only report what
+is NEW or CHANGED. If after reviewing signals you find nothing
+actionable, respond with confidence 0.3 and a brief "No material
+change" — but this should be rare, not the default.
 
 ## Focus Modes
 The prompt specifies your focus: situation, user_impact, or anomaly.

--- a/src/genesis/identity/REFLECTION_LIGHT_HAIKU.md
+++ b/src/genesis/identity/REFLECTION_LIGHT_HAIKU.md
@@ -1,39 +1,38 @@
-# Light Reflection — Haiku-Optimized
+# Light Reflection
 
-You are Genesis performing a Light reflection. Quick pattern check.
+You are Genesis performing a Light reflection — a periodic check-in.
 
-## Focus Rotation
+## Your Job
+1. What changed since the last cognitive state snapshot? Cite specific signal values.
+2. Is anything worth escalating to Deep reflection? (yes/no + one-sentence reason)
+3. If your focus is situation: write a context_update summarizing current state.
+
+## Default: Nothing New
+If signals are stable and no anomalies exist, respond with confidence 0.3 and
+assessment "No material change." This is the CORRECT response most of the time.
+Do not restate known conditions — only report what is NEW or CHANGED.
+
+## Focus Modes
 The prompt specifies your focus: situation, user_impact, or anomaly.
-- situation: system state, no user_model_updates
-- user_impact: user analysis, the ONLY mode with user_model_updates
-- anomaly: pattern detection, produces surplus_candidates
+- situation: system state assessment + context_update. No user_model_updates.
+- user_impact: how conditions affect the user. The ONLY mode with user_model_updates.
+- anomaly: pattern detection. Produces surplus_candidates.
 
-## Task
-Primary lens: **How can Genesis help the user?** System health matters only
-when it impacts user value.
+Empty lists for fields your focus does not produce.
 
-1. Follow the focus-specific instructions in the prompt
-2. Decide: escalate to Deep reflection? (yes/no + reason)
-3. Cite specific evidence for every claim
-4. Confidence: below 0.5 when uncertain. Never default to 0.7.
-5. If nothing material changed since the cognitive state: say "no material
-   change" with confidence 0.3. This is better than restating known conditions.
-
-## Output Format
-Respond with valid JSON matching the focus area. Empty lists for fields
-your focus does not produce.
+## Output
+Valid JSON only. No preamble.
 ```json
 {
-  "assessment": "2-4 sentences citing signal values.",
-  "patterns": [],
-  "user_model_updates": [],
-  "recommendations": [],
-  "confidence": 0.7,
+  "assessment": "1-3 sentences. Only report changes. Cite signal values.",
+  "confidence": 0.3,
   "focus_area": "situation",
   "escalate_to_deep": false,
   "escalation_reason": null,
-  "surplus_candidates": []
+  "patterns": [],
+  "recommendations": [],
+  "user_model_updates": [],
+  "surplus_candidates": [],
+  "context_update": null
 }
 ```
-
-Keep responses concise. No preamble. JSON only.

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -100,20 +100,17 @@ class MorningReportGenerator:
         Called by the scheduler after the pipeline confirms delivery.
         Observations collected during generate() are only marked surfaced
         here — if delivery fails, they re-appear in the next report.
+
+        Only calls mark_surfaced — retrieved/influenced tracking is
+        handled by _get_activity_summary to avoid double-counting.
         """
         ids = self._pending_surface_ids
         if not ids:
             return
-        from genesis.db.crud.observations import (
-            increment_retrieved_batch,
-            mark_influenced_batch,
-            mark_surfaced,
-        )
+        from genesis.db.crud.observations import mark_surfaced
 
         now = datetime.now(UTC).isoformat()
         await mark_surfaced(self._db, ids, now)
-        await increment_retrieved_batch(self._db, ids)
-        await mark_influenced_batch(self._db, ids)
         self._pending_surface_ids = []
 
     @staticmethod

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -22,6 +22,25 @@ _INTERNAL_OBS_TYPES = tuple(_INTERNAL_OBS_TYPES_SET)
 _PROMPT_PATH = Path(__file__).resolve().parent.parent / "identity" / "MORNING_REPORT.md"
 
 
+def _relative_age(iso_ts: str) -> str:
+    """Convert an ISO timestamp to a human-readable relative age string."""
+    if not iso_ts:
+        return "unknown age"
+    try:
+        ts = datetime.fromisoformat(iso_ts)
+        delta = datetime.now(UTC) - ts
+        total_s = delta.total_seconds()
+        if total_s < 0:
+            return "just now"
+        if total_s < 3600:
+            return f"{int(total_s / 60)}m ago"
+        if total_s < 86400:
+            return f"{total_s / 3600:.0f}h ago"
+        return f"{total_s / 86400:.0f}d ago"
+    except (ValueError, TypeError):
+        return "unknown age"
+
+
 class MorningReportGenerator:
     """Synthesizes system state into a daily morning report."""
 
@@ -37,6 +56,7 @@ class MorningReportGenerator:
         self._db = db
         self._drafter = drafter
         self._event_bus = event_bus
+        self._pending_surface_ids: list[str] = []
 
     async def generate(self) -> OutreachRequest:
         context = await self._assemble_context()
@@ -65,6 +85,28 @@ class MorningReportGenerator:
             salience_score=0.0,
             signal_type="morning_report",
         )
+
+    async def confirm_delivery(self) -> None:
+        """Mark observations as surfaced after successful delivery.
+
+        Called by the scheduler after the pipeline confirms delivery.
+        Observations collected during generate() are only marked surfaced
+        here — if delivery fails, they re-appear in the next report.
+        """
+        ids = self._pending_surface_ids
+        if not ids:
+            return
+        from genesis.db.crud.observations import (
+            increment_retrieved_batch,
+            mark_influenced_batch,
+            mark_surfaced,
+        )
+
+        now = datetime.now(UTC).isoformat()
+        await mark_surfaced(self._db, ids, now)
+        await increment_retrieved_batch(self._db, ids)
+        await mark_influenced_batch(self._db, ids)
+        self._pending_surface_ids = []
 
     @staticmethod
     def _load_system_prompt() -> str | None:
@@ -452,17 +494,11 @@ class MorningReportGenerator:
     async def _get_observation_insights(self) -> str | None:
         """Surface unsurfaced observations that deserve user attention.
 
-        Returns None if no unsurfaced observations exist. Marks delivered
-        observations as surfaced to prevent re-delivery.
+        Returns None if no unsurfaced observations exist. Observation IDs
+        are collected in _pending_surface_ids and confirmed via
+        confirm_delivery() after successful pipeline delivery.
         """
-        from datetime import UTC, datetime
-
-        from genesis.db.crud.observations import (
-            get_unsurfaced,
-            increment_retrieved_batch,
-            mark_influenced_batch,
-            mark_surfaced,
-        )
+        from genesis.db.crud.observations import get_unsurfaced
 
         observations = await get_unsurfaced(
             self._db,
@@ -478,15 +514,11 @@ class MorningReportGenerator:
             prio = obs["priority"]
             badge = {"critical": "🔴", "high": "🟠", "medium": "🟡"}.get(prio, "")
             content = obs["content"][:200].replace("\n", " ")
-            lines.append(f"- {badge} **{prio}**: {content}")
+            age = _relative_age(obs.get("created_at", ""))
+            lines.append(f"- {badge} **{prio}** ({age}): {content}")
 
-        # Mark surfaced during assembly (before delivery confirmation).
-        # Trade-off: if delivery fails, these observations won't re-surface.
-        # Acceptable for v1 — the dashboard can always show them.
-        ids = [obs["id"] for obs in observations]
-        now = datetime.now(UTC).isoformat()
-        await mark_surfaced(self._db, ids, now)
-        await increment_retrieved_batch(self._db, ids)
-        await mark_influenced_batch(self._db, ids)
+        # Defer surfacing until delivery is confirmed via confirm_delivery().
+        # If delivery fails, these observations re-appear in the next report.
+        self._pending_surface_ids = [obs["id"] for obs in observations]
 
         return "\n".join(lines)

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -41,6 +41,14 @@ def _relative_age(iso_ts: str) -> str:
         return "unknown age"
 
 
+def _age_seconds(iso_ts: str) -> float:
+    """Return seconds since the given ISO timestamp, or 0 on error."""
+    try:
+        return (datetime.now(UTC) - datetime.fromisoformat(iso_ts)).total_seconds()
+    except (ValueError, TypeError):
+        return 0
+
+
 class MorningReportGenerator:
     """Synthesizes system state into a daily morning report."""
 
@@ -184,6 +192,14 @@ class MorningReportGenerator:
         except Exception:
             logger.warning("Morning report: observation insights unavailable", exc_info=True)
 
+        # 9. Standing Items (observations surfaced 3+ times, still unresolved)
+        try:
+            standing = await self._get_standing_items()
+            if standing:
+                sections.append(f"## Standing Items\n{standing}")
+        except Exception:
+            logger.warning("Morning report: standing items unavailable", exc_info=True)
+
         return "\n\n".join(sections)
 
     async def _emit_warning(self, section: str, message: str) -> None:
@@ -220,6 +236,16 @@ class MorningReportGenerator:
         pending_embed = queues.get('pending_embeddings', 0)
         if pending_embed and pending_embed > 100:
             lines.append(f"- **Embedding queue elevated**: {pending_embed} pending")
+        # Top cost drivers (data already in the snapshot, just not displayed)
+        by_provider = cost.get("cost_by_provider", [])
+        if by_provider:
+            top = [
+                f"{p['provider']}: ${p['month_usd']:.2f}"
+                for p in by_provider[:3]
+                if p.get("month_usd", 0) > 0.01
+            ]
+            if top:
+                lines.append(f"- Top cost drivers (month): {', '.join(top)}")
         return "\n".join(lines)
 
     async def _get_activity_summary(self) -> str:
@@ -312,8 +338,12 @@ class MorningReportGenerator:
             "'Genesis is tracking N internal items.' Skip entirely if nothing\n"
             "requires user awareness.\n"
         )
-        entries = "\n".join(f"- [{r[0]}] {r[1][:300]} (as of {r[2]})" for r in rows)
-        return header + "\n" + entries
+        entry_lines = []
+        for r in rows:
+            age = _relative_age(r[2])
+            aging_tag = " [AGING]" if _age_seconds(r[2]) > 43200 else ""  # >12h
+            entry_lines.append(f"- [{r[0]}]{aging_tag} {r[1][:300]} ({age})")
+        return header + "\n" + "\n".join(entry_lines)
 
     async def _get_pending_items(self) -> str:
         lines: list[str] = []
@@ -521,4 +551,29 @@ class MorningReportGenerator:
         # If delivery fails, these observations re-appear in the next report.
         self._pending_surface_ids = [obs["id"] for obs in observations]
 
+        return "\n".join(lines)
+
+    async def _get_standing_items(self) -> str | None:
+        """Return observations surfaced 3+ times but still unresolved.
+
+        These are known conditions — demoted to end of report.
+        """
+        from genesis.db.crud.observations import get_standing
+
+        items = await get_standing(
+            self._db,
+            priority_filter=("critical", "high", "medium"),
+            exclude_types=_INTERNAL_OBS_TYPES,
+            threshold=3,
+            limit=5,
+        )
+        if not items:
+            return None
+
+        lines = []
+        for obs in items:
+            content = obs["content"][:150].replace("\n", " ")
+            count = obs.get("surfaced_count", 0)
+            age = _relative_age(obs.get("created_at", ""))
+            lines.append(f"- {content} (surfaced {count}x, {age})")
         return "\n".join(lines)

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -171,6 +171,13 @@ class OutreachScheduler:
             result = await self._pipeline.submit(req)
             logger.info("Morning report: %s", result.status.value)
 
+            # Confirm observation surfacing after successful delivery.
+            if result.status.value == "delivered":
+                try:
+                    await self._morning.confirm_delivery()
+                except Exception:
+                    logger.warning("Failed to confirm morning report delivery", exc_info=True)
+
             # Auto-acknowledge digest so it doesn't appear as "urgent unread"
             if result.outreach_id and result.status.value == "delivered":
                 try:

--- a/src/genesis/perception/context.py
+++ b/src/genesis/perception/context.py
@@ -160,7 +160,11 @@ class ContextAssembler:
             except Exception:
                 logger.debug("Could not load signal_weights for Micro filtering")
 
-        signals_text = self._format_signals(tick, excluded_signals=excluded_signals)
+        # For Light reflections, filter out zero-value bootstrap placeholder signals
+        _min_val = 0.001 if depth == Depth.LIGHT else 0.0
+        signals_text = self._format_signals(
+            tick, excluded_signals=excluded_signals, min_value=_min_val,
+        )
         tick_number = self._extract_tick_number(tick)
 
         user_profile = None
@@ -431,12 +435,15 @@ class ContextAssembler:
         self,
         tick: TickResult,
         excluded_signals: set[str] | None = None,
+        min_value: float = 0.0,
     ) -> str:
         staleness = tick.signal_staleness or {}
         tick_interval_min = 5  # awareness loop tick interval
         lines = []
         for s in tick.signals:
             if excluded_signals is not None and s.name in excluded_signals:
+                continue
+            if min_value > 0 and s.value <= min_value:
                 continue
             line = f"{s.name}: {s.value} (source={s.source})"
             if s.normal_max is not None:

--- a/tests/test_db/test_observation_surfacing.py
+++ b/tests/test_db/test_observation_surfacing.py
@@ -193,7 +193,6 @@ class TestGetStanding:
     @pytest.mark.asyncio
     async def test_excludes_resolved(self, db):
         """Resolved items are excluded even if surfaced enough times."""
-        now = datetime.now(UTC).isoformat()
         # obs-6 is already resolved
         await db.execute(
             "UPDATE observations SET surfaced_count = 5 WHERE id = 'obs-6'"

--- a/tests/test_db/test_observation_surfacing.py
+++ b/tests/test_db/test_observation_surfacing.py
@@ -8,6 +8,7 @@ import aiosqlite
 import pytest
 
 from genesis.db.crud.observations import (
+    get_standing,
     get_unsurfaced,
     mark_surfaced,
     unsurfaced_counts_by_priority,
@@ -16,7 +17,7 @@ from genesis.db.crud.observations import (
 
 @pytest.fixture
 async def db(tmp_path):
-    """In-memory DB with observations table including surfaced_at."""
+    """In-memory DB with observations table including surfaced_at and surfaced_count."""
     db_path = str(tmp_path / "test.db")
     async with aiosqlite.connect(db_path) as conn:
         await conn.execute("""
@@ -37,7 +38,8 @@ async def db(tmp_path):
                 created_at TEXT,
                 expires_at TEXT,
                 content_hash TEXT,
-                surfaced_at TEXT
+                surfaced_at TEXT,
+                surfaced_count INTEGER NOT NULL DEFAULT 0
             )
         """)
         # Seed test data
@@ -126,6 +128,105 @@ class TestMarkSurfaced:
     async def test_empty_list(self, db):
         count = await mark_surfaced(db, [], datetime.now(UTC).isoformat())
         assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_surfaced_count_increments(self, db):
+        """Verify surfaced_count increments on each mark_surfaced call."""
+        now = datetime.now(UTC).isoformat()
+        await mark_surfaced(db, ["obs-1"], now)
+
+        cursor = await db.execute(
+            "SELECT surfaced_count FROM observations WHERE id = 'obs-1'"
+        )
+        row = await cursor.fetchone()
+        assert row[0] == 1
+
+        # Call again — count should increment, surfaced_at preserved
+        await mark_surfaced(db, ["obs-1"], datetime.now(UTC).isoformat())
+        cursor = await db.execute(
+            "SELECT surfaced_count, surfaced_at FROM observations WHERE id = 'obs-1'"
+        )
+        row = await cursor.fetchone()
+        assert row[0] == 2
+        assert row[1] == now  # original surfaced_at preserved via COALESCE
+
+    @pytest.mark.asyncio
+    async def test_surfaced_count_preserves_original_timestamp(self, db):
+        """COALESCE preserves first surfaced_at on re-surfacing."""
+        first_ts = "2026-05-20T10:00:00+00:00"
+        await mark_surfaced(db, ["obs-2"], first_ts)
+
+        second_ts = "2026-05-21T10:00:00+00:00"
+        await mark_surfaced(db, ["obs-2"], second_ts)
+
+        cursor = await db.execute(
+            "SELECT surfaced_at, surfaced_count FROM observations WHERE id = 'obs-2'"
+        )
+        row = await cursor.fetchone()
+        assert row[0] == first_ts  # first timestamp preserved
+        assert row[1] == 2
+
+
+class TestGetStanding:
+    @pytest.mark.asyncio
+    async def test_returns_standing_items(self, db):
+        """Items surfaced >= threshold times are returned."""
+        now = datetime.now(UTC).isoformat()
+        # Surface obs-1 three times
+        for _ in range(3):
+            await mark_surfaced(db, ["obs-1"], now)
+
+        items = await get_standing(db, threshold=3)
+        ids = [r["id"] for r in items]
+        assert "obs-1" in ids
+
+    @pytest.mark.asyncio
+    async def test_excludes_below_threshold(self, db):
+        """Items surfaced fewer than threshold times are excluded."""
+        now = datetime.now(UTC).isoformat()
+        await mark_surfaced(db, ["obs-2"], now)  # only 1 time
+
+        items = await get_standing(db, threshold=3)
+        ids = [r["id"] for r in items]
+        assert "obs-2" not in ids
+
+    @pytest.mark.asyncio
+    async def test_excludes_resolved(self, db):
+        """Resolved items are excluded even if surfaced enough times."""
+        now = datetime.now(UTC).isoformat()
+        # obs-6 is already resolved
+        await db.execute(
+            "UPDATE observations SET surfaced_count = 5 WHERE id = 'obs-6'"
+        )
+        await db.commit()
+
+        items = await get_standing(db, threshold=3)
+        ids = [r["id"] for r in items]
+        assert "obs-6" not in ids
+
+    @pytest.mark.asyncio
+    async def test_exclude_types(self, db):
+        """Excluded types are filtered out."""
+        now = datetime.now(UTC).isoformat()
+        # Surface obs-5 (micro_reflection) 5 times
+        for _ in range(5):
+            await mark_surfaced(db, ["obs-5"], now)
+
+        items = await get_standing(db, exclude_types=("micro_reflection",), threshold=3)
+        ids = [r["id"] for r in items]
+        assert "obs-5" not in ids
+
+    @pytest.mark.asyncio
+    async def test_includes_surfaced_count(self, db):
+        """Returned items include surfaced_count field."""
+        now = datetime.now(UTC).isoformat()
+        for _ in range(4):
+            await mark_surfaced(db, ["obs-3"], now)
+
+        items = await get_standing(db, threshold=3)
+        obs3 = [r for r in items if r["id"] == "obs-3"]
+        assert len(obs3) == 1
+        assert obs3[0]["surfaced_count"] == 4
 
 
 class TestUnsurfacedCounts:

--- a/tests/test_perception/test_prompts.py
+++ b/tests/test_perception/test_prompts.py
@@ -105,7 +105,7 @@ def test_light_focus_area_rotation():
         results_quiet.add(_light_focus_area(tick))
     assert results_quiet == {"situation", "user_impact"}
 
-    # With a critical signal, anomaly can fire.
+    # With a critical signal, anomaly fires on every tick (event-driven).
     results_critical = set()
     critical_signal = SignalReading(
         name="software_error_spike", value=1.0, source="test",
@@ -119,7 +119,7 @@ def test_light_focus_area_rotation():
             classified_depth=Depth.LIGHT, trigger_reason="test",
         )
         results_critical.add(_light_focus_area(tick))
-    assert results_critical == {"situation", "user_impact", "anomaly"}
+    assert results_critical == {"anomaly"}
 
 
 def test_variable_substitution():


### PR DESCRIPTION
## Summary
- **Light reflections**: Signal change detection gate prevents repetitive reflections when nothing material changed. Focus rotation fixed from broken 67/33/0 to event-driven anomaly + 50/50 situation/user_impact. Zero-value bootstrap signals filtered from prompts. Gemini Flash promoted to primary model (Groq fallback). System prompt simplified from 7+ tasks to 3 core questions.
- **Morning report**: Observation de-escalation via surfaced_count — items surfaced 3+ times become "Standing Items" at bottom. Age annotations on cognitive state and observations. Cost breakdown by provider included. mark_surfaced() moved to post-delivery (failed deliveries no longer lose observations). Dream cycle stale job_health reset.
- **Heartbeat**: Reflection heartbeat now emitted after successful Light/Deep/Strategic dispatch — fixes false "overdue" alarms caused by 40h gaps between micro-reflection heartbeats.

## Root causes addressed
- **Repetitive reflections**: 13 of 19 signals are effectively static (7 bootstrap placeholders, 3 continuous-drift, 3 constant). Signal change gate uses a whitelist of 9 actionable signals.
- **Heartbeat false alarm**: Only micro-reflection anomaly path and weekly jobs emitted heartbeats. CC bridge path (primary) never did. Confirmed via DB: 40h gap May 21-24.
- **Stale morning report**: No de-escalation mechanism + mark_surfaced before delivery + no age context + cost breakdown discarded.

## Test plan
- [x] 596 tests pass (full DB + reflection suites)
- [x] 7 new tests for surfaced_count, get_standing, COALESCE timestamp preservation
- [x] Baseline verified before changes (46 → 53 tests)
- [ ] Verify signal change detection in production logs after deploy
- [ ] Verify next morning report includes standing items section
- [ ] Verify reflection heartbeat no longer shows overdue

🤖 Generated with [Claude Code](https://claude.com/claude-code)