### PR TITLE
feat(autonomy): WS-8 PR-C — deterministic email autonomy gate (D5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis won't send email on its own without your say-so** — outbound email now passes
+  a deterministic authorization check before it leaves. A reply on a thread you're already
+  in goes out normally, but anything else — a cold first email, a bulk or campaign send, or
+  anything involving money — is held for your approval and sent only once you approve it
+  (rejected or unanswered holds are never sent). Genesis earns the ability to send a given
+  kind of email on its own as you approve them over time, so you stay in the loop by default.
+
 - **See what Genesis did as a timeline** — the dashboard has a new **Traces** tab that
   renders each recorded operation (a reflection, an ego cycle, a dispatched session) as a
   nested waterfall: pick a recent trace and its LLM calls, sub-sessions, and tools lay out as

--- a/src/genesis/autonomy/approval_gate.py
+++ b/src/genesis/autonomy/approval_gate.py
@@ -469,10 +469,19 @@ class AutonomousCliApprovalGate:
         }
 
     async def approve_all_pending(self, *, resolved_by: str) -> int:
-        """Approve every pending approval request.  Returns count approved."""
+        """Approve every pending approval request.  Returns count approved.
+
+        WS-8 email capability-gate holds are EXCLUDED: each held email is an
+        independent send decision and must be approved individually, never
+        swept by a batch "approve all".
+        """
+        from genesis.autonomy.email_gate import EMAIL_GATE_ACTION_TYPE
+
         pending = await self._approval_manager.get_pending()
         count = 0
         for req in pending:
+            if req.get("action_type") == EMAIL_GATE_ACTION_TYPE:
+                continue
             ok = await self._approval_manager.resolve(
                 req["id"], status="approved", resolved_by=resolved_by,
             )

--- a/src/genesis/autonomy/email_gate.py
+++ b/src/genesis/autonomy/email_gate.py
@@ -1,0 +1,188 @@
+"""WS-8 email autonomy gate — the deterministic capability check at the
+``outreach.pipeline._deliver`` chokepoint (Tenet 0).
+
+For ``channel=="email"`` the pipeline calls :meth:`EmailAutonomyGate.check`
+BEFORE ``adapter.send_message``.  The gate decides send/hold in CODE, *below*
+the LLM tool call — it is never a permissions prompt the model sees, and it is
+unbypassable because every send path (MCP tool, scheduler drain, recovery
+retry, ~12 direct callers) converges on ``_deliver``.
+
+On HOLD it records the fully-resolved send to ``pending_email_sends`` and
+creates a linked ``approval_requests`` row (approval row FIRST so a crash can't
+leave a pending row with no approval), emits ``autonomy.gate_held`` at
+``Severity.INFO`` (an EXPECTED autonomy event, inert to the failure scorers),
+and returns a hold decision.  A resolution watcher later sends the held email
+below the gate on approval, or expires it on reject/timeout — see
+``runtime/init`` and ``db/crud/pending_email_sends``.
+
+GRANTED_EPHEMERAL = the basic per-hold approve-and-send: the watcher records a
+single ``record_success`` on the cell but does NOT promote it to GRANTED
+(promotion is earned via PR-D earn-back or an explicit grant).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import aiosqlite
+
+from genesis.autonomy.capabilities import InvalidTransition
+from genesis.autonomy.classification import classify_email_action
+from genesis.autonomy.types import CellEvent, CellState, RiskClass
+from genesis.db.crud import capability_grants as cg
+from genesis.db.crud import pending_email_sends as pes
+from genesis.observability.types import Severity, Subsystem
+
+logger = logging.getLogger(__name__)
+
+#: Distinct action_type so these holds are isolated from CLI-fallback approvals
+#: (excluded from ``approve_all_pending`` / the voice pending count).
+EMAIL_GATE_ACTION_TYPE = "email_capability_gate"
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Outcome of an autonomy-gate check. ``allow`` False ⇒ the send was held."""
+
+    allow: bool
+    pending_id: str | None = None
+    request_id: str | None = None
+    reason: str = ""
+
+
+class EmailAutonomyGate:
+    """Deterministic owner-authorization gate for outbound email (WS-8)."""
+
+    def __init__(
+        self,
+        *,
+        db: aiosqlite.Connection,
+        approval_manager: object,
+        event_bus: object | None = None,
+    ) -> None:
+        self._db = db
+        self._approval = approval_manager
+        self._event_bus = event_bus
+
+    async def check(
+        self, *, request: object, recipient: str, message_text: str,
+    ) -> GateDecision:
+        """Allow or hold an outbound email. ``recipient`` is the resolved
+        delivery address (validated thread recipient or pipeline default)."""
+        now = datetime.now(UTC).isoformat()
+
+        # 1. Derive classifier inputs in CODE — never from the LLM.
+        recipient_known = getattr(request, "validated_recipient", None) is not None
+        is_reply = await self._has_inbound(getattr(request, "thread_id", None))
+        is_bulk = bool(getattr(request, "labeled_surplus", False))
+        classification = classify_email_action(
+            is_reply=is_reply,
+            recipient_known=recipient_known,
+            is_bulk=is_bulk,
+            subject=getattr(request, "topic", "") or "",
+            body=message_text,
+        )
+        domain, verb, risk = classification.cell_key
+
+        # 2. FINANCIAL is hardline — held BEFORE any cell lookup, so a stray
+        #    approval can never create/unlock a financial cell.
+        if classification.risk_class == RiskClass.FINANCIAL:
+            return await self._hold(request, message_text, classification, recipient, now)
+
+        # 3. First sight of a cell moves NOT_DETERMINED → ASK; then read state.
+        #    Suppress InvalidTransition: the cell may already be past ASK.
+        with contextlib.suppress(InvalidTransition):
+            await cg.apply_event(
+                self._db, domain=domain, verb=verb, risk_class=risk,
+                event=CellEvent.CLASSIFY, updated_at=now,
+            )
+        cell = await cg.get_cell(self._db, domain, verb, risk)
+        state = CellState(cell["state"]) if cell else CellState.ASK
+
+        if state == CellState.GRANTED:
+            return GateDecision(allow=True, reason="granted")
+
+        # 4. ASK / NOT_DETERMINED / DENIED → hold for owner approval.
+        return await self._hold(request, message_text, classification, recipient, now)
+
+    async def _has_inbound(self, thread_id: str | None) -> bool:
+        """True iff the email thread has at least one received (inbound) message
+        — i.e. this send is a reply, not cold outreach."""
+        if not thread_id:
+            return False
+        cursor = await self._db.execute(
+            "SELECT 1 FROM email_thread_messages "
+            "WHERE thread_id = ? AND direction = 'received' LIMIT 1",
+            (thread_id,),
+        )
+        return await cursor.fetchone() is not None
+
+    async def _hold(
+        self, request: object, message_text: str, classification: object,
+        recipient: str, now: str,
+    ) -> GateDecision:
+        domain, verb, risk = classification.cell_key
+        thread_id = getattr(request, "thread_id", None)
+        category = getattr(request, "category", None)
+        category_val = category.value if category is not None else "outreach"
+        context = json.dumps({
+            "kind": EMAIL_GATE_ACTION_TYPE,
+            "cell": [domain, verb, risk],
+            "validated_recipient": recipient,
+            "thread_id": thread_id,
+            "subject": getattr(request, "topic", "") or "",
+            "category": category_val,
+        })
+
+        # Approval row FIRST — so a crash between the two writes never leaves a
+        # pending_email_sends row pointing at a non-existent approval.
+        request_id = await self._approval.request_approval(
+            action_type=EMAIL_GATE_ACTION_TYPE,
+            action_class=str(classification.action_class),
+            description=f"Send {classification.sub_class} email to {recipient}",
+            context=context,
+            timeout_seconds=None,  # wait for the owner; never auto-approve, never auto-drop
+        )
+        pending_id = str(uuid.uuid4())
+        await pes.create(
+            self._db,
+            id=pending_id,
+            request_id=request_id,
+            validated_recipient=recipient,
+            category=category_val,
+            message=message_text,
+            cell_domain=domain,
+            cell_verb=verb,
+            cell_risk_class=risk,
+            held_at=now,
+            thread_id=thread_id,
+        )
+        await self._emit_held(classification, recipient)
+        logger.info(
+            "Email gate HELD %s send to %s (cell=%s:%s:%s, request=%s)",
+            classification.sub_class, recipient, domain, verb, risk, request_id,
+        )
+        return GateDecision(
+            allow=False, pending_id=pending_id, request_id=request_id, reason="held",
+        )
+
+    async def _emit_held(self, classification: object, recipient: str) -> None:
+        """Emit the EXPECTED autonomy.gate_held event at INFO (Tenet 0b) — so
+        system monitoring knows a hold is routine, not a tool failure."""
+        if self._event_bus is None:
+            return
+        try:
+            await self._event_bus.emit(
+                Subsystem.AUTONOMY,
+                Severity.INFO,
+                "autonomy.gate_held",
+                f"Email capability gate held a {classification.sub_class} send "
+                f"to {recipient} (cell {':'.join(classification.cell_key)})",
+            )
+        except Exception:
+            logger.error("Failed to emit autonomy.gate_held", exc_info=True)

--- a/src/genesis/autonomy/email_gate_watcher.py
+++ b/src/genesis/autonomy/email_gate_watcher.py
@@ -65,6 +65,18 @@ async def drain_pending_email_sends(rt: object) -> int:
 
         status = approval.get("status")
         if status == "approved":
+            if approval.get("consumed_at") is not None:
+                # The approval was already consumed — a prior cycle delivered it
+                # but crashed before marking the hold 'sent'. Reconcile WITHOUT
+                # re-sending: this narrows the at-least-once window to the gap
+                # between adapter.send and mark_consumed.
+                await pes.mark_sent(db, row["id"], sent_at=now)
+                resolved += 1
+                logger.info(
+                    "Reconciled held email %s (approval already consumed) — not re-sent",
+                    row["id"],
+                )
+                continue
             # Deliver FIRST (verbatim, below the gate). Only on success do we
             # mark sent/consumed — a transient failure leaves the row held for
             # the next cycle (the drain owns resume retries).

--- a/src/genesis/autonomy/email_gate_watcher.py
+++ b/src/genesis/autonomy/email_gate_watcher.py
@@ -1,0 +1,105 @@
+"""WS-8 email gate resolution watcher — drains held sends.
+
+The correctness guarantee for the email autonomy gate: a periodic drain
+(``CronTrigger`` */5min, ``max_instances=1``) that resolves each
+``pending_email_sends`` row against its linked approval:
+
+- **approved**  → send below the gate (``pipeline.deliver_approved``,
+  ``gate_cleared``) + ``record_success`` on the cell + mark sent/consumed.
+- **rejected/cancelled** → mark rejected + ``record_correction`` (an explicit
+  no is competence-negative).
+- **expired** → mark expired, NO correction (no-decision ≠ rejection).
+- **orphaned** (approval row gone) → expire, never send.
+- **pending** → still waiting; left held.
+
+Single-threaded (``max_instances=1``) so there are no in-drain races.
+Deliver-first ordering makes an approved send **at-least-once**: a crash between
+a successful ``adapter.send`` and ``mark_sent`` re-delivers next cycle (rare).
+A transient delivery failure leaves the row held and is retried next cycle —
+``deliver_approved`` sets ``gate_cleared`` and ``_deliver`` skips ``_defer`` for
+gate-cleared sends, so the drain is the SOLE retry owner (no re-gate loop).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+
+from genesis.db.crud import approval_requests as approval_crud
+from genesis.db.crud import capability_grants as cg
+from genesis.db.crud import pending_email_sends as pes
+from genesis.outreach.types import OutreachStatus
+
+logger = logging.getLogger(__name__)
+
+
+def _subject(context: str | None) -> str:
+    if not context:
+        return ""
+    try:
+        return json.loads(context).get("subject", "") or ""
+    except (ValueError, TypeError):
+        return ""
+
+
+async def drain_pending_email_sends(rt: object) -> int:
+    """Resolve all held email sends. Returns the number of rows resolved."""
+    db = getattr(rt, "_db", None)
+    pipeline = getattr(rt, "_outreach_pipeline", None)
+    if db is None or pipeline is None:
+        return 0
+
+    resolved = 0
+    for row in await pes.list_held(db):
+        now = datetime.now(UTC).isoformat()
+        approval = await approval_crud.get_by_id(db, row["request_id"])
+
+        if approval is None:
+            await pes.mark_rejected(db, row["id"], rejected_at=now, expired=True)
+            logger.warning(
+                "Held email %s orphaned (approval missing) — expired", row["id"],
+            )
+            resolved += 1
+            continue
+
+        status = approval.get("status")
+        if status == "approved":
+            # Deliver FIRST (verbatim, below the gate). Only on success do we
+            # mark sent/consumed — a transient failure leaves the row held for
+            # the next cycle (the drain owns resume retries).
+            result = await pipeline.deliver_approved(
+                row, subject=_subject(approval.get("context")),
+            )
+            if result.status == OutreachStatus.DELIVERED:
+                await approval_crud.mark_consumed(db, row["request_id"], consumed_at=now)
+                await pes.mark_sent(db, row["id"], sent_at=now)
+                await cg.record_success(
+                    db, domain=row["cell_domain"], verb=row["cell_verb"],
+                    risk_class=row["cell_risk_class"], updated_at=now,
+                )
+                resolved += 1
+                logger.info(
+                    "Resolved held email %s → sent to %s",
+                    row["id"], row["validated_recipient"],
+                )
+            else:
+                logger.warning(
+                    "Held email %s delivery failed (%s) — retry next cycle",
+                    row["id"], result.status.value,
+                )
+        elif status in ("rejected", "cancelled"):
+            if await pes.mark_rejected(db, row["id"], rejected_at=now):
+                await cg.record_correction(
+                    db, domain=row["cell_domain"], verb=row["cell_verb"],
+                    risk_class=row["cell_risk_class"], updated_at=now,
+                )
+                resolved += 1
+        elif status == "expired":
+            # No-decision (the owner never answered) — expire the hold but do
+            # NOT record a correction; expiry is not a competence signal.
+            if await pes.mark_rejected(db, row["id"], rejected_at=now, expired=True):
+                resolved += 1
+        # status == 'pending' → still awaiting the owner; leave held.
+
+    return resolved

--- a/src/genesis/db/crud/pending_email_sends.py
+++ b/src/genesis/db/crud/pending_email_sends.py
@@ -1,0 +1,90 @@
+"""CRUD for ``pending_email_sends`` — the WS-8 email autonomy gate hold store.
+
+A row is written when the gate holds an outbound email (capability cell not
+GRANTED).  The resolution watcher drains ``status='held'`` rows: on approval it
+sends below the gate and marks 'sent'; on rejection/timeout it marks
+'rejected'/'expired'.  ``mark_sent``/``mark_rejected`` gate on
+``WHERE status='held'`` so a row can leave 'held' exactly once (double-send
+guard, alongside the ``request_id`` UNIQUE constraint).
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def create(
+    db: aiosqlite.Connection,
+    *,
+    id: str,
+    request_id: str,
+    validated_recipient: str,
+    category: str,
+    message: str,
+    cell_domain: str,
+    cell_verb: str,
+    cell_risk_class: str,
+    held_at: str,
+    channel: str = "email",
+    thread_id: str | None = None,
+) -> str:
+    await db.execute(
+        """INSERT INTO pending_email_sends
+             (id, request_id, thread_id, validated_recipient, channel, category,
+              message, cell_domain, cell_verb, cell_risk_class, held_at, status)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'held')""",
+        (id, request_id, thread_id, validated_recipient, channel, category,
+         message, cell_domain, cell_verb, cell_risk_class, held_at),
+    )
+    await db.commit()
+    return id
+
+
+async def get_by_id(db: aiosqlite.Connection, id: str) -> dict | None:
+    cursor = await db.execute(
+        "SELECT * FROM pending_email_sends WHERE id = ?", (id,)
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def get_by_request(db: aiosqlite.Connection, request_id: str) -> dict | None:
+    cursor = await db.execute(
+        "SELECT * FROM pending_email_sends WHERE request_id = ?", (request_id,)
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def list_held(db: aiosqlite.Connection) -> list[dict]:
+    """All rows still awaiting resolution — the drain's work list."""
+    cursor = await db.execute(
+        "SELECT * FROM pending_email_sends WHERE status = 'held' ORDER BY held_at"
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def mark_sent(db: aiosqlite.Connection, id: str, *, sent_at: str) -> bool:
+    """Transition held → sent. Returns False if the row already left 'held'
+    (double-send guard: only one caller can flip a given hold)."""
+    cursor = await db.execute(
+        "UPDATE pending_email_sends SET status = 'sent', sent_at = ? "
+        "WHERE id = ? AND status = 'held'",
+        (sent_at, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def mark_rejected(
+    db: aiosqlite.Connection, id: str, *, rejected_at: str, expired: bool = False
+) -> bool:
+    """Transition held → rejected (or expired). Returns False if not still held."""
+    status = "expired" if expired else "rejected"
+    cursor = await db.execute(
+        "UPDATE pending_email_sends SET status = ?, rejected_at = ? "
+        "WHERE id = ? AND status = 'held'",
+        (status, rejected_at, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0

--- a/src/genesis/db/migrations/0031_pending_email_sends.py
+++ b/src/genesis/db/migrations/0031_pending_email_sends.py
@@ -1,0 +1,56 @@
+"""Create ``pending_email_sends`` — the WS-8 email autonomy gate hold store.
+
+When the deterministic autonomy gate (in ``outreach.pipeline._deliver``, for
+``channel=="email"``) holds an outbound email whose capability cell isn't
+GRANTED, it records the fully-resolved send here (preserving the
+``validated_recipient`` that ``_defer`` would lose) and creates a linked
+``approval_requests`` row.  A periodic resolution watcher then sends below the
+gate on approval, or expires the hold on rejection/timeout.
+
+``request_id`` is UNIQUE — the schema-level double-send guard: even if the
+watcher fires twice, only one row per approval can transition out of 'held'.
+
+Idempotent (``IF NOT EXISTS``).  Fresh installs get the same DDL via
+``db/schema/_tables.py``; this migration covers existing installs.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+_TABLE_DDL = """
+    CREATE TABLE IF NOT EXISTS pending_email_sends (
+        id                  TEXT PRIMARY KEY,
+        request_id          TEXT NOT NULL UNIQUE,   -- FK approval_requests.id; double-send guard
+        thread_id           TEXT,
+        validated_recipient TEXT NOT NULL,
+        channel             TEXT NOT NULL DEFAULT 'email',
+        category            TEXT NOT NULL,
+        message             TEXT NOT NULL,
+        cell_domain         TEXT NOT NULL,
+        cell_verb           TEXT NOT NULL,
+        cell_risk_class     TEXT NOT NULL,
+        held_at             TEXT NOT NULL,
+        status              TEXT NOT NULL DEFAULT 'held'
+                                CHECK (status IN ('held', 'sent', 'rejected', 'expired')),
+        sent_at             TEXT,
+        rejected_at         TEXT
+    )
+"""
+
+_INDEX_DDL = (
+    "CREATE INDEX IF NOT EXISTS idx_pending_email_sends_status "
+    "ON pending_email_sends(status)",
+)
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # NOTE: must NOT call db.commit()/BEGIN — the runner owns the transaction.
+    await db.execute(_TABLE_DDL)
+    for stmt in _INDEX_DDL:
+        await db.execute(stmt)
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    """Drop the table (and its indexes) — development/testing only."""
+    await db.execute("DROP TABLE IF EXISTS pending_email_sends")

--- a/src/genesis/db/migrations/0031_pending_email_sends.py
+++ b/src/genesis/db/migrations/0031_pending_email_sends.py
@@ -10,6 +10,9 @@ gate on approval, or expires the hold on rejection/timeout.
 ``request_id`` is UNIQUE — the schema-level double-send guard: even if the
 watcher fires twice, only one row per approval can transition out of 'held'.
 
+The WS-8 deploy-state grant (Option B) is a SEPARATE migration (0032) so this
+one stays self-contained (no dependency on the capability_grants table).
+
 Idempotent (``IF NOT EXISTS``).  Fresh installs get the same DDL via
 ``db/schema/_tables.py``; this migration covers existing installs.
 """

--- a/src/genesis/db/migrations/0032_seed_email_standard_grant.py
+++ b/src/genesis/db/migrations/0032_seed_email_standard_grant.py
@@ -1,0 +1,40 @@
+"""WS-8 deploy-state seed (Option B) — pre-grant the lowest-risk email cell.
+
+On the email gate going live, the lowest-risk capability cell
+``email:send:standard`` (a reply to a thread that already has an inbound from a
+known recipient) starts GRANTED, so routine replies keep flowing autonomously
+while cold outreach, bulk/campaign, and financial sends hold for owner
+approval.  OUTREACH autonomy carries no earned per-cell evidence, so this is a
+deliberate trust grant for the safest class, not a derived one.
+
+``INSERT OR IGNORE`` makes it a one-time default that never overrides a cell the
+owner has already set (e.g. revoked).  Depends on the ``capability_grants``
+table from migration 0030 (always present here: ordered migrations on existing
+installs, ``create_all_tables`` on fresh installs).
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+_SEED = """
+    INSERT OR IGNORE INTO capability_grants
+        (id, domain, verb, risk_class, state, granted_at, created_at, updated_at)
+    VALUES ('email:send:standard', 'email', 'send', 'standard', 'granted',
+            datetime('now'), datetime('now'), datetime('now'))
+"""
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # NOTE: must NOT call db.commit()/BEGIN — the runner owns the transaction.
+    await db.execute(_SEED)
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    """Remove the seeded grant — development/testing only.  Only removes the
+    row if it is still exactly the seeded default (untouched 'granted')."""
+    await db.execute(
+        "DELETE FROM capability_grants "
+        "WHERE id = 'email:send:standard' AND state = 'granted' "
+        "AND successes = 0 AND corrections = 0"
+    )

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -636,6 +636,28 @@ TABLES = {
             UNIQUE (domain, verb, risk_class)
         )
     """,
+    # WS-8 email autonomy gate hold store — a held outbound email awaiting
+    # owner approval (gate lives in outreach.pipeline._deliver).  request_id
+    # UNIQUE = the schema-level double-send guard.
+    "pending_email_sends": """
+        CREATE TABLE IF NOT EXISTS pending_email_sends (
+            id                  TEXT PRIMARY KEY,
+            request_id          TEXT NOT NULL UNIQUE,
+            thread_id           TEXT,
+            validated_recipient TEXT NOT NULL,
+            channel             TEXT NOT NULL DEFAULT 'email',
+            category            TEXT NOT NULL,
+            message             TEXT NOT NULL,
+            cell_domain         TEXT NOT NULL,
+            cell_verb           TEXT NOT NULL,
+            cell_risk_class     TEXT NOT NULL,
+            held_at             TEXT NOT NULL,
+            status              TEXT NOT NULL DEFAULT 'held'
+                                    CHECK (status IN ('held', 'sent', 'rejected', 'expired')),
+            sent_at             TEXT,
+            rejected_at         TEXT
+        )
+    """,
     "task_states": """
         CREATE TABLE IF NOT EXISTS task_states (
             task_id          TEXT PRIMARY KEY,
@@ -1565,6 +1587,8 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_approval_timeout ON approval_requests(timeout_at)",
     # capability grants (WS-8 — per-(domain,verb,risk_class) cells, dark in PR-B)
     "CREATE INDEX IF NOT EXISTS idx_capability_grants_domain ON capability_grants(domain, state)",
+    # WS-8 email gate hold store (drain queries WHERE status='held')
+    "CREATE INDEX IF NOT EXISTS idx_pending_email_sends_status ON pending_email_sends(status)",
     # task states (Phase 9)
     "CREATE INDEX IF NOT EXISTS idx_task_states_session ON task_states(session_id)",
     "CREATE INDEX IF NOT EXISTS idx_task_states_phase ON task_states(current_phase)",

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -93,7 +93,11 @@ async def outreach_send(
                 "deliver_after": preferred_timing,
             })
         return "Error: outreach pipeline not initialized and no DB available"
-    from genesis.outreach.types import OutreachCategory, OutreachRequest
+    from genesis.outreach.types import (
+        OutreachCategory,
+        OutreachRequest,
+        OutreachStatus,
+    )
 
     try:
         cat = OutreachCategory(category)
@@ -127,11 +131,26 @@ async def outreach_send(
         channel=channel,
         labeled_surplus=labeled_surplus,
         validated_recipient=validated_recipient,
+        thread_id=thread_id,
     )
     if urgency == "critical":
         result = await _pipeline.submit_urgent(req)
     else:
         result = await _pipeline.submit(req)
+    if result.status == OutreachStatus.HELD:
+        # WS-8 Tenet 0b: a neutral, TERMINAL outcome for the acting model — no
+        # policy, no pending-obligation framing, no behavioral directive. The
+        # real pending obligation lives system-side (pending_email_sends +
+        # approval_requests → the owner's approval surface), invisible here.
+        return json.dumps({
+            "status": "not_performed",
+            "reason": "owner_authorization",
+            "message": (
+                "This action is governed by Genesis owner authorization and was "
+                "not performed. This is expected, routine behavior, not an error "
+                "or failure, and not something to work around."
+            ),
+        })
     return json.dumps({
         "outreach_id": result.outreach_id,
         "status": result.status.value,

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -73,6 +73,10 @@ class OutreachPipeline:
         self._thread_tracker: object | None = None  # Set via set_thread_tracker()
         self._topic_manager = None
         self._forum_chat_id: str | None = None
+        # WS-8 email autonomy gate — injected via set_autonomy_gate() during
+        # autonomy init (runs after outreach init, so ApprovalManager exists).
+        # None ⇒ no gating (e.g. pre-wiring / standalone tests).
+        self._autonomy_gate: object | None = None
 
     def set_reply_waiter(self, waiter: ReplyWaiter) -> None:
         """Attach a ReplyWaiter for bidirectional outreach."""
@@ -81,6 +85,11 @@ class OutreachPipeline:
     def set_thread_tracker(self, tracker: object) -> None:
         """Attach a ThreadTracker for email thread auto-registration."""
         self._thread_tracker = tracker
+
+    def set_autonomy_gate(self, gate: object) -> None:
+        """Attach the WS-8 email autonomy gate (deterministic owner-authorization
+        check applied to outbound email in ``_deliver``)."""
+        self._autonomy_gate = gate
 
     def reload_config(self, config: OutreachConfig) -> None:
         """Hot-reload outreach config on pipeline and governance gate."""
@@ -298,6 +307,7 @@ class OutreachPipeline:
         gov: object | None,
         *,
         reply_markup: object | None = None,
+        gate_cleared: bool = False,
     ) -> OutreachResult:
         adapter = self._channels.get(channel)
         recipient = request.validated_recipient or self._recipients.get(channel, "")
@@ -314,6 +324,28 @@ class OutreachPipeline:
                 message_content=formatted.text,
                 error=f"No adapter or recipient for {channel}",
             )
+
+        # WS-8 autonomy capability gate — deterministic owner-authorization for
+        # outbound email, BELOW the LLM tool call (Tenet 0). This is the sole
+        # unbypassable chokepoint: every send path converges on _deliver. A held
+        # send is recorded for owner approval and later resumed below the gate by
+        # the resolution watcher (gate_cleared=True). Non-email channels and the
+        # resume path skip it.
+        if channel == "email" and not gate_cleared and self._autonomy_gate is not None:
+            decision = await self._autonomy_gate.check(
+                request=request, recipient=recipient, message_text=formatted.text,
+            )
+            if not decision.allow:
+                logger.info(
+                    "Outreach %s HELD by email autonomy gate (pending=%s)",
+                    outreach_id, decision.pending_id,
+                )
+                return OutreachResult(
+                    outreach_id=outreach_id,
+                    status=OutreachStatus.HELD,
+                    channel=channel,
+                    message_content=formatted.text,
+                )
 
         # Determine delivery routing: supergroup, dm, or both
         routing = "supergroup"  # default
@@ -476,6 +508,32 @@ class OutreachPipeline:
             message_content=formatted.text,
             delivery_id=str(delivery_id),
             governance_result=gov,
+        )
+
+    async def deliver_approved(
+        self, pending: dict, *, subject: str | None = None,
+    ) -> OutreachResult:
+        """Send a previously-held email BELOW the autonomy gate.
+
+        Called ONLY by the resolution watcher after the owner approved the
+        hold.  The body was drafted + formatted when held, so it is delivered
+        verbatim (no re-draft, no governance).  ``gate_cleared=True`` skips
+        re-gating — the flag is set only here (trusted code), never by the LLM,
+        so it cannot be a re-entry / bypass vector.
+        """
+        req = OutreachRequest(
+            category=OutreachCategory(pending["category"]),
+            topic=subject or "",
+            context=pending["message"],
+            salience_score=0.5,
+            signal_type="email_gate_resume",
+            channel="email",
+            validated_recipient=pending["validated_recipient"],
+            thread_id=pending.get("thread_id"),
+        )
+        formatted = FormattedContent(text=pending["message"], target=FormatTarget.EMAIL)
+        return await self._deliver(
+            str(uuid.uuid4()), "email", formatted, req, None, gate_cleared=True,
         )
 
     def _should_voice(self, request: OutreachRequest) -> bool:

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -446,7 +446,12 @@ class OutreachPipeline:
                     logger.warning("DM copy failed for 'both' routing", exc_info=True)
         except Exception as exc:
             logger.error("Delivery failed on %s: %s", channel, exc, exc_info=True)
-            await self._defer(outreach_id, channel, formatted.text, request, str(exc))
+            if not gate_cleared:
+                # Gate-cleared (resume) sends are retried by the WS-8 email-gate
+                # drain, NOT the deferred-work queue: deferring here would route
+                # the retry back through _deliver and re-gate it. The drain owns
+                # resume retries (it leaves the hold 'held' on failure).
+                await self._defer(outreach_id, channel, formatted.text, request, str(exc))
             return OutreachResult(
                 outreach_id=outreach_id,
                 status=OutreachStatus.FAILED,

--- a/src/genesis/outreach/types.py
+++ b/src/genesis/outreach/types.py
@@ -33,6 +33,10 @@ class OutreachStatus(StrEnum):
     ENGAGED = "engaged"
     IGNORED = "ignored"
     FAILED = "failed"
+    # Outbound external action held by the WS-8 autonomy capability gate —
+    # not delivered, pending owner approval. Distinct from FAILED (this is not
+    # an error) and PENDING (not queued for automatic retry).
+    HELD = "held"
 
 
 class GovernanceVerdict(StrEnum):
@@ -56,6 +60,10 @@ class OutreachRequest:
     # delivery. Used by thread-aware email routing to send replies
     # to the correct per-thread recipient.
     validated_recipient: str | None = None
+    # Email thread this send belongs to, when known. Carried through to
+    # _deliver so the WS-8 autonomy gate can classify reply-vs-cold for the
+    # capability matrix. None for non-thread / cold sends.
+    thread_id: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/genesis/runtime/init/autonomy.py
+++ b/src/genesis/runtime/init/autonomy.py
@@ -57,6 +57,22 @@ async def init(rt: GenesisRuntime) -> None:
                 event_bus=rt._event_bus,
                 classifier=rt._action_classifier,
             )
+
+            # WS-8: wire the deterministic email autonomy gate into the
+            # (already-built) outreach pipeline. Autonomy init runs AFTER
+            # outreach init, so both the pipeline and the approval manager
+            # exist here — wiring it during outreach init would pass a None
+            # approval manager.
+            if rt._outreach_pipeline is not None:
+                from genesis.autonomy.email_gate import EmailAutonomyGate
+
+                rt._outreach_pipeline.set_autonomy_gate(EmailAutonomyGate(
+                    db=rt._db,
+                    approval_manager=rt._approval_manager,
+                    event_bus=rt._event_bus,
+                ))
+                logger.info("Email autonomy gate wired into outreach pipeline")
+
             rt._autonomous_cli_policy_exporter = AutonomousCliPolicyExporter()
             if rt._router is not None:
                 rt._autonomous_cli_approval_gate = AutonomousCliApprovalGate(

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -199,6 +199,38 @@ async def init(rt: GenesisRuntime) -> None:
             misfire_grace_time=3600,
         )
 
+        # WS-8: email autonomy gate resolution watcher — the correctness
+        # guarantee for held email sends. Drains pending_email_sends: approved →
+        # send below the gate + record_success; rejected → record_correction;
+        # orphaned/expired → close out. max_instances=1 ⇒ no in-drain races.
+        from genesis.autonomy.email_gate_watcher import drain_pending_email_sends
+
+        async def _email_gate_drain() -> None:
+            try:
+                if rt.paused:
+                    return
+            except Exception:
+                logger.warning(
+                    "Pause check failed — skipping email gate drain", exc_info=True,
+                )
+                return
+            try:
+                n = await drain_pending_email_sends(rt)
+                rt.record_job_success("email_gate_drain")
+                if n:
+                    logger.info("Email gate drain resolved %d held send(s)", n)
+            except Exception as exc:
+                rt.record_job_failure("email_gate_drain", str(exc))
+                raise
+
+        rt._learning_scheduler.add_job(
+            _email_gate_drain,
+            CronTrigger(minute="*/5", timezone=user_timezone()),
+            id="email_gate_drain",
+            max_instances=1,
+            misfire_grace_time=300,
+        )
+
         from genesis.db.crud import observations
         from genesis.learning.harvesting.auto_memory import harvest_auto_memory
 

--- a/tests/test_autonomy/test_email_gate.py
+++ b/tests/test_autonomy/test_email_gate.py
@@ -1,0 +1,129 @@
+"""Tests for the WS-8 EmailAutonomyGate (the deterministic email gate).
+
+Uses a real DB (full schema), a real ApprovalManager, and real capability /
+pending CRUD — only the event bus is stubbed.  Covers: cold/ungranted → HOLD
+(approval + pending rows, linked); granted-cell reply → ALLOW; FINANCIAL
+hardline → HOLD without ever creating a financial cell; is_reply derivation
+from email_thread_messages.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.autonomy.approval import ApprovalManager
+from genesis.autonomy.email_gate import EMAIL_GATE_ACTION_TYPE, EmailAutonomyGate
+from genesis.autonomy.types import CellEvent
+from genesis.db.crud import capability_grants as cg
+from genesis.db.crud import pending_email_sends as pes
+from genesis.db.schema import create_all_tables
+from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+_TS = "2026-06-21T00:00:00"
+
+
+@pytest.fixture
+async def db(tmp_path):
+    conn = await aiosqlite.connect(str(tmp_path / "t.db"))
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    await conn.commit()
+    yield conn
+    await conn.close()
+
+
+def _gate(db):
+    return EmailAutonomyGate(db=db, approval_manager=ApprovalManager(db=db), event_bus=None)
+
+
+def _req(**kw):
+    base = dict(
+        category=OutreachCategory.BLOCKER, topic="hi", context="body",
+        salience_score=0.5, channel="email",
+    )
+    base.update(kw)
+    return OutreachRequest(**base)
+
+
+async def _add_inbound(db, thread_id):
+    """Insert one received message so is_reply derives True (the gate's
+    _has_inbound only reads email_thread_messages)."""
+    await db.execute(
+        "INSERT INTO email_thread_messages "
+        "(thread_id, message_id, direction, received_at) VALUES (?, ?, 'received', ?)",
+        (thread_id, f"m-{thread_id}", _TS),
+    )
+    await db.commit()
+
+
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_cold_ungranted_email_is_held(db):
+    gate = _gate(db)
+    req = _req(validated_recipient=None, thread_id=None)  # cold, recipient unknown
+    decision = await gate.check(request=req, recipient="bob@example.com", message_text="hello")
+
+    assert decision.allow is False
+    assert decision.pending_id and decision.request_id
+    pend = await pes.get_by_request(db, decision.request_id)
+    assert pend["status"] == "held"
+    assert pend["validated_recipient"] == "bob@example.com"
+    assert pend["cell_risk_class"] == "identity"  # cold → identity
+    # linked approval row of the isolated action_type
+    cur = await db.execute(
+        "SELECT action_type, status FROM approval_requests WHERE id = ?",
+        (decision.request_id,),
+    )
+    row = await cur.fetchone()
+    assert row["action_type"] == EMAIL_GATE_ACTION_TYPE and row["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_granted_known_thread_reply_is_allowed(db):
+    # pre-grant the standard (known-thread reply) cell — the Option-B seed.
+    await cg.apply_event(db, domain="email", verb="send", risk_class="standard",
+                         event=CellEvent.CLASSIFY, updated_at=_TS)
+    await cg.apply_event(db, domain="email", verb="send", risk_class="standard",
+                         event=CellEvent.APPROVE, updated_at=_TS)
+    await _add_inbound(db, "t1")
+
+    gate = _gate(db)
+    req = _req(validated_recipient="alice@example.com", thread_id="t1")
+    decision = await gate.check(request=req, recipient="alice@example.com", message_text="re: hi")
+
+    assert decision.allow is True
+    assert decision.reason == "granted"
+    assert await pes.list_held(db) == []  # nothing held
+
+
+@pytest.mark.asyncio
+async def test_financial_is_hardline_held_without_a_cell(db):
+    # Even pre-granting a financial cell must not let a financial email through.
+    await cg.apply_event(db, domain="email", verb="send", risk_class="financial",
+                         event=CellEvent.CLASSIFY, updated_at=_TS)
+    await cg.apply_event(db, domain="email", verb="send", risk_class="financial",
+                         event=CellEvent.APPROVE, updated_at=_TS)
+    gate = _gate(db)
+    req = _req(validated_recipient="alice@example.com", thread_id="t1")
+    decision = await gate.check(
+        request=req, recipient="alice@example.com",
+        message_text="Please wire transfer the invoice balance to this IBAN.",
+    )
+    assert decision.allow is False  # hardline — held despite the granted cell
+    pend = await pes.get_by_request(db, decision.request_id)
+    assert pend["cell_risk_class"] == "financial"
+
+
+@pytest.mark.asyncio
+async def test_ungranted_reply_classifies_standard(db):
+    await _add_inbound(db, "t2")
+    gate = _gate(db)
+    req = _req(validated_recipient="alice@example.com", thread_id="t2")
+    decision = await gate.check(request=req, recipient="alice@example.com", message_text="re")
+    # standard cell isn't granted (no seed here) → held, but classified standard.
+    assert decision.allow is False
+    pend = await pes.get_by_request(db, decision.request_id)
+    assert pend["cell_risk_class"] == "standard"

--- a/tests/test_autonomy/test_email_gate.py
+++ b/tests/test_autonomy/test_email_gate.py
@@ -127,3 +127,29 @@ async def test_ungranted_reply_classifies_standard(db):
     assert decision.allow is False
     pend = await pes.get_by_request(db, decision.request_id)
     assert pend["cell_risk_class"] == "standard"
+
+
+@pytest.mark.asyncio
+async def test_approve_all_pending_excludes_email_gate(db):
+    """Batch 'approve all' must never sweep email-gate holds (each is its own
+    send decision)."""
+    from unittest.mock import MagicMock
+
+    from genesis.autonomy.approval_gate import AutonomousCliApprovalGate
+    from genesis.db.crud import approval_requests as ac
+
+    mgr = ApprovalManager(db=db)
+    email_rid = await mgr.request_approval(
+        action_type=EMAIL_GATE_ACTION_TYPE, action_class="costly_reversible",
+        description="email send",
+    )
+    other_rid = await mgr.request_approval(
+        action_type="autonomous_cli_fallback", action_class="reversible",
+        description="cli action",
+    )
+    gate = AutonomousCliApprovalGate(runtime=MagicMock(), approval_manager=mgr)
+
+    n = await gate.approve_all_pending(resolved_by="user")
+    assert n == 1  # only the non-email approval
+    assert (await ac.get_by_id(db, email_rid))["status"] == "pending"  # still held
+    assert (await ac.get_by_id(db, other_rid))["status"] == "approved"

--- a/tests/test_autonomy/test_email_gate_watcher.py
+++ b/tests/test_autonomy/test_email_gate_watcher.py
@@ -118,6 +118,20 @@ async def test_pending_approval_left_held(db):
 
 
 @pytest.mark.asyncio
+async def test_already_consumed_approval_is_reconciled_not_resent(db):
+    # Approval delivered + consumed by a prior cycle that crashed before marking
+    # the hold sent → reconcile WITHOUT re-sending (double-send guard).
+    rid = await _approval(db, status="approved")
+    await ac.mark_consumed(db, rid, consumed_at=_TS)
+    await _hold(db, pid="p1", rid=rid)
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+
+    assert await drain_pending_email_sends(_FakeRt(db, pipe)) == 1
+    assert pipe.calls == []  # NOT re-sent
+    assert (await pes.get_by_id(db, "p1"))["status"] == "sent"
+
+
+@pytest.mark.asyncio
 async def test_approved_but_delivery_fails_stays_held(db):
     rid = await _approval(db, status="approved")
     await _hold(db, pid="p1", rid=rid)

--- a/tests/test_autonomy/test_email_gate_watcher.py
+++ b/tests/test_autonomy/test_email_gate_watcher.py
@@ -1,0 +1,129 @@
+"""Tests for the WS-8 email gate resolution watcher (drain_pending_email_sends).
+
+Real DB + real ApprovalManager + a fake pipeline (so we control delivery
+outcome). Covers: approved → sent + consumed + record_success; rejected →
+record_correction (never sent); orphaned → expired; pending → left held;
+approved-but-delivery-fails → left held, approval NOT consumed (retried).
+"""
+
+from __future__ import annotations
+
+import json
+
+import aiosqlite
+import pytest
+
+from genesis.autonomy.approval import ApprovalManager
+from genesis.autonomy.email_gate_watcher import drain_pending_email_sends
+from genesis.db.crud import approval_requests as ac
+from genesis.db.crud import capability_grants as cg
+from genesis.db.crud import pending_email_sends as pes
+from genesis.db.schema import create_all_tables
+from genesis.outreach.types import OutreachResult, OutreachStatus
+
+_TS = "2026-06-21T00:00:00"
+_CELL = {"cell_domain": "email", "cell_verb": "send", "cell_risk_class": "standard"}
+
+
+@pytest.fixture
+async def db(tmp_path):
+    conn = await aiosqlite.connect(str(tmp_path / "t.db"))
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    await conn.commit()
+    yield conn
+    await conn.close()
+
+
+class _FakePipeline:
+    def __init__(self, status):
+        self._status = status
+        self.calls: list = []
+
+    async def deliver_approved(self, row, *, subject=None):
+        self.calls.append((row["id"], subject))
+        return OutreachResult(
+            outreach_id="o", status=self._status, channel="email", message_content="",
+        )
+
+
+class _FakeRt:
+    def __init__(self, db, pipeline):
+        self._db = db
+        self._outreach_pipeline = pipeline
+
+
+async def _hold(db, *, pid, rid):
+    await pes.create(
+        db, id=pid, request_id=rid, validated_recipient="a@b.c",
+        category="outreach", message="body", held_at=_TS, **_CELL,
+    )
+
+
+async def _approval(db, *, status):
+    mgr = ApprovalManager(db=db)
+    rid = await mgr.request_approval(
+        action_type="email_capability_gate", action_class="costly_reversible",
+        description="d", context=json.dumps({"subject": "hi"}),
+    )
+    if status != "pending":
+        await mgr.resolve(rid, status=status)
+    return rid
+
+
+@pytest.mark.asyncio
+async def test_approved_hold_is_sent(db):
+    rid = await _approval(db, status="approved")
+    await _hold(db, pid="p1", rid=rid)
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+
+    assert await drain_pending_email_sends(_FakeRt(db, pipe)) == 1
+    assert pipe.calls == [("p1", "hi")]  # delivered verbatim, with subject
+    assert (await pes.get_by_id(db, "p1"))["status"] == "sent"
+    assert (await ac.get_by_id(db, rid))["consumed_at"] is not None
+    assert (await cg.get_cell(db, "email", "send", "standard"))["successes"] == 1
+
+
+@pytest.mark.asyncio
+async def test_rejected_hold_records_correction(db):
+    rid = await _approval(db, status="rejected")
+    await _hold(db, pid="p1", rid=rid)
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+
+    assert await drain_pending_email_sends(_FakeRt(db, pipe)) == 1
+    assert pipe.calls == []  # never sent
+    assert (await pes.get_by_id(db, "p1"))["status"] == "rejected"
+    assert (await cg.get_cell(db, "email", "send", "standard"))["corrections"] == 1
+
+
+@pytest.mark.asyncio
+async def test_orphaned_hold_expired(db):
+    await _hold(db, pid="p1", rid="no-such-approval")
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+
+    assert await drain_pending_email_sends(_FakeRt(db, pipe)) == 1
+    assert pipe.calls == []
+    assert (await pes.get_by_id(db, "p1"))["status"] == "expired"
+
+
+@pytest.mark.asyncio
+async def test_pending_approval_left_held(db):
+    rid = await _approval(db, status="pending")
+    await _hold(db, pid="p1", rid=rid)
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+
+    assert await drain_pending_email_sends(_FakeRt(db, pipe)) == 0
+    assert pipe.calls == []
+    assert (await pes.get_by_id(db, "p1"))["status"] == "held"
+
+
+@pytest.mark.asyncio
+async def test_approved_but_delivery_fails_stays_held(db):
+    rid = await _approval(db, status="approved")
+    await _hold(db, pid="p1", rid=rid)
+    pipe = _FakePipeline(OutreachStatus.FAILED)
+
+    assert await drain_pending_email_sends(_FakeRt(db, pipe)) == 0
+    assert pipe.calls == [("p1", "hi")]  # attempted
+    assert (await pes.get_by_id(db, "p1"))["status"] == "held"  # retry next cycle
+    assert (await ac.get_by_id(db, rid))["consumed_at"] is None  # not consumed

--- a/tests/test_db/test_pending_email_sends.py
+++ b/tests/test_db/test_pending_email_sends.py
@@ -1,0 +1,164 @@
+"""Tests for pending_email_sends — table, migration 0031, and CRUD (WS-8 PR-C).
+
+Covers the fresh-install path (create_all_tables), the versioned migration
+(up/down/idempotency), the request_id UNIQUE + status CHECK constraints, and
+the held→sent / held→rejected transitions including the double-send guard
+(a hold can leave 'held' exactly once).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import pending_email_sends as pes
+
+MIGRATION = importlib.import_module("genesis.db.migrations.0031_pending_email_sends")
+
+_ROW = {
+    "id": "p1",
+    "request_id": "req-1",
+    "validated_recipient": "alice@example.com",
+    "category": "outreach",
+    "message": "hello there",
+    "cell_domain": "email",
+    "cell_verb": "send",
+    "cell_risk_class": "identity",
+    "held_at": "2026-06-21T00:00:00",
+}
+_TS = "2026-06-21T01:00:00"
+
+
+@pytest.fixture
+async def db(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    async with aiosqlite.connect(db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        await MIGRATION.up(conn)
+        await conn.commit()
+        yield conn
+
+
+# --------------------------------------------------------------------------- #
+# Schema / migration
+# --------------------------------------------------------------------------- #
+class TestSchema:
+    @pytest.mark.asyncio
+    async def test_table_and_index_exist(self, db):
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name='pending_email_sends'"
+        )
+        assert await cur.fetchone() is not None
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND name='idx_pending_email_sends_status'"
+        )
+        assert await cur.fetchone() is not None
+
+    @pytest.mark.asyncio
+    async def test_up_is_idempotent(self, tmp_path):
+        path = str(tmp_path / "idem.db")
+        async with aiosqlite.connect(path) as conn:
+            await MIGRATION.up(conn)
+            await MIGRATION.up(conn)
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='pending_email_sends'"
+            )
+            assert (await cur.fetchone())[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_down_drops_table(self, tmp_path):
+        path = str(tmp_path / "down.db")
+        async with aiosqlite.connect(path) as conn:
+            await MIGRATION.up(conn)
+            await MIGRATION.down(conn)
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='pending_email_sends'"
+            )
+            assert (await cur.fetchone())[0] == 0
+
+    @pytest.mark.asyncio
+    async def test_fresh_install_creates_table(self, tmp_path):
+        from genesis.db.schema import create_all_tables
+
+        path = str(tmp_path / "fresh.db")
+        async with aiosqlite.connect(path) as conn:
+            await create_all_tables(conn)
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='pending_email_sends'"
+            )
+            assert (await cur.fetchone())[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_status(self, db):
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute(
+                "INSERT INTO pending_email_sends "
+                "(id, request_id, validated_recipient, category, message, "
+                " cell_domain, cell_verb, cell_risk_class, held_at, status) "
+                "VALUES ('x','r','a@b.c','outreach','m','email','send','identity','t','BOGUS')"
+            )
+
+    @pytest.mark.asyncio
+    async def test_request_id_unique(self, db):
+        await pes.create(db, **_ROW)
+        with pytest.raises(aiosqlite.IntegrityError):
+            await pes.create(db, **{**_ROW, "id": "p2"})  # same request_id
+
+
+# --------------------------------------------------------------------------- #
+# CRUD + transitions
+# --------------------------------------------------------------------------- #
+class TestCrud:
+    @pytest.mark.asyncio
+    async def test_create_and_get(self, db):
+        await pes.create(db, **_ROW)
+        row = await pes.get_by_id(db, "p1")
+        assert row["status"] == "held"
+        assert row["validated_recipient"] == "alice@example.com"
+        assert row["channel"] == "email"  # default
+        assert (await pes.get_by_request(db, "req-1"))["id"] == "p1"
+
+    @pytest.mark.asyncio
+    async def test_list_held(self, db):
+        await pes.create(db, **_ROW)
+        await pes.create(db, **{**_ROW, "id": "p2", "request_id": "req-2"})
+        held = await pes.list_held(db)
+        assert {r["id"] for r in held} == {"p1", "p2"}
+
+    @pytest.mark.asyncio
+    async def test_mark_sent_once(self, db):
+        await pes.create(db, **_ROW)
+        assert await pes.mark_sent(db, "p1", sent_at=_TS) is True
+        # double-send guard: second flip is a no-op.
+        assert await pes.mark_sent(db, "p1", sent_at=_TS) is False
+        row = await pes.get_by_id(db, "p1")
+        assert row["status"] == "sent" and row["sent_at"] == _TS
+        assert await pes.list_held(db) == []
+
+    @pytest.mark.asyncio
+    async def test_mark_rejected_and_expired(self, db):
+        await pes.create(db, **_ROW)
+        assert await pes.mark_rejected(db, "p1", rejected_at=_TS) is True
+        assert (await pes.get_by_id(db, "p1"))["status"] == "rejected"
+
+        await pes.create(db, **{**_ROW, "id": "p2", "request_id": "req-2"})
+        assert await pes.mark_rejected(db, "p2", rejected_at=_TS, expired=True) is True
+        assert (await pes.get_by_id(db, "p2"))["status"] == "expired"
+
+    @pytest.mark.asyncio
+    async def test_sent_then_reject_is_noop(self, db):
+        await pes.create(db, **_ROW)
+        await pes.mark_sent(db, "p1", sent_at=_TS)
+        # already 'sent' — reject must not override.
+        assert await pes.mark_rejected(db, "p1", rejected_at=_TS) is False
+        assert (await pes.get_by_id(db, "p1"))["status"] == "sent"

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -56,6 +56,7 @@ EXPECTED_TABLES = [
     "campaigns",
     "campaign_runs",
     "capability_grants",  # WS-8 PR-B: per-(domain,verb,risk_class) cells
+    "pending_email_sends",  # WS-8 PR-C: email autonomy gate hold store
 ]
 
 

--- a/tests/test_db/test_seed_email_standard_grant.py
+++ b/tests/test_db/test_seed_email_standard_grant.py
@@ -1,0 +1,64 @@
+"""Tests for migration 0032 — the WS-8 Option-B deploy seed.
+
+Pre-grants email:send:standard, idempotently, without overriding an owner-set
+cell. Depends on capability_grants (migration 0030), set up in the fixture.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+MIG_0030 = importlib.import_module("genesis.db.migrations.0030_capability_grants")
+MIG_0032 = importlib.import_module("genesis.db.migrations.0032_seed_email_standard_grant")
+
+
+@pytest.fixture
+async def db(tmp_path):
+    conn = await aiosqlite.connect(str(tmp_path / "t.db"))
+    conn.row_factory = aiosqlite.Row
+    await MIG_0030.up(conn)  # capability_grants
+    await conn.commit()
+    yield conn
+    await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_seeds_standard_grant(db):
+    await MIG_0032.up(db)
+    await db.commit()
+    cur = await db.execute(
+        "SELECT state FROM capability_grants WHERE id = 'email:send:standard'"
+    )
+    assert (await cur.fetchone())["state"] == "granted"
+
+
+@pytest.mark.asyncio
+async def test_seed_is_idempotent(db):
+    await MIG_0032.up(db)
+    await MIG_0032.up(db)
+    await db.commit()
+    cur = await db.execute(
+        "SELECT COUNT(*) FROM capability_grants WHERE id = 'email:send:standard'"
+    )
+    assert (await cur.fetchone())[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_seed_does_not_override_owner_revoke(db):
+    # Owner already denied the cell — the seed must not re-grant it.
+    await db.execute(
+        "INSERT INTO capability_grants "
+        "(id, domain, verb, risk_class, state, created_at, updated_at) "
+        "VALUES ('email:send:standard','email','send','standard',"
+        "'denied_permanent','t','t')"
+    )
+    await db.commit()
+    await MIG_0032.up(db)
+    await db.commit()
+    cur = await db.execute(
+        "SELECT state FROM capability_grants WHERE id = 'email:send:standard'"
+    )
+    assert (await cur.fetchone())["state"] == "denied_permanent"  # unchanged


### PR DESCRIPTION
## What

The behavior-changing slice of **WS-8** (audit finding **D5**): Genesis no longer sends email autonomously without the owner in the loop, unless a per-`(domain, verb, risk_class)` capability cell is **granted**. Closes `mail-no-ego-escalation`. Enforcement-only (the asymmetric/consequence Bayesian + earn-back re-key + decay ride in PR-D).

## How — Tenet 0 (deterministic, unbypassable, below the LLM)

The gate is deterministic **code at `outreach/pipeline._deliver`** for `channel=="email"`, just before `adapter.send_message`. This is the **sole unbypassable chokepoint**: `submit`/`submit_raw`/`submit_urgent` all converge there, and email also reaches it via the scheduler drain, recovery retry, and ~12 direct `pipeline.submit` callers that never touch the `outreach_send` MCP tool. **A gate at the MCP tool would be bypassable** — this was caught and corrected during design; an E2E test proves the bypass path (`submit_raw`) is gated.

- **Classify** in code (never from the LLM): reply-on-known-thread → `standard`; cold → `identity`; bulk → `bulk`; anything financial → `financial` (**hardline, held before any cell lookup** — a granted financial cell can't let one through).
- **Granted** cell → send. **Else → HOLD**: record to `pending_email_sends` (preserving the recipient `_defer` would lose), create a linked approval (distinct `action_type`, excluded from batch "approve all"), emit `autonomy.gate_held`@INFO, and return `OutreachStatus.HELD`.
- The acting model gets a **neutral terminal** message via `outreach_send` (no "failed/error", no "queued/held" — Tenet 0b); the real pending obligation lives owner-side (approval surface).
- **Resolution watcher** (CronTrigger */5min, `max_instances=1`): approved → send below the gate (`deliver_approved`, `gate_cleared`) + `record_success`; rejected → `record_correction`; orphaned/expired → close; pending → leave held. Deliver-first (at-least-once for approved sends); `_deliver` skips `_defer` for resumes so the drain is the sole retry owner (no re-gate loop); an already-consumed hold is reconciled without re-sending.

## Deploy-state seeding (Option B, owner-chosen)

Migration `0032` pre-grants `email:send:standard` so **known-thread replies keep flowing** while cold, bulk, and financial sends hold for approval. `INSERT OR IGNORE` — never overrides a cell the owner has set/revoked. (OUTREACH autonomy carries zero earned per-cell evidence, so this is a deliberate trust grant for the safest class, not a derived one.)

## Verification

- **51 unit tests** (gate, watcher, hold store, migration, seed, approve-all isolation) + **4 behavioral E2E** through the real pipeline (cold→held→approve→sent; granted reply→immediate; rejected→never sent; **bypass `submit_raw`→also gated**) + migration-runner E2E (`0031`+`0032` apply on an existing install). ruff clean.
- Full `test_db/` + `test_autonomy/` regression: **1458 passed, 0 new failures** (1 pre-existing unrelated failure in `cli_policy.py`'s YAML loader — `test_load_autonomous_cli_policy_from_yaml`, fails identically on clean `main`; tracked separately).
- Code-reviewed; the one substantive finding (reconcile-already-consumed hold) is fixed. The reviewer's "index never created" P1/P3 were false positives — `_INDEX_DDL` is a 1-tuple (trailing comma) and the index is created (verified).

## Notes

- Goes live on a server restart (migration + the gate wiring). All non-email channels (Telegram/Discord/voice) are untouched — the gate is scoped to `channel=="email"`.
- Known minor (not blocking): a held email's subject is sourced from the approval context JSON on resume; Genesis doesn't currently pass a custom subject to the email adapter anyway, so impact is ~zero.