### PR TITLE
fix: restore ego proposal delivery + correct Telegram notification routing

### DIFF
--- a/config/outreach.yaml
+++ b/config/outreach.yaml
@@ -57,6 +57,10 @@ delivery_routing:
   approval: supergroup
   # Content review goes to dedicated topic — never DM.
   content: supergroup
+  # Ego notifications are the ego "talking to" the user — informational,
+  # not an official proposal. They belong in the private DM, never a
+  # supergroup topic. (Official proposals go to the Ego Proposals topic.)
+  notification: dm
 
 health_alerts:
   # Only these alert IDs go to Telegram (CRITICAL severity only).

--- a/src/genesis/channels/telegram/topics.py
+++ b/src/genesis/channels/telegram/topics.py
@@ -292,4 +292,16 @@ class TopicManager:
             "approval": "approvals",
             "content": "content_review",
         }
-        return mapping.get(outreach_category, "surplus")
+        topic = mapping.get(outreach_category)
+        if topic is None:
+            # Unmapped category — route to the visible conversation topic,
+            # NOT surplus (the debug dump where the Jun 2026 ego_notification
+            # misroute silently landed). Log so a missing mapping surfaces
+            # instead of vanishing.
+            logger.warning(
+                "No topic mapping for outreach category %r — routing to "
+                "'conversation'. Add an explicit mapping if this is real.",
+                outreach_category,
+            )
+            return "conversation"
+        return topic

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1007,13 +1007,18 @@ class EgoSession:
             return proposals
 
         try:
-            from genesis.eval.scorers import get_scorer
+            from genesis.eval.scorers import (
+                _JUDGE_CALL_FAIL,
+                _JUDGE_PARSE_FAIL,
+                get_scorer,
+            )
             from genesis.eval.types import ScorerType
 
             scorer = get_scorer(ScorerType.OUTPUT_QUALITY)
             scorer.set_router(self._router)
 
             held_count = 0
+            judge_unavailable = 0
             for p in proposals:
                 try:
                     passed, score, detail = await scorer.score_async(
@@ -1024,15 +1029,35 @@ class EgoSession:
                         expected="autonomous proposal",
                         config={"rubric_name": "output_quality"},
                     )
-                    if not passed:
-                        p["_realist_verdict"] = "quality_hold"
-                        p["_realist_reasoning"] = (
-                            f"Quality score {score:.2f} below threshold. {detail[:300]}"
-                        )
-                        held_count += 1
+                    if passed:
+                        continue
+                    # Fail OPEN on judge INFRASTRUCTURE errors (providers
+                    # exhausted / unparseable response) — a scoring failure is
+                    # not a quality failure. Quarantining proposals because the
+                    # judge was down is exactly how the proposal stream went
+                    # silent during the Jun 2026 provider outage. Only a genuine
+                    # below-threshold score holds a proposal.
+                    try:
+                        judge_error = json.loads(detail).get("error")
+                    except (json.JSONDecodeError, ValueError, TypeError):
+                        judge_error = None
+                    if judge_error in (_JUDGE_CALL_FAIL, _JUDGE_PARSE_FAIL):
+                        judge_unavailable += 1
+                        continue
+                    p["_realist_verdict"] = "quality_hold"
+                    p["_realist_reasoning"] = (
+                        f"Quality score {score:.2f} below threshold. {detail[:300]}"
+                    )
+                    held_count += 1
                 except Exception:
                     logger.debug("Quality scoring failed for proposal, passing", exc_info=True)
 
+            if judge_unavailable:
+                logger.warning(
+                    "Quality gate: judge unavailable for %d/%d proposal(s) — "
+                    "passed through (fail-open), NOT held",
+                    judge_unavailable, len(proposals),
+                )
             if held_count:
                 logger.info(
                     "Quality gate: held %d/%d proposals", held_count, len(proposals),
@@ -1237,6 +1262,14 @@ class EgoSession:
                 )
                 if delivery:
                     logger.info("Ego digest sent (delivery_id=%s)", delivery)
+                else:
+                    logger.warning(
+                        "Ego digest NOT delivered for batch %s (send_digest "
+                        "returned None): proposals stored but undelivered — "
+                        "check for all-quality_held, digest rate-limit, or a "
+                        "topic-send failure.",
+                        batch_id,
+                    )
             else:
                 logger.info(
                     "Ego decided stay_quiet — batch %s stored only",
@@ -1518,6 +1551,13 @@ class EgoSession:
             if not isinstance(notif, dict):
                 continue
             content = notif.get("content", "").strip()
+            # Strip one layer of matched wrapping quotes (straight or smart) —
+            # the ego LLM sometimes wraps its whole message in literal quote
+            # characters, which then render verbatim in the user's DM.
+            if len(content) >= 2 and (content[0], content[-1]) in (
+                ('"', '"'), ("'", "'"), ("“", "”"), ("‘", "’"),
+            ):
+                content = content[1:-1].strip()
             if not content:
                 continue
             # Cap content length to prevent runaway LLM output from

--- a/tests/ego/test_notifications.py
+++ b/tests/ego/test_notifications.py
@@ -135,6 +135,23 @@ class TestProcessNotifications:
         assert len(request.topic) == 100
         assert request.context == long_content
 
+    @pytest.mark.asyncio
+    async def test_wrapping_quotes_stripped(self, session):
+        """One layer of matched wrapping quotes (straight or smart) is
+        stripped; non-wrapped content is left untouched."""
+        cases = [
+            ('"Hello there"', "Hello there"),
+            ("'Single quoted'", "Single quoted"),
+            ("“Smart quoted”", "Smart quoted"),
+            ("No quotes here", "No quotes here"),
+            ('She said "hi"', 'She said "hi"'),  # not fully wrapped — untouched
+        ]
+        for raw, expected in cases:
+            session._outreach_pipeline.submit.reset_mock()
+            await session._process_notifications([{"content": raw}])
+            request = session._outreach_pipeline.submit.call_args[0][0]
+            assert request.context == expected, f"{raw!r} -> {request.context!r}"
+
 
 # ---------------------------------------------------------------------------
 # NOTIFICATION governance config tests
@@ -169,6 +186,14 @@ class TestNotificationGovernance:
         # Load from repo config
         config = load_outreach_config()
         assert config.thresholds.get("notification") == 0.0
+
+    def test_notification_routes_to_dm(self):
+        """Ego notifications route to the private DM, not a supergroup topic
+        (they are the ego talking to the user, not an official proposal)."""
+        from genesis.outreach.config import load_outreach_config
+
+        config = load_outreach_config()
+        assert config.delivery_routing.get("notification") == "dm"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ego/test_quality_gate.py
+++ b/tests/ego/test_quality_gate.py
@@ -1,0 +1,84 @@
+"""Tests for EgoSession._quality_gate — must fail OPEN on judge errors.
+
+Regression guard for the Jun 2026 incident: the LLM quality judge's providers
+were exhausted, the scorer returned ``(False, 0.0, {"error": "judge_call_fail"})``,
+and the gate quarantined every proposal as ``quality_hold`` — silently halting
+the entire proposal stream. A judge INFRASTRUCTURE failure is not a quality
+failure; the gate's documented contract is to fail open.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+class _FakeScorer:
+    """Stand-in scorer returning a fixed (passed, score, detail) tuple."""
+
+    def __init__(self, result: tuple[bool, float, str]) -> None:
+        self._result = result
+
+    def set_router(self, router: object) -> None:
+        pass
+
+    async def score_async(self, **kwargs: object) -> tuple[bool, float, str]:
+        return self._result
+
+
+def _patch_scorer(scorer: _FakeScorer):
+    return patch("genesis.eval.scorers.get_scorer", return_value=scorer)
+
+
+def _session():
+    from genesis.ego.session import EgoSession
+
+    s = object.__new__(EgoSession)
+    s._router = object()  # truthy → gate runs
+    return s
+
+
+def _detail(**fields: object) -> str:
+    return json.dumps({"rubric_name": "output_quality", **fields})
+
+
+@pytest.mark.asyncio
+async def test_judge_call_fail_passes_through():
+    """Providers exhausted (judge_call_fail) must NOT hold the proposal."""
+    detail = _detail(error="judge_call_fail", error_message="All providers exhausted")
+    proposals = [{"content": "Reprocess the DLQ", "rationale": "backlog"}]
+    with _patch_scorer(_FakeScorer((False, 0.0, detail))):
+        result = await _session()._quality_gate(proposals)
+    assert result[0].get("_realist_verdict") != "quality_hold"
+
+
+@pytest.mark.asyncio
+async def test_judge_parse_fail_passes_through():
+    """An unparseable judge response must NOT hold the proposal."""
+    detail = _detail(error="judge_parse_fail", error_message="bad json")
+    proposals = [{"content": "Ship the brief"}]
+    with _patch_scorer(_FakeScorer((False, 0.0, detail))):
+        result = await _session()._quality_gate(proposals)
+    assert result[0].get("_realist_verdict") != "quality_hold"
+
+
+@pytest.mark.asyncio
+async def test_genuine_low_score_is_held():
+    """A real below-threshold score (no judge error) still holds."""
+    detail = _detail(judge_score=0.2, rationale="incoherent")
+    proposals = [{"content": "garbage"}]
+    with _patch_scorer(_FakeScorer((False, 0.2, detail))):
+        result = await _session()._quality_gate(proposals)
+    assert result[0].get("_realist_verdict") == "quality_hold"
+
+
+@pytest.mark.asyncio
+async def test_passing_score_not_held():
+    """A passing score leaves the proposal unannotated."""
+    detail = _detail(judge_score=0.9, rationale="solid")
+    proposals = [{"content": "good"}]
+    with _patch_scorer(_FakeScorer((True, 0.9, detail))):
+        result = await _session()._quality_gate(proposals)
+    assert "_realist_verdict" not in result[0]

--- a/tests/test_channels/test_telegram_topics.py
+++ b/tests/test_channels/test_telegram_topics.py
@@ -128,7 +128,7 @@ async def test_resolve_outreach_category(manager):
     assert manager.resolve_outreach_category("alert") == "alert"
     assert manager.resolve_outreach_category("surplus") == "surplus"
     assert manager.resolve_outreach_category("recon") == "recon"
-    assert manager.resolve_outreach_category("unknown") == "surplus"
+    assert manager.resolve_outreach_category("unknown") == "conversation"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What & why

Investigating misrouted Telegram messages surfaced four connected bugs in the ego → outreach delivery path. This PR is the Phase A set — the verified, low-risk fixes.

### Fixes
- **Ego proposals silently stopped delivering.** The proposal "quality gate" is an LLM judge. When its providers were exhausted, the scorer returned a `judge_call_fail` (score 0.0) and the gate marked *every* proposal `quality_hold` — which `send_digest` silently drops. The gate's docstring promised "fail open," but it failed *closed*. Now a judge-infrastructure error (`judge_call_fail` / `judge_parse_fail`) passes the proposal through; only a genuine below-threshold score holds it.
- **The silent drop is no longer silent.** When `send_digest` returns `None`, we log a warning (proposals stored but undelivered) instead of nothing.
- **Ego notifications now go to the DM, not the Surplus topic.** `notification` had no `delivery_routing` entry, so it fell through to `supergroup` and then the `surplus` catch-all. Added `notification: dm`. Also changed the unmapped-category fallback from `surplus` → `conversation` with a warning, so a missing topic mapping surfaces instead of vanishing into the debug dump.
- **Notification text no longer arrives wrapped in literal quotes.** Strip one layer of matched wrapping quotes (straight or smart) the ego sometimes adds around its message.

### Tests
9 new/updated tests: quality-gate fail-open vs genuine-hold cases, a quote-strip matrix (including a non-wrapped `She said "hi"` case that must be left alone), the DM-routing config assertion, and the updated unmapped-category default. 32 pass locally; `ruff` clean.

### Not in this PR (deliberate)
- Releasing the proposals already stuck in `quality_hold` — a live-DB operation, handled separately.
- Surplus-topic JSON formatting cleanup (verify-first).
- Guardian recovery-approval rework (separate, architect-gated).

Independent code review (Claude reviewer; Codex was rate-limited): clean, no blocking findings.
