### PR TITLE
feat(install): D16 CLAUDE.md inheritance split + set_secret atomicity (WS-13 PR1)

### DIFF
--- a/config/operator-claude.md
+++ b/config/operator-claude.md
@@ -1,0 +1,30 @@
+# Operator — You're on a Genesis Host VM
+
+You (a human) are SSHed into the **host VM** of a Genesis install. You are **not** inside Genesis,
+and you are **not** the Guardian. Genesis (the autonomous agent) runs inside an Incus container; a
+host-side **Guardian** systemd timer watches that container and can auto-recover it.
+
+Shared install facts (host/container identity, IPs, dashboard URL) are in `~/.claude/CLAUDE.md`,
+auto-loaded alongside this file.
+
+## Stop / pause the Guardian (e.g. before host maintenance)
+
+The Guardian checks for a maintenance flag on every tick and stands down if it is present:
+
+- **Pause**:  `touch /var/lib/guardian-snapshots/.guardian-maintenance`
+- **Resume**: `rm /var/lib/guardian-snapshots/.guardian-maintenance`
+- **Hard stop**: `systemctl --user stop genesis-guardian.timer genesis-guardian-watchman.timer`
+  (stop the watchman too — it re-arms the guardian timer)
+- **Status / logs**: `systemctl --user status genesis-guardian.timer` ·
+  `journalctl --user -u genesis-guardian -n 50`
+
+## Work inside Genesis (the container)
+
+- `genesis`  — alias added to your `~/.bashrc`, or
+- `incus exec __CONTAINER_NAME__ --user __UBUNTU_UID__ --env HOME=/home/ubuntu --cwd /home/ubuntu/genesis -t -- bash -l`
+
+## Don't
+
+- Don't hand-edit `~/.local/share/genesis-guardian/` — it's a deploy target (overwritten on update).
+- Genesis's own config/state/database live **in the container** under `~/.genesis/` and `~/genesis/`,
+  not on the host.

--- a/config/operator-claude.md
+++ b/config/operator-claude.md
@@ -20,8 +20,8 @@ The Guardian checks for a maintenance flag on every tick and stands down if it i
 
 ## Work inside Genesis (the container)
 
-- `genesis`  — alias added to your `~/.bashrc`, or
-- `incus exec __CONTAINER_NAME__ --user __UBUNTU_UID__ --env HOME=/home/ubuntu --cwd /home/ubuntu/genesis -t -- bash -l`
+- `genesis`  — alias added to your `~/.bashrc` (drops you straight into the repo), or
+- `incus exec __CONTAINER_NAME__ --user __UBUNTU_UID__ --env HOME=/home/ubuntu -t -- bash -l`, then `cd genesis`
 
 ## Don't
 

--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -1206,6 +1206,81 @@ PYEOF
     fi
 fi
 
+# ── Shared user-level CLAUDE.md on the host (D16) ──────────────
+# Auto-loaded by every `claude` session on the host (operator + Guardian
+# diagnostic). Common "this is a Genesis install" facts inherited by the
+# operator-project and Guardian-project CLAUDE.mds. Managed blocks are rebuilt
+# each run from a quoted heredoc (no shell expansion → backticks safe) with
+# placeholders filled by sed; the hand-editable "Personal Notes" is preserved.
+_host_claude="$_host_home/.claude/CLAUDE.md"
+_hostname="$(hostname 2>/dev/null || echo unknown)"
+_host_tz="${_final_tz:-$(timedatectl show -p Timezone --value 2>/dev/null || echo unknown)}"
+_ctr_ip="${CONTAINER_IPV4:-unknown}"
+_hc_notes=""
+[ -f "$_host_claude" ] && _hc_notes="$(sed -n '/^## Personal Notes$/,$p' "$_host_claude")"
+[ -z "$_hc_notes" ] && _hc_notes='## Personal Notes
+
+(Install scripts preserve this section. Add machine-specific reminders here.)'
+cat > "$_host_claude" <<'HCDOC'
+# Genesis Host VM — Shared Context
+
+This machine is a **Genesis install host**. Genesis (the autonomous agent) runs inside an Incus
+container; a host-side **Guardian** systemd timer watches it and can recover it. This file is shared
+context auto-loaded by every `claude` session on this host (operator and Guardian-diagnostic).
+
+<!-- begin:host-identity -->
+## Host
+- **User**: __HOST_USER__
+- **Hostname**: __HOSTNAME__
+- **Timezone**: __HOST_TZ__
+<!-- end:host-identity -->
+
+<!-- begin:container-reference -->
+## Container
+- **Name**: __CONTAINER_NAME__
+- **IP**: __CONTAINER_IP__  (dashboard: http://__CONTAINER_IP__:5000)
+- **Enter it**: `genesis` alias, or `incus exec __CONTAINER_NAME__ --user __UBUNTU_UID__ --env HOME=/home/ubuntu -- bash -l`
+<!-- end:container-reference -->
+
+<!-- begin:guardian-paths -->
+## Guardian (host-side watcher)
+- **Install**: `~/.local/share/genesis-guardian`  ·  **State**: `~/.local/state/genesis-guardian`
+- **Pause**: `touch /var/lib/guardian-snapshots/.guardian-maintenance` (stands down each tick; `rm` to resume)
+- **Hard stop**: `systemctl --user stop genesis-guardian.timer genesis-guardian-watchman.timer`
+- **Status**: `systemctl --user status genesis-guardian.timer`
+<!-- end:guardian-paths -->
+
+HCDOC
+printf '%s\n' "$_hc_notes" >> "$_host_claude"
+sed -i \
+    -e "s|__HOST_USER__|$_host_user|g" \
+    -e "s|__HOSTNAME__|$_hostname|g" \
+    -e "s|__HOST_TZ__|$_host_tz|g" \
+    -e "s|__CONTAINER_NAME__|$CONTAINER_NAME|g" \
+    -e "s|__CONTAINER_IP__|$_ctr_ip|g" \
+    -e "s|__UBUNTU_UID__|$UBUNTU_UID|g" \
+    "$_host_claude"
+chown "$_host_user:" "$_host_claude" 2>/dev/null || true
+echo "  + Shared user-level CLAUDE.md written to $_host_claude"
+
+# ── Operator-project CLAUDE.md in the host SSH-landing dir (D16) ──
+# A human who SSHes in cold lands in their home dir; `claude` there auto-loads
+# this project file (orients the operator, not the Guardian). Static template
+# + container-name fill. Guard: never clobber an unrelated ~/CLAUDE.md.
+_operator_src="$(dirname "$_SCRIPT_DIR")/config/operator-claude.md"
+_operator_dst="$_host_home/CLAUDE.md"
+if [ -f "$_operator_src" ]; then
+    if [ ! -f "$_operator_dst" ] || grep -q "Operator — You're on a Genesis Host VM" "$_operator_dst" 2>/dev/null; then
+        sed -e "s|__CONTAINER_NAME__|$CONTAINER_NAME|g" -e "s|__UBUNTU_UID__|$UBUNTU_UID|g" "$_operator_src" > "$_operator_dst"
+        chown "$_host_user:" "$_operator_dst" 2>/dev/null || true
+        echo "  + Operator CLAUDE.md written to $_operator_dst"
+    else
+        echo "  . $_operator_dst exists and isn't ours — leaving it untouched"
+    fi
+else
+    echo "  WARNING: $_operator_src not found — operator CLAUDE.md not placed"
+fi
+
 # ── Convenience alias on host ─────────────────────────────────
 # The full incus exec command is long and easy to get wrong. Add a 'genesis'
 # alias that sets HOME, XDG_RUNTIME_DIR, and cwd correctly.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -53,13 +53,20 @@ should_prompt() {
     return 1
 }
 
-# Write a key=value to secrets.env without sed metacharacter risk
+# Write a key=value to secrets.env atomically (no sed metacharacter risk, and no
+# lost/duplicated key on interruption). Builds the full new content in a temp file
+# in the same dir, then a single atomic rename. mktemp creates the temp 0600, so
+# the secret is never world-readable mid-write; perms are matched to the original.
+# NOTE: `key` is used as a grep BRE anchor (`^${key}=`); all callers pass literal
+# [A-Z_]+ enum keys, so there is no regex metacharacter in the key name.
 set_secret() {
-    local key="$1" value="$2" file="$3"
-    if grep -q "^${key}=" "$file" 2>/dev/null; then
-        grep -v "^${key}=" "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
-    fi
-    echo "${key}=${value}" >> "$file"
+    local key="$1" value="$2" file="$3" tmp
+    tmp="$(mktemp "${file}.XXXXXX")" || return 1
+    # All existing lines except this key, then the (single) new line.
+    { grep -v "^${key}=" "$file" 2>/dev/null || true; printf '%s=%s\n' "$key" "$value"; } > "$tmp" \
+        || { rm -f "$tmp"; return 1; }
+    [ -f "$file" ] && chmod --reference="$file" "$tmp" 2>/dev/null || true
+    mv -f "$tmp" "$file" || { rm -f "$tmp"; return 1; }
 }
 
 # ── HOME guard ───────────────────────────────────────────────

--- a/scripts/install_guardian.sh
+++ b/scripts/install_guardian.sh
@@ -401,11 +401,35 @@ if [ -f "$INSTALL_DIR/config/guardian-claude.md" ]; then
     # tries to merge the repo's container CLAUDE.md over the Guardian version.
     if [ -d "$INSTALL_DIR/.git" ]; then
         cd "$INSTALL_DIR" && git update-index --skip-worktree CLAUDE.md 2>/dev/null || true
+    else
+        echo "  NOTE: $INSTALL_DIR/.git not found — CLAUDE.md skip-worktree not set"
+        echo "        (ok for a non-git deploy; a future 'git pull' here could overwrite CLAUDE.md)"
     fi
+
+    # D16: the diagnostic CC runs with cwd = cc.work_dir (see diagnosis.py), so the
+    # Guardian CLAUDE.md must live there to be auto-loaded as project context — the
+    # install-dir copy is never seen by that CC session. Symlink so it tracks every
+    # regeneration of the install-dir CLAUDE.md (install + gateway update/redeploy).
+    _gd_work_dir="/var/lib/guardian-snapshots/cc-sessions"   # = guardian.yaml cc.work_dir default
+    if [ ! -d "$_gd_work_dir" ]; then
+        if sudo -n true 2>/dev/null; then
+            sudo mkdir -p "$_gd_work_dir" \
+                && sudo chown "$(id -un):$(id -gn)" "$_gd_work_dir" "$(dirname "$_gd_work_dir")" 2>/dev/null || true
+        else
+            mkdir -p "$_gd_work_dir" 2>/dev/null || true
+        fi
+    fi
+    if [ -d "$_gd_work_dir" ]; then
+        ln -sf "$INSTALL_DIR/CLAUDE.md" "$_gd_work_dir/CLAUDE.md" \
+            && echo "  + Guardian CLAUDE.md linked into work_dir ($_gd_work_dir)" \
+            || echo "  WARN: could not link CLAUDE.md into $_gd_work_dir"
+    else
+        echo "  WARN: work_dir $_gd_work_dir absent — diagnostic CC won't load the Guardian CLAUDE.md"
+    fi
+    echo "  CLAUDE.md generated"
 else
     echo "  WARNING: config/guardian-claude.md not found — CLAUDE.md not generated"
 fi
-echo "  CLAUDE.md generated"
 
 # ── Step 8: Install systemd units ─────────────────────────────────────
 


### PR DESCRIPTION
## Summary

**WS-13 PR1 (surgical):** implements the audit's **D16 three-file CLAUDE.md inheritance split** on the host VM, plus a confirmed `set_secret` atomicity fix. PR2 (Guardian stop-reliability fixes — `cc-loop-01`, `GUARD-R2-01`) follows separately.

### D16 — three-file CLAUDE.md split

A `claude` session loads `~/.claude/CLAUDE.md` (user-level) plus a project `CLAUDE.md` discovered from its cwd. This PR wires that inheritance on the host:

- **Shared user-level `~/.claude/CLAUDE.md`** (`host-setup.sh`) — common "this is a Genesis install" facts (host / container / guardian) in managed `<!-- begin:SECTION -->` blocks; the hand-editable Personal Notes section is preserved across re-runs.
- **Guardian-project CLAUDE.md → the diagnosis CC work_dir** (`install_guardian.sh`) — the diagnostic CC runs with `cwd = cc.work_dir`, so the install-dir copy was **never auto-loaded**. It's now symlinked into the work_dir (tracking regenerations of the install-dir copy).
- **Operator-project CLAUDE.md** (new `config/operator-claude.md`) — orients a human who SSHes into the host cold: how to pause/stop the Guardian (`.guardian-maintenance` + `systemctl --user`), how to enter the container. Guarded so it never clobbers an unrelated `~/CLAUDE.md`.

### `set_secret` atomicity (`install.sh`)

The old `set_secret` could **lose** a key (interrupted between the `mv` and the `echo`) or **duplicate** it (on a `grep` short-circuit). It now builds the full new content in a co-located `mktemp` (0600) and does a single atomic rename, preserving the original perms.

### Also

- `install_guardian.sh`: warn instead of silently skipping `skip-worktree` when the install dir isn't a git checkout; fix a self-contradicting `"CLAUDE.md generated"` log that printed even on the template-missing path.

## Verification

- `shellcheck` clean on all modified scripts.
- `set_secret` unit test: overwrite produces no duplicate, values containing `&`/`$`/`\` survive, perms stay `0600`, no temp-file leak on failure.
- **Live end-to-end on a host:** `claude --print` in the Guardian work_dir loads the Guardian CLAUDE.md; a `claude` session in the operator home dir loads **both** the shared user-level and the operator project file; the Guardian stayed healthy throughout.
- Real-code isolation test of the `host-setup.sh` blocks: managed blocks fill correctly, idempotent re-run preserves Personal Notes (no duplication, no placeholder leakage), and the operator clobber-guard works.

## Review

Codex (primary adversarial reviewer) was quota-exhausted; the fallback reviewer flagged 5 issues — **3 applied** (temp-file leak on disk-full, operator-doc UID placeholder, self-contradicting log line) and **2 rejected with rationale** (the parent-dir `chown` is required for the operator-runnable maintenance-flag mechanism; a suggested `grep -Fv` change was itself buggy — `-F` makes the `^` anchor literal and would *cause* duplicate keys).

## Scope note

`install.sh` / `host-setup.sh` are the public installer and can't be fresh-tested in this environment, so changes are deliberately **surgical**. Lower-value install-script polish (tool-version centralization, container-specs population, etc.) is intentionally deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
