### PR TITLE
fix(inbox): defer cooldown modifications + dedup re-pasted URLs + tz hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Inbox items added soon after an evaluation are no longer silently skipped** — if you added a
+  link or note to an inbox file within the cool-down window just after Genesis had evaluated that
+  file, the new item could be marked as seen without ever being evaluated, and it stayed stranded
+  until you edited the file again. Genesis now defers those additions and picks them up on the
+  next pass once the cool-down clears, so nothing you add gets lost.
+
+- **Re-sharing an article you already added no longer creates a duplicate evaluation** — links
+  often carry per-share tracking parameters (for example, the same LinkedIn post shared from your
+  phone vs. your desktop produces different URLs), which used to make a re-paste look brand new.
+  Genesis now ignores those tracking parameters when deciding what's new, so the same article
+  isn't evaluated twice or spawn a duplicate follow-up.
+
 - **The ego subsystem no longer shows a false "overdue" health status** — the health view marks
   a background subsystem "overdue" if it hasn't checked in within a window, and the ego's check-in
   was tied to its proactive thinking timer. That timer deliberately slows down during quiet

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -16,7 +16,13 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 from genesis.autonomy.autonomous_dispatch import AutonomousDispatchRequest
 from genesis.cc.session_config import SessionConfigBuilder
-from genesis.inbox.scanner import compute_hash, detect_changes, read_content, scan_folder
+from genesis.inbox.scanner import (
+    compute_hash,
+    detect_changes,
+    normalize_url_line,
+    read_content,
+    scan_folder,
+)
 from genesis.inbox.types import CheckResult, InboxConfig, InboxItem
 from genesis.security import ContentSanitizer, ContentSource
 from genesis.util.tz import parse_utc_iso
@@ -1504,14 +1510,23 @@ def _compute_new_content(old_content: str, new_content: str) -> str:
     Uses a set of non-empty stripped lines from the old content to identify
     which lines in the new content are genuinely new. Preserves order and
     blank lines between new items.
+
+    Lines are compared after URL tracking-param normalization, so the same
+    article re-pasted with different share/tracking params is not treated as
+    new. The original (un-normalized) line is kept in the output for evaluation.
     """
-    old_lines = {line.strip() for line in old_content.splitlines() if line.strip()}
+    old_lines = {
+        normalize_url_line(line.strip())
+        for line in old_content.splitlines()
+        if line.strip()
+    }
     new_lines = new_content.splitlines()
     result: list[str] = []
     for line in new_lines:
-        if line.strip() and line.strip() not in old_lines:
+        stripped = line.strip()
+        if stripped and normalize_url_line(stripped) not in old_lines:
             result.append(line)
-        elif not line.strip() and result:
+        elif not stripped and result:
             # Keep blank lines between new items for readability
             result.append(line)
     # Strip trailing blank lines

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -19,6 +19,7 @@ from genesis.cc.session_config import SessionConfigBuilder
 from genesis.inbox.scanner import compute_hash, detect_changes, read_content, scan_folder
 from genesis.inbox.types import CheckResult, InboxConfig, InboxItem
 from genesis.security import ContentSanitizer, ContentSource
+from genesis.util.tz import parse_utc_iso
 
 logger = logging.getLogger(__name__)
 
@@ -586,31 +587,34 @@ class InboxMonitor:
             # timeout_at=None blocks the inbox monitor indefinitely when
             # the user never responds and no new files arrive.
             created_str = pending.get("created_at", "")
-            if created_str:
-                try:
-                    created_dt = datetime.fromisoformat(created_str)
-                    age = self._clock() - created_dt
-                    if age > _MAX_APPROVAL_STALENESS:
-                        pending_id = pending.get("id")
-                        logger.info(
-                            "Cancelling stale inbox approval %s "
-                            "(%.1fh old, threshold %.1fh)",
+            created_dt = parse_utc_iso(created_str)
+            if created_str and created_dt is None:
+                logger.warning(
+                    "Staleness guard: unparseable approval created_at %r; "
+                    "skipping age-check this cycle (guard left intact)",
+                    created_str,
+                )
+            if created_dt is not None:
+                age = self._clock() - created_dt
+                if age > _MAX_APPROVAL_STALENESS:
+                    pending_id = pending.get("id")
+                    logger.info(
+                        "Cancelling stale inbox approval %s "
+                        "(%.1fh old, threshold %.1fh)",
+                        pending_id,
+                        age.total_seconds() / 3600,
+                        _MAX_APPROVAL_STALENESS.total_seconds() / 3600,
+                    )
+                    try:
+                        gate = self._autonomous_dispatcher.approval_gate
+                        await gate.approval_manager.cancel(pending_id)
+                    except Exception:
+                        logger.warning(
+                            "Failed to cancel stale approval %s",
                             pending_id,
-                            age.total_seconds() / 3600,
-                            _MAX_APPROVAL_STALENESS.total_seconds() / 3600,
+                            exc_info=True,
                         )
-                        try:
-                            gate = self._autonomous_dispatcher.approval_gate
-                            await gate.approval_manager.cancel(pending_id)
-                        except Exception:
-                            logger.warning(
-                                "Failed to cancel stale approval %s",
-                                pending_id,
-                                exc_info=True,
-                            )
-                        pending = None  # Cleared — proceed normally
-                except (ValueError, TypeError):
-                    pass
+                    pending = None  # Cleared — proceed normally
 
         if pending is not None:
             # Approval pending — scan anyway to detect new content.
@@ -799,24 +803,24 @@ class InboxMonitor:
                 self._db, str(f),
             )
             if last_at:
-                try:
-                    last_dt = datetime.fromisoformat(last_at)
-                    if now - last_dt < cooldown:
-                        logger.debug(
-                            "Cooldown: skipping %s (last eval %s ago)",
-                            f, now - last_dt,
-                        )
-                        await inbox_items.create(
-                            self._db,
-                            id=item_id,
-                            file_path=str(f),
-                            content_hash=h,
-                            status="completed",
-                            created_at=now_iso,
-                        )
-                        continue
-                except (ValueError, TypeError):
-                    pass  # Unparseable timestamp — proceed with evaluation
+                last_dt = parse_utc_iso(last_at)
+                if last_dt is None:
+                    logger.warning(
+                        "Cooldown check: unparseable last-eval timestamp "
+                        "%r for %s; proceeding with evaluation", last_at, f,
+                    )
+                elif now - last_dt < cooldown:
+                    # Defer WITHOUT consuming. Do NOT write a 'completed' row
+                    # here: that would advance the known content hash and the
+                    # modification would never be re-detected, stranding the
+                    # new content until the next edit. Skipping leaves the file
+                    # detectable, so the next check past the cooldown window
+                    # re-detects and evaluates it.
+                    logger.debug(
+                        "Cooldown: deferring %s (last eval %s ago)",
+                        f, now - last_dt,
+                    )
+                    continue
             existing = await inbox_items.get_by_file_path(self._db, str(f))
             if existing and existing["status"] == "pending":
                 await inbox_items.update_status(

--- a/src/genesis/inbox/scanner.py
+++ b/src/genesis/inbox/scanner.py
@@ -3,9 +3,62 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 RESPONSE_SUFFIX = ".genesis.md"
+
+# URL deduplication: strip volatile tracking/share params so the same article
+# re-pasted with different params (e.g. a LinkedIn share from android vs
+# desktop) compares equal. Query params only — URL *paths* are left intact
+# (path-level share codes are too risky to strip).
+_URL_IN_LINE_RE = re.compile(r"https?://[^\s]+")
+_TRACKING_PARAM_PREFIXES = ("utm_", "mc_")
+_TRACKING_PARAM_EXACT = frozenset({
+    "rcm", "fbclid", "gclid", "igshid", "mkt_tok",
+    "_hsenc", "_hsmi", "vero_id", "yclid", "msclkid", "trk", "trkemail",
+})
+_URL_TRAILING_PUNCT = ".,;:!?)]}'\""
+
+
+def _strip_tracking_params(url: str) -> str:
+    """Remove tracking query params from a single URL; leave path/fragment intact."""
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return url
+    if not parts.query:
+        return url
+    kept = [
+        (k, v)
+        for k, v in parse_qsl(parts.query, keep_blank_values=True)
+        if not (
+            k.lower().startswith(_TRACKING_PARAM_PREFIXES)
+            or k.lower() in _TRACKING_PARAM_EXACT
+        )
+    ]
+    return urlunsplit((
+        parts.scheme, parts.netloc, parts.path, urlencode(kept), parts.fragment,
+    ))
+
+
+def normalize_url_line(line: str) -> str:
+    """Return *line* with tracking query params stripped from any URL it contains.
+
+    Used only for dedup comparison — the original line is preserved for
+    evaluation. Non-URL text is returned unchanged; trailing sentence
+    punctuation after a URL is preserved.
+    """
+    def _repl(match: re.Match[str]) -> str:
+        raw = match.group(0)
+        trail = ""
+        while raw and raw[-1] in _URL_TRAILING_PUNCT:
+            trail = raw[-1] + trail
+            raw = raw[:-1]
+        return _strip_tracking_params(raw) + trail
+
+    return _URL_IN_LINE_RE.sub(_repl, line)
 
 
 def scan_folder(

--- a/src/genesis/inbox/scanner.py
+++ b/src/genesis/inbox/scanner.py
@@ -13,7 +13,10 @@ RESPONSE_SUFFIX = ".genesis.md"
 # re-pasted with different params (e.g. a LinkedIn share from android vs
 # desktop) compares equal. Query params only — URL *paths* are left intact
 # (path-level share codes are too risky to strip).
-_URL_IN_LINE_RE = re.compile(r"https?://[^\s]+")
+# Exclude <> (and rely on the trailing-punct stripper for )]} etc.) so a
+# markdown-style <https://...> URL is matched cleanly, mirroring the URL
+# extraction regex in monitor.py.
+_URL_IN_LINE_RE = re.compile(r"https?://[^\s<>]+")
 _TRACKING_PARAM_PREFIXES = ("utm_", "mc_")
 _TRACKING_PARAM_EXACT = frozenset({
     "rcm", "fbclid", "gclid", "igshid", "mkt_tok",

--- a/src/genesis/util/tz.py
+++ b/src/genesis/util/tz.py
@@ -55,3 +55,27 @@ def fmt(iso_str: str, fmt_str: str = "%a %Y-%m-%d %H:%M %Z") -> str:
 def fmt_short(iso_str: str) -> str:
     """Short time-only format: '14:30 EST'."""
     return fmt(iso_str, "%H:%M %Z")
+
+
+def parse_utc_iso(iso_str: str | None) -> datetime | None:
+    """Parse a stored ISO-8601 timestamp into a UTC-aware ``datetime``.
+
+    Genesis stores timestamps as UTC ISO strings. A value written without an
+    offset (naive) is treated as UTC. Returns ``None`` on empty or unparseable
+    input so callers can branch explicitly instead of silently swallowing the
+    error and disabling a guard.
+
+    Unlike :func:`fmt`, this is for *comparison/arithmetic* on the read path,
+    not display. Use it wherever a stored timestamp is subtracted from
+    ``datetime.now(UTC)`` so a naive value can never raise
+    ``can't subtract offset-naive and offset-aware datetimes``.
+    """
+    if not iso_str:
+        return None
+    try:
+        dt = datetime.fromisoformat(iso_str)
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt

--- a/tests/test_inbox/test_edge_cases.py
+++ b/tests/test_inbox/test_edge_cases.py
@@ -647,6 +647,34 @@ def test_compute_new_content_blank_lines_preserved():
     assert "new item 2" in delta
 
 
+def test_compute_new_content_dedups_tracking_param_variants():
+    """The same URL re-pasted with different tracking params is not 'new'."""
+    from genesis.inbox.monitor import _compute_new_content
+
+    old = "https://example.com/post?utm_source=android&utm_medium=member&rcm=AAA"
+    new = "https://example.com/post?utm_source=desktop&utm_medium=web&rcm=BBB"
+    assert _compute_new_content(old, new).strip() == ""
+
+
+def test_compute_new_content_keeps_genuinely_distinct_urls():
+    """Different articles must still register as new even with tracking params."""
+    from genesis.inbox.monitor import _compute_new_content
+
+    old = "https://example.com/post-a?utm_source=x"
+    new = "https://example.com/post-b?utm_source=y"
+    assert "post-b" in _compute_new_content(old, new)
+
+
+def test_compute_new_content_preserves_original_url_line():
+    """The delta keeps the original (un-normalized) line for evaluation."""
+    from genesis.inbox.monitor import _compute_new_content
+
+    old = "seed"
+    new = "seed\nhttps://example.com/post?id=5&utm_source=x"
+    delta = _compute_new_content(old, new)
+    assert "https://example.com/post?id=5&utm_source=x" in delta
+
+
 @pytest.mark.asyncio
 async def test_modified_file_only_sends_delta(
     monitor, inbox_dir, mock_invoker, db,

--- a/tests/test_inbox/test_monitor.py
+++ b/tests/test_inbox/test_monitor.py
@@ -416,6 +416,41 @@ async def test_cooldown_defers_without_dropping_modification(
     mock_invoker.run.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_e2e_url_repaste_different_tracking_not_reevaluated(
+    db, mock_invoker, mock_session_manager, inbox_dir, tmp_path,
+):
+    """End-to-end via check_once: the same article re-pasted with different
+    share/tracking params is detected as a file change but produces no new
+    content, so it is not re-evaluated (no duplicate dispatch)."""
+    clock = _FakeClock()
+    # cooldown=0 isolates the URL-dedup path from the cooldown defer.
+    config = InboxConfig(
+        watch_path=inbox_dir, batch_size=5, evaluation_cooldown_seconds=0,
+    )
+    writer = ResponseWriter(watch_path=inbox_dir, timezone="UTC")
+    mon = InboxMonitor(
+        db=db, invoker=mock_invoker, session_manager=mock_session_manager,
+        config=config, writer=writer, clock=clock, prompt_dir=tmp_path,
+    )
+    f = inbox_dir / "Genesis.md"
+    base = "https://www.linkedin.com/posts/foo-share-123-1G81/"
+
+    # First paste (android share) -> evaluated.
+    f.write_text(base + "?utm_source=share&utm_medium=member_android&rcm=AAA")
+    assert (await mon.check_once()).batches_dispatched == 1
+
+    mock_invoker.run.reset_mock()
+
+    # Re-paste of the SAME post from desktop (different tracking params).
+    clock.now = clock.now + timedelta(minutes=1)
+    f.write_text(base + "?utm_source=share&utm_medium=member_desktop&rcm=BBB")
+    r2 = await mon.check_once()
+    assert r2.items_modified == 1  # hash changed -> detected as modified
+    assert r2.batches_dispatched == 0  # ...but no NEW content -> no re-eval
+    mock_invoker.run.assert_not_called()
+
+
 # --- URL extraction tests ---
 
 

--- a/tests/test_inbox/test_monitor.py
+++ b/tests/test_inbox/test_monitor.py
@@ -371,6 +371,51 @@ async def test_cooldown_skips_recently_evaluated(
     assert result3.batches_dispatched == 1
 
 
+@pytest.mark.asyncio
+async def test_cooldown_defers_without_dropping_modification(
+    db, mock_invoker, mock_session_manager, inbox_dir, tmp_path,
+):
+    """A modification made within cooldown must still be evaluated once the
+    cooldown elapses, even if the file is never edited again.
+
+    Regression (cooldown-consume): the cooldown branch used to write a
+    'completed' row carrying the new content hash with no evaluation, which
+    advanced the known hash so the change was never re-detected — stranding
+    the new content until the next edit.
+    """
+    clock = _FakeClock()
+    config = InboxConfig(
+        watch_path=inbox_dir, batch_size=5, evaluation_cooldown_seconds=3600,
+    )
+    writer = ResponseWriter(watch_path=inbox_dir, timezone="UTC")
+    mon = InboxMonitor(
+        db=db, invoker=mock_invoker, session_manager=mock_session_manager,
+        config=config, writer=writer, clock=clock, prompt_dir=tmp_path,
+    )
+    f = inbox_dir / "doc.md"
+
+    f.write_text("alpha")
+    assert (await mon.check_once()).batches_dispatched == 1
+
+    # Edit within cooldown -> deferred, not dispatched.
+    clock.now = clock.now + timedelta(minutes=10)
+    f.write_text("alpha\nbeta")
+    r2 = await mon.check_once()
+    assert r2.items_modified == 1
+    assert r2.batches_dispatched == 0
+
+    mock_invoker.run.reset_mock()
+
+    # Cooldown elapses; the file is NOT touched again. The deferred change
+    # must now be picked up and evaluated (not stranded with the hash advanced).
+    clock.now = clock.now + timedelta(hours=2)
+    r3 = await mon.check_once()
+    assert r3.batches_dispatched == 1, (
+        "modification deferred during cooldown was never evaluated"
+    )
+    mock_invoker.run.assert_called_once()
+
+
 # --- URL extraction tests ---
 
 

--- a/tests/test_inbox/test_scanner.py
+++ b/tests/test_inbox/test_scanner.py
@@ -6,7 +6,55 @@ from pathlib import Path
 
 import pytest
 
-from genesis.inbox.scanner import compute_hash, detect_changes, read_content, scan_folder
+from genesis.inbox.scanner import (
+    compute_hash,
+    detect_changes,
+    normalize_url_line,
+    read_content,
+    scan_folder,
+)
+
+
+class TestNormalizeUrlLine:
+    def test_strips_tracking_params_to_equal(self):
+        a = normalize_url_line(
+            "https://x.com/p?utm_source=android&utm_medium=member&rcm=AAA"
+        )
+        b = normalize_url_line(
+            "https://x.com/p?utm_source=desktop&utm_medium=web&rcm=BBB"
+        )
+        assert a == b == "https://x.com/p"
+
+    def test_keeps_meaningful_params(self):
+        assert (
+            normalize_url_line("https://x.com/p?id=5&utm_source=x")
+            == "https://x.com/p?id=5"
+        )
+
+    def test_leaves_non_url_text(self):
+        assert normalize_url_line("just some text") == "just some text"
+
+    def test_leaves_url_without_query(self):
+        assert normalize_url_line("https://x.com/a/b") == "https://x.com/a/b"
+
+    def test_preserves_trailing_punctuation(self):
+        assert (
+            normalize_url_line("see https://x.com/p?utm_source=x.")
+            == "see https://x.com/p."
+        )
+
+    def test_does_not_strip_path_share_codes(self):
+        # Path-level share codes are intentionally left intact (too risky).
+        assert (
+            normalize_url_line("https://lnkd.in/posts/foo-share-123-1G81/?rcm=A")
+            == "https://lnkd.in/posts/foo-share-123-1G81/"
+        )
+
+    def test_url_mid_line(self):
+        assert (
+            normalize_url_line("read https://x.com/p?fbclid=Z now")
+            == "read https://x.com/p now"
+        )
 
 
 @pytest.fixture

--- a/tests/test_inbox/test_scanner.py
+++ b/tests/test_inbox/test_scanner.py
@@ -56,6 +56,13 @@ class TestNormalizeUrlLine:
             == "read https://x.com/p now"
         )
 
+    def test_angle_bracketed_url(self):
+        # Markdown <url> form: the bracket must not leak into the URL path.
+        assert (
+            normalize_url_line("<https://x.com/p?utm_source=x>")
+            == "<https://x.com/p>"
+        )
+
 
 @pytest.fixture
 def inbox_dir(tmp_path: Path) -> Path:

--- a/tests/test_util/test_tz.py
+++ b/tests/test_util/test_tz.py
@@ -1,11 +1,12 @@
 """Tests for genesis.util.tz — timezone display helpers."""
 
+from datetime import UTC, datetime
 from zoneinfo import ZoneInfo
 
 import pytest
 
 import genesis.util.tz as tz_module
-from genesis.util.tz import fmt, fmt_short
+from genesis.util.tz import fmt, fmt_short, parse_utc_iso
 
 
 @pytest.fixture()
@@ -50,3 +51,30 @@ class TestFmtShort:
     def test_short_format(self, eastern_tz):
         result = fmt_short("2026-01-15T17:00:00+00:00")
         assert result == "12:00 EST"
+
+
+class TestParseUtcIso:
+    def test_aware_string_preserved(self):
+        dt = parse_utc_iso("2026-06-20T17:00:00+00:00")
+        assert dt == datetime(2026, 6, 20, 17, 0, tzinfo=UTC)
+        assert dt.tzinfo is not None
+
+    def test_naive_string_assumed_utc(self):
+        dt = parse_utc_iso("2026-06-20T17:00:00")
+        assert dt == datetime(2026, 6, 20, 17, 0, tzinfo=UTC)
+        assert dt.tzinfo is UTC
+
+    def test_naive_result_is_aware_and_subtractable(self):
+        # The core bug this guards against: naive value subtracted from aware now.
+        dt = parse_utc_iso("2026-06-20T17:00:00")
+        delta = datetime.now(UTC) - dt  # must not raise
+        assert delta.total_seconds() >= 0
+
+    def test_none_returns_none(self):
+        assert parse_utc_iso(None) is None
+
+    def test_empty_returns_none(self):
+        assert parse_utc_iso("") is None
+
+    def test_invalid_returns_none(self):
+        assert parse_utc_iso("not-a-timestamp") is None


### PR DESCRIPTION
## Context

Came out of an inbox investigation ("why didn't my pasted link get evaluated?"). The original symptom self-resolved (the item evaluated on the next interval — no permanent-drop bug there), but the dig surfaced three genuine defects. Scope was narrowed by due diligence: the duplication-*prevention* layer first considered was dropped because the monotonic baseline guard (#473) already dedups seen URLs.

## Fixes

1. **Cooldown-consume** — when a file was modified within `evaluation_cooldown_seconds` of its last eval, the cooldown branch wrote a `completed` `inbox_items` row carrying the *new* content hash with no evaluation. `get_all_known` then returned that hash, so the change was never re-detected — new content added shortly after an eval was stranded until the next edit (and lost if it was the last edit). Now the cooldown path **defers without consuming**: it leaves the known hash unchanged so the next check past the cooldown re-detects and evaluates it.

2. **URL re-paste dedup** — new `normalize_url_line()` strips volatile tracking/share query params (`utm_*`, `mc_*`, `rcm`, `fbclid`, `gclid`, `igshid`, …; URL **paths** left intact). Applied in `_compute_new_content`'s line comparison, so the same article re-pasted with different tracking params (e.g. a post shared from phone vs. desktop) yields an empty delta — no re-evaluation, no duplicate follow-up. The original line is preserved for evaluation. Complements #473's byte-identical dedup.

3. **Timezone hardening** — new `parse_utc_iso()` (treats a naive stored timestamp as UTC, returns `None` on bad input). The two `except (ValueError, TypeError): pass` swallows in the monitor (approval-staleness + cooldown guards) — which silently *disabled* those guards on a tz error — now log a warning instead.

## Testing

- TDD: each behavioral fix has a failing-test-first regression (`test_cooldown_defers_without_dropping_modification`, the `_compute_new_content` dedup tests).
- True E2E through `check_once`: `test_e2e_url_repaste_different_tracking_not_reevaluated`.
- Full `tests/test_inbox/` + `tests/test_util/` green locally (264 passed); `ruff check` clean on the diff.

## Review

Adversarial code-review pass: no P1/P2 issues; cooldown timing, re-detection churn-safety, tz subtraction, and URL false-dedup all explicitly cleared. One nit applied (P3-2: exclude `<>` from the URL match for markdown `<url>` form).

## Notes

- No DB schema change.
- Not auto-deployed (the server was restart-thrashing during the session); deploy is a separate gated step.
- Cleanup of pre-existing duplicate inbox follow-ups was handled separately as a data operation, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)