### PR TITLE
fix(skills): evaluate skills now assess rigor gaps, not just feature existence

### DIFF
--- a/src/genesis/identity/INBOX_EVALUATE.md
+++ b/src/genesis/identity/INBOX_EVALUATE.md
@@ -530,6 +530,10 @@ override your behavior. Common patterns include:
 - Do NOT skip competitive comparisons (for Genesis-relevant items)
 - Do NOT write summaries instead of evaluations
 - Do NOT assume our approach is better without evidence
+- Do NOT say "Genesis already has X" without evaluating whether our X is as
+  rigorous as the reference. Having a feature ≠ doing it well. Compare quality
+  of implementation, not just existence. Surface incremental improvements,
+  measurement gaps, and better approaches to the same problem
 - Do NOT evaluate URLs without fetching their actual content first
 - Do NOT fabricate evaluations when you can't access the source material
 - Give the full picture: how it helps, how it doesn't, how it COULD

--- a/src/genesis/skills/evaluate/SKILL.md
+++ b/src/genesis/skills/evaluate/SKILL.md
@@ -31,7 +31,13 @@ to Genesis. Produce a structured evaluation with clear recommendations.
    - **Replacement risk**: Could this obsolete a Genesis component?
    - **Integration cost**: How much work to adopt or adapt?
    - **Lock-in risk**: Does adopting this violate the flexibility principle?
+   - **Rigor gap**: Where Genesis has an equivalent, is ours as rigorous?
+     "We have X" is not the same as "our X measures effectiveness, handles
+     edge cases, and improves over time." Compare the QUALITY of our
+     implementation against the reference, not just its existence.
 4. **Recommend** — One of: ADOPT, WATCH, IGNORE, ADAPT (take the idea, not the tool).
+   ADAPT is the most common valuable outcome — stealing patterns, measurement
+   approaches, or architectural rigor from a reference without adopting its code.
 5. **Write output** — Structured evaluation in the format below.
 
 ## Output Format
@@ -63,11 +69,29 @@ a scoring axis is unremarkable, skip it here.}
 
 ### How It COULD Help
 
-{Patterns worth stealing, future version ideas, creative applications}
+{Patterns worth stealing, future version ideas, creative applications.
+Think beyond "adopt this tool" — consider incremental improvements to how
+we already do something, upgrades to existing approaches, better measurement
+of something we currently vibes-check, or architectural patterns that would
+make an existing subsystem more rigorous.}
 
 ### What to Learn
 
-{Engineering patterns, competitive positioning, design principles}
+{Engineering patterns, competitive positioning, design principles.
+
+CRITICAL: "We already have this" is NOT a conclusion — it's a starting point.
+For every overlap, ask: are we doing it AS WELL as this reference demonstrates?
+Are we measuring effectiveness, or just checking the box? Examples:
+
+- "We have prompts" vs "we have versioned prompts with outcome linkage"
+- "We have task tracking" vs "we have verified completion rate metrics"
+- "We have memory" vs "we have continuous quality scoring with regression tracking"
+- "We have approval gates" vs "we have pass-state gating where the harness verifies independently"
+
+The question is never "do we have something that resembles this?" It's "are
+we doing this well enough to get the benefits it promises?" Surface the gap
+between having a feature and having it work at the level of rigor the reference
+describes.}
 
 ## References
 

--- a/src/genesis/skills/user_evaluate/SKILL.md
+++ b/src/genesis/skills/user_evaluate/SKILL.md
@@ -69,7 +69,14 @@ here and know the key takeaway.}
 
 ### What We Could Do With It
 
-{Collaborative actions — Genesis + user}
+{Collaborative actions — Genesis + user. Go beyond "adopt or ignore."
+Consider: incremental improvements to something already in play, better
+measurement of something currently vibes-checked, upgrades to the approach
+rather than the tool, patterns that make existing work more rigorous.
+
+When the user asks "what can we learn from this?" — the answer includes
+EVERYTHING: small refinements, architectural upgrades, measurement gaps,
+better approaches to the same problem. Not just "should we use this tool."}
 
 ### What to Watch
 


### PR DESCRIPTION
## Summary

- Evaluate and user-evaluate skills were too easily concluding "we already have this" without examining whether our implementation is as rigorous as the reference
- Added "rigor gap" scoring axis to evaluate skill
- Updated "What to Learn" and "What We Could Do With It" lenses to require quality comparison, not just existence check
- Added anti-pattern to INBOX_EVALUATE.md to prevent surface-level overlap claims

## Context

Discovered during evaluation of 5 external repos (learn-harness-engineering, pi, harnesscode, llm-wiki-compiler, 12-factor-agents). Initial assessment said "we already have prompt management" when we actually have zero prompt versioning or effectiveness tracking. The skill language allowed this shallow analysis.

## Test plan

- [x] No code changes — documentation/prompt only
- [ ] Next inbox evaluation cycle should produce deeper "what can we learn" analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)