### PR TITLE
fix(memory,reflection): surplus retrieval gap + remove cost from reflections

### DIFF
--- a/src/genesis/cc/reflection_bridge.py
+++ b/src/genesis/cc/reflection_bridge.py
@@ -623,15 +623,6 @@ class CCReflectionBridge:
             if stats.low_performers:
                 parts.append(f"Low performers: {json.dumps(stats.low_performers)}")
 
-        # Cost summary
-        cost = bundle.cost_summary
-        parts.append(
-            f"\n## Cost Summary\n"
-            f"Today: ${cost.daily_usd:.4f} ({cost.daily_budget_pct:.0%} of daily budget)\n"
-            f"This week: ${cost.weekly_usd:.4f} ({cost.weekly_budget_pct:.0%} of weekly)\n"
-            f"This month: ${cost.monthly_usd:.4f} ({cost.monthly_budget_pct:.0%} of monthly)"
-        )
-
         # Recent user conversation
         if bundle.recent_conversations:
             conv_lines = []

--- a/src/genesis/cc/reflection_bridge/_prompts.py
+++ b/src/genesis/cc/reflection_bridge/_prompts.py
@@ -347,14 +347,6 @@ async def build_strategic_prompt_enriched(
         obs_summary = _format_observations_grouped(bundle.recent_observations)
         parts.append(f"\n## Recent Observations\n{obs_summary}")
 
-    cost = bundle.cost_summary
-    parts.append(
-        f"\n## Cost Summary\n"
-        f"Today: ${cost.daily_usd:.4f} ({cost.daily_budget_pct:.0%} of daily budget)\n"
-        f"This week: ${cost.weekly_usd:.4f} ({cost.weekly_budget_pct:.0%} of weekly)\n"
-        f"This month: ${cost.monthly_usd:.4f} ({cost.monthly_budget_pct:.0%} of monthly)"
-    )
-
     stats = bundle.procedure_stats
     if stats.total_active > 0:
         parts.append(
@@ -427,14 +419,6 @@ async def build_enriched_prompt(
         )
         if stats.low_performers:
             parts.append(f"Low performers: {json.dumps(stats.low_performers)}")
-
-    cost = bundle.cost_summary
-    parts.append(
-        f"\n## Cost Summary\n"
-        f"Today: ${cost.daily_usd:.4f} ({cost.daily_budget_pct:.0%} of daily budget)\n"
-        f"This week: ${cost.weekly_usd:.4f} ({cost.weekly_budget_pct:.0%} of weekly)\n"
-        f"This month: ${cost.monthly_usd:.4f} ({cost.monthly_budget_pct:.0%} of monthly)"
-    )
 
     if bundle.recent_conversations:
         conv_lines = []

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -28,7 +28,6 @@ class GenesisEgoContextBuilder:
     - awareness_ticks for recent signal values
     - observations for unresolved Genesis-internal items
     - follow_ups for maintenance threads
-    - cost_events for budget tracking
     """
 
     def __init__(
@@ -85,7 +84,11 @@ class GenesisEgoContextBuilder:
             ("signals", self._signals_section),
             ("observations", self._observations_section),
             ("follow_ups", self._follow_ups_section),
-            ("cost", self._cost_section),
+            # Cost section removed — the genesis ego's identity doc says
+            # "Do NOT opine on config values... budget caps... are user
+            # decisions."  Feeding cost data every cycle caused a 10+
+            # escalation loop.  Cost data remains visible via health_status
+            # MCP and the dashboard for human review.
             ("proposal_history", self._proposal_history_section),
             ("proposal_board", self._proposal_board_section),
             ("execution_outcomes", self._execution_outcomes_section),
@@ -378,41 +381,6 @@ class GenesisEgoContextBuilder:
 
             pin_tag = " [pinned]" if fu.get("pinned") else ""
             lines.append(f"- [id:{fid}] [{priority}/{status}]{pin_tag} **{strategy}**: {content}")
-
-        lines.append("")
-        return "\n".join(lines)
-
-    async def _cost_section(self, *, depth: str = "deep") -> str:
-        """Daily spend and budget status."""
-        lines = ["## Cost Status\n"]
-
-        try:
-            today = datetime.now(UTC).strftime("%Y-%m-%d")
-            cursor = await self._db.execute(
-                "SELECT COALESCE(SUM(cost_usd), 0.0) FROM cost_events "
-                "WHERE created_at >= ?",
-                (today,),
-            )
-            row = await cursor.fetchone()
-            daily_spend = row[0] if row else 0.0
-        except Exception:
-            logger.error("Failed to query cost_events", exc_info=True)
-            lines.append("*Cost data unavailable.*\n")
-            return "\n".join(lines)
-
-        lines.append(f"- **Today's spend**: ${daily_spend:.4f}")
-
-        try:
-            cursor = await self._db.execute(
-                "SELECT COALESCE(SUM(cost_usd), 0.0) FROM ego_cycles "
-                "WHERE created_at >= ?",
-                (today,),
-            )
-            row = await cursor.fetchone()
-            ego_spend = row[0] if row else 0.0
-            lines.append(f"- **Ego spend today**: ${ego_spend:.4f}")
-        except Exception:
-            pass
 
         lines.append("")
         return "\n".join(lines)

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -747,7 +747,7 @@ class UserEgoContextBuilder:
     # filtered from the user ego's view.  The genesis ego handles infra;
     # the user ego only sees user-impacting escalations.
     _INFRA_ESCALATION_KEYWORDS = frozenset({
-        "cost_unknown", "budget cap", "dream cycle", "deepseek",
+        "cost_unknown", "dream cycle", "deepseek",
         "provider fail", "circuit breaker", "qdrant", "heartbeat",
         "dead letter", "watchdog", "systemd", "memory growth",
     })

--- a/src/genesis/mcp/memory/knowledge.py
+++ b/src/genesis/mcp/memory/knowledge.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 _AUTHORITY_BOOST: dict[str, float] = {
     "curated": 1.5,
     "conversation": 1.0,
+    "surplus": 0.7,
     "recon": 0.5,
 }
 

--- a/src/genesis/reflection/context_gatherer.py
+++ b/src/genesis/reflection/context_gatherer.py
@@ -9,12 +9,10 @@ import aiosqlite
 
 from genesis.db.crud import (
     cognitive_state,
-    cost_events,
     observations,
 )
 from genesis.reflection.types import (
     ContextBundle,
-    CostSummary,
     PendingWorkSummary,
     ProcedureStats,
 )
@@ -29,19 +27,12 @@ _COGNITIVE_STATE_STALE_HOURS = 24
 class ContextGatherer:
     """Assembles comprehensive context for deep reflection from multiple DB sources."""
 
-    def __init__(self, *, budget_daily: float = 2.0, budget_weekly: float = 10.0,
-                 budget_monthly: float = 30.0):
-        self._budget_daily = budget_daily
-        self._budget_weekly = budget_weekly
-        self._budget_monthly = budget_monthly
-
     async def gather(self, db: aiosqlite.Connection) -> ContextBundle:
         """Gather all context needed for a deep reflection invocation."""
         cog_state = await cognitive_state.render(db)
         recent_obs = await self._recent_observations(db)
         proc_stats = await self._procedure_stats(db)
         intel_digest = await self._intelligence_digest(db)
-        cost = await self._cost_summary(db)
         pending = await self.detect_pending_work(db)
         conversations = self._recent_conversation_turns()
         surplus_digest, surplus_ids = await self._promoted_surplus_digest(db)
@@ -52,7 +43,6 @@ class ContextGatherer:
             recent_observations=recent_obs,
             procedure_stats=proc_stats,
             intelligence_digest=intel_digest,
-            cost_summary=cost,
             pending_work=pending,
             recent_conversations=conversations,
             surplus_digest=surplus_digest,
@@ -184,7 +174,6 @@ class ContextGatherer:
     async def gather_for_calibration(self, db: aiosqlite.Connection) -> dict:
         """Gather data for weekly quality calibration."""
         proc_stats = await self._procedure_stats(db)
-        cost = await self._cost_summary(db)
 
         # Get recent self-assessment scores for trend comparison
         assessments = await observations.query(
@@ -197,11 +186,6 @@ class ContextGatherer:
                 "avg_success_rate": proc_stats.avg_success_rate,
                 "low_performers": proc_stats.low_performers,
                 "quarantined": proc_stats.total_quarantined,
-            },
-            "cost_summary": {
-                "daily_usd": cost.daily_usd,
-                "weekly_usd": cost.weekly_usd,
-                "monthly_usd": cost.monthly_usd,
             },
             "recent_assessments": [
                 {"created_at": a["created_at"], "content": a["content"][:500]}
@@ -287,28 +271,6 @@ class ContextGatherer:
             total_quarantined=quarantined_count,
             avg_success_rate=round(avg_rate, 3),
             low_performers=sorted(low, key=lambda x: x["success_rate"]),
-        )
-
-    async def _cost_summary(self, db: aiosqlite.Connection) -> CostSummary:
-        """Compute cost summary for current day/week/month."""
-        now = datetime.now(UTC)
-        day_start = now.replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
-        week_start = (now - timedelta(days=now.weekday())).replace(
-            hour=0, minute=0, second=0, microsecond=0
-        ).isoformat()
-        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0).isoformat()
-
-        daily = await cost_events.sum_cost(db, since=day_start)
-        weekly = await cost_events.sum_cost(db, since=week_start)
-        monthly = await cost_events.sum_cost(db, since=month_start)
-
-        return CostSummary(
-            daily_usd=round(daily, 4),
-            weekly_usd=round(weekly, 4),
-            monthly_usd=round(monthly, 4),
-            daily_budget_pct=round(daily / self._budget_daily, 3) if self._budget_daily > 0 else 0,
-            weekly_budget_pct=round(weekly / self._budget_weekly, 3) if self._budget_weekly > 0 else 0,
-            monthly_budget_pct=round(monthly / self._budget_monthly, 3) if self._budget_monthly > 0 else 0,
         )
 
     async def _outreach_stats(self, db: aiosqlite.Connection) -> dict:

--- a/src/genesis/reflection/types.py
+++ b/src/genesis/reflection/types.py
@@ -85,18 +85,6 @@ class ProcedureStats:
 
 
 @dataclass(frozen=True)
-class CostSummary:
-    """Cost summary for a time period."""
-
-    daily_usd: float = 0.0
-    weekly_usd: float = 0.0
-    monthly_usd: float = 0.0
-    daily_budget_pct: float = 0.0
-    weekly_budget_pct: float = 0.0
-    monthly_budget_pct: float = 0.0
-
-
-@dataclass(frozen=True)
 class ContextBundle:
     """All context assembled for a deep reflection invocation."""
 
@@ -105,7 +93,6 @@ class ContextBundle:
     procedure_stats: ProcedureStats = field(default_factory=ProcedureStats)
     intelligence_digest: str = ""
     skill_reports: list[dict] = field(default_factory=list)
-    cost_summary: CostSummary = field(default_factory=CostSummary)
     pending_work: PendingWorkSummary = field(default_factory=PendingWorkSummary)
     recent_conversations: list[dict] = field(default_factory=list)
     surplus_digest: str = ""

--- a/src/genesis/routing/litellm_delegate.py
+++ b/src/genesis/routing/litellm_delegate.py
@@ -90,6 +90,27 @@ _CUSTOM_MODEL_COSTS: dict[str, dict] = {
         "mode": "chat",
         "litellm_provider": "nvidia_nim",
     },
+    # Response-model keys — OpenRouter's response.model omits the
+    # provider prefix. Register these so litellm.completion_cost() can
+    # look up costs even when it infers from response.model directly.
+    # Assumption: litellm has no built-in cost entry for deepseek-v4-*
+    # as of 2026-06-05 (litellm 1.78.7). Re-verify on litellm upgrades.
+    "deepseek/deepseek-v4-pro": {
+        "input_cost_per_token": 4.35e-7,
+        "output_cost_per_token": 8.7e-7,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "mode": "chat",
+        "litellm_provider": "openrouter",
+    },
+    "deepseek/deepseek-v4-flash": {
+        "input_cost_per_token": 9.83e-8,
+        "output_cost_per_token": 1.966e-7,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "mode": "chat",
+        "litellm_provider": "openrouter",
+    },
 }
 
 for _model, _cost in _CUSTOM_MODEL_COSTS.items():
@@ -144,7 +165,9 @@ class LiteLLMDelegate:
             else:
                 cost_known = True
                 try:
-                    cost = litellm.completion_cost(completion_response=response)
+                    cost = litellm.completion_cost(
+                        completion_response=response, model=model_string,
+                    )
                 except Exception:
                     cost = 0.0
                     cost_known = False

--- a/src/genesis/surplus/intake.py
+++ b/src/genesis/surplus/intake.py
@@ -537,6 +537,7 @@ async def _route_to_knowledge(
     # Build provenance.
     provenance = {
         "source_doc": f"intake:{scored.source.value}",
+        "source_pipeline": "surplus",
         "ingested_at": datetime.now(UTC).isoformat(),
     }
     if scored.generating_model:

--- a/tests/ego/test_genesis_context.py
+++ b/tests/ego/test_genesis_context.py
@@ -404,50 +404,13 @@ class TestGenesisEgoContextBuilder:
     # ── Cost ────────────────────────────────────────────────────────────
 
     @pytest.mark.asyncio
-    async def test_cost_section(self, db, mock_health_data, capabilities):
-        await db.execute(
-            "INSERT INTO cost_events "
-            "(id, event_type, cost_usd, created_at) "
-            "VALUES (?, ?, ?, datetime('now'))",
-            ("c1", "llm_call", 0.15, ),
-        )
-        await db.execute(
-            "INSERT INTO cost_events "
-            "(id, event_type, cost_usd, created_at) "
-            "VALUES (?, ?, ?, datetime('now'))",
-            ("c2", "llm_call", 0.25, ),
-        )
+    async def test_cost_section_removed(self, db, mock_health_data, capabilities):
+        """Cost section intentionally removed to prevent budget escalation loop."""
         builder = GenesisEgoContextBuilder(
             db=db, health_data=mock_health_data, capabilities=capabilities,
         )
         result = await builder.build()
-        assert "Cost Status" in result
-        assert "$0.40" in result
-
-    @pytest.mark.asyncio
-    async def test_cost_section_with_ego_spend(self, db, mock_health_data, capabilities):
-        await db.execute(
-            "INSERT INTO ego_cycles "
-            "(id, output_text, proposals_json, focus_summary, model_used, "
-            "cost_usd, input_tokens, output_tokens, duration_ms, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))",
-            ("cyc1", "output", "[]", "focus", "opus-4", 0.08, 1000, 500, 3000),
-        )
-        builder = GenesisEgoContextBuilder(
-            db=db, health_data=mock_health_data, capabilities=capabilities,
-        )
-        result = await builder.build()
-        assert "Ego spend today" in result
-        assert "$0.08" in result
-
-    @pytest.mark.asyncio
-    async def test_cost_section_empty(self, db, mock_health_data, capabilities):
-        builder = GenesisEgoContextBuilder(
-            db=db, health_data=mock_health_data, capabilities=capabilities,
-        )
-        result = await builder.build()
-        assert "Cost Status" in result
-        assert "$0.0000" in result
+        assert "Cost Status" not in result
 
     # ── Output Contract ─────────────────────────────────────────────────
 
@@ -490,7 +453,6 @@ class TestGenesisEgoContextBuilder:
             "## Awareness Signals",
             "## Unresolved Observations",
             "## Maintenance Follow-ups",
-            "## Cost Status",
             "## Active Proposals",
             "## Output Contract",
         ]

--- a/tests/test_cc/test_reflection_bridge.py
+++ b/tests/test_cc/test_reflection_bridge.py
@@ -311,7 +311,6 @@ async def test_strategic_enriched_path_includes_observations_and_pointers(db, mo
     """Strategic reflection with context_gatherer uses enriched path with observations."""
     from genesis.reflection.types import (
         ContextBundle,
-        CostSummary,
         PendingWorkSummary,
         ProcedureStats,
     )
@@ -326,8 +325,6 @@ async def test_strategic_enriched_path_includes_observations_and_pointers(db, mo
         intelligence_digest="",
         pending_work=PendingWorkSummary(memory_consolidation=False),
         procedure_stats=ProcedureStats(total_active=0, total_quarantined=0, avg_success_rate=0, low_performers=[]),
-        cost_summary=CostSummary(daily_usd=0.0, weekly_usd=0.0, monthly_usd=0.0,
-                                 daily_budget_pct=0.0, weekly_budget_pct=0.0, monthly_budget_pct=0.0),
         recent_conversations=[],
         gathered_observation_ids=("obs-1",),
     ))

--- a/tests/test_reflection/test_context_gatherer.py
+++ b/tests/test_reflection/test_context_gatherer.py
@@ -21,7 +21,7 @@ async def db():
 
 @pytest.fixture
 def gatherer():
-    return ContextGatherer(budget_daily=2.0, budget_weekly=10.0, budget_monthly=30.0)
+    return ContextGatherer()
 
 
 class TestDetectPendingWork:
@@ -108,7 +108,6 @@ class TestGather:
         bundle = await gatherer.gather(db)
         assert bundle.recent_observations == []
         assert bundle.intelligence_digest != ""  # always has a message
-        assert isinstance(bundle.cost_summary.daily_usd, float)
 
     @pytest.mark.asyncio
     async def test_gather_with_data(self, db, gatherer):
@@ -165,7 +164,6 @@ class TestGatherForCalibration:
     async def test_returns_expected_keys(self, db, gatherer):
         data = await gatherer.gather_for_calibration(db)
         assert "procedure_stats" in data
-        assert "cost_summary" in data
         assert "recent_assessments" in data
 
 
@@ -206,21 +204,9 @@ class TestProcedureStats:
         assert bundle.procedure_stats.low_performers[0]["success_rate"] == 0.2
 
 
-class TestCostSummary:
+class TestCostSummaryRemoved:
     @pytest.mark.asyncio
-    async def test_empty_costs(self, db, gatherer):
+    async def test_no_cost_summary_field(self, db, gatherer):
+        """Cost summary fully removed from ContextBundle."""
         bundle = await gatherer.gather(db)
-        assert bundle.cost_summary.daily_usd == 0.0
-
-    @pytest.mark.asyncio
-    async def test_with_cost_events(self, db, gatherer):
-        now = datetime.now(UTC).isoformat()
-        await db.execute(
-            "INSERT INTO cost_events (id, event_type, cost_usd, created_at) "
-            "VALUES ('c1', 'llm_call', 0.5, ?)",
-            (now,),
-        )
-        await db.commit()
-        bundle = await gatherer.gather(db)
-        assert bundle.cost_summary.daily_usd == 0.5
-        assert bundle.cost_summary.daily_budget_pct == 0.25
+        assert not hasattr(bundle, "cost_summary")

--- a/tests/test_reflection/test_types.py
+++ b/tests/test_reflection/test_types.py
@@ -5,7 +5,6 @@ import pytest
 from genesis.reflection.types import (
     AssessmentDimension,
     ContextBundle,
-    CostSummary,
     DeepReflectionJob,
     DeepReflectionOutput,
     DimensionScore,
@@ -72,18 +71,6 @@ class TestProcedureStats:
         assert ps.total_active == 0
         assert ps.avg_success_rate == 0.0
         assert ps.low_performers == []
-
-
-class TestCostSummary:
-    def test_defaults(self):
-        cs = CostSummary()
-        assert cs.daily_usd == 0.0
-        assert cs.monthly_budget_pct == 0.0
-
-    def test_with_values(self):
-        cs = CostSummary(daily_usd=1.5, daily_budget_pct=0.75)
-        assert cs.daily_usd == 1.5
-        assert cs.daily_budget_pct == 0.75
 
 
 class TestContextBundle:


### PR DESCRIPTION
## Summary

- **Surplus knowledge retrieval**: 88% of 914 surplus units were never retrieved because `source_pipeline` was NULL in the provenance dict. Added `"surplus"` to provenance and authority boost (0.7x). Backfilled 914 existing units.
- **Cost removal from reflections**: Removed `CostSummary`, `_cost_summary()`, and "## Cost Summary" rendering from all 3 reflection prompt builders. Cost data served no cognitive purpose and was the last vector for budget-related observation generation. Dead constructor parameters cleaned up.

## Test plan

- [x] 203/203 reflection + bridge tests pass
- [x] Ruff lint clean
- [x] Code review: dead constructor params and CostSummary class removed per review findings
- [x] Surplus backfill: 914 units updated with source_pipeline='surplus'
- [ ] Post-merge: verify knowledge_recall returns surplus units for relevant queries
- [ ] Post-merge: verify next reflection output has no "## Cost Summary" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)