### PR TITLE
fix(ego): clarify backlog header in proposal Telegram digests

### DIFF
--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -296,16 +296,26 @@ class ProposalWorkflow:
             warn_lines = "\n".join(f"  - {w}" for w in validation_warnings)
             digest_html = f"\u26a0\ufe0f <b>Validation:</b>\n{warn_lines}\n\n{digest_html}"
 
-        # Show pending count from other batches (same ego only) for visibility
+        # Show pending backlog from other batches (same ego only)
         try:
             all_pending = await ego_crud.list_pending_proposals(
                 self._db, ego_source=ego_source,
             )
             other_pending = [p for p in all_pending if p.get("batch_id") != batch_id]
             if other_pending:
+                summary_lines = []
+                for op in other_pending[:5]:
+                    preview = op.get("content", "")[:60]
+                    if len(op.get("content", "")) > 60:
+                        preview += "\u2026"
+                    action = op.get("action_type", "?")
+                    summary_lines.append(f"  \u2022 [{_ESC(action)}] {_ESC(preview)}")
+                backlog_text = "\n".join(summary_lines)
                 digest_html = (
-                    f"<i>{len(other_pending)} proposal(s) pending from previous "
-                    f"batches. Reply 'approve all pending' to resolve all.</i>\n\n" + digest_html
+                    f"<i>\U0001f4cb {len(other_pending)} older proposal(s) still "
+                    f"awaiting response:</i>\n{backlog_text}\n"
+                    f"<i>Reply 'approve all pending' to resolve all.</i>\n\n"
+                    + digest_html
                 )
         except Exception:
             pass  # Non-critical; skip header on error

--- a/tests/ego/test_delivery_execution.py
+++ b/tests/ego/test_delivery_execution.py
@@ -323,7 +323,7 @@ class TestPendingCountHeader:
         assert delivery_id is not None
         # Check that the sent HTML contains the pending count
         sent_html = mock_tm.send_to_category.call_args[0][1]
-        assert "1 proposal(s) pending from previous batches" in sent_html
+        assert "1 older proposal(s) still awaiting response" in sent_html
         assert "approve all pending" in sent_html
 
 

--- a/tests/ego/test_realist.py
+++ b/tests/ego/test_realist.py
@@ -462,4 +462,4 @@ class TestEgoSourceIsolation:
 
         sent_html = mock_tm.send_to_category.call_args[0][1]
         # Should show 1 pending from old user batch, not 2 (which would include genesis)
-        assert "1 proposal(s) pending" in sent_html
+        assert "1 older proposal(s) still awaiting response" in sent_html


### PR DESCRIPTION
## Summary
- Replace confusing "N proposal(s) pending from previous batches" with clear backlog summaries
- Shows one-line previews of each stale proposal (action type + first 60 chars)
- Capped at 5 items to prevent bloat
- Makes it unambiguous that these are NOT the proposals in the current message

## Test plan
- [x] 68 ego tests pass
- [x] ruff clean
- [ ] CI
- [ ] Post-merge: wait for next ego cycle → verify Telegram shows clear backlog summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)