### PR TITLE
feat(ego): dispatch debrief notifications in new Ego Dispatches topic

### DIFF
--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -467,8 +467,6 @@ class DirectSessionRunner:
             await update_proposal_outcome(
                 db, proposal_id, success=result.success, summary=summary,
             )
-            # Send after-action debrief to Telegram
-            await self._notify_dispatch_debrief(proposal_id, request, result)
             # On failure: create observation so ego sees it next cycle
             if not result.success:
                 try:
@@ -492,6 +490,8 @@ class DirectSessionRunner:
                 proposal_id,
                 exc_info=True,
             )
+        # Debrief is best-effort, fully self-contained (own try/except)
+        await self._notify_dispatch_debrief(proposal_id, request, result)
 
     async def _notify_dispatch_debrief(
         self,

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -467,6 +467,8 @@ class DirectSessionRunner:
             await update_proposal_outcome(
                 db, proposal_id, success=result.success, summary=summary,
             )
+            # Send after-action debrief to Telegram
+            await self._notify_dispatch_debrief(proposal_id, request, result)
             # On failure: create observation so ego sees it next cycle
             if not result.success:
                 try:
@@ -490,6 +492,38 @@ class DirectSessionRunner:
                 proposal_id,
                 exc_info=True,
             )
+
+    async def _notify_dispatch_debrief(
+        self,
+        proposal_id: str,
+        request: DirectSessionRequest,
+        result: DirectSessionResult,
+    ) -> None:
+        """Send after-action report to ego_dispatches Telegram topic."""
+        try:
+            import html as html_mod
+
+            pw = getattr(self._rt, "_ego_proposal_workflow", None)
+            tm = getattr(pw, "_topic_manager", None) if pw else None
+            if tm is None:
+                return
+
+            status = "✓ Completed" if result.success else "✗ Failed"
+            outcome = (result.output_text or result.error or "no output")[:400]
+            outcome_escaped = html_mod.escape(outcome)
+
+            cost_str = f"${result.cost_usd:.4f}" if result.cost_usd else "—"
+            dur_str = f"{result.duration_s:.0f}s" if result.duration_s else "—"
+
+            msg = (
+                f"<b>Dispatch Debrief</b> [{status}]\n"
+                f"<i>Proposal:</i> {proposal_id[:12]}\n"
+                f"<i>Duration:</i> {dur_str} | <i>Cost:</i> {cost_str}\n\n"
+                f"<b>Outcome:</b>\n{outcome_escaped}"
+            )
+            await tm.send_to_category("ego_dispatches", msg)
+        except Exception:
+            logger.debug("Failed to send dispatch debrief", exc_info=True)
 
     def _build_invocation(self, request: DirectSessionRequest) -> CCInvocation:
         system_prompt = request.system_prompt

--- a/src/genesis/channels/telegram/topics.py
+++ b/src/genesis/channels/telegram/topics.py
@@ -285,6 +285,7 @@ class TopicManager:
             "surplus": "surplus",
             "recon": "recon",
             "ego_proposals": "ego_proposals",
+            "ego_dispatches": "ego_dispatches",
             # Autonomous CLI approvals get their own topic so the inline
             # button UX and "approve all N pending" semantics are clearly
             # scoped — they don't mix with general alerts.

--- a/src/genesis/channels/telegram/topics.py
+++ b/src/genesis/channels/telegram/topics.py
@@ -36,6 +36,8 @@ DEFAULT_CATEGORIES: dict[str, str] = {
     "surplus": "Surplus",
     "recon": "Recon",
     "ego_proposals": "Ego Proposals",
+    # Dispatch lifecycle: "Dispatching..." on spawn, after-action debrief on completion.
+    "ego_dispatches": "Ego Dispatches",
     # Autonomous CLI approval prompts — inline ✅ buttons + optional
     # "approve all N pending" batch button.  Bare "approve"/"reject"
     # text messages in this topic resolve the most recent pending request.

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1613,7 +1613,7 @@ class EgoSession:
         return "\n".join(parts)
 
     async def _notify_execution(self, prop: dict, session_id: str) -> None:
-        """Send structured notification to ego_proposals topic."""
+        """Send structured notification to ego_dispatches topic."""
         try:
             import html as html_mod
 
@@ -1623,7 +1623,7 @@ class EgoSession:
             content = html_mod.escape(prop.get("content", "")[:200])
             action = html_mod.escape(prop.get("action_type", "unknown"))
             msg = f"<b>Dispatched</b> [{action}]: {content}\n<i>Session:</i> {session_id}"
-            await tm.send_to_category("ego_proposals", msg)
+            await tm.send_to_category("ego_dispatches", msg)
         except Exception:
             logger.debug("Failed to send execution notification", exc_info=True)
 


### PR DESCRIPTION
## Summary
- New Telegram topic **"Ego Dispatches"** separates dispatch lifecycle from proposal digests/approvals
- Existing "Dispatched [action]..." notification moved from Ego Proposals → Ego Dispatches topic
- New after-action debrief sent when dispatched session completes (success or failure) with outcome, duration, and cost

## Motivation
Previously, approving a proposal and seeing "Dispatched..." was the last user-facing signal. No notification when the session finished — outcome only visible via MCP tools or DB. Now the full lifecycle is in one topic: dispatch → debrief.

## Test plan
- [ ] Approve a proposal → dispatch notification in new "Ego Dispatches" topic
- [ ] Wait for session completion → debrief notification in same topic
- [ ] Verify Ego Proposals topic only shows digests/approvals (no dispatch noise)
- [ ] Verify graceful no-op when TopicManager is None (no Telegram)
- [ ] `ruff check .` passes
- [ ] `pytest tests/test_ego/ tests/test_cc/test_direct_session.py tests/test_db/test_schema.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)