### PR TITLE
fix(ego): bypass realist for critical directives + prompt hardening

### DIFF
--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -571,8 +571,27 @@ class EgoSession:
             # persisted to ego_state. It controls THIS cycle's delivery only.
             comm_decision = parsed.get("communication_decision", "send_digest")
             if proposals:
-                # Realist gate — LLM evaluates proposals against history
-                proposals = await self._filter_proposals(proposals)
+                # Bypass realist gate when critical directives are active —
+                # the user explicitly told the ego to propose something.
+                # The realist's zombie detection would incorrectly block
+                # re-proposals that were rejected for fixable reasons.
+                has_critical_directive = False
+                try:
+                    active_dirs = await ego_crud.list_active_directives(
+                        self._db, self._source_tag.replace("_cycle", ""),
+                    )
+                    has_critical_directive = any(
+                        d.get("priority") in ("critical", "high")
+                        for d in active_dirs
+                    )
+                except Exception:
+                    pass
+                if has_critical_directive:
+                    logger.info(
+                        "Realist bypassed — active critical/high directive(s)",
+                    )
+                else:
+                    proposals = await self._filter_proposals(proposals)
                 # Log realist cost for observability (cycle dataclass is frozen,
                 # so cost is tracked via logging; negligible vs ego cycle cost)
                 if self._last_realist_cost_usd > 0:

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -273,7 +273,16 @@ period of time. Each cycle is independent — if you have valuable
 proposals, output them. If you genuinely have nothing to propose, output
 zero proposals. But "holding" or "waiting" or "staying quiet until X" is
 NEVER valid. Delivery frequency is controlled programmatically by the
-cadence manager, not by your judgment.
+cadence manager, not by your judgment. "Panel prep", "user is busy",
+"don't distract" are NEVER valid reasons to output zero proposals. The
+user controls when they check proposals. Your job is to produce them.
+
+**Critical directives require proposals.** If you have an active
+directive with priority "critical" or "high", you MUST produce at least
+one proposal addressing it in that cycle. You cannot resolve, defer, or
+ignore it. A directive is not "completed" until the corresponding
+proposal exists in your proposals[] array. Resolving a directive without
+actually outputting the proposal is a violation.
 
 **Directives are narrowly scoped.** A directive about content publishing
 does NOT imply silence on career, infrastructure, or other domains. Read
@@ -281,9 +290,10 @@ directives literally — they apply to their stated domain only. Do not
 generalize or infer broader behavioral implications.
 
 **Focus summary must be a TOPIC, not a behavioral state.** Valid: "Suki
-application prep + infrastructure monitoring." Invalid: "Demo silence —
-holding for May 27." If your focus_summary describes what you are NOT
-doing, it is wrong. Describe what you ARE focused on.
+application prep + infrastructure monitoring." Invalid: "Panel eve —
+zero distractions." If your focus_summary describes what you are NOT
+doing, or implies suppression of activity, it is wrong. Describe what
+you ARE focused on.
 
 ## Genesis Ego Escalations
 


### PR DESCRIPTION
## Summary

- Realist gate bypass when critical/high directives are active — prevents zombie detection from blocking user-requested re-proposals
- Prompt: critical directives MUST produce proposals, cannot be resolved without output
- Prompt: expanded self-silence examples ("panel prep", "user is busy")

## Context

The ego was asked to re-propose Suki AI CDP submission after the original was rejected for an incorrect Ashby caveat. The ego produced the corrected proposal, but the realist gate rejected it as a "zombie" (same topic as a previously rejected proposal). This is correct behavior for unsolicited re-proposals but wrong for directive-driven ones.

## Test plan

- [x] Trigger ego with critical directive → proposal passes through
- [x] Without critical directive → realist gate still active
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)