### PR TITLE
feat(experimentation): Phase 7 — cognitive experimentation harness (offline A/B, recommend-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   cost, attributes). It reads the traces Genesis already captures, so you can inspect an
   operation end to end instead of piecing it together from logs.
 
+- **Genesis can A/B-test its own thinking before changing it** — a new experimentation
+  harness runs two versions of a cognitive config (for example a reflection prompt, or an
+  awareness signal weight) against a graded golden set, measures which does better with a
+  real significance test, and surfaces a recommendation you act on — it never promotes a
+  change on its own. It guards against gaming its own grader (the rubric must be calibrated,
+  and a "win" has to survive a second, independent judge). Results show up in the new
+  `experiment_status` health tool, and a weekly "cognitive drift" snapshot now tracks whether
+  Genesis is still challenging itself (dissent rate, proposal diversity).
+
 - **Genesis spots goals it's stuck on and asks before easing off them** — when a goal you
   set has been worked on (several dispatched sessions) but still isn't moving, Genesis now
   recognizes it as *stuck* rather than merely idle, bumps it up for review, and digs into

--- a/src/genesis/awareness/scorer.py
+++ b/src/genesis/awareness/scorer.py
@@ -107,6 +107,7 @@ async def compute_scores(
     *,
     now: str | None = None,
     weights_override: dict[str, float] | None = None,
+    decay_factors: dict[str, float] | None = None,
 ) -> list[DepthScore]:
     """Compute urgency scores for all four depths.
 
@@ -114,23 +115,30 @@ async def compute_scores(
     weights for this computation only — used by the experimentation harness to
     measure how a weight change shifts depth decisions WITHOUT mutating the live
     ``signal_weights`` table. Default None = live weights (identical behaviour).
+
+    ``decay_factors`` ({signal_name: factor}) supplies pre-computed staleness
+    decay and BYPASSES ``_update_staleness`` — which mutates module-level
+    consecutive-unchanged counters. The experimentation replay passes this (an
+    empty dict = no decay) so replaying historical ticks never corrupts the live
+    awareness loop's staleness state. Default None = live staleness (mutating).
     """
     if now is None:
         now = datetime.now(UTC).isoformat()
 
     signal_map = {s.name: s.value for s in signals}
 
-    # Fetch previous tick's signals for staleness comparison
-    prev_tick = await awareness_ticks.last_tick(db)
-    prev_signals: dict[str, float] = {}
-    if prev_tick and prev_tick.get("signals_json"):
-        try:
-            for entry in json.loads(prev_tick["signals_json"]):
-                prev_signals[entry["name"]] = entry["value"]
-        except (json.JSONDecodeError, KeyError, TypeError):
-            logger.debug("Could not parse previous tick signals for staleness")
-
-    decay_factors = _update_staleness(signal_map, prev_signals)
+    if decay_factors is None:
+        # Fetch previous tick's signals for staleness comparison (live path —
+        # mutates module-level unchanged counts via _update_staleness).
+        prev_tick = await awareness_ticks.last_tick(db)
+        prev_signals: dict[str, float] = {}
+        if prev_tick and prev_tick.get("signals_json"):
+            try:
+                for entry in json.loads(prev_tick["signals_json"]):
+                    prev_signals[entry["name"]] = entry["value"]
+            except (json.JSONDecodeError, KeyError, TypeError):
+                logger.debug("Could not parse previous tick signals for staleness")
+        decay_factors = _update_staleness(signal_map, prev_signals)
 
     thresholds = {r["depth_name"]: r for r in await depth_thresholds.list_all(db)}
     results = []

--- a/src/genesis/awareness/scorer.py
+++ b/src/genesis/awareness/scorer.py
@@ -106,8 +106,15 @@ async def compute_scores(
     signals: list[SignalReading],
     *,
     now: str | None = None,
+    weights_override: dict[str, float] | None = None,
 ) -> list[DepthScore]:
-    """Compute urgency scores for all four depths."""
+    """Compute urgency scores for all four depths.
+
+    ``weights_override`` ({signal_name: weight}) substitutes specific signal
+    weights for this computation only — used by the experimentation harness to
+    measure how a weight change shifts depth decisions WITHOUT mutating the live
+    ``signal_weights`` table. Default None = live weights (identical behaviour).
+    """
     if now is None:
         now = datetime.now(UTC).isoformat()
 
@@ -135,7 +142,12 @@ async def compute_scores(
         for w in weights_rows:
             val = signal_map.get(w["signal_name"], 0.0)
             factor = decay_factors.get(w["signal_name"], 1.0)
-            raw_score += val * w["current_weight"] * factor
+            weight = (
+                weights_override.get(w["signal_name"], w["current_weight"])
+                if weights_override
+                else w["current_weight"]
+            )
+            raw_score += val * weight * factor
 
         # Elapsed time since last tick at this depth
         last_tick = await awareness_ticks.last_at_depth(db, depth.value)

--- a/src/genesis/eval/db.py
+++ b/src/genesis/eval/db.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import aiosqlite
 
-from genesis.eval.types import EvalRunSummary, ScorerType
+from genesis.eval.types import EvalRunSummary, EvalTrigger, ScorerType
 
 
 async def insert_run(
@@ -84,6 +84,34 @@ async def insert_run(
 
     await db.commit()
     return run_id
+
+
+async def set_comparison_run(
+    db: aiosqlite.Connection,
+    run_id: str,
+    comparison_run_id: str,
+) -> None:
+    """Link one eval run to another (A/B pairing: treatment -> its control)."""
+    await db.execute(
+        "UPDATE eval_runs SET comparison_run_id = ? WHERE id = ?",
+        (comparison_run_id, run_id),
+    )
+    await db.commit()
+
+
+async def get_experiment_runs(
+    db: aiosqlite.Connection,
+    *,
+    limit: int = 20,
+) -> list[dict]:
+    """Fetch recent experiment-arm runs (trigger='experiment'), newest first."""
+    cursor = await db.execute(
+        "SELECT * FROM eval_runs WHERE trigger = ? ORDER BY created_at DESC LIMIT ?",
+        (EvalTrigger.EXPERIMENT.value, limit),
+    )
+    cols = [d[0] for d in cursor.description]
+    rows = await cursor.fetchall()
+    return [dict(zip(cols, row, strict=False)) for row in rows]
 
 
 async def get_runs(

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -1,4 +1,4 @@
-"""J-9 weekly eval aggregator — computes snapshots for all 5 dimensions.
+"""J-9 weekly eval aggregator — computes snapshots for all dimensions.
 
 Runs on a weekly CronTrigger. Reads eval_events and existing DB tables
 to compute metrics for each dimension, stores results in eval_snapshots.
@@ -9,6 +9,7 @@ Dimensions:
 3. Ego proposal quality (approval rate, confidence calibration)
 4. Cognitive loop value (recall vs no-recall session comparison)
 5. Procedural learning effectiveness (invocation rate, success rate)
+6. Cognitive drift (Phase 7, dark): dissent-rate + proposal-diversity
 """
 
 from __future__ import annotations
@@ -49,7 +50,7 @@ async def _compute_cognitive_drift(
     cursor = await db.execute(
         """SELECT action_type, alternatives, realist_verdict
            FROM ego_proposals
-           WHERE created_at >= ? AND created_at <= ?""",
+           WHERE created_at >= ? AND created_at < ?""",
         (period_start, period_end),
     )
     rows = [dict(r) for r in await cursor.fetchall()]

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -27,8 +27,66 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+async def _compute_cognitive_drift(
+    db: aiosqlite.Connection, period_start: str, period_end: str,
+) -> tuple[dict, int]:
+    """Dark drift metrics over ego_proposals (Phase 7 anti-overfitting baseline).
+
+    - dissent_rate: realist critic engagement = (amend + reject) / proposals with
+      a verdict. A FALLING rate is an overfitting alarm (the ego stops being
+      challenged / only proposes pre-vetted-safe work).
+    - alternative_rate: fraction of proposals that recorded a non-empty alternative.
+    - diversity_entropy: normalized Shannon entropy over action_type (mirrors the
+      j9 ``type_diversity`` convention). Falling = proposals collapsing/formulaic.
+
+    DARK: no cognitive path reads this; it establishes the baseline the future
+    personality-drift gates need. Self-silencing + exploration-floor are deferred
+    (statistically underpowered until more T1 negatives accrue).
+    """
+    import math
+    from collections import Counter
+
+    cursor = await db.execute(
+        """SELECT action_type, alternatives, realist_verdict
+           FROM ego_proposals
+           WHERE created_at >= ? AND created_at <= ?""",
+        (period_start, period_end),
+    )
+    rows = [dict(r) for r in await cursor.fetchall()]
+    total = len(rows)
+    if total == 0:
+        return {
+            "dissent_rate": None, "alternative_rate": None,
+            "diversity_entropy": None, "n_proposals": 0,
+        }, 0
+
+    verdicts = [r["realist_verdict"] for r in rows if r["realist_verdict"]]
+    dissent = sum(1 for v in verdicts if v in ("amend", "reject"))
+    dissent_rate = (dissent / len(verdicts)) if verdicts else None
+
+    alt = sum(1 for r in rows if (r["alternatives"] or "").strip())
+
+    counts = Counter(r["action_type"] for r in rows)
+    k = len(counts)
+    if k <= 1:
+        entropy = 0.0
+    else:
+        h = -sum((c / total) * math.log(c / total) for c in counts.values())
+        entropy = h / math.log(k)  # normalize to [0, 1]
+
+    metrics = {
+        "dissent_rate": round(dissent_rate, 4) if dissent_rate is not None else None,
+        "alternative_rate": round(alt / total, 4),
+        "diversity_entropy": round(entropy, 4),
+        "distinct_action_types": k,
+        "n_proposals": total,
+        "n_with_verdict": len(verdicts),
+    }
+    return metrics, total
+
+
 async def run_weekly_aggregation(db: aiosqlite.Connection) -> dict[str, dict]:
-    """Compute and store weekly snapshots for all 5 eval dimensions.
+    """Compute and store weekly snapshots for all 5 eval dimensions + drift.
 
     Returns dict of {dimension: metrics} for logging/inspection.
     """
@@ -44,6 +102,7 @@ async def run_weekly_aggregation(db: aiosqlite.Connection) -> dict[str, dict]:
         ("ego", _compute_ego_quality),
         ("cognitive", _compute_cognitive_loop),
         ("procedure", _compute_procedural_effectiveness),
+        ("cognitive_drift", _compute_cognitive_drift),
     ]:
         try:
             metrics, sample_count = await fn(db, period_start, period_end)

--- a/src/genesis/eval/stats.py
+++ b/src/genesis/eval/stats.py
@@ -1,0 +1,181 @@
+"""Paired-comparison statistics for cognitive A/B experiments.
+
+Pure-stdlib (no scipy/numpy) significance testing for the experimentation
+harness. The control and treatment arms run on the *same* golden cases with
+binary (pass/fail) outcomes, so the right test is McNemar's on the discordant
+pairs. For the small N of a golden set (tens of cases) we use the *exact*
+binomial form, not the chi-squared approximation.
+
+This lives in ``eval/`` (general eval infrastructure, beside ``calibration.py``)
+rather than ``experimentation/`` so any paired-eval caller can use it.
+"""
+
+from __future__ import annotations
+
+import math
+
+# Below this many discordant pairs the test has no power — report it honestly
+# rather than emitting a misleading "no_difference".
+_MIN_DISCORDANT = 5
+_ALPHA = 0.05
+
+
+def compute_winrate(
+    control_results: list[bool],
+    treatment_results: list[bool],
+) -> dict:
+    """Paired win-rate statistics for an A/B over the same golden cases.
+
+    Parameters
+    ----------
+    control_results, treatment_results:
+        Per-case pass (True) / fail (False) for each arm, in the SAME case
+        order. Must be equal length.
+
+    Returns
+    -------
+    dict with:
+        n_cases, control_pass_rate, treatment_pass_rate, treatment_delta,
+        n_concordant_pass, n_concordant_fail,
+        n_control_wins, n_treatment_wins, n_discordant,
+        p_value (McNemar exact two-sided; None if no discordant pairs),
+        significant (bool), effect_size,
+        recommendation: "treatment_wins" | "control_wins" | "no_difference"
+                        | "insufficient_data"
+    """
+    if len(control_results) != len(treatment_results):
+        msg = (
+            f"control ({len(control_results)}) and treatment "
+            f"({len(treatment_results)}) must be the same length"
+        )
+        raise ValueError(msg)
+    n = len(control_results)
+    if n == 0:
+        raise ValueError("no cases to compare")
+
+    pairs = list(zip(control_results, treatment_results, strict=True))
+    both_pass = sum(1 for c, t in pairs if c and t)
+    both_fail = sum(1 for c, t in pairs if not c and not t)
+    control_wins = sum(1 for c, t in pairs if c and not t)  # control pass, treatment fail
+    treatment_wins = sum(1 for c, t in pairs if not c and t)  # control fail, treatment pass
+    n_discordant = control_wins + treatment_wins
+
+    control_pass_rate = sum(1 for c, _ in pairs if c) / n
+    treatment_pass_rate = sum(1 for _, t in pairs if t) / n
+
+    p_value: float | None = None
+    if n_discordant > 0:
+        p_value = _mcnemar_exact_two_sided(n_discordant, min(control_wins, treatment_wins))
+
+    significant = p_value is not None and p_value < _ALPHA
+    # Asymmetry of the discordant pairs: 0.0 = even split, 1.0 = all one way.
+    effect_size = abs(treatment_wins - control_wins) / n_discordant if n_discordant else 0.0
+
+    if n_discordant < _MIN_DISCORDANT:
+        recommendation = "insufficient_data"
+    elif not significant:
+        recommendation = "no_difference"
+    elif treatment_wins > control_wins:
+        recommendation = "treatment_wins"
+    else:
+        recommendation = "control_wins"
+
+    return {
+        "n_cases": n,
+        "control_pass_rate": round(control_pass_rate, 4),
+        "treatment_pass_rate": round(treatment_pass_rate, 4),
+        "treatment_delta": round(treatment_pass_rate - control_pass_rate, 4),
+        "n_concordant_pass": both_pass,
+        "n_concordant_fail": both_fail,
+        "n_control_wins": control_wins,
+        "n_treatment_wins": treatment_wins,
+        "n_discordant": n_discordant,
+        "p_value": round(p_value, 4) if p_value is not None else None,
+        "significant": significant,
+        "effect_size": round(effect_size, 4),
+        "recommendation": recommendation,
+    }
+
+
+def compute_score_winrate(
+    control_scores: list[float],
+    treatment_scores: list[float],
+    *,
+    epsilon: float = 0.0,
+) -> dict:
+    """Paired win-rate over CONTINUOUS per-case judge scores.
+
+    More sensitive than `compute_winrate` for graded outputs: a case is a
+    "win" for whichever arm scored higher (by more than ``epsilon``), a tie
+    otherwise. This captures quality differences that a fixed pass/fail
+    threshold collapses (e.g. control 0.15 vs treatment 0.05 — both "fail" a
+    0.6 gate, yet control is clearly better). McNemar exact on the wins.
+
+    Returns the same shape as `compute_winrate`, with mean-score fields in
+    place of pass-rate fields and an ``n_ties`` count.
+    """
+    if len(control_scores) != len(treatment_scores):
+        msg = (
+            f"control ({len(control_scores)}) and treatment "
+            f"({len(treatment_scores)}) must be the same length"
+        )
+        raise ValueError(msg)
+    n = len(control_scores)
+    if n == 0:
+        raise ValueError("no cases to compare")
+
+    pairs = list(zip(control_scores, treatment_scores, strict=True))
+    control_wins = sum(1 for c, t in pairs if c - t > epsilon)
+    treatment_wins = sum(1 for c, t in pairs if t - c > epsilon)
+    ties = n - control_wins - treatment_wins
+    n_discordant = control_wins + treatment_wins
+
+    control_mean = sum(control_scores) / n
+    treatment_mean = sum(treatment_scores) / n
+
+    p_value: float | None = None
+    if n_discordant > 0:
+        p_value = _mcnemar_exact_two_sided(n_discordant, min(control_wins, treatment_wins))
+
+    significant = p_value is not None and p_value < _ALPHA
+    effect_size = abs(treatment_wins - control_wins) / n_discordant if n_discordant else 0.0
+
+    if n_discordant < _MIN_DISCORDANT:
+        recommendation = "insufficient_data"
+    elif not significant:
+        recommendation = "no_difference"
+    elif treatment_wins > control_wins:
+        recommendation = "treatment_wins"
+    else:
+        recommendation = "control_wins"
+
+    return {
+        "n_cases": n,
+        "control_mean_score": round(control_mean, 4),
+        "treatment_mean_score": round(treatment_mean, 4),
+        "mean_delta": round(treatment_mean - control_mean, 4),
+        "n_control_wins": control_wins,
+        "n_treatment_wins": treatment_wins,
+        "n_ties": ties,
+        "n_discordant": n_discordant,
+        "p_value": round(p_value, 4) if p_value is not None else None,
+        "significant": significant,
+        "effect_size": round(effect_size, 4),
+        "recommendation": recommendation,
+    }
+
+
+def _mcnemar_exact_two_sided(n_discordant: int, k_smaller: int) -> float:
+    """Exact two-sided McNemar p-value.
+
+    Under H0 each of ``n_discordant`` discordant pairs independently favours
+    either arm with probability 0.5, so the count favouring one arm is
+    Binomial(n_discordant, 0.5). The exact two-sided p-value is twice the
+    lower tail up to the smaller discordant count (the distribution is
+    symmetric), capped at 1.0.
+
+    ``k_smaller = min(control_wins, treatment_wins)``.
+    """
+    n = n_discordant
+    lower_tail = sum(math.comb(n, i) for i in range(k_smaller + 1)) / (2**n)
+    return min(1.0, 2.0 * lower_tail)

--- a/src/genesis/eval/types.py
+++ b/src/genesis/eval/types.py
@@ -20,6 +20,7 @@ class EvalTrigger(StrEnum):
     MANUAL = "manual"
     SURPLUS = "surplus"
     SCHEDULE = "schedule"
+    EXPERIMENT = "experiment"  # cognitive A/B experiment arm (Phase 7)
 
 
 class TaskCategory(StrEnum):

--- a/src/genesis/experimentation/__init__.py
+++ b/src/genesis/experimentation/__init__.py
@@ -1,0 +1,9 @@
+"""Cognitive experimentation harness (Phase 7).
+
+Offline A/B testing of Genesis's own cognitive *configs* (prompts, weights)
+against golden sets, with real significance, judge-hack guards, and a
+promotion *recommendation* the user acts on. Recommend-only: nothing here
+promotes a variant autonomously, and nothing writes to live cognition.
+
+See `~/.claude/plans/vectorized-dazzling-catmull.md` (PHASE 7 BUILD PLAN).
+"""

--- a/src/genesis/experimentation/guards.py
+++ b/src/genesis/experimentation/guards.py
@@ -1,0 +1,100 @@
+"""Judge-hack guards for the cognitive experimentation harness (Phase 7).
+
+A reflection A/B is scored by a live LLM judge, so the result is only as
+trustworthy as the judge. Three guards defend the eval layer against gaming
+(reward-hacking the judge rather than producing genuinely better reflections):
+
+1. **rubric-version pinning** — both arms scored by the same ``Rubric.version``,
+   recorded in the result so a silent rubric edit can't masquerade as a win.
+2. **calibration-required** — the rubric must clear the ≥0.80 human-agreement
+   ship-gate (``eval/calibration.py``) before its A/B verdicts are trusted.
+3. **held-out second judge** — re-run the A/B with a *different* judge provider;
+   a directional "win" that doesn't survive the held-out judge is flagged
+   ``judge_overfit`` (the win was the judge's bias, not real quality).
+
+All recommend-only: guards inform the human, they never auto-promote or block.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from genesis.eval.calibration import DEFAULT_AGREEMENT_THRESHOLD
+from genesis.experimentation.standalone_router import DEFAULT_JUDGE_PROVIDER
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_DIRECTIONAL_WINS = frozenset({"treatment_wins", "control_wins"})
+
+
+def pin_rubric_version(rubric_name: str) -> str:
+    """Return the rubric's semantic version (stored with the A/B for audit)."""
+    from genesis.eval.rubrics import get_rubric
+
+    return get_rubric(rubric_name).version
+
+
+def held_out_verdict(primary_recommendation: str, heldout_recommendation: str) -> dict:
+    """Does the primary judge's directional win survive a held-out judge?
+
+    A non-directional primary recommendation (no_difference / insufficient_data)
+    has no win to validate -> survives. A directional win survives only if the
+    held-out judge reaches the SAME recommendation; otherwise it's flagged
+    ``judge_overfit``.
+    """
+    if primary_recommendation not in _DIRECTIONAL_WINS:
+        return {"survives": True, "flag": None, "reason": "no directional win to validate"}
+    survives = heldout_recommendation == primary_recommendation
+    return {
+        "survives": survives,
+        "flag": None if survives else "judge_overfit",
+        "reason": (
+            "held-out judge agrees"
+            if survives
+            else f"primary={primary_recommendation}, held-out={heldout_recommendation}"
+        ),
+    }
+
+
+async def check_rubric_calibrated(
+    rubric_name: str,
+    golden_set_path: Path,
+    *,
+    judge_provider: str = DEFAULT_JUDGE_PROVIDER,
+    threshold: float = DEFAULT_AGREEMENT_THRESHOLD,
+    router: object | None = None,
+) -> dict:
+    """Run the rubric against its golden set; report whether it clears the gate.
+
+    The operator runs this once per (rubric, judge) before trusting A/B verdicts.
+    Reuses ``eval/calibration.py:run_calibration`` (judge.passed vs user_passed
+    agreement). ``router`` is injectable for tests; otherwise a standalone
+    litellm router for ``judge_provider`` is used.
+    """
+    from genesis.eval.calibration import run_calibration
+
+    own = router is None
+    if router is None:
+        from genesis.experimentation.standalone_router import StandaloneLiteLLMRouter
+
+        router = StandaloneLiteLLMRouter(judge_provider)
+    try:
+        result = await run_calibration(
+            rubric=rubric_name,
+            golden_set_path=golden_set_path,
+            router=router,
+            threshold=threshold,
+        )
+    finally:
+        if own:
+            await router.close()
+
+    return {
+        "calibrated": result.threshold_met,
+        "agreement_rate": round(result.agreement_rate, 4),
+        "threshold": threshold,
+        "n_cases": result.total_cases,
+        "rubric_version": result.rubric_version,
+        "judge_provider": judge_provider,
+    }

--- a/src/genesis/experimentation/persistence.py
+++ b/src/genesis/experimentation/persistence.py
@@ -1,0 +1,81 @@
+"""Persist a reflection A/B experiment into ``eval_runs`` (two linked rows).
+
+Reuses the existing ``eval_runs`` table — NO new table, no migration. One row
+per arm; the treatment row links to its control via ``comparison_run_id`` (the
+architect's reuse). The treatment row's ``metadata_json`` carries the win-rate
++ recommendation — the recommend-only surface the human reads via the
+``experiment_status`` MCP tool. Run-level only (no per-case ``eval_results``);
+per-case persistence is a follow-up.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from genesis.eval.db import insert_run, set_comparison_run
+from genesis.eval.types import EvalRunSummary, EvalTrigger, TaskCategory
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+    from genesis.experimentation.types import ExperimentResult
+
+
+def _arm_summary(
+    *, run_id: str, model_id: str, dataset: str, n: int, n_pass: int,
+    mean_score: float, metadata: dict,
+) -> EvalRunSummary:
+    return EvalRunSummary(
+        run_id=run_id,
+        model_id=model_id,
+        model_profile=str(metadata.get("arm", "")),
+        dataset=dataset,
+        trigger=EvalTrigger.EXPERIMENT,
+        task_category=TaskCategory.REASONING,  # reflection quality ~ reasoning
+        total_cases=n,
+        passed_cases=n_pass,
+        failed_cases=n - n_pass,
+        aggregate_score=mean_score,
+        metadata=metadata,
+        results=[],
+    )
+
+
+async def persist_experiment(
+    db: aiosqlite.Connection,
+    result: ExperimentResult,
+    *,
+    gen_provider: str,
+    judge_provider: str,
+) -> dict[str, str]:
+    """Write the control + treatment arms as two linked ``eval_runs`` rows.
+
+    Returns ``{"control_run_id": ..., "treatment_run_id": ...}``.
+    """
+    dataset = f"experiment:reflection:{result.experiment_name}"
+    control_id = uuid.uuid4().hex
+    treatment_id = uuid.uuid4().hex
+    n = result.n_cases
+
+    await insert_run(db, _arm_summary(
+        run_id=control_id, model_id=gen_provider, dataset=dataset, n=n,
+        n_pass=result.control.n_pass, mean_score=result.control.mean_score,
+        metadata={"arm": "control", "variant": result.control.variant_name},
+    ))
+    await insert_run(db, _arm_summary(
+        run_id=treatment_id, model_id=gen_provider, dataset=dataset, n=n,
+        n_pass=result.treatment.n_pass, mean_score=result.treatment.mean_score,
+        metadata={
+            "arm": "treatment",
+            "variant": result.treatment.variant_name,
+            "winrate": result.winrate,
+            "recommendation": result.winrate.get("recommendation"),
+            "judge_provider": judge_provider,
+            "control_run_id": control_id,
+            "experiment": result.metadata,
+            "errors": result.errors,
+        },
+    ))
+    await set_comparison_run(db, treatment_id, control_id)
+    return {"control_run_id": control_id, "treatment_run_id": treatment_id}

--- a/src/genesis/experimentation/runner.py
+++ b/src/genesis/experimentation/runner.py
@@ -1,0 +1,213 @@
+"""Offline reflection-prompt A/B runner — Phase 7 Target 1 (the engine proof).
+
+Runs a CONTROL vs TREATMENT reflection *prompt* variant over a calibrated
+golden set: for each golden case, generate a fresh reflection per arm from the
+case's stored ``session_context``, judge each with the ``reflection_quality``
+rubric, and compute a paired win-rate.
+
+Discipline:
+- **No live runtime, no side effects on cognition.** Generation + judging go
+  through a standalone litellm router; nothing writes to `observations`,
+  `memory`, or any cognitive table. The only optional persistence is an
+  `eval_runs`/`eval_results` record (observability), added separately.
+- **Single-shot, by design.** Live *deep* reflection is an agentic CC session;
+  this offline harness renders a single completion. That is sufficient to prove
+  the experiment *machinery* (variant -> generate -> judge -> win-rate). Realistic
+  agentic-reflection experiments are future work.
+- **Recommend-only.** The output is a win-rate + recommendation; nothing is
+  promoted.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from genesis.eval.calibration import _load_golden_set
+from genesis.eval.scorers import LLMJudgeScorer
+from genesis.eval.stats import compute_score_winrate, compute_winrate
+from genesis.experimentation.standalone_router import (
+    StandaloneLiteLLMRouter,
+    _default_config_path,
+)
+from genesis.experimentation.types import ArmResult, CognitiveVariant, ExperimentResult
+from genesis.routing.config import load_config
+from genesis.routing.litellm_delegate import LiteLLMDelegate
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Default offline providers (routing-config names). Overridable per call.
+# Generation and judging use *different* providers to avoid self-judging bias;
+# the judge defaults to the deepseek family (closest available to the
+# golden-set's calibrated judge — re-run calibration if you change it).
+DEFAULT_GEN_PROVIDER = "groq-free"
+DEFAULT_JUDGE_PROVIDER = "nvidia-nim-deepseek"
+
+
+def _extract_reflection_text(raw: str) -> str:
+    """Reduce a deep-reflection JSON output to a single scoreable text.
+
+    The deep prompt emits JSON with an ``observations`` array; the rubric scores
+    one reflection text, so join the observations. Robust to markdown fences and
+    prose-wrapped JSON; falls back to the raw string if it isn't the expected
+    shape (the judge then scores whatever the model produced — fair across arms).
+    """
+    if not raw:
+        return ""
+    # Try to locate a JSON object even if wrapped in prose / fences.
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start != -1 and end > start:
+        try:
+            data = json.loads(raw[start : end + 1])
+        except json.JSONDecodeError:
+            data = None
+        if isinstance(data, dict):
+            obs = data.get("observations")
+            if isinstance(obs, list) and obs:
+                return "\n".join(str(o) for o in obs)
+            csu = data.get("cognitive_state_update")
+            if isinstance(csu, str) and csu.strip():
+                return csu
+    return raw.strip()
+
+
+async def run_reflection_experiment(
+    *,
+    experiment_name: str,
+    control: CognitiveVariant,
+    treatment: CognitiveVariant,
+    golden_set_path: Path,
+    rubric_name: str = "reflection_quality",
+    gen_provider: str = DEFAULT_GEN_PROVIDER,
+    judge_provider: str = DEFAULT_JUDGE_PROVIDER,
+    limit: int | None = None,
+    gen_router: object | None = None,
+    judge: object | None = None,
+) -> ExperimentResult:
+    """Run a control-vs-treatment reflection-prompt A/B over the golden set.
+
+    Args:
+        experiment_name: Label for this experiment (stored in result metadata).
+        control / treatment: Variants whose ``system_prompt`` is the reflection
+            system prompt for that arm.
+        golden_set_path: JSONL golden set (reused: each case supplies the
+            generation context + the judge's ``scorer_config``).
+        rubric_name: Judge rubric (default ``reflection_quality``).
+        gen_provider / judge_provider: routing-config provider names for
+            generation and judging (used only when gen_router/judge are not
+            injected).
+        limit: If set, only the first N golden cases (for smoke tests).
+        gen_router / judge: Optional injected generation router (with
+            ``route_call``) and judge (with ``score_async``) — for testing or
+            to reuse a live runtime's router. Built from the providers when
+            omitted.
+
+    Returns:
+        ExperimentResult with both arms' per-case pass/fail and the win-rate.
+    """
+    cases = _load_golden_set(golden_set_path)
+    if limit is not None:
+        cases = cases[:limit]
+    if not cases:
+        raise ValueError(f"golden set {golden_set_path} has no cases")
+
+    if not control.system_prompt or not treatment.system_prompt:
+        raise ValueError("both control and treatment must set system_prompt for a reflection A/B")
+
+    created_gen = gen_router is None
+    if gen_router is None or judge is None:
+        config = load_config(_default_config_path())
+        delegate = LiteLLMDelegate(config)
+        if gen_router is None:
+            gen_router = StandaloneLiteLLMRouter(gen_provider, config=config, delegate=delegate)
+        if judge is None:
+            judge = LLMJudgeScorer(
+                router=StandaloneLiteLLMRouter(judge_provider, config=config, delegate=delegate),
+            )
+
+    control_scores: list[float] = []
+    treatment_scores: list[float] = []
+    control_pass: list[bool] = []
+    treatment_pass: list[bool] = []
+    errors = 0
+
+    async def _score_arm(
+        variant: CognitiveVariant, ctx: str, expected: str, scorer_config: dict,
+    ) -> tuple[bool, float]:
+        nonlocal errors
+        messages = [
+            {"role": "system", "content": variant.system_prompt},
+            {"role": "user", "content": ctx},
+        ]
+        gen = await gen_router.route_call("reflection_gen", messages)
+        if not gen.success or not gen.content:
+            errors += 1
+            return False, 0.0
+        actual = _extract_reflection_text(gen.content)
+        passed, score, _detail = await judge.score_async(actual, expected, scorer_config)
+        return bool(passed), float(score)
+
+    try:
+        for case in cases:
+            scorer_config = dict(case.get("scorer_config") or {})
+            scorer_config.setdefault("rubric_name", rubric_name)
+            ctx = scorer_config.get("session_context", "")
+            expected = case.get("expected", "")
+            for variant, scores, passes in (
+                (control, control_scores, control_pass),
+                (treatment, treatment_scores, treatment_pass),
+            ):
+                try:
+                    passed, score = await _score_arm(variant, ctx, expected, scorer_config)
+                except Exception:  # noqa: BLE001 — one bad case must not abort the run
+                    logger.warning(
+                        "experiment %s case %s arm %s failed",
+                        experiment_name, case.get("id"), variant.name, exc_info=True,
+                    )
+                    errors += 1
+                    passed, score = False, 0.0
+                scores.append(score)
+                passes.append(passed)
+    finally:
+        if created_gen:
+            await gen_router.close()
+
+    # Primary signal: continuous score comparison (sensitive to sub-threshold
+    # differences). Secondary: pass/fail at the rubric threshold, for context.
+    winrate = compute_score_winrate(control_scores, treatment_scores)
+    pass_winrate = compute_winrate(control_pass, treatment_pass)
+
+    n = len(cases)
+    return ExperimentResult(
+        experiment_name=experiment_name,
+        control=ArmResult(
+            variant_name=control.name,
+            case_scores=control_scores,
+            case_results=control_pass,
+            n_pass=sum(control_pass),
+            mean_score=round(sum(control_scores) / n, 4) if n else 0.0,
+        ),
+        treatment=ArmResult(
+            variant_name=treatment.name,
+            case_scores=treatment_scores,
+            case_results=treatment_pass,
+            n_pass=sum(treatment_pass),
+            mean_score=round(sum(treatment_scores) / n, 4) if n else 0.0,
+        ),
+        winrate=winrate,
+        n_cases=n,
+        errors=errors,
+        metadata={
+            "rubric_name": rubric_name,
+            "gen_provider": gen_provider,
+            "judge_provider": judge_provider,
+            "control_description": control.description,
+            "treatment_description": treatment.description,
+            "pass_winrate": pass_winrate,
+        },
+    )

--- a/src/genesis/experimentation/runner.py
+++ b/src/genesis/experimentation/runner.py
@@ -88,6 +88,7 @@ async def run_reflection_experiment(
     limit: int | None = None,
     gen_router: object | None = None,
     judge: object | None = None,
+    db: object | None = None,
 ) -> ExperimentResult:
     """Run a control-vs-treatment reflection-prompt A/B over the golden set.
 
@@ -183,7 +184,7 @@ async def run_reflection_experiment(
     pass_winrate = compute_winrate(control_pass, treatment_pass)
 
     n = len(cases)
-    return ExperimentResult(
+    result = ExperimentResult(
         experiment_name=experiment_name,
         control=ArmResult(
             variant_name=control.name,
@@ -211,3 +212,9 @@ async def run_reflection_experiment(
             "pass_winrate": pass_winrate,
         },
     )
+
+    if db is not None:
+        from genesis.experimentation.persistence import persist_experiment
+
+        await persist_experiment(db, result, gen_provider=gen_provider, judge_provider=judge_provider)
+    return result

--- a/src/genesis/experimentation/runner.py
+++ b/src/genesis/experimentation/runner.py
@@ -28,6 +28,8 @@ from genesis.eval.calibration import _load_golden_set
 from genesis.eval.scorers import LLMJudgeScorer
 from genesis.eval.stats import compute_score_winrate, compute_winrate
 from genesis.experimentation.standalone_router import (
+    DEFAULT_GEN_PROVIDER,
+    DEFAULT_JUDGE_PROVIDER,
     StandaloneLiteLLMRouter,
     _default_config_path,
 )
@@ -39,13 +41,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
-
-# Default offline providers (routing-config names). Overridable per call.
-# Generation and judging use *different* providers to avoid self-judging bias;
-# the judge defaults to the deepseek family (closest available to the
-# golden-set's calibrated judge — re-run calibration if you change it).
-DEFAULT_GEN_PROVIDER = "groq-free"
-DEFAULT_JUDGE_PROVIDER = "nvidia-nim-deepseek"
 
 
 def _extract_reflection_text(raw: str) -> str:
@@ -182,6 +177,12 @@ async def run_reflection_experiment(
     # differences). Secondary: pass/fail at the rubric threshold, for context.
     winrate = compute_score_winrate(control_scores, treatment_scores)
     pass_winrate = compute_winrate(control_pass, treatment_pass)
+    try:
+        from genesis.experimentation.guards import pin_rubric_version
+
+        rubric_version = pin_rubric_version(rubric_name)
+    except Exception:  # noqa: BLE001 — version pin is best-effort audit metadata
+        rubric_version = None
 
     n = len(cases)
     result = ExperimentResult(
@@ -205,6 +206,7 @@ async def run_reflection_experiment(
         errors=errors,
         metadata={
             "rubric_name": rubric_name,
+            "rubric_version": rubric_version,
             "gen_provider": gen_provider,
             "judge_provider": judge_provider,
             "control_description": control.description,

--- a/src/genesis/experimentation/runner.py
+++ b/src/genesis/experimentation/runner.py
@@ -116,15 +116,17 @@ async def run_reflection_experiment(
         raise ValueError("both control and treatment must set system_prompt for a reflection A/B")
 
     created_gen = gen_router is None
+    created_judge_router = None
     if gen_router is None or judge is None:
         config = load_config(_default_config_path())
         delegate = LiteLLMDelegate(config)
         if gen_router is None:
             gen_router = StandaloneLiteLLMRouter(gen_provider, config=config, delegate=delegate)
         if judge is None:
-            judge = LLMJudgeScorer(
-                router=StandaloneLiteLLMRouter(judge_provider, config=config, delegate=delegate),
+            created_judge_router = StandaloneLiteLLMRouter(
+                judge_provider, config=config, delegate=delegate,
             )
+            judge = LLMJudgeScorer(router=created_judge_router)
 
     control_scores: list[float] = []
     treatment_scores: list[float] = []
@@ -172,6 +174,8 @@ async def run_reflection_experiment(
     finally:
         if created_gen:
             await gen_router.close()
+        if created_judge_router is not None:
+            await created_judge_router.close()
 
     # Primary signal: continuous score comparison (sensitive to sub-threshold
     # differences). Secondary: pass/fail at the rubric threshold, for context.

--- a/src/genesis/experimentation/standalone_router.py
+++ b/src/genesis/experimentation/standalone_router.py
@@ -1,0 +1,108 @@
+"""Standalone Router-compatible wrapper for offline experiment/eval runs.
+
+`LLMJudgeScorer` (and the experimentation runner's generation step) expect a
+``Router`` exposing ``route_call(call_site_id, messages, **kwargs)``. The live
+Genesis Router needs the full runtime (breakers, cost tracker, degradation,
+delegate). For an *offline* experiment we only need a single model call.
+
+This wraps Genesis's own ``LiteLLMDelegate`` (the same path `eval/runner.py`
+uses) so provider→litellm mapping, API keys, and custom base-urls are handled
+natively — selecting a model by its routing-config *provider name* rather than a
+raw litellm model string. Mirrors the pattern in
+`run_reflection_calibration._LiteLLMRouter` (which should be refactored onto this
+— tracked as cleanup).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from genesis.routing.config import load_config
+from genesis.routing.litellm_delegate import LiteLLMDelegate
+from genesis.routing.types import RoutingConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _default_config_path() -> Path:
+    return Path(__file__).resolve().parents[3] / "config" / "model_routing.yaml"
+
+
+@dataclass
+class StandaloneRoutingResult:
+    """Minimal RoutingResult shape consumed by `LLMJudgeScorer`."""
+
+    success: bool
+    content: str | None
+    model_id: str | None
+    provider_used: str | None
+    error: str | None
+
+
+class StandaloneLiteLLMRouter:
+    """Minimal Router for offline use — one provider, no fallback chain.
+
+    Args:
+        provider_name: A provider key from ``model_routing.yaml``
+            (e.g. ``"groq-free"``).
+        config: Pre-loaded routing config (optional; loaded from the default
+            path if omitted).
+        delegate: A shared ``LiteLLMDelegate`` (optional; one is built from
+            ``config`` if omitted — pass a shared instance to avoid duplicate
+            delegates across the gen + judge routers).
+    """
+
+    def __init__(
+        self,
+        provider_name: str,
+        *,
+        config: RoutingConfig | None = None,
+        delegate: LiteLLMDelegate | None = None,
+    ) -> None:
+        # Load secrets.env into the environment so litellm finds provider API
+        # keys (the same hook the offline calibration CLI uses). Idempotent.
+        from genesis.eval.reflection_golden_set import _ensure_secrets
+
+        _ensure_secrets()
+
+        if config is None:
+            config = load_config(_default_config_path())
+        provider_cfg = config.providers.get(provider_name)
+        if provider_cfg is None:
+            raise ValueError(
+                f"unknown provider {provider_name!r} — available: "
+                f"{', '.join(sorted(config.providers))}"
+            )
+        self._provider_name = provider_name
+        self._model_id = provider_cfg.model_id
+        self._delegate = delegate or LiteLLMDelegate(config)
+
+    async def route_call(
+        self,
+        call_site_id: str,
+        messages: list[dict],
+        **kwargs,
+    ) -> StandaloneRoutingResult:
+        result = await self._delegate.call(
+            provider=self._provider_name,
+            model_id=self._model_id,
+            messages=messages,
+            **kwargs,
+        )
+        if not result.success:
+            logger.warning(
+                "standalone route_call failed (%s via %s): %s",
+                call_site_id, self._provider_name, result.error,
+            )
+        return StandaloneRoutingResult(
+            success=result.success,
+            content=result.content,
+            model_id=self._model_id,
+            provider_used=self._provider_name,
+            error=getattr(result, "error", None),
+        )
+
+    async def close(self) -> None:
+        """No persistent resources to release (litellm manages its own)."""

--- a/src/genesis/experimentation/standalone_router.py
+++ b/src/genesis/experimentation/standalone_router.py
@@ -15,6 +15,7 @@ raw litellm model string. Mirrors the pattern in
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -24,6 +25,15 @@ from genesis.routing.litellm_delegate import LiteLLMDelegate
 from genesis.routing.types import RoutingConfig
 
 logger = logging.getLogger(__name__)
+
+# Transient errors worth retrying (free-tier judges 429 readily). Mirrors the
+# retry posture of `eval/runner.py`.
+_RETRYABLE = (
+    "rate limit", "ratelimit", "too many requests", "429", "503",
+    "overloaded", "timeout", "connection", "temporarily",
+)
+_MAX_RETRIES = 2
+_RETRY_BASE_S = 5.0
 
 
 def _default_config_path() -> Path:
@@ -85,12 +95,28 @@ class StandaloneLiteLLMRouter:
         messages: list[dict],
         **kwargs,
     ) -> StandaloneRoutingResult:
-        result = await self._delegate.call(
-            provider=self._provider_name,
-            model_id=self._model_id,
-            messages=messages,
-            **kwargs,
-        )
+        result = None
+        for attempt in range(_MAX_RETRIES + 1):
+            result = await self._delegate.call(
+                provider=self._provider_name,
+                model_id=self._model_id,
+                messages=messages,
+                **kwargs,
+            )
+            if result.success:
+                break
+            msg = (result.error or "").lower()
+            if attempt < _MAX_RETRIES and any(k in msg for k in _RETRYABLE):
+                delay = _RETRY_BASE_S * (2 ** attempt)
+                logger.info(
+                    "standalone %s via %s transient (%s); retry %d/%d in %.0fs",
+                    call_site_id, self._provider_name, result.error,
+                    attempt + 1, _MAX_RETRIES, delay,
+                )
+                await asyncio.sleep(delay)
+                continue
+            break
+
         if not result.success:
             logger.warning(
                 "standalone route_call failed (%s via %s): %s",

--- a/src/genesis/experimentation/standalone_router.py
+++ b/src/genesis/experimentation/standalone_router.py
@@ -35,6 +35,12 @@ _RETRYABLE = (
 _MAX_RETRIES = 2
 _RETRY_BASE_S = 5.0
 
+# Default offline providers (routing-config names). Generation + judging use
+# DIFFERENT providers to avoid self-judging bias; the judge defaults to the
+# deepseek family (closest available to the golden-set's calibrated judge).
+DEFAULT_GEN_PROVIDER = "groq-free"
+DEFAULT_JUDGE_PROVIDER = "nvidia-nim-deepseek"
+
 
 def _default_config_path() -> Path:
     return Path(__file__).resolve().parents[3] / "config" / "model_routing.yaml"

--- a/src/genesis/experimentation/types.py
+++ b/src/genesis/experimentation/types.py
@@ -1,0 +1,49 @@
+"""Types for the cognitive experimentation harness."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CognitiveVariant:
+    """One arm of a cognitive A/B — a named overlay of one cognitive knob.
+
+    Exactly one knob field should be set per variant for a clean experiment:
+    - ``system_prompt``: the reflection-prompt A/B (Target 1) — the full
+      (deep) reflection system prompt for this arm.
+    - ``signal_weight_overrides``: the awareness signal-weight A/B (Target 2,
+      a deterministic divergence report) — ``{signal_name: weight}`` overrides.
+    """
+
+    name: str
+    description: str = ""
+    system_prompt: str | None = None
+    signal_weight_overrides: dict[str, float] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ArmResult:
+    """Per-arm outcome of an experiment run."""
+
+    variant_name: str
+    case_scores: list[float]  # per-case judge score (0-1) — the primary signal
+    case_results: list[bool]  # per-case pass/fail at the rubric threshold — context
+    n_pass: int
+    mean_score: float
+    run_id: str | None = None  # eval_runs.id when persisted
+
+
+@dataclass(frozen=True)
+class ExperimentResult:
+    """The full result of a control-vs-treatment experiment."""
+
+    experiment_name: str
+    control: ArmResult
+    treatment: ArmResult
+    winrate: dict[str, Any]  # genesis.eval.stats.compute_winrate output
+    n_cases: int
+    errors: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)

--- a/src/genesis/experimentation/weight_divergence.py
+++ b/src/genesis/experimentation/weight_divergence.py
@@ -1,0 +1,105 @@
+"""Target-2: deterministic awareness signal-weight divergence report (Phase 7).
+
+Measures how a signal-weight change would shift awareness depth decisions,
+replayed over historical ticks — WITHOUT mutating the live ``signal_weights``
+table or touching live cognition (uses ``compute_scores(weights_override=...)``).
+
+This is an IMPACT / DIVERGENCE report, NOT a win-rate: there is no ground-truth
+"correct depth" for an awareness tick, so a win-rate would be meaningless (per
+the firsthand DD finding). Instead it quantifies behavioural impact ("this weight
+change flips N% of historical ticks' depth decisions, skewing toward more-Deep /
+fewer-Micro") for a human promote/no-go decision — recommend-only.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter
+from typing import TYPE_CHECKING
+
+from genesis.awareness.scorer import compute_scores
+from genesis.awareness.types import SignalReading
+from genesis.db.crud import awareness_ticks
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+def _triggered_depths(scores) -> set[str]:
+    return {s.depth.value for s in scores if s.triggered}
+
+
+def _signals_from_tick(raw: str) -> list[SignalReading] | None:
+    try:
+        entries = json.loads(raw)
+        return [
+            SignalReading(
+                name=e["name"],
+                value=float(e["value"]),
+                source=e.get("source", "replay"),
+                collected_at=e.get("collected_at", ""),
+            )
+            for e in entries
+        ]
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+
+
+async def weight_divergence(
+    db: aiosqlite.Connection,
+    *,
+    signal_weight_overrides: dict[str, float],
+    limit: int = 200,
+) -> dict:
+    """Replay historical ticks under baseline vs overridden weights; report flips.
+
+    Returns:
+        dict with n_ticks, n_flipped, flip_rate, depths_gained (depth -> #ticks
+        where it NEWLY triggers under the variant), depths_lost, n_skipped, overrides.
+    """
+    if not signal_weight_overrides:
+        raise ValueError("signal_weight_overrides must be non-empty")
+
+    ticks = await awareness_ticks.query(db, limit=limit)
+    n_ticks = 0
+    n_flipped = 0
+    skipped = 0
+    gained: Counter = Counter()
+    lost: Counter = Counter()
+
+    for tick in ticks:
+        raw = tick.get("signals_json")
+        if not raw:
+            skipped += 1
+            continue
+        signals = _signals_from_tick(raw)
+        if signals is None:
+            skipped += 1
+            continue
+
+        base = await compute_scores(db, signals)
+        var = await compute_scores(db, signals, weights_override=signal_weight_overrides)
+        base_t = _triggered_depths(base)
+        var_t = _triggered_depths(var)
+
+        n_ticks += 1
+        if base_t != var_t:
+            n_flipped += 1
+            for d in var_t - base_t:
+                gained[d] += 1
+            for d in base_t - var_t:
+                lost[d] += 1
+
+    flip_rate = (n_flipped / n_ticks) if n_ticks else 0.0
+    return {
+        "n_ticks": n_ticks,
+        "n_flipped": n_flipped,
+        "flip_rate": round(flip_rate, 4),
+        "depths_gained": dict(gained),
+        "depths_lost": dict(lost),
+        "n_skipped": skipped,
+        "overrides": signal_weight_overrides,
+    }

--- a/src/genesis/experimentation/weight_divergence.py
+++ b/src/genesis/experimentation/weight_divergence.py
@@ -80,8 +80,14 @@ async def weight_divergence(
             skipped += 1
             continue
 
-        base = await compute_scores(db, signals)
-        var = await compute_scores(db, signals, weights_override=signal_weight_overrides)
+        # decay_factors={}: no staleness decay AND — critically — does NOT call
+        # _update_staleness, so replaying historical ticks never mutates the live
+        # awareness loop's module-level staleness counters. Both arms share the
+        # same (no-decay) basis, so the only difference is the weight override.
+        base = await compute_scores(db, signals, decay_factors={})
+        var = await compute_scores(
+            db, signals, weights_override=signal_weight_overrides, decay_factors={},
+        )
         base_t = _triggered_depths(base)
         var_t = _triggered_depths(var)
 

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -66,6 +66,7 @@ from genesis.mcp.health import direct_session_tools as _direct_session_tools  # 
 from genesis.mcp.health import ego_calibration as _ego_calibration  # noqa: E402, F401
 from genesis.mcp.health import ego_tools as _ego_tools  # noqa: E402
 from genesis.mcp.health import errors as _errors  # noqa: E402
+from genesis.mcp.health import experiment_status as _experiment_status  # noqa: E402, F401
 from genesis.mcp.health import follow_up_tools as _follow_up_tools  # noqa: E402
 from genesis.mcp.health import inbox_digest as _inbox_digest  # noqa: E402
 from genesis.mcp.health import j9_eval as _j9_eval  # noqa: E402, F401

--- a/src/genesis/mcp/health/experiment_status.py
+++ b/src/genesis/mcp/health/experiment_status.py
@@ -1,0 +1,97 @@
+"""Experiment status MCP tool — read-only surface for cognitive A/B results.
+
+The recommend-only delivery surface for the Phase-7 experimentation harness.
+It reads persisted experiment runs (``eval_runs``, trigger='experiment') and
+surfaces, per experiment, the control vs treatment scores, the win-rate stats,
+and the recommendation. It NEVER promotes a variant — ``autonomous_action`` is
+always False; a human acts on a recommendation manually (``settings_update`` for
+flag knobs, ``signal_weights.update_weight`` for weights).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+
+def _meta(row: dict) -> dict:
+    raw = row.get("metadata_json")
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+
+async def _impl_experiment_status(limit: int = 10) -> dict:
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    _service = health_mcp_mod._service
+    if _service is None or _service._db is None:
+        return {"status": "unavailable", "message": "DB not initialized"}
+
+    db = _service._db
+    from genesis.eval.db import get_experiment_runs
+
+    # Fetch both arms per experiment (control + treatment rows).
+    rows = await get_experiment_runs(db, limit=limit * 2)
+    by_id = {r["id"]: r for r in rows}
+
+    experiments = []
+    for r in rows:
+        meta = _meta(r)
+        if meta.get("arm") != "treatment":
+            continue  # the treatment row carries the comparison + win-rate
+        control = by_id.get(r.get("comparison_run_id")) or {}
+        control_meta = _meta(control)
+        experiments.append({
+            "experiment": r.get("dataset"),  # "experiment:reflection:<name>"
+            "created_at": r.get("created_at"),
+            "recommendation": meta.get("recommendation"),
+            "winrate": meta.get("winrate", {}),
+            "n_cases": r.get("total_cases"),
+            "control": {
+                "variant": control_meta.get("variant"),
+                "mean_score": control.get("aggregate_score"),
+                "n_pass": control.get("passed_cases"),
+            },
+            "treatment": {
+                "variant": meta.get("variant"),
+                "mean_score": r.get("aggregate_score"),
+                "n_pass": r.get("passed_cases"),
+            },
+            "judge_provider": meta.get("judge_provider"),
+            "errors": meta.get("errors"),
+        })
+        if len(experiments) >= limit:
+            break
+
+    return {
+        "status": "ok",
+        "autonomous_action": False,
+        "experiments": experiments,
+        "note": (
+            "Recommend-only: the harness NEVER promotes a variant. Act on a "
+            "recommendation manually — settings_update for flag knobs, "
+            "signal_weights.update_weight for awareness weights. "
+            "recommendation ∈ {treatment_wins, control_wins, no_difference, "
+            "insufficient_data}."
+        ),
+    }
+
+
+@mcp.tool()
+async def experiment_status(limit: int = 10) -> dict:
+    """Latest cognitive A/B experiment results + promotion recommendations.
+
+    Read-only surface for the Phase-7 experimentation harness: per experiment,
+    the control vs treatment mean scores, the paired win-rate (McNemar exact),
+    and the recommendation. The harness is RECOMMEND-ONLY — ``autonomous_action``
+    is always False; nothing is promoted automatically.
+    """
+    return await _impl_experiment_status(limit=limit)

--- a/tests/test_eval/test_cognitive_drift.py
+++ b/tests/test_eval/test_cognitive_drift.py
@@ -1,0 +1,58 @@
+"""Tests for the dark cognitive-drift dimension (Phase 7, j9_aggregator)."""
+
+import pytest
+
+from genesis.eval.j9_aggregator import _compute_cognitive_drift
+
+_PS = "2026-06-01T00:00:00+00:00"
+_PE = "2026-06-30T00:00:00+00:00"
+
+
+async def _insert(db, pid, action_type, alternatives="", verdict=None,
+                  created_at="2026-06-15T00:00:00+00:00"):
+    await db.execute(
+        """INSERT INTO ego_proposals (id, action_type, content, created_at,
+               alternatives, realist_verdict)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (pid, action_type, "content", created_at, alternatives, verdict),
+    )
+
+
+async def test_drift_metrics(db):
+    # action_types a,a,b,c ; verdicts pass,amend,reject,None ; alts on p1,p3
+    await _insert(db, "p1", "a", alternatives="x", verdict="pass")
+    await _insert(db, "p2", "a", alternatives="", verdict="amend")
+    await _insert(db, "p3", "b", alternatives="y", verdict="reject")
+    await _insert(db, "p4", "c", alternatives="", verdict=None)
+    await db.commit()
+
+    metrics, n = await _compute_cognitive_drift(db, _PS, _PE)
+    assert n == 4
+    # 3 verdicts present; dissent (amend+reject) = 2 -> 2/3
+    assert metrics["n_with_verdict"] == 3
+    assert metrics["dissent_rate"] == pytest.approx(0.6667, abs=1e-3)
+    # 2 of 4 proposals recorded an alternative
+    assert metrics["alternative_rate"] == 0.5
+    # distinct action_types a,b,c
+    assert metrics["distinct_action_types"] == 3
+    assert 0.0 < metrics["diversity_entropy"] <= 1.0
+
+
+async def test_drift_single_action_type_zero_entropy(db):
+    for i in range(3):
+        await _insert(db, f"s{i}", "same", verdict="pass")
+    await db.commit()
+    metrics, n = await _compute_cognitive_drift(db, _PS, _PE)
+    assert n == 3
+    assert metrics["distinct_action_types"] == 1
+    assert metrics["diversity_entropy"] == 0.0  # no diversity with one type
+    assert metrics["dissent_rate"] == 0.0  # all 'pass' -> no dissent
+
+
+async def test_drift_empty_window(db):
+    metrics, n = await _compute_cognitive_drift(
+        db, "2030-01-01T00:00:00+00:00", "2030-12-31T00:00:00+00:00",
+    )
+    assert n == 0
+    assert metrics["dissent_rate"] is None
+    assert metrics["diversity_entropy"] is None

--- a/tests/test_eval/test_stats.py
+++ b/tests/test_eval/test_stats.py
@@ -1,0 +1,93 @@
+"""Tests for the paired-comparison stats (McNemar exact, pure stdlib)."""
+
+import pytest
+
+from genesis.eval.stats import (
+    _mcnemar_exact_two_sided,
+    compute_score_winrate,
+    compute_winrate,
+)
+
+
+def test_mcnemar_exact_known_values():
+    # All 6 discordant pairs favour one arm: 2 * C(6,0)/2^6 = 2/64.
+    assert _mcnemar_exact_two_sided(6, 0) == pytest.approx(0.03125)
+    # 5 discordant, all one way: 2 * C(5,0)/2^5 = 2/32.
+    assert _mcnemar_exact_two_sided(5, 0) == pytest.approx(0.0625)
+    # Even split caps at 1.0.
+    assert _mcnemar_exact_two_sided(4, 2) == pytest.approx(1.0)
+
+
+# ---- compute_winrate (binary pass/fail) ----
+
+def test_winrate_length_mismatch_raises():
+    with pytest.raises(ValueError, match="same length"):
+        compute_winrate([True, False], [True])
+
+
+def test_winrate_empty_raises():
+    with pytest.raises(ValueError, match="no cases"):
+        compute_winrate([], [])
+
+
+def test_winrate_no_discordant_is_insufficient():
+    out = compute_winrate([True, True, False], [True, True, False])
+    assert out["n_discordant"] == 0
+    assert out["p_value"] is None
+    assert out["recommendation"] == "insufficient_data"
+
+
+def test_winrate_six_discordant_treatment_wins_significant():
+    out = compute_winrate([False] * 6, [True] * 6)
+    assert out["n_treatment_wins"] == 6
+    assert out["n_control_wins"] == 0
+    assert out["p_value"] == pytest.approx(0.0312)  # rounded to 4dp from 0.03125
+    assert out["significant"] is True
+    assert out["recommendation"] == "treatment_wins"
+
+
+def test_winrate_five_discordant_not_significant():
+    # Boundary: 5 discordant all one way -> p=0.0625 -> no_difference (not insufficient).
+    out = compute_winrate([False] * 5, [True] * 5)
+    assert out["n_discordant"] == 5
+    assert out["significant"] is False
+    assert out["recommendation"] == "no_difference"
+
+
+def test_winrate_four_discordant_insufficient():
+    out = compute_winrate([False] * 4, [True] * 4)
+    assert out["recommendation"] == "insufficient_data"
+
+
+# ---- compute_score_winrate (continuous judge scores) ----
+
+def test_score_winrate_control_wins_significant():
+    # The case[0] pattern: control consistently higher, both sub-threshold.
+    out = compute_score_winrate([0.15] * 6, [0.05] * 6)
+    assert out["n_control_wins"] == 6
+    assert out["n_treatment_wins"] == 0
+    assert out["control_mean_score"] == pytest.approx(0.15)
+    assert out["treatment_mean_score"] == pytest.approx(0.05)
+    assert out["p_value"] == pytest.approx(0.0312)  # rounded to 4dp from 0.03125
+    assert out["significant"] is True
+    assert out["recommendation"] == "control_wins"
+
+
+def test_score_winrate_equal_scores_are_ties():
+    out = compute_score_winrate([0.5] * 6, [0.5] * 6)
+    assert out["n_ties"] == 6
+    assert out["n_discordant"] == 0
+    assert out["recommendation"] == "insufficient_data"
+
+
+def test_score_winrate_epsilon_creates_ties():
+    # 0.02 difference is a win at epsilon=0 but a tie at epsilon=0.05.
+    strict = compute_score_winrate([0.52] * 6, [0.50] * 6, epsilon=0.0)
+    assert strict["n_control_wins"] == 6
+    loose = compute_score_winrate([0.52] * 6, [0.50] * 6, epsilon=0.05)
+    assert loose["n_ties"] == 6
+
+
+def test_score_winrate_length_mismatch_raises():
+    with pytest.raises(ValueError, match="same length"):
+        compute_score_winrate([0.1, 0.2], [0.1])

--- a/tests/test_experimentation/conftest.py
+++ b/tests/test_experimentation/conftest.py
@@ -1,0 +1,24 @@
+"""Shared fixtures for experimentation tests."""
+
+import pytest
+
+# eval_runs is migration-only (not in create_all_tables). The experimentation
+# harness only writes run-level rows (results=[]), so eval_results isn't needed.
+# DDL mirrors migration 0002_add_eval_tables.
+_EVAL_RUNS_DDL = """
+CREATE TABLE IF NOT EXISTS eval_runs (
+    id TEXT PRIMARY KEY, model_id TEXT NOT NULL, model_profile TEXT,
+    dataset TEXT NOT NULL, trigger TEXT NOT NULL, task_category TEXT NOT NULL,
+    total_cases INTEGER NOT NULL, passed_cases INTEGER NOT NULL,
+    failed_cases INTEGER NOT NULL, skipped_cases INTEGER DEFAULT 0,
+    aggregate_score REAL, scores_json TEXT, metadata_json TEXT,
+    comparison_run_id TEXT, created_at TEXT NOT NULL, duration_s REAL
+)
+"""
+
+
+@pytest.fixture
+async def eval_db(db):
+    await db.execute(_EVAL_RUNS_DDL)
+    await db.commit()
+    return db

--- a/tests/test_experimentation/test_experiment_status.py
+++ b/tests/test_experimentation/test_experiment_status.py
@@ -1,0 +1,58 @@
+"""Test the read-only experiment_status MCP surface."""
+
+from genesis.experimentation.persistence import persist_experiment
+from genesis.experimentation.types import ArmResult, ExperimentResult
+
+
+def _result(name="mcp_test"):
+    return ExperimentResult(
+        experiment_name=name,
+        control=ArmResult(
+            variant_name="ctrl", case_scores=[0.8] * 6, case_results=[True] * 6,
+            n_pass=6, mean_score=0.8,
+        ),
+        treatment=ArmResult(
+            variant_name="trt", case_scores=[0.1] * 6, case_results=[False] * 6,
+            n_pass=0, mean_score=0.1,
+        ),
+        winrate={"recommendation": "control_wins", "significant": True, "n_control_wins": 6},
+        n_cases=6,
+        errors=0,
+        metadata={"rubric_name": "reflection_quality"},
+    )
+
+
+async def test_experiment_status_surfaces_recommendation(eval_db, monkeypatch):
+    await persist_experiment(eval_db, _result(), gen_provider="g", judge_provider="nvidia-nim-deepseek")
+
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    class _Svc:
+        _db = eval_db
+
+    monkeypatch.setattr(health_mcp_mod, "_service", _Svc(), raising=False)
+
+    from genesis.mcp.health.experiment_status import _impl_experiment_status
+
+    out = await _impl_experiment_status()
+    assert out["status"] == "ok"
+    assert out["autonomous_action"] is False
+    assert len(out["experiments"]) == 1
+
+    exp = out["experiments"][0]
+    assert exp["recommendation"] == "control_wins"
+    assert exp["experiment"] == "experiment:reflection:mcp_test"
+    assert exp["control"]["variant"] == "ctrl"
+    assert exp["treatment"]["variant"] == "trt"
+    assert exp["winrate"]["n_control_wins"] == 6
+    assert exp["judge_provider"] == "nvidia-nim-deepseek"
+
+
+async def test_experiment_status_unavailable_without_db(monkeypatch):
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    monkeypatch.setattr(health_mcp_mod, "_service", None, raising=False)
+    from genesis.mcp.health.experiment_status import _impl_experiment_status
+
+    out = await _impl_experiment_status()
+    assert out["status"] == "unavailable"

--- a/tests/test_experimentation/test_guards.py
+++ b/tests/test_experimentation/test_guards.py
@@ -1,0 +1,90 @@
+"""Tests for the judge-hack guards."""
+
+import json
+from types import SimpleNamespace
+
+from genesis.experimentation.guards import (
+    check_rubric_calibrated,
+    held_out_verdict,
+    pin_rubric_version,
+)
+
+
+def test_pin_rubric_version_returns_version():
+    v = pin_rubric_version("reflection_quality")
+    assert isinstance(v, str) and v  # e.g. "1.0.0"
+
+
+def test_held_out_survives_when_judges_agree():
+    out = held_out_verdict("treatment_wins", "treatment_wins")
+    assert out["survives"] is True
+    assert out["flag"] is None
+
+
+def test_held_out_flags_judge_overfit_on_disagreement():
+    out = held_out_verdict("treatment_wins", "no_difference")
+    assert out["survives"] is False
+    assert out["flag"] == "judge_overfit"
+
+
+def test_held_out_non_directional_has_nothing_to_validate():
+    out = held_out_verdict("insufficient_data", "control_wins")
+    assert out["survives"] is True
+    assert out["flag"] is None
+
+
+class _StubJudgeRouter:
+    """Returns a fixed judge score so every golden case 'passes' the judge."""
+
+    def __init__(self, score=0.8):
+        self._score = score
+
+    async def route_call(self, call_site_id, messages, **kwargs):
+        return SimpleNamespace(
+            success=True,
+            content=json.dumps({"score": self._score, "rationale": "ok"}),
+            error=None,
+            model_id="stub-judge",
+            provider_used="stub",
+        )
+
+    async def close(self):
+        pass
+
+
+def _write_golden(tmp_path, n, *, user_passed):
+    path = tmp_path / "golden.jsonl"
+    lines = [
+        json.dumps({
+            "id": f"c{i}",
+            "actual": "some reflection text",
+            "user_passed": user_passed,
+            "expected": "deep_reflection_observation",
+            "scorer_config": {"rubric_name": "reflection_quality", "session_context": "sig"},
+        })
+        for i in range(n)
+    ]
+    path.write_text("\n".join(lines))
+    return path
+
+
+async def test_check_rubric_calibrated_passes(tmp_path):
+    # judge passes all (0.8 >= 0.6) and golden labels all pass -> 100% agreement
+    golden = _write_golden(tmp_path, 5, user_passed=True)
+    out = await check_rubric_calibrated(
+        "reflection_quality", golden, router=_StubJudgeRouter(score=0.8),
+    )
+    assert out["calibrated"] is True
+    assert out["agreement_rate"] == 1.0
+    assert out["n_cases"] == 5
+    assert out["rubric_version"]
+
+
+async def test_check_rubric_calibrated_fails_on_disagreement(tmp_path):
+    # judge passes all, golden labels all fail -> 0% agreement -> not calibrated
+    golden = _write_golden(tmp_path, 5, user_passed=False)
+    out = await check_rubric_calibrated(
+        "reflection_quality", golden, router=_StubJudgeRouter(score=0.8),
+    )
+    assert out["calibrated"] is False
+    assert out["agreement_rate"] == 0.0

--- a/tests/test_experimentation/test_persistence.py
+++ b/tests/test_experimentation/test_persistence.py
@@ -1,0 +1,83 @@
+"""Tests for experiment persistence — two linked eval_runs rows, no new table."""
+
+import json
+
+import pytest
+
+from genesis.eval.db import get_experiment_runs
+from genesis.experimentation.persistence import persist_experiment
+from genesis.experimentation.types import ArmResult, ExperimentResult
+
+# eval_runs is migration-only (not in create_all_tables), and we only write
+# run-level rows (results=[]) so eval_results isn't needed. Add eval_runs to the
+# conftest in-memory db (DDL mirrors migration 0002_add_eval_tables).
+_EVAL_RUNS_DDL = """
+CREATE TABLE IF NOT EXISTS eval_runs (
+    id TEXT PRIMARY KEY, model_id TEXT NOT NULL, model_profile TEXT,
+    dataset TEXT NOT NULL, trigger TEXT NOT NULL, task_category TEXT NOT NULL,
+    total_cases INTEGER NOT NULL, passed_cases INTEGER NOT NULL,
+    failed_cases INTEGER NOT NULL, skipped_cases INTEGER DEFAULT 0,
+    aggregate_score REAL, scores_json TEXT, metadata_json TEXT,
+    comparison_run_id TEXT, created_at TEXT NOT NULL, duration_s REAL
+)
+"""
+
+
+@pytest.fixture
+async def eval_db(db):
+    await db.execute(_EVAL_RUNS_DDL)
+    await db.commit()
+    return db
+
+
+def _result():
+    winrate = {
+        "recommendation": "control_wins",
+        "significant": True,
+        "n_control_wins": 6,
+        "n_treatment_wins": 0,
+    }
+    return ExperimentResult(
+        experiment_name="unit_test",
+        control=ArmResult(
+            variant_name="ctrl", case_scores=[0.8] * 6, case_results=[True] * 6,
+            n_pass=6, mean_score=0.8,
+        ),
+        treatment=ArmResult(
+            variant_name="trt", case_scores=[0.1] * 6, case_results=[False] * 6,
+            n_pass=0, mean_score=0.1,
+        ),
+        winrate=winrate,
+        n_cases=6,
+        errors=0,
+        metadata={"rubric_name": "reflection_quality", "pass_winrate": {"recommendation": "control_wins"}},
+    )
+
+
+async def test_persist_writes_two_linked_rows(eval_db):
+    ids = await persist_experiment(
+        eval_db, _result(), gen_provider="groq-free", judge_provider="nvidia-nim-deepseek",
+    )
+    assert set(ids) == {"control_run_id", "treatment_run_id"}
+
+    runs = await get_experiment_runs(eval_db, limit=10)
+    assert len(runs) == 2
+    by_id = {r["id"]: r for r in runs}
+    control = by_id[ids["control_run_id"]]
+    treatment = by_id[ids["treatment_run_id"]]
+
+    # control unlinked; treatment links back to control (A/B pairing)
+    assert control["comparison_run_id"] is None
+    assert treatment["comparison_run_id"] == ids["control_run_id"]
+    assert control["trigger"] == "experiment"
+
+    # aggregate scores landed on each arm
+    assert control["aggregate_score"] == pytest.approx(0.8)
+    assert treatment["aggregate_score"] == pytest.approx(0.1)
+
+    # the recommendation is queryable from the treatment row's metadata
+    meta = json.loads(treatment["metadata_json"])
+    assert meta["arm"] == "treatment"
+    assert meta["recommendation"] == "control_wins"
+    assert meta["winrate"]["n_control_wins"] == 6
+    assert meta["control_run_id"] == ids["control_run_id"]

--- a/tests/test_experimentation/test_persistence.py
+++ b/tests/test_experimentation/test_persistence.py
@@ -8,26 +8,7 @@ from genesis.eval.db import get_experiment_runs
 from genesis.experimentation.persistence import persist_experiment
 from genesis.experimentation.types import ArmResult, ExperimentResult
 
-# eval_runs is migration-only (not in create_all_tables), and we only write
-# run-level rows (results=[]) so eval_results isn't needed. Add eval_runs to the
-# conftest in-memory db (DDL mirrors migration 0002_add_eval_tables).
-_EVAL_RUNS_DDL = """
-CREATE TABLE IF NOT EXISTS eval_runs (
-    id TEXT PRIMARY KEY, model_id TEXT NOT NULL, model_profile TEXT,
-    dataset TEXT NOT NULL, trigger TEXT NOT NULL, task_category TEXT NOT NULL,
-    total_cases INTEGER NOT NULL, passed_cases INTEGER NOT NULL,
-    failed_cases INTEGER NOT NULL, skipped_cases INTEGER DEFAULT 0,
-    aggregate_score REAL, scores_json TEXT, metadata_json TEXT,
-    comparison_run_id TEXT, created_at TEXT NOT NULL, duration_s REAL
-)
-"""
-
-
-@pytest.fixture
-async def eval_db(db):
-    await db.execute(_EVAL_RUNS_DDL)
-    await db.commit()
-    return db
+# `eval_db` fixture is provided by tests/test_experimentation/conftest.py.
 
 
 def _result():

--- a/tests/test_experimentation/test_runner.py
+++ b/tests/test_experimentation/test_runner.py
@@ -1,0 +1,149 @@
+"""Tests for the reflection-prompt A/B runner (stubbed gen + judge — no API).
+
+Proves the runner's score aggregation, error handling, limit, validation, and
+that control-vs-treatment is decided on the continuous judge score.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from genesis.experimentation.runner import _extract_reflection_text, run_reflection_experiment
+from genesis.experimentation.types import CognitiveVariant
+
+
+class _StubGenRouter:
+    """Returns a 'good' reflection when the system prompt contains REAL, else weak."""
+
+    async def route_call(self, call_site_id, messages, **kwargs):
+        system = messages[0]["content"]
+        if "REAL" in system:
+            content = '{"observations": ["a specific grounded actionable insight about the scheduler"]}'
+        else:
+            content = '{"observations": ["vague thing"]}'
+        return SimpleNamespace(success=True, content=content, error=None)
+
+    async def close(self):
+        pass
+
+
+class _FailGenRouter:
+    async def route_call(self, call_site_id, messages, **kwargs):
+        return SimpleNamespace(success=False, content=None, error="boom")
+
+    async def close(self):
+        pass
+
+
+class _StubJudge:
+    """High score for the 'specific' (control) output, low for the weak one."""
+
+    async def score_async(self, actual, expected, config):
+        if "specific" in actual:
+            return True, 0.8, "{}"
+        return False, 0.1, "{}"
+
+
+def _write_golden(tmp_path, n):
+    path = tmp_path / "golden.jsonl"
+    lines = [
+        json.dumps(
+            {
+                "id": f"case_{i}",
+                "actual": "original reflection text",
+                "user_passed": True,
+                "expected": "deep_reflection_observation",
+                "scorer_config": {
+                    "rubric_name": "reflection_quality",
+                    "session_context": f"signals for tick {i}",
+                },
+            }
+        )
+        for i in range(n)
+    ]
+    path.write_text("\n".join(lines))
+    return path
+
+
+def _variants():
+    return (
+        CognitiveVariant(name="real", system_prompt="REAL deep reflection prompt"),
+        CognitiveVariant(name="weak", system_prompt="weak prompt"),
+    )
+
+
+async def test_control_wins_on_score(tmp_path):
+    golden = _write_golden(tmp_path, 6)
+    control, treatment = _variants()
+    res = await run_reflection_experiment(
+        experiment_name="t",
+        control=control,
+        treatment=treatment,
+        golden_set_path=golden,
+        gen_router=_StubGenRouter(),
+        judge=_StubJudge(),
+    )
+    assert res.errors == 0
+    assert res.control.mean_score == pytest.approx(0.8)
+    assert res.treatment.mean_score == pytest.approx(0.1)
+    assert res.winrate["n_control_wins"] == 6
+    assert res.winrate["significant"] is True
+    assert res.winrate["recommendation"] == "control_wins"
+    # binary pass/fail context agrees (control passes, treatment fails every case)
+    assert res.control.n_pass == 6
+    assert res.treatment.n_pass == 0
+    assert res.metadata["pass_winrate"]["recommendation"] == "control_wins"
+
+
+async def test_generation_failure_degrades_to_insufficient(tmp_path):
+    golden = _write_golden(tmp_path, 4)
+    control, treatment = _variants()
+    res = await run_reflection_experiment(
+        experiment_name="t",
+        control=control,
+        treatment=treatment,
+        golden_set_path=golden,
+        gen_router=_FailGenRouter(),
+        judge=_StubJudge(),
+    )
+    assert res.errors == 8  # 4 cases x 2 arms, all generation failures
+    assert res.control.mean_score == 0.0
+    assert res.winrate["recommendation"] == "insufficient_data"
+
+
+async def test_limit_truncates_cases(tmp_path):
+    golden = _write_golden(tmp_path, 10)
+    control, treatment = _variants()
+    res = await run_reflection_experiment(
+        experiment_name="t",
+        control=control,
+        treatment=treatment,
+        golden_set_path=golden,
+        limit=3,
+        gen_router=_StubGenRouter(),
+        judge=_StubJudge(),
+    )
+    assert res.n_cases == 3
+    assert len(res.control.case_scores) == 3
+
+
+async def test_missing_system_prompt_raises(tmp_path):
+    golden = _write_golden(tmp_path, 2)
+    with pytest.raises(ValueError, match="system_prompt"):
+        await run_reflection_experiment(
+            experiment_name="t",
+            control=CognitiveVariant(name="a", system_prompt=None),
+            treatment=CognitiveVariant(name="b", system_prompt="weak"),
+            golden_set_path=golden,
+            gen_router=_StubGenRouter(),
+            judge=_StubJudge(),
+        )
+
+
+def test_extract_reflection_text():
+    assert _extract_reflection_text('{"observations": ["a", "b"]}') == "a\nb"
+    assert _extract_reflection_text('prose {"observations": ["x"]} tail') == "x"
+    assert _extract_reflection_text('{"cognitive_state_update": "state"}') == "state"
+    assert _extract_reflection_text("not json at all") == "not json at all"
+    assert _extract_reflection_text("") == ""

--- a/tests/test_experimentation/test_standalone_router.py
+++ b/tests/test_experimentation/test_standalone_router.py
@@ -1,0 +1,134 @@
+"""Tests for the offline StandaloneLiteLLMRouter (stubbed delegate — no API).
+
+Covers the logic the live E2E doesn't exercise deterministically: provider
+lookup + ``ValueError`` on an unknown provider, the retryable-vs-non-retryable
+retry loop, ``StandaloneRoutingResult`` construction, and the ``_ensure_secrets``
+side-call. ``asyncio.sleep`` and ``_ensure_secrets`` are patched so the suite is
+hermetic and fast (no real backoff wait, no dependence on secrets.env).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from genesis.experimentation import standalone_router as sr
+from genesis.experimentation.standalone_router import StandaloneLiteLLMRouter
+
+
+@pytest.fixture(autouse=True)
+def _patch_secrets(monkeypatch):
+    """Replace the secrets.env loader with a counter — hermetic + assertable."""
+    calls = {"n": 0}
+
+    def _fake():
+        calls["n"] += 1
+
+    monkeypatch.setattr("genesis.eval.reflection_golden_set._ensure_secrets", _fake)
+    return calls
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Skip the real exponential backoff so retry tests don't wait seconds."""
+
+    async def _noop(_delay):
+        return None
+
+    monkeypatch.setattr(sr.asyncio, "sleep", _noop)
+
+
+def _config(model_id="groq/llama-test"):
+    return SimpleNamespace(providers={"groq-free": SimpleNamespace(model_id=model_id)})
+
+
+class _StubDelegate:
+    """Returns a scripted sequence of results, one per ``call`` invocation."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.calls = []
+
+    async def call(self, *, provider, model_id, messages, **kwargs):
+        self.calls.append({"provider": provider, "model_id": model_id, "messages": messages})
+        idx = min(len(self.calls) - 1, len(self._results) - 1)
+        return self._results[idx]
+
+
+def _result(success, content=None, error=None):
+    return SimpleNamespace(success=success, content=content, error=error)
+
+
+def test_unknown_provider_raises_with_available(_patch_secrets):
+    with pytest.raises(ValueError, match="unknown provider"):
+        StandaloneLiteLLMRouter("does-not-exist", config=_config(), delegate=_StubDelegate([]))
+    # The constructor must still load secrets before the lookup failure path.
+    assert _patch_secrets["n"] == 1
+
+
+def test_init_pulls_model_id_and_calls_ensure_secrets(_patch_secrets):
+    router = StandaloneLiteLLMRouter(
+        "groq-free", config=_config("groq/m"), delegate=_StubDelegate([]),
+    )
+    assert router._model_id == "groq/m"
+    assert router._provider_name == "groq-free"
+    assert _patch_secrets["n"] == 1
+
+
+async def test_route_call_success():
+    delegate = _StubDelegate([_result(True, content="hello")])
+    router = StandaloneLiteLLMRouter("groq-free", config=_config("groq/m"), delegate=delegate)
+
+    res = await router.route_call("gen", [{"role": "user", "content": "hi"}])
+
+    assert res.success is True
+    assert res.content == "hello"
+    assert res.model_id == "groq/m"
+    assert res.provider_used == "groq-free"
+    assert res.error is None
+    assert len(delegate.calls) == 1
+    assert delegate.calls[0]["provider"] == "groq-free"
+    assert delegate.calls[0]["model_id"] == "groq/m"
+
+
+async def test_route_call_retries_retryable_then_succeeds():
+    delegate = _StubDelegate([
+        _result(False, error="Rate limit exceeded (429)"),
+        _result(True, content="recovered"),
+    ])
+    router = StandaloneLiteLLMRouter("groq-free", config=_config(), delegate=delegate)
+
+    res = await router.route_call("gen", [])
+
+    assert res.success is True
+    assert res.content == "recovered"
+    assert len(delegate.calls) == 2  # one retry consumed
+
+
+async def test_route_call_does_not_retry_non_retryable():
+    delegate = _StubDelegate([
+        _result(False, error="Authentication failed: invalid api key"),
+        _result(True, content="should-not-be-reached"),
+    ])
+    router = StandaloneLiteLLMRouter("groq-free", config=_config(), delegate=delegate)
+
+    res = await router.route_call("gen", [])
+
+    assert res.success is False
+    assert res.error == "Authentication failed: invalid api key"
+    assert res.provider_used == "groq-free"
+    assert len(delegate.calls) == 1  # no retry on a non-retryable error
+
+
+async def test_route_call_exhausts_retries():
+    delegate = _StubDelegate([_result(False, error="503 overloaded")] * 5)
+    router = StandaloneLiteLLMRouter("groq-free", config=_config(), delegate=delegate)
+
+    res = await router.route_call("gen", [])
+
+    assert res.success is False
+    assert len(delegate.calls) == sr._MAX_RETRIES + 1  # initial + all retries
+
+
+async def test_close_is_noop():
+    router = StandaloneLiteLLMRouter("groq-free", config=_config(), delegate=_StubDelegate([]))
+    await router.close()  # must not raise

--- a/tests/test_experimentation/test_weight_divergence.py
+++ b/tests/test_experimentation/test_weight_divergence.py
@@ -1,0 +1,76 @@
+"""Tests for the Target-2 weight-divergence report (flip-counting logic).
+
+compute_scores is stubbed here — the real scorer + weights_override integration
+is covered by tests/test_awareness/test_scorer.py. This isolates the divergence
+module's flip/gain/lost accounting.
+"""
+
+import json
+
+import pytest
+
+from genesis.awareness.types import Depth, DepthScore
+from genesis.experimentation.weight_divergence import weight_divergence
+
+
+def _ds(depth: Depth, triggered: bool) -> DepthScore:
+    return DepthScore(
+        depth=depth, raw_score=0.0, time_multiplier=1.0,
+        final_score=0.0, threshold=0.5, triggered=triggered,
+    )
+
+
+async def _insert_ticks(db, n):
+    sig = json.dumps([{"name": "sig_a", "value": 0.4, "source": "x", "collected_at": "2026-01-01T00:00:00+00:00"}])
+    for i in range(n):
+        await db.execute(
+            """INSERT INTO awareness_ticks
+               (id, source, signals_json, scores_json, classified_depth,
+                trigger_reason, created_at, dispatched)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (f"tick_{i}", "scheduled", sig, "[]", "Micro", "test",
+             f"2026-01-{i + 1:02d}T00:00:00+00:00", 0),
+        )
+    await db.commit()
+
+
+async def test_divergence_counts_flips_and_gains(db, monkeypatch):
+    await _insert_ticks(db, 3)
+
+    async def fake_compute(dbc, signals, *, now=None, weights_override=None):
+        # Under the variant weights, Light additionally triggers (Micro always on).
+        if weights_override:
+            return [_ds(Depth.MICRO, True), _ds(Depth.LIGHT, True)]
+        return [_ds(Depth.MICRO, True), _ds(Depth.LIGHT, False)]
+
+    monkeypatch.setattr(
+        "genesis.experimentation.weight_divergence.compute_scores", fake_compute,
+    )
+
+    out = await weight_divergence(db, signal_weight_overrides={"sig_a": 5.0}, limit=10)
+    assert out["n_ticks"] == 3
+    assert out["n_flipped"] == 3
+    assert out["flip_rate"] == 1.0
+    assert out["depths_gained"] == {"Light": 3}
+    assert out["depths_lost"] == {}
+    assert out["n_skipped"] == 0
+
+
+async def test_divergence_no_flip_when_identical(db, monkeypatch):
+    await _insert_ticks(db, 2)
+
+    async def fake_compute(dbc, signals, *, now=None, weights_override=None):
+        return [_ds(Depth.MICRO, True), _ds(Depth.LIGHT, False)]
+
+    monkeypatch.setattr(
+        "genesis.experimentation.weight_divergence.compute_scores", fake_compute,
+    )
+
+    out = await weight_divergence(db, signal_weight_overrides={"sig_a": 5.0}, limit=10)
+    assert out["n_flipped"] == 0
+    assert out["flip_rate"] == 0.0
+
+
+async def test_divergence_empty_override_raises(db):
+    with pytest.raises(ValueError, match="non-empty"):
+        await weight_divergence(db, signal_weight_overrides={}, limit=10)

--- a/tests/test_experimentation/test_weight_divergence.py
+++ b/tests/test_experimentation/test_weight_divergence.py
@@ -37,7 +37,7 @@ async def _insert_ticks(db, n):
 async def test_divergence_counts_flips_and_gains(db, monkeypatch):
     await _insert_ticks(db, 3)
 
-    async def fake_compute(dbc, signals, *, now=None, weights_override=None):
+    async def fake_compute(dbc, signals, *, now=None, weights_override=None, decay_factors=None):
         # Under the variant weights, Light additionally triggers (Micro always on).
         if weights_override:
             return [_ds(Depth.MICRO, True), _ds(Depth.LIGHT, True)]
@@ -59,7 +59,7 @@ async def test_divergence_counts_flips_and_gains(db, monkeypatch):
 async def test_divergence_no_flip_when_identical(db, monkeypatch):
     await _insert_ticks(db, 2)
 
-    async def fake_compute(dbc, signals, *, now=None, weights_override=None):
+    async def fake_compute(dbc, signals, *, now=None, weights_override=None, decay_factors=None):
         return [_ds(Depth.MICRO, True), _ds(Depth.LIGHT, False)]
 
     monkeypatch.setattr(
@@ -74,3 +74,26 @@ async def test_divergence_no_flip_when_identical(db, monkeypatch):
 async def test_divergence_empty_override_raises(db):
     with pytest.raises(ValueError, match="non-empty"):
         await weight_divergence(db, signal_weight_overrides={}, limit=10)
+
+
+async def test_replay_does_not_mutate_live_staleness(db):
+    """The replay path (decay_factors=) must NOT touch the live awareness loop's
+    module-level staleness counters — the code-review P2 fix."""
+    import contextlib
+
+    from genesis.awareness import scorer
+    from genesis.awareness.types import SignalReading
+
+    signals = [SignalReading(name="x", value=0.5, source="replay", collected_at="")]
+
+    # Replay path: decay_factors provided -> _update_staleness is bypassed.
+    scorer._signal_unchanged_counts.clear()
+    with contextlib.suppress(Exception):  # missing seeded thresholds is fine
+        await scorer.compute_scores(db, signals, decay_factors={})
+    assert scorer._signal_unchanged_counts == {}, "replay must not mutate live staleness"
+
+    # Contrast — the live path (decay_factors=None) DOES update the counters.
+    scorer._signal_unchanged_counts.clear()
+    with contextlib.suppress(Exception):
+        await scorer.compute_scores(db, signals)
+    assert "x" in scorer._signal_unchanged_counts, "live path updates staleness as before"


### PR DESCRIPTION
## Phase 7 — Cognitive Experimentation Harness

Offline A/B testing of Genesis's **own** cognitive configs (reflection prompts, awareness weights) against golden sets, with paired significance, judge-gaming guards, and a promotion **recommendation the human acts on**. **Recommend-only** — nothing is promoted autonomously, and nothing writes to live cognition.

### What's in it
- **Engine (Target-1)** — `experimentation/runner.py` + `eval/stats.py`. A/Bs two reflection-*prompt* variants over the calibrated `reflection_quality` golden set. "Deep-direct" render (loads `REFLECTION_DEEP.md` + each case's session context, generates via a standalone litellm path, judges via the existing `LLMJudgeScorer`); it **never** touches the live reflection loop (no observation/memory/DB-cognition writes). Decided on the **continuous judge score** via pure-stdlib **McNemar exact** (no scipy) — offline single-shot reflections score uniformly low, so a fixed pass/fail threshold collapses the signal.
- **Target-2** — `experimentation/weight_divergence.py`. Replays historical awareness ticks under baseline vs an overridden signal weight (additive `compute_scores(weights_override=...)`, default-`None` byte-identical) and reports how many depth decisions *flip*. An impact report, not a win-rate (no ground-truth "correct depth").
- **Persistence** — two linked `eval_runs` rows (reuse `comparison_run_id` + `metadata_json`; **no migration**; new `EvalTrigger.EXPERIMENT`).
- **`experiment_status` MCP** — read-only; surfaces control/treatment scores + win-rate + recommendation; `autonomous_action` is always `False`.
- **Dark drift** — a 6th weekly `j9_aggregator` dimension (`dimension="cognitive_drift"`, no migration): dissent-rate, alternative-rate, and normalized entropy over `ego_proposals.action_type`. Dark (no cognitive reader) — the baseline for future personality-drift gates.
- **Judge-hack guards** — `experimentation/guards.py`: rubric-version pin, calibration-required (≥0.80 agreement gate), and a held-out second judge (`judge_overfit` flag).

### Verification
- 198 targeted tests green (`tests/test_experimentation/`, `tests/test_eval/test_stats.py`, `test_cognitive_drift.py`); awareness scorer suite unchanged (27/27); ruff clean.
- `feature-dev:code-reviewer`: **no P1**; 2 P2s fixed — including a real one (the weight replay was double-mutating the live awareness staleness counters; fixed via a `decay_factors` bypass + a proving test).
- Recommend-only + no-cognition-writes confirmed by review (grep-proven: no autonomous `signal_weights`/observation/promotion write).
- Live single-case proof: the real deep prompt scored **0.82 (pass)** vs a deliberately-weak prompt **0.05** — the engine detects real quality on live calls. The **full multi-case live A/B is pending a judge endpoint with headroom** (free-tier judges were rate-limited during the build); the harness degrades cleanly to `insufficient_data` when generation/judging is unavailable.

### No migration / no new tables
Reuses `eval_runs` (+ the never-populated `comparison_run_id`) and the `eval_snapshots.dimension` free-text column. No routing call sites added.

### Deferred (follow-ups)
Live shadow/holdout by the Outcome Bus (underpowered today); auto-promotion + auto-rollback; personality-drift **gates** (self-silencing, exploration-floor); Micro/Light golden sets; per-case `eval_results` persistence; folding the calibration CLI's private litellm router onto the shared standalone router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
