### PR TITLE
feat(autonomy): capability-grant matrix substrate (WS-8 PR-B, dark)

### DIFF
--- a/src/genesis/autonomy/capabilities.py
+++ b/src/genesis/autonomy/capabilities.py
@@ -1,0 +1,64 @@
+"""Capability-cell state machine + competence helpers (WS-8, PR-B).
+
+Pure, DB-free logic for the per-(domain, verb, risk_class) capability matrix
+that replaces the linear L1–L7 ladder for ported channel-domains (email
+first).  This module owns the *rules*; persistence lives in
+``genesis.db.crud.capability_grants`` and classification in
+``genesis.autonomy.classification.classify_email_action``.
+
+DARK in PR-B: no runtime caller mutates cells yet.  Enforcement at the
+``outreach_send`` chokepoint, the asymmetric / consequence-weighted competence
+upgrades, and the staleness-decay *sweep* all land in PR-C/PR-D, where they are
+wired to real send outcomes and can be calibrated.  ``autonomy_state`` stays
+authoritative for the legacy autonomy readers until then.
+"""
+
+from __future__ import annotations
+
+from genesis.autonomy.types import CellEvent, CellState
+
+# Posterior below which a *granted* cell regresses back to ASK.  Mirrors the
+# legacy L3 boundary (0.50 = "no longer majority-confident").  The richer
+# asymmetric / consequence-weighted competence model is deferred to PR-C/PR-D.
+GRANT_FLOOR = 0.50
+
+
+class InvalidTransition(ValueError):
+    """Raised when a (state, event) pair has no defined transition."""
+
+
+# Complete transition table.  DENIED_PERMANENT is reachable ONLY by explicit
+# user action (DENY_PERMANENT / REVOKE) — never by REGRESS or DECAY, so a
+# competence dip or staleness can never permanently lock a cell on its own.
+_TRANSITIONS: dict[tuple[CellState, CellEvent], CellState] = {
+    (CellState.NOT_DETERMINED, CellEvent.CLASSIFY): CellState.ASK,
+    (CellState.ASK, CellEvent.APPROVE): CellState.GRANTED,
+    (CellState.ASK, CellEvent.DENY_PERMANENT): CellState.DENIED_PERMANENT,
+    (CellState.GRANTED, CellEvent.REGRESS): CellState.ASK,
+    (CellState.GRANTED, CellEvent.DECAY): CellState.NOT_DETERMINED,
+    (CellState.GRANTED, CellEvent.REVOKE): CellState.DENIED_PERMANENT,
+}
+
+
+def transition(state: CellState, event: CellEvent) -> CellState:
+    """Return the next cell state for ``event`` applied to ``state``.
+
+    Raises :class:`InvalidTransition` if the event is illegal from the
+    current state (e.g. approving a cell that was never asked).
+    """
+    try:
+        return _TRANSITIONS[(state, event)]
+    except KeyError:
+        raise InvalidTransition(
+            f"no capability-cell transition: {state} --{event}--> ?"
+        ) from None
+
+
+def can_transition(state: CellState, event: CellEvent) -> bool:
+    """True iff ``(state, event)`` has a defined transition."""
+    return (state, event) in _TRANSITIONS
+
+
+def should_regress(posterior: float, *, floor: float = GRANT_FLOOR) -> bool:
+    """True iff a granted cell's competence has fallen below the grant floor."""
+    return posterior < floor

--- a/src/genesis/autonomy/classification.py
+++ b/src/genesis/autonomy/classification.py
@@ -15,13 +15,19 @@ from __future__ import annotations
 
 import logging
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import yaml
 
 from genesis.autonomy.rules import RuleContext, RuleEngine
-from genesis.autonomy.types import ActionClass, ActionDomain, ApprovalDecision
+from genesis.autonomy.types import (
+    ActionClass,
+    ActionDomain,
+    ApprovalDecision,
+    RiskClass,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -320,3 +326,77 @@ def classify_domain(action_type: str, execution_plan: str = "") -> ActionDomain:
             return ActionDomain.SELF_MODIFY
 
     return ActionDomain.EXTERNAL_READ
+
+
+# ---------------------------------------------------------------------------
+# Email action classification (WS-8 capability matrix)
+# ---------------------------------------------------------------------------
+# Maps an outbound email action to its capability-cell key
+# (domain="email", verb="send", risk_class) plus the irreversibility class.
+# Like classify_domain, this is derived EXTERNALLY — the acting model never
+# sees or reasons about the cell taxonomy (Tenet 0 opacity).  DARK in PR-B:
+# the gate that calls this lives at the outreach_send chokepoint (PR-C), where
+# thread/recipient context is in scope.
+
+EMAIL_DOMAIN = "email"
+EMAIL_VERB = "send"
+
+_FINANCIAL_EMAIL_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(
+        r"\b(?:wire\s+transfer|invoice|payment|remit|deposit|ach|iban|"
+        r"routing\s+number|bank\s+details)\b",
+        re.IGNORECASE,
+    ),
+]
+
+
+@dataclass(frozen=True)
+class EmailActionClassification:
+    """Classification of one outbound email action for the capability gate."""
+
+    domain: str                 # channel-domain for the cell key (always "email" here)
+    verb: str                   # cell verb (always "send" here)
+    risk_class: RiskClass       # cell risk axis
+    sub_class: str              # human label: reply | cold | bulk | financial
+    identity_bar: bool          # True = acts in the user's name (REPRESENT_USER)
+    action_class: ActionClass   # reversibility (reused keyword classifier)
+
+    @property
+    def cell_key(self) -> tuple[str, str, str]:
+        """The (domain, verb, risk_class) tuple used to look up the cell."""
+        return (self.domain, self.verb, str(self.risk_class))
+
+
+def classify_email_action(
+    *,
+    is_reply: bool = False,
+    recipient_known: bool = False,
+    is_bulk: bool = False,
+    subject: str = "",
+    body: str = "",
+) -> EmailActionClassification:
+    """Derive the capability-cell key for an outbound email.
+
+    Risk gradient (low → high): a known-thread reply (STANDARD) < cold
+    outreach to a new party, which crosses the identity bar (IDENTITY) <
+    a bulk/campaign send (BULK).  Any monetary email is FINANCIAL (hardline).
+    Inputs are supplied by the caller at the send chokepoint (PR-C).
+    """
+    text = f"{subject}\n{body}"
+    if any(p.search(text) for p in _FINANCIAL_EMAIL_PATTERNS):
+        risk, sub = RiskClass.FINANCIAL, "financial"
+    elif is_bulk:
+        risk, sub = RiskClass.BULK, "bulk"
+    elif is_reply and recipient_known:
+        risk, sub = RiskClass.STANDARD, "reply"
+    else:
+        risk, sub = RiskClass.IDENTITY, "cold"
+
+    return EmailActionClassification(
+        domain=EMAIL_DOMAIN,
+        verb=EMAIL_VERB,
+        risk_class=risk,
+        sub_class=sub,
+        identity_bar=True,  # email always represents the user (REPRESENT_USER)
+        action_class=classify_action(text),
+    )

--- a/src/genesis/autonomy/types.py
+++ b/src/genesis/autonomy/types.py
@@ -177,6 +177,67 @@ CONTEXT_CEILING_MAP: dict[ContextCeiling, int] = {
 
 
 # ---------------------------------------------------------------------------
+# Capability-grant matrix (WS-8) — per-(domain, verb, risk_class) cells
+# ---------------------------------------------------------------------------
+# A capability cell is the standing authorization state for one
+# (channel-domain, verb, risk-class) tuple — e.g. ("email", "send",
+# "standard").  Autonomy is earned per channel-domain and replaces the linear
+# L1–L7 ladder for ported domains (email first).  PR-B lays this substrate
+# DARK: nothing enforces or mutates cells at runtime yet (enforcement = PR-C
+# at the outreach_send chokepoint), and ``autonomy_state`` remains
+# authoritative for every existing reader until then.
+
+class CellState(StrEnum):
+    """Lifecycle of a single capability cell.
+
+    Four PERSISTED states.  ``GRANTED_EPHEMERAL`` (approve-one-action-without-
+    promoting) is intentionally NOT a cell state — it is a one-time approved
+    row in ``approval_requests`` consumed by the per-action gate (PR-C).
+    """
+
+    NOT_DETERMINED = "not_determined"       # never exercised; no decision yet
+    ASK = "ask"                             # requires per-action user approval
+    GRANTED = "granted"                     # standing authorization (still per-action gated)
+    DENIED_PERMANENT = "denied_permanent"   # user-blocked; terminal, user-only escape
+
+
+class RiskClass(StrEnum):
+    """Risk axis of a capability cell, shared across domains.
+
+    For email: a known-thread reply is STANDARD; cold outreach to a new party
+    crosses the IDENTITY bar; a campaign/bulk send is BULK; anything monetary
+    is FINANCIAL (hardline — never trust-unlockable).
+    """
+
+    STANDARD = "standard"
+    IDENTITY = "identity"
+    BULK = "bulk"
+    FINANCIAL = "financial"
+
+
+# Severity ordering for risk classes (higher = more consequential).  Lets call
+# sites reason about the within-domain risk gradient (reply < cold < bulk)
+# without hard-coding comparisons.
+RISK_SEVERITY: dict[RiskClass, int] = {
+    RiskClass.STANDARD: 0,
+    RiskClass.IDENTITY: 1,
+    RiskClass.BULK: 2,
+    RiskClass.FINANCIAL: 3,
+}
+
+
+class CellEvent(StrEnum):
+    """Events that drive capability-cell state transitions."""
+
+    CLASSIFY = "classify"               # first action needing this cell appears
+    APPROVE = "approve"                 # user promotes the cell (ask → granted)
+    DENY_PERMANENT = "deny_permanent"   # user blocks the cell permanently
+    REGRESS = "regress"                 # competence dropped below the grant floor
+    DECAY = "decay"                     # staleness — unused grant lapses (sweep = PR-D)
+    REVOKE = "revoke"                   # user explicitly revokes a standing grant
+
+
+# ---------------------------------------------------------------------------
 # Watchdog types
 # ---------------------------------------------------------------------------
 

--- a/src/genesis/db/crud/capability_grants.py
+++ b/src/genesis/db/crud/capability_grants.py
@@ -1,0 +1,177 @@
+"""CRUD for the capability_grants table — per-(domain, verb, risk_class) cells.
+
+The simple-posterior competence mirror of ``crud/autonomy.py``, re-keyed to
+capability cells (WS-8, PR-B).  DARK: no runtime caller writes here yet.
+
+Deliberately does NOT touch ``autonomy_state`` — that table stays
+authoritative for every existing reader (the ``autonomy_activity`` signal,
+``capability_aggregator``, the direct-session circuit breaker, the earn-back
+sweep) until PR-C ships the L1–L7 → cells read-out.  The asymmetric /
+consequence-weighted / staleness-decay upgrades to the posterior are deferred
+to PR-C/PR-D, where they are wired to real send outcomes and can be calibrated.
+
+These functions commit their own writes — do NOT call them inside a migration
+``up()`` (the runner's connection proxy forbids ``commit()``).
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+from genesis.autonomy.capabilities import should_regress, transition
+from genesis.autonomy.types import CellEvent, CellState
+
+
+def cell_id(domain: str, verb: str, risk_class: str) -> str:
+    """Deterministic cell identity — the (domain, verb, risk_class) key."""
+    return f"{domain}:{verb}:{risk_class}"
+
+
+def cell_posterior(successes: int, corrections: int) -> float:
+    """Beta(1,1) posterior mean — a straight per-cell mirror of
+    ``crud.autonomy.bayesian_posterior``.  Returns 0.5 (uninformative) with no
+    evidence; a fresh cell holds at ASK regardless of this value.
+    """
+    total = successes + corrections
+    if total == 0:
+        return 0.5
+    return (successes + 1) / (total + 2)
+
+
+async def get_cell(
+    db: aiosqlite.Connection, domain: str, verb: str, risk_class: str
+) -> dict | None:
+    cursor = await db.execute(
+        "SELECT * FROM capability_grants WHERE id = ?",
+        (cell_id(domain, verb, risk_class),),
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def ensure_cell(
+    db: aiosqlite.Connection,
+    *,
+    domain: str,
+    verb: str,
+    risk_class: str,
+    updated_at: str,
+) -> dict:
+    """Insert the cell at NOT_DETERMINED if absent; return the current row."""
+    cid = cell_id(domain, verb, risk_class)
+    await db.execute(
+        """INSERT INTO capability_grants
+             (id, domain, verb, risk_class, state, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(id) DO NOTHING""",
+        (cid, domain, verb, risk_class,
+         CellState.NOT_DETERMINED.value, updated_at, updated_at),
+    )
+    await db.commit()
+    row = await get_cell(db, domain, verb, risk_class)
+    if row is None:  # pragma: no cover — insert-or-existing guarantees a row
+        raise RuntimeError(f"capability cell {cid} missing after upsert")
+    return row
+
+
+async def list_all(db: aiosqlite.Connection) -> list[dict]:
+    cursor = await db.execute(
+        "SELECT * FROM capability_grants ORDER BY domain, verb, risk_class"
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def apply_event(
+    db: aiosqlite.Connection,
+    *,
+    domain: str,
+    verb: str,
+    risk_class: str,
+    event: CellEvent,
+    updated_at: str,
+) -> CellState:
+    """Apply a state-machine event to the cell and persist the new state.
+
+    Raises :class:`genesis.autonomy.capabilities.InvalidTransition` if the
+    event is illegal from the current state.  Sets ``granted_at`` when the
+    cell first reaches GRANTED.
+    """
+    row = await ensure_cell(
+        db, domain=domain, verb=verb, risk_class=risk_class, updated_at=updated_at
+    )
+    new_state = transition(CellState(row["state"]), event)
+
+    # granted_at is the decay-clock origin (PR-D): (re)stamp it on every entry
+    # into GRANTED so a cell that regressed and was re-granted isn't treated as
+    # older than it is.  Meaningful only while state == 'granted'.
+    granted_at = row["granted_at"]
+    if new_state == CellState.GRANTED:
+        granted_at = updated_at
+
+    await db.execute(
+        """UPDATE capability_grants
+             SET state = ?, granted_at = ?, updated_at = ?
+           WHERE id = ?""",
+        (new_state.value, granted_at, updated_at, row["id"]),
+    )
+    await db.commit()
+    return new_state
+
+
+async def record_success(
+    db: aiosqlite.Connection,
+    *,
+    domain: str,
+    verb: str,
+    risk_class: str,
+    updated_at: str,
+) -> bool:
+    """Increment the success counter.  Promotion stays explicit (user approve)."""
+    row = await ensure_cell(
+        db, domain=domain, verb=verb, risk_class=risk_class, updated_at=updated_at
+    )
+    cursor = await db.execute(
+        """UPDATE capability_grants
+             SET successes = successes + 1, last_used_at = ?, updated_at = ?
+           WHERE id = ?""",
+        (updated_at, updated_at, row["id"]),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def record_correction(
+    db: aiosqlite.Connection,
+    *,
+    domain: str,
+    verb: str,
+    risk_class: str,
+    updated_at: str,
+) -> CellState:
+    """Increment the correction counter; regress a granted cell if competence
+    drops below the grant floor.  The counter increment and any regression are
+    written in a SINGLE atomic UPDATE so a crash can't leave a sub-floor cell
+    stuck in GRANTED.  Returns the resulting cell state.
+
+    (Asymmetric / consequence weighting of the update is deferred to
+    PR-C/PR-D — here a correction is a plain +1.)
+    """
+    row = await ensure_cell(
+        db, domain=domain, verb=verb, risk_class=risk_class, updated_at=updated_at
+    )
+    new_corrections = row["corrections"] + 1
+
+    new_state = CellState(row["state"])
+    if new_state == CellState.GRANTED and should_regress(
+        cell_posterior(row["successes"], new_corrections)
+    ):
+        new_state = transition(new_state, CellEvent.REGRESS)
+
+    await db.execute(
+        """UPDATE capability_grants
+             SET corrections = ?, state = ?, updated_at = ?
+           WHERE id = ?""",
+        (new_corrections, new_state.value, updated_at, row["id"]),
+    )
+    await db.commit()
+    return new_state

--- a/src/genesis/db/migrations/0030_capability_grants.py
+++ b/src/genesis/db/migrations/0030_capability_grants.py
@@ -1,0 +1,58 @@
+"""Create the ``capability_grants`` table — the WS-8 capability-grant matrix.
+
+One row per (channel-domain, verb, risk-class) cell — e.g. ("email", "send",
+"standard").  Autonomy is earned per channel-domain; this replaces the linear
+L1–L7 ladder for ported domains (email first).
+
+DARK on creation: nothing enforces or mutates cells at runtime yet.
+Enforcement lives at the ``outreach_send`` chokepoint (PR-C); the
+asymmetric / consequence-weighted competence upgrades and the staleness-decay
+sweep land in PR-C/PR-D.  ``autonomy_state`` remains authoritative for every
+existing autonomy reader until then — this migration adds a wholly new table
+and touches nothing else.
+
+Idempotent (``IF NOT EXISTS``).  Fresh installs get the same DDL via
+``db/schema/_tables.py``; this migration covers existing installs.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+_TABLE_DDL = """
+    CREATE TABLE IF NOT EXISTS capability_grants (
+        id            TEXT PRIMARY KEY,
+        domain        TEXT NOT NULL,
+        verb          TEXT NOT NULL,
+        risk_class    TEXT NOT NULL DEFAULT 'standard' CHECK (risk_class IN (
+            'standard', 'identity', 'bulk', 'financial'
+        )),
+        state         TEXT NOT NULL DEFAULT 'not_determined' CHECK (state IN (
+            'not_determined', 'ask', 'granted', 'denied_permanent'
+        )),
+        successes     INTEGER NOT NULL DEFAULT 0,
+        corrections   INTEGER NOT NULL DEFAULT 0,
+        granted_at    TEXT,
+        last_used_at  TEXT,
+        created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE (domain, verb, risk_class)
+    )
+"""
+
+_INDEX_DDL = (
+    "CREATE INDEX IF NOT EXISTS idx_capability_grants_domain "
+    "ON capability_grants(domain, state)",
+)
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # NOTE: must NOT call db.commit()/BEGIN — the runner owns the transaction.
+    await db.execute(_TABLE_DDL)
+    for stmt in _INDEX_DDL:
+        await db.execute(stmt)
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    """Drop the table (and its indexes) — development/testing only."""
+    await db.execute("DROP TABLE IF EXISTS capability_grants")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -612,6 +612,30 @@ TABLES = {
             chain_hash       TEXT                     -- SHA-256(previous_hash:content_hash)
         )
     """,
+    # Capability-grant matrix (WS-8) — per-(domain, verb, risk_class) cells.
+    # Replaces the linear L1–L7 ladder for ported channel-domains (email
+    # first).  DARK in PR-B: no runtime reader/writer yet; autonomy_state
+    # stays authoritative until PR-C ships enforcement + the L1–L7 read-out.
+    "capability_grants": """
+        CREATE TABLE IF NOT EXISTS capability_grants (
+            id            TEXT PRIMARY KEY,           -- "{domain}:{verb}:{risk_class}"
+            domain        TEXT NOT NULL,              -- channel-domain, e.g. 'email'
+            verb          TEXT NOT NULL,              -- e.g. 'send'
+            risk_class    TEXT NOT NULL DEFAULT 'standard' CHECK (risk_class IN (
+                'standard', 'identity', 'bulk', 'financial'
+            )),
+            state         TEXT NOT NULL DEFAULT 'not_determined' CHECK (state IN (
+                'not_determined', 'ask', 'granted', 'denied_permanent'
+            )),
+            successes     INTEGER NOT NULL DEFAULT 0,
+            corrections   INTEGER NOT NULL DEFAULT 0,
+            granted_at    TEXT,                       -- when cell most recently entered 'granted' (decay-clock origin)
+            last_used_at  TEXT,
+            created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE (domain, verb, risk_class)
+        )
+    """,
     "task_states": """
         CREATE TABLE IF NOT EXISTS task_states (
             task_id          TEXT PRIMARY KEY,
@@ -1539,6 +1563,8 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_approval_status ON approval_requests(status)",
     "CREATE INDEX IF NOT EXISTS idx_approval_class ON approval_requests(action_class)",
     "CREATE INDEX IF NOT EXISTS idx_approval_timeout ON approval_requests(timeout_at)",
+    # capability grants (WS-8 — per-(domain,verb,risk_class) cells, dark in PR-B)
+    "CREATE INDEX IF NOT EXISTS idx_capability_grants_domain ON capability_grants(domain, state)",
     # task states (Phase 9)
     "CREATE INDEX IF NOT EXISTS idx_task_states_session ON task_states(session_id)",
     "CREATE INDEX IF NOT EXISTS idx_task_states_phase ON task_states(current_phase)",

--- a/tests/test_autonomy/test_capabilities.py
+++ b/tests/test_autonomy/test_capabilities.py
@@ -1,0 +1,162 @@
+"""Tests for the WS-8 capability-cell state machine, posterior, and classifier.
+
+Pure logic — no DB.  Covers the 4-state machine (legal transitions,
+denied-permanent-only-by-user, regression, decay), the simple posterior, and
+``classify_email_action``'s risk gradient (reply < cold < bulk).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.autonomy.capabilities import (
+    GRANT_FLOOR,
+    InvalidTransition,
+    can_transition,
+    should_regress,
+    transition,
+)
+from genesis.autonomy.classification import (
+    EmailActionClassification,
+    classify_email_action,
+)
+from genesis.autonomy.types import (
+    RISK_SEVERITY,
+    ActionClass,
+    CellEvent,
+    CellState,
+    RiskClass,
+)
+from genesis.db.crud.capability_grants import cell_posterior
+
+# --------------------------------------------------------------------------- #
+# State machine
+# --------------------------------------------------------------------------- #
+
+
+class TestTransitions:
+    def test_classify_starts_the_cell(self):
+        assert transition(CellState.NOT_DETERMINED, CellEvent.CLASSIFY) == CellState.ASK
+
+    def test_approve_promotes(self):
+        assert transition(CellState.ASK, CellEvent.APPROVE) == CellState.GRANTED
+
+    def test_deny_is_permanent(self):
+        assert (
+            transition(CellState.ASK, CellEvent.DENY_PERMANENT)
+            == CellState.DENIED_PERMANENT
+        )
+
+    def test_regress_drops_to_ask_keeping_history(self):
+        # GRANTED → ASK (not all the way to NOT_DETERMINED) preserves evidence.
+        assert transition(CellState.GRANTED, CellEvent.REGRESS) == CellState.ASK
+
+    def test_decay_returns_to_not_determined(self):
+        assert (
+            transition(CellState.GRANTED, CellEvent.DECAY)
+            == CellState.NOT_DETERMINED
+        )
+
+    def test_revoke_is_permanent(self):
+        assert (
+            transition(CellState.GRANTED, CellEvent.REVOKE)
+            == CellState.DENIED_PERMANENT
+        )
+
+    def test_denied_permanent_is_terminal(self):
+        # No event escapes DENIED_PERMANENT.
+        for event in CellEvent:
+            assert not can_transition(CellState.DENIED_PERMANENT, event)
+
+    def test_denied_permanent_only_reachable_by_user_action(self):
+        # Only DENY_PERMANENT / REVOKE land in DENIED_PERMANENT — never REGRESS
+        # or DECAY (a competence dip or staleness must not permanently lock a
+        # cell on its own).
+        user_only = {CellEvent.DENY_PERMANENT, CellEvent.REVOKE}
+        for state in CellState:
+            for event in CellEvent:
+                if not can_transition(state, event):
+                    continue
+                if transition(state, event) == CellState.DENIED_PERMANENT:
+                    assert event in user_only
+
+    def test_cannot_approve_a_cell_never_asked(self):
+        with pytest.raises(InvalidTransition):
+            transition(CellState.NOT_DETERMINED, CellEvent.APPROVE)
+
+    def test_cannot_regress_an_unasked_cell(self):
+        with pytest.raises(InvalidTransition):
+            transition(CellState.ASK, CellEvent.REGRESS)
+
+
+# --------------------------------------------------------------------------- #
+# Posterior + regression floor
+# --------------------------------------------------------------------------- #
+
+
+class TestPosterior:
+    def test_no_evidence_is_uninformative(self):
+        assert cell_posterior(0, 0) == 0.5
+
+    def test_mirror_of_legacy_formula(self):
+        # (s + 1) / (s + c + 2)
+        assert cell_posterior(3, 2) == pytest.approx(4 / 7)
+        assert cell_posterior(50, 2) == pytest.approx(51 / 54)
+
+    def test_should_regress_below_floor(self):
+        assert should_regress(0.0)  # well below the floor
+        assert should_regress(GRANT_FLOOR - 0.01)
+        assert not should_regress(GRANT_FLOOR)
+        assert not should_regress(0.9)
+
+
+# --------------------------------------------------------------------------- #
+# Email classification
+# --------------------------------------------------------------------------- #
+
+
+class TestClassifyEmailAction:
+    def test_known_thread_reply_is_standard(self):
+        c = classify_email_action(is_reply=True, recipient_known=True)
+        assert c.risk_class == RiskClass.STANDARD
+        assert c.sub_class == "reply"
+        assert c.cell_key == ("email", "send", "standard")
+        assert c.identity_bar is True
+
+    def test_cold_outreach_crosses_identity_bar(self):
+        c = classify_email_action(is_reply=False, recipient_known=False)
+        assert c.risk_class == RiskClass.IDENTITY
+        assert c.sub_class == "cold"
+
+    def test_reply_to_unknown_recipient_is_cold(self):
+        # is_reply alone isn't enough — an unknown recipient is still cold.
+        c = classify_email_action(is_reply=True, recipient_known=False)
+        assert c.risk_class == RiskClass.IDENTITY
+
+    def test_bulk_send_is_bulk(self):
+        c = classify_email_action(is_bulk=True, is_reply=True, recipient_known=True)
+        assert c.risk_class == RiskClass.BULK
+        assert c.sub_class == "bulk"
+
+    def test_financial_email_is_hardline(self):
+        c = classify_email_action(
+            is_reply=True, recipient_known=True,
+            subject="Invoice #42", body="Please wire transfer the balance.",
+        )
+        assert c.risk_class == RiskClass.FINANCIAL
+        assert c.sub_class == "financial"
+
+    def test_risk_gradient_reply_lt_cold_lt_bulk(self):
+        reply = classify_email_action(is_reply=True, recipient_known=True)
+        cold = classify_email_action(is_reply=False, recipient_known=False)
+        bulk = classify_email_action(is_bulk=True)
+        assert (
+            RISK_SEVERITY[reply.risk_class]
+            < RISK_SEVERITY[cold.risk_class]
+            < RISK_SEVERITY[bulk.risk_class]
+        )
+
+    def test_returns_frozen_dataclass_with_action_class(self):
+        c = classify_email_action(is_reply=True, recipient_known=True)
+        assert isinstance(c, EmailActionClassification)
+        assert isinstance(c.action_class, ActionClass)

--- a/tests/test_db/test_capability_grants.py
+++ b/tests/test_db/test_capability_grants.py
@@ -1,0 +1,211 @@
+"""Tests for the capability_grants table, migration 0030, and its CRUD (WS-8).
+
+Covers the fresh-install path (create_all_tables / _tables.py), the versioned
+migration (up/down/idempotency), CHECK constraints, and CRUD semantics — the
+4-state machine persisted, success/correction counters, and the granted→ask
+regression below the competence floor.  DARK substrate: no runtime caller yet.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+from genesis.autonomy.capabilities import InvalidTransition
+from genesis.autonomy.types import CellEvent, CellState
+from genesis.db.crud import capability_grants as cg
+
+MIGRATION = importlib.import_module("genesis.db.migrations.0030_capability_grants")
+
+_EMAIL = {"domain": "email", "verb": "send", "risk_class": "standard"}
+_TS = "2026-06-21T00:00:00"
+
+
+@pytest.fixture
+async def db(tmp_path):
+    """Fresh DB with capability_grants created via the real migration up()."""
+    db_path = str(tmp_path / "test.db")
+    async with aiosqlite.connect(db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        await MIGRATION.up(conn)  # up() must not commit — runner owns the txn
+        await conn.commit()
+        yield conn
+
+
+# --------------------------------------------------------------------------- #
+# Schema / migration
+# --------------------------------------------------------------------------- #
+class TestSchema:
+    @pytest.mark.asyncio
+    async def test_table_and_index_exist(self, db):
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name='capability_grants'"
+        )
+        assert await cur.fetchone() is not None
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND name='idx_capability_grants_domain'"
+        )
+        assert await cur.fetchone() is not None
+
+    @pytest.mark.asyncio
+    async def test_up_is_idempotent(self, tmp_path):
+        path = str(tmp_path / "idem.db")
+        async with aiosqlite.connect(path) as conn:
+            await MIGRATION.up(conn)
+            await MIGRATION.up(conn)  # IF NOT EXISTS → must not raise
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='capability_grants'"
+            )
+            assert (await cur.fetchone())[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_down_drops_table(self, tmp_path):
+        path = str(tmp_path / "down.db")
+        async with aiosqlite.connect(path) as conn:
+            await MIGRATION.up(conn)
+            await MIGRATION.down(conn)
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='capability_grants'"
+            )
+            assert (await cur.fetchone())[0] == 0
+
+    @pytest.mark.asyncio
+    async def test_fresh_install_creates_table(self, tmp_path):
+        """create_all_tables (the fresh-install / test path) creates it too."""
+        from genesis.db.schema import create_all_tables
+
+        path = str(tmp_path / "fresh.db")
+        async with aiosqlite.connect(path) as conn:
+            await create_all_tables(conn)
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='capability_grants'"
+            )
+            assert (await cur.fetchone())[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_state_and_risk_class(self, db):
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute(
+                "INSERT INTO capability_grants (id, domain, verb, risk_class, state) "
+                "VALUES ('x', 'email', 'send', 'standard', 'BOGUS')"
+            )
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute(
+                "INSERT INTO capability_grants (id, domain, verb, risk_class) "
+                "VALUES ('y', 'email', 'send', 'BOGUS')"
+            )
+
+
+# --------------------------------------------------------------------------- #
+# CRUD + state machine
+# --------------------------------------------------------------------------- #
+class TestCrud:
+    @pytest.mark.asyncio
+    async def test_ensure_creates_not_determined(self, db):
+        row = await cg.ensure_cell(db, updated_at=_TS, **_EMAIL)
+        assert row["state"] == CellState.NOT_DETERMINED.value
+        assert row["id"] == "email:send:standard"
+        assert row["successes"] == 0 and row["corrections"] == 0
+
+    @pytest.mark.asyncio
+    async def test_ensure_is_idempotent(self, db):
+        await cg.ensure_cell(db, updated_at=_TS, **_EMAIL)
+        await cg.ensure_cell(db, updated_at=_TS, **_EMAIL)
+        rows = await cg.list_all(db)
+        assert len(rows) == 1
+
+    @pytest.mark.asyncio
+    async def test_classify_then_approve_grants_and_stamps(self, db):
+        s1 = await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
+        assert s1 == CellState.ASK
+        s2 = await cg.apply_event(
+            db, event=CellEvent.APPROVE, updated_at="2026-06-21T01:00:00", **_EMAIL
+        )
+        assert s2 == CellState.GRANTED
+        row = await cg.get_cell(db, **_EMAIL)
+        assert row["state"] == CellState.GRANTED.value
+        assert row["granted_at"] == "2026-06-21T01:00:00"
+
+    @pytest.mark.asyncio
+    async def test_illegal_event_raises(self, db):
+        # APPROVE from NOT_DETERMINED is illegal.
+        with pytest.raises(InvalidTransition):
+            await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL)
+
+    @pytest.mark.asyncio
+    async def test_record_success_increments(self, db):
+        await cg.record_success(db, updated_at=_TS, **_EMAIL)
+        await cg.record_success(db, updated_at=_TS, **_EMAIL)
+        row = await cg.get_cell(db, **_EMAIL)
+        assert row["successes"] == 2
+        assert row["last_used_at"] == _TS
+
+    @pytest.mark.asyncio
+    async def test_correction_regresses_granted_cell_below_floor(self, db):
+        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
+        await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL)
+        # 0 successes, 1 correction → posterior 1/3 < 0.50 → regress to ASK.
+        state = await cg.record_correction(db, updated_at=_TS, **_EMAIL)
+        assert state == CellState.ASK
+        row = await cg.get_cell(db, **_EMAIL)
+        assert row["state"] == CellState.ASK.value
+        assert row["corrections"] == 1
+
+    @pytest.mark.asyncio
+    async def test_correction_keeps_well_supported_grant(self, db):
+        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
+        await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL)
+        for _ in range(5):
+            await cg.record_success(db, updated_at=_TS, **_EMAIL)
+        # 5 successes, 1 correction → posterior 6/8 = 0.75 ≥ floor → stays GRANTED.
+        state = await cg.record_correction(db, updated_at=_TS, **_EMAIL)
+        assert state == CellState.GRANTED
+
+    @pytest.mark.asyncio
+    async def test_correction_on_non_granted_is_inert(self, db):
+        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
+        state = await cg.record_correction(db, updated_at=_TS, **_EMAIL)
+        assert state == CellState.ASK  # unchanged; only counter moved
+        row = await cg.get_cell(db, **_EMAIL)
+        assert row["corrections"] == 1
+
+    @pytest.mark.asyncio
+    async def test_regrant_restamps_granted_at(self, db):
+        # grant → correction-regress → re-approve must refresh granted_at to the
+        # most recent grant (the decay clock must not see it as stale-old).
+        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
+        await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL)
+        assert (await cg.get_cell(db, **_EMAIL))["granted_at"] == _TS
+        # 0 successes + 1 correction → regress to ASK.
+        assert await cg.record_correction(db, updated_at=_TS, **_EMAIL) == CellState.ASK
+        later = "2026-06-22T12:00:00"
+        s = await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=later, **_EMAIL)
+        assert s == CellState.GRANTED
+        assert (await cg.get_cell(db, **_EMAIL))["granted_at"] == later
+
+    @pytest.mark.asyncio
+    async def test_correction_atomic_single_state(self, db):
+        # The counter increment and regression land together (one UPDATE).
+        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
+        await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL)
+        state = await cg.record_correction(db, updated_at=_TS, **_EMAIL)
+        row = await cg.get_cell(db, **_EMAIL)
+        assert state == CellState.ASK
+        assert row["state"] == CellState.ASK.value and row["corrections"] == 1
+
+    @pytest.mark.asyncio
+    async def test_list_all_orders_by_key(self, db):
+        await cg.ensure_cell(db, domain="email", verb="send", risk_class="bulk", updated_at=_TS)
+        await cg.ensure_cell(db, updated_at=_TS, **_EMAIL)
+        rows = await cg.list_all(db)
+        assert [r["risk_class"] for r in rows] == ["bulk", "standard"]

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -55,6 +55,7 @@ EXPECTED_TABLES = [
     "centrality_cache",
     "campaigns",
     "campaign_runs",
+    "capability_grants",  # WS-8 PR-B: per-(domain,verb,risk_class) cells
 ]
 
 
@@ -214,6 +215,22 @@ async def test_autonomy_state_rejects_level_out_of_range(db):
         await db.execute(
             "INSERT INTO autonomy_state (id, category, current_level, earned_level, updated_at) "
             "VALUES ('test', 'test', 8, 1, '2026-01-01T00:00:00')"
+        )
+
+
+async def test_capability_grants_rejects_invalid_state(db):
+    with pytest.raises(sqlite3.IntegrityError):
+        await db.execute(
+            "INSERT INTO capability_grants (id, domain, verb, risk_class, state) "
+            "VALUES ('email:send:standard', 'email', 'send', 'standard', 'INVALID')"
+        )
+
+
+async def test_capability_grants_rejects_invalid_risk_class(db):
+    with pytest.raises(sqlite3.IntegrityError):
+        await db.execute(
+            "INSERT INTO capability_grants (id, domain, verb, risk_class) "
+            "VALUES ('email:send:nope', 'email', 'send', 'INVALID')"
         )
 
 


### PR DESCRIPTION
## What

Lays the **dark substrate** for the per-`(domain, verb, risk_class)` **capability-grant matrix** that will replace the linear L1–L7 autonomy ladder for ported channel-domains (email first). This is WS-8 PR-B of a staged rollout.

**Zero runtime behavior change.** Nothing enforces or mutates cells yet — enforcement lands at the `outreach_send` chokepoint in PR-C. This PR only adds a new table + new pure logic + new CRUD + a classifier + tests. Mirrors the house dark-ship pattern (cf. `0025_outcome_events`).

## Contents

- **`capability_grants` table** + migration `0030` — 4 persisted states: `not_determined` / `ask` / `granted` / `denied_permanent`.
- **Pure cell state machine** (`autonomy/capabilities.py`) — `denied_permanent` reachable **only** by explicit user action (`deny_permanent`/`revoke`), never by `regress`/`decay`; `granted→ask` regression below the grant floor (0.50). Decay transition defined; the sweep that fires it is deferred to PR-D.
- **`classify_email_action`** (`autonomy/classification.py`) — within-email risk gradient `reply(standard) < cold(identity) < bulk`; financial keywords → `financial` (hardline). Derived **externally**, so the acting model never sees the cell taxonomy (the codebase's existing opacity convention).
- **Per-cell CRUD + simple posterior** (`crud/capability_grants.py`) — a straight per-cell mirror of `crud/autonomy.py`'s Beta(1,1) posterior. `autonomy_state` is left **untouched** so its 5 live readers stay authoritative (frozen-readout invariant).

## Deferred (ride with their callers, where they're calibratable)

- Asymmetric + consequence-weighted competence updates → **PR-C** (fire on real approve→success / reject→correction outcomes).
- Staleness-decay sweep → **PR-D** (scheduled job; `granted_at` is the decay-clock origin).
- Novelty/OOD gate → later (research-unsolved).

## Verification

- 63 targeted tests (state machine, posterior, classifier, schema, CRUD) + 118 adjacent suites (classification, types, migration runner, autonomy CRUD) green; `ruff` clean.
- Migration-runner **E2E**: confirmed `0030` applies on an existing install (drop table → mark priors applied → `run_pending()` creates it + round-trips a row).
- Code-reviewed; two P2s fixed (re-stamp `granted_at` on re-grant; atomic `record_correction`).
- No CHANGELOG entry: dark groundwork has no user-visible effect (the entry rides with PR-C's behavior change).

Goes live on a server restart (migration); no MCP/voice surface touched.