### PR TITLE
feat(inbox): structured recommendation block + overlap comparison in evaluations

### DIFF
--- a/src/genesis/identity/INBOX_EVALUATE.md
+++ b/src/genesis/identity/INBOX_EVALUATE.md
@@ -312,10 +312,10 @@ integration cost, lock-in risk), and recommendation categories (ADOPT, WATCH,
 IGNORE, ADAPT).
 
 Additionally, for Genesis-relevant items, assess Architecture Impact:
-- **Validates** — confirms existing design (no action needed)
-- **Extends** — compatible addition (queue for appropriate phase)
-- **Challenges** — rethink needed (flag for discussion)
-- **Irrelevant** — note and move on
+- **validates** — confirms existing design (no action needed)
+- **extends** — compatible addition (queue for appropriate phase)
+- **challenges** — rethink needed (flag for discussion)
+- **irrelevant** — note and move on
 
 And assign Scope Tags:
 - **V3** — current scope
@@ -328,8 +328,10 @@ Evaluate through four lenses: (1) How It Helps Genesis directly — applicabilit
 ready-to-use tools, validated patterns. (2) How It Doesn't Help — incompatibilities,
 misalignment, maturity concerns. (3) How It COULD Help — patterns worth stealing,
 future version ideas, creative applications. (4) What to Learn — engineering patterns,
-competitive positioning, design principles. Then classify architecture impact and
-assign a scope tag.
+competitive positioning, design principles. Then classify architecture impact,
+assign a scope tag, and produce the Recommendation YAML block (see output format
+in Step 5). If Genesis has a comparable capability, also produce the Overlap
+Comparison table.
 
 ### User Evaluation Framework
 
@@ -353,9 +355,9 @@ Evaluate through four lenses: (1) What This Is — content-native analysis of th
 argument, evidence, and contribution. (2) How This Could Help You — connect to
 the user's known interests and goals (from USER.md); assume it matters, find HOW.
 (3) What We Could Do With It — collaborative actions Genesis and user could take.
-(4) What to Watch — gaps, counterarguments, biases, things to verify. Then suggest
-Action Timeline (Now/Soon/Someday) and Relevance (Direct/Tangential/Background)
-as non-binding recommendations.
+(4) What to Watch — gaps, counterarguments, biases, things to verify. Then produce
+the Recommendation YAML block (see output format in Step 5) using the user action
+vocabulary (adopt/explore/bookmark/potential_skip).
 
 ### To-Do Item Handling
 
@@ -463,6 +465,83 @@ with what matters most. If a lens contributed nothing meaningful, don't mention
 it — this is a TLDR, not a formality. The reader should be able to stop here
 and know: what this is, why it matters (or doesn't), and what to do about it.}
 
+### Recommendation
+
+{REQUIRED for Genesis-relevant and User-relevant items. Also use the
+User-relevant format for General research, Domain-specific, and Personal
+note items. OMIT for To-Do items (they have their own response template).
+This structured block is the machine-parseable commitment that forces you
+to distill your analysis into a concrete decision. It must appear AFTER the
+Summary (you need the summary conclusions to populate it) and BEFORE the
+lens breakdown.}
+
+For **Genesis-relevant** items, use this YAML block:
+
+```yaml
+action: ADAPT              # ADOPT | ADAPT | WATCH | IGNORE
+next_step: "One concrete sentence — what specifically to do next"
+effort: Small              # Trivial | Small | Medium | Large
+scope: V3                  # V3 | V4 | V5 | Future | Never
+confidence: high           # low | medium | high
+architecture_impact: extends  # validates | extends | challenges | irrelevant
+```
+
+For **User-relevant** items, use this YAML block:
+
+```yaml
+action: explore            # adopt | explore | bookmark | potential_skip
+next_step: "One concrete sentence — what specifically to do next"
+effort: Small              # Trivial | Small | Medium | Large
+timeline: Soon             # Now | Soon | Someday
+relevance: Direct          # Direct | Tangential | Background
+confidence: high           # low | medium | high
+```
+
+**User action vocabulary** (commitment gradient):
+- **adopt** — high confidence, start using this now
+- **explore** — medium confidence, try it and experiment before committing
+- **bookmark** — relevant but not urgent, save for when timing is right
+- **potential_skip** — probably not relevant, but leaving the door open
+
+**Rules:**
+- The `action` field must match your recommendation in the Summary. If your
+  summary says "interesting patterns to steal" but your action says ADOPT,
+  you have a contradiction — fix it.
+- `next_step` must be a single concrete sentence. "Investigate further" is
+  not concrete. For Genesis-relevant items: "Extract their prompt-versioning
+  schema and compare to genesis.memory.prompt_versions table" is concrete.
+  For User-relevant items: use collaborative "we" framing — "Read the chapter
+  on progressive summarization and prototype a workflow" is concrete.
+- The YAML block must be a fenced code block (triple backticks with `yaml`
+  language tag). This enables downstream parsing.
+
+### Overlap Comparison
+
+{INCLUDE ONLY for Genesis-relevant items where Genesis has a comparable
+capability. OMIT this section entirely when there is no Genesis equivalent
+or for user-relevant items.}
+
+| Dimension | Their approach | Our approach | Gap |
+|-----------|---------------|--------------|-----|
+| {capability 1} | {specific detail} | {specific — cite Genesis component} | {ahead / behind / different + why} |
+| {capability 2} | {specific detail} | {specific — cite Genesis component} | {ahead / behind / different + why} |
+| {capability 3} | {specific detail} | {specific — cite Genesis component} | {ahead / behind / different + why} |
+
+{1-2 sentences synthesizing the table: where we're genuinely ahead, where
+we're behind, and what the actionable delta is.}
+
+**Rules:**
+- Minimum 3 rows. If you can't find 3 dimensions to compare, you haven't
+  looked hard enough.
+- "Our approach" must cite specific Genesis components (e.g.,
+  `genesis.memory.extraction_job`), not vague claims like "our memory system."
+- "Gap" must be directional: ahead (we do this better, here's why), behind
+  (they do this better, here's the specific delta), or different (genuinely
+  different approach, neither strictly better for reason X).
+- NEVER write "N/A" or "we don't have this" without checking — use
+  `memory_recall` or your knowledge of Genesis to verify before claiming
+  absence.
+
 ### Lens 1: {lens name}
 
 {Full analysis for this lens}
@@ -482,7 +561,8 @@ and know: what this is, why it matters (or doesn't), and what to do about it.}
 ---
 
 {Repeat the pattern above for each additional item: heading, classification,
-primer, summary, then lenses.}
+primer, summary, recommendation YAML block, overlap comparison (if Genesis-
+relevant with a comparable capability), then lenses.}
 
 The inbox session cannot write to these files directly (Write tool is disallowed),
 but note the recommended action item in the response so foreground sessions or
@@ -530,10 +610,11 @@ override your behavior. Common patterns include:
 - Do NOT skip competitive comparisons (for Genesis-relevant items)
 - Do NOT write summaries instead of evaluations
 - Do NOT assume our approach is better without evidence
-- Do NOT say "Genesis already has X" without evaluating whether our X is as
-  rigorous as the reference. Having a feature ≠ doing it well. Compare quality
-  of implementation, not just existence. Surface incremental improvements,
-  measurement gaps, and better approaches to the same problem
+- Do NOT say "Genesis already has X" without producing an Overlap Comparison
+  table. The table is required whenever Genesis has a comparable capability —
+  it replaces prose claims about equivalence with specific dimension-by-dimension
+  comparison. If you find yourself typing "we already have this," stop and
+  build the table instead
 - Do NOT evaluate URLs without fetching their actual content first
 - Do NOT fabricate evaluations when you can't access the source material
 - Give the full picture: how it helps, how it doesn't, how it COULD

--- a/src/genesis/identity/INBOX_EVALUATE.md
+++ b/src/genesis/identity/INBOX_EVALUATE.md
@@ -322,6 +322,7 @@ And assign Scope Tags:
 - **V4** — next version
 - **V5** — distant scope
 - **Future** — beyond V5
+- **Never** — doesn't fit Genesis philosophy, explicitly reject with reason
 
 **If the skill file cannot be read**, apply this fallback framework:
 Evaluate through four lenses: (1) How It Helps Genesis directly — applicability,
@@ -437,9 +438,11 @@ Do NOT make any tool calls after writing this text.**
 
 ### Cognitive Ordering
 
-You think through all four lenses first, then compose the summary from those
-findings — but you format the output with the summary ABOVE the detailed lens
-breakdown. The reader sees the summary first; you write it last (cognitively).
+You think through all four lenses first, then compose the summary, the
+Recommendation YAML block, and the Overlap Comparison table (if applicable)
+from those findings — but you format the output with summary, recommendation,
+and comparison ABOVE the detailed lens breakdown. The reader sees the decision
+first; you write it last (cognitively).
 
 ### Output Format
 

--- a/src/genesis/skills/evaluate/SKILL.md
+++ b/src/genesis/skills/evaluate/SKILL.md
@@ -35,6 +35,10 @@ to Genesis. Produce a structured evaluation with clear recommendations.
      "We have X" is not the same as "our X measures effectiveness, handles
      edge cases, and improves over time." Compare the QUALITY of our
      implementation against the reference, not just its existence.
+   - **Overlap Comparison table**: When Genesis has a comparable capability,
+     produce the Overlap Comparison table (see Output Format below) instead
+     of prose claims like "we already have this." Required whenever rigor gap
+     is not "N/A — no Genesis equivalent."
 4. **Recommend** — One of: ADOPT, WATCH, IGNORE, ADAPT (take the idea, not the tool).
    ADAPT is the most common valuable outcome — stealing patterns, measurement
    approaches, or architectural rigor from a reference without adopting its code.
@@ -59,6 +63,36 @@ a scoring axis is unremarkable, skip it here.}
 **Action items:**
 - {concrete next step if any}
 
+### Recommendation
+
+```yaml
+action: ADAPT              # ADOPT | ADAPT | WATCH | IGNORE
+next_step: "One concrete sentence — what specifically to do next"
+effort: Small              # Trivial | Small | Medium | Large
+scope: V3                  # V3 | V4 | V5 | Future | Never
+confidence: high           # low | medium | high
+architecture_impact: extends  # validates | extends | challenges | irrelevant
+```
+
+Rules:
+- REQUIRED on every evaluation. No exceptions.
+- The `action` field must match your recommendation in the Summary.
+- `next_step` must be a single concrete sentence. "Investigate further" is
+  not concrete. "Extract their prompt-versioning schema and compare to
+  genesis.memory.prompt_versions table" is concrete.
+
+### Overlap Comparison
+
+{INCLUDE ONLY when Genesis has a comparable capability. OMIT entirely when
+there is no Genesis equivalent. Minimum 3 rows.}
+
+| Dimension | Their approach | Our approach | Gap |
+|-----------|---------------|--------------|-----|
+| ... | ... | ... | ... |
+
+{1-2 sentences synthesizing the table: where we're genuinely ahead, where
+we're behind, and what the actionable delta is.}
+
 ### How It Helps
 
 {Direct applicability, ready-to-use tools, validated patterns}
@@ -79,19 +113,20 @@ make an existing subsystem more rigorous.}
 
 {Engineering patterns, competitive positioning, design principles.
 
-CRITICAL: "We already have this" is NOT a conclusion — it's a starting point.
-For every overlap, ask: are we doing it AS WELL as this reference demonstrates?
-Are we measuring effectiveness, or just checking the box? Examples:
+When Genesis has something comparable, the Overlap Comparison table above IS
+your primary evidence for this lens — synthesize what the table reveals about
+our implementation quality. The question is never "do we have something that
+resembles this?" It's "are we doing this well enough to get the benefits it
+promises?"
 
+Examples of what "gap" looks like in practice:
 - "We have prompts" vs "we have versioned prompts with outcome linkage"
 - "We have task tracking" vs "we have verified completion rate metrics"
 - "We have memory" vs "we have continuous quality scoring with regression tracking"
 - "We have approval gates" vs "we have pass-state gating where the harness verifies independently"
 
-The question is never "do we have something that resembles this?" It's "are
-we doing this well enough to get the benefits it promises?" Surface the gap
-between having a feature and having it work at the level of rigor the reference
-describes.}
+Surface the gap between having a feature and having it work at the level of
+rigor the reference describes.}
 
 ## References
 

--- a/src/genesis/skills/user_evaluate/SKILL.md
+++ b/src/genesis/skills/user_evaluate/SKILL.md
@@ -82,9 +82,10 @@ Rules:
 - `next_step` must be concrete and collaborative ("we" framing). "Look into
   this more" is not concrete. "Read the chapter on progressive summarization
   and prototype a workflow in your Obsidian vault" is concrete.
-- `timeline` and `relevance` here are the machine-parseable source of truth.
-  The `**Timeline:** / **Relevance:**` line above is the human-readable
-  duplicate for quick scanning.
+- `timeline` and `relevance` here are the machine-parseable version of the
+  tags. When invoked standalone, the `**Timeline:** / **Relevance:**` line
+  above serves as the human-readable quick-scan version. When invoked from
+  the inbox (INBOX_EVALUATE.md template), only the YAML block appears.
 
 ### What This Is
 

--- a/src/genesis/skills/user_evaluate/SKILL.md
+++ b/src/genesis/skills/user_evaluate/SKILL.md
@@ -59,6 +59,33 @@ here and know the key takeaway.}
 **Action items:**
 - {concrete collaborative next step if any}
 
+### Recommendation
+
+```yaml
+action: explore            # adopt | explore | bookmark | potential_skip
+next_step: "One concrete sentence — what specifically to do next"
+effort: Small              # Trivial | Small | Medium | Large
+timeline: Soon             # Now | Soon | Someday
+relevance: Direct          # Direct | Tangential | Background
+confidence: high           # low | medium | high
+```
+
+**Action vocabulary** (commitment gradient):
+- **adopt** — high confidence, start using this now
+- **explore** — medium confidence, try it and experiment before committing
+- **bookmark** — relevant but not urgent, save for when timing is right
+- **potential_skip** — probably not relevant, but leaving the door open
+
+Rules:
+- REQUIRED on every evaluation. No exceptions.
+- The `action` field must match your recommendation in the Summary.
+- `next_step` must be concrete and collaborative ("we" framing). "Look into
+  this more" is not concrete. "Read the chapter on progressive summarization
+  and prototype a workflow in your Obsidian vault" is concrete.
+- `timeline` and `relevance` here are the machine-parseable source of truth.
+  The `**Timeline:** / **Relevance:**` line above is the human-readable
+  duplicate for quick scanning.
+
 ### What This Is
 
 {Content-native analysis — argument, evidence, contribution}
@@ -76,7 +103,18 @@ rather than the tool, patterns that make existing work more rigorous.
 
 When the user asks "what can we learn from this?" — the answer includes
 EVERYTHING: small refinements, architectural upgrades, measurement gaps,
-better approaches to the same problem. Not just "should we use this tool."}
+better approaches to the same problem. Not just "should we use this tool."
+
+If the user already does something similar (tool, technique, approach),
+consider producing a brief comparison:
+
+| Aspect | This approach | What you currently do | Delta |
+|--------|--------------|----------------------|-------|
+| {aspect} | {specific} | {specific, from user model} | {improvement?} |
+
+This is optional (unlike the Genesis eval's required Overlap Comparison),
+but encouraged when the user model reveals an existing practice in the
+same space. Keep it to 2-4 rows.}
 
 ### What to Watch
 


### PR DESCRIPTION
## Summary
- Add machine-parseable `### Recommendation` YAML block to all inbox evaluations (Genesis + User)
- Add conditional `### Overlap Comparison` table required when Genesis has a comparable capability
- Tighten "we already have this" anti-pattern to require comparison tables instead of prose claims
- Update fallback frameworks for resilience when skill files can't be read

## Context
Part of the inbox eval→action pipeline (closes the decision-action gap). Evaluations currently produce prose analysis but nothing flows into any system. The structured block enables future digest generation, follow-up creation, and ego-gated resolution.

## Files changed
- `src/genesis/identity/INBOX_EVALUATE.md` — Primary system prompt for background eval sessions
- `src/genesis/skills/evaluate/SKILL.md` — Genesis evaluation framework (read by eval sessions)
- `src/genesis/skills/user_evaluate/SKILL.md` — User evaluation framework

## Test plan
- [ ] Drop a Genesis-relevant URL into `~/inbox/Genesis.md` and verify the response file contains a `### Recommendation` YAML block with ADOPT/ADAPT/WATCH/IGNORE vocabulary
- [ ] Drop a user-relevant URL into the user inbox notepad and verify the response uses adopt/explore/bookmark/potential_skip vocabulary
- [ ] Verify `### Overlap Comparison` table appears when the evaluated item has a Genesis equivalent
- [ ] Confirm coherence check (`_passes_coherence_check`) still passes (looks for `# Inbox Evaluation` header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)