### PR TITLE
fix(reflection): age-fair reflection-quality metric (no false decline from pool aging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Genesis stops false-alarming about its own reflection quality declining** — its weekly
+  self-assessment scored "reflection quality" from how often its recent reflections had been
+  retrieved, but counted a running total over the 50 newest reflections. Because brand-new
+  reflections haven't had time to be referenced yet, that score drifted downward purely as new
+  reflections were created — a measurement artifact that looked like an alarming "quality crater"
+  and fed scary (but baseless) warnings into the morning report. The score is now measured over a
+  fair, fixed age window (reflections that are 3-10 days old), counts a reflection as influential
+  only if it was actually retrieved first, and honestly reports "insufficient data" when there are
+  too few mature reflections to judge — rather than inventing a decline.
+
 - **Memory-quality self-evaluation got more honest** — every time Genesis searches its memory it
   logs an internal "recall" event that feeds the self-graded memory-quality metrics (the
   precision / MRR figures in its J-9 eval and morning report). It was logging that event *twice*

--- a/src/genesis/identity/SELF_ASSESSMENT.md
+++ b/src/genesis/identity/SELF_ASSESSMENT.md
@@ -8,10 +8,17 @@ Do NOT confabulate metrics.
 ## Dimensions
 
 ### 1. Reflection Quality
-How useful are Genesis's reflections? Measured by:
-- How often observations are retrieved (retrieved_count > 0)
-- How often observations influence actions (influenced_action > 0)
-- Ratio of high-priority vs low-priority observations
+How useful are Genesis's recent reflections? Measured over a fixed *maturity
+cohort* — deep-reflection observations created 3-10 days ago (old enough to
+have had a fair chance to be retrieved, recent enough to reflect current
+quality):
+- Retrieval rate: how many of the cohort were retrieved (`retrieved_count` of
+  `cohort_size`)
+- Influence rate: how many were retrieved AND went on to influence an action
+- If `reflection_quality.data_available` is false (the cohort is too small —
+  this is common, because deep-reflection volume is low), set this dimension's
+  `data_available` to false and do NOT assign a score. Never infer a quality
+  decline from a small or empty cohort.
 
 ### 2. Procedure Effectiveness
 How well do learned procedures work? Measured by:

--- a/src/genesis/reflection/context_gatherer.py
+++ b/src/genesis/reflection/context_gatherer.py
@@ -23,6 +23,14 @@ logger = logging.getLogger(__name__)
 _MIN_OBSERVATIONS_FOR_CONSOLIDATION = 10
 _COGNITIVE_STATE_STALE_HOURS = 24
 
+# Reflection-quality metric: an age-fair maturity cohort. Observations created
+# in this window are old enough to have had a fair chance to be retrieved, yet
+# recent enough to reflect current quality. Below _MIN_REFLECTION_COHORT rows
+# the dimension abstains (data_available=False) instead of scoring on noise.
+_REFLECTION_MATURITY_MIN_DAYS = 3
+_REFLECTION_MATURITY_MAX_DAYS = 10
+_MIN_REFLECTION_COHORT = 5
+
 
 class ContextGatherer:
     """Assembles comprehensive context for deep reflection from multiple DB sources."""
@@ -110,13 +118,40 @@ class ContextGatherer:
         week_ago = (now - timedelta(days=7)).isoformat()
         two_weeks_ago = (now - timedelta(days=14)).isoformat()
 
-        # Dimension 1: Reflection quality
-        # Note: NOT incrementing retrieved_count here — this query is for
-        # analysis/metrics, not for feeding content into an LLM prompt.
-        # Incrementing would inflate the quality metric this code measures.
-        recent_obs = await observations.query(db, source="cc_reflection_deep", limit=50)
-        obs_with_retrievals = [o for o in recent_obs if o.get("retrieved_count", 0) > 0]
-        obs_with_influence = [o for o in recent_obs if o.get("influenced_action", 0) > 0]
+        # Dimension 1: Reflection quality — age-fair maturity cohort.
+        # Count retrieval/influence on deep-reflection observations created
+        # 3-10 days ago. The previous metric counted a cumulative
+        # retrieved_count over the 50 MOST-RECENT observations, so the rate
+        # mechanically fell as new (not-yet-retrieved) observations entered the
+        # window — a measurement artifact, not a real quality change. Filtering
+        # to a fixed maturity window makes the reading age-fair.
+        # NOT incrementing retrieved_count here (metric read, not prompt input).
+        mature_lo = (now - timedelta(days=_REFLECTION_MATURITY_MAX_DAYS)).isoformat()
+        mature_hi = (now - timedelta(days=_REFLECTION_MATURITY_MIN_DAYS)).isoformat()
+        deep_obs = await observations.query(db, source="cc_reflection_deep", limit=200)
+        cohort = [
+            o for o in deep_obs
+            if mature_lo <= o.get("created_at", "") < mature_hi
+        ]
+        if not cohort and len(deep_obs) >= 200:
+            # The 200-row fetch was saturated by rows newer than the window, so
+            # the maturity cohort is empty for capacity reasons, not quality.
+            # Far off at current volume, but log it so a future saturation is
+            # diagnosable rather than a silent permanent abstention.
+            logger.debug(
+                "reflection_quality maturity cohort empty — 200-row "
+                "cc_reflection_deep fetch saturated by newer rows",
+            )
+        # Influence counted ONLY among retrieved observations: an observation
+        # can be flagged influenced via a memory-op target without ever being
+        # retrieved into context (nothing enforces influence ⊆ retrieved),
+        # which otherwise yields impossible influenced > retrieved ratios that
+        # drag the score down.
+        cohort_retrieved = [o for o in cohort if o.get("retrieved_count", 0) > 0]
+        cohort_influenced = [
+            o for o in cohort
+            if o.get("influenced_action", 0) > 0 and o.get("retrieved_count", 0) > 0
+        ]
 
         # Dimension 2: Procedure effectiveness
         proc_stats = await self._procedure_stats(db)
@@ -147,9 +182,15 @@ class ContextGatherer:
 
         return {
             "reflection_quality": {
-                "total_observations": len(recent_obs),
-                "retrieved_count": len(obs_with_retrievals),
-                "influenced_count": len(obs_with_influence),
+                "maturity_window_days": f"{_REFLECTION_MATURITY_MIN_DAYS}-{_REFLECTION_MATURITY_MAX_DAYS}",
+                "cohort_size": len(cohort),
+                "retrieved_count": len(cohort_retrieved),
+                "influenced_count": len(cohort_influenced),
+                # Honest abstention: deep-reflection volume is low (~one
+                # cohort's worth per week), so the cohort is frequently too
+                # small to score. The assessor must mark data_available=false
+                # rather than infer a decline from noise.
+                "data_available": len(cohort) >= _MIN_REFLECTION_COHORT,
             },
             "procedure_effectiveness": {
                 "total_active": proc_stats.total_active,

--- a/tests/test_reflection/test_context_gatherer.py
+++ b/tests/test_reflection/test_context_gatherer.py
@@ -160,6 +160,61 @@ class TestGatherForAssessment:
         assert "blind_spots" in data
 
 
+class TestReflectionQualityCohort:
+    """Dimension 1 uses an age-fair 3-10 day maturity cohort (not a LIMIT-50
+    recency window), counts influence only among retrieved observations, and
+    abstains when the cohort is too small to score."""
+
+    async def _insert_deep_obs(self, db, *, days_ago, retrieved=0, influenced=0):
+        created = (datetime.now(UTC) - timedelta(days=days_ago)).isoformat()
+        await db.execute(
+            "INSERT INTO observations "
+            "(id, source, type, content, priority, created_at, "
+            "retrieved_count, influenced_action) "
+            "VALUES (?, 'cc_reflection_deep', 'reflection', 'c', 'medium', ?, ?, ?)",
+            (str(uuid.uuid4()), created, retrieved, influenced),
+        )
+
+    @pytest.mark.asyncio
+    async def test_cohort_excludes_too_new_and_too_old(self, db, gatherer):
+        for _ in range(6):
+            await self._insert_deep_obs(db, days_ago=5, retrieved=1)
+        await self._insert_deep_obs(db, days_ago=1, retrieved=1)   # too new (<3d)
+        await self._insert_deep_obs(db, days_ago=20, retrieved=1)  # too old (>10d)
+        await db.commit()
+
+        rq = (await gatherer.gather_for_assessment(db))["reflection_quality"]
+        assert rq["cohort_size"] == 6
+        assert rq["retrieved_count"] == 6
+        assert rq["data_available"] is True
+        assert rq["maturity_window_days"] == "3-10"
+
+    @pytest.mark.asyncio
+    async def test_abstains_below_min_cohort(self, db, gatherer):
+        for _ in range(4):  # below the 5-row floor
+            await self._insert_deep_obs(db, days_ago=5, retrieved=1)
+        await db.commit()
+
+        rq = (await gatherer.gather_for_assessment(db))["reflection_quality"]
+        assert rq["cohort_size"] == 4
+        assert rq["data_available"] is False
+
+    @pytest.mark.asyncio
+    async def test_influence_counted_only_among_retrieved(self, db, gatherer):
+        await self._insert_deep_obs(db, days_ago=5, retrieved=1, influenced=1)  # counts
+        await self._insert_deep_obs(db, days_ago=5, retrieved=1, influenced=1)  # counts
+        await self._insert_deep_obs(db, days_ago=5, retrieved=0, influenced=1)  # influenced but NOT retrieved → excluded
+        await self._insert_deep_obs(db, days_ago=5, retrieved=1, influenced=0)  # retrieved only
+        await self._insert_deep_obs(db, days_ago=5, retrieved=0, influenced=0)  # neither
+        await db.commit()
+
+        rq = (await gatherer.gather_for_assessment(db))["reflection_quality"]
+        assert rq["cohort_size"] == 5
+        assert rq["retrieved_count"] == 3
+        assert rq["influenced_count"] == 2  # only the 2 retrieved-AND-influenced
+        assert rq["data_available"] is True
+
+
 class TestGatherForCalibration:
     @pytest.mark.asyncio
     async def test_returns_expected_keys(self, db, gatherer):


### PR DESCRIPTION
## What

Stop the weekly self-assessment from inventing a reflection-quality decline that the morning report then alarms on.

### The bug
`reflection_quality` was scored from how many of the **50 most-recent** `cc_reflection_deep` observations had `retrieved_count > 0`. `retrieved_count` is a cumulative lifetime counter and the pool is recency-windowed, so the rate mechanically fell as new (not-yet-retrieved) reflections entered the window — a **measurement artifact**, not real degradation. It produced a false "0.70 → 0.35 quality crater" that fed baseless warnings into the morning report. (Verified: the reflection pipeline is healthy; the newest reflections are the *most*-retrieved cohort. Full-corpus rate ≠ the windowed rate; retrieval rate is monotonic in observation age.)

### The fix
- **Age-fair maturity cohort:** count over `cc_reflection_deep` observations created **3–10 days ago** — old enough to have had a fair chance to be retrieved, recent enough to reflect current quality. Removes the age-composition artifact.
- **Influence ⊆ retrieved:** count a reflection as influential only if it was also retrieved. An observation can be flagged influenced via a memory-op target without being retrieved (nothing enforced the invariant), which produced impossible `influenced > retrieved` ratios that dragged the score down.
- **Honest abstention:** report `data_available: false` when the cohort is below 5 rows. Deep-reflection volume is low (~one cohort's worth/week), so the dimension honestly abstains rather than scoring on noise. `SELF_ASSESSMENT.md` dimension 1 is updated to match and to forbid inferring a decline from a small/empty cohort.

The whole gather dict is `json.dumps`-ed into the assessment prompt, so the new `data_available`/`cohort_size` fields surface to the assessor directly.

## Tests
- New `TestReflectionQualityCohort`: locks the 3–10d window (1d and 20d excluded), the `<5` abstention, the influence-among-retrieved rule (4-combination matrix), and the dict contract.
- Full `tests/test_reflection/` + `test_cc/test_reflection_bridge.py` green (207); ruff clean.

## Notes
- No consumer reads the dropped `total_observations` input key (`OutputRouter` parses the LLM's *output*; `check_regression` reads a different dimension). Confirmed in review.
- Stale-alarm lifecycle (superseding prior `quality_drift`/`learning_regression`, softening the regression alarm, morning-report staleness grounding) follows in a separate PR.
