### PR TITLE
fix(ego,dream): entity resolution OOM guard, proposal format, dashboard color

### DIFF
--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -4163,7 +4163,8 @@
                         const base = ue?.cadence_minutes || 90;
                         const max = ue?.max_interval_minutes || 240;
                         const pct = Math.min(100, (cur / max) * 100);
-                        const color = cur <= base ? '#4caf50' : cur < max * 0.75 ? '#f0ad4e' : '#d9534f';
+                        const cFail = ue?.cadence?.consecutive_failures || 0;
+                        const color = cFail >= 3 ? '#d9534f' : cur <= base ? '#4caf50' : '#f0ad4e';
                         return `width: ${pct}%; height: 100%; background: ${color}; border-radius: 2px; transition: width 0.5s;`;
                       })()"></div>
                     </div>
@@ -4189,7 +4190,8 @@
                         const base = ge?.cadence_minutes || 90;
                         const max = ge?.max_interval_minutes || 240;
                         const pct = Math.min(100, (cur / max) * 100);
-                        const color = cur <= base ? '#4caf50' : cur < max * 0.75 ? '#f0ad4e' : '#d9534f';
+                        const cFail = ge?.cadence?.consecutive_failures || 0;
+                        const color = cFail >= 3 ? '#d9534f' : cur <= base ? '#4caf50' : '#f0ad4e';
                         return `width: ${pct}%; height: 100%; background: ${color}; border-radius: 2px; transition: width 0.5s;`;
                       })()"></div>
                     </div>

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -69,52 +69,59 @@ def _sort_proposals(proposals: list[dict]) -> list[dict]:
     )
 
 
+def _truncate(text: str, limit: int) -> str:
+    """Truncate text to limit, adding ellipsis if needed."""
+    return text[:limit] + "\u2026" if len(text) > limit else text
+
+
 def _format_digest(
     proposals: list[dict],
     batch_id: str,
     ego_source: str | None = None,
 ) -> str:
-    """Format proposals as an HTML numbered digest for Telegram.
+    """Format proposals as a structured WHAT/WHY/HOW digest for Telegram.
 
     Proposals are sorted by urgency x confidence before numbering.
+    Fields map to: content → WHAT, rationale → WHY, execution_plan → HOW.
     """
     sorted_proposals = _sort_proposals(proposals)
     label = _EGO_LABELS.get(ego_source or "", "Ego")
-    lines = [f"<b>{_ESC(label)} Proposals</b> \u2014 Batch {_ESC(batch_id[:8])}\n"]
+    lines = [f"<b>{_ESC(label)}</b> \u2014 {_ESC(batch_id[:8])}\n"]
 
     for i, p in enumerate(sorted_proposals, 1):
-        content = p.get("content", "")
-        if len(content) > 800:
-            content = content[:800] + "\u2026"
-        rationale = p.get("rationale", "")
-        if len(rationale) > 500:
-            rationale = rationale[:500] + "\u2026"
-
         urgency = p.get("urgency", "normal")
         urgency_tag = _URGENCY_TAGS.get(urgency, "")
+        action_type = p.get("action_type", "?")
+
+        # Header: number + urgency + action type
         lines.append(
-            f"<b>{i}.</b> {_ESC(urgency_tag)}<b>[{_ESC(p.get('action_type', '?'))}]</b> "
-            f"{_ESC(content)}"
+            f"<b>{i}.</b> {_ESC(urgency_tag)}{_ESC(action_type)}"
         )
+
+        # WHAT (content)
+        content = _truncate(p.get("content", ""), 400)
+        lines.append(f"\n<b>WHAT:</b> {_ESC(content)}")
+
+        # WHY (rationale)
+        rationale = p.get("rationale", "")
         if rationale:
-            lines.append(f"<i>Rationale:</i> {_ESC(rationale)}")
-        memory_basis = p.get("memory_basis", "")
-        if memory_basis:
-            if len(memory_basis) > 500:
-                memory_basis = memory_basis[:500] + "\u2026"
-            lines.append(f"<i>{_ESC(memory_basis)}</i>")
+            rationale = _truncate(rationale, 300)
+            lines.append(f"\n<b>WHY:</b> {_ESC(rationale)}")
+
+        # HOW (execution_plan)
+        plan = p.get("execution_plan", "")
+        if plan:
+            plan = _truncate(plan, 200)
+            lines.append(f"\n<b>HOW:</b> {_ESC(plan)}")
+
+        # Confidence badge
         confidence = p.get("confidence", 0.0)
-        lines.append(f"<i>Confidence:</i> {confidence:.2f} | <i>Urgency:</i> {urgency}")
-        alts = p.get("alternatives", "")
-        if alts:
-            if len(alts) > 300:
-                alts = alts[:300] + "\u2026"
-            lines.append(f"<i>Alternatives:</i> {_ESC(alts)}")
+        lines.append(f"\n[{confidence:.2f} confidence]")
         lines.append("")
 
+    # Separator + compact reply instructions
     lines.append(
-        "<i>Reply: ok/yes/approve \u2022 no/reject \u2022 "
-        "\"approve 1, reject 2\" \u2022 or just talk</i>"
+        "<i>ok \u2022 no \u2022 \"approve 1, reject 2\" \u2022 or talk</i>"
     )
     return "\n".join(lines)
 

--- a/src/genesis/memory/dream_entity_scan.py
+++ b/src/genesis/memory/dream_entity_scan.py
@@ -87,10 +87,26 @@ async def run_entity_resolution(
     if total_points < 2:
         return report
 
+    # Large buckets cause O(n) Qdrant searches in find_dedup_candidates,
+    # which exhausts memory.  Skip buckets above this threshold — they
+    # need a chunked/batch algorithm (tracked as follow-up).
+    MAX_BUCKET_FOR_DEDUP = 500
+
     llm_checks_used = 0
 
     for (_wing, _room), points in buckets.items():
         if len(points) < 2:
+            continue
+
+        if len(points) > MAX_BUCKET_FOR_DEDUP:
+            logger.warning(
+                "Entity resolution: bucket (%s, %s) has %d points — "
+                "skipping dedup (limit %d)",
+                _wing, _room, len(points), MAX_BUCKET_FOR_DEDUP,
+            )
+            report.setdefault("skipped_large_buckets", []).append(
+                {"wing": _wing, "room": _room, "count": len(points)},
+            )
             continue
 
         # 2. Fetch vectors for this bucket

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -1056,12 +1056,18 @@ class SurplusScheduler:
             with contextlib.suppress(Exception):
                 GenesisRuntime.instance().record_job_success("dream_cycle")
         except Exception as exc:
-            logger.exception("Dream cycle failed")
+            logger.exception("Dream cycle failed: %s", exc)
             try:
                 from genesis.runtime import GenesisRuntime
-                GenesisRuntime.instance().record_job_failure("dream_cycle", str(exc))
-            except Exception:
-                pass
+                GenesisRuntime.instance().record_job_failure(
+                    "dream_cycle", str(exc)[:500],
+                )
+            except Exception as rec_err:
+                logger.error(
+                    "Failed to record dream_cycle failure: %s "
+                    "(original error: %s)",
+                    rec_err, exc,
+                )
         finally:
             # Always clear heavy workload flag, even on failure.
             # Use the captured `rt` reference (line 859) — re-looking up

--- a/tests/ego/test_proposals.py
+++ b/tests/ego/test_proposals.py
@@ -246,13 +246,20 @@ class TestProposalWorkflow:
 
     async def test_format_digest_html(self, workflow):
         digest = workflow.format_digest(_sample_proposals(2), "batch123")
-        assert "<b>Ego Proposals</b>" in digest
+        assert "<b>Ego</b>" in digest
         assert "batch123" in digest  # first 8 chars of batch_id
         assert "<b>1.</b>" in digest
         assert "<b>2.</b>" in digest
-        assert "[investigate]" in digest
-        # Footer removed — bidirectional comms replaces reply-to-approve
-        assert "approve all" not in digest
+        assert "<b>WHAT:</b>" in digest
+        assert "confidence]" in digest
+
+    async def test_format_digest_ego_source_labels(self, workflow):
+        """ego_source maps to readable labels in header."""
+        props = [{"action_type": "investigate", "content": "Test", "confidence": 0.5}]
+        user_digest = workflow.format_digest(props, "b1", ego_source="user_ego_cycle")
+        assert "<b>User Ego</b>" in user_digest
+        gen_digest = workflow.format_digest(props, "b1", ego_source="genesis_ego_cycle")
+        assert "<b>Genesis Ego</b>" in gen_digest
 
     async def test_format_digest_escapes_html(self, workflow):
         bad = [{"action_type": "<script>", "content": "a<b>c", "confidence": 0.5}]
@@ -260,23 +267,24 @@ class TestProposalWorkflow:
         assert "<script>" not in digest
         assert "&lt;script&gt;" in digest
 
-    async def test_format_digest_alternatives_shown(self, workflow):
-        props = [_sample_proposals(1)[0]]  # has alternatives
+    async def test_format_digest_alternatives_not_shown(self, workflow):
+        """Alternatives dropped from digest — WHAT/WHY/HOW format only."""
+        props = [_sample_proposals(1)[0]]  # has alternatives field
         digest = workflow.format_digest(props, "b1")
-        assert "Alternatives:" in digest
+        assert "Alternatives:" not in digest
 
     async def test_format_digest_alternatives_hidden(self, workflow):
         props = [_sample_proposals(2)[1]]  # no alternatives key or empty
         digest = workflow.format_digest(props, "b1")
         assert "Alternatives:" not in digest
 
-    async def test_format_digest_memory_basis_shown(self, workflow):
-        """memory_basis renders as italic text when present."""
+    async def test_format_digest_memory_basis_not_shown(self, workflow):
+        """memory_basis dropped from digest — internal attribution only."""
         props = [{"action_type": "investigate", "content": "Test",
                   "memory_basis": "the freelance goal from March",
                   "confidence": 0.8}]
         digest = workflow.format_digest(props, "b1")
-        assert "<i>the freelance goal from March</i>" in digest
+        assert "freelance goal" not in digest
 
     async def test_format_digest_memory_basis_hidden_when_empty(self, workflow):
         """Empty memory_basis does not render."""
@@ -286,14 +294,30 @@ class TestProposalWorkflow:
         # Should not have an empty italic tag
         assert "<i></i>" not in digest
 
-    async def test_format_digest_memory_basis_truncated(self, workflow):
-        """Long memory_basis is truncated to 500 chars."""
-        long_basis = "X" * 600
+    async def test_format_digest_rationale_shown_as_why(self, workflow):
+        """Rationale renders under WHY label."""
         props = [{"action_type": "investigate", "content": "Test",
-                  "memory_basis": long_basis, "confidence": 0.8}]
+                  "rationale": "This matters because deadlines",
+                  "confidence": 0.8}]
         digest = workflow.format_digest(props, "b1")
-        assert "X" * 500 in digest
-        assert "X" * 501 not in digest
+        assert "<b>WHY:</b>" in digest
+        assert "This matters because deadlines" in digest
+
+    async def test_format_digest_execution_plan_shown_as_how(self, workflow):
+        """execution_plan renders under HOW label when present."""
+        props = [{"action_type": "dispatch", "content": "Run analysis",
+                  "execution_plan": "Background CC session, opus model",
+                  "confidence": 0.9}]
+        digest = workflow.format_digest(props, "b1")
+        assert "<b>HOW:</b>" in digest
+        assert "Background CC session" in digest
+
+    async def test_format_digest_no_how_when_plan_empty(self, workflow):
+        """HOW section omitted when execution_plan is empty."""
+        props = [{"action_type": "outreach", "content": "Notify user",
+                  "confidence": 0.9}]
+        digest = workflow.format_digest(props, "b1")
+        assert "<b>HOW:</b>" not in digest
 
     async def test_send_digest_calls_topic_manager(
         self, workflow, db, mock_topic_manager,


### PR DESCRIPTION
## Summary

- **Dream cycle OOM fix**: Add bucket size guard (500 points max) to entity resolution's `find_dedup_candidates`. Buckets exceeding the limit are skipped with a warning. Prevents the ~2h crash on 28K+ memory points that occurred on June 1 first live run.
- **Dream cycle error recording**: Replace silent `except Exception: pass` in failure handler with proper logging, so crashes are visible in job_health.
- **Telegram proposal format**: Restructure from flat Rationale/Confidence/Alternatives to WHAT/WHY/HOW sections with inline confidence badge. Drops alternatives and memory_basis (internal, not decision-relevant).
- **Dashboard ego color**: Red only for circuit breaker (consecutive_failures >= 3), amber for backed-off intervals. Previously any interval >= 75% of max showed red, conflating healthy backoff with failures.

## Files changed

- `src/genesis/memory/dream_entity_scan.py` — bucket size guard in `run_entity_resolution`
- `src/genesis/surplus/scheduler.py` — fix silent error swallowing in dream cycle handler
- `src/genesis/ego/proposals.py` — `_format_digest()` restructured to WHAT/WHY/HOW
- `src/genesis/dashboard/templates/genesis_dashboard.html` — ego progress bar color logic
- `tests/ego/test_proposals.py` — updated format tests, added ego_source label + HOW section tests

## Follow-ups

- Genesis ego signal-driven cadence (separate from user activity)
- IdleDetector CC session awareness
- `find_dedup_candidates` algorithm optimization (O(n) → batch approach)

## Test plan

- [x] 102 tests pass (entity_resolution + proposals + proposal_parser + proposal_lifecycle)
- [x] Lint clean (ruff)
- [x] Code review (no critical issues)
- [ ] CI checks
- [ ] Visual verification of dashboard ego bars after restart
- [ ] Verify next ego proposal Telegram message uses new format