### PR TITLE
fix(recon): move star tracking to user-level config

### DIFF
--- a/config/recon_watchlist.yaml
+++ b/config/recon_watchlist.yaml
@@ -1,8 +1,7 @@
 # Recon Watchlist — Projects Genesis actively monitors for updates.
 #
-# These are hardcoded watch targets. The recon system checks these on schedule
-# regardless of salience scoring or LLM judgment. Add/remove entries here;
-# recon_config (MCP tool, aspect: sources) manages dynamic sources separately.
+# Base watch targets (committed). Install-specific entries (e.g., your own
+# repo for star tracking) go in recon_watchlist.local.yaml (gitignored).
 #
 # Fields:
 #   name:        Human-readable project name
@@ -13,14 +12,6 @@
 #   urls:        Additional non-GitHub URLs to monitor (docs, blogs, changelogs)
 
 projects:
-
-  - name: GENesis-AGI
-    repo: WingedGuardian/GENesis-AGI
-    track: [stars]
-    priority: high
-    notes: >
-      Genesis public repo. Star count is the primary growth metric for the
-      marketing campaign. Track changes to measure outreach effectiveness.
 
   - name: Claude Code
     repo: anthropics/claude-code

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -141,7 +141,7 @@ The daily drivers for professional productivity and general intelligence.
 - **Intelligence Tier:** A/S (Thoughtful reasoning)
 - **SWE-Bench:** ~62%
 - **Cost:** $1.00/$4.00 per MTok (input/output)
-- **Free Tier:** Available on Nvidia NIM (5,000 credits, 40 RPM)
+- **Free Tier:** Available on Nvidia NIM (5,000 credits, 40 RPM); also free on OpenRouter (`:free` suffix, 262k context)
 
 **Best At:**
 1. Needle in a Haystack: Specialized architecture for searching its own memory — king of long-context retrieval.
@@ -460,10 +460,11 @@ Loose guidance — not prescriptive. Use your judgment based on the task require
 - Best for burst scenarios or when Mistral's 2 RPM limit is too slow
 
 ### OpenRouter Free Tier
-- ~29 models available as free variants (`:free` suffix) on OpenRouter
+- ~27 models available as free variants (`:free` suffix) on OpenRouter
 - **Base rate limits:** 20 RPM, 200 RPD (shared across all free models)
 - **With $10 balance:** 1,000 RPD (5x increase, balance is not consumed by free models)
-- Includes Llama 4 Scout, DeepSeek-R1, Gemma 4 31B, Qwen3-Coder 480B, various community models
+- Includes Llama 4 Scout, DeepSeek-R1, Gemma 4 31B, Qwen3-Coder 480B, Nemotron 3 Ultra 550B, Kimi K2.6, various community models
+- Note: DeepSeek V4 Flash free variant removed as of June 2026
 - Use as overflow when other free sources are exhausted, or as primary diversity source
 - Free models use `pricing.prompt == "0"` in API — detectable programmatically
 
@@ -547,6 +548,10 @@ Models requiring benchmark or free-tier verification before routing decisions:
   reranking only. Evaluate for memory recall chain improvement.
 - **Voyage AI voyage-3** — 200M token one-time free embeddings. Evaluate for
   Qdrant embedding quality vs. current embeddings.
+- **NVIDIA Nemotron 3 Ultra 550B (free)** — 550B A55B MoE, 1M context, free on
+  OpenRouter (`nvidia/nemotron-3-ultra-550b-a55b:free`). Largest free model
+  available. Benchmark scores unverified — needs evaluation against existing
+  heavy lifters for quality routing.
 
 ---
 
@@ -647,6 +652,10 @@ High for adversarial review (#20) — without changing application code.
 ---
 
 ## Last Reviewed
+**2026-06-07** — Updated Kimi 2.6 free tier (added OpenRouter `:free` variant,
+262k context); updated OpenRouter free model count (~27, was ~29); noted
+DeepSeek V4 Flash free variant removal; added Nemotron 3 Ultra 550B to
+Pending Evaluation (1M context, largest free model on OpenRouter).
 2026-04-26 — updated GLM-5→5.1 (77.8% SWE, agent-focused), MiniMax M2.5→2.7
 (GPT-4o class, best economics), Kimi K2.5→2.6 (1M+ context, retrieval king),
 DeepSeek V4 specs (128K-512K context, corrected from 10M; updated pricing).

--- a/src/genesis/recon/gatherer.py
+++ b/src/genesis/recon/gatherer.py
@@ -379,15 +379,36 @@ class ReconGatherer:
 
     @staticmethod
     def _load_watchlist() -> list[dict]:
-        """Load the hardcoded project watchlist."""
+        """Load project watchlist with local overlay support.
+
+        Base: ``config/recon_watchlist.yaml`` (committed, project-level)
+        Overlay: ``config/recon_watchlist.local.yaml`` (gitignored, install-level)
+
+        Projects from the local overlay are appended to the base list.
+        """
         if not _WATCHLIST_PATH.exists():
             return []
         try:
             import yaml
 
             with open(_WATCHLIST_PATH) as f:
-                data = yaml.safe_load(f)
-            return data.get("projects", []) if data else []
+                data = yaml.safe_load(f) or {}
+            projects = list(data.get("projects", []))
+
+            # Merge install-specific overlay (gitignored)
+            local_path = _WATCHLIST_PATH.with_suffix(".local.yaml")
+            if local_path.exists():
+                with open(local_path) as f:
+                    local_data = yaml.safe_load(f) or {}
+                local_projects = local_data.get("projects", [])
+                # Deduplicate by repo name
+                existing_repos = {p.get("repo") for p in projects}
+                for lp in local_projects:
+                    if lp.get("repo") not in existing_repos:
+                        projects.append(lp)
+                        existing_repos.add(lp.get("repo"))
+
+            return projects
         except Exception:
             logger.error("Failed to load watchlist", exc_info=True)
             return []


### PR DESCRIPTION
## Summary

- Move GENesis-AGI star tracking entry from `config/recon_watchlist.yaml` to `config/recon_watchlist.local.yaml` (gitignored)
- Wire `_load_watchlist()` to merge local overlay entries, deduplicating by repo name
- Other watchlist entries (Claude Code, OpenClaw, Cognee, etc.) stay in base config — they're project-level intelligence, not install-specific

## Why

Star tracking for the marketing campaign is install-specific. Other GENesis-AGI clones shouldn't have `WingedGuardian/GENesis-AGI` in their watchlist.

## Test plan

- [x] All 31 gatherer tests pass
- [x] Lint clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)