### PR TITLE
fix(routing,ego): DeepSeek V4 cost tracking + budget escalation loop

### DIFF
--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -28,7 +28,6 @@ class GenesisEgoContextBuilder:
     - awareness_ticks for recent signal values
     - observations for unresolved Genesis-internal items
     - follow_ups for maintenance threads
-    - cost_events for budget tracking
     """
 
     def __init__(
@@ -85,7 +84,11 @@ class GenesisEgoContextBuilder:
             ("signals", self._signals_section),
             ("observations", self._observations_section),
             ("follow_ups", self._follow_ups_section),
-            ("cost", self._cost_section),
+            # Cost section removed — the genesis ego's identity doc says
+            # "Do NOT opine on config values... budget caps... are user
+            # decisions."  Feeding cost data every cycle caused a 10+
+            # escalation loop.  Cost data remains visible via health_status
+            # MCP and the dashboard for human review.
             ("proposal_history", self._proposal_history_section),
             ("proposal_board", self._proposal_board_section),
             ("execution_outcomes", self._execution_outcomes_section),
@@ -378,41 +381,6 @@ class GenesisEgoContextBuilder:
 
             pin_tag = " [pinned]" if fu.get("pinned") else ""
             lines.append(f"- [id:{fid}] [{priority}/{status}]{pin_tag} **{strategy}**: {content}")
-
-        lines.append("")
-        return "\n".join(lines)
-
-    async def _cost_section(self, *, depth: str = "deep") -> str:
-        """Daily spend and budget status."""
-        lines = ["## Cost Status\n"]
-
-        try:
-            today = datetime.now(UTC).strftime("%Y-%m-%d")
-            cursor = await self._db.execute(
-                "SELECT COALESCE(SUM(cost_usd), 0.0) FROM cost_events "
-                "WHERE created_at >= ?",
-                (today,),
-            )
-            row = await cursor.fetchone()
-            daily_spend = row[0] if row else 0.0
-        except Exception:
-            logger.error("Failed to query cost_events", exc_info=True)
-            lines.append("*Cost data unavailable.*\n")
-            return "\n".join(lines)
-
-        lines.append(f"- **Today's spend**: ${daily_spend:.4f}")
-
-        try:
-            cursor = await self._db.execute(
-                "SELECT COALESCE(SUM(cost_usd), 0.0) FROM ego_cycles "
-                "WHERE created_at >= ?",
-                (today,),
-            )
-            row = await cursor.fetchone()
-            ego_spend = row[0] if row else 0.0
-            lines.append(f"- **Ego spend today**: ${ego_spend:.4f}")
-        except Exception:
-            pass
 
         lines.append("")
         return "\n".join(lines)

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -747,7 +747,7 @@ class UserEgoContextBuilder:
     # filtered from the user ego's view.  The genesis ego handles infra;
     # the user ego only sees user-impacting escalations.
     _INFRA_ESCALATION_KEYWORDS = frozenset({
-        "cost_unknown", "budget cap", "dream cycle", "deepseek",
+        "cost_unknown", "dream cycle", "deepseek",
         "provider fail", "circuit breaker", "qdrant", "heartbeat",
         "dead letter", "watchdog", "systemd", "memory growth",
     })

--- a/src/genesis/routing/litellm_delegate.py
+++ b/src/genesis/routing/litellm_delegate.py
@@ -90,6 +90,27 @@ _CUSTOM_MODEL_COSTS: dict[str, dict] = {
         "mode": "chat",
         "litellm_provider": "nvidia_nim",
     },
+    # Response-model keys — OpenRouter's response.model omits the
+    # provider prefix. Register these so litellm.completion_cost() can
+    # look up costs even when it infers from response.model directly.
+    # Assumption: litellm has no built-in cost entry for deepseek-v4-*
+    # as of 2026-06-05 (litellm 1.78.7). Re-verify on litellm upgrades.
+    "deepseek/deepseek-v4-pro": {
+        "input_cost_per_token": 4.35e-7,
+        "output_cost_per_token": 8.7e-7,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "mode": "chat",
+        "litellm_provider": "openrouter",
+    },
+    "deepseek/deepseek-v4-flash": {
+        "input_cost_per_token": 9.83e-8,
+        "output_cost_per_token": 1.966e-7,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "mode": "chat",
+        "litellm_provider": "openrouter",
+    },
 }
 
 for _model, _cost in _CUSTOM_MODEL_COSTS.items():
@@ -144,7 +165,9 @@ class LiteLLMDelegate:
             else:
                 cost_known = True
                 try:
-                    cost = litellm.completion_cost(completion_response=response)
+                    cost = litellm.completion_cost(
+                        completion_response=response, model=model_string,
+                    )
                 except Exception:
                     cost = 0.0
                     cost_known = False

--- a/tests/ego/test_genesis_context.py
+++ b/tests/ego/test_genesis_context.py
@@ -404,50 +404,13 @@ class TestGenesisEgoContextBuilder:
     # ── Cost ────────────────────────────────────────────────────────────
 
     @pytest.mark.asyncio
-    async def test_cost_section(self, db, mock_health_data, capabilities):
-        await db.execute(
-            "INSERT INTO cost_events "
-            "(id, event_type, cost_usd, created_at) "
-            "VALUES (?, ?, ?, datetime('now'))",
-            ("c1", "llm_call", 0.15, ),
-        )
-        await db.execute(
-            "INSERT INTO cost_events "
-            "(id, event_type, cost_usd, created_at) "
-            "VALUES (?, ?, ?, datetime('now'))",
-            ("c2", "llm_call", 0.25, ),
-        )
+    async def test_cost_section_removed(self, db, mock_health_data, capabilities):
+        """Cost section intentionally removed to prevent budget escalation loop."""
         builder = GenesisEgoContextBuilder(
             db=db, health_data=mock_health_data, capabilities=capabilities,
         )
         result = await builder.build()
-        assert "Cost Status" in result
-        assert "$0.40" in result
-
-    @pytest.mark.asyncio
-    async def test_cost_section_with_ego_spend(self, db, mock_health_data, capabilities):
-        await db.execute(
-            "INSERT INTO ego_cycles "
-            "(id, output_text, proposals_json, focus_summary, model_used, "
-            "cost_usd, input_tokens, output_tokens, duration_ms, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))",
-            ("cyc1", "output", "[]", "focus", "opus-4", 0.08, 1000, 500, 3000),
-        )
-        builder = GenesisEgoContextBuilder(
-            db=db, health_data=mock_health_data, capabilities=capabilities,
-        )
-        result = await builder.build()
-        assert "Ego spend today" in result
-        assert "$0.08" in result
-
-    @pytest.mark.asyncio
-    async def test_cost_section_empty(self, db, mock_health_data, capabilities):
-        builder = GenesisEgoContextBuilder(
-            db=db, health_data=mock_health_data, capabilities=capabilities,
-        )
-        result = await builder.build()
-        assert "Cost Status" in result
-        assert "$0.0000" in result
+        assert "Cost Status" not in result
 
     # ── Output Contract ─────────────────────────────────────────────────
 
@@ -490,7 +453,6 @@ class TestGenesisEgoContextBuilder:
             "## Awareness Signals",
             "## Unresolved Observations",
             "## Maintenance Follow-ups",
-            "## Cost Status",
             "## Active Proposals",
             "## Output Contract",
         ]


### PR DESCRIPTION
## Summary

- **DeepSeek V4 cost fix**: `litellm.completion_cost()` wasn't passed the model string, causing it to infer the wrong provider and construct a bad lookup key. All DeepSeek V4 calls reported $0/cost_unknown. Fix: pass `model=model_string` + register unprefixed response-model keys as safety net.
- **Budget escalation loop**: Genesis ego had a `_cost_section` feeding spend data every cycle despite its identity doc saying "do NOT opine on budget caps." This caused 10+ budget escalations that the user ego couldn't see (because we filtered "budget cap" as infra). Fix: remove cost section from genesis ego context, remove "budget cap" from infra filter, resolve 8 stale escalations.
- **Dream cycle verified ready** for June 7 — all hardening code is wired (record_job_start, APScheduler error listener, 3 OOM guards). No code changes needed.

## Test plan

- [x] 165/165 ego tests pass, 242/242 routing tests pass
- [x] Ruff lint clean
- [x] Code review: dead `_cost_section` removed, litellm assumption documented
- [ ] Post-merge: monitor for `provider.cost_unknown` events — should stop within minutes
- [ ] Post-merge: verify no new budget escalations from genesis ego

🤖 Generated with [Claude Code](https://claude.com/claude-code)