### PR TITLE
fix(surplus): keep quotes raw in Telegram surplus posts

### DIFF
--- a/src/genesis/surplus/executor.py
+++ b/src/genesis/surplus/executor.py
@@ -751,9 +751,13 @@ class SurplusLLMExecutor:
             from html import escape
 
             label = task.task_type.replace("_", " ").title()
+            # quote=False: keep &/</> escaped (needed so the <b> label parses under
+            # parse_mode=HTML) but leave " and ' raw. With quote=True, html.escape turns
+            # them into &quot;/&#x27;, which Telegram's HTML parser renders LITERALLY in
+            # text content — surplus JSON/findings showed raw entities to the user.
             text = (
                 f"<b>Surplus: {escape(label)}</b>\n\n"
-                f"{escape(content[:2000])}"
+                f"{escape(content[:2000], quote=False)}"
             )
             await self._topic_manager.send_to_category("surplus", text)
             logger.info("Posted surplus insight to Telegram (task=%s)", task.task_type)

--- a/tests/test_surplus/test_executor.py
+++ b/tests/test_surplus/test_executor.py
@@ -59,6 +59,25 @@ async def test_insights_list_populated():
 
 
 @pytest.mark.asyncio
+async def test_post_to_telegram_keeps_quotes_raw():
+    """Regression: surplus content quotes/apostrophes must stay raw (Telegram HTML
+    renders &quot;/&#x27; literally), while &/</> stay escaped for HTML safety."""
+    ex = object.__new__(SurplusLLMExecutor)
+    ex._topic_manager = AsyncMock()
+    content = "{\"title\": \"Jay's plan & <next> steps\"}"
+    await ex._post_to_telegram(_make_task(), content)
+
+    ex._topic_manager.send_to_category.assert_called_once()
+    category, sent_text = ex._topic_manager.send_to_category.call_args[0][:2]
+    assert category == "surplus"
+    # quotes/apostrophes preserved, NOT entity-escaped
+    assert '"' in sent_text and "'" in sent_text
+    assert "&quot;" not in sent_text and "&#x27;" not in sent_text
+    # &, <, > still escaped (HTML-safe so the <b> label parses)
+    assert "&amp;" in sent_text and "&lt;next&gt;" in sent_text
+
+
+@pytest.mark.asyncio
 async def test_no_error():
     result = await StubExecutor().execute(_make_task())
     assert result.error is None


### PR DESCRIPTION
## What & why

Surplus-topic messages rendered literal `&quot;` / `&#x27;` instead of `"` / `'`.

`surplus/executor.py` `_post_to_telegram` escaped the body with `html.escape(content)` (default `quote=True`) and sent it `parse_mode="HTML"`. Telegram's HTML parser only unescapes `&lt;`/`&gt;`/`&amp;` in text content, so `&quot;`/`&#x27;` showed verbatim — surplus JSON/findings looked like raw entity soup.

## Change
- `escape(content[:2000])` → `escape(content[:2000], quote=False)`: still escapes `&`/`<`/`>` (needed so the `<b>Surplus: …</b>` label parses + tag-injection safety preserved), but leaves `"`/`'` raw so they render correctly.
- Adds a regression test (`test_post_to_telegram_keeps_quotes_raw`) that fails on the pre-fix code.

Single active surplus delivery path (the OutreachScheduler `_surplus_outreach_job` is unregistered). ruff clean; 32 surplus-executor tests pass. Independent review: clean.
