### PR TITLE
feat(infra): worktree lifecycle management — cross-session guard + trash bin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -233,6 +233,16 @@
                         "timeout": 2000
                     }
                 ]
+            },
+            {
+                "matcher": "ExitWorktree",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/worktree_cwd_guard.py --exit-worktree",
+                        "timeout": 2000
+                    }
+                ]
             }
         ],
         "Stop": [

--- a/scripts/hooks/worktree_cwd_guard.py
+++ b/scripts/hooks/worktree_cwd_guard.py
@@ -117,7 +117,7 @@ def _block_with_pids(target: str, pids: list[int]) -> int:
 def _block_no_direct_removal(target: str) -> int:
     """Print lifecycle-manager redirect and return exit code 2."""
     print(
-        f"BLOCKED: Direct worktree removal is disabled.",
+        "BLOCKED: Direct worktree removal is disabled.",
         file=sys.stderr,
     )
     print(

--- a/scripts/hooks/worktree_cwd_guard.py
+++ b/scripts/hooks/worktree_cwd_guard.py
@@ -1,12 +1,23 @@
 #!/usr/bin/env python3
-"""PreToolUse hook (Bash): block git worktree remove on the current working directory.
+"""PreToolUse hook: block worktree removal to protect active sessions.
 
-Removing a worktree that is the shell's CWD bricks the entire session —
-every subsequent Bash command fails with "Path does not exist" because the
-shell's persisted working directory no longer exists.
+Two modes:
+  1. Bash matcher (default) — intercepts `git worktree remove` commands.
+  2. ExitWorktree matcher (--exit-worktree) — intercepts ExitWorktree tool
+     with action "remove".
 
-Incident: 2026-05-27. Session permanently lost Bash capability after
-deleting the worktree it was running in.
+In both modes:
+  - If another process has its CWD inside the target worktree → hard block
+    with PID list (cross-session safety).
+  - If the current session's CWD IS the target → hard block (self-brick
+    prevention).
+  - If no conflicts → still block. Worktrees are never removed directly.
+    The lifecycle manager (scripts/worktree_lifecycle.py) handles cleanup
+    via a trash bin with 7-day recovery.
+
+Incident 1: 2026-05-27 — Session bricked after deleting its own worktree.
+Incident 2: 2026-06-09 — Session B deleted worktree still used by Session A,
+turning A into a zombie.
 
 Stdlib-only. Fail-open on parse errors.
 """
@@ -48,6 +59,153 @@ def _resolve_path(path: str) -> str:
     return os.path.realpath(os.path.abspath(expanded))
 
 
+def _find_processes_in_dir(dir_path: str) -> list[int]:
+    """Return PIDs (excluding self and parent) with CWD inside dir_path.
+
+    Scans /proc/[0-9]*/cwd symlinks. Each readlink is a single syscall.
+    Processes that vanish between enumeration and readlink are silently
+    skipped. ~250ms for ~100 processes on this container.
+
+    Excludes own PID and parent PID. The parent is the CC session that
+    fired this hook (genesis-hook uses exec, so the hook's ppid IS the
+    CC process). Excluding it avoids false positives from the current
+    session's own process chain.
+    """
+    exclude = {os.getpid(), os.getppid()}
+    pids: list[int] = []
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return pids  # fail-open
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        pid = int(entry)
+        if pid in exclude:
+            continue
+        try:
+            cwd = os.readlink(f"/proc/{pid}/cwd")
+            # Normalize — readlink may return path with trailing " (deleted)"
+            # for processes whose CWD has been removed, but we care about
+            # preventing removal, so at PreToolUse time the dir still exists.
+            if cwd == dir_path or cwd.startswith(dir_path + "/"):
+                pids.append(pid)
+        except (OSError, PermissionError, FileNotFoundError):
+            continue
+    return pids
+
+
+def _block_with_pids(target: str, pids: list[int]) -> int:
+    """Print cross-session block message and return exit code 2."""
+    pid_str = ", ".join(str(p) for p in pids[:10])
+    if len(pids) > 10:
+        pid_str += f" (+{len(pids) - 10} more)"
+    print(
+        f"BLOCKED: Cannot remove worktree '{target}' — "
+        f"{len(pids)} other process(es) have their working directory inside it.",
+        file=sys.stderr,
+    )
+    print(f"PIDs: {pid_str}", file=sys.stderr)
+    print(
+        "This would brick those sessions. Wait for them to finish "
+        "or use the lifecycle manager.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def _block_no_direct_removal(target: str) -> int:
+    """Print lifecycle-manager redirect and return exit code 2."""
+    print(
+        f"BLOCKED: Direct worktree removal is disabled.",
+        file=sys.stderr,
+    )
+    print(
+        "Worktrees are managed by the lifecycle manager "
+        "(scripts/worktree_lifecycle.py) which uses a trash bin "
+        "with 7-day recovery.",
+        file=sys.stderr,
+    )
+    print(
+        "The lifecycle manager runs daily via cron. To manually trigger: "
+        "python scripts/worktree_lifecycle.py --dry-run",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def _handle_bash(data: dict) -> int:
+    """Handle Bash tool — intercept `git worktree remove` commands."""
+    cmd = data.get("command", "")
+    if not cmd:
+        return 0
+
+    if not _WORKTREE_REMOVE.search(cmd):
+        return 0
+
+    # Get the current working directory
+    cwd = os.getcwd()
+    cwd_real = os.path.realpath(cwd)
+
+    targets = _extract_worktree_targets(cmd)
+    for target in targets:
+        target_real = _resolve_path(target)
+
+        # Check 1: Self-CWD — would brick this session
+        if cwd_real == target_real or cwd_real.startswith(target_real + "/"):
+            print(
+                f"BLOCKED: Cannot remove worktree '{target}' — "
+                f"it is your current working directory.",
+                file=sys.stderr,
+            )
+            print(
+                "This would brick the session (every Bash command would "
+                "fail with 'Path does not exist').",
+                file=sys.stderr,
+            )
+            return 2
+
+        # Check 2: Cross-session — another process is using it
+        other_pids = _find_processes_in_dir(target_real)
+        if other_pids:
+            return _block_with_pids(target, other_pids)
+
+        # Check 3: No conflict — still block, redirect to lifecycle manager
+        return _block_no_direct_removal(target)
+
+    # Fallthrough (no targets parsed) — shouldn't happen, but fail-open
+    return 0
+
+
+def _handle_exit_worktree(data: dict) -> int:
+    """Handle ExitWorktree tool — block action "remove"."""
+    action = data.get("action", "")
+    if action != "remove":
+        return 0  # "keep" is always allowed
+
+    # The session is still in the worktree at PreToolUse time
+    cwd = os.getcwd()
+    cwd_real = os.path.realpath(cwd)
+
+    # Check for other processes in this worktree
+    other_pids = _find_processes_in_dir(cwd_real)
+    if other_pids:
+        return _block_with_pids(cwd, other_pids)
+
+    # No conflict — still block, redirect to "keep"
+    print(
+        "BLOCKED: Direct worktree removal is disabled.",
+        file=sys.stderr,
+    )
+    print(
+        "Use ExitWorktree with action 'keep' instead. "
+        "The lifecycle manager (scripts/worktree_lifecycle.py) handles "
+        "cleanup automatically via a trash bin with 7-day recovery.",
+        file=sys.stderr,
+    )
+    return 2
+
+
 def main() -> int:
     try:
         raw = os.environ.get("CLAUDE_TOOL_INPUT", "")
@@ -55,39 +213,12 @@ def main() -> int:
             return 0
 
         data = json.loads(raw)
-        cmd = data.get("command", "")
-        if not cmd:
-            return 0
 
-        if not _WORKTREE_REMOVE.search(cmd):
-            return 0
-
-        # Get the current working directory
-        cwd = os.getcwd()
-        cwd_real = os.path.realpath(cwd)
-
-        targets = _extract_worktree_targets(cmd)
-        for target in targets:
-            target_real = _resolve_path(target)
-
-            # Block if CWD is inside the target worktree
-            # (CWD equals target or is a subdirectory of it)
-            if cwd_real == target_real or cwd_real.startswith(target_real + "/"):
-                print(
-                    f"BLOCKED: Cannot remove worktree '{target}' — "
-                    f"it is your current working directory.",
-                    file=sys.stderr,
-                )
-                print(
-                    "This would brick the session (every Bash command would "
-                    "fail with 'Path does not exist').",
-                    file=sys.stderr,
-                )
-                print(
-                    "Fix: cd to the main repo first, then remove the worktree.",
-                    file=sys.stderr,
-                )
-                return 2
+        # Determine mode from CLI args
+        if "--exit-worktree" in sys.argv:
+            return _handle_exit_worktree(data)
+        else:
+            return _handle_bash(data)
 
     except (json.JSONDecodeError, KeyError, OSError):
         pass  # Fail-open

--- a/scripts/worktree_lifecycle.py
+++ b/scripts/worktree_lifecycle.py
@@ -240,20 +240,25 @@ def _trash_worktree(
     try:
         TRASH_DIR.mkdir(parents=True, exist_ok=True)
 
-        # Write metadata before moving (in case move fails)
+        # Write metadata to staging file BEFORE the move. If the move
+        # fails we just have a harmless orphan file. If the process
+        # dies after the move but before metadata lands inside the
+        # trash dir, we still have it at the staging path.
         meta = {
             "original_path": str(wt_path),
             "branch": branch,
             "commit": wt.get("head", ""),
             "trashed_at": datetime.now(UTC).isoformat(),
         }
+        staging_meta = TRASH_DIR / f".{trash_path.name}.meta.staging"
+        staging_meta.write_text(json.dumps(meta, indent=2))
 
         # Move worktree to trash
         shutil.move(str(wt_path), str(trash_path))
 
-        # Write metadata into trash entry
-        meta_path = trash_path / ".trash_meta.json"
-        meta_path.write_text(json.dumps(meta, indent=2))
+        # Move staging metadata into the trash entry
+        final_meta = trash_path / ".trash_meta.json"
+        staging_meta.rename(final_meta)
 
         # Clean git's worktree registration
         subprocess.run(

--- a/scripts/worktree_lifecycle.py
+++ b/scripts/worktree_lifecycle.py
@@ -1,0 +1,540 @@
+#!/usr/bin/env python3
+"""Worktree lifecycle manager — automated stale cleanup with trash bin.
+
+Identifies and trashes worktrees that are:
+1. Not in use by any process (no /proc/*/cwd inside them)
+2. Inactive for 14+ days (no file modifications)
+3. Branch is merged (PR merged on GitHub) OR has zero unique commits
+
+Trashed worktrees are recoverable for 7 days. After that, permanently
+deleted along with their branches.
+
+Usage:
+    worktree_lifecycle.py                    # Run: trash stale, purge old trash
+    worktree_lifecycle.py --dry-run          # Show what would happen
+    worktree_lifecycle.py --list-trash       # Show trash contents with age
+    worktree_lifecycle.py --recover <name>   # Recover a trashed worktree
+
+Designed for daily cron:
+    0 4 * * * .venv/bin/python scripts/worktree_lifecycle.py
+
+Stdlib-only (no genesis package imports). Uses gh CLI for PR status.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+STALE_DAYS = 14
+TRASH_RETENTION_DAYS = 7
+TRASH_DIR = Path.home() / ".genesis" / "worktree-trash"
+LOG_DIR = Path.home() / ".genesis" / "logs"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _log(msg: str) -> None:
+    """Print a timestamped log line to stdout (captured by cron)."""
+    ts = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+    print(f"{ts} {msg}", flush=True)
+
+
+def _repo_root() -> Path:
+    """Resolve the repo root from this script's location."""
+    here = Path(__file__).resolve()
+    # scripts/worktree_lifecycle.py → repo root is ../
+    return here.parent.parent
+
+
+def _find_processes_in_dir(dir_path: str) -> list[int]:
+    """Return PIDs with CWD inside dir_path (excluding self + parent)."""
+    exclude = {os.getpid(), os.getppid()}
+    pids: list[int] = []
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return pids
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        pid = int(entry)
+        if pid in exclude:
+            continue
+        try:
+            cwd = os.readlink(f"/proc/{pid}/cwd")
+            if cwd == dir_path or cwd.startswith(dir_path + "/"):
+                pids.append(pid)
+        except (OSError, PermissionError, FileNotFoundError):
+            continue
+    return pids
+
+
+def _list_worktrees(repo_root: Path) -> list[dict]:
+    """Parse git worktree list --porcelain into structured data.
+
+    Returns list of dicts with keys: path, branch, head.
+    Excludes the main worktree (bare=True or first entry).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            capture_output=True, text=True, cwd=str(repo_root), timeout=10,
+        )
+        if result.returncode != 0:
+            return []
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+
+    worktrees: list[dict] = []
+    current: dict = {}
+    is_first = True
+
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            if current and "path" in current and not is_first:
+                worktrees.append(current)
+            current = {"path": line[len("worktree "):]}
+        elif line.startswith("HEAD "):
+            current["head"] = line[len("HEAD "):]
+        elif line.startswith("branch "):
+            # refs/heads/branch-name → branch-name
+            ref = line[len("branch "):]
+            current["branch"] = ref.removeprefix("refs/heads/")
+        elif line == "":
+            if current and "path" in current and not is_first:
+                worktrees.append(current)
+            is_first = False
+            current = {}
+
+    # Handle last entry (no trailing newline)
+    if current and "path" in current and not is_first:
+        worktrees.append(current)
+
+    return worktrees
+
+
+def _last_activity_time(worktree_path: str) -> float:
+    """Return the most recent mtime of any file in the worktree.
+
+    Depth-limited walk (top 2 levels) to avoid scanning deep
+    directories like node_modules or .git internals.
+    """
+    latest = os.path.getmtime(worktree_path)
+    root = Path(worktree_path)
+
+    for item in root.iterdir():
+        if item.name == ".git":
+            continue  # Skip git internals
+        try:
+            mtime = item.stat().st_mtime
+            if mtime > latest:
+                latest = mtime
+            # One level deeper
+            if item.is_dir():
+                for sub in item.iterdir():
+                    try:
+                        mtime = sub.stat().st_mtime
+                        if mtime > latest:
+                            latest = mtime
+                    except OSError:
+                        continue
+        except OSError:
+            continue
+
+    return latest
+
+
+def _branch_is_merged(branch: str, repo_root: Path) -> bool:
+    """Check if a branch's PR is merged on GitHub.
+
+    Three methods tried in order:
+    1. git merge-base --is-ancestor (fast, works for non-squash merges)
+    2. gh pr list --head <branch> --state merged (handles squash merges)
+    3. Zero unique commits vs main (git cherry)
+
+    Returns False on any error (fail-safe: keep the worktree).
+    """
+    # Method 1: git merge-base
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", branch, "main"],
+            capture_output=True, cwd=str(repo_root), timeout=10,
+        )
+        if result.returncode == 0:
+            return True
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    # Method 2: gh pr list (handles squash merges)
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "list", "--head", branch, "--state", "merged",
+             "--limit", "1", "--json", "number"],
+            capture_output=True, text=True, cwd=str(repo_root), timeout=30,
+        )
+        if result.returncode == 0:
+            prs = json.loads(result.stdout)
+            if prs:
+                return True
+    except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
+        pass
+
+    # Method 3: zero unique commits
+    try:
+        result = subprocess.run(
+            ["git", "cherry", "main", branch],
+            capture_output=True, text=True, cwd=str(repo_root), timeout=10,
+        )
+        if result.returncode == 0:
+            # Lines starting with '+' are unique commits not in main
+            unique = [line for line in result.stdout.strip().splitlines()
+                      if line.startswith("+")]
+            if not unique:
+                return True
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Trash operations
+# ---------------------------------------------------------------------------
+
+
+def _trash_worktree(
+    wt: dict, repo_root: Path, *, dry_run: bool = False,
+) -> bool:
+    """Move a worktree to the trash directory.
+
+    Returns True if trashed (or would be trashed in dry-run).
+    """
+    wt_path = Path(wt["path"])
+    branch = wt.get("branch", "unknown")
+    name = wt_path.name
+    date_str = datetime.now(UTC).strftime("%Y%m%d")
+    trash_name = f"{name}-{date_str}"
+    trash_path = TRASH_DIR / trash_name
+
+    # Avoid name collisions
+    counter = 1
+    while trash_path.exists():
+        trash_path = TRASH_DIR / f"{name}-{date_str}-{counter}"
+        counter += 1
+
+    if dry_run:
+        _log(f"WOULD TRASH {wt_path}: → {trash_path}")
+        return True
+
+    try:
+        TRASH_DIR.mkdir(parents=True, exist_ok=True)
+
+        # Write metadata before moving (in case move fails)
+        meta = {
+            "original_path": str(wt_path),
+            "branch": branch,
+            "commit": wt.get("head", ""),
+            "trashed_at": datetime.now(UTC).isoformat(),
+        }
+
+        # Move worktree to trash
+        shutil.move(str(wt_path), str(trash_path))
+
+        # Write metadata into trash entry
+        meta_path = trash_path / ".trash_meta.json"
+        meta_path.write_text(json.dumps(meta, indent=2))
+
+        # Clean git's worktree registration
+        subprocess.run(
+            ["git", "worktree", "prune"],
+            capture_output=True, cwd=str(repo_root), timeout=10,
+        )
+
+        _log(f"TRASH {wt_path}: branch={branch}, recoverable for {TRASH_RETENTION_DAYS}d at {trash_path}")
+        return True
+    except (OSError, shutil.Error) as e:
+        _log(f"ERROR trashing {wt_path}: {e}")
+        return False
+
+
+def _purge_old_trash(repo_root: Path, *, dry_run: bool = False) -> None:
+    """Permanently delete trash entries older than TRASH_RETENTION_DAYS."""
+    if not TRASH_DIR.exists():
+        return
+
+    now = time.time()
+
+    for entry in sorted(TRASH_DIR.iterdir()):
+        if not entry.is_dir():
+            continue
+
+        meta_path = entry / ".trash_meta.json"
+        trashed_at: float | None = None
+
+        if meta_path.exists():
+            try:
+                meta = json.loads(meta_path.read_text())
+                trashed_at_str = meta.get("trashed_at", "")
+                if trashed_at_str:
+                    dt = datetime.fromisoformat(trashed_at_str)
+                    trashed_at = dt.timestamp()
+            except (json.JSONDecodeError, ValueError, OSError):
+                pass
+
+        # Fallback: use the directory's mtime
+        if trashed_at is None:
+            try:
+                trashed_at = entry.stat().st_mtime
+            except OSError:
+                continue
+
+        age_days = (now - trashed_at) / 86400
+        if age_days < TRASH_RETENTION_DAYS:
+            continue
+
+        # Old enough to purge
+        branch = ""
+        if meta_path.exists():
+            try:
+                meta = json.loads(meta_path.read_text())
+                branch = meta.get("branch", "")
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        if dry_run:
+            _log(f"WOULD PURGE {entry.name}: trashed {age_days:.0f}d ago"
+                 + (f", branch={branch}" if branch else ""))
+            continue
+
+        try:
+            shutil.rmtree(str(entry))
+            _log(f"PURGE {entry.name}: trashed {age_days:.0f}d ago")
+        except OSError as e:
+            _log(f"ERROR purging {entry.name}: {e}")
+            continue
+
+        # Delete the branch if it still exists
+        if branch:
+            subprocess.run(
+                ["git", "branch", "-D", branch],
+                capture_output=True, cwd=str(repo_root), timeout=10,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Recovery
+# ---------------------------------------------------------------------------
+
+
+def _recover(name: str, repo_root: Path) -> bool:
+    """Recover a worktree from the trash."""
+    if not TRASH_DIR.exists():
+        print(f"No trash directory found at {TRASH_DIR}", file=sys.stderr)
+        return False
+
+    # Find matching trash entry
+    matches = [e for e in TRASH_DIR.iterdir()
+               if e.is_dir() and e.name.startswith(name)]
+    if not matches:
+        print(f"No trash entry matching '{name}'", file=sys.stderr)
+        return False
+    if len(matches) > 1:
+        print(f"Multiple matches for '{name}':", file=sys.stderr)
+        for m in matches:
+            print(f"  {m.name}", file=sys.stderr)
+        print("Be more specific.", file=sys.stderr)
+        return False
+
+    trash_path = matches[0]
+    meta_path = trash_path / ".trash_meta.json"
+
+    if not meta_path.exists():
+        print(f"No .trash_meta.json in {trash_path}", file=sys.stderr)
+        return False
+
+    meta = json.loads(meta_path.read_text())
+    original_path = meta.get("original_path", "")
+    branch = meta.get("branch", "")
+
+    if not original_path or not branch:
+        print(f"Incomplete metadata in {meta_path}", file=sys.stderr)
+        return False
+
+    # Check if original path is already occupied
+    if Path(original_path).exists():
+        print(f"Original path already exists: {original_path}", file=sys.stderr)
+        return False
+
+    # Try to recreate worktree from the branch
+    result = subprocess.run(
+        ["git", "worktree", "add", original_path, branch],
+        capture_output=True, text=True, cwd=str(repo_root), timeout=30,
+    )
+
+    if result.returncode != 0:
+        # Branch might not exist — fall back to just moving files back
+        print(f"git worktree add failed: {result.stderr.strip()}", file=sys.stderr)
+        print(f"Moving trash contents back to {original_path}...", file=sys.stderr)
+        try:
+            shutil.move(str(trash_path), original_path)
+            print(f"Recovered to {original_path} (as plain directory, not git worktree)")
+            return True
+        except (OSError, shutil.Error) as e:
+            print(f"Failed to move: {e}", file=sys.stderr)
+            return False
+
+    # Worktree recreated from branch — now copy any uncommitted files
+    # that were in the trash but not in the branch
+    trash_files = set()
+    for item in trash_path.rglob("*"):
+        if item.is_file() and ".git" not in item.parts:
+            rel = item.relative_to(trash_path)
+            if rel.name == ".trash_meta.json":
+                continue
+            target = Path(original_path) / rel
+            if not target.exists():
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(str(item), str(target))
+                trash_files.add(str(rel))
+
+    # Clean up trash entry
+    shutil.rmtree(str(trash_path))
+
+    print(f"Recovered to {original_path} (branch: {branch})")
+    if trash_files:
+        print(f"Restored {len(trash_files)} uncommitted file(s) from trash")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# List trash
+# ---------------------------------------------------------------------------
+
+
+def _list_trash() -> None:
+    """Show trash contents with age and metadata."""
+    if not TRASH_DIR.exists():
+        print("No trash directory found.")
+        return
+
+    entries = sorted(TRASH_DIR.iterdir())
+    if not entries:
+        print("Trash is empty.")
+        return
+
+    now = time.time()
+    print(f"{'Name':<40} {'Age':>6} {'Branch':<30} {'Original Path'}")
+    print("-" * 120)
+
+    for entry in entries:
+        if not entry.is_dir():
+            continue
+
+        meta_path = entry / ".trash_meta.json"
+        branch = ""
+        original = ""
+        age_days = 0.0
+
+        if meta_path.exists():
+            try:
+                meta = json.loads(meta_path.read_text())
+                branch = meta.get("branch", "")
+                original = meta.get("original_path", "")
+                trashed_at_str = meta.get("trashed_at", "")
+                if trashed_at_str:
+                    dt = datetime.fromisoformat(trashed_at_str)
+                    age_days = (now - dt.timestamp()) / 86400
+            except (json.JSONDecodeError, ValueError, OSError):
+                pass
+
+        if age_days == 0:
+            with contextlib.suppress(OSError):
+                age_days = (now - entry.stat().st_mtime) / 86400
+
+        purge_in = TRASH_RETENTION_DAYS - age_days
+        age_str = f"{age_days:.0f}d"
+        status = f" (purge in {purge_in:.0f}d)" if purge_in > 0 else " (OVERDUE)"
+
+        print(f"{entry.name:<40} {age_str:>6}{status}  {branch:<30} {original}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Worktree lifecycle manager")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would happen without doing it")
+    parser.add_argument("--list-trash", action="store_true",
+                        help="Show trash contents")
+    parser.add_argument("--recover", metavar="NAME",
+                        help="Recover a trashed worktree")
+    args = parser.parse_args()
+
+    if args.list_trash:
+        _list_trash()
+        return 0
+
+    repo_root = _repo_root()
+
+    if args.recover:
+        return 0 if _recover(args.recover, repo_root) else 1
+
+    # Normal run: trash stale worktrees + purge old trash
+    _log("Worktree lifecycle check starting")
+
+    worktrees = _list_worktrees(repo_root)
+    _log(f"Found {len(worktrees)} linked worktree(s)")
+
+    for wt in worktrees:
+        wt_path = wt.get("path", "")
+        branch = wt.get("branch", "unknown")
+
+        if not wt_path or not Path(wt_path).exists():
+            _log(f"SKIP {wt_path}: directory does not exist (ghost entry)")
+            continue
+
+        # Check 1: active processes
+        pids = _find_processes_in_dir(wt_path)
+        if pids:
+            pid_str = ", ".join(str(p) for p in pids[:5])
+            _log(f"SKIP {wt_path}: active processes (PIDs: {pid_str})")
+            continue
+
+        # Check 2: recent activity
+        last_activity = _last_activity_time(wt_path)
+        age_days = (time.time() - last_activity) / 86400
+        if age_days < STALE_DAYS:
+            _log(f"SKIP {wt_path}: activity {age_days:.0f}d ago (< {STALE_DAYS}d)")
+            continue
+
+        # Check 3: branch merged
+        if not _branch_is_merged(branch, repo_root):
+            _log(f"SKIP {wt_path}: branch '{branch}' not merged")
+            continue
+
+        # All checks passed — trash it
+        _trash_worktree(wt, repo_root, dry_run=args.dry_run)
+
+    # Purge old trash entries
+    _purge_old_trash(repo_root, dry_run=args.dry_run)
+
+    _log("Worktree lifecycle check complete")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_hooks/test_worktree_guard.py
+++ b/tests/test_hooks/test_worktree_guard.py
@@ -1,0 +1,258 @@
+"""Tests for worktree_cwd_guard.py — cross-session worktree protection.
+
+Tests the enhanced guard hook that:
+1. Blocks removal if another process has CWD inside the target worktree
+2. Blocks removal if the current session's CWD is the target (self-brick)
+3. Blocks ALL direct worktree removal (redirects to lifecycle manager)
+4. Handles ExitWorktree tool (--exit-worktree mode)
+
+Exit codes: 0 = allowed, 2 = blocked.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+
+def _find_guard_script() -> str:
+    """Resolve path to worktree_cwd_guard.py and return a command string."""
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        script = ancestor / "scripts" / "hooks" / "worktree_cwd_guard.py"
+        if script.exists():
+            venv_python = ancestor / ".venv" / "bin" / "python"
+            python = str(venv_python) if venv_python.exists() else "python3"
+            return f"{python} {script}"
+    raise FileNotFoundError("Could not find worktree_cwd_guard.py")
+
+
+@pytest.fixture(scope="module")
+def guard_cmd() -> str:
+    return _find_guard_script()
+
+
+def _run_guard(
+    cmd: str, tool_input: dict, extra_args: str = "", cwd: str | None = None,
+) -> subprocess.CompletedProcess:
+    """Run the guard hook with CLAUDE_TOOL_INPUT set."""
+    full_cmd = f"{cmd} {extra_args}".strip()
+    env = {**os.environ, "CLAUDE_TOOL_INPUT": json.dumps(tool_input)}
+    return subprocess.run(
+        full_cmd,
+        shell=True,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        cwd=cwd,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bash mode: non-worktree commands pass through
+# ---------------------------------------------------------------------------
+
+
+class TestBashPassthrough:
+    def test_non_worktree_command_allowed(self, guard_cmd: str) -> None:
+        result = _run_guard(guard_cmd, {"command": "ls -la"})
+        assert result.returncode == 0
+
+    def test_worktree_add_allowed(self, guard_cmd: str) -> None:
+        result = _run_guard(guard_cmd, {"command": "git worktree add /tmp/foo"})
+        assert result.returncode == 0
+
+    def test_worktree_list_allowed(self, guard_cmd: str) -> None:
+        result = _run_guard(guard_cmd, {"command": "git worktree list"})
+        assert result.returncode == 0
+
+    def test_empty_command_allowed(self, guard_cmd: str) -> None:
+        result = _run_guard(guard_cmd, {"command": ""})
+        assert result.returncode == 0
+
+    def test_empty_input_allowed(self, guard_cmd: str) -> None:
+        result = _run_guard(guard_cmd, {})
+        assert result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Bash mode: all git worktree remove is blocked
+# ---------------------------------------------------------------------------
+
+
+class TestBashBlockAll:
+    def test_worktree_remove_blocked(self, guard_cmd: str) -> None:
+        """Any git worktree remove is blocked (lifecycle manager only)."""
+        result = _run_guard(
+            guard_cmd,
+            {"command": "git worktree remove /tmp/nonexistent-worktree-xyz"},
+        )
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stderr
+
+    def test_worktree_remove_relative_blocked(self, guard_cmd: str) -> None:
+        result = _run_guard(
+            guard_cmd,
+            {"command": "git worktree remove .claude/worktrees/some-branch"},
+        )
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stderr
+
+    def test_block_message_mentions_lifecycle(self, guard_cmd: str) -> None:
+        result = _run_guard(
+            guard_cmd,
+            {"command": "git worktree remove /tmp/nonexistent-worktree-xyz"},
+        )
+        assert "lifecycle" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# Bash mode: self-CWD detection (original behavior preserved)
+# ---------------------------------------------------------------------------
+
+
+class TestBashSelfCwd:
+    def test_remove_own_cwd_blocked(self, guard_cmd: str) -> None:
+        """Removing your own CWD gives the specific brick-prevention message."""
+        cwd = os.getcwd()
+        result = _run_guard(guard_cmd, {"command": f"git worktree remove {cwd}"})
+        assert result.returncode == 2
+        assert "current working directory" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Bash mode: cross-session detection
+# ---------------------------------------------------------------------------
+
+
+class TestBashCrossSession:
+    def test_blocks_when_process_in_target(self, guard_cmd: str) -> None:
+        """Block removal when another process has CWD inside the target."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Spawn a sleep process with CWD in the target directory
+            proc = subprocess.Popen(
+                ["sleep", "60"],
+                cwd=tmpdir,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            try:
+                # Give the process a moment to start
+                time.sleep(0.1)
+                result = _run_guard(
+                    guard_cmd,
+                    {"command": f"git worktree remove {tmpdir}"},
+                )
+                assert result.returncode == 2
+                assert "BLOCKED" in result.stderr
+                assert str(proc.pid) in result.stderr
+            finally:
+                proc.terminate()
+                proc.wait(timeout=5)
+
+    def test_allows_when_no_process_in_target(self, guard_cmd: str) -> None:
+        """When no process is in the target, still blocked (lifecycle redirect).
+
+        This verifies the block-all behavior — even without conflicts,
+        direct removal is blocked in favor of the lifecycle manager.
+        """
+        result = _run_guard(
+            guard_cmd,
+            {"command": "git worktree remove /tmp/nonexistent-dir-abc123"},
+        )
+        assert result.returncode == 2
+        assert "lifecycle" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# ExitWorktree mode
+# ---------------------------------------------------------------------------
+
+
+class TestExitWorktree:
+    def test_keep_action_allowed(self, guard_cmd: str) -> None:
+        """ExitWorktree with action 'keep' always passes."""
+        result = _run_guard(
+            guard_cmd, {"action": "keep"}, extra_args="--exit-worktree",
+        )
+        assert result.returncode == 0
+
+    def test_remove_action_blocked_no_conflict(self, guard_cmd: str) -> None:
+        """ExitWorktree 'remove' blocked even when no other processes present.
+
+        Uses a tmpdir as CWD so no other process has CWD inside it.
+        Should get the 'use keep instead' message.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _run_guard(
+                guard_cmd, {"action": "remove"},
+                extra_args="--exit-worktree", cwd=tmpdir,
+            )
+            assert result.returncode == 2
+            assert "BLOCKED" in result.stderr
+            assert "keep" in result.stderr.lower()
+            assert "lifecycle" in result.stderr.lower()
+
+    def test_remove_with_cross_session_conflict(self, guard_cmd: str) -> None:
+        """ExitWorktree remove shows PIDs when other processes are in CWD."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Spawn a sleep process with CWD in the tmpdir
+            proc = subprocess.Popen(
+                ["sleep", "60"],
+                cwd=tmpdir,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            try:
+                time.sleep(0.1)
+                result = _run_guard(
+                    guard_cmd, {"action": "remove"},
+                    extra_args="--exit-worktree", cwd=tmpdir,
+                )
+                assert result.returncode == 2
+                assert "BLOCKED" in result.stderr
+                assert str(proc.pid) in result.stderr
+            finally:
+                proc.terminate()
+                proc.wait(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Fail-open behavior
+# ---------------------------------------------------------------------------
+
+
+class TestFailOpen:
+    def test_malformed_json_allowed(self, guard_cmd: str) -> None:
+        """Malformed CLAUDE_TOOL_INPUT → fail-open."""
+        env = {**os.environ, "CLAUDE_TOOL_INPUT": "not-json"}
+        result = subprocess.run(
+            guard_cmd,
+            shell=True,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0
+
+    def test_missing_env_var_allowed(self, guard_cmd: str) -> None:
+        """Missing CLAUDE_TOOL_INPUT → fail-open."""
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDE_TOOL_INPUT"}
+        result = subprocess.run(
+            guard_cmd,
+            shell=True,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0

--- a/tests/test_hooks/test_worktree_guard.py
+++ b/tests/test_hooks/test_worktree_guard.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import json
 import os
-import signal
 import subprocess
 import tempfile
 import time


### PR DESCRIPTION
## Summary

- **Cross-session guard hook**: Extends `worktree_cwd_guard.py` to scan `/proc/*/cwd` for OTHER sessions using a worktree before allowing removal. ALL direct worktree removal is now blocked — both `git worktree remove` (Bash) and ExitWorktree "remove" (CC built-in tool).
- **Lifecycle manager** (`scripts/worktree_lifecycle.py`): Automated stale worktree cleanup via daily cron. Worktrees are trashed (not deleted) when: no active processes, no activity for 14 days, and PR is merged. 7-day recovery window. CLI: `--dry-run`, `--list-trash`, `--recover`.
- **ExitWorktree interception**: New PreToolUse hook matcher for the ExitWorktree built-in tool. Blocks `action: "remove"` and guides to `action: "keep"`.

### Incident context
2026-06-09: Session B finished work in a shared worktree, user said "remove worktree" on `/exit`. Session A — still using that worktree — became a zombie. Every tool call failed with "Working directory no longer exists."

### Three safety layers
1. **Guard hook** — blocks removal if any process is using the worktree (hard guarantee)
2. **Block-all policy** — even without conflicts, redirects to lifecycle manager
3. **Trash bin** — 7-day recovery for worktrees reaped by the lifecycle manager

## Test plan
- [x] 16 new tests: passthrough, block-all, self-CWD, cross-session PID detection, ExitWorktree, fail-open (all passing)
- [x] 100 existing inline hook tests unaffected (all passing)
- [x] 360/360 total hook tests passing
- [x] E2E: cross-session detection correctly identifies PID 941743 in live worktree
- [x] E2E: ExitWorktree "keep" allowed, "remove" blocked
- [x] E2E: lifecycle `--dry-run` correctly skips active/recent worktrees
- [x] Code review: metadata write ordering fixed (staging file before move)
- [x] Daily cron installed: `0 4 * * *`

🤖 Generated with [Claude Code](https://claude.com/claude-code)