### PR TITLE
feat(ego): notification pipeline + content firewall

### DIFF
--- a/config/outreach.yaml
+++ b/config/outreach.yaml
@@ -16,6 +16,8 @@ channel_preferences:
   approval: telegram
   # Content drafts for user review — routed to Content Review topic.
   content: telegram
+  # Ego notifications — informational, no approval needed. Routed to default topic.
+  notification: telegram
 
 thresholds:
   blocker: 0.0
@@ -27,11 +29,14 @@ thresholds:
   approval: 0.0
   # Content review always delivers — manual review is the quality gate.
   content: 0.0
+  # Ego notifications always deliver — the ego already judged relevance.
+  notification: 0.0
 
 rate_limits:
   max_daily: 5
   surplus_daily: 1
   content_daily: 3
+  notification_daily: 10
 
 morning_report:
   trigger_time: "07:00"

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -526,6 +526,99 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
             exc_info=True,
         )
 
+    # Add 'notification' category for ego notifications routed through the
+    # outreach pipeline without approval gate.  Same rebuild pattern as above.
+    _NOTIFICATION_FRAGMENT = "'content', 'notification'"
+    try:
+        cursor = await db.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='outreach_history'"
+        )
+        row = await cursor.fetchone()
+        if row and _NOTIFICATION_FRAGMENT not in (row[0] or ""):
+            await db.execute("""
+                CREATE TABLE outreach_history_new (
+                    id                  TEXT PRIMARY KEY,
+                    person_id           TEXT,
+                    signal_type         TEXT NOT NULL,
+                    topic               TEXT NOT NULL,
+                    category            TEXT NOT NULL CHECK (category IN (
+                        'blocker', 'alert', 'finding', 'insight', 'opportunity',
+                        'digest', 'surplus', 'approval', 'content', 'notification'
+                    )),
+                    salience_score      REAL NOT NULL,
+                    channel             TEXT NOT NULL,
+                    message_content     TEXT NOT NULL,
+                    drive_alignment     TEXT,
+                    labeled_surplus     INTEGER DEFAULT 0,
+                    content_hash        TEXT,
+                    delivery_id         TEXT,
+                    delivered_at        TEXT,
+                    opened_at           TEXT,
+                    user_response       TEXT,
+                    action_taken        TEXT,
+                    engagement_outcome  TEXT CHECK (engagement_outcome IN (
+                        'useful', 'not_useful', 'ambivalent', 'ignored', NULL
+                    )),
+                    engagement_signal   TEXT,
+                    prediction_error    REAL,
+                    created_at          TEXT NOT NULL
+                )
+            """)
+            await db.execute("""
+                INSERT INTO outreach_history_new
+                    (id, person_id, signal_type, topic, category, salience_score,
+                     channel, message_content, drive_alignment, labeled_surplus,
+                     content_hash, delivery_id, delivered_at, opened_at,
+                     user_response, action_taken, engagement_outcome,
+                     engagement_signal, prediction_error, created_at)
+                SELECT
+                     id, person_id, signal_type, topic, category, salience_score,
+                     channel, message_content, drive_alignment, labeled_surplus,
+                     content_hash, delivery_id, delivered_at, opened_at,
+                     user_response, action_taken, engagement_outcome,
+                     engagement_signal, prediction_error, created_at
+                FROM outreach_history
+            """)
+            await db.execute("DROP TABLE outreach_history")
+            await db.execute(
+                "ALTER TABLE outreach_history_new RENAME TO outreach_history"
+            )
+            await db.execute(
+                "CREATE INDEX IF NOT EXISTS idx_outreach_channel "
+                "ON outreach_history(channel)"
+            )
+            await db.execute(
+                "CREATE INDEX IF NOT EXISTS idx_outreach_category "
+                "ON outreach_history(category)"
+            )
+            await db.execute(
+                "CREATE INDEX IF NOT EXISTS idx_outreach_delivered "
+                "ON outreach_history(delivered_at)"
+            )
+            await db.execute(
+                "CREATE INDEX IF NOT EXISTS idx_outreach_outcome "
+                "ON outreach_history(engagement_outcome)"
+            )
+            await db.execute(
+                "CREATE INDEX IF NOT EXISTS idx_outreach_dedup "
+                "ON outreach_history(signal_type, topic, category, delivered_at)"
+            )
+            await db.execute(
+                "CREATE INDEX IF NOT EXISTS idx_outreach_content_hash "
+                "ON outreach_history(signal_type, category, content_hash, delivered_at)"
+            )
+            await db.execute(
+                "CREATE INDEX IF NOT EXISTS idx_outreach_person "
+                "ON outreach_history(person_id)"
+            )
+            await db.commit()
+            logger.info("outreach_history table rebuilt with 'notification' category")
+    except Exception:
+        logger.error(
+            "outreach_history CHECK constraint migration (notification) failed",
+            exc_info=True,
+        )
+
     # Memory photographic: extraction watermark tracking on cc_sessions
     await _try_alter(db,
         "ALTER TABLE cc_sessions ADD COLUMN last_extracted_at TEXT",

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -671,6 +671,12 @@ class GenesisEgoContextBuilder:
             '      "alternatives": "what else you considered"\n'
             "    }\n"
             "  ],\n"
+            '  "notifications": [\n'
+            "    {\n"
+            '      "content": "what to tell the user (informational, no approval needed)",\n'
+            '      "urgency": "low|normal|high"\n'
+            "    }\n"
+            "  ],\n"
             '  "escalations": [\n'
             "    {\n"
             '      "content": "issue description the user ego should see",\n'

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1526,13 +1526,23 @@ class EgoSession:
             content = notif.get("content", "").strip()
             if not content:
                 continue
+            # Cap content length to prevent runaway LLM output from
+            # flooding the outreach pipeline with megabyte-sized payloads.
+            if len(content) > 2000:
+                content = content[:2000]
+
+            # Map ego urgency to salience score so governance thresholds
+            # can differentiate. NOTIFICATION threshold is 0.0 by default
+            # so all pass, but this preserves the signal for future tuning.
+            urgency = notif.get("urgency", "normal")
+            salience = {"low": 0.3, "normal": 0.6, "high": 0.9}.get(urgency, 0.6)
 
             try:
                 request = OutreachRequest(
                     category=OutreachCategory.NOTIFICATION,
                     topic=content[:100],
                     context=content,
-                    salience_score=0.5,
+                    salience_score=salience,
                     signal_type="ego_notification",
                     channel="telegram",
                 )
@@ -1957,8 +1967,10 @@ def _normalize_to_infra(category: str) -> bool:
 # -- Content dispatch detection + firewall rules ----------------------------
 
 _CONTENT_DISPATCH_KEYWORDS = frozenset({
-    "publish", "article", "medium", "content", "post", "draft", "blog",
+    "publish", "article", "medium", "post", "draft", "blog",
 })
+# "content" omitted — too broad for substring matching (matches
+# "content_hash", "content error rate"). Caught by action_type check.
 
 
 def _is_content_dispatch(prop: dict) -> bool:

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1271,6 +1271,11 @@ class EgoSession:
             if not proposal_id or not prompt:
                 continue
 
+            # Append content firewall rules to ego-authored dispatch prompt.
+            # The ego writes the brief prompt directly — this safety net
+            # catches information that slips through the ego's own judgment.
+            prompt = f"{prompt}\n\n{_CONTENT_FIREWALL_RULES}"
+
             # Map profile and model from brief
             profile = brief.get("profile", "observe")
             if profile not in VALID_PROFILES:
@@ -1890,42 +1895,49 @@ class EgoSession:
             except (ValueError, TypeError):
                 pass
 
-        # World model context — each section degrades independently
-        try:
-            from genesis.db.crud import user_goals
+        # World model context — ONLY for non-content dispatches.
+        # Content dispatches get minimal context to prevent information
+        # leakage (goals, contacts, events are leak vectors for published
+        # content). The proposal content + exec plan + rationale is sufficient.
+        if not _is_content_dispatch(prop):
+            try:
+                from genesis.db.crud import user_goals
 
-            goals = await user_goals.list_active(self._db)
-            if goals:
-                goal_lines = [
-                    f"- {g['title']} ({g['category']}, {g['priority']})" for g in goals[:5]
-                ]
-                parts.append("\n\nUser's active goals:\n" + "\n".join(goal_lines))
-        except Exception:
-            pass
+                goals = await user_goals.list_active(self._db)
+                if goals:
+                    goal_lines = [
+                        f"- {g['title']} ({g['category']}, {g['priority']})" for g in goals[:5]
+                    ]
+                    parts.append("\n\nUser's active goals:\n" + "\n".join(goal_lines))
+            except Exception:
+                pass
 
-        try:
-            from genesis.db.crud import user_contacts
+            try:
+                from genesis.db.crud import user_contacts
 
-            contacts = await user_contacts.recently_active(self._db, days=14)
-            if contacts:
-                contact_lines = [
-                    f"- {c['name']} ({c.get('relationship', 'contact')})" for c in contacts[:5]
-                ]
-                parts.append("\nRelevant contacts:\n" + "\n".join(contact_lines))
-        except Exception:
-            pass
+                contacts = await user_contacts.recently_active(self._db, days=14)
+                if contacts:
+                    contact_lines = [
+                        f"- {c['name']} ({c.get('relationship', 'contact')})" for c in contacts[:5]
+                    ]
+                    parts.append("\nRelevant contacts:\n" + "\n".join(contact_lines))
+            except Exception:
+                pass
 
-        try:
-            from genesis.db.crud import memory_events
+            try:
+                from genesis.db.crud import memory_events
 
-            events = await memory_events.upcoming_user_events(self._db, days=14)
-            if events:
-                event_lines = [
-                    f"- {e['object']} ({e.get('event_date', 'TBD')})" for e in events[:5]
-                ]
-                parts.append("\nUpcoming events:\n" + "\n".join(event_lines))
-        except Exception:
-            pass
+                events = await memory_events.upcoming_user_events(self._db, days=14)
+                if events:
+                    event_lines = [
+                        f"- {e['object']} ({e.get('event_date', 'TBD')})" for e in events[:5]
+                    ]
+                    parts.append("\nUpcoming events:\n" + "\n".join(event_lines))
+            except Exception:
+                pass
+
+        # Append content firewall rules to all dispatches as safety net
+        parts.append(f"\n\n{_CONTENT_FIREWALL_RULES}")
 
         return "\n".join(parts)
 
@@ -1966,6 +1978,40 @@ def _normalize_to_infra(category: str) -> bool:
         return False
     cat_lower = category.lower()
     return any(cat_lower.startswith(prefix) for prefix in _USER_EGO_INFRA_PREFIXES)
+
+
+# -- Content dispatch detection + firewall rules ----------------------------
+
+_CONTENT_DISPATCH_KEYWORDS = frozenset({
+    "publish", "article", "medium", "content", "post", "draft", "blog",
+})
+
+
+def _is_content_dispatch(prop: dict) -> bool:
+    """Check if a proposal is a content/publishing dispatch.
+
+    Used to apply information minimization at the dispatch boundary —
+    content dispatches should NOT receive world model context (goals,
+    contacts, events) that could leak into published output.
+    """
+    action_type = (prop.get("action_type") or "").lower()
+    if action_type in ("outreach", "dispatch", "content", "publish"):
+        return True
+    content = (prop.get("content") or "").lower()
+    return any(kw in content for kw in _CONTENT_DISPATCH_KEYWORDS)
+
+
+_CONTENT_FIREWALL_RULES = """
+## Content Firewall (externally-shared content only)
+Principle: release no more information than the task requires.
+- Use generic descriptions for private events ("a recent panel", not
+  the event name)
+- Use roles for people ("an engineer", not personal names)
+- Never reference active job search, applications, or career workflows
+- Never include calendar details, internal codenames, or infrastructure
+- Biographical detail: only if directly relevant to the thesis
+- When in doubt, omit. The user reviews before publish.
+""".strip()
 
 
 # -- Realist prompt & parser -----------------------------------------------

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -602,6 +602,11 @@ class EgoSession:
                         communication_decision=comm_decision,
                     )
 
+            # 9a. Process notifications (informational, no approval gate)
+            notifications = parsed.get("notifications", [])
+            if isinstance(notifications, list) and notifications:
+                await self._process_notifications(notifications)
+
             # 9b. Process tabled/withdrawn proposal IDs
             tabled_ids = parsed.get("tabled", [])
             if isinstance(tabled_ids, list):
@@ -1488,6 +1493,58 @@ class EgoSession:
                 len(escalations),
                 created,
                 deduped,
+            )
+
+    async def _process_notifications(self, notifications: list[dict]) -> None:
+        """Submit ego notifications to the outreach pipeline.
+
+        Notifications are informational messages that don't need user approval.
+        They route through the outreach pipeline with NOTIFICATION category,
+        subject to governance (dedup, rate limit, quiet hours) but exempt from
+        salience threshold and engagement throttle.
+
+        Fire-and-forget: errors are logged but never block the ego cycle.
+        """
+        if self._outreach_pipeline is None:
+            logger.warning(
+                "OutreachPipeline not available — skipping %d notification(s)",
+                len(notifications),
+            )
+            return
+
+        from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+        submitted = 0
+        for notif in notifications:
+            if not isinstance(notif, dict):
+                continue
+            content = notif.get("content", "").strip()
+            if not content:
+                continue
+
+            try:
+                request = OutreachRequest(
+                    category=OutreachCategory.NOTIFICATION,
+                    topic=content[:100],
+                    context=content,
+                    salience_score=0.5,
+                    signal_type="ego_notification",
+                    channel="telegram",
+                )
+                await self._outreach_pipeline.submit(request)
+                submitted += 1
+            except Exception:
+                logger.warning(
+                    "Failed to submit ego notification: %s",
+                    content[:80],
+                    exc_info=True,
+                )
+
+        if submitted:
+            logger.info(
+                "Submitted %d/%d ego notification(s) to outreach pipeline",
+                submitted,
+                len(notifications),
             )
 
     # -- Deferred intentions ------------------------------------------------

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1731,32 +1731,6 @@ class EgoSession:
                         exc_info=True,
                     )
 
-            # Self-notification shortcut: outreach proposals whose execution
-            # plan indicates a zero-cost Telegram message to the user were
-            # already delivered via the proposal digest.  Auto-complete them
-            # instead of spawning an expensive CC session.
-            exec_plan = (prop.get("execution_plan") or "").lower()
-            if (
-                prop.get("action_type") == "outreach"
-                and "telegram" in exec_plan
-                and ("$0" in exec_plan or "~$0" in exec_plan)
-            ):
-                cursor = await self._db.execute(
-                    "UPDATE ego_proposals SET status = 'executed', "
-                    "user_response = 'auto-completed: delivered via proposal digest' "
-                    "WHERE id = ? AND status = 'approved'",
-                    (prop["id"],),
-                )
-                await self._db.commit()
-                if cursor.rowcount > 0:
-                    dispatched.append(prop["id"])
-                    logger.info(
-                        "Proposal %s auto-completed (self-notification — "
-                        "already delivered via digest)",
-                        prop["id"],
-                    )
-                continue
-
             # Content integrity check — detect degradation since creation.
             # Log-only for now; tighten to a gate if we see real degradation.
             stored_hash = prop.get("content_hash")

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -116,6 +116,7 @@ class EgoSession:
         self._direct_session_runner = direct_session_runner
         self._autonomous_dispatcher = None
         self._proposal_gate = None
+        self._outreach_pipeline = None
         self._mcp_config_path = mcp_config_path
         self._call_site = call_site or _DEFAULT_CALL_SITE
         self._focus_summary_key = focus_summary_key or _DEFAULT_FOCUS_SUMMARY_KEY
@@ -149,6 +150,14 @@ class EgoSession:
         exceed the current autonomy level for their action domain.
         """
         self._proposal_gate = gate
+
+    def set_outreach_pipeline(self, pipeline: object) -> None:
+        """Inject the OutreachPipeline for ego notification delivery.
+
+        Late-binding because the outreach pipeline may not be available at
+        EgoSession construction time (same pattern as autonomous_dispatcher).
+        """
+        self._outreach_pipeline = pipeline
 
     # -- Public API --------------------------------------------------------
 

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -1465,6 +1465,12 @@ class UserEgoContextBuilder:
             '      "memory_basis": "non-obvious memory that informed this (optional)"\n'
             "    }\n"
             "  ],\n"
+            '  "notifications": [\n'
+            "    {\n"
+            '      "content": "what to tell the user (informational, no approval needed)",\n'
+            '      "urgency": "low|normal|high"\n'
+            "    }\n"
+            "  ],\n"
             '  "focus_summary": "one-line: what you are focused on for the user",\n'
             '  "resolved_follow_ups": [{"id": "follow_up_id", "resolution": "why resolved"}],\n'
             '  "resolved_directives": [{"id": "directive_id", "resolution": "what you decided"}],\n'

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -117,6 +117,24 @@ proposals. Most of your work routes through escalations to the user ego,
 not direct Telegram delivery. Use `"send_digest"` only when proposals need
 direct user attention that shouldn't go through the user ego filter.
 
+### Notifications vs Proposals
+
+- **Proposals**: actions needing user approval (investigations, maintenance,
+  config changes)
+- **Notifications**: informational messages, no approval needed (status
+  updates, "maintenance complete", "issue resolved", health summaries)
+- Rule of thumb: if it costs nothing and needs no decision, use a
+  notification. If it dispatches work or changes state, use a proposal.
+
+Notifications route through the outreach pipeline with dedup, rate
+limiting, and quiet hours — but no approval gate.
+
+### Information Boundary
+
+Your execution_brief `prompt` is the boundary between your internal
+world and the executing session's external world. Apply least privilege:
+only include information the session needs to complete its task.
+
 ## When to Escalate
 
 Add an escalation when:
@@ -251,6 +269,12 @@ Use MCP tools first, then output valid JSON:
   "tabled": ["proposal_id_to_table"],
   "withdrawn": ["proposal_id_to_withdraw"],
   "unboarded": ["proposal_id_to_remove_from_board_but_keep_pending"],
+  "notifications": [
+    {
+      "content": "What to tell the user (informational, no approval needed)",
+      "urgency": "low|normal|high"
+    }
+  ],
   "execution_briefs": [
     {
       "proposal_id": "approved_proposal_id",

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -257,6 +257,36 @@ To dispatch an approved proposal, output an `execution_briefs` entry:
 - Your dispatch prompt IS the session's only instruction. Be specific
   about the desired outcome, not just the topic.
 
+### Notifications vs Proposals
+
+- **Proposals**: actions needing user approval (dispatches, publishing,
+  outreach actions, config changes)
+- **Notifications**: informational messages, no approval needed (status
+  updates, reminders, "X is ready", completed task reports)
+- Rule of thumb: if it costs nothing and needs no decision, use a
+  notification. If it dispatches work or changes state, use a proposal.
+
+Notifications route through the outreach pipeline with dedup, rate
+limiting, and quiet hours — but no approval gate.
+
+### Information Boundary
+
+Your execution_brief `prompt` is the boundary between your internal
+world and the executing session's external world. Apply least privilege:
+
+Before writing a dispatch prompt, STOP and think:
+- What does this session NEED to know to complete its task?
+- What does it NOT need to know?
+- Am I including context that could leak into published output?
+
+Content/publish dispatches: provide the topic, angle, and any specific
+technical points. Do NOT include private events, company names, contact
+names, calendar details, or job search information unless ESSENTIAL to
+the article's thesis.
+
+Investigation/maintenance dispatches: richer context is appropriate
+since output stays internal.
+
 **Verify before assuming broken.** If your proposal downgrades because
 you believe something is broken, VERIFY in-cycle using your MCP tools.
 Observations age. Failures get fixed. Check `observation_query` for
@@ -484,6 +514,12 @@ Use MCP tools to verify beliefs first, then output valid JSON:
   "tabled": ["proposal_id_to_table"],
   "withdrawn": ["proposal_id_to_withdraw"],
   "unboarded": ["proposal_id_to_remove_from_board_but_keep_pending"],
+  "notifications": [
+    {
+      "content": "What to tell the user (informational, no approval needed)",
+      "urgency": "low|normal|high"
+    }
+  ],
   "execution_briefs": [
     {
       "proposal_id": "approved_proposal_id",

--- a/src/genesis/outreach/config.py
+++ b/src/genesis/outreach/config.py
@@ -26,6 +26,7 @@ class OutreachConfig:
     max_daily: int
     surplus_daily: int
     content_daily: int
+    notification_daily: int
     morning_report_time: str
     # morning_report_timezone removed — uses genesis.env.user_timezone()
     engagement_timeout_hours: int
@@ -57,6 +58,7 @@ _DEFAULTS = OutreachConfig(
     max_daily=5,
     surplus_daily=1,
     content_daily=3,
+    notification_daily=10,
     morning_report_time="07:00",
     engagement_timeout_hours=24,
     engagement_poll_minutes=60,
@@ -107,7 +109,7 @@ def validate_preferences(preferences: dict) -> list[str]:
 
     if "rate_limits" in preferences:
         rl = preferences["rate_limits"]
-        for field in ("max_daily", "surplus_daily", "content_daily"):
+        for field in ("max_daily", "surplus_daily", "content_daily", "notification_daily"):
             val = rl.get(field)
             if val is not None:
                 try:
@@ -136,6 +138,7 @@ def save_outreach_config(config: OutreachConfig, path: Path | None = None) -> No
             "max_daily": config.max_daily,
             "surplus_daily": config.surplus_daily,
             "content_daily": config.content_daily,
+            "notification_daily": config.notification_daily,
         },
         "morning_report": {
             "trigger_time": config.morning_report_time,
@@ -187,6 +190,7 @@ def load_outreach_config(path: Path | None = None) -> OutreachConfig:
         max_daily=raw.get("rate_limits", {}).get("max_daily", 5),
         surplus_daily=raw.get("rate_limits", {}).get("surplus_daily", 1),
         content_daily=raw.get("rate_limits", {}).get("content_daily", 3),
+        notification_daily=raw.get("rate_limits", {}).get("notification_daily", 10),
         morning_report_time=raw.get("morning_report", {}).get("trigger_time", "07:00"),
         engagement_timeout_hours=raw.get("engagement", {}).get("timeout_hours", 24),
         engagement_poll_minutes=raw.get("engagement", {}).get("poll_interval_minutes", 60),

--- a/src/genesis/outreach/governance.py
+++ b/src/genesis/outreach/governance.py
@@ -42,6 +42,7 @@ _DEDUP_WINDOWS: dict[str, int] = {
     "surplus_opportunity": 24,
     "content_review": 1,  # Short window — distinct content pieces may share topics
     "cli_approval": 0,  # Never dedup — every approval request must be delivered
+    "ego_notification": 12,  # Ego notifications — don't repeat same topic within 12h
 }
 _DEFAULT_DEDUP_HOURS = 24
 
@@ -126,9 +127,20 @@ class GovernanceGate:
             else:
                 failed.append(f"content_quota: daily content limit ({self._config.content_daily}) reached")
 
+        if request.category == OutreachCategory.NOTIFICATION:
+            if await self._notification_available():
+                passed.append("notification_quota")
+            else:
+                failed.append(f"notification_quota: daily notification limit ({self._config.notification_daily}) reached")
+
         # Engagement throttle: reduce outreach if ignore rate is high
-        # BLOCKER/ALERT categories always exempt
-        if request.category not in (OutreachCategory.BLOCKER, OutreachCategory.ALERT):
+        # BLOCKER/ALERT/NOTIFICATION categories always exempt — notifications
+        # are informational and should always deliver regardless of ignore rate.
+        if request.category not in (
+            OutreachCategory.BLOCKER,
+            OutreachCategory.ALERT,
+            OutreachCategory.NOTIFICATION,
+        ):
             throttle = await self._engagement_throttle(request)
             if throttle:
                 failed.append(throttle)
@@ -242,6 +254,15 @@ class GovernanceGate:
         )
         row = await cursor.fetchone()
         return (row[0] if row else 0) < self._config.content_daily
+
+    async def _notification_available(self) -> bool:
+        cursor = await self._db.execute(
+            "SELECT COUNT(*) FROM outreach_history "
+            "WHERE category = 'notification' AND delivered_at IS NOT NULL "
+            "AND delivered_at >= date('now')",
+        )
+        row = await cursor.fetchone()
+        return (row[0] if row else 0) < self._config.notification_daily
 
     async def _engagement_throttle(self, request) -> str | None:
         """Check if low engagement rate should throttle outreach.

--- a/src/genesis/outreach/types.py
+++ b/src/genesis/outreach/types.py
@@ -19,6 +19,10 @@ class OutreachCategory(StrEnum):
     # Content pipeline drafts for user review. Routed to the "Content Review"
     # supergroup topic. User approves before external publishing.
     CONTENT = "content"
+    # Ego notifications — informational messages that don't need user approval.
+    # Routed through the outreach pipeline with governance (dedup, rate limit,
+    # quiet hours) but no approval gate. Added in PR #530.
+    NOTIFICATION = "notification"
 
 
 class OutreachStatus(StrEnum):

--- a/src/genesis/runtime/init/ego.py
+++ b/src/genesis/runtime/init/ego.py
@@ -128,6 +128,9 @@ async def init(rt: GenesisRuntime) -> None:
         if getattr(rt, "_proposal_dispatch_gate", None) is not None:
             user_ego_session.set_proposal_gate(rt._proposal_dispatch_gate)
 
+        if getattr(rt, "_outreach_pipeline", None) is not None:
+            user_ego_session.set_outreach_pipeline(rt._outreach_pipeline)
+
         # Store as the primary ego session (backwards compatible)
         rt._ego_session = user_ego_session
 
@@ -203,6 +206,9 @@ async def init(rt: GenesisRuntime) -> None:
 
         if getattr(rt, "_proposal_dispatch_gate", None) is not None:
             genesis_ego_session.set_proposal_gate(rt._proposal_dispatch_gate)
+
+        if getattr(rt, "_outreach_pipeline", None) is not None:
+            genesis_ego_session.set_outreach_pipeline(rt._outreach_pipeline)
 
         rt._genesis_ego_session = genesis_ego_session
 

--- a/tests/ego/test_content_firewall.py
+++ b/tests/ego/test_content_firewall.py
@@ -1,0 +1,212 @@
+"""Tests for dispatch information boundary and content firewall.
+
+Covers:
+- _is_content_dispatch() — content dispatch detection
+- _build_dispatch_prompt() — context-selective world model injection
+- Firewall rules appended to both dispatch paths
+- Content-publish skill firewall step
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from genesis.ego.session import (
+    _CONTENT_DISPATCH_KEYWORDS,
+    _CONTENT_FIREWALL_RULES,
+    _is_content_dispatch,
+)
+
+# ---------------------------------------------------------------------------
+# _is_content_dispatch tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsContentDispatch:
+    """Tests for content dispatch detection heuristic."""
+
+    def test_outreach_action_type(self):
+        """action_type 'outreach' should be content dispatch."""
+        assert _is_content_dispatch({"action_type": "outreach"}) is True
+
+    def test_dispatch_action_type(self):
+        """action_type 'dispatch' should be content dispatch."""
+        assert _is_content_dispatch({"action_type": "dispatch"}) is True
+
+    def test_content_action_type(self):
+        """action_type 'content' should be content dispatch."""
+        assert _is_content_dispatch({"action_type": "content"}) is True
+
+    def test_publish_action_type(self):
+        """action_type 'publish' should be content dispatch."""
+        assert _is_content_dispatch({"action_type": "publish"}) is True
+
+    def test_investigate_action_type_not_content(self):
+        """action_type 'investigate' should NOT be content dispatch."""
+        assert _is_content_dispatch({"action_type": "investigate"}) is False
+
+    def test_maintenance_action_type_not_content(self):
+        """action_type 'maintenance' should NOT be content dispatch."""
+        assert _is_content_dispatch({"action_type": "maintenance"}) is False
+
+    def test_content_keyword_in_body(self):
+        """Keywords in content field should trigger detection."""
+        assert _is_content_dispatch({
+            "action_type": "investigate",
+            "content": "Publish a Medium article about earned autonomy",
+        }) is True
+
+    def test_keyword_medium_in_body(self):
+        """'medium' keyword should trigger."""
+        assert _is_content_dispatch({
+            "content": "Draft a Medium post",
+        }) is True
+
+    def test_no_keywords_not_content(self):
+        """Proposals without content keywords are not content dispatch."""
+        assert _is_content_dispatch({
+            "action_type": "investigate",
+            "content": "Check why the Qdrant service is down",
+        }) is False
+
+    def test_empty_proposal(self):
+        """Empty dict should not be content dispatch."""
+        assert _is_content_dispatch({}) is False
+
+    def test_all_keywords_present(self):
+        """Every keyword in _CONTENT_DISPATCH_KEYWORDS should trigger."""
+        for kw in _CONTENT_DISPATCH_KEYWORDS:
+            prop = {"content": f"Please {kw} this thing"}
+            assert _is_content_dispatch(prop) is True, f"Keyword '{kw}' failed"
+
+
+# ---------------------------------------------------------------------------
+# _build_dispatch_prompt context-selectivity tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDispatchPromptContextSelectivity:
+    """Tests that content dispatches omit world model context."""
+
+    @pytest.fixture()
+    def session(self):
+        """Minimal EgoSession mock with DB."""
+        from genesis.ego.session import EgoSession
+
+        s = object.__new__(EgoSession)
+        s._db = AsyncMock()
+        return s
+
+    @pytest.mark.asyncio
+    async def test_content_dispatch_omits_goals(self, session):
+        """Content dispatch should NOT include user goals."""
+        prop = {
+            "action_type": "outreach",
+            "content": "Publish article about autonomy",
+            "execution_plan": "Medium publish via browser",
+            "rationale": "Content strategy",
+        }
+        prompt = await session._build_dispatch_prompt(prop)
+        assert "User's active goals" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_content_dispatch_omits_contacts(self, session):
+        """Content dispatch should NOT include contacts."""
+        prop = {
+            "action_type": "outreach",
+            "content": "Publish article about autonomy",
+        }
+        prompt = await session._build_dispatch_prompt(prop)
+        assert "Relevant contacts" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_content_dispatch_omits_events(self, session):
+        """Content dispatch should NOT include events."""
+        prop = {
+            "action_type": "outreach",
+            "content": "Publish article about autonomy",
+        }
+        prompt = await session._build_dispatch_prompt(prop)
+        assert "Upcoming events" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_non_content_dispatch_includes_goals(self, session):
+        """Non-content dispatch should attempt to include goals."""
+        from genesis.db.crud import user_goals
+
+        # Mock the goals lookup to return results
+        mock_goals = [
+            {"title": "Test Goal", "category": "career", "priority": "high"},
+        ]
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(user_goals, "list_active", AsyncMock(return_value=mock_goals))
+            prop = {
+                "action_type": "investigate",
+                "content": "Check why Qdrant is unreachable",
+            }
+            prompt = await session._build_dispatch_prompt(prop)
+            assert "User's active goals" in prompt
+
+    @pytest.mark.asyncio
+    async def test_all_dispatches_include_firewall(self, session):
+        """ALL dispatch prompts should include firewall rules."""
+        # Content dispatch
+        prop_content = {
+            "action_type": "outreach",
+            "content": "Publish article",
+        }
+        prompt_content = await session._build_dispatch_prompt(prop_content)
+        assert "Content Firewall" in prompt_content
+
+        # Non-content dispatch
+        prop_investigate = {
+            "action_type": "investigate",
+            "content": "Check health",
+        }
+        prompt_investigate = await session._build_dispatch_prompt(prop_investigate)
+        assert "Content Firewall" in prompt_investigate
+
+
+# ---------------------------------------------------------------------------
+# Firewall rules constant tests
+# ---------------------------------------------------------------------------
+
+
+class TestFirewallRulesConstant:
+    """Tests for _CONTENT_FIREWALL_RULES content."""
+
+    def test_contains_generic_rules(self):
+        """Firewall should contain generic content hygiene rules."""
+        assert "generic descriptions" in _CONTENT_FIREWALL_RULES.lower()
+        assert "personal names" in _CONTENT_FIREWALL_RULES.lower()
+
+    def test_contains_identity_protection(self):
+        """Firewall should contain career/job search protection."""
+        assert "job search" in _CONTENT_FIREWALL_RULES.lower()
+        assert "career" in _CONTENT_FIREWALL_RULES.lower()
+
+    def test_contains_least_privilege_principle(self):
+        """Firewall should state the least-privilege principle."""
+        assert "no more information than the task requires" in _CONTENT_FIREWALL_RULES.lower()
+
+
+# ---------------------------------------------------------------------------
+# Content-publish skill firewall step test
+# ---------------------------------------------------------------------------
+
+
+class TestContentPublishSkillFirewall:
+    """Verify the content-publish skill has the firewall step."""
+
+    def test_skill_has_firewall_step(self):
+        """Content-publish SKILL.md should contain the firewall review step."""
+        from pathlib import Path
+
+        skill_path = Path.home() / ".claude" / "skills" / "content-publish" / "SKILL.md"
+        if not skill_path.exists():
+            pytest.skip("Content-publish skill not installed")
+        content = skill_path.read_text()
+        assert "Content Firewall Review" in content
+        assert "Step 5.5" in content

--- a/tests/ego/test_notifications.py
+++ b/tests/ego/test_notifications.py
@@ -1,0 +1,165 @@
+"""Tests for ego notification pipeline.
+
+Covers:
+- _process_notifications() — submitting notifications to outreach pipeline
+- Cycle output wiring — notifications parsed after proposals
+- Governance behavior for NOTIFICATION category
+- Self-notification hack removal
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+# ---------------------------------------------------------------------------
+# _process_notifications tests
+# ---------------------------------------------------------------------------
+
+
+class TestProcessNotifications:
+    """Tests for EgoSession._process_notifications()."""
+
+    @pytest.fixture()
+    def session(self):
+        """Minimal EgoSession mock with outreach pipeline."""
+        from genesis.ego.session import EgoSession
+
+        s = object.__new__(EgoSession)
+        s._outreach_pipeline = AsyncMock()
+        s._outreach_pipeline.submit = AsyncMock()
+        s._db = AsyncMock()
+        return s
+
+    @pytest.mark.asyncio
+    async def test_notification_submits_to_pipeline(self, session):
+        """Valid notification should be submitted as NOTIFICATION category."""
+        notifications = [{"content": "Backup complete", "urgency": "low"}]
+        await session._process_notifications(notifications)
+
+        session._outreach_pipeline.submit.assert_called_once()
+        request = session._outreach_pipeline.submit.call_args[0][0]
+        assert isinstance(request, OutreachRequest)
+        assert request.category == OutreachCategory.NOTIFICATION
+        assert request.signal_type == "ego_notification"
+        assert request.topic == "Backup complete"
+        assert request.context == "Backup complete"
+
+    @pytest.mark.asyncio
+    async def test_empty_notifications_no_calls(self, session):
+        """Empty list should not trigger any pipeline calls."""
+        await session._process_notifications([])
+        session._outreach_pipeline.submit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_malformed_notification_skipped(self, session):
+        """Non-dict and empty-content notifications are skipped."""
+        notifications = [
+            "not a dict",
+            {"content": ""},
+            {"content": "  "},
+            {"no_content_key": True},
+        ]
+        await session._process_notifications(notifications)
+        session._outreach_pipeline.submit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pipeline_error_does_not_crash(self, session):
+        """Pipeline errors should be logged, not raised."""
+        session._outreach_pipeline.submit.side_effect = RuntimeError("boom")
+        notifications = [{"content": "Test notification"}]
+        # Should not raise
+        await session._process_notifications(notifications)
+
+    @pytest.mark.asyncio
+    async def test_pipeline_unavailable_logs_warning(self):
+        """When pipeline is None, notifications are skipped with warning."""
+        from genesis.ego.session import EgoSession
+
+        s = object.__new__(EgoSession)
+        s._outreach_pipeline = None
+        s._db = AsyncMock()
+
+        with patch("genesis.ego.session.logger") as mock_logger:
+            await s._process_notifications([{"content": "Test"}])
+            mock_logger.warning.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_multiple_notifications_counted(self, session):
+        """Multiple valid notifications should all be submitted."""
+        notifications = [
+            {"content": "First notification"},
+            {"content": "Second notification"},
+            {"content": "Third notification"},
+        ]
+        await session._process_notifications(notifications)
+        assert session._outreach_pipeline.submit.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_topic_truncated_to_100_chars(self, session):
+        """Topic field should be first 100 chars of content."""
+        long_content = "x" * 200
+        notifications = [{"content": long_content}]
+        await session._process_notifications(notifications)
+
+        request = session._outreach_pipeline.submit.call_args[0][0]
+        assert len(request.topic) == 100
+        assert request.context == long_content
+
+
+# ---------------------------------------------------------------------------
+# NOTIFICATION governance config tests
+# ---------------------------------------------------------------------------
+
+
+class TestNotificationGovernance:
+    """Tests for NOTIFICATION category governance behavior."""
+
+    def test_notification_category_exists(self):
+        """NOTIFICATION should be a valid OutreachCategory."""
+        assert OutreachCategory.NOTIFICATION == "notification"
+
+    def test_notification_dedup_window(self):
+        """ego_notification signal type should have 12h dedup window."""
+        from genesis.outreach.governance import _DEDUP_WINDOWS
+
+        assert _DEDUP_WINDOWS.get("ego_notification") == 12
+
+    def test_notification_config_field(self):
+        """OutreachConfig should have notification_daily field."""
+        import dataclasses
+
+        from genesis.outreach.config import OutreachConfig
+        fields = {f.name for f in dataclasses.fields(OutreachConfig)}
+        assert "notification_daily" in fields
+
+    def test_notification_threshold_zero(self):
+        """Default config should have notification threshold 0.0."""
+        from genesis.outreach.config import load_outreach_config
+
+        # Load from repo config
+        config = load_outreach_config()
+        assert config.thresholds.get("notification") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Self-notification hack removal verification
+# ---------------------------------------------------------------------------
+
+
+class TestSelfNotificationHackRemoved:
+    """Verify the auto-complete hack for zero-cost outreach is gone."""
+
+    def test_no_self_notification_pattern(self):
+        """The 'auto-completed: delivered via proposal digest' pattern
+        should no longer exist in sweep_approved_proposals."""
+        import inspect
+
+        from genesis.ego.session import EgoSession
+
+        source = inspect.getsource(EgoSession.sweep_approved_proposals)
+        assert "self-notification" not in source
+        assert "auto-completed: delivered via proposal digest" not in source

--- a/tests/ego/test_notifications.py
+++ b/tests/ego/test_notifications.py
@@ -47,6 +47,32 @@ class TestProcessNotifications:
         assert request.signal_type == "ego_notification"
         assert request.topic == "Backup complete"
         assert request.context == "Backup complete"
+        assert request.salience_score == 0.3  # urgency=low maps to 0.3
+
+    @pytest.mark.asyncio
+    async def test_urgency_maps_to_salience(self, session):
+        """Urgency levels should map to different salience scores."""
+        for urgency, expected_salience in [
+            ("low", 0.3),
+            ("normal", 0.6),
+            ("high", 0.9),
+        ]:
+            session._outreach_pipeline.submit.reset_mock()
+            notifications = [{"content": f"Test {urgency}", "urgency": urgency}]
+            await session._process_notifications(notifications)
+            request = session._outreach_pipeline.submit.call_args[0][0]
+            assert request.salience_score == expected_salience, (
+                f"urgency={urgency} should map to salience={expected_salience}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_content_capped_at_2000_chars(self, session):
+        """Notification content should be capped at 2000 characters."""
+        long_content = "x" * 5000
+        notifications = [{"content": long_content}]
+        await session._process_notifications(notifications)
+        request = session._outreach_pipeline.submit.call_args[0][0]
+        assert len(request.context) == 2000
 
     @pytest.mark.asyncio
     async def test_empty_notifications_no_calls(self, session):

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -378,7 +378,9 @@ class TestProcessExecutionBriefs:
 
         mock_direct_runner.spawn.assert_called_once()
         req = mock_direct_runner.spawn.call_args[0][0]
-        assert req.prompt == "Do the thing"
+        assert req.prompt.startswith("Do the thing")
+        # Firewall rules are appended to all execution brief prompts
+        assert "Content Firewall" in req.prompt
         assert req.source_tag == "ego_dispatch"
         assert req.caller_context == "ego_proposal:prop_001"
 

--- a/tests/test_outreach/test_governance.py
+++ b/tests/test_outreach/test_governance.py
@@ -25,6 +25,7 @@ def config():
         max_daily=5,
         surplus_daily=1,
         content_daily=3,
+        notification_daily=10,
         morning_report_time="07:00",
         # morning_report_timezone removed — uses user_timezone()
         engagement_timeout_hours=24,
@@ -46,6 +47,7 @@ def _cfg_no_quiet(**overrides):
         max_daily=5,
         surplus_daily=1,
         content_daily=3,
+        notification_daily=10,
         morning_report_time="07:00",
         # morning_report_timezone removed — uses user_timezone()
         engagement_timeout_hours=24,

--- a/tests/test_outreach/test_pipeline.py
+++ b/tests/test_outreach/test_pipeline.py
@@ -26,6 +26,7 @@ def config():
         max_daily=5,
         surplus_daily=1,
         content_daily=3,
+        notification_daily=10,
         morning_report_time="07:00",
         engagement_timeout_hours=24,
         engagement_poll_minutes=60,

--- a/tests/test_outreach/test_scheduler.py
+++ b/tests/test_outreach/test_scheduler.py
@@ -17,7 +17,7 @@ def config():
         quiet_hours=QuietHours(start="22:00", end="07:00"),
         channel_preferences={"default": "telegram"},
         thresholds={"blocker": 0.0, "alert": 0.3, "surplus": 0.7, "digest": 0.0},
-        max_daily=5, surplus_daily=1, content_daily=3,
+        max_daily=5, surplus_daily=1, content_daily=3, notification_daily=10,
         morning_report_time="07:00",
         engagement_timeout_hours=24, engagement_poll_minutes=60,
     )


### PR DESCRIPTION
## Summary

- **Notification pipeline**: Ego can now output `notifications` alongside proposals. Notifications route through the outreach pipeline with NOTIFICATION category — subject to governance (dedup 12h, rate limit 10/day, quiet hours) but exempt from salience threshold and engagement throttle. No approval gate. Replaces the self-notification hack.
- **Content firewall**: Dispatch prompts now enforce least-privilege information boundary. Content dispatches omit world model (goals, contacts, events) to prevent leakage into published content. Static firewall rules appended to ALL dispatch prompts (both sweep and execution_briefs paths) covering generic content hygiene + identity protection + career search triangulation.
- Follows up on PR #529 (ego architecture fix) — addresses the ~70% proposal accumulation that was notifications trapped in the approval gate, and the content firewall gap that allowed article #2 to leak career-ops workflow details.

## Changes

| File | What |
|------|------|
| `src/genesis/outreach/types.py` | NOTIFICATION enum |
| `src/genesis/db/schema/_migrations.py` | DB CHECK constraint rebuild |
| `src/genesis/outreach/governance.py` | NOTIFICATION governance (engagement exempt, 12h dedup, quota) |
| `src/genesis/outreach/config.py` | `notification_daily` field |
| `config/outreach.yaml` | NOTIFICATION thresholds + rate limit |
| `src/genesis/ego/session.py` | `_process_notifications()`, context-selective dispatch, `_CONTENT_FIREWALL_RULES`, `_is_content_dispatch()`, removed self-notification hack |
| `src/genesis/runtime/init/ego.py` | Wire outreach pipeline into both egos |
| `src/genesis/identity/*.md` | Notifications in output schema + information boundary |
| `src/genesis/ego/*_context.py` | Notifications in output contracts |
| `tests/ego/test_notifications.py` | 14 notification pipeline tests |
| `tests/ego/test_content_firewall.py` | 20 content firewall tests |

## Test plan

- [x] 34 new tests pass (notifications + content firewall)
- [x] 626 existing ego tests pass (0 regressions)
- [x] Ruff lint clean
- [x] Code review: 4 findings addressed (urgency mapping, content cap, keyword false positive, test update)
- [ ] CI passes
- [ ] Post-deploy: trigger ego cycle, verify notifications in `outreach_history` with category='notification'
- [ ] Post-deploy: verify content dispatch prompts omit goals/contacts/events

🤖 Generated with [Claude Code](https://claude.ai/code)