### PR TITLE
fix(voice): surface silent HA delivery failures + drop device-specific entity defaults

### DIFF
--- a/src/genesis/channels/voice/adapter.py
+++ b/src/genesis/channels/voice/adapter.py
@@ -64,10 +64,18 @@ class VoiceChannelAdapter(ChannelAdapter):
         self._tts_entity = tts_entity or os.environ.get(
             "HA_TTS_ENTITY", "tts.piper",
         )
+        # No device-specific default — entity IDs are install-specific and a
+        # hardcoded default silently breaks when the device is renamed (a
+        # firmware reflash added a "_media_player" suffix on 2026-06-13,
+        # silently killing the chime). Require explicit config.
         self._media_player = media_player_entity or os.environ.get(
-            "HA_MEDIA_PLAYER_ENTITY",
-            "media_player.home_assistant_voice_0a2841",
+            "HA_MEDIA_PLAYER_ENTITY", "",
         )
+        if not self._media_player:
+            logger.warning(
+                "Voice adapter: HA_MEDIA_PLAYER_ENTITY is not set — proactive "
+                "voice (chime/TTS) is disabled until it is configured."
+            )
 
     async def start(self) -> None:
         """No-op — adapter is stateless, HA handles transport."""
@@ -99,6 +107,12 @@ class VoiceChannelAdapter(ChannelAdapter):
         if not self._ha_url or not self._ha_token:
             logger.warning("Voice adapter: HA not configured, skipping TTS")
             return ""
+        if not self._media_player:
+            logger.warning(
+                "Voice adapter: no media_player entity (set HA_MEDIA_PLAYER_ENTITY) "
+                "— skipping proactive voice delivery"
+            )
+            return ""
 
         delivery_id = str(uuid.uuid4())
         headers = {
@@ -111,7 +125,7 @@ class VoiceChannelAdapter(ChannelAdapter):
                 # Play pre-announce chime via media player (not voice assistant)
                 if preannounce and self._chime_media_id:
                     try:
-                        await client.post(
+                        chime_resp = await client.post(
                             f"{self._ha_url}/api/services/media_player/play_media",
                             headers=headers,
                             json={
@@ -121,6 +135,9 @@ class VoiceChannelAdapter(ChannelAdapter):
                                 "announce": True,
                             },
                         )
+                        # play_media returns [] even on success, so HTTP
+                        # status is the only reliable failure signal here.
+                        chime_resp.raise_for_status()
                         await asyncio.sleep(self.CHIME_DELAY_S)
                     except Exception:
                         logger.warning("Pre-announce chime failed", exc_info=True)
@@ -149,6 +166,22 @@ class VoiceChannelAdapter(ChannelAdapter):
             },
         )
         response.raise_for_status()
+        # HA returns the list of states changed by the service call. An empty
+        # list means tts.speak matched no target (wrong/unavailable entity)
+        # and produced NO audio — surface it instead of reporting a false
+        # success. This is the failure mode that hid a silent chime (HA 200
+        # + []) on 2026-06-13.
+        try:
+            changed = response.json()
+        except Exception:
+            changed = None
+        if isinstance(changed, list) and not changed:
+            logger.warning(
+                "Voice TTS changed no states — tts '%s' / media_player '%s' "
+                "may not exist or be unavailable; no audio delivered",
+                self._tts_entity, self._media_player,
+            )
+            return
         logger.info(
             "Voice TTS delivered: %d chars → %s",
             len(text), self._media_player,

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -157,30 +157,16 @@ class StandaloneAdapter:
         logger.info("Shutdown requested")
         self._shutdown_event.set()
 
-        # Voice "last breath" — play the HA built-in chime (3-ding) via
-        # assist_satellite.announce before services stop.  No TTS needed —
-        # the chime alone signals "going away."  4s drain lets the device
-        # finish playing before Wyoming shuts down.
-        ha_url = os.environ.get("HA_URL", "")
-        ha_token = os.environ.get("HA_LONG_LIVED_TOKEN", "")
-        if ha_url and ha_token:
+        # Voice "last breath" — speak via the held VoiceChannelAdapter, which
+        # uses media_player.play_media + tts.speak (the path that actually
+        # plays on the device). assist_satellite.announce silently no-ops when
+        # the satellite entity is 'unavailable', so it was a dead chime
+        # (2026-06-13). Reusing the adapter inherits its entity config and
+        # failure-surfacing. 4s drain lets playback finish.
+        voice_adapter = self._app.config.get("VOICE_ADAPTER") if self._app else None
+        if voice_adapter is not None:
             try:
-                import httpx
-                async with httpx.AsyncClient(timeout=10) as client:
-                    await client.post(
-                        f"{ha_url.rstrip('/')}/api/services/assist_satellite/announce",
-                        headers={
-                            "Authorization": f"Bearer {ha_token}",
-                            "Content-Type": "application/json",
-                        },
-                        json={
-                            "entity_id": os.environ.get(
-                                "HA_ASSIST_SATELLITE_ENTITY",
-                                "assist_satellite.home_assistant_voice_0a2841_assist_satellite",
-                            ),
-                            "message": "",
-                        },
-                    )
+                await voice_adapter.send_message("", "Genesis going offline.")
                 await asyncio.sleep(4)
             except Exception:
                 logger.debug("Shutdown chime failed", exc_info=True)

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -146,30 +146,35 @@ class StandaloneAdapter:
         await self._shutdown_event.wait()
         heartbeat_task.cancel()
 
+    async def _voice_last_breath(self) -> None:
+        """Best-effort spoken shutdown notice via the held VoiceChannelAdapter.
+
+        Uses the adapter's media_player.play_media + tts.speak path (which
+        actually plays on the device); assist_satellite.announce silently
+        no-ops when the satellite entity is 'unavailable'. No-op when no
+        voice adapter is configured. 4s drain lets playback finish.
+        """
+        voice_adapter = self._app.config.get("VOICE_ADAPTER") if self._app else None
+        if voice_adapter is None:
+            return
+        try:
+            await voice_adapter.send_message("", "Genesis going offline.")
+            await asyncio.sleep(4)
+        except Exception:
+            logger.debug("Shutdown chime failed", exc_info=True)
+
     async def shutdown(self) -> None:
         """Graceful shutdown.
 
-        Speaks "Server restarting" via HA TTS before stopping services.
-        If HA is unreachable, the TTS call may block up to 15s (httpx
-        timeout) before shutdown continues.  This is within systemd's
-        default TimeoutStopSec=90s.
+        Speaks a brief shutdown notice via HA TTS (the held voice adapter)
+        before stopping services. If HA is unreachable, the call may block
+        up to ~15s (httpx timeout) before shutdown continues — within
+        systemd's default TimeoutStopSec=90s.
         """
         logger.info("Shutdown requested")
         self._shutdown_event.set()
 
-        # Voice "last breath" — speak via the held VoiceChannelAdapter, which
-        # uses media_player.play_media + tts.speak (the path that actually
-        # plays on the device). assist_satellite.announce silently no-ops when
-        # the satellite entity is 'unavailable', so it was a dead chime
-        # (2026-06-13). Reusing the adapter inherits its entity config and
-        # failure-surfacing. 4s drain lets playback finish.
-        voice_adapter = self._app.config.get("VOICE_ADAPTER") if self._app else None
-        if voice_adapter is not None:
-            try:
-                await voice_adapter.send_message("", "Genesis going offline.")
-                await asyncio.sleep(4)
-            except Exception:
-                logger.debug("Shutdown chime failed", exc_info=True)
+        await self._voice_last_breath()
 
         if self._runtime and self._runtime.awareness_loop is not None:
             self._runtime.awareness_loop.request_stop()

--- a/tests/test_channels/test_voice.py
+++ b/tests/test_channels/test_voice.py
@@ -650,3 +650,44 @@ class TestVoiceAPI:
             assert "ask_genesis" in tool_names
             assert "web_search" in tool_names
             assert "approve_pending" in tool_names
+
+
+# ── Standalone shutdown chime ────────────────────────────────────────
+
+
+class TestShutdownVoiceLastBreath:
+    """StandaloneAdapter._voice_last_breath delegates the shutdown notice to
+    the held VoiceChannelAdapter (media_player path), not the dead
+    assist_satellite path; no-op when no adapter is configured."""
+
+    @pytest.mark.asyncio
+    async def test_calls_held_adapter(self):
+        from types import SimpleNamespace
+
+        from genesis.hosting.standalone import StandaloneAdapter
+
+        adapter = AsyncMock()
+        srv = SimpleNamespace(_app=SimpleNamespace(config={"VOICE_ADAPTER": adapter}))
+        with patch("genesis.hosting.standalone.asyncio.sleep", new_callable=AsyncMock):
+            await StandaloneAdapter._voice_last_breath(srv)
+        adapter.send_message.assert_awaited_once()
+        args, _ = adapter.send_message.call_args
+        assert args[0] == ""  # channel_id
+
+    @pytest.mark.asyncio
+    async def test_noop_without_adapter(self):
+        from types import SimpleNamespace
+
+        from genesis.hosting.standalone import StandaloneAdapter
+
+        srv = SimpleNamespace(_app=SimpleNamespace(config={}))
+        await StandaloneAdapter._voice_last_breath(srv)  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_app(self):
+        from types import SimpleNamespace
+
+        from genesis.hosting.standalone import StandaloneAdapter
+
+        srv = SimpleNamespace(_app=None)
+        await StandaloneAdapter._voice_last_breath(srv)  # must not raise

--- a/tests/test_channels/test_voice.py
+++ b/tests/test_channels/test_voice.py
@@ -238,8 +238,12 @@ class TestVoiceChannelAdapter:
         assert result == ""
 
     @pytest.mark.asyncio
-    async def test_send_message_with_chime(self):
-        """Default path: chime via media_player.play_media, then tts.speak."""
+    async def test_send_message_with_chime(self, caplog):
+        """Default path: chime via media_player.play_media, then tts.speak.
+        tts.speak returns a non-empty changed-states list (success), so the
+        delivered path runs and NO 'changed no states' warning is emitted."""
+        import logging
+
         adapter = VoiceChannelAdapter(
             ha_url="http://ha.local:8123",
             ha_token="test-token",
@@ -251,11 +255,16 @@ class TestVoiceChannelAdapter:
             payloads.append((url, kwargs.get("json", {})))
             resp = MagicMock()
             resp.raise_for_status = MagicMock()
+            # tts.speak returns the changed tts entity state on success;
+            # a non-empty list exercises the "delivered" branch (not the
+            # empty-list warning).
+            resp.json = MagicMock(return_value=[{"entity_id": "tts.piper"}])
             return resp
 
         with (
             patch("genesis.channels.voice.adapter.httpx.AsyncClient") as mock_client,
             patch("genesis.channels.voice.adapter.asyncio.sleep", new_callable=AsyncMock),
+            caplog.at_level(logging.WARNING, logger="genesis.channels.voice.adapter"),
         ):
             mock_client.return_value.__aenter__ = AsyncMock(
                 return_value=MagicMock(post=AsyncMock(side_effect=mock_post_fn)),
@@ -274,6 +283,8 @@ class TestVoiceChannelAdapter:
             assert "tts/speak" in payloads[1][0]
             # No assist_satellite calls
             assert not any("assist_satellite" in p[0] for p in payloads)
+            # Success path: non-empty changed-states → no false-failure warning
+            assert not any("changed no states" in r.getMessage() for r in caplog.records)
 
     @pytest.mark.asyncio
     async def test_send_message_no_preannounce(self):
@@ -333,33 +344,6 @@ class TestVoiceChannelAdapter:
             assert result  # Still returns delivery ID
             # Chime failed but tts.speak still called
             assert any("tts/speak" in c for c in calls)
-
-    @pytest.mark.asyncio
-    async def test_send_message_no_preannounce_skips_chime(self):
-        """preannounce=False skips chime even with chime configured."""
-        adapter = VoiceChannelAdapter(
-            ha_url="http://ha.local:8123",
-            ha_token="test-token",
-            media_player_entity="media_player.test",
-        )
-        calls = []
-
-        async def mock_post_fn(url, **kwargs):
-            calls.append(url)
-            resp = MagicMock()
-            resp.raise_for_status = MagicMock()
-            return resp
-
-        with patch("genesis.channels.voice.adapter.httpx.AsyncClient") as mock_client:
-            mock_client.return_value.__aenter__ = AsyncMock(
-                return_value=MagicMock(post=AsyncMock(side_effect=mock_post_fn)),
-            )
-            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
-
-            await adapter.send_message("ch-1", "direct tts", preannounce=False)
-
-            assert len(calls) == 1
-            assert "tts/speak" in calls[0]
 
     @pytest.mark.asyncio
     async def test_send_message_no_media_player_skips(self):

--- a/tests/test_channels/test_voice.py
+++ b/tests/test_channels/test_voice.py
@@ -207,15 +207,17 @@ class TestVoiceChannelAdapter:
             assert adapter._tts_entity == "tts.explicit"
             assert adapter._media_player == "media_player.explicit"
 
-    def test_entity_fallback_without_env(self):
-        """Without env vars or explicit params, falls back to hardcoded defaults."""
+    def test_media_player_empty_without_config(self):
+        """No device-specific default: without env/param, media_player is empty
+        (proactive voice disabled) — a hardcoded device id silently broke when
+        the device was renamed. tts keeps the generic piper default."""
         # Scrub any HA_ env vars that might be set in the test environment
         env = {k: v for k, v in os.environ.items()
                if not k.startswith("HA_")}
         with patch.dict("os.environ", env, clear=True):
             adapter = VoiceChannelAdapter()
             assert adapter._tts_entity == "tts.piper"
-            assert "home_assistant_voice_0a2841" in adapter._media_player
+            assert adapter._media_player == ""
 
     @pytest.mark.asyncio
     async def test_send_typing_noop(self):
@@ -241,6 +243,7 @@ class TestVoiceChannelAdapter:
         adapter = VoiceChannelAdapter(
             ha_url="http://ha.local:8123",
             ha_token="test-token",
+            media_player_entity="media_player.test",
         )
         payloads = []
 
@@ -278,6 +281,7 @@ class TestVoiceChannelAdapter:
         adapter = VoiceChannelAdapter(
             ha_url="http://ha.local:8123",
             ha_token="test-token",
+            media_player_entity="media_player.test",
         )
         calls = []
 
@@ -305,6 +309,7 @@ class TestVoiceChannelAdapter:
         adapter = VoiceChannelAdapter(
             ha_url="http://ha.local:8123",
             ha_token="test-token",
+            media_player_entity="media_player.test",
         )
         calls = []
 
@@ -335,6 +340,7 @@ class TestVoiceChannelAdapter:
         adapter = VoiceChannelAdapter(
             ha_url="http://ha.local:8123",
             ha_token="test-token",
+            media_player_entity="media_player.test",
         )
         calls = []
 
@@ -354,6 +360,66 @@ class TestVoiceChannelAdapter:
 
             assert len(calls) == 1
             assert "tts/speak" in calls[0]
+
+    @pytest.mark.asyncio
+    async def test_send_message_no_media_player_skips(self):
+        """No media_player entity configured → send_message skips delivery
+        entirely (no HA calls), instead of POSTing to a nonexistent entity."""
+        adapter = VoiceChannelAdapter(
+            ha_url="http://ha.local:8123",
+            ha_token="test-token",
+            media_player_entity="",
+        )
+        posted = []
+
+        async def mock_post_fn(url, **kwargs):
+            posted.append(url)
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            return resp
+
+        with patch("genesis.channels.voice.adapter.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__ = AsyncMock(
+                return_value=MagicMock(post=AsyncMock(side_effect=mock_post_fn)),
+            )
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await adapter.send_message("ch-1", "hello")
+            assert result == ""
+            assert posted == []
+
+    @pytest.mark.asyncio
+    async def test_tts_empty_changed_states_warns(self, caplog):
+        """tts.speak returning [] (no entity matched → no audio) logs a WARNING
+        rather than a false 'delivered'. Guards the silent-chime failure mode
+        (HA 200 + empty changed-states) from 2026-06-13."""
+        import logging
+
+        adapter = VoiceChannelAdapter(
+            ha_url="http://ha.local:8123",
+            ha_token="test-token",
+            media_player_entity="media_player.bogus",
+        )
+
+        async def mock_post_fn(url, **kwargs):
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json = MagicMock(return_value=[])  # HA: zero states changed
+            return resp
+
+        with (
+            patch("genesis.channels.voice.adapter.httpx.AsyncClient") as mock_client,
+            patch("genesis.channels.voice.adapter.asyncio.sleep", new_callable=AsyncMock),
+            caplog.at_level(logging.WARNING, logger="genesis.channels.voice.adapter"),
+        ):
+            mock_client.return_value.__aenter__ = AsyncMock(
+                return_value=MagicMock(post=AsyncMock(side_effect=mock_post_fn)),
+            )
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await adapter.send_message("ch-1", "hello")
+            assert result  # still returns a delivery id (best-effort)
+            assert any("changed no states" in r.getMessage() for r in caplog.records)
 
 
 # ── Voice API Endpoint ───────────────────────────────────────────────


### PR DESCRIPTION
## What

Harden the proactive voice path so silent delivery failures surface, and remove install-specific entity defaults that break silently.

## Why

A proactive voice chime was silently dead for an unknown period: Home Assistant accepted the service call (HTTP 200) but changed **zero** states because the configured `media_player` entity didn't exist (a device firmware reflash had renamed it). `VoiceChannelAdapter.send_message` swallowed this and returned a delivery id as if it succeeded — so nothing surfaced, and an automated E2E falsely passed. The runtime was fixed via config (`HA_MEDIA_PLAYER_ENTITY`); this PR fixes the **code** so the failure class can't hide again.

## Changes

- **Surface silent failures** (`channels/voice/adapter.py`): `_tts_speak` now warns when HA returns an empty changed-states list (no entity matched → no audio) instead of logging a false "delivered". The pre-announce chime checks HTTP status (`play_media` returns `[]` even on success, so status is its only reliable signal there).
- **No device-specific defaults**: drop the hardcoded `media_player` entity default; require `HA_MEDIA_PLAYER_ENTITY`, warn + skip delivery when unset (tts keeps the generic `tts.piper` default).
- **Shutdown notice** (`hosting/standalone.py`): switch from `assist_satellite.announce` (that satellite entity is often `unavailable`, so the call silently no-op'd) to the held `VoiceChannelAdapter` (media_player path), inheriting the working entity config + failure-surfacing.

## Testing

- `tests/test_channels/test_voice.py`: reconciled the two cases that assumed the old hardcoded default; added coverage for the no-media_player skip and the empty-changed-states warning. **39 voice + 31 hosting + 6 shutdown tests pass; ruff clean.**
- Live E2E against real HA: positive path delivers (no "changed no states" warning = states actually changed, audibly confirmed); negative path (no entity) skips with zero HA calls + warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
