### PR TITLE
feat(memory): selective corrective retrieval (CRAG) on high-stakes recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis self-corrects a bad memory recall instead of running with it** — on high-stakes
+  lookups (the explicit memory and knowledge recall tools), Genesis now grades whether the
+  recalled results are actually on-topic, and when a recall comes back clearly irrelevant it
+  automatically tries again — broadening the search, drawing on the knowledge base, and (for
+  knowledge queries only) the web — rather than feeding itself off-topic context. Conservative
+  by design: confident recalls are left untouched, grading is skipped when results are already
+  strong, and it fails fast so it never slows a recall if the grader is unavailable. Latency-
+  sensitive paths (the proactive hook, voice, in-session context injection) are unaffected.
+
 - **The dashboard's Observations panel shows where each item stands** — every observation
   now carries a colour-coded stage badge: **new** (unread, still needs attention), **read**
   (Genesis has seen it), **acted** (it drove a proposal or follow-up), or **resolved**.

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -615,6 +615,20 @@ call_sites:
     default_paid: true
     description: "Contribution pipeline \u2014 evaluates whether a code change is\
       \ already fixed upstream"
+  crag_grade:
+    chain:
+    - openrouter-haiku
+    - mistral-small-free
+    - groq-free
+    - gemini-free
+    default_paid: true
+    retry_profile: user_facing
+    dispatch: api
+    description: "CRAG retrieval grader — scores topical relevance of a recalled\
+      \ memory to the query for selective corrective retrieval\
+      \ (memory_recall/knowledge_recall). Fast cross-vendor chain; the corrective\
+      \ pass fail-fasts (bounded grade step — returns original results if the\
+      \ grader is slow/down) and sheds under REDUCED degradation."
   judge:
     chain:
     - openrouter-deepseek-v4

--- a/src/genesis/eval/j9_hooks.py
+++ b/src/genesis/eval/j9_hooks.py
@@ -232,6 +232,44 @@ async def emit_recall_diagnostics(
         logger.debug("eval: failed to emit recall_diagnostics", exc_info=True)
 
 
+async def emit_recall_corrected(
+    db: aiosqlite.Connection,
+    *,
+    recall_event_id: str | None,
+    bucket: str,
+    grades: list[float | None],
+    action_taken: str,
+    result_count_before: int,
+    result_count_after: int,
+    latency_ms: float,
+) -> None:
+    """Log a selective-corrective-retrieval (CRAG) decision for calibration.
+
+    Fired by ``genesis.memory.corrective.maybe_correct_recall`` for every graded
+    recall — including the dark ``Ambiguous`` branch that takes no action — so the
+    grader's bucket thresholds can be calibrated against real recalls before the
+    corrective loop is widened beyond the conservative ``Incorrect``-only action.
+    Linked to the originating recall via ``subject_id=recall_event_id``.
+    """
+    try:
+        await j9_eval.insert_event(
+            db,
+            dimension="memory",
+            event_type="recall_corrected",
+            subject_id=recall_event_id,
+            metrics={
+                "bucket": bucket,
+                "grades": [round(g, 3) if g is not None else None for g in grades],
+                "action_taken": action_taken,
+                "count_before": result_count_before,
+                "count_after": result_count_after,
+                "latency_ms": round(latency_ms, 1),
+            },
+        )
+    except Exception:
+        logger.debug("eval: failed to emit recall_corrected", exc_info=True)
+
+
 async def emit_recall_used(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/eval/rubrics/memory_recall_grounding.py
+++ b/src/genesis/eval/rubrics/memory_recall_grounding.py
@@ -77,3 +77,62 @@ MEMORY_RECALL_GROUNDING = Rubric(
 
 
 register_rubric(MEMORY_RECALL_GROUNDING)
+
+
+# Runtime variant for selective corrective retrieval (W-CRAG). Identical relevance
+# rules, but DROPS the eval-only {expected} placeholder (a dataset label with no
+# runtime equivalent). Kept under a SEPARATE rubric name so runtime CRAG grading
+# traces never mix with eval-harness calibration history. See genesis.memory.corrective.
+_RUNTIME_PROMPT = """\
+You are grading the *topical relevance* of a recalled memory to a query.
+You are NOT grading the memory's truthfulness, its overall quality, its
+freshness, or whether it should exist — only whether it is topically
+related enough to the query that a downstream consumer (a human or
+another LLM) COULD draw on it while responding.
+
+Three rules, applied in order:
+
+1. **Topic overlap is the bar, not keyword overlap.** A memory that
+   shares the query's topic counts as relevant even if the wording
+   differs. A memory that shares only surface keywords (same noun, same
+   tool name) without addressing the query's actual subject is NOT
+   relevant.
+
+2. **You do not assess truth.** If the memory makes a claim that is
+   wrong, biased, outdated, or self-contradictory, that does NOT make
+   it irrelevant. A wrong-but-on-topic memory still scores as relevant.
+
+3. **Procedural / investigation / decision memories count as relevant**
+   if they record activity or reasoning about the query's topic.
+
+Query the user asked:
+{query}
+
+Memory that was recalled:
+{actual}
+
+Score the topical relevance from 0.0 (off-topic / unrelated) through
+0.5 (tangential but on-topic) to 1.0 (directly on-topic, clearly
+related). Brief rationale required.
+
+Respond with ONLY a JSON object, no markdown fences, no prose:
+{{"score": <float 0.0-1.0>, "rationale": "<one sentence>"}}"""
+
+
+MEMORY_RECALL_GROUNDING_RUNTIME = Rubric(
+    name="memory_recall_grounding_runtime",
+    version="1.0.0",
+    description=(
+        "Runtime CRAG grader — topical relevance of a recalled memory to a "
+        "query, for selective corrective retrieval (genesis.memory.corrective). "
+        "Same relevance rules as memory_recall_grounding but without the "
+        "eval-only {expected} placeholder, so runtime grading traces stay "
+        "separate from eval-harness calibration history."
+    ),
+    prompt_template=_RUNTIME_PROMPT,
+    pass_threshold=0.6,
+    extra_placeholders=("query",),
+)
+
+
+register_rubric(MEMORY_RECALL_GROUNDING_RUNTIME)

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -57,6 +57,7 @@ async def memory_recall(
     only_subsystem: str | list[str] | None = None,
     rerank: bool = True,
     include_deprecated: bool = False,
+    corrective: bool = True,
 ) -> list[dict]:
     """Hybrid search: Qdrant vectors + FTS5, RRF fusion, with optional graph enrichment.
 
@@ -249,9 +250,10 @@ async def memory_recall(
         ]
 
     # MCP-layer instrumentation: emit with mode and pipeline attribution
+    recall_event_id: str | None = None
     try:
         from genesis.eval.j9_hooks import emit_recall_fired
-        await emit_recall_fired(
+        recall_event_id = await emit_recall_fired(
             memory_mod._db,
             query=query,
             result_count=len(results),
@@ -307,6 +309,23 @@ async def memory_recall(
                     "Graph enrichment failed for %s", r.memory_id, exc_info=True,
                 )
         enriched.append(d)
+
+    # Selective corrective retrieval (CRAG) — high-stakes explicit recall path.
+    # Default ON; gated + fail-fast so a confident/healthy recall is untouched.
+    # NOTE: only the full (non-compact) path runs corrective — the compact branch
+    # above returns truncated previews with no gradeable content; those callers
+    # expand later via memory_expand. (compact-corrective: deferred follow-up.)
+    if corrective:
+        from genesis.memory.corrective import maybe_correct_recall
+        enriched = await maybe_correct_recall(
+            query=query,
+            results=enriched,
+            retriever=memory_mod._retriever,
+            db=memory_mod._db,
+            path="memory",
+            pipeline_used=pipeline_used,
+            recall_event_id=recall_event_id,
+        )
     return enriched
 
 

--- a/src/genesis/mcp/memory/knowledge.py
+++ b/src/genesis/mcp/memory/knowledge.py
@@ -57,6 +57,7 @@ async def knowledge_recall(
     domain: str | None = None,
     limit: int = 5,
     min_score: float = 0.15,
+    corrective: bool = True,
 ) -> list[dict]:
     """Search the knowledge base (ingested authoritative sources like docs, APIs, papers).
 
@@ -118,7 +119,39 @@ async def knowledge_recall(
             })
 
     boosted = _apply_authority_boost(merged)
-    return [r for r in boosted if r.get("score", 0.0) >= min_score][:limit]
+    final = [r for r in boosted if r.get("score", 0.0) >= min_score][:limit]
+
+    # Selective corrective retrieval (CRAG). Default ON; gated + fail-fast.
+    # path="knowledge" → web fallback is permitted on an Incorrect verdict
+    # (external knowledge is legitimately on the web; episodic memory is not).
+    if corrective:
+        # Emit recall_fired first so the recall_corrected calibration event can
+        # link back to it (subject_id) — matches memory_recall's behavior.
+        recall_event_id: str | None = None
+        try:
+            from genesis.eval.j9_hooks import emit_recall_fired
+            recall_event_id = await emit_recall_fired(
+                memory_mod._db,
+                query=query,
+                result_count=len(final),
+                top_scores=[r.get("score", 0.0) for r in final[:5]],
+                memory_ids=[r.get("unit_id", "") for r in final[:10]],
+                latency_ms=0.0,
+                source="knowledge",
+            )
+        except Exception:
+            pass  # instrumentation must never break recall
+
+        from genesis.memory.corrective import maybe_correct_recall
+        final = await maybe_correct_recall(
+            query=query,
+            results=final,
+            retriever=memory_mod._retriever,
+            db=memory_mod._db,
+            path="knowledge",
+            recall_event_id=recall_event_id,
+        )
+    return final
 
 
 async def _ingest_knowledge_unit(

--- a/src/genesis/memory/corrective.py
+++ b/src/genesis/memory/corrective.py
@@ -1,0 +1,651 @@
+"""Selective corrective retrieval (W-CRAG v1).
+
+Implements a CRAG-style grade-and-correct loop on top of the existing
+hybrid recall pipeline. The entry point ``maybe_correct_recall`` takes the
+results an MCP recall tool already produced, grades the top few against a
+calibrated relevance rubric, and — only when the recall looks genuinely
+*Incorrect* — performs one conservative round of corrective augmentation
+(relaxed re-retrieval, raw KB, and for knowledge queries a web fallback).
+
+Design constraints (all LOCKED — see the module spec):
+
+- **Best-effort.** Every public path is wrapped so that any failure or
+  timeout returns the ORIGINAL ``results`` unchanged. Corrective retrieval
+  must never degrade a recall that already worked.
+- **Conservative rollout.** ``Ambiguous`` verdicts take NO action (DARK
+  mode — log only). Only an unambiguous ``Incorrect`` triggers
+  augmentation, and only one round.
+- **Latency-aware.** A confident top score skips grading entirely; grading
+  is parallel, capped, and per-call timeout-bounded.
+- **No new dependencies.** Reranking reuses ``VoyageReranker`` (which
+  degrades to ``[]`` on failure) rather than any hand-rolled similarity.
+
+Calibration data (grades + the action that was/would-have-been taken) is
+logged for every graded recall via ``emit_recall_corrected`` so the dark
+``Ambiguous`` branch still produces training signal.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import math
+import re
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tunables (module-level constants per spec — adjust here, not inline)
+# ---------------------------------------------------------------------------
+
+# Latency pre-gate: if the top result already scores at/above this, treat the
+# recall as Correct and skip grading entirely. Avoids spending grader calls on
+# recalls that are obviously fine.
+_SKIP_GRADE_ABOVE = 0.75
+
+# How many top results to grade. Grading the whole list is wasteful; the
+# bucket decision only needs the strongest few candidates.
+_GRADE_TOP_N = 4
+
+# Relevance bar from the runtime rubric (memory_recall_grounding_runtime,
+# pass_threshold=0.6). At/above this an item is "relevant".
+_RELEVANT = 0.6
+
+# Below this the best item is not even tangentially on-topic → Incorrect.
+_INCORRECT_MAX = 0.3
+
+# Per-grade call timeout. Grading is a single short LLM judge call; if a
+# provider hangs we drop that item's grade rather than block the recall.
+_GRADE_TIMEOUT_S = 8.0
+
+# Max concurrent grader calls. Keeps load on the router bounded while still
+# grading the top-N in parallel.
+_GRADE_CONCURRENCY = 3
+
+# Web fallback is slow (search + fetch + rerank); give it a generous bound
+# and skip silently on timeout.
+_WEB_TIMEOUT_S = 25.0
+
+# Re-retrieval / output sizing.
+_ORIG_LIMIT = 10            # assumed original recall limit (MCP default)
+_RELAXED_LIMIT = _ORIG_LIMIT * 2  # relaxed re-retrieve fetches a wider net
+_KB_LIMIT = 10              # raw knowledge-base re-retrieve limit
+
+# Web refinement bounds.
+_WEB_MAX_URLS = 2          # fetch at most this many search-result URLs
+_WEB_TOP_CHUNKS = 3        # keep this many reranked paragraphs per snippet
+_WEB_SNIPPET_MAX_CHARS = 1500  # recomposed snippet cap
+
+
+# ---------------------------------------------------------------------------
+# Result-shape normalization
+# ---------------------------------------------------------------------------
+
+
+def _norm(r: dict) -> dict:
+    """Normalize a recall result dict to ``{"id", "content", "score"}``.
+
+    ``memory_recall`` results carry ``memory_id``/``content``/``score`` (and a
+    ``payload``); ``knowledge_recall`` results carry
+    ``unit_id``/``content``/``score`` (and an ``origin``). We grade against the
+    normalized view but always return the ORIGINAL dicts, so this is a read-only
+    projection.
+    """
+    rid = r.get("memory_id") or r.get("unit_id") or r.get("id") or ""
+    content = r.get("content", "") or ""
+    try:
+        score = float(r.get("score", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        score = 0.0
+    return {"id": str(rid), "content": content, "score": score}
+
+
+def _result_id(r: dict) -> str:
+    """Best-effort stable identity for dedup across original + augmented dicts."""
+    return _norm(r)["id"]
+
+
+# ---------------------------------------------------------------------------
+# Tolerant grade parse (mirrors LLMJudgeScorer.score_async, scorers.py ~330-390)
+# ---------------------------------------------------------------------------
+
+
+def _extract_json(text: str) -> str:
+    """Extract a JSON object from text that may have fences or prose.
+
+    Replicated from ``genesis.eval.scorers._extract_json`` to avoid importing a
+    private helper across module boundaries.
+    """
+    text = (text or "").strip()
+    try:
+        json.loads(text)
+        return text
+    except (json.JSONDecodeError, ValueError):
+        pass
+    m = re.search(r"```(?:json)?\s*\n?(.*?)\n?\s*```", text, re.DOTALL)
+    if m:
+        return m.group(1).strip()
+    for start_char, end_char in (("{", "}"), ("[", "]")):
+        start = text.find(start_char)
+        end = text.rfind(end_char)
+        if start != -1 and end > start:
+            candidate = text[start : end + 1]
+            try:
+                json.loads(candidate)
+                return candidate
+            except (json.JSONDecodeError, ValueError):
+                pass
+    return text
+
+
+def _parse_grade(raw: str | None) -> float | None:
+    """Parse ``{"score": float, "rationale": str}`` tolerantly.
+
+    Mirrors the scorers.py judge parse: strip fences, ``json.loads``, clamp to
+    [0, 1], reject non-finite. A grade that fails to parse returns ``None``
+    (unknown), NEVER 0.0 — an unparseable grade is missing data, not a verdict
+    of "irrelevant".
+    """
+    extracted = _extract_json(raw or "")
+    try:
+        parsed = json.loads(extracted)
+        score_val = float(parsed.get("score", None))  # type: ignore[arg-type]
+    except (json.JSONDecodeError, ValueError, TypeError, AttributeError):
+        return None
+    if not math.isfinite(score_val):
+        return None
+    return max(0.0, min(1.0, score_val))
+
+
+# ---------------------------------------------------------------------------
+# Router resolution (mirrors knowledge.py _get_orchestrator ~632)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_router() -> Any | None:
+    """Fetch the live router, bootstrapping standalone if needed.
+
+    Returns ``None`` if the router cannot be obtained — the caller then skips
+    grading and returns the original results.
+    """
+    try:
+        from genesis.runtime._core import GenesisRuntime
+
+        rt = GenesisRuntime.instance()
+        if rt._router is None:
+            from genesis.routing.standalone import create_standalone_router
+
+            create_standalone_router()
+        return rt._router
+    except Exception:
+        logger.debug("CRAG: router resolution failed", exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Grading
+# ---------------------------------------------------------------------------
+
+
+async def _grade_one(
+    router: Any,
+    semaphore: asyncio.Semaphore,
+    query: str,
+    content: str,
+    prompt_template: str,
+) -> float | None:
+    """Grade a single (query, content) pair. Returns score or None on failure.
+
+    Each call is concurrency-capped and timeout-bounded. A grader call that
+    fails with ``result.success == False`` (provider down / degradation-skipped)
+    returns ``None`` — that is NOT an Incorrect verdict, it is missing data.
+    """
+    prompt = prompt_template.format(query=query, actual=content)
+    async with semaphore:
+        try:
+            result = await asyncio.wait_for(
+                router.route_call(
+                    call_site_id="crag_grade",
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=0.0,
+                ),
+                timeout=_GRADE_TIMEOUT_S,
+            )
+        except TimeoutError:
+            logger.debug("CRAG: grade timed out")
+            return None
+        except Exception:
+            logger.debug("CRAG: grade call raised", exc_info=True)
+            return None
+
+    if not getattr(result, "success", False):
+        # Grader unavailable / degradation-skipped — unknown, not Incorrect.
+        return None
+    return _parse_grade(getattr(result, "content", None))
+
+
+async def _grade_results(
+    router: Any,
+    query: str,
+    normalized: list[dict],
+) -> list[float | None]:
+    """Grade the top-N normalized results in parallel. Returns aligned grades.
+
+    Returns a list the same length as the graded slice (top-N). Each entry is a
+    float score or ``None`` (failed/unparseable/timed-out).
+    """
+    from genesis.eval.rubrics import get_rubric
+
+    rubric = get_rubric("memory_recall_grounding_runtime")
+    template = rubric.prompt_template
+
+    semaphore = asyncio.Semaphore(_GRADE_CONCURRENCY)
+    to_grade = normalized[:_GRADE_TOP_N]
+    grades = await asyncio.gather(
+        *(
+            _grade_one(router, semaphore, query, item["content"], template)
+            for item in to_grade
+        ),
+        return_exceptions=True,
+    )
+    # gather(return_exceptions=True) can surface raised exceptions as objects;
+    # coerce anything that isn't a float|None into None.
+    cleaned: list[float | None] = []
+    for g in grades:
+        if isinstance(g, float):
+            cleaned.append(g)
+        else:
+            cleaned.append(None)
+    return cleaned
+
+
+def _bucket(grades: list[float | None]) -> str:
+    """Classify the recall from per-item grades.
+
+    - ``Correct``     — best graded score >= _RELEVANT.
+    - ``Incorrect``   — best graded score < _INCORRECT_MAX (nothing even
+      tangentially relevant).
+    - ``Ambiguous``   — otherwise (best score in the borderline band).
+
+    Assumes at least one non-None grade (caller guards the all-None case).
+    """
+    valid = [g for g in grades if g is not None]
+    best = max(valid)
+    if best >= _RELEVANT:
+        return "Correct"
+    if best < _INCORRECT_MAX:
+        return "Incorrect"
+    return "Ambiguous"
+
+
+# ---------------------------------------------------------------------------
+# Web fallback (knowledge path only)
+# ---------------------------------------------------------------------------
+
+
+async def _web_augment(query: str) -> list[dict]:
+    """Search + fetch + web-strip refine into result-shaped dicts.
+
+    ONLY called for ``path == "knowledge"``. Search the web, fetch the top 1-2
+    URLs, chunk each fetch into paragraphs, rerank the chunks against the query,
+    and recompose the top chunks into a bounded snippet. Every web call is
+    wrapped — any failure yields an empty list (skip web silently).
+    """
+    from genesis.mcp.health.web_tools import _impl_web_fetch, _impl_web_search
+    from genesis.memory.reranker import VoyageReranker
+
+    out: list[dict] = []
+    try:
+        search = await _impl_web_search(query, max_results=5)
+    except Exception:
+        logger.debug("CRAG: web_search failed", exc_info=True)
+        return out
+
+    urls: list[str] = []
+    for item in (search or {}).get("results", []):
+        u = item.get("url")
+        if u:
+            urls.append(u)
+        if len(urls) >= _WEB_MAX_URLS:
+            break
+    if not urls:
+        return out
+
+    reranker = VoyageReranker()
+    for url in urls:
+        try:
+            fetched = await _impl_web_fetch(url)
+        except Exception:
+            logger.debug("CRAG: web_fetch failed for %s", url, exc_info=True)
+            continue
+        text = (fetched or {}).get("content", "") or ""
+        if not text.strip():
+            continue
+
+        # Chunk into paragraphs; rerank for query relevance; recompose.
+        chunks = [c.strip() for c in re.split(r"\n\s*\n", text) if c.strip()]
+        if not chunks:
+            continue
+        docs = [{"id": str(i), "text": c} for i, c in enumerate(chunks)]
+        snippet = ""
+        score = 0.0
+        try:
+            reranked = await reranker.rerank(query, docs, top_k=_WEB_TOP_CHUNKS)
+        except Exception:
+            reranked = []
+        if reranked:
+            by_id = {d["id"]: d["text"] for d in docs}
+            picked = [by_id[r["id"]] for r in reranked if r["id"] in by_id]
+            score = float(reranked[0].get("score", 0.0) or 0.0)
+        else:
+            # Reranker degraded — fall back to leading chunks.
+            picked = chunks[:_WEB_TOP_CHUNKS]
+        snippet = "\n\n".join(picked)[:_WEB_SNIPPET_MAX_CHARS]
+        if snippet.strip():
+            # Match the knowledge_recall result shape (unit_id/origin) so web
+            # candidates survive merge + don't KeyError downstream consumers.
+            out.append({
+                "unit_id": url,
+                "id": url,
+                "content": snippet,
+                "score": score,
+                "origin": "web",
+                "source_pipeline": "crag_web",
+            })
+
+    with contextlib.suppress(Exception):
+        await reranker.close()
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Corrective augmentation (Incorrect bucket only)
+# ---------------------------------------------------------------------------
+
+
+def _retrieval_to_dict(rr: Any) -> dict:
+    """Convert a RetrievalResult to the memory_recall result dict shape."""
+    return {
+        "memory_id": getattr(rr, "memory_id", ""),
+        "content": getattr(rr, "content", ""),
+        "score": getattr(rr, "score", 0.0),
+        "payload": getattr(rr, "payload", {}) or {},
+    }
+
+
+async def _augment(
+    *,
+    query: str,
+    kept: list[dict],
+    retriever: Any,
+    path: str,
+) -> list[dict]:
+    """One conservative round of corrective augmentation.
+
+    Relaxed re-retrieve via the RAW retriever, raw KB, optional web (knowledge
+    path only), then merge with ``kept``, dedup, rerank, and trim to the
+    original limit. Returns result-shaped dicts.
+    """
+    from genesis.memory.reranker import VoyageReranker
+
+    candidates: list[dict] = list(kept)
+
+    # 1. Relaxed re-retrieve via the raw retriever (wide net, no filters).
+    try:
+        relaxed = await retriever.recall(
+            query,
+            limit=_RELAXED_LIMIT,
+            min_activation=0.0,
+            wing=None,
+            room=None,
+            life_domain=None,
+            expand_query_terms=True,
+            include_subsystem=True,
+            rerank=True,
+        )
+        candidates.extend(_retrieval_to_dict(rr) for rr in relaxed)
+    except Exception:
+        logger.debug("CRAG: relaxed re-retrieve failed", exc_info=True)
+
+    # 2. Raw knowledge-base retrieve.
+    try:
+        kb = await retriever.recall(query, source="knowledge", limit=_KB_LIMIT)
+        candidates.extend(_retrieval_to_dict(rr) for rr in kb)
+    except Exception:
+        logger.debug("CRAG: raw KB re-retrieve failed", exc_info=True)
+
+    # 3. Web fallback — knowledge path ONLY, never for memory.
+    if path == "knowledge":
+        try:
+            web = await asyncio.wait_for(_web_augment(query), timeout=_WEB_TIMEOUT_S)
+            candidates.extend(web)
+        except TimeoutError:
+            logger.debug("CRAG: web augment timed out")
+        except Exception:
+            logger.debug("CRAG: web augment failed", exc_info=True)
+
+    # 4. Dedup by id (fallback to content) preserving first occurrence.
+    deduped: list[dict] = []
+    seen: set[str] = set()
+    for c in candidates:
+        key = _result_id(c) or _norm(c)["content"][:120]
+        if key and key in seen:
+            continue
+        if key:
+            seen.add(key)
+        deduped.append(c)
+
+    # 5. Re-rank the merged set (degrade gracefully) and trim.
+    docs = []
+    for i, c in enumerate(deduped):
+        content = _norm(c)["content"]
+        if content:
+            docs.append({"id": str(i), "text": content})
+    if docs:
+        reranker = VoyageReranker()
+        try:
+            reranked = await reranker.rerank(query, docs, top_k=_ORIG_LIMIT)
+        except Exception:
+            reranked = []
+        finally:
+            with contextlib.suppress(Exception):
+                await reranker.close()
+        if reranked:
+            ordered = [deduped[int(r["id"])] for r in reranked if r["id"].isdigit()]
+            if ordered:
+                return ordered[:_ORIG_LIMIT]
+
+    return deduped[:_ORIG_LIMIT]
+
+
+# ---------------------------------------------------------------------------
+# Calibration logging
+# ---------------------------------------------------------------------------
+
+
+async def _log(
+    *,
+    db: Any,
+    recall_event_id: str | None,
+    bucket: str,
+    grades: list[float | None],
+    action_taken: str,
+    result_count_before: int,
+    result_count_after: int,
+    latency_ms: float,
+) -> None:
+    """Best-effort calibration log. Never raises (logging must not break recall)."""
+    try:
+        from genesis.eval.j9_hooks import emit_recall_corrected
+
+        await emit_recall_corrected(
+            db,
+            recall_event_id=recall_event_id,
+            bucket=bucket,
+            grades=grades,
+            action_taken=action_taken,
+            result_count_before=result_count_before,
+            result_count_after=result_count_after,
+            latency_ms=latency_ms,
+        )
+    except Exception:
+        logger.debug("CRAG: emit_recall_corrected unavailable", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def maybe_correct_recall(
+    *,
+    query: str,
+    results: list[dict],
+    retriever: Any,
+    db: Any,
+    path: str,
+    pipeline_used: str | None = None,
+    recall_event_id: str | None = None,
+    router: Any | None = None,
+) -> list[dict]:
+    """Selective corrective retrieval (CRAG).
+
+    Returns possibly-corrected results in the SAME dict shape as input.
+    BEST-EFFORT: must NEVER raise — on any failure or timeout, return the
+    ORIGINAL ``results`` unchanged.
+    """
+    _t0 = time.monotonic()
+
+    def _ms() -> float:
+        return (time.monotonic() - _t0) * 1000
+
+    try:
+        # Drift skip — auto_drift already corrected; don't double-correct.
+        if pipeline_used == "auto_drift":
+            return results
+
+        normalized = [_norm(r) for r in results]
+
+        # Latency pre-gate: a confidently-high top score is treated as Correct
+        # WITHOUT grading. (Empty recall has no top score → falls through to
+        # grading as a candidate "Incorrect".)
+        if normalized:
+            top_score = max(n["score"] for n in normalized)
+            if top_score >= _SKIP_GRADE_ABOVE:
+                return results
+
+        # Resolve the router; without it we cannot grade → return original.
+        active_router = router if router is not None else _resolve_router()
+        if active_router is None:
+            await _log(
+                db=db,
+                recall_event_id=recall_event_id,
+                bucket="skipped",
+                grades=[],
+                action_taken="skipped_no_router",
+                result_count_before=len(results),
+                result_count_after=len(results),
+                latency_ms=_ms(),
+            )
+            return results
+
+        # Grade the top-N. If grading can't run at all, keep original.
+        try:
+            grades = await _grade_results(active_router, query, normalized)
+        except Exception:
+            logger.debug("CRAG: grading failed", exc_info=True)
+            return results
+
+        if not any(g is not None for g in grades):
+            # Grader effectively unavailable (all None/failed) — not Incorrect.
+            await _log(
+                db=db,
+                recall_event_id=recall_event_id,
+                bucket="skipped",
+                grades=grades,
+                action_taken="skipped_grader_unavailable",
+                result_count_before=len(results),
+                result_count_after=len(results),
+                latency_ms=_ms(),
+            )
+            return results
+
+        bucket = _bucket(grades)
+
+        if bucket == "Correct":
+            # Keep only items graded >= _RELEVANT, preserve order. Items beyond
+            # the graded top-N have no grade → conservatively keep them.
+            kept: list[dict] = []
+            for i, r in enumerate(results):
+                if i < len(grades):
+                    g = grades[i]
+                    if g is None or g >= _RELEVANT:
+                        kept.append(r)
+                else:
+                    kept.append(r)
+            out = kept if kept else results
+            await _log(
+                db=db,
+                recall_event_id=recall_event_id,
+                bucket=bucket,
+                grades=grades,
+                action_taken="keep_relevant",
+                result_count_before=len(results),
+                result_count_after=len(out),
+                latency_ms=_ms(),
+            )
+            return out
+
+        if bucket == "Ambiguous":
+            # DARK: take NO action. Log only what would have happened.
+            await _log(
+                db=db,
+                recall_event_id=recall_event_id,
+                bucket=bucket,
+                grades=grades,
+                action_taken="dark_ambiguous",
+                result_count_before=len(results),
+                result_count_after=len(results),
+                latency_ms=_ms(),
+            )
+            return results
+
+        # bucket == "Incorrect" → ACT: one round of corrective augmentation.
+        # Keep any items that DID grade relevant (usually none for Incorrect).
+        kept_relevant: list[dict] = [
+            results[i]
+            for i, g in enumerate(grades)
+            if g is not None and g >= _RELEVANT and i < len(results)
+        ]
+        try:
+            corrected = await _augment(
+                query=query,
+                kept=kept_relevant,
+                retriever=retriever,
+                path=path,
+            )
+        except Exception:
+            logger.debug("CRAG: augmentation failed", exc_info=True)
+            corrected = results
+
+        out = corrected if corrected else results
+        await _log(
+            db=db,
+            recall_event_id=recall_event_id,
+            bucket=bucket,
+            grades=grades,
+            action_taken="augment",
+            result_count_before=len(results),
+            result_count_after=len(out),
+            latency_ms=_ms(),
+        )
+        return out
+
+    except Exception:
+        logger.warning("CRAG: maybe_correct_recall failed, returning original",
+                       exc_info=True)
+        return results

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -330,6 +330,12 @@ _CALL_SITE_META: dict[str, dict] = {
         "frequency": "Per J9 eval scoring",
         "model_tier": "frontier",
     },
+    "crag_grade": {
+        "description": "CRAG retrieval grader — scores topical relevance of recalled memories to the query for selective corrective retrieval (memory_recall/knowledge_recall), reusing the memory_recall_grounding_runtime rubric. Gated (only borderline/low recalls) + fail-fast (returns original results if slow/down). In routing/degradation._L2_SKIP so it sheds under REDUCED degradation. Caller: memory/corrective.py.",
+        "category": "assessment",
+        "frequency": "Per corrective recall (gated)",
+        "model_tier": "slm",
+    },
     "voice_conversation": {
         "description": "Realtime voice S2S conversational-turn generation. Free API chain (Groq/Gemini/Mistral) with user-facing retry profile (latency-sensitive). Caller: channels/voice/handler.py.",
         "category": "reasoning",

--- a/src/genesis/routing/degradation.py
+++ b/src/genesis/routing/degradation.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from genesis.resilience.state import ResilienceStateMachine
 
 # L2 (Reduced) skips these call sites
-_L2_SKIP = {"12_surplus_brainstorm", "13_morning_report", "judge"}
+_L2_SKIP = {"12_surplus_brainstorm", "13_morning_report", "judge", "crag_grade"}
 
 # L3 (Essential) only keeps these call sites.
 # Note: "2_triage" removed from this set 2026-05-10 alongside its removal from
@@ -25,7 +25,7 @@ _TMP_MODERATE_SKIP = {"12_surplus_brainstorm", "13_morning_report"}
 _TMP_HIGH_SKIP = _TMP_MODERATE_SKIP | {
     "5_deep_reflection", "6_strategic_reflection", "7_ego_cycle",
     "14_weekly_self_assessment", "16_quality_calibration",
-    "28_observation_sweep", "judge",
+    "28_observation_sweep", "judge", "crag_grade",
 }
 
 

--- a/tests/test_memory/test_corrective.py
+++ b/tests/test_memory/test_corrective.py
@@ -1,0 +1,415 @@
+"""Tests for genesis.memory.corrective — selective corrective retrieval (W-CRAG).
+
+Everything external is mocked: the router (route_call), the retriever (recall),
+the reranker, the web tools (_impl_web_search / _impl_web_fetch), and the j9
+calibration emit (emit_recall_corrected — added separately in j9_hooks).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genesis.memory import corrective
+from genesis.memory.corrective import (
+    _bucket,
+    _norm,
+    _parse_grade,
+    maybe_correct_recall,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _routing_result(*, success: bool, content: str | None) -> MagicMock:
+    """A RoutingResult-like object with .success and .content."""
+    r = MagicMock()
+    r.success = success
+    r.content = content
+    return r
+
+
+def _grade_content(score: float) -> str:
+    return json.dumps({"score": score, "rationale": "ok"})
+
+
+def _mem_result(mid: str, content: str, score: float) -> dict:
+    """memory_recall-shaped result dict."""
+    return {"memory_id": mid, "content": content, "score": score, "payload": {}}
+
+
+def _kb_result(uid: str, content: str, score: float) -> dict:
+    """knowledge_recall-shaped result dict."""
+    return {"unit_id": uid, "content": content, "score": score, "origin": "vector"}
+
+
+@pytest.fixture(autouse=True)
+def _patch_emit():
+    """Stub the j9 calibration emit so tests don't depend on its addition."""
+    with patch.object(corrective, "_log", new=AsyncMock(return_value=None)):
+        yield
+
+
+@pytest.fixture
+def retriever():
+    """A retriever whose .recall is an AsyncMock (no real re-retrieval)."""
+    r = MagicMock()
+    r.recall = AsyncMock(return_value=[])
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestNorm:
+    def test_memory_id_shape(self):
+        n = _norm(_mem_result("m1", "hello", 0.5))
+        assert n == {"id": "m1", "content": "hello", "score": 0.5}
+
+    def test_unit_id_shape(self):
+        n = _norm(_kb_result("u1", "world", 0.4))
+        assert n == {"id": "u1", "content": "world", "score": 0.4}
+
+    def test_missing_fields_default(self):
+        n = _norm({})
+        assert n == {"id": "", "content": "", "score": 0.0}
+
+    def test_non_numeric_score_coerces(self):
+        n = _norm({"memory_id": "m", "content": "c", "score": "oops"})
+        assert n["score"] == 0.0
+
+
+class TestParseGrade:
+    def test_plain_json(self):
+        assert _parse_grade(_grade_content(0.7)) == 0.7
+
+    def test_fenced_json(self):
+        raw = "```json\n" + _grade_content(0.42) + "\n```"
+        assert _parse_grade(raw) == 0.42
+
+    def test_clamps(self):
+        assert _parse_grade(json.dumps({"score": 1.5})) == 1.0
+        assert _parse_grade(json.dumps({"score": -0.2})) == 0.0
+
+    def test_unparseable_is_none(self):
+        assert _parse_grade("not json at all") is None
+
+    def test_non_finite_is_none(self):
+        assert _parse_grade(json.dumps({"score": float("inf")})) is None
+
+
+class TestBucket:
+    def test_correct(self):
+        assert _bucket([0.8, 0.2, None]) == "Correct"
+
+    def test_incorrect(self):
+        assert _bucket([0.1, 0.05, None]) == "Incorrect"
+
+    def test_ambiguous(self):
+        assert _bucket([0.45, 0.4]) == "Ambiguous"
+
+
+# ---------------------------------------------------------------------------
+# Behavior: drift skip
+# ---------------------------------------------------------------------------
+
+
+async def test_drift_skip_returns_original(retriever):
+    results = [_mem_result("m1", "x", 0.2)]
+    router = MagicMock()
+    router.route_call = AsyncMock()
+
+    out = await maybe_correct_recall(
+        query="q",
+        results=results,
+        retriever=retriever,
+        db=MagicMock(),
+        path="memory",
+        pipeline_used="auto_drift",
+        router=router,
+    )
+
+    assert out is results
+    router.route_call.assert_not_called()
+    retriever.recall.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Behavior: latency pre-gate
+# ---------------------------------------------------------------------------
+
+
+async def test_latency_pregate_skips_grading(retriever):
+    # Top score above _SKIP_GRADE_ABOVE (0.75) → no grading.
+    results = [_mem_result("m1", "x", 0.9), _mem_result("m2", "y", 0.1)]
+    router = MagicMock()
+    router.route_call = AsyncMock()
+
+    out = await maybe_correct_recall(
+        query="q",
+        results=results,
+        retriever=retriever,
+        db=MagicMock(),
+        path="memory",
+        router=router,
+    )
+
+    assert out is results
+    router.route_call.assert_not_called()
+    retriever.recall.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Behavior: grader success=False → not Incorrect
+# ---------------------------------------------------------------------------
+
+
+async def test_grader_failure_returns_original(retriever):
+    results = [_mem_result("m1", "x", 0.2)]
+    router = MagicMock()
+    # success=False simulates degradation-skip / provider down.
+    router.route_call = AsyncMock(
+        return_value=_routing_result(success=False, content=None),
+    )
+
+    out = await maybe_correct_recall(
+        query="q",
+        results=results,
+        retriever=retriever,
+        db=MagicMock(),
+        path="memory",
+        router=router,
+    )
+
+    assert out is results
+    # The grader was attempted but its failure must NOT trigger correction.
+    router.route_call.assert_called()
+    retriever.recall.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Behavior: all grades time out → return original
+# ---------------------------------------------------------------------------
+
+
+async def test_all_grades_timeout_returns_original(retriever):
+    results = [_mem_result("m1", "x", 0.2), _mem_result("m2", "y", 0.2)]
+    router = MagicMock()
+
+    async def _hang(*_a, **_k):
+        raise TimeoutError
+
+    router.route_call = AsyncMock(side_effect=_hang)
+
+    out = await maybe_correct_recall(
+        query="q",
+        results=results,
+        retriever=retriever,
+        db=MagicMock(),
+        path="memory",
+        router=router,
+    )
+
+    assert out is results
+    retriever.recall.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Behavior: Correct bucket drops sub-0.6 items
+# ---------------------------------------------------------------------------
+
+
+async def test_correct_bucket_drops_irrelevant(retriever):
+    results = [
+        _mem_result("m1", "relevant", 0.2),
+        _mem_result("m2", "irrelevant", 0.2),
+    ]
+    grades = iter([_grade_content(0.9), _grade_content(0.1)])
+    router = MagicMock()
+
+    async def _route(*_a, **_k):
+        return _routing_result(success=True, content=next(grades))
+
+    router.route_call = AsyncMock(side_effect=_route)
+
+    out = await maybe_correct_recall(
+        query="q",
+        results=results,
+        retriever=retriever,
+        db=MagicMock(),
+        path="memory",
+        router=router,
+    )
+
+    # Max grade 0.9 >= 0.6 → Correct; the 0.1 item is dropped.
+    assert len(out) == 1
+    assert out[0]["memory_id"] == "m1"
+    retriever.recall.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Behavior: Ambiguous = dark (no action, no retriever re-call)
+# ---------------------------------------------------------------------------
+
+
+async def test_ambiguous_is_dark(retriever):
+    results = [_mem_result("m1", "x", 0.2), _mem_result("m2", "y", 0.2)]
+    grades = iter([_grade_content(0.45), _grade_content(0.4)])
+    router = MagicMock()
+
+    async def _route(*_a, **_k):
+        return _routing_result(success=True, content=next(grades))
+
+    router.route_call = AsyncMock(side_effect=_route)
+
+    out = await maybe_correct_recall(
+        query="q",
+        results=results,
+        retriever=retriever,
+        db=MagicMock(),
+        path="memory",
+        router=router,
+    )
+
+    # Best grade 0.45 → Ambiguous → DARK: original returned, no re-retrieval.
+    assert out is results
+    retriever.recall.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Behavior: Incorrect on memory path → re-retrieve + raw KB, NEVER web
+# ---------------------------------------------------------------------------
+
+
+async def test_incorrect_memory_path_no_web(retriever):
+    results = [_mem_result("m1", "off-topic", 0.2)]
+    router = MagicMock()
+    router.route_call = AsyncMock(
+        return_value=_routing_result(success=True, content=_grade_content(0.05)),
+    )
+    # Re-retrieval returns one augmented RetrievalResult-like object.
+    aug = MagicMock()
+    aug.memory_id = "m99"
+    aug.content = "augmented"
+    aug.score = 0.8
+    aug.payload = {}
+    retriever.recall = AsyncMock(return_value=[aug])
+
+    mock_search = AsyncMock(return_value={"results": []})
+    mock_fetch = AsyncMock(return_value={"content": ""})
+    mock_reranker = MagicMock()
+    mock_reranker.rerank = AsyncMock(return_value=[])
+    mock_reranker.close = AsyncMock()
+
+    with (
+        patch("genesis.mcp.health.web_tools._impl_web_search", mock_search),
+        patch("genesis.mcp.health.web_tools._impl_web_fetch", mock_fetch),
+        patch("genesis.memory.reranker.VoyageReranker", return_value=mock_reranker),
+    ):
+        out = await maybe_correct_recall(
+            query="q",
+            results=results,
+            retriever=retriever,
+            db=MagicMock(),
+            path="memory",
+            router=router,
+        )
+
+    # Re-retrieval happened (relaxed + KB = 2 recall calls), web did NOT.
+    assert retriever.recall.await_count == 2
+    mock_search.assert_not_called()
+    mock_fetch.assert_not_called()
+    # Augmented result is present in output.
+    assert any(r.get("memory_id") == "m99" for r in out)
+
+
+# ---------------------------------------------------------------------------
+# Behavior: Incorrect on knowledge path → MAY call web
+# ---------------------------------------------------------------------------
+
+
+async def test_incorrect_knowledge_path_may_call_web(retriever):
+    results = [_kb_result("u1", "off-topic", 0.2)]
+    router = MagicMock()
+    router.route_call = AsyncMock(
+        return_value=_routing_result(success=True, content=_grade_content(0.05)),
+    )
+    retriever.recall = AsyncMock(return_value=[])
+
+    mock_search = AsyncMock(
+        return_value={"results": [{"url": "https://example.com", "title": "t"}]},
+    )
+    mock_fetch = AsyncMock(
+        return_value={"content": "para one about q\n\npara two about q"},
+    )
+    mock_reranker = MagicMock()
+    mock_reranker.rerank = AsyncMock(return_value=[{"id": "0", "score": 0.7}])
+    mock_reranker.close = AsyncMock()
+
+    with (
+        patch("genesis.mcp.health.web_tools._impl_web_search", mock_search),
+        patch("genesis.mcp.health.web_tools._impl_web_fetch", mock_fetch),
+        patch("genesis.memory.reranker.VoyageReranker", return_value=mock_reranker),
+    ):
+        out = await maybe_correct_recall(
+            query="q",
+            results=results,
+            retriever=retriever,
+            db=MagicMock(),
+            path="knowledge",
+            router=router,
+        )
+
+    # Web search was reachable on the knowledge path.
+    mock_search.assert_called()
+    assert isinstance(out, list)
+
+
+# ---------------------------------------------------------------------------
+# Behavior: shape normalization works for both id flavors end-to-end
+# ---------------------------------------------------------------------------
+
+
+async def test_shape_normalization_both(retriever):
+    # memory_id flavor — Correct keeps the relevant one.
+    mem_results = [_mem_result("m1", "rel", 0.2), _mem_result("m2", "no", 0.2)]
+    grades_mem = iter([_grade_content(0.9), _grade_content(0.1)])
+    router = MagicMock()
+
+    async def _route_mem(*_a, **_k):
+        return _routing_result(success=True, content=next(grades_mem))
+
+    router.route_call = AsyncMock(side_effect=_route_mem)
+    out_mem = await maybe_correct_recall(
+        query="q",
+        results=mem_results,
+        retriever=retriever,
+        db=MagicMock(),
+        path="memory",
+        router=router,
+    )
+    assert [r["memory_id"] for r in out_mem] == ["m1"]
+
+    # unit_id flavor — same Correct-drop logic on a different shape.
+    kb_results = [_kb_result("u1", "rel", 0.2), _kb_result("u2", "no", 0.2)]
+    grades_kb = iter([_grade_content(0.9), _grade_content(0.1)])
+
+    async def _route_kb(*_a, **_k):
+        return _routing_result(success=True, content=next(grades_kb))
+
+    router.route_call = AsyncMock(side_effect=_route_kb)
+    out_kb = await maybe_correct_recall(
+        query="q",
+        results=kb_results,
+        retriever=retriever,
+        db=MagicMock(),
+        path="knowledge",
+        router=router,
+    )
+    assert [r["unit_id"] for r in out_kb] == ["u1"]

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -142,7 +142,9 @@ def test_load_full_yaml(monkeypatch):
     # 2026-05-24: 49 → 48 after models_md_synthesis removed (converted to CC session dispatch).
     # 2026-05-29: 48 → 49 after dream_cycle_entity_check added (Sprint 2).
     # 2026-06-06: 49 → 51 after dream_cycle_synthesis_challenge + dream_cycle_entity_challenge (immune system PR).
-    assert len(cfg.call_sites) == 51
+    # 2026-06-20: 51 → 52 after crag_grade added (W-CRAG selective corrective retrieval, PR #711).
+    assert len(cfg.call_sites) == 52
+    assert "crag_grade" in cfg.call_sites  # W-CRAG runtime grader (2026-06-20)
     assert "models_md_synthesis" not in cfg.call_sites  # removed 2026-05-24
     assert "2_triage" not in cfg.call_sites  # removed 2026-05-10
     assert "7_task_retrospective" not in cfg.call_sites  # removed 2026-05-10 (duplicate; live one is 43_task_retrospective)


### PR DESCRIPTION
## What & why

Genesis was expected to have CRAG (corrective retrieval) wired; only the calibrated
rubric existed. **W-CRAG v1** closes that: when an explicit `memory_recall` /
`knowledge_recall` returns clearly off-topic results, Genesis grades them and
self-corrects — broadening the search, drawing on the knowledge base (and, for
knowledge queries, the web) — instead of feeding itself junk context. Follows
canonical CRAG (arXiv 2401.15884): lightweight evaluator → confidence → 3-bucket policy.

## Design (decisions locked with the user)

- **Grader:** new `crag_grade` call site (fast cross-vendor: `openrouter-haiku` →
  free fallbacks), reusing a new `memory_recall_grounding_runtime` rubric variant
  (the calibrated relevance rubric, minus the eval-only `{expected}` placeholder so
  runtime traces don't pollute eval calibration). Added to degradation skip sets.
- **Conservative rollout:** latency pre-gate (skip grading when the top score is
  already confident); **ACT only on a clear `Incorrect` verdict** (relaxed
  re-retrieve + raw KB; **web fallback on the knowledge path only** — episodic
  memory isn't on the web); **`Ambiguous` is DARK** (logged, no action) so the
  grader's thresholds can be calibrated on real traffic before widening.
- **Best-effort & latency-safe:** per-grade `asyncio.wait_for` timeout + graceful
  pass-through on any failure → a working recall is never degraded or stalled, even
  if the grader is down. Augmentation uses the **raw retriever** (no self-nesting).
- **Wiring:** default-ON on `memory_recall` (non-compact path) + `knowledge_recall`.
  Latency-sensitive paths (proactive hook, voice, CC context injection, ego) use the
  raw retriever and are **unaffected**. `emit_recall_corrected` logs every decision
  for calibration.

## Verification

- ruff clean; **139 tests pass** — 21 new `test_corrective.py` unit tests + regression
  across `test_mcp/test_memory_mcp`, `test_memory/test_mcp_integration`,
  `test_dashboard/test_tool_api`, `test_eval/*` (no regressions).
- **E2E against the real grader** (`openrouter-haiku`): relevant memory → score **1.0**
  → Correct (kept, no augmentation); irrelevant → **0.0** → Incorrect → augmentation
  fires (`relaxed` + raw `source=knowledge`), no web on the memory path; calibration
  `recall_corrected` events written; grader-unavailable → graceful pass-through.
- Architecture-reviewed pre-build (8 risks folded in) and code-reviewed post-build
  (Codex quota-exhausted → Claude code-reviewer; 2 findings fixed: web-result shape,
  knowledge-path event linkage).

## Out of scope (deferred follow-ups)

- Widen `Ambiguous` → acting once logged calibration data validates the thresholds.
- Corrective on the **compact** recall path (compact returns truncated previews — no
  gradeable content; callers expand later).
- Episodic strip-refinement / LLM-graded web chunks; post-deploy grader calibration review.

## ⚠️ DO NOT MERGE YET

Holding merge — multiple concurrent sessions are working on closely related
memory/routing systems. Merge only after coordination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)