### PR TITLE
feat(ego): add goal-driven behavior — staleness signal + deep context + assessment

### DIFF
--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -1,8 +1,10 @@
 """Ego cadence manager — controls when the ego runs.
 
-Owns an APScheduler with two jobs:
-1. IntervalTrigger for regular cycles (adaptive backoff)
+Owns an APScheduler with jobs:
+1. IntervalTrigger for regular proactive cycles (adaptive backoff)
 2. CronTrigger for the mandatory morning report
+3. IntervalTrigger for the 30-min mechanical sweep (proposal expiry/dispatch)
+4. CronTrigger for goal staleness scanning (user ego only, twice daily)
 
 All cycle types (proactive, morning report, reactive, escalation) flow
 through the unified signal consumer loop: signal sources push EgoSignal
@@ -157,6 +159,17 @@ class EgoCadenceManager:
             max_instances=1,
             misfire_grace_time=300,
         )
+        # Goal staleness scanner: push goal_review signals for stale goals.
+        # User ego only — genesis ego has no goal jurisdiction. Skipped at
+        # runtime via source_tag check but also gate registration for clarity.
+        if self._session._source_tag == "user_ego_cycle":
+            self._scheduler.add_job(
+                self._check_stale_goals,
+                CronTrigger(hour="10,16", timezone=user_timezone()),
+                id="ego_goal_staleness",
+                max_instances=1,
+                misfire_grace_time=600,
+            )
         self._scheduler.start()
         from genesis.util.tasks import tracked_task
 
@@ -332,6 +345,66 @@ class EgoCadenceManager:
             logger.debug("Deadline scanner found %d approaching event(s)", len(events))
         except Exception:
             logger.debug("Deadline scanner failed", exc_info=True)
+
+    # -- Goal staleness scanner ------------------------------------------------
+
+    async def _check_stale_goals(self) -> None:
+        """Push goal_review signals for goals stale beyond threshold.
+
+        Queries user_goals.updated_at and pushes one signal per stale goal.
+        Only meaningful for the user ego — the genesis ego has no goal
+        jurisdiction.  Registration is gated in start() but we double-check
+        source_tag here as defense-in-depth.
+        """
+        if self._session._source_tag != "user_ego_cycle":
+            return
+        if not self._should_run(skip_idle_check=True):
+            return
+
+        try:
+            from genesis.db.crud import user_goals
+
+            goals = await user_goals.list_active(self._db)
+            if not goals:
+                return
+
+            threshold_days = self._config.goal_review_staleness_days
+            now = datetime.now(UTC)
+            pushed = 0
+
+            for g in goals:
+                updated_at = g.get("updated_at") or g.get("created_at") or ""
+                if not updated_at:
+                    continue
+                try:
+                    updated = datetime.fromisoformat(updated_at)
+                    if updated.tzinfo is None:
+                        updated = updated.replace(tzinfo=UTC)
+                    days_stale = (now - updated).days
+                except (ValueError, TypeError):
+                    continue
+
+                if days_stale < threshold_days:
+                    continue
+
+                title = (g.get("title") or "?")[:80]
+                signal = EgoSignal(
+                    signal_type="timer",
+                    focus_category="goal_review",
+                    summary=f"Goal stale ({days_stale}d): {title}",
+                    priority="medium",
+                    focus_id=g["id"],
+                    metadata={},
+                )
+                if self._signal_queue.push(signal):
+                    pushed += 1
+
+            if pushed:
+                logger.info(
+                    "Goal staleness scanner: %d signal(s) pushed", pushed,
+                )
+        except Exception:
+            logger.debug("Goal staleness scanner failed", exc_info=True)
 
     # -- Tick handlers -----------------------------------------------------
 

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -364,7 +364,7 @@ class EgoCadenceManager:
         try:
             from genesis.db.crud import user_goals
 
-            goals = await user_goals.list_active(self._db)
+            goals = await user_goals.list_active(self._session._db)
             if not goals:
                 return
 

--- a/src/genesis/ego/compaction.py
+++ b/src/genesis/ego/compaction.py
@@ -93,6 +93,7 @@ class CompactionEngine:
         *,
         context_builder: EgoContextBuilder,
         context_weights: dict[str, str] | None = None,
+        focus_id: str | None = None,
     ) -> str:
         """Assemble operational context for a new ego cycle.
 
@@ -106,6 +107,9 @@ class CompactionEngine:
             Optional per-section weight dict from the focus selector.
             Keys are section names, values are "always"/"deep"/"light"/"skip".
             When None, all sections are built at full depth (backward compat).
+        focus_id:
+            Optional target ID from the focus selector (e.g., goal_id).
+            Forwarded to the context builder for focused sections.
         """
         sections: list[str] = []
 
@@ -153,6 +157,7 @@ class CompactionEngine:
         sections.append("## Operational Context\n")
         fresh_context = await context_builder.build(
             context_weights=context_weights,
+            focus_id=focus_id,
         )
         sections.append(fresh_context)
 

--- a/src/genesis/ego/context.py
+++ b/src/genesis/ego/context.py
@@ -44,6 +44,7 @@ class EgoContextBuilder:
         self,
         *,
         context_weights: dict[str, str] | None = None,
+        focus_id: str | None = None,
     ) -> str:
         """Assemble the full EGO_CONTEXT.md content.
 
@@ -54,6 +55,9 @@ class EgoContextBuilder:
             Accepted for API compatibility with the unified loop, but this
             base class does not implement section filtering. Subclasses
             (UserEgoContextBuilder, GenesisEgoContextBuilder) implement it.
+        focus_id:
+            Optional target ID (e.g., goal_id) from the focus selector.
+            Used by UserEgoContextBuilder for goal-specific deep dives.
         """
         sections: list[str] = []
         sections.append("# EGO_CONTEXT — Operational Briefing\n")

--- a/src/genesis/ego/focus.py
+++ b/src/genesis/ego/focus.py
@@ -84,6 +84,7 @@ _ALL_SECTIONS = (
     "proposal_board",
     "execution_outcomes",
     "goal_progress",
+    "goal_deep_dive",
     "capability_performance",
     "autonomy_readiness",
     "recurring_patterns",
@@ -111,11 +112,12 @@ def _make_weights(overrides: dict[str, str]) -> dict[str, str]:
 _DEFAULT_WEIGHTS = _make_weights({})
 
 FOCUS_CONTEXT_WEIGHTS: dict[str, dict[str, str]] = {
-    # Proactive: breadth scan, everything deep (same as current)
-    "proactive": _DEFAULT_WEIGHTS,
+    # Proactive: breadth scan, everything deep — except goal_deep_dive
+    # (deep dive only fires during dedicated goal_review cycles)
+    "proactive": _make_weights({"goal_deep_dive": "skip"}),
 
-    # Daily briefing: needs full breadth for the morning report
-    "daily_briefing": _DEFAULT_WEIGHTS,
+    # Daily briefing: full breadth for the morning report — no deep dive
+    "daily_briefing": _make_weights({"goal_deep_dive": "skip"}),
 
     # Reactive: health/escalations deep, others light
     "reactive": _make_weights({
@@ -125,6 +127,7 @@ FOCUS_CONTEXT_WEIGHTS: dict[str, dict[str, str]] = {
         "follow_ups": "deep",
         "goals": "light",
         "goal_progress": "light",
+        "goal_deep_dive": "skip",
         "world_snapshot": "light",
         "activity_pulse": "light",
         "recent_conversations": "light",
@@ -140,6 +143,7 @@ FOCUS_CONTEXT_WEIGHTS: dict[str, dict[str, str]] = {
     "goal_review": _make_weights({
         "goals": "deep",
         "goal_progress": "deep",
+        "goal_deep_dive": "deep",
         "execution_outcomes": "deep",
         "follow_ups": "deep",
         "proposal_board": "deep",
@@ -160,6 +164,7 @@ FOCUS_CONTEXT_WEIGHTS: dict[str, dict[str, str]] = {
         "execution_outcomes": "deep",
         "goals": "deep",
         "goal_progress": "deep",
+        "goal_deep_dive": "skip",
         "proposal_board": "deep",
         "follow_ups": "light",
         "world_snapshot": "skip",
@@ -181,6 +186,7 @@ FOCUS_CONTEXT_WEIGHTS: dict[str, dict[str, str]] = {
         "proposal_board": "deep",
         "goals": "light",
         "goal_progress": "light",
+        "goal_deep_dive": "skip",
         "world_snapshot": "light",
         "activity_pulse": "light",
         "recent_conversations": "light",

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -46,6 +46,7 @@ class GenesisEgoContextBuilder:
         self,
         *,
         context_weights: dict[str, str] | None = None,
+        focus_id: str | None = None,
     ) -> str:
         """Assemble the full Genesis ego context.
 
@@ -55,6 +56,8 @@ class GenesisEgoContextBuilder:
             Per-section weight dict from the focus selector.
             Keys that match genesis section names are applied; unknown
             keys are ignored (default to "deep").
+        focus_id:
+            Accepted for API compatibility. Not used by Genesis ego.
         """
         import asyncio
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -186,6 +186,7 @@ class EgoSession:
         dynamic_context = await self._compaction.assemble_context(
             context_builder=self._context_builder,
             context_weights=focus.context_weights if focus else None,
+            focus_id=focus.focus_id if focus else None,
         )
 
         # Focus-specific prompt
@@ -305,6 +306,26 @@ class EgoSession:
         # 4. LEARN — record cycle outcome
         await self._record_cycle_outcome(cycle, focus)
 
+        # 5. Goal review post-processing: surface status recommendation
+        if focus.focus_type == "goal_review" and focus.focus_id:
+            try:
+                parsed_output = self._parse_output(cycle.output_text)
+                if parsed_output:
+                    goal_rec = parsed_output.get("goal_status_recommendation")
+                    if goal_rec and goal_rec != "continue":
+                        await self._surface_goal_recommendation(
+                            goal_id=focus.focus_id,
+                            recommendation=goal_rec,
+                            assessment=parsed_output.get(
+                                "goal_assessment", ""
+                            ),
+                        )
+            except Exception:
+                logger.debug(
+                    "Goal recommendation post-processing failed",
+                    exc_info=True,
+                )
+
         return cycle
 
     async def _perceive(self, signals: list[EgoSignal]) -> FocusResult | None:
@@ -377,12 +398,60 @@ class EgoSession:
                 signals_consumed=json.dumps(focus.signals_consumed),
                 perception_rationale=focus.rationale,
                 perceive_cost_usd=focus.perceive_cost_usd,
+                assessment=getattr(self, "_last_goal_assessment", None),
             )
         except Exception:
             logger.warning(
                 "Failed to record cycle outcome for %s",
                 cycle.id,
                 exc_info=True,
+            )
+
+    async def _surface_goal_recommendation(
+        self,
+        *,
+        goal_id: str,
+        recommendation: str,
+        assessment: str,
+    ) -> None:
+        """Surface a goal status recommendation as an observation.
+
+        The ego assesses; the user decides. Recommendations appear in the
+        user's morning report and may trigger Telegram notifications via
+        the outreach pipeline.
+        """
+        import uuid
+
+        from genesis.db.crud import observations as obs_crud
+
+        try:
+            from genesis.db.crud import user_goals
+
+            goal = await user_goals.get_by_id(self._db, goal_id)
+            title = (goal.get("title") or "?") if goal else "?"
+            content = (
+                f"Goal review recommendation for '{title}': "
+                f"**{recommendation}**\n\n"
+                f"Assessment: {assessment[:500]}"
+            )
+            await obs_crud.create(
+                self._db,
+                id=str(uuid.uuid4()),
+                source="user_ego",
+                type="goal_recommendation",
+                content=content,
+                priority="medium",
+                category="goal_review",
+                created_at=datetime.now(UTC).isoformat(),
+            )
+            logger.info(
+                "Goal recommendation surfaced: %s → %s",
+                goal_id[:12],
+                recommendation,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to surface goal recommendation", exc_info=True,
             )
 
     # -- Output processing --------------------------------------------------
@@ -456,6 +525,12 @@ class EgoSession:
                 )
             except Exception:
                 logger.warning("Failed to record ego last_run", exc_info=True)
+
+        # 8b. Extract goal_assessment for Learn phase (goal_review cycles).
+        # Stored in ego_cycle_outcomes.assessment by _record_cycle_outcome().
+        self._last_goal_assessment = (
+            parsed.get("goal_assessment") if parsed else None
+        )
 
         # 9. Process proposals
         if parsed:
@@ -709,7 +784,10 @@ class EgoSession:
             directive += (
                 "\n\nThis is a GOAL REVIEW cycle. Assess progress on the "
                 "focused goal, identify blockers, and propose goal-advancing "
-                "actions. Include the goal_assessment field."
+                "actions. Include the goal_assessment field with your analysis "
+                "of the goal's current state. Include "
+                "goal_status_recommendation: one of "
+                '"continue", "pause", "deprioritize", or "close".'
             )
         elif focus.focus_type == "reactive":
             directive += (
@@ -1820,5 +1898,19 @@ def _validate_output(data: dict) -> dict | None:
                 and isinstance(r.get("id"), str)
                 and r["id"]
             ]
+
+    # Sanitize goal_assessment — optional free text, string only.
+    if "goal_assessment" in data and not isinstance(
+        data["goal_assessment"], str
+    ):
+        data["goal_assessment"] = ""
+
+    # Sanitize goal_status_recommendation — optional enum.
+    _VALID_GOAL_RECS = ("continue", "pause", "deprioritize", "close")
+    if (
+        "goal_status_recommendation" in data
+        and data["goal_status_recommendation"] not in _VALID_GOAL_RECS
+    ):
+        del data["goal_status_recommendation"]
 
     return data

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -321,7 +321,7 @@ class EgoSession:
                             ),
                         )
             except Exception:
-                logger.debug(
+                logger.warning(
                     "Goal recommendation post-processing failed",
                     exc_info=True,
                 )
@@ -450,7 +450,7 @@ class EgoSession:
                 recommendation,
             )
         except Exception:
-            logger.debug(
+            logger.warning(
                 "Failed to surface goal recommendation", exc_info=True,
             )
 

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -1159,7 +1159,7 @@ class UserEgoContextBuilder:
         - All proposals linked to this goal (last 20, all statuses)
         """
         focus_id = getattr(self, "_current_focus_id", None)
-        if not focus_id or depth == "skip":
+        if depth in ("skip", "light") or not focus_id:
             return ""
 
         try:

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -84,6 +84,7 @@ class UserEgoContextBuilder:
         self,
         *,
         context_weights: dict[str, str] | None = None,
+        focus_id: str | None = None,
     ) -> str:
         """Assemble the full user ego context.
 
@@ -93,9 +94,14 @@ class UserEgoContextBuilder:
             Per-section weight dict from the focus selector.
             Values: "always", "deep", "light", "skip".
             When None, all sections render at full depth (backward compat).
+        focus_id:
+            Target ID from the focus selector (e.g., a goal_id for
+            goal_review cycles). Used by _goal_deep_dive_section to
+            render focused context on a specific goal.
         """
         from genesis.ego.focus import _ALWAYS_SECTIONS
 
+        self._current_focus_id = focus_id
         weights = dict(context_weights) if context_weights else {}
         # Primary enforcement is in compaction.assemble_context(). This
         # is a defense-in-depth guard for direct build() callers.
@@ -131,6 +137,7 @@ class UserEgoContextBuilder:
             ("proposal_board", self._proposal_board_section),
             ("execution_outcomes", self._execution_outcomes_section),
             ("goal_progress", self._goal_progress_section),
+            ("goal_deep_dive", self._goal_deep_dive_section),
             ("capability_performance", self._capability_performance_section),
             ("autonomy_readiness", self._autonomy_readiness_section),
             ("recurring_patterns", self._recurring_patterns_section),
@@ -1142,6 +1149,112 @@ class UserEgoContextBuilder:
         lines.append("")
         return "\n".join(lines)
 
+    async def _goal_deep_dive_section(self, *, depth: str = "deep") -> str:
+        """Deep dive on the focused goal — only rendered during goal_review.
+
+        When the focus selector targets a specific goal (via focus_id),
+        this section provides the ego with comprehensive context:
+        - Full goal metadata
+        - Complete progress note history (last 15)
+        - All proposals linked to this goal (last 20, all statuses)
+        """
+        focus_id = getattr(self, "_current_focus_id", None)
+        if not focus_id or depth == "skip":
+            return ""
+
+        try:
+            from genesis.db.crud import user_goals
+        except ImportError:
+            return ""
+
+        try:
+            goal = await user_goals.get_by_id(self._db, focus_id)
+        except Exception:
+            logger.debug("Failed to fetch goal %s for deep dive", focus_id)
+            return ""
+
+        if not goal:
+            return f"## Goal Deep Dive\n*Goal {focus_id} not found.*\n"
+
+        lines = [f"## Goal Deep Dive: {goal.get('title', '?')}\n"]
+
+        # Full goal metadata
+        lines.append(f"- **ID**: {focus_id}")
+        lines.append(f"- **Category**: {goal.get('category', '?')}")
+        lines.append(f"- **Priority**: {goal.get('priority', '?')}")
+        lines.append(f"- **Status**: {goal.get('status', '?')}")
+        lines.append(f"- **Timeline**: {goal.get('timeline') or 'None set'}")
+        lines.append(f"- **Created**: {(goal.get('created_at') or '?')[:10]}")
+        lines.append(f"- **Last Updated**: {(goal.get('updated_at') or '?')[:10]}")
+        lines.append(f"- **Confidence**: {goal.get('confidence', '?')}")
+        if goal.get("description"):
+            lines.append(f"- **Description**: {goal['description'][:300]}")
+        lines.append("")
+
+        # Full progress note history (last 15)
+        import json as _json
+
+        progress_raw = goal.get("progress_notes", "[]")
+        try:
+            notes = (
+                _json.loads(progress_raw)
+                if isinstance(progress_raw, str)
+                else progress_raw
+            )
+        except (_json.JSONDecodeError, TypeError):
+            notes = []
+
+        if notes and isinstance(notes, list):
+            lines.append("### Progress History\n")
+            for note in notes[-15:]:
+                if isinstance(note, dict):
+                    date = note.get("date", "?")
+                    text = note.get("note", str(note))[:200]
+                else:
+                    date = "?"
+                    text = str(note)[:200]
+                lines.append(f"- [{date}] {text}")
+            if len(notes) > 15:
+                lines.append(f"- ... and {len(notes) - 15} earlier entries")
+            lines.append("")
+        else:
+            lines.append("### Progress History\n*No progress notes recorded.*\n")
+
+        # All proposals linked to this goal (last 20, all statuses)
+        try:
+            cursor = await self._db.execute(
+                "SELECT action_type, content, status, rationale, "
+                "  created_at, user_response "
+                "FROM ego_proposals "
+                "WHERE goal_id = ? "
+                "ORDER BY created_at DESC "
+                "LIMIT 20",
+                (focus_id,),
+            )
+            proposal_rows = await cursor.fetchall()
+        except Exception:
+            logger.debug("Failed to query proposals for goal %s", focus_id)
+            proposal_rows = []
+
+        if proposal_rows:
+            from genesis.ego.types import NEUTRAL_STATUS
+
+            lines.append("### Goal-Linked Proposals\n")
+            for row in proposal_rows:
+                action = row[0] or "?"
+                content = (row[1] or "")[:150].replace("\n", " ")
+                status = NEUTRAL_STATUS.get(row[2], row[2]) if row[2] else "?"
+                created = (row[4] or "")[:10]
+                lines.append(f"- [{created}] [{status}] **{action}**: {content}")
+            lines.append("")
+        else:
+            lines.append(
+                "### Goal-Linked Proposals\n*No proposals for this goal.*\n"
+            )
+
+        lines.append("")
+        return "\n".join(lines)
+
     async def _capability_performance_section(self, *, depth: str = "deep") -> str:
         """Your track record — domain confidence from multiple data sources.
 
@@ -1305,7 +1418,9 @@ class UserEgoContextBuilder:
             '  "resolved_directives": [{"id": "directive_id", "resolution": "what you decided"}],\n'
             '  "intentions": {"review": [{"id": "...", "action": "keep|fire|withdraw|renew"}], '
             '"new": [{"content": "...", "trigger_condition": "...", "reasoning": "..."}]},\n'
-            '  "morning_report": "only if this is a morning trigger"\n'
+            '  "morning_report": "only if this is a morning trigger",\n'
+            '  "goal_assessment": "free-text analysis of the focused goal (goal_review cycles only)",\n'
+            '  "goal_status_recommendation": "continue|pause|deprioritize|close (goal_review cycles only)"\n'
             "}\n"
             "```\n\n"
             "If you have nothing to propose, return an empty proposals "

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -876,3 +876,107 @@ class TestEscalationSignals:
         call_args = mock_session.run_unified_cycle.call_args
         assert call_args[1]["model_override"] == "sonnet"
         assert call_args[1]["effort_override"] == "medium"
+
+
+# ---------------------------------------------------------------------------
+# Goal staleness scanner
+# ---------------------------------------------------------------------------
+
+
+class TestGoalStaleness:
+    """Tests for _check_stale_goals() — goal_review signal collector."""
+
+    @pytest.fixture
+    async def goal_db(self):
+        """DB with user_goals table."""
+        async with aiosqlite.connect(":memory:") as conn:
+            conn.row_factory = aiosqlite.Row
+            for table in ("ego_cycles", "ego_state", "cc_sessions", "user_goals"):
+                await conn.execute(TABLES[table])
+            await conn.commit()
+            yield conn
+
+    @pytest.fixture
+    def goal_cadence(self, mock_session, config, mock_idle_detector, goal_db):
+        mock_session._source_tag = "user_ego_cycle"
+        mock_session._db = goal_db
+        return EgoCadenceManager(
+            session=mock_session,
+            config=config,
+            idle_detector=mock_idle_detector,
+            db=goal_db,
+        )
+
+    async def test_stale_goal_pushes_signal(self, goal_cadence, goal_db):
+        """Goal stale beyond threshold pushes a goal_review signal."""
+        twenty_days_ago = (datetime.now(UTC) - timedelta(days=20)).isoformat()
+        await goal_db.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, priority, status, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("goal-1", "Test Goal", "project", "high", "active",
+             twenty_days_ago, twenty_days_ago),
+        )
+        await goal_db.commit()
+
+        await goal_cadence._check_stale_goals()
+
+        assert not goal_cadence._signal_queue.empty()
+        signals = goal_cadence._signal_queue.drain()
+        assert len(signals) == 1
+        sig = signals[0]
+        assert sig.focus_category == "goal_review"
+        assert sig.focus_id == "goal-1"
+        assert "20d" in sig.summary
+
+    async def test_fresh_goal_no_signal(self, goal_cadence, goal_db):
+        """Goal updated recently should NOT trigger a signal."""
+        now = datetime.now(UTC).isoformat()
+        await goal_db.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, priority, status, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("goal-2", "Fresh Goal", "project", "medium", "active", now, now),
+        )
+        await goal_db.commit()
+
+        await goal_cadence._check_stale_goals()
+        assert goal_cadence._signal_queue.empty()
+
+    async def test_genesis_ego_skipped(self, goal_cadence, goal_db):
+        """Genesis ego should NOT run goal staleness checks."""
+        goal_cadence._session._source_tag = "genesis_ego_cycle"
+        twenty_days_ago = (datetime.now(UTC) - timedelta(days=20)).isoformat()
+        await goal_db.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, priority, status, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("goal-3", "Stale Goal", "career", "high", "active",
+             twenty_days_ago, twenty_days_ago),
+        )
+        await goal_db.commit()
+
+        await goal_cadence._check_stale_goals()
+        assert goal_cadence._signal_queue.empty()
+
+    async def test_respects_config_threshold(self, goal_cadence, goal_db):
+        """Uses goal_review_staleness_days from config."""
+        # Set threshold to 30 days, goal is only 15 days old
+        goal_cadence._config.goal_review_staleness_days = 30
+        fifteen_days_ago = (datetime.now(UTC) - timedelta(days=15)).isoformat()
+        await goal_db.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, priority, status, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("goal-4", "Not Stale Yet", "learning", "medium", "active",
+             fifteen_days_ago, fifteen_days_ago),
+        )
+        await goal_db.commit()
+
+        await goal_cadence._check_stale_goals()
+        assert goal_cadence._signal_queue.empty()
+
+        # Now set threshold to 10 — same goal should trigger
+        goal_cadence._config.goal_review_staleness_days = 10
+        await goal_cadence._check_stale_goals()
+        assert not goal_cadence._signal_queue.empty()

--- a/tests/ego/test_context_weights.py
+++ b/tests/ego/test_context_weights.py
@@ -259,6 +259,7 @@ class TestCompactionWeightThreading:
 
         mock_builder.build.assert_called_once_with(
             context_weights={"goals": "light", "capabilities": "skip"},
+            focus_id=None,
         )
 
     async def test_always_sections_enforced_in_compaction(self, db):
@@ -305,7 +306,9 @@ class TestCompactionWeightThreading:
         mock_builder.build.return_value = "mock context"
 
         await engine.assemble_context(context_builder=mock_builder)
-        mock_builder.build.assert_called_once_with(context_weights=None)
+        mock_builder.build.assert_called_once_with(
+            context_weights=None, focus_id=None,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -368,6 +371,24 @@ class TestFocusWeightTable:
         assert FOCUS_CONTEXT_WEIGHTS["dispatch_outcome"]["proposal_history"] == "light"
 
     def test_section_count(self):
-        """_ALL_SECTIONS should have exactly 19 entries."""
+        """_ALL_SECTIONS should have exactly 20 entries."""
         from genesis.ego.focus import _ALL_SECTIONS
-        assert len(_ALL_SECTIONS) == 19
+        assert len(_ALL_SECTIONS) == 20
+
+    def test_goal_deep_dive_deep_for_goal_review(self):
+        """goal_deep_dive is 'deep' only during goal_review cycles."""
+        from genesis.ego.focus import FOCUS_CONTEXT_WEIGHTS
+
+        assert FOCUS_CONTEXT_WEIGHTS["goal_review"]["goal_deep_dive"] == "deep"
+
+    def test_goal_deep_dive_skip_for_non_goal_review(self):
+        """goal_deep_dive is 'skip' for all non-goal_review focus types."""
+        from genesis.ego.focus import FOCUS_CONTEXT_WEIGHTS
+
+        for focus_type in (
+            "proactive", "daily_briefing", "reactive",
+            "dispatch_outcome", "escalation",
+        ):
+            assert (
+                FOCUS_CONTEXT_WEIGHTS[focus_type]["goal_deep_dive"] == "skip"
+            ), f"goal_deep_dive should be 'skip' for {focus_type}"

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -615,3 +615,76 @@ class TestOutputContractCommDecision:
 # Focus sanitization tests removed — focus_summary is now system-computed
 # (computed_focus.py). Tests for compute_focus_summary are in
 # tests/ego/test_computed_focus.py.
+
+
+# ---------------------------------------------------------------------------
+# Goal assessment output
+# ---------------------------------------------------------------------------
+
+
+class TestGoalAssessmentOutput:
+    """Tests for goal_assessment + goal_status_recommendation processing."""
+
+    def test_validate_output_accepts_goal_assessment(self):
+        """goal_assessment string passes validation."""
+        from genesis.ego.session import _validate_output
+
+        data = {
+            "proposals": [],
+            "focus_summary": "Goal review",
+            "goal_assessment": "This goal is on track but needs more focus.",
+            "goal_status_recommendation": "continue",
+        }
+        result = _validate_output(data)
+        assert result is not None
+        assert result["goal_assessment"] == "This goal is on track but needs more focus."
+        assert result["goal_status_recommendation"] == "continue"
+
+    def test_validate_output_sanitizes_invalid_goal_assessment(self):
+        """Non-string goal_assessment gets sanitized to empty string."""
+        from genesis.ego.session import _validate_output
+
+        data = {
+            "proposals": [],
+            "focus_summary": "Goal review",
+            "goal_assessment": 42,
+        }
+        result = _validate_output(data)
+        assert result is not None
+        assert result["goal_assessment"] == ""
+
+    def test_validate_output_rejects_invalid_recommendation(self):
+        """Invalid goal_status_recommendation gets removed."""
+        from genesis.ego.session import _validate_output
+
+        data = {
+            "proposals": [],
+            "focus_summary": "Goal review",
+            "goal_status_recommendation": "invalid_value",
+        }
+        result = _validate_output(data)
+        assert result is not None
+        assert "goal_status_recommendation" not in result
+
+    def test_validate_output_accepts_all_valid_recommendations(self):
+        """All valid recommendation values pass validation."""
+        from genesis.ego.session import _validate_output
+
+        for rec in ("continue", "pause", "deprioritize", "close"):
+            data = {
+                "proposals": [],
+                "focus_summary": "Goal review",
+                "goal_status_recommendation": rec,
+            }
+            result = _validate_output(data)
+            assert result is not None
+            assert result["goal_status_recommendation"] == rec
+
+    def test_output_contract_includes_goal_fields(self):
+        """Output contract mentions goal_assessment and goal_status_recommendation."""
+        from genesis.ego.user_context import UserEgoContextBuilder
+
+        contract = UserEgoContextBuilder._output_contract_section()
+        assert "goal_assessment" in contract
+        assert "goal_status_recommendation" in contract
+        assert "continue|pause|deprioritize|close" in contract

--- a/tests/ego/test_user_context.py
+++ b/tests/ego/test_user_context.py
@@ -844,3 +844,102 @@ class TestUserEgoContextBuilder:
         )
         result = await builder._recurring_patterns_section()
         assert "No recurring patterns detected" in result
+
+    # ── Goal Deep Dive ──────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_goal_deep_dive_empty_without_focus_id(
+        self, db, mock_health_data, capabilities,
+    ):
+        """Deep dive returns empty string when no focus_id is set."""
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        await builder.build()
+        result = await builder._goal_deep_dive_section()
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_goal_deep_dive_renders_with_focus_id(
+        self, db, mock_health_data, capabilities,
+    ):
+        """Deep dive renders full goal info when focus_id is set."""
+        await db.execute(TABLES["user_goals"])
+        await db.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, priority, status, description, "
+            " timeline, confidence, created_at, updated_at, progress_notes) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("goal-dd1", "Master Kubernetes", "learning", "high", "active",
+             "Learn K8s for deployment", "2026-06-30", 0.6,
+             "2026-05-01", "2026-05-10",
+             json.dumps([
+                 {"date": "2026-05-05", "note": "Completed pods tutorial"},
+                 {"date": "2026-05-10", "note": "Started services chapter"},
+             ])),
+        )
+        await db.commit()
+
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        builder._current_focus_id = "goal-dd1"
+        result = await builder._goal_deep_dive_section()
+
+        assert "Goal Deep Dive: Master Kubernetes" in result
+        assert "goal-dd1" in result
+        assert "learning" in result
+        assert "high" in result
+        assert "2026-06-30" in result
+        assert "Completed pods tutorial" in result
+        assert "Started services chapter" in result
+
+    @pytest.mark.asyncio
+    async def test_goal_deep_dive_shows_proposals(
+        self, db, mock_health_data, capabilities,
+    ):
+        """Deep dive shows linked proposals."""
+        await db.execute(TABLES["user_goals"])
+        # Fixture creates ego_proposals inline without goal_id — add column
+        import contextlib
+        with contextlib.suppress(Exception):
+            await db.execute(
+                "ALTER TABLE ego_proposals ADD COLUMN goal_id TEXT",
+            )
+        await db.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, priority, status, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("goal-dd2", "Fix Auth", "project", "critical", "active",
+             "2026-05-01", "2026-05-10"),
+        )
+        await db.execute(
+            "INSERT INTO ego_proposals "
+            "(id, action_type, content, status, goal_id, confidence, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("prop-1", "investigate", "Audit auth middleware",
+             "executed", "goal-dd2", 0.9, "2026-05-12"),
+        )
+        await db.commit()
+
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        builder._current_focus_id = "goal-dd2"
+        result = await builder._goal_deep_dive_section()
+
+        assert "Goal-Linked Proposals" in result
+        assert "Audit auth middleware" in result
+        assert "completed" in result  # NEUTRAL_STATUS maps executed → completed
+
+    @pytest.mark.asyncio
+    async def test_goal_deep_dive_skip_depth(
+        self, db, mock_health_data, capabilities,
+    ):
+        """Deep dive returns empty when depth is 'skip'."""
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        builder._current_focus_id = "goal-123"
+        result = await builder._goal_deep_dive_section(depth="skip")
+        assert result == ""


### PR DESCRIPTION
## Summary

- **Goal staleness signal collector** — CronTrigger job in `cadence.py` runs at 10:00/16:00 user TZ (user ego only). Queries `user_goals.updated_at` and pushes `goal_review` signals for goals stale beyond `config.goal_review_staleness_days` (default 10d).
- **Goal deep-dive context section** — New `_goal_deep_dive_section()` in `user_context.py` renders full progress note history (last 15) + all goal-linked proposals (last 20) when `focus_id` targets a specific goal. Gated by context weights: `deep` only during `goal_review`, `skip` for all other focus types.
- **Structured output** — `goal_assessment` (free text) stored in `ego_cycle_outcomes.assessment` (column existed, never populated). `goal_status_recommendation` (continue/pause/deprioritize/close) surfaced as observation for user action when not "continue".
- **focus_id threading** — Threaded through `session.run_unified_cycle` → `compaction.assemble_context` → `context_builder.build()`. All 3 builder classes accept the parameter; only `UserEgoContextBuilder` uses it.

PR 6 of the ego v2 unified cognitive loop migration. Activates the `FocusCategory.GOAL_REVIEW` groundwork from PRs 1-4.

## Wiring

```
CronTrigger(10:00, 16:00)
  → _check_stale_goals()
    → SignalQueue.push(goal_review, focus_id=goal_id)
      → consumer → run_unified_cycle
        → _goal_deep_dive_section (deep context)
        → goal_assessment → ego_cycle_outcomes.assessment
        → goal_status_recommendation → observation
```

## Test plan

- [x] 15 new tests across 4 test files (staleness, deep-dive, assessment output, weight tables)
- [x] 514 total ego tests pass (zero regressions)
- [x] `ruff check` clean on all modified files
- [x] Code review: 3 findings addressed (DB consistency, depth guard, log level)
- [ ] CI green
- [ ] After deploy: monitor `ego_cycle_outcomes` for non-null `assessment` values on goal_review cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)