### PR TITLE
fix(scheduler): strip GitNexus block from CLAUDE.md after reindex (keep in AGENTS.md)

### DIFF
--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import hashlib
 import logging
+import re
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -31,6 +32,31 @@ if TYPE_CHECKING:
     from genesis.routing.router import Router
 
 logger = logging.getLogger(__name__)
+
+
+# `gitnexus analyze` injects a `<!-- gitnexus:start --> … <!-- gitnexus:end -->`
+# block into BOTH CLAUDE.md and AGENTS.md, with no per-file flag. We keep it in
+# AGENTS.md (read by cross-tool agents — Codex/Cursor/etc.) but strip it from
+# CLAUDE.md so Claude Code's instructions file stays clean.
+_GITNEXUS_BLOCK_RE = re.compile(
+    r"\n*<!-- gitnexus:start -->.*?<!-- gitnexus:end -->[^\n]*\n?",
+    re.DOTALL,
+)
+
+
+def _strip_gitnexus_block(path: Path) -> bool:
+    """Remove GitNexus's auto-injected block from a file. Returns True if removed."""
+    try:
+        text = path.read_text()
+    except OSError:
+        return False
+    stripped = _GITNEXUS_BLOCK_RE.sub("", text)
+    if stripped == text:
+        return False
+    if stripped and not stripped.endswith("\n"):
+        stripped += "\n"
+    path.write_text(stripped)
+    return True
 
 
 class SurplusScheduler:
@@ -1236,6 +1262,11 @@ class SurplusScheduler:
                 return
             if proc.returncode == 0:
                 logger.info("GitNexus reindex complete")
+                # Keep the gitnexus block in AGENTS.md (cross-tool agents) but
+                # strip it from CLAUDE.md — analyze injects both with no per-file flag.
+                with contextlib.suppress(Exception):
+                    if _strip_gitnexus_block(Path(repo_root) / "CLAUDE.md"):
+                        logger.info("Stripped GitNexus block from CLAUDE.md (kept in AGENTS.md)")
                 with contextlib.suppress(Exception):
                     GenesisRuntime.instance().record_job_success("gitnexus_reindex")
             else:

--- a/tests/test_surplus/test_gitnexus_strip.py
+++ b/tests/test_surplus/test_gitnexus_strip.py
@@ -1,0 +1,57 @@
+"""Tests for _strip_gitnexus_block — keeps GitNexus's block out of CLAUDE.md."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from genesis.surplus.scheduler import _strip_gitnexus_block
+
+_BLOCK = (
+    "<!-- gitnexus:start -->\n"
+    "# GitNexus — Code Intelligence\n\n"
+    "This project is indexed by GitNexus as **GENesis-AGI** (43479 symbols).\n"
+    "- MUST run impact analysis before editing any symbol.\n"
+    "<!-- gitnexus:end -->\n"
+)
+
+
+def test_strips_block_preserving_surrounding_content(tmp_path: Path) -> None:
+    f = tmp_path / "CLAUDE.md"
+    f.write_text("# Project Instructions\n\nReal content here.\n\n" + _BLOCK)
+    assert _strip_gitnexus_block(f) is True
+    out = f.read_text()
+    assert "gitnexus:start" not in out and "gitnexus:end" not in out
+    assert "GitNexus — Code Intelligence" not in out
+    assert "# Project Instructions" in out
+    assert "Real content here." in out
+    assert out.endswith("\n")
+
+
+def test_block_mid_file_only_removes_block(tmp_path: Path) -> None:
+    f = tmp_path / "CLAUDE.md"
+    f.write_text("top content\n\n" + _BLOCK + "\nbottom content\n")
+    assert _strip_gitnexus_block(f) is True
+    out = f.read_text()
+    assert "gitnexus" not in out
+    assert "top content" in out and "bottom content" in out
+
+
+def test_no_block_returns_false_unchanged(tmp_path: Path) -> None:
+    f = tmp_path / "CLAUDE.md"
+    original = "# Just instructions\n\nNo gitnexus here.\n"
+    f.write_text(original)
+    assert _strip_gitnexus_block(f) is False
+    assert f.read_text() == original
+
+
+def test_idempotent(tmp_path: Path) -> None:
+    f = tmp_path / "CLAUDE.md"
+    f.write_text("head\n\n" + _BLOCK)
+    assert _strip_gitnexus_block(f) is True
+    once = f.read_text()
+    assert _strip_gitnexus_block(f) is False  # nothing left to strip
+    assert f.read_text() == once
+
+
+def test_missing_file_returns_false(tmp_path: Path) -> None:
+    assert _strip_gitnexus_block(tmp_path / "nope.md") is False


### PR DESCRIPTION
GitNexus's `analyze` step injects a `<!-- gitnexus:start --> … <!-- gitnexus:end -->` block into **both** CLAUDE.md and AGENTS.md — there's no per-file flag (`--skip-agents-md` skips both; `--index-only` skips all injection). We want it in **AGENTS.md** (read by cross-tool agents) but **not** in Claude Code's CLAUDE.md.

This adds a post-reindex strip: after a successful `gitnexus analyze`, the scheduled reindex removes the gitnexus block from CLAUDE.md only (AGENTS.md keeps it). Marker-delimited, idempotent, preserves surrounding content. 5 unit tests; ruff clean.

Note: this is also why #652's drop of `--index-only` is fine — we *want* analyze to keep injecting (so AGENTS.md stays fresh); we just post-strip CLAUDE.md.