### PR TITLE
fix(eval): grading integrity — MRR by retrieval rank, judge errors not silent 0.0, persist metadata_json (WS-11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   brainstorm ideas posted to the Telegram "Surplus" topic now render as clean bulleted text
   (idea, detail, and why it matters) instead of the raw ```json``` code block the model
   produces. Plain-text and non-JSON messages are unaffected.
+- **Genesis's self-quality metrics are trustworthy again.** Three bugs were corrupting the
+  numbers Genesis uses to judge its own competence (the J9 readiness grades and the quality
+  gate that decides which self-improvements ship): the memory retrieval-quality metric (MRR)
+  was computed against database arrival order instead of the actual retrieval rank, making it
+  meaningless; and when the LLM judge returned a malformed verdict (valid JSON but missing the
+  score), it was silently recorded as a confident "0 / fail" instead of an error — quietly
+  polluting the quality gate and calibration. Both now reflect reality, so the readiness grades
+  and ship-gate are honest.
 
 - **The neural monitor labels every cognitive call site honestly.** Eight call sites
   that previously showed blank (the eval judge, voice conversation, session observer,

--- a/src/genesis/eval/db.py
+++ b/src/genesis/eval/db.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import aiosqlite
 
-from genesis.eval.types import EvalRunSummary
+from genesis.eval.types import EvalRunSummary, ScorerType
 
 
 async def insert_run(
@@ -51,8 +51,8 @@ async def insert_run(
             """INSERT INTO eval_results
                (id, run_id, case_id, input_text, expected_output, actual_output,
                 score, passed, skipped, scorer_type, scorer_detail, latency_ms,
-                input_tokens, output_tokens, cost_usd, created_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                input_tokens, output_tokens, cost_usd, created_at, metadata_json)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 uuid.uuid4().hex,
                 run_id,
@@ -70,6 +70,15 @@ async def insert_run(
                 result.output_tokens,
                 result.cost_usd,
                 now,
+                # migration 0014's documented dual-write: the structurally-
+                # queryable JSON view. ONLY the LLM-judge scorer packs JSON into
+                # scorer_detail; other scorers put a plain string there, which
+                # must NOT land in a column whose value is JSON-queryability.
+                (
+                    result.scorer_detail
+                    if result.scorer_type == ScorerType.LLM_JUDGE
+                    else None
+                ),
             ),
         )
 

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -170,7 +170,11 @@ async def _compute_memory_quality(
     total_recalls = len(by_recall)
 
     for _rid, memories in by_recall.items():
-        # Sort by original position (memory_ids order in recall_fired)
+        # Sort by retrieval rank (the memory's memory_ids[:5] position, persisted
+        # in each event's metrics by j9_batch). Events arrive in concurrent-insert /
+        # timestamp-DESC order, so list order is NOT the rank — without this sort
+        # MRR is meaningless. Pre-fix historical events lack a rank → sort last.
+        memories.sort(key=lambda m: m.get("rank", 1 << 30))
         relevant_count = sum(1 for m in memories if m.get("relevance", 0) >= 0.5)
         precisions.append(relevant_count / max(len(memories), 1))
 

--- a/src/genesis/eval/j9_batch.py
+++ b/src/genesis/eval/j9_batch.py
@@ -125,24 +125,29 @@ class J9EvalBatchExecutor:
         )
 
         # Build the judgment worklist (skipping already-judged pairs).
-        worklist: list[tuple[dict, str, str]] = []
+        worklist: list[tuple[dict, str, str, int]] = []
         for event in recall_events:
             metrics = event.get("metrics", {})
             query = metrics.get("query", "")
             memory_ids = metrics.get("memory_ids", [])
             if not query or not memory_ids:
                 continue
-            for mid in memory_ids[:5]:  # Cap at top-5 per recall
+            # rank = the memory's position in this recall's memory_ids[:5] (1-5),
+            # persisted per relevance event so the aggregator computes MRR by
+            # retrieval rank — not by concurrent-insert / DB (timestamp DESC) order.
+            for rank, mid in enumerate(memory_ids[:5], 1):  # Cap at top-5 per recall
                 if (event["id"], mid) in already_judged:
                     continue
-                worklist.append((event, query, mid))
+                worklist.append((event, query, mid, rank))
 
         scored = 0
         errors = 0
         deferred = 0
         sem = asyncio.Semaphore(_MAX_CONCURRENT_JUDGES)
 
-        async def _judge_and_store(index: int, event: dict, query: str, mid: str) -> None:
+        async def _judge_and_store(
+            index: int, event: dict, query: str, mid: str, rank: int,
+        ) -> None:
             nonlocal scored, errors, deferred
             # Deadline check before acquiring a slot — past the budget, defer
             # the rest to the next (checkpointed) run rather than risk the
@@ -173,6 +178,7 @@ class J9EvalBatchExecutor:
                         metrics={
                             "recall_event_id": event["id"],
                             "memory_id": mid,
+                            "rank": rank,
                             "relevance": relevance,
                             "judge_rationale": rationale,
                             "judge_model": model_used,
@@ -184,8 +190,8 @@ class J9EvalBatchExecutor:
 
         results = await asyncio.gather(
             *(
-                _judge_and_store(i, event, query, mid)
-                for i, (event, query, mid) in enumerate(worklist)
+                _judge_and_store(i, event, query, mid, rank)
+                for i, (event, query, mid, rank) in enumerate(worklist)
             ),
             return_exceptions=True,
         )
@@ -396,7 +402,12 @@ class J9EvalBatchExecutor:
             text = result.content or ""
             # Parse JSON response
             parsed = json.loads(text.strip())
-            relevance = float(parsed.get("relevance", 0.0))
+            if "relevance" not in parsed:
+                # Valid JSON but no 'relevance' — route to the error path (None)
+                # so it is NOT stored as a fake relevance=0.0 event that would
+                # silently pollute precision@5 / MRR.
+                raise ValueError("judge response missing required 'relevance' key")
+            relevance = float(parsed["relevance"])
             rationale = parsed.get("rationale", "")
             return (max(0.0, min(1.0, relevance)), rationale, model_used)
         except (json.JSONDecodeError, KeyError, ValueError) as exc:

--- a/src/genesis/eval/reflection_golden_set.py
+++ b/src/genesis/eval/reflection_golden_set.py
@@ -208,7 +208,11 @@ async def _grade_observation(
 
     try:
         parsed = json.loads(text)
-        score = float(parsed.get("score", 0.0))
+        if "score" not in parsed:
+            # Valid JSON but no 'score' — raise so the caller counts it as an
+            # error rather than mislabeling the golden case with a silent 0.0.
+            raise ValueError("judge response missing required 'score' key")
+        score = float(parsed["score"])
         score = max(0.0, min(1.0, score))
         rationale = str(parsed.get("rationale", ""))
         return score, rationale, used_model or "unknown"

--- a/src/genesis/eval/scorers.py
+++ b/src/genesis/eval/scorers.py
@@ -353,7 +353,12 @@ class LLMJudgeScorer(Scorer):
         extracted = _extract_json(raw)
         try:
             parsed = json.loads(extracted)
-            score_val = float(parsed.get("score", 0.0))
+            if "score" not in parsed:
+                # Valid JSON but no top-level 'score' — route to the parse-fail
+                # sentinel (below) instead of silently recording a confident 0.0,
+                # which calibration would miscount as a disagreement, not an error.
+                raise ValueError("judge response missing required 'score' key")
+            score_val = float(parsed["score"])
             rationale = str(parsed.get("rationale", ""))
         except (json.JSONDecodeError, ValueError, TypeError) as exc:
             logger.debug(

--- a/tests/test_eval/test_calibration.py
+++ b/tests/test_eval/test_calibration.py
@@ -246,3 +246,25 @@ def test_render_report_blocked_verdict():
     md = render_report(result)
     assert "**Verdict:** BLOCKED" in md
     assert "do NOT promote" in md
+
+
+async def test_grade_observation_missing_score_raises(monkeypatch):
+    """_grade_observation must RAISE on a judge response that is valid JSON but
+    lacks the 'score' key — so the caller counts it as an error — rather than
+    silently grading it 0.0 and mislabeling a golden-set case.
+    """
+    from types import SimpleNamespace
+
+    import genesis.eval.reflection_golden_set as rgs
+
+    async def _fake_acompletion(*args, **kwargs):
+        return SimpleNamespace(choices=[
+            SimpleNamespace(message=SimpleNamespace(
+                content='{"rationale": "valid json, no score key"}')),
+        ])
+
+    monkeypatch.setattr("litellm.acompletion", _fake_acompletion)
+    monkeypatch.setattr(rgs, "_ensure_secrets", lambda: None)
+
+    with pytest.raises(ValueError, match="score"):
+        await rgs._grade_observation("some observation text", "session context")

--- a/tests/test_eval/test_j9_batch.py
+++ b/tests/test_eval/test_j9_batch.py
@@ -84,6 +84,29 @@ async def test_judges_all_memories_happy_path(db):
     assert await _relevance_pairs(db) == {(eid, "m1"), (eid, "m2"), (eid, "m3")}
 
 
+async def test_missing_relevance_key_not_stored_as_zero(db):
+    """A judge response that is valid JSON but LACKS the 'relevance' key must be
+    treated as an ERROR (not stored), NOT recorded as a fake relevance=0.0
+    event that silently pollutes precision@5 / MRR with a false 'irrelevant'.
+    """
+    class _NoRelevanceRouter:
+        async def route_call(self, call_site_id, messages, *, chain_offset=0, **kwargs):
+            return SimpleNamespace(
+                success=True, provider_used="fake", model_id="fake-judge",
+                content=json.dumps({"rationale": "forgot the relevance field"}),
+                error=None,
+            )
+
+    await _seed_recall(db, query="q", memory_ids=["m1"])
+    ex = J9EvalBatchExecutor(db=db, router=_NoRelevanceRouter())
+
+    result = await ex.execute(_task())
+
+    assert result.success
+    # Missing key → judge error → the pair is NOT stored (no fake 0.0 event).
+    assert await _relevance_pairs(db) == set()
+
+
 async def test_checkpoint_skips_already_judged(db):
     eid = await _seed_recall(db, query="q", memory_ids=["m1", "m2"])
     # Pre-existing judgment for (eid, m1) — simulates a prior partial/retry.

--- a/tests/test_eval/test_j9_eval.py
+++ b/tests/test_eval/test_j9_eval.py
@@ -538,3 +538,90 @@ async def test_memory_quality_ignores_duplicate_relevance(db):
     assert total_recalls == 1
     assert metrics["precision_at_5"] == 0.5
     assert metrics["total_memories_judged"] == 2  # deduped, not 3
+
+
+async def test_memory_quality_mrr_uses_stored_rank_not_insert_order(db):
+    """MRR must use the retrieval rank persisted in the event metrics, NOT the
+    DB/insert order. recall_relevance events are inserted CONCURRENTLY (arbitrary
+    order, read back ORDER BY timestamp DESC), so list order != retrieval rank.
+
+    Insert the only RELEVANT memory at rank 3 LAST (so it's returned FIRST by
+    timestamp DESC); MRR must be 1/3 (first relevant is at rank 3), not 1/1.
+    """
+    from genesis.eval.j9_aggregator import _compute_memory_quality
+
+    # Out of rank order: rank-1 (irrelevant) first … rank-3 (relevant) last.
+    await j9_eval.insert_event(
+        db, dimension="memory", event_type="recall_relevance",
+        metrics={"recall_event_id": "r1", "memory_id": "m1", "relevance": 0.0, "rank": 1},
+    )
+    await j9_eval.insert_event(
+        db, dimension="memory", event_type="recall_relevance",
+        metrics={"recall_event_id": "r1", "memory_id": "m2", "relevance": 0.0, "rank": 2},
+    )
+    await j9_eval.insert_event(
+        db, dimension="memory", event_type="recall_relevance",
+        metrics={"recall_event_id": "r1", "memory_id": "m3", "relevance": 1.0, "rank": 3},
+    )
+
+    metrics, _ = await _compute_memory_quality(db, since="2000-01-01", until="2100-01-01")
+    # First relevant is at rank 3 → MRR ≈ 1/3 (aggregator rounds to 4dp).
+    # The bug would give 1.0 (relevant returned first by timestamp DESC).
+    assert metrics["mrr"] == pytest.approx(1.0 / 3.0, abs=1e-3)
+
+
+async def test_insert_run_persists_metadata_json_per_result(db):
+    """eval_results.metadata_json must be written (migration 0014's documented
+    dual-write) — it mirrors scorer_detail so calibration/drift tooling can
+    query the judge payload structurally without re-parsing scorer_detail.
+    """
+    import importlib
+    import json as _json
+
+    from genesis.eval import db as eval_db
+    from genesis.eval.types import (
+        EvalRunSummary,
+        EvalTrigger,
+        ScoredOutput,
+        ScorerType,
+        TaskCategory,
+    )
+
+    # eval_runs/eval_results come from migrations, not create_all_tables. Apply
+    # the full eval_results column chain: 0002 (create) → 0003 (skipped) →
+    # 0014 (metadata_json).
+    for _mig in (
+        "0002_add_eval_tables",
+        "0003_eval_results_skipped",
+        "0014_eval_results_metadata",
+    ):
+        await importlib.import_module(f"genesis.db.migrations.{_mig}").up(db)
+    await db.commit()
+
+    detail = _json.dumps({"judge_model": "x", "judge_score": 0.7, "rationale": "ok"})
+    summary = EvalRunSummary(
+        run_id="run_meta_1", model_id="m", model_profile="p", dataset="d",
+        trigger=EvalTrigger.MANUAL, task_category=TaskCategory.CLASSIFICATION,
+        total_cases=2, passed_cases=2, failed_cases=0,
+        results=[
+            ScoredOutput(
+                case_id="c1", passed=True, score=0.7, actual_output="out",
+                scorer_type=ScorerType.LLM_JUDGE, scorer_detail=detail,
+            ),
+            # Non-judge scorer: scorer_detail is a plain (non-JSON) string, so
+            # metadata_json (the queryable JSON view) must be NULL, not that string.
+            ScoredOutput(
+                case_id="c2", passed=True, score=1.0, actual_output="3",
+                scorer_type=ScorerType.EXACT_MATCH, scorer_detail="expected=3, got=3",
+            ),
+        ],
+    )
+    await eval_db.insert_run(db, summary)
+    rows = {
+        r[0]: r[1]
+        for r in await (await db.execute(
+            "SELECT case_id, metadata_json FROM eval_results WHERE run_id = 'run_meta_1'"
+        )).fetchall()
+    }
+    assert rows["c1"] == detail  # judge result → JSON dual-write
+    assert rows["c2"] is None  # non-judge result → NULL (not the plain string)

--- a/tests/test_eval/test_llm_judge_scorer.py
+++ b/tests/test_eval/test_llm_judge_scorer.py
@@ -332,3 +332,25 @@ async def test_set_router_after_construction(simple_rubric):
     )
     assert passed is True
     assert score == 0.6
+
+
+async def test_score_async_valid_json_missing_score_is_parse_fail(simple_rubric):
+    """Valid JSON LACKING the top-level 'score' key must route to parse_fail —
+    NOT be recorded as a confident 0.0. Otherwise calibration miscounts it as a
+    disagreement (user graded higher) instead of an error, polluting the ego
+    quality gate. The output_quality rubric invites this: it asks for
+    coherence/relevance/completeness PLUS a composite 'score', and a model can
+    return the parts but forget the composite.
+    """
+    router = StubRouter(
+        response_content='{"coherence": 0.8, "relevance": 0.7, "rationale": "no composite"}',
+    )
+    s = LLMJudgeScorer(router=router)
+    passed, score, detail_json = await s.score_async(
+        "a", "b", {"rubric_name": "test_simple"},
+    )
+    assert passed is False
+    assert score == 0.0
+    detail = json.loads(detail_json)
+    assert detail["error"] == "judge_parse_fail"
+    assert "score" in detail["error_message"].lower()


### PR DESCRIPTION
## WS-11 — Eval Grading Integrity (audit P4). **HELD for merge.**

Three integrity bugs in the offline J9 eval pipeline — the metrics the self-model trusts (J9 readiness grades, the ego quality gate, rubric-promotion calibration). Closes `j9-01`/`EVAL-R2-03`, `EVAL-R2-01`, `EVAL-R2-02`. (`#592`/`#604-606` fixed attribution/resume, not these.)

### 1. MRR by retrieval rank (`j9-01` / `EVAL-R2-03`)
MRR was computed over DB/insert order, not retrieval rank — the "sort by original position" comment never executed, and `recall_relevance` events are inserted **concurrently** (read back `ORDER BY timestamp DESC`). Now the `memory_ids[:5]` rank is persisted per event (`j9_batch`) and the aggregator **sorts by it** (`j9_aggregator`). Forward-only (pre-fix events lack rank → sort last).

### 2. Judge errors no longer silently score 0.0 (`EVAL-R2-01`)
A judge returning valid JSON **without** a `score`/`relevance` key was recorded as a confident `0.0` — miscounted by calibration as a *disagreement*, not an *error*, polluting the ego quality gate. Each of the 3 sites now routes a missing key to its existing error path: `scorers.py` → `_JUDGE_PARSE_FAIL`; `reflection_golden_set` → `raise` (caller counts an error); `j9_batch._judge_relevance` → `(None, …)` so it is **not** stored as a fake `relevance=0.0` event that pollutes precision/MRR.

### 3. `eval_results.metadata_json` written (`EVAL-R2-02`)
`insert_run` now writes it (migration 0014's documented dual-write) — the judge's JSON payload, queryable without re-parsing `scorer_detail`. **Gated to the LLM-judge scorer** (other scorers' `scorer_detail` is a plain string, not JSON).

### Verification
- TDD: 5 new tests + full `test_eval/` (134) green; ruff clean.
- Code review: 1 P2 fixed (gate `metadata_json` to the judge scorer so non-JSON details don't enter the queryable column); migration-0003 idempotency → follow-up.
- E2E: full **batch → aggregator** round-trip — the batch stores ranks 1/2/3, the aggregator computes MRR=0.333 (bug=1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)