### PR TITLE
fix(awareness): run session observer out-of-band of the tick lock

### DIFF
--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -371,6 +371,10 @@ class AwarenessLoop:
         self._interval = interval_minutes
         self._scheduler = AsyncIOScheduler()
         self._tick_lock = asyncio.Lock()
+        # Single-flight guard for the session observer, which now runs
+        # out-of-band (no longer serialized by _tick_lock). Prevents
+        # overlapping runs from racing the .jsonl→.processing file renames.
+        self._session_observer_lock = asyncio.Lock()
         self._event_bus = event_bus
         self._reflection_engine = reflection_engine
         self._cc_reflection_bridge = cc_reflection_bridge
@@ -739,20 +743,29 @@ class AwarenessLoop:
                 except Exception:
                     logger.warning("Sentinel fire alarm check failed", exc_info=True)
 
-            # Session observer — process pending tool observations into memories
-            if self._session_observer_fn:
-                try:
-                    obs_result = await self._session_observer_fn()
-                    if obs_result and obs_result.notes_stored > 0:
-                        logger.info(
-                            "Session observer: %d notes from %d observations",
-                            obs_result.notes_stored, obs_result.observations_read,
-                        )
-                except Exception:
-                    logger.warning("Session observer processing failed", exc_info=True)
+            # NOTE: the session observer used to run here, awaited inside the
+            # tick lock. It made an LLM call that, under provider exhaustion,
+            # held the lock for 16+ min and starved the heartbeat. It is now
+            # dispatched OUT-OF-BAND below (single-flight guarded).
 
         if result is None:
             return
+
+        from genesis.util.tasks import tracked_task
+
+        # Session observer: process tool observations into memories. Dispatched
+        # OUT-OF-BAND (previously awaited inside the tick lock) so the heartbeat
+        # fires on cadence even when its LLM call grinds through an exhausted
+        # provider chain. Single-flight (_session_observer_lock) prevents
+        # overlapping ticks from racing the observation-file renames. Runs
+        # regardless of the pause kill-switch (internal memory work, no external
+        # dispatch) — matching the prior in-lock behavior.
+        if self._session_observer_fn:
+            tracked_task(
+                self._run_session_observer(),
+                name=f"session-observer-{result.tick_id[:8]}",
+                subsystem=Subsystem.AWARENESS,
+            )
 
         # Kill switch — tick/heartbeats still run but no dispatches when paused
         try:
@@ -762,8 +775,6 @@ class AwarenessLoop:
                 return
         except Exception:
             pass
-
-        from genesis.util.tasks import tracked_task
 
         if result.classified_depth is not None:
             tracked_task(
@@ -788,6 +799,32 @@ class AwarenessLoop:
                 name=f"sentinel-resume-{result.tick_id[:8]}",
                 subsystem=Subsystem.AWARENESS,
             )
+
+    async def _run_session_observer(self) -> None:
+        """Run the session observer with single-flight (out-of-band of the tick).
+
+        If a prior run is still in progress (e.g. its LLM call is grinding
+        through an exhausted provider chain), skip this tick's run rather than
+        overlap — overlapping runs would race the observer's atomic
+        ``.jsonl→.processing`` file renames. The ``locked()`` check followed by
+        ``async with`` is safe in asyncio: there is no ``await`` between them, so
+        no other coroutine can acquire the lock in the gap.
+        """
+        if self._session_observer_fn is None:
+            return
+        if self._session_observer_lock.locked():
+            logger.debug("Session observer still running from a prior tick — skipping")
+            return
+        async with self._session_observer_lock:
+            try:
+                obs_result = await self._session_observer_fn()
+                if obs_result and obs_result.notes_stored > 0:
+                    logger.info(
+                        "Session observer: %d notes from %d observations",
+                        obs_result.notes_stored, obs_result.observations_read,
+                    )
+            except Exception:
+                logger.warning("Session observer processing failed", exc_info=True)
 
     async def _dispatch_reflection(self, result: TickResult) -> None:
         depth = result.classified_depth

--- a/src/genesis/memory/session_observer.py
+++ b/src/genesis/memory/session_observer.py
@@ -289,84 +289,91 @@ async def process_pending_observations(
     for _path, observations in all_observations:
         batch.extend(observations)
 
-    # Split into LLM-sized batches
-    for batch_start in range(0, len(batch), MAX_OBS_PER_LLM_CALL):
-        if time.monotonic() - start > MAX_PROCESSING_TIME_S:
-            logger.info("Session observer hit time budget, stopping")
-            break
+    # Split into LLM-sized batches. The whole loop is wrapped in try/finally so
+    # that if it's cancelled mid-flight (e.g. server shutdown cancels this
+    # out-of-band task while an LLM call is in progress), the renamed
+    # `.processing` files are still restored to `.jsonl` and reprocessed next
+    # tick — otherwise they'd be orphaned (the finder only scans `.jsonl`) and
+    # those observations lost. CancelledError is a BaseException, so the inner
+    # per-batch `except Exception` does not swallow it; it reaches this finally.
+    try:
+        for batch_start in range(0, len(batch), MAX_OBS_PER_LLM_CALL):
+            if time.monotonic() - start > MAX_PROCESSING_TIME_S:
+                logger.info("Session observer hit time budget, stopping")
+                break
 
-        batch_slice = batch[batch_start:batch_start + MAX_OBS_PER_LLM_CALL]
-        obs_text = _format_observations_for_prompt(batch_slice)
-        prompt = OBSERVER_PROMPT.replace("{observations_text}", obs_text)
+            batch_slice = batch[batch_start:batch_start + MAX_OBS_PER_LLM_CALL]
+            obs_text = _format_observations_for_prompt(batch_slice)
+            prompt = OBSERVER_PROMPT.replace("{observations_text}", obs_text)
 
-        try:
-            # 21_session_observer — session-observer-driven memory writes.
-            # Routes via the free chain for opportunistic context capture.
-            response = await router.route_call(
-                call_site_id="21_session_observer",
-                messages=[{"role": "user", "content": prompt}],
-            )
-            result.llm_calls += 1
-
-            if not response.success:
-                logger.warning("Session observer LLM call failed: %s", response.error)
-                result.errors += 1
-                continue
-
-            notes = _parse_notes(response.content)
-            result.notes_extracted += len(notes)
-
-            # Store each note as a memory
-            for note in notes:
-                try:
-                    content = f"[{note.note_type}] {note.title}\n{note.narrative}"
-                    tags = ["session_note", note.note_type]
-                    tags.extend(note.concepts[:3])
-
-                    wing = _infer_wing_from_files(note.files)
-
-                    await store.store(
-                        content=content,
-                        source="session_observer",
-                        memory_type="episodic",
-                        tags=tags,
-                        confidence=0.6,
-                        source_pipeline="session_observer",
-                        wing=wing,
-                    )
-                    result.notes_stored += 1
-                except Exception:
-                    logger.warning("Failed to store session note: %s", note.title, exc_info=True)
-                    result.errors += 1
-
-        except Exception:
-            logger.warning("Session observer batch processing failed", exc_info=True)
-            result.errors += 1
-
-    # Clean up processing files — already fully read, safe to remove
-    for processing_path, _observations in all_observations:
-        try:
-            processing_path.unlink(missing_ok=True)
-        except OSError:
-            logger.warning("Failed to remove %s", processing_path, exc_info=True)
-
-    # Also clean up any processing files we didn't read (budget exceeded)
-    for _original, processing_path in processing_files:
-        if processing_path.exists():
             try:
-                # These had observations we didn't process — rename back
-                # so they're picked up next tick
-                original = processing_path.with_suffix(".jsonl")
-                if original.exists():
-                    # Original was recreated by hook — append our unprocessed
-                    # data to the new file
-                    with open(original, "a") as dst, open(processing_path) as src:
-                        dst.write(src.read())
-                    processing_path.unlink(missing_ok=True)
-                else:
-                    os.rename(processing_path, original)
+                # 21_session_observer — session-observer-driven memory writes.
+                # Routes via the free chain for opportunistic context capture.
+                response = await router.route_call(
+                    call_site_id="21_session_observer",
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                result.llm_calls += 1
+
+                if not response.success:
+                    logger.warning("Session observer LLM call failed: %s", response.error)
+                    result.errors += 1
+                    continue
+
+                notes = _parse_notes(response.content)
+                result.notes_extracted += len(notes)
+
+                # Store each note as a memory
+                for note in notes:
+                    try:
+                        content = f"[{note.note_type}] {note.title}\n{note.narrative}"
+                        tags = ["session_note", note.note_type]
+                        tags.extend(note.concepts[:3])
+
+                        wing = _infer_wing_from_files(note.files)
+
+                        await store.store(
+                            content=content,
+                            source="session_observer",
+                            memory_type="episodic",
+                            tags=tags,
+                            confidence=0.6,
+                            source_pipeline="session_observer",
+                            wing=wing,
+                        )
+                        result.notes_stored += 1
+                    except Exception:
+                        logger.warning("Failed to store session note: %s", note.title, exc_info=True)
+                        result.errors += 1
+
+            except Exception:
+                logger.warning("Session observer batch processing failed", exc_info=True)
+                result.errors += 1
+
+        # Clean up processing files — already fully read, safe to remove
+        for processing_path, _observations in all_observations:
+            try:
+                processing_path.unlink(missing_ok=True)
             except OSError:
-                logger.warning("Failed to restore %s", processing_path, exc_info=True)
+                logger.warning("Failed to remove %s", processing_path, exc_info=True)
+    finally:
+        # Restore any `.processing` files still on disk. On normal completion
+        # these are the budget-exceeded/unread ones; on cancellation this
+        # restores everything not yet consumed so it's reprocessed next tick.
+        for _original, processing_path in processing_files:
+            if processing_path.exists():
+                try:
+                    original = processing_path.with_suffix(".jsonl")
+                    if original.exists():
+                        # Original was recreated by hook — append our unprocessed
+                        # data to the new file.
+                        with open(original, "a") as dst, open(processing_path) as src:
+                            dst.write(src.read())
+                        processing_path.unlink(missing_ok=True)
+                    else:
+                        os.rename(processing_path, original)
+                except OSError:
+                    logger.warning("Failed to restore %s", processing_path, exc_info=True)
 
     result.files_processed = len(all_observations)
     result.elapsed_s = time.monotonic() - start

--- a/tests/test_awareness/test_session_observer_decouple.py
+++ b/tests/test_awareness/test_session_observer_decouple.py
@@ -1,0 +1,82 @@
+"""Tests for decoupling the session observer from the awareness tick.
+
+The session observer used to be awaited INSIDE the tick lock; under provider
+exhaustion its LLM call held the lock 16+ min and starved the heartbeat. It now
+runs out-of-band via tracked_task with an asyncio.Lock single-flight guard.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from genesis.awareness.loop import AwarenessLoop
+
+
+@pytest.mark.asyncio
+async def test_on_tick_dispatches_observer_out_of_band(db, monkeypatch):
+    """_on_tick must hand the observer to tracked_task, NOT await it inline."""
+    loop = AwarenessLoop(db=db, collectors=[])
+
+    observer_awaited = {"v": False}
+
+    async def _observer():
+        observer_awaited["v"] = True
+
+    loop.set_session_observer(_observer)
+
+    dispatched_names: list[str] = []
+
+    def _fake_tracked_task(coro, *, name="", **kw):
+        dispatched_names.append(name)
+        coro.close()  # record the dispatch without running it
+        return None
+
+    monkeypatch.setattr("genesis.util.tasks.tracked_task", _fake_tracked_task)
+
+    await loop._on_tick()
+
+    # The observer was dispatched as an out-of-band task, never awaited in-tick.
+    assert any(n.startswith("session-observer-") for n in dispatched_names)
+    assert observer_awaited["v"] is False
+
+
+@pytest.mark.asyncio
+async def test_run_session_observer_single_flight(db):
+    """A second run is skipped while a prior one still holds the lock."""
+    loop = AwarenessLoop(db=db, collectors=[])
+
+    calls = {"n": 0}
+    release = asyncio.Event()
+
+    async def _slow_observer():
+        calls["n"] += 1
+        await release.wait()  # hold the lock until released
+        return None
+
+    loop.set_session_observer(_slow_observer)
+
+    first = asyncio.create_task(loop._run_session_observer())
+    await asyncio.sleep(0.05)  # let `first` acquire the lock and start
+
+    # Second invocation while the lock is held → skipped (no second call).
+    await loop._run_session_observer()
+    assert calls["n"] == 1
+
+    release.set()
+    await first
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_run_session_observer_swallows_errors(db):
+    """A failing observer must not raise out of the out-of-band runner."""
+    loop = AwarenessLoop(db=db, collectors=[])
+
+    async def _boom():
+        raise RuntimeError("observer blew up")
+
+    loop.set_session_observer(_boom)
+    await loop._run_session_observer()  # must not raise
+    # lock released even after failure → a subsequent run can proceed
+    assert not loop._session_observer_lock.locked()


### PR DESCRIPTION
## Problem (verified by measurement)

The awareness tick awaited `session_observer` INSIDE `_tick_lock`. Under provider exhaustion its LLM call (45s budget only checked *between* batches) ground through the chain for 16+ min, holding the lock and starving the heartbeat — APScheduler dropped ticks (`tick.max_instances`) and the host Guardian's health probe failed.

## Fix (architect-reviewed)

- **Out-of-band dispatch**: `session_observer` now runs via `tracked_task` (like reflections) so the tick fires on cadence regardless of provider state.
- **Single-flight guard** (`_session_observer_lock`): prevents overlapping runs from racing the observer's `.jsonl→.processing` renames. The `locked()`-then-`async with` pattern is asyncio-safe (no await in the gap).
- **Cancellation-safe cleanup**: the observer's processing-file restore is now in `try/finally`, so a shutdown mid-LLM-call restores `.processing` files instead of orphaning the observations.
- guardian-watchdog SSH (also in-lock, ~15s bounded) left as a follow-up.

## Tests
- Out-of-band dispatch (handed to tracked_task, not awaited inline), single-flight skip, error-swallowing. 136 passed across test_awareness + session_observer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)