### PR TITLE
feat(voice): S2S session rewrite + optimizations

### DIFF
--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -144,8 +144,8 @@ class GenesisBridge:
     async def _web_search(self, query: str) -> str:
         """Handle web_search tool call — quick factual lookup."""
         try:
-            from genesis.mcp.health.web_tools import web_search
-            result = await web_search(query, max_results=3)
+            from genesis.mcp.health.web_tools import _impl_web_search
+            result = await _impl_web_search(query, max_results=3)
             search_results = result.get("results", [])
             if search_results:
                 snippets = [

--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -32,17 +32,18 @@ TOOL_DECLARATIONS = [
         "type": "function",
         "name": "ask_genesis",
         "description": (
-            "Ask the Genesis backend for memory recall, knowledge lookup, "
-            "task dispatch, or any reasoning that requires the user's personal "
-            "context. Genesis will figure out what tools and capabilities to "
-            "use internally."
+            "REQUIRED for any question about: conversations, past events, "
+            "what we discussed, what we worked on, memories, personal context, "
+            "projects, tasks, or anything the user has told you before. "
+            "You do NOT have this information yourself — you MUST call this "
+            "tool to access the user's history. Genesis has full memory."
         ),
         "parameters": {
             "type": "object",
             "properties": {
                 "query": {
                     "type": "string",
-                    "description": "What to ask Genesis",
+                    "description": "The user's question, rephrased as a query",
                 },
             },
             "required": ["query"],
@@ -52,9 +53,10 @@ TOOL_DECLARATIONS = [
         "type": "function",
         "name": "web_search",
         "description": (
-            "Quick web search for current facts like weather, news, scores, "
-            "stock prices. Use for simple factual lookups that don't need "
-            "Genesis's memory or knowledge base."
+            "REQUIRED for any question about: current events, weather, news, "
+            "scores, stock prices, real-time facts, or anything that changes "
+            "over time. Also use when the user explicitly asks you to search. "
+            "You do NOT have current information yourself — call this tool."
         ),
         "parameters": {
             "type": "object",

--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -147,7 +147,7 @@ class GenesisBridge:
         """Handle web_search tool call — quick factual lookup."""
         try:
             from genesis.mcp.health.web_tools import _impl_web_search
-            result = await _impl_web_search(query, max_results=3)
+            result = await _impl_web_search(query, backend="brave", max_results=3)
             search_results = result.get("results", [])
             if search_results:
                 snippets = [

--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -72,19 +72,25 @@ TOOL_DECLARATIONS = [
 # System instructions for the S2S model
 SYSTEM_INSTRUCTIONS = """\
 You are Genesis, a cognitive AI partner, speaking through a voice interface.
-You remember the user's history, projects, and preferences through your tools.
+You have two tools. Use them.
 
-Rules:
-- Be concise. Spoken responses should be 1-3 sentences unless asked for detail.
-- Never use markdown. Speak naturally, like a knowledgeable colleague.
-- When the user asks about their past work, memories, or personal context: \
-call ask_genesis.
-- When the user asks about current events, weather, or real-time facts: \
-call web_search.
-- For general knowledge: answer directly, no tool call needed.
-- If a request would take time, say you'll look into it.
+TOOL RULES (important — follow these strictly):
+- "what did we do / work on / discuss" → ALWAYS call ask_genesis. Never guess.
+- "search / look up / what's the weather / news" → ALWAYS call web_search.
+- "can you search the web" or similar capability questions → call web_search \
+with a relevant query to demonstrate the capability.
+- Questions about the user's personal context, projects, history → call ask_genesis.
+- General knowledge you're confident about → answer directly, no tool call.
+- When in doubt between answering directly and calling a tool → call the tool. \
+Better to be thorough than to guess wrong.
 
-{essential_knowledge}
+VOICE RULES:
+- Keep responses to 1-2 sentences. Brevity is critical — every extra second \
+of speech is a second the user waits.
+- Never use markdown, bullet points, or formatting. Speak naturally.
+- Don't narrate what you're doing. Just do it and report the result.
+
+{voice_context}
 """
 
 
@@ -156,11 +162,47 @@ class GenesisBridge:
         return json.dumps({"error": "Web search unavailable"})
 
     def get_system_prompt(self) -> str:
-        """Build the system prompt with essential knowledge."""
-        ek = ""
+        """Build the system prompt with curated voice context.
+
+        Extracts only the Active Context section from essential knowledge —
+        the rest (wing counts, conversation pivots, ego proposals) is system
+        telemetry that wastes tokens and confuses the voice model.
+        """
+        voice_ctx = ""
         if _ESSENTIAL_KNOWLEDGE_PATH.exists():
-            ek = _ESSENTIAL_KNOWLEDGE_PATH.read_text()[:2000]
+            voice_ctx = _extract_voice_context(
+                _ESSENTIAL_KNOWLEDGE_PATH.read_text(),
+            )
 
         return SYSTEM_INSTRUCTIONS.format(
-            essential_knowledge=f"\nCurrent context:\n{ek}" if ek else "",
+            voice_context=f"\nWhat the user has been working on recently:\n{voice_ctx}"
+            if voice_ctx else "",
         )
+
+
+def _extract_voice_context(ek_text: str, max_chars: int = 500) -> str:
+    """Extract the Active Context section from essential knowledge.
+
+    Strips system telemetry (wing counts, conversation pivots, ego
+    proposals, observation IDs) — keep only plain-language project context.
+    """
+    lines = ek_text.split("\n")
+    in_active_context = False
+    context_lines = []
+
+    for line in lines:
+        # Start collecting at "Active Context"
+        if "### Active Context" in line:
+            in_active_context = True
+            continue
+        # Stop at the next section header
+        if in_active_context and line.startswith("### "):
+            break
+        if in_active_context and line.strip():
+            # Strip leading "- " for cleaner voice context
+            clean = line.strip().lstrip("- ")
+            if clean:
+                context_lines.append(clean)
+
+    result = ". ".join(context_lines)
+    return result[:max_chars] if result else ""

--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -87,8 +87,7 @@ with a relevant query to demonstrate the capability.
 Better to be thorough than to guess wrong.
 
 VOICE RULES:
-- Keep responses to 1-2 sentences. Brevity is critical — every extra second \
-of speech is a second the user waits.
+- Respond naturally.
 - Never use markdown, bullet points, or formatting. Speak naturally.
 - Don't narrate what you're doing. Just do it and report the result.
 

--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -111,7 +111,7 @@ class GenesisBridge:
         self._voice_handler = voice_handler
 
     async def handle_tool_call(
-        self, name: str, arguments: str,
+        self, name: str, arguments: str, *, satellite_id: str = "s2s-default",
     ) -> str:
         """Dispatch a tool call and return the result as JSON string."""
         try:
@@ -120,26 +120,46 @@ class GenesisBridge:
             return json.dumps({"error": f"Invalid arguments: {arguments}"})
 
         if name == "ask_genesis":
-            return await self._ask_genesis(args.get("query", ""))
+            return await self._ask_genesis(
+                args.get("query", ""), satellite_id=satellite_id,
+            )
         if name == "web_search":
             return await self._web_search(args.get("query", ""))
 
         return json.dumps({"error": f"Unknown tool: {name}"})
 
-    async def _ask_genesis(self, query: str) -> str:
-        """Delegate to VoiceConversationHandler — same cognitive path as Phase 1."""
+    async def _ask_genesis(
+        self, query: str, *, satellite_id: str = "s2s-default",
+    ) -> str:
+        """Recall memories and return raw snippets for S2S synthesis.
+
+        Uses raw_snippets=True to skip the Groq LLM call — GPT-Realtime
+        handles synthesis from the raw memory snippets, saving ~2s latency.
+        Falls back to the full LLM path if raw recall fails.
+        """
         if not self._voice_handler:
             return json.dumps({"answer": "Genesis voice handler not available."})
 
+        session_id = f"s2s-{satellite_id}"
         try:
-            # Use a stable session ID for S2S tool calls so context accumulates
             response = await self._voice_handler.handle(
                 transcript=query,
-                session_id="s2s-tool-bridge",
+                session_id=session_id,
+                raw_snippets=True,
             )
             return json.dumps({"answer": response})
         except Exception:
-            logger.exception("ask_genesis tool call failed")
+            logger.exception("ask_genesis raw recall failed, trying full path")
+
+        # Fallback: full LLM path (Groq synthesis)
+        try:
+            response = await self._voice_handler.handle(
+                transcript=query,
+                session_id=session_id,
+            )
+            return json.dumps({"answer": response})
+        except Exception:
+            logger.exception("ask_genesis full path also failed")
             return json.dumps({"error": "Genesis processing failed"})
 
     async def _web_search(self, query: str) -> str:

--- a/src/genesis/channels/voice/handler.py
+++ b/src/genesis/channels/voice/handler.py
@@ -60,23 +60,34 @@ class VoiceConversationHandler:
     def session_manager(self) -> VoiceSessionManager:
         return self._sessions
 
-    async def handle(self, transcript: str, session_id: str) -> str:
+    async def handle(
+        self, transcript: str, session_id: str, *, raw_snippets: bool = False,
+    ) -> str:
         """Process a voice transcript and return a spoken response.
 
+        Args:
+            transcript: The user's spoken text.
+            session_id: Voice session identifier.
+            raw_snippets: If True, return formatted memory snippets directly
+                without calling the LLM router. Used by S2S pipeline where
+                GPT-Realtime handles synthesis, saving ~2s of Groq LLM latency.
+
+        Steps (full path):
         1. Get/create session
         2. Recall relevant memories
         3. Assemble context (essential knowledge + memories + buffer)
         4. Call router with voice-optimized system prompt
         5. Store turn in buffer
         6. Return sanitized response
+
+        Steps (raw_snippets path):
+        1. Recall relevant memories
+        2. Return formatted snippets (skip LLM, session, context assembly)
         """
         if not transcript.strip():
             return "I didn't catch that. Could you say that again?"
 
-        # 1. Session — touch to reset sustain timer
-        await self._sessions.get_or_create(session_id)
-
-        # 2. Memory recall (best-effort — don't fail the whole request)
+        # Memory recall (best-effort — don't fail the whole request)
         memories_text = ""
         try:
             results = await self._retriever.recall(transcript, limit=5, rerank=False)
@@ -94,7 +105,16 @@ class VoiceConversationHandler:
                 session_id[:12], exc_info=True,
             )
 
-        # 3. Assemble context
+        # Raw snippets path — return memories directly for S2S synthesis
+        if raw_snippets:
+            return memories_text or "No relevant memories found for this query."
+
+        # Full path: session + context assembly + LLM call
+
+        # 1. Session — touch to reset sustain timer
+        await self._sessions.get_or_create(session_id)
+
+        # 2. Assemble context
         essential = ""
         try:
             if _ESSENTIAL_KNOWLEDGE_PATH.exists():
@@ -113,7 +133,7 @@ class VoiceConversationHandler:
         context_block = "\n\n".join(context_parts) if context_parts else ""
         system_prompt = _VOICE_SYSTEM_PROMPT.format(context=context_block)
 
-        # 4. Build messages (system + buffer + current transcript)
+        # 3. Build messages (system + buffer + current transcript)
         messages: list[dict[str, str]] = [
             {"role": "system", "content": system_prompt},
         ]
@@ -122,7 +142,7 @@ class VoiceConversationHandler:
             messages.extend(buffer)
         messages.append({"role": "user", "content": transcript})
 
-        # 5. Call router
+        # 4. Call router
         try:
             result = await self._router.route_call(
                 call_site_id=_VOICE_CALL_SITE,
@@ -141,9 +161,9 @@ class VoiceConversationHandler:
             )
             return "Something went wrong on my end. Try again."
 
-        # 6. Store turns in buffer
+        # 5. Store turns in buffer
         await self._sessions.add_turn(session_id, "user", transcript)
         await self._sessions.add_turn(session_id, "assistant", response)
 
-        # 7. Sanitize for speech (strip any markdown the LLM sneaks in)
+        # 6. Sanitize for speech (strip any markdown the LLM sneaks in)
         return sanitize_for_speech(response)

--- a/src/genesis/channels/voice/handler.py
+++ b/src/genesis/channels/voice/handler.py
@@ -34,7 +34,7 @@ provided, use them — don't say "this is our first conversation" unless
 the memories section is truly empty.
 
 Voice rules:
-- Be concise. 1-2 sentences unless the user asks for detail.
+- Respond naturally.
 - Never use markdown formatting. Speak naturally.
 - If you don't know something, say so briefly.
 

--- a/src/genesis/channels/voice/handler.py
+++ b/src/genesis/channels/voice/handler.py
@@ -24,15 +24,19 @@ _VOICE_CALL_SITE = "voice_conversation"
 _ESSENTIAL_KNOWLEDGE_PATH = Path.home() / ".genesis" / "essential_knowledge.md"
 
 _VOICE_SYSTEM_PROMPT = """\
-You are Genesis, a cognitive AI partner, speaking through a voice interface.
-You have access to recalled memories and knowledge provided below as context.
+You are Genesis, a cognitive AI partner. You are responding to a voice query.
+You have full memory across ALL channels — Telegram, dashboard, voice, and
+background sessions. The recalled memories below come from your complete
+history with the user, not just voice conversations.
+
+Answer the user's question using the recalled memories. If memories are
+provided, use them — don't say "this is our first conversation" unless
+the memories section is truly empty.
 
 Voice rules:
-- Be concise. Spoken responses should be 1-3 sentences unless the user asks for detail.
-- Never use markdown formatting — no bullets, headers, code blocks, or URLs.
-- Speak naturally, as a knowledgeable colleague would.
+- Be concise. 1-2 sentences unless the user asks for detail.
+- Never use markdown formatting. Speak naturally.
 - If you don't know something, say so briefly.
-- For complex requests that would take time, say you'll look into it.
 
 {context}
 """

--- a/src/genesis/channels/voice/s2s_session.py
+++ b/src/genesis/channels/voice/s2s_session.py
@@ -25,6 +25,7 @@ import logging
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 try:
     import openai
@@ -36,6 +37,9 @@ from genesis.channels.voice.genesis_bridge import (
     TOOL_DECLARATIONS,
     GenesisBridge,
 )
+
+if TYPE_CHECKING:
+    from genesis.memory.store import MemoryStore
 
 logger = logging.getLogger(__name__)
 
@@ -80,9 +84,11 @@ class S2SSessionManager:
         self,
         *,
         bridge: GenesisBridge,
+        memory_store: MemoryStore | None = None,
         max_idle_seconds: int = 300,
     ) -> None:
         self._bridge = bridge
+        self._memory_store = memory_store
         self._max_idle_seconds = max_idle_seconds
         self._sessions: dict[str, S2SSession] = {}
         self._client: openai.AsyncOpenAI | None = None
@@ -90,7 +96,8 @@ class S2SSessionManager:
 
     async def start_reaper(self) -> None:
         """Start the idle session reaper (runs every 15s)."""
-        self._reaper_task = asyncio.create_task(
+        from genesis.util.tasks import tracked_task
+        self._reaper_task = tracked_task(
             self._reap_loop(), name="s2s-session-reaper",
         )
 
@@ -255,8 +262,10 @@ class S2SSessionManager:
                             call_id=call_id,
                         )
 
-                        # Dispatch the tool call
-                        result = await self._bridge.handle_tool_call(name, args)
+                        # Dispatch the tool call (pass satellite for session scoping)
+                        result = await self._bridge.handle_tool_call(
+                            name, args, satellite_id=session.satellite_id,
+                        )
 
                         # Send result back to model
                         await conn.conversation.item.create(item={
@@ -292,7 +301,7 @@ class S2SSessionManager:
                 break
 
     async def close(self, satellite_id: str) -> tuple[str, str]:
-        """Close a session and return (input_transcript, output_transcript)."""
+        """Close a session, store transcripts, return (input, output)."""
         session = self._sessions.pop(satellite_id, None)
         if not session:
             return "", ""
@@ -307,6 +316,32 @@ class S2SSessionManager:
                     await conn_mgr.__aexit__(None, None, None)
             except Exception:
                 logger.exception("Error closing S2S session %s", session.session_id)
+
+        # Store conversation transcripts to episodic memory (best-effort)
+        if self._memory_store and (transcripts[0] or transcripts[1]):
+            try:
+                content = (
+                    f"Voice conversation [{satellite_id}]:\n"
+                    f"User: {transcripts[0]}\n"
+                    f"Genesis: {transcripts[1]}"
+                )
+                await self._memory_store.store(
+                    content,
+                    source="voice_s2s",
+                    memory_type="episodic",
+                    tags=["voice", "s2s", "conversation"],
+                    wing="channels",
+                    room="voice",
+                )
+                logger.info(
+                    "Voice transcript stored for session %s (%d turns)",
+                    session.session_id, session.turn_count,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to store voice transcript for %s",
+                    session.session_id, exc_info=True,
+                )
 
         logger.info(
             "S2S session closed: %s (turns=%d)",

--- a/src/genesis/channels/voice/s2s_session.py
+++ b/src/genesis/channels/voice/s2s_session.py
@@ -80,7 +80,7 @@ class S2SSessionManager:
         self,
         *,
         bridge: GenesisBridge,
-        max_idle_seconds: int = 60,
+        max_idle_seconds: int = 300,
     ) -> None:
         self._bridge = bridge
         self._max_idle_seconds = max_idle_seconds

--- a/src/genesis/channels/voice/s2s_session.py
+++ b/src/genesis/channels/voice/s2s_session.py
@@ -6,9 +6,15 @@ streaming with function calling for Genesis backend access.
 
 The session lifecycle:
 1. connect() — open WebSocket, configure tools + system prompt
-2. stream_audio(chunk) — forward PCM frames to the model
-3. receive loop — yields audio response chunks + function calls
-4. close() — tear down WebSocket, store transcriptions
+2. send_turn(audio) — send a complete utterance, collect full response
+3. close() — tear down WebSocket, store transcriptions
+
+Audio flow (VAD disabled — we receive complete utterances from Wyoming):
+  - Send bulk audio via conversation.item.create (input_audio content)
+  - Call response.create() to trigger inference
+  - Listen for response.done to detect function calls or audio output
+  - Function calls: send result, call response.create() again
+  - Audio: collect response.output_audio.delta chunks
 """
 
 from __future__ import annotations
@@ -127,23 +133,18 @@ class S2SSessionManager:
         model = voice_config.s2s_model()
         logger.info("Connecting to %s...", model)
 
-        # The connection context manager is entered manually here
-        # because the session outlives a single request
         conn_mgr = self._client.realtime.connect(model=model)
         conn = await conn_mgr.__aenter__()
         session.connection = conn
         session._conn_mgr = conn_mgr
 
-        # Configure session with tools, system prompt, and audio output
+        # Minimal config — defaults give us audio output (alloy voice),
+        # server VAD, 24kHz PCM. We use conversation.item.create for audio
+        # input so VAD doesn't interfere with bulk utterances from Wyoming.
         system_prompt = self._bridge.get_system_prompt()
-        voice = voice_config.s2s_voice()
         await conn.session.update(session={
-            "modalities": ["text", "audio"],
+            "type": "realtime",
             "instructions": system_prompt,
-            "voice": voice,
-            "input_audio_format": "pcm16",
-            "output_audio_format": "pcm16",
-            "input_audio_transcription": {"model": "gpt-4o-mini-transcribe"},
             "tools": TOOL_DECLARATIONS,
         })
 
@@ -157,34 +158,38 @@ class S2SSessionManager:
                     if event.type == "error":
                         msg = getattr(event, "error", event)
                         logger.error("S2S session config error: %s", msg)
+                        session.connection = None
                         raise RuntimeError(f"S2S session config failed: {msg}")
         except TimeoutError:
             logger.error("S2S session config timed out (10s)")
+            session.connection = None
             raise RuntimeError("S2S session config timed out") from None
 
-    async def send_audio(
+    async def send_turn(
         self, session: S2SSession, audio: bytes, *, input_rate: int = 16000,
     ) -> None:
-        """Send a PCM audio chunk to the S2S model.
+        """Send a complete utterance as a conversation item and trigger a response.
 
-        Resamples from input_rate (default 16kHz, Wyoming) to 24kHz (Realtime API).
+        Uses conversation.item.create with input_audio content — cleaner than
+        input_audio_buffer.append + commit for bulk audio (no VAD conflicts).
+        Resamples from input_rate (default 16kHz from Wyoming) to 24kHz.
         """
         if not session.connection or session._closed:
             return
 
-        # GPT-Realtime expects 24kHz 16-bit mono PCM
+        # Resample 16kHz → 24kHz (Realtime API requires 24kHz PCM)
         if input_rate != 24000:
             from genesis.channels.voice.wyoming_tts import _resample_pcm
             audio = _resample_pcm(audio, input_rate, 24000)
 
         encoded = base64.b64encode(audio).decode()
-        await session.connection.input_audio_buffer.append(audio=encoded)
 
-    async def commit_audio(self, session: S2SSession) -> None:
-        """Signal end of audio input — trigger model response."""
-        if not session.connection or session._closed:
-            return
-        await session.connection.input_audio_buffer.commit()
+        # Send as a conversation item (bypasses input_audio_buffer entirely)
+        await session.connection.conversation.item.create(item={
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_audio", "audio": encoded}],
+        })
         await session.connection.response.create()
 
     async def receive_response(
@@ -197,85 +202,91 @@ class S2SSessionManager:
         back, then continues yielding audio/transcript events from the
         follow-up response.
 
-        GPT-Realtime event sequence for tool calls:
-          Response 1: function_call_arguments.done → response.done (no audio)
-          Response 2: audio.delta (N chunks) → audio_transcript.delta → response.done
-        We must NOT break on Response 1's response.done — the audio comes in Response 2.
+        GPT-Realtime event sequence:
+          Response 1 (function call): response.done with output[0].type == "function_call"
+          → we send function_call_output + response.create()
+          Response 2 (audio): response.output_audio.delta chunks → response.done
         """
         if not session.connection or session._closed:
             return
 
         conn = session.connection
-        # Track whether we dispatched a tool call and are awaiting the audio response
-        awaiting_tool_response = False
 
         async for event in conn:
             etype = event.type
 
-            # Function call completed — dispatch to Genesis
-            if etype == "response.function_call_arguments.done":
-                yield S2SResponseEvent(
-                    type="function_call",
-                    function_name=event.name,
-                    function_args=event.arguments,
-                    call_id=event.call_id,
-                )
-
-                # Dispatch the tool call
-                result = await self._bridge.handle_tool_call(
-                    event.name, event.arguments,
-                )
-
-                # Send result back to the model and request a new response
-                await conn.conversation.item.create(item={
-                    "type": "function_call_output",
-                    "call_id": event.call_id,
-                    "output": result,
-                })
-                await conn.response.create()
-                awaiting_tool_response = True
-
-            # Audio data
-            elif etype == "response.audio.delta":
+            # Audio chunks — the actual spoken response
+            if etype == "response.output_audio.delta":
                 audio_bytes = base64.b64decode(event.delta)
                 yield S2SResponseEvent(type="audio", audio=audio_bytes)
 
-            # Audio transcript (what the model is saying)
-            elif etype in (
-                "response.audio_transcript.delta",
-                "response.output_audio_transcript.delta",
-            ):
+            # Audio transcript (text of what the model is saying)
+            elif etype == "response.output_audio_transcript.delta":
                 session.output_transcript += event.delta
                 yield S2SResponseEvent(type="transcript", text=event.delta)
 
-            # Input transcript (what the user said)
-            elif etype == "input_audio_buffer.speech_started":
-                session.input_transcript = ""
-
-            elif etype in (
-                "conversation.item.input_audio_transcription.completed",
-                "conversation.item.input_audio_transcription.delta",
-            ):
-                if hasattr(event, "transcript"):
+            # Input transcript (what the user said — async via Whisper)
+            elif etype == "conversation.item.input_audio_transcription.completed":
+                if hasattr(event, "transcript") and event.transcript:
                     session.input_transcript += event.transcript
 
-            # Response complete
+            # Response complete — check if it's a function call or final audio
             elif etype == "response.done":
-                if awaiting_tool_response:
-                    # This response.done is for the function-call response.
-                    # The audio response hasn't started yet — keep listening.
-                    logger.debug("Tool-call response done, awaiting audio response")
-                    awaiting_tool_response = False
-                    continue
-                session.turn_count += 1
-                session.last_activity = datetime.now(UTC)
-                session.output_transcript += "\n"  # Turn boundary
-                yield S2SResponseEvent(type="done")
-                break
+                response = getattr(event, "response", None)
+                output_items = getattr(response, "output", []) if response else []
 
-            # Error
+                # Check for function calls in this response
+                func_calls = [
+                    item for item in output_items
+                    if getattr(item, "type", None) == "function_call"
+                ]
+
+                if func_calls:
+                    # Handle each function call
+                    for fc in func_calls:
+                        name = getattr(fc, "name", "")
+                        args = getattr(fc, "arguments", "{}")
+                        call_id = getattr(fc, "call_id", "")
+
+                        yield S2SResponseEvent(
+                            type="function_call",
+                            function_name=name,
+                            function_args=args,
+                            call_id=call_id,
+                        )
+
+                        # Dispatch the tool call
+                        result = await self._bridge.handle_tool_call(name, args)
+
+                        # Send result back to model
+                        await conn.conversation.item.create(item={
+                            "type": "function_call_output",
+                            "call_id": call_id,
+                            "output": result,
+                        })
+
+                    # Trigger the follow-up audio response
+                    await conn.response.create()
+                    # Continue loop — next response will have audio
+                else:
+                    # No function calls — this is the final audio response
+                    session.turn_count += 1
+                    session.last_activity = datetime.now(UTC)
+                    session.output_transcript += "\n"
+                    yield S2SResponseEvent(type="done")
+                    break
+
+            # Error — log but only break on fatal errors
             elif etype == "error":
-                msg = str(getattr(event, "error", event))
+                error = getattr(event, "error", event)
+                code = getattr(error, "code", "")
+                msg = str(error)
+
+                # Non-fatal: stale buffer commit from previous VAD interaction
+                if code == "input_audio_buffer_commit_empty":
+                    logger.debug("Ignoring empty buffer commit error")
+                    continue
+
                 logger.error("S2S error: %s", msg)
                 yield S2SResponseEvent(type="error", text=msg)
                 break

--- a/src/genesis/channels/voice/wyoming_stt.py
+++ b/src/genesis/channels/voice/wyoming_stt.py
@@ -189,6 +189,7 @@ class STTEventHandler(AsyncEventHandler):
             elif not response_audio:
                 logger.warning("S2S response had no audio data")
 
+            logger.info("S2S transcript: %s", transcript[:200] if transcript else "(empty)")
             return transcript or "(no transcription)"
 
         except Exception:

--- a/src/genesis/channels/voice/wyoming_stt.py
+++ b/src/genesis/channels/voice/wyoming_stt.py
@@ -248,7 +248,8 @@ class WyomingSTTServer:
             tts_server=self._tts_server,
         )
 
-        self._task = asyncio.create_task(
+        from genesis.util.tasks import tracked_task
+        self._task = tracked_task(
             self._server.run(handler_factory),
             name="wyoming-stt",
         )

--- a/src/genesis/channels/voice/wyoming_stt.py
+++ b/src/genesis/channels/voice/wyoming_stt.py
@@ -151,9 +151,8 @@ class STTEventHandler(AsyncEventHandler):
             if session.connection is None:
                 await self._s2s_manager.connect(session)
 
-            # Send audio to model (resampled 16kHz → 24kHz internally)
-            await self._s2s_manager.send_audio(session, audio, input_rate=self._rate)
-            await self._s2s_manager.commit_audio(session)
+            # Send complete utterance as conversation item (no VAD conflicts)
+            await self._s2s_manager.send_turn(session, audio, input_rate=self._rate)
 
             # Collect full response — audio AND transcript — before returning.
             # HA's pipeline is sequential: STT → conversation agent → TTS.

--- a/src/genesis/channels/voice/wyoming_tts.py
+++ b/src/genesis/channels/voice/wyoming_tts.py
@@ -205,7 +205,8 @@ class WyomingTTSServer:
             audio_ready=self._audio_ready,
         )
 
-        self._task = asyncio.create_task(
+        from genesis.util.tasks import tracked_task
+        self._task = tracked_task(
             self._server.run(handler_factory),
             name="wyoming-tts",
         )

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -318,6 +318,15 @@ class StandaloneAdapter:
 
             self._s2s_manager = s2s_manager
 
+            # Pre-warm: open WebSocket to GPT-Realtime so the first wake
+            # word doesn't pay the 1.75s connection + config cost.
+            try:
+                session = await s2s_manager.get_or_create("ha-voice-default")
+                await s2s_manager.connect(session)
+                logger.info("S2S session pre-warmed for ha-voice-default")
+            except Exception:
+                logger.warning("S2S pre-warm failed (will connect on first request)")
+
         except Exception:
             logger.exception("Failed to initialize Wyoming voice servers")
 

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -296,8 +296,11 @@ class StandaloneAdapter:
             voice_handler = self._app.config.get("VOICE_HANDLER") if self._app else None
             bridge = GenesisBridge(voice_handler=voice_handler)
 
-            # S2S session manager
-            s2s_manager = S2SSessionManager(bridge=bridge)
+            # S2S session manager (memory_store for transcript persistence)
+            s2s_manager = S2SSessionManager(
+                bridge=bridge,
+                memory_store=self._runtime.memory_store if self._runtime else None,
+            )
             await s2s_manager.start_reaper()
             logger.info(
                 "S2S session manager created (provider=%s, model=%s)",

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -68,7 +68,7 @@ class TestGenesisBridge:
         assert names == {"ask_genesis", "web_search"}
 
     def test_system_prompt_has_placeholders(self):
-        assert "{essential_knowledge}" in SYSTEM_INSTRUCTIONS
+        assert "{voice_context}" in SYSTEM_INSTRUCTIONS
 
     async def test_handle_unknown_tool(self):
         bridge = GenesisBridge()

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -91,9 +91,9 @@ class TestGenesisBridge:
         data = json.loads(result)
         assert "answer" in data  # Returns "handler not available"
 
-    async def test_ask_genesis_delegates_to_handler(self):
+    async def test_ask_genesis_uses_raw_snippets(self):
         handler = AsyncMock()
-        handler.handle = AsyncMock(return_value="Yesterday you worked on voice Phase 1.")
+        handler.handle = AsyncMock(return_value="Recalled memories:\n- voice Phase 1")
 
         bridge = GenesisBridge(voice_handler=handler)
         result = await bridge.handle_tool_call(
@@ -102,7 +102,46 @@ class TestGenesisBridge:
         data = json.loads(result)
         assert "answer" in data
         assert "voice Phase 1" in data["answer"]
-        handler.handle.assert_awaited_once()
+        # Verify raw_snippets=True is passed
+        handler.handle.assert_awaited_once_with(
+            transcript="what did we do yesterday?",
+            session_id="s2s-s2s-default",
+            raw_snippets=True,
+        )
+
+    async def test_ask_genesis_passes_satellite_id(self):
+        handler = AsyncMock()
+        handler.handle = AsyncMock(return_value="memories here")
+
+        bridge = GenesisBridge(voice_handler=handler)
+        result = await bridge.handle_tool_call(
+            "ask_genesis",
+            json.dumps({"query": "test"}),
+            satellite_id="my-satellite",
+        )
+        data = json.loads(result)
+        assert "answer" in data
+        handler.handle.assert_awaited_once_with(
+            transcript="test",
+            session_id="s2s-my-satellite",
+            raw_snippets=True,
+        )
+
+    async def test_ask_genesis_falls_back_on_raw_failure(self):
+        handler = AsyncMock()
+        # First call (raw_snippets=True) fails, second (full path) succeeds
+        handler.handle = AsyncMock(
+            side_effect=[Exception("recall failed"), "Full LLM answer"],
+        )
+
+        bridge = GenesisBridge(voice_handler=handler)
+        result = await bridge.handle_tool_call(
+            "ask_genesis", json.dumps({"query": "test"}),
+        )
+        data = json.loads(result)
+        assert "answer" in data
+        assert data["answer"] == "Full LLM answer"
+        assert handler.handle.await_count == 2
 
     async def test_web_search_import_failure(self):
         bridge = GenesisBridge()
@@ -117,6 +156,62 @@ class TestGenesisBridge:
         prompt = bridge.get_system_prompt()
         assert "Genesis" in prompt
         assert "ask_genesis" in prompt
+
+
+# ─── VoiceConversationHandler tests ─────────────────────────────────────
+
+
+class TestVoiceConversationHandler:
+    async def test_raw_snippets_returns_memories(self):
+        from genesis.channels.voice.handler import VoiceConversationHandler
+
+        retriever = AsyncMock()
+        result_obj = MagicMock()
+        result_obj.content = "Yesterday we worked on voice pipeline."
+        retriever.recall = AsyncMock(return_value=[result_obj])
+
+        router = AsyncMock()
+        handler = VoiceConversationHandler(retriever=retriever, router=router)
+
+        response = await handler.handle("what did we do?", "test-session", raw_snippets=True)
+        assert "voice pipeline" in response
+        # Router should NOT be called in raw_snippets mode
+        router.route_call.assert_not_awaited()
+
+    async def test_raw_snippets_empty_recall(self):
+        from genesis.channels.voice.handler import VoiceConversationHandler
+
+        retriever = AsyncMock()
+        retriever.recall = AsyncMock(return_value=[])
+
+        router = AsyncMock()
+        handler = VoiceConversationHandler(retriever=retriever, router=router)
+
+        response = await handler.handle("what did we do?", "test-session", raw_snippets=True)
+        assert "No relevant memories" in response
+        router.route_call.assert_not_awaited()
+
+    async def test_raw_snippets_recall_failure(self):
+        from genesis.channels.voice.handler import VoiceConversationHandler
+
+        retriever = AsyncMock()
+        retriever.recall = AsyncMock(side_effect=Exception("Qdrant down"))
+
+        router = AsyncMock()
+        handler = VoiceConversationHandler(retriever=retriever, router=router)
+
+        response = await handler.handle("test", "test-session", raw_snippets=True)
+        assert "No relevant memories" in response
+
+    async def test_empty_transcript(self):
+        from genesis.channels.voice.handler import VoiceConversationHandler
+
+        retriever = AsyncMock()
+        router = AsyncMock()
+        handler = VoiceConversationHandler(retriever=retriever, router=router)
+
+        response = await handler.handle("   ", "test-session", raw_snippets=True)
+        assert "didn't catch that" in response
 
 
 # ─── Wyoming TTS server tests ───────────────────────────────────────────
@@ -183,3 +278,57 @@ class TestS2SSessionManager:
         assert inp == "hello"
         assert out == "hi there"
         assert "sat-1" not in mgr._sessions
+
+    async def test_close_stores_transcript(self):
+        from genesis.channels.voice.s2s_session import S2SSessionManager
+
+        store = AsyncMock()
+        store.store = AsyncMock(return_value="mem-123")
+
+        bridge = GenesisBridge()
+        mgr = S2SSessionManager(bridge=bridge, memory_store=store)
+        session = await mgr.get_or_create("sat-1")
+        session.input_transcript = "What did we work on?"
+        session.output_transcript = "We worked on voice pipeline."
+
+        await mgr.close("sat-1")
+
+        store.store.assert_awaited_once()
+        call_kwargs = store.store.call_args
+        content = call_kwargs[0][0]  # first positional arg
+        assert "What did we work on?" in content
+        assert "We worked on voice pipeline." in content
+        assert call_kwargs[1]["source"] == "voice_s2s"
+        assert call_kwargs[1]["wing"] == "channels"
+        assert call_kwargs[1]["room"] == "voice"
+
+    async def test_close_skips_store_when_empty(self):
+        from genesis.channels.voice.s2s_session import S2SSessionManager
+
+        store = AsyncMock()
+        store.store = AsyncMock()
+
+        bridge = GenesisBridge()
+        mgr = S2SSessionManager(bridge=bridge, memory_store=store)
+        await mgr.get_or_create("sat-1")
+        # No transcripts set
+
+        await mgr.close("sat-1")
+        store.store.assert_not_awaited()
+
+    async def test_close_handles_store_failure(self):
+        from genesis.channels.voice.s2s_session import S2SSessionManager
+
+        store = AsyncMock()
+        store.store = AsyncMock(side_effect=Exception("DB error"))
+
+        bridge = GenesisBridge()
+        mgr = S2SSessionManager(bridge=bridge, memory_store=store)
+        session = await mgr.get_or_create("sat-1")
+        session.input_transcript = "hello"
+        session.output_transcript = "hi"
+
+        # Should not raise — store failure is best-effort
+        inp, out = await mgr.close("sat-1")
+        assert inp == "hello"
+        assert out == "hi"


### PR DESCRIPTION
## Summary

Rewrites the S2S voice session manager based on live API testing and research, plus latency and quality optimizations. Includes Phase 3a changes: raw memory recall for latency reduction and transcript storage.

### Phase 2 Optimizations
- **S2S session rewrite**: correct GPT-Realtime GA API usage — `conversation.item.create` for bulk audio (no VAD conflicts), `response.output_audio.delta` event type, function call handling via `response.done` output items, connection cleanup on errors
- **Pre-warm WebSocket**: open GPT-Realtime connection at server startup, saves 1.75s on first wake word. 300s idle timeout (was 60s)
- **Tool use reliability**: stronger tool descriptions ("REQUIRED", "you MUST call this tool") — GPT-Realtime now consistently calls `ask_genesis` for personal context and `web_search` for factual lookups
- **Web search fixed**: import `_impl_web_search` (not the MCP `FunctionTool` wrapper), use Brave backend explicitly for better result quality
- **Cross-channel memory**: voice handler prompt clarifies Genesis has memory across ALL channels, not just voice
- **Voice essential knowledge**: extract only Active Context section from essential_knowledge.md (strip system telemetry, wing counts, conversation pivots), cap at 500 chars
- **Natural responses**: removed artificial brevity constraints ("1-2 sentences"), let model respond naturally

### Phase 3a: Latency + Transcript Storage
- **Raw memory recall for S2S**: skip Groq LLM in ask_genesis path — return raw memory snippets directly to GPT-Realtime for synthesis, saving ~2s per tool call. Falls back to full LLM path on failure.
- **Transcript storage**: store voice conversation transcripts to episodic memory when S2S sessions close (wing=channels, room=voice)
- **Multi-satellite safety**: pass satellite_id through tool call dispatch instead of hardcoded session ID
- **Tracked tasks**: use tracked_task() for Wyoming servers and S2S reaper (proper error propagation)

## Verified E2E

- `ask_genesis("What did we work on today?")` — accurate cross-channel memory recall
- `web_search("current weather")` — Brave search results spoken
- Direct responses (no tool call) for general knowledge
- Pre-warm logs: "S2S session pre-warmed for ha-voice-default"
- Three consecutive voice turns with audio served to speaker

## Test plan

- [x] `pytest tests/test_channels/test_voice_s2s.py -v` — 28/28 pass
- [x] `pytest tests/test_channels/test_voice.py tests/test_voice_delivery.py -v` — 36/36 pass (no regressions)
- [x] `ruff check` — clean
- [x] Architecture review: 7 issues found, all addressed
- [ ] Live E2E after merge: ask_genesis latency reduction, transcript storage verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)