### PR TITLE
chore(voice): disable ask_genesis tool pending memory refactor

### DIFF
--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -26,29 +26,12 @@ logger = logging.getLogger(__name__)
 
 _ESSENTIAL_KNOWLEDGE_PATH = Path.home() / ".genesis" / "essential_knowledge.md"
 
-# Tool declarations for the S2S model session config
+# Tool declarations for the S2S model session config.
+# NOTE: ask_genesis is intentionally DISABLED here pending the voice-memory
+# refactor — the raw-snippet dump it returned was poor input for the S2S model.
+# Its dispatch in handle_tool_call() and the _ask_genesis() implementation are
+# kept below, so re-enabling is just restoring its schema to this list.
 TOOL_DECLARATIONS = [
-    {
-        "type": "function",
-        "name": "ask_genesis",
-        "description": (
-            "REQUIRED for any question about: conversations, past events, "
-            "what we discussed, what we worked on, memories, personal context, "
-            "projects, tasks, or anything the user has told you before. "
-            "You do NOT have this information yourself — you MUST call this "
-            "tool to access the user's history. Genesis has full memory."
-        ),
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "query": {
-                    "type": "string",
-                    "description": "The user's question, rephrased as a query",
-                },
-            },
-            "required": ["query"],
-        },
-    },
     {
         "type": "function",
         "name": "web_search",
@@ -95,16 +78,18 @@ TOOL_DECLARATIONS = [
 # System instructions for the S2S model
 SYSTEM_INSTRUCTIONS = """\
 You are Genesis, a cognitive AI partner, speaking through a voice interface.
-You have two tools. Use them.
+You have two tools — web search and approvals. Use them.
 
 TOOL RULES (important — follow these strictly):
-- "what did we do / work on / discuss" → ALWAYS call ask_genesis. Never guess.
 - "what time is it / what's the date / what day is it" → answer from the \
 Current time in your context. No tool call needed.
 - "search / look up / what's the weather / news" → ALWAYS call web_search.
 - "can you search the web" or similar capability questions → call web_search \
 with a relevant query to demonstrate the capability.
-- Questions about the user's personal context, projects, history → call ask_genesis.
+- You do NOT currently have access to past conversations, stored memories, or \
+the user's history. If asked what you discussed or worked on before, or for \
+personal context you weren't given here, say plainly that you don't have that \
+available right now — never invent it.
 - General knowledge you're confident about → answer directly, no tool call.
 - When in doubt between answering directly and calling a tool → call the tool. \
 Better to be thorough than to guess wrong.
@@ -120,7 +105,7 @@ they can always ask for more.
 caveats, or "here's why" — over voice that's just noise. Don't restate the \
 question; no filler openers or closers ("let me know if you need anything"). \
 Lead with the answer.
-- For a dense tool result (memory, search), give only the 1-3 points that matter \
+- For a dense tool result (a web search), give only the 1-3 points that matter \
 for what they asked, then offer "Want me to go deeper?" — and only if there's \
 genuinely more worth hearing.
 - Never use markdown, bullet points, or formatting. Speak naturally, like someone \

--- a/tests/test_channels/test_voice.py
+++ b/tests/test_channels/test_voice.py
@@ -637,7 +637,8 @@ class TestVoiceAPI:
             assert "Genesis" in data["prompt"]
 
     def test_tool_declarations_endpoint(self, app):
-        """Tool declarations endpoint returns the 3 Genesis voice tools."""
+        """Tool declarations endpoint returns the advertised voice tools
+        (ask_genesis disabled until the memory refactor)."""
         with (
             patch.dict("os.environ", {"GENESIS_MCP_HTTP_TOKEN": ""}, clear=False),
             app.test_client() as client,
@@ -647,7 +648,7 @@ class TestVoiceAPI:
             data = resp.get_json()
             assert "tools" in data
             tool_names = [t["name"] for t in data["tools"]]
-            assert "ask_genesis" in tool_names
+            assert "ask_genesis" not in tool_names  # disabled until the memory refactor
             assert "web_search" in tool_names
             assert "approve_pending" in tool_names
 

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -63,9 +63,13 @@ class TestVoiceConfig:
 
 class TestGenesisBridge:
     def test_tool_declarations_structure(self):
-        assert len(TOOL_DECLARATIONS) == 3
+        # ask_genesis is disabled until the voice-memory refactor. Only
+        # web_search + approve_pending are advertised; the dispatch and
+        # _ask_genesis implementation stay in place for easy re-enable.
+        assert len(TOOL_DECLARATIONS) == 2
         names = {t["name"] for t in TOOL_DECLARATIONS}
-        assert names == {"ask_genesis", "web_search", "approve_pending"}
+        assert names == {"web_search", "approve_pending"}
+        assert "ask_genesis" not in names
 
     def test_system_prompt_has_placeholders(self):
         assert "{voice_context}" in SYSTEM_INSTRUCTIONS
@@ -155,7 +159,7 @@ class TestGenesisBridge:
         bridge = GenesisBridge()
         prompt = bridge.get_system_prompt()
         assert "Genesis" in prompt
-        assert "ask_genesis" in prompt
+        assert "ask_genesis" not in prompt  # disabled until the memory refactor
         assert "approve_pending" in prompt or "APPROVAL" in prompt
 
     async def test_approve_pending_no_gate(self):


### PR DESCRIPTION
## What
Disables the `ask_genesis` tool for the voice S2S model — removes it from the advertised tool declarations and from the system prompt.

## Why
The tool returned a raw dump of up to 5 memory snippets (300-char truncated, no synthesis) — poor input for a speech model, which improvised from fragments instead of getting a usable answer. Pending a broader voice-memory rework, it degrades the conversation more than it helps.

## Behavior
- The voice model keeps `web_search` + `approve_pending`.
- The prompt now tells the model to be honest about not having memory access rather than hallucinate it.
- The dispatch in `handle_tool_call()` and the `_ask_genesis()` implementation are left intact (dormant) — re-enabling is just restoring the schema to `TOOL_DECLARATIONS`. Both consumers (the `/v1/voice/tool_declarations` endpoint and the direct s2s session) drop it via the single source constant.

## Tests
95 voice tests pass (declaration/prompt tests updated to expect 2 tools; the `ask_genesis` dispatch tests are unchanged). ruff clean.