### PR TITLE
fix(db): cancellation-safe reads + WAL detection/bounding (database is locked / WAL bloat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Added
+
+- **Genesis now watches its own database journal size** — if SQLite's
+  write-ahead log grows abnormally large (the sign of a stuck database reader
+  holding the file open), Genesis raises a high/critical alert on Telegram and in
+  the morning report, instead of letting it balloon silently for days.
+
+### Fixed
+
+- **Memory writes no longer get stuck behind a database lock** — under heavy load
+  or a provider outage, a cancelled database read could leave a stale lock that
+  made saving to memory (`reference_store` / `memory_store`) fail with "database
+  is locked" while the write-ahead log ballooned (it reached ~2 GB). Database
+  reads are now cancellation-safe and the journal is size-bounded, so the lock
+  can't get stuck and the file can't run away.
+
 ### Changed
 
 - **`update.sh` now keeps Claude Code in sync on your host VM too** — if you run

--- a/scripts/genesis_mcp_server.py
+++ b/scripts/genesis_mcp_server.py
@@ -149,6 +149,7 @@ def _bootstrap_health(transport_kwargs: dict) -> None:
         db.row_factory = aiosqlite.Row
         await db.execute("PRAGMA journal_mode=WAL")
         await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+        await db.execute("PRAGMA journal_size_limit=67108864")  # 64 MB WAL file cap
         try:
 
             # Bootstrap standalone router for LLM-dependent tools
@@ -237,6 +238,7 @@ def _bootstrap_memory(transport_kwargs: dict) -> None:
         db.row_factory = aiosqlite.Row
         await db.execute("PRAGMA journal_mode=WAL")
         await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+        await db.execute("PRAGMA journal_size_limit=67108864")  # 64 MB WAL file cap
 
         try:
 
@@ -279,6 +281,7 @@ def _bootstrap_recon(transport_kwargs: dict) -> None:
         db.row_factory = aiosqlite.Row
         await db.execute("PRAGMA journal_mode=WAL")
         await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+        await db.execute("PRAGMA journal_size_limit=67108864")  # 64 MB WAL file cap
 
         try:
 
@@ -324,6 +327,7 @@ def _bootstrap_outreach(transport_kwargs: dict) -> None:
         db.row_factory = aiosqlite.Row
         await db.execute("PRAGMA journal_mode=WAL")
         await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+        await db.execute("PRAGMA journal_size_limit=67108864")  # 64 MB WAL file cap
 
         try:
             # Standalone: pipeline=None means outreach_send returns "not initialized".

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -14,6 +14,7 @@ import contextlib
 import hashlib
 import json
 import logging
+import time
 import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -40,17 +41,93 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _sqlite_wal_checkpoint(db) -> None:
-    """Attempt a non-blocking WAL checkpoint. SQLite-specific."""
+async def _sqlite_wal_checkpoint(db) -> None:
+    """Run a non-blocking PASSIVE WAL checkpoint via the async API.
+
+    MUST go through ``db.execute`` (the aiosqlite worker thread). Reaching into
+    ``db._conn._conn`` and calling it synchronously from the event-loop thread
+    raises ``ProgrammingError`` (sqlite3 connections are thread-bound) — which a
+    bare ``except`` silently swallows, making the checkpoint a no-op (this was a
+    latent bug). ``execute_fetchall`` consumes+closes the cursor (cancellation-
+    safe). SQLite-specific; best-effort."""
+    with contextlib.suppress(Exception):  # best-effort; failure is harmless
+        await db.execute_fetchall("PRAGMA wal_checkpoint(PASSIVE)")
+
+
+async def _sqlite_wal_truncate(db) -> None:
+    """Run a TRUNCATE WAL checkpoint via the async API to reclaim WAL *file* space.
+
+    PASSIVE checkpoints recycle WAL frames in place but never shrink the file;
+    TRUNCATE resets it to zero bytes once all readers have caught up. No-op
+    (busy) if a reader still holds a snapshot — that case is surfaced by
+    :func:`_check_wal_health`. Run on a slow cadence (not every tick) so it
+    doesn't needlessly contend with active readers. Goes through ``db.execute``
+    (worker thread); ``execute_fetchall`` is cancellation-safe. SQLite-specific;
+    best-effort."""
     try:
-        import sqlite3
-        # Access the raw connection for synchronous PRAGMA
-        if hasattr(db, '_conn') and hasattr(db._conn, '_conn'):
-            raw = db._conn._conn
-            if isinstance(raw, sqlite3.Connection):
-                raw.execute("PRAGMA wal_checkpoint(PASSIVE)")
+        rows = await db.execute_fetchall("PRAGMA wal_checkpoint(TRUNCATE)")
+        if rows and rows[0][0] == 1:
+            logger.debug("WAL TRUNCATE checkpoint blocked by an active reader")
     except Exception:
         pass  # Best-effort; failure is harmless
+
+
+# WAL-health detection: a pinned checkpoint (e.g. a long-lived connection holding
+# a read snapshot from an unclosed/cancelled cursor) makes the WAL file grow
+# unbounded. Alert on abnormal WAL size so a stuck reader is caught in minutes,
+# not days. Surfaces via the critical-observations job (Telegram) + morning report.
+_WAL_SIZE_WARN_BYTES = 100 * 1024 * 1024   # 100 MB → "high" (morning report)
+_WAL_SIZE_CRIT_BYTES = 500 * 1024 * 1024   # 500 MB → "critical" (Telegram now)
+_WAL_ALERT_COOLDOWN_S = 3600               # one alert per hour max
+_WAL_TRUNCATE_EVERY_N_TICKS = 12           # hourly TRUNCATE (tick ≈ 5 min)
+_last_wal_alert_at: float = 0.0
+
+
+async def _check_wal_health(db) -> None:
+    """Create a high/critical observation when the SQLite WAL file is abnormally
+    large — the direct symptom of a pinned checkpoint or chronic under-checkpointing.
+    Best-effort; never raises into the tick."""
+    global _last_wal_alert_at
+    try:
+        from pathlib import Path
+
+        from genesis.env import genesis_db_path
+        wal_path = Path(f"{genesis_db_path()}-wal")
+        if not wal_path.exists():
+            return
+        size = wal_path.stat().st_size
+    except Exception:
+        return  # can't stat — nothing to alert on
+
+    if size < _WAL_SIZE_WARN_BYTES or db is None:
+        return
+    now = time.monotonic()
+    if now - _last_wal_alert_at < _WAL_ALERT_COOLDOWN_S:
+        return
+
+    mb = size / (1024 * 1024)
+    priority = "critical" if size >= _WAL_SIZE_CRIT_BYTES else "high"
+    try:
+        await observations.create(
+            db,
+            id=str(uuid.uuid4()),
+            source="wal_health_monitor",
+            type="infrastructure_alert",
+            content=(
+                f"SQLite WAL file is {mb:.0f} MB (warn at "
+                f"{_WAL_SIZE_WARN_BYTES // 1024 // 1024} MB). Likely cause: a long-lived "
+                f"connection holding a read snapshot (unclosed/cancelled read cursor) "
+                f"pinning the WAL checkpoint, or chronic under-checkpointing. Find the "
+                f"stuck reader/MCP; a wal_checkpoint(TRUNCATE) reclaims the space once "
+                f"it is gone."
+            ),
+            priority=priority,
+            created_at=datetime.now(UTC).isoformat(),
+        )
+        _last_wal_alert_at = now
+        logger.warning("WAL health alert: %.0f MB (%s)", mb, priority)
+    except Exception:
+        logger.debug("Failed to create WAL health alert observation", exc_info=True)
 
 
 # Micro ticks are silent by default (counted for cascade, no LLM call).
@@ -675,7 +752,12 @@ class AwarenessLoop:
             # external scripts or concurrent writers. PASSIVE is non-blocking.
             # (SQLite-specific; remove when migrating to PostgreSQL.)
             if result is not None and result.db_available:
-                _sqlite_wal_checkpoint(self._db)
+                await _sqlite_wal_checkpoint(self._db)
+                # Hourly TRUNCATE reclaims WAL *file* space (PASSIVE can't), and a
+                # WAL-size check alerts if a stuck reader is pinning the checkpoint.
+                if self._tick_count % _WAL_TRUNCATE_EVERY_N_TICKS == 0:
+                    await _sqlite_wal_truncate(self._db)
+                await _check_wal_health(self._db)
 
             # Status file writes are handled by a dedicated loop in
             # runtime/init/memory.py (status-writer-loop). Decoupled from

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -107,6 +107,9 @@ async def _check_wal_health(db) -> None:
 
     mb = size / (1024 * 1024)
     priority = "critical" if size >= _WAL_SIZE_CRIT_BYTES else "high"
+    # Set the cooldown BEFORE the write so a failed create (e.g. DB locked — the
+    # very scenario this alerts on) still suppresses per-tick retries for an hour.
+    _last_wal_alert_at = now
     try:
         await observations.create(
             db,
@@ -124,7 +127,6 @@ async def _check_wal_health(db) -> None:
             priority=priority,
             created_at=datetime.now(UTC).isoformat(),
         )
-        _last_wal_alert_at = now
         logger.warning("WAL health alert: %.0f MB (%s)", mb, priority)
     except Exception:
         logger.debug("Failed to create WAL health alert observation", exc_info=True)

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -80,7 +80,9 @@ _WAL_SIZE_WARN_BYTES = 100 * 1024 * 1024   # 100 MB → "high" (morning report)
 _WAL_SIZE_CRIT_BYTES = 500 * 1024 * 1024   # 500 MB → "critical" (Telegram now)
 _WAL_ALERT_COOLDOWN_S = 3600               # one alert per hour max
 _WAL_TRUNCATE_EVERY_N_TICKS = 12           # hourly TRUNCATE (tick ≈ 5 min)
-_last_wal_alert_at: float = 0.0
+# None = "never alerted". Must NOT be 0.0: time.monotonic() is since boot, so on a
+# freshly-booted host `now - 0.0` is small and would wrongly suppress the first alert.
+_last_wal_alert_at: float | None = None
 
 
 async def _check_wal_health(db) -> None:
@@ -102,7 +104,7 @@ async def _check_wal_health(db) -> None:
     if size < _WAL_SIZE_WARN_BYTES or db is None:
         return
     now = time.monotonic()
-    if now - _last_wal_alert_at < _WAL_ALERT_COOLDOWN_S:
+    if _last_wal_alert_at is not None and now - _last_wal_alert_at < _WAL_ALERT_COOLDOWN_S:
         return
 
     mb = size / (1024 * 1024)

--- a/src/genesis/db/connection.py
+++ b/src/genesis/db/connection.py
@@ -237,6 +237,7 @@ async def get_db(path: str | Path = DEFAULT_DB_PATH) -> SerializedConnection:
     await db.execute("PRAGMA journal_mode=WAL")
     await db.execute("PRAGMA foreign_keys=ON")
     await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+    await db.execute("PRAGMA journal_size_limit=67108864")  # 64 MB WAL file cap
 
     # Build reconnect closure (SQLite-specific; replace for PostgreSQL)
     async def _reconnect() -> aiosqlite.Connection:
@@ -245,6 +246,7 @@ async def get_db(path: str | Path = DEFAULT_DB_PATH) -> SerializedConnection:
         await conn.execute("PRAGMA journal_mode=WAL")
         await conn.execute("PRAGMA foreign_keys=ON")
         await conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+        await conn.execute("PRAGMA journal_size_limit=67108864")  # 64 MB WAL file cap
         return conn
 
     return SerializedConnection(db, reconnect_fn=_reconnect)
@@ -275,6 +277,7 @@ async def get_raw_db(
         await db.execute("PRAGMA journal_mode=WAL")
         await db.execute("PRAGMA synchronous=NORMAL")
         await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+        await db.execute("PRAGMA journal_size_limit=67108864")  # 64 MB WAL file cap
         # NOTE: intentionally NOT setting `foreign_keys=ON` here (get_db does).
         # These standalone sites never enforced FKs before, and none touch
         # FK-cascading tables. If a future caller needs cascade deletes, enable

--- a/src/genesis/db/crud/knowledge.py
+++ b/src/genesis/db/crud/knowledge.py
@@ -81,14 +81,14 @@ async def insert(
 
 async def get(db: aiosqlite.Connection, unit_id: str) -> dict | None:
     """Get a knowledge unit by id."""
-    cursor = await db.execute(
+    async with db.execute(
         "SELECT * FROM knowledge_units WHERE id = ?", (unit_id,)
-    )
-    row = await cursor.fetchone()
-    if row is None:
-        return None
-    columns = [desc[0] for desc in cursor.description]
-    return dict(zip(columns, row, strict=False))
+    ) as cursor:
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        columns = [desc[0] for desc in cursor.description]
+        return dict(zip(columns, row, strict=False))
 
 
 async def find_by_unique_key(
@@ -104,16 +104,16 @@ async def find_by_unique_key(
     that stale Qdrant points for replaced content can be cleaned up before
     writing the new version.
     """
-    cursor = await db.execute(
+    async with db.execute(
         "SELECT * FROM knowledge_units WHERE project_type = ? "
         "AND domain = ? AND concept = ?",
         (project_type, domain, concept),
-    )
-    row = await cursor.fetchone()
-    if row is None:
-        return None
-    columns = [desc[0] for desc in cursor.description]
-    return dict(zip(columns, row, strict=False))
+    ) as cursor:
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        columns = [desc[0] for desc in cursor.description]
+        return dict(zip(columns, row, strict=False))
 
 
 async def upsert(
@@ -203,12 +203,12 @@ async def upsert(
     # unique key (different id).  This matters because callers passing
     # id=None on an UPSERT conflict would otherwise get back a brand-new
     # UUID that points at nothing.
-    cursor = await db.execute(
+    rows = await db.execute_fetchall(
         "SELECT id FROM knowledge_units WHERE project_type = ? "
         "AND domain = ? AND concept = ?",
         (project_type, domain, concept),
     )
-    row = await cursor.fetchone()
+    row = rows[0] if rows else None
     actual_id = row[0] if row else unit_id
     inserted = actual_id == unit_id
 
@@ -261,8 +261,7 @@ async def search_fts(
         params.append(domain)
     sql += " ORDER BY f.rank LIMIT ?"
     params.append(limit)
-    cursor = await db.execute(sql, params)
-    rows = await cursor.fetchall()
+    rows = await db.execute_fetchall(sql, params)
     return [
         {
             "unit_id": r[0], "concept": r[1], "body": r[2],
@@ -282,22 +281,22 @@ async def stats(
     where = "WHERE project_type = ?" if project else ""
     params: tuple = (project,) if project else ()
 
-    cursor = await db.execute(
+    rows = await db.execute_fetchall(
         f"SELECT COUNT(*), MIN(ingested_at), MAX(ingested_at) FROM knowledge_units {where}",
         params,
     )
-    row = await cursor.fetchone()
+    row = rows[0] if rows else None
     total, oldest, newest = row
 
     # Domain breakdown
-    cursor = await db.execute(
+    domain_rows = await db.execute_fetchall(
         f"SELECT domain, COUNT(*) FROM knowledge_units {where} GROUP BY domain",
         params,
     )
-    domains = {r[0]: r[1] for r in await cursor.fetchall()}
+    domains = {r[0]: r[1] for r in domain_rows}
 
     # Tier breakdown (curated vs recon vs other)
-    cursor = await db.execute(
+    tier_rows = await db.execute_fetchall(
         f"""SELECT
                 CASE
                     WHEN source_pipeline = 'curated' THEN 'curated'
@@ -310,7 +309,7 @@ async def stats(
             GROUP BY tier""",
         params,
     )
-    by_tier = {r[0]: r[1] for r in await cursor.fetchall()}
+    by_tier = {r[0]: r[1] for r in tier_rows}
 
     return {
         "total": total,
@@ -331,13 +330,12 @@ async def list_by_domain(
     Used by the mirror generator. Returns ``{domain: [{id, concept, body,
     ingested_at, tags}, ...]}`` sorted by domain then ingested_at desc.
     """
-    cursor = await db.execute(
+    rows = await db.execute_fetchall(
         "SELECT id, domain, concept, body, ingested_at, tags "
         "FROM knowledge_units WHERE project_type = ? "
         "ORDER BY domain, ingested_at DESC",
         (project_type,),
     )
-    rows = await cursor.fetchall()
     result: dict[str, list[dict]] = {}
     for uid, domain, concept, body, ingested_at, tags in rows:
         result.setdefault(domain, []).append({

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -99,14 +99,14 @@ async def find_exact_duplicate(
 
     # Pre-filter: match on length and first 200 chars to narrow candidates
     prefix = content[:200]
-    cursor = await db.execute(
+    rows = await db.execute_fetchall(
         "SELECT memory_id, content FROM memory_fts "
         "WHERE length(content) = ? "
         "AND substr(content, 1, 200) = ? "
         "LIMIT 200",
         (len(content), prefix),
     )
-    for row in await cursor.fetchall():
+    for row in rows:
         if row[1] == content:
             return row[0]
 
@@ -135,8 +135,7 @@ async def search(
         params.append(collection)
     sql += " LIMIT ?"
     params.append(limit)
-    cursor = await db.execute(sql, params)
-    rows = await cursor.fetchall()
+    rows = await db.execute_fetchall(sql, params)
     return [
         {"memory_id": r[0], "content": r[1], "source_type": r[2], "collection": r[3]}
         for r in rows
@@ -218,8 +217,7 @@ async def search_ranked(
         params.extend(include_only_subsystems)
     sql += " ORDER BY rank LIMIT ?"
     params.append(limit)
-    cursor = await db.execute(sql, params)
-    rows = await cursor.fetchall()
+    rows = await db.execute_fetchall(sql, params)
     return [
         {
             "memory_id": r[0], "content": r[1], "source_type": r[2],
@@ -322,13 +320,13 @@ async def get_metadata(
     memory_id: str,
 ) -> dict | None:
     """Return metadata row for a memory_id, or None if not found."""
-    cursor = await db.execute(
+    rows = await db.execute_fetchall(
         "SELECT memory_id, collection, embedding_status, deprecated, "
         "superseded_by, superseded_at FROM memory_metadata "
         "WHERE memory_id = ?",
         (memory_id,),
     )
-    row = await cursor.fetchone()
+    row = rows[0] if rows else None
     if not row:
         return None
     return {
@@ -352,7 +350,7 @@ async def delete_metadata(db: aiosqlite.Connection, *, memory_id: str) -> bool:
 
 async def get_by_id(db: aiosqlite.Connection, memory_id: str) -> dict | None:
     """Get a single memory by ID, joining FTS5 content with metadata."""
-    cursor = await db.execute(
+    rows = await db.execute_fetchall(
         "SELECT f.memory_id, f.content, f.source_type, f.tags, f.collection, "
         "       m.created_at, m.confidence, m.embedding_status, "
         "       m.valid_at, m.invalid_at "
@@ -361,7 +359,7 @@ async def get_by_id(db: aiosqlite.Connection, memory_id: str) -> dict | None:
         "WHERE f.memory_id = ?",
         (memory_id,),
     )
-    row = await cursor.fetchone()
+    row = rows[0] if rows else None
     if not row:
         return None
     return {
@@ -399,8 +397,7 @@ async def list_recent(
         params.append(collection)
     sql += "ORDER BY m.created_at DESC LIMIT ? OFFSET ?"
     params.extend([limit, offset])
-    cursor = await db.execute(sql, params)
-    rows = await cursor.fetchall()
+    rows = await db.execute_fetchall(sql, params)
     return [
         {
             "memory_id": r[0],
@@ -424,11 +421,11 @@ async def count(
 ) -> int:
     """Count memories in memory_metadata (optionally by collection)."""
     if collection:
-        cursor = await db.execute(
+        rows = await db.execute_fetchall(
             "SELECT COUNT(*) FROM memory_metadata WHERE collection = ?",
             (collection,),
         )
     else:
-        cursor = await db.execute("SELECT COUNT(*) FROM memory_metadata")
-    row = await cursor.fetchone()
+        rows = await db.execute_fetchall("SELECT COUNT(*) FROM memory_metadata")
+    row = rows[0] if rows else None
     return row[0]

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -428,4 +428,4 @@ async def count(
     else:
         rows = await db.execute_fetchall("SELECT COUNT(*) FROM memory_metadata")
     row = rows[0] if rows else None
-    return row[0]
+    return row[0] if row else 0

--- a/src/genesis/db/crud/memory_links.py
+++ b/src/genesis/db/crud/memory_links.py
@@ -28,20 +28,20 @@ async def create(
 
 async def get_links_for(db: aiosqlite.Connection, memory_id: str) -> list[dict]:
     """Get all links where memory_id is source or target."""
-    cursor = await db.execute(
+    rows = await db.execute_fetchall(
         "SELECT * FROM memory_links WHERE source_id = ? OR target_id = ?",
         (memory_id, memory_id),
     )
-    return [dict(r) for r in await cursor.fetchall()]
+    return [dict(r) for r in rows]
 
 
 async def count_links(db: aiosqlite.Connection, memory_id: str) -> int:
     """Count links where memory_id is source or target."""
-    cursor = await db.execute(
+    rows = await db.execute_fetchall(
         "SELECT COUNT(*) FROM memory_links WHERE source_id = ? OR target_id = ?",
         (memory_id, memory_id),
     )
-    row = await cursor.fetchone()
+    row = rows[0] if rows else None
     return row[0]
 
 
@@ -74,7 +74,7 @@ async def batch_link_counts(
         ph = ",".join("?" * len(chunk))
 
         # Bidirectional counts (replaces per-ID count_links loop)
-        cursor = await db.execute(
+        total_rows = await db.execute_fetchall(
             f"SELECT id, COUNT(*) FROM ("
             f"  SELECT source_id AS id FROM memory_links WHERE source_id IN ({ph})"
             f"  UNION ALL"
@@ -82,16 +82,16 @@ async def batch_link_counts(
             f") GROUP BY id",
             chunk + chunk,
         )
-        for row in await cursor.fetchall():
+        for row in total_rows:
             total_map[row[0]] = total_map.get(row[0], 0) + row[1]
 
         # Inbound-only counts (for graph-boosted retrieval)
-        cursor = await db.execute(
+        inbound_rows = await db.execute_fetchall(
             f"SELECT target_id, COUNT(*) FROM memory_links"
             f" WHERE target_id IN ({ph}) GROUP BY target_id",
             chunk,
         )
-        for row in await cursor.fetchall():
+        for row in inbound_rows:
             inbound_map[row[0]] = inbound_map.get(row[0], 0) + row[1]
 
     return {
@@ -115,12 +115,12 @@ async def inter_candidate_links(
     if len(memory_ids) > 499:
         memory_ids = memory_ids[:499]
     ph = ",".join("?" * len(memory_ids))
-    cursor = await db.execute(
+    rows = await db.execute_fetchall(
         f"SELECT source_id, target_id FROM memory_links"
         f" WHERE source_id IN ({ph}) AND target_id IN ({ph})",
         memory_ids + memory_ids,
     )
-    return [(row[0], row[1]) for row in await cursor.fetchall()]
+    return [(row[0], row[1]) for row in rows]
 
 
 async def get_bidirectional(db: aiosqlite.Connection, memory_id: str) -> list[dict]:

--- a/src/genesis/db/crud/memory_links.py
+++ b/src/genesis/db/crud/memory_links.py
@@ -42,7 +42,7 @@ async def count_links(db: aiosqlite.Connection, memory_id: str) -> int:
         (memory_id, memory_id),
     )
     row = rows[0] if rows else None
-    return row[0]
+    return row[0] if row else 0
 
 
 async def batch_link_counts(

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -283,13 +283,13 @@ async def exists_by_hash(
     if unresolved_only:
         sql += " AND resolved = 0"
     sql += " LIMIT 1"
-    cursor = await db.execute(sql, (source, content_hash))
-    return (await cursor.fetchone()) is not None
+    rows = await db.execute_fetchall(sql, (source, content_hash))
+    return len(rows) > 0
 
 
 async def get_by_id(db: aiosqlite.Connection, id: str) -> dict | None:
-    cursor = await db.execute("SELECT * FROM observations WHERE id = ?", (id,))
-    row = await cursor.fetchone()
+    rows = await db.execute_fetchall("SELECT * FROM observations WHERE id = ?", (id,))
+    row = rows[0] if rows else None
     return dict(row) if row else None
 
 
@@ -338,8 +338,8 @@ async def query(
         params.extend(exclude_types)
     sql += " ORDER BY created_at DESC LIMIT ?"
     params.append(limit)
-    cursor = await db.execute(sql, params)
-    return [dict(r) for r in await cursor.fetchall()]
+    rows = await db.execute_fetchall(sql, params)
+    return [dict(r) for r in rows]
 
 
 async def resolve(
@@ -477,14 +477,14 @@ async def exists_recent_by_type(
     comparison works correctly with ISO 8601 timestamps stored in created_at.
     """
     cutoff = (datetime.now(UTC) - timedelta(minutes=window_minutes)).isoformat()
-    cursor = await db.execute(
+    rows = await db.execute_fetchall(
         "SELECT 1 FROM observations "
         "WHERE source = ? AND type = ? AND resolved = 0 "
         "AND created_at > ? "
         "LIMIT 1",
         (source, type, cutoff),
     )
-    return (await cursor.fetchone()) is not None
+    return len(rows) > 0
 
 
 async def delete(db: aiosqlite.Connection, id: str) -> bool:
@@ -570,10 +570,10 @@ async def get_unsurfaced(
         " created_at DESC "
         f" LIMIT {limit}"
     )
-    cursor = await db.execute(sql, params)
-    rows = await cursor.fetchall()
-    cols = [d[0] for d in cursor.description]
-    return [dict(zip(cols, r, strict=False)) for r in rows]
+    async with db.execute(sql, params) as cursor:
+        rows = await cursor.fetchall()
+        cols = [d[0] for d in cursor.description]
+        return [dict(zip(cols, r, strict=False)) for r in rows]
 
 
 async def mark_surfaced(
@@ -632,8 +632,7 @@ async def get_standing(
         "LIMIT ?"
     )
     params.append(limit)
-    cursor = await db.execute(sql, params)
-    rows = await cursor.fetchall()
+    rows = await db.execute_fetchall(sql, params)
     return [
         {
             "id": r[0], "source": r[1], "type": r[2], "category": r[3],
@@ -646,12 +645,11 @@ async def get_standing(
 
 async def unsurfaced_counts_by_priority(db: aiosqlite.Connection) -> dict[str, int]:
     """Count unsurfaced, unresolved observations grouped by priority."""
-    cursor = await db.execute(
+    rows = await db.execute_fetchall(
         "SELECT priority, COUNT(*) FROM observations "
         "WHERE surfaced_at IS NULL AND resolved = 0 "
         "GROUP BY priority"
     )
-    rows = await cursor.fetchall()
     return {row[0]: row[1] for row in rows}
 
 
@@ -667,8 +665,8 @@ async def count_unresolved(
         placeholders = ",".join("?" for _ in exclude_types)
         sql += f" AND type NOT IN ({placeholders})"
         params.extend(exclude_types)
-    cursor = await db.execute(sql, params)
-    row = await cursor.fetchone()
+    rows = await db.execute_fetchall(sql, params)
+    row = rows[0] if rows else None
     return row[0] if row else 0
 
 
@@ -681,10 +679,10 @@ async def count_unresolved_by_types(
     if not types:
         return 0
     placeholders = ",".join("?" for _ in types)
-    cursor = await db.execute(
+    rows = await db.execute_fetchall(
         f"SELECT COUNT(*) FROM observations "
         f"WHERE resolved = 0 AND type IN ({placeholders})",
         tuple(types),
     )
-    row = await cursor.fetchone()
+    row = rows[0] if rows else None
     return row[0] if row else 0

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -84,6 +84,7 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     "light_reflection_candidate": timedelta(days=3),
     "process_reaper_kill": timedelta(days=3),
     "operational_alert": timedelta(days=3),
+    "infrastructure_alert": timedelta(days=3),
     "strategic_reflection": timedelta(days=3),
     # ── 1-day (transient) ──────────────────────────────────────────────
     "light_escalation_resolved": timedelta(days=1),

--- a/src/genesis/mcp/memory/conversation.py
+++ b/src/genesis/mcp/memory/conversation.py
@@ -39,13 +39,12 @@ async def conversation_history(
         if search:
             return await telegram_messages.search_all(memory_mod._db, search, limit=limit)
         if thread_id is not None:
-            cursor = await memory_mod._db.execute(
+            rows = await memory_mod._db.execute_fetchall(
                 """SELECT * FROM telegram_messages
                    WHERE thread_id = ?
                    ORDER BY timestamp DESC LIMIT ?""",
                 (thread_id, limit),
             )
-            rows = await cursor.fetchall()
             return [dict(r) for r in reversed(rows)]
         return await telegram_messages.query_all_recent(memory_mod._db, limit=limit)
 

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -587,8 +587,8 @@ async def memory_stats() -> dict:
         memory_mod._db, type="user_model_delta", resolved=False, limit=100000
     )
 
-    total_links_cursor = await memory_mod._db.execute("SELECT COUNT(*) FROM memory_links")
-    total_links_row = await total_links_cursor.fetchone()
+    total_links_rows = await memory_mod._db.execute_fetchall("SELECT COUNT(*) FROM memory_links")
+    total_links_row = total_links_rows[0] if total_links_rows else None
     total_links = total_links_row[0] if total_links_row else 0
 
     # Structural data from memory_health snapshot queries

--- a/tests/test_awareness/test_wal_health.py
+++ b/tests/test_awareness/test_wal_health.py
@@ -108,3 +108,12 @@ async def test_swallows_create_errors(tmp_path, monkeypatch, _tiny_thresholds):
 
     # Must not raise into the tick.
     await loop._check_wal_health(object())
+
+
+def test_infrastructure_alert_type_is_registered():
+    """The alert type must be in _TTL_BY_TYPE so creating one doesn't emit a
+    spurious 'unknown observation type' warning (also covers the dead-letter
+    monitor, which uses the same type)."""
+    from genesis.db.crud import observations
+
+    assert "infrastructure_alert" in observations._TTL_BY_TYPE

--- a/tests/test_awareness/test_wal_health.py
+++ b/tests/test_awareness/test_wal_health.py
@@ -1,0 +1,110 @@
+"""Tests for the WAL-size health alert (_check_wal_health).
+
+A pinned checkpoint (e.g. a long-lived connection holding a read snapshot from
+an unclosed/cancelled cursor) makes the SQLite WAL file grow unbounded. This
+monitor turns that 2-day-silent failure into a high/critical observation that
+surfaces to the user within minutes.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from genesis.awareness import loop
+
+
+def _make_wal(tmp_path, size_bytes: int):
+    db_path = tmp_path / "genesis.db"
+    (tmp_path / "genesis.db-wal").write_bytes(b"\0" * size_bytes)
+    return db_path
+
+
+@pytest.fixture(autouse=True)
+def _reset_cooldown():
+    loop._last_wal_alert_at = 0.0
+    yield
+    loop._last_wal_alert_at = 0.0
+
+
+@pytest.fixture
+def _tiny_thresholds(monkeypatch):
+    monkeypatch.setattr(loop, "_WAL_SIZE_WARN_BYTES", 100)
+    monkeypatch.setattr(loop, "_WAL_SIZE_CRIT_BYTES", 500)
+
+
+@pytest.mark.asyncio
+async def test_no_alert_below_threshold(tmp_path, monkeypatch, _tiny_thresholds):
+    db_path = _make_wal(tmp_path, 50)
+    monkeypatch.setattr("genesis.env.genesis_db_path", lambda: str(db_path))
+    spy = AsyncMock()
+    monkeypatch.setattr(loop.observations, "create", spy)
+
+    await loop._check_wal_health(object())
+
+    spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_critical_alert_on_large_wal(tmp_path, monkeypatch, _tiny_thresholds):
+    db_path = _make_wal(tmp_path, 600)
+    monkeypatch.setattr("genesis.env.genesis_db_path", lambda: str(db_path))
+    spy = AsyncMock()
+    monkeypatch.setattr(loop.observations, "create", spy)
+
+    await loop._check_wal_health(object())
+
+    spy.assert_called_once()
+    assert spy.call_args.kwargs["priority"] == "critical"
+    assert spy.call_args.kwargs["type"] == "infrastructure_alert"
+    assert spy.call_args.kwargs["source"] == "wal_health_monitor"
+
+
+@pytest.mark.asyncio
+async def test_high_alert_on_moderate_wal(tmp_path, monkeypatch, _tiny_thresholds):
+    db_path = _make_wal(tmp_path, 300)
+    monkeypatch.setattr("genesis.env.genesis_db_path", lambda: str(db_path))
+    spy = AsyncMock()
+    monkeypatch.setattr(loop.observations, "create", spy)
+
+    await loop._check_wal_health(object())
+
+    spy.assert_called_once()
+    assert spy.call_args.kwargs["priority"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_cooldown_one_alert_per_window(tmp_path, monkeypatch, _tiny_thresholds):
+    db_path = _make_wal(tmp_path, 600)
+    monkeypatch.setattr("genesis.env.genesis_db_path", lambda: str(db_path))
+    spy = AsyncMock()
+    monkeypatch.setattr(loop.observations, "create", spy)
+
+    await loop._check_wal_health(object())
+    await loop._check_wal_health(object())
+
+    spy.assert_called_once()  # second call suppressed by cooldown
+
+
+@pytest.mark.asyncio
+async def test_no_alert_when_wal_absent(tmp_path, monkeypatch):
+    db_path = tmp_path / "genesis.db"  # no -wal file created
+    monkeypatch.setattr("genesis.env.genesis_db_path", lambda: str(db_path))
+    spy = AsyncMock()
+    monkeypatch.setattr(loop.observations, "create", spy)
+
+    await loop._check_wal_health(object())
+
+    spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_swallows_create_errors(tmp_path, monkeypatch, _tiny_thresholds):
+    db_path = _make_wal(tmp_path, 600)
+    monkeypatch.setattr("genesis.env.genesis_db_path", lambda: str(db_path))
+    monkeypatch.setattr(
+        loop.observations, "create", AsyncMock(side_effect=RuntimeError("db down"))
+    )
+
+    # Must not raise into the tick.
+    await loop._check_wal_health(object())

--- a/tests/test_awareness/test_wal_health.py
+++ b/tests/test_awareness/test_wal_health.py
@@ -22,9 +22,9 @@ def _make_wal(tmp_path, size_bytes: int):
 
 @pytest.fixture(autouse=True)
 def _reset_cooldown():
-    loop._last_wal_alert_at = 0.0
+    loop._last_wal_alert_at = None
     yield
-    loop._last_wal_alert_at = 0.0
+    loop._last_wal_alert_at = None
 
 
 @pytest.fixture
@@ -117,3 +117,22 @@ def test_infrastructure_alert_type_is_registered():
     from genesis.db.crud import observations
 
     assert "infrastructure_alert" in observations._TTL_BY_TYPE
+
+
+@pytest.mark.asyncio
+async def test_first_alert_fires_on_fresh_boot_small_monotonic(
+    tmp_path, monkeypatch, _tiny_thresholds
+):
+    """Regression: time.monotonic() is since-boot, so on a freshly-booted host it
+    is small. With a 0.0 sentinel, `now - 0.0 < cooldown` wrongly suppressed the
+    FIRST alert (it passed only on a long-uptime host). The None sentinel must fire
+    the first alert regardless of the monotonic value."""
+    db_path = _make_wal(tmp_path, 600)
+    monkeypatch.setattr("genesis.env.genesis_db_path", lambda: str(db_path))
+    monkeypatch.setattr(loop.time, "monotonic", lambda: 5.0)  # fresh boot, ~5s uptime
+    spy = AsyncMock()
+    monkeypatch.setattr(loop.observations, "create", spy)
+
+    await loop._check_wal_health(object())
+
+    spy.assert_called_once()  # must NOT be suppressed by the cooldown on first run

--- a/tests/test_db/test_connection_pragmas.py
+++ b/tests/test_db/test_connection_pragmas.py
@@ -1,0 +1,55 @@
+"""Tests for WAL-bounding pragmas + the (now async) WAL checkpoint helpers.
+
+journal_size_limit caps the WAL file in normal operation; the checkpoint helpers
+must use the async aiosqlite API (the old sync ``db._conn._conn.execute`` path
+raised a thread-bound ProgrammingError that a bare except swallowed → no-op).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from genesis.awareness import loop
+from genesis.db.connection import get_db, get_raw_db
+
+_LIMIT = 67108864  # 64 MB
+
+
+@pytest.mark.asyncio
+async def test_get_db_sets_journal_size_limit(tmp_path):
+    db = await get_db(tmp_path / "g.db")
+    try:
+        rows = await db.execute_fetchall("PRAGMA journal_size_limit")
+        assert rows[0][0] == _LIMIT
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_get_raw_db_sets_journal_size_limit(tmp_path):
+    async with get_raw_db(tmp_path / "g.db") as db:
+        rows = await db.execute_fetchall("PRAGMA journal_size_limit")
+        assert rows[0][0] == _LIMIT
+
+
+@pytest.mark.asyncio
+async def test_wal_checkpoint_helpers_actually_run(tmp_path):
+    """Regression: the helpers use the async API, so a TRUNCATE actually reclaims
+    the WAL file (the old main-thread raw-cursor path was a silent no-op)."""
+    db_path = tmp_path / "g.db"
+    db = await get_db(db_path)
+    try:
+        await db.execute("CREATE TABLE t (x INTEGER)")
+        for i in range(200):
+            await db.execute("INSERT INTO t VALUES (?)", (i,))
+        await db.commit()
+
+        wal = Path(f"{db_path}-wal")
+        # PASSIVE must not raise; TRUNCATE should zero the WAL file (sole reader).
+        await loop._sqlite_wal_checkpoint(db)
+        await loop._sqlite_wal_truncate(db)
+
+        assert (not wal.exists()) or wal.stat().st_size == 0
+    finally:
+        await db.close()

--- a/tests/test_db/test_cursor_cancellation.py
+++ b/tests/test_db/test_cursor_cancellation.py
@@ -1,0 +1,146 @@
+"""Guard tests for DB read cancellation-safety (the WAL-pin root cause).
+
+Root cause (empirically proven 2026-06-15): on a long-lived aiosqlite connection
+in WAL mode, the pattern ``cursor = await db.execute(SELECT); await cursor.fetchone()``
+opens a read snapshot and, if the coroutine is CANCELLED between ``execute`` and the
+cursor closing, leaves the snapshot pinned — which (a) blocks the WAL checkpoint
+(unbounded WAL growth) and (b) makes that connection's next write fail
+``database is locked``.
+
+The fix routes reads through ``execute_fetchall`` (or ``async with db.execute(...)``),
+which never leaves a dangling cursor on the asyncio side. These tests lock in that
+property so a future aiosqlite change can't silently reintroduce the leak.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import aiosqlite
+import pytest
+
+
+async def _mk(path) -> aiosqlite.Connection:
+    c = await aiosqlite.connect(str(path))
+    c.row_factory = aiosqlite.Row
+    await c.execute("PRAGMA journal_mode=WAL")
+    await c.execute("PRAGMA busy_timeout=2000")
+    await c.execute("PRAGMA wal_autocheckpoint=0")  # don't auto-drain — we measure the pin
+    return c
+
+
+async def _seed(path) -> None:
+    c = await _mk(path)
+    await c.execute("CREATE TABLE t (k TEXT PRIMARY KEY, v TEXT)")
+    for i in range(5):
+        await c.execute("INSERT INTO t VALUES (?,?)", (f"multi{i}", str(i)))
+    await c.commit()
+    await c.close()
+
+
+async def _advance(writer: aiosqlite.Connection, n: int = 40) -> None:
+    """Push the WAL forward so a stale snapshot becomes detectable."""
+    for i in range(n):
+        await writer.execute("INSERT OR REPLACE INTO t VALUES (?,?)", (f"adv{i}", str(i)))
+        await writer.commit()
+
+
+async def _is_pinned(path) -> bool:
+    """True if a TRUNCATE checkpoint is blocked by a lingering reader."""
+    ck = await _mk(path)
+    try:
+        cur = await ck.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        busy, log, ckpt = tuple(await cur.fetchone())
+        return busy == 1 or (log > 0 and ckpt < log)
+    finally:
+        await ck.close()
+
+
+@pytest.mark.asyncio
+async def test_unsafe_cursor_pattern_leaks_under_cancellation(tmp_path):
+    """Characterization: the raw cursor pattern DOES pin under cancellation.
+
+    This documents *why* the fix exists. If this ever stops reproducing, the
+    cancellation-safety concern may no longer apply.
+    """
+    db_path = tmp_path / "leak.db"
+    await _seed(db_path)
+    conn = await _mk(db_path)
+    writer = await _mk(db_path)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def holder():
+        cur = await conn.execute("SELECT v FROM t WHERE k LIKE 'multi%'")
+        started.set()
+        await release.wait()  # parked — cancelled instead of released
+        await cur.fetchone()
+        await cur.close()
+
+    task = asyncio.create_task(holder())
+    await started.wait()
+    await _advance(writer)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert await _is_pinned(db_path) is True
+    await writer.close()
+    await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_execute_fetchall_is_cancellation_safe(tmp_path):
+    """The fix: execute_fetchall never leaves a snapshot pinned, even if cancelled."""
+    db_path = tmp_path / "safe.db"
+    await _seed(db_path)
+    conn = await _mk(db_path)
+    writer = await _mk(db_path)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def holder():
+        await conn.execute_fetchall("SELECT v FROM t WHERE k LIKE 'multi%'")
+        started.set()
+        await release.wait()
+
+    task = asyncio.create_task(holder())
+    await started.wait()
+    await _advance(writer)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert await _is_pinned(db_path) is False
+    # and the connection can still write
+    await conn.execute("INSERT OR REPLACE INTO t VALUES ('w','1')")
+    await conn.commit()
+    await writer.close()
+    await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_async_with_execute_is_cancellation_safe(tmp_path):
+    """async with db.execute(...) as cursor closes the cursor even on cancellation."""
+    db_path = tmp_path / "ctx.db"
+    await _seed(db_path)
+    conn = await _mk(db_path)
+    writer = await _mk(db_path)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def holder():
+        async with conn.execute("SELECT v FROM t WHERE k LIKE 'multi%'") as cur:
+            await cur.fetchone()
+            started.set()
+            await release.wait()  # parked inside the context — cancellation triggers __aexit__
+
+    task = asyncio.create_task(holder())
+    await started.wait()
+    await _advance(writer)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert await _is_pinned(db_path) is False
+    await writer.close()
+    await conn.close()

--- a/tests/test_memory/test_mcp_integration.py
+++ b/tests/test_memory/test_mcp_integration.py
@@ -228,6 +228,7 @@ async def test_memory_stats_returns_dict(mock_deps, tools):
         cursor_mock = AsyncMock()
         cursor_mock.fetchone = AsyncMock(return_value=(5,))
         db_mock.execute = AsyncMock(return_value=cursor_mock)
+        db_mock.execute_fetchall = AsyncMock(return_value=[(5,)])
 
         result = await tools["memory_stats"].fn()
 

--- a/tests/test_memory/test_supersession.py
+++ b/tests/test_memory/test_supersession.py
@@ -250,15 +250,13 @@ async def test_search_ranked_excludes_deprecated_by_default():
     import aiosqlite
 
     db = AsyncMock(spec=aiosqlite.Connection)
-    cursor = AsyncMock()
-    cursor.fetchall = AsyncMock(return_value=[])
-    db.execute = AsyncMock(return_value=cursor)
+    db.execute_fetchall = AsyncMock(return_value=[])
 
     from genesis.db.crud.memory import search_ranked
     await search_ranked(db, query="test query")
 
     # Verify the SQL includes the deprecated filter
-    sql = db.execute.call_args[0][0]
+    sql = db.execute_fetchall.call_args[0][0]
     assert "deprecated" in sql
     assert "deprecated = 0" in sql or "deprecated IS NULL" in sql
 
@@ -269,15 +267,13 @@ async def test_search_ranked_includes_deprecated_when_requested():
     import aiosqlite
 
     db = AsyncMock(spec=aiosqlite.Connection)
-    cursor = AsyncMock()
-    cursor.fetchall = AsyncMock(return_value=[])
-    db.execute = AsyncMock(return_value=cursor)
+    db.execute_fetchall = AsyncMock(return_value=[])
 
     from genesis.db.crud.memory import search_ranked
     await search_ranked(db, query="test query", include_deprecated=True)
 
     # Verify the SQL does NOT include the deprecated filter
-    sql = db.execute.call_args[0][0]
+    sql = db.execute_fetchall.call_args[0][0]
     assert "deprecated = 0" not in sql
 
 


### PR DESCRIPTION
## Problem

Under heavy load or a provider outage, saving to memory (`reference_store` /
`memory_store`) could fail with `OperationalError: database is locked`, and
SQLite's write-ahead log could balloon (it reached ~2 GB in the Jun-13 incident,
freezing checkpoints for ~2 days).

**Root cause (empirically reproduced):** a read coroutine on a long-lived MCP
connection, if cancelled between `cursor = await db.execute(SELECT…)` and the
cursor closing, leaves a pinned SQLite read snapshot. In WAL mode that (a) pins
the checkpoint so the WAL can't truncate, and (b) makes that connection's next
write fail `SQLITE_BUSY` permanently. An earlier `isolation_level=None`
(autocommit) hypothesis was **falsified** — it does not release a held snapshot
and breaks multi-statement atomic writes.

## Fix

1. **Cursor cancellation-safety** — memory-subsystem reads route through
   `execute_fetchall` (returns `list[Row]`, no dangling asyncio cursor) or
   `async with db.execute(...) as cursor:` for `cursor.description` sites. Writes
   are untouched; deferred-isolation atomicity is preserved.
2. **Detection** — `_check_wal_health` raises a high/critical observation
   (surfaced to Telegram + the morning report) when the WAL file is abnormally
   large, so a stuck reader is caught in minutes, not days.
3. **Bounding** — `PRAGMA journal_size_limit=64MB` on the connection helpers and
   the four MCP bootstraps; an hourly `wal_checkpoint(TRUNCATE)` reclaims WAL
   file space.
4. **Bug fix** — the manual WAL checkpoint was a silent no-op: it ran sqlite3
   from the event-loop thread (`db._conn._conn.execute`), which raises a
   thread-bound `ProgrammingError` that a bare `except` swallowed. It now goes
   through the async aiosqlite API so it actually runs.

## Scope

The conversion targets the **memory subsystem** — the connection that pinned the
WAL in production. The remaining ~520 CRUD read sites (mostly short-lived
`get_raw_db` connections that auto-close) are a tracked follow-up.

## Verification

- Empirical repro confirms the cancellation leak **and** that `execute_fetchall`
  is cancellation-safe (including cancelled in-flight).
- New guard tests: `test_db/test_cursor_cancellation.py`,
  `test_awareness/test_wal_health.py`, `test_db/test_connection_pragmas.py`
  (incl. a regression test proving the checkpoint now actually runs).
- `test_db` + `test_memory` + `test_awareness` green (1253 + 553 passing);
  ruff clean; an independent code-review pass was applied (registered the
  `infrastructure_alert` TTL; hardened `count()`).
