### PR TITLE
feat(knowledge): add PageIndex tree-based document indexing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ browser = [
 distribution = [
     "composio-client>=1.33.0",
 ]
+documents = [
+    "pageindex>=0.2.8",
+]
 release = []  # detect-secrets is now a core dep (see dependencies above)
 
 [build-system]

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -190,6 +190,14 @@ TTS_VOICE_ID_FISH=
 # Signup: deepinfra.com -> API Keys
 API_KEY_DEEPINFRA=
 
+# ─── Document Intelligence ───────────────────────────────────────────────
+
+# --- PageIndex ---
+# Used by: Tree-based document indexing for long structured PDFs.
+# Signup: dash.pageindex.ai -> API Keys
+# Free tier available.
+API_KEY_PAGEINDEX=
+
 # ─── Dashboard Security ──────────────────────────────────────────────────
 # Set a password to protect the dashboard from unauthorized LAN access.
 # Leave empty to disable auth (dashboard accessible without login).

--- a/src/genesis/knowledge/manifest.py
+++ b/src/genesis/knowledge/manifest.py
@@ -139,6 +139,21 @@ class ManifestManager:
         entry = manifest.get(h)
         return entry.get("unit_ids", []) if entry else []
 
+    def add_tree_index(self, source: str, *, doc_id: str) -> None:
+        """Associate a PageIndex doc_id with an existing source entry."""
+        manifest = self._load()
+        h = self.source_hash(source)
+        if h in manifest:
+            manifest[h]["pageindex_doc_id"] = doc_id
+            self._save()
+
+    def get_tree_index_doc_id(self, source: str) -> str | None:
+        """Look up the PageIndex doc_id for a source, if any."""
+        manifest = self._load()
+        h = self.source_hash(source)
+        entry = manifest.get(h)
+        return entry.get("pageindex_doc_id") if entry else None
+
     def list_sources(self) -> list[dict]:
         """List all ingested sources with metadata."""
         manifest = self._load()

--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -31,6 +31,7 @@ class IngestResult:
     unit_ids: list[str] = field(default_factory=list)
     quality_flags: list[str] = field(default_factory=list)
     error: str | None = None
+    tree_index_doc_id: str | None = None
 
 
 class KnowledgeOrchestrator:
@@ -42,11 +43,15 @@ class KnowledgeOrchestrator:
         registry: ContentProcessorRegistry,
         distillation: DistillationPipeline,
         manifest: ManifestManager,
+        tree_index_client: object | None = None,
+        tree_index_threshold: int = 25,
     ) -> None:
         self._registry = registry
         self._distillation = distillation
         self._manifest = manifest
         self._store_lock = asyncio.Lock()
+        self._tree_index = tree_index_client
+        self._tree_index_threshold = tree_index_threshold
 
     async def ingest_source(
         self,
@@ -99,6 +104,20 @@ class KnowledgeOrchestrator:
                 quality_flags=["empty_content"],
             )
 
+        # 3b. Kick off tree indexing in parallel (if applicable)
+        tree_task: asyncio.Task | None = None
+        should_tree_index = (
+            self._tree_index is not None
+            and content.source_type == "pdf"
+            and content.metadata.get("page_count", 0) >= self._tree_index_threshold
+            and Path(source).exists()
+        )
+        if should_tree_index:
+            tree_task = asyncio.create_task(
+                self._tree_index_source(source),
+                name=f"tree-index-{Path(source).name}",
+            )
+
         # 4. Save extracted text to disk
         extracted_path = self._manifest.save_extracted_text(
             source, content.text, content.source_type
@@ -124,11 +143,17 @@ class KnowledgeOrchestrator:
                 extracted_path=extracted_path,
                 original_path=original_path,
             )
+            # Still collect tree result if started
+            tree_doc_id = await self._collect_tree_result(tree_task, source)
+            flags = ["no_units_extracted"]
+            if tree_task is not None and tree_doc_id is None:
+                flags.append("tree_index_failed")
             return IngestResult(
                 source=source,
                 source_type=content.source_type,
                 units_created=0,
-                quality_flags=["no_units_extracted"],
+                quality_flags=flags,
+                tree_index_doc_id=tree_doc_id,
             )
 
         # 7. Store each unit
@@ -166,12 +191,18 @@ class KnowledgeOrchestrator:
         if ratio < MIN_EXTRACTION_RATIO and units:
             quality_flags.append("thin_extraction")
 
+        # 9. Collect tree indexing result (if started)
+        tree_doc_id = await self._collect_tree_result(tree_task, source)
+        if tree_task is not None and tree_doc_id is None:
+            quality_flags.append("tree_index_failed")
+
         return IngestResult(
             source=source,
             source_type=content.source_type,
             units_created=len(unit_ids),
             unit_ids=unit_ids,
             quality_flags=quality_flags,
+            tree_index_doc_id=tree_doc_id,
         )
 
     async def ingest_batch(
@@ -212,6 +243,42 @@ class KnowledgeOrchestrator:
             results.append(result)
 
         return results
+
+    async def _collect_tree_result(
+        self,
+        tree_task: asyncio.Task | None,
+        source: str,
+    ) -> str | None:
+        """Await a tree indexing task and update manifest on success.
+
+        Returns the doc_id on success, None on failure or if no task.
+        """
+        if tree_task is None:
+            return None
+        try:
+            doc_id = await tree_task
+            if doc_id:
+                self._manifest.add_tree_index(source, doc_id=doc_id)
+            return doc_id
+        except Exception as exc:
+            logger.warning(
+                "Tree indexing failed for %s (non-blocking): %s",
+                source, exc,
+            )
+            return None
+
+    async def _tree_index_source(self, source: str) -> str | None:
+        """Upload a document to PageIndex and save the tree index.
+
+        Returns the doc_id on success, None on failure.
+        """
+        from genesis.knowledge.tree_index import save_tree_index
+
+        doc_id = await self._tree_index.upload_document(source)
+        tree = await self._tree_index.get_tree(doc_id)
+        save_tree_index(source, doc_id, tree)
+        logger.info("Tree index built for %s (doc_id=%s)", source, doc_id)
+        return doc_id
 
     async def _store_units(
         self,

--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -7,6 +7,7 @@ distillation -> knowledge units -> storage (SQLite + Qdrant).
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import typing
@@ -165,6 +166,11 @@ class KnowledgeOrchestrator:
                 )
         except Exception as exc:
             logger.error("Storage failed for %s: %s", source, exc)
+            # Cancel tree task to avoid orphaned upload
+            if tree_task is not None:
+                tree_task.cancel()
+                with contextlib.suppress(Exception):
+                    await tree_task
             return IngestResult(
                 source=source,
                 source_type=content.source_type,

--- a/src/genesis/knowledge/tree_index.py
+++ b/src/genesis/knowledge/tree_index.py
@@ -1,0 +1,174 @@
+"""PageIndex cloud API wrapper for tree-based document indexing.
+
+Provides async wrappers around the synchronous PageIndex SDK for
+structured document retrieval. Documents are uploaded to PageIndex's
+cloud, which builds a hierarchical tree index for LLM-based navigation.
+
+Usage:
+    client = get_client()
+    if client:
+        doc_id = await client.upload_document("/path/to/file.pdf")
+        tree = await client.get_tree(doc_id)
+        answer = await client.query_document(doc_id, "What are the risk factors?")
+        await client.delete_document(doc_id)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_INDICES_DIR = Path.home() / ".genesis" / "knowledge" / "indices"
+
+
+class TreeIndexClient:
+    """Async wrapper around the synchronous PageIndex SDK."""
+
+    def __init__(self, api_key: str | None = None) -> None:
+        key = api_key or os.environ.get("API_KEY_PAGEINDEX")
+        if not key:
+            raise RuntimeError(
+                "PageIndex API key required — set API_KEY_PAGEINDEX in secrets.env"
+            )
+        from pageindex import PageIndexClient
+
+        self._client = PageIndexClient(api_key=key)
+
+    async def upload_document(
+        self,
+        path: str,
+        *,
+        timeout_seconds: int = 300,
+    ) -> str:
+        """Upload a PDF and poll until processing completes.
+
+        Returns the doc_id on success.
+        Raises TimeoutError if processing doesn't complete within timeout.
+        Raises RuntimeError if PageIndex reports processing failure.
+        """
+        result = await asyncio.to_thread(self._client.submit_document, path)
+        doc_id = result.get("doc_id") or result.get("id")
+        if not doc_id:
+            raise RuntimeError(f"No doc_id in submit response: {result}")
+
+        # Poll with exponential backoff
+        delays = [2, 4, 8, 16, 30]
+        elapsed = 0
+        attempt = 0
+
+        while elapsed < timeout_seconds:
+            delay = delays[min(attempt, len(delays) - 1)]
+            await asyncio.sleep(delay)
+            elapsed += delay
+            attempt += 1
+
+            status = await asyncio.to_thread(self._client.get_document, doc_id)
+            state = status.get("status", "unknown")
+
+            if state == "completed":
+                logger.info(
+                    "PageIndex document %s ready (%d pages, %ds)",
+                    doc_id,
+                    status.get("pageNum", 0),
+                    elapsed,
+                )
+                return doc_id
+
+            if state == "failed":
+                raise RuntimeError(
+                    f"PageIndex processing failed for {path}: {status}"
+                )
+
+        raise TimeoutError(
+            f"PageIndex processing timed out after {timeout_seconds}s for {path}"
+        )
+
+    async def get_tree(self, doc_id: str) -> dict:
+        """Fetch the hierarchical tree index for a document."""
+        return await asyncio.to_thread(
+            self._client.get_tree, doc_id, node_summary=True
+        )
+
+    async def query_document(self, doc_id: str, question: str) -> dict:
+        """Query a document using PageIndex chat completions.
+
+        Returns the full response dict with 'choices' and 'citations'.
+        """
+        return await asyncio.to_thread(
+            self._client.chat_completions,
+            messages=[{"role": "user", "content": question}],
+            doc_id=doc_id,
+            enable_citations=True,
+        )
+
+    async def delete_document(self, doc_id: str) -> None:
+        """Delete a document from PageIndex cloud."""
+        await asyncio.to_thread(self._client.delete_document, doc_id)
+        logger.info("Deleted PageIndex document %s", doc_id)
+
+
+def get_client() -> TreeIndexClient | None:
+    """Factory that returns None if PageIndex is not configured.
+
+    Safe to call unconditionally — returns None if:
+    - API_KEY_PAGEINDEX not set
+    - pageindex SDK not installed
+    """
+    try:
+        api_key = os.environ.get("API_KEY_PAGEINDEX")
+        if not api_key:
+            return None
+        return TreeIndexClient(api_key=api_key)
+    except Exception:
+        logger.debug("PageIndex client not available", exc_info=True)
+        return None
+
+
+def _source_hash(source: str) -> str:
+    """Deterministic hash for a source path."""
+    return hashlib.sha256(source.encode()).hexdigest()[:16]
+
+
+def save_tree_index(source: str, doc_id: str, tree: dict) -> Path:
+    """Persist a tree index to disk. Returns the file path."""
+    _INDICES_DIR.mkdir(parents=True, exist_ok=True)
+    h = _source_hash(source)
+    path = _INDICES_DIR / f"{h}.json"
+    data = {
+        "source": source,
+        "doc_id": doc_id,
+        "tree": tree,
+        "indexed_at": datetime.now(UTC).isoformat(),
+    }
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2, default=str))
+    tmp.replace(path)
+    return path
+
+
+def load_tree_index(source: str) -> dict | None:
+    """Load a cached tree index from disk. Returns None if not found."""
+    h = _source_hash(source)
+    path = _INDICES_DIR / f"{h}.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        logger.warning("Corrupt tree index at %s", path)
+        return None
+
+
+def delete_tree_index(source: str) -> None:
+    """Remove a cached tree index from disk."""
+    h = _source_hash(source)
+    path = _INDICES_DIR / f"{h}.json"
+    if path.exists():
+        path.unlink()

--- a/src/genesis/mcp/memory/__init__.py
+++ b/src/genesis/mcp/memory/__init__.py
@@ -159,6 +159,7 @@ def _resolve_session_id(session_id: str) -> str:
 _bookmarks_tools = importlib.import_module(".bookmarks", __name__)  # noqa: F401
 _conversation_tools = importlib.import_module(".conversation", __name__)  # noqa: F401
 _core_tools = importlib.import_module(".core", __name__)  # noqa: F401
+_documents_tools = importlib.import_module(".documents", __name__)  # noqa: F401
 _identity_tools = importlib.import_module(".identity", __name__)  # noqa: F401
 _knowledge_tools = importlib.import_module(".knowledge", __name__)  # noqa: F401
 _observations_tools = importlib.import_module(".observations", __name__)  # noqa: F401

--- a/src/genesis/mcp/memory/documents.py
+++ b/src/genesis/mcp/memory/documents.py
@@ -1,0 +1,196 @@
+"""MCP tools for PageIndex tree-based document querying.
+
+Provides document_index, document_query, and document_delete tools
+on the genesis-memory FastMCP server.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from ..memory import mcp
+
+logger = logging.getLogger(__name__)
+
+
+def _get_tree_client():
+    """Lazy-create a TreeIndexClient. Returns None if not configured."""
+    from genesis.knowledge.tree_index import get_client
+
+    return get_client()
+
+
+@mcp.tool()
+async def document_index(path: str) -> dict:
+    """Upload a document to PageIndex for tree-indexed querying.
+
+    Builds a hierarchical tree index that enables structure-aware
+    retrieval — better than chunk+embed for long, structured documents.
+
+    Returns the doc_id and a summary of the tree structure.
+    Use document_query to ask questions about the indexed document.
+
+    For large PDFs, processing may take 1-3 minutes.
+
+    Args:
+        path: Path to the PDF file.
+    """
+    from genesis.knowledge.tree_index import load_tree_index, save_tree_index
+
+    resolved = Path(path).expanduser().resolve()
+    if not resolved.exists():
+        return {"error": f"File not found: {path}"}
+    if resolved.suffix.lower() != ".pdf":
+        return {"error": "Only PDF files are supported for tree indexing"}
+
+    # Check cache first
+    cached = load_tree_index(str(resolved))
+    if cached:
+        return {
+            "doc_id": cached["doc_id"],
+            "source": cached["source"],
+            "indexed_at": cached["indexed_at"],
+            "tree_summary": _summarize_tree(cached["tree"]),
+            "status": "cached",
+        }
+
+    client = _get_tree_client()
+    if client is None:
+        return {"error": "PageIndex not configured — set API_KEY_PAGEINDEX"}
+
+    try:
+        doc_id = await client.upload_document(str(resolved))
+        tree = await client.get_tree(doc_id)
+        save_tree_index(str(resolved), doc_id, tree)
+        return {
+            "doc_id": doc_id,
+            "source": str(resolved),
+            "tree_summary": _summarize_tree(tree),
+            "status": "indexed",
+        }
+    except Exception as exc:
+        logger.error("document_index failed for %s: %s", path, exc)
+        return {"error": str(exc)}
+
+
+@mcp.tool()
+async def document_query(
+    question: str,
+    path_or_doc_id: str,
+) -> dict:
+    """Query a document using PageIndex tree-based retrieval.
+
+    Provide either a file path (auto-indexes if needed) or a doc_id
+    from a previous document_index call. Returns an answer with
+    page citations.
+
+    Args:
+        question: The question to ask about the document.
+        path_or_doc_id: A file path or a PageIndex doc_id (starts with 'pi-').
+    """
+    from genesis.knowledge.tree_index import load_tree_index, save_tree_index
+
+    client = _get_tree_client()
+    if client is None:
+        return {"error": "PageIndex not configured — set API_KEY_PAGEINDEX"}
+
+    # Determine doc_id
+    doc_id: str | None = None
+    if path_or_doc_id.startswith("pi-"):
+        doc_id = path_or_doc_id
+    else:
+        resolved = Path(path_or_doc_id).expanduser().resolve()
+        cached = load_tree_index(str(resolved))
+        if cached:
+            doc_id = cached["doc_id"]
+        elif resolved.exists():
+            # Auto-index
+            try:
+                doc_id = await client.upload_document(str(resolved))
+                tree = await client.get_tree(doc_id)
+                save_tree_index(str(resolved), doc_id, tree)
+            except Exception as exc:
+                return {"error": f"Auto-indexing failed: {exc}"}
+        else:
+            return {"error": f"Not a valid doc_id or file path: {path_or_doc_id}"}
+
+    try:
+        response = await client.query_document(doc_id, question)
+        choices = response.get("choices", [])
+        answer = choices[0]["message"]["content"] if choices else ""
+        return {
+            "answer": answer,
+            "citations": response.get("citations", []),
+            "doc_id": doc_id,
+            "usage": response.get("usage"),
+        }
+    except Exception as exc:
+        # If doc_id is stale, the error will surface here
+        logger.error("document_query failed for %s: %s", doc_id, exc)
+        return {"error": str(exc), "doc_id": doc_id}
+
+
+@mcp.tool()
+async def document_delete(doc_id: str) -> dict:
+    """Delete a document from PageIndex and remove local cache.
+
+    Use after finishing analysis of a temporarily indexed document.
+
+    Args:
+        doc_id: The PageIndex document ID to delete.
+    """
+    from genesis.knowledge.tree_index import (
+        _INDICES_DIR,
+    )
+
+    client = _get_tree_client()
+    if client is None:
+        return {"error": "PageIndex not configured — set API_KEY_PAGEINDEX"}
+
+    # Delete from cloud
+    try:
+        await client.delete_document(doc_id)
+    except Exception as exc:
+        logger.warning("Cloud delete failed for %s: %s", doc_id, exc)
+
+    # Remove local cache matching this doc_id
+    removed = False
+    if _INDICES_DIR.exists():
+        for f in _INDICES_DIR.glob("*.json"):
+            try:
+                import json
+
+                data = json.loads(f.read_text())
+                if data.get("doc_id") == doc_id:
+                    f.unlink()
+                    removed = True
+                    break
+            except Exception:
+                continue
+
+    return {
+        "deleted": True,
+        "doc_id": doc_id,
+        "local_cache_removed": removed,
+    }
+
+
+def _summarize_tree(tree: dict) -> str:
+    """Produce a concise summary of a tree structure."""
+    result_nodes = tree.get("result", [])
+    if not result_nodes:
+        return "Empty tree"
+
+    sections = []
+    for node in result_nodes:
+        title = node.get("title", "Untitled")
+        page = node.get("page_index", "?")
+        children = node.get("nodes", [])
+        child_count = len(children)
+        if child_count:
+            sections.append(f"  {title} (p.{page}, {child_count} subsections)")
+        else:
+            sections.append(f"  {title} (p.{page})")
+
+    return f"{len(result_nodes)} top-level sections:\n" + "\n".join(sections)

--- a/src/genesis/mcp/memory/documents.py
+++ b/src/genesis/mcp/memory/documents.py
@@ -14,11 +14,19 @@ from ..memory import mcp
 logger = logging.getLogger(__name__)
 
 
-def _get_tree_client():
-    """Lazy-create a TreeIndexClient. Returns None if not configured."""
-    from genesis.knowledge.tree_index import get_client
+_tree_client_cache: object | None = None
+_tree_client_checked = False
 
-    return get_client()
+
+def _get_tree_client():
+    """Lazy-create and cache a TreeIndexClient. Returns None if not configured."""
+    global _tree_client_cache, _tree_client_checked
+    if not _tree_client_checked:
+        from genesis.knowledge.tree_index import get_client
+
+        _tree_client_cache = get_client()
+        _tree_client_checked = True
+    return _tree_client_cache
 
 
 @mcp.tool()
@@ -105,6 +113,8 @@ async def document_query(
         if cached:
             doc_id = cached["doc_id"]
         elif resolved.exists():
+            if resolved.suffix.lower() != ".pdf":
+                return {"error": "Only PDF files are supported for tree indexing"}
             # Auto-index
             try:
                 doc_id = await client.upload_document(str(resolved))

--- a/src/genesis/mcp/memory/knowledge.py
+++ b/src/genesis/mcp/memory/knowledge.py
@@ -668,10 +668,13 @@ def _get_orchestrator():
             "Router not available — standalone bootstrap also failed"
         )
 
+    from genesis.knowledge.tree_index import get_client as get_tree_index_client
+
     return KnowledgeOrchestrator(
         registry=build_default_registry(),
         distillation=DistillationPipeline(router=rt._router),
         manifest=ManifestManager(),
+        tree_index_client=get_tree_index_client(),
     )
 
 
@@ -697,7 +700,7 @@ async def knowledge_ingest_source(
     result = await orchestrator.ingest_source(
         source, project_type=project_type, domain=domain, purpose=purpose,
     )
-    return {
+    response = {
         "source": result.source,
         "source_type": result.source_type,
         "units_created": result.units_created,
@@ -705,6 +708,9 @@ async def knowledge_ingest_source(
         "quality_flags": result.quality_flags,
         "error": result.error,
     }
+    if result.tree_index_doc_id:
+        response["tree_index_doc_id"] = result.tree_index_doc_id
+    return response
 
 
 @mcp.tool()

--- a/tests/test_knowledge/test_tree_index.py
+++ b/tests/test_knowledge/test_tree_index.py
@@ -1,0 +1,189 @@
+"""Tests for PageIndex tree-based document indexing."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from genesis.knowledge.tree_index import (
+    delete_tree_index,
+    get_client,
+    load_tree_index,
+    save_tree_index,
+)
+
+# ------------------------------------------------------------------
+# get_client() factory
+# ------------------------------------------------------------------
+
+
+def test_get_client_returns_none_without_key():
+    """get_client() returns None when API key is not set."""
+    with patch.dict("os.environ", {}, clear=True):
+        assert get_client() is None
+
+
+def test_get_client_returns_none_when_sdk_missing():
+    """get_client() returns None when pageindex is not importable."""
+    with patch.dict("os.environ", {"API_KEY_PAGEINDEX": "test-key"}), patch(
+        "genesis.knowledge.tree_index.TreeIndexClient",
+        side_effect=ImportError("no module"),
+    ):
+        assert get_client() is None
+
+
+# ------------------------------------------------------------------
+# save / load / delete round-trip
+# ------------------------------------------------------------------
+
+
+def test_save_load_roundtrip(tmp_path: Path):
+    """save_tree_index and load_tree_index round-trip correctly."""
+    with patch("genesis.knowledge.tree_index._INDICES_DIR", tmp_path):
+        tree = {"result": [{"title": "Intro", "node_id": "0000", "page_index": 1}]}
+        path = save_tree_index("/path/to/doc.pdf", "pi-test123", tree)
+
+        assert path.exists()
+
+        loaded = load_tree_index("/path/to/doc.pdf")
+        assert loaded is not None
+        assert loaded["doc_id"] == "pi-test123"
+        assert loaded["tree"] == tree
+        assert "indexed_at" in loaded
+
+
+def test_load_returns_none_for_missing(tmp_path: Path):
+    """load_tree_index returns None for non-existent source."""
+    with patch("genesis.knowledge.tree_index._INDICES_DIR", tmp_path):
+        assert load_tree_index("/nonexistent.pdf") is None
+
+
+def test_delete_tree_index(tmp_path: Path):
+    """delete_tree_index removes the cached file."""
+    with patch("genesis.knowledge.tree_index._INDICES_DIR", tmp_path):
+        save_tree_index("/path/to/doc.pdf", "pi-test", {})
+        assert load_tree_index("/path/to/doc.pdf") is not None
+
+        delete_tree_index("/path/to/doc.pdf")
+        assert load_tree_index("/path/to/doc.pdf") is None
+
+
+# ------------------------------------------------------------------
+# Orchestrator integration
+# ------------------------------------------------------------------
+
+
+async def test_orchestrator_skips_tree_index_when_no_client(tmp_path: Path):
+    """Orchestrator skips tree indexing when tree_index_client is None."""
+    from genesis.knowledge.distillation import DistillationPipeline
+    from genesis.knowledge.manifest import ManifestManager
+    from genesis.knowledge.orchestrator import KnowledgeOrchestrator
+    from genesis.knowledge.processors.registry import ContentProcessorRegistry
+    from genesis.knowledge.processors.text import TextProcessor
+
+    registry = ContentProcessorRegistry()
+    registry.register_extensions(TextProcessor(), [".txt"])
+    distillation = DistillationPipeline(router=MagicMock())
+    distillation.distill = AsyncMock(return_value=[])
+    manifest = ManifestManager(root=tmp_path / "knowledge")
+
+    orch = KnowledgeOrchestrator(
+        registry=registry,
+        distillation=distillation,
+        manifest=manifest,
+        tree_index_client=None,  # explicitly no client
+    )
+
+    file = tmp_path / "test.txt"
+    file.write_text("Some content.")
+    result = await orch.ingest_source(str(file), project_type="test")
+
+    assert result.tree_index_doc_id is None
+    assert "tree_index_failed" not in result.quality_flags
+
+
+async def test_orchestrator_skips_tree_index_below_threshold(tmp_path: Path):
+    """Orchestrator skips tree indexing for PDFs below page threshold."""
+    from genesis.knowledge.distillation import DistillationPipeline
+    from genesis.knowledge.manifest import ManifestManager
+    from genesis.knowledge.orchestrator import KnowledgeOrchestrator
+    from genesis.knowledge.processors.base import ProcessedContent
+    from genesis.knowledge.processors.registry import ContentProcessorRegistry
+
+    mock_processor = MagicMock()
+    mock_processor.process = AsyncMock(return_value=ProcessedContent(
+        text="short doc",
+        metadata={"page_count": 5},  # below threshold
+        source_type="pdf",
+        source_path="/fake.pdf",
+    ))
+
+    registry = ContentProcessorRegistry()
+    registry.get_processor = MagicMock(return_value=mock_processor)
+
+    distillation = DistillationPipeline(router=MagicMock())
+    distillation.distill = AsyncMock(return_value=[])
+    manifest = ManifestManager(root=tmp_path / "knowledge")
+
+    mock_tree_client = MagicMock()
+
+    orch = KnowledgeOrchestrator(
+        registry=registry,
+        distillation=distillation,
+        manifest=manifest,
+        tree_index_client=mock_tree_client,
+        tree_index_threshold=25,
+    )
+
+    result = await orch.ingest_source("/fake.pdf", project_type="test")
+
+    # Tree client should never have been called
+    mock_tree_client.upload_document.assert_not_called()
+    assert result.tree_index_doc_id is None
+
+
+async def test_orchestrator_continues_on_tree_index_failure(tmp_path: Path):
+    """Orchestrator continues normally when tree indexing fails."""
+    from genesis.knowledge.distillation import DistillationPipeline
+    from genesis.knowledge.manifest import ManifestManager
+    from genesis.knowledge.orchestrator import KnowledgeOrchestrator
+    from genesis.knowledge.processors.base import ProcessedContent
+    from genesis.knowledge.processors.registry import ContentProcessorRegistry
+
+    mock_processor = MagicMock()
+    mock_processor.process = AsyncMock(return_value=ProcessedContent(
+        text="long doc " * 1000,
+        metadata={"page_count": 50},  # above threshold
+        source_type="pdf",
+        source_path=str(tmp_path / "big.pdf"),
+    ))
+
+    registry = ContentProcessorRegistry()
+    registry.get_processor = MagicMock(return_value=mock_processor)
+
+    distillation = DistillationPipeline(router=MagicMock())
+    distillation.distill = AsyncMock(return_value=[])
+    manifest = ManifestManager(root=tmp_path / "knowledge")
+
+    # Tree client that fails
+    mock_tree_client = MagicMock()
+    mock_tree_client.upload_document = AsyncMock(
+        side_effect=RuntimeError("PageIndex down")
+    )
+
+    # Create the fake file so Path(source).exists() is True
+    big_pdf = tmp_path / "big.pdf"
+    big_pdf.write_bytes(b"%PDF-1.4 fake")
+
+    orch = KnowledgeOrchestrator(
+        registry=registry,
+        distillation=distillation,
+        manifest=manifest,
+        tree_index_client=mock_tree_client,
+        tree_index_threshold=25,
+    )
+
+    result = await orch.ingest_source(str(big_pdf), project_type="test")
+
+    # Should complete without error, with tree_index_failed flag
+    assert result.error is None
+    assert "tree_index_failed" in result.quality_flags
+    assert result.tree_index_doc_id is None


### PR DESCRIPTION
## Summary

- Integrates PageIndex cloud API for structured document retrieval alongside existing chunk+embed pipeline
- Tree indexing preserves document hierarchy for long PDFs (25+ pages) where vector search loses structural relationships
- Three use cases: knowledge ingestion (parallel enrichment), foreground MCP tools (ad-hoc analysis), task executor (background doc analysis)
- Graceful degradation — pipeline never fails because PageIndex is unavailable

## Changes

- **New:** `src/genesis/knowledge/tree_index.py` — async wrapper around PageIndex SDK (upload, poll, tree, query, delete, local caching)
- **New:** `src/genesis/mcp/memory/documents.py` — `document_index`, `document_query`, `document_delete` MCP tools
- **New:** `tests/test_knowledge/test_tree_index.py` — 8 tests covering wrapper, caching, orchestrator integration, failure handling
- **Modified:** `orchestrator.py` — parallel tree indexing via `asyncio.create_task`, non-blocking collection with `_collect_tree_result`
- **Modified:** `manifest.py` — `add_tree_index()` and `get_tree_index_doc_id()` for doc_id persistence
- **Modified:** `knowledge.py` — wire `get_client()` into `_get_orchestrator()`, include `tree_index_doc_id` in response
- **Modified:** `pyproject.toml` — `pageindex>=0.2.8` optional dependency

## Test plan

- [x] 8 new unit tests pass (wrapper, caching, orchestrator skip/failure)
- [x] 8 existing orchestrator tests pass (zero regressions)
- [x] API smoke-tested with live key (upload, tree, query, delete verified)
- [ ] Integration test: `document_index` + `document_query` MCP tools with real PDF
- [ ] Integration test: `knowledge_ingest_source` with 30+ page PDF → verify `tree_index_doc_id`
- [ ] Graceful degradation: remove API key → pipeline completes without tree indexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)