### PR TITLE
feat(browser): behavioral biometrics — jitter, hold time, scroll

### DIFF
--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import math
 import os
 import random
 import time
@@ -841,6 +842,31 @@ def _check_page_drift(page) -> dict | None:
     return None
 
 
+# Module-level mouse position tracking (Playwright doesn't expose this).
+# Updated by _stealth_click and _idle_jitter; used for micro-jitter.
+_mouse_pos: dict[str, float] = {"x": 960.0, "y": 540.0}
+
+
+async def _idle_jitter(page, duration_s: float) -> None:
+    """Emit micro-movements during dwell to simulate hand tremor.
+
+    Real cursors produce ±1-3px displacement at ~0.5-1Hz while "still."
+    Call this during any dwell period >2s to avoid dead-cursor detection.
+    """
+    end = time.monotonic() + duration_s
+    while time.monotonic() < end:
+        await asyncio.sleep(random.uniform(0.8, 2.5))
+        if time.monotonic() >= end:
+            break
+        dx = random.uniform(-3, 3)
+        dy = random.uniform(-3, 3)
+        new_x = max(0, _mouse_pos["x"] + dx)
+        new_y = max(0, _mouse_pos["y"] + dy)
+        await page.mouse.move(new_x, new_y, steps=1)
+        _mouse_pos["x"] = new_x
+        _mouse_pos["y"] = new_y
+
+
 async def _human_delay() -> None:
     """Random delay mimicking human interaction timing.
 
@@ -862,6 +888,29 @@ async def _human_delay() -> None:
         delay = min(random.lognormvariate(1.2, 0.6), 15.0)
         delay = max(delay, 1.0)
         await asyncio.sleep(delay)
+
+
+async def _human_scroll(page, pixels: int, *, direction: str = "down") -> None:
+    """Scroll with human-like momentum, variance, and occasional back-scroll.
+
+    Emits variable-delta wheel events with decelerating pauses.
+    30% chance of a small back-scroll after reaching the target.
+    """
+    sign = -1 if direction == "up" else 1
+    scrolled = 0
+    while scrolled < pixels:
+        remaining = pixels - scrolled
+        delta = min(random.randint(20, 100), remaining)
+        await page.mouse.wheel(0, sign * delta)
+        scrolled += delta
+        # Deceleration: longer pauses as we approach target
+        pause = random.uniform(0.05, 0.15) * (1.0 + scrolled / max(pixels, 1))
+        await asyncio.sleep(pause)
+    # Occasional back-scroll (30% chance)
+    if random.random() < 0.3:
+        await asyncio.sleep(random.uniform(0.2, 0.5))
+        back = random.randint(10, 40)
+        await page.mouse.wheel(0, -sign * back)
 
 
 # ---------------------------------------------------------------------------
@@ -962,6 +1011,8 @@ async def _stealth_click(page, selector: str, timeout: int = 10000) -> None:
 
         # Hover first — generates mousemove trail to the element
         await page.mouse.move(target_x, target_y, steps=random.randint(5, 15))
+        _mouse_pos["x"] = target_x
+        _mouse_pos["y"] = target_y
         await asyncio.sleep(random.uniform(0.05, 0.2))
 
         # Click with realistic mousedown/mouseup gap
@@ -1076,9 +1127,17 @@ async def _human_type(page, selector: str, value: str) -> None:
     await page.fill(selector, "", timeout=10000)
     # Click to focus the field
     await page.click(selector, timeout=10000)
-    # Type per-keystroke with TRUE per-character IKI jitter
+    # Type per-keystroke with hold time + flight time (IKI) jitter.
+    # Hold time: log-normal, median ~86ms (CMU Keystroke Dynamics calibration).
+    # Flight time: 50-200ms uniform with 5% thinking pauses.
     for char in value:
-        await page.keyboard.type(char)
+        # Hold phase: keydown → hold → keyup
+        hold_s = random.lognormvariate(math.log(0.086), 0.35)
+        hold_s = max(0.03, min(hold_s, 0.20))  # clamp 30-200ms
+        await page.keyboard.down(char)
+        await asyncio.sleep(hold_s)
+        await page.keyboard.up(char)
+        # Flight phase: gap to next key
         iki = random.uniform(0.05, 0.20)  # 50-200ms
         # 5% chance of a "thinking pause" (300-1000ms)
         if random.random() < 0.05:

--- a/src/genesis/skills/stealth-browser/SKILL.md
+++ b/src/genesis/skills/stealth-browser/SKILL.md
@@ -247,6 +247,84 @@ the browser's built-in anti-detection:
 
 ---
 
+## Advanced Behavioral Rules
+
+These rules address detection surfaces beyond basic timing and clicks.
+Apply them in all Camoufox sessions unless site-specific guidance overrides.
+
+### Idle Mouse Micro-Jitter
+
+Real hands produce ±1-3px tremor while "still." Between actions (any
+dwell period >2s), the cursor must not be dead-still.
+
+- Emit 1-3 mousemove events every 1-2s during all dwell periods
+- Displacement: ±1-3px from current position (random, not oscillating)
+- Do NOT jitter during active movement (only during stillness)
+- Implemented in `_idle_jitter()` in browser.py
+
+### Keystroke Hold Time (keydown-to-keyup gap)
+
+Real keys are held briefly before release. Each keypress fires
+`keyboard.down(char)` → hold → `keyboard.up(char)`.
+
+- Hold time per key: sample from log-normal distribution
+- Calibration: median ~86ms (p5=48ms, p95=149ms) per CMU Keystroke dataset
+- Vary per keystroke -- NOT uniform across all keys
+- Flight time (key-up to next key-down): existing 50-200ms IKI still applies
+- Implemented in `_human_type()` in browser.py
+
+### Navigation Graph Depth
+
+Arriving directly at a form/auth page with no prior navigation is a
+strong bot signal regardless of per-page behavior.
+
+- For ANY target that is a form, login, checkout, or data-heavy endpoint:
+  navigate through at least 2 prior pages on the same domain
+- Dwell 2-5s on each prior page before proceeding
+- This generalizes the existing "visit careers page" rule to all targets
+- Referrer chain must be organic (not cold-start direct navigation)
+
+### Tab Visibility Switch
+
+Sessions maintaining continuous focus for >15s are atypical for humans.
+
+- For pages with >15s dwell before form interaction: simulate one
+  visibilitychange event (tab hidden + visible) before submission
+- Use `browser_run_js` to dispatch: `document.dispatchEvent(new Event('visibilitychange'))`
+- Or use actual tab switching if available
+
+### Scroll Patterns
+
+Real scrolling decelerates, occasionally goes backwards, and pauses at
+content boundaries.
+
+- Include at least one upward scroll segment per page (probability 0.2)
+- Decelerate scroll to zero over 200-400ms at end of each gesture
+- Add "scroll past then back" pattern when targeting form fields (p=0.3)
+- Scroll delta variance: 20-100px per event (never constant)
+- Implemented in `_human_scroll()` in browser.py
+
+### Pre-Form Element Interaction
+
+Direct-to-form behavior (first interaction is a form field) scores
+-0.1 to -0.3 on reCAPTCHA v3.
+
+- Before filling the first form field: move cursor to 1-2 non-form
+  elements (nav link, header, image), dwell 0.3-1.5s each
+- Then move to the first form field
+- This produces an interaction graph that doesn't start at the form target
+
+### Typo and Self-Correction (long text fields only)
+
+Real typists make errors at ~2% rate and correct them.
+
+- For text fields >20 characters: introduce one typo per ~50 chars
+- Type 1-2 wrong characters, pause 200-500ms, backspace, type correct
+- Do NOT apply to short fields (names, emails, passwords)
+- This is LLM-guided behavior, not auto-enforced in code
+
+---
+
 ## What This Skill Does NOT Cover
 
 - Browser fingerprinting (handled by Camoufox at C++ level)

--- a/src/genesis/skills/stealth-browser/references/anti-detection-research.md
+++ b/src/genesis/skills/stealth-browser/references/anti-detection-research.md
@@ -77,3 +77,51 @@ Modern anti-detection browsers (Camoufox, Patchright) handle:
 - Residential proxies: necessary for high-detection sites
 - GeoIP must align with timezone/locale headers
 - IP stability matters: rotating too fast = suspicious
+
+## Vendor-Specific Intelligence (June 2026)
+
+### AudioContext Fingerprinting (all vendors)
+
+Camoufox handles AudioContext spoofing at the C++ level. Operators using
+non-Camoufox setups (plain Playwright, custom CDP) must independently
+verify that AudioContext oscillator output is not SwiftShader-identified.
+SwiftShader audio output is a primary PerimeterX and DataDome block trigger.
+
+### PerimeterX _px3 Token Lifecycle
+
+The _px3 security token expires in ~60 seconds -- the most aggressive
+expiry in any enterprise anti-bot system. Any pipeline navigating a
+PerimeterX site across multiple pages over >60s will fail mid-session.
+The `_pxvid` visitor ID cookie must persist across pages within a session.
+A fresh `_pxvid` on every navigation = strong automation signal.
+
+### WebRTC Local IP Consistency
+
+WebRTC STUN requests can expose the client's real local IP. When using
+residential proxies, ensure WebRTC is either disabled in the browser
+profile or routed through the proxy. A datacenter local IP behind a
+residential proxy creates a detectable inconsistency (PerimeterX, DataDome).
+
+### reCAPTCHA v3 History Signals
+
+- Active Google login (SID, HSID, SSID cookies) raises score +0.1 to +0.3
+- _GRECAPTCHA cookie: prior successful solves accumulate reputation
+- Cross-site reputation: good behavior on site A helps site B
+- Profile pre-warming should include visiting Google properties before
+  high-security reCAPTCHA v3 targets
+
+### DataDome Per-Site ML Cadence
+
+DataDome trains a separate ML model per protected site. Request cadence
+is site-specific -- what's human on a news site is bot-like on a checkout.
+After successful form submission or data extraction: wait 2-5s before
+navigating away or closing the session.
+
+## Calibration Datasets
+
+| Dataset | Content | Source |
+|---------|---------|--------|
+| CMU Keystroke Dynamics | 51 subjects, 20K reps, hold/flight distributions | cs.cmu.edu/~keystroke |
+| BlackTip | Pre-fitted calibration ranges from CMU data | github.com/rester159/blacktip |
+| Balabit Mouse Dynamics | 10 users, 8 weeks mouse trajectories | github.com/balabit/Mouse-Dynamics-Challenge |
+| BeCAPTCHA-Mouse | 9K trajectories, GAN-generated human paths | BiDAlab (request) |

--- a/tests/test_mcp/test_browser_tools.py
+++ b/tests/test_mcp/test_browser_tools.py
@@ -847,9 +847,11 @@ class TestRemoteInteraction:
             await browser._human_type(page, "#email", "hi")
 
         # Should clear field, click to focus, then type per-character
+        # (using keyboard.down + keyboard.up for hold-time simulation)
         page.fill.assert_awaited_once_with("#email", "", timeout=10000)
         page.click.assert_awaited_once_with("#email", timeout=10000)
-        assert page.keyboard.type.await_count == 2  # 'h', 'i'
+        assert page.keyboard.down.await_count == 2  # 'h', 'i'
+        assert page.keyboard.up.await_count == 2  # 'h', 'i'
 
     @pytest.mark.asyncio
     async def test_human_type_uses_atomic_fill_for_chromium(self):


### PR DESCRIPTION
## Summary
- Add "Advanced Behavioral Rules" section to stealth-browser skill (7 detection gaps)
- Implement 3 new browser helpers: `_idle_jitter`, upgraded `_human_type` with hold time, `_human_scroll`
- Add vendor intelligence (AudioContext, PerimeterX, WebRTC, reCAPTCHA, DataDome) + calibration dataset refs

## Motivation
Research identified 12 gaps vs reCAPTCHA v3, PerimeterX, DataDome, and Akamai. The stealth-browser skill covered Bezier curves and timing but missed idle behavior, keystroke quality, and scroll patterns. These are the highest-signal detection surfaces for modern anti-bot systems.

## Implementation Details

**Skill docs (LLM guidance):**
- Idle mouse micro-jitter (±1-3px during dwell)
- Keystroke hold time (log-normal, median 86ms per CMU dataset)
- Navigation graph depth (2+ pages before forms)
- Tab visibility switch (visibilitychange before submission)
- Scroll patterns (deceleration, back-scroll, variance)
- Pre-form element interaction noise
- Typo and self-correction (2% rate, long fields only)

**Code (browser.py):**
- `_idle_jitter(page, duration_s)` — micro-movements during dwell
- `_human_type()` upgraded: `keyboard.down(char)` → hold → `keyboard.up(char)` with log-normal timing
- `_human_scroll(page, pixels)` — variable-delta wheel events + momentum decay + 30% back-scroll
- `_mouse_pos` module-level tracking for position awareness

## Test plan
- [x] Lint clean (ruff)
- [ ] CI checks
- [ ] E2E: navigate to a page, verify keystroke timing in DevTools shows hold gaps
- [ ] E2E: verify scroll events show variable deltas

🤖 Generated with [Claude Code](https://claude.com/claude-code)