### PR TITLE
fix: deploy + CI reliability — update.sh restart race + harvest test date-bomb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Updates now reliably load the new code** — an update could finish "successfully"
+  while the running Genesis process kept executing the *old* code: when the updater
+  stopped the server, systemd's auto-restart could bring it back on the pre-update
+  code before the new code was even pulled, and the updater's final restart was a
+  no-op on the already-running process. The database migrated but the live process
+  didn't, leaving new code on disk and old code in memory. The updater now forces a
+  true restart at the end and makes sure the server stays down during the upgrade, so
+  an update always activates the version it just installed.
+
 - **Recovered providers stop alarming once they come back** — when a model provider's
   circuit breaker reopens after an outage, Genesis now clears that provider's "failing"
   alert instead of leaving it lingering for days until it expired. Per-session conversation

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -228,16 +228,49 @@ _stop_genesis_server() {
     sleep 1
 }
 
+_ensure_server_down() {
+    # Guarantee genesis-server is stopped AND stays stopped before mutating the
+    # repo/DB. systemd's Restart=on-failure can resurrect the server after a
+    # kill-based stop (the kill reads as a failure, arming a RestartSec timer); an
+    # explicit `systemctl stop` transitions the unit to inactive/dead and DISARMS
+    # that timer (on-failure only fires from active/running). Without this, an
+    # auto-restarted STALE-code process runs during the merge + migration window —
+    # the bug that shipped a deploy whose running process never loaded the new code.
+    systemctl --user stop genesis-server.service 2>/dev/null || true
+    for _ in $(seq 1 20); do
+        if ! systemctl --user is-active --quiet genesis-server.service 2>/dev/null \
+           && ! pgrep -f "python -m genesis serve" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.5
+    done
+    # The restart timer may have fired between the stop and the poll — stop again,
+    # then hard-kill as a last resort.
+    systemctl --user stop genesis-server.service 2>/dev/null || true
+    pkill -KILL -f "python -m genesis serve" 2>/dev/null || true
+    sleep 1
+    if pgrep -f "python -m genesis serve" >/dev/null 2>&1; then
+        echo "  ERROR: genesis-server could not be stopped"
+        return 1
+    fi
+    return 0
+}
+
 _start_genesis_server() {
-    # Try systemctl first (preferred — enables health monitoring + auto-restart)
-    if systemctl --user start genesis-server.service 2>&1; then
+    # Use `restart` (NOT `start`): systemd's Restart=on-failure can resurrect a
+    # STALE-code instance mid-update (a kill-based stop is seen as a failure and
+    # arms a RestartSec timer). `start` is a no-op on that already-running instance
+    # and would silently leave the OLD code live after the update. `restart` always
+    # stop+starts from the current on-disk code, and still starts the unit cleanly
+    # when it is already stopped.
+    if systemctl --user restart genesis-server.service 2>&1; then
         echo "  Started genesis-server via systemd"
         return 0
     fi
     # Fallback: start directly — DEGRADED MODE
     # This bypasses systemd monitoring, so health dashboard will show red.
-    echo "  WARNING: systemctl --user start failed — falling back to direct start (degraded)"
-    echo "  Health monitoring will not work correctly. Run: systemctl --user start genesis-server.service"
+    echo "  WARNING: systemctl --user restart failed — falling back to direct start (degraded)"
+    echo "  Health monitoring will not work correctly. Run: systemctl --user restart genesis-server.service"
     nohup "$VENV_DIR/bin/python" -m genesis serve --host 0.0.0.0 --port 5000 \
         >> "$HOME/.genesis/logs/genesis-server.log" 2>&1 &
     echo "  Started genesis-server in degraded mode (pid $!)"
@@ -266,6 +299,15 @@ WERE_RUNNING=()
 if systemctl --user is-active --quiet genesis-server.service 2>/dev/null || \
    pgrep -f "python -m genesis serve" >/dev/null 2>&1; then
     _stop_genesis_server
+    # Disarm systemd's on-failure auto-restart so a stale-code instance can't come
+    # back during the merge/migration window. The ERR-trap rollback is not armed
+    # yet, so aborting here leaves the repo/DB untouched — safe to exit.
+    if ! _ensure_server_down; then
+        echo "  Aborting update — could not stop genesis-server; refusing to merge over a live process."
+        echo "  genesis-server has been stopped and was NOT restarted. Bring it back with:"
+        echo "    systemctl --user restart genesis-server.service"
+        exit 1
+    fi
     WERE_RUNNING+=("genesis-server")
 fi
 
@@ -381,8 +423,11 @@ _do_rollback() {
     echo "  UPDATE FAILED — $reason"
     echo "  Rolling back to $ROLLBACK_TAG..."
 
-    # Stop any running services first
+    # Stop any running services first. _ensure_server_down also disarms the
+    # on-failure restart timer so a stale instance can't come back mid-rollback
+    # (best-effort here — the rollback continues even if it can't fully stop).
     _stop_genesis_server
+    _ensure_server_down || echo "  WARNING: genesis-server may still be running during rollback"
     systemctl --user stop genesis-bridge 2>/dev/null || true
 
     # Restore the original branch, then reset it to the rollback tag.

--- a/tests/feedback/test_harvest.py
+++ b/tests/feedback/test_harvest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import aiosqlite
 import pytest
 
@@ -31,11 +33,21 @@ async def db(tmp_path):
         yield conn
 
 
+def _recent(*, hours: float) -> str:
+    """An ISO timestamp `hours` in the past. Relative (not hardcoded) so the
+    windowed run() always sees default rows — fixed-date defaults silently
+    "expire" relative to the rolling window and break this suite as time passes.
+    """
+    return (datetime.now(UTC) - timedelta(hours=hours)).isoformat()
+
+
 async def _add_proposal(
     db, *, pid, status, user_response=None, confidence=0.8,
     action_type="investigate", cycle_id=None,
-    created_at="2026-06-18T00:00:00+00:00", resolved_at="2026-06-18T01:00:00+00:00",
+    created_at=None, resolved_at=None,
 ):
+    created_at = created_at or _recent(hours=2)
+    resolved_at = resolved_at or _recent(hours=1)
     await db.execute(
         "INSERT INTO ego_proposals "
         "(id, action_type, content, status, confidence, user_response, "
@@ -49,8 +61,9 @@ async def _add_proposal(
 
 async def _add_outreach(
     db, *, oid, engagement_outcome, user_response=None, category="notification",
-    prediction_error=None, delivered_at="2026-06-18T00:00:00+00:00",
+    prediction_error=None, delivered_at=None,
 ):
+    delivered_at = delivered_at or _recent(hours=1)
     await db.execute(
         "INSERT INTO outreach_history "
         "(id, signal_type, topic, category, salience_score, channel, "
@@ -58,7 +71,7 @@ async def _add_outreach(
         " delivered_at, created_at) "
         "VALUES (?, 'sig', 'topic', ?, 0.5, 'telegram', 'msg', ?, ?, ?, ?, ?)",
         (oid, category, engagement_outcome, user_response, prediction_error,
-         delivered_at, "2026-06-18T00:00:00+00:00"),
+         delivered_at, _recent(hours=2)),
     )
     await db.commit()
 


### PR DESCRIPTION
Two reliability fixes surfaced by tonight's deploy verification.

## 1. update.sh ran stale code after a "successful" deploy (`scripts/update.sh`)

- update.sh stops genesis-server, merges new code, applies DB migrations, then "restarts". The systemd unit has `Restart=on-failure` + `RestartUSec=10s`. The stop falls back to `kill -TERM` when systemctl is flaky, which systemd treats as a **failure** → it **auto-restarted the server ~1s before the merge completed**, so the process imported pre-merge Python and cached it.
- Migrations still applied (the runner scans migration **files on disk**, not loaded modules) — masking the problem.
- The final restart used `systemctl start` — a **no-op on the already-running process** — so the new code never loaded. Net: **new code on disk + new DB schema, but old code in the live process.** Confirmed empirically: a cron added in new code never registered while an older sibling cron fired on time.

**Fix:** `_start_genesis_server` uses `systemctl restart` (not `start`) so the final step always reloads current on-disk code; new `_ensure_server_down()` does an explicit `systemctl stop` (disarms the on-failure restart timer) + confirms the process is gone before merge/migrations, aborting the update if it can't. Wired into the main path and `_do_rollback`.

## 2. Harvest test was a date-bomb blocking all CI (`tests/feedback/test_harvest.py`)

`_add_proposal` hardcoded `resolved_at=2026-06-18T01:00`, which falls outside `run(window_days=2)` once wall-clock passes 2026-06-20 01:00 UTC — `test_incremental_run_is_idempotent_on_unique_key` started failing (`assert 0==1`) on main, **blocking every PR's CI**. The harvester is correct (it windows properly); the test was time-brittle. Defaulted the helper timestamps relative to `now` so the suite is time-independent (tests asserting window *exclusion* still override with explicit old dates).

## Verification
- `bash -n` + `shellcheck -S warning` clean on update.sh; `_ensure_server_down` logic-tested with mocked systemctl/pgrep (returns 0 when down, aborts when stuck up). The `restart` mechanism was confirmed live tonight (manual restart correctly reloaded the deployed commit).
- `tests/feedback/test_harvest.py`: 23 passed, ruff clean.
- Reviewed by genesis-architect (design) + code-reviewer (implementation); findings applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)