### PR TITLE
feat(ego): dual-ego dashboard card + jurisdiction enforcement

### DIFF
--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -10,7 +10,13 @@ from genesis.dashboard._blueprint import _async_route, blueprint
 @blueprint.route("/api/genesis/ego/status")
 @_async_route
 async def ego_status():
-    """Return ego subsystem status: config, recent activity, daily cost."""
+    """Return ego subsystem status: config, recent activity, daily cost.
+
+    Includes per-ego breakdown (user ego + genesis ego) for dual-ego
+    dashboard display.
+    """
+    import contextlib
+
     from genesis.db.crud import ego as ego_crud
     from genesis.ego.config import load_ego_config
     from genesis.runtime import GenesisRuntime
@@ -38,7 +44,6 @@ async def ego_status():
         }
 
     # Dispatch cost from cc_sessions
-    import contextlib
     dispatch_cost = 0.0
     with contextlib.suppress(Exception):
         dispatch_cost = await ego_crud.daily_dispatch_cost(rt._db)
@@ -47,6 +52,64 @@ async def ego_status():
     rolling_avg = 0.0
     with contextlib.suppress(Exception):
         rolling_avg = await ego_crud.rolling_daily_ego_cost(rt._db, days=7)
+
+    # ── Per-ego breakdown ──────────────────────────────────────────────
+    # Split pending proposals by ego_source for per-ego counts
+    user_pending = [p for p in pending if p.get("ego_source") == "user_ego_cycle"]
+    genesis_pending = [p for p in pending if p.get("ego_source") == "genesis_ego_cycle"]
+
+    # Genesis ego focus summary (separate state key)
+    genesis_focus = await ego_crud.get_state(rt._db, "genesis_ego_focus_summary")
+
+    # Cadence state from runtime managers
+    def _cadence_snapshot(mgr) -> dict:
+        if mgr is None:
+            return {"available": False}
+        return {
+            "available": True,
+            "is_running": mgr.is_running,
+            "is_paused": mgr.is_paused,
+            "current_interval_minutes": mgr.current_interval_minutes,
+            "consecutive_failures": mgr.consecutive_failures,
+        }
+
+    user_cadence = _cadence_snapshot(rt._ego_cadence_manager)
+    genesis_cadence = _cadence_snapshot(rt._genesis_ego_cadence_manager)
+
+    # Genesis ego config (derived from base config in init/ego.py)
+    genesis_ego_config = {
+        "model": "sonnet",
+        "default_effort": "high",
+        "cadence_minutes": max(config.cadence_minutes, 60),
+        "morning_report_enabled": False,
+    }
+
+    egos = {
+        "user_ego": {
+            "label": "User Ego",
+            "role": "CEO",
+            "model": config.model,
+            "effort": config.default_effort,
+            "focus_summary": focus or "no focus",
+            "pending_proposals": len(user_pending),
+            "cadence": user_cadence,
+            "cadence_minutes": config.cadence_minutes,
+            "max_interval_minutes": config.max_interval_minutes,
+            "morning_report": config.morning_report_enabled,
+        },
+        "genesis_ego": {
+            "label": "Genesis Ego",
+            "role": "COO",
+            "model": genesis_ego_config["model"],
+            "effort": genesis_ego_config["default_effort"],
+            "focus_summary": genesis_focus or "no focus",
+            "pending_proposals": len(genesis_pending),
+            "cadence": genesis_cadence,
+            "cadence_minutes": genesis_ego_config["cadence_minutes"],
+            "max_interval_minutes": config.max_interval_minutes,
+            "morning_report": False,
+        },
+    }
 
     return jsonify({
         "enabled": config.enabled,
@@ -63,6 +126,7 @@ async def ego_status():
         "uncompacted_cycles": uncompacted,
         "shadow_morning_report": config.shadow_morning_report,
         "board_size": config.board_size,
+        "egos": egos,
     })
 
 

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -2474,15 +2474,29 @@
           const ego = this.egoStatus;
           if (!ego || ego.status === "not_bootstrapped") return { state: "unknown", reason: "ego data unavailable" };
           if (!ego.enabled) return { state: "unknown", reason: "ego disabled by config" };
-          // Circuit breaker / cadence check
+          // Check both egos' cadence state via the per-ego data
+          const ue = ego.egos?.user_ego;
+          const ge = ego.egos?.genesis_ego;
+          const ueCad = ue?.cadence;
+          const geCad = ge?.cadence;
+          // Circuit breaker on either ego
+          if (ueCad?.consecutive_failures >= 3 || geCad?.consecutive_failures >= 3) {
+            const which = (ueCad?.consecutive_failures >= 3 ? "CEO" : "") +
+                          (geCad?.consecutive_failures >= 3 ? (ueCad?.consecutive_failures >= 3 ? " + COO" : "COO") : "");
+            return { state: "error", reason: `circuit open (${which})` };
+          }
+          // Fallback to modal cadence if per-ego data not available yet
           const cadence = this.egoModal.cadence;
-          if (cadence && cadence.available) {
-            if (cadence.consecutive_failures >= 3) {
-              return { state: "error", reason: `circuit open (${cadence.consecutive_failures} consecutive failures)` };
-            }
-            if (cadence.is_paused) {
-              return { state: "degraded", reason: "ego paused" };
-            }
+          if (!ue && cadence?.available) {
+            if (cadence.consecutive_failures >= 3) return { state: "error", reason: `circuit open (${cadence.consecutive_failures} failures)` };
+            if (cadence.is_paused) return { state: "degraded", reason: "ego paused" };
+          }
+          if (ueCad?.is_paused && geCad?.is_paused) {
+            return { state: "degraded", reason: "both egos paused" };
+          }
+          if (ueCad?.is_paused || geCad?.is_paused) {
+            const which = ueCad?.is_paused ? "CEO" : "COO";
+            return { state: "degraded", reason: `${which} paused` };
           }
           // Proposals piling up
           if (ego.pending_proposals > 5) {
@@ -4099,9 +4113,9 @@
             <div class="health-card-reason" x-text="$store.genesisDashboard.surplusSemantic().reason"></div>
           </div>
 
-          <!-- Ego -->
+          <!-- Ego — dual-ego display -->
           <template x-if="$store.genesisDashboard.egoStatus?.enabled">
-            <div class="health-card" title="Ego: autonomous decision-making cycle with adaptive cadence and budget controls."
+            <div class="health-card" title="Ego: dual autonomous decision-making cycles with adaptive cadence."
                  style="cursor: pointer;" @click="$store.genesisDashboard.egoModal.open = true; $store.genesisDashboard.fetchEgoDetail()">
               <div class="health-card-header">
                 <div class="health-card-title">Ego <span style="font-size: 0.6rem; opacity: 0.5;">click for details</span></div>
@@ -4109,19 +4123,65 @@
                       :style="`color:${$store.genesisDashboard.semanticStateColor($store.genesisDashboard.egoSemantic().state)}`"
                       x-text="$store.genesisDashboard.egoSemantic().state"></span>
               </div>
-              <div class="health-card-value">
-                <div>
-                  <span class="status-dot"
-                        :style="`background: ${$store.genesisDashboard.semanticStateColor($store.genesisDashboard.egoSemantic().state)}`"></span>
-                  <span style="font-size: 0.82rem"
-                        x-text="$store.genesisDashboard.egoStatus?.focus_summary || 'no focus'"></span>
-                  <!-- Daily cost (observational) -->
-                  <div style="margin-top: 0.3rem;">
-                    <span style="font-size: 0.68rem; color: var(--color-text-secondary);"
-                          x-text="'$' + ($store.genesisDashboard.egoStatus?.daily_cost_usd || 0).toFixed(2) + ' today (avg: $' + ($store.genesisDashboard.egoStatus?.rolling_daily_avg_usd || 0).toFixed(2) + '/day)'"></span>
+              <div class="health-card-value" style="width: 100%;">
+                <!-- User Ego (CEO) row -->
+                <div x-data="{ ue: $store.genesisDashboard.egoStatus?.egos?.user_ego }" style="margin-bottom: 0.4rem;">
+                  <div style="display: flex; align-items: center; gap: 0.4rem; margin-bottom: 0.15rem;">
+                    <span style="font-size: 0.72rem; font-weight: 600; color: #c084fc; min-width: 2.8rem;">CEO</span>
+                    <span style="font-size: 0.68rem; opacity: 0.6;" x-text="ue?.model || '?'"></span>
+                    <template x-if="ue?.pending_proposals > 0">
+                      <span style="font-size: 0.62rem; background: rgba(192,132,252,0.2); color: #c084fc; padding: 0 0.3rem; border-radius: 3px;"
+                            x-text="ue.pending_proposals + ' pending'"></span>
+                    </template>
                   </div>
-                  <div class="health-card-detail" style="font-size: 0.72rem;"
-                       x-text="($store.genesisDashboard.egoStatus?.pending_proposals || 0) + ' pending proposals'"></div>
+                  <!-- Cadence progress bar -->
+                  <div style="display: flex; align-items: center; gap: 0.3rem;">
+                    <div style="flex: 1; height: 4px; background: rgba(255,255,255,0.08); border-radius: 2px; overflow: hidden;"
+                         :title="'Interval: ' + (ue?.cadence?.current_interval_minutes || ue?.cadence_minutes || '?') + 'min / ' + (ue?.max_interval_minutes || 240) + 'min max'">
+                      <div :style="(() => {
+                        const cur = ue?.cadence?.current_interval_minutes || ue?.cadence_minutes || 60;
+                        const base = ue?.cadence_minutes || 60;
+                        const max = ue?.max_interval_minutes || 240;
+                        const pct = Math.min(100, (cur / max) * 100);
+                        const color = cur <= base ? '#4caf50' : cur < max * 0.75 ? '#f0ad4e' : '#d9534f';
+                        return `width: ${pct}%; height: 100%; background: ${color}; border-radius: 2px; transition: width 0.5s;`;
+                      })()"></div>
+                    </div>
+                    <span style="font-size: 0.6rem; color: var(--color-text-secondary); min-width: 2.2rem; text-align: right;"
+                          x-text="(ue?.cadence?.current_interval_minutes || ue?.cadence_minutes || '?') + 'm'"></span>
+                  </div>
+                </div>
+                <!-- Genesis Ego (COO) row -->
+                <div x-data="{ ge: $store.genesisDashboard.egoStatus?.egos?.genesis_ego }">
+                  <div style="display: flex; align-items: center; gap: 0.4rem; margin-bottom: 0.15rem;">
+                    <span style="font-size: 0.72rem; font-weight: 600; color: #60a5fa; min-width: 2.8rem;">COO</span>
+                    <span style="font-size: 0.68rem; opacity: 0.6;" x-text="ge?.model || '?'"></span>
+                    <template x-if="ge?.pending_proposals > 0">
+                      <span style="font-size: 0.62rem; background: rgba(96,165,250,0.2); color: #60a5fa; padding: 0 0.3rem; border-radius: 3px;"
+                            x-text="ge.pending_proposals + ' pending'"></span>
+                    </template>
+                  </div>
+                  <!-- Cadence progress bar -->
+                  <div style="display: flex; align-items: center; gap: 0.3rem;">
+                    <div style="flex: 1; height: 4px; background: rgba(255,255,255,0.08); border-radius: 2px; overflow: hidden;"
+                         :title="'Interval: ' + (ge?.cadence?.current_interval_minutes || ge?.cadence_minutes || '?') + 'min / ' + (ge?.max_interval_minutes || 240) + 'min max'">
+                      <div :style="(() => {
+                        const cur = ge?.cadence?.current_interval_minutes || ge?.cadence_minutes || 60;
+                        const base = ge?.cadence_minutes || 60;
+                        const max = ge?.max_interval_minutes || 240;
+                        const pct = Math.min(100, (cur / max) * 100);
+                        const color = cur <= base ? '#4caf50' : cur < max * 0.75 ? '#f0ad4e' : '#d9534f';
+                        return `width: ${pct}%; height: 100%; background: ${color}; border-radius: 2px; transition: width 0.5s;`;
+                      })()"></div>
+                    </div>
+                    <span style="font-size: 0.6rem; color: var(--color-text-secondary); min-width: 2.2rem; text-align: right;"
+                          x-text="(ge?.cadence?.current_interval_minutes || ge?.cadence_minutes || '?') + 'm'"></span>
+                  </div>
+                </div>
+                <!-- Cost footer -->
+                <div style="margin-top: 0.35rem; border-top: 1px solid rgba(255,255,255,0.05); padding-top: 0.25rem;">
+                  <span style="font-size: 0.62rem; color: var(--color-text-secondary);"
+                        x-text="'$' + ($store.genesisDashboard.egoStatus?.daily_cost_usd || 0).toFixed(2) + ' today'"></span>
                 </div>
               </div>
               <div class="health-card-reason" x-text="$store.genesisDashboard.egoSemantic().reason"></div>

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -135,6 +135,21 @@ Add an escalation when:
   escalate the operational issue only. The user ego decides what matters
   to the user. You fix what's broken.
 
+- **HARD BOUNDARY: Your jurisdiction is Genesis infrastructure ONLY.**
+  You are the COO — your domain is system health, performance,
+  maintenance, and operational reliability. You have NO jurisdiction
+  over the user's personal life, career, content strategy, networking,
+  professional development, or external goals. If something falls
+  outside Genesis infrastructure, it belongs to the user ego (CEO).
+  NEVER propose actions in these domains:
+  - Career: job applications, interviews, networking events, conferences
+  - Content: articles, social media, marketing, outreach strategy
+  - Personal: scheduling, reminders, life planning, financial decisions
+  - External tools: services Genesis doesn't operate (LinkedIn, Medium, etc.)
+  If you notice a user-domain issue during infrastructure work (e.g.,
+  an outreach job failed), escalate the infrastructure failure only.
+  Do not propose the user-domain follow-up action.
+
 ### Signal Threshold — What Deserves Your Attention
 
 Not all system changes are worth your cognitive budget. Apply these filters:


### PR DESCRIPTION
## Summary
- **Dual-ego display**: Ego overview card now shows both egos (User CEO/Opus + Genesis COO/Sonnet) with individual cadence progress bars and per-ego pending proposal counts
- **Cadence visualization**: Color-coded progress bars (green=base interval, yellow=backed off, red=near max) showing current interval as proportion of max
- **Jurisdiction enforcement**: Strengthened Genesis ego prompt with explicit hard boundary preventing user-domain proposals (career, content, personal, external tools)

## Changes

### Backend (`dashboard/routes/ego.py`)
- `ego_status` endpoint now returns an `egos` dict with per-ego breakdown:
  - Cadence state (current interval, running/paused, consecutive failures)
  - Per-ego pending proposals count (split by `ego_source`)
  - Genesis ego focus summary (separate state key)
  - Per-ego config (model, effort, cadence_minutes, max_interval)

### Frontend (`genesis_dashboard.html`)
- Ego card redesigned: two rows (CEO purple, COO blue) each with progress bar + interval label
- `egoSemantic()` updated to check both egos' circuit breakers and pause state
- Cost footer condensed to single line

### Prompt (`GENESIS_EGO_SESSION.md`)
- Added "HARD BOUNDARY" section with explicit negative examples
- Lists prohibited domains: career, content, personal, external tools
- Addresses the AI conference proposal incident where Genesis ego proposed user-domain work

## Context
- Addresses follow-up 33fad25a (ego dashboard card regression from PR #435)
- Genesis ego proposal delivery investigated and confirmed as by-design (`stay_quiet` default) — dashboard visibility is the correct fix
- Camoufox "broken" claim from session summary was a documented hallucination — no action needed

## Test plan
- [ ] Load dashboard, verify dual-ego card renders with two progress bars
- [ ] Verify cadence progress bars reflect actual interval (check via `/api/genesis/ego/status`)
- [ ] Verify per-ego pending proposal counts are correct
- [ ] Verify `egoSemantic()` reports circuit breaker state for either ego
- [ ] `ruff check .` passes

Generated with [Claude Code](https://claude.com/claude-code)