### PR TITLE
fix(ego): pending-proposal dedup in realist + content-hash guard

### DIFF
--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -141,7 +141,7 @@ The daily drivers for professional productivity and general intelligence.
 - **Intelligence Tier:** A/S (Thoughtful reasoning)
 - **SWE-Bench:** ~62%
 - **Cost:** $1.00/$4.00 per MTok (input/output)
-- **Free Tier:** Available on Nvidia NIM (5,000 credits, 40 RPM)
+- **Free Tier:** Available on Nvidia NIM (5,000 credits, 40 RPM); also free on OpenRouter (`:free` suffix, 262k context)
 
 **Best At:**
 1. Needle in a Haystack: Specialized architecture for searching its own memory — king of long-context retrieval.
@@ -460,10 +460,11 @@ Loose guidance — not prescriptive. Use your judgment based on the task require
 - Best for burst scenarios or when Mistral's 2 RPM limit is too slow
 
 ### OpenRouter Free Tier
-- ~29 models available as free variants (`:free` suffix) on OpenRouter
+- ~27 models available as free variants (`:free` suffix) on OpenRouter
 - **Base rate limits:** 20 RPM, 200 RPD (shared across all free models)
 - **With $10 balance:** 1,000 RPD (5x increase, balance is not consumed by free models)
-- Includes Llama 4 Scout, DeepSeek-R1, Gemma 4 31B, Qwen3-Coder 480B, various community models
+- Includes Llama 4 Scout, DeepSeek-R1, Gemma 4 31B, Qwen3-Coder 480B, Nemotron 3 Ultra 550B, Kimi K2.6, various community models
+- Note: DeepSeek V4 Flash free variant removed as of June 2026
 - Use as overflow when other free sources are exhausted, or as primary diversity source
 - Free models use `pricing.prompt == "0"` in API — detectable programmatically
 
@@ -547,6 +548,10 @@ Models requiring benchmark or free-tier verification before routing decisions:
   reranking only. Evaluate for memory recall chain improvement.
 - **Voyage AI voyage-3** — 200M token one-time free embeddings. Evaluate for
   Qdrant embedding quality vs. current embeddings.
+- **NVIDIA Nemotron 3 Ultra 550B (free)** — 550B A55B MoE, 1M context, free on
+  OpenRouter (`nvidia/nemotron-3-ultra-550b-a55b:free`). Largest free model
+  available. Benchmark scores unverified — needs evaluation against existing
+  heavy lifters for quality routing.
 
 ---
 
@@ -647,6 +652,10 @@ High for adversarial review (#20) — without changing application code.
 ---
 
 ## Last Reviewed
+**2026-06-07** — Updated Kimi 2.6 free tier (added OpenRouter `:free` variant,
+262k context); updated OpenRouter free model count (~27, was ~29); noted
+DeepSeek V4 Flash free variant removal; added Nemotron 3 Ultra 550B to
+Pending Evaluation (1M context, largest free model on OpenRouter).
 2026-04-26 — updated GLM-5→5.1 (77.8% SWE, agent-focused), MiniMax M2.5→2.7
 (GPT-4o class, best economics), Kimi K2.5→2.6 (1M+ context, retrieval king),
 DeepSeek V4 specs (128K-512K context, corrected from 10M; updated pricing).

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -348,6 +348,19 @@ async def set_mode(db: aiosqlite.Connection, mode: str, ego_key: str = "ego_mode
 # ---------------------------------------------------------------------------
 
 
+async def has_pending_proposal_with_hash(
+    db: aiosqlite.Connection, content_hash: str,
+) -> bool:
+    """Check if a pending or approved proposal with this content hash exists."""
+    cursor = await db.execute(
+        "SELECT 1 FROM ego_proposals "
+        "WHERE content_hash = ? AND status IN ('pending', 'approved') "
+        "LIMIT 1",
+        (content_hash,),
+    )
+    return await cursor.fetchone() is not None
+
+
 async def create_proposal(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -221,6 +221,25 @@ class ProposalWorkflow:
                 goal_id = raw_goal_id
 
             proposal_content = p.get("content", "")
+            hash_val = _content_hash(proposal_content)
+
+            # Dedup: skip if identical content already pending/approved
+            try:
+                cursor = await self._db.execute(
+                    "SELECT 1 FROM ego_proposals "
+                    "WHERE content_hash = ? AND status IN ('pending', 'approved') "
+                    "LIMIT 1",
+                    (hash_val,),
+                )
+                if await cursor.fetchone():
+                    logger.info(
+                        "Proposal dedup: skipping exact duplicate (hash=%s)",
+                        hash_val[:12],
+                    )
+                    continue
+            except Exception:
+                logger.debug("Proposal dedup check failed, proceeding", exc_info=True)
+
             await ego_crud.create_proposal(
                 self._db,
                 id=pid,
@@ -242,7 +261,7 @@ class ProposalWorkflow:
                 realist_reasoning=p.get("_realist_reasoning"),
                 ego_source=ego_source,
                 goal_id=goal_id,
-                content_hash=_content_hash(proposal_content),
+                content_hash=hash_val,
                 content_size=_content_size(proposal_content),
                 original_content=p.get("_original_content"),
                 expected_outputs=_serialize_expected_outputs(

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -231,13 +231,9 @@ class ProposalWorkflow:
             # the fixed SHA-256 of the empty string.
             if hash_val:
                 try:
-                    cursor = await self._db.execute(
-                        "SELECT 1 FROM ego_proposals "
-                        "WHERE content_hash = ? AND status IN ('pending', 'approved') "
-                        "LIMIT 1",
-                        (hash_val,),
-                    )
-                    if await cursor.fetchone():
+                    if await ego_crud.has_pending_proposal_with_hash(
+                        self._db, hash_val,
+                    ):
                         logger.info(
                             "Proposal dedup: skipping exact duplicate (hash=%s)",
                             hash_val[:12],

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -171,10 +171,12 @@ class ProposalWorkflow:
         *,
         cycle_id: str | None = None,
         ego_source: str | None = None,
-    ) -> tuple[str, list[str]]:
+    ) -> tuple[str, list[str], list[dict]]:
         """Create a batch of proposals from ego output dicts.
 
-        Returns ``(batch_id, [proposal_ids])``.
+        Returns ``(batch_id, [proposal_ids], [created_proposals])``.
+        The third element mirrors the created IDs so callers can pair
+        them correctly even when dedup skips mid-batch proposals.
         """
         batch_id = uuid.uuid4().hex[:16]
         created_at = datetime.now(UTC).isoformat()
@@ -198,6 +200,7 @@ class ProposalWorkflow:
         from genesis.ego.integrity import content_size as _content_size
 
         ids: list[str] = []
+        created_proposals: list[dict] = []
         for p in proposals:
             pid = uuid.uuid4().hex[:16]
             rank_val = p.get("rank")
@@ -221,24 +224,27 @@ class ProposalWorkflow:
                 goal_id = raw_goal_id
 
             proposal_content = p.get("content", "")
-            hash_val = _content_hash(proposal_content)
+            hash_val = _content_hash(proposal_content) if proposal_content else None
 
-            # Dedup: skip if identical content already pending/approved
-            try:
-                cursor = await self._db.execute(
-                    "SELECT 1 FROM ego_proposals "
-                    "WHERE content_hash = ? AND status IN ('pending', 'approved') "
-                    "LIMIT 1",
-                    (hash_val,),
-                )
-                if await cursor.fetchone():
-                    logger.info(
-                        "Proposal dedup: skipping exact duplicate (hash=%s)",
-                        hash_val[:12],
+            # Dedup: skip if identical content already pending/approved.
+            # Skip check for empty content to avoid false collisions on
+            # the fixed SHA-256 of the empty string.
+            if hash_val:
+                try:
+                    cursor = await self._db.execute(
+                        "SELECT 1 FROM ego_proposals "
+                        "WHERE content_hash = ? AND status IN ('pending', 'approved') "
+                        "LIMIT 1",
+                        (hash_val,),
                     )
-                    continue
-            except Exception:
-                logger.debug("Proposal dedup check failed, proceeding", exc_info=True)
+                    if await cursor.fetchone():
+                        logger.info(
+                            "Proposal dedup: skipping exact duplicate (hash=%s)",
+                            hash_val[:12],
+                        )
+                        continue
+                except Exception:
+                    logger.warning("Proposal dedup check failed, proceeding", exc_info=True)
 
             await ego_crud.create_proposal(
                 self._db,
@@ -269,13 +275,14 @@ class ProposalWorkflow:
                 ),
             )
             ids.append(pid)
+            created_proposals.append(p)
 
         logger.info(
             "Created ego proposal batch %s with %d proposals",
             batch_id,
             len(ids),
         )
-        return batch_id, ids
+        return batch_id, ids, created_proposals
 
     # -- Formatting --------------------------------------------------------
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1189,7 +1189,7 @@ class EgoSession:
             except Exception:
                 logger.debug("Pending cap check failed, proceeding", exc_info=True)
 
-            batch_id, ids = await self._proposals.create_batch(
+            batch_id, ids, created = await self._proposals.create_batch(
                 proposals,
                 cycle_id=cycle_id,
                 ego_source=self._source_tag,
@@ -1205,7 +1205,7 @@ class EgoSession:
                 from genesis.db.crud import intervention_journal as journal_crud
 
                 now = datetime.now(UTC).isoformat()
-                for pid, prop in zip(ids, proposals, strict=False):
+                for pid, prop in zip(ids, created, strict=False):
                     await journal_crud.create(
                         self._db,
                         ego_source=self._source_tag,

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -2114,10 +2114,16 @@ proposal and return a JSON array of verdicts.
 ## Rules
 {rule_1}
 
-2. **Check for zombies.** If a proposal covers substantially the same topic
-   as a recent proposal that was recycled/withdrawn/deferred/expired, and
-   nothing has changed in the circumstances, REJECT: "Zombie — proposed
-   before with no change in circumstances."
+2. **Check for zombies and duplicates.**
+   - ZOMBIE: If a proposal covers substantially the same topic as a recent
+     proposal that was recycled/withdrawn/deferred/expired, and nothing has
+     changed in the circumstances, REJECT: "Zombie — proposed before with
+     no change in circumstances."
+   - DUPLICATE: If a proposal covers substantially the same **topic** as a
+     currently **pending** or **approved** proposal in the history table,
+     REJECT: "Duplicate — same topic already pending/approved." Note: two
+     proposals about the same project but covering different aspects (e.g.,
+     different paper sections, different pipeline stages) are NOT duplicates.
 
 3. **Check feasibility.** If a proposal requires a capability Genesis
    genuinely doesn't have, AMEND with a feasible alternative.

--- a/tests/ego/test_proposals.py
+++ b/tests/ego/test_proposals.py
@@ -172,7 +172,7 @@ class TestProposalCRUD:
 
 class TestProposalWorkflow:
     async def test_create_batch_inserts(self, workflow, db):
-        batch_id, ids = await workflow.create_batch(
+        batch_id, ids, _ = await workflow.create_batch(
             _sample_proposals(3), cycle_id="cycle1",
         )
         assert len(ids) == 3
@@ -194,7 +194,7 @@ class TestProposalWorkflow:
             "execution_plan": "background CC, ~$0.30",
             "recurring": True,
         }]
-        batch_id, ids = await workflow.create_batch(props)
+        batch_id, ids, _ = await workflow.create_batch(props)
         row = (await ego_crud.list_proposals_by_batch(db, batch_id))[0]
         assert row["rank"] == 1
         assert row["execution_plan"] == "background CC, ~$0.30"
@@ -216,7 +216,7 @@ class TestProposalWorkflow:
             "confidence": 0.8,
             "goal_id": goal_id,
         }]
-        batch_id, ids = await workflow.create_batch(props)
+        batch_id, ids, _ = await workflow.create_batch(props)
         row = (await ego_crud.list_proposals_by_batch(db, batch_id))[0]
         assert row["goal_id"] == goal_id
 
@@ -229,7 +229,7 @@ class TestProposalWorkflow:
             "confidence": 0.7,
             "goal_id": "fake-goal-that-doesnt-exist",
         }]
-        batch_id, ids = await workflow.create_batch(props)
+        batch_id, ids, _ = await workflow.create_batch(props)
         row = (await ego_crud.list_proposals_by_batch(db, batch_id))[0]
         assert row["goal_id"] is None
 
@@ -240,7 +240,7 @@ class TestProposalWorkflow:
             "content": "Fix memory index",
             "confidence": 0.9,
         }]
-        batch_id, ids = await workflow.create_batch(props)
+        batch_id, ids, _ = await workflow.create_batch(props)
         row = (await ego_crud.list_proposals_by_batch(db, batch_id))[0]
         assert row["goal_id"] is None
 
@@ -322,7 +322,7 @@ class TestProposalWorkflow:
     async def test_send_digest_calls_topic_manager(
         self, workflow, db, mock_topic_manager,
     ):
-        batch_id, _ = await workflow.create_batch(_sample_proposals(2))
+        batch_id, _, _ = await workflow.create_batch(_sample_proposals(2))
         delivery = await workflow.send_digest(batch_id)
         assert delivery == "msg12345"
         mock_topic_manager.send_to_category.assert_called_once()
@@ -330,7 +330,7 @@ class TestProposalWorkflow:
         assert call_args[0][0] == "ego_proposals"
 
     async def test_send_digest_stores_mapping(self, workflow, db):
-        batch_id, _ = await workflow.create_batch(_sample_proposals(1))
+        batch_id, _, _ = await workflow.create_batch(_sample_proposals(1))
         delivery = await workflow.send_digest(batch_id)
         assert await ego_crud.get_batch_for_delivery(db, delivery) == batch_id
         assert await ego_crud.get_state(
@@ -339,13 +339,13 @@ class TestProposalWorkflow:
 
     async def test_send_digest_no_topic_manager(self, db):
         wf = ProposalWorkflow(db=db, topic_manager=None)
-        batch_id, _ = await wf.create_batch(_sample_proposals(1))
+        batch_id, _, _ = await wf.create_batch(_sample_proposals(1))
         assert await wf.send_digest(batch_id) is None
 
     async def test_correction_stored_on_reject_with_reason(
         self, workflow, db, mock_memory_store,
     ):
-        batch_id, ids = await workflow.create_batch(_sample_proposals(2))
+        batch_id, ids, _ = await workflow.create_batch(_sample_proposals(2))
         await workflow.send_digest(batch_id)
         mock_memory_store.reset_mock()
 
@@ -366,7 +366,7 @@ class TestProposalWorkflow:
     async def test_no_correction_on_reject_without_reason(
         self, workflow, db, mock_memory_store,
     ):
-        batch_id, ids = await workflow.create_batch(_sample_proposals(1))
+        batch_id, ids, _ = await workflow.create_batch(_sample_proposals(1))
         mock_memory_store.reset_mock()
 
         await workflow.resolve_proposals(
@@ -377,7 +377,7 @@ class TestProposalWorkflow:
     async def test_no_correction_on_approve(
         self, workflow, db, mock_memory_store,
     ):
-        batch_id, ids = await workflow.create_batch(_sample_proposals(1))
+        batch_id, ids, _ = await workflow.create_batch(_sample_proposals(1))
         mock_memory_store.reset_mock()
 
         await workflow.resolve_proposals(
@@ -394,7 +394,7 @@ class TestProposalWorkflow:
             topic_manager=mock_topic_manager,
             memory_store=bad_store,
         )
-        batch_id, ids = await wf.create_batch(_sample_proposals(1))
+        batch_id, ids, _ = await wf.create_batch(_sample_proposals(1))
         results = await wf.resolve_proposals(
             batch_id, {1: ("rejected", "bad idea")},
         )

--- a/tests/ego/test_realist.py
+++ b/tests/ego/test_realist.py
@@ -333,7 +333,7 @@ class TestRealistFilterIntegration:
         ]
 
         workflow = ProposalWorkflow(db=db)
-        batch_id, ids = await workflow.create_batch(proposals)
+        batch_id, ids, _ = await workflow.create_batch(proposals)
 
         prop = await ego_crud.get_proposal(db, ids[0])
         assert prop["realist_verdict"] == "pass"
@@ -353,7 +353,7 @@ class TestRealistFilterIntegration:
         ]
 
         workflow = ProposalWorkflow(db=db)
-        batch_id, ids = await workflow.create_batch(proposals)
+        batch_id, ids, _ = await workflow.create_batch(proposals)
 
         prop = await ego_crud.get_proposal(db, ids[0])
         assert prop["realist_verdict"] is None
@@ -371,7 +371,7 @@ class TestEgoSourceIsolation:
 
         proposals = [{"action_type": "dispatch", "content": "Test", "confidence": 0.8}]
         workflow = ProposalWorkflow(db=db)
-        _, ids = await workflow.create_batch(
+        _, ids, _ = await workflow.create_batch(
             proposals, ego_source="user_ego_cycle",
         )
         prop = await ego_crud.get_proposal(db, ids[0])
@@ -384,7 +384,7 @@ class TestEgoSourceIsolation:
 
         proposals = [{"action_type": "dispatch", "content": "Old", "confidence": 0.5}]
         workflow = ProposalWorkflow(db=db)
-        _, ids = await workflow.create_batch(proposals)
+        _, ids, _ = await workflow.create_batch(proposals)
         prop = await ego_crud.get_proposal(db, ids[0])
         assert prop["ego_source"] is None
 

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -114,7 +114,7 @@ def mock_context_builder():
 @pytest.fixture
 def mock_proposal_workflow():
     pw = AsyncMock()
-    pw.create_batch.return_value = ("batch123", ["p1"])
+    pw.create_batch.return_value = ("batch123", ["p1"], [{"content": "test"}])
     pw.send_digest.return_value = "msg456"
     return pw
 

--- a/tests/test_ego/test_integrity.py
+++ b/tests/test_ego/test_integrity.py
@@ -139,7 +139,7 @@ async def test_create_batch_skips_exact_duplicate(db):
     wf = ProposalWorkflow(db=db)
 
     # Create first batch — should succeed
-    _, ids1 = await wf.create_batch(
+    _, ids1, _ = await wf.create_batch(
         [{"content": "Investigate star spike", "action_type": "investigate"}],
         cycle_id="cycle-1",
         ego_source="user_ego_cycle",
@@ -147,7 +147,7 @@ async def test_create_batch_skips_exact_duplicate(db):
     assert len(ids1) == 1
 
     # Create second batch with identical content — should be deduped
-    _, ids2 = await wf.create_batch(
+    _, ids2, _ = await wf.create_batch(
         [{"content": "Investigate star spike", "action_type": "investigate"}],
         cycle_id="cycle-2",
         ego_source="user_ego_cycle",
@@ -161,14 +161,14 @@ async def test_create_batch_allows_different_content(db):
 
     wf = ProposalWorkflow(db=db)
 
-    _, ids1 = await wf.create_batch(
+    _, ids1, _ = await wf.create_batch(
         [{"content": "Investigate star spike", "action_type": "investigate"}],
         cycle_id="cycle-1",
         ego_source="user_ego_cycle",
     )
     assert len(ids1) == 1
 
-    _, ids2 = await wf.create_batch(
+    _, ids2, _ = await wf.create_batch(
         [{"content": "Draft Discord milestone post", "action_type": "dispatch"}],
         cycle_id="cycle-2",
         ego_source="user_ego_cycle",
@@ -182,7 +182,7 @@ async def test_create_batch_allows_after_rejection(db):
 
     wf = ProposalWorkflow(db=db)
 
-    _, ids1 = await wf.create_batch(
+    _, ids1, _ = await wf.create_batch(
         [{"content": "Investigate star spike", "action_type": "investigate"}],
         cycle_id="cycle-1",
         ego_source="user_ego_cycle",
@@ -193,12 +193,84 @@ async def test_create_batch_allows_after_rejection(db):
     await ego_crud.resolve_proposal(db, ids1[0], status="rejected")
 
     # Re-propose — should succeed since the original is no longer pending
-    _, ids2 = await wf.create_batch(
+    _, ids2, _ = await wf.create_batch(
         [{"content": "Investigate star spike", "action_type": "investigate"}],
         cycle_id="cycle-2",
         ego_source="user_ego_cycle",
     )
     assert len(ids2) == 1  # allowed — prior proposal was rejected
+
+
+async def test_create_batch_empty_content_not_blocked(db):
+    """Empty content proposals should not block each other via hash collision."""
+    from genesis.ego.proposals import ProposalWorkflow
+
+    wf = ProposalWorkflow(db=db)
+
+    _, ids1, _ = await wf.create_batch(
+        [{"content": "", "action_type": "investigate"}],
+        cycle_id="cycle-1",
+        ego_source="user_ego_cycle",
+    )
+    assert len(ids1) == 1
+
+    # Second empty-content proposal should NOT be blocked
+    _, ids2, _ = await wf.create_batch(
+        [{"content": "", "action_type": "dispatch"}],
+        cycle_id="cycle-2",
+        ego_source="user_ego_cycle",
+    )
+    assert len(ids2) == 1  # empty content bypasses dedup
+
+
+async def test_create_batch_returns_created_proposals(db):
+    """create_batch returns the proposals that were actually created."""
+    from genesis.ego.proposals import ProposalWorkflow
+
+    wf = ProposalWorkflow(db=db)
+
+    p1 = {"content": "First proposal", "action_type": "investigate"}
+    p2 = {"content": "Second proposal", "action_type": "dispatch"}
+    _, ids, created = await wf.create_batch(
+        [p1, p2],
+        cycle_id="cycle-1",
+        ego_source="user_ego_cycle",
+    )
+    assert len(ids) == 2
+    assert len(created) == 2
+    assert created[0]["content"] == "First proposal"
+    assert created[1]["content"] == "Second proposal"
+
+
+async def test_create_batch_created_proposals_exclude_deduped(db):
+    """created_proposals list excludes deduped proposals for correct pairing."""
+    from genesis.ego.proposals import ProposalWorkflow
+
+    wf = ProposalWorkflow(db=db)
+
+    # Create a pending proposal
+    _, ids1, _ = await wf.create_batch(
+        [{"content": "Duplicate me", "action_type": "investigate"}],
+        cycle_id="cycle-1",
+        ego_source="user_ego_cycle",
+    )
+    assert len(ids1) == 1
+
+    # Batch with dup in the middle: [new, dup, new]
+    _, ids2, created2 = await wf.create_batch(
+        [
+            {"content": "First new", "action_type": "dispatch"},
+            {"content": "Duplicate me", "action_type": "investigate"},
+            {"content": "Second new", "action_type": "dispatch"},
+        ],
+        cycle_id="cycle-2",
+        ego_source="user_ego_cycle",
+    )
+    assert len(ids2) == 2  # dup skipped
+    assert len(created2) == 2
+    # Verify alignment — ids pair with the right proposals
+    assert created2[0]["content"] == "First new"
+    assert created2[1]["content"] == "Second new"
 
 
 # ── Realist gate: _original_content propagation ─────────────────────────────

--- a/tests/test_ego/test_integrity.py
+++ b/tests/test_ego/test_integrity.py
@@ -129,6 +129,78 @@ async def test_create_proposal_without_integrity(db):
     assert row["original_content"] is None
 
 
+# ── Proposal dedup: content_hash enforcement in create_batch ────────────────
+
+
+async def test_create_batch_skips_exact_duplicate(db):
+    """create_batch skips proposals whose content_hash matches a pending one."""
+    from genesis.ego.proposals import ProposalWorkflow
+
+    wf = ProposalWorkflow(db=db)
+
+    # Create first batch — should succeed
+    _, ids1 = await wf.create_batch(
+        [{"content": "Investigate star spike", "action_type": "investigate"}],
+        cycle_id="cycle-1",
+        ego_source="user_ego_cycle",
+    )
+    assert len(ids1) == 1
+
+    # Create second batch with identical content — should be deduped
+    _, ids2 = await wf.create_batch(
+        [{"content": "Investigate star spike", "action_type": "investigate"}],
+        cycle_id="cycle-2",
+        ego_source="user_ego_cycle",
+    )
+    assert len(ids2) == 0  # deduped — no new proposals created
+
+
+async def test_create_batch_allows_different_content(db):
+    """create_batch allows proposals with different content."""
+    from genesis.ego.proposals import ProposalWorkflow
+
+    wf = ProposalWorkflow(db=db)
+
+    _, ids1 = await wf.create_batch(
+        [{"content": "Investigate star spike", "action_type": "investigate"}],
+        cycle_id="cycle-1",
+        ego_source="user_ego_cycle",
+    )
+    assert len(ids1) == 1
+
+    _, ids2 = await wf.create_batch(
+        [{"content": "Draft Discord milestone post", "action_type": "dispatch"}],
+        cycle_id="cycle-2",
+        ego_source="user_ego_cycle",
+    )
+    assert len(ids2) == 1  # different content — allowed
+
+
+async def test_create_batch_allows_after_rejection(db):
+    """Re-proposing content that was rejected should succeed."""
+    from genesis.ego.proposals import ProposalWorkflow
+
+    wf = ProposalWorkflow(db=db)
+
+    _, ids1 = await wf.create_batch(
+        [{"content": "Investigate star spike", "action_type": "investigate"}],
+        cycle_id="cycle-1",
+        ego_source="user_ego_cycle",
+    )
+    assert len(ids1) == 1
+
+    # Reject the proposal
+    await ego_crud.resolve_proposal(db, ids1[0], status="rejected")
+
+    # Re-propose — should succeed since the original is no longer pending
+    _, ids2 = await wf.create_batch(
+        [{"content": "Investigate star spike", "action_type": "investigate"}],
+        cycle_id="cycle-2",
+        ego_source="user_ego_cycle",
+    )
+    assert len(ids2) == 1  # allowed — prior proposal was rejected
+
+
 # ── Realist gate: _original_content propagation ─────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Realist Rule #2 now rejects proposals that semantically duplicate a currently **pending** or **approved** proposal (previously only caught recycled/withdrawn/expired "zombies")
- `create_batch()` pre-insert content-hash check catches exact-text duplicates as a belt-and-suspenders guard
- Includes carve-out so related-but-distinct proposals (e.g., different paper sections) aren't falsely rejected

## Root Cause

The ego re-words proposals each cycle, so content_hash (exact match) didn't catch them. The realist had the pending proposal data in its history table but no instruction to flag semantic overlaps with pending items.

## Test plan

- [x] 3 new tests: dedup blocks exact duplicate, allows different content, allows re-proposal after rejection
- [x] All 125 ego tests pass
- [x] Lint clean
- [ ] CI green
- [ ] Monitor next ego cycle for duplicate proposals

🤖 Generated with [Claude Code](https://claude.com/claude-code)