### PR TITLE
feat(cc): interactive consoles use auto permission mode, not bypass (WS-20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   module adapter now shell-quotes the model, effort, and path values it sends
   to a remote host, so a crafted value can no longer run arbitrary commands
   there. Normal dispatch is unchanged.
+- **Interactive Claude Code consoles no longer skip all permission checks.**
+  The dashboard web terminal and the SSH dev-console slot now launch Claude
+  Code in auto-permission mode instead of `--dangerously-skip-permissions`:
+  common operations still run without prompting, but risky ones ask for your
+  approval right there in the session (you're present to answer). Headless,
+  autonomous sessions are unchanged — they have no one to answer a prompt.
 
 ---
 

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -84,8 +84,12 @@ chmod 700 "$TMPDIR"
 export CLAUDE_CODE_TMPDIR="$HOME/.genesis/cc-tmp"
 
 # -u: force UTF-8 output even if a future client's locale detection fails
+# Interactive dev console (a human attaches over SSH), so use auto mode: it
+# auto-approves common ops but still prompts on deny/ask rules, which the
+# operator can answer in the tmux session. Headless/autonomous CC sessions
+# keep --dangerously-skip-permissions (no human present to answer a prompt).
 exec tmux -u new-session -A -s "$SESSION_NAME" \
     -e "GENESIS_SLOT=${SLOT}" \
     -e "CLAUDE_CODE_TMPDIR=$CLAUDE_CODE_TMPDIR" \
     -e "LANG=$LANG" \
-    "cd ${GENESIS_ROOT} && exec claude --dangerously-skip-permissions"
+    "cd ${GENESIS_ROOT} && exec claude --permission-mode auto"

--- a/src/genesis/dashboard/routes/terminal.py
+++ b/src/genesis/dashboard/routes/terminal.py
@@ -211,7 +211,11 @@ _TERMINAL_PAGE_HTML = """\
       const dims = fit.proposeDimensions();
       if (dims) ws.send(JSON.stringify({ resize: { rows: dims.rows, cols: dims.cols } }));
       // Prefill Claude Code launch command; user chooses when to execute.
-      setTimeout(() => ws.send("claude --dangerously-skip-permissions"), 500);
+      // Interactive terminal (a human drives it), so use auto mode: it
+      // auto-approves common ops but still prompts on deny/ask rules, which
+      // the operator can answer here. Headless/autonomous sessions keep
+      // --dangerously-skip-permissions (no human to answer a prompt).
+      setTimeout(() => ws.send("claude --permission-mode auto"), 500);
     };
 
     ws.onmessage = (evt) => {

--- a/tests/test_dashboard/test_terminal_permission_mode.py
+++ b/tests/test_dashboard/test_terminal_permission_mode.py
@@ -1,0 +1,32 @@
+"""WS-20: interactive CC sessions launch in auto permission mode, not bypass.
+
+The dashboard web terminal prefill and the SSH/tmux dev-console slot each spawn
+an INTERACTIVE Claude Code session that a human drives, so they use
+``--permission-mode auto`` (auto-approve common ops, prompt the human on gated
+ones, keep deny-rule safety) instead of ``--dangerously-skip-permissions``.
+
+Headless/autonomous sessions (every path through ``CCInvoker``, which hardcodes
+``-p``) intentionally KEEP bypass — there is no human to answer a prompt — and
+are deliberately out of scope for this test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from genesis.dashboard.routes.terminal import _TERMINAL_PAGE_HTML
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_dashboard_terminal_prefill_uses_auto_mode():
+    # Assert the *launched command* (not comment text) prefills auto mode.
+    assert 'ws.send("claude --permission-mode auto")' in _TERMINAL_PAGE_HTML
+    assert 'ws.send("claude --dangerously-skip-permissions")' not in _TERMINAL_PAGE_HTML
+
+
+def test_cc_slot_launches_auto_mode():
+    # cc-slot.sh launches the interactive tmux dev console a human attaches to.
+    cc_slot = (_REPO_ROOT / "scripts" / "cc-slot.sh").read_text()
+    assert "exec claude --permission-mode auto" in cc_slot
+    assert "exec claude --dangerously-skip-permissions" not in cc_slot


### PR DESCRIPTION
## What & why

Interactive Claude Code consoles — the dashboard **web terminal** and the **SSH/tmux dev-console slot** — are driven by a human, so they now launch `claude --permission-mode auto` instead of `--dangerously-skip-permissions`. Auto mode auto-approves common operations (Bash allowlist, edits, sandbox) but still prompts on `deny`/`ask` rules and forced safety checks — which the operator is right there to answer — and keeps deny-rule safety.

**Headless/autonomous sessions are unchanged.** Every path through `CCInvoker` hardcodes `-p` (no TTY to answer a prompt), so they intentionally keep `--dangerously-skip-permissions` (with the existing `disallowed_tools` blacklists + PreToolUse hooks as guardrails). Only the two genuinely interactive entry points change. No `acceptEdits` (it still prompts on edits-vs-bash unevenly and is the wrong tradeoff here).

WS-20 — security-on-merit, emergent from the 2026-06-13 audit's D1 discussion.

## Changes
- `src/genesis/dashboard/routes/terminal.py` — prefill `--permission-mode auto`
- `scripts/cc-slot.sh` — `exec claude --permission-mode auto`
- `tests/test_dashboard/test_terminal_permission_mode.py` — regression guard (asserts the launched command, not comment text)

## Tests
`tests/test_dashboard/` — 116 passed (incl. 2 new). `bash -n scripts/cc-slot.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)