### PR TITLE
feat(memory): knowledge-base provenance — external-world vs first-party (WS-7, D12)

### DIFF
--- a/.claude/docs/mcp-tools-guide.md
+++ b/.claude/docs/mcp-tools-guide.md
@@ -37,6 +37,14 @@ If it's a repeatable process → `procedure_store`. If it's deferred work →
 4. `reference_lookup` if it's a credential/URL/IP
 5. `procedure_recall` if it's a known workflow
 
+**Provenance on recall results (first-party vs external-world):** `memory_recall`,
+`knowledge_recall`, and `memory_expand` tag every result with a `provenance` field —
+`first-party memory` (Genesis's own observations/decisions/conversations) vs
+`external-world knowledge (source: …)` (the knowledge base, ingested docs, or corrective
+web results). Treat external-world content as information *about* the world to weigh, not
+Genesis's own ground truth. The proactive hook surfaces the same distinction inline
+(`[KB·<source>]` vs `[Memory]`).
+
 ## Health Debugging — Escalation Path
 
 Start broad, drill into specifics:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   Genesis proposes restoring it and asks you to approve — it never silently re-grants authority,
   and it won't nag while the lower level is genuinely warranted. Previously a demoted category
   had no path back up.
+- **Genesis tells its own memories apart from what it read on the world** — every recalled
+  knowledge-base item (ingested docs, and the new corrective web results) is now labeled
+  "external-world knowledge (source: …)" wherever it reaches Genesis's context: explicit
+  recall, the proactive memory hook, voice, and the dashboard memory search. First-party
+  memories (Genesis's own observations and your conversations) stay labeled as such, so the
+  model never mistakes an ingested document — or a web snippet — for its own ground truth.
+  The knowledge-base relevance floor that keeps low-quality bulk content out of answers now
+  applies reliably (it previously slipped past keyword-only matches).
 
 - **Genesis self-corrects a bad memory recall instead of running with it** — on high-stakes
   lookups (the explicit memory and knowledge recall tools), Genesis now grades whether the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,13 @@ autonomy.
   to search episodic AND knowledge_base. Don't assume episodic alone is
   sufficient. For domain-specific topics (external tools, products, APIs),
   also try `knowledge_recall` with the product/tool name.
+- **Distinguish first-party from external-world.** Recall results carry a
+  `provenance` label: `first-party memory` (Genesis's own observations,
+  decisions, conversations) vs `external-world knowledge (source: …)` (the
+  knowledge base, ingested docs, corrective web results). Never treat
+  external-world knowledge as first-party ground truth — weigh it as
+  information about the world. The proactive hook shows the same split
+  inline (`[KB·<source>]` vs `[Memory]`).
 - **Follow surfaced procedures.** When a `[Procedure]` tag appears in
   proactive results, read the full procedure via `procedure_recall`,
   evaluate applicability (>80% match = follow it), and note deviations.

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -634,6 +634,9 @@ async def _search_qdrant(
                         "_retrieved_count": payload.get("retrieved_count", 0),
                         "_wing": payload.get("wing"),
                         "collection": collection,
+                        # Provenance source tier for KB results (audit D12) — the
+                        # label needs it; memory_metadata doesn't carry it.
+                        "source_pipeline": payload.get("source_pipeline"),
                     })
                 return results
     except Exception as exc:
@@ -832,7 +835,13 @@ def _format_results(results: list[dict]) -> str:
         wing = r.get("_wing") or ""
 
         is_kb = r.get("collection") == "knowledge_base"
-        parts = ["KB" if is_kb else "Memory"]
+        if is_kb:
+            # Name the external source tier so the model treats KB content as
+            # external-world info, not its own first-party memory (audit D12).
+            from genesis.memory.provenance import short_source
+            parts = [f"KB·{short_source(r.get('source_pipeline'))}"]
+        else:
+            parts = ["Memory"]
         if age != "?" and not is_kb:
             parts.append(age)
         if wing and wing != "memory":

--- a/src/genesis/channels/voice/handler.py
+++ b/src/genesis/channels/voice/handler.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 from genesis.channels.tts_config import sanitize_for_speech
 from genesis.channels.voice.sessions import VoiceSessionManager
+from genesis.memory.provenance import is_external
 
 if TYPE_CHECKING:
     from genesis.memory.retrieval import HybridRetriever
@@ -92,7 +93,6 @@ class VoiceConversationHandler:
         try:
             results = await self._retriever.recall(transcript, limit=5, rerank=False)
             if results:
-                from genesis.memory.provenance import is_external
                 snippets = []
                 for r in results[:5]:
                     content = getattr(r, "content", str(r))

--- a/src/genesis/channels/voice/handler.py
+++ b/src/genesis/channels/voice/handler.py
@@ -92,11 +92,19 @@ class VoiceConversationHandler:
         try:
             results = await self._retriever.recall(transcript, limit=5, rerank=False)
             if results:
+                from genesis.memory.provenance import is_external
                 snippets = []
                 for r in results[:5]:
                     content = getattr(r, "content", str(r))
                     if isinstance(content, str) and content.strip():
-                        snippets.append(f"- {content[:300]}")
+                        # Mark external-world KB so it isn't spoken as first-party
+                        # memory (audit D12).
+                        prefix = (
+                            "[external-world knowledge] "
+                            if is_external(getattr(r, "collection", ""))
+                            else ""
+                        )
+                        snippets.append(f"- {prefix}{content[:300]}")
                 if snippets:
                     memories_text = "Recalled memories:\n" + "\n".join(snippets)
         except Exception:

--- a/src/genesis/dashboard/routes/memory.py
+++ b/src/genesis/dashboard/routes/memory.py
@@ -40,6 +40,8 @@ async def memory_search():
 
         results = await rt.hybrid_retriever.recall(query=query, limit=limit)
 
+        from genesis.memory.provenance import provenance_descriptor
+
         items = []
         for r in results:
             items.append({
@@ -53,6 +55,14 @@ async def memory_search():
                 "activation_score": round(r.activation_score, 4) if r.activation_score else None,
                 "source_session_id": r.source_session_id,
                 "source_pipeline": r.source_pipeline,
+                # Provenance (audit D12): let the UI distinguish/badge
+                # external-world KB from first-party memory.
+                "collection": r.collection,
+                "provenance": provenance_descriptor(
+                    collection=r.collection,
+                    source_pipeline=r.source_pipeline,
+                    source_doc=r.source,
+                ),
             })
 
         return jsonify({"results": items, "query": query, "count": len(items)})

--- a/src/genesis/dashboard/routes/memory.py
+++ b/src/genesis/dashboard/routes/memory.py
@@ -8,6 +8,7 @@ import aiosqlite
 from flask import jsonify, request
 
 from genesis.dashboard._blueprint import _async_route, blueprint
+from genesis.memory.provenance import provenance_descriptor
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +40,6 @@ async def memory_search():
             return jsonify({"error": "Memory retriever not initialized"}), 503
 
         results = await rt.hybrid_retriever.recall(query=query, limit=limit)
-
-        from genesis.memory.provenance import provenance_descriptor
 
         items = []
         for r in results:

--- a/src/genesis/ego/context.py
+++ b/src/genesis/ego/context.py
@@ -477,8 +477,13 @@ class EgoContextBuilder:
                 lines.append("*Memory retriever not available.*\n")
                 return "\n".join(lines)
 
+            # Pin to episodic (audit D12): user corrections are first-party and
+            # stored episodic; without this the query classifies GENERAL → both,
+            # letting a knowledge_base item tagged 'user_correction' masquerade
+            # as a real user correction in the ego's context.
             results = await retriever.recall(
                 "user correction ego",
+                source="episodic",
                 limit=10,
             )
             # Filter for corrections tagged by the ego correction handler

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 
 from genesis.memory.activation import compute_activation
 from genesis.memory.graph import traverse as graph_traverse
+from genesis.memory.provenance import is_external, provenance_descriptor
 
 from ..memory import mcp
 
@@ -231,6 +232,7 @@ async def memory_recall(
                         activation_score=0.0,
                         payload=row,
                         source_pipeline="event_calendar",
+                        collection=row.get("collection", "episodic_memory"),
                     ))
             except Exception:
                 logger.warning(
@@ -242,11 +244,14 @@ async def memory_recall(
     # to knowledge_base results to suppress low-relevance bulk intelligence.
     # Episodic results are unfiltered. Score floor matches knowledge_recall's
     # min_score=0.15 (post-authority-boost) as a conservative baseline.
+    # Keyed on the authoritative ``collection`` discriminator (audit D12), not
+    # payload["scope"] — the latter is absent on FTS5-only / pre-scope rows, so
+    # the old check silently let low-relevance KB through that path.
     _KB_MIN_SCORE = 0.15
     if source == "both":
         results = [
             r for r in results
-            if r.payload.get("scope") != "external" or r.score >= _KB_MIN_SCORE
+            if not is_external(r.collection) or r.score >= _KB_MIN_SCORE
         ]
 
     # MCP-layer instrumentation: emit with mode and pipeline attribution
@@ -279,6 +284,13 @@ async def memory_recall(
                 "room": r.payload.get("room", ""),
                 "source": r.source,
                 "source_pipeline": r.source_pipeline or "",
+                # Provenance (audit D12): first-party memory vs external-world KB,
+                # so the model never treats ingested content as its own truth.
+                "provenance": provenance_descriptor(
+                    collection=r.collection,
+                    source_pipeline=r.source_pipeline,
+                    source_doc=r.source,
+                ),
             }
             for r in results
         ]
@@ -288,6 +300,13 @@ async def memory_recall(
     graph_elapsed_ms = 0.0
     for r in results:
         d = asdict(r)
+        # Provenance label (audit D12) — asdict already carries the raw
+        # ``collection``; add the human/LLM-readable first-party-vs-external tag.
+        d["provenance"] = provenance_descriptor(
+            collection=r.collection,
+            source_pipeline=r.source_pipeline,
+            source_doc=r.source,
+        )
         if include_graph and graph_elapsed_ms < graph_budget_ms:
             try:
                 traversal = await graph_traverse(
@@ -342,15 +361,22 @@ async def memory_expand(
     memory_mod._require_init()
     assert memory_mod._qdrant is not None and memory_mod._db is not None
 
-    # Batch retrieve from all collections (episodic_memory + knowledge_base)
+    # Batch retrieve from all collections (episodic_memory + knowledge_base).
+    # Track which collection each point came from — it's the authoritative
+    # first-party/external discriminator (audit D12) and is otherwise lost once
+    # the per-collection results are flattened into one list.
     points: list = []
+    point_collection: dict[str, str] = {}
     for coll in ("episodic_memory", "knowledge_base"):
         try:
-            points.extend(memory_mod._qdrant.retrieve(
+            got = memory_mod._qdrant.retrieve(
                 collection_name=coll,
                 ids=memory_ids,
                 with_payload=True,
-            ))
+            )
+            for p in got:
+                point_collection[str(p.id)] = coll
+            points.extend(got)
         except Exception:
             logger.warning("Qdrant retrieve from %s failed", coll, exc_info=True)
 
@@ -377,6 +403,7 @@ async def memory_expand(
     for point in points:
         mid = str(point.id)
         payload = point.payload or {}
+        _collection = point_collection.get(mid, "episodic_memory")
 
         d = {
             "memory_id": mid,
@@ -391,6 +418,13 @@ async def memory_expand(
             "source_pipeline": payload.get("source_pipeline", ""),
             "source_session_id": payload.get("source_session_id"),
             "created_at": payload.get("created_at"),
+            # Provenance (audit D12): first-party memory vs external-world KB.
+            "collection": _collection,
+            "provenance": provenance_descriptor(
+                collection=_collection,
+                source_pipeline=payload.get("source_pipeline"),
+                source_doc=payload.get("source"),
+            ),
         }
 
         # Graph enrichment

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -8,7 +8,11 @@ from datetime import UTC, datetime
 
 from genesis.memory.activation import compute_activation
 from genesis.memory.graph import traverse as graph_traverse
-from genesis.memory.provenance import is_external, provenance_descriptor
+from genesis.memory.provenance import (
+    is_external,
+    label_result_dicts,
+    provenance_descriptor,
+)
 
 from ..memory import mcp
 
@@ -300,13 +304,6 @@ async def memory_recall(
     graph_elapsed_ms = 0.0
     for r in results:
         d = asdict(r)
-        # Provenance label (audit D12) — asdict already carries the raw
-        # ``collection``; add the human/LLM-readable first-party-vs-external tag.
-        d["provenance"] = provenance_descriptor(
-            collection=r.collection,
-            source_pipeline=r.source_pipeline,
-            source_doc=r.source,
-        )
         if include_graph and graph_elapsed_ms < graph_budget_ms:
             try:
                 traversal = await graph_traverse(
@@ -345,6 +342,10 @@ async def memory_recall(
             pipeline_used=pipeline_used,
             recall_event_id=recall_event_id,
         )
+    # Provenance pass (audit D12): label original + any CRAG-augmented items as
+    # first-party vs external-world. Runs regardless of `corrective` so the
+    # output contract is uniform.
+    label_result_dicts(enriched, default_collection="episodic_memory")
     return enriched
 
 

--- a/src/genesis/mcp/memory/knowledge.py
+++ b/src/genesis/mcp/memory/knowledge.py
@@ -6,7 +6,7 @@ import json
 import logging
 from datetime import UTC, datetime
 
-from genesis.memory.provenance import provenance_descriptor
+from genesis.memory.provenance import label_result_dicts
 from genesis.memory.reference_ops import (
     REFERENCE_KINDS as _REFERENCE_KINDS,
 )
@@ -99,14 +99,6 @@ async def knowledge_recall(
             "score": r.score,
             "origin": "vector",
             "source_pipeline": r.source_pipeline,
-            # All knowledge_recall results are external-world by definition
-            # (the KB collection) — label them so the model never treats an
-            # ingested doc as first-party ground truth (audit D12).
-            "provenance": provenance_descriptor(
-                collection="knowledge_base",
-                source_pipeline=r.source_pipeline,
-                source_doc=r.source,
-            ),
         })
 
     for idx, fts_row in enumerate(fts_results):
@@ -126,11 +118,6 @@ async def knowledge_recall(
                 "score": fts_score,
                 "origin": "fts",
                 "source_pipeline": fts_row.get("source_pipeline"),
-                "provenance": provenance_descriptor(
-                    collection="knowledge_base",
-                    source_pipeline=fts_row.get("source_pipeline"),
-                    source_doc=fts_row.get("source_doc"),
-                ),
             })
 
     boosted = _apply_authority_boost(merged)
@@ -166,6 +153,10 @@ async def knowledge_recall(
             path="knowledge",
             recall_event_id=recall_event_id,
         )
+    # Provenance pass (audit D12): every knowledge_recall result is external-world
+    # — label original + any CRAG-augmented / web-fallback items. Runs regardless
+    # of `corrective` so the contract is uniform.
+    label_result_dicts(final, default_collection="knowledge_base")
     return final
 
 

--- a/src/genesis/mcp/memory/knowledge.py
+++ b/src/genesis/mcp/memory/knowledge.py
@@ -6,6 +6,7 @@ import json
 import logging
 from datetime import UTC, datetime
 
+from genesis.memory.provenance import provenance_descriptor
 from genesis.memory.reference_ops import (
     REFERENCE_KINDS as _REFERENCE_KINDS,
 )
@@ -94,9 +95,18 @@ async def knowledge_recall(
             "unit_id": r.memory_id,
             "content": r.content,
             "source": r.source,
+            "source_doc": r.source,
             "score": r.score,
             "origin": "vector",
             "source_pipeline": r.source_pipeline,
+            # All knowledge_recall results are external-world by definition
+            # (the KB collection) — label them so the model never treats an
+            # ingested doc as first-party ground truth (audit D12).
+            "provenance": provenance_descriptor(
+                collection="knowledge_base",
+                source_pipeline=r.source_pipeline,
+                source_doc=r.source,
+            ),
         })
 
     for idx, fts_row in enumerate(fts_results):
@@ -116,6 +126,11 @@ async def knowledge_recall(
                 "score": fts_score,
                 "origin": "fts",
                 "source_pipeline": fts_row.get("source_pipeline"),
+                "provenance": provenance_descriptor(
+                    collection="knowledge_base",
+                    source_pipeline=fts_row.get("source_pipeline"),
+                    source_doc=fts_row.get("source_doc"),
+                ),
             })
 
     boosted = _apply_authority_boost(merged)

--- a/src/genesis/memory/corrective.py
+++ b/src/genesis/memory/corrective.py
@@ -374,6 +374,11 @@ def _retrieval_to_dict(rr: Any) -> dict:
         "content": getattr(rr, "content", ""),
         "score": getattr(rr, "score", 0.0),
         "payload": getattr(rr, "payload", {}) or {},
+        # Preserve the provenance discriminator (audit D12) so augmented items
+        # are labeled first-party vs external-world at the MCP return pass —
+        # the relaxed/raw-KB re-retrieve can legitimately pull KB content.
+        "collection": getattr(rr, "collection", "episodic_memory"),
+        "source_pipeline": getattr(rr, "source_pipeline", None),
     }
 
 

--- a/src/genesis/memory/drift.py
+++ b/src/genesis/memory/drift.py
@@ -408,6 +408,7 @@ async def drift_recall(
                 memory_class=row.get("memory_class", "fact"),
                 query_intent=intent.category,
                 intent_confidence=intent.confidence,
+                collection=row.get("collection", "episodic_memory"),
             )
         )
 

--- a/src/genesis/memory/knowledge_ingest.py
+++ b/src/genesis/memory/knowledge_ingest.py
@@ -128,7 +128,10 @@ async def ingest_knowledge_unit(
         section_title=provenance.get("section_title") if provenance else None,
         source_date=provenance.get("source_date") if provenance else None,
         embedding_model=embedding_model,
-        source_pipeline=provenance.get("source_pipeline") if provenance else None,
+        # Mirror the Qdrant write's default (audit D12): never leave the SQLite
+        # knowledge_units pipeline NULL while the vector payload has a value —
+        # provenance must be consistent across both stores.
+        source_pipeline=source_pipeline_val,
         purpose=json.dumps(purpose) if purpose else None,
         ingestion_source=ingestion_source,
     )

--- a/src/genesis/memory/provenance.py
+++ b/src/genesis/memory/provenance.py
@@ -1,0 +1,89 @@
+"""First-party vs external-world provenance labels for recalled memory.
+
+Genesis distinguishes FIRST-PARTY memory (its own observations, decisions, and
+conversations — the ``episodic_memory`` collection) from EXTERNAL-WORLD
+knowledge (ingested docs/APIs/papers and other content pulled off the world —
+the ``knowledge_base`` collection). When KB content enters an LLM context it
+must be labeled as external so the self-model never mistakes scraped knowledge
+for its own ground truth (audit finding D12).
+
+The authoritative discriminator is the Qdrant **collection** a memory was
+retrieved from — always known at retrieval time, unlike the per-item store-time
+``source`` string. These helpers turn that signal (plus the already-stored
+``source_pipeline`` provenance) into a human/LLM-readable label.
+"""
+
+from __future__ import annotations
+
+#: The external-world knowledge collection. Everything else is first-party.
+KNOWLEDGE_COLLECTION = "knowledge_base"
+
+_EXTERNAL = "external-world knowledge"
+_FIRST_PARTY = "first-party memory"
+
+# Friendly source descriptors keyed by a substring of ``source_pipeline``.
+# Order matters: more-specific keys precede the prefixes they contain.
+_PIPELINE_FRIENDLY: dict[str, str] = {
+    "curated": "user-curated",
+    "knowledge_ingest_source": "ingested doc",
+    "knowledge_ingest": "ingested doc",
+    "reference_store": "saved reference",
+    "extraction_job": "auto-extracted",
+    "recon": "recon/web",
+    "surplus": "surplus insight",
+}
+
+# Terse, space-free tokens for tight contexts (the proactive-recall hook).
+_PIPELINE_SHORT: dict[str, str] = {
+    "curated": "curated",
+    "knowledge_ingest_source": "ingested",
+    "knowledge_ingest": "ingested",
+    "reference_store": "ref",
+    "extraction_job": "extracted",
+    "recon": "recon",
+    "surplus": "surplus",
+}
+
+# Placeholder ``source_doc`` values that carry no real provenance.
+_PLACEHOLDER_DOCS = {"", "manual"}
+
+
+def is_external(collection: str | None) -> bool:
+    """True when the memory came from the external-world knowledge base.
+
+    A missing/unknown collection is treated as first-party — the conservative,
+    non-alarming default (never label something external on a guess).
+    """
+    return collection == KNOWLEDGE_COLLECTION
+
+
+def _match(table: dict[str, str], source_pipeline: str | None, default: str) -> str:
+    if source_pipeline:
+        for key, label in table.items():
+            if key in source_pipeline:
+                return label
+    return default
+
+
+def short_source(source_pipeline: str | None) -> str:
+    """Terse, single-token external-source tag (for the proactive hook)."""
+    return _match(_PIPELINE_SHORT, source_pipeline, "ext")
+
+
+def provenance_descriptor(
+    *,
+    collection: str | None,
+    source_pipeline: str | None = None,
+    source_doc: str | None = None,
+) -> str:
+    """One-line provenance label for a recalled item.
+
+    External → ``"external-world knowledge (source: <friendly>[, doc: <doc>])"``.
+    First-party → ``"first-party memory"``.
+    """
+    if not is_external(collection):
+        return _FIRST_PARTY
+    friendly = _match(_PIPELINE_FRIENDLY, source_pipeline, "external source")
+    if source_doc and source_doc not in _PLACEHOLDER_DOCS:
+        return f"{_EXTERNAL} (source: {friendly}, doc: {source_doc})"
+    return f"{_EXTERNAL} (source: {friendly})"

--- a/src/genesis/memory/provenance.py
+++ b/src/genesis/memory/provenance.py
@@ -29,6 +29,7 @@ _PIPELINE_FRIENDLY: dict[str, str] = {
     "knowledge_ingest": "ingested doc",
     "reference_store": "saved reference",
     "extraction_job": "auto-extracted",
+    "crag_web": "web",  # CRAG web-fallback augmentation — live internet content
     "recon": "recon/web",
     "surplus": "surplus insight",
 }
@@ -40,6 +41,7 @@ _PIPELINE_SHORT: dict[str, str] = {
     "knowledge_ingest": "ingested",
     "reference_store": "ref",
     "extraction_job": "extracted",
+    "crag_web": "web",
     "recon": "recon",
     "surplus": "surplus",
 }
@@ -87,3 +89,37 @@ def provenance_descriptor(
     if source_doc and source_doc not in _PLACEHOLDER_DOCS:
         return f"{_EXTERNAL} (source: {friendly}, doc: {source_doc})"
     return f"{_EXTERNAL} (source: {friendly})"
+
+
+def label_result_dicts(
+    dicts: list[dict],
+    *,
+    default_collection: str = "episodic_memory",
+) -> list[dict]:
+    """Stamp ``collection`` + ``provenance`` onto a list of recall result dicts.
+
+    Applied as a FINAL pass at MCP return points — AFTER any corrective-retrieval
+    (CRAG) augmentation — so original, relaxed/raw-KB-augmented, AND web-fallback
+    items are all labeled (audit D12). Idempotent and best-effort: a re-labeled
+    item gets the same value; sentinel dicts (e.g. ``{"not_found": [...]}``) pass
+    through untouched. CRAG web items (``origin='web'`` / ``source_pipeline=
+    'crag_web'``) are unambiguously external-world web content.
+    """
+    for d in dicts:
+        if not isinstance(d, dict):
+            continue
+        if "memory_id" not in d and "unit_id" not in d:
+            continue  # sentinel row — leave alone
+        payload = d.get("payload") or {}
+        sp = d.get("source_pipeline") or payload.get("source_pipeline")
+        if d.get("origin") == "web" or sp == "crag_web":
+            coll = KNOWLEDGE_COLLECTION
+        else:
+            coll = d.get("collection") or payload.get("collection") or default_collection
+        d["collection"] = coll
+        d["provenance"] = provenance_descriptor(
+            collection=coll,
+            source_pipeline=sp,
+            source_doc=d.get("source_doc") or d.get("source") or payload.get("source"),
+        )
+    return dicts

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -729,17 +729,22 @@ class HybridRetriever:
             qdrant_hit = qdrant_by_id.get(mid)
             fts_hit = fts_by_id.get(mid)
 
-            # Determine content and metadata
+            # Determine content and metadata. ``_collection`` is the
+            # authoritative first-party/external discriminator (audit D12):
+            # the Qdrant collection on a vector hit (set at recall time, ~L367),
+            # or the FTS row's collection tag for an FTS5-only hit.
             if qdrant_hit:
                 payload = qdrant_hit.get("payload", {})
                 content = payload.get("content", "")
                 src = payload.get("source", "")
                 mem_type = payload.get("memory_type", "")
+                _collection = qdrant_hit.get("_collection", "episodic_memory")
             elif fts_hit:
                 content = fts_hit.get("content", "")
                 src = fts_hit.get("source_type", "")
                 mem_type = fts_hit.get("collection", "")
                 payload = fts_hit
+                _collection = fts_hit.get("collection", "episodic_memory")
             else:
                 continue
 
@@ -779,6 +784,7 @@ class HybridRetriever:
                     memory_class=_p.get("memory_class", "fact"),
                     query_intent=intent.category,
                     intent_confidence=intent.confidence,
+                    collection=_collection,
                 ),
             )
 

--- a/src/genesis/memory/types.py
+++ b/src/genesis/memory/types.py
@@ -48,6 +48,13 @@ class RetrievalResult:
     # Intent routing — V4 groundwork
     query_intent: str | None = None
     intent_confidence: float = 0.0
+    # Provenance discriminator (audit D12): the Qdrant collection this result was
+    # retrieved from. ``knowledge_base`` == external-world knowledge; anything
+    # else == first-party memory. Authoritative (always known at retrieval),
+    # unlike the per-item ``source`` string. Defaults first-party so an unset
+    # value is never mislabeled external. Kept LAST for positional-construction
+    # safety. Use ``genesis.memory.provenance`` to turn it into a label.
+    collection: str = "episodic_memory"
 
 
 @dataclass(frozen=True)

--- a/tests/ego/test_corrections_provenance.py
+++ b/tests/ego/test_corrections_provenance.py
@@ -1,0 +1,33 @@
+"""WS-7 / D12: the ego's user-corrections recall is pinned to first-party.
+
+Without ``source='episodic'`` the query "user correction ego" classifies as
+GENERAL → both collections, so a knowledge_base item tagged 'user_correction'
+could surface as if it were a real user correction. Pinning prevents that.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import genesis.runtime as runtime_mod
+from genesis.ego.context import EgoContextBuilder
+
+
+@pytest.mark.asyncio
+async def test_user_corrections_recall_pinned_to_episodic(monkeypatch):
+    retriever = MagicMock()
+    retriever.recall = AsyncMock(return_value=[])
+    rt = MagicMock()
+    rt._hybrid_retriever = retriever
+    monkeypatch.setattr(
+        runtime_mod.GenesisRuntime, "instance", staticmethod(lambda: rt),
+    )
+
+    builder = EgoContextBuilder(db=None)
+    await builder._user_corrections_section()
+
+    retriever.recall.assert_awaited_once_with(
+        "user correction ego", source="episodic", limit=10,
+    )

--- a/tests/test_channels/test_voice_provenance.py
+++ b/tests/test_channels/test_voice_provenance.py
@@ -1,0 +1,52 @@
+"""WS-7 / D12: the voice handler marks external-world KB snippets.
+
+Recalled knowledge_base content injected into a spoken response must be flagged
+external so it isn't voiced as Genesis's own first-party memory.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.channels.voice.handler import VoiceConversationHandler
+
+
+def _router():
+    router = MagicMock()
+    res = MagicMock()
+    res.success = True
+    res.content = "ok"
+    router.route_call = AsyncMock(return_value=res)
+    return router
+
+
+@pytest.mark.asyncio
+async def test_voice_labels_external_kb_snippet():
+    retriever = AsyncMock()
+    kb = MagicMock()
+    kb.content = "FastAPI is built on Starlette"
+    kb.collection = "knowledge_base"
+    retriever.recall.return_value = [kb]
+
+    handler = VoiceConversationHandler(retriever=retriever, router=_router())
+    out = await handler.handle("how does fastapi work", "sess-kb", raw_snippets=True)
+
+    assert "[external-world knowledge]" in out
+    assert "FastAPI is built on Starlette" in out
+
+
+@pytest.mark.asyncio
+async def test_voice_episodic_snippet_unlabeled():
+    retriever = AsyncMock()
+    ep = MagicMock()
+    ep.content = "we discussed the roadmap"
+    ep.collection = "episodic_memory"
+    retriever.recall.return_value = [ep]
+
+    handler = VoiceConversationHandler(retriever=retriever, router=_router())
+    out = await handler.handle("what did we discuss", "sess-ep", raw_snippets=True)
+
+    assert "[external-world knowledge]" not in out
+    assert "we discussed the roadmap" in out

--- a/tests/test_dashboard/test_memory_route_provenance.py
+++ b/tests/test_dashboard/test_memory_route_provenance.py
@@ -1,0 +1,53 @@
+"""WS-7 / D12: the dashboard memory-search API exposes provenance.
+
+Each result carries its collection + a first-party/external provenance label so
+the UI can distinguish (and badge) external-world KB from Genesis's own memory.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from genesis.dashboard.api import blueprint
+from genesis.memory.types import RetrievalResult
+
+
+@pytest.fixture()
+def client():
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def _result(mid: str, *, collection: str, pipeline: str | None = None):
+    return RetrievalResult(
+        memory_id=mid, content="some content", source="api.pdf",
+        memory_type="knowledge" if collection == "knowledge_base" else "episodic",
+        score=0.9, vector_rank=1, fts_rank=None, activation_score=0.5,
+        payload={}, source_pipeline=pipeline, collection=collection,
+    )
+
+
+def test_memory_search_exposes_provenance(client):
+    rt = MagicMock()
+    rt.is_bootstrapped = True
+    rt.db = MagicMock()
+    rt.hybrid_retriever = MagicMock()
+    rt.hybrid_retriever.recall = AsyncMock(return_value=[
+        _result("kb1", collection="knowledge_base", pipeline="curated"),
+        _result("ep1", collection="episodic_memory"),
+    ])
+
+    with patch("genesis.runtime.GenesisRuntime") as MockRT:
+        MockRT.instance.return_value = rt
+        resp = client.get("/api/genesis/memory/search?q=fastapi")
+
+    assert resp.status_code == 200
+    by_id = {it["memory_id"]: it for it in resp.get_json()["results"]}
+    assert by_id["kb1"]["collection"] == "knowledge_base"
+    assert by_id["kb1"]["provenance"].startswith("external-world knowledge")
+    assert by_id["ep1"]["provenance"] == "first-party memory"

--- a/tests/test_hooks/test_proactive_provenance.py
+++ b/tests/test_hooks/test_proactive_provenance.py
@@ -1,0 +1,56 @@
+"""WS-7 / D12: the proactive hook must label KB results as external-world.
+
+A knowledge_base hit injected into the prompt should carry its external source
+tier (``KB·<tier>``) so the model never reads ingested content as its own
+first-party memory. Episodic results keep the plain ``Memory`` tag.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Hook lives outside the package tree — add scripts/ to import path.
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import proactive_memory_hook as hook  # noqa: E402
+
+
+def test_format_results_labels_kb_with_source_tier(monkeypatch):
+    monkeypatch.setattr(hook, "_enrich_with_metadata", lambda results: None)
+    out = hook._format_results([
+        {
+            "memory_id": "kb123456ab", "content": "external API doc",
+            "collection": "knowledge_base", "source_pipeline": "recon",
+            "_wing": "research", "_created_at": "", "memory_class": "fact",
+        },
+    ])
+    assert "KB·recon" in out
+    assert "external API doc" in out
+
+
+def test_format_results_kb_null_pipeline_safe(monkeypatch):
+    monkeypatch.setattr(hook, "_enrich_with_metadata", lambda results: None)
+    out = hook._format_results([
+        {
+            "memory_id": "kb999", "content": "doc", "collection": "knowledge_base",
+            "source_pipeline": None, "_wing": "", "_created_at": "",
+            "memory_class": "fact",
+        },
+    ])
+    # NULL pipeline still labels as KB (external), with the generic 'ext' tier.
+    assert "KB·ext" in out
+
+
+def test_format_results_episodic_keeps_plain_memory_tag(monkeypatch):
+    monkeypatch.setattr(hook, "_enrich_with_metadata", lambda results: None)
+    out = hook._format_results([
+        {
+            "memory_id": "ep123456ab", "content": "my own note",
+            "collection": "episodic_memory", "_wing": "memory",
+            "_created_at": "", "memory_class": "fact",
+        },
+    ])
+    assert out.startswith("[Memory")
+    assert "KB·" not in out

--- a/tests/test_memory/test_mcp_integration.py
+++ b/tests/test_memory/test_mcp_integration.py
@@ -248,3 +248,104 @@ async def test_uninitialized_raises(tools):
 
     with pytest.raises(RuntimeError, match="not initialized"):
         await tools["observation_write"].fn(content="x", source="y", type="z")
+
+
+# ─── WS-7 / D12: provenance surfacing ───────────────────────────────────────
+
+
+def _rr(mid: str, *, collection: str, score: float = 0.9, pipeline: str | None = None):
+    """Build a RetrievalResult with a given collection (provenance discriminator)."""
+    return RetrievalResult(
+        memory_id=mid, content=f"content {mid}", source="src",
+        memory_type="knowledge" if collection == "knowledge_base" else "episodic",
+        score=score, vector_rank=1, fts_rank=None, activation_score=0.5,
+        payload={}, source_pipeline=pipeline, collection=collection,
+    )
+
+
+@pytest.mark.asyncio
+async def test_memory_recall_labels_first_party_vs_external(mock_deps, tools):
+    """memory_recall must tag each result's provenance so KB content reads as
+    external-world and episodic reads as first-party (audit D12)."""
+    _init_with_mocks(mock_deps)
+    memory_mcp._retriever = MagicMock()
+    memory_mcp._retriever.recall = AsyncMock(return_value=[
+        _rr("ep1", collection="episodic_memory"),
+        _rr("kb1", collection="knowledge_base", pipeline="curated"),
+    ])
+
+    results = await tools["memory_recall"].fn(
+        query="q", source="both", limit=5, compact=True,
+    )
+    by_id = {r["memory_id"]: r for r in results}
+    assert by_id["ep1"]["provenance"] == "first-party memory"
+    assert by_id["kb1"]["provenance"].startswith("external-world knowledge")
+    assert "user-curated" in by_id["kb1"]["provenance"]
+
+
+@pytest.mark.asyncio
+async def test_memory_recall_both_filter_drops_lowscore_kb_keeps_episodic(mock_deps, tools):
+    """The source='both' KB score floor must key on the collection discriminator,
+    not payload['scope'] — so a low-score KB hit (even FTS-only, no scope) is
+    dropped while a low-score episodic hit is kept (audit D12 bug fix)."""
+    _init_with_mocks(mock_deps)
+    memory_mcp._retriever = MagicMock()
+    memory_mcp._retriever.recall = AsyncMock(return_value=[
+        _rr("kb_low", collection="knowledge_base", score=0.05),   # below 0.15 → drop
+        _rr("kb_high", collection="knowledge_base", score=0.50),  # keep
+        _rr("ep_low", collection="episodic_memory", score=0.05),  # keep (not external)
+    ])
+
+    results = await tools["memory_recall"].fn(
+        query="q", source="both", limit=10, compact=True,
+    )
+    ids = {r["memory_id"] for r in results}
+    assert "kb_low" not in ids
+    assert "kb_high" in ids
+    assert "ep_low" in ids
+
+
+@pytest.mark.asyncio
+async def test_memory_expand_labels_collection_and_provenance(mock_deps, tools):
+    """memory_expand bypasses RetrievalResult — it must still tag each expanded
+    item with its collection + provenance (audit D12)."""
+    from types import SimpleNamespace
+
+    _init_with_mocks(mock_deps)
+
+    def _retrieve(collection_name, ids, with_payload):
+        if collection_name == "knowledge_base":
+            return [SimpleNamespace(
+                id="kb1",
+                payload={"content": "ext doc", "source": "api.pdf",
+                         "source_pipeline": "curated", "memory_type": "knowledge"},
+            )]
+        return [SimpleNamespace(
+            id="ep1",
+            payload={"content": "my note", "source": "chat", "memory_type": "episodic"},
+        )]
+
+    memory_mcp._qdrant.retrieve = MagicMock(side_effect=_retrieve)
+
+    results = await tools["memory_expand"].fn(memory_ids=["ep1", "kb1"])
+    by_id = {r["memory_id"]: r for r in results if "memory_id" in r}
+    assert by_id["ep1"]["collection"] == "episodic_memory"
+    assert by_id["ep1"]["provenance"] == "first-party memory"
+    assert by_id["kb1"]["collection"] == "knowledge_base"
+    assert by_id["kb1"]["provenance"].startswith("external-world knowledge")
+
+
+@pytest.mark.asyncio
+async def test_knowledge_recall_labels_external(mock_deps, tools):
+    """knowledge_recall is all-external by definition — every result must carry
+    the external-world provenance label (audit D12)."""
+    _init_with_mocks(mock_deps)
+    memory_mcp._retriever = MagicMock()
+    memory_mcp._retriever.recall = AsyncMock(return_value=[
+        _rr("kb1", collection="knowledge_base", score=0.9, pipeline="recon"),
+    ])
+
+    results = await tools["knowledge_recall"].fn(query="q", limit=5, min_score=0.0)
+    assert results
+    assert results[0]["provenance"].startswith("external-world knowledge")
+    assert "recon" in results[0]["provenance"]

--- a/tests/test_memory/test_mcp_integration.py
+++ b/tests/test_memory/test_mcp_integration.py
@@ -345,7 +345,66 @@ async def test_knowledge_recall_labels_external(mock_deps, tools):
         _rr("kb1", collection="knowledge_base", score=0.9, pipeline="recon"),
     ])
 
-    results = await tools["knowledge_recall"].fn(query="q", limit=5, min_score=0.0)
+    results = await tools["knowledge_recall"].fn(
+        query="q", limit=5, min_score=0.0, corrective=False,
+    )
     assert results
     assert results[0]["provenance"].startswith("external-world knowledge")
     assert "recon" in results[0]["provenance"]
+
+
+@pytest.mark.asyncio
+async def test_knowledge_recall_labels_crag_web_item(mock_deps, tools, monkeypatch):
+    """A CRAG web-fallback item (origin='web' / source_pipeline='crag_web', no
+    collection) must be labeled external-world web by the post-CRAG pass — web
+    content is the most external thing there is (audit D12)."""
+    _init_with_mocks(mock_deps)
+    memory_mcp._retriever = MagicMock()
+    memory_mcp._retriever.recall = AsyncMock(return_value=[])
+
+    async def _fake_correct(**kwargs):
+        return [{
+            "unit_id": "https://example.com/doc", "content": "web snippet",
+            "score": 0.7, "origin": "web", "source_pipeline": "crag_web",
+        }]
+
+    import genesis.memory.corrective as corrective_mod
+    monkeypatch.setattr(corrective_mod, "maybe_correct_recall", _fake_correct)
+
+    results = await tools["knowledge_recall"].fn(query="q", limit=5, min_score=0.0)
+    assert results
+    web = results[0]
+    assert web["collection"] == "knowledge_base"
+    assert web["provenance"].startswith("external-world knowledge")
+    assert "web" in web["provenance"]
+
+
+@pytest.mark.asyncio
+async def test_memory_recall_full_path_labels_post_crag(mock_deps, tools, monkeypatch):
+    """The full (non-compact) path runs CRAG; the final provenance pass must label
+    BOTH the original episodic result AND a CRAG-augmented KB item (audit D12)."""
+    _init_with_mocks(mock_deps)
+    memory_mcp._retriever = MagicMock()
+    memory_mcp._retriever.recall = AsyncMock(return_value=[
+        _rr("ep1", collection="episodic_memory"),
+    ])
+
+    async def _fake_correct(**kwargs):
+        out = list(kwargs["results"])
+        out.append({
+            "memory_id": "kb_aug", "content": "ext doc", "score": 0.8,
+            "payload": {}, "collection": "knowledge_base",
+            "source_pipeline": "curated",
+        })
+        return out
+
+    import genesis.memory.corrective as corrective_mod
+    monkeypatch.setattr(corrective_mod, "maybe_correct_recall", _fake_correct)
+
+    results = await tools["memory_recall"].fn(
+        query="q", source="both", limit=5, include_graph=False,
+    )
+    by_id = {r["memory_id"]: r for r in results}
+    assert by_id["ep1"]["provenance"] == "first-party memory"
+    assert by_id["kb_aug"]["collection"] == "knowledge_base"
+    assert by_id["kb_aug"]["provenance"].startswith("external-world knowledge")

--- a/tests/test_memory/test_provenance.py
+++ b/tests/test_memory/test_provenance.py
@@ -1,0 +1,92 @@
+"""Tests for first-party vs external-world provenance labeling (audit D12).
+
+The KB (``knowledge_base`` collection) is external-world knowledge; episodic
+memory is Genesis's own first-party content. These helpers produce the labels
+that keep the two distinguishable wherever recalled content enters an LLM
+context.
+"""
+
+from __future__ import annotations
+
+from genesis.memory.provenance import (
+    is_external,
+    provenance_descriptor,
+    short_source,
+)
+
+
+def test_is_external_knowledge_base():
+    assert is_external("knowledge_base") is True
+
+
+def test_is_external_episodic():
+    assert is_external("episodic_memory") is False
+
+
+def test_is_external_none_is_first_party():
+    # Missing/unknown collection must NOT be treated as external — defaulting to
+    # first-party is the conservative, non-alarming choice.
+    assert is_external(None) is False
+    assert is_external("") is False
+
+
+def test_descriptor_first_party():
+    assert (
+        provenance_descriptor(collection="episodic_memory", source_pipeline="anything")
+        == "first-party memory"
+    )
+
+
+def test_descriptor_external_names_the_source():
+    d = provenance_descriptor(
+        collection="knowledge_base", source_pipeline="curated",
+    )
+    assert d.startswith("external-world knowledge")
+    assert "user-curated" in d
+
+
+def test_descriptor_external_recon():
+    d = provenance_descriptor(collection="knowledge_base", source_pipeline="recon")
+    assert "external-world knowledge" in d
+    assert "recon" in d
+
+
+def test_descriptor_external_null_pipeline_safe_default():
+    # A KB item with NO source_pipeline (the SQLite-NULL case) must still read
+    # as external, just with a generic source — never crash, never first-party.
+    d = provenance_descriptor(collection="knowledge_base", source_pipeline=None)
+    assert d.startswith("external-world knowledge")
+
+
+def test_descriptor_includes_source_doc_when_meaningful():
+    d = provenance_descriptor(
+        collection="knowledge_base",
+        source_pipeline="knowledge_ingest_source",
+        source_doc="fastapi-docs.pdf",
+    )
+    assert "fastapi-docs.pdf" in d
+
+
+def test_descriptor_omits_placeholder_source_doc():
+    d = provenance_descriptor(
+        collection="knowledge_base",
+        source_pipeline="knowledge_ingest",
+        source_doc="manual",
+    )
+    assert "manual" not in d
+
+
+def test_short_source_terse_tokens():
+    # Proactive-hook budget: single, space-free tokens.
+    assert short_source("curated") == "curated"
+    assert short_source("recon") == "recon"
+    assert short_source("knowledge_ingest_source") == "ingested"
+    assert short_source(None) == "ext"
+    assert " " not in short_source("extraction_job")
+
+
+def test_more_specific_pipeline_wins():
+    # 'knowledge_ingest' is a substring of 'knowledge_ingest_source'; both map
+    # to the same label here, but the match must be deterministic, not error.
+    assert short_source("knowledge_ingest_source") == "ingested"
+    assert short_source("knowledge_ingest") == "ingested"

--- a/tests/test_memory/test_provenance.py
+++ b/tests/test_memory/test_provenance.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from genesis.memory.provenance import (
     is_external,
+    label_result_dicts,
     provenance_descriptor,
     short_source,
 )
@@ -90,3 +91,52 @@ def test_more_specific_pipeline_wins():
     # to the same label here, but the match must be deterministic, not error.
     assert short_source("knowledge_ingest_source") == "ingested"
     assert short_source("knowledge_ingest") == "ingested"
+
+
+# ── label_result_dicts (post-CRAG MCP-return pass) ──────────────────────────
+
+
+def test_label_result_dicts_episodic_default():
+    dicts = [{"memory_id": "m1", "content": "x"}]
+    label_result_dicts(dicts, default_collection="episodic_memory")
+    assert dicts[0]["collection"] == "episodic_memory"
+    assert dicts[0]["provenance"] == "first-party memory"
+
+
+def test_label_result_dicts_knowledge_default():
+    dicts = [{"unit_id": "u1", "content": "doc", "source_pipeline": "curated"}]
+    label_result_dicts(dicts, default_collection="knowledge_base")
+    assert dicts[0]["collection"] == "knowledge_base"
+    assert dicts[0]["provenance"].startswith("external-world knowledge")
+    assert "user-curated" in dicts[0]["provenance"]
+
+
+def test_label_result_dicts_crag_web_is_external_web():
+    dicts = [{"unit_id": "https://x", "content": "w", "origin": "web",
+              "source_pipeline": "crag_web"}]
+    label_result_dicts(dicts, default_collection="episodic_memory")
+    assert dicts[0]["collection"] == "knowledge_base"
+    assert "web" in dicts[0]["provenance"]
+
+
+def test_label_result_dicts_reads_collection_from_payload():
+    # CRAG augmented dicts may carry collection at top level OR in payload.
+    dicts = [{"memory_id": "m", "content": "c", "payload": {"collection": "knowledge_base"}}]
+    label_result_dicts(dicts, default_collection="episodic_memory")
+    assert dicts[0]["collection"] == "knowledge_base"
+    assert dicts[0]["provenance"].startswith("external-world knowledge")
+
+
+def test_label_result_dicts_skips_sentinels():
+    dicts = [{"not_found": ["a", "b"]}]
+    label_result_dicts(dicts)
+    assert dicts[0] == {"not_found": ["a", "b"]}  # untouched
+
+
+def test_label_result_dicts_idempotent():
+    dicts = [{"memory_id": "m", "content": "c", "collection": "knowledge_base",
+              "source_pipeline": "recon"}]
+    label_result_dicts(dicts)
+    first = dicts[0]["provenance"]
+    label_result_dicts(dicts)
+    assert dicts[0]["provenance"] == first

--- a/tests/test_memory/test_retrieval.py
+++ b/tests/test_memory/test_retrieval.py
@@ -161,6 +161,69 @@ async def test_recall_knowledge_only(mock_qdrant, mock_crud, mock_links, _):
 @patch("genesis.memory.retrieval.memory_links")
 @patch("genesis.memory.retrieval.memory_crud")
 @patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_threads_collection_episodic(mock_qdrant, mock_crud, mock_links, _):
+    """A Qdrant hit from episodic_memory → result.collection == 'episodic_memory'
+    (the authoritative first-party/external discriminator, audit D12)."""
+    retriever, _, _, _ = _build_retriever()
+    mock_qdrant.search.return_value = [_make_qdrant_hit("mem-1", 0.9)]
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    _setup_link_mocks(mock_links)
+
+    results = await retriever.recall(
+        "test", source="episodic", limit=5, min_activation=0.0, rerank=False,
+    )
+    assert results
+    assert results[0].collection == "episodic_memory"
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_threads_collection_knowledge(mock_qdrant, mock_crud, mock_links, _):
+    """A Qdrant hit from knowledge_base → result.collection == 'knowledge_base'."""
+    retriever, _, _, _ = _build_retriever()
+    mock_qdrant.search.return_value = [_make_qdrant_hit("mem-1", 0.9)]
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    _setup_link_mocks(mock_links)
+
+    results = await retriever.recall(
+        "test", source="knowledge", limit=5, min_activation=0.0, rerank=False,
+    )
+    assert results
+    assert results[0].collection == "knowledge_base"
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_threads_collection_fts_only(mock_qdrant, mock_crud, mock_links, _):
+    """An FTS5-only hit (no Qdrant vector) must still carry its collection from
+    the FTS row — this is exactly the path where the old payload['scope'] signal
+    was absent, so the collection discriminator must cover it (audit D12)."""
+    retriever, _, _, _ = _build_retriever()
+    mock_qdrant.search.return_value = []  # no vector hits → FTS-only
+    mock_crud.search_ranked = AsyncMock(return_value=[
+        {**_make_fts_row("mem-kb", -5.0), "collection": "knowledge_base"},
+    ])
+    _setup_link_mocks(mock_links)
+
+    results = await retriever.recall(
+        "test", source="both", limit=5, min_activation=0.0, rerank=False,
+    )
+    assert results
+    assert results[0].memory_id == "mem-kb"
+    assert results[0].collection == "knowledge_base"
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
 async def test_recall_both_sources(mock_qdrant, mock_crud, mock_links, _):
     retriever, _, _, _ = _build_retriever()
 

--- a/tests/test_memory/test_types.py
+++ b/tests/test_memory/test_types.py
@@ -43,6 +43,26 @@ def test_retrieval_result_fields():
     assert r.payload == {"k": "v"}
 
 
+def test_retrieval_result_collection_defaults_episodic():
+    """collection defaults to episodic_memory (first-party) and is overridable.
+
+    The default must be first-party so an unset collection is never mislabeled
+    as external-world knowledge (audit D12)."""
+    r = RetrievalResult(
+        memory_id="m1", content="x", source="s", memory_type="t",
+        score=0.5, vector_rank=1, fts_rank=None, activation_score=0.3,
+        payload={},
+    )
+    assert r.collection == "episodic_memory"
+
+    kb = RetrievalResult(
+        memory_id="m2", content="x", source="s", memory_type="knowledge",
+        score=0.5, vector_rank=1, fts_rank=None, activation_score=0.3,
+        payload={}, collection="knowledge_base",
+    )
+    assert kb.collection == "knowledge_base"
+
+
 def test_link_record_frozen():
     link = LinkRecord(
         source_id="a", target_id="b", link_type="related",


### PR DESCRIPTION
## WS-7 — Knowledge-base provenance (audit D12)

**Problem:** external-world knowledge (the `knowledge_base` collection — ingested docs/APIs/papers, and now CRAG web results) could masquerade as first-party ground truth once recalled into an LLM context. The self-model couldn't tell what it *learned from the world* from what it *observed itself*, so it over-trusted ingested/scraped content.

**Fix:** draw the first-party-vs-external line at LLM-context entry.

- **Discriminator:** `RetrievalResult.collection` (new, defaulted, set at all 3 construction sites from the authoritative Qdrant collection — reliable where the per-item `source` string and `payload["scope"]` were not).
- **Shared labeller:** `genesis.memory.provenance` — `is_external`, `provenance_descriptor` ("first-party memory" vs "external-world knowledge (source: …)"), `short_source`, and `label_result_dicts` (a final MCP-return pass).
- **Surfaced everywhere KB enters context:** `memory_recall` (compact inline + full post-pass), `memory_expand` (builds a mid→collection map since it bypasses `RetrievalResult`), `knowledge_recall` (all-external), the proactive hook (`[KB·<tier>]`), the ego user-corrections recall (pinned to `source="episodic"` so KB can't pose as a correction), the voice handler (prefixes external snippets), and the dashboard memory-search API.
- **Reliability fix:** the `memory_recall` source="both" KB score floor now keys on the collection discriminator instead of `payload["scope"]` (absent on FTS5-only rows, so the floor previously slipped).
- **CRAG (#711) interaction:** corrective retrieval augments `memory_recall`/`knowledge_recall` with relaxed/raw-KB re-retrieval and a web fallback whose reduced-shape dicts dropped the discriminator. Labeling runs as a **final pass after** `maybe_correct_recall`, so original, augmented, **and web** items are all labeled; `_retrieval_to_dict` now preserves `collection`+`source_pipeline`; `crag_web` → "external-world knowledge (source: web)".

No schema migration (provenance already stored; collection always known at retrieval).

## Verification
- 1776 tests pass across memory / MCP / hooks / ego / voice / dashboard / routing (incl. CRAG's own `test_corrective.py` — #711 intact).
- Focused adversarial code review (CRAG interaction): no findings.
- **E2E on real Qdrant + real embeddings:** invariant held — every `knowledge_base` hit labeled external (with correct source tier), every episodic hit first-party; the MCP tools (`memory_recall`/`knowledge_recall`/`memory_expand`) surface correct provenance on live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
