### PR TITLE
fix(memory): gate reference auto-capture to user-shared values + mark provenance

### DIFF
--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -212,6 +212,12 @@ async def run_extraction_cycle(
             # modes — this is the dominant path that populates the
             # reference store from historical conversations.
             try:
+                # Gate reference auto-capture to the USER's own words — the
+                # classifier must not mine Genesis's analysis prose (the
+                # dominant source of junk refs) for credentials/IPs/URLs.
+                chunk_user_text = "\n".join(
+                    m.text for m in chunk if m.role == "user"
+                )
                 ref_count = await extract_references_from_chunk(
                     result.extractions,
                     store=store,
@@ -220,6 +226,7 @@ async def run_extraction_cycle(
                     # Normal: queue for paced embedding; history mining: embed
                     # inline (one-shot CLI won't have recovery worker running)
                     force_fts5_only=not reference_only_mode,
+                    user_text=chunk_user_text,
                 )
                 summary["references_captured"] += ref_count
             except Exception:

--- a/src/genesis/memory/knowledge_ingest.py
+++ b/src/genesis/memory/knowledge_ingest.py
@@ -44,6 +44,7 @@ async def ingest_knowledge_unit(
     ingestion_source: str | None = None,
     collection: str = "knowledge_base",
     memory_type: str = "knowledge",
+    confidence: float = 0.85,
 ) -> str:
     """Ingest or upsert a knowledge unit, returning the stable unit_id.
 
@@ -87,7 +88,7 @@ async def ingest_knowledge_unit(
         memory_type=memory_type,
         collection=collection,
         tags=[domain, project, authority],
-        confidence=0.85,
+        confidence=confidence,
         auto_link=False,
         source_pipeline=source_pipeline_val,
         memory_class=memory_class,
@@ -122,7 +123,7 @@ async def ingest_knowledge_unit(
         tags=resolved_tags,
         ingested_at=now_iso,
         qdrant_id=qdrant_memory_id,
-        confidence=0.85,
+        confidence=confidence,
         source_platform=provenance.get("platform") if provenance else None,
         section_title=provenance.get("section_title") if provenance else None,
         source_date=provenance.get("source_date") if provenance else None,

--- a/src/genesis/memory/reference_extraction.py
+++ b/src/genesis/memory/reference_extraction.py
@@ -16,6 +16,14 @@ Classification balances recall against precision:
   a network context word adjacent to the IP). They run over LLM-generated
   prose, where a loose match fabricates a misleading value rather than
   sitting idle harmlessly.
+- **Gated to the USER's own words.** ``classify_as_reference`` /
+  ``extract_references_from_chunk`` accept ``user_text`` (the chunk's
+  user-authored content); a match is only captured if its raw value appears
+  there. This stops the dominant noise source — mining Genesis's OWN analysis
+  prose ("HybridRetriever.recall() -> password: rerank") for references.
+- **Marked distinctly.** Auto-captured entries get the ``auto_captured`` tag
+  and confidence 0.60 (vs 0.85 for real-time ``reference_store`` captures), so
+  manual/verified vs auto/unverified is separable everywhere downstream.
 - The primary capture path is the LLM calling ``reference_store`` in
   real-time. This background path is a safety net that catches things
   the primary path missed.
@@ -221,15 +229,36 @@ def _derive_identifier(extraction: Extraction, *, default_prefix: str) -> str:
     return content[:80].strip() or default_prefix
 
 
-def classify_as_reference(extraction: Extraction) -> dict | None:
+def _user_shared(token: str | None, user_text: str | None) -> bool:
+    """True if a captured value is attributable to the USER's own words.
+
+    ``user_text`` is the concatenation of the user-authored messages in the
+    chunk. When None the gate is DISABLED (back-compat for direct callers and
+    unit tests). The check is a case-insensitive substring on the RAW matched
+    token (password/IP/URL/key) — concrete strings the LLM preserves verbatim —
+    so the auto-capture path can't mine Genesis's OWN analysis prose for
+    references.
+    """
+    if user_text is None:
+        return True
+    if not token:
+        return False
+    return token.lower() in user_text.lower()
+
+
+def classify_as_reference(
+    extraction: Extraction, user_text: str | None = None,
+) -> dict | None:
     """Attempt to classify an Extraction as a reference entry.
 
     Returns a dict shaped like the ``reference_store`` input
     (``kind``, ``identifier``, ``value``, ``description``, ``tags``) if
     the extraction looks like persistent reference data, otherwise None.
 
-    Errs on the side of capturing more — false positives are harmless,
-    false negatives lose credentials permanently.
+    When ``user_text`` is provided (the chunk's user-authored content), a match
+    is only returned if its raw value appears in the user's own words — so the
+    auto-capture path doesn't fabricate references from Genesis's analysis
+    prose. ``user_text=None`` disables the gate (direct callers / unit tests).
     """
     content = extraction.content or ""
     if len(content) < _MIN_CONTENT_LENGTH:
@@ -244,7 +273,10 @@ def classify_as_reference(extraction: Extraction) -> dict | None:
     if pair:
         user = pair.group("user")
         password = pair.group("pass")
-        if user and password and len(password) >= 4:
+        if (
+            user and password and len(password) >= 4
+            and _user_shared(password, user_text)
+        ):
             return {
                 "kind": "credentials",
                 "identifier": _derive_identifier(
@@ -260,7 +292,10 @@ def classify_as_reference(extraction: Extraction) -> dict | None:
     if email_pass:
         email = email_pass.group("email")
         password = email_pass.group("pass")
-        if email and password and len(password) >= 4:
+        if (
+            email and password and len(password) >= 4
+            and _user_shared(password, user_text)
+        ):
             return {
                 "kind": "credentials",
                 "identifier": _derive_identifier(
@@ -276,7 +311,10 @@ def classify_as_reference(extraction: Extraction) -> dict | None:
     if acct:
         account = acct.group("account")
         password = acct.group("pass")
-        if account and password and len(password) >= 4:
+        if (
+            account and password and len(password) >= 4
+            and _user_shared(password, user_text)
+        ):
             return {
                 "kind": "credentials",
                 "identifier": _derive_identifier(
@@ -291,7 +329,10 @@ def classify_as_reference(extraction: Extraction) -> dict | None:
     single = _SINGLE_CREDENTIAL_PATTERN.search(content)
     if single:
         password = single.group("value")
-        if password and len(password) >= 4:
+        if (
+            password and len(password) >= 4
+            and _user_shared(password, user_text)
+        ):
             return {
                 "kind": "credentials",
                 "identifier": _derive_identifier(
@@ -306,29 +347,31 @@ def classify_as_reference(extraction: Extraction) -> dict | None:
     known_key = _KNOWN_KEY_PREFIX_PATTERN.search(content)
     if known_key:
         tok_value = known_key.group("token")
-        return {
-            "kind": "credentials",
-            "identifier": _derive_identifier(
-                extraction, default_prefix="api_key",
-            ),
-            "value": f"token: {tok_value}",
-            "description": content,
-            "tags": tags,
-        }
+        if _user_shared(tok_value, user_text):
+            return {
+                "kind": "credentials",
+                "identifier": _derive_identifier(
+                    extraction, default_prefix="api_key",
+                ),
+                "value": f"token: {tok_value}",
+                "description": content,
+                "tags": tags,
+            }
 
     # 3. Standalone token / API key (labeled)
     token = _CREDENTIAL_TOKEN_PATTERN.search(content)
     if token:
         tok_value = token.group("token")
-        return {
-            "kind": "credentials",
-            "identifier": _derive_identifier(
-                extraction, default_prefix="token",
-            ),
-            "value": f"token: {tok_value}",
-            "description": content,
-            "tags": tags,
-        }
+        if _user_shared(tok_value, user_text):
+            return {
+                "kind": "credentials",
+                "identifier": _derive_identifier(
+                    extraction, default_prefix="token",
+                ),
+                "value": f"token: {tok_value}",
+                "description": content,
+                "tags": tags,
+            }
 
     # 3b. .env format — UPPER_SNAKE=value
     env = _ENV_ASSIGNMENT_PATTERN.search(content)
@@ -337,7 +380,9 @@ def classify_as_reference(extraction: Extraction) -> dict | None:
         val = env.group("val")
         # Only capture if the key name suggests a credential
         _CRED_KEY_WORDS = {"KEY", "SECRET", "TOKEN", "PASSWORD", "PASS", "AUTH", "API"}
-        if any(w in key.upper() for w in _CRED_KEY_WORDS):
+        if any(w in key.upper() for w in _CRED_KEY_WORDS) and _user_shared(
+            val, user_text,
+        ):
             return {
                 "kind": "credentials",
                 "identifier": _derive_identifier(
@@ -352,15 +397,16 @@ def classify_as_reference(extraction: Extraction) -> dict | None:
     ssh = _SSH_PATTERN.search(content)
     if ssh:
         userhost = ssh.group("userhost")
-        return {
-            "kind": "network",
-            "identifier": _derive_identifier(
-                extraction, default_prefix=f"ssh {userhost}",
-            ),
-            "value": f"ssh {userhost}",
-            "description": content,
-            "tags": tags,
-        }
+        if _user_shared(userhost, user_text):
+            return {
+                "kind": "network",
+                "identifier": _derive_identifier(
+                    extraction, default_prefix=f"ssh {userhost}",
+                ),
+                "value": f"ssh {userhost}",
+                "description": content,
+                "tags": tags,
+            }
 
     # 3. URL with context
     url_match = _URL_PATTERN.search(content)
@@ -369,7 +415,9 @@ def classify_as_reference(extraction: Extraction) -> dict | None:
         # Require meaningful context around the URL — bare "https://..."
         # with no explanation is ephemeral.
         context_remainder = content.replace(url_str, "").strip()
-        if len(context_remainder) >= _MIN_URL_CONTEXT_LENGTH:
+        if len(context_remainder) >= _MIN_URL_CONTEXT_LENGTH and _user_shared(
+            url_str, user_text,
+        ):
             return {
                 "kind": "url",
                 "identifier": _derive_identifier(
@@ -395,9 +443,12 @@ def classify_as_reference(extraction: Extraction) -> dict | None:
         window = content[
             max(0, start - _NETWORK_CONTEXT_WINDOW): end + _NETWORK_CONTEXT_WINDOW
         ].lower()
-        if any(
-            re.search(rf"\b{re.escape(word)}\b", window)
-            for word in _NETWORK_CONTEXT_WORDS
+        if (
+            any(
+                re.search(rf"\b{re.escape(word)}\b", window)
+                for word in _NETWORK_CONTEXT_WORDS
+            )
+            and _user_shared(net_match.group(0), user_text)
         ):
             return {
                 "kind": "network",
@@ -458,15 +509,20 @@ async def ingest_reference_from_extraction(
     db: aiosqlite.Connection,
     source_session_id: str | None = None,
     force_fts5_only: bool = False,
+    user_text: str | None = None,
 ) -> str | None:
     """Classify an Extraction and ingest it as a reference entry if matched.
+
+    ``user_text`` (the chunk's user-authored content) gates auto-capture to
+    values the USER actually shared; auto-captured entries are marked with the
+    ``auto_captured`` tag and a lower confidence (0.60 vs reference_store 0.85).
 
     Returns the unit_id on success, or None if the extraction was not
     classified as persistent reference data. Never raises — a classifier
     or ingestion failure logs a warning and returns None.
     """
     try:
-        ref = classify_as_reference(extraction)
+        ref = classify_as_reference(extraction, user_text=user_text)
     except Exception:
         logger.warning(
             "reference extractor classification failed", exc_info=True,
@@ -491,7 +547,7 @@ async def ingest_reference_from_extraction(
         session_id=source_session_id,
     )
 
-    all_tags = ["reference", kind, *tags]
+    all_tags = ["reference", kind, *tags, "auto_captured"]
     tags_json = json.dumps(all_tags)
 
     provenance: dict = {
@@ -517,6 +573,7 @@ async def ingest_reference_from_extraction(
             force_fts5_only=force_fts5_only,
             collection="episodic_memory",
             memory_type="episodic",
+            confidence=0.60,  # auto-captured: lower than reference_store (0.85)
         )
     except Exception:
         logger.warning(
@@ -539,6 +596,7 @@ async def extract_references_from_chunk(
     db: aiosqlite.Connection,
     source_session_id: str | None = None,
     force_fts5_only: bool = False,
+    user_text: str | None = None,
 ) -> int:
     """Run the classifier over a chunk of extractions, ingesting references.
 
@@ -554,6 +612,7 @@ async def extract_references_from_chunk(
             db=db,
             source_session_id=source_session_id,
             force_fts5_only=force_fts5_only,
+            user_text=user_text,
         )
         if unit_id:
             count += 1

--- a/tests/test_memory/test_reference_extraction_gating.py
+++ b/tests/test_memory/test_reference_extraction_gating.py
@@ -1,0 +1,179 @@
+"""Tests for user-shared gating + provenance marking of auto-captured references.
+
+Root-cause fix for reference-store noise: the 2h extraction job ran the regex
+classifier over LLM prose from BOTH user and Genesis turns, so Genesis's own
+analysis ("HybridRetriever.recall() -> password: rerank") became fake references.
+Fix: gate auto-capture to values that appear in the USER's own words, and mark
+auto-captured entries distinctly (``auto_captured`` tag + confidence 0.60) so
+they're separable from real-time ``reference_store`` captures.
+
+The gate is opt-in via ``user_text`` — ``None`` means ungated (back-compat).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from genesis.db.schema import create_all_tables
+from genesis.memory.extraction import Extraction
+from genesis.memory.reference_extraction import (
+    classify_as_reference,
+    extract_references_from_chunk,
+    ingest_reference_from_extraction,
+)
+
+
+def _ext(content: str, entities: list[str] | None = None) -> Extraction:
+    return Extraction(
+        content=content,
+        extraction_type="entity",
+        confidence=0.9,
+        entities=entities or [],
+    )
+
+
+# ─── Gate: only capture values that appear in the USER's own words ────────────
+
+
+class TestUserSharedGate:
+    def test_no_user_text_is_ungated(self):
+        # Back-compat: user_text=None must behave exactly as before.
+        ext = _ext("The admin password: Hunter2!xyz for the box")
+        assert classify_as_reference(ext) is not None
+        assert classify_as_reference(ext, user_text=None) is not None
+
+    def test_user_shared_credential_captured(self):
+        ext = _ext("The admin password: Hunter2!xyz for the box")
+        ref = classify_as_reference(ext, user_text="here it is, password: Hunter2!xyz")
+        assert ref is not None
+        assert ref["kind"] == "credentials"
+        assert "Hunter2!xyz" in ref["value"]
+
+    def test_genesis_derived_credential_dropped(self):
+        # The secret is in Genesis's analysis prose, NOT the user's words.
+        ext = _ext("The service password: rerankXYZ is used internally")
+        assert classify_as_reference(
+            ext, user_text="user asked about ranking and latency",
+        ) is None
+
+    def test_user_shared_pair_captured(self):
+        ext = _ext("login: username: bob and password: Hunter2!xyz works")
+        ref = classify_as_reference(
+            ext, user_text="username: bob password: Hunter2!xyz",
+        )
+        assert ref is not None and ref["kind"] == "credentials"
+
+    def test_user_shared_url_captured(self):
+        ext = _ext("Bookmark the dashboard at https://example.com/admin for later")
+        ref = classify_as_reference(
+            ext, user_text="save this: https://example.com/admin please",
+        )
+        assert ref is not None and ref["kind"] == "url"
+
+    def test_genesis_derived_url_dropped(self):
+        ext = _ext("Genesis suggests checking https://docs.internal.dev/guide first")
+        assert classify_as_reference(
+            ext, user_text="how do i call the api",
+        ) is None
+
+    def test_user_shared_ip_captured(self):
+        ext = _ext("The server runs on host 203.0.113.10 for the app")
+        ref = classify_as_reference(
+            ext, user_text="the server is at 203.0.113.10",
+        )
+        assert ref is not None and ref["kind"] == "network"
+
+    def test_genesis_derived_ip_dropped(self):
+        ext = _ext("The container host 203.0.113.99 appeared in the debug trace")
+        assert classify_as_reference(
+            ext, user_text="why did the debug run fail",
+        ) is None
+
+    def test_gate_is_case_insensitive(self):
+        # LLM may normalize case; the gate must not false-drop on case alone.
+        ext = _ext("password: SecretPass99 for the account")
+        ref = classify_as_reference(
+            ext, user_text="my password is secretpass99",
+        )
+        assert ref is not None
+
+
+# ─── Marking: auto_captured tag + confidence 0.60 on ingest ───────────────────
+
+
+@pytest.fixture
+async def _db():
+    async with aiosqlite.connect(":memory:") as conn:
+        await create_all_tables(conn)
+        await conn.commit()
+        yield conn
+
+
+@pytest.fixture
+def _store():
+    s = AsyncMock()
+    s.store = AsyncMock(return_value="qid")
+    s.delete = AsyncMock()
+    s._embeddings = MagicMock()
+    s._embeddings.model_name = "test-embed"
+    return s
+
+
+async def test_ingest_marks_auto_captured_and_low_confidence(_db, _store):
+    ext = _ext(
+        "login: username: bob password: Hunter2!xyz",
+        entities=["MyService"],
+    )
+    uid = await ingest_reference_from_extraction(
+        ext, store=_store, db=_db, source_session_id="s",
+        user_text="username: bob password: Hunter2!xyz",
+    )
+    assert uid is not None
+    cur = await _db.execute(
+        "SELECT tags, confidence FROM knowledge_units WHERE id=?", (uid,),
+    )
+    tags, confidence = await cur.fetchone()
+    assert "auto_captured" in json.loads(tags)
+    assert confidence == 0.60
+
+
+async def test_ingest_gate_blocks_non_user_shared(_db, _store):
+    ext = _ext("The internal password: rerankXYZ for ranking")
+    uid = await ingest_reference_from_extraction(
+        ext, store=_store, db=_db, source_session_id="s",
+        user_text="how does ranking work",
+    )
+    assert uid is None
+    cur = await _db.execute(
+        "SELECT COUNT(*) FROM knowledge_units WHERE project_type='reference'"
+    )
+    assert (await cur.fetchone())[0] == 0
+
+
+async def test_chunk_gating_e2e(_db, _store):
+    """E2E: a chunk mixing Genesis-analysis + a user-shared cred, gated by
+    user_text, ingests ONLY the user-shared one (marked auto_captured/0.60)."""
+    extractions = [
+        # Genesis analysis prose — value not in the user's words → dropped.
+        _ext("The internal password: rerankXYZ is used for ranking", ["Ranking"]),
+        # User-shared credential → captured.
+        _ext("login username: bob password: Hunter2!xyz", ["MyService"]),
+    ]
+    user_text = "here are my creds: username: bob password: Hunter2!xyz"
+    count = await extract_references_from_chunk(
+        extractions, store=_store, db=_db, source_session_id="s",
+        user_text=user_text,
+    )
+    assert count == 1
+    cur = await _db.execute(
+        "SELECT tags, confidence FROM knowledge_units WHERE project_type='reference'"
+    )
+    rows = await cur.fetchall()
+    assert len(rows) == 1
+    tags, confidence = rows[0]
+    assert "auto_captured" in json.loads(tags)
+    assert confidence == 0.60


### PR DESCRIPTION
## Problem
The 2h `memory_extraction` job auto-captures references by running the regex classifier (`classify_as_reference`) over LLM-extracted prose from **both** user and Genesis turns. Most of the resulting junk is Genesis's *own* analysis prose (e.g. a sentence about `HybridRetriever.recall()` producing a fabricated `password: rerank`), stored indistinguishably from references the user actually shared.

## Fix (root cause)
1. **Gate auto-capture to the user's own words.** `classify_as_reference` and `extract_references_from_chunk` accept `user_text` (the chunk's user-authored content). A match is captured only if its **raw matched token** (password / IP / URL / key) appears in `user_text` (case-insensitive substring — concrete strings the LLM preserves verbatim). `extraction_job` builds `user_text` from the chunk's `role == "user"` messages. `user_text=None` disables the gate (back-compat for direct callers/tests).
2. **Mark auto-captured entries distinctly.** They get the `auto_captured` tag and `confidence=0.60` (vs `0.85` for real-time `reference_store` captures), so manual/verified vs auto/unverified is separable everywhere downstream. Adds a `confidence` param to `ingest_knowledge_unit` (default `0.85`; other callers unaffected).

Scoped to **references only** — general knowledge / procedure / episodic extraction is untouched (the gate is applied at the reference-classification step, not the chunk level).

## Tests
`test_reference_extraction_gating.py` (12 tests): per-kind gating (credential/url/network captured when user-shared, dropped when only in Genesis prose), case-insensitivity, `auto_captured` + 0.60 marking, gate-blocks-ingest, and a mixed-chunk E2E. Existing #667 precision suite + `test_extract_references_from_chunk_counts` stay green; ruff clean.

## Notes
- API additions are backward-compatible (new params default to prior behavior).
- Pre-existing, out of scope: the MCP `_ingest_knowledge_unit` wrapper doesn't yet expose `confidence` (no current caller needs it).
