### PR TITLE
feat(ego): add goal decomposition — subgoals, cascade, goal_type, cadence

### DIFF
--- a/src/genesis/db/crud/user_goals.py
+++ b/src/genesis/db/crud/user_goals.py
@@ -251,12 +251,19 @@ async def check_completion_cascade(
     if parent.get("status") == "achieved":
         return None
 
-    # Check all children of this parent
+    # Check all children of this parent (exclude abandoned — they don't
+    # block cascade since they're intentionally dropped from scope)
     children = await list_children(db, parent_id, include_achieved=True)
     if not children:
         return None
 
-    all_achieved = all(c.get("status") == "achieved" for c in children)
+    live_children = [
+        c for c in children if c.get("status") != "abandoned"
+    ]
+    if not live_children:
+        return None
+
+    all_achieved = all(c.get("status") == "achieved" for c in live_children)
     if not all_achieved:
         return None
 

--- a/src/genesis/db/crud/user_goals.py
+++ b/src/genesis/db/crud/user_goals.py
@@ -21,6 +21,8 @@ async def create(
     parent_goal_id: str | None = None,
     evidence_source: str | None = None,
     confidence: float = 0.5,
+    goal_type: str = "milestone",
+    cadence_days: int | None = None,
 ) -> str:
     """Create a new goal. Returns the goal ID."""
     goal_id = str(uuid.uuid4())
@@ -29,12 +31,12 @@ async def create(
         """INSERT INTO user_goals
            (id, title, category, description, priority, status,
             timeline, parent_goal_id, evidence_source, confidence,
-            created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            goal_type, cadence_days, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             goal_id, title, category, description, priority, status,
             timeline, parent_goal_id, evidence_source, confidence,
-            now, now,
+            goal_type, cadence_days, now, now,
         ),
     )
     await db.commit()
@@ -50,7 +52,7 @@ async def update(
     allowed = {
         "title", "description", "category", "priority", "status",
         "timeline", "parent_goal_id", "evidence_source", "confidence",
-        "achieved_at",
+        "achieved_at", "goal_type", "cadence_days",
     }
     updates = {k: v for k, v in fields.items() if k in allowed}
     if not updates:
@@ -189,3 +191,73 @@ async def find_similar(
             best_match = goal
 
     return best_match
+
+
+async def list_children(
+    db: aiosqlite.Connection,
+    parent_goal_id: str,
+    *,
+    include_achieved: bool = False,
+) -> list[dict]:
+    """List child goals of a parent, ordered by priority."""
+    if include_achieved:
+        cursor = await db.execute(
+            "SELECT * FROM user_goals WHERE parent_goal_id = ? "
+            "ORDER BY CASE priority "
+            "  WHEN 'critical' THEN 0 WHEN 'high' THEN 1 "
+            "  WHEN 'medium' THEN 2 ELSE 3 END, created_at",
+            (parent_goal_id,),
+        )
+    else:
+        cursor = await db.execute(
+            "SELECT * FROM user_goals WHERE parent_goal_id = ? "
+            "AND status = 'active' "
+            "ORDER BY CASE priority "
+            "  WHEN 'critical' THEN 0 WHEN 'high' THEN 1 "
+            "  WHEN 'medium' THEN 2 ELSE 3 END, created_at",
+            (parent_goal_id,),
+        )
+    rows = await cursor.fetchall()
+    return [dict(r) for r in rows]
+
+
+async def check_completion_cascade(
+    db: aiosqlite.Connection,
+    goal_id: str,
+) -> dict | None:
+    """Check if achieving this goal completes all siblings of a parent.
+
+    Called after a child goal is marked achieved. If the parent is a
+    milestone goal and ALL its children are now achieved, returns the
+    parent info so the caller can surface a recommendation.
+
+    Returns ``{"parent_id": ..., "parent_title": ...}`` if cascade is
+    ready, or None otherwise.
+    """
+    goal = await get_by_id(db, goal_id)
+    if not goal or not goal.get("parent_goal_id"):
+        return None
+
+    parent_id = goal["parent_goal_id"]
+    parent = await get_by_id(db, parent_id)
+    if not parent:
+        return None
+
+    # Continuous goals don't cascade — they're ongoing by definition
+    if parent.get("goal_type") == "continuous":
+        return None
+
+    # Already achieved — no need to cascade again
+    if parent.get("status") == "achieved":
+        return None
+
+    # Check all children of this parent
+    children = await list_children(db, parent_id, include_achieved=True)
+    if not children:
+        return None
+
+    all_achieved = all(c.get("status") == "achieved" for c in children)
+    if not all_achieved:
+        return None
+
+    return {"parent_id": parent_id, "parent_title": parent.get("title", "?")}

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1341,6 +1341,21 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ON centrality_cache(centrality_score DESC)"
     )
 
+    # Goal decomposition (PR 7): goal_type + cadence_days on user_goals.
+    # goal_type distinguishes milestone (achievable) vs continuous (ongoing).
+    # cadence_days overrides the global staleness threshold per-goal.
+    await _try_alter(
+        db,
+        "ALTER TABLE user_goals ADD COLUMN goal_type TEXT NOT NULL "
+        "DEFAULT 'milestone' CHECK (goal_type IN ('milestone', 'continuous'))",
+        "user_goals.goal_type",
+    )
+    await _try_alter(
+        db,
+        "ALTER TABLE user_goals ADD COLUMN cadence_days INTEGER",
+        "user_goals.cadence_days",
+    )
+
 
 async def _migrate_cognitive_state_check(db: aiosqlite.Connection) -> None:
     """Rebuild cognitive_state if CHECK constraint lacks 'resilience_degradation'.

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1118,6 +1118,9 @@ TABLES = {
             parent_goal_id  TEXT,
             evidence_source TEXT,
             confidence      REAL NOT NULL DEFAULT 0.5,
+            goal_type       TEXT NOT NULL DEFAULT 'milestone'
+                            CHECK (goal_type IN ('milestone', 'continuous')),
+            cadence_days    INTEGER,              -- per-goal review cadence override (NULL = global default)
             created_at      TEXT NOT NULL
                             DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
             updated_at      TEXT NOT NULL

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -368,7 +368,7 @@ class EgoCadenceManager:
             if not goals:
                 return
 
-            threshold_days = self._config.goal_review_staleness_days
+            global_threshold = self._config.goal_review_staleness_days
             now = datetime.now(UTC)
             pushed = 0
 
@@ -384,6 +384,13 @@ class EgoCadenceManager:
                 except (ValueError, TypeError):
                     continue
 
+                # Per-goal cadence override (cadence_days > 0), else global
+                per_goal = g.get("cadence_days")
+                threshold_days = (
+                    per_goal
+                    if isinstance(per_goal, int) and per_goal > 0
+                    else global_threshold
+                )
                 if days_stale < threshold_days:
                     continue
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -784,9 +784,10 @@ class EgoSession:
             directive += (
                 "\n\nThis is a GOAL REVIEW cycle. Assess progress on the "
                 "focused goal, identify blockers, and propose goal-advancing "
-                "actions. Include the goal_assessment field with your analysis "
-                "of the goal's current state. Include "
-                "goal_status_recommendation: one of "
+                "actions. If this goal is too broad, suggest specific subgoals "
+                "in your goal_assessment that the user can create. Include "
+                "the goal_assessment field with your analysis of the goal's "
+                "current state. Include goal_status_recommendation: one of "
                 '"continue", "pause", "deprioritize", or "close".'
             )
         elif focus.focus_type == "reactive":

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -276,7 +276,7 @@ class UserEgoContextBuilder:
 
         try:
             from genesis.db.crud import user_goals
-            goals = await user_goals.list_active(self._db, limit=10)
+            goals = await user_goals.list_active(self._db, limit=20)
         except Exception:
             logger.debug("Failed to query user goals", exc_info=True)
             lines.append("*Goal tracking not yet populated.*\n")

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -318,13 +318,29 @@ class UserEgoContextBuilder:
 
         now = datetime.now(UTC)
 
+        # Group goals into hierarchy: top-level, children, orphans
+        active_ids = {g["id"] for g in goals}
+        top_level = []
+        children_by_parent: dict[str, list[dict]] = {}
         for g in goals:
+            pid = g.get("parent_goal_id")
+            if not pid:
+                top_level.append(g)
+            elif pid in active_ids:
+                children_by_parent.setdefault(pid, []).append(g)
+            else:
+                # Orphan: parent not in active list — render at top level
+                top_level.append(g)
+
+        async def _render_goal(g: dict, prefix: str = "- ") -> None:
             goal_id = g.get("id", "?")
             priority = g.get("priority", "medium")
             title = g.get("title", "?")[:120]
             category = g.get("category", "")
+            goal_type = g.get("goal_type", "milestone")
+            type_tag = " [continuous]" if goal_type == "continuous" else ""
 
-            # Staleness: days since updated_at
+            # Staleness
             updated_at = g.get("updated_at") or g.get("created_at") or ""
             stale_str = ""
             if updated_at:
@@ -341,10 +357,18 @@ class UserEgoContextBuilder:
             progress_notes_raw = g.get("progress_notes", "[]")
             try:
                 import json
-                notes = json.loads(progress_notes_raw) if isinstance(progress_notes_raw, str) else progress_notes_raw
+                notes = (
+                    json.loads(progress_notes_raw)
+                    if isinstance(progress_notes_raw, str)
+                    else progress_notes_raw
+                )
                 if notes and isinstance(notes, list):
                     latest = notes[-1]
-                    note_text = latest.get("note", str(latest)) if isinstance(latest, dict) else str(latest)
+                    note_text = (
+                        latest.get("note", str(latest))
+                        if isinstance(latest, dict)
+                        else str(latest)
+                    )
                     progress_str = f' | Last: "{note_text[:60]}"'
             except (json.JSONDecodeError, TypeError):
                 pass
@@ -352,24 +376,37 @@ class UserEgoContextBuilder:
             # Proposal outcome summary
             proposal_str = ""
             try:
-                summary = await ego_crud.get_goal_proposal_summary(self._db, goal_id)
+                summary = await ego_crud.get_goal_proposal_summary(
+                    self._db, goal_id,
+                )
                 if summary:
-                    parts = [f"{count} {status}" for status, count in summary.items()]
+                    parts = [
+                        f"{count} {status}"
+                        for status, count in summary.items()
+                    ]
                     proposal_str = f" | Proposals: {', '.join(parts)}"
             except Exception:
                 pass
 
-            # Render
             header = (
-                f"- [{priority.upper()}] **{title}** "
-                f"(id={goal_id}, {category})"
+                f"{prefix}[{priority.upper()}] **{title}** "
+                f"(id={goal_id}, {category}){type_tag}"
             )
-            detail_parts = [p for p in [stale_str, progress_str, proposal_str] if p]
+            detail_parts = [
+                p for p in [stale_str, progress_str, proposal_str] if p
+            ]
             if detail_parts:
                 detail = "".join(detail_parts).lstrip(" |")
-                lines.append(f"{header}\n  {detail}")
+                indent = "  " if prefix == "- " else "    "
+                lines.append(f"{header}\n{indent}{detail}")
             else:
                 lines.append(header)
+
+        # Render: top-level goals with children indented beneath
+        for g in top_level:
+            await _render_goal(g, prefix="- ")
+            for child in children_by_parent.get(g["id"], []):
+                await _render_goal(child, prefix="  ↳ ")
 
         lines.append("")
         return "\n".join(lines)
@@ -1251,6 +1288,42 @@ class UserEgoContextBuilder:
             lines.append(
                 "### Goal-Linked Proposals\n*No proposals for this goal.*\n"
             )
+
+        # Subgoals: show children if this is a parent goal
+        try:
+            from genesis.db.crud import user_goals as ug_crud
+
+            children = await ug_crud.list_children(
+                self._db, focus_id, include_achieved=True,
+            )
+            if children:
+                lines.append("### Subgoals\n")
+                for ch in children:
+                    ch_status = ch.get("status", "?")
+                    ch_title = (ch.get("title") or "?")[:100]
+                    ch_id = ch.get("id", "?")
+                    lines.append(
+                        f"- [{ch_status}] **{ch_title}** (id={ch_id})"
+                    )
+                lines.append("")
+        except Exception:
+            logger.debug("Failed to query subgoals for %s", focus_id)
+
+        # Parent context: if this is a child goal, show parent
+        if goal.get("parent_goal_id"):
+            try:
+                parent = await user_goals.get_by_id(
+                    self._db, goal["parent_goal_id"],
+                )
+                if parent:
+                    lines.append(
+                        f"### Parent Goal\n"
+                        f"**{parent.get('title', '?')}** "
+                        f"(id={parent.get('id', '?')}, "
+                        f"{parent.get('status', '?')})\n"
+                    )
+            except Exception:
+                pass
 
         lines.append("")
         return "\n".join(lines)

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -272,7 +272,7 @@ async def ego_goal_update(
         timeline: New timeline (optional)
         status: Set to 'achieved' or 'abandoned' to close the goal (optional)
         goal_type: milestone or continuous (optional)
-        cadence_days: Review cadence in days, 0 to clear / use global default (optional)
+        cadence_days: Review cadence in days (>0 to set, <0 to clear to global default, 0 = no change)
     """
     if category and category not in _VALID_GOAL_CATEGORIES:
         return {"status": "error", "reason": f"Invalid category: {category!r}. Must be one of: {sorted(_VALID_GOAL_CATEGORIES)}"}
@@ -359,6 +359,9 @@ async def ego_goal_update(
             fields["goal_type"] = goal_type
         if cadence_days > 0:
             fields["cadence_days"] = cadence_days
+        elif cadence_days < 0:
+            # Negative = explicit clear, revert to global default
+            fields["cadence_days"] = None
         if not fields:
             return {"status": "error", "reason": "no fields to update"}
 

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -20,6 +20,7 @@ _VALID_DIRECTIVE_PRIORITIES = frozenset({"low", "normal", "high", "critical"})
 _VALID_EGO_TARGETS = frozenset({"user_ego", "genesis_ego"})
 _VALID_GOAL_CATEGORIES = frozenset({"career", "project", "learning", "relationship", "financial", "other"})
 _VALID_GOAL_PRIORITIES = frozenset({"low", "medium", "high", "critical"})
+_VALID_GOAL_TYPES = frozenset({"milestone", "continuous"})
 
 
 def _get_db_path():
@@ -153,11 +154,15 @@ async def ego_goal_create(
     priority: str = "medium",
     description: str = "",
     timeline: str = "",
+    parent_goal_id: str = "",
+    goal_type: str = "milestone",
+    cadence_days: int = 0,
 ) -> dict:
     """Create a new user goal for the ego system.
 
     Goals are visible to the ego in its thinking cycles. The ego considers
-    goals when deciding what to propose.
+    goals when deciding what to propose. Use parent_goal_id to create
+    subgoals under an existing goal.
 
     Args:
         title: Goal title (concise, actionable)
@@ -165,11 +170,16 @@ async def ego_goal_create(
         priority: low, medium, high, or critical
         description: Detailed description of the goal
         timeline: Expected timeline (e.g., "Q2 2026")
+        parent_goal_id: ID of the parent goal (for subgoals)
+        goal_type: milestone (achievable) or continuous (ongoing)
+        cadence_days: Review frequency in days (0 = use global default)
     """
     if category not in _VALID_GOAL_CATEGORIES:
         return {"status": "error", "reason": f"Invalid category: {category!r}. Must be one of: {sorted(_VALID_GOAL_CATEGORIES)}"}
     if priority not in _VALID_GOAL_PRIORITIES:
         return {"status": "error", "reason": f"Invalid priority: {priority!r}. Must be one of: {sorted(_VALID_GOAL_PRIORITIES)}"}
+    if goal_type not in _VALID_GOAL_TYPES:
+        return {"status": "error", "reason": f"Invalid goal_type: {goal_type!r}. Must be 'milestone' or 'continuous'"}
 
     import aiosqlite
 
@@ -178,6 +188,13 @@ async def ego_goal_create(
     db_path = _get_db_path()
     async with aiosqlite.connect(str(db_path)) as db:
         db.row_factory = aiosqlite.Row
+
+        # Validate parent exists if specified
+        if parent_goal_id:
+            parent = await user_goals.get_by_id(db, parent_goal_id)
+            if not parent:
+                return {"status": "error", "reason": f"Parent goal {parent_goal_id!r} not found"}
+
         goal_id = await user_goals.create(
             db,
             title=title,
@@ -185,6 +202,9 @@ async def ego_goal_create(
             priority=priority,
             description=description,
             timeline=timeline or None,
+            parent_goal_id=parent_goal_id or None,
+            goal_type=goal_type,
+            cadence_days=cadence_days if cadence_days > 0 else None,
             confidence=0.9,
         )
 
@@ -194,6 +214,8 @@ async def ego_goal_create(
         "title": title,
         "category": category,
         "priority": priority,
+        "parent_goal_id": parent_goal_id or None,
+        "goal_type": goal_type,
     }
 
 
@@ -234,10 +256,12 @@ async def ego_goal_update(
     description: str = "",
     timeline: str = "",
     status: str = "",
+    goal_type: str = "",
+    cadence_days: int = 0,
 ) -> dict:
     """Update an existing user goal, or mark it as achieved/abandoned.
 
-    Pass only the fields you want to change. Empty strings are ignored.
+    Pass only the fields you want to change. Empty strings / zero are ignored.
 
     Args:
         goal_id: The goal ID to update
@@ -247,6 +271,8 @@ async def ego_goal_update(
         description: New description (optional)
         timeline: New timeline (optional)
         status: Set to 'achieved' or 'abandoned' to close the goal (optional)
+        goal_type: milestone or continuous (optional)
+        cadence_days: Review cadence in days, 0 to clear / use global default (optional)
     """
     if category and category not in _VALID_GOAL_CATEGORIES:
         return {"status": "error", "reason": f"Invalid category: {category!r}. Must be one of: {sorted(_VALID_GOAL_CATEGORIES)}"}
@@ -254,6 +280,8 @@ async def ego_goal_update(
         return {"status": "error", "reason": f"Invalid priority: {priority!r}. Must be one of: {sorted(_VALID_GOAL_PRIORITIES)}"}
     if status and status not in ("achieved", "abandoned"):
         return {"status": "error", "reason": f"Invalid status: {status!r}. Must be 'achieved' or 'abandoned'"}
+    if goal_type and goal_type not in _VALID_GOAL_TYPES:
+        return {"status": "error", "reason": f"Invalid goal_type: {goal_type!r}. Must be 'milestone' or 'continuous'"}
 
     import aiosqlite
 
@@ -265,7 +293,53 @@ async def ego_goal_update(
 
         if status == "achieved":
             await user_goals.mark_achieved(db, goal_id)
-            return {"status": "achieved", "goal_id": goal_id}
+
+            # Completion cascade: check if all siblings are achieved
+            cascade_info = None
+            try:
+                cascade = await user_goals.check_completion_cascade(
+                    db, goal_id,
+                )
+                if cascade:
+                    import uuid
+
+                    from genesis.db.crud import observations as obs_crud
+
+                    await obs_crud.create(
+                        db,
+                        id=str(uuid.uuid4()),
+                        source="goal_cascade",
+                        type="goal_recommendation",
+                        content=(
+                            f"All subgoals of '{cascade['parent_title']}' "
+                            f"are now achieved. Consider marking the parent "
+                            f"goal complete (id={cascade['parent_id']})."
+                        ),
+                        priority="medium",
+                        category="goal_review",
+                        created_at=datetime.now(UTC).isoformat(),
+                    )
+                    await user_goals.add_progress_note(
+                        db,
+                        cascade["parent_id"],
+                        "All subgoals achieved — cascade recommendation created",
+                    )
+                    cascade_info = cascade
+                    logger.info(
+                        "Goal cascade: all children of %s achieved",
+                        cascade["parent_id"][:12],
+                    )
+            except Exception:
+                logger.warning(
+                    "Goal cascade check failed for %s", goal_id,
+                    exc_info=True,
+                )
+
+            result: dict = {"status": "achieved", "goal_id": goal_id}
+            if cascade_info:
+                result["cascade"] = cascade_info
+            return result
+
         if status == "abandoned":
             await user_goals.mark_abandoned(db, goal_id)
             return {"status": "abandoned", "goal_id": goal_id}
@@ -281,6 +355,10 @@ async def ego_goal_update(
             fields["priority"] = priority
         if timeline:
             fields["timeline"] = timeline
+        if goal_type:
+            fields["goal_type"] = goal_type
+        if cadence_days > 0:
+            fields["cadence_days"] = cadence_days
         if not fields:
             return {"status": "error", "reason": "no fields to update"}
 

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -980,3 +980,38 @@ class TestGoalStaleness:
         goal_cadence._config.goal_review_staleness_days = 10
         await goal_cadence._check_stale_goals()
         assert not goal_cadence._signal_queue.empty()
+
+    async def test_per_goal_cadence_days(self, goal_cadence, goal_db):
+        """Goal with cadence_days=7 triggers at 8 days stale."""
+        goal_cadence._config.goal_review_staleness_days = 30  # global: 30d
+        eight_days_ago = (datetime.now(UTC) - timedelta(days=8)).isoformat()
+        await goal_db.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, priority, status, created_at, updated_at, "
+            " goal_type, cadence_days) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("goal-cad1", "Weekly Review Goal", "project", "high", "active",
+             eight_days_ago, eight_days_ago, "milestone", 7),
+        )
+        await goal_db.commit()
+
+        await goal_cadence._check_stale_goals()
+        # Should trigger: 8 days > cadence_days=7, despite global=30
+        assert not goal_cadence._signal_queue.empty()
+
+    async def test_per_goal_cadence_falls_back(self, goal_cadence, goal_db):
+        """Goal without cadence_days uses global threshold."""
+        goal_cadence._config.goal_review_staleness_days = 30
+        eight_days_ago = (datetime.now(UTC) - timedelta(days=8)).isoformat()
+        await goal_db.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, priority, status, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("goal-cad2", "No Cadence Goal", "project", "medium", "active",
+             eight_days_ago, eight_days_ago),
+        )
+        await goal_db.commit()
+
+        await goal_cadence._check_stale_goals()
+        # Should NOT trigger: 8 days < global 30
+        assert goal_cadence._signal_queue.empty()

--- a/tests/ego/test_user_context.py
+++ b/tests/ego/test_user_context.py
@@ -943,3 +943,71 @@ class TestUserEgoContextBuilder:
         builder._current_focus_id = "goal-123"
         result = await builder._goal_deep_dive_section(depth="skip")
         assert result == ""
+
+    # ── Goal Hierarchy Rendering ─────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_hierarchy_rendering(self, db, mock_health_data, capabilities):
+        """Goals with parent_goal_id render as indented children."""
+        await db.execute(TABLES["user_goals"])
+        now = "2026-05-30T12:00:00Z"
+        # Parent goal
+        await db.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, priority, status, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("parent-1", "Build Platform", "project", "high", "active",
+             now, now),
+        )
+        # Child goal
+        await db.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, priority, status, parent_goal_id, "
+            " created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("child-1", "Ship API", "project", "medium", "active",
+             "parent-1", now, now),
+        )
+        await db.commit()
+
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        result = await builder._user_goals_section()
+
+        assert "Build Platform" in result
+        assert "Ship API" in result
+        assert "↳" in result  # Child rendered with indent marker
+
+    @pytest.mark.asyncio
+    async def test_deep_dive_shows_subgoals(
+        self, db, mock_health_data, capabilities,
+    ):
+        """Deep dive on a parent shows its subgoals."""
+        await db.execute(TABLES["user_goals"])
+        now = "2026-05-30T12:00:00Z"
+        await db.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, priority, status, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("parent-dd", "Master Plan", "project", "high", "active",
+             now, now),
+        )
+        await db.execute(
+            "INSERT INTO user_goals "
+            "(id, title, category, priority, status, parent_goal_id, "
+            " created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("child-dd", "Phase 1", "project", "medium", "active",
+             "parent-dd", now, now),
+        )
+        await db.commit()
+
+        builder = UserEgoContextBuilder(
+            db=db, health_data=mock_health_data, capabilities=capabilities,
+        )
+        builder._current_focus_id = "parent-dd"
+        result = await builder._goal_deep_dive_section()
+
+        assert "Subgoals" in result
+        assert "Phase 1" in result

--- a/tests/ego/test_world_model.py
+++ b/tests/ego/test_world_model.py
@@ -76,6 +76,109 @@ class TestUserGoalsCRUD:
         assert career[0]["category"] == "career"
 
 
+# -- Goal hierarchy / cascade tests --
+
+
+class TestGoalHierarchy:
+    """Tests for goal decomposition: list_children + completion cascade."""
+
+    @pytest.mark.asyncio
+    async def test_list_children_returns_active(self, db):
+        """list_children returns active children of a parent."""
+        parent_id = await user_goals.create(
+            db, title="Parent Goal", category="project",
+        )
+        child1 = await user_goals.create(
+            db, title="Child 1", category="project",
+            parent_goal_id=parent_id,
+        )
+        child2 = await user_goals.create(
+            db, title="Child 2", category="project",
+            parent_goal_id=parent_id,
+        )
+        children = await user_goals.list_children(db, parent_id)
+        assert len(children) == 2
+        child_ids = {c["id"] for c in children}
+        assert child1 in child_ids
+        assert child2 in child_ids
+
+    @pytest.mark.asyncio
+    async def test_list_children_empty(self, db):
+        """list_children returns empty for goal without children."""
+        goal_id = await user_goals.create(
+            db, title="Leaf Goal", category="project",
+        )
+        children = await user_goals.list_children(db, goal_id)
+        assert children == []
+
+    @pytest.mark.asyncio
+    async def test_cascade_all_achieved(self, db):
+        """Cascade returns parent info when all children are achieved."""
+        parent_id = await user_goals.create(
+            db, title="Parent", category="project", goal_type="milestone",
+        )
+        child1 = await user_goals.create(
+            db, title="Child A", category="project",
+            parent_goal_id=parent_id,
+        )
+        child2 = await user_goals.create(
+            db, title="Child B", category="project",
+            parent_goal_id=parent_id,
+        )
+        await user_goals.mark_achieved(db, child1)
+        await user_goals.mark_achieved(db, child2)
+
+        result = await user_goals.check_completion_cascade(db, child2)
+        assert result is not None
+        assert result["parent_id"] == parent_id
+        assert result["parent_title"] == "Parent"
+
+    @pytest.mark.asyncio
+    async def test_cascade_not_all_achieved(self, db):
+        """Cascade returns None when some children are still active."""
+        parent_id = await user_goals.create(
+            db, title="Parent", category="project", goal_type="milestone",
+        )
+        child1 = await user_goals.create(
+            db, title="Done", category="project",
+            parent_goal_id=parent_id,
+        )
+        await user_goals.create(
+            db, title="Still Active", category="project",
+            parent_goal_id=parent_id,
+        )
+        await user_goals.mark_achieved(db, child1)
+
+        result = await user_goals.check_completion_cascade(db, child1)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_cascade_continuous_parent_skips(self, db):
+        """Cascade returns None for continuous parent goals."""
+        parent_id = await user_goals.create(
+            db, title="Ongoing", category="project", goal_type="continuous",
+        )
+        child = await user_goals.create(
+            db, title="Subtask", category="project",
+            parent_goal_id=parent_id,
+        )
+        await user_goals.mark_achieved(db, child)
+
+        result = await user_goals.check_completion_cascade(db, child)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_cascade_no_parent(self, db):
+        """Cascade returns None for goal without parent."""
+        goal_id = await user_goals.create(
+            db, title="Solo", category="project",
+        )
+        await user_goals.mark_achieved(db, goal_id)
+
+        result = await user_goals.check_completion_cascade(db, goal_id)
+        assert result is None
+
+
 # -- Contact CRUD tests --
 
 


### PR DESCRIPTION
## Summary

- **Goal hierarchy**: `parent_goal_id` (already existed) now wired end-to-end. `ego_goal_create` MCP tool gains `parent_goal_id` param with validation. Context renders hierarchy with ↳ indented children.
- **Completion cascade**: When all live subgoals of a milestone parent are achieved, creates observation + progress note recommending parent completion. Abandoned subgoals don't block cascade.
- **goal_type column**: `milestone` (default, achievable) or `continuous` (ongoing). Continuous parents don't cascade. Added via idempotent ALTER TABLE migration.
- **cadence_days column**: Nullable INT per-goal review frequency override. `_check_stale_goals` uses per-goal threshold if set, falls back to global 10d default.
- **Deep dive context**: Shows subgoals when reviewing parent, shows parent when reviewing child.

PR 7 of the ego v2 unified cognitive loop migration.

## Test plan

- [x] 10 new tests (6 cascade CRUD, 2 cadence, 2 context hierarchy)
- [x] 524 total ego tests pass (zero regressions)
- [x] `ruff check` clean on all modified files
- [x] Code review: 4 findings addressed (cascade semantics, cadence clearing, limit cap, abandoned children)
- [ ] CI green
- [ ] After deploy: create parent + child goals, achieve children → verify cascade observation

🤖 Generated with [Claude Code](https://claude.com/claude-code)