### PR TITLE
fix(scheduler): use user timezone for all CronTriggers, fix process reaper reset

### DIFF
--- a/src/genesis/mail/monitor.py
+++ b/src/genesis/mail/monitor.py
@@ -71,7 +71,10 @@ class MailMonitor:
         from apscheduler.schedulers.asyncio import AsyncIOScheduler
         from apscheduler.triggers.cron import CronTrigger
 
+        from genesis.env import user_timezone
+
         self._scheduler = AsyncIOScheduler()
+        tz = user_timezone()
 
         # Parse cron expression: "minute hour day_of_month month day_of_week"
         parts = self._config.cron_expression.split()
@@ -82,13 +85,14 @@ class MailMonitor:
                 day=parts[2],
                 month=parts[3],
                 day_of_week=parts[4],
+                timezone=tz,
             )
         else:
             logger.warning(
                 "Invalid cron expression %r, using default Sunday 5am",
                 self._config.cron_expression,
             )
-            trigger = CronTrigger(day_of_week="sun", hour=5)
+            trigger = CronTrigger(day_of_week="sun", hour=5, timezone=tz)
 
         self._scheduler.add_job(
             self._run_batch_safe,

--- a/src/genesis/mail/types.py
+++ b/src/genesis/mail/types.py
@@ -10,7 +10,7 @@ class MailConfig:
     """Configuration for the mail monitor."""
 
     enabled: bool = True
-    cron_expression: str = "0 5 * * 0"  # Sunday 05:00 UTC
+    cron_expression: str = "0 5 * * 0"  # Sunday 05:00 (user timezone)
     batch_size: int = 10  # Max emails per Layer 2 CC session
     model: str = "sonnet"  # Layer 2 model
     effort: str = "medium"  # Layer 2 effort
@@ -18,7 +18,7 @@ class MailConfig:
     max_retries: int = 3
     imap_timeout_s: int = 30
     max_emails_per_run: int = 50  # Safety cap per batch run
-    # timezone removed — uses genesis.env.user_timezone()
+    # timezone: caller passes user_timezone() to CronTrigger
     min_relevance: int = 3  # Layer 1 filter: only relevance >= this goes to judge
 
 

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -157,7 +157,7 @@ async def async_cleanup():
     individually guarded so a crashed Camoufox won't hang cleanup.
     Each cleanup step has a 10s timeout (user-approved) to prevent hanging
     if the Playwright Node.js driver or browser process is stuck. Orphaned
-    processes that survive timeout are caught by the process reaper (4h cycle).
+    processes that survive timeout are caught by the process reaper (hourly at :15).
     """
     global _playwright, _context, _page, _stealth_cm, _stealth_browser, _stealth_page, _active_page
     global _idle_task, _last_used

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -10,7 +10,7 @@ from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from genesis.env import cc_project_dir
+from genesis.env import cc_project_dir, user_timezone
 
 if TYPE_CHECKING:
     from genesis.runtime._core import GenesisRuntime
@@ -186,7 +186,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _calibration_with_health,
-            CronTrigger(hour=3, minute=0),
+            CronTrigger(hour=3, minute=0, timezone=user_timezone()),
             id="triage_calibration_daily",
             max_instances=1,
             misfire_grace_time=3600,
@@ -257,7 +257,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _harvest_and_store,
-            CronTrigger(hour="*/6", minute=15),
+            CronTrigger(hour="*/6", minute=15, timezone=user_timezone()),
             id="auto_memory_harvest",
             max_instances=1,
             misfire_grace_time=3600,
@@ -279,7 +279,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _observation_expiry_sweep,
-            CronTrigger(hour=2, minute=0),
+            CronTrigger(hour=2, minute=0, timezone=user_timezone()),
             id="observation_expiry_sweep",
             max_instances=1,
             misfire_grace_time=3600,
@@ -301,7 +301,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _follow_up_retention_sweep,
-            CronTrigger(hour=2, minute=30),
+            CronTrigger(hour=2, minute=30, timezone=user_timezone()),
             id="follow_up_retention_sweep",
             max_instances=1,
             misfire_grace_time=3600,
@@ -364,7 +364,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _expire_dead_letters,
-            CronTrigger(hour=1, minute=30),
+            CronTrigger(hour=1, minute=30, timezone=user_timezone()),
             id="dead_letter_expiry",
             max_instances=1,
             misfire_grace_time=3600,
@@ -386,7 +386,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _expire_stale_messages,
-            CronTrigger(hour=2, minute=30),
+            CronTrigger(hour=2, minute=30, timezone=user_timezone()),
             id="message_queue_expiry",
             max_instances=1,
             misfire_grace_time=3600,
@@ -419,7 +419,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _redispatch_dead_letters,
-            CronTrigger(hour="0,6,12,18", minute=45),
+            CronTrigger(hour="0,6,12,18", minute=45, timezone=user_timezone()),
             id="dead_letter_redispatch",
             max_instances=1,
             misfire_grace_time=3600,
@@ -510,7 +510,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _evolve_user_model,
-            CronTrigger(hour=4, minute=30),
+            CronTrigger(hour=4, minute=30, timezone=user_timezone()),
             id="user_model_evolution",
             max_instances=1,
             misfire_grace_time=3600,
@@ -537,7 +537,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _reap_stale_sessions,
-            CronTrigger(hour="1,7,13,19", minute=30),
+            CronTrigger(hour="1,7,13,19", minute=30, timezone=user_timezone()),
             id="session_reaper",
             max_instances=1,
             misfire_grace_time=3600,
@@ -559,7 +559,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _refresh_capability_map,
-            CronTrigger(hour="4,16", minute=15),
+            CronTrigger(hour="4,16", minute=15, timezone=user_timezone()),
             id="capability_map_refresh",
             max_instances=1,
             misfire_grace_time=3600,
@@ -579,7 +579,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _reap_activity_log,
-            CronTrigger(hour="2,8,14,20", minute=0),
+            CronTrigger(hour="2,8,14,20", minute=0, timezone=user_timezone()),
             id="activity_log_reaper",
             max_instances=1,
             misfire_grace_time=3600,
@@ -724,9 +724,13 @@ async def init(rt: GenesisRuntime) -> None:
                 rt.record_job_failure("process_reaper", str(exc))
                 logger.exception("Process reaper failed")
 
+        # CronTrigger instead of IntervalTrigger: IntervalTrigger resets on
+        # server restart, so the reaper never fires if the server restarts
+        # within the hour.  Runs at :15 past every hour to avoid collision
+        # with hour-boundary jobs.
         rt._learning_scheduler.add_job(
             _reap_stale_processes,
-            IntervalTrigger(hours=1),
+            CronTrigger(minute=15),
             id="process_reaper",
             max_instances=1,
             misfire_grace_time=600,
@@ -755,7 +759,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _run_skill_evolution,
-            CronTrigger(day_of_week="sun", hour=4, minute=0),
+            CronTrigger(day_of_week="sun", hour=4, minute=0, timezone=user_timezone()),
             id="skill_evolution",
             max_instances=1,
             misfire_grace_time=3600,
@@ -775,7 +779,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _run_j9_eval_aggregation,
-            CronTrigger(day_of_week="sun", hour=5, minute=0),
+            CronTrigger(day_of_week="sun", hour=5, minute=0, timezone=user_timezone()),
             id="j9_eval_aggregation",
             max_instances=1,
             misfire_grace_time=3600,

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -15,6 +15,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
 from genesis.db.crud import surplus as surplus_crud
+from genesis.env import user_timezone
 from genesis.observability.events import GenesisEventBus
 from genesis.observability.types import Severity, Subsystem
 from genesis.surplus.brainstorm import BrainstormRunner
@@ -150,7 +151,7 @@ class SurplusScheduler:
             from apscheduler.triggers.cron import CronTrigger
             self._scheduler.add_job(
                 self._schedule_fresh_session_test,
-                CronTrigger(day_of_week="sun", hour=5, timezone="UTC"),
+                CronTrigger(day_of_week="sun", hour=5, timezone=user_timezone()),
                 id="schedule_fresh_session_test",
                 max_instances=1,
                 misfire_grace_time=3600,
@@ -262,7 +263,7 @@ class SurplusScheduler:
             from apscheduler.triggers.cron import CronTrigger
             self._scheduler.add_job(
                 self.run_model_intelligence,
-                CronTrigger(day_of_week="sun", hour=6, timezone="UTC"),
+                CronTrigger(day_of_week="sun", hour=6, timezone=user_timezone()),
                 id="model_intelligence",
                 max_instances=1,
                 misfire_grace_time=3600,
@@ -272,7 +273,7 @@ class SurplusScheduler:
             from apscheduler.triggers.cron import CronTrigger
             self._scheduler.add_job(
                 self.run_models_md_synthesis,
-                CronTrigger(day_of_week="sun", hour=8, timezone="UTC"),
+                CronTrigger(day_of_week="sun", hour=8, timezone=user_timezone()),
                 id="models_md_synthesis",
                 max_instances=1,
                 misfire_grace_time=3600,
@@ -281,33 +282,33 @@ class SurplusScheduler:
         from apscheduler.triggers.cron import CronTrigger
         self._scheduler.add_job(
             self.run_dream_cycle,
-            CronTrigger(day_of_week="sun", hour=4, timezone="UTC"),
+            CronTrigger(day_of_week="sun", hour=4, timezone=user_timezone()),
             id="dream_cycle",
             max_instances=1,
             misfire_grace_time=3600,
         )
-        # GitNexus reindex: Mon & Thu 5am UTC (~72h apart).
+        # GitNexus reindex: Mon & Thu 5am local (~72h apart).
         # Uses CronTrigger (not IntervalTrigger) — IntervalTrigger resets
         # on restart and would never fire if server restarts more often.
         self._scheduler.add_job(
             self.run_gitnexus_reindex,
-            CronTrigger(day_of_week="mon,thu", hour=5, timezone="UTC"),
+            CronTrigger(day_of_week="mon,thu", hour=5, timezone=user_timezone()),
             id="gitnexus_reindex",
             max_instances=1,
             misfire_grace_time=3600,
         )
-        # Wing audit: twice-weekly memory taxonomy review (Sun & Wed 2am UTC)
+        # Wing audit: twice-weekly memory taxonomy review (Sun & Wed 2am local)
         self._scheduler.add_job(
             self.schedule_wing_audit,
-            CronTrigger(day_of_week="sun,wed", hour=2, timezone="UTC"),
+            CronTrigger(day_of_week="sun,wed", hour=2, timezone=user_timezone()),
             id="wing_audit",
             max_instances=1,
             misfire_grace_time=3600,
         )
-        # CC memory staleness scan: weekly Sunday 3am UTC
+        # CC memory staleness scan: weekly Sunday 3am local
         self._scheduler.add_job(
             self.schedule_cc_memory_staleness,
-            CronTrigger(day_of_week="sun", hour=3, timezone="UTC"),
+            CronTrigger(day_of_week="sun", hour=3, timezone=user_timezone()),
             id="cc_memory_staleness",
             max_instances=1,
             misfire_grace_time=3600,
@@ -335,17 +336,17 @@ class SurplusScheduler:
             from apscheduler.triggers.cron import CronTrigger
             self._scheduler.add_job(
                 self.schedule_j9_eval_batch,
-                CronTrigger(hour=3, timezone="UTC"),  # 3 AM UTC daily
+                CronTrigger(hour=3, timezone=user_timezone()),  # 3 AM local daily
                 id="schedule_j9_eval_batch",
                 max_instances=1,
                 misfire_grace_time=3600,
             )
-        # Fresh session test: weekly Sunday 5 AM UTC
+        # Fresh session test: weekly Sunday 5 AM local
         if self._fresh_session_test_executor is not None:
             from apscheduler.triggers.cron import CronTrigger
             self._scheduler.add_job(
                 self._schedule_fresh_session_test,
-                CronTrigger(day_of_week="sun", hour=5, timezone="UTC"),
+                CronTrigger(day_of_week="sun", hour=5, timezone=user_timezone()),
                 id="schedule_fresh_session_test",
                 max_instances=1,
                 misfire_grace_time=3600,


### PR DESCRIPTION
## Summary

- All CronTriggers in surplus scheduler (9), mail monitor (2), and learning init (13) were using hardcoded `timezone="UTC"` or no timezone at all, causing scheduled jobs to fire at wrong local times (e.g., dream cycle at midnight EDT instead of 4am EDT)
- Process reaper used `IntervalTrigger(hours=1)` which resets on every server restart, allowing orphaned browser processes to survive indefinitely — caused a 327% CPU Playwright leak discovered during CPU investigation
- Added explicit `timezone=user_timezone()` to all 24 CronTrigger sites across 3 scheduler files
- Converted process reaper to `CronTrigger(minute=15)` for restart-resilient hourly execution

## Files changed

- `src/genesis/surplus/scheduler.py` — 9 CronTriggers: UTC → user_timezone(), updated stale comments
- `src/genesis/mail/monitor.py` — 2 CronTriggers: added missing timezone parameter
- `src/genesis/mail/types.py` — fixed misleading comment about timezone handling
- `src/genesis/runtime/init/learning.py` — 13 CronTriggers: added explicit timezone; process reaper IntervalTrigger → CronTrigger
- `src/genesis/mcp/health/browser.py` — updated process reaper schedule comment

## Test plan

- [x] `ruff check` passes on all 5 files
- [x] `pytest tests/test_surplus/test_scheduler.py` — 12/12 passed
- [x] `pytest tests/test_mail/test_monitor.py` — 11/11 passed
- [x] `pytest tests/test_learning/` — 488/488 passed
- [x] E2E: `user_timezone()` returns `"America/New_York"`, CronTrigger accepts it, dream cycle next fire confirmed at `04:00:00-04:00` (EDT)
- [x] Verified no remaining `timezone="UTC"` in surplus scheduler
- [x] Verified only process reaper (minute-only) lacks explicit timezone in learning.py (intentional — timezone irrelevant for minute-only triggers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)