### PR TITLE
fix(voice): pipecat 1.3.0 audio path — transport audio flags, stale-socket guard, deploy fixes

### DIFF
--- a/src/genesis/channels/voice/s2s_bridge/Dockerfile
+++ b/src/genesis/channels/voice/s2s_bridge/Dockerfile
@@ -3,13 +3,13 @@
 # Override with: --build-arg BUILD_FROM=ghcr.io/home-assistant/aarch64-base:latest
 ARG BUILD_FROM=ghcr.io/home-assistant/aarch64-base:latest
 
-# Build stage - install dependencies with pip using pre-built wheels
+# Build stage - compile native deps then install Python packages
 FROM ${BUILD_FROM} AS builder
 
 # Set shell (use sh for Alpine, bash will be installed)
 SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 
-# Install build dependencies + gcompat (enables manylinux wheel support on Alpine)
+# Install build dependencies + LLVM 20 from Alpine edge (required by llvmlite 0.47.0)
 RUN \
     apk add --no-cache \
         bash \
@@ -21,8 +21,13 @@ RUN \
         curl \
         gcc \
         g++ \
-        gcompat \
-        libstdc++
+        make \
+        cmake \
+        libstdc++ \
+    && apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
+        llvm20-dev llvm20-static \
+    && ln -sf /usr/lib/llvm20/bin/llvm-config /usr/bin/llvm-config \
+    && /usr/bin/llvm-config --version
 
 # Switch to bash after installation
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -38,11 +43,16 @@ COPY pyproject.toml poetry.lock* /tmp/
 RUN mkdir -p /tmp/genesis_voice_bridge
 COPY app/ /tmp/genesis_voice_bridge/app/
 
-# Install dependencies using Poetry (pre-built manylinux wheels via gcompat)
+# Install dependencies — pre-install llvmlite from source (needs LLVM),
+# then let Poetry handle the rest
 WORKDIR /tmp
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 ENV POETRY_VIRTUALENVS_CREATE=false
-RUN poetry install --only=main --no-root --no-interaction --no-ansi \
+RUN LLVM_CONFIG=/usr/bin/llvm-config \
+    pip3 install --no-cache-dir --break-system-packages --no-build-isolation \
+    "llvmlite==0.47.0"
+RUN LLVM_CONFIG=/usr/bin/llvm-config \
+    poetry install --only=main --no-root --no-interaction --no-ansi \
     && rm -f pyproject.toml \
     && rm -rf genesis_voice_bridge/
 
@@ -59,7 +69,6 @@ FROM ${BUILD_FROM}
 SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 
 # Install only runtime dependencies (bash first for compatibility)
-# gcompat enables manylinux wheel binaries (numba, onnxruntime, llvmlite)
 RUN \
     apk add --no-cache \
         bash \
@@ -69,7 +78,6 @@ RUN \
         ffmpeg \
         alsa-lib \
         alsa-utils \
-        gcompat \
         libstdc++
 
 # Switch to bash after installation

--- a/src/genesis/channels/voice/s2s_bridge/Dockerfile
+++ b/src/genesis/channels/voice/s2s_bridge/Dockerfile
@@ -9,7 +9,7 @@ FROM ${BUILD_FROM} AS builder
 # Set shell (use sh for Alpine, bash will be installed)
 SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 
-# Install build dependencies + LLVM 20 from Alpine edge (required by llvmlite 0.47.0)
+# Install build dependencies (no LLVM — we skip numba/llvmlite, incompatible with Py3.14)
 RUN \
     apk add --no-cache \
         bash \
@@ -21,40 +21,62 @@ RUN \
         curl \
         gcc \
         g++ \
-        make \
-        cmake \
-        libstdc++ \
-    && apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main \
-        llvm20-dev llvm20-static \
-    && ln -sf /usr/lib/llvm20/bin/llvm-config /usr/bin/llvm-config \
-    && /usr/bin/llvm-config --version
+        libstdc++
 
 # Switch to bash after installation
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install Poetry
-RUN \
-    pip3 install --no-cache-dir --break-system-packages poetry \
-    && poetry config virtualenvs.create false \
-    && poetry config virtualenvs.in-project false
-
-# Copy Poetry configuration files
-COPY pyproject.toml poetry.lock* /tmp/
+# Copy app for later staging
 RUN mkdir -p /tmp/genesis_voice_bridge
 COPY app/ /tmp/genesis_voice_bridge/app/
 
-# Install dependencies — pre-install llvmlite from source (needs LLVM),
-# then let Poetry handle the rest
+# Install dependencies via pip — deterministic path that skips native deps.
+# numba/llvmlite/onnxruntime/resampy are incompatible with Python 3.14 in
+# HA base image and unused at runtime (we use server-side SemanticTurnDetection,
+# not local Silero VAD or resampy resampler).
 WORKDIR /tmp
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
-ENV POETRY_VIRTUALENVS_CREATE=false
-RUN LLVM_CONFIG=/usr/bin/llvm-config \
-    pip3 install --no-cache-dir --break-system-packages --no-build-isolation \
-    "llvmlite==0.47.0"
-RUN LLVM_CONFIG=/usr/bin/llvm-config \
-    poetry install --only=main --no-root --no-interaction --no-ansi \
-    && rm -f pyproject.toml \
-    && rm -rf genesis_voice_bridge/
+# Step 1: Install pipecat without dependencies
+RUN pip3 install --no-cache-dir --break-system-packages --no-deps \
+    "pipecat-ai[openai,websocket]==1.3.0"
+# Step 2: Install all runtime deps we actually need (excluding native-compiled ones)
+RUN pip3 install --no-cache-dir --break-system-packages \
+    openai "websockets>=13.0" "fastapi>=0.115.0" "uvicorn[standard]>=0.23.0" \
+    python-dotenv httpx \
+    aiohttp aiofiles pydantic loguru numpy Pillow protobuf \
+    nltk Markdown soxr pyloudnorm docstring_parser
+# Stub onnxruntime — pipecat imports it for local SmartTurn VAD but we use
+# server-side SemanticTurnDetection. No wheels exist for Alpine/musl.
+RUN PYTHON_SITE=$(python3 -c "import site; print(site.getsitepackages()[0])") \
+    && mkdir -p "$PYTHON_SITE/onnxruntime" \
+    && cat > "$PYTHON_SITE/onnxruntime/__init__.py" << 'STUB'
+"""Stub onnxruntime — real package unavailable on Alpine musl.
+Local SmartTurn VAD is disabled; server-side SemanticTurnDetection is used instead.
+"""
+
+class _StubMeta(type):
+    """Metaclass that returns stubs for any class-level attribute access."""
+    def __getattr__(cls, name):
+        return _Stub()
+
+class _Stub(metaclass=_StubMeta):
+    """Callable stub that accepts any args and returns itself."""
+    def __init__(self, *args, **kwargs): pass
+    def __call__(self, *args, **kwargs): return self
+    def __getattr__(self, name): return _Stub()
+    def __iter__(self): return iter([])
+    def __bool__(self): return False
+    def __int__(self): return 0
+    def __str__(self): return ""
+
+InferenceSession = _Stub
+SessionOptions = _Stub
+GraphOptimizationLevel = _Stub
+ExecutionMode = _Stub
+get_available_providers = lambda: []
+STUB
+# Cleanup
+RUN rm -rf genesis_voice_bridge/
 
 # Stage installed packages into a known directory for clean COPY
 RUN mkdir -p /staging/site-packages /staging/bin \

--- a/src/genesis/channels/voice/s2s_bridge/app/main.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/main.py
@@ -178,13 +178,16 @@ class Application:
                         logger.info(f"✅ OpenAI session reset for client {client_id}")
                     except Exception as e:
                         logger.warning(f"⚠️ Session reset failed, reconnecting: {e}")
-                        # Fallback: just reconnect (session.created will re-send config)
+                        self.openai_service._llm_needs_conversation_setup = True
                         await self.openai_service._connect()
                 else:
                     # No context yet (first-ever client, or service was just created).
-                    # Just connect — session.created fires on every new WS connection
-                    # and triggers _update_settings() to send tools/instructions.
+                    # Reset conversation setup flag so instructions and tools are sent
+                    # after session.created → session.updated cycle completes.
+                    # Without this, _create_response() skips conversation setup and
+                    # OpenAI has no context to generate audio from → silence.
                     logger.info(f"🔗 Connecting OpenAI session for client {client_id}...")
+                    self.openai_service._llm_needs_conversation_setup = True
                     await self.openai_service._connect()
                     logger.info(f"✅ OpenAI session connected for client {client_id}")
 

--- a/src/genesis/channels/voice/s2s_bridge/app/session_manager.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/session_manager.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from pipecat.frames.frames import Frame, LLMMessagesUpdateFrame, StartFrame
 from pipecat.processors.aggregators.llm_context import LLMContext
-from pipecat.processors.aggregators.llm_response_universal import LLMContextAggregatorPair
+from pipecat.processors.aggregators.llm_response_universal import LLMContextAggregatorPair, LLMUserAggregatorParams
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.services.openai.realtime.llm import OpenAIRealtimeLLMService
 
@@ -205,7 +205,12 @@ class SessionManager:
             LLMContextAggregatorPair with cached or new context
         """
         context = self.create_context_for_new_session(client_id)
-        aggregator_pair = LLMContextAggregatorPair(context)
+        # Disable local turn strategies — we use server-side SemanticTurnDetection
+        # (avoids onnxruntime dependency which is incompatible with HA's Python)
+        aggregator_pair = LLMContextAggregatorPair(
+            context,
+            user_params=LLMUserAggregatorParams(user_turn_strategies=None),
+        )
         self.set_context_aggregator(client_id, aggregator_pair)
         return aggregator_pair
 

--- a/src/genesis/channels/voice/s2s_bridge/app/session_manager.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/session_manager.py
@@ -5,10 +5,13 @@ from typing import Optional
 
 from pipecat.frames.frames import Frame, LLMMessagesUpdateFrame, StartFrame
 from pipecat.processors.aggregators.llm_context import LLMContext
-from pipecat.processors.aggregators.llm_response_universal import LLMContextAggregatorPair, LLMUserAggregatorParams
-from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
+)
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.services.openai.realtime.llm import OpenAIRealtimeLLMService
+from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies
 
 logger = logging.getLogger(__name__)
 

--- a/src/genesis/channels/voice/s2s_bridge/app/session_manager.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/session_manager.py
@@ -6,6 +6,7 @@ from typing import Optional
 from pipecat.frames.frames import Frame, LLMMessagesUpdateFrame, StartFrame
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.aggregators.llm_response_universal import LLMContextAggregatorPair, LLMUserAggregatorParams
+from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.services.openai.realtime.llm import OpenAIRealtimeLLMService
 
@@ -205,11 +206,14 @@ class SessionManager:
             LLMContextAggregatorPair with cached or new context
         """
         context = self.create_context_for_new_session(client_id)
-        # Disable local turn strategies — we use server-side SemanticTurnDetection
-        # (avoids onnxruntime dependency which is incompatible with HA's Python)
+        # Use external turn strategies — OpenAI Realtime's SemanticTurnDetection
+        # controls turns server-side. This also avoids the onnxruntime dependency
+        # (local SmartTurn) which is unavailable on HA's Alpine/musl.
         aggregator_pair = LLMContextAggregatorPair(
             context,
-            user_params=LLMUserAggregatorParams(user_turn_strategies=None),
+            user_params=LLMUserAggregatorParams(
+                user_turn_strategies=ExternalUserTurnStrategies(),
+            ),
         )
         self.set_context_aggregator(client_id, aggregator_pair)
         return aggregator_pair

--- a/src/genesis/channels/voice/s2s_bridge/app/websocket_handler.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/websocket_handler.py
@@ -81,6 +81,10 @@ class WebSocketHandler:
         self.pipeline: Pipeline | None = None
         self.runner: PipelineRunner | None = None
         self.current_task: PipelineTask | None = None
+        # Tracks the most recently connected client websocket. Used to detect
+        # stale-socket disconnects when the ESP32 opens a replacement
+        # connection (pipecat allows one client; new connections evict old).
+        self._active_websocket = None
 
     def create_transport(self) -> WebsocketServerTransport:
         """
@@ -101,6 +105,12 @@ class WebSocketHandler:
             port=self.port,
             params=WebsocketServerParams(
                 serializer=serializer,
+                # CRITICAL: these default to False on TransportParams (inherited,
+                # not deprecated). When False, the input audio task is never
+                # created and all audio frames are silently dropped
+                # (base_input.py) and output audio is discarded (base_output.py).
+                audio_in_enabled=True,
+                audio_out_enabled=True,
             )
         )
 
@@ -251,14 +261,35 @@ class WebSocketHandler:
         @transport.event_handler("on_client_connected")
         async def on_client_connected(transport: WebsocketServerTransport, websocket):
             """Handle new WebSocket client connection."""
+            is_replacement = (
+                self._active_websocket is not None
+                and self._active_websocket is not websocket
+            )
+            self._active_websocket = websocket
             client_id = self.extract_client_id(websocket)
             logger.info(f"🔗 New WebSocket connection from IP: {client_id}")
+            if is_replacement:
+                # The previous socket's disconnect event will fire shortly —
+                # the stale-socket guard below ignores it. Reuse the live
+                # OpenAI session instead of resetting it mid-conversation.
+                logger.info("♻️ Connection replaced an existing client — keeping session")
+                return
             await on_client_connected_callback(client_id)
 
         if on_client_disconnected_callback:
             @transport.event_handler("on_client_disconnected")
             async def on_client_disconnected(transport: WebsocketServerTransport, websocket, *args, **kwargs):
                 """Handle client disconnection."""
+                if self._active_websocket is not None and self._active_websocket is not websocket:
+                    # Stale socket: this client was replaced by a newer
+                    # connection. Pipecat's transport already nulled the
+                    # output client connection (set_client_connection(None))
+                    # for the OLD socket's disconnect — restore it for the
+                    # live socket, and do NOT tear down the OpenAI session.
+                    logger.info("🛡️ Ignoring stale-socket disconnect (client was replaced)")
+                    await transport.output().set_client_connection(self._active_websocket)
+                    return
+                self._active_websocket = None
                 client_id = self.extract_client_id(websocket)
                 if client_id:
                     logger.info(f"🔌 Client {client_id} disconnected")

--- a/src/genesis/channels/voice/s2s_bridge/app/websocket_handler.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/websocket_handler.py
@@ -286,8 +286,14 @@ class WebSocketHandler:
                     # output client connection (set_client_connection(None))
                     # for the OLD socket's disconnect — restore it for the
                     # live socket, and do NOT tear down the OpenAI session.
+                    # Only restore if the output is actually nulled:
+                    # set_client_connection() closes any socket it currently
+                    # holds, so restoring while the live socket is already
+                    # set would close it (rare interleaving, but fatal).
                     logger.info("🛡️ Ignoring stale-socket disconnect (client was replaced)")
-                    await transport.output().set_client_connection(self._active_websocket)
+                    output = transport.output()
+                    if getattr(output, "_websocket", None) is None:
+                        await output.set_client_connection(self._active_websocket)
                     return
                 self._active_websocket = None
                 client_id = self.extract_client_id(websocket)

--- a/src/genesis/channels/voice/s2s_bridge/root/run.sh
+++ b/src/genesis/channels/voice/s2s_bridge/root/run.sh
@@ -7,10 +7,8 @@ WEBSOCKET_PORT=$(bashio::config 'websocket_port')
 GENESIS_URL=$(bashio::config 'genesis_url')
 GENESIS_TOKEN=$(bashio::config 'genesis_token')
 
-# Turn detection settings
-VAD_THRESHOLD=$(bashio::config 'vad_threshold')
-VAD_PREFIX_PADDING_MS=$(bashio::config 'vad_prefix_padding_ms')
-VAD_SILENCE_DURATION_MS=$(bashio::config 'vad_silence_duration_ms')
+# Turn detection settings (semantic VAD — replaces old threshold-based server_vad)
+SEMANTIC_VAD_EAGERNESS=$(bashio::config 'semantic_vad_eagerness')
 
 # Session management
 SESSION_REUSE_TIMEOUT_SECONDS=$(bashio::config 'session_reuse_timeout_seconds')
@@ -30,9 +28,7 @@ export WEBSOCKET_PORT
 export GENESIS_URL
 export GENESIS_TOKEN
 
-export VAD_THRESHOLD
-export VAD_PREFIX_PADDING_MS
-export VAD_SILENCE_DURATION_MS
+export SEMANTIC_VAD_EAGERNESS
 
 export SESSION_REUSE_TIMEOUT_SECONDS
 export ENABLE_RECORDING


### PR DESCRIPTION
## Summary

Completes the pipecat 1.3.0 migration (#596) by fixing the audio-path regressions found during HA deployment. Root causes verified against pipecat source and live addon logs.

- **Enable transport audio**: `audio_in_enabled`/`audio_out_enabled` default to `False` on `TransportParams` (inherited, not deprecated). With them unset, the input audio task is never created and all audio is silently dropped in both directions — the root cause of the post-upgrade silence. This also caused the satellite firmware to give up and reconnect a few seconds into each session (no audio coming back).
- **Stale-socket disconnect guard**: defensive fix — pipecat allows one client and evicts the old socket when a replacement connects; the evicted socket's disconnect event would tear down the live OpenAI session and null the output client connection. Track the active websocket, ignore stale-socket disconnects, and restore the output client connection the transport clears.
- **External turn strategies**: user aggregator now accepts turn signals broadcast by the OpenAI Realtime service (server-side semantic VAD) instead of loading local SmartTurn (onnxruntime unavailable on the addon base image).
- **Conversation setup flag**: set `_llm_needs_conversation_setup` before raw `_connect()` so instructions/tools are re-sent on reconnect.
- **Config wiring**: `run.sh` now exports `SEMANTIC_VAD_EAGERNESS` (was still reading the removed `vad_*` options).
- **Build fixes** (earlier commits): onnxruntime stub for the addon base image, pip-based dependency install.

## Test plan

- [x] ruff + py_compile + bash -n on changed files
- [x] Deployed to HA, new code markers verified in logs
- [x] E2E: Genesis tools loaded (system prompt + 3 tool declarations fetched)
- [x] E2E: wake word → spoken audio response
- [x] E2E: conversation stable for ~60s with mid-conversation tool call (200 OK)
- [x] E2E: context cached on disconnect (7 messages)
- [ ] Interrupt/barge-in: known limitation — satellite firmware blocks mic audio during bot playback (half-duplex). Tracked as Phase 3C, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)