### PR TITLE
feat(learning): self-learning validation gate

### DIFF
--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -146,30 +146,41 @@ VALID_PROFILES = frozenset(PROFILES.keys())
 # Profile addendum + skill auto-injection
 # ---------------------------------------------------------------------------
 
+_MISSION_INJECTION = (
+    "If it's digital, it's within reach. Adapt and overcome. "
+    "Don't conclude \"impossible\" — conclude \"blocked by X\" and identify what would unblock it."
+)
+
 _PROFILE_ADDENDA: dict[str, str] = {
-    "interact": """
+    "interact": f"""
 
 ## Session Profile: interact
 
 You have: Write, browser MCP tools, memory MCP tools, outreach send.
 You do NOT have: Edit, Bash, NotebookEdit.
 Your final message IS your deliverable. Write files to `~/.genesis/output/`.
+
+{_MISSION_INJECTION}
 """,
-    "research": """
+    "research": f"""
 
 ## Session Profile: research
 
 You have: Write, memory MCP tools, web tools (web_search, web_fetch).
 You do NOT have: Edit, Bash, NotebookEdit, browser tools.
 Your final message IS your deliverable. Write files to `~/.genesis/output/`.
+
+{_MISSION_INJECTION}
 """,
-    "observe": """
+    "observe": f"""
 
 ## Session Profile: observe
 
 You have: memory MCP tools (read-only).
 You do NOT have: Write, Edit, Bash, NotebookEdit, browser tools.
 Your final message IS your deliverable.
+
+{_MISSION_INJECTION}
 """,
 }
 

--- a/src/genesis/db/crud/procedural.py
+++ b/src/genesis/db/crud/procedural.py
@@ -28,21 +28,24 @@ async def create(
     source: str | None = None,
     promotion_history: str | None = None,
     principle_embedding: bytes | None = None,
+    extraction_context: str | None = None,
+    first_mover: int = 0,
 ) -> str:
     await db.execute(
         """INSERT INTO procedural_memory
            (id, person_id, task_type, principle, steps, tools_used, context_tags,
             speculative, attempted_workarounds, version, created_at,
             activation_tier, tool_trigger, success_count, confidence,
-            source, promotion_history, principle_embedding)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            source, promotion_history, principle_embedding,
+            extraction_context, first_mover)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (id, person_id, task_type, principle, json.dumps(steps), json.dumps(tools_used),
          json.dumps(context_tags), speculative,
          json.dumps(attempted_workarounds) if attempted_workarounds else None,
          version, created_at, activation_tier,
          json.dumps(tool_trigger) if tool_trigger else None,
          success_count, confidence, source, promotion_history,
-         principle_embedding),
+         principle_embedding, extraction_context, first_mover),
     )
     await db.commit()
     return id

--- a/src/genesis/db/crud/watermarks.py
+++ b/src/genesis/db/crud/watermarks.py
@@ -1,0 +1,57 @@
+"""CRUD operations for task_type_watermarks table."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import aiosqlite
+
+
+async def get_watermark(db: aiosqlite.Connection, task_type: str) -> dict | None:
+    """Fetch the watermark row for a task_type, or None if not found."""
+    cursor = await db.execute(
+        "SELECT * FROM task_type_watermarks WHERE task_type = ?",
+        (task_type,),
+    )
+    row = cursor.description and await cursor.fetchone()
+    if not row:
+        return None
+    cols = [d[0] for d in cursor.description]
+    return dict(zip(cols, row, strict=True))
+
+
+async def upsert_watermark(
+    db: aiosqlite.Connection,
+    *,
+    task_type: str,
+    best_outcome: str,
+    total_sessions: int,
+    successful_sessions: int,
+) -> None:
+    """Create or update the watermark for a task_type.
+
+    Only ratchets best_outcome upward (caller handles comparison).
+    """
+    now = datetime.now(UTC).isoformat()
+    await db.execute(
+        """
+        INSERT INTO task_type_watermarks
+            (task_type, best_outcome, best_outcome_at, total_sessions,
+             successful_sessions, last_session_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(task_type) DO UPDATE SET
+            best_outcome = excluded.best_outcome,
+            best_outcome_at = CASE
+                WHEN excluded.best_outcome != task_type_watermarks.best_outcome
+                THEN excluded.best_outcome_at
+                ELSE task_type_watermarks.best_outcome_at
+            END,
+            total_sessions = excluded.total_sessions,
+            successful_sessions = excluded.successful_sessions,
+            last_session_at = excluded.last_session_at,
+            updated_at = excluded.updated_at
+        """,
+        (task_type, best_outcome, now, total_sessions,
+         successful_sessions, now, now),
+    )
+    await db.commit()

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1175,6 +1175,25 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         )
     """)
 
+    # Self-learning validation gate: watermarks table + procedural_memory columns.
+    await db.execute("""
+        CREATE TABLE IF NOT EXISTS task_type_watermarks (
+            task_type            TEXT PRIMARY KEY,
+            best_outcome         TEXT NOT NULL,
+            best_outcome_at      TEXT NOT NULL,
+            total_sessions       INTEGER NOT NULL DEFAULT 0,
+            successful_sessions  INTEGER NOT NULL DEFAULT 0,
+            last_session_at      TEXT NOT NULL,
+            updated_at           TEXT NOT NULL
+        )
+    """)
+    await _try_alter(db,
+        "ALTER TABLE procedural_memory ADD COLUMN extraction_context TEXT",
+        "procedural_memory.extraction_context")
+    await _try_alter(db,
+        "ALTER TABLE procedural_memory ADD COLUMN first_mover INTEGER NOT NULL DEFAULT 0",
+        "procedural_memory.first_mover")
+
 
 async def _migrate_cognitive_state_check(db: aiosqlite.Connection) -> None:
     """Rebuild cognitive_state if CHECK constraint lacks 'resilience_degradation'.

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1126,6 +1126,17 @@ TABLES = {
             error_message     TEXT
         )
     """,
+    "task_type_watermarks": """
+        CREATE TABLE IF NOT EXISTS task_type_watermarks (
+            task_type            TEXT PRIMARY KEY,
+            best_outcome         TEXT NOT NULL,
+            best_outcome_at      TEXT NOT NULL,
+            total_sessions       INTEGER NOT NULL DEFAULT 0,
+            successful_sessions  INTEGER NOT NULL DEFAULT 0,
+            last_session_at      TEXT NOT NULL,
+            updated_at           TEXT NOT NULL
+        )
+    """,
 }
 
 # FTS5 virtual tables (in-memory SQLite does NOT support FTS5 unless compiled with it)

--- a/src/genesis/eval/j9_hooks.py
+++ b/src/genesis/eval/j9_hooks.py
@@ -134,6 +134,33 @@ async def emit_procedure_outcome(
         logger.debug("eval: failed to emit procedure_outcome", exc_info=True)
 
 
+async def emit_gate_decision(
+    db: aiosqlite.Connection,
+    *,
+    task_type: str,
+    outcome: str,
+    allowed: bool,
+    confidence: float,
+    flags: list[str],
+) -> None:
+    """Log a validation gate decision for procedural extraction."""
+    try:
+        await j9_eval.insert_event(
+            db,
+            dimension="procedure",
+            event_type="gate_decision",
+            metrics={
+                "task_type": task_type,
+                "outcome": outcome,
+                "allowed": allowed,
+                "confidence": confidence,
+                "flags": flags[:5],
+            },
+        )
+    except Exception:
+        logger.debug("eval: failed to emit gate_decision", exc_info=True)
+
+
 async def emit_recall_diagnostics(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/learning/pipeline.py
+++ b/src/genesis/learning/pipeline.py
@@ -182,6 +182,7 @@ def build_triage_pipeline(
                     summary_text=summary_text,
                     outcome=outcome.value,
                     router=router,
+                    session_tools_count=len(summary.tool_calls),
                 )
             except Exception:
                 logger.error("Procedure extraction failed (non-fatal)", exc_info=True)

--- a/src/genesis/learning/procedural/extractor.py
+++ b/src/genesis/learning/procedural/extractor.py
@@ -194,6 +194,7 @@ async def extract_procedure(
     outcome: str,
     router: _Router,
     embedding_provider: EmbeddingProvider | None = None,
+    session_tools_count: int = 0,
 ) -> str | None:
     """Extract a procedure from an interaction summary via LLM.
 
@@ -346,6 +347,41 @@ async def extract_procedure(
                 exc_info=True,
             )
 
+    # ── Validation gate ───────────────────────────────────────────────────
+    from genesis.learning.procedural.validation_gate import validate_extraction
+
+    gate_result = await validate_extraction(
+        db,
+        task_type=data["task_type"],
+        principle=data["principle"],
+        steps=data["steps"],
+        tools_used=data["tools_used"],
+        outcome=outcome,
+        summary_text=summary_text,
+        session_tools_count=session_tools_count,
+    )
+
+    if not gate_result.allowed:
+        logger.info(
+            "Validation gate blocked extraction: task_type=%s flags=%s",
+            data["task_type"], gate_result.flags,
+        )
+        # Emit J9 event for monitoring
+        try:
+            from genesis.eval.j9_hooks import emit_gate_decision
+
+            await emit_gate_decision(
+                db,
+                task_type=data["task_type"],
+                outcome=outcome,
+                allowed=False,
+                confidence=0.0,
+                flags=gate_result.flags,
+            )
+        except Exception:
+            pass  # Fire-and-forget
+        return None
+
     try:
         proc_id = await store_procedure(
             db,
@@ -357,11 +393,28 @@ async def extract_procedure(
             tool_trigger=data.get("tool_trigger"),
             activation_tier="L3",
             speculative=1,
-            confidence=0.5,
+            confidence=gate_result.adjusted_confidence,
             source={"type": "auto_extracted", "triage_outcome": outcome},
             principle_embedding=principle_blob,
+            extraction_context=gate_result.extraction_context,
+            first_mover=1 if gate_result.first_mover else 0,
         )
-        logger.info("Extracted procedure %s: %s", proc_id, data["task_type"])
+        logger.info("Extracted procedure %s: %s (conf=%.2f)",
+                    proc_id, data["task_type"], gate_result.adjusted_confidence)
+        # Emit J9 event
+        try:
+            from genesis.eval.j9_hooks import emit_gate_decision
+
+            await emit_gate_decision(
+                db,
+                task_type=data["task_type"],
+                outcome=outcome,
+                allowed=True,
+                confidence=gate_result.adjusted_confidence,
+                flags=gate_result.flags,
+            )
+        except Exception:
+            pass  # Fire-and-forget
         return proc_id
     except Exception:
         logger.error("Procedure extraction: failed to store procedure", exc_info=True)

--- a/src/genesis/learning/procedural/operations.py
+++ b/src/genesis/learning/procedural/operations.py
@@ -40,6 +40,8 @@ async def store_procedure(
     confidence: float = 0.0,
     source: dict | None = None,
     principle_embedding: bytes | None = None,
+    extraction_context: str | None = None,
+    first_mover: int = 0,
 ) -> str:
     """Create a new procedure and return its ID.
 
@@ -52,6 +54,11 @@ async def store_procedure(
     `principle_embedding` is the packed BLOB returned by
     `procedural.embedding.pack_embedding`. Optional — when None, the
     proactive procedure hook skips this row.
+
+    `extraction_context` is a JSON blob from the validation gate recording
+    the gate's decision flags and modifiers (audit trail).
+
+    `first_mover` is 1 when this is the first extraction for this task_type.
     """
     proc_id = str(uuid.uuid4())
     now = datetime.now(UTC).isoformat()
@@ -71,6 +78,8 @@ async def store_procedure(
         confidence=confidence,
         source=json.dumps(source) if source else None,
         principle_embedding=principle_embedding,
+        extraction_context=extraction_context,
+        first_mover=first_mover,
     )
     return proc_id
 

--- a/src/genesis/learning/procedural/validation_gate.py
+++ b/src/genesis/learning/procedural/validation_gate.py
@@ -1,0 +1,291 @@
+"""Self-learning validation gate.
+
+Interposes between procedure extraction and storage to adjust confidence
+based on evidence quality, outcome history, and first-mover status.
+
+Design principles:
+- Pure filter: no side effects, no observation routing, no LLM calls.
+- Fail-open: any exception → allow with default confidence (0.5).
+- Outcome-class watermark: primary quality signal.
+- v1 conservative: first-mover and regression are tag/flag only (no penalty).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+
+import aiosqlite
+
+from genesis.db.crud.watermarks import get_watermark, upsert_watermark
+
+logger = logging.getLogger(__name__)
+
+# --- Patterns ----------------------------------------------------------------
+
+_IMPOSSIBILITY_PATTERNS = [
+    re.compile(p, re.IGNORECASE) for p in [
+        r"\b(?:impossible|cannot be done|not possible|broken|doesn't work|won't work)\b",
+        r"\b(?:deprecated|removed|discontinued|unsupported|no longer)\b",
+        r"\b(?:fundamentally|inherently|structurally)\s+(?:broken|flawed|impossible)\b",
+    ]
+]
+
+_EVIDENCE_MARKERS = [
+    re.compile(p, re.IGNORECASE) for p in [
+        r"HTTP\s+\d{3}",
+        r"Error:\s+\S+",
+        r"Traceback\s+\(most recent",
+        r"errno\s+\d+",
+        r"exit\s+code\s+\d+",
+        r"(?:API|endpoint)\s+returned",
+        r"Permission denied|Access denied",
+        r"ConnectionRefusedError|TimeoutError",
+        r"Cloudflare|WAF|captcha|blocked by",
+    ]
+]
+
+_OUTCOME_RANK = {"success": 3, "workaround_success": 2, "approach_failure": 1}
+
+# --- Result type --------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Gate decision output."""
+
+    allowed: bool
+    adjusted_confidence: float
+    flags: list[str] = field(default_factory=list)
+    extraction_context: str = ""  # JSON blob for DB audit trail
+    first_mover: bool = False
+
+
+# --- Public entry point -------------------------------------------------------
+
+
+async def validate_extraction(
+    db: aiosqlite.Connection,
+    *,
+    task_type: str,
+    principle: str,
+    steps: list[str],
+    tools_used: list[str],
+    outcome: str,
+    summary_text: str,
+    session_tools_count: int,
+) -> ValidationResult:
+    """Run all validation checks and return a gate decision.
+
+    Caller should:
+    - If allowed=True: store with adjusted_confidence.
+    - If allowed=False: discard extraction (evidence captured elsewhere).
+    """
+    try:
+        return await _validate_inner(
+            db,
+            task_type=task_type,
+            principle=principle,
+            steps=steps,
+            tools_used=tools_used,
+            outcome=outcome,
+            summary_text=summary_text,
+            session_tools_count=session_tools_count,
+        )
+    except Exception:
+        logger.warning("validation_gate: gate failed, allowing with default confidence",
+                       exc_info=True)
+        return ValidationResult(
+            allowed=True,
+            adjusted_confidence=0.5,
+            flags=["gate_error_fail_open"],
+            extraction_context=json.dumps({"error": "gate_exception"}),
+        )
+
+
+# --- Internal -----------------------------------------------------------------
+
+
+async def _validate_inner(
+    db: aiosqlite.Connection,
+    *,
+    task_type: str,
+    principle: str,
+    steps: list[str],
+    tools_used: list[str],
+    outcome: str,
+    summary_text: str,
+    session_tools_count: int,
+) -> ValidationResult:
+    flags: list[str] = []
+    context: dict = {"outcome": outcome, "session_tools_count": session_tools_count}
+
+    # --- Check 1: Evidence requirement ---
+    evidence_mod = _check_evidence(principle, summary_text, flags)
+    context["evidence_mod"] = evidence_mod
+
+    if evidence_mod == 0.0:
+        # Hard block: impossibility claim without evidence
+        context["blocked"] = True
+        return ValidationResult(
+            allowed=False,
+            adjusted_confidence=0.0,
+            flags=flags,
+            extraction_context=json.dumps(context),
+        )
+
+    # --- Check 2: Outcome-class watermark ---
+    watermark = await get_watermark(db, task_type)
+    watermark_mod = _check_watermark(watermark, outcome, flags)
+    context["watermark_mod"] = watermark_mod
+    context["watermark_existed"] = watermark is not None
+
+    # --- Check 3: Regression detection (flag only in v1) ---
+    regression_flag = False
+    if watermark_mod < 1.0:
+        regression_flag = await _check_regression(db, task_type, principle, flags)
+    context["regression_flag"] = regression_flag
+
+    # --- Check 4: First-mover (tag only in v1, no penalty) ---
+    first_mover = watermark is None or watermark["total_sessions"] == 0
+    if first_mover:
+        flags.append("first_mover")
+    context["first_mover"] = first_mover
+
+    # --- Compose confidence ---
+    # v1: only evidence_mod and watermark_mod affect confidence.
+    # First-mover and regression are observational (tag/flag).
+    adjusted = max(0.1, 0.5 * min(evidence_mod, watermark_mod))
+    context["adjusted_confidence"] = adjusted
+
+    # --- Update watermark ---
+    await _update_watermark(db, task_type, outcome, watermark)
+
+    logger.info(
+        "validation_gate: decision=allowed task_type=%s outcome=%s conf=%.2f "
+        "watermark=%s first_mover=%s flags=%s",
+        task_type, outcome, adjusted,
+        watermark is not None, first_mover, flags,
+    )
+
+    return ValidationResult(
+        allowed=True,
+        adjusted_confidence=adjusted,
+        flags=flags,
+        extraction_context=json.dumps(context),
+        first_mover=first_mover,
+    )
+
+
+def _check_evidence(principle: str, summary_text: str, flags: list[str]) -> float:
+    """Check 1: impossibility claims need evidence.
+
+    Returns 0.0 (block) if impossibility without evidence, else 1.0.
+    In v1 this is a penalty (conf=0.1) rather than hard block — see caller.
+    """
+    has_impossibility = any(p.search(principle) for p in _IMPOSSIBILITY_PATTERNS)
+    if not has_impossibility:
+        return 1.0
+
+    flags.append("impossibility_claim")
+    # Check both principle and summary for evidence
+    combined = f"{principle} {summary_text}"
+    has_evidence = any(m.search(combined) for m in _EVIDENCE_MARKERS)
+
+    if has_evidence:
+        flags.append("evidence_present")
+        return 1.0
+
+    flags.append("no_evidence_for_impossibility")
+    return 0.0
+
+
+def _check_watermark(
+    watermark: dict | None, outcome: str, flags: list[str],
+) -> float:
+    """Check 2: outcome quality vs historical best.
+
+    Returns modifier: 1.0 (no penalty), 0.5 (moderate), 0.3 (severe).
+    """
+    if watermark is None:
+        return 1.0
+
+    current_rank = _OUTCOME_RANK.get(outcome, 0)
+    best_rank = _OUTCOME_RANK.get(watermark["best_outcome"], 0)
+
+    if best_rank >= 3 and current_rank <= 1:
+        # Task has been SUCCEEDED, this is a failure
+        flags.append("regression_from_success")
+        return 0.3
+    elif best_rank >= 2 and current_rank <= 1:
+        # Task had workaround success, this is pure failure
+        flags.append("regression_from_workaround")
+        return 0.5
+
+    return 1.0
+
+
+async def _check_regression(
+    db: aiosqlite.Connection, task_type: str, principle: str, flags: list[str],
+) -> bool:
+    """Check 3: does new principle contradict validated procedures?
+
+    v1: flag only, no confidence penalty. Returns True if contradiction detected.
+    """
+    try:
+        cursor = await db.execute(
+            "SELECT principle FROM procedural_memory "
+            "WHERE task_type = ? AND success_count >= 2 AND quarantined = 0",
+            (task_type,),
+        )
+        rows = await cursor.fetchall()
+        for row in rows:
+            existing_principle = row[0]
+            overlap = _jaccard_words(principle, existing_principle)
+            if overlap > 0.3:
+                flags.append("regression_contradicts_validated")
+                return True
+    except Exception:
+        logger.debug("validation_gate: regression check failed", exc_info=True)
+    return False
+
+
+async def _update_watermark(
+    db: aiosqlite.Connection, task_type: str, outcome: str, watermark: dict | None,
+) -> None:
+    """Update watermark after gate passes. Only ratchets outcome upward."""
+    current_rank = _OUTCOME_RANK.get(outcome, 0)
+
+    if watermark is None:
+        await upsert_watermark(
+            db,
+            task_type=task_type,
+            best_outcome=outcome,
+            total_sessions=1,
+            successful_sessions=1 if outcome == "success" else 0,
+        )
+    else:
+        best_rank = _OUTCOME_RANK.get(watermark["best_outcome"], 0)
+        new_best = outcome if current_rank > best_rank else watermark["best_outcome"]
+        await upsert_watermark(
+            db,
+            task_type=task_type,
+            best_outcome=new_best,
+            total_sessions=watermark["total_sessions"] + 1,
+            successful_sessions=(
+                watermark["successful_sessions"] + (1 if outcome == "success" else 0)
+            ),
+        )
+
+
+def _jaccard_words(a: str, b: str) -> float:
+    """Word-level Jaccard similarity between two strings."""
+    words_a = set(a.lower().split())
+    words_b = set(b.lower().split())
+    if not words_a or not words_b:
+        return 0.0
+    intersection = words_a & words_b
+    union = words_a | words_b
+    return len(intersection) / len(union)

--- a/src/genesis/learning/procedural/validation_gate.py
+++ b/src/genesis/learning/procedural/validation_gate.py
@@ -182,8 +182,7 @@ async def _validate_inner(
 def _check_evidence(principle: str, summary_text: str, flags: list[str]) -> float:
     """Check 1: impossibility claims need evidence.
 
-    Returns 0.0 (block) if impossibility without evidence, else 1.0.
-    In v1 this is a penalty (conf=0.1) rather than hard block — see caller.
+    Returns 0.0 if impossibility without evidence (caller blocks), else 1.0.
     """
     has_impossibility = any(p.search(principle) for p in _IMPOSSIBILITY_PATTERNS)
     if not has_impossibility:

--- a/tests/test_cc/test_direct_session_profiles.py
+++ b/tests/test_cc/test_direct_session_profiles.py
@@ -224,6 +224,14 @@ def test_addenda_do_not_mention_reference_store_for_persistence():
         )
 
 
+def test_all_addenda_include_mission_injection():
+    """All profiles must include the adapt-and-overcome mission text."""
+    for profile, addendum in _PROFILE_ADDENDA.items():
+        assert "Adapt and overcome" in addendum, (
+            f"{profile} addendum should include mission injection"
+        )
+
+
 # --- Model override for interact profile ---
 
 def _make_runner():

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -91,6 +91,7 @@ async def test_no_unexpected_tables(db):
         "user_goals", "user_contacts", "ego_directives",
         "tool_call_outcomes",
         "user_jobs", "user_job_runs",
+        "task_type_watermarks",
     }
     for table in tables:
         assert table in known, f"Unexpected table: {table}"

--- a/tests/test_learning/test_validation_gate.py
+++ b/tests/test_learning/test_validation_gate.py
@@ -1,0 +1,318 @@
+"""Tests for the self-learning validation gate."""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.learning.procedural.validation_gate import (
+    _check_evidence,
+    _check_watermark,
+    _jaccard_words,
+    validate_extraction,
+)
+
+# --- Unit tests for _jaccard_words ---
+
+
+def test_jaccard_identical():
+    assert _jaccard_words("hello world", "hello world") == 1.0
+
+
+def test_jaccard_disjoint():
+    assert _jaccard_words("hello world", "foo bar") == 0.0
+
+
+def test_jaccard_partial():
+    result = _jaccard_words("hello world foo", "hello world bar")
+    # intersection: {hello, world} = 2, union: {hello, world, foo, bar} = 4
+    assert result == pytest.approx(0.5)
+
+
+def test_jaccard_empty():
+    assert _jaccard_words("", "hello") == 0.0
+    assert _jaccard_words("hello", "") == 0.0
+
+
+# --- Unit tests for _check_evidence ---
+
+
+def test_evidence_no_impossibility_claim():
+    """Non-impossibility principle passes with mod=1.0."""
+    flags: list[str] = []
+    result = _check_evidence("use yt-dlp for downloads", "ran yt-dlp", flags)
+    assert result == 1.0
+    assert flags == []
+
+
+def test_evidence_impossibility_with_evidence():
+    """Impossibility claim with error evidence passes."""
+    flags: list[str] = []
+    result = _check_evidence(
+        "this API is broken and doesn't work",
+        "HTTP 403 returned by the endpoint",
+        flags,
+    )
+    assert result == 1.0
+    assert "impossibility_claim" in flags
+    assert "evidence_present" in flags
+
+
+def test_evidence_impossibility_without_evidence():
+    """Impossibility claim without evidence returns 0.0 (block)."""
+    flags: list[str] = []
+    result = _check_evidence(
+        "this approach is impossible and won't work",
+        "I tried a few things but nothing worked",
+        flags,
+    )
+    assert result == 0.0
+    assert "impossibility_claim" in flags
+    assert "no_evidence_for_impossibility" in flags
+
+
+def test_evidence_deprecated_with_evidence():
+    """'Deprecated' claims with evidence pass."""
+    flags: list[str] = []
+    result = _check_evidence(
+        "the old API is deprecated and no longer available",
+        "Error: EndpointNotFound - API returned 404",
+        flags,
+    )
+    assert result == 1.0
+    assert "evidence_present" in flags
+
+
+def test_evidence_cloudflare_counts_as_evidence():
+    """Cloudflare/WAF mentions in summary count as evidence."""
+    flags: list[str] = []
+    result = _check_evidence(
+        "automated access doesn't work on this site",
+        "blocked by Cloudflare challenge page",
+        flags,
+    )
+    assert result == 1.0
+    assert "evidence_present" in flags
+
+
+# --- Unit tests for _check_watermark ---
+
+
+def test_watermark_none():
+    """No watermark → no penalty."""
+    flags: list[str] = []
+    result = _check_watermark(None, "approach_failure", flags)
+    assert result == 1.0
+
+
+def test_watermark_regression_from_success():
+    """Prior success + current failure → severe penalty."""
+    flags: list[str] = []
+    watermark = {"best_outcome": "success", "total_sessions": 3, "successful_sessions": 2}
+    result = _check_watermark(watermark, "approach_failure", flags)
+    assert result == 0.3
+    assert "regression_from_success" in flags
+
+
+def test_watermark_regression_from_workaround():
+    """Prior workaround success + current failure → moderate penalty."""
+    flags: list[str] = []
+    watermark = {"best_outcome": "workaround_success", "total_sessions": 2, "successful_sessions": 0}
+    result = _check_watermark(watermark, "approach_failure", flags)
+    assert result == 0.5
+    assert "regression_from_workaround" in flags
+
+
+def test_watermark_no_regression():
+    """Same or better outcome → no penalty."""
+    flags: list[str] = []
+    watermark = {"best_outcome": "approach_failure", "total_sessions": 1, "successful_sessions": 0}
+    result = _check_watermark(watermark, "success", flags)
+    assert result == 1.0
+    assert flags == []
+
+
+def test_watermark_equal_outcome_no_penalty():
+    """Same outcome class as best → no penalty."""
+    flags: list[str] = []
+    watermark = {"best_outcome": "workaround_success", "total_sessions": 2, "successful_sessions": 0}
+    result = _check_watermark(watermark, "workaround_success", flags)
+    assert result == 1.0
+
+
+# --- Integration tests for validate_extraction ---
+
+
+@pytest.mark.asyncio
+async def test_gate_allows_success_no_watermark(db):
+    """First successful extraction passes with first_mover tag."""
+    result = await validate_extraction(
+        db,
+        task_type="new-task",
+        principle="use API to fetch data",
+        steps=["call API", "parse response"],
+        tools_used=["WebFetch"],
+        outcome="success",
+        summary_text="Called the API and got results",
+        session_tools_count=3,
+    )
+    assert result.allowed is True
+    assert result.first_mover is True
+    assert result.adjusted_confidence == pytest.approx(0.5)  # 0.5 * min(1.0, 1.0) = 0.5
+    assert "first_mover" in result.flags
+
+
+@pytest.mark.asyncio
+async def test_gate_blocks_impossibility_without_evidence(db):
+    """Impossibility claim without evidence is blocked."""
+    result = await validate_extraction(
+        db,
+        task_type="browser-task",
+        principle="automated browser access is impossible on this site",
+        steps=["tried to access"],
+        tools_used=["browser_navigate"],
+        outcome="approach_failure",
+        summary_text="The site blocked access somehow",
+        session_tools_count=2,
+    )
+    assert result.allowed is False
+    assert "no_evidence_for_impossibility" in result.flags
+
+
+@pytest.mark.asyncio
+async def test_gate_allows_impossibility_with_evidence(db):
+    """Impossibility claim with concrete evidence passes."""
+    result = await validate_extraction(
+        db,
+        task_type="browser-task",
+        principle="automated access doesn't work due to Cloudflare",
+        steps=["navigate", "detect challenge"],
+        tools_used=["browser_navigate"],
+        outcome="approach_failure",
+        summary_text="Cloudflare challenge page detected, HTTP 403",
+        session_tools_count=5,
+    )
+    assert result.allowed is True
+    assert "evidence_present" in result.flags
+
+
+@pytest.mark.asyncio
+async def test_gate_penalizes_failure_after_prior_success(db):
+    """Failure extraction after a prior success gets reduced confidence."""
+    # Seed watermark with a success
+    from genesis.db.crud.watermarks import upsert_watermark
+
+    await upsert_watermark(
+        db, task_type="deploy-task", best_outcome="success",
+        total_sessions=2, successful_sessions=1,
+    )
+
+    result = await validate_extraction(
+        db,
+        task_type="deploy-task",
+        principle="deployment requires manual approval step",
+        steps=["try deploy", "get blocked"],
+        tools_used=["Bash"],
+        outcome="approach_failure",
+        summary_text="Deployment failed, needs approval",
+        session_tools_count=4,
+    )
+    assert result.allowed is True
+    assert result.adjusted_confidence == pytest.approx(0.15)  # 0.5 * 0.3 = 0.15
+    assert "regression_from_success" in result.flags
+
+
+@pytest.mark.asyncio
+async def test_gate_updates_watermark(db):
+    """Gate creates watermark on first extraction."""
+    from genesis.db.crud.watermarks import get_watermark
+
+    result = await validate_extraction(
+        db,
+        task_type="fresh-task",
+        principle="do the thing",
+        steps=["step1"],
+        tools_used=["tool1"],
+        outcome="success",
+        summary_text="did the thing",
+        session_tools_count=1,
+    )
+    assert result.allowed is True
+
+    wm = await get_watermark(db, "fresh-task")
+    assert wm is not None
+    assert wm["best_outcome"] == "success"
+    assert wm["total_sessions"] == 1
+    assert wm["successful_sessions"] == 1
+
+
+@pytest.mark.asyncio
+async def test_gate_watermark_ratchets_upward(db):
+    """Watermark best_outcome only ratchets up, never down."""
+    from genesis.db.crud.watermarks import get_watermark, upsert_watermark
+
+    await upsert_watermark(
+        db, task_type="ratchet-task", best_outcome="success",
+        total_sessions=1, successful_sessions=1,
+    )
+
+    # Now extract with a failure — watermark should keep 'success' as best
+    await validate_extraction(
+        db,
+        task_type="ratchet-task",
+        principle="try alternate approach",
+        steps=["step"],
+        tools_used=["tool"],
+        outcome="approach_failure",
+        summary_text="tried but failed",
+        session_tools_count=2,
+    )
+
+    wm = await get_watermark(db, "ratchet-task")
+    assert wm["best_outcome"] == "success"  # NOT downgraded
+    assert wm["total_sessions"] == 2
+
+
+@pytest.mark.asyncio
+async def test_gate_fail_open_on_error(db):
+    """Gate returns allowed=True on internal error (fail-open)."""
+    # Close DB to force an error
+    await db.close()
+
+    result = await validate_extraction(
+        db,
+        task_type="error-task",
+        principle="something",
+        steps=["step"],
+        tools_used=["tool"],
+        outcome="success",
+        summary_text="text",
+        session_tools_count=1,
+    )
+    assert result.allowed is True
+    assert result.adjusted_confidence == 0.5
+    assert "gate_error_fail_open" in result.flags
+
+
+@pytest.mark.asyncio
+async def test_gate_confidence_floor(db):
+    """Adjusted confidence never goes below 0.1."""
+    from genesis.db.crud.watermarks import upsert_watermark
+
+    await upsert_watermark(
+        db, task_type="floor-task", best_outcome="success",
+        total_sessions=5, successful_sessions=3,
+    )
+
+    result = await validate_extraction(
+        db,
+        task_type="floor-task",
+        principle="this approach requires different tooling",
+        steps=["step"],
+        tools_used=["tool"],
+        outcome="approach_failure",
+        summary_text="tried different approach",
+        session_tools_count=1,
+    )
+    # watermark_mod=0.3, confidence = max(0.1, 0.5 * 0.3) = 0.15
+    assert result.allowed is True
+    assert result.adjusted_confidence >= 0.1

--- a/tests/test_learning/test_validation_gate.py
+++ b/tests/test_learning/test_validation_gate.py
@@ -273,13 +273,16 @@ async def test_gate_watermark_ratchets_upward(db):
 
 
 @pytest.mark.asyncio
-async def test_gate_fail_open_on_error(db):
+async def test_gate_fail_open_on_error():
     """Gate returns allowed=True on internal error (fail-open)."""
-    # Close DB to force an error
-    await db.close()
+    import aiosqlite
+
+    # Use a separate connection that we close (won't affect fixture)
+    broken_db = await aiosqlite.connect(":memory:")
+    await broken_db.close()
 
     result = await validate_extraction(
-        db,
+        broken_db,
         task_type="error-task",
         principle="something",
         steps=["step"],


### PR DESCRIPTION
## Summary

- Adds a validation gate between procedural extraction and storage that adjusts confidence based on evidence quality and outcome history
- Prevents poisoning from confabulated failure lessons (impossibility claims without evidence are blocked)
- Tracks best outcome per task_type via new `task_type_watermarks` table — failures after prior success get penalized confidence
- First-mover and regression detection are v1 observational (tag/flag only, no penalty) — empirical tuning in v2
- Mission injection ("Adapt and overcome") in all background session profile addenda
- J9 eval hook (`emit_gate_decision`) for monitoring gate decisions via existing eval pipeline

## Design Decisions

- **Pure filter**: no observation routing, no side effects. Evidence captured by existing pipeline paths.
- **Fail-open**: all exceptions → allow with default confidence (0.5). No LLM calls, no timeouts.
- **Outcome-class watermark**: primary quality signal (SUCCESS > WORKAROUND_SUCCESS > APPROACH_FAILURE). Tool/step counts excluded as unreliable proxies.
- **Conservative v1**: first-mover penalty and regression detection are tag-only (no confidence impact). Tuned in v2 with empirical J9 data.

## Test plan

- [x] 22 new tests in `test_validation_gate.py` (unit + integration)
- [x] 14 existing extractor tests pass unmodified
- [x] 36 profile tests pass (including new mission injection assertion)
- [ ] CI passes
- [ ] After deploy: verify `task_type_watermarks` table created on server restart
- [ ] After deploy: confirm gate_decision events appear in J9 eval pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)