### PR TITLE
fix(memory): stop reference auto-classifier fabricating refs from prose

### DIFF
--- a/src/genesis/memory/reference_extraction.py
+++ b/src/genesis/memory/reference_extraction.py
@@ -10,10 +10,12 @@ the reference store via :func:`ingest_knowledge_unit`.
 This is the SILENT AUTO-CAPTURE path — no user prompt, no explicit flag.
 Runs on the existing extraction cadence with zero new LLM calls.
 
-Classification errs on the side of capturing more:
-- False positives are harmless (unused entries sit idle). False negatives
-  lose credentials permanently. Multiple overlapping patterns are
-  intentional — if any one fires, we capture.
+Classification balances recall against precision:
+- Genuine references are captured broadly, but the credential/network kinds
+  require precise signals (an explicit separator after a credential label;
+  a network context word adjacent to the IP). They run over LLM-generated
+  prose, where a loose match fabricates a misleading value rather than
+  sitting idle harmlessly.
 - The primary capture path is the LLM calling ``reference_store`` in
   real-time. This background path is a safety net that catches things
   the primary path missed.
@@ -40,10 +42,13 @@ logger = logging.getLogger(__name__)
 
 
 # ─── Classification patterns ─────────────────────────────────────────────────
-# Strategy: ERR ON THE SIDE OF CAPTURING MORE. False positives in the
-# reference store are harmless (unused entries sit idle). False negatives
-# lose credentials permanently. Multiple overlapping patterns are
-# intentional — if any one fires, we capture.
+# Strategy: capture genuine references broadly, but require PRECISION for the
+# credential/network kinds — these run over LLM-generated prose, where a loose
+# match fabricates a misleading value (e.g. "can pin checkpoints" -> a fake
+# credential "checkpoints"). So credential labels require an explicit separator
+# (: = is), not a bare space, and IP/network matches require a context word
+# adjacent to the match. Other kinds (known key prefixes, labeled API tokens,
+# URLs) stay broad — their formats are self-validating.
 
 # A. Credential pair — broadened. Any credential-label word near a value.
 # Doesn't require BOTH user+pass — a single "password: X" is enough.
@@ -52,7 +57,7 @@ _CREDENTIAL_PAIR_PATTERN = re.compile(
     r"\b(?:username|user|login)\s*(?:is\s+|[:=]\s*|\s+)"
     rf"(?P<user>(?!{_LABEL_WORDS}\b)[^\s,;]+)"
     r".{0,200}?"
-    r"\b(?:password|pass|pwd)\s*(?:is\s+|[:=]\s*|\s+)"
+    r"\b(?:password|pass|pwd)\s*(?:is\s+|[:=]\s*)"
     rf"(?P<pass>(?!{_LABEL_WORDS}\b)[^\s,;]+)",
     re.IGNORECASE | re.DOTALL,
 )
@@ -61,7 +66,7 @@ _CREDENTIAL_PAIR_PATTERN = re.compile(
 # "password: Z", "account u/Name", etc. without requiring a pair.
 _SINGLE_CREDENTIAL_PATTERN = re.compile(
     r"\b(?:password|pass(?:word)?|pwd|passphrase|passcode|pin)"
-    r"\s*(?:is\s+|[:=]\s*|\s+)"
+    r"\s*(?:is\s+|[:=]\s*)"
     r"(?P<value>[^\s,;]{4,})",
     re.IGNORECASE,
 )
@@ -72,7 +77,7 @@ _EMAIL_PASSWORD_PATTERN = re.compile(
     r"\b(?:e-?mail)\s*(?:is\s+|[:=]\s*|\s+)"
     r"(?P<email>[^\s,;]+@[^\s,;]+)"
     r".{0,200}?"
-    r"\b(?:password|pass|pwd)\s*(?:is\s+|[:=]\s*|\s+)"
+    r"\b(?:password|pass|pwd)\s*(?:is\s+|[:=]\s*)"
     r"(?P<pass>[^\s,;]{4,})",
     re.IGNORECASE | re.DOTALL,
 )
@@ -97,7 +102,7 @@ _CREDENTIAL_TOKEN_PATTERN = re.compile(
     r"\b(?:api[_\s-]?key|access[_\s-]?token|bearer[_\s-]?token|"
     r"secret[_\s-]?key|auth[_\s-]?token|refresh[_\s-]?token|"
     r"api[_\s-]?secret|private[_\s-]?key)"
-    r"\s*(?:is\s*|[:=]\s*|\s+)(?P<token>[A-Za-z0-9_\-\.]{16,})",
+    r"\s*(?:is\s+|[:=]\s*)(?P<token>[A-Za-z0-9_\-\.]{16,})",
     re.IGNORECASE,
 )
 
@@ -121,7 +126,7 @@ _ACCOUNT_LIFECYCLE_PATTERN = re.compile(
     r"(?:for\s+|named?\s+|called?\s+)?"
     r"(?P<account>[^\s,;]{2,})"
     r".{0,200}?"
-    r"\b(?:password|pass|pwd)\s*(?:is\s+|[:=]\s*|\s+)"
+    r"\b(?:password|pass|pwd)\s*(?:is\s+|[:=]\s*)"
     r"(?P<pass>[^\s,;]{4,})",
     re.IGNORECASE | re.DOTALL,
 )
@@ -151,6 +156,11 @@ _NETWORK_CONTEXT_WORDS = frozenset({
     "proxy", "gateway", "router", "port", "bind", "listen",
     "database", "db", "backend", "upstream",
 })
+
+# How far (chars) from the IP/env-var match to look for a context word. The
+# word must be NEAR the match, not just anywhere in the content — otherwise a
+# far-away "container"/"ip" promotes incidental-IP prose to a network ref.
+_NETWORK_CONTEXT_WINDOW = 40
 
 # Phrases that signal generic ephemeral examples — if content contains
 # any of these, don't auto-capture. Reduces false positives on
@@ -375,11 +385,20 @@ def classify_as_reference(extraction: Extraction) -> dict | None:
     env_match = _ENV_VAR_PATTERN.search(content) if not ip_match else None
     net_match = ip_match or env_match
     if net_match:
-        # For env-var matches, strip the match itself before checking context
-        # to avoid false positives from defaults like "localhost" containing "host".
-        ctx = content if ip_match else content.replace(net_match.group(0), "")
-        lower = ctx.lower()
-        if any(word in lower for word in _NETWORK_CONTEXT_WORDS):
+        # Require a network context word NEAR the match (windowed) with word
+        # boundaries — not anywhere in the content by substring. Prose that
+        # merely mentions an IP (code analysis, planning notes) with a far-away
+        # "container"/"ip" must NOT become a network reference. Word boundaries
+        # also stop the match itself (${CONTAINER_IP}, localhost) from
+        # supplying its own context.
+        start, end = net_match.span()
+        window = content[
+            max(0, start - _NETWORK_CONTEXT_WINDOW): end + _NETWORK_CONTEXT_WINDOW
+        ].lower()
+        if any(
+            re.search(rf"\b{re.escape(word)}\b", window)
+            for word in _NETWORK_CONTEXT_WORDS
+        ):
             return {
                 "kind": "network",
                 "identifier": _derive_identifier(

--- a/tests/test_memory/test_reference_extraction_precision.py
+++ b/tests/test_memory/test_reference_extraction_precision.py
@@ -1,0 +1,208 @@
+"""Precision regression tests for the reference classifier.
+
+The 2h ``memory_extraction`` job runs ``classify_as_reference`` over
+LLM-generated extraction prose. Before this fix it mis-classified ordinary
+conversation/analysis as references, fabricating credential/network values:
+
+- credential patterns matched a bare label word + space + the next word, so
+  prose like "can pin checkpoints" / "content pass committed" produced a
+  credential with value "checkpoints" / "committed".
+- the network gate checked for a context word ANYWHERE in the content (and by
+  substring), so an incidental IP plus a far-away "container" / "IP" inside
+  "IPs" produced a network reference.
+
+These tests pin the exact junk that was found in the live store, plus a
+pair-prose class case, and guard that genuine references still classify.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from genesis.db.schema import create_all_tables
+from genesis.memory.extraction import Extraction
+from genesis.memory.reference_extraction import (
+    classify_as_reference,
+    extract_references_from_chunk,
+)
+
+
+def _ext(content: str, entities: list[str] | None = None) -> Extraction:
+    return Extraction(
+        content=content,
+        extraction_type="entity",
+        confidence=0.9,
+        entities=entities or [],
+    )
+
+
+# ─── Must NOT classify (the real junk that polluted the store) ────────────────
+
+
+class TestRejectsProseFalsePositives:
+    def test_sqlite_wal_insight_is_not_a_credential(self):
+        # "can pin checkpoints" → was captured as credentials value "checkpoints"
+        ext = _ext(
+            "Long-held read transactions in SQLite WAL mode can pin checkpoints, "
+            "causing unbounded WAL growth (1.9 GB observed) and system-wide lock "
+            "contention. This is a durable system insight about SQLite behavior.",
+            entities=["SQLite"],
+        )
+        assert classify_as_reference(ext) is None
+
+    def test_portfolio_status_is_not_a_credential(self):
+        # "content pass committed" → was captured as credentials value "committed"
+        ext = _ext(
+            "The portfolio website is complete, with all four threads and the "
+            "content pass committed to main, authored by Jay Wingard.",
+            entities=["portfolio website"],
+        )
+        assert classify_as_reference(ext) is None
+
+    def test_code_analysis_with_incidental_ip_is_not_network(self):
+        # IP appears inside code-analysis prose; the only context word ("IP" in
+        # "IPs") is far from the IP → must not become a network reference.
+        ext = _ext(
+            "FTS search already handles IP addresses correctly: _prepare_fts5 "
+            "converts dots to spaces (203.0.113.45 to 192 168 50 123 as ANDed "
+            "tokens) and the porter tokenizer splits indexed IPs the same way.",
+            entities=["_prepare_fts5"],
+        )
+        assert classify_as_reference(ext) is None
+
+    def test_planning_commentary_with_incidental_ip_is_not_network(self):
+        # "incus container workflow" is ~130 chars from the IP → far-away context
+        # word must not promote this planning prose to a network reference.
+        ext = _ext(
+            "The straggler credential 04d00c42 (203.0.113.45, null qdrant_id, "
+            "0 FTS rows) is no longer the only copy. A clean entry cb50ffc8 now "
+            "exists. The broken one holds key-based SSH and incus container "
+            "workflow guidance; the working one holds the value.",
+            entities=["04d00c42"],
+        )
+        assert classify_as_reference(ext) is None
+
+    def test_labeled_token_prose_is_not_a_credential(self):
+        # "api key authentication-middleware-layer" → bare-space token match
+        # captured a fabricated token from code-description prose.
+        ext = _ext(
+            "The api key authentication-middleware-layer handles all inbound "
+            "requests for the gateway before they reach the service.",
+            entities=["api key"],
+        )
+        assert classify_as_reference(ext) is None
+
+    def test_pair_prose_is_not_a_credential(self):
+        # "user can pass through" → bare-space pair match captured can / through.
+        ext = _ext(
+            "The user can pass through the gateway to reach the backend service "
+            "without any additional authentication being required.",
+            entities=["gateway"],
+        )
+        assert classify_as_reference(ext) is None
+
+
+# ─── Must STILL classify (guards the fix didn't over-correct) ─────────────────
+
+
+class TestStillClassifiesGenuine:
+    def test_colon_separated_single_credential_still_captured(self):
+        ext = _ext(
+            "The Home Assistant dashboard password: Hunter2!xyz for the admin user",
+            entities=["Home Assistant"],
+        )
+        ref = classify_as_reference(ext)
+        assert ref is not None
+        assert ref["kind"] == "credentials"
+        assert "Hunter2!xyz" in ref["value"]
+
+    def test_lowercase_password_pair_still_captured(self):
+        # all-lowercase passwords are legitimate (no entropy gate that rejects them)
+        ext = _ext(
+            "ScarletAndRage login: username: buckeye614 password: verysecretword",
+            entities=["ScarletAndRage"],
+        )
+        ref = classify_as_reference(ext)
+        assert ref is not None
+        assert ref["kind"] == "credentials"
+        assert "verysecretword" in ref["value"]
+
+    def test_ip_with_adjacent_context_still_network(self):
+        ext = _ext(
+            "Server runs on host 203.0.113.50 listening for connections",
+            entities=["server"],
+        )
+        ref = classify_as_reference(ext)
+        assert ref is not None
+        assert ref["kind"] == "network"
+        assert ref["value"] == "203.0.113.50"
+
+
+# ─── End-to-end: full classify → ingest path over a mixed chunk ───────────────
+
+
+@pytest.fixture
+async def _db():
+    async with aiosqlite.connect(":memory:") as conn:
+        await create_all_tables(conn)
+        await conn.commit()
+        yield conn
+
+
+@pytest.fixture
+def _store():
+    store = AsyncMock()
+    store.store = AsyncMock(return_value="qid")
+    store.delete = AsyncMock()
+    store._embeddings = MagicMock()
+    store._embeddings.model_name = "test-embed"
+    return store
+
+
+async def test_mixed_chunk_ingests_only_genuine_references(_db, _store):
+    """E2E: a chunk of 4 junk-prose + 2 real refs ingests exactly the 2 real."""
+    extractions = [
+        _ext(
+            "Long-held read transactions in SQLite WAL mode can pin checkpoints, "
+            "causing unbounded WAL growth and system-wide lock contention.",
+            ["SQLite"],
+        ),
+        _ext(
+            "The portfolio website is complete; the content pass committed to "
+            "main, authored by Jay Wingard.",
+            ["portfolio website"],
+        ),
+        _ext(
+            "FTS handles IP addresses: _prepare_fts5 converts the dots in "
+            "203.0.113.45 to spaces; the porter tokenizer splits indexed IPs.",
+            ["_prepare_fts5"],
+        ),
+        _ext(
+            "The user can pass through the gateway to reach the backend service "
+            "with no extra authentication required.",
+            ["gateway"],
+        ),
+        # genuine references that MUST still be captured:
+        _ext(
+            "ScarletAndRage login: username: buckeye614 password: Sup3r!secret",
+            ["ScarletAndRage"],
+        ),
+        _ext(
+            "The Genesis API server runs on host 203.0.113.50 for embeddings",
+            ["Genesis API"],
+        ),
+    ]
+    count = await extract_references_from_chunk(
+        extractions, store=_store, db=_db, source_session_id="e2e",
+    )
+    assert count == 2
+
+    cur = await _db.execute(
+        "SELECT domain FROM knowledge_units WHERE project_type='reference' "
+        "ORDER BY domain"
+    )
+    domains = [r[0] for r in await cur.fetchall()]
+    assert domains == ["reference.credentials", "reference.network"]


### PR DESCRIPTION
## Problem
The 2h `memory_extraction` job runs `classify_as_reference()` (regex) over LLM-generated extraction prose and was fabricating credential/network reference-store entries from ordinary text — e.g. a credential label + a bare space + the next word ("can pin checkpoints" → a credential valued "checkpoints"), and an incidental IP inside code-analysis prose → a network reference. Several junk rows reached the live reference store.

## Fix
Two precision gates in `reference_extraction.py`:
- **Credential labels require an explicit separator** (`:`, `=`, or `is `) on the value side of the pair/email/account/single patterns and the labeled-token pattern — not a bare space. Bare-word prose no longer fabricates a value. The user/email label sides stay permissive (they cannot fabricate a value on their own — the value side gates them).
- **Network matches require a context word within 40 chars** of the IP/env-var match, matched on word boundaries (not a whole-content substring scan). This also retires the old env-var "strip the match" hack.

Genuine captures are unaffected: explicit-separator credentials, adjacent-context IPs, known key prefixes, and URLs all still classify.

## Tests
Adds `test_reference_extraction_precision.py` (10 tests): regression cases for every false-positive class (bare-space credential, labeled-token, pair-prose, incidental-IP) driven RED→GREEN; guards that genuine refs still capture; and an end-to-end mixed-chunk test (4 junk + 2 genuine → only the 2 genuine ingested). Full `test_memory` extraction suite stays green; ruff clean.

## Known residual
Colon-prose like `pin: word` can still match (rare, pre-existing — the `pin` label is inherently ambiguous). Tracked as a follow-up.
