### PR TITLE
feat(feedback): measure-only ego calibration (dark) [HOLD — do not merge]

### DIFF
--- a/src/genesis/db/crud/ego_calibration.py
+++ b/src/genesis/db/crud/ego_calibration.py
@@ -1,0 +1,83 @@
+"""CRUD for ``ego_calibration_snapshots`` — measure-only ego calibration trend.
+
+Read-only from the outside: nothing in Genesis's cognitive paths reads this
+table. It exists so the USER can see whether the ego's stated confidence tracks
+reality ("says 90%, right 82%") and whether that's improving over time. Injecting
+calibration back into the ego is a deliberate, separately-flagged future PR.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+async def record_snapshot(
+    db: aiosqlite.Connection,
+    *,
+    domain: str,
+    ece: float,
+    mce: float,
+    sample_count: int,
+    bucket_count: int,
+    low_confidence: bool,
+    curve: list[dict],
+) -> str:
+    """Insert one calibration snapshot. ``curve`` is the per-bucket list,
+    stored as JSON. Returns the snapshot id."""
+    sid = uuid.uuid4().hex[:16]
+    await db.execute(
+        """INSERT INTO ego_calibration_snapshots
+               (id, domain, ece, mce, sample_count, bucket_count,
+                low_confidence, curve_json, computed_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            sid, domain, ece, mce, sample_count, bucket_count,
+            1 if low_confidence else 0, json.dumps(curve),
+            datetime.now(UTC).isoformat(),
+        ),
+    )
+    await db.commit()
+    return sid
+
+
+async def get_latest(db: aiosqlite.Connection, *, domain: str = "ego") -> dict | None:
+    """Most recent snapshot for a domain, or ``None`` if there are none yet
+    (so the surface says "no data" instead of a spurious ECE=0.0)."""
+    cur = await db.execute(
+        "SELECT * FROM ego_calibration_snapshots "
+        "WHERE domain = ? ORDER BY computed_at DESC LIMIT 1",
+        (domain,),
+    )
+    row = await cur.fetchone()
+    if row is None:
+        return None
+    cols = [d[0] for d in cur.description]
+    snap = dict(zip(cols, row, strict=False))
+    snap["curve"] = json.loads(snap.pop("curve_json")) if snap.get("curve_json") else []
+    snap["low_confidence"] = bool(snap.get("low_confidence"))
+    return snap
+
+
+async def get_trend(
+    db: aiosqlite.Connection, *, domain: str = "ego", limit: int = 30
+) -> list[dict]:
+    """ECE/MCE over time (newest first) — the self-improvement signal."""
+    cur = await db.execute(
+        "SELECT computed_at, ece, mce, sample_count, bucket_count, low_confidence "
+        "FROM ego_calibration_snapshots WHERE domain = ? "
+        "ORDER BY computed_at DESC LIMIT ?",
+        (domain, limit),
+    )
+    rows = await cur.fetchall()
+    cols = [d[0] for d in cur.description]
+    out = [dict(zip(cols, r, strict=False)) for r in rows]
+    for o in out:
+        o["low_confidence"] = bool(o.get("low_confidence"))
+    return out

--- a/src/genesis/db/crud/outcome_events.py
+++ b/src/genesis/db/crud/outcome_events.py
@@ -168,11 +168,14 @@ async def calibration_by_domain(
     days: int = 90,
     tier: int = 1,
 ) -> list[dict]:
-    """Rows usable for calibration: a stated confidence paired with a graded
-    outcome value, within ``tier`` (ground truth by default).
+    """Rows usable for calibration grouped/labelled by their per-row ``domain``,
+    across ALL sources, within ``tier`` (ground truth by default).
 
-    Feeds Phase 2 (ego-decision calibration / ECE); returns raw paired rows so
-    the calibration engine owns the bucketing.
+    WARNING: does NOT filter by ``source``. Do NOT use this for ego calibration —
+    it would mix ego rows with outreach/triage and contaminate the ECE, and the
+    per-row ``domain`` is the action_type (e.g. 'dispatch'), not 'ego'. For an
+    aggregate ego calibration use ``calibration_pairs(source='ego', tier=1)``.
+    Retained for cross-source/diagnostic reads.
     """
     cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
     cur = await db.execute(
@@ -196,6 +199,37 @@ async def recent(db: aiosqlite.Connection, *, limit: int = 20) -> list[dict]:
     cur = await db.execute(
         "SELECT * FROM outcome_events ORDER BY occurred_at DESC LIMIT ?",
         (limit,),
+    )
+    rows = await cur.fetchall()
+    return _rows_to_dicts(cur, rows)
+
+
+async def calibration_pairs(
+    db: aiosqlite.Connection,
+    *,
+    source: str,
+    tier: int = 1,
+    days: int = 90,
+) -> list[dict]:
+    """Confidence/outcome pairs for ONE source at one tier — the calibration
+    input set. Filtered by ``source`` so e.g. ego calibration never mixes in
+    outreach/triage rows (cross-source contamination would corrupt the ECE).
+    Unlike ``calibration_by_domain``, this ignores the per-row ``domain`` so an
+    aggregate (e.g. all ego T1 rows) can be computed regardless of action_type.
+    """
+    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+    cur = await db.execute(
+        """
+        SELECT stated_confidence, value, occurred_at
+        FROM outcome_events
+        WHERE source = ?
+          AND signal_tier = ?
+          AND stated_confidence IS NOT NULL
+          AND value IS NOT NULL
+          AND occurred_at >= ?
+        ORDER BY occurred_at
+        """,
+        (source, tier, cutoff),
     )
     rows = await cur.fetchall()
     return _rows_to_dicts(cur, rows)

--- a/src/genesis/db/migrations/0026_ego_calibration_snapshots.py
+++ b/src/genesis/db/migrations/0026_ego_calibration_snapshots.py
@@ -1,0 +1,56 @@
+"""Create ``ego_calibration_snapshots`` — measure-only ego calibration over time.
+
+Each row is one snapshot of the ego's confidence calibration for a domain,
+computed from Outcome Bus T1 (ground-truth) rows: does the ego's stated
+confidence track actual success ("says 90%, right 82%")? One row per (domain,
+run) so the ECE-over-time TREND accrues — the actual self-improvement signal.
+
+DELIBERATELY a SEPARATE table from ``calibration_curves``: that shared table is
+auto-read by ``perception/context.py:_build_calibration_text`` (it injects every
+domain it finds into the perception context). Writing ego calibration there would
+silently change ego/perception behaviour. This table has NO readers except the
+read-only user surface — keeping the measurement DARK. Injecting calibration back
+into the ego (self-correction) is a deliberate, separately-flagged future PR.
+
+``sample_count`` is the count of calibratable T1 rows (both stated_confidence and
+value present) that were actually bucketed — NOT a raw row count. ``low_confidence``
+flags a statistically thin estimate so the surface never reports a noisy ECE=0.0 as
+"perfectly calibrated".
+
+Idempotent (``IF NOT EXISTS``). Fresh installs get the same DDL via ``_tables.py``.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+_TABLE_DDL = """
+    CREATE TABLE IF NOT EXISTS ego_calibration_snapshots (
+        id              TEXT PRIMARY KEY,
+        domain          TEXT NOT NULL,
+        ece             REAL NOT NULL,
+        mce             REAL NOT NULL,
+        sample_count    INTEGER NOT NULL,
+        bucket_count    INTEGER NOT NULL,
+        low_confidence  INTEGER NOT NULL DEFAULT 0,
+        curve_json      TEXT NOT NULL,
+        computed_at     TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+"""
+
+_INDEX_DDL = [
+    "CREATE INDEX IF NOT EXISTS idx_ego_calibration_domain_time "
+    "ON ego_calibration_snapshots(domain, computed_at)",
+]
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # NOTE: must NOT call db.commit()/BEGIN — the runner owns the transaction.
+    await db.execute(_TABLE_DDL)
+    for stmt in _INDEX_DDL:
+        await db.execute(stmt)
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    """Drop the table (development/testing only)."""
+    await db.execute("DROP TABLE IF EXISTS ego_calibration_snapshots")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -547,6 +547,19 @@ TABLES = {
             UNIQUE (source, ref_type, ref_id, signal_type)
         )
     """,
+    "ego_calibration_snapshots": """
+        CREATE TABLE IF NOT EXISTS ego_calibration_snapshots (
+            id              TEXT PRIMARY KEY,
+            domain          TEXT NOT NULL,
+            ece             REAL NOT NULL,
+            mce             REAL NOT NULL,
+            sample_count    INTEGER NOT NULL,
+            bucket_count    INTEGER NOT NULL,
+            low_confidence  INTEGER NOT NULL DEFAULT 0,
+            curve_json      TEXT NOT NULL,
+            computed_at     TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    """,
     "events": """
         CREATE TABLE IF NOT EXISTS events (
             id               TEXT PRIMARY KEY,
@@ -1475,6 +1488,9 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_outcome_events_calibration "
     "ON outcome_events(domain, signal_tier) "
     "WHERE stated_confidence IS NOT NULL AND value IS NOT NULL",
+    # ego calibration snapshots (measure-only trend)
+    "CREATE INDEX IF NOT EXISTS idx_ego_calibration_domain_time "
+    "ON ego_calibration_snapshots(domain, computed_at)",
     # approval requests (Phase 9)
     "CREATE INDEX IF NOT EXISTS idx_approval_status ON approval_requests(status)",
     "CREATE INDEX IF NOT EXISTS idx_approval_class ON approval_requests(action_class)",

--- a/src/genesis/feedback/calibration.py
+++ b/src/genesis/feedback/calibration.py
@@ -1,0 +1,129 @@
+"""feedback/calibration.py — measure-only ego confidence calibration.
+
+Computes whether the ego's stated confidence tracks actual outcomes, from the
+Outcome Bus T1 (ground-truth) rows: "the ego said 90%, it was right 82%". Writes
+one snapshot per run to ``ego_calibration_snapshots`` so the ECE trend over time
+accrues — the self-improvement signal.
+
+DARK by construction:
+- Writes only to ``ego_calibration_snapshots`` (no cognitive-path reader).
+- Never writes ``calibration_curves`` (auto-read by ``perception/context.py``).
+- Never injects calibration back into the ego — self-correction is a deliberate,
+  separately-flagged future PR.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+
+import aiosqlite
+
+from genesis.calibration.metrics import compute_ece, compute_mce
+from genesis.calibration.types import bucket_confidence
+from genesis.db.crud import ego_calibration as cal_crud
+from genesis.db.crud import outcome_events as oe_crud
+
+logger = logging.getLogger(__name__)
+
+EGO_DOMAIN = "ego"
+
+# A snapshot is flagged low-confidence (a noisy estimate) below these — so the
+# user surface never reports a thin ECE=0.0 as "perfectly calibrated".
+_LOW_CONF_MIN_SAMPLES = 20
+_LOW_CONF_MIN_BUCKETS = 3
+
+
+def _bucket_midpoint(bucket: str) -> float:
+    """Parse a '0.8-0.9' bucket label to its midpoint 0.85.
+
+    Mirrors the parse in ``calibration/curves.py`` so ego calibration and the
+    existing outreach/triage calibration stay consistent.
+    """
+    try:
+        low, high = bucket.split("-")
+        return (float(low) + float(high)) / 2
+    except (ValueError, IndexError):
+        return 0.5
+
+
+def build_curve(pairs: list[dict]) -> list[dict]:
+    """Bucket (stated_confidence, value) pairs into a calibration curve.
+
+    Reuses ``calibration.types.bucket_confidence`` for binning. Returns only
+    POPULATED buckets, each shaped for ``compute_ece``/``compute_mce``:
+    ``{confidence_bucket, predicted_confidence, actual_success_rate, sample_count}``.
+    """
+    buckets: dict[str, list[float]] = defaultdict(list)
+    for p in pairs:
+        conf = p.get("stated_confidence")
+        val = p.get("value")
+        if conf is None or val is None:
+            continue
+        buckets[bucket_confidence(float(conf))].append(float(val))
+
+    curve: list[dict] = []
+    for bucket, values in sorted(buckets.items()):
+        n = len(values)
+        curve.append(
+            {
+                "confidence_bucket": bucket,
+                "predicted_confidence": _bucket_midpoint(bucket),
+                "actual_success_rate": sum(values) / n,
+                "sample_count": n,
+            }
+        )
+    return curve
+
+
+async def compute_ego_calibration(
+    db: aiosqlite.Connection, *, days: int = 90
+) -> dict | None:
+    """Compute + persist one ego calibration snapshot.
+
+    Returns the snapshot dict, or ``None`` if there are no calibratable T1 rows
+    yet (in which case NOTHING is written — a missing snapshot reads as "no data",
+    never as a spurious perfect ECE=0.0).
+    """
+    pairs = await oe_crud.calibration_pairs(db, source="ego", tier=1, days=days)
+    if not pairs:
+        logger.info("ego calibration: no T1 rows yet — skipping snapshot")
+        return None
+
+    curve = build_curve(pairs)
+    if not curve:
+        logger.info("ego calibration: no calibratable buckets — skipping snapshot")
+        return None
+
+    ece = compute_ece(curve)
+    mce = compute_mce(curve)
+    sample_count = sum(b["sample_count"] for b in curve)
+    bucket_count = len(curve)
+    low_confidence = (
+        sample_count < _LOW_CONF_MIN_SAMPLES or bucket_count < _LOW_CONF_MIN_BUCKETS
+    )
+
+    await cal_crud.record_snapshot(
+        db,
+        domain=EGO_DOMAIN,
+        ece=ece,
+        mce=mce,
+        sample_count=sample_count,
+        bucket_count=bucket_count,
+        low_confidence=low_confidence,
+        curve=curve,
+    )
+    logger.info(
+        "ego calibration: ECE=%.4f MCE=%.4f n=%d buckets=%d%s",
+        ece, mce, sample_count, bucket_count,
+        " (low-confidence estimate)" if low_confidence else "",
+    )
+    return {
+        "domain": EGO_DOMAIN,
+        "ece": ece,
+        "mce": mce,
+        "sample_count": sample_count,
+        "bucket_count": bucket_count,
+        "low_confidence": low_confidence,
+        "curve": curve,
+    }

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -62,6 +62,7 @@ from genesis.mcp.health import campaign_tools as _campaign_tools  # noqa: E402, 
 from genesis.mcp.health import codebase as _codebase  # noqa: E402
 from genesis.mcp.health import db_schema as _db_schema  # noqa: E402
 from genesis.mcp.health import direct_session_tools as _direct_session_tools  # noqa: E402
+from genesis.mcp.health import ego_calibration as _ego_calibration  # noqa: E402, F401
 from genesis.mcp.health import ego_tools as _ego_tools  # noqa: E402
 from genesis.mcp.health import errors as _errors  # noqa: E402
 from genesis.mcp.health import follow_up_tools as _follow_up_tools  # noqa: E402

--- a/src/genesis/mcp/health/ego_calibration.py
+++ b/src/genesis/mcp/health/ego_calibration.py
@@ -1,0 +1,77 @@
+"""Ego calibration status MCP tool — does the ego's confidence track reality?
+
+Read-only surface over ``ego_calibration_snapshots``. This is the user-facing
+half of the measure-only ego calibration: it reports whether the ego's stated
+confidence matches actual outcomes ("says 90%, right 82%"), the ECE, and the
+trend over time. It does NOT change ego behaviour (self-correction is a separate,
+flagged future PR) and never writes anything.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+
+async def _impl_ego_calibration_status(domain: str = "ego") -> dict:
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    _service = health_mcp_mod._service
+    if _service is None or _service._db is None:
+        return {"status": "unavailable", "message": "DB not initialized"}
+
+    db = _service._db
+    from genesis.db.crud import ego_calibration as cal_crud
+
+    latest = await cal_crud.get_latest(db, domain=domain)
+    if latest is None:
+        return {
+            "status": "no_data",
+            "message": (
+                f"No calibration snapshots yet for domain={domain!r}. Computed at "
+                f"09:00/21:00 once the Outcome Bus has ground-truth (T1) rows."
+            ),
+        }
+
+    trend = await cal_crud.get_trend(db, domain=domain, limit=30)
+    curve = latest.get("curve", [])
+    curve_readable = [
+        f"says ~{c['predicted_confidence']:.0%} → right "
+        f"{c['actual_success_rate']:.0%} (n={c['sample_count']})"
+        for c in curve
+    ]
+    # MCE is the worst single bucket and can be inflated by a thin (low-n) bucket.
+    note = None
+    if latest["mce"] > 2 * latest["ece"]:
+        note = "MCE reflects the worst single bucket — check per-bucket n for thin (noisy) bins."
+
+    return {
+        "status": "ok",
+        "domain": domain,
+        "ece": latest["ece"],
+        "mce": latest["mce"],
+        "sample_count": latest["sample_count"],
+        "bucket_count": latest["bucket_count"],
+        "low_confidence": latest["low_confidence"],
+        "computed_at": latest["computed_at"],
+        "curve": curve,
+        "curve_readable": curve_readable,
+        "ece_trend": [t["ece"] for t in trend],  # newest first
+        "note": note,
+    }
+
+
+@mcp.tool()
+async def ego_calibration_status(domain: str = "ego") -> dict:
+    """How well-calibrated is the ego's confidence?
+
+    Reports whether the ego's stated confidence tracks actual outcomes
+    ("says 90%, right 82%"), the Expected Calibration Error (ECE, lower=better),
+    the per-confidence-bucket curve, and the ECE trend over time. Measure-only:
+    reading this does NOT change ego behaviour. ``low_confidence=true`` means the
+    estimate is statistically thin (few samples/buckets) — read it with caution.
+    """
+    return await _impl_ego_calibration_status(domain)

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -606,6 +606,38 @@ async def init(rt: GenesisRuntime) -> None:
             misfire_grace_time=3600,
         )
 
+        async def _run_ego_calibration() -> None:
+            # Compute the ego's confidence calibration from the Outcome Bus T1
+            # rows and snapshot it (ECE-over-time trend). MEASURE-ONLY / DARK:
+            # writes only ego_calibration_snapshots (no cognitive-path reader),
+            # never injects back into the ego. Runs 15 min after outcome_harvest
+            # (8:45/20:45) so it reads a fresh harvest, 15 min before
+            # capability_map_refresh (9:15/21:15) — a clean WAL gap.
+            if rt._db is None:
+                return
+            try:
+                from genesis.feedback.calibration import compute_ego_calibration
+
+                snap = await compute_ego_calibration(rt._db)
+                rt.record_job_success("ego_calibration")
+                if snap is not None:
+                    logger.info(
+                        "Ego calibration: ECE=%.4f n=%d%s",
+                        snap["ece"], snap["sample_count"],
+                        " (low-confidence)" if snap["low_confidence"] else "",
+                    )
+            except Exception as exc:
+                rt.record_job_failure("ego_calibration", str(exc))
+                logger.exception("Ego calibration failed")
+
+        rt._learning_scheduler.add_job(
+            _run_ego_calibration,
+            CronTrigger(hour="9,21", minute=0, timezone=user_timezone()),
+            id="ego_calibration",
+            max_instances=1,
+            misfire_grace_time=3600,
+        )
+
         async def _reap_activity_log() -> None:
             if rt._activity_tracker is None:
                 return

--- a/tests/feedback/test_calibration.py
+++ b/tests/feedback/test_calibration.py
@@ -1,0 +1,193 @@
+"""Tests for feedback/calibration.py + ego_calibration CRUD + migration 0026."""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import ego_calibration as cal_crud
+from genesis.db.crud import outcome_events as oe
+from genesis.feedback.calibration import build_curve, compute_ego_calibration
+
+MIGRATION = importlib.import_module("genesis.db.migrations.0026_ego_calibration_snapshots")
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """Full schema (outcome_events + ego_calibration_snapshots)."""
+    from genesis.db.schema import create_all_tables
+
+    path = str(tmp_path / "cal.db")
+    async with aiosqlite.connect(path) as conn:
+        await create_all_tables(conn)
+        await conn.commit()
+        yield conn
+
+
+async def _add_t1(db, *, ref, conf, value, source="ego"):
+    """Insert one tier-1 outcome_events row with confidence+value."""
+    await oe.record(
+        db, source=source, ref_type="proposal", ref_id=ref,
+        signal_type="execution_outcome", signal_tier=1,
+        polarity="positive" if value else "negative",
+        value=value, stated_confidence=conf,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# build_curve (pure)
+# --------------------------------------------------------------------------- #
+class TestBuildCurve:
+    def test_empty(self):
+        assert build_curve([]) == []
+
+    def test_buckets_and_rates(self):
+        pairs = [
+            {"stated_confidence": 0.85, "value": 1.0},
+            {"stated_confidence": 0.82, "value": 0.0},  # same bucket 0.8-0.9
+            {"stated_confidence": 0.95, "value": 1.0},  # bucket 0.9-1.0
+        ]
+        curve = build_curve(pairs)
+        by_bucket = {c["confidence_bucket"]: c for c in curve}
+        assert by_bucket["0.8-0.9"]["sample_count"] == 2
+        assert by_bucket["0.8-0.9"]["actual_success_rate"] == 0.5
+        assert abs(by_bucket["0.8-0.9"]["predicted_confidence"] - 0.85) < 1e-9  # midpoint
+        assert by_bucket["0.9-1.0"]["actual_success_rate"] == 1.0
+        assert abs(by_bucket["0.9-1.0"]["predicted_confidence"] - 0.95) < 1e-9
+
+    def test_skips_null(self):
+        pairs = [{"stated_confidence": None, "value": 1.0},
+                 {"stated_confidence": 0.7, "value": None}]
+        assert build_curve(pairs) == []
+
+
+# --------------------------------------------------------------------------- #
+# compute_ego_calibration
+# --------------------------------------------------------------------------- #
+class TestComputeEgoCalibration:
+    @pytest.mark.asyncio
+    async def test_zero_rows_writes_nothing(self, db):
+        result = await compute_ego_calibration(db)
+        assert result is None
+        assert await cal_crud.get_latest(db) is None  # no spurious ece=0.0
+
+    @pytest.mark.asyncio
+    async def test_ece_mce_math(self, db):
+        # Bucket 0.8-0.9: 10 rows, 9 success -> actual 0.9, predicted 0.85 -> |0.05|
+        for i in range(10):
+            await _add_t1(db, ref=f"a{i}", conf=0.85, value=1.0 if i < 9 else 0.0)
+        # Bucket 0.9-1.0: 10 rows, 8 success -> actual 0.8, predicted 0.95 -> |0.15|
+        for i in range(10):
+            await _add_t1(db, ref=f"b{i}", conf=0.95, value=1.0 if i < 8 else 0.0)
+
+        snap = await compute_ego_calibration(db)
+        assert snap is not None
+        assert snap["sample_count"] == 20
+        assert snap["bucket_count"] == 2
+        # ECE = 0.5*0.05 + 0.5*0.15 = 0.10 ; MCE = max(0.05, 0.15) = 0.15
+        assert abs(snap["ece"] - 0.10) < 1e-6
+        assert abs(snap["mce"] - 0.15) < 1e-6
+        # 2 buckets (< 3) => low-confidence estimate
+        assert snap["low_confidence"] is True
+
+        stored = await cal_crud.get_latest(db)
+        assert stored["ece"] == snap["ece"]
+        assert len(stored["curve"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_source_filter_excludes_non_ego(self, db):
+        # ego rows
+        for i in range(5):
+            await _add_t1(db, ref=f"e{i}", conf=0.8, value=1.0)
+        # outreach rows at tier 1 — MUST NOT be counted in ego calibration
+        for i in range(5):
+            await _add_t1(db, ref=f"o{i}", conf=0.2, value=0.0, source="outreach")
+
+        snap = await compute_ego_calibration(db)
+        assert snap["sample_count"] == 5  # only ego
+        # the 0.2 outreach rows would have created a 0.2-0.3 bucket if leaked
+        assert all(c["confidence_bucket"] != "0.2-0.3" for c in snap["curve"])
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_clears_with_enough_data(self, db):
+        # 3 buckets, 30 samples -> not low-confidence
+        for i in range(10):
+            await _add_t1(db, ref=f"x{i}", conf=0.75, value=1.0)
+        for i in range(10):
+            await _add_t1(db, ref=f"y{i}", conf=0.85, value=1.0 if i < 8 else 0.0)
+        for i in range(10):
+            await _add_t1(db, ref=f"z{i}", conf=0.95, value=1.0 if i < 9 else 0.0)
+        snap = await compute_ego_calibration(db)
+        assert snap["bucket_count"] == 3
+        assert snap["sample_count"] == 30
+        assert snap["low_confidence"] is False
+
+
+# --------------------------------------------------------------------------- #
+# CRUD + migration
+# --------------------------------------------------------------------------- #
+class TestCrudAndMigration:
+    @pytest.mark.asyncio
+    async def test_get_trend_orders_newest_first(self, db):
+        await cal_crud.record_snapshot(
+            db, domain="ego", ece=0.10, mce=0.2, sample_count=20,
+            bucket_count=2, low_confidence=True, curve=[{"x": 1}],
+        )
+        await cal_crud.record_snapshot(
+            db, domain="ego", ece=0.05, mce=0.1, sample_count=40,
+            bucket_count=4, low_confidence=False, curve=[{"x": 2}],
+        )
+        trend = await cal_crud.get_trend(db, domain="ego")
+        assert len(trend) == 2
+        assert trend[0]["ece"] == 0.05  # newest first
+        assert trend[0]["low_confidence"] is False
+
+    @pytest.mark.asyncio
+    async def test_mcp_surface_no_data_and_ok(self, db, monkeypatch):
+        import genesis.mcp.health_mcp as hm
+        from genesis.mcp.health.ego_calibration import _impl_ego_calibration_status
+
+        class _StubService:
+            def __init__(self, _db):
+                self._db = _db
+
+        monkeypatch.setattr(hm, "_service", _StubService(db), raising=False)
+
+        # No snapshots yet -> no_data (never a spurious ece=0.0)
+        res = await _impl_ego_calibration_status()
+        assert res["status"] == "no_data"
+
+        # Seed a snapshot -> ok, with readable curve + MCE caveat note
+        await cal_crud.record_snapshot(
+            db, domain="ego", ece=0.116, mce=0.45, sample_count=47,
+            bucket_count=5, low_confidence=False,
+            curve=[{"confidence_bucket": "0.8-0.9", "predicted_confidence": 0.85,
+                    "actual_success_rate": 0.82, "sample_count": 22}],
+        )
+        res = await _impl_ego_calibration_status()
+        assert res["status"] == "ok"
+        assert res["ece"] == 0.116
+        assert res["curve_readable"][0].startswith("says ~85%")
+        assert res["note"] is not None  # mce 0.45 > 2*ece 0.232 → caveat shown
+
+    @pytest.mark.asyncio
+    async def test_migration_up_down(self, tmp_path):
+        path = str(tmp_path / "m.db")
+        async with aiosqlite.connect(path) as conn:
+            await MIGRATION.up(conn)
+            await MIGRATION.up(conn)  # idempotent
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='ego_calibration_snapshots'"
+            )
+            assert await cur.fetchone() is not None
+            await MIGRATION.down(conn)
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='ego_calibration_snapshots'"
+            )
+            assert await cur.fetchone() is None

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -102,6 +102,7 @@ async def test_no_unexpected_tables(db):
         "reflection_corpus",
         "email_threads", "email_thread_messages",
         "outcome_events",  # self-improvement outcome bus
+        "ego_calibration_snapshots",  # measure-only ego calibration
     }
     for table in tables:
         assert table in known, f"Unexpected table: {table}"


### PR DESCRIPTION
## ⛔ HOLD — DO NOT MERGE YET

Several sessions are building adjacent self-improvement systems right now. This PR is opened as a **draft** to hold for review and de-confliction; do not merge without explicit owner sign-off.

---

## Measure-only ego calibration (dark)

Builds on the merged Outcome Bus (#690). It answers a concrete question about Genesis's self-improvement: **does the ego's stated confidence track reality?** It computes the ego's calibration from the bus's ground-truth (T1) outcomes, stores an ECE-over-time trend, and surfaces it to the user via a read-only MCP tool.

It is **fully dark** — it changes no ego or perception behaviour. Injecting calibration *back* into the ego (self-correction) is a deliberately deferred, separately-flagged future PR.

### What it does
- **`ego_calibration_snapshots`** table (migration `0026`) — one snapshot per run: `ece, mce, sample_count, bucket_count, low_confidence, curve_json`. The trend over time is the self-improvement signal. Deliberately **not** `calibration_curves` (that shared table is auto-read by the perception context — writing there would silently inject calibration into reasoning).
- **`feedback/calibration.py`** — buckets the ego's `(stated_confidence, value)` T1 pairs and computes ECE/MCE, reusing the existing `calibration/metrics.py` + `calibration/types.py:bucket_confidence`. Sources **only** `source='ego', tier=1` (a new `outcome_events.calibration_pairs`) so no cross-source/cross-domain contamination. Skips the write when there's no data (never a spurious `ECE=0.0`); `low_confidence` flags statistically thin estimates.
- **Scheduled** 09:00/21:00 (after the harvest, before the capability-map refresh).
- **`ego_calibration_status`** read-only MCP tool — the user-facing measurement.

### Verified
- 11 targeted tests (bucketing/ECE math, source isolation, zero-row skip, `low_confidence`, CRUD trend, migration up/down, MCP surface) + the schema-guard. Ruff clean.
- **E2E against a copy of prod:** 47 T1 rows → **ECE = 0.116**; the ego is systematically *under*confident (says ~65%, right 100%) with mild overconfidence at 0.8–0.9 (→82%). Trend accrues across runs.
- **Dark proof:** grep-confirmed nothing in any cognitive path reads `ego_calibration_snapshots`.

### Honest caveats
- 47 rows is a thin start — the value is the machinery + the ECE trend over time, not the day-1 number.
- `MCE` can be inflated by a low-n bucket; the MCP surface shows per-bucket `n` and a caveat note, and `low_confidence` qualifies the whole snapshot.
