### PR TITLE
fix(learning): skill refiner no longer overwrites SKILL.md from a truncated view (+ dashboard WAL/banner)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,23 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   holding the file open), Genesis raises a high/critical alert on Telegram and in
   the morning report, instead of letting it balloon silently for days.
 
+- **The dashboard shows your database journal (WAL) size at a glance** — the
+  Infrastructure health panel now displays the SQLite WAL size next to the
+  database probe, colored green / amber / red, so you can spot DB-lock pressure
+  building before it ever trips an alert.
+
 ### Fixed
+
+- **The skill auto-tuner can no longer truncate a large skill** — Genesis's
+  weekly skill-refinement pass reviewed long skill files from a clipped
+  3,000-character view and could auto-apply a much shorter rewrite, silently
+  dropping most of the content. It now reviews the full skill, and any
+  auto-applied edit that would shrink a skill below half its size is held for
+  review instead of overwriting the file.
+
+- **The dashboard's degraded-mode banner no longer overflows** — a long
+  "providers down" summary now wraps instead of spilling past the edge on
+  narrow windows.
 
 - **Telegram approval buttons work again** — tapping the inline **Approve** / **Approve all**
   buttons (and any inline-keyboard button) had silently stopped doing anything for several days.

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -3995,7 +3995,7 @@
       </template>
       <!-- Resilience degradation banner -->
       <template x-if="$store.genesisDashboard.health.resilience?.level && $store.genesisDashboard.health.resilience.level !== 'L0' && $store.genesisDashboard.health.resilience.level !== 'not configured'">
-        <div :style="`background: ${['L3', 'L4', 'L5', 'error'].includes($store.genesisDashboard.health.resilience.level) ? '#d9534f' : '#f0ad4e'}; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center;`"
+        <div :style="`background: ${['L3', 'L4', 'L5', 'error'].includes($store.genesisDashboard.health.resilience.level) ? '#d9534f' : '#f0ad4e'}; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center; overflow-wrap: break-word; white-space: normal; line-height: 1.3;`"
              x-text="'Resilience: ' + $store.genesisDashboard.health.resilience.level + ' — ' + ($store.genesisDashboard.health.resilience.summary || 'system is operating in degraded mode')">
         </div>
       </template>
@@ -4041,6 +4041,14 @@
                     <span class="status-dot"
                           :style="`background: ${$store.genesisDashboard.probeStatusColor(probe)}`"></span>
                     <span x-text="name" style="font-size: 0.82rem"></span>
+                    <template x-if="probe.wal_mb != null">
+                      <span style="margin-left: 0.4rem; font-size: 0.72rem; opacity: 0.75;"
+                            :title="'SQLite WAL sidecar size — green < 100MB, yellow ≥ 100MB, red ≥ 500MB'">
+                        <span class="status-dot"
+                              :style="`background: ${$store.genesisDashboard.probeStatusColor({status: probe.wal_status})}`"></span>
+                        <span x-text="'WAL: ' + probe.wal_mb + ' MB'"></span>
+                      </span>
+                    </template>
                     <template x-if="probe.total_points != null">
                       <span style="opacity: 0.6; font-size: 0.72rem;" x-text="'(' + probe.total_points + ' pts)'"></span>
                     </template>

--- a/src/genesis/learning/skills/pipeline.py
+++ b/src/genesis/learning/skills/pipeline.py
@@ -71,6 +71,7 @@ class SkillEvolutionPipeline:
 
             result = await self._applicator.apply(
                 proposal, self._db, router=self._router,
+                current_content=content,
             )
 
             if result["action"] == "applied":
@@ -114,6 +115,7 @@ class SkillEvolutionPipeline:
 
         result = await self._applicator.apply(
             proposal, self._db, router=self._router,
+            current_content=content,
         )
 
         if result["action"] == "staged" and proposal.change_size != ChangeSize.MINOR:

--- a/src/genesis/learning/skills/refiner.py
+++ b/src/genesis/learning/skills/refiner.py
@@ -93,7 +93,7 @@ class SkillRefiner:
             f"- Tools used: {', '.join(report.tools_used) or 'none'}\n"
             f"- Tools declared: {', '.join(report.tools_declared) or 'none'}\n"
             f"{notes_block}\n\n"
-            f"## Current Content ({lines} lines)\n```\n{current_content[:3000]}\n```\n\n"
+            f"## Current Content ({lines} lines)\n```\n{current_content}\n```\n\n"
             f"Respond with JSON:\n"
             f'{{"proposed_content": "...", "rationale": "...", '
             f'"change_size": "minor|moderate|major", '

--- a/src/genesis/learning/skills/validator.py
+++ b/src/genesis/learning/skills/validator.py
@@ -20,6 +20,13 @@ _SIZE_WARN = 150
 _SIZE_MAX = 300
 _SIZE_MIN = 20
 
+# Below this fraction of the original CHARACTER count, a MINOR proposal is
+# treated as content loss (likely a truncated-view overwrite) and BLOCKED —
+# see WS-10. Note: _SIZE_MIN/_SIZE_MAX above are line-based; this gate is
+# char-based and intentionally more conservative (chars capture long-line loss
+# that a line count misses). The two checks cover different axes, not 1:1.
+_CONTENT_LOSS_FLOOR = 0.5
+
 
 class SkillValidator:
     """Validates proposed SKILL.md content before auto-application.
@@ -219,6 +226,19 @@ class SkillValidator:
 
         if proposal.change_size != ChangeSize.MINOR:
             return "SKIP: only checks MINOR claims"
+
+        # Content-loss guard (WS-10): a MINOR proposal that shrinks the file
+        # below _CONTENT_LOSS_FLOOR of its original size is almost certainly a
+        # truncated-view overwrite. Block it (route to staging for human review)
+        # rather than silently overwriting a fuller file with a much shorter one.
+        cur_chars = len(current_content)
+        if cur_chars > 0 and len(proposal.proposed_content) < _CONTENT_LOSS_FLOOR * cur_chars:
+            pct = len(proposal.proposed_content) / cur_chars
+            failures.append(
+                f"content_loss: MINOR proposal is {pct:.0%} of the original SKILL.md "
+                f"size — refusing to auto-overwrite a fuller file with a much shorter one."
+            )
+            return f"FAIL: content_loss ({pct:.0%} of original)"
 
         current_lines = current_content.splitlines()
         proposed_lines = proposal.proposed_content.splitlines()

--- a/src/genesis/observability/health.py
+++ b/src/genesis/observability/health.py
@@ -33,6 +33,12 @@ _guardian_remote_config_checked: bool = False
 _guardian_ssh_cache: dict[str, tuple[float, ProbeResult]] = {}
 _GUARDIAN_SSH_TTL = 60.0
 
+# WAL size thresholds — mirror awareness/loop.py's _check_wal_health. Kept local
+# to avoid an observability→awareness import cycle (awareness imports
+# observability, not the reverse). 100 MB → DEGRADED, 500 MB → DOWN.
+_WAL_SIZE_WARN_BYTES = 100 * 1024 * 1024
+_WAL_SIZE_CRIT_BYTES = 500 * 1024 * 1024
+
 
 def _load_guardian_remote_from_config() -> object | None:
     """Lazy-load a GuardianRemote from ~/.genesis/guardian_remote.yaml.
@@ -280,6 +286,69 @@ async def probe_disk(
             message=f"Cannot stat {mount_path}: {exc}",
             checked_at=_clock().isoformat(),
         )
+
+
+async def probe_wal(
+    wal_path: str | Path | None = None,
+    *,
+    clock=None,
+) -> ProbeResult:
+    """Probe the SQLite WAL sidecar file size.
+
+    A bloated WAL is an early signal of DB-lock pressure: a long-lived
+    reader/MCP pinning an old snapshot prevents checkpoint, so the ``-wal``
+    file grows. Thresholds mirror the awareness loop's ``_check_wal_health``:
+    100 MB → DEGRADED, 500 MB → DOWN.
+
+    Returns ``details={"wal_mb": float}``. A missing WAL (DB in DELETE mode or
+    freshly checkpointed) is HEALTHY with ``wal_mb=0.0``.
+    """
+    from genesis.env import genesis_db_path
+
+    _clock = clock or (lambda: datetime.now(UTC))
+    start = time.monotonic()
+    path = Path(wal_path) if wal_path else Path(f"{genesis_db_path()}-wal")
+    try:
+        size = path.stat().st_size
+    except FileNotFoundError:
+        latency = (time.monotonic() - start) * 1000
+        return ProbeResult(
+            name="wal",
+            status=ProbeStatus.HEALTHY,
+            latency_ms=round(latency, 2),
+            checked_at=_clock().isoformat(),
+            details={"wal_mb": 0.0},
+        )
+    except OSError as exc:
+        latency = (time.monotonic() - start) * 1000
+        return ProbeResult(
+            name="wal",
+            status=ProbeStatus.DOWN,
+            latency_ms=round(latency, 2),
+            message=f"Cannot stat WAL: {exc}",
+            checked_at=_clock().isoformat(),
+        )
+
+    latency = (time.monotonic() - start) * 1000
+    wal_mb = round(size / (1024 * 1024), 1)
+    if size >= _WAL_SIZE_CRIT_BYTES:
+        status = ProbeStatus.DOWN
+        msg = f"WAL is {wal_mb} MB (>{_WAL_SIZE_CRIT_BYTES // 1024 // 1024} MB)"
+    elif size >= _WAL_SIZE_WARN_BYTES:
+        status = ProbeStatus.DEGRADED
+        msg = f"WAL is {wal_mb} MB"
+    else:
+        status = ProbeStatus.HEALTHY
+        msg = ""
+
+    return ProbeResult(
+        name="wal",
+        status=status,
+        latency_ms=round(latency, 2),
+        message=msg,
+        checked_at=_clock().isoformat(),
+        details={"wal_mb": wal_mb},
+    )
 
 
 async def probe_guardian(

--- a/src/genesis/observability/snapshots/infrastructure.py
+++ b/src/genesis/observability/snapshots/infrastructure.py
@@ -16,6 +16,7 @@ from genesis.observability.health import (
     probe_ollama,
     probe_qdrant,
     probe_scheduler,
+    probe_wal,
 )
 from genesis.observability.types import ProbeStatus
 from genesis.routing.types import DegradationLevel, RoutingConfig
@@ -133,6 +134,20 @@ async def infrastructure(
             _update_memory_axis(state_machine, ProbeStatus.DOWN)
     else:
         infra["genesis.db"] = {"status": "error", "error": "no database connection"}
+
+    # WAL size — only meaningful when the DB is connected. Early signal of
+    # DB-lock pressure (a long-lived reader pinning an old snapshot bloats the
+    # -wal sidecar). Attached to the genesis.db probe so the dashboard surfaces
+    # it without a new top-level entry. Skipped when db is None — a "WAL: 0 MB"
+    # readout next to a "no database connection" error would mislead operators.
+    if db:
+        try:
+            wal_result = await probe_wal()
+            if wal_result.details:
+                infra["genesis.db"]["wal_mb"] = wal_result.details.get("wal_mb")
+            infra["genesis.db"]["wal_status"] = str(wal_result.status)
+        except Exception as exc:
+            logger.warning("WAL probe failed: %s", exc)
 
     try:
         result = await probe_qdrant()

--- a/tests/test_learning/test_skill_evolution.py
+++ b/tests/test_learning/test_skill_evolution.py
@@ -13,6 +13,7 @@ import pytest
 
 from genesis.learning.skills.applicator import SkillApplicator
 from genesis.learning.skills.effectiveness import SkillEffectivenessAnalyzer
+from genesis.learning.skills.pipeline import SkillEvolutionPipeline
 from genesis.learning.skills.refiner import SkillRefiner
 from genesis.learning.skills.types import (
     ChangeSize,
@@ -21,6 +22,7 @@ from genesis.learning.skills.types import (
     SkillTrend,
     SkillType,
 )
+from genesis.learning.skills.validator import SkillValidator
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -395,6 +397,56 @@ class TestRefiner:
         assert result is not None
         assert result.proposed_content == "improved"
         router.route_call.assert_awaited_once()
+
+
+class TestWS10ContentLoss:
+    """WS-10 / LRN-01: never overwrite a SKILL.md from a truncated view.
+    (1) the refiner must prompt with the FULL content; (2) the pipeline must thread
+    current_content so the consistency check runs; (3) a MINOR auto-apply that drops
+    most of the file must be BLOCKED (falls through to staging), not silently applied."""
+
+    def test_build_prompt_includes_full_content_no_truncation(self):
+        refiner = SkillRefiner()
+        report = SkillReport(skill_name="big", usage_count=10, success_count=8,
+                             failure_count=2, success_rate=0.8)
+        content = ("filler content line\n" * 300) + "UNIQUE_TAIL_MARKER\n"  # >3000 chars; marker past 3000
+        assert len(content) > 3000
+        prompt = refiner._build_prompt(report, content)
+        assert "UNIQUE_TAIL_MARKER" in prompt, \
+            "refiner truncated the skill content — the LLM refines from a partial view and drops the tail"
+
+    def test_consistency_blocks_large_content_loss_for_minor(self):
+        validator = SkillValidator()
+        failures: list[str] = []
+        warnings: list[str] = []
+        current = "real content line\n" * 200  # the full file
+        proposal = SkillProposal(skill_name="x", proposed_content="real content line\n" * 20,  # 10% — content loss
+                                 rationale="r", change_size=ChangeSize.MINOR)
+        validator._test_consistency(proposal, current, failures, warnings)
+        assert any("content" in f.lower() and "loss" in f.lower() for f in failures), \
+            f"a MINOR proposal dropping most of the file must be a BLOCKING failure; failures={failures} warnings={warnings}"
+
+    @pytest.mark.asyncio
+    async def test_pipeline_threads_current_content_to_applicator(self, db):
+        pipeline = SkillEvolutionPipeline(db=db, router=MagicMock())
+        report = SkillReport(skill_name="s", usage_count=5, success_count=2,
+                             failure_count=3, success_rate=0.4)
+        pipeline._analyzer.analyze_all = AsyncMock(return_value=[report])
+        pipeline._analyzer.needs_review = lambda r: True
+        pipeline._refiner.propose = AsyncMock(return_value=SkillProposal(
+            skill_name="s", proposed_content="new", rationale="r", change_size=ChangeSize.MINOR))
+        pipeline._applicator.apply = AsyncMock(return_value={"action": "applied"})
+        import genesis.learning.skills.pipeline as pipeline_mod
+        original_load = pipeline_mod.load_skill
+        pipeline_mod.load_skill = lambda name: "the full current SKILL.md content"
+        try:
+            await pipeline.run()
+        finally:
+            pipeline_mod.load_skill = original_load
+        pipeline._applicator.apply.assert_awaited_once()
+        _, kwargs = pipeline._applicator.apply.await_args
+        assert kwargs.get("current_content") == "the full current SKILL.md content", \
+            f"pipeline must pass current_content so the consistency check can run; kwargs={kwargs}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_observability/test_health.py
+++ b/tests/test_observability/test_health.py
@@ -1,7 +1,7 @@
 """Tests for health probes."""
 
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -11,8 +11,9 @@ from genesis.observability.health import (
     probe_ollama,
     probe_qdrant,
     probe_scheduler,
+    probe_wal,
 )
-from genesis.observability.types import ProbeStatus
+from genesis.observability.types import ProbeResult, ProbeStatus
 
 FROZEN_CLOCK = lambda: datetime(2026, 3, 4, tzinfo=UTC)  # noqa: E731
 
@@ -141,3 +142,93 @@ class TestProbeDisk:
         with patch("os.statvfs", side_effect=OSError("read-only")):
             result = await probe_disk(clock=FROZEN_CLOCK)
         assert result.status == ProbeStatus.DOWN
+
+
+_MB = 1024 * 1024
+
+
+def _make_wal(tmp_path, size_bytes):
+    """Create a sparse <db>-wal file of the given size (near-zero real disk)."""
+    wal = tmp_path / "genesis.db-wal"
+    with open(wal, "wb") as f:
+        f.truncate(size_bytes)
+    return wal
+
+
+class TestProbeWal:
+    @pytest.mark.asyncio
+    async def test_healthy_small(self, tmp_path):
+        wal = _make_wal(tmp_path, 50 * _MB)
+        result = await probe_wal(wal_path=wal, clock=FROZEN_CLOCK)
+        assert result.status == ProbeStatus.HEALTHY
+        assert result.name == "wal"
+        assert result.details["wal_mb"] == 50.0
+
+    @pytest.mark.asyncio
+    async def test_degraded_at_warn(self, tmp_path):
+        wal = _make_wal(tmp_path, 150 * _MB)
+        result = await probe_wal(wal_path=wal, clock=FROZEN_CLOCK)
+        assert result.status == ProbeStatus.DEGRADED
+        assert result.details["wal_mb"] == 150.0
+
+    @pytest.mark.asyncio
+    async def test_down_at_critical(self, tmp_path):
+        wal = _make_wal(tmp_path, 600 * _MB)
+        result = await probe_wal(wal_path=wal, clock=FROZEN_CLOCK)
+        assert result.status == ProbeStatus.DOWN
+        assert result.details["wal_mb"] == 600.0
+        assert "MB" in result.message
+
+    @pytest.mark.asyncio
+    async def test_missing_wal_is_healthy_zero(self, tmp_path):
+        result = await probe_wal(
+            wal_path=tmp_path / "nonexistent.db-wal", clock=FROZEN_CLOCK
+        )
+        assert result.status == ProbeStatus.HEALTHY
+        assert result.details["wal_mb"] == 0.0
+
+
+class TestInfrastructureWalPlumbing:
+    """The WAL probe result must attach to the genesis.db entry in the
+    infrastructure snapshot the dashboard health payload reads."""
+
+    @pytest.mark.asyncio
+    async def test_wal_attached_to_genesis_db(self, db):
+        wal_probe = ProbeResult(
+            name="wal",
+            status=ProbeStatus.DEGRADED,
+            latency_ms=0.1,
+            details={"wal_mb": 150.0},
+        )
+        with patch(
+            "genesis.observability.snapshots.infrastructure.probe_wal",
+            new_callable=AsyncMock,
+            return_value=wal_probe,
+        ):
+            from genesis.observability.snapshots.infrastructure import infrastructure
+
+            infra = await infrastructure(
+                db=db,
+                routing_config=None,
+                learning_scheduler=None,
+                state_machine=None,
+            )
+
+        assert infra["genesis.db"]["wal_mb"] == 150.0
+        assert infra["genesis.db"]["wal_status"] == "degraded"
+
+    @pytest.mark.asyncio
+    async def test_wal_not_attached_when_db_none(self):
+        """No DB connection → no WAL readout (a green 0 MB next to a DB-error
+        row would mislead operators)."""
+        from genesis.observability.snapshots.infrastructure import infrastructure
+
+        infra = await infrastructure(
+            db=None,
+            routing_config=None,
+            learning_scheduler=None,
+            state_machine=None,
+        )
+
+        assert "wal_mb" not in infra["genesis.db"]
+        assert "wal_status" not in infra["genesis.db"]


### PR DESCRIPTION
## Summary

Bundles one correctness fix and two small dashboard observability improvements (different subsystems, all low-risk).

### WS-10 — skill refiner overwrites `SKILL.md` from a truncated view (LRN-01)

The weekly skill-evolution pipeline auto-applies **MINOR** proposals (`autonomy_level=2`) directly onto real `SKILL.md` files via `path.write_text()`. Two compounding bugs let it silently truncate a large skill:

1. `refiner.py` built the LLM prompt with `current_content[:3000]`, so a skill larger than 3000 chars was refined from a **partial view** (the largest real skill is ~17.7K chars).
2. The validator's consistency check was never threaded the original content, and even when reached it only **warned** — it never blocked. So a too-short proposal would auto-apply.

**Fix:**
- Refiner now prompts with the **full** skill content.
- The pipeline threads `current_content` to **both** `applicator.apply()` call sites (`run()` and `propose_for_skill()`).
- The validator now **blocks** (routes to staging for human review) any MINOR proposal under 50% of the original size, instead of only warning. The line-based size floor doesn't catch this — a short proposal above the line floor can still drop most of the content.

### Dashboard

- **Resilience banner wrap** — the resilience-degradation banner now wraps long provider summaries instead of overflowing on narrow widths (CSS only).
- **WAL-size health indicator** — a new `probe_wal()` surfaces the SQLite `-wal` sidecar size under the `genesis.db` health probe (green/yellow/red at 100 MB / 500 MB, mirroring the awareness loop's WAL thresholds). A bloated WAL is an early signal of DB-lock pressure. Skipped when there's no DB connection so a "0 MB" readout never sits next to a DB-error row.

## Testing

- `pytest tests/test_learning/test_skill_evolution.py tests/test_observability/test_health.py` — 62 passed (TDD: RED → GREEN).
- Adjacent consumers (`test_guardian/test_container_side.py`, `test_awareness/test_wal_health.py`) still green.
- `ruff check` clean on the full diff.
- Reviewed by a code-review agent; both flagged items addressed (gate WAL on DB presence; clarify the char-vs-line threshold comment).

## Risk

Low. WS-10 makes the auto-apply guard stricter (worst case: a borderline-but-legitimate proposal routes to human staging instead of auto-applying — non-destructive). The WAL probe and banner change are additive observability.