### PR TITLE
fix(mail): increase misfire grace to 6h for weekly job

### DIFF
--- a/config/mail_monitor.yaml
+++ b/config/mail_monitor.yaml
@@ -1,6 +1,6 @@
 mail_monitor:
   enabled: true
-  cron_expression: "0 5 * * 0"        # Sunday 05:00 UTC
+  cron_expression: "0 5 * * 0"        # Sunday 05:00 user timezone
   batch_size: 10                       # Max emails per Layer 2 CC session
   model: "sonnet"
   effort: "medium"

--- a/src/genesis/mail/monitor.py
+++ b/src/genesis/mail/monitor.py
@@ -99,7 +99,7 @@ class MailMonitor:
             trigger,
             id="mail_monitor_batch",
             max_instances=1,
-            misfire_grace_time=3600,
+            misfire_grace_time=21600,  # 6h — weekly job needs wide grace for restart churn
         )
         self._scheduler.start()
         logger.info("Mail monitor scheduled: %s", self._config.cron_expression)


### PR DESCRIPTION
## Summary

- Increase mail_monitor_batch misfire_grace_time from 1h to 6h
- Fix config comment: cron runs in user timezone, not UTC

## Why

Today's weekly mail run was missed because the server restarted 5 times
during the cron window (PR merges). The 1-hour grace wasn't enough to
survive the restart churn. 6 hours covers typical morning activity without
risk of double-firing (weekly cadence, single instance guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)