### PR TITLE
feat(learning): cognitive self-modification rollback ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **You can undo a change Genesis made to its own skills or calibration** — when Genesis
+  autonomously refines a skill, retunes its triage calibration, or re-synthesizes its user
+  knowledge, it now keeps a recoverable snapshot of the previous version. If one of those
+  self-edits turns out worse, you can list the recent self-modifications and roll any of them
+  back to its prior contents — with a safety check that refuses to overwrite a file that has
+  changed since (unless you force it).
+
 - **Genesis self-corrects a bad memory recall instead of running with it** — on high-stakes
   lookups (the explicit memory and knowledge recall tools), Genesis now grades whether the
   recalled results are actually on-topic, and when a recall comes back clearly irrelevant it

--- a/src/genesis/db/crud/cognitive_file_modifications.py
+++ b/src/genesis/db/crud/cognitive_file_modifications.py
@@ -1,0 +1,149 @@
+"""CRUD for ``cognitive_file_modifications`` — the cognitive self-mod ledger.
+
+Thin, strict data layer. Append-only ledger of cognitive-config file overwrites
+(skill ``SKILL.md`` / ``TRIAGE_CALIBRATION.md`` / ``USER_KNOWLEDGE.md``), each row
+capturing the PRE-IMAGE so the write can be rolled back. ``record`` raises
+``ValueError`` on malformed input; the best-effort leniency that protects the live
+cognitive write paths lives one layer up in ``learning/cognitive_ledger.py``.
+
+NOT the (dead, CC-tool-audit) ``file_modifications`` table — different scope, and
+this one stores ``prior_content``/``applied_content``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+_VALID_STATUSES = frozenset({"applied", "rolled_back"})
+
+
+def _row_to_dict(cur: aiosqlite.Cursor, row) -> dict:
+    """Map a row to a dict, parsing ``metadata`` JSON back to a dict."""
+    cols = [d[0] for d in cur.description]
+    out = dict(zip(cols, row, strict=False))
+    if out.get("metadata"):
+        with contextlib.suppress(json.JSONDecodeError, TypeError):
+            out["metadata"] = json.loads(out["metadata"])
+    return out
+
+
+async def record(
+    db: aiosqlite.Connection,
+    *,
+    actor: str,
+    target_path: str,
+    applied_content: str,
+    prior_content: str | None = None,
+    change_summary: str | None = None,
+    metadata: dict | None = None,
+    created_at: str | None = None,
+) -> str:
+    """Insert one ledger row (a captured cognitive file overwrite). Returns its id.
+
+    Raises ``ValueError`` on empty ``actor``/``target_path`` or ``None``
+    ``applied_content`` (the column is NOT NULL — a missing post-image is a bug).
+    """
+    if not actor or not target_path:
+        raise ValueError("cognitive_file_modifications.record: actor/target_path required")
+    if applied_content is None:
+        raise ValueError("cognitive_file_modifications.record: applied_content must not be None")
+
+    mod_id = uuid.uuid4().hex[:16]
+    created_at = created_at or datetime.now(UTC).isoformat()
+    meta_json = json.dumps(metadata) if metadata is not None else None
+
+    await db.execute(
+        """INSERT INTO cognitive_file_modifications
+               (id, actor, target_path, prior_content, applied_content,
+                change_summary, metadata, status, created_at, rolled_back_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, 'applied', ?, NULL)""",
+        (
+            mod_id, actor, target_path, prior_content, applied_content,
+            change_summary, meta_json, created_at,
+        ),
+    )
+    await db.commit()
+    return mod_id
+
+
+async def get(db: aiosqlite.Connection, mod_id: str) -> dict | None:
+    """Fetch one ledger row by id (metadata parsed to a dict)."""
+    cur = await db.execute(
+        "SELECT * FROM cognitive_file_modifications WHERE id = ?", (mod_id,),
+    )
+    row = await cur.fetchone()
+    return _row_to_dict(cur, row) if row else None
+
+
+async def recent(
+    db: aiosqlite.Connection, *, limit: int = 20, actor: str | None = None,
+) -> list[dict]:
+    """Most-recent ledger rows, newest first, optionally filtered by actor."""
+    if actor:
+        cur = await db.execute(
+            "SELECT * FROM cognitive_file_modifications WHERE actor = ? "
+            "ORDER BY created_at DESC, id DESC LIMIT ?",
+            (actor, limit),
+        )
+    else:
+        cur = await db.execute(
+            "SELECT * FROM cognitive_file_modifications "
+            "ORDER BY created_at DESC, id DESC LIMIT ?",
+            (limit,),
+        )
+    rows = await cur.fetchall()
+    return [_row_to_dict(cur, r) for r in rows]
+
+
+async def counts_by_target(db: aiosqlite.Connection) -> list[dict]:
+    """Per-target row counts + last-modified timestamp (operator overview)."""
+    cur = await db.execute(
+        "SELECT target_path, COUNT(*) AS n, MAX(created_at) AS last_at, "
+        "       SUM(CASE WHEN status = 'rolled_back' THEN 1 ELSE 0 END) AS rolled_back "
+        "FROM cognitive_file_modifications GROUP BY target_path ORDER BY last_at DESC",
+    )
+    rows = await cur.fetchall()
+    return [_row_to_dict(cur, r) for r in rows]
+
+
+async def mark_rolled_back(
+    db: aiosqlite.Connection, mod_id: str, *, rolled_back_at: str | None = None,
+) -> bool:
+    """Mark a row rolled back. Returns True iff a row was updated."""
+    rolled_back_at = rolled_back_at or datetime.now(UTC).isoformat()
+    cur = await db.execute(
+        "UPDATE cognitive_file_modifications "
+        "SET status = 'rolled_back', rolled_back_at = ? WHERE id = ?",
+        (rolled_back_at, mod_id),
+    )
+    await db.commit()
+    return cur.rowcount > 0
+
+
+async def prune_keep_per_target(
+    db: aiosqlite.Connection, target_path: str, *, keep: int,
+) -> int:
+    """Delete all but the most-recent ``keep`` rows for ``target_path``.
+
+    Bounds table growth (rows store full file contents). Returns rows deleted.
+    """
+    cur = await db.execute(
+        """DELETE FROM cognitive_file_modifications
+           WHERE target_path = ? AND id NOT IN (
+               SELECT id FROM cognitive_file_modifications
+               WHERE target_path = ?
+               ORDER BY created_at DESC, id DESC
+               LIMIT ?
+           )""",
+        (target_path, target_path, keep),
+    )
+    await db.commit()
+    return cur.rowcount

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -140,6 +140,8 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     "test_isolation_gap": timedelta(days=30),
     "operational_gap": timedelta(days=30),
     "interaction_theme": timedelta(days=30),
+    # cognitive self-mod rollback audit (operator-visible correction event)
+    "self_mod_rollback": timedelta(days=30),
     # ── 60-day (action-required, real issues) ──────────────────────────
     "bug_identified": timedelta(days=60),
     "tech_debt": timedelta(days=60),

--- a/src/genesis/db/migrations/0027_cognitive_file_modifications.py
+++ b/src/genesis/db/migrations/0027_cognitive_file_modifications.py
@@ -1,0 +1,63 @@
+"""Create ``cognitive_file_modifications`` — the cognitive self-modification ledger.
+
+Genesis autonomously OVERWRITES several of its own cognitive config files at
+runtime (skill ``SKILL.md`` refinement, daily ``TRIAGE_CALIBRATION.md`` regen,
+daily ``USER_KNOWLEDGE.md`` synthesis) with NO backup and NO undo. If a self-edit
+degrades cognition there is currently no way to revert it. This table is an
+append-only ledger that captures the PRE-IMAGE (``prior_content``) before each such
+overwrite, so a bad self-edit can be rolled back.
+
+File overwrites are NOT invertible (unlike the dream-cycle's DB-op tagging), so the
+pre-image must be stored inline. Files are small (<8 KB) → inline storage is
+queryable, transactional, and captured by the 6-hourly ``backup.sh`` DB dump.
+
+NOT to be confused with the (dead, CC-tool-audit) ``file_modifications`` table —
+different scope (Genesis cognitive self-edits), and it stores pre/post images.
+
+This table is an OPERATOR SURFACE ONLY: no automated cognitive path reads it (same
+discipline as ``ego_calibration_snapshots``). Rollback is manual/programmatic in v1.
+
+Idempotent (``IF NOT EXISTS``). Fresh installs get the same DDL via ``_tables.py``.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+_TABLE_DDL = """
+    CREATE TABLE IF NOT EXISTS cognitive_file_modifications (
+        id              TEXT PRIMARY KEY,
+        actor           TEXT NOT NULL,
+        target_path     TEXT NOT NULL,
+        prior_content   TEXT,
+        applied_content TEXT NOT NULL,
+        change_summary  TEXT,
+        metadata        TEXT,
+        status          TEXT NOT NULL DEFAULT 'applied',
+        created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+        rolled_back_at  TEXT
+    )
+"""
+
+_INDEX_DDL = [
+    "CREATE INDEX IF NOT EXISTS idx_cog_file_mods_target "
+    "ON cognitive_file_modifications(target_path)",
+    "CREATE INDEX IF NOT EXISTS idx_cog_file_mods_actor "
+    "ON cognitive_file_modifications(actor)",
+    "CREATE INDEX IF NOT EXISTS idx_cog_file_mods_created "
+    "ON cognitive_file_modifications(created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_cog_file_mods_status "
+    "ON cognitive_file_modifications(status)",
+]
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # NOTE: must NOT call db.commit()/BEGIN — the runner owns the transaction.
+    await db.execute(_TABLE_DDL)
+    for stmt in _INDEX_DDL:
+        await db.execute(stmt)
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    """Drop the table (development/testing only)."""
+    await db.execute("DROP TABLE IF EXISTS cognitive_file_modifications")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1039,6 +1039,20 @@ TABLES = {
             timestamp        TEXT NOT NULL
         )
     """,
+    "cognitive_file_modifications": """
+        CREATE TABLE IF NOT EXISTS cognitive_file_modifications (
+            id              TEXT PRIMARY KEY,
+            actor           TEXT NOT NULL,
+            target_path     TEXT NOT NULL,
+            prior_content   TEXT,
+            applied_content TEXT NOT NULL,
+            change_summary  TEXT,
+            metadata        TEXT,
+            status          TEXT NOT NULL DEFAULT 'applied',
+            created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+            rolled_back_at  TEXT
+        )
+    """,
     "tool_call_outcomes": """
         CREATE TABLE IF NOT EXISTS tool_call_outcomes (
             id               INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1573,6 +1587,11 @@ INDEXES = [
     # tool call outcomes (edit failure sensor)
     "CREATE INDEX IF NOT EXISTS idx_tco_tool_ts ON tool_call_outcomes(tool_name, timestamp)",
     "CREATE INDEX IF NOT EXISTS idx_tco_success ON tool_call_outcomes(success, timestamp)",
+    # cognitive self-modification ledger (rollback)
+    "CREATE INDEX IF NOT EXISTS idx_cog_file_mods_target ON cognitive_file_modifications(target_path)",
+    "CREATE INDEX IF NOT EXISTS idx_cog_file_mods_actor ON cognitive_file_modifications(actor)",
+    "CREATE INDEX IF NOT EXISTS idx_cog_file_mods_created ON cognitive_file_modifications(created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_cog_file_mods_status ON cognitive_file_modifications(status)",
     # direct session queue
     "CREATE INDEX IF NOT EXISTS idx_dsq_status_created ON direct_session_queue(status, created_at)",
     # J-9 eval infrastructure

--- a/src/genesis/learning/cognitive_ledger.py
+++ b/src/genesis/learning/cognitive_ledger.py
@@ -1,0 +1,219 @@
+"""Cognitive self-modification ledger — capture + rollback of cognitive file edits.
+
+Genesis autonomously overwrites its own cognitive config files at runtime (skill
+``SKILL.md`` refinement, daily ``TRIAGE_CALIBRATION.md`` regen, daily
+``USER_KNOWLEDGE.md`` synthesis). This module brackets those overwrites: it captures
+the PRE-IMAGE before each write into the ``cognitive_file_modifications`` ledger, so a
+self-edit that degrades cognition can be reverted with :func:`rollback`.
+
+Design notes:
+- **The write is primary; the ledger is best-effort.** A failing ledger insert is
+  logged (``exc_info``) and swallowed — instrumentation must never block cognition.
+  An actual file-write failure still propagates (same as the raw ``write_text`` it
+  replaces).
+- **Atomic, same-directory writes.** Temp file lives beside the target so the rename
+  never crosses a filesystem boundary (NEVER ``/tmp`` or ``cc-tmp``).
+- **Operator surface only.** No automated cognitive path reads this ledger (same
+  discipline as ``ego_calibration_snapshots``). Rollback is manual/programmatic in v1;
+  auto-rollback on a degradation signal is a deliberate, separately-flagged future PR.
+- **Known v1 limitation:** two concurrent writers to the SAME file can capture a stale
+  pre-image (the read-image and the write are not one transaction). The rollback drift
+  guard catches the common case; this is acceptable for the weekly/daily per-file jobs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import aiosqlite
+
+from genesis.db.crud import cognitive_file_modifications as cfm_crud
+
+logger = logging.getLogger(__name__)
+
+# Keep the most-recent N ledger rows per target file (rows store full file
+# contents). 30 → ~30 days of rollback history for the daily-regenerated files.
+_KEEP_PER_TARGET = 30
+
+
+def _read_current(path: Path) -> str | None:
+    """Read a file's current contents, or ``None`` if absent/unreadable."""
+    try:
+        return path.read_text(encoding="utf-8") if path.exists() else None
+    except OSError:
+        logger.warning("cognitive_ledger: could not read %s", path, exc_info=True)
+        return None
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write ``content`` to ``path`` atomically via a same-directory temp + rename."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".cogtmp")
+    tmp.write_text(content, encoding="utf-8")
+    tmp.replace(path)  # os.replace — atomic on the same filesystem, overwrites
+
+
+async def record_existing(
+    db: aiosqlite.Connection,
+    *,
+    actor: str,
+    path: Path,
+    prior_content: str | None,
+    applied_content: str,
+    summary: str | None = None,
+    metadata: dict | None = None,
+) -> str | None:
+    """Record a write the caller ALREADY performed (best-effort).
+
+    Use this when the caller owns the write (e.g. a sync writer that already ran).
+    Returns the new mod id, or ``None`` if the ledger insert failed (the file write
+    is unaffected). Never raises.
+    """
+    try:
+        mod_id = await cfm_crud.record(
+            db,
+            actor=actor,
+            target_path=str(path),
+            prior_content=prior_content,
+            applied_content=applied_content,
+            change_summary=summary,
+            metadata=metadata,
+        )
+    except Exception:
+        logger.warning(
+            "cognitive_ledger: ledger insert failed for %s (write unaffected)",
+            path, exc_info=True,
+        )
+        return None
+    # Prune-on-write: bound table growth (self-bounding, no scheduler job).
+    try:
+        await cfm_crud.prune_keep_per_target(db, str(path), keep=_KEEP_PER_TARGET)
+    except Exception:
+        logger.warning("cognitive_ledger: prune failed for %s", path, exc_info=True)
+    return mod_id
+
+
+async def record_file_modification(
+    db: aiosqlite.Connection,
+    *,
+    actor: str,
+    path: Path,
+    new_content: str,
+    summary: str | None = None,
+    metadata: dict | None = None,
+) -> str | None:
+    """Capture the pre-image, write ``new_content`` atomically, record the ledger row.
+
+    The write is the primary operation (propagates on failure, like the raw
+    ``write_text`` it replaces). The ledger half is best-effort. Returns the mod id
+    (or ``None`` if only the ledger insert failed — the write still happened).
+    """
+    prior = _read_current(path)
+    _atomic_write(path, new_content)  # primary op — may raise (preserves behavior)
+    return await record_existing(
+        db, actor=actor, path=path, prior_content=prior,
+        applied_content=new_content, summary=summary, metadata=metadata,
+    )
+
+
+async def rollback(
+    db: aiosqlite.Connection, mod_id: str, *, force: bool = False,
+) -> dict:
+    """Revert a recorded cognitive file modification to its pre-image.
+
+    Drift guard: if the file on disk no longer matches the ``applied_content`` of
+    this entry (a later write replaced it), the rollback is REFUSED unless
+    ``force=True`` — the operator should roll back the newer entry instead. Emits an
+    observation on every outcome (success / refused / failed) so it is visible in the
+    dashboard, not just in the return value.
+    """
+    row = await cfm_crud.get(db, mod_id)
+    if row is None:
+        return {"ok": False, "refused": False, "mod_id": mod_id,
+                "reason": "no such modification"}
+    if row.get("status") == "rolled_back":
+        return {"ok": False, "refused": False, "mod_id": mod_id,
+                "target_path": row.get("target_path"),
+                "reason": "already rolled back"}
+
+    path = Path(row["target_path"])
+    current = _read_current(path)
+
+    # Drift guard — refuse if the file changed since this modification.
+    if current != row.get("applied_content") and not force:
+        result = {
+            "ok": False, "refused": True, "mod_id": mod_id,
+            "target_path": row["target_path"],
+            "reason": ("file changed since this modification — a later write replaced "
+                       "it; roll back the newer entry, or pass force=True"),
+        }
+        await _emit_rollback_observation(db, row, result)
+        return result
+
+    # Restore the pre-image (or remove the file if it didn't exist before).
+    try:
+        if row.get("prior_content") is None:
+            path.unlink(missing_ok=True)
+            restored = "absent"
+        else:
+            _atomic_write(path, row["prior_content"])
+            restored = "prior"
+    except OSError as exc:
+        result = {"ok": False, "refused": False, "mod_id": mod_id,
+                  "target_path": row["target_path"], "reason": f"restore failed: {exc}"}
+        await _emit_rollback_observation(db, row, result)
+        return result
+
+    await cfm_crud.mark_rolled_back(db, mod_id)
+    result = {"ok": True, "refused": False, "mod_id": mod_id,
+              "target_path": row["target_path"], "restored_to": restored,
+              "forced": force}
+    await _emit_rollback_observation(db, row, result)
+    return result
+
+
+async def recent(
+    db: aiosqlite.Connection, *, limit: int = 20, actor: str | None = None,
+) -> list[dict]:
+    """Most-recent ledger rows (newest first), optionally filtered by actor."""
+    return await cfm_crud.recent(db, limit=limit, actor=actor)
+
+
+async def _emit_rollback_observation(
+    db: aiosqlite.Connection, row: dict, result: dict,
+) -> None:
+    """Best-effort observation so a rollback (or its refusal) is visible. Never raises."""
+    try:
+        from genesis.db.crud import observations
+
+        if result.get("ok"):
+            outcome = "rolled_back"
+        elif result.get("refused"):
+            outcome = "refused"
+        else:
+            outcome = "failed"
+        await observations.create(
+            db,
+            id=str(uuid.uuid4()),
+            source="cognitive_ledger",
+            type="self_mod_rollback",
+            content=json.dumps({
+                "mod_id": result.get("mod_id"),
+                "actor": row.get("actor"),
+                "target_path": row.get("target_path"),
+                "outcome": outcome,
+                "reason": result.get("reason"),
+                "restored_to": result.get("restored_to"),
+                "forced": result.get("forced", False),
+            }),
+            priority="high",
+            created_at=datetime.now(UTC).isoformat(),
+        )
+    except Exception:
+        logger.warning(
+            "cognitive_ledger: failed to emit rollback observation", exc_info=True,
+        )

--- a/src/genesis/learning/cognitive_ledger.py
+++ b/src/genesis/learning/cognitive_ledger.py
@@ -50,11 +50,20 @@ def _read_current(path: Path) -> str | None:
 
 
 def _atomic_write(path: Path, content: str) -> None:
-    """Write ``content`` to ``path`` atomically via a same-directory temp + rename."""
+    """Write ``content`` to ``path`` atomically via a same-directory temp + rename.
+
+    The temp name is UNIQUE so concurrent writers to the same target never share
+    (and corrupt) a temp file, and it is removed if the write fails before the
+    rename (no orphaned ``.cogtmp`` left behind).
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(path.name + ".cogtmp")
-    tmp.write_text(content, encoding="utf-8")
-    tmp.replace(path)  # os.replace — atomic on the same filesystem, overwrites
+    tmp = path.with_name(f"{path.name}.{uuid.uuid4().hex[:8]}.cogtmp")
+    try:
+        tmp.write_text(content, encoding="utf-8")
+        tmp.replace(path)  # os.replace — atomic on the same filesystem, overwrites
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
 
 
 async def record_existing(

--- a/src/genesis/learning/skills/applicator.py
+++ b/src/genesis/learning/skills/applicator.py
@@ -70,7 +70,22 @@ class SkillApplicator:
             if path is None:
                 return {"action": "failed", "reason": "skill not found"}
 
-            path.write_text(proposal.proposed_content, encoding="utf-8")
+            # Route the overwrite through the cognitive self-mod ledger so the
+            # pre-image is captured and a degrading skill edit can be rolled back.
+            from genesis.learning.cognitive_ledger import record_file_modification
+
+            await record_file_modification(
+                db,
+                actor="skill_evolution",
+                path=path,
+                new_content=proposal.proposed_content,
+                summary=f"MINOR auto-apply: {proposal.rationale[:200]}",
+                metadata={
+                    "skill_name": proposal.skill_name,
+                    "change_size": proposal.change_size.value,
+                    "confidence": proposal.confidence,
+                },
+            )
 
             # Log observation (include validation warnings if any)
             from genesis.db.crud import observations

--- a/src/genesis/learning/skills/applicator.py
+++ b/src/genesis/learning/skills/applicator.py
@@ -8,6 +8,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from genesis.learning.cognitive_ledger import record_file_modification
 from genesis.learning.skills.types import ChangeSize, SkillProposal
 from genesis.learning.skills.validator import SkillValidator
 
@@ -72,8 +73,6 @@ class SkillApplicator:
 
             # Route the overwrite through the cognitive self-mod ledger so the
             # pre-image is captured and a degrading skill edit can be rolled back.
-            from genesis.learning.cognitive_ledger import record_file_modification
-
             await record_file_modification(
                 db,
                 actor="skill_evolution",

--- a/src/genesis/learning/triage/calibration.py
+++ b/src/genesis/learning/triage/calibration.py
@@ -9,6 +9,7 @@ import re
 from datetime import UTC, datetime
 from pathlib import Path
 
+from genesis.learning.cognitive_ledger import record_file_modification
 from genesis.learning.events import LEARNING_EVENTS
 from genesis.learning.types import CalibrationRules
 from genesis.observability.types import Severity, Subsystem
@@ -145,8 +146,8 @@ class TriageCalibrator:
                 )
             return None
 
-        # 5. Write atomically
-        self._write_calibration(rules)
+        # 5. Write atomically (via the cognitive self-mod ledger)
+        await self._write_calibration(rules)
 
         if self._event_bus:
             await self._event_bus.emit(
@@ -231,11 +232,13 @@ class TriageCalibrator:
             source_model=source_model,
         )
 
-    def _write_calibration(self, rules: CalibrationRules) -> None:
-        """Write calibration file atomically (write .tmp, rename)."""
-        tmp_path = self._calibration_path.with_suffix(".md.tmp")
-        tmp_path.parent.mkdir(parents=True, exist_ok=True)
+    async def _write_calibration(self, rules: CalibrationRules) -> None:
+        """Render the calibration file and write it atomically.
 
+        The write is routed through the cognitive self-mod ledger
+        (:mod:`genesis.learning.cognitive_ledger`) so the prior version is
+        captured and a degrading regeneration can be rolled back.
+        """
         lines = [
             "---",
             # TODO(triage-calibration C): derive/bump the version instead of hardcoding
@@ -265,5 +268,15 @@ class TriageCalibrator:
             lines.append(f"- {rule}")
         lines.append("")
 
-        tmp_path.write_text("\n".join(lines))
-        tmp_path.rename(self._calibration_path)
+        await record_file_modification(
+            self._db,
+            actor="triage_calibration_daily",
+            path=self._calibration_path,
+            new_content="\n".join(lines),
+            summary=f"triage calibration regen by {rules.source_model}",
+            metadata={
+                "example_count": len(rules.examples),
+                "rule_count": len(rules.rules),
+                "source_model": rules.source_model,
+            },
+        )

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -60,6 +60,7 @@ def init_health_mcp(
 from genesis.mcp.health import browser as _browser  # noqa: E402
 from genesis.mcp.health import campaign_tools as _campaign_tools  # noqa: E402, F401
 from genesis.mcp.health import codebase as _codebase  # noqa: E402
+from genesis.mcp.health import cognitive_ledger_tools as _cognitive_ledger_tools  # noqa: E402, F401
 from genesis.mcp.health import db_schema as _db_schema  # noqa: E402
 from genesis.mcp.health import direct_session_tools as _direct_session_tools  # noqa: E402
 from genesis.mcp.health import ego_calibration as _ego_calibration  # noqa: E402, F401

--- a/src/genesis/mcp/health/cognitive_ledger_tools.py
+++ b/src/genesis/mcp/health/cognitive_ledger_tools.py
@@ -1,0 +1,105 @@
+"""Cognitive self-modification ledger MCP tools — operator surface.
+
+Read + rollback over the ``cognitive_file_modifications`` ledger (skill / triage
+calibration / user-knowledge self-edits). ``cognitive_modification_status`` is
+read-only; ``cognitive_modification_rollback`` reverts one recorded modification to
+its pre-image (drift-guarded — refuses if the file changed since, unless ``force``).
+
+The status tool truncates file contents to character counts (the full pre/post images
+live in the DB) so the response stays small.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+
+def _service_db():
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    _service = health_mcp_mod._service
+    if _service is None or _service._db is None:
+        return None
+    return _service._db
+
+
+async def _impl_cognitive_modification_status(
+    limit: int = 20, actor: str | None = None,
+) -> dict:
+    db = _service_db()
+    if db is None:
+        return {"status": "unavailable", "message": "DB not initialized"}
+
+    from genesis.db.crud import cognitive_file_modifications as cfm
+
+    by_target = await cfm.counts_by_target(db)
+    rows = await cfm.recent(db, limit=limit, actor=actor)
+    recent_view = [
+        {
+            "mod_id": r["id"],
+            "actor": r["actor"],
+            "target_path": r["target_path"],
+            "status": r["status"],
+            "created_at": r["created_at"],
+            "rolled_back_at": r.get("rolled_back_at"),
+            "summary": r.get("change_summary"),
+            "prior_chars": len(r["prior_content"]) if r.get("prior_content") else 0,
+            "applied_chars": len(r["applied_content"]) if r.get("applied_content") else 0,
+        }
+        for r in rows
+    ]
+    return {
+        "status": "ok",
+        "total_targets": len(by_target),
+        "by_target": by_target,
+        "recent": recent_view,
+        "note": (
+            "Operator surface for autonomous cognitive self-modifications. To revert "
+            "one, call cognitive_modification_rollback(mod_id). Reading this changes "
+            "nothing. Each target keeps its last 30 modifications."
+        ),
+    }
+
+
+async def _impl_cognitive_modification_rollback(
+    mod_id: str, force: bool = False,
+) -> dict:
+    db = _service_db()
+    if db is None:
+        return {"ok": False, "status": "unavailable", "message": "DB not initialized"}
+
+    from genesis.learning.cognitive_ledger import rollback
+
+    return await rollback(db, mod_id, force=force)
+
+
+@mcp.tool()
+async def cognitive_modification_status(
+    limit: int = 20, actor: str | None = None,
+) -> dict:
+    """What cognitive config files has Genesis autonomously overwritten, and can they
+    be rolled back?
+
+    Read-only view of the cognitive self-modification ledger: per-file modification
+    counts and the most-recent edits (skill SKILL.md refinement, daily
+    TRIAGE_CALIBRATION.md / USER_KNOWLEDGE.md regen) with their ``mod_id`` for
+    rollback. Filter by ``actor`` (skill_evolution / triage_calibration_daily /
+    user_model_evolution). Reading this changes nothing.
+    """
+    return await _impl_cognitive_modification_status(limit=limit, actor=actor)
+
+
+@mcp.tool()
+async def cognitive_modification_rollback(mod_id: str, force: bool = False) -> dict:
+    """Revert one autonomous cognitive file modification to its prior contents.
+
+    Restores the pre-image captured before the edit identified by ``mod_id`` (from
+    cognitive_modification_status). Drift-guarded: if the file changed since (a later
+    regen overwrote it), the rollback is REFUSED — roll back the newer entry, or pass
+    ``force=True`` to override. Emits an observation on every outcome.
+    """
+    return await _impl_cognitive_modification_rollback(mod_id, force=force)

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -497,11 +497,44 @@ async def init(rt: GenesisRuntime) -> None:
                                     "back to rules-based rendering",
                                 )
                         try:
+                            # Capture the pre-image before the loader overwrites it,
+                            # then record into the cognitive self-mod ledger so a bad
+                            # synthesis can be rolled back (Option B: no loader change).
+                            uk_path = identity_loader._dir / "USER_KNOWLEDGE.md"
+                            prior_uk = (
+                                uk_path.read_text(encoding="utf-8")
+                                if uk_path.exists() else None
+                            )
                             identity_loader.write_user_knowledge_md(
                                 result.model,
                                 evidence_count=result.evidence_count,
                                 narrative=narrative,
                             )
+                            try:
+                                from genesis.learning.cognitive_ledger import (
+                                    record_existing,
+                                )
+
+                                await record_existing(
+                                    rt._db,
+                                    actor="user_model_evolution",
+                                    path=uk_path,
+                                    prior_content=prior_uk,
+                                    applied_content=uk_path.read_text(encoding="utf-8"),
+                                    summary="USER_KNOWLEDGE synthesis ("
+                                    + ("narrative" if narrative else "rules")
+                                    + ")",
+                                    metadata={
+                                        "evidence_count": result.evidence_count,
+                                        "mode": "narrative" if narrative else "rules",
+                                    },
+                                )
+                            except Exception:
+                                logger.warning(
+                                    "cognitive_ledger: USER_KNOWLEDGE record failed "
+                                    "(write unaffected)",
+                                    exc_info=True,
+                                )
                             if narrative:
                                 logger.info(
                                     "USER_KNOWLEDGE.md updated via LLM "

--- a/tests/test_db/test_cognitive_file_modifications.py
+++ b/tests/test_db/test_cognitive_file_modifications.py
@@ -1,0 +1,205 @@
+"""Tests for cognitive_file_modifications — migration 0027 + its CRUD.
+
+Covers the versioned migration (up/down/idempotency), the fresh-install path
+(create_all_tables / _tables.py), and CRUD semantics (record/get/recent/
+counts_by_target/mark_rolled_back/prune_keep_per_target).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import cognitive_file_modifications as cfm
+
+# Migration module name starts with a digit — import via importlib.
+MIGRATION = importlib.import_module(
+    "genesis.db.migrations.0027_cognitive_file_modifications"
+)
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """Fresh DB with the table created via the real migration up()."""
+    db_path = str(tmp_path / "test.db")
+    async with aiosqlite.connect(db_path) as conn:
+        await MIGRATION.up(conn)  # up() must not commit — runner owns the txn
+        await conn.commit()
+        yield conn
+
+
+# --------------------------------------------------------------------------- #
+# Schema / migration
+# --------------------------------------------------------------------------- #
+class TestSchema:
+    @pytest.mark.asyncio
+    async def test_table_and_indexes_exist(self, db):
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name='cognitive_file_modifications'"
+        )
+        assert await cur.fetchone() is not None
+
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND name LIKE 'idx_cog_file_mods_%'"
+        )
+        idx = {r[0] for r in await cur.fetchall()}
+        assert {
+            "idx_cog_file_mods_target",
+            "idx_cog_file_mods_actor",
+            "idx_cog_file_mods_created",
+            "idx_cog_file_mods_status",
+        } <= idx
+
+    @pytest.mark.asyncio
+    async def test_up_is_idempotent(self, tmp_path):
+        path = str(tmp_path / "idem.db")
+        async with aiosqlite.connect(path) as conn:
+            await MIGRATION.up(conn)
+            await MIGRATION.up(conn)  # IF NOT EXISTS → must not raise
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='cognitive_file_modifications'"
+            )
+            assert (await cur.fetchone())[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_down_drops_table(self, tmp_path):
+        path = str(tmp_path / "down.db")
+        async with aiosqlite.connect(path) as conn:
+            await MIGRATION.up(conn)
+            await conn.commit()
+            await MIGRATION.down(conn)
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='cognitive_file_modifications'"
+            )
+            assert await cur.fetchone() is None
+
+    @pytest.mark.asyncio
+    async def test_fresh_install_path_creates_table(self, tmp_path):
+        from genesis.db.schema import create_all_tables
+
+        path = str(tmp_path / "fresh.db")
+        async with aiosqlite.connect(path) as conn:
+            await create_all_tables(conn)
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='cognitive_file_modifications'"
+            )
+            assert await cur.fetchone() is not None
+
+
+# --------------------------------------------------------------------------- #
+# CRUD
+# --------------------------------------------------------------------------- #
+class TestRecord:
+    @pytest.mark.asyncio
+    async def test_record_returns_id_and_persists(self, db):
+        mid = await cfm.record(
+            db, actor="skill_evolution", target_path="/skills/x/SKILL.md",
+            prior_content="old", applied_content="new",
+            change_summary="tweak", metadata={"skill": "x"},
+        )
+        assert isinstance(mid, str) and len(mid) == 16
+        row = await cfm.get(db, mid)
+        assert row["actor"] == "skill_evolution"
+        assert row["prior_content"] == "old"
+        assert row["applied_content"] == "new"
+        assert row["status"] == "applied"
+        assert row["rolled_back_at"] is None
+        assert row["metadata"] == {"skill": "x"}  # parsed back to dict
+
+    @pytest.mark.asyncio
+    async def test_record_allows_null_prior(self, db):
+        mid = await cfm.record(
+            db, actor="a", target_path="/p", applied_content="new",
+        )
+        row = await cfm.get(db, mid)
+        assert row["prior_content"] is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"actor": "", "target_path": "/p", "applied_content": "x"},
+            {"actor": "a", "target_path": "", "applied_content": "x"},
+            {"actor": "a", "target_path": "/p", "applied_content": None},
+        ],
+    )
+    async def test_record_validates(self, db, kwargs):
+        with pytest.raises(ValueError):
+            await cfm.record(db, **kwargs)
+
+    @pytest.mark.asyncio
+    async def test_get_missing_returns_none(self, db):
+        assert await cfm.get(db, "nope") is None
+
+
+class TestQueries:
+    @pytest.mark.asyncio
+    async def test_recent_newest_first_and_actor_filter(self, db):
+        await cfm.record(db, actor="a", target_path="/1", applied_content="x",
+                         created_at="2026-01-01T00:00:01")
+        await cfm.record(db, actor="b", target_path="/2", applied_content="y",
+                         created_at="2026-01-01T00:00:02")
+        await cfm.record(db, actor="a", target_path="/3", applied_content="z",
+                         created_at="2026-01-01T00:00:03")
+
+        rows = await cfm.recent(db, limit=10)
+        assert [r["target_path"] for r in rows] == ["/3", "/2", "/1"]
+
+        only_a = await cfm.recent(db, limit=10, actor="a")
+        assert [r["target_path"] for r in only_a] == ["/3", "/1"]
+
+    @pytest.mark.asyncio
+    async def test_counts_by_target(self, db):
+        await cfm.record(db, actor="a", target_path="/p", applied_content="1",
+                         created_at="2026-01-01T00:00:01")
+        await cfm.record(db, actor="a", target_path="/p", applied_content="2",
+                         created_at="2026-01-01T00:00:02")
+        await cfm.record(db, actor="a", target_path="/q", applied_content="3",
+                         created_at="2026-01-01T00:00:03")
+        counts = await cfm.counts_by_target(db)
+        by_path = {c["target_path"]: c for c in counts}
+        assert by_path["/p"]["n"] == 2
+        assert by_path["/q"]["n"] == 1
+        assert by_path["/p"]["rolled_back"] == 0
+
+
+class TestRollbackState:
+    @pytest.mark.asyncio
+    async def test_mark_rolled_back(self, db):
+        mid = await cfm.record(db, actor="a", target_path="/p", applied_content="x")
+        assert await cfm.mark_rolled_back(db, mid) is True
+        row = await cfm.get(db, mid)
+        assert row["status"] == "rolled_back"
+        assert row["rolled_back_at"] is not None
+        # missing id → False
+        assert await cfm.mark_rolled_back(db, "nope") is False
+
+
+class TestPrune:
+    @pytest.mark.asyncio
+    async def test_prune_keeps_most_recent_n(self, db):
+        for i in range(5):
+            await cfm.record(
+                db, actor="a", target_path="/p", applied_content=str(i),
+                created_at=f"2026-01-01T00:00:0{i}",
+            )
+        # Another target must be untouched by the per-target prune.
+        await cfm.record(db, actor="a", target_path="/other", applied_content="o")
+
+        deleted = await cfm.prune_keep_per_target(db, "/p", keep=2)
+        assert deleted == 3
+
+        rows = await cfm.recent(db, limit=10, actor="a")
+        kept_p = [r["applied_content"] for r in rows if r["target_path"] == "/p"]
+        assert kept_p == ["4", "3"]  # the two most recent
+        assert any(r["target_path"] == "/other" for r in rows)

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -103,6 +103,7 @@ async def test_no_unexpected_tables(db):
         "email_threads", "email_thread_messages",
         "outcome_events",  # self-improvement outcome bus
         "ego_calibration_snapshots",  # measure-only ego calibration
+        "cognitive_file_modifications",  # cognitive self-mod rollback ledger
     }
     for table in tables:
         assert table in known, f"Unexpected table: {table}"

--- a/tests/test_learning/test_cognitive_ledger.py
+++ b/tests/test_learning/test_cognitive_ledger.py
@@ -1,0 +1,173 @@
+"""Tests for the cognitive self-modification ledger (capture + rollback).
+
+Uses create_all_tables so both cognitive_file_modifications and observations
+exist (rollback emits an observation). Targets are temp files, not real cognitive
+config.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import aiosqlite
+import pytest
+
+import genesis.learning.cognitive_ledger as cl
+from genesis.db.crud import cognitive_file_modifications as cfm
+from genesis.learning.cognitive_ledger import (
+    record_existing,
+    record_file_modification,
+    rollback,
+)
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """Full-schema DB (table + observations)."""
+    db_path = str(tmp_path / "test.db")
+    async with aiosqlite.connect(db_path) as conn:
+        from genesis.db.schema import create_all_tables
+
+        await create_all_tables(conn)
+        await conn.commit()
+        yield conn
+
+
+# --------------------------------------------------------------------------- #
+# Capture
+# --------------------------------------------------------------------------- #
+class TestCapture:
+    @pytest.mark.asyncio
+    async def test_record_file_modification_new_file(self, db, tmp_path):
+        p = tmp_path / "SKILL.md"  # absent
+        mid = await record_file_modification(
+            db, actor="skill_evolution", path=p, new_content="hello",
+        )
+        assert mid is not None
+        assert p.read_text() == "hello"
+        row = await cfm.get(db, mid)
+        assert row["prior_content"] is None
+        assert row["applied_content"] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_record_file_modification_existing_captures_prior(self, db, tmp_path):
+        p = tmp_path / "SKILL.md"
+        p.write_text("v1")
+        mid = await record_file_modification(db, actor="a", path=p, new_content="v2")
+        assert p.read_text() == "v2"
+        row = await cfm.get(db, mid)
+        assert row["prior_content"] == "v1"
+
+    @pytest.mark.asyncio
+    async def test_record_existing_records_a_done_write(self, db, tmp_path):
+        p = tmp_path / "USER_KNOWLEDGE.md"
+        p.write_text("synth")  # caller already wrote it
+        mid = await record_existing(
+            db, actor="user_model_evolution", path=p,
+            prior_content="old", applied_content="synth",
+        )
+        row = await cfm.get(db, mid)
+        assert row["prior_content"] == "old"
+        assert row["applied_content"] == "synth"
+
+    @pytest.mark.asyncio
+    async def test_best_effort_write_survives_db_failure(self, tmp_path):
+        bad_db = AsyncMock()
+        bad_db.execute.side_effect = RuntimeError("db down")
+        p = tmp_path / "f.md"
+        mid = await record_file_modification(
+            bad_db, actor="a", path=p, new_content="written",
+        )
+        assert mid is None  # ledger insert failed
+        assert p.read_text() == "written"  # but the cognitive write still happened
+
+    @pytest.mark.asyncio
+    async def test_prune_on_write_caps_history(self, db, tmp_path, monkeypatch):
+        monkeypatch.setattr(cl, "_KEEP_PER_TARGET", 2)
+        p = tmp_path / "f.md"
+        for i in range(4):
+            await record_file_modification(db, actor="a", path=p, new_content=f"v{i}")
+        rows = await cfm.recent(db, limit=10)
+        assert len([r for r in rows if r["target_path"] == str(p)]) == 2
+
+
+# --------------------------------------------------------------------------- #
+# Rollback
+# --------------------------------------------------------------------------- #
+class TestRollback:
+    @pytest.mark.asyncio
+    async def test_restores_prior(self, db, tmp_path):
+        p = tmp_path / "f.md"
+        p.write_text("v1")
+        mid = await record_file_modification(db, actor="a", path=p, new_content="v2")
+        res = await rollback(db, mid)
+        assert res["ok"] is True
+        assert res["restored_to"] == "prior"
+        assert p.read_text() == "v1"
+        assert (await cfm.get(db, mid))["status"] == "rolled_back"
+
+    @pytest.mark.asyncio
+    async def test_deletes_file_when_prior_absent(self, db, tmp_path):
+        p = tmp_path / "new.md"  # absent before the mod
+        mid = await record_file_modification(db, actor="a", path=p, new_content="created")
+        assert p.exists()
+        res = await rollback(db, mid)
+        assert res["ok"] is True
+        assert res["restored_to"] == "absent"
+        assert not p.exists()
+
+    @pytest.mark.asyncio
+    async def test_drift_refused_then_forced(self, db, tmp_path):
+        p = tmp_path / "f.md"
+        p.write_text("v1")
+        mid = await record_file_modification(db, actor="a", path=p, new_content="v2")
+        p.write_text("v3-external")  # someone/another job changed it since
+
+        refused = await rollback(db, mid)
+        assert refused["ok"] is False and refused["refused"] is True
+        assert p.read_text() == "v3-external"  # untouched
+
+        forced = await rollback(db, mid, force=True)
+        assert forced["ok"] is True
+        assert p.read_text() == "v1"
+
+    @pytest.mark.asyncio
+    async def test_already_rolled_back(self, db, tmp_path):
+        p = tmp_path / "f.md"
+        p.write_text("v1")
+        mid = await record_file_modification(db, actor="a", path=p, new_content="v2")
+        await rollback(db, mid)
+        again = await rollback(db, mid)
+        assert again["ok"] is False
+        assert "already" in again["reason"]
+
+    @pytest.mark.asyncio
+    async def test_missing_id(self, db):
+        res = await rollback(db, "nope")
+        assert res["ok"] is False
+        assert "no such" in res["reason"]
+
+    @pytest.mark.asyncio
+    async def test_emits_observation_on_success(self, db, tmp_path):
+        p = tmp_path / "f.md"
+        p.write_text("v1")
+        mid = await record_file_modification(db, actor="a", path=p, new_content="v2")
+        await rollback(db, mid)
+        cur = await db.execute(
+            "SELECT content FROM observations WHERE source='cognitive_ledger'"
+        )
+        rows = await cur.fetchall()
+        assert any("rolled_back" in r[0] for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_emits_observation_on_drift_refused(self, db, tmp_path):
+        p = tmp_path / "f.md"
+        p.write_text("v1")
+        mid = await record_file_modification(db, actor="a", path=p, new_content="v2")
+        p.write_text("drift")
+        await rollback(db, mid)
+        cur = await db.execute(
+            "SELECT content FROM observations WHERE source='cognitive_ledger'"
+        )
+        rows = await cur.fetchall()
+        assert any("refused" in r[0] for r in rows)

--- a/tests/test_learning/test_cognitive_ledger.py
+++ b/tests/test_learning/test_cognitive_ledger.py
@@ -90,6 +90,23 @@ class TestCapture:
         rows = await cfm.recent(db, limit=10)
         assert len([r for r in rows if r["target_path"] == str(p)]) == 2
 
+    @pytest.mark.asyncio
+    async def test_atomic_write_cleans_temp_and_preserves_target_on_failure(
+        self, db, tmp_path, monkeypatch,
+    ):
+        p = tmp_path / "f.md"
+        p.write_text("orig")
+
+        def _boom(self, _target):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(cl.Path, "replace", _boom)
+        with pytest.raises(OSError):
+            await record_file_modification(db, actor="a", path=p, new_content="new")
+        # No orphaned temp; the original file is untouched (rename never completed).
+        assert not list(tmp_path.glob("*.cogtmp"))
+        assert p.read_text() == "orig"
+
 
 # --------------------------------------------------------------------------- #
 # Rollback

--- a/tests/test_learning/test_cognitive_ledger_mcp.py
+++ b/tests/test_learning/test_cognitive_ledger_mcp.py
@@ -1,0 +1,83 @@
+"""Tests for the cognitive-ledger MCP tools (operator surface).
+
+Exercises the _impl functions directly against a stubbed HealthDataService,
+mirroring the self_improvement_status / ego_calibration MCP surface tests.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.learning.cognitive_ledger import record_file_modification
+from genesis.mcp.health.cognitive_ledger_tools import (
+    _impl_cognitive_modification_rollback,
+    _impl_cognitive_modification_status,
+)
+
+
+@pytest.fixture
+async def db(tmp_path):
+    from genesis.db.schema import create_all_tables
+
+    path = str(tmp_path / "cl.db")
+    async with aiosqlite.connect(path) as conn:
+        await create_all_tables(conn)
+        await conn.commit()
+        yield conn
+
+
+class _StubService:
+    def __init__(self, _db):
+        self._db = _db
+
+
+@pytest.mark.asyncio
+async def test_unavailable_when_no_service(monkeypatch):
+    import genesis.mcp.health_mcp as hm
+
+    monkeypatch.setattr(hm, "_service", None, raising=False)
+    assert (await _impl_cognitive_modification_status())["status"] == "unavailable"
+    rb = await _impl_cognitive_modification_rollback("x")
+    assert rb["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_empty_status_is_coherent(db, monkeypatch):
+    import genesis.mcp.health_mcp as hm
+
+    monkeypatch.setattr(hm, "_service", _StubService(db), raising=False)
+    res = await _impl_cognitive_modification_status()
+    assert res["status"] == "ok"
+    assert res["total_targets"] == 0
+    assert res["recent"] == []
+
+
+@pytest.mark.asyncio
+async def test_status_lists_then_rollback_reverts(db, tmp_path, monkeypatch):
+    import genesis.mcp.health_mcp as hm
+
+    monkeypatch.setattr(hm, "_service", _StubService(db), raising=False)
+
+    p = tmp_path / "SKILL.md"
+    p.write_text("v1")
+    mid = await record_file_modification(
+        db, actor="skill_evolution", path=p, new_content="v2",
+        summary="auto-apply",
+    )
+
+    status = await _impl_cognitive_modification_status()
+    assert status["status"] == "ok"
+    assert status["total_targets"] == 1
+    listed = {r["mod_id"]: r for r in status["recent"]}
+    assert mid in listed
+    assert listed[mid]["actor"] == "skill_evolution"
+    assert listed[mid]["prior_chars"] == 2  # "v1"
+
+    rb = await _impl_cognitive_modification_rollback(mid)
+    assert rb["ok"] is True
+    assert p.read_text() == "v1"
+
+    # Filter by actor works too.
+    only = await _impl_cognitive_modification_status(actor="triage_calibration_daily")
+    assert only["recent"] == []

--- a/tests/test_learning/test_cognitive_ledger_wiring.py
+++ b/tests/test_learning/test_cognitive_ledger_wiring.py
@@ -1,0 +1,111 @@
+"""Wiring tests: the live cognitive write paths record into the ledger.
+
+Proves end-to-end (real DB, real file) that the skill applicator and the triage
+calibration regen now route their overwrite through the cognitive self-mod ledger,
+producing a recoverable ``cognitive_file_modifications`` row with the right actor.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import cognitive_file_modifications as cfm
+
+_VALID_CALIBRATION_JSON = """{
+  "examples": [
+    {"scenario": "a", "depth": 0, "rationale": "trivial"},
+    {"scenario": "b", "depth": 1, "rationale": "simple"},
+    {"scenario": "c", "depth": 2, "rationale": "moderate"},
+    {"scenario": "d", "depth": 3, "rationale": "complex"},
+    {"scenario": "e", "depth": 4, "rationale": "obstacle"}
+  ],
+  "rules": ["rule1", "BIAS RULE: corrections/frustration are depth 2+, praise alone is not"],
+  "source_model": "test-model"
+}"""
+
+
+@pytest.fixture
+async def db(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    async with aiosqlite.connect(db_path) as conn:
+        from genesis.db.schema import create_all_tables
+
+        await create_all_tables(conn)
+        await conn.commit()
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_skill_applicator_records_ledger_row(db, tmp_path, monkeypatch):
+    from genesis.learning.skills.applicator import SkillApplicator
+    from genesis.learning.skills.types import (
+        ChangeSize,
+        SkillProposal,
+        ValidationResult,
+    )
+
+    skill_dir = tmp_path / "test-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("old content")
+
+    proposal = SkillProposal(
+        skill_name="test-skill",
+        proposed_content="new content",
+        rationale="improvement",
+        change_size=ChangeSize.MINOR,
+    )
+    applicator = SkillApplicator(autonomy_level=2)
+    applicator._validator.validate = lambda *a, **kw: ValidationResult(
+        passed=True, test_results={}, blocking_failures=[], warnings=[],
+    )
+    import genesis.learning.skills.wiring as wiring_mod
+
+    monkeypatch.setattr(
+        wiring_mod, "get_skill_path", lambda name: skill_dir / "SKILL.md",
+    )
+
+    result = await applicator.apply(proposal, db)
+    assert result["action"] == "applied"
+    assert (skill_dir / "SKILL.md").read_text() == "new content"
+
+    rows = await cfm.recent(db, limit=10, actor="skill_evolution")
+    assert len(rows) == 1
+    assert rows[0]["prior_content"] == "old content"
+    assert rows[0]["applied_content"] == "new content"
+    assert rows[0]["metadata"]["skill_name"] == "test-skill"
+
+
+@pytest.mark.asyncio
+async def test_triage_calibration_records_ledger_row(db, tmp_path):
+    from genesis.db.crud import observations
+    from genesis.learning.triage.calibration import TriageCalibrator
+
+    # Seed a recent triage observation so calibration has something to chew on.
+    await observations.create(
+        db, id="o1", source="retrospective", type="triage_decision",
+        content="triage depth=2 correction", priority="medium",
+        created_at=datetime.now(UTC).isoformat(),
+    )
+
+    router = SimpleNamespace()
+
+    async def _route_call(_site, _messages):
+        return SimpleNamespace(success=True, content=_VALID_CALIBRATION_JSON)
+
+    router.route_call = _route_call
+
+    cal_path = tmp_path / "TRIAGE_CALIBRATION.md"
+    cal = TriageCalibrator(router=router, db=db, calibration_path=cal_path)
+    result = await cal.run_daily_calibration()
+
+    assert result is not None
+    assert cal_path.exists()  # the file was written via the ledger
+
+    rows = await cfm.recent(db, limit=10, actor="triage_calibration_daily")
+    assert len(rows) == 1
+    assert rows[0]["target_path"] == str(cal_path)
+    assert "Few-Shot Examples" in rows[0]["applied_content"]


### PR DESCRIPTION
## Problem

Genesis autonomously **overwrites its own cognitive config files at runtime with no backup and no undo** — skill `SKILL.md` refinement (weekly), `TRIAGE_CALIBRATION.md` regen (daily), and `USER_KNOWLEDGE.md` synthesis (daily). If a self-edit degrades cognition, there is no way to revert it. Two of these files are gitignored, so git is not a rollback path.

## What this adds

An append-only **cognitive self-modification ledger** that captures the pre-image before each overwrite, plus a drift-guarded rollback and operator MCP tools.

- **`cognitive_file_modifications` table** (migration `0027`) — stores `prior_content` + `applied_content` inline (files <8 KB; covered by the DB backup). Named to avoid the pre-existing dead `file_modifications` table (CC-tool audit, zero callers — removal tracked as a follow-up).
- **`learning/cognitive_ledger.py`** — `record_file_modification` (read pre-image → unique-temp same-dir atomic write → best-effort ledger insert → prune-on-write, keep 30/target), `record_existing` (record a write the caller already did), `rollback(mod_id, force=False)` (drift guard: refuse if the on-disk file changed since, unless forced; restore the pre-image or delete the file; emits an observation on every outcome), `recent`.
- **3 wired chokepoints** — the skill applicator and triage calibration route their write through the ledger; the user-knowledge synthesis brackets the existing loader call (no loader change).
- **Operator MCP tools** — `cognitive_modification_status` (read) and `cognitive_modification_rollback` (revert).

## Design

- **The write is primary; the ledger is best-effort** — a failing ledger insert is logged and swallowed, never blocking cognition; a real file-write failure still propagates.
- **Operator surface only** — no automated cognitive path reads the ledger (grep-verified), same discipline as `ego_calibration_snapshots`. Auto-rollback on a degradation signal is a deliberate, soak-gated follow-up.

## Verification

- 90 targeted tests (CRUD, ledger record/rollback/drift/prune, wiring, MCP surface, migration up/down/idempotency/fresh-install); ruff clean.
- genesis-architect design review + code-reviewer (a concurrent-temp race was caught and fixed: unique temp name + cleanup-on-failure, with a regression test).
- End-to-end against a copy of the live DB: migration applies cleanly, record → rollback restores, drift refused, force overrides, observations emitted, no orphaned temp files.

## Follow-ups (tracked)

- Remove the dead `file_modifications` table (separate schema-deletion change).
- Auto-rollback consumer wired to the Outcome Bus degradation signal (soak-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)