### PR TITLE
fix(observability): resolve dead-letter alerts on drain + band-dedup the writer

### DIFF
--- a/src/genesis/identity/MORNING_REPORT.md
+++ b/src/genesis/identity/MORNING_REPORT.md
@@ -57,6 +57,23 @@ delete it. See VOICE.md (advisory tone) for full reference.
 - Observation/finding counts without content — raw numbers are noise
 - Background task completion counts — unless something failed
 
+### Staleness check — cross-check stored alerts against live state
+
+Observations are point-in-time snapshots and may have resolved since they were
+written. Before surfacing ANY infrastructure / provider / security observation
+as urgent, check whether the live **System Health** data in this report
+corroborates it:
+- "Dead letter queue at 319" is STALE if System Health shows dead_letters at 0.
+- "Provider chain exhausted / circuit breaker open" is STALE if providers are
+  currently healthy.
+- "DASHBOARD_PASSWORD not set / endpoint unauthenticated" is STALE if the live
+  config shows it set.
+
+If a stored observation contradicts live System Health, treat it as resolved:
+note it at most as "earlier <condition>, now recovered", or omit it. Do NOT
+repeat the stale alarm as if it were current. When in doubt, trust the live
+System Health numbers over an older observation's text.
+
 ## What to Include
 
 **Primary focus (this is what the report is FOR):**

--- a/src/genesis/observability/snapshots/queues.py
+++ b/src/genesis/observability/snapshots/queues.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import time
 from datetime import UTC, datetime, timedelta
@@ -22,15 +23,47 @@ _DEAD_LETTER_ALERT_THRESHOLD = 50
 # Cooldown prevents alert spam — one observation per hour max.
 _DEAD_LETTER_ALERT_COOLDOWN_S = 3600
 _last_dead_letter_alert_at: float = 0.0
+# The band that was last actually alerted. A same-band re-alert respects the
+# cooldown; a band change is an escalation-worthy transition that bypasses it.
+_last_dead_letter_band: str = ""
+
+
+def _dlq_band(count: int) -> str:
+    """Bucket the dead-letter count into a stable band.
+
+    The alert's content_hash is derived from the band (not the raw count) so
+    minor count drift (310 -> 319 -> 326) does not defeat dedup and produce a
+    new observation row per tick. The exact count still appears in the content.
+    """
+    if count < 100:
+        return "50-99"
+    if count < 200:
+        return "100-199"
+    if count < 500:
+        return "200-499"
+    return "500+"
 
 
 async def _alert_dead_letter_accumulation(db: aiosqlite.Connection | None, count: int) -> None:
-    """Create a critical observation when dead letters accumulate."""
-    global _last_dead_letter_alert_at
+    """Create a critical observation when dead letters accumulate.
+
+    Dedup is band-based and DB-backed (skip_if_duplicate): while an unresolved
+    alert exists for the current band, repeated ticks do not create new rows.
+    Once the queue drains and _resolve_dead_letter_alerts() resolves them, a
+    fresh spike re-alerts.
+    """
+    global _last_dead_letter_alert_at, _last_dead_letter_band
 
     now = time.monotonic()
-    if now - _last_dead_letter_alert_at < _DEAD_LETTER_ALERT_COOLDOWN_S:
-        return  # Cooldown active
+    band = _dlq_band(count)
+    # Same-band re-alerts respect the cooldown; a band change (the count crossed
+    # a boundary — a worsening or improving transition) is escalation-worthy and
+    # bypasses the cooldown so it is not swallowed for up to an hour.
+    if (
+        now - _last_dead_letter_alert_at < _DEAD_LETTER_ALERT_COOLDOWN_S
+        and band == _last_dead_letter_band
+    ):
+        return  # Cooldown active for the same band
 
     if db is None:
         return
@@ -40,10 +73,10 @@ async def _alert_dead_letter_accumulation(db: aiosqlite.Connection | None, count
 
         from genesis.db.crud import observations as obs_crud
 
-        obs_id = str(uuid.uuid4())
-        await obs_crud.create(
+        content_hash = hashlib.sha256(f"dead_letter_alert:{band}".encode()).hexdigest()
+        created = await obs_crud.create(
             db,
-            id=obs_id,
+            id=str(uuid.uuid4()),
             source="dead_letter_monitor",
             type="infrastructure_alert",
             content=(
@@ -54,13 +87,60 @@ async def _alert_dead_letter_accumulation(db: aiosqlite.Connection | None, count
             ),
             priority="critical",
             created_at=datetime.now(UTC).isoformat(),
+            content_hash=content_hash,
+            skip_if_duplicate=True,
         )
+        if created is None:
+            return  # An unresolved alert for this band already exists.
         _last_dead_letter_alert_at = now
+        _last_dead_letter_band = band
         logger.warning(
             "Dead letter alert: %d pending items (critical observation created)", count
         )
     except Exception:
         logger.debug("Failed to create dead letter alert observation", exc_info=True)
+
+
+async def _resolve_dead_letter_alerts(db: aiosqlite.Connection | None, count: int) -> None:
+    """Resolve outstanding dead-letter alerts once the queue drains.
+
+    The observation pipeline is otherwise write-only: _alert_dead_letter_accumulation
+    creates infrastructure_alert rows when the queue grows, but nothing resolved
+    them when it recovered, so stale "DLQ at 319" alerts lingered for days (3-day
+    TTL) and poisoned the morning report. This is the compensating recovery path.
+    """
+    global _last_dead_letter_alert_at, _last_dead_letter_band
+
+    if db is None:
+        return
+
+    # Intentionally unconditional (no in-memory "is an alert active?" guard):
+    # such a guard would be lost on restart and reintroduce the write-only
+    # staleness. The UPDATE is a cheap no-op when no resolved=0 rows match.
+    try:
+        from genesis.db.crud import observations as obs_crud
+
+        resolved = await obs_crud.resolve_by_source_and_type(
+            db,
+            source="dead_letter_monitor",
+            type="infrastructure_alert",
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_notes=(
+                f"auto-resolved: dead-letter queue drained to {count} "
+                f"(< {_DEAD_LETTER_ALERT_THRESHOLD})"
+            ),
+        )
+        if resolved:
+            # Genuine recovery — allow an immediate re-alert if it spikes again.
+            _last_dead_letter_alert_at = 0.0
+            _last_dead_letter_band = ""
+            logger.info(
+                "Auto-resolved %d dead-letter alert observation(s) on drain (count=%d)",
+                resolved,
+                count,
+            )
+    except Exception:
+        logger.debug("Failed to resolve dead letter alert observations", exc_info=True)
 
 
 async def queues(
@@ -85,9 +165,13 @@ async def queues(
     if dead_letter:
         try:
             dead = await dead_letter.get_pending_count()
-            # Alert via observation when dead letters accumulate
+            # Alert when dead letters accumulate; resolve the alert when the
+            # queue drains. Without the resolve, the observation pipeline is
+            # write-only and stale "DLQ at N" alerts linger until TTL.
             if dead is not None and dead >= _DEAD_LETTER_ALERT_THRESHOLD:
                 await _alert_dead_letter_accumulation(db, dead)
+            elif dead is not None:
+                await _resolve_dead_letter_alerts(db, dead)
         except Exception:
             errors.append("dead_letters: query failed")
             logger.error("Failed to query dead letter queue", exc_info=True)

--- a/tests/test_observability/test_queues_dead_letter.py
+++ b/tests/test_observability/test_queues_dead_letter.py
@@ -1,0 +1,137 @@
+"""Tests for dead-letter alert dedup + auto-resolution in the queues snapshot.
+
+Guards two halves of the write-only-observation fix:
+  - the writer dedups by count *band* (stable content_hash + skip_if_duplicate),
+    so a spike that drifts (310 -> 319 -> 326) produces ONE unresolved row, not N;
+  - the queue draining resolves outstanding infrastructure_alert observations,
+    so stale "DLQ at N" alerts don't linger until TTL and poison the report.
+"""
+
+import importlib
+
+import aiosqlite
+import pytest
+
+from genesis.db.schema import create_all_tables
+
+# The snapshots package re-exports the ``queues`` function, which shadows the
+# submodule on attribute access — import the module object explicitly so we can
+# reach the helpers + the module-global cooldown.
+q = importlib.import_module("genesis.observability.snapshots.queues")
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_cooldown():
+    # The cooldown + last-band are process-globals; reset them around every test
+    # so each exercises the intended path, not leftover state.
+    q._last_dead_letter_alert_at = 0.0
+    q._last_dead_letter_band = ""
+    yield
+    q._last_dead_letter_alert_at = 0.0
+    q._last_dead_letter_band = ""
+
+
+async def _unresolved_infra(db) -> int:
+    rows = await db.execute_fetchall(
+        "SELECT COUNT(*) FROM observations WHERE source='dead_letter_monitor' "
+        "AND type='infrastructure_alert' AND resolved=0"
+    )
+    return rows[0][0]
+
+
+async def _total_infra(db) -> int:
+    rows = await db.execute_fetchall(
+        "SELECT COUNT(*) FROM observations WHERE source='dead_letter_monitor'"
+    )
+    return rows[0][0]
+
+
+def test_dlq_band_buckets():
+    assert q._dlq_band(50) == "50-99"
+    assert q._dlq_band(99) == "50-99"
+    assert q._dlq_band(150) == "100-199"
+    assert q._dlq_band(319) == "200-499"
+    assert q._dlq_band(900) == "500+"
+
+
+@pytest.mark.asyncio
+async def test_count_drift_in_same_band_dedups(db):
+    """310 -> 319 -> 326 all fall in the 200-499 band -> exactly one row."""
+    for count in (310, 319, 326):
+        q._last_dead_letter_alert_at = 0.0  # bypass the cooldown for the test
+        await q._alert_dead_letter_accumulation(db, count)
+    assert await _unresolved_infra(db) == 1
+
+
+@pytest.mark.asyncio
+async def test_band_crossing_creates_new_alert(db):
+    """A worsening that crosses a band boundary IS a new, distinct alert."""
+    q._last_dead_letter_alert_at = 0.0
+    await q._alert_dead_letter_accumulation(db, 60)  # 50-99
+    q._last_dead_letter_alert_at = 0.0
+    await q._alert_dead_letter_accumulation(db, 250)  # 200-499
+    assert await _unresolved_infra(db) == 2
+
+
+@pytest.mark.asyncio
+async def test_band_escalation_within_cooldown_still_alerts(db):
+    """A worsening that crosses a band boundary must NOT be swallowed by the 1h
+    cooldown — band changes bypass it. (The cooldown is NOT reset between calls.)"""
+    q._last_dead_letter_alert_at = 0.0
+    q._last_dead_letter_band = ""
+    await q._alert_dead_letter_accumulation(db, 60)  # 50-99; arms the cooldown
+    # Cooldown is now active. A worsening into a new band must still alert...
+    await q._alert_dead_letter_accumulation(db, 300)  # 200-499; band changed
+    assert await _unresolved_infra(db) == 2
+    # ...but a same-band tick while the cooldown is active does NOT add a row.
+    await q._alert_dead_letter_accumulation(db, 320)  # still 200-499
+    assert await _unresolved_infra(db) == 2
+
+
+@pytest.mark.asyncio
+async def test_resolve_on_drain(db):
+    q._last_dead_letter_alert_at = 0.0
+    await q._alert_dead_letter_accumulation(db, 319)
+    assert await _unresolved_infra(db) == 1
+    await q._resolve_dead_letter_alerts(db, 0)
+    assert await _unresolved_infra(db) == 0
+
+
+@pytest.mark.asyncio
+async def test_resolve_then_respike_realerts(db):
+    """After drain+resolve, a fresh spike in the same band creates a new row
+    (skip_if_duplicate only suppresses UNRESOLVED duplicates)."""
+    q._last_dead_letter_alert_at = 0.0
+    await q._alert_dead_letter_accumulation(db, 319)
+    await q._resolve_dead_letter_alerts(db, 0)  # resolves + resets cooldown to 0
+    await q._alert_dead_letter_accumulation(db, 330)  # same band, prior is resolved
+    assert await _unresolved_infra(db) == 1
+    assert await _total_infra(db) == 2
+
+
+@pytest.mark.asyncio
+async def test_queues_end_to_end_spike_then_drain(db):
+    """queues() alerts on spike and resolves on drain — the full snapshot path."""
+
+    class _DLQ:
+        def __init__(self, n: int) -> None:
+            self._n = n
+
+        async def get_pending_count(self) -> int:
+            return self._n
+
+    q._last_dead_letter_alert_at = 0.0
+    await q.queues(db, None, _DLQ(200), None)  # spike >= threshold
+    assert await _unresolved_infra(db) == 1
+
+    await q.queues(db, None, _DLQ(0), None)  # drained < threshold
+    assert await _unresolved_infra(db) == 0


### PR DESCRIPTION
## What

The observation pipeline was **write-only**. `_alert_dead_letter_accumulation`
(`observability/snapshots/queues.py`) created a `critical` `infrastructure_alert`
observation when the dead-letter queue grew past 50, but **nothing resolved it
when the queue drained** — so stale "DLQ at 319" alerts lingered for the 3-day
TTL and poisoned the morning report (which surfaces unresolved observations).
The writer also embedded the raw count in the content, so each hourly tick
produced a new `content_hash` and ~10 near-duplicate rows accumulated per spike.

## Fix

- **Band the count** (`50-99 / 100-199 / 200-499 / 500+`) and derive a stable
  `content_hash` from the band + pass `skip_if_duplicate` — a drifting spike is
  one row per band (the exact count still shows in the content). A **band change
  bypasses the 1h cooldown** so a worsening still escalates promptly.
- **`_resolve_dead_letter_alerts()`** — called from `queues()` when the queue
  drains below threshold. The compensating recovery path. Intentionally
  unconditional (an in-memory guard would be lost on restart and reintroduce
  the staleness).
- **`MORNING_REPORT.md`** staleness guard: cross-check stored infra/provider/
  security observations against the live System Health section and treat
  contradicted ones as resolved rather than repeating a stale alarm.

## Verification

- 7 new tests (`tests/test_observability/test_queues_dead_letter.py`): band
  bucketing, same-band dedup, band-escalation-within-cooldown, resolve-on-drain,
  resolve-then-respike re-alerts, `queues()` end-to-end. Full `test_observability`
  + `test_health_data`: **202 passed**; ruff clean.
- Code review caught and fixed a missed-escalation bug (a band-crossing
  worsening was being swallowed by the cooldown).
- Wiring: `queues()` is the same path (`health_data.py`) that created the
  original alerts, so the resolve rides a proven-live call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
