### PR TITLE
fix(campaigns): record tick job_health so crashes are observable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **A campaign that crashes mid-tick no longer fails silently** — when a scheduled campaign
+  tick raises an error, Genesis now records it in job-health tracking, so the failure surfaces
+  in the dashboard and to the ego instead of vanishing into the server log. Campaign
+  reliability problems become visible instead of going unnoticed.
+
 - **Surplus brainstorm messages read like prose, not raw JSON** — Genesis's background
   brainstorm ideas posted to the Telegram "Surplus" topic now render as clean bulleted text
   (idea, detail, and why it matters) instead of the raw ```json``` code block the model

--- a/src/genesis/campaigns/runner.py
+++ b/src/genesis/campaigns/runner.py
@@ -73,22 +73,37 @@ class CampaignRunner:
             )
             return
 
+        job_id = f"campaign_{camp['name']}"
         self._scheduler.add_job(
             self._tick_wrapper,
             trigger,
-            args=[camp["id"]],
-            id=f"campaign_{camp['name']}",
+            args=[camp["id"], job_id],
+            id=job_id,
             max_instances=1,
             misfire_grace_time=300,
             replace_existing=True,
         )
 
-    async def _tick_wrapper(self, campaign_id: str) -> None:
-        """APScheduler entry point — wraps campaign_tick with error handling."""
+    async def _tick_wrapper(self, campaign_id: str, job_id: str) -> None:
+        """APScheduler entry point — wraps campaign_tick with error handling.
+
+        Records job health (success / failure) via the runtime so a tick crash
+        is observable through job_health → JobHealthCollector → ego/dashboard,
+        not just the server log. Mirrors the surplus scheduler's pattern. The
+        recording is best-effort (suppressed) and never propagates to
+        APScheduler — the tick-level swallow contract is preserved.
+        """
+        from genesis.runtime import GenesisRuntime
+
         try:
             await self.campaign_tick(campaign_id)
-        except Exception:
+        except Exception as exc:
             logger.exception("Campaign tick failed for %s", campaign_id)
+            with contextlib.suppress(Exception):
+                GenesisRuntime.instance().record_job_failure(job_id, str(exc)[:500])
+            return
+        with contextlib.suppress(Exception):
+            GenesisRuntime.instance().record_job_success(job_id)
 
     async def campaign_tick(
         self,

--- a/tests/test_campaigns/test_runner.py
+++ b/tests/test_campaigns/test_runner.py
@@ -268,3 +268,69 @@ class TestDayBoundaryReset:
         state = {"posts_today": 3, "total_posts": 10}
         reset = _day_boundary_reset(state, "2026-06-07T08:00:00Z", "2026-06-07T16:00:00Z")
         assert reset["posts_today"] == 3  # Same day, no reset
+
+
+class TestTickWrapperJobHealth:
+    """_tick_wrapper records job health so tick crashes are observable (#15)."""
+
+    @pytest.mark.anyio
+    async def test_records_failure_on_exception(self, db, mock_session_runner):
+        from genesis.campaigns.runner import CampaignRunner
+
+        runner = CampaignRunner(db=db, session_runner=mock_session_runner)
+        runner.campaign_tick = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch("genesis.runtime.GenesisRuntime") as rt_cls:
+            inst = MagicMock()
+            rt_cls.instance.return_value = inst
+            # Must NOT propagate — the tick-level swallow contract is preserved.
+            await runner._tick_wrapper("camp-1", "campaign_test")
+
+        inst.record_job_failure.assert_called_once()
+        job_id, err = inst.record_job_failure.call_args[0][:2]
+        assert job_id == "campaign_test"
+        assert "boom" in err
+        inst.record_job_success.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_records_success_on_clean_tick(self, db, mock_session_runner):
+        from genesis.campaigns.runner import CampaignRunner
+
+        runner = CampaignRunner(db=db, session_runner=mock_session_runner)
+        runner.campaign_tick = AsyncMock(return_value={"outcome": "skip"})
+
+        with patch("genesis.runtime.GenesisRuntime") as rt_cls:
+            inst = MagicMock()
+            rt_cls.instance.return_value = inst
+            await runner._tick_wrapper("camp-1", "campaign_test")
+
+        inst.record_job_success.assert_called_once_with("campaign_test")
+        inst.record_job_failure.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_success_record_errors_are_suppressed(self, db, mock_session_runner):
+        """A failure recording the SUCCESS heartbeat must never propagate."""
+        from genesis.campaigns.runner import CampaignRunner
+
+        runner = CampaignRunner(db=db, session_runner=mock_session_runner)
+        runner.campaign_tick = AsyncMock(return_value={"outcome": "skip"})
+
+        with patch("genesis.runtime.GenesisRuntime") as rt_cls:
+            rt_cls.instance.side_effect = RuntimeError("runtime not ready")
+            # Must not raise even though instance() blows up.
+            await runner._tick_wrapper("camp-1", "campaign_test")
+
+    @pytest.mark.anyio
+    async def test_failure_record_errors_are_suppressed(self, db, mock_session_runner):
+        """A failed tick whose record_job_failure ALSO raises must not propagate."""
+        from genesis.campaigns.runner import CampaignRunner
+
+        runner = CampaignRunner(db=db, session_runner=mock_session_runner)
+        runner.campaign_tick = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch("genesis.runtime.GenesisRuntime") as rt_cls:
+            inst = MagicMock()
+            inst.record_job_failure.side_effect = RuntimeError("record blew up")
+            rt_cls.instance.return_value = inst
+            # tick raised AND record_job_failure raised — still must not propagate.
+            await runner._tick_wrapper("camp-1", "campaign_test")


### PR DESCRIPTION
## Problem
The campaign runner owns a private APScheduler with no error listener, and `_tick_wrapper` swallowed all exceptions with only `logger.exception`. A tick crash on the live discord-engagement campaign was invisible to job_health -> JobHealthCollector -> ego/dashboard (verified: zero `campaign_*` rows in the live job_health table despite weeks of active runs).

## Fix
`_tick_wrapper` now records job health via `GenesisRuntime.instance().record_job_success/failure(job_id)`, mirroring the surplus scheduler's established pattern. The recording is best-effort (suppressed) and never propagates to APScheduler, so the tick-level swallow contract is preserved. The `job_id` (`campaign_<name>`) matches the scheduler job id so dashboard/reconcile align.

## Verification
- Unit tests: failure recorded + not propagated; success recorded; both suppress paths (success and failure) covered.
- Full `tests/test_campaigns/` suite green (38).
- Real-runtime e2e: a failing tick records `consecutive_failures: 1` + `last_error`; a clean tick resets to `0` with `last_success`.