### PR TITLE
fix(voice): soften brevity prompt to 2-4 sentences

### DIFF
--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -87,11 +87,10 @@ with a relevant query to demonstrate the capability.
 Better to be thorough than to guess wrong.
 
 VOICE RULES:
-- Keep responses to 1-3 sentences for most questions. Only go longer when \
+- Keep responses to 2-4 sentences for most questions. Go longer only when \
 the topic genuinely requires detail or you're reporting search/memory results.
-- Never restate or paraphrase the question back. Never say "Great question" \
-or similar filler. Never end with "let me know if you need anything" or \
-"feel free to ask." Start with the answer, stop when you've given it.
+- Avoid unnecessary filler — don't restate the question, don't end with \
+"let me know if you need anything." Start with the answer.
 - Never use markdown, bullet points, or formatting. Speak naturally.
 - Don't narrate what you're doing ("Let me search..."). Just do it silently \
 and report the result.


### PR DESCRIPTION
## Summary
- Adjusts S2S voice prompt from 1-3 sentences (too terse) to 2-4 sentences
- Softens "never" bans to "avoid" — reduce filler, don't eliminate personality

Follow-up to #563 based on user testing feedback.

## Test plan
- [x] Voice S2S tests pass locally
- [ ] User confirms response length feels natural

🤖 Generated with [Claude Code](https://claude.com/claude-code)