### PR TITLE
feat(voice): allow exclamation marks in voice style-guide

### DIFF
--- a/src/genesis/skills/voice-master/references/style-guide.md
+++ b/src/genesis/skills/voice-master/references/style-guide.md
@@ -39,6 +39,11 @@ Real humans have mixed feelings. "This is impressive but also kind of unsettling
 - "I've seen this go wrong when..."
 - "What I don't understand is..."
 
+## Exclamation marks are fine
+
+Use them where they feel natural — they convey energy and genuine enthusiasm.
+Don't overdo it, but don't sterilize them out of otherwise-human writing either.
+
 ## Let some mess in
 
 Perfect structure feels algorithmic. Tangents, asides, and half-formed thoughts are human. Not every piece needs them, but they signal a real person behind the words.


### PR DESCRIPTION
Completes the user's voice preferences alongside #621's consolidation.

#621 already restored first-person use (`style-guide.md` → "Use first person when it fits") and dropped the old "don't open with I" ban — so those prefs are preserved. The one remaining piece was exclamation marks: this adds an "Exclamation marks are fine" note (use where natural; convey energy; don't sterilize them out), placed next to the first-person guidance in the canonical `src/genesis/skills/voice-master/references/style-guide.md`.

Reflects the user's standing voice rule (use `!` and first-person naturally).