### PR TITLE
feat(voice): Phase 3D — persist voice conversations to Genesis memory

### DIFF
--- a/src/genesis/channels/voice/s2s_bridge/app/genesis_tool_service.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/genesis_tool_service.py
@@ -93,7 +93,7 @@ class GenesisToolService:
             len(turns), len(transcript),
         )
 
-        async with httpx.AsyncClient(timeout=15) as client:
+        async with httpx.AsyncClient(timeout=60) as client:
             resp = await client.post(
                 f"{self._url}/api/t/memory_store",
                 headers=self._headers,

--- a/src/genesis/channels/voice/s2s_bridge/app/genesis_tool_service.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/genesis_tool_service.py
@@ -8,6 +8,7 @@ Endpoints called:
 - ``POST /v1/voice/tool_call`` — dispatch ask_genesis, web_search, approve_pending
 - ``GET /v1/voice/system_prompt`` — fetch Genesis persona + context
 - ``GET /v1/voice/tool_declarations`` — fetch tool schemas for session config
+- ``POST /api/t/memory_store`` — persist conversation transcripts (Phase 3D)
 """
 
 from __future__ import annotations
@@ -63,3 +64,48 @@ class GenesisToolService:
             )
             resp.raise_for_status()
             return resp.json().get("tools", [])
+
+    async def store_conversation(
+        self, messages: list, satellite_id: str = "s2s-default",
+    ) -> dict | None:
+        """Persist a voice conversation transcript to Genesis memory.
+
+        Matches the format used by ``S2SSessionManager.close()``
+        (s2s_session.py) — same source, tags, wing, room — so all voice
+        conversations appear in the same memory namespace regardless of
+        which pipeline produced them.
+        """
+        turns: list[str] = []
+        for msg in messages:
+            role = msg.get("role", "") if isinstance(msg, dict) else getattr(msg, "role", "")
+            content = msg.get("content", "") if isinstance(msg, dict) else getattr(msg, "content", "")
+            if role in ("user", "assistant") and isinstance(content, str) and content.strip():
+                label = "User" if role == "user" else "Genesis"
+                turns.append(f"{label}: {content}")
+
+        if not turns:
+            logger.debug("No user/assistant turns to persist")
+            return None
+
+        transcript = f"Voice conversation [{satellite_id}]:\n" + "\n".join(turns)
+        logger.info(
+            "Persisting voice conversation (%d turns, %d chars)",
+            len(turns), len(transcript),
+        )
+
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.post(
+                f"{self._url}/api/t/memory_store",
+                headers=self._headers,
+                json={
+                    "content": transcript,
+                    "source": "voice_s2s",
+                    "memory_type": "episodic",
+                    "tags": ["voice", "s2s", "conversation"],
+                    "confidence": 0.5,
+                    "wing": "channels",
+                    "room": "voice",
+                },
+            )
+            resp.raise_for_status()
+            return resp.json()

--- a/src/genesis/channels/voice/s2s_bridge/app/main.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/main.py
@@ -371,6 +371,21 @@ class Application:
             _cancel_rotation_timer()
             if self.session_manager:
                 self.session_manager.handle_client_disconnect(client_id, self.openai_service)
+
+            # Persist conversation transcript to Genesis memory (Phase 3D).
+            # Must run AFTER handle_client_disconnect caches the context.
+            if self.genesis_tool_service and self.session_manager:
+                cached = self.session_manager.get_cached_context(client_id)
+                if cached:
+                    messages = cached.get_messages()
+                    if messages:
+                        try:
+                            result = await self.genesis_tool_service.store_conversation(messages)
+                            if result:
+                                logger.info("💾 Voice conversation persisted to Genesis memory")
+                        except Exception as e:
+                            logger.warning("⚠️ Failed to persist voice conversation: %s", e)
+
             if self.audio_recording_service:
                 self.audio_recording_service.stop_recording()
             # Disconnect from OpenAI to stop the 60-min session clock.

--- a/src/genesis/channels/voice/s2s_bridge/app/main.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/main.py
@@ -384,7 +384,7 @@ class Application:
                             if result:
                                 logger.info("💾 Voice conversation persisted to Genesis memory")
                         except Exception as e:
-                            logger.warning("⚠️ Failed to persist voice conversation: %s", e)
+                            logger.warning("⚠️ Failed to persist voice conversation: %s: %s", type(e).__name__, e)
 
             if self.audio_recording_service:
                 self.audio_recording_service.stop_recording()


### PR DESCRIPTION
## Summary

On client disconnect, extracts conversation messages from the cached context, filters to user/assistant turns, and POSTs the transcript to Genesis via `POST /api/t/memory_store`. Uses the same format as `S2SSessionManager.close()` (source=voice_s2s, tags=[voice,s2s,conversation], wing=channels, room=voice) so all voice conversations appear in the same memory namespace regardless of pipeline.

Prerequisite: Bug 5 context cache keying (#615) — ensures the aggregator path works correctly.

**What this enables:**
- Cross-session continuity: "what were we talking about?" surfaces the prior voice conversation via ask_genesis → memory recall
- Full-text + semantic searchability via Genesis's existing FTS5 + Qdrant pipeline
- Dream cycle compression handles long-term memory management naturally

**Edge cases handled:**
- Empty conversations (no store call)
- Genesis unreachable (warning logged, addon continues)
- Non-string content from multi-modal turns (skipped via isinstance guard)
- Duplicate disconnects from stale-socket pattern (memory_store dedup rejects)

## Test plan

- [x] ruff + py_compile on both changed files
- [ ] Deploy to HA, have conversation, disconnect
- [ ] Addon logs: `💾 Voice conversation persisted to Genesis memory`
- [ ] `memory_recall("voice conversation", wing="channels")` returns transcript
- [ ] New conversation: "what were we talking about?" → Genesis recalls prior topics

🤖 Generated with [Claude Code](https://claude.com/claude-code)