### PR TITLE
fix(db): release MCP read snapshots + serialize connections to stop WAL pin (WS-15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Memory storage no longer gets wedged on "database is locked"** — a
+  long-lived MCP database connection left read transactions open after read-only
+  tool calls, which pinned the SQLite write-ahead log (it could grow to
+  gigabytes on disk) and made `memory_store` / `reference_store` fail until a
+  restart. MCP tool calls now release their database snapshot at each call
+  boundary, and the MCP connections are serialized to prevent transaction-state
+  corruption — so writes keep working and the WAL stays bounded.
 - **Outreach emails actually send now** — email (and Discord/voice) outreach was
   being misaddressed to the Telegram forum chat for any category that routes to
   the supergroup, so every such send failed and silently piled up as retries.

--- a/scripts/genesis_mcp_server.py
+++ b/scripts/genesis_mcp_server.py
@@ -141,14 +141,12 @@ def _bootstrap_health(transport_kwargs: dict) -> None:
 
     @asynccontextmanager
     async def _lifespan(server) -> AsyncIterator[None]:
-        import aiosqlite
+        from genesis.db.connection import get_db
 
-        from genesis.db.connection import BUSY_TIMEOUT_MS
-
-        db = await aiosqlite.connect(str(_DEFAULT_DB))
-        db.row_factory = aiosqlite.Row
-        await db.execute("PRAGMA journal_mode=WAL")
-        await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+        # Long-lived shared connection: use the SerializedConnection (get_db) so
+        # concurrent tool calls can't interleave-wedge the transaction state.
+        # foreign_keys=False preserves the prior raw-connection behavior.
+        db = await get_db(_DEFAULT_DB, foreign_keys=False)
         try:
 
             # Bootstrap standalone router for LLM-dependent tools
@@ -226,17 +224,15 @@ def _bootstrap_memory(transport_kwargs: dict) -> None:
 
     @asynccontextmanager
     async def _lifespan(server) -> AsyncIterator[None]:
-        import aiosqlite
         from qdrant_client import QdrantClient
 
-        from genesis.db.connection import BUSY_TIMEOUT_MS
+        from genesis.db.connection import get_db
         from genesis.mcp.memory_mcp import init
         from genesis.memory.embeddings import EmbeddingProvider
+        from genesis.observability.provider_activity import ProviderActivityTracker
 
-        db = await aiosqlite.connect(str(_DEFAULT_DB))
-        db.row_factory = aiosqlite.Row
-        await db.execute("PRAGMA journal_mode=WAL")
-        await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+        # Long-lived shared connection via SerializedConnection (see _bootstrap_health).
+        db = await get_db(_DEFAULT_DB, foreign_keys=False)
 
         try:
 
@@ -250,7 +246,14 @@ def _bootstrap_memory(transport_kwargs: dict) -> None:
 
             qdrant = QdrantClient(url=qdrant_url(), timeout=5)
             embedding = EmbeddingProvider()
-            init(db=db, qdrant_client=qdrant, embedding_provider=embedding)
+            # The activity tracker enables InstrumentationMiddleware, which also
+            # runs the per-call commit/rollback boundary that releases read
+            # snapshots (WS-15 follow-up). Without a tracker the middleware — and
+            # thus the boundary — never attaches.
+            tracker = ProviderActivityTracker()
+            tracker.set_db(db)
+            init(db=db, qdrant_client=qdrant, embedding_provider=embedding,
+                 activity_tracker=tracker)
             clear_mcp_crash("memory")
             yield
         finally:
@@ -270,15 +273,12 @@ def _bootstrap_recon(transport_kwargs: dict) -> None:
 
     @asynccontextmanager
     async def _lifespan(server) -> AsyncIterator[None]:
-        import aiosqlite
-
-        from genesis.db.connection import BUSY_TIMEOUT_MS
+        from genesis.db.connection import get_db
         from genesis.mcp.recon_mcp import init_recon_mcp
+        from genesis.observability.provider_activity import ProviderActivityTracker
 
-        db = await aiosqlite.connect(str(_DEFAULT_DB))
-        db.row_factory = aiosqlite.Row
-        await db.execute("PRAGMA journal_mode=WAL")
-        await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+        # Long-lived shared connection via SerializedConnection (see _bootstrap_health).
+        db = await get_db(_DEFAULT_DB, foreign_keys=False)
 
         try:
 
@@ -290,7 +290,11 @@ def _bootstrap_recon(transport_kwargs: dict) -> None:
             else:
                 create_standalone_router()
 
-            init_recon_mcp(db=db)
+            # Tracker enables InstrumentationMiddleware + its read-snapshot
+            # boundary (WS-15 follow-up) — see _bootstrap_memory.
+            tracker = ProviderActivityTracker()
+            tracker.set_db(db)
+            init_recon_mcp(db=db, activity_tracker=tracker)
             clear_mcp_crash("recon")
             yield
         finally:
@@ -315,15 +319,12 @@ def _bootstrap_outreach(transport_kwargs: dict) -> None:
 
     @asynccontextmanager
     async def _lifespan(server) -> AsyncIterator[None]:
-        import aiosqlite
-
-        from genesis.db.connection import BUSY_TIMEOUT_MS
+        from genesis.db.connection import get_db
         from genesis.mcp.outreach_mcp import init_outreach_mcp
+        from genesis.observability.provider_activity import ProviderActivityTracker
 
-        db = await aiosqlite.connect(str(_DEFAULT_DB))
-        db.row_factory = aiosqlite.Row
-        await db.execute("PRAGMA journal_mode=WAL")
-        await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+        # Long-lived shared connection via SerializedConnection (see _bootstrap_health).
+        db = await get_db(_DEFAULT_DB, foreign_keys=False)
 
         try:
             # Standalone: pipeline=None means outreach_send returns "not initialized".
@@ -336,7 +337,14 @@ def _bootstrap_outreach(transport_kwargs: dict) -> None:
             else:
                 create_standalone_router()
 
-            init_outreach_mcp(pipeline=None, engagement=None, config=None, db=db)
+            # Tracker enables InstrumentationMiddleware + its read-snapshot
+            # boundary (WS-15 follow-up) — see _bootstrap_memory.
+            tracker = ProviderActivityTracker()
+            tracker.set_db(db)
+            init_outreach_mcp(
+                pipeline=None, engagement=None, config=None, db=db,
+                activity_tracker=tracker,
+            )
             clear_mcp_crash("outreach")
             yield
         finally:

--- a/src/genesis/db/connection.py
+++ b/src/genesis/db/connection.py
@@ -222,29 +222,39 @@ class SerializedConnection:
         pass
 
 
-async def get_db(path: str | Path = DEFAULT_DB_PATH) -> SerializedConnection:
+async def get_db(
+    path: str | Path = DEFAULT_DB_PATH,
+    *,
+    foreign_keys: bool = True,
+) -> SerializedConnection:
     """Open a connection to the Genesis SQLite database.
 
-    Enables WAL mode and foreign keys.  Returns a SerializedConnection
-    that prevents concurrent coroutine interleaving.
+    Enables WAL mode and (by default) foreign keys.  Returns a
+    SerializedConnection that prevents concurrent coroutine interleaving.
     Caller is responsible for closing.
+
+    Set ``foreign_keys=False`` for the long-lived MCP server connections, which
+    historically opened raw connections without FK enforcement — keeping FK off
+    avoids surprising them with newly-enforced constraints (turning it on is a
+    deliberate, separate decision).
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
+    async def _configure(conn: aiosqlite.Connection) -> None:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute("PRAGMA journal_mode=WAL")
+        if foreign_keys:
+            await conn.execute("PRAGMA foreign_keys=ON")
+        await conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+
     db = await aiosqlite.connect(str(path))
-    db.row_factory = aiosqlite.Row
-    await db.execute("PRAGMA journal_mode=WAL")
-    await db.execute("PRAGMA foreign_keys=ON")
-    await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+    await _configure(db)
 
     # Build reconnect closure (SQLite-specific; replace for PostgreSQL)
     async def _reconnect() -> aiosqlite.Connection:
         conn = await aiosqlite.connect(str(path))
-        conn.row_factory = aiosqlite.Row
-        await conn.execute("PRAGMA journal_mode=WAL")
-        await conn.execute("PRAGMA foreign_keys=ON")
-        await conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+        await _configure(conn)
         return conn
 
     return SerializedConnection(db, reconnect_fn=_reconnect)

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -51,7 +51,8 @@ def init_health_mcp(
     if activity_tracker is not None:
         from genesis.observability.mcp_middleware import InstrumentationMiddleware
 
-        mcp.add_middleware(InstrumentationMiddleware(activity_tracker, "health"))
+        # service._db is the long-lived health connection (set in init_health_mcp's caller)
+        mcp.add_middleware(InstrumentationMiddleware(activity_tracker, "health", db=service._db))
 
     logger.info("Health MCP wired to HealthDataService")
 

--- a/src/genesis/mcp/memory/__init__.py
+++ b/src/genesis/mcp/memory/__init__.py
@@ -115,7 +115,7 @@ def init(
     if activity_tracker is not None:
         from genesis.observability.mcp_middleware import InstrumentationMiddleware
 
-        mcp.add_middleware(InstrumentationMiddleware(activity_tracker, "memory"))
+        mcp.add_middleware(InstrumentationMiddleware(activity_tracker, "memory", db=db))
 
 
 def _require_init() -> None:

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -42,7 +42,7 @@ def init_outreach_mcp(*, pipeline, engagement, config, db, activity_tracker=None
     if activity_tracker is not None:
         from genesis.observability.mcp_middleware import InstrumentationMiddleware
 
-        mcp.add_middleware(InstrumentationMiddleware(activity_tracker, "outreach"))
+        mcp.add_middleware(InstrumentationMiddleware(activity_tracker, "outreach", db=db))
 
 
 @mcp.tool()

--- a/src/genesis/mcp/recon_mcp.py
+++ b/src/genesis/mcp/recon_mcp.py
@@ -57,7 +57,7 @@ def init_recon_mcp(
     if activity_tracker is not None:
         from genesis.observability.mcp_middleware import InstrumentationMiddleware
 
-        mcp.add_middleware(InstrumentationMiddleware(activity_tracker, "recon"))
+        mcp.add_middleware(InstrumentationMiddleware(activity_tracker, "recon", db=db))
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────

--- a/src/genesis/observability/mcp_middleware.py
+++ b/src/genesis/observability/mcp_middleware.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import Any
 
 from fastmcp.server.middleware import Middleware
 
@@ -27,14 +28,31 @@ class InstrumentationMiddleware(Middleware):
 
     All tracking is fire-and-forget — tracker errors never propagate to
     the MCP tool handler.
+
+    Per-call transaction boundary (WS-15 follow-up): when constructed with the
+    server's long-lived ``db`` connection, each tool call ends with a
+    commit-on-success / rollback-on-error. This releases the read snapshot that
+    a read-only tool would otherwise leave open in deferred-isolation mode —
+    which pins the SQLite WAL checkpoint and makes later writes fail
+    "database is locked". Writes already commit at the CRUD layer before the
+    tool returns, so the commit here only closes a *trailing* read txn (it can
+    never discard a tool's own write); rollback-on-error discards a partial.
+    DB errors in this boundary never propagate to the tool handler.
     """
 
-    def __init__(self, tracker: ProviderActivityTracker, server_name: str) -> None:
+    def __init__(
+        self,
+        tracker: ProviderActivityTracker,
+        server_name: str,
+        db: Any = None,
+    ) -> None:
         self._tracker = tracker
         self._server = server_name
+        self._db = db
 
     async def on_call_tool(self, context, call_next):
-        """Wrap tool invocations with timing and error tracking."""
+        """Wrap tool invocations with timing, error tracking, and a per-call
+        commit/rollback boundary (see class docstring)."""
         tool_name = context.message.name
         provider = f"mcp.{self._server}.{tool_name}"
         t0 = time.monotonic()
@@ -46,6 +64,18 @@ class InstrumentationMiddleware(Middleware):
             success = False
             raise
         finally:
+            if self._db is not None:
+                try:
+                    if success:
+                        await self._db.commit()
+                    else:
+                        await self._db.rollback()
+                except Exception:
+                    logger.warning(
+                        "DB %s after %s failed",
+                        "commit" if success else "rollback",
+                        provider, exc_info=True,
+                    )
             try:
                 self._tracker.record(
                     provider,

--- a/tests/test_db/test_connection.py
+++ b/tests/test_db/test_connection.py
@@ -203,3 +203,30 @@ async def test_get_raw_db_closes_on_exit(tmp_path):
     # a private attribute).
     with pytest.raises(ValueError):
         await captured.execute("SELECT 1")
+
+
+# ── get_db foreign_keys param (WS-15 follow-up: long-lived MCP connections) ──
+
+async def test_get_db_enforces_foreign_keys_by_default(tmp_path):
+    """get_db() defaults to FK enforcement — runtime behavior unchanged."""
+    from genesis.db.connection import get_db
+
+    db = await get_db(tmp_path / "fk_on.db")
+    try:
+        cur = await db.execute("PRAGMA foreign_keys")
+        assert (await cur.fetchone())[0] == 1
+    finally:
+        await db.close()
+
+
+async def test_get_db_foreign_keys_opt_out(tmp_path):
+    """get_db(foreign_keys=False) leaves FK off — preserves the legacy behavior
+    of the long-lived MCP connections, which never enforced FK."""
+    from genesis.db.connection import get_db
+
+    db = await get_db(tmp_path / "fk_off.db", foreign_keys=False)
+    try:
+        cur = await db.execute("PRAGMA foreign_keys")
+        assert (await cur.fetchone())[0] == 0
+    finally:
+        await db.close()

--- a/tests/test_observability/test_mcp_middleware.py
+++ b/tests/test_observability/test_mcp_middleware.py
@@ -74,3 +74,74 @@ class TestInstrumentationMiddleware:
 
         result = await mw.on_call_tool(context, call_next)
         assert result == {"ok": True}
+
+
+@pytest.mark.asyncio
+class TestMiddlewareUnitOfWork:
+    """The per-call transaction boundary (WS-15 follow-up): release the read
+    snapshot after each tool call so it can't pin the WAL — commit on success,
+    rollback on error. DB errors never break the tool call."""
+
+    async def test_commits_on_successful_tool_call(self):
+        tracker = ProviderActivityTracker()
+        db = AsyncMock()
+        mw = InstrumentationMiddleware(tracker, "memory", db=db)
+        context = MagicMock()
+        context.message.name = "memory_recall"
+        call_next = AsyncMock(return_value={"ok": True})
+
+        result = await mw.on_call_tool(context, call_next)
+
+        assert result == {"ok": True}
+        db.commit.assert_awaited_once()
+        db.rollback.assert_not_awaited()
+
+    async def test_rolls_back_on_failed_tool_call(self):
+        tracker = ProviderActivityTracker()
+        db = AsyncMock()
+        mw = InstrumentationMiddleware(tracker, "memory", db=db)
+        context = MagicMock()
+        context.message.name = "memory_store"
+        call_next = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await mw.on_call_tool(context, call_next)
+
+        db.rollback.assert_awaited_once()
+        db.commit.assert_not_awaited()
+
+    async def test_no_db_is_backward_compatible(self):
+        """Without a db (default), no commit/rollback is attempted."""
+        tracker = ProviderActivityTracker()
+        mw = InstrumentationMiddleware(tracker, "test")  # no db param
+        context = MagicMock()
+        context.message.name = "t"
+        call_next = AsyncMock(return_value=1)
+
+        assert await mw.on_call_tool(context, call_next) == 1
+
+    async def test_commit_error_does_not_break_tool(self):
+        """A commit failure in the boundary must not break a successful result."""
+        tracker = ProviderActivityTracker()
+        db = AsyncMock()
+        db.commit.side_effect = RuntimeError("commit failed")
+        mw = InstrumentationMiddleware(tracker, "test", db=db)
+        context = MagicMock()
+        context.message.name = "t"
+        call_next = AsyncMock(return_value={"ok": True})
+
+        result = await mw.on_call_tool(context, call_next)
+        assert result == {"ok": True}
+
+    async def test_rollback_error_does_not_mask_tool_error(self):
+        """If rollback fails while handling a tool error, the ORIGINAL error wins."""
+        tracker = ProviderActivityTracker()
+        db = AsyncMock()
+        db.rollback.side_effect = RuntimeError("rollback failed")
+        mw = InstrumentationMiddleware(tracker, "test", db=db)
+        context = MagicMock()
+        context.message.name = "t"
+        call_next = AsyncMock(side_effect=ValueError("original tool error"))
+
+        with pytest.raises(ValueError, match="original tool error"):
+            await mw.on_call_tool(context, call_next)


### PR DESCRIPTION
## Problem
`memory_store` / `reference_store` were failing with **"database is locked"** while `follow_up_create` (a different connection) succeeded, and the SQLite WAL had grown to **~1.9 GB**. Root cause (verified in code): the four long-lived MCP connections (`scripts/genesis_mcp_server.py`) were opened as raw `aiosqlite.connect` in **deferred-isolation** mode, and read-only tool calls never committed — leaving a read transaction open that pinned the WAL checkpoint and blocked later writes. Being raw (not `SerializedConnection`) also let concurrent tool calls wedge the transaction state. This is the long-lived-connection case WS-15 (#634) deliberately deferred.

## Approach — staged (low-risk now, refactor later)
Phase 1 here keeps **write atomicity exactly as today** (writes already commit at the CRUD layer before a tool returns):

1. **Per-call read-snapshot release** — `InstrumentationMiddleware` takes the server's `db` and, at each tool call's `finally`, commits on success / rolls back on error. That closes the *trailing read* transaction so it can't pin the WAL. DB errors in the boundary never break the tool.
2. **Serialize the connections** — `get_db()` gains a `foreign_keys` param (default `True`); the 4 bootstrap connections now route through `get_db(foreign_keys=False)` → `SerializedConnection` (prior no-FK behavior preserved), preventing the interleave-wedge.
3. **Reclaim the 1.9 GB** — a one-time `wal_checkpoint(TRUNCATE)` after deploy, once the stale MCP readers cycle out (operational; no code).

**Phase 2 (separate, later):** `isolation_level=None` autocommit + a reentrant `transaction()` context manager for true concurrent multi-statement write atomicity.

## Review-driven fix
An inline code review caught that memory/recon/outreach bootstraps never passed an `activity_tracker`, so the middleware — and thus the new boundary — would never attach for them (including `memory_store`!). Fixed: those three now create a tracker so the boundary attaches for **all four** servers. (The tracker's own writes are batched + self-committing on a separate task, so they don't entangle with the boundary.)

## Tests / verification
- TDD: `test_mcp_middleware.py` (commit-on-success, rollback-on-error, no-db backward-compat, commit/rollback errors swallowed, original-error not masked); `test_connection.py` (FK on/off).
- `test_mcp/` 336 passed; observability+db+mcp 1061 passed (the only 3 failures are a pre-existing cross-dir logging-pollution in `test_manifest_tool.py`, visible only in a sequential combined run — passes alone; CI runs parallel workers).
- ruff clean; import smoke OK.
- **Post-merge E2E** (needs MCP servers to restart into the new code): `memory_store`/`reference_store` succeed, and `wal_checkpoint(TRUNCATE)` returns busy=0 with the WAL dropping to ~0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)