### PR TITLE
fix(dashboard): alert severity redesign + backup hardening + Guardian fixes

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -311,16 +311,43 @@ git add -A
 if git diff --cached --quiet; then
     log "No changes since last backup"
 else
-    git commit -m "backup: $(date -Iseconds)" --quiet
-    git push --quiet || {
-        log "WARNING: git push failed — backup committed locally only"
-    }
-    log "Backup committed and pushed"
+    # Explicit error handling — set -e is suppressed by ||.
+    # Without this, a corrupt git repo silently kills the script
+    # (as happened 2026-05-08 through 2026-05-25: 17 days unnoticed).
+    if git commit -m "backup: $(date -Iseconds)" --quiet 2>&1; then
+        git push --quiet || {
+            log "WARNING: git push failed — backup committed locally only"
+        }
+        log "Backup committed and pushed"
+    else
+        _FAILURE_REASON="git commit failed (corrupt repo or index error)"
+        log "ERROR: git commit failed — repository may need re-clone from remote"
+    fi
 fi
 
-if [ "$_SQLITE_LINES" -gt 0 ]; then
+if [ "$_SQLITE_LINES" -gt 0 ] && [ -z "$_FAILURE_REASON" ]; then
     _SUCCESS=true
 else
-    log "WARNING: No SQLite data backed up — marking as failure"
+    if [ -z "$_FAILURE_REASON" ]; then
+        _FAILURE_REASON="No SQLite data backed up"
+    fi
+    log "WARNING: Backup incomplete — marking as failure (reason: $_FAILURE_REASON)"
+fi
+
+# --- Alert on failure via Telegram ---
+if [ "$_SUCCESS" != "true" ]; then
+    if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_FORUM_CHAT_ID:-}" ]; then
+        _TG_MSG="🚨 *Backup failed*
+
+Reason: ${_FAILURE_REASON:-unknown}
+Time: $(date -Is)
+SQLite lines: $_SQLITE_LINES
+Duration: $(( $(date +%s) - _STARTED_AT ))s"
+        curl -sf -X POST \
+            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -H "Content-Type: application/json" \
+            -d "{\"chat_id\":\"${TELEGRAM_FORUM_CHAT_ID}\",\"text\":$(printf '%s' "$_TG_MSG" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))'),\"parse_mode\":\"Markdown\"}" \
+            > /dev/null 2>&1 || log "WARNING: Telegram alert failed to send"
+    fi
 fi
 log "Backup complete (success=$_SUCCESS)"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -315,10 +315,12 @@ else
     # Without this, a corrupt git repo silently kills the script
     # (as happened 2026-05-08 through 2026-05-25: 17 days unnoticed).
     if git commit -m "backup: $(date -Iseconds)" --quiet 2>&1; then
-        git push --quiet || {
-            log "WARNING: git push failed — backup committed locally only"
-        }
-        log "Backup committed and pushed"
+        if ! git push --quiet 2>&1; then
+            _FAILURE_REASON="git push failed — backup exists locally only (not replicated to remote)"
+            log "ERROR: $_FAILURE_REASON"
+        else
+            log "Backup committed and pushed"
+        fi
     else
         _FAILURE_REASON="git commit failed (corrupt repo or index error)"
         log "ERROR: git commit failed — repository may need re-clone from remote"

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -2933,10 +2933,15 @@
 
         get attentionItems() {
           const items = [];
-          const activeAlerts = (this.errorSummary.active_alerts || []).length;
+          const allAlerts = this.errorSummary.active_alerts || [];
+          const criticalAlerts = allAlerts.filter(a => a.severity === "CRITICAL");
+          const warningAlerts = allAlerts.filter(a => a.severity === "WARNING");
           const activeGroups = (this.errorSummary.groups || []).filter(g => g.still_active).length;
-          if (activeAlerts > 0) {
-            items.push({ level: "critical", title: `${activeAlerts} active alert${activeAlerts === 1 ? "" : "s"}`, detail: "health alerts need operator review", href: "/genesis/errors" });
+          if (criticalAlerts.length > 0) {
+            items.push({ level: "critical", title: `${criticalAlerts.length} critical alert${criticalAlerts.length === 1 ? "" : "s"}`, detail: criticalAlerts.map(a => a.message).slice(0, 3).join("; "), href: "/genesis/errors" });
+          }
+          if (warningAlerts.length > 0) {
+            items.push({ level: "warning", title: `${warningAlerts.length} system warning${warningAlerts.length === 1 ? "" : "s"}`, detail: `${warningAlerts.length} call site${warningAlerts.length === 1 ? "" : "s"} on fallback or degraded`, href: "/genesis/errors" });
           }
           if (activeGroups > 0) {
             items.push({ level: "warning", title: `${activeGroups} active error group${activeGroups === 1 ? "" : "s"}`, detail: "grouped warnings/errors across events, dead letters, or deferred work", href: "/genesis/errors" });
@@ -2947,10 +2952,11 @@
           if ((this.health.queues?.discarded_items?.length || 0) > 0) {
             items.push({ level: "warning", title: `${this.health.queues.discarded_items.length} discarded item${this.health.queues.discarded_items.length === 1 ? "" : "s"}`, detail: "work was dropped and can be reviewed or cleared below", href: "#queue-review", tab: "overview", anchor: "queue-review" });
           }
-          if (this.fallbackCallSiteCount > 0) {
-            const names = this.fallbackCallSites.join(", ");
-            items.push({ level: "warning", title: `${this.fallbackCallSiteCount} call site${this.fallbackCallSiteCount === 1 ? "" : "s"} on fallback`, detail: names, href: "#routing-health", tab: "internals", anchor: "routing-health" });
-          }
+          // Fallback call sites are already captured in the warningAlerts
+          // bucket above (severity=WARNING from health_alerts). The dedicated
+          // card was removed to avoid duplication — "14 warnings" + "14 on
+          // fallback" was confusing. Click the warnings card → /genesis/errors
+          // for details.
           if (this.pendingApprovalCount > 0) {
             items.push({ level: "warning", title: `${this.pendingApprovalCount} pending approval${this.pendingApprovalCount === 1 ? "" : "s"}`, detail: "autonomous CLI fallbacks are waiting for operator action", href: "#chat", tab: "chat", onClick: () => { this.commsTab = 'approvals'; this.fetchApprovals(); } });
           }

--- a/src/genesis/guardian/approval.py
+++ b/src/genesis/guardian/approval.py
@@ -65,19 +65,23 @@ class _ApprovalState:
             return True
 
 
-# Module-level state shared between handler and caller
-_state = _ApprovalState()
-
-
 class _ApprovalHandler(BaseHTTPRequestHandler):
-    """HTTP handler for approval URLs."""
+    """HTTP handler for approval URLs.
+
+    Each ApprovalServer instance creates a bound subclass with its own
+    _approval_state class attribute.  This prevents the module-level
+    singleton bug where a second ApprovalServer would overwrite the
+    first server's token.
+    """
+
+    _approval_state: _ApprovalState  # Set by ApprovalServer.start()
 
     def do_GET(self) -> None:  # noqa: N802
         path = self.path.rstrip("/")
 
         if path.startswith("/approve/"):
             token = path[len("/approve/"):]
-            if _state.try_approve(token):
+            if self._approval_state.try_approve(token):
                 self._respond(200, {
                     "status": "approved",
                     "message": "Recovery approved. Guardian will proceed.",
@@ -107,6 +111,11 @@ class _ApprovalHandler(BaseHTTPRequestHandler):
 class ApprovalServer:
     """Manages the approval HTTP server lifecycle.
 
+    Each instance owns its own _ApprovalState — no module-level
+    singleton. A bound handler subclass carries the state via a class
+    attribute, avoiding the bug where concurrent ApprovalServer instances
+    would share (and overwrite) each other's tokens.
+
     Starts in a background thread, generates single-use tokens,
     and auto-shuts down after approval or timeout.
     """
@@ -115,22 +124,31 @@ class ApprovalServer:
         self._config = config
         self._server: HTTPServer | None = None
         self._thread: threading.Thread | None = None
+        self._state = _ApprovalState()
 
     @property
     def is_approved(self) -> bool:
-        return _state.approved
+        return self._state.approved
 
     def start(self) -> str:
         """Start the approval server and return a new approval URL.
 
         Returns the full approval URL including token.
         """
-        token = _state.create_token(expiry_s=self._config.token_expiry_s)
+        token = self._state.create_token(expiry_s=self._config.token_expiry_s)
 
         host = self._config.bind_host or "0.0.0.0"  # noqa: S104
         port = self._config.port
 
-        self._server = HTTPServer((host, port), _ApprovalHandler)
+        # Create a handler subclass bound to THIS instance's state.
+        # HTTPServer takes a class (not instance), so we use a class
+        # attribute to carry the state into the handler.
+        state = self._state
+
+        class _BoundHandler(_ApprovalHandler):
+            _approval_state = state
+
+        self._server = HTTPServer((host, port), _BoundHandler)
         self._server.timeout = 1  # Allow periodic shutdown checks
 
         self._thread = threading.Thread(
@@ -165,7 +183,7 @@ class ApprovalServer:
 
         deadline = time.monotonic() + timeout_s
         while time.monotonic() < deadline:
-            if _state.approved:
+            if self._state.approved:
                 return True
             time.sleep(1)
         return False

--- a/src/genesis/guardian/cgroup_ops.py
+++ b/src/genesis/guardian/cgroup_ops.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import signal
+import time
 from pathlib import Path
 
 from genesis.guardian._subprocess import run_subprocess as _run_subprocess
@@ -101,11 +102,50 @@ def list_container_pids(container: str) -> list[int]:
         return []
 
 
+def _read_proc_io(pid: int) -> dict | None:
+    """Read /proc/PID/io and /proc/PID/comm for a single PID.
+
+    Returns a dict with read_bytes, write_bytes, total_bytes, comm,
+    or None if the PID is gone or unreadable.
+    """
+    try:
+        io_path = Path(f"/proc/{pid}/io")
+        if not io_path.exists():
+            return None
+
+        io_content = io_path.read_text()
+        read_bytes = 0
+        write_bytes = 0
+        for line in io_content.splitlines():
+            if line.startswith("read_bytes:"):
+                read_bytes = int(line.split(":")[1].strip())
+            elif line.startswith("write_bytes:"):
+                write_bytes = int(line.split(":")[1].strip())
+
+        comm = "unknown"
+        with contextlib.suppress(OSError):
+            comm = Path(f"/proc/{pid}/comm").read_text().strip()
+
+        return {
+            "pid": pid,
+            "read_bytes": read_bytes,
+            "write_bytes": write_bytes,
+            "total_bytes": read_bytes + write_bytes,
+            "comm": comm,
+        }
+    except (OSError, ValueError):
+        return None
+
+
 def find_top_io_pids(container: str, top_n: int = 5) -> list[dict]:
-    """Find top I/O consumers among container PIDs.
+    """Find top I/O consumers among container PIDs (cumulative).
 
     Reads /proc/PID/io for each container PID and returns the top N by
-    total bytes (read + write). Each entry is a dict with keys:
+    total bytes (read + write). These are CUMULATIVE lifetime counts —
+    long-running processes dominate. For current-rate ranking, use
+    find_top_io_pids_rate().
+
+    Each entry is a dict with keys:
     pid, read_bytes, write_bytes, total_bytes, comm.
 
     Returns an empty list on any error. Individual PID read failures are
@@ -115,42 +155,64 @@ def find_top_io_pids(container: str, top_n: int = 5) -> list[dict]:
     if not pids:
         return []
 
-    io_data: list[dict] = []
-    for pid in pids:
-        try:
-            io_path = Path(f"/proc/{pid}/io")
-            comm_path = Path(f"/proc/{pid}/comm")
-
-            if not io_path.exists():
-                continue
-
-            io_content = io_path.read_text()
-            read_bytes = 0
-            write_bytes = 0
-            for line in io_content.splitlines():
-                if line.startswith("read_bytes:"):
-                    read_bytes = int(line.split(":")[1].strip())
-                elif line.startswith("write_bytes:"):
-                    write_bytes = int(line.split(":")[1].strip())
-
-            comm = "unknown"
-            with contextlib.suppress(OSError):
-                comm = comm_path.read_text().strip()
-
-            io_data.append({
-                "pid": pid,
-                "read_bytes": read_bytes,
-                "write_bytes": write_bytes,
-                "total_bytes": read_bytes + write_bytes,
-                "comm": comm,
-            })
-        except (OSError, ValueError):
-            # Process may have exited between listing and reading
-            continue
-
-    # Sort by total I/O, descending
+    io_data = [d for pid in pids if (d := _read_proc_io(pid)) is not None]
     io_data.sort(key=lambda x: x["total_bytes"], reverse=True)
     return io_data[:top_n]
+
+
+def find_top_io_pids_rate(
+    container: str, top_n: int = 5, sample_interval_s: float = 0.5,
+) -> list[dict]:
+    """Find top I/O consumers by current rate (delta sampling).
+
+    Takes two /proc/PID/io snapshots separated by sample_interval_s and
+    computes the byte delta. Identifies the process actively writing NOW,
+    not just the one with the highest cumulative total.
+
+    Each entry is a dict with keys:
+      pid, comm, read_rate, write_rate, total_rate (bytes/sec),
+      read_bytes_cumulative, write_bytes_cumulative.
+
+    PIDs that disappear between samples are silently skipped.
+    Returns an empty list on any error.
+    """
+    pids = list_container_pids(container)
+    if not pids:
+        return []
+
+    # First sample
+    t0: dict[int, dict] = {}
+    for pid in pids:
+        data = _read_proc_io(pid)
+        if data:
+            t0[pid] = data
+
+    if not t0:
+        return []
+
+    time.sleep(sample_interval_s)
+
+    # Second sample + delta
+    rates: list[dict] = []
+    for pid, before in t0.items():
+        after = _read_proc_io(pid)
+        if after is None:
+            continue  # PID disappeared between samples
+        delta_read = max(0, after["read_bytes"] - before["read_bytes"])
+        delta_write = max(0, after["write_bytes"] - before["write_bytes"])
+        delta_total = delta_read + delta_write
+        rates.append({
+            "pid": pid,
+            "comm": after["comm"],
+            "read_rate": delta_read / sample_interval_s,
+            "write_rate": delta_write / sample_interval_s,
+            "total_rate": delta_total / sample_interval_s,
+            "read_bytes_cumulative": after["read_bytes"],
+            "write_bytes_cumulative": after["write_bytes"],
+        })
+
+    rates.sort(key=lambda x: x["total_rate"], reverse=True)
+    return rates[:top_n]
 
 
 async def kill_pid(

--- a/src/genesis/guardian/recovery.py
+++ b/src/genesis/guardian/recovery.py
@@ -202,24 +202,39 @@ class RecoveryEngine:
         """
         from genesis.guardian.cgroup_ops import (
             find_top_io_pids,
+            find_top_io_pids_rate,
             kill_pid,
             read_io_pressure,
         )
 
-        # 1. Collect diagnostics — find top 5 I/O consumers
-        top_pids = find_top_io_pids(container, top_n=5)
+        # 1. Collect diagnostics — rate-based ranking (500ms delta sample)
+        #    identifies the actual current I/O offender, not just the
+        #    process with the highest cumulative lifetime total.
+        top_pids = find_top_io_pids_rate(container, top_n=5)
         if not top_pids:
-            return False, "No I/O consuming processes found in container cgroup"
+            # Fallback to cumulative if rate sampling fails (all PIDs gone)
+            top_pids = find_top_io_pids(container, top_n=5)
+            if not top_pids:
+                return False, "No I/O consuming processes found in container cgroup"
 
         # Log all candidates for observability
         for entry in top_pids:
-            logger.info(
-                "IO_TRIAGE candidate: PID %d (%s) "
-                "read=%d write=%d total=%d bytes",
-                entry["pid"], entry["comm"],
-                entry["read_bytes"], entry["write_bytes"],
-                entry["total_bytes"],
-            )
+            if "total_rate" in entry:
+                logger.info(
+                    "IO_TRIAGE candidate: PID %d (%s) "
+                    "rate=%.0f bytes/s (cumulative: read=%d write=%d)",
+                    entry["pid"], entry["comm"], entry["total_rate"],
+                    entry.get("read_bytes_cumulative", 0),
+                    entry.get("write_bytes_cumulative", 0),
+                )
+            else:
+                logger.info(
+                    "IO_TRIAGE candidate (cumulative fallback): PID %d (%s) "
+                    "read=%d write=%d total=%d bytes",
+                    entry["pid"], entry["comm"],
+                    entry["read_bytes"], entry["write_bytes"],
+                    entry["total_bytes"],
+                )
 
         # 2. Assess PSI trend — is pressure accelerating or recovering?
         pressure = read_io_pressure(container)
@@ -241,9 +256,15 @@ class RecoveryEngine:
                 f"Failed to kill PID {target['pid']} ({target['comm']})"
             )
 
+        # Report rate if available, else cumulative
+        if "total_rate" in target:
+            io_detail = f"rate={target['total_rate']:.0f} bytes/s"
+        else:
+            io_detail = f"total_bytes={target['total_bytes']}"
+
         return True, (
             f"Killed top I/O consumer: PID {target['pid']} "
-            f"({target['comm']}) total_bytes={target['total_bytes']}"
+            f"({target['comm']}) {io_detail}"
         )
 
     async def _resource_clear(self, container: str) -> tuple[bool, str]:

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -567,6 +567,57 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
         except Exception:
             logger.error("Genesis update alert check failed", exc_info=True)
 
+    # ── Backup health ───────────────────────────────────────────────
+    from pathlib import Path
+
+    backup_status_file = Path.home() / ".genesis" / "backup_status.json"
+    if backup_status_file.is_file():
+        try:
+            backup_data = json.loads(backup_status_file.read_text())
+            if not backup_data.get("success", False):
+                alert_id = "backup:last_failed"
+                reason = backup_data.get("failure_reason") or "check backup log"
+                ts = backup_data.get("timestamp", "unknown")
+                alerts.append({
+                    "id": alert_id,
+                    "severity": "CRITICAL",
+                    "message": f"Last backup failed at {ts}: {reason}",
+                })
+                current_ids.add(alert_id)
+            else:
+                # Check staleness — backup succeeded but too long ago
+                ts = backup_data.get("timestamp")
+                if ts:
+                    try:
+                        last = datetime.fromisoformat(ts)
+                        age_h = (
+                            datetime.now(UTC) - last
+                        ).total_seconds() / 3600
+                        if age_h > 8:  # 6h schedule + 2h grace
+                            alert_id = "backup:overdue"
+                            alerts.append({
+                                "id": alert_id,
+                                "severity": "CRITICAL",
+                                "message": (
+                                    f"Backup overdue — last success "
+                                    f"was {age_h:.0f}h ago"
+                                ),
+                            })
+                            current_ids.add(alert_id)
+                    except (ValueError, TypeError):
+                        pass
+        except (json.JSONDecodeError, OSError):
+            pass
+    else:
+        # No status file = backups never configured or never ran
+        alert_id = "backup:not_configured"
+        alerts.append({
+            "id": alert_id,
+            "severity": "CRITICAL",
+            "message": "Backups not configured — no backup status file found",
+        })
+        current_ids.add(alert_id)
+
     now = datetime.now(UTC).isoformat()
     for old_id in list(_alert_history.keys()):
         if old_id in current_ids:

--- a/src/genesis/runtime/cgroup.py
+++ b/src/genesis/runtime/cgroup.py
@@ -1,0 +1,339 @@
+"""Cgroup v2 I/O isolation manager — container-side.
+
+Creates two cgroup subtrees under the current process's cgroup:
+  genesis-critical  — server, awareness loop, Sentinel process (high I/O priority)
+  genesis-background — CC sessions, surplus compute (throttled I/O)
+
+This is PREVENTIVE infrastructure: it stops CC sessions from saturating
+host io.max and causing D-state freezes.  Once D-state occurs, only
+Guardian (host-side) can help.
+
+Requires:
+  - Cgroup v2 filesystem (cgroup2fs) at /sys/fs/cgroup
+  - io controller delegated through the user slice hierarchy
+  - sudo for initial subtree_control setup (delegation doesn't persist)
+
+Design spec: docs/superpowers/specs/2026-05-25-cgroup-io-resilience.md
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _read_own_cgroup() -> Path | None:
+    """Read /proc/self/cgroup to find our cgroup v2 path."""
+    try:
+        content = Path("/proc/self/cgroup").read_text().strip()
+        # cgroup v2: single line "0::/path/to/cgroup"
+        for line in content.splitlines():
+            parts = line.split(":", 2)
+            if len(parts) == 3 and parts[0] == "0":
+                return Path("/sys/fs/cgroup") / parts[2].lstrip("/")
+        return None
+    except OSError as exc:
+        logger.warning("Cannot read /proc/self/cgroup: %s", exc)
+        return None
+
+
+def _detect_root_device() -> str | None:
+    """Detect the block device major:minor for the root filesystem.
+
+    For io.max, we need the REAL block device — not the virtual device
+    from os.stat("/").st_dev (which returns the btrfs/overlay device).
+
+    Strategy: parse /proc/self/mountinfo for the root mount, find the
+    backing device, resolve to major:minor via /sys/dev/block/.
+    If the root is on device-mapper (LVM), use that directly.
+    """
+    try:
+        mountinfo = Path("/proc/self/mountinfo").read_text()
+        for line in mountinfo.splitlines():
+            fields = line.split()
+            # Field 5 is the mount point
+            if len(fields) >= 10 and fields[4] == "/":
+                # Field 3 is major:minor of the mount
+                dev = fields[2]
+                # Verify this is a real block device by checking io.stat
+                # at the root cgroup — devices that appear there are the
+                # ones the kernel tracks I/O for.
+                logger.info("Root filesystem device from mountinfo: %s", dev)
+                return dev
+        return None
+    except OSError as exc:
+        logger.warning("Cannot parse mountinfo for root device: %s", exc)
+        return None
+
+
+def _sudo_write(path: Path, content: str) -> bool:
+    """Write to a cgroup file via sudo tee (cgroup files are root-owned)."""
+    try:
+        result = subprocess.run(
+            ["sudo", "tee", str(path)],
+            input=content.encode(),
+            capture_output=True,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.error("sudo write to %s failed: %s", path, exc)
+        return False
+
+
+def _sudo_mkdir(path: Path) -> bool:
+    """Create a cgroup directory via sudo mkdir."""
+    try:
+        result = subprocess.run(
+            ["sudo", "mkdir", "-p", str(path)],
+            capture_output=True,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.error("sudo mkdir %s failed: %s", path, exc)
+        return False
+
+
+class CgroupManager:
+    """Manages genesis-critical and genesis-background cgroup subtrees.
+
+    Call setup() at server startup (before awareness loop or scheduler).
+    Call move_to_background(pid) after forking CC sessions.
+    """
+
+    def __init__(self) -> None:
+        self._scope = _read_own_cgroup()
+        self._critical: Path | None = None
+        self._background: Path | None = None
+        self._init: Path | None = None
+        self._device = _detect_root_device()
+        self._ready = False
+
+    @property
+    def available(self) -> bool:
+        """Whether cgroup v2 I/O isolation is available and set up."""
+        return self._ready
+
+    @property
+    def device(self) -> str | None:
+        """The block device major:minor for io.max."""
+        return self._device
+
+    def setup(self) -> bool:
+        """Create cgroup subtrees and configure controllers.
+
+        Steps:
+        1. Create genesis-init child cgroup
+        2. Move all processes from scope into genesis-init
+        3. Enable io+memory+cpu+pids delegation on scope
+        4. Create genesis-critical and genesis-background
+        5. Set I/O weights and memory limits
+        6. Move server process to genesis-critical
+
+        Returns True if setup succeeded.  Returns False (and logs why)
+        if prerequisites aren't met — the system runs without isolation
+        (same as today, not worse).
+        """
+        if not self._scope:
+            logger.warning("cgroup: cannot determine own cgroup path")
+            return False
+
+        if not self._scope.is_dir():
+            logger.warning("cgroup: scope path %s doesn't exist", self._scope)
+            return False
+
+        # Check if io controller is available
+        try:
+            controllers = (self._scope / "cgroup.controllers").read_text()
+        except OSError:
+            logger.warning("cgroup: cannot read controllers at %s", self._scope)
+            return False
+
+        if "io" not in controllers:
+            logger.warning("cgroup: io controller not available (have: %s)", controllers.strip())
+            return False
+
+        # Step 1: Create genesis-init to hold existing processes
+        self._init = self._scope / "genesis-init"
+        if not _sudo_mkdir(self._init):
+            logger.error("cgroup: cannot create genesis-init")
+            return False
+
+        # Step 2: Move ALL processes from scope to genesis-init
+        # This is required by cgroup v2's "no internal processes" constraint
+        # before we can enable subtree_control.
+        try:
+            procs = (self._scope / "cgroup.procs").read_text().strip().splitlines()
+        except OSError as exc:
+            logger.error("cgroup: cannot read scope procs: %s", exc)
+            return False
+
+        moved = 0
+        for pid_str in procs:
+            pid_str = pid_str.strip()
+            if pid_str:
+                if _sudo_write(self._init / "cgroup.procs", pid_str + "\n"):
+                    moved += 1
+                else:
+                    # Some PIDs may have exited between read and write
+                    logger.debug("cgroup: couldn't move PID %s (may have exited)", pid_str)
+
+        logger.info("cgroup: moved %d/%d processes to genesis-init", moved, len(procs))
+
+        # Step 3: Enable controllers on scope's subtree_control
+        if not _sudo_write(self._scope / "cgroup.subtree_control", "+io +memory +cpu +pids\n"):
+            logger.error("cgroup: cannot enable subtree_control — processes may still be in scope")
+            # Try to move remaining processes
+            return False
+
+        # Step 4: Create genesis-critical and genesis-background
+        self._critical = self._scope / "genesis-critical"
+        self._background = self._scope / "genesis-background"
+
+        if not _sudo_mkdir(self._critical) or not _sudo_mkdir(self._background):
+            logger.error("cgroup: cannot create subtrees")
+            return False
+
+        # Verify io controller is delegated to children
+        try:
+            child_controllers = (self._critical / "cgroup.controllers").read_text()
+            if "io" not in child_controllers:
+                logger.error("cgroup: io controller not delegated to children (have: %s)", child_controllers.strip())
+                return False
+        except OSError:
+            logger.error("cgroup: cannot read child controllers")
+            return False
+
+        # Step 5: Set I/O weights
+        _sudo_write(self._critical / "io.weight", "default 500\n")
+        _sudo_write(self._background / "io.weight", "default 100\n")
+        logger.info("cgroup: io.weight set — critical=500, background=100")
+
+        # Set io.max on background (50% of host limit) if device is known
+        if self._device:
+            # We don't know the host's io.max, so we set a conservative
+            # absolute limit.  These values are for a 300G SSD:
+            #   rbps = 200MB/s (50% of typical SSD sequential read)
+            #   wbps = 100MB/s (50% of typical SSD sequential write)
+            # The io.weight already provides proportional fairness; io.max
+            # is the hard ceiling that prevents D-state.
+            rbps = 200 * 1024 * 1024  # 200 MB/s
+            wbps = 100 * 1024 * 1024  # 100 MB/s
+            io_max_line = f"{self._device} rbps={rbps} wbps={wbps}\n"
+            if _sudo_write(self._background / "io.max", io_max_line):
+                logger.info("cgroup: io.max set on background: %s", io_max_line.strip())
+            else:
+                logger.warning("cgroup: failed to set io.max on background (device %s)", self._device)
+
+        # Step 5b: Memory limits
+        container_max = self._read_container_memory_max()
+        if container_max:
+            self._set_memory_limits(container_max)
+
+        # Step 6: Move server process to genesis-critical
+        server_pid = str(os.getpid())
+        if _sudo_write(self._critical / "cgroup.procs", server_pid + "\n"):
+            logger.info("cgroup: server (PID %s) moved to genesis-critical", server_pid)
+        else:
+            logger.warning("cgroup: failed to move server to genesis-critical")
+
+        self._ready = True
+        logger.info("cgroup: I/O isolation active — critical and background subtrees ready")
+        return True
+
+    def move_to_background(self, pid: int) -> bool:
+        """Move a PID to genesis-background (for CC sessions)."""
+        if not self._ready or not self._background:
+            return False
+        return _sudo_write(self._background / "cgroup.procs", str(pid) + "\n")
+
+    def move_to_critical(self, pid: int) -> bool:
+        """Move a PID to genesis-critical (for essential processes)."""
+        if not self._ready or not self._critical:
+            return False
+        return _sudo_write(self._critical / "cgroup.procs", str(pid) + "\n")
+
+    def _read_container_memory_max(self) -> int | None:
+        """Read the container's memory.max from the root cgroup."""
+        try:
+            raw = Path("/sys/fs/cgroup/memory.max").read_text().strip()
+            if raw == "max":
+                return None  # No memory limit set
+            return int(raw)
+        except (OSError, ValueError):
+            return None
+
+    def _set_memory_limits(self, container_max: int) -> None:
+        """Set memory limits on background and critical subtrees.
+
+        Policy (adaptive, not static):
+          background memory.high = 62.5% of container max (soft limit)
+          background memory.max  = 75% of container max (hard ceiling)
+          critical   memory.min  = 2G (reserved, never reclaimed)
+
+        Constraints:
+          Floor: background memory.high >= 8G
+          Ceiling: background memory.high <= container_max - 4G
+          Recalculation: ONLY at boot (not during pressure)
+        """
+        if not self._background or not self._critical:
+            return
+
+        GiB = 1024 ** 3
+
+        bg_high = int(container_max * 0.625)
+        bg_max = int(container_max * 0.75)
+        crit_min = 2 * GiB
+
+        # Apply floor and ceiling
+        bg_high = max(bg_high, 8 * GiB)
+        bg_high = min(bg_high, container_max - 4 * GiB)
+        bg_max = max(bg_max, bg_high + 2 * GiB)
+        bg_max = min(bg_max, container_max - 2 * GiB)
+
+        if bg_high <= 0 or bg_max <= bg_high:
+            logger.warning(
+                "cgroup: memory limits don't make sense for container_max=%dG, skipping",
+                container_max // GiB,
+            )
+            return
+
+        _sudo_write(self._background / "memory.high", str(bg_high) + "\n")
+        _sudo_write(self._background / "memory.max", str(bg_max) + "\n")
+        _sudo_write(self._critical / "memory.min", str(crit_min) + "\n")
+
+        logger.info(
+            "cgroup: memory limits — background high=%dG max=%dG, critical min=%dG "
+            "(container max=%dG)",
+            bg_high // GiB, bg_max // GiB, crit_min // GiB, container_max // GiB,
+        )
+
+    def status(self) -> dict:
+        """Return current cgroup isolation status for health reporting."""
+        if not self._ready:
+            return {"active": False, "reason": "not set up"}
+
+        result: dict = {"active": True, "device": self._device}
+
+        for name, path in [
+            ("critical", self._critical),
+            ("background", self._background),
+        ]:
+            if path and path.is_dir():
+                try:
+                    procs = path.joinpath("cgroup.procs").read_text().strip().splitlines()
+                    result[name] = {"procs": len(procs)}
+                except OSError:
+                    result[name] = {"procs": -1}
+
+                # Read io.weight if available
+                with contextlib.suppress(OSError):
+                    result[name]["io_weight"] = path.joinpath("io.weight").read_text().strip()
+
+        return result

--- a/tests/test_guardian/test_approval.py
+++ b/tests/test_guardian/test_approval.py
@@ -1,0 +1,170 @@
+"""Tests for guardian approval server singleton fix."""
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from genesis.guardian.approval import ApprovalServer, _ApprovalState
+
+
+class TestApprovalState:
+    """Unit tests for _ApprovalState."""
+
+    def test_create_and_approve(self):
+        state = _ApprovalState()
+        token = state.create_token(expiry_s=60)
+        assert token is not None
+        assert state.approved is False
+        assert state.try_approve(token) is True
+        assert state.approved is True
+
+    def test_wrong_token_rejected(self):
+        state = _ApprovalState()
+        state.create_token(expiry_s=60)
+        assert state.try_approve("wrong-token") is False
+        assert state.approved is False
+
+    def test_double_approve_rejected(self):
+        state = _ApprovalState()
+        token = state.create_token(expiry_s=60)
+        assert state.try_approve(token) is True
+        assert state.try_approve(token) is False  # Already used
+
+    def test_expired_token_rejected(self):
+        state = _ApprovalState()
+        token = state.create_token(expiry_s=0)  # Immediate expiry
+        time.sleep(0.01)
+        assert state.try_approve(token) is False
+
+    def test_create_token_resets_state(self):
+        state = _ApprovalState()
+        token1 = state.create_token(expiry_s=60)
+        state.try_approve(token1)
+        assert state.approved is True
+
+        token2 = state.create_token(expiry_s=60)
+        assert state.approved is False
+        assert token2 != token1
+
+
+class TestApprovalServerIsolation:
+    """Tests that each ApprovalServer has its own state (singleton fix)."""
+
+    def _make_config(self, port: int) -> MagicMock:
+        cfg = MagicMock()
+        cfg.bind_host = "127.0.0.1"
+        cfg.port = port
+        cfg.token_expiry_s = 3600
+        return cfg
+
+    def test_two_servers_independent_state(self):
+        """Two ApprovalServer instances must not share state."""
+        server_a = ApprovalServer(self._make_config(18881))
+        server_b = ApprovalServer(self._make_config(18882))
+
+        # Each has its own _state
+        assert server_a._state is not server_b._state
+
+    def test_token_from_one_server_invalid_on_another(self):
+        """Token created by server A must not validate on server B."""
+        server_a = ApprovalServer(self._make_config(18883))
+        server_b = ApprovalServer(self._make_config(18884))
+
+        token_a = server_a._state.create_token(expiry_s=60)
+        # Try to approve token_a on server_b's state
+        assert server_b._state.try_approve(token_a) is False
+        # But it works on server_a's state
+        assert server_a._state.try_approve(token_a) is True
+
+    def test_second_server_does_not_invalidate_first(self):
+        """Starting a second server must not overwrite first server's token."""
+        server_a = ApprovalServer(self._make_config(18885))
+        token_a = server_a._state.create_token(expiry_s=60)
+
+        # Creating a token on server_b should not affect server_a
+        server_b = ApprovalServer(self._make_config(18886))
+        server_b._state.create_token(expiry_s=60)
+
+        # server_a's token should still be valid
+        assert server_a._state.try_approve(token_a) is True
+
+    def test_is_approved_uses_instance_state(self):
+        """is_approved property must check instance state, not module state."""
+        server = ApprovalServer(self._make_config(18887))
+        assert server.is_approved is False
+
+        token = server._state.create_token(expiry_s=60)
+        server._state.try_approve(token)
+        assert server.is_approved is True
+
+
+class TestApprovalServerHTTP:
+    """Integration test for the HTTP approval flow."""
+
+    def _make_config(self, port: int) -> MagicMock:
+        cfg = MagicMock()
+        cfg.bind_host = "127.0.0.1"
+        cfg.port = port
+        cfg.token_expiry_s = 3600
+        return cfg
+
+    def test_http_approval_flow(self):
+        """Full HTTP flow: start server, approve via HTTP, verify."""
+        import urllib.request
+
+        server = ApprovalServer(self._make_config(18888))
+        try:
+            url = server.start()
+            assert "/approve/" in url
+
+            # Hit the approval URL
+            req = urllib.request.Request(url)
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                assert resp.status == 200
+
+            assert server.is_approved is True
+        finally:
+            server.stop()
+
+    def test_http_wrong_token_rejected(self):
+        """Wrong token returns 404."""
+        import urllib.request
+
+        server = ApprovalServer(self._make_config(18889))
+        try:
+            server.start()
+
+            bad_url = "http://127.0.0.1:18889/approve/wrong-token"
+            req = urllib.request.Request(bad_url)
+            with pytest.raises(urllib.error.HTTPError) as exc_info:
+                urllib.request.urlopen(req, timeout=5)
+            assert exc_info.value.code == 404
+            assert server.is_approved is False
+        finally:
+            server.stop()
+
+    def test_two_http_servers_isolated(self):
+        """Two HTTP servers on different ports don't share state."""
+        import json
+        import urllib.request
+
+        server_a = ApprovalServer(self._make_config(18890))
+        server_b = ApprovalServer(self._make_config(18891))
+        try:
+            url_a = server_a.start()
+            url_b = server_b.start()
+
+            # Approve server A
+            with urllib.request.urlopen(url_a, timeout=5) as resp:
+                data = json.loads(resp.read())
+                assert data["status"] == "approved"
+
+            # Server A approved, server B still not
+            assert server_a.is_approved is True
+            assert server_b.is_approved is False
+        finally:
+            server_a.stop()
+            server_b.stop()

--- a/tests/test_guardian/test_approval.py
+++ b/tests/test_guardian/test_approval.py
@@ -1,7 +1,6 @@
 """Tests for guardian approval server singleton fix."""
 from __future__ import annotations
 
-import threading
 import time
 from unittest.mock import MagicMock
 
@@ -155,7 +154,7 @@ class TestApprovalServerHTTP:
         server_b = ApprovalServer(self._make_config(18891))
         try:
             url_a = server_a.start()
-            url_b = server_b.start()
+            server_b.start()  # Start but don't need its URL
 
             # Approve server A
             with urllib.request.urlopen(url_a, timeout=5) as resp:

--- a/tests/test_health_mcp.py
+++ b/tests/test_health_mcp.py
@@ -210,7 +210,20 @@ class TestHealthAlerts:
         assert any("throttled" in w["message"] for w in warnings)
 
     @pytest.mark.asyncio
-    async def test_no_alerts_when_all_healthy(self):
+    async def test_no_alerts_when_all_healthy(self, tmp_path, monkeypatch):
+        # Create a fake successful backup status so the backup alert doesn't fire
+        import json
+        from datetime import UTC, datetime
+        from pathlib import Path
+
+        fake_home = tmp_path / "fakehome"
+        (fake_home / ".genesis").mkdir(parents=True)
+        (fake_home / ".genesis" / "backup_status.json").write_text(json.dumps({
+            "timestamp": datetime.now(UTC).isoformat(),
+            "success": True, "sqlite_lines": 100,
+        }))
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
         svc = _mock_service({
             "call_sites": {"a": {"status": "healthy"}},
             "queues": {"deferred_work": 5},


### PR DESCRIPTION
## Summary
- **Dashboard attention strip**: split alerts into RED (critical) and YELLOW (warnings). Fallback/degraded call sites are normal system behavior → yellow. Real problems (backup failure, provider errors) → red.
- **Backup hardening**: Telegram push on failure, push failure = backup failure, backup status as health alert source (failed/overdue/not-configured → RED)
- **Approval server singleton**: move `_state` from module-level to instance-level, preventing token collision between concurrent approval cycles
- **Delta I/O sampling**: `find_top_io_pids_rate()` uses 500ms delta sampling to identify the actual current I/O offender, not just the process with highest cumulative lifetime total
- **Cgroup v2 manager**: container-side cgroup v2 isolation module (NOT yet wired — needs live testing of device detection, io.max, process migration)

## Test plan
- [x] 12 approval server tests (unit + HTTP integration, including isolation between instances)
- [x] 43 existing Guardian tests pass
- [x] Ruff clean on all modified files
- [ ] Dashboard verification: restart server → attention strip shows backup alert correctly
- [ ] Backup Telegram alert: trigger a backup failure → verify Telegram message arrives
- [ ] Cgroup v2 live testing deferred to after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)