### PR TITLE
fix(reflection): fresh calibration row per cycle + honest str return

### DIFF
--- a/src/genesis/reflection/output_router.py
+++ b/src/genesis/reflection/output_router.py
@@ -566,7 +566,12 @@ class OutputRouter:
             "self-assessment", content, output.overall_score,
         )
 
-        return obs_id
+        # `_write_observation` returns None when this week's content hashes
+        # identically to an existing unresolved row (content-hash dedup). Honor
+        # the `-> str` contract / "empty string on failure" docstring rather than
+        # leaking None to callers. (No supersession here: self_assessment is a
+        # historical ledger the maturity-cohort metric reads — see #725.)
+        return obs_id or ""
 
     async def route_calibration(
         self, output: QualityCalibrationOutput, db: aiosqlite.Connection,
@@ -585,19 +590,27 @@ class OutputRouter:
 
         obs_type = "quality_drift" if output.drift_detected else "quality_calibration"
 
-        # Supersede any prior unresolved quality_drift BEFORE writing this
-        # cycle's result (never after — resolve_by_source_and_type resolves ALL
-        # unresolved matches, so resolving after would bury the row we just
-        # wrote). Resolving regardless of the new type means a clean (non-drift)
-        # calibration also clears a standing drift alarm (resolve-on-recovery),
-        # and a fresh drift replaces the previous one instead of stacking.
-        await observations.resolve_by_source_and_type(
-            db,
-            source="quality_calibration",
-            type="quality_drift",
-            resolved_at=datetime.now(UTC).isoformat(),
-            resolution_notes="superseded by newer quality calibration",
-        )
+        # Supersede BOTH prior unresolved calibration outputs (quality_drift AND
+        # quality_calibration) BEFORE writing this cycle's result — never after,
+        # since resolve_by_source_and_type resolves ALL unresolved matches and
+        # would bury the row we just wrote. Resolving both types means:
+        #   • a clean (non-drift) calibration clears a standing drift alarm
+        #     (resolve-on-recovery), and a fresh drift replaces the previous one
+        #     instead of stacking (the original #728 behaviour); and
+        #   • each cycle always writes a *fresh* row — the prior identical
+        #     calibration is resolved first, so content-hash dedup can't suppress
+        #     this week's write. Without this, an unchanged week would dedup to
+        #     no new row, and scheduler._already_ran_this_week (which looks for a
+        #     this-week row) would miss the run and could re-trigger it.
+        now_iso = datetime.now(UTC).isoformat()
+        for prior_type in ("quality_drift", "quality_calibration"):
+            await observations.resolve_by_source_and_type(
+                db,
+                source="quality_calibration",
+                type=prior_type,
+                resolved_at=now_iso,
+                resolution_notes="superseded by newer quality calibration",
+            )
 
         content = json.dumps({
             "drift_detected": output.drift_detected,
@@ -616,7 +629,11 @@ class OutputRouter:
             drift=output.drift_detected,
         )
 
-        return obs_id
+        # Honor the `-> str` contract on the dedup path where `_write_observation`
+        # returns None. Supersession above makes that path structurally
+        # unreachable on the normal single-writer path (the prior identical row is
+        # always resolved first), so this is a defensive guard, not a hot path.
+        return obs_id or ""
 
     # ── Private helpers ───────────────────────────────────────────────
 

--- a/tests/test_reflection/test_output_router.py
+++ b/tests/test_reflection/test_output_router.py
@@ -246,6 +246,25 @@ class TestRouteAssessment:
         md_files = glob.glob(str(tmp_path / "reflections" / "**" / "*.md"), recursive=True)
         assert len(md_files) == 1
 
+    @pytest.mark.asyncio
+    async def test_returns_empty_string_on_dedup(self, db, router):
+        """self_assessment has no supersession (it's a historical ledger the
+        maturity-cohort metric reads), so an identical assessment two cycles
+        running genuinely content-hash dedups. route_assessment must honor its
+        `-> str` contract and return '' — never leak None to callers."""
+        output = WeeklyAssessmentOutput(overall_score=0.8, observations=["steady"])
+        first = await router.route_assessment(output, db)
+        second = await router.route_assessment(output, db)
+
+        assert first          # real id on first write
+        assert second == ""   # deduped → empty string, NOT None
+
+        # Ledger semantics preserved: still exactly one self_assessment row.
+        rows = (await (await db.execute(
+            "SELECT count(*) FROM observations WHERE type='self_assessment'"
+        )).fetchone())[0]
+        assert rows == 1
+
 
 class TestRouteCalibration:
     @pytest.mark.asyncio
@@ -303,6 +322,47 @@ class TestRouteCalibration:
             "WHERE type='quality_drift' AND resolved=0"
         )).fetchone())[0]
         assert unresolved == 1
+
+    @pytest.mark.asyncio
+    async def test_unchanged_clean_calibration_writes_fresh_row(self, db, router):
+        """An unchanged (byte-identical) clean calibration two cycles running must
+        still write a *fresh* this-week row. The prior identical row is superseded
+        first, so content-hash dedup can't suppress the write and leave the weekly
+        scheduler guard (_already_ran_this_week, which looks for a this-week row)
+        unable to see the run. Returns a real id both times, never None."""
+        output = QualityCalibrationOutput(drift_detected=False, observations=["all good"])
+        first = await router.route_calibration(output, db)
+        second = await router.route_calibration(output, db)
+
+        # Contract: a real id both times; the second is a genuinely new row.
+        assert first
+        assert second
+        assert second != first
+
+        # Exactly one UNRESOLVED quality_calibration row (the latest); the prior
+        # identical one was resolved (superseded), not deduped into oblivion.
+        unresolved = (await (await db.execute(
+            "SELECT count(*) FROM observations "
+            "WHERE type='quality_calibration' AND resolved=0"
+        )).fetchone())[0]
+        assert unresolved == 1
+        total = (await (await db.execute(
+            "SELECT count(*) FROM observations WHERE type='quality_calibration'"
+        )).fetchone())[0]
+        assert total == 2
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_string_when_write_dedups(self, db, router):
+        """If `_write_observation` ever dedups to None (a path supersession makes
+        structurally unreachable on the normal single-writer path), route_calibration
+        still honors its `-> str` contract. Mocked to test the guard in isolation."""
+        from unittest.mock import AsyncMock
+
+        router._write_observation = AsyncMock(return_value=None)
+        result = await router.route_calibration(
+            QualityCalibrationOutput(drift_detected=False), db,
+        )
+        assert result == ""
 
 
 # ── Reflection summary embedding tests ────────────────────────────────


### PR DESCRIPTION
## What

A small, focused fix to the weekly quality-calibration routing (`reflection/output_router.py`), follow-up to the #728 alarm-lifecycle work.

**Two coupled issues, both pre-existing:**

1. **Contract bug.** `route_calibration` and `route_assessment` are typed `-> str` with docstrings promising "observation ID or empty string on failure," but `_write_observation` returns `None` on a content-hash dedup hit — so both could leak `None`.
2. **The dedup quirk.** On the non-drift path, an unchanged week's byte-identical JSON deduped to no new row, so `scheduler._already_ran_this_week('quality_calibration')` (which looks for a *this-week* row) could miss the run and re-trigger the weekly calibration on a restart-catchup.

## The fix

- `route_calibration` / `route_assessment`: `return obs_id or ""` — honor the `-> str` contract (the docstrings were already promising this; they were just untrue).
- `route_calibration`: extend #728's supersede-before-write to **both** `quality_drift` *and* `quality_calibration`. The prior identical row is resolved first, so the new write is never deduped against an unresolved row → a fresh this-week row is always written and the scheduler guard sees the run.
- **Not** applied to `route_assessment`: `self_assessment` is a historical ledger the #725 maturity-cohort metric reads, so resolving old rows would corrupt the trend record.

## Why it's safe

- `_write_observation`'s shared semantics are unchanged; the only two non-test callers (in the reflection bridge) discard the return value.
- `quality_calibration` carries a 14-day TTL (state, not a ledger) and is excluded from L1 essential-knowledge; the only recency-reader is the scheduler guard this repairs. The new row is written *after* the resolve, so it still surfaces normally.

## Verification

- 45 targeted tests pass (3 new: assessment dedup→`""`; unchanged calibration writes a fresh row; calibration contract guard). Existing #728 supersession tests unaffected.
- **E2E against the real scheduler guard:** seeded a prior-week unresolved row + ran an identical clean cycle → prior row superseded, fresh this-week row written, `_already_ran_this_week('quality_calibration')` returns `True` (no false re-trigger).

## Deferred (follow-up)

A deeper idempotency-guard hardening — the drift-week type mismatch (guard checks `quality_calibration` but a drift week writes `quality_drift`) and switching the guard to the authoritative `job_health.last_run` — is tracked separately to keep this PR surgical.

No CHANGELOG entry: internal robustness/contract fix with no observable behavior change in normal operation.