### PR TITLE
fix(surplus): humanize brainstorm findings in Telegram (strip JSON fences)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Surplus brainstorm messages read like prose, not raw JSON** — Genesis's background
+  brainstorm ideas posted to the Telegram "Surplus" topic now render as clean bulleted text
+  (idea, detail, and why it matters) instead of the raw ```json``` code block the model
+  produces. Plain-text and non-JSON messages are unaffected.
+
 - **The neural monitor labels every cognitive call site honestly.** Eight call sites
   that previously showed blank (the eval judge, voice conversation, session observer,
   task pre-mortem, intelligence intake, both resume-review passes, and the executor's

--- a/src/genesis/surplus/executor.py
+++ b/src/genesis/surplus/executor.py
@@ -49,6 +49,60 @@ def _parse_search_queries(llm_output: str, max_queries: int = 5) -> list[str]:
     return queries
 
 
+# Matches ONLY a whole-message ```json fence (case-insensitive tag). `$` without
+# re.MULTILINE anchors to end-of-string, so combined with re.DOTALL the match
+# spans the entire message — inline fences (mid-text) and other-language blocks
+# (```python, bare ```) are deliberately NOT matched and pass through untouched.
+_FENCE_RE = re.compile(r"^\s*```(?i:json)\s*\n?(.*?)\n?\s*```\s*$", re.DOTALL)
+
+
+def _humanize_surplus_content(content: str) -> str:
+    """Render a surplus brainstorm findings-JSON payload as readable prose.
+
+    ``BRAINSTORM_USER``/``BRAINSTORM_SELF`` tasks are prompted to return
+    ``{"findings": [{"title", "content", "relevance", ...}]}`` wrapped in a
+    ```json fence.  Posted raw, the user sees ```json{...}``` in the Surplus
+    Telegram topic.  This unwraps a whole-message ```json fence and, when the
+    payload is a findings list, renders plain-text bullets.
+
+    Non-findings JSON and plain text are returned unchanged.  A malformed
+    ```json fence is still unwrapped (so no stray ```json reaches the user),
+    but non-JSON code fences (``` ```python ```, bare ``` ``` ```) are left
+    untouched.  Never raises.
+    """
+    if not content:
+        return content
+    text = content.strip()
+    match = _FENCE_RE.match(text)
+    unwrapped = match.group(1).strip() if match else text
+    try:
+        data = json.loads(unwrapped)
+    except (ValueError, TypeError):
+        # Not JSON — return the fence-unwrapped inner text when we unwrapped a
+        # whole-message fence, otherwise the original content untouched.
+        return unwrapped if match else content
+    findings = data.get("findings") if isinstance(data, dict) else None
+    if not isinstance(findings, list) or not findings:
+        return unwrapped if match else content
+    blocks: list[str] = []
+    for item in findings:
+        if not isinstance(item, dict):
+            continue
+        title = str(item.get("title") or "").strip()
+        body = str(item.get("content") or "").strip()
+        relevance = str(item.get("relevance") or "").strip()
+        lines: list[str] = []
+        if title:
+            lines.append(f"• {title}")
+        if body:
+            lines.append(body)
+        if relevance:
+            lines.append(f"Why: {relevance}")
+        if lines:
+            blocks.append("\n".join(lines))
+    return "\n\n".join(blocks) if blocks else (unwrapped if match else content)
+
+
 async def _fetch_search_results(queries: list[str]) -> str:
     """Fetch web search results for parsed queries.
 
@@ -750,6 +804,9 @@ class SurplusLLMExecutor:
         try:
             from html import escape
 
+            # Brainstorm tasks return fenced findings-JSON; render it as prose
+            # so the user never sees raw ```json{...}``` in the Surplus topic.
+            content = _humanize_surplus_content(content)
             label = task.task_type.replace("_", " ").title()
             # quote=False: keep &/</> escaped (needed so the <b> label parses under
             # parse_mode=HTML) but leave " and ' raw. With quote=True, html.escape turns

--- a/tests/test_surplus/test_executor.py
+++ b/tests/test_surplus/test_executor.py
@@ -10,6 +10,7 @@ import pytest
 from genesis.surplus.executor import (
     StubExecutor,
     SurplusLLMExecutor,
+    _humanize_surplus_content,
     _read_essential_knowledge,
     _read_user_model_compact,
 )
@@ -81,6 +82,83 @@ async def test_post_to_telegram_keeps_quotes_raw():
 async def test_no_error():
     result = await StubExecutor().execute(_make_task())
     assert result.error is None
+
+
+# ── _humanize_surplus_content (strip ```json fences → readable prose) ──
+
+
+def test_humanize_renders_fenced_findings():
+    raw = (
+        "```json\n"
+        '{"findings": [{"title": "Idea A", "content": "Do the thing",'
+        ' "relevance": "Saves time", "sources": []}]}\n'
+        "```"
+    )
+    out = _humanize_surplus_content(raw)
+    assert "```" not in out
+    assert "findings" not in out and "json" not in out.lower()
+    assert "• Idea A" in out
+    assert "Do the thing" in out
+    assert "Why: Saves time" in out
+
+
+def test_humanize_bare_json_findings_no_fence():
+    raw = '{"findings": [{"title": "T", "content": "B", "relevance": "R"}]}'
+    out = _humanize_surplus_content(raw)
+    assert "```" not in out and "findings" not in out
+    assert "• T" in out and "B" in out and "Why: R" in out
+
+
+def test_humanize_multiple_findings():
+    raw = '{"findings": [{"title": "A", "content": "a"}, {"title": "B", "content": "b"}]}'
+    out = _humanize_surplus_content(raw)
+    assert "• A" in out and "• B" in out
+    assert out.count("•") == 2
+
+
+def test_humanize_non_findings_json_unchanged():
+    # A JSON object without a findings list is returned verbatim — protects the
+    # keeps-quotes-raw regression and avoids mangling other structured output.
+    raw = '{"title": "Jay\'s plan & <next> steps"}'
+    assert _humanize_surplus_content(raw) == raw
+
+
+def test_humanize_plain_prose_unchanged():
+    raw = "System looks healthy. No action needed right now."
+    assert _humanize_surplus_content(raw) == raw
+
+
+def test_humanize_non_json_code_fence_untouched():
+    # Only ```json fences are unwrapped; legitimate code blocks pass through.
+    raw = "```python\nx = 1\n```"
+    assert _humanize_surplus_content(raw) == raw
+
+
+def test_humanize_malformed_json_in_fence_no_raise():
+    raw = "```json\n{not valid json,,,\n```"
+    out = _humanize_surplus_content(raw)  # must not raise
+    assert "```" not in out  # whole-message fence unwrapped
+    assert "not valid json" in out
+
+
+@pytest.mark.asyncio
+async def test_post_to_telegram_strips_json_fences():
+    """Fenced brainstorm findings are humanized before reaching Telegram."""
+    ex = object.__new__(SurplusLLMExecutor)
+    ex._topic_manager = AsyncMock()
+    content = (
+        "```json\n"
+        '{"findings": [{"title": "Wire X", "content": "Connect A to B",'
+        ' "relevance": "Closes the gap"}]}\n'
+        "```"
+    )
+    await ex._post_to_telegram(_make_task(), content)
+
+    ex._topic_manager.send_to_category.assert_called_once()
+    _category, sent_text = ex._topic_manager.send_to_category.call_args[0][:2]
+    assert "```" not in sent_text
+    assert '"findings"' not in sent_text  # the raw JSON key didn't leak
+    assert "Wire X" in sent_text and "Connect A to B" in sent_text
 
 
 # ── SurplusLLMExecutor tests ──────────────────────────────────────────


### PR DESCRIPTION
## Problem
Surplus `BRAINSTORM_USER`/`BRAINSTORM_SELF` tasks are prompted to return a fenced `{"findings":[{title,content,relevance,...}]}` JSON object. `_post_to_telegram` posted that verbatim, so the user saw a raw ```json{...}``` code block in the Telegram "surplus" topic on every brainstorm.

## Fix
New `_humanize_surplus_content` helper, called once at the top of `_post_to_telegram`:
- Unwraps a whole-message ```json fence and, when the payload is a findings list, renders plain-text bullets (title / body / `Why:` relevance).
- Non-findings JSON, plain text, and non-JSON code fences (```python, bare ```) pass through untouched.
- Never raises. Only the Telegram post is humanized; the stored insight content is left raw for downstream consumers.

Complements #665 (which kept quotes raw); this strips the fences.

## Verification
- Unit + integration tests (humanizer edge cases + `_post_to_telegram` integration), incl. a regression test that the existing keeps-quotes-raw behavior is unchanged.
- Full `tests/test_surplus/` suite green (199).
- In-process e2e: a realistic multi-finding payload renders as clean bulleted prose with no fences or JSON keys.