### PR TITLE
fix(dashboard): API key colors + manual ego trigger endpoint

### DIFF
--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -131,6 +131,43 @@ async def ego_status():
     })
 
 
+@blueprint.route("/api/genesis/ego/trigger", methods=["POST"])
+@_async_route
+async def ego_trigger():
+    """Manually trigger a user ego cycle.
+
+    Invokes the cadence manager's _on_tick() which respects the
+    asyncio lock (no concurrent cycles) and circuit breaker state.
+    Returns the cycle result or an error.
+    """
+    import logging
+
+    from genesis.runtime import GenesisRuntime
+
+    logger = logging.getLogger(__name__)
+    rt = GenesisRuntime.instance()
+
+    if not rt.is_bootstrapped:
+        return jsonify({"error": "not bootstrapped"}), 503
+
+    mgr = rt._ego_cadence_manager
+    if mgr is None:
+        return jsonify({"error": "ego cadence manager not available"}), 503
+
+    target = request.args.get("ego", "user")
+    if target == "genesis":
+        mgr = rt._genesis_ego_cadence_manager
+        if mgr is None:
+            return jsonify({"error": "genesis ego cadence manager not available"}), 503
+
+    try:
+        await mgr._on_tick()
+        return jsonify({"status": "ok", "message": f"{target} ego cycle triggered"})
+    except Exception as e:
+        logger.error("Manual ego trigger failed", exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+
 @blueprint.route("/api/genesis/ego/cycles")
 @_async_route
 async def ego_cycles():

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -4510,9 +4510,9 @@
                   <template x-for="(info, name) in ($store.genesisDashboard.health.api_keys?.providers || $store.genesisDashboard.health.api_keys || {})" :key="name">
                     <template x-if="info.status === 'missing' || info.status === 'failed'">
                       <div style="font-size: 0.72rem; margin-top: 0.1rem;"
-                           :style="`color: ${info.status === 'missing' ? '#d9534f' : '#f0ad4e'}`"
+                           :style="`color: ${info.status === 'failed' ? '#d9534f' : '#f0ad4e'}`"
                            :title="info.error || ''">
-                        <span class="status-dot" :style="`background: ${info.status === 'missing' ? '#d9534f' : '#f0ad4e'}`"></span>
+                        <span class="status-dot" :style="`background: ${info.status === 'failed' ? '#d9534f' : '#f0ad4e'}`"></span>
                         <span x-text="name + ' (' + (info.error ? info.error.substring(0, 40) : info.status) + ')'"></span>
                       </div>
                     </template>


### PR DESCRIPTION
## Summary

- **API key colors**: swap failed (now red) and missing (now yellow) — failed means broken and needs attention, missing just means not configured
- **Manual ego trigger**: `POST /api/genesis/ego/trigger` fires user ego cycle on demand. Add `?ego=genesis` for genesis ego. Protected by asyncio lock (no concurrent cycles) and circuit breaker.

## Test plan

- [ ] `curl -X POST localhost:5000/api/genesis/ego/trigger` returns success and fires cycle
- [ ] Dashboard shows failed providers in red, missing in yellow
- [ ] `ruff check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)