### PR TITLE
fix(routing): fail fast on provider timeouts + fallback chains for dream cycle & reflections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   failure (was 100% only), so you hear about pressure and degradation
   sooner, on both Telegram and voice.
 
+### Fixed
+
+- **Provider hangs no longer stall reflections and the dream cycle** — when a
+  model provider hangs (accepts the connection but never responds), Genesis
+  now fails over to the next provider within its timeout instead of blocking
+  for minutes. Reflections and the nightly dream cycle stop piling up
+  dead-lettered work during provider outages, and adversarial review and
+  reflections keep running when free-tier providers are down (extra free
+  fallbacks added, plus a paid last-resort for the dream-cycle challenge).
+
 ---
 
 ## [v3.0b15] - 2026-06-12

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -241,6 +241,14 @@ call_sites:
     - mistral-large-free
     - groq-free
     - gemini-free
+    # Additional free providers so an essential reflection (3_micro_reflection
+    # is in degradation._L3_KEEP) survives a broad free-tier outage without
+    # paid fallback. Healthy OpenRouter-free models first; NIM last (shared
+    # 40 RPM pool, currently flaky).
+    - openrouter-gemma4
+    - openrouter-trinity-free
+    - nvidia-nim-kimi
+    - nvidia-nim-deepseek
     retry_profile: background
   4_light_reflection:
     chain:
@@ -371,6 +379,10 @@ call_sites:
     chain:
     - nvidia-nim-kimi
     - groq-free
+    # Paid Kimi via OpenRouter as last-resort fallback — same model family as
+    # the free NIM primary, so the Kimi-challenges-DeepSeek independence holds
+    # even when both free tiers are down. Only billed during a free-tier outage.
+    - kimi-k2.5
     retry_profile: background
   dream_cycle_entity_check:
     chain:
@@ -378,6 +390,12 @@ call_sites:
     - groq-free
     - mistral-small-free
     - openrouter-free
+    # More free, NON-DeepSeek providers so the entity check stays independent
+    # from the DeepSeek entity_challenge while surviving a free-tier outage.
+    - gemini-free
+    - mistral-large-free
+    - openrouter-gemma4
+    - openrouter-trinity-free
     retry_profile: background
   # Adversarial challenge of entity "duplicate" verdicts. Flipped pairing:
   # DeepSeek challenges Kimi's entity judgments.

--- a/docs/architecture/genesis-v3-model-routing-registry.md
+++ b/docs/architecture/genesis-v3-model-routing-registry.md
@@ -277,8 +277,14 @@ Estimated ~2-4 API fallback calls/month, adding ~$0.50-1.00.
 All background LLM calls are **idempotent** — they analyze input and produce
 output with no stateful transactions.
 
-- **Timeout per call:** 60s for micro reflection, 120s for heavier work
-- **On timeout:** Retry once on the next fallback in the chain
+- **Timeout per call:** hard 120s wall-clock cap (`_DEFAULT_TIMEOUT_S`),
+  enforced via `asyncio.wait_for` with `num_retries=0` so litellm's internal
+  retries cannot stack past it (they previously did — ~361s on a 120s
+  timeout). Callers may override per call.
+- **On timeout:** classified `TIMEOUT` and failed fast to the next provider in
+  the chain — a hung provider is NOT retried in place (retrying a hung
+  provider only multiplies the wall-clock). The circuit breaker still records
+  the failure, so a repeatedly-hanging provider trips OPEN and is skipped.
 - **Awareness Loop 5-min tick:** Pings GPU health endpoint
 - **On failure:** Mark GPU as "potentially down." Stop sending tasks until
   the next health check passes

--- a/docs/architecture/genesis-v3-resilience-patterns.md
+++ b/docs/architecture/genesis-v3-resilience-patterns.md
@@ -34,10 +34,11 @@ but operates at the infrastructure level:
 
 | Error Type | Examples | Action |
 |-----------|---------|--------|
-| **Transient** | HTTP 429, 503, connection timeout, socket reset | Retry with backoff |
+| **Transient** | HTTP 429, 503, connection error, socket reset | Retry with backoff |
+| **Timeout** | HTTP 408, `litellm.Timeout`, "timed out" | Do NOT retry the same provider — fail fast to the next provider in the chain (a hung provider won't un-hang on retry). Circuit breaker still records the failure. |
 | **Degraded** | Partial response, malformed JSON, truncated output | Retry once; if repeated, route to fallback provider |
 | **Permanent** | HTTP 401 (auth), 404, invalid model name, quota exhausted | Do NOT retry. Log error, route to fallback provider or surface to user |
-| **Provider down** | Consecutive transient failures from same provider | Open circuit breaker, route all traffic to fallback |
+| **Provider down** | Consecutive failures (including timeouts) from same provider | Open circuit breaker, route all traffic to fallback |
 
 **Why this matters:** Retrying a permanent error wastes budget and delays fallback.
 Not retrying a transient error causes unnecessary failures. The classification

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -141,7 +141,7 @@ The daily drivers for professional productivity and general intelligence.
 - **Intelligence Tier:** A/S (Thoughtful reasoning)
 - **SWE-Bench:** ~62%
 - **Cost:** $1.00/$4.00 per MTok (input/output)
-- **Free Tier:** Available on Nvidia NIM (5,000 credits, 40 RPM); also free on OpenRouter (`:free` suffix, 262k context)
+- **Free Tier:** Available on Nvidia NIM (5,000 credits, 40 RPM); OpenRouter `:free` variant (`moonshotai/kimi-k2.6:free`) removed June 2026
 
 **Best At:**
 1. Needle in a Haystack: Specialized architecture for searching its own memory — king of long-context retrieval.
@@ -460,11 +460,12 @@ Loose guidance — not prescriptive. Use your judgment based on the task require
 - Best for burst scenarios or when Mistral's 2 RPM limit is too slow
 
 ### OpenRouter Free Tier
-- ~27 models available as free variants (`:free` suffix) on OpenRouter
+- ~26 models available as free variants (`:free` suffix) on OpenRouter
 - **Base rate limits:** 20 RPM, 200 RPD (shared across all free models)
 - **With $10 balance:** 1,000 RPD (5x increase, balance is not consumed by free models)
-- Includes Llama 4 Scout, DeepSeek-R1, Gemma 4 31B, Qwen3-Coder 480B, Nemotron 3 Ultra 550B, Kimi K2.6, various community models
-- Note: DeepSeek V4 Flash free variant removed as of June 2026
+- Includes Llama 4 Scout, DeepSeek-R1, Gemma 4 31B, Qwen3-Coder 480B, Nemotron 3 Ultra 550B, various community models
+- Note: DeepSeek V4 Flash free variant removed as of June 2026; Kimi K2.6 and
+  GLM-4.5-Air free variants removed June 2026
 - Use as overflow when other free sources are exhausted, or as primary diversity source
 - Free models use `pricing.prompt == "0"` in API — detectable programmatically
 
@@ -652,7 +653,13 @@ High for adversarial review (#20) — without changing application code.
 ---
 
 ## Last Reviewed
-**2026-06-07** — Updated Kimi 2.6 free tier (added OpenRouter `:free` variant,
+**2026-06-14** — OpenRouter free model count 27→26 (automated inventory:
+26 free, +1 new, −2 removed); removed Kimi K2.6 (`moonshotai/kimi-k2.6:free`)
+and GLM-4.5-Air (`z-ai/glm-4.5-air:free`) free variants (delisted June 2026);
+updated Kimi 2.6 entry to drop the now-removed OpenRouter `:free` variant (NIM
+still available); detected new free model Nex-N2-Pro (`nex-agi/nex-n2-pro:free`,
+262k context) — not promoted (unknown provider, no roster gap, no benchmarks).
+2026-06-07 — Updated Kimi 2.6 free tier (added OpenRouter `:free` variant,
 262k context); updated OpenRouter free model count (~27, was ~29); noted
 DeepSeek V4 Flash free variant removal; added Nemotron 3 Ultra 550B to
 Pending Evaluation (1M context, largest free model on OpenRouter).

--- a/src/genesis/routing/litellm_delegate.py
+++ b/src/genesis/routing/litellm_delegate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import time
@@ -148,6 +149,11 @@ class LiteLLMDelegate:
         call_kwargs = {**kwargs}
         if "timeout" not in call_kwargs:
             call_kwargs["timeout"] = _DEFAULT_TIMEOUT_S
+        # Genesis's router owns retry + provider fallback. litellm must make
+        # exactly ONE attempt — its internal retries stack on top of the
+        # per-attempt timeout (observed: 3 retries × 120s ≈ 361s on a 120s
+        # timeout, PR #582). Caller can still override.
+        call_kwargs.setdefault("num_retries", 0)
         if api_key:
             call_kwargs["api_key"] = api_key
         if cfg.base_url:
@@ -155,12 +161,20 @@ class LiteLLMDelegate:
         if cfg.keep_alive is not None and cfg.provider_type == "ollama":
             call_kwargs["keep_alive"] = cfg.keep_alive
 
+        # Hard wall-clock ceiling around the whole call. litellm's own
+        # ``timeout`` param has been observed not to fire (PR #582); this
+        # asyncio.wait_for cap guarantees the call is cancelled even if
+        # litellm/httpx ignore it. Belt-and-suspenders with num_retries=0.
+        hard_timeout = call_kwargs["timeout"]
         try:
-            response = await litellm.acompletion(
-                model=model_string,
-                messages=messages,
-                drop_params=True,
-                **call_kwargs,
+            response = await asyncio.wait_for(
+                litellm.acompletion(
+                    model=model_string,
+                    messages=messages,
+                    drop_params=True,
+                    **call_kwargs,
+                ),
+                timeout=hard_timeout,
             )
             content = response.choices[0].message.content
             usage = getattr(response, "usage", None)
@@ -195,6 +209,20 @@ class LiteLLMDelegate:
                 cache_read_tokens=cache_read,
                 cost_usd=cost,
                 cost_known=cost_known,
+            )
+        except TimeoutError:
+            # Hard wall-clock cap fired — the provider hung past hard_timeout.
+            # Returned as 408 so the router classifies it TIMEOUT and fails
+            # fast to the next provider (no same-provider retry).
+            if _should_log_failure(provider):
+                logger.warning(
+                    "Provider %s hard-timed out after %ss (asyncio.wait_for cap)",
+                    provider, hard_timeout,
+                )
+            return CallResult(
+                success=False,
+                error=f"litellm call exceeded hard timeout of {hard_timeout}s",
+                status_code=408,
             )
         except litellm.RateLimitError as e:
             if _should_log_failure(provider):

--- a/src/genesis/routing/retry.py
+++ b/src/genesis/routing/retry.py
@@ -6,7 +6,8 @@ import random
 
 from genesis.routing.types import ErrorCategory, RetryPolicy
 
-_TRANSIENT_CODES = {408, 429, 500, 502, 503, 504}
+_TRANSIENT_CODES = {429, 500, 502, 503, 504}
+_TIMEOUT_CODES = {408}  # 408 Request Timeout — litellm.Timeout maps here
 _PERMANENT_CODES = {401, 404}
 _QUOTA_CODES = {402}  # 402 Payment Required is always quota
 _MAYBE_QUOTA_CODES = {403}  # 403 is quota only if message contains keywords
@@ -27,11 +28,15 @@ def classify_error(status_code: int | None, error_msg: str) -> ErrorCategory:
             return ErrorCategory.PERMANENT
         if status_code in _PERMANENT_CODES:
             return ErrorCategory.PERMANENT
+        if status_code in _TIMEOUT_CODES:
+            return ErrorCategory.TIMEOUT
         if status_code in _TRANSIENT_CODES:
             return ErrorCategory.TRANSIENT
 
     msg = error_msg.lower()
-    if "timeout" in msg or "connection" in msg:
+    if "timeout" in msg:
+        return ErrorCategory.TIMEOUT
+    if "connection" in msg:
         return ErrorCategory.TRANSIENT
     if "malformed" in msg or "partial" in msg or "truncated" in msg:
         return ErrorCategory.DEGRADED

--- a/src/genesis/routing/router.py
+++ b/src/genesis/routing/router.py
@@ -390,8 +390,14 @@ class Router:
             last_result = result
             category = classify_error(result.status_code, result.error or "")
 
-            # Permanent errors: stop retrying
-            if category == ErrorCategory.PERMANENT:
+            # Stop retrying THIS provider for:
+            #  - PERMANENT: the error won't change on retry.
+            #  - TIMEOUT: the provider hung past its timeout and won't un-hang
+            #    on an immediate retry. Retrying just multiplies the timeout
+            #    wall-clock (this is what produced the ~30-min dream-cycle
+            #    hangs). Fail fast — route_call advances to the next provider,
+            #    and the circuit breaker still records this failure.
+            if category in (ErrorCategory.PERMANENT, ErrorCategory.TIMEOUT):
                 return result
 
             # Transient/degraded: retry with delay (skip delay on last attempt)

--- a/src/genesis/routing/types.py
+++ b/src/genesis/routing/types.py
@@ -18,6 +18,11 @@ class ErrorCategory(StrEnum):
     DEGRADED = "degraded"
     PERMANENT = "permanent"
     QUOTA_EXHAUSTED = "quota_exhausted"
+    # A provider that hung past its timeout. NOT retried against the same
+    # provider (a hung provider won't un-hang on immediate retry) — the router
+    # fails fast to the next provider in the chain, but the circuit breaker
+    # still records the failure so a repeatedly-hanging provider trips OPEN.
+    TIMEOUT = "timeout"
 
 
 class DegradationLevel(StrEnum):

--- a/tests/test_routing/test_litellm_delegate.py
+++ b/tests/test_routing/test_litellm_delegate.py
@@ -248,6 +248,46 @@ async def test_call_allows_timeout_override():
         assert call_kwargs["timeout"] == 300
 
 
+async def test_call_hard_timeout_cancels_hung_provider():
+    """A provider that hangs past the timeout must be hard-cancelled and
+    returned as a 408 — not allowed to run unbounded.
+
+    litellm's own ``timeout`` param has been observed NOT to fire (PR #582;
+    production hangs of ~361s on a 120s timeout because litellm retries
+    internally). A hard ``asyncio.wait_for`` cap guarantees the ceiling.
+    """
+    import asyncio
+    import time as _t
+
+    config = _config()
+    delegate = LiteLLMDelegate(config)
+
+    async def _hang(*args, **kwargs):
+        await asyncio.sleep(2.0)  # longer than the 0.2s cap below
+        return _mock_response()
+
+    with patch("genesis.routing.litellm_delegate.litellm") as mock_litellm:
+        mock_litellm.RateLimitError = type("RateLimitError", (Exception,), {})
+        mock_litellm.AuthenticationError = type("AuthenticationError", (Exception,), {})
+        mock_litellm.NotFoundError = type("NotFoundError", (Exception,), {})
+        mock_litellm.Timeout = type("Timeout", (Exception,), {})
+        mock_litellm.ServiceUnavailableError = type("ServiceUnavailableError", (Exception,), {})
+        mock_litellm.acompletion = _hang
+
+        start = _t.monotonic()
+        result = await delegate.call(
+            "test-provider", "llama-3.3-70b-versatile",
+            [{"role": "user", "content": "Hi"}],
+            timeout=0.2,
+        )
+        elapsed = _t.monotonic() - start
+
+    assert result.success is False
+    assert result.status_code == 408
+    # Cancelled promptly at the cap — did not wait the full 2s hang
+    assert elapsed < 1.5
+
+
 # ── Error classification ───────────────────────────────────────────────────
 
 

--- a/tests/test_routing/test_retry.py
+++ b/tests/test_routing/test_retry.py
@@ -27,11 +27,20 @@ def test_transient_codes():
         assert classify_error(code, "") == ErrorCategory.TRANSIENT
 
 
+def test_timeout_code():
+    # 408 Request Timeout means the provider hung (litellm.Timeout maps to 408
+    # in litellm_delegate). Retrying the same hung provider is futile — classify
+    # as TIMEOUT so the router fails fast to the next provider in the chain.
+    assert classify_error(408, "") == ErrorCategory.TIMEOUT
+
+
 def test_timeout_message():
-    assert classify_error(None, "request timeout") == ErrorCategory.TRANSIENT
+    assert classify_error(None, "request timeout") == ErrorCategory.TIMEOUT
 
 
 def test_connection_message():
+    # Connection errors are fast (not a hang) and may be a transient blip —
+    # keep them retryable.
     assert classify_error(None, "Connection refused") == ErrorCategory.TRANSIENT
 
 

--- a/tests/test_routing/test_router.py
+++ b/tests/test_routing/test_router.py
@@ -73,6 +73,41 @@ async def test_fallback_on_failure(sample_config, breakers, cost_tracker, degrad
 
 
 @pytest.mark.asyncio
+async def test_timeout_fails_fast_no_same_provider_retry(
+    sample_config, breakers, cost_tracker, degradation,
+):
+    """A timeout (408) must NOT be retried against the same provider.
+
+    A hung provider won't un-hang on an immediate retry — retrying just
+    multiplies the timeout wall-clock (the 30-min dream-cycle hangs). The
+    router fails fast to the next provider, but the circuit breaker still
+    records the failure so a repeatedly-hanging provider trips OPEN.
+    """
+    delegate = MockDelegate(responses={
+        "free-1": CallResult(
+            success=False,
+            error="litellm.Timeout: request timed out",
+            status_code=408,
+        ),
+    })
+    router = Router(
+        config=sample_config, breakers=breakers, cost_tracker=cost_tracker,
+        degradation=degradation, delegate=delegate,
+    )
+    result = await router.route_call("test_mixed", [{"role": "user", "content": "hi"}])
+
+    # Failed fast to the next provider
+    assert result.success is True
+    assert result.provider_used == "free-2"
+    assert "free-1" in result.failed_providers
+    # free-1 called exactly ONCE — not retried despite default max_retries=1
+    free1_calls = [c for c in delegate.calls if c["provider"] == "free-1"]
+    assert len(free1_calls) == 1
+    # The timeout is still recorded against free-1's circuit breaker
+    assert breakers.get("free-1").consecutive_failures == 1
+
+
+@pytest.mark.asyncio
 async def test_never_pays_skips_paid(sample_config, breakers, cost_tracker, degradation):
     delegate = MockDelegate(responses={
         "free-1": CallResult(success=False, error="down", status_code=503),

--- a/tests/test_routing/test_router.py
+++ b/tests/test_routing/test_router.py
@@ -108,6 +108,53 @@ async def test_timeout_fails_fast_no_same_provider_retry(
 
 
 @pytest.mark.asyncio
+async def test_timeout_failover_end_to_end(sample_config, breakers, cost_tracker, degradation):
+    """E2E: a hung provider routed through the REAL LiteLLMDelegate is
+    hard-capped by asyncio.wait_for and the router fails fast to the next
+    provider — proving the delegate cap (Change 2) and the router fail-fast
+    (Change 1) compose correctly, within the timeout wall-clock (not 5x it).
+    """
+    import asyncio
+    import time
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    import genesis.routing.litellm_delegate as ld
+    from genesis.routing.litellm_delegate import LiteLLMDelegate
+
+    async def _branching(*args, **kwargs):
+        # free-1 is a mistral provider — make it hang past the timeout.
+        if "mistral" in kwargs.get("model", ""):
+            await asyncio.sleep(2.0)
+        # free-2 (groq) responds normally.
+        usage = SimpleNamespace(prompt_tokens=5, completion_tokens=3)
+        message = SimpleNamespace(content="ok")
+        return SimpleNamespace(choices=[SimpleNamespace(message=message)], usage=usage)
+
+    delegate = LiteLLMDelegate(sample_config)
+    router = Router(
+        config=sample_config, breakers=breakers, cost_tracker=cost_tracker,
+        degradation=degradation, delegate=delegate,
+    )
+
+    with (
+        patch.object(ld, "_DEFAULT_TIMEOUT_S", 0.3),
+        patch("genesis.routing.litellm_delegate.litellm") as mock_litellm,
+    ):
+        mock_litellm.acompletion = _branching
+        start = time.monotonic()
+        result = await router.route_call("test_mixed", [{"role": "user", "content": "hi"}])
+        elapsed = time.monotonic() - start
+
+    # Failed over from the hung free-1 to free-2
+    assert result.success is True
+    assert result.provider_used == "free-2"
+    assert "free-1" in result.failed_providers
+    # Capped near the 0.3s timeout, NOT the 2s hang (and not retried 5x)
+    assert elapsed < 1.5
+
+
+@pytest.mark.asyncio
 async def test_never_pays_skips_paid(sample_config, breakers, cost_tracker, degradation):
     delegate = MockDelegate(responses={
         "free-1": CallResult(success=False, error="down", status_code=503),


### PR DESCRIPTION
## Problem

LLM operations were dead-lettering with "All providers exhausted" and the dream
cycle / reflections were stalling. Root cause is a **two-layer retry stack on a
hung provider**:

1. A provider that hangs (accepts the connection but never responds) returns a
   timeout that `classify_error` treated as `TRANSIENT`.
2. `Router._try_with_retry` retried that **same hung provider** up to
   `max_retries + 1` times — `5` for the `background` profile.
3. litellm's own internal retries stacked on top of the per-attempt timeout
   (the 120s default added in #582 was not being honored — ~361s observed on a
   120s timeout).

Net: up to ~30 minutes burned on one hung provider before the router even
reached the next provider in the chain. Several chains had no working fallback
left, so they exhausted and dead-lettered.

## Fix

**Fail fast on timeouts (keystone):**
- New `ErrorCategory.TIMEOUT`. `classify_error` maps HTTP 408 and "timeout"
  messages to it (`connection` errors stay `TRANSIENT`).
- `Router._try_with_retry` returns immediately on `TIMEOUT` — no same-provider
  retry. `route_call` advances to the next provider and the **circuit breaker
  still records the failure**, so a repeatedly-hanging provider trips OPEN.
- `litellm_delegate`: wrap `acompletion` in a hard `asyncio.wait_for` cap and
  set `num_retries=0`, so a single attempt cannot exceed the timeout. Completes
  the 120s ceiling from #582.

**Fallback chains (`config/model_routing.yaml`):**
- `dream_cycle_synthesis_challenge`: paid Kimi via OpenRouter (`kimi-k2.5`) as a
  last resort — same model family as the free NIM primary, preserving the
  Kimi-vs-DeepSeek independence. Billed only during a free-tier outage.
- `3_micro_reflection` and `dream_cycle_entity_check`: more free providers
  (non-DeepSeek for entity_check to preserve independence from the entity
  challenge). No paid creep.
- `4_light_reflection` intentionally unchanged (routes via the Claude Code
  background process; keeps `never_pays`).

## Testing

- New unit tests: TIMEOUT classification (408 + message), fail-fast no
  same-provider retry, hard-timeout cancellation of a hung call.
- New **end-to-end integration test**: real `LiteLLMDelegate` + `Router` with a
  hung provider — verifies the call is capped at the timeout and the router
  fails over to the next provider (not the full hang, not 5x).
- Full routing suite (250 tests) green; config loads via the real loader with
  all appended providers resolving and keyed.

## Notes

- Cost impact is bounded: only `dream_cycle_synthesis_challenge` adds a paid
  provider, and only when both free tiers are down.
- Follow-ups (non-blocking): suppress cosmetic dead letters logged on the
  CC-backstopped API attempt in dual dispatch; watch for idle-connection
  accumulation on providers that hang frequently (cancellation cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
