### PR TITLE
fix(eval): make J9 batch resumable + concurrent; dedupe metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Eval quality dashboard could stall** --- the nightly memory-scoring job
+  timed out and retried from scratch, so the compounding-intelligence
+  dashboard stopped getting fresh data and double-counted judgments. The job
+  now resumes where it left off, scores in parallel within provider rate
+  limits, and the aggregator ignores duplicate judgments --- metrics stay
+  accurate and update reliably.
+
+---
+
 ## [v3.0b14] - 2026-06-04
 
 ### Added

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -200,7 +200,9 @@ async def _compute_memory_quality(
         "mrr": round(sum(mrrs) / len(mrrs), 4) if mrrs else None,
         "usage_rate": round(total_used / total_usage_checked, 4) if total_usage_checked else None,
         "total_recalls": total_recalls,
-        "total_memories_judged": len(relevance_events),
+        # Count only memories that actually fed the metrics (grouped under a
+        # recall_event_id) — not orphan events that contribute nothing.
+        "total_memories_judged": sum(len(v) for v in by_recall.values()),
     }
     return metrics, total_recalls
 

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -116,6 +116,29 @@ async def run_weekly_aggregation(db: aiosqlite.Connection) -> dict[str, dict]:
 # ── Dimension 1: Memory Retrieval Quality ────────────────────────────────────
 
 
+def _dedupe_by_pair(events: list[dict]) -> list[dict]:
+    """Keep one event per (recall_event_id, memory_id) pair.
+
+    Defends the metrics against duplicate relevance/used events (e.g. produced
+    by a batch that re-judged the same window before checkpointing existed).
+    Keeps the first occurrence — callers pass timestamp-DESC events, so that is
+    the most recent judgment. Events missing either id are kept as-is.
+    """
+    seen: set[tuple[str, str]] = set()
+    out: list[dict] = []
+    for ev in events:
+        m = ev.get("metrics", {})
+        rid = m.get("recall_event_id")
+        mid = m.get("memory_id")
+        if rid and mid:
+            key = (rid, mid)
+            if key in seen:
+                continue
+            seen.add(key)
+        out.append(ev)
+    return out
+
+
 async def _compute_memory_quality(
     db: aiosqlite.Connection, since: str, until: str,
 ) -> tuple[dict, int]:
@@ -124,6 +147,9 @@ async def _compute_memory_quality(
         db, dimension="memory", event_type="recall_relevance",
         since=since, until=until, limit=5000,
     )
+    # Defensive dedup: duplicate (recall, memory) judgments must not skew the
+    # average (pre-checkpoint batches could emit the same pair multiple times).
+    relevance_events = _dedupe_by_pair(relevance_events)
 
     if not relevance_events:
         return {"precision_at_5": None, "hit_rate": None, "mrr": None,
@@ -164,6 +190,7 @@ async def _compute_memory_quality(
         db, dimension="memory", event_type="recall_used",
         since=since, until=until, limit=5000,
     )
+    used_events = _dedupe_by_pair(used_events)
     total_used = sum(1 for ev in used_events if ev.get("metrics", {}).get("used"))
     total_usage_checked = len(used_events)
 

--- a/src/genesis/eval/j9_batch.py
+++ b/src/genesis/eval/j9_batch.py
@@ -106,6 +106,7 @@ class J9EvalBatchExecutor:
             dimension="memory",
             event_type="recall_fired",
             since=since,
+            until=until,
             limit=200,
         )
 
@@ -181,21 +182,27 @@ class J9EvalBatchExecutor:
                 else:
                     errors += 1
 
-        await asyncio.gather(
+        results = await asyncio.gather(
             *(
                 _judge_and_store(i, event, query, mid)
                 for i, (event, query, mid) in enumerate(worklist)
             ),
             return_exceptions=True,
         )
+        # return_exceptions=True turns a raised coroutine into a returned value;
+        # surface it instead of silently dropping it.
+        for r in results:
+            if isinstance(r, Exception):
+                logger.warning("J9 judge coroutine raised: %s", r)
+                errors += 1
 
         # Pass 2: recall_used — check if recalled memories were referenced
         # in session-extracted content (text overlap, no LLM needed).
-        used_count = await self._compute_recall_used(
+        used_count, used_cut_short = await self._compute_recall_used(
             since, until, recall_events, deadline,
         )
 
-        partial = deferred > 0
+        partial = deferred > 0 or used_cut_short
         content = (
             f"J9 eval batch: scored {scored} memory-query pairs "
             f"({errors} errors, {len(already_judged)} already-judged skipped, "
@@ -229,6 +236,14 @@ class J9EvalBatchExecutor:
             until=until,
             limit=_CHECKPOINT_QUERY_LIMIT,
         )
+        if len(events) >= _CHECKPOINT_QUERY_LIMIT:
+            # Checkpoint may be incomplete → some pairs could be re-judged.
+            # Loud rather than silent (the very backlog this fix prevents).
+            logger.warning(
+                "J9 checkpoint query for %s hit limit %d — checkpoint may be "
+                "incomplete; some pairs may be re-judged this run",
+                event_type, _CHECKPOINT_QUERY_LIMIT,
+            )
         pairs: set[tuple[str, str]] = set()
         for ev in events:
             m = ev.get("metrics", {})
@@ -241,16 +256,19 @@ class J9EvalBatchExecutor:
     async def _compute_recall_used(
         self, since: str, until: str, recall_events: list[dict],
         deadline: float,
-    ) -> int:
+    ) -> tuple[int, bool]:
         """Check if recalled memories were referenced in session-extracted content.
 
         Uses text overlap (trigram similarity) between recalled memory content
         and memories extracted from the same session. No LLM calls needed.
         Checkpointed (skips already-emitted pairs) and deadline-aware so a
         retried run resumes rather than re-emitting duplicates.
+
+        Returns ``(used_count, cut_short)`` — ``cut_short`` is True if the
+        deadline interrupted pass 2 (remaining sessions resume next run).
         """
         if self._db is None:
-            return 0
+            return 0, False
 
         already_used = await self._judged_pairs(
             since, until, event_type="recall_used",
@@ -264,10 +282,12 @@ class J9EvalBatchExecutor:
                 by_session.setdefault(sid, []).append(ev)
 
         used_count = 0
+        cut_short = False
         for session_id, events in by_session.items():
             if not session_id:
                 continue  # Skip events without session attribution
             if time.monotonic() > deadline:
+                cut_short = True
                 break  # Out of budget — remaining sessions resume next run
             # Get memories extracted FROM this session via pending_embeddings
             # which tracks source_session_id for each extracted memory.
@@ -327,7 +347,7 @@ class J9EvalBatchExecutor:
                     except Exception:
                         logger.debug("Failed to emit recall_used for %s", mid)
 
-        return used_count
+        return used_count, cut_short
 
     async def _get_memory_content(self, memory_id: str) -> str | None:
         """Fetch memory content from Qdrant payload or FTS5."""

--- a/src/genesis/eval/j9_batch.py
+++ b/src/genesis/eval/j9_batch.py
@@ -10,8 +10,10 @@ provider is available — no hardcoded model dependency.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import time
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -24,6 +26,25 @@ if TYPE_CHECKING:
     from genesis.routing.router import Router
 
 logger = logging.getLogger(__name__)
+
+# Max concurrent judge calls. Mirrors knowledge.distillation's
+# _MAX_CONCURRENT_CHUNKS=4. The real throughput cap is the per-provider rate
+# gate (judge chain → openrouter-deepseek-v4 @ 20 RPM = 3s/dispatch); the
+# semaphore just bounds in-flight coroutines (≈ response_latency/interval),
+# so going higher only queues on the rate-gate lock.
+_MAX_CONCURRENT_JUDGES = 4
+
+# Internal wall-clock budget for one batch run. Chosen to sit comfortably below
+# the surplus "running" reaper threshold (2h, surplus/queue.py:recover_stuck
+# older_than_hours=2) so a slow run returns a graceful partial instead of being
+# killed and retried-from-scratch. A healthy run finishes in ~25 min (rate-gate
+# bound), so this only bites under a degraded provider — exactly when a partial
+# (resumed next run via checkpointing) beats a hard kill.
+_BATCH_DEADLINE_S = 90 * 60
+
+# Upper bound for the checkpoint lookback query. Generous so historical
+# duplicates from prior failed attempts are all captured and skipped.
+_CHECKPOINT_QUERY_LIMIT = 10000
 
 def _text_overlap(memory_text: str, reference_text: str, min_phrases: int = 2) -> bool:
     """Check if memory content appears in reference text via trigram overlap.
@@ -75,7 +96,11 @@ class J9EvalBatchExecutor:
         if self._db is None:
             return ExecutorResult(success=False, error="no db connection")
 
-        since = (datetime.now(UTC) - timedelta(hours=24)).isoformat()
+        now = datetime.now(UTC)
+        since = (now - timedelta(hours=24)).isoformat()
+        until = now.isoformat()
+        deadline = time.monotonic() + _BATCH_DEADLINE_S
+
         recall_events = await j9_eval.get_events(
             self._db,
             dimension="memory",
@@ -90,24 +115,53 @@ class J9EvalBatchExecutor:
                 content="J9 eval batch: no recall events in past 24h",
             )
 
-        scored = 0
-        errors = 0
+        # Checkpoint: skip (recall_event, memory) pairs already judged in this
+        # window. Makes a reaper-retried run RESUME instead of restarting from
+        # scratch, and eliminates the duplicate recall_relevance events that
+        # prior restart-from-scratch retries produced.
+        already_judged = await self._judged_pairs(
+            since, until, event_type="recall_relevance",
+        )
 
+        # Build the judgment worklist (skipping already-judged pairs).
+        worklist: list[tuple[dict, str, str]] = []
         for event in recall_events:
             metrics = event.get("metrics", {})
             query = metrics.get("query", "")
             memory_ids = metrics.get("memory_ids", [])
-
             if not query or not memory_ids:
                 continue
-
-            # Fetch memory content for each recalled memory
             for mid in memory_ids[:5]:  # Cap at top-5 per recall
+                if (event["id"], mid) in already_judged:
+                    continue
+                worklist.append((event, query, mid))
+
+        scored = 0
+        errors = 0
+        deferred = 0
+        sem = asyncio.Semaphore(_MAX_CONCURRENT_JUDGES)
+
+        async def _judge_and_store(index: int, event: dict, query: str, mid: str) -> None:
+            nonlocal scored, errors, deferred
+            # Deadline check before acquiring a slot — past the budget, defer
+            # the rest to the next (checkpointed) run rather than risk the
+            # 2h reaper.
+            if time.monotonic() > deadline:
+                deferred += 1
+                return
+            async with sem:
+                if time.monotonic() > deadline:
+                    deferred += 1
+                    return
                 content = await self._get_memory_content(mid)
                 if not content:
-                    continue
-
-                relevance, rationale, model_used = await self._judge_relevance(query, content)
+                    return
+                # chain_offset rotates the judge provider chain per item so
+                # concurrent calls spread across providers (same pattern as
+                # knowledge.distillation).
+                relevance, rationale, model_used = await self._judge_relevance(
+                    query, content, chain_offset=index,
+                )
                 if relevance is not None:
                     await j9_eval.insert_event(
                         self._db,
@@ -127,13 +181,26 @@ class J9EvalBatchExecutor:
                 else:
                     errors += 1
 
-        # Pass 2: recall_used — check if recalled memories were referenced
-        # in session-extracted content (text overlap, no LLM needed)
-        used_count = await self._compute_recall_used(since, recall_events)
+        await asyncio.gather(
+            *(
+                _judge_and_store(i, event, query, mid)
+                for i, (event, query, mid) in enumerate(worklist)
+            ),
+            return_exceptions=True,
+        )
 
+        # Pass 2: recall_used — check if recalled memories were referenced
+        # in session-extracted content (text overlap, no LLM needed).
+        used_count = await self._compute_recall_used(
+            since, until, recall_events, deadline,
+        )
+
+        partial = deferred > 0
         content = (
             f"J9 eval batch: scored {scored} memory-query pairs "
-            f"({errors} errors), {used_count} recall_used events"
+            f"({errors} errors, {len(already_judged)} already-judged skipped, "
+            f"{deferred} deferred to next run), {used_count} recall_used events"
+            + (" [PARTIAL — resumes next run]" if partial else "")
         )
         return ExecutorResult(
             success=True,
@@ -147,16 +214,47 @@ class J9EvalBatchExecutor:
             }],
         )
 
+    async def _judged_pairs(
+        self, since: str, until: str, *, event_type: str,
+    ) -> set[tuple[str, str]]:
+        """Return the set of (recall_event_id, memory_id) pairs already emitted
+        for *event_type* in the window — the checkpoint for resume/dedup."""
+        if self._db is None:
+            return set()
+        events = await j9_eval.get_events(
+            self._db,
+            dimension="memory",
+            event_type=event_type,
+            since=since,
+            until=until,
+            limit=_CHECKPOINT_QUERY_LIMIT,
+        )
+        pairs: set[tuple[str, str]] = set()
+        for ev in events:
+            m = ev.get("metrics", {})
+            rid = m.get("recall_event_id")
+            mid = m.get("memory_id")
+            if rid and mid:
+                pairs.add((rid, mid))
+        return pairs
+
     async def _compute_recall_used(
-        self, since: str, recall_events: list[dict],
+        self, since: str, until: str, recall_events: list[dict],
+        deadline: float,
     ) -> int:
         """Check if recalled memories were referenced in session-extracted content.
 
         Uses text overlap (trigram similarity) between recalled memory content
         and memories extracted from the same session. No LLM calls needed.
+        Checkpointed (skips already-emitted pairs) and deadline-aware so a
+        retried run resumes rather than re-emitting duplicates.
         """
         if self._db is None:
             return 0
+
+        already_used = await self._judged_pairs(
+            since, until, event_type="recall_used",
+        )
 
         # Group recall events by session
         by_session: dict[str, list[dict]] = {}
@@ -169,6 +267,8 @@ class J9EvalBatchExecutor:
         for session_id, events in by_session.items():
             if not session_id:
                 continue  # Skip events without session attribution
+            if time.monotonic() > deadline:
+                break  # Out of budget — remaining sessions resume next run
             # Get memories extracted FROM this session via pending_embeddings
             # which tracks source_session_id for each extracted memory.
             try:
@@ -198,6 +298,8 @@ class J9EvalBatchExecutor:
             for ev in events:
                 memory_ids = ev.get("metrics", {}).get("memory_ids", [])
                 for mid in memory_ids[:5]:
+                    if (ev["id"], mid) in already_used:
+                        continue  # Checkpoint: already emitted in this window
                     mem_content = await self._get_memory_content(mid)
                     if not mem_content:
                         continue
@@ -244,11 +346,13 @@ class J9EvalBatchExecutor:
         return None
 
     async def _judge_relevance(
-        self, query: str, memory_content: str,
+        self, query: str, memory_content: str, *, chain_offset: int = 0,
     ) -> tuple[float | None, str, str]:
         """Ask the judge model to score relevance via the router.
 
         Returns (relevance_score, rationale_or_error, model_used).
+        ``chain_offset`` rotates the provider chain so concurrent callers
+        spread across the judge chain's providers.
         """
         if self._router is None:
             return (None, "no router configured", "none")
@@ -263,6 +367,7 @@ class J9EvalBatchExecutor:
                 messages=[{"role": "user", "content": prompt}],
                 temperature=0.0,
                 max_tokens=150,
+                chain_offset=chain_offset,
             )
             model_used = result.model_id or result.provider_used or "router:judge"
             if not result.success:

--- a/tests/test_eval/test_j9_batch.py
+++ b/tests/test_eval/test_j9_batch.py
@@ -1,0 +1,128 @@
+"""Tests for the J-9 eval batch executor (J9EvalBatchExecutor).
+
+Covers the resumability/concurrency hardening: checkpoint-based dedup so a
+reaper-retried run resumes instead of restarting, and the internal deadline
+that returns a graceful partial instead of tripping the 2h surplus reaper.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from genesis.db.crud import j9_eval
+from genesis.eval.j9_batch import J9EvalBatchExecutor
+
+
+class _FakeRouter:
+    """Minimal router: records call count, returns a fixed relevance verdict."""
+
+    def __init__(self, relevance: float = 0.9) -> None:
+        self.calls = 0
+        self.chain_offsets: list[int] = []
+        self._relevance = relevance
+
+    async def route_call(self, call_site_id, messages, *, chain_offset=0, **kwargs):
+        self.calls += 1
+        self.chain_offsets.append(chain_offset)
+        return SimpleNamespace(
+            success=True,
+            provider_used="fake",
+            model_id="fake-judge",
+            content=json.dumps({"relevance": self._relevance, "rationale": "ok"}),
+            error=None,
+        )
+
+
+def _task():
+    return SimpleNamespace(task_type="j9_eval_batch")
+
+
+async def _seed_recall(db, *, query, memory_ids, session_id=None):
+    """Insert a recall_fired event plus memory_fts content for each memory."""
+    for mid in memory_ids:
+        await db.execute(
+            "INSERT INTO memory_fts (memory_id, content) VALUES (?, ?)",
+            (mid, f"content for {mid}"),
+        )
+    await db.commit()
+    return await j9_eval.insert_event(
+        db,
+        dimension="memory",
+        event_type="recall_fired",
+        session_id=session_id,
+        metrics={"query": query, "memory_ids": memory_ids},
+    )
+
+
+async def _relevance_pairs(db) -> set[tuple[str, str]]:
+    events = await j9_eval.get_events(
+        db, dimension="memory", event_type="recall_relevance", limit=1000,
+    )
+    return {
+        (e["metrics"]["recall_event_id"], e["metrics"]["memory_id"])
+        for e in events
+    }
+
+
+async def test_no_recall_events_returns_success(db):
+    ex = J9EvalBatchExecutor(db=db, router=_FakeRouter())
+    result = await ex.execute(_task())
+    assert result.success
+    assert "no recall events" in result.content
+
+
+async def test_judges_all_memories_happy_path(db):
+    eid = await _seed_recall(db, query="what is X", memory_ids=["m1", "m2", "m3"])
+    router = _FakeRouter()
+    ex = J9EvalBatchExecutor(db=db, router=router)
+
+    result = await ex.execute(_task())
+
+    assert result.success
+    assert router.calls == 3  # one judge call per memory
+    assert await _relevance_pairs(db) == {(eid, "m1"), (eid, "m2"), (eid, "m3")}
+
+
+async def test_checkpoint_skips_already_judged(db):
+    eid = await _seed_recall(db, query="q", memory_ids=["m1", "m2"])
+    # Pre-existing judgment for (eid, m1) — simulates a prior partial/retry.
+    await j9_eval.insert_event(
+        db,
+        dimension="memory",
+        event_type="recall_relevance",
+        subject_id="m1",
+        metrics={"recall_event_id": eid, "memory_id": "m1", "relevance": 0.5},
+    )
+    router = _FakeRouter()
+    ex = J9EvalBatchExecutor(db=db, router=router)
+
+    result = await ex.execute(_task())
+
+    assert result.success
+    assert router.calls == 1  # only m2 judged; m1 skipped via checkpoint
+    pairs = await _relevance_pairs(db)
+    assert (eid, "m1") in pairs and (eid, "m2") in pairs
+    assert len(pairs) == 2  # no duplicate for m1
+
+
+async def test_deadline_defers_remaining(db, monkeypatch):
+    await _seed_recall(db, query="q", memory_ids=["m1", "m2"])
+    router = _FakeRouter()
+    ex = J9EvalBatchExecutor(db=db, router=router)
+
+    # First monotonic() call sets the deadline; all later checks read past it.
+    state = {"n": 0}
+
+    def fake_monotonic():
+        state["n"] += 1
+        return 0.0 if state["n"] == 1 else 1e9
+
+    monkeypatch.setattr("genesis.eval.j9_batch.time.monotonic", fake_monotonic)
+
+    result = await ex.execute(_task())
+
+    assert result.success  # graceful partial, NOT a failure
+    assert "PARTIAL" in result.content
+    assert router.calls == 0  # everything deferred to next run
+    assert len(await _relevance_pairs(db)) == 0

--- a/tests/test_eval/test_j9_eval.py
+++ b/tests/test_eval/test_j9_eval.py
@@ -497,3 +497,44 @@ async def test_get_latest_subsystem_grades(db):
     assert len(latest) == 2
     subsystems = {g["subsystem"] for g in latest}
     assert subsystems == {"memory", "ego"}
+
+
+# ── aggregator dedup (defends metrics against duplicate judgments) ────────────
+
+
+def test_dedupe_by_pair_keeps_first():
+    from genesis.eval.j9_aggregator import _dedupe_by_pair
+
+    events = [
+        {"metrics": {"recall_event_id": "r1", "memory_id": "m1", "relevance": 1.0}},
+        {"metrics": {"recall_event_id": "r1", "memory_id": "m1", "relevance": 0.0}},
+        {"metrics": {"recall_event_id": "r1", "memory_id": "m2", "relevance": 0.5}},
+        {"metrics": {"foo": "bar"}},  # missing ids → kept as-is
+    ]
+    out = _dedupe_by_pair(events)
+    assert len(out) == 3
+    assert out[0]["metrics"]["relevance"] == 1.0  # first occurrence kept
+
+
+async def test_memory_quality_ignores_duplicate_relevance(db):
+    from genesis.eval.j9_aggregator import _compute_memory_quality
+
+    # Duplicate (r1, m1) relevant judgments + one non-relevant (r1, m2).
+    # Deduped precision for the recall = 1 relevant / 2 memories = 0.5
+    # (without dedup it would be 2/3 = 0.667).
+    for rel in (1.0, 1.0):
+        await j9_eval.insert_event(
+            db, dimension="memory", event_type="recall_relevance",
+            metrics={"recall_event_id": "r1", "memory_id": "m1", "relevance": rel},
+        )
+    await j9_eval.insert_event(
+        db, dimension="memory", event_type="recall_relevance",
+        metrics={"recall_event_id": "r1", "memory_id": "m2", "relevance": 0.0},
+    )
+
+    metrics, total_recalls = await _compute_memory_quality(
+        db, since="2000-01-01", until="2100-01-01",
+    )
+    assert total_recalls == 1
+    assert metrics["precision_at_5"] == 0.5
+    assert metrics["total_memories_judged"] == 2  # deduped, not 3


### PR DESCRIPTION
## Problem

The `j9_eval_batch` surplus task had been failing nightly since ~Jun 4
(`stuck: exceeded running timeout (max retries exhausted)`; only Jun 7
succeeded). Each 2h-reaper retry re-ran `execute()` from scratch, re-judging
the same 24h window with ~1000 sequential LLM judge calls — blowing past the
2h running-timeout and emitting duplicate `recall_relevance` events (216 from
92 inputs). Net effect: the weekly memory snapshot was computed from
incomplete, duplicated data.

(Note: the dashboard "looks frozen" symptom is mostly the **weekly** snapshot
cadence — `CronTrigger` Sun 07:30 — not this bug. This fixes the data *quality*
feeding that weekly snapshot, plus the nightly failure/compute waste.)

## Fix

- **Checkpoint/resume**: skip `(recall_event_id, memory_id)` pairs already
  judged in the window, so a retried run continues instead of restarting and
  stops duplicating events. Applied to both relevance and recall_used passes.
- **Bounded concurrency**: judge calls run via `asyncio.gather` + `Semaphore(4)`
  with `chain_offset` rotation (mirrors `knowledge.distillation`). Throughput is
  bounded by the per-provider rate gate (judge → `openrouter-deepseek-v4` @ 20
  RPM); responses overlap, cutting a clean run to ~25 min. No change to judge
  semantics (one memory per call), so precision@5 stays comparable.
- **90-min internal deadline**: returns a graceful PARTIAL (`success=True`) that
  resumes next run rather than being killed by the reaper.
- **Aggregator dedup**: `_compute_memory_quality` dedupes relevance/used events
  by `(recall_event_id, memory_id)` at read-time, so existing duplicates don't
  skew precision@5/MRR/hit_rate/usage_rate — no destructive DB cleanup needed.

## Testing

- New `tests/test_eval/test_j9_batch.py` (first coverage for the executor):
  happy-path, checkpoint-skip, deadline-partial.
- New aggregator dedup tests in `test_j9_eval.py`.
- Full `test_eval/` suite: 131 passed. ruff clean.

## Reviewed

Two review passes (initial + post-delta), findings applied: surfaced
swallowed gather exceptions, window/limit hardening, `cut_short` reporting,
and `total_memories_judged` now counts only scored memories.

## Not in this PR / follow-up

E2E (a real timed batch run + manual aggregation to refresh the dashboard) is
deferred to the production deploy after the in-flight `fix/cc-npm-prefix-detection`
work lands (follow-up tracked). The two "dead dimensions" (procedure/cognitive)
are a separate instrumentation gap, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)