### PR TITLE
fix(guardian): gateway-safe host CLAUDE.md regen, drop empty network block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Guardian host updates no longer silently stall** — on hosts where the
+  Guardian's `CLAUDE.md` had been pinned with git's skip-worktree flag, the
+  Guardian's self-update (`git pull`) would abort the moment that file changed
+  upstream, quietly leaving the host Guardian stuck on old code. The update now
+  clears the flag first, so existing installs self-heal and stay current.
+
 - **Telegram `/stop` now stops your session, not a background task** — when a
   background task (reflection, inbox, an ego session, etc.) was running at the
   same time as your chat, `/stop` could interrupt the wrong one. Each session's

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -100,6 +100,10 @@ PYEOF
             # repo's version would overwrite with the wrong content (container
             # dev instructions vs Guardian diagnostic instructions). We
             # regenerate it from config/guardian-claude.md after every pull.
+            # Clear skip-worktree first: legacy installs marked CLAUDE.md
+            # --skip-worktree, which wedges `git pull` ("local changes would be
+            # overwritten") the moment upstream touches the tracked CLAUDE.md.
+            git update-index --no-skip-worktree CLAUDE.md 2>/dev/null || true
             git checkout -- CLAUDE.md 2>/dev/null || true
             # Stash remaining local config changes (container_ip, etc.)
             STASHED=0
@@ -117,27 +121,11 @@ PYEOF
                         CONFIG_RESET=1
                     fi
                 fi
-                # Regenerate Guardian CLAUDE.md from template (never use repo version)
+                # Regenerate Guardian CLAUDE.md from template (never use repo
+                # version). Shared host/container facts live in the user-level
+                # ~/.claude/CLAUDE.md (D16), so nothing is appended here.
                 if [ -f "$INSTALL_DIR/config/guardian-claude.md" ]; then
                     cp "$INSTALL_DIR/config/guardian-claude.md" "$INSTALL_DIR/CLAUDE.md"
-                    # Append per-machine network identity from guardian.yaml
-                    _cfg="$INSTALL_DIR/config/guardian.yaml"
-                    if [ -f "$_cfg" ]; then
-                        _cname=$(grep 'container_name:' "$_cfg" | awk '{print $2}' | tr -d '"' || true)
-                        _cip=$(grep 'container_ip:' "$_cfg" | awk '{print $2}' | tr -d '"' || true)
-                        _hip=$(grep 'host_ip:' "$_cfg" | awk '{print $2}' | tr -d '"' || true)
-                        _hv6=$(ip -6 addr show scope global 2>/dev/null | grep -oP 'inet6 \K[^ /]+' | head -1 || echo '')
-                        {
-                            echo ""
-                            echo "## Network"
-                            echo ""
-                            echo "- **Container**: ${_cname} at ${_cip}"
-                            echo "- **Host VM**: ${_hip} (this machine)"
-                            [ -n "$_hv6" ] && echo "- **Host IPv6**: $_hv6"
-                            echo "- **Dashboard**: http://${_cip}:5000 (direct, container network)"
-                            [ -n "$_hip" ] && echo "               http://${_hip}:5000 (via proxy device)"
-                        } >> "$INSTALL_DIR/CLAUDE.md"
-                    fi
                 fi
                 # Self-update: copy gateway script from pulled repo to ~/.local/bin/
                 # Safe mid-execution: Linux preserves old inode while this process holds fd.
@@ -244,24 +232,11 @@ OOMSYSCTL
             mv "$HOME/.local/bin/guardian-gateway.sh.new" "$HOME/.local/bin/guardian-gateway.sh"
         fi
 
-        # Regenerate CLAUDE.md from template (never use repo version on host)
+        # Regenerate CLAUDE.md from template (never use repo version on host).
+        # Shared host/container facts live in the user-level ~/.claude/CLAUDE.md
+        # (D16), so nothing is appended here.
         if [ -f "$INSTALL_DIR/config/guardian-claude.md" ]; then
             cp "$INSTALL_DIR/config/guardian-claude.md" "$INSTALL_DIR/CLAUDE.md"
-            _cfg="$INSTALL_DIR/config/guardian.yaml"
-            if [ -f "$_cfg" ]; then
-                # || true: guardian.yaml is host-specific; some fields may be absent
-                _cname=$(grep 'container_name:' "$_cfg" 2>/dev/null | awk '{print $2}' | tr -d '"' || true)
-                _cip=$(grep 'container_ip:' "$_cfg" 2>/dev/null | awk '{print $2}' | tr -d '"' || true)
-                _hip=$(grep 'host_ip:' "$_cfg" 2>/dev/null | awk '{print $2}' | tr -d '"' || true)
-                {
-                    echo ""
-                    echo "## Network"
-                    echo ""
-                    [ -n "$_cname" ] && echo "- **Container**: ${_cname} at ${_cip}"
-                    [ -n "$_hip" ] && echo "- **Host VM**: ${_hip} (this machine)"
-                    [ -n "$_cip" ] && echo "- **Dashboard**: http://${_cip}:5000"
-                } >> "$INSTALL_DIR/CLAUDE.md"
-            fi
         fi
 
         # Record deployed commit (separate file — state.json is overwritten by Guardian ticks)

--- a/scripts/install_guardian.sh
+++ b/scripts/install_guardian.sh
@@ -382,29 +382,11 @@ echo "[7/14] Generating CLAUDE.md for diagnostic CC..."
 if [ -f "$INSTALL_DIR/config/guardian-claude.md" ]; then
     cp "$INSTALL_DIR/config/guardian-claude.md" "$INSTALL_DIR/CLAUDE.md"
 
-    # Append per-machine network identity (no hardcoded IPs in the template)
-    _host_v4="${TS_IP:-$(ip -4 route get 1.1.1.1 2>/dev/null | grep -oP 'src \K\S+' || echo '')}"
-    _host_v6="$(ip -6 addr show scope global 2>/dev/null | grep -oP 'inet6 \K[^ /]+' | head -1 || echo '')"
-    {
-        echo ""
-        echo "## Network"
-        echo ""
-        echo "- **Container**: $CONTAINER_NAME at $CONTAINER_IP"
-        echo "- **Host VM**: $_host_v4 (this machine)"
-        [ -n "$_host_v6" ] && echo "- **Host IPv6**: $_host_v6"
-        echo "- **Dashboard**: http://$CONTAINER_IP:5000 (direct, container network)"
-        [ -n "$_host_v4" ] && echo "               http://$_host_v4:5000 (via proxy device)"
-    } >> "$INSTALL_DIR/CLAUDE.md"
-
-    # Tell git to ignore local CLAUDE.md changes. The file is tracked but the
-    # host uses guardian-claude.md instead. Without skip-worktree, git pull
-    # tries to merge the repo's container CLAUDE.md over the Guardian version.
-    if [ -d "$INSTALL_DIR/.git" ]; then
-        cd "$INSTALL_DIR" && git update-index --skip-worktree CLAUDE.md 2>/dev/null || true
-    else
-        echo "  NOTE: $INSTALL_DIR/.git not found — CLAUDE.md skip-worktree not set"
-        echo "        (ok for a non-git deploy; a future 'git pull' here could overwrite CLAUDE.md)"
-    fi
+    # No network block is appended: shared host/container facts live in the
+    # user-level ~/.claude/CLAUDE.md (D16). CLAUDE.md is also deliberately NOT
+    # marked --skip-worktree — that wedges the gateway's `git pull` once upstream
+    # touches the tracked CLAUDE.md ("local changes would be overwritten"). The
+    # gateway regenerates CLAUDE.md via checkout+cp on every update instead.
 
     # D16: the diagnostic CC runs with cwd = cc.work_dir (see diagnosis.py), so the
     # Guardian CLAUDE.md must live there to be auto-loaded as project context — the

--- a/tests/test_scripts/test_guardian_gateway_update.py
+++ b/tests/test_scripts/test_guardian_gateway_update.py
@@ -1,0 +1,177 @@
+"""Tests for the guardian-gateway.sh ``update`` op CLAUDE.md regeneration.
+
+The Guardian's diagnostic CC loads the install-dir ``CLAUDE.md`` as project
+context, so the ``update`` op must regenerate it from ``config/guardian-claude.md``
+on every pull — never leave the repo's container-facing root ``CLAUDE.md`` in
+place. Two regressions are guarded here:
+
+* **skip-worktree must not wedge the pull.** If ``CLAUDE.md`` is marked
+  ``--skip-worktree`` (older installs did this), ``git pull --ff-only`` aborts
+  the moment upstream touches the tracked ``CLAUDE.md`` ("local changes would be
+  overwritten"), silently stalling every Guardian update. The op must clear the
+  bit before pulling so legacy installs self-heal.
+* **No spurious network block.** The regenerated file must equal
+  ``config/guardian-claude.md`` exactly — shared host/container facts live in the
+  user-level ``~/.claude/CLAUDE.md`` (D16), not duplicated (and half-empty) here.
+
+These run the REAL ``scripts/guardian-gateway.sh update`` against a throwaway git
+clone with ``systemctl``/``sudo`` stubbed so the systemd/sysctl side effects
+no-op. Real ``git`` is the thing under test.
+"""
+
+import io
+import os
+import stat
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+_GATEWAY = Path(__file__).resolve().parents[2] / "scripts" / "guardian-gateway.sh"
+
+# Sentinels: the repo-root CLAUDE.md is container-facing; the regenerated file
+# must instead be the Guardian identity from config/guardian-claude.md.
+_CONTAINER_V1 = "# Genesis v3 — Project Instructions\nCONTAINER SENTINEL v1\n"
+_CONTAINER_V2 = "# Genesis v3 — Project Instructions\nCONTAINER SENTINEL v2 UPSTREAM\n"
+_GUARDIAN_MD = "# Genesis Guardian — Immune System\nGUARDIAN IDENTITY SENTINEL\n"
+_GUARDIAN_YAML = 'container_name: genesis\ncontainer_ip: ""\n'
+
+
+def _make_stub(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=str(cwd), check=True,
+                   capture_output=True, text=True)
+
+
+@pytest.fixture
+def stub_bin(tmp_path):
+    """bin dir with no-op systemctl and a sudo that fails ``-n`` (skips sysctl)."""
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    _make_stub(bind / "systemctl", "#!/usr/bin/env bash\nexit 0\n")
+    # `sudo -n true` must fail so the host sysctl/udev block is skipped entirely.
+    _make_stub(bind / "sudo", "#!/usr/bin/env bash\nexit 1\n")
+    return bind
+
+
+def _seed_repo(home: Path) -> Path:
+    """Build a bare remote + an INSTALL_DIR clone in a diverged/legacy state.
+
+    Mirrors a real host: CLAUDE.md locally regenerated to the Guardian identity
+    (diverged from the tracked container file), then upstream advances the
+    tracked CLAUDE.md. Returns the install dir.
+    """
+    remote = home / "remote.git"
+    _git("-c", "init.defaultBranch=main", "init", "-q", "--bare", str(remote), cwd=home)
+
+    seed = home / "seed"
+    _git("clone", "-q", str(remote), str(seed), cwd=home)
+    # Force the unborn branch to 'main' regardless of the host git's default
+    # (older git ignores an empty remote's HEAD symref when cloning).
+    _git("symbolic-ref", "HEAD", "refs/heads/main", cwd=seed)
+    _git("config", "user.email", "t@t.t", cwd=seed)
+    _git("config", "user.name", "t", cwd=seed)
+    (seed / "CLAUDE.md").write_text(_CONTAINER_V1)
+    (seed / "config").mkdir()
+    (seed / "config" / "guardian-claude.md").write_text(_GUARDIAN_MD)
+    (seed / "config" / "guardian.yaml").write_text(_GUARDIAN_YAML)
+    _git("add", "-A", cwd=seed)
+    _git("commit", "-qm", "init", cwd=seed)
+    _git("push", "-q", "origin", "main", cwd=seed)
+
+    install = home / ".local" / "share" / "genesis-guardian"
+    install.parent.mkdir(parents=True, exist_ok=True)
+    _git("clone", "-q", str(remote), str(install), cwd=home)
+    _git("config", "user.email", "t@t.t", cwd=install)
+    _git("config", "user.name", "t", cwd=install)
+    # Prior regen state: CLAUDE.md == Guardian identity, diverged from tracked.
+    (install / "CLAUDE.md").write_text(_GUARDIAN_MD)
+
+    # Upstream advances the tracked container CLAUDE.md (the trigger for the bug).
+    pusher = home / "pusher"
+    _git("clone", "-q", str(remote), str(pusher), cwd=home)
+    _git("config", "user.email", "t@t.t", cwd=pusher)
+    _git("config", "user.name", "t", cwd=pusher)
+    (pusher / "CLAUDE.md").write_text(_CONTAINER_V2)
+    _git("commit", "-aqm", "upstream change", cwd=pusher)
+    _git("push", "-q", "origin", "main", cwd=pusher)
+    return install
+
+
+def _run_update(home: Path, stub_bin: Path):
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env["PATH"] = f"{stub_bin}:{env['PATH']}"
+    env["SSH_ORIGINAL_COMMAND"] = "update"
+    proc = subprocess.run(["bash", str(_GATEWAY)], env=env,
+                          capture_output=True, text=True)
+    return proc
+
+
+@pytest.mark.parametrize("skip_worktree", [False, True],
+                         ids=["clean", "legacy-skip-worktree"])
+def test_update_regenerates_guardian_identity_exactly(skip_worktree, stub_bin, tmp_path):
+    """`update` pulls, then regenerates CLAUDE.md == guardian-claude.md exactly.
+
+    Must hold whether or not CLAUDE.md was wedged with --skip-worktree (the
+    legacy state that aborts the pull on unfixed code).
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    install = _seed_repo(home)
+    if skip_worktree:
+        _git("update-index", "--skip-worktree", "CLAUDE.md", cwd=install)
+
+    proc = _run_update(home, stub_bin)
+
+    assert proc.returncode == 0, f"update failed: {proc.stdout}\n{proc.stderr}"
+    assert '"ok": true' in proc.stdout, proc.stdout
+    # Pull actually advanced HEAD to the upstream commit.
+    head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=str(install),
+                          capture_output=True, text=True).stdout.strip()
+    remote_head = subprocess.run(
+        ["git", "rev-parse", "main"], cwd=str(home / "remote.git"),
+        capture_output=True, text=True).stdout.strip()
+    assert head == remote_head, "update did not fast-forward to upstream"
+    # Regenerated file is the Guardian identity, byte-for-byte (no network block,
+    # not the upstream container file).
+    got = (install / "CLAUDE.md").read_text()
+    assert got == _GUARDIAN_MD, f"CLAUDE.md not regenerated cleanly:\n{got!r}"
+
+
+def _run_redeploy(home: Path, stub_bin: Path, commit: str, tar_bytes: bytes):
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env["PATH"] = f"{stub_bin}:{env['PATH']}"
+    env["SSH_ORIGINAL_COMMAND"] = f"redeploy {commit}"
+    (home / ".local" / "bin").mkdir(parents=True, exist_ok=True)
+    return subprocess.run(["bash", str(_GATEWAY)], env=env, input=tar_bytes,
+                          capture_output=True)
+
+
+def test_redeploy_regenerates_guardian_identity(stub_bin, tmp_path):
+    """`redeploy` extracts the pushed tree, then regenerates CLAUDE.md as the
+    Guardian identity — never the container-facing root CLAUDE.md in the tar."""
+    home = tmp_path / "home"
+    home.mkdir()
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        for name, content in (("CLAUDE.md", _CONTAINER_V1),
+                              ("config/guardian-claude.md", _GUARDIAN_MD)):
+            data = content.encode()
+            ti = tarfile.TarInfo(name)
+            ti.size = len(data)
+            tf.addfile(ti, io.BytesIO(data))
+
+    proc = _run_redeploy(home, stub_bin, "abc1234", buf.getvalue())
+
+    assert proc.returncode == 0, proc.stderr.decode(errors="replace")
+    assert b'"ok": true' in proc.stdout, proc.stdout
+    install = home / ".local" / "share" / "genesis-guardian"
+    got = (install / "CLAUDE.md").read_text()
+    assert got == _GUARDIAN_MD, f"redeploy left wrong CLAUDE.md:\n{got!r}"

--- a/tests/test_scripts/test_guardian_gateway_update.py
+++ b/tests/test_scripts/test_guardian_gateway_update.py
@@ -80,7 +80,8 @@ def _seed_repo(home: Path) -> Path:
     (seed / "config").mkdir()
     (seed / "config" / "guardian-claude.md").write_text(_GUARDIAN_MD)
     (seed / "config" / "guardian.yaml").write_text(_GUARDIAN_YAML)
-    _git("add", "-A", cwd=seed)
+    _git("add", "CLAUDE.md", "config/guardian-claude.md", "config/guardian.yaml",
+         cwd=seed)
     _git("commit", "-qm", "init", cwd=seed)
     _git("push", "-q", "origin", "main", cwd=seed)
 


### PR DESCRIPTION
## What

The host-side Guardian keeps a generated `CLAUDE.md` (from `config/guardian-claude.md`, symlinked into the diagnostic CC work_dir) that the diagnostic Claude Code session loads as project context. Two bugs in how it's regenerated:

1. **skip-worktree wedged gateway updates.** `install_guardian.sh` marked `CLAUDE.md` with `git update-index --skip-worktree`. With that bit set, the gateway `update` verb's `git checkout -- CLAUDE.md` errors and `git pull --ff-only` aborts ("local changes would be overwritten") the moment upstream touches the tracked `CLAUDE.md` — silently stalling every host Guardian update (returns `{"ok":false,"git pull failed"}`).

2. **Half-empty, redundant network block.** Both gateway verbs (`update`, `redeploy`) and the installer appended a `## Network` block built from `guardian.yaml`, but `container_ip` is empty by design (auto-detected) and `host_ip` isn't a key there, so it always produced `- **Container**: <name> at ` / `http://:5000`. It's also redundant: shared host/container facts live in the user-level `~/.claude/CLAUDE.md` (the D16 inheritance design), which the diagnostic CC also loads.

## Fix

- `install_guardian.sh`: stop setting `--skip-worktree`; drop the network-append. (Also removes a `cd` side-effect — verified nothing later in the script depends on cwd.)
- `guardian-gateway.sh` `update`: clear skip-worktree before the checkout so legacy installs self-heal; drop the network-append.
- `guardian-gateway.sh` `redeploy`: drop the network-append.
- The regenerated file is now exactly `config/guardian-claude.md`.

## Tests

`tests/test_scripts/test_guardian_gateway_update.py` runs the **real** gateway `update`/`redeploy` against a throwaway git clone (`systemctl`/`sudo` stubbed), parametrized over skip-worktree set/unset. Confirmed **RED** on the unfixed gateway (pull abort + spurious block), **GREEN** after. Existing `update-cc` gateway tests still pass (15/15); shellcheck + `bash -n` clean.

## Review

Code-reviewer pass: core fix verified correct; the `cd`-removal and consumer-grep claims confirmed. One pre-existing latent issue (failure-path `git stash` restore in the `update` else-branch) tracked as a follow-up — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)