### PR TITLE
feat(campaign): discord-bot MCP server + discord-monitor reactive campaign

### DIFF
--- a/config/mcp.json.template
+++ b/config/mcp.json.template
@@ -19,6 +19,10 @@
     "genesis-recon": {
       "command": "{{GENESIS_ROOT}}/.claude/mcp/run-mcp-server",
       "args": ["--server", "recon"]
+    },
+    "discord-bot": {
+      "command": "{{GENESIS_ROOT}}/.claude/mcp/run-mcp-server",
+      "args": ["--server", "discord-bot"]
     }
   }
 }

--- a/scripts/genesis_mcp_server.py
+++ b/scripts/genesis_mcp_server.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-_VALID_SERVERS = {"health", "memory", "outreach", "recon"}
+_VALID_SERVERS = {"health", "memory", "outreach", "recon", "discord-bot"}
 _DEFAULT_FLAG = Path.home() / ".genesis" / "cc_context_enabled"
 _DEFAULT_STATUS = Path.home() / ".genesis" / "status.json"
 
@@ -50,6 +50,7 @@ _DEFAULT_PORTS = {
     "memory": 8101,
     "outreach": 8102,
     "recon": 8103,
+    "discord-bot": 8104,
 }
 
 
@@ -349,11 +350,32 @@ def _bootstrap_outreach(transport_kwargs: dict) -> None:
     _run_mcp(mcp, transport_kwargs)
 
 
+def _bootstrap_discord_bot(transport_kwargs: dict) -> None:
+    """Bootstrap and run the discord-bot MCP server.
+
+    Provides read/write Discord access via bot token for campaign
+    sessions. No DB connection needed — fully stateless.
+    """
+    import os
+
+    from genesis.mcp.discord_bot_mcp import init_discord_bot, mcp
+
+    bot_token = os.environ.get("DISCORD_BOT_TOKEN", "")
+    if not bot_token:
+        logger.error("DISCORD_BOT_TOKEN not set — discord-bot cannot start")
+        return
+
+    init_discord_bot(bot_token=bot_token)
+    clear_mcp_crash("discord-bot")
+    _run_mcp(mcp, transport_kwargs)
+
+
 _BOOTSTRAPPERS = {
     "health": _bootstrap_health,
     "memory": _bootstrap_memory,
     "outreach": _bootstrap_outreach,
     "recon": _bootstrap_recon,
+    "discord-bot": _bootstrap_discord_bot,
 }
 
 
@@ -447,6 +469,8 @@ def main(argv: list[str] | None = None) -> None:
         "GENESIS_ENABLE_OLLAMA", "OLLAMA_EMBEDDING_MODEL",
         # HTTP transport auth
         "GENESIS_MCP_HTTP_TOKEN",
+        # Discord bot (used by discord-bot MCP server)
+        "DISCORD_BOT_TOKEN",
     }
     import os
 

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -153,6 +153,12 @@ PROFILES: dict[str, list[str]] = {
     "campaign": (
         _UNIVERSAL_DISALLOW + _NO_BROWSER_INTERACTION
     ),
+    # ── Discord monitor profile ─────────────────────────────────
+    # Reads Discord channels and responds via bot token API.
+    # MCP config loads discord-bot + health + outreach.
+    "discord-monitor": (
+        _UNIVERSAL_DISALLOW + _NO_BROWSER_INTERACTION
+    ),
     # ── Perimeter profile ────────────────────────────────────────
     # For sessions that process untrusted inbound content (email
     # replies, future Discord inbound). Maximally restricted: only
@@ -219,6 +225,20 @@ Your final message IS your deliverable. Write files to `~/.genesis/output/`.
 
 {_MISSION_INJECTION}
 """,
+    "discord-monitor": f"""
+
+## Session Profile: discord-monitor
+
+You have: discord-bot MCP tools (fetch_messages, fetch_forum_threads, send_reply), outreach_send, web tools.
+You do NOT have: Edit, Bash, NotebookEdit, browser tools, memory tools.
+Your final message IS your deliverable.
+
+You are a reactive community responder. Read Discord channels and respond
+to unanswered messages using send_reply. Do NOT post proactive content —
+that is the discord-engagement campaign's job.
+
+{_MISSION_INJECTION}
+""",
     "mail": """
 
 ## Session Profile: mail
@@ -240,6 +260,7 @@ _PROFILE_SKILLS: dict[str, list[str]] = {
     "research": [],
     "observe": [],
     "campaign": ["voice-master"],
+    "discord-monitor": ["genesis-voice"],
     "mail": ["genesis-voice"],
 }
 
@@ -784,6 +805,7 @@ class DirectSessionRunner:
             "research": "reflection",
             "interact": "sentinel",
             "campaign": "campaign",
+            "discord-monitor": "discord-monitor",
             "mail": "mail",
         }
         mcp_profile = _PROFILE_TO_MCP.get(request.profile, "reflection")

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -155,9 +155,12 @@ PROFILES: dict[str, list[str]] = {
     ),
     # ── Discord monitor profile ─────────────────────────────────
     # Reads Discord channels and responds via bot token API.
-    # MCP config loads discord-bot + health + outreach.
+    # MCP config loads discord-bot + health + outreach (no memory server).
+    # Belt-and-suspenders: block memory writes at tool level too, in case
+    # MCP config generation fails and falls back to full config.
     "discord-monitor": (
         _UNIVERSAL_DISALLOW + _NO_BROWSER_INTERACTION
+        + _NO_MEMORY_WRITES + _NO_FOLLOW_UPS
     ),
     # ── Perimeter profile ────────────────────────────────────────
     # For sessions that process untrusted inbound content (email

--- a/src/genesis/cc/session_config.py
+++ b/src/genesis/cc/session_config.py
@@ -35,6 +35,7 @@ _MCP_PROFILES: dict[str, list[str]] = {
     "user_reflection": ["genesis-memory"],  # User ego: memory only, no health tools
     "sentinel": ["genesis-health", "genesis-memory", "genesis-outreach"],
     "campaign": ["genesis-health", "genesis-memory", "genesis-outreach"],
+    "discord-monitor": ["genesis-health", "genesis-outreach", "discord-bot"],
     "interop": ["genesis-health", "genesis-memory"],
     "mail": ["genesis-outreach"],  # Perimeter: outreach only, no memory/health
 }

--- a/src/genesis/mcp/discord_bot_mcp.py
+++ b/src/genesis/mcp/discord_bot_mcp.py
@@ -71,7 +71,7 @@ def _chunk_text(text: str, limit: int = _MAX_MESSAGE_LENGTH) -> list[str]:
             break
         # Find last newline before limit
         idx = text.rfind("\n", 0, limit)
-        if idx == -1:
+        if idx <= 0:
             idx = limit
         chunks.append(text[:idx])
         text = text[idx:].lstrip("\n")

--- a/src/genesis/mcp/discord_bot_mcp.py
+++ b/src/genesis/mcp/discord_bot_mcp.py
@@ -1,0 +1,260 @@
+"""Standalone Discord bot MCP server — read-only message access + reply.
+
+Provides fetch_messages, fetch_forum_threads, and send_reply tools via
+the Discord bot token. Scoped to discord-monitor campaign sessions only
+(not loaded by foreground, ego, reflection, or other session types).
+
+Stateless — no DB connection needed. Token injected at bootstrap via
+init_discord_bot().
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import httpx
+from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+mcp = FastMCP("discord-bot")
+
+_bot_token: str | None = None
+
+# GENesis Discord guild ID (public — visible in access.json)
+_GUILD_ID = "1486075405579583538"
+
+# Discord API base
+_API = "https://discord.com/api/v10"
+
+# Discord message length limit
+_MAX_MESSAGE_LENGTH = 2000
+
+
+def init_discord_bot(*, bot_token: str) -> None:
+    """Wire the bot token for API calls."""
+    global _bot_token
+    _bot_token = bot_token
+    logger.info("Discord bot MCP wired (token=%s)", bool(bot_token))
+
+
+def _headers() -> dict[str, str]:
+    """Authorization headers for Discord API."""
+    if not _bot_token:
+        raise RuntimeError("DISCORD_BOT_TOKEN not configured")
+    return {"Authorization": f"Bot {_bot_token}"}
+
+
+def _format_message(msg: dict) -> dict:
+    """Extract essential fields from a Discord message object."""
+    author = msg.get("author", {})
+    return {
+        "id": msg["id"],
+        "author_name": author.get("username", "unknown"),
+        "author_id": author.get("id", ""),
+        "is_bot": author.get("bot", False),
+        "content": msg.get("content", ""),
+        "timestamp": msg.get("timestamp", ""),
+    }
+
+
+def _chunk_text(text: str, limit: int = _MAX_MESSAGE_LENGTH) -> list[str]:
+    """Split text into chunks at newline boundaries."""
+    if len(text) <= limit:
+        return [text]
+
+    chunks: list[str] = []
+    while text:
+        if len(text) <= limit:
+            chunks.append(text)
+            break
+        # Find last newline before limit
+        idx = text.rfind("\n", 0, limit)
+        if idx == -1:
+            idx = limit
+        chunks.append(text[:idx])
+        text = text[idx:].lstrip("\n")
+    return chunks
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def fetch_messages(channel_id: str, limit: int = 20) -> str:
+    """Fetch recent messages from a Discord text channel.
+
+    Returns oldest-first list of messages with author, content, timestamp.
+    Use this for regular text channels (#troubleshooting, #getting-started,
+    #general). For forum channels (#bug-reports, #feature-requests), use
+    fetch_forum_threads instead.
+
+    Args:
+        channel_id: Discord channel ID (numeric string).
+        limit: Max messages to fetch (1-100, default 20).
+    """
+    try:
+        headers = _headers()
+    except RuntimeError as exc:
+        return json.dumps({"error": str(exc)})
+
+    limit = max(1, min(limit, 100))
+    url = f"{_API}/channels/{channel_id}/messages?limit={limit}"
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.get(url, headers=headers)
+
+        if resp.status_code == 429:
+            retry_after = resp.json().get("retry_after", "unknown")
+            return json.dumps({
+                "error": f"Rate limited. Retry after {retry_after}s.",
+            })
+
+        if resp.status_code != 200:
+            return json.dumps({
+                "error": f"Discord API error {resp.status_code}: {resp.text[:200]}",
+            })
+
+        messages = resp.json()
+
+    # Discord returns newest-first; reverse to oldest-first
+    formatted = [_format_message(m) for m in reversed(messages)]
+    return json.dumps({"messages": formatted, "count": len(formatted)})
+
+
+@mcp.tool()
+async def fetch_forum_threads(channel_id: str, limit: int = 10) -> str:
+    """Fetch active and recent threads from a Discord forum channel.
+
+    Returns threads with their recent messages. Use this for forum channels
+    like #bug-reports and #feature-requests. For regular text channels, use
+    fetch_messages instead.
+
+    Args:
+        channel_id: Discord forum channel ID (numeric string).
+        limit: Max threads to return (default 10).
+    """
+    try:
+        headers = _headers()
+    except RuntimeError as exc:
+        return json.dumps({"error": str(exc)})
+
+    threads: list[dict] = []
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        # Step 1: Get active threads (guild-wide, then filter by parent)
+        resp = await client.get(
+            f"{_API}/guilds/{_GUILD_ID}/threads/active",
+            headers=headers,
+        )
+        if resp.status_code == 200:
+            for t in resp.json().get("threads", []):
+                if t.get("parent_id") == channel_id:
+                    threads.append(t)
+
+        # Step 2: Get recently archived threads
+        resp = await client.get(
+            f"{_API}/channels/{channel_id}/threads/archived/public?limit={limit}",
+            headers=headers,
+        )
+        if resp.status_code == 200:
+            for t in resp.json().get("threads", []):
+                if t["id"] not in {th["id"] for th in threads}:
+                    threads.append(t)
+
+        # Trim to limit
+        threads = threads[:limit]
+
+        # Step 3: Fetch recent messages for each thread
+        result = []
+        for t in threads:
+            thread_data = {
+                "thread_id": t["id"],
+                "name": t.get("name", ""),
+                "message_count": t.get("message_count", 0),
+                "messages": [],
+            }
+
+            msg_resp = await client.get(
+                f"{_API}/channels/{t['id']}/messages?limit=5",
+                headers=headers,
+            )
+            if msg_resp.status_code == 200:
+                msgs = msg_resp.json()
+                thread_data["messages"] = [
+                    _format_message(m) for m in reversed(msgs)
+                ]
+
+            result.append(thread_data)
+
+    return json.dumps({"threads": result, "count": len(result)})
+
+
+@mcp.tool()
+async def send_reply(
+    channel_id: str,
+    content: str,
+    reply_to: str | None = None,
+) -> str:
+    """Send a message to a Discord channel as the Gen bot.
+
+    Can reply to a specific message (threading) or post standalone.
+    Auto-chunks messages exceeding Discord's 2000-char limit.
+
+    Args:
+        channel_id: Discord channel or thread ID to post in.
+        content: Message text (Discord markdown supported).
+        reply_to: Message ID to reply to (creates a threaded reply).
+    """
+    try:
+        headers = _headers()
+    except RuntimeError as exc:
+        return json.dumps({"error": str(exc)})
+
+    chunks = _chunk_text(content)
+    sent_ids: list[str] = []
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        for i, chunk in enumerate(chunks):
+            payload: dict = {"content": chunk}
+
+            # Only thread the first chunk
+            if reply_to and i == 0:
+                payload["message_reference"] = {
+                    "message_id": reply_to,
+                    "fail_if_not_exists": False,
+                }
+
+            resp = await client.post(
+                f"{_API}/channels/{channel_id}/messages",
+                headers=headers,
+                json=payload,
+            )
+
+            if resp.status_code == 429:
+                retry_after = resp.json().get("retry_after", "unknown")
+                return json.dumps({
+                    "error": f"Rate limited after {len(sent_ids)} chunk(s). "
+                    f"Retry after {retry_after}s.",
+                    "sent_ids": sent_ids,
+                })
+
+            if resp.status_code not in (200, 201):
+                return json.dumps({
+                    "error": f"Discord API error {resp.status_code}: "
+                    f"{resp.text[:200]}",
+                    "sent_ids": sent_ids,
+                })
+
+            msg_data = resp.json()
+            sent_ids.append(msg_data.get("id", ""))
+
+    result_text = (
+        f"sent (id: {sent_ids[0]})"
+        if len(sent_ids) == 1
+        else f"sent {len(sent_ids)} parts (ids: {', '.join(sent_ids)})"
+    )
+    return json.dumps({"status": "sent", "message": result_text, "sent_ids": sent_ids})

--- a/tests/test_mcp/test_discord_bot_mcp.py
+++ b/tests/test_mcp/test_discord_bot_mcp.py
@@ -1,0 +1,260 @@
+"""Tests for discord-bot MCP server — fetch_messages, fetch_forum_threads, send_reply."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import genesis.mcp.discord_bot_mcp as bot_mod
+from genesis.mcp.discord_bot_mcp import mcp
+
+
+async def test_all_tools_registered():
+    """All three Discord tools should be registered."""
+    tools = await mcp.get_tools()
+    for name in ["fetch_messages", "fetch_forum_threads", "send_reply"]:
+        assert name in tools, f"Missing tool: {name}"
+
+
+# ── fetch_messages ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_messages_success():
+    """Should return formatted messages oldest-first."""
+    mock_messages = [
+        {
+            "id": "2",
+            "author": {"id": "u1", "username": "alice", "bot": False},
+            "content": "Newer message",
+            "timestamp": "2026-06-13T12:00:00Z",
+        },
+        {
+            "id": "1",
+            "author": {"id": "u2", "username": "bob", "bot": True},
+            "content": "Older message",
+            "timestamp": "2026-06-13T11:00:00Z",
+        },
+    ]
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = mock_messages
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    old_token = bot_mod._bot_token
+    try:
+        bot_mod._bot_token = "test-token"
+        with patch("genesis.mcp.discord_bot_mcp.httpx.AsyncClient", return_value=mock_client):
+            tools = await mcp.get_tools()
+            result = await tools["fetch_messages"].fn(channel_id="123", limit=10)
+
+        data = json.loads(result)
+        assert data["count"] == 2
+        # Should be oldest-first (reversed from API response)
+        assert data["messages"][0]["id"] == "1"
+        assert data["messages"][0]["author_name"] == "bob"
+        assert data["messages"][0]["is_bot"] is True
+        assert data["messages"][1]["id"] == "2"
+        assert data["messages"][1]["author_name"] == "alice"
+    finally:
+        bot_mod._bot_token = old_token
+
+
+@pytest.mark.asyncio
+async def test_fetch_messages_rate_limited():
+    """Should return error with retry_after on 429."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 429
+    mock_resp.json.return_value = {"retry_after": 5.0}
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    old_token = bot_mod._bot_token
+    try:
+        bot_mod._bot_token = "test-token"
+        with patch("genesis.mcp.discord_bot_mcp.httpx.AsyncClient", return_value=mock_client):
+            tools = await mcp.get_tools()
+            result = await tools["fetch_messages"].fn(channel_id="123")
+
+        data = json.loads(result)
+        assert "error" in data
+        assert "Rate limited" in data["error"]
+    finally:
+        bot_mod._bot_token = old_token
+
+
+@pytest.mark.asyncio
+async def test_fetch_messages_no_token():
+    """Should return error when bot token not configured."""
+    old_token = bot_mod._bot_token
+    try:
+        bot_mod._bot_token = None
+        tools = await mcp.get_tools()
+        result = await tools["fetch_messages"].fn(channel_id="123")
+
+        data = json.loads(result)
+        assert "error" in data
+        assert "not configured" in data["error"]
+    finally:
+        bot_mod._bot_token = old_token
+
+
+# ── fetch_forum_threads ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_forum_threads_success():
+    """Should return threads with their messages."""
+    mock_active_resp = MagicMock()
+    mock_active_resp.status_code = 200
+    mock_active_resp.json.return_value = {
+        "threads": [
+            {"id": "t1", "name": "Bug: crash on startup", "parent_id": "forum1", "message_count": 3},
+            {"id": "t2", "name": "Unrelated thread", "parent_id": "other", "message_count": 1},
+        ],
+    }
+
+    mock_archived_resp = MagicMock()
+    mock_archived_resp.status_code = 200
+    mock_archived_resp.json.return_value = {"threads": []}
+
+    mock_thread_msgs = MagicMock()
+    mock_thread_msgs.status_code = 200
+    mock_thread_msgs.json.return_value = [
+        {
+            "id": "m1",
+            "author": {"id": "u1", "username": "reporter", "bot": False},
+            "content": "App crashes on startup",
+            "timestamp": "2026-06-13T10:00:00Z",
+        },
+    ]
+
+    mock_client = AsyncMock()
+
+    async def mock_get(url, **kwargs):
+        if "threads/active" in url:
+            return mock_active_resp
+        if "threads/archived" in url:
+            return mock_archived_resp
+        return mock_thread_msgs
+
+    mock_client.get = mock_get
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    old_token = bot_mod._bot_token
+    try:
+        bot_mod._bot_token = "test-token"
+        with patch("genesis.mcp.discord_bot_mcp.httpx.AsyncClient", return_value=mock_client):
+            tools = await mcp.get_tools()
+            result = await tools["fetch_forum_threads"].fn(channel_id="forum1")
+
+        data = json.loads(result)
+        # Should only include the thread from the target forum (parent_id="forum1")
+        assert data["count"] == 1
+        assert data["threads"][0]["name"] == "Bug: crash on startup"
+        assert len(data["threads"][0]["messages"]) == 1
+        assert data["threads"][0]["messages"][0]["author_name"] == "reporter"
+    finally:
+        bot_mod._bot_token = old_token
+
+
+# ── send_reply ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_reply_success():
+    """Should POST message and return sent ID."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"id": "sent-123"}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    old_token = bot_mod._bot_token
+    try:
+        bot_mod._bot_token = "test-token"
+        with patch("genesis.mcp.discord_bot_mcp.httpx.AsyncClient", return_value=mock_client):
+            tools = await mcp.get_tools()
+            result = await tools["send_reply"].fn(
+                channel_id="456", content="Hello!", reply_to="msg-789",
+            )
+
+        data = json.loads(result)
+        assert data["status"] == "sent"
+        assert "sent-123" in data["sent_ids"]
+
+        # Verify POST payload included message_reference
+        call_args = mock_client.post.call_args
+        payload = call_args[1]["json"]
+        assert payload["content"] == "Hello!"
+        assert payload["message_reference"]["message_id"] == "msg-789"
+    finally:
+        bot_mod._bot_token = old_token
+
+
+@pytest.mark.asyncio
+async def test_send_reply_auto_chunks():
+    """Should split long messages into multiple chunks."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"id": "sent-1"}
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_resp
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    long_message = "A" * 3000  # Exceeds 2000-char limit
+
+    old_token = bot_mod._bot_token
+    try:
+        bot_mod._bot_token = "test-token"
+        with patch("genesis.mcp.discord_bot_mcp.httpx.AsyncClient", return_value=mock_client):
+            tools = await mcp.get_tools()
+            result = await tools["send_reply"].fn(
+                channel_id="456", content=long_message,
+            )
+
+        data = json.loads(result)
+        assert data["status"] == "sent"
+        # Should have been split into at least 2 chunks
+        assert mock_client.post.call_count >= 2
+    finally:
+        bot_mod._bot_token = old_token
+
+
+# ── Profile tests ───────────────────────────────────────────────────────
+
+
+def test_discord_monitor_profile_exists():
+    """discord-monitor should be a valid session profile."""
+    from genesis.cc.direct_session import VALID_PROFILES
+
+    assert "discord-monitor" in VALID_PROFILES
+
+
+def test_discord_monitor_mcp_profile_exists():
+    """discord-monitor should have an MCP profile with discord-bot server."""
+    from genesis.cc.session_config import _MCP_PROFILES
+
+    assert "discord-monitor" in _MCP_PROFILES
+    servers = _MCP_PROFILES["discord-monitor"]
+    assert "discord-bot" in servers
+    assert "genesis-health" in servers
+    assert "genesis-outreach" in servers
+    # Should NOT include genesis-memory (reactive doesn't need it)
+    assert "genesis-memory" not in servers

--- a/tests/test_mcp/test_discord_bot_mcp.py
+++ b/tests/test_mcp/test_discord_bot_mcp.py
@@ -11,6 +11,7 @@ import genesis.mcp.discord_bot_mcp as bot_mod
 from genesis.mcp.discord_bot_mcp import mcp
 
 
+@pytest.mark.asyncio
 async def test_all_tools_registered():
     """All three Discord tools should be registered."""
     tools = await mcp.get_tools()


### PR DESCRIPTION
## Summary

- **Discord bot MCP server** (`discord-bot`) — standalone MCP server with 3 tools: `fetch_messages`, `fetch_forum_threads`, `send_reply`. Uses the bot token to read channels and reply as Gen. Scoped exclusively to discord-monitor campaign sessions.
- **discord-monitor profile** — new session profile with belt-and-suspenders security (memory writes blocked at both MCP config and tool level). Includes genesis-voice skill for community tone.
- **Campaign registered** — `discord-monitor` at 6h cadence, checks bug-reports, feature-requests, troubleshooting, getting-started, and general. Responds to unanswered messages with proper threading.

## Architecture

```
Campaign Runner → DirectSession(profile="discord-monitor")
  → MCP config: genesis-health + genesis-outreach + discord-bot
  → Strategy doc: read channels → identify unanswered → send_reply
```

The discord-bot MCP server is NOT part of genesis-health. It's a separate, stateless server loaded only by discord-monitor sessions.

## Verified

- E2E read test: `fetch_messages` returns real messages from #dev-discussion
- E2E forum test: `fetch_forum_threads` returns "Windows integration" thread from #feature-requests with both user and bot messages
- 9 unit tests (tools, rate limiting, no-token, chunking, profile validation)
- Code review: fixed `_chunk_text` edge case (infinite loop on leading newline) and added memory-write blocking to profile

## Test plan

- [x] 9 unit tests pass
- [x] 28 total MCP tests pass (including campaign + outreach from PR #600)
- [x] E2E read verified against live Discord API
- [x] ruff clean
- [x] Code review addressed
- [ ] CI passes
- [ ] After merge: restart genesis-server to load new campaign into scheduler

🤖 Generated with [Claude Code](https://claude.com/claude-code)