### PR TITLE
test(outreach): make governance quiet-hours deterministic (fix wall-clock flake)

### DIFF
--- a/tests/test_outreach/conftest.py
+++ b/tests/test_outreach/conftest.py
@@ -1,0 +1,24 @@
+"""Shared fixtures for outreach tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_quiet_hours(monkeypatch):
+    """Pin the governance quiet-hours check OFF so outreach tests are
+    deterministic.
+
+    ``GovernanceGate._in_quiet_hours`` reads the real wall clock
+    (``datetime.now(user_timezone())``), so any test that exercises the ALLOW
+    path flakes when CI happens to run inside a configured quiet window. The
+    previous workaround — a 1-minute ``23:58-23:59`` "disable" window — only
+    moved the landmine (it tripped whenever CI ran in that minute). Patching the
+    check itself removes the wall-clock dependency entirely. Tests that assert
+    quiet-hours behaviour re-patch ``_in_quiet_hours`` to ``True`` explicitly.
+    """
+    monkeypatch.setattr(
+        "genesis.outreach.governance.GovernanceGate._in_quiet_hours",
+        lambda self: False,
+    )

--- a/tests/test_outreach/test_governance.py
+++ b/tests/test_outreach/test_governance.py
@@ -33,15 +33,12 @@ def config():
     )
 
 
-# Quiet window that cannot interfere with test execution regardless of
-# timezone.  The 1-minute window at 23:58-23:59 avoids the 02:00-02:30
-# collision that broke CI (GitHub Actions runs at ~02:18 UTC).
-_NO_QUIET_HOURS = QuietHours(start="23:58", end="23:59")
-
-
 def _cfg_no_quiet(**overrides):
+    # Quiet hours are pinned off for outreach tests by the autouse
+    # _disable_quiet_hours fixture (conftest.py), so the governance quiet-hours
+    # check can't flake on wall-clock time. The window value here is irrelevant.
     defaults = dict(
-        quiet_hours=_NO_QUIET_HOURS,
+        quiet_hours=QuietHours(start="22:00", end="07:00"),
         channel_preferences={"default": "telegram"},
         thresholds={"blocker": 0.0, "alert": 0.3, "surplus": 0.7, "digest": 0.0},
         max_daily=5,
@@ -122,6 +119,28 @@ async def test_surplus_above_threshold_allowed(db):
     )
     result = await gate.check(req)
     assert result.verdict == GovernanceVerdict.ALLOW
+
+
+@pytest.mark.asyncio
+async def test_quiet_hours_denies_non_bypass(db, monkeypatch):
+    """Quiet hours deny a non-bypass category. Verified deterministically by
+    forcing the quiet-hours check on — it reads the wall clock in production,
+    so the test must not depend on the actual time it runs."""
+    monkeypatch.setattr(
+        "genesis.outreach.governance.GovernanceGate._in_quiet_hours",
+        lambda self: True,
+    )
+    gate = GovernanceGate(_cfg_no_quiet(), db)
+    req = OutreachRequest(
+        category=OutreachCategory.SURPLUS,
+        topic="Valuable insight",
+        context="Important finding",
+        salience_score=0.9,
+        signal_type="surplus_insight",
+    )
+    result = await gate.check(req)
+    assert result.verdict == GovernanceVerdict.DENY
+    assert any("quiet" in c for c in result.checks_failed)
 
 
 @pytest.mark.asyncio

--- a/tests/test_outreach/test_pipeline.py
+++ b/tests/test_outreach/test_pipeline.py
@@ -20,7 +20,9 @@ from genesis.outreach.types import (
 @pytest.fixture
 def config():
     return OutreachConfig(
-        quiet_hours=QuietHours(start="23:58", end="23:59"),
+        # Quiet hours are pinned off by the autouse _disable_quiet_hours
+        # fixture (conftest.py) so this can't flake on wall-clock time.
+        quiet_hours=QuietHours(start="22:00", end="07:00"),
         channel_preferences={"default": "telegram"},
         thresholds={"blocker": 0.0, "alert": 0.3, "surplus": 0.7, "digest": 0.0},
         max_daily=5,


### PR DESCRIPTION
## What

Fix a pre-existing wall-clock flake in the outreach governance/pipeline tests that fails CI whenever the `test` job happens to run inside a configured quiet window.

### Root cause
The governance/pipeline tests build a `GovernanceGate` and assert the ALLOW path, but `GovernanceGate._in_quiet_hours()` reads the real wall clock (`datetime.now(user_timezone())`). When CI runs those tests during a quiet window, governance returns `DENY` → the ALLOW/DELIVERED assertions fail. The prior workaround — a 1-minute "disable" window at `23:58–23:59` — only **moved** the landmine; it trips when CI runs in that exact minute (it just did, on an unrelated PR whose `test` job crossed 23:58 UTC). The comment in the test even records a *previous* incarnation of this at ~02:18 UTC.

### Fix (test-only — production behaviour unchanged)
- Add an autouse fixture (`tests/test_outreach/conftest.py`) that patches `_in_quiet_hours` → `False` for all outreach tests, removing the wall-clock dependency entirely. `_in_quiet_hours` is the only `datetime.now`-based check in the verdict path (dedup/rate-limit/quota use SQL `datetime('now')`), so the patch is fully surgical.
- Drop the misleading `23:58–23:59` window hack in both `test_governance.py` and `test_pipeline.py`.
- Add `test_quiet_hours_denies_non_bypass`, which forces the check on and asserts `DENY` — deterministic coverage of the quiet-hours path that was previously only incidental (and flaky).

## Tests
- Full `tests/test_outreach/` green (120); ruff clean. Now time-independent by construction.
