### PR TITLE
fix(outreach): gate forum routing to telegram; run SMTP off event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Outreach emails actually send now** — email (and Discord/voice) outreach was
+  being misaddressed to the Telegram forum chat for any category that routes to
+  the supergroup, so every such send failed and silently piled up as retries.
+  Forum/topic routing is now correctly Telegram-only; other channels deliver to
+  their own recipient.
+- **A slow or failed email can no longer stall Genesis** — SMTP sending now runs
+  off the event loop, so a hung or rejected send no longer freezes heartbeats,
+  health checks, or the awareness loop.
 - **Provider hangs no longer stall reflections and the dream cycle** — when a
   model provider hangs (accepts the connection but never responds), Genesis
   now fails over to the next provider within its timeout instead of blocking

--- a/src/genesis/channels/email_adapter.py
+++ b/src/genesis/channels/email_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import email.message
 import logging
 import smtplib
@@ -68,10 +69,17 @@ class EmailAdapter(ChannelAdapter):
         msg["Subject"] = subject
         msg.set_content(text)
 
-        try:
+        def _send_sync() -> None:
+            # Synchronous smtplib runs in a worker thread (asyncio.to_thread) so
+            # the SMTP round-trip — connect, TLS, login, send — never blocks the
+            # event loop. A blocking send here froze heartbeats/health/awareness
+            # while the recovery worker retried failed sends (incident 2026-06-14).
             with smtplib.SMTP_SSL(self._host, self._port, timeout=30) as smtp:
                 smtp.login(self._username, self._password)
                 smtp.send_message(msg)
+
+        try:
+            await asyncio.to_thread(_send_sync)
         except smtplib.SMTPException:
             logger.exception("Failed to send email to %s", recipient)
             raise

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -321,39 +321,50 @@ class OutreachPipeline:
                 self._config.delivery_routing.get("default", "supergroup"),
             )
 
-        # Resolve forum topic for this outreach category
+        # Resolve forum topic + supergroup routing.
+        #
+        # Forum topics and the supergroup ``forum_chat_id`` are TELEGRAM-ONLY
+        # concepts (``forum_chat_id``/``topic_manager`` are wired solely from
+        # the Telegram startup paths). They must never touch email/discord/voice
+        # delivery: doing so overwrote prospect email recipients with the
+        # Telegram forum chat id (a large negative integer), which Gmail rejects
+        # as an invalid RFC 5321 address — the deferred-queue poison + blocking
+        # SMTP that starved the event loop on 2026-06-14. Gate ALL forum routing
+        # on the Telegram channel; other channels deliver to their own recipient
+        # with no thread_id.
         thread_id = None
         topic_cat: str | None = None
-        if routing in ("supergroup", "both") and self._topic_manager is not None:
-            topic_cat = self._topic_manager.resolve_outreach_category(
-                request.category.value,
-            )
-            thread_id = await self._topic_manager.get_or_create_persistent(topic_cat)
-
-        # Primary delivery — supergroup if available, fallback to DM
         delivery_recipient = recipient
-        if routing in ("supergroup", "both") and thread_id is not None and self._forum_chat_id:
-            delivery_recipient = self._forum_chat_id
-        else:
-            # DM delivery — never pass thread_id to non-forum chats.
-            # If we WANTED the topic but couldn't resolve a thread_id,
-            # surface the fallback so operators know messages are landing
-            # in DM instead of silently disappearing from the forum topic.
-            # (This is the "where did my approval go?" signal that was
-            # missing on 2026-04-10 when 7 approvals routed to DM.)
-            if (
-                routing in ("supergroup", "both")
-                and self._forum_chat_id
-                and self._topic_manager is not None
-            ):
-                logger.info(
-                    "outreach category=%s wanted supergroup topic "
-                    "routing but thread_id is None — falling back to DM "
-                    "(target category=%s); check earlier ERROR logs from "
-                    "TopicManager for the underlying cause",
-                    request.category.value, topic_cat or "?",
+        if channel == "telegram":
+            if routing in ("supergroup", "both") and self._topic_manager is not None:
+                topic_cat = self._topic_manager.resolve_outreach_category(
+                    request.category.value,
                 )
-            thread_id = None
+                thread_id = await self._topic_manager.get_or_create_persistent(topic_cat)
+
+            # Primary delivery — supergroup if available, fallback to DM
+            if routing in ("supergroup", "both") and thread_id is not None and self._forum_chat_id:
+                delivery_recipient = self._forum_chat_id
+            else:
+                # DM delivery — never pass thread_id to non-forum chats.
+                # If we WANTED the topic but couldn't resolve a thread_id,
+                # surface the fallback so operators know messages are landing
+                # in DM instead of silently disappearing from the forum topic.
+                # (This is the "where did my approval go?" signal that was
+                # missing on 2026-04-10 when 7 approvals routed to DM.)
+                if (
+                    routing in ("supergroup", "both")
+                    and self._forum_chat_id
+                    and self._topic_manager is not None
+                ):
+                    logger.info(
+                        "outreach category=%s wanted supergroup topic "
+                        "routing but thread_id is None — falling back to DM "
+                        "(target category=%s); check earlier ERROR logs from "
+                        "TopicManager for the underlying cause",
+                        request.category.value, topic_cat or "?",
+                    )
+                thread_id = None
 
         # Scan outbound email content for sensitive data patterns
         if channel == "email":

--- a/tests/test_channels/test_email_adapter.py
+++ b/tests/test_channels/test_email_adapter.py
@@ -63,6 +63,50 @@ class TestEmailAdapter:
             sent_msg = mock_smtp.send_message.call_args[0][0]
             assert sent_msg["Subject"] == "Message from Genesis"
 
+    @pytest.mark.asyncio
+    async def test_send_message_does_not_block_event_loop(self, adapter: EmailAdapter) -> None:
+        """A slow SMTP round-trip must not freeze the asyncio event loop.
+
+        Synchronous ``smtplib`` must run in a worker thread; otherwise a blocking
+        send starves the loop — the 2026-06-14 incident where retrying ~200
+        failed sends froze heartbeats, health checks, and the awareness tick.
+        """
+        import asyncio
+        import time
+
+        class _BlockingSMTP:
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args) -> bool:
+                return False
+
+            def login(self, *args) -> None:
+                pass
+
+            def send_message(self, msg) -> None:
+                time.sleep(0.3)  # simulate a slow SMTP round-trip
+
+        progressed = 0
+
+        async def _ticker() -> None:
+            nonlocal progressed
+            while True:
+                await asyncio.sleep(0.01)
+                progressed += 1
+
+        with patch("genesis.channels.email_adapter.smtplib.SMTP_SSL", _BlockingSMTP):
+            ticker = asyncio.create_task(_ticker())
+            await adapter.send_message("recipient@example.com", "body")
+            ticker.cancel()
+
+        # Blocking send → loop frozen for 0.3s → ticker can't advance (~0).
+        # Non-blocking (to_thread) → ticker runs concurrently (~25-30 times).
+        assert progressed >= 5, f"event loop appears blocked during send (ticks={progressed})"
+
     @pytest.mark.anyio
     async def test_engagement_signals_neutral(self, adapter: EmailAdapter) -> None:
         result = await adapter.get_engagement_signals("any-id")

--- a/tests/test_outreach/test_pipeline.py
+++ b/tests/test_outreach/test_pipeline.py
@@ -288,6 +288,103 @@ async def test_alert_submit_passes_system_prompt(config, db, mock_drafter, mock_
     assert draft_request.tone == "urgent"
 
 
+@pytest.fixture
+def supergroup_topic_manager():
+    """A TopicManager that resolves a forum thread_id (as in production)."""
+    tm = MagicMock()
+    tm.resolve_outreach_category.return_value = "general"
+    tm.get_or_create_persistent = AsyncMock(return_value=42)
+    return tm
+
+
+@pytest.mark.asyncio
+async def test_email_delivery_uses_email_recipient_not_forum_chat_id(
+    config, db, mock_drafter, mock_formatter, supergroup_topic_manager
+):
+    """Email sends must NOT have their recipient overwritten with the Telegram
+    forum chat id when the category routes to 'supergroup'.
+
+    Regression for the incident where notification-category follow-up emails
+    were addressed to the Telegram forum chat id (-1003741378738), which Gmail
+    rejects as an invalid RFC 5321 address — poisoning the deferred queue and,
+    via blocking SMTP, starving the event loop. The supergroup/forum routing
+    override is Telegram-only.
+    """
+    email_adapter = AsyncMock()
+    email_adapter.send_message.return_value = "<msgid@example.com>"
+
+    pipeline = OutreachPipeline(
+        governance=GovernanceGate(config, db),
+        drafter=mock_drafter,
+        formatter=mock_formatter,
+        channels={"email": email_adapter},
+        db=db,
+        config=config,
+        recipients={"email": "prospect@example.com"},
+    )
+    pipeline.set_forum_chat_id(-1003741378738)
+    pipeline.set_topic_manager(supergroup_topic_manager)
+
+    request = OutreachRequest(
+        category=OutreachCategory.NOTIFICATION,  # routes to supergroup by default
+        topic="Follow-up",
+        context="Following up on my note about Genesis",
+        salience_score=0.6,
+        signal_type="campaign_follow_up",
+        channel="email",
+    )
+
+    result = await pipeline.submit_raw("Following up on my note", request)
+
+    assert result.status == OutreachStatus.DELIVERED
+    recipient_arg = email_adapter.send_message.call_args[0][0]
+    assert recipient_arg == "prospect@example.com"
+    # message_thread_id is a Telegram concept and must not leak to email
+    assert email_adapter.send_message.call_args[1].get("message_thread_id") is None
+
+
+@pytest.mark.asyncio
+async def test_telegram_supergroup_routing_still_uses_forum_chat_id(
+    config, db, mock_drafter, mock_formatter, supergroup_topic_manager
+):
+    """Regression guard: the channel-gating fix must NOT break Telegram.
+
+    A supergroup-routed category on the Telegram channel must still deliver to
+    the forum chat id with the resolved thread_id (the original 2026-04-10
+    approval-routing behavior).
+    """
+    telegram_adapter = AsyncMock()
+    telegram_adapter.send_message.return_value = "tg-123"
+
+    pipeline = OutreachPipeline(
+        governance=GovernanceGate(config, db),
+        drafter=mock_drafter,
+        formatter=mock_formatter,
+        channels={"telegram": telegram_adapter},
+        db=db,
+        config=config,
+        recipients={"telegram": "12345"},
+    )
+    pipeline.set_forum_chat_id(-1003741378738)
+    pipeline.set_topic_manager(supergroup_topic_manager)
+
+    request = OutreachRequest(
+        category=OutreachCategory.NOTIFICATION,  # routes to supergroup
+        topic="Approval",
+        context="Approve pending action",
+        salience_score=0.6,
+        signal_type="approval",
+        channel="telegram",
+    )
+
+    result = await pipeline.submit_raw("Approve pending action", request)
+
+    assert result.status == OutreachStatus.DELIVERED
+    # Telegram supergroup routing intact: delivered to forum chat id + thread
+    assert telegram_adapter.send_message.call_args[0][0] == "-1003741378738"
+    assert telegram_adapter.send_message.call_args[1].get("message_thread_id") == 42
+
+
 @pytest.mark.asyncio
 async def test_surplus_submit_no_system_prompt(config, db, mock_drafter, mock_formatter, mock_channel):
     """Non-urgent categories should NOT get the alert system prompt."""


### PR DESCRIPTION
## Problem

Outreach on non-Telegram channels (email, Discord, voice) had its recipient overwritten with the Telegram forum chat id whenever a category routed to the supergroup (the default routing). Email sends were therefore addressed to a Telegram chat id, which the SMTP server rejects as an invalid address, so every such send failed and piled up in the deferred-work queue.

Compounding this, `EmailAdapter.send_message` ran synchronous `smtplib` directly inside an `async` function, so each (failing) send blocked the event loop. With the recovery worker retrying the queued failures, this starved heartbeats, health checks, and the awareness loop.

The routing override has been latent since the 2026-03-29 release; it only surfaced once email outreach for a supergroup-routed category became active.

## Fix

1. **`outreach/pipeline.py`** — gate the Telegram supergroup/forum routing (thread-id resolution + `forum_chat_id` override) on `channel == "telegram"`. Other channels now deliver to their own recipient with no thread id. Telegram supergroup/dm/both routing is unchanged.
2. **`channels/email_adapter.py`** — run the blocking `smtplib` send via `asyncio.to_thread` so a slow or rejected send can't freeze the event loop.

## Tests

- `test_pipeline.py`: email recipient is not clobbered by supergroup routing (RED→GREEN) + a Telegram supergroup-routing regression guard.
- `test_email_adapter.py`: a slow SMTP send no longer blocks the event loop (RED→GREEN).
- Full outreach + channels suites pass (382 tests); a live end-to-end send verified the correct recipient under the exact bug condition.

## Review

Independent code review passed with no findings. The external second-opinion reviewer was unavailable (usage limit) and is noted as quota-limited.

## Out of scope (follow-ups)

- Two pre-existing, unrelated test issues surfaced: a rare order-dependent flake in `test_pipeline.py` under random ordering, and `test_load_autonomous_cli_policy_from_yaml` reading local config. Tracked separately.
- Awareness-tick / session-observer lock scoping and the judge-call-site alerting are separate follow-up changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
