### PR TITLE
fix(observability): make dropped events visible + durable (WS-17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   casing mismatch), so a failing provider got retried immediately instead of
   serving out its backoff. Breaker state is now also written atomically, and
   MCP helper processes no longer overwrite the shared state file.
+- **The error log no longer silently under-counts during incident storms.**
+  When the event-persistence queue filled up, events were dropped without a
+  trace — so the dashboard and health views under-reported errors exactly when
+  things were worst. Dropped events are now counted and made visible (an
+  "event queue overflow" warning in the same error views, plus a live counter
+  on the health snapshot), the buffer is 10× larger (500 → 5000) to absorb
+  bursts, and a single un-serializable event can no longer drop a whole batch.
 
 ### Security
 

--- a/src/genesis/db/crud/events.py
+++ b/src/genesis/db/crud/events.py
@@ -10,6 +10,26 @@ from datetime import UTC, datetime
 import aiosqlite
 
 
+def _safe_details_json(details: dict | None) -> str | None:
+    """Serialize event details to JSON, degrading gracefully (OBS-002).
+
+    ``default=str`` lets common non-JSON values (datetimes, Paths, enums)
+    serialize as strings instead of raising; a last-resort marker guarantees a
+    single un-serializable event can never abort a whole ``insert_batch``.
+    """
+    if not details:
+        return None
+    try:
+        return json.dumps(details, default=str)
+    except (TypeError, ValueError):
+        try:
+            return json.dumps(
+                {"_unserializable": True, "keys": sorted(str(k) for k in details)}
+            )
+        except Exception:
+            return json.dumps({"_unserializable": True})
+
+
 async def insert(
     db: aiosqlite.Connection,
     *,
@@ -36,7 +56,7 @@ async def insert(
             severity,
             event_type,
             message,
-            json.dumps(details) if details else None,
+            _safe_details_json(details),
             session_id,
             ts,
         ),
@@ -59,7 +79,7 @@ async def insert_batch(
             e["severity"],
             e["event_type"],
             e["message"],
-            json.dumps(e["details"]) if e.get("details") else None,
+            _safe_details_json(e.get("details")),
             e.get("session_id"),
             e.get("timestamp") or datetime.now(UTC).isoformat(),
         ))

--- a/src/genesis/observability/events.py
+++ b/src/genesis/observability/events.py
@@ -18,6 +18,10 @@ logger = logging.getLogger(__name__)
 # Listener signature: async (event) -> None
 Listener = Callable[[GenesisEvent], Awaitable[None]]
 
+# WS-17: minimum spacing between persisted "events dropped" overflow notices,
+# so an incident storm produces one visible meta-event rather than thousands.
+_DROP_NOTICE_MIN_INTERVAL_S = 60.0
+
 
 class GenesisEventBus:
     """Lightweight async event bus for Genesis observability.
@@ -34,11 +38,19 @@ class GenesisEventBus:
         self._db = db
         self._write_queue: asyncio.Queue | None = None
         self._writer_task: asyncio.Task | None = None
+        # WS-17: count events dropped when the persistence queue is full so the
+        # silent loss is visible — surfaced on the health snapshot and via a
+        # rate-limited overflow meta-event emitted by the writer task.
+        self._dropped_count = 0
+        self._dropped_reported = 0
+        self._last_drop_notice_at: datetime | None = None
 
     def enable_persistence(self, db) -> None:
         """Enable DB persistence for events.  Safe to call after construction."""
         self._db = db
-        self._write_queue = asyncio.Queue(maxsize=500)
+        # Larger buffer (WS-17): absorbs incident storms before dropping; worst
+        # case ~a few MB. Drops are still counted and surfaced, never silent.
+        self._write_queue = asyncio.Queue(maxsize=5000)
         # Use bare create_task here to avoid circular import with
         # genesis.util.tasks (which imports from this module's types).
         # Error observation via done callback compensates for no tracked_task().
@@ -73,6 +85,8 @@ class GenesisEventBus:
                         break
                     batch.append(next_item)
                 await events_crud.insert_batch(self._db, batch)
+                # WS-17: off the hot path, surface any drops since last notice.
+                await self._flush_dropped_notice()
             except asyncio.CancelledError:
                 break
             except Exception:
@@ -90,6 +104,58 @@ class GenesisEventBus:
                 logger.info("Flushed %d events on shutdown", len(remaining))
             except Exception:
                 logger.error("Failed to flush %d events on shutdown", len(remaining), exc_info=True)
+
+    def dropped_event_count(self) -> int:
+        """Cumulative count of events dropped because the persistence queue was
+        full. Surfaced on the health snapshot as ``queues.events_dropped``."""
+        return self._dropped_count
+
+    async def _flush_dropped_notice(self) -> None:
+        """Persist a single rate-limited overflow meta-event when events have
+        been dropped since the last notice.
+
+        Called from the writer task only — it owns ``self._db`` and runs off the
+        hot ``emit()`` path. Writing to the DB inside ``emit()``'s QueueFull
+        handler would mean a DB write exactly when the DB is most contended.
+        """
+        if self._db is None:
+            return
+        dropped = self._dropped_count
+        if dropped <= self._dropped_reported:
+            return
+        now = self._clock()
+        if (
+            self._last_drop_notice_at is not None
+            and (now - self._last_drop_notice_at).total_seconds()
+            < _DROP_NOTICE_MIN_INTERVAL_S
+        ):
+            return
+        new_drops = dropped - self._dropped_reported
+        maxsize = self._write_queue.maxsize if self._write_queue else None
+        try:
+            from genesis.db.crud import events as events_crud
+
+            await events_crud.insert(
+                self._db,
+                subsystem=Subsystem.OBSERVABILITY.value,
+                severity=Severity.WARNING.value,
+                event_type="event_queue_overflow",
+                message=(
+                    f"Event persistence queue full — dropped {new_drops} "
+                    f"event(s) (total {dropped})"
+                ),
+                details={
+                    "dropped_new": new_drops,
+                    "dropped_total": dropped,
+                    "queue_maxsize": maxsize,
+                },
+                timestamp=now.isoformat(),
+            )
+        except Exception:
+            logger.debug("Failed to persist event-overflow notice", exc_info=True)
+            return
+        self._dropped_reported = dropped
+        self._last_drop_notice_at = now
 
     async def stop(self) -> None:
         """Stop the background writer task, draining queued events first."""
@@ -152,6 +218,9 @@ class GenesisEventBus:
                     ) if details else _get_context_session_id(),
                 })
             except asyncio.QueueFull:
+                # WS-17: count the drop (non-blocking) instead of losing it
+                # silently; the writer task surfaces it as a meta-event.
+                self._dropped_count += 1
                 logger.warning("Event write queue full — dropping event: %s/%s", event_type, message[:80])
 
         # Log via stdlib at the matching level

--- a/src/genesis/observability/health_data.py
+++ b/src/genesis/observability/health_data.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import aiosqlite
 
+    from genesis.observability.events import GenesisEventBus
     from genesis.observability.provider_health import ProviderHealthChecker
     from genesis.resilience.cc_budget import CCBudgetTracker
     from genesis.resilience.deferred_work import DeferredWorkQueue
@@ -54,6 +55,7 @@ class HealthDataService:
         resilience_state_machine: ResilienceStateMachine | None = None,
         activity_tracker: object | None = None,
         provider_health_checker: ProviderHealthChecker | None = None,
+        event_bus: GenesisEventBus | None = None,
     ) -> None:
         self._breakers = circuit_breakers
         self._routing_config = routing_config
@@ -67,6 +69,7 @@ class HealthDataService:
         self._state_machine = resilience_state_machine
         self._activity_tracker = activity_tracker
         self._provider_health = provider_health_checker
+        self._event_bus = event_bus
 
     async def snapshot(self) -> dict:
         """Return full system health state as a dict."""
@@ -113,7 +116,9 @@ class HealthDataService:
             "infrastructure": await infrastructure(
                 self._db, self._routing_config, self._learning_scheduler, self._state_machine
             ),
-            "queues": await queues(self._db, self._deferred_queue, self._dead_letter),
+            "queues": await queues(
+                self._db, self._deferred_queue, self._dead_letter, self._event_bus
+            ),
             "surplus": await surplus_status(self._db, self._surplus),
             "cost": await cost(self._db, self._cost_tracker, self._cc_budget),
             "awareness": await awareness(self._db),

--- a/src/genesis/observability/snapshots/queues.py
+++ b/src/genesis/observability/snapshots/queues.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import aiosqlite
 
+    from genesis.observability.events import GenesisEventBus
     from genesis.resilience.deferred_work import DeferredWorkQueue
     from genesis.routing.dead_letter import DeadLetterQueue
 
@@ -66,6 +67,7 @@ async def queues(
     db: aiosqlite.Connection | None,
     deferred_queue: DeferredWorkQueue | None,
     dead_letter: DeadLetterQueue | None,
+    event_bus: GenesisEventBus | None = None,
 ) -> dict:
     errors: list[str] = []
 
@@ -248,6 +250,13 @@ async def queues(
         "deferred_items": deferred_items,
         "discarded_count": discarded_count,
         "discarded_items": discarded_items,
+        # WS-17: cumulative count of events dropped because the event-bus
+        # persistence queue was full (0 when persistence/bus is unavailable).
+        # NOTE: a cumulative counter, not an instantaneous depth — deliberately
+        # NOT in errors.py:_QUEUE_DEPTH_FIELDS (which alerts on depth > 100).
+        "events_dropped": (
+            event_bus.dropped_event_count() if event_bus is not None else 0
+        ),
     }
     if errors:
         result["errors"] = errors

--- a/src/genesis/runtime/init/health_data.py
+++ b/src/genesis/runtime/init/health_data.py
@@ -43,6 +43,7 @@ def init(rt: GenesisRuntime) -> None:
             resilience_state_machine=rt._resilience_state_machine,
             activity_tracker=rt._activity_tracker,
             provider_health_checker=provider_health_checker,
+            event_bus=rt._event_bus,
         )
 
         from genesis.mcp.health_mcp import init_health_mcp

--- a/tests/test_observability/test_events.py
+++ b/tests/test_observability/test_events.py
@@ -1,5 +1,7 @@
 """Tests for GenesisEventBus."""
 
+import asyncio
+
 import pytest
 
 from genesis.observability.events import GenesisEventBus, _at_or_above
@@ -213,3 +215,104 @@ class TestSeverityOrdering:
         assert _at_or_above(Severity.CRITICAL, Severity.INFO)
         assert not _at_or_above(Severity.INFO, Severity.WARNING)
         assert not _at_or_above(Severity.DEBUG, Severity.INFO)
+
+
+class TestDroppedEventVisibility:
+    """WS-17: dropped events are counted (non-blocking) and surfaced."""
+
+    @pytest.mark.asyncio
+    async def test_emit_increments_dropped_count_when_queue_full(self, bus):
+        # Force a full persistence queue deterministically (no writer draining).
+        bus._write_queue = asyncio.Queue(maxsize=1)
+        bus._write_queue.put_nowait({"filler": True})
+        assert bus.dropped_event_count() == 0
+
+        # emit() must neither block nor raise even though the queue is full.
+        event = await bus.emit(Subsystem.ROUTING, Severity.ERROR, "drop_me", "boom")
+
+        assert isinstance(event, GenesisEvent)  # emit still returns the event
+        assert bus.dropped_event_count() == 1
+        # The in-memory ring still captured it even though the DB queue dropped it.
+        assert any(e.event_type == "drop_me" for e in bus._ring)
+
+    @pytest.mark.asyncio
+    async def test_enable_persistence_uses_large_queue(self):
+        from unittest.mock import AsyncMock
+
+        bus = GenesisEventBus(db=AsyncMock())
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("genesis.db.crud.events.insert_batch", AsyncMock())
+            bus.enable_persistence(AsyncMock())
+            try:
+                assert bus._write_queue.maxsize == 5000
+            finally:
+                await bus.stop()
+
+    @pytest.mark.asyncio
+    async def test_flush_dropped_notice_persists_rate_limited_overflow_event(self, db):
+        from datetime import UTC, datetime
+
+        from genesis.db.crud import events as events_crud
+
+        frozen = datetime(2026, 6, 14, tzinfo=UTC)
+        bus = GenesisEventBus(clock=lambda: frozen, db=db)
+        bus._dropped_count = 7
+
+        await bus._flush_dropped_notice()
+        rows = await events_crud.query(db, event_type="event_queue_overflow")
+        assert len(rows) == 1
+        assert "7" in rows[0]["message"]
+        assert rows[0]["severity"] == "warning"
+
+        # No new drops since the last notice → no second row.
+        await bus._flush_dropped_notice()
+        rows = await events_crud.query(db, event_type="event_queue_overflow")
+        assert len(rows) == 1
+
+        # New drops, but within the rate-limit window (same frozen clock) → suppressed.
+        bus._dropped_count = 12
+        await bus._flush_dropped_notice()
+        rows = await events_crud.query(db, event_type="event_queue_overflow")
+        assert len(rows) == 1
+
+
+class TestQueuesSnapshotEventsDropped:
+    """WS-17: the queues snapshot surfaces the dropped-event counter."""
+
+    @pytest.mark.asyncio
+    async def test_queues_surfaces_dropped_count(self):
+        from genesis.observability.snapshots.queues import queues
+
+        bus = GenesisEventBus()
+        bus._dropped_count = 3
+        result = await queues(None, None, None, event_bus=bus)
+        assert result["events_dropped"] == 3
+
+    @pytest.mark.asyncio
+    async def test_queues_dropped_defaults_zero_without_bus(self):
+        from genesis.observability.snapshots.queues import queues
+
+        result = await queues(None, None, None)
+        assert result["events_dropped"] == 0
+
+
+class TestEventSerialization:
+    """OBS-002: one un-serializable event must not drop the whole batch."""
+
+    @pytest.mark.asyncio
+    async def test_insert_batch_survives_unserializable_detail(self, db):
+        from genesis.db.crud import events as events_crud
+
+        batch = [
+            {"subsystem": "routing", "severity": "info",
+             "event_type": "ok", "message": "fine", "details": {"a": 1}},
+            {"subsystem": "routing", "severity": "error",
+             "event_type": "weird", "message": "bad detail",
+             "details": {"obj": object()}},  # not JSON-serializable
+        ]
+        n = await events_crud.insert_batch(db, batch)
+        assert n == 2
+
+        rows = await events_crud.query(db, limit=10)
+        types = {r["event_type"] for r in rows}
+        assert {"ok", "weird"} <= types  # the un-serializable event survived


### PR DESCRIPTION
## What & why

Event-bus persistence drops were **silent**. When the write queue (`maxsize=500`) filled during an incident storm, events were dropped with only a log line — so the dashboard unified-errors and `health_errors` MCP (which read the `events` table) **under-counted exactly when things were worst** (EH-03). Separately, one un-serializable `details` value aborted a whole batch insert (OBS-002).

## Changes
- **Visible, non-blocking drop counter** — `emit()` increments a cumulative counter on `QueueFull` (never blocks); surfaced on the health snapshot as `queues.events_dropped`.
- **Overflow meta-event** — the background writer task emits a rate-limited (60s) `event_queue_overflow` WARNING row via `events_crud.insert`, so the loss shows up in the same error surfaces that previously hid it. Emitted only from the writer (which owns the DB handle), never from the hot `emit()` path.
- **Bigger buffer** — queue `maxsize 500 → 5000` to absorb bursts before dropping.
- **OBS-002** — `insert`/`insert_batch` serialize via `json.dumps(default=str)` + a marker fallback, so a single un-serializable event degrades gracefully instead of dropping the whole batch.
- Threads the existing `rt._event_bus` into `HealthDataService` → `queues()` (init order verified: observability initializes before health-data).

**No blocking backpressure** (deliberate, per D14 intent + the project's anti-stall philosophy): `emit()` never awaits on a full queue — a slow DB must not stall hot cognitive paths. D14's "make the loss visible" is satisfied by the counter + meta-event.

## Tests
`tests/test_observability/` — 143 passed (incl. new: drop-counter non-blocking, queue maxsize, rate-limited overflow notice via in-memory DB, OBS-002 batch survival, snapshot surfacing). ruff clean. Independent code-reviewer pass: clean.

WS-17 / D14 + OBS-002 from the 2026-06-13 audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)