### PR TITLE
feat(observability): ambient capture health monitor + Telegram alert

### DIFF
--- a/src/genesis/observability/ambient_health.py
+++ b/src/genesis/observability/ambient_health.py
@@ -1,0 +1,174 @@
+"""Ambient-capture health monitor — read the edge bridge's health file + evaluate.
+
+The ambient bridge runs on a separate edge VM and writes ``ambient_health.json``
+every 60s. This module SSH-reads that file (connection in
+``~/.genesis/ambient_remote.yaml``, mirroring ``guardian_remote.yaml``) and turns
+a snapshot into an alert verdict. ``OutreachScheduler._ambient_health_job`` runs
+the read + evaluate on a cadence and alerts the user on a bad-state transition.
+
+No config file -> the monitor is a silent no-op, so installs without an ambient
+edge are unaffected. The edge host/IP lives ONLY in the install-local config,
+never in committed source.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_PATH = Path("~/.genesis/ambient_remote.yaml").expanduser()
+_DEFAULT_HEALTH_PATH = "~/ambient_health.json"
+_DEFAULT_KEY = "~/.ssh/id_ed25519"
+
+# A health snapshot whose heartbeat ``ts`` is older than this means the bridge
+# process is dead/hung (the bridge rewrites the file every 60s).
+_HEARTBEAT_STALE_S = 300.0
+_SSH_TIMEOUT_S = 10.0
+
+
+@dataclass(frozen=True)
+class AmbientRemoteConfig:
+    host_ip: str
+    host_user: str
+    ssh_key: str = _DEFAULT_KEY
+    health_path: str = _DEFAULT_HEALTH_PATH
+
+
+def load_ambient_remote_config() -> AmbientRemoteConfig | None:
+    """Load ``~/.genesis/ambient_remote.yaml``; return None if absent, disabled,
+    or invalid (monitor then no-ops). Never raises."""
+    if not _CONFIG_PATH.exists():
+        return None
+    try:
+        import yaml
+
+        data = yaml.safe_load(_CONFIG_PATH.read_text()) or {}
+        if not data.get("enabled", True):
+            return None
+        host_ip = data.get("host_ip")
+        host_user = data.get("host_user")
+        if not host_ip or not host_user:
+            logger.warning("ambient_remote.yaml missing host_ip/host_user — monitor disabled")
+            return None
+        return AmbientRemoteConfig(
+            host_ip=str(host_ip),
+            host_user=str(host_user),
+            ssh_key=str(data.get("ssh_key", _DEFAULT_KEY)),
+            health_path=str(data.get("health_path", _DEFAULT_HEALTH_PATH)),
+        )
+    except Exception:
+        logger.warning("Failed to load ambient_remote.yaml — monitor disabled", exc_info=True)
+        return None
+
+
+async def read_edge_health(cfg: AmbientRemoteConfig) -> dict | None:
+    """SSH-read the edge ``ambient_health.json``. Returns the parsed dict, or None
+    on any failure (unreachable / missing / bad JSON). Mirrors
+    ``GuardianRemote._ssh_command`` (BatchMode + ConnectTimeout + orphan-kill)."""
+    key = str(Path(cfg.ssh_key).expanduser())
+    cmd = [
+        "ssh", "-i", key,
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", f"ConnectTimeout={int(_SSH_TIMEOUT_S)}",
+        "-o", "BatchMode=yes",
+        f"{cfg.host_user}@{cfg.host_ip}",
+        f"cat {cfg.health_path}",
+    ]
+    proc = None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(), timeout=_SSH_TIMEOUT_S + 5,
+        )
+        if proc.returncode != 0:
+            logger.warning(
+                "ambient health read failed (rc=%s): %s",
+                proc.returncode, stderr.decode().strip()[:200],
+            )
+            return None
+        return json.loads(stdout.decode())
+    except TimeoutError:
+        if proc is not None:
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
+        logger.warning("ambient health SSH read timed out (%s@%s)", cfg.host_user, cfg.host_ip)
+        return None
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        logger.warning("ambient health read error: %s", exc)
+        return None
+
+
+@dataclass(frozen=True)
+class AmbientVerdict:
+    status: str  # "ok" | "degraded" | "down" | "unknown"
+    reasons: list[str]
+
+
+def _parse_ts(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+def evaluate_ambient_health(
+    data: dict | None, *, now: datetime | None = None,
+) -> AmbientVerdict:
+    """Turn an ``ambient_health.json`` snapshot into a verdict. Pure + testable.
+
+    - ``data is None`` (read failed / edge unreachable) -> ``unknown`` (transient;
+      the caller should not flip alert state on a single unknown).
+    - heartbeat ``ts`` missing or older than ``_HEARTBEAT_STALE_S`` -> ``down``
+      (bridge process dead/hung).
+    - ``active_connections == 0`` -> ``down`` (device disconnected; ``0`` is a
+      reliable negative).
+    - ``diar_worker_alive`` False while ``diar_enabled`` -> ``degraded``.
+    - otherwise -> ``ok``.
+
+    Deliberately does NOT consider ``last_ts`` (last captured utterance): a quiet
+    room naturally has an old ``last_ts``, which is not a fault.
+    """
+    if data is None:
+        return AmbientVerdict("unknown", ["edge health unreachable / unreadable"])
+
+    now = now or datetime.now(UTC)
+    reasons: list[str] = []
+    status = "ok"
+
+    ts = _parse_ts(data.get("ts"))
+    if ts is None:
+        reasons.append("health file has no/invalid heartbeat ts")
+        status = "down"
+    else:
+        age = (now - ts).total_seconds()
+        if age > _HEARTBEAT_STALE_S:
+            reasons.append(
+                f"heartbeat stale ({age:.0f}s > {_HEARTBEAT_STALE_S:.0f}s) — bridge dead/hung",
+            )
+            status = "down"
+
+    if data.get("active_connections", 0) == 0:
+        reasons.append("device not connected (active_connections=0)")
+        status = "down"
+
+    if data.get("diar_enabled") and not data.get("diar_worker_alive", False):
+        reasons.append("diarization worker not alive")
+        if status == "ok":
+            status = "degraded"
+
+    if status == "ok":
+        reasons.append("healthy")
+    return AmbientVerdict(status, reasons)

--- a/src/genesis/outreach/governance.py
+++ b/src/genesis/outreach/governance.py
@@ -42,6 +42,7 @@ _DEDUP_WINDOWS: dict[str, int] = {
     "surplus_opportunity": 24,
     "content_review": 1,  # Short window — distinct content pieces may share topics
     "cli_approval": 0,  # Never dedup — every approval request must be delivered
+    "ambient_health": 0,  # Never dedup — the monitor's state machine gates re-alerts/recovery
     "ego_notification": 12,  # Ego notifications — don't repeat same topic within 12h
     "mail_reply": 1,  # Email replies — short window to allow ack + full response
     "mail_follow_up": 24,  # Follow-up emails — one per day max per topic

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -61,6 +61,10 @@ class OutreachScheduler:
         # fallback when the DB query fails (e.g., lock contention).
         self._cached_critical_obs: list[dict] = []
         self._cached_critical_obs_at: float = 0.0  # monotonic time of cache
+        # Ambient-capture health — last-known status (state-change dedup) and
+        # last-alert time (hourly re-alert of a persistent bad state).
+        self._ambient_health_status: str = "ok"
+        self._ambient_health_last_alert: float = 0.0  # monotonic time
 
     @property
     def is_running(self) -> bool:
@@ -129,6 +133,15 @@ class OutreachScheduler:
             "interval",
             minutes=5,
             id="outreach_critical_observations",
+            replace_existing=True,
+        )
+        # Ambient capture health — alert if the edge ambient bridge goes dark.
+        # No-op when ~/.genesis/ambient_remote.yaml is absent (other installs).
+        self._scheduler.add_job(
+            self._ambient_health_job,
+            "interval",
+            minutes=10,
+            id="outreach_ambient_health",
             replace_existing=True,
         )
         self._scheduler.start()
@@ -477,6 +490,75 @@ class OutreachScheduler:
         except Exception as exc:
             logger.exception("Critical observations outreach job failed")
             await self._record_job_result("critical_observations", error=str(exc))
+
+    async def _ambient_health_job(self) -> None:
+        """Alert when the edge ambient-capture bridge goes dark.
+
+        SSH-reads the edge health file, evaluates it, and alerts the user
+        (Telegram) on a transition into a bad state, with a recovery note when it
+        comes back. No-op if ~/.genesis/ambient_remote.yaml is not configured.
+        Runs even when paused (observability, not a dispatch). A single "unknown"
+        (transient SSH failure) does not flip the alert state.
+        """
+        try:
+            import time
+
+            from genesis.observability.ambient_health import (
+                evaluate_ambient_health,
+                load_ambient_remote_config,
+                read_edge_health,
+            )
+
+            cfg = load_ambient_remote_config()
+            if cfg is None:
+                return  # no ambient edge on this install — silent no-op
+
+            verdict = evaluate_ambient_health(await read_edge_health(cfg))
+            prev = self._ambient_health_status
+            now_mono = time.monotonic()
+            _REALERT_S = 60 * 60  # re-alert a persistent bad state at most hourly
+
+            if verdict.status in ("down", "degraded"):
+                entered_bad = prev not in ("down", "degraded")
+                if entered_bad or (now_mono - self._ambient_health_last_alert) > _REALERT_S:
+                    emoji = "\U0001f534" if verdict.status == "down" else "\U0001f7e1"
+                    text = (
+                        f"{emoji} Ambient capture {verdict.status.upper()}\n"
+                        + "\n".join(f"• {r}" for r in verdict.reasons)
+                        + "\n\n(toggle Ambient Mode off→on to reconnect the device)"
+                    )
+                    envelope = OutreachRequest(
+                        category=OutreachCategory.BLOCKER,
+                        topic="Ambient Capture Health",
+                        context=text,
+                        salience_score=1.0,
+                        signal_type="ambient_health",
+                        source_id=f"ambient_health:{verdict.status}",
+                    )
+                    result = await self._pipeline.submit_raw(text, envelope)
+                    logger.info("Ambient health alert (%s): %s", verdict.status, result.status.value)
+                    self._ambient_health_last_alert = now_mono
+                self._ambient_health_status = verdict.status
+            elif verdict.status == "ok":
+                if prev in ("down", "degraded"):
+                    text = "\U0001f7e2 Ambient capture recovered (healthy)."
+                    envelope = OutreachRequest(
+                        category=OutreachCategory.BLOCKER,
+                        topic="Ambient Capture Health",
+                        context=text,
+                        salience_score=0.7,
+                        signal_type="ambient_health",
+                        source_id="ambient_health:ok",
+                    )
+                    await self._pipeline.submit_raw(text, envelope)
+                    logger.info("Ambient health recovered")
+                self._ambient_health_status = "ok"
+            # status == "unknown": transient — leave _ambient_health_status as-is
+
+            await self._record_job_result("ambient_health")
+        except Exception as exc:
+            logger.exception("Ambient health monitor job failed")
+            await self._record_job_result("ambient_health", error=str(exc))
 
     async def _calibration_job(self) -> None:
         """Reconcile predictions and recompute calibration curves."""

--- a/tests/test_observability/test_ambient_health.py
+++ b/tests/test_observability/test_ambient_health.py
@@ -1,0 +1,64 @@
+"""Unit tests for the pure ambient-health evaluator.
+
+Covers the alert-decision logic (the testable core); the SSH read + scheduler
+wiring are verified on-device (they need the edge + a running scheduler).
+"""
+from datetime import UTC, datetime, timedelta
+
+from genesis.observability.ambient_health import evaluate_ambient_health
+
+NOW = datetime(2026, 6, 18, 12, 0, 0, tzinfo=UTC)
+
+
+def _snapshot(**overrides) -> dict:
+    base = {
+        "ts": NOW.isoformat(),
+        "active_connections": 1,
+        "diar_enabled": True,
+        "diar_worker_alive": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_healthy_snapshot_is_ok():
+    assert evaluate_ambient_health(_snapshot(), now=NOW).status == "ok"
+
+
+def test_none_data_is_unknown():
+    # Transient SSH failure must not be reported as a hard "down".
+    assert evaluate_ambient_health(None, now=NOW).status == "unknown"
+
+
+def test_stale_heartbeat_is_down():
+    stale = (NOW - timedelta(minutes=10)).isoformat()
+    verdict = evaluate_ambient_health(_snapshot(ts=stale), now=NOW)
+    assert verdict.status == "down"
+    assert any("stale" in r for r in verdict.reasons)
+
+
+def test_missing_ts_is_down():
+    assert evaluate_ambient_health(_snapshot(ts=None), now=NOW).status == "down"
+
+
+def test_no_connection_is_down():
+    verdict = evaluate_ambient_health(_snapshot(active_connections=0), now=NOW)
+    assert verdict.status == "down"
+    assert any("not connected" in r for r in verdict.reasons)
+
+
+def test_dead_diar_worker_is_degraded():
+    verdict = evaluate_ambient_health(_snapshot(diar_worker_alive=False), now=NOW)
+    assert verdict.status == "degraded"
+
+
+def test_quiet_room_old_last_ts_is_still_ok():
+    # No recent utterance (quiet room) must NOT be treated as a fault.
+    old = (NOW - timedelta(hours=3)).isoformat()
+    assert evaluate_ambient_health(_snapshot(last_ts=old), now=NOW).status == "ok"
+
+
+def test_diar_disabled_does_not_degrade():
+    # If diarization is off, a False worker flag is irrelevant.
+    snap = _snapshot(diar_enabled=False, diar_worker_alive=False)
+    assert evaluate_ambient_health(snap, now=NOW).status == "ok"


### PR DESCRIPTION
## What
A Genesis-side monitor that alerts the user (Telegram) when the edge ambient-capture bridge goes dark — the companion to the bridge-side ping fix that just landed.

A periodic `OutreachScheduler` job (every 10 min) SSH-reads the edge bridge's `ambient_health.json` and evaluates it:
- **heartbeat `ts` stale (>5 min)** → bridge process dead/hung
- **`active_connections == 0`** → device disconnected (a reliable negative)
- **`diar_worker_alive` false while enabled** → degraded

It alerts **once per state transition** (with a recovery note when it comes back), and re-alerts a persistent outage at most hourly. A quiet room (old `last_ts`, i.e. no recent utterance) is deliberately **not** treated as a fault.

## Design notes
- The edge host/connection lives ONLY in an install-local `~/.genesis/ambient_remote.yaml` (mirroring `guardian_remote.yaml`); **no host/IP in committed source**. The monitor is a **silent no-op** where that file is absent, so other installs are unaffected.
- The SSH read mirrors `GuardianRemote._ssh_command` (BatchMode, ConnectTimeout, orphan-kill on timeout). Read-only (`cat`).
- `ambient_health` signals are added to the governance no-dedup list (like `cli_approval`) so the monitor's own state machine is the sole dedup authority — otherwise the 24h default dedup would swallow the recovery note + hourly re-alerts.
- Alert delivery reuses `OutreachPipeline.submit_raw` + `OutreachRequest(category=BLOCKER)`, matching the existing `_critical_observations_job`.

## Verification
- ruff clean; 8 unit tests for the pure evaluator (pass).
- Live data-flow run: real config → SSH-read the real edge → correct `ok` verdict.
- Independent code review (pass-with-notes; the recovery-dedup finding fixed).
- On-device E2E (job scheduled + fires; deliberate down→alert) confirmed on deploy.

Companion follow-up: device-side firmware ambient auto-reconnect (defense-in-depth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
