### PR TITLE
fix(backup): honest off-site (NAS) replication signal (DR-04)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **A backup that can't reach off-site storage no longer fails silently** — if
+  you've configured an off-site (NAS) backup target and a run captures your data
+  locally but can't replicate it off-site, Genesis now sends a distinct alert
+  ("off-site replication failed — local backup OK") and records `offsite_confirmed`
+  in the backup status. The backup still counts as successful (your local copy is
+  intact); only the off-site replica is flagged as missing. Local-only setups (no
+  off-site target) are unaffected.
+
 - **Restoring a backup is now safe against corruption** — `restore.sh` now stops
   the running Genesis server before swapping the SQLite database (so a live
   connection can't corrupt the restore), clears stale write-ahead-log sidecars

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -37,9 +37,12 @@ _write_status() {
     # Escape failure reason for JSON safety (quotes, backslashes, newlines)
     local _safe_reason
     _safe_reason=$(printf '%s' "$_FAILURE_REASON" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\n/\\n/g')
+    # offsite_confirmed: true only when the off-site (NAS) copy fully succeeded.
+    local _offsite_confirmed=false
+    if [ "${_T2_STATUS:-}" = "ok" ]; then _offsite_confirmed=true; fi
     mkdir -p "$(dirname "$_STATUS_FILE")"
     cat > "$_STATUS_FILE" <<STATUSEOF
-{"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","success":$_SUCCESS,"sqlite_lines":$_SQLITE_LINES,"qdrant_collections":$_QDRANT_COUNT,"transcript_files":$_TRANSCRIPT_COUNT,"memory_files":$_MEMORY_COUNT,"secrets_encrypted":$_SECRETS_OK,"duration_s":$_duration,"failure_reason":"$_safe_reason","tier2_status":"${_T2_STATUS:-unknown}"}
+{"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","success":$_SUCCESS,"sqlite_lines":$_SQLITE_LINES,"qdrant_collections":$_QDRANT_COUNT,"transcript_files":$_TRANSCRIPT_COUNT,"memory_files":$_MEMORY_COUNT,"secrets_encrypted":$_SECRETS_OK,"duration_s":$_duration,"failure_reason":"$_safe_reason","tier2_status":"${_T2_STATUS:-unknown}","offsite_confirmed":$_offsite_confirmed}
 STATUSEOF
 }
 trap '_write_status' EXIT
@@ -65,6 +68,18 @@ fi
 log() { echo "$LOG_PREFIX $(date -Iseconds) $*"; }
 
 die() { _FAILURE_REASON="$*"; log "FATAL: $*"; exit 1; }
+
+# Send a Telegram message (no-op unless bot token + chat id are configured).
+# Shared by the backup-failed and off-site-replication-failed alerts.
+_send_telegram() {
+    [ -n "${TELEGRAM_BOT_TOKEN:-}" ] || return 0
+    [ -n "${TELEGRAM_FORUM_CHAT_ID:-}" ] || return 0
+    curl -sf -X POST \
+        "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+        -H "Content-Type: application/json" \
+        -d "{\"chat_id\":\"${TELEGRAM_FORUM_CHAT_ID}\",\"text\":$(printf '%s' "$1" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))'),\"parse_mode\":\"Markdown\"}" \
+        > /dev/null 2>&1 || log "WARNING: Telegram alert failed to send"
+}
 
 # ── Encryption helpers ───────────────────────────────────────────────
 # All PII-bearing payloads (SQLite dump, transcripts, memory) use the
@@ -386,18 +401,31 @@ fi
 
 # --- Alert on failure via Telegram ---
 if [ "$_SUCCESS" != "true" ]; then
-    if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_FORUM_CHAT_ID:-}" ]; then
-        _TG_MSG="🚨 *Backup failed*
+    _send_telegram "🚨 *Backup failed*
 
 Reason: ${_FAILURE_REASON:-unknown}
 Time: $(date -Is)
 SQLite lines: $_SQLITE_LINES
 Duration: $(( $(date +%s) - _STARTED_AT ))s"
-        curl -sf -X POST \
-            "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-            -H "Content-Type: application/json" \
-            -d "{\"chat_id\":\"${TELEGRAM_FORUM_CHAT_ID}\",\"text\":$(printf '%s' "$_TG_MSG" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))'),\"parse_mode\":\"Markdown\"}" \
-            > /dev/null 2>&1 || log "WARNING: Telegram alert failed to send"
+fi
+
+# --- Alert on off-site (NAS) replication failure (local backup still OK) ---
+# Distinct from a backup failure: the local + Tier-1 backup succeeded, but the
+# off-site copy did not fully land. Local-only installs (NAS not configured) are
+# a valid choice and do NOT alert.
+if [ -n "$_NAS_TARGET" ] && [ "$_T2_STATUS" != "ok" ]; then
+    # Dedup: alert only on the transition INTO off-site failure. The status file
+    # still holds the PREVIOUS run's state at this point (the EXIT trap rewrites
+    # it after). This avoids a 6-hourly alert while a NAS stays down; it re-alerts
+    # once off-site recovers (offsite_confirmed flips true) and then fails again.
+    _prev_offsite=$(python3 -c "import json; print(json.load(open('$_STATUS_FILE')).get('offsite_confirmed', True))" 2>/dev/null || echo "True")
+    if [ "$_prev_offsite" != "False" ]; then
+        _send_telegram "⚠️ *Off-site replication failed*
+
+The local backup is OK, but it was NOT replicated off-site.
+Tier-2 status: ${_T2_STATUS}
+Time: $(date -Is)
+Off-site copies are missing — check the NAS target."
     fi
 fi
 log "Backup complete (success=$_SUCCESS)"

--- a/tests/test_scripts/test_backup_dr_signal.py
+++ b/tests/test_scripts/test_backup_dr_signal.py
@@ -52,7 +52,7 @@ def backup_env(tmp_path):
     _git("config", "user.email", "t@t.t", cwd=seed)
     _git("config", "user.name", "t", cwd=seed)
     (seed / "README").write_text("seed\n")
-    _git("add", "-A", cwd=seed)
+    _git("add", "README", cwd=seed)
     _git("commit", "-qm", "init", cwd=seed)
     _git("push", "-q", "origin", "main", cwd=seed)
     (home / "backups").mkdir(parents=True)
@@ -98,22 +98,25 @@ def _run(backup_env, *, smb_rc: int = 0, nas: bool = True, remove_db: bool = Fal
 
 
 def test_offsite_confirmed_true_when_nas_ok(backup_env):
+    """NAS upload succeeds → offsite_confirmed:true and no alert."""
     proc, status, tg = _run(backup_env, smb_rc=0, nas=True)
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     assert status["success"] is True, status
     assert status["tier2_status"] == "ok", status
     assert status["offsite_confirmed"] is True, status
-    assert "api.telegram.org" not in tg, f"unexpected alert on a fully-successful backup:\n{tg}"
+    # The curl stub only logs on a Telegram send → empty log == no alert.
+    assert not tg.strip(), f"unexpected alert on a fully-successful backup:\n{tg}"
 
 
 def test_offsite_failure_alerts_but_local_succeeds(backup_env):
+    """NAS configured but the upload fails → offsite_confirmed:false, the LOCAL
+    backup still succeeds, and a distinct off-site alert fires."""
     proc, status, tg = _run(backup_env, smb_rc=1, nas=True)  # NAS upload fails
-    # The LOCAL backup is still successful — only the off-site copy is missing.
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"  # off-site miss is not a hard failure
     assert status["success"] is True, status
     assert status["offsite_confirmed"] is False, status
     assert status["tier2_status"] != "ok", status
-    assert "api.telegram.org" in tg, f"off-site replication failure did not alert:\n{tg}"
+    assert tg.strip(), f"off-site replication failure did not alert:\n{tg}"
     assert "replication" in tg.lower() or "off-site" in tg.lower(), tg
 
 
@@ -136,8 +139,10 @@ def test_offsite_alert_deduplicated(backup_env):
 
 
 def test_local_only_not_configured_no_alert(backup_env):
+    """No NAS configured → offsite_confirmed:false, but local-only is a valid
+    choice (not a failure), so no alert."""
     proc, status, tg = _run(backup_env, nas=False)
     assert status["success"] is True, status
     assert status["tier2_status"] == "not_configured", status
     assert status["offsite_confirmed"] is False, status
-    assert "api.telegram.org" not in tg, f"local-only must not alert:\n{tg}"
+    assert not tg.strip(), f"local-only must not alert:\n{tg}"

--- a/tests/test_scripts/test_backup_dr_signal.py
+++ b/tests/test_scripts/test_backup_dr_signal.py
@@ -1,0 +1,143 @@
+"""DR-04 honest off-site signal tests for ``scripts/backup.sh``.
+
+A backup that captures local data but fails to replicate off-site (NAS) must say
+so. ``backup_status.json`` carries ``offsite_confirmed``; when a NAS IS configured
+but the upload didn't fully succeed, a *distinct* Telegram alert fires — and the
+local backup stays marked successful (only the off-site copy is missing, not the
+data). Local-only installs (no NAS configured) are a valid choice, not a failure.
+
+Fully sandboxed: ``HOME`` + ``GENESIS_DIR`` point at a tmp dir. Real
+``sqlite3``/``gpg``/``git``; ``smbclient`` and ``curl`` (Telegram + Qdrant)
+stubbed so the run is deterministic and offline.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_BACKUP = Path(__file__).resolve().parents[2] / "scripts" / "backup.sh"
+
+
+def _make_stub(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True)
+
+
+@pytest.fixture
+def backup_env(tmp_path):
+    home = tmp_path / "home"
+    gd = home / "genesis"
+    (gd / "data").mkdir(parents=True)
+    (home / ".genesis").mkdir(parents=True)
+    (home / ".gnupg").mkdir(mode=0o700)
+    subprocess.run(["sqlite3", str(gd / "data" / "genesis.db"),
+                    "CREATE TABLE t(x); INSERT INTO t VALUES(1);"],
+                   check=True, capture_output=True)
+
+    # Backup repo: bare remote (main) + a clone at $HOME/backups/genesis-backups
+    # so backup.sh skips its clone and `git push` lands on the local remote.
+    bare = tmp_path / "remote.git"
+    _git("init", "-q", "--bare", str(bare), cwd=tmp_path)
+    _git("symbolic-ref", "HEAD", "refs/heads/main", cwd=bare)
+    seed = tmp_path / "seed"
+    _git("-c", "init.defaultBranch=main", "clone", "-q", str(bare), str(seed), cwd=tmp_path)
+    _git("symbolic-ref", "HEAD", "refs/heads/main", cwd=seed)
+    _git("config", "user.email", "t@t.t", cwd=seed)
+    _git("config", "user.name", "t", cwd=seed)
+    (seed / "README").write_text("seed\n")
+    _git("add", "-A", cwd=seed)
+    _git("commit", "-qm", "init", cwd=seed)
+    _git("push", "-q", "origin", "main", cwd=seed)
+    (home / "backups").mkdir(parents=True)
+    _git("clone", "-q", str(bare), str(home / "backups" / "genesis-backups"), cwd=tmp_path)
+
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    tg = tmp_path / "telegram_calls.log"
+    # curl stub: capture Telegram sends; fail everything else (Qdrant → skipped).
+    _make_stub(
+        bind / "curl",
+        '#!/usr/bin/env bash\n'
+        'for a in "$@"; do case "$a" in\n'
+        f'  *api.telegram.org*) printf "%s\\n" "$*" >> "{tg}"; exit 0 ;;\n'
+        'esac; done\n'
+        'exit 1\n',
+    )
+    return {"home": home, "gd": gd, "bind": bind, "tg": tg, "tmp": tmp_path}
+
+
+def _run(backup_env, *, smb_rc: int = 0, nas: bool = True, remove_db: bool = False):
+    if remove_db:  # force _SUCCESS=false (no SQLite data) for the failure-alert path
+        (backup_env["gd"] / "data" / "genesis.db").unlink(missing_ok=True)
+    _make_stub(backup_env["bind"] / "smbclient", f'#!/usr/bin/env bash\nexit {smb_rc}\n')
+    env = dict(os.environ)
+    env.update(
+        HOME=str(backup_env["home"]), GENESIS_DIR=str(backup_env["gd"]),
+        GENESIS_BACKUP_PASSPHRASE="testpass", QDRANT_URL="http://127.0.0.1:1",
+        TELEGRAM_BOT_TOKEN="bot-x", TELEGRAM_FORUM_CHAT_ID="chat-y",
+        PATH=f'{backup_env["bind"]}:{os.environ["PATH"]}',
+    )
+    if nas:
+        env.update(GENESIS_BACKUP_NAS="//nas/share",
+                   GENESIS_BACKUP_NAS_USER="u", GENESIS_BACKUP_NAS_PASS="p")
+    else:
+        for k in ("GENESIS_BACKUP_NAS", "GENESIS_BACKUP_NAS_USER", "GENESIS_BACKUP_NAS_PASS"):
+            env.pop(k, None)
+    proc = subprocess.run(["bash", str(_BACKUP)], env=env,
+                          capture_output=True, text=True, stdin=subprocess.DEVNULL)
+    status = json.loads((backup_env["home"] / ".genesis" / "backup_status.json").read_text())
+    tg = backup_env["tg"].read_text() if backup_env["tg"].exists() else ""
+    return proc, status, tg
+
+
+def test_offsite_confirmed_true_when_nas_ok(backup_env):
+    proc, status, tg = _run(backup_env, smb_rc=0, nas=True)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert status["success"] is True, status
+    assert status["tier2_status"] == "ok", status
+    assert status["offsite_confirmed"] is True, status
+    assert "api.telegram.org" not in tg, f"unexpected alert on a fully-successful backup:\n{tg}"
+
+
+def test_offsite_failure_alerts_but_local_succeeds(backup_env):
+    proc, status, tg = _run(backup_env, smb_rc=1, nas=True)  # NAS upload fails
+    # The LOCAL backup is still successful — only the off-site copy is missing.
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"  # off-site miss is not a hard failure
+    assert status["success"] is True, status
+    assert status["offsite_confirmed"] is False, status
+    assert status["tier2_status"] != "ok", status
+    assert "api.telegram.org" in tg, f"off-site replication failure did not alert:\n{tg}"
+    assert "replication" in tg.lower() or "off-site" in tg.lower(), tg
+
+
+def test_backup_failure_still_alerts(backup_env):
+    """The _send_telegram refactor must not suppress the original backup-failed
+    alert: no SQLite data → success:false → 🚨 alert fires."""
+    proc, status, tg = _run(backup_env, smb_rc=0, nas=True, remove_db=True)
+    assert status["success"] is False, status
+    assert "backup failed" in tg.lower(), f"backup-failed alert did not fire:\n{tg}"
+
+
+def test_offsite_alert_deduplicated(backup_env):
+    """A persistent off-site outage alerts ONCE (on the transition), not every
+    6h run — the second consecutive failure is deduped via the prior status."""
+    _run(backup_env, smb_rc=1, nas=True)              # 1st failure → alert
+    _, status2, tg = _run(backup_env, smb_rc=1, nas=True)  # 2nd failure → deduped
+    assert status2["offsite_confirmed"] is False, status2
+    n = tg.lower().count("off-site replication failed")
+    assert n == 1, f"expected exactly 1 (deduped) off-site alert across two runs, got {n}:\n{tg}"
+
+
+def test_local_only_not_configured_no_alert(backup_env):
+    proc, status, tg = _run(backup_env, nas=False)
+    assert status["success"] is True, status
+    assert status["tier2_status"] == "not_configured", status
+    assert status["offsite_confirmed"] is False, status
+    assert "api.telegram.org" not in tg, f"local-only must not alert:\n{tg}"


### PR DESCRIPTION
## Problem

`backup.sh` (two-tier: Tier-1 git push of small encrypted text, Tier-2 NAS upload of large encrypted binaries) marked a run successful based only on SQLite + Tier-1. So a **Tier-2 off-site replication failure was silent** — the backup reported success and never alerted, even though the off-site copy (the entire point of disaster recovery) was missing.

## Fix (WS-2, part 2 — pairs with restore-safety #671)

Decided design: **precise signaling, not a false "failed."**

- **`offsite_confirmed`** in `backup_status.json` (true iff the NAS copy fully landed). `_SUCCESS` is unchanged — a local backup whose off-site copy missed stays successful (no false "backup failed" on the dashboard during a NAS outage).
- **Distinct alert** when a NAS is configured and Tier-2 didn't fully succeed: "off-site replication failed — local backup OK". **Deduped** to the *transition into failure* (reads the prior status file) so a sustained NAS outage doesn't spam a Telegram every 6h; it re-alerts once off-site recovers and fails again. Local-only installs (no NAS) never alert.
- DRY: a shared `_send_telegram` helper now backs both the backup-failed and off-site alerts.

## Testing

TDD, fully sandboxed (`HOME`+`GENESIS_DIR` overridden → live `~/genesis`/`~/.genesis` unreachable; real `sqlite3`/`gpg`/`git`, stubbed `smbclient`/`curl`). 5 tests, RED→GREEN: NAS-ok → `confirmed:true` + no alert; NAS-configured-but-failed → `offsite_confirmed:false` + `success:true` + one alert; **persistent failure deduped to a single alert**; the original `🚨 backup-failed` alert still fires (guards the refactor); local-only → no alert. `bash -n` + `shellcheck -S warning` + `ruff` clean.

## Review

Codex quota-exhausted → Claude code-reviewer (fallback). **No P1/data issues; signal state-machine verified correct for all six `_T2_STATUS` values; `_send_telegram` refactor faithful (no suppression regression); trap-safe; JSON valid + consumers tolerant.** Its P1 (alert fatigue — no dedup) is fixed above; the failure-alert + `returncode` test gaps are the new tests. (The `no_smbclient` status string is the same logic path as the tested `partial` case — verified analytically; `smbclient` is installed here so forcing that exact string needs PATH surgery, not worth it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)