### PR TITLE
fix(voice): resolve turn-behind bug and stale session recovery

### DIFF
--- a/src/genesis/channels/voice/s2s_session.py
+++ b/src/genesis/channels/voice/s2s_session.py
@@ -197,6 +197,17 @@ class S2SSessionManager:
             "role": "user",
             "content": [{"type": "input_audio", "audio": encoded}],
         })
+
+        # Brief pause to let the model ingest the audio before we request
+        # a response.  Without this, response.create() can fire before
+        # the audio is processed, causing the model to produce a generic
+        # greeting instead of answering the actual question.
+        # TODO: Replace with conversation.item.created ack-wait for a
+        # deterministic signal instead of a fixed delay.  Requires
+        # consuming events from the connection here without interfering
+        # with receive_response()'s async iterator.
+        await asyncio.sleep(0.3)
+
         await session.connection.response.create()
 
     async def receive_response(

--- a/src/genesis/channels/voice/wyoming_stt.py
+++ b/src/genesis/channels/voice/wyoming_stt.py
@@ -86,6 +86,13 @@ class STTEventHandler(AsyncEventHandler):
             self._width = start.width
             self._channels = start.channels
             self._audio_bytes.clear()
+            # Flush stale audio from previous failed pipeline runs.
+            # Safe: AudioStart fires once per pipeline run, always before
+            # any new audio is processed.  In normal operation the queue
+            # is already empty (TTS consumed it); this only catches
+            # orphaned audio left by ConnectionResetError or similar.
+            if self._tts_server:
+                self._tts_server.clear_queue()
             return True
 
         if AudioChunk.is_type(event.type):
@@ -116,7 +123,16 @@ class STTEventHandler(AsyncEventHandler):
             else:
                 transcript = await self._handle_fallback(audio)
 
-            await self.write_event(Transcript(text=transcript).event())
+            try:
+                await self.write_event(Transcript(text=transcript).event())
+            except Exception:
+                # Transcript write failed (e.g. ConnectionResetError).
+                # Audio is already queued on the TTS server — clear it
+                # to prevent the next pipeline run from serving stale
+                # audio (the "turn behind" bug).
+                if self._tts_server:
+                    self._tts_server.clear_queue()
+                raise
             return True
 
         return True
@@ -176,6 +192,12 @@ class STTEventHandler(AsyncEventHandler):
                     break
                 elif event.type == "error":
                     logger.error("S2S response error: %s", event.text)
+                    # Flush any partial audio and close the broken session
+                    # so the next call creates a fresh one.
+                    if self._tts_server:
+                        self._tts_server.clear_queue()
+                    with contextlib.suppress(Exception):
+                        await self._s2s_manager.close(satellite_id)
                     return await self._handle_fallback(audio)
 
             # Queue response audio for TTS server BEFORE returning transcript
@@ -194,6 +216,10 @@ class STTEventHandler(AsyncEventHandler):
 
         except Exception:
             logger.exception("S2S processing failed, falling back")
+            if self._tts_server:
+                self._tts_server.clear_queue()
+            with contextlib.suppress(Exception):
+                await self._s2s_manager.close(satellite_id)
             return await self._handle_fallback(audio)
 
     async def _handle_fallback(self, audio: bytes) -> str:

--- a/src/genesis/channels/voice/wyoming_tts.py
+++ b/src/genesis/channels/voice/wyoming_tts.py
@@ -193,6 +193,21 @@ class WyomingTTSServer:
         self._audio_queue.append(audio)
         self._audio_ready.set()
 
+    def clear_queue(self) -> None:
+        """Discard all queued audio (stale from failed pipeline runs).
+
+        Called on ``AudioStart`` to flush orphaned audio from previous
+        failed pipeline runs.  Without this, a ``ConnectionResetError``
+        during transcript write leaves audio in the queue, and the next
+        pipeline run serves the wrong (previous) response — the
+        "turn behind" bug.
+        """
+        count = len(self._audio_queue)
+        if count:
+            self._audio_queue.clear()
+            self._audio_ready.clear()
+            logger.info("Cleared %d stale audio item(s) from TTS queue", count)
+
     async def start(self) -> None:
         """Start the Wyoming TTS server."""
         uri = f"tcp://{self._host}:{self._port}"

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -281,6 +281,153 @@ class TestWyomingTTSServer:
         # maxlen=5
         assert len(server._audio_queue) == 5
 
+    def test_clear_queue_empties_and_resets_event(self):
+        from genesis.channels.voice.wyoming_tts import WyomingTTSServer
+
+        server = WyomingTTSServer()
+        server.queue_audio(b"\x01" * 100)
+        server.queue_audio(b"\x02" * 100)
+        assert len(server._audio_queue) == 2
+        assert server._audio_ready.is_set()
+
+        server.clear_queue()
+        assert len(server._audio_queue) == 0
+        assert not server._audio_ready.is_set()
+
+    def test_clear_queue_noop_when_empty(self):
+        from genesis.channels.voice.wyoming_tts import WyomingTTSServer
+
+        server = WyomingTTSServer()
+        # Should not raise or log when queue is already empty
+        server.clear_queue()
+        assert len(server._audio_queue) == 0
+
+
+# ─── STT handler queue + session cleanup tests ────────────────────────
+
+
+class TestSTTQueueCleanup:
+    """Tests for TTS queue clearing on failures and AudioStart."""
+
+    def _make_handler(self, *, s2s_manager=None, tts_server=None):
+        """Build a STTEventHandler with mocked dependencies."""
+        from genesis.channels.voice.wyoming_stt import STTEventHandler
+
+        handler = STTEventHandler(
+            MagicMock(),  # reader
+            MagicMock(),  # writer
+            s2s_manager=s2s_manager,
+            tts_server=tts_server,
+        )
+        return handler
+
+    async def test_audio_start_clears_tts_queue(self):
+        """AudioStart should flush stale audio from the TTS queue."""
+        from wyoming.audio import AudioStart
+
+        from genesis.channels.voice.wyoming_tts import WyomingTTSServer
+
+        tts = WyomingTTSServer()
+        tts.queue_audio(b"\x01" * 100)  # orphaned audio
+        assert len(tts._audio_queue) == 1
+
+        handler = self._make_handler(tts_server=tts)
+        event = AudioStart(rate=16000, width=2, channels=1).event()
+        await handler.handle_event(event)
+
+        assert len(tts._audio_queue) == 0
+        assert not tts._audio_ready.is_set()
+
+    async def test_audio_start_noop_without_tts_server(self):
+        """AudioStart should not fail when no TTS server is set."""
+        from wyoming.audio import AudioStart
+
+        handler = self._make_handler(tts_server=None)
+        event = AudioStart(rate=16000, width=2, channels=1).event()
+        # Should not raise
+        result = await handler.handle_event(event)
+        assert result is True
+
+    async def test_s2s_error_closes_session_and_clears_queue(self):
+        """S2S error event should close the dead session and clear queue."""
+        from genesis.channels.voice.s2s_session import S2SResponseEvent
+        from genesis.channels.voice.wyoming_tts import WyomingTTSServer
+
+        tts = WyomingTTSServer()
+        tts.queue_audio(b"\xff" * 100)  # simulate pre-existing audio
+        s2s_mgr = AsyncMock()
+        s2s_mgr.close = AsyncMock()
+
+        # Simulate: get_or_create returns session, connect succeeds,
+        # send_turn succeeds, but receive_response yields an error.
+        mock_session = MagicMock()
+        mock_session.connection = MagicMock()
+        s2s_mgr.get_or_create = AsyncMock(return_value=mock_session)
+        s2s_mgr.connect = AsyncMock()
+        s2s_mgr.send_turn = AsyncMock()
+
+        async def _error_response(session):
+            yield S2SResponseEvent(type="error", text="WebSocket closed")
+
+        s2s_mgr.receive_response = _error_response
+
+        handler = self._make_handler(s2s_manager=s2s_mgr, tts_server=tts)
+        handler._handle_fallback = AsyncMock(return_value="fallback text")
+
+        # Need enough audio to pass the minimum threshold
+        audio = b"\x00\x00" * 3200  # 200ms at 16kHz
+        result = await handler._handle_s2s(audio)
+
+        assert result == "fallback text"
+        assert len(tts._audio_queue) == 0  # queue was cleared
+        s2s_mgr.close.assert_awaited_once_with("ha-voice-default")
+
+    async def test_s2s_exception_closes_session_and_clears_queue(self):
+        """Exception in _handle_s2s should close session and clear queue."""
+        from genesis.channels.voice.wyoming_tts import WyomingTTSServer
+
+        tts = WyomingTTSServer()
+        tts.queue_audio(b"\x01" * 100)  # simulate partial audio queued
+        s2s_mgr = AsyncMock()
+        s2s_mgr.close = AsyncMock()
+
+        mock_session = MagicMock()
+        mock_session.connection = MagicMock()
+        s2s_mgr.get_or_create = AsyncMock(return_value=mock_session)
+        s2s_mgr.connect = AsyncMock()
+        s2s_mgr.send_turn = AsyncMock(side_effect=ConnectionError("dead WS"))
+
+        handler = self._make_handler(s2s_manager=s2s_mgr, tts_server=tts)
+        handler._handle_fallback = AsyncMock(return_value="fallback text")
+
+        audio = b"\x00\x00" * 3200
+        result = await handler._handle_s2s(audio)
+
+        assert result == "fallback text"
+        assert len(tts._audio_queue) == 0  # queue cleared
+        s2s_mgr.close.assert_awaited_once_with("ha-voice-default")
+
+    async def test_s2s_exception_close_failure_still_falls_back(self):
+        """If closing the session also fails, we still fall back gracefully."""
+        s2s_mgr = AsyncMock()
+        s2s_mgr.close = AsyncMock(side_effect=Exception("close also broken"))
+
+        mock_session = MagicMock()
+        mock_session.connection = MagicMock()
+        s2s_mgr.get_or_create = AsyncMock(return_value=mock_session)
+        s2s_mgr.connect = AsyncMock()
+        s2s_mgr.send_turn = AsyncMock(side_effect=ConnectionError("dead"))
+
+        handler = self._make_handler(s2s_manager=s2s_mgr, tts_server=None)
+        handler._handle_fallback = AsyncMock(return_value="fallback")
+
+        audio = b"\x00\x00" * 3200
+        result = await handler._handle_s2s(audio)
+
+        assert result == "fallback"
+        # close was attempted even though it failed
+        s2s_mgr.close.assert_awaited_once()
+
 
 # ─── S2S Session Manager tests ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Fix the "turn behind" bug where voice responses play one turn behind the actual conversation, caused by orphaned audio accumulating in the TTS queue after failed pipeline runs (ConnectionResetError)
- Fix "not activating" behavior by closing dead S2S WebSocket sessions on error instead of letting them linger until the 5-minute reaper
- Add 300ms processing pause in `send_turn()` to prevent GPT-Realtime from generating generic greetings before it has processed the audio input

## Changes

- `wyoming_tts.py`: Add `clear_queue()` method to discard orphaned audio
- `wyoming_stt.py`: Clear TTS queue on AudioStart (each new pipeline run), on transcript write failure, and on S2S error/exception paths; close dead sessions before falling back to Groq Whisper
- `s2s_session.py`: 300ms pause between `conversation.item.create` and `response.create()` to let the model ingest audio
- 7 new tests covering queue clearing, session cleanup, and graceful degradation

## Test plan

- [x] 48/48 tests pass (`pytest tests/test_channels/test_voice_s2s.py -v`)
- [x] Lint clean (`ruff check` on all modified files)
- [ ] Manual verification: after server restart, voice pipeline should no longer exhibit turn-behind or generic greeting on first turn
- [ ] Monitor logs for "Cleared N stale audio" messages — should only appear after actual failures, never during normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)