### PR TITLE
fix(observability): honest cost labels + fill 8 blind call sites in neural monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The neural monitor labels every cognitive call site honestly.** Eight call sites
+  that previously showed blank (the eval judge, voice conversation, session observer,
+  task pre-mortem, intelligence intake, both resume-review passes, and the executor's
+  failure-exit gate) now display their purpose, category, and cost. Sites that actually
+  run on the Claude Code subscription (the ego cycle and the deep/strategic/weekly/quality
+  reflections) now read "CC background" with their CC model shown in the chain, instead of
+  being mislabeled as a paid API cost.
+
 - **Recovered providers stop alarming once they come back** — when a model provider's
   circuit breaker reopens after an outage, Genesis now clears that provider's "failing"
   alert instead of leaving it lingering for days until it expired. Per-session conversation

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -8,8 +8,12 @@ Fields:
   category:       Subsystem grouping for neural monitor ring/color
   frequency:      How often this fires
   cost_policy:    Auto-derived for most; manual for CC-dispatched sites
-  dispatch:       "cc" (CC background only), "dual" (API-first, CC fallback)
-  cc_model:       Which CC model (Haiku/Sonnet/Opus) for dispatch=cc/dual
+  dispatch:       "api" (API providers only), "cli" (CC subprocess only),
+                  "dual" (API-first, CC fallback). OMIT for plain API/default
+                  sites — cost auto-derives from the chain. Legacy "cc" is a
+                  RETIRED alias, normalized to "cli" at YAML parse
+                  (routing.config._normalize_dispatch); author "cli" here.
+  cc_model:       Which CC model (Haiku/Sonnet/Opus) for dispatch=cli/dual
   wired:          False if config exists but no code invokes this call site
   model_tier:     What class of model this needs (embedding/slm/mid/frontier/cc)
   status_reason:  Machine-readable status (WIRED, WIRED_DIFFERENT_MECHANISM,
@@ -154,7 +158,7 @@ _CALL_SITE_META: dict[str, dict] = {
         "category": "reflection",
         "frequency": "Weekly + high urgency",
         "cost_policy": "CC background (Sonnet)",
-        "dispatch": "cc",
+        "dispatch": "cli",
         "cc_model": "Sonnet",
         "model_tier": "cc",
     },
@@ -163,7 +167,7 @@ _CALL_SITE_META: dict[str, dict] = {
         "category": "reflection",
         "frequency": "4-8/month",
         "cost_policy": "CC background (Opus)",
-        "dispatch": "cc",
+        "dispatch": "cli",
         "cc_model": "Opus",
         "model_tier": "cc",
     },
@@ -200,12 +204,12 @@ _CALL_SITE_META: dict[str, dict] = {
         "model_tier": "slm",
     },
     "14_weekly_self_assessment": {
-        "description": "Honest self-evaluation of Genesis's recent performance. Dispatched via CC background session (Sonnet).",
+        "description": "Honest self-evaluation of Genesis's recent performance. Dispatched via CC background session (Opus).",
         "category": "reasoning",
         "frequency": "Weekly",
-        "cost_policy": "CC background (Sonnet)",
-        "dispatch": "cc",
-        "cc_model": "Sonnet",
+        "cost_policy": "CC background (Opus)",
+        "dispatch": "cli",
+        "cc_model": "Opus",
         "model_tier": "cc",
     },
     "16_quality_calibration": {
@@ -213,7 +217,7 @@ _CALL_SITE_META: dict[str, dict] = {
         "category": "calibration",
         "frequency": "Weekly",
         "cost_policy": "CC background (Sonnet)",
-        "dispatch": "cc",
+        "dispatch": "cli",
         "cc_model": "Sonnet",
         "model_tier": "cc",
     },
@@ -320,14 +324,63 @@ _CALL_SITE_META: dict[str, dict] = {
         "model_tier": "slm",
         "status_reason": "WIRED",
     },
+    "judge": {
+        "description": "LLM-as-judge scorer for the J9 evaluation harness — scores rubric dimensions against model outputs. Eval-only (eval/j9_batch.py:386, eval/scorers.py:334); listed in routing/degradation._L2_SKIP so it sheds under REDUCED degradation. API dispatch, paid chain (DeepSeek V4 Pro primary).",
+        "category": "assessment",
+        "frequency": "Per J9 eval scoring",
+        "model_tier": "frontier",
+    },
+    "voice_conversation": {
+        "description": "Realtime voice S2S conversational-turn generation. Free API chain (Groq/Gemini/Mistral) with user-facing retry profile (latency-sensitive). Caller: channels/voice/handler.py.",
+        "category": "reasoning",
+        "frequency": "Per voice turn",
+        "model_tier": "slm",
+    },
+    "21_session_observer": {
+        "description": "Extracts memory notes from CC-session transcript observations (opportunistic context capture, batched). Free dual chain. Caller: memory/session_observer.py:313. NOTE: the '21' prefix is unrelated to 21_embeddings / 21b_query_embedding (embedding paths) — different subsystem.",
+        "category": "processing",
+        "frequency": "Per CC-session batch",
+        "model_tier": "slm",
+        "see_also": ["21_embeddings", "21b_query_embedding"],
+    },
+    "44_task_premortem": {
+        "description": "Pre-mortem failure analysis before the executor commits to a task: blocks execution below confidence 50, injects mitigations into plan context below 70. Paid-primary dual chain (DeepSeek V4 Pro + free fallback). Caller: autonomy/executor/review.py:101 (TaskReviewer).",
+        "category": "assessment",
+        "frequency": "Per task (pre-execution)",
+        "model_tier": "frontier",
+    },
+    "45_intelligence_intake": {
+        "description": "Intelligence intake pipeline — atomize / score / route surplus insights, recon findings, and web-search results into knowledge / observation / discard. Free-only (never pays). Caller: surplus/intake.py:324.",
+        "category": "processing",
+        "frequency": "Per intake finding",
+        "model_tier": "slm",
+    },
+    "41_resume_review_pass1": {
+        "description": "Resume review pass 1 — structural analysis (formatting, clarity, impact quantification, action verbs, ATS compatibility, JD keyword alignment). Free dual chain. Caller: knowledge/applications/resume_review.py:21.",
+        "category": "assessment",
+        "frequency": "Per resume review",
+        "model_tier": "slm",
+        "see_also": ["42_resume_review_pass2"],
+    },
+    "42_resume_review_pass2": {
+        "description": "Resume review pass 2 — knowledge-augmented critique: queries the knowledge base for professional/domain context, cross-references the resume, surfaces gaps and missed opportunities. Free dual chain. Caller: knowledge/applications/resume_review.py:22.",
+        "category": "assessment",
+        "frequency": "Per resume review",
+        "model_tier": "slm",
+        "see_also": ["41_resume_review_pass1"],
+    },
+    "failure_exit_gate": {
+        "description": "Executor failure-handling gate: when a step exhausts retries, judges whether the blockers are genuine (exit) or retryable (continue); defaults to accept on call failure to avoid infinite loops. Paid-primary dual chain (Sonnet primary, Qwen 3.6+ fallback via OpenRouter). Caller: autonomy/executor/engine.py:785.",
+        "category": "assessment",
+        "frequency": "Per executor step failure",
+        "model_tier": "frontier",
+    },
     # ── PARTIALLY WIRED: code exists, conditions haven't triggered yet ─
     "27_pre_execution_assessment": {
-        "description": "Sanity-checks proposed task execution plans before committing resources. Opus via CC invoker, route_call fallback.",
+        "description": "Pre-execution plan sanity-check (executor TaskReviewer.review_plan + autonomy/decomposer.py). The PRIMARY path is the CC invoker (Opus) directly; THIS call site is the API-dual fallback (GLM 5.1 / MiniMax M2.5 / DeepSeek V4 Flash) routed via route_call when the CC invoker is unavailable. Cost auto-derives from that chain — it is NOT a CC-subscription site (the prior dispatch=cli/cc_model=Opus meta was stale and mislabeled it).",
         "category": "reasoning",
-        "frequency": "Per task",
-        "model_tier": "cc",
-        "dispatch": "cli",
-        "cc_model": "Opus",
+        "frequency": "Per task (pre-execution)",
+        "model_tier": "frontier",
         "wired": True,
     },
     "33_skill_refiner": {

--- a/src/genesis/observability/snapshots/call_sites.py
+++ b/src/genesis/observability/snapshots/call_sites.py
@@ -22,6 +22,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Dispatch modes that route (at least partly) through a Claude Code subprocess
+# rather than purely paid/free APIs: "cli" (CC-only), "dual" (API-first, CC
+# fallback), plus the retired "cc" alias (normalized to "cli" at YAML parse —
+# kept here defensively so a stray legacy value can't silently mislabel cost).
+# For these, the rendered cost_policy is the manual CC-subscription label (not an
+# auto-derived per-provider cost), AND the neural monitor inserts a CC/{model}
+# entry into the chain. See observability/_call_site_meta.py.
+_CC_DISPATCH = frozenset({"cc", "cli", "dual"})
+
 
 def _derive_cost_policy(
     site_cfg: CallSiteConfig,
@@ -175,9 +184,11 @@ async def call_sites(
         meta = _CALL_SITE_META.get(site_id)
         if meta:
             site_data.update(meta)
-        # Derive costPolicy from chain config (CC-dispatched sites keep manual policy)
+        # Derive costPolicy from chain config. CC-dispatched sites (cli/dual,
+        # + retired cc alias) keep their manual CC-subscription label; pure API
+        # and default sites auto-derive from the provider chain.
         dispatch = meta.get("dispatch") if meta else None
-        if dispatch not in ("cc", "dual"):
+        if dispatch not in _CC_DISPATCH:
             site_data["cost_policy"] = _derive_cost_policy(site_cfg, routing_config)
         result[site_id] = site_data
 
@@ -269,8 +280,8 @@ async def call_sites(
                 else:
                     entry["probe_status"] = "reachable"
 
-        # 2. Insert CC entry for dual/cc dispatch sites
-        if dispatch in ("dual", "cc"):
+        # 2. Insert CC entry for CC-dispatch sites (cli/dual, + retired cc alias)
+        if dispatch in _CC_DISPATCH:
             cc_model = yaml_ov.get("cc_model") or (meta.get("cc_model", "?") if meta else "?")
             cc_entry: dict = {
                 "provider": f"CC/{cc_model}",

--- a/tests/test_observability/test_call_site_metadata.py
+++ b/tests/test_observability/test_call_site_metadata.py
@@ -1,0 +1,213 @@
+"""R2 — call-site metadata hygiene + dispatch-gate behavior.
+
+Locks three things the 2026-06-19 hygiene pass fixed:
+  * the 8 previously metadata-blind sites now carry accurate metadata and
+    auto-derive their cost (no frozen/wrong manual label);
+  * meta `dispatch`/`cc_model` no longer drift from authoritative YAML
+    (the broadened drift guard would have caught the 27 mislabel);
+  * both dispatch-consuming gates in call_sites.py — cost_policy retention
+    (line 180) and CC chain-entry insertion (line 273) — treat cli/dual as
+    CC-dispatch, via the shared `_CC_DISPATCH` set.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+import genesis.routing.config as routing_config_mod
+from genesis.observability._call_site_meta import _CALL_SITE_META
+from genesis.observability.snapshots.call_sites import _CC_DISPATCH, call_sites
+from genesis.routing.types import (
+    CallSiteConfig,
+    ProviderConfig,
+    ProviderState,
+    RetryPolicy,
+    RoutingConfig,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_YAML_PATH = _REPO_ROOT / "config" / "model_routing.yaml"
+
+
+def _live_config() -> RoutingConfig:
+    return routing_config_mod.load_config_from_string(_YAML_PATH.read_text())
+
+
+# The 8 sites that were absent from _CALL_SITE_META before this pass.
+_NEWLY_DOCUMENTED = [
+    "judge",
+    "voice_conversation",
+    "21_session_observer",
+    "44_task_premortem",
+    "45_intelligence_intake",
+    "41_resume_review_pass1",
+    "42_resume_review_pass2",
+    "failure_exit_gate",
+]
+
+
+# ── A: the 8 formerly-blind sites ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize("site_id", _NEWLY_DOCUMENTED)
+def test_newly_documented_sites_have_core_metadata(site_id: str):
+    meta = _CALL_SITE_META.get(site_id)
+    assert meta is not None, f"{site_id} is still blind in _CALL_SITE_META"
+    assert meta.get("description"), f"{site_id} missing description"
+    assert meta.get("category"), f"{site_id} missing category"
+    assert meta.get("model_tier"), f"{site_id} missing model_tier"
+
+
+@pytest.mark.parametrize("site_id", _NEWLY_DOCUMENTED)
+def test_newly_documented_sites_auto_derive_cost(site_id: str):
+    # These are api/dual sites, not CC-subscription. They must NOT carry a manual
+    # dispatch/cost_policy — that would freeze a (possibly stale) cost label and
+    # bypass auto-derivation. They also must not be wired=False (all are live).
+    meta = _CALL_SITE_META[site_id]
+    assert "dispatch" not in meta, f"{site_id} should omit dispatch (auto-derive)"
+    assert "cost_policy" not in meta, f"{site_id} should omit manual cost_policy"
+    assert meta.get("wired") is not False, f"{site_id} is live; must not be wired=False"
+
+
+# ── B: drift guard (would have caught the 27_pre_execution_assessment mislabel) ─
+
+
+def test_meta_dispatch_matches_authoritative_yaml():
+    """Every meta entry that sets `dispatch` must agree with the normalized YAML
+    dispatch (YAML is what routing actually uses). This catches a meta entry that
+    claims a CC mode for a site that really routes via API (the 27 bug)."""
+    cfg = _live_config()
+    mismatches = []
+    for sid, meta in _CALL_SITE_META.items():
+        md = meta.get("dispatch")
+        if md is None:
+            continue
+        cs = cfg.call_sites.get(sid)
+        assert cs is not None, f"{sid} sets meta dispatch={md!r} but is not a YAML call site"
+        if md != cs.dispatch:
+            mismatches.append((sid, md, cs.dispatch))
+    assert not mismatches, f"meta/YAML dispatch drift: {mismatches}"
+
+
+def test_meta_cc_model_matches_yaml():
+    raw = yaml.safe_load(_YAML_PATH.read_text())["call_sites"]
+    mismatches = []
+    for sid, meta in _CALL_SITE_META.items():
+        mcc = meta.get("cc_model")
+        rcc = raw.get(sid, {}).get("cc_model")
+        if mcc is not None and rcc is not None and mcc != rcc:
+            mismatches.append((sid, mcc, rcc))
+    assert not mismatches, f"meta/YAML cc_model drift: {mismatches}"
+
+
+def test_meta_dispatch_uses_canonical_vocab_only():
+    """No meta entry may use the retired `cc` alias or any non-canonical mode."""
+    bad = {
+        k: v["dispatch"]
+        for k, v in _CALL_SITE_META.items()
+        if v.get("dispatch") and v["dispatch"] not in routing_config_mod._VALID_DISPATCH_MODES
+    }
+    assert not bad, f"non-canonical/retired dispatch values in meta: {bad}"
+
+
+def test_27_pre_execution_assessment_not_mislabeled_as_cc():
+    """Regression lock: 27 is a dual API site (real chain), not a CC/Opus site."""
+    meta = _CALL_SITE_META["27_pre_execution_assessment"]
+    assert "dispatch" not in meta
+    assert "cc_model" not in meta
+
+
+def test_cc_dispatch_set_contents():
+    """Both gates key off this RUNTIME set; lock its contents (cli + dual + the
+    retired cc alias, kept defensively).
+
+    NOTE the deliberate asymmetry with ``test_meta_dispatch_uses_canonical_vocab_only``:
+    ``"cc"`` belongs in this runtime set (so a stray legacy value can't silently
+    mislabel cost) but is NOT a valid value to AUTHOR in ``_CALL_SITE_META`` — the
+    canonical-vocab test enforces that meta entries use only {api, cli, dual}.
+    These are not contradictory: one guards runtime tolerance, the other guards
+    hand-authored hygiene."""
+    assert sorted(_CC_DISPATCH) == ["cc", "cli", "dual"]
+
+
+# ── C/E: the two dispatch gates in call_sites() ─────────────────────────────
+
+
+def _provider(name: str, *, free: bool) -> ProviderConfig:
+    return ProviderConfig(
+        name=name, provider_type="test", model_id="m",
+        is_free=free, rpm_limit=None, open_duration_s=120,
+    )
+
+
+def _config(call_sites_map: dict, providers: dict) -> RoutingConfig:
+    return RoutingConfig(
+        providers=providers,
+        call_sites=call_sites_map,
+        retry_profiles={"default": RetryPolicy()},
+    )
+
+
+def _registry() -> MagicMock:
+    def _breaker(_name: str) -> MagicMock:
+        cb = MagicMock()
+        cb.state = ProviderState.CLOSED
+        cb.consecutive_failures = 0
+        cb.trip_count = 0
+        return cb
+
+    reg = MagicMock()
+    reg.get.side_effect = _breaker
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_cli_site_retains_manual_cost_policy():
+    """cli sites keep their manual 'CC background' label instead of auto-deriving
+    a misleading 'Paid primary' (7_ego_cycle mis-rendered before this fix)."""
+    providers = {
+        "openrouter-sonnet": _provider("openrouter-sonnet", free=False),
+        "openrouter-opus": _provider("openrouter-opus", free=False),
+    }
+    cfg = _config(
+        {
+            "5_deep_reflection": CallSiteConfig(id="5_deep_reflection", chain=["openrouter-sonnet"]),
+            "7_ego_cycle": CallSiteConfig(id="7_ego_cycle", chain=["openrouter-opus"]),
+        },
+        providers,
+    )
+    result = await call_sites(db=None, routing_config=cfg, breakers=_registry())
+    assert result["5_deep_reflection"]["cost_policy"] == "CC background (Sonnet)"
+    assert result["7_ego_cycle"]["cost_policy"] == "CC background (Opus)"
+    assert "Paid primary" not in result["7_ego_cycle"]["cost_policy"]
+
+
+@pytest.mark.asyncio
+async def test_cli_site_shows_cc_chain_entry():
+    """A cli site renders a CC/{model} entry in chain_health (line-273 gate)."""
+    providers = {"openrouter-sonnet": _provider("openrouter-sonnet", free=False)}
+    cfg = _config(
+        {"5_deep_reflection": CallSiteConfig(id="5_deep_reflection", chain=["openrouter-sonnet"])},
+        providers,
+    )
+    result = await call_sites(db=None, routing_config=cfg, breakers=_registry())
+    chain = result["5_deep_reflection"]["chain_health"]
+    assert any(entry.get("is_cc") for entry in chain), f"no CC entry in chain: {chain}"
+
+
+@pytest.mark.asyncio
+async def test_api_site_auto_derives_and_has_no_cc_entry():
+    """An api site (judge) auto-derives 'Paid primary' and gets no CC entry."""
+    providers = {"openrouter-deepseek-v4": _provider("openrouter-deepseek-v4", free=False)}
+    cfg = _config(
+        {"judge": CallSiteConfig(id="judge", chain=["openrouter-deepseek-v4"])},
+        providers,
+    )
+    result = await call_sites(db=None, routing_config=cfg, breakers=_registry())
+    assert result["judge"]["cost_policy"].startswith("Paid primary")
+    chain = result["judge"]["chain_health"]
+    assert not any(entry.get("is_cc") for entry in chain)


### PR DESCRIPTION
## What & why

The neural monitor's call-site registry (`_CALL_SITE_META`) had drifted from reality:
- **8 call sites rendered blank** (no description/category/cost) — the eval judge,
  voice conversation, session observer, task pre-mortem, intelligence intake, both
  resume-review passes, and the executor's failure-exit gate.
- **CC-subscription sites were mislabeled as paid API cost.** `7_ego_cycle` rendered
  "Paid primary (openrouter-opus)" instead of "CC background (Opus)" because the
  cost-policy gate only recognized the legacy `cc`/`dual` dispatch values, not `cli`.
- **`27_pre_execution_assessment` was mislabeled the *other* way** — its meta claimed
  `dispatch:cli` + `cc_model:Opus`, but it actually routes via a **dual API chain**
  (`glm51 / minimax-m25 / deepseek-v4-flash`). The metadata was stale.

This is **observability-only**. Routing is YAML-driven (`routing/config.py`); the
router never reads `_CALL_SITE_META`.

## Changes

- **`call_sites.py`:** introduce a shared `_CC_DISPATCH = {cc, cli, dual}` set and use it
  in the **two** dispatch-consuming gates — cost-policy retention and CC chain-entry
  insertion. Both now treat `cli` as CC-dispatch, fixing `7_ego_cycle`'s cost label and
  making the cli reflection sites (5/6/14/16/7) show their `CC/{model}` chain entry.
- **`_call_site_meta.py`:** populate the 8 blind sites with code-traced metadata (all
  auto-derive cost — none is a CC site); reconcile dispatch with authoritative YAML
  (5/6/14/16 `cc`→`cli`; `cc` is a retired alias normalized to `cli` at YAML parse);
  fix `14`'s cc_model `Sonnet`→`Opus`; **remove** `27`'s stale `dispatch`/`cc_model` so
  it auto-derives honestly; refresh the dispatch-vocab doc comment.
- **Tests:** `tests/test_observability/test_call_site_metadata.py` — metadata hygiene, a
  broadened drift guard (meta dispatch/cc_model must match YAML — this would have caught
  the `27` mislabel), and both gate behaviors.

## Verification

- ruff clean; **299 tests pass** across the observability suite and all three
  `_CALL_SITE_META` consumers (`call_sites.py`, `mcp/health/errors.py`,
  `dashboard/routes/routing.py`); new file = 24 tests.
- **E2E against real components** (real YAML config + real `CircuitBreakerRegistry` +
  real `call_sites()` snapshot): all 8 new sites render with accurate auto-derived cost;
  `5_deep`/`7_ego` render "CC background" + a `CC/{model}` chain entry; `27` renders
  "Paid primary (glm51)" with **no** false CC entry; `judge` renders "Paid primary
  (deepseek-v4)". Dashboard pixel-render deferred (the change is data-only; the frontend
  just displays these fields).
- Code-reviewed (Codex quota-exhausted → Claude code-reviewer): no regressions; both
  gates independently verified; one clarity note addressed.

## ⚠️ DO NOT MERGE YET

Holding merge intentionally: multiple concurrent sessions are working on closely related
observability/routing systems. Merge only after coordination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)