### PR TITLE
fix(hooks): resolve worktree venv without SIGPIPE in genesis-hook launcher

### DIFF
--- a/.claude/hooks/genesis-hook
+++ b/.claude/hooks/genesis-hook
@@ -17,8 +17,17 @@ GENESIS_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # Find the Python venv. In a worktree, .venv lives in the main repo, not here.
 PYTHON="$GENESIS_ROOT/.venv/bin/python"
 if [[ ! -x "$PYTHON" ]]; then
-    # Worktree detection: resolve the main worktree via git
-    MAIN_ROOT="$(cd "$GENESIS_ROOT" && git worktree list --porcelain 2>/dev/null | head -1 | sed 's/^worktree //')"
+    # Worktree: .venv lives in the MAIN repo. Resolve the main worktree root via
+    # `git rev-parse --git-common-dir` (the main repo's .git; its parent is the
+    # main worktree root). Do NOT use `git worktree list | head` here: head closes
+    # the pipe after one line, so with many worktrees git gets SIGPIPE, and under
+    # `set -euo pipefail` that silently kills this launcher (exit 141, no stderr),
+    # breaking every hook in the worktree.
+    _common_dir="$(cd "$GENESIS_ROOT" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null)" || _common_dir=""
+    MAIN_ROOT=""
+    if [[ -n "$_common_dir" ]]; then
+        MAIN_ROOT="$(cd "$GENESIS_ROOT" 2>/dev/null && cd "$(dirname "$_common_dir")" 2>/dev/null && pwd)" || MAIN_ROOT=""
+    fi
     if [[ -n "$MAIN_ROOT" && -x "$MAIN_ROOT/.venv/bin/python" ]]; then
         PYTHON="$MAIN_ROOT/.venv/bin/python"
     else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Claude Code hooks work from a git worktree again** — the hook launcher
+  located the Python venv via a `git worktree list | head` pipeline that, with
+  many worktrees, died on SIGPIPE under `set -o pipefail` and **silently
+  disabled every hook** (session activity capture, file/edit audit logging) when
+  you ran Claude Code from a worktree. It now resolves the main repo with
+  `git rev-parse --git-common-dir` (no pipe), so hooks fire reliably everywhere.
 - **Memory storage no longer gets wedged on "database is locked"** — a
   long-lived MCP database connection left read transactions open after read-only
   tool calls, which pinned the SQLite write-ahead log (it could grow to

--- a/tests/test_scripts/test_genesis_hook_wrapper.py
+++ b/tests/test_scripts/test_genesis_hook_wrapper.py
@@ -1,0 +1,57 @@
+"""Regression guard + smoke for the `.claude/hooks/genesis-hook` launcher.
+
+The launcher's worktree venv-fallback used `git worktree list --porcelain | head`
+under `set -euo pipefail`. `head` closes the pipe after one line, so when git's
+output exceeds the pipe buffer (many worktrees) git dies with SIGPIPE; pipefail
++ set -e then kill the launcher silently (exit 141, no stderr), breaking EVERY
+hook in that worktree. Fixed by resolving the main worktree via
+`git rev-parse --git-common-dir` (no pipe). These tests lock that in.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+_WRAPPER = Path(__file__).resolve().parents[2] / ".claude" / "hooks" / "genesis-hook"
+
+
+def _code_only() -> str:
+    """Wrapper text with comment-only lines stripped (test code, not comments)."""
+    return "\n".join(
+        ln for ln in _WRAPPER.read_text().splitlines()
+        if not ln.lstrip().startswith("#")
+    )
+
+
+def test_no_sigpipe_prone_pipe_in_code():
+    """The fragile `git worktree list … | head` must not be in executable code.
+
+    (Would FAIL on the pre-fix launcher — that's the regression this guards.)
+    """
+    code = _code_only()
+    assert "git worktree list" not in code, "fragile worktree-list pipeline returned"
+    assert "| head" not in code, "early-closing pipe under pipefail returned"
+
+
+def test_uses_git_common_dir_for_main_root():
+    """The venv fallback resolves the main worktree via the no-pipe rev-parse."""
+    assert "git rev-parse --git-common-dir" in _code_only()
+
+
+def test_wrapper_never_sigpipes_on_invocation():
+    """Invoking the launcher must never die with SIGPIPE (exit 141).
+
+    GENESIS_CC_SESSION=1 makes the hook exit early, so this exercises the
+    wrapper's venv resolution (the fixed path) without hook side effects. We
+    only assert it is not 141 — exit 0 (venv found) or 1 (clear "venv not
+    found" error) are both acceptable across environments.
+    """
+    env = {**os.environ, "GENESIS_CC_SESSION": "1"}
+    for _ in range(10):
+        proc = subprocess.run(
+            [str(_WRAPPER), "hooks/session_observer_hook.py"],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            env=env,
+        )
+        assert proc.returncode != 141, f"SIGPIPE (141)! stderr={proc.stderr!r}"


### PR DESCRIPTION
## Problem
In **worktree** Claude Code sessions, every Genesis hook was failing silently — "Failed with non-blocking status code: No stderr output" (exit **141 = SIGPIPE**). The `.claude/hooks/genesis-hook` launcher locates the Python venv; a worktree has no local `.venv`, so it took a fallback that ran, under `set -euo pipefail`:
```bash
MAIN_ROOT="$(cd "$GENESIS_ROOT" && git worktree list --porcelain 2>/dev/null | head -1 | sed 's/^worktree //')"
```
`head -1` closes the pipe after one line, so with **many worktrees** (this install had 40) git's output exceeds the 64 KB pipe buffer and git is still writing when the reader closes → **SIGPIPE** → `pipefail` + `set -e` silently kill the launcher → **every hook in that worktree fails** (session activity capture, file/edit audit logging, etc.). It read as "resume-specific," but the real determinant is *running from a worktree*.

## Fix
Replace the fragile pipeline with a no-pipe lookup of the main worktree root:
```bash
_common_dir="$(cd "$GENESIS_ROOT" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null)" || _common_dir=""
MAIN_ROOT=""
if [[ -n "$_common_dir" ]]; then
    MAIN_ROOT="$(cd "$GENESIS_ROOT" 2>/dev/null && cd "$(dirname "$_common_dir")" 2>/dev/null && pwd)" || MAIN_ROOT=""
fi
```
`git rev-parse --git-common-dir` returns the main repo's `.git` from any linked worktree; its parent is the main worktree root (where `.venv` lives). No early-closing pipe → no SIGPIPE. The `|| VAR=""` fallbacks keep it safe under `set -euo pipefail` and degrade to the existing clear "venv not found" error. The fast path (main repo with `.venv`) is untouched.

## Verification
- Reproduced the bug **39/40** iterations with the old pipeline; the fix is **0/40** SIGPIPE and resolves to the **executable main venv** 40/40.
- Before/after via the real launcher (invoked as CC does, from a worktree): old **20/20 fail** → fixed **0/20**; full real-hook run end-to-end → exit 0.
- `bash -n` + `shellcheck` clean.
- New regression-guard test (`tests/test_scripts/test_genesis_hook_wrapper.py`): asserts no `| head` pipeline in code, that `--git-common-dir` is used, and the launcher never exits 141 — would fail on the old code, passes on the fix.

## Deployment note
`genesis-hook` is a committed, per-worktree file, so this fixes the main repo and **future** worktrees; existing stale worktrees keep the old launcher until rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)