### PR TITLE
feat(memory): supersession chain for stale-fact replacement

### DIFF
--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -576,10 +576,16 @@ async def _search_qdrant(
         # Default exclusion of subsystem writes. ``must_not`` against a
         # missing payload key preserves the point — legacy rows without
         # ``source_subsystem`` continue to surface.
-        filter_block["must_not"] = [{
-            "key": "source_subsystem",
-            "match": {"any": list(_PROACTIVE_EXCLUDED_SUBSYSTEMS)},
-        }]
+        filter_block["must_not"] = [
+            {
+                "key": "source_subsystem",
+                "match": {"any": list(_PROACTIVE_EXCLUDED_SUBSYSTEMS)},
+            },
+            {
+                "key": "deprecated",
+                "match": {"value": True},
+            },
+        ]
         body["filter"] = filter_block
 
         async with httpx.AsyncClient(timeout=2.0) as client:

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -153,6 +153,7 @@ async def search_ranked(
     exclude_subsystems: list[str] | None = None,
     include_only_subsystems: list[str] | None = None,
     as_of: str | None = None,
+    include_deprecated: bool = False,
 ) -> list[dict]:
     """FTS5 search returning rank scores for RRF fusion.
 
@@ -194,12 +195,14 @@ async def search_ranked(
         "OR memory_metadata.invalid_at > ?)"
     )
     params.append(as_of)
-    # Always-on dream cycle deprecation filter: exclude consolidated memories.
+    # Dream cycle deprecation filter: exclude consolidated memories by default.
     # NULL deprecated (legacy rows pre-migration) = not deprecated.
-    sql += (
-        " AND (memory_metadata.deprecated IS NULL "
-        "OR memory_metadata.deprecated = 0)"
-    )
+    # Pass include_deprecated=True for audit/history queries.
+    if not include_deprecated:
+        sql += (
+            " AND (memory_metadata.deprecated IS NULL "
+            "OR memory_metadata.deprecated = 0)"
+        )
     if exclude_subsystems:
         placeholders = ",".join("?" * len(exclude_subsystems))
         sql += (

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -296,6 +296,51 @@ async def invalidate_memory(
     return cursor.rowcount > 0
 
 
+async def mark_superseded(
+    db: aiosqlite.Connection,
+    old_id: str,
+    new_id: str,
+    timestamp: str,
+) -> bool:
+    """Mark a memory as superseded by a newer memory.
+
+    Sets ``deprecated=1``, ``superseded_by``, and ``superseded_at``.
+    Returns True if the memory was found and updated.
+    """
+    cursor = await db.execute(
+        "UPDATE memory_metadata SET deprecated = 1, "
+        "superseded_by = ?, superseded_at = ? "
+        "WHERE memory_id = ?",
+        (new_id, timestamp, old_id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def get_metadata(
+    db: aiosqlite.Connection,
+    memory_id: str,
+) -> dict | None:
+    """Return metadata row for a memory_id, or None if not found."""
+    cursor = await db.execute(
+        "SELECT memory_id, collection, embedding_status, deprecated, "
+        "superseded_by, superseded_at FROM memory_metadata "
+        "WHERE memory_id = ?",
+        (memory_id,),
+    )
+    row = await cursor.fetchone()
+    if not row:
+        return None
+    return {
+        "memory_id": row[0],
+        "collection": row[1],
+        "embedding_status": row[2],
+        "deprecated": row[3],
+        "superseded_by": row[4],
+        "superseded_at": row[5],
+    }
+
+
 async def delete_metadata(db: aiosqlite.Connection, *, memory_id: str) -> bool:
     """Delete a memory_metadata row. Returns True if deleted."""
     cursor = await db.execute(

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1239,6 +1239,14 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE memory_metadata ADD COLUMN dream_cycle_run_id TEXT",
         "memory_metadata.dream_cycle_run_id")
 
+    # Memory supersession: track which memory replaced this one (PR #551+).
+    await _try_alter(db,
+        "ALTER TABLE memory_metadata ADD COLUMN superseded_by TEXT",
+        "memory_metadata.superseded_by")
+    await _try_alter(db,
+        "ALTER TABLE memory_metadata ADD COLUMN superseded_at TEXT",
+        "memory_metadata.superseded_at")
+
     # Observation de-escalation: track how many times an observation has
     # been surfaced (morning report, dashboard, critical alerting).
     await _try_alter(db,

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1428,6 +1428,7 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_memory_meta_valid_at ON memory_metadata(valid_at)",
     "CREATE INDEX IF NOT EXISTS idx_memory_meta_invalid_at ON memory_metadata(invalid_at)",
     "CREATE INDEX IF NOT EXISTS idx_memory_meta_deprecated ON memory_metadata(deprecated)",
+    "CREATE INDEX IF NOT EXISTS idx_memory_meta_superseded_by ON memory_metadata(superseded_by)",
     # knowledge_units
     "CREATE INDEX IF NOT EXISTS idx_knowledge_units_qdrant_id ON knowledge_units(qdrant_id)",
     # codebase index

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -102,6 +102,10 @@ async def memory_recall(
             fusion. Improves precision by rescoring candidates on semantic
             relevance. Adds ~300ms latency. Default True — disable with
             rerank=False for latency-sensitive calls.
+        include_deprecated: If True, include superseded/deprecated memories
+            in results. Default False — only current (non-deprecated) memories
+            are returned. Use True for audit/history queries (e.g., tracing
+            how a belief evolved over time).
     """
     import time as _time
 

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -56,6 +56,7 @@ async def memory_recall(
     include_subsystem: bool | list[str] = False,
     only_subsystem: str | list[str] | None = None,
     rerank: bool = True,
+    include_deprecated: bool = False,
 ) -> list[dict]:
     """Hybrid search: Qdrant vectors + FTS5, RRF fusion, with optional graph enrichment.
 
@@ -164,6 +165,7 @@ async def memory_recall(
             include_subsystem=include_subsystem,
             only_subsystem=only_subsystem,
             rerank=rerank,
+            include_deprecated=include_deprecated,
         )
         pipeline_used = "standard"
 
@@ -405,6 +407,7 @@ async def memory_store(
     wing: str | None = None,
     room: str | None = None,
     collection: str | None = None,
+    supersedes: str | None = None,
 ) -> str:
     """Store memory with source metadata and type tag. Returns memory_id.
 
@@ -415,6 +418,9 @@ async def memory_store(
         room: Topic within the wing (auto-classified if not provided).
         collection: Explicit Qdrant collection override. Bypasses the default
             collection routing when provided (e.g. "knowledge_base").
+        supersedes: Memory ID that this new memory replaces. The old memory
+            will be marked as deprecated with a ``succeeded_by`` link to the
+            new one. Use when correcting stale facts.
     """
     memory_mod = _memory_mod()
     memory_mod._require_init()
@@ -422,7 +428,7 @@ async def memory_store(
     return await memory_mod._store.store(
         content, source, memory_type=memory_type, tags=tags, confidence=confidence,
         memory_class=memory_class, source_pipeline="conversation",
-        wing=wing, room=room, collection=collection,
+        wing=wing, room=room, collection=collection, supersedes=supersedes,
     )
 
 

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -282,6 +282,7 @@ class HybridRetriever:
         include_subsystem: bool | list[str] = False,
         only_subsystem: str | list[str] | None = None,
         rerank: bool = True,
+        include_deprecated: bool = False,
     ) -> list[RetrievalResult]:
         """Hybrid retrieval: Qdrant + FTS5 + activation, fused via RRF.
 
@@ -360,6 +361,7 @@ class HybridRetriever:
                         project_type=project_type,
                         exclude_subsystems=exclude_subsystems,
                         include_only_subsystems=include_only_subsystems,
+                        include_deprecated=include_deprecated,
                     )
                 for hit in hits:
                     hit["_collection"] = coll
@@ -416,6 +418,7 @@ class HybridRetriever:
             boolean=fts_is_boolean,
             exclude_subsystems=exclude_subsystems,
             include_only_subsystems=include_only_subsystems,
+            include_deprecated=include_deprecated,
         )
 
         fts_by_id: dict[str, dict] = {}

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -367,27 +367,16 @@ class MemoryStore:
         SQLite.  Sets ``deprecated=True`` and ``merged_into`` in the Qdrant
         payload.  Creates a ``succeeded_by`` link from old to new.
         """
-        # SQLite: mark deprecated + record successor
-        await self._db.execute(
-            "UPDATE memory_metadata SET deprecated = 1, "
-            "superseded_by = ?, superseded_at = ? "
-            "WHERE memory_id = ?",
-            (new_id, timestamp, old_id),
-        )
-        await self._db.commit()
+        # SQLite: mark deprecated + record successor (via CRUD module)
+        await memory_crud.mark_superseded(self._db, old_id, new_id, timestamp)
 
         # Qdrant: look up collection from metadata, then update payload
-        cursor = await self._db.execute(
-            "SELECT collection, embedding_status FROM memory_metadata "
-            "WHERE memory_id = ?",
-            (old_id,),
-        )
-        row = await cursor.fetchone()
-        if row and row[1] != "fts5_only":
+        meta = await memory_crud.get_metadata(self._db, old_id)
+        if meta and meta["embedding_status"] != "fts5_only":
             try:
                 update_payload(
                     self._qdrant,
-                    collection=row[0],
+                    collection=meta["collection"],
                     point_id=old_id,
                     payload={"deprecated": True, "merged_into": new_id},
                 )

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -18,7 +18,7 @@ from genesis.observability.call_site_recorder import record_last_run
 from genesis.observability.events import GenesisEventBus
 from genesis.observability.provider_activity import track_operation
 from genesis.observability.types import Severity, Subsystem
-from genesis.qdrant.collections import delete_point, upsert_point
+from genesis.qdrant.collections import delete_point, update_payload, upsert_point
 
 # Qdrant connection errors — broad catch for any transport/protocol failure
 try:
@@ -102,6 +102,7 @@ class MemoryStore:
         source_subsystem: str | None = None,
         life_domain: str | None = None,
         project_type: str | None = None,
+        supersedes: str | None = None,
     ) -> str:
         """Full store pipeline: embed -> Qdrant -> FTS5 -> auto-link. Returns memory_id.
 
@@ -342,7 +343,77 @@ class MemoryStore:
         # else: subsystem write — no pending_embeddings, no auto_link
         # (vector wasn't computed; link graph isn't consumed for filtered content)
 
+        # Supersession: mark old memory as deprecated, link to this one
+        if supersedes:
+            try:
+                await self._mark_superseded(supersedes, memory_id, now_iso)
+            except Exception:
+                logger.warning(
+                    "Failed to mark memory %s as superseded by %s",
+                    supersedes, memory_id, exc_info=True,
+                )
+
         return memory_id
+
+    async def _mark_superseded(
+        self,
+        old_id: str,
+        new_id: str,
+        timestamp: str,
+    ) -> None:
+        """Mark *old_id* as superseded by *new_id* in both SQLite and Qdrant.
+
+        Sets ``deprecated=1``, ``superseded_by``, and ``superseded_at`` in
+        SQLite.  Sets ``deprecated=True`` and ``merged_into`` in the Qdrant
+        payload.  Creates a ``succeeded_by`` link from old to new.
+        """
+        # SQLite: mark deprecated + record successor
+        await self._db.execute(
+            "UPDATE memory_metadata SET deprecated = 1, "
+            "superseded_by = ?, superseded_at = ? "
+            "WHERE memory_id = ?",
+            (new_id, timestamp, old_id),
+        )
+        await self._db.commit()
+
+        # Qdrant: look up collection from metadata, then update payload
+        cursor = await self._db.execute(
+            "SELECT collection, embedding_status FROM memory_metadata "
+            "WHERE memory_id = ?",
+            (old_id,),
+        )
+        row = await cursor.fetchone()
+        if row and row[1] != "fts5_only":
+            try:
+                update_payload(
+                    self._qdrant,
+                    collection=row[0],
+                    point_id=old_id,
+                    payload={"deprecated": True, "merged_into": new_id},
+                )
+            except Exception:
+                logger.warning(
+                    "Qdrant update_payload failed for superseded memory %s",
+                    old_id, exc_info=True,
+                )
+
+        # Create succeeded_by link for graph traversal
+        try:
+            await memory_links_crud.create(
+                self._db,
+                source_id=old_id,
+                target_id=new_id,
+                link_type="succeeded_by",
+                strength=1.0,
+                created_at=timestamp,
+            )
+        except Exception as link_exc:
+            # PK collision is fine (link already exists); log unexpected errors
+            if "UNIQUE constraint" not in str(link_exc):
+                logger.warning(
+                    "Failed to create succeeded_by link %s → %s: %s",
+                    old_id, new_id, link_exc,
+                )
 
     async def delete(self, memory_id: str) -> dict:
         """Delete a memory from all layers. Returns per-layer status.

--- a/src/genesis/qdrant/collections.py
+++ b/src/genesis/qdrant/collections.py
@@ -85,6 +85,7 @@ def search(
     project_type: str | None = None,
     exclude_subsystems: list[str] | None = None,
     include_only_subsystems: list[str] | None = None,
+    include_deprecated: bool = False,
 ) -> list[dict]:
     """Search by vector similarity with optional payload filters.
 
@@ -98,12 +99,14 @@ def search(
     conditions: list = []
     must_not_conditions: list = []
 
-    # Always exclude deprecated memories (dream cycle soft-delete).
+    # Exclude deprecated memories (dream cycle soft-delete) by default.
     # Points without the field (legacy data) are preserved — Qdrant's
     # must_not only excludes points where the field exists AND matches.
-    must_not_conditions.append(
-        FieldCondition(key="deprecated", match=MatchValue(value=True))
-    )
+    # Pass include_deprecated=True for audit/history queries.
+    if not include_deprecated:
+        must_not_conditions.append(
+            FieldCondition(key="deprecated", match=MatchValue(value=True))
+        )
 
     if source_type:
         conditions.append(

--- a/tests/test_memory/test_mcp_integration.py
+++ b/tests/test_memory/test_mcp_integration.py
@@ -72,7 +72,7 @@ async def test_memory_store_delegates(mock_deps, tools):
     memory_mcp._store.store.assert_awaited_once_with(
         "hello", "test", memory_type="episodic", tags=None, confidence=0.5,
         memory_class=None, source_pipeline="conversation",
-        wing=None, room=None, collection=None,
+        wing=None, room=None, collection=None, supersedes=None,
     )
 
 
@@ -101,7 +101,7 @@ async def test_memory_recall_delegates(mock_deps, tools):
         wing=None, room=None, life_domain=None,
         expand_query_terms=True,
         include_subsystem=False, only_subsystem=None,
-        rerank=True,
+        rerank=True, include_deprecated=False,
     )
 
 

--- a/tests/test_memory/test_supersession.py
+++ b/tests/test_memory/test_supersession.py
@@ -1,7 +1,7 @@
 """Tests for memory supersession — store with supersedes, mark_superseded, retrieval filtering."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -72,7 +72,7 @@ async def test_store_with_supersedes_marks_old_deprecated(store, db):
     db.execute = AsyncMock(side_effect=track_execute)
 
     with patch("genesis.memory.store.upsert_point"), \
-         patch("genesis.memory.store.update_payload") as mock_update, \
+         patch("genesis.memory.store.update_payload"), \
          patch("genesis.memory.store.memory_crud") as mock_mem:
         mock_mem.upsert = AsyncMock(return_value="id")
         mock_mem.create_metadata = AsyncMock(return_value=None)

--- a/tests/test_memory/test_supersession.py
+++ b/tests/test_memory/test_supersession.py
@@ -1,0 +1,288 @@
+"""Tests for memory supersession — store with supersedes, mark_superseded, retrieval filtering."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+from genesis.memory.store import MemoryStore
+
+
+@pytest.fixture()
+def embedding_provider():
+    ep = MagicMock()
+    ep.embed = AsyncMock(return_value=[0.1] * 1024)
+    ep.enrich = MagicMock(return_value="episodic: test content")
+    return ep
+
+
+@pytest.fixture()
+def qdrant():
+    return MagicMock()
+
+
+@pytest.fixture()
+def db():
+    mock = AsyncMock()
+    # Default: execute returns a cursor with fetchone returning None
+    cursor = AsyncMock()
+    cursor.fetchone = AsyncMock(return_value=None)
+    mock.execute = AsyncMock(return_value=cursor)
+    return mock
+
+
+@pytest.fixture()
+def linker():
+    lnk = MagicMock()
+    lnk.auto_link = AsyncMock(return_value=[])
+    return lnk
+
+
+@pytest.fixture()
+def store(embedding_provider, qdrant, db, linker):
+    return MemoryStore(
+        embedding_provider=embedding_provider,
+        qdrant_client=qdrant,
+        db=db,
+        linker=linker,
+    )
+
+
+@pytest.mark.asyncio()
+async def test_store_with_supersedes_marks_old_deprecated(store, db):
+    """Storing with supersedes should mark the old memory as deprecated in SQLite."""
+    old_id = "old-memory-id"
+
+    # Mock the metadata lookup for the old memory (embedded, episodic_memory)
+    metadata_cursor = AsyncMock()
+    metadata_cursor.fetchone = AsyncMock(return_value=("episodic_memory", "embedded"))
+
+    # We need to track all execute calls
+    call_results = []
+    original_execute = db.execute
+
+    async def track_execute(sql, params=None):
+        result = await original_execute(sql, params)
+        call_results.append((sql, params))
+        # Return the metadata cursor for the SELECT query
+        if isinstance(sql, str) and "SELECT collection" in sql:
+            return metadata_cursor
+        return result
+
+    db.execute = AsyncMock(side_effect=track_execute)
+
+    with patch("genesis.memory.store.upsert_point"), \
+         patch("genesis.memory.store.update_payload") as mock_update, \
+         patch("genesis.memory.store.memory_crud") as mock_mem:
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+
+        new_id = await store.store(
+            "CC upgraded to v2.1.154",
+            "conversation",
+            supersedes=old_id,
+        )
+
+    assert isinstance(new_id, str)
+    assert len(new_id) == 36
+
+    # Verify SQLite UPDATE was called to deprecate old memory
+    deprecation_calls = [
+        (sql, params) for sql, params in call_results
+        if isinstance(sql, str) and "deprecated = 1" in sql and "superseded_by" in sql
+    ]
+    assert len(deprecation_calls) == 1
+    sql, params = deprecation_calls[0]
+    assert params[0] == new_id  # superseded_by = new_id
+    assert params[2] == old_id  # WHERE memory_id = old_id
+
+
+@pytest.mark.asyncio()
+async def test_store_with_supersedes_updates_qdrant(store, db):
+    """Storing with supersedes should update the old memory's Qdrant payload."""
+    old_id = "old-memory-id"
+
+    # Mock the metadata lookup — old memory exists and is embedded
+    metadata_cursor = AsyncMock()
+    metadata_cursor.fetchone = AsyncMock(return_value=("episodic_memory", "embedded"))
+
+    async def route_execute(sql, params=None):
+        if isinstance(sql, str) and "SELECT collection" in sql:
+            return metadata_cursor
+        cursor = AsyncMock()
+        cursor.fetchone = AsyncMock(return_value=None)
+        return cursor
+
+    db.execute = AsyncMock(side_effect=route_execute)
+
+    with patch("genesis.memory.store.upsert_point"), \
+         patch("genesis.memory.store.update_payload") as mock_update, \
+         patch("genesis.memory.store.memory_crud") as mock_mem:
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+
+        new_id = await store.store(
+            "new fact",
+            "conversation",
+            supersedes=old_id,
+        )
+
+    # Verify Qdrant update_payload was called
+    mock_update.assert_called_once()
+    call_kwargs = mock_update.call_args
+    assert call_kwargs.kwargs["collection"] == "episodic_memory"
+    assert call_kwargs.kwargs["point_id"] == old_id
+    assert call_kwargs.kwargs["payload"]["deprecated"] is True
+    assert call_kwargs.kwargs["payload"]["merged_into"] == new_id
+
+
+@pytest.mark.asyncio()
+async def test_store_with_supersedes_skips_qdrant_for_fts5_only(store, db):
+    """FTS5-only memories should not get a Qdrant update_payload call."""
+    old_id = "fts5-only-memory"
+
+    metadata_cursor = AsyncMock()
+    metadata_cursor.fetchone = AsyncMock(return_value=("episodic_memory", "fts5_only"))
+
+    async def route_execute(sql, params=None):
+        if isinstance(sql, str) and "SELECT collection" in sql:
+            return metadata_cursor
+        cursor = AsyncMock()
+        cursor.fetchone = AsyncMock(return_value=None)
+        return cursor
+
+    db.execute = AsyncMock(side_effect=route_execute)
+
+    with patch("genesis.memory.store.upsert_point"), \
+         patch("genesis.memory.store.update_payload") as mock_update, \
+         patch("genesis.memory.store.memory_crud") as mock_mem:
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+
+        await store.store("new fact", "conversation", supersedes=old_id)
+
+    # Qdrant update_payload should NOT be called for fts5_only memories
+    mock_update.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_store_with_supersedes_creates_succeeded_by_link(store, db):
+    """Supersession should create a succeeded_by link in memory_links."""
+    old_id = "old-memory-id"
+
+    metadata_cursor = AsyncMock()
+    metadata_cursor.fetchone = AsyncMock(return_value=("episodic_memory", "embedded"))
+
+    async def route_execute(sql, params=None):
+        if isinstance(sql, str) and "SELECT collection" in sql:
+            return metadata_cursor
+        cursor = AsyncMock()
+        cursor.fetchone = AsyncMock(return_value=None)
+        return cursor
+
+    db.execute = AsyncMock(side_effect=route_execute)
+
+    with patch("genesis.memory.store.upsert_point"), \
+         patch("genesis.memory.store.update_payload"), \
+         patch("genesis.memory.store.memory_crud") as mock_mem, \
+         patch("genesis.memory.store.memory_links_crud") as mock_links:
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        mock_links.create = AsyncMock(return_value=("old", "new"))
+
+        new_id = await store.store("new fact", "conversation", supersedes=old_id)
+
+    mock_links.create.assert_awaited_once()
+    link_kwargs = mock_links.create.call_args.kwargs
+    assert link_kwargs["source_id"] == old_id
+    assert link_kwargs["target_id"] == new_id
+    assert link_kwargs["link_type"] == "succeeded_by"
+    assert link_kwargs["strength"] == 1.0
+
+
+@pytest.mark.asyncio()
+async def test_store_without_supersedes_skips_deprecation(store, db):
+    """Normal store (no supersedes) should not trigger any deprecation logic."""
+    with patch("genesis.memory.store.upsert_point"), \
+         patch("genesis.memory.store.update_payload") as mock_update, \
+         patch("genesis.memory.store.memory_crud") as mock_mem:
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+
+        await store.store("normal content", "conversation")
+
+    mock_update.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_supersedes_failure_does_not_block_store(store, db):
+    """If supersession fails, the new memory should still be stored successfully."""
+    old_id = "nonexistent-id"
+
+    # Make the metadata lookup fail
+    async def failing_execute(sql, params=None):
+        if isinstance(sql, str) and "deprecated = 1" in sql:
+            raise RuntimeError("simulated DB error")
+        cursor = AsyncMock()
+        cursor.fetchone = AsyncMock(return_value=None)
+        return cursor
+
+    db.execute = AsyncMock(side_effect=failing_execute)
+
+    with patch("genesis.memory.store.upsert_point"), \
+         patch("genesis.memory.store.memory_crud") as mock_mem:
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+
+        result = await store.store(
+            "new content",
+            "conversation",
+            supersedes=old_id,
+        )
+
+    # Store should succeed despite supersession failure
+    assert isinstance(result, str)
+    assert len(result) == 36
+
+
+@pytest.mark.asyncio()
+async def test_search_ranked_excludes_deprecated_by_default():
+    """search_ranked should exclude deprecated memories by default."""
+    import aiosqlite
+
+    db = AsyncMock(spec=aiosqlite.Connection)
+    cursor = AsyncMock()
+    cursor.fetchall = AsyncMock(return_value=[])
+    db.execute = AsyncMock(return_value=cursor)
+
+    from genesis.db.crud.memory import search_ranked
+    await search_ranked(db, query="test query")
+
+    # Verify the SQL includes the deprecated filter
+    sql = db.execute.call_args[0][0]
+    assert "deprecated" in sql
+    assert "deprecated = 0" in sql or "deprecated IS NULL" in sql
+
+
+@pytest.mark.asyncio()
+async def test_search_ranked_includes_deprecated_when_requested():
+    """search_ranked with include_deprecated=True should not filter deprecated."""
+    import aiosqlite
+
+    db = AsyncMock(spec=aiosqlite.Connection)
+    cursor = AsyncMock()
+    cursor.fetchall = AsyncMock(return_value=[])
+    db.execute = AsyncMock(return_value=cursor)
+
+    from genesis.db.crud.memory import search_ranked
+    await search_ranked(db, query="test query", include_deprecated=True)
+
+    # Verify the SQL does NOT include the deprecated filter
+    sql = db.execute.call_args[0][0]
+    assert "deprecated = 0" not in sql

--- a/tests/test_memory/test_supersession.py
+++ b/tests/test_memory/test_supersession.py
@@ -73,10 +73,18 @@ async def test_store_with_supersedes_marks_old_deprecated(store, db):
 
     with patch("genesis.memory.store.upsert_point"), \
          patch("genesis.memory.store.update_payload"), \
-         patch("genesis.memory.store.memory_crud") as mock_mem:
+         patch("genesis.memory.store.memory_crud") as mock_mem, \
+         patch("genesis.memory.store.memory_links_crud") as mock_links:
         mock_mem.upsert = AsyncMock(return_value="id")
         mock_mem.create_metadata = AsyncMock(return_value=None)
         mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        mock_mem.mark_superseded = AsyncMock(return_value=True)
+        mock_mem.get_metadata = AsyncMock(return_value={
+            "memory_id": old_id, "collection": "episodic_memory",
+            "embedding_status": "embedded", "deprecated": 0,
+            "superseded_by": None, "superseded_at": None,
+        })
+        mock_links.create = AsyncMock(return_value=(old_id, "new"))
 
         new_id = await store.store(
             "CC upgraded to v2.1.154",
@@ -87,15 +95,11 @@ async def test_store_with_supersedes_marks_old_deprecated(store, db):
     assert isinstance(new_id, str)
     assert len(new_id) == 36
 
-    # Verify SQLite UPDATE was called to deprecate old memory
-    deprecation_calls = [
-        (sql, params) for sql, params in call_results
-        if isinstance(sql, str) and "deprecated = 1" in sql and "superseded_by" in sql
-    ]
-    assert len(deprecation_calls) == 1
-    sql, params = deprecation_calls[0]
-    assert params[0] == new_id  # superseded_by = new_id
-    assert params[2] == old_id  # WHERE memory_id = old_id
+    # Verify mark_superseded was called with old_id and new_id
+    mock_mem.mark_superseded.assert_awaited_once()
+    call_args = mock_mem.mark_superseded.call_args
+    assert call_args[0][1] == old_id  # old_id
+    assert call_args[0][2] == new_id  # new_id
 
 
 @pytest.mark.asyncio()
@@ -103,25 +107,20 @@ async def test_store_with_supersedes_updates_qdrant(store, db):
     """Storing with supersedes should update the old memory's Qdrant payload."""
     old_id = "old-memory-id"
 
-    # Mock the metadata lookup — old memory exists and is embedded
-    metadata_cursor = AsyncMock()
-    metadata_cursor.fetchone = AsyncMock(return_value=("episodic_memory", "embedded"))
-
-    async def route_execute(sql, params=None):
-        if isinstance(sql, str) and "SELECT collection" in sql:
-            return metadata_cursor
-        cursor = AsyncMock()
-        cursor.fetchone = AsyncMock(return_value=None)
-        return cursor
-
-    db.execute = AsyncMock(side_effect=route_execute)
-
     with patch("genesis.memory.store.upsert_point"), \
          patch("genesis.memory.store.update_payload") as mock_update, \
-         patch("genesis.memory.store.memory_crud") as mock_mem:
+         patch("genesis.memory.store.memory_crud") as mock_mem, \
+         patch("genesis.memory.store.memory_links_crud") as mock_links:
         mock_mem.upsert = AsyncMock(return_value="id")
         mock_mem.create_metadata = AsyncMock(return_value=None)
         mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        mock_mem.mark_superseded = AsyncMock(return_value=True)
+        mock_mem.get_metadata = AsyncMock(return_value={
+            "memory_id": old_id, "collection": "episodic_memory",
+            "embedding_status": "embedded", "deprecated": 0,
+            "superseded_by": None, "superseded_at": None,
+        })
+        mock_links.create = AsyncMock(return_value=(old_id, "new"))
 
         new_id = await store.store(
             "new fact",
@@ -173,18 +172,6 @@ async def test_store_with_supersedes_creates_succeeded_by_link(store, db):
     """Supersession should create a succeeded_by link in memory_links."""
     old_id = "old-memory-id"
 
-    metadata_cursor = AsyncMock()
-    metadata_cursor.fetchone = AsyncMock(return_value=("episodic_memory", "embedded"))
-
-    async def route_execute(sql, params=None):
-        if isinstance(sql, str) and "SELECT collection" in sql:
-            return metadata_cursor
-        cursor = AsyncMock()
-        cursor.fetchone = AsyncMock(return_value=None)
-        return cursor
-
-    db.execute = AsyncMock(side_effect=route_execute)
-
     with patch("genesis.memory.store.upsert_point"), \
          patch("genesis.memory.store.update_payload"), \
          patch("genesis.memory.store.memory_crud") as mock_mem, \
@@ -192,7 +179,13 @@ async def test_store_with_supersedes_creates_succeeded_by_link(store, db):
         mock_mem.upsert = AsyncMock(return_value="id")
         mock_mem.create_metadata = AsyncMock(return_value=None)
         mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
-        mock_links.create = AsyncMock(return_value=("old", "new"))
+        mock_mem.mark_superseded = AsyncMock(return_value=True)
+        mock_mem.get_metadata = AsyncMock(return_value={
+            "memory_id": old_id, "collection": "episodic_memory",
+            "embedding_status": "embedded", "deprecated": 0,
+            "superseded_by": None, "superseded_at": None,
+        })
+        mock_links.create = AsyncMock(return_value=(old_id, "new"))
 
         new_id = await store.store("new fact", "conversation", supersedes=old_id)
 
@@ -286,3 +279,61 @@ async def test_search_ranked_includes_deprecated_when_requested():
     # Verify the SQL does NOT include the deprecated filter
     sql = db.execute.call_args[0][0]
     assert "deprecated = 0" not in sql
+
+
+@pytest.mark.asyncio()
+async def test_qdrant_search_excludes_deprecated_by_default():
+    """Qdrant search() should include deprecated must_not filter by default."""
+    from unittest.mock import MagicMock
+
+    from genesis.qdrant.collections import search
+
+    client = MagicMock()
+    client.query_points = MagicMock(return_value=MagicMock(points=[]))
+
+    search(
+        client,
+        collection="episodic_memory",
+        query_vector=[0.1] * 1024,
+        limit=5,
+    )
+
+    # Verify the filter includes deprecated must_not
+    call_kwargs = client.query_points.call_args.kwargs
+    query_filter = call_kwargs["query_filter"]
+    must_not = query_filter.must_not
+    assert must_not is not None
+    assert any(
+        getattr(cond, "key", None) == "deprecated"
+        for cond in must_not
+    )
+
+
+@pytest.mark.asyncio()
+async def test_qdrant_search_skips_deprecated_filter_when_included():
+    """Qdrant search() with include_deprecated=True should not filter deprecated."""
+    from unittest.mock import MagicMock
+
+    from genesis.qdrant.collections import search
+
+    client = MagicMock()
+    client.query_points = MagicMock(return_value=MagicMock(points=[]))
+
+    search(
+        client,
+        collection="episodic_memory",
+        query_vector=[0.1] * 1024,
+        limit=5,
+        include_deprecated=True,
+    )
+
+    # Verify the filter does NOT include deprecated must_not
+    call_kwargs = client.query_points.call_args.kwargs
+    query_filter = call_kwargs["query_filter"]
+    must_not = query_filter.must_not
+    # must_not should be None or empty (no deprecated filter)
+    if must_not:
+        assert not any(
+            getattr(cond, "key", None) == "deprecated"
+            for cond in must_not
+        )


### PR DESCRIPTION
## Summary
- Add explicit memory supersession: `memory_store(supersedes=<old_id>)` marks old memory as deprecated with a `succeeded_by` link to the new one
- Fix proactive hook gap: deprecated memories were not filtered from Qdrant search in the proactive memory hook (the only retrieval path missing this filter)
- Add `include_deprecated` parameter to `memory_recall` for audit/history queries
- Schema: add `superseded_by` and `superseded_at` columns to `memory_metadata`

## Motivation
Stale facts persist in recall despite dream cycle deprecation. Old CC versions, dead providers, merged PR statuses surface alongside current facts. This adds an explicit supersession mechanism for interactive correction, complementing the dream cycle's automated consolidation.

## Changes
| File | Change |
|------|--------|
| `_migrations.py` | Add superseded_by, superseded_at columns |
| `_tables.py` | Add superseded_by index |
| `store.py` | Add supersedes param + _mark_superseded method |
| `core.py` (MCP) | Expose supersedes on store, include_deprecated on recall |
| `retrieval.py` | Thread include_deprecated to Qdrant + FTS5 queries |
| `collections.py` | Add include_deprecated to Qdrant search |
| `memory.py` (crud) | Add include_deprecated to search_ranked |
| `proactive_memory_hook.py` | Add deprecated filter to Qdrant search |
| `test_supersession.py` | 8 new tests covering store, Qdrant, links, error handling |

## Design decisions
- **Deprioritize, not hide**: superseded memories excluded from normal recall but available via `include_deprecated=True`
- **Explicit ID only**: no search-on-write; caller provides the old memory ID or lets dream cycle detect post-hoc
- **Does NOT touch `invalid_at`**: supersession uses `deprecated` flag (record-level); `invalid_at` is world-validity (independent dimension)
- **Reuses existing patterns**: same deprecation mechanism as `dream_entity_scan._deprecate_memory()` and `dream_cycle._synthesize_and_deprecate()`

## Test plan
- [x] 8 new tests in `test_supersession.py` — all pass
- [x] 24 existing memory tests — no regressions
- [x] Lint clean (ruff)
- [ ] CI checks
- [ ] E2E verification: store with supersedes, verify recall excludes old, verify include_deprecated returns both

🤖 Generated with [Claude Code](https://claude.com/claude-code)