### PR TITLE
fix(guardian): alert once per down-episode + restored ping (GUARD-R2-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The Guardian alerts once when Genesis goes down — and once when it's back** —
+  previously, if Genesis went down and its diagnosis couldn't reach Claude Code,
+  the host Guardian re-ran a full investigation and re-sent a critical Telegram
+  alert every 30 seconds until recovery — an alert storm. It now sends a single
+  "down" alert per outage (no repeats, however long it lasts), and when Genesis
+  comes back on its own it sends a single "restored" notification — which it
+  never did before.
+
 - **Memory writes no longer get stuck behind a database lock** — under heavy load
   or a provider outage, a cancelled database read could leave a stale lock that
   made saving to memory (`reference_store` / `memory_store`) fail with "database

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -236,6 +236,23 @@ async def _check_cycle(
 
     # Step 3: Act based on state
     if state == GuardianState.HEALTHY:
+        # GUARD-R2-01: on GENUINE recovery from a down-episode we alerted about,
+        # send ONE "restored" ping and clear the flag. Gate on snapshot.all_alive
+        # so auto-reset (routes CONFIRMED_DEAD→HEALTHY while STILL down,
+        # all_alive=False) neither pings nor clears — the storm stays suppressed.
+        if sm.state.down_alert_sent and snapshot.all_alive:
+            if transition.old_state == GuardianState.CONFIRMED_DEAD:
+                # Autonomous recovery (container returned on its own — process()
+                # detected all_alive). The recovery-engine / CC-resolved /
+                # approval / self-heal paths clear the flag at their own
+                # recovery point + emit their own success alert, so
+                # down_alert_sent is already False here for them — no double-ping.
+                await dispatcher.send(Alert(
+                    severity=AlertSeverity.INFO,
+                    title="Genesis recovered",
+                    body="Genesis is back online — all health signals passing.",
+                ))
+            sm.clear_down_alert_sent()
         await _handle_healthy(config, snapshots)
 
     elif state == GuardianState.SIGNAL_DROPPED:
@@ -493,6 +510,9 @@ async def _proceed_to_diagnosis(
         body="Genesis could not be contacted or could not self-heal. "
              "Running full diagnostics...",
     ))
+    # GUARD-R2-01: this episode's "down" alert has now fired — subsequent
+    # CONFIRMED_DEAD ticks must NOT re-diagnose/re-alert (no 30s storm).
+    sm.mark_down_alert_sent()
 
     diagnostic = await collect_diagnostics(config)
     signal_summary = json.dumps(sm.state.signal_history[-5:], indent=2)
@@ -561,6 +581,7 @@ async def _handle_cc_resolved(
 
     if sm.current_state == GuardianState.HEALTHY:
         logger.info("CC-driven recovery verified — Genesis is healthy")
+        sm.clear_down_alert_sent()  # GUARD-R2-01: episode over (CC auto-resolved)
         await dispatcher.send(Alert(
             severity=AlertSeverity.INFO,
             title="Genesis recovered (CC auto-resolved)",
@@ -616,9 +637,31 @@ async def _handle_confirmed_dead(
     recovery_engine: RecoveryEngine,
 ) -> None:
     """Handle confirmed dead state — re-diagnose and attempt recovery."""
-    diagnostic = await collect_diagnostics(config)
-    signal_summary = json.dumps(sm.state.signal_history[-5:], indent=2)
-    diagnosis = await diagnosis_engine.diagnose(diagnostic, signal_summary)
+    # GUARD-R2-01: alert once per down-episode. If we already notified the user
+    # this episode, stay quiet — no re-diagnosis (the expensive Opus run), no
+    # recovery retry, no re-alert — until genuine recovery (which clears the flag
+    # and sends a single "restored" ping). Recovery detection is unaffected: it
+    # happens in state_machine.process() via the cheap signal probes, not here.
+    if sm.state.down_alert_sent:
+        logger.info(
+            "Down alert already sent this episode — staying quiet until recovery "
+            "(no re-diagnosis/re-alert)",
+        )
+        return
+    # First handler for this episode (e.g. reached CONFIRMED_DEAD via the
+    # self-heal-escalation path that skips _proceed_to_diagnosis): own it now so
+    # the next tick skips.
+    sm.mark_down_alert_sent()
+
+    try:
+        diagnostic = await collect_diagnostics(config)
+        signal_summary = json.dumps(sm.state.signal_history[-5:], indent=2)
+        diagnosis = await diagnosis_engine.diagnose(diagnostic, signal_summary)
+    except Exception:
+        # Diagnosis failed before any alert fired — un-mark so the next tick
+        # retries instead of silently muting this episode.
+        sm.clear_down_alert_sent()
+        raise
 
     # Persist re-diagnosis to shared mount
     first_failure = sm.state.first_failure_at or datetime.now(UTC).isoformat()
@@ -729,6 +772,7 @@ async def _execute_recovery_with_approval(
                         "All signals healthy at approval time — skipping recovery"
                     )
                     sm.process(recheck)  # Transitions to HEALTHY
+                    sm.clear_down_alert_sent()  # GUARD-R2-01: episode over
                     await dispatcher.send(Alert(
                         severity=AlertSeverity.INFO,
                         title="Recovery cancelled — Genesis recovered",

--- a/src/genesis/guardian/recovery.py
+++ b/src/genesis/guardian/recovery.py
@@ -131,6 +131,7 @@ class RecoveryEngine:
             snapshot = await collect_all_signals(self._config)
             if snapshot.all_alive:
                 self._sm.set_recovered()
+                self._sm.clear_down_alert_sent()  # GUARD-R2-01: episode over
                 await self._dispatcher.send(Alert(
                     severity=AlertSeverity.INFO,
                     title=f"Recovery successful: {action.value}",

--- a/src/genesis/guardian/state_machine.py
+++ b/src/genesis/guardian/state_machine.py
@@ -69,6 +69,7 @@ class StateData:
     sentinel_state: str = ""  # Latest Sentinel state from dialogue response
     cc_unavailable_since: str | None = None
     last_cc_unavailable_alert_at: str | None = None
+    down_alert_sent: bool = False  # GUARD-R2-01: one "down" alert per episode (no storm)
     auto_reset_count: int = 0  # Oscillation guard for confirmed_dead timeout
     last_recovery_at: str | None = None  # ISO8601 timestamp of last recovery attempt
     io_triage_attempts: int = 0  # Separate counter for IO_TRIAGE (low-risk, repeatable)
@@ -93,6 +94,7 @@ class StateData:
             "sentinel_state": self.sentinel_state,
             "cc_unavailable_since": self.cc_unavailable_since,
             "last_cc_unavailable_alert_at": self.last_cc_unavailable_alert_at,
+            "down_alert_sent": self.down_alert_sent,
             "auto_reset_count": self.auto_reset_count,
             "last_recovery_at": self.last_recovery_at,
             "io_triage_attempts": self.io_triage_attempts,
@@ -123,6 +125,7 @@ class StateData:
             sentinel_state=data.get("sentinel_state", ""),
             cc_unavailable_since=data.get("cc_unavailable_since"),
             last_cc_unavailable_alert_at=data.get("last_cc_unavailable_alert_at"),
+            down_alert_sent=data.get("down_alert_sent", False),
             auto_reset_count=data.get("auto_reset_count", 0),
             last_recovery_at=data.get("last_recovery_at"),
             io_triage_attempts=data.get("io_triage_attempts", 0),
@@ -705,6 +708,20 @@ class ConfirmationStateMachine:
     def record_cc_unavailable_alert(self) -> None:
         """Record that we sent a CC-unavailable alert."""
         self._state.last_cc_unavailable_alert_at = datetime.now(UTC).isoformat()
+
+    def mark_down_alert_sent(self) -> None:
+        """Record that the one-per-episode 'down' alert has been sent (GUARD-R2-01).
+
+        Gates re-diagnosis/re-alert in CONFIRMED_DEAD so a downed-and-stays-down
+        container produces ONE down notification, not a 30s storm. Persisted in
+        state.json (each tick is a fresh oneshot process). Cleared only on genuine
+        recovery — NOT in _reset_to_healthy, which auto-reset also calls.
+        """
+        self._state.down_alert_sent = True
+
+    def clear_down_alert_sent(self) -> None:
+        """Clear the down-alert flag — called by check.py on genuine recovery only."""
+        self._state.down_alert_sent = False
 
     def should_escalate(self) -> bool:
         """Check if we've exceeded max recovery attempts."""

--- a/tests/test_guardian/test_check.py
+++ b/tests/test_guardian/test_check.py
@@ -9,12 +9,16 @@ import pytest
 
 from genesis.guardian.check import (
     _build_dispatcher,
+    _handle_cc_resolved,
+    _handle_confirmed_dead,
     _handle_healthy,
     _write_guardian_heartbeat,
     run_check,
 )
 from genesis.guardian.config import GuardianConfig
+from genesis.guardian.diagnosis import DiagnosisEngine, DiagnosisResult, RecoveryAction
 from genesis.guardian.health_signals import HealthSnapshot, PauseState, SignalResult
+from genesis.guardian.state_machine import ConfirmationStateMachine, GuardianState
 
 
 @pytest.fixture
@@ -221,3 +225,348 @@ class TestRunCheck:
         # State file should still be written
         state_file = config.state_path / "state.json"
         assert state_file.exists()
+
+
+def _dead_snapshot() -> HealthSnapshot:
+    """Container/probe failure — not all_alive."""
+    return HealthSnapshot(
+        signals={
+            "container_exists": SignalResult("container_exists", False, 1.0, "down", "t"),
+            "icmp_reachable": SignalResult("icmp_reachable", False, 1.0, "down", "t"),
+            "health_api": SignalResult("health_api", False, 1.0, "down", "t"),
+            "heartbeat_canary": SignalResult("heartbeat_canary", True, 1.0, "ok", "t"),
+            "log_freshness": SignalResult("log_freshness", True, 1.0, "ok", "t"),
+        },
+        pause_state=PauseState(paused=False),
+    )
+
+
+def _now_iso() -> str:
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC).isoformat()
+
+
+def _cc_unavailable_diagnosis() -> DiagnosisResult:
+    """The escalate/cc-unavailable diagnosis that storms today."""
+    return DiagnosisResult(
+        likely_cause="CC diagnosis unavailable — cannot determine root cause safely",
+        confidence_pct=0,
+        evidence=[],
+        recommended_action=RecoveryAction.ESCALATE,
+        reasoning="CC unavailable",
+        source="cc_unavailable",
+    )
+
+
+def _resolved_diagnosis() -> DiagnosisResult:
+    """CC reports it already fixed the issue (outcome=resolved)."""
+    return DiagnosisResult(
+        likely_cause="transient blip",
+        confidence_pct=90,
+        evidence=[],
+        recommended_action=RecoveryAction.RESTART_SERVICES,
+        reasoning="CC self-resolved",
+        source="cc",
+        outcome="resolved",
+        actions_taken=["restart_services"],
+    )
+
+
+def _seed_state(config: GuardianConfig, **fields) -> Path:
+    """Write a minimal state.json so run_check loads it (from_dict fills defaults)."""
+    import json
+
+    config.state_path.mkdir(parents=True, exist_ok=True)
+    state_path = config.state_path / "state.json"
+    state_path.write_text(json.dumps(fields))
+    return state_path
+
+
+def _alert_titles(mock_dispatcher: MagicMock) -> list[str]:
+    """Titles of every Alert passed to dispatcher.send (Alert is the positional arg)."""
+    return [call.args[0].title for call in mock_dispatcher.send.call_args_list]
+
+
+class TestGuardianAlertOnce:
+    """GUARD-R2-01 — alert once per down-episode + a single 'restored' ping.
+
+    Minimal scope: stop the every-30s storm (re-diagnosis + re-alert) and add the
+    currently-missing restored notification for autonomous recovery.
+    """
+
+    @pytest.mark.asyncio
+    async def test_handle_confirmed_dead_skips_when_down_alert_already_sent(
+        self, config: GuardianConfig
+    ) -> None:
+        """Repeat ticks must NOT re-diagnose or re-alert once the episode was handled."""
+        sm = ConfirmationStateMachine(config)
+        sm._state.current_state = GuardianState.CONFIRMED_DEAD
+        sm._state.down_alert_sent = True
+
+        dispatcher = MagicMock()
+        dispatcher.send = AsyncMock()
+        diagnosis_engine = MagicMock()
+        diagnosis_engine.diagnose = AsyncMock()
+        recovery_engine = MagicMock()
+        recovery_engine.execute = AsyncMock()
+
+        await _handle_confirmed_dead(
+            config, sm, dispatcher, diagnosis_engine, recovery_engine
+        )
+
+        diagnosis_engine.diagnose.assert_not_called()  # no expensive Opus re-run
+        dispatcher.send.assert_not_called()  # no re-alert
+        recovery_engine.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_confirmed_dead_proceeds_and_marks_flag_when_clear(
+        self, config: GuardianConfig
+    ) -> None:
+        """First handling (flag clear) diagnoses, then marks the episode as alerted."""
+        sm = ConfirmationStateMachine(config)
+        sm._state.current_state = GuardianState.CONFIRMED_DEAD
+        sm._state.down_alert_sent = False
+        sm._state.first_failure_at = _now_iso()
+
+        dispatcher = MagicMock()
+        dispatcher.send = AsyncMock()
+        diagnosis_engine = MagicMock()
+        diagnosis_engine.diagnose = AsyncMock(return_value=_cc_unavailable_diagnosis())
+        recovery_engine = MagicMock()
+        recovery_engine.execute = AsyncMock()
+
+        with (
+            patch("genesis.guardian.check.collect_diagnostics", AsyncMock(return_value={})),
+            patch("genesis.guardian.check.write_diagnosis_result"),
+        ):
+            await _handle_confirmed_dead(
+                config, sm, dispatcher, diagnosis_engine, recovery_engine
+            )
+
+        diagnosis_engine.diagnose.assert_awaited_once()
+        assert sm.state.down_alert_sent is True  # episode now marked — next tick skips
+
+    @pytest.mark.asyncio
+    async def test_autonomous_recovery_sends_one_restored_ping_and_clears_flag(
+        self, config: GuardianConfig
+    ) -> None:
+        """Container returns on its own from CONFIRMED_DEAD → exactly one restored ping."""
+        state_path = _seed_state(
+            config,
+            current_state="confirmed_dead",
+            down_alert_sent=True,
+            first_failure_at=_now_iso(),
+        )
+        mock_dispatcher = MagicMock()
+        mock_dispatcher.send = AsyncMock()
+
+        with (
+            patch(
+                "genesis.guardian.check.collect_all_signals",
+                AsyncMock(return_value=_healthy_snapshot()),
+            ),
+            patch("genesis.guardian.check._build_dispatcher", return_value=mock_dispatcher),
+            patch("genesis.guardian.check._handle_healthy", AsyncMock()),
+            patch("genesis.guardian.check._write_guardian_heartbeat", AsyncMock()),
+            patch("genesis.guardian.check.load_secrets", return_value={}),
+        ):
+            await run_check(config)
+
+        titles = _alert_titles(mock_dispatcher)
+        restored = [t for t in titles if "restored" in t.lower() or "recovered" in t.lower()]
+        assert len(restored) == 1, f"expected one restored ping, got titles={titles}"
+
+        import json
+
+        saved = json.loads(state_path.read_text())
+        assert saved["current_state"] == "healthy"
+        assert saved["down_alert_sent"] is False  # cleared on genuine recovery
+
+    @pytest.mark.asyncio
+    async def test_auto_reset_does_not_ping_or_clear_flag(
+        self, config: GuardianConfig
+    ) -> None:
+        """Auto-reset (still-down) must NOT emit a restored ping nor clear the flag.
+
+        The auto-reset trap: auto-reset routes CONFIRMED_DEAD→HEALTHY while the
+        container is STILL down (all_alive=False). A naive 'clear on recovery'
+        would wipe the throttle here and re-enable the storm.
+        """
+        state_path = _seed_state(
+            config,
+            current_state="confirmed_dead",
+            down_alert_sent=True,
+            first_failure_at="2026-01-01T00:00:00+00:00",  # long past timeout → auto-reset
+            auto_reset_count=0,
+        )
+        mock_dispatcher = MagicMock()
+        mock_dispatcher.send = AsyncMock()
+
+        with (
+            patch(
+                "genesis.guardian.check.collect_all_signals",
+                AsyncMock(return_value=_dead_snapshot()),
+            ),
+            patch("genesis.guardian.check._build_dispatcher", return_value=mock_dispatcher),
+            patch("genesis.guardian.check._handle_healthy", AsyncMock()),
+            patch("genesis.guardian.check._write_guardian_heartbeat", AsyncMock()),
+            patch("genesis.guardian.check.load_secrets", return_value={}),
+        ):
+            await run_check(config)
+
+        titles = _alert_titles(mock_dispatcher)
+        assert not any(
+            "restored" in t.lower() or "recovered" in t.lower() for t in titles
+        ), f"auto-reset must not ping restored; titles={titles}"
+
+        import json
+
+        saved = json.loads(state_path.read_text())
+        assert saved["down_alert_sent"] is True  # retained — storm stays suppressed
+
+    @pytest.mark.asyncio
+    async def test_storm_suppressed_across_ticks(self, config: GuardianConfig) -> None:
+        """Two CONFIRMED_DEAD ticks: alert on the first, silence on the second."""
+        _seed_state(
+            config,
+            current_state="confirmed_dead",
+            down_alert_sent=False,
+            first_failure_at=_now_iso(),  # recent → no auto-reset
+        )
+        mock_dispatcher = MagicMock()
+        mock_dispatcher.send = AsyncMock()
+
+        with (
+            patch(
+                "genesis.guardian.check.collect_all_signals",
+                AsyncMock(return_value=_dead_snapshot()),
+            ),
+            patch("genesis.guardian.check.collect_diagnostics", AsyncMock(return_value={})),
+            patch("genesis.guardian.check.write_diagnosis_result"),
+            patch.object(
+                DiagnosisEngine, "diagnose",
+                AsyncMock(return_value=_cc_unavailable_diagnosis()),
+            ),
+            patch("genesis.guardian.check._build_dispatcher", return_value=mock_dispatcher),
+            patch("genesis.guardian.check._write_guardian_heartbeat", AsyncMock()),
+            patch("genesis.guardian.check.load_secrets", return_value={}),
+        ):
+            await run_check(config)  # tick 1 — should alert
+            count_after_tick1 = mock_dispatcher.send.call_count
+            await run_check(config)  # tick 2 — should stay quiet
+            count_after_tick2 = mock_dispatcher.send.call_count
+
+        assert count_after_tick1 >= 1, "first down tick must alert"
+        assert count_after_tick2 == count_after_tick1, (
+            "second tick must NOT re-alert (storm killed)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_diagnosis_crash_unmarks_flag_for_retry(
+        self, config: GuardianConfig
+    ) -> None:
+        """If diagnosis raises before any alert, the flag is un-marked so the
+        next tick retries instead of silently muting the episode."""
+        sm = ConfirmationStateMachine(config)
+        sm._state.current_state = GuardianState.CONFIRMED_DEAD
+        sm._state.down_alert_sent = False
+
+        dispatcher = MagicMock()
+        dispatcher.send = AsyncMock()
+        diagnosis_engine = MagicMock()
+        diagnosis_engine.diagnose = AsyncMock(side_effect=RuntimeError("cc crashed"))
+        recovery_engine = MagicMock()
+        recovery_engine.execute = AsyncMock()
+
+        with (
+            patch("genesis.guardian.check.collect_diagnostics", AsyncMock(return_value={})),
+            pytest.raises(RuntimeError, match="cc crashed"),
+        ):
+            await _handle_confirmed_dead(
+                config, sm, dispatcher, diagnosis_engine, recovery_engine
+            )
+
+        assert sm.state.down_alert_sent is False  # un-marked → next tick retries
+
+    @pytest.mark.asyncio
+    async def test_cc_resolved_recovery_clears_flag(self, config: GuardianConfig) -> None:
+        """CC-auto-resolved recovery clears the flag at its recovery point (no leak)."""
+        sm = ConfirmationStateMachine(config)
+        sm._state.current_state = GuardianState.CONFIRMED_DEAD
+        sm._state.down_alert_sent = True
+
+        dispatcher = MagicMock()
+        dispatcher.send = AsyncMock()
+        recovery_engine = MagicMock()
+
+        with (
+            patch(
+                "genesis.guardian.check.collect_all_signals",
+                AsyncMock(return_value=_healthy_snapshot()),
+            ),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await _handle_cc_resolved(
+                config, sm, dispatcher, _resolved_diagnosis(), recovery_engine
+            )
+
+        assert sm.current_state == GuardianState.HEALTHY
+        assert sm.state.down_alert_sent is False
+
+    @pytest.mark.asyncio
+    async def test_full_episode_is_two_pings_regardless_of_duration(
+        self, config: GuardianConfig
+    ) -> None:
+        """Acceptance (user requirement): one 'down' + one 'restored' per episode,
+        no matter how many ticks it stays down."""
+        _seed_state(
+            config,
+            current_state="confirmed_dead",
+            down_alert_sent=False,
+            first_failure_at=_now_iso(),
+        )
+        mock_dispatcher = MagicMock()
+        mock_dispatcher.send = AsyncMock()
+
+        # Three consecutive down ticks (CC unavailable).
+        with (
+            patch(
+                "genesis.guardian.check.collect_all_signals",
+                AsyncMock(return_value=_dead_snapshot()),
+            ),
+            patch("genesis.guardian.check.collect_diagnostics", AsyncMock(return_value={})),
+            patch("genesis.guardian.check.write_diagnosis_result"),
+            patch.object(
+                DiagnosisEngine, "diagnose",
+                AsyncMock(return_value=_cc_unavailable_diagnosis()),
+            ),
+            patch("genesis.guardian.check._build_dispatcher", return_value=mock_dispatcher),
+            patch("genesis.guardian.check._write_guardian_heartbeat", AsyncMock()),
+            patch("genesis.guardian.check.load_secrets", return_value={}),
+        ):
+            await run_check(config)
+            down_side_alerts = mock_dispatcher.send.call_count
+            await run_check(config)
+            await run_check(config)
+
+        # Down-side alert count did NOT grow over the extra ticks.
+        assert mock_dispatcher.send.call_count == down_side_alerts
+        assert down_side_alerts >= 1
+
+        # Now it recovers on its own.
+        with (
+            patch(
+                "genesis.guardian.check.collect_all_signals",
+                AsyncMock(return_value=_healthy_snapshot()),
+            ),
+            patch("genesis.guardian.check._build_dispatcher", return_value=mock_dispatcher),
+            patch("genesis.guardian.check._handle_healthy", AsyncMock()),
+            patch("genesis.guardian.check._write_guardian_heartbeat", AsyncMock()),
+            patch("genesis.guardian.check.load_secrets", return_value={}),
+        ):
+            await run_check(config)
+
+        titles = _alert_titles(mock_dispatcher)
+        restored = [t for t in titles if "restored" in t.lower() or "recovered" in t.lower()]
+        assert len(restored) == 1, f"expected exactly one restored ping; titles={titles}"

--- a/tests/test_guardian/test_recovery.py
+++ b/tests/test_guardian/test_recovery.py
@@ -91,6 +91,23 @@ class TestRecoveryRestart:
         assert result.action == RecoveryAction.RESTART_SERVICES
 
     @pytest.mark.asyncio
+    async def test_successful_recovery_clears_down_alert_flag(
+        self, engine: RecoveryEngine
+    ) -> None:
+        """GUARD-R2-01: a successful recovery clears the down-alert flag so the
+        next down-episode is not suppressed."""
+        engine._sm.mark_down_alert_sent()
+        with (
+            patch("genesis.guardian.recovery._run_subprocess", _mock_subprocess(0, "")),
+            patch("genesis.guardian.recovery.collect_all_signals", return_value=_healthy_snapshot()),
+            patch.object(engine._snapshots, "take", return_value="pre-recovery"),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await engine.execute(_diagnosis(RecoveryAction.RESTART_SERVICES))
+        assert result.success is True
+        assert engine._sm.state.down_alert_sent is False
+
+    @pytest.mark.asyncio
     async def test_restart_services_failure(self, engine: RecoveryEngine) -> None:
         with (
             patch("genesis.guardian.recovery._run_subprocess", _mock_subprocess(1, "", "failed")),

--- a/tests/test_guardian/test_state_machine.py
+++ b/tests/test_guardian/test_state_machine.py
@@ -16,6 +16,7 @@ from genesis.guardian.health_signals import (
 from genesis.guardian.state_machine import (
     ConfirmationStateMachine,
     GuardianState,
+    StateData,
 )
 
 
@@ -393,3 +394,43 @@ class TestCCUnavailabilityTracking:
         sm2.load_state(state_file)
         assert sm2.state.cc_unavailable_since == sm.state.cc_unavailable_since
         assert sm2.state.last_cc_unavailable_alert_at == sm.state.last_cc_unavailable_alert_at
+
+
+class TestDownAlertFlag:
+    """GUARD-R2-01 — the per-episode 'down alert already sent' flag (alert once)."""
+
+    def test_defaults_false(self, sm: ConfirmationStateMachine) -> None:
+        assert sm.state.down_alert_sent is False
+
+    def test_mark_and_clear(self, sm: ConfirmationStateMachine) -> None:
+        sm.mark_down_alert_sent()
+        assert sm.state.down_alert_sent is True
+        sm.clear_down_alert_sent()
+        assert sm.state.down_alert_sent is False
+
+    def test_persists_across_save_load(
+        self, config: GuardianConfig, tmp_path: Path,
+    ) -> None:
+        """The flag MUST survive between oneshot invocations (state.json)."""
+        sm = ConfirmationStateMachine(config)
+        sm.mark_down_alert_sent()
+        state_file = tmp_path / "state.json"
+        sm.save_state(state_file)
+
+        sm2 = ConfirmationStateMachine(config)
+        sm2.load_state(state_file)
+        assert sm2.state.down_alert_sent is True
+
+    def test_defaults_false_for_legacy_state(self) -> None:
+        """Old state.json without the key loads as False (backward compatible)."""
+        sd = StateData.from_dict({"current_state": "confirmed_dead"})
+        assert sd.down_alert_sent is False
+
+    def test_not_cleared_by_reset_to_healthy(
+        self, sm: ConfirmationStateMachine,
+    ) -> None:
+        """_reset_to_healthy (shared by auto-reset) must NOT clear the flag —
+        that would let auto-reset oscillation re-enable the storm."""
+        sm.mark_down_alert_sent()
+        sm._reset_to_healthy("2026-06-16T00:00:00+00:00")
+        assert sm.state.down_alert_sent is True


### PR DESCRIPTION
## What & why

When Genesis goes down and the Guardian's diagnosis can't reach Claude Code, the host Guardian (a 30s systemd oneshot) re-ran a full Opus diagnosis **and re-sent a CRITICAL/EMERGENCY alert every 30 seconds** until recovery — an alert storm. Separately, when Genesis recovered **on its own**, the Guardian said nothing — there was no "restored" notification.

This makes the Guardian send **one "down" alert per outage (no repeats, however long it lasts) and one "restored" notification when it comes back** — two messages per episode, regardless of duration.

## Root cause

In `CONFIRMED_DEAD`, the state machine returns `action_needed=True` every tick → `_handle_confirmed_dead` re-diagnoses + re-alerts. The approvable-recovery path is already throttled (it blocks on approval, and the oneshot + 30s timer can't overlap), but the **CC-unavailable / ESCALATE path early-returns without blocking**, so each fresh oneshot tick re-fires. Because each tick is a *new process*, the only robust throttle is **persisted state**. Autonomous recovery (`CONFIRMED_DEAD → HEALTHY`) routed to `_handle_healthy`, which only prunes/heartbeats — no alert.

## Change (minimal scope)

- Persisted `StateData.down_alert_sent` episode flag (survives ticks via `state.json`). `_handle_confirmed_dead` returns early once set — no re-diagnosis (the expensive Opus run), no re-alert — until genuine recovery.
- One `INFO` "Genesis recovered" ping on the previously-silent autonomous `CONFIRMED_DEAD → HEALTHY`, gated on `snapshot.all_alive` so an **auto-reset** (which routes to HEALTHY while *still down*) neither pings nor clears the flag — the storm stays suppressed.
- Flag cleared at every recovery-confirmed point (autonomous, CC-resolved, approval-time, recovery-engine success); **never** in `_reset_to_healthy` (auto-reset also calls it — clearing there would re-enable the storm). Un-marked on a diagnosis crash so the episode isn't silently muted.

**Intended behavior change:** after the first handling, the Guardian no longer silently *retries* recovery on later ticks. The first attempt + its result alert still fire; re-attempting (with a fresh prompt) every 30s was part of the storm being removed.

The interactive approval flow and the existing first-pass alerts are deliberately left untouched (minimal scope).

## Verification

- 13 new tests: storm suppression across ticks, restored ping, the auto-reset trap, restored-ping dedup, diagnosis-crash retry, and a full-episode "exactly two pings regardless of duration" acceptance test.
- Full guardian suite green (360 passed); ruff clean.
- Adversarial code review (Codex quota-exhausted → Claude reviewer): two hardening findings (recovery-path flag-leak, mark-then-crash) applied + covered by tests.