### PR TITLE
fix(telegram): restore inline-button callbacks (allowed_updates filter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Telegram approval buttons work again** — tapping the inline **Approve** / **Approve all**
+  buttons (and any inline-keyboard button) had silently stopped doing anything for several days.
+  Telegram was dropping every button press before Genesis received it, because the Guardian's
+  recovery-approval check had narrowed the bot's update filter to text messages only. Genesis now
+  always requests Telegram's default update set (which includes button presses) — and the Guardian
+  check no longer narrows it — so button presses are delivered and resolve immediately again.
+
 - **Off-site backups can now actually be restored** — the large data (the
   database, vector memory, and transcripts) is stored only on your off-site
   (NAS) target, but the restore tool had no way to fetch it — so a from-scratch

--- a/docs/reference/autonomous-cli-approval-gate.md
+++ b/docs/reference/autonomous-cli-approval-gate.md
@@ -74,6 +74,15 @@ order:
    auto-batches** (removed from the April 10 UX redesign) — if you
    reply "approve" to one message, only that message resolves.
 
+> **Inline buttons depend on `callback_query` delivery.** Telegram only sends
+> `callback_query` updates (button presses) when `callback_query` is in the bot's
+> `allowed_updates`. That setting is sticky and bot-global: the main poller re-asserts
+> a non-narrowing value (Telegram's default set, sent as `[]`) on every `start_polling`,
+> and any secondary poller sharing the token (e.g. the Guardian recovery gate in
+> `guardian/alert/telegram.py`) must never narrow it. Narrowing it to `["message"]`
+> silently disables every inline button until reset (the #666 regression that broke
+> button approvals for ~5 days).
+
 ## Call-site gating
 
 The gate implements *gating*, not deduplication: when an approval is

--- a/src/genesis/channels/telegram/adapter_v2.py
+++ b/src/genesis/channels/telegram/adapter_v2.py
@@ -213,7 +213,7 @@ class TelegramAdapterV2(ChannelAdapter):
             self._app.updater._last_update_id = stored_offset
             log.info("Restored polling offset %d for bot %s", stored_offset, bot_id)
 
-        await self._app.updater.start_polling(drop_pending_updates=False)
+        await self._start_updater_polling()
         self._watchdog.start()
 
     async def stop(self) -> None:
@@ -365,6 +365,24 @@ class TelegramAdapterV2(ChannelAdapter):
             log.warning("Failed to query engagement signals for %s", delivery_id, exc_info=True)
             return {"signal": "neutral", "details": {}}
 
+    async def _start_updater_polling(self) -> None:
+        """Start PTB getUpdates polling with a non-narrowing ``allowed_updates``.
+
+        ``allowed_updates`` is a STICKY, bot-global Telegram setting: once any
+        getUpdates call narrows it, the bot keeps dropping the excluded update
+        types until a later call explicitly resets it. A secondary poller sharing
+        this token (the Guardian recovery gate, ``guardian/alert/telegram.py``)
+        narrowed it to ["message"], silently killing all ``callback_query``
+        (inline-button) delivery for ~5 days. Sending ``[]`` — Telegram's default
+        update set, which includes message + callback_query — resets and never
+        narrows it (PTB sends the empty list; only ``None`` is dropped). Both the
+        initial start and every stall-restart call this, so neither call site can
+        diverge or inherit a narrowed filter.
+        """
+        await self._app.updater.start_polling(
+            allowed_updates=[], drop_pending_updates=False,
+        )
+
     async def _handle_polling_stall(self) -> None:
         """Called by watchdog when polling stalls — force restart polling."""
         log.warning("Polling stall detected — restarting updater")
@@ -388,7 +406,7 @@ class TelegramAdapterV2(ChannelAdapter):
         # leaves polling dead for the full stall-backoff period (up to 15 min).
         for attempt in range(2):
             try:
-                await self._app.updater.start_polling(drop_pending_updates=False)
+                await self._start_updater_polling()
                 log.info("Polling restarted successfully after stall")
                 return
             except Exception:

--- a/src/genesis/guardian/alert/telegram.py
+++ b/src/genesis/guardian/alert/telegram.py
@@ -207,6 +207,14 @@ class TelegramAlertChannel(AlertChannel):
         only replies to our own gate prompt — which the main bot's handlers
         ignore — so we never need to ack.
 
+        SHARED-TOKEN SAFETY (offset's sibling): ``allowed_updates`` is *also*
+        sticky and bot-global, so we must NEVER narrow it here. Sending
+        ["message"] once silently disabled the main bot's ``callback_query``
+        (inline-button) delivery for ~5 days (#666 regression). We send an empty
+        list, which Telegram treats as the default set (message + callback_query
+        + …) — never narrowing it; our reply filter still ignores non-message
+        updates.
+
         Returns:
             - the matched keyword (uppercased) if a reply matches,
             - CONFLICT_SENTINEL on HTTP 409 (main bot is long-polling the same
@@ -216,7 +224,11 @@ class TelegramAlertChannel(AlertChannel):
         url = f"{self._api_base}/getUpdates"
         payload: dict[str, Any] = {
             "timeout": timeout_s,
-            "allowed_updates": ["message"],
+            # Empty list = Telegram's default update set (includes message AND
+            # callback_query). Do NOT narrow this to ["message"]: allowed_updates
+            # is sticky + bot-global and this token is shared with the main bot,
+            # so narrowing it disables the main bot's inline-button callbacks (#666).
+            "allowed_updates": [],
         }
         data = json.dumps(payload).encode("utf-8")
         req = urllib.request.Request(

--- a/tests/test_channels/test_telegram_adapter_v2.py
+++ b/tests/test_channels/test_telegram_adapter_v2.py
@@ -1,0 +1,75 @@
+"""Regression tests for TelegramAdapterV2 polling configuration.
+
+Guards the #666 regression: the bot's Telegram ``allowed_updates`` is a sticky,
+bot-global setting. The main poller must (re-)assert a non-narrowing value on
+EVERY ``start_polling`` so a filter narrowed by a secondary poller sharing the
+token cannot silently drop ``callback_query`` (inline-button) delivery. We send
+an empty list — Telegram's default update set, which includes ``callback_query``.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genesis.channels.telegram.adapter_v2 import TelegramAdapterV2
+
+
+def _adapter() -> TelegramAdapterV2:
+    return TelegramAdapterV2(token="123:abc", conversation_loop=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_stall_restart_reasserts_allowed_updates() -> None:
+    """A watchdog stall-restart must pass a non-narrowing allowed_updates so it
+    never inherits a narrowed sticky filter (which would drop callback_query)."""
+    adapter = _adapter()
+    adapter._app = MagicMock()
+    adapter._app.updater = AsyncMock()
+
+    await adapter._handle_polling_stall()
+
+    start_polling = adapter._app.updater.start_polling
+    start_polling.assert_awaited_once()
+    kwargs = start_polling.await_args.kwargs
+    # [] == Telegram's default update set (includes message + callback_query);
+    # the one thing we must never do is narrow it (e.g. to ["message"]).
+    assert kwargs["allowed_updates"] == []
+    assert kwargs["drop_pending_updates"] is False
+
+
+@pytest.mark.asyncio
+async def test_stall_restart_retry_also_asserts_allowed_updates() -> None:
+    """If the first restart attempt fails, the retry must STILL pass the
+    non-narrowing allowed_updates — the kwarg must be on every attempt, not just
+    the happy path."""
+    adapter = _adapter()
+    adapter._app = MagicMock()
+    updater = AsyncMock()
+    # First start_polling attempt raises; the retry succeeds.
+    updater.start_polling.side_effect = [RuntimeError("boom"), None]
+    adapter._app.updater = updater
+
+    # Patch the inter-attempt backoff so the test doesn't actually sleep 5s.
+    with patch(
+        "genesis.channels.telegram.adapter_v2.asyncio.sleep", new=AsyncMock()
+    ):
+        await adapter._handle_polling_stall()
+
+    assert updater.start_polling.await_count == 2
+    for call in updater.start_polling.await_args_list:
+        assert call.kwargs["allowed_updates"] == []
+
+
+@pytest.mark.asyncio
+async def test_start_updater_polling_never_narrows() -> None:
+    """The single polling-start helper — used by BOTH the initial ``start()`` and
+    every stall-restart — must always pass a non-narrowing ``allowed_updates=[]``,
+    so neither call site can drop callback_query (inline-button) delivery."""
+    adapter = _adapter()
+    adapter._app = MagicMock()
+    adapter._app.updater = AsyncMock()
+
+    await adapter._start_updater_polling()
+
+    kwargs = adapter._app.updater.start_polling.await_args.kwargs
+    assert kwargs["allowed_updates"] == []
+    assert kwargs["drop_pending_updates"] is False

--- a/tests/test_guardian/test_alert.py
+++ b/tests/test_guardian/test_alert.py
@@ -328,4 +328,8 @@ class TestTelegramKeywordGate:
         with patch.object(urllib.request, "urlopen", side_effect=_fake_urlopen):
             channel._poll_for_keyword_sync(100, frozenset({"APPROVE"}))
         assert "offset" not in captured["body"]
-        assert captured["body"]["allowed_updates"] == ["message"]
+        # SAFETY: allowed_updates is sticky + bot-global on a shared token. The
+        # gate must NOT narrow it (e.g. to ["message"]) or it disables the main
+        # bot's callback_query (inline-button) delivery (#666 regression). An
+        # empty list = Telegram's default set, which includes callback_query.
+        assert captured["body"]["allowed_updates"] == []


### PR DESCRIPTION
## Problem

Telegram inline-button approvals (**Approve** / **Approve all**, and any inline-keyboard callback) silently stopped being delivered for ~5 days — pressing a button did nothing and the approval stayed pending. Only the dashboard could resolve approvals.

## Root cause

`allowed_updates` is a **sticky, bot-global** Telegram `getUpdates` setting. The Guardian recovery-approval poller (`guardian/alert/telegram.py`, shares the bot token, added in #666) sent `getUpdates` with `allowed_updates=["message"]` — globally narrowing the bot's update filter and dropping every `callback_query` update. The main poller (`adapter_v2.py`) called `start_polling` **without** `allowed_updates`, so it inherited the sticky narrowed filter on every (re)start — which is why no restart recovered it.

Confirmed via `getWebhookInfo` (`allowed_updates` was `["message"]`) and a live button-press repro (the press produced zero updates; the request stayed pending).

## Fix

- **`adapter_v2.py`** — both `start_polling` sites (initial + watchdog stall-restart) now send `allowed_updates=[]`. An empty list is Telegram's *default* update set (includes `message` + `callback_query`), so it resets the sticky filter and restores the exact pre-#666 behavior. PTB reliably sends `[]` (its request layer drops only `None`).
- **`guardian/alert/telegram.py`** — sends `allowed_updates=[]` instead of `["message"]`, so a secondary poller sharing the token never narrows the global filter. Its `reply_to_message` filter still ignores non-message updates.
- **Tests** — guardian assertion updated; new `test_telegram_adapter_v2.py` asserts both the initial and retry restart paths send a non-narrowing `allowed_updates`.
- **Docs** — CHANGELOG (user-facing) + a note in `docs/reference/autonomous-cli-approval-gate.md`.

## Testing

- `tests/test_channels/test_telegram_adapter_v2.py` — 2 passed
- `tests/test_guardian/test_alert.py` — 25 passed
- `ruff check` — clean
- E2E verification (live button press after deploy) to follow.

## Regression watch

If inline buttons stop resolving again, check `getWebhookInfo` → `allowed_updates`; any new secondary `getUpdates` consumer sharing the bot token must not narrow it.