### PR TITLE
feat(memory): default rerank=True, opt-out for latency-sensitive callers

### DIFF
--- a/az_plugins/genesis/extensions/message_loop_prompts_after/_52_genesis_memory_recall.py
+++ b/az_plugins/genesis/extensions/message_loop_prompts_after/_52_genesis_memory_recall.py
@@ -31,7 +31,7 @@ class GenesisMemoryRecall(Extension):
                 return
 
             results = await asyncio.wait_for(
-                rt.hybrid_retriever.recall(query, source="both", limit=5),
+                rt.hybrid_retriever.recall(query, source="both", limit=5, rerank=False),
                 timeout=_TIMEOUT,
             )
 

--- a/src/genesis/channels/voice/handler.py
+++ b/src/genesis/channels/voice/handler.py
@@ -75,7 +75,7 @@ class VoiceConversationHandler:
         # 2. Memory recall (best-effort — don't fail the whole request)
         memories_text = ""
         try:
-            results = await self._retriever.recall(transcript, limit=5)
+            results = await self._retriever.recall(transcript, limit=5, rerank=False)
             if results:
                 snippets = []
                 for r in results[:5]:

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -54,7 +54,7 @@ async def memory_recall(
     time_range: str | None = None,
     include_subsystem: bool | list[str] = False,
     only_subsystem: str | list[str] | None = None,
-    rerank: bool = False,
+    rerank: bool = True,
 ) -> list[dict]:
     """Hybrid search: Qdrant vectors + FTS5, RRF fusion, with optional graph enrichment.
 
@@ -445,7 +445,7 @@ async def memory_proactive(
     # min_activation=0.0: use activation as a ranking signal, not a filter gate.
     # With confidence=0.5 (96% of memories) and retrieved_count=0 (80%),
     # even day-old memories fail a 0.3 threshold. Let RRF fusion rank instead.
-    results = await memory_mod._retriever.recall(current_message, limit=limit * 2, min_activation=0.0)
+    results = await memory_mod._retriever.recall(current_message, limit=limit * 2, min_activation=0.0, rerank=False)
     filtered = [
         r for r in results
         if "memory_operation" not in (r.payload.get("tags") or [])

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -187,7 +187,7 @@ class HybridRetriever:
         room: str | None = None,
         include_subsystem: bool | list[str] = False,
         only_subsystem: str | list[str] | None = None,
-        rerank: bool = False,
+        rerank: bool = True,
     ) -> list[RetrievalResult]:
         """Hybrid retrieval: Qdrant + FTS5 + activation, fused via RRF.
 

--- a/tests/test_memory/test_mcp_integration.py
+++ b/tests/test_memory/test_mcp_integration.py
@@ -100,7 +100,7 @@ async def test_memory_recall_delegates(mock_deps, tools):
         "query", source="both", limit=5, min_activation=0.0,
         wing=None, room=None, expand_query_terms=True,
         include_subsystem=False, only_subsystem=None,
-        rerank=False,
+        rerank=True,
     )
 
 
@@ -139,7 +139,7 @@ async def test_memory_proactive_delegates(mock_deps, tools):
     results = await tools["memory_proactive"].fn(current_message="hello world", limit=3)
     assert len(results) == 1
     memory_mcp._retriever.recall.assert_awaited_once_with(
-        "hello world", limit=6, min_activation=0.0
+        "hello world", limit=6, min_activation=0.0, rerank=False,
     )
 
 


### PR DESCRIPTION
## Summary

- Change `rerank` default from `False` to `True` in `HybridRetriever.recall()` and `memory_recall` MCP tool
- All recall paths now get Voyage cross-encoder reranking by default
- Three latency-sensitive callers explicitly opt out with `rerank=False`:
  - Voice handler (~300ms too expensive for voice UX)
  - a0 extension (proactive injection, budget-constrained)
  - `memory_proactive` MCP tool (same budget constraints)
- All other callers benefit automatically: `memory_recall`, `knowledge_recall`, `context_injector`, ego corrections, dashboard search

## Test plan

- [x] 46 memory tests pass (including updated mock assertions)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)