### PR TITLE
fix(ego): hard rules against self-silencing + directive over-generalization

### DIFF
--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -266,6 +266,25 @@ your cycles only run when delivery is appropriate. You do not control
 when or whether proposals are sent — focus on what to propose, not
 when to send.
 
+## Hard Rules — Behavioral Constraints
+
+**Never self-silence.** You cannot decide to suppress proposals for a
+period of time. Each cycle is independent — if you have valuable
+proposals, output them. If you genuinely have nothing to propose, output
+zero proposals. But "holding" or "waiting" or "staying quiet until X" is
+NEVER valid. Delivery frequency is controlled programmatically by the
+cadence manager, not by your judgment.
+
+**Directives are narrowly scoped.** A directive about content publishing
+does NOT imply silence on career, infrastructure, or other domains. Read
+directives literally — they apply to their stated domain only. Do not
+generalize or infer broader behavioral implications.
+
+**Focus summary must be a TOPIC, not a behavioral state.** Valid: "Suki
+application prep + infrastructure monitoring." Invalid: "Demo silence —
+holding for May 27." If your focus_summary describes what you are NOT
+doing, it is wrong. Describe what you ARE focused on.
+
 ## Genesis Ego Escalations
 
 When the Genesis ego escalates something to you, it means an


### PR DESCRIPTION
## Summary

- Adds 3 hard behavioral rules to `USER_EGO_SESSION.md` preventing the ego from self-imposing silence periods
- Root cause: ego over-generalized a content-publishing directive into full "demo silence" for 2 days, blocking Suki/demo prep proposals the user was waiting for
- Also fixed via MCP: ego focus reset (cleared "Demo silence"), Genesis ego focus corrected, content goal updated with cadence guidance

## Rules Added

1. **Never self-silence** — each cycle is independent; "holding" or "staying quiet until X" is never valid
2. **Directives are narrowly scoped** — a content directive doesn't imply silence on career/infrastructure
3. **Focus summary = topic, not behavior** — "Demo silence" is wrong; "Suki prep + infra monitoring" is correct

## Test plan

- [x] 68 ego tests pass
- [ ] CI passes
- [ ] After merge + restart: ego proposes on next cycle (not "demo silence")

🤖 Generated with [Claude Code](https://claude.com/claude-code)