### PR TITLE
perf(health): fix /api/genesis/health hang (call_sites N+1, parallelize, bridge timeout)

### DIFF
--- a/src/genesis/dashboard/_blueprint.py
+++ b/src/genesis/dashboard/_blueprint.py
@@ -58,6 +58,11 @@ def _async_route(f=None, *, timeout: float | None = None):
                 try:
                     return future.result(timeout=timeout)
                 except FuturesTimeoutError:
+                    # Cancel the coroutine so it doesn't keep running on the loop
+                    # after we've returned — otherwise repeated polling stacks
+                    # concurrent snapshots (run_coroutine_threadsafe futures
+                    # schedule task cancellation on the loop thread-safely).
+                    future.cancel()
                     logger.warning(
                         "async route %s exceeded %.1fs timeout — returning 503",
                         getattr(fn, "__name__", "?"), timeout or 0.0,

--- a/src/genesis/dashboard/_blueprint.py
+++ b/src/genesis/dashboard/_blueprint.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from functools import wraps
 from pathlib import Path
 
@@ -19,7 +20,7 @@ blueprint = Blueprint(
 )
 
 
-def _async_route(f):
+def _async_route(f=None, *, timeout: float | None = None):
     """Decorator to run async Flask route handlers.
 
     When the Genesis runtime loop is available (stored in
@@ -36,22 +37,42 @@ def _async_route(f):
 
     Falls back to a per-request ``new_event_loop()`` when no runtime loop
     is configured (e.g. during unit tests).
+
+    ``timeout`` (seconds) optionally bounds how long the Flask worker thread
+    waits for the coroutine. On expiry the route returns HTTP 503 instead of
+    blocking indefinitely, so a slow handler can never make the endpoint look
+    dead to the dashboard or the Guardian's health probe. ``None`` (default)
+    preserves the original unbounded behavior — required for long-running
+    routes (reply waiters, approval waits). Usable bare (``@_async_route``)
+    or parametrized (``@_async_route(timeout=15)``).
     """
 
-    @wraps(f)
-    def wrapper(*args, **kwargs):
-        from flask import current_app
+    def decorate(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            from flask import current_app, jsonify
 
-        loop = current_app.config.get("GENESIS_EVENT_LOOP")
-        if loop is not None and loop.is_running():
-            future = asyncio.run_coroutine_threadsafe(f(*args, **kwargs), loop)
-            return future.result()
+            loop = current_app.config.get("GENESIS_EVENT_LOOP")
+            if loop is not None and loop.is_running():
+                future = asyncio.run_coroutine_threadsafe(fn(*args, **kwargs), loop)
+                try:
+                    return future.result(timeout=timeout)
+                except FuturesTimeoutError:
+                    logger.warning(
+                        "async route %s exceeded %.1fs timeout — returning 503",
+                        getattr(fn, "__name__", "?"), timeout or 0.0,
+                    )
+                    return jsonify(
+                        {"status": "unavailable", "error": "request timed out"}
+                    ), 503
 
-        # Fallback for tests or pre-runtime contexts
-        loop = asyncio.new_event_loop()
-        try:
-            return loop.run_until_complete(f(*args, **kwargs))
-        finally:
-            loop.close()
+            # Fallback for tests or pre-runtime contexts
+            loop = asyncio.new_event_loop()
+            try:
+                return loop.run_until_complete(fn(*args, **kwargs))
+            finally:
+                loop.close()
 
-    return wrapper
+        return wrapper
+
+    return decorate(f) if f is not None else decorate

--- a/src/genesis/dashboard/routes/health.py
+++ b/src/genesis/dashboard/routes/health.py
@@ -12,9 +12,16 @@ from genesis.dashboard._blueprint import _async_route, blueprint
 
 logger = logging.getLogger(__name__)
 
+# Bound the health snapshot so a slow/contended snapshot returns 503 fast
+# instead of hanging the Flask worker — which previously made the dashboard
+# spin forever and failed the host Guardian's health probe. The snapshot is
+# ~2s after the call_sites + gather fixes; 15s is a generous never-hang
+# backstop, well under browser/proxy timeouts.
+_HEALTH_SNAPSHOT_TIMEOUT_S = 15.0
+
 
 @blueprint.route("/api/genesis/health")
-@_async_route
+@_async_route(timeout=_HEALTH_SNAPSHOT_TIMEOUT_S)
 async def health_snapshot():
     """Return system health snapshot with bridge status from status.json."""
     from genesis.runtime import GenesisRuntime

--- a/src/genesis/observability/health_data.py
+++ b/src/genesis/observability/health_data.py
@@ -6,6 +6,7 @@ for cleaner organization. Each function takes explicit dependencies as parameter
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
@@ -104,35 +105,58 @@ class HealthDataService:
                     logger.warning("Provider health probe failed", exc_info=True)
             probe_results = self._provider_health.results
 
-        return {
-            "timestamp": now,
-            "call_sites": await call_sites(
+        # Run the independent async sub-snapshots CONCURRENTLY. Serial execution
+        # summed to ~9s (and ballooned to 20s+ under load), hanging the dashboard
+        # and the Guardian's health probe. gather makes the total ≈ max(sub-call)
+        # instead of the sum: aiosqlite serializes DB queries on the single
+        # connection (safe), while network-bound calls (memory_health/Qdrant,
+        # mcp_status) overlap with them and each other.
+        (
+            r_call_sites, r_cc_sessions, r_infrastructure, r_queues, r_surplus,
+            r_cost, r_awareness, r_outreach, r_mcp, r_provider_activity,
+            r_memory_health, r_eval_staleness, r_vcr,
+        ) = await asyncio.gather(
+            call_sites(
                 self._db, self._routing_config, self._breakers,
-                probe_results=probe_results,
-                state_machine=self._state_machine,
+                probe_results=probe_results, state_machine=self._state_machine,
             ),
-            "cc_sessions": await cc_sessions(self._db, self._cc_budget, self._state_machine),
-            "resilience": self._resilience_state(),
-            "infrastructure": await infrastructure(
+            cc_sessions(self._db, self._cc_budget, self._state_machine),
+            infrastructure(
                 self._db, self._routing_config, self._learning_scheduler, self._state_machine
             ),
-            "queues": await queues(
-                self._db, self._deferred_queue, self._dead_letter, self._event_bus
-            ),
-            "surplus": await surplus_status(self._db, self._surplus),
-            "cost": await cost(self._db, self._cost_tracker, self._cc_budget),
-            "awareness": await awareness(self._db),
-            "outreach_stats": await outreach_stats(self._db),
+            queues(self._db, self._deferred_queue, self._dead_letter, self._event_bus),
+            surplus_status(self._db, self._surplus),
+            cost(self._db, self._cost_tracker, self._cc_budget),
+            awareness(self._db),
+            outreach_stats(self._db),
+            mcp_status(),
+            provider_activity(self._activity_tracker),
+            memory_health(self._db),
+            eval_staleness(self._db),
+            self._vcr_snapshot(),
+        )
+
+        return {
+            "timestamp": now,
+            "call_sites": r_call_sites,
+            "cc_sessions": r_cc_sessions,
+            "resilience": self._resilience_state(),
+            "infrastructure": r_infrastructure,
+            "queues": r_queues,
+            "surplus": r_surplus,
+            "cost": r_cost,
+            "awareness": r_awareness,
+            "outreach_stats": r_outreach,
             "services": services(),
             "api_keys": api_key_health(self._routing_config, breakers=self._breakers),
-            "mcp_servers": await mcp_status(),
+            "mcp_servers": r_mcp,
             "conversation": conversation_activity(),
-            "provider_activity": await provider_activity(self._activity_tracker),
+            "provider_activity": r_provider_activity,
             "proactive_memory": proactive_memory_metrics(),
-            "memory_health": await memory_health(self._db),
+            "memory_health": r_memory_health,
             "provider_health": self._serialize_provider_health(),
-            "eval_staleness": await eval_staleness(self._db),
-            "vcr": await self._vcr_snapshot(),
+            "eval_staleness": r_eval_staleness,
+            "vcr": r_vcr,
         }
 
     async def _vcr_snapshot(self) -> dict:

--- a/src/genesis/observability/snapshots/call_sites.py
+++ b/src/genesis/observability/snapshots/call_sites.py
@@ -68,6 +68,27 @@ async def call_sites(
         return {}
 
     result = {}
+
+    # Pre-fetch recent routing-failure events ONCE, then bucket by call site in
+    # memory below. Previously this ran a per-site `message LIKE '%site_id%'`
+    # query — ~one non-indexable full scan of `events` PER call site (~30 scans
+    # per snapshot). That was the dominant cost making /api/genesis/health take
+    # 4-5s and hang under DB contention. One scan instead of N.
+    failure_events: list[tuple] = []
+    if db:
+        try:
+            cutoff = (datetime.now(UTC) - timedelta(minutes=30)).isoformat()
+            async with db.execute(
+                "SELECT message, created_at FROM events "
+                "WHERE event_type IN "
+                "('all_exhausted', 'provider.fallback', 'breaker.tripped') "
+                "AND created_at >= ?",
+                (cutoff,),
+            ) as cursor:
+                failure_events = await cursor.fetchall()
+        except sqlite3.Error:
+            logger.debug("routing-failure events pre-fetch failed", exc_info=True)
+
     for site_id, site_cfg in routing_config.call_sites.items():
         chain_health = []
         first_closed = None
@@ -133,25 +154,15 @@ async def call_sites(
 
         recent_failures = 0
         last_failure_at: str | None = None
-        if db and status in ("healthy", "degraded"):
-            try:
-                cutoff = (datetime.now(UTC) - timedelta(minutes=30)).isoformat()
-                async with db.execute(
-                    "SELECT COUNT(*), MAX(created_at) FROM events "
-                    "WHERE event_type IN "
-                    "('all_exhausted', 'provider.fallback', 'breaker.tripped') "
-                    "AND message LIKE ? "
-                    "AND created_at >= ?",
-                    (f"%{site_id}%", cutoff),
-                ) as cursor:
-                    row = await cursor.fetchone()
-                    if row and row[0] > 0:
-                        recent_failures = row[0]
-                        last_failure_at = row[1]
-                        if status == "healthy" and last_failure_at:
-                            status = "warning"
-            except sqlite3.Error:
-                logger.debug("DB query failed for failure check on %s", site_id, exc_info=True)
+        if status in ("healthy", "degraded") and failure_events:
+            # Bucket the pre-fetched events by site_id — same substring match as
+            # the old per-site LIKE, done in memory (no per-site DB query).
+            matched = [c for (m, c) in failure_events if site_id in (m or "")]
+            if matched:
+                recent_failures = len(matched)
+                last_failure_at = max(matched)
+                if status == "healthy":
+                    status = "warning"
 
         site_data: dict = {
             "status": status,

--- a/tests/test_dashboard/test_async_route.py
+++ b/tests/test_dashboard/test_async_route.py
@@ -1,0 +1,85 @@
+"""Tests for the _async_route bridge — esp. the opt-in timeout backstop.
+
+The dashboard's async routes dispatch their coroutine onto the runtime event
+loop via run_coroutine_threadsafe and block the Flask worker thread on
+future.result(). Without a timeout, a slow/contended snapshot makes the
+endpoint hang indefinitely (the dashboard "spins forever" and the host
+Guardian's health probe times out). The opt-in timeout returns 503 instead.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+from flask import Flask
+
+from genesis.dashboard._blueprint import _async_route
+
+
+def _running_loop() -> asyncio.AbstractEventLoop:
+    loop = asyncio.new_event_loop()
+    t = threading.Thread(target=lambda: (asyncio.set_event_loop(loop), loop.run_forever()), daemon=True)
+    t.start()
+    deadline = time.monotonic() + 5
+    while not loop.is_running() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    return loop
+
+
+def test_async_route_timeout_returns_503():
+    """A handler that exceeds its timeout returns 503, not a hang."""
+    loop = _running_loop()
+    app = Flask(__name__)
+    app.config["GENESIS_EVENT_LOOP"] = loop
+
+    @_async_route(timeout=0.2)
+    async def slow():
+        await asyncio.sleep(5)
+        return "should not reach"
+
+    try:
+        start = time.monotonic()
+        with app.test_request_context("/"):
+            body, status = slow()
+        elapsed = time.monotonic() - start
+        assert status == 503
+        assert elapsed < 2  # returned promptly on timeout, did not wait 5s
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+
+
+def test_async_route_no_timeout_completes_normally():
+    """Bare @_async_route (no timeout) preserves unbounded behavior."""
+    loop = _running_loop()
+    app = Flask(__name__)
+    app.config["GENESIS_EVENT_LOOP"] = loop
+
+    @_async_route
+    async def fast():
+        await asyncio.sleep(0.01)
+        return "ok"
+
+    try:
+        with app.test_request_context("/"):
+            assert fast() == "ok"
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+
+
+def test_async_route_timeout_allows_fast_handler():
+    """A handler well under its timeout returns its value normally."""
+    loop = _running_loop()
+    app = Flask(__name__)
+    app.config["GENESIS_EVENT_LOOP"] = loop
+
+    @_async_route(timeout=5)
+    async def quick():
+        await asyncio.sleep(0.01)
+        return "fine"
+
+    try:
+        with app.test_request_context("/"):
+            assert quick() == "fine"
+    finally:
+        loop.call_soon_threadsafe(loop.stop)

--- a/tests/test_health_data.py
+++ b/tests/test_health_data.py
@@ -274,6 +274,65 @@ class TestProviderHealth:
         assert _provider_health({"state": "open", "probe_status": "not_configured"}) == "disabled"
 
 
+class TestCallSiteRecentFailures:
+    """Recent-failure bucketing from the events table (single-query path)."""
+
+    @pytest.mark.asyncio
+    async def test_recent_failures_bucketed_with_one_events_query(self):
+        from datetime import UTC, datetime
+
+        import aiosqlite
+
+        from genesis.db.schema import create_all_tables
+        from genesis.observability.snapshots.call_sites import call_sites
+
+        db = await aiosqlite.connect(":memory:")
+        db.row_factory = aiosqlite.Row
+        await create_all_tables(db)
+        now = datetime.now(UTC).isoformat()
+        for eid, et, msg in [
+            ("e1", "all_exhausted", "All providers exhausted for judge"),
+            ("e2", "provider.fallback", "Call site judge: primary failed"),
+            ("e3", "breaker.tripped", "Circuit breaker tripped for other_site"),
+        ]:
+            await db.execute(
+                "INSERT INTO events (id, timestamp, subsystem, severity, event_type, "
+                "message, created_at) VALUES (?,?,?,?,?,?,?)",
+                (eid, now, "routing", "warning", et, msg, now),
+            )
+        await db.commit()
+
+        providers = {"a": _make_provider("a")}
+        config = _make_config(providers, {
+            "judge": CallSiteConfig(id="judge", chain=["a"]),
+            "other_site": CallSiteConfig(id="other_site", chain=["a"]),
+        })
+        registry = _mock_registry({"a": _mock_breaker(ProviderState.CLOSED)})
+
+        # Count `FROM events` queries to prove the N+1 collapse: exactly ONE
+        # pre-fetch regardless of call-site count (was one-per-site before).
+        orig_execute = db.execute
+        n_events_q = {"n": 0}
+
+        def _counting(sql, *a, **k):
+            if "FROM events" in sql:
+                n_events_q["n"] += 1
+            return orig_execute(sql, *a, **k)
+
+        db.execute = _counting  # type: ignore[assignment]
+        result = await call_sites(
+            db=db, routing_config=config, breakers=registry, probe_results=None,
+        )
+        db.execute = orig_execute  # type: ignore[assignment]
+
+        assert result["judge"]["recent_failures"] == 2
+        assert result["judge"]["status"] == "warning"
+        assert result["judge"]["last_failure_at"] == now
+        assert result["other_site"]["recent_failures"] == 1
+        assert n_events_q["n"] == 1, f"expected 1 events query, got {n_events_q['n']} (N+1?)"
+        await db.close()
+
+
 class TestDisabledChainSemantics:
     """Disabled providers must be filtered, not treated as failures.
 


### PR DESCRIPTION
## Problem

`GET /api/genesis/health` was taking 9-20s and hanging the dashboard (spinning forever) and the host Guardian's health probe. Root cause was found by **instrumenting `snapshot()` and measuring** (not guessing — earlier theories about the guardian SSH probe and event-loop contention were disproved):

```
SNAPSHOT_TIMINGS total≈9s: call_sites 4.1-4.9s, memory_health ~2s, probe_all ~2s, awareness ~1s, rest <0.3s
```

`call_sites` ran a **per-call-site `message LIKE '%site_id%'` query** — ~30 non-indexable full scans of the `events` table per snapshot — and the ~17 sub-calls ran serially.

## Fix

1. **`call_sites` N+1 → one scan** (`observability/snapshots/call_sites.py`): pre-fetch the recent routing-failure events once, bucket by `site_id` in memory (same substring match as the old `LIKE`). ~30 scans → 1.
2. **Parallelize the snapshot** (`observability/health_data.py`): run the independent async sub-calls via `asyncio.gather` — total ≈ max(sub-call) instead of the sum; network-bound calls (Qdrant, MCP) overlap the serialized aiosqlite queries.
3. **Opt-in async-route timeout** (`dashboard/_blueprint.py`, `routes/health.py`): the health route returns HTTP 503 after 15s instead of blocking the Flask worker indefinitely on `future.result()`. Default (None) preserves unbounded behavior for long-running routes (reply waiters, approval waits). Timed-out coroutines are cancelled so they don't stack under polling.

Net: the health snapshot drops from ~9-20s to ~2s, and the endpoint can never hang regardless of any single sub-call's latency — so a degraded subsystem can't blind the dashboard or the Guardian.

## Tests

- `call_sites` bucketing test asserts correct per-site failure counts AND **exactly one** events query (guards against N+1 regression).
- `_async_route` timeout tests: slow handler → 503 promptly; bare decorator and fast handlers unaffected.
- Full sweep: 295 passed across `test_health_data` + `test_dashboard` + `test_observability`; ruff clean.

## Review

Independent code review: no P1; one P2 (timed-out coroutine should be cancelled) fixed in this branch. The external second-opinion reviewer is quota-limited and noted as such.

## Verification (post-merge)

Deploy + confirm against the live state: `/api/genesis/health` returns fast and the dashboard loads **while the Guardian is still down** — direct proof the snapshot no longer hangs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
