### PR TITLE
fix(ego): emit ego heartbeat on a dedicated 5-min liveness pulse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The ego subsystem no longer shows a false "overdue" health status** — the health view marks
+  a background subsystem "overdue" if it hasn't checked in within a window, and the ego's check-in
+  was tied to its proactive thinking timer. That timer deliberately slows down during quiet
+  periods and gets pushed back every time the ego does other work, so it could legitimately go
+  hours between ticks — long enough to trip the 4-hour "overdue" alarm even while the ego was
+  healthy and actively running cycles. The ego now sends a steady "alive" check-in every few
+  minutes, independent of its work pace, so its health status reflects reality.
+
 - **Stale "quality drift" and "learning regression" alarms no longer linger or cry wolf** — when
   Genesis's weekly self-checks flagged a quality drift or a learning regression, that flag stayed
   active until it expired days later, so the morning report kept repeating a days-old warning as if

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -163,6 +163,21 @@ class EgoCadenceManager:
             max_instances=1,
             misfire_grace_time=300,
         )
+        # Liveness pulse: emit a heartbeat every 5 min on a fixed, never-
+        # rescheduled cadence so health monitoring tracks "ego subsystem alive"
+        # independent of the proactive _on_tick interval. _on_tick's interval
+        # stretches via adaptive backoff (up to 72h) and is deferred by
+        # reschedule_job on every completed cycle, so a heartbeat tied to it
+        # routinely exceeds the 4h overdue threshold during normal operation
+        # even while the ego is healthy and cycling. Mirrors the fixed-interval
+        # liveness ticks of awareness/surplus/dashboard.
+        self._scheduler.add_job(
+            self._on_heartbeat,
+            IntervalTrigger(minutes=5),
+            id="ego_heartbeat",
+            max_instances=1,
+            misfire_grace_time=60,
+        )
         # Goal staleness scanner: push goal_review signals for stale goals.
         # User ego only — genesis ego has no goal jurisdiction. Skipped at
         # runtime via source_tag check but also gate registration for clarity.
@@ -952,6 +967,18 @@ class EgoCadenceManager:
                 )
 
     # -- Observability -----------------------------------------------------
+
+    async def _on_heartbeat(self) -> None:
+        """Fixed-interval liveness pulse (every 5 min), decoupled from the
+        proactive ``_on_tick`` work cadence.
+
+        Registered as the ``ego_heartbeat`` APScheduler job in :meth:`start`.
+        Pure liveness — emits regardless of pause/idle/circuit state so a
+        paused or quiet ego is not mistaken for a dead one. The only thing it
+        proves (and the only thing the heartbeat is for) is that the ego
+        subsystem's scheduler is alive. Best-effort via :meth:`_emit_heartbeat`.
+        """
+        self._emit_heartbeat("alive")
 
     def _emit_heartbeat(self, trigger: str) -> None:
         """Emit a DEBUG heartbeat event for the neural monitor."""

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -199,6 +199,10 @@ class EgoCadenceManager:
             logger=logger,
         )
         self._running = True
+        # Initial liveness pulse so a restart doesn't look stale to
+        # subsystem_heartbeats during the first 5-min ego_heartbeat window
+        # (mirrors awareness/surplus emitting a heartbeat at start).
+        self._emit_heartbeat("start")
         morning_str = (
             f", morning={self._config.morning_report_hour:02d}:"
             f"{self._config.morning_report_minute:02d} "
@@ -996,7 +1000,9 @@ class EgoCadenceManager:
                     f"ego_{trigger} (interval={self._current_interval}m, "
                     f"failures={self._consecutive_failures})",
                 ),
-                name="ego_heartbeat",
+                name=f"ego_heartbeat_{trigger}",
             )
         except Exception:
-            pass  # Heartbeat emission is best-effort
+            # Best-effort, but never silent — a dark heartbeat with a live
+            # scheduler is exactly the thing this method exists to prevent.
+            logger.debug("Ego heartbeat emission failed", exc_info=True)

--- a/src/genesis/mcp/health/manifest.py
+++ b/src/genesis/mcp/health/manifest.py
@@ -64,7 +64,7 @@ async def _impl_subsystem_heartbeats() -> dict:
         "reflection": (600, 14400),
         "outreach": (86400, 172800),
         "dashboard": (120, 240),
-        "ego": (7200, 14400),         # adaptive cadence 30-120min, overdue at 4h
+        "ego": (300, 14400),          # 5-min liveness pulse (ego_heartbeat job), overdue at 4h
     }
 
     result = {}

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -107,6 +107,8 @@ class TestCadenceLifecycle:
         job_ids = {j.id for j in jobs}
         assert "ego_cycle" in job_ids
         assert "ego_morning_report" in job_ids
+        # Dedicated liveness pulse, decoupled from the proactive _on_tick.
+        assert "ego_heartbeat" in job_ids
         # Consumer task should be running
         assert cadence._signal_consumer_task is not None
         assert not cadence._signal_consumer_task.done()
@@ -125,6 +127,62 @@ class TestCadenceLifecycle:
         assert cadence.is_paused
         cadence.resume()
         assert not cadence.is_paused
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat — dedicated fixed-interval liveness pulse (decoupled from _on_tick)
+# ---------------------------------------------------------------------------
+
+
+class TestCadenceHeartbeat:
+    async def test_on_heartbeat_emits_alive(self, cadence):
+        """The dedicated heartbeat job emits an 'alive' liveness pulse."""
+        cadence._emit_heartbeat = MagicMock()
+        await cadence._on_heartbeat()
+        cadence._emit_heartbeat.assert_called_once_with("alive")
+
+    async def test_on_heartbeat_emits_even_when_paused(self, cadence):
+        """Liveness pulse fires regardless of pause — a paused ego is alive,
+        not dead, and must not trigger a false 'overdue' health alarm."""
+        cadence.pause()
+        cadence._emit_heartbeat = MagicMock()
+        await cadence._on_heartbeat()
+        cadence._emit_heartbeat.assert_called_once_with("alive")
+
+    async def test_emit_heartbeat_reaches_event_bus_with_ego_contract(self, cadence):
+        """_emit_heartbeat fires a Subsystem.EGO 'heartbeat' event — the exact
+        (subsystem, event_type) contract the health read-path queries on."""
+        from unittest.mock import patch
+
+        from genesis.observability.types import Severity, Subsystem
+
+        bus = MagicMock()
+        bus.emit = AsyncMock()
+        cadence._event_bus = bus
+
+        # _emit_heartbeat builds the emit() coroutine synchronously (recording
+        # the call) then hands it to tracked_task. Stub tracked_task so no loose
+        # task is left pending, and close the captured coroutine cleanly.
+        def _fake_tracked_task(coro, **kwargs):
+            coro.close()
+            return None
+
+        with patch("genesis.util.tasks.tracked_task", side_effect=_fake_tracked_task):
+            cadence._emit_heartbeat("alive")
+
+        bus.emit.assert_called_once()
+        args = bus.emit.call_args.args
+        assert (args[0], args[1], args[2]) == (
+            Subsystem.EGO,
+            Severity.DEBUG,
+            "heartbeat",
+        )
+        assert args[3].startswith("ego_alive")
+
+    async def test_emit_heartbeat_noop_without_event_bus(self, cadence):
+        """No event bus (e.g. standalone/test) → silent no-op, never raises."""
+        assert cadence._event_bus is None
+        cadence._emit_heartbeat("alive")  # must not raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -163,6 +163,10 @@ class TestCadenceHeartbeat:
         # _emit_heartbeat builds the emit() coroutine synchronously (recording
         # the call) then hands it to tracked_task. Stub tracked_task so no loose
         # task is left pending, and close the captured coroutine cleanly.
+        # Patch the SOURCE module (genesis.util.tasks): _emit_heartbeat imports
+        # tracked_task inline (function-local) and re-resolves it from that
+        # module on each call, so there is no genesis.ego.cadence.tracked_task
+        # module-scope binding to target.
         def _fake_tracked_task(coro, **kwargs):
             coro.close()
             return None
@@ -183,6 +187,16 @@ class TestCadenceHeartbeat:
         """No event bus (e.g. standalone/test) → silent no-op, never raises."""
         assert cadence._event_bus is None
         cadence._emit_heartbeat("alive")  # must not raise
+
+    async def test_start_emits_initial_heartbeat(self, cadence):
+        """start() fires an immediate liveness pulse so a fresh restart is not
+        reported stale until the first 5-min ego_heartbeat firing."""
+        cadence._emit_heartbeat = MagicMock()
+        await cadence.start()
+        try:
+            cadence._emit_heartbeat.assert_called_once_with("start")
+        finally:
+            await cadence.stop()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The `ego` subsystem reads **`overdue`** in `subsystem_heartbeats` even when the ego is healthy and actively cycling (cycles every 15–60 min). It's a false alarm from a monitoring-wiring gap, not an ego outage.

## Root cause

The ego's health heartbeat was emitted **only** from `_emit_heartbeat("tick")` at the top of `EgoCadenceManager._on_tick` — i.e. bolted to the proactive interval tick, which is unreliable *by design*:

- **Stretches:** `_update_interval` backs the interval off geometrically up to `_recency_max_interval()` (`_RECENCY_TIERS`, up to 4320 min / 72h) during quiet periods.
- **Perpetually deferred:** every completed cycle calls `reschedule_job("ego_cycle", now+interval)`, so frequent reactive cycles keep resetting the proactive tick's next-run before it fires.
- **Resets on restart:** the `IntervalTrigger` restarts from zero on each server restart.

So a healthy ego routinely goes >4h between `_on_tick` firings — past the ego overdue threshold (14400s) — while cycles keep running via the signal-consumer loop (reactive/escalation/morning/sweep). The patient is fine; the wire to the monitor is loose.

## Fix

Add a dedicated `ego_heartbeat` APScheduler job (`IntervalTrigger(minutes=5)`, **never rescheduled**) that emits the liveness pulse independent of work cadence — mirroring the fixed-interval heartbeats of awareness/surplus/dashboard, and the recent reflection-idle-heartbeat normalization (#723). Registered in `start()`, so both the user-ego and genesis-ego cadence managers get one (each in its own scheduler). An initial pulse is emitted at `start()` so a fresh restart isn't briefly stale. The existing `_on_tick` heartbeat is kept (harmless extra context).

No change to ego cognition, cadence, or gating — purely an observability/liveness wiring fix.

Also: `mcp/health/manifest.py` ego heartbeat metadata/comment corrected to the real 5-min cadence (the value is display-only — bound to the unused `_interval_s`; only `overdue_s` drives the check).

## Verification

- `ruff` clean; 106 targeted tests pass (`tests/ego/test_cadence.py`, `tests/ego/test_init.py`, `tests/test_mcp/test_health_mcp.py`), including new heartbeat tests (registration, handler→emit, pause-still-emits, no-bus no-op, exact `Subsystem.EGO`/`heartbeat` contract, cold-start initial pulse).
- **Real-component E2E** (no prod server touched): real `EgoCadenceManager.start()` + `_on_heartbeat()` → real `GenesisEventBus` persistence → real `events` table → real `_impl_subsystem_heartbeats()` returns ego **`alive`** (age 0.5s).
- Reviewed by code-reviewer + genesis-architect (both: sound); all accepted findings applied.

## Notes

- Codex review unavailable (quota-exhausted); Claude code-reviewer + genesis-architect used.
- Follow-up (separate, not this PR): the proactive `_on_tick` itself is starved by the reschedule-deferral + restart trap, so the ego rarely runs its idle proactive cycle / deep-think upgrade — a behavioral question to address on its own.