### PR TITLE
fix(feedback): de-flake outcome-harvest incremental idempotency test (date drift)

### DIFF
--- a/tests/feedback/test_harvest.py
+++ b/tests/feedback/test_harvest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import aiosqlite
 import pytest
 
@@ -249,8 +251,14 @@ class TestIdempotencyAndScheduling:
 
     @pytest.mark.asyncio
     async def test_incremental_run_is_idempotent_on_unique_key(self, db):
+        # Stamp the proposal "now-ish" so it always falls inside run()'s default
+        # 2-day incremental window. The _add_proposal default is a FIXED calendar
+        # date, which silently drifts out of that window as the suite ages — this
+        # test passed when written and started failing two days later.
+        recent = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
         await _add_proposal(
             db, pid="p1", status="executed", user_response="s|completed:x",
+            created_at=recent, resolved_at=recent,
         )
         await OutcomeHarvester(db).run()
         await OutcomeHarvester(db).run()  # re-scan same window


### PR DESCRIPTION
## What & why

`tests/feedback/test_harvest.py::TestIdempotencyAndScheduling::test_incremental_run_is_idempotent_on_unique_key`
is **failing deterministically on `main`**, which reds the `test` CI job on **every
open PR** right now (discovered while verifying an unrelated PR).

**Root cause — date drift, not a product bug.** The test seeds a proposal using the
`_add_proposal` default date (`2026-06-18`) and then calls `OutcomeHarvester.run()`,
whose incremental scan window is `now − 2 days` (default `window_days=2`). The window
is relative to the current date, so once the calendar passed `2026-06-18 + 2 days`,
the proposal fell *outside* the window → the harvester scanned 0 rows →
`assert await oe.count(db) == 1` saw `0`. It passed when written (~Jun 18) and began
failing on Jun 20. (Same date-boundary class as the recent cost-reporting fix.)

The harvester itself is correct — the incremental window is working as designed (the
sibling `test_incremental_window_excludes_old_but_backfill_includes` deliberately
relies on a permanently-old date and still passes).

## Fix

Stamp the test proposal at `now − 1h` so it is always inside the incremental window,
regardless of the calendar date the suite runs on. **Test-only change**; no harvester
or product behavior is touched.

## Verification

- ruff clean.
- `tests/feedback/test_harvest.py`: **23 passed** (was 22 passed + 1 failed).
- Fix is calendar-robust: `now − 1h` is always within the `now − 2 days` window.

## Note

This unblocks the `test` CI job across all open PRs. Holding merge per the active
multi-session coordination — fast-track if you want CI green again sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)