### PR TITLE
feat(outreach): morning report "Next Steps & Blockers" section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,6 +398,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Changed
 
+- **Your morning report now tells you what to do, not just what happened** — it
+  ends with a **Next Steps & Blockers** section that names the few highest-leverage
+  actions for the day and what's blocking progress (a stalled follow-up, a pending
+  approval, an issue gating one of your goals), drawn only from items already in
+  the report. This replaces the vaguer "follow-up suggestions" guidance, so the
+  briefing highlights what matters and the action it implies instead of just
+  aggregating status.
+
 - **Interactive Claude Code consoles can run friction-free again, when you want
   them to** — the SSH/tmux dev-console slot and the dashboard web terminal still
   default to `--permission-mode auto` (auto-approves common operations, but still

--- a/src/genesis/identity/MORNING_REPORT.md
+++ b/src/genesis/identity/MORNING_REPORT.md
@@ -94,8 +94,10 @@ itself, evidence of a current problem.
   worked on, key decisions made, outcomes
 - Background brainstorm highlights — only genuinely insightful ideas,
   not routine outputs. If nothing insightful, skip this section.
-- Follow-up suggestions — things worth considering today, grounded in
-  yesterday's work. Not generic advice.
+- Next Steps & Blockers — the highest-leverage things to do today and what's
+  blocking progress, drawn from items already in the data (blocked/failed
+  follow-ups, pending approvals, observations tied to an active goal). Surface
+  what matters and what to do about it — not generic advice, not invented tasks.
 
 **Secondary (brief, factual):**
 - System health — one line if all nominal. Only detail if something is
@@ -125,7 +127,16 @@ Use these sections in order. Skip any that are empty/normal:
    noting. Only include genuinely useful insights.
 4. **System Health** — one line if normal. Detail only if something broke.
 5. **Open Items** — pending items requiring user input (inbox, approvals)
-6. **Standing Items** — only if provided. These are known conditions
+6. **Next Steps & Blockers** — the few highest-leverage actions for today and
+   anything blocking progress. Each bullet is one concrete item drawn from the
+   data above: a blocked/failed follow-up, a pending approval, or an observation
+   tied to an active user goal. Tag a blocker with "BLOCKER:" and, where the data
+   supports it, say what it is gating (e.g. a named active goal). Derive these
+   ONLY from items already present in the data — do not invent tasks or give
+   generic advice. Each bullet must name the specific item, not a category:
+   "Approve the proposal to pause the stalled campaign" is correct; "Review
+   pending approvals" is not. Skip the section if nothing actionable is present.
+7. **Standing Items** — only if provided. These are known conditions
    surfaced 3+ times without being resolved. They are NOT urgent —
    compress to a brief list. If unchanged since last report, write
    "N standing items unchanged." Do not lead the report with these.
@@ -168,4 +179,9 @@ system tracking context across days, not just reporting raw data.
 **Open Items**
 - 3 inbox items pending review.
 - 2 approval requests awaiting response.
+
+**Next Steps & Blockers**
+- BLOCKER: the champion on the outreach thread has been quiet 4 days — gating
+  the active employment goal.
+- Send the demo the stalled thread is waiting on — highest-leverage move today.
 ```

--- a/tests/test_outreach/test_morning_report.py
+++ b/tests/test_outreach/test_morning_report.py
@@ -87,6 +87,18 @@ async def test_generate_calls_drafter(db, mock_health, mock_drafter):
 
 
 @pytest.mark.asyncio
+async def test_system_prompt_includes_next_steps_section(db, mock_health, mock_drafter):
+    """The loaded MORNING_REPORT.md system prompt must instruct the LLM to produce
+    a 'Next Steps & Blockers' section — so the report highlights what to do, not
+    just status (the actionability gap the user flagged)."""
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    await gen.generate()
+    call_args = mock_drafter.draft.call_args[0][0]
+    assert call_args.system_prompt is not None
+    assert "Next Steps & Blockers" in call_args.system_prompt
+
+
+@pytest.mark.asyncio
 async def test_generate_includes_health_in_context(db, mock_health, mock_drafter):
     gen = MorningReportGenerator(mock_health, db, mock_drafter)
     await gen.generate()


### PR DESCRIPTION
## What

The morning report aggregated status but did not highlight what to *do* — standing user feedback: *"aggregating but not highlighting what matters."* The `MORNING_REPORT.md` prompt mentioned "Follow-up suggestions" in prose but never gave it a slot in the numbered output **Structure**, so it was easy for the model to drop.

This promotes it to an explicit numbered **Next Steps & Blockers** section (now #6; Standing Items → #7).

## The change (pure prompt — `identity/MORNING_REPORT.md`)

- New numbered section **Next Steps & Blockers**: the few highest-leverage actions for the day plus what is blocking progress. Each bullet is **one concrete item drawn ONLY from data already in the report** — a blocked/failed follow-up, a pending approval, or an observation tied to an active user goal.
- `BLOCKER:`-tagged blockers say what they are gating (e.g. a named active goal).
- Guardrails to stay consistent with the prompt’s existing *facts-only* rules: derive only from present data, **name the specific item, not a category** ("Approve the proposal to pause the stalled campaign", not "Review pending approvals"), no invented/generic advice, skip if nothing actionable.
- Updated the Primary-focus bullet + added an Example block.

No `morning_report.py` change needed — `_assemble_context()` already supplies blocked follow-ups, pending approvals, and active goals.

## Why it is safe

- The report context already carries all the raw material; this only tells the model how to surface it.
- The example contains no private/personal data (generic phrasing) — this file ships in the public repo.

## Verification

- 13 targeted tests pass, incl. a new wiring test that the `Next Steps & Blockers` section actually reaches `DraftRequest.system_prompt`.
- Code-reviewed (LLM-behavior change → extra scrutiny): tightened the guardrail against the "category-not-item" failure mode per review; numbering/voice/public-safety confirmed clean.
- **Real-LLM output check is post-deploy** (`MORNING_REPORT.md` is read at generation time; a live generation needs the full runtime/router). Will confirm the rendered section on the next report after deploy.

## Deferred follow-up

Surface follow-up item *ages* so stale blockers can be age-demoted like observations (#728) — a data-layer gap the prompt cannot fix on its own.