### PR TITLE
feat(ego,autonomy): verified autonomy batch 1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 test = [
     "pytest>=8.0",
     "pytest-asyncio",
-    "aioresponses",
+    "aioresponses>=0.7.7",
 ]
 browser = [
     "playwright>=1.40",

--- a/src/genesis/autonomy/approval.py
+++ b/src/genesis/autonomy/approval.py
@@ -63,7 +63,7 @@ class ApprovalManager:
 
         request_id = str(uuid4())
 
-        await crud.create(
+        await crud.create_chained(
             self._db,
             id=request_id,
             action_type=action_type,

--- a/src/genesis/autonomy/rules.py
+++ b/src/genesis/autonomy/rules.py
@@ -102,13 +102,38 @@ class RuleEngine:
         """Evaluate *ctx* against rules. First full match wins."""
         for rule in self._rules:
             if self._matches(rule, ctx):
-                return RuleResult(
+                result = RuleResult(
                     decision=rule.decision,
                     rule_id=rule.rule_id,
                     timeout_seconds=rule.timeout_seconds,
                     description=rule.description,
                 )
+                self._log_evaluation(ctx, result)
+                return result
+        self._log_evaluation(ctx, _DEFAULT_RESULT)
         return _DEFAULT_RESULT
+
+    def _log_evaluation(self, ctx: RuleContext, result: RuleResult) -> None:
+        """Structured audit log for rule evaluation (Verified Autonomy L5).
+
+        Key=value format in the message body so GenesisFormatter preserves
+        it in the log file. Tier 1 audit trail (log file, grep-searchable).
+        """
+        level = (
+            logging.DEBUG
+            if result.decision == ApprovalDecision.ACT
+            else logging.INFO
+        )
+        logger.log(
+            level,
+            "autonomy.rule_evaluated rule_id=%s decision=%s "
+            "action_class=%s protection_level=%s context=%s",
+            result.rule_id,
+            result.decision.value,
+            ctx.action_class.value if ctx.action_class else "none",
+            ctx.protection_level.value if ctx.protection_level else "none",
+            ctx.context_category or "none",
+        )
 
     def reload(self) -> None:
         """Re-read rules from YAML. Safe to call at runtime.

--- a/src/genesis/db/crud/approval_requests.py
+++ b/src/genesis/db/crud/approval_requests.py
@@ -60,12 +60,13 @@ async def create_chained(
         "action_type": action_type,
         "action_class": action_class,
         "description": description,
+        "context": context or "",
     }))
 
     cursor = await db.execute(
         "SELECT chain_hash FROM approval_requests "
         "WHERE chain_hash IS NOT NULL "
-        "ORDER BY created_at DESC LIMIT 1"
+        "ORDER BY created_at DESC, id DESC LIMIT 1"
     )
     row = await cursor.fetchone()
     prev_chain = row[0] if row else None

--- a/src/genesis/db/crud/approval_requests.py
+++ b/src/genesis/db/crud/approval_requests.py
@@ -16,14 +16,72 @@ async def create(
     status: str = "pending",
     timeout_at: str | None = None,
     created_at: str | None = None,
+    content_hash: str | None = None,
+    previous_hash: str | None = None,
+    chain_hash: str | None = None,
 ) -> str:
     await db.execute(
         """INSERT INTO approval_requests
            (id, action_type, action_class, description, context,
-            status, timeout_at, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')))""",
+            status, timeout_at, created_at,
+            content_hash, previous_hash, chain_hash)
+           VALUES (?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')),
+                   ?, ?, ?)""",
         (id, action_type, action_class, description, context,
-         status, timeout_at, created_at),
+         status, timeout_at, created_at,
+         content_hash, previous_hash, chain_hash),
+    )
+    await db.commit()
+    return id
+
+
+async def create_chained(
+    db: aiosqlite.Connection,
+    *,
+    id: str,
+    action_type: str,
+    action_class: str,
+    description: str,
+    context: str | None = None,
+    status: str = "pending",
+    timeout_at: str | None = None,
+    created_at: str | None = None,
+) -> str:
+    """Insert approval request with hash chain.
+
+    Note: the read-then-insert has a theoretical TOCTOU race if two
+    requests are created in the same asyncio tick. This is low-probability
+    and detectable: two records sharing the same previous_hash indicates
+    a fork (concurrent write), not tampering. verify_chain() catches it.
+    """
+    from genesis.ego.integrity import canonical_json, chained_hash, content_hash
+
+    c_hash = content_hash(canonical_json({
+        "action_type": action_type,
+        "action_class": action_class,
+        "description": description,
+    }))
+
+    cursor = await db.execute(
+        "SELECT chain_hash FROM approval_requests "
+        "WHERE chain_hash IS NOT NULL "
+        "ORDER BY created_at DESC LIMIT 1"
+    )
+    row = await cursor.fetchone()
+    prev_chain = row[0] if row else None
+
+    chain = chained_hash(c_hash, prev_chain)
+
+    await db.execute(
+        """INSERT INTO approval_requests
+           (id, action_type, action_class, description, context,
+            status, timeout_at, created_at,
+            content_hash, previous_hash, chain_hash)
+           VALUES (?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')),
+                   ?, ?, ?)""",
+        (id, action_type, action_class, description, context,
+         status, timeout_at, created_at,
+         c_hash, prev_chain, chain),
     )
     await db.commit()
     return id

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -31,6 +31,8 @@ async def create_cycle(
     output_hash: str | None = None,
     output_size: int | None = None,
     ego_source: str = "",
+    previous_hash: str | None = None,
+    chain_hash: str | None = None,
 ) -> str:
     """Insert a new ego cycle record. Returns the id."""
     if created_at is None:
@@ -40,8 +42,8 @@ async def create_cycle(
            (id, output_text, proposals_json, focus_summary,
             model_used, cost_usd, input_tokens, output_tokens,
             duration_ms, created_at, output_hash, output_size,
-            ego_source)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            ego_source, previous_hash, chain_hash)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             id,
             output_text,
@@ -56,6 +58,78 @@ async def create_cycle(
             output_hash,
             output_size,
             ego_source,
+            previous_hash,
+            chain_hash,
+        ),
+    )
+    await db.commit()
+    return id
+
+
+async def create_cycle_chained(
+    db: aiosqlite.Connection,
+    *,
+    id: str,
+    output_text: str,
+    proposals_json: str = "[]",
+    focus_summary: str = "",
+    model_used: str = "",
+    cost_usd: float = 0.0,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    duration_ms: int = 0,
+    created_at: str | None = None,
+    output_hash: str = "",
+    output_size: int | None = None,
+    ego_source: str = "",
+) -> str:
+    """Insert ego cycle with hash chain.
+
+    Fetches the previous cycle's chain_hash, computes the new chain link,
+    and inserts. Note: the read-then-insert has a theoretical TOCTOU race
+    if two ego sessions (user + genesis) create cycles simultaneously.
+    This is low-probability and detectable: two records sharing the same
+    previous_hash indicates a fork (concurrent write), not tampering.
+    verify_chain() catches it.
+    """
+    from genesis.ego.integrity import chained_hash
+
+    if created_at is None:
+        created_at = datetime.now(UTC).isoformat()
+
+    cursor = await db.execute(
+        "SELECT chain_hash FROM ego_cycles "
+        "WHERE chain_hash IS NOT NULL "
+        "ORDER BY created_at DESC, id DESC LIMIT 1"
+    )
+    row = await cursor.fetchone()
+    prev_chain = row[0] if row else None
+
+    chain = chained_hash(output_hash, prev_chain)
+
+    await db.execute(
+        """INSERT INTO ego_cycles
+           (id, output_text, proposals_json, focus_summary,
+            model_used, cost_usd, input_tokens, output_tokens,
+            duration_ms, created_at, output_hash, output_size,
+            ego_source, previous_hash, chain_hash)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            id,
+            output_text,
+            proposals_json,
+            focus_summary,
+            model_used,
+            cost_usd,
+            input_tokens,
+            output_tokens,
+            duration_ms,
+            created_at,
+            output_hash,
+            output_size,
+            ego_source,
+            prev_chain,
+            chain,
         ),
     )
     await db.commit()

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1356,6 +1356,35 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "user_goals.cadence_days",
     )
 
+    # Verified Autonomy L8: hash chain columns for tamper-evident audit trails.
+    # ego_cycles: chain links ego cycle decisions
+    await _try_alter(
+        db,
+        "ALTER TABLE ego_cycles ADD COLUMN previous_hash TEXT",
+        "ego_cycles.previous_hash",
+    )
+    await _try_alter(
+        db,
+        "ALTER TABLE ego_cycles ADD COLUMN chain_hash TEXT",
+        "ego_cycles.chain_hash",
+    )
+    # approval_requests: chain links approval decisions
+    await _try_alter(
+        db,
+        "ALTER TABLE approval_requests ADD COLUMN content_hash TEXT",
+        "approval_requests.content_hash",
+    )
+    await _try_alter(
+        db,
+        "ALTER TABLE approval_requests ADD COLUMN previous_hash TEXT",
+        "approval_requests.previous_hash",
+    )
+    await _try_alter(
+        db,
+        "ALTER TABLE approval_requests ADD COLUMN chain_hash TEXT",
+        "approval_requests.chain_hash",
+    )
+
 
 async def _migrate_cognitive_state_check(db: aiosqlite.Connection) -> None:
     """Rebuild cognitive_state if CHECK constraint lacks 'resilience_degradation'.

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -564,7 +564,10 @@ TABLES = {
             created_at       TEXT NOT NULL DEFAULT (datetime('now')),
             resolved_at      TEXT,
             resolved_by      TEXT,
-            consumed_at      TEXT
+            consumed_at      TEXT,
+            content_hash     TEXT,                    -- SHA-256 of canonical(action_type,class,desc,ctx)
+            previous_hash    TEXT,                    -- chain link: previous record's chain_hash
+            chain_hash       TEXT                     -- SHA-256(previous_hash:content_hash)
         )
     """,
     "task_states": """
@@ -754,7 +757,9 @@ TABLES = {
             compacted_into  TEXT,                    -- set when folded into compacted summary
             output_hash     TEXT,                    -- SHA-256 of output_text for audit trail
             output_size     INTEGER,                 -- byte count of output_text
-            ego_source      TEXT                     -- 'user_ego_cycle' or 'genesis_ego_cycle'
+            ego_source      TEXT,                    -- 'user_ego_cycle' or 'genesis_ego_cycle'
+            previous_hash   TEXT,                    -- chain link: previous record's chain_hash
+            chain_hash      TEXT                     -- SHA-256(previous_hash:output_hash)
         )
     """,
     "ego_proposals": """

--- a/src/genesis/ego/capability_aggregator.py
+++ b/src/genesis/ego/capability_aggregator.py
@@ -161,19 +161,27 @@ class _DomainAccumulator:
         if not self.signals:
             return None
 
-        # Weighted average: weight by sample size (more data = more influence)
         total_weight = sum(n for _, _, n in self.signals)
         if total_weight == 0:
             return None
 
-        weighted_sum = sum(rate * n for _, rate, n in self.signals)
-        confidence = round(weighted_sum / total_weight, 3)
+        # Inverse confidence weighting (Verified Autonomy L1): surfaces the
+        # weakest signal instead of hiding it behind the average.
+        from genesis.ego.confidence_weighting import inverse_confidence_weight
 
-        # Build evidence summary
+        field_scores = {source: rate for source, rate, _ in self.signals}
+        confidence = round(inverse_confidence_weight(field_scores), 3)
+
+        # Keep arithmetic mean for comparison during rollout
+        arithmetic_mean = round(
+            sum(rate * n for _, rate, n in self.signals) / total_weight, 3
+        )
+
+        # Build evidence summary — includes both scores for calibration
         parts = []
         for source, rate, n in self.signals:
             parts.append(f"{source}:{rate:.0%}({n})")
-        evidence = ", ".join(parts)
+        evidence = ", ".join(parts) + f" | icw={confidence} avg={arithmetic_mean}"
 
         return {
             "domain": self.domain,

--- a/src/genesis/ego/capability_aggregator.py
+++ b/src/genesis/ego/capability_aggregator.py
@@ -170,12 +170,15 @@ class _DomainAccumulator:
         from genesis.ego.confidence_weighting import inverse_confidence_weight
 
         field_scores = {source: rate for source, rate, _ in self.signals}
-        confidence = round(inverse_confidence_weight(field_scores), 3)
-
-        # Keep arithmetic mean for comparison during rollout
+        # Arithmetic mean as fallback if rates are out-of-range (shouldn't
+        # happen, but DB values could be corrupted)
         arithmetic_mean = round(
             sum(rate * n for _, rate, n in self.signals) / total_weight, 3
         )
+        try:
+            confidence = round(inverse_confidence_weight(field_scores), 3)
+        except ValueError:
+            confidence = arithmetic_mean
 
         # Build evidence summary — includes both scores for calibration
         parts = []

--- a/src/genesis/ego/compaction.py
+++ b/src/genesis/ego/compaction.py
@@ -66,12 +66,13 @@ class CompactionEngine:
     async def store_cycle(self, cycle: EgoCycle) -> str:
         """Persist a completed ego cycle to the database.
 
-        Returns the cycle id. Cycles are stored for audit logging,
-        cost tracking, and historical analysis.
+        Returns the cycle id. Uses chained hashing (Verified Autonomy L8)
+        for tamper-evident audit trails. BEGIN IMMEDIATE prevents TOCTOU
+        races between concurrent ego sessions.
         """
         from genesis.ego.integrity import content_hash, content_size
 
-        return await ego_crud.create_cycle(
+        return await ego_crud.create_cycle_chained(
             self._db,
             id=cycle.id,
             output_text=cycle.output_text,

--- a/src/genesis/ego/compaction.py
+++ b/src/genesis/ego/compaction.py
@@ -67,8 +67,8 @@ class CompactionEngine:
         """Persist a completed ego cycle to the database.
 
         Returns the cycle id. Uses chained hashing (Verified Autonomy L8)
-        for tamper-evident audit trails. BEGIN IMMEDIATE prevents TOCTOU
-        races between concurrent ego sessions.
+        for tamper-evident audit trails. Note: the read-then-insert has a
+        theoretical TOCTOU race between concurrent ego sessions (dual ego).
         """
         from genesis.ego.integrity import content_hash, content_size
 

--- a/src/genesis/ego/confidence_weighting.py
+++ b/src/genesis/ego/confidence_weighting.py
@@ -1,0 +1,51 @@
+"""Inverse confidence weighting — surface your weakest signal.
+
+Implements Layer 1 of the Verified Autonomy framework (Newman et al., 2026).
+When aggregating per-field confidence scores, standard averaging masks
+uncertainty in individual fields. Inverse weighting gives disproportionate
+influence to weak signals so the aggregate reflects the weakest point,
+not the average.
+
+Formula: weight = 2.0 - confidence
+  - A field at 0.0 confidence gets weight 2.0 (maximum pull)
+  - A field at 1.0 confidence gets weight 1.0 (minimum pull)
+  - Result is always <= arithmetic mean when values are non-uniform
+  - Result always falls between min and max input values
+
+Reference: doi.org/10.5281/zenodo.19096229, Section 4
+"""
+
+from __future__ import annotations
+
+
+def inverse_confidence_weight(scores: dict[str, float]) -> float:
+    """Aggregate per-field confidence scores with inverse weighting.
+
+    Parameters
+    ----------
+    scores:
+        Mapping of field names to confidence values in [0.0, 1.0].
+
+    Returns
+    -------
+    float:
+        Weighted aggregate in [0.0, 1.0], pulled toward the weakest signal.
+        Returns 0.0 for an empty dict.
+
+    Raises
+    ------
+    ValueError:
+        If any confidence value is outside [0.0, 1.0].
+    """
+    if not scores:
+        return 0.0
+
+    for name, val in scores.items():
+        if not (0.0 <= val <= 1.0):
+            msg = f"confidence for {name!r} outside [0.0, 1.0]: {val}"
+            raise ValueError(msg)
+
+    weights = {k: 2.0 - v for k, v in scores.items()}
+    total_weight = sum(weights.values())
+    weighted_sum = sum(scores[k] * weights[k] for k in scores)
+    return weighted_sum / total_weight

--- a/src/genesis/ego/integrity.py
+++ b/src/genesis/ego/integrity.py
@@ -57,15 +57,24 @@ def verify_chain(records: list[dict]) -> tuple[bool, int]:
     Parameters
     ----------
     records:
-        List of dicts, each with ``content_hash``, ``previous_hash``,
-        and ``chain_hash`` keys. Records with ``chain_hash=None``
-        (pre-migration) are skipped gracefully.
+        List of dicts, each with a content hash field, ``previous_hash``,
+        and ``chain_hash`` keys. The content hash field can be named
+        ``content_hash`` or ``output_hash`` (ego_cycles uses the latter).
+        Records with ``chain_hash=None`` (pre-migration) are skipped.
 
     Returns
     -------
     tuple[bool, int]:
         ``(True, -1)`` if chain is intact.
         ``(False, index)`` at the first broken link.
+
+    Note
+    ----
+    Pre-migration records (chain_hash=None) are skipped implicitly.
+    This means an attacker who replaces a chained record with an unchained
+    one mid-chain would not be detected. This is bounded by the INSERT
+    path: only newly inserted records get chain hashes, and the risk is
+    limited to direct database manipulation.
     """
     prev_chain: str | None = None
     for i, rec in enumerate(records):
@@ -80,8 +89,14 @@ def verify_chain(records: list[dict]) -> tuple[bool, int]:
         if (stored_prev or None) != (prev_chain or None):
             return False, i
 
+        # Accept both column names: ego_cycles uses output_hash,
+        # approval_requests uses content_hash
+        c_hash = rec.get("content_hash") or rec.get("output_hash")
+        if c_hash is None:
+            return False, i
+
         # Recompute and verify the chain_hash
-        recomputed = chained_hash(rec["content_hash"], stored_prev)
+        recomputed = chained_hash(c_hash, stored_prev)
         if stored_chain != recomputed:
             return False, i
 

--- a/src/genesis/ego/integrity.py
+++ b/src/genesis/ego/integrity.py
@@ -1,12 +1,17 @@
 """Content integrity utilities for ego pipeline audit tracking.
 
-Provides lightweight hash and size computation for tracking content
-mutations through the ego cycle → realist gate → proposal pipeline.
+Provides hash and size computation for tracking content mutations
+through the ego cycle → realist gate → proposal pipeline, plus
+hash-chain functions for tamper-evident audit trails (Verified
+Autonomy Layer 8).
+
+Reference: doi.org/10.5281/zenodo.19096229, Section 11
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 
 
 def content_hash(text: str) -> str:
@@ -17,3 +22,69 @@ def content_hash(text: str) -> str:
 def content_size(text: str) -> int:
     """Byte count of UTF-8 encoded text."""
     return len(text.encode())
+
+
+# -- Hash chain functions (Verified Autonomy L8) --
+
+
+def canonical_json(fields: dict) -> str:
+    """Deterministic JSON serialisation for reproducible hashes.
+
+    Sorted keys, no whitespace, ASCII-only. Two dicts with the same
+    key-value pairs always produce the same string regardless of
+    insertion order.
+    """
+    return json.dumps(fields, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def chained_hash(content_hash_val: str, previous_hash: str | None) -> str:
+    """SHA-256 of content hash chained to previous record's chain hash.
+
+    The chain structure: each record's digest includes the previous
+    record's chain_hash. Modifying any record cascades hash invalidation
+    through all subsequent records.
+
+    The genesis sentinel value ``"genesis"`` is used for the first record
+    in the chain (no predecessor).
+    """
+    payload = f"{previous_hash or 'genesis'}:{content_hash_val}"
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def verify_chain(records: list[dict]) -> tuple[bool, int]:
+    """Walk records oldest-first and verify chain integrity.
+
+    Parameters
+    ----------
+    records:
+        List of dicts, each with ``content_hash``, ``previous_hash``,
+        and ``chain_hash`` keys. Records with ``chain_hash=None``
+        (pre-migration) are skipped gracefully.
+
+    Returns
+    -------
+    tuple[bool, int]:
+        ``(True, -1)`` if chain is intact.
+        ``(False, index)`` at the first broken link.
+    """
+    prev_chain: str | None = None
+    for i, rec in enumerate(records):
+        stored_chain = rec.get("chain_hash")
+        if stored_chain is None:
+            # Pre-migration record — skip, don't break the chain
+            continue
+
+        stored_prev = rec.get("previous_hash")
+
+        # Verify the previous_hash link
+        if (stored_prev or None) != (prev_chain or None):
+            return False, i
+
+        # Recompute and verify the chain_hash
+        recomputed = chained_hash(rec["content_hash"], stored_prev)
+        if stored_chain != recomputed:
+            return False, i
+
+        prev_chain = stored_chain
+
+    return True, -1

--- a/tests/test_ego/test_capability_aggregator.py
+++ b/tests/test_ego/test_capability_aggregator.py
@@ -137,9 +137,10 @@ class TestComputeCapabilityMap:
         results = await compute_capability_map(db)
         investigate = next((r for r in results if r["domain"] == "investigate"), None)
         assert investigate is not None
-        # Weighted by sample size: proposals (n=10) dominate over journal (n=1)
-        # So result should be closer to 50% than 100%
-        assert 0.45 <= investigate["confidence"] <= 0.65
+        # Inverse confidence weighting: journal (100%, weight=1.0) and
+        # proposals (50%, weight=1.5). The weaker signal gets more influence,
+        # pulling toward 50%. Result is ~0.7 (sample size not used in ICW).
+        assert 0.65 <= investigate["confidence"] <= 0.75
 
     @pytest.mark.asyncio
     async def test_autonomy_state_contributes(self, db):

--- a/tests/test_ego/test_confidence_weighting.py
+++ b/tests/test_ego/test_confidence_weighting.py
@@ -1,0 +1,77 @@
+"""Tests for inverse confidence weighting (Verified Autonomy Layer 1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.ego.confidence_weighting import inverse_confidence_weight
+
+
+class TestInverseConfidenceWeight:
+    def test_empty_dict_returns_zero(self):
+        assert inverse_confidence_weight({}) == 0.0
+
+    def test_single_field_identity(self):
+        assert inverse_confidence_weight({"a": 0.7}) == pytest.approx(0.7)
+
+    def test_equal_confidence_identity(self):
+        """All fields at same value -> that value (no distortion)."""
+        result = inverse_confidence_weight({"a": 0.5, "b": 0.5, "c": 0.5})
+        assert result == pytest.approx(0.5)
+
+    def test_equal_high_confidence(self):
+        result = inverse_confidence_weight({"a": 0.9, "b": 0.9})
+        assert result == pytest.approx(0.9)
+
+    def test_weak_field_pulls_aggregate_down(self):
+        """One weak field among strong ones pulls the aggregate below mean."""
+        scores = {"a": 0.95, "b": 0.92, "c": 0.88, "d": 0.30}
+        result = inverse_confidence_weight(scores)
+        arithmetic_mean = sum(scores.values()) / len(scores)
+        assert result < arithmetic_mean
+
+    def test_boundary_zero_and_one(self):
+        """Paper's stated boundary case: {0.0, 1.0} -> 0.333."""
+        result = inverse_confidence_weight({"a": 0.0, "b": 1.0})
+        assert result == pytest.approx(1 / 3, abs=0.001)
+
+    def test_result_bounded_between_min_and_max(self):
+        scores = {"a": 0.2, "b": 0.8, "c": 0.5}
+        result = inverse_confidence_weight(scores)
+        assert min(scores.values()) <= result <= max(scores.values())
+
+    def test_result_always_leq_arithmetic_mean(self):
+        """Inverse-weighted aggregate is always <= arithmetic mean for non-uniform values."""
+        scores = {"a": 0.95, "b": 0.30}
+        result = inverse_confidence_weight(scores)
+        mean = sum(scores.values()) / len(scores)
+        assert result <= mean + 1e-9  # tolerance for float
+
+    def test_near_zero_field_dominates(self):
+        """Near-zero field among strong fields drops the aggregate sharply."""
+        scores = {"a": 0.92, "b": 0.95, "c": 0.01}
+        result = inverse_confidence_weight(scores)
+        assert result < 0.5  # well below the 0.62 arithmetic mean
+
+    def test_out_of_range_raises(self):
+        with pytest.raises(ValueError, match="outside"):
+            inverse_confidence_weight({"a": 1.5})
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError, match="outside"):
+            inverse_confidence_weight({"a": -0.1})
+
+    def test_all_zero(self):
+        result = inverse_confidence_weight({"a": 0.0, "b": 0.0})
+        assert result == pytest.approx(0.0)
+
+    def test_all_one(self):
+        result = inverse_confidence_weight({"a": 1.0, "b": 1.0})
+        assert result == pytest.approx(1.0)
+
+    def test_many_fields(self):
+        """Works with many fields."""
+        scores = {f"f{i}": 0.8 for i in range(20)}
+        scores["weak"] = 0.1
+        result = inverse_confidence_weight(scores)
+        assert result < 0.8  # weak field pulls down

--- a/tests/test_ego/test_integrity.py
+++ b/tests/test_ego/test_integrity.py
@@ -7,7 +7,13 @@ preservation, and cycle storage with hash/size.
 from __future__ import annotations
 
 from genesis.db.crud import ego as ego_crud
-from genesis.ego.integrity import content_hash, content_size
+from genesis.ego.integrity import (
+    canonical_json,
+    chained_hash,
+    content_hash,
+    content_size,
+    verify_chain,
+)
 
 # ── Utility ─────────────────────────────────────────────────────────────────
 
@@ -156,3 +162,136 @@ def test_realist_pass_no_original_content():
         prop["content"] = verdict["amended_content"]
 
     assert "_original_content" not in prop
+
+
+# ── Hash chain functions (Verified Autonomy L8) ──────────────────────────────
+
+
+def test_canonical_json_key_order_independent():
+    assert canonical_json({"b": 1, "a": 2}) == canonical_json({"a": 2, "b": 1})
+
+
+def test_canonical_json_deterministic():
+    d = {"action_type": "investigate", "description": "test"}
+    assert canonical_json(d) == canonical_json(d)
+
+
+def test_canonical_json_no_whitespace():
+    result = canonical_json({"a": 1, "b": 2})
+    assert " " not in result
+
+
+def test_chained_hash_deterministic():
+    h1 = chained_hash("abc123", "prev456")
+    h2 = chained_hash("abc123", "prev456")
+    assert h1 == h2
+
+
+def test_chained_hash_genesis_sentinel():
+    """First record in chain uses 'genesis' as sentinel."""
+    h = chained_hash("abc123", None)
+    expected_payload = "genesis:abc123"
+    import hashlib
+    assert h == hashlib.sha256(expected_payload.encode()).hexdigest()
+
+
+def test_chained_hash_different_previous():
+    h1 = chained_hash("content", "prev_a")
+    h2 = chained_hash("content", "prev_b")
+    assert h1 != h2
+
+
+def test_chained_hash_different_content():
+    h1 = chained_hash("content_a", "prev")
+    h2 = chained_hash("content_b", "prev")
+    assert h1 != h2
+
+
+def test_verify_chain_empty():
+    valid, idx = verify_chain([])
+    assert valid is True
+    assert idx == -1
+
+
+def test_verify_chain_single_record():
+    ch = content_hash("hello")
+    chain = chained_hash(ch, None)
+    records = [{"content_hash": ch, "previous_hash": None, "chain_hash": chain}]
+    valid, idx = verify_chain(records)
+    assert valid is True
+    assert idx == -1
+
+
+def test_verify_chain_three_records():
+    records = []
+    prev = None
+    for text in ["first", "second", "third"]:
+        ch = content_hash(text)
+        chain = chained_hash(ch, prev)
+        records.append({
+            "content_hash": ch,
+            "previous_hash": prev,
+            "chain_hash": chain,
+        })
+        prev = chain
+
+    valid, idx = verify_chain(records)
+    assert valid is True
+    assert idx == -1
+
+
+def test_verify_chain_tampered_content():
+    """Modifying content of a record breaks the chain."""
+    records = []
+    prev = None
+    for text in ["first", "second", "third"]:
+        ch = content_hash(text)
+        chain = chained_hash(ch, prev)
+        records.append({
+            "content_hash": ch,
+            "previous_hash": prev,
+            "chain_hash": chain,
+        })
+        prev = chain
+
+    # Tamper with second record's content
+    records[1]["content_hash"] = content_hash("TAMPERED")
+
+    valid, idx = verify_chain(records)
+    assert valid is False
+    assert idx == 1  # chain breaks at the tampered record
+
+
+def test_verify_chain_tampered_previous_hash():
+    """Modifying previous_hash link breaks the chain."""
+    records = []
+    prev = None
+    for text in ["first", "second", "third"]:
+        ch = content_hash(text)
+        chain = chained_hash(ch, prev)
+        records.append({
+            "content_hash": ch,
+            "previous_hash": prev,
+            "chain_hash": chain,
+        })
+        prev = chain
+
+    # Break the link between records 1 and 2
+    records[2]["previous_hash"] = "bogus_hash"
+
+    valid, idx = verify_chain(records)
+    assert valid is False
+    assert idx == 2
+
+
+def test_verify_chain_skips_pre_migration():
+    """Records with chain_hash=None (pre-migration) are skipped."""
+    pre_migration = {"content_hash": "old", "previous_hash": None, "chain_hash": None}
+
+    ch = content_hash("new")
+    chain = chained_hash(ch, None)
+    post_migration = {"content_hash": ch, "previous_hash": None, "chain_hash": chain}
+
+    valid, idx = verify_chain([pre_migration, post_migration])
+    assert valid is True
+    assert idx == -1

--- a/tests/test_observability/conftest.py
+++ b/tests/test_observability/conftest.py
@@ -1,10 +1,55 @@
 """Shared fixtures for observability tests."""
 
+import functools
+from unittest.mock import MagicMock
+
 import pytest
 from aioresponses import aioresponses
+
+import aiohttp
+
+
+def _patch_client_response_init():
+    """Patch ClientResponse.__init__ to accept stream_writer / writer kwargs.
+
+    Older aioresponses (<0.7.7) constructs ClientResponse without the
+    ``stream_writer`` (aiohttp >=3.10) or ``writer`` (aiohttp >=3.12) kwarg
+    that newer aiohttp versions require.  This shim silently absorbs
+    whichever variant the library passes and supplies a MagicMock default
+    when it is missing so the mock response can be created.
+    """
+    original_init = aiohttp.ClientResponse.__init__
+
+    @functools.wraps(original_init)
+    def _patched_init(self, *args, **kwargs):
+        # Ensure whichever kwarg the current aiohttp expects is present.
+        # aiohttp >=3.12 uses "writer"; >=3.10 used "stream_writer".
+        for key in ("writer", "stream_writer"):
+            kwargs.setdefault(key, MagicMock())
+        try:
+            return original_init(self, *args, **kwargs)
+        except TypeError:
+            # If the original __init__ doesn't accept both, strip the one
+            # it doesn't know about and retry.
+            for key in ("writer", "stream_writer"):
+                kwargs.pop(key, None)
+            kwargs.setdefault("writer", MagicMock())
+            try:
+                return original_init(self, *args, **kwargs)
+            except TypeError:
+                kwargs.pop("writer", None)
+                kwargs["stream_writer"] = MagicMock()
+                return original_init(self, *args, **kwargs)
+
+    aiohttp.ClientResponse.__init__ = _patched_init  # type: ignore[method-assign]
+    return original_init
 
 
 @pytest.fixture
 def aiohttp_mock():
-    with aioresponses() as m:
-        yield m
+    original_init = _patch_client_response_init()
+    try:
+        with aioresponses() as m:
+            yield m
+    finally:
+        aiohttp.ClientResponse.__init__ = original_init  # type: ignore[method-assign]

--- a/tests/test_observability/conftest.py
+++ b/tests/test_observability/conftest.py
@@ -3,10 +3,9 @@
 import functools
 from unittest.mock import MagicMock
 
+import aiohttp
 import pytest
 from aioresponses import aioresponses
-
-import aiohttp
 
 
 def _patch_client_response_init():


### PR DESCRIPTION
## Summary

Three quick-win items from a gap analysis against Newman et al.'s *Verified Autonomy* nine-layer framework (DOI: 10.5281/zenodo.19096229):

- **L1 — Inverse confidence weighting** on capability aggregator: replaces arithmetic averaging with `weight = 2.0 - confidence`, surfacing weak signals. Both scores emitted for A/B comparison.
- **L5 — Rule engine audit trail**: structured key=value log on every `RuleEngine.evaluate()`. DEBUG for ACT, INFO for BLOCK/PROPOSE.
- **L8 — Hash chains** on `ego_cycles` and `approval_requests`: each record's SHA-256 chains to previous. `verify_chain()` detects tampered/deleted records. Pre-migration records skipped gracefully.

Full spec: `~/.genesis/output/verified-autonomy-gap-spec.md`

## Test plan

- [x] 14 new tests for inverse confidence weighting (pure function + aggregator integration)
- [x] 22 existing rule engine tests pass unchanged
- [x] 13 new tests for hash chain functions (chain construction, tamper detection, pre-migration compat)
- [x] 12 existing approval tests pass with `create_chained()` wiring
- [x] Realist capability map fix test (`>= 0.4`) still passes
- [x] 100 total tests pass, 0 failures
- [x] ruff clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)