### PR TITLE
fix(campaign): wire MCP tools for standalone mode + validate outreach categories

### DIFF
--- a/scripts/genesis_mcp_server.py
+++ b/scripts/genesis_mcp_server.py
@@ -190,6 +190,19 @@ def _bootstrap_health(transport_kwargs: dict) -> None:
                     exc_info=True,
                 )
 
+            # Wire campaign tools with DB-only access.
+            # Standalone MCP provides read/update access to campaigns;
+            # trigger and schedule hot-reload require the main server.
+            try:
+                from genesis.mcp.health.campaign_tools import init_campaign_tools
+
+                init_campaign_tools(runner=None, db=db)
+            except Exception:
+                logger.warning(
+                    "Campaign tools not available in standalone MCP",
+                    exc_info=True,
+                )
+
             clear_mcp_crash("health")
             yield
         finally:

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -76,6 +76,7 @@ from genesis.mcp.health import task_tools as _task_tools  # noqa: E402
 from genesis.mcp.health import update_history as _update_history  # noqa: E402
 from genesis.mcp.health import web_tools as _web_tools  # noqa: E402, F401
 
+campaign_tools = _campaign_tools
 codebase = _codebase
 db_schema = _db_schema
 errors = _errors
@@ -129,12 +130,14 @@ _impl_direct_session_list = _direct_session_tools._impl_direct_session_list
 # Re-export init functions for runtime wiring
 init_task_tools = _task_tools.init_task_tools
 init_direct_session_tools = _direct_session_tools.init_direct_session_tools
+init_campaign_tools = _campaign_tools.init_campaign_tools
 
 __all__ = [
     "mcp",
     "init_health_mcp",
     "init_task_tools",
     "init_direct_session_tools",
+    "init_campaign_tools",
     "_service",
     "_event_bus",
     "_activity_tracker",

--- a/src/genesis/mcp/health/campaign_tools.py
+++ b/src/genesis/mcp/health/campaign_tools.py
@@ -2,6 +2,12 @@
 
 Provides campaign_create, campaign_list, campaign_status, campaign_pause,
 campaign_resume, campaign_trigger, and campaign_update.
+
+When running inside the main Genesis server, these tools use the wired
+runner/db references.  When running as a CC child process (MCP server),
+they fall back to direct DB connections for read/write operations.
+Runner-dependent operations (trigger, schedule hot-reload) return
+informational messages in standalone mode.
 """
 
 from __future__ import annotations
@@ -11,7 +17,11 @@ import json
 import logging
 import uuid
 from datetime import UTC, datetime
+from pathlib import Path
 
+import aiosqlite
+
+from genesis.db.connection import BUSY_TIMEOUT_MS
 from genesis.mcp.health import mcp
 
 logger = logging.getLogger(__name__)
@@ -20,13 +30,33 @@ logger = logging.getLogger(__name__)
 _runner = None
 _db = None
 
+# DB path for fallback connections (matches task_tools.py pattern)
+_DB_PATH = Path.home() / "genesis" / "data" / "genesis.db"
+
 
 def init_campaign_tools(*, runner, db) -> None:
-    """Wire campaign tools to their runtime dependencies."""
+    """Wire campaign tools to their runtime dependencies.
+
+    In runtime mode: both runner and db are provided.
+    In standalone MCP mode: runner=None, only db is provided.
+    """
     global _runner, _db
     _runner = runner
     _db = db
-    logger.info("Campaign MCP tools wired")
+    logger.info(
+        "Campaign MCP tools wired (db=%s, runner=%s)",
+        db is not None,
+        runner is not None,
+    )
+
+
+async def _get_db() -> aiosqlite.Connection:
+    """Open a direct DB connection for MCP fallback reads/writes."""
+    db = await aiosqlite.connect(str(_DB_PATH))
+    db.row_factory = aiosqlite.Row
+    await db.execute("PRAGMA journal_mode=WAL")
+    await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+    return db
 
 
 # ---------------------------------------------------------------------------
@@ -47,159 +77,245 @@ async def _impl_campaign_create(
     initial_state: dict | None = None,
 ) -> dict:
     """Create and activate a new campaign."""
-    if _db is None:
-        return {"error": "Database not available"}
+    db = _db
+    own_db = False
+    if db is None:
+        try:
+            db = await _get_db()
+            own_db = True
+        except Exception as exc:
+            logger.error("campaign_create DB connection failed", exc_info=True)
+            return {"error": f"Database unavailable: {type(exc).__name__}: {exc}"}
 
-    from genesis.db.crud import campaigns as crud
+    try:
+        from genesis.db.crud import campaigns as crud
 
-    existing = await crud.get_campaign_by_name(_db, name)
-    if existing:
-        return {"error": f"Campaign '{name}' already exists"}
+        existing = await crud.get_campaign_by_name(db, name)
+        if existing:
+            return {"error": f"Campaign '{name}' already exists"}
 
-    campaign_id = str(uuid.uuid4())
-    checks = json.dumps(pre_checks or ["rate_limit", "budget", "slots_available"])
-    state = json.dumps(initial_state or {})
+        campaign_id = str(uuid.uuid4())
+        checks = json.dumps(pre_checks or ["rate_limit", "budget", "slots_available"])
+        state = json.dumps(initial_state or {})
 
-    await crud.create_campaign(
-        _db,
-        id=campaign_id,
-        name=name,
-        strategy_doc_path=strategy_doc_path,
-        cron_cadence=cron_cadence,
-        model=model,
-        effort=effort,
-        session_profile=profile,
-        pre_checks=checks,
-        max_daily_cost_usd=max_daily_cost_usd,
-        state_json=state,
-        created_at=datetime.now(UTC).isoformat(),
-    )
+        await crud.create_campaign(
+            db,
+            id=campaign_id,
+            name=name,
+            strategy_doc_path=strategy_doc_path,
+            cron_cadence=cron_cadence,
+            model=model,
+            effort=effort,
+            session_profile=profile,
+            pre_checks=checks,
+            max_daily_cost_usd=max_daily_cost_usd,
+            state_json=state,
+            created_at=datetime.now(UTC).isoformat(),
+        )
 
-    # Schedule the campaign if runner is available
-    if _runner:
-        campaign = await crud.get_campaign(_db, campaign_id)
-        await _runner.add_campaign(campaign)
+        result: dict = {"id": campaign_id, "name": name, "status": "active"}
 
-    return {"id": campaign_id, "name": name, "status": "active"}
+        # Schedule the campaign if runner is available
+        if _runner:
+            campaign = await crud.get_campaign(db, campaign_id)
+            await _runner.add_campaign(campaign)
+        else:
+            result["note"] = (
+                "Campaign created in database. "
+                "Restart genesis-server to activate scheduling."
+            )
+
+        return result
+    finally:
+        if own_db:
+            await db.close()
 
 
 async def _impl_campaign_list(status_filter: str | None = None) -> dict:
     """List campaigns with status, last run, and health."""
-    if _db is None:
-        return {"error": "Database not available"}
+    db = _db
+    own_db = False
+    if db is None:
+        try:
+            db = await _get_db()
+            own_db = True
+        except Exception as exc:
+            logger.error("campaign_list DB connection failed", exc_info=True)
+            return {"error": f"Database unavailable: {type(exc).__name__}: {exc}"}
 
-    from genesis.db.crud import campaigns as crud
+    try:
+        from genesis.db.crud import campaigns as crud
 
-    campaigns = await crud.list_campaigns(_db, status_filter=status_filter)
-    items = []
-    for c in campaigns:
-        items.append({
-            "name": c["name"],
-            "status": c["status"],
-            "cadence": c["cron_cadence"],
-            "last_run": c.get("last_run_at"),
-            "total_runs": c["total_runs"],
-            "total_cost": f"${c['total_cost_usd']:.2f}",
-            "model": c["model"],
-        })
-    return {"campaigns": items, "count": len(items)}
+        campaigns = await crud.list_campaigns(db, status_filter=status_filter)
+        items = []
+        for c in campaigns:
+            items.append({
+                "name": c["name"],
+                "status": c["status"],
+                "cadence": c["cron_cadence"],
+                "last_run": c.get("last_run_at"),
+                "total_runs": c["total_runs"],
+                "total_cost": f"${c['total_cost_usd']:.2f}",
+                "model": c["model"],
+            })
+        return {"campaigns": items, "count": len(items)}
+    finally:
+        if own_db:
+            await db.close()
 
 
 async def _impl_campaign_status(name: str) -> dict:
     """Detailed status for a single campaign."""
-    if _db is None:
-        return {"error": "Database not available"}
+    db = _db
+    own_db = False
+    if db is None:
+        try:
+            db = await _get_db()
+            own_db = True
+        except Exception as exc:
+            logger.error("campaign_status DB connection failed", exc_info=True)
+            return {"error": f"Database unavailable: {type(exc).__name__}: {exc}"}
 
-    from genesis.db.crud import campaigns as crud
+    try:
+        from genesis.db.crud import campaigns as crud
 
-    campaign = await crud.get_campaign_by_name(_db, name)
-    if not campaign:
-        return {"error": f"Campaign '{name}' not found"}
+        campaign = await crud.get_campaign_by_name(db, name)
+        if not campaign:
+            return {"error": f"Campaign '{name}' not found"}
 
-    runs = await crud.list_runs(_db, campaign["id"], limit=5)
-    state = {}
-    with contextlib.suppress(json.JSONDecodeError, TypeError):
-        state = json.loads(campaign["state_json"])
+        runs = await crud.list_runs(db, campaign["id"], limit=5)
+        state = {}
+        with contextlib.suppress(json.JSONDecodeError, TypeError):
+            state = json.loads(campaign["state_json"])
 
-    # Filter internal keys from state display
-    visible_state = {k: v for k, v in state.items() if not k.startswith("_")}
+        # Filter internal keys from state display
+        visible_state = {k: v for k, v in state.items() if not k.startswith("_")}
 
-    return {
-        "name": campaign["name"],
-        "status": campaign["status"],
-        "cadence": campaign["cron_cadence"],
-        "model": campaign["model"],
-        "effort": campaign["effort"],
-        "profile": campaign["session_profile"],
-        "max_daily_cost": f"${campaign['max_daily_cost_usd']:.2f}",
-        "state": visible_state,
-        "last_run": campaign.get("last_run_at"),
-        "total_runs": campaign["total_runs"],
-        "total_cost": f"${campaign['total_cost_usd']:.2f}",
-        "recent_runs": [
-            {
-                "started": r["started_at"],
-                "outcome": r["outcome"],
-                "summary": r.get("summary", ""),
-                "cost": f"${r['cost_usd']:.2f}",
-            }
-            for r in runs
-        ],
-    }
+        return {
+            "name": campaign["name"],
+            "status": campaign["status"],
+            "cadence": campaign["cron_cadence"],
+            "model": campaign["model"],
+            "effort": campaign["effort"],
+            "profile": campaign["session_profile"],
+            "max_daily_cost": f"${campaign['max_daily_cost_usd']:.2f}",
+            "state": visible_state,
+            "last_run": campaign.get("last_run_at"),
+            "total_runs": campaign["total_runs"],
+            "total_cost": f"${campaign['total_cost_usd']:.2f}",
+            "recent_runs": [
+                {
+                    "started": r["started_at"],
+                    "outcome": r["outcome"],
+                    "summary": r.get("summary", ""),
+                    "cost": f"${r['cost_usd']:.2f}",
+                }
+                for r in runs
+            ],
+        }
+    finally:
+        if own_db:
+            await db.close()
 
 
 async def _impl_campaign_pause(name: str) -> dict:
     """Pause a campaign."""
-    if _db is None:
-        return {"error": "Database not available"}
+    db = _db
+    own_db = False
+    if db is None:
+        try:
+            db = await _get_db()
+            own_db = True
+        except Exception as exc:
+            logger.error("campaign_pause DB connection failed", exc_info=True)
+            return {"error": f"Database unavailable: {type(exc).__name__}: {exc}"}
 
-    from genesis.db.crud import campaigns as crud
+    try:
+        from genesis.db.crud import campaigns as crud
 
-    campaign = await crud.get_campaign_by_name(_db, name)
-    if not campaign:
-        return {"error": f"Campaign '{name}' not found"}
+        campaign = await crud.get_campaign_by_name(db, name)
+        if not campaign:
+            return {"error": f"Campaign '{name}' not found"}
 
-    await crud.update_campaign(
-        _db, campaign["id"],
-        status="paused",
-        paused_at=datetime.now(UTC).isoformat(),
-    )
+        await crud.update_campaign(
+            db, campaign["id"],
+            status="paused",
+            paused_at=datetime.now(UTC).isoformat(),
+        )
 
-    if _runner:
-        await _runner.remove_campaign(name)
+        if _runner:
+            await _runner.remove_campaign(name)
 
-    return {"name": name, "status": "paused"}
+        result: dict = {"name": name, "status": "paused"}
+        if not _runner:
+            result["note"] = (
+                "Paused in database. "
+                "Restart genesis-server for schedule changes to take effect."
+            )
+        return result
+    finally:
+        if own_db:
+            await db.close()
 
 
 async def _impl_campaign_resume(name: str) -> dict:
     """Resume a paused campaign."""
-    if _db is None:
-        return {"error": "Database not available"}
+    db = _db
+    own_db = False
+    if db is None:
+        try:
+            db = await _get_db()
+            own_db = True
+        except Exception as exc:
+            logger.error("campaign_resume DB connection failed", exc_info=True)
+            return {"error": f"Database unavailable: {type(exc).__name__}: {exc}"}
 
-    from genesis.db.crud import campaigns as crud
+    try:
+        from genesis.db.crud import campaigns as crud
 
-    campaign = await crud.get_campaign_by_name(_db, name)
-    if not campaign:
-        return {"error": f"Campaign '{name}' not found"}
+        campaign = await crud.get_campaign_by_name(db, name)
+        if not campaign:
+            return {"error": f"Campaign '{name}' not found"}
 
-    await crud.update_campaign(
-        _db, campaign["id"],
-        status="active",
-        paused_at=None,
-    )
+        await crud.update_campaign(
+            db, campaign["id"],
+            status="active",
+            paused_at=None,
+        )
 
-    if _runner:
-        campaign = await crud.get_campaign(_db, campaign["id"])
-        await _runner.add_campaign(campaign)
+        if _runner:
+            campaign = await crud.get_campaign(db, campaign["id"])
+            await _runner.add_campaign(campaign)
 
-    return {"name": name, "status": "active"}
+        result: dict = {"name": name, "status": "active"}
+        if not _runner:
+            result["note"] = (
+                "Resumed in database. "
+                "Restart genesis-server for schedule changes to take effect."
+            )
+        return result
+    finally:
+        if own_db:
+            await db.close()
 
 
 async def _impl_campaign_trigger(name: str) -> dict:
-    """Manually trigger a campaign tick."""
-    if _db is None or _runner is None:
-        return {"error": "Campaign runner not available"}
+    """Manually trigger a campaign tick.
 
+    Requires the main Genesis server — the campaign runner is not
+    available in standalone MCP mode.
+    """
+    if _runner is None:
+        return {
+            "error": (
+                "Campaign trigger requires the main Genesis server. "
+                "The campaign runner is not available in standalone MCP mode. "
+                "Use campaign_status to check campaign state, or restart "
+                "genesis-server to run campaigns on schedule."
+            ),
+        }
+
+    # When _runner is set, _db is guaranteed set (both wired by init_campaign_tools)
     from genesis.db.crud import campaigns as crud
 
     campaign = await crud.get_campaign_by_name(_db, name)
@@ -219,35 +335,54 @@ async def _impl_campaign_update(
     max_daily_cost_usd: float | None = None,
 ) -> dict:
     """Update campaign configuration."""
-    if _db is None:
-        return {"error": "Database not available"}
+    db = _db
+    own_db = False
+    if db is None:
+        try:
+            db = await _get_db()
+            own_db = True
+        except Exception as exc:
+            logger.error("campaign_update DB connection failed", exc_info=True)
+            return {"error": f"Database unavailable: {type(exc).__name__}: {exc}"}
 
-    from genesis.db.crud import campaigns as crud
+    try:
+        from genesis.db.crud import campaigns as crud
 
-    campaign = await crud.get_campaign_by_name(_db, name)
-    if not campaign:
-        return {"error": f"Campaign '{name}' not found"}
+        campaign = await crud.get_campaign_by_name(db, name)
+        if not campaign:
+            return {"error": f"Campaign '{name}' not found"}
 
-    updates = {}
-    if cron_cadence is not None:
-        updates["cron_cadence"] = cron_cadence
-    if model is not None:
-        updates["model"] = model
-    if effort is not None:
-        updates["effort"] = effort
-    if max_daily_cost_usd is not None:
-        updates["max_daily_cost_usd"] = max_daily_cost_usd
+        updates = {}
+        if cron_cadence is not None:
+            updates["cron_cadence"] = cron_cadence
+        if model is not None:
+            updates["model"] = model
+        if effort is not None:
+            updates["effort"] = effort
+        if max_daily_cost_usd is not None:
+            updates["max_daily_cost_usd"] = max_daily_cost_usd
 
-    if updates:
-        await crud.update_campaign(_db, campaign["id"], **updates)
+        if updates:
+            await crud.update_campaign(db, campaign["id"], **updates)
 
-        # Reschedule if cadence changed
-        if cron_cadence and _runner:
-            await _runner.remove_campaign(name)
-            updated = await crud.get_campaign(_db, campaign["id"])
-            await _runner.add_campaign(updated)
+            # Reschedule if cadence changed
+            if cron_cadence and _runner:
+                await _runner.remove_campaign(name)
+                updated = await crud.get_campaign(db, campaign["id"])
+                await _runner.add_campaign(updated)
 
-    return {"name": name, "updated": list(updates.keys())}
+        result: dict = {"name": name, "updated": list(updates.keys())}
+
+        if cron_cadence and not _runner:
+            result["note"] = (
+                "Cadence updated in database. "
+                "Restart genesis-server for schedule changes to take effect."
+            )
+
+        return result
+    finally:
+        if own_db:
+            await db.close()
 
 
 # ---------------------------------------------------------------------------

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -63,6 +63,17 @@ async def outreach_send(
     used for delivery.
     """
     if not _pipeline:
+        # Validate category before enqueuing (same check the pipeline path does)
+        from genesis.outreach.types import OutreachCategory
+
+        try:
+            OutreachCategory(category)
+        except ValueError:
+            valid = ", ".join(c.value for c in OutreachCategory)
+            return json.dumps({
+                "error": f"Invalid category '{category}'. Valid categories: {valid}",
+            })
+
         # Queue for genesis-server to pick up on next cycle
         if _db is not None:
             from genesis.db.crud import pending_outreach

--- a/tests/test_mcp/test_campaign_tools.py
+++ b/tests/test_mcp/test_campaign_tools.py
@@ -1,0 +1,224 @@
+"""Tests for campaign MCP tools — standalone fallback and runner-absent paths."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import aiosqlite
+import pytest
+
+import genesis.mcp.health.campaign_tools as ct_mod
+
+
+@pytest.fixture
+async def _test_db(tmp_path):
+    """In-memory-ish DB with campaigns + campaign_runs tables."""
+    db_path = tmp_path / "test.db"
+    db = await aiosqlite.connect(str(db_path))
+    db.row_factory = aiosqlite.Row
+    await db.execute("""
+        CREATE TABLE IF NOT EXISTS campaigns (
+            id TEXT PRIMARY KEY,
+            name TEXT UNIQUE NOT NULL,
+            strategy_doc_path TEXT NOT NULL,
+            cron_cadence TEXT NOT NULL,
+            model TEXT DEFAULT 'sonnet',
+            effort TEXT DEFAULT 'medium',
+            session_profile TEXT DEFAULT 'research',
+            status TEXT DEFAULT 'active',
+            state_json TEXT DEFAULT '{}',
+            pre_checks TEXT DEFAULT '[]',
+            max_daily_cost_usd REAL DEFAULT 1.0,
+            created_at TEXT NOT NULL,
+            paused_at TEXT,
+            last_run_at TEXT,
+            total_runs INTEGER DEFAULT 0,
+            total_cost_usd REAL DEFAULT 0.0
+        )
+    """)
+    await db.execute("""
+        CREATE TABLE IF NOT EXISTS campaign_runs (
+            id TEXT PRIMARY KEY,
+            campaign_id TEXT NOT NULL,
+            started_at TEXT NOT NULL,
+            finished_at TEXT,
+            trigger_type TEXT DEFAULT 'scheduled',
+            outcome TEXT DEFAULT 'pending',
+            skip_reason TEXT,
+            summary TEXT,
+            cost_usd REAL DEFAULT 0.0,
+            session_id TEXT,
+            state_snapshot TEXT
+        )
+    """)
+    # Seed a test campaign
+    await db.execute(
+        """INSERT INTO campaigns
+           (id, name, strategy_doc_path, cron_cadence, status, state_json,
+            max_daily_cost_usd, created_at, total_runs, total_cost_usd)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            "test-id-1", "test-campaign", "/tmp/strategy.md",
+            "0 */8 * * *", "active", '{"posts_today": 0}',
+            1.0, "2026-06-01T00:00:00+00:00", 3, 0.50,
+        ),
+    )
+    await db.commit()
+    try:
+        yield db
+    finally:
+        await db.close()
+
+
+class TestStandaloneFallback:
+    """Campaign tools should work when _db=None by using _get_db() fallback."""
+
+    @pytest.mark.asyncio
+    async def test_campaign_status_standalone(self, _test_db, tmp_path):
+        """_impl_campaign_status should fall back to _get_db when _db is None."""
+        old_db, old_runner = ct_mod._db, ct_mod._runner
+        try:
+            ct_mod._db = None
+            ct_mod._runner = None
+            # Patch _get_db to return our test DB
+            with patch.object(ct_mod, "_get_db", return_value=_test_db):
+                result = await ct_mod._impl_campaign_status("test-campaign")
+            assert "error" not in result
+            assert result["name"] == "test-campaign"
+            assert result["cadence"] == "0 */8 * * *"
+            assert result["status"] == "active"
+            assert result["total_runs"] == 3
+        finally:
+            ct_mod._db = old_db
+            ct_mod._runner = old_runner
+
+    @pytest.mark.asyncio
+    async def test_campaign_list_standalone(self, _test_db):
+        """_impl_campaign_list should fall back to _get_db when _db is None."""
+        old_db, old_runner = ct_mod._db, ct_mod._runner
+        try:
+            ct_mod._db = None
+            ct_mod._runner = None
+            with patch.object(ct_mod, "_get_db", return_value=_test_db):
+                result = await ct_mod._impl_campaign_list()
+            assert "error" not in result
+            assert result["count"] == 1
+            assert result["campaigns"][0]["name"] == "test-campaign"
+        finally:
+            ct_mod._db = old_db
+            ct_mod._runner = old_runner
+
+    @pytest.mark.asyncio
+    async def test_campaign_status_not_found(self, _test_db):
+        """Should return error for non-existent campaign."""
+        old_db, old_runner = ct_mod._db, ct_mod._runner
+        try:
+            ct_mod._db = None
+            ct_mod._runner = None
+            with patch.object(ct_mod, "_get_db", return_value=_test_db):
+                result = await ct_mod._impl_campaign_status("nonexistent")
+            assert "error" in result
+            assert "not found" in result["error"]
+        finally:
+            ct_mod._db = old_db
+            ct_mod._runner = old_runner
+
+
+class TestRunnerAbsent:
+    """Tests for operations when _runner is None (standalone MCP mode)."""
+
+    @pytest.mark.asyncio
+    async def test_campaign_trigger_without_runner(self):
+        """_impl_campaign_trigger should return helpful error without runner."""
+        old_db, old_runner = ct_mod._db, ct_mod._runner
+        try:
+            ct_mod._db = None
+            ct_mod._runner = None
+            result = await ct_mod._impl_campaign_trigger("test-campaign")
+            assert "error" in result
+            assert "main Genesis server" in result["error"]
+            assert "campaign_status" in result["error"]
+        finally:
+            ct_mod._db = old_db
+            ct_mod._runner = old_runner
+
+    @pytest.mark.asyncio
+    async def test_campaign_update_cadence_without_runner(self, _test_db, tmp_path):
+        """Cadence update should succeed in DB and include restart note."""
+        db_path = tmp_path / "test.db"
+        old_db, old_runner = ct_mod._db, ct_mod._runner
+        try:
+            ct_mod._db = None
+            ct_mod._runner = None
+            # _get_db returns the test DB; own_db=True will close it after use
+            with patch.object(ct_mod, "_get_db", return_value=_test_db):
+                result = await ct_mod._impl_campaign_update(
+                    "test-campaign", cron_cadence="0 */12 * * *",
+                )
+            assert "error" not in result
+            assert "cron_cadence" in result["updated"]
+            assert "note" in result
+            assert "Restart genesis-server" in result["note"]
+
+            # Verify DB was actually updated (re-open since own_db closed it)
+            async with aiosqlite.connect(str(db_path)) as verify_db:
+                verify_db.row_factory = aiosqlite.Row
+                cursor = await verify_db.execute(
+                    "SELECT cron_cadence FROM campaigns WHERE name = ?",
+                    ("test-campaign",),
+                )
+                row = await cursor.fetchone()
+                assert row["cron_cadence"] == "0 */12 * * *"
+        finally:
+            ct_mod._db = old_db
+            ct_mod._runner = old_runner
+
+    @pytest.mark.asyncio
+    async def test_campaign_pause_without_runner(self, _test_db):
+        """Pause should succeed in DB and include note when runner absent."""
+        old_db, old_runner = ct_mod._db, ct_mod._runner
+        try:
+            ct_mod._db = None
+            ct_mod._runner = None
+            with patch.object(ct_mod, "_get_db", return_value=_test_db):
+                result = await ct_mod._impl_campaign_pause("test-campaign")
+            assert result["status"] == "paused"
+            assert "note" in result
+            assert "Restart genesis-server" in result["note"]
+        finally:
+            ct_mod._db = old_db
+            ct_mod._runner = old_runner
+
+    @pytest.mark.asyncio
+    async def test_campaign_resume_without_runner(self, _test_db):
+        """Resume should succeed in DB and include note when runner absent."""
+        old_db, old_runner = ct_mod._db, ct_mod._runner
+        try:
+            ct_mod._db = None
+            ct_mod._runner = None
+            with patch.object(ct_mod, "_get_db", return_value=_test_db):
+                result = await ct_mod._impl_campaign_resume("test-campaign")
+            assert result["status"] == "active"
+            assert "note" in result
+        finally:
+            ct_mod._db = old_db
+            ct_mod._runner = old_runner
+
+
+class TestWiredDbPath:
+    """When _db is wired (e.g., via init_campaign_tools), _get_db is not called."""
+
+    @pytest.mark.asyncio
+    async def test_campaign_status_uses_wired_db(self, _test_db):
+        """When _db is set, _get_db should NOT be called."""
+        old_db, old_runner = ct_mod._db, ct_mod._runner
+        try:
+            ct_mod._db = _test_db
+            ct_mod._runner = None
+            with patch.object(ct_mod, "_get_db") as mock_get:
+                result = await ct_mod._impl_campaign_status("test-campaign")
+            mock_get.assert_not_called()
+            assert result["name"] == "test-campaign"
+        finally:
+            ct_mod._db = old_db
+            ct_mod._runner = old_runner

--- a/tests/test_mcp/test_outreach_mcp.py
+++ b/tests/test_mcp/test_outreach_mcp.py
@@ -188,3 +188,50 @@ async def test_outreach_poll_http_error():
     data = json.loads(result)
     assert "error" in data
     assert "403" in data["error"]
+
+
+# ── standalone category validation tests ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_standalone_invalid_category():
+    """Standalone path should reject invalid categories before enqueuing."""
+    mock_db = AsyncMock()
+    old_pipeline, old_db = mcp_mod._pipeline, mcp_mod._db
+    try:
+        mcp_mod._pipeline = None
+        mcp_mod._db = mock_db
+        tools = await mcp.get_tools()
+        result = await tools["outreach_send"].fn(
+            message="Test", category="discord", channel="discord",
+        )
+        data = json.loads(result)
+        assert "error" in data
+        assert "Invalid category" in data["error"]
+        assert "discord" in data["error"]
+        # Verify DB was NOT called (message not enqueued)
+        mock_db.execute.assert_not_called()
+    finally:
+        mcp_mod._pipeline = old_pipeline
+        mcp_mod._db = old_db
+
+
+@pytest.mark.asyncio
+async def test_send_standalone_valid_category():
+    """Standalone path should accept valid categories and enqueue."""
+    old_pipeline, old_db = mcp_mod._pipeline, mcp_mod._db
+    try:
+        mcp_mod._pipeline = None
+        mcp_mod._db = AsyncMock()
+        with patch("genesis.db.crud.pending_outreach.ensure_table", new_callable=AsyncMock), \
+             patch("genesis.db.crud.pending_outreach.enqueue", new_callable=AsyncMock, return_value="pending-123"):
+            tools = await mcp.get_tools()
+            result = await tools["outreach_send"].fn(
+                message="Test post", category="content", channel="discord",
+            )
+        data = json.loads(result)
+        assert data["status"] == "queued"
+        assert data["pending_id"] == "pending-123"
+    finally:
+        mcp_mod._pipeline = old_pipeline
+        mcp_mod._db = old_db


### PR DESCRIPTION
## Summary

- **Campaign MCP tools now work from CC sessions** — `campaign_status`, `campaign_update`, `campaign_list`, etc. no longer return "Database not available". Added `_get_db()` fallback (matching the proven `task_tools.py` pattern) so all read/write ops work in standalone MCP mode. Runner-dependent ops (`campaign_trigger`) return helpful messages.
- **Outreach category validation** — standalone `outreach_send` path now validates `OutreachCategory` before enqueuing to `pending_outreach`, preventing invalid categories like "discord" from entering the queue and triggering drain warnings.
- **Discord strategy doc** — disabled reactive section (campaign sessions lack Discord read access), added valid category documentation, reduced daily post limit 3→2, removed completed one-time Opus 4.6 section.

## Test plan

- [x] 8 new campaign_tools tests (standalone fallback, runner-absent, wired-db paths)
- [x] 2 new outreach_mcp tests (invalid + valid category in standalone mode)
- [x] All 19 tests pass, ruff clean
- [x] E2E verification against live DB — `campaign_status` returns real data via `_get_db()` fallback
- [ ] CI passes
- [ ] After merge: restart genesis-server for cadence change (8h→12h) to take effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)