### PR TITLE
feat(ci): add content validation hooks and gitleaks rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,21 @@ jobs:
           fi
           echo "Email scan: CLEAN"
 
+      - name: PR description scan
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          body=$(gh pr view ${{ github.event.pull_request.number }} --json body -q .body 2>/dev/null || echo "")
+          PATTERNS='10\.176\.[0-9]|192\.168\.50\.[0-9]|100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.|046056[0-9]{6}|moonandstar|zorror|assistant1'
+          if echo "$body" | grep -qE "$PATTERNS"; then
+            echo "::error::PR description contains private infrastructure details"
+            echo "$body" | grep -nE "$PATTERNS" || true
+            exit 1
+          fi
+          echo "PR description scan: CLEAN"
+
   migration-check:
     # Catch duplicate migration prefixes before merge — two PRs creating
     # the same NNNN_*.py prefix will collide at runtime.

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,50 @@
+# Genesis PII/infrastructure leak prevention rules.
+#
+# Extends gitleaks default rules (API keys, tokens, etc.) with
+# install-specific patterns that shouldn't reach the public repo.
+#
+# Allowlisted paths: sanitizer code, release scripts, CI workflows,
+# and test fixtures that legitimately contain these patterns.
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "genesis-private-ip-10-176"
+description = "Install-specific private IP (Tailscale 10.176.x.x)"
+regex = '''10\.176\.\d{1,3}\.\d{1,3}'''
+tags = ["infrastructure", "genesis"]
+
+[[rules]]
+id = "genesis-private-ip-192-168-50"
+description = "Install-specific private IP (LAN 192.168.50.x)"
+regex = '''192\.168\.50\.\d{1,3}'''
+tags = ["infrastructure", "genesis"]
+
+[[rules]]
+id = "genesis-tailscale-cgnat"
+description = "Tailscale CGNAT address (100.64-127.x.x)"
+regex = '''100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}'''
+tags = ["infrastructure", "genesis"]
+
+[[rules]]
+id = "genesis-aws-account-id"
+description = "AWS account ID near identifying keyword"
+regex = '''(?i)(account.?id|aws.?account)[\s=:"']+\d{12}'''
+tags = ["cloud", "genesis"]
+
+[[rules]]
+id = "genesis-private-hostname"
+description = "Known private hostnames"
+regex = '''\b(zorror|assistant1)\b'''
+tags = ["infrastructure", "genesis"]
+
+# Global allowlist — paths that legitimately contain these patterns
+[allowlist]
+paths = [
+    '''tests/''',
+    '''scripts/prepare-public-release\.sh''',
+    '''\.github/workflows/''',
+    '''src/genesis/contribution/sanitize\.py''',
+    '''\.gitleaks\.toml''',
+]

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Genesis commit-msg hook — block private infrastructure details in commit messages.
+#
+# Patterns match install-specific IPs, personal email, AWS account IDs,
+# and private hostnames. Covers the gap that gitleaks (file-content only)
+# does not scan commit messages.
+
+PATTERNS='10\.176\.[0-9]|192\.168\.50\.[0-9]|100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.|046056[0-9]{6}|moonandstar|zorror|assistant1'
+
+if grep -qE "$PATTERNS" "$1"; then
+    echo ""
+    echo "BLOCKED: Commit message contains private infrastructure details."
+    echo ""
+    grep -nE "$PATTERNS" "$1"
+    echo ""
+    echo "Remove private IPs, hostnames, or account IDs from the commit message."
+    echo "If this is a false positive, commit with --no-verify (but think twice)."
+    echo ""
+    exit 1
+fi
+
+exit 0

--- a/scripts/hooks/sync-hooks.sh
+++ b/scripts/hooks/sync-hooks.sh
@@ -63,6 +63,7 @@ fi
 # Hooks to sync. Executable hook scripts AND their colocated helpers.
 # Extend this list as Phase 6 adds more hooks.
 HOOKS_TO_SYNC=(
+    "commit-msg"
     "post-commit"
     "pre-commit"
     "pre-push"


### PR DESCRIPTION
## Summary
Three-layer content validation for commit hygiene:

1. **gitleaks custom rules** (`.gitleaks.toml`) — extends default rules with project-specific patterns. Allowlists test fixtures and sanitizer code.
2. **commit-msg hook** — scans commit message text for the same patterns. Synced via `sync-hooks.sh`.
3. **CI PR description scan** — GitHub Actions step validates PR descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)