### PR TITLE
feat(observability): surface ambient edge health in the infrastructure snapshot

### DIFF
--- a/src/genesis/observability/health.py
+++ b/src/genesis/observability/health.py
@@ -33,6 +33,11 @@ _guardian_remote_config_checked: bool = False
 _guardian_ssh_cache: dict[str, tuple[float, ProbeResult]] = {}
 _GUARDIAN_SSH_TTL = 60.0
 
+# Ambient-edge SSH probe cache: {host_ip: (monotonic_timestamp, ProbeResult)}.
+# Mirrors the guardian TTL so repeated snapshot reads don't re-SSH the edge.
+_ambient_ssh_cache: dict[str, tuple[float, ProbeResult]] = {}
+_AMBIENT_SSH_TTL = 60.0
+
 # WAL size thresholds — mirror awareness/loop.py's _check_wal_health. Kept local
 # to avoid an observability→awareness import cycle (awareness imports
 # observability, not the reverse). 100 MB → DEGRADED, 500 MB → DOWN.
@@ -609,4 +614,65 @@ async def _probe_guardian_ssh(remote, latency_ms: float, clock) -> ProbeResult:
 
     # Update cache
     _guardian_ssh_cache[host_ip] = (now, result)
+    return result
+
+
+# Maps the ambient-health evaluator's verdict vocabulary to ProbeStatus.
+# "unknown" (edge unreachable / file unreadable) -> DEGRADED: we genuinely can't
+# tell, which is neither healthy nor a confirmed-dead bridge. The alert policy
+# (OutreachScheduler) deliberately does NOT alert on unknown; this is the
+# observability surface, where "can't reach the edge" is worth showing.
+_AMBIENT_VERDICT_TO_PROBE = {
+    "ok": ProbeStatus.HEALTHY,
+    "degraded": ProbeStatus.DEGRADED,
+    "down": ProbeStatus.DOWN,
+    "unknown": ProbeStatus.DEGRADED,
+}
+
+
+async def probe_ambient_health(clock=None) -> ProbeResult | None:
+    """Probe the ambient-capture edge bridge for the observability surface.
+
+    Reuses the existing ambient-health module: load the install-local config
+    (``~/.genesis/ambient_remote.yaml``), SSH-read the edge ``ambient_health.json``,
+    and evaluate it — so ambient health is queryable via the infrastructure
+    snapshot / ``health_status``, not just emitted as a transient Telegram alert.
+
+    Returns ``None`` when no ambient edge is configured (the install has no
+    ambient capture): the caller then omits ambient from the snapshot entirely
+    (unlike guardian, an absent ambient edge is not a fault). Mirrors
+    ``probe_guardian``'s SSH-with-TTL-cache so repeated snapshot reads don't
+    hammer the edge.
+    """
+    from genesis.observability.ambient_health import (
+        evaluate_ambient_health,
+        load_ambient_remote_config,
+        read_edge_health,
+    )
+
+    _clock = clock or (lambda: datetime.now(UTC))
+    cfg = load_ambient_remote_config()
+    if cfg is None:
+        return None  # no ambient edge configured — observability no-op
+
+    now_mono = time.monotonic()
+    cached = _ambient_ssh_cache.get(cfg.host_ip)
+    if cached is not None:
+        cache_time, cache_result = cached
+        if (now_mono - cache_time) < _AMBIENT_SSH_TTL:
+            return cache_result
+
+    start = time.monotonic()
+    data = await read_edge_health(cfg)
+    latency = (time.monotonic() - start) * 1000
+    verdict = evaluate_ambient_health(data, now=_clock())
+    result = ProbeResult(
+        name="ambient",
+        status=_AMBIENT_VERDICT_TO_PROBE.get(verdict.status, ProbeStatus.DEGRADED),
+        latency_ms=round(latency, 2),
+        message="; ".join(verdict.reasons) if verdict.reasons else "",
+        checked_at=_clock().isoformat(),
+        details={"verdict": verdict.status},
+    )
+    _ambient_ssh_cache[cfg.host_ip] = (now_mono, result)
     return result

--- a/src/genesis/observability/snapshots/infrastructure.py
+++ b/src/genesis/observability/snapshots/infrastructure.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 from genesis.env import ollama_enabled
 from genesis.observability.health import (
+    probe_ambient_health,
     probe_db,
     probe_guardian,
     probe_ollama,
@@ -261,6 +262,22 @@ async def infrastructure(
             infra["guardian"].update(result.details)
     except Exception as exc:
         infra["guardian"] = {"status": "error", "error": str(exc)}
+
+    # Ambient-capture edge bridge (observability only). Omitted entirely when no
+    # ambient edge is configured — an absent ambient edge is not a fault.
+    try:
+        result = await probe_ambient_health()
+        if result is not None:
+            infra["ambient"] = {
+                "status": str(result.status),
+                "latency_ms": result.latency_ms,
+            }
+            if result.message:
+                infra["ambient"]["message"] = result.message
+            if result.details:
+                infra["ambient"].update(result.details)
+    except Exception as exc:
+        infra["ambient"] = {"status": "error", "error": str(exc)}
 
     if ollama_enabled():
         try:

--- a/tests/test_observability/test_health.py
+++ b/tests/test_observability/test_health.py
@@ -1,11 +1,12 @@
 """Tests for health probes."""
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from genesis.observability.health import (
+    probe_ambient_health,
     probe_db,
     probe_disk,
     probe_ollama,
@@ -232,3 +233,150 @@ class TestInfrastructureWalPlumbing:
 
         assert "wal_mb" not in infra["genesis.db"]
         assert "wal_status" not in infra["genesis.db"]
+
+
+class TestProbeAmbientHealth:
+    """probe_ambient_health: maps the ambient evaluator's verdict to a
+    ProbeResult for the observability surface (config + SSH read are mocked;
+    the real, pure evaluate_ambient_health runs)."""
+
+    _MOD = "genesis.observability.ambient_health"
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        from genesis.observability import health
+
+        health._ambient_ssh_cache.clear()
+        yield
+        health._ambient_ssh_cache.clear()
+
+    def _cfg(self):
+        from genesis.observability.ambient_health import AmbientRemoteConfig
+
+        return AmbientRemoteConfig(host_ip="ambient-test-host", host_user="edge")
+
+    @pytest.mark.asyncio
+    async def test_not_configured_returns_none(self):
+        # No ambient edge configured -> observability no-op (caller omits it).
+        with patch(f"{self._MOD}.load_ambient_remote_config", return_value=None):
+            result = await probe_ambient_health(clock=FROZEN_CLOCK)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_healthy(self):
+        snap = {"ts": FROZEN_CLOCK().isoformat(), "diar_enabled": True, "diar_worker_alive": True}
+        with (
+            patch(f"{self._MOD}.load_ambient_remote_config", return_value=self._cfg()),
+            patch(f"{self._MOD}.read_edge_health", new_callable=AsyncMock, return_value=snap),
+        ):
+            result = await probe_ambient_health(clock=FROZEN_CLOCK)
+        assert result is not None
+        assert result.name == "ambient"
+        assert result.status == ProbeStatus.HEALTHY
+        assert result.details["verdict"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_stale_heartbeat_is_down(self):
+        stale = (FROZEN_CLOCK() - timedelta(minutes=10)).isoformat()
+        snap = {"ts": stale, "diar_enabled": True, "diar_worker_alive": True}
+        with (
+            patch(f"{self._MOD}.load_ambient_remote_config", return_value=self._cfg()),
+            patch(f"{self._MOD}.read_edge_health", new_callable=AsyncMock, return_value=snap),
+        ):
+            result = await probe_ambient_health(clock=FROZEN_CLOCK)
+        assert result.status == ProbeStatus.DOWN
+        assert result.details["verdict"] == "down"
+
+    @pytest.mark.asyncio
+    async def test_dead_diar_worker_is_degraded(self):
+        snap = {"ts": FROZEN_CLOCK().isoformat(), "diar_enabled": True, "diar_worker_alive": False}
+        with (
+            patch(f"{self._MOD}.load_ambient_remote_config", return_value=self._cfg()),
+            patch(f"{self._MOD}.read_edge_health", new_callable=AsyncMock, return_value=snap),
+        ):
+            result = await probe_ambient_health(clock=FROZEN_CLOCK)
+        assert result.status == ProbeStatus.DEGRADED
+        assert result.details["verdict"] == "degraded"
+
+    @pytest.mark.asyncio
+    async def test_unreachable_edge_is_degraded_not_down(self):
+        # Read failure -> verdict "unknown" -> DEGRADED: we can't confirm, which
+        # is neither healthy nor a confirmed-dead bridge.
+        with (
+            patch(f"{self._MOD}.load_ambient_remote_config", return_value=self._cfg()),
+            patch(f"{self._MOD}.read_edge_health", new_callable=AsyncMock, return_value=None),
+        ):
+            result = await probe_ambient_health(clock=FROZEN_CLOCK)
+        assert result.status == ProbeStatus.DEGRADED
+        assert result.details["verdict"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_ttl_cache_avoids_second_ssh(self):
+        snap = {"ts": FROZEN_CLOCK().isoformat(), "diar_enabled": True, "diar_worker_alive": True}
+        read_mock = AsyncMock(return_value=snap)
+        with (
+            patch(f"{self._MOD}.load_ambient_remote_config", return_value=self._cfg()),
+            patch(f"{self._MOD}.read_edge_health", read_mock),
+        ):
+            first = await probe_ambient_health(clock=FROZEN_CLOCK)
+            second = await probe_ambient_health(clock=FROZEN_CLOCK)
+        assert first == second  # cached result returned
+        assert read_mock.await_count == 1  # the real "no second SSH" guarantee
+
+
+class TestInfrastructureAmbientPlumbing:
+    """Ambient health must surface in the infrastructure snapshot (so it flows
+    into health_status), and be ABSENT when no ambient edge is configured."""
+
+    @pytest.mark.asyncio
+    async def test_ambient_attached_when_configured(self):
+        ambient_probe = ProbeResult(
+            name="ambient",
+            status=ProbeStatus.HEALTHY,
+            latency_ms=1.2,
+            message="healthy",
+            details={"verdict": "ok"},
+        )
+        with patch(
+            "genesis.observability.snapshots.infrastructure.probe_ambient_health",
+            new_callable=AsyncMock,
+            return_value=ambient_probe,
+        ):
+            from genesis.observability.snapshots.infrastructure import infrastructure
+
+            infra = await infrastructure(
+                db=None, routing_config=None, learning_scheduler=None, state_machine=None,
+            )
+        assert infra["ambient"]["status"] == "healthy"
+        assert infra["ambient"]["verdict"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_ambient_absent_when_not_configured(self):
+        with patch(
+            "genesis.observability.snapshots.infrastructure.probe_ambient_health",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            from genesis.observability.snapshots.infrastructure import infrastructure
+
+            infra = await infrastructure(
+                db=None, routing_config=None, learning_scheduler=None, state_machine=None,
+            )
+        assert "ambient" not in infra
+
+    @pytest.mark.asyncio
+    async def test_ambient_error_surfaced_when_probe_raises(self):
+        # The probe normally swallows read failures (-> "unknown"), but the
+        # snapshot's defensive guard must still surface an unexpected raise.
+        with patch(
+            "genesis.observability.snapshots.infrastructure.probe_ambient_health",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ):
+            from genesis.observability.snapshots.infrastructure import infrastructure
+
+            infra = await infrastructure(
+                db=None, routing_config=None, learning_scheduler=None, state_machine=None,
+            )
+        assert infra["ambient"]["status"] == "error"
+        assert "boom" in infra["ambient"]["error"]


### PR DESCRIPTION
## What
Stage D of the ambient-capture roadmap: make the ambient edge bridge's health **queryable** via the infrastructure snapshot / `health_status` MCP — instead of only a transient Telegram alert (#680/#685 added the alert, but nothing surfaced the verdict anywhere you could query it).

## How
- New `probe_ambient_health()` in `observability/health.py` — reuses the existing `ambient_health` module (config load → SSH read → `evaluate_ambient_health`) and maps the verdict to a `ProbeResult`:
  - `ok→HEALTHY`, `degraded→DEGRADED`, `down→DOWN`, `unknown→DEGRADED` (edge unreachable is neither healthy nor a confirmed-dead bridge).
  - Returns `None` when no ambient edge is configured → the snapshot omits ambient entirely (an absent edge is not a fault, unlike guardian).
  - Mirrors `probe_guardian`'s SSH-with-TTL-cache (60s) so repeated snapshot reads don't re-SSH.
- Wired into `infrastructure()` after the guardian block → flows into `health_status` automatically.

## Scope
Observability only. Deliberately does NOT touch `_KNOWN_SUBSYSTEMS` or the dream cycle (those belong to the deferred Stage C memory-graduation work).

## Tests / verification
- 9 new unit + integration tests (verdict mapping, unconfigured→None, unreachable→DEGRADED, TTL cache, snapshot attach/omit/error-guard); full `test_observability/test_health.py` + `test_ambient_health.py` green (38 tests).
- Verified **live** against the running ambient edge: the probe SSH-reads the bridge and `infra["ambient"]` surfaces a real healthy verdict.