### PR TITLE
feat(guardian): I/O resilience hardening — Designs 1-3 + review fixes

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -34,7 +34,7 @@ Genesis needs at least one LLM provider. The cheapest path:
 
 Add keys to `secrets.env`:
 ```
-GEMINI_API_KEY=your-key-here
+GOOGLE_API_KEY=your-key-here
 GROQ_API_KEY=your-key-here
 ```
 

--- a/config/guardian-claude.md
+++ b/config/guardian-claude.md
@@ -26,6 +26,7 @@ data and signal history. DO NOT stop at that data — investigate:
 
 ## Available Commands
 
+Container inspection (via incus exec):
 - `incus exec genesis -- su - ubuntu -c "<cmd>"` — Run as ubuntu user
 - `incus exec genesis -- su - ubuntu -c "systemctl --user restart genesis-bridge"` — Restart main service
 - `incus exec genesis -- su - ubuntu -c "journalctl --user -n 200 --no-pager"` — Read logs
@@ -38,13 +39,70 @@ data and signal history. DO NOT stop at that data — investigate:
 - `incus restart genesis` — Restart container (last resort)
 - `incus snapshot create genesis guardian-pre-recovery` — Snapshot BEFORE recovery
 
+Direct host reads (work when container is frozen/D-state and incus exec is unresponsive):
+- `cat /sys/fs/cgroup/lxc.payload.genesis/io.pressure` — I/O pressure (PSI)
+- `cat /sys/fs/cgroup/lxc.payload.genesis/cgroup.procs` — All container PIDs
+- `cat /proc/{pid}/io` — Per-process I/O stats (container PIDs visible on host)
+- `cat /sys/fs/cgroup/lxc.payload.genesis/memory.pressure` — Memory pressure
+
 ## Rules
 
 - ALWAYS take an Incus snapshot before destructive recovery actions
-- Prefer least destructive: restart service > clear resources > restart container > rollback
+- Prefer least destructive: restart service > IO_TRIAGE > clear resources > restart container > rollback
 - Never raise resource limits — fix root causes
 - Never work around symptoms — diagnose the actual problem
+- Never touch host io.max — it is a safety boundary to prevent disk corruption
 - Check temporal patterns: what changed? what degraded first?
+- IO_TRIAGE kills ONE process per cycle. Check PSI trend before killing.
+
+## I/O Pressure (PSI) Guide
+
+The host can read container I/O pressure directly from the cgroup filesystem.
+Format: `some avg10=X avg60=X avg300=X total=N` and `full avg10=X avg60=X avg300=X total=N`
+(avg values are percentages of time tasks were stalled).
+
+- `full avg10 > 50%` = critical I/O saturation (container may be freezing)
+- `full avg10 > 10%` = warning (early I/O pressure)
+- Trend: avg10 > avg60 > avg300 = accelerating — intervention needed
+- Trend: avg10 < avg60 = recovering — let it resolve naturally
+
+## Sentinel Awareness
+
+Genesis has a container-side health guardian called the Sentinel. Before you
+act, check if the Sentinel has already tried to fix the problem:
+
+- `cat ~/.local/state/genesis-guardian/shared/sentinel/last_run.json` — what Sentinel tried
+- `cat ~/.local/state/genesis-guardian/shared/sentinel/sentinel_state.json` — current Sentinel state
+
+If the Sentinel already diagnosed and attempted to fix this problem, do NOT
+repeat the same actions. Either try something different or escalate.
+
+Guardian coordinates with Sentinel via event-driven standing: as long as
+Sentinel is actively investigating or awaiting user approval, Guardian waits.
+Guardian proceeds only when Sentinel escalates, reports healthy (but probes
+disagree), or becomes unreachable.
+
+## IO_TRIAGE
+
+When I/O pressure is the root cause, recommend IO_TRIAGE instead of
+RESTART_CONTAINER. IO_TRIAGE kills the single highest I/O consumer (one process
+per cycle) and reassesses. Less destructive than a full container restart.
+
+Before recommending IO_TRIAGE, check the PSI trend:
+- `full avg10 > avg60 > avg300` = accelerating → IO_TRIAGE appropriate
+- `full avg10 < avg60` = pressure dropping → stand down, let it recover
+
+## Operational Context
+
+- Recovery uses exponential backoff (100s base, 3x multiplier, max 3 attempts)
+- IO_TRIAGE has a separate counter (max 5 attempts, 30s base, 2x multiplier)
+- Maintenance mode: if `/var/lib/guardian-snapshots/.guardian-maintenance` exists,
+  check cycle is skipped entirely
+- CC diagnosis runs in `/var/lib/guardian-snapshots/cc-sessions` (isolated work dir)
+- Diagnosis refused if pool usage > 90% (disk space preflight)
+- Guardian service limited to 6GB memory (MemoryMax=6G), OOMScoreAdjust=500
+- Snapshot gating: headroom-based check (requires free > max(5GB, 2x avg recent
+  snapshots)), not fixed percentage
 
 ## Genesis Context
 
@@ -63,6 +121,7 @@ A shared mount connects Genesis (container) and Guardian (host):
 Subdirectories:
 - briefing/ — Genesis writes curated briefings here (service baselines, incidents, metric norms)
 - findings/ — Guardian writes diagnosis results here for Genesis to ingest on recovery
+- sentinel/ — Sentinel state and run logs (last_run.json, sentinel_state.json, sentinel_log.jsonl)
 
 The briefing file (guardian_briefing.md) is injected into your prompt automatically
 when available. It gives you context about what Genesis was doing before it went down.
@@ -83,5 +142,5 @@ When done (resolved or escalating), output a JSON block at the end:
 }
 ```
 
-Actions: RESTART_SERVICES | RESOURCE_CLEAR | REVERT_CODE | RESTART_CONTAINER | SNAPSHOT_ROLLBACK | ESCALATE
+Actions: RESTART_SERVICES | IO_TRIAGE | RESOURCE_CLEAR | REVERT_CODE | RESTART_CONTAINER | SNAPSHOT_ROLLBACK | ESCALATE
 Outcomes: "resolved" | "partially_resolved" | "escalate"

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -48,9 +48,9 @@ case "${SSH_ORIGINAL_COMMAND:-}" in
         CURRENT=$(python3 -c "import json; print(json.load(open('$STATE_FILE')).get('current_state','unknown'))" 2>/dev/null || echo "unknown")
         case "$CURRENT" in
             confirmed_dead|recovering|recovered)
-                # Read-modify-write: preserve any future fields added to state.json
+                # Read-modify-write with atomic rename (matches state_machine.py save_state)
                 python3 << PYEOF
-import json
+import json, os, tempfile
 from datetime import datetime, timezone
 sf = "$STATE_FILE"
 with open(sf) as f:
@@ -61,9 +61,15 @@ d.update(current_state="healthy", consecutive_failures=0, recheck_count=0,
          first_failure_at=None, recovery_attempts=0, last_healthy_at=now,
          last_check_at=now, auto_reset_count=0, dialogue_sent_at=None,
          dialogue_eta_s=0, dialogue_action=None, cc_unavailable_since=None,
-         last_cc_unavailable_alert_at=None)
-with open(sf, "w") as f:
-    json.dump(d, f, indent=2)
+         last_cc_unavailable_alert_at=None, io_triage_attempts=0,
+         sentinel_state="")
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(sf), suffix=".tmp")
+try:
+    os.write(fd, json.dumps(d, indent=2).encode())
+    os.fsync(fd)
+finally:
+    os.close(fd)
+os.rename(tmp, sf)
 print(json.dumps({"ok": True, "action": "reset-state", "previous_state": prev}))
 PYEOF
                 ;;
@@ -100,11 +106,13 @@ PYEOF
             fi
             if git pull --ff-only 2>/dev/null; then
                 # Restore local config changes
+                CONFIG_RESET=0
                 if [ "$STASHED" -eq 1 ]; then
                     if ! git stash pop --quiet 2>/dev/null; then
                         # Conflict — drop the stash and warn (config can be re-set)
                         git checkout -- . 2>/dev/null || true
                         git stash drop --quiet 2>/dev/null || true
+                        CONFIG_RESET=1
                     fi
                 fi
                 # Regenerate Guardian CLAUDE.md from template (never use repo version)
@@ -165,7 +173,11 @@ IOSYSCTL
                 # Restart timer so new check.py code takes effect immediately
                 systemctl --user restart genesis-guardian.timer 2>/dev/null || true
                 NEW=$(git rev-parse --short HEAD 2>/dev/null)
-                printf '{"ok": true, "action": "update", "old": "%s", "new": "%s"}\n' "$OLD" "$NEW"
+                if [ "$CONFIG_RESET" -eq 1 ]; then
+                    printf '{"ok": true, "action": "update", "old": "%s", "new": "%s", "warning": "local config changes were discarded due to merge conflict — re-run install_guardian.sh to regenerate"}\n' "$OLD" "$NEW"
+                else
+                    printf '{"ok": true, "action": "update", "old": "%s", "new": "%s"}\n' "$OLD" "$NEW"
+                fi
             else
                 [ "$STASHED" -eq 1 ] && git stash pop --quiet 2>/dev/null || true
                 printf '{"ok": false, "action": "update", "error": "git pull failed"}\n' >&2

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -147,6 +147,21 @@ PYEOF
                     fi
                 done
                 systemctl --user daemon-reload 2>/dev/null || true
+                # Refresh host sysctl/udev configs (I/O tuning, BFQ scheduler)
+                if sudo -n true 2>/dev/null; then
+                    if [ -f "$INSTALL_DIR/config/60-ioscheduler.rules" ]; then
+                        sudo cp "$INSTALL_DIR/config/60-ioscheduler.rules" /etc/udev/rules.d/ 2>/dev/null
+                        sudo udevadm control --reload-rules 2>/dev/null || true
+                    fi
+                    # Regenerate I/O sysctl from canonical values
+                    sudo tee /etc/sysctl.d/99-genesis-io-tuning.conf > /dev/null 2>&1 << 'IOSYSCTL'
+vm.swappiness = 10
+vm.dirty_ratio = 10
+vm.dirty_background_ratio = 3
+vm.vfs_cache_pressure = 50
+IOSYSCTL
+                    sudo sysctl --system > /dev/null 2>&1 || true
+                fi
                 # Restart timer so new check.py code takes effect immediately
                 systemctl --user restart genesis-guardian.timer 2>/dev/null || true
                 NEW=$(git rev-parse --short HEAD 2>/dev/null)

--- a/scripts/install_guardian.sh
+++ b/scripts/install_guardian.sh
@@ -474,9 +474,8 @@ fi
 # Reference configs: config/99-container-host.conf, config/60-ioscheduler.rules
 
 if sudo -n true 2>/dev/null; then
-    # I/O sysctl — only the settings not handled by 99-genesis-oom-tuning.conf
-    if [ ! -f /etc/sysctl.d/99-genesis-io-tuning.conf ]; then
-        sudo tee /etc/sysctl.d/99-genesis-io-tuning.conf > /dev/null << 'SYSCTL'
+    # I/O sysctl — always overwrite to pick up value changes on update
+    sudo tee /etc/sysctl.d/99-genesis-io-tuning.conf > /dev/null << 'SYSCTL'
 # Genesis — I/O pressure reduction (installed by install_guardian.sh)
 # Reduces dirty page cache to prevent I/O death spirals under sustained write load.
 vm.swappiness = 10
@@ -484,21 +483,14 @@ vm.dirty_ratio = 10
 vm.dirty_background_ratio = 3
 vm.vfs_cache_pressure = 50
 SYSCTL
-        sudo sysctl --system > /dev/null 2>&1
-        echo "  + I/O tuning applied (swappiness=10, dirty_ratio=10)"
-    else
-        echo "  I/O tuning already installed"
-    fi
+    sudo sysctl --system > /dev/null 2>&1
+    echo "  + I/O tuning applied (swappiness=10, dirty_ratio=10)"
 
-    # BFQ I/O scheduler — fairer than mq-deadline for mixed workloads
-    if [ ! -f /etc/udev/rules.d/60-ioscheduler.rules ]; then
-        if [ -d "$INSTALL_DIR/config" ] && [ -f "$INSTALL_DIR/config/60-ioscheduler.rules" ]; then
-            sudo cp "$INSTALL_DIR/config/60-ioscheduler.rules" /etc/udev/rules.d/
-            sudo udevadm control --reload-rules 2>/dev/null || true
-            echo "  + BFQ I/O scheduler rule installed"
-        fi
-    else
-        echo "  BFQ scheduler rule already installed"
+    # BFQ I/O scheduler — always refresh from repo
+    if [ -d "$INSTALL_DIR/config" ] && [ -f "$INSTALL_DIR/config/60-ioscheduler.rules" ]; then
+        sudo cp "$INSTALL_DIR/config/60-ioscheduler.rules" /etc/udev/rules.d/
+        sudo udevadm control --reload-rules 2>/dev/null || true
+        echo "  + BFQ I/O scheduler rule installed"
     fi
 else
     echo "  SKIP  I/O tuning (no passwordless sudo). See config/99-container-host.conf"

--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -509,6 +509,14 @@ def reclaim_page_cache(target_bytes: str = "128M") -> bool:
 
     now = time.monotonic()
 
+    # Cooldown: don't reclaim more than once per 5 minutes. Repeated
+    # reclaims cause I/O storms in I/O-limited containers (incident 2026-03-16).
+    _RECLAIM_COOLDOWN_S = 300.0
+    if now - _last_reclaim_time < _RECLAIM_COOLDOWN_S:
+        remaining = _RECLAIM_COOLDOWN_S - (now - _last_reclaim_time)
+        logger.debug("Skipping reclaim — cooldown %.0fs remaining", remaining)
+        return False
+
     # Cap at 256M: small reclaims let the kernel LRU pick inactive pages
     # instead of evicting the active working set
     allowed = {"64M", "128M", "256M"}

--- a/src/genesis/contribution/version_gate.py
+++ b/src/genesis/contribution/version_gate.py
@@ -44,7 +44,7 @@ CONFIDENCE_THRESHOLD = 75
 _FALLBACK_MODELS = [
     ("openrouter/anthropic/claude-haiku-4.5", "API_KEY_OPENROUTER"),
     ("groq/llama-3.3-70b-versatile", "GROQ_API_KEY"),
-    ("gemini/gemini-2.0-flash", "GEMINI_API_KEY"),
+    ("gemini/gemini-2.0-flash", "GOOGLE_API_KEY"),
 ]
 
 # contribution_gate — gates community contribution submissions (Phase 6 pipeline).
@@ -305,7 +305,7 @@ def _load_models_from_config() -> list[tuple[str, str]]:
         _ENV = {
             "openrouter": "API_KEY_OPENROUTER",
             "groq": "GROQ_API_KEY",
-            "google": "GEMINI_API_KEY",
+            "google": "GOOGLE_API_KEY",
         }
         result = []
         for pname in site.chain:

--- a/src/genesis/dashboard/routes/health.py
+++ b/src/genesis/dashboard/routes/health.py
@@ -144,7 +144,9 @@ async def guardian_dialogue():
     except (ValueError, TypeError, AttributeError) as exc:
         logger.debug("Failed to parse Guardian concern payload: %s", exc, exc_info=True)
 
-    # Dispatch Sentinel if available — container-side guardian handles it
+    # Dispatch Sentinel if available — container-side guardian handles it.
+    # Guardian uses sentinel_state for event-driven standing (no wall-clock
+    # timeout). As long as Sentinel is active, Guardian waits indefinitely.
     sentinel = getattr(rt, "_sentinel", None)
     if sentinel is not None and not sentinel.is_active:
         try:
@@ -160,12 +162,16 @@ async def guardian_dialogue():
                 )),
                 name="sentinel-guardian-dialogue",
             )
+            # Sentinel just dispatched — report its initial state
+            s_state = getattr(sentinel, "_state", None)
+            state_val = s_state.current_state if s_state else "investigating"
             return jsonify({
                 "acknowledged": True,
                 "status": "handling",
                 "action": "sentinel_dispatched",
-                "eta_s": 300,
-                "context": "Sentinel dispatched to diagnose and fix",
+                "eta_s": 0,
+                "sentinel_state": state_val,
+                "context": f"Sentinel dispatched ({state_val})",
             }), 200
         except Exception:
             logger.warning("Sentinel dispatch failed — falling back to need_help", exc_info=True)
@@ -173,14 +179,15 @@ async def guardian_dialogue():
         # Sentinel is already mid-remediation — tell Guardian to wait.
         # Without this, Guardian interprets the fallthrough as "need_help"
         # and escalates, causing competing restart attempts.
-        current = getattr(sentinel, "_state", None)
-        state_str = current.current_state if current else "active"
+        s_state = getattr(sentinel, "_state", None)
+        state_val = s_state.current_state if s_state else "investigating"
         return jsonify({
             "acknowledged": True,
             "status": "handling",
             "action": "sentinel_already_active",
-            "eta_s": 600,
-            "context": f"Sentinel already remediating ({state_str})",
+            "eta_s": 0,
+            "sentinel_state": state_val,
+            "context": f"Sentinel active ({state_val})",
         }), 200
 
     return jsonify({

--- a/src/genesis/guardian/DEPLOYMENT.md
+++ b/src/genesis/guardian/DEPLOYMENT.md
@@ -14,12 +14,14 @@ CLAUDE.md: Generated from `config/guardian-claude.md` (NOT the repo root CLAUDE.
 - `diagnosis.py` — CC diagnosis engine (invokes `claude -p` on host)
 - `diagnosis_writer.py` — writes diagnosis results to shared mount
 - `collector.py` — gathers diagnostic metrics (memory, disk, processes, journal)
-- `recovery.py` — executes recovery actions (restart, revert, rollback)
-- `health_signals.py` — 5 probes + 6 suspicious checks
-- `state_machine.py` — confirmation protocol (prevents false positives)
-- `snapshots.py` — Incus snapshot management
+- `recovery.py` — executes recovery actions (restart, IO_TRIAGE, revert, rollback)
+- `health_signals.py` — 5 probes + 6 suspicious checks (including I/O pressure)
+- `state_machine.py` — confirmation protocol with event-driven Sentinel coordination
+- `snapshots.py` — Incus snapshot management with headroom-based gating
+- `_subprocess.py` — shared async subprocess runner (used by 5+ modules)
+- `cgroup_ops.py` — host-side cgroup operations (I/O pressure, PID enumeration, process kill)
 - `approval.py` — HTTP approval server for recovery confirmation
-- `dialogue.py` — Guardian↔Genesis dialogue protocol
+- `dialogue.py` — Guardian↔Genesis dialogue protocol (sentinel_state aware)
 - `alert/` — alert channels (Telegram, journal)
 
 ## CONTAINER-SIDE (runs inside Genesis container via awareness loop)
@@ -48,3 +50,4 @@ Subdirectories:
 - `briefing/` — Genesis→Guardian (service baselines, metric norms, recent activity)
 - `findings/` — Guardian→Genesis (diagnosis results for post-recovery learning)
 - `guardian/` — Genesis→Guardian (Telegram credentials)
+- `sentinel/` — Sentinel→Guardian (state, last run, logs)

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -411,11 +411,20 @@ async def _handle_awaiting_self_heal(
     recovery_engine: RecoveryEngine,
     snapshot: object,
 ) -> None:
-    """Check if Genesis's self-heal worked. If ETA expired and still down, proceed.
+    """Event-driven self-heal check. Re-queries Sentinel state each tick.
 
-    Uses the snapshot already collected and processed by _check_cycle.
-    The state machine transition was already computed — we act on the current state.
+    Guardian waits as long as Sentinel is in an active state (investigating,
+    remediating, awaiting approval). No wall-clock timeout. User sovereignty
+    is absolute — if Sentinel is parked on approval for 8 hours, Guardian
+    waits 8 hours.
+
+    Proceeds to diagnosis ONLY when:
+    - Sentinel escalated (explicitly gave up)
+    - Sentinel healthy but probes still fail (fixed wrong thing)
+    - Genesis unreachable (Sentinel is down too)
     """
+    from genesis.guardian.health_signals import HealthSnapshot
+
     current = sm.current_state
 
     if current == GuardianState.HEALTHY:
@@ -427,10 +436,34 @@ async def _handle_awaiting_self_heal(
         ))
         return
 
+    # Re-query Genesis for updated Sentinel state on each tick.
+    # The dialogue endpoint is safe to re-POST: the is_active check
+    # prevents re-dispatching Sentinel when it's already running.
+    first_failure = sm.state.first_failure_at or datetime.now(UTC).isoformat()
+    try:
+        duration = (datetime.now(UTC) - datetime.fromisoformat(first_failure)).total_seconds()
+    except (ValueError, TypeError):
+        duration = 0.0
+
+    request = build_request(
+        snapshot=snapshot if isinstance(snapshot, HealthSnapshot) else HealthSnapshot(),
+        duration_s=duration,
+        guardian_state="awaiting_self_heal",
+    )
+    response = await send_dialogue(config, request)
+
+    if response.acknowledged and response.sentinel_state:
+        sm.update_sentinel_state(response.sentinel_state)
+    elif not response.acknowledged:
+        # Genesis unreachable — Sentinel is down too
+        sm.update_sentinel_state("")
+
     if current == GuardianState.CONFIRMED_DEAD:
-        # ETA expired, Genesis failed to self-heal
+        # State machine already decided to proceed (Sentinel escalated,
+        # healthy-but-failing, or unreachable)
         logger.warning(
-            "Genesis self-heal failed (ETA expired for: %s)",
+            "Sentinel state '%s' — proceeding to diagnosis (was: %s)",
+            sm.state.sentinel_state or "unreachable",
             sm.state.dialogue_action,
         )
         await _proceed_to_diagnosis(
@@ -438,9 +471,10 @@ async def _handle_awaiting_self_heal(
         )
         return
 
-    # Still waiting — ETA not expired yet
+    # Still waiting — Sentinel is active
     logger.info(
-        "Waiting for Genesis self-heal: %s",
+        "Waiting for Sentinel (%s): %s",
+        sm.state.sentinel_state,
         sm.state.dialogue_action,
     )
 

--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -123,6 +123,7 @@ class RecoveryConfig:
 
     verification_delay_s: int = 30
     max_escalations: int = 3
+    max_io_triage_attempts: int = 5  # Separate budget for IO_TRIAGE (low-risk)
 
 
 @dataclass

--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -113,7 +113,8 @@ class SnapshotConfig:
     retention: int = 1
     prefix: str = "guardian-"
     take_pre_recovery: bool = True  # Take snapshot before recovery action
-    max_pool_usage_pct: float = 80.0  # Refuse snapshots if pool above this
+    max_pool_usage_pct: float = 80.0  # Fallback threshold if headroom check unavailable
+    min_headroom_gb: float = 5.0  # Minimum free space floor for headroom check
 
 
 @dataclass

--- a/src/genesis/guardian/diagnosis.py
+++ b/src/genesis/guardian/diagnosis.py
@@ -61,6 +61,7 @@ class RecoveryAction(StrEnum):
     """Available recovery actions, in escalation order."""
 
     RESTART_SERVICES = "RESTART_SERVICES"
+    IO_TRIAGE = "IO_TRIAGE"
     RESOURCE_CLEAR = "RESOURCE_CLEAR"
     REVERT_CODE = "REVERT_CODE"
     RESTART_CONTAINER = "RESTART_CONTAINER"
@@ -100,6 +101,7 @@ Known failure mode inventory (from real incidents):
 | killpg(1) | All processes dead simultaneously | Bad PGID in test/code | RESTART_CONTAINER |
 | Systemd user manager death | All user services dead, systemd --user gone | OOM cascading | RESTART_CONTAINER |
 | Page cache I/O storm | D-state processes, high io.pressure | Memory pressure cascade | RESTART_CONTAINER |
+| I/O saturation | io.pressure full avg10 high, system partially responsive | CC sessions saturating I/O bandwidth | IO_TRIAGE (kill top I/O consumer, one per cycle) |
 """
 
 
@@ -235,6 +237,23 @@ Run these via Bash:
 - `incus info {container_name}` — Container status and resource usage
 - `incus restart {container_name}` — Restart the entire container (last resort)
 - `incus snapshot create {container_name} guardian-pre-recovery` — Snapshot BEFORE recovery
+- `cat /sys/fs/cgroup/lxc.payload.{container_name}/io.pressure` — I/O pressure (direct host read, works when incus exec is unresponsive)
+- `cat /sys/fs/cgroup/lxc.payload.{container_name}/cgroup.procs` — All container PIDs (host read)
+
+## IO_TRIAGE Guidance
+
+When I/O pressure is the root cause (`io.pressure full avg10` is high), recommend
+IO_TRIAGE instead of RESTART_CONTAINER. IO_TRIAGE kills the single highest I/O
+consumer (one process per cycle) and reassesses. This is less destructive than a
+full container restart.
+
+**Before recommending IO_TRIAGE**, check the PSI trend:
+- `full avg10 > avg60 > avg300` = accelerating pressure → IO_TRIAGE appropriate
+- `full avg10 < avg60` = pressure dropping → stand down, let it recover naturally
+- Read I/O pressure: `cat /sys/fs/cgroup/lxc.payload.{container_name}/io.pressure`
+  Format: `full avg10=X avg60=X avg300=X total=N` (avg values are percentages)
+
+**Never touch host io.max** — it is a safety boundary to prevent disk corruption.
 
 ## Investigation Protocol
 
@@ -276,7 +295,7 @@ report as a JSON block:
 ```
 
 Field values:
-- `recommended_action`: RESTART_SERVICES | RESOURCE_CLEAR | REVERT_CODE | RESTART_CONTAINER | SNAPSHOT_ROLLBACK | ESCALATE
+- `recommended_action`: RESTART_SERVICES | IO_TRIAGE | RESOURCE_CLEAR | REVERT_CODE | RESTART_CONTAINER | SNAPSHOT_ROLLBACK | ESCALATE
 - `actions_taken`: what you actually did (investigation steps + recovery actions)
 - `outcome`: "resolved" (you fixed it), "partially_resolved" (improved but not fully), or "escalate" (needs human)
 

--- a/src/genesis/guardian/diagnosis.py
+++ b/src/genesis/guardian/diagnosis.py
@@ -29,9 +29,12 @@ from genesis.guardian.config import GuardianConfig
 
 logger = logging.getLogger(__name__)
 
-# Pre-flight memory warning threshold.  Guardian must always attempt
-# diagnosis — refusing means Genesis stays down with no information.
-# We log a warning when memory is low but never block the attempt.
+# Pre-flight memory thresholds.  Guardian must always attempt diagnosis
+# above the hard floor.  The systemd MemoryMax=6G cap on the Guardian
+# service is the real safety boundary — Python-level checks are advisory.
+# Hard floor: refuse only at catastrophic levels (host is almost dead).
+# Warn floor: log warning but proceed (Guardian's job is to diagnose).
+_CC_PREFLIGHT_HARD_FLOOR_GiB = 2.0
 _CC_PREFLIGHT_WARN_GiB = 8.0
 
 
@@ -387,16 +390,29 @@ class DiagnosisEngine:
         except Exception as exc:
             logger.warning("Disk space preflight failed (non-fatal): %s", exc)
 
-        # Pre-flight: log host memory for observability.
-        # Guardian must always attempt diagnosis — its one job.  A failed
-        # attempt with an error log is more useful than no attempt at all.
+        # Pre-flight: check host memory.  The systemd MemoryMax=6G on the
+        # Guardian service is the real safety boundary — this Python check
+        # is advisory.  Only refuse at catastrophic levels (< 2 GiB means
+        # the host is almost dead, not just Genesis).
         effective_model = self._config.cc.model
         available_gib = _host_mem_available_gib()
         if available_gib is not None:
+            if available_gib < _CC_PREFLIGHT_HARD_FLOOR_GiB:
+                logger.error(
+                    "Host memory catastrophically low (%.1f GiB free < %.0f GiB) "
+                    "— refusing CC diagnosis (host is near death, not just Genesis)",
+                    available_gib, _CC_PREFLIGHT_HARD_FLOOR_GiB,
+                )
+                raise CCDiagnosisError(
+                    f"Host memory catastrophically low: "
+                    f"{available_gib:.1f} GiB free < "
+                    f"{_CC_PREFLIGHT_HARD_FLOOR_GiB:.0f} GiB — "
+                    f"host VM itself is at risk"
+                )
             if available_gib < _CC_PREFLIGHT_WARN_GiB:
                 logger.warning(
                     "Host memory low (%.1f GiB free < %.0f GiB) "
-                    "— proceeding with CC diagnosis anyway",
+                    "— proceeding with CC diagnosis (MemoryMax=6G caps usage)",
                     available_gib, _CC_PREFLIGHT_WARN_GiB,
                 )
         else:

--- a/src/genesis/guardian/diagnosis.py
+++ b/src/genesis/guardian/diagnosis.py
@@ -29,11 +29,10 @@ from genesis.guardian.config import GuardianConfig
 
 logger = logging.getLogger(__name__)
 
-# Pre-flight memory thresholds for CC launch decisions.
-# Hard floor: refuse to launch CC entirely (OOM risk too high).
-# Soft floor: downgrade to sonnet (smaller CC footprint).
-_CC_PREFLIGHT_HARD_FLOOR_GiB = 8.0
-_CC_PREFLIGHT_SOFT_FLOOR_GiB = 14.0
+# Pre-flight memory warning threshold.  Guardian must always attempt
+# diagnosis — refusing means Genesis stays down with no information.
+# We log a warning when memory is low but never block the attempt.
+_CC_PREFLIGHT_WARN_GiB = 8.0
 
 
 def _host_mem_available_gib() -> float | None:
@@ -369,32 +368,18 @@ class DiagnosisEngine:
         except Exception as exc:
             logger.warning("Disk space preflight failed (non-fatal): %s", exc)
 
-        # Pre-flight: check host memory before launching CC.
-        # CC + its tool subprocesses run on the host unconstrained by any
-        # container cgroup. Launching during memory pressure risks a VM freeze
-        # (incident 2026-05-15: min_free_kbytes too low → kernel death spiral).
+        # Pre-flight: log host memory for observability.
+        # Guardian must always attempt diagnosis — its one job.  A failed
+        # attempt with an error log is more useful than no attempt at all.
         effective_model = self._config.cc.model
         available_gib = _host_mem_available_gib()
         if available_gib is not None:
-            if available_gib < _CC_PREFLIGHT_HARD_FLOOR_GiB:
-                logger.error(
-                    "Host memory critically low (%.1f GiB free < %.0f GiB floor) "
-                    "— refusing CC diagnosis to prevent OOM",
-                    available_gib, _CC_PREFLIGHT_HARD_FLOOR_GiB,
-                )
-                raise CCDiagnosisError(
-                    f"Host memory too low for CC diagnosis: "
-                    f"{available_gib:.1f} GiB free < "
-                    f"{_CC_PREFLIGHT_HARD_FLOOR_GiB:.0f} GiB minimum"
-                )
-            if available_gib < _CC_PREFLIGHT_SOFT_FLOOR_GiB:
+            if available_gib < _CC_PREFLIGHT_WARN_GiB:
                 logger.warning(
                     "Host memory low (%.1f GiB free < %.0f GiB) "
-                    "— downgrading CC model from %s to sonnet",
-                    available_gib, _CC_PREFLIGHT_SOFT_FLOOR_GiB,
-                    self._config.cc.model,
+                    "— proceeding with CC diagnosis anyway",
+                    available_gib, _CC_PREFLIGHT_WARN_GiB,
                 )
-                effective_model = "sonnet"
         else:
             logger.warning("Cannot read /proc/meminfo — skipping memory preflight")
 

--- a/src/genesis/guardian/dialogue.py
+++ b/src/genesis/guardian/dialogue.py
@@ -57,6 +57,12 @@ class DialogueRequest:
         }
 
 
+_ACTIVE_SENTINEL_STATES = frozenset({
+    "investigating", "remediating",
+    "awaiting_dispatch_approval", "awaiting_action_approval",
+})
+
+
 @dataclass(frozen=True)
 class DialogueResponse:
     """What Genesis sends back to the Guardian."""
@@ -66,6 +72,12 @@ class DialogueResponse:
     action: str
     eta_s: int
     context: str
+    sentinel_state: str = ""
+
+    @property
+    def sentinel_active(self) -> bool:
+        """True if Sentinel is in an active state (Guardian should wait)."""
+        return self.sentinel_state in _ACTIVE_SENTINEL_STATES
 
     @classmethod
     def unreachable(cls) -> DialogueResponse:
@@ -76,6 +88,7 @@ class DialogueResponse:
             action="",
             eta_s=0,
             context="Genesis unreachable — no response to dialogue",
+            sentinel_state="",
         )
 
     @classmethod
@@ -87,6 +100,7 @@ class DialogueResponse:
             action="",
             eta_s=0,
             context=f"Genesis responded with error: {detail}",
+            sentinel_state="",
         )
 
 
@@ -186,6 +200,7 @@ async def send_dialogue(
             action=data.get("action", ""),
             eta_s=int(data.get("eta_s", 0)),
             context=data.get("context", ""),
+            sentinel_state=data.get("sentinel_state", ""),
         )
 
     except json.JSONDecodeError as exc:

--- a/src/genesis/guardian/recovery.py
+++ b/src/genesis/guardian/recovery.py
@@ -91,12 +91,16 @@ class RecoveryEngine:
         self._sm.set_recovering()
 
         # Pre-recovery snapshot (gated on config flag and disk space)
+        snap_history = self._sm.state.snapshot_size_history
         if (
             action != RecoveryAction.SNAPSHOT_ROLLBACK
             and self._config.snapshots.take_pre_recovery
-            and await self._snapshots.safe_to_snapshot()
+            and await self._snapshots.safe_to_snapshot(snap_history)
         ):
-            snap_name = await self._snapshots.take(label="pre-recovery")
+            snap_name = await self._snapshots.take(
+                label="pre-recovery",
+                snapshot_size_history=snap_history,
+            )
             if snap_name:
                 logger.info("Pre-recovery snapshot: %s", snap_name)
 

--- a/src/genesis/guardian/recovery.py
+++ b/src/genesis/guardian/recovery.py
@@ -64,11 +64,16 @@ class RecoveryEngine:
             return await self._escalate(diagnosis)
 
         # Check exponential backoff before proceeding
-        backoff_s = self._sm.recovery_backoff_remaining_s()
+        backoff_s = self._sm.recovery_backoff_remaining_s(action.value)
         if backoff_s > 0:
+            attempts = (
+                self._sm.state.io_triage_attempts
+                if action == RecoveryAction.IO_TRIAGE
+                else self._sm.state.recovery_attempts
+            )
             logger.warning(
                 "Recovery backoff: %.0fs remaining before attempt %d — deferring",
-                backoff_s, self._sm.state.recovery_attempts + 1,
+                backoff_s, attempts + 1,
             )
             return RecoveryResult(
                 action=action,
@@ -113,7 +118,7 @@ class RecoveryEngine:
             detail = str(exc)
 
         # Record attempt timestamp for backoff tracking
-        self._sm.record_recovery_attempt()
+        self._sm.record_recovery_attempt(action.value)
 
         duration = (datetime.now(UTC) - t0).total_seconds()
 
@@ -162,6 +167,8 @@ class RecoveryEngine:
 
         if action == RecoveryAction.RESTART_SERVICES:
             return await self._restart_services(container)
+        elif action == RecoveryAction.IO_TRIAGE:
+            return await self._io_triage(container)
         elif action == RecoveryAction.RESOURCE_CLEAR:
             return await self._resource_clear(container)
         elif action == RecoveryAction.REVERT_CODE:
@@ -184,6 +191,59 @@ class RecoveryEngine:
         if rc != 0:
             return False, f"systemctl restart failed: {stderr}"
         return True, "genesis-bridge restarted"
+
+    async def _io_triage(self, container: str) -> tuple[bool, str]:
+        """Kill the top I/O consumer. One process per cycle — reassess after.
+
+        Checks PSI trend before acting: if pressure is already dropping,
+        stands down and lets the system recover naturally.
+        Never touches io.max (host safety boundary).
+        """
+        from genesis.guardian.cgroup_ops import (
+            find_top_io_pids,
+            kill_pid,
+            read_io_pressure,
+        )
+
+        # 1. Collect diagnostics — find top 5 I/O consumers
+        top_pids = find_top_io_pids(container, top_n=5)
+        if not top_pids:
+            return False, "No I/O consuming processes found in container cgroup"
+
+        # Log all candidates for observability
+        for entry in top_pids:
+            logger.info(
+                "IO_TRIAGE candidate: PID %d (%s) "
+                "read=%d write=%d total=%d bytes",
+                entry["pid"], entry["comm"],
+                entry["read_bytes"], entry["write_bytes"],
+                entry["total_bytes"],
+            )
+
+        # 2. Assess PSI trend — is pressure accelerating or recovering?
+        pressure = read_io_pressure(container)
+        if pressure:
+            avg10 = pressure.get("full_avg10", 0)
+            avg60 = pressure.get("full_avg60", 0)
+            if avg10 < avg60:
+                # Pressure is dropping — stand down
+                return True, (
+                    f"I/O pressure recovering (avg10={avg10:.1f}%, "
+                    f"avg60={avg60:.1f}%) — standing down"
+                )
+
+        # 3. Kill top consumer only (one per cycle)
+        target = top_pids[0]
+        killed = await kill_pid(target["pid"], container=container)
+        if not killed:
+            return False, (
+                f"Failed to kill PID {target['pid']} ({target['comm']})"
+            )
+
+        return True, (
+            f"Killed top I/O consumer: PID {target['pid']} "
+            f"({target['comm']}) total_bytes={target['total_bytes']}"
+        )
 
     async def _resource_clear(self, container: str) -> tuple[bool, str]:
         """Clear /tmp and reclaim page cache, then restart services."""

--- a/src/genesis/guardian/recovery.py
+++ b/src/genesis/guardian/recovery.py
@@ -2,11 +2,12 @@
 
 Recovery actions in escalation order:
 1. RESTART_SERVICES  — systemctl restart genesis-bridge
-2. RESOURCE_CLEAR    — clear /tmp, reclaim page cache, restart
-3. REVERT_CODE       — git stash && git revert HEAD, restart
-4. RESTART_CONTAINER — incus restart genesis
-5. SNAPSHOT_ROLLBACK — incus snapshot restore genesis {last_healthy}
-6. ESCALATE          — alert user, stop automated recovery
+2. IO_TRIAGE         — kill top I/O consumer (one per cycle)
+3. RESOURCE_CLEAR    — clear /tmp, reclaim page cache, restart
+4. REVERT_CODE       — git stash && git revert HEAD, restart
+5. RESTART_CONTAINER — incus restart genesis
+6. SNAPSHOT_ROLLBACK — incus snapshot restore genesis {last_healthy}
+7. ESCALATE          — alert user, stop automated recovery
 
 Each step: pre-alert → pre-snapshot → execute → wait → verify → post-alert.
 """

--- a/src/genesis/guardian/snapshots.py
+++ b/src/genesis/guardian/snapshots.py
@@ -60,25 +60,107 @@ class SnapshotManager:
             logger.warning("Failed to parse pool space output: %s", stdout)
             return 100.0
 
-    async def safe_to_snapshot(self) -> bool:
-        """Check if it's safe to take a snapshot (pool usage below threshold)."""
-        max_pct = self._config.snapshots.max_pool_usage_pct
-        usage = await self.check_pool_space()
-        if usage > max_pct:
+    async def _get_pool_free_bytes(self) -> tuple[int, int] | None:
+        """Get (total_bytes, free_bytes) for the storage pool. None on failure."""
+        rc, pool_name, _ = await _run_subprocess(
+            "incus", "config", "device", "get", self._container, "root", "pool",
+            timeout=10.0,
+        )
+        if rc != 0 or not pool_name.strip():
+            return None
+
+        pool_path = f"/var/lib/incus/storage-pools/{pool_name.strip()}"
+        rc, stdout, stderr = await _run_subprocess(
+            "df", "--output=size,avail", "--block-size=1", pool_path,
+            timeout=10.0,
+        )
+        if rc != 0:
+            logger.warning("Failed to get pool bytes at %s: %s", pool_path, stderr)
+            return None
+
+        try:
+            lines = stdout.strip().splitlines()
+            if len(lines) < 2:
+                return None
+            parts = lines[-1].split()
+            if len(parts) < 2:
+                return None
+            return int(parts[0]), int(parts[1])
+        except (ValueError, IndexError):
+            return None
+
+    async def safe_to_snapshot(
+        self, snapshot_size_history: list[int] | None = None,
+    ) -> bool:
+        """Check if it's safe to take a snapshot using headroom-based gating.
+
+        Strategy:
+        - With snapshot size history: require free > max(min_headroom_gb, 2x avg
+          of last 3 snapshot sizes). Adapts to actual snapshot sizes.
+        - Without history: require at least 10% of pool free (safe default for
+          first snapshots before any size data is available).
+        - If pool detection fails entirely: fall back to percentage threshold
+          (max_pool_usage_pct) for robustness.
+        """
+        pool_info = await self._get_pool_free_bytes()
+        if pool_info is None:
+            # Can't get byte-level info — fall back to percentage check
+            max_pct = self._config.snapshots.max_pool_usage_pct
+            usage = await self.check_pool_space()
+            if usage > max_pct:
+                logger.error(
+                    "Pool usage %.0f%% exceeds %.0f%% threshold — refusing snapshot",
+                    usage, max_pct,
+                )
+                return False
+            return True
+
+        total_bytes, free_bytes = pool_info
+        min_headroom = int(self._config.snapshots.min_headroom_gb * 1024**3)
+
+        history = snapshot_size_history or []
+        if not history:
+            # No history — require at least 10% of pool free
+            threshold = int(total_bytes * 0.10)
+            if free_bytes < threshold:
+                logger.error(
+                    "Pool free %d bytes < 10%% threshold %d bytes — refusing snapshot",
+                    free_bytes, threshold,
+                )
+                return False
+            return True
+
+        # History available — require free > max(min_headroom, 2x avg last 3)
+        recent = history[-3:]
+        avg_size = sum(recent) // len(recent)
+        required = max(min_headroom, 2 * avg_size)
+
+        if free_bytes < required:
             logger.error(
-                "Pool usage %.0f%% exceeds %.0f%% threshold — refusing snapshot",
-                usage, max_pct,
+                "Pool free %d bytes < required headroom %d bytes "
+                "(min_headroom=%d, 2x_avg=%d, history=%d samples) — refusing snapshot",
+                free_bytes, required, min_headroom, 2 * avg_size, len(recent),
             )
             return False
+
+        logger.info(
+            "Headroom check passed: %d bytes free, %d required "
+            "(avg snapshot %d bytes, %d samples)",
+            free_bytes, required, avg_size, len(recent),
+        )
         return True
 
-    async def take(self, label: str = "") -> str | None:
+    async def take(
+        self,
+        label: str = "",
+        snapshot_size_history: list[int] | None = None,
+    ) -> str | None:
         """Create a snapshot. Returns the snapshot name or None on failure.
 
         Checks disk space before proceeding. Deletes excess snapshots
         before creating the new one to stay within retention limit.
         """
-        if not await self.safe_to_snapshot():
+        if not await self.safe_to_snapshot(snapshot_size_history):
             return None
 
         # Delete-before-create: remove excess snapshots to stay within retention
@@ -175,9 +257,13 @@ class SnapshotManager:
 
         return deleted
 
-    async def mark_healthy(self) -> str | None:
+    async def mark_healthy(
+        self, snapshot_size_history: list[int] | None = None,
+    ) -> str | None:
         """Take a snapshot labeled 'healthy'."""
-        return await self.take(label="healthy")
+        return await self.take(
+            label="healthy", snapshot_size_history=snapshot_size_history,
+        )
 
     async def get_latest_healthy(self) -> str | None:
         """Get the name of the most recent 'healthy' snapshot."""

--- a/src/genesis/guardian/snapshots.py
+++ b/src/genesis/guardian/snapshots.py
@@ -181,6 +181,9 @@ class SnapshotManager:
         if label:
             name = f"{name}-{label}"
 
+        # Measure pool free before snapshot (for size estimation after)
+        pre_info = await self._get_pool_free_bytes()
+
         rc, stdout, stderr = await _run_subprocess(
             "incus", "snapshot", "create", self._container, name,
             timeout=120.0,  # BTRFS is instant, dir is slow — compromise
@@ -190,6 +193,23 @@ class SnapshotManager:
             return None
 
         logger.info("Created snapshot: %s", name)
+
+        # Record snapshot size estimate (delta in pool free space)
+        if snapshot_size_history is not None and pre_info is not None:
+            post_info = await self._get_pool_free_bytes()
+            if post_info is not None:
+                _, pre_free = pre_info
+                _, post_free = post_info
+                size_estimate = max(0, pre_free - post_free)
+                if size_estimate > 0:
+                    snapshot_size_history.append(size_estimate)
+                    # Keep last 5 entries
+                    del snapshot_size_history[:-5]
+                    logger.info(
+                        "Snapshot size estimate: %d bytes (%d samples in history)",
+                        size_estimate, len(snapshot_size_history),
+                    )
+
         return name
 
     async def restore(self, name: str) -> bool:

--- a/src/genesis/guardian/state_machine.py
+++ b/src/genesis/guardian/state_machine.py
@@ -70,6 +70,7 @@ class StateData:
     last_cc_unavailable_alert_at: str | None = None
     auto_reset_count: int = 0  # Oscillation guard for confirmed_dead timeout
     last_recovery_at: str | None = None  # ISO8601 timestamp of last recovery attempt
+    io_triage_attempts: int = 0  # Separate counter for IO_TRIAGE (low-risk, repeatable)
     snapshot_size_history: list[int] = field(default_factory=list)  # Last N snapshot sizes in bytes
 
     def to_dict(self) -> dict:
@@ -92,6 +93,7 @@ class StateData:
             "last_cc_unavailable_alert_at": self.last_cc_unavailable_alert_at,
             "auto_reset_count": self.auto_reset_count,
             "last_recovery_at": self.last_recovery_at,
+            "io_triage_attempts": self.io_triage_attempts,
             "snapshot_size_history": self.snapshot_size_history[-5:],
         }
 
@@ -120,6 +122,7 @@ class StateData:
             last_cc_unavailable_alert_at=data.get("last_cc_unavailable_alert_at"),
             auto_reset_count=data.get("auto_reset_count", 0),
             last_recovery_at=data.get("last_recovery_at"),
+            io_triage_attempts=data.get("io_triage_attempts", 0),
             snapshot_size_history=data.get("snapshot_size_history", []),
         )
 
@@ -181,18 +184,31 @@ class ConfirmationStateMachine:
         except OSError as exc:
             logger.error("Failed to save state: %s", exc, exc_info=True)
 
-    def recovery_backoff_remaining_s(self) -> float:
+    def recovery_backoff_remaining_s(self, action: str = "") -> float:
         """Seconds remaining before next recovery attempt is allowed.
 
-        Exponential backoff: 100s, 300s, 900s (~2min, 5min, 15min).
+        IO_TRIAGE has a separate counter (low-risk, one kill per cycle).
+        All other actions share the main counter with exponential backoff:
+        100s, 300s, 900s (~2min, 5min, 15min).
+
         Returns 0 if no backoff needed, inf if already escalated.
         """
-        if self._state.recovery_attempts == 0:
-            return 0.0
-        if self._state.recovery_attempts >= self._config.recovery.max_escalations:
-            return float("inf")
-
-        backoff_s = 100.0 * (3.0 ** (self._state.recovery_attempts - 1))
+        if action == "IO_TRIAGE":
+            max_io = getattr(self._config.recovery, "max_io_triage_attempts", 5)
+            attempts = self._state.io_triage_attempts
+            if attempts == 0:
+                return 0.0
+            if attempts >= max_io:
+                return float("inf")
+            # Shorter backoff for IO_TRIAGE: 30s base, 2x multiplier
+            backoff_s = 30.0 * (2.0 ** (attempts - 1))
+        else:
+            attempts = self._state.recovery_attempts
+            if attempts == 0:
+                return 0.0
+            if attempts >= self._config.recovery.max_escalations:
+                return float("inf")
+            backoff_s = 100.0 * (3.0 ** (attempts - 1))
 
         if not self._state.last_recovery_at:
             return backoff_s
@@ -203,17 +219,17 @@ class ConfirmationStateMachine:
         except (ValueError, TypeError):
             return backoff_s
 
-    def record_recovery_attempt(self) -> None:
+    def record_recovery_attempt(self, action: str = "") -> None:
         """Record that a recovery attempt was made (for backoff tracking).
 
-        Advances both the timestamp AND the attempt counter. The counter
-        must advance on every attempt — including action failures — so that
-        backoff grows even when recovery never reaches the RECOVERED state.
-        Without this, action-failure loops retry at the 30s check interval
-        with no backoff (the exact cascade pattern from the 2026-05-25 incident).
+        IO_TRIAGE increments its own counter. All other actions increment
+        the main counter. Both share the last_recovery_at timestamp.
         """
         self._state.last_recovery_at = datetime.now(UTC).isoformat()
-        self._state.recovery_attempts += 1
+        if action == "IO_TRIAGE":
+            self._state.io_triage_attempts += 1
+        else:
+            self._state.recovery_attempts += 1
 
     def process(self, snapshot: HealthSnapshot) -> Transition:
         """Process a health snapshot and return the state transition.
@@ -592,6 +608,7 @@ class ConfirmationStateMachine:
         self._state.first_failure_at = None
         self._state.last_healthy_at = now
         self._state.recovery_attempts = 0
+        self._state.io_triage_attempts = 0
         self._state.last_recovery_at = None
         self._clear_dialogue_state()
         self.clear_cc_unavailable()

--- a/src/genesis/guardian/state_machine.py
+++ b/src/genesis/guardian/state_machine.py
@@ -66,6 +66,7 @@ class StateData:
     dialogue_sent_at: str | None = None
     dialogue_eta_s: int = 0
     dialogue_action: str | None = None
+    sentinel_state: str = ""  # Latest Sentinel state from dialogue response
     cc_unavailable_since: str | None = None
     last_cc_unavailable_alert_at: str | None = None
     auto_reset_count: int = 0  # Oscillation guard for confirmed_dead timeout
@@ -89,6 +90,7 @@ class StateData:
             "dialogue_sent_at": self.dialogue_sent_at,
             "dialogue_eta_s": self.dialogue_eta_s,
             "dialogue_action": self.dialogue_action,
+            "sentinel_state": self.sentinel_state,
             "cc_unavailable_since": self.cc_unavailable_since,
             "last_cc_unavailable_alert_at": self.last_cc_unavailable_alert_at,
             "auto_reset_count": self.auto_reset_count,
@@ -118,6 +120,7 @@ class StateData:
             dialogue_sent_at=data.get("dialogue_sent_at"),
             dialogue_eta_s=data.get("dialogue_eta_s", 0),
             dialogue_action=data.get("dialogue_action"),
+            sentinel_state=data.get("sentinel_state", ""),
             cc_unavailable_since=data.get("cc_unavailable_since"),
             last_cc_unavailable_alert_at=data.get("last_cc_unavailable_alert_at"),
             auto_reset_count=data.get("auto_reset_count", 0),
@@ -303,19 +306,26 @@ class ConfirmationStateMachine:
                     new_state=GuardianState.HEALTHY,
                     reason="Genesis self-healed successfully",
                 )
-            # Check if ETA has expired
-            if self._dialogue_eta_expired():
+            # Event-driven: check Sentinel state, not wall-clock timeout
+            if self._should_proceed_past_self_heal():
+                reason = (
+                    f"Sentinel state '{self._state.sentinel_state or 'unreachable'}' "
+                    f"— proceeding to diagnosis"
+                )
                 self._state.current_state = GuardianState.CONFIRMED_DEAD
                 return Transition(
                     old_state=old_state,
                     new_state=GuardianState.CONFIRMED_DEAD,
-                    reason="Genesis self-heal ETA expired, still unhealthy",
+                    reason=reason,
                     action_needed=True,
                 )
             return Transition(
                 old_state=old_state,
                 new_state=GuardianState.AWAITING_SELF_HEAL,
-                reason=f"waiting for Genesis self-heal: {self._state.dialogue_action}",
+                reason=(
+                    f"waiting for Sentinel ({self._state.sentinel_state}): "
+                    f"{self._state.dialogue_action}"
+                ),
             )
         elif old_state == GuardianState.CONFIRMED_DEAD:
             if snapshot.all_alive:
@@ -615,22 +625,37 @@ class ConfirmationStateMachine:
 
     # ── External state manipulation (called by recovery engine) ────────
 
-    def _dialogue_eta_expired(self) -> bool:
-        """Check if the self-heal ETA has passed."""
-        if not self._state.dialogue_sent_at or not self._state.dialogue_eta_s:
-            return True
-        try:
-            sent = datetime.fromisoformat(self._state.dialogue_sent_at)
-            elapsed = (datetime.now(UTC) - sent).total_seconds()
-            return elapsed > self._state.dialogue_eta_s
-        except (ValueError, TypeError):
-            return True
+    def _should_proceed_past_self_heal(self) -> bool:
+        """Check if Guardian should stop waiting for Sentinel.
+
+        Event-driven standing — NO wall-clock timeout. Proceeds ONLY when:
+        - Sentinel state is empty (Genesis unreachable, no state reported)
+        - Sentinel transitioned to "escalated" (explicitly gave up)
+        - Sentinel returned to "healthy" (thinks it fixed it — but probes
+          say otherwise, so Guardian should proceed to its own diagnosis)
+
+        NEVER proceeds based on elapsed time. If Sentinel is investigating
+        or awaiting approval for 8 hours, Guardian waits 8 hours. User
+        sovereignty is absolute.
+        """
+        state = self._state.sentinel_state
+        if not state:
+            return True  # No state = Genesis unreachable
+        if state == "escalated":
+            return True  # Sentinel explicitly gave up
+        # "healthy" = Sentinel thinks it fixed it, but probes still fail
+        return state == "healthy"
 
     def _clear_dialogue_state(self) -> None:
         """Clear dialogue tracking fields."""
         self._state.dialogue_sent_at = None
         self._state.dialogue_eta_s = 0
         self._state.dialogue_action = None
+        self._state.sentinel_state = ""
+
+    def update_sentinel_state(self, state: str) -> None:
+        """Update the latest Sentinel state (called by check.py on re-query)."""
+        self._state.sentinel_state = state
 
     # ── External state manipulation (called by check.py) ───────────────
 

--- a/src/genesis/guardian/state_machine.py
+++ b/src/genesis/guardian/state_machine.py
@@ -70,6 +70,7 @@ class StateData:
     last_cc_unavailable_alert_at: str | None = None
     auto_reset_count: int = 0  # Oscillation guard for confirmed_dead timeout
     last_recovery_at: str | None = None  # ISO8601 timestamp of last recovery attempt
+    snapshot_size_history: list[int] = field(default_factory=list)  # Last N snapshot sizes in bytes
 
     def to_dict(self) -> dict:
         return {
@@ -91,6 +92,7 @@ class StateData:
             "last_cc_unavailable_alert_at": self.last_cc_unavailable_alert_at,
             "auto_reset_count": self.auto_reset_count,
             "last_recovery_at": self.last_recovery_at,
+            "snapshot_size_history": self.snapshot_size_history[-5:],
         }
 
     @classmethod
@@ -118,6 +120,7 @@ class StateData:
             last_cc_unavailable_alert_at=data.get("last_cc_unavailable_alert_at"),
             auto_reset_count=data.get("auto_reset_count", 0),
             last_recovery_at=data.get("last_recovery_at"),
+            snapshot_size_history=data.get("snapshot_size_history", []),
         )
 
 

--- a/src/genesis/observability/snapshots/api_keys.py
+++ b/src/genesis/observability/snapshots/api_keys.py
@@ -162,27 +162,22 @@ def api_key_health(
         )
         results[name] = entry
 
-    # Include disabled providers as dormant
+    # Include disabled providers for visibility — but mark as "disabled",
+    # not "missing".  A deliberately disabled provider must not generate
+    # alerts or poison the aggregate for its provider type.
     for name, ptype in getattr(routing_config, "disabled_providers", {}).items():
         if name not in results:
-            crit_info = crit_map.get(ptype, {})
             results[name] = {
-                "status": "missing",
+                "status": "disabled",
                 "provider_type": ptype,
-                "chain_count": crit_info.get("chain_count", 0),
-                "chain_usage": crit_info.get("chain_usage", []),
-                "criticality": crit_info.get("criticality", "dormant"),
-                "is_free": crit_info.get("is_free", False),
-                "sole_sites": crit_info.get("sole_sites", []),
+                "chain_count": 0,
+                "chain_usage": [],
+                "criticality": "dormant",
+                "is_free": True,
+                "sole_sites": [],
                 "cb_state": "closed",
                 "cb_reason": None,
-                "alert_severity": _compute_alert_severity(
-                    status="missing",
-                    criticality=crit_info.get("criticality", "dormant"),
-                    is_free=crit_info.get("is_free", False),
-                    cb_state="closed",
-                    cb_reason=None,
-                ),
+                "alert_severity": None,
             }
 
     # Build attention-strip alerts

--- a/src/genesis/sentinel/prompts/SENTINEL.md
+++ b/src/genesis/sentinel/prompts/SENTINEL.md
@@ -117,11 +117,33 @@ Common infrastructure failures and their fixes:
 | Watchdog timer inactive | `systemctl --user status genesis-watchdog.timer` | `systemctl --user start genesis-watchdog.timer` |
 | Qdrant unreachable | Check port 6333, `systemctl status qdrant` | `sudo systemctl restart qdrant` |
 | Bridge service down | `systemctl --user status genesis-server` | `systemctl --user restart genesis-server.service` |
-| Memory pressure >90% | Check `/sys/fs/cgroup/memory.current` vs `memory.max` | `sync && echo 1 > /proc/sys/vm/drop_caches` or identify leak |
+| Memory pressure >90% | Check `/sys/fs/cgroup/memory.stat` (anon + kernel) vs `memory.max` | `sync && echo 1 > /proc/sys/vm/drop_caches` or identify leak |
+| I/O saturation | `cat /sys/fs/cgroup/io.pressure` — check full avg10 | Identify top I/O consumer; container I/O may be throttled by host io.max |
 | /tmp full | `df /tmp` | Clean old files: `find /tmp -type f -not -name '*.sock' -mmin +5 -delete` |
 | Disk >90% | `df -h /` | `sudo journalctl --vacuum-size=100M` |
 | Guardian heartbeat stale | Check `~/.genesis/guardian_heartbeat.json` age | SSH probe to verify Guardian is alive vs heartbeat delivery broken |
 | Auth blocking health probes | Check dashboard auth config | Verify /api/ routes are exempted from auth |
+
+## Guardian Coordination
+
+Your state (INVESTIGATING, REMEDIATING, AWAITING_DISPATCH_APPROVAL,
+AWAITING_ACTION_APPROVAL, ESCALATED, HEALTHY) is read by the external Guardian
+on every 30-second tick. As long as you are in any active state, Guardian waits
+indefinitely — there is no wall-clock timeout. User sovereignty is absolute.
+
+This means: be thorough, not fast. Take the time to properly diagnose. Guardian
+will not jump the gun while you are working.
+
+Your state is written to `~/.genesis/shared/sentinel/sentinel_state.json` by the
+dispatcher. Guardian reads this file (or queries it via the dialogue endpoint)
+to decide whether to wait or proceed to its own diagnosis.
+
+## Partial Protection
+
+You run inside the Genesis server process. If the server is frozen (D-state from
+I/O saturation), you are frozen too. If Python is healthy but I/O is saturated,
+you might be responsive but slow. Acknowledge this limitation in your diagnosis —
+if you're experiencing high latency on every command, I/O saturation is likely.
 
 ## Grounding Rules
 

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -319,6 +319,12 @@ class TestYamlLoading:
 
 
 class TestPageCacheReclaim:
+    @pytest.fixture(autouse=True)
+    def _reset_reclaim_cooldown(self):
+        """Reset the module-level cooldown so each test starts fresh."""
+        import genesis.autonomy.watchdog as w
+        w._last_reclaim_time = 0.0
+
     def test_reclaim_succeeds_when_path_exists(self, tmp_path: Path):
         reclaim_file = tmp_path / "memory.reclaim"
         reclaim_file.write_text("")

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -322,8 +322,12 @@ class TestPageCacheReclaim:
     @pytest.fixture(autouse=True)
     def _reset_reclaim_cooldown(self):
         """Reset the module-level cooldown so each test starts fresh."""
+        import time
+
         import genesis.autonomy.watchdog as w
-        w._last_reclaim_time = 0.0
+        # Set to far in the past so cooldown check passes even on fresh CI runners
+        # where time.monotonic() may be small (recently booted).
+        w._last_reclaim_time = time.monotonic() - 600
 
     def test_reclaim_succeeds_when_path_exists(self, tmp_path: Path):
         reclaim_file = tmp_path / "memory.reclaim"

--- a/tests/test_contribution/test_version_gate.py
+++ b/tests/test_contribution/test_version_gate.py
@@ -188,7 +188,7 @@ async def test_no_api_key_fails_open(monkeypatch):
     fake_commits = [{"sha": "x", "subject": "unrelated", "body": ""}]
     monkeypatch.setattr(version_gate, "fetch_upstream_log", lambda *a, **k: fake_commits)
     # Clear all known keys
-    for var in ("API_KEY_OPENROUTER", "GROQ_API_KEY", "GEMINI_API_KEY"):
+    for var in ("API_KEY_OPENROUTER", "GROQ_API_KEY", "GOOGLE_API_KEY"):
         monkeypatch.delenv(var, raising=False)
     r = await version_gate.check_version_gate(
         user_subject="s", user_body="b", user_diff="d",

--- a/tests/test_guardian/test_diagnosis.py
+++ b/tests/test_guardian/test_diagnosis.py
@@ -232,13 +232,15 @@ class TestRecoveryAction:
 
     def test_all_actions_defined(self) -> None:
         actions = list(RecoveryAction)
-        assert len(actions) == 6
+        assert len(actions) == 7
         assert RecoveryAction.RESTART_SERVICES in actions
+        assert RecoveryAction.IO_TRIAGE in actions
         assert RecoveryAction.ESCALATE in actions
 
     def test_escalation_order(self) -> None:
         ordered = [
             RecoveryAction.RESTART_SERVICES,
+            RecoveryAction.IO_TRIAGE,
             RecoveryAction.RESOURCE_CLEAR,
             RecoveryAction.REVERT_CODE,
             RecoveryAction.RESTART_CONTAINER,

--- a/tests/test_guardian/test_dialogue.py
+++ b/tests/test_guardian/test_dialogue.py
@@ -242,14 +242,14 @@ class TestDialogueStateMachineIntegration:
         assert t.new_state == GuardianState.HEALTHY
         assert "self-healed" in t.reason
 
-    def test_awaiting_self_heal_eta_expires(self) -> None:
+    def test_awaiting_self_heal_sentinel_escalated(self) -> None:
+        """Sentinel escalated → Guardian proceeds to diagnosis."""
         from genesis.guardian.state_machine import ConfirmationStateMachine, GuardianState
 
         config = GuardianConfig()
         sm = ConfirmationStateMachine(config)
-        sm.set_awaiting_self_heal(action="restarting bridge", eta_s=60)
-        # Set dialogue_sent_at to the past so ETA is expired
-        sm._state.dialogue_sent_at = "2026-03-25T11:00:00+00:00"
+        sm.set_awaiting_self_heal(action="sentinel_dispatched", eta_s=0)
+        sm.update_sentinel_state("escalated")
 
         dead = HealthSnapshot(
             signals={
@@ -260,19 +260,17 @@ class TestDialogueStateMachineIntegration:
         )
         t = sm.process(dead)
         assert t.new_state == GuardianState.CONFIRMED_DEAD
-        assert "ETA expired" in t.reason
+        assert "escalated" in t.reason
         assert t.action_needed is True
 
-    def test_awaiting_self_heal_still_waiting(self) -> None:
-        from datetime import UTC, datetime
-
+    def test_awaiting_self_heal_sentinel_active(self) -> None:
+        """Sentinel investigating → Guardian waits (event-driven, no timeout)."""
         from genesis.guardian.state_machine import ConfirmationStateMachine, GuardianState
 
         config = GuardianConfig()
         sm = ConfirmationStateMachine(config)
-        sm.set_awaiting_self_heal(action="restarting bridge", eta_s=300)
-        # ETA is 5 min, set sent_at to now so it hasn't expired
-        sm._state.dialogue_sent_at = datetime.now(UTC).isoformat()
+        sm.set_awaiting_self_heal(action="sentinel_dispatched", eta_s=0)
+        sm.update_sentinel_state("investigating")
 
         dead = HealthSnapshot(
             signals={
@@ -284,3 +282,45 @@ class TestDialogueStateMachineIntegration:
         t = sm.process(dead)
         assert t.new_state == GuardianState.AWAITING_SELF_HEAL
         assert "waiting" in t.reason.lower()
+
+    def test_awaiting_self_heal_awaiting_approval_indefinitely(self) -> None:
+        """User sovereignty: Sentinel awaiting approval → Guardian waits forever."""
+        from genesis.guardian.state_machine import ConfirmationStateMachine, GuardianState
+
+        config = GuardianConfig()
+        sm = ConfirmationStateMachine(config)
+        sm.set_awaiting_self_heal(action="sentinel_dispatched", eta_s=0)
+        sm.update_sentinel_state("awaiting_action_approval")
+        # Even with a very old dialogue_sent_at, Guardian does NOT timeout
+        sm._state.dialogue_sent_at = "2026-01-01T00:00:00+00:00"
+
+        dead = HealthSnapshot(
+            signals={
+                "container_exists": SignalResult("container_exists", True, 1.0, "ok", "t"),
+                "health_api": SignalResult("health_api", False, 1.0, "down", "t"),
+            },
+            pause_state=PauseState(paused=False),
+        )
+        t = sm.process(dead)
+        assert t.new_state == GuardianState.AWAITING_SELF_HEAL
+        assert "waiting" in t.reason.lower()
+
+    def test_awaiting_self_heal_unreachable(self) -> None:
+        """Genesis unreachable (empty sentinel_state) → proceed to diagnosis."""
+        from genesis.guardian.state_machine import ConfirmationStateMachine, GuardianState
+
+        config = GuardianConfig()
+        sm = ConfirmationStateMachine(config)
+        sm.set_awaiting_self_heal(action="sentinel_dispatched", eta_s=0)
+        # sentinel_state empty = unreachable
+        sm.update_sentinel_state("")
+
+        dead = HealthSnapshot(
+            signals={
+                "container_exists": SignalResult("container_exists", False, 1.0, "down", "t"),
+            },
+            pause_state=PauseState(paused=False),
+        )
+        t = sm.process(dead)
+        assert t.new_state == GuardianState.CONFIRMED_DEAD
+        assert t.action_needed is True

--- a/tests/test_guardian/test_recovery.py
+++ b/tests/test_guardian/test_recovery.py
@@ -168,6 +168,52 @@ class TestRecoveryResourceClear:
         assert result.success is True
 
 
+class TestRecoveryIOTriage:
+
+    @pytest.mark.asyncio
+    async def test_io_triage_kills_top_consumer(self, engine: RecoveryEngine) -> None:
+        """IO_TRIAGE should kill the top I/O consumer when PSI is not dropping."""
+        with (
+            patch("genesis.guardian.recovery.collect_all_signals", return_value=_healthy_snapshot()),
+            patch.object(engine._snapshots, "safe_to_snapshot", return_value=True),
+            patch.object(engine._snapshots, "take", return_value="pre-recovery"),
+            patch("genesis.guardian.recovery.RecoveryEngine._io_triage") as mock_triage,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_triage.return_value = (True, "Killed PID 1234 (claude)")
+            result = await engine.execute(_diagnosis(RecoveryAction.IO_TRIAGE))
+        assert result.success is True
+        assert result.action == RecoveryAction.IO_TRIAGE
+
+    @pytest.mark.asyncio
+    async def test_io_triage_stands_down_when_recovering(self, engine: RecoveryEngine) -> None:
+        """IO_TRIAGE should stand down when PSI trend shows recovery."""
+        with (
+            patch("genesis.guardian.recovery.collect_all_signals", return_value=_healthy_snapshot()),
+            patch.object(engine._snapshots, "safe_to_snapshot", return_value=True),
+            patch.object(engine._snapshots, "take", return_value="pre-recovery"),
+            patch("genesis.guardian.recovery.RecoveryEngine._io_triage") as mock_triage,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_triage.return_value = (True, "I/O pressure recovering — standing down")
+            result = await engine.execute(_diagnosis(RecoveryAction.IO_TRIAGE))
+        assert result.success is True
+        assert "recovering" in result.detail.lower() or result.detail  # stood down
+
+    @pytest.mark.asyncio
+    async def test_io_triage_separate_counter(self, engine: RecoveryEngine) -> None:
+        """IO_TRIAGE should use io_triage_attempts, not recovery_attempts."""
+        # Record an IO_TRIAGE attempt
+        engine._sm.record_recovery_attempt("IO_TRIAGE")
+        assert engine._sm.state.io_triage_attempts == 1
+        assert engine._sm.state.recovery_attempts == 0  # Separate counter
+
+        # Record a regular recovery attempt
+        engine._sm.record_recovery_attempt("RESTART_SERVICES")
+        assert engine._sm.state.io_triage_attempts == 1  # Unchanged
+        assert engine._sm.state.recovery_attempts == 1
+
+
 class TestRecoveryRevertCode:
 
     @pytest.mark.asyncio

--- a/tests/test_guardian/test_snapshots.py
+++ b/tests/test_guardian/test_snapshots.py
@@ -197,6 +197,143 @@ class TestMarkHealthy:
         assert name.endswith("-healthy")
 
 
+def _mock_subprocess_headroom(
+    total_bytes: int = 300 * 1024**3,
+    free_bytes: int = 100 * 1024**3,
+    snapshot_rc: int = 0,
+    post_free_bytes: int | None = None,
+):
+    """Mock that returns byte-level pool info for headroom tests."""
+    state = {"snapshot_created": False}
+
+    async def mock(*args, **kwargs):
+        cmd = args[0] if args else ""
+        all_args = " ".join(str(a) for a in args)
+        if cmd == "incus" and len(args) > 3 and args[1] == "config":
+            return (0, "genesis-pool\n", "")
+        if cmd == "df" and "--block-size=1" in all_args:
+            # After snapshot create, return post_free_bytes
+            if state["snapshot_created"] and post_free_bytes is not None:
+                return (0, f"1B-blocks Avail\n{total_bytes} {post_free_bytes}\n", "")
+            return (0, f"1B-blocks Avail\n{total_bytes} {free_bytes}\n", "")
+        if cmd == "df":
+            # Percentage-based (check_pool_space fallback)
+            pct = int((1 - free_bytes / total_bytes) * 100) if total_bytes else 100
+            return (0, f"Use%\n {pct}%\n", "")
+        if cmd == "incus" and len(args) > 2 and args[1] == "snapshot":
+            if args[2] == "list":
+                return (0, "[]", "")
+            if args[2] == "create":
+                state["snapshot_created"] = True
+            return (snapshot_rc, "", "")
+        return (snapshot_rc, "", "")
+    return mock
+
+
+class TestHeadroomGating:
+    """Tests for headroom-based snapshot gating."""
+
+    @pytest.mark.asyncio
+    async def test_no_history_requires_10pct_free(self, manager: SnapshotManager) -> None:
+        """Without snapshot size history, require 10% of pool free."""
+        # 300GB pool, 100GB free = 33% free → should pass
+        with patch(
+            "genesis.guardian.snapshots._run_subprocess",
+            _mock_subprocess_headroom(
+                total_bytes=300 * 1024**3, free_bytes=100 * 1024**3,
+            ),
+        ):
+            ok = await manager.safe_to_snapshot(snapshot_size_history=[])
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_no_history_rejects_low_free(self, manager: SnapshotManager) -> None:
+        """Without history, reject if < 10% free."""
+        # 300GB pool, 5GB free = 1.7% → should fail
+        with patch(
+            "genesis.guardian.snapshots._run_subprocess",
+            _mock_subprocess_headroom(
+                total_bytes=300 * 1024**3, free_bytes=5 * 1024**3,
+            ),
+        ):
+            ok = await manager.safe_to_snapshot(snapshot_size_history=[])
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_with_history_uses_headroom(self, manager: SnapshotManager) -> None:
+        """With history, require free > max(5GB, 2x avg last 3 snapshots)."""
+        # History: 3 snapshots averaging 2GB each → need max(5GB, 4GB) = 5GB
+        # 300GB pool, 10GB free → should pass (10GB > 5GB)
+        history = [2 * 1024**3, 2 * 1024**3, 2 * 1024**3]
+        with patch(
+            "genesis.guardian.snapshots._run_subprocess",
+            _mock_subprocess_headroom(
+                total_bytes=300 * 1024**3, free_bytes=10 * 1024**3,
+            ),
+        ):
+            ok = await manager.safe_to_snapshot(snapshot_size_history=history)
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_with_history_rejects_tight_headroom(self, manager: SnapshotManager) -> None:
+        """Reject when free space < required headroom."""
+        # History: 3 snapshots averaging 10GB each → need max(5GB, 20GB) = 20GB
+        # 300GB pool, 15GB free → should fail (15GB < 20GB)
+        history = [10 * 1024**3, 10 * 1024**3, 10 * 1024**3]
+        with patch(
+            "genesis.guardian.snapshots._run_subprocess",
+            _mock_subprocess_headroom(
+                total_bytes=300 * 1024**3, free_bytes=15 * 1024**3,
+            ),
+        ):
+            ok = await manager.safe_to_snapshot(snapshot_size_history=history)
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_pool_detection_failure_falls_back_to_percentage(
+        self, manager: SnapshotManager,
+    ) -> None:
+        """If _get_pool_free_bytes returns None, fall back to old pct check."""
+        call_count = {"pool": 0}
+
+        async def mock(*args, **kwargs):
+            cmd = args[0] if args else ""
+            all_args = " ".join(str(a) for a in args)
+            if cmd == "incus" and len(args) > 3 and args[1] == "config":
+                call_count["pool"] += 1
+                if "--block-size=1" in all_args or call_count["pool"] <= 1:
+                    # First pool detection (for _get_pool_free_bytes) fails
+                    return (1, "", "error")
+                # Second pool detection (for check_pool_space) succeeds
+                return (0, "genesis-pool\n", "")
+            if cmd == "df":
+                return (0, "Use%\n 20%\n", "")
+            return (0, "", "")
+
+        with patch("genesis.guardian.snapshots._run_subprocess", mock):
+            ok = await manager.safe_to_snapshot(snapshot_size_history=[1024])
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_take_records_size_to_history(self, manager: SnapshotManager) -> None:
+        """After successful take(), snapshot size should be appended to history."""
+        history: list[int] = []
+        free_before = 100 * 1024**3
+        free_after = 98 * 1024**3  # 2GB snapshot
+        with patch(
+            "genesis.guardian.snapshots._run_subprocess",
+            _mock_subprocess_headroom(
+                total_bytes=300 * 1024**3,
+                free_bytes=free_before,
+                post_free_bytes=free_after,
+            ),
+        ):
+            name = await manager.take(label="test", snapshot_size_history=history)
+        assert name is not None
+        assert len(history) == 1
+        assert history[0] == free_before - free_after
+
+
 class TestGetLatestHealthy:
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Post-incident hardening from the 2026-05-25 I/O death spiral. Implements 3 of 4 designs from the [cgroup v2 I/O resilience spec](docs/superpowers/specs/2026-05-25-cgroup-io-resilience.md). Design 4 (cgroup v2 isolation) deferred to a dedicated session for live testing.

- **Snapshot headroom gating (Design 1):** Replaces fixed 80% pool threshold with adaptive headroom — requires free > max(5GB, 2x avg recent snapshots). Records snapshot sizes for learning.
- **IO_TRIAGE recovery action (Design 3):** New escalation step that kills the top I/O consumer (one per cycle). Separate attempt counter (max 5) from main escalation budget (max 3). PSI trend check stands down if pressure is dropping. Never touches io.max.
- **Event-driven Sentinel coordination (Design 2):** Replaces fixed 300s/600s ETA timeout. Guardian re-queries Sentinel state every tick, waits as long as Sentinel is active. No wall-clock timeout. User sovereignty is absolute.
- **CC memory preflight:** Removed sonnet downgrade (model runs in cloud). Hard floor lowered to 2 GiB (catastrophic host-level only). MemoryMax=6G is the real safety boundary.
- **Dashboard fix:** Disabled provider (openrouter-deepseek-r1) no longer poisons the API key alert aggregate.
- **Deploy fix:** Existing users get sysctl/udev I/O tuning on update via gateway script.
- **Docs:** Guardian CLAUDE.md, Sentinel prompt, DEPLOYMENT.md fully updated.
- **Bug fix:** GEMINI_API_KEY → GOOGLE_API_KEY in contribution version gate (post-merge review catch from PR #447).

## Test plan

- [x] 491 tests passing (10 new: 7 headroom, 3 IO_TRIAGE)
- [x] ruff check clean
- [x] Code review (structured + adversarial)
- [x] Post-merge reviews on PRs #446 and #447
- [ ] CI green
- [ ] Verify dashboard alert cleared after restart
- [ ] Verify Guardian CLAUDE.md deployed to host via update

🤖 Generated with [Claude Code](https://claude.com/claude-code)