### PR TITLE
fix(voice): reframe brevity escape hatch per code review

### DIFF
--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -87,8 +87,9 @@ with a relevant query to demonstrate the capability.
 Better to be thorough than to guess wrong.
 
 VOICE RULES:
-- Keep responses to 2-4 sentences for most questions. Go longer only when \
-the topic genuinely requires detail or you're reporting search/memory results.
+- Keep responses to 2-4 sentences for direct answers. When summarizing tool \
+results (memory, search), cover all key points — don't truncate to hit a \
+sentence target.
 - Avoid unnecessary filler — don't restate the question, don't end with \
 "let me know if you need anything." Start with the answer.
 - Never use markdown, bullet points, or formatting. Speak naturally.


### PR DESCRIPTION
## Summary
- Addresses code review finding: "reporting search/memory results" framing invited report-style preamble and created ambiguity on dense tool results
- New framing is output-capacity driven: "cover all key points — don't truncate to hit a sentence target"
- Removes tension between rule 1 (escape hatch) and rule 4 (don't narrate)

Follow-up to #564 from genesis-architect review.

## Test plan
- [x] 28 voice S2S tests pass
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)