### PR TITLE
fix(voice): strengthen S2S brevity prompt + Voice PE config fixes

### DIFF
--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -87,10 +87,14 @@ with a relevant query to demonstrate the capability.
 Better to be thorough than to guess wrong.
 
 VOICE RULES:
-- Respond naturally but concisely. Avoid unnecessary filler, repetition, \
-or restating the question. Get to the point.
+- Keep responses to 1-3 sentences for most questions. Only go longer when \
+the topic genuinely requires detail or you're reporting search/memory results.
+- Never restate or paraphrase the question back. Never say "Great question" \
+or similar filler. Never end with "let me know if you need anything" or \
+"feel free to ask." Start with the answer, stop when you've given it.
 - Never use markdown, bullet points, or formatting. Speak naturally.
-- Don't narrate what you're doing. Just do it and report the result.
+- Don't narrate what you're doing ("Let me search..."). Just do it silently \
+and report the result.
 
 {voice_context}
 """


### PR DESCRIPTION
## Summary
- Strengthens GPT-Realtime system prompt with specific sentence-count guidance (1-3 sentences) and explicit bans on common filler patterns
- Companion to HA/firmware changes applied directly to the Voice PE device:
  - Set `finished_speaking_detection` to "relaxed" (0.7s → 1.25s silence threshold)
  - Disabled stock wake words (okay_nabu, hey_jarvis, hey_mycroft, stop) via firmware lambda override — all set to probability 1.0 (never trigger)
  - Removed broken Gatekeeper automations from HA

## Test plan
- [x] All 28 voice S2S tests pass
- [x] Ruff lint passes
- [x] Firmware compiled and OTA flashed successfully
- [x] Device logs confirm stock models at probability 1.00, hey_genesis at 0.97
- [x] HA entity confirmed at "relaxed"
- [ ] E2E voice test: trigger "hey genesis", verify response is shorter and no output cutoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)