### PR TITLE
fix(routing): RATE_LIMITED + BAD_REQUEST error classes — fail fast, don't trip breakers (WS-4 PR-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   was reloaded (e.g. toggling a provider in the dashboard), Genesis was expiring *all* of the
   queued "retry the whole chain" requests before its scheduled retry job could replay them.
   Those items now persist across a config reload and get retried as intended.
+- **A rate-limited or over-budget request no longer knocks a working provider offline** —
+  when a provider replied "too many requests" (429) or rejected a single request as too large
+  or against policy (400/422), Genesis treated it like an outage: it retried the doomed request
+  several times and tripped that provider's circuit breaker, taking it out of rotation for
+  everything else for up to 30 minutes. Now those responses fail straight over to the next
+  provider without retrying or benching the one that's actually healthy — so you get faster
+  failover and far fewer false "provider down" blips.
 
 - **Recovered providers stop alarming once they come back** — when a model provider's
   circuit breaker reopens after an outage, Genesis now clears that provider's "failing"

--- a/src/genesis/routing/litellm_delegate.py
+++ b/src/genesis/routing/litellm_delegate.py
@@ -306,6 +306,19 @@ class LiteLLMDelegate:
             if _should_log_failure(provider):
                 logger.warning("Provider %s unavailable: %s", provider, e)
             return CallResult(success=False, error=str(e), status_code=503)
+        except litellm.BadRequestError as e:
+            # 400-family: context-window-exceeded, content-policy, malformed
+            # request. ContextWindowExceededError + ContentPolicyViolationError
+            # subclass BadRequestError, so this catches them too. Deterministic:
+            # the router classifies BAD_REQUEST, fails fast to the next provider,
+            # and does NOT trip the breaker (it's our payload, not the provider).
+            if _should_log_failure(provider):
+                logger.warning("Provider %s bad request: %s", provider, e)
+            return CallResult(success=False, error=str(e), status_code=400)
+        except litellm.UnprocessableEntityError as e:
+            if _should_log_failure(provider):
+                logger.warning("Provider %s unprocessable request: %s", provider, e)
+            return CallResult(success=False, error=str(e), status_code=422)
         except Exception as e:
             raw_status = getattr(e, "status_code", None)
             status = raw_status if raw_status is not None else 500

--- a/src/genesis/routing/retry.py
+++ b/src/genesis/routing/retry.py
@@ -6,7 +6,9 @@ import random
 
 from genesis.routing.types import ErrorCategory, RetryPolicy
 
-_TRANSIENT_CODES = {429, 500, 502, 503, 504}
+_TRANSIENT_CODES = {500, 502, 503, 504}
+_RATE_LIMITED_CODES = {429}  # provider backpressure — fail fast, do NOT trip the breaker
+_BAD_REQUEST_CODES = {400, 422}  # deterministic client errors — no retry, no trip
 _TIMEOUT_CODES = {408}  # 408 Request Timeout — litellm.Timeout maps here
 _PERMANENT_CODES = {401, 404}
 _QUOTA_CODES = {402}  # 402 Payment Required is always quota
@@ -28,6 +30,10 @@ def classify_error(status_code: int | None, error_msg: str) -> ErrorCategory:
             return ErrorCategory.PERMANENT
         if status_code in _PERMANENT_CODES:
             return ErrorCategory.PERMANENT
+        if status_code in _BAD_REQUEST_CODES:
+            return ErrorCategory.BAD_REQUEST
+        if status_code in _RATE_LIMITED_CODES:
+            return ErrorCategory.RATE_LIMITED
         if status_code in _TIMEOUT_CODES:
             return ErrorCategory.TIMEOUT
         if status_code in _TRANSIENT_CODES:

--- a/src/genesis/routing/router.py
+++ b/src/genesis/routing/router.py
@@ -311,18 +311,26 @@ class Router:
                     cost_usd=result.cost_usd,
                 )
             else:
-                # Record CB failure
                 failed_providers.append(provider_name)
                 category = classify_error(result.status_code, result.error or "")
-                tripped = cb.record_failure(category)
-                if tripped and self._event_bus:
-                    await self._event_bus.emit(
-                        Subsystem.ROUTING, Severity.WARNING,
-                        "breaker.tripped",
-                        f"Circuit breaker tripped for {provider_name}",
-                        provider=provider_name,
-                        call_site=call_site_id,
-                    )
+                # RATE_LIMITED (429) and BAD_REQUEST (400/422) are NOT provider-
+                # health signals: a 429 is expected backpressure (the rate gate
+                # is the brake) and a 400/422 is our payload's fault. Tripping
+                # the breaker on these would wrongly take a reachable provider
+                # offline for every other call site — fail through to the next
+                # chain member WITHOUT recording a breaker failure.
+                if category not in (
+                    ErrorCategory.RATE_LIMITED, ErrorCategory.BAD_REQUEST,
+                ):
+                    tripped = cb.record_failure(category)
+                    if tripped and self._event_bus:
+                        await self._event_bus.emit(
+                            Subsystem.ROUTING, Severity.WARNING,
+                            "breaker.tripped",
+                            f"Circuit breaker tripped for {provider_name}",
+                            provider=provider_name,
+                            call_site=call_site_id,
+                        )
 
         # All exhausted
         if self._event_bus:
@@ -397,7 +405,15 @@ class Router:
             #    wall-clock (this is what produced the ~30-min dream-cycle
             #    hangs). Fail fast — route_call advances to the next provider,
             #    and the circuit breaker still records this failure.
-            if category in (ErrorCategory.PERMANENT, ErrorCategory.TIMEOUT):
+            #  - RATE_LIMITED: a 429 won't clear on an immediate same-provider
+            #    retry — fall through to the next chain member instead of
+            #    burning more of this provider's rate quota.
+            #  - BAD_REQUEST: a 400/422 is deterministic (our payload) — the
+            #    same provider with the same payload fails identically.
+            if category in (
+                ErrorCategory.PERMANENT, ErrorCategory.TIMEOUT,
+                ErrorCategory.RATE_LIMITED, ErrorCategory.BAD_REQUEST,
+            ):
                 return result
 
             # Transient/degraded: retry with delay (skip delay on last attempt)

--- a/src/genesis/routing/types.py
+++ b/src/genesis/routing/types.py
@@ -23,6 +23,16 @@ class ErrorCategory(StrEnum):
     # fails fast to the next provider in the chain, but the circuit breaker
     # still records the failure so a repeatedly-hanging provider trips OPEN.
     TIMEOUT = "timeout"
+    # A rate-limit (HTTP 429). Expected provider backpressure, NOT a health
+    # failure: the router fails fast to the next chain member and the breaker
+    # does NOT trip (the per-provider rate gate is the right brake — tripping
+    # would take a reachable provider offline for every other call site).
+    RATE_LIMITED = "rate_limited"
+    # A deterministic client-side error (HTTP 400/422: context-overflow,
+    # content-policy, malformed/unprocessable request). No same-provider retry
+    # and the breaker does NOT trip — it's our payload's fault, not the
+    # provider's health, so tripping would wrongly take a healthy provider down.
+    BAD_REQUEST = "bad_request"
 
 
 class DegradationLevel(StrEnum):

--- a/tests/test_routing/test_litellm_delegate.py
+++ b/tests/test_routing/test_litellm_delegate.py
@@ -49,6 +49,18 @@ def _mock_response(content="Hello", prompt_tokens=10, completion_tokens=5):
     return SimpleNamespace(choices=[choice], usage=usage)
 
 
+def _install_litellm_exceptions(mock_litellm):
+    """Install real exception classes on a MagicMock'd litellm so the delegate's
+    ``except litellm.X`` chain evaluates. An un-set Mock attribute used in an
+    ``except`` clause raises ``TypeError: catching classes that do not inherit
+    from BaseException``."""
+    for _name in (
+        "RateLimitError", "AuthenticationError", "NotFoundError", "Timeout",
+        "ServiceUnavailableError", "BadRequestError", "UnprocessableEntityError",
+    ):
+        setattr(mock_litellm, _name, type(_name, (Exception,), {}))
+
+
 # ── Model string construction ──────────────────────────────────────────────
 
 
@@ -267,11 +279,7 @@ async def test_call_hard_timeout_cancels_hung_provider():
         return _mock_response()
 
     with patch("genesis.routing.litellm_delegate.litellm") as mock_litellm:
-        mock_litellm.RateLimitError = type("RateLimitError", (Exception,), {})
-        mock_litellm.AuthenticationError = type("AuthenticationError", (Exception,), {})
-        mock_litellm.NotFoundError = type("NotFoundError", (Exception,), {})
-        mock_litellm.Timeout = type("Timeout", (Exception,), {})
-        mock_litellm.ServiceUnavailableError = type("ServiceUnavailableError", (Exception,), {})
+        _install_litellm_exceptions(mock_litellm)
         mock_litellm.acompletion = _hang
 
         start = _t.monotonic()
@@ -296,11 +304,7 @@ async def test_call_rate_limit_error():
     delegate = LiteLLMDelegate(config)
 
     with patch("genesis.routing.litellm_delegate.litellm") as mock_litellm:
-        mock_litellm.RateLimitError = type("RateLimitError", (Exception,), {})
-        mock_litellm.AuthenticationError = type("AuthenticationError", (Exception,), {})
-        mock_litellm.NotFoundError = type("NotFoundError", (Exception,), {})
-        mock_litellm.Timeout = type("Timeout", (Exception,), {})
-        mock_litellm.ServiceUnavailableError = type("ServiceUnavailableError", (Exception,), {})
+        _install_litellm_exceptions(mock_litellm)
         mock_litellm.acompletion = AsyncMock(
             side_effect=mock_litellm.RateLimitError("rate limited"),
         )
@@ -319,11 +323,7 @@ async def test_call_auth_error():
     delegate = LiteLLMDelegate(config)
 
     with patch("genesis.routing.litellm_delegate.litellm") as mock_litellm:
-        mock_litellm.RateLimitError = type("RateLimitError", (Exception,), {})
-        mock_litellm.AuthenticationError = type("AuthenticationError", (Exception,), {})
-        mock_litellm.NotFoundError = type("NotFoundError", (Exception,), {})
-        mock_litellm.Timeout = type("Timeout", (Exception,), {})
-        mock_litellm.ServiceUnavailableError = type("ServiceUnavailableError", (Exception,), {})
+        _install_litellm_exceptions(mock_litellm)
         mock_litellm.acompletion = AsyncMock(
             side_effect=mock_litellm.AuthenticationError("bad key"),
         )
@@ -342,11 +342,7 @@ async def test_call_timeout_error():
     delegate = LiteLLMDelegate(config)
 
     with patch("genesis.routing.litellm_delegate.litellm") as mock_litellm:
-        mock_litellm.RateLimitError = type("RateLimitError", (Exception,), {})
-        mock_litellm.AuthenticationError = type("AuthenticationError", (Exception,), {})
-        mock_litellm.NotFoundError = type("NotFoundError", (Exception,), {})
-        mock_litellm.Timeout = type("Timeout", (Exception,), {})
-        mock_litellm.ServiceUnavailableError = type("ServiceUnavailableError", (Exception,), {})
+        _install_litellm_exceptions(mock_litellm)
         mock_litellm.acompletion = AsyncMock(
             side_effect=mock_litellm.Timeout("timed out"),
         )
@@ -365,11 +361,7 @@ async def test_call_generic_error():
     delegate = LiteLLMDelegate(config)
 
     with patch("genesis.routing.litellm_delegate.litellm") as mock_litellm:
-        mock_litellm.RateLimitError = type("RateLimitError", (Exception,), {})
-        mock_litellm.AuthenticationError = type("AuthenticationError", (Exception,), {})
-        mock_litellm.NotFoundError = type("NotFoundError", (Exception,), {})
-        mock_litellm.Timeout = type("Timeout", (Exception,), {})
-        mock_litellm.ServiceUnavailableError = type("ServiceUnavailableError", (Exception,), {})
+        _install_litellm_exceptions(mock_litellm)
         mock_litellm.acompletion = AsyncMock(
             side_effect=RuntimeError("something broke"),
         )
@@ -382,6 +374,58 @@ async def test_call_generic_error():
     assert result.success is False
     assert result.status_code == 500
     assert "something broke" in result.error
+
+
+async def test_call_bad_request_error():
+    """litellm.BadRequestError (and its ContextWindowExceeded / ContentPolicy
+    subclasses) must map to status 400 so the router classifies it BAD_REQUEST
+    and fails fast without same-provider retries or a breaker trip."""
+    config = _config()
+    delegate = LiteLLMDelegate(config)
+
+    with patch("genesis.routing.litellm_delegate.litellm") as mock_litellm:
+        _install_litellm_exceptions(mock_litellm)
+        mock_litellm.acompletion = AsyncMock(
+            side_effect=mock_litellm.BadRequestError("context window exceeded"),
+        )
+
+        result = await delegate.call(
+            "test-provider", "llama-3.3-70b-versatile",
+            [{"role": "user", "content": "Hi"}],
+        )
+
+    assert result.success is False
+    assert result.status_code == 400
+
+
+async def test_call_unprocessable_entity_error():
+    """litellm.UnprocessableEntityError must map to status 422 (→ BAD_REQUEST)."""
+    config = _config()
+    delegate = LiteLLMDelegate(config)
+
+    with patch("genesis.routing.litellm_delegate.litellm") as mock_litellm:
+        _install_litellm_exceptions(mock_litellm)
+        mock_litellm.acompletion = AsyncMock(
+            side_effect=mock_litellm.UnprocessableEntityError("unprocessable"),
+        )
+
+        result = await delegate.call(
+            "test-provider", "llama-3.3-70b-versatile",
+            [{"role": "user", "content": "Hi"}],
+        )
+
+    assert result.success is False
+    assert result.status_code == 422
+
+
+def test_litellm_badrequest_subclasses_are_stable():
+    """Regression guard against a litellm upgrade: the delegate catches
+    litellm.BadRequestError to map context-overflow + content-policy errors to
+    400. That relies on these being BadRequestError subclasses — assert it
+    against the INSTALLED litellm so a hierarchy change fails loudly here."""
+    import litellm
+    assert issubclass(litellm.ContextWindowExceededError, litellm.BadRequestError)
+    assert issubclass(litellm.ContentPolicyViolationError, litellm.BadRequestError)
 
 
 # ── Cost extraction fallback ───────────────────────────────────────────────
@@ -493,11 +537,7 @@ async def test_auth_error_logs_warning():
         patch("genesis.routing.litellm_delegate.litellm") as mock_litellm,
         patch("genesis.routing.litellm_delegate.logger") as mock_logger,
     ):
-        mock_litellm.RateLimitError = type("RateLimitError", (Exception,), {})
-        mock_litellm.AuthenticationError = type("AuthenticationError", (Exception,), {})
-        mock_litellm.NotFoundError = type("NotFoundError", (Exception,), {})
-        mock_litellm.Timeout = type("Timeout", (Exception,), {})
-        mock_litellm.ServiceUnavailableError = type("ServiceUnavailableError", (Exception,), {})
+        _install_litellm_exceptions(mock_litellm)
         mock_litellm.acompletion = AsyncMock(
             side_effect=mock_litellm.AuthenticationError("bad key"),
         )
@@ -523,11 +563,7 @@ async def test_rate_limit_logs_warning():
         patch("genesis.routing.litellm_delegate.litellm") as mock_litellm,
         patch("genesis.routing.litellm_delegate.logger") as mock_logger,
     ):
-        mock_litellm.RateLimitError = type("RateLimitError", (Exception,), {})
-        mock_litellm.AuthenticationError = type("AuthenticationError", (Exception,), {})
-        mock_litellm.NotFoundError = type("NotFoundError", (Exception,), {})
-        mock_litellm.Timeout = type("Timeout", (Exception,), {})
-        mock_litellm.ServiceUnavailableError = type("ServiceUnavailableError", (Exception,), {})
+        _install_litellm_exceptions(mock_litellm)
         mock_litellm.acompletion = AsyncMock(
             side_effect=mock_litellm.RateLimitError("rate limited"),
         )
@@ -583,11 +619,7 @@ async def test_failure_logging_rate_limited():
         patch("genesis.routing.litellm_delegate.litellm") as mock_litellm,
         patch("genesis.routing.litellm_delegate.logger") as mock_logger,
     ):
-        mock_litellm.RateLimitError = type("RateLimitError", (Exception,), {})
-        mock_litellm.AuthenticationError = type("AuthenticationError", (Exception,), {})
-        mock_litellm.NotFoundError = type("NotFoundError", (Exception,), {})
-        mock_litellm.Timeout = type("Timeout", (Exception,), {})
-        mock_litellm.ServiceUnavailableError = type("ServiceUnavailableError", (Exception,), {})
+        _install_litellm_exceptions(mock_litellm)
         mock_litellm.acompletion = AsyncMock(
             side_effect=mock_litellm.AuthenticationError("bad key"),
         )

--- a/tests/test_routing/test_retry.py
+++ b/tests/test_routing/test_retry.py
@@ -23,8 +23,24 @@ def test_quota_codes():
 
 
 def test_transient_codes():
-    for code in (429, 500, 502, 503, 504):
+    # 429 is no longer TRANSIENT — it is RATE_LIMITED (see test_rate_limited_code).
+    for code in (500, 502, 503, 504):
         assert classify_error(code, "") == ErrorCategory.TRANSIENT
+
+
+def test_rate_limited_code():
+    # 429 → RATE_LIMITED: expected provider backpressure, not a health failure.
+    # The router fails fast to the next chain member and does NOT trip the
+    # breaker (the rate gate is the right brake, not the circuit breaker).
+    assert classify_error(429, "") == ErrorCategory.RATE_LIMITED
+
+
+def test_bad_request_codes():
+    # 400 / 422 → BAD_REQUEST: deterministic client-side errors (context
+    # overflow, content policy, malformed request). Retrying is futile and
+    # tripping the breaker would wrongly take a healthy provider offline.
+    assert classify_error(400, "") == ErrorCategory.BAD_REQUEST
+    assert classify_error(422, "") == ErrorCategory.BAD_REQUEST
 
 
 def test_timeout_code():

--- a/tests/test_routing/test_router.py
+++ b/tests/test_routing/test_router.py
@@ -108,6 +108,90 @@ async def test_timeout_fails_fast_no_same_provider_retry(
 
 
 @pytest.mark.asyncio
+async def test_rate_limited_fails_fast_no_retry_no_breaker_trip(
+    sample_config, breakers, cost_tracker, degradation,
+):
+    """A 429 (RATE_LIMITED) must fail fast to the next provider WITHOUT a
+    same-provider retry AND WITHOUT tripping the breaker. A rate limit is
+    expected backpressure (the rate gate is the right brake) — tripping the
+    breaker would wrongly take a reachable provider offline for every other
+    call site that uses it.
+    """
+    delegate = MockDelegate(responses={
+        "free-1": CallResult(success=False, error="rate limited", status_code=429),
+    })
+    router = Router(
+        config=sample_config, breakers=breakers, cost_tracker=cost_tracker,
+        degradation=degradation, delegate=delegate,
+    )
+    result = await router.route_call("test_mixed", [{"role": "user", "content": "hi"}])
+
+    assert result.success is True
+    assert result.provider_used == "free-2"
+    assert "free-1" in result.failed_providers
+    # Called exactly ONCE — not retried despite default max_retries=1
+    free1_calls = [c for c in delegate.calls if c["provider"] == "free-1"]
+    assert len(free1_calls) == 1
+    # The breaker must NOT record the rate-limit as a failure
+    assert breakers.get("free-1").consecutive_failures == 0
+    assert breakers.get("free-1").trip_count == 0
+
+
+@pytest.mark.asyncio
+async def test_bad_request_fails_fast_no_retry_no_breaker_trip(
+    sample_config, breakers, cost_tracker, degradation,
+):
+    """A 400 (BAD_REQUEST: context overflow / content policy / malformed) must
+    fail fast WITHOUT a same-provider retry AND WITHOUT tripping the breaker —
+    the error is our payload's fault, not the provider being unhealthy.
+    """
+    delegate = MockDelegate(responses={
+        "free-1": CallResult(
+            success=False, error="context window exceeded", status_code=400,
+        ),
+    })
+    router = Router(
+        config=sample_config, breakers=breakers, cost_tracker=cost_tracker,
+        degradation=degradation, delegate=delegate,
+    )
+    result = await router.route_call("test_mixed", [{"role": "user", "content": "hi"}])
+
+    assert result.success is True
+    assert result.provider_used == "free-2"
+    free1_calls = [c for c in delegate.calls if c["provider"] == "free-1"]
+    assert len(free1_calls) == 1
+    assert breakers.get("free-1").consecutive_failures == 0
+    assert breakers.get("free-1").trip_count == 0
+
+
+@pytest.mark.asyncio
+async def test_transient_still_retries_and_records_breaker_failure(
+    sample_config, breakers, cost_tracker, degradation,
+):
+    """Contrast guard: a 503 (TRANSIENT) is STILL retried on the same provider
+    (default max_retries=1 → 2 calls) and STILL recorded against the breaker —
+    proving the RATE_LIMITED/BAD_REQUEST no-trip gating did not disable real
+    health failures.
+    """
+    delegate = MockDelegate(responses={
+        "free-1": CallResult(success=False, error="service unavailable", status_code=503),
+    })
+    router = Router(
+        config=sample_config, breakers=breakers, cost_tracker=cost_tracker,
+        degradation=degradation, delegate=delegate,
+    )
+    result = await router.route_call("test_mixed", [{"role": "user", "content": "hi"}])
+
+    assert result.success is True
+    assert result.provider_used == "free-2"
+    # Retried once on free-1 (2 calls total) since 503 is transient
+    free1_calls = [c for c in delegate.calls if c["provider"] == "free-1"]
+    assert len(free1_calls) == 2
+    # And the breaker recorded the failure (one record per provider per route_call)
+    assert breakers.get("free-1").consecutive_failures == 1
+
+
+@pytest.mark.asyncio
 async def test_timeout_failover_end_to_end(sample_config, breakers, cost_tracker, degradation):
     """E2E: a hung provider routed through the REAL LiteLLMDelegate is
     hard-capped by asyncio.wait_for and the router fails fast to the next


### PR DESCRIPTION
## WS-4 Routing resilience — PR-B of 3 (audit D3). **HELD for merge.**

Adds two `ErrorCategory` members so expected, non-health errors no longer take a healthy provider offline. Closes `ROUTE-01`, `R2-01`.

### Behavior change
| Status | Before | After |
|---|---|---|
| **429** | `TRANSIENT` → retried on same provider (up to `max_retries`), tripped the breaker | `RATE_LIMITED` → fail fast to next provider, **breaker NOT tripped** |
| **400 / 422** | fell through to generic `500` → `TRANSIENT` → retried + tripped | `BAD_REQUEST` → fail fast, **breaker NOT tripped** |
| 401 / 404 | `PERMANENT` (trips) | unchanged |
| 408 / 5xx / 402-403 | TIMEOUT / TRANSIENT / QUOTA (trip) | unchanged |

**Why no breaker trip:** a 429 is expected backpressure (the per-provider rate gate is the right brake), and a 400/422 is *our* payload's fault (context-overflow / content-policy), not the provider's health. Tripping would wrongly take a reachable provider offline for every other call site. Complements #698's coverage-based degradation (fewer false trips → fewer false ESSENTIAL alarms).

### Changes
- `types.py`: `RATE_LIMITED`, `BAD_REQUEST` categories.
- `retry.py`: 429 → RATE_LIMITED (out of `_TRANSIENT_CODES`); 400/422 → BAD_REQUEST.
- `litellm_delegate.py`: explicit `except litellm.BadRequestError` (covers `ContextWindowExceeded`/`ContentPolicy` subclasses) + `UnprocessableEntityError` → 400/422, before the generic handler (was 500).
- `router.py`: both classes added to the fail-fast set; `record_failure` gated to skip them.

### Verification
- TDD: 7 new tests; full `test_routing/` (276) + `test_eval/` (129) green; ruff clean.
- Code review: exception hierarchy + clause ordering verified against installed litellm (no shadowing; `UnprocessableEntityError` is not a `BadRequestError` subclass); test-mock helper applied uniformly. P3 chronic-429 observability gap tracked as a follow-up.
- E2E: **real** litellm `RateLimitError`/`BadRequestError`/`ServiceUnavailableError` through real `LiteLLMDelegate`→`classify_error`→`Router`→`CircuitBreaker` — 429/400 fail over with `consecutive_failures=0`; 503 still records `=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)