### PR TITLE
feat(routing): add NVIDIA NIM providers (DeepSeek V4 Pro + Kimi K2.6)

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -73,6 +73,20 @@ providers:
     rpm_limit: 20
     open_duration_s: 120
   # ── Phase 2 providers (gated on eval before chain promotion) ──
+  nvidia-nim-deepseek:
+    type: nvidia_nim
+    model: deepseek-ai/deepseek-v4-pro
+    profile: nvidia-nim-deepseek-v4-pro
+    free: true
+    rpm_limit: 20  # 40 RPM shared pool — 20 each to stay within aggregate limit
+    open_duration_s: 120
+  nvidia-nim-kimi:
+    type: nvidia_nim
+    model: moonshotai/kimi-k2.6
+    profile: nvidia-nim-kimi-k2.6
+    free: true
+    rpm_limit: 20  # 40 RPM shared pool — 20 each to stay within aggregate limit
+    open_duration_s: 120
   cerebras-qwen:
     type: cerebras
     model: qwen-3-235b-a22b-instruct-2507
@@ -263,6 +277,7 @@ call_sites:
     - groq-free
     - gemini-free
     - cerebras-qwen
+    - nvidia-nim-deepseek
     - mistral-large-free
     - openrouter-deepseek-v4-flash
   # V4 placeholder: cognitive state IS actively maintained today, but via direct
@@ -287,6 +302,8 @@ call_sites:
     - mistral-large-free
     - groq-free
     - openrouter-free
+    - nvidia-nim-deepseek
+    - nvidia-nim-kimi
     never_pays: true
   13_morning_report:
     chain:
@@ -343,6 +360,7 @@ call_sites:
   # Free-tier only. Separate from 22_tagging (entity extraction).
   dream_cycle_synthesis:
     chain:
+    - nvidia-nim-kimi
     - groq-free
     - mistral-small-free
     - openrouter-free
@@ -393,12 +411,16 @@ call_sites:
     chain:
     - gemini-free
     - groq-free
+    - nvidia-nim-deepseek
+    - mistral-large-free
     description: LLM-driven skill improvement proposals
   34_research_synthesis:
     chain:
     - gemini-free
     - groq-free
     - mistral-large-free
+    - nvidia-nim-deepseek
+    - nvidia-nim-kimi
     description: Synthesize research results into concise summaries
   38_procedure_extraction:
     chain:
@@ -471,6 +493,7 @@ call_sites:
     description: "Proactive infrastructure monitoring \u2014 trend detection and forecasting"
   40_knowledge_distillation:
     chain:
+    - nvidia-nim-deepseek
     - cerebras-qwen
     - groq-free
     - gemini-free

--- a/src/genesis/routing/litellm_delegate.py
+++ b/src/genesis/routing/litellm_delegate.py
@@ -53,6 +53,7 @@ _TYPE_TO_PREFIX: dict[str, str] = {
     "cerebras": "cerebras",  # Cerebras — native LiteLLM support
     "github": "github",  # GitHub Models — native LiteLLM support (Azure-backed)
     "sambanova": "sambanova",  # SambaNova — native LiteLLM support
+    "nvidia_nim": "nvidia_nim",  # NVIDIA NIM API Catalog — native LiteLLM support
 }
 
 

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -121,10 +121,11 @@ def test_load_full_yaml(monkeypatch):
 
     path = Path(__file__).resolve().parents[2] / "config" / "model_routing.yaml"
     cfg = load_config(path)
-    # lmstudio-30b, github-o3mini, deepseek-chat disabled → 27 enabled
+    # lmstudio-30b, github-o3mini, deepseek-chat disabled → 29 enabled
     # (3 direct anthropic providers removed, 2 openrouter added;
-    # openrouter-deepseek-r1 removed entirely 2026-05-24)
-    assert len(cfg.providers) == 27
+    # openrouter-deepseek-r1 removed entirely 2026-05-24;
+    # nvidia-nim-deepseek + nvidia-nim-kimi added 2026-05-25)
+    assert len(cfg.providers) == 29
     assert "lmstudio-30b" not in cfg.providers
     assert "github-o3mini" not in cfg.providers
     assert "openrouter-deepseek-r1" not in cfg.providers  # removed from config

--- a/tests/test_routing/test_integration.py
+++ b/tests/test_routing/test_integration.py
@@ -82,6 +82,8 @@ async def test_surplus_never_pays(real_config, breakers, cost_tracker, degradati
         "groq-free": CallResult(success=False, error="down", status_code=503),
         "gemini-free": CallResult(success=False, error="down", status_code=503),
         "openrouter-free": CallResult(success=False, error="down", status_code=503),
+        "nvidia-nim-deepseek": CallResult(success=False, error="down", status_code=503),
+        "nvidia-nim-kimi": CallResult(success=False, error="down", status_code=503),
     })
     router = Router(
         config=real_config, breakers=breakers, cost_tracker=cost_tracker,


### PR DESCRIPTION
## Summary

- Add two NVIDIA NIM API Catalog providers as free-tier frontier model fallbacks
  - `nvidia-nim-deepseek` → DeepSeek V4 Pro (reasoning, coding)
  - `nvidia-nim-kimi` → Kimi K2.6 (1T MoE, creative, long-context)
- Wire into 6 call site chains — dream cycle gets Kimi as primary, knowledge distillation gets DeepSeek as primary, 4 others get NIM as fallback depth
- Fix `33_skill_refiner` thin chain (was only 2 providers, now 4)
- RPM set to 20 each (40 RPM shared pool at NIM account level)
- Add `nvidia_nim` to litellm delegate type mapping

## Prerequisites

After merge, add `API_KEY_NVIDIA_NIM=nvapi-...` to `~/genesis/secrets.env` (sign up at build.nvidia.com) and restart genesis-server.

## Test plan

- [x] 233 routing tests pass
- [x] Config parser validates all chain references
- [x] litellm resolves both NIM models correctly
- [x] `_build_model_string` produces correct prefixed strings
- [x] `_resolve_api_key` finds `API_KEY_NVIDIA_NIM`
- [ ] Live call test after API key obtained

🤖 Generated with [Claude Code](https://claude.com/claude-code)