### PR TITLE
fix(dashboard): support folder uploads, fix drop-hang on directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Dropping a folder onto the dashboard uploader hung forever** --- dragging a
+  folder onto the Files-tab upload zone got stuck showing the folder's name and
+  never finished, because folders weren't expanded into their contents. Folder
+  drops now upload every file inside, preserving the folder structure under the
+  uploads directory. Single-file and multi-file uploads are unchanged.
+
 - **Eval quality dashboard could stall** --- the nightly memory-scoring job
   timed out and retried from scratch, so the compounding-intelligence
   dashboard stopped getting fresh data and double-counted judgments. The job

--- a/src/genesis/dashboard/routes/files.py
+++ b/src/genesis/dashboard/routes/files.py
@@ -68,6 +68,23 @@ def _deduplicate_filename(directory: Path, name: str) -> str:
     return f"{stem}-{counter}{suffix}"
 
 
+def _sanitize_relpath(relpath: str | None) -> list[str]:
+    """Split a client-supplied relative path into traversal-safe segments.
+
+    Used by folder uploads to preserve directory structure under the uploads
+    root. Each segment is reduced to its basename, run through the filename
+    charset filter, and stripped of leading/trailing dots/spaces — so empty,
+    ``.``, and ``..`` segments collapse away and can never escape the base
+    directory. Returns ``[]`` for empty/invalid input.
+    """
+    segments: list[str] = []
+    for raw in re.split(r"[\\/]+", relpath or ""):
+        seg = _SAFE_FILENAME_RE.sub("_", Path(raw).name).strip(". ")
+        if seg and len(seg) <= _MAX_FILENAME_LEN:
+            segments.append(seg)
+    return segments
+
+
 def _is_allowed(path: Path) -> bool:
     """Check that *path* resolves inside an allowed root and isn't blocked."""
     resolved = path.resolve()
@@ -354,16 +371,31 @@ def file_upload():
     if request.content_length and request.content_length > _MAX_UPLOAD_SIZE:
         return jsonify({"error": f"File too large (>{_MAX_UPLOAD_SIZE // (1024 * 1024)}MB)"}), 413
 
-    safe_name = _sanitize_filename(file.filename)
+    # Optional folder upload: ``relpath`` carries the file's path within a
+    # dropped directory (e.g. "Project/data/notes.txt"). All segments are
+    # sanitized to be traversal-safe; the leading ones become subdirectories
+    # under the uploads root, the last is the filename. Absent/flat uploads
+    # fall back to the file's own name (unchanged single-file behavior).
+    rel_segments = _sanitize_relpath(request.form.get("relpath"))
+    if rel_segments:
+        *subdirs, base_name = rel_segments
+    else:
+        subdirs, base_name = [], _sanitize_filename(file.filename)
+    base_name = base_name or _sanitize_filename(file.filename)
 
-    # Ensure uploads directory exists
-    _UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    dest_dir = _UPLOAD_DIR.joinpath(*subdirs)
 
-    # Deduplicate filename
-    safe_name = _deduplicate_filename(_UPLOAD_DIR, safe_name)
-    dest = _UPLOAD_DIR / safe_name
+    # Containment check BEFORE any filesystem write. The explicit
+    # is_relative_to(_UPLOAD_DIR) guard ensures a crafted relpath can never
+    # escape the uploads root (resolve() works on not-yet-created paths).
+    if not dest_dir.resolve().is_relative_to(_UPLOAD_DIR.resolve()):
+        return jsonify({"error": "Path not allowed"}), 403
 
-    # Security check
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    safe_name = _deduplicate_filename(dest_dir, base_name)
+    dest = dest_dir / safe_name
+
+    # Leaf-level guard: blocked names (secrets.env, .env, …) and allowlist.
     if not _is_allowed(dest):
         return jsonify({"error": "Path not allowed"}), 403
 
@@ -375,10 +407,11 @@ def file_upload():
         dest.unlink()
         return jsonify({"error": f"File too large (>{_MAX_UPLOAD_SIZE // (1024 * 1024)}MB)"}), 413
 
-    logger.info("File uploaded: %s (%d bytes)", safe_name, file_size)
+    rel_display = "/".join([*subdirs, safe_name])
+    logger.info("File uploaded: %s (%d bytes)", rel_display, file_size)
 
     return jsonify({
         "path": str(dest),
-        "filename": safe_name,
+        "filename": rel_display,
         "size": file_size,
     })

--- a/src/genesis/dashboard/routes/files.py
+++ b/src/genesis/dashboard/routes/files.py
@@ -381,27 +381,37 @@ def file_upload():
         *subdirs, base_name = rel_segments
     else:
         subdirs, base_name = [], _sanitize_filename(file.filename)
-    base_name = base_name or _sanitize_filename(file.filename)
+    # base_name is always non-empty here (_sanitize_relpath keeps only truthy
+    # segments; _sanitize_filename defaults to "unnamed").
 
     dest_dir = _UPLOAD_DIR.joinpath(*subdirs)
 
-    # Containment check BEFORE any filesystem write. The explicit
-    # is_relative_to(_UPLOAD_DIR) guard ensures a crafted relpath can never
-    # escape the uploads root (resolve() works on not-yet-created paths).
-    if not dest_dir.resolve().is_relative_to(_UPLOAD_DIR.resolve()):
+    # Validate BEFORE any filesystem write. Two guards: containment to the
+    # uploads root (defends even if sanitization ever regresses — resolve()
+    # works on not-yet-created paths) and the leaf/component guard (blocked
+    # names like secrets.env, "secret" in any path part, allowlist). Dedup
+    # only appends a numeric suffix, so checking the pre-dedup name is correct
+    # and avoids creating directories for a request we're about to reject.
+    candidate = dest_dir / base_name
+    if not dest_dir.resolve().is_relative_to(_UPLOAD_DIR.resolve()) or not _is_allowed(candidate):
         return jsonify({"error": "Path not allowed"}), 403
 
-    dest_dir.mkdir(parents=True, exist_ok=True)
-    safe_name = _deduplicate_filename(dest_dir, base_name)
-    dest = dest_dir / safe_name
-
-    # Leaf-level guard: blocked names (secrets.env, .env, …) and allowlist.
-    if not _is_allowed(dest):
-        return jsonify({"error": "Path not allowed"}), 403
-
-    # Save and verify size (content_length can be spoofed, so double-check)
-    file.save(str(dest))
-    file_size = dest.stat().st_size
+    # Create the validated destination and write. Guard the filesystem ops: a
+    # relpath subdir can collide with an existing file (FileExistsError), and
+    # writes can fail (disk full, permissions) — return a clean error, not a
+    # 500 stack trace.
+    try:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        safe_name = _deduplicate_filename(dest_dir, base_name)
+        dest = dest_dir / safe_name
+        # Save and verify size (content_length can be spoofed, so double-check)
+        file.save(str(dest))
+        file_size = dest.stat().st_size
+    except OSError as exc:
+        logger.warning(
+            "Upload failed for %r: %s", request.form.get("relpath") or file.filename, exc
+        )
+        return jsonify({"error": "Could not save file"}), 400
 
     if file_size > _MAX_UPLOAD_SIZE:
         dest.unlink()

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -722,12 +722,13 @@
           }
 
           this.fileUpload.uploading = true;
-          // Build the work list of { file, relpath }. If any dropped entry is a
-          // folder, walk all entries (files + folders) preserving structure;
+          // Build the work list of { file, relpath }. If an actual folder was
+          // dropped, walk all entries (files + folders) preserving structure;
           // otherwise use the flat file list (drop or click-to-browse).
+          const droppedFolder = !!(dirEntries && dirEntries.some((e) => e && e.isDirectory));
           let items = [];
           try {
-            if (dirEntries && dirEntries.some((e) => e && e.isDirectory)) {
+            if (droppedFolder) {
               this.fileUpload.progress = "Reading folder…";
               items = await this._collectDroppedFiles(dirEntries);
             } else {
@@ -743,7 +744,7 @@
           if (items.length === 0) {
             this.fileUpload.progress = null;
             this.fileUpload.uploading = false;
-            if (dirEntries) this.fileUpload.error = "No files found in the dropped folder.";
+            if (droppedFolder) this.fileUpload.error = "No files found in the dropped folder.";
             if (event.target && event.target.value !== undefined) { event.target.value = ""; }
             return;
           }
@@ -751,6 +752,10 @@
           const uploaded = [];
           const failures = [];
           let lastDir = null;
+          // Uploads root (…/uploads), derived from the first success by stripping
+          // the returned relative path — used as the destination shown for
+          // folder / multi-file uploads instead of one file's deep subfolder.
+          let uploadRoot = null;
           // Upload each file sequentially via the single-file endpoint so every
           // file gets the backend's sanitize / dedup / size-cap checks. The
           // file's relative path (relpath) lets the backend recreate folder
@@ -769,6 +774,9 @@
                 const data = await resp.json();
                 uploaded.push(data.filename);
                 lastDir = data.path.substring(0, data.path.lastIndexOf("/"));
+                if (uploadRoot === null && typeof data.filename === "string") {
+                  uploadRoot = data.path.slice(0, data.path.length - data.filename.length).replace(/\/$/, "");
+                }
               } else {
                 const err = resp ? await resp.json() : {};
                 failures.push(`${relpath}: ${err.error || "failed"}`);
@@ -780,7 +788,8 @@
           this.fileUpload.progress = null;
           this.fileUpload.uploading = false;
           if (uploaded.length) {
-            const dest = lastDir || "~/.genesis/uploads";
+            // Single file → its own directory; multi/folder → the uploads root.
+            const dest = (uploaded.length === 1 ? lastDir : uploadRoot) || "~/.genesis/uploads";
             this.fileUpload.success = uploaded.length === 1
               ? `Uploaded ${uploaded[0]} → ${dest}`
               : `Uploaded ${uploaded.length} files → ${dest} (${uploaded.join(", ")})`;

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -676,6 +676,33 @@
           } catch (e) { alert("Save failed: " + e.message); }
           this.fileBrowser.saving = false;
         },
+        // Recursively walk dropped directory entries (File and Directory
+        // Entries API) into a flat list of { file, relpath }. Folders dropped
+        // onto the zone arrive as FileSystemEntry objects, not plain Files —
+        // without this they'd be appended to FormData as unreadable dirs and
+        // the request would hang. The entries themselves stay valid across
+        // awaits; only the parent DataTransferItemList does not, so callers
+        // must capture entries synchronously before the first await.
+        async _collectDroppedFiles(entries) {
+          const out = [];
+          const walk = async (entry) => {
+            if (entry.isFile) {
+              const file = await new Promise((res, rej) => entry.file(res, rej));
+              out.push({ file, relpath: entry.fullPath.replace(/^\/+/, "") });
+            } else if (entry.isDirectory) {
+              const reader = entry.createReader();
+              // readEntries returns at most ~100 children per call; loop until
+              // it yields an empty batch.
+              while (true) {
+                const batch = await new Promise((res, rej) => reader.readEntries(res, rej));
+                if (!batch.length) break;
+                for (const child of batch) await walk(child);
+              }
+            }
+          };
+          for (const e of entries) await walk(e);
+          return out;
+        },
         async uploadFile(event) {
           event.preventDefault();
           this.fileUpload.dragging = false;
@@ -685,22 +712,58 @@
           if (this.fileUpload.uploading) return;
           this.fileUpload.error = null;
           this.fileUpload.success = null;
-          const fileList = Array.from(event.dataTransfer?.files || event.target?.files || []);
-          if (fileList.length === 0) return;
+
+          // Capture directory entries SYNCHRONOUSLY — the DataTransferItemList
+          // is invalidated once this handler yields to an await.
+          let dirEntries = null;
+          const dt = event.dataTransfer;
+          if (dt && dt.items && dt.items.length && typeof dt.items[0].webkitGetAsEntry === "function") {
+            dirEntries = Array.from(dt.items, (it) => it.webkitGetAsEntry()).filter(Boolean);
+          }
+
           this.fileUpload.uploading = true;
+          // Build the work list of { file, relpath }. If any dropped entry is a
+          // folder, walk all entries (files + folders) preserving structure;
+          // otherwise use the flat file list (drop or click-to-browse).
+          let items = [];
+          try {
+            if (dirEntries && dirEntries.some((e) => e && e.isDirectory)) {
+              this.fileUpload.progress = "Reading folder…";
+              items = await this._collectDroppedFiles(dirEntries);
+            } else {
+              const flat = Array.from(dt?.files || event.target?.files || []);
+              items = flat.map((f) => ({ file: f, relpath: f.name }));
+            }
+          } catch (e) {
+            this.fileUpload.error = `Could not read dropped items: ${e.message}`;
+            this.fileUpload.progress = null;
+            this.fileUpload.uploading = false;
+            return;
+          }
+          if (items.length === 0) {
+            this.fileUpload.progress = null;
+            this.fileUpload.uploading = false;
+            if (dirEntries) this.fileUpload.error = "No files found in the dropped folder.";
+            if (event.target && event.target.value !== undefined) { event.target.value = ""; }
+            return;
+          }
+
           const uploaded = [];
           const failures = [];
           let lastDir = null;
           // Upload each file sequentially via the single-file endpoint so every
-          // file gets the backend's sanitize / dedup / size-cap checks.
-          for (let i = 0; i < fileList.length; i++) {
-            const f = fileList[i];
-            this.fileUpload.progress = fileList.length > 1
-              ? `Uploading ${i + 1} of ${fileList.length}: ${f.name}`
-              : `Uploading ${f.name}...`;
+          // file gets the backend's sanitize / dedup / size-cap checks. The
+          // file's relative path (relpath) lets the backend recreate folder
+          // structure under the uploads root.
+          for (let i = 0; i < items.length; i++) {
+            const { file: f, relpath } = items[i];
+            this.fileUpload.progress = items.length > 1
+              ? `Uploading ${i + 1} of ${items.length}: ${relpath}`
+              : `Uploading ${relpath}...`;
             try {
               const form = new FormData();
               form.append("file", f);
+              form.append("relpath", relpath);
               const resp = await fetchApi("/api/genesis/files/upload", { method: "POST", body: form });
               if (resp && resp.ok) {
                 const data = await resp.json();
@@ -708,10 +771,10 @@
                 lastDir = data.path.substring(0, data.path.lastIndexOf("/"));
               } else {
                 const err = resp ? await resp.json() : {};
-                failures.push(`${f.name}: ${err.error || "failed"}`);
+                failures.push(`${relpath}: ${err.error || "failed"}`);
               }
             } catch (e) {
-              failures.push(`${f.name}: ${e.message}`);
+              failures.push(`${relpath}: ${e.message}`);
             }
           }
           this.fileUpload.progress = null;
@@ -7924,7 +7987,7 @@
              @click="$refs.fileUploadInput.click()"
              :style="`border: 1px dashed ${$store.genesisDashboard.fileUpload.dragging ? 'var(--color-accent)' : 'var(--color-border)'}; border-radius: 6px; padding: 0.6rem 1rem; text-align: center; cursor: pointer; margin-bottom: 0.75rem; transition: border-color .2s; background: ${$store.genesisDashboard.fileUpload.dragging ? 'rgba(99,102,241,.06)' : 'transparent'};`">
           <span style="font-size: .8rem; color: var(--color-text-secondary);"
-                x-text="$store.genesisDashboard.fileUpload.uploading ? ($store.genesisDashboard.fileUpload.progress || 'Uploading...') : 'Drop files here to upload — no processing, just storage'"></span>
+                x-text="$store.genesisDashboard.fileUpload.uploading ? ($store.genesisDashboard.fileUpload.progress || 'Uploading...') : 'Drop files or folders here to upload — no processing, just storage'"></span>
           <input type="file" multiple x-ref="fileUploadInput" style="display:none" @change="$store.genesisDashboard.uploadFile($event)">
         </div>
         <template x-if="$store.genesisDashboard.fileUpload.error">

--- a/tests/test_dashboard/test_files_api.py
+++ b/tests/test_dashboard/test_files_api.py
@@ -1,6 +1,9 @@
-"""Tests for the file browser download endpoint."""
+"""Tests for the file browser upload and download endpoints."""
 
 from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
 
 import pytest
 from flask import Flask
@@ -15,13 +18,17 @@ def app(tmp_path):
     app.register_blueprint(blueprint)
     app.config["TESTING"] = True
 
-    # Patch allowed roots to use tmp_path
+    # Patch allowed roots AND the uploads dir to use tmp_path, so upload tests
+    # never touch the real ~/.genesis/uploads.
     import genesis.dashboard.routes.files as files_mod
 
     original_roots = files_mod._ALLOWED_ROOTS
+    original_upload = files_mod._UPLOAD_DIR
     files_mod._ALLOWED_ROOTS = [tmp_path]
+    files_mod._UPLOAD_DIR = tmp_path / "uploads"
     yield app
     files_mod._ALLOWED_ROOTS = original_roots
+    files_mod._UPLOAD_DIR = original_upload
 
 
 @pytest.fixture()
@@ -114,3 +121,86 @@ def test_download_symlink_to_blocked(client, tmp_path):
 
     resp = client.get(f"/api/genesis/files/download?path={link}")
     assert resp.status_code == 403
+
+
+# ── Upload endpoint ───────────────────────────────────────────────────
+
+
+def _post_upload(client, content: bytes, filename: str, relpath: str | None = None):
+    """Helper to POST a multipart file upload, optionally with a relpath."""
+    data = {"file": (BytesIO(content), filename)}
+    if relpath is not None:
+        data["relpath"] = relpath
+    return client.post(
+        "/api/genesis/files/upload", data=data, content_type="multipart/form-data"
+    )
+
+
+def test_upload_single_file(client, tmp_path):
+    """A plain file (no relpath) lands directly in the uploads root."""
+    resp = _post_upload(client, b"hello world", "notes.txt")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["filename"] == "notes.txt"
+    dest = tmp_path / "uploads" / "notes.txt"
+    assert dest.read_bytes() == b"hello world"
+
+
+def test_upload_preserves_folder_structure(client, tmp_path):
+    """A relpath recreates the folder tree under the uploads root."""
+    resp = _post_upload(
+        client, b"data", "notes.txt", relpath="FDE Project Challenge/data/notes.txt"
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["filename"] == "FDE Project Challenge/data/notes.txt"
+    dest = tmp_path / "uploads" / "FDE Project Challenge" / "data" / "notes.txt"
+    assert dest.read_bytes() == b"data"
+
+
+def test_upload_relpath_traversal_stays_contained(client, tmp_path):
+    """Traversal segments (..) are dropped; the file cannot escape uploads."""
+    resp = _post_upload(client, b"x", "evil.txt", relpath="../../etc/evil.txt")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    # ".." segments dropped → lands at uploads/etc/evil.txt, still contained.
+    uploads = (tmp_path / "uploads").resolve()
+    assert uploads in Path(body["path"]).resolve().parents
+    assert (tmp_path / "uploads" / "etc" / "evil.txt").exists()
+    # Nothing was written outside the uploads sandbox.
+    assert not (tmp_path / "etc").exists()
+
+
+def test_upload_absolute_relpath_reinterpreted_under_uploads(client, tmp_path):
+    """An absolute-looking relpath is treated as relative to the uploads root."""
+    resp = _post_upload(client, b"x", "passwd", relpath="/etc/passwd")
+    assert resp.status_code == 200
+    assert (tmp_path / "uploads" / "etc" / "passwd").exists()
+
+
+def test_upload_deduplicates_within_folder(client, tmp_path):
+    """Uploading the same relpath twice keeps both via -1 suffix."""
+    _post_upload(client, b"first", "notes.txt", relpath="Proj/notes.txt")
+    resp2 = _post_upload(client, b"second", "notes.txt", relpath="Proj/notes.txt")
+    assert resp2.status_code == 200
+    assert (tmp_path / "uploads" / "Proj" / "notes.txt").read_bytes() == b"first"
+    assert (tmp_path / "uploads" / "Proj" / "notes-1.txt").read_bytes() == b"second"
+
+
+def test_upload_blocked_leaf_name(client, tmp_path):
+    """A blocked filename (secrets.env) as the leaf is rejected with 403."""
+    resp = _post_upload(client, b"SECRET=1", "secrets.env", relpath="Proj/secrets.env")
+    assert resp.status_code == 403
+
+
+def test_upload_too_large(client, tmp_path):
+    """A file exceeding the upload size limit returns 413."""
+    import genesis.dashboard.routes.files as files_mod
+
+    original_limit = files_mod._MAX_UPLOAD_SIZE
+    files_mod._MAX_UPLOAD_SIZE = 100
+    try:
+        resp = _post_upload(client, b"x" * 200, "big.txt")
+        assert resp.status_code == 413
+    finally:
+        files_mod._MAX_UPLOAD_SIZE = original_limit

--- a/tests/test_dashboard/test_files_api.py
+++ b/tests/test_dashboard/test_files_api.py
@@ -193,6 +193,26 @@ def test_upload_blocked_leaf_name(client, tmp_path):
     assert resp.status_code == 403
 
 
+def test_upload_subdir_collides_with_existing_file(client, tmp_path):
+    """A relpath subdir colliding with an existing file returns a clean 400, not 500."""
+    # Pre-create a regular file where the folder upload wants a directory.
+    uploads = tmp_path / "uploads"
+    uploads.mkdir(parents=True, exist_ok=True)
+    (uploads / "data").write_text("i am a file, not a dir")
+
+    resp = _post_upload(client, b"x", "x.txt", relpath="data/x.txt")
+    assert resp.status_code == 400
+    assert "save" in resp.get_json()["error"].lower()
+
+
+def test_upload_blocked_subdir_creates_no_orphan_dir(client, tmp_path):
+    """A relpath whose subdir is blocked is rejected WITHOUT creating the dir."""
+    resp = _post_upload(client, b"x", "x.txt", relpath="topsecret/x.txt")
+    assert resp.status_code == 403
+    # The rejected upload must not have created the directory on disk.
+    assert not (tmp_path / "uploads" / "topsecret").exists()
+
+
 def test_upload_too_large(client, tmp_path):
     """A file exceeding the upload size limit returns 413."""
     import genesis.dashboard.routes.files as files_mod


### PR DESCRIPTION
## Problem

Dragging a **folder** onto the dashboard Files-tab upload zone hung forever, stuck showing the folder's name. `dataTransfer.files` delivers a dropped directory as a single unreadable `File`, which `FormData`/`fetch` then stalls on — the request never resolves, so the UI freezes.

## Fix

**Frontend** (`genesis_dashboard.html`): dropped folders are now walked via the File and Directory Entries API (`webkitGetAsEntry`/`readEntries`) into their individual files, each posted with a relative path. Drag-drop only; single-file and multi-file uploads are unchanged. Entries are captured synchronously before the first `await` (the `DataTransferItemList` is invalidated once the handler yields), and `readEntries` is looped to handle its ~100-entry pagination.

**Backend** (`routes/files.py`): `file_upload()` honors an optional `relpath` form field and recreates the folder structure under the uploads root. Each path segment is sanitized to be traversal-safe (reusing the existing filename charset filter); validation (containment + blocked-name/allowlist guards) runs **before** any filesystem write, and `mkdir`/`save` are wrapped so a subdir colliding with an existing file — or a write error — returns a clean error instead of a 500.

## Tests

`tests/test_dashboard/test_files_api.py` gains upload coverage: folder-structure preservation, traversal containment (`../../etc` stays inside uploads), absolute-path reinterpretation, dedup within a folder, blocked leaf name, subdir/file collision → clean 400, and the size cap.

## Verification

- 18 backend tests pass (real Flask WSGI dispatch).
- Real-HTTP E2E: a 3-level nested folder recreates exactly under uploads; `../../etc/evil.txt` lands contained with nothing escaping.
- Frontend traversal logic verified via a Node simulation of the exact functions; the page's inline script syntax-checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)