### PR TITLE
feat(memory+ego): graph-boosted retrieval + post-dispatch verification

### DIFF
--- a/docs/superpowers/specs/2026-05-29-honcho-integration-db-adapter-design.md
+++ b/docs/superpowers/specs/2026-05-29-honcho-integration-db-adapter-design.md
@@ -1,0 +1,431 @@
+# Design Spec: Honcho Integration + Database Adapter
+
+**Date:** 2026-05-29
+**Status:** Draft
+**Scope:** Phase 1 (Honcho as separate service) + Phase 2 (DB adapter + Postgres groundwork)
+
+---
+
+## Context
+
+Genesis needs user-modeling capabilities that go beyond its current approach:
+specifically, systematic per-conversation user model extraction, an observation
+type system with reasoning chains (deductive/inductive/contradiction linked via
+premise graphs), dream specialists that build higher-order insights, and a
+dialectic query interface that can reason about the user on demand.
+
+Honcho (Plastic Labs, AGPL-3.0, production-ready) provides all of these. Rather
+than building a knockoff adapted to SQLite, Genesis will run Honcho as a
+separate service with its own Postgres — the same pattern used for Qdrant today.
+
+Separately, Genesis will build a thin database adapter to prepare for a possible
+future Postgres migration of its own relational data. This is insurance, not
+commitment — it makes the migration feasible without requiring it.
+
+---
+
+## Phase 1: Honcho Integration (Separate Service)
+
+### 1.1 Architecture
+
+```
+Genesis (SQLite, aiosqlite)
+    |
+    ├── Qdrant (localhost:6333)
+    |   └── 27K+ episodic + knowledge memories
+    |       Wings/rooms, activation scoring, RRF fusion
+    |
+    └── Honcho (localhost:8000, own Postgres)
+        ├── API (FastAPI, REST)
+        ├── Deriver (background worker, LLM extraction)
+        ├── Dreamer (consolidation specialists)
+        └── PostgreSQL + pgvector
+            └── User observations, reasoning chains, peer cards
+```
+
+Honcho is a **peer service**, not an embedded library. Genesis talks to it via
+REST API, the same way it talks to Qdrant. No shared database, no shared schema.
+
+### 1.2 Services to Install
+
+| Service | Runtime | Port | Managed By |
+|---------|---------|------|------------|
+| PostgreSQL 15 + pgvector | Docker or systemd | 5432 | systemd |
+| Honcho API | Python (FastAPI) | 8000 | systemd |
+| Honcho Deriver | Python (background worker) | — | systemd |
+| Redis (optional) | Docker or systemd | 6379 | systemd |
+
+Resource impact: ~2-4 GB additional RAM on a 32 GB system. No GPU.
+
+### 1.3 Honcho Data Model
+
+Honcho uses a peer-centric model:
+
+- **Workspace**: Top-level isolation container. One workspace for Genesis.
+- **Peers**: Two peers — "Jay" (human) and "Genesis" (AI). Both are first-class
+  entities. Honcho builds models of both.
+- **Sessions**: Each Genesis foreground conversation maps to a Honcho session.
+- **Messages**: Conversation turns piped from Genesis to Honcho after each session.
+
+### 1.4 Integration Points
+
+#### 1.4.1 Conversation Transcript Pipeline
+
+**When:** After each foreground CC session ends (or at session checkpoints).
+
+**Trigger mechanism:** Genesis does not currently have a "session ended" hook.
+Two options for detecting session completion:
+- **Option A (preferred):** The awareness loop already tracks `cc_sessions` and
+  detects session state changes. Add a check: if a session that was `active` is
+  now `completed` and hasn't been sent to Honcho, pipe its transcript.
+- **Option B:** A periodic scan (e.g., every 5 minutes) that checks for new
+  completed sessions not yet sent to Honcho. Simpler but less responsive.
+
+**How:** A new Genesis component (`src/genesis/honcho/adapter.py`) reads the
+session transcript and sends messages to Honcho's API:
+
+```
+Session state change detected → read transcript → POST /workspaces/{ws}/sessions/{s}/messages
+```
+
+The Honcho deriver then asynchronously:
+1. Extracts explicit observations (one LLM call per batch)
+2. Embeds observations in pgvector
+3. Updates the peer card
+4. Queues dream consolidation when idle
+
+**Transcript source:** CC session transcripts are available at
+`~/.claude/projects/-home-ubuntu-genesis/{session_id}.jsonl`. Parse assistant
+and user turns, map to Honcho message format.
+
+**Cost:** The deriver uses a cheap model (configurable — default gpt-5.4-mini
+equivalent). One LLM call per conversation, extracting atomic facts. Estimated
+cost: $0.001-0.01 per conversation.
+
+#### 1.4.2 Ego Context Injection
+
+**Where:** `src/genesis/ego/user_context.py` — `UserEgoContextBuilder`
+
+**What changes:** Add a new section to the ego's user context that queries
+Honcho for a synthesized user representation:
+
+```python
+# In UserEgoContextBuilder.build()
+honcho_context = await honcho_client.get_peer_representation("Jay")
+honcho_card = await honcho_client.get_peer_card("Jay")
+# Inject into ego context alongside existing user_model_cache data
+```
+
+This supplements (does NOT replace) the existing user model pipeline. The ego
+sees both Genesis's synthesized user model AND Honcho's peer representation.
+Over time, the two should converge — if they diverge, that's a signal that
+one or both need calibration.
+
+#### 1.4.3 Dialectic Query MCP Tool
+
+**New MCP tool:** `user_model_query` (or `honcho_query`)
+
+```
+user_model_query(question: str, reasoning_level: str = "medium") -> str
+```
+
+Calls Honcho's dialectic API: `POST /workspaces/{ws}/peers/{peer}/chat`
+
+Available in foreground sessions and ego cycles. Enables questions like:
+- "What's the best way to present this technical decision to Jay?"
+- "What are Jay's current priorities based on recent conversations?"
+- "How does Jay typically respond to architectural proposals?"
+
+Reasoning levels map to Honcho's 5 levels: minimal ($0.001), low ($0.01),
+medium ($0.05), high ($0.10), max ($0.50).
+
+#### 1.4.4 Session-Start Context Prewarm
+
+**When:** On foreground session start (UserPromptSubmit hook or session init).
+
+**What:** Fire a background dialectic query at medium depth so the first turn
+has immediate access to synthesized user context. This is what Hermes does —
+prewarm the dialectic so turn 1 isn't cold.
+
+**How:** The existing SessionStart hook can trigger an async Honcho query.
+Result is cached and available for proactive recall injection.
+
+### 1.5 Configuration
+
+New config section in `~/.genesis/config/genesis.yaml`:
+
+```yaml
+honcho:
+  enabled: true
+  api_url: http://localhost:8000
+  workspace: genesis
+  peers:
+    user: Jay
+    ai: Genesis
+  deriver:
+    model: gpt-5.4-mini  # or a free-tier model via Genesis routing
+    batch_max_tokens: 25000
+  dialectic:
+    default_level: medium
+    prewarm_on_session_start: true
+  dream:
+    enabled: true
+    idle_timeout_minutes: 60
+    min_interval_hours: 8
+```
+
+### 1.6 What Stays Unchanged
+
+- Genesis's memory system (Qdrant + FTS5 + SQLite) — untouched
+- Genesis's observation system — untouched (Honcho observations are separate)
+- Genesis's dream cycle — runs independently of Honcho's dream cycle
+- USER.md / USER_KNOWLEDGE.md — still generated by Genesis's synthesis cycle
+- Essential knowledge — still generated from Genesis's data
+
+Honcho is additive. It provides a new user-modeling signal that supplements
+existing signals. Nothing is removed or replaced.
+
+### 1.7 Future Consolidation (Optional, Not In Scope)
+
+If the two systems prove redundant over time, the following consolidations
+could be considered (but are explicitly NOT part of this spec):
+
+- Replace `user_model_cache` synthesis with Honcho peer representation
+- Replace ad-hoc `user_signal` observations with Honcho's typed observations
+- Replace USER_KNOWLEDGE.md auto-synthesis with Honcho peer card
+- Merge Genesis dream cycle with Honcho dream cycle
+
+These are evaluations for 3+ months after integration, once we have data on
+how well the two systems complement each other.
+
+---
+
+## Phase 2: Database Adapter + Postgres Groundwork
+
+### 2.1 Purpose
+
+Build a thin database abstraction layer so that Genesis's 55 CRUD modules
+(10,232 LOC) can be incrementally migrated from raw aiosqlite to an
+engine-agnostic interface. This makes a future Postgres migration feasible
+without committing to it.
+
+### 2.2 The Adapter Interface
+
+```python
+# src/genesis/db/adapter.py
+
+class DatabaseAdapter(Protocol):
+    """Thin interface between business logic and database engine."""
+
+    async def execute(self, query: str, params: dict | None = None) -> None:
+        """Execute a write query (INSERT, UPDATE, DELETE)."""
+        ...
+
+    async def fetch_one(self, query: str, params: dict | None = None) -> Row | None:
+        """Fetch a single row."""
+        ...
+
+    async def fetch_all(self, query: str, params: dict | None = None) -> list[Row]:
+        """Fetch all matching rows."""
+        ...
+
+    async def fetch_val(self, query: str, params: dict | None = None) -> Any:
+        """Fetch a single scalar value."""
+        ...
+
+    async def transaction(self) -> AsyncContextManager:
+        """Begin a transaction. Commits on clean exit, rolls back on exception."""
+        ...
+
+    def json_get(self, column: str, path: str) -> str:
+        """Return SQL expression for JSON field access.
+        SQLite: json_extract({column}, '$.{path}')
+        Postgres: {column}->>{path}
+        """
+        ...
+
+    def upsert_clause(self, conflict_columns: list[str],
+                      update_columns: list[str] | None = None) -> str:
+        """Return SQL clause for upsert.
+        SQLite: INSERT OR IGNORE / INSERT OR REPLACE
+        Postgres: ON CONFLICT (cols) DO NOTHING / DO UPDATE SET ...
+        """
+        ...
+```
+
+### 2.3 SQLiteAdapter Implementation
+
+The first (and initially only) adapter implementation wraps the existing
+`SerializedConnection`:
+
+```python
+class SQLiteAdapter(DatabaseAdapter):
+    """Wraps aiosqlite with the adapter interface."""
+
+    def __init__(self, db_path: str):
+        self._conn = SerializedConnection(db_path)
+
+    async def execute(self, query: str, params: dict | None = None) -> None:
+        # Translate :name params to ? positional for aiosqlite
+        translated_query, positional_params = self._translate(query, params)
+        await self._conn.execute(translated_query, positional_params)
+
+    async def fetch_one(self, query: str, params: dict | None = None) -> Row | None:
+        translated_query, positional_params = self._translate(query, params)
+        cursor = await self._conn.execute(translated_query, positional_params)
+        return await cursor.fetchone()
+
+    # ... etc
+```
+
+### 2.4 Migration Strategy for CRUD Files
+
+**Approach:** Incremental, file-by-file. No big bang.
+
+**Priority order** (highest-traffic and most SQLite-specific first):
+1. `memory_metadata.py` — FTS5 queries, heaviest traffic
+2. `knowledge_units.py` — FTS5 queries
+3. `observations.py` — high traffic, JSON operations
+4. `ego_proposals.py` — ego-critical path
+5. `cc_sessions.py` — high traffic
+6. Remaining 50 files — as touched for other work
+
+**Per-file migration steps:**
+1. Replace `aiosqlite.connect(DB_PATH)` with adapter injection
+2. Convert `?` params to `:name` params
+3. Replace `INSERT OR IGNORE` with `adapter.upsert_clause()`
+4. Replace `json_extract()` with `adapter.json_get()`
+5. Test that existing behavior is preserved
+
+**Estimated effort per file:** 30-60 minutes for simple files, 2-4 hours for
+FTS-heavy files.
+
+### 2.5 FTS5 Abstraction
+
+The most important dialect-specific abstraction. FTS5 is used in two places:
+
+1. `memory_fts` — 27K rows, used in hybrid search (FTS5 + Qdrant + RRF)
+2. `knowledge_fts` — 1.7K rows, used in knowledge recall
+
+**Interface:**
+
+```python
+class TextSearchProvider(Protocol):
+    """Full-text search abstraction."""
+
+    async def search(self, query: str, table: str,
+                     limit: int = 20) -> list[TextSearchResult]:
+        """Search with BM25 ranking. Returns scored results."""
+        ...
+
+    async def index(self, doc_id: str, content: str, table: str) -> None:
+        """Add or update a document in the search index."""
+        ...
+
+    async def delete(self, doc_id: str, table: str) -> None:
+        """Remove a document from the search index."""
+        ...
+```
+
+**SQLite implementation:** Uses FTS5 MATCH + bm25(). Wraps `_prepare_fts5()`.
+**Future Postgres implementation:** Uses `tsvector`/`tsquery` + `ts_rank()`.
+
+This abstraction isolates the ~8 FTS-specific queries in the codebase behind
+a clean interface. The memory retrieval pipeline (`memory_recall`) calls
+`TextSearchProvider.search()` instead of raw FTS5 SQL.
+
+### 2.6 Other Groundwork Items
+
+**PRAGMA consolidation:**
+Move all SQLite PRAGMAs into `SQLiteAdapter.__init__()`:
+- `PRAGMA journal_mode=WAL`
+- `PRAGMA foreign_keys=ON`
+- `PRAGMA busy_timeout=5000`
+- `PRAGMA wal_checkpoint(PASSIVE)` (awareness loop)
+
+Currently scattered across ~10 files. Centralizing them means a future
+`PostgresAdapter` simply doesn't set them.
+
+**Migration runner:**
+Update `src/genesis/db/migrations/runner.py` to accept a `DatabaseAdapter`
+instead of raw aiosqlite connection. Replace `BEGIN IMMEDIATE` with
+`adapter.transaction()`. Replace `PRAGMA table_info()` with
+`adapter.table_exists()` / `adapter.column_exists()`.
+
+**Backup scripts:**
+No change needed now. When/if Postgres migration happens, swap
+`sqlite3 .dump` for `pg_dump`. Trivial.
+
+### 2.7 What This Does NOT Do
+
+- Does NOT migrate Genesis to Postgres (that's a separate future decision)
+- Does NOT change the database schema
+- Does NOT affect runtime behavior — same queries, same results, same perf
+- Does NOT add Postgres as a dependency
+- Does NOT touch Qdrant or the vector search pipeline
+
+### 2.8 Success Criteria
+
+**Phase 1:**
+- Honcho API + Deriver + Postgres running as systemd services
+- Foreground session transcripts flowing to Honcho after each session
+- `user_model_query` MCP tool functional (can ask questions about the user)
+- Ego context includes Honcho peer representation
+- Honcho dream cycle running on configured schedule
+- No degradation to existing Genesis functionality
+
+**Phase 2:**
+- DatabaseAdapter Protocol defined and SQLiteAdapter implemented
+- TextSearchProvider Protocol defined and FTS5SearchProvider implemented
+- At least the top 5 highest-traffic CRUD files migrated to adapter
+- All PRAGMAs consolidated into adapter init
+- All existing tests pass unchanged
+- Migration runner accepts adapter
+
+---
+
+## Sequencing
+
+| Phase | Effort | Dependencies |
+|-------|--------|-------------|
+| 1a: Install Honcho services | 1 day | None |
+| 1b: Transcript pipeline (Genesis → Honcho) | 2-3 days | 1a |
+| 1c: MCP tool + ego context integration | 2 days | 1a |
+| 1d: Session prewarm + configuration | 1 day | 1b, 1c |
+| 2a: Adapter interface + SQLiteAdapter | 2-3 days | None (parallel with 1) |
+| 2b: FTS abstraction | 2-3 days | 2a |
+| 2c: PRAGMA consolidation + migration runner | 1 day | 2a |
+| 2d: Incremental CRUD migration (top 5 files) | 3-5 days | 2a |
+
+**Total Phase 1:** ~1 week
+**Total Phase 2:** ~2 weeks (can overlap with Phase 1)
+
+---
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| Honcho deriver LLM costs accumulate | Medium | Use cheapest viable model; gate on session length (skip trivial sessions) |
+| Dual user models (Genesis + Honcho) diverge | Low | Monitor divergence; consolidation is a future option, not a requirement |
+| Postgres adds operational burden | Low | Single-purpose (Honcho only); automated backups via cron |
+| Adapter migration introduces regressions | Medium | File-by-file with existing test coverage; no behavioral changes |
+| FTS5 abstraction performance regression | Medium | Benchmark before/after; the abstraction is a thin wrapper, not a rewrite |
+| Honcho upstream breaking changes | Low | Pin version; evaluate upgrades deliberately |
+
+---
+
+## Decision Record
+
+- **Honcho as separate service, not embedded:** Avoids Postgres migration for
+  Genesis core. Same pattern as Qdrant. Clean service boundary.
+- **Supplement, not replace:** Honcho adds to Genesis's user modeling; does not
+  replace existing memory/observation systems. Consolidation is a future
+  evaluation, not a commitment.
+- **Adapter, not ORM:** Thin interface preserves hand-written SQL (well-optimized,
+  well-understood) while enabling engine portability. ORM rewrite would be
+  multi-week with uncertain benefit.
+- **Qdrant stays:** Qdrant and pgvector serve different purposes (Genesis memories
+  vs Honcho user observations). No consolidation needed or planned.
+- **Incremental migration:** CRUD files migrate to adapter one at a time, not
+  big-bang. Reduces risk, allows course correction.

--- a/docs/superpowers/specs/2026-05-29-memory-retrieval-quality-design.md
+++ b/docs/superpowers/specs/2026-05-29-memory-retrieval-quality-design.md
@@ -1,0 +1,661 @@
+# Design Spec: Memory Retrieval Quality + Graph Wiring + Dream Cycle Enhancement
+
+**Date:** 2026-05-29
+**Status:** Draft
+**Source:** Inbox review session — GBrain analysis, Iusztin entity resolution
+posts, agent product analytics, Honcho observation patterns
+**Scope:** Wire existing graph infrastructure into retrieval, extend dream
+cycle, add entity resolution, establish retrieval quality metrics
+
+---
+
+## Context
+
+Genesis has substantial graph infrastructure (77K edges, NetworkX, 11 typed
+relationships, centrality computation, BFS traversal) that is NOT used in
+the retrieval hot path. GBrain's backlink-boosted ranking produces a
++31.4 P@5 improvement — the single largest quality signal in their system —
+using the same pattern Genesis could implement with existing data.
+
+Additionally, Genesis's dream cycle runs a single consolidation phase while
+GBrain runs 17 phases covering link repair, orphan detection, theme
+discovery, and entity enrichment. Genesis detects only 2 contradictions out
+of 77K edges, meaning the system is essentially blind to conflicting
+information in its own memory.
+
+This spec covers the concrete wiring and enhancement work identified during
+the 2026-05-29 inbox evaluation review.
+
+---
+
+## Part 1: Graph-Boosted Retrieval
+
+### 1.1 Backlink Boost
+
+**What:** After RRF fusion produces ranked results, multiply each result's
+score by a factor derived from its inbound link count in `memory_links`.
+
+**Formula** (from GBrain, validated at +31.4 P@5):
+```python
+BACKLINK_BOOST_COEF = 0.05
+boosted_score = score * (1 + BACKLINK_BOOST_COEF * math.log(1 + inbound_link_count))
+```
+
+This is logarithmic — diminishing returns at high link counts:
+- 0 links: 1.00x (no change)
+- 5 links: 1.09x
+- 10 links: 1.12x
+- 50 links: 1.20x
+- 100 links: 1.23x
+
+**Where:** `src/genesis/memory/retrieval.py`, after RRF fusion (step 7 in
+the current pipeline), before final ranking.
+
+**Implementation:**
+1. After collecting all candidate memory_ids from RRF, batch-query inbound
+   link counts:
+   ```sql
+   SELECT target_id, COUNT(*) as link_count
+   FROM memory_links
+   WHERE target_id IN (?, ?, ...)
+   GROUP BY target_id
+   ```
+2. Apply boost formula to each candidate's fused score.
+3. Re-sort by boosted score.
+
+**Estimated effort:** ~50 lines. The SQL query is trivial, the boost is one
+line per result.
+
+**Implementation note (Sprint 1):** Also fixed the N+1 per-ID
+`count_links()` loop in activation scoring (step 5) by introducing
+`batch_link_counts()` which returns both bidirectional and inbound-only
+counts in 2 batch queries instead of N individual queries. Inbound counts
+are then reused for the backlink boost in step 7b. Chunks at 400 IDs for
+SQLite placeholder safety. Link distribution validated: median inbound=3,
+99th pct=39, max outlier=1680 (37% boost with log dampening).
+
+### 1.2 Adjacency Boost
+
+**What:** If multiple top-K results link to each other (graph cluster
+coherence), give a small boost. This rewards results that form a coherent
+knowledge cluster rather than isolated hits.
+
+**Formula:**
+```python
+ADJACENCY_BOOST = 1.05  # 5% bump
+# For each result in top-K:
+#   Count how many OTHER top-K results link to it
+#   If >= 2, apply boost
+```
+
+**Where:** Same location as backlink boost, applied after backlink boost.
+
+**Implementation:**
+1. Take top-K results (K=20)
+2. For each, check if ≥2 other top-K results have edges to it in
+   `memory_links`
+3. If yes, multiply score by 1.05
+
+**Estimated effort:** ~30 lines. Uses the same link data already loaded.
+
+### 1.3 Floor-Gated Boost Stacking
+
+**What:** Prevent weak results from accumulating boosts past legitimate hits.
+Results below a floor threshold skip ALL boost stages.
+
+**Formula:**
+```python
+FLOOR_RATIO = 0.85
+floor_score = top_score * FLOOR_RATIO
+# Skip boosts for any result with pre-boost score < floor_score
+```
+
+**Why:** Without floor gating, a low-relevance memory with 100 backlinks
+could boost past a high-relevance memory with 0 backlinks. The floor ensures
+retrieval relevance always dominates structural signals.
+
+**Where:** Computed once before applying any boosts. Applied as a guard
+condition around backlink + adjacency boosts.
+
+**Estimated effort:** ~10 lines.
+
+### 1.4 Centrality Wiring (Deferred)
+
+`centrality_scores()` already exists in `graph.py` but computing betweenness
+centrality on 77K edges is expensive (~200-500ms even with k-approximation).
+This should NOT be in the retrieval hot path.
+
+**Alternative:** Pre-compute centrality scores periodically (dream cycle or
+awareness tick), store in a `memory_centrality` table or as metadata on
+`memory_metadata`. Use pre-computed values as an additional boost factor in
+retrieval — same pattern as activation scoring.
+
+**Deferred to Part 3** (dream cycle enhancement).
+
+---
+
+## Part 2: Entity Resolution
+
+### 2.1 Surface Form Resolution (Layer 1 — At Ingestion)
+
+**What:** Normalize entity names to canonical forms before storage.
+
+**Implementation:**
+1. Maintain an alias dictionary in `~/.genesis/config/entity_aliases.yaml`:
+   ```yaml
+   aliases:
+     "CC": "Claude Code"
+     "claude-code": "Claude Code"
+     "LLM": "large language model"
+     "SK": "SkillOpt"
+   ```
+2. In `memory_store` and `knowledge_ingest_source`, run content through
+   a normalization step that expands known aliases.
+3. The dictionary grows over time — dream cycle discovers new aliases.
+
+**Where:** New function in `src/genesis/memory/entity_resolution.py`.
+Called from `store.py` before Qdrant upsert.
+
+**Estimated effort:** ~60 lines + config file.
+
+### 2.2 Deduplication Scan (Layer 2 — Periodic)
+
+**What:** Find near-duplicate memories using embedding similarity + graph
+structure + content overlap. Apply confidence-tiered merge decisions.
+
+**Implementation:**
+1. Query Qdrant for high-similarity pairs (cosine > 0.92) in each collection
+2. For each candidate pair:
+   a. Check if they share `supports`/`related_to` links (graph signal)
+   b. Compare content for semantic overlap (quick LLM check)
+   c. Score confidence:
+      - ≥0.95: Auto-merge (keep newer, soft-delete older, preserve links)
+      - >0.85: Flag as observation for review
+      - ≤0.85: Ignore (similar but distinct)
+3. Log decisions for audit trail
+
+**Where:** New function in `src/genesis/memory/entity_resolution.py`.
+Called from dream cycle (Part 3).
+
+**Estimated effort:** ~150 lines.
+
+### 2.3 Contradiction Detection
+
+**What:** Find memories that contradict each other. Currently 2 out of 77K
+links are `contradicts` type — the system is essentially blind.
+
+**Implementation:**
+1. During dedup scan, when two memories are about the same topic but contain
+   conflicting claims, create a `contradicts` link
+2. Contradiction criteria:
+   - High embedding similarity (>0.85) — same topic
+   - Different or opposing content (LLM classification)
+   - Different timestamps — temporal resolution possible
+3. For temporal contradictions (e.g., "cost is $200/mo" vs "cost is $231/mo"),
+   the newer memory supersedes — mark the older as `succeeded_by`
+
+**Where:** Same module as dedup scan. Integrated into dream cycle.
+
+**Estimated effort:** ~100 lines (the LLM call is the same as dedup
+assessment, just with a different decision branch).
+
+---
+
+## Part 3: Dream Cycle Enhancement
+
+### 3.1 Current State
+
+Genesis's dream cycle runs one phase: semantic clustering + consolidation.
+GBrain runs 17 phases. Genesis needs to add at minimum:
+
+### 3.2 New Phases
+
+**Phase 0: Link Repair (before consolidation)**
+- Check all `memory_links` for orphaned references (target_id points to
+  deleted or nonexistent memory)
+- Remove stale links
+- Check bidirectionality where appropriate (if A `supports` B, should B
+  `supported_by` A?)
+
+**Phase 1: Existing Consolidation (unchanged)**
+- Semantic clustering + LLM synthesis
+- Already works. No changes needed.
+
+**Phase 2: Entity Resolution Scan**
+- Run Layer 2 dedup (2.2 above) on memories modified since last dream
+- Run contradiction detection (2.3 above)
+- Discover new aliases for Layer 1 dictionary
+
+**Phase 3: Orphan Detection**
+- Find memories with zero inbound AND zero outbound links
+- These are "islands" — potentially valuable but disconnected from the graph
+- For each orphan, attempt to discover connections via embedding similarity
+  to linked memories
+- If connections found, create links. If not, flag for review.
+
+**Phase 4: Centrality Recomputation**
+- Run `centrality_scores()` (already built)
+- Store results in `memory_metadata` or a dedicated table
+- These pre-computed scores feed into Part 1's retrieval boost
+
+**Phase 5: Theme Discovery (Future)**
+- Cross-session pattern identification
+- Find concepts that appear across many sessions but aren't explicitly linked
+- Create `categorized_as` links to discovered themes
+- This is the most complex phase — defer to a later sprint
+
+### 3.3 Phase Coordination
+
+- Add phase tracking to dream cycle: `dream_phase` column or metadata
+- Each phase runs sequentially with error isolation (one phase failing
+  doesn't block others)
+- Log phase timing for observability
+- Advisory-style lock to prevent concurrent dream cycles
+
+### 3.4 Tiered Enrichment by Reference Count
+
+**What:** Entities (people, tools, concepts) referenced frequently across
+memories deserve more enrichment than one-off mentions.
+
+**Implementation:**
+- Count references per entity across `memory_links` (inbound degree)
+- Tier 1 (≥8 references): Full enrichment — web research, entity page,
+  comprehensive profile
+- Tier 2 (3-7 references): Light enrichment — basic profile, key facts
+- Tier 3 (1-2 references): Stub only — name and context of first mention
+
+**Where:** Dream cycle Phase 2 or a separate surplus task.
+
+**Estimated effort:** ~100 lines for the tiering logic. Enrichment actions
+use existing web_search/web_fetch infrastructure.
+
+---
+
+## Part 4: Retrieval Quality Metrics
+
+### 4.1 Retrieval Audit Trail
+
+**What:** Log every `memory_recall` query with its parameters and result
+summary. This is the prerequisite for any quality improvement loop.
+
+**Implementation decision (Sprint 1):** No new `recall_audit` table needed.
+The J-9 eval hooks (`emit_recall_fired` in `src/genesis/eval/j9_hooks.py`)
+already capture recall events with query, result_count, top_scores,
+memory_ids, latency_ms, source, and intent_category into the generic
+`eval_events` table. Sprint 1 extended `emit_recall_fired` with three
+additional optional fields:
+- `graph_boost_applied: bool` — whether backlink/adjacency boosts fired
+- `mean_score: float` — average score across returned results
+- `wing: str` — the wing filter if one was applied
+
+This avoids table proliferation while providing all the data needed for
+quality analysis. Re-query detection (4.2) and benchmarking (4.3) can
+query the existing `eval_events` table filtered by `event_type='recall_fired'`.
+
+### 4.2 Re-Query Detection
+
+**What:** Detect when the user asks the same question differently — a signal
+that the first recall failed.
+
+**Implementation:**
+- After each recall, compute embedding of the query
+- Compare against recent queries (last 10 minutes) in `recall_audit`
+- If cosine similarity > 0.85 to a recent query, flag as "re-query" —
+  the previous recall probably failed to satisfy
+- Store the re-query flag in the audit trail
+
+**Where:** Same as audit trail, with a Qdrant similarity check added.
+
+**Estimated effort:** ~30 lines.
+
+### 4.3 Quality Benchmarking (Future)
+
+**What:** Establish P@5 and R@5 benchmarks for Genesis retrieval.
+
+**Implementation:**
+- Build a test set: 50+ query/expected-result pairs from real usage
+- Run retrieval against test set periodically (weekly)
+- Track precision@5 and recall@5 over time
+- Alert on regression
+
+**Deferred:** This requires curating a test set, which is manual work. The
+audit trail (4.1) provides the raw data to build the test set from. Do 4.1
+first, then build the benchmark from the accumulated data.
+
+---
+
+## Part 5: Visual Content Generation
+
+### 5.1 HTML/CSS + Playwright Screenshots
+
+**What:** Generate branded visual content (header images, social cards, quote
+cards, infographics) for the content pipeline using existing dependencies.
+
+**Dependencies already installed:** Playwright 1.58, Pillow, CairoSVG,
+Jinja2, Chrome. Zero new dependencies needed.
+
+**Implementation:**
+1. Create `src/genesis/modules/content_pipeline/visuals/` package
+2. Jinja2 templates for each content type:
+   - Medium header (1500x750)
+   - LinkedIn post image (1200x627)
+   - OG/social card (1200x630)
+   - Quote card
+   - Comparison table
+3. Renderer function:
+   ```python
+   async def render_visual(template: str, context: dict,
+                           width: int, height: int) -> bytes:
+       async with async_playwright() as p:
+           browser = await p.chromium.launch(headless=True)
+           page = await browser.new_page(viewport={"width": width, "height": height})
+           html = jinja_env.get_template(template).render(**context)
+           await page.set_content(html)
+           screenshot = await page.screenshot(type="png")
+           await browser.close()
+           return screenshot
+   ```
+4. Integration point in `ScriptEngine`: after drafting text, generate
+   visuals alongside
+
+**Estimated effort:** ~200 lines + template files.
+
+---
+
+## Part 6: Voice Channel (Vapi)
+
+### 6.1 Architecture
+
+**What:** Add voice/phone calls as a Genesis communication channel via Vapi.
+
+```
+Genesis outreach_send(channel="voice", ...)
+    └── VapiAdapter (new)
+        ├── Outbound: Vapi REST API + Claude as LLM brain
+        ├── Inbound: Vapi webhook → Genesis endpoint → dynamic config
+        └── Call events/transcripts → event bus → memory
+```
+
+**Why Vapi:** BYO LLM (Genesis uses Claude as the call brain — same memory,
+same personality), API-first, $0.05/min + provider costs, startup grant
+(90K free minutes).
+
+**Implementation:**
+1. `src/genesis/channels/voice/adapter.py` — VapiAdapter alongside
+   TelegramAdapter and DashboardAdapter
+2. Outbound call function: `POST /call` with recipient + assistant config
+3. Inbound webhook handler: return assistant config dynamically
+4. Transcript capture: call events → `memory_store` as episodic memories
+5. Configuration in `genesis.yaml`:
+   ```yaml
+   voice:
+     enabled: true
+     provider: vapi
+     api_key: ${VAPI_API_KEY}
+     phone_number: "+1XXXXXXXXXX"
+     default_assistant:
+       model: claude-sonnet-4-6
+       system_prompt_source: SOUL.md
+   ```
+
+**Estimated effort:** ~300 lines + Vapi account setup.
+
+---
+
+## Part 7: Post-Dispatch Verification (Ego)
+
+### 7.1 Level 1 — Shell Verification
+
+**What:** After ego_executor dispatches a session and it completes, run
+machine-verifiable checks before marking the proposal as executed. Currently
+the ego trusts self-reported session status — zero-output sessions get
+marked "complete" with no verification.
+
+**Source:** Codex/CC/Hermes verification pattern (inbox Genesis-33). The
+principle: "if you can't verify it from a shell, it isn't done."
+
+**Implementation:**
+1. Before dispatch, define expected outputs in proposal metadata:
+   ```python
+   expected_outputs = {
+       "files": ["/path/to/expected/output.md"],
+       "min_size_bytes": 500,
+       "required_strings": ["## Summary"],  # optional
+   }
+   ```
+2. After dispatch completes, run verification:
+   ```python
+   async def verify_dispatch_output(proposal) -> VerificationResult:
+       for f in proposal.expected_outputs.get("files", []):
+           if not Path(f).exists():
+               return VerificationResult(passed=False, reason=f"Missing: {f}")
+           size = Path(f).stat().st_size
+           if size < proposal.expected_outputs.get("min_size_bytes", 0):
+               return VerificationResult(passed=False, reason=f"Too small: {size}B")
+       return VerificationResult(passed=True)
+   ```
+3. If verification fails, mark proposal as `failed` (not `executed`),
+   create an observation with the failure reason, and surface in next
+   ego cycle.
+
+**Where:**
+- `src/genesis/ego/session.py` — add `expected_outputs` to execution brief
+- `src/genesis/cc/direct_session.py` — add verification step after session
+  completion, before updating proposal status
+
+**Implementation note (Sprint 1):** `expected_outputs` is a dedicated
+TEXT column on `ego_proposals` (not inside `execution_plan`, which is
+always a plain string like "background CC, ~$0.50"). Added via
+`_try_alter` migration. Verification module at
+`src/genesis/ego/verification.py`. Wired into
+`_record_proposal_outcome()` — runs after session success, before
+recording outcome. Failed verification transitions proposal from
+'executed' to 'failed' via `mark_proposal_verification_failed()`.
+
+**Estimated effort:** ~100 lines (actual: ~180 lines across module + CRUD + wiring).
+
+### 7.2 Level 2 — Cross-Model Review (Future)
+
+Wire Codex CLI for independent review of dispatch outputs. Genesis already
+has the `codex` skill infrastructure. After Level 1 verification passes,
+optionally dispatch Codex for an independent quality check on the output.
+Different model, different blind spots.
+
+**Deferred to after Level 1 is validated in production.**
+
+---
+
+## Part 8: Content Pipeline Enhancements
+
+### 8.1 Content Repurposing Skill
+
+**What:** Take one piece of content (e.g., a Medium article) and
+automatically generate derivative content for other platforms with
+appropriate format and tone.
+
+**Transformations:**
+- Medium article → LinkedIn post (hook + 3-4 key insights + CTA)
+- Medium article → Tweet/thread (punchy, conversational, thread structure)
+- Medium article → Newsletter excerpt (personal tone, "here's what I found")
+
+**Implementation:**
+1. New skill: `src/genesis/skills/content_repurpose/SKILL.md`
+2. Input: source content + target platform
+3. Output: platform-adapted version following voice-master conventions
+4. Templates per platform defining structure, length, tone shift
+
+**Estimated effort:** ~150 lines (skill file + templates).
+
+### 8.2 Audience Segmentation in Drafting
+
+**What:** Content pipeline maintains audience personas and adapts
+tone/depth per platform automatically.
+
+**Implementation:**
+- Define personas in config: `technical` (developers, deep detail),
+  `business` (decision-makers, outcomes-focused), `general` (accessible)
+- Platform → persona mapping: Medium=technical, LinkedIn=business
+- ScriptEngine includes persona context in drafting prompt
+
+**Estimated effort:** ~50 lines (config + prompt modification).
+
+---
+
+## Part 9: Skill Evolution — Validation Gate + Routing Fixtures
+
+### 9.1 Validation Gate (from SkillOpt)
+
+**What:** Every proposed skill edit is tested on a validation set BEFORE
+being accepted. Rejection is the default — prove improvement or revert.
+
+**Implementation:**
+1. Each skill gets a `validation/` directory with 5-15 test tasks
+2. New `src/genesis/learning/skills/gate.py`:
+   ```python
+   def evaluate_gate(candidate_score, current_score, best_score):
+       if candidate_score > best_score:
+           return GateResult(action="accept_new_best")
+       elif candidate_score > current_score:
+           return GateResult(action="accept")
+       else:
+           return GateResult(action="reject")
+   ```
+3. New `src/genesis/learning/skills/harness.py` — execution harness that
+   runs a skill against validation tasks via `direct_session_run`
+4. Modify `applicator.py`: insert gate between validation and apply
+
+**Estimated effort:** ~300 lines + validation task definitions.
+
+### 9.2 Rejection Memory (Step Buffer)
+
+**What:** Persist rejected proposals as observations so the refiner doesn't
+propose the same ineffective changes next week.
+
+**Implementation:**
+- On rejection, write observation:
+  `type="skill_evolution_rejected"`, content=proposal summary + rejection reason
+- Feed recent rejected observations into the refiner prompt as context
+
+**Estimated effort:** ~30 lines.
+
+### 9.3 Routing-Eval Fixtures (from GBrain)
+
+**What:** Each skill ships with test cases that verify it triggers for the
+right queries. CI-verifiable skill routing.
+
+**Implementation:**
+- `routing-eval.jsonl` per skill: `{"query": "...", "should_trigger": true}`
+- Test runner checks that the skill injection hook correctly matches/doesn't
+  match each query
+
+**Estimated effort:** ~50 lines + fixture files.
+
+---
+
+## Part 10: Distribution & Surplus Routing
+
+### 10.1 Public MCP Server Spec (Marketing/Distribution)
+
+**What:** Define a public-facing Genesis MCP server spec that any Claude Code
+or Cursor session could connect to. Turns Genesis from "install and run" to
+"connect and use."
+
+**Capability tiers:**
+- Read-only (low trust): `web_search`, `web_fetch`, `knowledge_recall`
+- Memory (medium trust): `memory_store`, `memory_recall`
+- Outreach (high trust, gated): `outreach_send`, `outreach_queue`
+- Autonomy (highest trust): `task_submit`
+
+**Deferred:** This is a marketing/distribution decision, not a development
+one. Track for the GTM campaign. No implementation needed yet — Genesis
+already has the MCP infrastructure internally.
+
+### 10.2 Surplus Free-Tier Routing
+
+**What:** Add Mistral's free tier and/or Cloudflare Workers AI to surplus
+task routing. Genesis runs ~60 surplus tasks/day — routing appropriate ones
+through free-tier models reduces cost.
+
+**Investigation needed:**
+- Mistral free tier: ~1B tokens/month, quality sufficient for surplus
+  summarization and analysis
+- Cloudflare Workers AI: ~20M tokens/month
+- Per-provider budget tracking (pattern from FreeLLMAPI) to stay within
+  free-tier limits
+
+**Implementation:** Add providers to `model_routing.yaml` with surplus-only
+routing rules. Add token budget tracking per provider per day.
+
+**Estimated effort:** ~100 lines (routing config + budget tracker).
+
+---
+
+## Sequencing
+
+### Sprint 1: Graph-Boosted Retrieval + Post-Dispatch Verification (2-3 days)
+- 1.1 Backlink boost (~50 lines)
+- 1.2 Adjacency boost (~30 lines)
+- 1.3 Floor-gated boost stacking (~10 lines)
+- 4.1 Retrieval audit trail (~40 lines)
+- 7.1 Post-dispatch shell verification (~100 lines)
+- Test: verify retrieval quality improves on sample queries; verify
+  dispatch verification catches zero-output sessions
+
+### Sprint 2: Dream Cycle Enhancement + Entity Resolution (3-4 days)
+- 3.2 Phase 0: Link repair
+- 3.2 Phase 2: Entity resolution scan (2.2 + 2.3)
+- 3.2 Phase 3: Orphan detection
+- 3.2 Phase 4: Centrality recomputation
+- 2.1 Surface form resolution at ingestion
+- Test: run enhanced dream cycle, verify new phases complete
+
+### Sprint 3: Skill Evolution Quality (2-3 days)
+- 9.1 Validation gate + execution harness
+- 9.2 Rejection memory (step buffer)
+- 9.3 Routing-eval fixtures for top 5 skills
+- Test: propose a skill change, verify gate accepts/rejects correctly
+
+### Sprint 4: Content Pipeline (3-4 days)
+- 5.1 Visual templates + Playwright renderer
+- 8.1 Content repurposing skill
+- 8.2 Audience segmentation
+- Integration with ScriptEngine
+- Test: generate Medium article with header image + LinkedIn derivative
+
+### Sprint 5: Voice Channel (2-3 days)
+- 6.1 VapiAdapter
+- Outbound/inbound call handling
+- Transcript capture
+- Test: make a test call with Genesis brain
+
+### Sprint 6: Surplus Optimization (1-2 days)
+- 10.2 Add Mistral free tier + Cloudflare Workers AI to surplus routing
+- Per-provider token budget tracking
+- Test: verify surplus tasks route to free tier and stay within limits
+
+### Parallel workstreams:
+- Honcho integration (separate spec: 2026-05-29-honcho-integration-db-adapter-design.md)
+- DB adapter + Postgres groundwork (same spec as Honcho)
+- Retrieval quality metrics (4.2 re-query detection, 4.3 benchmarking)
+- Public MCP server spec (10.1 — marketing/distribution, no code needed yet)
+
+---
+
+## Success Criteria
+
+- **Retrieval:** Backlink boost measurably improves result quality on sample
+  queries (A/B comparison with audit trail data)
+- **Post-dispatch:** Shell verification catches at least one zero-output
+  dispatch session that would have been marked "complete" without it
+- **Dream cycle:** All new phases complete without error; contradiction
+  detection finds >0 contradictions; orphan detection identifies disconnected
+  memories
+- **Entity resolution:** Dedup scan quantifies duplication rate; auto-merges
+  at ≥0.95 confidence work correctly
+- **Skill evolution:** Validation gate correctly rejects at least one
+  proposal that would have auto-applied under the old system
+- **Content pipeline:** Produces Medium article with branded header image +
+  auto-generated LinkedIn post derivative
+- **Voice:** Outbound test call completes with Genesis as conversation brain
+- **Surplus:** Free-tier routing reduces surplus task cost by ≥30%
+- **Audit:** 30 days of retrieval audit data accumulated for quality analysis

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -458,11 +458,51 @@ class DirectSessionRunner:
             return
         proposal_id = request.caller_context.split(":", 1)[1]
         try:
-            from genesis.db.crud.ego import update_proposal_outcome
+            from genesis.db.crud.ego import (
+                mark_proposal_verification_failed,
+                update_proposal_outcome,
+            )
 
             db = getattr(self._rt, "_db", None)
             if db is None:
                 return
+
+            # Post-dispatch verification: if the session succeeded and the
+            # proposal defines expected_outputs, verify deliverables before
+            # recording the outcome.
+            if result.success:
+                verification_failed = await self._verify_proposal_outputs(
+                    db, proposal_id,
+                )
+                if verification_failed:
+                    # Mark as failed + store observation; skip normal outcome
+                    await mark_proposal_verification_failed(
+                        db, proposal_id, summary=verification_failed,
+                    )
+                    try:
+                        store = getattr(self._rt, "_memory_store", None)
+                        if store is not None:
+                            await store.store(
+                                content=(
+                                    f"Ego dispatch VERIFICATION FAILED for "
+                                    f"proposal {proposal_id}: {verification_failed}"
+                                ),
+                                source="ego_dispatch_verification",
+                                tags=["ego", "verification_failure"],
+                                memory_type="episodic",
+                                wing="autonomy",
+                                room="ego",
+                            )
+                    except Exception:
+                        logger.debug(
+                            "Failed to store verification observation",
+                            exc_info=True,
+                        )
+                    await self._notify_dispatch_debrief(
+                        proposal_id, request, result,
+                    )
+                    return
+
             summary = (result.output_text or result.error or "")[:1000]
             await update_proposal_outcome(
                 db, proposal_id, success=result.success, summary=summary,
@@ -492,6 +532,37 @@ class DirectSessionRunner:
             )
         # Debrief is best-effort, fully self-contained (own try/except)
         await self._notify_dispatch_debrief(proposal_id, request, result)
+
+    async def _verify_proposal_outputs(
+        self,
+        db: object,
+        proposal_id: str,
+    ) -> str | None:
+        """Check expected outputs for a completed proposal.
+
+        Returns a failure summary string if verification fails,
+        or ``None`` if verification passes or is not configured.
+        """
+        try:
+            from genesis.db.crud.ego import get_proposal
+            from genesis.ego.verification import parse_expected_outputs, verify_outputs
+
+            proposal = await get_proposal(db, proposal_id)
+            if not proposal:
+                return None
+            expected = parse_expected_outputs(proposal.get("expected_outputs"))
+            if expected is None:
+                return None  # no verification configured
+            result = verify_outputs(expected)
+            if not result.passed:
+                return "; ".join(result.failures)
+        except Exception:
+            logger.warning(
+                "Post-dispatch verification error for %s (skipping)",
+                proposal_id,
+                exc_info=True,
+            )
+        return None
 
     async def _notify_dispatch_debrief(
         self,

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -301,6 +301,7 @@ async def create_proposal(
     content_hash: str | None = None,
     content_size: int | None = None,
     original_content: str | None = None,
+    expected_outputs: str | None = None,
 ) -> str:
     """Insert a new ego proposal. Returns the id."""
     if created_at is None:
@@ -311,8 +312,10 @@ async def create_proposal(
             confidence, urgency, alternatives, status, cycle_id,
             batch_id, created_at, expires_at, rank, execution_plan,
             recurring, memory_basis, realist_verdict, realist_reasoning,
-            ego_source, goal_id, content_hash, content_size, original_content)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ego_source, goal_id, content_hash, content_size,
+            original_content, expected_outputs)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                   ?, ?)""",
         (
             id,
             action_type,
@@ -338,6 +341,7 @@ async def create_proposal(
             content_hash,
             content_size,
             original_content,
+            expected_outputs,
         ),
     )
     await db.commit()
@@ -468,6 +472,29 @@ async def update_proposal_outcome(
     suffix = f"|{'completed' if success else 'failed'}:{summary[:1000]}"
     cursor = await db.execute(
         "UPDATE ego_proposals SET user_response = COALESCE(user_response, '') || ? "
+        "WHERE id = ? AND status = 'executed'",
+        (suffix, proposal_id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def mark_proposal_verification_failed(
+    db: aiosqlite.Connection,
+    proposal_id: str,
+    *,
+    summary: str,
+) -> bool:
+    """Transition an executed proposal to 'failed' after verification failure.
+
+    Called when post-dispatch output verification detects missing or
+    insufficient deliverables. Distinct from :func:`update_proposal_outcome`
+    which appends outcome text but keeps status as 'executed'.
+    """
+    suffix = f"|verification_failed:{summary[:1000]}"
+    cursor = await db.execute(
+        "UPDATE ego_proposals SET status = 'failed', "
+        "user_response = COALESCE(user_response, '') || ? "
         "WHERE id = ? AND status = 'executed'",
         (suffix, proposal_id),
     )

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -926,15 +926,21 @@ async def compute_vcr(
         if status in ("pending",):
             continue  # not yet resolved
         total_resolved += 1
+        resp = user_response or ""
         if status == "executed":
             total_executed += 1
-            resp = user_response or ""
             if "|completed:" in resp:
                 completed += 1
             elif "|failed:" in resp:
                 failed += 1
             else:
                 unknown += 1
+        elif status == "failed" and "|verification_failed:" in resp:
+            # Verification-failed proposals were dispatched (reached
+            # 'executed' before verification flipped them to 'failed').
+            # Count them as dispatch failures for VCR accuracy.
+            total_executed += 1
+            failed += 1
 
     vcr = completed / total_executed if total_executed > 0 else 0.0
     dispatch_rate = total_executed / total_resolved if total_resolved > 0 else 0.0

--- a/src/genesis/db/crud/memory_links.py
+++ b/src/genesis/db/crud/memory_links.py
@@ -107,10 +107,13 @@ async def inter_candidate_links(
     """Return all directed edges ``(source, target)`` between *memory_ids*.
 
     Used for adjacency boost: finding which candidates in a top-K set
-    link to each other.
+    link to each other. The query uses ``2 * len(memory_ids)``
+    placeholders, so callers must keep the list under ~499 IDs.
     """
     if not memory_ids:
         return []
+    if len(memory_ids) > 499:
+        memory_ids = memory_ids[:499]
     ph = ",".join("?" * len(memory_ids))
     cursor = await db.execute(
         f"SELECT source_id, target_id FROM memory_links"

--- a/src/genesis/db/crud/memory_links.py
+++ b/src/genesis/db/crud/memory_links.py
@@ -45,6 +45,81 @@ async def count_links(db: aiosqlite.Connection, memory_id: str) -> int:
     return row[0]
 
 
+async def batch_link_counts(
+    db: aiosqlite.Connection,
+    memory_ids: list[str],
+) -> dict[str, tuple[int, int]]:
+    """Batch-count links for multiple memory IDs.
+
+    Returns ``{memory_id: (total_links, inbound_links)}`` where:
+
+    * *total_links*: bidirectional count (source OR target) — same
+      semantics as :func:`count_links`.
+    * *inbound_links*: count of links where the memory is the **target**
+      only (a measure of importance/reference frequency).
+
+    Uses two batch queries instead of N individual ``count_links`` calls.
+    Chunks at 400 IDs per batch to stay within SQLite's 999-placeholder
+    limit (the bidirectional query doubles the placeholder count).
+    """
+    if not memory_ids:
+        return {}
+
+    _CHUNK = 400
+    total_map: dict[str, int] = {}
+    inbound_map: dict[str, int] = {}
+
+    for offset in range(0, len(memory_ids), _CHUNK):
+        chunk = memory_ids[offset : offset + _CHUNK]
+        ph = ",".join("?" * len(chunk))
+
+        # Bidirectional counts (replaces per-ID count_links loop)
+        cursor = await db.execute(
+            f"SELECT id, COUNT(*) FROM ("
+            f"  SELECT source_id AS id FROM memory_links WHERE source_id IN ({ph})"
+            f"  UNION ALL"
+            f"  SELECT target_id AS id FROM memory_links WHERE target_id IN ({ph})"
+            f") GROUP BY id",
+            chunk + chunk,
+        )
+        for row in await cursor.fetchall():
+            total_map[row[0]] = total_map.get(row[0], 0) + row[1]
+
+        # Inbound-only counts (for graph-boosted retrieval)
+        cursor = await db.execute(
+            f"SELECT target_id, COUNT(*) FROM memory_links"
+            f" WHERE target_id IN ({ph}) GROUP BY target_id",
+            chunk,
+        )
+        for row in await cursor.fetchall():
+            inbound_map[row[0]] = inbound_map.get(row[0], 0) + row[1]
+
+    return {
+        mid: (total_map.get(mid, 0), inbound_map.get(mid, 0))
+        for mid in memory_ids
+    }
+
+
+async def inter_candidate_links(
+    db: aiosqlite.Connection,
+    memory_ids: list[str],
+) -> list[tuple[str, str]]:
+    """Return all directed edges ``(source, target)`` between *memory_ids*.
+
+    Used for adjacency boost: finding which candidates in a top-K set
+    link to each other.
+    """
+    if not memory_ids:
+        return []
+    ph = ",".join("?" * len(memory_ids))
+    cursor = await db.execute(
+        f"SELECT source_id, target_id FROM memory_links"
+        f" WHERE source_id IN ({ph}) AND target_id IN ({ph})",
+        memory_ids + memory_ids,
+    )
+    return [(row[0], row[1]) for row in await cursor.fetchall()]
+
+
 async def get_bidirectional(db: aiosqlite.Connection, memory_id: str) -> list[dict]:
     """Get all links where memory_id is source or target (undirected query)."""
     return await get_links_for(db, memory_id)

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1228,6 +1228,11 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE ego_proposals ADD COLUMN content_size INTEGER",
         "ego_proposals.content_size")
 
+    # Post-dispatch verification: structured expected-outputs metadata
+    await _try_alter(db,
+        "ALTER TABLE ego_proposals ADD COLUMN expected_outputs TEXT",
+        "ego_proposals.expected_outputs")
+
     # surplus_tasks.not_before — existed in CREATE TABLE DDL but lacked
     # ALTER TABLE migration for installs created before the column was added.
     await _try_alter(db,

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -784,7 +784,8 @@ TABLES = {
             goal_id          TEXT,                    -- FK to user_goals.id (nullable — not all proposals serve a goal)
             content_hash     TEXT,                    -- SHA-256 of content at creation time
             content_size     INTEGER,                 -- byte count of content at creation time
-            original_content TEXT                     -- pre-realist-amendment content (NULL if not amended)
+            original_content TEXT,                    -- pre-realist-amendment content (NULL if not amended)
+            expected_outputs TEXT                     -- JSON: post-dispatch verification criteria (files, min_size, required_strings)
         )
     """,
     "ego_state": """

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -7,6 +7,7 @@ via TopicManager, and status resolution.
 from __future__ import annotations
 
 import html
+import json
 import logging
 import re
 import uuid
@@ -25,6 +26,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 TOPIC_CATEGORY = "ego_proposals"
+
+
+def _serialize_expected_outputs(raw: dict | str | None) -> str | None:
+    """Serialize expected_outputs from ego LLM output for DB storage.
+
+    Accepts a dict (from parsed LLM JSON) or a pre-serialized string.
+    Returns a JSON string or None.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        return json.dumps(raw)
+    if isinstance(raw, str):
+        return raw  # already serialized
+    return None
+
 
 # ---------------------------------------------------------------------------
 # Digest formatting
@@ -221,6 +238,9 @@ class ProposalWorkflow:
                 content_hash=_content_hash(proposal_content),
                 content_size=_content_size(proposal_content),
                 original_content=p.get("_original_content"),
+                expected_outputs=_serialize_expected_outputs(
+                    p.get("expected_outputs"),
+                ),
             )
             ids.append(pid)
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1631,6 +1631,28 @@ class EgoSession:
             f"\nRationale: {prop.get('rationale') or ''}",
         ]
 
+        # Post-dispatch verification context
+        eo_raw = prop.get("expected_outputs")
+        if eo_raw:
+            try:
+                import json as _json
+
+                parsed_eo = _json.loads(eo_raw) if isinstance(eo_raw, str) else eo_raw
+                if isinstance(parsed_eo, dict) and parsed_eo.get("files"):
+                    eo_lines = [
+                        "\nExpected outputs (auto-verified after completion):",
+                        f"  Files: {', '.join(parsed_eo['files'])}",
+                    ]
+                    if parsed_eo.get("min_size_bytes"):
+                        eo_lines.append(f"  Min size: {parsed_eo['min_size_bytes']} bytes")
+                    if parsed_eo.get("required_strings"):
+                        eo_lines.append(
+                            f"  Required content: {', '.join(parsed_eo['required_strings'])}"
+                        )
+                    parts.append("\n".join(eo_lines))
+            except (ValueError, TypeError):
+                pass
+
         # World model context — each section degrades independently
         try:
             from genesis.db.crud import user_goals

--- a/src/genesis/ego/verification.py
+++ b/src/genesis/ego/verification.py
@@ -78,7 +78,6 @@ def verify_outputs(expected: ExpectedOutputs) -> VerificationResult:
             failures.append(
                 f"File too small: {filepath} ({size}B < {expected.min_size_bytes}B)"
             )
-            continue
         if expected.required_strings:
             try:
                 content = path.read_text(errors="replace")

--- a/src/genesis/ego/verification.py
+++ b/src/genesis/ego/verification.py
@@ -1,0 +1,93 @@
+"""Post-dispatch output verification for ego proposals.
+
+After an ego-dispatched session completes, this module checks whether
+the expected deliverables actually exist and meet minimum criteria.
+Verification is opt-in: proposals without ``expected_outputs`` metadata
+skip verification entirely.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ExpectedOutputs:
+    """Structured verification criteria for dispatch deliverables."""
+
+    files: list[str]
+    min_size_bytes: int = 0
+    required_strings: list[str] = field(default_factory=list)
+
+
+@dataclass
+class VerificationResult:
+    """Outcome of a post-dispatch verification check."""
+
+    passed: bool
+    failures: list[str] = field(default_factory=list)
+
+
+def parse_expected_outputs(raw: str | None) -> ExpectedOutputs | None:
+    """Parse an ``expected_outputs`` JSON string into a typed object.
+
+    Returns ``None`` if the input is absent, empty, or malformed JSON.
+    This is the backward-compatibility gate: proposals without
+    ``expected_outputs`` simply skip verification.
+    """
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    files = data.get("files")
+    if not files or not isinstance(files, list):
+        return None
+    return ExpectedOutputs(
+        files=[str(f) for f in files],
+        min_size_bytes=int(data.get("min_size_bytes", 0)),
+        required_strings=list(data.get("required_strings") or []),
+    )
+
+
+def verify_outputs(expected: ExpectedOutputs) -> VerificationResult:
+    """Check file existence, size, and required content strings.
+
+    This is synchronous filesystem I/O — callers in async contexts should
+    wrap in ``asyncio.to_thread`` if latency is a concern. In practice
+    this runs after a multi-minute CC session, so the overhead is
+    negligible.
+    """
+    failures: list[str] = []
+
+    for filepath in expected.files:
+        path = Path(filepath)
+        if not path.exists():
+            failures.append(f"Missing file: {filepath}")
+            continue
+        size = path.stat().st_size
+        if size < expected.min_size_bytes:
+            failures.append(
+                f"File too small: {filepath} ({size}B < {expected.min_size_bytes}B)"
+            )
+            continue
+        if expected.required_strings:
+            try:
+                content = path.read_text(errors="replace")
+                for req in expected.required_strings:
+                    if req not in content:
+                        failures.append(
+                            f"Missing required string in {filepath}: {req!r}"
+                        )
+            except OSError as exc:
+                failures.append(f"Cannot read {filepath}: {exc}")
+
+    return VerificationResult(passed=len(failures) == 0, failures=failures)

--- a/src/genesis/eval/j9_hooks.py
+++ b/src/genesis/eval/j9_hooks.py
@@ -29,6 +29,9 @@ async def emit_recall_fired(
     mode: str | None = None,
     pipeline_used: str | None = None,
     intent_category: str | None = None,
+    graph_boost_applied: bool = False,
+    mean_score: float | None = None,
+    wing: str | None = None,
 ) -> str | None:
     """Log a memory recall() invocation as an eval event.
 
@@ -42,6 +45,7 @@ async def emit_recall_fired(
             "memory_ids": memory_ids[:10],
             "latency_ms": round(latency_ms, 1),
             "source": source,
+            "graph_boost_applied": graph_boost_applied,
         }
         if mode:
             metrics["mode"] = mode
@@ -49,6 +53,10 @@ async def emit_recall_fired(
             metrics["pipeline_used"] = pipeline_used
         if intent_category:
             metrics["intent_category"] = intent_category
+        if mean_score is not None:
+            metrics["mean_score"] = round(mean_score, 4)
+        if wing:
+            metrics["wing"] = wing
         return await j9_eval.insert_event(
             db,
             dimension="memory",

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -73,7 +73,10 @@ Every cycle:
 1. **Review your board.** Re-rank based on current system state. Assign
    `rank` to each board proposal (1 = highest priority).
 2. **Include an `execution_plan`** for each board proposal — how it would
-   be executed, estimated cost, and time.
+   be executed, estimated cost, and time. Optionally include
+   `expected_outputs` — a dict with `files` (paths that must exist after
+   dispatch), `min_size_bytes`, and `required_strings`. Auto-verified
+   after completion; failed verification marks the proposal as failed.
 3. **Mark `recurring: true`** for ongoing operational tasks.
 4. **Unboard** items you no longer need to focus on — output their IDs
    in the `unboarded` array. They stay pending for user decision.
@@ -229,6 +232,7 @@ Use MCP tools first, then output valid JSON:
       "urgency": "low|normal|high|critical",
       "alternatives": "What else you considered",
       "execution_plan": "health check via MCP tools, ~$0.10, ~2 min",
+      "expected_outputs": {"files": ["/path/to/output.md"], "min_size_bytes": 200},
       "rank": 1,
       "recurring": false
     }

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -132,6 +132,10 @@ Every brainstorming cycle:
    to each board proposal (1 = highest priority).
 2. **Include an `execution_plan`** for each board proposal — brief
    description of how it would be executed, estimated cost, and time.
+   Optionally include `expected_outputs` — a dict with `files` (paths
+   that must exist after dispatch), `min_size_bytes`, and
+   `required_strings`. The system auto-verifies these after completion;
+   failed verification marks the proposal as failed and resurfaces it.
 3. **Mark `recurring: true`** for proposals that imply ongoing work.
 4. **Unboard** items you no longer want to focus on — output their IDs
    in the `unboarded` array. Unboarded proposals stay pending in the
@@ -472,6 +476,7 @@ Use MCP tools to verify beliefs first, then output valid JSON:
       "memory_basis": "Natural description (obs:ID, mem:ID) — include IDs for cited observations/memories",
       "goal_id": "optional — ID from User Goals section if this proposal advances a specific goal",
       "execution_plan": "background CC session, ~$0.50, ~15 min",
+      "expected_outputs": {"files": ["/path/to/output.md"], "min_size_bytes": 500, "required_strings": ["## Summary"]},
       "rank": 1,
       "recurring": false
     }

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -452,6 +452,9 @@ class HybridRetriever:
                     graph_boost_applied = True
 
             # 7b-ii. Adjacency boost: reward cluster coherence in top-K
+            # Recompute floor after backlink boost — the top score may
+            # have changed, and the adjacency gate should use the new top.
+            floor_score = max(fused.values()) * _FLOOR_RATIO
             boosted_ranked = sorted(fused, key=fused.get, reverse=True)  # type: ignore[arg-type]
             top_k = boosted_ranked[:_ADJACENCY_TOP_K]
             if len(top_k) >= 3:

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import time
 from datetime import UTC, datetime
 
@@ -38,6 +39,15 @@ _SOURCE_TO_COLLECTIONS: dict[str, list[str]] = {
 # doesn't pollute user-facing answers. Surplus is intentionally absent —
 # its direct-session profile blocks memory writes entirely.
 _KNOWN_SUBSYSTEMS: tuple[str, ...] = ("ego", "triage", "reflection")
+
+# ---------------------------------------------------------------------------
+# Graph-boosted retrieval constants (spec Part 1)
+# ---------------------------------------------------------------------------
+_BACKLINK_BOOST_COEF = 0.05     # log-scale boost per inbound link
+_ADJACENCY_BOOST = 1.05         # 5% bump for cluster-coherent results
+_ADJACENCY_MIN_INLINKS = 2      # need ≥2 top-K peers linking to you
+_ADJACENCY_TOP_K = 20           # adjacency check on top-K after backlink boost
+_FLOOR_RATIO = 0.85             # skip boosts for results below 85% of top score
 
 
 def _resolve_subsystem_filter(
@@ -343,10 +353,17 @@ class HybridRetriever:
             if not all_ids:
                 return []
 
-        # 5. Compute activation scores
+        # 5. Batch-fetch link counts for all candidates (replaces N+1 per-ID loop)
         now_str = datetime.now(UTC).isoformat()
+        link_counts = await memory_links.batch_link_counts(self._db, list(all_ids))
+
+        # 5b. Compute activation scores using batched link data
         activation_by_id: dict[str, float] = {}
+        inbound_by_id: dict[str, int] = {}  # saved for graph boost in step 7b
         for mid in all_ids:
+            total_links, inbound_links = link_counts.get(mid, (0, 0))
+            inbound_by_id[mid] = inbound_links
+
             qdrant_hit = qdrant_by_id.get(mid)
             if qdrant_hit:
                 payload = qdrant_hit.get("payload", {})
@@ -358,13 +375,12 @@ class HybridRetriever:
                 created_at = now_str
                 retrieved_count = 0
 
-            link_count = await memory_links.count_links(self._db, mid)
             mem_class = payload.get("memory_class", "fact") if qdrant_hit else "fact"
             act = compute_activation(
                 confidence=confidence,
                 created_at=created_at,
                 retrieved_count=retrieved_count,
-                link_count=link_count,
+                link_count=total_links,
                 source=payload.get("source", "") if qdrant_hit else "",
                 tags=payload.get("tags") or [] if qdrant_hit else [],
                 now=now_str,
@@ -419,6 +435,43 @@ class HybridRetriever:
         if event_memory_ids:
             ranked_lists.append(event_memory_ids)
         fused = _rrf_fuse(ranked_lists)
+
+        # 7b. Graph boost: backlink + adjacency (floor-gated)
+        graph_boost_applied = False
+        if fused:
+            top_fused = max(fused.values())
+            floor_score = top_fused * _FLOOR_RATIO
+
+            # 7b-i. Backlink boost: reward memories referenced by many others
+            for mid in fused:
+                if fused[mid] < floor_score:
+                    continue  # floor-gated: skip weak candidates
+                inbound = inbound_by_id.get(mid, 0)
+                if inbound > 0:
+                    fused[mid] *= 1 + _BACKLINK_BOOST_COEF * math.log(1 + inbound)
+                    graph_boost_applied = True
+
+            # 7b-ii. Adjacency boost: reward cluster coherence in top-K
+            boosted_ranked = sorted(fused, key=fused.get, reverse=True)  # type: ignore[arg-type]
+            top_k = boosted_ranked[:_ADJACENCY_TOP_K]
+            if len(top_k) >= 3:
+                try:
+                    edges = await memory_links.inter_candidate_links(
+                        self._db, top_k,
+                    )
+                    intra_inbound: dict[str, int] = {}
+                    for src, tgt in edges:
+                        if src != tgt:
+                            intra_inbound[tgt] = intra_inbound.get(tgt, 0) + 1
+                    for mid, count in intra_inbound.items():
+                        if count >= _ADJACENCY_MIN_INLINKS and fused[mid] >= floor_score:
+                            fused[mid] *= _ADJACENCY_BOOST
+                            graph_boost_applied = True
+                except Exception:
+                    logger.warning(
+                        "Adjacency boost query failed, skipping",
+                        exc_info=True,
+                    )
 
         # 8. Filter by min_activation
         candidates = [
@@ -575,6 +628,7 @@ class HybridRetriever:
             emit_recall_fired,
         )
 
+        _scores = [r.score for r in results]
         recall_event_id = await emit_recall_fired(
             self._db,
             query=query,
@@ -584,11 +638,13 @@ class HybridRetriever:
             latency_ms=(time.monotonic() - _t0) * 1000,
             source=source,
             intent_category=intent.category,
+            graph_boost_applied=graph_boost_applied,
+            mean_score=sum(_scores) / len(_scores) if _scores else None,
+            wing=wing,
         )
 
         # Recall diagnostics: capture intermediate pipeline metrics
         _overlap = len(set(qdrant_by_id) & set(fts_by_id))
-        _scores = [r.score for r in results]
         await emit_recall_diagnostics(
             self._db,
             recall_event_id=recall_event_id,

--- a/tests/test_db/test_memory_links.py
+++ b/tests/test_db/test_memory_links.py
@@ -69,3 +69,66 @@ async def test_duplicate_pk_raises(db):
         await memory_links.create(
             db, source_id="g1", target_id="g2", link_type="contradicts", created_at="2026-01-02",
         )
+
+
+# --- Batch link count tests ---
+
+
+async def test_batch_link_counts(db):
+    """batch_link_counts returns (total, inbound) per memory_id."""
+    # c1 -> c2, c1 -> c3, c3 -> c2
+    await memory_links.create(
+        db, source_id="c1", target_id="c2", link_type="supports", created_at="2026-01-01",
+    )
+    await memory_links.create(
+        db, source_id="c1", target_id="c3", link_type="extends", created_at="2026-01-01",
+    )
+    await memory_links.create(
+        db, source_id="c3", target_id="c2", link_type="supports", created_at="2026-01-01",
+    )
+
+    counts = await memory_links.batch_link_counts(db, ["c1", "c2", "c3"])
+    # c1: 2 outbound, 0 inbound → total=2, inbound=0
+    assert counts["c1"] == (2, 0)
+    # c2: 0 outbound, 2 inbound → total=2, inbound=2
+    assert counts["c2"] == (2, 2)
+    # c3: 1 outbound (c3→c2) + 1 inbound (c1→c3) → total=2, inbound=1
+    assert counts["c3"] == (2, 1)
+
+
+async def test_batch_link_counts_empty(db):
+    """Empty input returns empty dict."""
+    counts = await memory_links.batch_link_counts(db, [])
+    assert counts == {}
+
+
+async def test_batch_link_counts_no_links(db):
+    """Memories with no links get (0, 0)."""
+    counts = await memory_links.batch_link_counts(db, ["orphan1", "orphan2"])
+    assert counts["orphan1"] == (0, 0)
+    assert counts["orphan2"] == (0, 0)
+
+
+async def test_inter_candidate_links(db):
+    """inter_candidate_links returns only edges within the candidate set."""
+    await memory_links.create(
+        db, source_id="a", target_id="b", link_type="supports", created_at="2026-01-01",
+    )
+    await memory_links.create(
+        db, source_id="b", target_id="c", link_type="extends", created_at="2026-01-01",
+    )
+    await memory_links.create(
+        db, source_id="d", target_id="e", link_type="supports", created_at="2026-01-01",
+    )
+
+    edges = await memory_links.inter_candidate_links(db, ["a", "b", "c"])
+    assert ("a", "b") in edges
+    assert ("b", "c") in edges
+    assert ("d", "e") not in edges  # d not in candidate set
+    assert len(edges) == 2
+
+
+async def test_inter_candidate_links_empty(db):
+    """Empty candidate set returns empty list."""
+    edges = await memory_links.inter_candidate_links(db, [])
+    assert edges == []

--- a/tests/test_ego/test_verification.py
+++ b/tests/test_ego/test_verification.py
@@ -1,0 +1,134 @@
+"""Tests for post-dispatch output verification."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from genesis.ego.verification import (
+    ExpectedOutputs,
+    parse_expected_outputs,
+    verify_outputs,
+)
+
+# --- parse_expected_outputs ---
+
+
+def test_parse_none():
+    assert parse_expected_outputs(None) is None
+
+
+def test_parse_empty_string():
+    assert parse_expected_outputs("") is None
+
+
+def test_parse_non_json_string():
+    assert parse_expected_outputs("background CC session, ~$0.50") is None
+
+
+def test_parse_malformed_json():
+    assert parse_expected_outputs("{bad json}") is None
+
+
+def test_parse_json_without_files():
+    """JSON without 'files' key should return None."""
+    assert parse_expected_outputs(json.dumps({"min_size_bytes": 100})) is None
+
+
+def test_parse_json_with_empty_files():
+    """Empty files list should return None."""
+    assert parse_expected_outputs(json.dumps({"files": []})) is None
+
+
+def test_parse_valid_minimal():
+    """Minimal valid expected_outputs with only files."""
+    raw = json.dumps({"files": ["/tmp/test.md"]})
+    result = parse_expected_outputs(raw)
+    assert result is not None
+    assert result.files == ["/tmp/test.md"]
+    assert result.min_size_bytes == 0
+    assert result.required_strings == []
+
+
+def test_parse_valid_full():
+    """Full expected_outputs with all fields."""
+    raw = json.dumps({
+        "files": ["/tmp/a.md", "/tmp/b.md"],
+        "min_size_bytes": 500,
+        "required_strings": ["## Summary", "## Conclusion"],
+    })
+    result = parse_expected_outputs(raw)
+    assert result is not None
+    assert result.files == ["/tmp/a.md", "/tmp/b.md"]
+    assert result.min_size_bytes == 500
+    assert result.required_strings == ["## Summary", "## Conclusion"]
+
+
+# --- verify_outputs ---
+
+
+def test_verify_all_pass(tmp_path: Path):
+    """Files exist, right size, required strings present."""
+    f = tmp_path / "output.md"
+    f.write_text("## Summary\nThis is the output.\n## Conclusion\nDone.")
+    expected = ExpectedOutputs(
+        files=[str(f)],
+        min_size_bytes=10,
+        required_strings=["## Summary"],
+    )
+    result = verify_outputs(expected)
+    assert result.passed is True
+    assert result.failures == []
+
+
+def test_verify_missing_file(tmp_path: Path):
+    """Missing file produces a failure."""
+    expected = ExpectedOutputs(files=[str(tmp_path / "nonexistent.md")])
+    result = verify_outputs(expected)
+    assert result.passed is False
+    assert len(result.failures) == 1
+    assert "Missing file" in result.failures[0]
+
+
+def test_verify_file_too_small(tmp_path: Path):
+    """File exists but under min_size_bytes."""
+    f = tmp_path / "small.md"
+    f.write_text("hi")
+    expected = ExpectedOutputs(files=[str(f)], min_size_bytes=1000)
+    result = verify_outputs(expected)
+    assert result.passed is False
+    assert "too small" in result.failures[0].lower()
+
+
+def test_verify_missing_required_string(tmp_path: Path):
+    """File exists, right size, but missing a required string."""
+    f = tmp_path / "output.md"
+    f.write_text("## Introduction\nSome content here.\n")
+    expected = ExpectedOutputs(
+        files=[str(f)],
+        min_size_bytes=5,
+        required_strings=["## Summary"],
+    )
+    result = verify_outputs(expected)
+    assert result.passed is False
+    assert "Missing required string" in result.failures[0]
+
+
+def test_verify_multiple_files(tmp_path: Path):
+    """Multiple files: one exists, one doesn't."""
+    good = tmp_path / "good.md"
+    good.write_text("content")
+    expected = ExpectedOutputs(
+        files=[str(good), str(tmp_path / "missing.md")],
+    )
+    result = verify_outputs(expected)
+    assert result.passed is False
+    assert len(result.failures) == 1
+    assert "missing.md" in result.failures[0]
+
+
+def test_verify_no_files():
+    """Empty files list passes vacuously."""
+    expected = ExpectedOutputs(files=[])
+    result = verify_outputs(expected)
+    assert result.passed is True

--- a/tests/test_memory/test_retrieval.py
+++ b/tests/test_memory/test_retrieval.py
@@ -74,6 +74,13 @@ def _make_fts_row(mid: str, rank: float) -> dict:
     }
 
 
+def _setup_link_mocks(mock_links, *, link_count: int = 0, batch: dict | None = None):
+    """Configure memory_links mocks for both old count_links and new batch APIs."""
+    mock_links.count_links = AsyncMock(return_value=link_count)
+    mock_links.batch_link_counts = AsyncMock(return_value=batch or {})
+    mock_links.inter_candidate_links = AsyncMock(return_value=[])
+
+
 def _build_retriever():
     embed_provider = MagicMock()
     embed_provider.embed = AsyncMock(return_value=[0.1] * 1024)
@@ -102,7 +109,7 @@ async def test_recall_returns_results(mock_qdrant, mock_crud, mock_links, _mock_
         _make_fts_row("mem-1", -5.0),
         _make_fts_row("mem-3", -3.0),
     ])
-    mock_links.count_links = AsyncMock(return_value=2)
+    _setup_link_mocks(mock_links, link_count=2)
 
     results = await retriever.recall("test query", limit=10)
     assert len(results) > 0
@@ -121,7 +128,7 @@ async def test_recall_episodic_only(mock_qdrant, mock_crud, mock_links, _):
 
     mock_qdrant.search.return_value = [_make_qdrant_hit("mem-1", 0.9)]
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     await retriever.recall("test", source="episodic", limit=5)
 
@@ -141,7 +148,7 @@ async def test_recall_knowledge_only(mock_qdrant, mock_crud, mock_links, _):
 
     mock_qdrant.search.return_value = [_make_qdrant_hit("mem-1", 0.9)]
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     await retriever.recall("test", source="knowledge", limit=5)
 
@@ -159,7 +166,7 @@ async def test_recall_both_sources(mock_qdrant, mock_crud, mock_links, _):
 
     mock_qdrant.search.return_value = [_make_qdrant_hit("mem-1", 0.9)]
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     await retriever.recall("test", source="both", limit=5)
 
@@ -187,7 +194,7 @@ async def test_fts5_collection_filter_matches_source_episodic(
 
     mock_qdrant.search.return_value = []
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     await retriever.recall("test", source="episodic", limit=5)
 
@@ -207,7 +214,7 @@ async def test_fts5_collection_filter_matches_source_knowledge(
 
     mock_qdrant.search.return_value = []
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     await retriever.recall("test", source="knowledge", limit=5)
 
@@ -229,7 +236,7 @@ async def test_fts5_collection_filter_both_searches_all(
 
     mock_qdrant.search.return_value = []
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     await retriever.recall("test", source="both", limit=5)
 
@@ -250,7 +257,7 @@ async def test_source_none_routes_by_intent_episodic(
 
     mock_qdrant.search.return_value = []
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     # WHY intent → recommended_source = 'episodic'
     await retriever.recall("why did we decide x?", limit=5)
@@ -273,7 +280,7 @@ async def test_source_none_routes_by_intent_both(
 
     mock_qdrant.search.return_value = []
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     await retriever.recall("what is the cc_relay?", limit=5)
 
@@ -296,7 +303,7 @@ async def test_explicit_source_overrides_intent(
 
     mock_qdrant.search.return_value = []
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     # WHY intent would route episodic, but caller forces knowledge
     await retriever.recall("why did we decide x?", source="knowledge", limit=5)
@@ -331,7 +338,7 @@ async def test_recall_min_activation_filters(mock_qdrant, mock_crud, mock_links,
         _make_qdrant_hit("mem-2", 0.80, confidence=0.01),
     ]
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     # Very high min_activation should filter out low-confidence results
     results = await retriever.recall("test", min_activation=0.99, limit=10)
@@ -348,7 +355,7 @@ async def test_recall_increments_retrieved_count(mock_qdrant, mock_crud, mock_li
 
     mock_qdrant.search.return_value = [_make_qdrant_hit("mem-1", 0.95)]
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     await retriever.recall("test", limit=5)
 
@@ -424,7 +431,7 @@ async def test_recall_why_intent_boosts_decision_memories(
         ),
     ]
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     results = await retriever.recall("why did we choose subprocess?", limit=2)
     assert len(results) == 2
@@ -447,7 +454,7 @@ async def test_recall_general_intent_no_bias(mock_qdrant, mock_crud, mock_links,
         _make_qdrant_hit("mem-2", 0.80),
     ]
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     results = await retriever.recall("subprocess popen error", limit=2)
     assert len(results) > 0
@@ -470,7 +477,7 @@ async def test_recall_default_excludes_subsystems(
     retriever, _, _, _ = _build_retriever()
     mock_qdrant.search.return_value = []
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     await retriever.recall("what is x", limit=5)
 
@@ -493,7 +500,7 @@ async def test_recall_include_subsystem_true_no_filter(
     retriever, _, _, _ = _build_retriever()
     mock_qdrant.search.return_value = []
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     await retriever.recall("what is x", limit=5, include_subsystem=True)
 
@@ -514,7 +521,7 @@ async def test_recall_include_subsystem_list_keeps_ego(
     retriever, _, _, _ = _build_retriever()
     mock_qdrant.search.return_value = []
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     await retriever.recall("x", limit=5, include_subsystem=["ego"])
 
@@ -535,7 +542,7 @@ async def test_recall_only_subsystem_inverts_filter(
     retriever, _, _, _ = _build_retriever()
     mock_qdrant.search.return_value = []
     mock_crud.search_ranked = AsyncMock(return_value=[])
-    mock_links.count_links = AsyncMock(return_value=0)
+    _setup_link_mocks(mock_links)
 
     await retriever.recall("x", limit=5, only_subsystem="ego")
 
@@ -553,3 +560,119 @@ async def test_recall_mutually_exclusive_params() -> None:
             "x", limit=5,
             include_subsystem=["ego"], only_subsystem="triage",
         )
+
+
+# --- Graph-boosted retrieval tests ---
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_graph_boost_backlink(mock_qdrant, mock_crud, mock_links, _):
+    """Memories with more inbound links get higher fused scores via backlink boost."""
+    retriever, _, _, _ = _build_retriever()
+
+    mock_qdrant.search.return_value = [
+        _make_qdrant_hit("mem-low", 0.90),
+        _make_qdrant_hit("mem-high", 0.89),  # slightly lower vector score
+    ]
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+
+    # mem-high has 20 inbound links; mem-low has 0
+    mock_links.batch_link_counts = AsyncMock(return_value={
+        "mem-low": (0, 0),
+        "mem-high": (20, 20),
+    })
+    mock_links.inter_candidate_links = AsyncMock(return_value=[])
+    mock_links.count_links = AsyncMock(return_value=0)
+
+    results = await retriever.recall("test", limit=2)
+    assert len(results) == 2
+    # mem-high should be boosted above mem-low despite lower vector score
+    assert results[0].memory_id == "mem-high"
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_graph_boost_floor_gating(mock_qdrant, mock_crud, mock_links, _):
+    """Low-scoring results should NOT receive graph boosts (floor gate).
+
+    To create a genuine fused-score gap: s1-s3 appear in Qdrant AND FTS
+    (contributing to 3 ranked lists), while weak appears ONLY in FTS
+    (contributing to 2 lists: fts + activation). This gives weak a
+    meaningfully lower fused score that falls below the 85% floor.
+    """
+    retriever, _, _, _ = _build_retriever()
+
+    # weak NOT in Qdrant results — only s1-s3
+    mock_qdrant.search.return_value = [
+        _make_qdrant_hit("s1", 0.95),
+        _make_qdrant_hit("s2", 0.90),
+        _make_qdrant_hit("s3", 0.85),
+    ]
+    # weak appears only in FTS with the worst rank
+    mock_crud.search_ranked = AsyncMock(return_value=[
+        _make_fts_row("s1", -10.0),
+        _make_fts_row("s2", -8.0),
+        _make_fts_row("s3", -6.0),
+        _make_fts_row("weak", -1.0),
+    ])
+
+    # weak has massive inbound links — but should be floor-gated
+    mock_links.batch_link_counts = AsyncMock(return_value={
+        "s1": (0, 0),
+        "s2": (0, 0),
+        "s3": (0, 0),
+        "weak": (0, 200),
+    })
+    mock_links.inter_candidate_links = AsyncMock(return_value=[])
+    mock_links.count_links = AsyncMock(return_value=0)
+
+    results = await retriever.recall("test", limit=4)
+    assert len(results) == 4
+    # s1 must still rank first — floor gating prevents weak's boost
+    assert results[0].memory_id == "s1"
+    # weak should remain last despite 200 inbound links
+    assert results[-1].memory_id == "weak"
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_graph_boost_adjacency(mock_qdrant, mock_crud, mock_links, _):
+    """Adjacency boost rewards memories that link to each other in top-K."""
+    retriever, _, _, _ = _build_retriever()
+
+    mock_qdrant.search.return_value = [
+        _make_qdrant_hit("a", 0.90),
+        _make_qdrant_hit("b", 0.89),
+        _make_qdrant_hit("c", 0.88),
+    ]
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+
+    mock_links.batch_link_counts = AsyncMock(return_value={
+        "a": (0, 0),
+        "b": (0, 0),
+        "c": (2, 2),  # c has 2 inbound overall
+    })
+    # Both a and b link to c within the top-K set
+    mock_links.inter_candidate_links = AsyncMock(return_value=[
+        ("a", "c"),
+        ("b", "c"),
+    ])
+    mock_links.count_links = AsyncMock(return_value=0)
+
+    results = await retriever.recall("test", limit=3)
+    assert len(results) == 3
+    # c should get both backlink boost and adjacency boost
+    c_result = next(r for r in results if r.memory_id == "c")
+    a_result = next(r for r in results if r.memory_id == "a")
+    # c's boosted score should exceed a's (despite lower vector score)
+    assert c_result.score > a_result.score

--- a/tests/test_memory/test_retrieval_fallback.py
+++ b/tests/test_memory/test_retrieval_fallback.py
@@ -51,6 +51,8 @@ async def test_recall_fts_only_on_embedding_failure(mock_qdrant, mock_crud, mock
         _make_fts_row("mem-2", -3.0),
     ])
     mock_links.count_links = AsyncMock(return_value=0)
+    mock_links.batch_link_counts = AsyncMock(return_value={})
+    mock_links.inter_candidate_links = AsyncMock(return_value=[])
 
     results = await retriever.recall("test query", limit=10)
 
@@ -75,6 +77,8 @@ async def test_recall_fts_only_vector_rank_is_none(mock_qdrant, mock_crud, mock_
         _make_fts_row("mem-1", -5.0),
     ])
     mock_links.count_links = AsyncMock(return_value=0)
+    mock_links.batch_link_counts = AsyncMock(return_value={})
+    mock_links.inter_candidate_links = AsyncMock(return_value=[])
 
     results = await retriever.recall("test query", limit=10)
     assert len(results) == 1
@@ -109,6 +113,8 @@ async def test_recall_normal_unchanged(mock_qdrant, mock_crud, mock_links, _):
     }]
     mock_crud.search_ranked = AsyncMock(return_value=[])
     mock_links.count_links = AsyncMock(return_value=0)
+    mock_links.batch_link_counts = AsyncMock(return_value={})
+    mock_links.inter_candidate_links = AsyncMock(return_value=[])
 
     results = await retriever.recall("test query", source="episodic", limit=10)
     assert len(results) == 1


### PR DESCRIPTION
## Summary
- **Graph-boosted retrieval**: Wire 77K-edge knowledge graph into retrieval hot path with backlink boost (+31.4 P@5 validated by GBrain), adjacency boost for cluster coherence, and floor gate to prevent weak results from accumulating boosts
- **N+1 fix**: Replace per-ID `count_links()` loop (30-90 queries) with 2 batch queries via new `batch_link_counts()`
- **Post-dispatch verification**: Ego proposals can now define `expected_outputs` (files, min_size, required_strings) that are auto-verified after session completion — failed verification transitions proposal to 'failed' status
- **J-9 eval extension**: Graph boost metrics (graph_boost_applied, mean_score, wing) added to existing recall events — no new table
- **VCR accuracy**: Verification-failed proposals correctly counted as dispatch failures in VCR metric

## Design specs
- `docs/superpowers/specs/2026-05-29-memory-retrieval-quality-design.md` (Sprint 1: Parts 1, 4.1, 7.1)
- `docs/superpowers/specs/2026-05-29-honcho-integration-db-adapter-design.md` (future sprints)

## Test plan
- [x] 12/12 memory_links tests pass (5 new batch tests)
- [x] 27/27 retrieval tests pass (3 new graph boost tests, 18 mock updates)
- [x] 3/3 retrieval fallback tests pass (mock updates)
- [x] 86/86 ego tests pass (14 new verification tests)
- [x] 128 total tests, 0 failures
- [x] ruff check clean on all modified files
- [x] Code review: 5 findings addressed (floor recomputation, VCR visibility, placeholder safety, multi-failure reporting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)