### PR TITLE
feat(backup): include memory/config/secrets in off-site snapshot (A2a)

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -369,6 +369,49 @@ else
         fi
     done
 
+    # Upload memory / config overlays / secrets — previously git-Tier-1 only. Including
+    # them here makes the off-site snapshot a COMPLETE copy, so a no-git fresh-box DR can
+    # rehydrate everything (restore.sh §4/§6/§7 read them from the pulled snapshot). Memory
+    # is flat (MEMORY_DIR has no subdirs); config overlays ship as-is (plaintext, mirroring
+    # the existing Tier-1 + private-repo posture); secrets is the encrypted blob. A failed
+    # upload of a present file flips _T2_OK so COMPLETE is gated on these landing too.
+    backend_mkdir "${_T2_DIR}/memory"
+    for f in memory/*.gpg; do
+        [ -f "$f" ] || continue
+        fname=$(basename "$f")
+        if backend_put "$f" "${_T2_DIR}/memory/$fname"; then
+            log "  off-site: uploaded memory/$fname"
+        else
+            log "WARNING: off-site upload failed for memory/$fname"
+            _T2_OK=false
+        fi
+    done
+
+    backend_mkdir "${_T2_DIR}/config_overrides"
+    for f in config_overrides/*.local.yaml; do
+        [ -f "$f" ] || continue
+        fname=$(basename "$f")
+        if backend_put "$f" "${_T2_DIR}/config_overrides/$fname"; then
+            log "  off-site: uploaded config_overrides/$fname"
+        else
+            log "WARNING: off-site upload failed for config_overrides/$fname"
+            _T2_OK=false
+        fi
+    done
+
+    # Secrets is best-effort: a MISSING payload (no passphrase → no .gpg) is not an
+    # off-site failure (that path already fails the backup via _SQLITE_LINES=0); only a
+    # failed upload of a PRESENT payload flips _T2_OK.
+    if [ -f secrets/secrets.env.gpg ]; then
+        backend_mkdir "${_T2_DIR}/secrets"
+        if backend_put "secrets/secrets.env.gpg" "${_T2_DIR}/secrets/secrets.env.gpg"; then
+            log "  off-site: uploaded secrets/secrets.env.gpg"
+        else
+            log "WARNING: off-site upload failed for secrets/secrets.env.gpg"
+            _T2_OK=false
+        fi
+    fi
+
     # Mark the snapshot COMPLETE only when every upload succeeded, so restore never
     # picks a half-uploaded snapshot (it selects the latest COMPLETE one). If the
     # marker itself fails to upload, the snapshot is unusable for restore — treat

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -258,6 +258,30 @@ _pull_from_offsite() {
             fi
         done || true
     done
+
+    # memory / config overlays / secrets — previously only in the Tier-1 git clone. Pull
+    # them from the snapshot too so a no-git fresh box can rehydrate them (the §4/§6/§7
+    # restore sections read from these BACKUP_DIR subdirs). memory is flat; config overlays
+    # are plaintext .local.yaml; secrets is the encrypted blob. Staging dirs are created
+    # only when there's something to pull (mirrors the qdrant/transcripts loop above).
+    backend_list "$snap/memory" | grep -oE '[A-Za-z0-9._-]+\.gpg' | sort -u | while read -r fname; do
+        mkdir -p "$BACKUP_DIR/memory"
+        if backend_get "$snap/memory/$fname" "$BACKUP_DIR/memory/$fname"; then
+            log "  off-site: pulled memory/$fname"
+        fi
+    done || true
+    backend_list "$snap/config_overrides" | grep -oE '[A-Za-z0-9._-]+\.local\.yaml' | sort -u | while read -r fname; do
+        mkdir -p "$BACKUP_DIR/config_overrides"
+        if backend_get "$snap/config_overrides/$fname" "$BACKUP_DIR/config_overrides/$fname"; then
+            log "  off-site: pulled config_overrides/$fname"
+        fi
+    done || true
+    if backend_exists "$snap/secrets/secrets.env.gpg"; then
+        mkdir -p "$BACKUP_DIR/secrets"
+        if backend_get "$snap/secrets/secrets.env.gpg" "$BACKUP_DIR/secrets/secrets.env.gpg"; then
+            log "  off-site: pulled secrets/secrets.env.gpg"
+        fi
+    fi
 }
 _pull_from_offsite
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -263,23 +263,34 @@ _pull_from_offsite() {
     # them from the snapshot too so a no-git fresh box can rehydrate them (the §4/§6/§7
     # restore sections read from these BACKUP_DIR subdirs). memory is flat; config overlays
     # are plaintext .local.yaml; secrets is the encrypted blob. Staging dirs are created
-    # only when there's something to pull (mirrors the qdrant/transcripts loop above).
-    backend_list "$snap/memory" | grep -oE '[A-Za-z0-9._-]+\.gpg' | sort -u | while read -r fname; do
+    # only when there's something to pull.
+    #
+    # Process substitution (not a `… | while`) is deliberate: a failed pull of these
+    # payloads is the silent DR footgun this PR exists to prevent, so a failed get must
+    # `warn` (→ _FAILURES → non-zero restore). A pipe-into-while runs the body in a
+    # SUBSHELL where _FAILURES appends are lost; `done < <(…)` runs it in THIS shell.
+    while read -r fname; do
         mkdir -p "$BACKUP_DIR/memory"
         if backend_get "$snap/memory/$fname" "$BACKUP_DIR/memory/$fname"; then
             log "  off-site: pulled memory/$fname"
+        else
+            warn "off-site: failed to pull memory/$fname from snapshot $latest"
         fi
-    done || true
-    backend_list "$snap/config_overrides" | grep -oE '[A-Za-z0-9._-]+\.local\.yaml' | sort -u | while read -r fname; do
+    done < <(backend_list "$snap/memory" | grep -oE '[A-Za-z0-9._-]+\.gpg' | sort -u)
+    while read -r fname; do
         mkdir -p "$BACKUP_DIR/config_overrides"
         if backend_get "$snap/config_overrides/$fname" "$BACKUP_DIR/config_overrides/$fname"; then
             log "  off-site: pulled config_overrides/$fname"
+        else
+            warn "off-site: failed to pull config_overrides/$fname from snapshot $latest"
         fi
-    done || true
+    done < <(backend_list "$snap/config_overrides" | grep -oE '[A-Za-z0-9._-]+\.local\.yaml' | sort -u)
     if backend_exists "$snap/secrets/secrets.env.gpg"; then
         mkdir -p "$BACKUP_DIR/secrets"
         if backend_get "$snap/secrets/secrets.env.gpg" "$BACKUP_DIR/secrets/secrets.env.gpg"; then
             log "  off-site: pulled secrets/secrets.env.gpg"
+        else
+            warn "off-site: failed to pull secrets.env.gpg from snapshot $latest — secrets will not be restored"
         fi
     fi
 }

--- a/tests/test_scripts/test_backup_dated_snapshots.py
+++ b/tests/test_scripts/test_backup_dated_snapshots.py
@@ -40,6 +40,15 @@ def backup_env(tmp_path):
     subprocess.run(["sqlite3", str(gd / "data" / "genesis.db"),
                     "CREATE TABLE t(x); INSERT INTO t VALUES(1);"],
                    check=True, capture_output=True)
+    # A2a inputs: auto-memory (flat), a config overlay, and a secrets file — so the
+    # off-site snapshot can include them alongside data/qdrant/transcripts.
+    cc_id = str(gd).replace("/", "-")
+    mem_dir = home / ".claude" / "projects" / cc_id / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "note.md").write_text("remembered\n")
+    (gd / "config").mkdir(parents=True)
+    (gd / "config" / "sample.local.yaml").write_text("key: val\n")
+    (gd / "secrets.env").write_text("FOO=bar\n")  # sourced by backup.sh; innocuous
     bare = tmp_path / "remote.git"
     _git("init", "-q", "--bare", str(bare), cwd=tmp_path)
     _git("symbolic-ref", "HEAD", "refs/heads/main", cwd=bare)
@@ -157,3 +166,31 @@ def test_local_backend_writes_dated_snapshot_to_real_fs(backup_env, tmp_path):
     status = json.loads((backup_env["home"] / ".genesis" / "backup_status.json").read_text())
     assert status["tier2_status"] == "ok", status
     assert status["offsite_confirmed"] is True, status
+
+
+def test_local_backend_snapshot_includes_memory_config_secrets(backup_env, tmp_path):
+    """A2a: the off-site snapshot must ALSO contain memory/, config_overrides/, and
+    secrets/ (previously git-Tier-1 only), so the destination is a COMPLETE copy and a
+    no-git fresh-box DR works. Real `local` backend, real fs."""
+    offsite = tmp_path / "offsite"
+    offsite.mkdir()
+    proc = _run_local(backup_env, offsite)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+    host_dirs = list((offsite / "Genesis").iterdir())
+    assert len(host_dirs) == 1, f"expected one host dir, got {[d.name for d in host_dirs]}"
+    snaps = [d for d in host_dirs[0].iterdir() if _STAMP_RE.fullmatch(d.name)]
+    assert len(snaps) == 1, f"expected one dated snapshot, got {[d.name for d in snaps]}"
+    snap = snaps[0]
+
+    # memory: at least one flat .gpg under the snapshot's memory/.
+    mem_gpgs = list((snap / "memory").glob("*.gpg")) if (snap / "memory").is_dir() else []
+    assert mem_gpgs, f"no memory/*.gpg in the off-site snapshot: {[d.name for d in snap.iterdir()]}"
+    # config_overrides: the overlay shipped as-is (plaintext, mirrors Tier-1).
+    assert (snap / "config_overrides" / "sample.local.yaml").is_file(), \
+        f"config overlay missing from off-site snapshot: {[d.name for d in snap.iterdir()]}"
+    # secrets: the encrypted secrets payload.
+    assert (snap / "secrets" / "secrets.env.gpg").is_file(), \
+        f"secrets payload missing from off-site snapshot: {[d.name for d in snap.iterdir()]}"
+    # COMPLETE still written (and only because all three landed too).
+    assert (snap / "COMPLETE").is_file(), "COMPLETE marker not written"

--- a/tests/test_scripts/test_restore_offsite_pull.py
+++ b/tests/test_scripts/test_restore_offsite_pull.py
@@ -53,15 +53,37 @@ def sandbox(tmp_path):
                     "--passphrase", "testpass", "--symmetric", "--cipher-algo", "AES256",
                     "-o", str(dump_gpg), str(sql)], check=True, capture_output=True)
 
+    def _enc(text: str, name: str) -> Path:
+        plain = tmp_path / f"{name}.plain"
+        plain.write_text(text)
+        out = tmp_path / name
+        subprocess.run(["gpg", "--batch", "--yes", "--homedir", str(home / ".gnupg"),
+                        "--passphrase", "testpass", "--symmetric", "--cipher-algo", "AES256",
+                        "-o", str(out), str(plain)], check=True, capture_output=True)
+        return out
+
+    # A2a extra payloads: memory + secrets encrypted, config plaintext.
+    mem_gpg = _enc("remembered\n", "note.md.gpg")
+    sec_gpg = _enc("SECRET=xyz\n", "secrets.env.gpg")
+
     return {"home": home, "gd": gd, "backup": backup, "offsite": offsite,
-            "bind": bind, "dump_gpg": dump_gpg}
+            "bind": bind, "dump_gpg": dump_gpg, "mem_gpg": mem_gpg, "sec_gpg": sec_gpg}
 
 
-def _snapshot(sandbox, host: str, stamp: str, *, complete: bool = True) -> None:
+def _snapshot(sandbox, host: str, stamp: str, *, complete: bool = True,
+              with_extras: bool = False) -> None:
     """Create an off-site dated snapshot on the real filesystem."""
     snap = sandbox["offsite"] / "Genesis" / host / stamp
     (snap / "data").mkdir(parents=True)
     (snap / "data" / "genesis.sql.gpg").write_bytes(sandbox["dump_gpg"].read_bytes())
+    if with_extras:
+        # A2a: memory/ (flat .gpg), config_overrides/ (plaintext yaml), secrets/ (encrypted).
+        (snap / "memory").mkdir()
+        (snap / "memory" / "note.md.gpg").write_bytes(sandbox["mem_gpg"].read_bytes())
+        (snap / "config_overrides").mkdir()
+        (snap / "config_overrides" / "sample.local.yaml").write_text("key: val\n")
+        (snap / "secrets").mkdir()
+        (snap / "secrets" / "secrets.env.gpg").write_bytes(sandbox["sec_gpg"].read_bytes())
     if complete:
         (snap / "COMPLETE").write_text("")
 
@@ -162,3 +184,24 @@ def test_no_backend_configured_skips_pull(sandbox):
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     # nothing pulled → restore finds no SQL payload
     assert "no backup payload" in proc.stdout.lower() or _db_value(sandbox) != "99"
+
+
+def test_pulls_and_rehydrates_memory_config_secrets(sandbox):
+    """A2a: on a no-git fresh box, restore must pull memory/config/secrets from the
+    off-site snapshot (not just data/qdrant/transcripts) and rehydrate them — so DR
+    works without the Tier-1 git clone."""
+    _snapshot(sandbox, "sourcebox", _NEW, with_extras=True)
+    proc = _run(sandbox, host_override="sourcebox")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+    cc_id = str(sandbox["gd"]).replace("/", "-")
+    mem_file = sandbox["home"] / ".claude" / "projects" / cc_id / "memory" / "note.md"
+    assert mem_file.is_file() and mem_file.read_text() == "remembered\n", \
+        f"memory not rehydrated from off-site:\n{proc.stdout}"
+    cfg_file = sandbox["gd"] / "config" / "sample.local.yaml"
+    assert cfg_file.is_file() and cfg_file.read_text() == "key: val\n", \
+        f"config overlay not rehydrated from off-site:\n{proc.stdout}"
+    sec_file = sandbox["gd"] / "secrets.env"
+    assert sec_file.is_file() and sec_file.read_text() == "SECRET=xyz\n", \
+        f"secrets not rehydrated from off-site:\n{proc.stdout}"
+    assert oct(sec_file.stat().st_mode)[-3:] == "600", "secrets not chmod 0600"

--- a/tests/test_scripts/test_restore_offsite_pull.py
+++ b/tests/test_scripts/test_restore_offsite_pull.py
@@ -205,3 +205,20 @@ def test_pulls_and_rehydrates_memory_config_secrets(sandbox):
     assert sec_file.is_file() and sec_file.read_text() == "SECRET=xyz\n", \
         f"secrets not rehydrated from off-site:\n{proc.stdout}"
     assert oct(sec_file.stat().st_mode)[-3:] == "600", "secrets not chmod 0600"
+
+
+def test_failed_memory_pull_warns_and_fails(sandbox):
+    """A failed off-site pull of a memory payload must WARN (→ non-zero restore), not be
+    silent — silent DR data-loss is the footgun this PR exists to prevent. The pull loop
+    runs in this shell (process substitution), so warn's _FAILURES append survives. We
+    force a get failure by staging the 'file' as a directory (the local backend's `cp`
+    without -r fails on a directory)."""
+    snap = sandbox["offsite"] / "Genesis" / "sourcebox" / _NEW
+    (snap / "data").mkdir(parents=True)
+    (snap / "data" / "genesis.sql.gpg").write_bytes(sandbox["dump_gpg"].read_bytes())
+    (snap / "memory" / "note.md.gpg").mkdir(parents=True)  # a dir → backend_get (cp) fails
+    (snap / "COMPLETE").write_text("")
+    proc = _run(sandbox, host_override="sourcebox")
+    assert proc.returncode != 0, f"failed memory pull must fail the restore:\n{proc.stdout}"
+    assert "failed to pull memory/note.md.gpg" in proc.stdout, \
+        f"failed memory pull was silent (no warn):\n{proc.stdout}"


### PR DESCRIPTION
## What & why

The off-site backup snapshot held only `data/` (SQLite), `qdrant/`, and `transcripts/`. Auto-memory, config overlays, and secrets went to the **git Tier-1** backup *only*. A no-git fresh-box disaster recovery (Tier-1 repo unreachable) therefore could not rehydrate memory or API keys — the off-site copy wasn't actually complete.

This makes the dated off-site snapshot a **complete copy** so a destination-only restore works.

## What changed

- **`backup.sh`** — after the data/qdrant/transcripts uploads (and before the `COMPLETE` gate), also upload:
  - `memory/*.gpg` (flat — the memory dir has no subdirs)
  - `config_overrides/*.local.yaml` (plaintext, mirroring the existing Tier-1 posture)
  - `secrets/secrets.env.gpg` (encrypted blob)
  - A failed upload of a *present* payload flips `_T2_OK`, so `COMPLETE` is gated on these landing too. A *missing* secrets payload (no passphrase) is best-effort and does not fail the snapshot.
- **`restore.sh`** — `_pull_from_offsite` now also pulls those three subdirs into the staging dir, so the existing memory/config/secrets restore sections work without the git clone. Failed pulls `warn` (→ non-zero restore) rather than failing silently.
- **No behaviour change to the git-data push** — this is the additive, no-gap step; retiring the git-data push is a later staged change.
- **No `backup_status.json` field or value-string changes** (dashboard/health contract untouched).

## Testing

- TDD (RED→GREEN). Extended the real-filesystem `local`-backend anchors: backup writes memory/config/secrets into the snapshot + `COMPLETE`; restore rehydrates them from an empty (no-git) source via real GPG decrypt; plus a regression test that a failed pull warns and fails the restore.
- `tests/test_scripts/` — 87 passed. `bash -n` + `shellcheck -S warning` clean.

## Review

Adversarial review via the Claude code-reviewer agent (Codex CLI quota-limited this cycle). It confirmed pipefail safety, `COMPLETE` gating, smb mkdir-before-put ordering, source paths, and the unchanged status contract. It found two observability gaps (silent failed pulls) — both fixed: failed pulls now `warn`, and the loops use process substitution so the warn registers in the parent shell.

No user-visible change yet, so no CHANGELOG entry.