### PR TITLE
feat(dr): off-site recovery — dated NAS snapshots + restore-from-NAS (2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Off-site backups can now actually be restored** — the large data (the
+  database, vector memory, and transcripts) is stored only on your off-site
+  (NAS) target, but the restore tool had no way to fetch it — so a from-scratch
+  recovery silently couldn't bring back your database or memory. Restore now
+  pulls the latest off-site snapshot before restoring, and backups are written
+  as dated point-in-time snapshots (so you can recover a *specific* run, not just
+  the last one) with transcripts included off-site too.
+
 - **A backup that can't reach off-site storage no longer fails silently** — if
   you've configured an off-site (NAS) backup target and a run captures your data
   locally but can't replicate it off-site, Genesis now sends a distinct alert

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -315,6 +315,7 @@ if [ -n "$_NAS_TARGET" ]; then
         _SMB_CREDS=$(mktemp)
         chmod 600 "$_SMB_CREDS"
         printf 'username=%s\npassword=%s\n' "$_NAS_USER" "$_NAS_PASS" > "$_SMB_CREDS"
+        _SMB_COMPLETE=$(mktemp)  # empty marker, uploaded only after a full snapshot
 
         _smb() { smbclient "$_NAS_TARGET" -A "$_SMB_CREDS" "$@"; }
 
@@ -359,7 +360,13 @@ if [ -n "$_NAS_TARGET" ]; then
             fi
         done
 
-        rm -f "$_SMB_CREDS"
+        # Mark the snapshot COMPLETE only when every upload succeeded, so restore
+        # never picks a half-uploaded snapshot (it selects the latest COMPLETE one).
+        if [ "$_T2_OK" = true ]; then
+            _smb -c "cd \"${_NAS_DIR}\"; put \"$_SMB_COMPLETE\" COMPLETE" 2>/dev/null || true
+        fi
+
+        rm -f "$_SMB_CREDS" "$_SMB_COMPLETE"
 
         if [ "$_T2_OK" = true ]; then
             _T2_STATUS="ok"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -299,7 +299,12 @@ _T2_STATUS="skipped"
 if [ -n "$_NAS_TARGET" ]; then
     _NAS_USER="${GENESIS_BACKUP_NAS_USER:-}"
     _NAS_PASS="${GENESIS_BACKUP_NAS_PASS:-}"
-    _NAS_DIR="Genesis/$(hostname)"
+    _NAS_HOST_DIR="Genesis/$(hostname)"
+    # Per-run DATED snapshot dir — a consistent point-in-time copy that
+    # restore.sh selects the latest of and GFS retention prunes (replaces the
+    # old fixed filenames that were overwritten every run).
+    _NAS_STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+    _NAS_DIR="${_NAS_HOST_DIR}/${_NAS_STAMP}"
 
     if ! command -v smbclient >/dev/null 2>&1; then
         log "WARNING: smbclient not installed — Tier 2 backup skipped"
@@ -313,8 +318,9 @@ if [ -n "$_NAS_TARGET" ]; then
 
         _smb() { smbclient "$_NAS_TARGET" -A "$_SMB_CREDS" "$@"; }
 
-        # Create directory structure on NAS
-        _smb -c "mkdir Genesis; mkdir \"${_NAS_DIR}\"; mkdir \"${_NAS_DIR}/qdrant\"; mkdir \"${_NAS_DIR}/data\"" \
+        # Create the snapshot directory tree (smbclient mkdir is non-recursive,
+        # so each level is created; pre-existing levels fail harmlessly).
+        _smb -c "mkdir \"Genesis\"; mkdir \"${_NAS_HOST_DIR}\"; mkdir \"${_NAS_DIR}\"; mkdir \"${_NAS_DIR}/data\"; mkdir \"${_NAS_DIR}/qdrant\"; mkdir \"${_NAS_DIR}/transcripts\"" \
             2>/dev/null || true
 
         _T2_OK=true
@@ -341,11 +347,23 @@ if [ -n "$_NAS_TARGET" ]; then
             fi
         fi
 
+        # Upload transcripts (previously local-only — now part of the off-site snapshot)
+        for f in transcripts/*.gpg; do
+            [ -f "$f" ] || continue
+            fname=$(basename "$f")
+            if _smb -c "cd \"${_NAS_DIR}/transcripts\"; put \"$f\" \"$fname\"" 2>/dev/null; then
+                log "  NAS: uploaded transcripts/$fname"
+            else
+                log "WARNING: NAS upload failed for transcripts/$fname"
+                _T2_OK=false
+            fi
+        done
+
         rm -f "$_SMB_CREDS"
 
         if [ "$_T2_OK" = true ]; then
             _T2_STATUS="ok"
-            log "Tier 2 backup copied to NAS ($_NAS_TARGET)"
+            log "Tier 2 backup copied to NAS snapshot ${_NAS_STAMP}"
         else
             _T2_STATUS="partial"
             log "WARNING: Tier 2 backup partially failed"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -362,8 +362,13 @@ if [ -n "$_NAS_TARGET" ]; then
 
         # Mark the snapshot COMPLETE only when every upload succeeded, so restore
         # never picks a half-uploaded snapshot (it selects the latest COMPLETE one).
+        # If the marker itself fails to upload, the snapshot is unusable for
+        # restore — treat that as an off-site failure (partial + alert), not ok.
         if [ "$_T2_OK" = true ]; then
-            _smb -c "cd \"${_NAS_DIR}\"; put \"$_SMB_COMPLETE\" COMPLETE" 2>/dev/null || true
+            if ! _smb -c "cd \"${_NAS_DIR}\"; put \"$_SMB_COMPLETE\" COMPLETE" 2>/dev/null; then
+                log "WARNING: NAS upload failed for COMPLETE marker — snapshot unusable for restore"
+                _T2_OK=false
+            fi
         fi
 
         rm -f "$_SMB_CREDS" "$_SMB_COMPLETE"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -17,6 +17,10 @@
 #                                the DB/Qdrant/transcripts live ONLY here (not git)
 #   GENESIS_BACKUP_NAS_USER    — SMB username for the off-site pull
 #   GENESIS_BACKUP_NAS_PASS    — SMB password for the off-site pull
+#   GENESIS_BACKUP_NAS_HOST    — SOURCE host name the snapshot was backed up under
+#                                (default: this host; set it on a fresh DR box
+#                                whose hostname differs — or rely on auto-detect
+#                                when only one host exists on the NAS)
 #
 # Behavior:
 #   - Skips destinations that already exist AND are newer than the backup
@@ -179,27 +183,42 @@ _pull_from_nas() {
         return 0
     fi
 
-    local host_dir creds latest snap fname dst stamp
-    host_dir="Genesis/$(hostname)"
+    local host_dir nas_host creds latest snap fname dst hosts n
     creds=$(mktemp); chmod 600 "$creds"
     trap 'rm -f "$creds"' RETURN   # clean up creds on ANY exit from this function
     printf 'username=%s\npassword=%s\n' "${GENESIS_BACKUP_NAS_USER:-}" "${GENESIS_BACKUP_NAS_PASS:-}" > "$creds"
     _nsmb() { smbclient "$nas" -A "$creds" "$@"; }
 
-    # Pick the latest snapshot that is COMPLETE — a marker backup.sh writes only
-    # after every file uploaded — so a half-uploaded snapshot from a crashed
-    # backup is never selected. Newest first; grep the stamp pattern out of the
-    # listing (robust to smbclient ls format/locale).
-    latest=""
-    while read -r stamp; do
-        [ -n "$stamp" ] || continue
-        if _nsmb -c "cd \"$host_dir/$stamp\"; ls COMPLETE" 2>/dev/null | grep -q "COMPLETE"; then
-            latest="$stamp"; break
-        fi
-        log "NAS: snapshot $stamp is incomplete (no COMPLETE marker) — trying the previous one"
-    done < <(_nsmb -c "cd \"$host_dir\"; ls" 2>/dev/null | grep -oE '[0-9]{8}T[0-9]{6}Z' | sort -ru)
+    # Latest snapshot under host dir $1 that is COMPLETE — a marker backup.sh
+    # writes only after every file uploaded — so a half-uploaded snapshot from a
+    # crashed backup is never selected. Echoes the stamp; returns 1 if none.
+    # Newest first; grep the stamp pattern out of the listing (robust to format).
+    _latest_complete() {
+        local hd="$1" st
+        while read -r st; do
+            [ -n "$st" ] || continue
+            _nsmb -c "cd \"$hd/$st\"; ls COMPLETE" 2>/dev/null | grep -q "COMPLETE" && { echo "$st"; return 0; }
+        done < <(_nsmb -c "cd \"$hd\"; ls" 2>/dev/null | grep -oE '[0-9]{8}T[0-9]{6}Z' | sort -ru)
+        return 1
+    }
+
+    # The snapshot was written under the SOURCE host's name. On a fresh DR box the
+    # hostname differs, so honour an explicit override, and otherwise fall back to
+    # the sole host dir on the NAS when there's exactly one (the common case).
+    nas_host="${GENESIS_BACKUP_NAS_HOST:-$(hostname)}"
+    host_dir="Genesis/$nas_host"
+    latest="$(_latest_complete "$host_dir" || true)"
     if [ -z "$latest" ]; then
-        log "NAS: no COMPLETE dated snapshot under $host_dir — skipping off-site pull"
+        hosts=$(_nsmb -c "cd \"Genesis\"; ls" 2>/dev/null | awk '$2=="D" && $1!="." && $1!=".."{print $1}' || true)
+        n=$(printf '%s' "$hosts" | grep -c . || true)
+        if [ "$n" = 1 ]; then
+            host_dir="Genesis/$hosts"
+            log "NAS: no snapshots under host '$nas_host' — using the only host on the NAS: $hosts"
+            latest="$(_latest_complete "$host_dir" || true)"
+        fi
+    fi
+    if [ -z "$latest" ]; then
+        log "NAS: no COMPLETE dated snapshot found (set GENESIS_BACKUP_NAS_HOST to the source host name) — skipping off-site pull"
         return 0
     fi
     log "NAS: pulling latest off-site snapshot $latest"

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -13,6 +13,10 @@
 #   GENESIS_DIR                — target Genesis root (default: ~/genesis)
 #   QDRANT_URL                 — target Qdrant server (default: http://localhost:6333)
 #   SECRETS_PATH               — target secrets file (default: $GENESIS_DIR/secrets.env)
+#   GENESIS_BACKUP_NAS         — SMB share for the off-site pull (e.g. //nas/share);
+#                                the DB/Qdrant/transcripts live ONLY here (not git)
+#   GENESIS_BACKUP_NAS_USER    — SMB username for the off-site pull
+#   GENESIS_BACKUP_NAS_PASS    — SMB password for the off-site pull
 #
 # Behavior:
 #   - Skips destinations that already exist AND are newer than the backup
@@ -168,19 +172,35 @@ _pull_from_nas() {
     [ -n "$nas" ] || return 0
     if $DRY_RUN; then log "NAS: (dry-run) would pull latest off-site snapshot from $nas"; return 0; fi
     command -v smbclient >/dev/null 2>&1 || { log "NAS: smbclient not installed — skipping off-site pull"; return 0; }
+    # Don't clobber a payload already staged locally (same-box re-run) unless
+    # forced — the NAS pull is for fresh-box DR.
+    if [ -f "$BACKUP_DIR/data/genesis.sql.gpg" ] && ! $FORCE; then
+        log "NAS: local payload already present — skipping off-site pull (use --force to override)"
+        return 0
+    fi
 
-    local host_dir creds latest snap fname
+    local host_dir creds latest snap fname dst stamp
     host_dir="Genesis/$(hostname)"
     creds=$(mktemp); chmod 600 "$creds"
+    trap 'rm -f "$creds"' RETURN   # clean up creds on ANY exit from this function
     printf 'username=%s\npassword=%s\n' "${GENESIS_BACKUP_NAS_USER:-}" "${GENESIS_BACKUP_NAS_PASS:-}" > "$creds"
     _nsmb() { smbclient "$nas" -A "$creds" "$@"; }
 
-    # Latest dated snapshot: grep the stamp pattern out of the listing (robust to
-    # smbclient's ls format/locale), newest first.
-    latest=$(_nsmb -c "cd \"$host_dir\"; ls" 2>/dev/null | grep -oE '[0-9]{8}T[0-9]{6}Z' | sort -ru | head -1 || true)
+    # Pick the latest snapshot that is COMPLETE — a marker backup.sh writes only
+    # after every file uploaded — so a half-uploaded snapshot from a crashed
+    # backup is never selected. Newest first; grep the stamp pattern out of the
+    # listing (robust to smbclient ls format/locale).
+    latest=""
+    while read -r stamp; do
+        [ -n "$stamp" ] || continue
+        if _nsmb -c "cd \"$host_dir/$stamp\"; ls COMPLETE" 2>/dev/null | grep -q "COMPLETE"; then
+            latest="$stamp"; break
+        fi
+        log "NAS: snapshot $stamp is incomplete (no COMPLETE marker) — trying the previous one"
+    done < <(_nsmb -c "cd \"$host_dir\"; ls" 2>/dev/null | grep -oE '[0-9]{8}T[0-9]{6}Z' | sort -ru)
     if [ -z "$latest" ]; then
-        log "NAS: no dated snapshots under $host_dir — skipping off-site pull"
-        rm -f "$creds"; return 0
+        log "NAS: no COMPLETE dated snapshot under $host_dir — skipping off-site pull"
+        return 0
     fi
     log "NAS: pulling latest off-site snapshot $latest"
     snap="$host_dir/$latest"
@@ -189,13 +209,15 @@ _pull_from_nas() {
     mkdir -p "$BACKUP_DIR/data"
     if _nsmb -c "cd \"$snap/data\"; get genesis.sql.gpg \"$BACKUP_DIR/data/genesis.sql.gpg\"" 2>/dev/null; then
         log "  NAS: pulled data/genesis.sql.gpg"
+    else
+        warn "NAS: failed to pull genesis.sql.gpg from snapshot $latest — the database will not be restored from off-site"
     fi
     # Qdrant snapshots + transcripts: list the subdir, then get each *.gpg. The
     # staging dir is created only when there's actually something to pull, so an
     # empty set doesn't make the restore sections below run (and e.g. warn that
     # Qdrant isn't reachable yet → spurious failure).
     for sub in qdrant transcripts; do
-        local dst="$BACKUP_DIR/data/qdrant"
+        dst="$BACKUP_DIR/data/qdrant"
         [ "$sub" = transcripts ] && dst="$BACKUP_DIR/transcripts"
         # `|| true`: an empty subdir makes `grep` exit non-zero → pipefail would
         # otherwise abort the whole restore.
@@ -206,7 +228,6 @@ _pull_from_nas() {
             fi
         done || true
     done
-    rm -f "$creds"
 }
 _pull_from_nas
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -159,6 +159,57 @@ if [ -d "$BACKUP_DIR/.git" ]; then
     (cd "$BACKUP_DIR" && git pull --rebase --quiet 2>/dev/null) || log "git pull failed, continuing with local backup state"
 fi
 
+# ── Off-site (NAS) pull ──────────────────────────────────────────────
+# The large binaries (SQLite dump, Qdrant snapshots, transcripts) live ONLY on
+# the NAS — gitignored from Tier-1 — so on a fresh DR box they must be pulled
+# from the latest dated snapshot before the restore sections below can find them.
+_pull_from_nas() {
+    local nas="${GENESIS_BACKUP_NAS:-}"
+    [ -n "$nas" ] || return 0
+    if $DRY_RUN; then log "NAS: (dry-run) would pull latest off-site snapshot from $nas"; return 0; fi
+    command -v smbclient >/dev/null 2>&1 || { log "NAS: smbclient not installed — skipping off-site pull"; return 0; }
+
+    local host_dir creds latest snap fname
+    host_dir="Genesis/$(hostname)"
+    creds=$(mktemp); chmod 600 "$creds"
+    printf 'username=%s\npassword=%s\n' "${GENESIS_BACKUP_NAS_USER:-}" "${GENESIS_BACKUP_NAS_PASS:-}" > "$creds"
+    _nsmb() { smbclient "$nas" -A "$creds" "$@"; }
+
+    # Latest dated snapshot: grep the stamp pattern out of the listing (robust to
+    # smbclient's ls format/locale), newest first.
+    latest=$(_nsmb -c "cd \"$host_dir\"; ls" 2>/dev/null | grep -oE '[0-9]{8}T[0-9]{6}Z' | sort -ru | head -1 || true)
+    if [ -z "$latest" ]; then
+        log "NAS: no dated snapshots under $host_dir — skipping off-site pull"
+        rm -f "$creds"; return 0
+    fi
+    log "NAS: pulling latest off-site snapshot $latest"
+    snap="$host_dir/$latest"
+
+    # SQLite dump.
+    mkdir -p "$BACKUP_DIR/data"
+    if _nsmb -c "cd \"$snap/data\"; get genesis.sql.gpg \"$BACKUP_DIR/data/genesis.sql.gpg\"" 2>/dev/null; then
+        log "  NAS: pulled data/genesis.sql.gpg"
+    fi
+    # Qdrant snapshots + transcripts: list the subdir, then get each *.gpg. The
+    # staging dir is created only when there's actually something to pull, so an
+    # empty set doesn't make the restore sections below run (and e.g. warn that
+    # Qdrant isn't reachable yet → spurious failure).
+    for sub in qdrant transcripts; do
+        local dst="$BACKUP_DIR/data/qdrant"
+        [ "$sub" = transcripts ] && dst="$BACKUP_DIR/transcripts"
+        # `|| true`: an empty subdir makes `grep` exit non-zero → pipefail would
+        # otherwise abort the whole restore.
+        _nsmb -c "cd \"$snap/$sub\"; ls" 2>/dev/null | grep -oE '[A-Za-z0-9._-]+\.gpg' | sort -u | while read -r fname; do
+            mkdir -p "$dst"
+            if _nsmb -c "cd \"$snap/$sub\"; get \"$fname\" \"$dst/$fname\"" 2>/dev/null; then
+                log "  NAS: pulled $sub/$fname"
+            fi
+        done || true
+    done
+    rm -f "$creds"
+}
+_pull_from_nas
+
 # Check encrypted payloads exist without passphrase → fail fast.
 _has_encrypted=false
 for candidate in "$BACKUP_DIR"/data/genesis.sql.gpg "$BACKUP_DIR"/secrets/secrets.env.gpg; do

--- a/tests/test_scripts/test_backup_dated_snapshots.py
+++ b/tests/test_scripts/test_backup_dated_snapshots.py
@@ -1,0 +1,115 @@
+"""2a: backup.sh uploads to per-run DATED snapshot dirs on the NAS.
+
+Instead of fixed filenames (overwritten every run), each backup uploads to
+``Genesis/<host>/<UTC-stamp>/{data,qdrant,transcripts}/…`` — a consistent
+point-in-time snapshot that restore.sh can later pick the latest of, and that
+GFS retention can prune. Transcripts are uploaded too (previously local-only).
+
+Sandboxed (HOME + GENESIS_DIR → tmp). Real sqlite3/gpg/git; the smbclient stub
+LOGS every ``-c`` command so we can assert the upload paths.
+"""
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_BACKUP = Path(__file__).resolve().parents[2] / "scripts" / "backup.sh"
+_STAMP_RE = re.compile(r"\d{8}T\d{6}Z")
+
+
+def _make_stub(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True)
+
+
+@pytest.fixture
+def backup_env(tmp_path):
+    home = tmp_path / "home"
+    gd = home / "genesis"
+    (gd / "data").mkdir(parents=True)
+    (home / ".genesis").mkdir(parents=True)
+    (home / ".gnupg").mkdir(mode=0o700)
+    subprocess.run(["sqlite3", str(gd / "data" / "genesis.db"),
+                    "CREATE TABLE t(x); INSERT INTO t VALUES(1);"],
+                   check=True, capture_output=True)
+    bare = tmp_path / "remote.git"
+    _git("init", "-q", "--bare", str(bare), cwd=tmp_path)
+    _git("symbolic-ref", "HEAD", "refs/heads/main", cwd=bare)
+    seed = tmp_path / "seed"
+    _git("-c", "init.defaultBranch=main", "clone", "-q", str(bare), str(seed), cwd=tmp_path)
+    _git("symbolic-ref", "HEAD", "refs/heads/main", cwd=seed)
+    _git("config", "user.email", "t@t.t", cwd=seed)
+    _git("config", "user.name", "t", cwd=seed)
+    (seed / "README").write_text("seed\n")
+    _git("add", "README", cwd=seed)
+    _git("commit", "-qm", "init", cwd=seed)
+    _git("push", "-q", "origin", "main", cwd=seed)
+    (home / "backups").mkdir(parents=True)
+    _git("clone", "-q", str(bare), str(home / "backups" / "genesis-backups"), cwd=tmp_path)
+
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    smb_log = tmp_path / "smb_commands.log"
+    # smbclient stub: log the -c command (the arg after -c), succeed.
+    _make_stub(
+        bind / "smbclient",
+        '#!/usr/bin/env bash\n'
+        'prev=""\n'
+        'for a in "$@"; do\n'
+        f'  [ "$prev" = "-c" ] && printf "%s\\n" "$a" >> "{smb_log}"\n'
+        '  prev="$a"\n'
+        'done\n'
+        'exit 0\n',
+    )
+    # curl stub: Telegram captured (unused here), everything else fails (Qdrant skipped).
+    _make_stub(bind / "curl", '#!/usr/bin/env bash\nexit 1\n')
+    return {"home": home, "gd": gd, "bind": bind, "smb_log": smb_log, "tmp": tmp_path}
+
+
+def _run(backup_env):
+    env = dict(os.environ)
+    env.update(
+        HOME=str(backup_env["home"]), GENESIS_DIR=str(backup_env["gd"]),
+        GENESIS_BACKUP_PASSPHRASE="testpass", QDRANT_URL="http://127.0.0.1:1",
+        GENESIS_BACKUP_NAS="//nas/share", GENESIS_BACKUP_NAS_USER="u",
+        GENESIS_BACKUP_NAS_PASS="p",
+        PATH=f'{backup_env["bind"]}:{os.environ["PATH"]}',
+    )
+    for k in ("TELEGRAM_BOT_TOKEN", "TELEGRAM_FORUM_CHAT_ID"):
+        env.pop(k, None)
+    proc = subprocess.run(["bash", str(_BACKUP)], env=env,
+                          capture_output=True, text=True, stdin=subprocess.DEVNULL)
+    cmds = backup_env["smb_log"].read_text() if backup_env["smb_log"].exists() else ""
+    return proc, cmds
+
+
+def test_sqlite_uploaded_under_dated_snapshot_dir(backup_env):
+    """genesis.sql.gpg is put into Genesis/<host>/<stamp>/data, not a fixed path."""
+    proc, cmds = _run(backup_env)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    put_sql = [ln for ln in cmds.splitlines() if "put" in ln and "genesis.sql.gpg" in ln]
+    assert put_sql, f"no SQL upload command logged:\n{cmds}"
+    # The cd target for the SQL put must include a dated snapshot dir + /data.
+    assert any(_STAMP_RE.search(ln) for ln in put_sql), \
+        f"SQL upload not under a dated snapshot dir:\n{put_sql}"
+    assert any("/data" in ln for ln in put_sql), f"SQL upload not under .../data:\n{put_sql}"
+
+
+def test_snapshot_dir_is_created(backup_env):
+    """The dated snapshot dir (and its data/qdrant/transcripts subdirs) is mkdir'd."""
+    proc, cmds = _run(backup_env)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    mkdir_lines = [ln for ln in cmds.splitlines() if "mkdir" in ln]
+    assert mkdir_lines, f"no mkdir commands logged:\n{cmds}"
+    blob = "\n".join(mkdir_lines)
+    assert _STAMP_RE.search(blob), f"no dated snapshot dir created:\n{blob}"
+    # All three payload subdirs under the snapshot.
+    for sub in ("data", "qdrant", "transcripts"):
+        assert sub in blob, f"snapshot subdir '{sub}' not created:\n{blob}"

--- a/tests/test_scripts/test_backup_dr_signal.py
+++ b/tests/test_scripts/test_backup_dr_signal.py
@@ -73,10 +73,15 @@ def backup_env(tmp_path):
     return {"home": home, "gd": gd, "bind": bind, "tg": tg, "tmp": tmp_path}
 
 
-def _run(backup_env, *, smb_rc: int = 0, nas: bool = True, remove_db: bool = False):
+def _run(backup_env, *, smb_rc: int = 0, nas: bool = True, remove_db: bool = False,
+         fail_complete: bool = False):
     if remove_db:  # force _SUCCESS=false (no SQLite data) for the failure-alert path
         (backup_env["gd"] / "data" / "genesis.db").unlink(missing_ok=True)
-    _make_stub(backup_env["bind"] / "smbclient", f'#!/usr/bin/env bash\nexit {smb_rc}\n')
+    if fail_complete:  # payloads upload OK, only the COMPLETE marker fails
+        _make_stub(backup_env["bind"] / "smbclient",
+                   '#!/usr/bin/env bash\ncase "$*" in *COMPLETE*) exit 1 ;; esac\nexit 0\n')
+    else:
+        _make_stub(backup_env["bind"] / "smbclient", f'#!/usr/bin/env bash\nexit {smb_rc}\n')
     env = dict(os.environ)
     env.update(
         HOME=str(backup_env["home"]), GENESIS_DIR=str(backup_env["gd"]),
@@ -146,3 +151,13 @@ def test_local_only_not_configured_no_alert(backup_env):
     assert status["tier2_status"] == "not_configured", status
     assert status["offsite_confirmed"] is False, status
     assert not tg.strip(), f"local-only must not alert:\n{tg}"
+
+
+def test_complete_marker_failure_is_offsite_failure(backup_env):
+    """If payloads upload but the COMPLETE marker fails, restore would skip the
+    snapshot — so it must report partial + offsite_confirmed:false + alert, not ok."""
+    proc, status, tg = _run(backup_env, fail_complete=True, nas=True)
+    assert status["success"] is True, status          # local backup is still fine
+    assert status["tier2_status"] == "partial", status
+    assert status["offsite_confirmed"] is False, status
+    assert "replication" in tg.lower() or "off-site" in tg.lower(), tg

--- a/tests/test_scripts/test_restore_nas_pull.py
+++ b/tests/test_scripts/test_restore_nas_pull.py
@@ -75,6 +75,8 @@ def nas_sandbox(tmp_path):
         '      for s in ${COMPLETE_STAMPS:-}; do case "$cmd" in *"$s"*) echo "  COMPLETE  A  0  x"; break ;; esac; done ;;\n'
         '  *"/qdrant"*) [ "${SERVE_QDRANT:-0}" = 1 ] && echo "  qsnap.gpg  A  10  x" || : ;;\n'
         '  *"/transcripts"*) : ;;\n'
+        '  *"Genesis/ghost\\"; ls"*) : ;;\n'                       # host \'ghost\' has no snapshots
+        '  *"cd \\"Genesis\\"; ls"*) echo "  realhost  D  0  x" ;;\n'  # host listing (auto-detect)
         f'  *ls*) printf "  {_OLD_STAMP}  D  0  x\\n  {_NEW_STAMP}  D  0  x\\n" ;;\n'
         'esac\n'
         'exit 0\n',
@@ -83,7 +85,8 @@ def nas_sandbox(tmp_path):
             "smb_log": smb_log, "tmp": tmp_path}
 
 
-def _run(nas_sandbox, *, nas=True, complete=(_OLD_STAMP, _NEW_STAMP), serve_qdrant=False):
+def _run(nas_sandbox, *, nas=True, complete=(_OLD_STAMP, _NEW_STAMP),
+         serve_qdrant=False, nas_host=None):
     env = dict(os.environ)
     env.update(
         HOME=str(nas_sandbox["home"]), GENESIS_DIR=str(nas_sandbox["gd"]),
@@ -91,6 +94,8 @@ def _run(nas_sandbox, *, nas=True, complete=(_OLD_STAMP, _NEW_STAMP), serve_qdra
         COMPLETE_STAMPS=" ".join(complete), SERVE_QDRANT="1" if serve_qdrant else "0",
         PATH=f'{nas_sandbox["bind"]}:{os.environ["PATH"]}',
     )
+    if nas_host is not None:
+        env["GENESIS_BACKUP_NAS_HOST"] = nas_host
     if nas:
         env.update(GENESIS_BACKUP_NAS="//nas/share",
                    GENESIS_BACKUP_NAS_USER="u", GENESIS_BACKUP_NAS_PASS="p")
@@ -144,6 +149,30 @@ def test_no_complete_snapshot_skips_pull(nas_sandbox):
     proc = _run(nas_sandbox, complete=())  # none complete
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     assert "no complete dated snapshot" in proc.stdout.lower()
+
+
+def test_restore_uses_explicit_nas_host_override(nas_sandbox):
+    """Fresh box with a different hostname: GENESIS_BACKUP_NAS_HOST points the
+    pull at the SOURCE host's snapshots (the P1 the restore host was using its
+    own hostname)."""
+    proc = _run(nas_sandbox, complete=(_OLD_STAMP, _NEW_STAMP), nas_host="sourcebox")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert "Genesis/sourcebox/" in _smb_cmds(nas_sandbox), "did not use the override host"
+    db = nas_sandbox["gd"] / "data" / "genesis.db"
+    assert subprocess.run(["sqlite3", str(db), "SELECT x FROM t;"],
+                          capture_output=True, text=True).stdout.strip() == "99"
+
+
+def test_restore_autodetects_sole_nas_host(nas_sandbox):
+    """Hostname has no snapshots but exactly one host dir exists on the NAS → the
+    pull auto-detects it, so fresh-box DR works without setting the host name."""
+    proc = _run(nas_sandbox, complete=(_OLD_STAMP, _NEW_STAMP), nas_host="ghost")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert "Genesis/realhost/" in _smb_cmds(nas_sandbox), "did not auto-detect the sole host"
+    assert "using the only host" in proc.stdout.lower()
+    db = nas_sandbox["gd"] / "data" / "genesis.db"
+    assert subprocess.run(["sqlite3", str(db), "SELECT x FROM t;"],
+                          capture_output=True, text=True).stdout.strip() == "99"
 
 
 def test_no_nas_configured_skips_pull(nas_sandbox):

--- a/tests/test_scripts/test_restore_nas_pull.py
+++ b/tests/test_scripts/test_restore_nas_pull.py
@@ -1,13 +1,14 @@
-"""2a: restore.sh pulls the latest off-site (NAS) snapshot before restoring.
+"""2a: restore.sh pulls the latest COMPLETE off-site (NAS) snapshot.
 
 On a fresh DR box the SQLite dump / Qdrant / transcripts live ONLY on the NAS
-(gitignored from Tier-1). restore.sh must pull the latest dated snapshot from
-the NAS into BACKUP_DIR so the restore can proceed. This is the gap that made
-off-site recovery impossible.
+(gitignored from Tier-1). restore.sh must pull the latest *complete* dated
+snapshot (a half-uploaded snapshot from a crashed backup must be skipped) into
+BACKUP_DIR before restoring.
 
-Real E2E: a genuine GPG-encrypted SQL dump is served by the smbclient stub on
-`get`, so the full pull→decrypt→.read chain runs (real sqlite3 + gpg). Fully
-sandboxed (HOME + GENESIS_DIR → tmp); systemctl + smbclient stubbed.
+Real E2E: a genuine GPG-encrypted dump is served by the smbclient stub on `get`,
+so the full pull→decrypt→.read chain runs. Fully sandboxed (HOME + GENESIS_DIR →
+tmp); systemctl + smbclient stubbed. The stub treats snapshots named in
+``COMPLETE_STAMPS`` (env) as having a COMPLETE marker.
 """
 
 import os
@@ -19,7 +20,7 @@ import pytest
 
 _RESTORE = Path(__file__).resolve().parents[2] / "scripts" / "restore.sh"
 _OLD_STAMP = "20260615T180000Z"
-_NEW_STAMP = "20260617T180000Z"  # the latest — restore must pick this one
+_NEW_STAMP = "20260617T180000Z"  # the latest
 
 
 def _make_stub(path: Path, body: str) -> None:
@@ -34,23 +35,29 @@ def nas_sandbox(tmp_path):
     (gd / "data").mkdir(parents=True)
     (home / ".genesis").mkdir(parents=True)
     (home / ".gnupg").mkdir(mode=0o700)
-    backup = tmp_path / "backup"            # fresh-box BACKUP_DIR: no data/ locally
+    backup = tmp_path / "backup"
     backup.mkdir()
     bind = tmp_path / "bin"
     bind.mkdir()
     smb_log = tmp_path / "smb.log"
 
-    # A real GPG-encrypted SQL dump the NAS stub will serve on `get`.
     sql = tmp_path / "dump.sql"
     sql.write_text("CREATE TABLE t(x);\nINSERT INTO t VALUES(99);\n")
     dump_gpg = tmp_path / "genesis.sql.gpg"
     subprocess.run(["gpg", "--batch", "--yes", "--homedir", str(home / ".gnupg"),
                     "--passphrase", "testpass", "--symmetric", "--cipher-algo",
                     "AES256", "-o", str(dump_gpg), str(sql)], check=True, capture_output=True)
+    qfile = tmp_path / "qsnap.gpg"
+    qfile.write_text("QDRANT-SNAPSHOT-BYTES")  # served verbatim; not restored here
 
     _make_stub(bind / "systemctl", "#!/usr/bin/env bash\nexit 3\n")  # server inactive
-    # smbclient stub: serve the host-dir listing (two dated snapshots), copy the
-    # encrypted dump on `get`, and report empty qdrant/transcripts listings.
+    # smbclient stub. Dispatches on the -c command:
+    #   get genesis.sql.gpg  → cp the real encrypted dump
+    #   get <qfile>          → cp the qdrant file
+    #   ls COMPLETE          → echo COMPLETE iff this stamp is in $COMPLETE_STAMPS
+    #   <snap>/qdrant; ls    → list a qdrant file (so the get loop is exercised)
+    #   <snap>/transcripts;ls→ empty
+    #   <host>; ls           → the two dated snapshot dirs
     _make_stub(
         bind / "smbclient",
         '#!/usr/bin/env bash\n'
@@ -60,9 +67,14 @@ def nas_sandbox(tmp_path):
         'case "$cmd" in\n'
         '  *"get genesis.sql.gpg"*)\n'
         '      dest=$(printf "%s" "$cmd" | sed -E \'s/.*get genesis.sql.gpg +"([^"]*)".*/\\1/\')\n'
-        '      mkdir -p "$(dirname "$dest")"\n'
-        f'      cp "{dump_gpg}" "$dest" ;;\n'
-        '  *"/qdrant; ls"*|*"/transcripts; ls"*) : ;;\n'
+        f'      mkdir -p "$(dirname "$dest")"; cp "{dump_gpg}" "$dest" ;;\n'
+        '  *"get \\"qsnap.gpg\\""*)\n'
+        '      dest=$(printf "%s" "$cmd" | sed -E \'s/.*get "qsnap.gpg" +"([^"]*)".*/\\1/\')\n'
+        f'      mkdir -p "$(dirname "$dest")"; cp "{qfile}" "$dest" ;;\n'
+        '  *"ls COMPLETE"*)\n'
+        '      for s in ${COMPLETE_STAMPS:-}; do case "$cmd" in *"$s"*) echo "  COMPLETE  A  0  x"; break ;; esac; done ;;\n'
+        '  *"/qdrant"*) [ "${SERVE_QDRANT:-0}" = 1 ] && echo "  qsnap.gpg  A  10  x" || : ;;\n'
+        '  *"/transcripts"*) : ;;\n'
         f'  *ls*) printf "  {_OLD_STAMP}  D  0  x\\n  {_NEW_STAMP}  D  0  x\\n" ;;\n'
         'esac\n'
         'exit 0\n',
@@ -71,11 +83,12 @@ def nas_sandbox(tmp_path):
             "smb_log": smb_log, "tmp": tmp_path}
 
 
-def _run(nas_sandbox, *, nas=True):
+def _run(nas_sandbox, *, nas=True, complete=(_OLD_STAMP, _NEW_STAMP), serve_qdrant=False):
     env = dict(os.environ)
     env.update(
         HOME=str(nas_sandbox["home"]), GENESIS_DIR=str(nas_sandbox["gd"]),
         GENESIS_BACKUP_PASSPHRASE="testpass", QDRANT_URL="http://127.0.0.1:1",
+        COMPLETE_STAMPS=" ".join(complete), SERVE_QDRANT="1" if serve_qdrant else "0",
         PATH=f'{nas_sandbox["bind"]}:{os.environ["PATH"]}',
     )
     if nas:
@@ -94,26 +107,47 @@ def _smb_cmds(nas_sandbox) -> str:
     return nas_sandbox["smb_log"].read_text() if nas_sandbox["smb_log"].exists() else ""
 
 
-def test_restore_pulls_latest_snapshot_and_restores_db(nas_sandbox):
-    """End-to-end: pull the latest NAS snapshot's dump → decrypt → restore the DB."""
-    proc = _run(nas_sandbox, nas=True)
+def test_restore_pulls_latest_complete_snapshot_and_restores_db(nas_sandbox):
+    """E2E: pull the latest COMPLETE snapshot's dump → decrypt → restore the DB."""
+    proc = _run(nas_sandbox, complete=(_OLD_STAMP, _NEW_STAMP))
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
-    # The restored DB holds the dump's content (proves pull→decrypt→.read worked).
     db = nas_sandbox["gd"] / "data" / "genesis.db"
-    out = subprocess.run(["sqlite3", str(db), "SELECT x FROM t;"],
-                         capture_output=True, text=True)
+    out = subprocess.run(["sqlite3", str(db), "SELECT x FROM t;"], capture_output=True, text=True)
     assert out.stdout.strip() == "99", f"DB not restored from the NAS dump: {out.stdout!r}"
-    # And it pulled from the LATEST snapshot, not the older one.
-    cmds = _smb_cmds(nas_sandbox)
-    got = [ln for ln in cmds.splitlines() if "get genesis.sql.gpg" in ln]
-    assert got, f"no SQL get issued:\n{cmds}"
-    assert all(_NEW_STAMP in ln for ln in got), f"pulled a non-latest snapshot:\n{got}"
-    assert all(_OLD_STAMP not in ln for ln in got), f"pulled the OLD snapshot:\n{got}"
+    got = [ln for ln in _smb_cmds(nas_sandbox).splitlines() if "get genesis.sql.gpg" in ln]
+    assert got and all(_NEW_STAMP in ln for ln in got), f"didn't pull from the latest snapshot:\n{got}"
+
+
+def test_restore_pulls_qdrant_files_from_snapshot(nas_sandbox):
+    """The qdrant pull loop fetches each *.gpg into BACKUP_DIR/data/qdrant.
+    (Exit code isn't checked: staging a qdrant file makes restore.sh probe the
+    test's dead Qdrant and warn — irrelevant to the pull itself.)"""
+    _run(nas_sandbox, complete=(_NEW_STAMP,), serve_qdrant=True)
+    staged = nas_sandbox["backup"] / "data" / "qdrant" / "qsnap.gpg"
+    assert staged.exists() and staged.read_text() == "QDRANT-SNAPSHOT-BYTES", \
+        "qdrant snapshot not pulled from the NAS"
+
+
+def test_restore_skips_incomplete_latest_snapshot(nas_sandbox):
+    """If the newest snapshot has no COMPLETE marker (crashed mid-upload), restore
+    falls back to the previous COMPLETE one — never a half-uploaded snapshot."""
+    proc = _run(nas_sandbox, complete=(_OLD_STAMP,))  # newest is INCOMPLETE
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    got = [ln for ln in _smb_cmds(nas_sandbox).splitlines() if "get genesis.sql.gpg" in ln]
+    assert got and all(_OLD_STAMP in ln for ln in got), f"didn't fall back to the older complete snapshot:\n{got}"
+    assert all(_NEW_STAMP not in ln for ln in got), f"pulled the incomplete latest snapshot:\n{got}"
+    assert "incomplete" in proc.stdout.lower()
+
+
+def test_no_complete_snapshot_skips_pull(nas_sandbox):
+    """No COMPLETE snapshot anywhere → pull skipped, no crash."""
+    proc = _run(nas_sandbox, complete=())  # none complete
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert "no complete dated snapshot" in proc.stdout.lower()
 
 
 def test_no_nas_configured_skips_pull(nas_sandbox):
-    """Without a NAS target, no pull happens and the (absent) local payload just
-    yields 'no backup payload' — no crash, no smbclient calls."""
+    """Without a NAS target, no pull happens and there are no smbclient calls."""
     proc = _run(nas_sandbox, nas=False)
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     assert _smb_cmds(nas_sandbox).strip() == "", "smbclient called without a NAS target"

--- a/tests/test_scripts/test_restore_nas_pull.py
+++ b/tests/test_scripts/test_restore_nas_pull.py
@@ -1,0 +1,120 @@
+"""2a: restore.sh pulls the latest off-site (NAS) snapshot before restoring.
+
+On a fresh DR box the SQLite dump / Qdrant / transcripts live ONLY on the NAS
+(gitignored from Tier-1). restore.sh must pull the latest dated snapshot from
+the NAS into BACKUP_DIR so the restore can proceed. This is the gap that made
+off-site recovery impossible.
+
+Real E2E: a genuine GPG-encrypted SQL dump is served by the smbclient stub on
+`get`, so the full pull→decrypt→.read chain runs (real sqlite3 + gpg). Fully
+sandboxed (HOME + GENESIS_DIR → tmp); systemctl + smbclient stubbed.
+"""
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_RESTORE = Path(__file__).resolve().parents[2] / "scripts" / "restore.sh"
+_OLD_STAMP = "20260615T180000Z"
+_NEW_STAMP = "20260617T180000Z"  # the latest — restore must pick this one
+
+
+def _make_stub(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+@pytest.fixture
+def nas_sandbox(tmp_path):
+    home = tmp_path / "home"
+    gd = home / "genesis"
+    (gd / "data").mkdir(parents=True)
+    (home / ".genesis").mkdir(parents=True)
+    (home / ".gnupg").mkdir(mode=0o700)
+    backup = tmp_path / "backup"            # fresh-box BACKUP_DIR: no data/ locally
+    backup.mkdir()
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    smb_log = tmp_path / "smb.log"
+
+    # A real GPG-encrypted SQL dump the NAS stub will serve on `get`.
+    sql = tmp_path / "dump.sql"
+    sql.write_text("CREATE TABLE t(x);\nINSERT INTO t VALUES(99);\n")
+    dump_gpg = tmp_path / "genesis.sql.gpg"
+    subprocess.run(["gpg", "--batch", "--yes", "--homedir", str(home / ".gnupg"),
+                    "--passphrase", "testpass", "--symmetric", "--cipher-algo",
+                    "AES256", "-o", str(dump_gpg), str(sql)], check=True, capture_output=True)
+
+    _make_stub(bind / "systemctl", "#!/usr/bin/env bash\nexit 3\n")  # server inactive
+    # smbclient stub: serve the host-dir listing (two dated snapshots), copy the
+    # encrypted dump on `get`, and report empty qdrant/transcripts listings.
+    _make_stub(
+        bind / "smbclient",
+        '#!/usr/bin/env bash\n'
+        'cmd=""; prev=""\n'
+        'for a in "$@"; do [ "$prev" = "-c" ] && cmd="$a"; prev="$a"; done\n'
+        f'printf "%s\\n" "$cmd" >> "{smb_log}"\n'
+        'case "$cmd" in\n'
+        '  *"get genesis.sql.gpg"*)\n'
+        '      dest=$(printf "%s" "$cmd" | sed -E \'s/.*get genesis.sql.gpg +"([^"]*)".*/\\1/\')\n'
+        '      mkdir -p "$(dirname "$dest")"\n'
+        f'      cp "{dump_gpg}" "$dest" ;;\n'
+        '  *"/qdrant; ls"*|*"/transcripts; ls"*) : ;;\n'
+        f'  *ls*) printf "  {_OLD_STAMP}  D  0  x\\n  {_NEW_STAMP}  D  0  x\\n" ;;\n'
+        'esac\n'
+        'exit 0\n',
+    )
+    return {"home": home, "gd": gd, "backup": backup, "bind": bind,
+            "smb_log": smb_log, "tmp": tmp_path}
+
+
+def _run(nas_sandbox, *, nas=True):
+    env = dict(os.environ)
+    env.update(
+        HOME=str(nas_sandbox["home"]), GENESIS_DIR=str(nas_sandbox["gd"]),
+        GENESIS_BACKUP_PASSPHRASE="testpass", QDRANT_URL="http://127.0.0.1:1",
+        PATH=f'{nas_sandbox["bind"]}:{os.environ["PATH"]}',
+    )
+    if nas:
+        env.update(GENESIS_BACKUP_NAS="//nas/share",
+                   GENESIS_BACKUP_NAS_USER="u", GENESIS_BACKUP_NAS_PASS="p")
+    else:
+        for k in ("GENESIS_BACKUP_NAS", "GENESIS_BACKUP_NAS_USER", "GENESIS_BACKUP_NAS_PASS"):
+            env.pop(k, None)
+    return subprocess.run(
+        ["bash", str(_RESTORE), "--from", str(nas_sandbox["backup"]), "--force"],
+        env=env, capture_output=True, text=True, stdin=subprocess.DEVNULL,
+    )
+
+
+def _smb_cmds(nas_sandbox) -> str:
+    return nas_sandbox["smb_log"].read_text() if nas_sandbox["smb_log"].exists() else ""
+
+
+def test_restore_pulls_latest_snapshot_and_restores_db(nas_sandbox):
+    """End-to-end: pull the latest NAS snapshot's dump → decrypt → restore the DB."""
+    proc = _run(nas_sandbox, nas=True)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    # The restored DB holds the dump's content (proves pull→decrypt→.read worked).
+    db = nas_sandbox["gd"] / "data" / "genesis.db"
+    out = subprocess.run(["sqlite3", str(db), "SELECT x FROM t;"],
+                         capture_output=True, text=True)
+    assert out.stdout.strip() == "99", f"DB not restored from the NAS dump: {out.stdout!r}"
+    # And it pulled from the LATEST snapshot, not the older one.
+    cmds = _smb_cmds(nas_sandbox)
+    got = [ln for ln in cmds.splitlines() if "get genesis.sql.gpg" in ln]
+    assert got, f"no SQL get issued:\n{cmds}"
+    assert all(_NEW_STAMP in ln for ln in got), f"pulled a non-latest snapshot:\n{got}"
+    assert all(_OLD_STAMP not in ln for ln in got), f"pulled the OLD snapshot:\n{got}"
+
+
+def test_no_nas_configured_skips_pull(nas_sandbox):
+    """Without a NAS target, no pull happens and the (absent) local payload just
+    yields 'no backup payload' — no crash, no smbclient calls."""
+    proc = _run(nas_sandbox, nas=False)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert _smb_cmds(nas_sandbox).strip() == "", "smbclient called without a NAS target"
+    assert "no backup payload" in proc.stdout.lower()


### PR DESCRIPTION
## Problem

The two-tier backup stores the large data (SQLite DB, Qdrant snapshots, transcripts) **only** on the off-site NAS — gitignored from Tier-1. But `restore.sh` had **no NAS code**, so on a fresh DR box it could recover memory/config/secrets but **not the database or vector memory**. The off-site tier was effectively *write-only* — the most important state was stranded.

## Fix (DR upgrade 2a)

- **`backup.sh`** uploads Tier-2 to per-run **dated snapshot dirs** `Genesis/<host>/<UTC-stamp>/{data,qdrant,transcripts}/…` (was fixed filenames overwritten each run), now including **transcripts** (previously local-only). After every upload succeeds it writes a **`COMPLETE`** marker.
- **`restore.sh`** gains a NAS-pull (after the git-pull, before restore): finds the **latest `COMPLETE`** snapshot (`grep` the stamp pattern out of `smbclient ls` — robust to format — newest first, skipping any half-uploaded snapshot), and pulls its `data`/`qdrant`/`transcripts` into `BACKUP_DIR`. The integrity-check from #671 then guards the pulled DB. **This closes the off-site-recovery gap.**

## Safety / robustness
- **No half-restores:** a crashed-mid-upload snapshot lacks `COMPLETE`, so restore falls back to the previous good one (never restores partial data); a failed SQL pull `warn`s → non-zero exit (loud, not silent).
- **`set -e`/`pipefail`:** grep-over-empty-listing pipelines guarded (a bug found + fixed during the build); staging dirs created only when a file is pulled (an empty Qdrant set must not trigger the Qdrant probe).
- **Creds:** NAS creds file (chmod 600, never on cmdline) cleaned up via a `RETURN` trap on any function exit.
- **Same-box re-run:** NAS pull skipped if a local payload already exists unless `--force`.

## Testing

TDD, fully sandboxed (`HOME`+`GENESIS_DIR` → tmp; real `sqlite3`/`gpg`/`git`, stubbed `smbclient`/`systemctl`). 18 DR-script tests:
- **Real E2E:** a genuine GPG-encrypted dump served by the smbclient stub is pulled → decrypted → restored (DB content verified), latest-of-two snapshots selected; qdrant file staged via the pull loop.
- **Incomplete-latest snapshot → falls back** to the older COMPLETE one; no-complete → skips; no-NAS → skips cleanly.
- backup: dated paths + snapshot-tree mkdir; plus the existing restore-safety (6) + DR-04 (5) suites still green.
- `bash -n` + `shellcheck -S warning` + `ruff` clean.

## Review

Codex quota-exhausted → Claude code-reviewer (fallback). Two P1s it found (partial-snapshot data correctness; creds leak) are fixed via the COMPLETE sentinel + `RETURN` trap; the P2s (header docs, warn-on-miss, local-payload skip) and test gaps (incomplete fallback, qdrant loop) are addressed above.

Next: GFS retention + local prune (2b), cloud Tier-2 via rclone (2c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)