### PR TITLE
fix(guardian): harden gateway self-update + add recovery verb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   upstream, quietly leaving the host Guardian stuck on old code. The update now
   clears the flag first, so existing installs self-heal and stay current.
 
+- **Guardian host self-updates are now reliable on hosts with passwordless sudo**
+  — an unguarded step while refreshing kernel tuning could make the Guardian's
+  self-update abort partway, so it reported a failure (and could leave its own
+  updater script frozen on old code) even though the code pull had already
+  succeeded. Kernel tuning is now strictly best-effort and can't derail the
+  update; the update reliably refreshes the updater first and records what it
+  deployed; and there's a new one-step recovery path to refresh a stalled updater.
+
 - **Telegram `/stop` now stops your session, not a background task** — when a
   background task (reflection, inbox, an ego session, etc.) was running at the
   same time as your chat, `/stop` could interrupt the wrong one. Each session's

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -9,6 +9,7 @@
 #   reset-state    — reset stuck state machine to healthy
 #   version        — report CC, code, and Node versions
 #   update         — pull latest code + self-update gateway script
+#   sync-gateway    — redeploy gateway script from install dir (no pull; recovery)
 #   redeploy <hash> — receive tar archive on stdin, deploy to install dir
 #   update-cc <ver> — install a pinned Claude Code version (validated semver)
 #   test-approval   — E2E test the keyword-reply approval gate (no recovery)
@@ -89,8 +90,13 @@ PYEOF
         CODE_VER=$(cd "$INSTALL_DIR" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
         CODE_DATE=$(cd "$INSTALL_DIR" && git log -1 --format=%ci 2>/dev/null || echo "unknown")
         DEPLOYED=$(python3 -c "import json; print(json.load(open('$STATE_DIR/deploy_state.json')).get('deployed_commit','unknown'))" 2>/dev/null || echo "unknown")
-        printf '{"cc_version": "%s", "node_version": "%s", "code_version": "%s", "code_date": "%s", "deployed_commit": "%s"}\n' \
-            "$CC_VER" "$NODE_VER" "$CODE_VER" "$CODE_DATE" "$DEPLOYED"
+        # sha256 of the DEPLOYED gateway script — lets the container detect a
+        # stale/frozen gateway whose self-update silently failed (the install-dir
+        # code can be current while ~/.local/bin/guardian-gateway.sh lags).
+        GW_SHA=$(sha256sum "$HOME/.local/bin/guardian-gateway.sh" 2>/dev/null | cut -d' ' -f1 || echo "unknown")
+        [ -n "$GW_SHA" ] || GW_SHA="unknown"
+        printf '{"cc_version": "%s", "node_version": "%s", "code_version": "%s", "code_date": "%s", "deployed_commit": "%s", "gateway_sha": "%s"}\n' \
+            "$CC_VER" "$NODE_VER" "$CODE_VER" "$CODE_DATE" "$DEPLOYED" "$GW_SHA"
         ;;
     update)
         INSTALL_DIR="${HOME}/.local/share/genesis-guardian"
@@ -122,58 +128,89 @@ PYEOF
                         CONFIG_RESET=1
                     fi
                 fi
+                # Self-update FIRST (before any best-effort step): copy the freshly
+                # pulled gateway to ~/.local/bin so nothing below can leave the
+                # deployed gateway stale. Atomic rename is safe mid-execution —
+                # Linux preserves the old inode for this running process's fd.
+                # Guarded so `set -e` can't abort the whole update if it fails.
+                if [ -f "$INSTALL_DIR/scripts/guardian-gateway.sh" ]; then
+                    cp "$INSTALL_DIR/scripts/guardian-gateway.sh" "$HOME/.local/bin/guardian-gateway.sh.new" \
+                        && chmod +x "$HOME/.local/bin/guardian-gateway.sh.new" \
+                        && mv "$HOME/.local/bin/guardian-gateway.sh.new" "$HOME/.local/bin/guardian-gateway.sh" \
+                        || true
+                fi
                 # Regenerate Guardian CLAUDE.md from template (never use repo
                 # version). Shared host/container facts live in the user-level
                 # ~/.claude/CLAUDE.md (D16), so nothing is appended here.
                 if [ -f "$INSTALL_DIR/config/guardian-claude.md" ]; then
-                    cp "$INSTALL_DIR/config/guardian-claude.md" "$INSTALL_DIR/CLAUDE.md"
+                    cp "$INSTALL_DIR/config/guardian-claude.md" "$INSTALL_DIR/CLAUDE.md" || true
                 fi
-                # Self-update: copy gateway script from pulled repo to ~/.local/bin/
-                # Safe mid-execution: Linux preserves old inode while this process holds fd.
-                # Atomic rename ensures next SSH invocation picks up the new script.
-                if [ -f "$INSTALL_DIR/scripts/guardian-gateway.sh" ]; then
-                    cp "$INSTALL_DIR/scripts/guardian-gateway.sh" "$HOME/.local/bin/guardian-gateway.sh.new"
-                    chmod +x "$HOME/.local/bin/guardian-gateway.sh.new"
-                    mv "$HOME/.local/bin/guardian-gateway.sh.new" "$HOME/.local/bin/guardian-gateway.sh"
-                fi
+                # --- BEST-EFFORT host tuning below: every command is guarded so a
+                # sudo/tee/cp failure can NEVER abort the update or suppress the
+                # success JSON (Bug A — froze the deployed gateway for ~2 months
+                # on a passwordless-sudo host where an unguarded sudo tee failed). ---
                 # Update systemd units from repo (picks up MemoryMax, OOMScoreAdjust, etc.)
                 SYSTEMD_DIR="$HOME/.config/systemd/user"
                 mkdir -p "$SYSTEMD_DIR"
                 for unit in genesis-guardian.service genesis-guardian.timer \
                             genesis-guardian-watchman.service genesis-guardian-watchman.timer; do
                     if [ -f "$INSTALL_DIR/config/$unit" ]; then
-                        cp "$INSTALL_DIR/config/$unit" "$SYSTEMD_DIR/$unit"
+                        cp "$INSTALL_DIR/config/$unit" "$SYSTEMD_DIR/$unit" || true
                     fi
                 done
                 systemctl --user daemon-reload 2>/dev/null || true
                 # Refresh host sysctl/udev configs (I/O tuning, BFQ scheduler)
                 if sudo -n true 2>/dev/null; then
                     if [ -f "$INSTALL_DIR/config/60-ioscheduler.rules" ]; then
-                        sudo cp "$INSTALL_DIR/config/60-ioscheduler.rules" /etc/udev/rules.d/ 2>/dev/null
+                        sudo cp "$INSTALL_DIR/config/60-ioscheduler.rules" /etc/udev/rules.d/ 2>/dev/null || true
                         sudo udevadm control --reload-rules 2>/dev/null || true
                     fi
                     # Regenerate I/O sysctl from canonical values
-                    sudo tee /etc/sysctl.d/99-genesis-io-tuning.conf > /dev/null 2>&1 << 'IOSYSCTL'
+                    sudo tee /etc/sysctl.d/99-genesis-io-tuning.conf > /dev/null 2>&1 << 'IOSYSCTL' || true
 vm.swappiness = 10
 vm.dirty_ratio = 10
 vm.dirty_background_ratio = 3
 vm.vfs_cache_pressure = 50
 IOSYSCTL
-                    # Regenerate OOM sysctl (same formula as install_guardian.sh Step 9)
-                    _HOST_RAM_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
-                    _MIN_FREE=$(( _HOST_RAM_KB / 100 ))
-                    [ "$_MIN_FREE" -lt 131072 ] && _MIN_FREE=131072
-                    [ "$_MIN_FREE" -gt 1048576 ] && _MIN_FREE=1048576
-                    sudo tee /etc/sysctl.d/99-genesis-oom-tuning.conf > /dev/null 2>&1 << OOMSYSCTL
+                    # Regenerate OOM sysctl (same formula as install_guardian.sh Step 9).
+                    # Guard the arithmetic: empty/odd /proc/meminfo would make
+                    # $(( _HOST_RAM_KB / 100 )) a syntax error that aborts under set -e.
+                    _HOST_RAM_KB=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}' || echo "")
+                    if [ -n "$_HOST_RAM_KB" ]; then
+                        _MIN_FREE=$(( _HOST_RAM_KB / 100 ))
+                        # if-form (not `[ ] && x`): clearer + avoids any set -e
+                        # ambiguity when the clamp condition is false.
+                        if [ "$_MIN_FREE" -lt 131072 ]; then _MIN_FREE=131072; fi
+                        if [ "$_MIN_FREE" -gt 1048576 ]; then _MIN_FREE=1048576; fi
+                        sudo tee /etc/sysctl.d/99-genesis-oom-tuning.conf > /dev/null 2>&1 << OOMSYSCTL || true
 vm.min_free_kbytes = $_MIN_FREE
 vm.watermark_scale_factor = 50
 vm.oom_kill_allocating_task = 1
 OOMSYSCTL
+                    fi
                     sudo sysctl --system > /dev/null 2>&1 || true
                 fi
                 # Restart timer so new check.py code takes effect immediately
                 systemctl --user restart genesis-guardian.timer 2>/dev/null || true
-                NEW=$(git rev-parse --short HEAD 2>/dev/null)
+                NEW=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+                # Record the deployed commit so the watchdog's drift detection works
+                # for pull-based installs (previously only `redeploy` wrote this →
+                # drift detection silently skipped on a "unknown" deployed_commit).
+                mkdir -p "$STATE_DIR"
+                python3 << PYEOF 2>/dev/null || true
+import json
+from datetime import datetime, timezone
+sf = "$STATE_DIR/deploy_state.json"
+try:
+    with open(sf) as f:
+        d = json.load(f)
+except Exception:
+    d = {}
+d["deployed_commit"] = "$NEW"
+d["deployed_at"] = datetime.now(timezone.utc).isoformat()
+with open(sf, "w") as f:
+    json.dump(d, f, indent=2)
+PYEOF
                 if [ "$CONFIG_RESET" -eq 1 ]; then
                     printf '{"ok": true, "action": "update", "old": "%s", "new": "%s", "warning": "local config changes were discarded due to merge conflict — re-run install_guardian.sh to regenerate"}\n' "$OLD" "$NEW"
                 else
@@ -318,6 +355,34 @@ PYEOF
         GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
         GUARDIAN_SECRETS="$INSTALL_DIR/secrets.env" \
             timeout 130 "$VENV_PY" -m genesis.guardian --test-approval
+        ;;
+    sync-gateway)
+        # Recovery: redeploy the gateway script from the (already-pulled) install
+        # dir to ~/.local/bin, WITHOUT a git pull. Recovers a stale/frozen deployed
+        # gateway when the `update` self-update path is unavailable (e.g. a gateway
+        # too old to have this verb is bootstrapped by a one-time host-local copy).
+        # No git, no sudo — just an idempotent copy of a repo-tracked file.
+        INSTALL_DIR="${HOME}/.local/share/genesis-guardian"
+        SRC="$INSTALL_DIR/scripts/guardian-gateway.sh"
+        DEST="$HOME/.local/bin/guardian-gateway.sh"
+        if [ ! -f "$SRC" ]; then
+            echo '{"ok": false, "action": "sync-gateway", "error": "install-dir gateway not found"}' >&2
+            exit 1
+        fi
+        OLD_SHA=$(sha256sum "$DEST" 2>/dev/null | cut -d' ' -f1 || echo "none")
+        [ -n "$OLD_SHA" ] || OLD_SHA="none"
+        mkdir -p "$(dirname "$DEST")"
+        # Guard the copy so a write failure reports a clean JSON error rather
+        # than a bare set -e abort with no output.
+        if cp "$SRC" "$DEST.new" && chmod +x "$DEST.new" && mv "$DEST.new" "$DEST"; then
+            NEW_SHA=$(sha256sum "$DEST" 2>/dev/null | cut -d' ' -f1 || echo "unknown")
+            printf '{"ok": true, "action": "sync-gateway", "old_sha": "%s", "new_sha": "%s"}\n' \
+                "$OLD_SHA" "$NEW_SHA"
+        else
+            rm -f "$DEST.new" 2>/dev/null || true
+            echo '{"ok": false, "action": "sync-gateway", "error": "failed to deploy gateway"}' >&2
+            exit 1
+        fi
         ;;
     ping)
         echo '{"ok": true, "action": "ping"}'

--- a/scripts/install_guardian.sh
+++ b/scripts/install_guardian.sh
@@ -439,8 +439,8 @@ _host_mem_gb=$(( ${_host_mem_kb:-0} / 1048576 ))
 if [ "$_host_mem_gb" -gt 0 ] 2>/dev/null; then
     # Scale min_free_kbytes to ~1% of host RAM (floor 128MB, cap 1024MB)
     _min_free_mb=$(( _host_mem_gb * 10 ))  # ~1% in MB
-    [ "$_min_free_mb" -lt 128 ] && _min_free_mb=128
-    [ "$_min_free_mb" -gt 1024 ] && _min_free_mb=1024
+    if [ "$_min_free_mb" -lt 128 ]; then _min_free_mb=128; fi
+    if [ "$_min_free_mb" -gt 1024 ]; then _min_free_mb=1024; fi
     _min_free_kb=$(( _min_free_mb * 1024 ))
 
     # Idempotency: don't downgrade if someone already set a higher value.
@@ -448,14 +448,17 @@ if [ "$_host_mem_gb" -gt 0 ] 2>/dev/null; then
     if [ "${_current_min_free:-0}" -ge "$_min_free_kb" ]; then
         echo "  OOM tuning already adequate (min_free_kbytes=${_current_min_free})"
     elif sudo -n true 2>/dev/null; then
-        sudo tee /etc/sysctl.d/99-genesis-oom-tuning.conf > /dev/null << SYSCTL
+        # Best-effort tuning: guard each sudo command so a failure can't abort
+        # the install under `set -euo pipefail` (the WARN branch below is the
+        # intended fallback when tuning can't be applied).
+        sudo tee /etc/sysctl.d/99-genesis-oom-tuning.conf > /dev/null << SYSCTL || true
 # Genesis — kernel OOM protection (installed by install_guardian.sh)
 # Prevents VM freeze under memory pressure. Safe to customize.
 vm.min_free_kbytes = $_min_free_kb
 vm.watermark_scale_factor = 50
 vm.oom_kill_allocating_task = 1
 SYSCTL
-        sudo sysctl --system > /dev/null 2>&1
+        sudo sysctl --system > /dev/null 2>&1 || true
         echo "  + OOM tuning applied (min_free=${_min_free_mb}MB for ${_host_mem_gb}GB host)"
     else
         echo "  WARN  Cannot apply OOM tuning (no passwordless sudo)"
@@ -475,8 +478,10 @@ fi
 # Reference configs: config/99-container-host.conf, config/60-ioscheduler.rules
 
 if sudo -n true 2>/dev/null; then
+    # Best-effort tuning: guard each sudo command so a failure can't abort the
+    # install under `set -euo pipefail` (the SKIP branch below is the fallback).
     # I/O sysctl — always overwrite to pick up value changes on update
-    sudo tee /etc/sysctl.d/99-genesis-io-tuning.conf > /dev/null << 'SYSCTL'
+    sudo tee /etc/sysctl.d/99-genesis-io-tuning.conf > /dev/null << 'SYSCTL' || true
 # Genesis — I/O pressure reduction (installed by install_guardian.sh)
 # Reduces dirty page cache to prevent I/O death spirals under sustained write load.
 vm.swappiness = 10
@@ -484,12 +489,12 @@ vm.dirty_ratio = 10
 vm.dirty_background_ratio = 3
 vm.vfs_cache_pressure = 50
 SYSCTL
-    sudo sysctl --system > /dev/null 2>&1
+    sudo sysctl --system > /dev/null 2>&1 || true
     echo "  + I/O tuning applied (swappiness=10, dirty_ratio=10)"
 
     # BFQ I/O scheduler — always refresh from repo
     if [ -d "$INSTALL_DIR/config" ] && [ -f "$INSTALL_DIR/config/60-ioscheduler.rules" ]; then
-        sudo cp "$INSTALL_DIR/config/60-ioscheduler.rules" /etc/udev/rules.d/
+        sudo cp "$INSTALL_DIR/config/60-ioscheduler.rules" /etc/udev/rules.d/ || true
         sudo udevadm control --reload-rules 2>/dev/null || true
         echo "  + BFQ I/O scheduler rule installed"
     fi

--- a/src/genesis/guardian/remote.py
+++ b/src/genesis/guardian/remote.py
@@ -8,7 +8,8 @@ script via an authorized_keys ``command=`` directive — even if this code
 tried to run arbitrary commands, the host would reject them. OpenSSH
 enforces this restriction, not our code.
 
-Seven operations: restart-timer, pause, resume, status, reset-state, version, update.
+Gateway allowlist: restart-timer, pause, resume, status, reset-state, version,
+update, sync-gateway, redeploy, update-cc, test-approval, ping.
 """
 
 from __future__ import annotations

--- a/tests/test_scripts/test_guardian_gateway_update.py
+++ b/tests/test_scripts/test_guardian_gateway_update.py
@@ -1,9 +1,10 @@
-"""Tests for the guardian-gateway.sh ``update`` op CLAUDE.md regeneration.
+"""Tests for the guardian-gateway.sh ``update``/``sync-gateway``/``version`` ops.
 
 The Guardian's diagnostic CC loads the install-dir ``CLAUDE.md`` as project
 context, so the ``update`` op must regenerate it from ``config/guardian-claude.md``
 on every pull — never leave the repo's container-facing root ``CLAUDE.md`` in
-place. Two regressions are guarded here:
+place. The op must also self-update the deployed gateway and report success
+reliably. These regressions are guarded here:
 
 * **skip-worktree must not wedge the pull.** If ``CLAUDE.md`` is marked
   ``--skip-worktree`` (older installs did this), ``git pull --ff-only`` aborts
@@ -13,13 +14,28 @@ place. Two regressions are guarded here:
 * **No spurious network block.** The regenerated file must equal
   ``config/guardian-claude.md`` exactly — shared host/container facts live in the
   user-level ``~/.claude/CLAUDE.md`` (D16), not duplicated (and half-empty) here.
+* **Best-effort host tuning must not abort the update (Bug A).** On a host WITH
+  passwordless sudo, an unguarded ``sudo cp``/``sudo tee`` in the sysctl/udev
+  block used to abort under ``set -euo pipefail`` *before* the success JSON —
+  so ``update`` exited 1, swallowed its result, and (on some orderings) skipped
+  the self-update. The deployed gateway then silently froze. The tuning must be
+  best-effort: ``update`` self-updates and emits ``{"ok":true}`` regardless.
+* **deployed_commit is recorded.** ``update`` writes the new HEAD to
+  ``deploy_state.json`` so the watchdog's drift detection works for pull-based
+  installs (previously only ``redeploy`` wrote it → drift detection silently
+  skipped).
+* **sync-gateway / gateway_sha.** A recovery verb re-deploys the install-dir
+  gateway without a pull, and ``version`` reports the deployed gateway's sha256
+  so a stale gateway is detectable.
 
-These run the REAL ``scripts/guardian-gateway.sh update`` against a throwaway git
-clone with ``systemctl``/``sudo`` stubbed so the systemd/sysctl side effects
-no-op. Real ``git`` is the thing under test.
+These run the REAL ``scripts/guardian-gateway.sh`` against throwaway git clones
+with ``systemctl``/``sudo`` stubbed so the systemd/sysctl side effects no-op.
+Real ``git`` is the thing under test.
 """
 
+import hashlib
 import io
+import json
 import os
 import stat
 import subprocess
@@ -36,6 +52,9 @@ _CONTAINER_V1 = "# Genesis v3 — Project Instructions\nCONTAINER SENTINEL v1\n"
 _CONTAINER_V2 = "# Genesis v3 — Project Instructions\nCONTAINER SENTINEL v2 UPSTREAM\n"
 _GUARDIAN_MD = "# Genesis Guardian — Immune System\nGUARDIAN IDENTITY SENTINEL\n"
 _GUARDIAN_YAML = 'container_name: genesis\ncontainer_ip: ""\n'
+# Stand-in for the tracked scripts/guardian-gateway.sh: lets us assert the
+# self-update / sync-gateway actually deployed the install-dir copy.
+_SEED_GATEWAY = "#!/usr/bin/env bash\n# SEED GATEWAY SENTINEL\necho seed\n"
 
 
 def _make_stub(path: Path, body: str) -> None:
@@ -59,13 +78,33 @@ def stub_bin(tmp_path):
     return bind
 
 
+@pytest.fixture
+def stub_bin_sudo_passwordless(tmp_path):
+    """systemctl no-op; sudo where ``-n true`` SUCCEEDS but every real sudo
+    command FAILS — the passwordless-sudo host whose sysctl/udev tuning errors.
+
+    This is the path that hid Bug A: the prior ``stub_bin`` makes ``sudo -n true``
+    fail, so the whole tuning block was skipped and never exercised. Here the
+    block runs and its commands fail — ``update`` must NOT abort.
+    """
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    _make_stub(bind / "systemctl", "#!/usr/bin/env bash\nexit 0\n")
+    _make_stub(bind / "sudo",
+               '#!/usr/bin/env bash\n[ "$1" = "-n" ] && exit 0\nexit 1\n')
+    return bind
+
+
 def _seed_repo(home: Path) -> Path:
     """Build a bare remote + an INSTALL_DIR clone in a diverged/legacy state.
 
     Mirrors a real host: CLAUDE.md locally regenerated to the Guardian identity
     (diverged from the tracked container file), then upstream advances the
-    tracked CLAUDE.md. Returns the install dir.
+    tracked CLAUDE.md. The tracked tree includes scripts/guardian-gateway.sh so
+    the self-update path is exercised. Returns the install dir.
     """
+    (home / ".local" / "bin").mkdir(parents=True, exist_ok=True)
+
     remote = home / "remote.git"
     _git("-c", "init.defaultBranch=main", "init", "-q", "--bare", str(remote), cwd=home)
 
@@ -80,8 +119,10 @@ def _seed_repo(home: Path) -> Path:
     (seed / "config").mkdir()
     (seed / "config" / "guardian-claude.md").write_text(_GUARDIAN_MD)
     (seed / "config" / "guardian.yaml").write_text(_GUARDIAN_YAML)
+    (seed / "scripts").mkdir()
+    (seed / "scripts" / "guardian-gateway.sh").write_text(_SEED_GATEWAY)
     _git("add", "CLAUDE.md", "config/guardian-claude.md", "config/guardian.yaml",
-         cwd=seed)
+         "scripts/guardian-gateway.sh", cwd=seed)
     _git("commit", "-qm", "init", cwd=seed)
     _git("push", "-q", "origin", "main", cwd=seed)
 
@@ -104,14 +145,25 @@ def _seed_repo(home: Path) -> Path:
     return install
 
 
-def _run_update(home: Path, stub_bin: Path):
+def _run_verb(home: Path, stub_bin: Path, verb: str, stdin_bytes: bytes | None = None):
     env = dict(os.environ)
     env["HOME"] = str(home)
     env["PATH"] = f"{stub_bin}:{env['PATH']}"
-    env["SSH_ORIGINAL_COMMAND"] = "update"
-    proc = subprocess.run(["bash", str(_GATEWAY)], env=env,
-                          capture_output=True, text=True)
-    return proc
+    env["SSH_ORIGINAL_COMMAND"] = verb
+    if stdin_bytes is None:
+        return subprocess.run(["bash", str(_GATEWAY)], env=env,
+                              capture_output=True, stdin=subprocess.DEVNULL)
+    return subprocess.run(["bash", str(_GATEWAY)], env=env,
+                          capture_output=True, input=stdin_bytes)
+
+
+def _run_update(home: Path, stub_bin: Path):
+    return _run_verb(home, stub_bin, "update")
+
+
+def _short_head(install: Path) -> str:
+    return subprocess.run(["git", "rev-parse", "--short", "HEAD"], cwd=str(install),
+                          capture_output=True, text=True).stdout.strip()
 
 
 @pytest.mark.parametrize("skip_worktree", [False, True],
@@ -131,7 +183,7 @@ def test_update_regenerates_guardian_identity_exactly(skip_worktree, stub_bin, t
     proc = _run_update(home, stub_bin)
 
     assert proc.returncode == 0, f"update failed: {proc.stdout}\n{proc.stderr}"
-    assert '"ok": true' in proc.stdout, proc.stdout
+    assert b'"ok": true' in proc.stdout, proc.stdout
     # Pull actually advanced HEAD to the upstream commit.
     head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=str(install),
                           capture_output=True, text=True).stdout.strip()
@@ -143,6 +195,75 @@ def test_update_regenerates_guardian_identity_exactly(skip_worktree, stub_bin, t
     # not the upstream container file).
     got = (install / "CLAUDE.md").read_text()
     assert got == _GUARDIAN_MD, f"CLAUDE.md not regenerated cleanly:\n{got!r}"
+
+
+def test_update_self_updates_and_succeeds_when_sudo_tuning_fails(
+        stub_bin_sudo_passwordless, tmp_path):
+    """Bug A regression: on a passwordless-sudo host whose sysctl/udev `sudo`
+    commands fail, `update` must STILL self-update the deployed gateway and exit
+    0 with JSON. The best-effort host tuning must never abort the update."""
+    home = tmp_path / "home"
+    home.mkdir()
+    _seed_repo(home)
+
+    proc = _run_update(home, stub_bin_sudo_passwordless)
+
+    assert proc.returncode == 0, (
+        f"update aborted on best-effort sudo tuning failure (Bug A): "
+        f"{proc.stdout}\n{proc.stderr}")
+    assert b'"ok": true' in proc.stdout, proc.stdout
+    deployed = (home / ".local" / "bin" / "guardian-gateway.sh").read_text()
+    assert deployed == _SEED_GATEWAY, (
+        "self-update did not deploy the install-dir gateway despite a clean pull")
+
+
+def test_update_writes_deployed_commit(stub_bin, tmp_path):
+    """`update` records the new HEAD in deploy_state.json so the watchdog drift
+    check (which reads deployed_commit) works for pull-based installs."""
+    home = tmp_path / "home"
+    home.mkdir()
+    install = _seed_repo(home)
+
+    proc = _run_update(home, stub_bin)
+
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    ds = home / ".local" / "state" / "genesis-guardian" / "deploy_state.json"
+    assert ds.exists(), "deploy_state.json not written by update"
+    assert json.loads(ds.read_text())["deployed_commit"] == _short_head(install)
+
+
+def test_sync_gateway_redeploys_from_install_dir(stub_bin, tmp_path):
+    """`sync-gateway` copies the install-dir gateway to ~/.local/bin WITHOUT a
+    pull — the recovery lever when the update self-update path is unavailable."""
+    home = tmp_path / "home"
+    home.mkdir()
+    _seed_repo(home)
+    deployed_path = home / ".local" / "bin" / "guardian-gateway.sh"
+    deployed_path.write_text("#!/usr/bin/env bash\n# STALE FROZEN GATEWAY\n")
+
+    proc = _run_verb(home, stub_bin, "sync-gateway")
+
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert b'"ok": true' in proc.stdout, proc.stdout
+    assert deployed_path.read_text() == _SEED_GATEWAY, (
+        "sync-gateway did not refresh the deployed gateway from the install dir")
+
+
+def test_version_reports_gateway_sha(stub_bin, tmp_path):
+    """`version` reports gateway_sha = sha256 of the deployed gateway, so the
+    container can detect a stale/frozen deployed gateway."""
+    home = tmp_path / "home"
+    home.mkdir()
+    _seed_repo(home)
+    deployed_path = home / ".local" / "bin" / "guardian-gateway.sh"
+    content = "#!/usr/bin/env bash\n# DEPLOYED GATEWAY CONTENT\n"
+    deployed_path.write_text(content)
+
+    proc = _run_verb(home, stub_bin, "version")
+
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    data = json.loads(proc.stdout)
+    assert data["gateway_sha"] == hashlib.sha256(content.encode()).hexdigest(), data
 
 
 def _run_redeploy(home: Path, stub_bin: Path, commit: str, tar_bytes: bytes):


### PR DESCRIPTION
## Problem

The host Guardian's gateway `update` verb ran best-effort host tuning (sudo sysctl/udev) **unguarded** under `set -euo pipefail`. On a host with **passwordless sudo**, an errant `sudo tee` returned non-zero and `set -e` aborted the script **before the final `{"ok":true}` printf** — so `update` exited 1, swallowed its JSON result, and (because the deployed-gateway self-update lived in that same branch) the deployed `~/.local/bin/guardian-gateway.sh` **silently froze**. The install dir kept pulling current via the git-pull step, while the deployed gateway went stale for months — masked entirely because every update *looked* like a failure and nothing monitored deployed-gateway version.

Reproduced in a scratch harness: `sudo -n true` passes + a `sudo` tuning command fails → "Already up to date." + exit 1 + no JSON (matches the live host exactly); with sudo unavailable (block skipped) → exit 0 + clean JSON.

## Fix

- **`update`:** self-update the deployed gateway **first** after a successful pull (so no later best-effort step can leave it stale), and guard every best-effort step (`|| true`) so tuning failures can't abort the update or suppress the success result. The `_HOST_RAM_KB` arithmetic is guarded against empty/odd `/proc/meminfo`.
- **`update`:** record `deployed_commit` in `deploy_state.json` — previously only `redeploy` wrote it, so the watchdog's drift detection silently skipped (`deployed_commit == "unknown"`) for pull-based installs.
- **`version`:** report `gateway_sha` (sha256 of the deployed gateway) so a stale/frozen gateway is detectable from the container.
- **New `sync-gateway` verb:** redeploy the gateway from the (already-pulled) install dir without a git pull — a clean recovery lever when the self-update path is unavailable. No git, no sudo; idempotent copy of a repo-tracked file.
- **`install_guardian.sh`:** same DRY guards on its best-effort sudo tuning; clamp lines converted to `if`-form to remove `set -e` ambiguity.

## Testing

- TDD: 4 new tests, RED on pre-fix code, GREEN after. The key one (`test_update_self_updates_and_succeeds_when_sudo_tuning_fails`) exercises the **passwordless-sudo-failure path that the prior test suite skipped** (its `sudo` stub made `sudo -n true` fail, bypassing the whole block — which is why the bug survived review). Plus `deployed_commit` / `sync-gateway` / `gateway_sha` coverage. `_seed_repo` now seeds the gateway script + `~/.local/bin` so self-update is actually exercised.
- `bash -n` clean on both scripts; `ruff` clean; 7/7 tests pass.
- Adversarial review: Codex (quota-exhausted → Claude code-reviewer fallback). One flagged "P1" (clamp lines aborting under `set -e`) was empirically falsified (the compound's non-zero from an `-e`-ignored `&&` left-operand does not exit; verified on a 32 GiB host) — clamp lines converted to `if`-form anyway for clarity; two nits fixed.

## Follow-up (PR2)

Container-side watchdog `gateway_sha` staleness monitoring + `GuardianRemote.sync_gateway()` wiring for autonomous recovery (consumes the signals this PR emits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)