### PR TITLE
fix(guardian): preserve local config on update conflict + JSON-only response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   deliberately leaves the server stopped afterward so you can verify the restore
   before bringing Genesis back up.
 
+- **The host Guardian's self-update no longer throws away your local config on a
+  conflict** — when it pulls new code and a local setting (e.g. the container IP)
+  clashes with an upstream change to the same lines, the update used to silently
+  discard those local changes. It now preserves them in a recoverable git stash
+  (and tells you they're recoverable) instead of dropping them. The update also
+  reports its result reliably, so a successful update that pulled changes is no
+  longer misread as a failure.
+
 - **Guardian host updates no longer silently stall** — on hosts where the
   Guardian's `CLAUDE.md` had been pinned with git's skip-worktree flag, the
   Guardian's self-update (`git pull`) would abort the moment that file changed

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -111,20 +111,31 @@ PYEOF
             # --skip-worktree, which wedges `git pull` ("local changes would be
             # overwritten") the moment upstream touches the tracked CLAUDE.md.
             git update-index --no-skip-worktree CLAUDE.md 2>/dev/null || true
-            git checkout -- CLAUDE.md 2>/dev/null || true
+            git checkout -- CLAUDE.md >/dev/null 2>&1 || true
             # Stash remaining local config changes (container_ip, etc.)
             STASHED=0
             if ! git diff --quiet 2>/dev/null; then
-                git stash --quiet 2>/dev/null && STASHED=1
+                git stash --quiet >/dev/null 2>&1 && STASHED=1
             fi
-            if git pull --ff-only 2>/dev/null; then
+            # NOTE: every git command in this verb redirects stdout to /dev/null.
+            # The verb's contract is "JSON on stdout ONLY" (the container parses the
+            # whole stdout with json.loads); git's diffstat / "Updating.."/ conflict
+            # chatter on stdout would otherwise corrupt the response into a parse
+            # failure (a successful update misread as {"ok": false}).
+            if git pull --ff-only >/dev/null 2>&1; then
                 # Restore local config changes
                 CONFIG_RESET=0
                 if [ "$STASHED" -eq 1 ]; then
-                    if ! git stash pop --quiet 2>/dev/null; then
-                        # Conflict — drop the stash and warn (config can be re-set)
-                        git checkout -- . 2>/dev/null || true
-                        git stash drop --quiet 2>/dev/null || true
+                    if ! git stash pop --quiet >/dev/null 2>&1; then
+                        # Conflict applying local config onto the freshly pulled
+                        # tree. Reset the worktree to a clean post-pull state so the
+                        # gateway stays functional, but DO NOT `git stash drop` — the
+                        # local config (container_ip, etc.) stays recoverable via
+                        # `git stash list`. Dropping it here silently destroyed the
+                        # operator's config (the bug this fixes). Stashes may
+                        # accumulate across repeated conflicts — that is benign and
+                        # recoverable, unlike silent loss.
+                        git reset --hard --quiet HEAD >/dev/null 2>&1 || git checkout -- . >/dev/null 2>&1 || true
                         CONFIG_RESET=1
                     fi
                 fi
@@ -212,12 +223,12 @@ with open(sf, "w") as f:
     json.dump(d, f, indent=2)
 PYEOF
                 if [ "$CONFIG_RESET" -eq 1 ]; then
-                    printf '{"ok": true, "action": "update", "old": "%s", "new": "%s", "warning": "local config changes were discarded due to merge conflict — re-run install_guardian.sh to regenerate"}\n' "$OLD" "$NEW"
+                    printf '{"ok": true, "action": "update", "old": "%s", "new": "%s", "warning": "local config changes conflicted with the update and were preserved in git stash (recover with: git stash list); or re-run install_guardian.sh to regenerate"}\n' "$OLD" "$NEW"
                 else
                     printf '{"ok": true, "action": "update", "old": "%s", "new": "%s"}\n' "$OLD" "$NEW"
                 fi
             else
-                [ "$STASHED" -eq 1 ] && git stash pop --quiet 2>/dev/null || true
+                [ "$STASHED" -eq 1 ] && git stash pop --quiet >/dev/null 2>&1 || true
                 printf '{"ok": false, "action": "update", "error": "git pull failed"}\n' >&2
                 exit 1
             fi

--- a/tests/test_scripts/test_guardian_gateway_update.py
+++ b/tests/test_scripts/test_guardian_gateway_update.py
@@ -232,6 +232,82 @@ def test_update_writes_deployed_commit(stub_bin, tmp_path):
     assert json.loads(ds.read_text())["deployed_commit"] == _short_head(install)
 
 
+def test_update_conflict_preserves_local_config_in_stash(stub_bin, tmp_path):
+    """On a `git stash pop` CONFLICT, the operator's local config must be PRESERVED
+    in the stash (recoverable), NOT silently `git stash drop`ped.
+
+    The bug: when a local config change (e.g. container_ip) conflicts with an
+    upstream change to the same line, `update` used to `git checkout -- .` +
+    `git stash drop`, destroying the local config. The fix resets the worktree to a
+    clean post-pull state (gateway stays functional) but keeps the stash, and the
+    JSON reports a *recoverable* warning.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    install = _seed_repo(home)
+
+    # Local uncommitted config change in the install dir → becomes the stash.
+    (install / "config" / "guardian.yaml").write_text(
+        'container_name: genesis\ncontainer_ip: "LOCAL-ONLY-VALUE"\n')
+
+    # Upstream changes the SAME line differently → `git stash pop` will conflict.
+    pusher2 = home / "pusher2"
+    _git("clone", "-q", str(home / "remote.git"), str(pusher2), cwd=home)
+    _git("config", "user.email", "t@t.t", cwd=pusher2)
+    _git("config", "user.name", "t", cwd=pusher2)
+    (pusher2 / "config" / "guardian.yaml").write_text(
+        'container_name: genesis\ncontainer_ip: "UPSTREAM-VALUE"\n')
+    _git("commit", "-aqm", "upstream guardian.yaml change", cwd=pusher2)
+    _git("push", "-q", "origin", "main", cwd=pusher2)
+
+    proc = _run_update(home, stub_bin)
+
+    # update still succeeds and reports the *recoverable* (not discarded) warning.
+    # The ENTIRE stdout must parse as JSON even on this path — a conflicted
+    # `git stash pop` is the noisiest case, so this is the strongest JSON-purity guard.
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    data = json.loads(proc.stdout)
+    assert data["ok"] is True, data
+    assert "preserved in git stash" in data["warning"], (
+        f"conflict warning must say the config is recoverable, not discarded:\n{data}")
+
+    # The stash was NOT dropped — the operator's local config is recoverable.
+    stash_list = subprocess.run(["git", "stash", "list"], cwd=str(install),
+                                capture_output=True, text=True).stdout
+    assert stash_list.strip(), "stash was dropped — local config silently lost (the bug)"
+    stash_show = subprocess.run(["git", "stash", "show", "-p"], cwd=str(install),
+                                capture_output=True, text=True).stdout
+    assert "LOCAL-ONLY-VALUE" in stash_show, (
+        f"stash does not contain the operator's local config value:\n{stash_show}")
+
+    # guardian.yaml is reset cleanly to the upstream state — no leftover conflict
+    # markers (the gateway worktree stays functional for the next pull).
+    gy = (install / "config" / "guardian.yaml").read_text()
+    assert "<<<<<<<" not in gy and "UPSTREAM-VALUE" in gy, (
+        f"guardian.yaml left in conflict / not reset to upstream:\n{gy!r}")
+
+
+def test_update_response_is_pure_json(stub_bin, tmp_path):
+    """The `update` verb's stdout contract is JSON-ONLY: the container
+    (`remote.py`) parses the whole stdout with `json.loads`. A real-change pull
+    emits git's diffstat ("Updating.. / Fast-forward / <stats>") to STDOUT; if that
+    leaks before the JSON, `json.loads` throws and a SUCCESSFUL update is misread as
+    {"ok": false}. Every git command in the verb must suppress stdout so the
+    response stays pure JSON.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    _seed_repo(home)  # upstream advances CLAUDE.md → `git pull` produces a diffstat
+
+    proc = _run_update(home, stub_bin)
+
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    # The ENTIRE stdout must be valid JSON — no git diffstat/chatter prefix.
+    data = json.loads(proc.stdout)  # raises if polluted → guards the contract
+    assert data["ok"] is True, data
+    assert data["action"] == "update", data
+
+
 def test_sync_gateway_redeploys_from_install_dir(stub_bin, tmp_path):
     """`sync-gateway` copies the install-dir gateway to ~/.local/bin WITHOUT a
     pull — the recovery lever when the update self-update path is unavailable."""


### PR DESCRIPTION
## What

Two defects in the host Guardian's `update` verb (`scripts/guardian-gateway.sh`), both fixed:

1. **Silent local-config loss on stash-pop conflict.** When `update` pulls new code and the operator's local config (e.g. the container IP) conflicts with an upstream change to the same lines, the old code did `git checkout -- .` + `git stash drop` — silently destroying the local changes. It now resets the worktree to a clean post-pull state but **keeps the stash**, so the config is recoverable via `git stash list`. The success-JSON warning is reworded from "discarded" to "preserved in git stash (recoverable)".

2. **JSON response polluted by git stdout.** The verb's contract is "JSON on stdout only" — the container parses the whole stdout with `json.loads` (`src/genesis/guardian/remote.py:155`). But `git pull` / `git stash pop` write their diffstat / conflict chatter to **stdout**, so a successful update that pulled changes was misread as `{"ok": false}`. Every git command in the verb now redirects stdout to `/dev/null`; the response is pure JSON. (Latent today — no automated caller of `remote.update()` — but a real correctness defect in the deploy path, and it also hardens the conflict path above.)

## Tests

- `test_update_conflict_preserves_local_config_in_stash` — induces a real pop conflict; asserts the stash is kept + contains the local value, the worktree is reset clean (no conflict markers), and the full stdout parses as JSON carrying a recoverable warning.
- `test_update_response_is_pure_json` — a real-change pull whose entire stdout must `json.loads`.
- Both RED-proven against the old behavior; all 9 gateway tests green; shellcheck + `bash -n` clean.

## Review

Codex (first per protocol) was quota-exhausted → Claude code-reviewer: **P1 None, P2 None**; one P3 (the conflict-path test should assert `json.loads`, not a substring, to prove JSON-purity on the noisiest path) — applied.
