### PR TITLE
feat(voice): make S2S conversational voice a configurable add-on option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   now fires at 85% (was 90%) and the vector-search-failure alert at 50%
   failure (was 100% only), so you hear about pressure and degradation
   sooner, on both Telegram and voice.
+- **Voice: the assistant's spoken voice is now a configurable add-on option**
+  — pick the conversational voice in the Genesis Voice Bridge add-on settings
+  (default "ash"); changing it no longer needs a code edit. No change to how
+  you talk to it — only which preset voice answers.
 
 ---
 

--- a/src/genesis/channels/voice/config.py
+++ b/src/genesis/channels/voice/config.py
@@ -25,8 +25,12 @@ def s2s_model() -> str:
 
 
 def s2s_voice() -> str:
-    """Voice name for the S2S model's TTS output."""
-    return os.environ.get("VOICE_S2S_VOICE", "alloy")
+    """Voice name for the S2S model's spoken output (preset).
+
+    Default "ash" matches the s2s_bridge add-on default so both the active
+    (add-on) and fallback (in-server Wyoming) paths use the same voice.
+    """
+    return os.environ.get("VOICE_S2S_VOICE", "ash")
 
 
 def wyoming_stt_port() -> int:

--- a/src/genesis/channels/voice/s2s_bridge/app/main.py
+++ b/src/genesis/channels/voice/s2s_bridge/app/main.py
@@ -59,6 +59,9 @@ class Application:
         # reconnect handshake + context replay. Configurable via env for
         # testing (e.g. SESSION_ROTATION_SECONDS=30).
         self._rotation_interval: float = 55 * 60
+        # OpenAI Realtime voice (preset). Configurable via the VOICE_S2S_VOICE
+        # add-on option; default "ash". Re-read from env in initialize().
+        self.s2s_voice: str = "ash"
 
     async def initialize(self) -> None:
         """Initialize all components."""
@@ -70,6 +73,9 @@ class Application:
         # Semantic VAD eagerness (replaces old threshold-based server_vad)
         # Options: "low" (less interrupts), "medium" (default), "high" (more responsive)
         self.semantic_vad_eagerness = os.environ.get("SEMANTIC_VAD_EAGERNESS", "medium")
+
+        # OpenAI Realtime voice preset (configurable add-on option; default "ash")
+        self.s2s_voice = os.environ.get("VOICE_S2S_VOICE", "ash")
 
         # Session rotation interval (override for testing)
         self._rotation_interval = float(
@@ -236,7 +242,7 @@ class Application:
                         noise_reduction=InputAudioNoiseReduction(type="near_field"),
                         transcription=InputAudioTranscription(),
                     ),
-                    output=AudioOutput(voice="ash")
+                    output=AudioOutput(voice=self.s2s_voice)
                 ),
                 tools=all_tools
             )

--- a/src/genesis/channels/voice/s2s_bridge/config.yaml
+++ b/src/genesis/channels/voice/s2s_bridge/config.yaml
@@ -1,5 +1,5 @@
 name: Genesis Voice Bridge
-version: "0.3.0"
+version: "0.3.1"
 slug: genesis_voice_bridge
 description: Bidirectional voice bridge using OpenAI Realtime API — connects Voice PE to Genesis via WebSocket
 url: https://github.com/WingedGuardian/GENesis-AGI
@@ -17,6 +17,8 @@ options:
   genesis_token: ""
   # Semantic VAD eagerness: low (fewer interrupts), medium (default), high (more responsive)
   semantic_vad_eagerness: "medium"
+  # OpenAI Realtime spoken voice (preset). Default "ash".
+  voice: "ash"
   # Session management
   session_reuse_timeout_seconds: 300
   # Audio recording (optional, for debugging)
@@ -27,5 +29,6 @@ schema:
   genesis_url: str
   genesis_token: password  # pragma: allowlist secret
   semantic_vad_eagerness: "list(low|medium|high)"
+  voice: "list(alloy|ash|ballad|coral|echo|sage|shimmer|verse|cedar|marin)"
   session_reuse_timeout_seconds: int(0,3600)
   enable_recording: bool

--- a/src/genesis/channels/voice/s2s_bridge/repository.json
+++ b/src/genesis/channels/voice/s2s_bridge/repository.json
@@ -6,7 +6,7 @@
     {
       "slug": "genesis_voice_bridge",
       "name": "Genesis Voice Bridge",
-      "version": "0.2.0"
+      "version": "0.3.1"
     }
   ]
 }

--- a/src/genesis/channels/voice/s2s_bridge/root/run.sh
+++ b/src/genesis/channels/voice/s2s_bridge/root/run.sh
@@ -10,6 +10,9 @@ GENESIS_TOKEN=$(bashio::config 'genesis_token')
 # Turn detection settings (semantic VAD — replaces old threshold-based server_vad)
 SEMANTIC_VAD_EAGERNESS=$(bashio::config 'semantic_vad_eagerness')
 
+# OpenAI Realtime spoken voice preset
+VOICE_S2S_VOICE=$(bashio::config 'voice')
+
 # Session management
 SESSION_REUSE_TIMEOUT_SECONDS=$(bashio::config 'session_reuse_timeout_seconds')
 
@@ -29,6 +32,7 @@ export GENESIS_URL
 export GENESIS_TOKEN
 
 export SEMANTIC_VAD_EAGERNESS
+export VOICE_S2S_VOICE
 
 export SESSION_REUSE_TIMEOUT_SECONDS
 export ENABLE_RECORDING

--- a/src/genesis/channels/voice/s2s_session.py
+++ b/src/genesis/channels/voice/s2s_session.py
@@ -145,13 +145,15 @@ class S2SSessionManager:
         session.connection = conn
         session._conn_mgr = conn_mgr
 
-        # Minimal config — defaults give us audio output (alloy voice),
-        # server VAD, 24kHz PCM. We use conversation.item.create for audio
-        # input so VAD doesn't interfere with bulk utterances from Wyoming.
+        # Minimal config — server VAD, 24kHz PCM. We use
+        # conversation.item.create for audio input so VAD doesn't interfere
+        # with bulk utterances from Wyoming. Voice preset is configurable via
+        # VOICE_S2S_VOICE (default "ash") so this fallback matches the add-on.
         system_prompt = self._bridge.get_system_prompt()
         await conn.session.update(session={
             "type": "realtime",
             "instructions": system_prompt,
+            "voice": voice_config.s2s_voice(),
             "tools": TOOL_DECLARATIONS,
         })
 

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -29,7 +29,7 @@ class TestVoiceConfig:
         with patch.dict("os.environ", {}, clear=True):
             assert s2s_provider() == "openai"
             assert s2s_model() == "gpt-realtime-1.5"
-            assert s2s_voice() == "alloy"
+            assert s2s_voice() == "ash"
             assert wyoming_stt_port() == 10300
             assert wyoming_tts_port() == 10301
 
@@ -41,6 +41,10 @@ class TestVoiceConfig:
     def test_custom_model(self):
         with patch.dict("os.environ", {"VOICE_S2S_MODEL": "gpt-realtime-2"}):
             assert s2s_model() == "gpt-realtime-2"
+
+    def test_custom_voice(self):
+        with patch.dict("os.environ", {"VOICE_S2S_VOICE": "cedar"}):
+            assert s2s_voice() == "cedar"
 
     def test_s2s_enabled_openai(self):
         with patch.dict("os.environ", {"OPENAI_API_KEY": "test"}):
@@ -56,6 +60,60 @@ class TestVoiceConfig:
             "GOOGLE_API_KEY": "test",
         }):
             assert s2s_enabled()
+
+
+class TestS2SSessionVoiceConfig:
+    """The in-server fallback (Wyoming) S2S path must send the configured
+    voice preset in session.update — wiring the previously-unused s2s_voice()
+    knob. (The device's active path is the s2s_bridge add-on, configured
+    separately via the VOICE_S2S_VOICE add-on option.)"""
+
+    async def test_connect_sends_configured_voice(self):
+        from types import SimpleNamespace
+
+        from genesis.channels.voice.s2s_session import (
+            S2SSession,
+            S2SSessionManager,
+        )
+
+        class _FakeConn:
+            def __init__(self):
+                self.session = MagicMock()
+                self.session.update = AsyncMock()
+                self._events = [SimpleNamespace(type="session.updated")]
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self._events:
+                    return self._events.pop(0)
+                raise StopAsyncIteration
+
+        class _FakeConnMgr:
+            def __init__(self, conn):
+                self._conn = conn
+
+            async def __aenter__(self):
+                return self._conn
+
+            async def __aexit__(self, *exc):
+                return False
+
+        conn = _FakeConn()
+        bridge = MagicMock()
+        bridge.get_system_prompt.return_value = "system prompt"
+        mgr = S2SSessionManager(bridge=bridge)
+        mgr._client = MagicMock()
+        mgr._client.realtime.connect = MagicMock(return_value=_FakeConnMgr(conn))
+
+        session = S2SSession(session_id="s", satellite_id="sat")
+        with patch.dict("os.environ", {"VOICE_S2S_VOICE": "verse"}):
+            await mgr.connect(session)
+
+        conn.session.update.assert_awaited_once()
+        sent = conn.session.update.await_args.kwargs["session"]
+        assert sent["voice"] == "verse"
 
 
 # ─── GenesisBridge tests ─────────────────────────────────────────────────


### PR DESCRIPTION
## What

Un-hardcodes the OpenAI Realtime conversational voice (previously fixed to `ash`) into a `VOICE_S2S_VOICE` knob, so the spoken voice can be changed without a code edit.

## Why

The bridge voice was hardcoded in `s2s_bridge/app/main.py`. Making it a config option is the groundwork for future voice swaps (and an eventual custom voice) without touching code. **Default stays `ash` — no audible change.**

## Changes

**Active path — the `s2s_bridge` HA add-on:**
- `app/main.py`: `Application.s2s_voice` (init default `ash`, re-read from `VOICE_S2S_VOICE` in `initialize()`); `AudioOutput(voice=...)` now uses it.
- `config.yaml`: new `voice` add-on option + `list(...)` schema; bumped `0.3.0` → `0.3.1`.
- `repository.json`: bumped `0.2.0` → `0.3.1`, reconciling a pre-existing version drift vs `config.yaml`.
- `root/run.sh`: reads the `voice` add-on option via bashio and exports `VOICE_S2S_VOICE`.

**Fallback path — in-server Wyoming (`s2s_session.py`):**
- Wires the previously-dead `config.s2s_voice()` into the session config and aligns its default `alloy` → `ash` so both paths agree on one knob.

**Tests + docs:**
- `test_voice_s2s.py`: env-override test + a `connect()` wiring test asserting the configured voice preset is sent.
- CHANGELOG entry (user-facing).

## Testing
- `ruff check` clean; `pytest tests/test_channels/test_voice_s2s.py` → 56 passed.
- Validated: `config.yaml`/`repository.json`/`run.sh` parse, versions match, `main.py` compiles.

## Deploy note
The active-path option only takes effect after an **HA-side add-on update** (Supervisor pull + restart) — not a genesis-server restart. Default `ash` means no audible change; the update just surfaces the new option.

## Note (not addressed here)
`s2s_session.py`'s `session.update` carries a pre-existing `"type": "realtime"` field that isn't a documented Realtime session field (API ignores unknowns). Pre-existing, in the unused Wyoming path — left as-is to keep this change scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)