### PR TITLE
fix(runtime): stale state cleanup + ego content integrity

### DIFF
--- a/src/genesis/db/crud/cognitive_state.py
+++ b/src/genesis/db/crud/cognitive_state.py
@@ -392,7 +392,10 @@ async def expire_old(db: aiosqlite.Connection) -> int:
     cursor = await db.execute(
         "DELETE FROM cognitive_state WHERE "
         "(expires_at IS NOT NULL AND expires_at < ?) OR "
-        "(expires_at IS NULL AND created_at < ?)",
+        "(expires_at IS NULL AND created_at < ? AND section IN ("
+        "  'active_context', 'pending_actions', 'state_flags',"
+        "  'resilience_degradation'"
+        "))",
         (now, seven_days_ago),
     )
     await db.commit()

--- a/src/genesis/db/crud/cognitive_state.py
+++ b/src/genesis/db/crud/cognitive_state.py
@@ -4,11 +4,21 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import aiosqlite
 
 logger = logging.getLogger(__name__)
+
+# Default TTL per section type (hours).  When expires_at is not explicitly
+# provided, these values are used to auto-compute it from created_at.
+_SECTION_TTL_HOURS: dict[str, int] = {
+    "active_context": 72,           # 3 days — deep reflection refreshes
+    "pending_actions": 72,          # 3 days — strategic reflection refreshes
+    "state_flags": 24,              # 1 day — stale flags are the main problem
+    "resilience_degradation": 6,    # 6 hours — awareness loop refreshes
+}
 
 # Canonical location — also duplicated in scripts/genesis_session_end.py (keep in sync).
 _PATCHES_FILE = Path.home() / ".genesis" / "session_patches.json"
@@ -41,6 +51,22 @@ def clear_session_patches(patches_file: Path | None = None) -> None:
         logger.debug("Failed to clear session patches", exc_info=True)
 
 
+def _auto_expires_at(section: str, created_at: str, expires_at: str | None) -> str | None:
+    """Compute expires_at from section TTL if not explicitly provided."""
+    if expires_at is not None:
+        return expires_at
+    ttl_hours = _SECTION_TTL_HOURS.get(section)
+    if ttl_hours is None:
+        return None
+    try:
+        created_dt = datetime.fromisoformat(created_at)
+        if created_dt.tzinfo is None:
+            created_dt = created_dt.replace(tzinfo=UTC)
+        return (created_dt + timedelta(hours=ttl_hours)).isoformat()
+    except (ValueError, TypeError):
+        return None
+
+
 async def create(
     db: aiosqlite.Connection,
     *,
@@ -51,6 +77,7 @@ async def create(
     created_at: str,
     expires_at: str | None = None,
 ) -> str:
+    expires_at = _auto_expires_at(section, created_at, expires_at)
     await db.execute(
         """INSERT INTO cognitive_state
            (id, content, section, generated_by, created_at, expires_at)
@@ -71,16 +98,20 @@ async def get_by_id(db: aiosqlite.Connection, id: str) -> dict | None:
 
 async def get_by_section(db: aiosqlite.Connection, section: str) -> list[dict]:
     cursor = await db.execute(
-        "SELECT * FROM cognitive_state WHERE section = ? ORDER BY created_at DESC",
-        (section,),
+        "SELECT * FROM cognitive_state WHERE section = ? "
+        "AND (expires_at IS NULL OR expires_at > ?) "
+        "ORDER BY created_at DESC",
+        (section, datetime.now(UTC).isoformat()),
     )
     return [dict(r) for r in await cursor.fetchall()]
 
 
 async def get_current(db: aiosqlite.Connection, section: str) -> dict | None:
     cursor = await db.execute(
-        "SELECT * FROM cognitive_state WHERE section = ? ORDER BY created_at DESC LIMIT 1",
-        (section,),
+        "SELECT * FROM cognitive_state WHERE section = ? "
+        "AND (expires_at IS NULL OR expires_at > ?) "
+        "ORDER BY created_at DESC LIMIT 1",
+        (section, datetime.now(UTC).isoformat()),
     )
     row = await cursor.fetchone()
     return dict(row) if row else None
@@ -327,6 +358,7 @@ async def replace_section(
     expires_at: str | None = None,
 ) -> str:
     """Delete all rows for a section, then insert a new one."""
+    expires_at = _auto_expires_at(section, created_at, expires_at)
     await db.execute(
         "DELETE FROM cognitive_state WHERE section = ?", (section,),
     )
@@ -346,3 +378,22 @@ async def delete(db: aiosqlite.Connection, id: str) -> bool:
     )
     await db.commit()
     return cursor.rowcount > 0
+
+
+async def expire_old(db: aiosqlite.Connection) -> int:
+    """Delete cognitive_state entries past their expires_at.
+
+    Also removes entries older than 7 days that were created before
+    TTL auto-computation was added (expires_at IS NULL).
+    """
+    now = datetime.now(UTC).isoformat()
+    seven_days_ago = (datetime.now(UTC) - timedelta(days=7)).isoformat()
+
+    cursor = await db.execute(
+        "DELETE FROM cognitive_state WHERE "
+        "(expires_at IS NOT NULL AND expires_at < ?) OR "
+        "(expires_at IS NULL AND created_at < ?)",
+        (now, seven_days_ago),
+    )
+    await db.commit()
+    return cursor.rowcount

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -296,6 +296,7 @@ async def create_proposal(
     ego_source: str | None = None,
     goal_id: str | None = None,
     content_hash: str | None = None,
+    content_size: int | None = None,
     original_content: str | None = None,
 ) -> str:
     """Insert a new ego proposal. Returns the id."""
@@ -307,8 +308,8 @@ async def create_proposal(
             confidence, urgency, alternatives, status, cycle_id,
             batch_id, created_at, expires_at, rank, execution_plan,
             recurring, memory_basis, realist_verdict, realist_reasoning,
-            ego_source, goal_id, content_hash, original_content)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ego_source, goal_id, content_hash, content_size, original_content)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             id,
             action_type,
@@ -332,6 +333,7 @@ async def create_proposal(
             ego_source,
             goal_id,
             content_hash,
+            content_size,
             original_content,
         ),
     )

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1211,6 +1211,18 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
             "  AND pinned = 0"
         )
 
+    # Ego proposals: content integrity tracking (content_hash existed in
+    # CREATE TABLE but lacked ALTER TABLE migration for existing installs).
+    await _try_alter(db,
+        "ALTER TABLE ego_proposals ADD COLUMN content_hash TEXT",
+        "ego_proposals.content_hash")
+    await _try_alter(db,
+        "ALTER TABLE ego_proposals ADD COLUMN original_content TEXT",
+        "ego_proposals.original_content")
+    await _try_alter(db,
+        "ALTER TABLE ego_proposals ADD COLUMN content_size INTEGER",
+        "ego_proposals.content_size")
+
 
 async def _migrate_cognitive_state_check(db: aiosqlite.Connection) -> None:
     """Rebuild cognitive_state if CHECK constraint lacks 'resilience_degradation'.

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -782,6 +782,7 @@ TABLES = {
             ego_source       TEXT,                    -- which ego created this (user_ego_cycle / genesis_ego_cycle)
             goal_id          TEXT,                    -- FK to user_goals.id (nullable — not all proposals serve a goal)
             content_hash     TEXT,                    -- SHA-256 of content at creation time
+            content_size     INTEGER,                 -- byte count of content at creation time
             original_content TEXT                     -- pre-realist-amendment content (NULL if not amended)
         )
     """,

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -171,6 +171,7 @@ class ProposalWorkflow:
                 )
 
         from genesis.ego.integrity import content_hash as _content_hash
+        from genesis.ego.integrity import content_size as _content_size
 
         ids: list[str] = []
         for p in proposals:
@@ -218,6 +219,7 @@ class ProposalWorkflow:
                 ego_source=ego_source,
                 goal_id=goal_id,
                 content_hash=_content_hash(proposal_content),
+                content_size=_content_size(proposal_content),
                 original_content=p.get("_original_content"),
             )
             ids.append(pid)

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1447,6 +1447,31 @@ class EgoSession:
                     )
                 continue
 
+            # Content integrity check — detect degradation since creation.
+            # Log-only for now; tighten to a gate if we see real degradation.
+            stored_hash = prop.get("content_hash")
+            stored_size = prop.get("content_size")
+            if stored_hash and stored_size:
+                from genesis.ego.integrity import content_hash as _chash
+                from genesis.ego.integrity import content_size as _csize
+
+                current_hash = _chash(prop["content"])
+                current_size = _csize(prop["content"])
+                if current_hash != stored_hash:
+                    logger.warning(
+                        "Proposal %s content hash mismatch — content may "
+                        "have been modified since creation",
+                        prop["id"],
+                    )
+                if stored_size > 0:
+                    shrinkage = (stored_size - current_size) / stored_size * 100
+                    if shrinkage > 15:
+                        logger.warning(
+                            "Proposal %s content shrank %.0f%% "
+                            "(was %d, now %d bytes)",
+                            prop["id"], shrinkage, stored_size, current_size,
+                        )
+
             prompt = await self._build_dispatch_prompt(prop)
             profile = _infer_profile(prop.get("action_type", ""))
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1451,7 +1451,7 @@ class EgoSession:
             # Log-only for now; tighten to a gate if we see real degradation.
             stored_hash = prop.get("content_hash")
             stored_size = prop.get("content_size")
-            if stored_hash and stored_size:
+            if stored_hash is not None and stored_size is not None:
                 from genesis.ego.integrity import content_hash as _chash
                 from genesis.ego.integrity import content_size as _csize
 

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -427,6 +427,14 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
 
         await self._load_persisted_job_health()
 
+        # Clear stale failure counts from pre-restart failures so the
+        # dashboard starts clean after a code fix + deploy.
+        from genesis.runtime._job_health import clear_stale_job_failures
+
+        cleared = clear_stale_job_failures(self)
+        if cleared:
+            logger.info("Cleared stale failures from %d jobs on startup", cleared)
+
         self._wire_job_retry_registry()
 
         critical_ok = all(

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -435,6 +435,17 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
         if cleared:
             logger.info("Cleared stale failures from %d jobs on startup", cleared)
 
+        # Expire stale cognitive state entries (TTL-based + legacy NULL cleanup)
+        if self._db is not None:
+            try:
+                from genesis.db.crud import cognitive_state
+
+                expired = await cognitive_state.expire_old(self._db)
+                if expired:
+                    logger.info("Expired %d stale cognitive state entries", expired)
+            except Exception:
+                logger.warning("Failed to expire cognitive state entries", exc_info=True)
+
         self._wire_job_retry_registry()
 
         critical_ok = all(

--- a/src/genesis/runtime/_job_health.py
+++ b/src/genesis/runtime/_job_health.py
@@ -63,6 +63,40 @@ async def load_persisted_job_health(rt: GenesisRuntime) -> None:
         logger.error("Failed to load persisted job health", exc_info=True)
 
 
+def clear_stale_job_failures(rt: GenesisRuntime) -> int:
+    """Reset consecutive_failures for jobs that last failed before this startup.
+
+    After a code fix + deploy, pre-restart failures are stale — the code
+    that caused them no longer exists.  Resetting gives the job a clean
+    slate to prove itself on the new code.
+
+    Returns count of jobs cleared.
+    """
+    if not rt._job_health:
+        return 0
+
+    now_iso = datetime.now(UTC).isoformat()
+    cleared = 0
+
+    for job_name, entry in rt._job_health.items():
+        if entry.get("consecutive_failures", 0) == 0:
+            continue
+        last_failure = entry.get("last_failure")
+        if not last_failure:
+            continue
+        logger.info(
+            "Cleared stale failures for job %s (last_failure=%s, was=%d)",
+            job_name, last_failure, entry["consecutive_failures"],
+        )
+        entry["consecutive_failures"] = 0
+        entry.pop("last_failure", None)
+        entry.pop("last_error", None)
+        persist_job_health(rt, job_name, entry, now_iso)
+        cleared += 1
+
+    return cleared
+
+
 def persist_job_health(rt: GenesisRuntime, job_name: str, entry: dict, now: str) -> None:
     """Schedule a background write of the current job_health entry to the DB.
 

--- a/tests/test_cc/test_system_prompt.py
+++ b/tests/test_cc/test_system_prompt.py
@@ -54,6 +54,7 @@ async def test_assemble_includes_cognitive_state(assembler, db):
         content="Working on vehicle registration.",
         generated_by="test",
         created_at="2026-03-08T12:00:00",
+        expires_at="2099-01-01T00:00:00+00:00",
     )
     result = await assembler.assemble(db=db)
     assert "Working on vehicle registration." in result

--- a/tests/test_db/test_cognitive_state.py
+++ b/tests/test_db/test_cognitive_state.py
@@ -71,12 +71,12 @@ async def test_render_active_tier_shows_only_flags_and_patches(db, tmp_path):
     await cognitive_state.create(
         db, id="cs-1", content="Big stale narrative about old bugs.",
         section="active_context", generated_by="deep_reflection",
-        created_at="2026-03-25T10:00:00+00:00",
+        created_at="2026-03-25T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     await cognitive_state.create(
         db, id="cs-2", content="Do X, Y, Z.",
         section="pending_actions", generated_by="deep_reflection",
-        created_at="2026-03-25T10:00:00+00:00",
+        created_at="2026-03-25T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     patches_file = tmp_path / "session_patches.json"
     patches_file.write_text(json.dumps([
@@ -99,12 +99,12 @@ async def test_render_returning_tier_skips_active_context(db, tmp_path):
     await cognitive_state.create(
         db, id="cs-1", content="Big stale narrative.",
         section="active_context", generated_by="deep_reflection",
-        created_at="2026-03-25T10:00:00+00:00",
+        created_at="2026-03-25T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     await cognitive_state.create(
         db, id="cs-2", content="Do X, Y, Z.",
         section="pending_actions", generated_by="deep_reflection",
-        created_at="2026-03-25T10:00:00+00:00",
+        created_at="2026-03-25T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     patches_file = tmp_path / "session_patches.json"
     patches_file.write_text(json.dumps([
@@ -127,7 +127,7 @@ async def test_render_away_tier_shows_everything(db, tmp_path):
     await cognitive_state.create(
         db, id="cs-1", content="Full catch-up narrative.",
         section="active_context", generated_by="deep_reflection",
-        created_at="2026-03-25T10:00:00+00:00",
+        created_at="2026-03-25T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     patches_file = tmp_path / "session_patches.json"
     patches_file.write_text(json.dumps([
@@ -149,7 +149,7 @@ async def test_render_default_tier_is_away(db):
     await cognitive_state.create(
         db, id="cs-1", content="Full narrative.",
         section="active_context", generated_by="test",
-        created_at="2026-03-25T10:00:00+00:00",
+        created_at="2026-03-25T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     rendered = await cognitive_state.render(db)
     assert "Full narrative" in rendered
@@ -163,7 +163,7 @@ async def test_render_active_tier_shows_fresh_narrative(db, tmp_path):
     await cognitive_state.create(
         db, id="cs-1", content="Fresh narrative from mid-day reflection.",
         section="active_context", generated_by="deep_reflection",
-        created_at="2026-03-26T08:00:00+00:00",
+        created_at="2026-03-26T08:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     patches_file = tmp_path / "session_patches.json"
     patches_file.write_text(json.dumps([
@@ -187,7 +187,7 @@ async def test_create_and_get(db):
     row_id = await cognitive_state.create(
         db, id="cs-1", content="User is working on Genesis Phase 4.",
         section="active_context", generated_by="glm5",
-        created_at="2026-03-05T10:00:00+00:00",
+        created_at="2026-03-05T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     assert row_id == "cs-1"
     row = await cognitive_state.get_by_id(db, "cs-1")
@@ -202,12 +202,12 @@ async def test_get_by_section(db):
     await cognitive_state.create(
         db, id="cs-1", content="Active context here.",
         section="active_context", generated_by="glm5",
-        created_at="2026-03-05T10:00:00+00:00",
+        created_at="2026-03-05T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     await cognitive_state.create(
         db, id="cs-2", content="Pending actions here.",
         section="pending_actions", generated_by="glm5",
-        created_at="2026-03-05T10:00:00+00:00",
+        created_at="2026-03-05T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     rows = await cognitive_state.get_by_section(db, "active_context")
     assert len(rows) == 1
@@ -225,7 +225,7 @@ async def test_get_current_returns_latest(db):
     await cognitive_state.create(
         db, id="cs-new", content="New context.",
         section="active_context", generated_by="glm5",
-        created_at="2026-03-05T10:00:00+00:00",
+        created_at="2026-03-05T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     row = await cognitive_state.get_current(db, "active_context")
     assert row is not None
@@ -239,19 +239,19 @@ async def test_render_includes_stored_sections_and_focus(db):
     await cognitive_state.create(
         db, id="cs-1", content="Working on Phase 4.",
         section="active_context", generated_by="glm5",
-        created_at="2026-03-05T10:00:00+00:00",
+        created_at="2026-03-05T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     await cognitive_state.create(
         db, id="cs-2", content="Draft user.md after Phase 4.",
         section="pending_actions", generated_by="glm5",
-        created_at="2026-03-05T10:00:00+00:00",
+        created_at="2026-03-05T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     # Focus directive stored in state_flags section
     await cognitive_state.create(
         db, id="cs-3",
         content="## Deep Reflection Focus Directive\nFix memory retrieval.",
         section="state_flags", generated_by="deep_reflection",
-        created_at="2026-03-05T10:00:00+00:00",
+        created_at="2026-03-05T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     rendered = await cognitive_state.render(db)
     assert "Working on Phase 4." in rendered
@@ -273,7 +273,7 @@ async def test_delete(db):
     await cognitive_state.create(
         db, id="cs-1", content="temp",
         section="active_context", generated_by="glm5",
-        created_at="2026-03-05T10:00:00+00:00",
+        created_at="2026-03-05T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     deleted = await cognitive_state.delete(db, "cs-1")
     assert deleted is True
@@ -291,7 +291,7 @@ async def test_replace_section(db):
     await cognitive_state.replace_section(
         db, section="active_context", id="cs-new",
         content="Replaced.", generated_by="claude-sonnet",
-        created_at="2026-03-05T10:00:00+00:00",
+        created_at="2026-03-05T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     rows = await cognitive_state.get_by_section(db, "active_context")
     assert len(rows) == 1
@@ -311,7 +311,7 @@ async def test_compute_flags_memory_retrieval_failure(db):
         await observations.create(
             db, id=f"obs-{i}", source="test", type="test",
             content=f"Test observation {i}", priority="medium",
-            created_at="2026-03-05T10:00:00+00:00",
+            created_at="2026-03-05T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
         )
 
     flags = await cognitive_state.compute_state_flags(db)
@@ -326,7 +326,7 @@ async def test_compute_flags_memory_retrieval_ok(db):
     await observations.create(
         db, id="obs-1", source="test", type="test",
         content="Test observation", priority="medium",
-        created_at="2026-03-05T10:00:00+00:00",
+        created_at="2026-03-05T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     # Simulate retrieval
     await observations.increment_retrieved(db, "obs-1")
@@ -399,14 +399,14 @@ async def test_render_includes_computed_flags(db):
     await cognitive_state.create(
         db, id="cs-1", content="Active context.",
         section="active_context", generated_by="test",
-        created_at="2026-03-05T10:00:00+00:00",
+        created_at="2026-03-05T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
     # Create observations that will trigger the retrieval flag
     for i in range(3):
         await observations.create(
             db, id=f"obs-{i}", source="test", type="test",
             content=f"Obs {i}", priority="medium",
-            created_at="2026-03-05T10:00:00+00:00",
+            created_at="2026-03-05T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
         )
 
     rendered = await cognitive_state.render(db)
@@ -422,7 +422,7 @@ async def test_render_auto_clears_resolved_flags(db):
     await observations.create(
         db, id="obs-1", source="test", type="test",
         content="Test", priority="medium",
-        created_at="2026-03-05T10:00:00+00:00",
+        created_at="2026-03-05T10:00:00+00:00", expires_at="2099-01-01T00:00:00+00:00",
     )
 
     # Before retrieval — flag present

--- a/tests/test_perception/test_context.py
+++ b/tests/test_perception/test_context.py
@@ -87,6 +87,7 @@ async def test_light_context_includes_user_and_cognitive_state(db, identity_dir)
         db, id="cs-1", content="Working on Phase 4.",
         section="active_context", generated_by="glm5",
         created_at="2026-03-05T10:00:00+00:00",
+        expires_at="2099-01-01T00:00:00+00:00",
     )
 
     loader = IdentityLoader(identity_dir)


### PR DESCRIPTION
## Summary

- **Job health auto-clear**: `consecutive_failures` reset on server startup so stale failure counts from pre-restart code don't persist on the dashboard (dream cycle showed 7 days of stale failures after PR #385 fix)
- **Cognitive state expiry**: Section-type TTLs auto-compute `expires_at` (3d context, 24h flags, 6h degradation). Readers filter expired entries. Bootstrap cleans up expired + legacy NULL entries >7d. Fixes stale "resilience REDUCED" influencing reflections for days after conditions resolved
- **Ego content integrity guard**: Proposals track `content_size` alongside `content_hash`. Dispatch sweep verifies hash integrity + checks for >15% content shrinkage (log-only gate for v1). Migration backfills missing columns for existing installs

## Test plan

- [x] `ruff check` passes on all changed files
- [x] `pytest tests/ -k "cognitive_state or ego or job_health"` — 49 tests pass
- [x] Code review: 2 findings addressed (expire_old section scope, size truthiness check)
- [ ] Server restart: verify "Cleared stale failures" and "Expired N stale cognitive state entries" in startup log
- [ ] Verify `SELECT expires_at FROM cognitive_state` shows TTLs on new entries after next deep reflection
- [ ] Ego dispatch log: no integrity warnings on happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)