### PR TITLE
fix(routing): third free fallback for procedure-extraction chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Procedure learning survives a two-provider outage** — the routine that captures reusable
+  procedures from Genesis's own struggles ran on only two free model providers; when both were
+  down at once it exhausted its chain and silently stopped learning. A third independent free
+  fallback now keeps it working through overlapping provider outages.
+
 - **A campaign that crashes mid-tick no longer fails silently** — when a scheduled campaign
   tick raises an error, Genesis now records it in job-health tracking, so the failure surfaces
   in the dashboard and to the ego instead of vanishing into the server log. Campaign

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -465,6 +465,7 @@ call_sites:
     chain:
     - openrouter-deepseek-v4
     - groq-free
+    - mistral-large-free
     default_paid: true
     description: Judge + store procedures from struggle detection and extraction
       pipeline candidates


### PR DESCRIPTION
## What
Add `mistral-large-free` as a third fallback to the `38_procedure_extraction` routing chain (previously `[openrouter-deepseek-v4, groq-free]`).

## Why
With only two free providers, a simultaneous OpenRouter + Groq outage exhausted the chain — live errors `"All providers exhausted for 38_procedure_extraction"` (2026-06-18) — silently halting the self-learning routine that captures reusable procedures from struggle detection.

`mistral-large-free` is an independent vendor (survives an OpenRouter+Groq outage), verified healthy in live routing (0 self-failures, actively rescuing other call sites).

## Verification
- Loaded the edited config through the real `genesis.routing.config.load_config` parser: chain resolves to **3 registered providers** (the parser raises on any unknown provider, so a clean load is a real reference check).
- Fallback-only: `mistral-large-free` fires only when the first two providers fail — can only add resilience, never changes primary routing.

## Risk
Minimal — single config line; no code paths changed.
