### PR TITLE
fix(awareness): emit reflection idle heartbeat on quiet (depth=None) ticks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   signal — whether its ranking merely favors the memories it retrieves most often — so
   entrenchment of stale-but-popular memories can be watched over time (measured, not acted on).
 
+- **Reflection is no longer falsely reported as "dark" during quiet periods** — the health and
+  morning reports track each subsystem by a periodic heartbeat, but the reflection loop only emitted
+  one when it actually ran a reflection. During legitimately calm stretches (most overnight ticks do
+  no reflection by design), that heartbeat could age past its overdue threshold and the report would
+  warn that reflection had gone silent or "dark" even though the loop was perfectly healthy. Reflection
+  now emits a lightweight idle heartbeat on those quiet ticks, so it only reads as overdue during a
+  genuine outage.
+
 - **Knowledge-base searches stopped silently returning nothing** — the relevance floor that
   trims low-quality knowledge results was a fixed absolute cutoff that, on the score scale recall
   actually produces, sat above the entire range — so searching the knowledge base (or a broad

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -878,6 +878,12 @@ class AwarenessLoop:
                 name=f"reflection-{result.classified_depth.value.lower()}-{result.tick_id[:8]}",
                 subsystem=Subsystem.AWARENESS,
             )
+        else:
+            # Idle alive-pulse: a quiet tick (depth=None) ran no reflection.
+            # Refresh the reflection heartbeat so subsystem_heartbeats does not
+            # falsely report reflection "dark" during calm periods. Degraded
+            # ticks are filtered inside the helper so a real outage still alarms.
+            await self._emit_reflection_idle_heartbeat(result)
 
         if not self._stopping:
             tracked_task(
@@ -921,6 +927,29 @@ class AwarenessLoop:
                     )
             except Exception:
                 logger.warning("Session observer processing failed", exc_info=True)
+
+    async def _emit_reflection_idle_heartbeat(self, result: TickResult) -> None:
+        """Emit a reflection heartbeat for a quiet tick that ran no reflection.
+
+        A tick that classified to ``depth=None`` (nothing triggered, or a
+        ceiling/floor throttle) correctly ran no reflection. Emitting a
+        heartbeat keeps ``subsystem_heartbeats`` fresh during the quiet ticks
+        that dominate calm periods (``depth=None`` is ~93% of ticks), so
+        reflection is not falsely reported "dark" overnight while the loop is
+        healthy. Called from ``_on_tick`` on the depth=None dispatch branch.
+
+        Skipped for a DEGRADED tick (``db_available`` is False — the DB was
+        unavailable so scoring/classification was skipped): a genuine
+        reflection outage must still age out past the heartbeat threshold and
+        alarm, rather than being masked by this pulse.
+        """
+        if not (result.db_available and self._event_bus):
+            return
+        with contextlib.suppress(Exception):
+            await self._event_bus.emit(
+                Subsystem.REFLECTION, Severity.DEBUG,
+                "heartbeat", "reflection idle (no depth triggered)",
+            )
 
     async def _dispatch_reflection(self, result: TickResult) -> None:
         depth = result.classified_depth

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -538,10 +538,12 @@ _CALL_SITE_META: dict[str, dict] = {
         "status_reason": "TEMP_DISABLED",
     },
     "outreach_fallback": {
-        "description": "Deferred outreach delivery retry. Enqueue path active (pipeline.py:335), but consumer NOT BUILT — deferred messages silently marked completed without retry. CRITICAL BUG: needs consumer implementation.",
+        "description": "Deferred outreach delivery retry. Enqueue active (outreach/pipeline.py:_defer → deferred-work work_type='outreach_delivery'). Consumer = OutreachRecoveryWorker (resilience/outreach_recovery.py): polls the deferred-work queue, retries via the pipeline with exponential backoff (max 5 attempts), and writes an observation on exhaustion. Wired at runtime/init/outreach.py (started whenever the deferred-work queue is present).",
         "category": "content",
         "frequency": "On outreach failure",
         "model_tier": "slm",
+        "wired": True,
+        "status_reason": "WIRED",
     },
     "40_knowledge_distillation": {
         "description": "Distills ingested knowledge sources into atomic units. Parallelized across provider chain via chain_offset.",

--- a/tests/test_awareness/test_loop.py
+++ b/tests/test_awareness/test_loop.py
@@ -11,6 +11,7 @@ from genesis.awareness.loop import AwarenessLoop, perform_tick
 from genesis.awareness.signals import ConversationCollector
 from genesis.awareness.types import Depth, DepthScore, SignalReading, TickResult
 from genesis.db.crud import awareness_ticks, observations
+from genesis.observability.types import Subsystem
 
 
 async def _persist_tick(db, tick: TickResult) -> None:
@@ -227,3 +228,75 @@ async def test_micro_dispatch_fires_llm_on_critical_failure(db):
     await loop._dispatch_reflection(tick)
 
     engine.reflect.assert_called_once()
+
+
+# ── depth=None idle alive-pulse (keep reflection heartbeat fresh when quiet) ──
+
+
+def _idle_tick(*, db_available: bool = True, tick_id: str = "idle-tick") -> TickResult:
+    """Helper: a quiet tick that classified to depth=None (no reflection ran)."""
+    return TickResult(
+        tick_id=tick_id,
+        timestamp="2026-06-20T04:00:00+00:00",
+        source="scheduled",
+        signals=[],
+        scores=[],
+        classified_depth=None,
+        trigger_reason="no trigger",
+        db_available=db_available,
+    )
+
+
+async def test_idle_heartbeat_helper_emits_when_healthy(db):
+    """The idle-pulse helper emits a REFLECTION heartbeat for a healthy
+    depth=None tick so subsystem_heartbeats does not falsely report 'dark'."""
+    event_bus = MagicMock()
+    event_bus.emit = AsyncMock()
+    loop = AwarenessLoop(db=db, collectors=[], event_bus=event_bus)
+
+    await loop._emit_reflection_idle_heartbeat(_idle_tick())
+
+    event_bus.emit.assert_called_once()
+    call_args = event_bus.emit.call_args.args
+    assert call_args[0] == Subsystem.REFLECTION
+    assert call_args[2] == "heartbeat"
+
+
+async def test_idle_heartbeat_helper_skips_degraded_tick(db):
+    """A DEGRADED tick (db_available=False) must NOT pulse — a genuine
+    reflection outage should still age out and alarm rather than be masked."""
+    event_bus = MagicMock()
+    event_bus.emit = AsyncMock()
+    loop = AwarenessLoop(db=db, collectors=[], event_bus=event_bus)
+
+    await loop._emit_reflection_idle_heartbeat(
+        _idle_tick(db_available=False, tick_id="degraded-tick"),
+    )
+
+    event_bus.emit.assert_not_called()
+
+
+async def test_on_tick_pulses_reflection_heartbeat_when_idle(db, monkeypatch):
+    """Wiring: a real quiet tick (no signals → depth=None) routes through
+    _on_tick to the idle pulse and emits exactly one REFLECTION heartbeat.
+
+    This guards against the pulse being placed on a path _on_tick never calls
+    (e.g. inside _dispatch_reflection, which only runs when depth is non-None)."""
+    event_bus = MagicMock()
+    event_bus.emit = AsyncMock()
+    loop = AwarenessLoop(db=db, collectors=[], event_bus=event_bus)
+
+    # Record out-of-band dispatches without running them (deferred-retry etc.).
+    def _fake_tracked_task(coro, *, name="", **kw):
+        coro.close()
+        return None
+
+    monkeypatch.setattr("genesis.util.tasks.tracked_task", _fake_tracked_task)
+
+    await loop._on_tick()
+
+    reflection_beats = [
+        c for c in event_bus.emit.call_args_list
+        if c.args and c.args[0] == Subsystem.REFLECTION and c.args[2] == "heartbeat"
+    ]
+    assert len(reflection_beats) == 1


### PR DESCRIPTION
## What

Two fixes that stop the daily morning/health report from false-alarming about reflection.

### Fix A — reflection no longer falsely reported "dark" during quiet periods
The reflection heartbeat (read by `subsystem_heartbeats`, overdue threshold 4h) was only refreshed when a reflection actually ran. Quiet ticks classify to `depth=None` (~93% of ticks — nothing triggered, or a ceiling/floor throttle) and dispatch no reflection, so during calm periods (especially overnight) the heartbeat aged past 4h and the report warned reflection had gone "dark" while the loop was perfectly healthy. Verified against live data: real 8–13h overnight heartbeat gaps.

Emit a lightweight reflection heartbeat on the `depth=None` dispatch branch of `_on_tick`, via a new `_emit_reflection_idle_heartbeat` helper. Gated on `result.db_available` so a DEGRADED tick (DB unavailable → classification skipped) does **not** pulse — a genuine reflection outage still ages out and alarms. Extends the existing Micro-silent idle pulse (#695), which only covered `depth=MICRO` ticks and never reached the dominant `depth=None` path.

### Fix B — correct a stale call-site comment
`outreach_fallback` was documented as "consumer NOT BUILT … CRITICAL BUG". That is false: `OutreachRecoveryWorker` (`resilience/outreach_recovery.py`) polls the deferred-work queue, retries with exponential backoff, and is wired in `runtime/init/outreach.py`. Marked wired.

## Tests
- `_emit_reflection_idle_heartbeat` gate, both directions (healthy quiet tick pulses; degraded tick does not).
- Wiring test through the real `_on_tick` (no signals → `depth=None` → exactly one REFLECTION heartbeat) — guards against re-introducing a dead-code placement inside `_dispatch_reflection`.
- Full `tests/test_awareness/` package green (126 tests); ruff clean.
