### PR TITLE
feat(memory): add real-time Active Work section to essential knowledge

### DIFF
--- a/src/genesis/memory/essential_knowledge.py
+++ b/src/genesis/memory/essential_knowledge.py
@@ -54,6 +54,13 @@ async def generate_deterministic(db: aiosqlite.Connection) -> str:
         parts.append("\n### System State")
         parts.extend(state_lines)
 
+    # Active work: most recent pivot per active session (last 4h)
+    active_work = await _active_session_pivots(db)
+    if active_work:
+        parts.append("\n### Active Work (now)")
+        for line in active_work:
+            parts.append(f"- {line}")
+
     # Active context: recent session topics (last 7 days)
     sessions = await _recent_session_topics(db, days=7)
     if sessions:
@@ -129,6 +136,39 @@ async def _count_observations(db: aiosqlite.Connection) -> int:
         return 0
 
 
+async def _active_session_pivots(db: aiosqlite.Connection) -> list[str]:
+    """Get the most recent conversation pivot per session active in last 4h.
+
+    Provides a real-time "what's happening right now" snapshot without LLM.
+    Groups by session, takes most recent pivot per session, returns top 5.
+    """
+    try:
+        cursor = await db.execute(
+            "SELECT source, content, MAX(created_at) as latest "
+            "FROM observations "
+            "WHERE type = 'conversation_pivot' "
+            "AND created_at > datetime('now', '-4 hours') "
+            "GROUP BY source "
+            "ORDER BY latest DESC LIMIT 5"
+        )
+        rows = await cursor.fetchall()
+        results = []
+        for row in rows:
+            content = row[1] or ""
+            # Strip the "Conversation pivot: " prefix if present
+            if content.startswith("Conversation pivot:"):
+                content = content[len("Conversation pivot:"):].strip()
+            # Extract trigger text (more useful than the summary slug)
+            if "Trigger:" in content:
+                trigger = content.split("Trigger:", 1)[1].strip()
+                results.append(trigger[:120])
+            else:
+                results.append(content[:120])
+        return results
+    except Exception:
+        return []
+
+
 async def _recent_session_topics(db: aiosqlite.Connection, days: int = 7) -> list[str]:
     """Get recent foreground session topics."""
     try:
@@ -183,6 +223,7 @@ async def _recent_decisions(db: aiosqlite.Connection, days: int = 7) -> list[str
         "code_audit",
         "version_change",
         "tech_debt",
+        "conversation_pivot",
         # Autonomy gate data — must never surface to ego context (opacity)
         "autonomy_audit",
         "autonomy_gate_decision",


### PR DESCRIPTION
## Summary

- Adds `### Active Work (now)` section to essential knowledge showing the most recent conversation pivot per active session (last 4h)
- Provides a real-time "what's happening right now" snapshot — no LLM needed, pure DB queries
- Excludes `conversation_pivot` from Key Insights section to avoid duplication

## Context

Design session identified a gap: essential knowledge shows 7-day session topics (stale) and cognitive state updates every 48h (from Deep reflections). Nothing captured "what's happening right now across active sessions" in real-time. This fills that gap programmatically.

## Example output

```
### Active Work (now)
- I don't know, could we perhaps sample this? If we were to use the same size LLM
- Yeah, just try to send something through Cerebrus, via an API, via our API
- All right, anything else left to do here, then?
```

## Test plan

- [x] `ruff check` clean
- [x] Tested against live DB — produces correct output
- [x] Conversation pivots no longer leak into Key Insights
- [ ] Verify on next session start that Active Work section appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)