### PR TITLE
feat(eval): add reflection corpus recording for quality measurement

### DIFF
--- a/src/genesis/cc/reflection_bridge/_bridge.py
+++ b/src/genesis/cc/reflection_bridge/_bridge.py
@@ -446,6 +446,23 @@ class CCReflectionBridge:
                 output_tokens=output.output_tokens,
             )
 
+        # 4b. Record corpus entry (prompt + raw output, before gating)
+        try:
+            from genesis.cc.reflection_bridge._prompts import _light_focus_area
+            from genesis.db.crud import reflection_corpus
+            _focus = _light_focus_area(tick) if depth == Depth.LIGHT else None
+            await reflection_corpus.record(
+                db,
+                depth=depth.value,
+                prompt_text=prompt,
+                response_text=output.text or "",
+                tick_id=getattr(tick, "tick_id", None),
+                focus_area=_focus,
+                model_used=output.model_used or str(model),
+            )
+        except Exception:
+            logger.debug("Corpus recording failed (table may not exist yet)", exc_info=True)
+
         # 5. Route output
         routing_failed = False
         if self._output_router and depth == Depth.DEEP:

--- a/src/genesis/db/crud/reflection_corpus.py
+++ b/src/genesis/db/crud/reflection_corpus.py
@@ -1,0 +1,87 @@
+"""CRUD operations for reflection_corpus table.
+
+Records prompt I/O pairs from every reflection dispatch for quality
+measurement and future DSPy optimization.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+async def record(
+    db: aiosqlite.Connection,
+    *,
+    depth: str,
+    prompt_text: str,
+    response_text: str,
+    tick_id: str | None = None,
+    focus_area: str | None = None,
+    model_used: str | None = None,
+    parsed_ok: bool | None = None,
+) -> str | None:
+    """Record a prompt/response pair.  Returns the row ID or None on error."""
+    row_id = str(uuid.uuid4())
+    try:
+        await db.execute(
+            """INSERT INTO reflection_corpus
+               (id, depth, focus_area, prompt_text, response_text,
+                parsed_ok, model_used, tick_id, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                row_id,
+                depth,
+                focus_area,
+                prompt_text,
+                response_text,
+                int(parsed_ok) if parsed_ok is not None else None,
+                model_used,
+                tick_id,
+                datetime.now(UTC).isoformat(),
+            ),
+        )
+        await db.commit()
+        return row_id
+    except Exception:
+        logger.debug("reflection_corpus record failed", exc_info=True)
+        return None
+
+
+async def mark_parsed(
+    db: aiosqlite.Connection, row_id: str, *, parsed_ok: bool,
+) -> None:
+    """Update the parsed_ok flag after output parsing completes."""
+    try:
+        await db.execute(
+            "UPDATE reflection_corpus SET parsed_ok = ? WHERE id = ?",
+            (int(parsed_ok), row_id),
+        )
+        await db.commit()
+    except Exception:
+        logger.debug("reflection_corpus mark_parsed failed", exc_info=True)
+
+
+async def count(
+    db: aiosqlite.Connection,
+    *,
+    depth: str | None = None,
+    quality_label: str | None = None,
+) -> int:
+    """Count corpus entries, optionally filtered."""
+    sql = "SELECT COUNT(*) FROM reflection_corpus WHERE 1=1"
+    params: list = []
+    if depth is not None:
+        sql += " AND depth = ?"
+        params.append(depth)
+    if quality_label is not None:
+        sql += " AND quality_label = ?"
+        params.append(quality_label)
+    cursor = await db.execute(sql, params)
+    row = await cursor.fetchone()
+    return row[0] if row else 0

--- a/src/genesis/db/migrations/0022_reflection_corpus.py
+++ b/src/genesis/db/migrations/0022_reflection_corpus.py
@@ -1,0 +1,42 @@
+"""Add reflection_corpus table for recording prompt I/O pairs.
+
+Captures the full prompt text and raw LLM response for every reflection
+dispatch (Micro, Light, Deep, Strategic).  Records are written BEFORE
+storage gates (salience, dedup, cooldown) so we have visibility into
+what the pipeline produces regardless of what gets stored.
+
+Primary consumer: DSPy prompt optimization (future).  Immediate value:
+observability and quality measurement via the reflection_quality rubric.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute("""
+        CREATE TABLE IF NOT EXISTS reflection_corpus (
+            id TEXT PRIMARY KEY,
+            depth TEXT NOT NULL,
+            focus_area TEXT,
+            prompt_text TEXT NOT NULL,
+            response_text TEXT NOT NULL,
+            parsed_ok INTEGER,
+            model_used TEXT,
+            quality_score REAL,
+            quality_label TEXT,
+            graded_at TEXT,
+            tick_id TEXT,
+            created_at TEXT NOT NULL,
+            used_in_optimization INTEGER DEFAULT 0
+        )
+    """)
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_corpus_depth "
+        "ON reflection_corpus(depth)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_corpus_quality "
+        "ON reflection_corpus(quality_label)"
+    )

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1219,6 +1219,24 @@ TABLES = {
             PRIMARY KEY (hash, call_site)
         )
     """,
+    # ── Reflection Corpus ────────────────────────────────────────────────
+    "reflection_corpus": """
+        CREATE TABLE IF NOT EXISTS reflection_corpus (
+            id                    TEXT PRIMARY KEY,
+            depth                 TEXT NOT NULL,
+            focus_area            TEXT,
+            prompt_text           TEXT NOT NULL,
+            response_text         TEXT NOT NULL,
+            parsed_ok             INTEGER,
+            model_used            TEXT,
+            quality_score         REAL,
+            quality_label         TEXT,
+            graded_at             TEXT,
+            tick_id               TEXT,
+            created_at            TEXT NOT NULL,
+            used_in_optimization  INTEGER DEFAULT 0
+        )
+    """,
 }
 
 # FTS5 virtual tables (in-memory SQLite does NOT support FTS5 unless compiled with it)
@@ -1446,6 +1464,9 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_user_jobs_status ON user_jobs(status)",
     "CREATE INDEX IF NOT EXISTS idx_user_jobs_next_run ON user_jobs(next_run_at)",
     "CREATE INDEX IF NOT EXISTS idx_user_job_runs_job ON user_job_runs(job_id, started_at DESC)",
+    # reflection corpus
+    "CREATE INDEX IF NOT EXISTS idx_corpus_depth ON reflection_corpus(depth)",
+    "CREATE INDEX IF NOT EXISTS idx_corpus_quality ON reflection_corpus(quality_label)",
 ]
 
 # ─── Seed Data ────────────────────────────────────────────────────────────────

--- a/src/genesis/perception/engine.py
+++ b/src/genesis/perception/engine.py
@@ -91,6 +91,13 @@ class ReflectionEngine:
                 reason="all_providers_exhausted",
             )
 
+        # 3b. Record corpus entry (prompt + raw response, before gating)
+        corpus_id = await self._record_corpus(
+            depth_str, prompt, response, tick,
+            focus_area=getattr(context, "suggested_focus", None),
+            db=db,
+        )
+
         # 4. Parse output (with retries)
         parsed = self._parser.parse(response, depth_str)
         retries = 0
@@ -112,10 +119,19 @@ class ReflectionEngine:
             parsed = self._parser.parse(response, depth_str)
 
         if not parsed.success:
+            # Backfill corpus parse status
+            if corpus_id:
+                from genesis.db.crud import reflection_corpus
+                await reflection_corpus.mark_parsed(db, corpus_id, parsed_ok=False)
             return ReflectionResult(
                 success=False,
                 reason="max_retries_exceeded",
             )
+
+        # Backfill corpus parse status
+        if corpus_id:
+            from genesis.db.crud import reflection_corpus
+            await reflection_corpus.mark_parsed(db, corpus_id, parsed_ok=True)
 
         # 5. Write results (returns False if gated by salience/dedup)
         stored = await self._writer.write(parsed.output, depth, tick, db=db)
@@ -123,3 +139,29 @@ class ReflectionEngine:
         # Always return the parsed output — Telegram delivery should not
         # be coupled to observation storage gates (PR #101 rule).
         return ReflectionResult(success=True, output=parsed.output, stored=stored)
+
+    @staticmethod
+    async def _record_corpus(
+        depth: str,
+        prompt: str,
+        response,
+        tick,
+        *,
+        focus_area: str | None,
+        db,
+    ) -> str | None:
+        """Record prompt/response pair in reflection_corpus for quality tracking."""
+        try:
+            from genesis.db.crud import reflection_corpus
+            return await reflection_corpus.record(
+                db,
+                depth=depth,
+                prompt_text=prompt,
+                response_text=response.text,
+                tick_id=tick.tick_id,
+                focus_area=focus_area,
+                model_used=response.model,
+            )
+        except Exception:
+            logger.debug("Corpus recording failed (table may not exist yet)", exc_info=True)
+            return None

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -97,6 +97,7 @@ async def test_no_unexpected_tables(db):
         "task_type_watermarks",
         "prompt_versions",
         "eval_subsystem_grades",
+        "reflection_corpus",
     }
     for table in tables:
         assert table in known, f"Unexpected table: {table}"

--- a/tests/test_perception/test_engine.py
+++ b/tests/test_perception/test_engine.py
@@ -188,6 +188,53 @@ async def test_reflect_output_preserved_when_writer_gates(db):
     assert result.stored is False     # But flagged as not stored
 
 
+async def test_reflect_records_corpus_entry(db):
+    """Successful reflection records an I/O pair in reflection_corpus."""
+    from genesis.perception.engine import ReflectionEngine
+
+    assembler = AsyncMock()
+    assembler.assemble = AsyncMock(return_value=PromptContext(
+        depth="Light", identity="Genesis", signals_text="cpu: 0.3",
+        tick_number=1, suggested_focus="situation",
+    ))
+    builder = MagicMock()
+    builder.build = MagicMock(return_value="Test prompt for corpus")
+    caller = AsyncMock()
+    caller.call = AsyncMock(return_value=LLMResponse(
+        text='{"tags":["idle"],"salience":0.1,"anomaly":false,"summary":"Normal.","signals_examined":1}',
+        model="gemini-flash", input_tokens=100, output_tokens=50,
+        cost_usd=0.0, latency_ms=200,
+    ))
+    parser = MagicMock()
+    parser.parse = MagicMock(return_value=ParseResult(
+        success=True, output=_micro_output(),
+    ))
+    writer = AsyncMock()
+    writer.write = AsyncMock(return_value=True)
+
+    engine = ReflectionEngine(
+        context_assembler=assembler,
+        prompt_builder=builder,
+        llm_caller=caller,
+        output_parser=parser,
+        result_writer=writer,
+    )
+
+    result = await engine.reflect(Depth.LIGHT, _make_tick(Depth.LIGHT), db=db)
+    assert result.success is True
+
+    # Verify corpus entry was recorded
+    cursor = await db.execute("SELECT * FROM reflection_corpus")
+    rows = await cursor.fetchall()
+    assert len(rows) == 1
+    row = dict(rows[0])
+    assert row["depth"] == "Light"
+    assert row["focus_area"] == "situation"
+    assert row["prompt_text"] == "Test prompt for corpus"
+    assert row["model_used"] == "gemini-flash"
+    assert row["parsed_ok"] == 1
+
+
 async def test_reflect_max_retries_exceeded(db):
     from genesis.perception.engine import ReflectionEngine
 


### PR DESCRIPTION
## Summary

- New `reflection_corpus` table records prompt I/O pairs from every reflection dispatch
- Instrumented in both CC Bridge (primary) and Perception Engine (fallback) paths
- Entries captured BEFORE storage gates for full pipeline visibility
- Parse success backfilled after output parsing; quality scores left NULL for future grading job

## Why

DSPy prompt optimization requires labeled input/output examples. Before we can optimize, we need to collect data. This is the data collection layer — no DSPy dependency, pure observability infrastructure.

Also immediately useful: gives us visibility into what the reflection pipeline produces vs what gets stored (e.g., light reflections that get gated by salience/dedup).

## Files changed

| File | Change |
|------|--------|
| `src/genesis/db/migrations/0022_reflection_corpus.py` | New migration |
| `src/genesis/db/schema/_tables.py` | Table + indexes in schema |
| `src/genesis/db/crud/reflection_corpus.py` | CRUD operations |
| `src/genesis/perception/engine.py` | Instrumentation (fallback path) |
| `src/genesis/cc/reflection_bridge/_bridge.py` | Instrumentation (primary path) |
| `tests/test_perception/test_engine.py` | New test for corpus recording |

## Test plan

- [x] `pytest tests/test_perception/test_engine.py -v` — all 6 pass
- [x] `ruff check` on all modified files — clean
- [ ] CI pipeline
- [ ] After deploy: `SELECT COUNT(*) FROM reflection_corpus` grows with each tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)