### PR TITLE
feat(content-publish): log published articles to Discord showcase pool

### DIFF
--- a/.claude/skills/content-publish/SKILL.md
+++ b/.claude/skills/content-publish/SKILL.md
@@ -169,6 +169,13 @@ Store the outcome in memory:
 - `memory_store` with tags: `["content", "published", "medium"]`
 - Content: topic, URL, date, any engagement data later
 
+Append to the Discord campaign showcase pool so the next campaign tick
+can reference this article:
+- File: `~/.genesis/campaigns/discord-engagement/showcase-pool.md`
+- Append under `## Published Medium Articles` with today's date, title,
+  and a 2-3 line summary of the article's argument/angle
+- The campaign session uses this as safe public content to share
+
 ## Error Handling
 
 | Error | Action |


### PR DESCRIPTION
## What
Step 8 of the `content-publish` skill now appends each published article (date, title, 2-3 line argument summary) to the Discord campaign showcase pool, so the next campaign tick has already-approved public content to reuse instead of re-sourcing it.

## Scope
Documentation/procedure only — one skill file, +7 lines. No code.

## Review
Reviewed via Claude code-reviewer (Codex temporarily out of credits): PASS, no issues. Confirmed only already-approved public content (topic/URL/date/summary) flows through the showcase path; no private data, credentials, or infra details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)