### PR TITLE
fix(eval): dashboard white flash + J9 eval session attribution bugs

### DIFF
--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -153,6 +153,13 @@ class ConversationLoop:
             thread_id=thread_id,
         )
 
+        # Set session context so downstream code (CCInvoker, eval hooks)
+        # can attribute work to this session without explicit threading.
+        # Uses set/clear rather than session_scope() to avoid re-indenting
+        # the entire lock block; follows the pattern in direct_session.py.
+        from genesis.observability.session_context import set_session_id
+        set_session_id(session["id"])
+
         async with self._get_lock(session["id"]):
             await self._persist_overrides(session, model, effort)
 
@@ -351,6 +358,10 @@ class ConversationLoop:
             user_id=user_id, channel=channel, model=model, effort=effort,
             thread_id=thread_id,
         )
+
+        # Set session context for eval attribution (same as handle_message).
+        from genesis.observability.session_context import set_session_id as _set_sid
+        _set_sid(session["id"])
 
         async with self._get_lock(session["id"]):
             # Capture old values before persisting overrides (for change feedback)

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -179,6 +179,14 @@ class CCInvoker:
         # The genesis_session_context.py hook skips identity injection when set,
         # preventing double injection (identity is in the system prompt arg).
         env["GENESIS_CC_SESSION"] = "1"
+        # Propagate Genesis session_id to child CC + MCP server processes
+        # so eval hooks can attribute recall events to specific sessions.
+        from genesis.observability.session_context import get_session_id
+        _sid = get_session_id()
+        if _sid:
+            env["GENESIS_SESSION_ID"] = _sid
+        else:
+            env.pop("GENESIS_SESSION_ID", None)
         if inv and inv.stream_idle_timeout_ms is not None:
             env["CLAUDE_STREAM_IDLE_TIMEOUT_MS"] = str(inv.stream_idle_timeout_ms)
         if inv and inv.anthropic_base_url:

--- a/src/genesis/dashboard/routes/eval.py
+++ b/src/genesis/dashboard/routes/eval.py
@@ -57,7 +57,7 @@ async def metrics_compounding():
         dimensions[dim] = {
             "headline_metric": headline_key,
             "current_value": (
-                latest["metrics"].get(headline_key) if latest else None
+                latest.get("metrics", {}).get(headline_key) if latest else None
             ),
             "series": series,
             "weeks_of_data": len(series),

--- a/src/genesis/dashboard/routes/surplus.py
+++ b/src/genesis/dashboard/routes/surplus.py
@@ -184,7 +184,14 @@ async def surplus_config():
                 SELECT dimension, metrics_json, sample_count, created_at
                 FROM eval_snapshots ORDER BY created_at DESC LIMIT 10
             """)
-            eval_metrics["j9"] = [dict(r) for r in await cursor.fetchall()]
+            j9_rows = []
+            for r in await cursor.fetchall():
+                row = dict(r)
+                if row.get("metrics_json"):
+                    row["metrics"] = json.loads(row["metrics_json"])
+                    del row["metrics_json"]
+                j9_rows.append(row)
+            eval_metrics["j9"] = j9_rows
         except Exception:
             logger.debug("eval_metrics query failed (tables may not exist yet)")
 

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="background-color:#131313;color:#fff;">
 
 <head>
   <meta charset="UTF-8">
+  <meta name="color-scheme" content="dark">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <title>Genesis Dashboard</title>
   <link rel="icon" type="image/svg+xml" href="/public/favicon.svg">

--- a/src/genesis/dashboard/templates/genesis_errors.html
+++ b/src/genesis/dashboard/templates/genesis_errors.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="background-color:#131313;color:#fff;">
 
 <head>
   <meta charset="UTF-8">
+  <meta name="color-scheme" content="dark">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <title>Genesis Error Log</title>
   <link rel="icon" type="image/svg+xml" href="/public/favicon.svg">

--- a/src/genesis/dashboard/templates/genesis_logs.html
+++ b/src/genesis/dashboard/templates/genesis_logs.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="background-color:#131313;color:#fff;">
 
 <head>
   <meta charset="UTF-8">
+  <meta name="color-scheme" content="dark">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <title>Genesis Event Log</title>
   <link rel="icon" type="image/svg+xml" href="/public/favicon.svg">

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="background-color:#131313;color:#fff;">
 <head>
 <meta charset="UTF-8">
+<meta name="color-scheme" content="dark">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Genesis Neural Monitor</title>
 <link rel="icon" type="image/svg+xml" href="/public/favicon.svg">

--- a/src/genesis/eval/j9_batch.py
+++ b/src/genesis/eval/j9_batch.py
@@ -167,15 +167,20 @@ class J9EvalBatchExecutor:
 
         used_count = 0
         for session_id, events in by_session.items():
-            # Get memories extracted FROM this session (content created by the session)
+            if not session_id:
+                continue  # Skip events without session attribution
+            # Get memories extracted FROM this session via pending_embeddings
+            # which tracks source_session_id for each extracted memory.
             try:
                 cursor = await self._db.execute(
                     """SELECT content FROM memory_fts
                        WHERE memory_id IN (
-                           SELECT memory_id FROM memory_metadata
-                           WHERE created_at >= ? LIMIT 100
+                           SELECT memory_id FROM pending_embeddings
+                           WHERE source_session_id = ?
+                             AND status = 'embedded'
+                           LIMIT 100
                        )""",
-                    (since,),
+                    (session_id,),
                 )
                 session_content = " ".join(
                     (row[0] if isinstance(row, tuple) else row["content"])

--- a/src/genesis/eval/j9_hooks.py
+++ b/src/genesis/eval/j9_hooks.py
@@ -8,12 +8,31 @@ code paths.
 from __future__ import annotations
 
 import logging
+import os
 
 import aiosqlite
 
 from genesis.db.crud import j9_eval
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_session_id(explicit: str | None) -> str | None:
+    """Resolve session_id via fallback chain: explicit → ContextVar → env var.
+
+    MCP servers run in separate processes and can't see the ContextVar,
+    but they inherit GENESIS_SESSION_ID from the CCInvoker's env.
+    """
+    if explicit:
+        return explicit
+    try:
+        from genesis.observability.session_context import get_session_id
+        ctx_sid = get_session_id()
+        if ctx_sid:
+            return ctx_sid
+    except ImportError:
+        pass  # MCP servers may not have session_context available
+    return os.environ.get("GENESIS_SESSION_ID")
 
 
 async def emit_recall_fired(
@@ -61,7 +80,7 @@ async def emit_recall_fired(
             db,
             dimension="memory",
             event_type="recall_fired",
-            session_id=session_id,
+            session_id=_resolve_session_id(session_id),
             metrics=metrics,
         )
     except Exception:
@@ -109,7 +128,7 @@ async def emit_procedure_invoked(
             dimension="procedure",
             event_type="procedure_invoked",
             subject_id=procedure_id,
-            session_id=session_id,
+            session_id=_resolve_session_id(session_id),
             metrics={
                 "confidence_at_invoke": confidence,
                 "matched_tags": matched_tags[:10],


### PR DESCRIPTION
## Summary

- **Dashboard white flash**: All 4 page templates now have inline dark background (#131313) on `<html>` + `<meta name="color-scheme" content="dark">` to prevent white flash during full-page navigation
- **surplus.py raw JSON**: Deserialize `metrics_json` before returning to frontend (was returning raw string, breaking Neural Monitor)
- **eval.py null deref**: Defensive `.get("metrics", {})` on line 60, matching safe pattern on line 48
- **J9 session attribution**: `emit_recall_fired` and `emit_procedure_invoked` now resolve `session_id` via fallback chain (explicit → ContextVar → `GENESIS_SESSION_ID` env var), fixing cognitive dimension being permanently null
- **Session leak in `_compute_recall_used`**: Now queries `pending_embeddings.source_session_id` instead of all recent memories via `memory_metadata.created_at` — fixes inflated `usage_rate` metric
- **Foreground session context**: `ConversationLoop` sets ContextVar for both `handle_message` and `handle_message_streaming` paths
- **CCInvoker env propagation**: Propagates session ContextVar → `GENESIS_SESSION_ID` env var for child MCP processes, clears stale values

## Audit context

Full J9 eval system audit identified 7 bugs — 2 dead dimensions (cognitive, procedure), session data leak inflating usage_rate, raw JSON API response, null deref, and missing session attribution. This PR fixes the code bugs. Methodology changes (ego grade weights, awareness scoring, missing-data inflation) are deferred to a separate PR.

## Test plan

- [x] `ruff check` — all changed files pass
- [x] `pytest tests/test_eval/test_j9_eval.py tests/test_eval/test_recall_instrumentation.py` — 38 passed
- [x] `pytest tests/test_dashboard/` — 102 passed
- [ ] E2E: Navigate Dashboard → Error Log → Event Log → Neural Monitor — no white flash
- [ ] E2E: After server restart, trigger recall, verify `session_id` populated in `eval_events`
- [ ] E2E: Verify `/api/genesis/surplus/config` returns `metrics` (object) not `metrics_json` (string) in j9 data

🤖 Generated with [Claude Code](https://claude.com/claude-code)