### PR TITLE
fix(observability): de-noise L1 (ghost sessions, harness blobs, wings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   lane. They're now recorded at low priority — still tracked for trend deltas, just no longer
   treated as urgent.
 
+- **Genesis's at-a-glance state views stopped showing internal noise** — three cleanups to the
+  dashboard and to Genesis's own always-on context: empty sessions (ended before any messages were
+  exchanged) no longer appear as ghost "0 msgs" rows in the recent-sessions list; the "Active Work"
+  summary no longer ingests raw harness notifications (task-completion blobs, system reminders,
+  slash-command metadata) as if they were your prompts; and the memory "Wings" breakdown shows only
+  real, controlled-vocabulary domains instead of malformed or one-off tags. What you — and Genesis —
+  see reflects genuine activity, not plumbing.
+
 - **A campaign that crashes mid-tick no longer fails silently** — when a scheduled campaign
   tick raises an error, Genesis now records it in job-health tracking, so the failure surfaces
   in the dashboard and to the ego instead of vanishing into the server log. Campaign

--- a/scripts/genesis_session_end.py
+++ b/scripts/genesis_session_end.py
@@ -163,14 +163,19 @@ def main() -> None:
         except OSError as exc:
             print(f"SessionEnd hook: failed to write pending bookmark: {exc}", file=sys.stderr)
 
-    # 3. Append session patch for cognitive state freshness
-    patch_topic = _extract_topic(messages, fallback=topic_hint)
-    _append_session_patch(
-        session_id=session_id,
-        topic_hint=patch_topic,
-        message_count=len(messages),
-        ended_at=now,
-    )
+    # 3. Append session patch for cognitive state freshness — only for sessions
+    #    that actually had messages. A zero-message session (e.g. one ended
+    #    during a server restart before any messages.jsonl was written) would
+    #    otherwise write a ghost "no topic · 0 msgs" row into the dashboard's
+    #    recent-sessions list.
+    if messages:
+        patch_topic = _extract_topic(messages, fallback=topic_hint)
+        _append_session_patch(
+            session_id=session_id,
+            topic_hint=patch_topic,
+            message_count=len(messages),
+            ended_at=now,
+        )
 
     # 4. If session ran in a worktree, backup transcript to main project dir.
     _backup_worktree_transcript(transcript_path)

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -171,6 +171,23 @@ def _detect_pivot(current_kw: list[str], trail: dict) -> bool:
     return similarity < _PIVOT_SIMILARITY_THRESHOLD
 
 
+# Harness-injected prompt envelopes — task-completion notifications, system
+# reminders, slash-command metadata, and local-command output. These are not
+# user messages; recording them as conversation pivots pollutes the L1 "Active
+# Work" view and the session-trail line with raw <task-notification> blobs.
+_HARNESS_ENVELOPE_PREFIXES = (
+    "<task-notification>",
+    "<system-reminder>",
+    "<local-command-",
+    "<command-",  # name, message, args, flag, and any future <command-*> variant
+)
+
+
+def _is_harness_envelope(prompt: str) -> bool:
+    """True if *prompt* is a harness-injected envelope, not genuine user input."""
+    return prompt.lstrip().startswith(_HARNESS_ENVELOPE_PREFIXES)
+
+
 def _record_pivot_observation(
     db_path: Path, session_id: str, label: str, trigger: str,
 ) -> None:
@@ -210,6 +227,12 @@ def _update_and_format_trail(
     Returns None if trail has fewer than 2 pivots (not useful yet).
     """
     if not session_id:
+        return None
+
+    # Skip harness-injected turns (task notifications, system reminders,
+    # slash-command metadata, local-command output) — they are not user
+    # messages and would pollute the pivot trail and L1 "Active Work".
+    if _is_harness_envelope(prompt):
         return None
 
     trail = _load_trail(session_id)

--- a/src/genesis/memory/essential_knowledge.py
+++ b/src/genesis/memory/essential_knowledge.py
@@ -325,7 +325,17 @@ async def _active_session_count(db: aiosqlite.Connection) -> int:
 
 
 async def _wing_stats(db: aiosqlite.Connection) -> dict[str, int]:
-    """Count memories per wing from memory_metadata."""
+    """Count memories per wing from memory_metadata (canonical wings only).
+
+    Filters to the controlled ``taxonomy.WINGS`` vocabulary so malformed or
+    off-vocabulary wing values (e.g. a leaked ``wing=channels`` prefix or a
+    one-off LLM-invented wing) don't surface in the L1 "Wings" view.
+    """
+    # Deferred import by module convention: essential_knowledge keeps all
+    # genesis.* imports function-level (it is loaded early, low in the import
+    # graph), as elsewhere in this file (e.g. the taxonomy wing-set import in
+    # generate_deterministic).
+    from genesis.memory.taxonomy import WINGS
     try:
         cursor = await db.execute(
             "SELECT wing, COUNT(*) FROM memory_metadata "
@@ -333,7 +343,7 @@ async def _wing_stats(db: aiosqlite.Connection) -> dict[str, int]:
             "GROUP BY wing ORDER BY COUNT(*) DESC"
         )
         rows = await cursor.fetchall()
-        return {row[0]: row[1] for row in rows}
+        return {row[0]: row[1] for row in rows if row[0] in WINGS}
     except Exception:
         return {}
 

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -39,6 +39,26 @@ except ImportError:  # pragma: no cover — safety for minimal installs
 
 logger = logging.getLogger(__name__)
 
+
+def _strip_kv_prefix(value: str | None, key: str) -> str | None:
+    """Strip a leaked ``key=`` / ``key:`` prefix from a taxonomy value.
+
+    Synthesis (dream_cycle) prompts model tags as ``wing={wing}, room={room}``;
+    the LLM occasionally echoes the literal ``wing=channels`` form into its JSON
+    output. Without this guard that value is stored verbatim into the FTS5 tag,
+    the Qdrant payload, and ``memory_metadata.wing`` — polluting the wing
+    taxonomy and the L1 "Wings" view. Strips only a leading ``key=``/``key:``.
+    """
+    if not value:
+        return value
+    stripped = value.strip()
+    for sep in ("=", ":"):
+        prefix = f"{key}{sep}"
+        if stripped.startswith(prefix):
+            return stripped[len(prefix):].strip()
+    return stripped
+
+
 _COLLECTION_MAP = {
     "episodic": "episodic_memory",
     "knowledge": "knowledge_base",  # External knowledge → knowledge_base
@@ -175,6 +195,11 @@ class MemoryStore:
         class_tag = f"class:{resolved_class}"
         if class_tag not in resolved_tags:
             resolved_tags = [*resolved_tags, class_tag]
+
+        # Defensive: strip a leaked ``wing=`` / ``room=`` prefix before the value
+        # fans out to the FTS5 tag, the Qdrant payload, and memory_metadata.
+        wing = _strip_kv_prefix(wing, "wing")
+        room = _strip_kv_prefix(room, "room")
 
         # Taxonomy classification — auto-classify if not explicitly provided
         if not wing or not room:

--- a/tests/test_intent_trail.py
+++ b/tests/test_intent_trail.py
@@ -223,3 +223,47 @@ class TestObservationStorage:
         assert row[2] == "conversation_pivot"  # type
         assert "memory search" in row[3]  # content
         assert row[6] is not None  # expires_at should be set
+
+
+class TestHarnessEnvelopeFiltering:
+    """#16: harness-injected prompts must not be recorded as pivots."""
+
+    def test_detects_task_notification(self) -> None:
+        assert _mod._is_harness_envelope(
+            "<task-notification><task-id>abc</task-id></task-notification>"
+        )
+
+    def test_detects_system_reminder(self) -> None:
+        assert _mod._is_harness_envelope("<system-reminder>do the thing</system-reminder>")
+
+    def test_detects_local_command(self) -> None:
+        assert _mod._is_harness_envelope("<local-command-stdout>output</local-command-stdout>")
+        assert _mod._is_harness_envelope("<local-command-caveat>note</local-command-caveat>")
+
+    def test_detects_slash_command(self) -> None:
+        assert _mod._is_harness_envelope("<command-name>/compact</command-name>")
+        assert _mod._is_harness_envelope("<command-flag>--all</command-flag>")
+
+    def test_detects_with_leading_whitespace(self) -> None:
+        assert _mod._is_harness_envelope("\n  <task-notification>x</task-notification>")
+
+    def test_false_for_genuine_user_prompt(self) -> None:
+        assert not _mod._is_harness_envelope("fix the executor pipeline bug")
+        # A user prompt that merely mentions a tag mid-text is NOT an envelope
+        assert not _mod._is_harness_envelope("can you look into the <foo> tag handling?")
+
+    def test_update_trail_skips_harness_prompt(self, tmp_path: Path) -> None:
+        """A harness turn records no pivot, no observation, and no trail state."""
+        with patch.object(_mod, "_TRAIL_DIR", tmp_path), \
+             patch.object(_mod, "_DB_PATH", tmp_path / "fake.db"):
+            result = _update_and_format_trail(
+                "s_harness", ["task", "notification"],
+                "<task-notification><task-id>abc</task-id></task-notification>",
+            )
+            assert result is None
+            # No pivot recorded and msg_count not incremented for a harness turn
+            trail = _load_trail("s_harness")
+            assert trail.get("pivots", []) == []
+            assert trail.get("msg_count", 0) == 0
+            # No observation DB written
+            assert not (tmp_path / "fake.db").exists()

--- a/tests/test_memory/test_store_tagging.py
+++ b/tests/test_memory/test_store_tagging.py
@@ -65,6 +65,43 @@ async def test_store_without_source_pipeline_omits_from_payload(store):
     assert "source_pipeline" not in payload
 
 
+def test_strip_kv_prefix():
+    """#17: defensive strip of a leaked ``wing=``/``room=`` prefix."""
+    from genesis.memory.store import _strip_kv_prefix
+
+    assert _strip_kv_prefix("wing=channels", "wing") == "channels"
+    assert _strip_kv_prefix("wing:channels", "wing") == "channels"
+    assert _strip_kv_prefix("room=uncategorized", "room") == "uncategorized"
+    assert _strip_kv_prefix("channels", "wing") == "channels"  # already clean
+    assert _strip_kv_prefix(None, "wing") is None
+    assert _strip_kv_prefix("", "wing") == ""
+    # Only a leading ``key=`` is stripped — a non-matching key/mid-string '=' is kept
+    assert _strip_kv_prefix("a=b", "wing") == "a=b"
+
+
+@pytest.mark.asyncio()
+async def test_store_strips_leaked_wing_prefix(store):
+    """A leaked ``wing=channels`` value is sanitized before it reaches the Qdrant
+    payload, the FTS5 wing tag, and the memory_metadata write."""
+    with patch("genesis.memory.store.upsert_point") as mock_upsert, \
+         patch("genesis.memory.store.memory_crud") as mock_mem:
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        await store.store(
+            "test content", "src", wing="wing=channels", room="room=uncategorized",
+        )
+
+    payload = mock_upsert.call_args.kwargs["payload"]
+    assert payload["wing"] == "channels"
+    assert payload["room"] == "uncategorized"
+    assert "wing:channels" in payload["tags"]
+    assert "wing:wing=channels" not in payload["tags"]
+    # The memory_metadata companion write gets the sanitized value too
+    assert mock_mem.create_metadata.call_args.kwargs["wing"] == "channels"
+    assert mock_mem.create_metadata.call_args.kwargs["room"] == "uncategorized"
+
+
 @pytest.mark.asyncio()
 async def test_store_source_pipeline_various_values(store):
     """All expected source_pipeline values should work."""

--- a/tests/test_memory/test_wing_stats.py
+++ b/tests/test_memory/test_wing_stats.py
@@ -1,0 +1,35 @@
+"""Tests for L1 wing-stats canonical filtering (essential_knowledge._wing_stats).
+
+#17: the L1 "Wings" view must only surface controlled-vocabulary wings, so a
+leaked ``wing=channels`` prefix or a one-off LLM-invented wing doesn't pollute
+the display.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.db.crud.memory import create_metadata
+from genesis.memory.essential_knowledge import _wing_stats
+
+
+@pytest.mark.asyncio()
+async def test_wing_stats_filters_to_canonical_vocab(empty_db):
+    rows = [
+        ("m1", "channels"),
+        ("m2", "channels"),
+        ("m3", "memory"),
+        ("m4", "wing=channels"),  # leaked prefix — malformed
+        ("m5", "technology"),     # LLM-invented, off-vocabulary
+    ]
+    for mid, wing in rows:
+        await create_metadata(
+            empty_db, memory_id=mid,
+            created_at="2026-06-20T00:00:00+00:00", wing=wing,
+        )
+
+    stats = await _wing_stats(empty_db)
+
+    assert stats == {"channels": 2, "memory": 1}
+    assert "wing=channels" not in stats
+    assert "technology" not in stats

--- a/tests/test_scripts/test_session_end_patches.py
+++ b/tests/test_scripts/test_session_end_patches.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 from pathlib import Path
 
@@ -156,3 +157,51 @@ def test_extract_topic_empty_messages():
     """Empty message list returns fallback."""
     assert _extract_topic([], fallback="fb") == "fb"
     assert _extract_topic([]) == ""
+
+
+# ── main() zero-message guard (RC-1: no ghost recent-session rows) ───────────
+
+
+def _run_main(monkeypatch, tmp_path, *, session_id, messages=None):
+    """Invoke the hook's main() with module paths redirected into tmp_path."""
+    genesis_dir = tmp_path / ".genesis"
+    (genesis_dir / "sessions" / session_id).mkdir(parents=True, exist_ok=True)
+    flag = genesis_dir / "cc_context_enabled"
+    flag.write_text("1")
+    patches = genesis_dir / "session_patches.json"
+    if messages:
+        (genesis_dir / "sessions" / session_id / "messages.jsonl").write_text(
+            "\n".join(json.dumps(m) for m in messages)
+        )
+    monkeypatch.setattr(_mod, "_GENESIS_DIR", genesis_dir)
+    monkeypatch.setattr(_mod, "_FLAG", flag)
+    monkeypatch.setattr(_mod, "_PATCHES_FILE", patches)
+    monkeypatch.setattr(_mod, "_LAST_SESSION_FILE", genesis_dir / "last.json")
+    monkeypatch.setattr(_mod, "_PENDING_BOOKMARK_FILE", genesis_dir / "pending.json")
+    monkeypatch.setattr(_mod, "_trigger_essential_knowledge_regen", lambda: None)
+    monkeypatch.delenv("GENESIS_CC_SESSION", raising=False)
+    monkeypatch.setattr(
+        "sys.stdin",
+        io.StringIO(json.dumps({"session_id": session_id, "reason": "clear"})),
+    )
+    _mod.main()
+    return patches
+
+
+def test_main_skips_patch_for_zero_message_session(tmp_path, monkeypatch):
+    """A session that ended with no messages must NOT write a ghost patch row."""
+    patches = _run_main(monkeypatch, tmp_path, session_id="ghost1", messages=None)
+    assert not patches.exists()
+
+
+def test_main_writes_patch_for_session_with_messages(tmp_path, monkeypatch):
+    """A session with real messages still writes its patch (no regression)."""
+    patches = _run_main(
+        monkeypatch, tmp_path, session_id="real1",
+        messages=[{"text": "fix the memory leak in the awareness loop"}],
+    )
+    assert patches.exists()
+    data = json.loads(patches.read_text())
+    assert len(data) == 1
+    assert data[0]["session_id"] == "real1"
+    assert data[0]["message_count"] == 1


### PR DESCRIPTION
Three small "cognitive-state hygiene" fixes — each targets noise that was showing up on the dashboard and in Genesis's own always-on L1 context. All verified against current `main`.

## Fixes

**RC-1 — ghost zero-message sessions** (`scripts/genesis_session_end.py`)
A session that ended before any messages were exchanged (e.g. mid server-restart) still wrote a patch into `session_patches.json`, producing ghost "no topic · 0 msgs" rows in the dashboard recent-sessions list. Now gated on `if messages:`. (`_LAST_SESSION_FILE` — a separate single-value temporal-awareness file — is intentionally left as-is; it does not feed the recent-sessions list.)

**#16 — harness noise in L1 "Active Work"** (`scripts/proactive_memory_hook.py`)
The UserPromptSubmit hook recorded a `conversation_pivot` for every prompt, including harness-injected turns (`<task-notification>`, `<system-reminder>`, slash-command and local-command envelopes). Those raw blobs then surfaced in L1 "Active Work" and the session-trail line. New `_is_harness_envelope()` early-returns for those turns, so only genuine user prompts become pivots.

**#17 — wing prefix leak + vocab pollution** (`src/genesis/memory/store.py`, `essential_knowledge.py`)
Synthesis prompts model tags as `wing={wing}`; the LLM occasionally echoed the literal `wing=channels` value, stored verbatim. New `_strip_kv_prefix` sanitizes `wing`/`room` at the top of `store()` — before the value fans out to the FTS5 tag, the Qdrant payload, and `memory_metadata`. The L1 `_wing_stats` view now filters to the controlled `taxonomy.WINGS` vocabulary (display-only; no DB mutation).

## Verification
- 50 targeted tests pass (RC-1 `main()` end-to-end both sides; harness-envelope detection incl. `<command-flag>`; store strip across all three sinks; `_wing_stats` canonical filtering). Lint clean.
- Wiring confirmed: hook passes the real prompt into the trail fn; `_strip_kv_prefix` precedes all three store sinks.
- Inline code-review pass (one finding applied: collapsed `<command-*>` entries to a single `<command-` prefix to catch `<command-flag>` and future variants).

## Risk
Low. RC-1 and #16 only *suppress* writes that shouldn't happen; #17's strip only fires on a leading `key=`/`key:` prefix (real values pass through), and the wings filter is display-only.
