### PR TITLE
feat(outreach): morning report anti-drift signal

### DIFF
--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -295,7 +295,8 @@ class MorningReportGenerator:
             "WHERE status = 'active' "
             "ORDER BY CASE priority "
             "  WHEN 'critical' THEN 1 WHEN 'high' THEN 2 "
-            "  WHEN 'medium' THEN 3 ELSE 4 END"
+            "  WHEN 'medium' THEN 3 ELSE 4 END "
+            "LIMIT 10"
         )
         goal_rows = await cursor.fetchall()
         if goal_rows:

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -275,6 +275,34 @@ class MorningReportGenerator:
         else:
             lines.append("- CC sessions: none in last 24h")
 
+        # Session topics (foreground only, last 24h) — what was actually worked on
+        cursor = await self._db.execute(
+            "SELECT topic FROM cc_sessions "
+            "WHERE started_at >= datetime('now', '-24 hours') "
+            "AND session_type = 'foreground' "
+            "AND topic != '' AND topic IS NOT NULL "
+            "ORDER BY started_at DESC LIMIT 15"
+        )
+        topic_rows = await cursor.fetchall()
+        if topic_rows:
+            lines.append("- Session topics (foreground):")
+            for r in topic_rows:
+                lines.append(f"  - {r[0][:120]}")
+
+        # Active user goals — enables the LLM to note priority alignment/drift
+        cursor = await self._db.execute(
+            "SELECT title, priority, category FROM user_goals "
+            "WHERE status = 'active' "
+            "ORDER BY CASE priority "
+            "  WHEN 'critical' THEN 1 WHEN 'high' THEN 2 "
+            "  WHEN 'medium' THEN 3 ELSE 4 END"
+        )
+        goal_rows = await cursor.fetchall()
+        if goal_rows:
+            lines.append("- Active user goals:")
+            for g in goal_rows:
+                lines.append(f"  - [{g[1]}] ({g[2]}) {g[0]}")
+
         # Inbox items — only report genuinely pending DB items (not filesystem output files)
         cursor = await self._db.execute(
             "SELECT COUNT(*) FROM inbox_items WHERE status = 'pending'"

--- a/tests/test_outreach/test_morning_report.py
+++ b/tests/test_outreach/test_morning_report.py
@@ -89,6 +89,61 @@ async def test_generate_includes_health_in_context(db, mock_health, mock_drafter
 
 
 @pytest.mark.asyncio
+async def test_context_includes_session_topics(db, mock_health, mock_drafter):
+    """Session topics from foreground sessions appear in the activity context."""
+    await db.execute(
+        "INSERT INTO cc_sessions (id, session_type, model, effort, status, "
+        "started_at, last_activity_at, topic) VALUES (?, ?, ?, ?, ?, "
+        "datetime('now', '-2 hours'), datetime('now', '-1 hour'), ?)",
+        ("s1", "foreground", "opus", "high", "completed",
+         "Working on memory supersession chain"),
+    )
+    await db.commit()
+
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    await gen.generate()
+    call_args = mock_drafter.draft.call_args[0][0]
+    assert "memory supersession" in call_args.context.lower()
+    assert "Session topics" in call_args.context
+
+
+@pytest.mark.asyncio
+async def test_context_includes_user_goals(db, mock_health, mock_drafter):
+    """Active user goals appear in the activity context for drift detection."""
+    await db.execute(
+        "INSERT INTO user_goals (id, title, category, priority, status, "
+        "created_at, updated_at) VALUES (?, ?, ?, ?, ?, "
+        "datetime('now', '-7 days'), datetime('now'))",
+        ("g1", "W2 employment", "career", "high", "active"),
+    )
+    await db.commit()
+
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    await gen.generate()
+    call_args = mock_drafter.draft.call_args[0][0]
+    assert "W2 employment" in call_args.context
+    assert "Active user goals" in call_args.context
+
+
+@pytest.mark.asyncio
+async def test_background_sessions_excluded_from_topics(db, mock_health, mock_drafter):
+    """Background sessions should NOT appear in session topics."""
+    await db.execute(
+        "INSERT INTO cc_sessions (id, session_type, model, effort, status, "
+        "started_at, last_activity_at, topic) VALUES (?, ?, ?, ?, ?, "
+        "datetime('now', '-2 hours'), datetime('now', '-1 hour'), ?)",
+        ("bg1", "background_reflection", "sonnet", "medium", "completed",
+         "Internal reflection cycle"),
+    )
+    await db.commit()
+
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    await gen.generate()
+    call_args = mock_drafter.draft.call_args[0][0]
+    assert "Internal reflection cycle" not in call_args.context
+
+
+@pytest.mark.asyncio
 async def test_event_bus_emits_on_section_failure(db, mock_health, mock_drafter):
     """When a section fails, event_bus.emit should be called with WARNING."""
     event_bus = AsyncMock()


### PR DESCRIPTION
## Summary

- Adds foreground session topics (last 24h) to morning report activity context
- Adds active user goals with priority/category to the same section
- Enables the report LLM to naturally observe alignment or drift between work and priorities
- No prompt changes needed — MORNING_REPORT.md already asks for "what was worked on"

Background: The morning report claimed to summarize "what was worked on" but only received session counts by status. The LLM had no topic data and no goal context to produce meaningful summaries or notice priority drift.

## Test plan

- [x] 3 new tests: topics appear, goals appear, background sessions excluded
- [x] All 9 tests pass (6 existing + 3 new)
- [x] Lint clean
- [ ] Verify morning report output includes topics after merge (next morning cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)