### PR TITLE
feat(ego): calibration self-correction injection (dark flag, default on) [HOLD — stacked on #692]

### DIFF
--- a/config/ego.yaml
+++ b/config/ego.yaml
@@ -41,3 +41,8 @@ dispatch_model_overrides:
 # Circuit breaker
 consecutive_failure_limit: 3
 failure_backoff_minutes: 60  # pause after N consecutive failures
+
+# Self-improvement: inject the ego's own confidence calibration into its context
+# so it can self-correct (informational only, never a mechanical rescale).
+# Live — takes effect next cycle. Set false to turn off instantly.
+calibration_injection_enabled: true

--- a/src/genesis/ego/config.py
+++ b/src/genesis/ego/config.py
@@ -145,4 +145,8 @@ def validate_ego_config(changes: dict) -> list[str]:
             for action, model in v.items():
                 if model not in valid_models:
                     errors.append(f"dispatch_model_overrides[{action}]: model must be one of {valid_models}")
+    if "calibration_injection_enabled" in changes and not isinstance(
+        changes["calibration_injection_enabled"], bool
+    ):
+        errors.append("calibration_injection_enabled must be a boolean")
     return errors

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -93,6 +93,7 @@ class GenesisEgoContextBuilder:
             ("proposal_board", self._proposal_board_section),
             ("execution_outcomes", self._execution_outcomes_section),
             ("capability_performance", self._capability_performance_section),
+            ("confidence_calibration", self._confidence_calibration_section),
             ("output_contract", self._output_contract_section),
         ]
 
@@ -579,6 +580,40 @@ class GenesisEgoContextBuilder:
 
         lines.append("")
         return "\n".join(lines)
+
+    async def _confidence_calibration_section(self, *, depth: str = "deep") -> str:
+        """The ego's own confidence calibration — so it can self-correct.
+
+        Informational context for the ``confidence`` field (rendered right before
+        the output contract), NOT a limiter and NOT a mechanical rescale. Reads
+        ``ego_calibration_snapshots`` ONLY (never ``calibration_curves`` — that table
+        is auto-injected into the perception context). Genesis ego only for v1 — the
+        aggregate calibration is genesis-ego dominated; per-ego split is future work.
+
+        Live flag ``EgoConfig.calibration_injection_enabled`` (default ON) is read
+        fresh each cycle, so toggling it takes effect next cycle without a restart.
+        Must be ``async`` (calls async ``get_latest``). Not in ``_ALL_SECTIONS``
+        (that table is user-ego only); the genesis section_map drives it directly.
+        """
+        try:
+            from genesis.ego.config import load_ego_config
+
+            cfg = load_ego_config()
+            if not getattr(cfg, "calibration_injection_enabled", True):
+                return ""
+
+            from genesis.db.crud import ego_calibration as cal_crud
+            from genesis.feedback.calibration import format_calibration_section
+
+            snapshot = await cal_crud.get_latest(self._db, domain="ego")
+            return format_calibration_section(snapshot, depth=depth)
+        except aiosqlite.OperationalError:
+            # Expected before PR-B is deployed (table absent) — not an error.
+            logger.debug("ego_calibration_snapshots not yet available")
+            return ""
+        except Exception:
+            logger.warning("Failed to build confidence calibration section", exc_info=True)
+            return ""
 
     async def _capability_performance_section(self, *, depth: str = "deep") -> str:
         """System capability performance — domain confidence from multiple sources."""

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -599,7 +599,9 @@ class GenesisEgoContextBuilder:
             from genesis.ego.config import load_ego_config
 
             cfg = load_ego_config()
-            if not getattr(cfg, "calibration_injection_enabled", True):
+            # Default ON: disable ONLY on an explicit False (a YAML null / missing
+            # key / truthy value all keep it on, so it can't be silently disabled).
+            if getattr(cfg, "calibration_injection_enabled", True) is False:
                 return ""
 
             from genesis.db.crud import ego_calibration as cal_crud

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -137,5 +137,9 @@ class EgoConfig:
     # names ("opus", "sonnet", "haiku").  Falls back to profile-based
     # selection when the action_type is not listed.
     dispatch_model_overrides: dict = field(default_factory=dict)
+    # Inject the ego's own confidence calibration into its context so it can
+    # self-correct (informational, never a mechanical rescale). Live-read each
+    # cycle; default ON. Genesis ego only for now.
+    calibration_injection_enabled: bool = True
 
 

--- a/src/genesis/feedback/calibration.py
+++ b/src/genesis/feedback/calibration.py
@@ -76,6 +76,45 @@ def build_curve(pairs: list[dict]) -> list[dict]:
     return curve
 
 
+def format_calibration_section(snapshot: dict | None, *, depth: str = "deep") -> str:
+    """Render an ego calibration snapshot as ego-context text (informational).
+
+    For the ego's ``confidence`` field. Returns "" when there is no snapshot or the
+    snapshot is flagged ``low_confidence`` (not trustworthy to act on), so the ego is
+    never nudged by noise. Shared by the genesis-ego context section and the MCP
+    status surface (one source of formatting). NO mechanical rescaling — the text
+    invites the ego to weigh its history while keeping its own judgment.
+    """
+    if not snapshot or snapshot.get("low_confidence"):
+        return ""
+    ece = snapshot.get("ece", 0.0)
+    n = snapshot.get("sample_count", 0)
+
+    if depth == "light":
+        return (
+            "## Confidence Calibration\n"
+            f"Your stated confidence vs reality: ECE={ece:.2f} over n={n} outcomes "
+            "(weigh when setting the `confidence` field).\n"
+        )
+
+    lines = [
+        "## Confidence Calibration (for the `confidence` field below)",
+        "Your stated confidence vs actual outcomes. Weigh this — do NOT mechanically "
+        "rescale; keep your own judgment. Small-n buckets are directional only:",
+    ]
+    for c in snapshot.get("curve", []):
+        pred = round(c.get("predicted_confidence", 0.0) * 100)
+        actual = round(c.get("actual_success_rate", 0.0) * 100)
+        nb = c.get("sample_count", 0)
+        lines.append(
+            f"  - When you report ~{pred}% confidence, "
+            f"you're historically right ~{actual}% (n={nb})"
+        )
+    lines.append(f"Overall ECE={ece:.2f} over n={n} (0 = perfectly calibrated).")
+    lines.append("")
+    return "\n".join(lines)
+
+
 async def compute_ego_calibration(
     db: aiosqlite.Connection, *, days: int = 90
 ) -> dict | None:

--- a/src/genesis/feedback/calibration.py
+++ b/src/genesis/feedback/calibration.py
@@ -103,8 +103,9 @@ def format_calibration_section(snapshot: dict | None, *, depth: str = "deep") ->
         "rescale; keep your own judgment. Small-n buckets are directional only:",
     ]
     for c in snapshot.get("curve", []):
-        pred = round(c.get("predicted_confidence", 0.0) * 100)
-        actual = round(c.get("actual_success_rate", 0.0) * 100)
+        # half-up rounding (avoid banker's rounding misrepresenting .5 boundaries)
+        pred = int(c.get("predicted_confidence", 0.0) * 100 + 0.5)
+        actual = int(c.get("actual_success_rate", 0.0) * 100 + 0.5)
         nb = c.get("sample_count", 0)
         lines.append(
             f"  - When you report ~{pred}% confidence, "

--- a/tests/ego/test_calibration_injection.py
+++ b/tests/ego/test_calibration_injection.py
@@ -1,0 +1,160 @@
+"""Tests for ego calibration self-correction injection (genesis ego context)."""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import ego_calibration as cal_crud
+
+# These imports are the SUT — they don't exist until implemented (TDD red first).
+from genesis.feedback.calibration import format_calibration_section
+
+
+def _snapshot(*, low_confidence=False):
+    return {
+        "domain": "ego",
+        "ece": 0.116,
+        "mce": 0.45,
+        "sample_count": 47,
+        "bucket_count": 5,
+        "low_confidence": low_confidence,
+        "curve": [
+            {"confidence_bucket": "0.6-0.7", "predicted_confidence": 0.65,
+             "actual_success_rate": 1.0, "sample_count": 7},
+            {"confidence_bucket": "0.8-0.9", "predicted_confidence": 0.85,
+             "actual_success_rate": 0.82, "sample_count": 22},
+        ],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# format_calibration_section (pure)
+# --------------------------------------------------------------------------- #
+class TestFormatter:
+    def test_none_is_empty(self):
+        assert format_calibration_section(None) == ""
+
+    def test_low_confidence_is_empty(self):
+        assert format_calibration_section(_snapshot(low_confidence=True)) == ""
+
+    def test_deep_renders_curve(self):
+        out = format_calibration_section(_snapshot(), depth="deep")
+        assert "Confidence Calibration" in out
+        assert "~65%" in out and "~100%" in out and "n=7" in out
+        assert "~85%" in out and "~82%" in out and "n=22" in out
+        assert "0.12" in out or "0.116" in out  # ECE present
+        # anti-overfitting framing present
+        assert "directional" in out.lower() or "weigh" in out.lower()
+
+    def test_light_is_summary_not_curve(self):
+        out = format_calibration_section(_snapshot(), depth="light")
+        assert "ECE" in out
+        # light must NOT include the per-bucket lines
+        assert "When you report" not in out
+
+
+# --------------------------------------------------------------------------- #
+# _confidence_calibration_section (genesis ego context)
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+async def db(tmp_path):
+    from genesis.db.schema import create_all_tables
+
+    path = str(tmp_path / "inj.db")
+    async with aiosqlite.connect(path) as conn:
+        await create_all_tables(conn)
+        await conn.commit()
+        yield conn
+
+
+def _builder(db):
+    from genesis.ego.genesis_context import GenesisEgoContextBuilder
+
+    return GenesisEgoContextBuilder(db=db, health_data=None, capabilities={})
+
+
+def _set_flag(monkeypatch, enabled: bool):
+    from genesis.ego.types import EgoConfig
+
+    monkeypatch.setattr(
+        "genesis.ego.config.load_ego_config",
+        lambda *a, **k: EgoConfig(calibration_injection_enabled=enabled),
+    )
+
+
+class TestSection:
+    @pytest.mark.asyncio
+    async def test_renders_when_flag_on_and_snapshot(self, db, monkeypatch):
+        _set_flag(monkeypatch, True)
+        await cal_crud.record_snapshot(
+            db, domain="ego", ece=0.116, mce=0.45, sample_count=47,
+            bucket_count=5, low_confidence=False, curve=_snapshot()["curve"],
+        )
+        out = await _builder(db)._confidence_calibration_section()
+        assert "Confidence Calibration" in out
+        assert "n=22" in out
+
+    @pytest.mark.asyncio
+    async def test_flag_off_is_empty(self, db, monkeypatch):
+        _set_flag(monkeypatch, False)
+        await cal_crud.record_snapshot(
+            db, domain="ego", ece=0.116, mce=0.45, sample_count=47,
+            bucket_count=5, low_confidence=False, curve=_snapshot()["curve"],
+        )
+        assert await _builder(db)._confidence_calibration_section() == ""
+
+    @pytest.mark.asyncio
+    async def test_no_snapshot_is_empty(self, db, monkeypatch):
+        _set_flag(monkeypatch, True)
+        assert await _builder(db)._confidence_calibration_section() == ""
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_snapshot_is_empty(self, db, monkeypatch):
+        _set_flag(monkeypatch, True)
+        await cal_crud.record_snapshot(
+            db, domain="ego", ece=0.30, mce=0.5, sample_count=4,
+            bucket_count=1, low_confidence=True, curve=_snapshot()["curve"],
+        )
+        assert await _builder(db)._confidence_calibration_section() == ""
+
+    @pytest.mark.asyncio
+    async def test_missing_table_is_empty_not_raise(self, tmp_path, monkeypatch):
+        # No create_all_tables -> ego_calibration_snapshots absent -> OperationalError
+        _set_flag(monkeypatch, True)
+        path = str(tmp_path / "bare.db")
+        async with aiosqlite.connect(path) as conn:
+            out = await _builder(conn)._confidence_calibration_section()
+            assert out == ""  # graceful pre-deploy state
+
+
+    @pytest.mark.asyncio
+    async def test_section_appears_in_full_build(self, db, monkeypatch):
+        """WIRING: the section must show up in the assembled context build(),
+        not just when called directly (built != wired)."""
+        _set_flag(monkeypatch, True)
+        await cal_crud.record_snapshot(
+            db, domain="ego", ece=0.116, mce=0.45, sample_count=47,
+            bucket_count=5, low_confidence=False, curve=_snapshot()["curve"],
+        )
+        full = await _builder(db).build()
+        assert "## Confidence Calibration" in full
+        # rendered before the output contract (highest salience for the confidence field)
+        assert full.index("Confidence Calibration") < full.index("Output Contract")
+
+    @pytest.mark.asyncio
+    async def test_section_absent_from_build_when_flag_off(self, db, monkeypatch):
+        _set_flag(monkeypatch, False)
+        await cal_crud.record_snapshot(
+            db, domain="ego", ece=0.116, mce=0.45, sample_count=47,
+            bucket_count=5, low_confidence=False, curve=_snapshot()["curve"],
+        )
+        full = await _builder(db).build()
+        assert "Confidence Calibration" not in full
+
+
+class TestConfigFlag:
+    def test_default_is_on(self):
+        from genesis.ego.types import EgoConfig
+
+        assert EgoConfig().calibration_injection_enabled is True

--- a/tests/ego/test_calibration_injection.py
+++ b/tests/ego/test_calibration_injection.py
@@ -143,6 +143,22 @@ class TestSection:
         assert full.index("Confidence Calibration") < full.index("Output Contract")
 
     @pytest.mark.asyncio
+    async def test_null_flag_stays_on(self, db, monkeypatch):
+        # YAML null / unexpected value must NOT silently disable (default-ON;
+        # only an explicit False disables).
+        from genesis.ego.types import EgoConfig
+
+        cfg = EgoConfig()
+        cfg.calibration_injection_enabled = None  # simulate YAML null
+        monkeypatch.setattr("genesis.ego.config.load_ego_config", lambda *a, **k: cfg)
+        await cal_crud.record_snapshot(
+            db, domain="ego", ece=0.116, mce=0.45, sample_count=47,
+            bucket_count=5, low_confidence=False, curve=_snapshot()["curve"],
+        )
+        out = await _builder(db)._confidence_calibration_section()
+        assert "Confidence Calibration" in out  # stayed ON
+
+    @pytest.mark.asyncio
     async def test_section_absent_from_build_when_flag_off(self, db, monkeypatch):
         _set_flag(monkeypatch, False)
         await cal_crud.record_snapshot(


### PR DESCRIPTION
## ⛔ HOLD — DO NOT MERGE YET · stacked on #692

Draft, held for review/de-confliction (concurrent sessions touch adjacent systems). **Base is `feat/ego-calibration` (#692), not main** — this is the *self-correction* half of ego calibration; it depends on #692's `ego_calibration_snapshots` table. Merge order: #692 first, then this.

---

## Ego calibration self-correction (the consumption half)

PR #692 *measures* the ego's confidence calibration. This PR *feeds it back* so the ego can self-correct. It adds a **"Confidence Calibration" section to the Genesis-ego context**, placed immediately before the output contract (highest salience for the `confidence` field), rendering the ego's own history:

```
## Confidence Calibration (for the `confidence` field below)
Your stated confidence vs actual outcomes. Weigh this — do NOT mechanically
rescale; keep your own judgment. Small-n buckets are directional only:
  - When you report ~65% confidence, you're historically right ~100% (n=7)
  - When you report ~85% confidence, you're historically right ~82% (n=22)
  ...
Overall ECE=0.12 over n=47
```

This is a **live-ego behaviour change** — the text reaches the proposal-generation prompt (traced: `session.py` → `assemble_context` → `build()` → `section_map` → THINK). The ego is currently *under*confident, so it's mostly encouragement to trust itself more.

### Design choices
- **Informational, never mechanical** — no code rescales the confidence number; the ego weighs its history (LLM-first + anti-overfitting). Per-bucket `n` is shown; thin buckets are framed as directional only.
- **Live flag, default ON** — `EgoConfig.calibration_injection_enabled` (in `config/ego.yaml`), read fresh each cycle (cadence hot-reload), so toggling takes effect next cycle with no restart. Disabled only on an explicit `false`.
- **Genesis ego only (v1)** — the aggregate calibration is genesis-ego-dominated; injecting it into the user ego would be a semantic mismatch. Per-ego split is future work.
- **Reads `ego_calibration_snapshots` only, never `calibration_curves`** (that shared table auto-injects into the perception context).
- **Cannot break the ego cycle** — the section returns `""` on any error; `OperationalError` (table absent before #692 deploys) is caught at DEBUG.

### Verified
- 14 targeted tests + regression on `genesis_context`/`ego config` (53 green). Ruff clean. Architect review + code review (findings fixed: explicit-`False`-only disable, bool validator, half-up rounding).
- **E2E vs prod copy:** the section renders in the assembled context with the real curve, before the output contract.

### Inert until
#692 merged + deployed → snapshots accrue → a non-low-confidence snapshot exists → flag ON (default). Today's data already qualifies, so once #692 deploys the ego will see this.
