### PR TITLE
fix(memory): show full session-trail arc in proactive hook (cap 50, was 8)

### DIFF
--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -104,7 +104,10 @@ _STOP_WORDS = frozenset({
 _TRAIL_DIR = Path.home() / ".genesis" / "sessions"
 _PIVOT_SIMILARITY_THRESHOLD = 0.3
 _PIVOT_DEBOUNCE_MSGS = 3
-_MAX_TRAIL_DISPLAY = 8  # Show at most this many pivots in injected line
+_MAX_TRAIL_DISPLAY = 50  # Show up to this many pivots — the full session arc for
+# typical sessions. Was 8; the small window dropped early-session topics across long
+# multi-phase sessions (e.g. an audit phase scrolling off before a later backup phase),
+# leaving only the recent tail visible after compaction.
 _GENESIS_PREFIX = str(Path.home() / "genesis") + "/"
 
 

--- a/tests/test_intent_trail.py
+++ b/tests/test_intent_trail.py
@@ -159,28 +159,39 @@ class TestUpdateAndFormatTrail:
             result = _update_and_format_trail("s2", ["topic", "three"], "topic three stuff")
             assert result == "[Session trail] topic one → topic two → topic three"
 
-    def test_long_trail_truncated(self, tmp_path: Path) -> None:
+    def test_full_arc_shown_under_cap(self, tmp_path: Path) -> None:
+        """A long-but-under-cap session shows its FULL arc (no truncation) — early topics
+        must survive, not just the recent tail. Regression: the old 8-window dropped an
+        early audit phase before a later backup phase, so only the tail was visible."""
         with patch.object(_mod, "_TRAIL_DIR", tmp_path), \
              patch.object(_mod, "_DB_PATH", tmp_path / "fake.db"):
             pivots = [
                 {"idx": i, "label": f"topic {i}", "ts": "", "at_msg": i * 5}
-                for i in range(12)
+                for i in range(30)  # 30 < 50 cap → full arc
             ]
-            trail = {
-                "session_id": "s3",
-                "pivots": pivots,
-                "last_keywords": ["topic", "eleven"],
-                "msg_count": 60,
-            }
-            _save_trail("s3", trail)
-            # Use same keywords to avoid triggering a new pivot
-            result = _update_and_format_trail("s3", ["topic", "eleven"], "topic eleven")
+            _save_trail("s3", {"session_id": "s3", "pivots": pivots,
+                               "last_keywords": ["topic", "twentynine"], "msg_count": 150})
+            result = _update_and_format_trail("s3", ["topic", "twentynine"], "topic twentynine")
+            assert result is not None
+            assert not result.startswith("[Session trail] … → "), "under cap → no truncation"
+            assert "topic 0 " in result and "topic 29" in result, "full arc must show first+last"
+
+    def test_long_trail_truncated_at_cap(self, tmp_path: Path) -> None:
+        """Beyond the cap, show the most recent _MAX_TRAIL_DISPLAY pivots + a '… →' prefix."""
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path), \
+             patch.object(_mod, "_DB_PATH", tmp_path / "fake.db"):
+            n = _mod._MAX_TRAIL_DISPLAY + 5
+            pivots = [
+                {"idx": i, "label": f"topic {i}", "ts": "", "at_msg": i * 5}
+                for i in range(n)
+            ]
+            _save_trail("s4", {"session_id": "s4", "pivots": pivots,
+                               "last_keywords": ["topic", "last"], "msg_count": n * 5})
+            result = _update_and_format_trail("s4", ["topic", "last"], "topic last")
             assert result is not None
             assert result.startswith("[Session trail] … → ")
-            # Should show last 8 (indices 4-11)
-            assert "topic 11" in result
-            assert "topic 4" in result
-            assert "topic 3" not in result
+            assert f"topic {n - 1}" in result                 # most recent shown
+            assert "topic 0 " not in result                   # earliest dropped beyond cap
 
 
 class TestObservationStorage:


### PR DESCRIPTION
## What & why

The per-prompt `[Session trail]` breadcrumb (from `proactive_memory_hook.py`) showed only the **last 8** pivots (`_MAX_TRAIL_DISPLAY = 8`). On a long multi-phase session, early phases scroll off — e.g. an early audit phase became invisible once later phases pushed past 8 pivots, so after compaction only the recent tail was surfaced. The full pivot list is always persisted in `~/.genesis/sessions/<id>/intent_trail.json`; this just widens what's shown.

## Change

- `_MAX_TRAIL_DISPLAY`: **8 → 50** — shows the full arc for typical sessions; the `… →` truncation prefix still applies beyond 50. Display-only constant (used only at the format step), no logic change.
- Tests: replaced the old "last-8" truncation test with `test_full_arc_shown_under_cap` (30 pivots → full arc, no prefix) + `test_long_trail_truncated_at_cap` (reads the actual cap, asserts the window + prefix beyond it).

## Testing

`tests/test_intent_trail.py` — 21 passed. ruff clean. Takes effect on the next prompt after merge (the hook re-reads its script per invocation).

No CHANGELOG (internal observability tweak).