### PR TITLE
fix(voice): bump S2S idle timeout to 30min

### DIFF
--- a/src/genesis/channels/voice/s2s_session.py
+++ b/src/genesis/channels/voice/s2s_session.py
@@ -85,7 +85,7 @@ class S2SSessionManager:
         *,
         bridge: GenesisBridge,
         memory_store: MemoryStore | None = None,
-        max_idle_seconds: int = 300,
+        max_idle_seconds: int = 1800,
     ) -> None:
         self._bridge = bridge
         self._memory_store = memory_store


### PR DESCRIPTION
## Summary

- Bump S2S WebSocket idle timeout from 300s (5min) to 1800s (30min)
- Idle WebSocket costs nothing (billing per audio second, not connection time)
- 5min was too short — sessions reaped between voice interactions, forcing ~1.5s reconnect + loss of conversation context

## Test plan

- [x] `pytest tests/test_channels/test_voice_s2s.py` — 28/28 pass
- [x] `ruff check` — clean
- [ ] Verify in logs: session survives 10+ min idle without reaping

🤖 Generated with [Claude Code](https://claude.com/claude-code)