### PR TITLE
fix(test): add pytest-timeout with 30-min ceiling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 test = [
     "pytest>=8.0",
     "pytest-asyncio",
+    "pytest-timeout",
     "aioresponses>=0.7.7",
 ]
 browser = [
@@ -81,3 +82,4 @@ quote-style = "double"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+timeout = 1800


### PR DESCRIPTION
## Summary
- Adds `pytest-timeout` dependency and sets a 30-minute (1800s) per-test timeout
- Prevents runaway test processes from consuming CPU indefinitely
- Triggered by incident: 6 stuck `test_dead_letter_queue.py` processes ran 2+ hours at ~450% CPU

## Test plan
- [x] `pytest --co` confirms tests still collect with plugin active
- [ ] Verify CI passes with the new dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)