### PR TITLE
fix(knowledge): add path traversal guard on source file resolution

### DIFF
--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -107,7 +107,13 @@ class KnowledgeOrchestrator:
 
         # 3b. Kick off tree indexing in parallel (if applicable)
         tree_task: asyncio.Task | None = None
-        source_resolved = Path(source).resolve() if not source.startswith(("http://", "https://")) else None
+        source_resolved = None
+        if not source.startswith(("http://", "https://")):
+            candidate = Path(source).resolve()
+            # Path traversal guard: only allow files under $HOME
+            home = Path.home().resolve()
+            if candidate.is_relative_to(home):
+                source_resolved = candidate
         should_tree_index = (
             self._tree_index is not None
             and content.source_type == "pdf"


### PR DESCRIPTION
## Summary

Resolve CodeQL alerts #128/#129: user-provided `source` path in the
knowledge orchestrator is now validated against `$HOME` before
`resolve()` and `exists()` calls, preventing path traversal outside
the home directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)