### PR TITLE
fix(eval): single recall_fired + activation-entrenchment metric (WS-5 PR-B, MEM-003/MEM-005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Memory-quality self-evaluation got more honest** — every time Genesis searches its memory it
+  logs an internal "recall" event that feeds the self-graded memory-quality metrics (the
+  precision / MRR figures in its J-9 eval and morning report). It was logging that event *twice*
+  per search, inflating the counts and skewing the math. Each search now logs exactly one event,
+  so the memory-quality numbers Genesis reports on itself are accurate. It also now records a new
+  signal — whether its ranking merely favors the memories it retrieves most often — so
+  entrenchment of stale-but-popular memories can be watched over time (measured, not acted on).
+
 - **Knowledge-base searches stopped silently returning nothing** — the relevance floor that
   trims low-quality knowledge results was a fixed absolute cutoff that, on the score scale recall
   actually produces, sat above the entire range — so searching the knowledge base (or a broad

--- a/src/genesis/db/crud/j9_eval.py
+++ b/src/genesis/db/crud/j9_eval.py
@@ -45,6 +45,33 @@ async def insert_event(
     return eid
 
 
+async def update_event_metrics(
+    db: aiosqlite.Connection, event_id: str, **fields: object,
+) -> bool:
+    """Merge ``fields`` into an existing event's ``metrics_json``.
+
+    Enriches an already-emitted event in place rather than emitting a second
+    event (audit MEM-003: the MCP recall layer adds mode/pipeline_used/post-
+    filter counts to the single event the retriever already emitted). Existing
+    metric keys are overwritten by ``fields``; absent keys are added. Returns
+    ``True`` if a row was updated, ``False`` if no event has that id.
+    """
+    cursor = await db.execute(
+        "SELECT metrics_json FROM eval_events WHERE id = ?", (event_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return False
+    metrics = json.loads(row[0]) if row[0] else {}
+    metrics.update(fields)
+    await db.execute(
+        "UPDATE eval_events SET metrics_json = ? WHERE id = ?",
+        (json.dumps(metrics), event_id),
+    )
+    await db.commit()
+    return True
+
+
 async def get_events(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -139,10 +139,48 @@ def _dedupe_by_pair(events: list[dict]) -> list[dict]:
     return out
 
 
+async def _recall_entrenchment(
+    db: aiosqlite.Connection, since: str, until: str,
+) -> dict:
+    """MEM-005: weekly aggregation of the activation-entrenchment signal.
+
+    Reads ``recall_fired`` events (a separate read path from the relevance-based
+    quality metrics) and averages the per-recall ``entrenchment_corr`` (rank
+    correlation between a result's retrieval frequency and its final score),
+    plus mean retrieval count and mean recalled-memory age. Monitor-only (D7):
+    surfaced in the memory snapshot so a sustained rise can be spotted; it never
+    feeds the quality grade.
+    """
+    fired = await j9_eval.get_events(
+        db, dimension="memory", event_type="recall_fired",
+        since=since, until=until, limit=5000,
+    )
+    corrs = [m["entrenchment_corr"] for ev in fired
+             if (m := ev.get("metrics", {})).get("entrenchment_corr") is not None]
+    ret_counts = [ev.get("metrics", {})["mean_retrieved_count"] for ev in fired
+                  if ev.get("metrics", {}).get("mean_retrieved_count") is not None]
+    ages = [ev.get("metrics", {})["mean_age_days"] for ev in fired
+            if ev.get("metrics", {}).get("mean_age_days") is not None]
+    return {
+        "entrenchment_corr_mean": round(sum(corrs) / len(corrs), 4) if corrs else None,
+        "entrenchment_mean_retrieved_count": (
+            round(sum(ret_counts) / len(ret_counts), 2) if ret_counts else None),
+        "entrenchment_mean_age_days": (
+            round(sum(ages) / len(ages), 1) if ages else None),
+        "entrenchment_sample": len(corrs),
+    }
+
+
 async def _compute_memory_quality(
     db: aiosqlite.Connection, since: str, until: str,
 ) -> tuple[dict, int]:
-    """Precision@5, hit rate, MRR from recall_relevance events."""
+    """Precision@5, hit rate, MRR from recall_relevance events.
+
+    Also folds in the MEM-005 entrenchment aggregation (separate read path over
+    recall_fired) as distinct ``entrenchment_*`` keys — monitor-only, not part
+    of the quality grade.
+    """
+    entrenchment = await _recall_entrenchment(db, since, until)
     relevance_events = await j9_eval.get_events(
         db, dimension="memory", event_type="recall_relevance",
         since=since, until=until, limit=5000,
@@ -153,7 +191,7 @@ async def _compute_memory_quality(
 
     if not relevance_events:
         return {"precision_at_5": None, "hit_rate": None, "mrr": None,
-                "usage_rate": None, "total_recalls": 0}, 0
+                "usage_rate": None, "total_recalls": 0, **entrenchment}, 0
 
     # Group by recall_event_id
     by_recall: dict[str, list[dict]] = defaultdict(list)
@@ -207,6 +245,8 @@ async def _compute_memory_quality(
         # Count only memories that actually fed the metrics (grouped under a
         # recall_event_id) — not orphan events that contribute nothing.
         "total_memories_judged": sum(len(v) for v in by_recall.values()),
+        # MEM-005 entrenchment signal (monitor-only, distinct from the grade).
+        **entrenchment,
     }
     return metrics, total_recalls
 

--- a/src/genesis/eval/j9_hooks.py
+++ b/src/genesis/eval/j9_hooks.py
@@ -51,10 +51,18 @@ async def emit_recall_fired(
     graph_boost_applied: bool = False,
     mean_score: float | None = None,
     wing: str | None = None,
+    entrenchment_corr: float | None = None,
+    mean_retrieved_count: float | None = None,
+    mean_age_days: float | None = None,
 ) -> str | None:
     """Log a memory recall() invocation as an eval event.
 
     Returns the event id so callers can link diagnostics events.
+
+    ``entrenchment_corr`` / ``mean_retrieved_count`` / ``mean_age_days`` carry
+    the MEM-005 activation-entrenchment signal (monitor-only): the rank
+    correlation between a result's retrieval frequency and its final score,
+    plus the mean retrieval count and age of the returned set.
     """
     try:
         metrics: dict = {
@@ -76,6 +84,12 @@ async def emit_recall_fired(
             metrics["mean_score"] = round(mean_score, 4)
         if wing:
             metrics["wing"] = wing
+        if entrenchment_corr is not None:
+            metrics["entrenchment_corr"] = round(entrenchment_corr, 4)
+        if mean_retrieved_count is not None:
+            metrics["mean_retrieved_count"] = mean_retrieved_count
+        if mean_age_days is not None:
+            metrics["mean_age_days"] = mean_age_days
         return await j9_eval.insert_event(
             db,
             dimension="memory",
@@ -86,6 +100,23 @@ async def emit_recall_fired(
     except Exception:
         logger.debug("eval: failed to emit recall_fired", exc_info=True)
         return None
+
+
+async def update_recall_metrics(
+    db: aiosqlite.Connection, event_id: str, **fields: object,
+) -> None:
+    """Merge additional metrics into an already-emitted ``recall_fired`` event.
+
+    MEM-003: the MCP recall layer (memory_recall / knowledge_recall) enriches
+    the single event the retriever already emitted — adding mode, pipeline_used,
+    and post-filter counts — instead of emitting a second recall_fired event
+    that would double-count in the J-9 aggregator and batch judge. Fire-and-
+    forget: errors are logged, never propagated.
+    """
+    try:
+        await j9_eval.update_event_metrics(db, event_id, **fields)
+    except Exception:
+        logger.debug("eval: failed to update recall metrics", exc_info=True)
 
 
 async def emit_proposal_resolved(

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -152,6 +152,11 @@ async def memory_recall(
         except Exception:
             logger.warning("time_range event query failed", exc_info=True)
 
+    # MEM-003: collect the recall_fired event id the retriever emits (standard /
+    # auto_drift paths) so the single event is enriched below instead of a second
+    # one being emitted. Drift mode calls drift_recall (no emit) → stays empty.
+    recall_event_sink: list[str] = []
+
     if mode == "drift":
         # Direct DRIFT invocation — skip standard recall entirely
         from genesis.memory.drift import drift_recall
@@ -177,6 +182,7 @@ async def memory_recall(
             only_subsystem=only_subsystem,
             rerank=rerank,
             include_deprecated=include_deprecated,
+            event_id_sink=recall_event_sink,
         )
         pipeline_used = "standard"
 
@@ -262,21 +268,55 @@ async def memory_recall(
             is_kb=lambda r: is_external(r.collection),
         )
 
-    # MCP-layer instrumentation: emit with mode and pipeline attribution
-    recall_event_id: str | None = None
+    # MCP-layer instrumentation: exactly ONE recall_fired per logical recall
+    # (MEM-003). The standard / auto_drift paths already emitted one inside
+    # recall() (its id is in recall_event_sink) — enrich THAT event in place with
+    # the MCP-layer attribution (mode / pipeline_used) and the final post-filter
+    # results. Drift mode emitted nothing (empty sink) → emit a fresh event here.
+    recall_event_id: str | None = (
+        recall_event_sink[0] if recall_event_sink else None
+    )
     try:
-        from genesis.eval.j9_hooks import emit_recall_fired
-        recall_event_id = await emit_recall_fired(
-            memory_mod._db,
-            query=query,
-            result_count=len(results),
-            top_scores=[r.score for r in results[:5]],
-            memory_ids=[r.memory_id for r in results[:10]],
-            latency_ms=(_time.monotonic() - _t0) * 1000,
-            source=source,
-            mode=mode,
-            pipeline_used=pipeline_used,
+        _top_scores = [r.score for r in results[:5]]
+        _memory_ids = [r.memory_id for r in results[:10]]
+        _all_scores = [r.score for r in results]
+        _mean_score = (
+            round(sum(_all_scores) / len(_all_scores), 4) if _all_scores else None
         )
+        _latency_ms = round((_time.monotonic() - _t0) * 1000, 1)
+        if recall_event_id is not None:
+            from genesis.eval.j9_hooks import update_recall_metrics
+            # Realign the retriever's event with the FINAL returned set — the KB
+            # floor and any auto_drift fallback change result_count / ids / scores
+            # after the inner emit. The MEM-005 entrenchment fields stay as the
+            # retriever computed them (they need per-memory retrieved_count not
+            # available here); on the rare auto_drift path they describe the
+            # sparse standard pool — pipeline_used="auto_drift" flags those events.
+            await update_recall_metrics(
+                memory_mod._db,
+                recall_event_id,
+                mode=mode,
+                pipeline_used=pipeline_used,
+                result_count=len(results),
+                top_scores=_top_scores,
+                memory_ids=_memory_ids,
+                mean_score=_mean_score,
+                latency_ms=_latency_ms,
+            )
+        else:
+            from genesis.eval.j9_hooks import emit_recall_fired
+            recall_event_id = await emit_recall_fired(
+                memory_mod._db,
+                query=query,
+                result_count=len(results),
+                top_scores=_top_scores,
+                memory_ids=_memory_ids,
+                latency_ms=_latency_ms,
+                source=source,
+                mode=mode,
+                pipeline_used=pipeline_used,
+                mean_score=_mean_score,
+            )
     except Exception:
         pass  # instrumentation must never break recall
 

--- a/src/genesis/mcp/memory/knowledge.py
+++ b/src/genesis/mcp/memory/knowledge.py
@@ -81,8 +81,13 @@ async def knowledge_recall(
     assert memory_mod._retriever is not None
     assert memory_mod._db is not None
 
+    # MEM-003: capture the recall_fired event the retriever emits so we enrich
+    # that single event with the final knowledge_recall result set below, rather
+    # than emitting a second recall_fired that double-counts downstream.
+    recall_event_sink: list[str] = []
     vector_results = await memory_mod._retriever.recall(
         query, source="knowledge", limit=limit, project_type=project,
+        event_id_sink=recall_event_sink,
     )
 
     fts_results: list[dict] = []
@@ -137,27 +142,44 @@ async def knowledge_recall(
         is_kb=lambda r: True,
     )[:limit]
 
-    # Selective corrective retrieval (CRAG). Default ON; gated + fail-fast.
-    # path="knowledge" → web fallback is permitted on an Incorrect verdict
-    # (external knowledge is legitimately on the web; episodic memory is not).
-    if corrective:
-        # Emit recall_fired first so the recall_corrected calibration event can
-        # link back to it (subject_id) — matches memory_recall's behavior.
-        recall_event_id: str | None = None
-        try:
+    # MEM-003: exactly ONE recall_fired per knowledge_recall. The retriever
+    # already emitted one (its id is in recall_event_sink) — enrich it with the
+    # final, post-merge/floor result set; emit a fresh one only if the retriever
+    # didn't (e.g. it returned early). Done before CRAG so the recall_corrected
+    # calibration event can link back to recall_event_id (subject_id).
+    recall_event_id: str | None = (
+        recall_event_sink[0] if recall_event_sink else None
+    )
+    try:
+        _top_scores = [r.get("score", 0.0) for r in final[:5]]
+        _memory_ids = [r.get("unit_id", "") for r in final[:10]]
+        if recall_event_id is not None:
+            from genesis.eval.j9_hooks import update_recall_metrics
+            await update_recall_metrics(
+                memory_mod._db,
+                recall_event_id,
+                result_count=len(final),
+                top_scores=_top_scores,
+                memory_ids=_memory_ids,
+            )
+        else:
             from genesis.eval.j9_hooks import emit_recall_fired
             recall_event_id = await emit_recall_fired(
                 memory_mod._db,
                 query=query,
                 result_count=len(final),
-                top_scores=[r.get("score", 0.0) for r in final[:5]],
-                memory_ids=[r.get("unit_id", "") for r in final[:10]],
+                top_scores=_top_scores,
+                memory_ids=_memory_ids,
                 latency_ms=0.0,
                 source="knowledge",
             )
-        except Exception:
-            pass  # instrumentation must never break recall
+    except Exception:
+        pass  # instrumentation must never break recall
 
+    # Selective corrective retrieval (CRAG). Default ON; gated + fail-fast.
+    # path="knowledge" → web fallback is permitted on an Incorrect verdict
+    # (external knowledge is legitimately on the web; episodic memory is not).
+    if corrective:
         from genesis.memory.corrective import maybe_correct_recall
         final = await maybe_correct_recall(
             query=query,

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -130,6 +130,43 @@ def _rrf_fuse(
     return scores
 
 
+def _rank(values: list[float]) -> list[float]:
+    """Average (tie-corrected) ranks of ``values``, 1-based. Ties share the
+    mean of the positions they span."""
+    order = sorted(range(len(values)), key=lambda i: values[i])
+    ranks = [0.0] * len(values)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and values[order[j + 1]] == values[order[i]]:
+            j += 1
+        avg = (i + j) / 2 + 1  # 1-based mean position across the tie group
+        for k in range(i, j + 1):
+            ranks[order[k]] = avg
+        i = j + 1
+    return ranks
+
+
+def _spearman_rank_corr(xs: list[float], ys: list[float]) -> float | None:
+    """Spearman rank correlation in [-1, 1] (Pearson on tie-corrected ranks).
+
+    Hand-rolled — scipy is not a dependency (MEM-005). Returns ``None`` when
+    undefined: fewer than 2 points, mismatched lengths, or zero ranking
+    variance in either input (e.g. all values equal).
+    """
+    n = len(xs)
+    if n < 2 or len(ys) != n:
+        return None
+    rx, ry = _rank(xs), _rank(ys)
+    mx, my = sum(rx) / n, sum(ry) / n
+    cov = sum((a - mx) * (b - my) for a, b in zip(rx, ry, strict=True))
+    vx = sum((a - mx) ** 2 for a in rx)
+    vy = sum((b - my) ** 2 for b in ry)
+    if vx <= 0 or vy <= 0:
+        return None
+    return cov / (vx**0.5 * vy**0.5)
+
+
 def _get_candidate_content(
     mid: str,
     qdrant_by_id: dict[str, dict],
@@ -283,6 +320,7 @@ class HybridRetriever:
         only_subsystem: str | list[str] | None = None,
         rerank: bool = True,
         include_deprecated: bool = False,
+        event_id_sink: list[str] | None = None,
     ) -> list[RetrievalResult]:
         """Hybrid retrieval: Qdrant + FTS5 + activation, fused via RRF.
 
@@ -463,6 +501,10 @@ class HybridRetriever:
         # 5b. Compute activation scores using batched link data
         activation_by_id: dict[str, float] = {}
         inbound_by_id: dict[str, int] = {}  # saved for graph boost in step 7b
+        # MEM-005: capture retrieval frequency + age per id to measure (not act
+        # on) whether the activation loop entrenches frequently-retrieved memories.
+        retrieved_count_by_id: dict[str, int] = {}
+        created_at_by_id: dict[str, str] = {}
         for mid in all_ids:
             total_links, inbound_links = link_counts.get(mid, (0, 0))
             inbound_by_id[mid] = inbound_links
@@ -491,6 +533,8 @@ class HybridRetriever:
                 last_retrieved_at=payload.get("last_retrieved_at") if qdrant_hit else None,
             )
             activation_by_id[mid] = act.final_score
+            retrieved_count_by_id[mid] = retrieved_count
+            created_at_by_id[mid] = created_at
 
         # 6. Build ranked lists for RRF (or FTS5-only if no embedding)
         vector_ranked_dedup: list[str] = []
@@ -795,6 +839,38 @@ class HybridRetriever:
         )
 
         _scores = [r.score for r in results]
+        # MEM-005: entrenchment signal — does retrieval frequency predict final
+        # ranking? A positive corr(retrieved_count, score) means the activation
+        # loop is rewarding mere frequency in the ranking. Monitor-only (D7:
+        # instrument, do NOT re-rank); a sustained strong-positive trend over
+        # time flags entrenchment of stale-but-popular memories. Defensive — it
+        # reads external payload data and must never break recall.
+        _entrenchment = _mean_retrieved = _mean_age_days = None
+        try:
+            _ret_counts = [
+                float(retrieved_count_by_id.get(r.memory_id, 0)) for r in results
+            ]
+            if _ret_counts:
+                _entrenchment = _spearman_rank_corr(_ret_counts, _scores)
+                _mean_retrieved = round(sum(_ret_counts) / len(_ret_counts), 2)
+                _now_dt = datetime.fromisoformat(now_str.replace("Z", "+00:00"))
+                _ages: list[float] = []
+                for r in results:
+                    _ca = created_at_by_id.get(r.memory_id)
+                    if not _ca:
+                        continue
+                    try:
+                        _ages.append(
+                            (_now_dt - datetime.fromisoformat(
+                                _ca.replace("Z", "+00:00"))).total_seconds() / 86400.0
+                        )
+                    except (ValueError, AttributeError):
+                        continue
+                if _ages:
+                    _mean_age_days = round(sum(_ages) / len(_ages), 1)
+        except Exception:
+            logger.debug("MEM-005 entrenchment metric failed", exc_info=True)
+
         recall_event_id = await emit_recall_fired(
             self._db,
             query=query,
@@ -807,7 +883,17 @@ class HybridRetriever:
             graph_boost_applied=graph_boost_applied,
             mean_score=sum(_scores) / len(_scores) if _scores else None,
             wing=wing,
+            entrenchment_corr=_entrenchment,
+            mean_retrieved_count=_mean_retrieved,
+            mean_age_days=_mean_age_days,
         )
+
+        # MEM-003: hand the emitted event id back to an MCP caller so it can
+        # enrich THIS event (mode / pipeline_used / post-filter counts) instead
+        # of emitting a second recall_fired that double-counts in the J-9
+        # aggregator and batch judge.
+        if event_id_sink is not None and recall_event_id is not None:
+            event_id_sink.append(recall_event_id)
 
         # Recall diagnostics: capture intermediate pipeline metrics
         _overlap = len(set(qdrant_by_id) & set(fts_by_id))

--- a/tests/test_eval/test_j9_eval.py
+++ b/tests/test_eval/test_j9_eval.py
@@ -42,6 +42,75 @@ async def test_insert_and_get_event(db):
     assert events[0]["session_id"] == "sess-1"
 
 
+async def test_update_event_metrics_merges_in_place(db):
+    """update_event_metrics enriches an existing event's metrics without
+    creating a second row (audit MEM-003: one recall_fired per logical recall)."""
+    eid = await j9_eval.insert_event(
+        db, dimension="memory", event_type="recall_fired",
+        metrics={"query": "q", "result_count": 1},
+    )
+    updated = await j9_eval.update_event_metrics(
+        db, eid, result_count=5, mode="auto", pipeline_used="standard",
+    )
+    assert updated is True
+
+    events = await j9_eval.get_events(db, event_type="recall_fired")
+    assert len(events) == 1  # merged in place, NOT a second event
+    m = events[0]["metrics"]
+    assert m["query"] == "q"          # pre-existing field preserved
+    assert m["result_count"] == 5      # overwritten
+    assert m["mode"] == "auto"         # new field added
+    assert m["pipeline_used"] == "standard"
+
+
+async def test_update_event_metrics_missing_id_is_noop(db):
+    """Updating a non-existent event returns False and inserts nothing."""
+    updated = await j9_eval.update_event_metrics(db, "does-not-exist", foo=1)
+    assert updated is False
+    events = await j9_eval.get_events(db, dimension="memory")
+    assert len(events) == 0
+
+
+async def test_recall_entrenchment_aggregates(db):
+    """MEM-005: the aggregator averages the per-recall entrenchment signal from
+    recall_fired events, ignoring events that carry no entrenchment fields."""
+    from genesis.eval.j9_aggregator import _recall_entrenchment
+
+    for corr, rc, age in [(0.8, 5.0, 10.0), (0.6, 3.0, 20.0)]:
+        await j9_eval.insert_event(
+            db, dimension="memory", event_type="recall_fired",
+            metrics={"entrenchment_corr": corr,
+                     "mean_retrieved_count": rc, "mean_age_days": age},
+        )
+    # An older-style event without entrenchment fields must not skew the means.
+    await j9_eval.insert_event(
+        db, dimension="memory", event_type="recall_fired", metrics={"query": "q"},
+    )
+
+    result = await _recall_entrenchment(db, since="2000-01-01", until="2099-01-01")
+    assert result["entrenchment_corr_mean"] == pytest.approx(0.7)
+    assert result["entrenchment_mean_retrieved_count"] == pytest.approx(4.0)
+    assert result["entrenchment_mean_age_days"] == pytest.approx(15.0)
+    assert result["entrenchment_sample"] == 2
+
+
+async def test_memory_quality_includes_entrenchment_when_no_relevance(db):
+    """Entrenchment surfaces even when there are no recall_relevance events
+    (the early-return path still carries the MEM-005 keys)."""
+    from genesis.eval.j9_aggregator import _compute_memory_quality
+
+    await j9_eval.insert_event(
+        db, dimension="memory", event_type="recall_fired",
+        metrics={"entrenchment_corr": 0.5, "mean_retrieved_count": 2.0},
+    )
+    metrics, sample = await _compute_memory_quality(
+        db, since="2000-01-01", until="2099-01-01",
+    )
+    assert metrics["precision_at_5"] is None      # no relevance events
+    assert metrics["entrenchment_corr_mean"] == pytest.approx(0.5)
+    assert metrics["entrenchment_sample"] == 1
+
+
 async def test_get_events_filter_by_type(db):
     await j9_eval.insert_event(db, dimension="memory", event_type="recall_fired", metrics={})
     await j9_eval.insert_event(db, dimension="memory", event_type="recall_relevance", metrics={})

--- a/tests/test_eval/test_recall_instrumentation.py
+++ b/tests/test_eval/test_recall_instrumentation.py
@@ -50,6 +50,36 @@ async def test_emit_recall_fired_returns_none_on_error():
     assert result is None
 
 
+# ── update_recall_metrics (MEM-003: enrich the single event in place) ───────
+
+
+async def test_update_recall_metrics_merges(db):
+    from genesis.eval.j9_hooks import update_recall_metrics
+
+    eid = await emit_recall_fired(
+        db, query="q", result_count=1, top_scores=[], memory_ids=[],
+        latency_ms=1.0, source="both",
+    )
+    await update_recall_metrics(
+        db, eid, mode="auto", pipeline_used="standard", result_count=5,
+    )
+    events = await j9_eval.get_events(db, event_type="recall_fired")
+    assert len(events) == 1  # enriched in place, not duplicated
+    assert events[0]["metrics"]["mode"] == "auto"
+    assert events[0]["metrics"]["pipeline_used"] == "standard"
+    assert events[0]["metrics"]["result_count"] == 5
+
+
+async def test_update_recall_metrics_fire_and_forget():
+    """Should never propagate errors."""
+    from genesis.eval.j9_hooks import update_recall_metrics
+
+    bad_db = AsyncMock()
+    bad_db.execute = AsyncMock(side_effect=RuntimeError("db gone"))
+    # Should not raise
+    await update_recall_metrics(bad_db, "evt-x", mode="auto")
+
+
 # ── emit_recall_diagnostics ─────────────────────────────────────────────────
 
 

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -1303,3 +1303,94 @@ async def test_memory_recall_explicit_both_still_works():
         assert call_kwargs.get("source") == "both"
     finally:
         mod._store, mod._db, mod._retriever, mod._qdrant = old
+
+
+# ── MEM-003: exactly one recall_fired per logical recall ────────────────────
+
+
+def _ri_result(mid: str):
+    from genesis.memory.types import RetrievalResult
+
+    return RetrievalResult(
+        memory_id=mid, content=f"c-{mid}", source="test", memory_type="episodic",
+        score=0.5, vector_rank=1, fts_rank=1, activation_score=0.3, payload={},
+        source_pipeline="hybrid", collection="episodic_memory",
+    )
+
+
+async def test_memory_recall_standard_emits_exactly_one_recall_fired(db):
+    """MEM-003: the standard path emits ONE recall_fired (the retriever's),
+    enriched in place by the MCP layer with mode/pipeline_used — not a 2nd."""
+    import genesis.mcp.memory_mcp as mod
+    from genesis.db.crud import j9_eval
+    from genesis.eval.j9_hooks import emit_recall_fired
+
+    results = [_ri_result("a"), _ri_result("b"), _ri_result("c")]
+
+    async def fake_recall(*_a, event_id_sink=None, **_k):
+        # Mirror the real retriever: emit the inner event + populate the sink.
+        eid = await emit_recall_fired(
+            db, query="q", result_count=len(results),
+            top_scores=[r.score for r in results],
+            memory_ids=[r.memory_id for r in results],
+            latency_ms=1.0, source="both",
+        )
+        if event_id_sink is not None and eid is not None:
+            event_id_sink.append(eid)
+        return list(results)
+
+    mock_retriever = AsyncMock()
+    mock_retriever.recall = fake_recall
+    mock_retriever._embeddings = MagicMock()
+
+    old = (mod._store, mod._db, mod._retriever, mod._qdrant)
+    try:
+        mod._store = MagicMock()
+        mod._db = db
+        mod._retriever = mock_retriever
+        mod._qdrant = MagicMock()
+        tools = await _get_tools()
+        await tools["memory_recall"].fn(
+            query="q", source="both", limit=10, compact=True,
+        )
+        events = await j9_eval.get_events(db, event_type="recall_fired")
+        assert len(events) == 1  # ONE event, enriched in place
+        m = events[0]["metrics"]
+        assert m["pipeline_used"] == "standard"  # MCP-layer attribution merged
+        assert m["mode"] == "auto"
+        assert m["result_count"] == 3
+        # Realigned to the final returned set (the inner emit sent no mean_score).
+        assert m["mean_score"] == pytest.approx(0.5)
+        assert "latency_ms" in m
+    finally:
+        mod._store, mod._db, mod._retriever, mod._qdrant = old
+
+
+async def test_memory_recall_drift_mode_emits_exactly_one_recall_fired(db):
+    """MEM-003: drift mode calls drift_recall (no inner emit) → the MCP layer
+    emits exactly one fresh recall_fired (empty sink → INSERT)."""
+    import genesis.mcp.memory_mcp as mod
+    from genesis.db.crud import j9_eval
+
+    drift_results = [_ri_result("x"), _ri_result("y")]
+
+    mock_retriever = AsyncMock()
+    mock_retriever._embeddings = MagicMock()
+
+    old = (mod._store, mod._db, mod._retriever, mod._qdrant)
+    try:
+        mod._store = MagicMock()
+        mod._db = db
+        mod._retriever = mock_retriever
+        mod._qdrant = MagicMock()
+        with patch.object(_drift_patch(), "drift_recall",
+                          new_callable=AsyncMock, return_value=drift_results):
+            tools = await _get_tools()
+            await tools["memory_recall"].fn(
+                query="q", source="both", mode="drift", limit=10, compact=True,
+            )
+        events = await j9_eval.get_events(db, event_type="recall_fired")
+        assert len(events) == 1  # exactly one, freshly inserted
+        assert events[0]["metrics"]["pipeline_used"] == "drift"
+    finally:
+        mod._store, mod._db, mod._retriever, mod._qdrant = old

--- a/tests/test_memory/test_mcp_integration.py
+++ b/tests/test_memory/test_mcp_integration.py
@@ -102,6 +102,9 @@ async def test_memory_recall_delegates(mock_deps, tools):
         expand_query_terms=True,
         include_subsystem=False, only_subsystem=None,
         rerank=True, include_deprecated=False,
+        # MEM-003: the MCP layer passes an event-id sink so it can enrich the
+        # retriever's single recall_fired event instead of emitting a 2nd.
+        event_id_sink=[],
     )
 
 

--- a/tests/test_memory/test_retrieval.py
+++ b/tests/test_memory/test_retrieval.py
@@ -739,3 +739,46 @@ async def test_recall_graph_boost_adjacency(mock_qdrant, mock_crud, mock_links, 
     a_result = next(r for r in results if r.memory_id == "a")
     # c's boosted score should exceed a's (despite lower vector score)
     assert c_result.score > a_result.score
+
+
+# --- MEM-005: entrenchment signal (hand-rolled Spearman) ---
+
+
+class TestSpearmanRankCorr:
+    """_spearman_rank_corr powers the activation-entrenchment metric (MEM-005):
+    does retrieval frequency predict final ranking? scipy is not a dependency,
+    so it is hand-rolled."""
+
+    def test_perfect_positive(self):
+        from genesis.memory.retrieval import _spearman_rank_corr
+
+        assert _spearman_rank_corr([1, 2, 3, 4], [10, 20, 30, 40]) == pytest.approx(1.0)
+
+    def test_perfect_negative(self):
+        from genesis.memory.retrieval import _spearman_rank_corr
+
+        assert _spearman_rank_corr([1, 2, 3, 4], [40, 30, 20, 10]) == pytest.approx(-1.0)
+
+    def test_none_when_too_short(self):
+        from genesis.memory.retrieval import _spearman_rank_corr
+
+        assert _spearman_rank_corr([1], [1]) is None
+        assert _spearman_rank_corr([], []) is None
+
+    def test_none_on_zero_variance(self):
+        from genesis.memory.retrieval import _spearman_rank_corr
+
+        # Constant xs → no ranking variance → undefined correlation.
+        assert _spearman_rank_corr([5, 5, 5], [1, 2, 3]) is None
+
+    def test_handles_ties_monotonic(self):
+        from genesis.memory.retrieval import _spearman_rank_corr
+
+        v = _spearman_rank_corr([1, 2, 2, 3], [10, 20, 20, 30])
+        assert v == pytest.approx(1.0)
+
+    def test_in_range(self):
+        from genesis.memory.retrieval import _spearman_rank_corr
+
+        v = _spearman_rank_corr([1, 5, 2, 8, 3], [2, 1, 4, 3, 9])
+        assert -1.0 <= v <= 1.0


### PR DESCRIPTION
**WS-5 PR-B of 3** (audit 2026-06-13, P4) — the final WS-5 PR. Siblings merged: PR-C/DLI-04 (#719), PR-A/MEM-001+004 (#721). **Hold for merge** — the MCP-layer changes take effect next CC session; no server restart needed for the recall path (the floor/eval live in the MCP memory server).

## MEM-003 — exactly one `recall_fired` per logical recall
`HybridRetriever.recall()` emits a `recall_fired` event, and the MCP tools `memory_recall` / `knowledge_recall` emitted a **second** one — double-counting in the J-9 aggregator (`_compute_memory_quality`) and batch judge (`j9_batch`), inflating recall counts and skewing the self-graded precision/MRR.

Fix: `recall()` appends its emitted event id to a new optional `event_id_sink`. The MCP layer enriches **that single event in place** — new `j9_eval.update_event_metrics` (read `metrics_json` → merge → UPDATE) + `j9_hooks.update_recall_metrics` wrapper — adding `mode`/`pipeline_used` and the **final** post-floor/post-drift result set; it emits a fresh event only when the retriever didn't (drift mode). Per path:
- standard / auto_drift → retriever emitted (sink populated) → UPDATE → **1 event**
- `mode="drift"` → `drift_recall` (no inner emit, empty sink) → INSERT → **1 event**
- `knowledge_recall` → same, and the emit was moved out of the `if corrective:` block so exactly one fires regardless of `corrective`

`recall_event_id` stays set for the downstream CRAG `maybe_correct_recall(recall_event_id=…)` link. `event_id_sink` is additive (default `None`) → the other ~17 `recall()` callers are unaffected. The UPDATE also realigns `latency_ms`/`mean_score` to the final set (per code review) — the one field it can't recompute at the MCP layer is the MEM-005 entrenchment signal, which on the rare auto_drift path describes the sparse standard pool (flagged by `pipeline_used="auto_drift"`, documented inline).

## MEM-005 — activation-entrenchment metric (monitor-only; audit D7: instrument, do NOT re-rank)
Hand-rolled `_spearman_rank_corr` / `_rank` in `retrieval.py` (scipy isn't a dependency; tie-corrected, returns `None` on n<2 / zero-variance). The activation loop captures `retrieved_count` + `created_at` per id; the single `recall_fired` now carries `entrenchment_corr` (rank correlation between a result's retrieval frequency and its final score), `mean_retrieved_count`, and `mean_age_days` — all behind a `try/except` that can never break recall. `j9_aggregator._recall_entrenchment` averages them weekly as distinct `entrenchment_*` keys (separate read path, **not** folded into the quality grade). A sustained rise flags entrenchment of stale-but-popular memories.

## Tests
- `update_event_metrics` (merge / missing-id no-op); `update_recall_metrics` (merge / fire-and-forget).
- `_spearman_rank_corr` (perfect ±1, ties, zero-variance→None, range); `_recall_entrenchment` + `_compute_memory_quality` aggregation (incl. the no-relevance early-return path).
- Integration: `memory_recall` standard → exactly ONE event (enriched, realigned `mean_score`); drift mode → exactly ONE (fresh).
- Full `tests/test_eval/` + `tests/test_memory/` + `tests/test_mcp/` sweep: **1137 passed**. ruff clean.

## E2E (live)
A real `retriever.recall("kubernetes deployment…", source="both")` against live Qdrant emitted **exactly one** new `recall_fired` carrying real entrenchment fields: `entrenchment_corr=0.117` (weak — not entrenched), `mean_retrieved_count=4.3`, `mean_age_days=17.3`.

## Review
`feature-dev:code-reviewer`: **NO-BLOCK** (Codex quota-exhausted). Its one finding — stale `latency_ms`/`mean_score` on the auto_drift UPDATE — is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)