### PR TITLE
fix(skills): record resolved skills in session metadata + precise effectiveness matching

### DIFF
--- a/scripts/contribution_offer_hook.py
+++ b/scripts/contribution_offer_hook.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Phase 6 — UserPromptSubmit hook that surfaces pending contribution offers.
+"""UserPromptSubmit hook that surfaces pending contribution offers.
 
 Runs on every user prompt via .claude/settings.json. Hot path:
 
@@ -60,7 +60,7 @@ def _format_reminder(marker_data: dict) -> str:
     subject = str(marker_data.get("subject", "<unknown subject>"))
     return (
         f"[Contribution] A 'fix:' commit just landed ({sha} \"{subject}\"). "
-        f"Per the Phase 6 contribution pipeline, proactively offer the user "
+        f"Per the contribution pipeline, proactively offer the user "
         f"the option to contribute this fix upstream to the public Genesis "
         f"repo. Ask conversationally; do not run the pipeline without explicit "
         f"user approval. If the user declines or ignores, do nothing."

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -456,6 +456,10 @@ class DirectSessionRunner:
             source_tag=request.source_tag,
             dispatch_mode="direct",
             profile=request.profile,
+            # Record the skills resolved for this session so the
+            # skill-evolution effectiveness analyzer has usage signal.
+            # (Same resolution used for prompt injection in _build_invocation.)
+            skill_tags=_resolve_skills(request),
         )
         session_id = session["id"]
 

--- a/src/genesis/db/crud/cc_sessions.py
+++ b/src/genesis/db/crud/cc_sessions.py
@@ -238,6 +238,26 @@ async def query_by_skill_tag(
     return [dict(r) for r in await cursor.fetchall()]
 
 
+async def get_by_session_types(
+    db: aiosqlite.Connection,
+    session_types: set[str],
+) -> list[dict]:
+    """Return all sessions whose session_type is in the given set.
+
+    Used by the skill-effectiveness baseline computation, which then filters
+    in Python on skill_tags membership. Returns [] for an empty input.
+    """
+    types = list(session_types)
+    if not types:
+        return []
+    placeholders = ",".join("?" * len(types))
+    cursor = await db.execute(
+        f"SELECT * FROM cc_sessions WHERE session_type IN ({placeholders})",  # noqa: S608
+        (*types,),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
 async def update_rate_limit(
     db: aiosqlite.Connection,
     id: str,

--- a/src/genesis/learning/skills/effectiveness.py
+++ b/src/genesis/learning/skills/effectiveness.py
@@ -6,6 +6,7 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
+from genesis.db.crud import cc_sessions
 from genesis.learning.skills.types import SkillReport, SkillTrend
 
 if TYPE_CHECKING:
@@ -21,17 +22,15 @@ class SkillEffectivenessAnalyzer:
 
     async def analyze(self, db: aiosqlite.Connection, skill_name: str) -> SkillReport:
         """Analyze effectiveness of a single skill."""
-        cursor = await db.execute(
-            "SELECT * FROM cc_sessions WHERE metadata LIKE ? ORDER BY started_at DESC",
-            (f'%"{skill_name}"%',),
-        )
-        # The LIKE is a cheap prefilter; on its own it also matches the skill
-        # name appearing in OTHER metadata fields (e.g. a `profile` value —
-        # "research" is both a profile and a skill name). Keep only sessions
-        # that actually list this skill in `skill_tags`.
+        # query_by_skill_tag does the cheap `metadata LIKE '%"skill"%'`
+        # prefilter; on its own that also matches the skill name appearing in
+        # OTHER metadata fields (e.g. a `profile` value — "research" is both a
+        # profile and a skill name). Keep only sessions that actually list this
+        # skill in `skill_tags`.
+        candidate_rows = await cc_sessions.query_by_skill_tag(db, skill_tag=skill_name)
         rows = [
             r
-            for r in (dict(row) for row in await cursor.fetchall())
+            for r in candidate_rows
             if skill_name in _parse_metadata(r.get("metadata")).get("skill_tags", [])
         ]
 
@@ -143,25 +142,20 @@ class SkillEffectivenessAnalyzer:
         if not session_types:
             return None
 
-        placeholders = ",".join("?" * len(session_types))
-        cursor = await db.execute(
-            f"SELECT status, metadata FROM cc_sessions "  # noqa: S608
-            f"WHERE session_type IN ({placeholders})",
-            (*session_types,),
-        )
+        same_type_rows = await cc_sessions.get_by_session_types(db, session_types)
         # Baseline = same-type sessions that do NOT use this skill. Match on
         # skill_tags membership (not a loose substring) for the same reason as
         # analyze() — a session whose `profile` equals the skill name is not a
         # user of the skill.
         baseline_rows = [
             r
-            for r in await cursor.fetchall()
-            if skill_name not in _parse_metadata(r[1]).get("skill_tags", [])
+            for r in same_type_rows
+            if skill_name not in _parse_metadata(r.get("metadata")).get("skill_tags", [])
         ]
         if not baseline_rows:
             return None
 
-        completed = sum(1 for r in baseline_rows if r[0] == "completed")
+        completed = sum(1 for r in baseline_rows if r.get("status") == "completed")
         return completed / len(baseline_rows)
 
 

--- a/src/genesis/learning/skills/effectiveness.py
+++ b/src/genesis/learning/skills/effectiveness.py
@@ -25,7 +25,15 @@ class SkillEffectivenessAnalyzer:
             "SELECT * FROM cc_sessions WHERE metadata LIKE ? ORDER BY started_at DESC",
             (f'%"{skill_name}"%',),
         )
-        rows = [dict(r) for r in await cursor.fetchall()]
+        # The LIKE is a cheap prefilter; on its own it also matches the skill
+        # name appearing in OTHER metadata fields (e.g. a `profile` value —
+        # "research" is both a profile and a skill name). Keep only sessions
+        # that actually list this skill in `skill_tags`.
+        rows = [
+            r
+            for r in (dict(row) for row in await cursor.fetchall())
+            if skill_name in _parse_metadata(r.get("metadata")).get("skill_tags", [])
+        ]
 
         success_count = sum(1 for r in rows if r["status"] == "completed")
         failure_count = sum(1 for r in rows if r["status"] == "failed")
@@ -137,12 +145,19 @@ class SkillEffectivenessAnalyzer:
 
         placeholders = ",".join("?" * len(session_types))
         cursor = await db.execute(
-            f"SELECT status FROM cc_sessions "  # noqa: S608
-            f"WHERE session_type IN ({placeholders}) "
-            f"AND (metadata IS NULL OR metadata NOT LIKE ?)",
-            (*session_types, f'%"{skill_name}"%'),
+            f"SELECT status, metadata FROM cc_sessions "  # noqa: S608
+            f"WHERE session_type IN ({placeholders})",
+            (*session_types,),
         )
-        baseline_rows = await cursor.fetchall()
+        # Baseline = same-type sessions that do NOT use this skill. Match on
+        # skill_tags membership (not a loose substring) for the same reason as
+        # analyze() — a session whose `profile` equals the skill name is not a
+        # user of the skill.
+        baseline_rows = [
+            r
+            for r in await cursor.fetchall()
+            if skill_name not in _parse_metadata(r[1]).get("skill_tags", [])
+        ]
         if not baseline_rows:
             return None
 

--- a/tests/test_cc/test_direct_session.py
+++ b/tests/test_cc/test_direct_session.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+from unittest.mock import AsyncMock
+
 import pytest
 
-from genesis.cc.direct_session import DirectSessionRequest
+from genesis.cc.direct_session import DirectSessionRequest, DirectSessionRunner
+from genesis.cc.session_manager import SessionManager
+from genesis.db.crud import cc_sessions
 
 
 class TestDirectSessionRequest:
@@ -27,3 +33,139 @@ class TestDirectSessionRequest:
         """Invalid profile raises ValueError."""
         with pytest.raises(ValueError, match="Invalid profile"):
             DirectSessionRequest(prompt="test", profile="admin")
+
+
+class TestSpawnRecordsSkillSignal:
+    """spawn() must record the resolved skills into session metadata so the
+    skill-evolution effectiveness analyzer has usage signal. Regression guard
+    for the bug where skills were injected into the prompt but never recorded
+    (background_task sessions had zero skill_tags → analyzer never fired)."""
+
+    async def test_spawn_records_resolved_skills_in_metadata(self, db):
+        sm = SessionManager(db=db, invoker=AsyncMock(), day_boundary_hour=0)
+        runner = DirectSessionRunner(
+            invoker=AsyncMock(),
+            session_manager=sm,
+            config_builder=AsyncMock(),
+            runtime=object(),  # no _autonomy_manager attr -> ceiling check skipped
+        )
+        # Neutralize the fire-and-forget run so no real CC invocation happens.
+        runner._run_session = lambda _req, _sid: asyncio.sleep(0)
+
+        req = DirectSessionRequest(
+            prompt="draft a post",
+            profile="research",
+            skills=["voice-master", "research"],
+        )
+        sid = await runner.spawn(req)
+
+        try:
+            row = await cc_sessions.get_by_id(db, sid)
+            assert row is not None
+            meta = json.loads(row["metadata"])
+            assert meta["skill_tags"] == ["voice-master", "research"]
+            # The analyzer matches via `metadata LIKE '%"<skill>"%'` — confirm
+            # the persisted JSON shape actually satisfies that query.
+            assert '"voice-master"' in row["metadata"]
+        finally:
+            t = runner._active.get(sid)
+            if t is not None:
+                await asyncio.gather(t, return_exceptions=True)
+
+    async def test_effectiveness_analyzer_sees_tagged_session(self, db):
+        """E2E: a skill-tagged session is visible to the skill-evolution
+        effectiveness analyzer (closes the Phase A loop — tagging produces
+        non-zero usage signal where before there was none)."""
+        from genesis.cc.types import CCModel, EffortLevel, SessionType
+        from genesis.learning.skills.effectiveness import SkillEffectivenessAnalyzer
+
+        sm = SessionManager(db=db, invoker=AsyncMock(), day_boundary_hour=0)
+        sess = await sm.create_background(
+            session_type=SessionType.BACKGROUND_TASK,
+            model=CCModel.SONNET,
+            effort=EffortLevel.HIGH,
+            skill_tags=["voice-master"],
+        )
+        await cc_sessions.update_status(db, sess["id"], status="completed")
+
+        report = await SkillEffectivenessAnalyzer().analyze(db, "voice-master")
+        assert report.usage_count >= 1
+        assert report.success_count >= 1
+
+    async def test_skill_tags_survive_store_result_merge(self, db):
+        """_store_result is read-merge-write; skill_tags set at creation must
+        survive session completion (the analyzer reads completed sessions).
+        Guards against a refactor that replaces metadata wholesale."""
+        from types import SimpleNamespace
+
+        from genesis.cc.direct_session import DirectSessionResult
+        from genesis.cc.types import CCModel, EffortLevel, SessionType
+
+        sm = SessionManager(db=db, invoker=AsyncMock(), day_boundary_hour=0)
+        runner = DirectSessionRunner(
+            invoker=AsyncMock(),
+            session_manager=sm,
+            config_builder=AsyncMock(),
+            runtime=SimpleNamespace(_db=db),  # _store_result reads rt._db
+        )
+        sess = await sm.create_background(
+            session_type=SessionType.BACKGROUND_TASK,
+            model=CCModel.SONNET,
+            effort=EffortLevel.HIGH,
+            skill_tags=["voice-master"],
+        )
+        req = DirectSessionRequest(
+            prompt="x", profile="research", skills=["voice-master"],
+        )
+        result = DirectSessionResult(
+            session_id=sess["id"], success=True, output_text="done",
+        )
+        await runner._store_result(sess["id"], req, result)
+
+        row = await cc_sessions.get_by_id(db, sess["id"])
+        meta = json.loads(row["metadata"])
+        assert meta["skill_tags"] == ["voice-master"]  # survived the merge
+        assert meta["output_text"] == "done"  # merge actually ran
+
+    async def test_spawn_records_auto_resolved_profile_skills(self, db):
+        """Auto-resolved (profile-bound) skills are recorded too, not just
+        explicit request.skills. The campaign profile injects voice-master."""
+        sm = SessionManager(db=db, invoker=AsyncMock(), day_boundary_hour=0)
+        runner = DirectSessionRunner(
+            invoker=AsyncMock(),
+            session_manager=sm,
+            config_builder=AsyncMock(),
+            runtime=object(),
+        )
+        runner._run_session = lambda _req, _sid: asyncio.sleep(0)
+        req = DirectSessionRequest(prompt="x", profile="campaign")  # no explicit skills
+        sid = await runner.spawn(req)
+        try:
+            row = await cc_sessions.get_by_id(db, sid)
+            meta = json.loads(row["metadata"])
+            assert "voice-master" in meta.get("skill_tags", [])
+        finally:
+            t = runner._active.get(sid)
+            if t is not None:
+                await asyncio.gather(t, return_exceptions=True)
+
+    async def test_profile_name_collision_not_counted_as_skill(self, db):
+        """Regression guard: 'research' is both a profile and a skill. A
+        research-PROFILE session (which injects no skills) must NOT be counted
+        as research-SKILL usage by the effectiveness analyzer — only skill_tags
+        membership counts, not a loose metadata substring match."""
+        from genesis.cc.types import CCModel, EffortLevel, SessionType
+        from genesis.learning.skills.effectiveness import SkillEffectivenessAnalyzer
+
+        sm = SessionManager(db=db, invoker=AsyncMock(), day_boundary_hour=0)
+        sess = await sm.create_background(
+            session_type=SessionType.BACKGROUND_TASK,
+            model=CCModel.SONNET,
+            effort=EffortLevel.HIGH,
+            profile="research",  # writes {"profile": "research"} to metadata
+            skill_tags=[],  # research profile injects no skills
+        )
+        await cc_sessions.update_status(db, sess["id"], status="completed")
+
+        report = await SkillEffectivenessAnalyzer().analyze(db, "research")
+        assert report.usage_count == 0  # profile match must not count as skill usage

--- a/tests/test_db/test_cc_sessions.py
+++ b/tests/test_db/test_cc_sessions.py
@@ -149,3 +149,22 @@ async def test_cc_session_id_null_by_default(db, sess_fields):
     await cc_sessions.create(db, **sess_fields)
     row = await cc_sessions.get_by_id(db, "sess-1")
     assert row["cc_session_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_by_session_types(db, sess_fields):
+    """Filters to the requested session_types; empty input returns []."""
+    await cc_sessions.create(db, **sess_fields)  # foreground
+    await cc_sessions.create(
+        db, **{**sess_fields, "id": "sess-2", "session_type": "background_task"})
+    await cc_sessions.create(
+        db, **{**sess_fields, "id": "sess-3", "session_type": "background_task"})
+
+    bg = await cc_sessions.get_by_session_types(db, {"background_task"})
+    assert {r["id"] for r in bg} == {"sess-2", "sess-3"}
+
+    both = await cc_sessions.get_by_session_types(
+        db, {"background_task", "foreground"})
+    assert {r["id"] for r in both} == {"sess-1", "sess-2", "sess-3"}
+
+    assert await cc_sessions.get_by_session_types(db, set()) == []


### PR DESCRIPTION
Two changes, both small.

## 1. Revive the skill-evolution signal (`fix(skills)`)
The pipeline was dormant — **0 proposals ever**. `background_task` sessions resolved/injected skills but never recorded them, so the effectiveness analyzer (reads `cc_sessions.metadata`) only saw the 3 reflection skills.

- `direct_session.spawn()` now passes `skill_tags=_resolve_skills(request)` to `create_background` (same resolution used for injection; survives `_store_result`'s read-merge-write).
- `effectiveness.analyze()` / `_compute_baseline()` now match `skill_tags` membership precisely instead of a loose `metadata LIKE '%"<skill>"%'` substring — which miscounted the `research` profile/skill name collision (found in review, reproduced empirically).

## 2. Drop dated "Phase 6" wording from the contribution offer hook (`docs(hooks)`)
The user-facing contribution offer referenced an internal build-phase label; reworded to "the contribution pipeline."

## Tests
5 new tests (spawn records skills; E2E analyzer sees a tagged session; `skill_tags` survive `_store_result`; auto-resolved profile skills recorded; `research` collision regression guard). Existing analyzer tests unchanged and green. 58 affected tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
