### PR TITLE
refactor(ego): remove CycleType enum and legacy run_cycle()

### DIFF
--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -30,9 +30,7 @@ from genesis.cc.types import (
 )
 from genesis.db.crud import ego as ego_crud
 from genesis.ego.types import (
-    CYCLE_TYPE_DEFAULTS,
     NEUTRAL_STATUS,
-    CycleType,
     EgoConfig,
     EgoCycle,
 )
@@ -144,147 +142,6 @@ class EgoSession:
 
     # -- Public API --------------------------------------------------------
 
-    async def run_cycle(
-        self,
-        *,
-        is_morning_report: bool = False,
-        cycle_type: CycleType | None = None,
-        model_override: str | None = None,
-    ) -> EgoCycle | None:
-        """Execute one ego thinking cycle.
-
-        Parameters
-        ----------
-        is_morning_report:
-            Legacy flag, still supported. Equivalent to
-            ``cycle_type=CycleType.MORNING_REPORT``.
-        cycle_type:
-            Determines model and effort for this cycle. If None,
-            inferred from ``is_morning_report``.
-        model_override:
-            Override model selection (e.g., "opus" for deep-think cycles).
-            Takes precedence over both config and cycle_type defaults.
-
-        Returns the stored EgoCycle, or None if the cycle failed (CC error).
-
-        Raises:
-            CycleBlockedError: Approval gate blocked the cycle (not a failure).
-        """
-        # Resolve cycle type
-        if cycle_type is None:
-            cycle_type = CycleType.MORNING_REPORT if is_morning_report else CycleType.PROACTIVE
-        is_morning_report = cycle_type == CycleType.MORNING_REPORT
-
-        # Select model + effort: config is the base, cycle type overrides
-        # only for specific types (morning report → sonnet/low, etc.)
-        cycle_model, cycle_effort = CYCLE_TYPE_DEFAULTS.get(cycle_type, (None, None))
-        model = CCModel(cycle_model or self._config.model)
-        effort = EffortLevel(cycle_effort or self._config.default_effort)
-
-        # model_override takes precedence (e.g., deep-think Opus cycle)
-        if model_override:
-            model = CCModel(model_override)
-
-        # 1. Assemble operational context (previous focus + fresh context)
-        dynamic_context = await self._compaction.assemble_context(
-            context_builder=self._context_builder,
-        )
-
-        # 3. Build prompts — system prompt is identity ONLY (cacheable),
-        #    operational context goes in the user message.
-        #    Record prompt version on first use for versioning/outcome linkage.
-        if not self._prompt_version_recorded and self._db is not None:
-            try:
-                from genesis.db.crud.prompt_versions import record_version
-                await record_version(
-                    self._db,
-                    prompt_hash=self._prompt_hash,
-                    call_site="ego_cycle",
-                    content_preview=self._static_prompt[:200],
-                )
-                self._prompt_version_recorded = True
-            except Exception:
-                logger.debug("Failed to record ego prompt version", exc_info=True)
-        system_prompt = self._static_prompt
-        user_prompt = self._build_user_prompt(
-            dynamic_context=dynamic_context,
-            is_morning_report=is_morning_report,
-        )
-
-        # 4. Build invocation — ephemeral (no resume).
-        # append_system_prompt=True: preserve CC's tool framework
-        # underneath the ego identity prompt (see feedback_append_system_prompt.md).
-        invocation = CCInvocation(
-            prompt=user_prompt,
-            model=model,
-            effort=effort,
-            resume_session_id=None,
-            append_system_prompt=True,
-            system_prompt=system_prompt,
-            timeout_s=2400,
-            skip_permissions=True,
-            working_dir=background_session_dir(),
-            mcp_config=self._mcp_config_path,
-        )
-
-        output = None
-        session_id: str | None = None
-        if self._autonomous_dispatcher is not None:
-            decision = await self._autonomous_dispatcher.route(
-                AutonomousDispatchRequest(
-                    subsystem="ego",
-                    policy_id=self._source_tag,
-                    action_label=self._source_tag.replace("_", " "),
-                    messages=[
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt},
-                    ],
-                    cli_invocation=invocation,
-                    dispatch_mode="cli",
-                    cli_fallback_allowed=True,
-                    approval_required_for_cli=True,
-                    approval_key_stable=True,
-                ),
-            )
-            if decision.mode == "blocked":
-                logger.warning("Ego cycle blocked: %s", decision.reason)
-                raise CycleBlockedError(decision.reason or "approval pending")
-
-        if output is None:
-            try:
-                sess = await self._session_manager.create_background(
-                    session_type=SessionType.BACKGROUND_TASK,
-                    model=model,
-                    effort=effort,
-                    source_tag=self._source_tag,
-                )
-                session_id = sess["id"]
-                _set_obs_session(session_id)
-            except Exception:
-                logger.error("Failed to create ego background session", exc_info=True)
-                return None
-
-            try:
-                output = await self._invoker.run(invocation)
-            except Exception:
-                logger.error("Ego CC invocation failed", exc_info=True)
-                try:
-                    await self._session_manager.fail(session_id, reason="CC invocation error")
-                except Exception:
-                    logger.error("Session fail() also errored", exc_info=True)
-                return None
-
-        if output.is_error:
-            logger.error("Ego CC session returned error: %s", output.error_message)
-            if session_id is not None:
-                try:
-                    await self._session_manager.fail(session_id, reason=output.error_message)
-                except Exception:
-                    logger.error("Session fail() also errored", exc_info=True)
-            return None
-
-        return await self._process_cycle_output(output, model, session_id)
-
     async def run_unified_cycle(
         self,
         signals: list[EgoSignal],
@@ -292,12 +149,9 @@ class EgoSession:
         model_override: str | None = None,
         effort_override: str | None = None,
     ) -> EgoCycle | None:
-        """Execute one ego cycle via the unified perceive→think→act→learn pipeline.
+        """Execute one ego cycle via the perceive→think→act→learn pipeline.
 
-        This is the new entry point for the unified cognitive loop.
-        It coexists with ``run_cycle()`` during migration (PRs 1-4).
-        After PR 5, ``run_cycle()`` is removed and this becomes the
-        sole cycle method.
+        Entry point for all ego cycles via the unified cognitive loop.
 
         Parameters
         ----------
@@ -349,7 +203,7 @@ class EgoSession:
             effort = EffortLevel(self._config.default_effort)
 
         # System prompt is identity ONLY (cacheable)
-        # Record prompt version on first use (same guard as run_cycle)
+        # Record prompt version on first use
         if not self._prompt_version_recorded and self._db is not None:
             try:
                 from genesis.db.crud.prompt_versions import record_version
@@ -364,7 +218,7 @@ class EgoSession:
                 logger.debug("Failed to record ego prompt version", exc_info=True)
         system_prompt = self._static_prompt
 
-        # Build invocation — same pattern as run_cycle
+        # Build invocation — ephemeral (no resume)
         invocation = CCInvocation(
             prompt=user_prompt,
             model=model,
@@ -531,7 +385,7 @@ class EgoSession:
                 exc_info=True,
             )
 
-    # -- Output processing (shared by run_cycle and run_unified_cycle) -----
+    # -- Output processing --------------------------------------------------
 
     async def _process_cycle_output(
         self,
@@ -539,7 +393,7 @@ class EgoSession:
         model: CCModel,
         session_id: str | None,
     ) -> EgoCycle:
-        """Post-invocation processing shared by run_cycle and run_unified_cycle.
+        """Post-invocation processing for ego cycles.
 
         Handles: parse → focus sanitize → store cycle → complete session →
         record last_run → realist gate → proposals → table/withdraw/unboard →
@@ -818,41 +672,17 @@ class EgoSession:
 
     # -- Prompt building ---------------------------------------------------
 
-    def _build_user_prompt(
-        self,
-        *,
-        dynamic_context: str,
-        is_morning_report: bool,
-    ) -> str:
-        """Build the user message: operational context + directive.
-
-        The system prompt is the static identity only (cacheable).
-        All dynamic content goes here in the user message.
-        """
-        directive = (
-            "Run your ego cycle. Review the operational context below, "
-            "check your open threads, and use your MCP tools to verify "
-            "any beliefs before proposing actions. End with valid JSON "
-            "matching the ego output schema."
-        )
-        if is_morning_report:
-            directive += (
-                "\n\nThis is a MORNING REPORT cycle. Include the morning_report "
-                "field with your daily briefing for the user."
-            )
-        return f"{directive}\n\n---\n\n{dynamic_context}"
-
     def _build_focused_prompt(
         self,
         *,
         dynamic_context: str,
         focus: FocusResult,
     ) -> str:
-        """Build a focus-specific user message for the unified cognitive loop.
+        """Build a focus-specific user message for ego cycles.
 
-        Similar to ``_build_user_prompt`` but with a focus directive instead
-        of the generic "run your ego cycle" directive. The focus comes from
-        the perceive phase (FocusSelector output).
+        The system prompt is the static identity only (cacheable).
+        All dynamic content goes here in the user message.  The focus
+        directive comes from the perceive phase (FocusSelector output).
 
         Parameters
         ----------

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -8,24 +8,11 @@ from datetime import UTC, datetime
 from enum import StrEnum
 
 
-class CycleType(StrEnum):
-    """Types of ego thinking cycles.
-
-    DEPRECATED: will be removed in PR 5 when all cycle types are
-    migrated to the unified cognitive loop (FocusCategory).
-    """
-
-    PROACTIVE = "proactive"        # Regular brainstorming (uses config model/effort)
-    MORNING_REPORT = "morning_report"  # Daily briefing (always Sonnet, Low)
-    REACTIVE = "reactive"          # User message response (uses config model/effort)
-    ESCALATION = "escalation"      # Health/escalation eval (always Sonnet, Medium)
-
-
 class FocusCategory(StrEnum):
     """Focus categories for the unified cognitive loop.
 
-    Replaces CycleType — signals carry a focus_category that determines
-    context weighting and prompt specialization.
+    Signals carry a focus_category that determines context weighting
+    and prompt specialization.
     """
 
     PROACTIVE = "proactive"
@@ -34,17 +21,6 @@ class FocusCategory(StrEnum):
     GOAL_REVIEW = "goal_review"
     DISPATCH_OUTCOME = "dispatch_outcome"
     ESCALATION = "escalation"
-
-
-# Per-cycle-type model/effort OVERRIDES.  Only cycle types listed here
-# bypass the ego's config.model / config.default_effort.  PROACTIVE is
-# intentionally absent — it respects the per-ego config so genesis ego
-# can run Sonnet while user ego runs Opus.
-CYCLE_TYPE_DEFAULTS: dict[CycleType, tuple[str, str]] = {
-    CycleType.MORNING_REPORT: ("sonnet", "low"),
-    CycleType.ESCALATION: ("sonnet", "medium"),
-    CycleType.REACTIVE: ("opus", "high"),  # fires need the best model
-}
 
 
 class ProposalStatus(StrEnum):

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -677,7 +677,7 @@ class TestReactiveSignals:
         assert cadence._signal_queue.empty()
 
     def test_push_reactive_model_override_is_opus(self, cadence):
-        """Reactive signals carry opus/high to match CYCLE_TYPE_DEFAULTS[REACTIVE]."""
+        """Reactive signals carry opus/high model/effort overrides."""
         cadence._running = True
         cadence.push_reactive_event({"type": "test", "summary": "alert"})
         signals = cadence._signal_queue.drain()

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -13,7 +13,8 @@ from genesis.db.crud import ego as ego_crud
 from genesis.db.schema import TABLES
 from genesis.ego.dispatch import EgoDispatcher
 from genesis.ego.session import EgoSession
-from genesis.ego.types import CycleType, EgoConfig
+from genesis.ego.signals import EgoSignal
+from genesis.ego.types import EgoConfig
 
 # ---------------------------------------------------------------------------
 # Sample ego output
@@ -148,81 +149,82 @@ def ego_session(
 
 
 # ---------------------------------------------------------------------------
-# Session cycle tests
+# Helpers
 # ---------------------------------------------------------------------------
 
 
-class TestEgoSession:
-    async def test_run_cycle_success(self, ego_session, mock_invoker, db):
-        """Full successful cycle: proposals created, focus stored."""
-        cycle = await ego_session.run_cycle()
+def _make_signal(**overrides) -> EgoSignal:
+    """Build a minimal EgoSignal for testing."""
+    defaults = {
+        "signal_type": "timer",
+        "focus_category": "proactive",
+        "summary": "Idle tick",
+        "priority": "medium",
+    }
+    defaults.update(overrides)
+    return EgoSignal(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Session cycle tests (unified cognitive loop)
+# ---------------------------------------------------------------------------
+
+
+class TestUnifiedCycle:
+    """Tests for run_unified_cycle — the sole cycle entry point."""
+
+    async def test_success(self, ego_session, mock_invoker, db):
+        """Full successful cycle: signal → perceive → invoke → proposals."""
+        cycle = await ego_session.run_unified_cycle([_make_signal()])
 
         assert cycle is not None
         assert cycle.cost_usd == 0.15
         assert cycle.model_used == "opus"
         assert cycle.focus_summary == "investigating backlog growth"
-        # Invoker called for ego cycle + realist filter (2 calls when proposals exist)
         assert mock_invoker.run.call_count >= 1
 
-        # Focus summary stored in ego_state is system-computed (not ego-authored).
-        # The test DB lacks ego_directives etc., so computed_focus falls back.
+        # Focus summary stored in ego_state is system-computed.
         focus = await ego_crud.get_state(db, "ego_focus_summary")
         assert focus == "general system awareness"
 
-    async def test_run_cycle_no_proposals(
+    async def test_no_proposals(
         self, ego_session, mock_invoker, mock_proposal_workflow,
     ):
         """Cycle with empty proposals array still stores the cycle."""
         mock_invoker.run.return_value = _cc_output(
             _valid_output(proposals=[], follow_ups=[]),
         )
-        cycle = await ego_session.run_cycle()
+        cycle = await ego_session.run_unified_cycle([_make_signal()])
 
         assert cycle is not None
         mock_proposal_workflow.create_batch.assert_not_called()
 
-    async def test_run_cycle_with_follow_ups(self, ego_session, dispatcher):
-        """Follow-up recording is disabled — output is parsed but not stored."""
-        cycle = await ego_session.run_cycle()
-        assert cycle is not None
-
-        # record_follow_ups is a no-op (PR #375), so nothing lands in DB
-        pending = await dispatcher.get_pending_follow_ups()
-        assert len(pending) == 0
-
-    async def test_run_cycle_morning_report(self, ego_session, mock_invoker):
-        """Morning report flag appears in the user prompt."""
-        await ego_session.run_cycle(is_morning_report=True)
-
-        call_args = mock_invoker.run.call_args_list[0][0][0]
-        assert "MORNING REPORT" in call_args.prompt
-
-    async def test_run_cycle_cc_error(
+    async def test_cc_error(
         self, ego_session, mock_invoker, mock_session_manager,
     ):
-        """CC error causes graceful failure."""
+        """CC error causes graceful failure — returns None."""
         mock_invoker.run.return_value = _cc_output(is_error=True)
-        cycle = await ego_session.run_cycle()
+        cycle = await ego_session.run_unified_cycle([_make_signal()])
 
         assert cycle is None
         mock_session_manager.fail.assert_called_once()
 
-    async def test_run_cycle_cc_exception(
+    async def test_cc_exception(
         self, ego_session, mock_invoker, mock_session_manager,
     ):
         """CC invocation exception causes graceful failure."""
         mock_invoker.run.side_effect = TimeoutError("CC timed out")
-        cycle = await ego_session.run_cycle()
+        cycle = await ego_session.run_unified_cycle([_make_signal()])
 
         assert cycle is None
         mock_session_manager.fail.assert_called_once()
 
-    async def test_run_cycle_parse_failure(
+    async def test_parse_failure(
         self, ego_session, mock_invoker, mock_proposal_workflow,
     ):
         """Invalid output stores cycle but creates no proposals."""
         mock_invoker.run.return_value = _cc_output("not json at all")
-        cycle = await ego_session.run_cycle()
+        cycle = await ego_session.run_unified_cycle([_make_signal()])
 
         assert cycle is not None
         assert cycle.proposals_json == "[]"
@@ -230,27 +232,70 @@ class TestEgoSession:
 
     async def test_invocation_args(self, ego_session, mock_invoker):
         """Verify CCInvocation has correct model, effort, append mode."""
-        await ego_session.run_cycle()
+        await ego_session.run_unified_cycle([_make_signal()])
 
-        # First call is the ego cycle; subsequent calls are realist filter
         invocation = mock_invoker.run.call_args_list[0][0][0]
-        assert invocation.model.value == "opus"
-        assert invocation.effort.value == "high"  # default from EgoConfig
+        assert invocation.model.value == "opus"  # from EgoConfig default
+        assert invocation.effort.value == "high"  # from EgoConfig default
         assert invocation.append_system_prompt is True
         assert invocation.skip_permissions is True
 
-    async def test_context_assembled_before_cycle(
-        self, ego_session, mock_compaction, mock_invoker,
-    ):
-        """assemble_context is called to build operational context."""
-        await ego_session.run_cycle()
-        mock_compaction.assemble_context.assert_called_once()
+    async def test_model_override(self, ego_session, mock_invoker):
+        """model_override takes precedence over config default."""
+        await ego_session.run_unified_cycle(
+            [_make_signal()], model_override="sonnet",
+        )
+        invocation = mock_invoker.run.call_args_list[0][0][0]
+        assert invocation.model.value == "sonnet"
+
+    async def test_effort_override(self, ego_session, mock_invoker):
+        """effort_override takes precedence over config default."""
+        await ego_session.run_unified_cycle(
+            [_make_signal()], effort_override="low",
+        )
+        invocation = mock_invoker.run.call_args_list[0][0][0]
+        assert invocation.effort.value == "low"
+
+    async def test_daily_briefing_prompt(self, ego_session, mock_invoker):
+        """Daily briefing signal → DAILY BRIEFING directive in prompt."""
+        signal = _make_signal(focus_category="daily_briefing")
+        await ego_session.run_unified_cycle([signal])
+
+        invocation = mock_invoker.run.call_args_list[0][0][0]
+        assert "DAILY BRIEFING" in invocation.prompt
+        assert "morning_report" in invocation.prompt
+
+    async def test_reactive_prompt(self, ego_session, mock_invoker):
+        """Reactive signal → REACTIVE directive in prompt."""
+        signal = _make_signal(focus_category="reactive", summary="health alert")
+        await ego_session.run_unified_cycle([signal])
+
+        invocation = mock_invoker.run.call_args_list[0][0][0]
+        assert "REACTIVE" in invocation.prompt
+
+    async def test_ephemeral_no_resume(self, ego_session, mock_invoker):
+        """Every cycle is ephemeral — resume_session_id is always None."""
+        await ego_session.run_unified_cycle([_make_signal()])
+        invocation = mock_invoker.run.call_args_list[0][0][0]
+        assert invocation.resume_session_id is None
+
+    async def test_system_prompt_is_static(self, ego_session, mock_invoker):
+        """System prompt is the static identity — no dynamic content."""
+        await ego_session.run_unified_cycle([_make_signal()])
+        invocation = mock_invoker.run.call_args_list[0][0][0]
+        assert invocation.system_prompt == ego_session._static_prompt
+
+    async def test_dynamic_context_in_user_message(self, ego_session, mock_invoker):
+        """Operational context appears in the user message, not system prompt."""
+        await ego_session.run_unified_cycle([_make_signal()])
+        invocation = mock_invoker.run.call_args_list[0][0][0]
+        assert "Test operational context" in invocation.prompt
 
     async def test_session_manager_lifecycle(
         self, ego_session, mock_session_manager,
     ):
         """Session is created and completed on success."""
-        await ego_session.run_cycle()
+        await ego_session.run_unified_cycle([_make_signal()])
         mock_session_manager.create_background.assert_called_once()
         mock_session_manager.complete.assert_called_once()
 
@@ -258,60 +303,25 @@ class TestEgoSession:
         self, ego_session, mock_proposal_workflow,
     ):
         """Proposals from ego output are sent as a batch."""
-        await ego_session.run_cycle()
+        await ego_session.run_unified_cycle([_make_signal()])
         mock_proposal_workflow.create_batch.assert_called_once()
         mock_proposal_workflow.send_digest.assert_called_once()
 
-    async def test_ephemeral_no_resume(self, ego_session, mock_invoker):
-        """Every cycle is ephemeral — resume_session_id is always None."""
-        await ego_session.run_cycle()
-        # First call is the ego cycle
-        invocation = mock_invoker.run.call_args_list[0][0][0]
-        assert invocation.resume_session_id is None
+    async def test_empty_signals_returns_none(self, ego_session, mock_invoker):
+        """Empty signal list → no cycle, returns None."""
+        cycle = await ego_session.run_unified_cycle([])
+        assert cycle is None
+        mock_invoker.run.assert_not_called()
 
-    async def test_ephemeral_consecutive_cycles(self, ego_session, mock_invoker):
-        """Consecutive cycles are independent — no resume between them."""
-        await ego_session.run_cycle()
-        mock_invoker.run.reset_mock()
+    async def test_focus_in_prompt(self, ego_session, mock_invoker):
+        """Focus type and rationale appear in the user prompt."""
+        signal = _make_signal(summary="Goal stale for 12 days",
+                              focus_category="goal_review")
+        await ego_session.run_unified_cycle([signal])
 
-        await ego_session.run_cycle()
-        # First call after reset is the ego cycle
         invocation = mock_invoker.run.call_args_list[0][0][0]
-        assert invocation.resume_session_id is None
-
-    async def test_morning_report_uses_sonnet_low(self, ego_session, mock_invoker):
-        """Morning report cycle uses Sonnet/Low per cycle type defaults."""
-        await ego_session.run_cycle(is_morning_report=True)
-        invocation = mock_invoker.run.call_args_list[0][0][0]
-        assert invocation.model.value == "sonnet"
-        assert invocation.effort.value == "low"
-
-    async def test_cycle_type_proactive(self, ego_session, mock_invoker):
-        """Proactive cycle type uses Opus/High."""
-        await ego_session.run_cycle(cycle_type=CycleType.PROACTIVE)
-        invocation = mock_invoker.run.call_args_list[0][0][0]
-        assert invocation.model.value == "opus"
-        assert invocation.effort.value == "high"
-
-    async def test_cycle_type_escalation(self, ego_session, mock_invoker):
-        """Escalation cycle type uses Sonnet/Medium."""
-        await ego_session.run_cycle(cycle_type=CycleType.ESCALATION)
-        invocation = mock_invoker.run.call_args_list[0][0][0]
-        assert invocation.model.value == "sonnet"
-        assert invocation.effort.value == "medium"
-
-    async def test_system_prompt_is_static(self, ego_session, mock_invoker):
-        """System prompt is the static identity — no dynamic content."""
-        await ego_session.run_cycle()
-        invocation = mock_invoker.run.call_args_list[0][0][0]
-        # System prompt should be the cached static prompt
-        assert invocation.system_prompt == ego_session._static_prompt
-
-    async def test_dynamic_context_in_user_message(self, ego_session, mock_invoker):
-        """Operational context appears in the user message, not system prompt."""
-        await ego_session.run_cycle()
-        invocation = mock_invoker.run.call_args_list[0][0][0]
-        assert "Test operational context" in invocation.prompt
+        assert "goal_review" in invocation.prompt
+        assert "GOAL REVIEW" in invocation.prompt
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ego/test_unified_cycle.py
+++ b/tests/test_ego/test_unified_cycle.py
@@ -190,17 +190,6 @@ def test_focus_category_values():
     assert FocusCategory.ESCALATION == "escalation"
 
 
-def test_focus_category_coexists_with_cycle_type():
-    """FocusCategory and CycleType should coexist without conflict."""
-    from genesis.ego.types import CycleType, FocusCategory
-
-    # Both should import cleanly
-    assert CycleType.PROACTIVE == "proactive"
-    assert FocusCategory.PROACTIVE == "proactive"
-    # But they are different types
-    assert type(CycleType.PROACTIVE) is not type(FocusCategory.PROACTIVE)
-
-
 # ── EgoConfig goal_review_staleness_days ──────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Remove `CycleType` enum and `CYCLE_TYPE_DEFAULTS` dict from `types.py` — dead code after PRs 1-4 migrated all emitters to the signal-based unified cognitive loop
- Delete `run_cycle()` (~140 lines) and `_build_user_prompt()` from `session.py` — zero production callers (verified via Serena LSP `find_referencing_symbols`)
- Replace 18 `run_cycle` tests with 17 `run_unified_cycle` tests covering: success, CC error, CC exception, parse failure, model/effort overrides, daily briefing/reactive/goal_review prompts, ephemeral sessions, session lifecycle, proposals
- Delete `CycleType` coexistence test from `test_unified_cycle.py`
- Clean up all comments referencing `run_cycle` coexistence

Net: -195 lines. 578 ego tests pass.

Part of the ego v2 unified cognitive loop migration (PR 5 of 7).

## Test plan

- [x] `pytest tests/ego/test_session.py -v` — 40 tests pass (17 new unified cycle + 23 existing)
- [x] `pytest tests/test_ego/test_unified_cycle.py -v` — coexistence test removed, rest pass
- [x] `pytest tests/ego/test_cadence.py -v` — no regressions
- [x] `pytest tests/ego/ tests/test_ego/ -v` — full ego suite: 578 pass
- [x] `ruff check` — lint clean
- [x] `grep -r "CycleType\|CYCLE_TYPE_DEFAULTS" src/ tests/` — zero hits (except 3 historical comments in test_cadence.py explaining why signals replaced run_cycle)
- [x] Serena `find_referencing_symbols(CycleType)` — confirmed only 4 files, all addressed
- [x] Serena `find_referencing_symbols(EgoSession/run_cycle)` — returned `{}` (zero external callers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)