### PR TITLE
fix(routing): suppress cosmetic dead letters + add run-now trigger for system jobs

### DIFF
--- a/src/genesis/autonomy/dispatch_router.py
+++ b/src/genesis/autonomy/dispatch_router.py
@@ -118,8 +118,15 @@ class AutonomousDispatchRouter:
             )
 
         if request.api_call_site_id:
+            # Suppress the chain_exhausted dead letter on the API attempt when a
+            # CLI (Claude Code) fallback will run — the CC background session
+            # backstops the work, so a dead letter here would be a cosmetic
+            # false positive. In dispatch=api mode no fallback runs, so a real
+            # exhaustion must still be recorded.
+            suppress_dl = request.cli_fallback_allowed and dispatch_mode != "api"
             result = await self._router.route_call(
                 request.api_call_site_id, request.messages,
+                suppress_dead_letter=suppress_dl,
             )
             # Success is only a real success if the provider actually
             # produced content.  Free-tier providers (notably gemini-free)

--- a/src/genesis/autonomy/dispatch_router.py
+++ b/src/genesis/autonomy/dispatch_router.py
@@ -118,12 +118,17 @@ class AutonomousDispatchRouter:
             )
 
         if request.api_call_site_id:
-            # Suppress the chain_exhausted dead letter on the API attempt when a
-            # CLI (Claude Code) fallback will run — the CC background session
-            # backstops the work, so a dead letter here would be a cosmetic
-            # false positive. In dispatch=api mode no fallback runs, so a real
-            # exhaustion must still be recorded.
-            suppress_dl = request.cli_fallback_allowed and dispatch_mode != "api"
+            # Suppress the chain_exhausted dead letter on the API attempt ONLY
+            # when a Claude Code fallback will actually run, so the dead letter
+            # isn't a cosmetic false positive for CC-backstopped work. That
+            # requires: not api-only mode, the caller allows CLI fallback, AND
+            # the system policy has CLI fallback enabled — if the policy
+            # disables it, no fallback runs and a real exhaustion must still be
+            # recorded. Policy is loaded only on this candidate path (not on
+            # every dispatch) to keep the success path free of the YAML read.
+            suppress_dl = False
+            if dispatch_mode != "api" and request.cli_fallback_allowed:
+                suppress_dl = self._policy_loader().autonomous_cli_fallback_enabled
             result = await self._router.route_call(
                 request.api_call_site_id, request.messages,
                 suppress_dead_letter=suppress_dl,

--- a/src/genesis/dashboard/routes/scheduler.py
+++ b/src/genesis/dashboard/routes/scheduler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 
 from flask import jsonify, request
 
@@ -62,6 +63,48 @@ def _extract_apscheduler_jobs(component, subsystem: str) -> list[dict]:
         logger.debug("Failed to extract jobs from %s", subsystem, exc_info=True)
 
     return jobs
+
+
+def _trigger_system_job(rt, job_id: str) -> bool:
+    """Reschedule a system APScheduler job to run immediately.
+
+    Walks the system scheduler components (surplus/learning/outreach/reflection),
+    finds the one owning ``job_id``, and sets its next_run_time to now. Returns
+    True if the job was found and triggered. APScheduler's per-job max_instances
+    guards against double-running a job that's already in progress.
+    """
+    for attr_name in _SCHEDULER_SUBSYSTEMS:
+        component = getattr(rt, attr_name, None)
+        if component is None:
+            continue
+        scheduler = getattr(component, "_scheduler", None)
+        if scheduler is None and hasattr(component, "get_jobs"):
+            scheduler = component
+        if scheduler is None or not getattr(scheduler, "running", False):
+            continue
+        try:
+            if scheduler.get_job(job_id) is not None:
+                scheduler.modify_job(job_id, next_run_time=datetime.now(UTC))
+                return True
+        except Exception:
+            logger.debug("Failed to trigger job %s on %s", job_id, attr_name, exc_info=True)
+    return False
+
+
+@blueprint.route("/api/genesis/scheduler/system/<job_id>/run", methods=["POST"])
+@_async_route
+async def system_job_run_endpoint(job_id: str):
+    """Trigger a system job (e.g. dream_cycle) to run immediately."""
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped:
+        return jsonify({"error": "Runtime not bootstrapped"}), 503
+
+    if _trigger_system_job(rt, job_id):
+        logger.info("System job '%s' triggered via run-now endpoint", job_id)
+        return jsonify({"success": True, "job_id": job_id, "action": "run_now"})
+    return jsonify({"success": False, "error": f"System job '{job_id}' not found"}), 404
 
 
 @blueprint.route("/api/genesis/scheduler/system")

--- a/tests/test_autonomy/test_autonomous_dispatch.py
+++ b/tests/test_autonomy/test_autonomous_dispatch.py
@@ -286,6 +286,54 @@ async def test_dispatch_router_blocks_pending_cli_fallback(approval_gate):
     assert "approval" in decision.reason
 
 
+@pytest.mark.asyncio
+async def test_dispatch_router_suppresses_dead_letter_with_cli_fallback(approval_gate):
+    """Dual dispatch WITH a CLI fallback: the API attempt must pass
+    suppress_dead_letter=True. The Claude Code background session backstops the
+    work, so a chain_exhausted dead letter for the failed API attempt is a
+    cosmetic false positive (the reflection still completes via CC)."""
+    router = AsyncMock()
+    router.route_call = AsyncMock(return_value=SimpleNamespace(success=False, error="exhausted"))
+    dispatch = AutonomousDispatchRouter(router=router, approval_gate=approval_gate)
+
+    await dispatch.route(AutonomousDispatchRequest(
+        subsystem="reflection",
+        policy_id="reflection_light",
+        action_label="light reflection",
+        messages=[{"role": "user", "content": "x"}],
+        cli_invocation=_invocation(),
+        api_call_site_id="4_light_reflection",
+        dispatch_mode="dual",
+        cli_fallback_allowed=True,
+    ))
+
+    _, kwargs = router.route_call.call_args
+    assert kwargs.get("suppress_dead_letter") is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_router_records_dead_letter_when_api_only(approval_gate):
+    """dispatch=api has NO CLI fallback, so the API attempt must NOT suppress
+    the dead letter — exhaustion is a real failure that must be recorded (not
+    silently dropped)."""
+    router = AsyncMock()
+    router.route_call = AsyncMock(return_value=SimpleNamespace(success=False, error="exhausted"))
+    dispatch = AutonomousDispatchRouter(router=router, approval_gate=approval_gate)
+
+    await dispatch.route(AutonomousDispatchRequest(
+        subsystem="ego",
+        policy_id="ego_cycle",
+        action_label="ego cycle",
+        messages=[{"role": "user", "content": "x"}],
+        cli_invocation=_invocation(),
+        api_call_site_id="7_ego_cycle",
+        dispatch_mode="api",
+    ))
+
+    _, kwargs = router.route_call.call_args
+    assert kwargs.get("suppress_dead_letter") is False
+
+
 def test_load_autonomous_cli_policy_from_yaml(tmp_path: Path):
     path = tmp_path / "autonomous_cli_policy.yaml"
     path.write_text(

--- a/tests/test_autonomy/test_autonomous_dispatch.py
+++ b/tests/test_autonomy/test_autonomous_dispatch.py
@@ -294,7 +294,10 @@ async def test_dispatch_router_suppresses_dead_letter_with_cli_fallback(approval
     cosmetic false positive (the reflection still completes via CC)."""
     router = AsyncMock()
     router.route_call = AsyncMock(return_value=SimpleNamespace(success=False, error="exhausted"))
-    dispatch = AutonomousDispatchRouter(router=router, approval_gate=approval_gate)
+    policy = SimpleNamespace(autonomous_cli_fallback_enabled=True, manual_approval_required=False)
+    dispatch = AutonomousDispatchRouter(
+        router=router, approval_gate=approval_gate, policy_loader=lambda: policy,
+    )
 
     await dispatch.route(AutonomousDispatchRequest(
         subsystem="reflection",
@@ -309,6 +312,33 @@ async def test_dispatch_router_suppresses_dead_letter_with_cli_fallback(approval
 
     _, kwargs = router.route_call.call_args
     assert kwargs.get("suppress_dead_letter") is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_router_records_dead_letter_when_policy_disables_cli(approval_gate):
+    """Dual dispatch + cli_fallback_allowed, but the SYSTEM POLICY disables CLI
+    fallback → no CC fallback runs, so the dead letter must NOT be suppressed.
+    Suppressing here would silently drop a real, unhandled exhaustion."""
+    router = AsyncMock()
+    router.route_call = AsyncMock(return_value=SimpleNamespace(success=False, error="exhausted"))
+    policy = SimpleNamespace(autonomous_cli_fallback_enabled=False, manual_approval_required=False)
+    dispatch = AutonomousDispatchRouter(
+        router=router, approval_gate=approval_gate, policy_loader=lambda: policy,
+    )
+
+    await dispatch.route(AutonomousDispatchRequest(
+        subsystem="reflection",
+        policy_id="reflection_light",
+        action_label="light reflection",
+        messages=[{"role": "user", "content": "x"}],
+        cli_invocation=_invocation(),
+        api_call_site_id="4_light_reflection",
+        dispatch_mode="dual",
+        cli_fallback_allowed=True,
+    ))
+
+    _, kwargs = router.route_call.call_args
+    assert kwargs.get("suppress_dead_letter") is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_dashboard/test_scheduler_routes.py
+++ b/tests/test_dashboard/test_scheduler_routes.py
@@ -1,0 +1,52 @@
+"""Tests for system-job scheduler control helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from genesis.dashboard.routes.scheduler import _trigger_system_job
+
+
+def _rt_with(scheduler):
+    """A fake runtime exposing one system scheduler component."""
+    return SimpleNamespace(
+        _surplus_scheduler=SimpleNamespace(_scheduler=scheduler),
+        _learning_scheduler=None,
+        _outreach_scheduler=None,
+        _reflection_scheduler=None,
+    )
+
+
+def test_trigger_system_job_found_runs_now():
+    """A known system job (e.g. dream_cycle) is rescheduled to run immediately."""
+    sched = MagicMock()
+    sched.running = True
+    sched.get_job.return_value = object()  # job exists in this scheduler
+
+    rt = _rt_with(sched)
+    assert _trigger_system_job(rt, "dream_cycle") is True
+    sched.modify_job.assert_called_once()
+    # Triggered by setting next_run_time to "now"
+    assert "next_run_time" in sched.modify_job.call_args.kwargs
+
+
+def test_trigger_system_job_not_found():
+    """An unknown job triggers nothing and reports not-found."""
+    sched = MagicMock()
+    sched.running = True
+    sched.get_job.return_value = None  # job not present
+
+    rt = _rt_with(sched)
+    assert _trigger_system_job(rt, "no_such_job") is False
+    sched.modify_job.assert_not_called()
+
+
+def test_trigger_system_job_skips_stopped_scheduler():
+    """A not-running scheduler is skipped without error."""
+    sched = MagicMock()
+    sched.running = False
+
+    rt = _rt_with(sched)
+    assert _trigger_system_job(rt, "dream_cycle") is False
+    sched.get_job.assert_not_called()


### PR DESCRIPTION
Follow-ups from PR #627 (routing timeout fix).

## 1. Suppress cosmetic dead letters on CC-backstopped API attempts

In dual-dispatch reflections, the API `route_call` ran without
`suppress_dead_letter`, so a free-chain exhaustion logged a
`chain_exhausted` dead letter even though the Claude Code background
session then completed the work — the ~627 cosmetic
`chain_exhausted:4_light_reflection` rows.

Now the API attempt suppresses the dead letter **only when a CC fallback
will actually run**: `dispatch_mode != "api"` AND `cli_fallback_allowed`
AND `policy.autonomous_cli_fallback_enabled`. In `dispatch=api` mode, or
when the system policy disables CLI fallback, the exhaustion is a real
failure and is still recorded (no silent drops). Policy is loaded only on
this candidate path, so the success path stays free of the YAML read.

## 2. Run-now trigger for system jobs

System jobs (e.g. the weekly `dream_cycle`) could only run on their cron
schedule — `run_now` existed only for *user* jobs. Adds
`_trigger_system_job` + `POST /api/genesis/scheduler/system/<job_id>/run`,
which sets the job's `next_run_time` to now across the system schedulers,
preserving the underlying cron schedule. APScheduler `max_instances`
guards against double-running an in-progress job. Consistent with the
existing user-job control endpoint.

## Testing

- New tests: dead-letter suppression with CC fallback, NOT suppressed in
  api-only mode, NOT suppressed when policy disables CLI; system-job
  trigger found / not-found / stopped-scheduler.
- Full dispatch suite (30) + dashboard suite (114) green.
- Note: the system-job trigger's real `modify_job` firing is exercised
  manually post-deploy (unit tests use a mock scheduler).

## Review

Local adversarial review (Claude reviewer; Codex/OpenCode unavailable)
found one P1 — suppression ignored the CLI policy flag — now fixed and
covered by a test. Remaining advisories are non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
