### PR TITLE
fix(telegram): wire proposal_workflow into standalone adapter

### DIFF
--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -493,6 +493,7 @@ class StandaloneAdapter:
                 reply_waiter=reply_waiter,
                 engagement_tracker=rt.engagement_tracker,
                 autonomous_cli_gate=autonomous_cli_gate,
+                proposal_workflow=rt._ego_proposal_workflow,
             )
             self._telegram_adapter = adapter
 


### PR DESCRIPTION
## Summary

- Add missing `proposal_workflow=rt._ego_proposal_workflow` parameter to the standalone server's Telegram adapter constructor
- This is a one-line fix for a copy-paste divergence between `bridge.py` (which had it) and `standalone.py` (which didn't)

## Root cause

`standalone.py:486-496` constructed the adapter without `proposal_workflow`, causing `ctx.proposal_workflow` to be `None` in all Telegram handlers. Ego proposal resolution from quote-replies was silently disabled — messages fell through to the CC conversation handler instead.

## Evidence

- Diagnostic log confirmed: `Proposal resolution skipped: workflow=False db=True`
- After fix: `Proposal a82cdfd1007043ee → approved` + `Proposal batch resolved for delivery 3346`
- Live-tested: user sent "ok" quote-reply to proposal, got "✅ Resolved: 1 approved"

## Test plan

- [x] `ruff check` — clean
- [x] Live verification: quote-reply "ok" to proposal → resolved correctly
- [x] Server restart → healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)