### PR TITLE
feat(watchgod): log cc-tmp pressure + top consumers for diagnosability

### DIFF
--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -195,12 +195,18 @@ _log_cc_pressure() {
     local stamp snap top
     stamp=$(date -u +%Y%m%dT%H%M%SZ)
     snap="$(dirname "$LOG_FILE")/cc_tmp_top_${stamp}.txt"
-    top=$(du -sm "$CC_TMP_DIR"/* 2>/dev/null | sort -rn | head -8)
+    # `|| true` inside the substitution: an empty cc-tmp (e.g. the sacred-ground RED path,
+    # disk-full but cc-tmp empty) makes the glob literal → du fails → set -e would abort the
+    # whole daemon. Tolerate it; `top` is just empty then.
+    top=$(du -sm "$CC_TMP_DIR"/* 2>/dev/null | sort -rn | head -8 || true)
     {
         echo "# cc-tmp pressure ${stamp}  tier=${tier} used=${used}MB free=${free}MB budget=${CC_TMP_BUDGET_MB}MB"
         echo "$top"
     } > "$snap" 2>/dev/null || true
     log WARN "cc-tmp ${tier^^}: used=${used}MB free=${free}MB budget=${CC_TMP_BUDGET_MB}MB — top consumers → ${snap}"
+    # Bound the snapshot count — a sustained ORANGE/RED episode would otherwise accumulate
+    # these unbounded on the very filesystem we're protecting. Keep the 20 most recent.
+    ls -1t "$(dirname "$LOG_FILE")"/cc_tmp_top_*.txt 2>/dev/null | tail -n +21 | xargs -r rm -f 2>/dev/null || true
 }
 
 check_cc_tmp() {

--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -171,10 +171,13 @@ clean_cc_red() {
     find "$CC_TMP_DIR" -type d \( -name "claude-skills" -o -name "tsx-*" \) \
         -exec rm -rf {} + 2>/dev/null || true
 
-    # Kill ALL idle CC sessions
+    # Kill ALL idle CC sessions (log each — so it's clear which terminals were reaped)
     while IFS= read -r sname; do
         [[ -z "$sname" ]] && continue
-        [[ "$sname" =~ ^cc- ]] && tmux kill-session -t "$sname" 2>/dev/null || true
+        if [[ "$sname" =~ ^cc- ]]; then
+            log WARN "RED killing idle CC session: $sname"
+            tmux kill-session -t "$sname" 2>/dev/null || true
+        fi
     done < <(tmux list-sessions -F '#{session_name}:#{session_attached}' 2>/dev/null \
              | grep ':0$' | cut -d: -f1 || true)
 
@@ -182,6 +185,22 @@ clean_cc_red() {
     mkdir -p "$ALERT_DIR"
     touch "$ALERT_DIR/tmp_emergency"
     log WARN "Zone A RED — nuclear cleanup complete"
+}
+
+# Record cc-tmp pressure + top consumers BEFORE a cleanup runs — so a filled-folder
+# incident is diagnosable afterward (the nuclear cleanup erases the evidence otherwise).
+# The snapshot goes under the log dir (NOT cc-tmp), so it survives the cleanup.
+_log_cc_pressure() {
+    local tier="$1" used="$2" free="$3"
+    local stamp snap top
+    stamp=$(date -u +%Y%m%dT%H%M%SZ)
+    snap="$(dirname "$LOG_FILE")/cc_tmp_top_${stamp}.txt"
+    top=$(du -sm "$CC_TMP_DIR"/* 2>/dev/null | sort -rn | head -8)
+    {
+        echo "# cc-tmp pressure ${stamp}  tier=${tier} used=${used}MB free=${free}MB budget=${CC_TMP_BUDGET_MB}MB"
+        echo "$top"
+    } > "$snap" 2>/dev/null || true
+    log WARN "cc-tmp ${tier^^}: used=${used}MB free=${free}MB budget=${CC_TMP_BUDGET_MB}MB — top consumers → ${snap}"
 }
 
 check_cc_tmp() {
@@ -199,12 +218,15 @@ check_cc_tmp() {
 
     if (( used_mb > threshold_red )) || (( free_mb < SACRED_GROUND_MB )); then
         tier="red"
+        _log_cc_pressure red "$used_mb" "$free_mb"   # capture BEFORE the nuclear cleanup erases it
         clean_cc_red
     elif (( used_mb > threshold_orange )); then
         tier="orange"
+        _log_cc_pressure orange "$used_mb" "$free_mb"
         clean_cc_orange
     elif (( used_mb > threshold_yellow )); then
         tier="yellow"
+        log INFO "cc-tmp YELLOW: used=${used_mb}MB free=${free_mb}MB budget=${CC_TMP_BUDGET_MB}MB"
         clean_cc_yellow
     fi
 
@@ -309,4 +331,8 @@ main() {
     done
 }
 
-main "$@"
+# Run the poll loop only when executed directly — sourcing (e.g. from tests) loads the
+# functions without starting the daemon.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/test_scripts/test_watchgod_instrumentation.py
+++ b/tests/test_scripts/test_watchgod_instrumentation.py
@@ -1,0 +1,73 @@
+"""tmp_watchgod instrumentation — pressure logging + top-consumers snapshot.
+
+Before this, the watchgod logged only the tier name, so a filled-cc-tmp incident
+couldn't be diagnosed once the nuclear cleanup erased the evidence. These verify
+`_log_cc_pressure` writes a persisted top-consumers snapshot (under the log dir, which
+survives the cleanup) + a measured log line, and that `check_cc_tmp` invokes it at RED
+BEFORE cleaning up.
+
+tmux is STUBBED to a no-op so the cleanup's kill-idle-sessions loop can never touch a
+real CC session during the test (it would otherwise reap unattached cc-* tmux sessions).
+The script's new sourcing guard lets us load its functions without starting the daemon.
+"""
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+_WATCHGOD = Path(__file__).resolve().parents[2] / "scripts" / "tmp_watchgod.sh"
+
+
+def _make_stub(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _sandbox(tmp_path):
+    home = tmp_path / "home"
+    (home / ".genesis" / "logs").mkdir(parents=True)
+    cctmp = home / ".genesis" / "cc-tmp"   # the script's default CC_TMP_DIR under HOME
+    cctmp.mkdir(parents=True)
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    # Bulletproof: tmux returns NOTHING for list-sessions, so the kill loop has no input
+    # and never reaps a real session; any tmux call is a harmless exit-0 no-op.
+    _make_stub(bind / "tmux", "#!/usr/bin/env bash\nexit 0\n")
+    return home, cctmp, bind
+
+
+def _run(home, bind, snippet):
+    env = dict(os.environ)
+    env.update(HOME=str(home), PATH=f"{bind}:{os.environ['PATH']}")
+    return subprocess.run(
+        ["bash", "-c", f"source '{_WATCHGOD}'\n{snippet}"],
+        env=env, capture_output=True, text=True, stdin=subprocess.DEVNULL,
+    )
+
+
+def test_log_cc_pressure_writes_snapshot_and_logline(tmp_path):
+    home, cctmp, bind = _sandbox(tmp_path)
+    (cctmp / "big.bin").write_bytes(b"x" * (3 * 1024 * 1024))  # a 3MB consumer
+    proc = _run(home, bind, "_log_cc_pressure red 460 120")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    logs = home / ".genesis" / "logs"
+    snaps = list(logs.glob("cc_tmp_top_*.txt"))
+    assert snaps, "no persisted top-consumers snapshot written"
+    body = snaps[0].read_text()
+    assert "tier=red used=460MB free=120MB" in body, body
+    assert "big.bin" in body, f"top consumers not captured:\n{body}"
+    logtext = (logs / "tmp_watchgod.log").read_text()
+    assert "cc-tmp RED: used=460MB free=120MB" in logtext, logtext
+
+
+def test_check_cc_tmp_red_logs_pressure_before_cleanup(tmp_path):
+    """check_cc_tmp at RED records pressure BEFORE the nuclear cleanup erases it."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    (cctmp / "big.bin").write_bytes(b"x" * (5 * 1024 * 1024))  # 5MB
+    # budget=4 → RED threshold 3MB; 5MB used → RED. sacred=1 so disk-free never trips it.
+    out = _run(home, bind, "CC_TMP_BUDGET_MB=4; SACRED_GROUND_MB=1; check_cc_tmp")
+    assert out.returncode == 0, f"{out.stdout}\n{out.stderr}"
+    assert out.stdout.strip().startswith("red:"), out.stdout
+    snaps = list((home / ".genesis" / "logs").glob("cc_tmp_top_*.txt"))
+    assert snaps, "RED did not write a pressure snapshot before cleanup"

--- a/tests/test_scripts/test_watchgod_instrumentation.py
+++ b/tests/test_scripts/test_watchgod_instrumentation.py
@@ -71,3 +71,16 @@ def test_check_cc_tmp_red_logs_pressure_before_cleanup(tmp_path):
     assert out.stdout.strip().startswith("red:"), out.stdout
     snaps = list((home / ".genesis" / "logs").glob("cc_tmp_top_*.txt"))
     assert snaps, "RED did not write a pressure snapshot before cleanup"
+
+
+def test_pressure_snapshots_are_bounded(tmp_path):
+    """A sustained ORANGE/RED episode must not accumulate snapshots unbounded — the
+    helper keeps only the most recent ~20 so it can't fill the fs it's protecting."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    logs = home / ".genesis" / "logs"
+    for i in range(25):  # pre-seed 25 stale snapshots
+        (logs / f"cc_tmp_top_20260101T0000{i:02d}Z.txt").write_text("old")
+    proc = _run(home, bind, "_log_cc_pressure orange 400 200")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    remaining = list(logs.glob("cc_tmp_top_*.txt"))
+    assert len(remaining) <= 20, f"snapshots not bounded: {len(remaining)} remain"


### PR DESCRIPTION
## What & why

Final piece of the temp-hygiene remediation (after #681, #682). When `~/.genesis/cc-tmp` filled (2026-06-18 incident), `tmp_watchgod` **correctly** reclaimed it by killing idle CC sessions — but it logged only the *tier name*, and the nuclear cleanup erased the evidence, so it was impossible to see *what* had filled the folder after the fact.

## Change (observability only — cleanup/kill thresholds & logic unchanged)

- `_log_cc_pressure()`: on ORANGE/RED, **before** cleanup, log measured `used/free/budget` and write a persisted top-8-consumers snapshot to `~/.genesis/logs/cc_tmp_top_<stamp>.txt` (under the log dir, so it survives the nuclear cleanup of cc-tmp).
- Log **which** sessions the RED cleanup kills (previously silent) + log YELLOW's measured numbers.
- **Sourcing guard** (`if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then main "$@"; fi`) so the functions are unit-testable without starting the daemon (the systemd `ExecStart` runs it directly, so `main` still runs in production).

## Review fixes (Claude code-reviewer)

The reviewer passed 5/6 checks and caught one real Important issue + I fixed a related one it surfaced:
- **Unbounded snapshots** — one file per ORANGE/RED poll would accumulate without limit on the very filesystem being protected → keep only the 20 most recent.
- **`set -e` abort on empty cc-tmp** — the top-consumers `du` ran an unguarded command substitution; on the sacred-ground RED path (disk-full but cc-tmp *empty*) the glob is literal, `du` fails, and `set -e` would have aborted the whole daemon → tolerate with `|| true`.

## Testing

- `tests/test_scripts/test_watchgod_instrumentation.py` (3): snapshot+logline written; `check_cc_tmp` at RED captures pressure before cleanup; snapshots stay bounded (also exercises the empty-cc-tmp path). **tmux is stubbed** so the test can never touch a real CC session.
- `bash -n` + `shellcheck -S warning` clean.

Takes effect on the next `genesis-tmp-watchgod` restart. No CHANGELOG (internal observability).