### PR TITLE
fix(voice): enable S2S audio output + fix response handling

### DIFF
--- a/src/genesis/channels/voice/s2s_session.py
+++ b/src/genesis/channels/voice/s2s_session.py
@@ -134,11 +134,16 @@ class S2SSessionManager:
         session.connection = conn
         session._conn_mgr = conn_mgr
 
-        # Configure session with tools and system prompt
+        # Configure session with tools, system prompt, and audio output
         system_prompt = self._bridge.get_system_prompt()
+        voice = voice_config.s2s_voice()
         await conn.session.update(session={
-            "type": "realtime",
+            "modalities": ["text", "audio"],
             "instructions": system_prompt,
+            "voice": voice,
+            "input_audio_format": "pcm16",
+            "output_audio_format": "pcm16",
+            "input_audio_transcription": {"model": "gpt-4o-mini-transcribe"},
             "tools": TOOL_DECLARATIONS,
         })
 
@@ -157,13 +162,20 @@ class S2SSessionManager:
             logger.error("S2S session config timed out (10s)")
             raise RuntimeError("S2S session config timed out") from None
 
-    async def send_audio(self, session: S2SSession, audio: bytes) -> None:
+    async def send_audio(
+        self, session: S2SSession, audio: bytes, *, input_rate: int = 16000,
+    ) -> None:
         """Send a PCM audio chunk to the S2S model.
 
-        Audio format: 16-bit PCM, 16kHz, mono (matches Wyoming input).
+        Resamples from input_rate (default 16kHz, Wyoming) to 24kHz (Realtime API).
         """
         if not session.connection or session._closed:
             return
+
+        # GPT-Realtime expects 24kHz 16-bit mono PCM
+        if input_rate != 24000:
+            from genesis.channels.voice.wyoming_tts import _resample_pcm
+            audio = _resample_pcm(audio, input_rate, 24000)
 
         encoded = base64.b64encode(audio).decode()
         await session.connection.input_audio_buffer.append(audio=encoded)
@@ -182,12 +194,21 @@ class S2SSessionManager:
 
         Handles function calls internally: when the model calls a tool,
         this method dispatches it via GenesisBridge and sends the result
-        back, then continues yielding audio/transcript events.
+        back, then continues yielding audio/transcript events from the
+        follow-up response.
+
+        GPT-Realtime event sequence for tool calls:
+          Response 1: function_call_arguments.done → response.done (no audio)
+          Response 2: audio.delta (N chunks) → audio_transcript.delta → response.done
+        We must NOT break on Response 1's response.done — the audio comes in Response 2.
         """
         if not session.connection or session._closed:
             return
 
         conn = session.connection
+        # Track whether we dispatched a tool call and are awaiting the audio response
+        awaiting_tool_response = False
+
         async for event in conn:
             etype = event.type
 
@@ -205,13 +226,14 @@ class S2SSessionManager:
                     event.name, event.arguments,
                 )
 
-                # Send result back to the model
+                # Send result back to the model and request a new response
                 await conn.conversation.item.create(item={
                     "type": "function_call_output",
                     "call_id": event.call_id,
                     "output": result,
                 })
                 await conn.response.create()
+                awaiting_tool_response = True
 
             # Audio data
             elif etype == "response.audio.delta":
@@ -237,8 +259,14 @@ class S2SSessionManager:
                 if hasattr(event, "transcript"):
                     session.input_transcript += event.transcript
 
-            # Response complete — add turn separator for transcript accumulation
+            # Response complete
             elif etype == "response.done":
+                if awaiting_tool_response:
+                    # This response.done is for the function-call response.
+                    # The audio response hasn't started yet — keep listening.
+                    logger.debug("Tool-call response done, awaiting audio response")
+                    awaiting_tool_response = False
+                    continue
                 session.turn_count += 1
                 session.last_activity = datetime.now(UTC)
                 session.output_transcript += "\n"  # Turn boundary

--- a/src/genesis/channels/voice/wyoming_stt.py
+++ b/src/genesis/channels/voice/wyoming_stt.py
@@ -121,6 +121,10 @@ class STTEventHandler(AsyncEventHandler):
 
         return True
 
+    # GPT-Realtime requires >= 100ms of audio. At 16kHz 16-bit mono,
+    # 100ms = 3200 bytes. Use 150ms (4800 bytes) as safety margin.
+    _MIN_AUDIO_BYTES = 4800
+
     async def _handle_s2s(self, audio: bytes) -> str:
         """Forward audio to S2S model, play response via TTS server.
 
@@ -128,6 +132,15 @@ class STTEventHandler(AsyncEventHandler):
         response should never take >60s including tool calls. If it does,
         the connection is dead and we fall back to Groq Whisper.
         """
+        # Reject clips too short for the Realtime API (< 150ms)
+        if len(audio) < self._MIN_AUDIO_BYTES:
+            duration_ms = len(audio) / (self._rate * self._width) * 1000
+            logger.warning(
+                "Audio too short for S2S (%.0fms < 150ms), falling back",
+                duration_ms,
+            )
+            return await self._handle_fallback(audio)
+
         # Derive satellite ID from peer address — supports multiple satellites
         satellite_id = "ha-voice-default"
         if hasattr(self, "client_id") and self.client_id:
@@ -138,11 +151,14 @@ class STTEventHandler(AsyncEventHandler):
             if session.connection is None:
                 await self._s2s_manager.connect(session)
 
-            # Send audio to model
-            await self._s2s_manager.send_audio(session, audio)
+            # Send audio to model (resampled 16kHz → 24kHz internally)
+            await self._s2s_manager.send_audio(session, audio, input_rate=self._rate)
             await self._s2s_manager.commit_audio(session)
 
-            # Collect response
+            # Collect full response — audio AND transcript — before returning.
+            # HA's pipeline is sequential: STT → conversation agent → TTS.
+            # The audio MUST be queued on the TTS server BEFORE we return
+            # the transcript, otherwise HA fires TTS with an empty queue.
             response_audio = bytearray()
             transcript = ""
 
@@ -163,9 +179,16 @@ class STTEventHandler(AsyncEventHandler):
                     logger.error("S2S response error: %s", event.text)
                     return await self._handle_fallback(audio)
 
-            # Queue response audio for TTS server to deliver
+            # Queue response audio for TTS server BEFORE returning transcript
             if response_audio and self._tts_server:
                 self._tts_server.queue_audio(bytes(response_audio))
+                logger.info(
+                    "S2S audio queued: %d bytes (%.1fs at 24kHz)",
+                    len(response_audio),
+                    len(response_audio) / (24000 * 2),
+                )
+            elif not response_audio:
+                logger.warning("S2S response had no audio data")
 
             return transcript or "(no transcription)"
 


### PR DESCRIPTION
## Summary

First E2E test of the S2S voice pipeline (PR #524) revealed GPT-Realtime was returning text-only responses — no audio reaching the speaker. Three root causes identified and fixed:

- **Missing `modalities: ["text", "audio"]`** in session config — GPT-Realtime defaulted to text-only output. Added modalities, voice ("alloy"), and explicit audio format (pcm16)
- **`receive_response()` broke on first `response.done` after function calls** — the function-call response completes before the audio response starts. Added `awaiting_tool_response` flag to continue listening through the follow-up audio response
- **"Buffer too small" crash on short audio clips** — HA sometimes sends <100ms audio on rapid wake word retrigger. Added 150ms minimum guard with graceful fallback to Groq Whisper
- **Input audio sample rate mismatch** — Wyoming sends 16kHz, Realtime API expects 24kHz. Added resampling via existing `_resample_pcm()` utility

## Test plan

- [x] `pytest tests/test_channels/test_voice_s2s.py -v` — 19/19 pass
- [x] `ruff check` — clean
- [ ] Server restart + live E2E test: "okay nabu" → GPT-Realtime → audio plays on speaker
- [ ] Function call path: "what did we work on today?" → ask_genesis tool call → audio response
- [ ] Short audio rejection: rapid double wake word → falls back to Whisper instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)