### PR TITLE
fix(campaigns): outreach dedup, drain guard, transcript backup

### DIFF
--- a/scripts/genesis_session_end.py
+++ b/scripts/genesis_session_end.py
@@ -172,9 +172,62 @@ def main() -> None:
         ended_at=now,
     )
 
-    # 4. Trigger async essential knowledge regeneration (fire-and-forget).
+    # 4. If session ran in a worktree, backup transcript to main project dir.
+    _backup_worktree_transcript(transcript_path)
+
+    # 5. Trigger async essential knowledge regeneration (fire-and-forget).
     # Spawns a background subprocess since LLM/DB work exceeds 1500ms budget.
     _trigger_essential_knowledge_regen()
+
+
+def _backup_worktree_transcript(transcript_path: str) -> None:
+    """Copy worktree session JSONL to main project dir for --resume discovery.
+
+    When a CC session runs from a worktree, its conversation file lives in a
+    worktree-specific project dir (e.g., ~/.claude/projects/...-worktrees-foo/).
+    If the worktree is later removed, the session becomes undiscoverable by
+    --resume. This creates a hardlink (instant, no copy) in the main project
+    dir as a safety net.
+
+    Only fires on clean session exit. If the process is killed, this hook
+    does not run — that scenario needs a separate periodic backup.
+    """
+    if not transcript_path:
+        return
+    tp = Path(transcript_path)
+    if not tp.exists() or tp.suffix != ".jsonl":
+        return
+
+    project_dir = tp.parent
+    dir_name = project_dir.name
+    # Worktree project dirs contain "--claude-worktrees-" in their name
+    marker = "--claude-worktrees-"
+    if marker not in dir_name:
+        return
+
+    main_name = dir_name.split(marker)[0]
+    main_project_dir = project_dir.parent / main_name
+    if not main_project_dir.exists():
+        return
+
+    backup_path = main_project_dir / f"wt-{tp.name}"
+    if backup_path.exists():
+        return
+
+    try:
+        # Hardlink is instant — no data copy, survives worktree dir deletion
+        os.link(tp, backup_path)
+    except OSError:
+        # Cross-device or permission issue — fall back to copy
+        import shutil
+
+        try:
+            shutil.copy2(tp, backup_path)
+        except OSError as exc:
+            print(
+                f"SessionEnd hook: worktree transcript backup failed: {exc}",
+                file=sys.stderr,
+            )
 
 
 def _trigger_essential_knowledge_regen() -> None:

--- a/src/genesis/campaigns/runner.py
+++ b/src/genesis/campaigns/runner.py
@@ -177,7 +177,11 @@ class CampaignRunner:
             return {"outcome": "error", "error": "Strategy doc not found or empty"}
 
         recent_runs = await crud.list_runs(self._db, campaign_id, limit=3)
-        prompt = _build_session_prompt(campaign, state, recent_runs, strategy_text)
+        channel_history = await _recent_channel_posts(self._db, days=7)
+        prompt = _build_session_prompt(
+            campaign, state, recent_runs, strategy_text,
+            channel_history=channel_history,
+        )
 
         from genesis.cc.direct_session import DirectSessionRequest
 
@@ -452,11 +456,35 @@ def _day_boundary_reset(
     return reset
 
 
+async def _recent_channel_posts(db: Any, *, days: int = 7) -> list[dict]:
+    """Fetch recent outreach_history entries for non-Telegram channels.
+
+    Gives campaign sessions visibility into what has already been posted,
+    preventing duplicate content.
+    """
+    try:
+        cursor = await db.execute(
+            "SELECT signal_type, topic, channel, delivered_at "
+            "FROM outreach_history "
+            "WHERE channel != 'telegram' AND delivered_at IS NOT NULL "
+            "AND delivered_at >= datetime('now', ?) "
+            "ORDER BY delivered_at DESC LIMIT 20",
+            (f"-{days} days",),
+        )
+        columns = [d[0] for d in cursor.description]
+        return [dict(zip(columns, row, strict=False)) for row in await cursor.fetchall()]
+    except Exception:
+        logger.debug("Failed to fetch channel history for campaign prompt", exc_info=True)
+        return []
+
+
 def _build_session_prompt(
     campaign: dict,
     state: dict,
     recent_runs: list[dict],
     strategy_text: str,
+    *,
+    channel_history: list[dict] | None = None,
 ) -> str:
     """Build the user-message prompt for the CC session."""
     # Remove internal state keys from what the LLM sees
@@ -477,6 +505,18 @@ def _build_session_prompt(
 
     if run_summaries:
         parts.append("\n## Recent Runs\n" + "\n".join(run_summaries))
+
+    if channel_history:
+        lines = []
+        for post in channel_history:
+            lines.append(
+                f"- [{post['delivered_at']}] {post['signal_type']} → "
+                f"#{post['channel']}: {post['topic']}"
+            )
+        parts.append(
+            "\n## Recent Channel Activity (already posted — do NOT repeat)\n"
+            + "\n".join(lines)
+        )
 
     parts.append(
         "\n## Instructions"

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -183,7 +183,7 @@ async def outreach_poll(
                     topic=question[:100],
                     category="content",
                     salience_score=0.5,
-                    channel=channel,
+                    channel="discord",  # adapter name, not sub-channel
                     message_content=question,
                     created_at=now_iso,
                     delivery_id=msg_id,

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import uuid
+from datetime import UTC, datetime
 
 import httpx
 from fastmcp import FastMCP
@@ -125,6 +127,26 @@ async def outreach_poll(
     if not webhook_url:
         return json.dumps({"error": f"No webhook URL found (tried {env_key} and DISCORD_WEBHOOK_URL)"})
 
+    # ── Dedup check: skip if same poll posted within 7 days ──
+    if _db is not None:
+        from genesis.outreach.governance import content_hash
+
+        chash = content_hash(question)
+        try:
+            cursor = await _db.execute(
+                "SELECT COUNT(*) FROM outreach_history "
+                "WHERE signal_type = 'discord_poll' AND content_hash = ? "
+                "AND delivered_at IS NOT NULL "
+                "AND delivered_at >= datetime('now', '-7 days')",
+                (chash,),
+            )
+            row = await cursor.fetchone()
+            if row and row[0] > 0:
+                logger.info("Discord poll dedup: skipping duplicate (hash=%s)", chash[:12])
+                return json.dumps({"status": "skipped", "reason": "duplicate_poll_within_7_days"})
+        except Exception:
+            logger.debug("Poll dedup check failed, proceeding", exc_info=True)
+
     url = f"{webhook_url}?wait=true"
     payload = {
         "poll": {
@@ -144,6 +166,35 @@ async def outreach_poll(
             data = resp.json()
             msg_id = data.get("id", "")
         logger.info("Discord poll created via %s (msg_id=%s)", channel, msg_id)
+
+        # ── Record to outreach_history for dedup + campaign visibility ──
+        if _db is not None:
+            from genesis.outreach.governance import content_hash as _ch
+
+            now_iso = datetime.now(UTC).isoformat()
+            outreach_id = str(uuid.uuid4())
+            try:
+                from genesis.db.crud import outreach as outreach_crud
+
+                await outreach_crud.create(
+                    _db,
+                    id=outreach_id,
+                    signal_type="discord_poll",
+                    topic=question[:100],
+                    category="content",
+                    salience_score=0.5,
+                    channel=channel,
+                    message_content=question,
+                    created_at=now_iso,
+                    delivery_id=msg_id,
+                    content_hash=_ch(question),
+                )
+                await outreach_crud.record_delivery(
+                    _db, outreach_id, delivered_at=now_iso,
+                )
+            except Exception:
+                logger.warning("Failed to record poll in outreach_history", exc_info=True)
+
         return json.dumps({"status": "created", "message_id": msg_id, "channel": channel})
     except httpx.HTTPStatusError as exc:
         error_body = exc.response.text[:200] if exc.response else ""

--- a/src/genesis/outreach/governance.py
+++ b/src/genesis/outreach/governance.py
@@ -45,6 +45,7 @@ _DEDUP_WINDOWS: dict[str, int] = {
     "ego_notification": 12,  # Ego notifications — don't repeat same topic within 12h
     "mail_reply": 1,  # Email replies — short window to allow ack + full response
     "mail_follow_up": 24,  # Follow-up emails — one per day max per topic
+    "discord_poll": 168,  # Discord polls — 7 days (matches default poll duration)
 }
 _DEFAULT_DEDUP_HOURS = 24
 

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -12,9 +12,17 @@ from genesis.outreach.config import OutreachConfig
 from genesis.outreach.engagement import EngagementTracker
 from genesis.outreach.morning_report import MorningReportGenerator
 from genesis.outreach.pipeline import OutreachPipeline
-from genesis.outreach.types import OutreachCategory, OutreachRequest
+from genesis.outreach.types import OutreachCategory, OutreachRequest, OutreachStatus
 
 logger = logging.getLogger(__name__)
+
+# Discord sub-channel names used by campaign sessions in pending_outreach.
+# The outreach pipeline routes via adapter name ("discord"), not sub-channel.
+_DISCORD_CHANNELS = frozenset({
+    "announcements", "dev-discussion", "general", "showcase",
+    "getting-started", "design", "bug-reports", "feature-requests",
+    "troubleshooting",
+})
 
 
 class OutreachScheduler:
@@ -520,27 +528,44 @@ class OutreachScheduler:
                                 "Unknown category '%s' in pending outreach %s, using DIGEST",
                                 raw_cat, row["id"],
                             )
+
+                    # Map Discord sub-channel names to adapter name.
+                    # Campaign sessions queue with channel="announcements" etc.,
+                    # but the pipeline adapter is registered as "discord".
+                    raw_channel = row.get("channel", "telegram")
+                    channel = "discord" if raw_channel in _DISCORD_CHANNELS else raw_channel
+
                     req = OutreachRequest(
                         category=cat,
                         topic=row["message"][:100],
                         context=row["message"],
                         salience_score=0.7,
                         signal_type="pending_queue",
-                        channel=row.get("channel", "telegram"),
+                        channel=channel,
                     )
                     if row.get("urgency") == "high":
                         result = await self._pipeline.submit_urgent(req)
                     else:
                         result = await self._pipeline.submit(req)
-                    logger.info(
-                        "Drained pending outreach %s: %s",
-                        row["id"], result.status.value,
-                    )
-                    # Only mark delivered on success
-                    delivered_at = datetime.now(UTC).isoformat()
-                    await pending_outreach.mark_delivered(
-                        self._db, row["id"], delivered_at=delivered_at,
-                    )
+
+                    # Only mark delivered on actual success
+                    if result.status in (
+                        OutreachStatus.DELIVERED,
+                        OutreachStatus.ENGAGED,
+                    ):
+                        delivered_at = datetime.now(UTC).isoformat()
+                        await pending_outreach.mark_delivered(
+                            self._db, row["id"], delivered_at=delivered_at,
+                        )
+                        logger.info(
+                            "Drained pending outreach %s: %s",
+                            row["id"], result.status.value,
+                        )
+                    else:
+                        logger.warning(
+                            "Pending outreach %s not delivered (%s: %s) — will retry",
+                            row["id"], result.status.value, result.error or "",
+                        )
                 except Exception:
                     logger.error(
                         "Failed to deliver pending outreach %s — will retry next cycle",


### PR DESCRIPTION
## Summary

Six fixes addressing campaign duplicate Discord posts and related outreach pipeline bugs:

- **`outreach_poll()` dedup + history recording** — polls now check `outreach_history` for duplicate content hash (7-day window) before posting, and record after posting. Previously completely stateless.
- **Campaign prompt channel awareness** — `_build_session_prompt()` now injects recent channel activity from `outreach_history`, giving the LLM session visibility into prior posts.
- **Drain delivery guard** — `_drain_pending_job()` now checks `OutreachResult.status` before marking entries as delivered. Previously marked delivered regardless of success/failure.
- **Drain Discord channel mapping** — maps sub-channel names (announcements, dev-discussion) to the "discord" adapter name so delivery actually finds the adapter.
- **Governance dedup window** — adds `discord_poll: 168h` to `_DEDUP_WINDOWS`.
- **SessionEnd transcript backup** — hardlinks worktree conversation JSONL to main project dir on clean exit, so `--resume` can discover worktree sessions after worktree removal.

Root cause: `discord-engagement` campaign's midnight tick re-posted an announcement and poll because `outreach_poll()` had no dedup, the drain silently failed delivery but marked it done, and the campaign prompt had zero visibility into prior posts.

## Test plan

- [x] `pytest tests/test_mcp/test_outreach_mcp.py` — 9 passed
- [x] `pytest tests/test_outreach/` — 112 passed
- [x] `pytest tests/test_campaigns/` — 35 passed
- [x] `ruff check` — clean
- [ ] CI green
- [ ] E2E: verify next campaign tick doesn't duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)