### PR TITLE
docs: remove private infra reference from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 - **User job timezone fix** (#490) --- scheduler respects user timezone
   for job scheduling.
 - **Ego CycleType removal** (#486) --- legacy run_cycle() enum removed.
+- **AWS EC2 install testing** (#488) --- real AWS provider for weekly
+  install validation. Ephemeral instances, auto-resolved AMIs, SSH via
+  system client.
+- **PageIndex document indexing** (#487) --- tree-based vectorless RAG
+  for structured PDFs via PageIndex cloud API.
+- **Dream cycle entity resolution** (#483) --- graph enrichment during
+  dream cycles with entity resolution and relationship extraction.
+
+### Fixed
+
+- **CodeQL security alerts** (#485) --- resolved all 8 open alerts.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,6 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 - **User job timezone fix** (#490) --- scheduler respects user timezone
   for job scheduling.
 - **Ego CycleType removal** (#486) --- legacy run_cycle() enum removed.
-- **AWS EC2 install testing** (#488) --- real AWS provider for weekly
-  install validation. Ephemeral instances, auto-resolved AMIs, SSH via
-  system client.
 - **PageIndex document indexing** (#487) --- tree-based vectorless RAG
   for structured PDFs via PageIndex cloud API.
 - **Dream cycle entity resolution** (#483) --- graph enrichment during


### PR DESCRIPTION
Remove #488 entry from v3.0b12.1 changelog — private testing infrastructure, not user-facing.