### PR TITLE
feat(ego): migrate reactive + escalation to signal consumer (PR 4)

### DIFF
--- a/scripts/hooks/worktree_cwd_guard.py
+++ b/scripts/hooks/worktree_cwd_guard.py
@@ -18,7 +18,6 @@ import os
 import re
 import sys
 
-
 # Matches 'git worktree remove' with optional flags
 _WORKTREE_REMOVE = re.compile(
     r"\bgit\s+worktree\s+remove\b"

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -3,6 +3,11 @@
 Owns an APScheduler with two jobs:
 1. IntervalTrigger for regular cycles (adaptive backoff)
 2. CronTrigger for the mandatory morning report
+
+All cycle types (proactive, morning report, reactive, escalation) flow
+through the unified signal consumer loop: signal sources push EgoSignal
+objects to the SignalQueue, and _signal_consumer_loop() drains + runs
+run_unified_cycle().
 """
 
 from __future__ import annotations
@@ -45,6 +50,18 @@ _RECENCY_TIERS: list[tuple[timedelta | None, int]] = [
 ]
 
 
+def _map_priority(severity_or_priority: str) -> str:
+    """Map event severity/priority strings to signal priority levels."""
+    s = severity_or_priority.lower()
+    if s in ("critical",):
+        return "critical"
+    if s in ("error", "high"):
+        return "high"
+    if s in ("warning", "medium"):
+        return "medium"
+    return "low"
+
+
 class EgoCadenceManager:
     """Manages when the ego runs.
 
@@ -55,7 +72,8 @@ class EgoCadenceManager:
     - Circuit breaker (N consecutive failures -> pause)
     - Pause/resume controls
 
-    Does NOT own the EgoSession — just calls ``session.run_cycle()``.
+    All cycle dispatch goes through ``session.run_unified_cycle()`` via
+    the signal consumer loop.
     """
 
     def __init__(
@@ -93,22 +111,18 @@ class EgoCadenceManager:
         self._deep_think_interval = 5
         self._proactive_cycle_count = 0
 
-        # Unified signal queue: _on_tick() pushes here, consumer loop drains
+        # Unified signal queue: all signal sources push here, consumer loop drains.
+        # Proactive (_on_tick), morning report (_on_morning_report), reactive
+        # (push_reactive_event), and escalation (push_escalation_event) all
+        # converge on this queue.
         self._signal_queue = SignalQueue()
         self._signal_consumer_task: asyncio.Task | None = None
 
-        # Reactive event queue: events push here, debounce loop drains
-        self._reactive_queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=100)
-        self._reactive_task: asyncio.Task | None = None
-        self._reactive_debounce_s = 300  # 5 minutes
+        # Reactive rate limiting: max N reactive-focused cycles per hour.
+        # Checked at the consumer (not at push time) to preserve batch semantics —
+        # a burst of events batches into one cycle consuming one rate-limit slot.
         self._reactive_max_per_hour = 3
         self._reactive_timestamps: list[datetime] = []
-
-        # Reactive dedup: skip events with same summary within window.
-        # Prevents the same deadline or observation from re-triggering
-        # a reactive cycle every 30 min (sweep interval).
-        self._reactive_seen: dict[str, datetime] = {}
-        self._reactive_dedup_hours = 6
 
     # -- Lifecycle ---------------------------------------------------------
 
@@ -146,12 +160,6 @@ class EgoCadenceManager:
         self._scheduler.start()
         from genesis.util.tasks import tracked_task
 
-        self._reactive_task = tracked_task(
-            self._reactive_loop(),
-            name=f"ego_reactive_{id(self)}",
-            event_bus=self._event_bus,
-            logger=logger,
-        )
         self._signal_consumer_task = tracked_task(
             self._signal_consumer_loop(),
             name=f"ego_signal_consumer_{id(self)}",
@@ -173,18 +181,17 @@ class EgoCadenceManager:
         )
 
     async def stop(self) -> None:
-        """Shut down APScheduler, reactive loop, and signal consumer.
+        """Shut down APScheduler and signal consumer.
 
         Awaits task cancellation so any held lock is released before
         stop() returns — prevents deadlock if caller re-acquires the lock.
         """
-        for attr in ("_reactive_task", "_signal_consumer_task"):
-            task = getattr(self, attr, None)
-            if task is not None:
-                task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
-                setattr(self, attr, None)
+        task = self._signal_consumer_task
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            self._signal_consumer_task = None
         if self._scheduler.running:
             self._scheduler.shutdown(wait=False)
         self._running = False
@@ -216,117 +223,62 @@ class EgoCadenceManager:
     def consecutive_failures(self) -> int:
         return self._consecutive_failures
 
-    # -- Reactive event queue -----------------------------------------------
+    # -- Reactive / escalation signal emitters --------------------------------
 
     def push_reactive_event(self, event: dict) -> None:
         """Push an event that may trigger a reactive ego cycle.
 
-        Events are debounced: the reactive loop waits 5 minutes after the
-        first event before running a cycle (batching concurrent events).
-        Rate-limited to 3 reactive cycles per hour.
-        Content-deduped: same summary within 6h window is skipped.
+        Creates an EgoSignal and pushes to the unified signal queue.
+        Content dedup is handled by SignalQueue (6h window on
+        ``reactive:{summary}``). Rate limiting happens at the consumer
+        (``_process_signals``) to preserve batch semantics.
 
         event keys: {"type": str, "summary": str, "priority": str?, "source": str?}
         """
         if not self._running or self._paused:
             return
 
-        # Content dedup: skip if same summary seen recently
-        summary = event.get("summary", "")[:100]
-        now = datetime.now(UTC)
-        if summary in self._reactive_seen:
-            age = (now - self._reactive_seen[summary]).total_seconds()
-            if age < self._reactive_dedup_hours * 3600:
-                logger.debug("Reactive event deduped (%.0fm old): %s", age / 60, summary[:50])
-                return
+        signal = EgoSignal(
+            signal_type="event",
+            focus_category="reactive",
+            summary=event.get("summary", "")[:200],
+            priority=_map_priority(event.get("priority", "high")),
+            metadata={
+                "model_override": "opus",
+                "effort_override": "high",
+                "event_type": event.get("type"),
+                "source": event.get("source"),
+            },
+        )
+        if self._signal_queue.push(signal):
+            logger.debug("Reactive signal pushed: %s", event.get("type", "?"))
 
-        # Prune old entries (keep dict bounded)
-        cutoff = now - timedelta(hours=self._reactive_dedup_hours)
-        self._reactive_seen = {
-            k: v for k, v in self._reactive_seen.items() if v > cutoff
-        }
-        self._reactive_seen[summary] = now
+    def push_escalation_event(self, event: dict) -> None:
+        """Push a critical event as an escalation signal.
 
-        try:
-            self._reactive_queue.put_nowait(event)
-            logger.debug("Reactive event queued: %s", event.get("type", "?"))
-        except asyncio.QueueFull:
-            logger.warning("Reactive queue full — dropping event")
+        Escalation signals get ``focus_category="escalation"`` which
+        selects escalation-specific context weights and prompt directive.
+        No rate limit — escalation signals are critical and rare.
 
-    async def _reactive_loop(self) -> None:
-        """Background task: drain reactive queue with debounce, run cycle."""
-        while True:
-            try:
-                # Block until first event arrives
-                first_event = await self._reactive_queue.get()
-                events = [first_event]
+        event keys: {"type": str, "summary": str, "priority": str?, "source": str?}
+        """
+        if not self._running or self._paused:
+            return
 
-                # Debounce: wait, then drain anything that arrived meanwhile
-                await asyncio.sleep(self._reactive_debounce_s)
-                while not self._reactive_queue.empty():
-                    try:
-                        events.append(self._reactive_queue.get_nowait())
-                    except asyncio.QueueEmpty:
-                        break
-
-                # Rate limit: max N reactive cycles per hour
-                now = datetime.now(UTC)
-                cutoff = now - timedelta(hours=1)
-                self._reactive_timestamps = [
-                    ts for ts in self._reactive_timestamps if ts > cutoff
-                ]
-                if len(self._reactive_timestamps) >= self._reactive_max_per_hour:
-                    logger.info(
-                        "Reactive rate limit: %d/%d in last hour, skipping %d event(s)",
-                        len(self._reactive_timestamps),
-                        self._reactive_max_per_hour,
-                        len(events),
-                    )
-                    continue
-
-                # Run reactive cycle
-                event_summary = "; ".join(
-                    e.get("summary", e.get("type", "?"))[:80] for e in events[:5]
-                )
-                logger.info(
-                    "Reactive cycle triggered by %d event(s): %s",
-                    len(events),
-                    event_summary,
-                )
-
-                async with self._lock:
-                    if not self._should_run(skip_idle_check=True):
-                        continue
-
-                    try:
-                        from genesis.ego.types import CycleType
-
-                        cycle = await self._session.run_cycle(
-                            cycle_type=CycleType.REACTIVE,
-                        )
-                    except CycleBlockedError as exc:
-                        logger.info("Reactive cycle gated: %s", exc)
-                        continue
-                    except Exception:
-                        logger.error("Reactive cycle failed", exc_info=True)
-                        self._record_failure("reactive cycle failed")
-                        continue
-
-                    if cycle is not None:
-                        self._record_success()
-                        self._reactive_timestamps.append(datetime.now(UTC))
-                        logger.info(
-                            "Reactive cycle %s completed (cost=$%.4f)",
-                            cycle.id,
-                            cycle.cost_usd,
-                        )
-
-            except asyncio.CancelledError:
-                logger.debug("Reactive loop cancelled")
-                return
-            except Exception:
-                logger.error("Reactive loop error", exc_info=True)
-                await asyncio.sleep(60)  # Back off on unexpected errors
+        signal = EgoSignal(
+            signal_type="event",
+            focus_category="escalation",
+            summary=event.get("summary", "")[:200],
+            priority="critical",
+            metadata={
+                "model_override": "sonnet",
+                "effort_override": "medium",
+                "event_type": event.get("type"),
+                "source": event.get("source"),
+            },
+        )
+        if self._signal_queue.push(signal):
+            logger.info("Escalation signal pushed: %s", event.get("type", "?"))
 
     # -- Sweep helpers -----------------------------------------------------
 
@@ -433,13 +385,45 @@ class EgoCadenceManager:
 
         Separated from the consumer loop for testability — tests call
         this directly after pushing signals.
+
+        Reactive rate limiting happens here (not at push time) to preserve
+        batch semantics: a burst of events batches into one cycle consuming
+        one rate-limit slot.
         """
         signals = self._signal_queue.drain()
         if not signals:
             return
 
-        # Extract overrides from signal metadata (deep-think model, morning effort).
-        # Use `is None` checks (not falsy) so empty strings don't slip through.
+        # Reactive rate limit: max N reactive-focused cycles per hour.
+        # If the batch contains reactive signals and the limit is hit,
+        # drop reactive signals but keep non-reactive ones (e.g., a
+        # proactive tick that landed in the same batch window).
+        has_reactive = any(s.focus_category == "reactive" for s in signals)
+        if has_reactive:
+            now = datetime.now(UTC)
+            cutoff = now - timedelta(hours=1)
+            self._reactive_timestamps = [
+                ts for ts in self._reactive_timestamps if ts > cutoff
+            ]
+            if len(self._reactive_timestamps) >= self._reactive_max_per_hour:
+                non_reactive = [
+                    s for s in signals if s.focus_category != "reactive"
+                ]
+                if not non_reactive:
+                    logger.info(
+                        "Reactive rate limit: %d/%d in last hour, "
+                        "dropping %d signal(s)",
+                        len(self._reactive_timestamps),
+                        self._reactive_max_per_hour,
+                        len(signals),
+                    )
+                    return
+                signals = non_reactive
+                has_reactive = False
+
+        # Extract overrides from signal metadata (deep-think model, morning effort,
+        # reactive model/effort). Use `is None` checks (not falsy) so empty
+        # strings don't slip through.
         model_override = None
         effort_override = None
         for sig in signals:
@@ -498,6 +482,11 @@ class EgoCadenceManager:
                 return
 
             self._record_success()
+
+            # Record reactive timestamp for rate limiting
+            if has_reactive:
+                self._reactive_timestamps.append(datetime.now(UTC))
+
             # Morning report always resets interval to base (it's a
             # reporting event, not a proposal-productivity measurement).
             is_morning_report = any(
@@ -511,7 +500,8 @@ class EgoCadenceManager:
         """Background consumer for the unified signal queue.
 
         Blocks until signals arrive, brief batch window, then processes.
-        Same outer structure as _reactive_loop() for reliability.
+        All cycle types (proactive, morning, reactive, escalation) flow
+        through this single loop.
         """
         while True:
             try:

--- a/src/genesis/runtime/init/ego.py
+++ b/src/genesis/runtime/init/ego.py
@@ -328,7 +328,7 @@ async def init(rt: GenesisRuntime) -> None:
             logger.info("Ego dispatch outcome hook registered")
 
         # ================================================================
-        # REACTIVE EVENT WIRING — EventBus → ego reactive queue
+        # EVENT SIGNAL WIRING — EventBus → ego signal queue
         # ================================================================
         if rt._event_bus is not None:
             from genesis.observability.types import Severity
@@ -345,14 +345,18 @@ async def init(rt: GenesisRuntime) -> None:
             })
 
             async def _on_high_severity_event(event) -> None:
-                """Route high-severity events to the appropriate ego's reactive queue."""
+                """Route high-severity events to the appropriate ego's signal queue.
+
+                WARNING/ERROR → reactive signal (push_reactive_event)
+                CRITICAL → escalation signal (push_escalation_event)
+                """
                 # Only react to WARNING+ events with actionable types
                 if event.event_type in ("heartbeat", "metric"):
                     return
 
                 subsystem = str(getattr(event, "subsystem", ""))
 
-                reactive_event = {
+                event_dict = {
                     "type": event.event_type,
                     "summary": str(event.message)[:200],
                     "priority": event.severity.name if hasattr(event, "severity") else "high",
@@ -361,19 +365,29 @@ async def init(rt: GenesisRuntime) -> None:
 
                 # Route by subsystem (reliable field on every event)
                 if subsystem in _USER_SUBSYSTEMS:
-                    user_ego_cadence.push_reactive_event(reactive_event)
+                    target = user_ego_cadence
                 elif subsystem in _SYSTEM_SUBSYSTEMS:
-                    genesis_ego_cadence.push_reactive_event(reactive_event)
+                    target = genesis_ego_cadence
                 else:
                     # ego, perception, memory, etc. — route to Genesis ego
                     # (system-internal concerns)
-                    genesis_ego_cadence.push_reactive_event(reactive_event)
+                    target = genesis_ego_cadence
+
+                # CRITICAL → escalation signal, WARNING/ERROR → reactive signal
+                is_critical = (
+                    hasattr(event, "severity")
+                    and event.severity.name == "CRITICAL"
+                )
+                if is_critical:
+                    target.push_escalation_event(event_dict)
+                else:
+                    target.push_reactive_event(event_dict)
 
             rt._event_bus.subscribe(
                 _on_high_severity_event,
                 min_severity=Severity.WARNING,
             )
-            logger.info("Ego reactive event subscriber registered")
+            logger.info("Ego event signal subscriber registered")
 
     except ImportError:
         logger.warning("genesis.ego not available")

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -632,3 +632,236 @@ class TestRecencyTiersConstant:
             _, max_a = _RECENCY_TIERS[i]
             _, max_b = _RECENCY_TIERS[i + 1]
             assert max_b > max_a
+
+
+# ---------------------------------------------------------------------------
+# Reactive signals — push_reactive_event → signal queue → unified cycle
+# ---------------------------------------------------------------------------
+
+
+class TestReactiveSignals:
+    def test_push_reactive_creates_signal(self, cadence):
+        """push_reactive_event creates an EgoSignal in the signal queue."""
+        cadence._running = True
+        cadence.push_reactive_event({
+            "type": "breaker.tripped",
+            "summary": "Provider X circuit breaker tripped",
+            "priority": "high",
+            "source": "routing",
+        })
+        assert not cadence._signal_queue.empty()
+        signals = cadence._signal_queue.drain()
+        assert len(signals) == 1
+        sig = signals[0]
+        assert sig.signal_type == "event"
+        assert sig.focus_category == "reactive"
+        assert "Provider X" in sig.summary
+        assert sig.metadata["model_override"] == "opus"
+        assert sig.metadata["effort_override"] == "high"
+        assert sig.metadata["event_type"] == "breaker.tripped"
+        assert sig.metadata["source"] == "routing"
+
+    def test_push_reactive_dedup_via_signal_queue(self, cadence):
+        """Same summary rejected by SignalQueue's 6h dedup."""
+        cadence._running = True
+        event = {
+            "type": "test",
+            "summary": "Same event summary",
+            "priority": "high",
+        }
+        cadence.push_reactive_event(event)
+        cadence.push_reactive_event(event)  # Should be deduped
+        signals = cadence._signal_queue.drain()
+        assert len(signals) == 1
+
+    def test_push_reactive_skips_when_paused(self, cadence):
+        """No signal pushed when paused."""
+        cadence._running = True
+        cadence.pause()
+        cadence.push_reactive_event({"type": "test", "summary": "x"})
+        assert cadence._signal_queue.empty()
+
+    def test_push_reactive_skips_when_not_running(self, cadence):
+        """No signal pushed when not running."""
+        cadence._running = False
+        cadence.push_reactive_event({"type": "test", "summary": "x"})
+        assert cadence._signal_queue.empty()
+
+    def test_push_reactive_model_override_is_opus(self, cadence):
+        """Reactive signals carry opus/high to match CYCLE_TYPE_DEFAULTS[REACTIVE]."""
+        cadence._running = True
+        cadence.push_reactive_event({"type": "test", "summary": "alert"})
+        signals = cadence._signal_queue.drain()
+        assert signals[0].metadata["model_override"] == "opus"
+        assert signals[0].metadata["effort_override"] == "high"
+
+    async def test_reactive_flows_through_unified_cycle(
+        self, cadence, mock_session,
+    ):
+        """push_reactive_event + _process_signals → run_unified_cycle."""
+        cadence._running = True
+        cadence.push_reactive_event({
+            "type": "health.degraded",
+            "summary": "System health degraded",
+            "priority": "high",
+        })
+        await cadence._process_signals()
+        mock_session.run_unified_cycle.assert_called_once()
+        call_args = mock_session.run_unified_cycle.call_args
+        signals = call_args[0][0]
+        assert len(signals) == 1
+        assert signals[0].focus_category == "reactive"
+        assert call_args[1]["model_override"] == "opus"
+        assert call_args[1]["effort_override"] == "high"
+
+    async def test_reactive_rate_limit_at_consumer(
+        self, cadence, mock_session,
+    ):
+        """Consumer drops reactive signals when rate limit (3/hour) is hit."""
+        cadence._running = True
+        # Simulate 3 prior reactive cycles this hour
+        now = datetime.now(UTC)
+        cadence._reactive_timestamps = [
+            now - timedelta(minutes=10),
+            now - timedelta(minutes=20),
+            now - timedelta(minutes=30),
+        ]
+        cadence.push_reactive_event({
+            "type": "test",
+            "summary": "4th event this hour",
+            "priority": "high",
+        })
+        await cadence._process_signals()
+        mock_session.run_unified_cycle.assert_not_called()
+
+    async def test_reactive_rate_limit_preserves_non_reactive(
+        self, cadence, mock_session,
+    ):
+        """Non-reactive signals survive when reactive rate limit is hit."""
+        cadence._running = True
+        # Saturate reactive rate limit
+        now = datetime.now(UTC)
+        cadence._reactive_timestamps = [
+            now - timedelta(minutes=10),
+            now - timedelta(minutes=20),
+            now - timedelta(minutes=30),
+        ]
+        # Push a reactive signal AND a proactive signal
+        from genesis.ego.signals import EgoSignal
+
+        cadence._signal_queue.push(EgoSignal(
+            signal_type="event",
+            focus_category="reactive",
+            summary="reactive event",
+            priority="high",
+        ))
+        cadence._signal_queue.push(EgoSignal(
+            signal_type="timer",
+            focus_category="proactive",
+            summary="proactive tick",
+            priority="medium",
+        ))
+        await cadence._process_signals()
+        # Should still run with the proactive signal
+        mock_session.run_unified_cycle.assert_called_once()
+        call_args = mock_session.run_unified_cycle.call_args
+        signals = call_args[0][0]
+        assert len(signals) == 1
+        assert signals[0].focus_category == "proactive"
+
+    async def test_reactive_records_timestamp_on_success(
+        self, cadence, mock_session,
+    ):
+        """Successful reactive cycle records a timestamp for rate limiting."""
+        cadence._running = True
+        assert len(cadence._reactive_timestamps) == 0
+        cadence.push_reactive_event({
+            "type": "test",
+            "summary": "alert event",
+            "priority": "high",
+        })
+        await cadence._process_signals()
+        assert len(cadence._reactive_timestamps) == 1
+
+    def test_push_reactive_priority_mapping(self, cadence):
+        """Event priority strings map to signal priority levels."""
+        from genesis.ego.cadence import _map_priority
+
+        assert _map_priority("CRITICAL") == "critical"
+        assert _map_priority("ERROR") == "high"
+        assert _map_priority("WARNING") == "medium"
+        assert _map_priority("high") == "high"
+        assert _map_priority("medium") == "medium"
+        assert _map_priority("low") == "low"
+        assert _map_priority("unknown") == "low"
+
+
+# ---------------------------------------------------------------------------
+# Escalation signals — push_escalation_event → signal queue → unified cycle
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationSignals:
+    def test_push_escalation_creates_signal(self, cadence):
+        """push_escalation_event creates a critical escalation signal."""
+        cadence._running = True
+        cadence.push_escalation_event({
+            "type": "health.critical",
+            "summary": "Database unreachable",
+            "priority": "CRITICAL",
+            "source": "health",
+        })
+        assert not cadence._signal_queue.empty()
+        signals = cadence._signal_queue.drain()
+        assert len(signals) == 1
+        sig = signals[0]
+        assert sig.signal_type == "event"
+        assert sig.focus_category == "escalation"
+        assert sig.priority == "critical"
+        assert sig.metadata["model_override"] == "sonnet"
+        assert sig.metadata["effort_override"] == "medium"
+
+    async def test_escalation_not_rate_limited(
+        self, cadence, mock_session,
+    ):
+        """Escalation signals are NOT subject to reactive rate limiting."""
+        cadence._running = True
+        # Saturate reactive rate limit
+        now = datetime.now(UTC)
+        cadence._reactive_timestamps = [
+            now - timedelta(minutes=10),
+            now - timedelta(minutes=20),
+            now - timedelta(minutes=30),
+        ]
+        cadence.push_escalation_event({
+            "type": "health.critical",
+            "summary": "Critical system failure",
+        })
+        await cadence._process_signals()
+        # Should still run — escalation is not reactive
+        mock_session.run_unified_cycle.assert_called_once()
+        call_args = mock_session.run_unified_cycle.call_args
+        signals = call_args[0][0]
+        assert signals[0].focus_category == "escalation"
+
+    def test_push_escalation_skips_when_paused(self, cadence):
+        """No signal pushed when paused."""
+        cadence._running = True
+        cadence.pause()
+        cadence.push_escalation_event({"type": "test", "summary": "x"})
+        assert cadence._signal_queue.empty()
+
+    async def test_escalation_flows_through_unified_cycle(
+        self, cadence, mock_session,
+    ):
+        """push_escalation_event + _process_signals → run_unified_cycle."""
+        cadence._running = True
+        cadence.push_escalation_event({
+            "type": "guardian.alert",
+            "summary": "Container OOM detected",
+        })
+        await cadence._process_signals()
+        mock_session.run_unified_cycle.assert_called_once()
+        call_args = mock_session.run_unified_cycle.call_args
+        assert call_args[1]["model_override"] == "sonnet"
+        assert call_args[1]["effort_override"] == "medium"

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -49,19 +49,9 @@ def config():
 
 @pytest.fixture
 def mock_session():
-    """Mock EgoSession with controllable run_cycle and run_unified_cycle."""
+    """Mock EgoSession with controllable run_unified_cycle."""
     session = AsyncMock()
-    # Legacy path (morning report, reactive loop)
-    session.run_cycle.return_value = EgoCycle(
-        id="c1",
-        output_text="test",
-        proposals_json=json.dumps([{"action_type": "test"}]),
-        focus_summary="testing",
-        model_used="opus",
-        cost_usd=0.15,
-        ego_source="user_ego_cycle",
-    )
-    # Unified path (proactive via signal consumer)
+    # All cycle types flow through run_unified_cycle via the signal consumer
     session.run_unified_cycle.return_value = EgoCycle(
         id="u1",
         output_text="unified test",
@@ -321,7 +311,6 @@ class TestMorningReport:
     ):
         cadence.pause()
         await cadence._on_morning_report()
-        mock_session.run_cycle.assert_not_called()
         assert cadence._signal_queue.empty()
 
     async def test_morning_report_pushes_daily_briefing_signal(
@@ -850,6 +839,28 @@ class TestEscalationSignals:
         cadence.pause()
         cadence.push_escalation_event({"type": "test", "summary": "x"})
         assert cadence._signal_queue.empty()
+
+    async def test_escalation_survives_reactive_rate_limit_in_mixed_batch(
+        self, cadence, mock_session,
+    ):
+        """Escalation survives reactive rate limit when batched with reactive signal."""
+        cadence._running = True
+        now = datetime.now(UTC)
+        cadence._reactive_timestamps = [
+            now - timedelta(minutes=10),
+            now - timedelta(minutes=20),
+            now - timedelta(minutes=30),
+        ]
+        # Push both reactive and escalation in the same batch
+        cadence.push_reactive_event({"type": "test", "summary": "rate limited reactive"})
+        cadence.push_escalation_event({"type": "health.critical", "summary": "critical failure"})
+        await cadence._process_signals()
+        # Escalation must survive; reactive must be dropped
+        mock_session.run_unified_cycle.assert_called_once()
+        call_args = mock_session.run_unified_cycle.call_args
+        signals = call_args[0][0]
+        assert len(signals) == 1
+        assert signals[0].focus_category == "escalation"
 
     async def test_escalation_flows_through_unified_cycle(
         self, cadence, mock_session,


### PR DESCRIPTION
## Summary
- Reactive events now flow through the unified signal consumer loop instead of the separate `_reactive_loop` background task
- New `push_escalation_event()` method routes CRITICAL-severity events through escalation focus category (sonnet/medium, escalation-specific context weights + prompt)
- Consumer-side rate limiting (3 reactive cycles/hour) preserves batch semantics — a burst of events batches into one cycle consuming one rate-limit slot
- Event bus subscriber splits CRITICAL → escalation, WARNING/ERROR → reactive
- Removed `_reactive_loop`, `_reactive_queue`, `_reactive_seen`, `_reactive_task` (~74 lines deleted)
- 15 new tests (reactive signals, escalation, rate limiting, priority mapping, mixed batch)

## Behavioral changes
- Reactive response time: ~5min → ~2s (debounce removed; dedup + rate limit sufficient)
- Reactive cycles now influence adaptive backoff (correct: productivity should feed scheduling)
- CRITICAL events get dedicated escalation focus (different context weights + prompt directive)

## Files changed
- `src/genesis/ego/cadence.py` — core migration
- `src/genesis/runtime/init/ego.py` — event bus severity routing
- `tests/ego/test_cadence.py` — 15 new tests, fixture cleanup

## Test plan
- [x] 566 ego tests pass (baseline was 565, +1 from new mixed batch test)
- [x] Lint clean (`ruff check`)
- [x] No stale references to `_reactive_loop`, `_reactive_queue`, `_reactive_seen`
- [x] No `run_cycle(REACTIVE)` calls remain in cadence.py
- [x] Code review completed — 2 findings fixed (stale mock, mixed batch test)

## Ego v2 roadmap
- [x] PR 1: Signal system + focus selector (#420)
- [x] PR 2: Proactive → signal consumer (#466)
- [x] PR 3: Morning report + context weights (#467)
- [x] **PR 4: Reactive + escalation → signals (this PR)**
- [ ] PR 5: Remove CycleType, old `run_cycle()`
- [ ] PR 6: Goal-driven behavior
- [ ] PR 7: Goal decomposition

🤖 Generated with [Claude Code](https://claude.com/claude-code)