### PR TITLE
fix(config): read .local.yaml overlays user-dir-first (WS-14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   casing mismatch), so a failing provider got retried immediately instead of
   serving out its backoff. Breaker state is now also written atomically, and
   MCP helper processes no longer overwrite the shared state file.
+- **Dashboard settings changes now actually take effect.** Overrides you saved
+  from the dashboard (or the settings tool) are written to `~/.genesis/config/`,
+  but several subsystems (inbox, surplus, resilience, voice/TTS, perception
+  confidence, and more) still read their `.local.yaml` overlay from the repo's
+  `config/` dir — so your changes were silently ignored, even after a restart.
+  Loaders now read the user-config overlay first (falling back to the repo path
+  for older installs), and the settings tool reports the correct saved path.
 
 ### Security
 

--- a/src/genesis/_config_overlay.py
+++ b/src/genesis/_config_overlay.py
@@ -16,16 +16,42 @@ from pathlib import Path
 import yaml
 
 
+def _user_config_dir() -> Path:
+    """Canonical user config dir (``~/.genesis/config``).
+
+    Defined here rather than imported from ``genesis.env`` so this module stays
+    dependency-free (stdlib + yaml only, no import cycles), and as a function so
+    tests can monkeypatch it.
+    """
+    return Path.home() / ".genesis" / "config"
+
+
+def _resolve_overlay_path(base_path: Path) -> Path:
+    """Resolve the ``.local.yaml`` overlay for *base_path*, preferring the user
+    config dir (``~/.genesis/config/``) where the dashboard/MCP settings writers
+    land, then falling back to the repo-relative sibling for back-compat.
+
+    Mirrors ``settings.py._load_yaml_local`` so loaders and writers agree on the
+    overlay location (cfg-001).
+    """
+    local_name = base_path.with_suffix(".local.yaml").name
+    user_path = _user_config_dir() / local_name
+    if user_path.is_file():
+        return user_path
+    return base_path.with_suffix(".local.yaml")
+
+
 def merge_local_overlay(base: dict, base_path: Path) -> dict:
     """Deep-merge a ``.local.yaml`` overlay into *base* if it exists.
 
     *base_path* is the path to the base YAML file (e.g.
-    ``config/inbox_monitor.yaml``).  The overlay path is derived by
-    inserting ``.local`` before the ``.yaml`` suffix.
+    ``config/inbox_monitor.yaml``).  The overlay is resolved user-dir-first
+    (``~/.genesis/config/{stem}.local.yaml``), falling back to the repo-relative
+    sibling.
 
     Returns *base* unchanged when no overlay file exists.
     """
-    local_path = base_path.with_suffix(".local.yaml")
+    local_path = _resolve_overlay_path(base_path)
     if not local_path.exists():
         return base
     try:
@@ -36,8 +62,8 @@ def merge_local_overlay(base: dict, base_path: Path) -> dict:
 
 
 def local_overlay_mtime(base_path: Path) -> float:
-    """Return the mtime of the ``.local.yaml`` overlay, or ``0.0``."""
-    local_path = base_path.with_suffix(".local.yaml")
+    """Return the mtime of the ``.local.yaml`` overlay (user-dir-first), or ``0.0``."""
+    local_path = _resolve_overlay_path(base_path)
     try:
         return local_path.stat().st_mtime
     except OSError:

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -744,7 +744,7 @@ async def _impl_settings_update(
         "domain": domain,
         "status": "applied",
         "changes_applied": changes,
-        "local_override_file": f"config/{local_file}",
+        "local_override_file": f"~/.genesis/config/{local_file}",
         "needs_restart": entry.needs_restart,
     }
     if entry.needs_restart:

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -1,0 +1,74 @@
+"""WS-14: config overlays resolve user-dir-first (``~/.genesis/config/``).
+
+The dashboard/MCP writers land ``.local.yaml`` overlays in ``~/.genesis/config/``,
+but subsystem loaders historically read them from the repo-relative sibling — so
+dashboard settings changes were silently ignored (cfg-001). ``merge_local_overlay``
+and ``local_overlay_mtime`` now check the user dir first, falling back to the
+repo-relative sibling for back-compat.
+
+Every test monkeypatches ``_user_config_dir`` so it never touches the real
+``~/.genesis/config/`` on the dev machine.
+"""
+
+from __future__ import annotations
+
+from genesis import _config_overlay
+
+
+def test_merge_reads_user_dir_overlay_first(tmp_path, monkeypatch):
+    user_dir = tmp_path / "user_config"
+    user_dir.mkdir()
+    monkeypatch.setattr(_config_overlay, "_user_config_dir", lambda: user_dir)
+
+    # Base file lives in a *different* (repo-like) dir with no sibling overlay.
+    repo_dir = tmp_path / "repo_config"
+    repo_dir.mkdir()
+    base_path = repo_dir / "foo.yaml"
+    base_path.write_text("a: 1\nb: 2\n")
+    (user_dir / "foo.local.yaml").write_text("b: 99\n")
+
+    merged = _config_overlay.merge_local_overlay({"a": 1, "b": 2}, base_path)
+    assert merged == {"a": 1, "b": 99}  # picked up the user-dir overlay
+
+
+def test_merge_falls_back_to_repo_sibling(tmp_path, monkeypatch):
+    user_dir = tmp_path / "user_config"
+    user_dir.mkdir()  # exists, but has no overlay for foo
+    monkeypatch.setattr(_config_overlay, "_user_config_dir", lambda: user_dir)
+
+    repo_dir = tmp_path / "repo_config"
+    repo_dir.mkdir()
+    base_path = repo_dir / "foo.yaml"
+    (repo_dir / "foo.local.yaml").write_text("b: 42\n")
+
+    merged = _config_overlay.merge_local_overlay({"a": 1, "b": 2}, base_path)
+    assert merged == {"a": 1, "b": 42}  # back-compat: repo-relative sibling
+
+
+def test_merge_no_overlay_returns_base(tmp_path, monkeypatch):
+    user_dir = tmp_path / "user_config"
+    user_dir.mkdir()
+    monkeypatch.setattr(_config_overlay, "_user_config_dir", lambda: user_dir)
+    base_path = tmp_path / "foo.yaml"
+    base = {"a": 1}
+    assert _config_overlay.merge_local_overlay(base, base_path) == base
+
+
+def test_local_overlay_mtime_prefers_user_dir(tmp_path, monkeypatch):
+    user_dir = tmp_path / "user_config"
+    user_dir.mkdir()
+    monkeypatch.setattr(_config_overlay, "_user_config_dir", lambda: user_dir)
+    repo_dir = tmp_path / "repo_config"
+    repo_dir.mkdir()
+    base_path = repo_dir / "foo.yaml"
+    overlay = user_dir / "foo.local.yaml"
+    overlay.write_text("b: 1\n")
+    assert _config_overlay.local_overlay_mtime(base_path) == overlay.stat().st_mtime
+
+
+def test_mtime_zero_when_no_overlay(tmp_path, monkeypatch):
+    user_dir = tmp_path / "user_config"
+    user_dir.mkdir()
+    monkeypatch.setattr(_config_overlay, "_user_config_dir", lambda: user_dir)
+    base_path = tmp_path / "foo.yaml"
+    assert _config_overlay.local_overlay_mtime(base_path) == 0.0


### PR DESCRIPTION
## What & why

Dashboard / settings-MCP writers save `.local.yaml` overrides to **`~/.genesis/config/`**, but the shared `merge_local_overlay()` — used by **9 subsystem loaders** (inbox, surplus, resilience, voice/TTS, perception confidence, ego, outreach, cli_policy, genesis-updates) — read the overlay from the **repo-relative sibling**. So dashboard settings changes were **silently ignored at runtime**, even after a restart (cfg-001).

## Changes
- `src/genesis/_config_overlay.py` — `merge_local_overlay()` and `local_overlay_mtime()` now resolve the overlay **user-dir-first** (`~/.genesis/config/{stem}.local.yaml`), falling back to the repo-relative sibling for older installs. Mirrors `settings.py._load_yaml_local`. The module stays dependency-free; `_user_config_dir()` is a small monkeypatchable function (no `genesis.env` import → no cycle, and test-isolatable).
- `src/genesis/mcp/health/settings.py` — `settings_update` now reports the real `~/.genesis/config/{file}` path instead of the wrong `config/{file}` (cfg-003), matching `settings_get`.
- `tests/test_config_overlay.py` — new (user-dir-first, repo fallback, no-overlay, mtime), each monkeypatching `_user_config_dir` so the dev box's real overlays don't leak in.

Backward-compatible: when no user-dir overlay exists, behavior is unchanged. Caller set confirmed via Serena (9 sites, uniform `raw = merge_local_overlay(raw, path)`).

## Tests
- `tests/test_config_overlay.py` + `tests/test_mcp/test_settings.py` — 50 passed; ruff clean; all 9 loader modules import.
- Collateral verified in isolation: `test_learning` 520 passed, `channels/inbox/resilience` (the dirs with real overlays on the dev box) 583 passed. (A 9-dir combined run shows ~43 unrelated failures from a **pre-existing cross-dir test-isolation issue** — reproduces on clean `origin/main` too, not from this change.)

WS-14 / D6 from the 2026-06-13 audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)