### PR TITLE
fix(memory): capacity breaker for dream cycle — bound attempts, not just successes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   dead-lettered work during provider outages, and adversarial review and
   reflections keep running when free-tier providers are down (extra free
   fallbacks added, plus a paid last-resort for the dream-cycle challenge).
+- **The weekly memory consolidation (dream cycle) no longer melts down during a
+  provider outage.** Previously, if its LLM providers were unavailable, the run
+  attempted every cluster anyway — burning hours and flooding the retry queue
+  while merging almost nothing. It now aborts early once the providers are
+  clearly saturated and defers the rest to the next run, and no longer
+  dead-letters its own consolidation attempts.
 - **Job health no longer shows a permanent failure after a job recovers.**
   A scheduled job that failed once kept that failure timestamp in the health
   view forever, even after it started succeeding again; recovery now clears

--- a/src/genesis/memory/adversarial_review.py
+++ b/src/genesis/memory/adversarial_review.py
@@ -71,9 +71,17 @@ Lean toward "distinct" — it is safer to keep both than to lose information."""
 class SynthesisBlockedError(Exception):
     """Raised when adversarial review blocks a synthesis."""
 
-    def __init__(self, missing: list[str] | None = None, error: str | None = None):
+    def __init__(
+        self,
+        missing: list[str] | None = None,
+        error: str | None = None,
+        exhausted: bool = False,
+    ):
         self.missing = missing or []
         self.error = error
+        # True when the block was caused by provider-chain exhaustion (capacity)
+        # rather than a genuine quality failure. Drives the capacity breaker.
+        self.exhausted = exhausted
         detail = ", ".join(self.missing) if self.missing else (error or "unknown")
         super().__init__(f"Synthesis blocked by adversarial review: {detail}")
 
@@ -85,6 +93,11 @@ class AdversarialVerdict:
     missing: list[str] = field(default_factory=list)
     raw_response: str = ""
     error: str | None = None
+    # True when the review could not run because the provider chain was
+    # exhausted / errored (capacity failure), as opposed to a review that ran
+    # and legitimately failed on quality. The dream-cycle capacity breaker uses
+    # this to abort early on saturation without aborting on real quality blocks.
+    exhausted: bool = False
 
 
 def _parse_verdict(raw: str) -> AdversarialVerdict:
@@ -140,17 +153,18 @@ async def check_synthesis_faithfulness(
         result = await router.route_call(
             CALL_SITE_SYNTHESIS,
             [{"role": "user", "content": prompt}],
+            suppress_dead_letter=True,
         )
     except Exception as exc:
         logger.error("Adversarial review call failed: %s", exc)
         return AdversarialVerdict(
-            passed=False, error=f"router error: {exc}",
+            passed=False, error=f"router error: {exc}", exhausted=True,
         )
 
     if not result.success:
         logger.warning("Adversarial review LLM call failed: %s", result.error)
         return AdversarialVerdict(
-            passed=False, error=f"LLM error: {result.error}",
+            passed=False, error=f"LLM error: {result.error}", exhausted=True,
         )
 
     return _parse_verdict(result.content or "")
@@ -176,6 +190,7 @@ async def check_entity_duplicate(
         result = await router.route_call(
             CALL_SITE_ENTITY,
             [{"role": "user", "content": prompt}],
+            suppress_dead_letter=True,
         )
     except Exception as exc:
         logger.error("Entity adversarial review failed: %s", exc)

--- a/src/genesis/memory/dream_cycle.py
+++ b/src/genesis/memory/dream_cycle.py
@@ -13,6 +13,9 @@ sleep.
 - Dry-run mode is the default until manually reviewed
 - Max 100 cluster merges per run (configurable)
 - Clusters > 10 memories flagged for manual review, not auto-merged
+- Capacity breaker: the synthesis sweep aborts after N consecutive provider
+  exhaustions and defers the rest, so a run during a provider outage fails
+  fast instead of grinding every cluster (bounds attempts, not just successes)
 
 Spec: docs/superpowers/specs/2026-05-14-dream-cycle-design.md
 """
@@ -50,6 +53,38 @@ MIN_AVAILABLE_MB: int = 256
 _YIELD_EVERY: int = 50  # yield to event loop every N search calls
 CALL_SITE_ID: str = "dream_cycle_synthesis"
 COLLECTION: str = "episodic_memory"
+# Abort the synthesis loop after this many CONSECUTIVE provider-exhaustion
+# failures. Prevents a run during a provider outage from grinding every cluster
+# into a saturated chain (root cause of the 2026-06-14 near-total failure:
+# the loop bounded successes, not attempts, so a degraded run attempted ~782
+# clusters). Genuine quality blocks reset the streak.
+_CAPACITY_ABORT_THRESHOLD: int = 5
+
+
+class ProvidersExhaustedError(Exception):
+    """A dream-cycle LLM call exhausted its entire provider chain — a capacity
+    failure (not a logic error). Drives the capacity breaker; counted as a run
+    error, distinct from a genuine quality block."""
+
+
+class _CapacityBreaker:
+    """Tracks consecutive provider-exhaustion failures and trips once the
+    threshold is hit. Any progress (a success or a genuine quality block)
+    resets the streak, so only sustained saturation aborts the run."""
+
+    def __init__(self, threshold: int) -> None:
+        self._threshold = threshold
+        self._consecutive = 0
+
+    def record_exhaustion(self) -> None:
+        self._consecutive += 1
+
+    def record_progress(self) -> None:
+        self._consecutive = 0
+
+    @property
+    def tripped(self) -> bool:
+        return self._consecutive >= self._threshold
 
 # ── Union-Find ───────────────────────────────────────────────────────────
 
@@ -134,6 +169,7 @@ async def run(
         "adversarial_blocked": 0,
         "shrink_gate_blocked": 0,
         "rollback_flagged": False,
+        "aborted_capacity": False,
         "errors": [],
     }
 
@@ -216,75 +252,17 @@ async def run(
 
     # Phase 3+4 — Synthesize and deprecate (live mode only)
     if not dry_run:
-        all_clusters.sort(key=len, reverse=True)
-        merged = 0
-
-        for cluster in all_clusters:
-            if merged >= max_merges:
-                break
-
-            if len(cluster) > max_cluster_size:
-                report["clusters_skipped_large"] += 1
-                logger.info(
-                    "Dream cycle %s: skipping cluster of %d in %s/%s (too large)",
-                    run_id[:8], len(cluster),
-                    cluster[0].get("wing", "?"), cluster[0].get("room", "?"),
-                )
-                continue
-
-            try:
-                result = await _synthesize_and_deprecate(
-                    cluster=cluster,
-                    run_id=run_id,
-                    qdrant=qdrant,
-                    db=db,
-                    router=router,
-                    store=store,
-                )
-                merged += 1
-                report["memories_deprecated"] += result["deprecated_count"]
-            except SynthesisBlockedError as exc:
-                # Adversarial review or shrink gate blocked this cluster.
-                # Not an error — a quality gate working as intended.
-                if "catastrophic shrink" in str(exc):
-                    report["shrink_gate_blocked"] += 1
-                else:
-                    report["adversarial_blocked"] += 1
-                logger.info(
-                    "Dream cycle %s: cluster of %d blocked: %s",
-                    run_id[:8], len(cluster), exc,
-                )
-            except Exception as exc:
-                report["errors"].append({
-                    "cluster_size": len(cluster),
-                    "error": str(exc),
-                })
-                logger.warning(
-                    "Dream cycle %s: synthesis failed for cluster of %d: %s",
-                    run_id[:8], len(cluster), exc, exc_info=True,
-                )
-
-        report["clusters_merged"] = merged
-        logger.info(
-            "Dream cycle %s: merged %d clusters, deprecated %d memories, %d errors",
-            run_id[:8], merged, report["memories_deprecated"], len(report["errors"]),
+        await _synthesize_clusters(
+            all_clusters,
+            run_id=run_id,
+            qdrant=qdrant,
+            db=db,
+            router=router,
+            store=store,
+            max_merges=max_merges,
+            max_cluster_size=max_cluster_size,
+            report=report,
         )
-
-        # ── Rollback flagging ──
-        # If >50% of synthesis attempts were blocked, flag the run for
-        # manual review. Do NOT auto-rollback.
-        total_blocked = report["adversarial_blocked"] + report["shrink_gate_blocked"]
-        total_attempted = merged + total_blocked
-        if total_attempted > 0:
-            block_rate = total_blocked / total_attempted
-            if block_rate > 0.50:
-                report["rollback_flagged"] = True
-                logger.critical(
-                    "Dream cycle %s: %.0f%% of syntheses blocked (%d/%d). "
-                    "Manual review recommended. Run rollback('%s') if needed.",
-                    run_id[:8], block_rate * 100,
-                    total_blocked, total_attempted, run_id,
-                )
 
     # ── Sprint 2 phases (each handles dry_run internally) ──────────────
 
@@ -628,6 +606,126 @@ def _get_vector(qdrant: QdrantClient, point_id: str) -> list[float]:
 # ── Phase 3+4: Synthesize and Deprecate ──────────────────────────────────
 
 
+async def _synthesize_clusters(
+    all_clusters: list[list[dict]],
+    *,
+    run_id: str,
+    qdrant: QdrantClient,
+    db: aiosqlite.Connection,
+    router: Router,
+    store: MemoryStore,
+    max_merges: int,
+    max_cluster_size: int,
+    report: dict[str, Any],
+) -> None:
+    """Synthesize/deprecate clusters with a capacity breaker (mutates report).
+
+    Aborts early (``report['aborted_capacity']=True``) after
+    ``_CAPACITY_ABORT_THRESHOLD`` CONSECUTIVE provider-exhaustion failures, so a
+    run during a provider outage fails fast instead of grinding every cluster
+    into a saturated chain. Genuine quality blocks reset the streak and never
+    trip the breaker.
+    """
+    all_clusters.sort(key=len, reverse=True)
+    merged = 0
+    breaker = _CapacityBreaker(_CAPACITY_ABORT_THRESHOLD)
+
+    for cluster in all_clusters:
+        if merged >= max_merges:
+            break
+
+        if breaker.tripped:
+            report["aborted_capacity"] = True
+            logger.error(
+                "Dream cycle %s: aborting synthesis — provider chains exhausted "
+                "(%d consecutive). Deferring remaining clusters to a future run.",
+                run_id[:8], _CAPACITY_ABORT_THRESHOLD,
+            )
+            break
+
+        if len(cluster) > max_cluster_size:
+            report["clusters_skipped_large"] += 1
+            logger.info(
+                "Dream cycle %s: skipping cluster of %d in %s/%s (too large)",
+                run_id[:8], len(cluster),
+                cluster[0].get("wing", "?"), cluster[0].get("room", "?"),
+            )
+            continue
+
+        try:
+            result = await _synthesize_and_deprecate(
+                cluster=cluster,
+                run_id=run_id,
+                qdrant=qdrant,
+                db=db,
+                router=router,
+                store=store,
+            )
+            merged += 1
+            report["memories_deprecated"] += result["deprecated_count"]
+            breaker.record_progress()
+        except SynthesisBlockedError as exc:
+            # Adversarial review or shrink gate blocked this cluster.
+            if exc.exhausted:
+                # Block caused by provider exhaustion (capacity), not quality.
+                report["adversarial_blocked"] += 1
+                breaker.record_exhaustion()
+            else:
+                # Genuine quality gate working as intended — resets the breaker.
+                if "catastrophic shrink" in str(exc):
+                    report["shrink_gate_blocked"] += 1
+                else:
+                    report["adversarial_blocked"] += 1
+                breaker.record_progress()
+            logger.info(
+                "Dream cycle %s: cluster of %d blocked: %s",
+                run_id[:8], len(cluster), exc,
+            )
+        except ProvidersExhaustedError as exc:
+            report["errors"].append({
+                "cluster_size": len(cluster),
+                "error": str(exc),
+            })
+            breaker.record_exhaustion()
+            logger.warning(
+                "Dream cycle %s: synthesis exhausted for cluster of %d: %s",
+                run_id[:8], len(cluster), exc,
+            )
+        except Exception as exc:
+            # Non-capacity error — record it but do NOT trip the capacity breaker.
+            report["errors"].append({
+                "cluster_size": len(cluster),
+                "error": str(exc),
+            })
+            breaker.record_progress()
+            logger.warning(
+                "Dream cycle %s: synthesis failed for cluster of %d: %s",
+                run_id[:8], len(cluster), exc, exc_info=True,
+            )
+
+    report["clusters_merged"] = merged
+    logger.info(
+        "Dream cycle %s: merged %d clusters, deprecated %d memories, %d errors",
+        run_id[:8], merged, report["memories_deprecated"], len(report["errors"]),
+    )
+
+    # ── Rollback flagging ──
+    # If >50% of synthesis attempts were blocked, flag for manual review.
+    # Skip when we aborted on capacity — the abort is the signal, and a small
+    # "all blocked" count from an early abort is not a quality problem.
+    if not report["aborted_capacity"]:
+        total_blocked = report["adversarial_blocked"] + report["shrink_gate_blocked"]
+        total_attempted = merged + total_blocked
+        if total_attempted > 0 and (total_blocked / total_attempted) > 0.50:
+            report["rollback_flagged"] = True
+            logger.critical(
+                "Dream cycle %s: %.0f%% of syntheses blocked (%d/%d). "
+                "Manual review recommended. Run rollback('%s') if needed.",
+                run_id[:8], (total_blocked / total_attempted) * 100,
+                total_blocked, total_attempted, run_id,
+            )
+
+
 async def _synthesize_and_deprecate(
     *,
     cluster: list[dict],
@@ -646,10 +744,12 @@ async def _synthesize_and_deprecate(
     prompt = _build_synthesis_prompt(cluster, wing, room)
     messages = [{"role": "user", "content": prompt}]
 
-    # LLM synthesis via router
-    result = await router.route_call(CALL_SITE_ID, messages)
+    # LLM synthesis via router. suppress_dead_letter: dream-cycle ops re-cluster
+    # fresh each run, so dead-lettering exhausted syntheses is pointless and
+    # floods the queue (it tripled the backlog on 2026-06-14).
+    result = await router.route_call(CALL_SITE_ID, messages, suppress_dead_letter=True)
     if not result.success:
-        raise RuntimeError(f"LLM synthesis failed: {result.error}")
+        raise ProvidersExhaustedError(f"LLM synthesis failed: {result.error}")
 
     synthesis = _parse_synthesis_response(result.content, wing, room)
 
@@ -670,6 +770,7 @@ async def _synthesize_and_deprecate(
         raise SynthesisBlockedError(
             missing=adversarial_verdict.missing,
             error=adversarial_verdict.error,
+            exhausted=adversarial_verdict.exhausted,
         )
 
     # ── Catastrophic-shrink gate ──

--- a/src/genesis/memory/dream_cycle.py
+++ b/src/genesis/memory/dream_cycle.py
@@ -280,16 +280,25 @@ async def run(
         report["errors"].append({"phase": "link_repair", "error": str(exc)})
         logger.warning("Dream phase link_repair failed: %s", exc, exc_info=True)
 
-    # Phase 6 — Entity resolution (dedup + contradiction detection)
-    try:
-        from genesis.memory.dream_entity_scan import run_entity_resolution
-
-        report["entity_resolution"] = await run_entity_resolution(
-            **phase_kwargs, buckets=buckets,
+    # Phase 6 — Entity resolution (dedup + contradiction detection).
+    # Skip when synthesis aborted on capacity: entity resolution is LLM-heavy
+    # and would just hammer the same saturated providers (Phases 5/7/8 are
+    # non-LLM SQL/graph work and run regardless).
+    if report["aborted_capacity"]:
+        logger.info(
+            "Dream cycle %s: skipping entity resolution — synthesis aborted on capacity",
+            run_id[:8],
         )
-    except Exception as exc:
-        report["errors"].append({"phase": "entity_resolution", "error": str(exc)})
-        logger.warning("Dream phase entity_resolution failed: %s", exc, exc_info=True)
+    else:
+        try:
+            from genesis.memory.dream_entity_scan import run_entity_resolution
+
+            report["entity_resolution"] = await run_entity_resolution(
+                **phase_kwargs, buckets=buckets,
+            )
+        except Exception as exc:
+            report["errors"].append({"phase": "entity_resolution", "error": str(exc)})
+            logger.warning("Dream phase entity_resolution failed: %s", exc, exc_info=True)
 
     # Phase 7 — Orphan detection
     try:

--- a/src/genesis/memory/entity_resolution.py
+++ b/src/genesis/memory/entity_resolution.py
@@ -236,6 +236,7 @@ async def check_semantic_overlap(
         result = await router.route_call(
             CALL_SITE_ID,
             [{"role": "user", "content": prompt}],
+            suppress_dead_letter=True,
         )
         if not result.success:
             logger.warning("Entity check LLM call failed: %s", result.error)

--- a/tests/test_memory/test_adversarial_review.py
+++ b/tests/test_memory/test_adversarial_review.py
@@ -151,6 +151,46 @@ class TestCheckSynthesisFaithfulness:
         )
         assert result.passed is False
 
+    @pytest.mark.asyncio
+    async def test_exhaustion_marks_verdict_exhausted(self):
+        """When the review can't run (route_call exhausts all providers OR
+        raises), the verdict is FAIL AND flagged exhausted=True — a capacity
+        failure, not a quality verdict — so the dream-cycle breaker can tell
+        them apart."""
+        # route_call returns failure (all providers exhausted)
+        router = AsyncMock()
+        router.route_call = AsyncMock(return_value=MagicMock(
+            success=False, error="All providers exhausted",
+        ))
+        result = await check_synthesis_faithfulness(
+            router=router, originals=[{"content": "x"}], synthesis_text="y",
+        )
+        assert result.passed is False
+        assert result.exhausted is True
+
+        # route_call raises (infra error) — also exhausted
+        router2 = AsyncMock()
+        router2.route_call = AsyncMock(side_effect=RuntimeError("connection refused"))
+        result2 = await check_synthesis_faithfulness(
+            router=router2, originals=[{"content": "x"}], synthesis_text="y",
+        )
+        assert result2.exhausted is True
+
+    @pytest.mark.asyncio
+    async def test_quality_fail_is_not_exhausted(self):
+        """A genuine quality FAIL (review ran, found missing info) is NOT
+        flagged exhausted — the breaker must not abort on real quality blocks."""
+        router = AsyncMock()
+        router.route_call = AsyncMock(return_value=MagicMock(
+            success=True,
+            content=json.dumps({"verdict": "FAIL", "missing": ["a date"]}),
+        ))
+        result = await check_synthesis_faithfulness(
+            router=router, originals=[{"content": "x"}], synthesis_text="y",
+        )
+        assert result.passed is False
+        assert result.exhausted is False
+
 
 class TestCheckEntityDuplicate:
     """Tests for entity duplicate second opinion."""

--- a/tests/test_memory/test_dream_cycle.py
+++ b/tests/test_memory/test_dream_cycle.py
@@ -11,7 +11,6 @@ from genesis.memory.dream_cycle import (
     _CAPACITY_ABORT_THRESHOLD,
     MAX_BUCKET_SIZE,
     MAX_CLUSTER_SIZE,
-    ProvidersExhaustedError,
     _build_synthesis_prompt,
     _CapacityBreaker,
     _parse_synthesis_response,

--- a/tests/test_memory/test_dream_cycle.py
+++ b/tests/test_memory/test_dream_cycle.py
@@ -8,15 +8,37 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from genesis.memory.dream_cycle import (
+    _CAPACITY_ABORT_THRESHOLD,
     MAX_BUCKET_SIZE,
     MAX_CLUSTER_SIZE,
+    ProvidersExhaustedError,
     _build_synthesis_prompt,
+    _CapacityBreaker,
     _parse_synthesis_response,
     _read_mem_available_mb,
     _size_distribution,
+    _synthesize_clusters,
     _UnionFind,
     run,
 )
+
+
+def _fake_cluster(n: int = 2, wing: str = "memory", room: str = "store"):
+    """A minimal cluster of n memory points for synthesis-loop tests."""
+    return [
+        {"id": f"{wing}-{room}-{i}", "wing": wing, "room": room,
+         "payload": {"content": f"fact {i}", "confidence": 0.8}}
+        for i in range(n)
+    ]
+
+
+def _fresh_report():
+    return {
+        "clusters_merged": 0, "clusters_skipped_large": 0,
+        "memories_deprecated": 0, "adversarial_blocked": 0,
+        "shrink_gate_blocked": 0, "rollback_flagged": False,
+        "aborted_capacity": False, "errors": [],
+    }
 
 # All Qdrant functions are imported inside function bodies, so we patch
 # at the source (genesis.qdrant.collections.*) not at dream_cycle.*.
@@ -25,6 +47,82 @@ _SEARCH = "genesis.qdrant.collections.search"
 _UPDATE = "genesis.qdrant.collections.update_payload"
 _DELETE = "genesis.qdrant.collections.delete_point"
 _BATCH_VEC = "genesis.memory.dream_cycle._batch_get_vectors"
+
+
+# ── Capacity breaker ─────────────────────────────────────────────────────
+
+
+class TestCapacityBreaker:
+    def test_trips_after_threshold_consecutive_exhaustions(self):
+        b = _CapacityBreaker(threshold=3)
+        assert b.tripped is False
+        b.record_exhaustion()
+        b.record_exhaustion()
+        assert b.tripped is False
+        b.record_exhaustion()
+        assert b.tripped is True
+
+    def test_progress_resets_the_streak(self):
+        b = _CapacityBreaker(threshold=3)
+        b.record_exhaustion()
+        b.record_exhaustion()
+        b.record_progress()
+        b.record_exhaustion()
+        b.record_exhaustion()
+        assert b.tripped is False
+
+
+class TestSynthesizeClustersBreaker:
+    @pytest.mark.asyncio
+    async def test_aborts_on_consecutive_exhaustion(self):
+        """Provider-chain exhaustion aborts the loop after the threshold instead
+        of grinding every cluster (the 2026-06-14 pathology)."""
+        clusters = [_fake_cluster() for _ in range(_CAPACITY_ABORT_THRESHOLD + 3)]
+        router = AsyncMock()
+        router.route_call = AsyncMock(return_value=MagicMock(
+            success=False, error="All providers exhausted",
+        ))
+        report = _fresh_report()
+        await _synthesize_clusters(
+            clusters, run_id="t", qdrant=MagicMock(), db=AsyncMock(),
+            router=router, store=AsyncMock(),
+            max_merges=100, max_cluster_size=10, report=report,
+        )
+        assert report["aborted_capacity"] is True
+        assert report["clusters_merged"] == 0
+        # Aborted after ~threshold attempts, NOT all clusters
+        assert len(report["errors"]) == _CAPACITY_ABORT_THRESHOLD
+        # rollback flag must NOT fire on a capacity abort
+        assert report["rollback_flagged"] is False
+
+    @pytest.mark.asyncio
+    async def test_quality_blocks_do_not_abort(self):
+        """Genuine adversarial quality blocks do NOT trip the capacity breaker —
+        every cluster is processed."""
+        n = _CAPACITY_ABORT_THRESHOLD + 3
+        clusters = [_fake_cluster() for _ in range(n)]
+        synthesis_json = json.dumps({
+            "content": "consolidated " * 20, "tags": ["t"], "confidence": 0.9,
+            "memory_class": "fact", "wing": "memory", "room": "store",
+            "synthesis_notes": "x",
+        })
+        challenge_fail = json.dumps({"verdict": "FAIL", "missing": ["a detail"]})
+
+        async def _call(call_site, messages, **kw):
+            if call_site == "dream_cycle_synthesis":
+                return MagicMock(success=True, content=synthesis_json)
+            return MagicMock(success=True, content=challenge_fail)
+        router = AsyncMock()
+        router.route_call = AsyncMock(side_effect=_call)
+        report = _fresh_report()
+        await _synthesize_clusters(
+            clusters, run_id="t", qdrant=MagicMock(), db=AsyncMock(),
+            router=router, store=AsyncMock(),
+            max_merges=100, max_cluster_size=10, report=report,
+        )
+        assert report["aborted_capacity"] is False
+        assert report["adversarial_blocked"] == n
+        assert report["clusters_merged"] == 0
 
 
 # ── Union-Find ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The dream cycle near-totally failed on 2026-06-14 (838 clusters → **1 merged**,
556 synthesis errors, 225 blocks; dead-letter queue 376 → 1,079). Root cause:
the synthesis loop caps successful **merges** (`max_merges=100`) but not
**attempts** — blocked/errored clusters don't break the loop. So during a
provider outage (NVIDIA NIM down) it ground through all ~782 eligible clusters
(~1,560 LLM calls) into rate-limited fallbacks. The failure mode maximizes load
exactly when capacity is lowest. (Jun 7 succeeded because NIM was healthy —
verified by spend signature: 0 vs 771 paid-flash calls.)

## Fix (P1 — immediate reliability)

- **Capacity breaker:** extract `_synthesize_clusters` from `run()` and abort
  the sweep after `_CAPACITY_ABORT_THRESHOLD` (5) **consecutive** provider
  exhaustions, setting `report['aborted_capacity']` and deferring the rest. A
  degraded run now fails in ~5 attempts instead of ~782.
- **Exhaustion vs quality:** thread an `exhausted` flag through
  `AdversarialVerdict` → `SynthesisBlockedError`, and raise
  `ProvidersExhaustedError` on synthesis exhaustion, so a *capacity* block is
  distinguished from a genuine quality block (the latter resets the breaker and
  never trips it).
- **Stop the dead-letter flood:** `suppress_dead_letter=True` on all 4
  dream-cycle call sites (they re-cluster fresh each run; redispatch is
  pointless — it tripled the backlog).
- **Don't pile on:** skip the LLM-heavy entity-resolution phase on a capacity
  abort; `rollback_flagged` is not raised on a capacity abort.

This is the immediate reliability core. The larger rebuild (incremental
clustering/synthesis split + chain-agnostic capacity calculus, the user-chosen
direction) is deferred to its own design pass — the qdrant clustering phase is
full-collection ~3h/run, which materially changes that design.

## Testing

- New unit + integration tests: breaker trips after N consecutive exhaustions
  and resets on progress; genuine quality blocks don't trip it; the loop aborts
  early (`aborted_capacity`, bounded errors, no rollback flag); `exhausted`
  classification (capacity vs quality). Existing `TestLiveRun`/`TestDryRun`
  still green (extraction preserved behavior).
- E2E (manual, post-deploy): trigger via the run-now endpoint — aborts early if
  NIM is down, completes cleanly if NIM recovered.

## Review

Local adversarial review (Claude reviewer; Codex/OpenCode unavailable):
**0 P1**, one P2 (entity-resolution running on abort) fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
