### PR TITLE
fix(runtime): route large runtime temp to ~/tmp, not cc-tmp

### DIFF
--- a/src/genesis/channels/stt.py
+++ b/src/genesis/channels/stt.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import httpx
 
+from genesis.util.tmp import big_tmp_dir
+
 log = logging.getLogger(__name__)
 
 _GROQ_STT_URL = "https://api.groq.com/openai/v1/audio/transcriptions"
@@ -24,7 +26,7 @@ async def transcribe(audio_bytes: bytes, model_name: str = "whisper-large-v3") -
         return ""
 
     # Write to temp file — Groq API needs a file upload
-    with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
+    with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False, dir=big_tmp_dir()) as f:
         f.write(audio_bytes)
         tmp_path = f.name
 

--- a/src/genesis/contribution/pr_opener.py
+++ b/src/genesis/contribution/pr_opener.py
@@ -37,6 +37,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from genesis.util.tmp import big_tmp_dir
+
 from .findings import (
     InstallInfo,
     ReviewResult,
@@ -382,7 +384,7 @@ def _prepare_and_push_branch(
         cwd=str(repo_path), timeout=10, check=False,
     )
 
-    wt_dir = Path(tempfile.mkdtemp(prefix="genesis-contrib-"))
+    wt_dir = Path(tempfile.mkdtemp(prefix="genesis-contrib-", dir=big_tmp_dir()))
     worktree_added = False
     try:
         # 1. detached worktree at upstream HEAD

--- a/src/genesis/eval/promptfoo.py
+++ b/src/genesis/eval/promptfoo.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 import yaml
 
+from genesis.util.tmp import big_tmp_dir
+
 logger = logging.getLogger(__name__)
 
 
@@ -62,7 +64,7 @@ async def compare_models(
     # Build promptfoo config
     config = _build_promptfoo_config(model_a, model_b, dataset_path, delay_ms)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory(dir=big_tmp_dir()) as tmpdir:
         config_path = Path(tmpdir) / "promptfoo.yaml"
         output_path = Path(tmpdir) / "output.json"
         config_path.write_text(yaml.dump(config, default_flow_style=False))

--- a/src/genesis/knowledge/processors/youtube.py
+++ b/src/genesis/knowledge/processors/youtube.py
@@ -9,6 +9,7 @@ import re
 import shutil
 
 from genesis.knowledge.processors.base import ProcessedContent
+from genesis.util.tmp import big_tmp_dir
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +105,7 @@ class YouTubeProcessor:
         """Download subtitles to a temp dir and read them."""
         import tempfile
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(dir=big_tmp_dir()) as tmpdir:
             proc = await asyncio.create_subprocess_exec(
                 "yt-dlp",
                 "--write-auto-subs",
@@ -131,7 +132,7 @@ class YouTubeProcessor:
         from pathlib import Path
 
         try:
-            with tempfile.TemporaryDirectory() as tmpdir:
+            with tempfile.TemporaryDirectory(dir=big_tmp_dir()) as tmpdir:
                 out_path = f"{tmpdir}/audio.mp3"
                 proc = await asyncio.create_subprocess_exec(
                     "yt-dlp",

--- a/src/genesis/util/tmp.py
+++ b/src/genesis/util/tmp.py
@@ -1,0 +1,31 @@
+"""Dedicated on-disk location for LARGE temporary files.
+
+Genesis routes its working temp (Claude Code's sandbox, the genesis-server systemd
+unit, etc.) to ``~/.genesis/cc-tmp`` via ``TMPDIR`` — a small, budget-policed folder
+the ``genesis-tmp-watchgod`` service cleans and, when it fills, reclaims by **killing
+idle CC sessions**. So code that produces a LARGE temp file (audio/video downloads,
+git worktrees, eval artifacts, DB dumps) must NOT use the default temp dir — it would
+land in cc-tmp (or, off the unit, ``/tmp`` which is tmpfs/RAM).
+
+Per the ``tmp_filesystem_limit`` procedure, large temp goes to ``~/tmp`` — an on-disk
+dir that is not watchgod-budgeted. Pass :func:`big_tmp_dir` as the ``dir=`` argument to
+``tempfile.NamedTemporaryFile`` / ``mkdtemp`` / ``TemporaryDirectory``. Do NOT override
+the process ``TMPDIR`` to achieve this — that breaks Claude Code (it assumes
+``TMPDIR``/``CLAUDE_CODE_TMPDIR`` consistency) and violates the procedure.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def big_tmp_dir() -> str:
+    """Return a dedicated on-disk dir for large temp files, creating it if missing.
+
+    Honors the ``GENESIS_BIG_TMP`` env override (else ``~/tmp``). Returns a ``str``
+    so it can be passed directly as the ``dir=`` argument of ``tempfile`` helpers.
+    """
+    target = os.environ.get("GENESIS_BIG_TMP") or str(Path.home() / "tmp")
+    Path(target).mkdir(parents=True, exist_ok=True)
+    return target

--- a/tests/test_util/test_tmp.py
+++ b/tests/test_util/test_tmp.py
@@ -1,0 +1,37 @@
+"""Tests for genesis.util.tmp.big_tmp_dir — the dedicated large-temp directory.
+
+Large runtime producers (yt-dlp audio, STT uploads, git worktrees, eval artifacts)
+must keep their temp OFF ~/.genesis/cc-tmp (the watchgod-policed 'oxygen' folder) by
+passing dir=big_tmp_dir(). These verify the helper resolves + creates the right dir
+and that tempfile actually honors it.
+"""
+
+import tempfile
+from pathlib import Path
+
+from genesis.util.tmp import big_tmp_dir
+
+
+def test_default_is_home_tmp_and_is_created(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("GENESIS_BIG_TMP", raising=False)
+    d = big_tmp_dir()
+    assert d == str(tmp_path / "tmp")
+    assert Path(d).is_dir(), "big_tmp_dir must create the directory"
+
+
+def test_honors_env_override(tmp_path, monkeypatch):
+    override = tmp_path / "custom-big-tmp"
+    monkeypatch.setenv("GENESIS_BIG_TMP", str(override))
+    d = big_tmp_dir()
+    assert d == str(override)
+    assert Path(d).is_dir()
+
+
+def test_tempfile_lands_under_big_tmp_dir(tmp_path, monkeypatch):
+    """A NamedTemporaryFile created with dir=big_tmp_dir() lives under it — the exact
+    mechanism the runtime large-producers use to keep temp off cc-tmp."""
+    monkeypatch.setenv("GENESIS_BIG_TMP", str(tmp_path / "big"))
+    d = big_tmp_dir()
+    with tempfile.NamedTemporaryFile(dir=d, suffix=".x") as f:
+        assert Path(f.name).parent == Path(d)


### PR DESCRIPTION
## What & why

Follow-up to #681 (the bash side). The `genesis-server` systemd unit sets `TMPDIR=~/.genesis/cc-tmp` — the budget-policed working-temp folder the `genesis-tmp-watchgod` service reclaims by **killing idle CC sessions** when it fills. Runtime code that creates a **large** temp file via the default temp location lands it there, so the runtime can fill the oxygen folder and take out CC sessions (the runtime side of the 2026-06-18 incident class).

## Fix

New helper `genesis.util.tmp.big_tmp_dir()` — returns `~/tmp` (honors `GENESIS_BIG_TMP`, creates it), mirroring the `util/atomic.py` pattern. Passed as `dir=` at the confirmed large producers:
- `knowledge/processors/youtube.py` — yt-dlp audio download (and subtitle temp) `TemporaryDirectory`
- `channels/stt.py` — Groq audio-upload `NamedTemporaryFile`
- `contribution/pr_opener.py` — git-worktree-scratch `mkdtemp`
- `eval/promptfoo.py` — eval-artifacts `TemporaryDirectory`

`TMPDIR` is **not** overridden — only these explicit calls move — honoring the `tmp_filesystem_limit` procedure and Claude Code's documented `TMPDIR`/`CLAUDE_CODE_TMPDIR` coupling. (For yt-dlp, the download target is `{tmpdir}/...`, so `dir=` on the `TemporaryDirectory` does steer the download location.)

## Testing

- New `tests/test_util/test_tmp.py` (3): default `~/tmp`, `GENESIS_BIG_TMP` override, and a `NamedTemporaryFile(dir=big_tmp_dir())` lands under it.
- `tests/test_contribution/test_pr_opener.py` (27) pass — exercises the changed `mkdtemp`.
- All 5 modules import cleanly (no circular import); ruff clean.

## Review

Claude code-reviewer agent (Codex quota-limited): **clean** — verified `dir=` validity per call, no circular import, `big_tmp_dir` scope in youtube's locally-`import tempfile` methods, stt cleanup keys on `f.name`/`finally` (unaffected), empty-string env fallback, and no behavior change beyond temp location.

**Takes effect on the next `genesis-server` restart** (a code change to the running service). No CHANGELOG (no user-visible behavior change).