### PR TITLE
fix(surplus): restart-resilient scheduling + heartbeat refresh + realist tightening

### DIFF
--- a/src/genesis/db/crud/surplus_tasks.py
+++ b/src/genesis/db/crud/surplus_tasks.py
@@ -211,6 +211,22 @@ async def count_active_by_type(db: aiosqlite.Connection, task_type: str) -> int:
     return row[0]
 
 
+async def last_completed_at(db: aiosqlite.Connection, task_type: str) -> str | None:
+    """Return the most recent ``completed_at`` timestamp for *task_type*.
+
+    Used by the scheduler's cooldown check to avoid re-enqueuing tasks
+    that completed recently (e.g. after a server restart).
+    """
+    cursor = await db.execute(
+        "SELECT completed_at FROM surplus_tasks "
+        "WHERE task_type = ? AND status = 'completed' AND completed_at IS NOT NULL "
+        "ORDER BY completed_at DESC LIMIT 1",
+        (task_type,),
+    )
+    row = await cursor.fetchone()
+    return row[0] if row else None
+
+
 async def delete(db: aiosqlite.Connection, id: str) -> bool:
     cursor = await db.execute("DELETE FROM surplus_tasks WHERE id = ?", (id,))
     await db.commit()

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1294,6 +1294,7 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_surplus_tasks_status ON surplus_tasks(status)",
     "CREATE INDEX IF NOT EXISTS idx_surplus_tasks_priority ON surplus_tasks(priority DESC)",
     "CREATE INDEX IF NOT EXISTS idx_surplus_tasks_tier ON surplus_tasks(compute_tier)",
+    "CREATE INDEX IF NOT EXISTS idx_surplus_tasks_type_completed ON surplus_tasks(task_type, status, completed_at DESC)",
     # awareness loop
     "CREATE INDEX IF NOT EXISTS idx_ticks_depth ON awareness_ticks(classified_depth)",
     "CREATE INDEX IF NOT EXISTS idx_ticks_created ON awareness_ticks(created_at)",

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -549,14 +549,14 @@ class EgoSession:
                         self._db, self._source_tag.replace("_cycle", ""),
                     )
                     has_critical_directive = any(
-                        d.get("priority") in ("critical", "high")
+                        d.get("priority") == "critical"
                         for d in active_dirs
                     )
                 except Exception:
                     pass
                 if has_critical_directive:
                     logger.info(
-                        "Realist bypassed — active critical/high directive(s)",
+                        "Realist bypassed — active critical directive(s)",
                     )
                 else:
                     proposals = await self._filter_proposals(proposals)

--- a/src/genesis/surplus/queue.py
+++ b/src/genesis/surplus/queue.py
@@ -104,6 +104,10 @@ class SurplusQueue:
         """Count tasks that are pending OR running for a given type."""
         return await surplus_tasks.count_active_by_type(self._db, str(task_type))
 
+    async def last_completed_at(self, task_type: TaskType | str) -> str | None:
+        """Most recent ``completed_at`` for *task_type*, or ``None``."""
+        return await surplus_tasks.last_completed_at(self._db, str(task_type))
+
     async def _apply_drive_weight(self, base_priority: float, drive: str) -> float:
         """Multiply base priority by the drive's current weight."""
         cursor = await self._db.execute(

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -442,6 +442,26 @@ class SurplusScheduler:
                     "Brainstorm check failed with exception",
                 )
 
+    async def _recently_completed(
+        self, task_type, cooldown_hours: int | float,
+    ) -> bool:
+        """Return ``True`` if *task_type* completed within *cooldown_hours*.
+
+        Used on startup to avoid re-enqueuing tasks that already ran
+        recently — prevents Telegram flooding after server restarts.
+        """
+        last = await self._queue.last_completed_at(task_type)
+        if last is None:
+            return False
+        try:
+            completed = datetime.fromisoformat(last)
+            if completed.tzinfo is None:
+                completed = completed.replace(tzinfo=UTC)
+            age_s = (self._clock() - completed).total_seconds()
+            return age_s < cooldown_hours * 3600
+        except (ValueError, TypeError):
+            return False
+
     async def schedule_code_audit(self) -> None:
         """Enqueue a code audit task if none pending/running."""
         if not self._enable_code_audits:
@@ -473,7 +493,9 @@ class SurplusScheduler:
             from genesis.surplus.types import ComputeTier, TaskType
 
             active = await self._queue.active_by_type(TaskType.CODE_INDEX)
-            if active == 0:
+            if active == 0 and not await self._recently_completed(
+                TaskType.CODE_INDEX, self._code_index_hours,
+            ):
                 await self._queue.enqueue(
                     TaskType.CODE_INDEX, ComputeTier.FREE_API, 0.6, "competence"
                 )
@@ -496,7 +518,9 @@ class SurplusScheduler:
             from genesis.surplus.types import ComputeTier, TaskType
 
             active = await self._queue.active_by_type(TaskType.J9_EVAL_BATCH)
-            if active == 0:
+            if active == 0 and not await self._recently_completed(
+                TaskType.J9_EVAL_BATCH, self._j9_eval_batch_hours,
+            ):
                 await self._queue.enqueue(
                     TaskType.J9_EVAL_BATCH, ComputeTier.FREE_API, 0.3, "competence"
                 )
@@ -544,7 +568,9 @@ class SurplusScheduler:
             from genesis.surplus.types import ComputeTier, TaskType
 
             active = await self._queue.active_by_type(TaskType.MODEL_EVAL)
-            if active == 0:
+            if active == 0 and not await self._recently_completed(
+                TaskType.MODEL_EVAL, self._model_eval_hours,
+            ):
                 payload = json.dumps({"model_id": "groq-free"})
                 await self._queue.enqueue(
                     TaskType.MODEL_EVAL, ComputeTier.FREE_API, 0.4, "competence",
@@ -577,7 +603,9 @@ class SurplusScheduler:
             ]
             for task_type, priority, drive in maintenance_tasks:
                 active = await self._queue.active_by_type(task_type)
-                if active == 0:
+                if active == 0 and not await self._recently_completed(
+                    task_type, self._maintenance_hours,
+                ):
                     await self._queue.enqueue(
                         task_type, ComputeTier.FREE_API, priority, drive,
                     )
@@ -667,7 +695,9 @@ class SurplusScheduler:
             ]
             for task_type, priority, drive in analytical_tasks:
                 active = await self._queue.active_by_type(task_type)
-                if active == 0:
+                if active == 0 and not await self._recently_completed(
+                    task_type, self._analytical_hours,
+                ):
                     await self._queue.enqueue(
                         task_type, ComputeTier.FREE_API, priority, drive,
                     )
@@ -751,6 +781,14 @@ class SurplusScheduler:
         # running.  Checks RUNNING too — otherwise a slow pipeline step
         # could allow a duplicate enqueue on the next scheduled cycle.
         if await self._queue.active_by_type(step1.task_type) > 0:
+            return None
+
+        # Cooldown: skip if the pipeline's final step completed recently.
+        # Uses the last step because that's when the full pipeline finished.
+        last_step = defn.steps[-1]
+        if await self._recently_completed(
+            last_step.task_type, self._analytical_hours,
+        ):
             return None
 
         payload = build_initial_payload(pipeline_name, len(defn.steps))
@@ -1441,19 +1479,28 @@ class SurplusScheduler:
         except Exception:
             pass
         try:
-            for _ in range(3):
-                if not await self.dispatch_once():
-                    break
-            if self._event_bus:
-                await self._event_bus.emit(
-                    Subsystem.SURPLUS, Severity.DEBUG,
-                    "heartbeat", "surplus_scheduler dispatch completed",
-                )
+            # Record heartbeat at loop entry so the watchdog sees liveness
+            # even when a single dispatch_once() blocks for 15-30 minutes
+            # (sequential task execution + intake pipeline overhead).
             try:
                 from genesis.runtime import GenesisRuntime
                 GenesisRuntime.instance().record_job_success("surplus_dispatch")
             except Exception:
                 pass
+
+            for _ in range(3):
+                if not await self.dispatch_once():
+                    break
+                # Refresh heartbeat after each task so long-running
+                # sequences don't trip the 900s watchdog threshold.
+                with contextlib.suppress(Exception):
+                    GenesisRuntime.instance().record_job_success("surplus_dispatch")
+
+            if self._event_bus:
+                await self._event_bus.emit(
+                    Subsystem.SURPLUS, Severity.DEBUG,
+                    "heartbeat", "surplus_scheduler dispatch completed",
+                )
         except Exception as exc:
             logger.exception("Surplus dispatch loop failed")
             if self._event_bus:

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -470,7 +470,9 @@ class SurplusScheduler:
             from genesis.surplus.types import ComputeTier, TaskType
 
             active = await self._queue.active_by_type(TaskType.CODE_AUDIT)
-            if active == 0:
+            if active == 0 and not await self._recently_completed(
+                TaskType.CODE_AUDIT, self._code_audit_hours,
+            ):
                 await self._queue.enqueue(
                     TaskType.CODE_AUDIT, ComputeTier.FREE_API, 0.5, "competence"
                 )
@@ -1489,12 +1491,12 @@ class SurplusScheduler:
                 pass
 
             for _ in range(3):
-                if not await self.dispatch_once():
-                    break
-                # Refresh heartbeat after each task so long-running
-                # sequences don't trip the 900s watchdog threshold.
+                # Refresh heartbeat before each dispatch so slow or
+                # failing tasks don't trip the 900s watchdog threshold.
                 with contextlib.suppress(Exception):
                     GenesisRuntime.instance().record_job_success("surplus_dispatch")
+                if not await self.dispatch_once():
+                    break
 
             if self._event_bus:
                 await self._event_bus.emit(

--- a/tests/test_surplus/test_cooldown.py
+++ b/tests/test_surplus/test_cooldown.py
@@ -204,3 +204,41 @@ async def test_schedule_pipeline_enqueues_when_cooldown_expired(db):
 
     # Step 1 should be enqueued
     assert await queue.active_by_type(TaskType.PROMPT_REVIEW_CATALOG) == 1
+
+
+# ── Realist bypass — critical-only ───────────────────────────────────
+
+
+async def test_realist_bypass_only_on_critical_directive(db):
+    """The realist bypass should trigger on critical directives only,
+    not high-priority ones (which may be informational)."""
+    from genesis.db.crud import ego as ego_crud
+
+    # Create a high-priority directive
+    await db.execute(
+        "INSERT INTO ego_directives (id, content, priority, source, ego_target, status, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("test-high", "Some guidance", "high", "user", "genesis_ego", "active",
+         datetime.now(UTC).isoformat()),
+    )
+    await db.commit()
+
+    dirs = await ego_crud.list_active_directives(db, "genesis_ego")
+    assert len(dirs) == 1
+
+    # High-priority should NOT trigger bypass (the actual check from session.py)
+    has_critical = any(d.get("priority") == "critical" for d in dirs)
+    assert has_critical is False
+
+    # Now add a critical directive
+    await db.execute(
+        "INSERT INTO ego_directives (id, content, priority, source, ego_target, status, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("test-crit", "Must do this", "critical", "user", "genesis_ego", "active",
+         datetime.now(UTC).isoformat()),
+    )
+    await db.commit()
+
+    dirs = await ego_crud.list_active_directives(db, "genesis_ego")
+    has_critical = any(d.get("priority") == "critical" for d in dirs)
+    assert has_critical is True

--- a/tests/test_surplus/test_cooldown.py
+++ b/tests/test_surplus/test_cooldown.py
@@ -1,0 +1,206 @@
+"""Tests for restart-resilient scheduling — cooldown via completed_at."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from genesis.db.crud import surplus_tasks
+from genesis.surplus.compute_availability import ComputeAvailability
+from genesis.surplus.executor import StubExecutor
+from genesis.surplus.idle_detector import IdleDetector
+from genesis.surplus.queue import SurplusQueue
+from genesis.surplus.scheduler import SurplusScheduler
+from genesis.surplus.types import ComputeTier, TaskType
+
+pytestmark = pytest.mark.asyncio
+
+
+def _make_scheduler(db, *, maintenance_hours=24, analytical_hours=12,
+                    code_index_hours=4, model_eval_hours=24,
+                    j9_eval_batch_hours=24):
+    idle_detector = IdleDetector()
+    idle_detector._last_activity_at = datetime.now(UTC) - timedelta(minutes=30)
+    compute = ComputeAvailability(lmstudio_url="http://fake:1234/v1/models")
+    return SurplusScheduler(
+        db=db, queue=SurplusQueue(db), idle_detector=idle_detector,
+        compute_availability=compute, executor=StubExecutor(),
+        enable_code_audits=False,
+        maintenance_hours=maintenance_hours,
+        analytical_hours=analytical_hours,
+        code_index_hours=code_index_hours,
+        model_eval_hours=model_eval_hours,
+        j9_eval_batch_hours=j9_eval_batch_hours,
+    )
+
+
+# ── CRUD: last_completed_at ──────────────────────────────────────────
+
+
+async def test_last_completed_at_returns_none_when_empty(db):
+    result = await surplus_tasks.last_completed_at(db, "disk_cleanup")
+    assert result is None
+
+
+async def test_last_completed_at_returns_most_recent(db):
+    queue = SurplusQueue(db=db)
+
+    # Create and complete two tasks
+    t1 = await queue.enqueue(TaskType.DISK_CLEANUP, ComputeTier.FREE_API, 0.4, "preservation")
+    await queue.mark_running(t1)
+    await surplus_tasks.mark_completed(db, t1, completed_at="2026-05-30T10:00:00+00:00")
+
+    t2 = await queue.enqueue(TaskType.DISK_CLEANUP, ComputeTier.FREE_API, 0.4, "preservation")
+    await queue.mark_running(t2)
+    await surplus_tasks.mark_completed(db, t2, completed_at="2026-05-30T12:00:00+00:00")
+
+    result = await surplus_tasks.last_completed_at(db, "disk_cleanup")
+    assert result == "2026-05-30T12:00:00+00:00"
+
+
+async def test_last_completed_at_ignores_failed(db):
+    queue = SurplusQueue(db=db)
+
+    t1 = await queue.enqueue(TaskType.DISK_CLEANUP, ComputeTier.FREE_API, 0.4, "preservation")
+    await queue.mark_running(t1)
+    await surplus_tasks.mark_failed(db, t1, failure_reason="test")
+
+    result = await surplus_tasks.last_completed_at(db, "disk_cleanup")
+    assert result is None
+
+
+async def test_last_completed_at_ignores_other_types(db):
+    queue = SurplusQueue(db=db)
+
+    t1 = await queue.enqueue(TaskType.BACKUP_VERIFICATION, ComputeTier.FREE_API, 0.7, "preservation")
+    await queue.mark_running(t1)
+    await surplus_tasks.mark_completed(db, t1, completed_at="2026-05-30T12:00:00+00:00")
+
+    result = await surplus_tasks.last_completed_at(db, "disk_cleanup")
+    assert result is None
+
+
+# ── SurplusScheduler._recently_completed ─────────────────────────────
+
+
+async def test_recently_completed_true_when_within_window(db):
+    sched = _make_scheduler(db, maintenance_hours=24)
+    queue = sched._queue
+
+    t1 = await queue.enqueue(TaskType.DISK_CLEANUP, ComputeTier.FREE_API, 0.4, "preservation")
+    await queue.mark_running(t1)
+    now = datetime.now(UTC)
+    await surplus_tasks.mark_completed(
+        db, t1, completed_at=(now - timedelta(hours=1)).isoformat(),
+    )
+
+    assert await sched._recently_completed(TaskType.DISK_CLEANUP, 24) is True
+
+
+async def test_recently_completed_false_when_outside_window(db):
+    sched = _make_scheduler(db, maintenance_hours=24)
+    queue = sched._queue
+
+    t1 = await queue.enqueue(TaskType.DISK_CLEANUP, ComputeTier.FREE_API, 0.4, "preservation")
+    await queue.mark_running(t1)
+    now = datetime.now(UTC)
+    await surplus_tasks.mark_completed(
+        db, t1, completed_at=(now - timedelta(hours=25)).isoformat(),
+    )
+
+    assert await sched._recently_completed(TaskType.DISK_CLEANUP, 24) is False
+
+
+async def test_recently_completed_false_when_no_completions(db):
+    sched = _make_scheduler(db)
+    assert await sched._recently_completed(TaskType.DISK_CLEANUP, 24) is False
+
+
+# ── schedule_maintenance with cooldown ───────────────────────────────
+
+
+async def test_schedule_maintenance_skips_recently_completed(db):
+    sched = _make_scheduler(db, maintenance_hours=24)
+    queue = sched._queue
+
+    # Complete a disk_cleanup task 1 hour ago
+    t1 = await queue.enqueue(TaskType.DISK_CLEANUP, ComputeTier.FREE_API, 0.4, "preservation")
+    await queue.mark_running(t1)
+    now = datetime.now(UTC)
+    await surplus_tasks.mark_completed(
+        db, t1, completed_at=(now - timedelta(hours=1)).isoformat(),
+    )
+
+    # Run schedule_maintenance — should NOT re-enqueue disk_cleanup
+    await sched.schedule_maintenance()
+
+    # disk_cleanup should NOT have a new pending task
+    assert await queue.active_by_type(TaskType.DISK_CLEANUP) == 0
+
+    # But backup_verification (never completed) should be enqueued
+    assert await queue.active_by_type(TaskType.BACKUP_VERIFICATION) == 1
+
+
+async def test_schedule_maintenance_enqueues_when_cooldown_expired(db):
+    sched = _make_scheduler(db, maintenance_hours=24)
+    queue = sched._queue
+
+    # Complete a disk_cleanup task 25 hours ago (beyond 24h cooldown)
+    t1 = await queue.enqueue(TaskType.DISK_CLEANUP, ComputeTier.FREE_API, 0.4, "preservation")
+    await queue.mark_running(t1)
+    now = datetime.now(UTC)
+    await surplus_tasks.mark_completed(
+        db, t1, completed_at=(now - timedelta(hours=25)).isoformat(),
+    )
+
+    await sched.schedule_maintenance()
+
+    # disk_cleanup should be re-enqueued
+    assert await queue.active_by_type(TaskType.DISK_CLEANUP) == 1
+
+
+# ── schedule_pipeline with cooldown ──────────────────────────────────
+
+
+async def test_schedule_pipeline_skips_when_final_step_recently_completed(db):
+    sched = _make_scheduler(db, analytical_hours=12)
+    queue = sched._queue
+
+    # Complete a PROMPT_EFFECTIVENESS_REVIEW (last step of prompt_effectiveness)
+    t1 = await queue.enqueue(
+        TaskType.PROMPT_EFFECTIVENESS_REVIEW, ComputeTier.FREE_API, 0.5, "competence",
+    )
+    await queue.mark_running(t1)
+    now = datetime.now(UTC)
+    await surplus_tasks.mark_completed(
+        db, t1, completed_at=(now - timedelta(hours=1)).isoformat(),
+    )
+
+    # schedule_pipeline should skip — final step completed recently
+    result = await sched.schedule_pipeline("prompt_effectiveness")
+    assert result is None
+
+    # Step 1 should NOT be enqueued
+    assert await queue.active_by_type(TaskType.PROMPT_REVIEW_CATALOG) == 0
+
+
+async def test_schedule_pipeline_enqueues_when_cooldown_expired(db):
+    sched = _make_scheduler(db, analytical_hours=12)
+    queue = sched._queue
+
+    # Complete final step 13 hours ago (beyond 12h cooldown)
+    t1 = await queue.enqueue(
+        TaskType.PROMPT_EFFECTIVENESS_REVIEW, ComputeTier.FREE_API, 0.5, "competence",
+    )
+    await queue.mark_running(t1)
+    now = datetime.now(UTC)
+    await surplus_tasks.mark_completed(
+        db, t1, completed_at=(now - timedelta(hours=13)).isoformat(),
+    )
+
+    result = await sched.schedule_pipeline("prompt_effectiveness")
+    assert result is not None  # Returns task ID
+
+    # Step 1 should be enqueued
+    assert await queue.active_by_type(TaskType.PROMPT_REVIEW_CATALOG) == 1


### PR DESCRIPTION
## Summary

- Add cooldown check to 5 surplus scheduling methods + `schedule_pipeline`, preventing re-enqueuing tasks that completed within their configured interval (maintenance=24h, analytical=12h, code_index=4h, model_eval=24h, j9_eval_batch=24h). Uses existing `completed_at` column — no schema migration needed.
- Refresh surplus_dispatch heartbeat at loop entry and per-iteration, preventing watchdog from detecting stale heartbeat during sequential task processing (which blocks dispatch loop for 20-25 minutes).
- Tighten ego realist bypass from `high+critical` to `critical`-only. A stale high-priority informational directive silently disabled the realist gate for 4 days (May 26-30).
- Add composite index `idx_surplus_tasks_type_completed` for the cooldown query.

## Context

Server restarted 15 times on 2026-05-30 (7 watchdog + 8 deployment). Each restart re-enqueued all surplus task types, producing 168 tasks and 97 Telegram messages. Root cause: startup scheduling only checked pending/running tasks, not recently completed ones.

## Verified safe to skip (no cooldown needed)
- `brainstorm_check`: has own date-based dedup (checked via Serena)
- `run_recon_gather`: calls GitHub APIs directly, no surplus tasks
- `schedule_code_audit`: currently disabled
- CronTrigger-only jobs: not run on startup

## Test plan
- [x] 11 new tests for cooldown logic (CRUD, helper, maintenance, pipeline)
- [x] 60 existing surplus tests pass
- [x] 85 existing ego tests pass
- [x] Lint clean (ruff)
- [ ] CI passes
- [ ] Post-deploy: monitor `journalctl --user -u genesis-watchdog | grep "Zombie scheduler"` — should stop
- [ ] Post-deploy: Telegram message count in thread 141 drops from ~97/day to <15/day

🤖 Generated with [Claude Code](https://claude.com/claude-code)