### PR TITLE
refactor(skills): consolidate voice-master into one canonical skill

### DIFF
--- a/.claude/skills/voice-master/SKILL.md
+++ b/.claude/skills/voice-master/SKILL.md
@@ -1,215 +1,35 @@
 ---
 name: voice-master
 description: >
-  Apply the user's voice when writing or editing content. Activate when
-  the user says "use the voice-master skill", "write this in my voice",
-  "make this sound like me", or any equivalent instruction. Use for any
-  content type: professional proposals, long-form writing, social posts,
-  emails, or short-form copy. Do NOT activate for code, technical docs,
-  or any output the user hasn't asked to be written in their voice.
+  Foundational voice authority and AI humanizer — writes content in the user's
+  authentic voice with built-in AI detection, and supports stealth / anti-
+  attribution writing (forum personas, anonymous posts, "write as not-me").
+  Use when asked to write/draft/generate content, invoke /voice, /write-as-me,
+  or /humanize, run voice calibration, check "does this sound like me?", "make
+  this sound human" / "de-AI this", "write a forum post as [persona]", or run
+  AI detection ("does this sound like AI?", "check for AI patterns", "anti-slop
+  check"). Do NOT use this skill for code, technical docs, or any output the
+  user has not asked to be written in their voice — code styling defers to the
+  separate code-voice skill.
+consumer: cc_foreground
+phase: content
+skill_type: generation
 ---
 
-## THIS IS A TWO-PART SKILL — BOTH PARTS ARE MANDATORY
+# Voice Master — entry point (canonical skill in the repo skill library)
 
-1. **Voice matching** — use exemplars to match tone, vocabulary, rhythm
-2. **Anti-AI-slop pass** — review output for AI tells and fix them
+This Tier-1 entry exists so the skill is natively discoverable. The **complete**
+voice-master skill — workflow, Quick Mode, calibration, stealth mode, anti-slop
+rules, and all references — is maintained as the single source of truth at:
 
-You MUST apply BOTH passes on every use. Never apply exemplar matching
-without the slop pass. Never skip the slop pass because "the voice sounds
-right." The slop pass catches what exemplars can't — structural patterns,
-banned words, em dash abuse, uniform sentence length.
+> `src/genesis/skills/voice-master/SKILL.md`
 
-If you are editing existing text (not generating): run the full Step 6
-audit. If generating: Steps 1-5 produce the draft, Step 6 audits it.
-Both paths end with the audit. No exceptions.
+**To use this skill:** read `src/genesis/skills/voice-master/SKILL.md` and
+follow it exactly — including its mandatory two-part workflow (voice match +
+anti-slop audit) and its **User Calibration Overlay** resolution. All reference
+files it cites live in `src/genesis/skills/voice-master/references/`.
 
----
-
-## Companion Files
-
-This is the **project-level** skill (workflow + AI-tell audit rules). The
-**user-level** companion at `~/.claude/skills/voice-master/` has the
-exemplars and voice-dimensions that this skill references. Always load
-both locations when using this skill:
-
-- **Exemplars:** `~/.claude/skills/voice-master/exemplars/` (index.md,
-  social.md, professional.md, longform.md)
-- **Voice dimensions:** `~/.claude/skills/voice-master/voice-dimensions.md`
-
-## Overview
-
-Generates content that sounds like the user — not an AI impression of the
-user. The exemplars are the primary source of truth. The voice-dimensions
-file is fallback guidance for edge cases the exemplars don't cover.
-**When exemplars conflict with voice-dimensions, exemplars win.**
-
-The final output must pass an AI-tell audit before delivery. No exceptions.
-
-## Quick Mode
-
-For short content, skip the exemplar research pipeline. Quick Mode runs
-Steps 5–7 only (generate + audit + deliver). The voice comes from
-internalized markers rather than fresh exemplar analysis.
-
-**Auto-triggers** (self-detected unless overridden):
-- Content request is <200 words of output
-- Content type is email, reply, DM, or Slack message
-- Caller explicitly says "quick" / "quick mode" / "just dash this off"
-
-**Audit-only** (editing existing text, not generating):
-- Skip Steps 1–5 entirely
-- Run Step 6 (full enhanced audit) on the provided text
-- Deliver the cleaned version
-
-**Quick Mode generation (Step 5 lite):**
-- Characteristic openers where natural ("Here's the thing," "Frankly,"
-  "Not for nothing")
-- Match register to audience (use Register Quick Reference below)
-- Evidence-first, no windup, no padding
-- Do NOT load exemplar files — use internalized voice markers only
-
-**Override:** If the user says "full mode" or "use exemplars," run the
-complete 7-step workflow regardless of content length.
-
-## Workflow
-
-### Step 1 — Read the exemplar index
-
-Read `exemplars/index.md`. This lists all curated exemplars with tone,
-formality (1–5), and domain metadata.
-
-### Step 2 — Select 3–5 matching exemplars
-
-Match on:
-- **Medium** — proposal, long-form, social, email, short-form?
-- **Tone** — direct, analytical, reflective, blunt, measured?
-- **Formality** — 1 (inner circle) to 5 (formal/public)?
-- **Domain** — technical, strategy, AI, security, general?
-
-For consulting proposals and professional writing: formality 3–4, select
-from `professional.md` and `longform.md`. For social/short-form: formality
-1–2, select from `social.md`.
-
-### Step 3 — Read the matched exemplar files
-
-Read the full text of each matched exemplar. Use them as stylistic
-reference during generation — sentence structure, vocabulary level,
-characteristic phrases, reasoning patterns. **Do not copy content.**
-
-### Step 4 — Read voice-dimensions (if needed)
-
-Read `voice-dimensions.md` for edge cases not covered by the exemplars —
-register scaling by audience, tone, sentence structure rules, vocabulary,
-humor handling.
-
-### Step 5 — Generate
-
-Write the content. Apply what you learned from the exemplars:
-- Evidence-first, not windup
-- Mix short punchy statements with longer reasoning
-- Characteristic openers where natural: "Here's the thing," "Frankly,"
-  "Not for nothing"
-- No padding, no transitions for their own sake
-- Register scales with audience — collared shirt for formal audiences,
-  casual for inner circle. Drop profanity entirely at formality 3+.
-
-### Step 6 — AI-tell audit (mandatory, every time)
-
-Before delivering, scan the output and eliminate any of the following:
-
-**Banned words and phrases:**
-- delve, leverage, utilize, ensure, robust, seamless, streamline
-- clean (as filler/intensifier, e.g. "clean architecture" — OK for
-  literal cleanliness), smoking gun, landscape, ecosystem (when not
-  literal), holistic, synergy, empower, elevate, harness, foster
-- pivotal, crucial, enhance, underscore, vibrant, testament, showcase,
-  intricate, evolving, navigate, journey
-- it's worth noting, it is important to note, it's important to
-- in conclusion, in summary, to summarize
-- cutting-edge, game-changing, transformative, revolutionary
-- I'd be happy to, certainly, absolutely, of course
-- this allows us to, this enables, this ensures
-
-**Banned structural patterns:**
-- Opening with "I" on the first sentence
-- Three-part lists that follow the exact same grammatical structure
-- Passive voice overuse ("it was determined," "it should be noted")
-- Rhetorical questions that aren't genuinely rhetorical
-- Em-dash overuse and wrong format. Two rules, both hard:
-  1. **Format:** NEVER spaced. `word — word` is the #1 AI punctuation tell.
-     Acceptable: `word—word` (bare unicode) or `word--word` (double hyphen).
-     Preferred: restructure the sentence to use a period, comma, colon, or
-     semicolon instead. If you must use an em dash, no spaces touching it.
-  2. **Frequency:** Reach for a comma, period, colon, or semicolon first.
-     Every time. Em-dashes are for emphasis or asides where nothing else fits.
-     Max 1-2 per page, not per paragraph. Stacking them is an AI fingerprint.
-  The anti-slop pass MUST catch and fix any spaced em dashes. This is a
-  hard fail — if ` — ` appears anywhere in the output, the audit failed.
-- Hedging openers ("It's worth considering that...")
-- Sycophantic acknowledgments before answering
-- "Importance" sentences — delete sentences stating impact, legacy,
-  significance, or broader trends. Show why it matters, don't state
-  that it matters.
-- Contrast structures — delete "It's not X, it's Y" / "Not A. Not B.
-  But C" / "Despite this..." patterns. AI cadence markers.
-- Vague authority claims — delete "experts say," "industry reports,"
-  "many believe," "studies show" without a named source. No source =
-  no claim.
-- General claims without evidence — replace with specifics or delete.
-  No proof = doesn't belong.
-- Sentence length bias — strong bias toward sentences under 16 words.
-  Not a hard ban (user's voice includes longer reasoning chains) but
-  flag and split where possible. If you can say it shorter, do.
-- Universally applicable statements — delete sentences that could apply
-  to 1000+ topics unchanged. Not specific to THIS subject = padding.
-
-**Test:** Read each paragraph out loud. If it sounds like a polished AI
-response, it needs a rewrite. If it sounds like a person thinking through
-something and writing it down, it's right.
-
-### Step 7 — Deliver
-
-Output the final content directly. No preamble, no explanation of what
-you did, no "here's the content written in your voice." Just the content.
-
-## Register Quick Reference
-
-| Audience | Formality | Profanity | Exemplar source |
-|----------|-----------|-----------|-----------------|
-| Inner circle / Genesis | 1–2 | OK | social.md |
-| Professional peers | 2–3 | OK | professional.md |
-| Formal / cold outreach | 3–4 | None | professional.md, longform.md |
-| Public content | 4–5 | None | longform.md |
-
-## Examples
-
-### Single paragraph, professional proposal
-**Input:** "Use the voice-master skill to write an intro paragraph for a
-security section of a consulting proposal. Owner/founder audience."
-
-**Action:** Index → select professional.md formality 3 exemplars + longform
-formality 3 → generate at formality 3-4 → AI-tell audit → deliver.
-
-### Social post
-**Input:** "Write a LinkedIn post about this in my voice."
-
-**Action:** Index → select social.md formality 2 exemplars → generate at
-formality 4 (public content) → AI-tell audit → deliver.
-
-### Full document section
-**Input:** "Rewrite this section in my voice."
-
-**Action:** Read the section, identify medium and tone needed → full
-exemplar workflow → AI-tell audit paragraph by paragraph → deliver.
-
-### Quick email reply
-**Input:** "Write a reply declining the meeting. Keep it short."
-
-**Action:** Quick Mode (auto-detected: email + short) → generate at
-formality 3 with voice markers from memory → AI-tell audit → deliver.
-
-### Audit existing text
-**Input:** "Run the AI-tell audit on this paragraph."
-
-**Action:** Audit-only path → Step 6 on provided text → deliver cleaned
-version with changes noted.
+Your private voice data (exemplars, voice-dimensions) stays in the user overlay
+at `~/.claude/skills/voice-master/` and is never read from or written to this
+repo. This file holds no voice behavior of its own — there is one source of
+truth, in the repo skill library above.

--- a/src/genesis/skills/voice-master/SKILL.md
+++ b/src/genesis/skills/voice-master/SKILL.md
@@ -102,10 +102,17 @@ curate) × **whose voice** (user's [default] / stealth, see Stealth Mode).
 2. **Load voice** — run the User Calibration Overlay resolution; pick 3-5
    exemplars by medium + tone + formality + domain. (Quick Mode skips this and
    uses internalized markers.)
-3. **Generate** — use exemplars as stylistic reference: match sentence
-   structure, vocabulary level, directness, and rough edges; do not copy their
-   content. Register scales with audience (see table); drop profanity at
-   formality 3 and above.
+3. **Generate** — use exemplars as a *stylistic* reference only: match sentence
+   structure, vocabulary level, directness, and rough edges. **Never copy their
+   content** — not sentences, claims, phrasings, or specifics; lift the rhythm,
+   never the substance. **On-topic trap:** if an exemplar happens to share the
+   task's topic, that is the single highest-risk case for accidental copying —
+   take its cadence and nothing else, because its facts are stale and not yours.
+   **Facts, numbers, dates, and durations come ONLY from the task input** — never
+   invent stale-able specifics (elapsed time like "four months building",
+   star/line/version counts, adoption stats); if a number isn't given, omit it.
+   Register scales with audience (see table); drop profanity at formality 3 and
+   above.
 4. **Hand off to medium skill** — if a downstream skill exists for the medium
    (e.g., linkedin-post-writer), hand the voice-loaded content off for
    medium-specific formatting.

--- a/src/genesis/skills/voice-master/SKILL.md
+++ b/src/genesis/skills/voice-master/SKILL.md
@@ -1,17 +1,16 @@
 ---
 name: voice-master
 description: >
-  Foundational voice authority and AI humanizer — writes content in user's
+  Foundational voice authority and AI humanizer — writes content in the user's
   authentic voice with built-in AI detection, and supports stealth / anti-
   attribution writing (forum personas, anonymous posts, "write as not-me").
-  Use when asked to write/draft/generate content, invoke /voice or /write-as-me
+  Use when asked to write/draft/generate content, invoke /voice, /write-as-me,
   or /humanize, run voice calibration, check "does this sound like me?", "make
   this sound human" / "de-AI this", "write a forum post as [persona]", or run
   AI detection ("does this sound like AI?", "check for AI patterns", "anti-slop
-  check"). The anti-slop filter and ai-vocabulary.md function as an AI content
-  detector — scanning for 290+ known AI writing patterns, statistical tells,
-  and vocabulary signals across 3 severity tiers, now medium-scoped (universal
-  / professional / forum / long-form).
+  check"). Do NOT use this skill for code, technical docs, or any output the
+  user has not asked to be written in their voice — code styling defers to the
+  separate code-voice skill.
 consumer: cc_foreground
 phase: content
 skill_type: generation
@@ -19,356 +18,182 @@ skill_type: generation
 
 # Voice Master (AI Humanizer + Stealth Writer)
 
+## THIS IS A TWO-PART SKILL — BOTH PARTS ARE MANDATORY
+
+1. **Voice matching** — load exemplars, match tone, vocabulary, rhythm.
+2. **Anti-AI-slop pass** — audit the output for AI tells and fix them.
+
+Apply BOTH on every use. Never match voice without the slop pass; never skip
+the slop pass because "it sounds right." If you are editing existing text
+rather than generating, run the audit (Workflow step 5) on it directly. Both
+paths end with the audit. No exceptions.
+
 ## Purpose
 
 Write content that sounds authentically like the user — across any medium, for
-any audience. The bar: a reader who knows the user cannot distinguish this from
-something the user wrote themselves.
+any audience. The bar: a reader who knows the user cannot tell it from
+something they wrote. This skill is the voice authority; downstream content
+skills (LinkedIn, email, blog) reference its overlay loader and anti-slop
+rules. When writing as someone other than the user (forum personas, anonymous
+posts, genericized output), **stealth mode** neutralizes the user's voice
+fingerprints and layers a persona or anonymous register on top.
 
-This skill is the voice authority. All downstream content skills (LinkedIn,
-email, blog, etc.) reference this skill's overlay-loader for voice loading and
-its anti-slop rules for AI detection.
+## When to Use / Boundaries
 
-When writing as someone other than the user — forum personas, anonymous posts,
-or intentionally genericized output — this skill's **stealth-writing mode**
-neutralizes the user's voice fingerprints and layers a persona or anonymous
-register on top.
+- USE for: any content the user wants in their voice — proposals, long-form,
+  social posts, emails, forum posts, persona/stealth writing; voice
+  calibration; AI-detection / "does this sound like AI?" audits.
+- Do NOT use this skill for code, technical documentation, commit messages, or
+  any output the user has not asked to be written in a human voice. Code
+  styling defers to the separate `code-voice` skill. If unsure whether the
+  user wants their voice applied, ask before activating.
 
----
+## Quick Mode
 
-## User Calibration Overlay (MANDATORY — READ THIS FIRST)
+For short content, skip the exemplar-research pipeline and generate from
+internalized voice markers plus the audit.
 
-Voice-master separates **skill machinery** (rules, anti-slop, style guidance,
-this instructions file) from **user data** (exemplars, voice-dimensions). The
-machinery ships in the repo; the user data lives outside the repo so personal
-writing samples never enter version control.
+- **Auto-triggers** (self-detected unless overridden): output < ~200 words; or
+  content type is email / reply / DM / Slack; or the user says "quick" / "just
+  dash this off".
+- **Audit-only** (editing existing text, not generating): skip voice loading;
+  run the Workflow step-5 audit on the provided text; deliver the cleaned text.
+- **Override:** if the user says "full mode" / "use exemplars", run the full
+  pipeline regardless of length.
 
-**Overlay default location**: `~/.claude/skills/voice-master/` (no trailing
-slash when concatenating; see the resolution procedure below). Override via
-the `GENESIS_VOICE_OVERLAY` environment variable.
+In Quick Mode, use characteristic markers where natural ("Here's the thing,"
+"Frankly," "Not for nothing"), match register to audience (see table below),
+lead with evidence, no windup. Do NOT load exemplar files — use internalized
+markers. Always still run the anti-slop audit.
 
-```
-<overlay_root>/
-├── voice-dimensions.md      # user's actual voice description
-└── exemplars/
-    ├── index.md
-    ├── social.md
-    ├── professional.md
-    └── longform.md
-```
+## User Calibration Overlay
 
-### Overlay Resolution Procedure (follow these steps EXACTLY)
+Voice-master separates **skill machinery** (this file, the rules, anti-slop and
+style references — shipped in the repo) from **user data** (exemplars,
+voice-dimensions — kept OUTSIDE the repo so personal writing never enters
+version control).
 
-Do NOT mentally expand shell parameter substitution. The Read tool does not
-perform shell expansion on its input. You MUST resolve the overlay path
-using Bash first, then pass the resolved absolute path to the Read tool.
+- **Overlay root:** `~/.claude/skills/voice-master/` (override via
+  `GENESIS_VOICE_OVERLAY`). Layout: `voice-dimensions.md` + `exemplars/`
+  (index.md, social.md, professional.md, longform.md, …).
+- **Resolution** (full procedure in `references/overlay-loading.md` — follow it
+  exactly; resolve the path with Bash, never shell-expand inside the Read tool):
+  1. Resolve `<overlay_root>` via Bash: `echo "${GENESIS_VOICE_OVERLAY:-$HOME/.claude/skills/voice-master}"`.
+  2. Read `<overlay_root>/voice-dimensions.md`. If missing, fall back to
+     `references/voice-dimensions-TEMPLATE.md` AND emit the MANDATORY
+     no-overlay warning (see overlay-loading.md) — output won't match the user.
+  3. Read `<overlay_root>/exemplars/index.md`; pick 3-5 matches; read those
+     files. If missing, see `references/exemplars/README.md` and warn that no
+     exemplars were loaded.
+  4. Never cache overlay state — re-resolve every request.
+- **Hygiene:** never write user data into the in-repo template files;
+  calibration writes go only to `<overlay_root>/`. Exemplars take precedence
+  over voice-dimensions.
 
-**Step 1 — Resolve the overlay root.** Run this via the Bash tool:
+## Workflow
 
-```bash
-echo "${GENESIS_VOICE_OVERLAY:-$HOME/.claude/skills/voice-master}"
-```
+Two orthogonal axes: **what** (generate [default] / calibrate / analyze /
+curate) × **whose voice** (user's [default] / stealth, see Stealth Mode).
 
-Capture the output. That is `<overlay_root>` for the rest of this session.
-Strip any trailing slash if present.
+1. **Detect medium** — social / professional / forum / longform. An explicit
+   medium wins; else map the named platform; else infer from shape (default to
+   professional). Medium selects the anti-slop section to apply and whether
+   `references/media/forum.md` loads (forum only).
+2. **Load voice** — run the User Calibration Overlay resolution; pick 3-5
+   exemplars by medium + tone + formality + domain. (Quick Mode skips this and
+   uses internalized markers.)
+3. **Generate** — use exemplars as stylistic reference: match sentence
+   structure, vocabulary level, directness, and rough edges; do not copy their
+   content. Register scales with audience (see table); drop profanity at
+   formality 3 and above.
+4. **Hand off to medium skill** — if a downstream skill exists for the medium
+   (e.g., linkedin-post-writer), hand the voice-loaded content off for
+   medium-specific formatting.
+5. **Anti-slop audit (mandatory, every time)** — scan against
+   `references/anti-slop.md` (the Universal section plus the current-medium
+   section) and Tier-1 words in `references/ai-vocabulary.md`. **Em-dash hard
+   rule:** a spaced em dash (` — `) is the #1 AI tell — if it appears anywhere,
+   the audit FAILED; never spaced, max 1-2 per page, prefer a comma / period /
+   colon. Also check specificity (one concrete detail that couldn't apply to
+   any topic) and natural sentence-length variation. On failure, revise with
+   specific feedback; max 2 passes, then surface the best version with
+   remaining flags noted. Final gut check — read it aloud: if it sounds like a
+   polished AI response, rewrite it; if it sounds like a person thinking on the
+   page, it's right.
 
-**Step 2 — Load voice-dimensions.** Try to Read `<overlay_root>/voice-dimensions.md`
-with the Read tool (absolute path, no shell syntax).
+**Modes** beyond the default generate:
 
-- **If Read succeeds**: this is the active voice profile. Use it as the
-  authoritative description of how the user sounds.
-- **If Read fails** (file not found or other error): fall back to
-  `references/voice-dimensions-TEMPLATE.md` in this skill directory. The
-  template is generic — your output will not match any specific user voice.
-  Begin your reply with a prominent warning on its own line:
-
-  ```
-  WARNING: No voice overlay detected. Generating with generic template voice. Run the voice-master calibration workflow to build a profile.
-  ```
-
-  The warning is MANDATORY in the fallback path. Do not skip it. Do not bury
-  it mid-paragraph. The user needs to see this before reading any generated
-  content, because the content is not in their voice.
-
-**Step 3 — Load the exemplar index.** Try to Read `<overlay_root>/exemplars/index.md`.
-
-- **If Read succeeds**: this is the active exemplar registry. Use it to pick
-  3-5 best matches for the request, then Read the appropriate exemplar files
-  from `<overlay_root>/exemplars/{social,professional,longform}.md` as needed.
-- **If Read fails**: there are no calibrated exemplars. Read
-  `references/exemplars/README.md` in this skill directory for the onboarding
-  instructions. Proceed with voice-dimensions guidance only. Note in your
-  reply that no exemplars were loaded — the warning from Step 2 covers this
-  if voice-dimensions also fell back, otherwise add a second line:
-
-  ```
-  WARNING: No exemplars in overlay — generation is based on voice-dimensions only.
-  ```
-
-**Step 4 — Never cache overlay state across invocations.** Repeat Steps 1-3
-on every generation request. The overlay can be updated between calls
-(e.g., the user ran calibration and added new exemplars).
-
-### Overlay Hygiene Rules
-
-- **Do not write personal user data into the in-repo files.** The in-repo
-  `voice-dimensions-TEMPLATE.md` and `exemplars/README.md` are generic
-  template scaffolding. Real writing samples and voice profiles go only
-  in `<overlay_root>/`.
-- **Do not mention the fallback warning if the overlay loaded successfully.**
-  The warning exists to surface a missing-overlay state, not as boilerplate.
-- **If the user asks you to write to the overlay** (e.g., during a
-  calibration session), write to the resolved `<overlay_root>/` path, not
-  to the in-repo template files.
-
----
-
-## Voice Loading Pipeline (MANDATORY BEFORE GENERATION)
-
-BEFORE generating any content, you MUST read the following files using the Read
-tool. Do not skip this step. Do not generate from memory.
-
-1. Follow the **User Calibration Overlay** resolution above to load either
-   (a) the overlay's voice-dimensions + exemplars, or (b) the template fallback
-   with a warning.
-2. From whichever exemplar index is active, identify 3-5 exemplars whose tone,
-   formality, and domain best match the current request.
-3. Read the appropriate exemplar file(s) to get the actual exemplar text.
-4. Read `references/anti-slop.md` for patterns to avoid. Scan **only the
-   sections matching the current medium** (see Medium Detection below) plus
-   the **Universal** section. Do not apply professional/LinkedIn rules to a
-   forum post or vice versa — they contradict.
-5. Scan `references/ai-vocabulary.md` for Tier 1 dead-giveaway words to ban.
-
-**Precedence rule:** Exemplars always take precedence over voice-dimensions.
-Exemplars show what the user actually sounds like. Voice dimensions are
-supplementary guidance for edge cases the exemplars don't cover.
-
-**If exemplar files are empty or have no good matches:**
-1. Use cross-medium exemplars that match on tone and domain. Note in output:
-   "Used cross-medium exemplars — consider a calibration session for [medium]."
-2. If no exemplars match at all, use voice-dimensions as your only voice
-   guidance.
-3. At minimum, always apply the anti-slop filter. Never generate content with
-   zero voice constraint.
-
----
-
-## Medium Detection
-
-Voice-master explicitly models **medium** as a first-class axis of voice.
-Different mediums have different native registers, and anti-slop rules that
-catch AI-sounding content in one medium actively miss-fire in another.
-
-Medium options:
-
-- **social** — short, public posts (Twitter/X, LinkedIn feed, short posts)
-- **professional** — email, Slack DMs, work documents, LinkedIn messages,
-  anything where the user is identified and the stakes are reputational
-- **forum** — long-running threaded discussions on hobbyist/community sites
-  (Reddit, Discourse, phpBB-style forums, HN comments). Forum register is
-  casual, fragment-heavy, idiom-rich, and allergic to the structured
-  polish that wins on LinkedIn.
-- **longform** — blog posts, essays, long-form articles, substack pieces
-
-Detection precedence:
-1. The request explicitly names a medium — use it.
-2. The request names a platform (e.g., "LinkedIn post") — map it to medium.
-3. Infer from the request shape (length, audience, formatting) — default to
-   `professional` if ambiguous.
-
-The selected medium determines which section of `references/anti-slop.md`
-applies and whether `references/media/forum.md` is loaded (forum only).
-
----
-
-## Standalone Modes
-
-Voice-master has two orthogonal mode dimensions:
-
-1. **What the user asks the skill to do**: generate, calibrate, analyze, curate.
-2. **Whose voice to produce**: user's actual voice (default) or stealth voice
-   (user's voice fingerprints neutralized, optionally layered with a persona).
-
-These combine: you can generate in the user's voice, generate in stealth mode,
-analyze a piece of text for whose voice it matches, etc.
-
-### Generate (default mode)
-
-Write content directly when no medium-specific skill applies. Follow the
-Voice Loading Pipeline above, then the Core Pipeline below. Output the final
-content.
-
-### Calibrate
-
-Run an edit-and-learn session to refine the user's voice profile:
-
-1. Ask the user for a topic they care about (or pick from their known domains)
-2. Generate a short piece (2-3 paragraphs) using current exemplars
-3. Write the generated content to a temporary file (e.g., `~/tmp/voice-calibrate-draft.md`)
-4. Tell the user the file path and ask them to edit it to sound right, then
-   let you know when done (or they can paste the edited version back)
-5. Diff the original vs edited version
-6. Analyze the diff: What changed? Added personality? Removed hedging? Changed
-   vocabulary? Restructured sentences? Made it more direct?
-7. Propose a voice insight: "You prefer X over Y in this context"
-8. User confirms or corrects
-9. Encode the insight — write it to the **overlay** directory
-   (`${GENESIS_VOICE_OVERLAY:-$HOME/.claude/skills/voice-master/}exemplars/` or
-   `voice-dimensions.md`). **Never** to the in-repo template files.
-10. Repeat. Initial session: ~10 rounds (20-30 minutes). Tune-ups: 2-3 rounds.
-
-### Analyze
-
-"Does this text sound like me?" Compare provided text against the active
-(overlay or fallback) exemplars:
-- Sentence length variation
-- Vocabulary register
-- Directness vs hedging
-- Specificity vs abstraction
-- Presence of AI-tell patterns
-
-Report a verdict with specific observations.
-
-### Curate
-
-Propose new exemplars from recent transcripts or calibration sessions:
-- Present candidates in batches of 5-10
-- User rates: "yes this is me" / "no" / "this is me but for a different medium"
-- Tag accepted exemplars with medium, tone, formality, domain
-- Update the appropriate exemplar file and index **in the overlay directory**
-
----
+- **Calibrate** — edit-and-learn loop to refine the profile: generate a short
+  piece → user edits → diff → propose a voice insight → on confirmation, write
+  it to the **overlay** (never the in-repo template). Full loop in
+  `references/overlay-loading.md`.
+- **Analyze** — "does this sound like me?" Compare the text to the active
+  exemplars on sentence variation, register, directness, specificity, and
+  AI-tells; report a verdict with specific observations.
+- **Curate** — propose new exemplars from transcripts in batches of 5-10; on
+  acceptance, tag (medium / tone / formality / domain) and write to the overlay.
 
 ## Stealth Mode (Anti-Attribution Writing)
 
-Use stealth mode when the output should **not** be attributable to the user.
-Canonical use cases: forum personas, anonymous posts, sock-puppet/test
-accounts, intentionally genericized writing that can't be traced.
+Use when the output must NOT be attributable to the user — forum personas,
+anonymous posts, test accounts, intentionally genericized writing. Load
+`references/stealth-writing.md` and follow its protocol. Three sub-modes:
 
-### Activating Stealth Mode
+1. **Anonymous** — not-the-user, with no positive target.
+2. **Persona** — write AS a defined character from `~/.claude/personas/<name>/`.
+3. **Impersonation** — mimic a specific named voice; **hard limits apply** (see
+   stealth-writing.md); never impersonate a living public figure in
+   adversarial or defamatory contexts.
 
-Stealth mode is activated by the request. Triggers:
-- Explicit: "stealth mode", "anti-attribution", "anonymous", "write as [persona]"
-- Implicit: the request names a persona directory under `~/.claude/personas/`
-- Implicit: the request targets a forum/platform where the user is not
-  self-identifying (e.g., "post on this forum as a regular")
+Pipeline (abbreviated; full version in `references/stealth-writing.md`): load
+the user's profile to identify the fingerprints to **neutralize** (not the
+voice to produce); load the persona directory if one is specified; generate
+candidates that avoid the user's fingerprints; run the **adversarial critic**
+(a separate scoring call, 0-10 on plausibility); select if the best candidate
+scores ≥7, otherwise regenerate once, then surface to the user. In persona
+mode, log the result to `~/.genesis/personas.db`.
 
-When stealth mode is active, **load** `references/stealth-writing.md` in
-addition to the normal voice loading pipeline. Follow its protocol.
+## Output Format
 
-### Three Stealth Sub-Modes
+Output the final content directly — no preamble, no "here's the content in your
+voice," no explanation of what you did. In the no-overlay fallback, prepend the
+MANDATORY warning line first. In stealth mode, return only the neutralized /
+persona text. When auditing existing text, return the cleaned version (note the
+changes if asked).
 
-1. **Anonymous** — no persona, just not-the-user. The output should be
-   unrecognizable as the user's voice but has no other positive target.
-2. **Persona** — writing AS a defined character from
-   `~/.claude/personas/<persona_name>/`. The persona directory provides a
-   positive voice target to replace the user's voice with.
-3. **Impersonation** — mimicking a specific named voice. **Hard limits
-   apply**: see stealth-writing.md for the full list. Never impersonate a
-   named living public figure in adversarial/defamatory contexts.
+## Examples
 
-### Stealth Mode Pipeline (abbreviated; full version in stealth-writing.md)
+- **Professional proposal paragraph** (owner/founder audience): overlay →
+  professional + longform exemplars (formality 3-4) → generate → audit → deliver.
+- **LinkedIn post**: overlay → social exemplars → generate at public formality
+  → audit (watch em dashes and hype words) → deliver.
+- **Quick email reply** ("decline the meeting, keep it short"): Quick Mode
+  (email + short) → markers from memory → audit → deliver.
+- **"Does this sound like me?"**: Analyze mode → compare to exemplars → verdict.
+- **Audit existing text** ("de-AI this paragraph"): audit-only path → step-5
+  audit → cleaned version.
 
-1. Load user's voice profile via the Calibration Overlay resolution — this
-   identifies the **fingerprints to neutralize**, not the voice to produce.
-2. If a persona is specified, load the persona directory:
-   `~/.claude/personas/<name>/persona.md` (identity, constraints, backstory)
-   and `~/.claude/personas/<name>/exemplars.md` (style targets).
-3. Generate candidates with the persona's voice (or generic anonymous voice),
-   actively avoiding the user's fingerprints.
-4. Run the **adversarial critic** protocol (separate LLM call, no generation
-   context, scores 0-10 on plausibility as the intended voice).
-5. If best candidate scores ≥7, select it. Otherwise regenerate once; if
-   still below threshold, surface to the user.
-6. Log the result in `~/.genesis/personas.db` (persona mode only).
+## Register Quick Reference
 
-Full protocol in `references/stealth-writing.md`.
-
----
-
-## Core Pipeline
-
-When generating content in the **user's** voice (default, non-stealth):
-
-1. **Read the request** — topic, target medium, tone, audience, constraints.
-2. **Detect the medium** — see Medium Detection above. This selects the
-   anti-slop section to apply and whether to load `references/media/forum.md`.
-3. **Load voice** — follow the User Calibration Overlay resolution and the
-   Voice Loading Pipeline.
-4. **Pick exemplars** — from the overlay (or template fallback), select 3-5
-   best matches by medium + tone + formality + domain.
-5. **Generate content** — use selected exemplars as stylistic reference.
-   Match sentence structure, vocabulary level, directness, and rough edges.
-   Do NOT copy exemplar content — match the style.
-6. **Hand off to medium skill** — if a downstream skill exists for this medium
-   (e.g., linkedin-post-writer for LinkedIn), hand off the voice-loaded content
-   for medium-specific formatting.
-7. **Anti-slop filter** — review output against the three checks in
-   `references/anti-slop.md`, scoped to the current medium. If it fails,
-   revise with specific feedback. Maximum 2 revision passes. After that,
-   surface the best version with remaining flags noted.
-
-When generating in **stealth mode**, follow the Stealth Mode Pipeline above.
-
----
-
-## Anti-Slop Filter
-
-Applied as the final step of every content generation. Three checks, now
-medium-scoped:
-
-1. **Pattern matching** — scan for known AI writing tells in
-   `references/anti-slop.md`. Scan the **Universal** section always, plus the
-   section matching the current medium (**Professional**, **Forum**, or
-   **Long-form**). Any match in an applicable section is a failure.
-2. **Voice consistency** — compare against selected exemplars. Does sentence
-   length vary naturally? Does vocabulary match the user's register? Is the
-   perspective personal or abstract? Does it have opinions or hedge everything?
-3. **Specificity check** — does the content contain at least one concrete
-   detail, specific reference, or personal experience that could NOT have
-   been generated about any topic by any person? If you removed the topic
-   keywords, would it be indistinguishable from a template? If yes, fail.
-
-**On failure:** don't just flag — revise. Send specific feedback: "Paragraph 2
-uses 'In today's landscape' — rephrase with a specific observation."
-
-**Revision limit:** maximum 2 passes. If still failing, surface the best
-version with remaining flags noted for the user.
-
-In stealth mode, the anti-slop filter is augmented by the adversarial critic
-from `references/stealth-writing.md`.
-
----
+| Audience | Formality | Profanity | Exemplar source |
+|---|---|---|---|
+| Inner circle / Genesis | 1–2 | OK | social.md |
+| Professional peers | 2–3 | OK | professional.md |
+| Formal / cold outreach | 3–4 | None | professional.md, longform.md |
+| Public content | 4–5 | None | longform.md |
 
 ## References
 
-All reference files are in this skill's `references/` directory. User-specific
-data (exemplars, voice-dimensions) is loaded from the **overlay** at
-`${GENESIS_VOICE_OVERLAY:-$HOME/.claude/skills/voice-master/}`; see User
-Calibration Overlay above.
+In-repo machinery (generic, shipped in the public template):
 
-**In-repo machinery (generic, shipped in the public template):**
+- `references/overlay-loading.md` — full overlay resolution + calibrate loop + hygiene.
+- `references/anti-slop.md` — medium-scoped AI-tell patterns + the em-dash hard rule.
+- `references/ai-vocabulary.md` — 290+ AI words/phrases in 3 severity tiers.
+- `references/style-guide.md` — how to write like a human (opinions, rhythm, specificity).
+- `references/stealth-writing.md` — anti-attribution / persona / anonymous writing.
+- `references/media/forum.md` — forum-writing craft; loaded when medium=forum.
+- `references/voice-dimensions-TEMPLATE.md` — fallback voice; never populate with user data.
+- `references/exemplars/README.md` — onboarding for building the voice overlay.
 
-- `references/anti-slop.md` — Medium-scoped AI-tell patterns to avoid
-  (Universal / Professional / Forum / Long-form). Three-check framework.
-- `references/ai-vocabulary.md` — 290+ AI words/phrases in 3 severity tiers
-  with alternatives. Medium-agnostic (Tier 1 words are bad everywhere).
-- `references/style-guide.md` — How to write like a human (opinions, rhythm,
-  specificity).
-- `references/stealth-writing.md` — Anti-attribution / persona / anonymous
-  writing. Used in stealth mode.
-- `references/media/forum.md` — Positive forum-writing craft (reply-culture
-  norms, pacing, vibe-matching). Loaded when medium=forum.
-- `references/voice-dimensions-TEMPLATE.md` — Fallback voice guidance used
-  when no overlay is present. Generic; do not populate with user data.
-- `references/exemplars/README.md` — Onboarding doc for building a voice
-  overlay. The overlay itself lives outside the repo.
-
-**User overlay (private, outside the repo):**
-
-- `${overlay}/voice-dimensions.md` — User's actual voice description.
-- `${overlay}/exemplars/index.md` — Exemplar registry.
-- `${overlay}/exemplars/social.md` — Social media voice exemplars.
-- `${overlay}/exemplars/professional.md` — Professional comms exemplars.
-- `${overlay}/exemplars/longform.md` — Long-form writing exemplars.
+User overlay (private, outside the repo): `${overlay}/voice-dimensions.md` and
+`${overlay}/exemplars/{index,social,professional,longform}.md`.

--- a/src/genesis/skills/voice-master/SKILL.md
+++ b/src/genesis/skills/voice-master/SKILL.md
@@ -126,7 +126,12 @@ curate) × **whose voice** (user's [default] / stealth, see Stealth Mode).
    specific feedback; max 2 passes, then surface the best version with
    remaining flags noted. Final gut check — read it aloud: if it sounds like a
    polished AI response, rewrite it; if it sounds like a person thinking on the
-   page, it's right.
+   page, it's right. **Mechanical backstop:** the spaced-em-dash and banned-word
+   tells are also enforced in code — run `python -m genesis.content.antislop
+   <file>` (cleaned text to stdout, fixes/flags to stderr) to auto-fix spaced em
+   dashes and flag banned words deterministically. Content sent through Genesis's
+   external channels (email, Discord) and Medium drafts passes through this
+   scrubber automatically; your audit is the first line, not the only one.
 
 **Modes** beyond the default generate:
 

--- a/src/genesis/skills/voice-master/references/anti-slop.md
+++ b/src/genesis/skills/voice-master/references/anti-slop.md
@@ -118,6 +118,25 @@ in any medium. Tier 1 words include "delve", "tapestry", "testament",
 "fostering", "garner", "interplay", "enduring", "vibrant", "crucial",
 "enhance".
 
+### Em dashes (hard rule)
+
+A spaced em dash (` — `) is the #1 AI punctuation tell. **Hard fail:** if
+` — ` appears anywhere in output, the audit failed. Never put spaces around an
+em dash. Prefer restructuring to a comma, period, colon, or semicolon; if an
+em dash is genuinely needed, use it unspaced (`word—word`). Max 1–2 per page,
+not per paragraph. Stacking them is an AI fingerprint.
+
+### Structural tells
+
+- Opening the first sentence with "I".
+- Three-part lists whose items share the exact same grammatical structure.
+- Uniform sentence length — vary it. Favor sentences under ~16 words but keep
+  the user's natural longer reasoning chains; don't flatten everything to one
+  rhythm.
+- Sycophantic acknowledgments before answering ("Great question", "Certainly",
+  "Absolutely").
+- Hedging openers ("It's worth considering that…", "It's important to note…").
+
 ---
 
 ## Professional / LinkedIn

--- a/src/genesis/skills/voice-master/references/overlay-loading.md
+++ b/src/genesis/skills/voice-master/references/overlay-loading.md
@@ -1,0 +1,111 @@
+# Overlay Loading & Calibration (voice-master)
+
+The full procedure for resolving the user voice overlay, loading voice data,
+and running calibration. SKILL.md keeps a condensed version; this is the
+authoritative detail. **Generic machinery — never put user voice data here.**
+
+## Why an overlay
+
+Voice-master separates **skill machinery** (this file, SKILL.md, the anti-slop
+and style references — shipped in the repo) from **user data** (exemplars,
+voice-dimensions). The machinery is public template; the user data lives
+OUTSIDE the repo so personal writing samples never enter version control.
+
+**Overlay default location:** `~/.claude/skills/voice-master/` (no trailing
+slash when concatenating). Override via the `GENESIS_VOICE_OVERLAY` env var.
+
+```
+<overlay_root>/
+├── voice-dimensions.md      # user's actual voice description
+└── exemplars/
+    ├── index.md
+    ├── social.md
+    ├── professional.md
+    └── longform.md
+```
+
+## Overlay Resolution Procedure (follow EXACTLY)
+
+Do NOT mentally expand shell parameter substitution. The Read tool does not
+perform shell expansion. Resolve the path with Bash first, then pass the
+resolved absolute path to the Read tool.
+
+**Step 1 — Resolve the overlay root.** Run via Bash:
+
+```bash
+echo "${GENESIS_VOICE_OVERLAY:-$HOME/.claude/skills/voice-master}"
+```
+
+Capture the output as `<overlay_root>` for the session. Strip any trailing slash.
+
+**Step 2 — Load voice-dimensions.** Read `<overlay_root>/voice-dimensions.md`
+(absolute path, no shell syntax).
+
+- **If Read succeeds:** this is the authoritative voice profile.
+- **If Read fails:** fall back to `references/voice-dimensions-TEMPLATE.md` in
+  this skill dir. The template is generic — output will not match the user.
+  Begin your reply with this MANDATORY warning on its own line:
+
+  ```
+  WARNING: No voice overlay detected. Generating with generic template voice. Run the voice-master calibration workflow to build a profile.
+  ```
+
+  Do not skip it, do not bury it mid-paragraph. The reader must see it before
+  any generated content.
+
+**Step 3 — Load the exemplar index.** Read `<overlay_root>/exemplars/index.md`.
+
+- **If Read succeeds:** pick 3-5 best matches for the request, then read the
+  matching `<overlay_root>/exemplars/{social,professional,longform}.md` files.
+- **If Read fails:** read `references/exemplars/README.md` (onboarding) and
+  proceed on voice-dimensions only. If voice-dimensions also fell back, the
+  Step 2 warning covers it; otherwise add:
+
+  ```
+  WARNING: No exemplars in overlay — generation is based on voice-dimensions only.
+  ```
+
+**Step 4 — Never cache overlay state.** Repeat Steps 1-3 on every generation
+request. The overlay can change between calls (the user may have run
+calibration and added exemplars).
+
+**Precedence:** exemplars always beat voice-dimensions. Exemplars show what the
+user actually sounds like; voice-dimensions is supplementary guidance for edge
+cases the exemplars don't cover. If exemplars are empty/no match, use
+cross-medium exemplars (note it) or voice-dimensions; never generate with zero
+voice constraint — at minimum apply the anti-slop filter.
+
+## Overlay Hygiene Rules
+
+- Do NOT write personal user data into the in-repo files. `voice-dimensions-
+  TEMPLATE.md` and `exemplars/README.md` are generic scaffolding. Real samples
+  and profiles go only in `<overlay_root>/`.
+- Do not emit the fallback warning if the overlay loaded successfully.
+- If asked to write to the overlay (e.g., during calibration), write to the
+  resolved `<overlay_root>/` path, never to the in-repo template files.
+
+## Calibrate — edit-and-learn loop (full procedure)
+
+Run to refine the user's voice profile:
+
+1. Ask the user for a topic they care about (or pick from a known domain).
+2. Generate a short piece (2-3 paragraphs) using current exemplars.
+3. Write the draft to a temp file (e.g., `~/tmp/voice-calibrate-draft.md`).
+4. Give the user the path; ask them to edit it to sound right and signal when
+   done (or paste the edited version back).
+5. Diff original vs edited.
+6. Analyze the diff: what changed? Added personality? Removed hedging? Changed
+   vocabulary? Restructured sentences? Made it more direct?
+7. Propose a voice insight: "You prefer X over Y in this context."
+8. User confirms or corrects.
+9. Encode the insight — write it to the **overlay**
+   (`<overlay_root>/exemplars/` or `<overlay_root>/voice-dimensions.md`).
+   **Never** to the in-repo template files.
+10. Repeat. Initial session ~10 rounds (20-30 min); tune-ups 2-3 rounds.
+
+## Curate — propose exemplars
+
+- Present candidates from recent transcripts in batches of 5-10.
+- User rates: "yes this is me" / "no" / "me but for a different medium".
+- Tag accepted exemplars with medium, tone, formality, domain.
+- Write to the appropriate exemplar file + index **in the overlay directory**.


### PR DESCRIPTION
Consolidates the two divergent voice-master skill copies into a single canonical skill.

**What changed**
- One source of truth: the full voice-master skill lives in `src/genesis/skills/voice-master/` (SKILL.md + references). The lean SKILL.md (199 lines) routes detail to `references/`; a new `references/overlay-loading.md` holds the full overlay-resolution + calibration procedure.
- `.claude/skills/voice-master/` becomes a thin entry point that redirects to the canonical, so interactive sessions, background sessions, and the skills pipeline all resolve to the same file (eliminates the prior catalog-vs-runtime divergence).
- `references/anti-slop.md` gains a hardened em-dash rule and a few structural tells.

**Privacy**
No user voice data enters the repo. Exemplars and the filled-in voice-dimensions stay in the user overlay (`~/.claude/skills/voice-master/`); the repo keeps only generic machinery + the empty exemplars README + voice-dimensions-TEMPLATE. Verified against the publishable `git archive` tree: the release privacy gate passes (exemplars README-only, no voice-dimensions.md) and no PII is present.

**Verification**
- Skill validator passes (199 lines, under the 300-line cap).
- Skill catalog resolves to a single voice-master entry.
- Downstream deps intact (linkedin-* `../voice-master/references/anti-slop.md` + the `## User Calibration Overlay` header; direct_session profiles).
- E2E behavior confirmed: voice generation, the code-activation boundary (declines code), and Quick Mode all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)