### PR TITLE
feat(feedback): Self-Improvement Outcome Bus — foundation (dark capture)

### DIFF
--- a/src/genesis/db/crud/outcome_events.py
+++ b/src/genesis/db/crud/outcome_events.py
@@ -1,0 +1,201 @@
+"""CRUD for ``outcome_events`` — the Self-Improvement Outcome Bus ledger.
+
+Thin, strict data layer. ``record`` raises ``ValueError`` on malformed input
+(invalid tier/class/polarity, empty key fields) so bugs surface in tests; the
+fire-and-forget leniency that protects production paths lives one layer up in
+``feedback/bus.py``. Writes are idempotent on the unique key
+``(source, ref_type, ref_id, signal_type)``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+# Enum domains enforced by the table CHECK constraints — validated here too so
+# we raise a clear ValueError instead of relying on INSERT OR IGNORE silently
+# swallowing a CHECK violation (OR IGNORE skips BOTH unique AND check failures).
+_VALID_TIERS = frozenset({1, 2, 3})
+_VALID_CLASSES = frozenset({"implicit", "explicit"})
+_VALID_POLARITIES = frozenset({"positive", "negative", "neutral"})
+
+_COLUMNS = (
+    "id", "source", "ref_type", "ref_id", "domain", "signal_type",
+    "signal_class", "signal_tier", "polarity", "value", "stated_confidence",
+    "prediction_error", "reason", "reason_text", "metadata", "harvested_from",
+    "occurred_at",
+)
+
+
+def _rows_to_dicts(cur: aiosqlite.Cursor, rows: list) -> list[dict]:
+    cols = [d[0] for d in cur.description]
+    return [dict(zip(cols, r, strict=False)) for r in rows]
+
+
+async def record(
+    db: aiosqlite.Connection,
+    *,
+    source: str,
+    ref_type: str,
+    ref_id: str,
+    signal_type: str,
+    signal_tier: int,
+    domain: str | None = None,
+    signal_class: str = "implicit",
+    polarity: str | None = None,
+    value: float | None = None,
+    stated_confidence: float | None = None,
+    prediction_error: float | None = None,
+    reason: str | None = None,
+    reason_text: str | None = None,
+    metadata: dict | None = None,
+    harvested_from: str | None = None,
+    occurred_at: str | None = None,
+) -> str | None:
+    """Insert one outcome event, idempotently.
+
+    Returns the new row id if inserted, or ``None`` if a row with the same
+    ``(source, ref_type, ref_id, signal_type)`` already exists (OR IGNORE).
+
+    Raises ``ValueError`` on invalid enum values or empty key fields.
+    """
+    if not source or not ref_type or not ref_id or not signal_type:
+        raise ValueError(
+            "outcome_events.record: source/ref_type/ref_id/signal_type are required"
+        )
+    if signal_tier not in _VALID_TIERS:
+        raise ValueError(f"signal_tier must be one of {sorted(_VALID_TIERS)}, got {signal_tier!r}")
+    if signal_class not in _VALID_CLASSES:
+        raise ValueError(f"signal_class must be one of {sorted(_VALID_CLASSES)}, got {signal_class!r}")
+    if polarity is not None and polarity not in _VALID_POLARITIES:
+        raise ValueError(f"polarity must be None or one of {sorted(_VALID_POLARITIES)}, got {polarity!r}")
+
+    eid = uuid.uuid4().hex[:16]
+    occurred_at = occurred_at or datetime.now(UTC).isoformat()
+    meta_json = json.dumps(metadata) if metadata is not None else None
+
+    cur = await db.execute(
+        """INSERT OR IGNORE INTO outcome_events
+               (id, source, ref_type, ref_id, domain, signal_type, signal_class,
+                signal_tier, polarity, value, stated_confidence, prediction_error,
+                reason, reason_text, metadata, harvested_from, occurred_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            eid, source, ref_type, ref_id, domain, signal_type, signal_class,
+            signal_tier, polarity, value, stated_confidence, prediction_error,
+            reason, reason_text, meta_json, harvested_from, occurred_at,
+        ),
+    )
+    await db.commit()
+    return eid if cur.rowcount > 0 else None
+
+
+async def exists(
+    db: aiosqlite.Connection,
+    *,
+    source: str,
+    ref_type: str,
+    ref_id: str,
+    signal_type: str,
+) -> bool:
+    """True if an event with this unique key already exists."""
+    cur = await db.execute(
+        "SELECT 1 FROM outcome_events "
+        "WHERE source = ? AND ref_type = ? AND ref_id = ? AND signal_type = ? LIMIT 1",
+        (source, ref_type, ref_id, signal_type),
+    )
+    return await cur.fetchone() is not None
+
+
+async def count(db: aiosqlite.Connection) -> int:
+    """Total number of recorded outcome events."""
+    cur = await db.execute("SELECT COUNT(*) FROM outcome_events")
+    row = await cur.fetchone()
+    return row[0] if row else 0
+
+
+async def count_by_signal_type(db: aiosqlite.Connection) -> dict[str, int]:
+    """Coverage accounting: row counts grouped by signal_type."""
+    cur = await db.execute(
+        "SELECT signal_type, COUNT(*) FROM outcome_events GROUP BY signal_type"
+    )
+    rows = await cur.fetchall()
+    return {r[0]: r[1] for r in rows}
+
+
+async def aggregate_by_domain(
+    db: aiosqlite.Connection,
+    *,
+    days: int = 30,
+    tier: int | None = None,
+) -> list[dict]:
+    """Per-domain outcome rollup over a recent window.
+
+    ``tier`` optionally restricts to one signal tier (e.g. tier=1 for the
+    ground-truth view that downstream quality scoring should weight highest).
+    """
+    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+    sql = """
+        SELECT domain,
+               COUNT(*)                                                   AS n,
+               SUM(CASE WHEN polarity = 'positive' THEN 1 ELSE 0 END)     AS positive,
+               SUM(CASE WHEN polarity = 'negative' THEN 1 ELSE 0 END)     AS negative,
+               AVG(value)                                                 AS avg_value,
+               AVG(stated_confidence)                                     AS avg_confidence,
+               AVG(prediction_error)                                      AS avg_prediction_error
+        FROM outcome_events
+        WHERE occurred_at >= ?
+    """
+    params: list = [cutoff]
+    if tier is not None:
+        sql += " AND signal_tier = ?"
+        params.append(tier)
+    sql += " GROUP BY domain ORDER BY n DESC"
+    cur = await db.execute(sql, params)
+    rows = await cur.fetchall()
+    return _rows_to_dicts(cur, rows)
+
+
+async def calibration_by_domain(
+    db: aiosqlite.Connection,
+    *,
+    days: int = 90,
+    tier: int = 1,
+) -> list[dict]:
+    """Rows usable for calibration: a stated confidence paired with a graded
+    outcome value, within ``tier`` (ground truth by default).
+
+    Feeds Phase 2 (ego-decision calibration / ECE); returns raw paired rows so
+    the calibration engine owns the bucketing.
+    """
+    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+    cur = await db.execute(
+        """
+        SELECT domain, stated_confidence, value, polarity, signal_type, occurred_at
+        FROM outcome_events
+        WHERE signal_tier = ?
+          AND stated_confidence IS NOT NULL
+          AND value IS NOT NULL
+          AND occurred_at >= ?
+        ORDER BY domain, occurred_at
+        """,
+        (tier, cutoff),
+    )
+    rows = await cur.fetchall()
+    return _rows_to_dicts(cur, rows)
+
+
+async def recent(db: aiosqlite.Connection, *, limit: int = 20) -> list[dict]:
+    """Most recent outcome events (debug/verification/display)."""
+    cur = await db.execute(
+        "SELECT * FROM outcome_events ORDER BY occurred_at DESC LIMIT ?",
+        (limit,),
+    )
+    rows = await cur.fetchall()
+    return _rows_to_dicts(cur, rows)

--- a/src/genesis/db/migrations/0025_outcome_events.py
+++ b/src/genesis/db/migrations/0025_outcome_events.py
@@ -1,0 +1,76 @@
+"""Create the ``outcome_events`` table — the Self-Improvement Outcome Bus ledger.
+
+An append-only, attributed, quality-weighted record of what actually happened
+after Genesis acted: post-execution outcomes (T1 ground truth), user decisions
+(T2/T3), and coverage events. It unifies signals that today are siloed or buried
+(e.g. the T1 "did it work" outcome is currently a ``|completed:``/``|failed:``
+suffix on ``ego_proposals.user_response`` — captured for ~1.6% of executions).
+
+Neutral framing (``outcome_events``, not ``reward_signals``): this is observation,
+not RL training. The bus is DARK on creation — nothing emits or consumes here;
+Step 1 only lays the table + CRUD.
+
+Idempotent (``IF NOT EXISTS``). Fresh installs get the same DDL via
+``db/schema/_tables.py``; this migration covers existing installs.
+
+The UNIQUE key ``(source, ref_type, ref_id, signal_type)`` makes harvest/backfill
+idempotent. ``signal_type`` uses a controlled vocabulary so distinct event classes
+on the SAME ref (e.g. a T2 ``user_decision`` and a later T1 ``execution_outcome``
+on one proposal) never collide on the key — preventing the bus from silently
+dropping the higher-tier ground-truth signal.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+_TABLE_DDL = """
+    CREATE TABLE IF NOT EXISTS outcome_events (
+        id                TEXT PRIMARY KEY,
+        source            TEXT NOT NULL,
+        ref_type          TEXT NOT NULL,
+        ref_id            TEXT NOT NULL,
+        domain            TEXT,
+        signal_type       TEXT NOT NULL,
+        signal_class      TEXT NOT NULL DEFAULT 'implicit'
+                              CHECK (signal_class IN ('implicit', 'explicit')),
+        signal_tier       INTEGER NOT NULL CHECK (signal_tier IN (1, 2, 3)),
+        polarity          TEXT CHECK (polarity IN ('positive', 'negative', 'neutral')),
+        value             REAL,
+        stated_confidence REAL,
+        prediction_error  REAL,
+        reason            TEXT,
+        reason_text       TEXT,
+        metadata          TEXT,
+        harvested_from    TEXT,
+        occurred_at       TEXT NOT NULL,
+        created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE (source, ref_type, ref_id, signal_type)
+    )
+"""
+
+_INDEX_DDL = (
+    "CREATE INDEX IF NOT EXISTS idx_outcome_events_domain ON outcome_events(domain)",
+    "CREATE INDEX IF NOT EXISTS idx_outcome_events_source ON outcome_events(source)",
+    "CREATE INDEX IF NOT EXISTS idx_outcome_events_tier ON outcome_events(signal_tier)",
+    "CREATE INDEX IF NOT EXISTS idx_outcome_events_signal_type ON outcome_events(signal_type)",
+    "CREATE INDEX IF NOT EXISTS idx_outcome_events_ref ON outcome_events(ref_type, ref_id)",
+    "CREATE INDEX IF NOT EXISTS idx_outcome_events_occurred ON outcome_events(occurred_at)",
+    # Calibration reads pull tier-1 rows that carry both a stated confidence and
+    # a graded outcome value; partial index keeps that scan cheap.
+    "CREATE INDEX IF NOT EXISTS idx_outcome_events_calibration "
+    "ON outcome_events(domain, signal_tier) "
+    "WHERE stated_confidence IS NOT NULL AND value IS NOT NULL",
+)
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # NOTE: must NOT call db.commit()/BEGIN — the runner owns the transaction.
+    await db.execute(_TABLE_DDL)
+    for stmt in _INDEX_DDL:
+        await db.execute(stmt)
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    """Drop the table (and its indexes) — development/testing only."""
+    await db.execute("DROP TABLE IF EXISTS outcome_events")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -523,6 +523,30 @@ TABLES = {
             matched_at        TEXT
         )
     """,
+    "outcome_events": """
+        CREATE TABLE IF NOT EXISTS outcome_events (
+            id                TEXT PRIMARY KEY,
+            source            TEXT NOT NULL,
+            ref_type          TEXT NOT NULL,
+            ref_id            TEXT NOT NULL,
+            domain            TEXT,
+            signal_type       TEXT NOT NULL,
+            signal_class      TEXT NOT NULL DEFAULT 'implicit'
+                                  CHECK (signal_class IN ('implicit', 'explicit')),
+            signal_tier       INTEGER NOT NULL CHECK (signal_tier IN (1, 2, 3)),
+            polarity          TEXT CHECK (polarity IN ('positive', 'negative', 'neutral')),
+            value             REAL,
+            stated_confidence REAL,
+            prediction_error  REAL,
+            reason            TEXT,
+            reason_text       TEXT,
+            metadata          TEXT,
+            harvested_from    TEXT,
+            occurred_at       TEXT NOT NULL,
+            created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE (source, ref_type, ref_id, signal_type)
+        )
+    """,
     "events": """
         CREATE TABLE IF NOT EXISTS events (
             id               TEXT PRIMARY KEY,
@@ -1441,6 +1465,16 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_predictions_domain ON predictions(domain)",
     "CREATE INDEX IF NOT EXISTS idx_predictions_bucket ON predictions(confidence_bucket)",
     "CREATE INDEX IF NOT EXISTS idx_predictions_unmatched ON predictions(outcome) WHERE outcome IS NULL",
+    # outcome bus (self-improvement ledger)
+    "CREATE INDEX IF NOT EXISTS idx_outcome_events_domain ON outcome_events(domain)",
+    "CREATE INDEX IF NOT EXISTS idx_outcome_events_source ON outcome_events(source)",
+    "CREATE INDEX IF NOT EXISTS idx_outcome_events_tier ON outcome_events(signal_tier)",
+    "CREATE INDEX IF NOT EXISTS idx_outcome_events_signal_type ON outcome_events(signal_type)",
+    "CREATE INDEX IF NOT EXISTS idx_outcome_events_ref ON outcome_events(ref_type, ref_id)",
+    "CREATE INDEX IF NOT EXISTS idx_outcome_events_occurred ON outcome_events(occurred_at)",
+    "CREATE INDEX IF NOT EXISTS idx_outcome_events_calibration "
+    "ON outcome_events(domain, signal_tier) "
+    "WHERE stated_confidence IS NOT NULL AND value IS NOT NULL",
     # approval requests (Phase 9)
     "CREATE INDEX IF NOT EXISTS idx_approval_status ON approval_requests(status)",
     "CREATE INDEX IF NOT EXISTS idx_approval_class ON approval_requests(action_class)",

--- a/src/genesis/feedback/__init__.py
+++ b/src/genesis/feedback/__init__.py
@@ -1,0 +1,19 @@
+"""feedback — the Self-Improvement Outcome Bus.
+
+Connective tissue over Genesis's existing, siloed self-improvement signals.
+An append-only, attributed, quality-weighted ledger (``outcome_events``) of what
+actually happened after Genesis acted, so downstream calibration, deficiency
+modelling, and the objective function can read one neutral source of truth
+instead of six buried ones.
+
+Layers:
+- ``db/crud/outcome_events`` — strict storage primitive (raises on bad input).
+- ``feedback.bus`` — fire-and-forget write path + signal taxonomy (tier policy).
+- ``feedback.harvest`` — scheduled idempotent folding of existing signals
+  + one-shot backfill.
+
+Neutral framing: ``outcome_events``, not ``reward_signals`` — this is
+observation, not reinforcement-learning training.
+"""
+
+from __future__ import annotations

--- a/src/genesis/feedback/bus.py
+++ b/src/genesis/feedback/bus.py
@@ -1,0 +1,148 @@
+"""feedback/bus.py — the Outcome Bus write path + signal taxonomy.
+
+``record_outcome`` is the single, fire-and-forget entry point for recording what
+happened after Genesis acted. It applies the signal taxonomy (controlled
+``signal_type`` vocabulary + tier policy) and NEVER raises — instrumentation must
+never break a production path (modeled on ``eval/j9_hooks.py``).
+
+Signal-quality hierarchy (the whole point of the bus):
+- **Tier 1 — ground truth.** Post-execution outcome: did the dispatched work
+  actually succeed / pass deliverable verification. Outranks user approval.
+- **Tier 2 — informative.** A rationale-bearing signal (a rejection WITH a
+  reason, an outreach reply, a triage correction). Discounted, never absolute.
+- **Tier 3 — coverage only.** Bare status / lifecycle / weak implicit signals
+  (a timeout is not disapproval; a dispatch is not an outcome). ~zero quality
+  weight; recorded so the loop closes, kept out of any quality denominator.
+
+Anti-timidity: nothing here teaches the ego to propose *less*. Tiering measures
+signal quality, not desirability of proposing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import aiosqlite
+
+from genesis.db.crud import outcome_events as _crud
+
+logger = logging.getLogger(__name__)
+
+
+class SignalType:
+    """Controlled ``signal_type`` vocabulary.
+
+    Distinct values per event class guarantee that two different signals on the
+    SAME ref (e.g. a user_decision and a later execution_outcome on one proposal)
+    never collide on the unique key ``(source, ref_type, ref_id, signal_type)`` —
+    so the bus can never silently drop the higher-tier ground-truth signal.
+    """
+
+    # Tier 1 — post-execution ground truth
+    EXECUTION_OUTCOME = "execution_outcome"
+    VERIFICATION_FAILED = "verification_failed"
+    # Tier 2 — informative (rationale-bearing)
+    USER_DECISION = "user_decision"          # tier 2 WITH a rationale, else tier 3
+    OUTREACH_REPLY = "outreach_reply"
+    TRIAGE_CORRECTION = "triage_correction"
+    # Tier 3 — coverage / lifecycle / weak implicit
+    DISPATCH = "dispatch"
+    LIFECYCLE_TABLED = "lifecycle_tabled"
+    LIFECYCLE_WITHDRAWN = "lifecycle_withdrawn"
+    OUTREACH_IMPLICIT = "outreach_implicit"
+    MEMORY_INFLUENCE = "memory_influence"
+
+
+# Default tier per signal_type. USER_DECISION is special-cased: a bare decision
+# is coverage-only (T3), but a decision carrying a rationale is informative (T2).
+_DEFAULT_TIER: dict[str, int] = {
+    SignalType.EXECUTION_OUTCOME: 1,
+    SignalType.VERIFICATION_FAILED: 1,
+    SignalType.USER_DECISION: 3,
+    SignalType.OUTREACH_REPLY: 2,
+    SignalType.TRIAGE_CORRECTION: 2,
+    SignalType.DISPATCH: 3,
+    SignalType.LIFECYCLE_TABLED: 3,
+    SignalType.LIFECYCLE_WITHDRAWN: 3,
+    SignalType.OUTREACH_IMPLICIT: 3,
+    SignalType.MEMORY_INFLUENCE: 3,
+}
+
+KNOWN_SIGNAL_TYPES = frozenset(_DEFAULT_TIER)
+
+
+def default_tier(signal_type: str, *, has_rationale: bool = False) -> int:
+    """Resolve the signal tier from the taxonomy.
+
+    A ``user_decision`` is upgraded from coverage (T3) to informative (T2) only
+    when it carries a rationale — the user's *why* is the best signal we get from
+    a decision, and even then it is discounted, never treated as ground truth.
+    """
+    if signal_type == SignalType.USER_DECISION:
+        return 2 if has_rationale else 3
+    return _DEFAULT_TIER.get(signal_type, 3)
+
+
+async def record_outcome(
+    db: aiosqlite.Connection,
+    *,
+    source: str,
+    ref_type: str,
+    ref_id: str,
+    signal_type: str,
+    signal_tier: int | None = None,
+    domain: str | None = None,
+    signal_class: str = "implicit",
+    polarity: str | None = None,
+    value: float | None = None,
+    stated_confidence: float | None = None,
+    prediction_error: float | None = None,
+    reason: str | None = None,
+    reason_text: str | None = None,
+    metadata: dict | None = None,
+    harvested_from: str | None = None,
+    occurred_at: str | None = None,
+) -> str | None:
+    """Record one outcome event — fire-and-forget, never raises.
+
+    The single write path for the bus (live emit hooks AND the harvester). If
+    ``signal_tier`` is not given it is derived from the taxonomy; for a
+    ``user_decision`` the presence of ``reason``/``reason_text`` upgrades it to
+    Tier 2. Returns the row id, or ``None`` if the event already existed
+    (idempotent) or anything went wrong (logged, never propagated).
+    """
+    try:
+        if signal_type not in KNOWN_SIGNAL_TYPES:
+            # Forward-compatible: record at coverage tier, but flag the unknown
+            # so the vocabulary can be extended deliberately, not by accident.
+            logger.debug("outcome bus: unknown signal_type %r — recording at T3", signal_type)
+
+        if signal_tier is None:
+            has_rationale = bool(reason or reason_text)
+            signal_tier = default_tier(signal_type, has_rationale=has_rationale)
+
+        return await _crud.record(
+            db,
+            source=source,
+            ref_type=ref_type,
+            ref_id=ref_id,
+            signal_type=signal_type,
+            signal_tier=signal_tier,
+            domain=domain,
+            signal_class=signal_class,
+            polarity=polarity,
+            value=value,
+            stated_confidence=stated_confidence,
+            prediction_error=prediction_error,
+            reason=reason,
+            reason_text=reason_text,
+            metadata=metadata,
+            harvested_from=harvested_from,
+            occurred_at=occurred_at,
+        )
+    except Exception:
+        logger.debug(
+            "outcome bus: record_outcome failed (%s/%s/%s/%s)",
+            source, ref_type, ref_id, signal_type, exc_info=True,
+        )
+        return None

--- a/src/genesis/feedback/bus.py
+++ b/src/genesis/feedback/bus.py
@@ -49,6 +49,7 @@ class SignalType:
     DISPATCH = "dispatch"
     LIFECYCLE_TABLED = "lifecycle_tabled"
     LIFECYCLE_WITHDRAWN = "lifecycle_withdrawn"
+    LIFECYCLE_EXPIRED = "lifecycle_expired"
     OUTREACH_IMPLICIT = "outreach_implicit"
     MEMORY_INFLUENCE = "memory_influence"
 
@@ -64,6 +65,7 @@ _DEFAULT_TIER: dict[str, int] = {
     SignalType.DISPATCH: 3,
     SignalType.LIFECYCLE_TABLED: 3,
     SignalType.LIFECYCLE_WITHDRAWN: 3,
+    SignalType.LIFECYCLE_EXPIRED: 3,
     SignalType.OUTREACH_IMPLICIT: 3,
     SignalType.MEMORY_INFLUENCE: 3,
 }

--- a/src/genesis/feedback/harvest.py
+++ b/src/genesis/feedback/harvest.py
@@ -99,18 +99,42 @@ class OutcomeHarvester:
         }
 
     async def run_backfill(self) -> dict:
-        """One-shot harvest of ALL history, guarded so it runs exactly once."""
+        """One-shot harvest of ALL history, guarded so it runs exactly once.
+
+        The guard marker is set ONLY when every source completed without an
+        exception — so a transient failure (e.g. a startup DB race) cannot
+        permanently lock the backfill gate and silently lose the historical
+        rows. A clean run over genuinely-empty tables (0 rows, no error) DOES
+        set the marker — there is nothing to backfill.
+        """
         if await ego_crud.get_state(self._db, BACKFILL_MARKER):
             return {"skipped": True}
-        result = {
-            "skipped": False,
-            "proposals": await self._safe(self._harvest_proposals, None),
-            "outreach": await self._safe(self._harvest_outreach, None),
-        }
-        await ego_crud.set_state(
-            self._db, key=BACKFILL_MARKER, value=datetime.now(UTC).isoformat()
-        )
-        logger.info("Outcome backfill complete: %s", result)
+
+        failures = 0
+        counts: dict[str, int] = {}
+        for name, fn in (
+            ("proposals", self._harvest_proposals),
+            ("outreach", self._harvest_outreach),
+        ):
+            try:
+                counts[name] = await fn(None)
+            except Exception:
+                logger.exception("Outcome backfill: source %r failed", name)
+                counts[name] = 0
+                failures += 1
+
+        result = {"skipped": False, **counts}
+        if failures == 0:
+            await ego_crud.set_state(
+                self._db, key=BACKFILL_MARKER, value=datetime.now(UTC).isoformat()
+            )
+            logger.info("Outcome backfill complete: %s", result)
+        else:
+            result["incomplete"] = True
+            logger.warning(
+                "Outcome backfill incomplete (%d source failure(s)) — marker NOT "
+                "set; will retry next tick. %s", failures, result,
+            )
         return result
 
     # -- per-source harvesters --------------------------------------------- #
@@ -173,10 +197,12 @@ class OutcomeHarvester:
                     polarity="negative", reason_text=r["user_response"],
                 )
             elif status == "approved":
-                reason = None if suffix else r["user_response"]
+                # user_response on an approved (not-yet-executed) proposal is an
+                # optional approval note — execution suffixes only appear once a
+                # proposal is `executed` (handled above).
                 eid = await record_outcome(
                     self._db, **common, signal_type=SignalType.USER_DECISION,
-                    polarity="positive", reason_text=reason,
+                    polarity="positive", reason_text=r["user_response"],
                 )
             elif status == "tabled":
                 eid = await record_outcome(
@@ -186,6 +212,14 @@ class OutcomeHarvester:
             elif status == "withdrawn":
                 eid = await record_outcome(
                     self._db, **common, signal_type=SignalType.LIFECYCLE_WITHDRAWN,
+                    polarity="neutral",
+                )
+            elif status == "expired":
+                # The user let the proposal time out. Per the signal-quality
+                # design a timeout is NOT disapproval — coverage only (T3),
+                # kept out of any quality denominator.
+                eid = await record_outcome(
+                    self._db, **common, signal_type=SignalType.LIFECYCLE_EXPIRED,
                     polarity="neutral",
                 )
             else:
@@ -201,7 +235,7 @@ class OutcomeHarvester:
             "SELECT id, engagement_outcome, user_response, category, "
             "       prediction_error, delivered_at, created_at "
             "FROM outreach_history "
-            "WHERE engagement_outcome IS NOT NULL AND engagement_outcome != ''"
+            "WHERE engagement_outcome IS NOT NULL AND trim(engagement_outcome) != ''"
         )
         params: list = []
         if cutoff is not None:

--- a/src/genesis/feedback/harvest.py
+++ b/src/genesis/feedback/harvest.py
@@ -1,0 +1,248 @@
+"""feedback/harvest.py — fold existing siloed signals into the Outcome Bus.
+
+The ``OutcomeHarvester`` reads Genesis's authoritative outcome tables and records
+them as structured ``outcome_events`` via the fire-and-forget bus. It NEVER
+mutates the source tables or touches their writers/consumers — it only reads.
+
+Two entry points:
+- ``run()`` — scheduled, incremental: re-scan a recent window each tick.
+  Idempotent on the unique key, so re-scanning is a cheap no-op.
+- ``run_backfill()`` — one-shot over ALL history, guarded by an ``ego_state``
+  marker so it executes exactly once. This is what closes the historical gap
+  (e.g. the ~63 executed/failed proposal outcomes currently buried as a string
+  suffix on ``ego_proposals.user_response``, captured for ~1.6% today).
+
+Source authority (no double-counting):
+- **ego_proposals** — the source of truth for proposal lifecycle AND the buried
+  T1 execution outcome. ``intervention_journal`` is a redundant echo of the same
+  proposals, so it is intentionally NOT harvested here (the unique key would
+  dedupe it anyway, but skipping the redundant read is cleaner).
+- **outreach_history** — engagement outcomes.
+- ``ego_cycle_outcomes`` is process telemetry (cycle assessments / costs), not a
+  per-action outcome signal, so it is captured as attribution metadata
+  (``cycle_id``) on proposal events rather than as standalone rows.
+
+Each source read is wrapped independently (``_safe``) so one bad source can never
+abort the others.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+
+from genesis.db.crud import ego as ego_crud
+from genesis.feedback.bus import SignalType, record_outcome
+
+logger = logging.getLogger(__name__)
+
+BACKFILL_MARKER = "outcome_backfill_done"
+
+# Markers update_proposal_outcome appends to ego_proposals.user_response.
+# Two forms exist: "<session_id>|completed:<summary>" and a bare
+# "|completed:<summary>" (when the dispatch-record step was skipped). ``find``
+# handles both regardless of any prefix.
+_SUFFIX_MAP = (
+    ("|completed:", "positive", 1.0),
+    ("|failed:", "negative", 0.0),
+)
+
+
+# engagement_outcome → (signal_type, polarity, value). The live vocabulary is
+# richer than the schema CHECK (which lists only useful/not_useful/ambivalent/
+# ignored): prod also carries 'acted_on' and 'acknowledged' (positive behavioural
+# signals) — a pre-existing outreach schema/data drift, tracked separately. We map
+# what actually exists; explicit > implicit-negative defaulting (which would
+# mislabel acted_on/acknowledged and the empty-string rows).
+_OUTREACH_MAP: dict[str, tuple[str, str, float | None]] = {
+    "useful":       ("outreach_reply", "positive", 1.0),
+    "acted_on":     ("outreach_reply", "positive", 1.0),
+    "acknowledged": ("outreach_reply", "positive", 0.5),
+    "not_useful":   ("outreach_reply", "negative", 0.0),
+    "ambivalent":   ("outreach_implicit", "neutral", None),
+    "ignored":      ("outreach_implicit", "negative", 0.0),
+}
+
+
+def _parse_execution_suffix(user_response: str | None) -> tuple[str, float, str] | None:
+    """Extract the buried T1 outcome from ``user_response``.
+
+    Returns ``(polarity, value, summary)`` if a completion/failure suffix is
+    present, else ``None`` (the field holds a user rationale, a bare session id,
+    or nothing).
+    """
+    if not user_response:
+        return None
+    for marker, polarity, value in _SUFFIX_MAP:
+        idx = user_response.find(marker)
+        if idx != -1:
+            return polarity, value, user_response[idx + len(marker):][:1000]
+    return None
+
+
+class OutcomeHarvester:
+    """Idempotently folds existing outcome signals into ``outcome_events``."""
+
+    def __init__(self, db: aiosqlite.Connection) -> None:
+        self._db = db
+
+    # -- public entry points ------------------------------------------------ #
+
+    async def run(self, *, window_days: int = 2) -> dict:
+        """Incremental harvest of a recent window (scheduled cadence)."""
+        cutoff = (datetime.now(UTC) - timedelta(days=window_days)).isoformat()
+        return {
+            "proposals": await self._safe(self._harvest_proposals, cutoff),
+            "outreach": await self._safe(self._harvest_outreach, cutoff),
+        }
+
+    async def run_backfill(self) -> dict:
+        """One-shot harvest of ALL history, guarded so it runs exactly once."""
+        if await ego_crud.get_state(self._db, BACKFILL_MARKER):
+            return {"skipped": True}
+        result = {
+            "skipped": False,
+            "proposals": await self._safe(self._harvest_proposals, None),
+            "outreach": await self._safe(self._harvest_outreach, None),
+        }
+        await ego_crud.set_state(
+            self._db, key=BACKFILL_MARKER, value=datetime.now(UTC).isoformat()
+        )
+        logger.info("Outcome backfill complete: %s", result)
+        return result
+
+    # -- per-source harvesters --------------------------------------------- #
+
+    async def _harvest_proposals(self, cutoff: str | None) -> int:
+        """ego_proposals → execution_outcome (T1) / user_decision (T2-3) /
+        lifecycle (T3). ``cutoff`` (ISO) limits to recent rows; ``None`` = all."""
+        sql = (
+            "SELECT id, status, user_response, confidence, action_type, "
+            "       cycle_id, created_at, resolved_at "
+            "FROM ego_proposals WHERE status != 'pending'"
+        )
+        params: list = []
+        if cutoff is not None:
+            sql += " AND COALESCE(resolved_at, created_at) >= ?"
+            params.append(cutoff)
+
+        cur = await self._db.execute(sql, params)
+        rows = await cur.fetchall()
+        cols = [d[0] for d in cur.description]
+
+        inserted = 0
+        for raw in rows:
+            r = dict(zip(cols, raw, strict=False))
+            status = r["status"]
+            occurred_at = r["resolved_at"] or r["created_at"]
+            metadata = {"cycle_id": r["cycle_id"]} if r["cycle_id"] else None
+            common = dict(
+                source="ego",
+                ref_type="proposal",
+                ref_id=r["id"],
+                domain=r["action_type"],
+                stated_confidence=r["confidence"],
+                occurred_at=occurred_at,
+                harvested_from="ego_proposals",
+                metadata=metadata,
+            )
+            suffix = _parse_execution_suffix(r["user_response"])
+
+            if status == "executed" and suffix is not None:
+                polarity, value, summary = suffix
+                eid = await record_outcome(
+                    self._db, **common, signal_type=SignalType.EXECUTION_OUTCOME,
+                    polarity=polarity, value=value, reason_text=summary,
+                )
+            elif status == "executed":
+                # Dispatched, but no outcome recorded yet → coverage only.
+                eid = await record_outcome(
+                    self._db, **common, signal_type=SignalType.DISPATCH,
+                    polarity="neutral",
+                )
+            elif status == "failed":
+                eid = await record_outcome(
+                    self._db, **common, signal_type=SignalType.EXECUTION_OUTCOME,
+                    polarity="negative", value=0.0, reason_text="dispatch failed",
+                )
+            elif status == "rejected":
+                eid = await record_outcome(
+                    self._db, **common, signal_type=SignalType.USER_DECISION,
+                    polarity="negative", reason_text=r["user_response"],
+                )
+            elif status == "approved":
+                reason = None if suffix else r["user_response"]
+                eid = await record_outcome(
+                    self._db, **common, signal_type=SignalType.USER_DECISION,
+                    polarity="positive", reason_text=reason,
+                )
+            elif status == "tabled":
+                eid = await record_outcome(
+                    self._db, **common, signal_type=SignalType.LIFECYCLE_TABLED,
+                    polarity="neutral",
+                )
+            elif status == "withdrawn":
+                eid = await record_outcome(
+                    self._db, **common, signal_type=SignalType.LIFECYCLE_WITHDRAWN,
+                    polarity="neutral",
+                )
+            else:
+                continue  # unknown/non-terminal status — skip
+
+            if eid:
+                inserted += 1
+        return inserted
+
+    async def _harvest_outreach(self, cutoff: str | None) -> int:
+        """outreach_history → outreach_reply (T2) / outreach_implicit (T3)."""
+        sql = (
+            "SELECT id, engagement_outcome, user_response, category, "
+            "       prediction_error, delivered_at, created_at "
+            "FROM outreach_history "
+            "WHERE engagement_outcome IS NOT NULL AND engagement_outcome != ''"
+        )
+        params: list = []
+        if cutoff is not None:
+            sql += " AND COALESCE(delivered_at, created_at) >= ?"
+            params.append(cutoff)
+
+        cur = await self._db.execute(sql, params)
+        rows = await cur.fetchall()
+        cols = [d[0] for d in cur.description]
+
+        inserted = 0
+        for raw in rows:
+            r = dict(zip(cols, raw, strict=False))
+            mapping = _OUTREACH_MAP.get((r["engagement_outcome"] or "").strip())
+            if mapping is None:
+                continue  # empty / unknown engagement value — no real signal
+            signal_type, polarity, value = mapping
+            eid = await record_outcome(
+                self._db,
+                source="outreach",
+                ref_type="outreach",
+                ref_id=r["id"],
+                domain=r["category"],
+                prediction_error=r["prediction_error"],
+                occurred_at=r["delivered_at"] or r["created_at"],
+                harvested_from="outreach_history",
+                signal_type=signal_type,
+                polarity=polarity,
+                value=value,
+                reason_text=r["user_response"],
+            )
+            if eid:
+                inserted += 1
+        return inserted
+
+    # -- helper ------------------------------------------------------------- #
+
+    async def _safe(self, fn, cutoff: str | None) -> int:
+        """Run one source harvest; isolate its failure from the others."""
+        try:
+            return await fn(cutoff)
+        except Exception:
+            logger.debug("OutcomeHarvester: source %s failed", fn.__name__, exc_info=True)
+            return 0

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -572,6 +572,41 @@ async def init(rt: GenesisRuntime) -> None:
             misfire_grace_time=3600,
         )
 
+        async def _run_outcome_harvest() -> None:
+            # Fold existing siloed outcome signals into the outcome_events
+            # ledger. DARK: nothing consumes the ledger yet, so this is
+            # behaviour-neutral — it only populates a new table. The one-shot
+            # backfill (guarded by an ego_state marker) runs once; run() keeps
+            # the recent window fresh thereafter.
+            if rt._db is None:
+                return
+            try:
+                from genesis.feedback.harvest import OutcomeHarvester
+
+                harvester = OutcomeHarvester(rt._db)
+                backfill = await harvester.run_backfill()
+                incremental = await harvester.run()
+                rt.record_job_success("outcome_harvest")
+                if not backfill.get("skipped"):
+                    logger.info("Outcome backfill: %s", backfill)
+                if any(incremental.values()):
+                    logger.info("Outcome harvest: %s", incremental)
+            except Exception as exc:
+                rt.record_job_failure("outcome_harvest", str(exc))
+                logger.exception("Outcome harvest failed")
+
+        rt._learning_scheduler.add_job(
+            _run_outcome_harvest,
+            # 30 min before capability_map_refresh (9:15/21:15) in CLOCK time —
+            # APScheduler fires by trigger time, not registration order — so the
+            # map step (a future PR) reads a fresh harvest. Avoids the loaded
+            # 0-6h windows (calibration, reapers, dream cycle, user-model).
+            CronTrigger(hour="8,20", minute=45, timezone=user_timezone()),
+            id="outcome_harvest",
+            max_instances=1,
+            misfire_grace_time=3600,
+        )
+
         async def _reap_activity_log() -> None:
             if rt._activity_tracker is None:
                 return

--- a/tests/feedback/test_bus.py
+++ b/tests/feedback/test_bus.py
@@ -1,0 +1,121 @@
+"""Tests for feedback/bus.py — the Outcome Bus write path + signal taxonomy."""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import outcome_events as oe
+from genesis.feedback import bus
+from genesis.feedback.bus import SignalType, default_tier, record_outcome
+
+MIGRATION = importlib.import_module("genesis.db.migrations.0025_outcome_events")
+
+
+@pytest.fixture
+async def db(tmp_path):
+    db_path = str(tmp_path / "bus.db")
+    async with aiosqlite.connect(db_path) as conn:
+        await MIGRATION.up(conn)
+        await conn.commit()
+        yield conn
+
+
+class TestTaxonomy:
+    def test_tier1_ground_truth(self):
+        assert default_tier(SignalType.EXECUTION_OUTCOME) == 1
+        assert default_tier(SignalType.VERIFICATION_FAILED) == 1
+
+    def test_user_decision_tier_depends_on_rationale(self):
+        assert default_tier(SignalType.USER_DECISION) == 3
+        assert default_tier(SignalType.USER_DECISION, has_rationale=True) == 2
+
+    def test_informative_and_coverage(self):
+        assert default_tier(SignalType.OUTREACH_REPLY) == 2
+        assert default_tier(SignalType.TRIAGE_CORRECTION) == 2
+        assert default_tier(SignalType.DISPATCH) == 3
+        assert default_tier(SignalType.OUTREACH_IMPLICIT) == 3
+
+    def test_unknown_defaults_to_coverage(self):
+        assert default_tier("something_new") == 3
+
+
+class TestRecordOutcome:
+    @pytest.mark.asyncio
+    async def test_records_and_derives_tier(self, db):
+        eid = await record_outcome(
+            db, source="ego", ref_type="proposal", ref_id="p1",
+            signal_type=SignalType.EXECUTION_OUTCOME, polarity="positive", value=1.0,
+        )
+        assert eid is not None
+        rows = await oe.recent(db, limit=1)
+        assert rows[0]["signal_tier"] == 1  # derived from taxonomy
+
+    @pytest.mark.asyncio
+    async def test_user_decision_rationale_upgrades_tier(self, db):
+        await record_outcome(
+            db, source="ego", ref_type="proposal", ref_id="with_reason",
+            signal_type=SignalType.USER_DECISION, reason="timing", reason_text="not now",
+        )
+        await record_outcome(
+            db, source="ego", ref_type="proposal", ref_id="bare",
+            signal_type=SignalType.USER_DECISION,
+        )
+        rows = {r["ref_id"]: r for r in await oe.recent(db, limit=10)}
+        assert rows["with_reason"]["signal_tier"] == 2
+        assert rows["bare"]["signal_tier"] == 3
+
+    @pytest.mark.asyncio
+    async def test_explicit_tier_overrides_default(self, db):
+        await record_outcome(
+            db, source="ego", ref_type="proposal", ref_id="p2",
+            signal_type=SignalType.DISPATCH, signal_tier=1,
+        )
+        rows = await oe.recent(db, limit=1)
+        assert rows[0]["signal_tier"] == 1
+
+    @pytest.mark.asyncio
+    async def test_never_raises_on_bad_input(self, db):
+        # Invalid polarity would make the strict CRUD raise ValueError; the bus
+        # must swallow it and return None — production paths can't break.
+        result = await record_outcome(
+            db, source="ego", ref_type="proposal", ref_id="bad",
+            signal_type=SignalType.EXECUTION_OUTCOME, polarity="sideways",
+        )
+        assert result is None
+        assert await oe.count(db) == 0
+
+    @pytest.mark.asyncio
+    async def test_idempotent(self, db):
+        first = await record_outcome(
+            db, source="ego", ref_type="proposal", ref_id="dup",
+            signal_type=SignalType.EXECUTION_OUTCOME,
+        )
+        second = await record_outcome(
+            db, source="ego", ref_type="proposal", ref_id="dup",
+            signal_type=SignalType.EXECUTION_OUTCOME,
+        )
+        assert first is not None
+        assert second is None
+        assert await oe.count(db) == 1
+
+    @pytest.mark.asyncio
+    async def test_unknown_signal_type_still_records_at_t3(self, db):
+        eid = await record_outcome(
+            db, source="ego", ref_type="proposal", ref_id="novel",
+            signal_type="novel_signal",
+        )
+        assert eid is not None
+        rows = await oe.recent(db, limit=1)
+        assert rows[0]["signal_tier"] == 3
+
+    @pytest.mark.asyncio
+    async def test_known_vocabulary_is_collision_safe(self):
+        # All vocabulary values must be distinct (the unique-key guarantee).
+        values = [
+            getattr(SignalType, n) for n in dir(SignalType) if not n.startswith("_")
+        ]
+        assert len(values) == len(set(values))
+        assert set(values) == set(bus.KNOWN_SIGNAL_TYPES)

--- a/tests/feedback/test_bus.py
+++ b/tests/feedback/test_bus.py
@@ -37,6 +37,7 @@ class TestTaxonomy:
         assert default_tier(SignalType.TRIAGE_CORRECTION) == 2
         assert default_tier(SignalType.DISPATCH) == 3
         assert default_tier(SignalType.OUTREACH_IMPLICIT) == 3
+        assert default_tier(SignalType.LIFECYCLE_EXPIRED) == 3
 
     def test_unknown_defaults_to_coverage(self):
         assert default_tier("something_new") == 3

--- a/tests/feedback/test_harvest.py
+++ b/tests/feedback/test_harvest.py
@@ -1,0 +1,247 @@
+"""Tests for feedback/harvest.py — folding existing signals into the bus."""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import ego as ego_crud
+from genesis.db.crud import outcome_events as oe
+from genesis.feedback.harvest import (
+    BACKFILL_MARKER,
+    OutcomeHarvester,
+    _parse_execution_suffix,
+)
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """Full schema (ego_proposals, outreach_history, ego_state, outcome_events)."""
+    from genesis.db.schema import create_all_tables
+
+    path = str(tmp_path / "harvest.db")
+    async with aiosqlite.connect(path) as conn:
+        await create_all_tables(conn)
+        # Live prod carries engagement_outcome values ('acted_on', 'acknowledged',
+        # '') that violate the current CHECK — the harvester must handle data that
+        # already exists. Disable CHECK enforcement so the fixture can reproduce
+        # that real-world condition.
+        await conn.execute("PRAGMA ignore_check_constraints = ON")
+        await conn.commit()
+        yield conn
+
+
+async def _add_proposal(
+    db, *, pid, status, user_response=None, confidence=0.8,
+    action_type="investigate", cycle_id=None,
+    created_at="2026-06-18T00:00:00+00:00", resolved_at="2026-06-18T01:00:00+00:00",
+):
+    await db.execute(
+        "INSERT INTO ego_proposals "
+        "(id, action_type, content, status, confidence, user_response, "
+        " cycle_id, created_at, resolved_at) "
+        "VALUES (?, ?, 'content', ?, ?, ?, ?, ?, ?)",
+        (pid, action_type, status, confidence, user_response, cycle_id,
+         created_at, resolved_at),
+    )
+    await db.commit()
+
+
+async def _add_outreach(
+    db, *, oid, engagement_outcome, user_response=None, category="notification",
+    prediction_error=None, delivered_at="2026-06-18T00:00:00+00:00",
+):
+    await db.execute(
+        "INSERT INTO outreach_history "
+        "(id, signal_type, topic, category, salience_score, channel, "
+        " message_content, engagement_outcome, user_response, prediction_error, "
+        " delivered_at, created_at) "
+        "VALUES (?, 'sig', 'topic', ?, 0.5, 'telegram', 'msg', ?, ?, ?, ?, ?)",
+        (oid, category, engagement_outcome, user_response, prediction_error,
+         delivered_at, "2026-06-18T00:00:00+00:00"),
+    )
+    await db.commit()
+
+
+# --------------------------------------------------------------------------- #
+# Suffix parser
+# --------------------------------------------------------------------------- #
+class TestSuffixParser:
+    def test_session_prefixed_completed(self):
+        assert _parse_execution_suffix("session:abc|completed:did it") == (
+            "positive", 1.0, "did it",
+        )
+
+    def test_bare_completed(self):
+        assert _parse_execution_suffix("|completed:done") == ("positive", 1.0, "done")
+
+    def test_failed(self):
+        polarity, value, summary = _parse_execution_suffix("sid|failed:broke")
+        assert polarity == "negative" and value == 0.0 and summary == "broke"
+
+    def test_no_suffix(self):
+        assert _parse_execution_suffix("just a user reason") is None
+        assert _parse_execution_suffix(None) is None
+        assert _parse_execution_suffix("") is None
+
+
+# --------------------------------------------------------------------------- #
+# Proposal harvest
+# --------------------------------------------------------------------------- #
+class TestHarvestProposals:
+    @pytest.mark.asyncio
+    async def test_executed_with_suffix_is_t1_ground_truth(self, db):
+        await _add_proposal(
+            db, pid="p1", status="executed",
+            user_response="session:s1|completed:shipped the fix",
+            confidence=0.9, cycle_id="cyc1",
+        )
+        await OutcomeHarvester(db).run_backfill()
+        rows = await oe.recent(db, limit=10)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["signal_type"] == "execution_outcome"
+        assert row["signal_tier"] == 1
+        assert row["polarity"] == "positive"
+        assert row["value"] == 1.0
+        assert row["domain"] == "investigate"
+        assert row["stated_confidence"] == 0.9
+        assert row["reason_text"] == "shipped the fix"
+        assert row["metadata"] == '{"cycle_id": "cyc1"}'
+        assert row["harvested_from"] == "ego_proposals"
+
+    @pytest.mark.asyncio
+    async def test_failed_is_t1_negative(self, db):
+        await _add_proposal(db, pid="p2", status="failed")
+        await OutcomeHarvester(db).run_backfill()
+        row = (await oe.recent(db, limit=1))[0]
+        assert row["signal_type"] == "execution_outcome"
+        assert row["signal_tier"] == 1
+        assert row["polarity"] == "negative"
+        assert row["value"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_executed_without_suffix_is_coverage(self, db):
+        await _add_proposal(db, pid="p3", status="executed", user_response="session:s3")
+        await OutcomeHarvester(db).run_backfill()
+        row = (await oe.recent(db, limit=1))[0]
+        assert row["signal_type"] == "dispatch"
+        assert row["signal_tier"] == 3
+
+    @pytest.mark.asyncio
+    async def test_rejected_with_reason_is_t2(self, db):
+        await _add_proposal(
+            db, pid="p4", status="rejected", user_response="not now, bad timing",
+        )
+        await OutcomeHarvester(db).run_backfill()
+        row = (await oe.recent(db, limit=1))[0]
+        assert row["signal_type"] == "user_decision"
+        assert row["signal_tier"] == 2  # rationale present → informative
+        assert row["polarity"] == "negative"
+        assert row["reason_text"] == "not now, bad timing"
+
+    @pytest.mark.asyncio
+    async def test_tabled_and_withdrawn_are_lifecycle_t3(self, db):
+        await _add_proposal(db, pid="p5", status="tabled")
+        await _add_proposal(db, pid="p6", status="withdrawn")
+        await OutcomeHarvester(db).run_backfill()
+        by_type = await oe.count_by_signal_type(db)
+        assert by_type == {"lifecycle_tabled": 1, "lifecycle_withdrawn": 1}
+
+    @pytest.mark.asyncio
+    async def test_pending_is_skipped(self, db):
+        await _add_proposal(db, pid="p7", status="pending")
+        await OutcomeHarvester(db).run_backfill()
+        assert await oe.count(db) == 0
+
+
+# --------------------------------------------------------------------------- #
+# Outreach harvest
+# --------------------------------------------------------------------------- #
+class TestHarvestOutreach:
+    @pytest.mark.asyncio
+    async def test_useful_reply_is_t2_positive(self, db):
+        await _add_outreach(
+            db, oid="o1", engagement_outcome="useful", user_response="thanks!",
+            prediction_error=0.2,
+        )
+        await OutcomeHarvester(db).run_backfill()
+        row = (await oe.recent(db, limit=1))[0]
+        assert row["signal_type"] == "outreach_reply"
+        assert row["signal_tier"] == 2
+        assert row["polarity"] == "positive"
+        assert row["reason_text"] == "thanks!"
+        assert row["prediction_error"] == 0.2
+        assert row["source"] == "outreach"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "outcome, exp_type, exp_polarity",
+        [
+            ("useful", "outreach_reply", "positive"),
+            ("acted_on", "outreach_reply", "positive"),       # was mislabeled negative
+            ("acknowledged", "outreach_reply", "positive"),   # was mislabeled negative
+            ("not_useful", "outreach_reply", "negative"),
+            ("ambivalent", "outreach_implicit", "neutral"),
+            ("ignored", "outreach_implicit", "negative"),
+        ],
+    )
+    async def test_engagement_polarity_mapping(self, db, outcome, exp_type, exp_polarity):
+        await _add_outreach(db, oid=f"o-{outcome}", engagement_outcome=outcome)
+        await OutcomeHarvester(db).run_backfill()
+        row = (await oe.recent(db, limit=1))[0]
+        assert row["signal_type"] == exp_type
+        assert row["polarity"] == exp_polarity
+
+    @pytest.mark.asyncio
+    async def test_empty_string_outcome_is_skipped(self, db):
+        # Live data has 15 empty-string rows — they are NOT a real signal.
+        await _add_outreach(db, oid="empty", engagement_outcome="")
+        await _add_outreach(db, oid="real", engagement_outcome="useful")
+        await OutcomeHarvester(db).run_backfill()
+        assert await oe.count(db) == 1  # only the real one
+
+
+# --------------------------------------------------------------------------- #
+# Idempotency / window / marker
+# --------------------------------------------------------------------------- #
+class TestIdempotencyAndScheduling:
+    @pytest.mark.asyncio
+    async def test_backfill_is_idempotent_and_guarded(self, db):
+        await _add_proposal(
+            db, pid="p1", status="executed",
+            user_response="s|completed:x",
+        )
+        first = await OutcomeHarvester(db).run_backfill()
+        assert first["skipped"] is False
+        assert first["proposals"] == 1
+        # Marker set
+        assert await ego_crud.get_state(db, BACKFILL_MARKER) is not None
+        # Second run is guarded → skipped, no new rows
+        second = await OutcomeHarvester(db).run_backfill()
+        assert second["skipped"] is True
+        assert await oe.count(db) == 1
+
+    @pytest.mark.asyncio
+    async def test_incremental_run_is_idempotent_on_unique_key(self, db):
+        await _add_proposal(
+            db, pid="p1", status="executed", user_response="s|completed:x",
+        )
+        await OutcomeHarvester(db).run()
+        await OutcomeHarvester(db).run()  # re-scan same window
+        assert await oe.count(db) == 1  # unique key dedupes
+
+    @pytest.mark.asyncio
+    async def test_incremental_window_excludes_old_but_backfill_includes(self, db):
+        await _add_proposal(
+            db, pid="old", status="executed", user_response="s|completed:x",
+            created_at="2026-05-01T00:00:00+00:00",
+            resolved_at="2026-05-01T00:00:00+00:00",
+        )
+        # Recent window misses the old row...
+        run_result = await OutcomeHarvester(db).run(window_days=2)
+        assert run_result["proposals"] == 0
+        assert await oe.count(db) == 0
+        # ...but backfill (all history) captures it.
+        await OutcomeHarvester(db).run_backfill()
+        assert await oe.count(db) == 1

--- a/tests/feedback/test_harvest.py
+++ b/tests/feedback/test_harvest.py
@@ -154,6 +154,16 @@ class TestHarvestProposals:
         await OutcomeHarvester(db).run_backfill()
         assert await oe.count(db) == 0
 
+    @pytest.mark.asyncio
+    async def test_expired_is_lifecycle_t3(self, db):
+        # A timeout is NOT disapproval — coverage only.
+        await _add_proposal(db, pid="pe", status="expired")
+        await OutcomeHarvester(db).run_backfill()
+        row = (await oe.recent(db, limit=1))[0]
+        assert row["signal_type"] == "lifecycle_expired"
+        assert row["signal_tier"] == 3
+        assert row["polarity"] == "neutral"
+
 
 # --------------------------------------------------------------------------- #
 # Outreach harvest
@@ -221,6 +231,21 @@ class TestIdempotencyAndScheduling:
         second = await OutcomeHarvester(db).run_backfill()
         assert second["skipped"] is True
         assert await oe.count(db) == 1
+
+    @pytest.mark.asyncio
+    async def test_backfill_marker_not_set_when_a_source_fails(self, db):
+        # Reliability guard: a source exception must NOT lock the backfill gate,
+        # else the historical rows are lost forever. (Reproduce by dropping a
+        # source table — the startup-race / missing-table scenario.)
+        await _add_proposal(
+            db, pid="p1", status="executed", user_response="s|completed:x",
+        )
+        await db.execute("DROP TABLE outreach_history")
+        await db.commit()
+        result = await OutcomeHarvester(db).run_backfill()
+        assert result.get("incomplete") is True
+        assert result["proposals"] == 1  # per-source isolation: proposals still ran
+        assert await ego_crud.get_state(db, BACKFILL_MARKER) is None  # NOT locked
 
     @pytest.mark.asyncio
     async def test_incremental_run_is_idempotent_on_unique_key(self, db):

--- a/tests/test_db/test_outcome_events.py
+++ b/tests/test_db/test_outcome_events.py
@@ -1,0 +1,252 @@
+"""Tests for the outcome_events table, migration 0025, and its CRUD.
+
+Covers the fresh-install path (create_all_tables / _tables.py), the versioned
+migration (up/down/idempotency), and CRUD semantics — including the regression
+guard for the architect's CRITICAL finding: a T2 user_decision and a T1
+execution_outcome on the SAME proposal must both persist (distinct signal_type),
+never colliding on the unique key and silently dropping ground truth.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import outcome_events as oe
+
+# Migration module name starts with a digit — must import via importlib.
+MIGRATION = importlib.import_module("genesis.db.migrations.0025_outcome_events")
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """Fresh DB with outcome_events created via the real migration up()."""
+    db_path = str(tmp_path / "test.db")
+    async with aiosqlite.connect(db_path) as conn:
+        await MIGRATION.up(conn)  # up() must not commit — runner owns the txn
+        await conn.commit()
+        yield conn
+
+
+# --------------------------------------------------------------------------- #
+# Schema / migration
+# --------------------------------------------------------------------------- #
+class TestSchema:
+    @pytest.mark.asyncio
+    async def test_table_and_indexes_exist(self, db):
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='outcome_events'"
+        )
+        assert await cur.fetchone() is not None
+
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND name LIKE 'idx_outcome_events_%'"
+        )
+        idx = {r[0] for r in await cur.fetchall()}
+        assert "idx_outcome_events_domain" in idx
+        assert "idx_outcome_events_tier" in idx
+        assert "idx_outcome_events_calibration" in idx  # partial index
+
+    @pytest.mark.asyncio
+    async def test_up_is_idempotent(self, tmp_path):
+        path = str(tmp_path / "idem.db")
+        async with aiosqlite.connect(path) as conn:
+            await MIGRATION.up(conn)
+            await MIGRATION.up(conn)  # IF NOT EXISTS → must not raise
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='outcome_events'"
+            )
+            assert (await cur.fetchone())[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_down_drops_table(self, tmp_path):
+        path = str(tmp_path / "down.db")
+        async with aiosqlite.connect(path) as conn:
+            await MIGRATION.up(conn)
+            await conn.commit()
+            await MIGRATION.down(conn)
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='outcome_events'"
+            )
+            assert await cur.fetchone() is None
+
+    @pytest.mark.asyncio
+    async def test_fresh_install_path_creates_table(self, tmp_path):
+        """create_all_tables (the _tables.py registration) must include it."""
+        from genesis.db.schema import create_all_tables
+
+        path = str(tmp_path / "fresh.db")
+        async with aiosqlite.connect(path) as conn:
+            await create_all_tables(conn)
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='outcome_events'"
+            )
+            assert await cur.fetchone() is not None
+
+    @pytest.mark.asyncio
+    async def test_check_constraint_rejects_bad_tier_at_db_level(self, db):
+        """A plain INSERT (not OR IGNORE) with a bad tier must hit the CHECK."""
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute(
+                "INSERT INTO outcome_events "
+                "(id, source, ref_type, ref_id, signal_type, signal_tier, occurred_at) "
+                "VALUES ('x','ego','proposal','p','execution_outcome', 9, '2026-01-01')"
+            )
+
+
+# --------------------------------------------------------------------------- #
+# CRUD
+# --------------------------------------------------------------------------- #
+class TestRecord:
+    @pytest.mark.asyncio
+    async def test_record_returns_id_and_persists(self, db):
+        eid = await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="p1",
+            signal_type="execution_outcome", signal_tier=1, domain="investigate",
+            polarity="positive", value=1.0, stated_confidence=0.8,
+            metadata={"session": "s1"}, harvested_from="ego_proposals",
+        )
+        assert isinstance(eid, str) and len(eid) == 16
+        assert await oe.count(db) == 1
+        rows = await oe.recent(db, limit=5)
+        assert rows[0]["ref_id"] == "p1"
+        assert rows[0]["signal_tier"] == 1
+        assert rows[0]["metadata"] == '{"session": "s1"}'  # serialized
+
+    @pytest.mark.asyncio
+    async def test_record_idempotent_on_unique_key(self, db):
+        key = dict(
+            source="ego", ref_type="proposal", ref_id="p2",
+            signal_type="user_decision", signal_tier=2,
+        )
+        first = await oe.record(db, **key, reason="timing")
+        second = await oe.record(db, **key, reason="safety")  # same unique key
+        assert first is not None
+        assert second is None  # OR IGNORE → not inserted
+        assert await oe.count(db) == 1
+
+    @pytest.mark.asyncio
+    async def test_distinct_signal_types_coexist_on_same_ref(self, db):
+        """REGRESSION (architect Finding 1): T2 user_decision + T1 execution_outcome
+        on ONE proposal must both survive — ground truth never dropped."""
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="p3",
+            signal_type="user_decision", signal_tier=2, polarity="positive",
+        )
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="p3",
+            signal_type="execution_outcome", signal_tier=1,
+            polarity="positive", value=1.0,
+        )
+        assert await oe.count(db) == 2
+        assert await oe.count_by_signal_type(db) == {
+            "user_decision": 1, "execution_outcome": 1,
+        }
+
+    @pytest.mark.asyncio
+    async def test_exists(self, db):
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="p4",
+            signal_type="execution_outcome", signal_tier=1,
+        )
+        assert await oe.exists(
+            db, source="ego", ref_type="proposal", ref_id="p4",
+            signal_type="execution_outcome",
+        ) is True
+        assert await oe.exists(
+            db, source="ego", ref_type="proposal", ref_id="p4",
+            signal_type="user_decision",
+        ) is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            dict(signal_tier=4),                      # bad tier
+            dict(signal_tier=1, signal_class="bogus"),  # bad class
+            dict(signal_tier=1, polarity="sideways"),   # bad polarity
+            dict(signal_tier=1, source=""),             # empty key field
+        ],
+    )
+    async def test_record_validates(self, db, kwargs):
+        base = dict(
+            source="ego", ref_type="proposal", ref_id="pX",
+            signal_type="execution_outcome",
+        )
+        base.update(kwargs)
+        with pytest.raises(ValueError):
+            await oe.record(db, **base)
+
+
+class TestAggregates:
+    @pytest.mark.asyncio
+    async def test_aggregate_by_domain(self, db):
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="a1",
+            signal_type="execution_outcome", signal_tier=1, domain="investigate",
+            polarity="positive", value=1.0, stated_confidence=0.9,
+        )
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="a2",
+            signal_type="execution_outcome", signal_tier=1, domain="investigate",
+            polarity="negative", value=0.0, stated_confidence=0.6,
+        )
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="a3",
+            signal_type="execution_outcome", signal_tier=1, domain="outreach",
+            polarity="positive", value=1.0,
+        )
+        aggs = await oe.aggregate_by_domain(db, days=30)
+        inv = next(a for a in aggs if a["domain"] == "investigate")
+        assert inv["n"] == 2
+        assert inv["positive"] == 1
+        assert inv["negative"] == 1
+        assert abs(inv["avg_value"] - 0.5) < 1e-9
+
+    @pytest.mark.asyncio
+    async def test_aggregate_tier_filter(self, db):
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="t1",
+            signal_type="execution_outcome", signal_tier=1, domain="d",
+        )
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="t2",
+            signal_type="user_decision", signal_tier=3, domain="d",
+        )
+        aggs = await oe.aggregate_by_domain(db, tier=1)
+        d = next(a for a in aggs if a["domain"] == "d")
+        assert d["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_calibration_by_domain_requires_confidence_and_value(self, db):
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="c1",
+            signal_type="execution_outcome", signal_tier=1, domain="investigate",
+            stated_confidence=0.8, value=1.0,
+        )
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="c2",
+            signal_type="execution_outcome", signal_tier=1, domain="investigate",
+            stated_confidence=0.5, value=0.0,
+        )
+        # Excluded: has confidence but no graded value.
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="c3",
+            signal_type="execution_outcome", signal_tier=1, domain="investigate",
+            stated_confidence=0.7,
+        )
+        rows = await oe.calibration_by_domain(db, tier=1)
+        assert len(rows) == 2
+        assert all(
+            r["stated_confidence"] is not None and r["value"] is not None
+            for r in rows
+        )

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -101,6 +101,7 @@ async def test_no_unexpected_tables(db):
         "eval_subsystem_grades",
         "reflection_corpus",
         "email_threads", "email_thread_messages",
+        "outcome_events",  # self-improvement outcome bus
     }
     for table in tables:
         assert table in known, f"Unexpected table: {table}"


### PR DESCRIPTION
## Self-Improvement Outcome Bus — foundation (PR-A, dark capture)

Genesis has the *organs* of self-improvement (calibration, capability model, per-subsystem quality scoring) but no closed feedback loop — the loop is open at **capture**. The single most valuable signal, post-execution "did it actually work" (T1), is written today as a `|completed:`/`|failed:` string suffix on `ego_proposals.user_response` and is otherwise unsurfaced: of 63 proposals that actually ran, only **1** has a structured outcome anywhere a learning loop can read.

This PR lays the foundation: an append-only, attributed, quality-weighted `outcome_events` ledger plus the machinery to populate it. It is **DARK** — nothing in production emits to it and nothing consumes it yet (those are follow-up PRs). The only live wiring is a scheduled, behavior-neutral harvester.

### What's here (Steps 1–3)
- **`outcome_events` table** — migration `0025` (+ `down`) and fresh-install registration in `_tables.py`; strict CRUD (`record`/`exists`/`count`/`aggregate_by_domain`/`calibration_by_domain`/`recent`).
- **`feedback/bus.py`** — fire-and-forget `record_outcome` (never raises) + the signal taxonomy: a controlled `signal_type` vocabulary and a tier policy (T1 ground truth › T2 rationale-bearing › T3 coverage). The controlled vocabulary guarantees that two signals on the same ref (e.g. a user decision and a later execution outcome on one proposal) never collide on the unique key — so the bus can never silently drop ground truth.
- **`feedback/harvest.py`** — `OutcomeHarvester` folds existing siloed signals (`ego_proposals`, `outreach_history`) into the ledger without mutating them; incremental `run()` + one-shot `run_backfill()` guarded by an `ego_state` marker. Per-source isolation; idempotent on the unique key.
- **Scheduler wiring** — `CronTrigger(8:45/20:45)`, clock-time before the capability-map refresh, off the loaded overnight windows. Behavior-neutral (populates a table nothing reads).

### Signal-quality discipline
Tiering measures signal *quality*, not desirability of proposing — nothing here teaches the ego to propose less. A timeout/expiry is recorded as coverage (T3), never as disapproval, and stays out of any quality denominator. A bare approve/reject is T3; only a rationale-bearing decision is T2; post-execution outcome is T1 and outranks user approval.

### Verification
- 50 targeted tests (migration up/down/idempotency, fresh-install path, DB CHECK, CRUD, taxonomy, harvester mapping, backfill guard, regression test for the unique-key non-collision). Ruff clean.
- **End-to-end against a copy of the live DB:** T1 `execution_outcome` capture **1 → 47**; calibratable rows (T1 + confidence + value) **~1 → 47**; 764 rows correctly tiered (47 T1 / 58 T2 / 659 T3); backfill idempotent (guarded re-run is a no-op).
- Reviewed by an architecture pass (pre-implementation) and a code-review pass; findings fixed and re-verified.

### Deploy note
On merge + deploy the table is created at startup and the harvester backfills on its first scheduled tick — there is no separate manual step. Still dark: no behavior change until the emit-hooks and consumer PRs land.

### Deferred (next PRs)
- **PR-B:** emit hooks at the deep CRUD chokepoints (behind a flag) + capability-map rewire to read the ledger.
- **PR-C:** advisory deficiency consumer, after a 1–2 week dark-capture soak.
