### PR TITLE
refactor(voice): parameterize HA entity IDs via env vars

### DIFF
--- a/src/genesis/channels/voice/adapter.py
+++ b/src/genesis/channels/voice/adapter.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import uuid
 
 import httpx
@@ -54,14 +55,19 @@ class VoiceChannelAdapter(ChannelAdapter):
         ha_url: str | None = None,
         ha_token: str | None = None,
         chime_media_id: str = "",
-        tts_entity: str = "tts.piper",
-        media_player_entity: str = "media_player.home_assistant_voice_0a2841",
+        tts_entity: str = "",
+        media_player_entity: str = "",
     ) -> None:
         self._ha_url = ha_url.rstrip("/") if ha_url else None
         self._ha_token = ha_token
         self._chime_media_id = chime_media_id or self.DEFAULT_CHIME_MEDIA_ID
-        self._tts_entity = tts_entity
-        self._media_player = media_player_entity
+        self._tts_entity = tts_entity or os.environ.get(
+            "HA_TTS_ENTITY", "tts.piper",
+        )
+        self._media_player = media_player_entity or os.environ.get(
+            "HA_MEDIA_PLAYER_ENTITY",
+            "media_player.home_assistant_voice_0a2841",
+        )
 
     async def start(self) -> None:
         """No-op — adapter is stateless, HA handles transport."""

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -174,7 +174,10 @@ class StandaloneAdapter:
                             "Content-Type": "application/json",
                         },
                         json={
-                            "entity_id": "assist_satellite.home_assistant_voice_0a2841_assist_satellite",
+                            "entity_id": os.environ.get(
+                                "HA_ASSIST_SATELLITE_ENTITY",
+                                "assist_satellite.home_assistant_voice_0a2841_assist_satellite",
+                            ),
                             "message": "",
                         },
                     )

--- a/tests/test_channels/test_voice.py
+++ b/tests/test_channels/test_voice.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -182,6 +183,39 @@ class TestVoiceChannelAdapter:
         assert caps["voice"] is True
         assert caps["markdown"] is False
         assert caps["buttons"] is False
+
+    def test_entity_defaults_from_env(self):
+        """Entity IDs read from env vars when not passed explicitly."""
+        with patch.dict("os.environ", {
+            "HA_TTS_ENTITY": "tts.custom",
+            "HA_MEDIA_PLAYER_ENTITY": "media_player.custom_device",
+        }):
+            adapter = VoiceChannelAdapter()
+            assert adapter._tts_entity == "tts.custom"
+            assert adapter._media_player == "media_player.custom_device"
+
+    def test_entity_explicit_overrides_env(self):
+        """Explicit constructor params take precedence over env vars."""
+        with patch.dict("os.environ", {
+            "HA_TTS_ENTITY": "tts.from_env",
+            "HA_MEDIA_PLAYER_ENTITY": "media_player.from_env",
+        }):
+            adapter = VoiceChannelAdapter(
+                tts_entity="tts.explicit",
+                media_player_entity="media_player.explicit",
+            )
+            assert adapter._tts_entity == "tts.explicit"
+            assert adapter._media_player == "media_player.explicit"
+
+    def test_entity_fallback_without_env(self):
+        """Without env vars or explicit params, falls back to hardcoded defaults."""
+        # Scrub any HA_ env vars that might be set in the test environment
+        env = {k: v for k, v in os.environ.items()
+               if not k.startswith("HA_")}
+        with patch.dict("os.environ", env, clear=True):
+            adapter = VoiceChannelAdapter()
+            assert adapter._tts_entity == "tts.piper"
+            assert "home_assistant_voice_0a2841" in adapter._media_player
 
     @pytest.mark.asyncio
     async def test_send_typing_noop(self):


### PR DESCRIPTION
## Summary
- Voice adapter and shutdown chime had MAC-specific entity IDs hardcoded (`0a2841`). Now reads from `HA_TTS_ENTITY`, `HA_MEDIA_PLAYER_ENTITY`, and `HA_ASSIST_SATELLITE_ENTITY` env vars with backward-compatible fallback to existing defaults.
- Prerequisite for Voice PE public repo packaging — other Genesis users can't use voice without editing source code otherwise.
- 3 new tests for env var override, explicit param precedence, and fallback behavior.

## Test plan
- [x] `ruff check` passes on all 3 changed files
- [x] `pytest tests/test_channels/test_voice.py -v` — 31/31 pass (28 existing + 3 new)
- [ ] E2E: trigger proactive notification → hear chime + TTS (backward compat with no env vars set)
- [ ] E2E: server restart → hear 3-ding shutdown chime

🤖 Generated with [Claude Code](https://claude.com/claude-code)