### PR TITLE
fix(scheduler): spread weekly jobs, convert IntervalTriggers, dashboard visibility

### DIFF
--- a/src/genesis/dashboard/routes/scheduler.py
+++ b/src/genesis/dashboard/routes/scheduler.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 # Maps scheduler attribute names to subsystem display names
 _SCHEDULER_SUBSYSTEMS = {
     "_surplus_scheduler": "Surplus",
+    "_learning_scheduler": "Learning",
     "_outreach_scheduler": "Outreach",
     "_reflection_scheduler": "Reflection",
     "_awareness_loop": "Awareness",
@@ -22,8 +23,15 @@ _SCHEDULER_SUBSYSTEMS = {
 
 
 def _extract_apscheduler_jobs(component, subsystem: str) -> list[dict]:
-    """Extract job info from an APScheduler-backed component."""
+    """Extract job info from an APScheduler-backed component.
+
+    Handles both wrapper objects (with ``._scheduler``) and raw
+    ``AsyncIOScheduler`` instances (e.g., ``_learning_scheduler``).
+    """
     scheduler = getattr(component, "_scheduler", None)
+    # Fall back to treating component itself as the scheduler (raw scheduler case)
+    if scheduler is None and hasattr(component, "get_jobs"):
+        scheduler = component
     if scheduler is None or not getattr(scheduler, "running", False):
         return []
 

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -517,7 +517,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _evolve_user_model,
-            CronTrigger(hour=4, minute=30, timezone=user_timezone()),
+            CronTrigger(hour=6, minute=30, timezone=user_timezone()),  # moved from 4:30 to avoid dream cycle window
             id="user_model_evolution",
             max_instances=1,
             misfire_grace_time=3600,
@@ -566,7 +566,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _refresh_capability_map,
-            CronTrigger(hour="4,16", minute=15, timezone=user_timezone()),
+            CronTrigger(hour="9,21", minute=15, timezone=user_timezone()),  # moved from 4:15/16:15 to avoid dream cycle window
             id="capability_map_refresh",
             max_instances=1,
             misfire_grace_time=3600,
@@ -766,13 +766,14 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _run_skill_evolution,
-            CronTrigger(day_of_week="sun", hour=4, minute=0, timezone=user_timezone()),
+            CronTrigger(day_of_week="sat", hour=4, minute=0, timezone=user_timezone()),  # moved off Sunday to avoid dream cycle
             id="skill_evolution",
             max_instances=1,
             misfire_grace_time=3600,
         )
 
-        # J-9 eval weekly aggregation (Sundays 5am — after skill evolution)
+        # J-9 eval weekly aggregation (Sundays 7am — after dream cycle clears).
+        # Hard dep on 7-day rolling window — must stay Sunday.
         async def _run_j9_eval_aggregation():
             try:
                 from genesis.eval.j9_aggregator import run_weekly_aggregation
@@ -786,7 +787,7 @@ async def init(rt: GenesisRuntime) -> None:
 
         rt._learning_scheduler.add_job(
             _run_j9_eval_aggregation,
-            CronTrigger(day_of_week="sun", hour=5, minute=0, timezone=user_timezone()),
+            CronTrigger(day_of_week="sun", hour=7, minute=30, timezone=user_timezone()),  # :30 to avoid schedule_analytical at 7:00
             id="j9_eval_aggregation",
             max_instances=1,
             misfire_grace_time=3600,

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -151,7 +151,7 @@ class SurplusScheduler:
             from apscheduler.triggers.cron import CronTrigger
             self._scheduler.add_job(
                 self._schedule_fresh_session_test,
-                CronTrigger(day_of_week="sun", hour=5, timezone=user_timezone()),
+                CronTrigger(day_of_week="sat", hour=9, timezone=user_timezone()),
                 id="schedule_fresh_session_test",
                 max_instances=1,
                 misfire_grace_time=3600,
@@ -219,12 +219,17 @@ class SurplusScheduler:
 
     async def start(self) -> None:
         """Start the surplus scheduler with brainstorm check and dispatch jobs."""
+        # Brainstorm check: twice daily (1am + 1pm local).
+        # CronTrigger instead of IntervalTrigger — IntervalTrigger resets on
+        # restart.  Config param brainstorm_check_hours is unused since this
+        # conversion; the fixed schedule replaces the interval cadence.
+        from apscheduler.triggers.cron import CronTrigger
         self._scheduler.add_job(
             self.brainstorm_check,
-            IntervalTrigger(hours=self._brainstorm_interval),
+            CronTrigger(hour="1,13", minute=0, timezone=user_timezone()),
             id="surplus_brainstorm_check",
             max_instances=1,
-            misfire_grace_time=300,
+            misfire_grace_time=3600,
         )
         self._scheduler.add_job(
             self._dispatch_loop,
@@ -251,29 +256,32 @@ class SurplusScheduler:
             max_instances=1,
             misfire_grace_time=300,
         )
+        # Recon gather: Tue & Fri 1:45am local (~3.5 day cadence).
+        # CronTrigger instead of IntervalTrigger — IntervalTrigger(hours=84)
+        # never fires if server restarts within 84h.  Config param
+        # recon_gather_hours is unused since this conversion.
         self._scheduler.add_job(
             self.run_recon_gather,
-            IntervalTrigger(hours=self._recon_gather_hours),
+            CronTrigger(day_of_week="tue,fri", hour=1, minute=45, timezone=user_timezone()),
             id="recon_gather",
             max_instances=1,
-            misfire_grace_time=300,
+            misfire_grace_time=3600,
         )
-        # Model intelligence: weekly Sunday 6am (per config/recon_schedules.yaml)
+        # Model intelligence: weekly Sunday 8am local (after dream cycle clears)
         if self._model_intelligence_job is not None:
-            from apscheduler.triggers.cron import CronTrigger
             self._scheduler.add_job(
                 self.run_model_intelligence,
-                CronTrigger(day_of_week="sun", hour=6, timezone=user_timezone()),
+                CronTrigger(day_of_week="sun", hour=8, timezone=user_timezone()),
                 id="model_intelligence",
                 max_instances=1,
                 misfire_grace_time=3600,
             )
-        # Models.md synthesis: weekly Sunday 8am — updates model catalog from recon
+        # Models.md synthesis: weekly Sunday 10am — updates model catalog from recon.
+        # Runs 2h after model_intelligence to consume its findings (soft dep).
         if self._models_md_synthesis_job is not None:
-            from apscheduler.triggers.cron import CronTrigger
             self._scheduler.add_job(
                 self.run_models_md_synthesis,
-                CronTrigger(day_of_week="sun", hour=8, timezone=user_timezone()),
+                CronTrigger(day_of_week="sun", hour=10, timezone=user_timezone()),
                 id="models_md_synthesis",
                 max_instances=1,
                 misfire_grace_time=3600,
@@ -297,18 +305,20 @@ class SurplusScheduler:
             max_instances=1,
             misfire_grace_time=3600,
         )
-        # Wing audit: twice-weekly memory taxonomy review (Sun & Wed 2am local)
+        # Wing audit: twice-weekly memory taxonomy review (Tue & Fri 2am local).
+        # Moved off Sunday to avoid dream cycle congestion.
         self._scheduler.add_job(
             self.schedule_wing_audit,
-            CronTrigger(day_of_week="sun,wed", hour=2, timezone=user_timezone()),
+            CronTrigger(day_of_week="tue,fri", hour=2, timezone=user_timezone()),
             id="wing_audit",
             max_instances=1,
             misfire_grace_time=3600,
         )
-        # CC memory staleness scan: weekly Sunday 3am local
+        # CC memory staleness scan: weekly Wednesday 3am local.
+        # Moved off Sunday to spread weekly jobs across the week.
         self._scheduler.add_job(
             self.schedule_cc_memory_staleness,
-            CronTrigger(day_of_week="sun", hour=3, timezone=user_timezone()),
+            CronTrigger(day_of_week="wed", hour=3, timezone=user_timezone()),
             id="cc_memory_staleness",
             max_instances=1,
             misfire_grace_time=3600,
@@ -320,13 +330,18 @@ class SurplusScheduler:
             max_instances=1,
             misfire_grace_time=300,
         )
+        # Analytical tasks: daily 7am local — LLM-based gap clustering,
+        # prompt effectiveness, anticipatory research.
+        # CronTrigger instead of IntervalTrigger — IntervalTrigger resets on
+        # restart.  Config param analytical_hours is unused since this
+        # conversion.
         if self._analytical_hours > 0:
             self._scheduler.add_job(
                 self.schedule_analytical,
-                IntervalTrigger(hours=self._analytical_hours),
+                CronTrigger(hour=7, minute=0, timezone=user_timezone()),
                 id="schedule_analytical",
                 max_instances=1,
-                misfire_grace_time=300,
+                misfire_grace_time=3600,
             )
         if self._j9_eval_batch_hours > 0:
             # CronTrigger instead of IntervalTrigger: IntervalTrigger resets
@@ -341,23 +356,27 @@ class SurplusScheduler:
                 max_instances=1,
                 misfire_grace_time=3600,
             )
-        # Fresh session test: weekly Sunday 5 AM local
+        # Fresh session test: weekly Saturday 9 AM local.
+        # Moved off Sunday to avoid dream cycle congestion.
         if self._fresh_session_test_executor is not None:
-            from apscheduler.triggers.cron import CronTrigger
             self._scheduler.add_job(
                 self._schedule_fresh_session_test,
-                CronTrigger(day_of_week="sun", hour=5, timezone=user_timezone()),
+                CronTrigger(day_of_week="sat", hour=9, timezone=user_timezone()),
                 id="schedule_fresh_session_test",
                 max_instances=1,
                 misfire_grace_time=3600,
             )
+        # Model eval: daily 7:30am local — model quality benchmarks.
+        # CronTrigger instead of IntervalTrigger — IntervalTrigger resets on
+        # restart.  Config param model_eval_hours is unused since this
+        # conversion.
         if self._model_eval_hours > 0:
             self._scheduler.add_job(
                 self.schedule_model_eval,
-                IntervalTrigger(hours=self._model_eval_hours),
+                CronTrigger(hour=7, minute=30, timezone=user_timezone()),
                 id="schedule_model_eval",
                 max_instances=1,
-                misfire_grace_time=300,
+                misfire_grace_time=3600,
             )
         if self._follow_up_dispatcher is not None:
             self._scheduler.add_job(


### PR DESCRIPTION
## Summary

- Spread 7 weekly jobs across Tue-Sat instead of piling them all on Sunday 3-6am, giving the dream cycle (Sun 4am, 1-2 hours, 164% Qdrant CPU) a clear 2-hour window
- Converted 4 IntervalTriggers to CronTriggers (brainstorm_check, recon_gather, schedule_analytical, schedule_model_eval) — IntervalTrigger resets on server restart, silently preventing jobs from ever firing. schedule_code_audit hadn't fired in 51 days
- Added `_learning_scheduler` to dashboard scheduler API so 13+ learning init jobs are visible. Fixed raw-scheduler extraction (learning scheduler is a raw AsyncIOScheduler, not a wrapper)

## Schedule changes

| Job | Before | After |
|-----|--------|-------|
| wing_audit | Sun/Wed 2am | Tue/Fri 2am |
| cc_memory_staleness | Sun 3am | Wed 3am |
| model_intelligence | Sun 6am | Sun 8am |
| models_md_synthesis | Sun 8am | Sun 10am |
| fresh_session_test | Sun 5am | Sat 9am |
| skill_evolution | Sun 4am | Sat 4am |
| j9_eval_aggregation | Sun 5am | Sun 7:30am |
| user_model_evolution | daily 4:30am | daily 6:30am |
| capability_map_refresh | daily 4:15/16:15 | daily 9:15/21:15 |
| brainstorm_check | 12h interval | 1am/1pm CronTrigger |
| recon_gather | 84h interval | Tue/Fri 1:45am |
| analytical | 24h interval | daily 7am |
| model_eval | 24h interval | daily 7:30am |

## Test plan

- [x] `ruff check` passes on all 3 files
- [x] `pytest tests/test_surplus/test_scheduler.py tests/test_learning/` — 503 passed
- [x] E2E: verified no Sunday 4-6am collisions via CronTrigger.get_next_fire_time()
- [x] j9_eval_aggregation stays Sunday (7-day rolling window hard dependency verified)
- [x] Dashboard fix handles raw AsyncIOScheduler (fallback to `hasattr(component, "get_jobs")`)
- [x] Code review: fixed 7am Sunday collision (analytical vs j9_eval_aggregation → offset to 7:30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)