### PR TITLE
fix(memory): allow multiple link types between a memory pair (DLI-04)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Genesis no longer loses contradicting or superseding links between memories** — its memory
+  graph could only hold one relationship between any two memories, so recording a second kind
+  (for example marking a pair as "contradicts" when they were already linked as "supports", or
+  "succeeded_by" when one memory replaces another) was silently dropped. Different relationship
+  types between the same two memories are now all kept, so Genesis reasons over a fuller, more
+  honest picture of how its memories relate.
+
 - **Procedure learning survives a two-provider outage** — the routine that captures reusable
   procedures from Genesis's own struggles ran on only two free model providers; when both were
   down at once it exhausted its chain and silently stopped learning. A third independent free

--- a/src/genesis/db/crud/memory_links.py
+++ b/src/genesis/db/crud/memory_links.py
@@ -115,8 +115,11 @@ async def inter_candidate_links(
     if len(memory_ids) > 499:
         memory_ids = memory_ids[:499]
     ph = ",".join("?" * len(memory_ids))
+    # DISTINCT: adjacency is a binary "are these two linked" signal. Since
+    # link_type joined the PK (DLI-04), a pair with multiple types yields
+    # multiple rows — collapse them so the adjacency boost isn't inflated.
     rows = await db.execute_fetchall(
-        f"SELECT source_id, target_id FROM memory_links"
+        f"SELECT DISTINCT source_id, target_id FROM memory_links"
         f" WHERE source_id IN ({ph}) AND target_id IN ({ph})",
         memory_ids + memory_ids,
     )
@@ -133,12 +136,26 @@ async def delete(
     *,
     source_id: str,
     target_id: str,
+    link_type: str | None = None,
 ) -> bool:
-    """Delete a memory link. Returns True if deleted."""
-    cursor = await db.execute(
-        "DELETE FROM memory_links WHERE source_id = ? AND target_id = ?",
-        (source_id, target_id),
-    )
+    """Delete memory link(s) between a pair. Returns True if any row deleted.
+
+    With ``link_type`` set, deletes only that typed link. Without it, deletes
+    ALL link types between the pair — be deliberate, since ``link_type`` joined
+    the PK (DLI-04) a pair can now hold several edges and the untyped form
+    removes every one of them.
+    """
+    if link_type is not None:
+        cursor = await db.execute(
+            "DELETE FROM memory_links "
+            "WHERE source_id = ? AND target_id = ? AND link_type = ?",
+            (source_id, target_id, link_type),
+        )
+    else:
+        cursor = await db.execute(
+            "DELETE FROM memory_links WHERE source_id = ? AND target_id = ?",
+            (source_id, target_id),
+        )
     await db.commit()
     return cursor.rowcount > 0
 

--- a/src/genesis/db/migrations/0029_memory_links_link_type_pk.py
+++ b/src/genesis/db/migrations/0029_memory_links_link_type_pk.py
@@ -1,0 +1,137 @@
+"""Migration 0029 — add ``link_type`` to the ``memory_links`` primary key.
+
+The original PK ``(source_id, target_id)`` allowed only ONE link between any
+two memories, so a second link of a *different* type (e.g. ``contradicts``
+after ``supports``, or ``succeeded_by``) was silently dropped on insert — the
+writers (linker, connection_pass, dream_cycle) swallow the IntegrityError.
+Audit finding DLI-04 / decision D15: the PK becomes
+``(source_id, target_id, link_type)`` so distinct relationship types between
+the same pair coexist.
+
+SQLite can't ALTER a primary key, so this rebuilds the table. The OLD PK was
+*stricter* than the new one (it already guaranteed one row per pair), so every
+existing row is unique under the new PK — the copy needs no dedup
+(``INSERT OR IGNORE`` is belt-and-suspenders). Idempotent: re-running detects
+``link_type`` in the PK and exits.
+
+Runner contract (see ``runner.py``): ``up()`` MUST NOT call ``db.commit()`` /
+``BEGIN`` / ``executescript()`` / ``cursor()`` — the runner owns the atomic
+transaction and a proxy raises ``RuntimeError`` on those. Fresh installs get the
+new PK directly via ``_tables.py`` (this migration is a no-op there).
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+_NEW_DDL = """
+    CREATE TABLE memory_links_new (
+        source_id   TEXT NOT NULL,
+        target_id   TEXT NOT NULL,
+        link_type   TEXT NOT NULL CHECK (
+            link_type IN (
+                'supports','contradicts','extends','elaborates',
+                'discussed_in','evaluated_for','decided',
+                'action_item_for','categorized_as','related_to',
+                'succeeded_by','preceded_by'
+            )
+        ),
+        strength    REAL NOT NULL DEFAULT 0.5,
+        created_at  TEXT NOT NULL,
+        PRIMARY KEY (source_id, target_id, link_type)
+    )
+"""
+
+
+async def _pk_columns(db: aiosqlite.Connection) -> list[str]:
+    """Return memory_links PK column names in key order (empty if no table)."""
+    cursor = await db.execute("PRAGMA table_info(memory_links)")
+    rows = await cursor.fetchall()
+    # PRAGMA columns: (cid, name, type, notnull, dflt_value, pk)
+    # pk > 0 is the 1-based position within the primary key.
+    pk = sorted((row[5], row[1]) for row in rows if row[5] and row[5] > 0)
+    return [name for _, name in pk]
+
+
+async def _table_exists(db: aiosqlite.Connection) -> bool:
+    cursor = await db.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='memory_links'"
+    )
+    return await cursor.fetchone() is not None
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # No table yet (fresh DB) → _tables.py already creates the new shape.
+    if not await _table_exists(db):
+        return
+    # Already migrated → exit (idempotent).
+    if "link_type" in await _pk_columns(db):
+        return
+
+    # Drop any leftover temp table from a prior interrupted run.
+    await db.execute("DROP TABLE IF EXISTS memory_links_new")
+    await db.execute(_NEW_DDL)
+    await db.execute(
+        "INSERT OR IGNORE INTO memory_links_new "
+        "(source_id, target_id, link_type, strength, created_at) "
+        "SELECT source_id, target_id, link_type, strength, created_at "
+        "FROM memory_links"
+    )
+    await db.execute("DROP TABLE memory_links")
+    await db.execute("ALTER TABLE memory_links_new RENAME TO memory_links")
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_links_source "
+        "ON memory_links(source_id)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_links_target "
+        "ON memory_links(target_id)"
+    )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    """Reverse to the ``(source_id, target_id)`` PK (development/testing only).
+
+    LOSSY if multi-type pairs exist — ``INSERT OR IGNORE`` keeps one row per
+    pair. The forward migration is the supported direction.
+    """
+    if not await _table_exists(db):
+        return
+    if "link_type" not in await _pk_columns(db):
+        return
+    await db.execute("DROP TABLE IF EXISTS memory_links_old")
+    await db.execute(
+        """
+        CREATE TABLE memory_links_old (
+            source_id   TEXT NOT NULL,
+            target_id   TEXT NOT NULL,
+            link_type   TEXT NOT NULL CHECK (
+                link_type IN (
+                    'supports','contradicts','extends','elaborates',
+                    'discussed_in','evaluated_for','decided',
+                    'action_item_for','categorized_as','related_to',
+                    'succeeded_by','preceded_by'
+                )
+            ),
+            strength    REAL NOT NULL DEFAULT 0.5,
+            created_at  TEXT NOT NULL,
+            PRIMARY KEY (source_id, target_id)
+        )
+        """
+    )
+    await db.execute(
+        "INSERT OR IGNORE INTO memory_links_old "
+        "(source_id, target_id, link_type, strength, created_at) "
+        "SELECT source_id, target_id, link_type, strength, created_at "
+        "FROM memory_links"
+    )
+    await db.execute("DROP TABLE memory_links")
+    await db.execute("ALTER TABLE memory_links_old RENAME TO memory_links")
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_links_source "
+        "ON memory_links(source_id)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memory_links_target "
+        "ON memory_links(target_id)"
+    )

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -464,7 +464,11 @@ TABLES = {
             ),
             strength    REAL NOT NULL DEFAULT 0.5,
             created_at  TEXT NOT NULL,
-            PRIMARY KEY (source_id, target_id)
+            -- link_type is part of the PK (audit DLI-04 / D15): distinct
+            -- relationship types between the same pair (e.g. supports AND
+            -- contradicts) must coexist, not silently overwrite. Migration
+            -- 0029 brings existing DBs to this shape.
+            PRIMARY KEY (source_id, target_id, link_type)
         )
     """,
     "deferred_work_queue": """

--- a/tests/test_db/test_memory_links.py
+++ b/tests/test_db/test_memory_links.py
@@ -61,14 +61,63 @@ async def test_delete_nonexistent(db):
     assert await memory_links.delete(db, source_id="nope1", target_id="nope2") is False
 
 
-async def test_duplicate_pk_raises(db):
+async def test_same_triplet_raises(db):
+    """The same (source, target, link_type) twice still violates the PK."""
     await memory_links.create(
         db, source_id="g1", target_id="g2", link_type="supports", created_at="2026-01-01",
     )
     with pytest.raises(IntegrityError):
         await memory_links.create(
-            db, source_id="g1", target_id="g2", link_type="contradicts", created_at="2026-01-02",
+            db, source_id="g1", target_id="g2", link_type="supports", created_at="2026-01-02",
         )
+
+
+async def test_different_link_type_same_pair_persists(db):
+    """DLI-04: a 2nd link of a DIFFERENT type between the same pair must persist.
+
+    The old PK (source_id, target_id) silently dropped this; the fixed PK
+    (source_id, target_id, link_type) keeps both edges.
+    """
+    await memory_links.create(
+        db, source_id="g1", target_id="g2", link_type="supports", created_at="2026-01-01",
+    )
+    await memory_links.create(
+        db, source_id="g1", target_id="g2", link_type="contradicts", created_at="2026-01-02",
+    )
+    links = await memory_links.get_links_for(db, "g1")
+    types = sorted(link["link_type"] for link in links)
+    assert types == ["contradicts", "supports"]
+
+
+async def test_inter_candidate_links_dedupes_multi_type_pairs(db):
+    """Adjacency boost is binary per pair — a multi-type pair counts once."""
+    await memory_links.create(
+        db, source_id="a", target_id="b", link_type="supports", created_at="2026-01-01",
+    )
+    await memory_links.create(
+        db, source_id="a", target_id="b", link_type="contradicts", created_at="2026-01-02",
+    )
+    edges = await memory_links.inter_candidate_links(db, ["a", "b"])
+    assert edges == [("a", "b")]  # deduped, not [("a","b"), ("a","b")]
+
+
+async def test_delete_by_link_type(db):
+    """delete(link_type=...) removes only that type; without it, all types go."""
+    await memory_links.create(
+        db, source_id="a", target_id="b", link_type="supports", created_at="2026-01-01",
+    )
+    await memory_links.create(
+        db, source_id="a", target_id="b", link_type="contradicts", created_at="2026-01-02",
+    )
+    # Targeted delete removes only the typed link.
+    assert await memory_links.delete(
+        db, source_id="a", target_id="b", link_type="supports",
+    ) is True
+    remaining = await memory_links.get_links_for(db, "a")
+    assert [link["link_type"] for link in remaining] == ["contradicts"]
+    # Untyped delete removes whatever is left for the pair.
+    assert await memory_links.delete(db, source_id="a", target_id="b") is True
+    assert await memory_links.get_links_for(db, "a") == []
 
 
 # --- Batch link count tests ---

--- a/tests/test_db/test_migration_0029.py
+++ b/tests/test_db/test_migration_0029.py
@@ -1,0 +1,155 @@
+"""Migration 0029 — link_type joins the memory_links primary key (DLI-04 / D15)."""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+_OLD_DDL = """
+    CREATE TABLE memory_links (
+        source_id   TEXT NOT NULL,
+        target_id   TEXT NOT NULL,
+        link_type   TEXT NOT NULL CHECK (
+            link_type IN (
+                'supports','contradicts','extends','elaborates',
+                'discussed_in','evaluated_for','decided',
+                'action_item_for','categorized_as','related_to',
+                'succeeded_by','preceded_by'
+            )
+        ),
+        strength    REAL NOT NULL DEFAULT 0.5,
+        created_at  TEXT NOT NULL,
+        PRIMARY KEY (source_id, target_id)
+    )
+"""
+
+_MIG = "genesis.db.migrations.0029_memory_links_link_type_pk"
+
+
+async def _make_fixture_db(path: str, rows: list[tuple] | None = None) -> None:
+    """Build memory_links with the OLD (source_id, target_id) PK + seed rows."""
+    async with aiosqlite.connect(path) as conn:
+        await conn.execute(_OLD_DDL)
+        if rows:
+            await conn.executemany(
+                "INSERT INTO memory_links "
+                "(source_id, target_id, link_type, strength, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                rows,
+            )
+        await conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_second_type_persists_after_migration(tmp_path) -> None:
+    """After migration a 2nd link of a different type for the same pair persists."""
+    db_path = tmp_path / "mig.db"
+    await _make_fixture_db(
+        str(db_path),
+        rows=[("a", "b", "supports", 0.5, "2026-01-01")],
+    )
+    mod = importlib.import_module(_MIG)
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await mod.up(conn)
+        await conn.commit()
+
+        # This INSERT raised IntegrityError under the old PK; now it succeeds.
+        await conn.execute(
+            "INSERT INTO memory_links "
+            "(source_id, target_id, link_type, strength, created_at) "
+            "VALUES ('a', 'b', 'contradicts', 0.5, '2026-01-02')"
+        )
+        await conn.commit()
+
+        cursor = await conn.execute(
+            "SELECT link_type FROM memory_links "
+            "WHERE source_id='a' AND target_id='b' ORDER BY link_type"
+        )
+        types = [r[0] for r in await cursor.fetchall()]
+        assert types == ["contradicts", "supports"]
+
+
+@pytest.mark.asyncio
+async def test_pre_existing_rows_survive(tmp_path) -> None:
+    """All existing rows survive the table rebuild."""
+    db_path = tmp_path / "mig.db"
+    seed = [
+        ("m1", "m2", "supports", 0.5, "2026-01-01"),
+        ("m2", "m3", "extends", 0.7, "2026-01-02"),
+        ("m3", "m1", "contradicts", 0.5, "2026-01-03"),
+    ]
+    await _make_fixture_db(str(db_path), rows=seed)
+    mod = importlib.import_module(_MIG)
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await mod.up(conn)
+        await conn.commit()
+        cursor = await conn.execute("SELECT COUNT(*) FROM memory_links")
+        assert (await cursor.fetchone())[0] == 3
+
+
+@pytest.mark.asyncio
+async def test_same_triplet_still_rejected(tmp_path) -> None:
+    """The same (source, target, link_type) still violates the new PK."""
+    db_path = tmp_path / "mig.db"
+    await _make_fixture_db(
+        str(db_path),
+        rows=[("x", "y", "supports", 0.5, "2026-01-01")],
+    )
+    mod = importlib.import_module(_MIG)
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await mod.up(conn)
+        await conn.commit()
+        with pytest.raises(aiosqlite.IntegrityError):
+            await conn.execute(
+                "INSERT INTO memory_links "
+                "(source_id, target_id, link_type, strength, created_at) "
+                "VALUES ('x', 'y', 'supports', 0.5, '2026-01-02')"
+            )
+            await conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_indexes_recreated(tmp_path) -> None:
+    """The source/target indexes exist after the rebuild."""
+    db_path = tmp_path / "mig.db"
+    await _make_fixture_db(str(db_path), rows=[("a", "b", "supports", 0.5, "2026-01-01")])
+    mod = importlib.import_module(_MIG)
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await mod.up(conn)
+        await conn.commit()
+        cursor = await conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND tbl_name='memory_links'"
+        )
+        idx = {r[0] for r in await cursor.fetchall()}
+        assert "idx_memory_links_source" in idx
+        assert "idx_memory_links_target" in idx
+
+
+@pytest.mark.asyncio
+async def test_idempotent(tmp_path) -> None:
+    """Running up() twice is safe (second run detects the new PK and exits)."""
+    db_path = tmp_path / "mig.db"
+    await _make_fixture_db(
+        str(db_path),
+        rows=[("a", "b", "supports", 0.5, "2026-01-01")],
+    )
+    mod = importlib.import_module(_MIG)
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await mod.up(conn)
+        await mod.up(conn)  # must not error or drop data
+        await conn.commit()
+        cursor = await conn.execute("SELECT COUNT(*) FROM memory_links")
+        assert (await cursor.fetchone())[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_table_is_noop(tmp_path) -> None:
+    """A fresh DB with no memory_links table: up() is a safe no-op."""
+    db_path = tmp_path / "empty.db"
+    async with aiosqlite.connect(str(db_path)) as conn:
+        mod = importlib.import_module(_MIG)
+        await mod.up(conn)  # must not raise
+        await conn.commit()


### PR DESCRIPTION
## What & why (audit DLI-04 / decision D15)

Genesis's `memory_links` table had a primary key of `(source_id, target_id)`, so only **one** link could exist between any two memories. A second link of a *different* type between the same pair — e.g. marking a pair `contradicts` when it was already linked `supports`, or `succeeded_by` when one memory replaces another — raised a UNIQUE violation that the writers (linker / connection_pass / dream_cycle) catch and swallow. The edge was **silently dropped**, so the memory graph quietly lost contradicting and superseding relationships.

This makes `link_type` part of the primary key — `(source_id, target_id, link_type)` — so distinct relationship types between the same pair coexist.

## Changes
- **`migrations/0029_memory_links_link_type_pk.py`** (new) — rebuilds the table with the new PK. No dedup needed (the old PK was *stricter*, so existing rows are already unique under the new one); idempotent (`PRAGMA table_info` PK check); obeys the runner's no-commit contract; ships a `down()`.
- **`_tables.py`** — canonical PK updated so fresh installs match.
- **`crud/memory_links.py`** — `inter_candidate_links` now `SELECT DISTINCT` so a multi-type pair doesn't inflate the binary adjacency boost in retrieval; `delete` gains an optional `link_type` to remove a single typed edge instead of every edge for the pair.

## Verification
- 21 new/updated unit tests (CRUD behavior + a full migration matrix: 2nd-type persists, rows survive, same-triplet still rejected, indexes recreated, idempotent, missing-table no-op).
- 751-test blast-radius sweep across the `memory_links` consumers (linker, graph, dream-cycle, dream-link-repair, supersession, health, retrieval) — all green.
- **Real `MigrationRunner` applied `0029` to a copy of the production DB**: 125,170 rows preserved, `integrity_check: ok`, 2.85s, idempotent, multi-type insert confirmed working.
- Code review: clean (no P1/P2).

Readers verified compatible. `graph.py`'s `DiGraph` collapses multi-type pairs to one edge — a documented, pre-existing limitation (true multi-relational traversal would need `MultiDiGraph`); out of scope here.

Part of audit work-stream **WS-5** (memory retrieval correctness). Held for review + merge approval.