### PR TITLE
fix(backup): mirror dotfiles to off-site snapshot (find, not shell glob)

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -375,9 +375,13 @@ else
     # is flat (MEMORY_DIR has no subdirs); config overlays ship as-is (plaintext, mirroring
     # the existing Tier-1 + private-repo posture); secrets is the encrypted blob. A failed
     # upload of a present file flips _T2_OK so COMPLETE is gated on these landing too.
+    #
+    # Enumerate with `find` (not a `*.gpg` shell glob): §4/§6 stage these via `find`, which
+    # includes DOTFILES (e.g. a transient .consolidate-lock), so a glob would silently drop
+    # leading-dot names and leave the off-site copy short of Tier-1. Process substitution
+    # (not `find | while`) keeps the loop in THIS shell so the _T2_OK flip survives.
     backend_mkdir "${_T2_DIR}/memory"
-    for f in memory/*.gpg; do
-        [ -f "$f" ] || continue
+    while IFS= read -r -d '' f; do
         fname=$(basename "$f")
         if backend_put "$f" "${_T2_DIR}/memory/$fname"; then
             log "  off-site: uploaded memory/$fname"
@@ -385,11 +389,10 @@ else
             log "WARNING: off-site upload failed for memory/$fname"
             _T2_OK=false
         fi
-    done
+    done < <(find memory -maxdepth 1 -type f -name '*.gpg' -print0 2>/dev/null)
 
     backend_mkdir "${_T2_DIR}/config_overrides"
-    for f in config_overrides/*.local.yaml; do
-        [ -f "$f" ] || continue
+    while IFS= read -r -d '' f; do
         fname=$(basename "$f")
         if backend_put "$f" "${_T2_DIR}/config_overrides/$fname"; then
             log "  off-site: uploaded config_overrides/$fname"
@@ -397,7 +400,7 @@ else
             log "WARNING: off-site upload failed for config_overrides/$fname"
             _T2_OK=false
         fi
-    done
+    done < <(find config_overrides -maxdepth 1 -type f -name '*.local.yaml' -print0 2>/dev/null)
 
     # Secrets is best-effort: a MISSING payload (no passphrase → no .gpg) is not an
     # off-site failure (that path already fails the backup via _SQLITE_LINES=0); only a

--- a/tests/test_scripts/test_backup_dated_snapshots.py
+++ b/tests/test_scripts/test_backup_dated_snapshots.py
@@ -46,6 +46,9 @@ def backup_env(tmp_path):
     mem_dir = home / ".claude" / "projects" / cc_id / "memory"
     mem_dir.mkdir(parents=True)
     (mem_dir / "note.md").write_text("remembered\n")
+    # A dotfile (e.g. a transient consolidate lock) — §4 stages it via `find`, so the
+    # off-site upload must mirror it too (a shell glob would silently skip leading-dot names).
+    (mem_dir / ".consolidate-lock").write_text("12345\n")
     (gd / "config").mkdir(parents=True)
     (gd / "config" / "sample.local.yaml").write_text("key: val\n")
     (gd / "secrets.env").write_text("FOO=bar\n")  # sourced by backup.sh; innocuous
@@ -194,3 +197,20 @@ def test_local_backend_snapshot_includes_memory_config_secrets(backup_env, tmp_p
         f"secrets payload missing from off-site snapshot: {[d.name for d in snap.iterdir()]}"
     # COMPLETE still written (and only because all three landed too).
     assert (snap / "COMPLETE").is_file(), "COMPLETE marker not written"
+
+
+def test_offsite_memory_includes_dotfiles(backup_env, tmp_path):
+    """The off-site memory upload must include DOTFILES (e.g. .consolidate-lock.gpg) so the
+    snapshot is a faithful mirror of Tier-1 (§4 stages dotfiles via `find`). A shell glob
+    `memory/*.gpg` silently skips leading-dot names; the upload must enumerate like §4."""
+    offsite = tmp_path / "offsite"
+    offsite.mkdir()
+    proc = _run_local(backup_env, offsite)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    host = next((offsite / "Genesis").iterdir())
+    snaps = [d for d in host.iterdir() if _STAMP_RE.fullmatch(d.name)]
+    assert len(snaps) == 1, [d.name for d in snaps]
+    mem = snaps[0] / "memory"
+    assert (mem / ".consolidate-lock.gpg").is_file(), \
+        f"dotfile dropped from off-site memory mirror: {sorted(p.name for p in mem.iterdir())}"
+    assert (mem / "note.md.gpg").is_file()  # regular file still mirrored (no regression)


### PR DESCRIPTION
## What & why

Follow-up to #678. The off-site memory/config upload enumerated with a `*.gpg` **shell glob**, which silently skips files beginning with `.`. Tier-1 staging (backup.sh §4/§6) enumerates with `find`, which **includes** dotfiles — so the off-site snapshot diverged from the Tier-1 copy by exactly the dotfiles. In practice a transient `.consolidate-lock.gpg` was dropped (300 files staged to Tier-1, 299 reached the off-site snapshot — caught during the live-NAS E2E).

Harmless today (the git Tier-1 backup still has it), but it breaks the "off-site is a *complete* copy" contract and would silently lose files once the git-data push is retired in a later step.

## Fix

- `backup.sh` — enumerate the memory and config_overrides off-site uploads with `find -maxdepth 1 -type f … -print0` + `while … read -d ''`, mirroring exactly how §4/§6 stage them (dotfiles included). Process substitution (not `find | while`) keeps the loop in the parent shell so the `_T2_OK` failure flip still gates the `COMPLETE` marker.
- Restore needs no change: it already lists dotfiles (`ls -1A` / smb) and the filename grep class matches leading dots, so the round-trip is symmetric.

## Testing

- TDD: a new regression test stages a dotfile (`.consolidate-lock`) in the memory dir and asserts `.consolidate-lock.gpg` reaches the off-site snapshot — RED on the glob, GREEN with `find`.
- `tests/test_scripts/` — 88 passed. `bash -n` + `shellcheck -S warning` clean.

## Review

Claude code-reviewer agent (Codex quota-limited this cycle): clean across all six dimensions (parent-shell `_T2_OK`, NUL-safe iteration, safe removal of the `[ -f ]` glob guard, correct `$BACKUP_DIR`-relative paths, no `set -e` abort, correct dotfile basename).

No CHANGELOG (no user-visible change).