### PR TITLE
fix(mail): wire thread tracker in outreach init, not mail init

### DIFF
--- a/src/genesis/runtime/init/mail.py
+++ b/src/genesis/runtime/init/mail.py
@@ -101,11 +101,8 @@ async def init(rt: GenesisRuntime) -> None:
                 _register_reply_poll_job(rt._mail_monitor, reply_poller)
                 logger.info("Email reply poller registered (every 4h)")
 
-                # Wire thread tracker into outreach pipeline for auto-registration
-                pipeline = getattr(rt, "_outreach_pipeline", None)
-                if pipeline is not None and hasattr(pipeline, "set_thread_tracker"):
-                    pipeline.set_thread_tracker(thread_tracker)
-                    logger.info("Thread tracker wired into outreach pipeline")
+                # Thread tracker → outreach pipeline wiring happens in
+                # init/outreach.py (runs after mail init, so pipeline exists).
             except Exception:
                 logger.exception("Failed to initialize reply poller (mail monitor still active)")
         else:

--- a/src/genesis/runtime/init/outreach.py
+++ b/src/genesis/runtime/init/outreach.py
@@ -104,6 +104,13 @@ async def init(rt: GenesisRuntime) -> None:
         if hasattr(rt, "_output_router") and rt._output_router is not None:
             rt._output_router.set_outreach_pipeline(rt._outreach_pipeline)
 
+        # Wire thread tracker (created during mail init) into pipeline for
+        # automatic email thread registration on outbound sends.
+        thread_tracker = getattr(rt, "_thread_tracker", None)
+        if thread_tracker is not None:
+            rt._outreach_pipeline.set_thread_tracker(thread_tracker)
+            logger.info("Thread tracker wired into outreach pipeline")
+
         engagement = EngagementTracker(rt._db)
         rt._engagement_tracker = engagement
 


### PR DESCRIPTION
## Summary
- Thread tracker was wired in mail init, but outreach pipeline doesn't exist yet at that point in the boot sequence (mail init runs before outreach init)
- Moved the `set_thread_tracker()` call to outreach init where `_outreach_pipeline` is already created and `_thread_tracker` is available on the runtime

## Test plan
- [x] `tests/test_mail/test_threads.py` — 19/19 pass
- [x] Lint clean
- [ ] Verify "Thread tracker wired into outreach pipeline" appears in server logs after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)