### PR TITLE
refactor: CLAUDE.md SNR compression + dashboard VCR card

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -192,6 +192,15 @@ Verify before any commit:
 - Staged files do not include secrets (`secrets.env`, `.env`, credentials)
 - GROUNDWORK-tagged code not accidentally deleted
 - New capabilities registered in `_capabilities.py` + bootstrap manifest
+- **Conventional commit prefixes**: `feat:`, `fix:`, `refactor:`, `docs:`,
+  `test:`, `chore:`. Scope optional: `feat(ego): add cadence manager`.
+  Subject line under 72 characters. Dominant category wins if mixed.
+- **NEVER push to main or merge into main without a PR and user approval.**
+  Enforced by PreToolUse hook.
+- **Targeted tests during development.** Run ONLY the relevant test file(s)
+  for your changes. NEVER run the full test suite locally — CI handles that.
+  Check CI via `gh pr checks`. Bare `pytest` without a file path is banned.
+- **Commit continuously**: after every logical unit of work. Uncommitted = lost.
 
 ## Reference Router
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,41 +64,11 @@ systemctl --user status genesis-server            # Verify server running
 
 ## Code Intelligence
 
-Four tool layers for code search and analysis, lightest to richest:
-
-1. **Grep/Glob/Read** — text search, file patterns, direct reads. Configs, docs, non-code.
-2. **Serena** (`mcp__serena__*`) — Python LSP. Symbol lookup, references, type hierarchies, safe rename.
-3. **codebase-memory-mcp** (`mcp__codebase-memory-mcp__*`) — 66-language code graph. search_graph, trace_path, get_architecture.
-4. **GitNexus** (`mcp__gitnexus__*`) — blast radius, impact analysis, execution flows, rename.
-   CLI: `gitnexus <command>`. ~34K nodes, ~51K edges.
-
-**When to reach for GitNexus (all session types):**
-- Before editing code: `gitnexus impact <symbol>` for blast radius
-- Before committing: `gitnexus detect-changes` to verify affected scope
-- Understanding a subsystem: `gitnexus context <symbol>` for 360° view,
-  or browse `gitnexus://repo/GENesis-AGI/processes` for execution flows
-- Exploring coupling: `gitnexus://repo/GENesis-AGI/clusters` for
-  functional areas, or `gitnexus cypher` for custom graph queries
-- API/MCP work: `route_map` and `tool_map` (MCP-only tools)
-
-**Development rules:**
-- MUST run impact analysis before editing any symbol — warn user if
-  risk is HIGH or CRITICAL
-- MUST run detect-changes before committing
-- Use `gitnexus rename` for multi-file renames, not find-and-replace
-
-**Exploration rule (dependency/coupling questions):**
-- If tracing who calls a function or how many sites use a symbol →
-  Serena `find_referencing_symbols`, NOT reading files manually
-- If assessing coupling, blast radius, or extraction feasibility →
-  GitNexus `impact`/`context`, NOT grepping through imports
-- Direct reads are for *known files*, not *discovery*. If you're about
-  to read 3+ files to answer a dependency question, stop and use
-  Serena/GitNexus/CBM instead.
-
-**FTS text search:** Fixed in GitNexus 1.6.5 (@ladybugdb/core 0.16.1).
-`gitnexus query` now works for text search on Linux.
-
+Four tool layers: (1) Grep/Glob/Read for text/configs, (2) Serena for
+Python LSP, (3) codebase-memory-mcp for code graph, (4) GitNexus for
+blast radius and impact analysis. Use GitNexus `impact` before editing
+symbols and `detect-changes` before committing. Use Serena or GitNexus
+for dependency questions, not manual file reads.
 Full decision matrix: `.claude/docs/code-intelligence.md`
 
 ## Skill Library
@@ -111,32 +81,16 @@ one matches.
 
 ## Web Tools
 
-**MCP tools (canonical — work in ALL session types):**
-- `web_fetch(url)` — fetch any URL with anti-bot bypass (Scrapling→Crawl4AI→httpx)
-- `web_search(query)` — search web (TinyFish→SearXNG→Brave, or explicit tavily/exa/perplexity)
-
-**CC built-in tools (foreground convenience):**
-- CC `WebFetch` — AI-processed summary (use when you need a summary, not raw content)
-- CC `WebSearch` — quick general lookups (fine for simple questions)
-
-**Default to MCP tools.** They handle anti-bot, work in background sessions,
-and return structured data. Use CC tools only when AI summarization is the goal.
-
-Browser tools for interactive pages. ATS APIs for job listings.
-Full decision guide: `.claude/docs/web-tools-guide.md`
+**Default to MCP tools** (`web_fetch`, `web_search`) — they handle anti-bot,
+work in background sessions, and return structured data. CC built-in
+`WebFetch`/`WebSearch` are fine for quick lookups or when AI summarization
+is the goal. Full decision guide: `.claude/docs/web-tools-guide.md`
 
 ## Background Sessions
 
-**When to use a background session vs sub-agent:**
-- Task > 20 min OR needs persistent `memory_store` writes → **background session**
-- Quick research returning results to this conversation → **sub-agent**
-
-Always instruct background sessions to write progress incrementally — never batch at the end.
-
-Profiles: `observe` · `interact` · `research` — use the minimum that covers the task.
-
-**Always read the full guide before dispatching a background session:**
-`.claude/docs/background-sessions.md`
+Task > 20 min or needs persistent writes → **background session**. Quick
+research → **sub-agent**. Profiles: `observe` · `interact` · `research`.
+Full guide: `.claude/docs/background-sessions.md`
 
 ## Genesis Development Work
 
@@ -298,19 +252,6 @@ When a user shares a file path or URL in conversation:
 - Never auto-ingest without explicit user confirmation.
 - The dashboard also supports drag-drop file upload on the Knowledge tab.
 
-## Community Contributions
-
-When you see a `[Contribution]` system-reminder, a post-commit hook has
-detected a bug fix eligible for upstream contribution. Ask the user
-conversationally — never run the pipeline without explicit approval. If
-approved, invoke `genesis contribute <sha>`. If declined, do nothing.
-Full pipeline details are in the `genesis-development` skill's
-`references/contribution.md`.
-
-## Scheduling Reminders
-
-To send the user a future Telegram reminder, use `mcp__genesis-outreach__outreach_send` with `preferred_timing` set to an ISO timestamp. This persists in the DB and fires via the Genesis outreach pipeline. Do NOT use the `/schedule` skill — that routes to Claude Code's remote cloud scheduler, not Genesis.
-
 ## Traps
 
 - **Ego** (`src/genesis/ego/`) — Live. Two egos: user (CEO/Opus) and
@@ -321,108 +262,45 @@ To send the user a future Telegram reminder, use `mcp__genesis-outreach__outreac
 
 ## Rules
 
-- **Output files go outside the repo.** Write all Genesis-generated output
-  (handoffs, analysis, guides, brainstorms, exports) to `~/.genesis/output/`,
-  never into the repo tree. The repo is for source code and product docs only.
-- **Execute, don't delegate.** When Genesis has API or exec access to a
-  system (local or remote), perform the action directly instead of
-  telling the user to run terminal commands. If unsure whether to act,
-  ask "Want me to handle this?" — never silently list commands and
-  expect the user to copy-paste. The exception: irreversible, financial,
-  or destructive actions need explicit approval first. The user's role
-  is strategy and decisions; Genesis's role is execution.
-- **No unsanctioned financial transactions.** Genesis must NEVER send
-  money, transfer credits, or initiate any financial transaction without
-  explicit user approval — every single time, for every transaction.
-  Prior approval does not carry forward. The only exception is a
-  dedicated account the user has explicitly authorized for autonomous
-  spending within stated limits.
-- **Timeout policy.** Burden of proof is on you to justify any timeout.
-  Identify the specific failure mode, justify the specific value, and
-  surface the request to the user. Default floor: 2 hours (7200s) when
-  no stronger justification exists. Full policy in genesis-development
-  skill.
-- **Verify the outcome, not just the tests.** End-to-end verification
-  required — "if the system restarts now, will this work?" Details in
-  genesis-development skill.
-- **Built ≠ wired. Wired ≠ verified.** Every component needs a live call
-  site in the actual runtime path, not just a unit test. Taxonomy in
-  genesis-development skill.
-- **Code review after code changes.** Dispatch superpowers:code-reviewer.
+- **Output files go outside the repo.** Write to `~/.genesis/output/`,
+  never into the repo tree.
+- **Execute, don't delegate.** Perform actions directly instead of
+  telling the user to run terminal commands. Exception: irreversible,
+  financial, or destructive actions need explicit approval first.
+- **No unsanctioned financial transactions.** Every transaction needs
+  explicit user approval, every time. Prior approval does not carry forward.
+- **Timeout policy.** Justify any timeout with a specific failure mode.
+  Default floor: 2 hours (7200s). Full policy in genesis-development skill.
+- **Verify outcomes, not just tests.** "If the system restarts now, will
+  this work?" Built ≠ wired ≠ verified. Details in genesis-development skill.
+- **Code review after code changes.** Codex will review your output.
   Protocol in genesis-development skill.
-- **Codex will review your output once you finish.**
-- **Commit continuously**: after every logical unit of work. Uncommitted = lost.
-  The user is the only human on this project — uncommitted work is invisible
-  work, and invisible work is lost work.
-- **NEVER push to main or merge into main without a PR and user approval.**
-  Enforced by PreToolUse hook. Details in genesis-development skill.
-- **Conventional commit prefixes**: `feat:`, `fix:`, `refactor:`, `docs:`,
-  `test:`, `chore:`. Scope is optional: `feat(ego): add cadence manager`.
-  Keep subject line under 72 characters. Dominant category wins if mixed.
-- **Procedure recall is automatic.** The proactive procedure hook surfaces
-  the single most relevant stored procedure (cosine ≥ 0.7) as a
-  `[Procedure | task_type | id:xxx]` tag on every prompt, when one applies.
-  No manual `procedure_recall` call needed for routine work — use it only
-  when you want broader matches or wider context.
-- **Store procedures when you discover them.** When you find a non-obvious
-  reusable workflow (multi-step, hard-won, capability that took effort to
-  learn), call `procedure_store` immediately — don't defer.
-- **Never insert directly into `task_states`.** All task submissions MUST
-  go through `task_submit` MCP after completing `/task` intake. Direct DB
-  writes are rejected by a SQLite trigger that requires a valid intake
-  token. This is a procedural friction gate — it prevents accidental
-  bypass of the guided intake process.
-- **Never pipe background Bash commands.** `run_in_background` with piped
-  commands (`| tail`, `| head`, `| grep`) produces empty output files.
-  Run without pipes, or run in the foreground. If you need the last N
-  lines, run the full command first, then read the output file.
-- **Targeted tests during development.** Run ONLY the relevant test
-  file(s) for your changes (`pytest tests/test_mcp/test_browser_tools.py -v`).
-  NEVER run the full test suite locally — CI handles that on every push.
-  Check CI results via `gh pr checks` or `gh run view`. If a local
-  verification step takes >60s, the scope is wrong. Bare `pytest`
-  without a file path is banned — it wastes 10+ minutes, gets
-  backgrounded, and produces no value that CI doesn't already provide.
-- **Plan mode by default.** Enter plan mode for any task with 3+ steps or
-  architectural decisions. Plan verification steps, not just build steps. If
-  something goes sideways mid-execution — STOP and re-plan immediately. Don't
-  push through a broken approach hoping it resolves itself.
-- **Use subagents to keep main context clean.** Offload research, exploration,
-  and parallel analysis to subagents. One concern per subagent for focused
-  execution. For complex problems, throw more compute at it rather than
-  cramming everything into the main context window.
-- Do NOT modify `docs/history/` unless correcting factual errors
-- Architecture docs in `docs/architecture/` are the single source of truth
+- **Commit continuously**: uncommitted = invisible = lost.
+- **Procedure recall is automatic** — the proactive hook surfaces relevant
+  procedures. Store new procedures immediately when you discover them.
+- **Never insert directly into `task_states`.** Use `task_submit` MCP
+  after `/task` intake.
+- **Never pipe background Bash commands.** `run_in_background` with pipes
+  produces empty output. Run without pipes or in foreground.
+- **Plan mode by default** for any task with 3+ steps or architectural
+  decisions. If something goes sideways — STOP and re-plan.
+- **Use subagents** to keep main context clean. One concern per subagent.
 - **NEVER `rm -rf` the working directory.** Never run destructive commands
   without explicit user confirmation.
-- **Session wrap-up**: structured handoff — what changed, what's pending, what
-  was learned. If it's not committed, it doesn't exist.
-- **Follow-up ownership**: For each follow-up item identified during a session:
-  1. State what it is and why
-  2. State what Genesis will do: schedule it, flag for ego, or surface to user
-  3. Create the follow-up via the `follow_up_create` MCP tool before session ends
-  4. Never leave a follow-up as just text — every deferred item needs a backing
-     record. Genesis owns follow-through, not the user.
-- **No laziness.** Find root causes. No temporary fixes. No "good enough"
-  shortcuts. No skipping steps because the answer seems obvious. Hold yourself
-  to senior developer standards — if you wouldn't approve it in a code review,
-  don't write it. When you feel the pull to take a shortcut, that's the moment
-  to slow down and do it properly. Don't EVER mute the symptom — fix the fucking
-  problem.
-- **Read before writing.** Never modify code you haven't fully read. Don't
-  assume what a function does based on its name — read the implementation.
-  Don't edit a file based on a grep match — read the surrounding context.
-  Wrong assumptions from skimming produce wrong fixes.
-- **Self-correction loop**: when the user corrects a mistake, persist the lesson
-  as a concrete rule — one that PREVENTS the mistake, not just documents it.
-  Ruthlessly iterate on these lessons until the mistake rate drops. Review
-  relevant lessons at session start (the memory system surfaces these
-  automatically — read them, don't skip them).
-- **Register new capabilities** in bootstrap manifest + capabilities file.
-- **NEVER hide, suppress, or work around broken things — FIX THEM.** When
-  you encounter something broken, your first instinct must be to fix the
-  root cause. Not hide the element, not skip the section, not propose
-  "we'll address it later." This is a thinking rule, not just a code rule.
-- **Bugs you see get fixed or tracked — never ignored.** Every bug you
-  encounter during any work must be either fixed inline or filed as a
-  follow-up AND raised in your next user-facing report.
+- **Session wrap-up**: structured handoff — what changed, what's pending,
+  what was learned. If it's not committed, it doesn't exist.
+- **Follow-up ownership**: create follow-ups via `follow_up_create` MCP
+  before session ends. Never leave a follow-up as just text.
+- **No laziness.** Find root causes. No temporary fixes. No shortcuts.
+  Don't EVER mute the symptom — fix the problem.
+- **Read before writing.** Never modify code you haven't fully read.
+  Don't assume what a function does based on its name.
+- **Self-correction loop**: persist lessons as concrete rules that PREVENT
+  mistakes, not just document them.
+- **NEVER hide broken things — FIX THEM.** Fix the root cause, not the
+  symptom. This is a thinking rule, not just a code rule.
+- **Bugs you see get fixed or tracked — never ignored.**
+- **Telegram reminders**: use `outreach_send` with `preferred_timing`,
+  NOT the `/schedule` skill (that's Claude Code's remote scheduler).
+- Dev-specific rules (commit prefixes, targeted tests, push/PR workflow,
+  capability registration) are in the genesis-development skill.

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -356,3 +356,23 @@ async def ego_follow_ups():
         }
         for f in items
     ])
+
+
+@blueprint.route("/api/genesis/ego/vcr")
+@_async_route
+async def ego_vcr():
+    """Return Verified Completion Rate for ego proposals."""
+    from genesis.db.crud.ego import compute_vcr
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt._db is None:
+        return jsonify({
+            "vcr": 0.0, "dispatch_rate": 0.0,
+            "total_resolved": 0, "total_executed": 0,
+            "outcomes_completed": 0, "outcomes_failed": 0,
+            "outcomes_unknown": 0,
+        })
+
+    data = await compute_vcr(rt._db, days=30)
+    return jsonify(data)

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -116,6 +116,7 @@
           proposals: [],
           cadence: null,
           followUps: [],
+          vcr: null,
           expandedCycle: null,
           rejectingId: null,
           rejectReason: "",
@@ -3018,18 +3019,20 @@
         async fetchEgoDetail() {
           this.startModalFetch("egoModal");
           try {
-            const [statusR, cadenceR, cyclesR, proposalsR, followUpsR] = await Promise.all([
+            const [statusR, cadenceR, cyclesR, proposalsR, followUpsR, vcrR] = await Promise.all([
               fetchApi("/api/genesis/ego/status"),
               fetchApi("/api/genesis/ego/cadence"),
               fetchApi("/api/genesis/ego/cycles"),
               fetchApi("/api/genesis/ego/proposals/all"),
               fetchApi("/api/genesis/ego/follow-ups"),
+              fetchApi("/api/genesis/ego/vcr"),
             ]);
             if (statusR?.ok) this.egoStatus = await statusR.json();
             if (cadenceR?.ok) this.egoModal.cadence = await cadenceR.json();
             if (cyclesR?.ok) this.egoModal.cycles = await cyclesR.json();
             if (proposalsR?.ok) this.egoModal.proposals = await proposalsR.json();
             if (followUpsR?.ok) this.egoModal.followUps = await followUpsR.json();
+            if (vcrR?.ok) this.egoModal.vcr = await vcrR.json();
             this.finishModalFetch("egoModal");
           } catch {
             this.failModalFetch("egoModal", "Ego detail unavailable");
@@ -6605,6 +6608,30 @@
                     <span x-text="($store.genesisDashboard.egoStatus?.uncompacted_cycles || 0) + ' uncompacted'"></span>
                   </div>
                 </div>
+                <!-- VCR (Verified Completion Rate) -->
+                <template x-if="$store.genesisDashboard.egoModal.vcr">
+                  <div style="background: rgba(76,175,80,0.06); border: 1px solid rgba(76,175,80,0.15); border-radius: 6px; padding: 0.8rem; grid-column: 1 / -1;">
+                    <div style="font-size: 0.72rem; color: #4caf50; font-weight: 600; margin-bottom: 0.3rem;">Verified Completion Rate (30d)</div>
+                    <div style="display: flex; align-items: baseline; gap: 1.5rem; flex-wrap: wrap;">
+                      <div>
+                        <span style="font-size: 1.3rem; font-weight: 700;"
+                              x-text="(($store.genesisDashboard.egoModal.vcr.vcr || 0) * 100).toFixed(0) + '%'"></span>
+                        <span style="font-size: 0.72rem; color: var(--color-text-secondary);"> VCR</span>
+                      </div>
+                      <div>
+                        <span style="font-size: 1.1rem; font-weight: 600;"
+                              x-text="(($store.genesisDashboard.egoModal.vcr.dispatch_rate || 0) * 100).toFixed(0) + '%'"></span>
+                        <span style="font-size: 0.72rem; color: var(--color-text-secondary);"> dispatch rate</span>
+                      </div>
+                      <div style="font-size: 0.78rem; color: var(--color-text-secondary);">
+                        <span x-text="$store.genesisDashboard.egoModal.vcr.outcomes_completed || 0"></span> completed,
+                        <span x-text="$store.genesisDashboard.egoModal.vcr.outcomes_failed || 0"></span> failed,
+                        <span x-text="$store.genesisDashboard.egoModal.vcr.outcomes_unknown || 0"></span> unknown
+                        <span> / <span x-text="$store.genesisDashboard.egoModal.vcr.total_executed || 0"></span> executed</span>
+                      </div>
+                    </div>
+                  </div>
+                </template>
               </div>
               <!-- Effort selector -->
               <div style="margin-top: 1rem; padding: 0.6rem 0.8rem; background: rgba(192,132,252,0.04); border: 1px solid rgba(192,132,252,0.12); border-radius: 6px;">


### PR DESCRIPTION
## Summary

- **CLAUDE.md refactored from 429 to 306 lines** (-29%) based on SNR audit findings. All removed content lives in topic docs, genesis-development skill, or hooks.
- **VCR metric card** added to ego modal on dashboard

## CLAUDE.md changes

Compressed 3 sections that were duplicating topic docs (Code Intelligence 39→7, Web Tools 16→4, Background Sessions 13→3). Removed 2 sections handled by hooks (Community Contributions, Scheduling Reminders — merged as Rules bullet). Moved 4 dev-only rules to genesis-development skill. Compressed 3 rules that already pointed to the skill.

Key principle: keep 3-5 line summaries with pointers, not bare links AND not full duplicates.

## Dashboard VCR

New `/api/genesis/ego/vcr` endpoint + Alpine.js card in the ego modal overview tab. Shows VCR %, dispatch rate %, and outcome counts.

## Test plan

- [x] `wc -l CLAUDE.md` = 306 (target was ≤345)
- [x] Genesis-development skill has the 4 moved rules
- [x] ruff check passes
- [x] 102 dashboard tests pass
- [ ] Visual verify: VCR card renders correctly on dashboard ego modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)