### PR TITLE
fix(restore): make SQLite restore corruption-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Restoring a backup is now safe against corruption** — `restore.sh` now stops
+  the running Genesis server before swapping the SQLite database (so a live
+  connection can't corrupt the restore), clears stale write-ahead-log sidecars
+  that would otherwise replay onto and corrupt the restored DB, and runs an
+  integrity check on the result — warning loudly if it's not sound. It
+  deliberately leaves the server stopped afterward so you can verify the restore
+  before bringing Genesis back up.
+
 - **Guardian host updates no longer silently stall** — on hosts where the
   Guardian's `CLAUDE.md` had been pinned with git's skip-worktree flag, the
   Guardian's self-update (`git pull`) would abort the moment that file changed

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -79,6 +79,26 @@ log()  { echo "$LOG_PREFIX $(date -Iseconds) $*"; }
 warn() { log "WARNING: $*"; _FAILURES+=("$*"); }
 die()  { log "FATAL: $*"; _FAILURES+=("$*"); exit 1; }
 
+# Quiesce the live writer before swapping the SQLite DB — a live WAL connection
+# would corrupt the restore. Guarded for fresh-box DR (no systemctl / no unit /
+# no user session → no-op). Intentionally does NOT restart: the operator
+# verifies the restored DB first, then starts the server.
+_SERVER_WAS_STOPPED=false
+_quiesce_genesis_server() {
+    command -v systemctl >/dev/null 2>&1 || return 0
+    if systemctl --user is-active --quiet genesis-server 2>/dev/null; then
+        log "Stopping genesis-server before SQLite restore (will NOT auto-restart)..."
+        # Only record "stopped" if the stop actually succeeded — otherwise the
+        # end-of-run note would tell the operator to restart a server that never
+        # stopped (and is still holding the DB).
+        if systemctl --user stop genesis-server 2>/dev/null; then
+            _SERVER_WAS_STOPPED=true
+        else
+            warn "could not stop genesis-server — proceeding (a live writer may still hold the DB; verify before trusting the restore)"
+        fi
+    fi
+}
+
 _BACKUP_PASSPHRASE="${GENESIS_BACKUP_PASSPHRASE:-}"
 
 # decrypt_file <src.gpg> <dst>
@@ -176,12 +196,23 @@ if resolve_payload "$BACKUP_DIR/data/genesis.sql"; then
                 if [ -f "$DB_FILE" ]; then
                     cp "$DB_FILE" "${DB_FILE}.pre-restore.$(date +%s)"
                 fi
-                # Fresh DB from the SQL dump.
-                rm -f "$DB_FILE"
+                # Fresh DB from the SQL dump. Stop the live writer first, and
+                # clear stale WAL/SHM sidecars — a leftover -wal would replay
+                # onto the new DB and corrupt it.
+                _quiesce_genesis_server
+                rm -f "$DB_FILE" "$DB_FILE-wal" "$DB_FILE-shm"
                 if command -v sqlite3 >/dev/null; then
                     if sqlite3 "$DB_FILE" ".read $_SQL_TMP"; then
                         _SQLITE_RESTORED=true
                         log "SQLite: restored → $DB_FILE"
+                        # Verify the restored DB is structurally sound — loud on failure.
+                        # 2>&1 so a sqlite3 error (can't open, etc.) surfaces in the warn.
+                        _ic=$(sqlite3 "$DB_FILE" "PRAGMA integrity_check;" 2>&1 | head -1)
+                        if [ "$_ic" = "ok" ]; then
+                            log "SQLite: integrity_check ok"
+                        else
+                            warn "SQLite: integrity_check FAILED (${_ic:-no output}) — restored DB may be corrupt; inspect ${DB_FILE}.pre-restore.*"
+                        fi
                     else
                         warn "SQLite .read failed — inspect ${DB_FILE}.pre-restore.*"
                     fi
@@ -412,6 +443,10 @@ else
 fi
 
 # ── Done ─────────────────────────────────────────────────────────────
+if $_SERVER_WAS_STOPPED; then
+    log "NOTE: genesis-server was stopped for the restore and left stopped."
+    log "      Verify the restored DB, then: systemctl --user start genesis-server"
+fi
 if [ ${#_FAILURES[@]} -eq 0 ]; then
     _SUCCESS=true
     log "Restore complete"

--- a/tests/test_scripts/test_restore_safety.py
+++ b/tests/test_scripts/test_restore_safety.py
@@ -1,0 +1,187 @@
+"""Safety tests for ``scripts/restore.sh`` SQLite restore.
+
+``restore.sh`` rehydrates the live SQLite DB — the highest-stakes path in DR.
+Three safety properties are guarded here:
+
+* **Quiesce the writer.** Stop ``genesis-server`` before swapping the DB so a
+  live WAL connection can't corrupt the restore — and do NOT auto-restart it
+  (the operator verifies the restore first).
+* **Clear stale WAL/SHM.** ``rm`` must remove ``-wal``/``-shm`` sidecars; a
+  leftover WAL would replay onto the restored DB and corrupt it.
+* **Integrity-check the result.** Run ``PRAGMA integrity_check`` after ``.read``
+  so a corrupt restore is loud, not silent.
+
+Fully sandboxed: ``HOME`` and ``GENESIS_DIR`` point at a tmp dir, so the live
+``~/genesis/data/genesis.db`` is never touched. Real ``sqlite3`` is the thing
+under test; ``systemctl`` is stubbed (and records its calls).
+"""
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_RESTORE = Path(__file__).resolve().parents[2] / "scripts" / "restore.sh"
+
+
+def _make_stub(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _write_systemctl(bind: Path, calls: Path, *, active: bool = True, stop_rc: int = 0) -> None:
+    """Configurable systemctl stub: logs every call; `is-active --quiet` exits 0
+    iff ``active`` (the gateway uses the exit code, not output); `stop` exits
+    ``stop_rc``."""
+    active_rc = 0 if active else 3
+    _make_stub(
+        bind / "systemctl",
+        '#!/usr/bin/env bash\n'
+        f'echo "$*" >> "{calls}"\n'
+        'case "$*" in\n'
+        f'  *is-active*) exit {active_rc} ;;\n'
+        f'  *stop*) exit {stop_rc} ;;\n'
+        'esac\n'
+        'exit 0\n',
+    )
+
+
+def _write_sqlite3_integrity_intercept(bind: Path) -> None:
+    """sqlite3 wrapper that reports a CORRUPT integrity_check but passes
+    everything else (incl. `.read`) through to the real sqlite3."""
+    real = shutil.which("sqlite3")
+    _make_stub(
+        bind / "sqlite3",
+        '#!/usr/bin/env bash\n'
+        'for a in "$@"; do case "$a" in\n'
+        '  *integrity_check*) echo "*** in database main ***"; exit 0 ;;\n'
+        'esac; done\n'
+        f'exec {real} "$@"\n',
+    )
+
+
+@pytest.fixture
+def sandbox(tmp_path):
+    home = tmp_path / "home"
+    gd = home / "genesis"
+    (gd / "data").mkdir(parents=True)
+    (home / ".genesis").mkdir(parents=True)
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    calls = tmp_path / "systemctl_calls.log"
+    _write_systemctl(bind, calls)  # default: server active, stop succeeds
+    return {"home": home, "gd": gd, "bind": bind, "calls": calls, "tmp": tmp_path}
+
+
+def _seed_live_db(gd: Path) -> Path:
+    """A real SQLite DB plus deliberately-stray -wal/-shm sidecars."""
+    db = gd / "data" / "genesis.db"
+    subprocess.run(
+        ["sqlite3", str(db), "CREATE TABLE t(x); INSERT INTO t VALUES(1);"],
+        check=True, capture_output=True,
+    )
+    (gd / "data" / "genesis.db-wal").write_bytes(b"STALE-WAL-SHOULD-BE-REMOVED")
+    (gd / "data" / "genesis.db-shm").write_bytes(b"STALE-SHM-SHOULD-BE-REMOVED")
+    return db
+
+
+def _seed_backup(tmp_path: Path) -> Path:
+    """Backup dir with a plaintext SQL dump (no GPG)."""
+    bkp = tmp_path / "backup"
+    (bkp / "data").mkdir(parents=True)
+    (bkp / "data" / "genesis.sql").write_text(
+        "CREATE TABLE t(x);\nINSERT INTO t VALUES(42);\n")
+    return bkp
+
+
+def _run_restore(sandbox):
+    bkp = _seed_backup(sandbox["tmp"])
+    env = dict(os.environ)
+    env["HOME"] = str(sandbox["home"])
+    env["GENESIS_DIR"] = str(sandbox["gd"])
+    env["QDRANT_URL"] = "http://127.0.0.1:1"  # dead → Qdrant restore skips fast
+    env["PATH"] = f'{sandbox["bind"]}:{env["PATH"]}'
+    return subprocess.run(
+        ["bash", str(_RESTORE), "--from", str(bkp), "--force"],
+        env=env, capture_output=True, text=True, stdin=subprocess.DEVNULL,
+    )
+
+
+def _calls(sandbox) -> str:
+    return sandbox["calls"].read_text() if sandbox["calls"].exists() else ""
+
+
+def test_restore_stops_server_and_does_not_restart(sandbox):
+    _seed_live_db(sandbox["gd"])
+    proc = _run_restore(sandbox)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    calls = _calls(sandbox)
+    assert "stop genesis-server" in calls, f"server not stopped before restore:\n{calls}"
+    assert "start genesis-server" not in calls and "restart genesis-server" not in calls, \
+        f"server must be left stopped (no auto-restart):\n{calls}"
+
+
+def test_restore_clears_stale_wal_shm(sandbox):
+    db = _seed_live_db(sandbox["gd"])
+    proc = _run_restore(sandbox)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert not (sandbox["gd"] / "data" / "genesis.db-wal").exists(), "stale -wal not removed"
+    assert not (sandbox["gd"] / "data" / "genesis.db-shm").exists(), "stale -shm not removed"
+    out = subprocess.run(["sqlite3", str(db), "SELECT x FROM t;"],
+                         capture_output=True, text=True)
+    assert out.stdout.strip() == "42", f"DB not restored from backup dump: {out.stdout!r}"
+
+
+# NOTE: this test's name must NOT contain the marker word — restore.sh logs the
+# (tmp) DB path, and a test name leaking into that path would false-match.
+def test_restore_verifies_db_after_restore(sandbox):
+    _seed_live_db(sandbox["gd"])
+    proc = _run_restore(sandbox)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    # New code emits this exact marker only on a passing PRAGMA integrity_check.
+    assert "integrity_check ok" in proc.stdout.lower(), \
+        f"integrity_check not run/logged after restore:\n{proc.stdout}"
+    status = json.loads((sandbox["home"] / ".genesis" / "restore_status.json").read_text())
+    assert status["sqlite_restored"] is True, status
+
+
+def test_restore_proceeds_and_warns_when_stop_fails(sandbox):
+    """If genesis-server can't be stopped, the restore proceeds with a warning —
+    and must NOT claim 'left stopped' (the server never stopped)."""
+    _write_systemctl(sandbox["bind"], sandbox["calls"], active=True, stop_rc=1)
+    db = _seed_live_db(sandbox["gd"])
+    proc = _run_restore(sandbox)
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"  # warn → failure → exit 1
+    assert "could not stop genesis-server" in proc.stdout
+    assert "left stopped" not in proc.stdout, "misleading note after a failed stop"
+    assert subprocess.run(["sqlite3", str(db), "SELECT x FROM t;"],
+                          capture_output=True, text=True).stdout.strip() == "42"
+
+
+def test_restore_skips_stop_when_server_inactive(sandbox):
+    """Fresh-box / not-running case: no stop attempted, restore still succeeds."""
+    _write_systemctl(sandbox["bind"], sandbox["calls"], active=False)
+    db = _seed_live_db(sandbox["gd"])
+    proc = _run_restore(sandbox)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert "stop genesis-server" not in _calls(sandbox), "stopped a server that wasn't active"
+    assert "left stopped" not in proc.stdout
+    assert subprocess.run(["sqlite3", str(db), "SELECT x FROM t;"],
+                          capture_output=True, text=True).stdout.strip() == "42"
+
+
+def test_restore_warns_on_integrity_failure(sandbox):
+    """A restored DB that fails PRAGMA integrity_check must warn loudly, record a
+    failure, and exit non-zero — never silently accept a corrupt restore."""
+    _write_sqlite3_integrity_intercept(sandbox["bind"])
+    _seed_live_db(sandbox["gd"])
+    proc = _run_restore(sandbox)
+    assert proc.returncode == 1, f"{proc.stdout}\n{proc.stderr}"
+    assert "integrity_check failed" in proc.stdout.lower(), proc.stdout
+    status = json.loads((sandbox["home"] / ".genesis" / "restore_status.json").read_text())
+    assert status["success"] is False
+    assert status["failures"], "integrity failure not recorded in restore_status.json"


### PR DESCRIPTION
## Problem

`scripts/restore.sh` rehydrates the live SQLite DB during disaster recovery — the **highest-stakes path in the system** (a bug here destroys data *on recovery*). Three latent corruption risks:
- It `rm`'d **only** the DB file, leaving stale `-wal`/`-shm` sidecars → SQLite would replay the leftover WAL onto the freshly-restored DB and corrupt it.
- It ran **no integrity check** after `.read` → a corrupt restore was silently accepted.
- It **never stopped `genesis-server`** → restoring under a live writer holding the DB could corrupt the result.

## Fix (WS-2, part 1 of the DR-safety track)

- **Quiesce the writer:** stop `genesis-server` before swapping the DB. Guarded (`command -v systemctl` + `is-active --quiet`) so a fresh-box DR with no `systemctl` / inactive unit is a clean no-op; only records "stopped" if the stop actually succeeded. **No auto-restart** — the operator verifies the restore first (an end-of-run note prints the start command).
- **Clear stale WAL/SHM:** `rm -f "$DB_FILE" "$DB_FILE-wal" "$DB_FILE-shm"`.
- **Integrity-check the result:** `PRAGMA integrity_check` after `.read`; `warn` loudly + record a failure (→ non-zero exit) if not sound.

The pre-existing `.pre-restore.<ts>` backup of the old DB is preserved.

## Testing

TDD, fully sandboxed (`HOME` + `GENESIS_DIR` both overridden → the live `~/genesis/data/genesis.db` is unreachable; real `sqlite3`, stubbed `systemctl`). 6 tests, RED→GREEN:
- server stopped before restore + **not** restarted; stale `-wal`/`-shm` cleared; `integrity_check ok` on the happy path;
- **failed-stop** proceeds with a warning and **no** misleading "left stopped" note; **inactive** server skips the stop; **corrupt** restore (intercepted `integrity_check`) → warn + recorded failure + non-zero exit.
- `bash -n` + `shellcheck -S warning` clean; `ruff` clean. An E2E sandbox run shows the full behavior end-to-end.

## Review

Codex quota-exhausted → Claude code-reviewer (fallback per protocol). **No P1/data-loss issues** (the quiesce→`rm` sidecars→`.read`→integrity sequence is correctly ordered). Two P2 semantic bugs fixed: `_SERVER_WAS_STOPPED` was set even when `stop` failed (misleading the operator) → now if/else; and `integrity_check`'s `2>/dev/null` swallowed sqlite3 diagnostics → now `2>&1`. The three flagged test gaps (failed-stop, inactive, integrity-failure) are the new tests above.

Next in WS-2: `backup.sh` DR-04 honest off-site signal (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)