### PR TITLE
fix(resilience): recovery no longer drops un-executed work or blocks reflections (+ real email Message-ID)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Genesis can now detect replies to the emails it sends** — outbound email
+  was going out without a real Message-ID header, so mail clients couldn't thread
+  it and Genesis couldn't match incoming replies back to the original message.
+  Outbound mail now carries a proper Message-ID, so replies are recognized and
+  routed to the right conversation.
+
+- **Background work deferred during an outage is no longer silently dropped** —
+  when the system was degraded, the recovery pass marked queued reflection and
+  outreach work "done" without ever running it, and a stuck outreach item could
+  block reflection retries entirely. Deferred work is now kept until it actually
+  runs, reflections are no longer blocked behind it, and recovery holds off
+  re-trying until the system is genuinely stable.
+
 - **The skill auto-tuner can no longer truncate a large skill** — Genesis's
   weekly skill-refinement pass reviewed long skill files from a clipped
   3,000-character view and could auto-apply a much shorter rewrite, silently

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -1196,8 +1196,8 @@ class AwarenessLoop:
             logger.debug("Skipping deferred reflection retry — loop is stopping")
             return
 
-        item = await self._deferred_queue.next_pending(max_priority=40)
-        if not item or item.get("work_type") != "reflection":
+        item = await self._deferred_queue.next_pending(work_type="reflection", max_priority=40)
+        if not item:
             return
 
         item_id = item["id"]

--- a/src/genesis/channels/email_adapter.py
+++ b/src/genesis/channels/email_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import email.message
+import email.utils
 import logging
 import smtplib
 from typing import Any
@@ -67,6 +68,11 @@ class EmailAdapter(ChannelAdapter):
         msg["From"] = f"{self._from_name} <{self._from_address}>"
         msg["To"] = recipient
         msg["Subject"] = subject
+        # Real RFC 5322 Message-ID so recipients can thread and our reply-poller can
+        # match replies (WS-9a). EmailMessage() sets no Message-ID by default, so the
+        # sent mail previously had none and the returned id was a fabricated placeholder.
+        domain = self._from_address.rsplit("@", 1)[-1] if "@" in self._from_address else None
+        msg["Message-ID"] = email.utils.make_msgid(domain=domain)
         msg.set_content(text)
 
         def _send_sync() -> None:
@@ -84,7 +90,7 @@ class EmailAdapter(ChannelAdapter):
             logger.exception("Failed to send email to %s", recipient)
             raise
 
-        message_id = msg["Message-ID"] or f"email-{id(msg)}"
+        message_id = msg["Message-ID"]
         logger.info("Email sent to %s (Message-ID: %s)", recipient, message_id)
         return message_id
 

--- a/src/genesis/resilience/deferred_work.py
+++ b/src/genesis/resilience/deferred_work.py
@@ -84,10 +84,17 @@ class DeferredWorkQueue:
         )
         return item_id
 
-    async def next_pending(self, max_priority: int = 100) -> dict | None:
-        """Return the highest-priority pending item, or None."""
+    async def next_pending(
+        self, work_type: str | None = None, max_priority: int = 100
+    ) -> dict | None:
+        """Return the highest-priority pending item, or None.
+
+        Pass ``work_type`` to filter to a single type — without it, a higher-priority
+        item of another type head-of-line-blocks the caller (WS-6: a failed outreach
+        item at priority 20 was blocking reflection retries at priority 30).
+        """
         items = await crud.query_pending(
-            self._db, max_priority=max_priority, limit=1,
+            self._db, work_type=work_type, max_priority=max_priority, limit=1,
         )
         return items[0] if items else None
 

--- a/src/genesis/resilience/recovery.py
+++ b/src/genesis/resilience/recovery.py
@@ -14,10 +14,9 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class RecoveryReport:
-    items_drained: int = 0
+    items_pending: int = 0  # deferred work left pending (not executed by recovery)
     items_expired: int = 0
     items_unstuck: int = 0
-    items_failed: int = 0
     embeddings_recovered: int = 0
     dead_letters_replayed: int = 0
     dead_letters_failed: int = 0
@@ -109,34 +108,43 @@ class RecoveryOrchestrator:
             except Exception:
                 logger.warning("Failed to reset failed embeddings", exc_info=True)
 
-        # 2. Drain pending embeddings — limit=500 to handle full extraction
-        # cycle output (extraction queues FTS5-only, recovery embeds at pace)
-        report.embeddings_recovered = await self._embedding_worker.drain_pending(limit=500)
-
-        # 3. Drain deferred work by priority
-        items = await self._deferred_queue.drain_by_priority(limit=50)
-        for item in items:
-            try:
-                await self._deferred_queue.mark_processing(item["id"])
-                # Actual re-dispatch is Phase 8/9 work — just mark completed
-                await self._deferred_queue.mark_completed(item["id"])
-                report.items_drained += 1
-            except Exception:
-                report.items_failed += 1
-                logger.exception("Failed to process deferred item %s", item["id"])
-
-        # 4. Re-dispatch dead letters (or mark-only if no dispatch_fn)
-        if self._dispatch_fn is not None and hasattr(self._dead_letter, "redispatch"):
-            succeeded, failed = await self._dead_letter.redispatch(self._dispatch_fn)
-            report.dead_letters_replayed = succeeded
-            report.dead_letters_failed = failed
-        else:
-            report.dead_letters_replayed = await self._dead_letter.replay_pending(
-                target_provider="all",
+        # Re-dispatch (embedding drain + dead-letter replay) re-attempts work against
+        # downstreams (Qdrant, providers). Gate it on a stable system — re-dispatching
+        # into a still-degraded system just churns and re-fails (WS-6: AUTO-RECOV-02).
+        # Housekeeping above (expire stuck/stale, reset-failed) runs unconditionally.
+        if self._state_machine is not None and self._state_machine.is_any_degraded(
+            include_tmp_pressure=False
+        ):
+            logger.info(
+                "Recovery: system still degraded — skipping re-dispatch "
+                "(embedding drain + dead-letter replay) this cycle"
             )
+        else:
+            # 2. Drain pending embeddings — limit=500 to handle a full extraction
+            # cycle output (extraction queues FTS5-only, recovery embeds at pace).
+            report.embeddings_recovered = await self._embedding_worker.drain_pending(limit=500)
 
-        # Check queue overflow
+            # 3. Re-dispatch dead letters (or mark-only if no dispatch_fn).
+            if self._dispatch_fn is not None and hasattr(self._dead_letter, "redispatch"):
+                succeeded, failed = await self._dead_letter.redispatch(self._dispatch_fn)
+                report.dead_letters_replayed = succeeded
+                report.dead_letters_failed = failed
+            else:
+                report.dead_letters_replayed = await self._dead_letter.replay_pending(
+                    target_provider="all",
+                )
+
+        # Deferred work is intentionally LEFT PENDING (WS-6: AUTO-RECOV-01). The old
+        # drain marked items completed without executing them — silently dropping
+        # reflection/outreach work. Reflections are re-dispatched by the awareness loop
+        # (next_pending(work_type="reflection")); outreach awaits a dedicated consumer
+        # (tracked follow-up). The overflow check below surfaces any accumulation.
+
+        # Check queue overflow. pending_count is the deferred backlog left for the
+        # normal consumers (reflection via the awareness loop; outreach via a future
+        # consumer) — surfaced honestly instead of drained-to-completed.
         pending_count = await self._deferred_queue.count_pending()
+        report.items_pending = pending_count
         if pending_count > self._queue_overflow_threshold and self._event_bus:
             await self._event_bus.emit(
                 Subsystem.HEALTH,
@@ -149,8 +157,8 @@ class RecoveryOrchestrator:
 
         report.duration_s = time.monotonic() - start
         logger.info(
-            "Recovery completed: drained=%d expired=%d embeddings=%d dead_letters=%d (%.1fs)",
-            report.items_drained, report.items_expired,
+            "Recovery completed: pending=%d expired=%d embeddings=%d dead_letters=%d (%.1fs)",
+            report.items_pending, report.items_expired,
             report.embeddings_recovered, report.dead_letters_replayed,
             report.duration_s,
         )

--- a/src/genesis/resilience/state.py
+++ b/src/genesis/resilience/state.py
@@ -151,15 +151,22 @@ class ResilienceStateMachine:
     def current(self) -> ResilienceState:
         return self._state
 
-    def is_any_degraded(self) -> bool:
-        """Return True if any axis is below NORMAL."""
-        return (
+    def is_any_degraded(self, *, include_tmp_pressure: bool = True) -> bool:
+        """Return True if any axis is below NORMAL.
+
+        Pass ``include_tmp_pressure=False`` to ignore cc-tmp pressure — useful for
+        gating work that cc-tmp pressure does not actually impair (e.g. recovery
+        re-dispatch into Qdrant / LLM providers).
+        """
+        degraded = (
             self._state.cloud != CloudStatus.NORMAL
             or self._state.memory != MemoryStatus.NORMAL
             or self._state.embedding != EmbeddingStatus.NORMAL
             or self._state.cc != CCStatus.NORMAL
-            or self._state.tmp_pressure != TmpPressureStatus.NORMAL
         )
+        if include_tmp_pressure:
+            degraded = degraded or self._state.tmp_pressure != TmpPressureStatus.NORMAL
+        return degraded
 
     def update_cloud(self, status: CloudStatus) -> list[StateTransition]:
         return self._update("cloud", status)

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -319,13 +319,12 @@ async def init(rt: GenesisRuntime) -> None:
                 try:
                     report = await rt._recovery_orchestrator.run_recovery()
                     rt.record_job_success("recovery_orchestrator")
-                    if (report.dead_letters_replayed or report.embeddings_recovered
-                            or report.items_drained):
+                    if report.dead_letters_replayed or report.embeddings_recovered:
                         logger.info(
-                            "Recovery: replayed=%d embeddings=%d drained=%d",
+                            "Recovery: replayed=%d embeddings=%d pending=%d",
                             report.dead_letters_replayed,
                             report.embeddings_recovered,
-                            report.items_drained,
+                            report.items_pending,
                         )
                 except Exception:
                     rt.record_job_failure("recovery_orchestrator", "recovery failed")

--- a/tests/test_awareness/test_loop_resilience.py
+++ b/tests/test_awareness/test_loop_resilience.py
@@ -172,6 +172,9 @@ async def test_retry_deferred_reflection_success_marks_completed(db):
 
     dq.mark_completed.assert_awaited_once_with("item-1")
     dq.reset_to_pending.assert_not_awaited()
+    # WS-6 head-of-line: the consumer must filter by work_type so a higher-priority
+    # non-reflection item at the head can't block reflection retries.
+    dq.next_pending.assert_awaited_once_with(work_type="reflection", max_priority=40)
 
 
 async def test_retry_deferred_reflection_failure_resets_to_pending(db):

--- a/tests/test_channels/test_email_adapter.py
+++ b/tests/test_channels/test_email_adapter.py
@@ -108,6 +108,31 @@ class TestEmailAdapter:
         assert progressed >= 5, f"event loop appears blocked during send (ticks={progressed})"
 
     @pytest.mark.anyio
+    async def test_send_message_sets_real_message_id(self, adapter: EmailAdapter) -> None:
+        """WS-9a: outbound mail must carry a real RFC Message-ID, not a fake email-<id>.
+
+        Without it, recipients can't thread and our reply-poller can't match replies.
+        """
+        mock_smtp = MagicMock()
+        with patch("genesis.channels.email_adapter.smtplib.SMTP_SSL") as smtp_cls:
+            smtp_cls.return_value.__enter__ = MagicMock(return_value=mock_smtp)
+            smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            delivery_id = await adapter.send_message(
+                "recipient@example.com", "body", subject="S",
+            )
+
+            sent_msg = mock_smtp.send_message.call_args[0][0]
+            mid = sent_msg["Message-ID"]
+            assert mid, "no Message-ID header on the sent email"
+            assert mid.startswith("<") and mid.endswith(">") and "@" in mid, \
+                f"not an RFC-shaped Message-ID: {mid}"
+            assert not mid.startswith("<email-"), "fabricated id leaked into the header"
+            assert delivery_id == mid, "returned delivery id must equal the real Message-ID"
+            assert mid.rstrip(">").endswith("@gmail.com"), \
+                f"Message-ID domain not from from_address: {mid}"
+
+    @pytest.mark.anyio
     async def test_engagement_signals_neutral(self, adapter: EmailAdapter) -> None:
         result = await adapter.get_engagement_signals("any-id")
         assert result["signal"] == "neutral"

--- a/tests/test_channels/test_email_adapter.py
+++ b/tests/test_channels/test_email_adapter.py
@@ -129,7 +129,8 @@ class TestEmailAdapter:
                 f"not an RFC-shaped Message-ID: {mid}"
             assert not mid.startswith("<email-"), "fabricated id leaked into the header"
             assert delivery_id == mid, "returned delivery id must equal the real Message-ID"
-            assert mid.rstrip(">").endswith("@gmail.com"), \
+            expected_domain = adapter._from_address.rsplit("@", 1)[-1]
+            assert mid.rstrip(">").endswith("@" + expected_domain), \
                 f"Message-ID domain not from from_address: {mid}"
 
     @pytest.mark.anyio

--- a/tests/test_resilience/test_deferred_work.py
+++ b/tests/test_resilience/test_deferred_work.py
@@ -66,6 +66,20 @@ class TestEnqueueDequeue:
         item2 = await queue.next_pending(max_priority=5)
         assert item2 is None
 
+    @pytest.mark.asyncio
+    async def test_next_pending_filters_by_work_type(self, queue):
+        # WS-6 head-of-line: a higher-priority outreach item (20) sits ahead of
+        # a reflection (30). Without a filter the consumer is blocked by it.
+        await queue.enqueue("outreach_delivery", None, 20, "{}", "reason")
+        await queue.enqueue("reflection", None, REFLECTION, "{}", "reason")
+
+        top = await queue.next_pending(max_priority=40)
+        assert top["work_type"] == "outreach_delivery"  # head-of-line blocker
+
+        refl = await queue.next_pending(work_type="reflection", max_priority=40)
+        assert refl is not None
+        assert refl["work_type"] == "reflection"  # reached past the blocker
+
 
 class TestMarkStatus:
     @pytest.mark.asyncio

--- a/tests/test_resilience/test_recovery.py
+++ b/tests/test_resilience/test_recovery.py
@@ -106,13 +106,20 @@ class TestRunRecovery:
         assert report.embeddings_recovered == 5
         mocks["embedding_worker"].drain_pending.assert_awaited_once_with(limit=500)
 
-    async def test_processes_deferred_work(self, orchestrator, mocks):
+    async def test_deferred_work_left_pending_not_completed(self, orchestrator, mocks):
+        """WS-6: recovery must NOT mark un-executed deferred items completed (data loss).
+
+        The old behaviour drained items and marked them completed without executing
+        them — silently dropping reflection/outreach work. Items must be left pending.
+        """
         items = [{"id": "a"}, {"id": "b"}]
         mocks["deferred_queue"].drain_by_priority = AsyncMock(return_value=items)
         mocks["deferred_queue"].mark_processing = AsyncMock(return_value=True)
         mocks["deferred_queue"].mark_completed = AsyncMock(return_value=True)
+        mocks["deferred_queue"].count_pending = AsyncMock(return_value=2)
         report = await orchestrator.run_recovery()
-        assert report.items_drained == 2
+        mocks["deferred_queue"].mark_completed.assert_not_awaited()
+        assert report.items_pending == 2  # left pending, not completed
 
     async def test_replays_dead_letters(self, orchestrator, mocks):
         mocks["dead_letter"].replay_pending = AsyncMock(return_value=4)
@@ -147,3 +154,27 @@ class TestRunRecovery:
         report = await orchestrator.run_recovery()
         assert report.dead_letters_replayed == 2
         mocks["dead_letter"].replay_pending.assert_awaited_once()
+
+    async def test_redispatch_skipped_when_degraded(self, orchestrator, mocks):
+        """WS-6: while any axis is degraded, re-dispatch (embedding drain + dead-letter
+        replay) is skipped, but housekeeping (expire) still runs."""
+        from genesis.resilience.state import CloudStatus as _Cloud
+        mocks["state_machine"].update_cloud(_Cloud.FALLBACK)  # degrade
+        report = await orchestrator.run_recovery()
+        mocks["embedding_worker"].drain_pending.assert_not_awaited()
+        mocks["dead_letter"].replay_pending.assert_not_awaited()
+        # housekeeping still runs
+        mocks["deferred_queue"].expire_stale.assert_awaited()
+        mocks["deferred_queue"].expire_stuck_processing.assert_awaited()
+        assert report.embeddings_recovered == 0
+        assert report.dead_letters_replayed == 0
+
+    async def test_tmp_pressure_does_not_gate_redispatch(self, orchestrator, mocks):
+        """WS-6: cc-tmp pressure (a monitoring signal) must NOT suppress re-dispatch —
+        it doesn't impair Qdrant or LLM providers."""
+        from genesis.resilience.state import TmpPressureStatus
+        mocks["state_machine"].update_tmp_pressure(TmpPressureStatus.MODERATE)
+        mocks["embedding_worker"].drain_pending = AsyncMock(return_value=5)
+        report = await orchestrator.run_recovery()
+        mocks["embedding_worker"].drain_pending.assert_awaited_once_with(limit=500)
+        assert report.embeddings_recovered == 5

--- a/tests/test_resilience/test_state.py
+++ b/tests/test_resilience/test_state.py
@@ -70,6 +70,19 @@ class TestBasicTransitions:
         assert sm.current.cloud == CloudStatus.NORMAL
         assert not sm.is_any_degraded()
 
+    def test_is_any_degraded_excludes_tmp_pressure_when_requested(self):
+        from genesis.resilience.state import TmpPressureStatus
+        sm = ResilienceStateMachine()
+        sm.update_tmp_pressure(TmpPressureStatus.MODERATE)
+        # cc-tmp pressure counts as degraded by default...
+        assert sm.is_any_degraded() is True
+        # ...but is excluded when the caller opts out (e.g. recovery re-dispatch gating —
+        # cc-tmp pressure doesn't impair Qdrant/providers).
+        assert sm.is_any_degraded(include_tmp_pressure=False) is False
+        # a real axis still registers even with tmp_pressure excluded.
+        sm.update_cloud(CloudStatus.FALLBACK)
+        assert sm.is_any_degraded(include_tmp_pressure=False) is True
+
     def test_transitions_recorded(self):
         sm = ResilienceStateMachine()
         sm.update_cloud(CloudStatus.FALLBACK)


### PR DESCRIPTION
## Summary

Two verified-live correctness fixes from the 2026-06-13 audit (P3).

### WS-6 — recovery orchestrator (`resilience/recovery.py`, `deferred_work.py`, `awareness/loop.py`, `state.py`)

The 30-minute `RecoveryOrchestrator` had three bugs:

1. **Silent data loss** — it drained pending deferred-work items and marked them **completed without executing them** (the code comment admitted it was a Phase 8/9 stub). The drain is removed; deferred work is left **pending**. Reflection items are already re-dispatched by the awareness loop; outreach items await a dedicated consumer (tracked follow-up).
2. **Head-of-line blocking** — the deferred queue carries reflection (priority 30) and `outreach_delivery` (priority 20) items. The awareness consumer pulled the single highest-priority item and bailed if it wasn't a reflection, so a higher-priority outreach item **starved every reflection retry** — and the lossy drain was the only thing clearing it. `next_pending` now takes a `work_type` filter (already supported by the query layer), and the awareness loop filters to reflections.
3. **Unconditional run** — re-dispatch (embedding drain + dead-letter replay) is now **gated** on a stable system (`is_any_degraded`, excluding cc-tmp pressure, which doesn't impair Qdrant/providers); housekeeping (expire stuck/stale, reset-failed-embeddings, overflow check) still runs every cycle. The always-zero `items_drained` report field is replaced by an honest `items_pending`.

### WS-9a — email Message-ID (`channels/email_adapter.py`)

Outbound email set **no Message-ID**, so mail shipped without one and the returned id was a fabricated placeholder — replies couldn't thread and our reply-poller couldn't match them. The adapter now sets a real RFC `Message-ID` via `email.utils.make_msgid` before send and returns it; the thread tracker already registers that returned id, so inbound reply-matching works.

(Outbound `In-Reply-To`/`References` so *our* replies thread in the recipient's client — WS-9b — is a separate follow-up; it needs deeper plumbing through the outreach pipeline.)

## Testing

- `pytest tests/test_resilience/ tests/test_channels/test_email_adapter.py tests/test_awareness/test_loop_resilience.py` — 78 passed (TDD: RED → GREEN).
- Covers: head-of-line filter, data-loss prevention (items left pending), re-dispatch gated when degraded, cc-tmp pressure does **not** gate, real RFC Message-ID.
- `ruff check` clean. Signature change to `next_pending` verified safe (no positional callers).
- Reviewed by a code-review agent; both findings (over-broad gate, misleading dead report field) addressed.

## Risk

Low-medium. The recovery change alters re-dispatch semantics — the deliberate trade-off is that deferred work now accumulates **pending** (surfaced by the existing overflow alert) instead of being silently dropped. `drain_by_priority` remains as an independently-tested queue utility, now unused by recovery.