### PR TITLE
fix(routing): add 120s default timeout to litellm calls + fix watchdog messaging

### DIFF
--- a/az_plugins/genesis/templates/neural_monitor.html
+++ b/az_plugins/genesis/templates/neural_monitor.html
@@ -1113,7 +1113,11 @@ function updateSidePanel(data) {
 
         const wd = services.watchdog || {};
         if (wd.consecutive_failures > 0) {
-            svcEl.appendChild(sectionRow('WD Failures', String(wd.consecutive_failures), 'color:#facc15;font-weight:600'));
+            const label = wd.last_reason ? wd.last_reason.replace(/_/g, ' ') : 'restart';
+            const val = wd.consecutive_failures <= 3
+                ? `${wd.consecutive_failures} (${label})`
+                : `${wd.consecutive_failures} restarts`;
+            svcEl.appendChild(sectionRow('WD Restarts', val, 'color:#facc15;font-weight:600'));
         }
         if (wd.in_backoff) {
             svcEl.appendChild(sectionRow('WD Status', 'in backoff', 'color:#facc15'));

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -2575,8 +2575,9 @@
           if (hf?.detected && hf.status === "degraded") {
             return { state: "degraded", reason: `${hf.name} is degraded` };
           }
-          if ((services?.watchdog?.consecutive_failures || 0) > 0) {
-            return { state: "degraded", reason: "watchdog has recent consecutive failures" };
+          if ((services?.watchdog?.consecutive_failures || 0) > 3) {
+            const wd = services.watchdog;
+            return { state: "degraded", reason: `watchdog: ${wd.consecutive_failures} repeated restarts (${wd.last_reason || 'unknown'})` };
           }
           // Sentinel — container-side guardian. Below liveness checks above so a
           // dead bridge/timer/host_framework still wins; an escalated Sentinel
@@ -4289,7 +4290,7 @@
                           :style="`background: ${$store.genesisDashboard.health.services?.watchdog_timer?.active_state === 'active' ? '#4caf50' : ['failed', 'inactive'].includes($store.genesisDashboard.health.services?.watchdog_timer?.active_state) ? '#d9534f' : '#666'}`"></span>
                     Watchdog
                     <span style="opacity: 0.6; font-size: 0.75rem"
-                          x-text="($store.genesisDashboard.health.services?.watchdog?.consecutive_failures || 0) > 0 ? '(' + $store.genesisDashboard.health.services.watchdog.consecutive_failures + ' fails)' : ''"></span>
+                          x-text="(() => { const n = $store.genesisDashboard.health.services?.watchdog?.consecutive_failures || 0; if (n === 0) return ''; const reason = $store.genesisDashboard.health.services?.watchdog?.last_reason; const label = reason ? reason.replace(/_/g, ' ') : 'restart'; return n <= 3 ? `(${label})` : `(${n} restarts)`; })()"></span>
                   </div>
                   <!-- Sentinel (container-side guardian) -->
                   <div style="font-size: 0.82rem; margin-bottom: 0.2rem; cursor: default;"

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -635,7 +635,11 @@ function updateSidePanel(data) {
 
         const wd = services.watchdog || {};
         if (wd.consecutive_failures > 0) {
-            svcEl.appendChild(sectionRow('WD Failures', String(wd.consecutive_failures), 'color:#ffe600;font-weight:600'));
+            const label = wd.last_reason ? wd.last_reason.replace(/_/g, ' ') : 'restart';
+            const val = wd.consecutive_failures <= 3
+                ? `${wd.consecutive_failures} (${label})`
+                : `${wd.consecutive_failures} restarts`;
+            svcEl.appendChild(sectionRow('WD Restarts', val, 'color:#ffe600;font-weight:600'));
         }
         if (wd.in_backoff) {
             svcEl.appendChild(sectionRow('WD Status', 'in backoff', 'color:#ffe600'));

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -343,7 +343,7 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
         alerts.append({
             "id": alert_id,
             "severity": "WARNING",
-            "message": f"Watchdog has {wd_failures} consecutive failures (reason: {watchdog_state.get('last_reason', 'unknown')})",
+            "message": f"Watchdog triggered {wd_failures} consecutive restarts (reason: {watchdog_state.get('last_reason', 'unknown')})",
         })
         current_ids.add(alert_id)
 

--- a/src/genesis/routing/litellm_delegate.py
+++ b/src/genesis/routing/litellm_delegate.py
@@ -17,6 +17,15 @@ logger = logging.getLogger(__name__)
 _FAILURE_LOG_INTERVAL_S = 300
 _last_failure_log: dict[str, float] = {}
 
+# Default timeout for litellm.acompletion() calls (seconds).  Prevents
+# indefinite hangs when a provider accepts TCP but stalls on response.
+# litellm's own default is ambiguous (600s in completion(), 6000s global
+# constant) and clearly failed to fire during a 20-minute production hang
+# (deepseek-v4-pro via OpenRouter, 2026-06-08).  120s is generous for all
+# Genesis call sites (max observed: ~1500 input / ~8K output tokens).
+# Callers can override via kwargs if a specific call site needs longer.
+_DEFAULT_TIMEOUT_S = 120
+
 
 def _should_log_failure(provider: str) -> bool:
     now = time.monotonic()
@@ -137,6 +146,8 @@ class LiteLLMDelegate:
         api_key = _resolve_api_key(cfg.provider_type)
 
         call_kwargs = {**kwargs}
+        if "timeout" not in call_kwargs:
+            call_kwargs["timeout"] = _DEFAULT_TIMEOUT_S
         if api_key:
             call_kwargs["api_key"] = api_key
         if cfg.base_url:

--- a/tests/test_routing/test_litellm_delegate.py
+++ b/tests/test_routing/test_litellm_delegate.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from genesis.routing.litellm_delegate import (
+    _DEFAULT_TIMEOUT_S,
     LiteLLMDelegate,
     _build_model_string,
     _resolve_api_key,
@@ -203,6 +204,48 @@ async def test_call_passes_api_key():
 
         call_args = mock_litellm.acompletion.call_args
         assert call_args.kwargs["api_key"] == "test-key-xyz"
+
+
+# ── Timeout default ───────────────────────────────────────────────────────
+
+
+async def test_call_passes_default_timeout():
+    """acompletion should receive timeout=_DEFAULT_TIMEOUT_S by default."""
+    config = _config()
+    delegate = LiteLLMDelegate(config)
+    mock_resp = _mock_response()
+
+    with patch("genesis.routing.litellm_delegate.litellm") as mock_litellm:
+        mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+        mock_litellm.completion_cost.return_value = 0.0
+
+        await delegate.call(
+            "test-provider", "llama-3.3-70b-versatile",
+            [{"role": "user", "content": "Hi"}],
+        )
+
+        call_kwargs = mock_litellm.acompletion.call_args.kwargs
+        assert call_kwargs["timeout"] == _DEFAULT_TIMEOUT_S
+
+
+async def test_call_allows_timeout_override():
+    """Caller-supplied timeout should override the default."""
+    config = _config()
+    delegate = LiteLLMDelegate(config)
+    mock_resp = _mock_response()
+
+    with patch("genesis.routing.litellm_delegate.litellm") as mock_litellm:
+        mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+        mock_litellm.completion_cost.return_value = 0.0
+
+        await delegate.call(
+            "test-provider", "llama-3.3-70b-versatile",
+            [{"role": "user", "content": "Hi"}],
+            timeout=300,
+        )
+
+        call_kwargs = mock_litellm.acompletion.call_args.kwargs
+        assert call_kwargs["timeout"] == 300
 
 
 # ── Error classification ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **LLM timeout**: Adds explicit `timeout=120` to all `litellm.acompletion()` calls via `LiteLLMDelegate.call()`. Prevents indefinite hangs when a provider accepts TCP but stalls on response (production incident: deepseek-v4-pro via OpenRouter hung for 20 minutes on 2026-06-08, blocking the surplus dispatch loop until the watchdog killed the server). Callers can override via kwargs.
- **Watchdog messaging**: Changes "consecutive failures" to "restarts" across dashboard, neural monitor, and health alerts — the watchdog detecting and restarting a broken server is a success, not a failure. Dashboard degraded threshold raised from >0 to >3 (matching existing alert threshold).

## Changes

| File | Change |
|------|--------|
| `src/genesis/routing/litellm_delegate.py` | `_DEFAULT_TIMEOUT_S = 120`, injected into `call_kwargs` |
| `src/genesis/mcp/health/errors.py` | Alert text: "failures" → "restarts" |
| `src/genesis/dashboard/templates/genesis_dashboard.html` | Threshold >0→>3, wording + reason display |
| `src/genesis/dashboard/templates/neural_monitor.html` | "WD Failures" → "WD Restarts" with reason |
| `az_plugins/genesis/templates/neural_monitor.html` | Same fix for AZ plugins copy |
| `tests/test_routing/test_litellm_delegate.py` | 2 new tests: default timeout applied, caller override works |

## Test plan

- [x] `pytest tests/test_routing/test_litellm_delegate.py` — 27/27 pass (25 existing + 2 new)
- [x] `ruff check` — clean
- [ ] CI green
- [ ] Dashboard shows "WD Restarts" with reason, not "fails"
- [ ] Automated review

🤖 Generated with [Claude Code](https://claude.com/claude-code)