### PR TITLE
chore: bump Claude Code 2.1.160 → 2.1.170 and fix background-session transcript path

### DIFF
--- a/docs/reference/cc-compatibility.md
+++ b/docs/reference/cc-compatibility.md
@@ -15,7 +15,7 @@
 
 ## Current CC Version
 
-**Installed:** Claude Code 2.1.170 (upgraded 2026-06-10 from 2.1.160 — adds Fable 5 access + inherited-env transcript fix)
+**Installed:** Claude Code 2.1.170 — **container + host VM** (both upgraded 2026-06-10 from 2.1.160 — adds Fable 5 access + inherited-env transcript fix). Container via npm (`--prefix /usr/local`); host via native installer (`claude install 2.1.170`).
 **Pin in scripts:** `CC_VERSION=2.1.170` in `scripts/install.sh` and `scripts/host-setup.sh`
 **Minimum required by Genesis:** Not yet formalized (all current code works with 2.0+).
 `requiredMinimumVersion`/`requiredMaximumVersion` (2.1.163) were evaluated as a way
@@ -206,19 +206,30 @@ Running `sudo npm install -g` without `--prefix /usr/local` lands in `/usr/lib/`
 does not update the `claude` binary on PATH. **`scripts/install.sh` now passes
 `--prefix /usr/local` automatically** — manual upgrades still need it.
 
-**Host VM variation:** The host VM uses CC's **native installer** (stores versioned
-binaries in `~/.local/share/claude/versions/`). On host VMs with this setup, install
-without `--prefix`:
+**Host VM variation (verified 2026-06-10):** The host VM uses CC's **native
+installer** — NOT npm. Versioned binaries live in `~/.local/share/claude/versions/`
+with `~/.local/bin/claude` a symlink to the active version. **Do NOT `npm install`
+on the host** — npm and the native installer conflict. Update to a specific version
+with the native installer's own command (use the full path, since `~/.local/bin` is
+usually not on the host's login/SSH PATH):
 ```bash
-sudo env "PATH=$PATH" npm install -g @anthropic-ai/claude-code@<version>
+"$HOME/.local/bin/claude" install <version>   # e.g. 2.1.170 — repoints the symlink, keeps old versions for rollback
+"$HOME/.local/bin/claude" --version           # verify
 ```
-The `env "PATH=$PATH"` is needed when npm is installed via nvm (not in sudo's secure
-PATH). If the native installer's postinstall fails to download the new binary,
-manually update the symlink:
+Rollback is just `claude install <old-version>` (prior versions remain in
+`versions/`). `DISABLE_AUTOUPDATER=1` is set on the host, so updates are manual.
+
+**Host CC reachability — important:** The host's login/SSH shell PATH does NOT
+include `~/.local/bin`, so a bare `claude --version` over SSH (and the Guardian
+gateway's `version` op) reports `"unavailable"` even when CC is installed and fine.
+What matters is that the **`genesis-guardian.service` systemd unit explicitly sets
+`PATH=$HOME/.local/bin:...`**, so Guardian diagnosis (`cc.path: "claude"`)
+resolves the binary correctly. Verify the real state with:
 ```bash
-ln -sf ~/.nvm/versions/node/<version>/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe \
-  ~/.local/bin/claude
+env -i PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin" claude --version
 ```
+The host CC binary is managed separately from the Genesis→Guardian *code* sync
+(`redeploy`/`update` gateway verbs sync code only, never the CC binary).
 
 ### Auto-Updater Suppression Requires User-Level Settings
 

--- a/docs/reference/cc-compatibility.md
+++ b/docs/reference/cc-compatibility.md
@@ -9,15 +9,20 @@
 > through 8 evaluation lenses (see analyzer prompt for details). This document
 > is updated manually after each evaluation.
 >
-> Created: 2026-03-09 | Last updated: 2026-06-02
+> Created: 2026-03-09 | Last updated: 2026-06-10
 
 ---
 
 ## Current CC Version
 
-**Installed:** Claude Code 2.1.160 (upgraded 2026-06-01 from 2.1.138 — enables Opus 4.8)
-**Pin in scripts:** `CC_VERSION=2.1.160` in `scripts/install.sh` and `scripts/host-setup.sh`
-**Minimum required by Genesis:** Not yet formalized (all current code works with 2.0+)
+**Installed:** Claude Code 2.1.170 (upgraded 2026-06-10 from 2.1.160 — adds Fable 5 access + inherited-env transcript fix)
+**Pin in scripts:** `CC_VERSION=2.1.170` in `scripts/install.sh` and `scripts/host-setup.sh`
+**Minimum required by Genesis:** Not yet formalized (all current code works with 2.0+).
+`requiredMinimumVersion`/`requiredMaximumVersion` (2.1.163) were evaluated as a way
+to enforce a floor, but they are **managed-settings-only** (read only from
+`/etc/claude-code/managed-settings.json` on Linux — never from user/project
+`settings.json`). Formalizing a floor would require a system-level managed-settings
+file + install-script automation; deferred as a separate follow-up.
 
 ---
 
@@ -154,6 +159,13 @@ When a new CC version is released, run through this:
 | 2.1.157 | — | Fix tmux copy-on-select regression | Relevant for Linux/tmux users |
 | 2.1.159 | 2026-06-01 | Opus 4.8 stable | Tested — all 8 integration tests passed; CCInvoker E2E verified |
 | 2.1.160 | 2026-06-01 | Current `latest` tag (promoted from `next` mid-upgrade) | **Upgraded to this version.** Auto-updater bumped from 2.1.159 in flight. Re-verified E2E via CCInvoker for Sonnet and Opus 4.8. |
+| 2.1.161 | 2026-06-10 | Fixes `--output-format json`/`text` stdout corruption from background subagents; parallel-tool failures no longer cancel sibling calls; background sessions no longer boot a stale model from daemon env; `claude mcp` secret redaction | **Benefits Genesis** (json output + per-session `--model` pinning). No action. |
+| 2.1.162 | 2026-06-10 | `claude agents --json waitingFor`; WebFetch permission precedence for preapproved domains; MCP sub-1000 ms timeout fix; read-only config-dir hang fix | Additive/fixes. Genesis blocks WebFetch via a hook, not `WebFetch()` rules — no impact. |
+| 2.1.163 | 2026-06-10 | `requiredMinimumVersion`/`requiredMaximumVersion` (**managed-settings only**); `/plugin list`; Stop/SubagentStop hooks gain `additionalContext`; hook `if:"Bash(...)"` now matches inside subshells/backticks | Version floor noted (managed-only — deferred, see Current CC Version). Genesis hooks use tool-name `matcher`s, not `if:` command conditions — `if:` change does not apply. |
+| 2.1.165, 2.1.167–2.1.168 | — | Bug fixes and reliability improvements | No action |
+| 2.1.166 | 2026-06-10 | `fallbackModel` (up to 3 fallbacks); glob patterns in deny tool-name position; hardened cross-session `SendMessage` authority; thinking-disable on think-by-default models | `fallbackModel` deliberately **not** adopted — silent auto-degrade conflicts with "quality over cost." Glob deny redundant with `bash_safety_hook.sh`. |
+| 2.1.169 | 2026-06-10 | `--safe-mode`/`CLAUDE_CODE_SAFE_MODE`; `/cd`; `disableBundledSkills`; `--mcp-config` + managed-MCP enforcement fixes; background sessions preserve `--bare`/`--ide` across retire→wake; project-env (`ANTHROPIC_MODEL`) honored on pre-warmed workers | Fixes touch flags Genesis uses (`--mcp-config`, `--bare`). Smoke-tested post-upgrade. No config change. |
+| 2.1.170 | 2026-06-10 | **Claude Fable 5 (Mythos-class)** model access; fixed sessions not saving transcripts (and missing from `--resume`) when launched from a shell that inherited CC env vars | **Upgraded to this version.** Fable 5 → separate eval follow-up (background sessions pin `--model`, so no leak). Transcript fix benefits Genesis background sessions (inherited-env spawn path). |
 
 ---
 

--- a/genesis-container-setup.md
+++ b/genesis-container-setup.md
@@ -148,7 +148,7 @@ curl -s http://localhost:6333/collections | jq .
 ## Step 10: Claude Code
 
 ```bash
-npm install -g @anthropic-ai/claude-code@2.1.160
+npm install -g @anthropic-ai/claude-code@2.1.170
 ```
 
 ## Step 11: Verification

--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -1133,7 +1133,7 @@ if [ "$_host_node_ok" = "0" ]; then
     fi
 fi
 
-CC_VERSION="${CC_VERSION:-2.1.160}"  # CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1 fixes scrollback (added in PR #479)
+CC_VERSION="${CC_VERSION:-2.1.170}"  # CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1 fixes scrollback (added in PR #479)
 if ! command -v claude &>/dev/null; then
     echo "  Installing Claude Code v${CC_VERSION} on host..."
     if command -v npm &>/dev/null; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,7 +21,7 @@
 #   OLLAMA_EMBEDDING_MODEL — Ollama embedding model (default: qwen3-embedding:0.6b-fp16)
 #   GENESIS_ENABLE_OLLAMA  — Enable local Ollama (default: false; cloud is default)
 #   QDRANT_VERSION         — Qdrant version to install if missing (default: 1.14.0)
-#   CC_VERSION             — Claude Code version to install (default: 2.1.160)
+#   CC_VERSION             — Claude Code version to install (default: 2.1.170)
 #   GH_VERSION             — gh CLI version if pkg-mgr fails (default: 2.65.0)
 #   RIPGREP_VERSION        — ripgrep version if pkg-mgr fails (default: 14.1.1)
 #   NODE_MAJOR             — Node.js major version (default: 20)
@@ -1144,7 +1144,7 @@ echo ""
 # ══════════════════════════════════════════════════════════════
 #  Step 12 — Claude Code install + login
 # ══════════════════════════════════════════════════════════════
-CC_VERSION="${CC_VERSION:-2.1.160}"  # CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1 fixes scrollback (added in PR #479)
+CC_VERSION="${CC_VERSION:-2.1.170}"  # CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1 fixes scrollback (added in PR #479)
 echo "  [12/$TOTAL_STEPS] Setting up Claude Code (v${CC_VERSION})..."
 
 if command -v claude &>/dev/null; then

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -35,6 +35,7 @@ from genesis.cc.types import (
     SessionType,
     StreamEvent,
     background_session_dir,
+    cc_project_key,
 )
 from genesis.observability.session_context import set_session_id as _set_obs_session
 from genesis.util.tasks import tracked_task
@@ -836,19 +837,18 @@ class DirectSessionRunner:
 
         # Derive transcript path from CC's project-key convention:
         # working_dir ~/.genesis/background-sessions → project key
-        # -home-ubuntu--genesis-background-sessions → transcript .jsonl
+        # -home-ubuntu--genesis-background-sessions → transcript .jsonl.
+        # NOTE: CC encodes EVERY non-alphanumeric char (incl. the leading
+        # dot of ~/.genesis) as '-', so use cc_project_key — a bare
+        # .replace("/", "-") leaves the dot and yields a wrong path.
         transcript_path = ""
         if result.cc_session_id:
             from pathlib import Path
 
-            project_key = (
-                background_session_dir()
-                .replace("/", "-")
-                .lstrip("-")
-            )
+            project_key = cc_project_key(background_session_dir())
             transcript_path = str(
                 Path.home() / ".claude" / "projects"
-                / f"-{project_key}" / f"{result.cc_session_id}.jsonl"
+                / project_key / f"{result.cc_session_id}.jsonl"
             )
 
         existing.update({

--- a/src/genesis/cc/types.py
+++ b/src/genesis/cc/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -153,6 +154,23 @@ def background_session_dir() -> str:
     """
     _BACKGROUND_SESSION_DIR.mkdir(parents=True, exist_ok=True)
     return str(_BACKGROUND_SESSION_DIR)
+
+
+def cc_project_key(working_dir: str) -> str:
+    """Claude Code's project-key encoding for a working-directory path.
+
+    CC names each project's transcript directory under
+    ``~/.claude/projects/`` by replacing every non-alphanumeric character
+    in the absolute path with ``-`` (consecutive separators are NOT
+    collapsed).  e.g. ``/home/u/.genesis/background-sessions`` →
+    ``-home-u--genesis-background-sessions`` (the ``/.`` becomes ``--``).
+
+    Replicating the FULL encoding (not just ``/`` → ``-``) matters because
+    the background-session dir is ``~/.genesis/...``: the leading dot must
+    be encoded too, or the derived transcript path is wrong and downstream
+    readers (audit, bookmark enrichment) silently miss the transcript.
+    """
+    return re.sub(r"[^A-Za-z0-9]", "-", working_dir)
 
 
 @dataclass(frozen=True)

--- a/tests/test_cc/test_types.py
+++ b/tests/test_cc/test_types.py
@@ -12,7 +12,24 @@ from genesis.cc.types import (
     SessionType,
     StreamEvent,
     background_session_dir,
+    cc_project_key,
 )
+
+
+def test_cc_project_key_encodes_slashes_and_dots():
+    # CC names the transcript dir under ~/.claude/projects/ by mapping
+    # EVERY non-alphanumeric char in the abs working-dir path to '-'
+    # (no collapsing). The leading dot of ~/.genesis must become '-',
+    # yielding a double-dash. The old bug only replaced '/', leaving the
+    # dot intact and producing a wrong (nonexistent) path.
+    assert (
+        cc_project_key("/home/ubuntu/.genesis/background-sessions")
+        == "-home-ubuntu--genesis-background-sessions"
+    )
+
+
+def test_cc_project_key_preserves_existing_dashes():
+    assert cc_project_key("/a/b-c/d") == "-a-b-c-d"
 
 
 def test_enums_have_expected_values():


### PR DESCRIPTION
## What

- **Bump pinned Claude Code 2.1.160 → 2.1.170** (install scripts + setup docs). New installs get 2.1.170, which adds Claude Fable 5 access and fixes transcript saving for sessions launched from a shell that inherited Claude Code environment variables.
- **Fix background-session transcript path derivation.** The project-key encoding only replaced `/` and left the leading dot of `~/.genesis` intact, so the stored transcript path pointed at a nonexistent directory — downstream transcript readers (audit, bookmark enrichment) silently found nothing. Now replicates Claude Code's full encoding via a new `cc_project_key()` helper.
- **Correct the host-VM update docs** to the native-installer method (`claude install <version>`); npm conflicts with the native installer on hosts that use it.

## Why

- Keep installs on a current, verified Claude Code release.
- Background-session transcripts are now reliably located by Genesis.

## Verification

- 2.1.170 installed and verified on both reference environments (live `claude -p` round-trip + targeted CC integration tests; a real background session spawned and saved its transcript).
- Transcript-path fix written test-first (TDD): unit tests assert the encoding (incl. the dot case that the old code missed); CC test suite green; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)