### PR TITLE
fix(telegram): make response path resilient to DB lock errors

### DIFF
--- a/scripts/hooks/worktree_cwd_guard.py
+++ b/scripts/hooks/worktree_cwd_guard.py
@@ -18,7 +18,6 @@ import os
 import re
 import sys
 
-
 # Matches 'git worktree remove' with optional flags
 _WORKTREE_REMOVE = re.compile(
     r"\bgit\s+worktree\s+remove\b"

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -233,13 +233,23 @@ class ConversationLoop:
                 self._fire_failure_detection("generic_error")
                 return f"[Genesis error: {e}]"
 
-            # Store cc_session_id from first response
+            # Store cc_session_id from first response (non-critical — next
+            # turn re-checks the guard so a transient DB lock just delays
+            # session resume by one turn).
             if not session.get("cc_session_id") and output.session_id:
-                await cc_sessions.update_cc_session_id(
-                    self._db, session["id"], cc_session_id=output.session_id,
-                )
+                try:
+                    await cc_sessions.update_cc_session_id(
+                        self._db, session["id"], cc_session_id=output.session_id,
+                    )
+                except Exception:
+                    logger.warning("Failed to store cc_session_id", exc_info=True)
 
-            await self._session_mgr.update_activity(session["id"])
+            # Activity timestamp — non-critical, but reap_stale() uses it so
+            # persistent failures deserve monitoring (WARNING, not debug).
+            try:
+                await self._session_mgr.update_activity(session["id"])
+            except Exception:
+                logger.warning("Failed to update session activity", exc_info=True)
 
             # Record cost incrementally (session stays active)
             if output.cost_usd or output.input_tokens or output.output_tokens:
@@ -474,12 +484,23 @@ class ConversationLoop:
                 self._fire_failure_detection("generic_error")
                 return f"[Genesis error: {e}]"
 
+            # Store cc_session_id from first response (non-critical — next
+            # turn re-checks the guard so a transient DB lock just delays
+            # session resume by one turn).
             if not session.get("cc_session_id") and output.session_id:
-                await cc_sessions.update_cc_session_id(
-                    self._db, session["id"], cc_session_id=output.session_id,
-                )
+                try:
+                    await cc_sessions.update_cc_session_id(
+                        self._db, session["id"], cc_session_id=output.session_id,
+                    )
+                except Exception:
+                    logger.warning("Failed to store cc_session_id", exc_info=True)
 
-            await self._session_mgr.update_activity(session["id"])
+            # Activity timestamp — non-critical, but reap_stale() uses it so
+            # persistent failures deserve monitoring (WARNING, not debug).
+            try:
+                await self._session_mgr.update_activity(session["id"])
+            except Exception:
+                logger.warning("Failed to update session activity", exc_info=True)
 
             # Record cost incrementally (session stays active)
             if output.cost_usd or output.input_tokens or output.output_tokens:

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -791,7 +791,11 @@ async def _try_bare_approval_resolution(
         )
     except Exception:
         log.error("Failed to resolve bare approval", exc_info=True)
-        return False
+        try:
+            await msg.reply_text("Failed to process approval — please try again.")
+        except Exception:
+            log.debug("Failed to send approval error reply", exc_info=True)
+        return True  # Consume — user intended approval, not conversation
     if resolved_id is None:
         log.debug(
             "Bare %s in Approvals topic ignored — no pending requests",
@@ -1324,10 +1328,15 @@ async def handle_callback_query(
 
     user = update.effective_user
     if not user or not ctx.authorized(user.id):
-        await query.answer("Not authorized", show_alert=True)
+        with contextlib.suppress(Exception):
+            await query.answer("Not authorized", show_alert=True)
         return
 
-    await query.answer()  # Dismiss spinner immediately
+    # Dismiss spinner — purely cosmetic.  Stale callbacks (>30s old, common
+    # after polling restarts) raise BadRequest here; the approval resolution
+    # below must still proceed.
+    with contextlib.suppress(Exception):
+        await query.answer()
 
     data = query.data or ""
     parts = data.split(":", 1)
@@ -1370,7 +1379,7 @@ async def handle_callback_query(
                 parse_mode="HTML",
             )
         except Exception:
-            log.debug("Failed to edit message after cli_approve", exc_info=True)
+            log.warning("Failed to edit message after cli_approve", exc_info=True)
         _wake_inbox_monitor()
         return
 
@@ -1423,7 +1432,7 @@ async def handle_callback_query(
                 parse_mode="HTML",
             )
         except Exception:
-            log.debug("Failed to edit message after cli_approve_all", exc_info=True)
+            log.warning("Failed to edit message after cli_approve_all", exc_info=True)
         _wake_inbox_monitor()
         return
 
@@ -1444,7 +1453,7 @@ async def handle_callback_query(
                     parse_mode="HTML",
                 )
             except Exception:
-                log.debug("Failed to edit message after callback resolution", exc_info=True)
+                log.warning("Failed to edit message after callback resolution", exc_info=True)
         else:
             # Waiter expired or already processed — still show user feedback
             # so button presses aren't silently swallowed.
@@ -1462,7 +1471,7 @@ async def handle_callback_query(
                     parse_mode="HTML",
                 )
             except Exception:
-                log.debug("Failed to edit expired waiter message", exc_info=True)
+                log.warning("Failed to edit expired waiter message", exc_info=True)
 
 
 async def handle_voice(ctx: HandlerContext, update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -794,7 +794,7 @@ async def _try_bare_approval_resolution(
         try:
             await msg.reply_text("Failed to process approval — please try again.")
         except Exception:
-            log.debug("Failed to send approval error reply", exc_info=True)
+            log.warning("Failed to send approval error reply", exc_info=True)
         return True  # Consume — user intended approval, not conversation
     if resolved_id is None:
         log.debug(
@@ -1328,15 +1328,19 @@ async def handle_callback_query(
 
     user = update.effective_user
     if not user or not ctx.authorized(user.id):
-        with contextlib.suppress(Exception):
+        try:
             await query.answer("Not authorized", show_alert=True)
+        except Exception:
+            log.debug("Failed to answer unauthorized callback query", exc_info=True)
         return
 
     # Dismiss spinner — purely cosmetic.  Stale callbacks (>30s old, common
     # after polling restarts) raise BadRequest here; the approval resolution
     # below must still proceed.
-    with contextlib.suppress(Exception):
+    try:
         await query.answer()
+    except Exception:
+        log.debug("Failed to answer callback query (stale?)", exc_info=True)
 
     data = query.data or ""
     parts = data.split(":", 1)

--- a/src/genesis/channels/telegram/adapter_v2.py
+++ b/src/genesis/channels/telegram/adapter_v2.py
@@ -189,6 +189,17 @@ class TelegramAdapterV2(ChannelAdapter):
 
         self._app.add_handler(TypeHandler(Update, _record_any_update), group=-1)
 
+        # Global error handler — catches unhandled exceptions in any handler
+        # so they are logged with full traceback rather than silently dropped.
+        async def _on_error(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+            log.error(
+                "Unhandled exception in Telegram handler: %s",
+                context.error,
+                exc_info=context.error,
+            )
+
+        self._app.add_error_handler(_on_error)
+
         log.info("Starting Telegram bot V2 (polling)...")
         await self._app.initialize()
         await self._app.start()

--- a/src/genesis/db/crud/cc_sessions.py
+++ b/src/genesis/db/crud/cc_sessions.py
@@ -127,10 +127,17 @@ async def reap_stale(
     *,
     older_than: str,
 ) -> int:
-    """Mark stale active sessions as completed. Returns count reaped."""
+    """Mark stale active sessions as completed. Returns count reaped.
+
+    Foreground sessions are excluded — they should never be auto-expired
+    (the user might resume).  This matches the policy in
+    ``SessionManager.cleanup_stale()``.
+    """
     cursor = await db.execute(
         """UPDATE cc_sessions SET status = 'completed'
-           WHERE status = 'active' AND last_activity_at < ?""",
+           WHERE status = 'active'
+             AND session_type != 'foreground'
+             AND last_activity_at < ?""",
         (older_than,),
     )
     await db.commit()

--- a/src/genesis/db/crud/cc_sessions.py
+++ b/src/genesis/db/crud/cc_sessions.py
@@ -113,9 +113,16 @@ async def query_stale(
     *,
     older_than: str,
 ) -> list[dict]:
+    """Return active non-foreground sessions older than *older_than*.
+
+    Foreground sessions are excluded at the SQL level — they should never
+    be auto-expired (the user might resume).
+    """
     cursor = await db.execute(
         """SELECT * FROM cc_sessions
-           WHERE status = 'active' AND last_activity_at < ?
+           WHERE status = 'active'
+             AND session_type != 'foreground'
+             AND last_activity_at < ?
            ORDER BY last_activity_at ASC""",
         (older_than,),
     )

--- a/tests/test_db/test_cc_sessions.py
+++ b/tests/test_db/test_cc_sessions.py
@@ -67,11 +67,51 @@ async def test_query_active(db, sess_fields):
 
 
 async def test_query_stale(db, sess_fields):
+    # Background sessions should appear in stale results
     await cc_sessions.create(
-        db, **{**sess_fields, "last_activity_at": "2026-03-07T06:00:00"},
+        db,
+        **{**sess_fields, "session_type": "background_task",
+           "last_activity_at": "2026-03-07T06:00:00"},
     )
     rows = await cc_sessions.query_stale(db, older_than="2026-03-07T07:00:00")
     assert len(rows) == 1
+
+
+async def test_query_stale_excludes_foreground(db, sess_fields):
+    """Foreground sessions must never appear in stale query results."""
+    await cc_sessions.create(
+        db,
+        **{**sess_fields, "session_type": "foreground",
+           "last_activity_at": "2026-03-07T06:00:00"},
+    )
+    rows = await cc_sessions.query_stale(db, older_than="2026-03-07T07:00:00")
+    assert len(rows) == 0
+
+
+async def test_reap_stale_excludes_foreground(db, sess_fields):
+    """reap_stale must never mark foreground sessions as completed."""
+    await cc_sessions.create(
+        db,
+        **{**sess_fields, "session_type": "foreground",
+           "last_activity_at": "2026-03-07T06:00:00"},
+    )
+    reaped = await cc_sessions.reap_stale(db, older_than="2026-03-07T07:00:00")
+    assert reaped == 0
+    row = await cc_sessions.get_by_id(db, "sess-1")
+    assert row["status"] == "active"  # Still active, not reaped
+
+
+async def test_reap_stale_expires_background(db, sess_fields):
+    """reap_stale should expire stale background sessions."""
+    await cc_sessions.create(
+        db,
+        **{**sess_fields, "session_type": "background_task",
+           "last_activity_at": "2026-03-07T06:00:00"},
+    )
+    reaped = await cc_sessions.reap_stale(db, older_than="2026-03-07T07:00:00")
+    assert reaped == 1
+    row = await cc_sessions.get_by_id(db, "sess-1")
+    assert row["status"] == "completed"
 
 
 async def test_delete(db, sess_fields):


### PR DESCRIPTION
## Summary

- **Wrap non-critical DB writes** in `conversation.py` (`update_cc_session_id`, `update_activity`) with try/except in both `handle_message` and `handle_message_streaming` — DB lock errors no longer lose successful CC responses
- **Fix `reap_stale()` foreground protection** — add `session_type != 'foreground'` guard matching `cleanup_stale()` policy (latent bug: foreground sessions could be incorrectly expired)
- **Protect `query.answer()` in callback handler** — stale callbacks after polling restarts no longer abort approval resolution
- **Register global PTB error handler** — unhandled handler exceptions now log at ERROR instead of being silently dropped
- **Promote approval edit failure logs** from DEBUG to WARNING for monitoring visibility
- **Fix bare approval error fallthrough** — errors now show feedback and consume the message instead of sending "approve" to the LLM

## Evidence

From 2026-05-27 22:11 UTC logs:
- 65 DB lock errors in one window
- `update_activity()` DB lock crashed response delivery, losing 624 chars of successful CC output
- 8 consecutive `BadRequest: Query is too old` crashes in callback handler
- 182 polling stalls triggering stale callback replay

## Test plan

- [x] `ruff check` — all 4 files clean
- [x] `pytest tests/test_channels/test_telegram_handlers_v2.py` — 47 passed
- [x] `pytest tests/test_channels/test_transport.py` — 44 passed
- [x] `pytest tests/ -k cc_session` — 24 passed
- [ ] Restart server → send message via Telegram → confirm response delivered
- [ ] Click approval button → confirm no spinner hang
- [ ] Check logs for WARNING-level approval edit entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)