### PR TITLE
feat(ego): migrate proactive cycle to signal consumer loop

### DIFF
--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -448,9 +448,9 @@ class EgoCadenceManager:
             except CycleBlockedError as exc:
                 logger.info("Unified cycle gated: %s", exc)
                 return
-            except Exception:
+            except Exception as exc:
                 logger.error("Unified cycle failed", exc_info=True)
-                self._record_failure("unified cycle failed")
+                self._record_failure(str(exc))
                 return
 
             if cycle is None:
@@ -463,8 +463,12 @@ class EgoCadenceManager:
 
             # Validate output (same logic as the old _on_tick)
             proposals = []
-            with contextlib.suppress(json.JSONDecodeError, TypeError):
+            try:
                 proposals = json.loads(cycle.proposals_json)
+            except (json.JSONDecodeError, TypeError):
+                logger.debug(
+                    "Could not parse proposals_json for cycle %s", cycle.id,
+                )
 
             if not cycle.focus_summary and not proposals:
                 logger.warning(

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -144,12 +144,19 @@ class EgoCadenceManager:
             misfire_grace_time=300,
         )
         self._scheduler.start()
-        self._reactive_task = asyncio.create_task(
-            self._reactive_loop(), name=f"ego_reactive_{id(self)}",
+        from genesis.util.tasks import tracked_task
+
+        self._reactive_task = tracked_task(
+            self._reactive_loop(),
+            name=f"ego_reactive_{id(self)}",
+            event_bus=self._event_bus,
+            logger=logger,
         )
-        self._signal_consumer_task = asyncio.create_task(
+        self._signal_consumer_task = tracked_task(
             self._signal_consumer_loop(),
             name=f"ego_signal_consumer_{id(self)}",
+            event_bus=self._event_bus,
+            logger=logger,
         )
         self._running = True
         morning_str = (
@@ -417,6 +424,9 @@ class EgoCadenceManager:
         )
         if self._signal_queue.push(signal):
             logger.debug("Proactive signal pushed: %s", signal.summary)
+        else:
+            # Roll back count so deep-think alignment is preserved
+            self._proactive_cycle_count -= 1
 
     async def _process_signals(self) -> None:
         """Drain signal queue and run unified cycle.
@@ -437,7 +447,9 @@ class EgoCadenceManager:
                 break
 
         async with self._lock:
-            # Re-check gates under lock (state may have changed since emission)
+            # Re-check gates under lock (state may have changed since emission).
+            # If rejected, drained signals are lost — acceptable for timer ticks
+            # since the next scheduled tick will push a new signal.
             if not self._should_run(skip_idle_check=True):
                 return
 

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -166,13 +166,18 @@ class EgoCadenceManager:
         )
 
     async def stop(self) -> None:
-        """Shut down APScheduler, reactive loop, and signal consumer."""
-        if self._reactive_task is not None:
-            self._reactive_task.cancel()
-            self._reactive_task = None
-        if self._signal_consumer_task is not None:
-            self._signal_consumer_task.cancel()
-            self._signal_consumer_task = None
+        """Shut down APScheduler, reactive loop, and signal consumer.
+
+        Awaits task cancellation so any held lock is released before
+        stop() returns — prevents deadlock if caller re-acquires the lock.
+        """
+        for attr in ("_reactive_task", "_signal_consumer_task"):
+            task = getattr(self, attr, None)
+            if task is not None:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+                setattr(self, attr, None)
         if self._scheduler.running:
             self._scheduler.shutdown(wait=False)
         self._running = False
@@ -449,6 +454,10 @@ class EgoCadenceManager:
                 return
 
             if cycle is None:
+                # None here means CC-level failure (session creation,
+                # invocation error). The "no actionable signals" path
+                # from _perceive cannot reach here because we guard
+                # `if not signals: return` above.
                 self._record_failure("unified cycle returned None")
                 return
 

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -8,6 +8,7 @@ Owns an APScheduler with two jobs:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 from datetime import UTC, datetime, timedelta
@@ -19,6 +20,7 @@ from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
 from genesis.ego.session import CycleBlockedError
+from genesis.ego.signals import EgoSignal, SignalQueue
 from genesis.ego.types import EgoConfig
 from genesis.env import user_timezone
 
@@ -91,6 +93,10 @@ class EgoCadenceManager:
         self._deep_think_interval = 5
         self._proactive_cycle_count = 0
 
+        # Unified signal queue: _on_tick() pushes here, consumer loop drains
+        self._signal_queue = SignalQueue()
+        self._signal_consumer_task: asyncio.Task | None = None
+
         # Reactive event queue: events push here, debounce loop drains
         self._reactive_queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=100)
         self._reactive_task: asyncio.Task | None = None
@@ -141,6 +147,10 @@ class EgoCadenceManager:
         self._reactive_task = asyncio.create_task(
             self._reactive_loop(), name=f"ego_reactive_{id(self)}",
         )
+        self._signal_consumer_task = asyncio.create_task(
+            self._signal_consumer_loop(),
+            name=f"ego_signal_consumer_{id(self)}",
+        )
         self._running = True
         morning_str = (
             f", morning={self._config.morning_report_hour:02d}:"
@@ -156,10 +166,13 @@ class EgoCadenceManager:
         )
 
     async def stop(self) -> None:
-        """Shut down APScheduler and reactive loop."""
+        """Shut down APScheduler, reactive loop, and signal consumer."""
         if self._reactive_task is not None:
             self._reactive_task.cancel()
             self._reactive_task = None
+        if self._signal_consumer_task is not None:
+            self._signal_consumer_task.cancel()
+            self._signal_consumer_task = None
         if self._scheduler.running:
             self._scheduler.shutdown(wait=False)
         self._running = False
@@ -359,67 +372,120 @@ class EgoCadenceManager:
     # -- Tick handlers -----------------------------------------------------
 
     async def _on_tick(self) -> None:
-        """Interval trigger handler. Checks all gates then runs cycle."""
+        """Interval trigger handler. Pushes idle signal for consumer loop.
+
+        Gate checks run here (emission-time). The consumer loop re-checks
+        under lock before running the cycle. Lock is NOT held here —
+        _on_tick only pushes signals, no shared mutable state besides
+        _proactive_cycle_count (serialized by APScheduler max_instances=1).
+        """
         self._emit_heartbeat("tick")
         logger.debug(
             "Ego tick fired (current_interval=%dm, config_cadence=%dm)",
             self._current_interval,
             self._config.cadence_minutes,
         )
-        async with self._lock:
-            if not self._should_run(skip_idle_check=False):
-                return
+        if not self._should_run(skip_idle_check=False):
+            return
 
-            # Deep-think: every Nth proactive cycle upgrades to Opus.
-            # Only effective for egos that normally run Sonnet (Genesis ego).
-            self._proactive_cycle_count += 1
-            model_override = None
-            if (
-                self._deep_think_interval > 0
-                and self._proactive_cycle_count % self._deep_think_interval == 0
-                and self._config.model != "opus"
-            ):
-                model_override = "opus"
-                logger.info(
-                    "Deep-think cycle %d — upgrading to Opus",
-                    self._proactive_cycle_count,
-                )
+        # Deep-think: every Nth proactive cycle upgrades to Opus.
+        # Only effective for egos that normally run Sonnet (Genesis ego).
+        self._proactive_cycle_count += 1
+        model_override = None
+        if (
+            self._deep_think_interval > 0
+            and self._proactive_cycle_count % self._deep_think_interval == 0
+            and self._config.model != "opus"
+        ):
+            model_override = "opus"
+            logger.info(
+                "Deep-think cycle %d — upgrading to Opus",
+                self._proactive_cycle_count,
+            )
+
+        signal = EgoSignal(
+            signal_type="timer",
+            focus_category="proactive",
+            summary=f"Idle tick #{self._proactive_cycle_count}",
+            priority="medium",
+            metadata={"model_override": model_override} if model_override else {},
+        )
+        if self._signal_queue.push(signal):
+            logger.debug("Proactive signal pushed: %s", signal.summary)
+
+    async def _process_signals(self) -> None:
+        """Drain signal queue and run unified cycle.
+
+        Separated from the consumer loop for testability — tests call
+        this directly after pushing signals.
+        """
+        signals = self._signal_queue.drain()
+        if not signals:
+            return
+
+        # Extract model override from signal metadata (deep-think)
+        model_override = None
+        for sig in signals:
+            mo = sig.metadata.get("model_override")
+            if mo:
+                model_override = mo
+                break
+
+        async with self._lock:
+            # Re-check gates under lock (state may have changed since emission)
+            if not self._should_run(skip_idle_check=True):
+                return
 
             try:
-                cycle = await self._session.run_cycle(
-                    model_override=model_override,
+                cycle = await self._session.run_unified_cycle(
+                    signals, model_override=model_override,
                 )
             except CycleBlockedError as exc:
-                # Approval gate is a gate, not a failure.
-                # Don't trip the circuit breaker.
-                logger.info("Ego cycle gated: %s", exc)
+                logger.info("Unified cycle gated: %s", exc)
                 return
-            except Exception as exc:
-                logger.error("Ego cycle failed with exception", exc_info=True)
-                self._record_failure(str(exc))
+            except Exception:
+                logger.error("Unified cycle failed", exc_info=True)
+                self._record_failure("unified cycle failed")
                 return
 
             if cycle is None:
-                # CC error or session creation failure
-                self._record_failure("cycle returned None")
+                self._record_failure("unified cycle returned None")
                 return
 
-            # Check if the cycle produced meaningful output.
-            # A parse-failure cycle has empty focus_summary — treat as soft failure
-            # so the circuit breaker can detect persistent LLM issues.
+            # Validate output (same logic as the old _on_tick)
             proposals = []
-            try:
+            with contextlib.suppress(json.JSONDecodeError, TypeError):
                 proposals = json.loads(cycle.proposals_json)
-            except (json.JSONDecodeError, TypeError):
-                logger.debug("Could not parse proposals_json for cycle %s", cycle.id)
 
             if not cycle.focus_summary and not proposals:
-                logger.warning("Ego cycle %s produced no usable output", cycle.id)
+                logger.warning(
+                    "Unified cycle %s produced no usable output", cycle.id,
+                )
                 self._record_failure("cycle produced no usable output")
                 return
 
             self._record_success()
             await self._update_interval(had_proposals=bool(proposals))
+
+    async def _signal_consumer_loop(self) -> None:
+        """Background consumer for the unified signal queue.
+
+        Blocks until signals arrive, brief batch window, then processes.
+        Same outer structure as _reactive_loop() for reliability.
+        """
+        while True:
+            try:
+                await self._signal_queue.wait()
+                await asyncio.sleep(2)  # Brief batch window
+                await self._process_signals()
+            except asyncio.CancelledError:
+                logger.debug("Signal consumer loop cancelled")
+                break
+            except Exception:
+                logger.warning(
+                    "Signal consumer error — backing off 60s", exc_info=True,
+                )
+                await asyncio.sleep(60)
 
     async def _on_morning_report(self) -> None:
         """Cron trigger handler. Morning report cycle (skips idle check)."""

--- a/src/genesis/ego/signals.py
+++ b/src/genesis/ego/signals.py
@@ -101,6 +101,8 @@ class SignalQueue:
         self._dedup_hours = dedup_hours
         # summary → last_seen timestamp (same pattern as cadence.py:104)
         self._seen: dict[str, datetime] = {}
+        # Blocking notification for consumer loop (set on push, cleared on drain)
+        self._notify = asyncio.Event()
 
     def push(self, signal: EgoSignal) -> bool:
         """Add a signal to the queue.
@@ -136,6 +138,7 @@ class SignalQueue:
         # Try to enqueue
         try:
             self._queue.put_nowait(signal)
+            self._notify.set()
             logger.debug(
                 "Signal queued [%s]: %s",
                 signal.priority,
@@ -151,7 +154,11 @@ class SignalQueue:
 
         Returns signals sorted by priority (highest first — they
         come out in priority order from the PriorityQueue).
+
+        Clears the notify event BEFORE draining so that a push()
+        during drain re-sets it — the next wait() returns immediately.
         """
+        self._notify.clear()
         signals: list[EgoSignal] = []
         while not self._queue.empty():
             try:
@@ -175,8 +182,13 @@ class SignalQueue:
         """Whether the queue is empty."""
         return self._queue.empty()
 
+    async def wait(self) -> None:
+        """Block until at least one signal is pushed."""
+        await self._notify.wait()
+
     def clear(self) -> None:
         """Drop all signals and reset dedup state."""
+        self._notify.clear()
         while not self._queue.empty():
             try:
                 self._queue.get_nowait()

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -347,7 +347,7 @@ _CALL_SITE_META: dict[str, dict] = {
         "category": "classification",
         "frequency": "Per ego cycle (4-6/day), skipped when single signal",
         "model_tier": "slm",
-        "status_reason": "BUILT",  # Wired to cadence consumer loop in PR 2
+        "status_reason": "WIRED",  # Consumer loop → run_unified_cycle → _perceive → FocusSelector
     },
     "contingency_foreground": {
         "description": "API-based foreground conversation fallback when CC is rate-limited or unavailable.",

--- a/src/genesis/runtime/init/ego.py
+++ b/src/genesis/runtime/init/ego.py
@@ -119,6 +119,7 @@ async def init(rt: GenesisRuntime) -> None:
             session_id_key="user_ego_cc_session_id",
             focus_summary_key="ego_focus_summary",  # User ego owns the canonical focus
             source_tag="user_ego_cycle",
+            router=rt._router,
         )
 
         if rt._autonomous_dispatcher is not None:
@@ -191,6 +192,7 @@ async def init(rt: GenesisRuntime) -> None:
             session_id_key="genesis_ego_cc_session_id",
             focus_summary_key="genesis_ego_focus_summary",  # Separate from user ego
             source_tag="genesis_ego_cycle",
+            router=rt._router,
         )
 
         if rt._autonomous_dispatcher is not None:

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -1,4 +1,10 @@
-"""Tests for the ego cadence manager."""
+"""Tests for the ego cadence manager.
+
+After PR 2 (unified cognitive loop), _on_tick() pushes signals to the
+SignalQueue and _process_signals() drains the queue and calls
+run_unified_cycle(). Tests that verify end-to-end proactive behavior
+call _on_tick() then _process_signals().
+"""
 
 from __future__ import annotations
 
@@ -43,8 +49,9 @@ def config():
 
 @pytest.fixture
 def mock_session():
-    """Mock EgoSession with controllable run_cycle."""
+    """Mock EgoSession with controllable run_cycle and run_unified_cycle."""
     session = AsyncMock()
+    # Legacy path (morning report, reactive loop)
     session.run_cycle.return_value = EgoCycle(
         id="c1",
         output_text="test",
@@ -52,6 +59,17 @@ def mock_session():
         focus_summary="testing",
         model_used="opus",
         cost_usd=0.15,
+        ego_source="user_ego_cycle",
+    )
+    # Unified path (proactive via signal consumer)
+    session.run_unified_cycle.return_value = EgoCycle(
+        id="u1",
+        output_text="unified test",
+        proposals_json=json.dumps([{"action_type": "test"}]),
+        focus_summary="unified testing",
+        model_used="opus",
+        cost_usd=0.15,
+        ego_source="user_ego_cycle",
     )
     return session
 
@@ -99,6 +117,9 @@ class TestCadenceLifecycle:
         job_ids = {j.id for j in jobs}
         assert "ego_cycle" in job_ids
         assert "ego_morning_report" in job_ids
+        # Consumer task should be running
+        assert cadence._signal_consumer_task is not None
+        assert not cadence._signal_consumer_task.done()
         await cadence.stop()
 
     async def test_stop_shuts_down(self, cadence):
@@ -106,6 +127,7 @@ class TestCadenceLifecycle:
         assert cadence.is_running
         await cadence.stop()
         assert not cadence.is_running
+        assert cadence._signal_consumer_task is None
 
     async def test_pause_resume(self, cadence):
         assert not cadence.is_paused
@@ -116,26 +138,37 @@ class TestCadenceLifecycle:
 
 
 # ---------------------------------------------------------------------------
-# Tick behavior
+# Tick behavior — _on_tick() now pushes signals, _process_signals() runs cycle
 # ---------------------------------------------------------------------------
 
 
 class TestCadenceTick:
-    async def test_tick_runs_cycle_when_idle(
-        self, cadence, mock_session, mock_idle_detector,
+    async def test_tick_pushes_signal_to_queue(
+        self, cadence, mock_idle_detector,
     ):
+        """_on_tick() pushes a signal to the queue (doesn't call run_cycle)."""
         mock_idle_detector.is_idle.return_value = True
         await cadence._on_tick()
-        mock_session.run_cycle.assert_called_once()
+        assert not cadence._signal_queue.empty()
+
+    async def test_tick_runs_unified_cycle_when_idle(
+        self, cadence, mock_session, mock_idle_detector,
+    ):
+        """_on_tick() + _process_signals() calls run_unified_cycle."""
+        mock_idle_detector.is_idle.return_value = True
+        await cadence._on_tick()
+        await cadence._process_signals()
+        mock_session.run_unified_cycle.assert_called_once()
         # model_override is None for normal proactive cycles
-        assert mock_session.run_cycle.call_args.kwargs.get("model_override") is None
+        assert mock_session.run_unified_cycle.call_args.kwargs.get("model_override") is None
 
     async def test_tick_skips_when_active(
         self, cadence, mock_session, mock_idle_detector,
     ):
         mock_idle_detector.is_idle.return_value = False
         await cadence._on_tick()
-        mock_session.run_cycle.assert_not_called()
+        mock_session.run_unified_cycle.assert_not_called()
+        assert cadence._signal_queue.empty()
 
     async def test_tick_skips_when_onboarding_incomplete(
         self, cadence, mock_session, tmp_path,
@@ -143,35 +176,41 @@ class TestCadenceTick:
         # Remove the marker created by autouse fixture
         (tmp_path / ".genesis" / "setup-complete").unlink()
         await cadence._on_tick()
-        mock_session.run_cycle.assert_not_called()
+        mock_session.run_unified_cycle.assert_not_called()
+        assert cadence._signal_queue.empty()
 
     async def test_tick_skips_when_paused(
         self, cadence, mock_session,
     ):
         cadence.pause()
         await cadence._on_tick()
-        mock_session.run_cycle.assert_not_called()
+        mock_session.run_unified_cycle.assert_not_called()
+        assert cadence._signal_queue.empty()
 
     async def test_tick_skips_when_circuit_open(
         self, cadence, mock_session,
     ):
         cadence._circuit_open_until = datetime.now(UTC) + timedelta(hours=1)
         await cadence._on_tick()
-        mock_session.run_cycle.assert_not_called()
+        mock_session.run_unified_cycle.assert_not_called()
+        assert cadence._signal_queue.empty()
 
     async def test_tick_handles_exception(
         self, cadence, mock_session,
     ):
-        mock_session.run_cycle.side_effect = RuntimeError("boom")
+        """Exception in run_unified_cycle records a failure."""
+        mock_session.run_unified_cycle.side_effect = RuntimeError("boom")
         await cadence._on_tick()
+        await cadence._process_signals()
         assert cadence.consecutive_failures == 1
 
     async def test_tick_cycle_blocked_does_not_trip_breaker(
         self, cadence, mock_session,
     ):
         """CycleBlockedError is a gate, not a failure — no circuit breaker impact."""
-        mock_session.run_cycle.side_effect = CycleBlockedError("approval pending")
+        mock_session.run_unified_cycle.side_effect = CycleBlockedError("approval pending")
         await cadence._on_tick()
+        await cadence._process_signals()
         assert cadence.consecutive_failures == 0
 
     async def test_morning_report_cycle_blocked_does_not_trip_breaker(
@@ -184,7 +223,82 @@ class TestCadenceTick:
 
 
 # ---------------------------------------------------------------------------
-# Morning report
+# Signal consumer — _process_signals() tests
+# ---------------------------------------------------------------------------
+
+
+class TestProcessSignals:
+    async def test_process_signals_calls_unified_cycle(
+        self, cadence, mock_session,
+    ):
+        """_process_signals() drains queue and calls run_unified_cycle."""
+        from genesis.ego.signals import EgoSignal
+
+        cadence._signal_queue.push(EgoSignal(
+            signal_type="timer",
+            focus_category="proactive",
+            summary="Idle tick #1",
+        ))
+        await cadence._process_signals()
+        mock_session.run_unified_cycle.assert_called_once()
+        # Signals are passed as first positional arg
+        call_args = mock_session.run_unified_cycle.call_args
+        signals = call_args[0][0]
+        assert len(signals) == 1
+        assert signals[0].summary == "Idle tick #1"
+
+    async def test_process_signals_empty_queue_noop(
+        self, cadence, mock_session,
+    ):
+        """Empty queue → no cycle call."""
+        await cadence._process_signals()
+        mock_session.run_unified_cycle.assert_not_called()
+
+    async def test_deep_think_passes_model_override_via_metadata(
+        self, cadence, mock_session, mock_idle_detector, monkeypatch,
+    ):
+        """Every Nth proactive cycle passes model_override='opus' via signal metadata."""
+        mock_idle_detector.is_idle.return_value = True
+        sonnet_config = EgoConfig(
+            cadence_minutes=60, model="sonnet",  # Non-opus so deep-think triggers
+        )
+        cadence._config = sonnet_config
+        # Prevent hot-reload from overwriting test config back to disk values
+        monkeypatch.setattr(
+            "genesis.ego.config.load_ego_config",
+            lambda: sonnet_config,
+        )
+        cadence._deep_think_interval = 2  # Every 2nd cycle
+
+        # Cycle 1: no override
+        await cadence._on_tick()
+        await cadence._process_signals()
+        assert mock_session.run_unified_cycle.call_args.kwargs.get("model_override") is None
+
+        # Cycle 2: deep-think → opus override
+        mock_session.run_unified_cycle.reset_mock()
+        await cadence._on_tick()
+        await cadence._process_signals()
+        assert mock_session.run_unified_cycle.call_args.kwargs.get("model_override") == "opus"
+
+    async def test_signal_queue_created_on_init(self, cadence):
+        """EgoCadenceManager creates a SignalQueue on init."""
+        assert cadence._signal_queue is not None
+        assert cadence._signal_queue.empty()
+
+    async def test_consumer_loop_lifecycle(self, cadence):
+        """start() creates consumer task, stop() cancels it."""
+        assert cadence._signal_consumer_task is None
+        await cadence.start()
+        assert cadence._signal_consumer_task is not None
+        task = cadence._signal_consumer_task
+        assert not task.done()
+        await cadence.stop()
+        assert cadence._signal_consumer_task is None
+
+
+# ---------------------------------------------------------------------------
+# Morning report (unchanged — still uses run_cycle)
 # ---------------------------------------------------------------------------
 
 
@@ -206,36 +320,42 @@ class TestMorningReport:
 
 
 # ---------------------------------------------------------------------------
-# Circuit breaker
+# Circuit breaker — driven via _on_tick() + _process_signals()
 # ---------------------------------------------------------------------------
 
 
 class TestCircuitBreaker:
     async def test_opens_after_n_failures(self, cadence, mock_session, config):
-        mock_session.run_cycle.return_value = None  # failure signal
+        mock_session.run_unified_cycle.return_value = None  # failure signal
         for _ in range(config.consecutive_failure_limit):
             await cadence._on_tick()
+            await cadence._process_signals()
 
         assert cadence.consecutive_failures == config.consecutive_failure_limit
         assert cadence._circuit_open_until is not None
 
         # Next tick should be skipped due to circuit breaker
-        mock_session.run_cycle.reset_mock()
+        mock_session.run_unified_cycle.reset_mock()
         await cadence._on_tick()
-        mock_session.run_cycle.assert_not_called()
+        mock_session.run_unified_cycle.assert_not_called()
+        assert cadence._signal_queue.empty()
 
     async def test_resets_on_success(self, cadence, mock_session):
         # Simulate 2 failures
-        mock_session.run_cycle.return_value = None
+        mock_session.run_unified_cycle.return_value = None
         await cadence._on_tick()
+        await cadence._process_signals()
         await cadence._on_tick()
+        await cadence._process_signals()
         assert cadence.consecutive_failures == 2
 
         # Success resets
-        mock_session.run_cycle.return_value = EgoCycle(
+        mock_session.run_unified_cycle.return_value = EgoCycle(
             output_text="ok", proposals_json="[]", focus_summary="ok",
+            ego_source="user_ego_cycle",
         )
         await cadence._on_tick()
+        await cadence._process_signals()
         assert cadence.consecutive_failures == 0
 
     async def test_expires_after_backoff(self, cadence, config):
@@ -248,7 +368,7 @@ class TestCircuitBreaker:
 
 
 # ---------------------------------------------------------------------------
-# Adaptive interval
+# Adaptive interval — driven via _on_tick() + _process_signals()
 # ---------------------------------------------------------------------------
 
 
@@ -263,37 +383,45 @@ class TestAdaptiveInterval:
 
     async def test_backoff_increases_interval(self, cadence, mock_session, config):
         # Cycle with no proposals → backoff
-        mock_session.run_cycle.return_value = EgoCycle(
+        mock_session.run_unified_cycle.return_value = EgoCycle(
             output_text="quiet", proposals_json="[]", focus_summary="idle",
+            ego_source="user_ego_cycle",
         )
         await cadence._on_tick()
+        await cadence._process_signals()
         assert cadence.current_interval_minutes == int(config.cadence_minutes * config.backoff_multiplier)
 
     async def test_proposals_reset_interval(self, cadence, mock_session, config):
         # First: backoff
-        mock_session.run_cycle.return_value = EgoCycle(
+        mock_session.run_unified_cycle.return_value = EgoCycle(
             output_text="quiet", proposals_json="[]", focus_summary="idle",
+            ego_source="user_ego_cycle",
         )
         await cadence._on_tick()
+        await cadence._process_signals()
         assert cadence.current_interval_minutes > config.cadence_minutes
 
         # Then: proposals reset
-        mock_session.run_cycle.return_value = EgoCycle(
+        mock_session.run_unified_cycle.return_value = EgoCycle(
             output_text="active",
             proposals_json=json.dumps([{"action_type": "test"}]),
             focus_summary="active",
+            ego_source="user_ego_cycle",
         )
         await cadence._on_tick()
+        await cadence._process_signals()
         assert cadence.current_interval_minutes == config.cadence_minutes
 
     async def test_backoff_capped_at_max(self, cadence, mock_session, config):
         """Multiple idle cycles don't exceed max_interval_minutes."""
-        mock_session.run_cycle.return_value = EgoCycle(
+        mock_session.run_unified_cycle.return_value = EgoCycle(
             output_text="quiet", proposals_json="[]", focus_summary="idle",
+            ego_source="user_ego_cycle",
         )
         # Run enough times to exceed max
         for _ in range(10):
             await cadence._on_tick()
+            await cadence._process_signals()
         assert cadence.current_interval_minutes <= config.max_interval_minutes
 
 
@@ -384,17 +512,26 @@ class TestRecencyMaxInterval:
 class TestRecencyAwareBackoff:
     """_update_interval respects recency-adjusted max."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_config(self, monkeypatch, config):
+        monkeypatch.setattr(
+            "genesis.ego.config.load_ego_config",
+            lambda: config,
+        )
+
     async def test_backoff_respects_recency_tier(self, cadence, mock_session, db):
         """When user was active 2 days ago, backoff caps at 480 (not 240)."""
         ts = (datetime.now(UTC) - timedelta(days=2)).isoformat()
         await _insert_foreground_session(db, last_activity_at=ts)
 
-        mock_session.run_cycle.return_value = EgoCycle(
+        mock_session.run_unified_cycle.return_value = EgoCycle(
             output_text="quiet", proposals_json="[]", focus_summary="idle",
+            ego_source="user_ego_cycle",
         )
         # Run enough idle cycles to hit the cap
         for _ in range(10):
             await cadence._on_tick()
+            await cadence._process_signals()
 
         assert cadence.current_interval_minutes <= 480
         # Should have backed off beyond the old 240 cap
@@ -406,20 +543,24 @@ class TestRecencyAwareBackoff:
         old_ts = (datetime.now(UTC) - timedelta(days=10)).isoformat()
         await _insert_foreground_session(db, last_activity_at=old_ts)
 
-        mock_session.run_cycle.return_value = EgoCycle(
+        mock_session.run_unified_cycle.return_value = EgoCycle(
             output_text="quiet", proposals_json="[]", focus_summary="idle",
+            ego_source="user_ego_cycle",
         )
         for _ in range(5):
             await cadence._on_tick()
+            await cadence._process_signals()
         assert cadence.current_interval_minutes > cadence._config.cadence_minutes
 
         # Productive cycle → reset to base
-        mock_session.run_cycle.return_value = EgoCycle(
+        mock_session.run_unified_cycle.return_value = EgoCycle(
             output_text="active",
             proposals_json=json.dumps([{"action_type": "test"}]),
             focus_summary="active",
+            ego_source="user_ego_cycle",
         )
         await cadence._on_tick()
+        await cadence._process_signals()
         assert cadence.current_interval_minutes == cadence._config.cadence_minutes
 
 

--- a/tests/test_ego/test_signals.py
+++ b/tests/test_ego/test_signals.py
@@ -5,7 +5,10 @@ Covers: priority ordering, dedup, expiry, queue overflow, drain, clear.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
+
+import pytest
 
 from genesis.ego.signals import EgoSignal, SignalQueue
 
@@ -180,10 +183,6 @@ def test_queue_dedup_truncates_long_summary():
 
 
 # ── SignalQueue.wait() ───────────────────────────────────────────────────
-
-import asyncio
-
-import pytest
 
 
 @pytest.mark.asyncio

--- a/tests/test_ego/test_signals.py
+++ b/tests/test_ego/test_signals.py
@@ -177,3 +177,57 @@ def test_queue_dedup_truncates_long_summary():
 
     assert q.push(sig1) is True
     assert q.push(sig2) is False  # deduped by first 100 chars
+
+
+# ── SignalQueue.wait() ───────────────────────────────────────────────────
+
+import asyncio
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_wait_returns_on_push():
+    """wait() should return once a signal is pushed."""
+    q = SignalQueue(maxsize=10)
+
+    async def push_after_delay():
+        await asyncio.sleep(0.05)
+        q.push(EgoSignal(summary="wake up"))
+
+    asyncio.create_task(push_after_delay())
+    await asyncio.wait_for(q.wait(), timeout=2.0)
+    assert not q.empty()
+
+
+@pytest.mark.asyncio
+async def test_wait_blocks_when_empty():
+    """wait() should not return if nothing is pushed (within timeout)."""
+    q = SignalQueue(maxsize=10)
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(q.wait(), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_drain_clears_notify():
+    """After drain(), wait() should block again until next push."""
+    q = SignalQueue(maxsize=10)
+    q.push(EgoSignal(summary="first"))
+    q.drain()
+
+    # Event was cleared by drain — wait should block
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(q.wait(), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_push_during_drain_resets_notify():
+    """If push() happens after drain clears the event, wait() returns immediately."""
+    q = SignalQueue(maxsize=10)
+    q.push(EgoSignal(summary="original"))
+    q.drain()  # clears notify
+
+    # Push a new signal — should re-set the event
+    q.push(EgoSignal(summary="new signal"))
+    await asyncio.wait_for(q.wait(), timeout=1.0)
+    assert not q.empty()


### PR DESCRIPTION
## Summary

PR 2 of the unified cognitive loop redesign (see plan in PR #420).

- **`_on_tick()` → signal emitter**: Reduced from ~70 lines (gate checks + full cycle execution) to ~25 lines (gate checks + push `EgoSignal`). Lock removed — APScheduler serializes ticks via `max_instances=1`; only `_proactive_cycle_count` is modified.
- **Signal consumer loop**: New `_signal_consumer_loop()` background task blocks on `SignalQueue.wait()`, sleeps 2s (batch window), then calls `_process_signals()` — which drains the queue and routes through `run_unified_cycle()` (PR 1's perceive→think→act pipeline).
- **SignalQueue.wait()**: `asyncio.Event`-based blocking. Set on push, cleared before drain. Race-safe for single-consumer pattern.
- **Router wired**: Both EgoSession constructors in `init/ego.py` now receive `router=rt._router`, enabling the FocusSelector's LLM-based perception phase.
- **Deep-think preserved**: Cycle counter stays in `_on_tick()`, model override flows via signal metadata `{"model_override": "opus"}`.
- **Dedup safety**: Each idle tick signal includes cycle count in summary (`Idle tick #N`), preventing 6h dedup window from rejecting all ticks.

### What this PR does NOT change
- `_reactive_loop()` (PR 4)
- `_on_morning_report()` (PR 3)
- Context weights in `build()` (PR 3)
- `CycleType` removal (PR 5)

## Files changed (6)

| File | Change |
|------|--------|
| `src/genesis/ego/signals.py` | `asyncio.Event` notify + `wait()` method |
| `src/genesis/ego/cadence.py` | `_on_tick()` rewrite, `_process_signals()`, `_signal_consumer_loop()`, lifecycle |
| `src/genesis/runtime/init/ego.py` | `router=rt._router` on both EgoSession constructors |
| `src/genesis/observability/_call_site_meta.py` | `40_ego_focus_selection` BUILT → WIRED |
| `tests/ego/test_cadence.py` | 38 tests (was 32): updated proactive path + 6 new consumer tests |
| `tests/test_ego/test_signals.py` | 21 tests (was 17): 4 new `wait()` tests |

## Test plan

- [x] `ruff check` on all modified files — clean
- [x] `pytest tests/test_ego/test_signals.py` — 21/21 pass (4 new wait() tests)
- [x] `pytest tests/ego/test_cadence.py` — 38/38 pass (6 new + 10 updated + 22 unchanged)
- [x] `pytest tests/test_ego/ tests/ego/` — 528/528 pass (zero regressions)
- [x] `pytest tests/test_routing/test_config.py` — 20/20 pass (call site count unchanged)
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)