### PR TITLE
fix(ego): dashboard approval triggers sweep + auto-complete self-notifications

### DIFF
--- a/src/genesis/dashboard/routes/comms.py
+++ b/src/genesis/dashboard/routes/comms.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import logging
@@ -195,5 +196,31 @@ async def comms_resolve_proposal(proposal_id: str):
         )
     except Exception:
         logger.warning("Journal resolve failed for proposal %s", proposal_id)
+
+    # Trigger delayed sweep on approval — same 5-min grace as Telegram,
+    # so the user can revoke before dispatch fires.
+    if status == "approved" and rt.ego_session:
+        try:
+            from genesis.util.tasks import tracked_task
+
+            async def _dashboard_delayed_sweep() -> None:
+                await asyncio.sleep(300)  # 5-min grace period
+                if rt.ego_session:
+                    await rt.ego_session.sweep_approved_proposals()
+
+            tracked_task(
+                _dashboard_delayed_sweep(),
+                name="dashboard_proposal_sweep",
+            )
+            logger.info(
+                "Dashboard approval — sweep scheduled in 5 min for proposal %s",
+                proposal_id,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to schedule sweep after dashboard approval for %s",
+                proposal_id,
+                exc_info=True,
+            )
 
     return jsonify({"id": proposal_id, "status": status})

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1328,8 +1328,9 @@ class EgoSession:
         """Mechanically dispatch approved proposals via DirectSessionRunner.
 
         Called on a fixed 30-minute interval by EgoCadenceManager AND
-        immediately after user approval via Telegram.  The sweep lock
-        prevents concurrent execution (double-dispatch guard).
+        after user approval via Telegram or dashboard (5-min grace).
+        The sweep lock prevents concurrent execution (double-dispatch
+        guard).
 
         Returns list of dispatched proposal IDs.
         """
@@ -1363,6 +1364,32 @@ class EgoSession:
             except (KeyError, TypeError, ValueError):
                 continue
 
+            # Self-notification shortcut: outreach proposals whose execution
+            # plan indicates a zero-cost Telegram message to the user were
+            # already delivered via the proposal digest.  Auto-complete them
+            # instead of spawning an expensive CC session.
+            exec_plan = (prop.get("execution_plan") or "").lower()
+            if (
+                prop.get("action_type") == "outreach"
+                and "telegram" in exec_plan
+                and ("$0" in exec_plan or "~$0" in exec_plan)
+            ):
+                cursor = await self._db.execute(
+                    "UPDATE ego_proposals SET status = 'executed', "
+                    "user_response = 'auto-completed: delivered via proposal digest' "
+                    "WHERE id = ? AND status = 'approved'",
+                    (prop["id"],),
+                )
+                await self._db.commit()
+                if cursor.rowcount > 0:
+                    dispatched.append(prop["id"])
+                    logger.info(
+                        "Proposal %s auto-completed (self-notification — "
+                        "already delivered via digest)",
+                        prop["id"],
+                    )
+                continue
+
             prompt = await self._build_dispatch_prompt(prop)
             profile = _infer_profile(prop.get("action_type", ""))
 
@@ -1382,7 +1409,7 @@ class EgoSession:
             )
             await self._db.commit()
             if cursor.rowcount == 0:
-                logger.info(
+                logger.debug(
                     "Proposal %s already claimed — skipping",
                     prop["id"],
                 )


### PR DESCRIPTION
## Summary

- Dashboard proposal approvals now trigger a delayed sweep (5-min grace), matching Telegram's existing behavior. Previously dashboard approvals waited up to 30 min for the next periodic sweep.
- Outreach proposals with execution plans indicating "Telegram, $0" are auto-completed without spawning a CC session — the proposal digest already delivered the notification to the user.
- Demoted "already claimed" sweep log from INFO to DEBUG to reduce noise.

## Test plan

- [x] All 68 ego tests pass
- [x] Dashboard API tests pass
- [x] Lint clean (`ruff check`)
- [ ] Approve a proposal via dashboard → verify sweep fires within 5 min in server logs
- [ ] Verify self-notification outreach proposals auto-complete without spawning CC session

🤖 Generated with [Claude Code](https://claude.com/claude-code)