### PR TITLE
feat(voice): Phase 3B — session rotation + response brevity + settings fix

### DIFF
--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -111,8 +111,8 @@ Better to be thorough than to guess wrong.
 
 VOICE RULES:
 - Keep responses to 2-4 sentences for direct answers. When summarizing tool \
-results (memory, search), cover all key points — don't truncate to hit a \
-sentence target.
+results (memory, search), cover the most important 2-3 points. If there's \
+more to share, end with "Want me to go deeper?" and wait for the user.
 - Avoid unnecessary filler — don't restate the question, don't end with \
 "let me know if you need anything." Start with the answer.
 - Never use markdown, bullet points, or formatting. Speak naturally.

--- a/src/genesis/channels/voice/s2s_bridge/app/main.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/main.py
@@ -53,6 +53,12 @@ class Application:
         self.session_manager: SessionManager | None = None
         self.current_task: PipelineTask | None = None
         self._pipeline_lock: asyncio.Lock | None = None
+        self._rotation_task: asyncio.Task | None = None
+        # Session rotation interval in seconds. OpenAI Realtime sessions
+        # expire at 60 minutes — rotate at 55 to leave margin for the
+        # reconnect handshake + context replay. Configurable via env for
+        # testing (e.g. SESSION_ROTATION_SECONDS=30).
+        self._rotation_interval: float = 55 * 60
 
     async def initialize(self) -> None:
         """Initialize all components."""
@@ -64,6 +70,11 @@ class Application:
         # Semantic VAD eagerness (replaces old threshold-based server_vad)
         # Options: "low" (less interrupts), "medium" (default), "high" (more responsive)
         self.semantic_vad_eagerness = os.environ.get("SEMANTIC_VAD_EAGERNESS", "medium")
+
+        # Session rotation interval (override for testing)
+        self._rotation_interval = float(
+            os.environ.get("SESSION_ROTATION_SECONDS", str(55 * 60))
+        )
 
         # Get recording setting (optional, defaults to false)
         enable_recording = os.environ.get("ENABLE_RECORDING", "false").lower() == "true"
@@ -310,15 +321,54 @@ class Application:
                     return
             logger.warning("⚠️ Deferred disconnect: service never connected (pipeline may not have started)")
 
-        # Setup WebSocket event handlers
+        # ── Session rotation ──────────────────────────────────────────
+        async def _session_rotation_loop():
+            """Proactively rotate the OpenAI session before the 60-min expiry.
+
+            Runs while a client is connected. Each cycle sleeps for
+            ``_rotation_interval`` seconds (default 55 min), then calls
+            ``reset_conversation()`` which disconnects the WebSocket,
+            reconnects (new 60-min clock), and replays cached context.
+            The user hears ~1-2 s of silence during the handshake.
+            """
+            while True:
+                await asyncio.sleep(self._rotation_interval)
+                async with self._pipeline_lock:
+                    if not (self.openai_service and self.openai_service._websocket):
+                        # Client disconnected while we slept — stop rotating
+                        logger.info("⏰ Rotation timer fired but no active session — skipping")
+                        return
+                    logger.info("🔄 Session rotation — resetting OpenAI conversation (%.0f min interval)",
+                                self._rotation_interval / 60)
+                    try:
+                        await self.openai_service.reset_conversation()
+                        logger.info("✅ Session rotated — new 60-min clock started")
+                    except Exception as e:
+                        logger.warning("⚠️ Session rotation failed: %s — will retry next interval", e)
+
+        def _start_rotation_timer():
+            """Start (or restart) the rotation background task."""
+            if self._rotation_task and not self._rotation_task.done():
+                self._rotation_task.cancel()
+            self._rotation_task = asyncio.create_task(_session_rotation_loop())
+
+        def _cancel_rotation_timer():
+            """Cancel the rotation timer (client disconnected)."""
+            if self._rotation_task and not self._rotation_task.done():
+                self._rotation_task.cancel()
+                self._rotation_task = None
+
+        # ── WebSocket event handlers ──────────────────────────────────
         async def on_client_connected(client_id: str):
             """Handle new client connection."""
             await self._ensure_openai_service(client_id=client_id)
             if self.audio_recording_service:
                 self.audio_recording_service.start_new_session(client_id)
+            _start_rotation_timer()
 
         async def on_client_disconnected(client_id: str):
             """Handle client disconnection."""
+            _cancel_rotation_timer()
             if self.session_manager:
                 self.session_manager.handle_client_disconnect(client_id, self.openai_service)
             if self.audio_recording_service:

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -114,11 +114,10 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
     ),
     "outreach": SettingsDomain(
         name="outreach",
-        description="Outreach preferences (quiet hours, rate limits, channels)",
+        description="Outreach preferences (quiet hours, rate limits, channels, voice alert IDs)",
         config_filename="outreach.yaml",
         readonly=False,
         needs_restart=False,
-        dedicated_tool="outreach_preferences",
     ),
     "recon_schedules": SettingsDomain(
         name="recon_schedules",

--- a/tests/test_mcp/test_settings.py
+++ b/tests/test_mcp/test_settings.py
@@ -67,10 +67,11 @@ async def test_settings_list_includes_metadata():
         assert "dedicated_tool" in item
 
 
-async def test_settings_list_marks_outreach_as_dedicated():
+async def test_settings_list_outreach_is_writable():
     result = await _impl_settings_list()
     outreach = next(d for d in result if d["domain"] == "outreach")
-    assert outreach["dedicated_tool"] == "outreach_preferences"
+    assert outreach["dedicated_tool"] is None
+    assert outreach["readonly"] is False
 
 
 # ── settings_get ───────────────────────────────────────────────────────
@@ -97,12 +98,11 @@ async def test_settings_get_readonly_domain(config_dir: Path):
     assert result["config"]["defaults"]["direct_session"] == 1
 
 
-async def test_settings_get_dedicated_tool_redirect():
+async def test_settings_get_outreach_returns_config():
     result = await _impl_settings_get("outreach")
-    assert "note" in result
-    assert "outreach_preferences" in result["note"]
-    assert result["dedicated_tool"] == "outreach_preferences"
-    assert "config" not in result  # No config returned for redirects
+    assert "config" in result
+    assert result["readonly"] is False
+    assert result["domain"] == "outreach"
 
 
 async def test_settings_get_unknown_domain():
@@ -214,10 +214,11 @@ async def test_settings_update_readonly_rejected():
     assert "read-only" in result["error"]
 
 
-async def test_settings_update_dedicated_tool_rejected():
+async def test_settings_update_outreach_applies(config_dir: Path):
+    _write_config(config_dir, "outreach.yaml", {"quiet_hours": {"start": "22:00", "end": "08:00"}})
     result = await _impl_settings_update("outreach", {"quiet_hours": {"start": "23:00"}})
-    assert "error" in result
-    assert "outreach_preferences" in result["error"]
+    assert result.get("status") == "applied"
+    assert result["changes_applied"]["quiet_hours"]["start"] == "23:00"
 
 
 async def test_settings_update_unknown_domain():


### PR DESCRIPTION
## Summary

Three independent improvements to the voice channel:

**Phase 3B — 55-min session rotation** (`s2s_bridge/app/main.py`):
OpenAI Realtime sessions expire after 60 minutes with no warning. Adds a background rotation loop that proactively calls `reset_conversation()` at 55 minutes — disconnects, reconnects (new 60-min clock), replays cached conversation context. User hears ~1-2s silence. Timer starts on client connect, cancels on disconnect, guarded by pipeline_lock. Configurable via `SESSION_ROTATION_SECONDS` env var for testing.

**Response length tuning** (`genesis_bridge.py`):
Tighten the tool-result escape hatch from "cover all key points" to "cover 2-3 most important points, then offer to go deeper." Prevents verbose tool-backed responses while preserving opt-in expansion.

**Settings fix** (`mcp/health/settings.py`):
The outreach domain had `dedicated_tool="outreach_preferences"` — a tool that doesn't exist — causing `settings_get("outreach")` to return a redirect instead of the config. Removed the dead reference so `voice_alert_ids` and all outreach settings are now accessible via the generic settings MCP tools.

## Test plan

- [x] ruff + py_compile on all changed files
- [ ] Deploy with short rotation timer (30s), verify rotation log + context preserved
- [ ] Verify `settings_get("outreach")` returns full config including voice.alert_ids
- [ ] Voice conversation: tool-backed answers ≤3 points + "go deeper?" offer

🤖 Generated with [Claude Code](https://claude.com/claude-code)