### PR TITLE
feat(voice): Phase 3C — full-duplex barge-in + interrupt plumbing

### DIFF
--- a/config/voice-pe/esphome/components/voice_assistant_websocket/voice_assistant_websocket.cpp
+++ b/config/voice-pe/esphome/components/voice_assistant_websocket/voice_assistant_websocket.cpp
@@ -469,8 +469,16 @@ void VoiceAssistantWebSocket::on_microphone_data_(const std::vector<uint8_t> &da
     return;
   }
   
-  // Block microphone audio if bot is currently speaking
-  if (this->is_bot_speaking()) {
+  // Block microphone audio if bot is currently speaking — unless
+  // full-duplex mode is enabled (experimental open-mic barge-in).
+  //
+  // AEC experiment (2026-06-09): XMOS hardware AEC partially works
+  // (first ~7s clean) but is not robust — Voice PE lacks the I2S
+  // reference trace for proper hardware AEC, and the old threshold
+  // server_vad (0.5) triggered on residual echo + ambient noise,
+  // causing an interrupt cascade. Re-testing under SemanticTurnDetection
+  // + near_field noise reduction via the Full Duplex Mode switch.
+  if (!this->full_duplex_ && this->is_bot_speaking()) {
     return;  // Don't send microphone audio while bot is speaking
   }
   
@@ -636,6 +644,13 @@ void VoiceAssistantWebSocket::handle_websocket_event_(esp_websocket_event_id_t e
           if (this->speaker_ != nullptr) {
             this->speaker_->stop();
           }
+          // Mirror the send-path interrupt cleanup (see interrupt()):
+          // clear queued audio so loop() doesn't resume stale playback,
+          // and briefly ignore in-flight audio from the server.
+          while (!this->audio_queue_.empty()) {
+            this->audio_queue_.pop();
+          }
+          this->interrupt_time_ = millis();
         } else if (message.find("\"type\":\"disconnect\"") != std::string::npos ||
                    message.find("\"type\": \"disconnect\"") != std::string::npos) {
           ESP_LOGI(TAG, "Disconnect message received, stopping voice assistant and going to idle");

--- a/config/voice-pe/esphome/components/voice_assistant_websocket/voice_assistant_websocket.cpp
+++ b/config/voice-pe/esphome/components/voice_assistant_websocket/voice_assistant_websocket.cpp
@@ -57,7 +57,18 @@ void VoiceAssistantWebSocket::loop() {
     ESP_LOGI(TAG, "Voice Assistant WebSocket stopped");
     return;  // Skip other loop operations after disconnect
   }
-  
+
+  // Handle server-initiated interrupt cleanup (flag set from the websocket
+  // task — audio_queue_ must only be touched from the main loop task)
+  if (this->pending_interrupt_cleanup_) {
+    this->pending_interrupt_cleanup_ = false;
+    while (!this->audio_queue_.empty()) {
+      this->audio_queue_.pop();
+    }
+    this->interrupt_time_ = millis();
+    ESP_LOGI(TAG, "Cleared queued audio after server interrupt");
+  }
+
   // Try to process queued audio if speaker is running
   if (this->speaker_ != nullptr && this->speaker_->is_running() && !this->audio_queue_.empty()) {
     const std::vector<uint8_t> &queued_data = this->audio_queue_.front();
@@ -644,13 +655,16 @@ void VoiceAssistantWebSocket::handle_websocket_event_(esp_websocket_event_id_t e
           if (this->speaker_ != nullptr) {
             this->speaker_->stop();
           }
-          // Mirror the send-path interrupt cleanup (see interrupt()):
-          // clear queued audio so loop() doesn't resume stale playback,
-          // and briefly ignore in-flight audio from the server.
-          while (!this->audio_queue_.empty()) {
-            this->audio_queue_.pop();
+          // Debounce: when WE initiated the interrupt (send path), the
+          // server echoes it back — cleanup already ran, don't re-arm the
+          // ignore window.
+          if (this->interrupt_time_ == 0 ||
+              (millis() - this->interrupt_time_) >= INTERRUPT_IGNORE_AUDIO_MS) {
+            // Defer queue cleanup to loop(): audio_queue_ is not
+            // thread-safe and this handler runs on the websocket task
+            // (same pattern as pending_disconnect_).
+            this->pending_interrupt_cleanup_ = true;
           }
-          this->interrupt_time_ = millis();
         } else if (message.find("\"type\":\"disconnect\"") != std::string::npos ||
                    message.find("\"type\": \"disconnect\"") != std::string::npos) {
           ESP_LOGI(TAG, "Disconnect message received, stopping voice assistant and going to idle");

--- a/config/voice-pe/esphome/components/voice_assistant_websocket/voice_assistant_websocket.h
+++ b/config/voice-pe/esphome/components/voice_assistant_websocket/voice_assistant_websocket.h
@@ -45,6 +45,12 @@ class VoiceAssistantWebSocket : public Component {
   bool is_running() const { return this->state_ == VOICE_ASSISTANT_WEBSOCKET_RUNNING; }
   bool is_connected() const { return this->websocket_client_ != nullptr && esp_websocket_client_is_connected(this->websocket_client_); }
   bool is_bot_speaking() const;  // Check if bot is currently speaking (within 1500ms of last audio)
+
+  // Full-duplex mode: when enabled, microphone audio streams to the server
+  // even while the bot is speaking (experimental open-mic barge-in —
+  // relies on server-side semantic VAD + noise reduction to reject echo).
+  void set_full_duplex(bool enabled) { this->full_duplex_ = enabled; }
+  bool is_full_duplex() const { return this->full_duplex_; }
   
   void set_state_callback(std::function<void(VoiceAssistantWebSocketState)> &&callback) {
     this->state_callback_ = std::move(callback);
@@ -88,6 +94,7 @@ class VoiceAssistantWebSocket : public Component {
   Trigger<> bot_started_speaking_trigger_{};
   Trigger<> bot_stopped_speaking_trigger_{};
   bool was_bot_speaking_{false};  // For edge detection in loop()
+  bool full_duplex_{false};  // Open-mic barge-in (set via Full Duplex Mode switch)
   
   // Audio buffers
   std::vector<uint8_t> input_buffer_;

--- a/config/voice-pe/esphome/components/voice_assistant_websocket/voice_assistant_websocket.h
+++ b/config/voice-pe/esphome/components/voice_assistant_websocket/voice_assistant_websocket.h
@@ -95,6 +95,7 @@ class VoiceAssistantWebSocket : public Component {
   Trigger<> bot_stopped_speaking_trigger_{};
   bool was_bot_speaking_{false};  // For edge detection in loop()
   bool full_duplex_{false};  // Open-mic barge-in (set via Full Duplex Mode switch)
+  bool pending_interrupt_cleanup_{false};  // Set from websocket task; loop() drains audio_queue_
   
   // Audio buffers
   std::vector<uint8_t> input_buffer_;

--- a/config/voice-pe/voice_pe_config.yaml
+++ b/config/voice-pe/voice_pe_config.yaml
@@ -230,6 +230,21 @@ switch:
     entity_category: config
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
+  # Full Duplex Mode — experimental open-mic barge-in. When ON, mic audio
+  # streams to the server even while the bot speaks (semantic VAD + noise
+  # reduction must reject the speaker echo). ALWAYS_OFF: the experiment
+  # never survives a reboot.
+  - platform: template
+    id: full_duplex_mode
+    name: "Full Duplex Mode"
+    icon: "mdi:account-voice"
+    entity_category: config
+    optimistic: true
+    restore_mode: ALWAYS_OFF
+    turn_on_action:
+      - lambda: 'id(voice_assistant_ws).set_full_duplex(true);'
+    turn_off_action:
+      - lambda: 'id(voice_assistant_ws).set_full_duplex(false);'
   - platform: gpio
     pin: GPIO47
     id: internal_speaker_amp

--- a/src/genesis/channels/voice/s2s_bridge/app/interrupt_relay.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/interrupt_relay.py
@@ -1,0 +1,47 @@
+"""Relay client-initiated interrupts into the pipeline."""
+import logging
+
+from pipecat.frames.frames import Frame, InputTransportMessageFrame
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.services.openai.realtime import events
+
+logger = logging.getLogger(__name__)
+
+
+class InterruptRelay(FrameProcessor):
+    """Converts firmware ``{"type": "interrupt"}`` messages into interruptions.
+
+    The Voice PE firmware sends an interrupt text frame when the user barges
+    in via the wake word during bot speech (it also stops its own speaker
+    locally). This processor completes the server side:
+
+    1. Cancels the in-flight OpenAI response. The service only does this
+       itself when turn detection is disabled (``_handle_interruption``);
+       with semantic VAD the server cancels on ``speech_started``, which
+       never fires for client-side interrupts because the firmware mic gate
+       blocked the wake word audio.
+    2. Broadcasts an ``InterruptionFrame`` — truncates the OpenAI context,
+       flushes queued output audio, and (via the output transport +
+       ``RawAudioSerializer``) echoes the interrupt back to the device.
+    """
+
+    def __init__(self, openai_service, **kwargs):
+        super().__init__(**kwargs)
+        self._openai_service = openai_service
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+
+        if isinstance(frame, InputTransportMessageFrame) and self._is_interrupt(frame.message):
+            logger.info("🖐️ Client interrupt received — cancelling response and broadcasting interruption")
+            try:
+                await self._openai_service.send_client_event(events.ResponseCancelEvent())
+            except Exception as exc:
+                logger.warning("Could not cancel OpenAI response: %s", exc)
+            await self.broadcast_interruption()
+
+        await self.push_frame(frame, direction)
+
+    @staticmethod
+    def _is_interrupt(message) -> bool:
+        return isinstance(message, dict) and message.get("type") == "interrupt"

--- a/src/genesis/channels/voice/s2s_bridge/app/interrupt_relay.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/interrupt_relay.py
@@ -39,6 +39,7 @@ class InterruptRelay(FrameProcessor):
             except Exception as exc:
                 logger.warning("Could not cancel OpenAI response: %s", exc)
             await self.broadcast_interruption()
+            return  # consume the control message — nothing downstream needs it
 
         await self.push_frame(frame, direction)
 

--- a/src/genesis/channels/voice/s2s_bridge/app/raw_audio_serializer.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/raw_audio_serializer.py
@@ -1,26 +1,49 @@
 """Simple serializer for raw binary PCM audio frames."""
+import json
 import logging
 
-from pipecat.frames.frames import Frame, InputAudioRawFrame, OutputAudioRawFrame
+from pipecat.frames.frames import (
+    Frame,
+    InputAudioRawFrame,
+    InputTransportMessageFrame,
+    InterruptionFrame,
+    OutputAudioRawFrame,
+)
 from pipecat.serializers.base_serializer import FrameSerializer
 
 logger = logging.getLogger(__name__)
 
 
 class RawAudioSerializer(FrameSerializer):
-    """Serializer that treats all binary messages as raw PCM audio."""
+    """Serializer for the Voice PE protocol.
 
-    async def deserialize(self, message: bytes) -> InputAudioRawFrame:
-        """Deserialize binary message as raw PCM audio frame.
+    Binary WebSocket frames carry raw PCM audio (16-bit, 24kHz, mono).
+    Text frames carry JSON control messages (e.g. ``{"type": "interrupt"}``).
+    """
+
+    async def deserialize(self, message: bytes | str) -> Frame | None:
+        """Deserialize a WebSocket message into a pipeline frame.
 
         Args:
-            message: Binary PCM audio data (16-bit, 24kHz, mono)
+            message: Binary PCM audio data (16-bit, 24kHz, mono) or a JSON
+                text control message from the firmware.
 
         Returns:
-            InputAudioRawFrame with the audio data, or None if invalid
+            InputAudioRawFrame for audio, InputTransportMessageFrame for
+            control messages, or None if invalid.
         """
+        if isinstance(message, str):
+            # Text frames are JSON control messages from the firmware
+            # (e.g. wake-word barge-in sends {"type": "interrupt"}).
+            try:
+                data = json.loads(message)
+            except ValueError:
+                logger.warning(f"⚠️ Ignoring non-JSON text message: {message[:100]}")
+                return None
+            logger.info(f"📥 Control message from client: {data}")
+            return InputTransportMessageFrame(message=data)
+
         if not isinstance(message, bytes):
-            # Skip non-binary messages (text/JSON)
             return None
 
         # Validate audio format: 16-bit = 2 bytes per sample
@@ -38,16 +61,26 @@ class RawAudioSerializer(FrameSerializer):
 
         return frame
 
-    async def serialize(self, frame: Frame) -> bytes:
-        """Serialize frame to binary message.
+    async def serialize(self, frame: Frame) -> bytes | str:
+        """Serialize a frame to a WebSocket message.
 
-        For output audio frames, we just return the raw audio bytes.
-        Other frames are not serialized (return empty bytes).
+        Output audio frames become binary messages (raw PCM bytes).
+        InterruptionFrame becomes a JSON text message — the firmware stops
+        its speaker and clears buffered audio on receipt (a str return is
+        sent as a WebSocket text frame by the websockets library).
+        Other frames are not serialized (empty bytes are skipped by the
+        transport's send guard).
         """
         if isinstance(frame, OutputAudioRawFrame):
             audio_bytes = frame.audio
             logger.debug(f"📤 Serializing OutputAudioRawFrame: {len(audio_bytes)} bytes")
             return audio_bytes
+        if isinstance(frame, InterruptionFrame):
+            # The websocket output transport forwards InterruptionFrame here
+            # (pipecat server.py process_frame). Tell the device to stop
+            # playback immediately instead of draining its local buffer.
+            logger.info("📤 Sending interrupt control message to client")
+            return '{"type":"interrupt"}'
         # For other frame types, return empty bytes (not serialized)
         logger.debug(f"📤 Serializing non-audio frame: {type(frame).__name__}, returning empty bytes")
         return b""

--- a/src/genesis/channels/voice/s2s_bridge/app/websocket_handler.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/websocket_handler.py
@@ -19,6 +19,7 @@ from pipecat.services.openai.realtime.llm import OpenAIRealtimeLLMService
 from pipecat.transports.websocket.server import WebsocketServerParams, WebsocketServerTransport
 
 from app.audio_recording_service import AudioRecordingService
+from app.interrupt_relay import InterruptRelay
 from app.raw_audio_serializer import RawAudioSerializer
 from app.session_manager import SessionManager
 
@@ -158,9 +159,15 @@ class WebSocketHandler:
             context_aggregator = self.session_manager.create_context_aggregator(client_id)
             context_initializer = self.session_manager.create_context_initializer(client_id, context_aggregator)
 
+        # Relay firmware {"type":"interrupt"} messages into the pipeline
+        # (wake-word barge-in during bot speech). Placed right after
+        # transport input so interrupts act before anything else.
+        interrupt_relay = InterruptRelay(openai_service=openai_service)
+
         # Build pipeline components
         pipeline_components = [
             transport.input(),
+            interrupt_relay,
             input_activity_tracker,
         ]
 


### PR DESCRIPTION
## Summary

Restores interrupt/barge-in in both directions (broken since the 1.3.0 upgrade removed `on_client_message`) and adds experimental Full Duplex Mode for talk-over interrupts without a wake word.

**Bridge (addon):**
- `raw_audio_serializer.py`: text frames → `InputTransportMessageFrame` (in), `InterruptionFrame` → `{"type":"interrupt"}` text frame (out)
- `interrupt_relay.py` (new): converts client interrupt messages into `ResponseCancelEvent` + `broadcast_interruption()`, consumes the control frame
- Wired into pipeline in `websocket_handler.py`

**Firmware (Voice PE):**
- Receive-interrupt handler hardened: defers `audio_queue_` drain to `loop()` via `pending_interrupt_cleanup_` flag (thread safety — websocket task ≠ main task), debounces server echo
- Full Duplex Mode template switch: HA-toggleable (`ALWAYS_OFF` on boot), bypasses mic gate when ON
- AEC experiment history ported to code comments

**Code review findings fixed:**
1. Interrupt frame consumed at relay (not leaked downstream)
2. `audio_queue_` race resolved via deferred flag pattern
3. Server echo debounced to prevent re-triggering device handler

## E2E Results (2026-06-13)

- Full Duplex Mode ON + `semantic_vad_eagerness: low`
- 4 successful talk-over interrupts in ~60s conversation
- No echo cascade, no false triggers from background noise
- Speaker stops cleanly, queued audio cleared, 500ms ignore window, new response resumes
- Tool calls work, context cached (8 messages)
- Wake-word barge-in structurally wired but untested (micro_wake_word unreliable — separate retraining effort)

## Test plan

- [x] ruff + py_compile on bridge files
- [x] Serializer smoke test (deserialize text, serialize InterruptionFrame, audio passthrough)
- [x] Code review with 3 critical findings fixed
- [x] Deployed to HA, firmware OTA flashed
- [x] E2E: conversation + tool call regression pass
- [x] E2E: full-duplex barge-in with low eagerness — 4/4 clean interrupts, user confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)