### PR TITLE
fix(reflection): supersede + soften stale quality/regression alarms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Stale "quality drift" and "learning regression" alarms no longer linger or cry wolf** — when
+  Genesis's weekly self-checks flagged a quality drift or a learning regression, that flag stayed
+  active until it expired days later, so the morning report kept repeating a days-old warning as if
+  it were current. Now each weekly check supersedes the previous flag and clears it outright once the
+  underlying metric recovers, the regression alarm only fires on a meaningful sustained drop (not a
+  small wobble in a noisy self-score), and any observation older than three days is shown in the
+  report demoted and tagged as historical rather than as a fresh alarm.
+
 - **Genesis stops false-alarming about its own reflection quality declining** — its weekly
   self-assessment scored "reflection quality" from how often its recent reflections had been
   retrieved, but counted a running total over the 50 newest reflections. Because brand-new

--- a/src/genesis/identity/MORNING_REPORT.md
+++ b/src/genesis/identity/MORNING_REPORT.md
@@ -76,6 +76,17 @@ note it at most as "earlier <condition>, now recovered", or omit it. Do NOT
 repeat the stale alarm as if it were current. When in doubt, trust the live
 System Health numbers over an older observation's text.
 
+**Observation age tiers.** Every observation in "What I Noticed" is tagged with
+its age; treat age as a strong prior on relevance:
+- Under 24h: current — surface normally.
+- 1-3 days old: surface only if still actionable; lead with the age.
+- Over 3 days old (shown demoted and tagged "[aged]"): a historical signal, not
+  a current condition. Do NOT present it as a fresh alarm — mention it at most
+  as "earlier <condition>", or omit it if a newer signal supersedes it.
+This applies to ALL observation types, including cognitive-quality and learning
+signals: a days-old "quality drift" or "learning regression" note is not, by
+itself, evidence of a current problem.
+
 ## What to Include
 
 **Primary focus (this is what the report is FOR):**

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -48,6 +48,14 @@ def _age_seconds(iso_ts: str) -> float:
         return 0
 
 
+# Observations older than this in "What I Noticed" are historical signals, not
+# current conditions: their DISPLAYED severity is demoted one level and tagged
+# so a days-old write (e.g. a stale quality_drift) doesn't read as a fresh
+# critical alarm. Stored priority is never changed.
+_STALE_OBS_SECONDS = 3 * 86400
+_STALE_PRIORITY_DEMOTION = {"critical": "high", "high": "medium", "medium": "medium"}
+
+
 class MorningReportGenerator:
     """Synthesizes system state into a daily morning report."""
 
@@ -564,10 +572,19 @@ class MorningReportGenerator:
         lines = []
         for obs in observations:
             prio = obs["priority"]
+            # Stale grounding: a >3d-old observation is a historical signal, not
+            # a current condition — demote its displayed severity one level and
+            # tag it so it doesn't surface as a fresh alarm (stored priority
+            # unchanged).
+            if _age_seconds(obs.get("created_at", "")) > _STALE_OBS_SECONDS:
+                prio = _STALE_PRIORITY_DEMOTION.get(prio, prio)
+                aged = " [aged]"
+            else:
+                aged = ""
             badge = {"critical": "🔴", "high": "🟠", "medium": "🟡"}.get(prio, "")
             content = obs["content"][:200].replace("\n", " ")
             age = _relative_age(obs.get("created_at", ""))
-            lines.append(f"- {badge} **{prio}** ({age}): {content}")
+            lines.append(f"- {badge} **{prio}**{aged} ({age}): {content}")
 
         # Defer surfacing until delivery is confirmed via confirm_delivery().
         # If delivery fails, these observations re-appear in the next report.

--- a/src/genesis/reflection/output_router.py
+++ b/src/genesis/reflection/output_router.py
@@ -585,6 +585,20 @@ class OutputRouter:
 
         obs_type = "quality_drift" if output.drift_detected else "quality_calibration"
 
+        # Supersede any prior unresolved quality_drift BEFORE writing this
+        # cycle's result (never after — resolve_by_source_and_type resolves ALL
+        # unresolved matches, so resolving after would bury the row we just
+        # wrote). Resolving regardless of the new type means a clean (non-drift)
+        # calibration also clears a standing drift alarm (resolve-on-recovery),
+        # and a fresh drift replaces the previous one instead of stacking.
+        await observations.resolve_by_source_and_type(
+            db,
+            source="quality_calibration",
+            type="quality_drift",
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_notes="superseded by newer quality calibration",
+        )
+
         content = json.dumps({
             "drift_detected": output.drift_detected,
             "quarantine_candidates": output.quarantine_candidates,

--- a/src/genesis/reflection/scheduler.py
+++ b/src/genesis/reflection/scheduler.py
@@ -182,6 +182,10 @@ class ReflectionScheduler:
                 if regression:
                     await self._stability.emit_regression_signal(self._db)
                     logger.warning("Learning regression detected after calibration")
+                else:
+                    # Resolve-on-recovery: clear any standing regression alarm
+                    # once effectiveness recovers, so it doesn't persist stale.
+                    await self._stability.resolve_regression_if_standing(self._db)
 
             if result.success:
                 await self._record_job_result("weekly_calibration")

--- a/src/genesis/reflection/stability.py
+++ b/src/genesis/reflection/stability.py
@@ -22,6 +22,14 @@ logger = logging.getLogger(__name__)
 _MIN_USES_FOR_QUARANTINE = 3
 _MAX_SUCCESS_RATE_FOR_QUARANTINE = 0.40
 
+# Learning-regression alarm gating. A regression fires only when the
+# procedure-effectiveness score declines for N consecutive assessments AND the
+# total drop is meaningful AND the latest score is below a healthy floor. This
+# keeps noisy LLM-assigned scores from latching a persistent CRITICAL alarm on
+# small dips or a high-but-slightly-declining trajectory.
+_MIN_REGRESSION_DROP = 0.10
+_MAX_HEALTHY_SCORE = 0.60
+
 # Negation patterns for simple contradiction detection
 _NEGATION_PAIRS = [
     ("always", "never"),
@@ -132,14 +140,32 @@ class LearningStabilityMonitor:
         if len(scores) < weeks + 1:
             return False
 
-        # Check consecutive decline (scores are ordered newest first)
-        return all(scores[i] < scores[i + 1] for i in range(weeks))
+        # Consecutive decline (scores ordered newest-first: scores[0] = newest).
+        if not all(scores[i] < scores[i + 1] for i in range(weeks)):
+            return False
+        # Gate on magnitude AND absolute level: a couple of small dips in noisy
+        # LLM-assigned scores, or a high-but-dipping trajectory (e.g.
+        # 0.85 -> 0.80 -> 0.75), must not latch a persistent regression alarm.
+        total_drop = scores[weeks] - scores[0]  # oldest minus newest; >0 = declined
+        return total_drop >= _MIN_REGRESSION_DROP and scores[0] < _MAX_HEALTHY_SCORE
 
     async def emit_regression_signal(
         self, db: aiosqlite.Connection,
     ) -> None:
         """Emit a learning regression event and update cognitive state."""
         now = datetime.now(UTC).isoformat()
+
+        # Supersede any prior unresolved learning_regression so only the latest
+        # standing signal remains and its timestamp reflects this detection —
+        # stale regression notes otherwise persist in ego / morning-report
+        # context until their TTL.
+        await observations.resolve_by_source_and_type(
+            db,
+            source="stability_monitor",
+            type="learning_regression",
+            resolved_at=now,
+            resolution_notes="superseded by newer regression detection",
+        )
 
         # Write observation instead of overwriting state_flags.
         # State flags are now computed from real data; regressions surface
@@ -166,6 +192,29 @@ class LearningStabilityMonitor:
             )
 
         logger.warning("Learning regression signal emitted")
+
+    async def resolve_regression_if_standing(
+        self, db: aiosqlite.Connection,
+    ) -> None:
+        """Resolve a standing learning_regression once effectiveness recovers.
+
+        Called from the calibration path when ``check_regression`` returns
+        False, so a regression alarm clears on recovery instead of lingering in
+        ego / morning-report context until its TTL.
+        """
+        now = datetime.now(UTC).isoformat()
+        resolved = await observations.resolve_by_source_and_type(
+            db,
+            source="stability_monitor",
+            type="learning_regression",
+            resolved_at=now,
+            resolution_notes="procedure effectiveness recovered (no regression this cycle)",
+        )
+        if resolved:
+            logger.info(
+                "Resolved %d standing learning_regression observation(s) on recovery",
+                resolved,
+            )
 
     def find_contradictions(
         self, obs_list: list[dict],

--- a/tests/test_outreach/test_morning_report.py
+++ b/tests/test_outreach/test_morning_report.py
@@ -122,6 +122,39 @@ async def test_format_health_cost_line_grounded(db, mock_health, mock_drafter):
 
 
 @pytest.mark.asyncio
+async def test_observation_insights_demotes_aged(db, mock_health, mock_drafter):
+    """A >3d-old observation is shown demoted and tagged [aged] so a stale write
+    doesn't surface as a fresh critical alarm; a recent one is left as-is."""
+    from datetime import UTC, datetime, timedelta
+
+    fresh = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+    old = (datetime.now(UTC) - timedelta(days=6)).isoformat()
+    await db.execute(
+        "INSERT INTO observations (id, source, type, content, priority, created_at) "
+        "VALUES ('fresh', 'test', 'quality_drift', 'fresh critical thing', 'critical', ?)",
+        (fresh,),
+    )
+    await db.execute(
+        "INSERT INTO observations (id, source, type, content, priority, created_at) "
+        "VALUES ('old', 'test', 'quality_drift', 'old critical thing', 'critical', ?)",
+        (old,),
+    )
+    await db.commit()
+
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    out = await gen._get_observation_insights()
+    assert out is not None
+    aged_line = next(line for line in out.splitlines() if "old critical thing" in line)
+    fresh_line = next(line for line in out.splitlines() if "fresh critical thing" in line)
+    # 6-day-old critical: demoted to high and tagged.
+    assert "[aged]" in aged_line
+    assert "**high**" in aged_line
+    # 2-hour-old critical: unchanged.
+    assert "[aged]" not in fresh_line
+    assert "**critical**" in fresh_line
+
+
+@pytest.mark.asyncio
 async def test_format_health_cost_line_without_budget(db, mock_health, mock_drafter):
     """When no budget cap is configured, fall back to a bare MTD spend line."""
     gen = MorningReportGenerator(mock_health, db, mock_drafter)

--- a/tests/test_reflection/test_output_router.py
+++ b/tests/test_reflection/test_output_router.py
@@ -273,6 +273,37 @@ class TestRouteCalibration:
         assert len(rows) == 1
         assert dict(rows[0])["priority"] == "medium"
 
+    @pytest.mark.asyncio
+    async def test_clean_cycle_clears_standing_drift(self, db, router):
+        """A clean (non-drift) calibration resolves a prior standing
+        quality_drift — resolve-on-recovery, so it stops surfacing."""
+        await router.route_calibration(
+            QualityCalibrationOutput(drift_detected=True, observations=["drift 1"]), db,
+        )
+        await router.route_calibration(
+            QualityCalibrationOutput(drift_detected=False), db,
+        )
+        unresolved = (await (await db.execute(
+            "SELECT count(*) FROM observations "
+            "WHERE type='quality_drift' AND resolved=0"
+        )).fetchone())[0]
+        assert unresolved == 0
+
+    @pytest.mark.asyncio
+    async def test_fresh_drift_supersedes_prior(self, db, router):
+        """Two consecutive drift cycles leave only the latest drift unresolved."""
+        await router.route_calibration(
+            QualityCalibrationOutput(drift_detected=True, observations=["drift 1"]), db,
+        )
+        await router.route_calibration(
+            QualityCalibrationOutput(drift_detected=True, observations=["drift 2"]), db,
+        )
+        unresolved = (await (await db.execute(
+            "SELECT count(*) FROM observations "
+            "WHERE type='quality_drift' AND resolved=0"
+        )).fetchone())[0]
+        assert unresolved == 1
+
 
 # ── Reflection summary embedding tests ────────────────────────────────
 

--- a/tests/test_reflection/test_stability.py
+++ b/tests/test_reflection/test_stability.py
@@ -186,6 +186,38 @@ class TestCheckRegression:
         result = await monitor.check_regression(db)
         assert not result
 
+    @pytest.mark.asyncio
+    async def test_small_dip_not_regression(self, db, monitor):
+        """Consecutive decline but total drop < 0.10 → noise, not a regression."""
+        for i, score in enumerate([0.55, 0.60, 0.63]):  # newest first; drop 0.08
+            await db.execute(
+                "INSERT INTO observations (id, source, type, content, priority, created_at) "
+                "VALUES (?, 'weekly_assessment', 'self_assessment', ?, 'medium', ?)",
+                (
+                    f"a{i}",
+                    json.dumps({"dimensions": [{"dimension": "procedure_effectiveness", "score": score}]}),
+                    f"2026-03-{10-i:02d}T00:00:00",
+                ),
+            )
+        await db.commit()
+        assert not await monitor.check_regression(db)
+
+    @pytest.mark.asyncio
+    async def test_high_baseline_decline_not_regression(self, db, monitor):
+        """Meaningful drop but the latest score is still healthy (>= 0.60) → not flagged."""
+        for i, score in enumerate([0.70, 0.80, 0.85]):  # newest first; drop 0.15, newest 0.70
+            await db.execute(
+                "INSERT INTO observations (id, source, type, content, priority, created_at) "
+                "VALUES (?, 'weekly_assessment', 'self_assessment', ?, 'medium', ?)",
+                (
+                    f"a{i}",
+                    json.dumps({"dimensions": [{"dimension": "procedure_effectiveness", "score": score}]}),
+                    f"2026-03-{10-i:02d}T00:00:00",
+                ),
+            )
+        await db.commit()
+        assert not await monitor.check_regression(db)
+
 
 class TestEmitRegressionSignal:
     @pytest.mark.asyncio
@@ -206,6 +238,40 @@ class TestEmitRegressionSignal:
         monitor = LearningStabilityMonitor(event_bus=bus)
         await monitor.emit_regression_signal(db)
         bus.emit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_supersedes_prior_unresolved(self, db, monitor):
+        """Emitting again resolves the prior signal so only one stands unresolved."""
+        await monitor.emit_regression_signal(db)
+        await monitor.emit_regression_signal(db)
+
+        unresolved = (await (await db.execute(
+            "SELECT count(*) FROM observations "
+            "WHERE type='learning_regression' AND resolved=0"
+        )).fetchone())[0]
+        total = (await (await db.execute(
+            "SELECT count(*) FROM observations WHERE type='learning_regression'"
+        )).fetchone())[0]
+        assert unresolved == 1
+        assert total == 2  # prior superseded (resolved) + current
+
+
+class TestResolveRegressionIfStanding:
+    @pytest.mark.asyncio
+    async def test_resolves_standing(self, db, monitor):
+        """A standing regression is cleared on recovery."""
+        await monitor.emit_regression_signal(db)
+        await monitor.resolve_regression_if_standing(db)
+        unresolved = (await (await db.execute(
+            "SELECT count(*) FROM observations "
+            "WHERE type='learning_regression' AND resolved=0"
+        )).fetchone())[0]
+        assert unresolved == 0
+
+    @pytest.mark.asyncio
+    async def test_noop_when_none(self, db, monitor):
+        """No standing regression → no error, nothing to resolve."""
+        await monitor.resolve_regression_if_standing(db)  # must not raise
 
 
 class TestFindContradictions:


### PR DESCRIPTION
## What

Final PR of the morning-report false-alarm batch: stop stale `quality_drift` / `learning_regression` alarms from persisting and from surfacing as fresh. (PR-1 fixed the reflection "dark" heartbeat; PR-2 fixed the age-diluted quality metric; this closes the loop on the *alarm lifecycle*.)

These observations were written weekly but never resolved, so the morning report kept repeating a days-old flag as current, and the regression alarm fired on any 2 consecutive declines in a noisy LLM-assigned self-score.

### Changes
- **Supersession (resolve-before-write).** `route_calibration` resolves any prior unresolved `quality_drift` before writing this cycle's result; `emit_regression_signal` does the same for `learning_regression`. Ordering matters: `resolve_by_source_and_type` resolves *all* unresolved matches, so resolving after the write would bury the new row. Resolving regardless of the new result also clears a standing alarm when the metric recovers.
- **Resolve-on-recovery.** New `LearningStabilityMonitor.resolve_regression_if_standing`, called from the calibration scheduler in the `else` of the regression check — clears a standing regression once effectiveness recovers, instead of letting it linger until its TTL.
- **Softened `check_regression`.** Still requires consecutive decline, but now also a meaningful total drop (≥ 0.10) **and** a latest score below a healthy floor (< 0.60), so small wobbles and high-but-dipping trajectories don't latch a persistent CRITICAL.
- **Morning-report staleness grounding.** Observations older than 3 days are shown with their displayed severity demoted one level and tagged `[aged]` (stored priority unchanged); `MORNING_REPORT.md` gains observation age-tier guidance so the LLM treats aged signals as historical.

## Tests
- `test_stability.py`: small-dip / high-baseline → no regression; supersession; resolve-on-recovery (+ no-op).
- `test_output_router.py`: clean cycle clears a standing drift; fresh drift supersedes prior.
- `test_morning_report.py`: a 6-day-old critical is demoted to high and tagged `[aged]`; a 2-hour-old one is untouched.
- 307 tests green across `tests/test_reflection/` + `tests/test_outreach/`; ruff clean.
