### PR TITLE
fix(ego,campaigns): dispatch profile bug + campaign MCP wiring + dashboard UX

### DIFF
--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -4244,7 +4244,10 @@
                         x-text="'$' + ($store.genesisDashboard.egoStatus?.daily_cost_usd || 0).toFixed(2) + ' today'"></span>
                 </div>
               </div>
-              <div class="health-card-reason" x-text="$store.genesisDashboard.egoSemantic().reason"></div>
+              <div class="health-card-reason"
+                   :style="$store.genesisDashboard.egoSemantic().reason?.includes('proposals awaiting') ? 'cursor:pointer; text-decoration:underline;' : ''"
+                   @click="if ($store.genesisDashboard.egoSemantic().reason?.includes('proposals awaiting')) { location.hash = 'chat'; $store.genesisDashboard.commsTab = 'proposals'; $store.genesisDashboard.commsProposalFilter = 'pending'; $store.genesisDashboard.fetchComms(); }"
+                   x-text="$store.genesisDashboard.egoSemantic().reason"></div>
             </div>
           </template>
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1276,10 +1276,16 @@ class EgoSession:
             # catches information that slips through the ego's own judgment.
             prompt = f"{prompt}\n\n{_CONTENT_FIREWALL_RULES}"
 
-            # Map profile and model from brief
-            profile = brief.get("profile", "observe")
-            if profile not in VALID_PROFILES:
-                profile = "observe"
+            # Map profile from brief, falling back to action_type inference.
+            # The ego may omit profile from the brief; defaulting to
+            # "observe" silently killed code-change dispatches (6 instances).
+            brief_profile = brief.get("profile", "")
+            if brief_profile in VALID_PROFILES:
+                profile = brief_profile
+            else:
+                # Infer from proposal action_type if available
+                brief_action = brief.get("action_type", "")
+                profile = _infer_profile(brief_action)
             model_str = brief.get("model", "sonnet")
             if model_str == "opus":
                 model = CCModel.OPUS
@@ -2208,17 +2214,33 @@ _VALID_URGENCIES = frozenset({"low", "normal", "high", "critical"})
 # as defense-in-depth for the essential knowledge injection path.
 
 
-_INTERACT_TYPES = frozenset({"outreach", "dispatch", "publish"})
-_RESEARCH_TYPES = frozenset({"investigate"})
+_INTERACT_TYPES = frozenset({
+    "outreach", "dispatch", "publish",
+    "code_change", "refactor",
+    "maintenance", "config", "optimize",
+    "email", "apply",
+    "notification", "alert",
+    "content", "post",
+    "purchase", "payment",
+})
+_RESEARCH_TYPES = frozenset({
+    "investigate", "research", "analyze",
+    "diagnose", "monitor",
+})
 
 
 def _infer_profile(action_type: str) -> str:
-    """Map proposal action_type to a DirectSession profile."""
+    """Map proposal action_type to a DirectSession profile.
+
+    Covers all action_types from autonomy/classification.py's
+    ACTION_TYPE_DOMAIN_MAP.  Defaults to ``research`` (not ``observe``)
+    so unrecognized types can at least write findings.
+    """
     if action_type in _INTERACT_TYPES:
         return "interact"
     if action_type in _RESEARCH_TYPES:
         return "research"
-    return "observe"
+    return "research"
 
 
 def _validate_output(data: dict) -> dict | None:

--- a/tests/ego/test_dispatch_model.py
+++ b/tests/ego/test_dispatch_model.py
@@ -115,19 +115,73 @@ class TestModelSelectionLogic:
         assert self._select_model("outreach", {}) == CCModel.OPUS
         assert self._select_model("dispatch", {}) == CCModel.OPUS
         assert self._select_model("publish", {}) == CCModel.OPUS
+        assert self._select_model("code_change", {}) == CCModel.OPUS
+        assert self._select_model("refactor", {}) == CCModel.OPUS
+        assert self._select_model("maintenance", {}) == CCModel.OPUS
+        assert self._select_model("email", {}) == CCModel.OPUS
+        assert self._select_model("content", {}) == CCModel.OPUS
 
     def test_interact_override_to_sonnet(self):
         # An explicit override can downgrade interact types
         assert self._select_model("outreach", {"outreach": "sonnet"}) == CCModel.SONNET
 
-    def test_observe_defaults_to_sonnet(self):
+    def test_research_types_default_to_sonnet(self):
         assert self._select_model("monitor", {}) == CCModel.SONNET
+        assert self._select_model("research", {}) == CCModel.SONNET
+        assert self._select_model("analyze", {}) == CCModel.SONNET
+        assert self._select_model("diagnose", {}) == CCModel.SONNET
 
-    def test_observe_with_override(self):
+    def test_research_with_override(self):
         assert self._select_model("monitor", {"monitor": "opus"}) == CCModel.OPUS
 
-    def test_empty_action_type(self):
+    def test_unknown_action_type_defaults_to_research_sonnet(self):
+        # Unknown types now default to research (not observe), still Sonnet
         assert self._select_model("", {}) == CCModel.SONNET
+        assert self._select_model("unknown_action", {}) == CCModel.SONNET
 
     def test_override_haiku(self):
         assert self._select_model("investigate", {"investigate": "haiku"}) == CCModel.HAIKU
+
+
+class TestInferProfile:
+    """Direct tests for _infer_profile — covers all action types from
+    ACTION_TYPE_DOMAIN_MAP in autonomy/classification.py."""
+
+    def test_interact_profile_for_self_modify(self):
+        assert _infer_profile("code_change") == "interact"
+        assert _infer_profile("refactor") == "interact"
+
+    def test_interact_profile_for_internal_write(self):
+        assert _infer_profile("maintenance") == "interact"
+        assert _infer_profile("config") == "interact"
+        assert _infer_profile("optimize") == "interact"
+
+    def test_interact_profile_for_represent_user(self):
+        assert _infer_profile("outreach") == "interact"
+        assert _infer_profile("email") == "interact"
+        assert _infer_profile("apply") == "interact"
+
+    def test_interact_profile_for_external_write(self):
+        assert _infer_profile("publish") == "interact"
+        assert _infer_profile("content") == "interact"
+        assert _infer_profile("post") == "interact"
+
+    def test_interact_profile_for_notify_user(self):
+        assert _infer_profile("notification") == "interact"
+        assert _infer_profile("alert") == "interact"
+
+    def test_interact_profile_for_dispatch(self):
+        assert _infer_profile("dispatch") == "interact"
+
+    def test_research_profile_for_external_read(self):
+        assert _infer_profile("investigate") == "research"
+        assert _infer_profile("research") == "research"
+        assert _infer_profile("analyze") == "research"
+
+    def test_research_profile_for_observe(self):
+        assert _infer_profile("diagnose") == "research"
+        assert _infer_profile("monitor") == "research"
+
+    def test_unknown_defaults_to_research(self):
+        assert _infer_profile("") == "research"
+        assert _infer_profile("something_new") == "research"

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -450,8 +450,8 @@ class TestProcessExecutionBriefs:
         assert req.profile == "research"
         assert req.model.value == "haiku"
 
-    async def test_invalid_profile_defaults_observe(self, ego_with_runner, mock_direct_runner, db):
-        """Invalid profile falls back to observe."""
+    async def test_invalid_profile_infers_from_action_type(self, ego_with_runner, mock_direct_runner, db):
+        """Invalid profile falls back to action_type inference (research default)."""
         await self._insert_proposal(db, "prop_008")
 
         briefs = [{"proposal_id": "prop_008", "prompt": "Do it",
@@ -459,7 +459,7 @@ class TestProcessExecutionBriefs:
         await ego_with_runner._process_execution_briefs(briefs)
 
         req = mock_direct_runner.spawn.call_args[0][0]
-        assert req.profile == "observe"
+        assert req.profile == "research"
 
     async def test_interact_profile_accepted(self, ego_with_runner, mock_direct_runner, db):
         """Interact profile is valid and passes through to the request."""


### PR DESCRIPTION
## Summary
- **Dispatch profile bug**: `_infer_profile()` only recognized 4 action types, defaulting everything else to `observe` (read-only). Code-change, refactor, maintenance dispatches silently failed ($0, 0 tokens). Expanded to cover all 20 action types from `ACTION_TYPE_DOMAIN_MAP`. Changed default fallback from `observe` → `research`. Fixed `_process_execution_briefs` second dispatch path.
- **Campaign MCP wiring**: Campaign tools were only initialized during full server bootstrap, never in standalone MCP mode. CC sessions couldn't access `campaign_list`, `campaign_status`, etc. Wired `init_campaign_tools(runner=None, db=db)` into standalone bootstrap. Added warning responses when runner unavailable.
- **Dashboard UX**: Ego health card "N proposals awaiting review" text was not clickable. Now navigates to Chat → Proposals → Pending filter.

## Test plan
- [x] `tests/ego/test_dispatch_model.py` — 26 tests pass (added `TestInferProfile` with full action_type coverage)
- [x] Lint clean
- [ ] Verify dashboard proposal link navigates correctly
- [ ] Verify campaign_list works in CC session after server restart
- [ ] Verify code_change proposals dispatch with `interact` profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)