### PR TITLE
feat(guardian): detect + auto-heal a stale deployed gateway (watchdog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis now detects and auto-heals a stalled Guardian updater** — it watches whether the
+  Guardian's *deployed* updater script on the host matches the code it has actually pulled. If
+  the updater silently froze (the failure that left it ~2 months stale), Genesis notices within
+  a few checks, automatically redeploys the current updater once, and re-verifies — escalating
+  to you only if the self-heal doesn't resolve it. Closes the blind spot where the host kept
+  pulling new code while its updater quietly stopped refreshing.
+
 - **A new "deliverable-builder" skill produces send-ready work, not raw markdown** — when you
   ask Genesis to build a job take-home, client report, one-pager, or deck, it runs a gated
   pipeline: it frames the deliverable with you (audience, format, what leads), drafts and

--- a/src/genesis/guardian/remote.py
+++ b/src/genesis/guardian/remote.py
@@ -158,3 +158,19 @@ class GuardianRemote:
                 return {"ok": False, "raw": output[:200]}
         logger.error("Guardian update failed: %s", output[:200])
         return {"ok": False, "error": output[:200]}
+
+    async def sync_gateway(self) -> dict:
+        """Redeploy the gateway script from the install dir, without a git pull.
+
+        Recovery lever for a stale/frozen deployed gateway when the `update`
+        self-update path is unavailable. Returns old/new sha on success.
+        """
+        ok, output = await self._ssh_command("sync-gateway")
+        if ok:
+            try:
+                return json.loads(output)
+            except json.JSONDecodeError:
+                logger.warning("Guardian sync-gateway returned non-JSON: %s", output[:200])
+                return {"ok": True, "raw": output[:200]}
+        logger.error("Guardian sync-gateway failed: %s", output[:200])
+        return {"ok": False, "error": output[:200]}

--- a/src/genesis/guardian/watchdog.py
+++ b/src/genesis/guardian/watchdog.py
@@ -62,6 +62,11 @@ class GuardianWatchdog:
         self._last_reset_at: datetime | None = None
         self._consecutive_stuck: int = 0
         self._drift_count: int = 0
+        # Deployed-gateway staleness: the install-dir code can be current while
+        # ~/.local/bin/guardian-gateway.sh lags (the bug that froze it ~2 months).
+        self._gateway_drift_count: int = 0
+        self._gateway_resync_attempted: bool = False
+        self._gateway_escalated: bool = False
 
     def _in_cooldown(self) -> bool:
         if self._last_recovery_at is None:
@@ -254,6 +259,14 @@ class GuardianWatchdog:
         version_info = await self._remote.version()
         if not isinstance(version_info, dict):
             return
+
+        # Deployed-gateway staleness check reuses this same version() payload.
+        # Isolated in its own suppress so a failure here can't skip the
+        # code-drift logic below.
+        import contextlib
+        with contextlib.suppress(Exception):
+            await self._check_gateway_staleness(version_info)
+
         host_hash = version_info.get("deployed_commit", "unknown")
 
         if not isinstance(host_hash, str) or host_hash == "unknown":
@@ -290,4 +303,107 @@ class GuardianWatchdog:
                     "Check update logs or run install_guardian.sh --non-interactive on host.",
                     priority="high",
                     source="guardian_watchdog",
+                )
+
+    async def _expected_gateway_sha(self, code_version: str) -> str | None:
+        """sha256 of the gateway script at the host's install-dir commit.
+
+        Returns None if the container's git can't resolve that commit (e.g. the
+        host is ahead of the container) — the caller then skips, never
+        false-alarms. Split out so tests can stub the expected value.
+        """
+        import asyncio
+        import hashlib
+
+        show = await asyncio.to_thread(
+            subprocess.run,
+            ["git", "-C", str(Path.home() / "genesis"),
+             "show", f"{code_version}:scripts/guardian-gateway.sh"],
+            capture_output=True, timeout=5,
+        )
+        if show.returncode != 0 or not show.stdout:
+            return None
+        return hashlib.sha256(show.stdout).hexdigest()
+
+    async def _check_gateway_staleness(self, version_info: dict) -> None:
+        """Detect (and self-heal) a stale DEPLOYED gateway script.
+
+        The `update` self-update can fail while the git pull succeeds, leaving
+        ``~/.local/bin/guardian-gateway.sh`` frozen while the install dir
+        advances — the bug that froze the host gateway ~2 months. We compare the
+        host's reported ``gateway_sha`` against the sha of the gateway script at
+        the host's install-dir commit. On a confirmed mismatch we attempt ONE
+        guarded ``sync-gateway`` self-heal per episode, then escalate if still
+        unresolved. Best-effort (invoked under _check_code_drift's suppress).
+        """
+        host_gw_sha = version_info.get("gateway_sha", "unknown")
+        host_code_ver = version_info.get("code_version", "unknown")
+        if not isinstance(host_gw_sha, str) or host_gw_sha in ("", "unknown"):
+            return  # host gateway predates gateway_sha, or unreadable
+        if not isinstance(host_code_ver, str) or host_code_ver in ("", "unknown"):
+            return
+
+        expected = await self._expected_gateway_sha(host_code_ver)
+        if expected is None:
+            return  # can't determine expected sha — don't false-alarm
+
+        if host_gw_sha == expected:
+            if self._gateway_drift_count > 0:
+                logger.info("Guardian deployed-gateway staleness resolved (sha=%s)",
+                            host_gw_sha[:12])
+            self._gateway_drift_count = 0
+            self._gateway_resync_attempted = False
+            self._gateway_escalated = False
+            return
+
+        # Deployed gateway does not match the install-dir's gateway → stale.
+        self._gateway_drift_count += 1
+        if self._gateway_drift_count < self.DRIFT_ALERT_THRESHOLD:
+            return
+
+        if not self._gateway_resync_attempted:
+            # One guarded self-heal attempt per episode: redeploy from install dir.
+            self._gateway_resync_attempted = True
+            logger.warning(
+                "Guardian deployed gateway stale (deployed=%s expected=%s @ %s) "
+                "— auto-running sync-gateway",
+                host_gw_sha[:12], expected[:12], host_code_ver,
+            )
+            try:
+                res = await self._remote.sync_gateway()
+            except Exception:
+                logger.exception("sync-gateway self-heal raised")
+                res = {"ok": False}
+            if self._event_bus:
+                from genesis.observability.types import Severity, Subsystem
+                ok = res.get("ok")
+                await self._event_bus.emit(
+                    Subsystem.GUARDIAN, Severity.WARNING,
+                    "guardian.gateway_resync",
+                    f"Deployed gateway was stale (sha {host_gw_sha[:12]} vs "
+                    f"{expected[:12]} @ {host_code_ver}); auto sync-gateway "
+                    f"ok={ok}. Re-verifying next tick.",
+                )
+            return
+
+        # Self-heal already attempted and it's STILL stale → escalate once via
+        # the event bus (ERROR surfaces in health/observability). NOTE: a
+        # user-facing outreach (Telegram) path for Guardian watchdog escalations
+        # is not yet wired — init builds the watchdog without an outreach_queue,
+        # the same gap as the code-drift escalation above. Tracked as a follow-up.
+        if not self._gateway_escalated:
+            self._gateway_escalated = True
+            logger.error(
+                "Guardian deployed gateway STILL stale after auto sync-gateway "
+                "(deployed=%s expected=%s @ %s)",
+                host_gw_sha[:12], expected[:12], host_code_ver,
+            )
+            if self._event_bus:
+                from genesis.observability.types import Severity, Subsystem
+                await self._event_bus.emit(
+                    Subsystem.GUARDIAN, Severity.ERROR,
+                    "guardian.gateway_stale",
+                    f"Deployed gateway still stale after auto-resync (sha "
+                    f"{host_gw_sha[:12]} vs expected {expected[:12]} @ "
+                    f"{host_code_ver}). Manual check needed.",
                 )

--- a/tests/test_guardian/test_remote.py
+++ b/tests/test_guardian/test_remote.py
@@ -127,3 +127,31 @@ class TestPauseResume:
     async def test_resume(self, remote):
         with patch.object(remote, "_ssh_command", return_value=(True, '{"ok": true}')):
             assert await remote.resume() is True
+
+
+class TestSyncGateway:
+    @pytest.mark.asyncio
+    async def test_parses_json(self, remote):
+        with patch.object(
+            remote, "_ssh_command",
+            return_value=(True,
+                          '{"ok": true, "action": "sync-gateway", '
+                          '"old_sha": "aaa", "new_sha": "bbb"}'),
+        ):
+            result = await remote.sync_gateway()
+        assert result["ok"] is True
+        assert result["new_sha"] == "bbb"
+
+    @pytest.mark.asyncio
+    async def test_non_json_success(self, remote):
+        with patch.object(remote, "_ssh_command", return_value=(True, "not json")):
+            result = await remote.sync_gateway()
+        assert result["ok"] is True
+        assert "raw" in result
+
+    @pytest.mark.asyncio
+    async def test_ssh_failure(self, remote):
+        with patch.object(remote, "_ssh_command", return_value=(False, "timeout")):
+            result = await remote.sync_gateway()
+        assert result["ok"] is False
+        assert "error" in result

--- a/tests/test_guardian/test_watchdog.py
+++ b/tests/test_guardian/test_watchdog.py
@@ -208,3 +208,150 @@ class TestStuckDetection:
             await watchdog.check_and_recover()
         remote.reset_state.assert_not_called()
         assert watchdog._consecutive_stuck == 0
+
+
+# sha256 hexdigests are 64 chars; values are arbitrary for the staleness logic.
+_EXPECTED_GW_SHA = "a" * 64
+_STALE_GW_SHA = "b" * 64
+_THRESHOLD = GuardianWatchdog.DRIFT_ALERT_THRESHOLD
+
+
+def _gw_watchdog(sync_ok: bool = True):
+    """Watchdog wired with mock remote/event_bus/outreach and a stubbed
+    expected-gateway-sha (so tests don't touch the real container git)."""
+    r = AsyncMock()
+    r.sync_gateway = AsyncMock(return_value={"ok": sync_ok})
+    event_bus = AsyncMock()
+    outreach = AsyncMock()
+    wd = GuardianWatchdog(r, event_bus=event_bus, outreach_queue=outreach)
+    wd._expected_gateway_sha = AsyncMock(return_value=_EXPECTED_GW_SHA)
+    return wd, r, event_bus, outreach
+
+
+def _emitted_events(event_bus) -> list[str]:
+    return [c.args[2] for c in event_bus.emit.call_args_list]
+
+
+class TestGatewayStaleness:
+    """Deployed-gateway staleness detection + guarded sync-gateway self-heal."""
+
+    @pytest.mark.asyncio
+    async def test_match_no_action(self):
+        wd, r, eb, outreach = _gw_watchdog()
+        await wd._check_gateway_staleness(
+            {"gateway_sha": _EXPECTED_GW_SHA, "code_version": "abc1234"})
+        r.sync_gateway.assert_not_called()
+        eb.emit.assert_not_called()
+        assert wd._gateway_drift_count == 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_gateway_sha_skips(self):
+        """Host gateway too old to report gateway_sha → never alarm."""
+        wd, r, _, _ = _gw_watchdog()
+        await wd._check_gateway_staleness(
+            {"gateway_sha": "unknown", "code_version": "abc1234"})
+        r.sync_gateway.assert_not_called()
+        assert wd._gateway_drift_count == 0
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_expected_skips(self):
+        """Container can't resolve the host's commit (host ahead) → no false alarm."""
+        wd, r, _, _ = _gw_watchdog()
+        wd._expected_gateway_sha = AsyncMock(return_value=None)
+        await wd._check_gateway_staleness(
+            {"gateway_sha": _STALE_GW_SHA, "code_version": "abc1234"})
+        r.sync_gateway.assert_not_called()
+        assert wd._gateway_drift_count == 0
+
+    @pytest.mark.asyncio
+    async def test_stale_below_threshold_no_resync(self):
+        wd, r, _, _ = _gw_watchdog()
+        vi = {"gateway_sha": _STALE_GW_SHA, "code_version": "abc1234"}
+        for _ in range(_THRESHOLD - 1):
+            await wd._check_gateway_staleness(vi)
+        r.sync_gateway.assert_not_called()
+        assert wd._gateway_drift_count == _THRESHOLD - 1
+
+    @pytest.mark.asyncio
+    async def test_threshold_triggers_single_resync(self):
+        wd, r, eb, outreach = _gw_watchdog()
+        vi = {"gateway_sha": _STALE_GW_SHA, "code_version": "abc1234"}
+        for _ in range(_THRESHOLD):
+            await wd._check_gateway_staleness(vi)
+        r.sync_gateway.assert_called_once()
+        assert any("gateway_resync" in e for e in _emitted_events(eb))
+        outreach.enqueue.assert_not_called()  # not escalated yet
+
+    @pytest.mark.asyncio
+    async def test_still_stale_after_resync_escalates_once(self):
+        wd, r, eb, _ = _gw_watchdog()
+        vi = {"gateway_sha": _STALE_GW_SHA, "code_version": "abc1234"}
+        for _ in range(_THRESHOLD):
+            await wd._check_gateway_staleness(vi)   # → one resync
+        await wd._check_gateway_staleness(vi)        # still stale → escalate (event bus)
+        await wd._check_gateway_staleness(vi)        # quiet — no second escalation
+        stale_events = [e for e in _emitted_events(eb) if "gateway_stale" in e]
+        assert len(stale_events) == 1               # escalated exactly once
+        r.sync_gateway.assert_called_once()          # resync attempted exactly once
+
+    @pytest.mark.asyncio
+    async def test_resolved_after_resync_resets_state(self):
+        wd, r, _, _ = _gw_watchdog()
+        vi_stale = {"gateway_sha": _STALE_GW_SHA, "code_version": "abc1234"}
+        for _ in range(_THRESHOLD):
+            await wd._check_gateway_staleness(vi_stale)
+        r.sync_gateway.assert_called_once()
+        # Next tick: sync worked → deployed sha now matches expected.
+        await wd._check_gateway_staleness(
+            {"gateway_sha": _EXPECTED_GW_SHA, "code_version": "abc1234"})
+        assert wd._gateway_drift_count == 0
+        assert wd._gateway_resync_attempted is False
+        assert wd._gateway_escalated is False
+
+    @pytest.mark.asyncio
+    async def test_rearms_after_resolution(self):
+        """After a resolved episode, a fresh staleness episode must self-heal
+        again (the most safety-critical transition — no 'quiet forever')."""
+        wd, r, _, _ = _gw_watchdog()
+        vi_stale = {"gateway_sha": _STALE_GW_SHA, "code_version": "abc1234"}
+        vi_ok = {"gateway_sha": _EXPECTED_GW_SHA, "code_version": "abc1234"}
+        for _ in range(_THRESHOLD):
+            await wd._check_gateway_staleness(vi_stale)   # episode 1 → resync
+        await wd._check_gateway_staleness(vi_ok)           # resolved → reset
+        assert r.sync_gateway.call_count == 1
+        for _ in range(_THRESHOLD):
+            await wd._check_gateway_staleness(vi_stale)   # episode 2 → re-armed
+        assert r.sync_gateway.call_count == 2
+
+
+class TestExpectedGatewaySha:
+    """Direct coverage of the git-show + sha256 helper (stubbed in the staleness
+    tests). A wrong repo path / git failure silently disables detection, so the
+    skip paths matter."""
+
+    @pytest.mark.asyncio
+    async def test_success_returns_sha(self):
+        import hashlib
+        from unittest.mock import MagicMock
+        wd = GuardianWatchdog(AsyncMock(), event_bus=None)
+        content = b"#!/usr/bin/env bash\n# gateway\n"
+        fake = MagicMock(returncode=0, stdout=content)
+        with patch("genesis.guardian.watchdog.subprocess.run", return_value=fake):
+            sha = await wd._expected_gateway_sha("abc1234")
+        assert sha == hashlib.sha256(content).hexdigest()
+
+    @pytest.mark.asyncio
+    async def test_nonzero_returncode_returns_none(self):
+        from unittest.mock import MagicMock
+        wd = GuardianWatchdog(AsyncMock(), event_bus=None)
+        fake = MagicMock(returncode=128, stdout=b"")
+        with patch("genesis.guardian.watchdog.subprocess.run", return_value=fake):
+            assert await wd._expected_gateway_sha("deadbeef") is None
+
+    @pytest.mark.asyncio
+    async def test_empty_stdout_returns_none(self):
+        from unittest.mock import MagicMock
+        wd = GuardianWatchdog(AsyncMock(), event_bus=None)
+        fake = MagicMock(returncode=0, stdout=b"")
+        with patch("genesis.guardian.watchdog.subprocess.run", return_value=fake):
+            assert await wd._expected_gateway_sha("abc1234") is None


### PR DESCRIPTION
## Context

PR2 of the Guardian gateway-reliability work. **PR1 (#669, merged + deployed + E2E-verified)** fixed the host `update` verb so it reliably self-updates the deployed gateway and reports success, and added a `gateway_sha` field to `version` + a `sync-gateway` recovery verb. The incident PR1 fixed went **unnoticed for ~2 months** because nothing watched whether the *deployed* gateway actually matched the code being pulled. This PR adds that detection — the autonomous half.

## What it does

In `watchdog.py` (`_check_code_drift_inner`, reusing the already-fetched `version()` payload):
- Compare the host's reported `gateway_sha` against the sha256 of `scripts/guardian-gateway.sh` at the host's install-dir commit (`git show <code_version>:…` in the container repo).
- On a sustained mismatch (`DRIFT_ALERT_THRESHOLD` = 3 ticks), attempt **one guarded `sync-gateway` self-heal per episode**, re-verify next tick, and **escalate via the event bus (ERROR)** if still unresolved. State re-arms on resolution.
- Runs under its **own `contextlib.suppress`** so a staleness-check failure can never disturb the pre-existing code-drift detection.

Plus `GuardianRemote.sync_gateway()` (SSH wrapper mirroring `update()`), and full test coverage of the state machine + the `_expected_gateway_sha` git-show/sha paths.

## Safety / autonomy rails
- **One** self-heal attempt per drift episode (flag-guarded — no resync loop), **one** escalation, then quiet until resolved; re-arms on recovery (tested).
- `sync-gateway` is idempotent (copies a repo-tracked file, no sudo). If the container can't resolve the host's commit (host ahead), the check skips — never false-alarms.

## Review
Codex quota-exhausted → Claude code-reviewer (fallback per protocol). Findings addressed:
- **Isolated the new check under its own `suppress`** so it can't skip the code-drift logic on an exception.
- **Dropped a non-functional outreach call** (init builds the watchdog without an `outreach_queue`, and the `enqueue` kwargs matched no real queue — a pre-existing gap shared with the code-drift escalation). Escalation now relies on the working event-bus ERROR emit; proper Telegram outreach wiring is filed as a **follow-up** (`11569455…`) rather than shipping dead code.
- Added the missing **re-arm** test (most safety-critical transition) and **direct `_expected_gateway_sha`** coverage (git-failure → no false alarm).
- Tests: 24 watchdog + 14 remote = 38 pass; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)