### PR TITLE
fix(recon): pin github_stars findings to low priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   down at once it exhausted its chain and silently stopped learning. A third independent free
   fallback now keeps it working through overlapping provider outages.
 
+- **Star-count updates no longer crowd high-priority alerts** — GitHub star-count reconnaissance
+  pings inherited their watched project's priority (e.g. "high" for the main repo), so vanity
+  "+N stars" deltas competed with genuinely important findings in the morning report and alert
+  lane. They're now recorded at low priority — still tracked for trend deltas, just no longer
+  treated as urgent.
+
 - **A campaign that crashes mid-tick no longer fails silently** — when a scheduled campaign
   tick raises an error, Genesis now records it in job-health tracking, so the failure surfaces
   in the dashboard and to the ego instead of vanishing into the server log. Campaign

--- a/src/genesis/recon/gatherer.py
+++ b/src/genesis/recon/gatherer.py
@@ -184,7 +184,10 @@ class ReconGatherer:
             type="finding",
             category="github_stars",
             content=content,
-            priority=project.get("priority", "medium"),
+            # Star-count deltas are vanity/informational signal — pin them to
+            # "low" regardless of the watched project's priority so they don't
+            # crowd the high-priority recon lane or trigger proactive delivery.
+            priority="low",
             created_at=now,
             content_hash=content_hash,
         )

--- a/tests/test_recon/test_gatherer.py
+++ b/tests/test_recon/test_gatherer.py
@@ -454,6 +454,26 @@ class TestGatherStars:
         assert "30 stars" in rows[0]["content"]
 
     @pytest.mark.asyncio
+    async def test_star_findings_pinned_to_low_priority(self, db):
+        """#13: github_stars findings are 'low' even when the watched project is
+        high-priority, so vanity star deltas don't crowd the high recon lane."""
+        gatherer = ReconGatherer(db)
+
+        with (
+            patch.object(ReconGatherer, "_load_watchlist", return_value=_STAR_WATCHLIST),
+            patch.object(ReconGatherer, "_run_gh", return_value="100"),
+        ):
+            await gatherer.gather_stars()
+
+        # _STAR_WATCHLIST's GENesis-AGI project is priority "high"...
+        rows = await observations.query(
+            db, source="recon", type="finding", category="github_stars"
+        )
+        assert len(rows) == 1
+        # ...but the star-count finding itself must be low.
+        assert rows[0]["priority"] == "low"
+
+    @pytest.mark.asyncio
     async def test_dedup_same_count(self, db):
         gatherer = ReconGatherer(db)
 


### PR DESCRIPTION
## What
Pin GitHub star-count reconnaissance findings to `low` priority, regardless of the watched project's configured priority (`src/genesis/recon/gatherer.py`).

## Why
Star-count findings inherited their project's priority via `project.get("priority", "medium")`. For the main repo (priority `high`), every "+N stars" ping landed in the **high-priority recon lane** and the morning report, crowding genuinely important findings. A live check confirmed the entire "high" unresolved recon backlog was nothing but these vanity star pings.

Star deltas are vanity/informational signal — they shouldn't compete with real findings.

## Scope note
This was originally scoped alongside a job_health `is_stale` annotation (#12); that turned out to require fragile multi-scheduler reconciliation and was dropped + tracked as a follow-up (it's cosmetic and doesn't mislead automated consumers). This PR is the clean, real half.

## Verification
- New test `test_star_findings_pinned_to_low_priority` asserts a star finding is `low` even when its project is `high`; full `test_gatherer.py` passes (32 tests). Lint clean.
- Trend tracking is unaffected — delta computation queries by `category`, not `priority`.

## Risk
Minimal — one-line priority change on a single finding type. Existing high-priority star rows in the DB age out naturally as new low-priority ones supersede them; no data migration.
