### PR TITLE
fix(voice): make S2S response length a judgment, not a sentence quota

### DIFF
--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -110,14 +110,22 @@ with a relevant query to demonstrate the capability.
 Better to be thorough than to guess wrong.
 
 VOICE RULES:
-- Keep responses to 2-4 sentences for direct answers. When summarizing tool \
-results (memory, search), cover the most important 2-3 points. If there's \
-more to share, end with "Want me to go deeper?" and wait for the user.
-- Avoid unnecessary filler — don't restate the question, don't end with \
-"let me know if you need anything." Start with the answer.
-- Never use markdown, bullet points, or formatting. Speak naturally.
-- Don't narrate what you're doing ("Let me search..."). Just do it silently \
-and report the result.
+- Length is a judgment call, not a quota. Match it to what the question actually \
+needs — and nothing more. A simple, factual question ("what time is it?", "is the \
+server up?") deserves ONE sentence: answer it and stop. Add a second or third \
+sentence only when the question is genuinely open-ended, the user asks for more, \
+or a detail would actually change what they do next. When in doubt, say less — \
+they can always ask for more.
+- Never explain things the user didn't ask about. No unsolicited background, \
+caveats, or "here's why" — over voice that's just noise. Don't restate the \
+question; no filler openers or closers ("let me know if you need anything"). \
+Lead with the answer.
+- For a dense tool result (memory, search), give only the 1-3 points that matter \
+for what they asked, then offer "Want me to go deeper?" — and only if there's \
+genuinely more worth hearing.
+- Never use markdown, bullet points, or formatting. Speak naturally, like someone \
+who respects the listener's time.
+- Don't narrate what you're doing ("Let me search..."). Just do it and report the result.
 
 APPROVAL RULES:
 - "approve it" / "yes go ahead" / "do it" → call approve_pending with \


### PR DESCRIPTION
## What
Voice responses padded trivial questions with unsolicited explanation. Asking the device *"what time and day is it?"* produced a ~26-second, 3-sentence answer (verified in live logs) when one sentence was wanted.

## Why
The prompt (`genesis_bridge.py` VOICE RULES) said *"Keep responses to 2-4 sentences for direct answers"* — a **floor** of 2 sentences. The model padded simple answers up to the range with irrelevant elaboration.

## Change
Replace the fixed range with **length-to-fit judgment**:
- A simple factual question gets **one sentence** and stops; elaborate only when the question is open-ended, the user asks, or a detail changes what they do next. "When in doubt, say less."
- Ban unsolicited background/caveats/"here's why" outright.
- Keep: the tool-result "Want me to go deeper?" offer, no-markdown/no-narration rules, and the `{voice_context}` placeholder.

Can't be hardcoded per-case (length is situational) — this is guidance for the model to *judge*.

## Verification
- `ruff` clean; targeted `test_voice_s2s.py` (system-prompt assertions) pass; `{voice_context}` placeholder intact.
- Behavioral validation is **live** (a prompt change's real test is the device): deploy = genesis-server restart + bridge re-fetch, then a voice conversation confirms simple questions get short answers without regressing genuine depth.