### PR TITLE
fix(voice): consistent context cache keying (Bug 5)

### DIFF
--- a/src/genesis/channels/voice/s2s_bridge/app/websocket_handler.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/websocket_handler.py
@@ -273,15 +273,18 @@ class WebSocketHandler:
                 and self._active_websocket is not websocket
             )
             self._active_websocket = websocket
-            client_id = self.extract_client_id(websocket)
-            logger.info(f"🔗 New WebSocket connection from IP: {client_id}")
+            client_ip = self.extract_client_id(websocket)
+            logger.info(f"🔗 New WebSocket connection from IP: {client_ip}")
             if is_replacement:
                 # The previous socket's disconnect event will fire shortly —
                 # the stale-socket guard below ignores it. Reuse the live
                 # OpenAI session instead of resetting it mid-conversation.
                 logger.info("♻️ Connection replaced an existing client — keeping session")
                 return
-            await on_client_connected_callback(client_id)
+            # Use "server" as the logical client_id — pipecat only allows
+            # one active client, and the pipeline + context aggregators
+            # are registered under "server" at startup (main.py).
+            await on_client_connected_callback("server")
 
         if on_client_disconnected_callback:
             @transport.event_handler("on_client_disconnected")
@@ -303,10 +306,9 @@ class WebSocketHandler:
                         await output.set_client_connection(self._active_websocket)
                     return
                 self._active_websocket = None
-                client_id = self.extract_client_id(websocket)
-                if client_id:
-                    logger.info(f"🔌 Client {client_id} disconnected")
-                    await on_client_disconnected_callback(client_id)
+                client_ip = self.extract_client_id(websocket)
+                logger.info(f"🔌 Client {client_ip} disconnected")
+                await on_client_disconnected_callback("server")
 
     async def cleanup(self):
         """Cleanup WebSocket handler resources."""


### PR DESCRIPTION
## Summary

Pipeline builds once with `client_id="server"`, registering context aggregators under that key. But connect/disconnect handlers used the client's IP address from `extract_client_id()`, causing a key mismatch — the aggregator was never found, context caching fell through to `service._context` fallback, and the `No context aggregator found` warning logged on every disconnect.

Use `"server"` as the logical client_id for all SessionManager operations. Pipecat only allows one active client, so per-client keying was unused. The client IP is still logged for observability.

Closes follow-up 77941ede (identified during Phase 3A due diligence, Jun 11). Prerequisite for Phase 3D (voice conversation memory).

## Test plan

- [x] ruff + py_compile
- [ ] Deploy to HA, verify `Found context in aggregator` replaces `No context aggregator found` warning
- [ ] Disconnect + reconnect within 5 min → context restored with message count

🤖 Generated with [Claude Code](https://claude.com/claude-code)