### PR TITLE
perf(health): cache /health snapshot briefly (30s TTL)

### DIFF
--- a/src/genesis/dashboard/routes/health.py
+++ b/src/genesis/dashboard/routes/health.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from pathlib import Path
 
 from flask import jsonify, request
@@ -19,6 +20,16 @@ logger = logging.getLogger(__name__)
 # backstop, well under browser/proxy timeouts.
 _HEALTH_SNAPSHOT_TIMEOUT_S = 15.0
 
+# Snapshot cache — the full snapshot is ~2s; cache it briefly so frequent
+# dashboard/Guardian polls are served instantly without recomputing every time.
+# Defense-in-depth atop the call_sites + gather speedups: even if the snapshot
+# ever regresses, the cache (plus the route timeout) keeps /health responsive
+# and cuts repeated load. Bridge status and the healthy/unhealthy verdict are
+# still computed fresh per request; only the expensive snapshot() is cached.
+_snapshot_cache: dict | None = None
+_snapshot_cache_ts: float = 0.0
+_SNAPSHOT_CACHE_TTL_S = 30.0
+
 
 @blueprint.route("/api/genesis/health")
 @_async_route(timeout=_HEALTH_SNAPSHOT_TIMEOUT_S)
@@ -30,7 +41,15 @@ async def health_snapshot():
     if not rt.is_bootstrapped or rt.health_data is None:
         return jsonify({"status": "unhealthy", "error": "not bootstrapped"}), 503
 
-    snapshot = await rt.health_data.snapshot()
+    global _snapshot_cache, _snapshot_cache_ts
+    now_mono = time.monotonic()
+    if _snapshot_cache is not None and (now_mono - _snapshot_cache_ts) < _SNAPSHOT_CACHE_TTL_S:
+        snapshot = dict(_snapshot_cache)
+    else:
+        fresh = await rt.health_data.snapshot()
+        _snapshot_cache = fresh
+        _snapshot_cache_ts = now_mono
+        snapshot = dict(fresh)
 
     status_path = Path.home() / ".genesis" / "status.json"
     bridge_health = None

--- a/tests/test_dashboard/test_health_cache.py
+++ b/tests/test_dashboard/test_health_cache.py
@@ -1,0 +1,82 @@
+"""Tests for the /api/genesis/health snapshot cache (TTL).
+
+The full snapshot is ~2s; the route caches it briefly so frequent polls are
+served instantly and don't recompute every request. These tests exercise the
+undecorated coroutine (`__wrapped__`) directly so we avoid the cross-thread
+event-loop machinery of _async_route and just verify the cache logic.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from genesis.dashboard.routes import health as health_route
+
+
+def _fake_runtime(counter: dict):
+    async def _snapshot():
+        counter["n"] += 1
+        return {"infrastructure": {"genesis.db": {"status": "healthy"}}, "timestamp": "t"}
+
+    rt = MagicMock()
+    rt.is_bootstrapped = True
+    rt.health_data = MagicMock()
+    rt.health_data.snapshot = _snapshot
+    return rt
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_within_ttl_computes_once():
+    health_route._snapshot_cache = None
+    health_route._snapshot_cache_ts = 0.0
+    calls = {"n": 0}
+    rt = _fake_runtime(calls)
+    app = Flask(__name__)
+
+    with patch("genesis.runtime.GenesisRuntime") as GR:
+        GR.instance.return_value = rt
+        with app.test_request_context("/api/genesis/health"):
+            await health_route.health_snapshot.__wrapped__()
+            await health_route.health_snapshot.__wrapped__()
+
+    # Two requests within the TTL → snapshot() computed exactly once.
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_recomputes_after_ttl():
+    health_route._snapshot_cache = None
+    health_route._snapshot_cache_ts = 0.0
+    calls = {"n": 0}
+    rt = _fake_runtime(calls)
+    app = Flask(__name__)
+
+    with patch("genesis.runtime.GenesisRuntime") as GR:
+        GR.instance.return_value = rt
+        with app.test_request_context("/api/genesis/health"):
+            await health_route.health_snapshot.__wrapped__()
+            # Force the cache to look stale (older than the TTL).
+            health_route._snapshot_cache_ts -= health_route._SNAPSHOT_CACHE_TTL_S + 1
+            await health_route.health_snapshot.__wrapped__()
+
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_cache_does_not_taint_on_per_request_mutation():
+    """Bridge/status added per request must not pollute the cached snapshot."""
+    health_route._snapshot_cache = None
+    health_route._snapshot_cache_ts = 0.0
+    calls = {"n": 0}
+    rt = _fake_runtime(calls)
+    app = Flask(__name__)
+
+    with patch("genesis.runtime.GenesisRuntime") as GR:
+        GR.instance.return_value = rt
+        with app.test_request_context("/api/genesis/health"):
+            await health_route.health_snapshot.__wrapped__()
+            # The cached snapshot should not carry the per-request "bridge"/"status"
+            assert "bridge" not in health_route._snapshot_cache
+            assert "status" not in health_route._snapshot_cache


### PR DESCRIPTION
Defense-in-depth on top of #640: the snapshot is ~2s; cache it 30s so frequent dashboard/Guardian polls are instant and don't recompute each request. Bridge status + healthy verdict stay fresh per request; only snapshot() is cached (shallow copy, no taint). Tests: cache-hit-within-TTL, recompute-after-TTL, no-taint. Reconciles a route cache another session had drafted into a committed change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)