### PR TITLE
fix(deps): declare tzlocal (apscheduler local-tz path) for clean CI installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "aiosqlite",
     "aiohttp<3.14",  # 3.14 adds required stream_writer kwarg to ClientResponse; aioresponses 0.7.8 doesn't pass it
     "apscheduler>=3.11,<4",
+    "tzlocal>=5",  # transitive dep of apscheduler (ego/cadence uses the local-timezone path); declare so a clean/cached install can't drop it
     "python-telegram-bot>=21.0",
     "litellm==1.78.7",  # pinned — 1.82.7/1.82.8 contain malware; CVE-2026-35030/35029 not exploitable
                        # (Genesis uses acompletion/completion_cost only, no proxy server or OIDC)


### PR DESCRIPTION
**Root cause.** `apscheduler>=3.11` lists `tzlocal`, but a clean/cached CI build can satisfy apscheduler without pulling tzlocal. `ego/cadence.py` uses the local-timezone path (`user_timezone()` → APScheduler), so a fresh-cache run hits **83 `No module named 'tzlocal'` collection errors in `tests/ego`**. `main` is green only because its runner cache still has tzlocal; any fresh PR (e.g. #657) trips it.

**Fix.** Declare `tzlocal>=5` directly in `pyproject.toml` (same pattern as the existing `wsproto` transitive pin). Makes the dep explicit for code that genuinely needs local-tz resolution, and the pyproject change busts the stale cache so the install resolves it.

No behavior change; one dependency line.