### PR TITLE
feat(inbox): follow-up creation + dashboard filter + digest tool

### DIFF
--- a/src/genesis/dashboard/routes/follow_ups.py
+++ b/src/genesis/dashboard/routes/follow_ups.py
@@ -39,9 +39,6 @@ async def follow_up_list():
     if source_filter == "user" and source_mode == "all":
         source_mode = "mine"
 
-    # Legacy exclude_source only used when source_mode is "all"
-    exclude_source = "ego" if source_filter == "user" else None
-
     try:
         if status_filter:
             items = await follow_ups.get_by_status(rt.db, status_filter)
@@ -50,8 +47,6 @@ async def follow_up_list():
                 items = [i for i in items if i.get("source") == "foreground_session"]
             elif source_mode == "system":
                 items = [i for i in items if i.get("source") != "foreground_session"]
-            elif exclude_source:
-                items = [i for i in items if exclude_source not in i.get("source", "")]
             items = items[:limit]
         else:
             items = await follow_ups.get_recent(

--- a/src/genesis/dashboard/routes/follow_ups.py
+++ b/src/genesis/dashboard/routes/follow_ups.py
@@ -32,20 +32,30 @@ async def follow_up_list():
 
     status_filter = request.args.get("status", "").strip() or None
     source_filter = request.args.get("source", "").strip() or None
+    source_mode = request.args.get("source_mode", "all").strip()
     limit = min(request.args.get("limit", 30, type=int), 200)
 
-    # source=user excludes ego-generated follow-ups from the view
+    # Backward compat: source=user maps to source_mode=mine
+    if source_filter == "user" and source_mode == "all":
+        source_mode = "mine"
+
+    # Legacy exclude_source only used when source_mode is "all"
     exclude_source = "ego" if source_filter == "user" else None
 
     try:
         if status_filter:
             items = await follow_ups.get_by_status(rt.db, status_filter)
-            if exclude_source:
+            # Apply source_mode filter post-query for status-filtered results
+            if source_mode == "mine":
+                items = [i for i in items if i.get("source") == "foreground_session"]
+            elif source_mode == "system":
+                items = [i for i in items if i.get("source") != "foreground_session"]
+            elif exclude_source:
                 items = [i for i in items if exclude_source not in i.get("source", "")]
             items = items[:limit]
         else:
             items = await follow_ups.get_recent(
-                rt.db, limit=limit, exclude_source=exclude_source,
+                rt.db, limit=limit, source_mode=source_mode,
             )
 
         counts = await follow_ups.get_summary_counts(rt.db)

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -176,6 +176,7 @@
         sessionsExpanded: null,
         followUpsList: [],
         followUpsView: 'active',   // 'active' or 'all'
+        followUpsSourceMode: 'all', // 'all' | 'mine' | 'system'
         followUpsCounts: {},
         followUpsExpanded: null,
 
@@ -768,7 +769,9 @@
         },
         async fetchFollowUps() {
           try {
-            const resp = await fetchApi("/api/genesis/follow-ups?limit=50");
+            const sm = this.followUpsSourceMode;
+            const url = `/api/genesis/follow-ups?limit=50${sm !== 'all' ? '&source_mode=' + sm : ''}`;
+            const resp = await fetchApi(url);
             if (resp && resp.ok) {
               const data = await resp.json();
               this.followUpsList = data.follow_ups || [];
@@ -8280,6 +8283,17 @@
           <button style="font-size:0.72rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer; transition:all 0.15s;"
                   :style="$store.genesisDashboard.followUpsView === 'all' ? 'background:#2196F333; border:1px solid #2196F3; color:#2196F3; font-weight:600;' : 'background:transparent; border:1px solid #666; color:#aaa;'"
                   @click="$store.genesisDashboard.followUpsView = 'all'">All</button>
+          <!-- Source filter -->
+          <span style="border-left:1px solid #555; margin:0 0.25rem;"></span>
+          <button style="font-size:0.72rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer; transition:all 0.15s;"
+                  :style="$store.genesisDashboard.followUpsSourceMode === 'all' ? 'background:#9c27b033; border:1px solid #9c27b0; color:#9c27b0; font-weight:600;' : 'background:transparent; border:1px solid #666; color:#aaa;'"
+                  @click="$store.genesisDashboard.followUpsSourceMode = 'all'; $store.genesisDashboard.fetchFollowUps()">All Sources</button>
+          <button style="font-size:0.72rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer; transition:all 0.15s;"
+                  :style="$store.genesisDashboard.followUpsSourceMode === 'mine' ? 'background:#ff980033; border:1px solid #ff9800; color:#ff9800; font-weight:600;' : 'background:transparent; border:1px solid #666; color:#aaa;'"
+                  @click="$store.genesisDashboard.followUpsSourceMode = 'mine'; $store.genesisDashboard.fetchFollowUps()">Mine</button>
+          <button style="font-size:0.72rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer; transition:all 0.15s;"
+                  :style="$store.genesisDashboard.followUpsSourceMode === 'system' ? 'background:#00bcd433; border:1px solid #00bcd4; color:#00bcd4; font-weight:600;' : 'background:transparent; border:1px solid #666; color:#aaa;'"
+                  @click="$store.genesisDashboard.followUpsSourceMode = 'system'; $store.genesisDashboard.fetchFollowUps()">System</button>
         </div>
         <template x-if="$store.genesisDashboard.followUpsList.filter(f => {
           if ($store.genesisDashboard.followUpsView === 'active') return ['pending','in_progress','blocked'].includes(f.status);

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -297,6 +297,7 @@ async def get_recently_resolved(
     limit: int = 20,
 ) -> list[dict]:
     """Get recently completed follow-ups, optionally filtered by source."""
+    days = max(1, days)
     query = "SELECT * FROM follow_ups WHERE status = 'completed'"
     params: list[str | int] = []
     if source:

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -221,6 +221,7 @@ async def get_recent(
     *,
     limit: int = 20,
     exclude_source: str | None = None,
+    source_mode: str = "all",
 ) -> list[dict]:
     """Get recent follow-ups for dashboard display.
 
@@ -229,8 +230,28 @@ async def get_recent(
     exclude_source:
         If set, exclude rows where ``source LIKE %{exclude_source}%``.
         Use ``"ego"`` to hide ego-generated follow-ups from the user view.
+    source_mode:
+        Filter by source category:
+        - ``"all"`` — no filter (default)
+        - ``"mine"`` — only ``foreground_session`` source
+        - ``"system"`` — everything except ``foreground_session``
+        Takes precedence over ``exclude_source`` when not ``"all"``.
     """
-    if exclude_source:
+    if source_mode == "mine":
+        cursor = await db.execute(
+            "SELECT * FROM follow_ups "
+            "WHERE source = 'foreground_session' "
+            "ORDER BY created_at DESC LIMIT ?",
+            (limit,),
+        )
+    elif source_mode == "system":
+        cursor = await db.execute(
+            "SELECT * FROM follow_ups "
+            "WHERE source != 'foreground_session' "
+            "ORDER BY created_at DESC LIMIT ?",
+            (limit,),
+        )
+    elif exclude_source:
         cursor = await db.execute(
             "SELECT * FROM follow_ups "
             "WHERE source NOT LIKE ? "
@@ -242,6 +263,50 @@ async def get_recent(
             "SELECT * FROM follow_ups ORDER BY created_at DESC LIMIT ?",
             (limit,),
         )
+    return [dict(row) for row in await cursor.fetchall()]
+
+
+async def get_by_source(
+    db: aiosqlite.Connection,
+    source: str,
+    *,
+    status: str | None = None,
+    days: int | None = None,
+    limit: int = 50,
+) -> list[dict]:
+    """Get follow-ups by source, optionally filtered by status and recency."""
+    query = "SELECT * FROM follow_ups WHERE source = ?"
+    params: list[str | int] = [source]
+    if status:
+        query += " AND status = ?"
+        params.append(status)
+    if days:
+        query += " AND created_at >= datetime('now', ? || ' days')"
+        params.append(f"-{days}")
+    query += " ORDER BY created_at DESC LIMIT ?"
+    params.append(limit)
+    cursor = await db.execute(query, params)
+    return [dict(row) for row in await cursor.fetchall()]
+
+
+async def get_recently_resolved(
+    db: aiosqlite.Connection,
+    *,
+    source: str | None = None,
+    days: int = 7,
+    limit: int = 20,
+) -> list[dict]:
+    """Get recently completed follow-ups, optionally filtered by source."""
+    query = "SELECT * FROM follow_ups WHERE status = 'completed'"
+    params: list[str | int] = []
+    if source:
+        query += " AND source = ?"
+        params.append(source)
+    query += " AND completed_at >= datetime('now', ? || ' days')"
+    params.append(f"-{days}")
+    query += " ORDER BY completed_at DESC LIMIT ?"
+    params.append(limit)
+    cursor = await db.execute(query, params)
     return [dict(row) for row in await cursor.fetchall()]
 
 

--- a/src/genesis/db/crud/inbox_items.py
+++ b/src/genesis/db/crud/inbox_items.py
@@ -379,3 +379,26 @@ async def query_by_batch(db: aiosqlite.Connection, batch_id: str) -> list[dict]:
         (batch_id,),
     )
     return [dict(r) for r in await cursor.fetchall()]
+
+
+async def get_recent_completed(
+    db: aiosqlite.Connection,
+    *,
+    days: int = 7,
+    limit: int = 20,
+) -> list[dict]:
+    """Return recently completed inbox items with response paths.
+
+    Used by the inbox digest tool to show what was evaluated recently.
+    """
+    cursor = await db.execute(
+        """SELECT id, file_path, response_path, batch_id,
+                  created_at, processed_at
+           FROM inbox_items
+           WHERE status = 'completed'
+             AND response_path IS NOT NULL
+             AND created_at >= datetime('now', ? || ' days')
+           ORDER BY created_at DESC LIMIT ?""",
+        (f"-{days}", limit),
+    )
+    return [dict(row) for row in await cursor.fetchall()]

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -1196,6 +1196,25 @@ class InboxMonitor:
                     errors.append(err)
                     logger.error(err)
 
+            # Create follow-ups from Recommendation blocks (non-fatal)
+            if output_text:
+                try:
+                    fu_count = await self._create_follow_ups_from_eval(
+                        evaluation_text=output_text,
+                        batch_id=batch_id,
+                        source_files=[item.file_path for item in batch],
+                    )
+                    if fu_count:
+                        logger.info(
+                            "Created %d follow-up(s) from inbox eval %s",
+                            fu_count, batch_id[:8],
+                        )
+                except Exception:
+                    logger.warning(
+                        "Follow-up creation from inbox eval failed (non-fatal)",
+                        exc_info=True,
+                    )
+
             url_failures = _has_url_failures(output_text, batch_content)
             if url_failures:
                 logger.warning(
@@ -1409,6 +1428,70 @@ class InboxMonitor:
                     "check.failed",
                     "Inbox check failed with exception",
                 )
+
+    # ------------------------------------------------------------------
+    # Follow-up creation from evaluation Recommendation blocks
+    # ------------------------------------------------------------------
+
+    # Classification → (strategy, priority, pinned)
+    _ACTION_MAP: dict[str, tuple[str, str, bool]] = {
+        "adopt":  ("user_input_needed", "high",   True),
+        "adapt":  ("user_input_needed", "medium", True),
+        "watch":  ("ego_judgment",      "low",    False),
+        "explore": ("user_input_needed", "medium", True),
+        "bookmark": ("ego_judgment",     "low",    False),
+    }
+
+    async def _create_follow_ups_from_eval(
+        self,
+        evaluation_text: str,
+        batch_id: str,
+        source_files: list[str],
+    ) -> int:
+        """Parse Recommendation blocks and create follow-ups for actionable items.
+
+        Returns the number of follow-ups created.
+        """
+        from genesis.db.crud import follow_ups
+        from genesis.inbox.recommendation import parse_recommendations
+
+        recs = parse_recommendations(evaluation_text)
+        created = 0
+        source_name = ", ".join(Path(f).name for f in source_files)
+
+        for rec in recs:
+            if not rec.is_actionable:
+                continue
+
+            action_key = rec.action.lower().replace("_", " ").strip()
+            mapping = self._ACTION_MAP.get(action_key)
+            if mapping is None:
+                logger.debug(
+                    "Unmapped action '%s' — skipping follow-up", rec.action,
+                )
+                continue
+
+            strategy, priority, pinned = mapping
+
+            title = rec.item_title or "Untitled"
+            content = f"[{rec.action.upper()}] {title}: {rec.next_step}"
+            reason = (
+                f"Inbox evaluation {batch_id[:8]}: {source_name}. "
+                f"Confidence: {rec.confidence}. Effort: {rec.effort}."
+            )
+
+            await follow_ups.create(
+                self._db,
+                content=content,
+                source="inbox_evaluation",
+                reason=reason,
+                strategy=strategy,
+                priority=priority,
+                pinned=pinned,
+            )
+            created += 1
+
+        return created
 
 
 def _compute_new_content(old_content: str, new_content: str) -> str:

--- a/src/genesis/inbox/recommendation.py
+++ b/src/genesis/inbox/recommendation.py
@@ -73,12 +73,6 @@ _YAML_BLOCK_RE = re.compile(
     r"```\s*yaml\s*\n(.*?)```", re.DOTALL,
 )
 
-# Extract item title from ## heading line
-_TITLE_RE = re.compile(
-    r"^## (?:\d+\.\s*)?(.+?)(?:\s*\{.*\})?\s*$", re.MULTILINE,
-)
-
-
 def parse_recommendations(evaluation_text: str) -> list[Recommendation]:
     """Extract all Recommendation YAML blocks from an evaluation response.
 

--- a/src/genesis/inbox/recommendation.py
+++ b/src/genesis/inbox/recommendation.py
@@ -1,0 +1,188 @@
+"""Parse Recommendation YAML blocks from inbox evaluation output.
+
+Inbox evaluations produce `.genesis.md` files with structured
+``### Recommendation`` YAML blocks.  This module extracts those blocks
+so downstream systems (follow-up creation, digest) can consume them
+programmatically.
+
+Two vocabularies:
+- Genesis-relevant: ADOPT | ADAPT | WATCH | IGNORE
+- User-relevant:    adopt | explore | bookmark | potential_skip
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# Actions that should NOT produce follow-ups.
+_SKIP_ACTIONS: frozenset[str] = frozenset({
+    "ignore",
+    "potential_skip",
+    "potential skip",
+})
+
+# ---------------------------------------------------------------------------
+# Dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Recommendation:
+    """A single parsed Recommendation from an inbox evaluation."""
+
+    action: str
+    next_step: str
+    effort: str = "Small"
+    confidence: str = "medium"
+    # Genesis-relevant fields
+    scope: str | None = None
+    architecture_impact: str | None = None
+    # User-relevant fields
+    timeline: str | None = None
+    relevance: str | None = None
+    # Context
+    item_title: str = ""
+    classification: str = ""  # "genesis" or "user"
+
+    @property
+    def is_actionable(self) -> bool:
+        """True when this recommendation should produce a follow-up."""
+        return self.action.lower().replace("_", " ") not in _SKIP_ACTIONS
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+# Match ## N. Title  or  ## Title  headings (item sections in multi-item evals)
+_SECTION_RE = re.compile(r"^## ", re.MULTILINE)
+
+# Match ### Recommendation heading
+_REC_HEADING_RE = re.compile(
+    r"^### Recommendation\s*$", re.MULTILINE,
+)
+
+# Match ```yaml ... ``` fenced code block (tolerant of whitespace)
+_YAML_BLOCK_RE = re.compile(
+    r"```\s*yaml\s*\n(.*?)```", re.DOTALL,
+)
+
+# Extract item title from ## heading line
+_TITLE_RE = re.compile(
+    r"^## (?:\d+\.\s*)?(.+?)(?:\s*\{.*\})?\s*$", re.MULTILINE,
+)
+
+
+def parse_recommendations(evaluation_text: str) -> list[Recommendation]:
+    """Extract all Recommendation YAML blocks from an evaluation response.
+
+    Handles multi-item evaluations where each ``## N. Title`` section has
+    its own ``### Recommendation`` block with a fenced YAML code block.
+
+    Returns an empty list if no valid recommendations are found.  Malformed
+    blocks are logged and skipped — never raises.
+    """
+    if not evaluation_text:
+        return []
+
+    results: list[Recommendation] = []
+
+    # Split evaluation text into per-item sections on ## headings.
+    # The first chunk (before the first ##) is preamble — skip it.
+    sections = _SECTION_RE.split(evaluation_text)
+
+    for section in sections:
+        # Look for ### Recommendation in this section
+        rec_match = _REC_HEADING_RE.search(section)
+        if not rec_match:
+            continue
+
+        # Find the YAML fenced block after the heading
+        after_heading = section[rec_match.end():]
+        yaml_match = _YAML_BLOCK_RE.search(after_heading)
+        if not yaml_match:
+            logger.debug(
+                "### Recommendation heading found but no ```yaml block follows",
+            )
+            continue
+
+        yaml_text = yaml_match.group(1)
+        try:
+            data = yaml.safe_load(yaml_text)
+        except yaml.YAMLError as exc:
+            logger.warning("Malformed YAML in Recommendation block: %s", exc)
+            continue
+
+        if not isinstance(data, dict):
+            logger.warning(
+                "Recommendation YAML is not a mapping: %s", type(data).__name__,
+            )
+            continue
+
+        # Extract action — required field
+        action = data.get("action")
+        if not action:
+            logger.warning("Recommendation block missing 'action' field")
+            continue
+
+        action = str(action).strip()
+        next_step = str(data.get("next_step", "")).strip()
+
+        # Detect classification by field presence
+        has_scope = "scope" in data
+        has_timeline = "timeline" in data
+        if has_scope:
+            classification = "genesis"
+        elif has_timeline:
+            classification = "user"
+        else:
+            # Fallback: uppercase action = genesis, lowercase = user
+            classification = "genesis" if action == action.upper() else "user"
+
+        # Extract item title from the ## heading
+        title = _extract_item_title(section)
+
+        rec = Recommendation(
+            action=action,
+            next_step=next_step,
+            effort=str(data.get("effort", "Small")).strip(),
+            confidence=str(data.get("confidence", "medium")).strip(),
+            scope=str(data["scope"]).strip() if has_scope else None,
+            architecture_impact=(
+                str(data["architecture_impact"]).strip()
+                if "architecture_impact" in data else None
+            ),
+            timeline=(
+                str(data["timeline"]).strip()
+                if has_timeline else None
+            ),
+            relevance=(
+                str(data["relevance"]).strip()
+                if "relevance" in data else None
+            ),
+            item_title=title,
+            classification=classification,
+        )
+        results.append(rec)
+
+    return results
+
+
+def _extract_item_title(section_text: str) -> str:
+    """Extract the item title from the first line of a ## section.
+
+    The section_text is everything AFTER the ``## `` prefix (since we split
+    on ``^## ``).  So the title is the first line.
+    """
+    first_line = section_text.split("\n", 1)[0].strip()
+    # Strip leading number + dot (e.g., "1. Evo — Autoresearch...")
+    numbered = re.match(r"^\d+\.\s*(.+)$", first_line)
+    if numbered:
+        return numbered.group(1).strip()
+    return first_line

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -63,6 +63,7 @@ from genesis.mcp.health import direct_session_tools as _direct_session_tools  # 
 from genesis.mcp.health import ego_tools as _ego_tools  # noqa: E402
 from genesis.mcp.health import errors as _errors  # noqa: E402
 from genesis.mcp.health import follow_up_tools as _follow_up_tools  # noqa: E402
+from genesis.mcp.health import inbox_digest as _inbox_digest  # noqa: E402
 from genesis.mcp.health import j9_eval as _j9_eval  # noqa: E402, F401
 from genesis.mcp.health import manifest as _manifest  # noqa: E402
 from genesis.mcp.health import module_ops as _module_ops  # noqa: E402
@@ -115,6 +116,7 @@ _impl_browser_clear_domain = _browser._impl_browser_clear_domain
 _impl_update_history_recent = _update_history._impl_update_history_recent
 _impl_follow_up_create = _follow_up_tools._impl_follow_up_create
 _impl_follow_up_list = _follow_up_tools._impl_follow_up_list
+_impl_inbox_digest = _inbox_digest._impl_inbox_digest
 _impl_ego_focus_reset = _ego_tools._impl_ego_focus_reset
 
 # direct_session_tools wired here
@@ -175,6 +177,8 @@ __all__ = [
     "_follow_up_tools",
     "_impl_follow_up_create",
     "_impl_follow_up_list",
+    "_inbox_digest",
+    "_impl_inbox_digest",
     "_ego_tools",
     "_impl_ego_focus_reset",
     "direct_session_tools",

--- a/src/genesis/mcp/health/inbox_digest.py
+++ b/src/genesis/mcp/health/inbox_digest.py
@@ -1,0 +1,188 @@
+"""inbox_digest MCP tool — prioritized digest of recent inbox evaluations.
+
+Provides an on-demand summary of recent inbox evaluation output and
+related follow-ups for foreground session review.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+
+def _get_db():
+    """Late-import DB from the health MCP module state."""
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    svc = health_mcp_mod._service
+    if svc is None:
+        return None
+    return getattr(svc, "_db", None)
+
+
+# ---------------------------------------------------------------------------
+# Implementation (testable without FastMCP)
+# ---------------------------------------------------------------------------
+
+
+async def _impl_inbox_digest(
+    days: int = 7,
+    include_resolved: bool = False,
+) -> dict:
+    """Build a prioritized digest of recent inbox evaluations and follow-ups.
+
+    Returns a dict with:
+    - summary: one-line status string
+    - pending_follow_ups: list of inbox-sourced pending follow-ups
+    - resolved_follow_ups: list of inbox-sourced completed follow-ups (if requested)
+    - recent_evaluations: list of completed inbox items
+    - formatted: markdown table for direct display
+    """
+    db = _get_db()
+    if db is None:
+        return {"error": "Database not available"}
+
+    try:
+        from genesis.db.crud import follow_ups as fu_crud
+        from genesis.db.crud import inbox_items as inbox_crud
+
+        # 1. Pending inbox follow-ups
+        pending = await fu_crud.get_by_source(
+            db, "inbox_evaluation", status="pending",
+        )
+
+        # 2. Recently resolved inbox follow-ups
+        resolved = []
+        if include_resolved:
+            resolved = await fu_crud.get_recently_resolved(
+                db, source="inbox_evaluation", days=days,
+            )
+
+        # 3. Recent completed evaluations
+        evals = await inbox_crud.get_recent_completed(db, days=days)
+
+        # Build formatted output
+        formatted = _format_digest(pending, resolved, evals, days)
+
+        # Summary line
+        parts = [f"{len(pending)} pending"]
+        if resolved:
+            parts.append(f"{len(resolved)} resolved")
+        parts.append(f"{len(evals)} evaluated")
+        summary = f"Inbox digest ({days}d): {', '.join(parts)}"
+
+        return {
+            "summary": summary,
+            "pending_follow_ups": pending,
+            "resolved_follow_ups": resolved,
+            "recent_evaluations": evals,
+            "formatted": formatted,
+        }
+    except Exception as exc:
+        logger.error("inbox_digest failed", exc_info=True)
+        return {"error": f"Failed to generate inbox digest: {exc}"}
+
+
+def _format_digest(
+    pending: list[dict],
+    resolved: list[dict],
+    evals: list[dict],
+    days: int,
+) -> str:
+    """Format digest data into markdown tables."""
+    lines = [f"## Inbox Digest — Last {days} Days", ""]
+
+    # Pending action items
+    if pending:
+        lines.append(f"### Pending Action ({len(pending)} items)")
+        lines.append("")
+        lines.append("| Priority | Item | Strategy |")
+        lines.append("|----------|------|----------|")
+        for fu in pending:
+            priority = fu.get("priority", "medium")
+            content = fu.get("content", "")[:120]
+            strategy = fu.get("strategy", "")
+            lines.append(f"| {priority} | {content} | {strategy} |")
+        lines.append("")
+
+    # Resolved items
+    if resolved:
+        lines.append(f"### Recently Resolved ({len(resolved)} items)")
+        lines.append("")
+        lines.append("| Item | Resolution | When |")
+        lines.append("|------|------------|------|")
+        for fu in resolved:
+            content = fu.get("content", "")[:100]
+            notes = (fu.get("resolution_notes") or "—")[:80]
+            completed_at = fu.get("completed_at", "")
+            age = _relative_age(completed_at)
+            lines.append(f"| {content} | {notes} | {age} |")
+        lines.append("")
+
+    # Recent evaluations
+    if evals:
+        lines.append(f"### Evaluations ({len(evals)} completed)")
+        lines.append("")
+        lines.append("| Date | Source | Response |")
+        lines.append("|------|--------|----------|")
+        for ev in evals:
+            created = ev.get("created_at", "")[:10]
+            source_file = Path(ev.get("file_path", "")).name
+            response = Path(ev.get("response_path", "")).name if ev.get("response_path") else "—"
+            lines.append(f"| {created} | {source_file} | {response} |")
+        lines.append("")
+
+    if not pending and not resolved and not evals:
+        lines.append("No inbox activity in this period.")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _relative_age(iso_timestamp: str) -> str:
+    """Convert ISO timestamp to human-readable relative age."""
+    if not iso_timestamp:
+        return "—"
+    try:
+        ts = datetime.fromisoformat(iso_timestamp.replace("Z", "+00:00"))
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+        delta = datetime.now(UTC) - ts
+        if delta < timedelta(hours=1):
+            return f"{max(1, int(delta.total_seconds() / 60))}m ago"
+        if delta < timedelta(days=1):
+            return f"{int(delta.total_seconds() / 3600)}h ago"
+        return f"{delta.days}d ago"
+    except (ValueError, TypeError):
+        return "—"
+
+
+# ---------------------------------------------------------------------------
+# MCP tool decorator
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def inbox_digest(
+    days: int = 7,
+    include_resolved: bool = False,
+) -> str:
+    """Prioritized digest of recent inbox evaluations and related follow-ups.
+
+    Shows pending action items from inbox evaluations, recently resolved items,
+    and completed evaluations. Call this when reviewing inbox evaluation output
+    or at the start of a foreground session to catch up on inbox activity.
+
+    Args:
+        days: Look-back window in days (default 7)
+        include_resolved: Include recently resolved follow-ups (default false)
+    """
+    result = await _impl_inbox_digest(days=days, include_resolved=include_resolved)
+    if "error" in result:
+        return result["error"]
+    return result["formatted"]

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -163,6 +163,14 @@ class MorningReportGenerator:
         except Exception:
             logger.warning("Morning report: follow-ups unavailable", exc_info=True)
 
+        # 5b. Inbox follow-ups resolved by ego (weekly safety net)
+        try:
+            inbox_resolved = await self._get_inbox_resolved_digest()
+            if inbox_resolved:
+                sections.append(f"## Inbox Follow-ups (Ego-resolved)\n{inbox_resolved}")
+        except Exception:
+            logger.warning("Morning report: inbox resolved digest unavailable", exc_info=True)
+
         # 6. Outreach summary (just total count, no self-analysis)
         try:
             engagement = await self._get_engagement_summary()
@@ -435,6 +443,28 @@ class MorningReportGenerator:
                 lines.append(f"- ✓ {row[0][:200]}")
 
         return "\n".join(lines) if lines else None
+
+    async def _get_inbox_resolved_digest(self) -> str | None:
+        """Weekly digest of inbox follow-ups resolved by ego.
+
+        Only included when there are ego-resolved inbox follow-ups in the
+        last 7 days. Gives the user visibility into what the ego handled
+        without requiring them to check the dashboard.
+        """
+        from genesis.db.crud import follow_ups
+
+        resolved = await follow_ups.get_recently_resolved(
+            self._db, source="inbox_evaluation", days=7,
+        )
+        if not resolved:
+            return None
+
+        lines = [f"Ego resolved {len(resolved)} inbox follow-up(s) this week:"]
+        for fu in resolved[:10]:
+            content = (fu.get("content") or "?")[:150]
+            notes = (fu.get("resolution_notes") or "no notes")[:100]
+            lines.append(f"- {content} — {notes}")
+        return "\n".join(lines)
 
     async def _get_critical_issues(self) -> str | None:
         """Return critical issues text ONLY if WARNING+ alerts are active.

--- a/tests/test_inbox/test_inbox_digest.py
+++ b/tests/test_inbox/test_inbox_digest.py
@@ -1,0 +1,249 @@
+"""Tests for inbox_digest MCP tool and supporting CRUD functions."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import follow_ups as fu_crud
+from genesis.db.crud import inbox_items as inbox_crud
+
+
+@pytest.fixture
+async def db():
+    """In-memory DB with follow_ups and inbox_items tables."""
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await conn.execute("""CREATE TABLE follow_ups (
+        id TEXT PRIMARY KEY,
+        source TEXT NOT NULL,
+        source_session TEXT,
+        content TEXT NOT NULL,
+        reason TEXT,
+        strategy TEXT,
+        scheduled_at TEXT,
+        status TEXT DEFAULT 'pending',
+        linked_task_id TEXT,
+        priority TEXT DEFAULT 'medium',
+        created_at TEXT NOT NULL,
+        completed_at TEXT,
+        resolution_notes TEXT,
+        blocked_reason TEXT,
+        escalated_to TEXT,
+        verified_at TEXT,
+        verification_notes TEXT,
+        pinned INTEGER DEFAULT 0
+    )""")
+    await conn.execute("""CREATE TABLE inbox_items (
+        id TEXT PRIMARY KEY,
+        file_path TEXT NOT NULL,
+        content_hash TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        batch_id TEXT,
+        response_path TEXT,
+        created_at TEXT NOT NULL,
+        processed_at TEXT,
+        error_message TEXT,
+        retry_count INTEGER NOT NULL DEFAULT 0,
+        evaluated_content TEXT
+    )""")
+    await conn.commit()
+    yield conn
+    await conn.close()
+
+
+def _now_iso(offset_days: int = 0) -> str:
+    dt = datetime.now(UTC) + timedelta(days=offset_days)
+    return dt.isoformat()
+
+
+class TestGetBySource:
+    async def test_returns_matching_source(self, db):
+        await fu_crud.create(
+            db, content="inbox item", source="inbox_evaluation",
+            reason="test", strategy="ego_judgment",
+        )
+        await fu_crud.create(
+            db, content="user item", source="foreground_session",
+            reason="test", strategy="user_input_needed",
+        )
+
+        results = await fu_crud.get_by_source(db, "inbox_evaluation")
+        assert len(results) == 1
+        assert results[0]["source"] == "inbox_evaluation"
+
+    async def test_filters_by_status(self, db):
+        fid = await fu_crud.create(
+            db, content="completed", source="inbox_evaluation",
+            reason="test", strategy="ego_judgment",
+        )
+        await fu_crud.update_status(db, fid, "completed", resolution_notes="done")
+        await fu_crud.create(
+            db, content="pending", source="inbox_evaluation",
+            reason="test", strategy="ego_judgment",
+        )
+
+        pending = await fu_crud.get_by_source(db, "inbox_evaluation", status="pending")
+        assert len(pending) == 1
+        assert pending[0]["content"] == "pending"
+
+    async def test_empty_for_unknown_source(self, db):
+        results = await fu_crud.get_by_source(db, "nonexistent")
+        assert results == []
+
+
+class TestGetRecentlyResolved:
+    async def test_returns_completed_in_window(self, db):
+        fid = await fu_crud.create(
+            db, content="resolved item", source="inbox_evaluation",
+            reason="test", strategy="ego_judgment",
+        )
+        await fu_crud.update_status(db, fid, "completed", resolution_notes="ego resolved")
+
+        results = await fu_crud.get_recently_resolved(
+            db, source="inbox_evaluation", days=7,
+        )
+        assert len(results) == 1
+        assert results[0]["content"] == "resolved item"
+
+    async def test_excludes_pending(self, db):
+        await fu_crud.create(
+            db, content="still pending", source="inbox_evaluation",
+            reason="test", strategy="ego_judgment",
+        )
+
+        results = await fu_crud.get_recently_resolved(
+            db, source="inbox_evaluation", days=7,
+        )
+        assert results == []
+
+    async def test_days_zero_guard(self, db):
+        """days=0 should be clamped to 1, not return empty."""
+        fid = await fu_crud.create(
+            db, content="just resolved", source="inbox_evaluation",
+            reason="test", strategy="ego_judgment",
+        )
+        await fu_crud.update_status(db, fid, "completed")
+
+        results = await fu_crud.get_recently_resolved(
+            db, source="inbox_evaluation", days=0,
+        )
+        # Should find it (days clamped to 1, item was just completed)
+        assert len(results) == 1
+
+
+class TestGetRecentCompleted:
+    async def test_returns_completed_with_response(self, db):
+        now = _now_iso()
+        await db.execute(
+            """INSERT INTO inbox_items
+               (id, file_path, content_hash, status, response_path, created_at, processed_at)
+               VALUES (?, ?, ?, 'completed', ?, ?, ?)""",
+            (str(uuid.uuid4()), "/inbox/Genesis.md", "abc123",
+             "/inbox/Genesis-1.genesis.md", now, now),
+        )
+        await db.commit()
+
+        results = await inbox_crud.get_recent_completed(db, days=7)
+        assert len(results) == 1
+        assert results[0]["response_path"] == "/inbox/Genesis-1.genesis.md"
+
+    async def test_excludes_no_response(self, db):
+        now = _now_iso()
+        await db.execute(
+            """INSERT INTO inbox_items
+               (id, file_path, content_hash, status, created_at, processed_at)
+               VALUES (?, ?, ?, 'completed', ?, ?)""",
+            (str(uuid.uuid4()), "/inbox/Genesis.md", "abc123", now, now),
+        )
+        await db.commit()
+
+        results = await inbox_crud.get_recent_completed(db, days=7)
+        assert results == []
+
+    async def test_excludes_old_items(self, db):
+        old = _now_iso(offset_days=-30)
+        await db.execute(
+            """INSERT INTO inbox_items
+               (id, file_path, content_hash, status, response_path, created_at, processed_at)
+               VALUES (?, ?, ?, 'completed', ?, ?, ?)""",
+            (str(uuid.uuid4()), "/inbox/Genesis.md", "abc123",
+             "/inbox/Genesis-1.genesis.md", old, old),
+        )
+        await db.commit()
+
+        results = await inbox_crud.get_recent_completed(db, days=7)
+        assert results == []
+
+
+class TestGetRecentSourceMode:
+    async def test_mine_returns_foreground_only(self, db):
+        await fu_crud.create(
+            db, content="user item", source="foreground_session",
+            reason="test", strategy="user_input_needed",
+        )
+        await fu_crud.create(
+            db, content="system item", source="inbox_evaluation",
+            reason="test", strategy="ego_judgment",
+        )
+
+        mine = await fu_crud.get_recent(db, source_mode="mine")
+        assert len(mine) == 1
+        assert mine[0]["source"] == "foreground_session"
+
+    async def test_system_excludes_foreground(self, db):
+        await fu_crud.create(
+            db, content="user item", source="foreground_session",
+            reason="test", strategy="user_input_needed",
+        )
+        await fu_crud.create(
+            db, content="system item", source="inbox_evaluation",
+            reason="test", strategy="ego_judgment",
+        )
+
+        system = await fu_crud.get_recent(db, source_mode="system")
+        assert len(system) == 1
+        assert system[0]["source"] == "inbox_evaluation"
+
+    async def test_all_returns_everything(self, db):
+        await fu_crud.create(
+            db, content="user", source="foreground_session",
+            reason="test", strategy="user_input_needed",
+        )
+        await fu_crud.create(
+            db, content="system", source="inbox_evaluation",
+            reason="test", strategy="ego_judgment",
+        )
+
+        all_items = await fu_crud.get_recent(db, source_mode="all")
+        assert len(all_items) == 2
+
+
+class TestFormatDigest:
+    def test_format_with_data(self):
+        from genesis.mcp.health.inbox_digest import _format_digest
+
+        pending = [
+            {"priority": "high", "content": "[ADOPT] Tool X: Do thing", "strategy": "user_input_needed"},
+            {"priority": "low", "content": "[WATCH] Tool Y: Bookmark", "strategy": "ego_judgment"},
+        ]
+        evals = [
+            {"created_at": "2026-06-06", "file_path": "/inbox/Genesis.md",
+             "response_path": "/inbox/Genesis-53.genesis.md"},
+        ]
+
+        output = _format_digest(pending, [], evals, 7)
+        assert "## Inbox Digest" in output
+        assert "Pending Action (2 items)" in output
+        assert "[ADOPT] Tool X" in output
+        assert "Evaluations (1 completed)" in output
+        assert "Genesis.md" in output
+
+    def test_format_empty(self):
+        from genesis.mcp.health.inbox_digest import _format_digest
+
+        output = _format_digest([], [], [], 7)
+        assert "No inbox activity" in output

--- a/tests/test_inbox/test_recommendation.py
+++ b/tests/test_inbox/test_recommendation.py
@@ -1,0 +1,362 @@
+"""Tests for genesis.inbox.recommendation — YAML block parser."""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.inbox.recommendation import (
+    Recommendation,
+    _extract_item_title,
+    parse_recommendations,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — trimmed from real production output
+# ---------------------------------------------------------------------------
+
+GENESIS_SINGLE = """\
+---
+date: 2026-06-06
+---
+
+# Inbox Evaluation — 2026-06-06
+
+## 1. Evo — Autoresearch Loop for Codebase Optimization
+
+**Classification:** Genesis-relevant | **Decision:** Research
+
+### Summary
+
+Evo applies autoresearch methodology to automated codebase improvement.
+
+### Recommendation
+
+```yaml
+action: ADAPT
+next_step: "Prototype a metric-gated selection pattern for surplus code tasks"
+effort: Medium
+scope: V4
+confidence: medium
+architecture_impact: extends
+```
+
+### Lens 1: How It Helps Genesis
+
+Some analysis here.
+"""
+
+USER_SINGLE = """\
+---
+date: 2026-06-06
+---
+
+# Inbox Evaluation — 2026-06-06
+
+## AI Engineer/architect
+
+**Classification:** Personal note — career musing | **Decision:** Research
+
+### Summary
+
+A role-title refinement signal.
+
+### Recommendation
+
+```yaml
+action: explore
+next_step: "Audit your current application targets against AI Engineer vs AI Architect role titles"
+effort: Small
+timeline: Soon
+relevance: Direct
+confidence: high
+```
+
+### Lens 1: What This Is
+
+Some analysis here.
+"""
+
+MULTI_ITEM = """\
+---
+date: 2026-06-06
+---
+
+# Inbox Evaluation — 2026-06-06
+
+Genesis evaluated 4 items.
+
+---
+
+## 1. Evo — Autoresearch Loop
+
+**Classification:** Genesis-relevant | **Decision:** Research
+
+### Summary
+
+Evo stuff.
+
+### Recommendation
+
+```yaml
+action: ADAPT
+next_step: "Prototype a metric-gated selection pattern"
+effort: Medium
+scope: V4
+confidence: medium
+architecture_impact: extends
+```
+
+### Lens 1: How It Helps Genesis
+
+---
+
+## 2. Memanto — Agent Memory
+
+**Classification:** Genesis-relevant | **Decision:** Research
+
+### Summary
+
+Memanto stuff.
+
+### Recommendation
+
+```yaml
+action: ADAPT
+next_step: "Audit Genesis memory_store schema for supersession fields"
+effort: Medium
+scope: V3
+confidence: high
+architecture_impact: extends
+```
+
+---
+
+## 3. Forkd — Fork-Based MicroVM Sandboxing
+
+**Classification:** Genesis-relevant | **Decision:** Research
+
+### Summary
+
+Forkd stuff.
+
+### Recommendation
+
+```yaml
+action: WATCH
+next_step: "Bookmark Forkd for re-evaluation in V5"
+effort: Trivial
+scope: V5
+confidence: medium
+architecture_impact: irrelevant
+```
+
+---
+
+## 4. EntityMap — Open Standard
+
+**Classification:** Genesis-relevant | **Decision:** Research
+
+### Summary
+
+EntityMap stuff.
+
+### Recommendation
+
+```yaml
+action: IGNORE
+next_step: "No action needed — low relevance"
+effort: Trivial
+scope: Never
+confidence: high
+architecture_impact: irrelevant
+```
+"""
+
+NO_RECOMMENDATION = """\
+# Inbox Evaluation — 2026-06-06
+
+## To-Do: Buy groceries
+
+**Classification:** To-Do item
+
+### Summary
+
+This is a to-do item with no Recommendation block.
+"""
+
+MALFORMED_YAML = """\
+## 1. Bad Item
+
+### Recommendation
+
+```yaml
+action: ADAPT
+next_step: "unbalanced quote
+effort: [invalid
+```
+
+## 2. Good Item
+
+### Recommendation
+
+```yaml
+action: WATCH
+next_step: "This one is fine"
+effort: Small
+scope: V4
+confidence: medium
+architecture_impact: validates
+```
+"""
+
+BOOKMARK_USER = """\
+## Karpathy on Agentic Engineering
+
+**Classification:** User-relevant
+
+### Summary
+
+Video breakdown of agentic engineering framing.
+
+### Recommendation
+
+```yaml
+action: bookmark
+next_step: "Use agentic engineering framing in networking"
+effort: Trivial
+timeline: Soon
+relevance: Direct
+confidence: high
+```
+"""
+
+POTENTIAL_SKIP = """\
+## Some Irrelevant Thing
+
+### Recommendation
+
+```yaml
+action: potential_skip
+next_step: "Probably not relevant"
+effort: Trivial
+timeline: Someday
+relevance: Background
+confidence: low
+```
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseRecommendations:
+    def test_genesis_single(self):
+        recs = parse_recommendations(GENESIS_SINGLE)
+        assert len(recs) == 1
+        r = recs[0]
+        assert r.action == "ADAPT"
+        assert r.next_step == "Prototype a metric-gated selection pattern for surplus code tasks"
+        assert r.effort == "Medium"
+        assert r.scope == "V4"
+        assert r.confidence == "medium"
+        assert r.architecture_impact == "extends"
+        assert r.classification == "genesis"
+        assert r.item_title == "Evo — Autoresearch Loop for Codebase Optimization"
+        assert r.is_actionable is True
+
+    def test_user_single(self):
+        recs = parse_recommendations(USER_SINGLE)
+        assert len(recs) == 1
+        r = recs[0]
+        assert r.action == "explore"
+        assert r.timeline == "Soon"
+        assert r.relevance == "Direct"
+        assert r.confidence == "high"
+        assert r.classification == "user"
+        assert r.scope is None
+        assert r.architecture_impact is None
+        assert r.item_title == "AI Engineer/architect"
+        assert r.is_actionable is True
+
+    def test_multi_item(self):
+        recs = parse_recommendations(MULTI_ITEM)
+        assert len(recs) == 4
+
+        actions = [r.action for r in recs]
+        assert actions == ["ADAPT", "ADAPT", "WATCH", "IGNORE"]
+
+        # All are genesis classification
+        assert all(r.classification == "genesis" for r in recs)
+
+        # ADAPT items are actionable, WATCH is actionable, IGNORE is not
+        assert recs[0].is_actionable is True
+        assert recs[1].is_actionable is True
+        assert recs[2].is_actionable is True
+        assert recs[3].is_actionable is False
+
+        # Titles extracted correctly
+        assert recs[0].item_title == "Evo — Autoresearch Loop"
+        assert recs[1].item_title == "Memanto — Agent Memory"
+        assert recs[2].item_title == "Forkd — Fork-Based MicroVM Sandboxing"
+        assert recs[3].item_title == "EntityMap — Open Standard"
+
+    def test_no_recommendation(self):
+        recs = parse_recommendations(NO_RECOMMENDATION)
+        assert recs == []
+
+    def test_empty_input(self):
+        assert parse_recommendations("") == []
+        assert parse_recommendations(None) == []  # type: ignore[arg-type]
+
+    def test_malformed_yaml_skips_bad_keeps_good(self):
+        recs = parse_recommendations(MALFORMED_YAML)
+        # The malformed block should be skipped, good one kept
+        assert len(recs) == 1
+        assert recs[0].action == "WATCH"
+        assert recs[0].item_title == "Good Item"
+
+    def test_bookmark_user(self):
+        recs = parse_recommendations(BOOKMARK_USER)
+        assert len(recs) == 1
+        r = recs[0]
+        assert r.action == "bookmark"
+        assert r.classification == "user"
+        assert r.is_actionable is True  # bookmark creates follow-up
+
+    def test_potential_skip_not_actionable(self):
+        recs = parse_recommendations(POTENTIAL_SKIP)
+        assert len(recs) == 1
+        r = recs[0]
+        assert r.action == "potential_skip"
+        assert r.is_actionable is False
+
+
+class TestExtractItemTitle:
+    def test_numbered(self):
+        assert _extract_item_title("1. Evo — Autoresearch\nSome text") == "Evo — Autoresearch"
+
+    def test_unnumbered(self):
+        assert _extract_item_title("AI Engineer/architect\nMore text") == "AI Engineer/architect"
+
+    def test_single_line(self):
+        assert _extract_item_title("Just a Title") == "Just a Title"
+
+
+class TestRecommendationIsActionable:
+    @pytest.mark.parametrize("action,expected", [
+        ("ADOPT", True),
+        ("ADAPT", True),
+        ("WATCH", True),
+        ("IGNORE", False),
+        ("ignore", False),
+        ("adopt", True),
+        ("explore", True),
+        ("bookmark", True),
+        ("potential_skip", False),
+        ("potential skip", False),
+    ])
+    def test_actionability(self, action: str, expected: bool):
+        r = Recommendation(action=action, next_step="test")
+        assert r.is_actionable is expected


### PR DESCRIPTION
## Summary

Closes the decision-action gap in the inbox evaluation pipeline (items 3-5 from the design in `project_inbox_workflow_automation.md`).

- **Follow-up creation from evals**: After an inbox evaluation completes, parses `### Recommendation` YAML blocks and auto-creates follow-ups. ADOPT/ADAPT items are pinned (user-only), WATCH items are ego-resolvable, IGNORE items produce no follow-up.
- **Dashboard source filter**: All Sources / Mine / System toggle on the follow-ups panel. Filters by `source` field — "Mine" = foreground_session, "System" = everything else.
- **Inbox digest MCP tool**: On-demand `inbox_digest` tool that generates a prioritized markdown table of pending inbox follow-ups and recent evaluations.
- **Morning report section**: Weekly digest of ego-resolved inbox follow-ups — safety net for classification-gated resolution (Option C).

## Details

### New files
- `src/genesis/inbox/recommendation.py` — Pure-function YAML parser, validated against 6 production eval files
- `src/genesis/mcp/health/inbox_digest.py` — MCP tool following `follow_up_tools.py` pattern
- `tests/test_inbox/test_recommendation.py` — 21 tests covering all action types, malformed YAML, multi-item evals

### Modified files
- `src/genesis/inbox/monitor.py` — Hook at line ~1198, wrapped in try/except (non-fatal)
- `src/genesis/db/crud/follow_ups.py` — `source_mode` param, `get_by_source()`, `get_recently_resolved()`
- `src/genesis/db/crud/inbox_items.py` — `get_recent_completed()`
- `src/genesis/dashboard/routes/follow_ups.py` — `source_mode` query param
- `src/genesis/dashboard/templates/genesis_dashboard.html` — Source filter toggle UI
- `src/genesis/mcp/health/__init__.py` — Register `inbox_digest`
- `src/genesis/outreach/morning_report.py` — Section 5b: ego-resolved inbox digest

### Classification → follow-up mapping
| Action | Strategy | Priority | Pinned |
|--------|----------|----------|--------|
| ADOPT/adopt | user_input_needed | high | Yes |
| ADAPT/explore | user_input_needed | medium | Yes |
| WATCH/bookmark | ego_judgment | low | No |
| IGNORE/potential_skip | — | — | — |

## Test plan

- [x] 21 unit tests for YAML parser (all pass)
- [x] 71 existing monitor tests (no regressions)
- [x] Validated parser against 6 real production `.genesis.md` files
- [x] E2E simulation: in-memory DB creation of follow-ups with correct source/strategy/pinned
- [x] Live DB queries: source_mode filtering, inbox digest data, import chain verification
- [x] Code reviewer agent: addressed all findings (dead code removal, days=0 guard)
- [ ] Live eval cycle: wait for next inbox eval to verify follow-ups appear in production DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)