### PR TITLE
fix(routing): preserve DLQ 'all' sentinel on reload + cost visibility for aggregator models (WS-4 PR-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   didn't, leaving new code on disk and old code in memory. The updater now forces a
   true restart at the end and makes sure the server stays down during the upgrade, so
   an update always activates the version it just installed.
+- **Spend on GLM, MiniMax and other aggregator models is now reported accurately** — these
+  providers' usage was silently recorded as $0 because their model names aren't in the cost
+  library Genesis relies on, hiding real spend in cost reports. Genesis now falls back to each
+  model's configured price when the library can't price it, so spend reflects what you're
+  actually using. (Visibility only — it never throttles or blocks calls.)
+
+- **Queued retries survive a routing-config change** — every time the provider routing config
+  was reloaded (e.g. toggling a provider in the dashboard), Genesis was expiring *all* of the
+  queued "retry the whole chain" requests before its scheduled retry job could replay them.
+  Those items now persist across a config reload and get retried as intended.
 
 - **Recovered providers stop alarming once they come back** — when a model provider's
   circuit breaker reopens after an outage, Genesis now clears that provider's "failing"

--- a/src/genesis/db/crud/dead_letter.py
+++ b/src/genesis/db/crud/dead_letter.py
@@ -99,9 +99,16 @@ async def expire_orphans_by_provider(
     scan to proactively clean up items targeting providers that were
     removed from the routing config.
 
+    The reserved ``'all'`` sentinel is ALWAYS preserved: the router enqueues
+    chain-exhausted items with ``target_provider='all'`` to mean "retry the
+    WHOLE chain", not a single provider. ``'all'`` is never a real provider
+    name, so excluding it here stops every config reload from expiring 100% of
+    chain-exhausted items before the redispatch job can replay them.
+
     Args:
         active_providers: provider names that ARE still in the active
-            config. An empty list means every pending item is an orphan.
+            config. An empty list means every real-provider pending item is an
+            orphan (the ``'all'`` sentinel is still preserved).
 
     Returns:
         List of ``(id, target_provider)`` tuples that were expired.
@@ -110,14 +117,15 @@ async def expire_orphans_by_provider(
         placeholders = ",".join("?" * len(active_providers))
         sql = (
             "UPDATE dead_letter SET status = 'expired' "
-            f"WHERE status = 'pending' AND target_provider NOT IN ({placeholders}) "
+            "WHERE status = 'pending' AND target_provider != 'all' "
+            f"AND target_provider NOT IN ({placeholders}) "
             "RETURNING id, target_provider"
         )
         params: list = list(active_providers)
     else:
         sql = (
             "UPDATE dead_letter SET status = 'expired' "
-            "WHERE status = 'pending' "
+            "WHERE status = 'pending' AND target_provider != 'all' "
             "RETURNING id, target_provider"
         )
         params = []

--- a/src/genesis/routing/litellm_delegate.py
+++ b/src/genesis/routing/litellm_delegate.py
@@ -128,6 +128,35 @@ for _model, _cost in _CUSTOM_MODEL_COSTS.items():
         litellm.model_cost[_model] = _cost
 
 
+# Module-level cache for the cost-fallback profile registry: loaded ONCE and
+# shared across all delegate constructions. The production delegate is built once
+# at startup, but the standalone/MCP, eval, and test paths build many — don't
+# re-read the YAML (or re-warn) each time. Injected registries (tests) bypass it.
+_PROFILE_REGISTRY = None
+_PROFILE_REGISTRY_LOADED = False
+
+
+def _load_profile_registry():
+    """Load (once, cached) the model-profile registry for the cost-visibility
+    fallback. Defensive: a missing/unreadable file caches None (cost stays
+    "unknown"), never a delegate-construction failure."""
+    global _PROFILE_REGISTRY, _PROFILE_REGISTRY_LOADED
+    if _PROFILE_REGISTRY_LOADED:
+        return _PROFILE_REGISTRY
+    try:
+        from genesis.env import repo_root
+        from genesis.routing.model_profiles import ModelProfileRegistry
+
+        registry = ModelProfileRegistry(repo_root() / "config" / "model_profiles.yaml")
+        registry.load()
+        _PROFILE_REGISTRY = registry
+    except Exception:
+        logger.warning("Could not load model_profiles for cost fallback", exc_info=True)
+        _PROFILE_REGISTRY = None
+    _PROFILE_REGISTRY_LOADED = True
+    return _PROFILE_REGISTRY
+
+
 class LiteLLMDelegate:
     """CallDelegate implementation using litellm.acompletion().
 
@@ -135,8 +164,34 @@ class LiteLLMDelegate:
     at startup via python-dotenv.
     """
 
-    def __init__(self, config: RoutingConfig) -> None:
+    def __init__(self, config: RoutingConfig, *, profile_registry: object = None) -> None:
         self._config = config
+        # Model-profile registry for the cost fallback (ROUTE-03 / ROUT-03):
+        # when litellm.completion_cost can't price an aggregator model (the
+        # OpenAI-compat-prefixed glm/minimax/qwen strings raise "model isn't
+        # mapped yet"), compute cost from the provider's profile cost_per_mtok
+        # instead of silently recording $0. Injected in tests; self-loaded from
+        # config/model_profiles.yaml in production. Visibility ONLY — never
+        # gates routing or budget ("cost tracking is observability, not control").
+        self._profiles = (
+            profile_registry if profile_registry is not None else _load_profile_registry()
+        )
+
+    def _cost_from_profile(self, cfg, usage) -> tuple[float, bool]:
+        """Fallback cost from model_profiles cost_per_mtok when litellm can't
+        price the model. Returns ``(cost_usd, cost_known)``."""
+        if not getattr(cfg, "profile", None) or usage is None or self._profiles is None:
+            return 0.0, False
+        profile = self._profiles.get(cfg.profile)
+        if profile is None:
+            return 0.0, False
+        in_tok = getattr(usage, "prompt_tokens", 0) or 0
+        out_tok = getattr(usage, "completion_tokens", 0) or 0
+        cost = (
+            (in_tok / 1_000_000) * profile.cost_per_mtok_in
+            + (out_tok / 1_000_000) * profile.cost_per_mtok_out
+        )
+        return cost, True
 
     async def call(
         self, provider: str, model_id: str, messages: list[dict], **kwargs
@@ -194,9 +249,16 @@ class LiteLLMDelegate:
                         completion_response=response, model=model_string,
                     )
                 except Exception:
-                    cost = 0.0
-                    cost_known = False
-                    if _should_log_failure(provider):
+                    # litellm can't price this model (aggregator strings not in
+                    # its DB). Fall back to the provider's model_profiles cost so
+                    # spend stays visible, not silently $0 (ROUTE-03 / ROUT-03).
+                    cost, cost_known = self._cost_from_profile(cfg, usage)
+                    if cost_known:
+                        logger.debug(
+                            "litellm couldn't price %s/%s; used model_profiles "
+                            "fallback: $%.6f", provider, model_string, cost,
+                        )
+                    elif _should_log_failure(provider):
                         logger.warning(
                             "Cost calculation failed for %s/%s — recording as $0.00",
                             provider, model_string, exc_info=True,

--- a/tests/test_routing/test_litellm_delegate.py
+++ b/tests/test_routing/test_litellm_delegate.py
@@ -388,9 +388,80 @@ async def test_call_generic_error():
 
 
 async def test_call_cost_extraction_fallback():
-    """If completion_cost raises on a paid provider, cost_usd should be 0.0 and cost_known False."""
+    """Graceful-degrade path: when completion_cost raises on a paid provider that
+    has NO model_profiles entry (cfg.profile is unset here), cost_usd stays 0.0
+    and cost_known False. The profile-PRESENT path is covered by
+    test_call_cost_profile_fallback_when_litellm_unknown."""
     config = _config(is_free=False)
     delegate = LiteLLMDelegate(config)
+    mock_resp = _mock_response()
+
+    with patch("genesis.routing.litellm_delegate.litellm") as mock_litellm:
+        mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+        mock_litellm.completion_cost.side_effect = Exception("unknown model")
+
+        result = await delegate.call(
+            "test-provider", "llama-3.3-70b-versatile",
+            [{"role": "user", "content": "Hi"}],
+        )
+
+    assert result.success is True
+    assert result.cost_usd == 0.0
+    assert result.cost_known is False
+
+
+async def test_call_cost_profile_fallback_when_litellm_unknown():
+    """When litellm.completion_cost raises (aggregator model not in litellm's DB)
+    but the provider has a model_profiles entry, cost is computed from the
+    profile's cost_per_mtok and cost_known is True — closing the blind-spend gap
+    (ROUTE-03 / ROUT-03). Visibility only; never gates routing or budget.
+    """
+    from types import SimpleNamespace
+
+    class _FakeRegistry:
+        def get(self, name):
+            if name == "glm-5.1":
+                return SimpleNamespace(cost_per_mtok_in=0.80, cost_per_mtok_out=2.56)
+            return None
+
+    config = RoutingConfig(
+        providers={
+            "glm51": ProviderConfig(
+                name="glm51", provider_type="zenmux", model_id="z-ai/glm-5.1",
+                is_free=False, rpm_limit=None, open_duration_s=120, profile="glm-5.1",
+            ),
+        },
+        call_sites={},
+        retry_profiles={},
+    )
+    delegate = LiteLLMDelegate(config, profile_registry=_FakeRegistry())
+    # 1M in + 1M out → cost = 1*0.80 + 1*2.56 = 3.36 (clean arithmetic).
+    mock_resp = _mock_response(prompt_tokens=1_000_000, completion_tokens=1_000_000)
+
+    with patch("genesis.routing.litellm_delegate.litellm") as mock_litellm:
+        mock_litellm.acompletion = AsyncMock(return_value=mock_resp)
+        mock_litellm.completion_cost.side_effect = Exception("This model isn't mapped yet")
+
+        result = await delegate.call(
+            "glm51", "z-ai/glm-5.1", [{"role": "user", "content": "Hi"}],
+        )
+
+    assert result.success is True
+    assert result.cost_known is True
+    assert result.cost_usd == pytest.approx(3.36)
+
+
+async def test_call_cost_profile_fallback_missing_profile_stays_unknown():
+    """Paid provider whose profile is absent from the registry → graceful
+    degrade: cost 0.0, cost_known False (logged, not silent)."""
+    from types import SimpleNamespace  # noqa: F401
+
+    class _EmptyRegistry:
+        def get(self, name):
+            return None
+
+    config = _config(is_free=False)
+    delegate = LiteLLMDelegate(config, profile_registry=_EmptyRegistry())
     mock_resp = _mock_response()
 
     with patch("genesis.routing.litellm_delegate.litellm") as mock_litellm:

--- a/tests/test_routing/test_router_reload.py
+++ b/tests/test_routing/test_router_reload.py
@@ -277,3 +277,103 @@ async def test_scan_dlq_orphans_no_dlq_wired_returns_zero():
     )
 
     assert await router.scan_dlq_orphans_after_reload() == 0
+
+
+@pytest.mark.asyncio
+async def test_scan_dlq_orphans_preserves_all_sentinel():
+    """Chain-exhausted items enqueue with target_provider='all' (router.py) — a
+    SENTINEL meaning 'retry the whole chain', NOT a removed provider. The orphan
+    scan must NOT expire them on config reload.
+
+    Regression (routing-dlq-orphan-nukes-all): 'all' is never in the active
+    provider set, so the NOT IN filter expired 100% of chain-exhausted items on
+    EVERY config reload — before the 6-hourly redispatch job could replay them.
+    """
+    import aiosqlite
+
+    from genesis.db.schema import create_all_tables
+    from genesis.routing.dead_letter import DeadLetterQueue
+    from genesis.routing.router import Router
+
+    async with aiosqlite.connect(":memory:") as db:
+        db.row_factory = aiosqlite.Row
+        await create_all_tables(db)
+
+        dlq = DeadLetterQueue(db)
+        # Chain-exhausted sentinel item — must SURVIVE reload.
+        all_id = await dlq.enqueue(
+            operation_type="chain_exhausted:site_1",
+            payload={"call_site_id": "site_1", "messages": []},
+            target_provider="all",
+            failure_reason="All providers exhausted",
+        )
+        # A genuine orphan for a provider about to be dropped — must expire.
+        orphan_id = await dlq.enqueue(
+            operation_type="route_call",
+            payload={"call_site_id": "site_1", "messages": []},
+            target_provider="prov_b",
+            failure_reason="provider down",
+        )
+
+        old_config = _make_config()
+        breakers = CircuitBreakerRegistry(old_config.providers)
+        router = Router(
+            config=old_config,
+            breakers=breakers,
+            cost_tracker=MagicMock(),
+            degradation=MagicMock(),
+            delegate=AsyncMock(),
+            dead_letter=dlq,
+        )
+
+        # Reload dropping prov_b (prov_a only).
+        router.reload_config(_make_config(providers={
+            "prov_a": ProviderConfig(
+                name="prov_a", provider_type="test", model_id="m1",
+                is_free=True, rpm_limit=None, open_duration_s=60,
+            ),
+        }))
+
+        count = await router.scan_dlq_orphans_after_reload()
+
+        from genesis.db.crud import dead_letter as dl_crud
+        pending_ids = {p["id"] for p in await dl_crud.query_pending(db)}
+        assert all_id in pending_ids, "the 'all' sentinel item must NOT be expired on reload"
+        assert orphan_id not in pending_ids, "the dropped-provider orphan should expire"
+        assert count == 1, "only the genuine provider-removed orphan should expire"
+
+
+@pytest.mark.asyncio
+async def test_expire_orphans_preserves_all_when_active_set_empty():
+    """The empty-active-set branch (no providers in config) must STILL preserve
+    the 'all' sentinel — only real-provider orphans expire."""
+    import aiosqlite
+
+    from genesis.db.crud import dead_letter as dl_crud
+    from genesis.db.schema import create_all_tables
+    from genesis.routing.dead_letter import DeadLetterQueue
+
+    async with aiosqlite.connect(":memory:") as db:
+        db.row_factory = aiosqlite.Row
+        await create_all_tables(db)
+
+        dlq = DeadLetterQueue(db)
+        all_id = await dlq.enqueue(
+            operation_type="chain_exhausted:site_1",
+            payload={"call_site_id": "site_1", "messages": []},
+            target_provider="all",
+            failure_reason="exhausted",
+        )
+        await dlq.enqueue(
+            operation_type="route_call",
+            payload={"call_site_id": "site_1", "messages": []},
+            target_provider="prov_x",
+            failure_reason="down",
+        )
+
+        expired = await dl_crud.expire_orphans_by_provider(db, active_providers=[])
+        expired_targets = {t for _, t in expired}
+        assert "all" not in expired_targets
+        assert "prov_x" in expired_targets
+        pending_ids = {p["id"] for p in await dl_crud.query_pending(db)}
+        assert all_id in pending_ids


### PR DESCRIPTION
## WS-4 Routing resilience — PR-A of 3 (audit D3). **HELD for merge.**

Two independent, low-risk routing correctness fixes — first of the WS-4 series (PR-A: DLQ + cost · PR-B: error classes + breaker-trip · PR-C: half-open heal + aggregate deadline).

### 1. DLQ `'all'` sentinel preserved on config reload (`routing-dlq-orphan-nukes-all`)
The router enqueues chain-exhausted items with `target_provider='all'` (a sentinel meaning "retry the whole chain"). The orphan sweep that runs on every routing-config reload used `target_provider NOT IN (active_providers)`, which treated `'all'` as a removed provider and **expired 100% of chain-exhausted items on every reload** — before the 6-hourly redispatch job could replay them. Fix: exclude the `'all'` sentinel in both SQL branches of `expire_orphans_by_provider`.

### 2. Cost visibility for aggregator models (`ROUTE-03` / `ROUT-03`)
Several paid providers (GLM/MiniMax/Qwen-direct via OpenAI-compatible endpoints) build model strings litellm can't price (`completion_cost` raises "model isn't mapped yet"), so their spend was silently recorded as **\$0 / cost_known=False**. Fix: when litellm can't price a model, the delegate falls back to the provider's `model_profiles` `cost_per_mtok`. **Observability only — never gates routing or budget.**

### Verification
- TDD: 4 new tests + full `test_routing/` suite (272 passed); ruff clean.
- Code review (code-reviewer): 3 findings addressed (fallback-success DEBUG log, module-cached registry load, test docstring clarity).
- E2E vs the **real** config + `model_profiles`: a real paid provider priced from its profile when litellm can't price it; the `'all'` sentinel survives a scan over the real 28-provider active set while a removed provider's item expires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)