### PR TITLE
fix(backup): route large temp files to ~/tmp, not cc-tmp/RAM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,16 @@ reflection) → Services (routing, memory, outreach, autonomy, surplus) → Data
 - **Env scrub**: `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1` is NOT used — Genesis
   hooks and MCP servers require inherited API keys (DeepInfra, Qwen, etc.).
 - **Setup**: `./scripts/bootstrap.sh` (venv, config, services, memory)
-- **Temp files**: `~/tmp/` for transient downloads (media, audio, exports).
-  NEVER use `/tmp/` — it shares the root filesystem and competes with all
-  CC sessions.  Clean up after use.
+- **Temp files**: `~/tmp/` for transient files and any LARGE temp (downloads,
+  media, DB dumps, exports). NEVER write large files to `/tmp/` (a small
+  tmpfs/RAM) or `~/.genesis/cc-tmp/` — the latter is Claude Code's working temp
+  ("oxygen"), policed by the `genesis-tmp-watchgod` service, which **kills CC
+  sessions** when it fills. A CC session's `TMPDIR` points at `cc-tmp` by design;
+  do NOT override `TMPDIR` in scripts or service files (breaks CC — see the
+  `tmp_filesystem_limit` procedure). Code that creates large temp must pass an
+  explicit dir (`mktemp -p ~/tmp` / `tempfile(dir=…)`), never the default. For a
+  heavy one-off you run interactively, prefix `TMPDIR=~/tmp/job <cmd>`. Clean up
+  after use.
 
 ## Process Management
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -87,6 +87,16 @@ _send_telegram() {
         > /dev/null 2>&1 || log "WARNING: Telegram alert failed to send"
 }
 
+# Large intermediate files (the multi-hundred-MB SQLite .dump) must NOT land in the
+# inherited TMPDIR: for a CC-launched run that is ~/.genesis/cc-tmp (the watchgod-policed
+# "oxygen" folder — filling it kills CC sessions); for the 6h cron it is /tmp (tmpfs/RAM).
+# Route them to a dedicated on-disk dir, per the tmp_filesystem_limit procedure ("use ~/tmp
+# for large temporary files"). We do NOT export TMPDIR — only the big files move; everything
+# else (and Claude Code) keeps its normal TMPDIR.
+GENESIS_BIG_TMP="${GENESIS_BACKUP_TMPDIR:-$HOME/tmp}"
+mkdir -p "$GENESIS_BIG_TMP"
+log "big-temp dir: $GENESIS_BIG_TMP"
+
 # ── Encryption helpers ───────────────────────────────────────────────
 # All PII-bearing payloads (SQLite dump, transcripts, memory) use the
 # same GPG symmetric passphrase as secrets. If the passphrase is unset,
@@ -147,7 +157,7 @@ if [ -f "$DB_FILE" ]; then
     if ! $_ENCRYPT_READY; then
         log "WARNING: GENESIS_BACKUP_PASSPHRASE not set — skipping SQLite backup (refusing plaintext)"
     else
-        _SQL_TMP=$(mktemp)
+        _SQL_TMP=$(mktemp -p "$GENESIS_BIG_TMP")  # ~269MB dump — keep off cc-tmp/RAM
         if sqlite3 "$DB_FILE" .dump > "$_SQL_TMP" 2>/dev/null; then
             _SQLITE_LINES=$(wc -l < "$_SQL_TMP")
             if encrypt_file "$_SQL_TMP" data/genesis.sql.gpg; then

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -97,6 +97,14 @@ log()  { echo "$LOG_PREFIX $(date -Iseconds) $*"; }
 warn() { log "WARNING: $*"; _FAILURES+=("$*"); }
 die()  { log "FATAL: $*"; _FAILURES+=("$*"); exit 1; }
 
+# Large intermediate files (the ~269MB decrypted SQLite .dump, decrypted Qdrant snapshots)
+# must NOT land in the inherited TMPDIR (cc-tmp = the watchgod "oxygen" folder for a CC run;
+# /tmp tmpfs/RAM otherwise). Route them to a dedicated on-disk dir per the tmp_filesystem_limit
+# procedure. NOT an `export TMPDIR` — only the big files move.
+GENESIS_BIG_TMP="${GENESIS_BACKUP_TMPDIR:-$HOME/tmp}"
+mkdir -p "$GENESIS_BIG_TMP"
+log "big-temp dir: $GENESIS_BIG_TMP"
+
 # Quiesce the live writer before swapping the SQLite DB — a live WAL connection
 # would corrupt the restore. Guarded for fresh-box DR (no systemctl / no unit /
 # no user session → no-op). Intentionally does NOT restart: the operator
@@ -322,7 +330,7 @@ if resolve_payload "$BACKUP_DIR/data/genesis.sql"; then
             log "SQLite: would restore from $src → $DB_FILE"
         elif confirm "Restore SQLite from $(basename "$src") into $DB_FILE?"; then
             mkdir -p "$(dirname "$DB_FILE")"
-            _SQL_TMP=$(mktemp)
+            _SQL_TMP=$(mktemp -p "$GENESIS_BIG_TMP")  # ~269MB dump — keep off cc-tmp/RAM
             if $__PAYLOAD_NEEDS_DECRYPT; then
                 decrypt_file "$src" "$_SQL_TMP" || { warn "SQLite decrypt failed"; rm -f "$_SQL_TMP"; }
             else
@@ -421,7 +429,7 @@ if [ -d "$BACKUP_DIR/data/qdrant" ]; then
                     warn "Qdrant: '$coll' is encrypted but GENESIS_BACKUP_PASSPHRASE unset — skipping"
                     continue
                 fi
-                _QDRANT_TMP=$(mktemp --suffix=.snapshot)
+                _QDRANT_TMP=$(mktemp -p "$GENESIS_BIG_TMP" --suffix=.snapshot)  # large — keep off cc-tmp/RAM
                 if ! decrypt_file "$snap" "$_QDRANT_TMP"; then
                     warn "Qdrant: decrypt failed for '$coll'"
                     rm -f "$_QDRANT_TMP"

--- a/tests/test_scripts/test_backup_dated_snapshots.py
+++ b/tests/test_scripts/test_backup_dated_snapshots.py
@@ -214,3 +214,32 @@ def test_offsite_memory_includes_dotfiles(backup_env, tmp_path):
     assert (mem / ".consolidate-lock.gpg").is_file(), \
         f"dotfile dropped from off-site memory mirror: {sorted(p.name for p in mem.iterdir())}"
     assert (mem / "note.md.gpg").is_file()  # regular file still mirrored (no regression)
+
+
+def test_large_temp_goes_to_dedicated_dir_not_inherited_tmpdir(backup_env, tmp_path):
+    """The big SQLite .dump must be created in a dedicated dir (GENESIS_BACKUP_TMPDIR,
+    default ~/tmp) — NOT the inherited TMPDIR, which in a CC session is the watchgod-
+    policed ~/.genesis/cc-tmp 'oxygen' folder. Regression for the 2026-06-18 incident:
+    a 269MB dump via bare `mktemp` filled cc-tmp and the watchgod killed CC sessions.
+    The seeded `tmp_filesystem_limit` procedure already mandates ~/tmp for large temp."""
+    offsite = tmp_path / "offsite"; offsite.mkdir()
+    cctmp = tmp_path / "cc-tmp-sentinel"; cctmp.mkdir()      # stand-in for the oxygen folder
+    bigtmp = tmp_path / "dedicated-big-tmp"; bigtmp.mkdir()
+    env = dict(os.environ)
+    env.update(
+        HOME=str(backup_env["home"]), GENESIS_DIR=str(backup_env["gd"]),
+        GENESIS_BACKUP_PASSPHRASE="testpass", QDRANT_URL="http://127.0.0.1:1",
+        GENESIS_BACKUP_TIER2_BACKEND="local", GENESIS_BACKUP_LOCAL_PATH=str(offsite),
+        TMPDIR=str(cctmp),                  # inherited — MUST NOT be used for the big dump
+        GENESIS_BACKUP_TMPDIR=str(bigtmp),  # the dedicated dir the dump MUST use
+        PATH=f'{backup_env["bind"]}:{os.environ["PATH"]}',
+    )
+    for k in ("GENESIS_BACKUP_NAS", "GENESIS_BACKUP_NAS_USER", "GENESIS_BACKUP_NAS_PASS",
+              "TELEGRAM_BOT_TOKEN", "TELEGRAM_FORUM_CHAT_ID"):
+        env.pop(k, None)
+    proc = subprocess.run(["bash", str(_BACKUP)], env=env, capture_output=True,
+                          text=True, stdin=subprocess.DEVNULL)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    # The script announces where large temp goes; it must be the dedicated dir, not cc-tmp.
+    assert f"big-temp dir: {bigtmp}" in proc.stdout, (
+        f"backup did not route large temp to the dedicated dir (expected {bigtmp}):\n{proc.stdout}")

--- a/tests/test_scripts/test_backup_dated_snapshots.py
+++ b/tests/test_scripts/test_backup_dated_snapshots.py
@@ -222,9 +222,12 @@ def test_large_temp_goes_to_dedicated_dir_not_inherited_tmpdir(backup_env, tmp_p
     policed ~/.genesis/cc-tmp 'oxygen' folder. Regression for the 2026-06-18 incident:
     a 269MB dump via bare `mktemp` filled cc-tmp and the watchgod killed CC sessions.
     The seeded `tmp_filesystem_limit` procedure already mandates ~/tmp for large temp."""
-    offsite = tmp_path / "offsite"; offsite.mkdir()
-    cctmp = tmp_path / "cc-tmp-sentinel"; cctmp.mkdir()      # stand-in for the oxygen folder
-    bigtmp = tmp_path / "dedicated-big-tmp"; bigtmp.mkdir()
+    offsite = tmp_path / "offsite"
+    offsite.mkdir()
+    cctmp = tmp_path / "cc-tmp-sentinel"   # stand-in for the watchgod "oxygen" folder
+    cctmp.mkdir()
+    bigtmp = tmp_path / "dedicated-big-tmp"
+    bigtmp.mkdir()
     env = dict(os.environ)
     env.update(
         HOME=str(backup_env["home"]), GENESIS_DIR=str(backup_env["gd"]),


### PR DESCRIPTION
## What & why

`backup.sh` and `restore.sh` created their **large** intermediate files — a ~269MB SQLite `.dump` and decrypted Qdrant snapshots — via bare `mktemp`, which inherits `TMPDIR`. That has two bad failure modes:

- **From a Claude Code session**, `TMPDIR` points at `~/.genesis/cc-tmp` — a 500MB budget-policed working-temp folder watched by `genesis-tmp-watchgod`, which **kills idle CC sessions** when it fills. A single 269MB dump is >half the budget; running backups/restores from a session filled it and the watchdog reaped detached terminals.
- **From the 6h cron**, bare `mktemp` lands in `/tmp`, which is **tmpfs (RAM)** — a recurring ~269MB RAM spike.

An existing seeded procedure (`tmp_filesystem_limit`) already mandates "use `~/tmp/` for large temporary files" and "never override `TMPDIR` in scripts/service files." The code just wasn't following it.

## Fix (surgical — does not touch `TMPDIR`)

Route **only the large** `mktemp` calls to a dedicated on-disk dir via `mktemp -p`:
- `GENESIS_BIG_TMP="${GENESIS_BACKUP_TMPDIR:-$HOME/tmp}"` (created with `mkdir -p`, logged).
- `backup.sh`: the SQL dump. `restore.sh`: the SQL dump + the Qdrant snapshot decrypt.
- `TMPDIR` is **not** exported/overridden — Claude Code and all other temp keep their normal location, honoring the procedure and CC's documented `TMPDIR`/`CLAUDE_CODE_TMPDIR` coupling. Tiny temp (COMPLETE marker, SMB creds) stays as-is.

Also strengthens the `CLAUDE.md` "Temp files" rule to name `cc-tmp` explicitly (it previously warned only about `/tmp`).

## Testing

- New regression test: runs `backup.sh` with `TMPDIR`=a cc-tmp stand-in + `GENESIS_BACKUP_TMPDIR`=a dedicated dir, asserts the large dump routes to the dedicated dir (RED before the fix, GREEN after).
- `tests/test_scripts/` (backup + restore files): 15 passed. `bash -n` + `shellcheck -S warning` clean.

## Review

Claude code-reviewer agent (Codex quota-limited this cycle): **clean** — verified variable ordering (after secrets sourcing), GNU `mktemp -p … --suffix` validity, `set -e`/EXIT-trap coverage, that `GENESIS_BIG_TMP` is not exported, absolute-path safety across `cd`, and no remaining large bare `mktemp`.

Follow-ups (separate PRs): runtime Python large-producers (yt-dlp/STT/pr_opener) pass explicit `dir=`; instrument `tmp_watchgod` to log measured size + top consumers. No CHANGELOG (no user-visible behavior change).