### PR TITLE
fix(outreach): dedup window never expired within a UTC day

### DIFF
--- a/src/genesis/outreach/governance.py
+++ b/src/genesis/outreach/governance.py
@@ -192,12 +192,17 @@ class GovernanceGate:
             return False
         window_spec = f"-{window_hours} hours"
 
-        # Primary key: (signal_type, topic, category) within the window
+        # Primary key: (signal_type, topic, category) within the window.
+        # NB: wrap delivered_at in datetime(). Stored values are ISO-8601 with a
+        # 'T' separator (datetime.now(UTC).isoformat()); a raw string compare
+        # against SQLite's space-separated datetime('now', ?) is wrong because
+        # 'T' (0x54) > ' ' (0x20), which made the window never expire within a
+        # UTC day. datetime() parses both sides before comparing.
         cursor = await self._db.execute(
             "SELECT COUNT(*) FROM outreach_history "
             "WHERE signal_type = ? AND topic = ? AND category = ? "
             "AND delivered_at IS NOT NULL "
-            "AND delivered_at >= datetime('now', ?)",
+            "AND datetime(delivered_at) >= datetime('now', ?)",
             (request.signal_type, request.topic, request.category.value, window_spec),
         )
         row = await cursor.fetchone()
@@ -210,13 +215,14 @@ class GovernanceGate:
             )
             return True
 
-        # Secondary: content-hash match (catches near-duplicate topics with same body)
+        # Secondary: content-hash match (catches near-duplicate topics with same
+        # body). Same datetime(delivered_at) normalization as the primary query.
         chash = content_hash(request.context)
         cursor = await self._db.execute(
             "SELECT COUNT(*) FROM outreach_history "
             "WHERE signal_type = ? AND category = ? AND content_hash = ? "
             "AND delivered_at IS NOT NULL "
-            "AND delivered_at >= datetime('now', ?)",
+            "AND datetime(delivered_at) >= datetime('now', ?)",
             (request.signal_type, request.category.value, chash, window_spec),
         )
         row = await cursor.fetchone()

--- a/tests/test_outreach/test_governance.py
+++ b/tests/test_outreach/test_governance.py
@@ -1,6 +1,6 @@
 """Tests for the deterministic governance gate."""
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import aiosqlite
 import pytest
@@ -275,6 +275,61 @@ async def test_expired_window_allows_resend(db):
         signal_type="surplus_insight",
     )
     result = await gate.check(req)
+    assert result.verdict == GovernanceVerdict.ALLOW
+
+
+@pytest.mark.asyncio
+async def test_iso_t_delivered_at_outside_window_not_deduped(db):
+    """Regression: ISO-8601 'T'-separator delivered_at must compare correctly
+    against SQLite's space-separated datetime('now', ?).
+
+    Production stores delivered_at via ``datetime.now(UTC).isoformat()`` →
+    ``'2026-06-19T03:18:54+00:00'`` (literal 'T'). A *raw* string comparison
+    treats 'T' (0x54) > ' ' (0x20), so a row delivered earlier on the cutoff's
+    own UTC date sorts as "newer" than the space-separated cutoff — the dedup
+    window then never expires within a calendar day. Wrapping the column in
+    ``datetime(delivered_at)`` makes SQLite parse both sides before comparing.
+
+    The existing expired-window test uses ``datetime('now', '-25 hours')`` for
+    delivered_at — that value is space-separated, so it never exercises this bug.
+    """
+    cfg = _cfg_no_quiet()
+    gate = GovernanceGate(cfg, db)
+
+    # surplus_insight uses the 24h default window. Anchor delivered_at to the
+    # START of the cutoff's UTC date, in ISO-'T' format: strictly earlier than
+    # the cutoff in real time (=> OUTSIDE the window) yet sharing the cutoff's
+    # date prefix (=> the exact T-vs-space trigger). The guard covers the rare
+    # (~1s/day) case where the cutoff itself lands at midnight.
+    cutoff = datetime.now(UTC) - timedelta(hours=24)
+    delivered_dt = cutoff.replace(hour=0, minute=0, second=1, microsecond=0)
+    if delivered_dt >= cutoff:
+        delivered_dt -= timedelta(days=1)
+    delivered = delivered_dt.isoformat()
+
+    await outreach_crud.create(
+        db,
+        id="iso-old",
+        signal_type="surplus_insight",
+        topic="Old ISO topic",
+        category="surplus",
+        salience_score=0.9,
+        channel="telegram",
+        message_content="Old",
+        created_at=delivered,
+    )
+    await outreach_crud.record_delivery(db, "iso-old", delivered_at=delivered)
+
+    req = OutreachRequest(
+        category=OutreachCategory.SURPLUS,
+        topic="Old ISO topic",
+        context="Same topic, window long expired",
+        salience_score=0.9,
+        signal_type="surplus_insight",
+    )
+    result = await gate.check(req)
+    # delivered_at is > 24h old → must ALLOW. The pre-fix raw-string compare
+    # wrongly DENYs because 'T' (0x54) > ' ' (0x20).
     assert result.verdict == GovernanceVerdict.ALLOW
 
 


### PR DESCRIPTION
## What

Outreach dedup (`GovernanceGate._is_duplicate`) compared a stored ISO-8601
`delivered_at` (with a `T` separator) against SQLite's space-separated
`datetime('now', ?)` as **raw strings**. `T` (0x54) sorts after space (0x20),
so a row delivered earlier on the cutoff's own UTC date was treated as *inside*
the window — the dedup window never expired within a calendar day (a 24h window
behaved like ~41h). Outreach deliveries were suppressed for hours, then flushed
together in a single batch (the "10 critical observations at once" symptom).

## Fix

Wrap `delivered_at` in `datetime()` in both dedup queries so SQLite parses both
operands before comparing. The rate-limit and `*_available` quota checks compare
against `date('now')` (no time component, so no `T`-vs-space mismatch) and are
unaffected — left untouched.

## Verification

- New regression test (`test_iso_t_delivered_at_outside_window_not_deduped`)
  uses the production ISO-`T` format at the 24h boundary: **RED** on old code,
  **GREEN** after the fix. Full `test_outreach` suite: **117 passed**; ruff clean.
- Query plan unchanged — still a covering-index search on `idx_outreach_dedup`.
- Verified against real history: of rows genuinely 24–48h old, the old
  comparison wrongly kept **3** inside the window; the fixed comparison keeps
  **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
