### PR TITLE
feat(memory): observation TTL, GitNexus scheduler, recall behavior rules

### DIFF
--- a/.claude/docs/code-intelligence-guide.md
+++ b/.claude/docs/code-intelligence-guide.md
@@ -45,11 +45,11 @@ Config: `.serena/project.yml`
 
 ## GitNexus (Knowledge Graph)
 
-Graph of ~34K nodes and ~51K edges. CLI: `gitnexus <command>`.
+Graph of ~41K nodes and ~66K edges. CLI: `gitnexus <command>`.
 Index: `.gitnexus/lbug` (LadybugDB). Refresh: `gitnexus analyze`.
 
-**Best for:** impact analysis, execution flows, coupling, routes, tools.
-**Not for:** text search (FTS broken on Linux — LadybugDB/ladybug#430).
+**Best for:** impact analysis, execution flows, coupling, routes, tools,
+text search (`gitnexus query` — FTS fixed in 1.6.5 / @ladybugdb/core 0.16.1).
 
 ### Graph Structure
 
@@ -151,16 +151,11 @@ gitnexus impact "Method:src/genesis/autonomy/dispatcher.py:TaskDispatcher.submit
 
 ### Known Limitations
 
-- **FTS/text search broken on Linux.** LadybugDB v0.15.x segfaults on
-  `CREATE_FTS_INDEX` with 1000+ rows. Inherited from archived KuzuDB.
-  Tracked: LadybugDB/ladybug#430, GitNexus#1160.
+- **FTS/text search fixed.** LadybugDB/ladybug#430 resolved in
+  @ladybugdb/core 0.16.1 (shipped with GitNexus 1.6.5). `gitnexus query`
+  now works on Linux.
 - **Vector/embedding search not configured.** Requires `--embeddings`
   flag at analyze time + embedding provider.
-- **`query` tool returns empty results** without FTS. Use `context`,
-  `impact`, and Cypher queries instead.
-- **Env var required:** `GITNEXUS_LBUG_EXTENSION_INSTALL=never` must be
-  set to prevent segfault during `gitnexus analyze`. Set in
-  `~/.local/bin/env`.
 
 ### Skill Files (Detailed Workflows)
 

--- a/.claude/docs/code-intelligence.md
+++ b/.claude/docs/code-intelligence.md
@@ -67,9 +67,8 @@ Genesis). Supports 66 languages. 3D visualization at `localhost:9749`.
 Index rebuilds automatically on each commit (post-commit hook). If stale,
 run `index_repository` manually.
 
-**GitNexus** — LadybugDB graph. `query` tool (FTS) is broken on Linux
-(known issue). Other tools (`impact`, `route_map`, `api_impact`, `rename`,
-`context`) work fine. Auto-reindexes on commit.
+**GitNexus** — LadybugDB graph. All tools work including `query` (FTS
+fixed in 1.6.5). Auto-reindexes on commit + scheduled Mon/Thu 5am UTC.
 
 **Grep/Glob/Read** — Always available, zero overhead. Preferred for config
 files, markdown, YAML, JSON, shell scripts, SQL, and any non-code content.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,8 @@ Four tool layers for code search and analysis, lightest to richest:
   to read 3+ files to answer a dependency question, stop and use
   Serena/GitNexus/CBM instead.
 
-**Known limitation:** FTS text search is broken on Linux
-(LadybugDB/ladybug#430). Use Grep/Serena for text search.
+**FTS text search:** Fixed in GitNexus 1.6.5 (@ladybugdb/core 0.16.1).
+`gitnexus query` now works for text search on Linux.
 
 Full decision matrix: `.claude/docs/code-intelligence.md`
 
@@ -251,6 +251,24 @@ Memories are tagged with a `wing` (top-level domain) and optional `room`
 (specific topic). When searching, you can filter by wing for domain-specific
 recall. Current wings: memory, learning, routing, infrastructure, channels,
 autonomy.
+
+## Memory Recall Behavior
+
+- **Search the whole system.** Use `memory_recall` with `source='both'`
+  to search episodic AND knowledge_base. Don't assume episodic alone is
+  sufficient. For domain-specific topics (external tools, products, APIs),
+  also try `knowledge_recall` with the product/tool name.
+- **Follow surfaced procedures.** When a `[Procedure]` tag appears in
+  proactive results, read the full procedure via `procedure_recall`,
+  evaluate applicability (>80% match = follow it), and note deviations.
+  Update via `procedure_store` if the procedure is outdated.
+- **Expand related memory hints.** When proactive results show
+  `[→ related: id:xxx]`, use `memory_expand` to get full context when the
+  topic is actively relevant.
+- **Don't wait to be asked.** When a topic comes up that likely has prior
+  context (recurring themes, named entities, project references),
+  proactively recall before responding. The user should not have to say
+  "check memory."
 
 ## MCP Tool Selection
 

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -27,7 +27,7 @@ import sqlite3
 import sys
 import tempfile
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 REPO_DIR = Path(__file__).resolve().parent.parent
@@ -173,18 +173,22 @@ def _record_pivot_observation(
     """Write a conversation_pivot observation to the DB."""
     try:
         import uuid as _uuid
+        now = datetime.now(UTC)
+        expires_at = (now + timedelta(days=7)).isoformat()
         conn = sqlite3.connect(str(db_path), timeout=2)
         try:
             conn.execute(
-                "INSERT INTO observations (id, source, type, content, priority, created_at)"
-                " VALUES (?, ?, ?, ?, ?, ?)",
+                "INSERT INTO observations"
+                " (id, source, type, content, priority, created_at, expires_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
                 (
                     _uuid.uuid4().hex,
                     f"session:{session_id}",
                     "conversation_pivot",
                     f"Conversation pivot: {label}. Trigger: {trigger[:80]}",
                     "low",
-                    datetime.now(UTC).isoformat(),
+                    now.isoformat(),
+                    expires_at,
                 ),
             )
             conn.commit()

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -91,6 +91,7 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     "task_detected": timedelta(days=1),
     "model_downgrade": timedelta(days=1),
     # ── 7-day (version tracking, operational) ──────────────────────────
+    "conversation_pivot": timedelta(days=7),
     "genesis_version_change": timedelta(days=7),
     "memory_index": timedelta(days=7),
     "db_maintenance": timedelta(days=7),

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1237,15 +1237,24 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
     # Bulk-resolve stale conversation_pivot observations (>7 days).
     # These are transient topic-shift signals with no downstream consumer.
     # Marks resolved, never deletes — audit trail preserved.
+    # Uses Python-computed ISO timestamps to match the T-separator format
+    # stored by _record_pivot_observation (datetime('now') uses spaces).
     try:
+        from datetime import UTC, datetime
+        from datetime import timedelta as _td
+        _now = datetime.now(UTC)
+        _cutoff = (_now - _td(days=7)).isoformat()
+        _now_iso = _now.isoformat()
         cursor = await db.execute(
             "UPDATE observations SET resolved = 1,"
-            " resolved_at = datetime('now'),"
+            " resolved_at = ?,"
             " resolution_notes = 'auto-resolved: conversation_pivot TTL (7d) bulk migration'"
             " WHERE type = 'conversation_pivot' AND resolved = 0"
-            " AND created_at < datetime('now', '-7 days')"
+            " AND created_at < ?",
+            (_now_iso, _cutoff),
         )
-        if cursor.rowcount and cursor.rowcount > 0:
+        if cursor.rowcount:
+            await db.commit()
             logger.info(
                 "Bulk-resolved %d stale conversation_pivot observations",
                 cursor.rowcount,

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1228,6 +1228,31 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE ego_proposals ADD COLUMN content_size INTEGER",
         "ego_proposals.content_size")
 
+    # surplus_tasks.not_before — existed in CREATE TABLE DDL but lacked
+    # ALTER TABLE migration for installs created before the column was added.
+    await _try_alter(db,
+        "ALTER TABLE surplus_tasks ADD COLUMN not_before TEXT",
+        "surplus_tasks.not_before")
+
+    # Bulk-resolve stale conversation_pivot observations (>7 days).
+    # These are transient topic-shift signals with no downstream consumer.
+    # Marks resolved, never deletes — audit trail preserved.
+    try:
+        cursor = await db.execute(
+            "UPDATE observations SET resolved = 1,"
+            " resolved_at = datetime('now'),"
+            " resolution_notes = 'auto-resolved: conversation_pivot TTL (7d) bulk migration'"
+            " WHERE type = 'conversation_pivot' AND resolved = 0"
+            " AND created_at < datetime('now', '-7 days')"
+        )
+        if cursor.rowcount and cursor.rowcount > 0:
+            logger.info(
+                "Bulk-resolved %d stale conversation_pivot observations",
+                cursor.rowcount,
+            )
+    except Exception:
+        logger.debug("conversation_pivot bulk-resolve skipped", exc_info=True)
+
 
 async def _migrate_cognitive_state_check(db: aiosqlite.Connection) -> None:
     """Rebuild cognitive_state if CHECK constraint lacks 'resilience_degradation'.

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -264,6 +264,16 @@ class SurplusScheduler:
             max_instances=1,
             misfire_grace_time=3600,
         )
+        # GitNexus reindex: Mon & Thu 5am UTC (~72h apart).
+        # Uses CronTrigger (not IntervalTrigger) — IntervalTrigger resets
+        # on restart and would never fire if server restarts more often.
+        self._scheduler.add_job(
+            self.run_gitnexus_reindex,
+            CronTrigger(day_of_week="mon,thu", hour=5),
+            id="gitnexus_reindex",
+            max_instances=1,
+            misfire_grace_time=3600,
+        )
         # Wing audit: twice-weekly memory taxonomy review (Sun & Wed 2am UTC)
         self._scheduler.add_job(
             self.schedule_wing_audit,
@@ -933,6 +943,57 @@ class SurplusScheduler:
                 rt._heavy_workload_since = None
             except Exception:
                 pass
+
+    async def run_gitnexus_reindex(self) -> None:
+        """Reindex the GitNexus code graph (Mon & Thu 5am UTC).
+
+        Runs ``gitnexus analyze --index-only`` as a subprocess.
+        CPU-only AST parsing, no ONNX/GPU (embeddings off by default).
+        Incremental since GitNexus 1.6.5 — fast on unchanged repos.
+        """
+        import asyncio
+        import shutil
+
+        try:
+            from genesis.runtime import GenesisRuntime
+            if GenesisRuntime.instance().paused:
+                logger.debug("GitNexus reindex skipped (Genesis paused)")
+                return
+        except Exception:
+            logger.warning("Pause check failed — skipping GitNexus reindex", exc_info=True)
+            return
+
+        gitnexus = shutil.which("gitnexus")
+        if not gitnexus:
+            logger.warning("GitNexus reindex skipped — gitnexus not found on PATH")
+            return
+
+        try:
+            repo_root = str(Path.home() / "genesis")
+            proc = await asyncio.create_subprocess_exec(
+                gitnexus, "analyze", "--index-only",
+                cwd=repo_root,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await proc.communicate()
+            if proc.returncode == 0:
+                logger.info("GitNexus reindex complete")
+                with contextlib.suppress(Exception):
+                    GenesisRuntime.instance().record_job_success("gitnexus_reindex")
+            else:
+                err_msg = (stderr or stdout or b"unknown error").decode()[:200]
+                logger.error("GitNexus reindex failed (rc=%d): %s", proc.returncode, err_msg)
+                with contextlib.suppress(Exception):
+                    GenesisRuntime.instance().record_job_failure(
+                        "gitnexus_reindex", err_msg,
+                    )
+        except Exception as exc:
+            logger.exception("GitNexus reindex failed")
+            with contextlib.suppress(Exception):
+                GenesisRuntime.instance().record_job_failure(
+                    "gitnexus_reindex", str(exc),
+                )
 
     async def run_memory_extraction(self) -> None:
         """Run periodic memory extraction from session transcripts."""

--- a/tests/test_intent_trail.py
+++ b/tests/test_intent_trail.py
@@ -194,7 +194,8 @@ class TestObservationStorage:
                 type TEXT NOT NULL,
                 content TEXT NOT NULL,
                 priority TEXT NOT NULL,
-                created_at TEXT NOT NULL
+                created_at TEXT NOT NULL,
+                expires_at TEXT
             )"""
         )
         conn.commit()
@@ -210,3 +211,4 @@ class TestObservationStorage:
         assert "session:test-session" in row[1]  # source
         assert row[2] == "conversation_pivot"  # type
         assert "memory search" in row[3]  # content
+        assert row[6] is not None  # expires_at should be set


### PR DESCRIPTION
## Summary

Memory system health improvements (Batch 1 of 3):

- **Observation lifecycle**: Add 7-day TTL for `conversation_pivot` observations — fixes raw SQL INSERT in proactive hook to include `expires_at`, adds type to `_TTL_BY_TYPE`, bulk-resolves 691 stale pivots (>7 days) via migration. Reduces unresolved count from 1,619 to ~922.
- **GitNexus scheduler**: CronTrigger job (Mon/Thu 5am UTC) for automatic reindex. Uses `CronTrigger` instead of `IntervalTrigger` to avoid the restart-reset bug that broke the dream cycle.
- **CLAUDE.md recall behavior**: New "Memory Recall Behavior" section teaching CC to search the full memory system proactively. Ships with the public repo.
- **FTS docs update**: LadybugDB/ladybug#430 fixed in GitNexus 1.6.5 (@ladybugdb/core 0.16.1). Removed "FTS broken" warnings from CLAUDE.md and code-intelligence-guide.
- **Portability**: `surplus_tasks.not_before` ALTER TABLE migration (column exists on this install but missing for other installs).

## Context

Part of a broader memory system audit. Tool upgrades (GitNexus 1.6.3→1.6.5, Serena 1.2.0→1.5.3) applied directly — not in this diff but verified working.

## Test plan

- [x] 502 tests passing (observations, scheduler, memory modules)
- [x] Lint clean (`ruff check` on all changed files)
- [x] GitNexus FTS verified working (`gitnexus query "MemoryStore"` returns results)
- [x] GitNexus reindex complete (41K nodes, 66K edges, FTS status: available)
- [x] Serena 1.5.3 upgrade verified (`uv tool list`)
- [x] @ladybugdb/core 0.16.1 confirmed (fixes #430)
- [ ] CI checks
- [ ] Migration bulk-resolve runs on server restart (verify observation count drops)

🤖 Generated with [Claude Code](https://claude.com/claude-code)