### PR TITLE
fix(voice): scope "approve" to a named pending action (WS-8 / D5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,11 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   healthy and actively running cycles. The ego now sends a steady "alive" check-in every few
   minutes, independent of its work pace, so its health status reflects reality.
 
+- **Voice approvals now resolve the action you actually mean** — when you say "approve" or
+  "reject" over voice, Genesis tells you which action it acted on, and if more than one action is
+  awaiting your decision it reads the options back and asks which one — instead of silently
+  resolving whichever was most recent (which could be the wrong one).
+
 - **Stale "quality drift" and "learning regression" alarms no longer linger or cry wolf** — when
   Genesis's weekly self-checks flagged a quality drift or a learning regression, that flag stayed
   active until it expired days later, so the morning report kept repeating a days-old warning as if

--- a/src/genesis/autonomy/approval_gate.py
+++ b/src/genesis/autonomy/approval_gate.py
@@ -41,6 +41,16 @@ def _context_dump(data: dict[str, Any]) -> str:
     return json.dumps(data, sort_keys=True)
 
 
+def _voice_action_label(req: dict[str, Any]) -> str:
+    """A short, speakable label for a pending approval (voice read-back)."""
+    desc = str(req.get("description") or "").strip()
+    if desc:
+        return desc[:120]
+    ctx = _json_loads(req.get("context"))
+    label = ctx.get("action_label") or req.get("action_type") or "a pending action"
+    return str(label)[:120]
+
+
 def _approval_key(
     *,
     subsystem: str,
@@ -106,6 +116,13 @@ async def _is_timed_out(row: dict[str, Any], approval_manager: Any) -> bool:
 
 class AutonomousCliApprovalGate:
     """Manual-approval gate for autonomous CLI fallback dispatch."""
+
+    # Approval types a voice "approve"/"reject" is allowed to resolve.
+    _VOICE_GATED_TYPES = frozenset({
+        "autonomous_cli_fallback",
+        "sentinel_dispatch",
+        "sentinel_action",
+    })
 
     def __init__(
         self,
@@ -375,48 +392,81 @@ class AutonomousCliApprovalGate:
             return request_id
         return None
 
-    async def resolve_most_recent_pending_voice(
-        self, *, decision: str, resolved_by: str,
-    ) -> str | None:
-        """Resolve the most-recent pending approval of ANY gated type.
+    async def pending_voice_actions(self) -> list[dict[str, str]]:
+        """Voice-gated pending approvals, oldest->newest.
 
-        Unlike :meth:`resolve_most_recent_pending` (which is intentionally
-        narrow to ``autonomous_cli_fallback`` for Telegram bare-text safety),
-        this method resolves sentinel_dispatch, sentinel_action, AND
-        autonomous_cli_fallback.  Appropriate for voice where the user
-        explicitly said "approve it" in response to a spoken notification.
+        Each item is ``{id, action_type, label}`` where *label* is a short
+        spoken-readback string.  Used to disambiguate when more than one
+        approval is pending and to let the caller read back what it resolved.
+        """
+        pending = await self._approval_manager.get_pending()
+        return [
+            {
+                "id": str(req["id"]),
+                "action_type": str(req.get("action_type") or ""),
+                "label": _voice_action_label(req),
+            }
+            for req in pending
+            if req.get("action_type") in self._VOICE_GATED_TYPES
+        ]
+
+    async def resolve_pending_voice(
+        self,
+        *,
+        decision: str,
+        resolved_by: str,
+        request_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Resolve a voice-gated pending approval, bound to a NAMED action.
+
+        Returns a structured result so the voice layer can read back what it
+        did and ask the user to disambiguate when needed:
+
+        - ``{"status": "resolved", "request_id": id, "label": label}``
+        - ``{"status": "none"}``        -- nothing pending
+        - ``{"status": "not_found"}``   -- *request_id* isn't a pending voice-gated request
+        - ``{"status": "ambiguous", "candidates": [{id, label}, ...]}``
+          -- more than one pending and no *request_id* given
+        - ``{"status": "invalid_decision"}``
+
+        When *request_id* is None this resolves ONLY when exactly one
+        voice-gated approval is pending.  With several pending it refuses to
+        guess -- the previous behaviour silently resolved the most-recent one,
+        which could be the wrong action.
         """
         if decision not in ("approved", "rejected"):
-            logger.warning(
-                "resolve_most_recent_pending_voice: invalid decision %r",
-                decision,
-            )
-            return None
-        _VOICE_GATED = {
-            "autonomous_cli_fallback",
-            "sentinel_dispatch",
-            "sentinel_action",
-        }
-        pending = await self._approval_manager.get_pending()
-        candidates = [
-            req for req in pending
-            if req.get("action_type") in _VOICE_GATED
-        ]
+            logger.warning("resolve_pending_voice: invalid decision %r", decision)
+            return {"status": "invalid_decision"}
+
+        candidates = await self.pending_voice_actions()
         if not candidates:
-            return None
-        most_recent = candidates[-1]
-        request_id = str(most_recent["id"])
-        ok = await self._approval_manager.resolve(
-            request_id, status=decision, resolved_by=resolved_by,
-        )
-        if ok:
-            logger.info(
-                "Resolved most-recent approval %s (%s) as %s via %s",
-                request_id, most_recent.get("action_type"), decision,
-                resolved_by,
+            return {"status": "none"}
+
+        if request_id is not None:
+            target = next(
+                (c for c in candidates if c["id"] == str(request_id)), None,
             )
-            return request_id
-        return None
+            if target is None:
+                return {"status": "not_found"}
+        elif len(candidates) == 1:
+            target = candidates[0]
+        else:
+            return {"status": "ambiguous", "candidates": candidates}
+
+        ok = await self._approval_manager.resolve(
+            target["id"], status=decision, resolved_by=resolved_by,
+        )
+        if not ok:
+            return {"status": "not_found"}
+        logger.info(
+            "Resolved voice approval %s (%s) as %s via %s",
+            target["id"], target["action_type"], decision, resolved_by,
+        )
+        return {
+            "status": "resolved",
+            "request_id": target["id"],
+            "label": target["label"],
+        }
 
     async def approve_all_pending(self, *, resolved_by: str) -> int:
         """Approve every pending approval request.  Returns count approved."""
@@ -582,11 +632,10 @@ class AutonomousCliApprovalGate:
         Used by ``_send_request`` to decide whether to include the
         "✅✅ Approve all N pending" batch button in the inline keyboard.
         """
-        _GATED_TYPES = {"autonomous_cli_fallback", "sentinel_dispatch", "sentinel_action"}
         pending = await self._approval_manager.get_pending()
         return sum(
             1 for req in pending
-            if req.get("action_type") in _GATED_TYPES
+            if req.get("action_type") in self._VOICE_GATED_TYPES
         )
 
     async def _maybe_resend(

--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -58,8 +58,8 @@ TOOL_DECLARATIONS = [
         "description": (
             "Approve or reject a pending action that requires user confirmation. "
             "Call this when the user says 'approve', 'yes go ahead', 'do it', "
-            "'reject it', or similar. Resolves the most recent pending request. "
-            "You do NOT need a request ID — just the decision."
+            "'reject it', or similar. If more than one action is pending you'll "
+            "be told the options; call again with the matching request_id."
         ),
         "parameters": {
             "type": "object",
@@ -68,6 +68,14 @@ TOOL_DECLARATIONS = [
                     "type": "string",
                     "enum": ["approved", "rejected"],
                     "description": "The user's decision",
+                },
+                "request_id": {
+                    "type": "string",
+                    "description": (
+                        "Which pending action to resolve. Omit when only one is "
+                        "pending; when several are, pass the id of the one the "
+                        "user chose."
+                    ),
                 },
             },
             "required": ["decision"],
@@ -118,7 +126,11 @@ decision "approved".
 - "reject it" / "reject that" / "don't do that" → call approve_pending with \
 decision "rejected". Note: a bare "no" in conversation is NOT a rejection — \
 only explicit rejection language like "reject" triggers this.
-- You don't need a request ID. The system resolves the most recent pending request.
+- After it resolves, tell the user in one short sentence what you approved or \
+rejected (the tool returns the action).
+- If the tool reports more than one action is pending, read the options back \
+and ask which one, then call approve_pending again with that request_id. \
+Never guess.
 
 {voice_context}
 """
@@ -157,7 +169,9 @@ class GenesisBridge:
         if name == "web_search":
             return await self._web_search(args.get("query", ""))
         if name == "approve_pending":
-            return await self._approve_pending(args.get("decision", ""))
+            return await self._approve_pending(
+                args.get("decision", ""), request_id=args.get("request_id"),
+            )
 
         return json.dumps({"error": f"Unknown tool: {name}"})
 
@@ -215,11 +229,14 @@ class GenesisBridge:
 
         return json.dumps({"error": "Web search unavailable"})
 
-    async def _approve_pending(self, decision: str) -> str:
-        """Approve or reject the most recent pending approval request.
+    async def _approve_pending(
+        self, decision: str, *, request_id: str | None = None,
+    ) -> str:
+        """Approve or reject a voice-gated pending approval.
 
-        Resolves sentinel_dispatch, sentinel_action, and
-        autonomous_cli_fallback types — all gated action types.
+        Binds to a specific request when *request_id* is given (or when only
+        one is pending); refuses to guess when several are pending and returns
+        the options so the model can ask the user which one.
         """
         if not self._approval_gate:
             return json.dumps({"error": "Approval system not available"})
@@ -227,18 +244,36 @@ class GenesisBridge:
             return json.dumps({"error": f"Invalid decision: {decision}"})
 
         try:
-            request_id = await self._approval_gate.resolve_most_recent_pending_voice(
-                decision=decision, resolved_by="voice:s2s",
+            result = await self._approval_gate.resolve_pending_voice(
+                decision=decision, resolved_by="voice:s2s", request_id=request_id,
             )
         except Exception:
             logger.exception("Voice approval failed")
             return json.dumps({"error": "Approval processing failed"})
 
-        if request_id:
+        status = result.get("status")
+        if status == "resolved":
             return json.dumps({
                 "result": f"Request {decision}",
-                "request_id": request_id[:8],
+                "action": result.get("label", ""),
+                "request_id": str(result.get("request_id", ""))[:8],
             })
+        if status == "ambiguous":
+            options = [
+                {"request_id": c["id"], "action": c["label"]}
+                for c in result.get("candidates", [])
+            ]
+            return json.dumps({
+                "needs_clarification": (
+                    "More than one action is pending. Ask the user which one, "
+                    "then call approve_pending again with its request_id."
+                ),
+                "pending": options,
+            })
+        if status == "not_found":
+            return json.dumps({"error": "That request is no longer pending"})
+        if status == "invalid_decision":
+            return json.dumps({"error": f"Invalid decision: {decision}"})
         return json.dumps({"error": "No pending approval request found"})
 
     def get_system_prompt(self) -> str:

--- a/tests/test_autonomy/test_approval.py
+++ b/tests/test_autonomy/test_approval.py
@@ -159,3 +159,118 @@ async def test_event_emitted_on_request(db):
     mgr = ApprovalManager(db=db, event_bus=event_bus)
     await _create_request(mgr)
     event_bus.emit.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# Voice-gated approval resolution (AutonomousCliApprovalGate)
+# ------------------------------------------------------------------
+
+
+def _voice_gate(mgr):
+    from genesis.autonomy.approval_gate import AutonomousCliApprovalGate
+
+    return AutonomousCliApprovalGate(runtime=MagicMock(), approval_manager=mgr)
+
+
+@pytest.mark.asyncio
+async def test_resolve_pending_voice_single(db):
+    mgr = ApprovalManager(db=db)
+    rid = await _create_request(
+        mgr, action_type="sentinel_dispatch", description="investigate the thing",
+    )
+    gate = _voice_gate(mgr)
+    result = await gate.resolve_pending_voice(
+        decision="approved", resolved_by="voice:s2s",
+    )
+    assert result["status"] == "resolved"
+    assert result["request_id"] == rid
+    assert result["label"] == "investigate the thing"
+    assert (await mgr.get_by_id(rid))["status"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_resolve_pending_voice_by_id(db):
+    mgr = ApprovalManager(db=db)
+    rid1 = await _create_request(
+        mgr, action_type="sentinel_dispatch", description="a",
+    )
+    rid2 = await _create_request(
+        mgr, action_type="autonomous_cli_fallback", description="b",
+    )
+    gate = _voice_gate(mgr)
+    result = await gate.resolve_pending_voice(
+        decision="approved", resolved_by="voice:s2s", request_id=rid2,
+    )
+    assert result["status"] == "resolved"
+    assert result["request_id"] == rid2
+    assert (await mgr.get_by_id(rid1))["status"] == "pending"
+    assert (await mgr.get_by_id(rid2))["status"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_resolve_pending_voice_ambiguous_resolves_nothing(db):
+    mgr = ApprovalManager(db=db)
+    rid1 = await _create_request(
+        mgr, action_type="sentinel_dispatch", description="a",
+    )
+    rid2 = await _create_request(
+        mgr, action_type="sentinel_action", description="b",
+    )
+    gate = _voice_gate(mgr)
+    result = await gate.resolve_pending_voice(
+        decision="approved", resolved_by="voice:s2s",
+    )
+    assert result["status"] == "ambiguous"
+    assert {c["id"] for c in result["candidates"]} == {rid1, rid2}
+    # Neither was resolved — refuses to guess.
+    assert (await mgr.get_by_id(rid1))["status"] == "pending"
+    assert (await mgr.get_by_id(rid2))["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_resolve_pending_voice_none(db):
+    mgr = ApprovalManager(db=db)
+    gate = _voice_gate(mgr)
+    result = await gate.resolve_pending_voice(
+        decision="approved", resolved_by="voice:s2s",
+    )
+    assert result["status"] == "none"
+
+
+@pytest.mark.asyncio
+async def test_resolve_pending_voice_not_found(db):
+    mgr = ApprovalManager(db=db)
+    await _create_request(
+        mgr, action_type="sentinel_dispatch", description="a",
+    )
+    gate = _voice_gate(mgr)
+    result = await gate.resolve_pending_voice(
+        decision="approved", resolved_by="voice:s2s", request_id="does-not-exist",
+    )
+    assert result["status"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_resolve_pending_voice_invalid_decision(db):
+    mgr = ApprovalManager(db=db)
+    gate = _voice_gate(mgr)
+    result = await gate.resolve_pending_voice(
+        decision="maybe", resolved_by="voice:s2s",
+    )
+    assert result["status"] == "invalid_decision"
+
+
+@pytest.mark.asyncio
+async def test_pending_voice_actions_excludes_non_voice_types(db):
+    mgr = ApprovalManager(db=db)
+    await _create_request(
+        mgr, action_type="sentinel_dispatch", description="voice one",
+    )
+    await _create_request(
+        mgr, action_type="ego_proposal", description="not voice",
+    )
+    gate = _voice_gate(mgr)
+    actions = await gate.pending_voice_actions()
+    assert len(actions) == 1
+    assert actions[0]["action_type"] == "sentinel_dispatch"
+    assert actions[0]["label"] == "voice one"

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -173,7 +173,9 @@ class TestGenesisBridge:
 
     async def test_approve_pending_success(self):
         gate = AsyncMock()
-        gate.resolve_most_recent_pending_voice = AsyncMock(return_value="abc12345")
+        gate.resolve_pending_voice = AsyncMock(return_value={
+            "status": "resolved", "request_id": "abc12345", "label": "run tests",
+        })
 
         bridge = GenesisBridge(approval_gate=gate)
         result = await bridge.handle_tool_call(
@@ -182,13 +184,62 @@ class TestGenesisBridge:
         data = json.loads(result)
         assert "result" in data
         assert "approved" in data["result"]
-        gate.resolve_most_recent_pending_voice.assert_awaited_once_with(
-            decision="approved", resolved_by="voice:s2s",
+        assert data["action"] == "run tests"
+        gate.resolve_pending_voice.assert_awaited_once_with(
+            decision="approved", resolved_by="voice:s2s", request_id=None,
         )
+
+    async def test_approve_pending_by_id(self):
+        gate = AsyncMock()
+        gate.resolve_pending_voice = AsyncMock(return_value={
+            "status": "resolved", "request_id": "id-2", "label": "send email",
+        })
+
+        bridge = GenesisBridge(approval_gate=gate)
+        result = await bridge.handle_tool_call(
+            "approve_pending",
+            json.dumps({"decision": "approved", "request_id": "id-2"}),
+        )
+        data = json.loads(result)
+        assert "result" in data
+        gate.resolve_pending_voice.assert_awaited_once_with(
+            decision="approved", resolved_by="voice:s2s", request_id="id-2",
+        )
+
+    async def test_approve_pending_ambiguous_asks_which(self):
+        gate = AsyncMock()
+        gate.resolve_pending_voice = AsyncMock(return_value={
+            "status": "ambiguous",
+            "candidates": [
+                {"id": "id-1", "label": "run tests"},
+                {"id": "id-2", "label": "send email"},
+            ],
+        })
+
+        bridge = GenesisBridge(approval_gate=gate)
+        result = await bridge.handle_tool_call(
+            "approve_pending", json.dumps({"decision": "approved"}),
+        )
+        data = json.loads(result)
+        assert "needs_clarification" in data
+        assert {p["request_id"] for p in data["pending"]} == {"id-1", "id-2"}
+
+    async def test_approve_pending_not_found(self):
+        gate = AsyncMock()
+        gate.resolve_pending_voice = AsyncMock(return_value={"status": "not_found"})
+
+        bridge = GenesisBridge(approval_gate=gate)
+        result = await bridge.handle_tool_call(
+            "approve_pending",
+            json.dumps({"decision": "approved", "request_id": "gone"}),
+        )
+        data = json.loads(result)
+        assert "error" in data
+        assert "no longer pending" in data["error"]
 
     async def test_approve_pending_no_pending(self):
         gate = AsyncMock()
-        gate.resolve_most_recent_pending_voice = AsyncMock(return_value=None)
+        gate.resolve_pending_voice = AsyncMock(return_value={"status": "none"})
 
         bridge = GenesisBridge(approval_gate=gate)
         result = await bridge.handle_tool_call(
@@ -207,6 +258,79 @@ class TestGenesisBridge:
         data = json.loads(result)
         assert "error" in data
         assert "Invalid" in data["error"]
+
+    async def test_approve_pending_gate_invalid_decision(self):
+        # Defensive: if the gate reports invalid_decision, surface it clearly
+        # rather than the misleading "No pending approval request found".
+        gate = AsyncMock()
+        gate.resolve_pending_voice = AsyncMock(
+            return_value={"status": "invalid_decision"},
+        )
+        bridge = GenesisBridge(approval_gate=gate)
+        result = await bridge._approve_pending("approved")
+        data = json.loads(result)
+        assert "error" in data
+        assert "Invalid decision" in data["error"]
+
+    async def test_approve_pending_e2e_real_gate(self, tmp_path):
+        """E2E: bridge -> real gate -> real ApprovalManager -> real DB.
+
+        Two pending => "approve" must NOT guess; resolving by id hits exactly
+        one; then a lone pending resolves unambiguously.
+        """
+        from unittest.mock import MagicMock
+
+        import aiosqlite
+
+        from genesis.autonomy.approval import ApprovalManager
+        from genesis.autonomy.approval_gate import AutonomousCliApprovalGate
+        from genesis.db.schema import create_all_tables
+
+        conn = await aiosqlite.connect(str(tmp_path / "e2e.db"))
+        conn.row_factory = aiosqlite.Row
+        await create_all_tables(conn)
+        try:
+            mgr = ApprovalManager(db=conn)
+            rid1 = await mgr.request_approval(
+                action_type="sentinel_dispatch", action_class="reversible",
+                description="investigate the disk alert",
+            )
+            rid2 = await mgr.request_approval(
+                action_type="autonomous_cli_fallback", action_class="reversible",
+                description="run the deploy script",
+            )
+            gate = AutonomousCliApprovalGate(
+                runtime=MagicMock(), approval_manager=mgr,
+            )
+            bridge = GenesisBridge(approval_gate=gate)
+
+            # Two pending -> bare "approve" refuses to guess.
+            amb = json.loads(await bridge.handle_tool_call(
+                "approve_pending", json.dumps({"decision": "approved"}),
+            ))
+            assert "needs_clarification" in amb
+            assert {p["request_id"] for p in amb["pending"]} == {rid1, rid2}
+            assert (await mgr.get_by_id(rid1))["status"] == "pending"
+            assert (await mgr.get_by_id(rid2))["status"] == "pending"
+
+            # Resolve the specific one by id.
+            ok = json.loads(await bridge.handle_tool_call(
+                "approve_pending",
+                json.dumps({"decision": "approved", "request_id": rid2}),
+            ))
+            assert ok["result"] == "Request approved"
+            assert ok["action"] == "run the deploy script"
+            assert (await mgr.get_by_id(rid2))["status"] == "approved"
+            assert (await mgr.get_by_id(rid1))["status"] == "pending"
+
+            # Now only one pending -> unambiguous resolution.
+            ok2 = json.loads(await bridge.handle_tool_call(
+                "approve_pending", json.dumps({"decision": "rejected"}),
+            ))
+            assert ok2["result"] == "Request rejected"
+            assert (await mgr.get_by_id(rid1))["status"] == "rejected"
+        finally:
+            await conn.close()
 
 
 # ─── VoiceConversationHandler tests ─────────────────────────────────────


### PR DESCRIPTION
## What & why
Voice "approve"/"reject" previously resolved `candidates[-1]` — the most recent of *any* voice-gated pending approval (CLI fallback / sentinel dispatch / sentinel action) — so a spoken "approve" could silently act on the **wrong** pending action. Audit finding: `voice-approve-pending-unscoped` (WS-8 / D5).

## Change
- `AutonomousCliApprovalGate.resolve_pending_voice(*, decision, resolved_by, request_id=None)`:
  - binds to a specific `request_id` when given (validated against the voice-gated pending set),
  - resolves the lone pending request when exactly one is pending,
  - **refuses to guess when ≥2 are pending** — returns the candidates (id + speakable label) without resolving anything.
- `pending_voice_actions()` exposes voice-gated pending requests with read-back labels; `_VOICE_GATED_TYPES` is now the single source of truth (consolidated `get_pending_count`).
- `genesis_bridge`: the `approve_pending` voice tool gains an optional `request_id`; the model reads back what it resolved and asks which when ambiguous. Replaces the unscoped `resolve_most_recent_pending_voice` (sole caller updated).

## Behavior
- One pending → "approve" resolves it and confirms what it did (unchanged UX).
- Several pending → "approve" reads the options back and asks which, then resolves by id. It can no longer silently resolve the wrong one.

## Tests
78 passing incl. a real-wiring E2E (bridge → real gate → real ApprovalManager → real SQLite): two-pending refuses to guess, by-id resolves exactly one, lone-pending resolves cleanly. ruff clean.