### PR TITLE
fix(campaigns): use user timezone for CronTriggers

### DIFF
--- a/src/genesis/campaigns/runner.py
+++ b/src/genesis/campaigns/runner.py
@@ -61,8 +61,12 @@ class CampaignRunner:
         """Add an APScheduler job for a campaign."""
         from apscheduler.triggers.cron import CronTrigger
 
+        from genesis.env import user_timezone
+
         try:
-            trigger = CronTrigger.from_crontab(camp["cron_cadence"])
+            trigger = CronTrigger.from_crontab(
+                camp["cron_cadence"], timezone=user_timezone()
+            )
         except (ValueError, KeyError) as exc:
             logger.error(
                 "Invalid cron for campaign %s: %s", camp["name"], exc


### PR DESCRIPTION
## Summary

- Pass `timezone=user_timezone()` to `CronTrigger.from_crontab()` in CampaignRunner
- Without this, campaign ticks fire at UTC offsets instead of the user's local schedule
- Matches the pattern established in PR #548 for all other Genesis CronTriggers

One-line fix. No test changes needed — existing tests don't exercise the scheduler.

🤖 Generated with [Claude Code](https://claude.ai/code)