### PR TITLE
fix(routing): half-open providers heal via probes + aggregate retry deadline (WS-4 PR-C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   everything else for up to 30 minutes. Now those responses fail straight over to the next
   provider without retrying or benching the one that's actually healthy — so you get faster
   failover and far fewer false "provider down" blips.
+- **Idle fallback providers heal on their own instead of staying stuck** — a provider that
+  recovered from an outage but then received little or no traffic could sit in a half-recovered
+  "on probation" state indefinitely, because only a real successful request could fully clear it.
+  Genesis's free health probes now confirm such a provider is reachable and restore it to normal
+  rotation (and clear its lingering "failing" alert), so rarely-used backups don't get permanently
+  benched.
+
+- **A single request can't hang for minutes across retries and failover** — each routing profile
+  now has an aggregate time budget, so the worst case where one request's retries multiply across
+  the whole provider chain into a multi-minute stall is bounded. It only caps the retry/failover
+  multiplier on one request (checked between attempts, never mid-call) — background thinking that
+  legitimately takes a while is unaffected.
 
 - **Recovered providers stop alarming once they come back** — when a model provider's
   circuit breaker reopens after an outage, Genesis now clears that provider's "failing"

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -638,18 +638,29 @@ call_sites:
       \ for HA voice assistant. Groq first for speed (~1s), Gemini/Mistral\
       \ as fallbacks."
 retry:
+  # max_total_s: aggregate wall-clock ceiling (seconds) across a single
+  # route_call's retries x chain length. A safety net against pathological
+  # multi-minute hangs, checked only BETWEEN attempts (never interrupts an
+  # in-flight call). It bounds ONE completion's retry-multiplier, NOT Genesis's
+  # cognition (a reflection is many bounded completions). Omit for no cap.
   default:
     max_retries: 3
     base_delay_ms: 500
     max_delay_ms: 30000
+    max_total_s: 300
   user_facing:
     max_retries: 2
     base_delay_ms: 300
     max_delay_ms: 5000
+    max_total_s: 180
   background:
     max_retries: 4
     base_delay_ms: 1000
     max_delay_ms: 60000
+    # Generous safety net only — should never fire in normal operation. Dream /
+    # reflection / ego are exactly where a single completion may legitimately
+    # take a while across failovers; we only stop the pathology, not cognition.
+    max_total_s: 1800
 surplus:
   idle_threshold_minutes: 15
   dispatch_interval_minutes: 5

--- a/src/genesis/observability/provider_health.py
+++ b/src/genesis/observability/provider_health.py
@@ -155,7 +155,10 @@ class ProviderHealthChecker:
         """Push probe findings to circuit breakers.
 
         Unreachable or rate-limited providers get tripped to HALF_OPEN
-        (probe = scout, CB = judge). Only downgrades — never closes a CB.
+        (probe = scout, CB = judge). A clean probe (reachable AND this provider's
+        model is listed) advances a HALF_OPEN breaker toward recovery so a
+        low/no-traffic fallback provider can heal instead of being stuck forever.
+        Only downgrades a CLOSED breaker; only heals a HALF_OPEN one.
         """
         if not self._breakers:
             return
@@ -170,6 +173,19 @@ class ProviderHealthChecker:
                     logger.debug("CB sync failed for probed provider %s", name, exc_info=True)
                 except Exception:
                     logger.debug("Unexpected CB sync error for %s", name, exc_info=True)
+            elif result.model_available is True:
+                # Positive confirmation (reachable + this model listed). record_probe_success
+                # is a no-op unless the breaker is HALF_OPEN, so this only heals a
+                # recovering provider — never closes a CLOSED one prematurely. Best-effort:
+                # a 200 on /v1/models is weaker than a real completion (hence the stricter
+                # probe_success_threshold), and a falsely-healed provider re-trips on its
+                # next real failure.
+                try:
+                    self._breakers.get(name).record_probe_success()
+                except (KeyError, OSError):
+                    logger.debug("CB heal sync failed for probed provider %s", name, exc_info=True)
+                except Exception:
+                    logger.debug("Unexpected CB heal sync error for %s", name, exc_info=True)
 
     async def _probe_one(self, cfg: ProviderConfig) -> ProviderProbeResult:
         """Probe a single provider's models endpoint."""

--- a/src/genesis/routing/circuit_breaker.py
+++ b/src/genesis/routing/circuit_breaker.py
@@ -40,6 +40,7 @@ class CircuitBreaker:
         failure_threshold: int = 3,
         open_duration_s: int = 120,
         success_threshold: int = 2,
+        probe_success_threshold: int = 3,
         clock: object = None,
         on_state_change: object = None,
         on_recovery: object = None,
@@ -48,6 +49,10 @@ class CircuitBreaker:
         self._failure_threshold = failure_threshold
         self._open_duration_s = open_duration_s
         self._success_threshold = success_threshold
+        # Stricter than success_threshold: a free /v1/models probe (used by
+        # record_probe_success) is weaker evidence than a real completion, so a
+        # HALF_OPEN provider needs MORE consecutive clean probes to heal.
+        self._probe_success_threshold = probe_success_threshold
         self._clock = clock or time.monotonic
         self._on_state_change = on_state_change
         self._on_recovery = on_recovery
@@ -135,6 +140,34 @@ class CircuitBreaker:
             self._notify_change()
             return True
         return False
+
+    def record_probe_success(self) -> None:
+        """A free health probe (GET /v1/models returned 200 with this provider's
+        model listed) confirmed reachability while the breaker is HALF_OPEN.
+
+        Advances toward recovery with the STRICTER ``probe_success_threshold``
+        (a probe is weaker evidence than a real completion), so a low/no-traffic
+        fallback provider can heal instead of being stuck in HALF_OPEN forever.
+        No-op outside HALF_OPEN (uses the ``state`` property so an OPEN breaker
+        whose window has expired transitions to HALF_OPEN first). On full
+        recovery it fires ``on_recovery`` — exactly like ``record_success`` — so
+        the provider's lingering ``provider_failure`` observation auto-resolves.
+        """
+        if self.state != ProviderState.HALF_OPEN:
+            return
+        was_tripped = self._trip_count > 0
+        self._consecutive_successes += 1
+        if self._consecutive_successes >= self._probe_success_threshold:
+            old = self._state
+            self._state = ProviderState.CLOSED
+            self._consecutive_successes = 0
+            self._consecutive_failures = 0
+            self._last_failure_category = None
+            self._trip_count = 0  # recovered — reset backoff
+            if self._state != old:
+                self._notify_change()
+            if was_tripped and self._on_recovery:
+                self._on_recovery(self._provider.name)
 
     def record_failure(self, category: ErrorCategory) -> bool:
         """Record a failed call. Returns True if this failure caused the breaker to trip OPEN."""

--- a/src/genesis/routing/config.py
+++ b/src/genesis/routing/config.py
@@ -181,6 +181,7 @@ def _parse(raw: dict, *, check_api_keys: bool = True) -> RoutingConfig:
             max_delay_ms=rp.get("max_delay_ms", 30000),
             backoff_multiplier=rp.get("backoff_multiplier", 2.0),
             jitter_pct=rp.get("jitter_pct", 0.25),
+            max_total_s=rp.get("max_total_s"),  # None = no aggregate cap
         )
     # Ensure "default" always exists
     if "default" not in retry_profiles:

--- a/src/genesis/routing/router.py
+++ b/src/genesis/routing/router.py
@@ -196,7 +196,22 @@ class Router:
         first_provider = chain[0]
         failed_providers: list[str] = []
 
+        # Aggregate wall-clock deadline across the whole chain walk (retries x
+        # chain length). A GATE only — checked between providers/attempts, never
+        # interrupts an in-flight call (the delegate's per-attempt timeout owns
+        # that). None = no cap (today's behavior).
+        route_start = time.monotonic()
+        deadline = (
+            (route_start + policy.max_total_s)
+            if policy.max_total_s is not None
+            else None
+        )
+
         for provider_name in chain:
+            # Out of aggregate budget — stop walking the chain. The primary
+            # provider always gets a shot; later providers are gated.
+            if deadline is not None and time.monotonic() >= deadline:
+                break
             provider_cfg = self.config.providers[provider_name]
 
             # Skip providers with no API key — treat as down-by-config.
@@ -228,7 +243,8 @@ class Router:
             # Try with retry (timed for activity tracking)
             t0 = time.monotonic()
             result = await self._try_with_retry(
-                provider_name, provider_cfg.model_id, messages, policy, **kwargs,
+                provider_name, provider_cfg.model_id, messages, policy,
+                deadline=deadline, **kwargs,
             )
             latency_ms = (time.monotonic() - t0) * 1000
             attempts += 1
@@ -384,13 +400,20 @@ class Router:
         return list(site.chain)
 
     async def _try_with_retry(
-        self, provider: str, model_id: str, messages: list[dict], policy, **kwargs,
+        self, provider: str, model_id: str, messages: list[dict], policy,
+        *, deadline: float | None = None, **kwargs,
     ) -> CallResult:
         """Try calling a provider with retries. Returns last result."""
         last_result = CallResult(success=False, error="no attempts made")
         max_attempts = policy.max_retries + 1
 
         for attempt in range(max_attempts):
+            # Aggregate deadline: stop starting RETRIES once the budget is spent.
+            # Attempt 0 always runs (the chain gate already admitted this
+            # provider) — only same-provider retries are bounded, and never an
+            # in-flight call.
+            if attempt > 0 and deadline is not None and time.monotonic() >= deadline:
+                return last_result
             result = await self.delegate.call(provider, model_id, messages, **kwargs)
             if result.success:
                 return result

--- a/src/genesis/routing/types.py
+++ b/src/genesis/routing/types.py
@@ -97,6 +97,13 @@ class RetryPolicy:
     max_delay_ms: int = 30000
     backoff_multiplier: float = 2.0
     jitter_pct: float = 0.25
+    # Aggregate wall-clock ceiling (seconds) across the whole route_call chain
+    # walk — retries x chain length. None = no aggregate cap (today's behavior).
+    # A GATE checked only BETWEEN attempts/providers: it never interrupts an
+    # in-flight call (the delegate's per-attempt timeout owns that). It bounds
+    # the retry-multiplier on a SINGLE completion, NOT Genesis's cognition (a
+    # reflection is many bounded completions).
+    max_total_s: float | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/test_routing/test_circuit_breaker.py
+++ b/tests/test_routing/test_circuit_breaker.py
@@ -476,6 +476,91 @@ def test_trip_count_capped_on_restore(tmp_path):
         cb_mod._STATE_FILE = original_path
 
 
+# --- Probe-based recovery (record_probe_success) ---
+
+
+def _half_open_breaker(probe_threshold=3, **kw):
+    """A breaker driven to HALF_OPEN: tripped OPEN (failure_threshold=2), then
+    its open window expired so the next state read auto-transitions to HALF_OPEN.
+    """
+    t = [0.0]
+    cb = CircuitBreaker(
+        _provider("p1"), failure_threshold=2, open_duration_s=10,
+        clock=lambda: t[0], probe_success_threshold=probe_threshold, **kw,
+    )
+    cb.record_failure(ErrorCategory.TRANSIENT)
+    cb.record_failure(ErrorCategory.TRANSIENT)  # trips OPEN
+    assert cb.state == ProviderState.OPEN
+    t[0] = 100.0  # past the open window
+    assert cb.state == ProviderState.HALF_OPEN
+    return cb, t
+
+
+def test_probe_success_heals_half_open_after_threshold():
+    cb, _ = _half_open_breaker(probe_threshold=3)
+    cb.record_probe_success()
+    assert cb.state == ProviderState.HALF_OPEN  # 1 < 3
+    cb.record_probe_success()
+    assert cb.state == ProviderState.HALF_OPEN  # 2 < 3
+    cb.record_probe_success()
+    assert cb.state == ProviderState.CLOSED     # 3 → healed
+    assert cb.trip_count == 0
+
+
+def test_probe_success_noop_when_closed():
+    cb = CircuitBreaker(_provider(), clock=lambda: 0)
+    assert cb.state == ProviderState.CLOSED
+    cb.record_probe_success()
+    assert cb.state == ProviderState.CLOSED
+    assert cb.trip_count == 0
+
+
+def test_probe_success_noop_when_open_not_expired():
+    """A probe success must NOT heal a breaker whose open window has not yet
+    expired (still genuinely OPEN)."""
+    t = [0.0]
+    cb = CircuitBreaker(_provider(), failure_threshold=2, open_duration_s=100, clock=lambda: t[0])
+    cb.record_failure(ErrorCategory.TRANSIENT)
+    cb.record_failure(ErrorCategory.TRANSIENT)
+    assert cb.state == ProviderState.OPEN
+    cb.record_probe_success()
+    assert cb.state == ProviderState.OPEN
+
+
+def test_probe_success_fires_on_recovery():
+    """On full recovery the breaker fires on_recovery — this is what drives
+    #698's escalation observation-resolve, so a probe-healed provider does not
+    leave a stale 'provider_failure' observation."""
+    recovered = []
+    t = [0.0]
+    cb = CircuitBreaker(
+        _provider("p1"), failure_threshold=2, open_duration_s=10,
+        clock=lambda: t[0], probe_success_threshold=2,
+        on_recovery=lambda name: recovered.append(name),
+    )
+    cb.record_failure(ErrorCategory.TRANSIENT)
+    cb.record_failure(ErrorCategory.TRANSIENT)
+    t[0] = 100.0
+    assert cb.state == ProviderState.HALF_OPEN
+    cb.record_probe_success()
+    assert recovered == []  # below threshold — no recovery yet
+    cb.record_probe_success()
+    assert cb.state == ProviderState.CLOSED
+    assert recovered == ["p1"]
+
+
+def test_real_failure_after_probe_heal_can_retrip():
+    """A provider healed via probe must still re-trip on real failures —
+    healing must not disable failure tracking."""
+    cb, _ = _half_open_breaker(probe_threshold=2)
+    cb.record_probe_success()
+    cb.record_probe_success()
+    assert cb.state == ProviderState.CLOSED
+    cb.record_failure(ErrorCategory.TRANSIENT)
+    cb.record_failure(ErrorCategory.TRANSIENT)  # failure_threshold=2
+    assert cb.state == ProviderState.OPEN
+
+
 # --- Coverage-based degradation (essential_sites map injected) ---
 
 

--- a/tests/test_routing/test_provider_health_heal.py
+++ b/tests/test_routing/test_provider_health_heal.py
@@ -1,0 +1,94 @@
+"""ProviderHealthChecker._sync_to_breakers heals a HALF_OPEN breaker on a clean
+probe (the low/no-traffic recovery path) and still only downgrades on failure.
+"""
+
+from __future__ import annotations
+
+from genesis.observability.provider_health import (
+    ProviderHealthChecker,
+    ProviderProbeResult,
+)
+from genesis.routing.circuit_breaker import CircuitBreakerRegistry
+from genesis.routing.types import (
+    ErrorCategory,
+    ProviderConfig,
+    ProviderState,
+    RoutingConfig,
+)
+
+
+def _provider(name: str = "free-1") -> ProviderConfig:
+    return ProviderConfig(
+        name=name, provider_type="groq", model_id="m",
+        is_free=True, rpm_limit=None, open_duration_s=10,
+    )
+
+
+def _config(provider: ProviderConfig) -> RoutingConfig:
+    return RoutingConfig(
+        providers={provider.name: provider}, call_sites={}, retry_profiles={},
+    )
+
+
+def _half_open_registry():
+    """Registry with free-1 driven to HALF_OPEN."""
+    t = [0.0]
+    prov = _provider("free-1")
+    reg = CircuitBreakerRegistry({"free-1": prov}, clock=lambda: t[0], persist=False)
+    cb = reg.get("free-1")
+    for _ in range(3):  # default failure_threshold = 3
+        cb.record_failure(ErrorCategory.TRANSIENT)
+    assert cb.state == ProviderState.OPEN
+    t[0] = 100.0  # past the open window
+    assert cb.state == ProviderState.HALF_OPEN
+    return reg, prov
+
+
+def test_clean_probe_heals_half_open_breaker():
+    """A reachable + model_available probe on a HALF_OPEN provider advances it to
+    CLOSED via record_probe_success after the default probe threshold (3)."""
+    reg, prov = _half_open_registry()
+    checker = ProviderHealthChecker(_config(prov), breakers=reg)
+    checker._results = {
+        "free-1": ProviderProbeResult(
+            provider_name="free-1", reachable=True, configured=True,
+            model_available=True,
+        ),
+    }
+    # default probe_success_threshold = 3 → three clean syncs heal it.
+    for _ in range(3):
+        checker._sync_to_breakers()
+    assert reg.get("free-1").state == ProviderState.CLOSED
+
+
+def test_probe_model_unavailable_does_not_heal():
+    """Reachable but model_available is False/None (endpoint up but this model
+    not listed) must NOT heal — weaker signal than a real completion."""
+    reg, prov = _half_open_registry()
+    checker = ProviderHealthChecker(_config(prov), breakers=reg)
+    checker._results = {
+        "free-1": ProviderProbeResult(
+            provider_name="free-1", reachable=True, configured=True,
+            model_available=None,
+        ),
+    }
+    for _ in range(5):
+        checker._sync_to_breakers()
+    assert reg.get("free-1").state == ProviderState.HALF_OPEN
+
+
+def test_unreachable_probe_still_only_downgrades():
+    """Regression: an unreachable probe must still only downgrade a CLOSED
+    breaker to HALF_OPEN (probe_suspect), never heal."""
+    prov = _provider("free-1")
+    reg = CircuitBreakerRegistry({"free-1": prov}, clock=lambda: 0, persist=False)
+    assert reg.get("free-1").state == ProviderState.CLOSED
+    checker = ProviderHealthChecker(_config(prov), breakers=reg)
+    checker._results = {
+        "free-1": ProviderProbeResult(
+            provider_name="free-1", reachable=False, configured=True,
+            error="ConnectionError",
+        ),
+    }
+    checker._sync_to_breakers()
+    assert reg.get("free-1").state == ProviderState.HALF_OPEN

--- a/tests/test_routing/test_router.py
+++ b/tests/test_routing/test_router.py
@@ -505,3 +505,130 @@ async def test_failed_providers_tracked_on_open_breaker(sample_config, breakers,
     assert result.success is True
     assert result.provider_used == "free-2"
     assert "free-1" in result.failed_providers
+
+
+# ── Aggregate wall-clock deadline (RetryPolicy.max_total_s) ───────────────────
+
+
+def _three_free_config(max_total_s, max_retries=0):
+    from genesis.routing.types import CallSiteConfig, ProviderConfig, RetryPolicy, RoutingConfig
+    providers = {
+        f"free-{i}": ProviderConfig(
+            name=f"free-{i}", provider_type="test", model_id="m",
+            is_free=True, rpm_limit=None, open_duration_s=120,
+        ) for i in range(1, 4)
+    }
+    return RoutingConfig(
+        providers=providers,
+        call_sites={"site": CallSiteConfig(id="site", chain=["free-1", "free-2", "free-3"])},
+        retry_profiles={"default": RetryPolicy(
+            max_retries=max_retries, base_delay_ms=0, jitter_pct=0.0, max_total_s=max_total_s,
+        )},
+    )
+
+
+def _clock_advancing_delegate(clock, per_call=0.1):
+    """A MockDelegate that fails every provider and advances `clock` per call."""
+    delegate = MockDelegate(responses={
+        f"free-{i}": CallResult(success=False, status_code=503, error="down")
+        for i in range(1, 4)
+    })
+    orig = delegate.call
+
+    async def _timed(provider, model_id, messages, **kwargs):
+        r = await orig(provider, model_id, messages, **kwargs)
+        clock[0] += per_call
+        return r
+
+    delegate.call = _timed
+    return delegate
+
+
+@pytest.mark.asyncio
+async def test_aggregate_deadline_stops_chain_walk(cost_tracker, degradation):
+    """With max_total_s set, route_call stops walking the chain once the
+    aggregate wall-clock budget is exceeded — it does NOT try every remaining
+    provider. The gate is checked BETWEEN providers (never interrupts a call).
+    """
+    from unittest.mock import patch
+
+    config = _three_free_config(max_total_s=0.15)
+    breakers = CircuitBreakerRegistry(config.providers)
+    clock = [0.0]
+    delegate = _clock_advancing_delegate(clock)
+    router = Router(
+        config=config, breakers=breakers, cost_tracker=cost_tracker,
+        degradation=degradation, delegate=delegate,
+    )
+
+    with patch("genesis.routing.router.time.monotonic", lambda: clock[0]):
+        result = await router.route_call("site", [{"role": "user", "content": "hi"}])
+
+    assert result.success is False
+    # free-1 (0.0→0.1) + free-2 (0.1→0.2); at the top of free-3 the elapsed
+    # (0.2) already exceeds max_total_s (0.15) → free-3 is never attempted.
+    called = [c["provider"] for c in delegate.calls]
+    assert called == ["free-1", "free-2"]
+    assert "free-3" not in called
+
+
+@pytest.mark.asyncio
+async def test_no_aggregate_deadline_tries_full_chain(cost_tracker, degradation):
+    """max_total_s=None (default) keeps today's behavior — the whole chain is
+    attempted no matter how long the cumulative wall-clock is.
+    """
+    from unittest.mock import patch
+
+    config = _three_free_config(max_total_s=None)
+    breakers = CircuitBreakerRegistry(config.providers)
+    clock = [0.0]
+    delegate = _clock_advancing_delegate(clock, per_call=10.0)  # huge per-call
+    router = Router(
+        config=config, breakers=breakers, cost_tracker=cost_tracker,
+        degradation=degradation, delegate=delegate,
+    )
+
+    with patch("genesis.routing.router.time.monotonic", lambda: clock[0]):
+        result = await router.route_call("site", [{"role": "user", "content": "hi"}])
+
+    assert result.success is False
+    called = [c["provider"] for c in delegate.calls]
+    assert called == ["free-1", "free-2", "free-3"]
+
+
+@pytest.mark.asyncio
+async def test_aggregate_deadline_stops_inner_retries(cost_tracker, degradation):
+    """The deadline also bounds same-provider RETRIES: a single provider with a
+    long retry budget stops retrying once the aggregate deadline passes (never
+    interrupting an in-flight attempt — checked between attempts).
+    """
+    from unittest.mock import patch
+
+    from genesis.routing.types import CallSiteConfig, ProviderConfig, RetryPolicy, RoutingConfig
+
+    providers = {"free-1": ProviderConfig(
+        name="free-1", provider_type="test", model_id="m",
+        is_free=True, rpm_limit=None, open_duration_s=120,
+    )}
+    config = RoutingConfig(
+        providers=providers,
+        call_sites={"site": CallSiteConfig(id="site", chain=["free-1"])},
+        retry_profiles={"default": RetryPolicy(
+            max_retries=5, base_delay_ms=0, jitter_pct=0.0, max_total_s=0.25,
+        )},
+    )
+    breakers = CircuitBreakerRegistry(providers)
+    clock = [0.0]
+    delegate = _clock_advancing_delegate(clock)  # advances 0.1 per call
+
+    router = Router(
+        config=config, breakers=breakers, cost_tracker=cost_tracker,
+        degradation=degradation, delegate=delegate,
+    )
+    with patch("genesis.routing.router.time.monotonic", lambda: clock[0]):
+        result = await router.route_call("site", [{"role": "user", "content": "hi"}])
+
+    assert result.success is False
+    # attempt0(0.0→0.1) attempt1(0.1→0.2) attempt2(0.2→0.3); attempt3 sees
+    # 0.3 >= 0.25 and stops — 3 calls, NOT the full 6 (max_retries+1).
+    assert len(delegate.calls) == 3


### PR DESCRIPTION
## WS-4 Routing resilience — PR-C of 3 (audit D3). **HELD for merge.**

Final WS-4 PR. Two changes; closes `ROUTE-02` and `R2-02`.

### 1. Half-open providers heal via health probes (`ROUTE-02`)
A low/no-traffic fallback provider could sit in `HALF_OPEN` **forever** — only a real completion success (`record_success`) closed the breaker, and a rarely-used backup may never get organic traffic. New `CircuitBreaker.record_probe_success()`: a clean `/v1/models` probe (reachable **and this provider's model listed**) advances a HALF_OPEN breaker toward `CLOSED` after a **stricter** `probe_success_threshold` (3, vs organic 2 — a 200 on `/v1/models` is weaker evidence than a completion). Wired in `provider_health._sync_to_breakers` (no-op unless HALF_OPEN; only downgrades a CLOSED breaker).
On full recovery it fires `on_recovery` exactly like `record_success`, so **#698's escalation auto-resolves the provider's `provider_failure` observation** — a probe-healed provider doesn't leave a stale "failing" alert.

### 2. Aggregate wall-clock deadline on `route_call` (`R2-02`)
No ceiling existed across a single `route_call`'s retries × chain length → pathological multi-minute hangs. New `RetryPolicy.max_total_s` — a **gate checked only BETWEEN attempts/providers** (never interrupts an in-flight call; the per-attempt delegate timeout owns that). The primary provider always gets a shot. Per-profile: `user_facing 180s · default 300s · background 1800s` (a should-never-fire safety net). It bounds **one completion's** retry-multiplier, **not** Genesis's cognition (a reflection is many bounded completions).

### Verification
- TDD: new breaker/router/provider-health tests; full `test_routing/` (279) + `test_health_data` + credit-exhaustion (39) green; ruff clean.
- Code review: `record_probe_success` recovery/`on_recovery` semantics, deadline `**kwargs` non-leak, `break`-vs-`continue`, `attempt>0` primary-always-runs, and in-flight non-interrupt all verified. Fixed: `max_total_s` `is not None` guard (so `0` = 0-budget, not "no cap"). Documented the shared-`/v1/models`-endpoint best-effort heal (self-corrects: re-trips on next real failure).
- E2E: probe-heal → `on_recovery` → escalation → the `provider_failure` observation **auto-resolves in the DB**; the real `model_routing.yaml` parses `max_total_s` 180/300/1800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)