### PR TITLE
feat(hooks): wire outcome verification + skill injection + feedback audit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "3.0.0b11"
 requires-python = ">=3.12"
 dependencies = [
     "aiosqlite",
-    "aiohttp",
+    "aiohttp<3.14",  # 3.14 adds required stream_writer kwarg to ClientResponse; aioresponses 0.7.8 doesn't pass it
     "apscheduler>=3.11,<4",
     "python-telegram-bot>=21.0",
     "litellm==1.78.7",  # pinned — 1.82.7/1.82.8 contain malware; CVE-2026-35030/35029 not exploitable

--- a/scripts/genesis_stop_hook.py
+++ b/scripts/genesis_stop_hook.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Stop hook: detect resume signals, giving-up patterns, and unreviewed code.
+"""Stop hook: detect resume signals, giving-up, outcome verification, and unreviewed code.
 
 Runs when Claude finishes responding (via .claude/settings.json Stop hook).
 
@@ -11,7 +11,11 @@ Runs when Claude finishes responding (via .claude/settings.json Stop hook).
    delegate work back to the user instead of exhausting available tools.
    If detected, outputs a nudge for the next turn.
 
-3. Checks for unreviewed code changes. If found, outputs a reminder that
+3. Checks the assistant's last message for completion claims without
+   verification evidence. If finishing language is present but no integration
+   or e2e proof, injects a reminder to verify outcomes before claiming done.
+
+4. Checks for unreviewed code changes. If found, outputs a reminder that
    gets injected into context for the next turn.
 
 Reads hook input from stdin as JSON:
@@ -90,6 +94,7 @@ def main() -> None:
     # needs the assistant's last message from hook input.
     assistant_msg = hook_input.get("last_assistant_message", "")
     _check_giving_up(assistant_msg)
+    _check_outcome_verification(assistant_msg)
 
     # Check for unreviewed code changes
     _check_review_state()
@@ -128,6 +133,58 @@ _GIVING_UP_PATTERNS = re.compile(
     r")",
     re.IGNORECASE,
 )
+
+
+# Patterns indicating the assistant is at the "finishing" stage —
+# offering to merge, create PRs, or declaring implementation complete.
+_FINISHING_PATTERNS = re.compile(
+    r"(?:"
+    r"[Mm]erge\s+(?:back\s+)?to\s+main"
+    r"|[Cc]reate\s+a\s+[Pp]ull\s+[Rr]equest"
+    r"|[Pp]ush\s+and\s+create"
+    r"|[Ii]mplementation\s+complete"
+    r"|What\s+would\s+you\s+like\s+to\s+do\?"
+    r"|Keep\s+the\s+branch\s+as-is"
+    r"|Discard\s+this\s+work"
+    r"|[Rr]eady\s+to\s+(?:ship|merge|land|deploy)"
+    r"|[Aa]ll\s+(?:changes|work)\s+(?:are\s+)?(?:done|complete)"
+    r")",
+)
+
+# Patterns indicating integration/e2e verification was actually done.
+# If any of these appear alongside finishing language, skip the reminder.
+_VERIFICATION_EVIDENCE = re.compile(
+    r"(?:"
+    r"[Ii]ntegration\s+test"
+    r"|[Ee]2[Ee]\s+test"
+    r"|[Ss]moke\s+test"
+    r"|[Aa][Pp][Ii]\s+(?:smoke\s+)?test"
+    r"|[Vv]erif(?:y|ied)\s+(?:the\s+)?(?:actual|end-to-end|e2e)"
+    r"|[Mm]anual(?:ly)?\s+(?:test|verif)"
+    r"|[Ll]ive\s+(?:test|verif)"
+    r"|[Tt]elegram\s+API\s+(?:smoke|confirmed|test)"
+    r"|[Aa]syncio\s+integration"
+    r"|[Pp]roduction\s+(?:test|verif)"
+    r"|[Oo]utcome\s+verif"
+    r")",
+)
+
+
+def _check_outcome_verification(assistant_message: str) -> None:
+    """Remind to verify actual outcomes before presenting completion options."""
+    if not assistant_message:
+        return
+    if not _FINISHING_PATTERNS.search(assistant_message):
+        return
+    if _VERIFICATION_EVIDENCE.search(assistant_message):
+        return
+    print(
+        "OUTCOME VERIFICATION REMINDER: You're presenting completion options "
+        "but haven't mentioned integration or e2e verification beyond unit tests. "
+        "Before the user decides, use superpowers:verification-before-completion — "
+        "run the actual verification command, read the full output, THEN claim status. "
+        "Evidence before assertions."
+    )
 
 
 def _check_giving_up(assistant_message: str) -> None:

--- a/scripts/genesis_stop_hook.py
+++ b/scripts/genesis_stop_hook.py
@@ -139,34 +139,36 @@ _GIVING_UP_PATTERNS = re.compile(
 # offering to merge, create PRs, or declaring implementation complete.
 _FINISHING_PATTERNS = re.compile(
     r"(?:"
-    r"[Mm]erge\s+(?:back\s+)?to\s+main"
-    r"|[Cc]reate\s+a\s+[Pp]ull\s+[Rr]equest"
-    r"|[Pp]ush\s+and\s+create"
-    r"|[Ii]mplementation\s+complete"
-    r"|What\s+would\s+you\s+like\s+to\s+do\?"
-    r"|Keep\s+the\s+branch\s+as-is"
-    r"|Discard\s+this\s+work"
-    r"|[Rr]eady\s+to\s+(?:ship|merge|land|deploy)"
-    r"|[Aa]ll\s+(?:changes|work)\s+(?:are\s+)?(?:done|complete)"
+    r"merge\s+(?:back\s+)?to\s+main"
+    r"|create\s+a\s+pull\s+request"
+    r"|push\s+and\s+create"
+    r"|implementation\s+complete"
+    r"|what\s+would\s+you\s+like\s+to\s+do\?"
+    r"|keep\s+the\s+branch\s+as-is"
+    r"|discard\s+this\s+work"
+    r"|ready\s+to\s+(?:ship|merge|land|deploy)"
+    r"|all\s+(?:changes|work)\s+(?:are\s+)?(?:done|complete)"
     r")",
+    re.IGNORECASE,
 )
 
 # Patterns indicating integration/e2e verification was actually done.
 # If any of these appear alongside finishing language, skip the reminder.
 _VERIFICATION_EVIDENCE = re.compile(
     r"(?:"
-    r"[Ii]ntegration\s+test"
-    r"|[Ee]2[Ee]\s+test"
-    r"|[Ss]moke\s+test"
-    r"|[Aa][Pp][Ii]\s+(?:smoke\s+)?test"
-    r"|[Vv]erif(?:y|ied)\s+(?:the\s+)?(?:actual|end-to-end|e2e)"
-    r"|[Mm]anual(?:ly)?\s+(?:test|verif)"
-    r"|[Ll]ive\s+(?:test|verif)"
-    r"|[Tt]elegram\s+API\s+(?:smoke|confirmed|test)"
-    r"|[Aa]syncio\s+integration"
-    r"|[Pp]roduction\s+(?:test|verif)"
-    r"|[Oo]utcome\s+verif"
+    r"integration\s+test"
+    r"|e2e\s+test"
+    r"|smoke\s+test"
+    r"|api\s+(?:smoke\s+)?test"
+    r"|verif(?:y|ied)\s+(?:the\s+)?(?:actual|end-to-end|e2e)"
+    r"|manual(?:ly)?\s+(?:test|verif)"
+    r"|live\s+(?:test|verif)"
+    r"|telegram\s+api\s+(?:smoke|confirmed|test)"
+    r"|asyncio\s+integration"
+    r"|production\s+(?:test|verif)"
+    r"|outcome\s+verif"
     r")",
+    re.IGNORECASE,
 )
 
 

--- a/scripts/hooks/audit_feedback_coverage.py
+++ b/scripts/hooks/audit_feedback_coverage.py
@@ -30,9 +30,12 @@ from pathlib import Path
 
 _GENESIS_DB = Path.home() / "genesis" / "data" / "genesis.db"
 _SETTINGS_JSON = Path.home() / "genesis" / ".claude" / "settings.json"
-_FEEDBACK_DIR = (
-    Path.home() / ".claude" / "projects" / "-home-ubuntu-genesis" / "memory"
-)
+
+# Derive the CC project slug from the genesis repo path — avoids hardcoding
+# the username. CC encodes project dirs as "-"-separated path components.
+_GENESIS_ROOT = Path.home() / "genesis"
+_PROJECT_SLUG = "-" + str(_GENESIS_ROOT).replace("/", "-").lstrip("-")
+_FEEDBACK_DIR = Path.home() / ".claude" / "projects" / _PROJECT_SLUG / "memory"
 
 
 def _load_feedback_files() -> list[dict]:

--- a/scripts/hooks/audit_feedback_coverage.py
+++ b/scripts/hooks/audit_feedback_coverage.py
@@ -60,29 +60,28 @@ def _load_db_rules() -> list[dict]:
     if not _GENESIS_DB.exists():
         return []
     try:
-        db = sqlite3.connect(str(_GENESIS_DB))
-        db.row_factory = sqlite3.Row
-        rows = db.execute(
-            """
-            SELECT m.memory_id, f.content, f.tags
-            FROM memory_metadata m
-            JOIN memory_fts f ON m.memory_id = f.memory_id
-            WHERE m.memory_class = 'rule' AND m.deprecated = 0
-            """
-        ).fetchall()
-        results = []
-        for r in rows:
-            content = r["content"] or ""
-            name_match = re.search(r"^name:\s*(.+)$", content, re.MULTILINE)
-            results.append({
-                "source": "db_rule",
-                "memory_id": r["memory_id"][:12],
-                "name": name_match.group(1).strip() if name_match else "",
-                "tags": r["tags"] or "",
-                "content_preview": content[:300],
-            })
-        db.close()
-        return results
+        with sqlite3.connect(str(_GENESIS_DB)) as db:
+            db.row_factory = sqlite3.Row
+            rows = db.execute(
+                """
+                SELECT m.memory_id, f.content, f.tags
+                FROM memory_metadata m
+                JOIN memory_fts f ON m.memory_id = f.memory_id
+                WHERE m.memory_class = 'rule' AND m.deprecated = 0
+                """
+            ).fetchall()
+            results = []
+            for r in rows:
+                content = r["content"] or ""
+                name_match = re.search(r"^name:\s*(.+)$", content, re.MULTILINE)
+                results.append({
+                    "source": "db_rule",
+                    "memory_id": r["memory_id"][:12],
+                    "name": name_match.group(1).strip() if name_match else "",
+                    "tags": r["tags"] or "",
+                    "content_preview": content[:300],
+                })
+            return results
     except Exception:
         return []
 
@@ -92,28 +91,27 @@ def _load_procedures() -> list[dict]:
     if not _GENESIS_DB.exists():
         return []
     try:
-        db = sqlite3.connect(str(_GENESIS_DB))
-        db.row_factory = sqlite3.Row
-        rows = db.execute(
-            """
-            SELECT id, task_type, principle, confidence, tool_trigger
-            FROM procedural_memory
-            WHERE deprecated = 0
-            ORDER BY confidence DESC
-            """
-        ).fetchall()
-        results = []
-        for r in rows:
-            results.append({
-                "source": "procedure",
-                "id": r["id"][:12] if r["id"] else "",
-                "task_type": r["task_type"] or "",
-                "principle": (r["principle"] or "")[:200],
-                "confidence": r["confidence"],
-                "tool_trigger": r["tool_trigger"] or "",
-            })
-        db.close()
-        return results
+        with sqlite3.connect(str(_GENESIS_DB)) as db:
+            db.row_factory = sqlite3.Row
+            rows = db.execute(
+                """
+                SELECT id, task_type, principle, confidence, tool_trigger
+                FROM procedural_memory
+                WHERE deprecated = 0
+                ORDER BY confidence DESC
+                """
+            ).fetchall()
+            results = []
+            for r in rows:
+                results.append({
+                    "source": "procedure",
+                    "id": r["id"][:12] if r["id"] else "",
+                    "task_type": r["task_type"] or "",
+                    "principle": (r["principle"] or "")[:200],
+                    "confidence": r["confidence"],
+                    "tool_trigger": r["tool_trigger"] or "",
+                })
+            return results
     except Exception:
         return []
 
@@ -178,15 +176,32 @@ def _classify_coverage(
 ) -> tuple[list[dict], list[dict]]:
     """Classify feedback items as covered or uncovered by hooks.
 
-    Simple heuristic: check if keywords from the feedback name/description
-    appear in any hook command or script name. Not perfect, but useful for
-    identifying obvious gaps.
+    Heuristic: check if domain-specific keywords from the feedback
+    name/description appear in hook enforcement patterns or script names.
+    Filters out generic path/language words to reduce false positives.
     """
     enforced = _extract_enforced_patterns(hooks)
-    hook_commands = " ".join(
-        h.get("command_preview", "") + " " + h.get("script", "")
-        for h in hooks
-    ).lower()
+
+    # Extract only script names and inline command arguments — not file paths
+    hook_terms = set()
+    for h in hooks:
+        script = h.get("script", "").lower()
+        # Script names are meaningful (e.g., "destructive_command_guard.py")
+        hook_terms.update(re.findall(r"[a-z_]{5,}", script))
+        cmd = h.get("command_preview", "").lower()
+        # Extract quoted strings and flag-like arguments from inline bash
+        hook_terms.update(re.findall(r"'([a-z_]{5,})'", cmd))
+        hook_terms.update(re.findall(r'"([a-z_]{5,})"', cmd))
+
+    # Words too generic to be meaningful matches
+    _NOISE_WORDS = {
+        "hooks", "check", "guard", "genesis", "claude", "python",
+        "script", "shell", "print", "error", "false",
+        "return", "import", "output", "input", "should", "would",
+        "could", "never", "always", "about", "their", "there",
+        "which", "where", "these", "those", "other", "after",
+        "before", "first", "every", "using", "because", "process",
+    }
 
     covered = []
     uncovered = []
@@ -196,13 +211,18 @@ def _classify_coverage(
         desc = item.get("description", "").lower()
         combined = name + " " + desc
 
-        # Check if any significant word from the feedback name appears
-        # in the hook commands
-        words = re.findall(r"[a-z_]{4,}", combined)
-        match_count = sum(1 for w in words if w in hook_commands)
+        # Extract meaningful domain words (5+ chars, not noise)
+        words = [
+            w for w in re.findall(r"[a-z_]{5,}", combined)
+            if w not in _NOISE_WORDS
+        ]
+        match_count = sum(1 for w in words if w in hook_terms)
 
         if match_count >= 2 or any(p in combined for p in enforced):
-            covered.append({**item, "match_strength": "strong" if match_count >= 3 else "weak"})
+            covered.append({
+                **item,
+                "match_strength": "strong" if match_count >= 3 else "weak",
+            })
         else:
             uncovered.append(item)
 

--- a/scripts/hooks/audit_feedback_coverage.py
+++ b/scripts/hooks/audit_feedback_coverage.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Audit feedback memory coverage against hook enforcement.
+
+Standalone script (NOT a CC hook). Compares feedback memories stored in
+the Genesis memory system against the hooks registered in settings.json
+to identify coverage gaps — feedback lessons that have no corresponding
+enforcement mechanism.
+
+Three data sources:
+  1. Feedback files on disk (~/.claude/projects/-home-ubuntu-genesis/memory/feedback_*.md)
+  2. Rule-class memories in SQLite (memory_metadata + memory_fts)
+  3. Procedures in SQLite (procedural_memory)
+
+Outputs a JSON report to stdout with covered/uncovered/unmatched items.
+
+Usage:
+  python scripts/hooks/audit_feedback_coverage.py
+  python scripts/hooks/audit_feedback_coverage.py --summary  # compact output
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+# --- Configuration ---
+
+_GENESIS_DB = Path.home() / "genesis" / "data" / "genesis.db"
+_SETTINGS_JSON = Path.home() / "genesis" / ".claude" / "settings.json"
+_FEEDBACK_DIR = (
+    Path.home() / ".claude" / "projects" / "-home-ubuntu-genesis" / "memory"
+)
+
+
+def _load_feedback_files() -> list[dict]:
+    """Load feedback memory files from disk."""
+    results = []
+    if not _FEEDBACK_DIR.exists():
+        return results
+    for f in sorted(_FEEDBACK_DIR.glob("feedback_*.md")):
+        text = f.read_text(errors="replace")
+        # Extract name from YAML frontmatter
+        name_match = re.search(r"^name:\s*(.+)$", text, re.MULTILINE)
+        desc_match = re.search(r"^description:\s*(.+)$", text, re.MULTILINE)
+        results.append({
+            "source": "file",
+            "path": str(f.name),
+            "name": name_match.group(1).strip() if name_match else f.stem,
+            "description": desc_match.group(1).strip() if desc_match else "",
+            "content_preview": text[:300],
+        })
+    return results
+
+
+def _load_db_rules() -> list[dict]:
+    """Load rule-class memories from SQLite."""
+    if not _GENESIS_DB.exists():
+        return []
+    try:
+        db = sqlite3.connect(str(_GENESIS_DB))
+        db.row_factory = sqlite3.Row
+        rows = db.execute(
+            """
+            SELECT m.memory_id, f.content, f.tags
+            FROM memory_metadata m
+            JOIN memory_fts f ON m.memory_id = f.memory_id
+            WHERE m.memory_class = 'rule' AND m.deprecated = 0
+            """
+        ).fetchall()
+        results = []
+        for r in rows:
+            content = r["content"] or ""
+            name_match = re.search(r"^name:\s*(.+)$", content, re.MULTILINE)
+            results.append({
+                "source": "db_rule",
+                "memory_id": r["memory_id"][:12],
+                "name": name_match.group(1).strip() if name_match else "",
+                "tags": r["tags"] or "",
+                "content_preview": content[:300],
+            })
+        db.close()
+        return results
+    except Exception:
+        return []
+
+
+def _load_procedures() -> list[dict]:
+    """Load active procedures from SQLite."""
+    if not _GENESIS_DB.exists():
+        return []
+    try:
+        db = sqlite3.connect(str(_GENESIS_DB))
+        db.row_factory = sqlite3.Row
+        rows = db.execute(
+            """
+            SELECT id, task_type, principle, confidence, tool_trigger
+            FROM procedural_memory
+            WHERE deprecated = 0
+            ORDER BY confidence DESC
+            """
+        ).fetchall()
+        results = []
+        for r in rows:
+            results.append({
+                "source": "procedure",
+                "id": r["id"][:12] if r["id"] else "",
+                "task_type": r["task_type"] or "",
+                "principle": (r["principle"] or "")[:200],
+                "confidence": r["confidence"],
+                "tool_trigger": r["tool_trigger"] or "",
+            })
+        db.close()
+        return results
+    except Exception:
+        return []
+
+
+def _load_hook_inventory() -> list[dict]:
+    """Parse settings.json to inventory all registered hooks."""
+    if not _SETTINGS_JSON.exists():
+        return []
+    try:
+        settings = json.loads(_SETTINGS_JSON.read_text())
+    except Exception:
+        return []
+
+    hooks_config = settings.get("hooks", {})
+    inventory = []
+
+    for event_type, hook_groups in hooks_config.items():
+        for group in hook_groups:
+            matcher = group.get("matcher", "*")
+            for hook_def in group.get("hooks", []):
+                command = hook_def.get("command", "")
+                # Extract the script name from the command
+                script_name = ""
+                if "genesis-hook" in command:
+                    parts = command.split("genesis-hook")
+                    if len(parts) > 1:
+                        script_name = parts[1].strip()
+                elif command.startswith("bash -c"):
+                    # Inline bash — extract a summary
+                    script_name = "(inline bash)"
+
+                inventory.append({
+                    "event": event_type,
+                    "matcher": matcher,
+                    "script": script_name,
+                    "command_preview": command[:120],
+                })
+    return inventory
+
+
+def _extract_enforced_patterns(hooks: list[dict]) -> set[str]:
+    """Extract keywords from hook commands that indicate what they enforce."""
+    patterns = set()
+    for h in hooks:
+        cmd = h.get("command_preview", "").lower()
+        script = h.get("script", "").lower()
+        # Extract meaningful keywords
+        for keyword in [
+            "destructive", "credential", "git_push", "force",
+            "nohup", "pip install", "worktree", "protected_path",
+            "review", "concurrent", "full_suite", "rm -r",
+            "reset --hard", "clean -f", "sqlite3", "youtube",
+            "web_tools", "stealth", "behavioral", "pretool",
+        ]:
+            if keyword in cmd or keyword in script:
+                patterns.add(keyword)
+    return patterns
+
+
+def _classify_coverage(
+    feedback: list[dict], hooks: list[dict]
+) -> tuple[list[dict], list[dict]]:
+    """Classify feedback items as covered or uncovered by hooks.
+
+    Simple heuristic: check if keywords from the feedback name/description
+    appear in any hook command or script name. Not perfect, but useful for
+    identifying obvious gaps.
+    """
+    enforced = _extract_enforced_patterns(hooks)
+    hook_commands = " ".join(
+        h.get("command_preview", "") + " " + h.get("script", "")
+        for h in hooks
+    ).lower()
+
+    covered = []
+    uncovered = []
+
+    for item in feedback:
+        name = item.get("name", "").lower()
+        desc = item.get("description", "").lower()
+        combined = name + " " + desc
+
+        # Check if any significant word from the feedback name appears
+        # in the hook commands
+        words = re.findall(r"[a-z_]{4,}", combined)
+        match_count = sum(1 for w in words if w in hook_commands)
+
+        if match_count >= 2 or any(p in combined for p in enforced):
+            covered.append({**item, "match_strength": "strong" if match_count >= 3 else "weak"})
+        else:
+            uncovered.append(item)
+
+    return covered, uncovered
+
+
+def main() -> None:
+    summary_mode = "--summary" in sys.argv
+
+    feedback_files = _load_feedback_files()
+    db_rules = _load_db_rules()
+    procedures = _load_procedures()
+    hooks = _load_hook_inventory()
+
+    covered, uncovered = _classify_coverage(feedback_files, hooks)
+
+    report = {
+        "summary": {
+            "feedback_files": len(feedback_files),
+            "db_rules": len(db_rules),
+            "procedures": len(procedures),
+            "hooks_registered": len(hooks),
+            "covered": len(covered),
+            "uncovered": len(uncovered),
+            "coverage_pct": round(
+                len(covered) / max(len(feedback_files), 1) * 100, 1
+            ),
+        },
+        "uncovered_feedback": [
+            {"name": u["name"], "path": u.get("path", ""), "description": u.get("description", "")}
+            for u in uncovered
+        ],
+    }
+
+    if not summary_mode:
+        report["covered_feedback"] = [
+            {"name": c["name"], "match_strength": c["match_strength"]}
+            for c in covered
+        ]
+        report["hooks"] = [
+            {"event": h["event"], "matcher": h["matcher"], "script": h["script"]}
+            for h in hooks
+        ]
+        report["procedures"] = [
+            {"task_type": p["task_type"], "confidence": p["confidence"]}
+            for p in procedures[:10]
+        ]
+
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/skill_injection_hook.py
+++ b/scripts/hooks/skill_injection_hook.py
@@ -24,8 +24,9 @@ _CATALOG_MAX_AGE_S = 3600  # Regenerate catalog if older than 1h
 # the skill. With 10 prompt keywords, a single keyword match = 0.1 (name)
 # or 0.05 (desc). Threshold of 0.1 means 1 name/keyword match suffices.
 _MIN_CONFIDENCE = 0.1
-# Max nudges per prompt
-_MAX_NUDGES = 1
+# Total nudge budget per prompt (process + catalog combined).
+# If process nudges consume slots, catalog gets fewer.
+_MAX_TOTAL_NUDGES = 2
 
 # --- Process Discipline Detection ---
 # Superpowers skills aren't in the Genesis catalog but need nudges
@@ -35,6 +36,7 @@ _MAX_NUDGES = 1
 _PLAN_INTENT_KEYWORDS = {
     "plan", "implement", "build", "feature", "architect", "design",
     "refactor", "redesign", "rewrite", "migrate", "integrate",
+    "overhaul", "consolidate", "extract", "split", "decouple", "scaffold",
 }
 
 # Intent: "about to write code that should be test-driven"
@@ -42,6 +44,7 @@ _CODE_INTENT_KEYWORDS = {
     "implement", "build", "add", "create", "fix", "feature",
     "endpoint", "handler", "function", "class", "module",
     "refactor", "wire", "connect",
+    "api", "route", "service", "hook", "guard", "plugin", "migration", "schema",
 }
 
 # These don't need TDD/brainstorming nudges
@@ -49,6 +52,7 @@ _EXCLUDE_KEYWORDS = {
     "docs", "documentation", "readme", "config", "yaml", "markdown",
     "comment", "typo", "rename", "changelog", "version", "memory",
     "evaluate", "research", "look", "check", "review", "read",
+    "status", "list", "show", "explain", "describe", "summarize", "analyze",
 }
 
 
@@ -142,9 +146,10 @@ def _extract_keywords(prompt: str) -> list[str]:
     stop = {
         "the", "is", "are", "was", "and", "or", "but", "for", "with",
         "this", "that", "can", "you", "how", "what", "when", "where",
-        "why", "not", "let", "use",
+        "why", "not", "let", "use", "need", "want", "please", "just",
+        "some", "make", "get", "also", "then", "into",
     }
-    return [w for w in words if len(w) >= 3 and w not in stop][:10]
+    return [w for w in words if len(w) >= 3 and w not in stop][:12]
 
 
 def _check_process_discipline(
@@ -244,7 +249,9 @@ def main() -> None:
 
         candidates.sort(key=lambda x: x[0], reverse=True)
 
-        for _score, skill in candidates[:_MAX_NUDGES]:
+        # Dynamic budget: total nudges (process + catalog) capped at _MAX_TOTAL_NUDGES
+        catalog_budget = max(0, _MAX_TOTAL_NUDGES - len(process_nudges))
+        for _score, skill in candidates[:catalog_budget]:
             name = skill.get("name", "")
             tier = skill.get("tier", "?")
             desc = skill.get("description", "")

--- a/scripts/outcome_verification_hook.py
+++ b/scripts/outcome_verification_hook.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python3
-"""Stop hook: remind to verify actual outcomes before claiming done.
+"""DEPRECATED: Logic merged into genesis_stop_hook.py (2026-06-01).
+
+This file had two issues:
+1. It was never registered in settings.json (built but not wired).
+2. It read the wrong field name ('stop_response' instead of
+   'last_assistant_message'), so it would have silently failed even if wired.
+
+The outcome verification logic now lives in genesis_stop_hook.py alongside
+the giving-up detection and review enforcement checks.
+
+Original description:
+Stop hook: remind to verify actual outcomes before claiming done.
 
 When the assistant's response contains finishing-stage language (merge options,
 PR creation, "implementation complete") but lacks evidence of integration or

--- a/tests/test_hooks/test_skill_injection.py
+++ b/tests/test_hooks/test_skill_injection.py
@@ -56,7 +56,7 @@ def test_extract_keywords_limit():
 
     long_prompt = " ".join(f"word{i}" for i in range(50))
     keywords = _extract_keywords(long_prompt)
-    assert len(keywords) <= 10
+    assert len(keywords) <= 12
 
 
 def test_catalog_parse_frontmatter():

--- a/tests/test_knowledge/test_tree_index.py
+++ b/tests/test_knowledge/test_tree_index.py
@@ -181,7 +181,10 @@ async def test_orchestrator_continues_on_tree_index_failure(tmp_path: Path):
         tree_index_threshold=25,
     )
 
-    result = await orch.ingest_source(str(big_pdf), project_type="test")
+    # Mock Path.home() so the path traversal guard passes on CI
+    # (tmp_path is under /tmp/ on CI, not under /home/runner/)
+    with patch("genesis.knowledge.orchestrator.Path.home", return_value=tmp_path.parent):
+        result = await orch.ingest_source(str(big_pdf), project_type="test")
 
     # Should complete without error, with tree_index_failed flag
     assert result.error is None


### PR DESCRIPTION
## Summary

- **Wire outcome verification into Stop hook** — `outcome_verification_hook.py` was built but never registered in settings.json, and had a field name bug (`stop_response` instead of `last_assistant_message`). Merged its logic into the existing `genesis_stop_hook.py` with corrected field name, added `re.IGNORECASE`, and expanded completion patterns. Now nudges the `verification-before-completion` skill when completion language is detected without verification evidence.

- **Improve skill injection hook** — Expanded keyword sets for plan intent (+6), code intent (+8), and exclude (+7) words. Dynamic nudge budget: total process + catalog capped at 2 (previously unlimited process + fixed 1 catalog). Expanded stop words and keyword extraction cap (10 to 12).

- **Add feedback coverage audit script** — Standalone script (`scripts/hooks/audit_feedback_coverage.py`) that compares 94 feedback memories against 35 registered hooks. Reports coverage gaps. Current result: 16% coverage (15/94), revealing the gap between lessons learned and deterministic enforcement.

## Test plan

- [x] Stop hook: completion without evidence fires reminder
- [x] Stop hook: completion WITH evidence suppresses reminder (no output)
- [x] Stop hook: non-completion message produces no output
- [x] Stop hook: lowercase completion phrases now detected (IGNORECASE fix)
- [x] Skill injection: plan intent triggers brainstorming nudge
- [x] Skill injection: exclude keywords suppress process nudges
- [x] Skill injection: execution stays under 500ms (measured: 69ms)
- [x] Audit script: runs against live data, produces valid JSON
- [x] All files pass ruff check