### PR TITLE
docs: lead README with ego + capability layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ With personal AI, you are the intelligence directing the tool. With personal AGI
 
 **How it does this:**
 
+- **Autonomous cognitive cycle** — a dual-ego architecture that wakes up, assesses the situation, proposes actions, and earns the right to execute them. Not waiting for prompts. Not following scripts. Thinking.
+- **Massive capability layer** — 60+ tools out of the box: browser automation, outreach pipeline, research, content creation, infrastructure monitoring, campaign execution. Not a framework you build on—a system that works, out of the box.
 - **4-layer memory** — essential knowledge, proactive recall, deep search, knowledge pipeline. Hybrid retrieval that compounds across months, not conversations.
 - **Closed-loop learning** — outcome classification, causal attribution, procedure extraction. Laplace-smoothed confidence, not vibes.
-- **Background cognition** — thinks, researches, audits, and communicates on free-tier compute while you sleep.
 - **Earned autonomy** — trust granted per action category through demonstrated competence. The system gets measurably better at its job, and it can show you the receipts.
 
 Day 1 — a strong generalist with full cognitive infrastructure.


### PR DESCRIPTION
## Summary

- Add "Autonomous cognitive cycle" as the first bullet in the "How it does this" section
- Add "Massive capability layer" (60+ tools) as the second bullet
- Remove "Background cognition" (subsumed by the ego bullet)
- Memory, learning, and earned autonomy bullets unchanged

## Why

The ego is the headline differentiator. Memory and learning enable it, but they're not the product. This was surfacing in pitch framing — we kept leading with memory because the README did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)