### PR TITLE
refactor(ego): remove budget gating — cost is observational only

### DIFF
--- a/config/ego.yaml
+++ b/config/ego.yaml
@@ -21,10 +21,6 @@ morning_report_effort: low   # effort for morning reports
 board_size: 3                # max active proposals on the bulletin board
 batch_digest: true           # send proposals as batch (vs individual)
 
-# Budget
-ego_thinking_budget_usd: 10.0  # daily cap for ego cycle (thinking) costs — shadow API pricing, not real spend on subscription
-ego_dispatch_budget_usd: 2.50 # daily cap for dispatched background sessions
-
 # Morning report
 morning_report_hour: 8       # 24h format, local time
 morning_report_minute: 0

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -43,28 +43,20 @@ async def ego_status():
     with contextlib.suppress(Exception):
         dispatch_cost = await ego_crud.daily_dispatch_cost(rt._db)
 
+    # Rolling 7-day average (observational only — no gating)
+    rolling_avg = 0.0
+    with contextlib.suppress(Exception):
+        rolling_avg = await ego_crud.rolling_daily_ego_cost(rt._db, days=7)
+
     return jsonify({
         "enabled": config.enabled,
         "model": config.model,
         "default_effort": config.default_effort,
         "morning_report_effort": config.morning_report_effort,
         "cadence_minutes": config.cadence_minutes,
-        "ego_thinking_budget_usd": config.ego_thinking_budget_usd,
-        "ego_dispatch_budget_usd": config.ego_dispatch_budget_usd,
         "daily_cost_usd": round(daily_cost, 4),
         "daily_dispatch_cost_usd": round(dispatch_cost, 4),
-        "thinking_budget_remaining_usd": round(
-            max(0, config.ego_thinking_budget_usd - daily_cost), 4,
-        ),
-        "dispatch_budget_remaining_usd": round(
-            max(0, config.ego_dispatch_budget_usd - dispatch_cost), 4,
-        ),
-        # Backwards compat: total budget view
-        "daily_budget_cap_usd": config.ego_thinking_budget_usd + config.ego_dispatch_budget_usd,
-        "budget_remaining_usd": round(
-            max(0, (config.ego_thinking_budget_usd - daily_cost)
-                + (config.ego_dispatch_budget_usd - dispatch_cost)), 4,
-        ),
+        "rolling_daily_avg_usd": round(rolling_avg, 4),
         "focus_summary": focus,
         "last_cycle": last_cycle,
         "pending_proposals": len(pending),

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1455,8 +1455,6 @@
           activity_threshold_minutes: 'Activity Threshold (min)',
           max_interval_minutes: 'Max Interval (min)', backoff_multiplier: 'Backoff Multiplier',
           board_size: 'Board Size', batch_digest: 'Batch Digest',
-          ego_thinking_budget_usd: 'Thinking Budget ($)',
-          ego_dispatch_budget_usd: 'Dispatch Budget ($)',
           morning_report_hour: 'Morning Report Hour', morning_report_minute: 'Morning Report Minute',
           shadow_morning_report: 'Shadow Morning Report',
           consecutive_failure_limit: 'Failure Limit', failure_backoff_minutes: 'Failure Backoff (min)',
@@ -1524,8 +1522,6 @@
           backoff_multiplier: 'How much to increase interval on idle cycles',
           board_size: 'Max active proposals on the bulletin board (ego tables excess)',
           batch_digest: 'Bundle ego proposals into periodic digests instead of individual messages',
-          ego_thinking_budget_usd: 'Daily cap for ego cycle (thinking) costs',
-          ego_dispatch_budget_usd: 'Daily cap for dispatched background sessions',
           morning_report_hour: 'Hour (0\u201323) to send the daily morning report',
           morning_report_minute: 'Minute (0\u201359) for morning report delivery',
           shadow_morning_report: 'Send reports to a test topic for validation before going live',
@@ -2490,14 +2486,6 @@
             if (cadence.is_paused) {
               return { state: "degraded", reason: "ego paused" };
             }
-          }
-          // Budget exhausted
-          if (ego.daily_budget_cap_usd > 0 && ego.budget_remaining_usd <= 0) {
-            return { state: "error", reason: "daily budget exhausted" };
-          }
-          // Budget >80%
-          if (ego.daily_budget_cap_usd > 0 && ego.daily_cost_usd / ego.daily_budget_cap_usd > 0.8) {
-            return { state: "degraded", reason: `budget ${Math.round(ego.daily_cost_usd / ego.daily_budget_cap_usd * 100)}% used` };
           }
           // Proposals piling up
           if (ego.pending_proposals > 5) {
@@ -4157,13 +4145,10 @@
                         :style="`background: ${$store.genesisDashboard.semanticStateColor($store.genesisDashboard.egoSemantic().state)}`"></span>
                   <span style="font-size: 0.82rem"
                         x-text="$store.genesisDashboard.egoStatus?.focus_summary || 'no focus'"></span>
-                  <!-- Budget gauge -->
-                  <div style="margin-top: 0.3rem; display: flex; align-items: center; gap: 0.4rem;">
-                    <div style="flex: 1; height: 4px; background: rgba(255,255,255,0.1); border-radius: 2px; overflow: hidden;">
-                      <div :style="`width: ${Math.min(100, ($store.genesisDashboard.egoStatus?.daily_cost_usd || 0) / ($store.genesisDashboard.egoStatus?.daily_budget_cap_usd || 1) * 100)}%; height: 100%; border-radius: 2px; background: ${($store.genesisDashboard.egoStatus?.daily_cost_usd || 0) / ($store.genesisDashboard.egoStatus?.daily_budget_cap_usd || 1) > 0.8 ? '#d9534f' : ($store.genesisDashboard.egoStatus?.daily_cost_usd || 0) / ($store.genesisDashboard.egoStatus?.daily_budget_cap_usd || 1) > 0.5 ? '#f0ad4e' : '#4caf50'}`"></div>
-                    </div>
+                  <!-- Daily cost (observational) -->
+                  <div style="margin-top: 0.3rem;">
                     <span style="font-size: 0.68rem; color: var(--color-text-secondary);"
-                          x-text="'$' + ($store.genesisDashboard.egoStatus?.daily_cost_usd || 0).toFixed(2) + ' / $' + ($store.genesisDashboard.egoStatus?.daily_budget_cap_usd || 0).toFixed(2)"></span>
+                          x-text="'$' + ($store.genesisDashboard.egoStatus?.daily_cost_usd || 0).toFixed(2) + ' today (avg: $' + ($store.genesisDashboard.egoStatus?.rolling_daily_avg_usd || 0).toFixed(2) + '/day)'"></span>
                   </div>
                   <div class="health-card-detail" style="font-size: 0.72rem;"
                        x-text="($store.genesisDashboard.egoStatus?.pending_proposals || 0) + ' pending proposals'"></div>
@@ -6563,17 +6548,14 @@
                     <span style="font-size: 0.82rem; color: var(--color-text-secondary);">Cadence manager not available</span>
                   </template>
                 </div>
-                <!-- Budget -->
+                <!-- Daily Cost (observational) -->
                 <div style="background: rgba(255,255,255,0.03); border: 1px solid var(--color-border); border-radius: 6px; padding: 0.8rem;">
-                  <div style="font-size: 0.72rem; color: var(--color-text-secondary); font-weight: 600; margin-bottom: 0.3rem;">Daily Budget</div>
+                  <div style="font-size: 0.72rem; color: var(--color-text-secondary); font-weight: 600; margin-bottom: 0.3rem;">Daily Cost</div>
                   <div style="display: flex; align-items: center; gap: 0.5rem;">
                     <span style="font-size: 1.1rem; font-weight: 600;"
                           x-text="'$' + ($store.genesisDashboard.egoStatus?.daily_cost_usd || 0).toFixed(2)"></span>
                     <span style="font-size: 0.78rem; color: var(--color-text-secondary);"
-                          x-text="'/ $' + ($store.genesisDashboard.egoStatus?.daily_budget_cap_usd || 0).toFixed(2)"></span>
-                  </div>
-                  <div style="margin-top: 0.4rem; height: 6px; background: rgba(255,255,255,0.1); border-radius: 3px; overflow: hidden;">
-                    <div :style="`width: ${Math.min(100, ($store.genesisDashboard.egoStatus?.daily_cost_usd || 0) / ($store.genesisDashboard.egoStatus?.daily_budget_cap_usd || 1) * 100)}%; height: 100%; border-radius: 3px; transition: width 0.3s; background: ${($store.genesisDashboard.egoStatus?.daily_cost_usd || 0) / ($store.genesisDashboard.egoStatus?.daily_budget_cap_usd || 1) > 0.8 ? '#d9534f' : ($store.genesisDashboard.egoStatus?.daily_cost_usd || 0) / ($store.genesisDashboard.egoStatus?.daily_budget_cap_usd || 1) > 0.5 ? '#f0ad4e' : '#4caf50'}`"></div>
+                          x-text="'avg $' + ($store.genesisDashboard.egoStatus?.rolling_daily_avg_usd || 0).toFixed(2) + '/day'"></span>
                   </div>
                 </div>
                 <!-- Quick stats -->
@@ -6604,7 +6586,7 @@
                   </select>
                 </div>
               </div>
-              <!-- Model / Cadence / Budget controls -->
+              <!-- Model / Cadence controls -->
               <div style="margin-top: 0.6rem; padding: 0.6rem 0.8rem; background: rgba(192,132,252,0.04); border: 1px solid rgba(192,132,252,0.12); border-radius: 6px; display: grid; grid-template-columns: 1fr 1fr; gap: 0.6rem;">
                 <!-- Model -->
                 <div>
@@ -6619,7 +6601,7 @@
                 </div>
                 <!-- Cadence -->
                 <div>
-                  <div style="font-size: 0.72rem; color: #c084fc; font-weight: 600; margin-bottom: 0.2rem;">Cadence (min)</div>
+                  <div style="font-size: 0.72rem; color: #c084fc; font-weight: 600; margin-bottom: 0.2rem;">Base Cadence</div>
                   <select style="width: 100%; background: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-border); border-radius: 4px; padding: 0.3rem 0.5rem; font-size: 0.82rem;"
                           @change="fetchApi('/api/genesis/settings/ego', { method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({cadence_minutes: parseInt($event.target.value)}) })">
                     <template x-for="c in [30, 60, 120, 240]" :key="c">
@@ -6628,31 +6610,9 @@
                     </template>
                   </select>
                 </div>
-                <!-- Thinking Budget -->
-                <div>
-                  <div style="font-size: 0.72rem; color: #c084fc; font-weight: 600; margin-bottom: 0.2rem;">Think Budget</div>
-                  <select style="width: 100%; background: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-border); border-radius: 4px; padding: 0.3rem 0.5rem; font-size: 0.82rem;"
-                          @change="fetchApi('/api/genesis/settings/ego', { method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({ego_thinking_budget_usd: parseFloat($event.target.value)}) })">
-                    <template x-for="b in [2, 5, 10, 15, 20]" :key="b">
-                      <option :value="b" x-text="'$' + b + '/day'"
-                              :selected="b === ($store.genesisDashboard.egoStatus?.ego_thinking_budget_usd || 10)"></option>
-                    </template>
-                  </select>
-                </div>
-                <!-- Dispatch Budget -->
-                <div>
-                  <div style="font-size: 0.72rem; color: #c084fc; font-weight: 600; margin-bottom: 0.2rem;">Dispatch Budget</div>
-                  <select style="width: 100%; background: var(--color-bg-secondary); color: var(--color-text-primary); border: 1px solid var(--color-border); border-radius: 4px; padding: 0.3rem 0.5rem; font-size: 0.82rem;"
-                          @change="fetchApi('/api/genesis/settings/ego', { method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({ego_dispatch_budget_usd: parseFloat($event.target.value)}) })">
-                    <template x-for="b in [1, 2.5, 5, 10]" :key="b">
-                      <option :value="b" x-text="'$' + b + '/day'"
-                              :selected="b === ($store.genesisDashboard.egoStatus?.ego_dispatch_budget_usd || 2.5)"></option>
-                    </template>
-                  </select>
-                </div>
               </div>
               <div style="font-size: 0.65rem; color: var(--color-text-secondary); margin-top: 0.3rem; padding: 0 0.8rem;">
-                Changes saved to local overlay. Restart server to apply.
+                Adaptive cadence: runs at base interval when active, backs off up to 4h when idle. Currently every <span x-text="$store.genesisDashboard.egoCadence?.current_interval_minutes || '?'"></span>min. Changes saved to local overlay. Restart server to apply.
               </div>
               <!-- Last cycle -->
               <template x-if="$store.genesisDashboard.egoStatus?.last_cycle">

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -749,6 +749,30 @@ async def daily_dispatch_cost(
         return 0.0
 
 
+async def rolling_daily_ego_cost(
+    db: aiosqlite.Connection,
+    *,
+    days: int = 7,
+) -> float:
+    """Average daily ego cycle cost over the last N days.
+
+    Returns 0.0 if no cycles found. Used for observational display only.
+    """
+    from datetime import timedelta
+
+    end_date = datetime.now(UTC).strftime("%Y-%m-%d")
+    start_date = (datetime.now(UTC) - timedelta(days=days)).strftime("%Y-%m-%d")
+    async with db.execute(
+        "SELECT COALESCE(SUM(cost_usd), 0.0) FROM ego_cycles "
+        "WHERE created_at >= ? || 'T00:00:00' "
+        "AND created_at < ? || 'T00:00:00'",
+        (start_date, end_date),
+    ) as cur:
+        row = await cur.fetchone()
+        total = float(row[0]) if row else 0.0
+    return round(total / max(days, 1), 4)
+
+
 # ---------------------------------------------------------------------------
 # ego_directives
 # ---------------------------------------------------------------------------

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -18,7 +18,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
-from genesis.ego.session import BudgetExceededError, CycleBlockedError
+from genesis.ego.session import CycleBlockedError
 from genesis.ego.types import EgoConfig
 from genesis.env import user_timezone
 
@@ -279,7 +279,7 @@ class EgoCadenceManager:
                         cycle = await self._session.run_cycle(
                             cycle_type=CycleType.REACTIVE,
                         )
-                    except (BudgetExceededError, CycleBlockedError) as exc:
+                    except CycleBlockedError as exc:
                         logger.info("Reactive cycle gated: %s", exc)
                         continue
                     except Exception:
@@ -389,11 +389,6 @@ class EgoCadenceManager:
                 cycle = await self._session.run_cycle(
                     model_override=model_override,
                 )
-            except BudgetExceededError:
-                # Budget exhaustion is intentional, not a failure.
-                # Don't trip the circuit breaker.
-                logger.info("Ego cycle skipped — budget exceeded")
-                return
             except CycleBlockedError as exc:
                 # Approval gate is a gate, not a failure.
                 # Don't trip the circuit breaker.
@@ -434,9 +429,6 @@ class EgoCadenceManager:
 
             try:
                 cycle = await self._session.run_cycle(is_morning_report=True)
-            except BudgetExceededError:
-                logger.info("Ego morning report skipped — budget exceeded")
-                return
             except CycleBlockedError as exc:
                 logger.info("Ego morning report gated: %s", exc)
                 return

--- a/src/genesis/ego/config.py
+++ b/src/genesis/ego/config.py
@@ -98,14 +98,6 @@ def validate_ego_config(changes: dict) -> list[str]:
         valid_models = {"opus", "sonnet", "haiku"}
         if changes["model"] not in valid_models:
             errors.append(f"model must be one of {valid_models}")
-    if "ego_thinking_budget_usd" in changes:
-        v = changes["ego_thinking_budget_usd"]
-        if not isinstance(v, (int, float)) or v < 0:
-            errors.append("ego_thinking_budget_usd must be >= 0")
-    if "ego_dispatch_budget_usd" in changes:
-        v = changes["ego_dispatch_budget_usd"]
-        if not isinstance(v, (int, float)) or v < 0:
-            errors.append("ego_dispatch_budget_usd must be >= 0")
     if "board_size" in changes:
         v = changes["board_size"]
         if not isinstance(v, int) or v < 1:

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -292,7 +292,6 @@ class EgoSession:
         actionable or the CC invocation failed.
 
         Raises:
-            BudgetExceededError: Daily budget cap exceeded.
             CycleBlockedError: Approval gate blocked the cycle.
         """
         if not signals:
@@ -303,7 +302,7 @@ class EgoSession:
         if focus is None:
             return None
 
-        # 2. THINK — budget, context, prompt, invoke
+        # 2. THINK — context, prompt, invoke
 
         # Context assembly — uses assemble_context() as-is.
         # Context weights are DEFINED in focus.py lookup table but NOT

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -59,10 +59,6 @@ _DEFAULT_CALL_SITE = "7_ego_cycle"
 _DEFAULT_FOCUS_SUMMARY_KEY = "ego_focus_summary"
 
 
-class BudgetExceededError(Exception):
-    """Raised when the ego's daily budget cap is exceeded."""
-
-
 class CycleBlockedError(Exception):
     """Raised when the ego cycle is blocked by an approval gate.
 
@@ -168,7 +164,6 @@ class EgoSession:
         Returns the stored EgoCycle, or None if the cycle failed (CC error).
 
         Raises:
-            BudgetExceededError: Daily budget cap exceeded (not a failure).
             CycleBlockedError: Approval gate blocked the cycle (not a failure).
         """
         # Resolve cycle type
@@ -186,13 +181,7 @@ class EgoSession:
         if model_override:
             model = CCModel(model_override)
 
-        # 1. Budget check — raises BudgetExceededError (not a failure)
-        if not await self._check_budget():
-            raise BudgetExceededError(
-                f"Daily ego thinking spend exceeds cap ${self._config.ego_thinking_budget_usd}"
-            )
-
-        # 2. Assemble operational context (previous focus + fresh context)
+        # 1. Assemble operational context (previous focus + fresh context)
         dynamic_context = await self._compaction.assemble_context(
             context_builder=self._context_builder,
         )
@@ -315,13 +304,6 @@ class EgoSession:
             return None
 
         # 2. THINK — budget, context, prompt, invoke
-
-        # Budget check
-        if not await self._check_budget():
-            raise BudgetExceededError(
-                f"Daily ego thinking spend exceeds cap "
-                f"${self._config.ego_thinking_budget_usd}"
-            )
 
         # Context assembly — uses assemble_context() as-is.
         # Context weights are DEFINED in focus.py lookup table but NOT
@@ -1102,11 +1084,6 @@ class EgoSession:
             logger.warning("No DirectSessionRunner — cannot dispatch execution briefs")
             return
 
-        # Check dispatch budget before spawning any sessions
-        if not await self._check_dispatch_budget():
-            logger.warning("Dispatch budget exceeded — skipping execution briefs")
-            return
-
         from genesis.cc.direct_session import VALID_PROFILES, DirectSessionRequest
         from genesis.cc.types import CCModel, EffortLevel
 
@@ -1365,10 +1342,6 @@ class EgoSession:
         if self._direct_session_runner is None:
             return []
 
-        if not await self._check_dispatch_budget():
-            logger.info("Sweep skipped — dispatch budget exceeded")
-            return []
-
         from genesis.cc.direct_session import DirectSessionRequest
 
         approved = await ego_crud.list_proposals(
@@ -1527,36 +1500,6 @@ class EgoSession:
             await tm.send_to_category("ego_proposals", msg)
         except Exception:
             logger.debug("Failed to send execution notification", exc_info=True)
-
-    async def _check_budget(self) -> bool:
-        """True if daily ego thinking spend is under the budget cap."""
-        try:
-            daily = await ego_crud.daily_ego_cost(self._db)
-            if daily >= self._config.ego_thinking_budget_usd:
-                logger.warning(
-                    "Ego thinking spend $%.2f exceeds cap $%.2f",
-                    daily,
-                    self._config.ego_thinking_budget_usd,
-                )
-                return False
-        except Exception:
-            logger.warning("Budget check failed — allowing cycle", exc_info=True)
-        return True
-
-    async def _check_dispatch_budget(self) -> bool:
-        """True if daily ego dispatch spend is under the budget cap."""
-        try:
-            daily = await ego_crud.daily_dispatch_cost(self._db)
-            if daily >= self._config.ego_dispatch_budget_usd:
-                logger.warning(
-                    "Ego dispatch spend $%.2f exceeds cap $%.2f",
-                    daily,
-                    self._config.ego_dispatch_budget_usd,
-                )
-                return False
-        except Exception:
-            logger.warning("Dispatch budget check failed — allowing", exc_info=True)
-        return True
 
 
 # -- Realist prompt & parser -----------------------------------------------

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -142,8 +142,6 @@ class EgoConfig:
     morning_report_effort: str = "low"  # effort for morning reports
     morning_report_enabled: bool = True  # set False for Genesis ego
     board_size: int = 3  # max active proposals on the board
-    ego_thinking_budget_usd: float = 10.0  # daily cap for ego cycle costs (shadow API pricing)
-    ego_dispatch_budget_usd: float = 2.50  # daily cap for dispatched sessions
     morning_report_hour: int = 8  # 24h format, local time
     morning_report_minute: int = 0
     # morning_report_timezone removed — uses genesis.env.user_timezone()

--- a/src/genesis/runtime/init/ego.py
+++ b/src/genesis/runtime/init/ego.py
@@ -153,8 +153,6 @@ async def init(rt: GenesisRuntime) -> None:
             default_effort="high",
             cadence_minutes=max(config.cadence_minutes, 60),
             morning_report_enabled=False,
-            ego_thinking_budget_usd=2.0,
-            ego_dispatch_budget_usd=1.0,
         )
 
         # NOTE: "8_genesis_ego_compaction" is an OBSERVABILITY LABEL only

--- a/tests/ego/test_config.py
+++ b/tests/ego/test_config.py
@@ -25,19 +25,14 @@ class TestLoadEgoConfig:
         assert config.enabled is True
         assert config.cadence_minutes == 60
         assert config.model == "opus"
-        assert config.ego_thinking_budget_usd == 10.0
-        assert config.ego_dispatch_budget_usd == 2.50
-
     def test_loads_from_yaml(self, tmp_config):
         tmp_config.write_text(yaml.dump({
             "cadence_minutes": 30,
             "model": "sonnet",
-            "ego_thinking_budget_usd": 5.0,
         }))
         config = load_ego_config(tmp_config)
         assert config.cadence_minutes == 30
         assert config.model == "sonnet"
-        assert config.ego_thinking_budget_usd == 5.0
         # Unspecified fields keep defaults
         assert config.enabled is True
         assert config.activity_threshold_minutes == 30
@@ -63,14 +58,12 @@ class TestSaveEgoConfig:
         original = EgoConfig(
             cadence_minutes=45,
             model="sonnet",
-            ego_thinking_budget_usd=5.0,
         )
         save_ego_config(original, tmp_config)
 
         loaded = load_ego_config(tmp_config)
         assert loaded.cadence_minutes == 45
         assert loaded.model == "sonnet"
-        assert loaded.ego_thinking_budget_usd == 5.0
 
     def test_creates_file(self, tmp_config):
         assert not tmp_config.exists()
@@ -88,7 +81,6 @@ class TestValidateEgoConfig:
         errors = validate_ego_config({
             "cadence_minutes": 30,
             "model": "sonnet",
-            "ego_thinking_budget_usd": 5.0,
         })
         assert errors == []
 
@@ -101,10 +93,6 @@ class TestValidateEgoConfig:
         errors = validate_ego_config({"model": "gpt-4"})
         assert len(errors) == 1
         assert "model" in errors[0]
-
-    def test_invalid_budget(self):
-        errors = validate_ego_config({"ego_thinking_budget_usd": -1})
-        assert len(errors) == 1
 
     def test_invalid_morning_hour(self):
         errors = validate_ego_config({"morning_report_hour": 25})
@@ -128,9 +116,8 @@ class TestValidateEgoConfig:
         errors = validate_ego_config({
             "cadence_minutes": -1,
             "model": "invalid",
-            "ego_thinking_budget_usd": -5,
         })
-        assert len(errors) == 3
+        assert len(errors) == 2
 
     def test_empty_changes_valid(self):
         assert validate_ego_config({}) == []

--- a/tests/ego/test_init.py
+++ b/tests/ego/test_init.py
@@ -87,8 +87,7 @@ class TestEgoInitWiring:
             mock_config.enabled = True
             mock_config.cadence_minutes = 60
             mock_config.model = "opus"
-            mock_config.ego_thinking_budget_usd = 4.0
-            mock_config.ego_dispatch_budget_usd = 2.5
+            # Budget fields removed — cost is observational only
             mock_load.return_value = mock_config
 
             mock_cadence = AsyncMock()
@@ -122,8 +121,7 @@ class TestEgoInitWiring:
             mock_config.enabled = True
             mock_config.cadence_minutes = 60
             mock_config.model = "opus"
-            mock_config.ego_thinking_budget_usd = 4.0
-            mock_config.ego_dispatch_budget_usd = 2.5
+            # Budget fields removed — cost is observational only
             mock_load.return_value = mock_config
 
             mock_cadence = AsyncMock()
@@ -154,8 +152,7 @@ class TestEgoInitWiring:
             mock_config.enabled = True
             mock_config.cadence_minutes = 60
             mock_config.model = "opus"
-            mock_config.ego_thinking_budget_usd = 4.0
-            mock_config.ego_dispatch_budget_usd = 2.5
+            # Budget fields removed — cost is observational only
             mock_load.return_value = mock_config
 
             mock_cadence = AsyncMock()
@@ -185,8 +182,7 @@ class TestEgoInitWiring:
             mock_config.enabled = True
             mock_config.cadence_minutes = 60
             mock_config.model = "opus"
-            mock_config.ego_thinking_budget_usd = 4.0
-            mock_config.ego_dispatch_budget_usd = 2.5
+            # Budget fields removed — cost is observational only
             mock_load.return_value = mock_config
 
             mock_cadence = AsyncMock()

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -125,7 +125,7 @@ def dispatcher(db):
 
 @pytest.fixture
 def config():
-    return EgoConfig(ego_thinking_budget_usd=10.0, ego_dispatch_budget_usd=5.0)
+    return EgoConfig()
 
 
 @pytest.fixture
@@ -195,21 +195,6 @@ class TestEgoSession:
 
         call_args = mock_invoker.run.call_args_list[0][0][0]
         assert "MORNING REPORT" in call_args.prompt
-
-    async def test_run_cycle_budget_exceeded(
-        self, ego_session, mock_invoker, db, config,
-    ):
-        """Cycle raises BudgetExceededError when budget is exceeded."""
-        from genesis.ego.session import BudgetExceededError
-
-        # Insert a costly cycle to exhaust budget
-        await ego_crud.create_cycle(
-            db, id="expensive", output_text="x",
-            cost_usd=config.ego_thinking_budget_usd + 1.0,
-        )
-        with pytest.raises(BudgetExceededError):
-            await ego_session.run_cycle()
-        mock_invoker.run.assert_not_called()
 
     async def test_run_cycle_cc_error(
         self, ego_session, mock_invoker, mock_session_manager,
@@ -438,19 +423,6 @@ class TestProcessExecutionBriefs:
 
         # Proposal unchanged (no runner to dispatch)
         prop = await ego_crud.get_proposal(db, "prop_005")
-        assert prop["status"] == "approved"
-
-    async def test_dispatch_budget_exceeded(self, ego_with_runner, mock_direct_runner, db, config):
-        """Dispatch budget exhausted → no spawns."""
-        config.ego_dispatch_budget_usd = 0.0  # Exhausted
-        await self._insert_proposal(db, "prop_006")
-
-        briefs = [{"proposal_id": "prop_006", "prompt": "Do the thing"}]
-        await ego_with_runner._process_execution_briefs(briefs)
-
-        mock_direct_runner.spawn.assert_not_called()
-        # Proposal unchanged
-        prop = await ego_crud.get_proposal(db, "prop_006")
         assert prop["status"] == "approved"
 
     async def test_profile_mapping(self, ego_with_runner, mock_direct_runner, db):

--- a/tests/ego/test_types.py
+++ b/tests/ego/test_types.py
@@ -68,8 +68,6 @@ class TestEgoConfig:
         assert cfg.max_interval_minutes == 240
         assert cfg.model == "opus"
         assert cfg.board_size == 3
-        assert cfg.ego_thinking_budget_usd == 10.0
-        assert cfg.ego_dispatch_budget_usd == 2.50
         assert cfg.consecutive_failure_limit == 3
         assert cfg.batch_digest is True
         assert cfg.shadow_morning_report is True


### PR DESCRIPTION
## Summary
- Remove ego budget enforcement — thinking and dispatch budgets no longer block ego cycles
- Cost tracking (daily_ego_cost, daily_dispatch_cost) remains as pure observability
- Dashboard: replace budget gauge + Think/Dispatch Budget dropdowns with "Daily Cost: $X.XX (avg: $Y.YY/day)"
- Add adaptive cadence explanation to ego modal
- Add rolling_daily_ego_cost() CRUD function for 7-day average

## Why
Budget system was actively harmful:
- Default settings ($10 think / $2.50 dispatch) would hit the cap partway through the day, silently blocking the ego
- Both egos shared the same cost counter — Genesis ego's $2 hardcoded cap was blown by user ego Opus spend
- Dashboard showed confusing "$X / $35" (meaningless sum of two independent caps)
- Budget fights cadence — cadence already controls frequency

## Test plan
- [x] `ruff check` passes (all modified files)
- [x] 513 ego tests pass
- [ ] CI passes
- [ ] Server restart: ego cycles run without "budget exceeded" in logs
- [ ] Dashboard shows cost display instead of budget controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)