### PR TITLE
fix(cc): make the session status header fire reliably

### DIFF
--- a/scripts/genesis_session_context.py
+++ b/scripts/genesis_session_context.py
@@ -109,14 +109,17 @@ def main() -> None:
         _SESSION_START_FILE.parent.mkdir(parents=True, exist_ok=True)
         _SESSION_START_FILE.write_text(datetime.now(UTC).isoformat())
 
-        # 0.5. Session Configuration — inject effort level for the LLM's
-        # status header. Model is NOT injected here because the LLM can
-        # derive it from CC's "You are powered by..." system text, which
-        # is always accurate. The sidecar file goes stale when CC's native
-        # /model command is used (it doesn't call Genesis MCP tools).
-        # Effort is injected because CC doesn't expose it in its system
-        # prompt — the sidecar (written by session_config MCP) is the
-        # best-available signal.
+        # 0.5. Session Configuration — inject the effort level AND the
+        # first-reply status-header directive into the highest-salience slot
+        # (the very top of the injection). The header itself
+        # (`[<model> / <effort>]`) is fully specified in CONVERSATION.md →
+        # "Session Start", but that spec sits hundreds of lines deep in the
+        # identity block and gets buried under the user's first task, so it
+        # fired unreliably. Echoing the directive here — where the LLM reads it
+        # first — is what actually makes it emit. Model is NOT injected: it is
+        # derived from CC's always-accurate "You are powered by..." system text
+        # (the sidecar's model goes stale on a native /model switch). Effort
+        # comes from the sidecar (written by the session_config MCP tool).
         effort = "high"  # default — user's preferred effort level
         if _SESSION_CONFIG.exists():
             import json
@@ -126,7 +129,15 @@ def main() -> None:
                 effort = cfg.get("effort", "high")
             except Exception as exc:
                 print(f"[session_context] Failed to read session config: {exc}", file=sys.stderr)
-        _emit(f"## Session Configuration\n\neffort: {effort}\n")
+        _emit(
+            "## Session Configuration\n\n"
+            f"- Thinking effort: {effort}\n\n"
+            "Begin your first reply of this session with a one-line status header "
+            f"on its own line — `[<model> / {effort}]` — then your normal reply. "
+            'Derive <model> from your environment\'s "You are powered by the model '
+            'named …" line (e.g. `Opus 4.8`), per CONVERSATION.md → Session Start. '
+            "No emoji, no explanation.\n"
+        )
         first = False
 
         # 1. Identity files (disk, always available, no external deps)

--- a/src/genesis/identity/CONVERSATION.md
+++ b/src/genesis/identity/CONVERSATION.md
@@ -23,8 +23,9 @@ You are running as a Claude Code session with full tool access.
 - **Output**: Text (markdown), voice (TTS, if enabled for the chat).
 
 ### Session Control
-You can read your own model and effort from the Session Configuration block
-in your system prompt. You can change them using the `session_config` MCP tool with your
+You can read your own effort from the Session Configuration block in your
+system prompt; your model comes from your environment's "You are powered by
+the model named …" line. You can change them using the `session_config` MCP tool with your
 Session ID. Pass `model` and/or `effort` parameters. When the user asks
 to switch, do it directly — don't tell them to use a command themselves.
 
@@ -129,8 +130,9 @@ well-represented in USER.md. Don't store transient conversational context
 
 ## Session Start
 
-On the FIRST message of a new session (not on resume), begin your response
-with a one-line status header before your actual reply:
+On your FIRST reply after a session starts (a fresh start, a resume, or after a
+context compaction), begin your response with a one-line status header before
+your actual reply:
 
 `[model version / effort]`
 

--- a/tests/test_cc/test_session_context.py
+++ b/tests/test_cc/test_session_context.py
@@ -64,6 +64,25 @@ class TestSessionContextHook:
         assert "outreach" in result.stdout.lower()
         assert result.returncode == 0
 
+    def test_session_config_block_carries_header_directive(self, flag_dir: Path) -> None:
+        """The top Session Configuration block must instruct the first-reply header.
+
+        Regression guard: the `[<model> / <effort>]` header is specified in
+        CONVERSATION.md but fired unreliably when only that deep spec existed.
+        The hook now echoes the directive into the high-salience top block — if
+        that echo is dropped, the header silently stops appearing again.
+        """
+        env = {"HOME": str(flag_dir.parent), "PATH": "/usr/bin"}
+        result = subprocess.run(
+            [_PYTHON, str(_CONTEXT_SCRIPT)],
+            capture_output=True, text=True, env=env, timeout=10,
+        )
+        assert "## Session Configuration" in result.stdout
+        assert "status header" in result.stdout
+        # Effort defaults to "high" with no session_config.json present.
+        assert "[<model> / high]" in result.stdout
+        assert result.returncode == 0
+
     def test_writes_session_start_file(self, flag_dir: Path) -> None:
         """Hook should write session start timestamp for urgent-alerts hook."""
         env = {"HOME": str(flag_dir.parent), "PATH": "/usr/bin"}


### PR DESCRIPTION
## Problem
The first-reply status header `[model version / effort]` (e.g. `[Opus 4.8 / high]`) is specified in `CONVERSATION.md` → *Session Start*, but it fired unreliably. That spec sits hundreds of lines deep in the injected identity block, so it got buried under the user's first message and was frequently not emitted. The high-salience top-of-injection `## Session Configuration` block carried only `effort:` and never mentioned the header.

## Fix
Echo the header directive into the top `## Session Configuration` block (the first thing the model reads in the SessionStart injection), so the trigger is co-located with the effort value at maximum salience.

Also:
- Reconcile `CONVERSATION.md`: the model is derived from the environment's "You are powered by the model named …" line (not the config block, which never carried it); emit on every session start (fresh, resume, or post-compact).
- Add a regression test asserting the emitted block contains the header directive, so this can't silently regress again.

## Testing
`pytest tests/test_cc/test_session_context.py tests/test_scripts/test_session_context_tier.py -v` → 24 passed (includes the new `test_session_config_block_carries_header_directive`). Ruff clean. No programmatic consumer parses the block (it is LLM-facing only), so the format change is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)