### PR TITLE
fix(observability): ambient-health alerts only on software failure, no nag

### DIFF
--- a/src/genesis/observability/ambient_health.py
+++ b/src/genesis/observability/ambient_health.py
@@ -129,17 +129,19 @@ def evaluate_ambient_health(
 ) -> AmbientVerdict:
     """Turn an ``ambient_health.json`` snapshot into a verdict. Pure + testable.
 
+    Policy: alert ONLY on a SOFTWARE failure, NEVER on the device being absent.
     - ``data is None`` (read failed / edge unreachable) -> ``unknown`` (transient;
       the caller should not flip alert state on a single unknown).
     - heartbeat ``ts`` missing or older than ``_HEARTBEAT_STALE_S`` -> ``down``
-      (bridge process dead/hung).
-    - ``active_connections == 0`` -> ``down`` (device disconnected; ``0`` is a
-      reliable negative).
-    - ``diar_worker_alive`` False while ``diar_enabled`` -> ``degraded``.
-    - otherwise -> ``ok``.
+      (the bridge process is dead/hung — it stopped writing the health file).
+    - ``diar_worker_alive`` False while ``diar_enabled`` -> ``degraded`` (the
+      diarization worker crashed).
+    - otherwise -> ``ok`` — INCLUDING when the device is offline
+      (``active_connections == 0``): an absent device is not a software bug.
 
-    Deliberately does NOT consider ``last_ts`` (last captured utterance): a quiet
-    room naturally has an old ``last_ts``, which is not a fault.
+    Deliberately does NOT consider ``active_connections`` or ``last_ts``: a device
+    that is unplugged/idle, or a quiet room with no recent utterance, is normal —
+    not a fault to alert on.
     """
     if data is None:
         return AmbientVerdict("unknown", ["edge health unreachable / unreadable"])
@@ -159,10 +161,6 @@ def evaluate_ambient_health(
                 f"heartbeat stale ({age:.0f}s > {_HEARTBEAT_STALE_S:.0f}s) — bridge dead/hung",
             )
             status = "down"
-
-    if data.get("active_connections", 0) == 0:
-        reasons.append("device not connected (active_connections=0)")
-        status = "down"
 
     if data.get("diar_enabled") and not data.get("diar_worker_alive", False):
         reasons.append("diarization worker not alive")

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -61,10 +61,8 @@ class OutreachScheduler:
         # fallback when the DB query fails (e.g., lock contention).
         self._cached_critical_obs: list[dict] = []
         self._cached_critical_obs_at: float = 0.0  # monotonic time of cache
-        # Ambient-capture health — last-known status (state-change dedup) and
-        # last-alert time (hourly re-alert of a persistent bad state).
+        # Ambient-capture health — last-known status (alert only on a state change).
         self._ambient_health_status: str = "ok"
-        self._ambient_health_last_alert: float = 0.0  # monotonic time
 
     @property
     def is_running(self) -> bool:
@@ -501,8 +499,6 @@ class OutreachScheduler:
         (transient SSH failure) does not flip the alert state.
         """
         try:
-            import time
-
             from genesis.observability.ambient_health import (
                 evaluate_ambient_health,
                 load_ambient_remote_config,
@@ -515,17 +511,15 @@ class OutreachScheduler:
 
             verdict = evaluate_ambient_health(await read_edge_health(cfg))
             prev = self._ambient_health_status
-            now_mono = time.monotonic()
-            _REALERT_S = 60 * 60  # re-alert a persistent bad state at most hourly
 
             if verdict.status in ("down", "degraded"):
-                entered_bad = prev not in ("down", "degraded")
-                if entered_bad or (now_mono - self._ambient_health_last_alert) > _REALERT_S:
+                # Alert ONCE on entering a bad state — no nagging, no periodic re-alert.
+                if prev not in ("down", "degraded"):
                     emoji = "\U0001f534" if verdict.status == "down" else "\U0001f7e1"
                     text = (
                         f"{emoji} Ambient capture {verdict.status.upper()}\n"
                         + "\n".join(f"• {r}" for r in verdict.reasons)
-                        + "\n\n(toggle Ambient Mode off→on to reconnect the device)"
+                        + "\n\n(ambient bridge process down/hung — check/restart ambient-bridge.service)"
                     )
                     envelope = OutreachRequest(
                         category=OutreachCategory.BLOCKER,
@@ -537,7 +531,6 @@ class OutreachScheduler:
                     )
                     result = await self._pipeline.submit_raw(text, envelope)
                     logger.info("Ambient health alert (%s): %s", verdict.status, result.status.value)
-                    self._ambient_health_last_alert = now_mono
                 self._ambient_health_status = verdict.status
             elif verdict.status == "ok":
                 if prev in ("down", "degraded"):

--- a/tests/test_observability/test_ambient_health.py
+++ b/tests/test_observability/test_ambient_health.py
@@ -41,10 +41,19 @@ def test_missing_ts_is_down():
     assert evaluate_ambient_health(_snapshot(ts=None), now=NOW).status == "down"
 
 
-def test_no_connection_is_down():
-    verdict = evaluate_ambient_health(_snapshot(active_connections=0), now=NOW)
-    assert verdict.status == "down"
-    assert any("not connected" in r for r in verdict.reasons)
+def test_device_offline_is_not_a_fault():
+    # Device absent (active_connections=0) with a fresh heartbeat + live worker is
+    # NOT a software bug — must NOT alert (policy: only software failures alert).
+    assert evaluate_ambient_health(_snapshot(active_connections=0), now=NOW).status == "ok"
+
+
+def test_device_offline_does_not_mask_software_failure():
+    # A real software failure (dead diar worker) still fires even if the device
+    # happens to be offline at the same time.
+    verdict = evaluate_ambient_health(
+        _snapshot(active_connections=0, diar_worker_alive=False), now=NOW,
+    )
+    assert verdict.status == "degraded"
 
 
 def test_dead_diar_worker_is_degraded():


### PR DESCRIPTION
## Problem
The ambient-capture health monitor (added in #680) alerted whenever the **device** was absent (`active_connections==0`) and re-alerted hourly. A device being offline — unplugged, idle, or its firmware crashed — is **not a software bug**, so those alerts are noise.

## Policy (user-mandated)
Alert **only when the software/infra itself breaks**, and **never nag**.

## Fix
- `observability/ambient_health.py`: removed the `active_connections==0 → down` branch. The verdict is now `down` only on a **missing/stale heartbeat** (the bridge process is dead/hung — it stopped writing the health file), `degraded` if the **diarization worker crashed** (`diar_worker_alive` false while enabled), `unknown` on a transient read failure (no alert), else `ok` — *including* when the device is simply offline.
- `outreach/scheduler.py`: dropped the hourly re-alert — now alerts **once** on entering down/degraded, with **one** recovery note. Removed the now-unused re-alert timing state (`_ambient_health_last_alert`, `import time`). Hint text now points at the bridge service.
- Tests: `test_device_offline_is_not_a_fault` (offline + healthy → `ok`) and `test_device_offline_does_not_mask_software_failure` (offline + dead worker → still `degraded`).

This is the only Telegram alert in the voice pipeline.

## Verification
- ruff clean; 9/9 unit tests pass; py_compile OK.
- Independent code review: pass (no findings).
- On-device E2E (after deploy): device disconnected but bridge running → no Telegram; bridge process down >5min → one alert; recovery once; no nag across cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
