### PR TITLE
feat(cc): opt-in bypass permission mode for interactive consoles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Changed
 
+- **Interactive Claude Code consoles can run friction-free again, when you want
+  them to** — the SSH/tmux dev-console slot and the dashboard web terminal still
+  default to `--permission-mode auto` (auto-approves common operations, but still
+  prompts you on deny/ask rules), but you can now opt a session back into
+  `--dangerously-skip-permissions` by setting `GENESIS_CC_PERMISSION_MODE=bypass`.
+  For the SSH slot, put that line in `~/.genesis/cc-slot.env` (SSH sessions don't
+  read your shell profile); for the dashboard terminal, set it in the dashboard's
+  environment. Headless autonomous sessions are unaffected.
+
 - **`update.sh` now keeps Claude Code in sync on your host VM too** — if you run
   Genesis with a Guardian on a separate host VM, updates previously only touched
   the container's Claude Code, letting the host drift behind. `update.sh` now

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -83,13 +83,30 @@ chmod 700 "$TMPDIR"
 # Without this, intermittent ENOENT failures on /tmp break the Bash tool.
 export CLAUDE_CODE_TMPDIR="$HOME/.genesis/cc-tmp"
 
+# Permission mode for this interactive dev console. Default: auto — auto-approves
+# common ops but still prompts on deny/ask rules, which the operator answers in
+# the tmux session (keeps deny-rule safety). To launch friction-free with
+# --dangerously-skip-permissions, set GENESIS_CC_PERMISSION_MODE=bypass. SSH
+# RemoteCommand does not source .bashrc, so this script also reads an optional
+# ~/.genesis/cc-slot.env (e.g. a single line: GENESIS_CC_PERMISSION_MODE=bypass).
+# Headless/autonomous CC sessions (CCInvoker -p) keep bypass separately — no
+# human is present to answer a prompt.
+if [ -f "${HOME}/.genesis/cc-slot.env" ]; then
+    # Don't let a malformed override file kill the session under `set -e` (the
+    # sourced file is the final command of an && chain, so a non-zero exit would
+    # abort the script and drop the SSH session with no diagnostic).
+    . "${HOME}/.genesis/cc-slot.env" \
+        || echo "cc-slot: warning: ~/.genesis/cc-slot.env sourced with errors (continuing)" >&2
+fi
+case "${GENESIS_CC_PERMISSION_MODE:-auto}" in
+    bypass|dangerous|skip) CC_PERM_FLAG="--dangerously-skip-permissions" ;;
+    *)                     CC_PERM_FLAG="--permission-mode auto" ;;
+esac
+
 # -u: force UTF-8 output even if a future client's locale detection fails
-# Interactive dev console (a human attaches over SSH), so use auto mode: it
-# auto-approves common ops but still prompts on deny/ask rules, which the
-# operator can answer in the tmux session. Headless/autonomous CC sessions
-# keep --dangerously-skip-permissions (no human present to answer a prompt).
 exec tmux -u new-session -A -s "$SESSION_NAME" \
     -e "GENESIS_SLOT=${SLOT}" \
+    -e "GENESIS_CC_PERMISSION_MODE=${GENESIS_CC_PERMISSION_MODE:-auto}" \
     -e "CLAUDE_CODE_TMPDIR=$CLAUDE_CODE_TMPDIR" \
     -e "LANG=$LANG" \
-    "cd ${GENESIS_ROOT} && exec claude --permission-mode auto"
+    "cd ${GENESIS_ROOT} && exec claude ${CC_PERM_FLAG}"

--- a/src/genesis/dashboard/routes/terminal.py
+++ b/src/genesis/dashboard/routes/terminal.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import threading
 from typing import TYPE_CHECKING
 
@@ -166,12 +167,27 @@ def vendor_xterm_static(filename):
     return send_from_directory(str(xterm_dir), filename)
 
 
+def _cc_launch_command() -> str:
+    """Claude Code launch command prefilled in the interactive web terminal.
+
+    Defaults to ``--permission-mode auto`` (auto-approve common ops, still
+    prompt on deny/ask rules the operator answers here — keeps deny-rule
+    safety). Set ``GENESIS_CC_PERMISSION_MODE=bypass`` in the dashboard process
+    environment to prefill ``--dangerously-skip-permissions`` instead, for
+    friction-free interactive sessions.
+    """
+    mode = os.environ.get("GENESIS_CC_PERMISSION_MODE", "auto").strip().lower()
+    if mode in ("bypass", "dangerous", "skip"):
+        return "claude --dangerously-skip-permissions"
+    return "claude --permission-mode auto"
+
+
 @blueprint.route("/genesis/terminal")
 def terminal_page():
     """Standalone terminal page — opened in a new window from the Chat tab."""
     from flask import render_template_string
 
-    return render_template_string(_TERMINAL_PAGE_HTML)
+    return render_template_string(_TERMINAL_PAGE_HTML, launch_cmd=_cc_launch_command())
 
 
 _TERMINAL_PAGE_HTML = """\
@@ -211,11 +227,12 @@ _TERMINAL_PAGE_HTML = """\
       const dims = fit.proposeDimensions();
       if (dims) ws.send(JSON.stringify({ resize: { rows: dims.rows, cols: dims.cols } }));
       // Prefill Claude Code launch command; user chooses when to execute.
-      // Interactive terminal (a human drives it), so use auto mode: it
-      // auto-approves common ops but still prompts on deny/ask rules, which
-      // the operator can answer here. Headless/autonomous sessions keep
-      // --dangerously-skip-permissions (no human to answer a prompt).
-      setTimeout(() => ws.send("claude --permission-mode auto"), 500);
+      // Defaults to auto mode (auto-approves common ops, still prompts on
+      // deny/ask rules the operator answers here — keeps deny-rule safety).
+      // Set GENESIS_CC_PERMISSION_MODE=bypass in the dashboard environment to
+      // prefill --dangerously-skip-permissions. Headless/autonomous sessions
+      // keep bypass separately (no human to answer a prompt).
+      setTimeout(() => ws.send("{{ launch_cmd | e }}"), 500);
     };
 
     ws.onmessage = (evt) => {

--- a/tests/test_dashboard/test_terminal_permission_mode.py
+++ b/tests/test_dashboard/test_terminal_permission_mode.py
@@ -1,32 +1,60 @@
-"""WS-20: interactive CC sessions launch in auto permission mode, not bypass.
+"""Interactive CC consoles default to auto permission mode, with an opt-in bypass.
 
-The dashboard web terminal prefill and the SSH/tmux dev-console slot each spawn
-an INTERACTIVE Claude Code session that a human drives, so they use
+WS-20 made the dashboard web terminal and the SSH/tmux dev-console slot launch
 ``--permission-mode auto`` (auto-approve common ops, prompt the human on gated
 ones, keep deny-rule safety) instead of ``--dangerously-skip-permissions``.
 
+This follow-up keeps ``auto`` as the default but lets an operator opt back into
+bypass per environment via ``GENESIS_CC_PERMISSION_MODE=bypass`` — for
+friction-free interactive sessions — without editing tracked files.
+
 Headless/autonomous sessions (every path through ``CCInvoker``, which hardcodes
 ``-p``) intentionally KEEP bypass — there is no human to answer a prompt — and
-are deliberately out of scope for this test.
+are deliberately out of scope here.
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from unittest import mock
 
-from genesis.dashboard.routes.terminal import _TERMINAL_PAGE_HTML
+from genesis.dashboard.routes.terminal import _TERMINAL_PAGE_HTML, _cc_launch_command
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_dashboard_terminal_prefill_uses_auto_mode():
-    # Assert the *launched command* (not comment text) prefills auto mode.
-    assert 'ws.send("claude --permission-mode auto")' in _TERMINAL_PAGE_HTML
+def test_launch_command_defaults_to_auto():
+    with mock.patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GENESIS_CC_PERMISSION_MODE", None)
+        assert _cc_launch_command() == "claude --permission-mode auto"
+
+
+def test_launch_command_bypass_optin():
+    with mock.patch.dict(os.environ, {"GENESIS_CC_PERMISSION_MODE": "bypass"}):
+        assert _cc_launch_command() == "claude --dangerously-skip-permissions"
+
+
+def test_launch_command_unknown_value_falls_back_to_auto():
+    with mock.patch.dict(os.environ, {"GENESIS_CC_PERMISSION_MODE": "wat"}):
+        assert _cc_launch_command() == "claude --permission-mode auto"
+
+
+def test_terminal_prefill_is_templated():
+    # The prefill must be a Jinja placeholder so the mode toggle actually applies,
+    # not a hardcoded literal.
+    assert 'ws.send("{{ launch_cmd | e }}")' in _TERMINAL_PAGE_HTML
+    assert 'ws.send("claude --permission-mode auto")' not in _TERMINAL_PAGE_HTML
     assert 'ws.send("claude --dangerously-skip-permissions")' not in _TERMINAL_PAGE_HTML
 
 
-def test_cc_slot_launches_auto_mode():
-    # cc-slot.sh launches the interactive tmux dev console a human attaches to.
+def test_cc_slot_supports_default_auto_and_bypass_optin():
     cc_slot = (_REPO_ROOT / "scripts" / "cc-slot.sh").read_text()
-    assert "exec claude --permission-mode auto" in cc_slot
-    assert "exec claude --dangerously-skip-permissions" not in cc_slot
+    # Default branch keeps auto — WS-20's safety default is preserved.
+    assert "--permission-mode auto" in cc_slot
+    # Opt-in branch restores bypass.
+    assert "--dangerously-skip-permissions" in cc_slot
+    # Gated on the env var, with an optional sourced override (SSH RemoteCommand
+    # does not source .bashrc, so a plain env var alone is not operator-settable).
+    assert "GENESIS_CC_PERMISSION_MODE" in cc_slot
+    assert "cc-slot.env" in cc_slot


### PR DESCRIPTION
## What

WS-20 (#630) switched the two **interactive** Claude Code launchers — the SSH/tmux dev-console slot (`cc-slot.sh`) and the dashboard web terminal (`terminal.py`) — from `--dangerously-skip-permissions` to `--permission-mode auto`. Auto mode still prompts on deny/ask rules, which adds friction for an operator actively driving the session.

This keeps `auto` as the default (preserving WS-20's safety posture) and adds an **opt-in** to launch friction-free again:

- Set `GENESIS_CC_PERMISSION_MODE=bypass` → launches with `--dangerously-skip-permissions`.
- `cc-slot.sh` also sources an optional `~/.genesis/cc-slot.env`, because SSH `RemoteCommand` does not read `.bashrc`, so a plain env var alone is not operator-settable. A single line in that file (`GENESIS_CC_PERMISSION_MODE=bypass`) enables it for all slots.
- `terminal.py` reads the same var from the dashboard process environment and prefills the command via Jinja.

Unknown/empty values fall back to `auto`. Headless/autonomous sessions (every `CCInvoker -p` path) are intentionally **unchanged**.

## Why

Auto mode's prompting is disruptive for day-to-day interactive work, but a hard revert would undo WS-20's deny-rule safety net. A per-environment opt-in gives operators the choice without changing the secure default.

## Testing

- Unit tests (`tests/test_dashboard/test_terminal_permission_mode.py`): default→auto, bypass opt-in, unknown→auto fallback, templated prefill, cc-slot.sh branches.
- Verified Jinja `render_template_string` renders both modes correctly (the HTML/CSS/JS template body is unaffected).
- `cc-slot.sh` exercised end-to-end via a tmux shim across all modes, including the regression case where a malformed `cc-slot.env` exits non-zero: it now warns and continues instead of silently dropping the SSH session under `set -e`.

## Review notes

Independent review surfaced two issues, both fixed here:
- The `cc-slot.env` source was guarded by `[ -f ] && . file`, making the source the final command of an `&&` list — under `set -euo pipefail` a bad file would abort the launcher silently. Now isolated with a warning-and-continue path.
- Added `{{ launch_cmd | e }}` as defensive escaping (current values are fixed literals; hardens against future dynamic values since `render_template_string` autoescape is filename-dependent).