### PR TITLE
feat(ego): upgrade realist to Opus + domain boundary enforcement

### DIFF
--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -819,12 +819,12 @@ class EgoSession:
             logger.warning("Realist: failed to fetch history, passing through")
             return proposals
 
-        prompt = _build_realist_prompt(proposals, recent)
+        prompt = _build_realist_prompt(proposals, recent, ego_source=self._source_tag)
 
         try:
             invocation = CCInvocation(
                 prompt=prompt,
-                model=CCModel.SONNET,
+                model=CCModel.OPUS,
                 effort=EffortLevel.MEDIUM,
                 skip_permissions=True,
                 working_dir=background_session_dir(),
@@ -1546,6 +1546,8 @@ _NEUTRAL_STATUS = NEUTRAL_STATUS  # re-export for backwards compat
 def _build_realist_prompt(
     proposals: list[dict],
     recent_history: list[dict],
+    *,
+    ego_source: str = "",
 ) -> str:
     """Build the realist evaluation prompt.
 
@@ -1572,9 +1574,36 @@ def _build_realist_prompt(
         conf = p.get("confidence", 0.0)
         proposal_lines.append(f"{i}. [{action}] (confidence: {conf:.2f}) {content}")
 
+    # Domain boundary context — only for the Genesis/operations ego.
+    ego_section = ""
+    if ego_source == "genesis_ego_cycle":
+        ego_section = """
+## Ego Source
+These proposals are from the **Genesis ego (COO/operations)**.
+Its jurisdiction is Genesis infrastructure ONLY: system health,
+performance, maintenance, and operational reliability. It has NO
+jurisdiction over the user's career, content publishing, social media,
+marketing, outreach strategy, job applications, networking, conferences,
+personal scheduling, or external platforms Genesis doesn't operate.
+
+"""
+
+    domain_rule = ""
+    if ego_source == "genesis_ego_cycle":
+        domain_rule = """
+7. **Domain boundary (operations ego only).** These proposals come from
+   the operations ego. REJECT any proposal outside Genesis infrastructure.
+   Career, job applications, content publishing, social media, marketing,
+   outreach strategy, networking, conferences, personal scheduling, and
+   external platforms are user ego domain. If a proposal mentions a
+   user-domain topic as context for an infrastructure fix (e.g., "CDP
+   dropped during a job application session"), AMEND to focus on the
+   infrastructure component only and remove the user-domain framing.
+"""
+
     return f"""You are the Realist — a quality gate for ego proposals. Evaluate each
 proposal and return a JSON array of verdicts.
-
+{ego_section}
 ## Rules
 
 1. **Read operations are NOT proposals.** Investigating, researching, reading,
@@ -1604,7 +1633,7 @@ proposal and return a JSON array of verdicts.
    patterns in the history. A proposal that failed before may succeed
    now — circumstances change. Judge the proposal on its own merits,
    not on inferred system state.
-
+{domain_rule}
 ## Recent Proposal History (48h)
 {chr(10).join(history_lines)}
 

--- a/tests/ego/test_realist.py
+++ b/tests/ego/test_realist.py
@@ -463,3 +463,70 @@ class TestEgoSourceIsolation:
         sent_html = mock_tm.send_to_category.call_args[0][1]
         # Should show 1 pending from old user batch, not 2 (which would include genesis)
         assert "1 older proposal(s) still awaiting response" in sent_html
+
+
+# -- Domain boundary enforcement tests --
+
+
+class TestDomainBoundary:
+    """Tests for domain boundary enforcement in the realist prompt."""
+
+    def test_genesis_ego_gets_domain_context(self):
+        """Genesis ego source adds domain boundary section to prompt."""
+        prompt = _build_realist_prompt(
+            [{"content": "test", "action_type": "investigate", "confidence": 0.8}],
+            [],
+            ego_source="genesis_ego_cycle",
+        )
+        assert "Genesis ego (COO/operations)" in prompt
+        assert "infrastructure ONLY" in prompt
+
+    def test_genesis_ego_gets_domain_rule(self):
+        """Genesis ego source adds rule 7 for domain boundary."""
+        prompt = _build_realist_prompt(
+            [{"content": "test", "action_type": "dispatch", "confidence": 0.8}],
+            [],
+            ego_source="genesis_ego_cycle",
+        )
+        assert "Domain boundary" in prompt
+        assert "REJECT any proposal outside Genesis infrastructure" in prompt
+
+    def test_user_ego_no_domain_context(self):
+        """User ego source does NOT add domain boundary section."""
+        prompt = _build_realist_prompt(
+            [{"content": "test", "action_type": "dispatch", "confidence": 0.8}],
+            [],
+            ego_source="user_ego_cycle",
+        )
+        assert "Genesis ego (COO/operations)" not in prompt
+        assert "Domain boundary" not in prompt
+
+    def test_empty_ego_source_no_domain_context(self):
+        """Empty/missing ego source does NOT add domain boundary section."""
+        prompt = _build_realist_prompt(
+            [{"content": "test", "action_type": "dispatch", "confidence": 0.8}],
+            [],
+        )
+        assert "Genesis ego (COO/operations)" not in prompt
+        assert "Domain boundary" not in prompt
+
+    def test_domain_rule_mentions_key_user_domains(self):
+        """Rule 7 explicitly lists the user-domain categories to reject."""
+        prompt = _build_realist_prompt(
+            [{"content": "test", "action_type": "dispatch", "confidence": 0.8}],
+            [],
+            ego_source="genesis_ego_cycle",
+        )
+        for domain in ("career", "content publishing", "social media",
+                        "marketing", "job applications", "networking"):
+            assert domain.lower() in prompt.lower(), f"Missing domain: {domain}"
+
+    def test_domain_rule_allows_amend_for_mixed(self):
+        """Rule 7 instructs AMEND (not reject) for infra fixes with user context."""
+        prompt = _build_realist_prompt(
+            [{"content": "test", "action_type": "dispatch", "confidence": 0.8}],
+            [],
+            ego_source="genesis_ego_cycle",
+        )
+        assert "AMEND" in prompt
+        assert "infrastructure component" in prompt


### PR DESCRIPTION
## Summary

- Upgrade realist gate model from Sonnet to **Opus** for stronger judgment on proposal quality
- Add **domain boundary enforcement** for the Genesis ego (COO): the realist now REJECTs proposals outside Genesis infrastructure (career, content, social media, outreach, etc.) and AMENDs mixed proposals to focus on the infrastructure component only
- User ego proposals are unaffected — no domain section or rule is added for user ego

**Problem:** The Genesis ego crosses domain boundaries in 50% of its proposals (11/22 total). Examples: "Publish Medium article", "Research AI conference networking prep", "Re-draft social media posts." The system prompt has 26 lines of boundary language but it decays over long contexts. A directive was added as a band-aid but competes for the 5-slot limit.

**Solution:** Structural enforcement at the realist gate. The realist runs fresh every cycle with a small prompt (~2-3K tokens) — no context decay. Opus has the judgment to catch nuanced crossovers. The `ego_source` parameter lets the realist conditionally apply domain rules only for the Genesis ego.

## Test plan

- [x] `pytest tests/ego/test_realist.py -v` — 36 tests pass (6 new domain boundary tests)
- [x] `pytest tests/ego/test_session.py -v` — 40 tests pass (no regressions)
- [x] `ruff check` — lint clean
- [x] Verified prompt rendering: Genesis ego gets domain section + rule 7, user ego and empty source do not
- [x] Code review: clean, no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)