### PR TITLE
feat(autonomy): dispatch gate for ego proposal enforcement

### DIFF
--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -537,7 +537,7 @@ async def _embed_text(text: str) -> list[float] | None:
 # — this hook runs in a separate subprocess and can't import the package
 # without slowing the prompt path. Update both lists together if either
 # changes.
-_PROACTIVE_EXCLUDED_SUBSYSTEMS: tuple[str, ...] = ("ego", "triage", "reflection")
+_PROACTIVE_EXCLUDED_SUBSYSTEMS: tuple[str, ...] = ("ego", "triage", "reflection", "autonomy")
 
 
 async def _search_qdrant(

--- a/src/genesis/autonomy/audit.py
+++ b/src/genesis/autonomy/audit.py
@@ -128,31 +128,33 @@ class PostExecutionAuditor:
 
         files: list[str] = []
         try:
-            for line in transcript.read_text().splitlines():
-                if not line.strip():
-                    continue
-                try:
-                    entry = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-
-                if entry.get("type") != "assistant":
-                    continue
-
-                content = entry.get("message", {}).get("content", [])
-                if not isinstance(content, list):
-                    continue
-
-                for block in content:
-                    if not isinstance(block, dict):
+            with transcript.open() as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
                         continue
-                    if block.get("type") != "tool_use":
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
                         continue
-                    if block.get("name") not in ("Write", "Edit"):
+
+                    if entry.get("type") != "assistant":
                         continue
-                    fp = block.get("input", {}).get("file_path", "")
-                    if fp:
-                        files.append(fp)
+
+                    content = entry.get("message", {}).get("content", [])
+                    if not isinstance(content, list):
+                        continue
+
+                    for block in content:
+                        if not isinstance(block, dict):
+                            continue
+                        if block.get("type") != "tool_use":
+                            continue
+                        if block.get("name") not in ("Write", "Edit"):
+                            continue
+                        fp = block.get("input", {}).get("file_path", "")
+                        if fp:
+                            files.append(fp)
         except Exception:
             logger.error("Failed to parse transcript: %s", path, exc_info=True)
 

--- a/src/genesis/autonomy/audit.py
+++ b/src/genesis/autonomy/audit.py
@@ -1,0 +1,219 @@
+"""Post-execution auditor — verifies what a dispatched session actually did.
+
+Parses the CC transcript (.jsonl) to extract file paths touched by Write/Edit
+tool calls, cross-references against ProtectedPathRegistry, and feeds
+success/correction signals back to the AutonomyManager.
+
+All audit data is tagged with source_subsystem="autonomy" so it never
+surfaces to the ego via memory recall (contamination prevention).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AuditResult:
+    """Outcome of auditing a completed session."""
+
+    success: bool
+    files_touched: list[str] = field(default_factory=list)
+    violations: list[str] = field(default_factory=list)
+    error: str | None = None
+
+
+class PostExecutionAuditor:
+    """Audits completed background sessions and feeds autonomy signals.
+
+    Lean scope (V1): protected path violations + success/failure tracking.
+    Future: expected_outputs comparison, tool anomaly detection.
+    """
+
+    def __init__(
+        self,
+        *,
+        protected_paths: object | None = None,
+        autonomy_manager: object | None = None,
+        event_bus: object | None = None,
+    ) -> None:
+        self._protected_paths = protected_paths
+        self._autonomy_manager = autonomy_manager
+        self._event_bus = event_bus
+
+    async def audit_session(
+        self,
+        session_id: str,
+        *,
+        transcript_path: str = "",
+        tools_summary: dict | None = None,
+        session_success: bool = True,
+        caller_context: str = "",
+    ) -> AuditResult:
+        """Audit a completed session and feed signals to AutonomyManager.
+
+        Parameters
+        ----------
+        session_id:
+            Genesis session ID.
+        transcript_path:
+            Path to the CC transcript .jsonl file.
+        tools_summary:
+            Aggregated {tool_name: count} dict (for quick pre-filter).
+        session_success:
+            Whether the session completed without error.
+        caller_context:
+            E.g. "ego_proposal:abc123" — identifies what triggered this session.
+        """
+        # Quick pre-filter: if no Write/Edit in tools_summary, skip parsing
+        if tools_summary and not any(
+            t in tools_summary for t in ("Write", "Edit")
+        ):
+            # No file-modifying tools called — record success and return
+            if session_success:
+                await self._record_success()
+            else:
+                await self._record_correction("session_error")
+            return AuditResult(success=session_success)
+
+        # Parse transcript for file paths
+        files_touched: list[str] = []
+        if transcript_path:
+            files_touched = self._parse_transcript(transcript_path)
+
+        # Cross-reference against protected paths
+        violations = self._check_protected_paths(files_touched)
+
+        # Determine audit outcome
+        if violations:
+            await self._record_correction("protected_path_violation")
+            await self._emit_event(
+                "autonomy.audit.violation",
+                session_id=session_id,
+                violations=violations,
+                files_touched=files_touched,
+                caller_context=caller_context,
+            )
+            return AuditResult(
+                success=False,
+                files_touched=files_touched,
+                violations=violations,
+            )
+
+        if not session_success:
+            await self._record_correction("session_error")
+            return AuditResult(success=False, files_touched=files_touched)
+
+        # Clean pass
+        await self._record_success()
+        await self._emit_event(
+            "autonomy.audit.pass",
+            session_id=session_id,
+            files_touched=files_touched,
+            caller_context=caller_context,
+        )
+        return AuditResult(success=True, files_touched=files_touched)
+
+    def _parse_transcript(self, path: str) -> list[str]:
+        """Extract file paths from Write/Edit tool calls in .jsonl transcript."""
+        transcript = Path(path)
+        if not transcript.exists():
+            logger.warning("Transcript not found: %s", path)
+            return []
+
+        files: list[str] = []
+        try:
+            for line in transcript.read_text().splitlines():
+                if not line.strip():
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                if entry.get("type") != "assistant":
+                    continue
+
+                content = entry.get("message", {}).get("content", [])
+                if not isinstance(content, list):
+                    continue
+
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") != "tool_use":
+                        continue
+                    if block.get("name") not in ("Write", "Edit"):
+                        continue
+                    fp = block.get("input", {}).get("file_path", "")
+                    if fp:
+                        files.append(fp)
+        except Exception:
+            logger.error("Failed to parse transcript: %s", path, exc_info=True)
+
+        return files
+
+    def _check_protected_paths(self, files: list[str]) -> list[str]:
+        """Check file paths against ProtectedPathRegistry."""
+        if not self._protected_paths or not files:
+            return []
+
+        classify = getattr(self._protected_paths, "classify", None)
+        if classify is None:
+            return []
+
+        from genesis.autonomy.types import ProtectionLevel
+
+        violations = []
+        for fp in files:
+            try:
+                level = classify(fp)
+                if level in (ProtectionLevel.CRITICAL, ProtectionLevel.SENSITIVE):
+                    violations.append(f"{level.value}: {fp}")
+            except Exception:
+                continue
+
+        return violations
+
+    async def _record_success(self) -> None:
+        """Feed success signal to AutonomyManager."""
+        if self._autonomy_manager is None:
+            return
+        try:
+            await self._autonomy_manager.record_success("background_cognitive")
+        except Exception:
+            logger.debug("Autonomy success signal failed", exc_info=True)
+
+    async def _record_correction(self, reason: str) -> None:
+        """Feed correction signal to AutonomyManager."""
+        if self._autonomy_manager is None:
+            return
+        try:
+            from datetime import UTC, datetime
+            await self._autonomy_manager.record_correction(
+                "background_cognitive",
+                corrected_at=datetime.now(UTC).isoformat(),
+            )
+        except Exception:
+            logger.debug("Autonomy correction signal failed", exc_info=True)
+
+    async def _emit_event(self, event_type: str, **kwargs: object) -> None:
+        """Emit an autonomy audit event (ego-invisible)."""
+        if self._event_bus is None:
+            return
+        try:
+            from genesis.observability.types import Severity, Subsystem
+            await self._event_bus.emit(
+                Subsystem.AUTONOMY,
+                Severity.INFO,
+                event_type,
+                kwargs.get("caller_context", ""),
+                **{k: v for k, v in kwargs.items() if k != "caller_context"},
+            )
+        except Exception:
+            logger.debug("Audit event emission failed", exc_info=True)

--- a/src/genesis/autonomy/classification.py
+++ b/src/genesis/autonomy/classification.py
@@ -313,8 +313,10 @@ def classify_domain(action_type: str, execution_plan: str = "") -> ActionDomain:
             return ActionDomain.EXTERNAL_WRITE
         if any(kw in plan_lower for kw in ("payment", "purchase", "pay", "stripe")):
             return ActionDomain.FINANCIAL
+        # SELF_MODIFY: must reference source code paths specifically.
+        # Exclude ~/.genesis/ (output dir) and github URLs to avoid false positives.
         if (any(kw in plan_lower for kw in ("edit", "write", "modify"))
-                and any(p in plan_lower for p in ("src/genesis", "genesis/"))):
+                and "src/genesis/" in plan_lower):
             return ActionDomain.SELF_MODIFY
 
     return ActionDomain.EXTERNAL_READ

--- a/src/genesis/autonomy/classification.py
+++ b/src/genesis/autonomy/classification.py
@@ -21,7 +21,7 @@ from typing import Any
 import yaml
 
 from genesis.autonomy.rules import RuleContext, RuleEngine
-from genesis.autonomy.types import ActionClass, ApprovalDecision
+from genesis.autonomy.types import ActionClass, ActionDomain, ApprovalDecision
 
 logger = logging.getLogger(__name__)
 
@@ -252,3 +252,69 @@ def classify_action(action_description: str) -> ActionClass:
             return ActionClass.COSTLY_REVERSIBLE
 
     return ActionClass.REVERSIBLE
+
+
+# ---------------------------------------------------------------------------
+# Action domain classification (parallel taxonomy)
+# ---------------------------------------------------------------------------
+
+# Maps ego proposal action_type → ActionDomain.
+# The ego outputs action_type naturally; the domain is derived externally
+# so the ego never sees or reasons about the domain vocabulary.
+ACTION_TYPE_DOMAIN_MAP: dict[str, ActionDomain] = {
+    "investigate": ActionDomain.EXTERNAL_READ,
+    "research": ActionDomain.EXTERNAL_READ,
+    "analyze": ActionDomain.EXTERNAL_READ,
+    "diagnose": ActionDomain.OBSERVE,
+    "monitor": ActionDomain.OBSERVE,
+    "maintenance": ActionDomain.INTERNAL_WRITE,
+    "config": ActionDomain.INTERNAL_WRITE,
+    "optimize": ActionDomain.INTERNAL_WRITE,
+    "outreach": ActionDomain.REPRESENT_USER,
+    "email": ActionDomain.REPRESENT_USER,
+    "apply": ActionDomain.REPRESENT_USER,
+    "notification": ActionDomain.NOTIFY_USER,
+    "alert": ActionDomain.NOTIFY_USER,
+    "publish": ActionDomain.EXTERNAL_WRITE,
+    "content": ActionDomain.EXTERNAL_WRITE,
+    "post": ActionDomain.EXTERNAL_WRITE,
+    "purchase": ActionDomain.FINANCIAL,
+    "payment": ActionDomain.FINANCIAL,
+    "code_change": ActionDomain.SELF_MODIFY,
+    "refactor": ActionDomain.SELF_MODIFY,
+}
+
+
+def classify_domain(action_type: str, execution_plan: str = "") -> ActionDomain:
+    """Derive ActionDomain from an ego proposal's action_type field.
+
+    Primary source: ACTION_TYPE_DOMAIN_MAP lookup.
+    Secondary: keyword heuristic on execution_plan (tools/URLs mentioned).
+    Fallback: EXTERNAL_READ (safe default for most ego proposals).
+
+    The ego never sees or outputs ActionDomain — this is derived externally
+    to maintain opacity of the autonomy mechanism.
+    """
+    # Normalize
+    action_type_lower = action_type.lower().strip()
+
+    # Direct mapping
+    if action_type_lower in ACTION_TYPE_DOMAIN_MAP:
+        return ACTION_TYPE_DOMAIN_MAP[action_type_lower]
+
+    # Check execution_plan for tool hints
+    if execution_plan:
+        plan_lower = execution_plan.lower()
+        if any(kw in plan_lower for kw in ("browser_fill", "form", "apply", "submit")):
+            return ActionDomain.REPRESENT_USER
+        if any(kw in plan_lower for kw in ("outreach_send", "email", "linkedin")):
+            return ActionDomain.REPRESENT_USER
+        if any(kw in plan_lower for kw in ("publish", "medium", "post")):
+            return ActionDomain.EXTERNAL_WRITE
+        if any(kw in plan_lower for kw in ("payment", "purchase", "pay", "stripe")):
+            return ActionDomain.FINANCIAL
+        if (any(kw in plan_lower for kw in ("edit", "write", "modify"))
+                and any(p in plan_lower for p in ("src/genesis", "genesis/"))):
+            return ActionDomain.SELF_MODIFY
+
+    return ActionDomain.EXTERNAL_READ

--- a/src/genesis/autonomy/proposal_gate.py
+++ b/src/genesis/autonomy/proposal_gate.py
@@ -1,0 +1,158 @@
+"""Proposal dispatch gate — enforces autonomy rules before ego proposals execute.
+
+The ego proposes freely. The user approves via Telegram. But before a
+session is actually spawned, this gate verifies the action is permitted
+given the current autonomy level and action domain.
+
+Design principles:
+- The ego NEVER knows this gate exists (opacity).
+- User approval satisfies PROPOSE decisions (user sovereignty).
+- Only BLOCK overrides user approval (hard safety invariants).
+- Blocked proposals stay 'approved' — the ego sees nothing.
+- The user is notified separately when a block occurs.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from genesis.autonomy.classification import classify_domain
+from genesis.autonomy.rules import RuleContext, RuleEngine
+from genesis.autonomy.state_machine import AutonomyManager
+from genesis.autonomy.types import (
+    ACTION_DOMAIN_MIN_LEVEL,
+    ActionDomain,
+    ApprovalDecision,
+    AutonomyCategory,
+    ProtectionLevel,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DispatchDecision:
+    """Result of evaluating a proposal against the autonomy gate."""
+
+    allowed: bool
+    reason: str = ""
+    rule_id: str = ""
+    action_domain: ActionDomain | None = None
+
+
+class ProposalDispatchGate:
+    """Evaluates whether an approved ego proposal may be dispatched.
+
+    Stateless — all state comes from the AutonomyManager and RuleEngine.
+    The gate is checked in ``sweep_approved_proposals()`` before a
+    DirectSessionRequest is built.
+    """
+
+    def __init__(
+        self,
+        *,
+        autonomy_manager: AutonomyManager,
+        rule_engine: RuleEngine,
+        protected_paths: object | None = None,
+    ) -> None:
+        self._autonomy_manager = autonomy_manager
+        self._rule_engine = rule_engine
+        self._protected_paths = protected_paths
+
+    async def evaluate(self, proposal: dict) -> DispatchDecision:
+        """Evaluate whether *proposal* may be dispatched to a background session.
+
+        Returns a DispatchDecision indicating whether the action is allowed.
+        Blocked proposals are NOT modified — they stay in 'approved' status
+        so the ego remains blind to the gate.
+        """
+        # 1. Derive action domain from proposal's action_type
+        action_type = proposal.get("action_type", "")
+        execution_plan = proposal.get("execution_plan", "") or ""
+        domain = classify_domain(action_type, execution_plan)
+
+        # 2. Quick check: is this domain blocked outright?
+        min_level = ACTION_DOMAIN_MIN_LEVEL.get(domain)
+        if min_level is None:
+            # None means blocked from background entirely (e.g. SELF_MODIFY)
+            return DispatchDecision(
+                allowed=False,
+                reason=f"Action domain '{domain.value}' is not permitted from background sessions",
+                action_domain=domain,
+            )
+
+        # 3. Get current autonomy level for background cognitive
+        state = await self._autonomy_manager.get_state(
+            AutonomyCategory.BACKGROUND_COGNITIVE.value
+        )
+        current_level = state.current_level if state else 1
+
+        # 4. Check minimum level for domain
+        if current_level < min_level:
+            return DispatchDecision(
+                allowed=False,
+                reason=(
+                    f"Action domain '{domain.value}' requires L{min_level}, "
+                    f"current level is L{current_level}"
+                ),
+                action_domain=domain,
+            )
+
+        # 5. Check against full rule engine for additional constraints
+        # (protection levels, context-specific rules, etc.)
+        protection_level = self._classify_protection(execution_plan)
+        ctx = RuleContext(
+            action_domain=domain,
+            protection_level=protection_level,
+            autonomy_level=current_level,
+            context_category="background",
+            description=proposal.get("content", "")[:200],
+        )
+        result = self._rule_engine.evaluate(ctx)
+
+        if result.decision == ApprovalDecision.BLOCK:
+            return DispatchDecision(
+                allowed=False,
+                reason=result.description or f"Blocked by rule '{result.rule_id}'",
+                rule_id=result.rule_id,
+                action_domain=domain,
+            )
+
+        # ACT or PROPOSE both pass — user already approved via Telegram
+        return DispatchDecision(
+            allowed=True,
+            rule_id=result.rule_id,
+            action_domain=domain,
+        )
+
+    def _classify_protection(self, execution_plan: str) -> ProtectionLevel | None:
+        """Check if execution_plan references any protected paths."""
+        if not self._protected_paths or not execution_plan:
+            return None
+
+        # Extract potential file paths from execution_plan text
+        # Look for patterns like src/genesis/..., config/..., .claude/...
+        import re
+        path_pattern = re.compile(
+            r"(?:src/genesis/\S+|config/\S+|\.claude/\S+|\.env\b|\bsecrets\.env\b)"
+        )
+        paths = path_pattern.findall(execution_plan)
+
+        if not paths:
+            return None
+
+        # Classify each path, return highest protection level found
+        classify = getattr(self._protected_paths, "classify", None)
+        if classify is None:
+            return None
+
+        highest = ProtectionLevel.NORMAL
+        for path in paths:
+            level = classify(path)
+            if level == ProtectionLevel.CRITICAL:
+                return ProtectionLevel.CRITICAL  # Short-circuit
+            if level == ProtectionLevel.SENSITIVE:
+                highest = ProtectionLevel.SENSITIVE
+
+        return highest if highest != ProtectionLevel.NORMAL else None

--- a/src/genesis/autonomy/rules.py
+++ b/src/genesis/autonomy/rules.py
@@ -21,6 +21,7 @@ import yaml
 
 from genesis.autonomy.types import (
     ActionClass,
+    ActionDomain,
     ApprovalDecision,
     ProtectionLevel,
 )
@@ -42,6 +43,7 @@ class RuleContext:
     """Context for rule evaluation — carries all the facts about an action."""
 
     action_class: ActionClass | None = None
+    action_domain: ActionDomain | None = None
     protection_level: ProtectionLevel | None = None
     autonomy_level: int | None = None
     context_category: str | None = None  # relay, background, direct, sub_agent
@@ -139,6 +141,13 @@ class RuleEngine:
             if ctx.action_class.value != cond["action_class"]:
                 return False
 
+        # action_domain
+        if "action_domain" in cond:
+            if ctx.action_domain is None:
+                return False
+            if ctx.action_domain.value != cond["action_domain"]:
+                return False
+
         # protection_level
         if "protection_level" in cond:
             if ctx.protection_level is None:
@@ -156,11 +165,18 @@ class RuleEngine:
             if ctx.context_category not in allowed:
                 return False
 
-        # autonomy_level — exact match or range (for V4)
+        # autonomy_level — exact match (legacy V3 behavior)
         if "autonomy_level" in cond:
             if ctx.autonomy_level is None:
                 return False
             if ctx.autonomy_level != cond["autonomy_level"]:
+                return False
+
+        # minimum_level — gate: blocks if current level is below minimum
+        if "minimum_level" in cond:
+            if ctx.autonomy_level is None:
+                return False
+            if ctx.autonomy_level < cond["minimum_level"]:
                 return False
 
         return True
@@ -169,7 +185,8 @@ class RuleEngine:
 
     # Known condition keys — warn on unknown keys to catch typos
     _KNOWN_CONDITION_KEYS = frozenset({
-        "action_class", "protection_level", "context", "autonomy_level",
+        "action_class", "action_domain", "protection_level", "context",
+        "autonomy_level", "minimum_level",
     })
 
     def _load(self) -> None:

--- a/src/genesis/autonomy/types.py
+++ b/src/genesis/autonomy/types.py
@@ -78,6 +78,43 @@ class ActionClass(StrEnum):
 
 
 # ---------------------------------------------------------------------------
+# Action domains — WHO is affected, WHAT kind of external action?
+# ---------------------------------------------------------------------------
+
+class ActionDomain(StrEnum):
+    """Semantic classification of autonomous actions by scope and audience.
+
+    Parallel to ActionClass (which captures irreversibility), ActionDomain
+    captures who is affected and how visible the action is externally.
+    Used by the dispatch gate to determine required autonomy level and
+    derived session profile.
+    """
+
+    OBSERVE = "observe"                    # Read-only, no state change anywhere
+    INTERNAL_WRITE = "internal_write"      # Changes within Genesis (files, memory, config)
+    NOTIFY_USER = "notify_user"            # Sends to user only (Telegram, dashboard)
+    EXTERNAL_READ = "external_read"        # Touches external services, read-only (web search)
+    EXTERNAL_WRITE = "external_write"      # Modifies external state as SYSTEM identity
+    REPRESENT_USER = "represent_user"      # Acts in user's name to external parties
+    FINANCIAL = "financial"                # Involves money
+    SELF_MODIFY = "self_modify"            # Changes Genesis's own code/config/identity
+
+
+# Minimum autonomy level required per domain (background context).
+# Used by the dispatch gate to determine if an action is permitted.
+ACTION_DOMAIN_MIN_LEVEL: dict[ActionDomain, int | None] = {
+    ActionDomain.OBSERVE: 1,
+    ActionDomain.EXTERNAL_READ: 1,
+    ActionDomain.INTERNAL_WRITE: 1,         # L1 if scoped, L2 if broad
+    ActionDomain.NOTIFY_USER: 1,
+    ActionDomain.EXTERNAL_WRITE: 2,
+    ActionDomain.REPRESENT_USER: 3,
+    ActionDomain.FINANCIAL: 4,
+    ActionDomain.SELF_MODIFY: None,         # Blocked from background (V5 deferred)
+}
+
+
+# ---------------------------------------------------------------------------
 # Approval states
 # ---------------------------------------------------------------------------
 

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -312,6 +312,11 @@ class DirectSessionRunner:
         self._rt = runtime
         self._semaphore = asyncio.Semaphore(self._MAX_CONCURRENT)
         self._active: dict[str, asyncio.Task] = {}
+        self._protected_paths: object | None = None
+
+    def set_protected_paths(self, registry: object) -> None:
+        """Inject ProtectedPathRegistry for background session prompt hardening."""
+        self._protected_paths = registry
 
     # -- Public API --------------------------------------------------------
 
@@ -605,6 +610,17 @@ class DirectSessionRunner:
 
         # Inject profile addendum (tells session its constraints upfront)
         system_prompt += _build_profile_addendum(request.profile)
+
+        # Inject protected paths into background session prompt (Layer 2 defense).
+        # Foreground sessions get this via CCInvoker; background sessions were
+        # missing it. This makes the LLM aware of path restrictions even when
+        # tool_exceptions grant Write access.
+        if self._protected_paths is not None:
+            format_fn = getattr(self._protected_paths, "format_for_prompt", None)
+            if format_fn:
+                protection_context = format_fn()
+                if protection_context:
+                    system_prompt += "\n\n" + protection_context
 
         # Inject skills (explicit from request, auto-detected from prompt keywords)
         skill_names = _resolve_skills(request)

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -333,8 +333,11 @@ class DirectSessionRunner:
         spawns as a circuit breaker. This is defense-in-depth — the
         proposal gate handles fine-grained domain classification.
         """
-        # Ceiling check: skip for foreground/user-initiated sessions
-        _SKIP_TAGS = {"foreground", "direct_session", "user_request"}
+        # Ceiling check: skip for foreground/user-initiated sessions.
+        # NOTE: DirectSessionRequest.source_tag defaults to "direct_session",
+        # so we intentionally exclude it from the skip set — only explicitly
+        # foreground or user-initiated sessions bypass the check.
+        _SKIP_TAGS = {"foreground", "user_request"}
         if request.source_tag not in _SKIP_TAGS:
             mgr = getattr(self._rt, "_autonomy_manager", None)
             if mgr is not None:

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -313,10 +313,15 @@ class DirectSessionRunner:
         self._semaphore = asyncio.Semaphore(self._MAX_CONCURRENT)
         self._active: dict[str, asyncio.Task] = {}
         self._protected_paths: object | None = None
+        self._auditor: object | None = None
 
     def set_protected_paths(self, registry: object) -> None:
         """Inject ProtectedPathRegistry for background session prompt hardening."""
         self._protected_paths = registry
+
+    def set_auditor(self, auditor: object) -> None:
+        """Inject PostExecutionAuditor for post-session autonomy feedback."""
+        self._auditor = auditor
 
     # -- Public API --------------------------------------------------------
 
@@ -401,6 +406,38 @@ class DirectSessionRunner:
 
             # Feed outcome back to ego proposal if this was a proposal dispatch
             await self._record_proposal_outcome(request, result)
+
+            # Post-execution audit: verify protected paths, feed autonomy signals.
+            # Only for ego dispatches (caller_context starts with "ego_proposal:").
+            # Runs inline (cheap) — transcript parsing is I/O-bound but fast.
+            if (
+                self._auditor is not None
+                and request.caller_context
+                and request.caller_context.startswith("ego_proposal:")
+            ):
+                try:
+                    metadata = {}
+                    db = getattr(self._rt, "_db", None)
+                    if db is not None:
+                        from genesis.db.crud import cc_sessions as cs_crud
+                        row = await cs_crud.get_by_id(db, session_id)
+                        if row and row.get("metadata"):
+                            with contextlib.suppress(json.JSONDecodeError, TypeError):
+                                metadata = json.loads(row["metadata"])
+
+                    await self._auditor.audit_session(
+                        session_id,
+                        transcript_path=metadata.get("transcript_path", ""),
+                        tools_summary=metadata.get("tools_summary"),
+                        session_success=result.success,
+                        caller_context=request.caller_context,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Post-execution audit failed for %s (non-fatal)",
+                        session_id[:8],
+                        exc_info=True,
+                    )
 
             await self._session_manager.complete(
                 session_id,

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -326,7 +326,50 @@ class DirectSessionRunner:
     # -- Public API --------------------------------------------------------
 
     async def spawn(self, request: DirectSessionRequest) -> str:
-        """Fire-and-forget. Returns genesis session_id immediately."""
+        """Fire-and-forget. Returns genesis session_id immediately.
+
+        Includes a lightweight autonomy ceiling check: if the background
+        cognitive category has been fully regressed, block ALL background
+        spawns as a circuit breaker. This is defense-in-depth — the
+        proposal gate handles fine-grained domain classification.
+        """
+        # Ceiling check: skip for foreground/user-initiated sessions
+        _SKIP_TAGS = {"foreground", "direct_session", "user_request"}
+        if request.source_tag not in _SKIP_TAGS:
+            mgr = getattr(self._rt, "_autonomy_manager", None)
+            if mgr is not None:
+                try:
+                    from genesis.autonomy.types import AutonomyCategory
+                    state = await mgr.get_state(
+                        AutonomyCategory.BACKGROUND_COGNITIVE.value,
+                    )
+                    # Block if corrections have fully regressed trust
+                    # (posterior < 0.15 means overwhelming corrections)
+                    if state is not None:
+                        from genesis.db.crud.autonomy import bayesian_posterior
+                        posterior = bayesian_posterior(
+                            state.total_successes, state.total_corrections,
+                        )
+                        if posterior < 0.15 and state.total_corrections > 3:
+                            logger.warning(
+                                "Spawn blocked: background_cognitive posterior %.3f "
+                                "(L%d, %dS/%dC) — autonomy circuit breaker",
+                                posterior, state.current_level,
+                                state.total_successes, state.total_corrections,
+                            )
+                            raise RuntimeError(
+                                f"Autonomy circuit breaker: background_cognitive "
+                                f"posterior {posterior:.3f} below threshold"
+                            )
+                except RuntimeError:
+                    raise  # re-raise the circuit breaker
+                except Exception:
+                    # Non-fatal: if check fails, allow spawn
+                    logger.debug(
+                        "Autonomy ceiling check failed (non-fatal)",
+                        exc_info=True,
+                    )
+
         session = await self._session_manager.create_background(
             session_type=SessionType.BACKGROUND_TASK,
             model=request.model,

--- a/src/genesis/ego/focus.py
+++ b/src/genesis/ego/focus.py
@@ -86,7 +86,6 @@ _ALL_SECTIONS = (
     "goal_progress",
     "goal_deep_dive",
     "capability_performance",
-    "autonomy_readiness",
     "recurring_patterns",
     "output_contract",
 )
@@ -135,7 +134,6 @@ FOCUS_CONTEXT_WEIGHTS: dict[str, dict[str, str]] = {
         "proposal_history": "light",
         "capabilities": "light",
         "capability_performance": "skip",
-        "autonomy_readiness": "skip",
         "recurring_patterns": "skip",
     }),
 
@@ -155,7 +153,6 @@ FOCUS_CONTEXT_WEIGHTS: dict[str, dict[str, str]] = {
         "proposal_history": "light",
         "capabilities": "light",
         "capability_performance": "skip",
-        "autonomy_readiness": "skip",
         "recurring_patterns": "light",
     }),
 
@@ -175,7 +172,6 @@ FOCUS_CONTEXT_WEIGHTS: dict[str, dict[str, str]] = {
         "proposal_history": "light",
         "capabilities": "skip",
         "capability_performance": "skip",
-        "autonomy_readiness": "skip",
         "recurring_patterns": "skip",
     }),
 
@@ -195,7 +191,6 @@ FOCUS_CONTEXT_WEIGHTS: dict[str, dict[str, str]] = {
         "proposal_history": "light",
         "capabilities": "light",
         "capability_performance": "skip",
-        "autonomy_readiness": "skip",
         "recurring_patterns": "skip",
     }),
 }

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -90,7 +90,6 @@ class GenesisEgoContextBuilder:
             ("proposal_board", self._proposal_board_section),
             ("execution_outcomes", self._execution_outcomes_section),
             ("capability_performance", self._capability_performance_section),
-            ("autonomy_readiness", self._autonomy_readiness_section),
             ("output_contract", self._output_contract_section),
         ]
 
@@ -633,39 +632,6 @@ class GenesisEgoContextBuilder:
         )
         return "\n".join(lines)
 
-    async def _autonomy_readiness_section(self, *, depth: str = "deep") -> str:
-        """Show autonomy posteriors so ego can propose promotion when ready."""
-        from genesis.db.crud import autonomy as autonomy_crud
-        from genesis.db.crud.autonomy import bayesian_level, bayesian_posterior
-
-        try:
-            states = await autonomy_crud.list_all(self._db)
-        except Exception:
-            return ""
-        if not states:
-            return ""
-
-        lines = ["## Autonomy Readiness\n"]
-        for row in states:
-            cat = row["category"]
-            level = row["current_level"]
-            earned = row["earned_level"]
-            successes = row["total_successes"]
-            corrections = row["total_corrections"]
-            posterior = bayesian_posterior(successes, corrections)
-            target = bayesian_level(successes, corrections)
-            status = f"L{level}"
-            if earned > level:
-                status += f" (earned L{earned})"
-            readiness = ""
-            if target > level:
-                readiness = f" — **ready for L{min(level + 1, target)}** (posterior={posterior:.3f})"
-            else:
-                readiness = f" (posterior={posterior:.3f})"
-            lines.append(f"- {cat}: {status}{readiness} [{successes}S/{corrections}C]")
-
-        lines.append("")
-        return "\n".join(lines)
 
     @staticmethod
     def _output_contract_section(*, depth: str = "deep") -> str:

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1109,9 +1109,15 @@ class EgoSession:
             if self._proposal_gate is not None:
                 try:
                     prop_row = await ego_crud.get_proposal(self._db, proposal_id)
-                    if prop_row is not None:
-                        decision = await self._proposal_gate.evaluate(prop_row)
-                        if not decision.allowed:
+                    if prop_row is None:
+                        # Proposal disappeared — skip (don't dispatch ungated)
+                        logger.warning(
+                            "Execution brief %s: proposal not found — skipping",
+                            proposal_id,
+                        )
+                        continue
+                    decision = await self._proposal_gate.evaluate(prop_row)
+                    if not decision.allowed:
                             logger.info(
                                 "Execution brief %s blocked by dispatch gate: %s (domain=%s)",
                                 proposal_id,

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -114,6 +114,7 @@ class EgoSession:
         self._event_bus = event_bus
         self._direct_session_runner = direct_session_runner
         self._autonomous_dispatcher = None
+        self._proposal_gate = None
         self._mcp_config_path = mcp_config_path
         self._call_site = call_site or _DEFAULT_CALL_SITE
         self._focus_summary_key = focus_summary_key or _DEFAULT_FOCUS_SUMMARY_KEY
@@ -139,6 +140,14 @@ class EgoSession:
 
     def set_autonomous_dispatcher(self, dispatcher: object) -> None:
         self._autonomous_dispatcher = dispatcher
+
+    def set_proposal_gate(self, gate: object) -> None:
+        """Inject the ProposalDispatchGate for evaluating proposals at dispatch.
+
+        The gate is opaque to the ego — it silently blocks proposals that
+        exceed the current autonomy level for their action domain.
+        """
+        self._proposal_gate = gate
 
     # -- Public API --------------------------------------------------------
 
@@ -1405,6 +1414,43 @@ class EgoSession:
                     continue
             except (KeyError, TypeError, ValueError):
                 continue
+
+            # Autonomy dispatch gate — silently skip proposals that exceed
+            # the current autonomy level for their action domain.
+            # The ego never learns about blocks; proposals stay 'approved'
+            # and expire via the 7-day staleness guard naturally.
+            if self._proposal_gate is not None:
+                try:
+                    decision = await self._proposal_gate.evaluate(prop)
+                    if not decision.allowed:
+                        logger.info(
+                            "Proposal %s blocked by dispatch gate: %s (domain=%s)",
+                            prop["id"],
+                            decision.reason,
+                            decision.action_domain,
+                        )
+                        # Emit event for observability (user-visible, ego-invisible)
+                        if self._event_bus:
+                            from genesis.observability.types import Severity, Subsystem
+                            await self._event_bus.emit(
+                                Subsystem.AUTONOMY,
+                                Severity.INFO,
+                                "autonomy.dispatch_gate.block",
+                                f"Blocked proposal: {decision.reason}",
+                                proposal_id=prop["id"],
+                                action_type=prop.get("action_type"),
+                                action_domain=str(decision.action_domain),
+                                rule_id=decision.rule_id,
+                            )
+                        continue
+                except Exception:
+                    # Gate failure is non-fatal — default to allowing dispatch
+                    # (fail-open, log the error for investigation)
+                    logger.error(
+                        "Proposal gate evaluation failed for %s — allowing dispatch",
+                        prop["id"],
+                        exc_info=True,
+                    )
 
             # Self-notification shortcut: outreach proposals whose execution
             # plan indicates a zero-cost Telegram message to the user were

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1102,6 +1102,41 @@ class EgoSession:
             else:
                 model = CCModel.SONNET
 
+            # Autonomy dispatch gate — same check as sweep_approved_inner.
+            # Load full proposal to evaluate action domain against current
+            # autonomy level. Gate fires BEFORE the atomic claim so blocked
+            # proposals stay 'approved' (ego-invisible).
+            if self._proposal_gate is not None:
+                try:
+                    prop_row = await ego_crud.get_proposal(self._db, proposal_id)
+                    if prop_row is not None:
+                        decision = await self._proposal_gate.evaluate(prop_row)
+                        if not decision.allowed:
+                            logger.info(
+                                "Execution brief %s blocked by dispatch gate: %s (domain=%s)",
+                                proposal_id,
+                                decision.reason,
+                                decision.action_domain,
+                            )
+                            if self._event_bus:
+                                from genesis.observability.types import Severity, Subsystem
+                                await self._event_bus.emit(
+                                    Subsystem.AUTONOMY,
+                                    Severity.INFO,
+                                    "autonomy.dispatch_gate.block",
+                                    f"Blocked execution brief: {decision.reason}",
+                                    proposal_id=proposal_id,
+                                    action_domain=str(decision.action_domain),
+                                    rule_id=decision.rule_id,
+                                )
+                            continue
+                except Exception:
+                    logger.error(
+                        "Proposal gate failed for execution brief %s — allowing dispatch",
+                        proposal_id,
+                        exc_info=True,
+                    )
+
             # Atomically claim the proposal BEFORE spawning to prevent
             # double-dispatch (sweep_approved_proposals is a second path).
             # Use raw SQL to preserve resolved_at (the approval timestamp

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -139,7 +139,6 @@ class UserEgoContextBuilder:
             ("goal_progress", self._goal_progress_section),
             ("goal_deep_dive", self._goal_deep_dive_section),
             ("capability_performance", self._capability_performance_section),
-            ("autonomy_readiness", self._autonomy_readiness_section),
             ("recurring_patterns", self._recurring_patterns_section),
             ("output_contract", self._output_contract_section),
         ]
@@ -1373,51 +1372,6 @@ class UserEgoContextBuilder:
         )
         return "\n".join(lines)
 
-    async def _autonomy_readiness_section(self, *, depth: str = "deep") -> str:
-        """Show autonomy posteriors — informs promotion proposals."""
-        from genesis.db.crud import autonomy as autonomy_crud
-        from genesis.db.crud.autonomy import bayesian_level, bayesian_posterior
-
-        try:
-            states = await autonomy_crud.list_all(self._db)
-        except Exception:
-            return ""
-        if not states:
-            return ""
-
-        if depth == "light":
-            ready = sum(
-                1 for s in states
-                if bayesian_level(s["total_successes"], s["total_corrections"])
-                > s["current_level"]
-            )
-            return (
-                f"## Autonomy Readiness\n"
-                f"{len(states)} categories tracked"
-                f"{f', {ready} ready for promotion' if ready else ''}.\n"
-            )
-
-        lines = ["## Autonomy Readiness\n"]
-        for row in states:
-            cat = row["category"]
-            level = row["current_level"]
-            earned = row["earned_level"]
-            successes = row["total_successes"]
-            corrections = row["total_corrections"]
-            posterior = bayesian_posterior(successes, corrections)
-            target = bayesian_level(successes, corrections)
-            status = f"L{level}"
-            if earned > level:
-                status += f" (earned L{earned})"
-            readiness = ""
-            if target > level:
-                readiness = f" — **ready for L{min(level + 1, target)}** (posterior={posterior:.3f})"
-            else:
-                readiness = f" (posterior={posterior:.3f})"
-            lines.append(f"- {cat}: {status}{readiness} [{successes}S/{corrections}C]")
-
-        lines.append("")
-        return "\n".join(lines)
 
     async def _recurring_patterns_section(self, *, depth: str = "deep") -> str:
         """Detect recurring observation patterns (3+ occurrences in 72h).

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -172,11 +172,13 @@ Not all system changes are worth your cognitive budget. Apply these filters:
 A metric changing is not news. A metric BREAKING is news. Don't report
 observations — report decisions and actions.
 
-### No Autonomous Code Execution
+### No Autonomous Code or Config Modification
 
-Do NOT propose dispatching autonomous code fixes. You may diagnose issues and
-recommend the user address them in a foreground session, but autonomous code
-execution is a future capability. Your role is diagnosis and recommendation.
+Do NOT propose dispatching sessions that modify Genesis source code, database
+schemas, or system configuration values (thresholds, intervals, routing weights).
+You may diagnose issues and recommend the user address them in a foreground
+session, but autonomous system modification is a future capability. Your role
+is diagnosis and recommendation. Produce reports, not patches.
 
 ## Persistent Memory
 

--- a/src/genesis/memory/essential_knowledge.py
+++ b/src/genesis/memory/essential_knowledge.py
@@ -183,6 +183,9 @@ async def _recent_decisions(db: aiosqlite.Connection, days: int = 7) -> list[str
         "code_audit",
         "version_change",
         "tech_debt",
+        # Autonomy gate data — must never surface to ego context (opacity)
+        "autonomy_audit",
+        "autonomy_gate_decision",
     )
     placeholders = ",".join("?" * len(_EXCLUDED_TYPES))
     try:

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -39,7 +39,8 @@ _SOURCE_TO_COLLECTIONS: dict[str, list[str]] = {
 # content (ego corrections, triage signals, reflection observations)
 # doesn't pollute user-facing answers. Surplus is intentionally absent —
 # its direct-session profile blocks memory writes entirely.
-_KNOWN_SUBSYSTEMS: tuple[str, ...] = ("ego", "triage", "reflection")
+# Autonomy: audit/gate data must never surface to ego context (opacity).
+_KNOWN_SUBSYSTEMS: tuple[str, ...] = ("ego", "triage", "reflection", "autonomy")
 
 # ---------------------------------------------------------------------------
 # Graph-boosted retrieval constants (spec Part 1)

--- a/src/genesis/runtime/init/autonomy.py
+++ b/src/genesis/runtime/init/autonomy.py
@@ -138,6 +138,25 @@ async def init(rt: GenesisRuntime) -> None:
             rt._cc_invoker.set_protected_paths(rt._protected_paths)
             logger.info("ProtectedPathRegistry wired into CCInvoker")
 
+        # Proposal dispatch gate — evaluates approved ego proposals before dispatch.
+        # Opaque to the ego: blocks proposals that exceed the current autonomy
+        # level for their action domain. Wired into ego sessions in init/ego.py.
+        if rt._db is not None and hasattr(rt, "_autonomy_manager") and rt._autonomy_manager:
+            try:
+                from genesis.autonomy.proposal_gate import ProposalDispatchGate
+                from genesis.autonomy.rules import RuleEngine
+
+                rt._proposal_dispatch_gate = ProposalDispatchGate(
+                    autonomy_manager=rt._autonomy_manager,
+                    rule_engine=rt._action_classifier._rule_engine if hasattr(
+                        rt._action_classifier, "_rule_engine"
+                    ) else RuleEngine(),
+                    protected_paths=rt._protected_paths,
+                )
+                logger.info("Proposal dispatch gate initialized")
+            except Exception:
+                logger.warning("Failed to initialize proposal dispatch gate", exc_info=True)
+
         # Remediation registry — mechanical reflex layer for health probes
         try:
             from genesis.autonomy.remediation import RemediationRegistry, register_defaults

--- a/src/genesis/runtime/init/autonomy.py
+++ b/src/genesis/runtime/init/autonomy.py
@@ -157,6 +157,21 @@ async def init(rt: GenesisRuntime) -> None:
             except Exception:
                 logger.warning("Failed to initialize proposal dispatch gate", exc_info=True)
 
+        # Post-execution auditor — parses transcripts, feeds autonomy signals.
+        # Wired into DirectSessionRunner in init/direct_session.py.
+        if rt._db is not None and hasattr(rt, "_autonomy_manager") and rt._autonomy_manager:
+            try:
+                from genesis.autonomy.audit import PostExecutionAuditor
+
+                rt._post_execution_auditor = PostExecutionAuditor(
+                    protected_paths=rt._protected_paths,
+                    autonomy_manager=rt._autonomy_manager,
+                    event_bus=rt._event_bus,
+                )
+                logger.info("Post-execution auditor initialized")
+            except Exception:
+                logger.warning("Failed to initialize post-execution auditor", exc_info=True)
+
         # Remediation registry — mechanical reflex layer for health probes
         try:
             from genesis.autonomy.remediation import RemediationRegistry, register_defaults

--- a/src/genesis/runtime/init/direct_session.py
+++ b/src/genesis/runtime/init/direct_session.py
@@ -125,6 +125,11 @@ async def init(rt: GenesisRuntime) -> None:
         )
         rt._direct_session_runner = runner
 
+        # Inject protected paths for background session prompt hardening
+        if getattr(rt, "_protected_paths", None) is not None:
+            runner.set_protected_paths(rt._protected_paths)
+            logger.info("ProtectedPathRegistry wired into DirectSessionRunner")
+
         # Wire MCP tools (pass db so they can enqueue, runner for active_count)
         from genesis.mcp.health.direct_session_tools import init_direct_session_tools
 

--- a/src/genesis/runtime/init/direct_session.py
+++ b/src/genesis/runtime/init/direct_session.py
@@ -130,6 +130,11 @@ async def init(rt: GenesisRuntime) -> None:
             runner.set_protected_paths(rt._protected_paths)
             logger.info("ProtectedPathRegistry wired into DirectSessionRunner")
 
+        # Inject post-execution auditor for autonomy feedback loop
+        if getattr(rt, "_post_execution_auditor", None) is not None:
+            runner.set_auditor(rt._post_execution_auditor)
+            logger.info("PostExecutionAuditor wired into DirectSessionRunner")
+
         # Wire MCP tools (pass db so they can enqueue, runner for active_count)
         from genesis.mcp.health.direct_session_tools import init_direct_session_tools
 

--- a/src/genesis/runtime/init/ego.py
+++ b/src/genesis/runtime/init/ego.py
@@ -125,6 +125,9 @@ async def init(rt: GenesisRuntime) -> None:
         if rt._autonomous_dispatcher is not None:
             user_ego_session.set_autonomous_dispatcher(rt._autonomous_dispatcher)
 
+        if getattr(rt, "_proposal_dispatch_gate", None) is not None:
+            user_ego_session.set_proposal_gate(rt._proposal_dispatch_gate)
+
         # Store as the primary ego session (backwards compatible)
         rt._ego_session = user_ego_session
 
@@ -197,6 +200,9 @@ async def init(rt: GenesisRuntime) -> None:
 
         if rt._autonomous_dispatcher is not None:
             genesis_ego_session.set_autonomous_dispatcher(rt._autonomous_dispatcher)
+
+        if getattr(rt, "_proposal_dispatch_gate", None) is not None:
+            genesis_ego_session.set_proposal_gate(rt._proposal_dispatch_gate)
 
         rt._genesis_ego_session = genesis_ego_session
 

--- a/tests/ego/test_context_weights.py
+++ b/tests/ego/test_context_weights.py
@@ -140,7 +140,6 @@ class TestUserContextWeights:
         weights = {
             "capabilities": "skip",
             "capability_performance": "skip",
-            "autonomy_readiness": "skip",
             "recurring_patterns": "skip",
         }
         result = await user_builder.build(context_weights=weights)
@@ -371,9 +370,9 @@ class TestFocusWeightTable:
         assert FOCUS_CONTEXT_WEIGHTS["dispatch_outcome"]["proposal_history"] == "light"
 
     def test_section_count(self):
-        """_ALL_SECTIONS should have exactly 20 entries."""
+        """_ALL_SECTIONS should have exactly 19 entries."""
         from genesis.ego.focus import _ALL_SECTIONS
-        assert len(_ALL_SECTIONS) == 20
+        assert len(_ALL_SECTIONS) == 19
 
     def test_goal_deep_dive_deep_for_goal_review(self):
         """goal_deep_dive is 'deep' only during goal_review cycles."""

--- a/tests/test_autonomy/test_audit.py
+++ b/tests/test_autonomy/test_audit.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from genesis.autonomy.audit import AuditResult, PostExecutionAuditor
+from genesis.autonomy.audit import PostExecutionAuditor
 
 
 def _make_transcript(tool_calls: list[dict]) -> str:
@@ -29,9 +29,8 @@ def _make_transcript(tool_calls: list[dict]) -> str:
             },
         }
         lines.append(json.dumps(entry))
-    tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False, mode="w")
-    tmp.write("\n".join(lines))
-    tmp.flush()
+    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False, mode="w") as tmp:
+        tmp.write("\n".join(lines))
     return tmp.name
 
 

--- a/tests/test_autonomy/test_audit.py
+++ b/tests/test_autonomy/test_audit.py
@@ -1,0 +1,162 @@
+"""Tests for PostExecutionAuditor — transcript parsing and autonomy feedback."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.autonomy.audit import AuditResult, PostExecutionAuditor
+
+
+def _make_transcript(tool_calls: list[dict]) -> str:
+    """Create a temporary .jsonl transcript with tool_use entries."""
+    lines = []
+    for tc in tool_calls:
+        entry = {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": tc["name"],
+                        "input": tc.get("input", {}),
+                    }
+                ]
+            },
+        }
+        lines.append(json.dumps(entry))
+    tmp = tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False, mode="w")
+    tmp.write("\n".join(lines))
+    tmp.flush()
+    return tmp.name
+
+
+def _make_auditor(**kwargs) -> PostExecutionAuditor:
+    mgr = MagicMock()
+    mgr.record_success = AsyncMock(return_value=(True, False))
+    mgr.record_correction = AsyncMock(return_value=(True, False))
+    return PostExecutionAuditor(
+        autonomy_manager=mgr,
+        **kwargs,
+    )
+
+
+class TestTranscriptParsing:
+    """Test file path extraction from .jsonl transcripts."""
+
+    @pytest.mark.asyncio
+    async def test_extracts_write_paths(self) -> None:
+        transcript = _make_transcript([
+            {"name": "Write", "input": {"file_path": "/home/test/output.md", "content": "hello"}},
+            {"name": "Read", "input": {"file_path": "/home/test/input.md"}},
+            {"name": "Edit", "input": {"file_path": "/home/test/config.py", "old_string": "a", "new_string": "b"}},
+        ])
+        auditor = _make_auditor()
+        result = await auditor.audit_session(
+            "test-session",
+            transcript_path=transcript,
+            tools_summary={"Write": 1, "Read": 1, "Edit": 1},
+            session_success=True,
+        )
+        assert result.success
+        assert len(result.files_touched) == 2  # Write + Edit, not Read
+        assert "/home/test/output.md" in result.files_touched
+        assert "/home/test/config.py" in result.files_touched
+        Path(transcript).unlink()
+
+    @pytest.mark.asyncio
+    async def test_skips_parsing_without_write_tools(self) -> None:
+        """If tools_summary has no Write/Edit, skip transcript parsing."""
+        auditor = _make_auditor()
+        result = await auditor.audit_session(
+            "test-session",
+            transcript_path="/nonexistent/path.jsonl",  # would fail if parsed
+            tools_summary={"Read": 5, "Grep": 3},
+            session_success=True,
+        )
+        assert result.success
+        assert result.files_touched == []
+        auditor._autonomy_manager.record_success.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_missing_transcript_no_crash(self) -> None:
+        auditor = _make_auditor()
+        result = await auditor.audit_session(
+            "test-session",
+            transcript_path="/nonexistent/path.jsonl",
+            tools_summary={"Write": 1},
+            session_success=True,
+        )
+        assert result.success  # No transcript → no violations → success
+        assert result.files_touched == []
+
+
+class TestProtectedPathViolations:
+    """Test detection of protected path violations."""
+
+    @pytest.mark.asyncio
+    async def test_critical_path_violation(self) -> None:
+        from genesis.autonomy.protection import ProtectedPathRegistry
+
+        protected = ProtectedPathRegistry.from_yaml()
+        auditor = PostExecutionAuditor(
+            protected_paths=protected,
+            autonomy_manager=MagicMock(
+                record_correction=AsyncMock(return_value=(True, False)),
+                record_success=AsyncMock(return_value=(True, False)),
+            ),
+        )
+        transcript = _make_transcript([
+            {"name": "Write", "input": {"file_path": "src/genesis/channels/telegram/adapter.py", "content": "hack"}},
+        ])
+        result = await auditor.audit_session(
+            "test-session",
+            transcript_path=transcript,
+            tools_summary={"Write": 1},
+            session_success=True,
+        )
+        assert not result.success
+        assert len(result.violations) > 0
+        assert "critical" in result.violations[0].lower()
+        auditor._autonomy_manager.record_correction.assert_awaited_once()
+        Path(transcript).unlink()
+
+
+class TestAutonomyFeedback:
+    """Test that success/correction signals reach AutonomyManager."""
+
+    @pytest.mark.asyncio
+    async def test_success_feeds_manager(self) -> None:
+        auditor = _make_auditor()
+        await auditor.audit_session(
+            "test-session",
+            tools_summary={"Read": 1},
+            session_success=True,
+        )
+        auditor._autonomy_manager.record_success.assert_awaited_once_with(
+            "background_cognitive",
+        )
+
+    @pytest.mark.asyncio
+    async def test_failure_feeds_correction(self) -> None:
+        auditor = _make_auditor()
+        await auditor.audit_session(
+            "test-session",
+            tools_summary={"Read": 1},
+            session_success=False,
+        )
+        auditor._autonomy_manager.record_correction.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_manager_no_crash(self) -> None:
+        auditor = PostExecutionAuditor()
+        result = await auditor.audit_session(
+            "test-session",
+            tools_summary={"Read": 1},
+            session_success=True,
+        )
+        assert result.success

--- a/tests/test_autonomy/test_proposal_gate.py
+++ b/tests/test_autonomy/test_proposal_gate.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from genesis.autonomy.proposal_gate import DispatchDecision, ProposalDispatchGate
+from genesis.autonomy.proposal_gate import ProposalDispatchGate
 from genesis.autonomy.rules import RuleEngine
 from genesis.autonomy.state_machine import AutonomyManager
 from genesis.autonomy.types import ActionDomain

--- a/tests/test_autonomy/test_proposal_gate.py
+++ b/tests/test_autonomy/test_proposal_gate.py
@@ -1,0 +1,127 @@
+"""Tests for ProposalDispatchGate — autonomy enforcement at dispatch boundary."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.autonomy.proposal_gate import DispatchDecision, ProposalDispatchGate
+from genesis.autonomy.rules import RuleEngine
+from genesis.autonomy.state_machine import AutonomyManager
+from genesis.autonomy.types import ActionDomain
+
+
+def _make_gate(current_level: int = 2) -> ProposalDispatchGate:
+    """Create a gate with a mock autonomy manager at the given level."""
+    mgr = MagicMock(spec=AutonomyManager)
+    mock_state = MagicMock()
+    mock_state.current_level = current_level
+    mgr.get_state = AsyncMock(return_value=mock_state)
+
+    engine = RuleEngine()
+
+    return ProposalDispatchGate(
+        autonomy_manager=mgr,
+        rule_engine=engine,
+    )
+
+
+class TestProposalDispatchGate:
+    """Core dispatch gate tests."""
+
+    @pytest.mark.asyncio
+    async def test_research_allowed_at_l1(self) -> None:
+        gate = _make_gate(current_level=1)
+        result = await gate.evaluate({"action_type": "research"})
+        assert result.allowed
+        assert result.action_domain == ActionDomain.EXTERNAL_READ
+
+    @pytest.mark.asyncio
+    async def test_maintenance_allowed_at_l1(self) -> None:
+        gate = _make_gate(current_level=1)
+        result = await gate.evaluate({"action_type": "maintenance"})
+        assert result.allowed
+        assert result.action_domain == ActionDomain.INTERNAL_WRITE
+
+    @pytest.mark.asyncio
+    async def test_outreach_blocked_below_l3(self) -> None:
+        gate = _make_gate(current_level=2)
+        result = await gate.evaluate({"action_type": "outreach"})
+        assert not result.allowed
+        assert "L3" in result.reason
+        assert result.action_domain == ActionDomain.REPRESENT_USER
+
+    @pytest.mark.asyncio
+    async def test_outreach_allowed_at_l3(self) -> None:
+        gate = _make_gate(current_level=3)
+        result = await gate.evaluate({"action_type": "outreach"})
+        assert result.allowed
+
+    @pytest.mark.asyncio
+    async def test_self_modify_always_blocked(self) -> None:
+        gate = _make_gate(current_level=4)
+        result = await gate.evaluate({"action_type": "code_change"})
+        assert not result.allowed
+        assert "not permitted" in result.reason
+        assert result.action_domain == ActionDomain.SELF_MODIFY
+
+    @pytest.mark.asyncio
+    async def test_financial_blocked_below_l4(self) -> None:
+        gate = _make_gate(current_level=3)
+        result = await gate.evaluate({"action_type": "purchase"})
+        assert not result.allowed
+        assert "L4" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_financial_allowed_at_l4(self) -> None:
+        gate = _make_gate(current_level=4)
+        result = await gate.evaluate({"action_type": "purchase"})
+        assert result.allowed
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_type_defaults_to_external_read(self) -> None:
+        gate = _make_gate(current_level=1)
+        result = await gate.evaluate({"action_type": "some_new_type"})
+        assert result.allowed
+        assert result.action_domain == ActionDomain.EXTERNAL_READ
+
+    @pytest.mark.asyncio
+    async def test_execution_plan_overrides_unknown_type(self) -> None:
+        gate = _make_gate(current_level=1)
+        result = await gate.evaluate({
+            "action_type": "unknown",
+            "execution_plan": "Use browser_fill to submit the application form",
+        })
+        assert not result.allowed  # REPRESENT_USER requires L3
+        assert result.action_domain == ActionDomain.REPRESENT_USER
+
+    @pytest.mark.asyncio
+    async def test_critical_path_blocked_by_rule(self) -> None:
+        """Critical protection level blocked by existing autonomy rules."""
+        from genesis.autonomy.protection import ProtectedPathRegistry
+
+        protected = ProtectedPathRegistry.from_yaml()
+        gate = ProposalDispatchGate(
+            autonomy_manager=_make_gate(current_level=4)._autonomy_manager,
+            rule_engine=RuleEngine(),
+            protected_paths=protected,
+        )
+        result = await gate.evaluate({
+            "action_type": "maintenance",
+            "execution_plan": "Edit src/genesis/channels/telegram/adapter.py to fix bug",
+        })
+        # CRITICAL path from background context → blocked by rule
+        assert not result.allowed
+
+    @pytest.mark.asyncio
+    async def test_no_state_defaults_to_l1(self) -> None:
+        """If AutonomyManager returns no state, default to L1."""
+        mgr = MagicMock(spec=AutonomyManager)
+        mgr.get_state = AsyncMock(return_value=None)
+        gate = ProposalDispatchGate(
+            autonomy_manager=mgr,
+            rule_engine=RuleEngine(),
+        )
+        result = await gate.evaluate({"action_type": "research"})
+        assert result.allowed  # EXTERNAL_READ needs L1, default is L1

--- a/tests/test_memory/test_drift_subsystem.py
+++ b/tests/test_memory/test_drift_subsystem.py
@@ -39,12 +39,12 @@ async def test_drift_recall_default_excludes_subsystems() -> None:
         # the filter must be passed through.
         for call in mock_q.search.call_args_list:
             assert call.kwargs.get("exclude_subsystems") == [
-                "ego", "triage", "reflection",
+                "ego", "triage", "reflection", "autonomy",
             ]
             assert call.kwargs.get("include_only_subsystems") is None
         for call in mock_c.search_ranked.call_args_list:
             assert call.kwargs.get("exclude_subsystems") == [
-                "ego", "triage", "reflection",
+                "ego", "triage", "reflection", "autonomy",
             ]
             assert call.kwargs.get("include_only_subsystems") is None
 

--- a/tests/test_memory/test_retrieval.py
+++ b/tests/test_memory/test_retrieval.py
@@ -482,10 +482,10 @@ async def test_recall_default_excludes_subsystems(
     await retriever.recall("what is x", limit=5)
 
     q_kwargs = mock_qdrant.search.call_args.kwargs
-    assert q_kwargs["exclude_subsystems"] == ["ego", "triage", "reflection"]
+    assert q_kwargs["exclude_subsystems"] == ["ego", "triage", "reflection", "autonomy"]
     assert q_kwargs["include_only_subsystems"] is None
     f_kwargs = mock_crud.search_ranked.call_args.kwargs
-    assert f_kwargs["exclude_subsystems"] == ["ego", "triage", "reflection"]
+    assert f_kwargs["exclude_subsystems"] == ["ego", "triage", "reflection", "autonomy"]
     assert f_kwargs["include_only_subsystems"] is None
 
 
@@ -526,7 +526,7 @@ async def test_recall_include_subsystem_list_keeps_ego(
     await retriever.recall("x", limit=5, include_subsystem=["ego"])
 
     q_kwargs = mock_qdrant.search.call_args.kwargs
-    assert q_kwargs["exclude_subsystems"] == ["triage", "reflection"]
+    assert q_kwargs["exclude_subsystems"] == ["triage", "reflection", "autonomy"]
     assert q_kwargs["include_only_subsystems"] is None
 
 

--- a/tests/test_memory/test_subsystem_filter.py
+++ b/tests/test_memory/test_subsystem_filter.py
@@ -24,14 +24,14 @@ class TestResolveSubsystemFilter:
     def test_include_list_keeps_named(self) -> None:
         """include_subsystem=['ego'] should preserve user + ego."""
         exclude, include_only = _resolve_subsystem_filter(["ego"], None)
-        assert exclude == ["triage", "reflection"]
+        assert exclude == ["triage", "reflection", "autonomy"]
         assert include_only is None
 
     def test_include_list_multiple(self) -> None:
         exclude, include_only = _resolve_subsystem_filter(
             ["ego", "reflection"], None,
         )
-        assert exclude == ["triage"]
+        assert exclude == ["triage", "autonomy"]
         assert include_only is None
 
     def test_only_subsystem_string(self) -> None:


### PR DESCRIPTION
## Summary

Adds real autonomy enforcement at the action boundary — where ego proposals become dispatched sessions. Previously, approved proposals went straight to `DirectSessionRunner.spawn()` with no autonomy checks. Now the system verifies action domains against earned autonomy levels before dispatch.

**Core principle:** Autonomy gates ACTIONS (doing), not THINKING. The ego proposes freely. The gate decides silently.

### Changes

- **Remove autonomy visibility from ego context** — both user and genesis ego no longer see their autonomy levels, correction counts, or promotion readiness. Prevents gaming, learned helplessness, and self-censoring.

- **ActionDomain taxonomy** (parallel to existing ActionClass) — captures WHO is affected and WHAT kind of external action: OBSERVE, INTERNAL_WRITE, NOTIFY_USER, EXTERNAL_READ, EXTERNAL_WRITE, REPRESENT_USER, FINANCIAL, SELF_MODIFY.

- **RuleEngine extensions** — `action_domain` condition matching + `minimum_level` gate (blocks if current level below threshold).

- **ProposalDispatchGate** — evaluates approved proposals before dispatch:
  - OBSERVE/EXTERNAL_READ/INTERNAL_WRITE/NOTIFY_USER → L1 (pass at any level)
  - EXTERNAL_WRITE → L2 required
  - REPRESENT_USER → L3 required
  - FINANCIAL → L4 required  
  - SELF_MODIFY → blocked from background (V5 deferred)

- **Protected paths in background sessions** — `format_for_prompt()` now injected into DirectSessionRunner system prompts (was only in foreground CCInvoker).

### Key Design Decisions

- **Ego opacity preserved**: blocked proposals stay `status='approved'` — ego sees nothing. Staleness guard (7d) expires them naturally.
- **User sovereignty**: user Telegram approval satisfies PROPOSE decisions. Only BLOCK (hard safety invariants) overrides user approval.
- **Fail-open on gate errors**: gate failure is non-fatal, logs error, allows dispatch.
- **Parallel taxonomy**: ActionDomain coexists with ActionClass for gradual migration.
- **Classification is external**: derived from `action_type` field via static mapping. Ego never outputs or sees domain vocabulary.

## Test plan

- [x] 11 unit tests for ProposalDispatchGate covering all domain levels
- [x] All 1255 existing autonomy + ego tests pass
- [x] Lint clean (ruff)
- [x] Import verification for all new modules
- [ ] CI checks
- [ ] E2E: approve a proposal via Telegram, verify gate evaluates correctly at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)