### PR TITLE
feat(ego): information separation + domain-aware realist + philosophy doc

### DIFF
--- a/config/ego.yaml
+++ b/config/ego.yaml
@@ -23,6 +23,7 @@ morning_report_effort: low   # effort for morning reports
 
 # Proposals
 board_size: 3                # max active proposals on the bulletin board
+max_pending_proposals: 15    # auto-table oldest unranked when exceeded
 batch_digest: true           # send proposals as batch (vs individual)
 
 # Morning report

--- a/docs/ego-philosophy.md
+++ b/docs/ego-philosophy.md
@@ -1,0 +1,128 @@
+# Genesis Ego Philosophy
+
+**Status:** Active | **Last updated:** 2026-06-02
+
+The ego is Genesis's executive function — the part that decides what to
+DO. This document defines the dual-ego architecture, domain boundaries,
+and coordination protocol.
+
+---
+
+## Two Perspectives, One System
+
+The user ego and genesis ego are two lenses on the same system, not two
+independent minds. They exist because a single ego conflated user-domain
+and infrastructure-domain thinking — it would see infrastructure alerts
+alongside career goals and produce muddled proposals that served neither
+domain well. Separation forces specialization.
+
+- **User Ego (CEO)**: Sees the user's world — goals, events, contacts,
+  conversations. Creates value for the user. Channels Cooperation
+  (deliver results, anticipate needs) and Curiosity (connect dots across
+  the user's world).
+
+- **Genesis Ego (COO)**: Sees the system's world — health, performance,
+  costs, infrastructure observations. Keeps Genesis running. Channels
+  Preservation (protect what works) and Competence (improve processes).
+
+Both are the LIDA SELECT step for their domain: they evaluate options,
+resolve conflicts, and make coherent decisions within their jurisdiction.
+
+---
+
+## Information Separation as Architecture
+
+Each ego sees only its domain's data: its own proposals, its own
+observations, its own outcomes. This is enforced at the **context builder
+level** — the data layer — not by prompts or post-hoc filters. Prompts
+reinforce what code already enforces.
+
+If an ego generates a cross-domain proposal, that means something leaked
+in its context, and the leak should be fixed at the source.
+
+**Enforcement layers (in priority order):**
+
+1. **Context builders** — what each ego sees. Primary enforcement.
+2. **Code filters** — domain boundary checks on proposals. Safety net.
+3. **Realist prompt rules** — LLM-level domain judgment. Defense-in-depth.
+
+---
+
+## Investigation Is Free, Proposals Are Gated
+
+Both egos have full tool access (Bash, Read, MCP tools,
+`skip_permissions=True`). They investigate during their cycle using MCP
+tools. Proposals are a **write permission gate** — only for actions that
+change state and need user approval.
+
+A proposal to "investigate X" is the ego failing to use its own tools —
+unless the investigation requires dedicated session time beyond what the
+ego cycle allows (e.g., a 30-minute deep dive that would block the
+cycle), in which case it is a dispatch proposal.
+
+---
+
+## Domain-Aware Realist
+
+The realist gate serves different purposes for each ego:
+
+**User Ego**: Full quality control — catch vague proposals, zombie
+re-proposals, infeasible ideas, read-ops disguised as proposals, and
+cross-domain leaks into infrastructure.
+
+**Genesis Ego**: Focused quality control — catch zombie re-proposals and
+infeasible proposals. No "read operation" filtering — the genesis ego's
+investigate-and-dispatch pattern is a legitimate proposal type for work
+that exceeds in-cycle capacity.
+
+---
+
+## Cross-Ego Communication
+
+The coordination interface is narrow and typed:
+
+- **Genesis ego → User ego**: Escalations, delivered as observations
+  (`type='escalation_to_user_ego'`). This is the ONLY path for
+  infrastructure data to reach the user ego.
+
+- **Cross-domain redirect**: If an ego generates a proposal outside its
+  domain (information leak), the proposal is redirected as an observation
+  for the correct ego. The proposal is not stored.
+
+Neither ego sees the other's proposals, history, or outcomes. They
+coordinate through the observation interface, not by watching each
+other work. When they see each other's work, they blend into one
+generalist and neither does their specific job well.
+
+---
+
+## Scope
+
+| Domain | User Ego (CEO) | Genesis Ego (COO) |
+|--------|---------------|-------------------|
+| Career, content, goals | Primary | Never |
+| Outreach to user | Primary | Via escalation only |
+| System health, performance | Never (sees escalations) | Primary |
+| Cost tracking, maintenance | Never | Primary |
+| Morning report | Primary | Never |
+
+---
+
+## Design Notes
+
+**Why not one ego with two modes?** Two CC sessions force domain purity
+at the architectural level. One session with mode switching relies on the
+LLM to stay in its lane — and LLMs conflate domains when they see
+cross-domain context. Keep the separation mechanical until better
+attention control exists.
+
+**Future: notifications.** Not everything the ego thinks is worth sharing
+requires user approval. "Dream cycle needs fixing before June 7" is a
+notification; "Dispatch a session to fix the dream cycle" is a proposal.
+The notifications output mode (autonomous via outreach pipeline, with
+rate limiting and dedup) is planned as a follow-up to this architecture.
+
+**Future: unified workspace.** The V4 workspace controller concept — one
+evaluation point with domain-aware routing — may eventually replace the
+dual-ego split. The information separation and domain boundary patterns
+established here are the foundation for that evolution.

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -702,7 +702,43 @@ async def auto_table_stale_proposals(
     )
     await db.commit()
     logger.info("Auto-tabled %d stale proposal(s) (>%dd)", len(ids), max_age_days)
-    return len(ids)
+
+    # Shorter threshold for unranked proposals — proposals that were never
+    # put on the board are lower-priority and should be cleaned up faster.
+    unranked_days = min(max_age_days, 5)
+    unranked_threshold = f"-{unranked_days} days"
+    cursor2 = await db.execute(
+        "SELECT id FROM ego_proposals "
+        "WHERE status = 'pending' AND rank IS NULL "
+        "AND created_at < datetime('now', ?)",
+        (unranked_threshold,),
+    )
+    unranked_rows = await cursor2.fetchall()
+    unranked_count = 0
+    if unranked_rows:
+        unranked_ids = [r[0] for r in unranked_rows]
+        await db.execute(
+            "UPDATE ego_proposals SET status = 'tabled', rank = NULL, "
+            "resolved_at = ? "
+            "WHERE status = 'pending' AND rank IS NULL "
+            "AND created_at < datetime('now', ?)",
+            (now, unranked_threshold),
+        )
+        placeholders2 = ",".join("?" * len(unranked_ids))
+        await db.execute(
+            f"UPDATE intervention_journal SET outcome_status = 'tabled', "
+            f"resolved_at = ? WHERE proposal_id IN ({placeholders2}) "
+            f"AND outcome_status = 'pending'",
+            (now, *unranked_ids),
+        )
+        await db.commit()
+        unranked_count = len(unranked_ids)
+        logger.info(
+            "Auto-tabled %d unranked proposal(s) (>%dd)",
+            unranked_count, unranked_days,
+        )
+
+    return len(ids) + unranked_count
 
 
 async def get_board(

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -473,18 +473,27 @@ async def list_proposals(
     *,
     status: str | None = None,
     limit: int = 50,
+    ego_source: str | None = None,
 ) -> list[dict]:
-    """All proposals, optionally filtered by status, newest first."""
+    """All proposals, optionally filtered by status and/or ego_source, newest first.
+
+    If ``ego_source`` is provided, only returns proposals from that ego.
+    NULL ego_source proposals (pre-migration) match any filter.
+    """
+    clauses: list[str] = []
+    params: list[str | int] = []
     if status:
-        cursor = await db.execute(
-            "SELECT * FROM ego_proposals WHERE status = ? ORDER BY created_at DESC LIMIT ?",
-            (status, limit),
-        )
-    else:
-        cursor = await db.execute(
-            "SELECT * FROM ego_proposals ORDER BY created_at DESC LIMIT ?",
-            (limit,),
-        )
+        clauses.append("status = ?")
+        params.append(status)
+    if ego_source:
+        clauses.append("(ego_source = ? OR ego_source IS NULL)")
+        params.append(ego_source)
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    params.append(limit)
+    cursor = await db.execute(
+        f"SELECT * FROM ego_proposals{where} ORDER BY created_at DESC LIMIT ?",
+        tuple(params),
+    )
     return [dict(r) for r in await cursor.fetchall()]
 
 
@@ -715,11 +724,27 @@ async def get_board(
     return [dict(r) for r in await cursor.fetchall()]
 
 
-async def get_tabled(db: aiosqlite.Connection) -> list[dict]:
-    """All tabled proposals, newest first."""
-    cursor = await db.execute(
-        "SELECT * FROM ego_proposals WHERE status = 'tabled' ORDER BY resolved_at DESC",
-    )
+async def get_tabled(
+    db: aiosqlite.Connection,
+    *,
+    ego_source: str | None = None,
+) -> list[dict]:
+    """All tabled proposals, newest first.
+
+    If ``ego_source`` is provided, only returns proposals from that ego.
+    NULL ego_source proposals (pre-migration) match any filter.
+    """
+    if ego_source:
+        cursor = await db.execute(
+            "SELECT * FROM ego_proposals "
+            "WHERE status = 'tabled' AND (ego_source = ? OR ego_source IS NULL) "
+            "ORDER BY resolved_at DESC",
+            (ego_source,),
+        )
+    else:
+        cursor = await db.execute(
+            "SELECT * FROM ego_proposals WHERE status = 'tabled' ORDER BY resolved_at DESC",
+        )
     return [dict(r) for r in await cursor.fetchall()]
 
 

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -417,13 +417,14 @@ class GenesisEgoContextBuilder:
         )
 
         try:
-            # Section 1: Active proposals
+            # Section 1: Active proposals (genesis ego only)
             cursor = await self._db.execute(
                 "SELECT action_type, content, status, "
                 "user_response, created_at "
                 "FROM ego_proposals "
                 "WHERE created_at >= datetime('now', '-7 days') "
                 "AND status IN ('pending', 'approved', 'executed') "
+                "AND (ego_source = 'genesis_ego_cycle' OR ego_source IS NULL) "
                 "ORDER BY created_at DESC "
                 "LIMIT 15"
             )
@@ -442,7 +443,7 @@ class GenesisEgoContextBuilder:
                     )
                 lines.append("")
 
-            # Section 2: Recently tried
+            # Section 2: Recently tried (genesis ego only)
             lines.append("## Recently Tried (do not re-propose)\n")
             cursor2 = await self._db.execute(
                 "SELECT action_type, content, status, "
@@ -450,6 +451,7 @@ class GenesisEgoContextBuilder:
                 "FROM ego_proposals "
                 "WHERE created_at >= datetime('now', '-7 days') "
                 "AND status IN ('withdrawn', 'tabled', 'rejected', 'failed', 'expired') "
+                "AND (ego_source = 'genesis_ego_cycle' OR ego_source IS NULL) "
                 "ORDER BY created_at DESC "
                 "LIMIT 10"
             )
@@ -501,7 +503,7 @@ class GenesisEgoContextBuilder:
 
         # ---- Fetch all pending proposals ----
         try:
-            all_pending = await ego_crud.get_pending_queue(self._db)
+            all_pending = await ego_crud.get_pending_queue(self._db, ego_source='genesis_ego_cycle')
         except Exception:
             logger.error("Failed to query pending proposals", exc_info=True)
             lines.append("## Operational Focus\n")
@@ -545,7 +547,7 @@ class GenesisEgoContextBuilder:
 
         # ---- Approved proposals ready for execution ----
         try:
-            approved = await ego_crud.list_proposals(self._db, status="approved", limit=5)
+            approved = await ego_crud.list_proposals(self._db, status="approved", limit=5, ego_source='genesis_ego_cycle')
         except Exception:
             approved = []
 

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -319,6 +319,20 @@ class GenesisEgoContextBuilder:
                 f"- [{priority}] **{source}{cat_str}** ({obs_type}): {short}"
             )
 
+        # Count redirect observations requiring in-cycle investigation
+        redirect_count = sum(
+            1 for row in rows
+            if row[1] in ("cross_domain_redirect", "realist_redirect")
+        )
+        if redirect_count:
+            lines.append(
+                f"\n**{redirect_count} redirect{'s' if redirect_count != 1 else ''} "
+                f"require in-cycle investigation.** Use your MCP tools "
+                f"(health_status, observation_query, memory_recall) to "
+                f"investigate each during THIS cycle. Then propose a "
+                f"concrete fix or escalate findings to user ego.\n"
+            )
+
         lines.append("")
         return "\n".join(lines)
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -16,6 +16,7 @@ import contextlib
 import json
 import logging
 import re
+import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -582,6 +583,8 @@ class EgoSession:
                 # (content, career, etc.) are rejected and auto-escalated.
                 if proposals and self._source_tag == "genesis_ego_cycle":
                     proposals = self._enforce_domain_boundary(proposals)
+                elif proposals and self._source_tag == "user_ego_cycle":
+                    proposals = await self._enforce_user_domain_boundary(proposals)
 
                 if proposals:
                     await self._process_proposals(
@@ -948,6 +951,16 @@ class EgoSession:
                         prop.get("content", "")[:80],
                         verdict.get("reasoning", "")[:100],
                     )
+                    # Create redirect observation for genesis ego so it
+                    # investigates in-cycle next time instead of proposing.
+                    if self._source_tag == "genesis_ego_cycle":
+                        reason = verdict.get("reasoning", "").lower()
+                        if "read operation" in reason or "during your cycle" in reason:
+                            with contextlib.suppress(Exception):
+                                await self._create_redirect_observation(
+                                    prop,
+                                    redirect_type="realist_redirect",
+                                )
 
             if rejected_count or amended_count:
                 logger.info(
@@ -1045,6 +1058,69 @@ class EgoSession:
                     p.get("content", "")[:80],
                 )
         return allowed
+
+    async def _enforce_user_domain_boundary(
+        self,
+        proposals: list[dict],
+    ) -> list[dict]:
+        """Redirect infrastructure proposals from the user ego.
+
+        The user ego (CEO) should not propose on infrastructure domains.
+        When it does, the proposal is redirected as an observation for the
+        genesis ego to pick up, preserving the signal without polluting
+        the user ego's proposal queue.
+        """
+        allowed = []
+        for p in proposals:
+            category = p.get("action_category", "")
+            if _normalize_to_infra(category):
+                logger.info(
+                    "User ego infra redirect: category=%r → observation (content: %s)",
+                    category,
+                    p.get("content", "")[:80],
+                )
+                await self._create_redirect_observation(
+                    p, redirect_type="cross_domain_redirect",
+                )
+            else:
+                allowed.append(p)
+        return allowed
+
+    async def _create_redirect_observation(
+        self,
+        proposal: dict,
+        *,
+        redirect_type: str = "cross_domain_redirect",
+    ) -> None:
+        """Create a redirect observation for a cross-domain proposal.
+
+        Uses dedup (skip_if_duplicate) and 3-day TTL so redirects
+        auto-expire if the target ego doesn't act on them.
+        """
+        try:
+            from genesis.db.crud import observations as obs_crud
+
+            content = (
+                f"Redirected from {self._source_tag}: "
+                f"{proposal.get('content', '')[:300]}"
+            )
+            expires = (datetime.now(UTC) + timedelta(days=3)).isoformat()
+            await obs_crud.create(
+                self._db,
+                id=uuid.uuid4().hex,
+                source=f"ego_domain_redirect:{self._source_tag}",
+                type=redirect_type,
+                content=content,
+                priority=proposal.get("urgency", "medium"),
+                created_at=datetime.now(UTC).isoformat(),
+                category="infrastructure",
+                expires_at=expires,
+                skip_if_duplicate=True,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to create redirect observation", exc_info=True,
+            )
 
     async def _process_proposals(
         self,
@@ -1764,6 +1840,29 @@ class EgoSession:
             logger.debug("Failed to send execution notification", exc_info=True)
 
 
+# -- User ego domain boundary -----------------------------------------------
+
+# User ego blocked categories — infrastructure belongs to genesis ego.
+# Uses prefix matching: "infrastructure" matches "infrastructure_bug", etc.
+_USER_EGO_INFRA_PREFIXES = frozenset({
+    "system_health", "infrastructure", "performance",
+    "maintenance", "security", "cost_protection",
+    "system_monitoring", "genesis_maintenance",
+})
+
+
+def _normalize_to_infra(category: str) -> bool:
+    """Check if a category belongs to the infrastructure domain.
+
+    Uses prefix matching to catch LLM-generated variants like
+    'infrastructure_maintenance', 'infrastructure_bug', etc.
+    """
+    if not category:
+        return False
+    cat_lower = category.lower()
+    return any(cat_lower.startswith(prefix) for prefix in _USER_EGO_INFRA_PREFIXES)
+
+
 # -- Realist prompt & parser -----------------------------------------------
 
 _NEUTRAL_STATUS = NEUTRAL_STATUS  # re-export for backwards compat
@@ -1800,7 +1899,7 @@ def _build_realist_prompt(
         conf = p.get("confidence", 0.0)
         proposal_lines.append(f"{i}. [{action}] (confidence: {conf:.2f}) {content}")
 
-    # Domain boundary context — only for the Genesis/operations ego.
+    # Domain boundary context — ego-specific jurisdiction framing.
     ego_section = ""
     if ego_source == "genesis_ego_cycle":
         ego_section = """
@@ -1811,6 +1910,16 @@ performance, maintenance, and operational reliability. It has NO
 jurisdiction over the user's career, content publishing, social media,
 marketing, outreach strategy, job applications, networking, conferences,
 personal scheduling, or external platforms Genesis doesn't operate.
+
+"""
+    elif ego_source == "user_ego_cycle":
+        ego_section = """
+## Ego Source
+These proposals are from the **User ego (CEO)**.
+Its jurisdiction is user value ONLY: career, content, goals,
+networking, and personal advancement. It has NO jurisdiction over
+Genesis infrastructure, system health, cost tracking, performance
+monitoring, or internal maintenance.
 
 """
 
@@ -1826,17 +1935,39 @@ personal scheduling, or external platforms Genesis doesn't operate.
    dropped during a job application session"), AMEND to focus on the
    infrastructure component only and remove the user-domain framing.
 """
+    elif ego_source == "user_ego_cycle":
+        domain_rule = """
+7. **Domain boundary (user ego only).** These proposals come from the
+   user ego. REJECT any proposal about Genesis infrastructure, system
+   health, cost optimization, performance tuning, or internal
+   maintenance. Those belong to the Genesis ego (COO).
+"""
+
+    # Build Rule #1 based on ego source — genesis ego is allowed to
+    # propose investigation dispatches (background sessions for diagnosis),
+    # while user ego should do read-only work in-cycle.
+    if ego_source == "genesis_ego_cycle":
+        rule_1 = """
+1. **Dispatch investigations are valid proposals.** The genesis ego may
+   propose dispatching investigation sessions for issues that require
+   dedicated time beyond the current cycle. Pure in-cycle reads (health
+   checks, observation queries) should still be done in-cycle, but
+   proposing a background session to diagnose a complex issue is a
+   legitimate maintenance action. PASS these unless they are clearly
+   something the ego could resolve with a single MCP tool call."""
+    else:
+        rule_1 = """
+1. **Read operations are NOT proposals.** Investigating, researching, reading,
+   profiling, querying, checking, monitoring — these are things the ego should
+   do during its normal cycle without asking permission. If a proposal is
+   purely investigative with no write/action/outreach component, REJECT it:
+   "Read operation — do this during your cycle, don't propose it.\""""
 
     return f"""You are the Realist — a quality gate for ego proposals. Evaluate each
 proposal and return a JSON array of verdicts.
 {ego_section}
 ## Rules
-
-1. **Read operations are NOT proposals.** Investigating, researching, reading,
-   profiling, querying, checking, monitoring — these are things the ego should
-   do during its normal cycle without asking permission. If a proposal is
-   purely investigative with no write/action/outreach component, REJECT it:
-   "Read operation — do this during your cycle, don't propose it."
+{rule_1}
 
 2. **Check for zombies.** If a proposal covers substantially the same topic
    as a recent proposal that was recycled/withdrawn/deferred/expired, and

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -952,15 +952,15 @@ class EgoSession:
                         verdict.get("reasoning", "")[:100],
                     )
                     # Create redirect observation for genesis ego so it
-                    # investigates in-cycle next time instead of proposing.
+                    # picks up the topic in its next cycle. Any realist
+                    # rejection of a genesis ego proposal creates a
+                    # redirect — the wording of the rejection may vary.
                     if self._source_tag == "genesis_ego_cycle":
-                        reason = verdict.get("reasoning", "").lower()
-                        if "read operation" in reason or "during your cycle" in reason:
-                            with contextlib.suppress(Exception):
-                                await self._create_redirect_observation(
-                                    prop,
-                                    redirect_type="realist_redirect",
-                                )
+                        with contextlib.suppress(Exception):
+                            await self._create_redirect_observation(
+                                prop,
+                                redirect_type="realist_redirect",
+                            )
 
             if rejected_count or amended_count:
                 logger.info(
@@ -1031,7 +1031,8 @@ class EgoSession:
     # Genesis ego allowed action categories (infrastructure/operations only)
     _GENESIS_EGO_ALLOWED_CATEGORIES = frozenset({
         "system_health", "infrastructure", "performance",
-        "maintenance", "security",
+        "maintenance", "security", "cost_protection",
+        "system_monitoring", "genesis_maintenance",
     })
 
     def _enforce_domain_boundary(
@@ -1079,9 +1080,10 @@ class EgoSession:
                     category,
                     p.get("content", "")[:80],
                 )
-                await self._create_redirect_observation(
-                    p, redirect_type="cross_domain_redirect",
-                )
+                with contextlib.suppress(Exception):
+                    await self._create_redirect_observation(
+                        p, redirect_type="cross_domain_redirect",
+                    )
             else:
                 allowed.append(p)
         return allowed
@@ -1111,7 +1113,12 @@ class EgoSession:
                 source=f"ego_domain_redirect:{self._source_tag}",
                 type=redirect_type,
                 content=content,
-                priority=proposal.get("urgency", "medium"),
+                # Map proposal urgency to observation priority.
+                # Proposal uses "normal"; observations use "medium".
+                priority={"normal": "medium"}.get(
+                    proposal.get("urgency", "medium"),
+                    proposal.get("urgency", "medium"),
+                ),
                 created_at=datetime.now(UTC).isoformat(),
                 category="infrastructure",
                 expires_at=expires,

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1136,6 +1136,38 @@ class EgoSession:
         - ``stay_quiet``: create batch only (proposals stored, not sent)
         """
         try:
+            # Auto-table oldest unranked proposals when queue exceeds cap.
+            # Respects the 24h guard — proposals < 24h old are not tabled.
+            try:
+                pending = await ego_crud.list_pending_proposals(
+                    self._db, ego_source=self._source_tag,
+                )
+                max_pending = getattr(self._config, "max_pending_proposals", 15)
+                if len(pending) + len(proposals) > max_pending:
+                    unranked = [
+                        p for p in pending if p.get("rank") is None
+                    ]
+                    excess = len(pending) + len(proposals) - max_pending
+                    oldest = sorted(
+                        unranked, key=lambda x: x.get("created_at", ""),
+                    )
+                    for p in oldest[:excess]:
+                        created = p.get("created_at", "")
+                        if created:
+                            try:
+                                age = datetime.now(UTC) - datetime.fromisoformat(created)
+                                if age.total_seconds() < 86400:
+                                    continue  # 24h guard
+                            except (ValueError, TypeError):
+                                pass
+                        await ego_crud.table_proposal(self._db, p["id"])
+                        logger.info(
+                            "Auto-tabled proposal %s (queue cap %d)",
+                            p["id"][:12], max_pending,
+                        )
+            except Exception:
+                logger.debug("Pending cap check failed, proceeding", exc_info=True)
+
             batch_id, ids = await self._proposals.create_batch(
                 proposals,
                 cycle_id=cycle_id,

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -131,6 +131,7 @@ class EgoConfig:
     # Genesis ego (COO) independent scheduling — defaults match user ego
     genesis_cadence_minutes: int = 90  # base interval for genesis ego
     genesis_max_interval_minutes: int = 240  # backoff ceiling for genesis ego
+    max_pending_proposals: int = 15  # auto-table oldest unranked when exceeded
     # Per-action-type model overrides for proposal dispatch.
     # Keys are action_type strings (e.g. "investigate"), values are model
     # names ("opus", "sonnet", "haiku").  Falls back to profile-based

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -28,6 +28,11 @@ logger = logging.getLogger(__name__)
 _USER_WORLD_CATEGORIES = frozenset({
     "email_recon", "inbox", "finding", "interest", "interests",
     "contribution", "user_model_delta",
+    # User-domain categories — genesis ego should not see these
+    "career", "career_advancement", "career_application",
+    "content", "content_publishing", "content_distribution",
+    "goal_management", "goal_review", "portfolio",
+    "marketing", "outreach", "networking",
 })
 
 # Keywords indicating a session is about Genesis internals (not user-world).

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -885,14 +885,16 @@ class UserEgoContextBuilder:
                 cursor = await self._db.execute(
                     "SELECT COUNT(*) FROM ego_proposals "
                     "WHERE created_at >= datetime('now', '-7 days') "
-                    "AND status IN ('pending', 'approved', 'executed')"
+                    "AND status IN ('pending', 'approved', 'executed') "
+                    "AND (ego_source = 'user_ego_cycle' OR ego_source IS NULL)"
                 )
                 active = (await cursor.fetchone())[0]
                 cursor2 = await self._db.execute(
                     "SELECT COUNT(*) FROM ego_proposals "
                     "WHERE created_at >= datetime('now', '-7 days') "
                     "AND status IN ('withdrawn', 'tabled', 'rejected', "
-                    "'failed', 'expired')"
+                    "'failed', 'expired') "
+                    "AND (ego_source = 'user_ego_cycle' OR ego_source IS NULL)"
                 )
                 tried = (await cursor2.fetchone())[0]
                 return (
@@ -924,13 +926,14 @@ class UserEgoContextBuilder:
             return f"| {action_type} | {short} | {status} | {realist} |"
 
         try:
-            # Section 1: Active proposals
+            # Section 1: Active proposals (user ego only)
             cursor = await self._db.execute(
                 "SELECT action_type, content, status, realist_verdict, "
                 "realist_reasoning, created_at "
                 "FROM ego_proposals "
                 "WHERE created_at >= datetime('now', '-7 days') "
                 "AND status IN ('pending', 'approved', 'executed') "
+                "AND (ego_source = 'user_ego_cycle' OR ego_source IS NULL) "
                 "ORDER BY created_at DESC "
                 "LIMIT 15",
             )
@@ -944,7 +947,7 @@ class UserEgoContextBuilder:
                     lines.append(_format_row(row))
                 lines.append("")
 
-            # Section 2: Recently tried
+            # Section 2: Recently tried (user ego only)
             lines.append("## Recently Tried (do not re-propose)\n")
             cursor2 = await self._db.execute(
                 "SELECT action_type, content, status, realist_verdict, "
@@ -952,6 +955,7 @@ class UserEgoContextBuilder:
                 "FROM ego_proposals "
                 "WHERE created_at >= datetime('now', '-7 days') "
                 "AND status IN ('withdrawn', 'tabled', 'rejected', 'failed', 'expired') "
+                "AND (ego_source = 'user_ego_cycle' OR ego_source IS NULL) "
                 "ORDER BY created_at DESC "
                 "LIMIT 10",
             )
@@ -997,7 +1001,7 @@ class UserEgoContextBuilder:
 
         # ---- Fetch all pending proposals ----
         try:
-            all_pending = await ego_crud.get_pending_queue(self._db)
+            all_pending = await ego_crud.get_pending_queue(self._db, ego_source='user_ego_cycle')
         except Exception:
             logger.error("Failed to query pending proposals", exc_info=True)
             lines.append("## Proposal Board\n")
@@ -1059,7 +1063,7 @@ class UserEgoContextBuilder:
 
         # ---- Approved proposals ready for execution ----
         try:
-            approved = await ego_crud.list_proposals(self._db, status="approved", limit=5)
+            approved = await ego_crud.list_proposals(self._db, status="approved", limit=5, ego_source='user_ego_cycle')
         except Exception:
             approved = []
 
@@ -1079,7 +1083,7 @@ class UserEgoContextBuilder:
 
         # ---- Deferred (tabled) proposals ----
         try:
-            tabled = await ego_crud.get_tabled(self._db)
+            tabled = await ego_crud.get_tabled(self._db, ego_source='user_ego_cycle')
         except Exception:
             tabled = []
 

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -155,22 +155,31 @@ Add an escalation when:
 
 ### Signal Threshold — What Deserves Your Attention
 
-Not all system changes are worth your cognitive budget. Apply these filters:
+**Always investigate (use your tools during this cycle):**
+- Unresolved observations in your context — especially redirect observations
+  from user ego or the realist gate. These are items explicitly routed to you.
+- Awareness signals trending in one direction across 2+ ticks
+- Queues growing: deferred work, dead letter, pending items
+- Cost anomalies: today vs 7-day average
+- Any metric that degraded since your last cycle
 
-**Act on (propose fix or escalate):**
-- Actual failures: something that worked yesterday is broken today
-- Trend toward failure: a metric growing linearly toward a hard limit
-- Cascading degradation: one failure causing others
-- User-impacting: something the user will notice in their experience
+**Propose a fix when investigation reveals:**
+- A root cause you can address via maintenance dispatch
+- A pattern that will escalate without intervention
+- A cascading failure or dependency chain
 
-**Ignore (noise, not signal):**
-- Normal fluctuations: memory usage varying by 5-10% is not news
-- Single data points without trend: one timeout, one retry, one fallback
-- Metrics that self-heal: circuit breaker cycling is designed behavior
-- Dashboard cosmetics: widgets showing yellow with no user impact
+**Escalate when:**
+- You cannot diagnose the issue with available tools
+- The fix requires code or config changes (not your jurisdiction)
+- User impact is likely or confirmed
 
-A metric changing is not news. A metric BREAKING is news. Don't report
-observations — report decisions and actions.
+**Ignore:**
+- Normal fluctuations within established baselines
+- Self-healing circuit breaker cycling (designed behavior)
+- Cosmetic dashboard issues with no operational impact
+
+Investigate first, then decide. "All green" in the health snapshot does
+not mean "nothing to do" — check observations, signals, and trends.
 
 ### No Autonomous Code or Config Modification
 

--- a/tests/ego/test_context_separation.py
+++ b/tests/ego/test_context_separation.py
@@ -1,0 +1,623 @@
+"""Tests for ego_source filtering — proposals visible only to their owning ego.
+
+Phase 1a of the ego architecture fix: each ego (genesis / user) must only
+see its own proposals in history and board sections.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import ego as ego_crud
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_EGO_PROPOSALS_DDL = """
+CREATE TABLE IF NOT EXISTS ego_proposals (
+    id               TEXT PRIMARY KEY,
+    action_type      TEXT NOT NULL,
+    action_category  TEXT NOT NULL DEFAULT '',
+    content          TEXT NOT NULL,
+    rationale        TEXT NOT NULL DEFAULT '',
+    confidence       REAL NOT NULL DEFAULT 0.0,
+    urgency          TEXT NOT NULL DEFAULT 'normal',
+    alternatives     TEXT NOT NULL DEFAULT '',
+    status           TEXT NOT NULL DEFAULT 'pending',
+    user_response    TEXT,
+    cycle_id         TEXT,
+    batch_id         TEXT,
+    created_at       TEXT NOT NULL,
+    resolved_at      TEXT,
+    expires_at       TEXT,
+    rank             INTEGER,
+    execution_plan   TEXT,
+    recurring        INTEGER DEFAULT 0,
+    memory_basis     TEXT DEFAULT '',
+    realist_verdict  TEXT,
+    realist_reasoning TEXT,
+    ego_source       TEXT,
+    goal_id          TEXT,
+    content_hash     TEXT,
+    original_content TEXT,
+    content_size     INTEGER,
+    expected_outputs TEXT
+)
+"""
+
+
+@pytest.fixture
+async def db():
+    """In-memory DB with the ego_proposals table."""
+    async with aiosqlite.connect(":memory:") as conn:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute(_EGO_PROPOSALS_DDL)
+        await conn.commit()
+        yield conn
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _recent_iso(hours_ago: int = 1) -> str:
+    return (datetime.now(UTC) - timedelta(hours=hours_ago)).isoformat()
+
+
+async def _insert_proposal(
+    db: aiosqlite.Connection,
+    *,
+    id: str,
+    ego_source: str | None,
+    status: str = "pending",
+    action_type: str = "research",
+    content: str = "test proposal",
+    rank: int | None = None,
+    created_at: str | None = None,
+    resolved_at: str | None = None,
+    realist_verdict: str | None = None,
+    realist_reasoning: str | None = None,
+) -> None:
+    await db.execute(
+        "INSERT INTO ego_proposals "
+        "(id, action_type, content, status, ego_source, rank, created_at, "
+        "resolved_at, realist_verdict, realist_reasoning) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            id,
+            action_type,
+            content,
+            status,
+            ego_source,
+            rank,
+            created_at or _recent_iso(),
+            resolved_at,
+            realist_verdict,
+            realist_reasoning,
+        ),
+    )
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# CRUD function tests
+# ---------------------------------------------------------------------------
+
+
+class TestListProposalsEgoSource:
+    @pytest.mark.asyncio
+    async def test_filter_returns_matching_source(self, db):
+        await _insert_proposal(db, id="g1", ego_source="genesis_ego_cycle")
+        await _insert_proposal(db, id="u1", ego_source="user_ego_cycle")
+
+        genesis_results = await ego_crud.list_proposals(db, ego_source="genesis_ego_cycle")
+        assert len(genesis_results) == 1
+        assert genesis_results[0]["id"] == "g1"
+
+        user_results = await ego_crud.list_proposals(db, ego_source="user_ego_cycle")
+        assert len(user_results) == 1
+        assert user_results[0]["id"] == "u1"
+
+    @pytest.mark.asyncio
+    async def test_null_ego_source_visible_to_both(self, db):
+        await _insert_proposal(db, id="legacy", ego_source=None)
+        await _insert_proposal(db, id="g1", ego_source="genesis_ego_cycle")
+
+        genesis_results = await ego_crud.list_proposals(db, ego_source="genesis_ego_cycle")
+        ids = {r["id"] for r in genesis_results}
+        assert "legacy" in ids
+        assert "g1" in ids
+
+        user_results = await ego_crud.list_proposals(db, ego_source="user_ego_cycle")
+        ids = {r["id"] for r in user_results}
+        assert "legacy" in ids
+        assert "g1" not in ids
+
+    @pytest.mark.asyncio
+    async def test_no_filter_returns_all(self, db):
+        await _insert_proposal(db, id="g1", ego_source="genesis_ego_cycle")
+        await _insert_proposal(db, id="u1", ego_source="user_ego_cycle")
+        await _insert_proposal(db, id="legacy", ego_source=None)
+
+        all_results = await ego_crud.list_proposals(db)
+        assert len(all_results) == 3
+
+    @pytest.mark.asyncio
+    async def test_filter_with_status(self, db):
+        await _insert_proposal(db, id="g1", ego_source="genesis_ego_cycle", status="approved")
+        await _insert_proposal(db, id="g2", ego_source="genesis_ego_cycle", status="pending")
+        await _insert_proposal(db, id="u1", ego_source="user_ego_cycle", status="approved")
+
+        results = await ego_crud.list_proposals(
+            db, status="approved", ego_source="genesis_ego_cycle"
+        )
+        assert len(results) == 1
+        assert results[0]["id"] == "g1"
+
+
+class TestGetPendingQueueEgoSource:
+    @pytest.mark.asyncio
+    async def test_filter_returns_matching_source(self, db):
+        await _insert_proposal(db, id="g1", ego_source="genesis_ego_cycle", rank=1)
+        await _insert_proposal(db, id="u1", ego_source="user_ego_cycle", rank=2)
+
+        genesis_results = await ego_crud.get_pending_queue(db, ego_source="genesis_ego_cycle")
+        assert len(genesis_results) == 1
+        assert genesis_results[0]["id"] == "g1"
+
+    @pytest.mark.asyncio
+    async def test_null_ego_source_visible_to_both(self, db):
+        await _insert_proposal(db, id="legacy", ego_source=None, rank=1)
+
+        genesis_results = await ego_crud.get_pending_queue(db, ego_source="genesis_ego_cycle")
+        assert len(genesis_results) == 1
+        assert genesis_results[0]["id"] == "legacy"
+
+        user_results = await ego_crud.get_pending_queue(db, ego_source="user_ego_cycle")
+        assert len(user_results) == 1
+        assert user_results[0]["id"] == "legacy"
+
+    @pytest.mark.asyncio
+    async def test_no_filter_returns_all(self, db):
+        await _insert_proposal(db, id="g1", ego_source="genesis_ego_cycle")
+        await _insert_proposal(db, id="u1", ego_source="user_ego_cycle")
+
+        all_results = await ego_crud.get_pending_queue(db)
+        assert len(all_results) == 2
+
+
+class TestGetTabledEgoSource:
+    @pytest.mark.asyncio
+    async def test_filter_returns_matching_source(self, db):
+        await _insert_proposal(
+            db, id="g1", ego_source="genesis_ego_cycle", status="tabled",
+            resolved_at=_now_iso(),
+        )
+        await _insert_proposal(
+            db, id="u1", ego_source="user_ego_cycle", status="tabled",
+            resolved_at=_now_iso(),
+        )
+
+        genesis_results = await ego_crud.get_tabled(db, ego_source="genesis_ego_cycle")
+        assert len(genesis_results) == 1
+        assert genesis_results[0]["id"] == "g1"
+
+        user_results = await ego_crud.get_tabled(db, ego_source="user_ego_cycle")
+        assert len(user_results) == 1
+        assert user_results[0]["id"] == "u1"
+
+    @pytest.mark.asyncio
+    async def test_null_ego_source_visible_to_both(self, db):
+        await _insert_proposal(
+            db, id="legacy", ego_source=None, status="tabled",
+            resolved_at=_now_iso(),
+        )
+
+        genesis_results = await ego_crud.get_tabled(db, ego_source="genesis_ego_cycle")
+        assert len(genesis_results) == 1
+
+        user_results = await ego_crud.get_tabled(db, ego_source="user_ego_cycle")
+        assert len(user_results) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_filter_returns_all(self, db):
+        await _insert_proposal(
+            db, id="g1", ego_source="genesis_ego_cycle", status="tabled",
+            resolved_at=_now_iso(),
+        )
+        await _insert_proposal(
+            db, id="u1", ego_source="user_ego_cycle", status="tabled",
+            resolved_at=_now_iso(),
+        )
+
+        all_results = await ego_crud.get_tabled(db)
+        assert len(all_results) == 2
+
+
+# ---------------------------------------------------------------------------
+# Context builder integration tests
+# ---------------------------------------------------------------------------
+
+# Additional tables needed by the context builders
+_EXTRA_TABLES_DDL = [
+    """CREATE TABLE awareness_ticks (
+        id TEXT PRIMARY KEY, source TEXT NOT NULL DEFAULT '',
+        signals_json TEXT NOT NULL DEFAULT '{}',
+        scores_json TEXT NOT NULL DEFAULT '{}',
+        signal_data TEXT, classified_depth TEXT,
+        trigger_reason TEXT, created_at TEXT NOT NULL
+    )""",
+    """CREATE TABLE observations (
+        id TEXT PRIMARY KEY, person_id TEXT, source TEXT NOT NULL,
+        type TEXT NOT NULL, category TEXT, content TEXT NOT NULL,
+        priority TEXT NOT NULL, speculative INTEGER NOT NULL DEFAULT 0,
+        retrieved_count INTEGER NOT NULL DEFAULT 0,
+        influenced_action INTEGER NOT NULL DEFAULT 0,
+        resolved INTEGER NOT NULL DEFAULT 0, resolved_at TEXT,
+        resolution_notes TEXT, created_at TEXT NOT NULL,
+        expires_at TEXT, content_hash TEXT
+    )""",
+    """CREATE TABLE cost_events (
+        id TEXT PRIMARY KEY, event_type TEXT NOT NULL,
+        model TEXT, provider TEXT, engine TEXT, task_id TEXT,
+        person_id TEXT, input_tokens INTEGER, output_tokens INTEGER,
+        cost_usd REAL NOT NULL DEFAULT 0.0, metadata TEXT,
+        created_at TEXT NOT NULL
+    )""",
+    """CREATE TABLE ego_cycles (
+        id TEXT PRIMARY KEY, output_text TEXT NOT NULL,
+        proposals_json TEXT NOT NULL DEFAULT '[]',
+        focus_summary TEXT NOT NULL DEFAULT '',
+        model_used TEXT NOT NULL DEFAULT '',
+        cost_usd REAL NOT NULL DEFAULT 0.0,
+        input_tokens INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        duration_ms INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL, compacted_into TEXT
+    )""",
+    """CREATE TABLE follow_ups (
+        id TEXT PRIMARY KEY, source TEXT NOT NULL,
+        source_session TEXT, content TEXT NOT NULL,
+        reason TEXT, strategy TEXT NOT NULL,
+        scheduled_at TEXT, status TEXT NOT NULL DEFAULT 'pending',
+        linked_task_id TEXT, priority TEXT NOT NULL DEFAULT 'medium',
+        created_at TEXT NOT NULL, completed_at TEXT,
+        resolution_notes TEXT, blocked_reason TEXT,
+        escalated_to TEXT
+    )""",
+    """CREATE TABLE user_model_cache (
+        id TEXT PRIMARY KEY DEFAULT 'current', person_id TEXT,
+        model_json TEXT NOT NULL, version INTEGER NOT NULL DEFAULT 1,
+        synthesized_at TEXT NOT NULL, synthesized_by TEXT NOT NULL,
+        evidence_count INTEGER NOT NULL DEFAULT 0,
+        last_change_type TEXT, last_changed_at TEXT
+    )""",
+    """CREATE TABLE cc_sessions (
+        id TEXT PRIMARY KEY, session_type TEXT NOT NULL,
+        user_id TEXT, channel TEXT, model TEXT NOT NULL,
+        effort TEXT NOT NULL DEFAULT 'medium',
+        status TEXT NOT NULL DEFAULT 'active', pid INTEGER,
+        started_at TEXT NOT NULL, last_activity_at TEXT NOT NULL,
+        checkpointed_at TEXT, completed_at TEXT,
+        source_tag TEXT NOT NULL DEFAULT 'foreground',
+        metadata TEXT, cc_session_id TEXT, thread_id TEXT,
+        topic TEXT DEFAULT ''
+    )""",
+    """CREATE TABLE inbox_items (
+        id TEXT PRIMARY KEY, file_path TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        batch_id TEXT, response_path TEXT,
+        created_at TEXT NOT NULL, processed_at TEXT,
+        error_message TEXT, retry_count INTEGER NOT NULL DEFAULT 0,
+        evaluated_content TEXT
+    )""",
+]
+
+
+@pytest.fixture
+async def full_db():
+    """In-memory DB with all tables needed by both context builders."""
+    async with aiosqlite.connect(":memory:") as conn:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute(_EGO_PROPOSALS_DDL)
+        for ddl in _EXTRA_TABLES_DDL:
+            await conn.execute(ddl)
+        await conn.commit()
+        yield conn
+
+
+def _mock_health():
+    hd = AsyncMock()
+    hd.snapshot.return_value = {
+        "timestamp": _now_iso(),
+        "infrastructure": {
+            "genesis.db": {"status": "healthy", "latency_ms": 0.5},
+        },
+        "resilience": "healthy",
+        "queues": {},
+        "surplus": {},
+        "conversation": {
+            "status": "idle",
+            "last_user_message_age_s": 600.0,
+            "recent_user_turns": 1,
+            "recent_assistant_turns": 1,
+        },
+        "cost": {"daily_total": 0.10},
+    }
+    return hd
+
+
+class TestGenesisContextSeparation:
+    """Genesis context builder should only see genesis_ego_cycle proposals."""
+
+    @pytest.mark.asyncio
+    async def test_proposal_history_filters_by_genesis_source(self, full_db):
+        from genesis.ego.genesis_context import GenesisEgoContextBuilder
+
+        # Insert genesis proposal (should appear)
+        await _insert_proposal(
+            full_db, id="g1", ego_source="genesis_ego_cycle",
+            status="pending", content="Genesis ops task",
+        )
+        # Insert user proposal (should NOT appear)
+        await _insert_proposal(
+            full_db, id="u1", ego_source="user_ego_cycle",
+            status="pending", content="User strategic task",
+        )
+
+        builder = GenesisEgoContextBuilder(
+            db=full_db, health_data=_mock_health(),
+            capabilities={"db": "SQLite"},
+        )
+        section = await builder._proposal_history_section()
+
+        assert "Genesis ops task" in section
+        assert "User strategic task" not in section
+
+    @pytest.mark.asyncio
+    async def test_proposal_history_includes_null_source(self, full_db):
+        from genesis.ego.genesis_context import GenesisEgoContextBuilder
+
+        await _insert_proposal(
+            full_db, id="legacy", ego_source=None,
+            status="approved", content="Legacy proposal",
+        )
+
+        builder = GenesisEgoContextBuilder(
+            db=full_db, health_data=_mock_health(),
+            capabilities={"db": "SQLite"},
+        )
+        section = await builder._proposal_history_section()
+        assert "Legacy proposal" in section
+
+    @pytest.mark.asyncio
+    async def test_proposal_board_filters_by_genesis_source(self, full_db):
+        from genesis.ego.genesis_context import GenesisEgoContextBuilder
+
+        await _insert_proposal(
+            full_db, id="g1", ego_source="genesis_ego_cycle",
+            status="pending", content="Genesis board item", rank=1,
+        )
+        await _insert_proposal(
+            full_db, id="u1", ego_source="user_ego_cycle",
+            status="pending", content="User board item", rank=2,
+        )
+
+        builder = GenesisEgoContextBuilder(
+            db=full_db, health_data=_mock_health(),
+            capabilities={"db": "SQLite"},
+        )
+        section = await builder._proposal_board_section()
+
+        assert "Genesis board item" in section
+        assert "User board item" not in section
+
+    @pytest.mark.asyncio
+    async def test_approved_proposals_filtered(self, full_db):
+        from genesis.ego.genesis_context import GenesisEgoContextBuilder
+
+        await _insert_proposal(
+            full_db, id="g1", ego_source="genesis_ego_cycle",
+            status="approved", content="Genesis approved",
+        )
+        await _insert_proposal(
+            full_db, id="u1", ego_source="user_ego_cycle",
+            status="approved", content="User approved",
+        )
+
+        builder = GenesisEgoContextBuilder(
+            db=full_db, health_data=_mock_health(),
+            capabilities={"db": "SQLite"},
+        )
+        section = await builder._proposal_board_section()
+
+        assert "Genesis approved" in section
+        assert "User approved" not in section
+
+
+class TestUserContextSeparation:
+    """User context builder should only see user_ego_cycle proposals."""
+
+    @pytest.mark.asyncio
+    async def test_proposal_history_filters_by_user_source(self, full_db):
+        from genesis.ego.user_context import UserEgoContextBuilder
+
+        await _insert_proposal(
+            full_db, id="u1", ego_source="user_ego_cycle",
+            status="pending", content="User strategic task",
+        )
+        await _insert_proposal(
+            full_db, id="g1", ego_source="genesis_ego_cycle",
+            status="pending", content="Genesis ops task",
+        )
+
+        builder = UserEgoContextBuilder(
+            db=full_db, health_data=_mock_health(),
+        )
+        section = await builder._proposal_history_section()
+
+        assert "User strategic task" in section
+        assert "Genesis ops task" not in section
+
+    @pytest.mark.asyncio
+    async def test_proposal_history_light_depth_filtered(self, full_db):
+        from genesis.ego.user_context import UserEgoContextBuilder
+
+        # 2 user proposals, 1 genesis proposal
+        await _insert_proposal(
+            full_db, id="u1", ego_source="user_ego_cycle",
+            status="pending", content="User task 1",
+        )
+        await _insert_proposal(
+            full_db, id="u2", ego_source="user_ego_cycle",
+            status="rejected", content="User task 2",
+        )
+        await _insert_proposal(
+            full_db, id="g1", ego_source="genesis_ego_cycle",
+            status="pending", content="Genesis task",
+        )
+
+        builder = UserEgoContextBuilder(
+            db=full_db, health_data=_mock_health(),
+        )
+        section = await builder._proposal_history_section(depth="light")
+
+        # Light depth returns counts like "Active: 1 | Recently tried: 1"
+        assert "Active: 1" in section
+        assert "Recently tried: 1" in section
+
+    @pytest.mark.asyncio
+    async def test_proposal_history_includes_null_source(self, full_db):
+        from genesis.ego.user_context import UserEgoContextBuilder
+
+        await _insert_proposal(
+            full_db, id="legacy", ego_source=None,
+            status="executed", content="Legacy proposal",
+        )
+
+        builder = UserEgoContextBuilder(
+            db=full_db, health_data=_mock_health(),
+        )
+        section = await builder._proposal_history_section()
+        assert "Legacy proposal" in section
+
+    @pytest.mark.asyncio
+    async def test_proposal_board_filters_by_user_source(self, full_db):
+        from genesis.ego.user_context import UserEgoContextBuilder
+
+        await _insert_proposal(
+            full_db, id="u1", ego_source="user_ego_cycle",
+            status="pending", content="User board item", rank=1,
+        )
+        await _insert_proposal(
+            full_db, id="g1", ego_source="genesis_ego_cycle",
+            status="pending", content="Genesis board item", rank=2,
+        )
+
+        builder = UserEgoContextBuilder(
+            db=full_db, health_data=_mock_health(),
+        )
+        section = await builder._proposal_board_section()
+
+        assert "User board item" in section
+        assert "Genesis board item" not in section
+
+    @pytest.mark.asyncio
+    async def test_approved_proposals_filtered(self, full_db):
+        from genesis.ego.user_context import UserEgoContextBuilder
+
+        await _insert_proposal(
+            full_db, id="u1", ego_source="user_ego_cycle",
+            status="approved", content="User approved",
+        )
+        await _insert_proposal(
+            full_db, id="g1", ego_source="genesis_ego_cycle",
+            status="approved", content="Genesis approved",
+        )
+
+        builder = UserEgoContextBuilder(
+            db=full_db, health_data=_mock_health(),
+        )
+        section = await builder._proposal_board_section()
+
+        assert "User approved" in section
+        assert "Genesis approved" not in section
+
+    @pytest.mark.asyncio
+    async def test_tabled_proposals_filtered(self, full_db):
+        from genesis.ego.user_context import UserEgoContextBuilder
+
+        await _insert_proposal(
+            full_db, id="u1", ego_source="user_ego_cycle",
+            status="tabled", content="User tabled item",
+            resolved_at=_now_iso(),
+        )
+        await _insert_proposal(
+            full_db, id="g1", ego_source="genesis_ego_cycle",
+            status="tabled", content="Genesis tabled item",
+            resolved_at=_now_iso(),
+        )
+
+        builder = UserEgoContextBuilder(
+            db=full_db, health_data=_mock_health(),
+        )
+        section = await builder._proposal_board_section()
+
+        assert "User tabled item" in section
+        assert "Genesis tabled item" not in section
+
+
+class TestCrossEgoIsolation:
+    """End-to-end isolation: each ego's full context excludes the other's proposals."""
+
+    @pytest.mark.asyncio
+    async def test_full_isolation(self, full_db):
+        from genesis.ego.genesis_context import GenesisEgoContextBuilder
+        from genesis.ego.user_context import UserEgoContextBuilder
+
+        # Seed proposals from both egos
+        await _insert_proposal(
+            full_db, id="g1", ego_source="genesis_ego_cycle",
+            status="pending", content="GENESIS_ONLY_MARKER", rank=1,
+        )
+        await _insert_proposal(
+            full_db, id="u1", ego_source="user_ego_cycle",
+            status="pending", content="USER_ONLY_MARKER", rank=1,
+        )
+        await _insert_proposal(
+            full_db, id="legacy", ego_source=None,
+            status="pending", content="LEGACY_SHARED_MARKER", rank=2,
+        )
+
+        genesis_builder = GenesisEgoContextBuilder(
+            db=full_db, health_data=_mock_health(),
+            capabilities={"db": "SQLite"},
+        )
+        user_builder = UserEgoContextBuilder(
+            db=full_db, health_data=_mock_health(),
+        )
+
+        genesis_history = await genesis_builder._proposal_history_section()
+        genesis_board = await genesis_builder._proposal_board_section()
+        user_history = await user_builder._proposal_history_section()
+        user_board = await user_builder._proposal_board_section()
+
+        # Genesis sees its own + legacy, not user's
+        assert "GENESIS_ONLY_MARKER" in genesis_history
+        assert "GENESIS_ONLY_MARKER" in genesis_board
+        assert "LEGACY_SHARED_MARKER" in genesis_history
+        assert "LEGACY_SHARED_MARKER" in genesis_board
+        assert "USER_ONLY_MARKER" not in genesis_history
+        assert "USER_ONLY_MARKER" not in genesis_board
+
+        # User sees its own + legacy, not genesis's
+        assert "USER_ONLY_MARKER" in user_history
+        assert "USER_ONLY_MARKER" in user_board
+        assert "LEGACY_SHARED_MARKER" in user_history
+        assert "LEGACY_SHARED_MARKER" in user_board
+        assert "GENESIS_ONLY_MARKER" not in user_history
+        assert "GENESIS_ONLY_MARKER" not in user_board

--- a/tests/ego/test_domain_boundary.py
+++ b/tests/ego/test_domain_boundary.py
@@ -1,0 +1,329 @@
+"""Tests for ego domain boundary enforcement.
+
+Covers:
+- _normalize_to_infra() — prefix matching for infrastructure categories
+- _enforce_user_domain_boundary() — filtering and redirect observation creation
+- _enforce_domain_boundary() — genesis ego user-domain proposal dropping
+- _build_realist_prompt() — domain-specific context and rules for both egos
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.ego.session import (
+    _USER_EGO_INFRA_PREFIXES,
+    _build_realist_prompt,
+    _normalize_to_infra,
+)
+
+# ---------------------------------------------------------------------------
+# _normalize_to_infra tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeToInfra:
+    """Tests for prefix-based infrastructure category detection."""
+
+    def test_exact_matches(self):
+        """Exact category names in the prefix set should match."""
+        for prefix in _USER_EGO_INFRA_PREFIXES:
+            assert _normalize_to_infra(prefix) is True, f"Failed for: {prefix}"
+
+    def test_prefix_variants(self):
+        """LLM-generated variants with suffixes should match."""
+        assert _normalize_to_infra("infrastructure_maintenance") is True
+        assert _normalize_to_infra("infrastructure_bug") is True
+        assert _normalize_to_infra("infrastructure_health") is True
+        assert _normalize_to_infra("system_health_check") is True
+        assert _normalize_to_infra("performance_tuning") is True
+        assert _normalize_to_infra("maintenance_window") is True
+        assert _normalize_to_infra("security_audit") is True
+        assert _normalize_to_infra("cost_protection_budget") is True
+        assert _normalize_to_infra("system_monitoring_alert") is True
+        assert _normalize_to_infra("genesis_maintenance_task") is True
+
+    def test_case_insensitive(self):
+        """Matching should be case-insensitive."""
+        assert _normalize_to_infra("Infrastructure") is True
+        assert _normalize_to_infra("SYSTEM_HEALTH") is True
+        assert _normalize_to_infra("Performance_Tuning") is True
+
+    def test_non_infra_categories(self):
+        """User-domain categories should NOT match."""
+        assert _normalize_to_infra("career") is False
+        assert _normalize_to_infra("content") is False
+        assert _normalize_to_infra("networking") is False
+        assert _normalize_to_infra("marketing") is False
+        assert _normalize_to_infra("outreach") is False
+        assert _normalize_to_infra("goal_management") is False
+        assert _normalize_to_infra("portfolio") is False
+
+    def test_empty_and_none(self):
+        """Empty or falsy category should return False."""
+        assert _normalize_to_infra("") is False
+        # We don't pass None due to type hint, but test defensive behavior
+        assert _normalize_to_infra("") is False
+
+    def test_partial_non_match(self):
+        """Strings that contain infra words but don't start with them."""
+        assert _normalize_to_infra("career_infrastructure") is False
+        assert _normalize_to_infra("my_performance") is False
+        assert _normalize_to_infra("user_security") is False
+
+
+# ---------------------------------------------------------------------------
+# _enforce_user_domain_boundary tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnforceUserDomainBoundary:
+    """Tests for user ego infrastructure proposal redirection."""
+
+    @pytest.fixture
+    def mock_session(self):
+        """Create a minimal mock EgoSession for testing."""
+        session = MagicMock()
+        session._source_tag = "user_ego_cycle"
+        session._db = AsyncMock()
+        # Bind the real method to our mock
+        from genesis.ego.session import EgoSession
+
+        session._enforce_user_domain_boundary = (
+            EgoSession._enforce_user_domain_boundary.__get__(session)
+        )
+        session._create_redirect_observation = AsyncMock()
+        return session
+
+    @pytest.mark.asyncio
+    async def test_infra_proposals_filtered(self, mock_session):
+        """Infrastructure proposals are removed from the list."""
+        proposals = [
+            {"action_category": "infrastructure", "content": "Fix server", "urgency": "high"},
+            {"action_category": "career", "content": "Apply to job", "urgency": "normal"},
+        ]
+        result = await mock_session._enforce_user_domain_boundary(proposals)
+        assert len(result) == 1
+        assert result[0]["action_category"] == "career"
+
+    @pytest.mark.asyncio
+    async def test_redirect_observation_created(self, mock_session):
+        """Filtered proposals create redirect observations."""
+        proposals = [
+            {"action_category": "system_health_check", "content": "Check DB", "urgency": "high"},
+        ]
+        result = await mock_session._enforce_user_domain_boundary(proposals)
+        assert len(result) == 0
+        mock_session._create_redirect_observation.assert_called_once()
+        call_kwargs = mock_session._create_redirect_observation.call_args
+        assert call_kwargs[1]["redirect_type"] == "cross_domain_redirect"
+
+    @pytest.mark.asyncio
+    async def test_non_infra_proposals_pass_through(self, mock_session):
+        """User-domain proposals pass through untouched."""
+        proposals = [
+            {"action_category": "career", "content": "Apply to job", "urgency": "normal"},
+            {"action_category": "content", "content": "Write article", "urgency": "low"},
+            {"action_category": "networking", "content": "Reach out", "urgency": "normal"},
+        ]
+        result = await mock_session._enforce_user_domain_boundary(proposals)
+        assert len(result) == 3
+        mock_session._create_redirect_observation.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_prefix_variants_filtered(self, mock_session):
+        """LLM-generated category variants are caught."""
+        proposals = [
+            {"action_category": "infrastructure_maintenance", "content": "Fix bug", "urgency": "normal"},
+            {"action_category": "performance_tuning", "content": "Optimize", "urgency": "normal"},
+            {"action_category": "cost_protection_alert", "content": "Budget", "urgency": "high"},
+        ]
+        result = await mock_session._enforce_user_domain_boundary(proposals)
+        assert len(result) == 0
+        assert mock_session._create_redirect_observation.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_empty_category_passes(self, mock_session):
+        """Proposals with empty category pass through."""
+        proposals = [
+            {"action_category": "", "content": "Something", "urgency": "normal"},
+        ]
+        result = await mock_session._enforce_user_domain_boundary(proposals)
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_mixed_proposals(self, mock_session):
+        """Mixed list of infra and user-domain proposals."""
+        proposals = [
+            {"action_category": "career", "content": "Job search", "urgency": "normal"},
+            {"action_category": "infrastructure", "content": "Fix server", "urgency": "high"},
+            {"action_category": "content_publishing", "content": "Blog post", "urgency": "low"},
+            {"action_category": "system_monitoring_alert", "content": "Alert", "urgency": "critical"},
+        ]
+        result = await mock_session._enforce_user_domain_boundary(proposals)
+        assert len(result) == 2
+        assert result[0]["action_category"] == "career"
+        assert result[1]["action_category"] == "content_publishing"
+        assert mock_session._create_redirect_observation.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _enforce_domain_boundary tests (existing genesis ego boundary)
+# ---------------------------------------------------------------------------
+
+
+class TestEnforceDomainBoundary:
+    """Tests for genesis ego user-domain proposal dropping."""
+
+    @pytest.fixture
+    def mock_session(self):
+        """Create a minimal mock EgoSession for testing."""
+        session = MagicMock()
+        session._source_tag = "genesis_ego_cycle"
+        from genesis.ego.session import EgoSession
+
+        session._GENESIS_EGO_ALLOWED_CATEGORIES = (
+            EgoSession._GENESIS_EGO_ALLOWED_CATEGORIES
+        )
+        session._enforce_domain_boundary = (
+            EgoSession._enforce_domain_boundary.__get__(session)
+        )
+        return session
+
+    def test_allowed_categories_pass(self, mock_session):
+        """Infrastructure categories pass through."""
+        proposals = [
+            {"action_category": "system_health", "content": "Check health"},
+            {"action_category": "infrastructure", "content": "Fix infra"},
+            {"action_category": "performance", "content": "Optimize"},
+            {"action_category": "maintenance", "content": "Maintain"},
+            {"action_category": "security", "content": "Audit"},
+        ]
+        result = mock_session._enforce_domain_boundary(proposals)
+        assert len(result) == 5
+
+    def test_user_domain_proposals_dropped(self, mock_session):
+        """User-domain categories are dropped."""
+        proposals = [
+            {"action_category": "career", "content": "Apply to job"},
+            {"action_category": "content", "content": "Write blog"},
+            {"action_category": "marketing", "content": "Campaign"},
+            {"action_category": "networking", "content": "Reach out"},
+        ]
+        result = mock_session._enforce_domain_boundary(proposals)
+        assert len(result) == 0
+
+    def test_mixed_proposals(self, mock_session):
+        """Only allowed categories survive."""
+        proposals = [
+            {"action_category": "infrastructure", "content": "Fix bug"},
+            {"action_category": "career", "content": "Job app"},
+            {"action_category": "security", "content": "Audit"},
+        ]
+        result = mock_session._enforce_domain_boundary(proposals)
+        assert len(result) == 2
+        assert result[0]["action_category"] == "infrastructure"
+        assert result[1]["action_category"] == "security"
+
+
+# ---------------------------------------------------------------------------
+# _build_realist_prompt domain context tests
+# ---------------------------------------------------------------------------
+
+
+class TestRealistPromptDomainContext:
+    """Tests for domain-specific context in the realist prompt."""
+
+    def test_user_ego_gets_ego_section(self):
+        """User ego source adds CEO jurisdiction section."""
+        prompt = _build_realist_prompt(
+            [{"content": "test", "action_type": "dispatch", "confidence": 0.8}],
+            [],
+            ego_source="user_ego_cycle",
+        )
+        assert "User ego (CEO)" in prompt
+        assert "user value ONLY" in prompt
+        assert "NO jurisdiction over" in prompt
+        assert "Genesis infrastructure" in prompt
+
+    def test_user_ego_gets_domain_rule(self):
+        """User ego source adds Rule #7 for domain boundary."""
+        prompt = _build_realist_prompt(
+            [{"content": "test", "action_type": "dispatch", "confidence": 0.8}],
+            [],
+            ego_source="user_ego_cycle",
+        )
+        assert "Domain boundary (user ego only)" in prompt
+        assert "REJECT any proposal about Genesis infrastructure" in prompt
+        assert "Genesis ego (COO)" in prompt
+
+    def test_user_ego_domain_rule_mentions_blocked_topics(self):
+        """User ego Rule #7 lists the infrastructure topics to reject."""
+        prompt = _build_realist_prompt(
+            [{"content": "test", "action_type": "dispatch", "confidence": 0.8}],
+            [],
+            ego_source="user_ego_cycle",
+        )
+        for topic in ("system health", "cost optimization", "performance tuning",
+                      "internal maintenance"):
+            assert topic.lower() in prompt.lower(), f"Missing topic: {topic}"
+
+    def test_genesis_ego_does_not_get_user_ego_section(self):
+        """Genesis ego gets its own section, not user ego's."""
+        prompt = _build_realist_prompt(
+            [{"content": "test", "action_type": "dispatch", "confidence": 0.8}],
+            [],
+            ego_source="genesis_ego_cycle",
+        )
+        assert "User ego (CEO)" not in prompt
+        assert "Genesis ego (COO/operations)" in prompt
+
+    def test_empty_ego_source_no_domain_context(self):
+        """Empty/missing ego source adds no ego section or domain rule."""
+        prompt = _build_realist_prompt(
+            [{"content": "test", "action_type": "dispatch", "confidence": 0.8}],
+            [],
+        )
+        assert "User ego (CEO)" not in prompt
+        assert "Genesis ego (COO/operations)" not in prompt
+        # No rule 7
+        assert "Domain boundary" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# _USER_WORLD_CATEGORIES expansion tests
+# ---------------------------------------------------------------------------
+
+
+class TestUserWorldCategories:
+    """Tests for expanded _USER_WORLD_CATEGORIES."""
+
+    def test_original_categories_present(self):
+        """Original categories are still present."""
+        from genesis.ego.user_context import _USER_WORLD_CATEGORIES
+
+        original = {"email_recon", "inbox", "finding", "interest", "interests",
+                    "contribution", "user_model_delta"}
+        assert original.issubset(_USER_WORLD_CATEGORIES)
+
+    def test_expanded_categories_present(self):
+        """New user-domain categories are present."""
+        from genesis.ego.user_context import _USER_WORLD_CATEGORIES
+
+        expanded = {
+            "career", "career_advancement", "career_application",
+            "content", "content_publishing", "content_distribution",
+            "goal_management", "goal_review", "portfolio",
+            "marketing", "outreach", "networking",
+        }
+        assert expanded.issubset(_USER_WORLD_CATEGORIES)
+
+    def test_infra_categories_not_in_user_world(self):
+        """Infrastructure categories should NOT be in user world."""
+        from genesis.ego.user_context import _USER_WORLD_CATEGORIES
+
+        infra = {"system_health", "infrastructure", "performance",
+                 "maintenance", "security"}
+        assert infra.isdisjoint(_USER_WORLD_CATEGORIES)

--- a/tests/ego/test_genesis_context.py
+++ b/tests/ego/test_genesis_context.py
@@ -97,7 +97,15 @@ async def db():
                 rank            INTEGER,
                 execution_plan  TEXT,
                 recurring       INTEGER DEFAULT 0,
-                memory_basis    TEXT DEFAULT ''
+                memory_basis    TEXT DEFAULT '',
+                realist_verdict  TEXT,
+                realist_reasoning TEXT,
+                ego_source       TEXT,
+                goal_id          TEXT,
+                content_hash     TEXT,
+                original_content TEXT,
+                content_size     INTEGER,
+                expected_outputs TEXT
             )
         """)
         await conn.execute("""

--- a/tests/ego/test_realist.py
+++ b/tests/ego/test_realist.py
@@ -491,15 +491,16 @@ class TestDomainBoundary:
         assert "Domain boundary" in prompt
         assert "REJECT any proposal outside Genesis infrastructure" in prompt
 
-    def test_user_ego_no_domain_context(self):
-        """User ego source does NOT add domain boundary section."""
+    def test_user_ego_gets_domain_context(self):
+        """User ego source adds its own domain boundary section."""
         prompt = _build_realist_prompt(
             [{"content": "test", "action_type": "dispatch", "confidence": 0.8}],
             [],
             ego_source="user_ego_cycle",
         )
         assert "Genesis ego (COO/operations)" not in prompt
-        assert "Domain boundary" not in prompt
+        assert "User ego (CEO)" in prompt
+        assert "Domain boundary (user ego only)" in prompt
 
     def test_empty_ego_source_no_domain_context(self):
         """Empty/missing ego source does NOT add domain boundary section."""
@@ -530,3 +531,56 @@ class TestDomainBoundary:
         )
         assert "AMEND" in prompt
         assert "infrastructure component" in prompt
+
+
+# -- Genesis ego realist rule changes tests --
+
+
+class TestGenesisEgoRealist:
+    """Tests for genesis ego realist rule changes."""
+
+    def test_genesis_ego_no_read_operation_rule(self):
+        """Genesis ego realist should NOT have the read-operation rejection rule."""
+        prompt = _build_realist_prompt(
+            [{"action_type": "investigate", "content": "test", "confidence": 0.8}],
+            [],
+            ego_source="genesis_ego_cycle",
+        )
+        assert "Read operations are NOT proposals" not in prompt
+        assert "Dispatch investigations are valid" in prompt
+
+    def test_user_ego_has_read_operation_rule(self):
+        """User ego realist SHOULD have the read-operation rejection rule."""
+        prompt = _build_realist_prompt(
+            [{"action_type": "investigate", "content": "test", "confidence": 0.8}],
+            [],
+            ego_source="user_ego_cycle",
+        )
+        assert "Read operations are NOT proposals" in prompt
+        assert "Dispatch investigations are valid" not in prompt
+
+    def test_no_ego_source_has_read_operation_rule(self):
+        """Default (no ego source) should have read-operation rule."""
+        prompt = _build_realist_prompt(
+            [{"action_type": "investigate", "content": "test", "confidence": 0.8}],
+            [],
+        )
+        assert "Read operations are NOT proposals" in prompt
+
+    def test_genesis_ego_still_has_zombie_rule(self):
+        """Genesis ego should still have zombie detection."""
+        prompt = _build_realist_prompt(
+            [{"action_type": "investigate", "content": "test", "confidence": 0.8}],
+            [],
+            ego_source="genesis_ego_cycle",
+        )
+        assert "Check for zombies" in prompt
+
+    def test_genesis_ego_still_has_domain_boundary(self):
+        """Genesis ego should still have domain boundary rule."""
+        prompt = _build_realist_prompt(
+            [{"action_type": "investigate", "content": "test", "confidence": 0.8}],
+            [],
+            ego_source="genesis_ego_cycle",
+        )
+        assert "Domain boundary" in prompt

--- a/tests/ego/test_user_context.py
+++ b/tests/ego/test_user_context.py
@@ -90,7 +90,15 @@ async def db():
                 rank            INTEGER,
                 execution_plan  TEXT,
                 recurring       INTEGER DEFAULT 0,
-                memory_basis    TEXT DEFAULT ''
+                memory_basis    TEXT DEFAULT '',
+                realist_verdict  TEXT,
+                realist_reasoning TEXT,
+                ego_source       TEXT,
+                goal_id          TEXT,
+                content_hash     TEXT,
+                original_content TEXT,
+                content_size     INTEGER,
+                expected_outputs TEXT
             )
         """)
         await conn.execute("""
@@ -497,8 +505,6 @@ class TestUserEgoContextBuilder:
     ):
         """Goal progress section shows executed proposals grouped by goal."""
         await db.execute(TABLES["user_goals"])
-        # Fixture creates ego_proposals inline without goal_id — add the column
-        await db.execute("ALTER TABLE ego_proposals ADD COLUMN goal_id TEXT")
         await db.execute(
             "INSERT INTO user_goals "
             "(id, title, category, priority, status, confidence, created_at, updated_at) "


### PR DESCRIPTION
## Summary

Fixes three interconnected ego regressions that degraded the dual-ego architecture into a single-ego system:

- **Genesis ego silent since May 30**: PR #504 re-enabled the realist gate, which killed all genesis ego proposals via Rule #1 ("read operations are not proposals"). Genesis ego has never coexisted with the realist successfully.
- **User ego leaking into infrastructure domain**: No code-level enforcement prevented user ego from proposing on infrastructure. 8+ infrastructure proposals found in DB from user ego.
- **10 pending proposals accumulating**: Most were notifications trapped in the proposal pipeline, plus infrastructure proposals that shouldn't have been user ego's.

### Architecture Changes

**Information separation (Phase 1)**: Each ego now sees only its own proposals in history and board sections. `_USER_WORLD_CATEGORIES` expanded to exclude career/content/goal observations from genesis ego.

**Domain-aware realist (Phase 3)**: Rule #1 removed for genesis ego — its investigate-and-dispatch pattern is legitimate. User ego gets new domain rules (Rule #7). All genesis ego realist rejections create redirect observations.

**Cross-ego boundary enforcement (Phase 2)**: User ego infrastructure proposals redirected as observations for genesis ego (3-day TTL, deduped). Prefix-based category matching catches LLM variants.

**Proposal accumulation cap (Phase 4)**: `max_pending_proposals` config (default 15). 5-day auto-table for unranked proposals.

**Signal threshold revision (Phase 5)**: Genesis ego prompt lowered from "metric BREAKING is news" to "investigate unresolved items, then decide."

**Philosophy document**: `docs/ego-philosophy.md` — defines the dual-ego architecture as spec.

### Code Review Fixes

- Stale realist redirect trigger strings (dead code path after Rule #1 refactor)
- Missing error isolation in `_enforce_user_domain_boundary`
- Urgency "normal" → priority "medium" mapping mismatch
- Genesis ego allowlist expanded to match user ego blocklist

## Test plan

- [x] 705 ego tests passing (49 new, 656 pre-existing)
- [x] `tests/ego/test_context_separation.py` — 21 tests for ego_source isolation
- [x] `tests/ego/test_domain_boundary.py` — 23 tests for domain enforcement
- [x] `tests/ego/test_realist.py` — 5 new tests for domain-aware realist
- [x] Lint clean (`ruff check` passes)
- [ ] CI passing
- [ ] Monitor 3 genesis ego cycles post-deploy for proposal generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)