### PR TITLE
feat(feedback): self-improvement soak-status MCP tool (dark)

### DIFF
--- a/src/genesis/db/crud/outcome_events.py
+++ b/src/genesis/db/crud/outcome_events.py
@@ -129,18 +129,34 @@ async def count_by_signal_type(db: aiosqlite.Connection) -> dict[str, int]:
     return {r[0]: r[1] for r in rows}
 
 
+async def count_by_tier(db: aiosqlite.Connection) -> dict[int, int]:
+    """Coverage accounting: row counts grouped by signal_tier (1/2/3).
+
+    signal_type does NOT map 1:1 to tier (``user_decision`` is T2 when it
+    carries a rationale, else T3), so the tier breakdown cannot be derived
+    from ``count_by_signal_type`` — it needs its own GROUP BY.
+    """
+    cur = await db.execute(
+        "SELECT signal_tier, COUNT(*) FROM outcome_events GROUP BY signal_tier"
+    )
+    rows = await cur.fetchall()
+    return {r[0]: r[1] for r in rows}
+
+
 async def aggregate_by_domain(
     db: aiosqlite.Connection,
     *,
-    days: int = 30,
+    days: int | None = 30,
     tier: int | None = None,
 ) -> list[dict]:
-    """Per-domain outcome rollup over a recent window.
+    """Per-domain outcome rollup.
 
-    ``tier`` optionally restricts to one signal tier (e.g. tier=1 for the
-    ground-truth view that downstream quality scoring should weight highest).
+    ``days`` bounds the window by ``occurred_at``; pass ``None`` for an
+    all-time rollup (so the per-domain breakdown reconciles with the lifetime
+    ``count_by_tier``/``count_by_signal_type`` totals). ``tier`` optionally
+    restricts to one signal tier (e.g. tier=1 for the ground-truth view that
+    downstream quality scoring should weight highest).
     """
-    cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
     sql = """
         SELECT domain,
                COUNT(*)                                                   AS n,
@@ -150,12 +166,17 @@ async def aggregate_by_domain(
                AVG(stated_confidence)                                     AS avg_confidence,
                AVG(prediction_error)                                      AS avg_prediction_error
         FROM outcome_events
-        WHERE occurred_at >= ?
     """
-    params: list = [cutoff]
+    clauses: list[str] = []
+    params: list = []
+    if days is not None:
+        clauses.append("occurred_at >= ?")
+        params.append((datetime.now(UTC) - timedelta(days=days)).isoformat())
     if tier is not None:
-        sql += " AND signal_tier = ?"
+        clauses.append("signal_tier = ?")
         params.append(tier)
+    if clauses:
+        sql += " WHERE " + " AND ".join(clauses)
     sql += " GROUP BY domain ORDER BY n DESC"
     cur = await db.execute(sql, params)
     rows = await cur.fetchall()

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -71,6 +71,7 @@ from genesis.mcp.health import j9_eval as _j9_eval  # noqa: E402, F401
 from genesis.mcp.health import manifest as _manifest  # noqa: E402
 from genesis.mcp.health import module_ops as _module_ops  # noqa: E402
 from genesis.mcp.health import provider as _provider  # noqa: E402
+from genesis.mcp.health import self_improvement_status  # noqa: E402, F401
 from genesis.mcp.health import session_control as _session_control  # noqa: E402
 from genesis.mcp.health import settings as _settings  # noqa: E402
 from genesis.mcp.health import status as _status  # noqa: E402

--- a/src/genesis/mcp/health/self_improvement_status.py
+++ b/src/genesis/mcp/health/self_improvement_status.py
@@ -1,0 +1,111 @@
+"""Self-improvement status MCP tool — soak observability for the Outcome Bus.
+
+Read-only surface for watching the Phase-1 DARK soak of the self-improvement
+control plane. It answers two questions a human needs while the bus accrues:
+how much ground-truth has it captured (tier/coverage), and how is the ego's
+calibration trending?
+
+It reads three existing CRUD surfaces directly — the Outcome Bus ledger
+(``outcome_events``) and the measure-only ego calibration snapshots — and does
+NOT rank, score, or change any behaviour. There is deliberately no ``worst_at``
+weakness ranking here: with the live data still all-positive and no consumer
+yet, the ranking semantics belong with the eventual consumer (the bus → 6th
+source of capability_map → Phase-3 orchestrator), not baked into a dark tool.
+Raw numbers; the human reading them applies judgement.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+
+async def _impl_self_improvement_status() -> dict:
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    _service = health_mcp_mod._service
+    if _service is None or _service._db is None:
+        return {"status": "unavailable", "message": "DB not initialized"}
+
+    db = _service._db
+    from genesis.db.crud import ego_calibration as cal_crud
+    from genesis.db.crud import outcome_events as oe_crud
+
+    tier_counts = await oe_crud.count_by_tier(db)
+    signal_type_counts = await oe_crud.count_by_signal_type(db)
+    total_events = sum(tier_counts.values())
+
+    # Per-domain T1 ground truth, ALL-TIME (days=None) so the breakdown
+    # reconciles with the lifetime tier_counts above. value is strictly 1.0/0.0
+    # for execution_outcome rows, so AVG(value) == success rate. Raw counts; no ranking.
+    domains_t1 = await oe_crud.aggregate_by_domain(db, tier=1, days=None)
+    t1_view = [
+        {
+            "domain": d["domain"],
+            "n": d["n"],
+            "success_rate": (
+                round(d["avg_value"], 3) if d["avg_value"] is not None else None
+            ),
+            "positive": d["positive"],
+            "negative": d["negative"],
+        }
+        for d in domains_t1
+    ]
+
+    # Measure-only ego calibration (separate store, no cognitive-path reader).
+    latest = await cal_crud.get_latest(db, domain="ego")
+    if latest is None:
+        calibration: dict = {
+            "status": "no_data",
+            "message": (
+                "No ego calibration snapshot yet — computed at 09:00/21:00 once "
+                "the Outcome Bus has ground-truth (T1) rows."
+            ),
+        }
+    else:
+        trend = await cal_crud.get_trend(db, domain="ego", limit=10)
+        calibration = {
+            "status": "ok",
+            "ece": latest["ece"],
+            "mce": latest["mce"],
+            "sample_count": latest["sample_count"],
+            "low_confidence": latest["low_confidence"],
+            "computed_at": latest["computed_at"],
+            "ece_trend": [t["ece"] for t in trend],  # newest first
+        }
+
+    return {
+        "status": "ok",
+        "bus_total_events": total_events,
+        # Stringify keys: FastMCP serialises through JSON (which coerces dict
+        # keys to strings), so present the same shape a client receives.
+        # "1" = ground-truth, "2" = rationale, "3" = coverage.
+        "tier_counts": {str(k): v for k, v in tier_counts.items()},
+        "signal_type_counts": signal_type_counts,
+        "t1_domains": t1_view,
+        "ego_calibration": calibration,
+        "note": (
+            "DARK soak instrument — reading this does NOT change behaviour. T1 "
+            "success_rate = AVG(value) over execution_outcome rows (1.0/0.0). No "
+            "ranking: raw data for human judgement. T1 feeds capability_map as a "
+            "6th source only after the soak (deferred follow-up)."
+        ),
+    }
+
+
+@mcp.tool()
+async def self_improvement_status() -> dict:
+    """What is the self-improvement Outcome Bus accumulating, and how is the ego's
+    confidence calibration trending?
+
+    Read-only soak instrument for the self-improvement control plane: bus
+    coverage by quality tier (T1 ground-truth > T2 rationale > T3 coverage) and
+    by signal_type, the per-domain T1 success picture (actual execution
+    outcomes, not user-approval proxies), and the ego Expected Calibration Error
+    (ECE) trend. DARK — reading this does NOT change Genesis's behaviour. No
+    ranking or scoring; raw data only.
+    """
+    return await _impl_self_improvement_status()

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -442,9 +442,14 @@ async def init(rt: GenesisRuntime) -> None:
                 rt.record_job_failure("procedure_promotion", str(exc))
                 logger.exception("Procedure promotion failed")
 
+        # CronTrigger instead of IntervalTrigger: IntervalTrigger resets its
+        # countdown on every server restart, so under frequent restarts the job
+        # can keep slipping its hour and never fire (same class of bug that bit
+        # user_model_evolution / process_reaper).  Runs at :30 past every hour
+        # (:15 is the process_reaper; hour-boundary minutes carry heavier jobs).
         rt._learning_scheduler.add_job(
             _run_procedure_promotion,
-            IntervalTrigger(hours=1),
+            CronTrigger(minute=30),
             id="procedure_promotion",
             max_instances=1,
             misfire_grace_time=600,

--- a/tests/feedback/test_self_improvement_status.py
+++ b/tests/feedback/test_self_improvement_status.py
@@ -1,0 +1,113 @@
+"""Tests for the self_improvement_status MCP tool (soak observability).
+
+DARK, read-only: the tool surfaces Outcome Bus coverage (tiers/signal_types),
+the per-domain T1 success picture, and the ego ECE trend — without ranking or
+changing behaviour. Exercises the _impl directly against a stubbed
+HealthDataService, mirroring the ego_calibration MCP surface test.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import ego_calibration as cal_crud
+from genesis.db.crud import outcome_events as oe
+from genesis.mcp.health.self_improvement_status import _impl_self_improvement_status
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """Full schema (outcome_events + ego_calibration_snapshots)."""
+    from genesis.db.schema import create_all_tables
+
+    path = str(tmp_path / "sis.db")
+    async with aiosqlite.connect(path) as conn:
+        await create_all_tables(conn)
+        await conn.commit()
+        yield conn
+
+
+class _StubService:
+    def __init__(self, _db):
+        self._db = _db
+
+
+@pytest.mark.asyncio
+async def test_unavailable_when_no_service(monkeypatch):
+    import genesis.mcp.health_mcp as hm
+
+    monkeypatch.setattr(hm, "_service", None, raising=False)
+    res = await _impl_self_improvement_status()
+    assert res["status"] == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_empty_db_is_coherent(db, monkeypatch):
+    import genesis.mcp.health_mcp as hm
+
+    monkeypatch.setattr(hm, "_service", _StubService(db), raising=False)
+    res = await _impl_self_improvement_status()
+    assert res["status"] == "ok"
+    assert res["bus_total_events"] == 0
+    assert res["tier_counts"] == {}
+    assert res["t1_domains"] == []
+    # No snapshot yet → no_data (never a spurious ece=0.0).
+    assert res["ego_calibration"]["status"] == "no_data"
+
+
+@pytest.mark.asyncio
+async def test_seeded_soak_snapshot(db, monkeypatch):
+    import genesis.mcp.health_mcp as hm
+
+    monkeypatch.setattr(hm, "_service", _StubService(db), raising=False)
+
+    # T1 ground truth: dispatch 1 pass + 1 fail (→0.5), investigate 1 pass (→1.0)
+    await oe.record(
+        db, source="ego", ref_type="proposal", ref_id="d1",
+        signal_type="execution_outcome", signal_tier=1, domain="dispatch",
+        polarity="positive", value=1.0, stated_confidence=0.9,
+    )
+    await oe.record(
+        db, source="ego", ref_type="proposal", ref_id="d2",
+        signal_type="execution_outcome", signal_tier=1, domain="dispatch",
+        polarity="negative", value=0.0, stated_confidence=0.7,
+    )
+    await oe.record(
+        db, source="ego", ref_type="proposal", ref_id="i1",
+        signal_type="execution_outcome", signal_tier=1, domain="investigate",
+        polarity="positive", value=1.0,
+    )
+    # One T3 coverage row (neutral, no value) — must NOT contaminate the T1 view.
+    await oe.record(
+        db, source="ego", ref_type="proposal", ref_id="x1",
+        signal_type="dispatch", signal_tier=3, domain="approval",
+        polarity="neutral",
+    )
+    await cal_crud.record_snapshot(
+        db, domain="ego", ece=0.116, mce=0.45, sample_count=47,
+        bucket_count=5, low_confidence=False,
+        curve=[{"confidence_bucket": "0.8-0.9", "predicted_confidence": 0.85,
+                "actual_success_rate": 0.82, "sample_count": 22}],
+    )
+
+    res = await _impl_self_improvement_status()
+    assert res["status"] == "ok"
+    assert res["bus_total_events"] == 4
+    # Keys are stringified to match the JSON wire shape an MCP client receives.
+    assert res["tier_counts"] == {"1": 3, "3": 1}
+
+    t1 = {d["domain"]: d for d in res["t1_domains"]}
+    # The T3-only 'approval' domain must be ABSENT from the tier-1 view.
+    assert "approval" not in t1
+    assert t1["dispatch"]["n"] == 2
+    assert t1["dispatch"]["success_rate"] == 0.5
+    assert t1["dispatch"]["positive"] == 1
+    assert t1["dispatch"]["negative"] == 1
+    assert t1["investigate"]["success_rate"] == 1.0
+
+    cal = res["ego_calibration"]
+    assert cal["status"] == "ok"
+    assert cal["ece"] == 0.116
+    assert cal["low_confidence"] is False
+    assert cal["ece_trend"] == [0.116]

--- a/tests/test_db/test_outcome_events.py
+++ b/tests/test_db/test_outcome_events.py
@@ -227,6 +227,43 @@ class TestAggregates:
         assert d["n"] == 1
 
     @pytest.mark.asyncio
+    async def test_count_by_tier(self, db):
+        # Two T1, one T3 — tier cannot be derived from signal_type alone, so
+        # this needs its own GROUP BY (the soak instrument relies on it).
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="ct1",
+            signal_type="execution_outcome", signal_tier=1, domain="d",
+        )
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="ct2",
+            signal_type="execution_outcome", signal_tier=1, domain="e",
+        )
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="ct3",
+            signal_type="dispatch", signal_tier=3, domain="d",
+        )
+        assert await oe.count_by_tier(db) == {1: 2, 3: 1}
+
+    @pytest.mark.asyncio
+    async def test_count_by_tier_empty(self, db):
+        assert await oe.count_by_tier(db) == {}
+
+    @pytest.mark.asyncio
+    async def test_aggregate_all_time_window(self, db):
+        # A row outside the 30-day window is excluded by default but included
+        # when days=None — the all-time view the soak instrument uses so the
+        # per-domain breakdown reconciles with the lifetime tier counts.
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="old",
+            signal_type="execution_outcome", signal_tier=1, domain="d",
+            value=1.0, occurred_at="2020-01-01T00:00:00+00:00",
+        )
+        assert await oe.aggregate_by_domain(db, tier=1, days=30) == []
+        all_time = await oe.aggregate_by_domain(db, tier=1, days=None)
+        d = next(a for a in all_time if a["domain"] == "d")
+        assert d["n"] == 1
+
+    @pytest.mark.asyncio
     async def test_calibration_by_domain_requires_confidence_and_value(self, db):
         await oe.record(
             db, source="ego", ref_type="proposal", ref_id="c1",


### PR DESCRIPTION
## What & why

Adds the **soak-observability instrument** for the self-improvement Outcome Bus, plus a small unrelated scheduler-hardening fix. The Outcome Bus (#690/#692/#696) is deployed and in a 1–2 week **dark soak**, but nothing was watching it accrue. This adds a read-only MCP tool so the soak is observable.

Both changes are **DARK / behavior-neutral**: nothing in Genesis's cognitive paths reads them, and reading the tool changes no behavior.

## Commits

**`feat(feedback): self-improvement soak-status MCP tool (dark)`**
- New `mcp/health/self_improvement_status.py` — mirrors `ego_calibration.py` (lazy CRUD imports, `_service` guard, `@mcp.tool()`). Returns: bus coverage by tier (T1 ground-truth > T2 rationale > T3 coverage) + signal_type, the per-domain T1 success picture (actual execution outcomes, not approval proxies), and the ego ECE trend. No ranking — raw data for human judgement.
- `outcome_events.count_by_tier()` — `GROUP BY signal_tier` (signal_type is not 1:1 with tier, so it can't be derived from `count_by_signal_type`).
- `outcome_events.aggregate_by_domain(days=None)` — all-time option so the T1 per-domain breakdown reconciles with the lifetime tier counts.

**`fix(learning): procedure_promotion CronTrigger survives restarts`**
- `IntervalTrigger(hours=1)` → `CronTrigger(minute=30)`, matching the existing `process_reaper` precedent (the resets-on-restart class of bug). Preventive hardening — the job is currently firing fine.

## Why no `worst_at` / deficiency ranking?

A genesis-architect review ruled that a standalone deficiency reader would be a **second self-model overlapping the live `capability_map`**. The correct home for a T1 weakness view is as the 6th source of `compute_capability_map`, gated on the soak (tracked as a pinned follow-up). So this PR ships only the dark observability — no ranking.

## Verification
- `ruff` clean; **126 targeted tests** green (feedback + outcome_events CRUD + MCP health).
- Tool **registers** with FastMCP.
- **E2E against the live DB**: 777 events, tiers 47/58/672, ECE 0.116, 5 T1 domains all-positive; the T1 tier-count reconciles with the per-domain breakdown.
- DARK confirmed: only the MCP surface + tests reference the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
