### PR TITLE
fix(install): auto-detect npm prefix instead of hardcoding /usr/local

### DIFF
--- a/docs/reference/cc-compatibility.md
+++ b/docs/reference/cc-compatibility.md
@@ -196,15 +196,20 @@ npm pinning gives full version control. Upgrades are deliberate via recon triage
 from npm. Set `DISABLE_INSTALLATION_CHECKS=1` to suppress this. The install script
 adds this to `~/.bashrc` automatically. Do NOT run `claude install`.
 
-**Dual npm prefix gotcha (2026-06-01):** Container systems may have two npm prefix
-locations (`/usr/local` and `/usr`). `which claude` resolves to `/usr/local/bin/claude`,
-so installs must explicitly target that prefix:
+**Dual npm prefix gotcha (2026-06-01, revised 2026-06-10):** Containers may have
+multiple npm prefix locations. The install script now auto-detects which prefix PATH
+resolves by checking `npm config get prefix`:
+- **User-level prefix** (e.g. `~/.npm-global`): installs without sudo or `--prefix`,
+  so `which claude` finds the new binary directly.
+- **System-level prefix** (`/usr/local` or `/usr`): installs with `sudo --prefix /usr/local`
+  to avoid the `/usr/lib` misrouting issue.
+
+For manual upgrades, use plain `npm install -g` (no `--prefix`) — it installs to
+your configured prefix, which is what PATH finds:
 ```bash
-sudo npm install -g --prefix /usr/local @anthropic-ai/claude-code@<version>
+npm install -g @anthropic-ai/claude-code@<version>
 ```
-Running `sudo npm install -g` without `--prefix /usr/local` lands in `/usr/lib/` and
-does not update the `claude` binary on PATH. **`scripts/install.sh` now passes
-`--prefix /usr/local` automatically** — manual upgrades still need it.
+If your prefix requires root (`/usr/local`), add `sudo --prefix /usr/local`.
 
 **Host VM variation (verified 2026-06-10):** The host VM uses CC's **native
 installer** — NOT npm. Versioned binaries live in `~/.local/share/claude/versions/`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1152,20 +1152,28 @@ if command -v claude &>/dev/null; then
     echo "    . Claude Code already installed ($cc_ver)"
 else
     echo "    Installing Claude Code via npm..."
-    # Pin to /usr/local prefix explicitly. Without this, dual-prefix containers
-    # (where the system has both /usr/lib/node_modules and /usr/local/lib/node_modules)
-    # land CC in the wrong place — `which claude` resolves to /usr/local/bin/claude
-    # but the install goes to /usr/lib/. See docs/reference/cc-compatibility.md.
-    _npm_cmd="npm install -g --prefix /usr/local @anthropic-ai/claude-code@${CC_VERSION}"
-    if [ "$(id -u)" != "0" ] && command -v sudo &>/dev/null; then
-        _npm_cmd="sudo npm install -g --prefix /usr/local @anthropic-ai/claude-code@${CC_VERSION}"
+    # Detect the npm prefix that PATH will actually resolve. The user may have
+    # a custom prefix (~/.npm-global) that shadows /usr/local. Install to
+    # whichever prefix `npm config get prefix` returns so `which claude` finds
+    # the new binary. See docs/reference/cc-compatibility.md.
+    _npm_prefix="$(npm config get prefix 2>/dev/null)"
+    if [ -n "$_npm_prefix" ] && [ "$_npm_prefix" != "/usr/local" ] && [ "$_npm_prefix" != "/usr" ]; then
+        # User-level prefix (e.g. ~/.npm-global) — no sudo needed
+        _npm_cmd="npm install -g @anthropic-ai/claude-code@${CC_VERSION}"
+        echo "    Using user npm prefix: $_npm_prefix"
+    else
+        # System prefix — use sudo + explicit /usr/local to avoid /usr/lib misrouting
+        _npm_cmd="npm install -g --prefix /usr/local @anthropic-ai/claude-code@${CC_VERSION}"
+        if [ "$(id -u)" != "0" ] && command -v sudo &>/dev/null; then
+            _npm_cmd="sudo npm install -g --prefix /usr/local @anthropic-ai/claude-code@${CC_VERSION}"
+        fi
     fi
     if timeout 300 $_npm_cmd; then
         cc_ver=$(claude --version 2>/dev/null || echo "unknown")
         echo "    + Claude Code installed ($cc_ver)"
     else
         echo "    WARNING: Claude Code installation failed"
-        echo "    Install manually: sudo npm install -g --prefix /usr/local @anthropic-ai/claude-code@${CC_VERSION}"
+        echo "    Install manually: npm install -g @anthropic-ai/claude-code@${CC_VERSION}"
         SETUP_WARNINGS=1
     fi
 fi


### PR DESCRIPTION
Cherry-picked from the in-flight `fix/cc-npm-prefix-detection` branch to land
this standalone install fix on its own, separate from the incomplete voice-HA
work on that branch.

## Problem
The `--prefix /usr/local` override assumed `which claude` resolves to
`/usr/local/bin/claude`, but machines with a user-level npm prefix
(`~/.npm-global`) have `claude` there instead — making the `/usr/local`
install invisible to PATH.

## Fix
Check `npm config get prefix` and install to the user prefix when it differs
from the system default, falling back to the explicit `/usr/local` prefix for
system-level installs. Updates `docs/reference/cc-compatibility.md` to match.

Touches only `scripts/install.sh` + the compat doc — no overlap with the
voice work it was previously stacked on. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)