### PR TITLE
fix(voice): conciseness nudge for S2S prompt

### DIFF
--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -87,7 +87,8 @@ with a relevant query to demonstrate the capability.
 Better to be thorough than to guess wrong.
 
 VOICE RULES:
-- Respond naturally.
+- Respond naturally but concisely. Avoid unnecessary filler, repetition, \
+or restating the question. Get to the point.
 - Never use markdown, bullet points, or formatting. Speak naturally.
 - Don't narrate what you're doing. Just do it and report the result.
 


### PR DESCRIPTION
## Summary

- Add gentle conciseness guidance to GPT-Realtime voice prompt: "respond naturally but concisely, avoid filler and repetition"
- Addresses 28.6s audio responses for simple questions (e.g., DSPy discussion recall)
- No hard length constraints — just a nudge toward conciseness

## Test plan

- [x] `pytest tests/test_channels/test_voice_s2s.py -v` — 28/28 pass
- [x] `ruff check` — clean
- [ ] Voice E2E: ask_genesis response should be shorter without losing content

🤖 Generated with [Claude Code](https://claude.com/claude-code)