### PR TITLE
feat(scheduler): install test runner + multi-cloud VM provider stubs

### DIFF
--- a/src/genesis/scheduler/install_test.py
+++ b/src/genesis/scheduler/install_test.py
@@ -1,0 +1,233 @@
+"""Install test runner — provisions a cloud VM, runs the public install
+script, verifies it works, tears down the VM, and reports results.
+
+This is the first user job type. It runs weekly (default: Sunday 2am UTC)
+to ensure the public install script works for new users.
+
+The runner:
+1. Provisions a fresh cloud VM via the configured provider
+2. Waits for SSH availability
+3. Clones the public repo and runs scripts/install.sh --non-interactive
+4. Captures output and classifies errors (transient vs structural)
+5. Runs smoke tests (systemd services up, health endpoint responds)
+6. Tears down the VM (always, even on failure)
+7. Reports results via Telegram
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+
+logger = logging.getLogger(__name__)
+
+# Default config for the install test job
+DEFAULT_CONFIG = {
+    "provider": "aws",
+    "region": "us-east-1",
+    "instance_type": "t3.medium",
+    "image_id": "",  # Ubuntu 24.04 AMI — set when account is ready
+    "ssh_key_name": "",
+    "repo_url": "https://github.com/WingedGuardian/GENesis-AGI.git",
+    "install_command": "scripts/install.sh --non-interactive",
+    "smoke_timeout_s": 120,
+}
+
+# Error patterns that indicate structural issues (not transient)
+_STRUCTURAL_PATTERNS = [
+    "ModuleNotFoundError",
+    "No such file or directory",
+    "command not found",
+    "Permission denied",
+    "SyntaxError",
+    "ImportError",
+    "pkg_resources.DistributionNotFound",
+    "FileNotFoundError",
+]
+
+# Error patterns that indicate transient issues (retry-worthy)
+_TRANSIENT_PATTERNS = [
+    "Could not resolve host",
+    "Connection timed out",
+    "Temporary failure in name resolution",
+    "Unable to fetch some archives",
+    "Hash Sum mismatch",
+    "Failed to fetch",
+    "Connection reset by peer",
+    "503 Service Temporarily Unavailable",
+]
+
+
+def classify_error(output: str) -> str:
+    """Classify install output as 'structural', 'transient', or 'unknown'."""
+    for pattern in _STRUCTURAL_PATTERNS:
+        if pattern in output:
+            return "structural"
+    for pattern in _TRANSIENT_PATTERNS:
+        if pattern in output:
+            return "transient"
+    return "unknown"
+
+
+async def run_install_test(config: dict) -> dict:
+    """Execute a full install test cycle.
+
+    Args:
+        config: Provider-specific config merged with DEFAULT_CONFIG.
+
+    Returns:
+        dict with keys: success, provider, duration_s, install_output,
+        smoke_output, error_type, error_message
+    """
+    from genesis.scheduler.vm_provider import VMInstance, get_provider
+
+    merged = {**DEFAULT_CONFIG, **config}
+    provider_name = merged["provider"]
+    start = datetime.now(UTC)
+    instance: VMInstance | None = None
+    result = {
+        "success": False,
+        "provider": provider_name,
+        "duration_s": 0,
+        "install_output": "",
+        "smoke_output": "",
+        "error_type": None,
+        "error_message": None,
+    }
+
+    try:
+        provider = get_provider(provider_name)
+
+        # 1. Provision VM
+        logger.info("Install test: provisioning %s VM in %s", provider_name, merged.get("region"))
+        instance = await provider.provision(merged)
+        logger.info("Install test: VM %s at %s", instance.instance_id, instance.ip)
+
+        # 2. Wait for SSH
+        ssh_ok = await provider.wait_for_ssh(instance)
+        if not ssh_ok:
+            result["error_type"] = "transient"
+            result["error_message"] = "SSH not available after provisioning"
+            return result
+
+        # 3. Clone repo and run install
+        repo_url = merged["repo_url"]
+        install_cmd = merged["install_command"]
+        clone_output = await provider.ssh_command(
+            instance,
+            f"git clone {repo_url} ~/GENesis-AGI 2>&1",
+        )
+        logger.info("Install test: clone complete (%d chars)", len(clone_output))
+
+        install_output = await provider.ssh_command(
+            instance,
+            f"cd ~/GENesis-AGI && bash {install_cmd} 2>&1",
+        )
+        result["install_output"] = install_output[-5000:]  # Cap for storage
+        logger.info("Install test: install script complete (%d chars)", len(install_output))
+
+        # 4. Check for errors in install output
+        # If the SSH command itself succeeded, the script exited 0
+        # But we still check output for warning signs
+        error_type = classify_error(install_output)
+        if error_type == "structural":
+            result["error_type"] = "structural"
+            result["error_message"] = "Install script produced structural errors"
+            return result
+
+        # 5. Smoke tests
+        smoke_output = ""
+        try:
+            # Check systemd services
+            svc_output = await provider.ssh_command(
+                instance,
+                "systemctl --user is-active genesis-server 2>&1 || echo 'SERVICE_NOT_ACTIVE'",
+            )
+            smoke_output += f"Service check: {svc_output}\n"
+
+            # Check health endpoint
+            health_output = await provider.ssh_command(
+                instance,
+                "curl -sf http://localhost:5000/api/genesis/health 2>&1 || echo 'HEALTH_UNREACHABLE'",
+            )
+            smoke_output += f"Health check: {health_output[:500]}\n"
+
+            result["smoke_output"] = smoke_output
+            if "SERVICE_NOT_ACTIVE" in svc_output or "HEALTH_UNREACHABLE" in health_output:
+                result["error_type"] = "structural"
+                result["error_message"] = "Smoke tests failed — service not running or health unreachable"
+                return result
+
+        except Exception as exc:
+            result["smoke_output"] = f"Smoke test error: {exc}"
+            result["error_type"] = "unknown"
+            result["error_message"] = f"Smoke test exception: {exc}"
+            return result
+
+        # Success
+        result["success"] = True
+        logger.info("Install test: PASSED")
+
+    except NotImplementedError as exc:
+        result["error_type"] = "config"
+        result["error_message"] = str(exc)
+        logger.warning("Install test: provider not implemented — %s", exc)
+
+    except Exception as exc:
+        result["error_type"] = classify_error(str(exc))
+        result["error_message"] = str(exc)
+        logger.exception("Install test failed")
+
+    finally:
+        # Always teardown
+        if instance is not None:
+            try:
+                provider = get_provider(provider_name)
+                await provider.teardown(instance)
+                logger.info("Install test: VM %s terminated", instance.instance_id)
+            except Exception:
+                logger.warning("Install test: teardown failed", exc_info=True)
+
+        result["duration_s"] = (datetime.now(UTC) - start).total_seconds()
+
+    return result
+
+
+async def notify_result(result: dict) -> None:
+    """Send install test result via Telegram."""
+    try:
+        from genesis.runtime import GenesisRuntime
+
+        rt = GenesisRuntime.instance()
+        pipeline = getattr(rt, "_outreach_pipeline", None)
+        if pipeline is None:
+            logger.warning("No outreach pipeline — cannot notify install test result")
+            return
+
+        from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+        if result["success"]:
+            message = (
+                "Weekly install test PASSED\n"
+                f"Provider: {result['provider']}\n"
+                f"Duration: {result['duration_s']:.0f}s"
+            )
+            category = OutreachCategory.DIGEST
+        else:
+            message = (
+                f"Weekly install test FAILED\n"
+                f"Provider: {result['provider']}\n"
+                f"Error type: {result.get('error_type', 'unknown')}\n"
+                f"Error: {result.get('error_message', 'unknown')[:200]}\n"
+                f"Duration: {result['duration_s']:.0f}s"
+            )
+            category = OutreachCategory.BLOCKER
+
+        await pipeline.route_request(OutreachRequest(
+            category=category,
+            message=message,
+            metadata={"source": "install_test", "result": json.dumps(result)[:1000]},
+        ))
+    except Exception:
+        logger.warning("Failed to notify install test result", exc_info=True)

--- a/src/genesis/scheduler/vm_provider.py
+++ b/src/genesis/scheduler/vm_provider.py
@@ -1,0 +1,175 @@
+"""Provider-agnostic VM lifecycle interface for install testing.
+
+Defines the VMProvider protocol and VMInstance dataclass used by
+the install test runner to provision, manage, and tear down cloud
+VMs. Provider implementations (AWS, Azure, GCP) are stubs until
+their respective accounts are configured.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class VMInstance:
+    """A provisioned cloud VM instance."""
+
+    instance_id: str
+    provider: str  # "aws", "azure", "gcp"
+    ip: str
+    ssh_user: str = "ubuntu"
+    ssh_key_path: str = ""
+    region: str = ""
+    metadata: dict = field(default_factory=dict)
+
+
+class VMProvider(ABC):
+    """Abstract base for cloud VM providers."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Provider identifier (e.g., 'aws', 'azure', 'gcp')."""
+
+    @abstractmethod
+    async def provision(self, config: dict) -> VMInstance:
+        """Provision a new VM from config.
+
+        Config keys (provider-specific):
+          - region: Cloud region
+          - instance_type: VM size/type
+          - image_id: AMI/image to boot
+          - ssh_key_name: SSH key pair name
+          - tags: dict of resource tags
+
+        Returns a VMInstance with connection details.
+        Raises RuntimeError if provisioning fails.
+        """
+
+    @abstractmethod
+    async def teardown(self, instance: VMInstance) -> None:
+        """Terminate the VM and clean up resources.
+
+        Must be idempotent — calling on an already-terminated
+        instance should not raise.
+        """
+
+    @abstractmethod
+    async def ssh_command(self, instance: VMInstance, cmd: str) -> str:
+        """Execute a command on the VM via SSH.
+
+        Returns stdout. Raises RuntimeError on failure (non-zero exit
+        or SSH connection error).
+        """
+
+    async def wait_for_ssh(
+        self, instance: VMInstance, *, max_wait_s: int = 300, poll_s: int = 10,
+    ) -> bool:
+        """Poll until SSH is available. Returns True if reachable."""
+        import asyncio
+
+        elapsed = 0
+        while elapsed < max_wait_s:
+            try:
+                result = await self.ssh_command(instance, "echo ready")
+                if "ready" in result:
+                    return True
+            except Exception:
+                pass
+            await asyncio.sleep(poll_s)
+            elapsed += poll_s
+
+        logger.warning(
+            "VM %s SSH not available after %ds", instance.instance_id, max_wait_s,
+        )
+        return False
+
+
+# ─── Provider Implementations (Stubs) ────────────────────────────────────────
+
+
+class AWSProvider(VMProvider):
+    """AWS EC2 provider — stub until credentials are configured."""
+
+    @property
+    def name(self) -> str:
+        return "aws"
+
+    async def provision(self, config: dict) -> VMInstance:
+        raise NotImplementedError(
+            "AWS provider not yet implemented. "
+            "Requires: boto3, IAM credentials, VPC/subnet/SG setup. "
+            "Config expects: region, instance_type, image_id, ssh_key_name."
+        )
+
+    async def teardown(self, instance: VMInstance) -> None:
+        raise NotImplementedError("AWS teardown not yet implemented.")
+
+    async def ssh_command(self, instance: VMInstance, cmd: str) -> str:
+        raise NotImplementedError("AWS SSH not yet implemented.")
+
+
+class AzureProvider(VMProvider):
+    """Azure VM provider — stub until credentials are configured."""
+
+    @property
+    def name(self) -> str:
+        return "azure"
+
+    async def provision(self, config: dict) -> VMInstance:
+        raise NotImplementedError(
+            "Azure provider not yet implemented. "
+            "Requires: azure-mgmt-compute SDK, service principal credentials. "
+            "Config expects: region, vm_size, image_reference, ssh_key_name."
+        )
+
+    async def teardown(self, instance: VMInstance) -> None:
+        raise NotImplementedError("Azure teardown not yet implemented.")
+
+    async def ssh_command(self, instance: VMInstance, cmd: str) -> str:
+        raise NotImplementedError("Azure SSH not yet implemented.")
+
+
+class GCPProvider(VMProvider):
+    """GCP Compute Engine provider — stub until credentials are configured."""
+
+    @property
+    def name(self) -> str:
+        return "gcp"
+
+    async def provision(self, config: dict) -> VMInstance:
+        raise NotImplementedError(
+            "GCP provider not yet implemented. "
+            "Requires: google-cloud-compute SDK, service account key. "
+            "Config expects: zone, machine_type, image_family, ssh_key."
+        )
+
+    async def teardown(self, instance: VMInstance) -> None:
+        raise NotImplementedError("GCP teardown not yet implemented.")
+
+    async def ssh_command(self, instance: VMInstance, cmd: str) -> str:
+        raise NotImplementedError("GCP SSH not yet implemented.")
+
+
+# ─── Provider Registry ────────────────────────────────────────────────────────
+
+_PROVIDERS: dict[str, type[VMProvider]] = {
+    "aws": AWSProvider,
+    "azure": AzureProvider,
+    "gcp": GCPProvider,
+}
+
+
+def get_provider(name: str) -> VMProvider:
+    """Get a provider instance by name. Raises KeyError if unknown."""
+    cls = _PROVIDERS.get(name)
+    if cls is None:
+        raise KeyError(
+            f"Unknown VM provider '{name}'. Available: {', '.join(_PROVIDERS.keys())}"
+        )
+    return cls()

--- a/tests/test_scheduler/test_install_test.py
+++ b/tests/test_scheduler/test_install_test.py
@@ -1,0 +1,120 @@
+"""Tests for install test runner and VM provider."""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.scheduler.install_test import classify_error
+from genesis.scheduler.vm_provider import (
+    AWSProvider,
+    AzureProvider,
+    GCPProvider,
+    VMInstance,
+    get_provider,
+)
+
+
+class TestClassifyError:
+    """Error classification for install output."""
+
+    def test_structural_module_not_found(self) -> None:
+        assert classify_error("ModuleNotFoundError: no module named 'foo'") == "structural"
+
+    def test_structural_command_not_found(self) -> None:
+        assert classify_error("bash: ruff: command not found") == "structural"
+
+    def test_structural_import_error(self) -> None:
+        assert classify_error("ImportError: cannot import name 'x'") == "structural"
+
+    def test_structural_permission_denied(self) -> None:
+        assert classify_error("Permission denied (publickey)") == "structural"
+
+    def test_transient_dns(self) -> None:
+        assert classify_error("Could not resolve host github.com") == "transient"
+
+    def test_transient_timeout(self) -> None:
+        assert classify_error("Connection timed out after 30s") == "transient"
+
+    def test_transient_apt_mirror(self) -> None:
+        assert classify_error("Unable to fetch some archives, maybe run apt-get update") == "transient"
+
+    def test_unknown_generic(self) -> None:
+        assert classify_error("Something else went wrong") == "unknown"
+
+    def test_empty_output(self) -> None:
+        assert classify_error("") == "unknown"
+
+
+class TestVMProviderRegistry:
+    """Provider registry and stub behavior."""
+
+    def test_get_aws_provider(self) -> None:
+        p = get_provider("aws")
+        assert isinstance(p, AWSProvider)
+        assert p.name == "aws"
+
+    def test_get_azure_provider(self) -> None:
+        p = get_provider("azure")
+        assert isinstance(p, AzureProvider)
+        assert p.name == "azure"
+
+    def test_get_gcp_provider(self) -> None:
+        p = get_provider("gcp")
+        assert isinstance(p, GCPProvider)
+        assert p.name == "gcp"
+
+    def test_unknown_provider_raises(self) -> None:
+        with pytest.raises(KeyError, match="Unknown VM provider"):
+            get_provider("digitalocean")
+
+    @pytest.mark.asyncio
+    async def test_aws_provision_not_implemented(self) -> None:
+        p = AWSProvider()
+        with pytest.raises(NotImplementedError, match="AWS provider"):
+            await p.provision({})
+
+    @pytest.mark.asyncio
+    async def test_azure_provision_not_implemented(self) -> None:
+        p = AzureProvider()
+        with pytest.raises(NotImplementedError, match="Azure provider"):
+            await p.provision({})
+
+    @pytest.mark.asyncio
+    async def test_gcp_provision_not_implemented(self) -> None:
+        p = GCPProvider()
+        with pytest.raises(NotImplementedError, match="GCP provider"):
+            await p.provision({})
+
+
+class TestVMInstance:
+    """VMInstance dataclass."""
+
+    def test_defaults(self) -> None:
+        vm = VMInstance(instance_id="i-123", provider="aws", ip="1.2.3.4")
+        assert vm.ssh_user == "ubuntu"
+        assert vm.region == ""
+        assert vm.metadata == {}
+
+    def test_custom_fields(self) -> None:
+        vm = VMInstance(
+            instance_id="i-456",
+            provider="gcp",
+            ip="10.0.0.1",
+            ssh_user="admin",
+            region="us-central1-a",
+            metadata={"zone": "a"},
+        )
+        assert vm.provider == "gcp"
+        assert vm.ssh_user == "admin"
+        assert vm.metadata["zone"] == "a"
+
+
+@pytest.mark.asyncio
+async def test_run_install_test_not_implemented():
+    """Running with a stub provider returns config error."""
+    from genesis.scheduler.install_test import run_install_test
+
+    result = await run_install_test({"provider": "aws"})
+    assert not result["success"]
+    assert result["error_type"] == "config"
+    assert "not yet implemented" in result["error_message"].lower()


### PR DESCRIPTION
## Summary

- **VMProvider protocol** — abstract base for cloud VM lifecycle (provision/teardown/ssh_command/wait_for_ssh)
- **Provider stubs** — AWS, Azure, GCP implementations (raise NotImplementedError until accounts configured)
- **Install test runner** — full orchestration: provision VM → clone repo → run `install.sh --non-interactive` → smoke tests → teardown → Telegram notification
- **Error classification** — distinguishes structural errors (code bugs) from transient (network) to avoid false-positive PRs
- **19 tests** — error classifier, provider registry, VMInstance dataclass, end-to-end stub behavior

Blocked on cloud account setup. Once credentials are configured, implement the provider (likely AWS first) and register the install test as a user job via `user_job_create`.

## Test plan

- [x] `ruff check` passes
- [x] 19 tests pass (all testable paths without cloud credentials)
- [ ] CI passes
- [ ] When account is ready: implement AWS provider, run `user_job_create` with `job_type: install_test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)