### PR TITLE
feat(autonomy): evidence-gated earn-back promotion proposals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Earned autonomy can be restored after a regression** — when Genesis loses a level of
+  autonomy in a category (e.g. after a correction), that demotion is no longer a dead end. Once
+  the category's track record recovers enough that the evidence again supports the earned level,
+  Genesis proposes restoring it and asks you to approve — it never silently re-grants authority,
+  and it won't nag while the lower level is genuinely warranted. Previously a demoted category
+  had no path back up.
+
 - **Genesis self-corrects a bad memory recall instead of running with it** — on high-stakes
   lookups (the explicit memory and knowledge recall tools), Genesis now grades whether the
   recalled results are actually on-topic, and when a recall comes back clearly irrelevant it

--- a/docs/architecture/autonomy-deep-dive.md
+++ b/docs/architecture/autonomy-deep-dive.md
@@ -91,9 +91,19 @@ reasonable inference from sparse data.
 | 10 | 5 | 0.73 | L3 |
 | 50 | 5 | 0.90 | L4 |
 
-Promotion caps at +1 level per success — prevents overfitting to lucky streaks.
-Regression has no such cap. A single correction can drop multiple levels if the
-posterior crosses a threshold.
+Regression is automatic and uncapped: a single correction can drop multiple
+levels if the posterior crosses a threshold. Promotion is **not** automatic —
+recording a success only accrues evidence; restoring a level always requires
+explicit user approval (see **Earn-back** below).
+
+**Earn-back.** After a category regresses (`current_level < earned_level`), the
+user ego watches for recovery. Once the Bayesian posterior again supports the
+earned level, it raises an `autonomy_earnback` proposal ("restore <category> to
+L<n>"); only on the user's approval does `AutonomyManager.promote()` restore the
+level. A demotion therefore stays in place for as long as the evidence — and the
+user — agree it belongs there, and authority is never silently re-granted.
+Implementation: `AutonomyManager.detect_earnback_candidates`,
+`EgoCadenceManager._check_earnback_opportunities`, `ego/earnback.py`.
 
 ---
 

--- a/src/genesis/autonomy/state_machine.py
+++ b/src/genesis/autonomy/state_machine.py
@@ -144,6 +144,46 @@ class AutonomyManager:
             return None
         return _row_to_state(row)
 
+    async def detect_earnback_candidates(self) -> list[dict]:
+        """Categories whose autonomy can be earned back, gated on EVIDENCE.
+
+        A category is a candidate iff it is demoted (``current_level <
+        earned_level``) AND the system's own Bayesian evidence now supports the
+        earned level again (``bayesian_level(successes, corrections) >=
+        earned_level``). This keeps proposals silent while the lower level is
+        genuinely correct and fires only once the category re-earns the level.
+        Promotion itself still requires explicit user approval — this only
+        identifies who is eligible.
+
+        Note: ``consecutive_corrections`` is deliberately NOT part of the gate.
+        ``record_correction`` resets it to 0 on a regression, so it would be 0
+        right after a category got worse; the Bayesian posterior is the honest,
+        sufficient signal.
+
+        Returns dicts: ``{category, current_level, target_level,
+        total_successes, total_corrections, posterior, last_regression_at}``.
+        """
+        candidates: list[dict] = []
+        for row in await crud.list_all(self._db):
+            current = row["current_level"]
+            earned = row["earned_level"]
+            if current >= earned:
+                continue  # not demoted — nothing to earn back
+            successes = row.get("total_successes", 0)
+            corrections = row.get("total_corrections", 0)
+            if crud.bayesian_level(successes, corrections) < earned:
+                continue  # evidence does not yet support the earned level
+            candidates.append({
+                "category": row["category"],
+                "current_level": current,
+                "target_level": earned,
+                "total_successes": successes,
+                "total_corrections": corrections,
+                "posterior": crud.bayesian_posterior(successes, corrections),
+                "last_regression_at": row.get("last_regression_at"),
+            })
+        return candidates
+
     # ------------------------------------------------------------------
     # Level queries
     # ------------------------------------------------------------------

--- a/src/genesis/dashboard/routes/comms.py
+++ b/src/genesis/dashboard/routes/comms.py
@@ -197,6 +197,18 @@ async def comms_resolve_proposal(proposal_id: str):
     except Exception:
         logger.warning("Journal resolve failed for proposal %s", proposal_id)
 
+    # Autonomy earn-back: promote on approval / cooldown on reject.
+    try:
+        from genesis.ego.earnback import handle_earnback_resolution
+
+        prop = await ego.get_proposal(rt.db, proposal_id)
+        if prop:
+            await handle_earnback_resolution(
+                rt.db, prop, status, getattr(rt, "_autonomy_manager", None),
+            )
+    except Exception:
+        logger.warning("earnback resolution hook failed for %s", proposal_id)
+
     # Trigger delayed sweep on approval — same 5-min grace as Telegram,
     # so the user can revoke before dispatch fires.
     if status == "approved" and rt.ego_session:

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -329,6 +329,21 @@ async def ego_proposal_resolve(proposal_id: str):
         import logging
         logging.getLogger(__name__).warning("Journal resolve failed for %s", proposal_id)
 
+    # Autonomy earn-back: promote on approval / cooldown on reject.
+    try:
+        from genesis.ego.earnback import handle_earnback_resolution
+
+        prop = await ego_crud.get_proposal(rt._db, proposal_id)
+        if prop:
+            await handle_earnback_resolution(
+                rt._db, prop, status, getattr(rt, "_autonomy_manager", None),
+            )
+    except Exception:
+        import logging
+        logging.getLogger(__name__).warning(
+            "earnback resolution hook failed for %s", proposal_id,
+        )
+
     return jsonify({"ok": True, "id": proposal_id, "status": status})
 
 

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -86,12 +86,16 @@ class EgoCadenceManager:
         idle_detector: IdleDetector | None = None,
         db: aiosqlite.Connection,
         event_bus: GenesisEventBus | None = None,
+        autonomy_manager: object | None = None,
     ) -> None:
         self._session = session
         self._config = config
         self._idle_detector = idle_detector
         self._db = db
         self._event_bus = event_bus
+        # AutonomyManager (duck-typed: detect_earnback_candidates / promote),
+        # used by the user-ego earn-back check. None disables earn-back.
+        self._autonomy_manager = autonomy_manager
 
         self._scheduler = AsyncIOScheduler()
         self._paused = False
@@ -320,6 +324,10 @@ class EgoCadenceManager:
         # Deadline scanner: push reactive events for approaching deadlines
         await self._check_approaching_deadlines()
 
+        # Autonomy earn-back: propose restoring earned levels whose evidence
+        # now supports it (user ego only; no-op otherwise).
+        await self._check_earnback_opportunities()
+
     async def _check_approaching_deadlines(self) -> None:
         """Push reactive events for events approaching within 48h."""
         try:
@@ -412,6 +420,110 @@ class EgoCadenceManager:
                 )
         except Exception:
             logger.debug("Goal staleness scanner failed", exc_info=True)
+
+    # -- Autonomy earn-back ------------------------------------------------
+
+    _EARNBACK_REJECT_COOLDOWN_DAYS = 7
+
+    async def _check_earnback_opportunities(self) -> None:
+        """Propose restoring earned autonomy for categories whose evidence now
+        supports it. User-ego only; evidence-gated; the user approves each
+        promotion. Never auto-promotes.
+        """
+        if self._session._source_tag != "user_ego_cycle":
+            return
+        if self._autonomy_manager is None:
+            return
+        try:
+            candidates = await self._autonomy_manager.detect_earnback_candidates()
+            if not candidates:
+                return
+
+            from genesis.db.crud import ego as ego_crud
+
+            # Anti-spam: skip categories that already have a pending earn-back
+            # proposal (also covered by create_batch content-hash dedup) or an
+            # active reject cooldown.
+            pending = await ego_crud.list_pending_proposals(self._session._db)
+            pending_cats = {
+                p.get("action_category")
+                for p in pending
+                if p.get("action_type") == "autonomy_earnback"
+            }
+
+            to_make: list[dict] = []
+            for cand in candidates:
+                category = cand["category"]
+                if category in pending_cats:
+                    continue
+                if await self._earnback_in_cooldown(category):
+                    continue
+                to_make.append(self._build_earnback_proposal(cand))
+
+            if not to_make:
+                return
+
+            batch_id, ids, _ = await self._session._proposals.create_batch(
+                to_make, ego_source="user_ego_cycle",
+            )
+            if ids:
+                await self._session._proposals.send_digest(
+                    batch_id, ego_source="user_ego_cycle",
+                )
+                logger.info(
+                    "Earn-back: proposed promotion for %d categor(ies)", len(ids),
+                )
+        except Exception:
+            logger.warning("Earn-back opportunity check failed", exc_info=True)
+
+    async def _earnback_in_cooldown(self, category: str) -> bool:
+        """True if *category*'s earn-back was rejected within the cooldown window."""
+        from genesis.db.crud import ego as ego_crud
+
+        ts = await ego_crud.get_state(
+            self._session._db, f"earnback_reject:{category}",
+        )
+        if not ts:
+            return False
+        try:
+            rejected_at = datetime.fromisoformat(ts)
+        except (ValueError, TypeError):
+            return False
+        if rejected_at.tzinfo is None:
+            rejected_at = rejected_at.replace(tzinfo=UTC)
+        age_days = (datetime.now(UTC) - rejected_at).days
+        return age_days < self._EARNBACK_REJECT_COOLDOWN_DAYS
+
+    @staticmethod
+    def _build_earnback_proposal(cand: dict) -> dict:
+        """Build a proposal dict for an earn-back candidate."""
+        category = cand["category"]
+        current = cand["current_level"]
+        target = cand["target_level"]
+        posterior = cand.get("posterior")
+        conf = round(float(posterior), 2) if posterior is not None else 0.7
+        regressed_on = (cand.get("last_regression_at") or "")[:10]
+        since = f" (demoted {regressed_on})" if regressed_on else ""
+        content = (
+            f"Restore {category} autonomy to L{target}. It was reduced to "
+            f"L{current}{since} after a Bayesian regression; the success record "
+            f"has since recovered enough to support L{target} again "
+            f"(posterior {conf})."
+        )
+        rationale = (
+            "Evidence-gated earn-back: the category's own success/correction "
+            "history now supports the earned level. Approve to restore it; "
+            "reject to keep it where it is."
+        )
+        return {
+            "action_type": "autonomy_earnback",
+            "action_category": category,
+            "content": content,
+            "rationale": rationale,
+            "confidence": conf,
+            "urgency": "low",
+            "expected_outputs": {"target_level": target},
+        }
 
     # -- Tick handlers -----------------------------------------------------
 

--- a/src/genesis/ego/earnback.py
+++ b/src/genesis/ego/earnback.py
@@ -1,0 +1,176 @@
+"""Autonomy earn-back — the shared promote hook fired when an earn-back proposal
+is resolved.
+
+An ``autonomy_earnback`` proposal is created by the ego cadence when a demoted
+autonomy category's Bayesian evidence again supports its earned level (see
+``EgoCadenceManager._check_earnback_opportunities``). Promotion is gated on the
+user's explicit approval.
+
+A proposal can be resolved from four entry points — a Telegram reply
+(``ProposalWorkflow.resolve_proposals``), the ``ego_proposal_resolve`` MCP tool,
+and two dashboard routes — so the promote/cooldown logic lives here and every
+path calls it identically. This is intentionally narrow: it does ONLY the
+earn-back side-effect, leaving each path's other behaviour (J-9, journal,
+correction memory) untouched.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+from datetime import UTC, datetime
+
+import aiosqlite
+
+from genesis.db.crud import autonomy as autonomy_crud
+from genesis.db.crud import ego as ego_crud
+
+logger = logging.getLogger(__name__)
+
+EARNBACK_ACTION_TYPE = "autonomy_earnback"
+
+
+def _parse_target_level(expected_outputs: object) -> int | None:
+    """Extract the integer ``target_level`` from a proposal's expected_outputs.
+
+    ``expected_outputs`` is stored as a JSON string but may already be a dict.
+    """
+    data = expected_outputs
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except (ValueError, TypeError):
+            return None
+    if not isinstance(data, dict):
+        return None
+    val = data.get("target_level")
+    try:
+        return int(val) if val is not None else None
+    except (ValueError, TypeError):
+        return None
+
+
+def _regression_after(last_regression: str | None, created: str | None) -> bool:
+    """True if a regression timestamp strictly postdates the proposal creation.
+
+    Parses both to timezone-aware datetimes (rather than comparing ISO strings
+    lexically, which is brittle if formats ever diverge). On any parse failure
+    returns False — a freshness check that can't be evaluated must not block a
+    user-approved, evidence-gated promotion.
+    """
+    if not last_regression or not created:
+        return False
+    try:
+        lr = datetime.fromisoformat(last_regression)
+        cr = datetime.fromisoformat(created)
+    except (ValueError, TypeError):
+        return False
+    if lr.tzinfo is None:
+        lr = lr.replace(tzinfo=UTC)
+    if cr.tzinfo is None:
+        cr = cr.replace(tzinfo=UTC)
+    return lr > cr
+
+
+async def handle_earnback_resolution(
+    db: aiosqlite.Connection,
+    proposal: dict,
+    status: object,
+    autonomy_manager: object | None,
+) -> bool:
+    """Apply the earn-back side-effect of resolving *proposal*.
+
+    No-op unless *proposal* is an ``autonomy_earnback`` proposal. On approval:
+    re-read the live autonomy state, skip the promote if a regression landed
+    after the proposal was created (the evidence the user approved on no longer
+    holds), otherwise call ``manager.promote()`` and mark the proposal
+    ``executed`` so the approved-proposal sweep never dispatches it as a session.
+    On rejection: record a reject timestamp so the cadence applies its cooldown
+    before re-proposing.
+
+    *status* may be a ``ProposalStatus`` enum or a plain string.
+    Returns True iff a promotion was applied.
+    """
+    if proposal.get("action_type") != EARNBACK_ACTION_TYPE:
+        return False
+
+    status_str = getattr(status, "value", status)
+    category = (proposal.get("action_category") or "").strip()
+
+    if status_str == "rejected":
+        if category:
+            with contextlib.suppress(Exception):
+                await ego_crud.set_state(
+                    db,
+                    key=f"earnback_reject:{category}",
+                    value=datetime.now(UTC).isoformat(),
+                )
+        return False
+
+    if status_str != "approved":
+        return False
+
+    if autonomy_manager is None:
+        logger.warning(
+            "earnback proposal %s approved but no autonomy_manager available",
+            proposal.get("id"),
+        )
+        return False
+
+    target = _parse_target_level(proposal.get("expected_outputs"))
+    if not category or target is None:
+        logger.warning(
+            "earnback proposal %s missing category/target_level (cat=%r target=%r)",
+            proposal.get("id"), category, target,
+        )
+        return False
+
+    # Staleness guard: if a regression landed after the proposal was created, the
+    # evidence the user approved on no longer holds — mark executed, don't promote.
+    try:
+        row = await autonomy_crud.get_by_category(db, category)
+    except Exception:
+        logger.warning(
+            "earnback: could not re-read autonomy state for %s", category, exc_info=True,
+        )
+        row = None
+    if row is not None and _regression_after(
+        row.get("last_regression_at"), proposal.get("created_at"),
+    ):
+        logger.info(
+            "earnback for %s skipped — regression at %s postdates proposal %s",
+            category, row.get("last_regression_at"), proposal.get("created_at"),
+        )
+        with contextlib.suppress(Exception):
+            await ego_crud.execute_proposal(
+                db, proposal["id"], status="executed",
+                user_response="earnback skipped: conditions changed",
+            )
+        return False
+
+    ok = await autonomy_manager.promote(
+        category, target, reason="user_approved_earnback",
+    )
+    if ok:
+        with contextlib.suppress(Exception):
+            await ego_crud.execute_proposal(
+                db, proposal["id"], status="executed",
+                user_response=f"earnback applied: restored to L{target}",
+            )
+        logger.info(
+            "Autonomy earn-back applied: %s restored to L%d (user approved)",
+            category, target,
+        )
+    else:
+        # promote() declined (already at/above target, or category missing).
+        # Mark executed anyway so the proposal doesn't linger as 'approved' —
+        # which would clutter the dashboard AND block the cadence from
+        # re-proposing (its pending-check only sees 'pending' rows).
+        logger.warning("earnback promote returned False for %s -> L%s", category, target)
+        with contextlib.suppress(Exception):
+            await ego_crud.execute_proposal(
+                db, proposal["id"], status="executed",
+                user_response=f"earnback no-op: promote to L{target} declined",
+            )
+    return ok

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -152,10 +152,14 @@ class ProposalWorkflow:
         db: aiosqlite.Connection,
         topic_manager: TopicManager | None = None,
         memory_store: MemoryStore | None = None,
+        autonomy_manager: object | None = None,
     ) -> None:
         self._db = db
         self._topic_manager = topic_manager
         self._memory_store = memory_store
+        # AutonomyManager (duck-typed) for the earn-back promote hook in
+        # resolve_proposals. None disables earn-back on the Telegram path.
+        self._autonomy_manager = autonomy_manager
 
     # -- Late-binding setters (wired in standalone.py after Telegram init) --
 
@@ -512,6 +516,20 @@ class ProposalWorkflow:
                 # Auto-store correction memory on rejection with reason
                 if status == ProposalStatus.REJECTED and reason and self._memory_store:
                     await self._store_correction(prop, reason)
+                # Autonomy earn-back: promote on approval / cooldown on reject.
+                # No-op unless this is an autonomy_earnback proposal. Wrapped so a
+                # failure here never aborts resolution of sibling proposals.
+                try:
+                    from genesis.ego.earnback import handle_earnback_resolution
+
+                    await handle_earnback_resolution(
+                        self._db, prop, status, self._autonomy_manager,
+                    )
+                except Exception:
+                    logger.warning(
+                        "earnback resolution hook failed for %s",
+                        prop.get("id"), exc_info=True,
+                    )
             else:
                 logger.warning(
                     "Proposal %s not updated (already resolved?)",

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1659,6 +1659,11 @@ class EgoSession:
 
         dispatched: list[str] = []
         for prop in approved:
+            # Autonomy earn-back proposals are resolved (promoted + marked
+            # executed) at approval time and must NEVER be dispatched as a
+            # session. Defense-in-depth in case one is still 'approved' here.
+            if prop.get("action_type") == "autonomy_earnback":
+                continue
             # Staleness guard — skip proposals approved more than 7 days ago.
             # Proposals go stale by clock only as a safety net; semantic
             # staleness (premise invalid) is the ego's job to evaluate.

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -519,6 +519,18 @@ async def ego_proposal_resolve(
                 user_response=reason or None,
             )
             results[prop["id"]] = status if updated else "not updated"
+            if updated:
+                # Autonomy earn-back: promote on approval / cooldown on reject.
+                try:
+                    from genesis.ego.earnback import handle_earnback_resolution
+                    from genesis.runtime import GenesisRuntime
+
+                    _rt = GenesisRuntime.instance()
+                    await handle_earnback_resolution(
+                        db, prop, status, getattr(_rt, "_autonomy_manager", None),
+                    )
+                except Exception:
+                    logger.debug("earnback resolution hook failed", exc_info=True)
 
     resolved = sum(1 for v in results.values() if v in ("approved", "rejected"))
     return {

--- a/src/genesis/runtime/init/ego.py
+++ b/src/genesis/runtime/init/ego.py
@@ -74,6 +74,7 @@ async def init(rt: GenesisRuntime) -> None:
         proposal_workflow = ProposalWorkflow(
             db=rt._db,
             memory_store=rt._memory_store,
+            autonomy_manager=getattr(rt, "_autonomy_manager", None),
         )
         rt._ego_proposal_workflow = proposal_workflow
 
@@ -140,6 +141,7 @@ async def init(rt: GenesisRuntime) -> None:
             idle_detector=rt._idle_detector,
             db=rt._db,
             event_bus=rt._event_bus,
+            autonomy_manager=getattr(rt, "_autonomy_manager", None),
         )
         rt._ego_cadence_manager = user_ego_cadence
 
@@ -218,6 +220,7 @@ async def init(rt: GenesisRuntime) -> None:
             idle_detector=rt._idle_detector,
             db=rt._db,
             event_bus=rt._event_bus,
+            autonomy_manager=getattr(rt, "_autonomy_manager", None),
         )
         rt._genesis_ego_cadence_manager = genesis_ego_cadence
 

--- a/tests/ego/test_earnback.py
+++ b/tests/ego/test_earnback.py
@@ -1,0 +1,292 @@
+"""Tests for autonomy earn-back (#18): the shared resolution helper and the
+cadence detection/anti-spam path."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import autonomy as autonomy_crud
+from genesis.db.crud import ego as ego_crud
+from genesis.db.schema import create_all_tables
+from genesis.ego.cadence import EgoCadenceManager
+from genesis.ego.earnback import (
+    _parse_target_level,
+    _regression_after,
+    handle_earnback_resolution,
+)
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+async def _make_earnback_proposal(db, *, category="direct_session", target=4, status="approved"):
+    pid = f"eb_{category}"
+    await ego_crud.create_proposal(
+        db,
+        id=pid,
+        action_type="autonomy_earnback",
+        action_category=category,
+        content=f"Restore {category} to L{target}",
+        status="pending",
+        created_at="2026-06-20T00:00:00+00:00",
+        expected_outputs=json.dumps({"target_level": target}),
+    )
+    await ego_crud.resolve_proposal(db, pid, status=status)
+    return await ego_crud.get_proposal(db, pid)
+
+
+# ── _parse_target_level ──────────────────────────────────────────────────
+
+
+def test_parse_target_level():
+    assert _parse_target_level('{"target_level": 4}') == 4
+    assert _parse_target_level({"target_level": 3}) == 3
+    assert _parse_target_level("not json") is None
+    assert _parse_target_level(None) is None
+    assert _parse_target_level('{"other": 1}') is None
+
+
+def test_regression_after():
+    # regression strictly postdates proposal
+    assert _regression_after("2026-06-21T00:00:00+00:00", "2026-06-20T00:00:00+00:00") is True
+    # regression predates proposal
+    assert _regression_after("2026-06-20T00:00:00+00:00", "2026-06-21T00:00:00+00:00") is False
+    # missing values
+    assert _regression_after(None, "2026-06-20T00:00:00+00:00") is False
+    assert _regression_after("2026-06-20T00:00:00+00:00", None) is False
+    # unparseable → False (don't block a user-approved promotion on a parse error)
+    assert _regression_after("garbage", "2026-06-20T00:00:00+00:00") is False
+    # naive timestamp on one side is coerced to UTC, comparison still works
+    assert _regression_after("2026-06-21T00:00:00", "2026-06-20T00:00:00+00:00") is True
+
+
+# ── handle_earnback_resolution ───────────────────────────────────────────
+
+
+async def test_approved_promotes_and_marks_executed(db):
+    prop = await _make_earnback_proposal(db, category="direct_session", target=4)
+    mgr = AsyncMock()
+    mgr.promote = AsyncMock(return_value=True)
+
+    applied = await handle_earnback_resolution(db, prop, "approved", mgr)
+
+    assert applied is True
+    mgr.promote.assert_awaited_once_with(
+        "direct_session", 4, reason="user_approved_earnback",
+    )
+    row = await ego_crud.get_proposal(db, prop["id"])
+    assert row["status"] == "executed"
+
+
+async def test_rejected_sets_cooldown_no_promote(db):
+    prop = await _make_earnback_proposal(db, category="direct_session", status="rejected")
+    mgr = AsyncMock()
+    mgr.promote = AsyncMock(return_value=True)
+
+    applied = await handle_earnback_resolution(db, prop, "rejected", mgr)
+
+    assert applied is False
+    mgr.promote.assert_not_awaited()
+    assert await ego_crud.get_state(db, "earnback_reject:direct_session")
+
+
+async def test_non_earnback_proposal_is_noop(db):
+    await ego_crud.create_proposal(
+        db, id="p_inv", action_type="investigate", content="x", status="pending",
+    )
+    await ego_crud.resolve_proposal(db, "p_inv", status="approved")
+    prop = await ego_crud.get_proposal(db, "p_inv")
+    mgr = AsyncMock()
+    mgr.promote = AsyncMock(return_value=True)
+
+    applied = await handle_earnback_resolution(db, prop, "approved", mgr)
+
+    assert applied is False
+    mgr.promote.assert_not_awaited()
+
+
+async def test_skips_promote_when_regression_postdates_proposal(db):
+    await autonomy_crud.create(
+        db, id="a1", category="direct_session",
+        current_level=3, earned_level=4, updated_at="2026-06-20T00:00:00+00:00",
+    )
+    # Regression AFTER the proposal's created_at (2026-06-20T00:00:00).
+    await db.execute(
+        "UPDATE autonomy_state SET last_regression_at=? WHERE id=?",
+        ("2026-06-21T00:00:00+00:00", "a1"),
+    )
+    await db.commit()
+    prop = await _make_earnback_proposal(db, category="direct_session", target=4)
+    mgr = AsyncMock()
+    mgr.promote = AsyncMock(return_value=True)
+
+    applied = await handle_earnback_resolution(db, prop, "approved", mgr)
+
+    assert applied is False
+    mgr.promote.assert_not_awaited()
+    # Still marked executed so the dispatch sweep never picks it up.
+    row = await ego_crud.get_proposal(db, prop["id"])
+    assert row["status"] == "executed"
+
+
+async def test_none_manager_does_not_crash(db):
+    prop = await _make_earnback_proposal(db, category="direct_session")
+    applied = await handle_earnback_resolution(db, prop, "approved", None)
+    assert applied is False
+
+
+async def test_promote_declined_still_marks_executed(db):
+    """If promote() declines (e.g. already at target), the proposal must not
+    linger as 'approved' — it's marked executed so it can't block re-proposing."""
+    prop = await _make_earnback_proposal(db, category="direct_session", target=4)
+    mgr = AsyncMock()
+    mgr.promote = AsyncMock(return_value=False)
+
+    applied = await handle_earnback_resolution(db, prop, "approved", mgr)
+
+    assert applied is False
+    row = await ego_crud.get_proposal(db, prop["id"])
+    assert row["status"] == "executed"
+
+
+# ── cadence _check_earnback_opportunities ────────────────────────────────
+
+
+_CANDIDATE = {
+    "category": "direct_session", "current_level": 3, "target_level": 4,
+    "total_successes": 50, "total_corrections": 2, "posterior": 0.94,
+    "last_regression_at": "2026-05-25T00:00:00+00:00",
+}
+
+
+def _make_cadence(db, *, source_tag="user_ego_cycle", autonomy_manager=None):
+    session = MagicMock()
+    session._source_tag = source_tag
+    session._db = db
+    session._proposals = AsyncMock()
+    session._proposals.create_batch = AsyncMock(return_value=("batch1", ["pid1"], []))
+    session._proposals.send_digest = AsyncMock(return_value="delivery1")
+    config = MagicMock()
+    config.cadence_minutes = 30
+    cadence = EgoCadenceManager(
+        session=session, config=config, db=db,
+        event_bus=None, autonomy_manager=autonomy_manager,
+    )
+    return cadence, session
+
+
+async def test_cadence_creates_earnback_proposal(db):
+    mgr = AsyncMock()
+    mgr.detect_earnback_candidates = AsyncMock(return_value=[dict(_CANDIDATE)])
+    cadence, session = _make_cadence(db, autonomy_manager=mgr)
+
+    await cadence._check_earnback_opportunities()
+
+    session._proposals.create_batch.assert_awaited_once()
+    proposals = session._proposals.create_batch.call_args.args[0]
+    assert proposals[0]["action_type"] == "autonomy_earnback"
+    assert proposals[0]["action_category"] == "direct_session"
+    assert proposals[0]["expected_outputs"] == {"target_level": 4}
+    session._proposals.send_digest.assert_awaited_once()
+
+
+async def test_cadence_genesis_ego_is_noop(db):
+    mgr = AsyncMock()
+    mgr.detect_earnback_candidates = AsyncMock(return_value=[dict(_CANDIDATE)])
+    cadence, session = _make_cadence(db, source_tag="genesis_ego_cycle", autonomy_manager=mgr)
+
+    await cadence._check_earnback_opportunities()
+
+    mgr.detect_earnback_candidates.assert_not_awaited()
+    session._proposals.create_batch.assert_not_awaited()
+
+
+async def test_cadence_skips_when_pending_exists(db):
+    await ego_crud.create_proposal(
+        db, id="pend1", action_type="autonomy_earnback",
+        action_category="direct_session", content="already pending",
+        status="pending", created_at="2026-06-20T00:00:00+00:00",
+    )
+    mgr = AsyncMock()
+    mgr.detect_earnback_candidates = AsyncMock(return_value=[dict(_CANDIDATE)])
+    cadence, session = _make_cadence(db, autonomy_manager=mgr)
+
+    await cadence._check_earnback_opportunities()
+
+    session._proposals.create_batch.assert_not_awaited()
+
+
+# ── end-to-end through the real resolution path ──────────────────────────
+
+
+async def test_e2e_earnback_promotes_through_resolution(db):
+    """detect → proposal → approve via the real Telegram resolution path → real
+    AutonomyManager.promote → level restored. Runs entirely against an in-memory
+    test DB; no live autonomy state is touched.
+    """
+    from genesis.autonomy.state_machine import AutonomyManager
+    from genesis.ego.proposals import ProposalWorkflow
+
+    # Demoted-but-recovered: current L2, earned L4, evidence (50S/2C → 0.94) → L4.
+    await autonomy_crud.create(
+        db, id="ds", category="direct_session",
+        current_level=2, earned_level=4, updated_at="2026-06-20T00:00:00+00:00",
+    )
+    await db.execute(
+        "UPDATE autonomy_state SET total_successes=50, total_corrections=2 WHERE id='ds'",
+    )
+    await db.commit()
+
+    mgr = AutonomyManager(db=db)
+    workflow = ProposalWorkflow(db=db, autonomy_manager=mgr)
+
+    candidates = await mgr.detect_earnback_candidates()
+    assert len(candidates) == 1
+    cand = candidates[0]
+    proposal = {
+        "action_type": "autonomy_earnback",
+        "action_category": cand["category"],
+        "content": f"Restore {cand['category']} to L{cand['target_level']}",
+        "rationale": "evidence recovered enough to support the earned level",
+        "confidence": 0.9,
+        "urgency": "low",
+        "expected_outputs": {"target_level": cand["target_level"]},
+    }
+    batch_id, ids, _ = await workflow.create_batch(
+        [proposal], ego_source="user_ego_cycle",
+    )
+    assert len(ids) == 1
+
+    # Approve via the real resolution path (the Telegram entry point).
+    await workflow.resolve_proposals(batch_id, {1: ("approved", None)})
+
+    # The real promote fired: current_level restored to the earned level...
+    state = await mgr.get_state("direct_session")
+    assert int(state.current_level) == 4
+    # ...and the proposal was marked executed (never dispatched as a session).
+    row = await ego_crud.get_proposal(db, ids[0])
+    assert row["status"] == "executed"
+
+
+async def test_cadence_skips_on_cooldown(db):
+    await ego_crud.set_state(
+        db, key="earnback_reject:direct_session", value=datetime.now(UTC).isoformat(),
+    )
+    mgr = AsyncMock()
+    mgr.detect_earnback_candidates = AsyncMock(return_value=[dict(_CANDIDATE)])
+    cadence, session = _make_cadence(db, autonomy_manager=mgr)
+
+    await cadence._check_earnback_opportunities()
+
+    session._proposals.create_batch.assert_not_awaited()

--- a/tests/test_autonomy/test_state_machine.py
+++ b/tests/test_autonomy/test_state_machine.py
@@ -421,3 +421,60 @@ class TestForceRegress:
     @pytest.mark.asyncio
     async def test_force_regress_missing_category(self, manager):
         assert await manager.force_regress("nonexistent") is False
+
+
+async def _seed_autonomy_state(
+    db, category, *, current, earned, successes, corrections, last_regression_at=None,
+):
+    """Insert an autonomy_state row with explicit counts for earn-back tests."""
+    await db.execute(
+        "INSERT INTO autonomy_state (id, category, current_level, earned_level, "
+        "total_successes, total_corrections, last_regression_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (category, category, current, earned, successes, corrections,
+         last_regression_at, "2026-06-20T00:00:00+00:00"),
+    )
+    await db.commit()
+
+
+class TestDetectEarnbackCandidates:
+    @pytest.mark.asyncio
+    async def test_candidate_when_demoted_and_evidence_recovered(self, manager, db):
+        # 50 successes / 2 corrections → posterior 0.94 → L4 supports earned L4.
+        await _seed_autonomy_state(
+            db, "direct_session", current=2, earned=4, successes=50, corrections=2,
+        )
+        cands = await manager.detect_earnback_candidates()
+        assert len(cands) == 1
+        assert cands[0]["category"] == "direct_session"
+        assert cands[0]["current_level"] == 2
+        assert cands[0]["target_level"] == 4
+
+    @pytest.mark.asyncio
+    async def test_no_candidate_when_not_demoted(self, manager, db):
+        await _seed_autonomy_state(
+            db, "direct_session", current=4, earned=4, successes=50, corrections=2,
+        )
+        assert await manager.detect_earnback_candidates() == []
+
+    @pytest.mark.asyncio
+    async def test_no_candidate_when_evidence_insufficient(self, manager, db):
+        # Live direct_session shape: 33S / 14C → posterior 0.694 → L3 < earned L4.
+        await _seed_autonomy_state(
+            db, "direct_session", current=3, earned=4, successes=33, corrections=14,
+        )
+        assert await manager.detect_earnback_candidates() == []
+
+    @pytest.mark.asyncio
+    async def test_returns_only_eligible_categories(self, manager, db):
+        await _seed_autonomy_state(
+            db, "direct_session", current=2, earned=4, successes=50, corrections=2,
+        )  # eligible
+        await _seed_autonomy_state(
+            db, "outreach", current=1, earned=1, successes=0, corrections=0,
+        )  # not demoted
+        await _seed_autonomy_state(
+            db, "sub_agent", current=2, earned=3, successes=3, corrections=14,
+        )  # evidence too low (L1 < earned L3)
+        cands = await manager.detect_earnback_candidates()
+        assert [c["category"] for c in cands] == ["direct_session"]


### PR DESCRIPTION
Wires an **evidence-gated, user-approved "earn-back"** path so a demoted autonomy category isn't stuck forever. `promote()`/`restore_earned_level()` previously had zero non-test callers and `record_success` no longer auto-promotes, so once a category regressed it could never climb back.

## Design (user-chosen: evidence-gated)
- **Detection** — `AutonomyManager.detect_earnback_candidates()`: a category is a candidate iff `current_level < earned_level` AND `bayesian_level(successes, corrections) >= earned_level`. The Bayesian gate keeps it **silent while the lower level is genuinely correct** (e.g. the live `direct_session` at 33S/14C → posterior 0.694 → L3 < earned L4 does **not** fire) and only proposes once the category re-earns the level. `consecutive_corrections` is deliberately excluded (it resets to 0 on regression).
- **Proposal** — `EgoCadenceManager._check_earnback_opportunities()` runs in the existing 30-min `_sweep_with_expiry`, **user-ego only**, raising an `autonomy_earnback` proposal. Anti-spam: skip a category with a pending earn-back proposal (+ create_batch content-hash dedup) or an active **7-day reject cooldown**.
- **Approval → promote** — `ego/earnback.py::handle_earnback_resolution` is a narrow, shared hook called from **all four** resolution paths (Telegram `resolve_proposals`, the `ego_proposal_resolve` MCP tool, and the two dashboard routes). On approval it re-reads state, **skips the promote if a regression postdates the proposal**, otherwise calls `manager.promote()` and marks the proposal `executed`. On reject it sets the cooldown. It is a no-op for any non-earn-back proposal and never changes the other paths' behaviour.
- **Guard B** — the approved-proposal sweep (`_sweep_approved_inner`) skips `autonomy_earnback` so it can never be dispatched as a session.

**Never auto-promotes** — every restoration is the user's explicit decision, and it respects a legitimate demotion (no nagging while the evidence agrees the lower level belongs).

## Architecture review
Ran a `genesis-architect` pass **before** coding (it steered me off a risky "re-route all four paths through `resolve_proposals`" approach toward the narrow shared hook) and a `code-reviewer` pass after, which found 3 issues — all fixed: (1) wrap the Telegram-path hook in try/except so a DB error can't abort sibling-proposal resolution; (2) parse ISO timestamps instead of comparing strings in the staleness guard; (3) mark the proposal `executed` even when `promote()` declines, so it can't linger `approved` or block re-proposing.

## Verification
- **24 new tests** + no regression in 129 existing ego tests. Includes an **E2E test through the real resolution path with a real `AutonomyManager`**: seed a demoted-but-recovered category → detect → proposal → approve → real `promote()` fires → `current_level` 2→4, proposal `executed`. All runs against an in-memory test DB — **no live autonomy state touched** (`direct_session` stays at L3, which is correct).
- No DB migration (the `autonomy_state` regression-timestamp columns already exist). Lint clean.
- Docs: `autonomy-deep-dive.md` updated (its "promotion caps at +1 per success" line was stale — promotion is approval-gated now) + earn-back documented.
