### PR TITLE
feat(eval,ego): verified autonomy batch 2 — ECE metric + quality scorer

### DIFF
--- a/src/genesis/calibration/curves.py
+++ b/src/genesis/calibration/curves.py
@@ -56,4 +56,24 @@ class CalibrationCurveComputer:
             )
         if curves:
             logger.info("Saved %d calibration curves for domain=%s", len(curves), domain)
+
+            # Compute and emit ECE (Verified Autonomy L4)
+            from genesis.calibration.metrics import compute_ece
+
+            ece = compute_ece(curves)
+            total_samples = sum(c["sample_count"] for c in curves)
+            if ece > 0.10:
+                logger.info(
+                    "Calibration: domain=%s ECE=%.4f (above 0.10 threshold, n=%d)",
+                    domain, ece, total_samples,
+                )
+            try:
+                from genesis.eval.j9_hooks import emit_calibration_ece
+
+                await emit_calibration_ece(
+                    self._db, domain=domain, ece=ece, sample_count=total_samples,
+                )
+            except Exception:
+                logger.debug("Failed to emit calibration ECE event", exc_info=True)
+
         return curves

--- a/src/genesis/calibration/metrics.py
+++ b/src/genesis/calibration/metrics.py
@@ -1,0 +1,61 @@
+"""Calibration quality metrics — pure functions, no dependencies.
+
+Computes Expected Calibration Error (ECE) and Maximum Calibration Error
+(MCE) from calibration curve data. These are monitoring metrics that
+quantify how well confidence scores track actual accuracy.
+
+Reference: Guo et al. (2017), "On Calibration of Modern Neural Networks"
+Verified Autonomy Layer 4: doi.org/10.5281/zenodo.19096229, Section 7
+"""
+
+from __future__ import annotations
+
+
+def compute_ece(curves: list[dict]) -> float:
+    """Expected Calibration Error from calibration curve data.
+
+    ECE = Σ (bucket_weight × |actual_success_rate - predicted_confidence|)
+
+    Parameters
+    ----------
+    curves:
+        List of dicts from ``CalibrationCurveComputer.compute()``, each with
+        ``sample_count``, ``actual_success_rate``, ``predicted_confidence``.
+
+    Returns
+    -------
+    float:
+        ECE in [0.0, 1.0]. Lower is better. 0.0 means perfectly calibrated.
+        Returns 0.0 for empty input.
+    """
+    if not curves:
+        return 0.0
+    total = sum(c["sample_count"] for c in curves)
+    if total == 0:
+        return 0.0
+    return round(
+        sum(
+            (c["sample_count"] / total)
+            * abs(c["actual_success_rate"] - c["predicted_confidence"])
+            for c in curves
+        ),
+        4,
+    )
+
+
+def compute_mce(curves: list[dict]) -> float:
+    """Maximum Calibration Error — worst-case bucket miscalibration.
+
+    MCE = max over buckets of |actual_success_rate - predicted_confidence|
+
+    Returns 0.0 for empty input.
+    """
+    if not curves:
+        return 0.0
+    return round(
+        max(
+            abs(c["actual_success_rate"] - c["predicted_confidence"])
+            for c in curves
+        ),
+        4,
+    )

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -224,6 +224,7 @@ async def ego_proposals():
             "execution_plan": p.get("execution_plan"),
             "recurring": bool(p.get("recurring", 0)),
             "ego_source": p.get("ego_source"),
+            "realist_verdict": p.get("realist_verdict"),
         }
         for p in pending
     ])

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -351,6 +351,12 @@ class ProposalWorkflow:
             logger.warning("No proposals found for batch %s", batch_id)
             return None
 
+        # Skip quality-held proposals — stored in DB but not delivered
+        proposals = [p for p in proposals if p.get("realist_verdict") != "quality_hold"]
+        if not proposals:
+            logger.info("All proposals in batch %s quality-held — no digest", batch_id)
+            return None
+
         digest_html = self.format_digest(proposals, batch_id, ego_source=ego_source)
 
         # Prepend validation warnings if any
@@ -363,7 +369,11 @@ class ProposalWorkflow:
             all_pending = await ego_crud.list_pending_proposals(
                 self._db, ego_source=ego_source,
             )
-            other_pending = [p for p in all_pending if p.get("batch_id") != batch_id]
+            other_pending = [
+                p for p in all_pending
+                if p.get("batch_id") != batch_id
+                and p.get("realist_verdict") != "quality_hold"
+            ]
             if other_pending:
                 summary_lines = []
                 for op in other_pending[:5]:

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -958,10 +958,62 @@ class EgoSession:
                     amended_count,
                 )
 
-            return filtered
         except Exception:
             logger.warning("Realist filter failed, passing through", exc_info=True)
+            filtered = proposals  # fail-open: use unfiltered list
+
+        # Quality gate (Verified Autonomy L3) — runs AFTER realist gate.
+        # Placed outside the realist try-except so a quality gate failure
+        # cannot accidentally undo realist rejections. _quality_gate has
+        # its own fail-open error handling.
+        filtered = await self._quality_gate(filtered)
+        return filtered
+
+    async def _quality_gate(self, proposals: list[dict]) -> list[dict]:
+        """Score proposals for coherence/relevance/completeness.
+
+        Proposals below threshold get ``_realist_verdict = "quality_hold"``
+        and stay in the list (stored in DB) but ``send_digest()`` skips them.
+        Fails open: any error passes all proposals through.
+        """
+        if not proposals or not self._router:
             return proposals
+
+        try:
+            from genesis.eval.scorers import get_scorer
+            from genesis.eval.types import ScorerType
+
+            scorer = get_scorer(ScorerType.OUTPUT_QUALITY)
+            scorer.set_router(self._router)
+
+            held_count = 0
+            for p in proposals:
+                try:
+                    passed, score, detail = await scorer.score_async(
+                        actual=(
+                            f"{p.get('content', '')}\n\n"
+                            f"Rationale: {p.get('rationale', '')}"
+                        ),
+                        expected="autonomous proposal",
+                        config={"rubric_name": "output_quality"},
+                    )
+                    if not passed:
+                        p["_realist_verdict"] = "quality_hold"
+                        p["_realist_reasoning"] = (
+                            f"Quality score {score:.2f} below threshold. {detail[:300]}"
+                        )
+                        held_count += 1
+                except Exception:
+                    logger.debug("Quality scoring failed for proposal, passing", exc_info=True)
+
+            if held_count:
+                logger.info(
+                    "Quality gate: held %d/%d proposals", held_count, len(proposals),
+                )
+        except Exception:
+            logger.warning("Quality gate failed, passing all proposals", exc_info=True)
+
+        return proposals
 
     # Genesis ego allowed action categories (infrastructure/operations only)
     _GENESIS_EGO_ALLOWED_CATEGORIES = frozenset({

--- a/src/genesis/eval/j9_hooks.py
+++ b/src/genesis/eval/j9_hooks.py
@@ -239,3 +239,27 @@ async def emit_recall_used(
         )
     except Exception:
         logger.debug("eval: failed to emit recall_used", exc_info=True)
+
+
+async def emit_calibration_ece(
+    db: aiosqlite.Connection,
+    *,
+    domain: str,
+    ece: float,
+    sample_count: int,
+) -> str | None:
+    """Emit calibration ECE metric (Verified Autonomy L4)."""
+    try:
+        return await j9_eval.insert_event(
+            db,
+            dimension="system",
+            event_type="calibration_ece",
+            metrics={
+                "domain": domain,
+                "ece": ece,
+                "sample_count": sample_count,
+            },
+        )
+    except Exception:
+        logger.debug("eval: failed to emit calibration_ece", exc_info=True)
+        return None

--- a/src/genesis/eval/rubrics/__init__.py
+++ b/src/genesis/eval/rubrics/__init__.py
@@ -90,4 +90,8 @@ def list_rubrics() -> list[Rubric]:
 
 # Auto-import first-party rubrics so they self-register.
 # New rubrics are added here.
-from genesis.eval.rubrics import memory_recall_grounding, reflection_quality  # noqa: E402,F401
+from genesis.eval.rubrics import (  # noqa: E402,F401
+    memory_recall_grounding,
+    output_quality,
+    reflection_quality,
+)

--- a/src/genesis/eval/rubrics/output_quality.py
+++ b/src/genesis/eval/rubrics/output_quality.py
@@ -1,0 +1,54 @@
+"""Output quality rubric for autonomous outputs (Verified Autonomy L3).
+
+Grades ego proposals and task deliverables on three dimensions:
+coherence (internal consistency), relevance (addresses the intent),
+and completeness (covers necessary points). Outputs flagged below
+threshold are held for human review instead of auto-executing.
+
+Reference: doi.org/10.5281/zenodo.19096229, Section 6
+"""
+
+from __future__ import annotations
+
+from genesis.eval.rubrics import Rubric, register_rubric
+
+_PROMPT = """Score this AI-generated output on three quality dimensions.
+
+OUTPUT:
+{actual}
+
+CONTEXT (what this output is meant to address):
+{expected}
+
+Score each dimension from 0.0 to 1.0:
+
+1. **coherence** (weight 40%): Is the output internally consistent? Does it
+   contradict itself? Are the claims logically connected? Does it make sense
+   as a whole? Score 0.0 for self-contradictory, 1.0 for fully coherent.
+
+2. **relevance** (weight 40%): Does the output address what was intended?
+   Is it on-topic or does it drift into unrelated territory? Score 0.0 for
+   completely off-topic, 1.0 for directly relevant.
+
+3. **completeness** (weight 20%): Does the output cover the necessary points?
+   Are there obvious gaps or missing considerations? Score 0.0 for severely
+   incomplete, 1.0 for thorough.
+
+Compute the final score as: 0.4 * coherence + 0.4 * relevance + 0.2 * completeness
+
+Return ONLY a JSON object:
+{{"coherence": <float>, "relevance": <float>, "completeness": <float>, "score": <float>, "rationale": "<brief explanation>"}}
+"""
+
+OUTPUT_QUALITY = Rubric(
+    name="output_quality",
+    version="1.0.0",
+    description=(
+        "Grades autonomous output on coherence (40%), relevance (40%), "
+        "and completeness (20%). Outputs below threshold are held for review."
+    ),
+    prompt_template=_PROMPT,
+    pass_threshold=0.6,
+)
+
+register_rubric(OUTPUT_QUALITY)

--- a/src/genesis/eval/scorers.py
+++ b/src/genesis/eval/scorers.py
@@ -403,6 +403,27 @@ class LLMJudgeScorer(Scorer):
         return passed, score_val, detail
 
 
+class OutputQualityScorer(LLMJudgeScorer):
+    """Quality scorer for autonomous outputs (Verified Autonomy L3).
+
+    Grades coherence, relevance, and completeness via the output_quality
+    rubric. Inherits all async/router/judge infrastructure from
+    LLMJudgeScorer — the only difference is the default rubric name.
+
+    Usage::
+
+        scorer = get_scorer(ScorerType.OUTPUT_QUALITY)
+        scorer.set_router(router)
+        passed, score, detail = await scorer.score_async(
+            actual="proposal content...",
+            expected="autonomous proposal",
+            config={"rubric_name": "output_quality"},
+        )
+    """
+
+    scorer_type = ScorerType.OUTPUT_QUALITY
+
+
 # -- Helpers --
 
 def _extract_json(text: str) -> str:

--- a/src/genesis/eval/types.py
+++ b/src/genesis/eval/types.py
@@ -13,6 +13,7 @@ class ScorerType(StrEnum):
     JSON_VALIDITY = "json_validity"
     SLOP_DETECTION = "slop_detection"
     LLM_JUDGE = "llm_judge"
+    OUTPUT_QUALITY = "output_quality"
 
 
 class EvalTrigger(StrEnum):

--- a/tests/test_calibration/test_metrics.py
+++ b/tests/test_calibration/test_metrics.py
@@ -1,0 +1,75 @@
+"""Tests for calibration quality metrics (Verified Autonomy L4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.calibration.metrics import compute_ece, compute_mce
+
+
+class TestComputeECE:
+    def test_empty_returns_zero(self):
+        assert compute_ece([]) == 0.0
+
+    def test_zero_samples_returns_zero(self):
+        curves = [{"sample_count": 0, "actual_success_rate": 0.5, "predicted_confidence": 0.7}]
+        assert compute_ece(curves) == 0.0
+
+    def test_perfectly_calibrated(self):
+        """When actual == predicted for all buckets, ECE is 0."""
+        curves = [
+            {"sample_count": 50, "actual_success_rate": 0.3, "predicted_confidence": 0.3},
+            {"sample_count": 50, "actual_success_rate": 0.7, "predicted_confidence": 0.7},
+            {"sample_count": 50, "actual_success_rate": 0.9, "predicted_confidence": 0.9},
+        ]
+        assert compute_ece(curves) == 0.0
+
+    def test_uniform_miscalibration(self):
+        """Every bucket off by 0.1 -> ECE = 0.1."""
+        curves = [
+            {"sample_count": 100, "actual_success_rate": 0.6, "predicted_confidence": 0.7},
+            {"sample_count": 100, "actual_success_rate": 0.8, "predicted_confidence": 0.9},
+        ]
+        assert compute_ece(curves) == pytest.approx(0.1, abs=0.001)
+
+    def test_weighted_by_sample_count(self):
+        """Larger buckets contribute more to ECE."""
+        curves = [
+            {"sample_count": 10, "actual_success_rate": 0.0, "predicted_confidence": 1.0},  # gap=1.0
+            {"sample_count": 90, "actual_success_rate": 0.5, "predicted_confidence": 0.5},  # gap=0.0
+        ]
+        # ECE = (10/100)*1.0 + (90/100)*0.0 = 0.1
+        assert compute_ece(curves) == pytest.approx(0.1, abs=0.001)
+
+    def test_single_bucket(self):
+        curves = [{"sample_count": 42, "actual_success_rate": 0.65, "predicted_confidence": 0.75}]
+        assert compute_ece(curves) == pytest.approx(0.1, abs=0.001)
+
+    def test_severe_miscalibration(self):
+        """ResNet-110 CIFAR-100 style: ECE around 12.75%."""
+        # Simulated: model reports high confidence but accuracy is moderate
+        curves = [
+            {"sample_count": 200, "actual_success_rate": 0.72, "predicted_confidence": 0.85},
+            {"sample_count": 300, "actual_success_rate": 0.60, "predicted_confidence": 0.75},
+            {"sample_count": 500, "actual_success_rate": 0.88, "predicted_confidence": 0.95},
+        ]
+        ece = compute_ece(curves)
+        assert 0.05 < ece < 0.20  # moderate miscalibration range
+
+
+class TestComputeMCE:
+    def test_empty_returns_zero(self):
+        assert compute_mce([]) == 0.0
+
+    def test_perfectly_calibrated(self):
+        curves = [
+            {"sample_count": 50, "actual_success_rate": 0.5, "predicted_confidence": 0.5},
+        ]
+        assert compute_mce(curves) == 0.0
+
+    def test_worst_bucket_dominates(self):
+        curves = [
+            {"sample_count": 100, "actual_success_rate": 0.5, "predicted_confidence": 0.5},  # gap=0
+            {"sample_count": 10, "actual_success_rate": 0.2, "predicted_confidence": 0.8},   # gap=0.6
+        ]
+        assert compute_mce(curves) == pytest.approx(0.6, abs=0.001)

--- a/tests/test_eval/test_output_quality.py
+++ b/tests/test_eval/test_output_quality.py
@@ -1,0 +1,145 @@
+"""Tests for the output quality scorer and rubric (Verified Autonomy L3)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.eval.rubrics import get_rubric
+from genesis.eval.scorers import get_scorer
+from genesis.eval.types import ScorerType
+
+
+class TestOutputQualityRubricRegistered:
+    def test_rubric_exists(self):
+        rubric = get_rubric("output_quality")
+        assert rubric.name == "output_quality"
+        assert rubric.version == "1.0.0"
+        assert rubric.pass_threshold == 0.6
+
+    def test_rubric_prompt_has_placeholders(self):
+        rubric = get_rubric("output_quality")
+        assert "{actual}" in rubric.prompt_template
+        assert "{expected}" in rubric.prompt_template
+
+
+class TestOutputQualityScorerType:
+    def test_enum_value_exists(self):
+        assert ScorerType.OUTPUT_QUALITY == "output_quality"
+
+    def test_scorer_registered(self):
+        scorer = get_scorer(ScorerType.OUTPUT_QUALITY)
+        assert scorer is not None
+        assert scorer.scorer_type == ScorerType.OUTPUT_QUALITY
+
+
+class TestOutputQualityScorerAsync:
+    @pytest.mark.asyncio
+    async def test_high_quality_passes(self):
+        """Coherent, relevant, complete output scores above threshold."""
+        scorer = get_scorer(ScorerType.OUTPUT_QUALITY)
+
+        mock_router = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.content = json.dumps({
+            "coherence": 0.9,
+            "relevance": 0.85,
+            "completeness": 0.8,
+            "score": 0.87,
+            "rationale": "Well-structured proposal with clear reasoning",
+        })
+        mock_result.model_id = "test-model"
+        mock_result.provider_used = "test"
+        mock_result.error = None
+        mock_router.route_call.return_value = mock_result
+        scorer.set_router(mock_router)
+
+        passed, score, detail = await scorer.score_async(
+            actual="Investigate memory drift by querying Qdrant for stale vectors",
+            expected="autonomous proposal",
+            config={"rubric_name": "output_quality"},
+        )
+
+        assert passed is True
+        assert score >= 0.6
+
+    @pytest.mark.asyncio
+    async def test_low_quality_fails(self):
+        """Incoherent output scores below threshold."""
+        scorer = get_scorer(ScorerType.OUTPUT_QUALITY)
+
+        mock_router = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.content = json.dumps({
+            "coherence": 0.2,
+            "relevance": 0.3,
+            "completeness": 0.1,
+            "score": 0.24,
+            "rationale": "Self-contradictory, off-topic, incomplete",
+        })
+        mock_result.model_id = "test-model"
+        mock_result.provider_used = "test"
+        mock_result.error = None
+        mock_router.route_call.return_value = mock_result
+        scorer.set_router(mock_router)
+
+        passed, score, detail = await scorer.score_async(
+            actual="something something the thing about the stuff",
+            expected="autonomous proposal",
+            config={"rubric_name": "output_quality"},
+        )
+
+        assert passed is False
+        assert score < 0.6
+
+    @pytest.mark.asyncio
+    async def test_router_failure_returns_false(self):
+        """Router call failure returns failed with zero score."""
+        scorer = get_scorer(ScorerType.OUTPUT_QUALITY)
+
+        mock_router = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.error = "timeout"
+        mock_result.content = None
+        mock_result.model_id = None
+        mock_result.provider_used = None
+        mock_router.route_call.return_value = mock_result
+        scorer.set_router(mock_router)
+
+        passed, score, detail = await scorer.score_async(
+            actual="test",
+            expected="test",
+            config={"rubric_name": "output_quality"},
+        )
+
+        assert passed is False
+        assert score == 0.0
+
+
+class TestQualityGateIntegration:
+    """Test the quality_hold filtering in send_digest."""
+
+    def test_quality_hold_filtered_from_digest(self):
+        """Proposals with realist_verdict=quality_hold are excluded."""
+        proposals = [
+            {"id": "1", "content": "good", "realist_verdict": "pass"},
+            {"id": "2", "content": "held", "realist_verdict": "quality_hold"},
+            {"id": "3", "content": "also good", "realist_verdict": None},
+        ]
+        filtered = [p for p in proposals if p.get("realist_verdict") != "quality_hold"]
+        assert len(filtered) == 2
+        assert all(p["id"] != "2" for p in filtered)
+
+    def test_all_held_returns_empty(self):
+        """If all proposals are quality_hold, filtered list is empty."""
+        proposals = [
+            {"id": "1", "realist_verdict": "quality_hold"},
+            {"id": "2", "realist_verdict": "quality_hold"},
+        ]
+        filtered = [p for p in proposals if p.get("realist_verdict") != "quality_hold"]
+        assert filtered == []


### PR DESCRIPTION
## Summary

Two items from the Verified Autonomy gap analysis (batch 2):

- **L4 — ECE metric**: `compute_ece()` in `calibration/metrics.py`. Emitted as J-9 eval event after calibration cycles. Currently no-op in production (0 matched predictions), but infrastructure ready.
- **L3 — Quality scorer**: `output_quality` rubric + `OutputQualityScorer` integrated into ego proposal pipeline. Proposals below coherence/relevance/completeness threshold get `realist_verdict="quality_hold"` — stored in DB but not delivered to Telegram. Dashboard API includes `realist_verdict`.

Code review findings addressed:
- Quality gate placed outside realist try-except (prevents accidental realist rollback)
- Backlog display filters quality_hold proposals (prevents spurious "approve all pending")
- Dead guard removed from quality gate

## Test plan

- [x] 10 ECE metric tests (perfect calibration, miscalibration, weighted, edge cases)
- [x] 9 quality scorer tests (rubric registration, scorer type, async scoring, quality_hold filtering)
- [x] 675 existing tests pass across all affected modules
- [x] E2E integration tests (ECE computation, rubric registration, scorer wiring, filtering)
- [x] ruff clean on all changed files
- [x] Code review with 3 findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)