### PR TITLE
fix(cc): correct stale profile addendum + Opus for interact

### DIFF
--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -151,47 +151,25 @@ _PROFILE_ADDENDA: dict[str, str] = {
 
 ## Session Profile: interact
 
-You have access to: browser MCP tools, memory MCP tools, outreach send.
-You do NOT have: Write, Edit, Bash, NotebookEdit.
-
-**Output rules:**
-- Your final message IS your deliverable. Write it clearly and completely.
-- If you need to persist data, use observation_write, reference_store, or
-  procedure_store MCP tools (SQLite-backed, not file-based).
-- Write files ONLY to `~/.genesis/output/` if absolutely necessary (via
-  browser_run_js or clipboard methods, not Write tool).
-- Do NOT waste time searching for Write/Edit/Bash tools. They are not
-  available to you. Do NOT spawn subagents to work around this.
+You have: Write, browser MCP tools, memory MCP tools, outreach send.
+You do NOT have: Edit, Bash, NotebookEdit.
+Your final message IS your deliverable. Write files to `~/.genesis/output/`.
 """,
     "research": """
 
 ## Session Profile: research
 
-You have access to: memory MCP tools, web tools (web_search, web_fetch),
-observation_write, procedure_store, reference_store, follow_up_create.
-You do NOT have: Write, Edit, Bash, NotebookEdit, browser tools.
-
-**Output rules:**
-- Your final message IS your deliverable. Write it clearly and completely.
-- Use observation_write for findings that should persist beyond this session.
-- Use reference_store for URLs, credentials, or identifiers discovered.
-- Do NOT waste time searching for Write/Edit/Bash/browser tools. They are
-  not available to you. Do NOT spawn subagents to work around this.
+You have: Write, memory MCP tools, web tools (web_search, web_fetch).
+You do NOT have: Edit, Bash, NotebookEdit, browser tools.
+Your final message IS your deliverable. Write files to `~/.genesis/output/`.
 """,
     "observe": """
 
 ## Session Profile: observe
 
-You are in read-only mode. You can read, search, and analyze but cannot
-modify anything.
-You do NOT have: Write, Edit, Bash, NotebookEdit, browser interaction,
-memory writes, outreach send, follow-up creation.
-
-**Output rules:**
-- Your final message IS your deliverable. Write it clearly and completely.
-- You cannot persist anything. Your message is the only output.
-- Do NOT waste time searching for Write/Edit/Bash tools. They are not
-  available to you. Do NOT spawn subagents to work around this.
+You have: memory MCP tools (read-only).
+You do NOT have: Write, Edit, Bash, NotebookEdit, browser tools.
+Your final message IS your deliverable.
 """,
 }
 
@@ -533,9 +511,16 @@ class DirectSessionRunner:
         if request.planning_instruction:
             prompt = f"{request.planning_instruction}\n\n{prompt}"
 
+        # Interact profile requires Opus — browser reasoning is complex and
+        # ATS anti-bot detection demands higher capability.
+        model = request.model
+        if request.profile == "interact" and model != CCModel.OPUS:
+            logger.info("interact profile: upgrading model %s → opus", model)
+            model = CCModel.OPUS
+
         return CCInvocation(
             prompt=prompt,
-            model=request.model,
+            model=model,
             effort=request.effort,
             system_prompt=system_prompt,
             append_system_prompt=True,
@@ -634,7 +619,7 @@ class DirectSessionRunner:
         body = (
             f"<b>Direct Session FAILED</b>\n\n"
             f"Profile: {request.profile} | "
-            f"Model: {request.model} | "
+            f"Model: {result.model_used or request.model} | "
             f"Duration: {result.duration_s:.0f}s\n\n"
             f"Error: {result.error or 'unknown'}\n\n"
             f"Tools before failure: {tools_str}"

--- a/tests/test_cc/test_direct_session_profiles.py
+++ b/tests/test_cc/test_direct_session_profiles.py
@@ -3,10 +3,17 @@
 Validates that profile changes don't accidentally grant or revoke tool access.
 """
 
+from unittest.mock import MagicMock
+
 from genesis.cc.direct_session import (
+    _PROFILE_ADDENDA,
     PROFILES,
     VALID_PROFILES,
+    DirectSessionRequest,
+    DirectSessionRunner,
+    _build_profile_addendum,
 )
+from genesis.cc.types import CCModel
 
 # --- Profile existence ---
 
@@ -187,3 +194,79 @@ def test_interact_and_research_share_universal_base():
     research_set = set(PROFILES["research"])
     assert _UNIVERSAL_BLOCKED.issubset(interact_set)
     assert _UNIVERSAL_BLOCKED.issubset(research_set)
+
+
+# --- Profile addendum correctness ---
+
+def test_interact_addendum_mentions_write_available():
+    """Interact addendum must tell session Write is available."""
+    addendum = _build_profile_addendum("interact")
+    assert "You have: Write" in addendum
+
+
+def test_research_addendum_mentions_write_available():
+    """Research addendum must tell session Write is available."""
+    addendum = _build_profile_addendum("research")
+    assert "You have: Write" in addendum
+
+
+def test_observe_addendum_does_not_mention_write_available():
+    """Observe addendum must NOT claim Write is available."""
+    addendum = _build_profile_addendum("observe")
+    assert "You have: Write" not in addendum
+
+
+def test_addenda_do_not_mention_reference_store_for_persistence():
+    """Addenda must NOT direct sessions to use reference_store for persistence."""
+    for profile, addendum in _PROFILE_ADDENDA.items():
+        assert "reference_store" not in addendum, (
+            f"{profile} addendum should not mention reference_store"
+        )
+
+
+# --- Model override for interact profile ---
+
+def _make_runner():
+    """Construct a DirectSessionRunner with mock dependencies."""
+    config_builder = MagicMock()
+    surplus_cfg = {"system_prompt": "test"}
+    config_builder.build_surplus_config.return_value = surplus_cfg
+    config_builder.build_mcp_config.return_value = None
+    return DirectSessionRunner(
+        invoker=MagicMock(),
+        session_manager=MagicMock(),
+        config_builder=config_builder,
+        runtime=MagicMock(),
+    )
+
+
+def test_interact_profile_upgrades_model_to_opus():
+    """Interact sessions must always use Opus regardless of requested model."""
+    runner = _make_runner()
+    req = DirectSessionRequest(prompt="test", profile="interact", model=CCModel.SONNET)
+    inv = runner._build_invocation(req)
+    assert inv.model == CCModel.OPUS
+
+
+def test_interact_profile_keeps_opus_when_already_opus():
+    """Opus request + interact should stay Opus (idempotent)."""
+    runner = _make_runner()
+    req = DirectSessionRequest(prompt="test", profile="interact", model=CCModel.OPUS)
+    inv = runner._build_invocation(req)
+    assert inv.model == CCModel.OPUS
+
+
+def test_research_profile_does_not_upgrade_model():
+    """Non-interact profiles must NOT override the requested model."""
+    runner = _make_runner()
+    req = DirectSessionRequest(prompt="test", profile="research", model=CCModel.SONNET)
+    inv = runner._build_invocation(req)
+    assert inv.model == CCModel.SONNET
+
+
+def test_observe_profile_does_not_upgrade_model():
+    """Observe profile must NOT override the requested model."""
+    runner = _make_runner()
+    req = DirectSessionRequest(prompt="test", profile="observe", model=CCModel.HAIKU)
+    inv = runner._build_invocation(req)
+    assert inv.model == CCModel.HAIKU


### PR DESCRIPTION
## Summary
- **Profile addendum was stale**: told sessions they don't have Write (false since PR #448) and directed them to use `reference_store` for persistence — root cause of reference store pollution (4 dirty entries cleaned)
- **Minimal addendum**: now just states tool availability + output location. Sessions decide persistence strategy themselves.
- **Interact → Opus**: interact profile always upgrades to Opus (browser reasoning + ATS anti-bot detection demands it)
- **Failure notification fix**: reports `result.model_used` instead of `request.model`
- **Interop prompt update**: corrected browser guidance from Camoufox → CDP for ATS submissions
- **Job submission procedure stored**: 11-step flow from interop prompt, specifies CDP mode
- **Suki dossier extracted**: session 506486a6 output written to `~/.genesis/output/suki-application-prep.md`, ego proposal e9b102e3 resolved

## Test plan
- [x] 35 profile tests pass (8 new: addendum accuracy, reference_store absence, model override idempotency)
- [x] `ruff check` clean
- [ ] CI green
- [ ] Restart genesis-server, verify interact dispatches use Opus in logs
- [ ] Verify ego's next cycle sees Suki prep file and proposes application submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)