### PR TITLE
fix(observability): capture CC tool spans in dispatched sessions via --settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -348,11 +348,6 @@
                         "type": "command",
                         "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/session_observer_hook.py",
                         "timeout": 500
-                    },
-                    {
-                        "type": "command",
-                        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/cc_span_hook.py",
-                        "timeout": 500
                     }
                 ]
             },

--- a/scripts/hooks/cc_span_hook.py
+++ b/scripts/hooks/cc_span_hook.py
@@ -15,6 +15,11 @@ write the DB, but only on Write/Edit; a ``.*`` matcher fires far more often).
 
 Budget: <50ms (JSON parse + locked file append). No LLM, no network, no SQLite.
 Honors ``GENESIS_SPANS_INCOMING_DIR`` (test override).
+
+Registration: NOT via the repo ``.claude/settings.json`` — dispatched sessions
+run with a cwd outside any git repo, so CC never discovers project settings
+there. ``CCInvoker`` injects this hook per-dispatch via ``--settings`` pointing
+at a generated minimal file (``cc_span_settings_path`` in ``genesis.cc.invoker``).
 """
 
 from __future__ import annotations

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -74,6 +74,78 @@ def _get_scope_args() -> list[str]:
     return _SCOPE_ARGS
 
 
+# A minimal, runtime-generated CC settings file that registers ONLY the span
+# PostToolUse hook. Lives outside the repo so it is install-local and never
+# committed; regenerated idempotently (see cc_span_settings_path).
+_CC_SPAN_SETTINGS_PATH = Path.home() / ".genesis" / "cc-span-settings.json"
+
+
+def cc_span_settings_path() -> str | None:
+    """Generate (idempotently) a minimal CC settings file that registers ONLY
+    the span PostToolUse hook, and return its absolute path — or ``None`` if the
+    launcher is unavailable.
+
+    Why this exists: dispatched CC sessions run with a working directory outside
+    any git repo (``~/.genesis/background-sessions``), and Claude Code discovers
+    project ``.claude/settings.json`` via git-root detection — so the repo-level
+    hook registration never loads there and ``cc_span_hook`` never fires. Passing
+    this file via ``--settings`` injects JUST that hook; CC merges it with the
+    user's settings, leaving every other hook untouched. The hook itself no-ops
+    unless ``GENESIS_TRACE_ID`` is set, so attaching it to every dispatch is safe
+    (and is why this is the *single* registration — the repo-level one was
+    removed to avoid a double-fire when a dispatch runs in a worktree cwd, which
+    *does* load repo settings).
+
+    The hook command uses an ABSOLUTE path to the ``genesis-hook`` launcher,
+    which self-locates the install root from its own filesystem position — NOT
+    ``${CLAUDE_PROJECT_DIR}``, which CC leaves unset in dispatched sessions.
+    Written atomically and only when stale, so it tracks the install root across
+    updates with no bootstrap-ordering dependency and no per-dispatch churn.
+    """
+    from genesis import env
+
+    genesis_hook = env.repo_root() / ".claude" / "hooks" / "genesis-hook"
+    if not genesis_hook.exists():
+        return None
+
+    desired = json.dumps(
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": f"{genesis_hook} hooks/cc_span_hook.py",
+                                "timeout": 500,
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        indent=2,
+    )
+
+    path = _CC_SPAN_SETTINGS_PATH
+    try:
+        if path.exists() and path.read_text(encoding="utf-8") == desired:
+            return str(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Unique temp name (pid-suffixed) so concurrent processes can't clobber
+        # each other mid-write; os.replace is atomic.
+        tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        tmp.write_text(desired, encoding="utf-8")
+        os.replace(tmp, path)
+        return str(path)
+    except OSError:
+        logger.warning(
+            "Could not write CC span settings file at %s", path, exc_info=True,
+        )
+        return None
+
+
 class CCInvoker:
     """Invokes claude CLI as async subprocess."""
 
@@ -160,6 +232,14 @@ class CCInvoker:
             args += ["--resume", inv.resume_session_id]
         if inv.mcp_config:
             args += ["--mcp-config", inv.mcp_config]
+        # Register the span-capture PostToolUse hook for this dispatched session.
+        # Dispatched sessions run with a cwd outside any git repo, so CC never
+        # loads the repo's .claude/settings.json; --settings injects just this
+        # hook (CC merges it with the user's settings). No-op unless a trace is
+        # active (GENESIS_TRACE_ID). See cc_span_settings_path.
+        span_settings = cc_span_settings_path()
+        if span_settings:
+            args += ["--settings", span_settings]
         if inv.skip_permissions:
             args.append("--dangerously-skip-permissions")
         if inv.allowed_tools:
@@ -531,8 +611,11 @@ class CCInvoker:
     ) -> CCOutput:
         """Run CC with stream-json output, calling on_event for each line."""
         args = self._build_args(invocation)
-        # Override output format to stream-json (requires --verbose with -p)
-        fmt_idx = args.index("json")
+        # Override output format to stream-json (requires --verbose with -p).
+        # Target the --output-format value by its flag, not a bare args.index("json")
+        # scan — other args (e.g. --settings .../cc-span-settings.json) can contain
+        # the substring "json", and keying off the flag is unambiguous.
+        fmt_idx = args.index("--output-format") + 1
         args[fmt_idx] = "stream-json"
         args.insert(1, "--verbose")
 

--- a/tests/test_cc/conftest.py
+++ b/tests/test_cc/conftest.py
@@ -1,0 +1,19 @@
+"""Shared fixtures for CC invoker tests.
+
+``CCInvoker._build_args`` lazily generates a per-install CC span-settings file
+(``cc_span_settings_path``). Redirect it to a temp path for every test in this
+package so the suite never writes the real ``~/.genesis/cc-span-settings.json``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cc_span_settings(tmp_path, monkeypatch):
+    from genesis.cc import invoker as inv_mod
+
+    monkeypatch.setattr(
+        inv_mod, "_CC_SPAN_SETTINGS_PATH", tmp_path / "cc-span-settings.json",
+    )

--- a/tests/test_cc/test_invoker.py
+++ b/tests/test_cc/test_invoker.py
@@ -57,6 +57,98 @@ def test_build_args_with_mcp_config(invoker):
     assert "/path/to/mcp.json" in args
 
 
+def test_build_args_includes_span_settings(invoker, monkeypatch):
+    """Dispatched sessions get --settings pointing at the span-hook file."""
+    import genesis.cc.invoker as inv_mod
+
+    monkeypatch.setattr(
+        inv_mod, "cc_span_settings_path", lambda: "/tmp/cc-span-settings.json",
+    )
+    args = invoker._build_args(CCInvocation(prompt="hi"))
+    assert "--settings" in args
+    assert args[args.index("--settings") + 1] == "/tmp/cc-span-settings.json"
+
+
+def test_build_args_omits_span_settings_when_unavailable(invoker, monkeypatch):
+    """No --settings when the span-hook file can't be generated (None)."""
+    import genesis.cc.invoker as inv_mod
+
+    monkeypatch.setattr(inv_mod, "cc_span_settings_path", lambda: None)
+    args = invoker._build_args(CCInvocation(prompt="hi"))
+    assert "--settings" not in args
+
+
+def _fake_genesis_hook_repo(tmp_path):
+    """Create a fake repo root containing a genesis-hook launcher."""
+    hook = tmp_path / "repo" / ".claude" / "hooks" / "genesis-hook"
+    hook.parent.mkdir(parents=True)
+    hook.write_text("#!/bin/bash\n")
+    return tmp_path / "repo", hook
+
+
+def test_cc_span_settings_path_generates_file(monkeypatch, tmp_path):
+    """Generates a minimal settings file with the span hook at an ABSOLUTE path."""
+    import genesis.cc.invoker as inv_mod
+
+    fake_repo, hook = _fake_genesis_hook_repo(tmp_path)
+    monkeypatch.setenv("GENESIS_REPO_ROOT", str(fake_repo))
+    out = tmp_path / "settings.json"
+    monkeypatch.setattr(inv_mod, "_CC_SPAN_SETTINGS_PATH", out)
+
+    result = inv_mod.cc_span_settings_path()
+    assert result == str(out)
+    data = json.loads(out.read_text())
+    entry = data["hooks"]["PostToolUse"][0]
+    assert entry["matcher"] == ".*"
+    cmd = entry["hooks"][0]["command"]
+    # Absolute launcher path, no ${CLAUDE_PROJECT_DIR} (unset in dispatched cwd).
+    assert cmd == f"{hook} hooks/cc_span_hook.py"
+    assert cmd.startswith("/")
+    assert "${CLAUDE_PROJECT_DIR}" not in cmd
+
+
+def test_cc_span_settings_path_none_when_hook_missing(monkeypatch, tmp_path):
+    """Returns None (→ no --settings) when the launcher is absent."""
+    import genesis.cc.invoker as inv_mod
+
+    fake_repo = tmp_path / "repo"  # no .claude/hooks/genesis-hook
+    fake_repo.mkdir()
+    monkeypatch.setenv("GENESIS_REPO_ROOT", str(fake_repo))
+    monkeypatch.setattr(inv_mod, "_CC_SPAN_SETTINGS_PATH", tmp_path / "x.json")
+    assert inv_mod.cc_span_settings_path() is None
+
+
+def test_cc_span_settings_path_idempotent(monkeypatch, tmp_path):
+    """Second call with unchanged content does not rewrite the file."""
+    import genesis.cc.invoker as inv_mod
+
+    fake_repo, _ = _fake_genesis_hook_repo(tmp_path)
+    monkeypatch.setenv("GENESIS_REPO_ROOT", str(fake_repo))
+    out = tmp_path / "settings.json"
+    monkeypatch.setattr(inv_mod, "_CC_SPAN_SETTINGS_PATH", out)
+
+    inv_mod.cc_span_settings_path()
+    mtime1 = out.stat().st_mtime_ns
+    inv_mod.cc_span_settings_path()
+    assert out.stat().st_mtime_ns == mtime1
+
+
+def test_cc_span_settings_path_rewrites_when_stale(monkeypatch, tmp_path):
+    """A stale/corrupt file is rewritten to the correct content."""
+    import genesis.cc.invoker as inv_mod
+
+    fake_repo, _ = _fake_genesis_hook_repo(tmp_path)
+    monkeypatch.setenv("GENESIS_REPO_ROOT", str(fake_repo))
+    out = tmp_path / "settings.json"
+    monkeypatch.setattr(inv_mod, "_CC_SPAN_SETTINGS_PATH", out)
+
+    inv_mod.cc_span_settings_path()
+    out.write_text("STALE")  # corrupt it
+    inv_mod.cc_span_settings_path()  # should rewrite
+    data = json.loads(out.read_text())
+    assert data["hooks"]["PostToolUse"][0]["matcher"] == ".*"
+
+
 def test_build_env_strips_claudecode(invoker):
     with patch.dict(
         "os.environ",


### PR DESCRIPTION
## Problem

The tracing/spans backbone (#718) records server-side spans (reflection / ego / `llm.call`), but `otel_spans` had **0 `kind='tool'` rows** despite ~2,400 dispatched CC sessions. The `cc_span_hook` PostToolUse hook never fired in dispatched sessions.

**Root cause:** dispatched sessions run `claude -p` with a working directory outside any git repo (`~/.genesis/background-sessions`). Claude Code discovers project `.claude/settings.json` via **git-root detection**, so it never loaded the repo's hooks there — the hook was registered only in the repo settings. Confirmed three ways: official CC docs, a controlled probe, and a proxy hook (`file_modification_audit_hook`, same launcher) that produced 0 rows across all dispatched sessions.

## Fix

1. **`cc_span_settings_path()`** (`cc/invoker.py`) — lazily + idempotently generates a minimal CC settings file (`~/.genesis/cc-span-settings.json`) registering **only** the span hook, with an **absolute** `genesis-hook` launcher path (cwd-independent; not `${CLAUDE_PROJECT_DIR}`, which CC leaves unset in dispatched sessions). Atomic write, content-compare to avoid churn.
2. **`_build_args`** passes `--settings <that file>` on every dispatch — the supported headless mechanism (CC merges it with user settings). Safe universally: the hook no-ops unless `GENESIS_TRACE_ID` is set.
3. **Removed** the now-redundant repo-level `cc_span_hook` registration from `.claude/settings.json`. Some dispatches (executor) run with a git-**worktree** cwd, which *does* load repo settings — keeping both would fire the hook twice → duplicate spans.
4. **Hardening:** `_run_streaming` now targets the output-format value via the `--output-format` flag instead of a bare `args.index("json")` scan (the new `--settings .../cc-span-settings.json` arg contains the substring "json").

The hook, ingest, and reader are unchanged — they were correct, just never loading.

## Verification

- `ruff check` clean.
- **627 tests pass** (`test_cc/` + `test_observability/` + otel schema), incl. 6 new tests + an isolation conftest.
- **E2E (×2): real dispatched `claude -p` in a non-git cwd → hook fires → JSONL with the injected `trace_id`/`parent_span_id` → ingest → `otel_spans kind='tool'` nested under `cc.session`.** This is the cross-process chain the original A4 E2E never exercised (it invoked the hook directly).

## Notes
- Codex review was **quota-limited**; the Claude code-reviewer pass was clean (one brittleness finding, addressed in #4 above).
- Separate finding filed for review: background-cwd dispatched sessions load none of the repo PreToolUse safety guards (only worktree-cwd dispatches do) — likely intentional (gated via allowed-tools + the autonomy gate), flagged for a decision.
- Activates on the next server deploy (restart regenerates the settings file with the correct install path).