### PR TITLE
fix(autonomy): watchdog verifies restart via is-active, not client exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   now resumes where it left off, scores in parallel within provider rate
   limits, and the aggregator ignores duplicate judgments --- metrics stay
   accurate and update reliably.
+- **Watchdog falsely reported failure after a slow restart** --- when a
+  server restart took longer than expected under load, the health watchdog
+  timed out waiting and marked itself failed even though the restart
+  succeeded. It now confirms the service is actually back up before reporting,
+  so a successful recovery no longer shows as a failed health check.
 
 ---
 

--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -586,8 +586,45 @@ def get_container_anon_memory() -> tuple[int, int] | None:
         return None
 
 
-def restart_bridge(service: str = "genesis-bridge.service") -> int:
+def _wait_until_active(
+    service: str, *, timeout_s: int = 60, poll_interval_s: float = 2.0,
+) -> bool:
+    """Poll ``systemctl --user is-active`` until *service* is active or timeout.
+
+    Mirrors WatchdogChecker._is_bridge_active's probe. Used to confirm the
+    true post-restart state instead of trusting the restart client's exit.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            result = subprocess.run(
+                ["systemctl", "--user", "is-active", service],
+                capture_output=True, text=True, timeout=5, env=systemctl_env(),
+            )
+            if result.stdout.strip() == "active":
+                return True
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            pass
+        time.sleep(poll_interval_s)
+    return False
+
+
+def restart_bridge(service: str = "genesis-bridge.service", *, timeout_s: int = 120) -> int:
     """Restart the specified Genesis service via systemctl. Returns exit code.
+
+    Returns 0 if the service is confirmed active after the restart, 1 if not,
+    -2 if systemctl is missing.
+
+    Verifies the *actual* service state rather than trusting the systemctl
+    client's exit. A graceful genesis-server restart's stop phase is bounded
+    by systemd's ~90s TimeoutStopSec; under load it can exceed a short client
+    timeout, but killing the client does NOT abort the systemd restart job —
+    systemd completes it independently. So on a slow/timed-out client we poll
+    is-active before declaring failure, instead of returning a spurious error
+    (which previously left the watchdog unit `failed` after a successful
+    restart). ``timeout_s`` (default 120s) clears systemd's stop bound with
+    margin while still bounding a genuinely hung systemctl — important because
+    the watchdog timer cannot overlap oneshot runs.
 
     Defaults to genesis-bridge.service for backward compatibility.
     Pass checker.target_service to restart the auto-detected service.
@@ -596,18 +633,29 @@ def restart_bridge(service: str = "genesis-bridge.service") -> int:
     try:
         result = subprocess.run(
             ["systemctl", "--user", "restart", service],
-            capture_output=True, text=True, timeout=30, env=systemctl_env(),
+            capture_output=True, text=True, timeout=timeout_s, env=systemctl_env(),
         )
         if result.returncode == 0:
             logger.info("%s restart command succeeded", service)
-        else:
-            logger.error("%s restart failed: %s", service, result.stderr)
-        return result.returncode
+            return 0
+        logger.error("%s restart returned %d: %s — verifying actual state",
+                     service, result.returncode, result.stderr)
     except subprocess.TimeoutExpired:
-        logger.error("%s restart command timed out", service, exc_info=True)
-        return -1
+        # Client exceeded the budget; systemd finishes the restart job
+        # independently. Verify rather than assume failure.
+        logger.warning(
+            "%s restart client exceeded %ds — verifying actual service state "
+            "(systemd completes the restart independently of the client)",
+            service, timeout_s,
+        )
     except FileNotFoundError:
-        logger.error("systemctl not found — cannot restart bridge")
+        logger.error("systemctl not found — cannot restart %s", service)
         return -2
+
+    if _wait_until_active(service):
+        logger.info("%s confirmed active after restart", service)
+        return 0
+    logger.error("%s not active after restart attempt", service)
+    return 1
 
 

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -464,3 +465,59 @@ class TestZombieSuppressionDuringHeavyWorkload:
         checker = _make_checker(tmp_path, status, stabilization_s=120)
         result = checker.check()
         assert result == WatchdogAction.SKIP
+
+
+class TestRestartBridge:
+    """restart_bridge verifies actual service state instead of trusting the
+    systemctl client's exit (regression: a slow-but-successful restart used to
+    return -1 → exit 255 → watchdog unit `failed`)."""
+
+    def test_clean_restart_returns_zero(self):
+        from genesis.autonomy import watchdog as wd
+
+        completed = MagicMock(returncode=0, stderr="")
+        with patch.object(wd.subprocess, "run", return_value=completed) as run, \
+                patch.object(wd, "_wait_until_active") as wait:
+            assert wd.restart_bridge("genesis-server.service") == 0
+            run.assert_called_once()
+            wait.assert_not_called()  # clean exit needs no verification
+
+    def test_timeout_then_active_returns_zero(self):
+        from genesis.autonomy import watchdog as wd
+
+        timeout = subprocess.TimeoutExpired(cmd=["systemctl"], timeout=120)
+        with patch.object(wd.subprocess, "run", side_effect=timeout), \
+                patch.object(wd, "_wait_until_active", return_value=True):
+            # Killing the client doesn't abort the systemd job; it came up.
+            assert wd.restart_bridge("genesis-server.service") == 0
+
+    def test_timeout_then_not_active_returns_one(self):
+        from genesis.autonomy import watchdog as wd
+
+        timeout = subprocess.TimeoutExpired(cmd=["systemctl"], timeout=120)
+        with patch.object(wd.subprocess, "run", side_effect=timeout), \
+                patch.object(wd, "_wait_until_active", return_value=False):
+            assert wd.restart_bridge("genesis-server.service") == 1
+
+    def test_nonzero_then_active_returns_zero(self):
+        from genesis.autonomy import watchdog as wd
+
+        failed = MagicMock(returncode=1, stderr="boom")
+        with patch.object(wd.subprocess, "run", return_value=failed), \
+                patch.object(wd, "_wait_until_active", return_value=True):
+            assert wd.restart_bridge("genesis-server.service") == 0
+
+    def test_systemctl_missing_returns_minus_two(self):
+        from genesis.autonomy import watchdog as wd
+
+        with patch.object(wd.subprocess, "run", side_effect=FileNotFoundError()):
+            assert wd.restart_bridge("genesis-server.service") == -2
+
+    def test_wait_until_active_polls_until_active(self):
+        from genesis.autonomy import watchdog as wd
+
+        inactive = MagicMock(stdout="activating")
+        active = MagicMock(stdout="active")
+        with patch.object(wd.subprocess, "run", side_effect=[inactive, active]), \
+                patch.object(wd.time, "sleep"):
+            assert wd._wait_until_active("genesis-server.service", timeout_s=30) is True


### PR DESCRIPTION
## Problem

`genesis-watchdog.service` ended `failed` (exit 255) after a **successful**
`genesis-server` restart. `restart_bridge` used `subprocess.run(..., timeout=30)`
and returned `-1` on `TimeoutExpired` — but a graceful server restart's stop
phase is bounded by systemd's ~90s `TimeoutStopSec` and exceeded 30s under load.
Killing the `systemctl` client does **not** abort the systemd restart job (the
server came up anyway), yet the watchdog reported failure and left its unit
`failed`.

## Fix

- Raise the client timeout 30s → 120s (clears systemd's stop bound with margin;
  still bounds a genuinely hung `systemctl`, important since watchdog oneshots
  can't overlap).
- On non-zero return **or** `TimeoutExpired`, poll `systemctl is-active` (new
  `_wait_until_active`, mirrors `_is_bridge_active`) and return 0 if the service
  is actually up — only return 1 when it genuinely didn't come back.
- Clean exit codes (0 / 1 / -2) so a successful restart never leaves the unit
  `failed`.

No consumer reads the watchdog *service* exit/failed state (verified: consumers
read the timer unit's active state + `watchdog_state.json`, written before
`restart_bridge` runs).

## Testing

- New `TestRestartBridge` coverage (clean, timeout→active, timeout→inactive,
  non-zero→active, systemctl-missing, poll loop).
- Full `test_autonomy/` suite: 727 passed. ruff clean.

## Not in this PR

Live slow-restart E2E is deferred to the production deploy after the in-flight
`fix/cc-npm-prefix-detection` work (follow-up tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)