### PR TITLE
fix(campaigns): wire genesis-outreach MCP for campaign sessions

### DIFF
--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -736,10 +736,17 @@ class DirectSessionRunner:
             exceptions = set(request.tool_exceptions)
             disallowed = [t for t in disallowed if t not in exceptions]
 
-        # Give background sessions access to Genesis MCP servers (health + memory).
-        # Without this, the spawned CC process has no MCP tools (no browser, no
-        # memory_store, no observation_write).
-        mcp_config = self._config_builder.build_mcp_config(profile="reflection")
+        # Give background sessions access to Genesis MCP servers.
+        # Profile determines which servers: campaign/interact get outreach,
+        # observe/research get health + memory only.
+        _PROFILE_TO_MCP: dict[str, str] = {
+            "observe": "reflection",
+            "research": "reflection",
+            "interact": "sentinel",
+            "campaign": "campaign",
+        }
+        mcp_profile = _PROFILE_TO_MCP.get(request.profile, "reflection")
+        mcp_config = self._config_builder.build_mcp_config(profile=mcp_profile)
 
         # Prepend planning instruction if the caller opted in.
         prompt = request.prompt

--- a/src/genesis/cc/session_config.py
+++ b/src/genesis/cc/session_config.py
@@ -34,6 +34,7 @@ _MCP_PROFILES: dict[str, list[str]] = {
     "reflection": ["genesis-health", "genesis-memory"],
     "user_reflection": ["genesis-memory"],  # User ego: memory only, no health tools
     "sentinel": ["genesis-health", "genesis-memory", "genesis-outreach"],
+    "campaign": ["genesis-health", "genesis-memory", "genesis-outreach"],
     "interop": ["genesis-health", "genesis-memory"],
 }
 

--- a/src/genesis/observability/snapshots/queues.py
+++ b/src/genesis/observability/snapshots/queues.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -13,6 +14,52 @@ if TYPE_CHECKING:
     from genesis.routing.dead_letter import DeadLetterQueue
 
 logger = logging.getLogger(__name__)
+
+# Dead letter accumulation alerting — creates a critical observation when
+# pending items exceed this threshold. Checked on every awareness tick.
+_DEAD_LETTER_ALERT_THRESHOLD = 50
+# Cooldown prevents alert spam — one observation per hour max.
+_DEAD_LETTER_ALERT_COOLDOWN_S = 3600
+_last_dead_letter_alert_at: float = 0.0
+
+
+async def _alert_dead_letter_accumulation(db: aiosqlite.Connection | None, count: int) -> None:
+    """Create a critical observation when dead letters accumulate."""
+    global _last_dead_letter_alert_at
+
+    now = time.monotonic()
+    if now - _last_dead_letter_alert_at < _DEAD_LETTER_ALERT_COOLDOWN_S:
+        return  # Cooldown active
+
+    if db is None:
+        return
+
+    try:
+        import uuid
+
+        from genesis.db.crud import observations as obs_crud
+
+        obs_id = str(uuid.uuid4())
+        await obs_crud.create(
+            db,
+            id=obs_id,
+            source="dead_letter_monitor",
+            type="infrastructure_alert",
+            content=(
+                f"Dead letter queue has {count} pending items (threshold: "
+                f"{_DEAD_LETTER_ALERT_THRESHOLD}). Likely cause: provider "
+                f"chain exhaustion or circuit breaker stuck open. "
+                f"Check circuit breaker state and provider health."
+            ),
+            priority="critical",
+            created_at=datetime.now(UTC).isoformat(),
+        )
+        _last_dead_letter_alert_at = now
+        logger.warning(
+            "Dead letter alert: %d pending items (critical observation created)", count
+        )
+    except Exception:
+        logger.debug("Failed to create dead letter alert observation", exc_info=True)
 
 
 async def queues(
@@ -36,6 +83,9 @@ async def queues(
     if dead_letter:
         try:
             dead = await dead_letter.get_pending_count()
+            # Alert via observation when dead letters accumulate
+            if dead is not None and dead >= _DEAD_LETTER_ALERT_THRESHOLD:
+                await _alert_dead_letter_accumulation(db, dead)
         except Exception:
             errors.append("dead_letters: query failed")
             logger.error("Failed to query dead letter queue", exc_info=True)

--- a/src/genesis/routing/dead_letter.py
+++ b/src/genesis/routing/dead_letter.py
@@ -141,13 +141,31 @@ class DeadLetterQueue:
             )
         return len(expired)
 
+    # Per-operation-type TTLs. Patterns matched against operation_type field.
+    # More specific patterns checked first; fallback is the default max_age_hours.
+    _OPERATION_TTL_HOURS: dict[str, int] = {
+        "chain_exhausted:judge": 1,  # Stale scoring requests — worthless after minutes
+        "chain_exhausted:": 6,       # Other chain exhaustions — moderate staleness
+    }
+
     async def expire_old(self, max_age_hours: int = 72) -> int:
-        """Mark pending items older than max_age_hours as 'expired'. Returns count."""
-        cutoff = self._clock() - timedelta(hours=max_age_hours)
-        cutoff_iso = cutoff.isoformat()
+        """Mark pending items older than their TTL as 'expired'. Returns count.
+
+        Uses per-operation-type TTLs where configured, falling back to
+        max_age_hours for operations without a specific TTL.
+        """
+        now = self._clock()
         items = await dl_crud.query_pending(self.db)
         count = 0
         for item in items:
+            op_type = item.get("operation_type", "")
+            # Find matching TTL — longest prefix match
+            ttl_hours = max_age_hours
+            for pattern, hours in self._OPERATION_TTL_HOURS.items():
+                if op_type.startswith(pattern):
+                    ttl_hours = hours
+                    break
+            cutoff_iso = (now - timedelta(hours=ttl_hours)).isoformat()
             if item["created_at"] < cutoff_iso:
                 await dl_crud.update_status(self.db, item["id"], status="expired")
                 count += 1


### PR DESCRIPTION
## Summary

Two commits:

1. **Wire genesis-outreach MCP for campaign sessions** — Campaign sessions couldn't use `outreach_send` because MCP config was hardcoded to `profile="reflection"` (health + memory only). Now maps DirectSession profiles to appropriate MCP configs.

2. **Per-operation-type dead letter TTL + Telegram alerting** — Judge evaluations expire after 1h instead of 72h (they're stale immediately). Critical observation created when 50+ dead letters accumulate (triggers Telegram alert via existing critical-obs pipeline).

## Root causes

- Campaign sessions spent $2.21 finding workarounds because `genesis-outreach` MCP server was never loaded
- 570 dead letters accumulated over 12h with no notification (only dashboard WARNING)

## Changes

| File | Change |
|------|--------|
| `src/genesis/cc/session_config.py` | Add "campaign" MCP profile |
| `src/genesis/cc/direct_session.py` | Map profile → MCP config |
| `src/genesis/routing/dead_letter.py` | Per-operation-type TTLs in `expire_old()` |
| `src/genesis/observability/snapshots/queues.py` | Dead letter accumulation → critical observation |

## Test plan

- [x] Existing tests pass
- [x] Lint clean
- [x] Verified `build_mcp_config(profile="campaign")` generates config with genesis-outreach
- [x] Profile-to-MCP mapping verified for all profiles
- [ ] CI green
- [ ] E2E: restart server, trigger campaign, confirm outreach_send available

🤖 Generated with [Claude Code](https://claude.ai/code)