### PR TITLE
fix(inbox): cumulative baseline guard prevents re-evaluation of cleared files

### DIFF
--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -504,12 +504,16 @@ class InboxMonitor:
                     processed_at=now_iso,
                 )
                 continue
+            # source_content = re-read at resume time, not original
+            # detection.  Safe: hash guard above ensures file is unchanged
+            # since it was parked for approval.
             resume_items.append(InboxItem(
                 id=row_id,
                 file_path=file_path,
                 content=content,
                 content_hash=stored_hash,
                 detected_at=str(row["created_at"]),
+                source_content=content,
             ))
 
         resumed_ids: set[str] = {item.id for item in resume_items}
@@ -746,6 +750,7 @@ class InboxMonitor:
                 pending_items.append(InboxItem(
                     id=existing_failed["id"], file_path=str(f),
                     content=content, content_hash=h, detected_at=now_iso,
+                    source_content=content,
                 ))
                 continue
 
@@ -760,6 +765,7 @@ class InboxMonitor:
             pending_items.append(InboxItem(
                 id=item_id, file_path=str(f), content=content,
                 content_hash=h, detected_at=now_iso,
+                source_content=content,
             ))
 
         cooldown = timedelta(seconds=self._config.evaluation_cooldown_seconds)
@@ -844,6 +850,7 @@ class InboxMonitor:
             pending_items.append(InboxItem(
                 id=item_id, file_path=str(f), content=eval_content,
                 content_hash=h, detected_at=now_iso,
+                source_content=content,
             ))
 
         return pending_items
@@ -1058,12 +1065,44 @@ class InboxMonitor:
                 )
                 completed_at = self._clock().isoformat()
                 for item in batch:
+                    source = item.source_content or item.content
+                    prev = await inbox_items.get_evaluated_content(
+                        self._db, item.file_path,
+                    )
+                    full_content = _merge_evaluated_content(prev, source)
+                    # Diagnostic: detect file changes during evaluation
                     try:
-                        full_content = read_content(Path(item.file_path))
+                        current_content = read_content(Path(item.file_path))
                     except (FileNotFoundError, PermissionError):
-                        full_content = item.content
-                    if not full_content.strip():
-                        full_content = item.content
+                        current_content = None
+                    if current_content is not None and current_content != source:
+                        logger.warning(
+                            "BASELINE_GUARD: file changed during eval "
+                            "for %s (detection=%d chars, completion=%d "
+                            "chars, merge_baseline=%d chars)",
+                            item.file_path,
+                            len(source), len(current_content),
+                            len(full_content),
+                        )
+                        if self._event_bus:
+                            try:
+                                from genesis.observability.types import (
+                                    Severity,
+                                    Subsystem,
+                                )
+                                await self._event_bus.emit(
+                                    Subsystem.INBOX, Severity.WARNING,
+                                    "baseline_guard.file_changed",
+                                    f"File changed during evaluation: "
+                                    f"detection={len(source)}, "
+                                    f"completion={len(current_content)}",
+                                    file_path=item.file_path,
+                                )
+                            except Exception:
+                                logger.debug(
+                                    "BASELINE_GUARD event emit failed",
+                                    exc_info=True,
+                                )
                     await inbox_items.update_status(
                         self._db, item.id, status="completed",
                         processed_at=completed_at,
@@ -1151,12 +1190,47 @@ class InboxMonitor:
                         processed_at=completed_at,
                     )
                 else:
+                    source = item.source_content or item.content
+                    prev = await inbox_items.get_evaluated_content(
+                        self._db, item.file_path,
+                    )
+                    full_content = _merge_evaluated_content(prev, source)
+                    # Diagnostic: detect file changes during evaluation
                     try:
-                        full_content = read_content(Path(item.file_path))
+                        current_content = read_content(
+                            Path(item.file_path),
+                        )
                     except (FileNotFoundError, PermissionError):
-                        full_content = item.content
-                    if not full_content.strip():
-                        full_content = item.content
+                        current_content = None
+                    if (current_content is not None
+                            and current_content != source):
+                        logger.warning(
+                            "BASELINE_GUARD: file changed during eval "
+                            "for %s (detection=%d chars, completion=%d "
+                            "chars, merge_baseline=%d chars)",
+                            item.file_path,
+                            len(source), len(current_content),
+                            len(full_content),
+                        )
+                        if self._event_bus:
+                            try:
+                                from genesis.observability.types import (
+                                    Severity,
+                                    Subsystem,
+                                )
+                                await self._event_bus.emit(
+                                    Subsystem.INBOX, Severity.WARNING,
+                                    "baseline_guard.file_changed",
+                                    f"File changed during evaluation: "
+                                    f"detection={len(source)}, "
+                                    f"completion={len(current_content)}",
+                                    file_path=item.file_path,
+                                )
+                            except Exception:
+                                logger.debug(
+                                    "BASELINE_GUARD event emit failed",
+                                    exc_info=True,
+                                )
                     if response_path:
                         await inbox_items.set_response_path(
                             self._db, item.id,
@@ -1334,3 +1408,25 @@ def _compute_new_content(old_content: str, new_content: str) -> str:
     while result and not result[-1].strip():
         result.pop()
     return "\n".join(result)
+
+
+def _merge_evaluated_content(
+    prev_content: str | None, source_content: str,
+) -> str:
+    """Merge previous baseline with detection-time content.
+
+    Returns the union of all non-empty stripped lines from both inputs,
+    sorted for deterministic output.  This makes ``evaluated_content``
+    monotonically grow — once a line has been evaluated it stays in the
+    baseline forever, preventing re-evaluation even if the source file
+    is cleared and refilled by sync (e.g. rclone from Dropbox).
+    """
+    lines: set[str] = set()
+    if prev_content:
+        lines.update(
+            line.strip() for line in prev_content.splitlines() if line.strip()
+        )
+    lines.update(
+        line.strip() for line in source_content.splitlines() if line.strip()
+    )
+    return "\n".join(sorted(lines))

--- a/src/genesis/inbox/types.py
+++ b/src/genesis/inbox/types.py
@@ -54,6 +54,16 @@ class InboxItem:
     content: str
     content_hash: str
     detected_at: str
+    source_content: str = ""
+    """Full file content at detection time.
+
+    For new files this equals ``content``.  For modified files
+    ``content`` holds only the delta while ``source_content``
+    preserves the complete file snapshot captured during Phase 3.
+    Used at completion to build a cumulative evaluated-content
+    baseline that survives mid-evaluation file changes (e.g. rclone
+    sync clearing the source while a CC session is running).
+    """
 
 
 @dataclass(frozen=True)

--- a/tests/test_inbox/test_monitor.py
+++ b/tests/test_inbox/test_monitor.py
@@ -1451,3 +1451,166 @@ def test_coherence_check_passes_with_domain_stem_fallback():
     evaluation = "# Inbox Evaluation\n\n**Classification:** Technology\n\nLangChain's new feature " + "x" * 300
     source = "https://www.langchain.com/blog/something"
     assert _passes_coherence_check(evaluation, source) is True
+
+
+# ── Baseline guard tests ──────────────────────────────────────────────
+
+
+class TestMergeEvaluatedContent:
+    """Unit tests for _merge_evaluated_content."""
+
+    def test_empty_prev_returns_source_lines(self):
+        from genesis.inbox.monitor import _merge_evaluated_content
+        result = _merge_evaluated_content(None, "alpha\nbeta\n")
+        lines = result.splitlines()
+        assert "alpha" in lines
+        assert "beta" in lines
+
+    def test_empty_source_returns_prev_lines(self):
+        from genesis.inbox.monitor import _merge_evaluated_content
+        result = _merge_evaluated_content("alpha\nbeta\n", "")
+        lines = result.splitlines()
+        assert "alpha" in lines
+        assert "beta" in lines
+
+    def test_union_of_both(self):
+        from genesis.inbox.monitor import _merge_evaluated_content
+        result = _merge_evaluated_content("alpha\nbeta", "beta\ngamma")
+        lines = set(result.splitlines())
+        assert lines == {"alpha", "beta", "gamma"}
+
+    def test_deduplicates_stripped(self):
+        from genesis.inbox.monitor import _merge_evaluated_content
+        result = _merge_evaluated_content("  alpha  \nbeta", "alpha\n  beta  ")
+        lines = result.splitlines()
+        assert lines.count("alpha") == 1
+        assert lines.count("beta") == 1
+
+    def test_blank_lines_excluded(self):
+        from genesis.inbox.monitor import _merge_evaluated_content
+        result = _merge_evaluated_content("\n\nalpha\n\n", "\n\nbeta\n\n")
+        assert "" not in result.splitlines()
+
+    def test_sorted_output(self):
+        from genesis.inbox.monitor import _merge_evaluated_content
+        result = _merge_evaluated_content("gamma\nalpha", "beta")
+        assert result.splitlines() == ["alpha", "beta", "gamma"]
+
+    def test_both_none_and_empty(self):
+        from genesis.inbox.monitor import _merge_evaluated_content
+        result = _merge_evaluated_content(None, "")
+        assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_baseline_guard_survives_file_clear(
+    db, mock_invoker, mock_session_manager, inbox_dir, tmp_path,
+):
+    """evaluated_content preserves detection-time content even if the file
+    is cleared during evaluation (the race condition that caused Genesis-19
+    through Genesis-26 to re-evaluate the same items)."""
+    from genesis.db.crud import inbox_items
+
+    clock = _FakeClock()
+    config = InboxConfig(watch_path=inbox_dir, batch_size=1)
+    writer = ResponseWriter(watch_path=inbox_dir, timezone="UTC")
+    mon = InboxMonitor(
+        db=db, invoker=mock_invoker, session_manager=mock_session_manager,
+        config=config, writer=writer, clock=clock, prompt_dir=tmp_path,
+    )
+
+    original_content = (
+        "Numenta\n\n"
+        "https://example.com/article-1\n\n"
+        "https://example.com/article-2\n"
+    )
+
+    mock_invoker.run.return_value = _success_output(
+        "# Inbox Evaluation\n\n## 1. Numenta\nGood stuff.\n\n"
+        "## 2. example.com/article-1\nInteresting.\n\n"
+        "## 3. example.com/article-2\nNoted.\n" + "x" * 300
+    )
+
+    # Write file and do first evaluation
+    (inbox_dir / "Genesis.md").write_text(original_content)
+    result = await mon.check_once()
+    assert result.batches_dispatched == 1
+
+    # Verify evaluated_content was stored
+    row = await inbox_items.get_by_file_path(
+        db, str(inbox_dir / "Genesis.md"),
+    )
+    assert row is not None
+    stored = row["evaluated_content"]
+    assert stored is not None
+    # All original lines should be in the merged baseline
+    assert "Numenta" in stored
+    assert "https://example.com/article-1" in stored
+    assert "https://example.com/article-2" in stored
+
+    # Simulate: file is cleared by sync during NEXT evaluation
+    # First, advance clock past cooldown
+    clock.now += timedelta(hours=2)
+
+    # Write file with only new content (simulates user clearing old items)
+    (inbox_dir / "Genesis.md").write_text("https://example.com/article-3\n")
+
+    result2 = await mon.check_once()
+    assert result2.batches_dispatched == 1
+
+    # Verify: evaluated_content now has BOTH old and new lines
+    row2 = await inbox_items.get_by_file_path(
+        db, str(inbox_dir / "Genesis.md"),
+    )
+    stored2 = row2["evaluated_content"]
+    assert "Numenta" in stored2, "Old content lost from baseline"
+    assert "https://example.com/article-1" in stored2, "Old URL lost"
+    assert "https://example.com/article-2" in stored2, "Old URL lost"
+    assert "https://example.com/article-3" in stored2, "New URL missing"
+
+
+@pytest.mark.asyncio
+async def test_baseline_guard_delta_only_new_items(
+    db, mock_invoker, mock_session_manager, inbox_dir, tmp_path,
+):
+    """After a successful evaluation, adding new items to the file should
+    produce a delta containing ONLY the new items, not previously evaluated ones."""
+    from genesis.db.crud import inbox_items
+    from genesis.inbox.monitor import _compute_new_content
+
+    clock = _FakeClock()
+    config = InboxConfig(watch_path=inbox_dir, batch_size=1)
+    writer = ResponseWriter(watch_path=inbox_dir, timezone="UTC")
+    mon = InboxMonitor(
+        db=db, invoker=mock_invoker, session_manager=mock_session_manager,
+        config=config, writer=writer, clock=clock, prompt_dir=tmp_path,
+    )
+
+    mock_invoker.run.return_value = _success_output(
+        "# Eval\n\n## 1. Article 1\nGood.\n\n"
+        "## 2. Article 2\nNoted.\n" + "x" * 300
+    )
+
+    # Initial evaluation
+    (inbox_dir / "test.md").write_text(
+        "https://example.com/article-1\nhttps://example.com/article-2\n"
+    )
+    await mon.check_once()
+
+    # Get the stored baseline
+    prev = await inbox_items.get_evaluated_content(
+        db, str(inbox_dir / "test.md"),
+    )
+    assert prev is not None
+
+    # Add a new URL
+    new_content = (
+        "https://example.com/article-1\n"
+        "https://example.com/article-2\n"
+        "https://example.com/article-3\n"
+    )
+
+    delta = _compute_new_content(prev, new_content)
+    assert "article-3" in delta
+    assert "article-1" not in delta
+    assert "article-2" not in delta


### PR DESCRIPTION
## Summary

- Fixes the inbox monitor re-evaluating the same Genesis.md content repeatedly (Genesis-19 through Genesis-26 all covered the same ~12 items over 5 days)
- Root cause: the completion handler re-read the source file to store the `evaluated_content` baseline, but rclone sync from Dropbox could clear/modify the file during the 5-10 min CC evaluation window, corrupting the baseline
- Adds `source_content` field to `InboxItem` to capture full file content at detection time
- Replaces file re-read at completion with cumulative merge (set-union of lines) — once a line has been evaluated, it stays in the baseline forever
- Adds `BASELINE_GUARD` diagnostic logging that still reads the file at completion for comparison — catches the race in the act if it fires

## Evidence

- 2026-05-26T17:10 stored `evaluated_content = "Numenta\n\n"` (9 chars) because the file was cleared during evaluation
- Delta from 9-char baseline vs full file = 1677 chars (empirically verified)
- Delta from correct baseline vs full file = 0 chars (empirically verified)  
- The re-read behavior was added March 13, 2026 (commit c4505497)
- Sync mechanism: rclone cron (every 5 min) from Dropbox/Obsidian

## Test plan

- [x] 7 unit tests for `_merge_evaluated_content` (empty, union, dedup, sort, edge cases)
- [x] Integration test: baseline survives file clear between evaluations
- [x] Integration test: delta contains only genuinely new items
- [x] All 188 inbox tests pass (was 179, +9 new)
- [x] ruff check passes
- [ ] Live verification: after merge + data fix, monitor for BASELINE_GUARD events

🤖 Generated with [Claude Code](https://claude.com/claude-code)