### PR TITLE
fix(memory): reference mirror renders reference.* only + refresh on boot

### DIFF
--- a/src/genesis/memory/reference_mirror.py
+++ b/src/genesis/memory/reference_mirror.py
@@ -1,7 +1,10 @@
 """Markdown mirror of the reference store at ~/.genesis/known-to-genesis.md.
 
 Read-only human view. Regenerated on reference_store / reference_delete /
-reference_export operations. NOT a source of truth — the database is.
+reference_export operations and once at memory init (boot) so references added
+by non-triggering paths (extraction job, bulk imports) still surface. Only
+genuine reference kinds (``domain`` like ``reference.*``) are rendered. NOT a
+source of truth — the database is.
 """
 
 from __future__ import annotations
@@ -80,8 +83,14 @@ async def regenerate_mirror(db: aiosqlite.Connection) -> Path:
         for entry in entries:
             lines.extend(_render_entry(entry, domain_key))
 
-    # Any domains not in _DOMAIN_ORDER (future-proofing).
+    # Any reference.* domains not in _DOMAIN_ORDER (future-proofing). Only
+    # genuine reference kinds (domain "reference.*") belong in the human
+    # reference view — skip anything else so a row mis-tagged
+    # project_type='reference' with a non-reference domain (e.g. bulk-curated
+    # knowledge) can't leak into the mirror.
     for domain_key, entries in sorted(grouped.items()):
+        if not domain_key.startswith("reference."):
+            continue
         total += len(entries)
         heading = domain_key.removeprefix("reference.").replace("_", " ").title()
         lines.append(f"## {heading}")

--- a/src/genesis/runtime/init/memory.py
+++ b/src/genesis/runtime/init/memory.py
@@ -66,6 +66,18 @@ async def init(rt: GenesisRuntime) -> None:
         # URLs, IPs) that belong alongside episodic memories.
         await _migrate_reference_vectors(qdrant, rt._db)
 
+        # Refresh the human-readable reference mirror (~/.genesis/known-to-genesis.md)
+        # on boot so it reflects references added by paths that don't trigger it
+        # live (e.g. the extraction job, bulk imports). reference_store/delete/export
+        # keep it fresh during a session; this catches everything else each restart.
+        try:
+            from genesis.memory.reference_mirror import regenerate_mirror
+            await regenerate_mirror(rt._db)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("reference mirror boot refresh failed", exc_info=True)
+
         # Split embedding chains: storage (Ollama first) vs recall (cloud first).
         # Both share the same L2 diskcache — cache keys are text-based, not
         # provider-dependent, so a write cached via Ollama is instantly

--- a/src/genesis/runtime/init/memory.py
+++ b/src/genesis/runtime/init/memory.py
@@ -70,13 +70,7 @@ async def init(rt: GenesisRuntime) -> None:
         # on boot so it reflects references added by paths that don't trigger it
         # live (e.g. the extraction job, bulk imports). reference_store/delete/export
         # keep it fresh during a session; this catches everything else each restart.
-        try:
-            from genesis.memory.reference_mirror import regenerate_mirror
-            await regenerate_mirror(rt._db)
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.warning("reference mirror boot refresh failed", exc_info=True)
+        await _refresh_reference_mirror(rt._db)
 
         # Split embedding chains: storage (Ollama first) vs recall (cloud first).
         # Both share the same L2 diskcache — cache keys are text-based, not
@@ -228,6 +222,23 @@ async def init(rt: GenesisRuntime) -> None:
         )
         from genesis.runtime._degradation import record_init_degradation
         await record_init_degradation(rt._db, rt._event_bus, "memory", "MemoryStore", str(exc), severity="error")
+
+
+async def _refresh_reference_mirror(db: aiosqlite.Connection) -> None:
+    """Regenerate the reference mirror on boot — best-effort, non-fatal.
+
+    Surfaces references added by paths that don't refresh the mirror live
+    (extraction job, bulk imports). The mirror is a derived view, not a source
+    of truth, so a failure is logged and swallowed — but a mid-boot cancel must
+    still propagate so shutdown isn't blocked.
+    """
+    try:
+        from genesis.memory.reference_mirror import regenerate_mirror
+        await regenerate_mirror(db)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.warning("reference mirror boot refresh failed", exc_info=True)
 
 
 async def _migrate_reference_vectors(

--- a/tests/test_memory/test_reference_mirror.py
+++ b/tests/test_memory/test_reference_mirror.py
@@ -104,6 +104,28 @@ class TestRegenerateMirror:
         assert "### Custom" in content
 
     @pytest.mark.asyncio
+    async def test_mistagged_non_reference_domain_excluded(self, db, tmp_path, monkeypatch):
+        """A project_type='reference' row whose domain is NOT reference.* (e.g.
+        bulk-curated knowledge mis-tagged as a reference) must not leak into the
+        human reference mirror — only genuine reference kinds belong there."""
+        mirror_path = tmp_path / "known-to-genesis.md"
+        monkeypatch.setattr(
+            "genesis.memory.reference_mirror._MIRROR_PATH", mirror_path,
+        )
+        await _insert_ref(
+            db, domain="reference.url", concept="RealRef", body="real ref body",
+        )
+        await _insert_ref(
+            db, domain="cloud_architecture", concept="MistaggedKnowledge",
+            body="curated knowledge, not a reference",
+        )
+        await regenerate_mirror(db)
+        content = mirror_path.read_text()
+        assert "### RealRef" in content  # genuine reference still rendered
+        assert "MistaggedKnowledge" not in content  # mis-tagged row excluded
+        assert "Cloud Architecture" not in content  # and no heading for it
+
+    @pytest.mark.asyncio
     async def test_non_credential_value_not_redacted(self, db, tmp_path, monkeypatch):
         mirror_path = tmp_path / "known-to-genesis.md"
         monkeypatch.setattr(

--- a/tests/test_runtime/test_boot_mirror_refresh.py
+++ b/tests/test_runtime/test_boot_mirror_refresh.py
@@ -1,0 +1,48 @@
+"""Tests for the best-effort reference-mirror boot refresh.
+
+`init()` regenerates the human-readable reference mirror once at startup so
+references added by non-triggering paths (extraction job, bulk imports) surface
+after a restart. The refresh is best-effort: a failure is swallowed (the mirror
+is a derived view, not a source of truth), but a mid-boot cancel must propagate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from genesis.runtime.init import memory as init_memory
+
+
+@pytest.mark.asyncio
+async def test_refresh_calls_regenerate(monkeypatch):
+    """Happy path: the boot refresh forwards the db to regenerate_mirror."""
+    regen = AsyncMock()
+    # The helper imports regenerate_mirror at call time, so patch the source.
+    monkeypatch.setattr("genesis.memory.reference_mirror.regenerate_mirror", regen)
+
+    db = object()
+    await init_memory._refresh_reference_mirror(db)
+
+    regen.assert_awaited_once_with(db)
+
+
+@pytest.mark.asyncio
+async def test_refresh_swallows_exceptions(monkeypatch):
+    """A regenerate failure must not crash boot — a stale mirror is acceptable."""
+    regen = AsyncMock(side_effect=RuntimeError("db locked"))
+    monkeypatch.setattr("genesis.memory.reference_mirror.regenerate_mirror", regen)
+
+    await init_memory._refresh_reference_mirror(object())  # no raise
+
+
+@pytest.mark.asyncio
+async def test_refresh_propagates_cancellation(monkeypatch):
+    """CancelledError is re-raised so a mid-boot SIGTERM isn't swallowed."""
+    regen = AsyncMock(side_effect=asyncio.CancelledError)
+    monkeypatch.setattr("genesis.memory.reference_mirror.regenerate_mirror", regen)
+
+    with pytest.raises(asyncio.CancelledError):
+        await init_memory._refresh_reference_mirror(object())


### PR DESCRIPTION
## What

The `known-to-genesis.md` reference mirror rendered every `project_type='reference'` row — including bulk-curated knowledge mis-tagged with non-`reference.*` domains — and only regenerated on `reference_store`/`delete`/`export`. References added by other paths (the extraction job, bulk imports) never refreshed it, so the file drifted stale and polluted.

## Changes

- **`reference_mirror.py`** — the catch-all for non-ordered domains now skips anything whose domain isn't `reference.*`, so a row mis-tagged `project_type='reference'` with a non-reference domain can't leak into the human reference view.
- **`runtime/init/memory.py`** — regenerate the mirror once on boot (guarded; re-raises `CancelledError` so a mid-boot SIGTERM isn't swallowed), so references added by non-triggering paths surface on the next restart.
- **`test_reference_mirror.py`** — covers the mis-tagged-exclusion case.

## Verification

- `pytest tests/test_memory/test_reference_mirror.py` → 9 passed
- `ruff check` clean

## Scope note

This is the **code half** of a larger reference-store repair. The data cleanup (re-embedding a straggler reference so it's findable via `reference_lookup`, removing an orphaned vector, reclassifying mis-tagged curated rows) is intentionally **deferred to a separate change** while the production DB is stabilized — it requires a server stop + bulk SQLite/Qdrant writes and is not safe to run yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)