### PR TITLE
feat(voice): curate which alerts are spoken aloud + earlier mem/qdrant alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Changed
+
+- **Voice: you now choose exactly which alerts are spoken aloud** — the
+  Voice PE only speaks alerts on an allowlist you control (`voice.alert_ids`
+  in `outreach.yaml`) instead of chiming for every blocker, alert, and
+  approval. The default set covers what's worth interrupting you for: disk
+  and memory emergencies, memory-system failures (embeddings, vector
+  search), a stalled awareness loop, Sentinel decisions that need your
+  approval, and blocked autonomous tasks. CLI approval prompts and generic
+  provider credit-exhaustion no longer chime by default. Everything still
+  arrives on Telegram regardless — this only controls what's spoken out loud.
+- **Earlier memory and memory-search alerts** — the container-memory alert
+  now fires at 85% (was 90%) and the vector-search-failure alert at 50%
+  failure (was 100% only), so you hear about pressure and degradation
+  sooner, on both Telegram and voice.
+
 ---
 
 ## [v3.0b15] - 2026-06-12

--- a/config/outreach.yaml
+++ b/config/outreach.yaml
@@ -70,3 +70,27 @@ health_alerts:
     - "provider:embedding_failing"
     - "provider:qdrant_unreachable"
     - "awareness:tick_overdue"
+
+# Voice proactive chiming — the spoken-aloud allowlist (THE menu).
+# A request is spoken through the Voice PE only if its signal_type or a
+# source_id part matches one of these by prefix (OutreachPipeline._should_voice).
+# Everything still goes to Telegram regardless — this only controls what
+# interrupts the user out loud during `hours`. This block is authoritative;
+# editing it changes behavior on next server restart. Keep entries specific
+# (prefix match) and keep `task_notification` in sync with the signal_type
+# set in src/genesis/autonomy/executor/engine.py _notify.
+voice:
+  alert_ids:
+    # Memory-system + resource emergencies (matched via source_id)
+    - "infra:disk_low"
+    - "infra:container_memory_high"
+    - "provider:embedding_failing"
+    - "provider:qdrant_unreachable"
+    - "awareness:tick_overdue"
+    # Autonomous system needs your decision (matched via signal_type)
+    - "sentinel_escalation"
+    - "sentinel_approval"
+    - "sentinel_action_approval"
+    # Autonomous task hit a blocker/alert
+    - "task_notification"
+  hours: [9, 2]   # 9am-2am local (wraps midnight); end hour exclusive

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -1179,8 +1179,7 @@ class CCSessionExecutor:
             salience_score=0.9 if cat == OutreachCategory.BLOCKER else 0.5,
             # signal_type makes task notifications a toggleable voice menu
             # item (voice_alert_ids -> OutreachPipeline._should_voice matches
-            # this). source_id carries the task for history/observability and
-            # potential future per-task voice control.
+            # this). source_id identifies the task in outreach history.
             signal_type="task_notification",
             source_id=f"task:{task_id}",
         )

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -1177,6 +1177,12 @@ class CCSessionExecutor:
             topic=f"Task {task_id[:8]}",
             context=message,
             salience_score=0.9 if cat == OutreachCategory.BLOCKER else 0.5,
+            # signal_type makes task notifications a toggleable voice menu
+            # item (voice_alert_ids -> OutreachPipeline._should_voice matches
+            # this). source_id carries the task for history/observability and
+            # potential future per-task voice control.
+            signal_type="task_notification",
+            source_id=f"task:{task_id}",
         )
 
         try:

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -296,9 +296,14 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
     anon_pct = container_mem.get("anon_pct", container_mem.get("used_pct", 0))
     if anon_pct > 85:
         alert_id = "infra:container_memory_high"
+        # CRITICAL at >85% (lowered from >90% on 2026-06-13). This is a
+        # deliberate escalation-threshold expansion, not a cleanup: it moves
+        # both the Telegram alert AND the voice chime earlier. anon_pct is
+        # non-reclaimable memory, so >85% is genuine pressure (the box idles
+        # ~76-79%). 6h dedup prevents repeat spam.
         alerts.append({
             "id": alert_id,
-            "severity": "CRITICAL" if anon_pct > 90 else "WARNING",
+            "severity": "CRITICAL",
             "message": f"Container memory at {anon_pct}% anon+kernel ({container_mem.get('current_gb', '?')}/{container_mem.get('limit_gb', '?')}GB total)",
         })
         current_ids.add(alert_id)
@@ -412,15 +417,23 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
         if (
             isinstance(qdrant_summary, dict)
             and qdrant_summary.get("calls", 0) > 0
-            and qdrant_summary.get("error_rate", 0) == 1.0
+            and qdrant_summary.get("error_rate", 0) >= 0.5
         ):
+            # Fire at >=50% failure (lowered from ==100% on 2026-06-13) to
+            # match provider:embedding_failing and warn on partial memory-
+            # search degradation, not just total outage. Id keeps the
+            # "unreachable" name (referenced by config lists); message shows
+            # the actual rate.
             alert_id = "provider:qdrant_unreachable"
+            _qdrant_rate = qdrant_summary.get("error_rate", 0)
+            _qdrant_errors = qdrant_summary.get("errors", 0)
+            _qdrant_calls = qdrant_summary.get("calls", 0)
             alerts.append({
                 "id": alert_id,
                 "severity": "CRITICAL",
                 "message": (
-                    f"Qdrant search 100% failure rate "
-                    f"({qdrant_summary['errors']} consecutive failures)"
+                    f"Qdrant search {_qdrant_rate:.0%} failure rate "
+                    f"({_qdrant_errors}/{_qdrant_calls} calls failed)"
                 ),
             })
             current_ids.add(alert_id)

--- a/src/genesis/outreach/config.py
+++ b/src/genesis/outreach/config.py
@@ -41,14 +41,26 @@ class OutreachConfig:
         "awareness:tick_overdue",
         "service:health_data_uninitialized",
     )
-    # Voice proactive chiming — spoken alerts via HA TTS
+    # Voice proactive chiming — the spoken-aloud allowlist. This IS the menu:
+    # a request is spoken only if its signal_type or a source_id part matches
+    # one of these by prefix (see OutreachPipeline._should_voice). Everything
+    # still goes to Telegram regardless; this only controls what interrupts
+    # the user out loud during voice_hours. Mirror lives in config/outreach.yaml
+    # (voice.alert_ids), which overrides this default when present.
     voice_alert_ids: tuple[str, ...] = (
+        # Memory-system + resource emergencies (matched via source_id)
         "infra:disk_low",
         "infra:container_memory_high",
-        "cc:quota_exhausted",
-        "provider:credit_exhaustion",
         "provider:embedding_failing",
         "provider:qdrant_unreachable",
+        "awareness:tick_overdue",
+        # Autonomous system needs your decision (matched via signal_type)
+        "sentinel_escalation",
+        "sentinel_approval",
+        "sentinel_action_approval",
+        # Autonomous task hit a blocker/alert — signal_type set in
+        # autonomy/executor/engine.py _notify (keep these two in sync).
+        "task_notification",
     )
     voice_hours: tuple[int, int] = (9, 2)  # 9am–2am local (wraps midnight)
     # Delivery routing: per-category target — "supergroup", "dm", or "both".

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -453,24 +453,44 @@ class OutreachPipeline:
         )
 
     def _should_voice(self, request: OutreachRequest) -> bool:
-        """Check if this request qualifies for voice secondary delivery.
+        """Check if this request qualifies for voice (spoken-aloud) delivery.
 
-        Matches on category (BLOCKER, ALERT, APPROVAL) rather than
-        signal_type because health alerts use generic signal_type.
-        APPROVAL included so pending approval requests are spoken
-        aloud — the user can then say "hey genesis, approve it".
+        Pure allowlist: ``config.voice_alert_ids`` IS the menu of what gets
+        spoken. A request voices only if its ``signal_type`` or any part of
+        its ``source_id`` matches an allowlist entry by prefix — the same
+        matching convention as the immediate-escalation list in
+        ``health_outreach.py``. There is no category-based fallback, so
+        nothing is voiced by an invisible rule: every spoken alert is one
+        editable line in ``voice_alert_ids`` (config.py / outreach.yaml).
+        Everything still reaches Telegram regardless; this gate only
+        controls what interrupts the user out loud.
+
+        Matching notes:
+        - ``source_id`` is comma-split to handle the batched health-alert
+          envelope (``scheduler.py`` joins ids with commas).
+        - prefix match (``startswith``) lets a family entry like
+          ``provider:credit_exhaustion`` match ``…:<provider>``; keep
+          entries specific to avoid unintended prefix hits.
+        - ``signal_type`` matching is how non-health signals opt in
+          (e.g. ``sentinel_escalation``; ``task_notification`` is set in
+          ``autonomy/executor/engine.py`` ``_notify``).
         """
         if not self._channels.get("voice"):
             return False
         if not self._config:
             return False
-        if request.category not in (
-            OutreachCategory.BLOCKER,
-            OutreachCategory.ALERT,
-            OutreachCategory.APPROVAL,
-        ):
+        if not self._in_voice_hours():
             return False
-        return self._in_voice_hours()
+        # Pre-strip allowlist entries so a stray space in hand-edited
+        # outreach.yaml doesn't silently break a match.
+        allow = [aid.strip() for aid in self._config.voice_alert_ids if aid.strip()]
+        candidates = [request.signal_type or "", *(request.source_id or "").split(",")]
+        return any(
+            cand.strip().startswith(aid)
+            for cand in candidates
+            if cand.strip()
+            for aid in allow
+        )
 
     def _in_voice_hours(self) -> bool:
         """Check if current time is within voice notification hours."""

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -534,11 +534,14 @@ class TestS2SSessionManager:
 class TestVoiceHours:
     """Test _in_voice_hours midnight-wrap logic and _should_voice filtering."""
 
-    def _make_pipeline(self, *, voice_hours=(9, 2), has_voice=True):
+    def _make_pipeline(self, *, voice_hours=(9, 2), has_voice=True, voice_alert_ids=None):
         """Build a minimal pipeline with voice config for testing."""
         from genesis.outreach.config import OutreachConfig, QuietHours
         from genesis.outreach.pipeline import OutreachPipeline
 
+        # When voice_alert_ids is None, use the dataclass default (the
+        # shipped 9-item menu) so tests exercise the real allowlist.
+        extra = {} if voice_alert_ids is None else {"voice_alert_ids": tuple(voice_alert_ids)}
         config = OutreachConfig(
             quiet_hours=QuietHours(start="22:00", end="07:00"),
             channel_preferences={"default": "telegram"},
@@ -551,6 +554,7 @@ class TestVoiceHours:
             engagement_timeout_hours=24,
             engagement_poll_minutes=60,
             voice_hours=voice_hours,
+            **extra,
         )
         channels = {}
         if has_voice:
@@ -605,41 +609,133 @@ class TestVoiceHours:
         req = OutreachRequest(
             category=OutreachCategory.ALERT,
             topic="test", context="test", salience_score=1.0,
-        )
-        assert not pipe._should_voice(req)
-
-    def test_should_voice_wrong_category(self):
-        """_should_voice returns False for non-alert categories."""
-        from genesis.outreach.types import OutreachCategory, OutreachRequest
-
-        pipe = self._make_pipeline()
-        req = OutreachRequest(
-            category=OutreachCategory.SURPLUS,
-            topic="test", context="test", salience_score=1.0,
+            source_id="infra:disk_low",
         )
         with patch.object(pipe, "_in_voice_hours", return_value=True):
             assert not pipe._should_voice(req)
 
-    def test_should_voice_alert_in_hours(self):
-        """_should_voice returns True for ALERT category during voice hours."""
+    def test_should_voice_unlisted_is_silent_any_category(self):
+        """Pure allowlist: a request with no allowlisted signal_type/source_id
+        is silent on voice REGARDLESS of category (the old category gate is
+        gone). Covers the behavior change from category-based gating."""
         from genesis.outreach.types import OutreachCategory, OutreachRequest
 
         pipe = self._make_pipeline()
-        req = OutreachRequest(
-            category=OutreachCategory.ALERT,
-            topic="test", context="test", salience_score=1.0,
-        )
-        with patch.object(pipe, "_in_voice_hours", return_value=True):
-            assert pipe._should_voice(req)
+        for cat in (
+            OutreachCategory.SURPLUS,
+            OutreachCategory.ALERT,
+            OutreachCategory.BLOCKER,
+            OutreachCategory.APPROVAL,
+        ):
+            req = OutreachRequest(
+                category=cat, topic="t", context="t", salience_score=1.0,
+            )
+            with patch.object(pipe, "_in_voice_hours", return_value=True):
+                assert not pipe._should_voice(req), f"category={cat}"
 
-    def test_should_voice_blocker_in_hours(self):
-        """_should_voice returns True for BLOCKER category during voice hours."""
+    def test_should_voice_allowlisted_source_id(self):
+        """A health alert whose source_id is on the allowlist voices."""
         from genesis.outreach.types import OutreachCategory, OutreachRequest
 
         pipe = self._make_pipeline()
         req = OutreachRequest(
             category=OutreachCategory.BLOCKER,
-            topic="test", context="test", salience_score=1.0,
+            topic="t", context="t", salience_score=1.0,
+            signal_type="health_alert", source_id="infra:disk_low",
         )
         with patch.object(pipe, "_in_voice_hours", return_value=True):
             assert pipe._should_voice(req)
+
+    def test_should_voice_batched_envelope_any_match(self):
+        """Comma-joined batched source_id voices if ANY part is allowlisted."""
+        from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+        pipe = self._make_pipeline()
+        req = OutreachRequest(
+            category=OutreachCategory.BLOCKER,
+            topic="t", context="t", salience_score=1.0,
+            signal_type="health_alert",
+            source_id="queue:stale_dead_letters,infra:disk_low",
+        )
+        with patch.object(pipe, "_in_voice_hours", return_value=True):
+            assert pipe._should_voice(req)
+
+    def test_should_voice_signal_type_match(self):
+        """Non-health signals opt in via signal_type (e.g. sentinel)."""
+        from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+        pipe = self._make_pipeline()
+        req = OutreachRequest(
+            category=OutreachCategory.BLOCKER,
+            topic="t", context="t", salience_score=1.0,
+            signal_type="sentinel_escalation",
+            source_id="sentinel-escalation:mem:123",
+        )
+        with patch.object(pipe, "_in_voice_hours", return_value=True):
+            assert pipe._should_voice(req)
+
+    def test_should_voice_task_notification(self):
+        """task_notification signal_type is on the default allowlist."""
+        from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+        pipe = self._make_pipeline()
+        req = OutreachRequest(
+            category=OutreachCategory.BLOCKER,
+            topic="t", context="t", salience_score=1.0,
+            signal_type="task_notification", source_id="task:abc123",
+        )
+        with patch.object(pipe, "_in_voice_hours", return_value=True):
+            assert pipe._should_voice(req)
+
+    def test_should_voice_critical_observation_silent(self):
+        """Critical observations (obs UUIDs, not allowlisted) stay silent."""
+        from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+        pipe = self._make_pipeline()
+        req = OutreachRequest(
+            category=OutreachCategory.BLOCKER,
+            topic="t", context="t", salience_score=1.0,
+            signal_type="critical_observation",
+            source_id="obs-uuid-1,obs-uuid-2",
+        )
+        with patch.object(pipe, "_in_voice_hours", return_value=True):
+            assert not pipe._should_voice(req)
+
+    def test_should_voice_cli_approval_off(self):
+        """cli_approval was removed from the allowlist — stays silent."""
+        from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+        pipe = self._make_pipeline()
+        req = OutreachRequest(
+            category=OutreachCategory.APPROVAL,
+            topic="t", context="t", salience_score=1.0,
+            signal_type="cli_approval", source_id="cli-approval:42",
+        )
+        with patch.object(pipe, "_in_voice_hours", return_value=True):
+            assert not pipe._should_voice(req)
+
+    def test_should_voice_prefix_match_family(self):
+        """Prefix matching: a family entry matches suffixed produced ids."""
+        from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+        pipe = self._make_pipeline(voice_alert_ids=("provider:credit_exhaustion",))
+        req = OutreachRequest(
+            category=OutreachCategory.BLOCKER,
+            topic="t", context="t", salience_score=1.0,
+            source_id="provider:credit_exhaustion:deepinfra",
+        )
+        with patch.object(pipe, "_in_voice_hours", return_value=True):
+            assert pipe._should_voice(req)
+
+    def test_should_voice_out_of_hours(self):
+        """An allowlisted alert outside voice hours is silent."""
+        from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+        pipe = self._make_pipeline()
+        req = OutreachRequest(
+            category=OutreachCategory.BLOCKER,
+            topic="t", context="t", salience_score=1.0,
+            source_id="infra:disk_low",
+        )
+        with patch.object(pipe, "_in_voice_hours", return_value=False):
+            assert not pipe._should_voice(req)

--- a/tests/test_observability/test_operational_vitals_e2e.py
+++ b/tests/test_observability/test_operational_vitals_e2e.py
@@ -130,6 +130,109 @@ class TestAlertConditions:
             health_mcp._service = old_service
 
     @pytest.mark.asyncio
+    async def test_qdrant_alert_fires_at_50pct_boundary(self):
+        """Threshold lowered from ==100% to >=50% (2026-06-13). 1/2 failures
+        (50%) must fire, and the message must report the actual rate."""
+        from genesis.mcp import health_mcp
+
+        tracker = ProviderActivityTracker()
+        tracker.record("qdrant.search", latency_ms=5000, success=False)
+        tracker.record("qdrant.search", latency_ms=10, success=True)  # 1/2 = 50%
+
+        old_tracker = health_mcp._activity_tracker
+        old_service = health_mcp._service
+        try:
+            health_mcp._activity_tracker = tracker
+            health_mcp._service = MagicMock()
+            health_mcp._service.snapshot = AsyncMock(return_value={
+                "call_sites": {}, "queues": {}, "cc_sessions": {},
+                "infrastructure": {}, "services": {}, "awareness": {},
+            })
+            alerts = await health_mcp._impl_health_alerts()
+            q = [a for a in alerts if a["id"] == "provider:qdrant_unreachable"]
+            assert len(q) == 1
+            assert "50%" in q[0]["message"]
+        finally:
+            health_mcp._activity_tracker = old_tracker
+            health_mcp._service = old_service
+
+    @pytest.mark.asyncio
+    async def test_qdrant_alert_silent_below_50pct(self):
+        """1/3 failures (~33%) is below the new >=50% boundary — no alert."""
+        from genesis.mcp import health_mcp
+
+        tracker = ProviderActivityTracker()
+        tracker.record("qdrant.search", latency_ms=5000, success=False)
+        tracker.record("qdrant.search", latency_ms=10, success=True)
+        tracker.record("qdrant.search", latency_ms=10, success=True)  # 1/3 = 33%
+
+        old_tracker = health_mcp._activity_tracker
+        old_service = health_mcp._service
+        try:
+            health_mcp._activity_tracker = tracker
+            health_mcp._service = MagicMock()
+            health_mcp._service.snapshot = AsyncMock(return_value={
+                "call_sites": {}, "queues": {}, "cc_sessions": {},
+                "infrastructure": {}, "services": {}, "awareness": {},
+            })
+            alerts = await health_mcp._impl_health_alerts()
+            q = [a for a in alerts if a["id"] == "provider:qdrant_unreachable"]
+            assert len(q) == 0
+        finally:
+            health_mcp._activity_tracker = old_tracker
+            health_mcp._service = old_service
+
+    @pytest.mark.asyncio
+    async def test_container_memory_critical_in_86_to_90_band(self):
+        """Container memory CRITICAL threshold lowered >90% -> >85% (2026-06-13).
+        The 86-90% band must now be CRITICAL (was WARNING)."""
+        from genesis.mcp import health_mcp
+
+        tracker = ProviderActivityTracker()  # no provider calls -> no provider alerts
+        old_tracker = health_mcp._activity_tracker
+        old_service = health_mcp._service
+        try:
+            health_mcp._activity_tracker = tracker
+            health_mcp._service = MagicMock()
+            health_mcp._service.snapshot = AsyncMock(return_value={
+                "call_sites": {}, "queues": {}, "cc_sessions": {},
+                "infrastructure": {"container_memory": {
+                    "anon_pct": 87, "current_gb": 28, "limit_gb": 32}},
+                "services": {}, "awareness": {},
+            })
+            alerts = await health_mcp._impl_health_alerts()
+            mem = [a for a in alerts if a["id"] == "infra:container_memory_high"]
+            assert len(mem) == 1
+            assert mem[0]["severity"] == "CRITICAL"
+        finally:
+            health_mcp._activity_tracker = old_tracker
+            health_mcp._service = old_service
+
+    @pytest.mark.asyncio
+    async def test_container_memory_silent_at_or_below_85(self):
+        """Container memory at 84% (<=85) fires no alert."""
+        from genesis.mcp import health_mcp
+
+        tracker = ProviderActivityTracker()
+        old_tracker = health_mcp._activity_tracker
+        old_service = health_mcp._service
+        try:
+            health_mcp._activity_tracker = tracker
+            health_mcp._service = MagicMock()
+            health_mcp._service.snapshot = AsyncMock(return_value={
+                "call_sites": {}, "queues": {}, "cc_sessions": {},
+                "infrastructure": {"container_memory": {
+                    "anon_pct": 84, "current_gb": 27, "limit_gb": 32}},
+                "services": {}, "awareness": {},
+            })
+            alerts = await health_mcp._impl_health_alerts()
+            mem = [a for a in alerts if a["id"] == "infra:container_memory_high"]
+            assert len(mem) == 0
+        finally:
+            health_mcp._activity_tracker = old_tracker
+            health_mcp._service = old_service
+
+    @pytest.mark.asyncio
     async def test_job_quarantine_alert(self):
         from genesis.mcp import health_mcp
 


### PR DESCRIPTION
## What

Make the spoken-aloud voice alerts a **user-controlled allowlist**. Previously `OutreachPipeline._should_voice()` gated on category — every in-hours BLOCKER/ALERT/APPROVAL chimed through the Voice PE — and the `voice_alert_ids` config (exposed via MCP settings) was dead: nothing read it. Now `voice_alert_ids` (in `config/outreach.yaml`) is the editable menu: a request is spoken only if its `signal_type` or a comma-split `source_id` part prefix-matches an allowlist entry. Nothing is voiced by an invisible rule. Everything still reaches Telegram regardless — this only controls what interrupts the user out loud during voice hours.

### Default menu (9)
- **Memory-system + resource emergencies:** `infra:disk_low`, `infra:container_memory_high`, `provider:embedding_failing`, `provider:qdrant_unreachable`, `awareness:tick_overdue`
- **Autonomous decisions:** `sentinel_escalation`, `sentinel_approval`, `sentinel_action_approval`
- **Blocked autonomous tasks:** `task_notification`

Removed from voice: `cli_approval` (too frequent when autonomy is busy) and generic `provider:credit_exhaustion` (noise — the memory-affecting case is still covered by `provider:embedding_failing`).

### Threshold tuning (earlier warning, Telegram + voice)
- Container memory now CRITICAL at **>85%** (was >90%).
- Qdrant search alert now fires at **>=50%** failure (was ==100% only); message shows the actual rate.

Blast radius verified: these two alert IDs are consumed only by outreach config lists — not the Sentinel classifier (different `memory:`/`qdrant:` namespace) or autonomy remediation.

### Also
- Task notifications now carry `signal_type="task_notification"` (+ a `source_id`) so they're individually toggleable on the menu.

## Why

`voice_alert_ids` was built-not-wired. This makes the setting functional and lets the user pick exactly which alerts interrupt them out loud, instead of chiming for everything.

## Behavior change

Pure allowlist replaces category gating: in-hours BLOCKER/ALERT/APPROVAL no longer chime unless allowlisted. CRITICAL alerts not in `immediate_escalation_alerts` (`service:genesis_down`, `guardian:heartbeat_stale`, `infra:qdrant_collections_missing`) were never voiced — they route to the Sentinel — so none are silenced.

## Testing

- 332 targeted tests pass (voice, outreach, health-mcp, observability, sentinel, engine, settings, credit-exhaustion).
- E2E data-flow: real `outreach.yaml` → loader → `_should_voice`, 13/13 representative cases correct (9 ON, removals OFF, out-of-hours silent).
- genesis-architect pre-review + code-reviewer pass; 2 minor findings fixed (strip allowlist entries; defensive `.get()` in the qdrant message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
