### PR TITLE
fix(db): busy-timeout on standalone connections via shared get_raw_db (WS-15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   `config/` dir — so your changes were silently ignored, even after a restart.
   Loaders now read the user-config overlay first (falling back to the repo path
   for older installs), and the settings tool reports the correct saved path.
+- **Fewer "database is locked" errors under heavy concurrent load.** Several
+  standalone database connections (the ego tools, web-agent cost tracking, the
+  contribution gate, and two hooks) opened without a busy-timeout, so a brief
+  write lock made them fail immediately instead of waiting their turn. They now
+  share one connection helper (WAL + a bounded wait), so transient contention
+  is ridden out rather than surfaced as an error.
 
 ### Security
 

--- a/scripts/genesis_session_context.py
+++ b/scripts/genesis_session_context.py
@@ -243,7 +243,7 @@ def main() -> None:
             _db_path_l0 = Path.home() / "genesis" / "data" / "genesis.db"
             if _db_path_l0.exists():
                 async def _load_l0():
-                    async with aiosqlite.connect(str(_db_path_l0)) as db:
+                    async with aiosqlite.connect(str(_db_path_l0), timeout=2) as db:
                         db.row_factory = aiosqlite.Row
                         cursor = await db.execute(
                             "SELECT package, COUNT(*) as modules, SUM(loc) as loc "

--- a/scripts/hooks/audit_feedback_coverage.py
+++ b/scripts/hooks/audit_feedback_coverage.py
@@ -63,7 +63,7 @@ def _load_db_rules() -> list[dict]:
     if not _GENESIS_DB.exists():
         return []
     try:
-        with sqlite3.connect(str(_GENESIS_DB)) as db:
+        with sqlite3.connect(str(_GENESIS_DB), timeout=2) as db:
             db.row_factory = sqlite3.Row
             rows = db.execute(
                 """
@@ -94,7 +94,7 @@ def _load_procedures() -> list[dict]:
     if not _GENESIS_DB.exists():
         return []
     try:
-        with sqlite3.connect(str(_GENESIS_DB)) as db:
+        with sqlite3.connect(str(_GENESIS_DB), timeout=2) as db:
             db.row_factory = sqlite3.Row
             rows = db.execute(
                 """

--- a/src/genesis/contribution/version_gate.py
+++ b/src/genesis/contribution/version_gate.py
@@ -350,8 +350,7 @@ async def _call_llm(prompt: str, model: str) -> str:
 async def _record_to_monitor(model: str, response_text: str | None, *, success: bool) -> None:
     """Best-effort recording to neural monitor. Never raises."""
     try:
-        import aiosqlite
-
+        from genesis.db.connection import get_raw_db
         from genesis.env import genesis_db_path
         from genesis.observability.call_site_recorder import record_last_run
 
@@ -359,7 +358,7 @@ async def _record_to_monitor(model: str, response_text: str | None, *, success: 
         provider = model.split("/", 1)[0] if "/" in model else model
         model_id = model.split("/", 1)[1] if "/" in model else model
 
-        async with aiosqlite.connect(str(genesis_db_path())) as db:
+        async with get_raw_db(str(genesis_db_path())) as db:
             await record_last_run(
                 db, _CALL_SITE_ID,
                 provider=provider, model_id=model_id,

--- a/src/genesis/db/connection.py
+++ b/src/genesis/db/connection.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
-from collections.abc import Awaitable, Callable, Iterable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
@@ -251,7 +251,9 @@ async def get_db(path: str | Path = DEFAULT_DB_PATH) -> SerializedConnection:
 
 
 @asynccontextmanager
-async def get_raw_db(path: str | Path = DEFAULT_DB_PATH):
+async def get_raw_db(
+    path: str | Path = DEFAULT_DB_PATH,
+) -> AsyncIterator[aiosqlite.Connection]:
     """Open a plain aiosqlite connection with Genesis's standard pragmas.
 
     For short-lived, **standalone** opens — MCP fallback paths and one-shot

--- a/src/genesis/db/connection.py
+++ b/src/genesis/db/connection.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 import sqlite3
 from collections.abc import Awaitable, Callable, Iterable
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
@@ -247,6 +248,38 @@ async def get_db(path: str | Path = DEFAULT_DB_PATH) -> SerializedConnection:
         return conn
 
     return SerializedConnection(db, reconnect_fn=_reconnect)
+
+
+@asynccontextmanager
+async def get_raw_db(path: str | Path = DEFAULT_DB_PATH):
+    """Open a plain aiosqlite connection with Genesis's standard pragmas.
+
+    For short-lived, **standalone** opens — MCP fallback paths and one-shot
+    reads/writes that own their own connection lifetime. Applies the same
+    contention-safe pragmas every connection should have: WAL, ``synchronous=
+    NORMAL`` (safe + standard with WAL), ``busy_timeout`` (so a concurrent write
+    lock waits instead of failing immediately with "database is locked"), and a
+    ``Row`` factory.
+
+    Unlike :func:`get_db` this is **not** a :class:`SerializedConnection` — it
+    has no cross-coroutine lock, so use it only for connections that are not
+    shared across coroutines. Yields the connection and closes it on exit.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    db = await aiosqlite.connect(str(path))
+    try:
+        db.row_factory = aiosqlite.Row
+        await db.execute("PRAGMA journal_mode=WAL")
+        await db.execute("PRAGMA synchronous=NORMAL")
+        await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+        # NOTE: intentionally NOT setting `foreign_keys=ON` here (get_db does).
+        # These standalone sites never enforced FKs before, and none touch
+        # FK-cascading tables. If a future caller needs cascade deletes, enable
+        # it explicitly rather than relying on this helper.
+        yield db
+    finally:
+        await db.close()
 
 
 async def init_db(path: str | Path = DEFAULT_DB_PATH) -> SerializedConnection:

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -38,8 +38,7 @@ async def _impl_ego_focus_reset(
     If new_focus is provided, sets it as the new focus.
     Otherwise clears to a neutral default.
     """
-    import aiosqlite
-
+    from genesis.db.connection import get_raw_db
     from genesis.db.crud import ego as ego_crud
 
     default_focus = "general system awareness"
@@ -52,7 +51,7 @@ async def _impl_ego_focus_reset(
     results = {}
     db_path = _get_db_path()
 
-    async with aiosqlite.connect(str(db_path)) as db:
+    async with get_raw_db(db_path) as db:
         for key in ("ego_focus_summary", "genesis_ego_focus_summary"):
             old_val = await ego_crud.get_state(db, key)
             if old_val is not None:
@@ -121,13 +120,11 @@ async def ego_directive(
     if ego_target not in _VALID_EGO_TARGETS:
         return {"status": "error", "reason": f"Invalid ego_target: {ego_target!r}. Must be one of: {sorted(_VALID_EGO_TARGETS)}"}
 
-    import aiosqlite
-
+    from genesis.db.connection import get_raw_db
     from genesis.db.crud import ego as ego_crud
 
     db_path = _get_db_path()
-    async with aiosqlite.connect(str(db_path)) as db:
-        db.row_factory = aiosqlite.Row
+    async with get_raw_db(db_path) as db:
         directive_id = await ego_crud.create_directive(
             db,
             content=content,
@@ -181,13 +178,11 @@ async def ego_goal_create(
     if goal_type not in _VALID_GOAL_TYPES:
         return {"status": "error", "reason": f"Invalid goal_type: {goal_type!r}. Must be 'milestone' or 'continuous'"}
 
-    import aiosqlite
-
+    from genesis.db.connection import get_raw_db
     from genesis.db.crud import user_goals
 
     db_path = _get_db_path()
-    async with aiosqlite.connect(str(db_path)) as db:
-        db.row_factory = aiosqlite.Row
+    async with get_raw_db(db_path) as db:
 
         # Validate parent exists if specified
         if parent_goal_id:
@@ -222,13 +217,11 @@ async def ego_goal_create(
 @mcp.tool()
 async def ego_goal_list() -> dict:
     """List all active user goals in the ego system."""
-    import aiosqlite
-
+    from genesis.db.connection import get_raw_db
     from genesis.db.crud import user_goals
 
     db_path = _get_db_path()
-    async with aiosqlite.connect(str(db_path)) as db:
-        db.row_factory = aiosqlite.Row
+    async with get_raw_db(db_path) as db:
         goals = await user_goals.list_active(db, limit=20)
 
     return {
@@ -283,13 +276,11 @@ async def ego_goal_update(
     if goal_type and goal_type not in _VALID_GOAL_TYPES:
         return {"status": "error", "reason": f"Invalid goal_type: {goal_type!r}. Must be 'milestone' or 'continuous'"}
 
-    import aiosqlite
-
+    from genesis.db.connection import get_raw_db
     from genesis.db.crud import user_goals
 
     db_path = _get_db_path()
-    async with aiosqlite.connect(str(db_path)) as db:
-        db.row_factory = aiosqlite.Row
+    async with get_raw_db(db_path) as db:
 
         if status == "achieved":
             await user_goals.mark_achieved(db, goal_id)
@@ -387,13 +378,11 @@ async def ego_goal_progress(
     if not note.strip():
         return {"status": "error", "reason": "Note cannot be empty"}
 
-    import aiosqlite
-
+    from genesis.db.connection import get_raw_db
     from genesis.db.crud import user_goals
 
     db_path = _get_db_path()
-    async with aiosqlite.connect(str(db_path)) as db:
-        db.row_factory = aiosqlite.Row
+    async with get_raw_db(db_path) as db:
         goal = await user_goals.get_by_id(db, goal_id)
         if not goal:
             return {"status": "error", "reason": f"Goal {goal_id} not found"}
@@ -433,8 +422,7 @@ async def ego_proposal_resolve(
             "reason": f"action must be 'approve' or 'reject', got {action!r}",
         }
 
-    import aiosqlite
-
+    from genesis.db.connection import get_raw_db
     from genesis.db.crud import ego as ego_crud
 
     status = "approved" if action == "approve" else "rejected"
@@ -442,8 +430,7 @@ async def ego_proposal_resolve(
     results: dict[str, str] = {}
     batch_id = None
 
-    async with aiosqlite.connect(str(db_path)) as db:
-        db.row_factory = aiosqlite.Row
+    async with get_raw_db(db_path) as db:
 
         # Find most recent pending batch (prefer user_ego_cycle)
         pending = await ego_crud.list_pending_proposals(

--- a/src/genesis/mcp/health/task_tools.py
+++ b/src/genesis/mcp/health/task_tools.py
@@ -71,6 +71,7 @@ async def _get_db() -> aiosqlite.Connection:
     """Open a direct DB connection for MCP fallback reads/writes."""
     db = await aiosqlite.connect(str(_DB_PATH))
     db.row_factory = aiosqlite.Row
+    await db.execute("PRAGMA journal_mode=WAL")
     await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
     return db
 

--- a/src/genesis/mcp/health/task_tools.py
+++ b/src/genesis/mcp/health/task_tools.py
@@ -69,9 +69,13 @@ def init_task_tools(dispatcher, executor, *, db=None) -> None:
 
 async def _get_db() -> aiosqlite.Connection:
     """Open a direct DB connection for MCP fallback reads/writes."""
+    # Standalone fallback connection. Not routed through get_raw_db() because
+    # callers hold this connection across awaits (it's returned, not scoped to
+    # a context manager); it sets the same pragmas get_raw_db() applies.
     db = await aiosqlite.connect(str(_DB_PATH))
     db.row_factory = aiosqlite.Row
     await db.execute("PRAGMA journal_mode=WAL")
+    await db.execute("PRAGMA synchronous=NORMAL")
     await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
     return db
 

--- a/src/genesis/mcp/health/web_tools.py
+++ b/src/genesis/mcp/health/web_tools.py
@@ -581,12 +581,11 @@ async def web_agent(
 
     # Budget check before execution — agent calls cost $0.015/step
     try:
-        import aiosqlite
-
+        from genesis.db.connection import get_raw_db
         from genesis.env import genesis_db_path
         from genesis.routing.cost_tracker import CostTracker
 
-        async with aiosqlite.connect(genesis_db_path()) as db:
+        async with get_raw_db(genesis_db_path()) as db:
             tracker = CostTracker(db)
             status = await tracker.check_budget()
             if hasattr(status, "value"):
@@ -617,14 +616,13 @@ async def web_agent(
                 import uuid
                 from datetime import datetime
 
-                import aiosqlite
-
+                from genesis.db.connection import get_raw_db
                 from genesis.db.crud import cost_events
                 from genesis.env import genesis_db_path
 
                 num_steps = data.get("num_of_steps", 0)
                 cost_usd = round(num_steps * COST_PER_STEP_USD, 4)
-                async with aiosqlite.connect(genesis_db_path()) as db:
+                async with get_raw_db(genesis_db_path()) as db:
                     await cost_events.create(
                         db,
                         id=str(uuid.uuid4()),

--- a/tests/test_db/test_connection.py
+++ b/tests/test_db/test_connection.py
@@ -161,3 +161,43 @@ async def test_error_does_not_corrupt_connection(sconn):
     cur = await sconn.execute("SELECT count(*) as cnt FROM t")
     row = await cur.fetchone()
     assert row["cnt"] == 2  # seed + good_writer
+
+
+# ── WS-15: shared raw-connection helper for ad-hoc / standalone opens ──
+
+async def test_get_raw_db_sets_standard_pragmas(tmp_path):
+    """get_raw_db must apply WAL + NORMAL sync + busy_timeout + Row factory so
+    ad-hoc/subprocess opens can't fail immediately on a concurrent write lock."""
+    from genesis.db.connection import BUSY_TIMEOUT_MS, get_raw_db
+
+    db_path = tmp_path / "raw.db"
+    async with get_raw_db(db_path) as db:
+        assert db.row_factory is aiosqlite.Row
+
+        cur = await db.execute("PRAGMA busy_timeout")
+        assert (await cur.fetchone())[0] == BUSY_TIMEOUT_MS
+
+        cur = await db.execute("PRAGMA journal_mode")
+        assert (await cur.fetchone())[0].lower() == "wal"
+
+        cur = await db.execute("PRAGMA synchronous")
+        assert (await cur.fetchone())[0] == 1  # 1 == NORMAL
+
+        # usable for a real round-trip
+        await db.execute("CREATE TABLE x (id INTEGER PRIMARY KEY, v TEXT)")
+        await db.execute("INSERT INTO x VALUES (1, 'ok')")
+        await db.commit()
+        cur = await db.execute("SELECT v FROM x WHERE id = 1")
+        assert (await cur.fetchone())["v"] == "ok"
+
+
+async def test_get_raw_db_closes_on_exit(tmp_path):
+    """The connection is closed when the context manager exits."""
+    from genesis.db.connection import get_raw_db
+
+    db_path = tmp_path / "raw2.db"
+    async with get_raw_db(db_path) as db:
+        captured = db
+        assert captured._running is True  # alive inside the context
+    # After exit the background thread is stopped — connection is closed.
+    assert captured._running is False

--- a/tests/test_db/test_connection.py
+++ b/tests/test_db/test_connection.py
@@ -198,6 +198,8 @@ async def test_get_raw_db_closes_on_exit(tmp_path):
     db_path = tmp_path / "raw2.db"
     async with get_raw_db(db_path) as db:
         captured = db
-        assert captured._running is True  # alive inside the context
-    # After exit the background thread is stopped — connection is closed.
-    assert captured._running is False
+        await captured.execute("SELECT 1")  # usable inside the context
+    # After exit the connection is closed — reusing it raises (behavior, not
+    # a private attribute).
+    with pytest.raises(ValueError):
+        await captured.execute("SELECT 1")


### PR DESCRIPTION
## What & why

Several **standalone** SQLite opens lacked `PRAGMA busy_timeout`, so under a concurrent write lock they failed *immediately* with `database is locked` instead of waiting their turn (CONC-05 / decision D9). This routes them through one shared helper that always applies the contention-safe pragmas.

## Changes
- **`db/connection.py`** — new `get_raw_db()` (`@asynccontextmanager`): a plain aiosqlite connection (NOT a `SerializedConnection`) with WAL + `synchronous=NORMAL` + `busy_timeout` + Row factory, closed on exit. The canonical `get_db()` is left **unchanged** (main-connection durability untouched — conservative).
- **Migrated 10 ad-hoc sites** to `get_raw_db`: `mcp/health/ego_tools.py` (7; redundant `row_factory` lines removed), `mcp/health/web_tools.py` (2), `contribution/version_gate.py` (1).
- **`mcp/health/task_tools.py`** — added the missing `journal_mode=WAL` to its `_get_db()`.
- **Hooks** — the 3 sqlite opens with *no* timeout (`audit_feedback_coverage.py` ×2, `genesis_session_context.py`) now pass `timeout=2`, **lowering** worst-case blocking from sqlite3's 5s default to 2s. The other hooks already have explicit fail-fast timeouts; WAL is a database-level property (already set), so no per-connection WAL churn was needed.

**GAPS-FILL ONLY (no retry wrapper), per D9:** `busy_timeout` already provides the bounded wait, and an app-level retry inside the process-wide `SerializedConnection` lock would stall every coroutine during backoff. D9's "bounded retry" is satisfied by `busy_timeout`.

## Tests
- `tests/test_db/test_connection.py` — new `get_raw_db` tests (pragmas, close-on-exit). 13 passed.
- Broad isolation run `tests/test_mcp tests/test_db tests/test_contribution` — **1060 passed**. ruff clean. Independent code-reviewer pass: clean (verified Row-factory safety at every migrated site, helper equivalence, hook timeout lowering).

WS-15 / D9 from the 2026-06-13 audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)