### PR TITLE
feat(routing): remove direct Anthropic providers, route through OpenRouter

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -58,6 +58,20 @@ providers:
     free: false
     rpm_limit: 20
     open_duration_s: 120
+  openrouter-sonnet:
+    type: openrouter
+    model: anthropic/claude-sonnet-4-6-20250514
+    profile: claude-sonnet-4.6
+    free: false
+    rpm_limit: 20
+    open_duration_s: 120
+  openrouter-opus:
+    type: openrouter
+    model: anthropic/claude-opus-4-6-20250514
+    profile: claude-opus-4.6
+    free: false
+    rpm_limit: 20
+    open_duration_s: 120
   # ── Phase 2 providers (gated on eval before chain promotion) ──
   cerebras-qwen:
     type: cerebras
@@ -154,24 +168,6 @@ providers:
     profile: qwen-3.5-plus
     free: false
     open_duration_s: 120
-  claude-haiku:
-    type: anthropic
-    model: claude-haiku-4-5-20251001
-    profile: claude-haiku-4.5
-    free: false
-    open_duration_s: 120
-  claude-sonnet:
-    type: anthropic
-    model: claude-sonnet-4-6-20250514
-    profile: claude-sonnet-4.6
-    free: false
-    open_duration_s: 120
-  claude-opus:
-    type: anthropic
-    model: claude-opus-4-6-20250514
-    profile: claude-opus-4.6
-    free: false
-    open_duration_s: 120
   glm51:
     type: zenmux
     model: z-ai/glm-5.1
@@ -247,28 +243,28 @@ call_sites:
     never_pays: true
   5_deep_reflection:
     chain:
-    - claude-sonnet
+    - openrouter-sonnet
     default_paid: true
     retry_profile: background
     cc_model: Sonnet
     dispatch: cli
   6_strategic_reflection:
     chain:
-    - claude-opus
+    - openrouter-opus
     default_paid: true
     retry_profile: background
     cc_model: Opus
     dispatch: cli
   7_ego_cycle:
     chain:
-    - claude-opus
+    - openrouter-opus
     default_paid: true
     retry_profile: background
     dispatch: cli
     cc_model: Opus
   8_ego_compaction:
     chain:
-    - claude-haiku
+    - openrouter-haiku
     - mistral-large-free
     default_paid: true
   9_fact_extraction:
@@ -284,7 +280,7 @@ call_sites:
   10_cognitive_state:
     chain:
     - glm51
-    - claude-sonnet
+    - openrouter-sonnet
     default_paid: true
   11_user_model_synthesis:
     chain:
@@ -309,13 +305,13 @@ call_sites:
     - openrouter-free
   14_weekly_self_assessment:
     chain:
-    - claude-opus
+    - openrouter-opus
     default_paid: true
     dispatch: cli
     cc_model: Opus
   16_quality_calibration:
     chain:
-    - claude-sonnet
+    - openrouter-sonnet
     default_paid: true
     dispatch: cli
     cc_model: Sonnet
@@ -531,7 +527,7 @@ call_sites:
       \ (cheap periodic ticks, quality not critical)"
   autonomous_executor_reasoning:
     chain:
-    - claude-sonnet
+    - openrouter-sonnet
     - openrouter-qwen36plus
     - gpt-5.4
     default_paid: true
@@ -539,7 +535,7 @@ call_sites:
     description: Autonomous executor non-tooling reasoning via API
   failure_exit_gate:
     chain:
-    - claude-sonnet
+    - openrouter-sonnet
     - openrouter-qwen36plus
     default_paid: true
     retry_profile: background
@@ -554,7 +550,7 @@ call_sites:
     description: Analyze CC version changes for impact on Genesis
   models_md_synthesis:
     chain:
-    - claude-sonnet
+    - openrouter-sonnet
     default_paid: true
     retry_profile: background
     description: "Weekly models.md synthesis \u2014 updates model catalog from recon findings"
@@ -570,7 +566,7 @@ call_sites:
       \ 29_retrospective_triage and 30_triage_calibration in the learning domain)."
   contribution_gate:
     chain:
-    - claude-haiku
+    - openrouter-haiku
     - groq-free
     - gemini-free
     default_paid: true

--- a/docs/reference/routing-call-sites.md
+++ b/docs/reference/routing-call-sites.md
@@ -178,3 +178,7 @@ New behaviour: keyless providers stay registered in `cfg.providers` with `has_ap
 Call site `11_user_model_synthesis` was originally marked wired (commit `eb5c350`, 2026-04-06) when the surrounding pipeline got wired, but the actual `router.route_call()` invocation was missing — the synthesis path used pure-Python rules-based dict rendering instead.
 
 This was caught during the Sentinel spam investigation: ghost-down status on call site 11 (because Anthropic providers report unreachable without an `ANTHROPIC_API_KEY`) was waking the Sentinel every 5 minutes. The fix: (1) actually wire the LLM call in `runtime/init/learning.py` via `UserModelEvolver.synthesize_narrative()` with a free-first chain (mistral-small → groq → gemini → openrouter), (2) teach the call_sites snapshot to distinguish `not_configured` providers from `unreachable` ones, (3) skip alerts for `disabled` and `wired=False` sites in `health_alerts()`. Call site 11 now does what its name says.
+
+### 2026-05-25 — Remove direct Anthropic providers, route through OpenRouter
+
+All three direct `type: anthropic` providers (`claude-haiku`, `claude-sonnet`, `claude-opus`) removed. Claude models now route through OpenRouter as `openrouter-haiku`, `openrouter-sonnet`, `openrouter-opus`. This eliminates the `ANTHROPIC_API_KEY` dependency for LiteLLM routing — the key is retained only for CC background sessions (which bypass the provider chain entirely via `dispatch: cli`). The ghost-down issue described above is now structurally impossible.

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -45,7 +45,8 @@ GOOGLE_API_KEY=
 API_KEY_OPENROUTER=
 
 # --- Anthropic (Claude API) ---
-# Used by: 7 call sites — deep/strategic reflection, user model synthesis.
+# Used by: Claude Code background sessions (not LiteLLM routing).
+# All LiteLLM call sites now route Claude models through OpenRouter.
 # Signup: console.anthropic.com
 # Paid: per-token pricing
 ANTHROPIC_API_KEY=

--- a/src/genesis/contribution/version_gate.py
+++ b/src/genesis/contribution/version_gate.py
@@ -42,7 +42,7 @@ CONFIDENCE_THRESHOLD = 75
 # Fallback model chain when routing config is unavailable.
 # Production can override by passing `model=...` to `check_version_gate()`.
 _FALLBACK_MODELS = [
-    ("anthropic/claude-haiku-4-5", "ANTHROPIC_API_KEY"),
+    ("openrouter/anthropic/claude-haiku-4.5", "API_KEY_OPENROUTER"),
     ("groq/llama-3.3-70b-versatile", "GROQ_API_KEY"),
     ("gemini/gemini-2.0-flash", "GEMINI_API_KEY"),
 ]
@@ -300,10 +300,10 @@ def _load_models_from_config() -> list[tuple[str, str]]:
         if site is None:
             return []
         # Map provider type to litellm prefix
-        _PREFIX = {"anthropic": "anthropic", "groq": "groq", "google": "gemini"}
+        _PREFIX = {"openrouter": "openrouter", "groq": "groq", "google": "gemini"}
         # Map provider type to conventional env var for API key
         _ENV = {
-            "anthropic": "ANTHROPIC_API_KEY",
+            "openrouter": "API_KEY_OPENROUTER",
             "groq": "GROQ_API_KEY",
             "google": "GEMINI_API_KEY",
         }

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1377,7 +1377,6 @@
           API_KEY_MISTRAL: ['mistral'],
           GOOGLE_API_KEY: ['google'],
           API_KEY_OPENROUTER: ['openrouter'],
-          ANTHROPIC_API_KEY: ['anthropic'],
           API_KEY_DEEPSEEK: ['deepseek'],
           API_KEY_QWEN: ['qwen'],
           API_KEY_ZENMUX: ['zenmux'],

--- a/src/genesis/observability/snapshots/api_keys.py
+++ b/src/genesis/observability/snapshots/api_keys.py
@@ -15,12 +15,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _LOCAL_TYPES = frozenset({"ollama", "lmstudio"})
-# Anthropic providers require ANTHROPIC_API_KEY when configured as direct
-# API providers (via LiteLLM).  CC-dispatched call sites (dispatch=cli)
-# bypass the provider chain entirely and work regardless.  Previously
-# "anthropic" was exempted here, which caused phantom circuit-breaker
-# failures: providers registered without keys, failed every API call,
-# and counted as "down" — triggering false L2 resilience state.
+# Previously Anthropic providers required ANTHROPIC_API_KEY as direct API
+# providers (via LiteLLM).  As of PR #447, all Claude models route through
+# OpenRouter, eliminating the direct Anthropic dependency.  CC-dispatched
+# call sites (dispatch=cli) bypass the provider chain entirely regardless.
 _CC_MANAGED_TYPES: frozenset[str] = frozenset()
 
 

--- a/src/genesis/routing/litellm_delegate.py
+++ b/src/genesis/routing/litellm_delegate.py
@@ -37,7 +37,6 @@ def _should_log_failure(provider: str) -> bool:
 # Maps our config 'type' field to LiteLLM model prefix.
 # See https://docs.litellm.ai/docs/providers
 _TYPE_TO_PREFIX: dict[str, str] = {
-    "anthropic": "anthropic",
     "groq": "groq",
     "mistral": "mistral",
     "google": "gemini",

--- a/src/genesis/skills/onboarding/references/provider-guide.md
+++ b/src/genesis/skills/onboarding/references/provider-guide.md
@@ -90,8 +90,8 @@ about what they can do, not which API to call.
 
 #### Anthropic (Claude API)
 - **Capability:** Heavyweight autonomous reasoning.
-- **What it unlocks:** 13 call sites — deep/strategic reflection, user model
-  synthesis, pre-execution assessment. The tasks that require careful, nuanced thinking.
+- **What it unlocks:** Claude Code background sessions only. All LiteLLM
+  call sites now route Claude models through OpenRouter.
 - **Signup:** console.anthropic.com
 - **Pricing:** Per-token. Higher cost, highest quality.
 - **Important distinction:** Claude Code sessions use the user's CC

--- a/tests/test_autonomy/test_autonomous_dispatch.py
+++ b/tests/test_autonomy/test_autonomous_dispatch.py
@@ -149,7 +149,7 @@ async def test_dispatch_router_uses_api_first(approval_gate):
     router.route_call = AsyncMock(return_value=SimpleNamespace(
         success=True,
         content="api-response",
-        provider_used="claude-sonnet",
+        provider_used="openrouter-sonnet",
         model_id="claude-sonnet-4",
         cost_usd=0.12,
         input_tokens=10,
@@ -779,7 +779,7 @@ def _router_with_dispatch(call_site_id: str, dispatch: str) -> AsyncMock:
     from genesis.routing.types import CallSiteConfig
     site = CallSiteConfig(
         id=call_site_id,
-        chain=["claude-sonnet"],
+        chain=["openrouter-sonnet"],
         dispatch=dispatch,
     )
     router = AsyncMock()
@@ -827,7 +827,7 @@ async def test_dispatch_api_blocks_on_exhaustion(approval_gate):
     router.route_call = AsyncMock(return_value=SimpleNamespace(
         success=False,
         content=None,
-        provider_used="claude-sonnet",
+        provider_used="openrouter-sonnet",
         model_id=None,
         cost_usd=0.0,
         input_tokens=0,
@@ -866,7 +866,7 @@ async def test_dispatch_dual_default_preserves_existing_behavior(approval_gate):
     router.route_call = AsyncMock(return_value=SimpleNamespace(
         success=True,
         content="dual-mode api response",
-        provider_used="claude-sonnet",
+        provider_used="openrouter-sonnet",
         model_id="claude-sonnet-4",
         cost_usd=0.05,
         input_tokens=10,

--- a/tests/test_contribution/test_version_gate.py
+++ b/tests/test_contribution/test_version_gate.py
@@ -188,7 +188,7 @@ async def test_no_api_key_fails_open(monkeypatch):
     fake_commits = [{"sha": "x", "subject": "unrelated", "body": ""}]
     monkeypatch.setattr(version_gate, "fetch_upstream_log", lambda *a, **k: fake_commits)
     # Clear all known keys
-    for var in ("ANTHROPIC_API_KEY", "GROQ_API_KEY", "GEMINI_API_KEY"):
+    for var in ("API_KEY_OPENROUTER", "GROQ_API_KEY", "GEMINI_API_KEY"):
         monkeypatch.delenv(var, raising=False)
     r = await version_gate.check_version_gate(
         user_subject="s", user_body="b", user_diff="d",

--- a/tests/test_dashboard/test_api.py
+++ b/tests/test_dashboard/test_api.py
@@ -457,16 +457,16 @@ def test_routing_config_read_includes_call_sites(client):
     mock_cfg = SimpleNamespace()
     mock_cfg.disabled_providers = {}
     mock_cfg.providers = {
-        "claude-sonnet": SimpleNamespace(
-            name="claude-sonnet",
-            provider_type="anthropic",
-            model_id="claude-sonnet-4-6-20250514",
+        "openrouter-sonnet": SimpleNamespace(
+            name="openrouter-sonnet",
+            provider_type="openrouter",
+            model_id="anthropic/claude-sonnet-4-6-20250514",
             is_free=False,
         ),
     }
     mock_cfg.call_sites = {
         "autonomous_executor_reasoning": SimpleNamespace(
-            chain=["claude-sonnet"],
+            chain=["openrouter-sonnet"],
             default_paid=True,
             never_pays=False,
             retry_profile="background",
@@ -474,7 +474,7 @@ def test_routing_config_read_includes_call_sites(client):
     }
     mock_router = MagicMock()
     mock_router.config = mock_cfg
-    mock_router.breakers = {"claude-sonnet": MagicMock(state=MagicMock(value="closed"))}
+    mock_router.breakers = {"openrouter-sonnet": MagicMock(state=MagicMock(value="closed"))}
     mock_rt = MagicMock()
     mock_rt.is_bootstrapped = True
     mock_rt.router = mock_router
@@ -486,7 +486,7 @@ def test_routing_config_read_includes_call_sites(client):
     assert resp.status_code == 200
     data = resp.get_json()
     assert "autonomous_executor_reasoning" in data["call_sites"]
-    assert data["call_sites"]["autonomous_executor_reasoning"]["chain"] == ["claude-sonnet"]
+    assert data["call_sites"]["autonomous_executor_reasoning"]["chain"] == ["openrouter-sonnet"]
     assert data["call_sites"]["autonomous_executor_reasoning"]["default_paid"] is True
 
 

--- a/tests/test_health_data.py
+++ b/tests/test_health_data.py
@@ -277,14 +277,13 @@ class TestProviderHealth:
 class TestDisabledChainSemantics:
     """Disabled providers must be filtered, not treated as failures.
 
-    The bug this addresses: Anthropic providers (claude-sonnet, claude-opus,
-    claude-haiku) have no ANTHROPIC_API_KEY in this deployment because Genesis
-    accesses Claude only via Claude Code background sessions. The probe
-    correctly returned configured=False, but the call_sites snapshot then
-    treated them as "unreachable → down → CRITICAL alert → Sentinel wake."
+    The bug this originally addressed: providers with missing API keys were
+    treated as "unreachable → down → CRITICAL alert → Sentinel wake."
     The fix: filter disabled providers out of the chain walk, and if every
     provider is disabled, mark the site itself "disabled" (config state, not
-    alert condition).
+    alert condition). Note: direct Anthropic providers were removed in PR #447
+    (all Claude models now route through OpenRouter), but the logic remains
+    important for any keyless provider.
     """
 
     @pytest.mark.asyncio
@@ -333,27 +332,27 @@ class TestDisabledChainSemantics:
         from genesis.observability.snapshots.call_sites import call_sites
 
         providers = {
-            "claude-sonnet": _make_provider("claude-sonnet"),
-            "claude-opus": _make_provider("claude-opus"),
+            "openrouter-sonnet": _make_provider("openrouter-sonnet"),
+            "openrouter-opus": _make_provider("openrouter-opus"),
         }
         config = _make_config(providers, {
             "11_user_model_synthesis": CallSiteConfig(
                 id="11_user_model_synthesis",
-                chain=["claude-sonnet", "claude-opus"],
+                chain=["openrouter-sonnet", "openrouter-opus"],
             ),
         })
         breakers = _mock_registry({
-            "claude-sonnet": _mock_breaker(ProviderState.CLOSED),
-            "claude-opus": _mock_breaker(ProviderState.CLOSED),
+            "openrouter-sonnet": _mock_breaker(ProviderState.CLOSED),
+            "openrouter-opus": _mock_breaker(ProviderState.CLOSED),
         })
         probe_results = {
-            "claude-sonnet": ProviderProbeResult(
-                provider_name="claude-sonnet",
+            "openrouter-sonnet": ProviderProbeResult(
+                provider_name="openrouter-sonnet",
                 reachable=False, configured=False,
                 error="no API key configured",
             ),
-            "claude-opus": ProviderProbeResult(
-                provider_name="claude-opus",
+            "openrouter-opus": ProviderProbeResult(
+                provider_name="openrouter-opus",
                 reachable=False, configured=False,
                 error="no API key configured",
             ),
@@ -372,16 +371,16 @@ class TestDisabledChainSemantics:
         from genesis.observability.provider_health import ProviderProbeResult
         from genesis.observability.snapshots.call_sites import call_sites
 
-        providers = {"claude-sonnet": _make_provider("claude-sonnet")}
+        providers = {"openrouter-sonnet": _make_provider("openrouter-sonnet")}
         config = _make_config(providers, {
-            "test_site": CallSiteConfig(id="test_site", chain=["claude-sonnet"]),
+            "test_site": CallSiteConfig(id="test_site", chain=["openrouter-sonnet"]),
         })
         breakers = _mock_registry({
-            "claude-sonnet": _mock_breaker(ProviderState.CLOSED),
+            "openrouter-sonnet": _mock_breaker(ProviderState.CLOSED),
         })
         probe_results = {
-            "claude-sonnet": ProviderProbeResult(
-                provider_name="claude-sonnet",
+            "openrouter-sonnet": ProviderProbeResult(
+                provider_name="openrouter-sonnet",
                 reachable=False, configured=False,
                 error="no API key configured",
             ),
@@ -405,17 +404,17 @@ class TestDisabledChainSemantics:
         from genesis.observability.snapshots.call_sites import call_sites
 
         providers = {
-            "claude-sonnet": dataclasses.replace(
-                _make_provider("claude-sonnet"),
-                provider_type="anthropic",
+            "openrouter-sonnet": dataclasses.replace(
+                _make_provider("openrouter-sonnet"),
+                provider_type="openrouter",
                 has_api_key=False,
             ),
         }
         config = _make_config(providers, {
-            "test_site": CallSiteConfig(id="test_site", chain=["claude-sonnet"]),
+            "test_site": CallSiteConfig(id="test_site", chain=["openrouter-sonnet"]),
         })
         breakers = _mock_registry({
-            "claude-sonnet": _mock_breaker(ProviderState.CLOSED),
+            "openrouter-sonnet": _mock_breaker(ProviderState.CLOSED),
         })
         # No probe_results — cold-start condition
         result = await call_sites(
@@ -424,7 +423,7 @@ class TestDisabledChainSemantics:
         )
         chain = result["test_site"]["chain_health"]
         assert chain[0]["has_api_key"] is False
-        assert chain[0]["missing_env_var"] == "API_KEY_ANTHROPIC"
+        assert chain[0]["missing_env_var"] == "API_KEY_OPENROUTER"
 
     @pytest.mark.asyncio
     async def test_keyless_chain_cascades_to_disabled_no_probes(self):
@@ -444,18 +443,18 @@ class TestDisabledChainSemantics:
             "p_zenmux": dataclasses.replace(
                 _make_provider("p_zenmux"), provider_type="zenmux", has_api_key=False,
             ),
-            "p_anthropic": dataclasses.replace(
-                _make_provider("p_anthropic"), provider_type="anthropic", has_api_key=False,
+            "p_openrouter": dataclasses.replace(
+                _make_provider("p_openrouter"), provider_type="openrouter", has_api_key=False,
             ),
         }
         config = _make_config(providers, {
             "active_site_with_no_keys": CallSiteConfig(
-                id="active_site_with_no_keys", chain=["p_zenmux", "p_anthropic"],
+                id="active_site_with_no_keys", chain=["p_zenmux", "p_openrouter"],
             ),
         })
         breakers = _mock_registry({
             "p_zenmux": _mock_breaker(ProviderState.CLOSED),
-            "p_anthropic": _mock_breaker(ProviderState.CLOSED),
+            "p_openrouter": _mock_breaker(ProviderState.CLOSED),
         })
         result = await call_sites(
             db=None, routing_config=config, breakers=breakers,
@@ -467,7 +466,7 @@ class TestDisabledChainSemantics:
         assert site["status_reason"] == "NO_API_KEYS"
         # Both chain entries must surface their missing env var
         env_vars = {c["missing_env_var"] for c in site["chain_health"]}
-        assert env_vars == {"API_KEY_ZENMUX", "API_KEY_ANTHROPIC"}
+        assert env_vars == {"API_KEY_ZENMUX", "API_KEY_OPENROUTER"}
 
     @pytest.mark.asyncio
     async def test_intrinsic_status_reason_wins_over_no_api_keys(self):
@@ -482,18 +481,18 @@ class TestDisabledChainSemantics:
         from genesis.observability.snapshots.call_sites import call_sites
 
         providers = {
-            "claude-sonnet": dataclasses.replace(
-                _make_provider("claude-sonnet"),
-                provider_type="anthropic", has_api_key=False,
+            "openrouter-sonnet": dataclasses.replace(
+                _make_provider("openrouter-sonnet"),
+                provider_type="openrouter", has_api_key=False,
             ),
         }
         config = _make_config(providers, {
             "future_site": CallSiteConfig(
-                id="future_site", chain=["claude-sonnet"],
+                id="future_site", chain=["openrouter-sonnet"],
             ),
         })
         breakers = _mock_registry({
-            "claude-sonnet": _mock_breaker(ProviderState.CLOSED),
+            "openrouter-sonnet": _mock_breaker(ProviderState.CLOSED),
         })
         # Inject intrinsic meta entry. wired=True so idle override
         # doesn't short-circuit the chain walk before NO_API_KEYS would

--- a/tests/test_health_mcp.py
+++ b/tests/test_health_mcp.py
@@ -163,9 +163,9 @@ class TestHealthAlerts:
     async def test_disabled_call_site_alert_suppressed(self):
         """Sites with status='disabled' (no API key) MUST NOT emit alerts.
 
-        This is the root-cause fix for the Sentinel spam loop: Anthropic
-        providers without ANTHROPIC_API_KEY → call site marked disabled
-        (config state, not outage) → no alert → no Sentinel wake.
+        This is the root-cause fix for the Sentinel spam loop: providers
+        without API keys → call site marked disabled (config state, not
+        outage) → no alert → no Sentinel wake.
         """
         svc = _mock_service({
             "call_sites": {

--- a/tests/test_routing/conftest.py
+++ b/tests/test_routing/conftest.py
@@ -39,7 +39,7 @@ def sample_providers():
     return {
         "free-1": ProviderConfig(name="free-1", provider_type="mistral", model_id="mistral-large", is_free=True, rpm_limit=2, open_duration_s=120),
         "free-2": ProviderConfig(name="free-2", provider_type="groq", model_id="llama-70b", is_free=True, rpm_limit=30, open_duration_s=120),
-        "paid-1": ProviderConfig(name="paid-1", provider_type="anthropic", model_id="claude-haiku", is_free=False, rpm_limit=None, open_duration_s=120),
+        "paid-1": ProviderConfig(name="paid-1", provider_type="openrouter", model_id="anthropic/claude-haiku-4.5", is_free=False, rpm_limit=None, open_duration_s=120),
         "paid-2": ProviderConfig(name="paid-2", provider_type="openai", model_id="gpt-5-nano", is_free=False, rpm_limit=None, open_duration_s=120),
     }
 

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -121,10 +121,9 @@ def test_load_full_yaml(monkeypatch):
 
     path = Path(__file__).resolve().parents[2] / "config" / "model_routing.yaml"
     cfg = load_config(path)
-    # lmstudio-30b, github-o3mini, openrouter-deepseek-r1 disabled → 27 enabled providers
-    # (32 total - 4 disabled; added openrouter-deepseek-v4, openrouter-gpt55 for
-    # executor review gates)
-    assert len(cfg.providers) == 28
+    # lmstudio-30b, github-o3mini, openrouter-deepseek-r1, deepseek-chat disabled → 27 enabled
+    # (31 total - 4 disabled; 3 direct anthropic providers removed, 2 openrouter added)
+    assert len(cfg.providers) == 27
     assert "lmstudio-30b" not in cfg.providers
     assert "github-o3mini" not in cfg.providers
     assert "openrouter-deepseek-r1" not in cfg.providers

--- a/tests/test_routing/test_litellm_delegate.py
+++ b/tests/test_routing/test_litellm_delegate.py
@@ -55,7 +55,6 @@ def _mock_response(content="Hello", prompt_tokens=10, completion_tokens=5):
     ("provider_type", "model_id", "expected"),
     [
         ("groq", "llama-3.3-70b-versatile", "groq/llama-3.3-70b-versatile"),
-        ("anthropic", "claude-sonnet-4-6", "anthropic/claude-sonnet-4-6"),
         ("google", "gemini-2.5-flash", "gemini/gemini-2.5-flash"),
         ("openai", "gpt-5-nano", "gpt-5-nano"),  # no prefix
         ("ollama", "qwen2.5:3b", "ollama/qwen2.5:3b"),

--- a/tests/test_routing/test_provider_criticality.py
+++ b/tests/test_routing/test_provider_criticality.py
@@ -70,14 +70,14 @@ class TestCallSitesForProviderType:
     def test_excludes_cc_dispatched(self):
         config = _make_config(
             providers=[
-                _ProviderCfg(name="claude-opus", provider_type="anthropic"),
+                _ProviderCfg(name="openrouter-opus", provider_type="openrouter"),
             ],
             call_sites=[
-                _CallSiteCfg(id="ego", chain=["claude-opus"], dispatch="cli"),
-                _CallSiteCfg(id="compact", chain=["claude-opus"], dispatch="dual"),
+                _CallSiteCfg(id="ego", chain=["openrouter-opus"], dispatch="cli"),
+                _CallSiteCfg(id="compact", chain=["openrouter-opus"], dispatch="dual"),
             ],
         )
-        result = call_sites_for_provider_type(config, "anthropic")
+        result = call_sites_for_provider_type(config, "openrouter")
         assert result == ["compact"]
 
     def test_empty_for_unknown_type(self):
@@ -157,13 +157,13 @@ class TestDeriveCriticality:
         config = _make_config(
             providers=[
                 _ProviderCfg(name="groq-free", provider_type="groq", is_free=True),
-                _ProviderCfg(name="claude-sonnet", provider_type="anthropic", is_free=False),
+                _ProviderCfg(name="openrouter-sonnet", provider_type="openrouter", is_free=False),
             ],
             call_sites=[],
         )
         result = derive_criticality(config)
         assert result["groq"]["is_free"] is True
-        assert result["anthropic"]["is_free"] is False
+        assert result["openrouter"]["is_free"] is False
 
     def test_mixed_free_paid_same_type(self):
         """If any provider of a type is paid, the type is not free."""


### PR DESCRIPTION
## Summary

- Remove 3 direct `type: anthropic` providers (`claude-haiku`, `claude-sonnet`, `claude-opus`)
- Add `openrouter-sonnet` and `openrouter-opus` providers (alongside existing `openrouter-haiku`)
- Update all 11 call site chains to use OpenRouter providers
- Update version_gate fallback chain and prefix maps
- Remove `anthropic` from litellm_delegate `_TYPE_TO_PREFIX` map
- Remove `ANTHROPIC_API_KEY` → `['anthropic']` mapping from dashboard
- Update docs, secrets.env.example comment, provider guide, and routing-call-sites reference
- Update 8 test files to match new provider names/types

`ANTHROPIC_API_KEY` is retained in secrets.env for CC background sessions (bypass provider chain via `dispatch:cli`). No longer needed for any LiteLLM routing path.

## Motivation

The `ANTHROPIC_API_KEY` was empty in this deployment, causing phantom circuit-breaker failures and false health alerts. Routing through OpenRouter (which already works for haiku) eliminates this dependency entirely.

## Test plan

- [x] All 157 affected tests pass (routing, health_data, health_mcp, contribution, dashboard, autonomy)
- [ ] CI passes
- [ ] After merge: verify `5_deep_reflection` and `7_ego_cycle` reach Claude via OpenRouter
- [ ] Check circuit breaker states for new providers within 1 hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)