### PR TITLE
feat(autonomy): WS-8 PR-D — earned + auto-revocable email autonomy (D5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,21 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 ### Added
 
 - **Genesis won't send email on its own without your say-so** — outbound email now passes
-  a deterministic authorization check before it leaves. A reply on a thread you're already
-  in goes out normally, but anything else — a cold first email, a bulk or campaign send, or
-  anything involving money — is held for your approval and sent only once you approve it
-  (rejected or unanswered holds are never sent). Genesis earns the ability to send a given
-  kind of email on its own as you approve them over time, so you stay in the loop by default.
+  a deterministic authorization check before it leaves. By default every send is held for your
+  approval: a reply on a thread you're already in is the lowest-risk kind, while a cold first
+  email, a bulk or campaign send, or anything involving money is held with a higher bar.
+  Rejected or unanswered holds are never sent. Over time Genesis can earn the ability to send a
+  given kind of email on its own (see below), so you stay in the loop by default.
+
+- **Genesis earns email autonomy you can revoke in one click** — once Genesis has sent a kind
+  of email with your approval enough times, it proposes a promotion: it asks "may I send these
+  on my own from now on?" — and only you can say yes. If a promoted send ever goes wrong, that
+  autonomy is revoked immediately and the next send holds for your approval again, whether the
+  system catches it (a send to the wrong person, or a sudden burst of sends) or you flag it
+  yourself. A new dashboard **Autonomy** tab shows what Genesis is allowed to do on its own and
+  a log of what it has done, with a "Flag as bad" button on every autonomous send. A per-send
+  Telegram notice is available but off by default (the tab is where to look) — turn it on with
+  `email_send_notify` in the autonomy config.
 
 - **See what Genesis did as a timeline** — the dashboard has a new **Traces** tab that
   renders each recorded operation (a reflection, an ego cycle, a dispatched session) as a

--- a/config/autonomy.yaml
+++ b/config/autonomy.yaml
@@ -1,5 +1,10 @@
 # Genesis v3 Autonomy Configuration
 
+# WS-8 PR-D — owner notification on each autonomous (GRANTED-cell) email send.
+# Muted by default; the dashboard "Activity" tab is the primary visibility path.
+# Set true to also receive a per-send Telegram notice. Needs a server restart.
+email_send_notify: false
+
 # Default autonomy levels per category (user can override via natural language)
 defaults:
   direct_session: 1      # L1 — conservative start

--- a/src/genesis/autonomy/email_gate.py
+++ b/src/genesis/autonomy/email_gate.py
@@ -60,6 +60,9 @@ class GateDecision:
     pending_id: str | None = None
     request_id: str | None = None
     reason: str = ""
+    #: (domain, verb, risk_class) of the cell — set on a GRANTED (autonomous)
+    #: allow so the pipeline can log the send to the owner-visible ledger.
+    cell: tuple[str, str, str] | None = None
 
 
 class EmailAutonomyGate:
@@ -117,7 +120,9 @@ class EmailAutonomyGate:
             # which regresses GRANTED→ASK) AND hold THIS send for owner approval.
             trip = await self._scope_guard_trip(request, recipient, domain, verb, risk)
             if trip is None:
-                return GateDecision(allow=True, reason="granted")
+                return GateDecision(
+                    allow=True, reason="granted", cell=(domain, verb, risk),
+                )
             logger.warning(
                 "Email scope guard '%s' tripped on GRANTED cell %s:%s:%s "
                 "(recipient=%s) — demoting + holding",

--- a/src/genesis/autonomy/email_gate.py
+++ b/src/genesis/autonomy/email_gate.py
@@ -180,14 +180,17 @@ class EmailAutonomyGate:
         self, thread_id: str | None, recipient: str,
     ) -> bool:
         """True iff ``recipient`` is a known participant (received-message sender)
-        of the thread.  A NULL sender (legacy / auto-reply rows) gets the benefit
-        of the doubt — we never demote a grant on missing data alone."""
+        of the thread.  The inbound path always records ``sender`` (the From
+        header — ``reply_poller``/``threads.record_reply`` require it), so a
+        normal reply matches its correspondent here.  We deliberately do NOT
+        treat a NULL/blank sender as a match: that would let a single
+        unparsed-sender row in a thread grant unbounded recipient scope (the safe
+        failure for a SECURITY guard is to trip and hold, not to wave through)."""
         if not thread_id:
             return False  # a 'standard' reply with no thread is itself suspect
         cursor = await self._db.execute(
             "SELECT 1 FROM email_thread_messages "
-            "WHERE thread_id = ? AND direction = 'received' "
-            "AND (sender = ? OR sender IS NULL) LIMIT 1",
+            "WHERE thread_id = ? AND direction = 'received' AND sender = ? LIMIT 1",
             (thread_id, recipient),
         )
         return await cursor.fetchone() is not None

--- a/src/genesis/autonomy/email_gate.py
+++ b/src/genesis/autonomy/email_gate.py
@@ -27,13 +27,14 @@ import json
 import logging
 import uuid
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import aiosqlite
 
 from genesis.autonomy.capabilities import InvalidTransition
 from genesis.autonomy.classification import classify_email_action
 from genesis.autonomy.types import CellEvent, CellState, RiskClass
+from genesis.db.crud import autonomous_email_sends as aes
 from genesis.db.crud import capability_grants as cg
 from genesis.db.crud import pending_email_sends as pes
 from genesis.observability.types import Severity, Subsystem
@@ -43,6 +44,12 @@ logger = logging.getLogger(__name__)
 #: Distinct action_type so these holds are isolated from CLI-fallback approvals
 #: (excluded from ``approve_all_pending`` / the voice pending count).
 EMAIL_GATE_ACTION_TYPE = "email_capability_gate"
+
+#: WS-8 PR-D deterministic pre-send scope guards for a GRANTED cell.  A trip is
+#: treated as scope drift inside the grant ⇒ the send is HELD and the cell is
+#: demoted (recorded as a correction).  Conservative defaults; calibration here.
+_RATE_LIMIT_WINDOW = timedelta(hours=1)   # g3: per-cell autonomous-send window
+_RATE_LIMIT_MAX = 10                      # g3: max autonomous sends per cell per window
 
 
 @dataclass(frozen=True)
@@ -105,7 +112,21 @@ class EmailAutonomyGate:
         state = CellState(cell["state"]) if cell else CellState.ASK
 
         if state == CellState.GRANTED:
-            return GateDecision(allow=True, reason="granted")
+            # WS-8 PR-D auto-revert net: deterministic pre-send scope guards.
+            # A trip = scope drift inside the grant → demote (record a correction,
+            # which regresses GRANTED→ASK) AND hold THIS send for owner approval.
+            trip = await self._scope_guard_trip(request, recipient, domain, verb, risk)
+            if trip is None:
+                return GateDecision(allow=True, reason="granted")
+            logger.warning(
+                "Email scope guard '%s' tripped on GRANTED cell %s:%s:%s "
+                "(recipient=%s) — demoting + holding",
+                trip, domain, verb, risk, recipient,
+            )
+            await cg.record_correction(
+                self._db, domain=domain, verb=verb, risk_class=risk, updated_at=now,
+            )
+            return await self._hold(request, message_text, classification, recipient, now)
 
         # 4. ASK / NOT_DETERMINED / DENIED → hold for owner approval.
         return await self._hold(request, message_text, classification, recipient, now)
@@ -119,6 +140,50 @@ class EmailAutonomyGate:
             "SELECT 1 FROM email_thread_messages "
             "WHERE thread_id = ? AND direction = 'received' LIMIT 1",
             (thread_id,),
+        )
+        return await cursor.fetchone() is not None
+
+    async def _scope_guard_trip(
+        self, request: object, recipient: str, domain: str, verb: str, risk: str,
+    ) -> str | None:
+        """Deterministic pre-send scope guards for a GRANTED cell.
+
+        Returns a trip-reason if the send drifts outside the grant's scope (so
+        the caller demotes + holds), else None (allow).  These are the ONLY
+        autonomous safety net once a cell is GRANTED — a GRANTED cell no longer
+        holds for owner approval, so nothing else would catch the drift.
+        """
+        # g1 (defense-in-depth): a standard reply must go to a participant of its
+        # thread.  validated_recipient is already thread-derived, so this rarely
+        # fires — but it catches a thread_id/recipient mismatch deterministically.
+        if risk == RiskClass.STANDARD.value:
+            thread_id = getattr(request, "thread_id", None)
+            if not await self._recipient_in_thread(thread_id, recipient):
+                return "recipient_mismatch"
+
+        # g3 (primary): a burst of autonomous sends for one cell = a runaway loop.
+        since = (datetime.now(UTC) - _RATE_LIMIT_WINDOW).isoformat()
+        count = await aes.count_for_cell_since(
+            self._db, cell_domain=domain, cell_verb=verb, cell_risk_class=risk,
+            since=since,
+        )
+        if count >= _RATE_LIMIT_MAX:
+            return "rate_limit"
+        return None
+
+    async def _recipient_in_thread(
+        self, thread_id: str | None, recipient: str,
+    ) -> bool:
+        """True iff ``recipient`` is a known participant (received-message sender)
+        of the thread.  A NULL sender (legacy / auto-reply rows) gets the benefit
+        of the doubt — we never demote a grant on missing data alone."""
+        if not thread_id:
+            return False  # a 'standard' reply with no thread is itself suspect
+        cursor = await self._db.execute(
+            "SELECT 1 FROM email_thread_messages "
+            "WHERE thread_id = ? AND direction = 'received' "
+            "AND (sender = ? OR sender IS NULL) LIMIT 1",
+            (thread_id, recipient),
         )
         return await cursor.fetchone() is not None
 

--- a/src/genesis/dashboard/routes/__init__.py
+++ b/src/genesis/dashboard/routes/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from genesis.dashboard.routes import (
     activity,
+    autonomy,
     backup,
     budget,
     comms,
@@ -46,6 +47,7 @@ from genesis.dashboard.routes import (
 
 __all__ = [
     "activity",
+    "autonomy",
     "backup",
     "budget",
     "comms",

--- a/src/genesis/dashboard/routes/autonomy.py
+++ b/src/genesis/dashboard/routes/autonomy.py
@@ -1,0 +1,101 @@
+"""Dashboard routes for the WS-8 owner-visibility "Activity" tab (autonomy).
+
+Read-only views of what Genesis is AUTHORIZED to do autonomously (GRANTED
+capability cells) and what it has DONE under that authority (the
+``autonomous_email_sends`` ledger), plus a flag-as-bad action that records a
+correction on the send's cell (demoting a GRANTED cell back to ASK).  This is the
+owner's pull-based visibility + control path — the per-send Telegram notification
+is muted by default, so this tab is how the owner keeps tabs and corrects.
+
+Every route is gated with ``is_authenticated()`` (a no-op when
+``DASHBOARD_PASSWORD`` is unset, a 403 when it is set).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from flask import jsonify, request
+
+from genesis.dashboard._blueprint import _async_route, blueprint
+from genesis.dashboard.auth import is_authenticated
+
+logger = logging.getLogger(__name__)
+
+
+def _auth_or_403():
+    """Return a 403 response tuple if not authenticated, else None."""
+    if not is_authenticated():
+        return jsonify({"error": "authentication required"}), 403
+    return None
+
+
+@blueprint.route("/api/genesis/autonomy/grants")
+@_async_route
+async def autonomy_grants():
+    """Standing autonomy — the GRANTED capability cells (what Genesis may do
+    without owner approval)."""
+    if (resp := _auth_or_403()) is not None:
+        return resp
+    from genesis.db.crud import capability_grants as cg
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"grants": []})
+    return jsonify({"grants": await cg.list_granted(rt.db)})
+
+
+@blueprint.route("/api/genesis/autonomy/sends")
+@_async_route
+async def autonomy_sends():
+    """The autonomous-send action log (most recent first)."""
+    if (resp := _auth_or_403()) is not None:
+        return resp
+    from genesis.db.crud import autonomous_email_sends as aes
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"sends": []})
+    limit = max(1, min(request.args.get("limit", 100, type=int), 500))
+    return jsonify({"sends": await aes.list_recent(rt.db, limit=limit)})
+
+
+@blueprint.route("/api/genesis/autonomy/sends/<send_id>/flag", methods=["POST"])
+@_async_route
+async def autonomy_flag_send(send_id: str):
+    """Flag a sent autonomous email as bad → record a correction on its cell,
+    demoting a GRANTED cell back to ASK.  Idempotent: a second flag on the same
+    send is a no-op (never double-demotes)."""
+    if (resp := _auth_or_403()) is not None:
+        return resp
+    from genesis.db.crud import autonomous_email_sends as aes
+    from genesis.db.crud import capability_grants as cg
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"error": "not bootstrapped"}), 503
+
+    send = await aes.get_by_id(rt.db, send_id)
+    if send is None:
+        return jsonify({"error": "send not found"}), 404
+
+    now = datetime.now(UTC).isoformat()
+    newly_flagged = await aes.mark_flagged(rt.db, send_id, flagged_at=now)
+    cell_state = None
+    if newly_flagged:
+        state = await cg.record_correction(
+            rt.db,
+            domain=send["cell_domain"], verb=send["cell_verb"],
+            risk_class=send["cell_risk_class"], updated_at=now,
+        )
+        cell_state = state.value
+        logger.info(
+            "Owner flagged autonomous send %s — corrected cell %s:%s:%s (now %s)",
+            send_id, send["cell_domain"], send["cell_verb"],
+            send["cell_risk_class"], cell_state,
+        )
+    return jsonify({"flagged": newly_flagged, "cell_state": cell_state})

--- a/src/genesis/dashboard/routes/comms.py
+++ b/src/genesis/dashboard/routes/comms.py
@@ -220,6 +220,12 @@ async def comms_resolve_proposal(proposal_id: str):
             await handle_goal_status_change_resolution(rt.db, prop, status)
         except Exception:
             logger.warning("goal status-change hook failed for %s", proposal_id)
+        try:
+            from genesis.ego.cell_promotion import handle_cell_promotion_resolution
+
+            await handle_cell_promotion_resolution(rt.db, prop, status)
+        except Exception:
+            logger.warning("cell promotion hook failed for %s", proposal_id)
 
     # Trigger delayed sweep on approval — same 5-min grace as Telegram,
     # so the user can revoke before dispatch fires.

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -360,6 +360,14 @@ async def ego_proposal_resolve(proposal_id: str):
             _logging.getLogger(__name__).warning(
                 "goal status-change hook failed for %s", proposal_id,
             )
+        try:
+            from genesis.ego.cell_promotion import handle_cell_promotion_resolution
+
+            await handle_cell_promotion_resolution(rt._db, prop, status)
+        except Exception:
+            _logging.getLogger(__name__).warning(
+                "cell promotion hook failed for %s", proposal_id,
+            )
 
     return jsonify({"ok": True, "id": proposal_id, "status": status})
 

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -26,7 +26,7 @@
       Alpine.store("genesisDashboard", {
         // Tab state
         activeTab: "overview",
-        _tabInitialized: { overview: false, chat: false, internals: false, config: false, files: false, work: false, observations: false, traces: false, memory: false, knowledge: false, backup: false },
+        _tabInitialized: { overview: false, chat: false, internals: false, config: false, files: false, work: false, observations: false, traces: false, autonomy: false, memory: false, knowledge: false, backup: false },
 
         // State
         health: {},
@@ -324,6 +324,13 @@
         tracesLoadingTrace: false,
         _traceReq: 0,
 
+        // Autonomy tab state
+        autonomyGrants: [],
+        autonomySends: [],
+        autonomyLoading: false,
+        autonomyFlagging: {},
+        _autonomyInterval: null,
+
         // Tab management
         _TAB_INTERVALS: {
           overview:  ["_cognitiveInterval", "_ekInterval", "_modulesInterval"],
@@ -334,6 +341,7 @@
           work:      ["_tasksInterval", "_workSessionsInterval", "_followUpsInterval"],
           observations: ["_observationsInterval"],
           traces:    ["_tracesInterval"],
+          autonomy:  ["_autonomyInterval"],
           memory:    [],
           knowledge: [],
           backup:    [],
@@ -341,7 +349,7 @@
 
         initTab() {
           const hash = location.hash.replace("#", "") || "overview";
-          const valid = ["overview", "chat", "internals", "config", "files", "work", "observations", "traces", "memory", "knowledge", "references", "backup"];
+          const valid = ["overview", "chat", "internals", "config", "files", "work", "observations", "traces", "autonomy", "memory", "knowledge", "references", "backup"];
           this.activeTab = valid.includes(hash) ? hash : "overview";
           window.addEventListener("hashchange", () => {
             const h = location.hash.replace("#", "");
@@ -407,6 +415,10 @@
             case "traces":
               if (first) { this.fetchSpansRecent(); }
               this._tracesInterval = setInterval(() => this.fetchSpansRecent(), 30000);
+              break;
+            case "autonomy":
+              if (first) { this.fetchAutonomyGrants(); this.fetchAutonomySends(); }
+              this._autonomyInterval = setInterval(() => { this.fetchAutonomyGrants(); this.fetchAutonomySends(); }, 30000);
               break;
             case "memory":
               if (first) { this.fetchMemoryRecent(); this.fetchMemoryStats(); }
@@ -479,7 +491,7 @@
 
         cleanup() {
           if (this._healthInterval) clearInterval(this._healthInterval);
-          for (const tab of ["overview", "chat", "internals", "config", "work", "observations", "traces"]) {
+          for (const tab of ["overview", "chat", "internals", "config", "work", "observations", "traces", "autonomy"]) {
             this._stopTabIntervals(tab);
           }
           // Terminal runs in its own window — no cleanup needed here
@@ -1104,6 +1116,47 @@
           } finally {
             if (reqId === this._traceReq) this.tracesLoadingTrace = false;
           }
+        },
+
+        // ── Autonomy tab fetches ──────────────────────────────────
+        async fetchAutonomyGrants() {
+          try {
+            const resp = await fetchApi("/api/genesis/autonomy/grants");
+            if (resp && resp.ok) {
+              const data = await resp.json();
+              this.autonomyGrants = data.grants || [];
+            }
+          } catch (e) { console.warn("Autonomy grants fetch failed:", e); }
+        },
+        async fetchAutonomySends() {
+          try {
+            const resp = await fetchApi("/api/genesis/autonomy/sends?limit=100");
+            if (resp && resp.ok) {
+              const data = await resp.json();
+              this.autonomySends = data.sends || [];
+            }
+          } catch (e) { console.warn("Autonomy sends fetch failed:", e); }
+        },
+        async refreshAutonomy() {
+          this.autonomyLoading = true;
+          try {
+            await Promise.all([this.fetchAutonomyGrants(), this.fetchAutonomySends()]);
+          } finally { this.autonomyLoading = false; }
+        },
+        async flagAutonomousSend(sendId) {
+          this.autonomyFlagging = { ...this.autonomyFlagging, [sendId]: true };
+          try {
+            const resp = await fetchApi(`/api/genesis/autonomy/sends/${sendId}/flag`, {
+              method: "POST",
+            });
+            if (resp && resp.ok) {
+              // Flagging records a correction that demotes the cell, so refresh
+              // both the sends log and the standing-autonomy grants list.
+              await this.fetchAutonomySends();
+              await this.fetchAutonomyGrants();
+            }
+          } catch (e) { console.warn("Flag autonomous send failed:", e); }
+          finally { const { [sendId]: _, ...rest } = this.autonomyFlagging; this.autonomyFlagging = rest; }
         },
 
         // ── Comms fetches (on Chat tab) ──────────────────────────
@@ -4146,6 +4199,8 @@
       </button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'traces' }"
               @click="location.hash = 'traces'">Traces</button>
+      <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'autonomy' }"
+              @click="location.hash = 'autonomy'">Autonomy</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'memory' }"
               @click="location.hash = 'memory'">Memory</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'knowledge' }"
@@ -9095,6 +9150,119 @@
             </div>
           </template>
         </div>
+      </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════════════════════
+         Panel: Autonomy (standing grants + autonomous sends) [Tab: autonomy]
+         ═══════════════════════════════════════════════════════════ -->
+    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'autonomy'">
+      <div class="panel-header">
+        <span class="material-symbols-outlined">verified_user</span>
+        Autonomy
+        <button style="margin-left:auto; font-size:0.72rem; padding:0.22rem 0.55rem; border-radius:4px; border:1px solid var(--color-border); color:var(--color-text-secondary); background:transparent; cursor:pointer;"
+                :disabled="$store.genesisDashboard.autonomyLoading"
+                @click="$store.genesisDashboard.refreshAutonomy()"
+                x-text="$store.genesisDashboard.autonomyLoading ? 'Refreshing…' : 'Refresh'"></button>
+      </div>
+      <div class="panel-body">
+        <div style="font-size:0.68rem; color:var(--color-text-secondary); margin-bottom:0.8rem;">
+          What Genesis is authorized to do on its own, and a log of what it has done. Everything defaults to holding for your approval — autonomy is earned cell by cell. Flagging a send records a correction that demotes its cell back toward approval.
+        </div>
+
+        <!-- ── Standing autonomy ─────────────────────────────────── -->
+        <div style="font-size:0.78rem; font-weight:600; margin-bottom:0.4rem;">Standing autonomy</div>
+
+        <!-- Empty state (calm / good given the all-ASK default) -->
+        <template x-if="$store.genesisDashboard.autonomyGrants.length === 0">
+          <div style="padding:1.1rem; text-align:center; color:var(--color-text-secondary); font-size:0.74rem; margin-bottom:1.2rem;">
+            No standing autonomy — every action holds for your approval.
+          </div>
+        </template>
+
+        <!-- Granted cells table -->
+        <template x-if="$store.genesisDashboard.autonomyGrants.length > 0">
+          <div style="overflow-x: auto; margin-bottom:1.2rem;">
+            <table style="width: 100%; border-collapse: collapse; font-size: 0.72rem;">
+              <thead>
+                <tr style="border-bottom: 1px solid var(--color-border); text-transform: uppercase; letter-spacing: 0.05em; font-size: 0.65rem;">
+                  <th style="text-align: left; padding: 0.3rem 0.4rem;">Cell</th>
+                  <th style="text-align: right; padding: 0.3rem 0.4rem;">Successes</th>
+                  <th style="text-align: right; padding: 0.3rem 0.4rem;">Granted at</th>
+                  <th style="text-align: right; padding: 0.3rem 0.4rem;">Last used</th>
+                </tr>
+              </thead>
+              <tbody>
+                <template x-for="g in $store.genesisDashboard.autonomyGrants" :key="g.id">
+                  <tr style="border-bottom: 1px solid rgba(255,255,255,0.04);">
+                    <td style="padding: 0.25rem 0.4rem; font-family: monospace;" x-text="g.id"></td>
+                    <td style="text-align: right; padding: 0.25rem 0.4rem;" x-text="g.successes != null ? g.successes : '—'"></td>
+                    <td style="text-align: right; padding: 0.25rem 0.4rem; font-family: monospace; font-size: 0.65rem;"
+                        x-text="$store.genesisDashboard.formatDateTime(g.granted_at)"></td>
+                    <td style="text-align: right; padding: 0.25rem 0.4rem; font-family: monospace; font-size: 0.65rem;"
+                        x-text="g.last_used_at ? $store.genesisDashboard.formatDateTime(g.last_used_at) : 'never'"></td>
+                  </tr>
+                </template>
+              </tbody>
+            </table>
+          </div>
+        </template>
+
+        <!-- ── Autonomous sends ──────────────────────────────────── -->
+        <div style="font-size:0.78rem; font-weight:600; margin-bottom:0.4rem;">Autonomous sends</div>
+
+        <!-- Empty state -->
+        <template x-if="$store.genesisDashboard.autonomySends.length === 0">
+          <div style="padding:1.1rem; text-align:center; color:var(--color-text-secondary); font-size:0.74rem;">
+            No autonomous sends yet.
+          </div>
+        </template>
+
+        <!-- Sends table -->
+        <template x-if="$store.genesisDashboard.autonomySends.length > 0">
+          <div style="overflow-x: auto;">
+            <table style="width: 100%; border-collapse: collapse; font-size: 0.72rem;">
+              <thead>
+                <tr style="border-bottom: 1px solid var(--color-border); text-transform: uppercase; letter-spacing: 0.05em; font-size: 0.65rem;">
+                  <th style="text-align: left; padding: 0.3rem 0.4rem;">Recipient</th>
+                  <th style="text-align: left; padding: 0.3rem 0.4rem;">Subject</th>
+                  <th style="text-align: left; padding: 0.3rem 0.4rem;">Cell</th>
+                  <th style="text-align: right; padding: 0.3rem 0.4rem;">Sent at</th>
+                  <th style="text-align: right; padding: 0.3rem 0.4rem;">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                <template x-for="s in $store.genesisDashboard.autonomySends" :key="s.id">
+                  <tr :style="s.flagged_at ? 'background: rgba(217,83,79,0.08)' : ''"
+                      style="border-bottom: 1px solid rgba(255,255,255,0.04);">
+                    <td style="padding: 0.25rem 0.4rem; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; max-width:160px;"
+                        :title="s.recipient" x-text="s.recipient || '—'"></td>
+                    <td style="padding: 0.25rem 0.4rem; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; max-width:220px;"
+                        :title="s.subject" x-text="s.subject || '(no subject)'"></td>
+                    <td style="padding: 0.25rem 0.4rem; font-family: monospace; font-size: 0.65rem;">
+                      <span x-text="(s.cell_domain || '?') + '/' + (s.cell_verb || '?')"></span>
+                      <span x-show="s.cell_risk_class" style="color:var(--color-text-secondary);"
+                            x-text="' (' + (s.cell_risk_class || '') + ')'"></span>
+                    </td>
+                    <td style="text-align: right; padding: 0.25rem 0.4rem; font-family: monospace; font-size: 0.65rem;"
+                        x-text="$store.genesisDashboard.formatDateTime(s.sent_at)"></td>
+                    <td style="text-align: right; padding: 0.25rem 0.4rem;">
+                      <template x-if="s.flagged_at">
+                        <span style="font-size:0.62rem; padding:0.12rem 0.4rem; border-radius:3px; background:rgba(217,83,79,0.15); color:#d9534f; font-weight:600;">Flagged</span>
+                      </template>
+                      <template x-if="!s.flagged_at">
+                        <button style="font-size:0.68rem; padding:0.2rem 0.5rem; border-radius:4px; border:1px solid rgba(217,83,79,0.4); color:#d9534f; background:transparent; cursor:pointer;"
+                                :disabled="$store.genesisDashboard.autonomyFlagging[s.id]"
+                                @click="$store.genesisDashboard.flagAutonomousSend(s.id)"
+                                x-text="$store.genesisDashboard.autonomyFlagging[s.id] ? 'Flagging…' : 'Flag as bad'"></button>
+                      </template>
+                    </td>
+                  </tr>
+                </template>
+              </tbody>
+            </table>
+          </div>
+        </template>
       </div>
     </div>
 

--- a/src/genesis/db/crud/autonomous_email_sends.py
+++ b/src/genesis/db/crud/autonomous_email_sends.py
@@ -1,0 +1,93 @@
+"""CRUD for ``autonomous_email_sends`` — the WS-8 PR-D autonomous-send ledger.
+
+One row per email the gate let through under a GRANTED capability cell (NOT an
+owner-approved hold).  This is the keystone read/write layer for:
+
+- the owner-visibility "Activity" dashboard tab (``list_recent``),
+- the flag-as-bad correction (``mark_flagged`` → ``record_correction`` on the
+  send's cell), and
+- the per-cell rate-limit scope guard (``count_for_cell_since``),
+
+because ``outreach_history`` carries no recipient / thread / cell column.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def create(
+    db: aiosqlite.Connection,
+    *,
+    id: str,
+    recipient: str,
+    cell_domain: str,
+    cell_verb: str,
+    cell_risk_class: str,
+    sent_at: str,
+    outreach_id: str | None = None,
+    thread_id: str | None = None,
+    subject: str | None = None,
+) -> str:
+    """Record an autonomous send.  Best-effort ledger — callers must not let a
+    failure here block or unwind an already-delivered email."""
+    await db.execute(
+        """INSERT INTO autonomous_email_sends
+             (id, outreach_id, thread_id, recipient, subject,
+              cell_domain, cell_verb, cell_risk_class, sent_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (id, outreach_id, thread_id, recipient, subject,
+         cell_domain, cell_verb, cell_risk_class, sent_at),
+    )
+    await db.commit()
+    return id
+
+
+async def count_for_cell_since(
+    db: aiosqlite.Connection,
+    *,
+    cell_domain: str,
+    cell_verb: str,
+    cell_risk_class: str,
+    since: str,
+) -> int:
+    """Number of autonomous sends for this cell at/after ``since`` (ISO ts) —
+    the per-cell rate-limit window."""
+    cursor = await db.execute(
+        """SELECT COUNT(*) FROM autonomous_email_sends
+           WHERE cell_domain = ? AND cell_verb = ? AND cell_risk_class = ?
+             AND sent_at >= ?""",
+        (cell_domain, cell_verb, cell_risk_class, since),
+    )
+    row = await cursor.fetchone()
+    return row[0] if row else 0
+
+
+async def get_by_id(db: aiosqlite.Connection, id: str) -> dict | None:
+    cursor = await db.execute(
+        "SELECT * FROM autonomous_email_sends WHERE id = ?", (id,)
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def list_recent(db: aiosqlite.Connection, *, limit: int = 100) -> list[dict]:
+    """Most-recent autonomous sends first — the Activity-tab action log."""
+    cursor = await db.execute(
+        "SELECT * FROM autonomous_email_sends ORDER BY sent_at DESC LIMIT ?",
+        (limit,),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def mark_flagged(db: aiosqlite.Connection, id: str, *, flagged_at: str) -> bool:
+    """Mark a send as owner-flagged.  Atomic + idempotent: only the FIRST flag
+    succeeds (``rowcount > 0``), so a double-click can't double-demote the cell.
+    The caller records the correction only when this returns True."""
+    cursor = await db.execute(
+        "UPDATE autonomous_email_sends SET flagged_at = ? "
+        "WHERE id = ? AND flagged_at IS NULL",
+        (flagged_at, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0

--- a/src/genesis/db/crud/capability_grants.py
+++ b/src/genesis/db/crud/capability_grants.py
@@ -117,6 +117,17 @@ async def list_all(db: aiosqlite.Connection) -> list[dict]:
     return [dict(r) for r in await cursor.fetchall()]
 
 
+async def list_granted(db: aiosqlite.Connection) -> list[dict]:
+    """All GRANTED cells — what Genesis is authorized to do autonomously (the
+    'standing autonomy' pane of the owner-visibility Activity tab)."""
+    cursor = await db.execute(
+        "SELECT * FROM capability_grants WHERE state = ? "
+        "ORDER BY domain, verb, risk_class",
+        (CellState.GRANTED.value,),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
 async def apply_event(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/db/crud/capability_grants.py
+++ b/src/genesis/db/crud/capability_grants.py
@@ -311,6 +311,7 @@ async def decay_stale_cells(
         """UPDATE capability_grants
              SET state = ?, granted_at = NULL, last_decayed_at = ?, updated_at = ?
            WHERE state = ?
+             AND granted_at IS NOT NULL
              AND COALESCE(last_used_at, granted_at) < ?
            RETURNING id""",
         (CellState.NOT_DETERMINED.value, now, now, CellState.GRANTED.value, cutoff),

--- a/src/genesis/db/crud/capability_grants.py
+++ b/src/genesis/db/crud/capability_grants.py
@@ -1,14 +1,15 @@
 """CRUD for the capability_grants table — per-(domain, verb, risk_class) cells.
 
-The simple-posterior competence mirror of ``crud/autonomy.py``, re-keyed to
-capability cells (WS-8, PR-B).  DARK: no runtime caller writes here yet.
+The per-cell competence model, re-keyed from ``crud/autonomy.py`` (WS-8).  Live
+since PR-C (the email gate's resolution watcher records success/correction on
+cells); PR-D adds the consequence-weighted RE-earn posterior, the deterministic
+GRANTED→ASK demotion ("trust is easy to lose"), and promotion-candidate
+detection.
 
-Deliberately does NOT touch ``autonomy_state`` — that table stays
-authoritative for every existing reader (the ``autonomy_activity`` signal,
-``capability_aggregator``, the direct-session circuit breaker, the earn-back
-sweep) until PR-C ships the L1–L7 → cells read-out.  The asymmetric /
-consequence-weighted / staleness-decay upgrades to the posterior are deferred
-to PR-C/PR-D, where they are wired to real send outcomes and can be calibrated.
+Deliberately does NOT touch ``autonomy_state`` — that table stays authoritative
+for every existing (non-email) reader (the ``autonomy_activity`` signal,
+``capability_aggregator``, the direct-session circuit breaker, the legacy
+earn-back sweep).  Email autonomy is cell-only.
 
 These functions commit their own writes — do NOT call them inside a migration
 ``up()`` (the runner's connection proxy forbids ``commit()``).
@@ -18,8 +19,35 @@ from __future__ import annotations
 
 import aiosqlite
 
-from genesis.autonomy.capabilities import should_regress, transition
-from genesis.autonomy.types import CellEvent, CellState
+from genesis.autonomy.capabilities import transition
+from genesis.autonomy.types import CellEvent, CellState, RiskClass
+
+#: Owner-approved-promotion bar (mirrors the legacy L-threshold): a cell is
+#: PROPOSABLE for promotion only at/above this re-earn posterior AND with real
+#: evidence behind it.
+PROMOTE_THRESHOLD = 0.70
+#: Minimum approved successes before a cell may be PROPOSED for promotion —
+#: closes the low-N trap (one lucky success is not earned trust).
+MIN_PROMOTE_N = 5
+
+#: Consequence weights by risk_class (WS-8 PR-D).  A correction's damage to a
+#: cell's RE-earn posterior is severity-proportional.  GATE-DERIVED from the
+#: classified risk_class — NEVER supplied by the LLM.  (financial never grants,
+#: but is defined for completeness.)
+_CORRECTION_WEIGHTS: dict[RiskClass, float] = {
+    RiskClass.STANDARD: 1.0,
+    RiskClass.IDENTITY: 1.5,
+    RiskClass.BULK: 2.0,
+    RiskClass.FINANCIAL: 3.0,
+}
+
+
+def correction_weight(risk_class: str) -> float:
+    """Severity weight for a correction on a cell of this risk_class (≥ 1.0)."""
+    try:
+        return _CORRECTION_WEIGHTS[RiskClass(risk_class)]
+    except (ValueError, KeyError):
+        return 1.0
 
 
 def cell_id(domain: str, verb: str, risk_class: str) -> str:
@@ -27,12 +55,20 @@ def cell_id(domain: str, verb: str, risk_class: str) -> str:
     return f"{domain}:{verb}:{risk_class}"
 
 
-def cell_posterior(successes: int, corrections: int) -> float:
-    """Beta(1,1) posterior mean — a straight per-cell mirror of
+def cell_posterior(
+    successes: int, corrections: int, weighted_corrections: float = 0.0
+) -> float:
+    """Beta(1,1) posterior mean, re-earn flavour (WS-8 PR-D).
+
+    ``weighted_corrections`` is the Σ of consequence-weighted corrections; when
+    present it replaces the raw correction count in the denominator so a heavier
+    past harm leaves a deeper crater (more clean successes needed to re-promote).
+    With ``weighted_corrections == 0.0`` this is the plain mirror of
     ``crud.autonomy.bayesian_posterior``.  Returns 0.5 (uninformative) with no
     evidence; a fresh cell holds at ASK regardless of this value.
     """
-    total = successes + corrections
+    eff_corrections = max(float(corrections), weighted_corrections)
+    total = successes + eff_corrections
     if total == 0:
         return 0.5
     return (successes + 1) / (total + 2)
@@ -147,31 +183,98 @@ async def record_correction(
     verb: str,
     risk_class: str,
     updated_at: str,
+    consequence_weight: float | None = None,
 ) -> CellState:
-    """Increment the correction counter; regress a granted cell if competence
-    drops below the grant floor.  The counter increment and any regression are
-    written in a SINGLE atomic UPDATE so a crash can't leave a sub-floor cell
-    stuck in GRANTED.  Returns the resulting cell state.
+    """Record a correction on a cell and, if it was GRANTED, DEMOTE it to ASK.
 
-    (Asymmetric / consequence weighting of the update is deferred to
-    PR-C/PR-D — here a correction is a plain +1.)
+    WS-8 PR-D — "trust is hard to earn, easy to lose": a GRANTED cell regresses
+    to ASK on ANY confirmed correction (deterministic, NOT posterior-gated — one
+    bad autonomous send means autonomy stops NOW, not "if the running average
+    dips").  The severity-weighted ``weighted_corrections`` accumulator governs
+    how hard the cell is to RE-earn, not whether it demotes.
+
+    ``consequence_weight`` defaults to the risk-class severity (gate-derived;
+    NEVER LLM-supplied).  The counter bump and any regression land in ONE atomic
+    UPDATE so a crash can't leave a corrected cell stuck GRANTED.  Returns the
+    resulting cell state.
     """
     row = await ensure_cell(
         db, domain=domain, verb=verb, risk_class=risk_class, updated_at=updated_at
     )
+    weight = (
+        consequence_weight
+        if consequence_weight is not None
+        else correction_weight(risk_class)
+    )
     new_corrections = row["corrections"] + 1
+    new_weighted = (row["weighted_corrections"] or 0.0) + weight
 
     new_state = CellState(row["state"])
-    if new_state == CellState.GRANTED and should_regress(
-        cell_posterior(row["successes"], new_corrections)
-    ):
-        new_state = transition(new_state, CellEvent.REGRESS)
+    granted_at = row["granted_at"]
+    if new_state == CellState.GRANTED:
+        new_state = transition(new_state, CellEvent.REGRESS)  # any correction → ASK
+        granted_at = None  # clear the decay-clock origin on demotion
 
     await db.execute(
         """UPDATE capability_grants
-             SET corrections = ?, state = ?, updated_at = ?
+             SET corrections = ?, weighted_corrections = ?, state = ?,
+                 granted_at = ?, updated_at = ?
            WHERE id = ?""",
-        (new_corrections, new_state.value, updated_at, row["id"]),
+        (new_corrections, new_weighted, new_state.value, granted_at,
+         updated_at, row["id"]),
     )
     await db.commit()
     return new_state
+
+
+async def touch_used(
+    db: aiosqlite.Connection,
+    *,
+    domain: str,
+    verb: str,
+    risk_class: str,
+    used_at: str,
+) -> bool:
+    """Mark a GRANTED cell as just-used WITHOUT recording a success.
+
+    An autonomous send under a GRANTED cell is not a competence signal (no human
+    confirmed it was good) — competence-in-GRANTED is measured by the ABSENCE of
+    corrections.  This only bumps ``last_used_at`` so the staleness-decay sweep
+    can tell an active grant from an idle one.
+    """
+    cursor = await db.execute(
+        "UPDATE capability_grants SET last_used_at = ?, updated_at = ? WHERE id = ?",
+        (used_at, used_at, cell_id(domain, verb, risk_class)),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def detect_promotable_cells(
+    db: aiosqlite.Connection,
+    *,
+    min_successes: int = MIN_PROMOTE_N,
+    threshold: float = PROMOTE_THRESHOLD,
+) -> list[dict]:
+    """ASK cells with enough evidence to PROPOSE for owner-approved promotion.
+
+    A cell qualifies when it has ≥ ``min_successes`` approved successes AND its
+    severity-weighted re-earn posterior is ≥ ``threshold``.  Recommend-only:
+    this never promotes — it surfaces candidates for the cadence to propose and
+    the owner to approve.  Each returned row carries a computed ``posterior``.
+    """
+    cursor = await db.execute(
+        "SELECT * FROM capability_grants WHERE state = ?", (CellState.ASK.value,)
+    )
+    out: list[dict] = []
+    for r in await cursor.fetchall():
+        row = dict(r)
+        if row["successes"] < min_successes:
+            continue
+        posterior = cell_posterior(
+            row["successes"], row["corrections"], row.get("weighted_corrections") or 0.0
+        )
+        if posterior >= threshold:
+            row["posterior"] = posterior
+            out.append(row)
+    return out

--- a/src/genesis/db/crud/capability_grants.py
+++ b/src/genesis/db/crud/capability_grants.py
@@ -17,6 +17,8 @@ These functions commit their own writes — do NOT call them inside a migration
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
+
 import aiosqlite
 
 from genesis.autonomy.capabilities import transition
@@ -289,3 +291,30 @@ async def detect_promotable_cells(
             row["posterior"] = posterior
             out.append(row)
     return out
+
+
+async def decay_stale_cells(
+    db: aiosqlite.Connection, *, now: str, half_life_days: int = 90,
+) -> list[str]:
+    """Decay GRANTED cells idle longer than the half-life back to NOT_DETERMINED
+    (the ``DECAY`` transition, applied in bulk).
+
+    Staleness is measured from the most recent activity (``last_used_at``, else
+    the grant time).  A decayed cell holds again on its next send (CLASSIFY→ASK),
+    so a long-unused standing autonomy lapses rather than entrenching.  Atomic
+    ``UPDATE…RETURNING``.  Returns the decayed cell ids.
+    """
+    cutoff = (
+        datetime.fromisoformat(now) - timedelta(days=half_life_days)
+    ).isoformat()
+    cursor = await db.execute(
+        """UPDATE capability_grants
+             SET state = ?, granted_at = NULL, last_decayed_at = ?, updated_at = ?
+           WHERE state = ?
+             AND COALESCE(last_used_at, granted_at) < ?
+           RETURNING id""",
+        (CellState.NOT_DETERMINED.value, now, now, CellState.GRANTED.value, cutoff),
+    )
+    rows = await cursor.fetchall()
+    await db.commit()
+    return [r[0] for r in rows]

--- a/src/genesis/db/migrations/0033_autonomy_earn_lose.py
+++ b/src/genesis/db/migrations/0033_autonomy_earn_lose.py
@@ -60,7 +60,7 @@ _AUTONOMOUS_SENDS_INDEXES = (
 _REVERT_SEED = (
     "DELETE FROM capability_grants "
     "WHERE id = 'email:send:standard' AND state = 'granted' "
-    "AND successes = 0 AND corrections = 0"
+    "AND successes = 0 AND corrections = 0 AND weighted_corrections = 0.0"
 )
 
 
@@ -105,5 +105,5 @@ async def down(db: aiosqlite.Connection) -> None:
         "INSERT OR IGNORE INTO capability_grants "
         "(id, domain, verb, risk_class, state, granted_at, created_at, updated_at) "
         "VALUES ('email:send:standard', 'email', 'send', 'standard', 'granted', "
-        "datetime('now'), datetime('now'), datetime('now'))"
+        "strftime('%Y-%m-%dT%H:%M:%S+00:00','now'), datetime('now'), datetime('now'))"
     )

--- a/src/genesis/db/migrations/0033_autonomy_earn_lose.py
+++ b/src/genesis/db/migrations/0033_autonomy_earn_lose.py
@@ -1,0 +1,109 @@
+"""WS-8 PR-D — the earn/lose autonomy loop + auto-revert (schema).
+
+Three coupled schema changes that let an email capability cell be *earned*
+(promoted to GRANTED with the owner's approval) and *lost* (auto-reverted to
+ASK on any confirmed harm signal):
+
+1. ``capability_grants.weighted_corrections`` — Σ of consequence-weighted
+   corrections. Demotion (GRANTED→ASK) is deterministic on any correction; this
+   accumulator governs how hard the cell is to RE-earn (heavier harm ⇒ deeper
+   crater ⇒ more clean successes before re-promotion).
+2. ``capability_grants.last_decayed_at`` — bookkeeping for the staleness-decay
+   sweep (a long-unused GRANTED cell decays GRANTED→NOT_DETERMINED).
+3. ``autonomous_email_sends`` — the autonomous-send ledger. One row per email
+   the gate let through under a GRANTED cell (NOT owner-approved holds). It is
+   the keystone the owner-visibility "Activity" tab, the flag-as-bad correction,
+   and the per-cell rate-limit guard all read, because ``outreach_history``
+   carries no recipient/thread/cell column.
+
+Plus the **seed neutralization** (WS-8 all-ASK decision): the PR-C Option-B seed
+(migration 0032) pre-granted ``email:send:standard``. Promotion must be earned +
+owner-approved, never automatic, so this migration removes that pristine grant —
+surgically, so it never touches a cell the owner has since acted on.
+
+Idempotent (PRAGMA-guarded ALTERs, ``IF NOT EXISTS`` table/indexes, a WHERE-
+scoped DELETE). Fresh installs get the columns + table from ``db/schema/_tables``;
+this migration covers existing installs. ``up()`` must NOT call
+``db.commit()``/``BEGIN`` — the runner owns the transaction.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import aiosqlite
+
+_AUTONOMOUS_SENDS_DDL = """
+    CREATE TABLE IF NOT EXISTS autonomous_email_sends (
+        id                  TEXT PRIMARY KEY,
+        outreach_id         TEXT,
+        thread_id           TEXT,
+        recipient           TEXT NOT NULL,
+        subject             TEXT,
+        cell_domain         TEXT NOT NULL,
+        cell_verb           TEXT NOT NULL,
+        cell_risk_class     TEXT NOT NULL,
+        sent_at             TEXT NOT NULL,
+        flagged_at          TEXT,
+        created_at          TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+"""
+
+_AUTONOMOUS_SENDS_INDEXES = (
+    "CREATE INDEX IF NOT EXISTS idx_autonomous_email_sends_cell "
+    "ON autonomous_email_sends(cell_domain, cell_verb, cell_risk_class, sent_at)",
+    "CREATE INDEX IF NOT EXISTS idx_autonomous_email_sends_sent "
+    "ON autonomous_email_sends(sent_at)",
+)
+
+#: The pristine PR-C Option-B seed, scoped so it only matches an untouched grant.
+_REVERT_SEED = (
+    "DELETE FROM capability_grants "
+    "WHERE id = 'email:send:standard' AND state = 'granted' "
+    "AND successes = 0 AND corrections = 0"
+)
+
+
+async def _columns(db: aiosqlite.Connection, table: str) -> set[str]:
+    cursor = await db.execute(f"PRAGMA table_info({table})")
+    return {row[1] for row in await cursor.fetchall()}
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # NOTE: must NOT call db.commit()/BEGIN — the runner owns the transaction.
+    cols = await _columns(db, "capability_grants")
+    if "weighted_corrections" not in cols:
+        await db.execute(
+            "ALTER TABLE capability_grants "
+            "ADD COLUMN weighted_corrections REAL NOT NULL DEFAULT 0.0"
+        )
+    if "last_decayed_at" not in cols:
+        await db.execute(
+            "ALTER TABLE capability_grants ADD COLUMN last_decayed_at TEXT"
+        )
+
+    await db.execute(_AUTONOMOUS_SENDS_DDL)
+    for stmt in _AUTONOMOUS_SENDS_INDEXES:
+        await db.execute(stmt)
+
+    # Seed neutralization (all-ASK): remove the pristine PR-C Option-B grant so
+    # nothing sends autonomously until earned + owner-approved.
+    await db.execute(_REVERT_SEED)
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    """Reverse the schema changes — development/testing only.
+
+    Restores the PR-C Option-B seed for symmetry. SQLite ``DROP COLUMN`` needs
+    3.35+; suppressed if unavailable (the columns are harmless if they remain).
+    """
+    await db.execute("DROP TABLE IF EXISTS autonomous_email_sends")
+    for col in ("weighted_corrections", "last_decayed_at"):
+        with contextlib.suppress(aiosqlite.OperationalError):
+            await db.execute(f"ALTER TABLE capability_grants DROP COLUMN {col}")
+    await db.execute(
+        "INSERT OR IGNORE INTO capability_grants "
+        "(id, domain, verb, risk_class, state, granted_at, created_at, updated_at) "
+        "VALUES ('email:send:standard', 'email', 'send', 'standard', 'granted', "
+        "datetime('now'), datetime('now'), datetime('now'))"
+    )

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -629,8 +629,10 @@ TABLES = {
             )),
             successes     INTEGER NOT NULL DEFAULT 0,
             corrections   INTEGER NOT NULL DEFAULT 0,
+            weighted_corrections REAL NOT NULL DEFAULT 0.0,  -- WS-8 PR-D: Σ consequence-weighted corrections (governs re-earn difficulty)
             granted_at    TEXT,                       -- when cell most recently entered 'granted' (decay-clock origin)
             last_used_at  TEXT,
+            last_decayed_at TEXT,                     -- WS-8 PR-D: most recent staleness-decay sweep that touched this cell
             created_at    TEXT NOT NULL DEFAULT (datetime('now')),
             updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
             UNIQUE (domain, verb, risk_class)
@@ -656,6 +658,27 @@ TABLES = {
                                     CHECK (status IN ('held', 'sent', 'rejected', 'expired')),
             sent_at             TEXT,
             rejected_at         TEXT
+        )
+    """,
+    # WS-8 PR-D autonomous-send ledger — one row per email sent autonomously
+    # under a GRANTED capability cell (i.e. the gate allowed it without holding
+    # for owner approval).  This is the keystone the owner-visibility "Activity"
+    # tab, the flag-as-bad correction, and the per-cell rate-limit guard all read
+    # (outreach_history carries no recipient/thread/cell column).  Approved (held
+    # then owner-approved) sends are NOT logged here — only autonomous ones.
+    "autonomous_email_sends": """
+        CREATE TABLE IF NOT EXISTS autonomous_email_sends (
+            id                  TEXT PRIMARY KEY,
+            outreach_id         TEXT,                   -- link to outreach_history.id
+            thread_id           TEXT,
+            recipient           TEXT NOT NULL,
+            subject             TEXT,
+            cell_domain         TEXT NOT NULL,
+            cell_verb           TEXT NOT NULL,
+            cell_risk_class     TEXT NOT NULL,
+            sent_at             TEXT NOT NULL,
+            flagged_at          TEXT,                   -- owner flagged this send as bad → correction recorded on the cell
+            created_at          TEXT NOT NULL DEFAULT (datetime('now'))
         )
     """,
     "task_states": """
@@ -1589,6 +1612,10 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_capability_grants_domain ON capability_grants(domain, state)",
     # WS-8 email gate hold store (drain queries WHERE status='held')
     "CREATE INDEX IF NOT EXISTS idx_pending_email_sends_status ON pending_email_sends(status)",
+    # WS-8 PR-D autonomous-send ledger — per-cell rate-limit window + ledger ordering
+    "CREATE INDEX IF NOT EXISTS idx_autonomous_email_sends_cell "
+    "ON autonomous_email_sends(cell_domain, cell_verb, cell_risk_class, sent_at)",
+    "CREATE INDEX IF NOT EXISTS idx_autonomous_email_sends_sent ON autonomous_email_sends(sent_at)",
     # task states (Phase 9)
     "CREATE INDEX IF NOT EXISTS idx_task_states_session ON task_states(session_id)",
     "CREATE INDEX IF NOT EXISTS idx_task_states_phase ON task_states(current_phase)",

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -347,6 +347,11 @@ class EgoCadenceManager:
         # now supports it (user ego only; no-op otherwise).
         await self._check_earnback_opportunities()
 
+        # Cell promotion (WS-8 PR-D): propose standing autonomy for email
+        # capability cells whose approved competence now supports it (user ego
+        # only; the user approves each promotion).
+        await self._check_cell_promotion_opportunities()
+
     async def _check_approaching_deadlines(self) -> None:
         """Push reactive events for events approaching within 48h."""
         try:
@@ -568,6 +573,112 @@ class EgoCadenceManager:
             "confidence": conf,
             "urgency": "low",
             "expected_outputs": {"target_level": target},
+        }
+
+    # -- Cell promotion (WS-8 PR-D) ----------------------------------------
+
+    _CELL_PROMOTION_REJECT_COOLDOWN_DAYS = 7
+
+    async def _check_cell_promotion_opportunities(self) -> None:
+        """Propose promoting email capability cells whose approved competence now
+        supports standing autonomy. User-ego only; evidence-gated; the user
+        approves each promotion. Never auto-promotes.
+        """
+        if self._session._source_tag != "user_ego_cycle":
+            return
+        db = self._session._db
+        if db is None:
+            return
+        try:
+            from genesis.db.crud import capability_grants as cg
+            from genesis.db.crud import ego as ego_crud
+
+            candidates = await cg.detect_promotable_cells(db)
+            if not candidates:
+                return
+
+            # Anti-spam: skip cells that already have a pending promotion proposal
+            # or an active reject cooldown (the digest rate-limiter is disabled, so
+            # these guards are the only backstop).
+            pending = await ego_crud.list_pending_proposals(db)
+            pending_cells = {
+                p.get("action_category")
+                for p in pending
+                if p.get("action_type") == "cell_promotion"
+            }
+
+            to_make: list[dict] = []
+            for cand in candidates:
+                cell_id = cand["id"]
+                if cell_id in pending_cells:
+                    continue
+                if await self._cell_promotion_in_cooldown(cell_id):
+                    continue
+                to_make.append(self._build_cell_promotion_proposal(cand))
+
+            if not to_make:
+                return
+
+            batch_id, ids, _ = await self._session._proposals.create_batch(
+                to_make, ego_source="user_ego_cycle",
+            )
+            if ids:
+                await self._session._proposals.send_digest(
+                    batch_id, ego_source="user_ego_cycle",
+                )
+                logger.info(
+                    "Cell promotion: proposed standing autonomy for %d cell(s)",
+                    len(ids),
+                )
+        except Exception:
+            logger.warning("Cell promotion opportunity check failed", exc_info=True)
+
+    async def _cell_promotion_in_cooldown(self, cell_id: str) -> bool:
+        """True if *cell_id*'s promotion was rejected within the cooldown window."""
+        from genesis.db.crud import ego as ego_crud
+
+        ts = await ego_crud.get_state(
+            self._session._db, f"cell_promotion_reject:{cell_id}",
+        )
+        if not ts:
+            return False
+        try:
+            rejected_at = datetime.fromisoformat(ts)
+        except (ValueError, TypeError):
+            return False
+        if rejected_at.tzinfo is None:
+            rejected_at = rejected_at.replace(tzinfo=UTC)
+        age_days = (datetime.now(UTC) - rejected_at).days
+        return age_days < self._CELL_PROMOTION_REJECT_COOLDOWN_DAYS
+
+    @staticmethod
+    def _build_cell_promotion_proposal(cand: dict) -> dict:
+        """Build a proposal dict for a promotable capability cell."""
+        cell_id = cand["id"]
+        domain, verb, risk = cand["domain"], cand["verb"], cand["risk_class"]
+        successes = cand.get("successes", 0)
+        posterior = cand.get("posterior")
+        conf = round(float(posterior), 2) if posterior is not None else 0.7
+        content = (
+            f"Promote the {cell_id} capability to standing autonomy. I've handled "
+            f"this {successes} times with your approval (confidence {conf}); "
+            f"promoting it means routine {risk} {domain} {verb}s won't need your "
+            f"sign-off each time. The auto-revert net still applies — any harm "
+            f"signal immediately drops it back to needing your approval."
+        )
+        rationale = (
+            "Evidence-gated promotion: the cell's own approved-success history "
+            "supports standing autonomy. Approve to grant; reject to keep holding "
+            "each send for approval."
+        )
+        return {
+            "action_type": "cell_promotion",
+            "action_category": cell_id,
+            "content": content,
+            "rationale": rationale,
+            "confidence": conf,
+            "urgency": "low",
+            "expected_outputs": {"cell": [domain, verb, risk]},
         }
 
     # -- Tick handlers -----------------------------------------------------

--- a/src/genesis/ego/cell_promotion.py
+++ b/src/genesis/ego/cell_promotion.py
@@ -23,7 +23,7 @@ from datetime import UTC, datetime
 
 import aiosqlite
 
-from genesis.autonomy.types import CellEvent
+from genesis.autonomy.types import CellEvent, CellState
 from genesis.db.crud import capability_grants as cg
 from genesis.db.crud import ego as ego_crud
 
@@ -98,11 +98,22 @@ async def handle_cell_promotion_resolution(
     domain, verb, risk = cell
     now = datetime.now(UTC).isoformat()
 
-    # Staleness guard: re-verify the cell still qualifies.  A correction landing
-    # between proposal and approval craters the posterior / demotes the cell —
-    # the evidence the user approved on no longer holds, so don't promote.
-    promotable = await cg.detect_promotable_cells(db)
-    if not any(c["id"] == f"{domain}:{verb}:{risk}" for c in promotable):
+    # Staleness guard: re-fetch THIS cell immediately before promoting (not a
+    # batch scan taken moments earlier — that leaves a TOCTOU window for a
+    # concurrent correction).  A correction landing between the proposal and the
+    # approval demotes the cell + craters its re-earn posterior, so the evidence
+    # the owner approved on no longer holds — don't promote.
+    current = await cg.get_cell(db, domain, verb, risk)
+    still_promotable = (
+        current is not None
+        and current["state"] == CellState.ASK.value
+        and current["successes"] >= cg.MIN_PROMOTE_N
+        and cg.cell_posterior(
+            current["successes"], current["corrections"],
+            current["weighted_corrections"] or 0.0,
+        ) >= cg.PROMOTE_THRESHOLD
+    )
+    if not still_promotable:
         logger.info(
             "cell_promotion for %s skipped — no longer promotable (evidence changed)",
             cell_key,

--- a/src/genesis/ego/cell_promotion.py
+++ b/src/genesis/ego/cell_promotion.py
@@ -1,0 +1,141 @@
+"""Cell promotion — the shared hook fired when a ``cell_promotion`` proposal is
+resolved (WS-8 PR-D).
+
+A ``cell_promotion`` proposal is created by the ego cadence
+(``EgoCadenceManager._check_cell_promotion_opportunities``) when an email
+capability cell has earned enough approved competence to be PROPOSED for
+standing autonomy.  **Recommend-only:** the cell is promoted to GRANTED only on
+the user's explicit approval, never autonomously — the user is the gate.
+
+Like ``autonomy_earnback`` / ``goal_status_change``, a proposal can be resolved
+from four entry points (a Telegram reply, the ``ego_proposal_resolve`` MCP tool,
+and two dashboard routes), so the promote/cooldown logic lives here and every
+path calls it identically.  It does ONLY the cell-promotion side-effect, leaving
+each path's other behaviour untouched.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+from datetime import UTC, datetime
+
+import aiosqlite
+
+from genesis.autonomy.types import CellEvent
+from genesis.db.crud import capability_grants as cg
+from genesis.db.crud import ego as ego_crud
+
+logger = logging.getLogger(__name__)
+
+CELL_PROMOTION_ACTION_TYPE = "cell_promotion"
+
+
+def _parse_cell(expected_outputs: object) -> tuple[str, str, str] | None:
+    """Extract the ``(domain, verb, risk_class)`` cell from a proposal's
+    expected_outputs (stored as JSON ``{"cell": [domain, verb, risk]}``)."""
+    data = expected_outputs
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except (ValueError, TypeError):
+            return None
+    if not isinstance(data, dict):
+        return None
+    cell = data.get("cell")
+    if not isinstance(cell, list | tuple) or len(cell) != 3:
+        return None
+    domain, verb, risk = (str(x) for x in cell)
+    return domain, verb, risk
+
+
+async def handle_cell_promotion_resolution(
+    db: aiosqlite.Connection,
+    proposal: dict,
+    status: object,
+) -> bool:
+    """Apply the cell-promotion side-effect of resolving *proposal*.
+
+    No-op unless *proposal* is a ``cell_promotion`` proposal.  On rejection:
+    record a reject timestamp so the cadence applies its cooldown before
+    re-proposing.  On approval: re-verify the cell is STILL promotable (a
+    correction may have landed since the proposal was shown — never promote on
+    stale evidence), then promote ASK→GRANTED via ``apply_event(APPROVE)`` and
+    mark the proposal ``executed`` so the approved-proposal sweep never
+    dispatches it as a session.
+
+    *status* may be a ``ProposalStatus`` enum or a plain string.
+    Returns True iff a promotion was applied.
+    """
+    if proposal.get("action_type") != CELL_PROMOTION_ACTION_TYPE:
+        return False
+
+    status_str = getattr(status, "value", status)
+    cell_key = (proposal.get("action_category") or "").strip()
+
+    if status_str == "rejected":
+        if cell_key:
+            with contextlib.suppress(Exception):
+                await ego_crud.set_state(
+                    db,
+                    key=f"cell_promotion_reject:{cell_key}",
+                    value=datetime.now(UTC).isoformat(),
+                )
+        return False
+
+    if status_str != "approved":
+        return False
+
+    cell = _parse_cell(proposal.get("expected_outputs"))
+    if cell is None:
+        logger.warning(
+            "cell_promotion proposal %s missing/invalid expected_outputs cell",
+            proposal.get("id"),
+        )
+        return False
+
+    domain, verb, risk = cell
+    now = datetime.now(UTC).isoformat()
+
+    # Staleness guard: re-verify the cell still qualifies.  A correction landing
+    # between proposal and approval craters the posterior / demotes the cell —
+    # the evidence the user approved on no longer holds, so don't promote.
+    promotable = await cg.detect_promotable_cells(db)
+    if not any(c["id"] == f"{domain}:{verb}:{risk}" for c in promotable):
+        logger.info(
+            "cell_promotion for %s skipped — no longer promotable (evidence changed)",
+            cell_key,
+        )
+        with contextlib.suppress(Exception):
+            await ego_crud.execute_proposal(
+                db, proposal["id"], status="executed",
+                user_response="cell promotion skipped: evidence changed",
+            )
+        return False
+
+    try:
+        await cg.apply_event(
+            db, domain=domain, verb=verb, risk_class=risk,
+            event=CellEvent.APPROVE, updated_at=now,
+        )
+        ok = True
+    except Exception:
+        logger.warning(
+            "cell_promotion apply_event failed for %s", cell_key, exc_info=True,
+        )
+        ok = False
+
+    # Mark executed regardless so the proposal doesn't linger as 'approved'
+    # (which would clutter the board AND let the sweep dispatch it as a session).
+    with contextlib.suppress(Exception):
+        await ego_crud.execute_proposal(
+            db, proposal["id"], status="executed",
+            user_response=(
+                f"cell {cell_key} promoted to GRANTED" if ok
+                else f"cell {cell_key} promotion failed"
+            ),
+        )
+    if ok:
+        logger.info("Cell promotion applied: %s → GRANTED (user approved)", cell_key)
+    return ok

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -552,6 +552,18 @@ class ProposalWorkflow:
                         "goal status-change hook failed for %s",
                         prop.get("id"), exc_info=True,
                     )
+                # Cell promotion (WS-8 PR-D): promote on approval / cooldown on reject.
+                try:
+                    from genesis.ego.cell_promotion import (
+                        handle_cell_promotion_resolution,
+                    )
+
+                    await handle_cell_promotion_resolution(self._db, prop, status)
+                except Exception:
+                    logger.warning(
+                        "cell promotion hook failed for %s",
+                        prop.get("id"), exc_info=True,
+                    )
             else:
                 logger.warning(
                     "Proposal %s not updated (already resolved?)",

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1777,7 +1777,7 @@ class EgoSession:
             # dispatched as a session. Defense-in-depth in case one is still
             # 'approved' here.
             if prop.get("action_type") in (
-                "autonomy_earnback", "goal_status_change",
+                "autonomy_earnback", "goal_status_change", "cell_promotion",
             ):
                 continue
             # Staleness guard — skip proposals approved more than 7 days ago.

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -542,6 +542,15 @@ async def ego_proposal_resolve(
                     logger.debug(
                         "goal status-change hook failed", exc_info=True,
                     )
+                # Cell promotion (WS-8 PR-D).
+                try:
+                    from genesis.ego.cell_promotion import (
+                        handle_cell_promotion_resolution,
+                    )
+
+                    await handle_cell_promotion_resolution(db, prop, status)
+                except Exception:
+                    logger.debug("cell promotion hook failed", exc_info=True)
 
     resolved = sum(1 for v in results.values() if v in ("approved", "rejected"))
     return {

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -15,6 +15,8 @@ from genesis.content.drafter import ContentDrafter
 from genesis.content.egress import gate
 from genesis.content.formatter import ContentFormatter
 from genesis.content.types import DraftRequest, FormatTarget, FormattedContent
+from genesis.db.crud import autonomous_email_sends as aes
+from genesis.db.crud import capability_grants as cg
 from genesis.db.crud import outreach as outreach_crud
 from genesis.outreach.config import OutreachConfig
 from genesis.outreach.fresh_eyes import FreshEyesReview
@@ -77,6 +79,10 @@ class OutreachPipeline:
         # autonomy init (runs after outreach init, so ApprovalManager exists).
         # None ⇒ no gating (e.g. pre-wiring / standalone tests).
         self._autonomy_gate: object | None = None
+        # WS-8 PR-D — per-send owner notification for autonomous (GRANTED-cell)
+        # email sends.  MUTED by default; the dashboard "Activity" ledger is the
+        # primary visibility path.  Toggled via set_autonomous_send_notify().
+        self._autonomous_send_notify: bool = False
 
     def set_reply_waiter(self, waiter: ReplyWaiter) -> None:
         """Attach a ReplyWaiter for bidirectional outreach."""
@@ -90,6 +96,66 @@ class OutreachPipeline:
         """Attach the WS-8 email autonomy gate (deterministic owner-authorization
         check applied to outbound email in ``_deliver``)."""
         self._autonomy_gate = gate
+
+    def set_autonomous_send_notify(self, enabled: bool) -> None:
+        """Toggle the per-send owner notification for autonomous email sends
+        (WS-8 PR-D).  Muted by default; the dashboard Activity tab is primary."""
+        self._autonomous_send_notify = bool(enabled)
+
+    async def _record_autonomous_send(
+        self,
+        request: OutreachRequest,
+        cell: tuple[str, str, str],
+        recipient: str,
+        outreach_id: str,
+        sent_at: str,
+    ) -> None:
+        """Log an autonomous (GRANTED-cell) email send (WS-8 PR-D).  Best-effort:
+        the email is already delivered, so a ledger/notify failure must NEVER
+        unwind it.  Writes the owner-visible ledger row + bumps the cell's
+        ``last_used_at`` (an autonomous send is not a competence signal — only the
+        ABSENCE of corrections is — so it does NOT record a success)."""
+        domain, verb, risk = cell
+        try:
+            await aes.create(
+                self._db,
+                id=str(uuid.uuid4()),
+                recipient=recipient,
+                subject=request.topic or "",
+                thread_id=getattr(request, "thread_id", None),
+                outreach_id=outreach_id,
+                cell_domain=domain,
+                cell_verb=verb,
+                cell_risk_class=risk,
+                sent_at=sent_at,
+            )
+            await cg.touch_used(
+                self._db, domain=domain, verb=verb, risk_class=risk, used_at=sent_at,
+            )
+        except Exception:
+            logger.warning("autonomous-send ledger write failed", exc_info=True)
+        await self._maybe_notify_autonomous_send(request, recipient)
+
+    async def _maybe_notify_autonomous_send(
+        self, request: OutreachRequest, recipient: str,
+    ) -> None:
+        """Owner notification for an autonomous send — MUTED by default (WS-8
+        PR-D); the dashboard Activity tab is the primary visibility path."""
+        if not self._autonomous_send_notify:
+            return
+        adapter = self._channels.get("telegram")
+        owner = self._recipients.get("telegram")
+        if adapter is None or not owner:
+            return
+        subject = request.topic or "(no subject)"
+        try:
+            await adapter.send_message(
+                owner,
+                f'Autonomous email sent to {recipient} — "{subject}". '
+                "Review or flag it in the dashboard Activity tab.",
+            )
+        except Exception:
+            logger.warning("autonomous-send notification failed", exc_info=True)
 
     def reload_config(self, config: OutreachConfig) -> None:
         """Hot-reload outreach config on pipeline and governance gate."""
@@ -331,6 +397,11 @@ class OutreachPipeline:
         # send is recorded for owner approval and later resumed below the gate by
         # the resolution watcher (gate_cleared=True). Non-email channels and the
         # resume path skip it.
+        # WS-8 PR-D: capture whether this send is AUTONOMOUS (gate allowed a
+        # GRANTED cell) so the post-send block can log it to the owner-visible
+        # ledger.  Stays None for non-email, the gate_cleared resume path, no
+        # gate, or a held send.
+        gate_cell: tuple[str, str, str] | None = None
         if channel == "email" and not gate_cleared and self._autonomy_gate is not None:
             decision = await self._autonomy_gate.check(
                 request=request, recipient=recipient, message_text=formatted.text,
@@ -346,6 +417,8 @@ class OutreachPipeline:
                     channel=channel,
                     message_content=formatted.text,
                 )
+            if decision.reason == "granted":
+                gate_cell = decision.cell
 
         # Determine delivery routing: supergroup, dm, or both
         routing = "supergroup"  # default
@@ -480,6 +553,15 @@ class OutreachPipeline:
                 content_hash=content_hash(request.context),
             )
             await outreach_crud.record_delivery(self._db, outreach_id, delivered_at=now)
+
+            # WS-8 PR-D: log autonomous (GRANTED-cell) email sends for owner
+            # visibility (Activity tab), the flag-as-bad correction, and the
+            # per-cell rate-limit guard.  Owner-APPROVED holds resume via
+            # deliver_approved (gate_cleared, gate_cell None) and are NOT logged.
+            if gate_cell is not None:
+                await self._record_autonomous_send(
+                    request, gate_cell, recipient, outreach_id, now,
+                )
 
         # Auto-register email threads for reply tracking
         if channel == "email" and self._thread_tracker is not None:

--- a/src/genesis/runtime/init/autonomy.py
+++ b/src/genesis/runtime/init/autonomy.py
@@ -73,6 +73,24 @@ async def init(rt: GenesisRuntime) -> None:
                 ))
                 logger.info("Email autonomy gate wired into outreach pipeline")
 
+                # WS-8 PR-D: muted-by-default owner notification for autonomous
+                # sends — toggled via config/autonomy.yaml `email_send_notify`.
+                try:
+                    from pathlib import Path
+
+                    import yaml
+
+                    import genesis as _genesis
+                    _cfg = (
+                        Path(_genesis.__file__).resolve().parents[2]
+                        / "config" / "autonomy.yaml"
+                    )
+                    _data = yaml.safe_load(_cfg.read_text()) if _cfg.exists() else {}
+                    _notify = bool((_data or {}).get("email_send_notify", False))
+                except Exception:
+                    _notify = False
+                rt._outreach_pipeline.set_autonomous_send_notify(_notify)
+
             rt._autonomous_cli_policy_exporter = AutonomousCliPolicyExporter()
             if rt._router is not None:
                 rt._autonomous_cli_approval_gate = AutonomousCliApprovalGate(

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -231,6 +231,42 @@ async def init(rt: GenesisRuntime) -> None:
             misfire_grace_time=300,
         )
 
+        # WS-8 PR-D capability staleness decay — a GRANTED email cell idle past
+        # the half-life lapses back to NOT_DETERMINED (holds again on next use),
+        # so standing autonomy can't entrench unused. Daily, INFO-level.
+        from genesis.db.crud import capability_grants as _cg
+
+        async def _capability_decay_sweep() -> None:
+            try:
+                if rt.paused:
+                    return
+            except Exception:
+                logger.warning(
+                    "Pause check failed — skipping capability decay", exc_info=True,
+                )
+                return
+            try:
+                decayed = await _cg.decay_stale_cells(
+                    rt._db, now=datetime.now(UTC).isoformat(),
+                )
+                rt.record_job_success("capability_decay_sweep")
+                if decayed:
+                    logger.info(
+                        "Capability decay: %d stale grant(s) lapsed: %s",
+                        len(decayed), ", ".join(decayed),
+                    )
+            except Exception as exc:
+                rt.record_job_failure("capability_decay_sweep", str(exc))
+                raise
+
+        rt._learning_scheduler.add_job(
+            _capability_decay_sweep,
+            CronTrigger(hour=3, minute=30, timezone=user_timezone()),
+            id="capability_decay_sweep",
+            max_instances=1,
+            misfire_grace_time=3600,
+        )
+
         from genesis.db.crud import observations
         from genesis.learning.harvesting.auto_memory import harvest_auto_memory
 

--- a/tests/ego/test_cell_promotion.py
+++ b/tests/ego/test_cell_promotion.py
@@ -1,0 +1,141 @@
+"""Tests for cell_promotion (WS-8 PR-D): the shared resolution hook that promotes
+an email capability cell ASK→GRANTED on the owner's approval, plus guards that
+the hook is wired into every resolution entry point and excluded from the
+approved-proposal dispatch sweep."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+import genesis
+from genesis.autonomy.types import CellEvent, CellState
+from genesis.db.crud import capability_grants as cg
+from genesis.db.crud import ego as ego_crud
+from genesis.db.schema import create_all_tables
+from genesis.ego.cell_promotion import _parse_cell, handle_cell_promotion_resolution
+
+_TS = "2026-06-21T00:00:00"
+_CELL = {"domain": "email", "verb": "send", "risk_class": "standard"}
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+async def _promotable_cell(db, successes=5):
+    """An ASK cell with enough approved successes to be promotable."""
+    await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_CELL)
+    for _ in range(successes):
+        await cg.record_success(db, updated_at=_TS, **_CELL)
+
+
+async def _make_proposal(db, *, status="approved", action_type="cell_promotion",
+                         cell=("email", "send", "standard")):
+    pid = "cp1"
+    await ego_crud.create_proposal(
+        db, id=pid, action_type=action_type, action_category=":".join(cell),
+        content="promote", status="pending",
+        created_at="2026-06-20T00:00:00+00:00",
+        expected_outputs=json.dumps({"cell": list(cell)}),
+    )
+    await ego_crud.resolve_proposal(db, pid, status=status)
+    return await ego_crud.get_proposal(db, pid)
+
+
+# ── _parse_cell ───────────────────────────────────────────────────────────
+
+
+def test_parse_cell():
+    assert _parse_cell('{"cell": ["email", "send", "standard"]}') == ("email", "send", "standard")
+    assert _parse_cell({"cell": ["email", "send", "bulk"]}) == ("email", "send", "bulk")
+    assert _parse_cell("not json") is None
+    assert _parse_cell({"cell": ["only", "two"]}) is None
+    assert _parse_cell(None) is None
+
+
+# ── handle_cell_promotion_resolution ──────────────────────────────────────
+
+
+async def test_approved_promotes_ask_cell(db):
+    await _promotable_cell(db)
+    prop = await _make_proposal(db, status="approved")
+
+    ok = await handle_cell_promotion_resolution(db, prop, "approved")
+
+    assert ok is True
+    assert (await cg.get_cell(db, **_CELL))["state"] == CellState.GRANTED.value
+    assert (await ego_crud.get_proposal(db, prop["id"]))["status"] == "executed"
+
+
+async def test_rejected_sets_cooldown_no_promote(db):
+    await _promotable_cell(db)
+    prop = await _make_proposal(db, status="rejected")
+
+    ok = await handle_cell_promotion_resolution(db, prop, "rejected")
+
+    assert ok is False
+    assert (await cg.get_cell(db, **_CELL))["state"] == CellState.ASK.value
+    assert await ego_crud.get_state(
+        db, "cell_promotion_reject:email:send:standard",
+    ) is not None
+
+
+async def test_non_cell_proposal_is_noop(db):
+    await _promotable_cell(db)
+    prop = await _make_proposal(db, status="approved", action_type="autonomy_earnback")
+
+    ok = await handle_cell_promotion_resolution(db, prop, "approved")
+
+    assert ok is False
+    assert (await cg.get_cell(db, **_CELL))["state"] == CellState.ASK.value
+
+
+async def test_approve_skips_when_evidence_changed(db):
+    # Too few successes → not promotable → approval must NOT promote (the
+    # staleness guard: a correction may have landed since the proposal was shown).
+    await _promotable_cell(db, successes=2)
+    prop = await _make_proposal(db, status="approved")
+
+    ok = await handle_cell_promotion_resolution(db, prop, "approved")
+
+    assert ok is False
+    assert (await cg.get_cell(db, **_CELL))["state"] == CellState.ASK.value
+    # still marked executed so it doesn't linger / get dispatched
+    assert (await ego_crud.get_proposal(db, prop["id"]))["status"] == "executed"
+
+
+# ── Wiring guards (built ≠ wired) ─────────────────────────────────────────
+
+
+def test_handler_wired_into_all_resolution_paths():
+    """Every proposal-resolution entry point MUST call the cell-promotion hook,
+    or an approval there silently no-ops."""
+    root = Path(genesis.__file__).parent
+    for path in [
+        root / "ego" / "proposals.py",
+        root / "mcp" / "health" / "ego_tools.py",
+        root / "dashboard" / "routes" / "ego.py",
+        root / "dashboard" / "routes" / "comms.py",
+    ]:
+        src = path.read_text()
+        assert "handle_cell_promotion_resolution" in src, (
+            f"{path} is missing the cell-promotion apply hook — "
+            "an approval there would silently no-op"
+        )
+
+
+def test_excluded_from_approved_proposal_sweep():
+    """P1-A: cell_promotion must be in the sweep exclusion list, else an approved
+    promotion gets dispatched as a CC session."""
+    root = Path(genesis.__file__).parent
+    src = (root / "ego" / "session.py").read_text()
+    assert '"cell_promotion"' in src

--- a/tests/test_autonomy/test_dashboard_autonomy_routes.py
+++ b/tests/test_autonomy/test_dashboard_autonomy_routes.py
@@ -1,0 +1,58 @@
+"""Tests for the WS-8 PR-D dashboard autonomy routes (the owner "Activity" tab).
+
+Registration + not-bootstrapped smoke (the cross-event-loop aiosqlite limit makes
+full DB-backed route tests impractical here — the flag→demote behaviour is covered
+by the CRUD unit tests and the browser E2E, matching the Traces-tab precedent)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+import genesis.dashboard.routes.autonomy  # noqa: F401 — registers the routes
+from genesis.dashboard._blueprint import blueprint
+
+
+@pytest.fixture()
+def client():
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def test_routes_registered():
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    rules = {r.rule for r in app.url_map.iter_rules()}
+    assert "/api/genesis/autonomy/grants" in rules
+    assert "/api/genesis/autonomy/sends" in rules
+    assert "/api/genesis/autonomy/sends/<send_id>/flag" in rules
+
+
+def test_grants_empty_when_not_bootstrapped(client):
+    rt = MagicMock(is_bootstrapped=False, db=None)
+    with patch("genesis.runtime.GenesisRuntime") as MockRT:
+        MockRT.instance.return_value = rt
+        resp = client.get("/api/genesis/autonomy/grants")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"grants": []}
+
+
+def test_sends_empty_when_not_bootstrapped(client):
+    rt = MagicMock(is_bootstrapped=False, db=None)
+    with patch("genesis.runtime.GenesisRuntime") as MockRT:
+        MockRT.instance.return_value = rt
+        resp = client.get("/api/genesis/autonomy/sends")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"sends": []}
+
+
+def test_flag_503_when_not_bootstrapped(client):
+    rt = MagicMock(is_bootstrapped=False, db=None)
+    with patch("genesis.runtime.GenesisRuntime") as MockRT:
+        MockRT.instance.return_value = rt
+        resp = client.post("/api/genesis/autonomy/sends/x/flag")
+        assert resp.status_code == 503

--- a/tests/test_autonomy/test_email_gate.py
+++ b/tests/test_autonomy/test_email_gate.py
@@ -107,12 +107,13 @@ async def test_cold_ungranted_email_is_held(db):
 
 @pytest.mark.asyncio
 async def test_granted_known_thread_reply_is_allowed(db):
-    # pre-grant the standard (known-thread reply) cell — the Option-B seed.
+    # pre-grant the standard (known-thread reply) cell, with the recipient as a
+    # recorded thread participant so the g1 recipient-match guard passes.
     await cg.apply_event(db, domain="email", verb="send", risk_class="standard",
                          event=CellEvent.CLASSIFY, updated_at=_TS)
     await cg.apply_event(db, domain="email", verb="send", risk_class="standard",
                          event=CellEvent.APPROVE, updated_at=_TS)
-    await _add_inbound(db, "t1")
+    await _add_inbound_from(db, "t1", "alice@example.com")
 
     gate = _gate(db)
     req = _req(validated_recipient="alice@example.com", thread_id="t1")
@@ -202,18 +203,20 @@ async def test_granted_reply_recipient_mismatch_demotes_and_holds(db):
 
 
 @pytest.mark.asyncio
-async def test_granted_reply_null_sender_gets_benefit_of_doubt(db):
-    # P2-B: a received message with NULL sender must NOT false-trip g1 (which
-    # would silently revoke the grant on missing data).
+async def test_granted_reply_unknown_sender_trips_guard(db):
+    # A thread whose only inbound has no recorded sender is genuinely-ambiguous
+    # scope — g1 trips (hold + demote) rather than waving any recipient through.
+    # The real reply path always records a sender (reply_poller/record_reply), so
+    # this only affects anomalous/unparsed rows; the SAFE failure is to hold.
     await _grant_standard(db)
-    await _add_inbound(db, "t1")  # NULL sender
+    await _add_inbound(db, "t1")  # NULL sender (anomalous)
     gate = _gate(db)
     req = _req(validated_recipient="anyone@example.com", thread_id="t1")
     decision = await gate.check(
         request=req, recipient="anyone@example.com", message_text="re",
     )
-    assert decision.allow is True
-    assert (await cg.get_cell(db, "email", "send", "standard"))["state"] == "granted"
+    assert decision.allow is False  # held — ambiguous scope is not waved through
+    assert (await cg.get_cell(db, "email", "send", "standard"))["state"] == "ask"
 
 
 @pytest.mark.asyncio

--- a/tests/test_autonomy/test_email_gate.py
+++ b/tests/test_autonomy/test_email_gate.py
@@ -9,12 +9,19 @@ from email_thread_messages.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import aiosqlite
 import pytest
 
 from genesis.autonomy.approval import ApprovalManager
-from genesis.autonomy.email_gate import EMAIL_GATE_ACTION_TYPE, EmailAutonomyGate
+from genesis.autonomy.email_gate import (
+    _RATE_LIMIT_MAX,
+    EMAIL_GATE_ACTION_TYPE,
+    EmailAutonomyGate,
+)
 from genesis.autonomy.types import CellEvent
+from genesis.db.crud import autonomous_email_sends as aes
 from genesis.db.crud import capability_grants as cg
 from genesis.db.crud import pending_email_sends as pes
 from genesis.db.schema import create_all_tables
@@ -55,6 +62,23 @@ async def _add_inbound(db, thread_id):
         (thread_id, f"m-{thread_id}", _TS),
     )
     await db.commit()
+
+
+async def _add_inbound_from(db, thread_id, sender):
+    """Inbound message with a KNOWN sender (for the recipient-match guard)."""
+    await db.execute(
+        "INSERT INTO email_thread_messages "
+        "(thread_id, message_id, direction, sender, received_at) "
+        "VALUES (?, ?, 'received', ?, ?)",
+        (thread_id, f"m-{thread_id}-{sender}", sender, _TS),
+    )
+    await db.commit()
+
+
+async def _grant_standard(db):
+    for event in (CellEvent.CLASSIFY, CellEvent.APPROVE):
+        await cg.apply_event(db, domain="email", verb="send", risk_class="standard",
+                             event=event, updated_at=_TS)
 
 
 # --------------------------------------------------------------------------- #
@@ -153,3 +177,61 @@ async def test_approve_all_pending_excludes_email_gate(db):
     assert n == 1  # only the non-email approval
     assert (await ac.get_by_id(db, email_rid))["status"] == "pending"  # still held
     assert (await ac.get_by_id(db, other_rid))["status"] == "approved"
+
+
+# --------------------------------------------------------------------------- #
+# WS-8 PR-D — deterministic pre-send scope guards on a GRANTED cell
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_granted_reply_recipient_mismatch_demotes_and_holds(db):
+    # g1: the granted standard cell's recipient is NOT a participant of the thread
+    # → scope drift → hold THIS send + demote the cell GRANTED→ASK.
+    await _grant_standard(db)
+    await _add_inbound_from(db, "t1", "alice@example.com")  # known correspondent
+    gate = _gate(db)
+    req = _req(validated_recipient="mallory@evil.com", thread_id="t1")
+    decision = await gate.check(
+        request=req, recipient="mallory@evil.com", message_text="re",
+    )
+    assert decision.allow is False  # held
+    cell = await cg.get_cell(db, "email", "send", "standard")
+    assert cell["state"] == "ask"  # demoted
+    assert cell["corrections"] == 1
+
+
+@pytest.mark.asyncio
+async def test_granted_reply_null_sender_gets_benefit_of_doubt(db):
+    # P2-B: a received message with NULL sender must NOT false-trip g1 (which
+    # would silently revoke the grant on missing data).
+    await _grant_standard(db)
+    await _add_inbound(db, "t1")  # NULL sender
+    gate = _gate(db)
+    req = _req(validated_recipient="anyone@example.com", thread_id="t1")
+    decision = await gate.check(
+        request=req, recipient="anyone@example.com", message_text="re",
+    )
+    assert decision.allow is True
+    assert (await cg.get_cell(db, "email", "send", "standard"))["state"] == "granted"
+
+
+@pytest.mark.asyncio
+async def test_granted_rate_limit_burst_demotes_and_holds(db):
+    # g3 (primary): a burst of autonomous sends for one cell within the window =
+    # a runaway loop → hold + demote.  g1 passes (recipient matches the thread).
+    await _grant_standard(db)
+    await _add_inbound_from(db, "t1", "alice@example.com")
+    now = datetime.now(UTC).isoformat()
+    for i in range(_RATE_LIMIT_MAX):
+        await aes.create(
+            db, id=f"a{i}", recipient="alice@example.com", sent_at=now,
+            cell_domain="email", cell_verb="send", cell_risk_class="standard",
+        )
+    gate = _gate(db)
+    req = _req(validated_recipient="alice@example.com", thread_id="t1")
+    decision = await gate.check(
+        request=req, recipient="alice@example.com", message_text="re",
+    )
+    assert decision.allow is False  # rate-limit tripped
+    assert (await cg.get_cell(db, "email", "send", "standard"))["state"] == "ask"

--- a/tests/test_db/test_autonomous_email_sends.py
+++ b/tests/test_db/test_autonomous_email_sends.py
@@ -1,0 +1,67 @@
+"""Tests for the WS-8 PR-D autonomous-send ledger CRUD."""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import autonomous_email_sends as aes
+from genesis.db.schema import create_all_tables
+
+_CELL = {"cell_domain": "email", "cell_verb": "send", "cell_risk_class": "standard"}
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await create_all_tables(conn)
+        await conn.commit()
+        yield conn
+
+
+async def _mk(db, *, id, sent_at, recipient="a@b.c", **over):
+    await aes.create(
+        db, id=id, recipient=recipient, sent_at=sent_at,
+        subject="hi", thread_id="t1", outreach_id="o1",
+        **{**_CELL, **over},
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_and_get(db):
+    await _mk(db, id="s1", sent_at="2026-06-21T10:00:00")
+    row = await aes.get_by_id(db, "s1")
+    assert row["recipient"] == "a@b.c"
+    assert row["cell_risk_class"] == "standard"
+    assert row["flagged_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_count_for_cell_since_windows(db):
+    await _mk(db, id="old", sent_at="2026-06-21T08:00:00")
+    await _mk(db, id="new1", sent_at="2026-06-21T10:30:00")
+    await _mk(db, id="new2", sent_at="2026-06-21T10:45:00")
+    # a send for a DIFFERENT cell must not count
+    await _mk(db, id="bulk", sent_at="2026-06-21T10:50:00", cell_risk_class="bulk")
+    n = await aes.count_for_cell_since(db, since="2026-06-21T10:00:00", **_CELL)
+    assert n == 2
+
+
+@pytest.mark.asyncio
+async def test_list_recent_orders_desc(db):
+    await _mk(db, id="a", sent_at="2026-06-21T09:00:00")
+    await _mk(db, id="b", sent_at="2026-06-21T11:00:00")
+    await _mk(db, id="c", sent_at="2026-06-21T10:00:00")
+    rows = await aes.list_recent(db, limit=2)
+    assert [r["id"] for r in rows] == ["b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_mark_flagged_is_idempotent(db):
+    await _mk(db, id="s1", sent_at="2026-06-21T10:00:00")
+    assert await aes.mark_flagged(db, "s1", flagged_at="2026-06-21T12:00:00") is True
+    # second flag is a no-op (already flagged) → caller must not re-demote
+    assert await aes.mark_flagged(db, "s1", flagged_at="2026-06-21T13:00:00") is False
+    row = await aes.get_by_id(db, "s1")
+    assert row["flagged_at"] == "2026-06-21T12:00:00"  # first flag preserved

--- a/tests/test_db/test_capability_grants.py
+++ b/tests/test_db/test_capability_grants.py
@@ -299,3 +299,27 @@ class TestPRDCompetence:
                              event=CellEvent.CLASSIFY, updated_at=_TS)
         granted = await cg.list_granted(db)
         assert [g["id"] for g in granted] == ["email:send:standard"]
+
+    @pytest.mark.asyncio
+    async def test_decay_lapses_only_stale_grants(self, db):
+        from datetime import UTC, datetime, timedelta
+        now_dt = datetime(2026, 6, 21, tzinfo=UTC)
+        now = now_dt.isoformat()
+        # fresh grant (used today) — must NOT decay
+        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=now, **_EMAIL)
+        await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=now, **_EMAIL)
+        await cg.touch_used(db, used_at=now, **_EMAIL)
+        # stale grant (granted 100d ago, never used) — must decay
+        old = (now_dt - timedelta(days=100)).isoformat()
+        for ev in (CellEvent.CLASSIFY, CellEvent.APPROVE):
+            await cg.apply_event(db, domain="email", verb="send", risk_class="bulk",
+                                 event=ev, updated_at=old)
+
+        decayed = await cg.decay_stale_cells(db, now=now, half_life_days=90)
+
+        assert decayed == ["email:send:bulk"]
+        assert (await cg.get_cell(db, **_EMAIL))["state"] == CellState.GRANTED.value
+        bulk = await cg.get_cell(db, "email", "send", "bulk")
+        assert bulk["state"] == CellState.NOT_DETERMINED.value
+        assert bulk["granted_at"] is None
+        assert bulk["last_decayed_at"] == now

--- a/tests/test_db/test_capability_grants.py
+++ b/tests/test_db/test_capability_grants.py
@@ -289,3 +289,13 @@ class TestPRDCompetence:
         # Same evidence, heavier past harm ⇒ lower re-earn posterior ⇒ harder
         # to climb back to the 0.70 promotion bar.
         assert cg.cell_posterior(5, 1, 2.0) < cg.cell_posterior(5, 1, 1.0)
+
+    @pytest.mark.asyncio
+    async def test_list_granted_returns_only_granted(self, db):
+        # standard → GRANTED; bulk left at ASK.
+        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
+        await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL)
+        await cg.apply_event(db, domain="email", verb="send", risk_class="bulk",
+                             event=CellEvent.CLASSIFY, updated_at=_TS)
+        granted = await cg.list_granted(db)
+        assert [g["id"] for g in granted] == ["email:send:standard"]

--- a/tests/test_db/test_capability_grants.py
+++ b/tests/test_db/test_capability_grants.py
@@ -18,6 +18,7 @@ from genesis.autonomy.types import CellEvent, CellState
 from genesis.db.crud import capability_grants as cg
 
 MIGRATION = importlib.import_module("genesis.db.migrations.0030_capability_grants")
+MIGRATION_PRD = importlib.import_module("genesis.db.migrations.0033_autonomy_earn_lose")
 
 _EMAIL = {"domain": "email", "verb": "send", "risk_class": "standard"}
 _TS = "2026-06-21T00:00:00"
@@ -25,11 +26,13 @@ _TS = "2026-06-21T00:00:00"
 
 @pytest.fixture
 async def db(tmp_path):
-    """Fresh DB with capability_grants created via the real migration up()."""
+    """Fresh DB via the real migration up()s (0030 + the PR-D 0033 columns the
+    CRUD now reads/writes)."""
     db_path = str(tmp_path / "test.db")
     async with aiosqlite.connect(db_path) as conn:
         conn.row_factory = aiosqlite.Row
         await MIGRATION.up(conn)  # up() must not commit — runner owns the txn
+        await MIGRATION_PRD.up(conn)
         await conn.commit()
         yield conn
 
@@ -162,14 +165,19 @@ class TestCrud:
         assert row["corrections"] == 1
 
     @pytest.mark.asyncio
-    async def test_correction_keeps_well_supported_grant(self, db):
+    async def test_correction_demotes_any_granted_cell(self, db):
+        # WS-8 PR-D "easy to lose": even a heavily-supported GRANTED cell
+        # regresses to ASK on a SINGLE correction (deterministic, NOT posterior-
+        # gated).  The well-supported counters only make it cheaper to re-earn.
         await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
         await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL)
         for _ in range(5):
             await cg.record_success(db, updated_at=_TS, **_EMAIL)
-        # 5 successes, 1 correction → posterior 6/8 = 0.75 ≥ floor → stays GRANTED.
         state = await cg.record_correction(db, updated_at=_TS, **_EMAIL)
-        assert state == CellState.GRANTED
+        assert state == CellState.ASK
+        row = await cg.get_cell(db, **_EMAIL)
+        assert row["state"] == CellState.ASK.value
+        assert row["granted_at"] is None  # decay-clock origin cleared on demotion
 
     @pytest.mark.asyncio
     async def test_correction_on_non_granted_is_inert(self, db):
@@ -209,3 +217,75 @@ class TestCrud:
         await cg.ensure_cell(db, updated_at=_TS, **_EMAIL)
         rows = await cg.list_all(db)
         assert [r["risk_class"] for r in rows] == ["bulk", "standard"]
+
+
+# --------------------------------------------------------------------------- #
+# WS-8 PR-D — consequence-weighted demotion + re-earn + promotion detection
+# --------------------------------------------------------------------------- #
+class TestPRDCompetence:
+    @pytest.mark.asyncio
+    async def test_correction_accumulates_severity_weight(self, db):
+        # A standard correction adds 1.0; a bulk correction adds 2.0.
+        await cg.record_correction(
+            db, updated_at=_TS, domain="email", verb="send", risk_class="standard"
+        )
+        assert (await cg.get_cell(db, "email", "send", "standard"))[
+            "weighted_corrections"
+        ] == pytest.approx(1.0)
+        await cg.record_correction(
+            db, updated_at=_TS, domain="email", verb="send", risk_class="bulk"
+        )
+        assert (await cg.get_cell(db, "email", "send", "bulk"))[
+            "weighted_corrections"
+        ] == pytest.approx(2.0)
+
+    @pytest.mark.asyncio
+    async def test_consequence_weight_override(self, db):
+        await cg.record_correction(db, updated_at=_TS, consequence_weight=3.5, **_EMAIL)
+        row = await cg.get_cell(db, **_EMAIL)
+        assert row["weighted_corrections"] == pytest.approx(3.5)
+        assert row["corrections"] == 1
+
+    @pytest.mark.asyncio
+    async def test_correction_on_ask_accrues_crater_without_regress(self, db):
+        # Demotion fires only on GRANTED; an ASK cell stays ASK but still
+        # accumulates the weighted crater (a rejected held send is negative).
+        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
+        state = await cg.record_correction(db, updated_at=_TS, **_EMAIL)
+        assert state == CellState.ASK
+        assert (await cg.get_cell(db, **_EMAIL))[
+            "weighted_corrections"
+        ] == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    async def test_touch_used_bumps_last_used_not_successes(self, db):
+        await cg.ensure_cell(db, updated_at=_TS, **_EMAIL)
+        assert await cg.touch_used(db, used_at="2026-06-22T00:00:00", **_EMAIL) is True
+        row = await cg.get_cell(db, **_EMAIL)
+        assert row["last_used_at"] == "2026-06-22T00:00:00"
+        assert row["successes"] == 0  # autonomous use is not a competence signal
+
+    @pytest.mark.asyncio
+    async def test_detect_promotable_requires_min_n_and_threshold(self, db):
+        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
+        for _ in range(4):  # below MIN_PROMOTE_N
+            await cg.record_success(db, updated_at=_TS, **_EMAIL)
+        assert await cg.detect_promotable_cells(db) == []
+        await cg.record_success(db, updated_at=_TS, **_EMAIL)  # 5th → promotable
+        cands = await cg.detect_promotable_cells(db)
+        assert [c["id"] for c in cands] == ["email:send:standard"]
+        assert cands[0]["posterior"] > 0.70
+
+    @pytest.mark.asyncio
+    async def test_detect_promotable_excludes_granted(self, db):
+        await cg.apply_event(db, event=CellEvent.CLASSIFY, updated_at=_TS, **_EMAIL)
+        await cg.apply_event(db, event=CellEvent.APPROVE, updated_at=_TS, **_EMAIL)
+        for _ in range(5):
+            await cg.record_success(db, updated_at=_TS, **_EMAIL)
+        assert await cg.detect_promotable_cells(db) == []  # already GRANTED
+
+    @pytest.mark.asyncio
+    async def test_heavier_harm_craters_reearn_deeper(self, db):
+        # Same evidence, heavier past harm ⇒ lower re-earn posterior ⇒ harder
+        # to climb back to the 0.70 promotion bar.
+        assert cg.cell_posterior(5, 1, 2.0) < cg.cell_posterior(5, 1, 1.0)

--- a/tests/test_db/test_migration_0033_earn_lose.py
+++ b/tests/test_db/test_migration_0033_earn_lose.py
@@ -1,0 +1,139 @@
+"""Tests for migration 0033 — WS-8 PR-D earn/lose schema.
+
+Covers the two new ``capability_grants`` columns, the ``autonomous_email_sends``
+ledger + indexes, idempotency, fresh-install parity (``create_all_tables``), the
+seed-revert (pristine PR-C grant removed, owner-touched cell preserved), and down.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M30 = importlib.import_module("genesis.db.migrations.0030_capability_grants")
+M33 = importlib.import_module("genesis.db.migrations.0033_autonomy_earn_lose")
+
+
+async def _cols(db: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await db.execute(f"PRAGMA table_info({table})")
+    return {r[1] for r in await cur.fetchall()}
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await M30.up(conn)
+        await M33.up(conn)
+        await conn.commit()
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_adds_columns(db):
+    cols = await _cols(db, "capability_grants")
+    assert "weighted_corrections" in cols
+    assert "last_decayed_at" in cols
+
+
+@pytest.mark.asyncio
+async def test_creates_ledger_table_and_index(db):
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        "AND name='autonomous_email_sends'"
+    )
+    assert await cur.fetchone() is not None
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' "
+        "AND name='idx_autonomous_email_sends_cell'"
+    )
+    assert await cur.fetchone() is not None
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "idem.db")) as conn:
+        await M30.up(conn)
+        await M33.up(conn)
+        await M33.up(conn)  # PRAGMA-guarded ALTER + IF NOT EXISTS → must not raise
+        await conn.commit()
+        cur = await conn.execute("PRAGMA table_info(capability_grants)")
+        names = [r[1] for r in await cur.fetchall()]
+        assert names.count("weighted_corrections") == 1
+        assert names.count("last_decayed_at") == 1
+
+
+@pytest.mark.asyncio
+async def test_fresh_install_parity(tmp_path):
+    """create_all_tables (fresh-install path) yields the same columns + table."""
+    from genesis.db.schema import create_all_tables
+
+    async with aiosqlite.connect(str(tmp_path / "fresh.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await create_all_tables(conn)
+        await conn.commit()
+        cols = await _cols(conn, "capability_grants")
+        assert {"weighted_corrections", "last_decayed_at"} <= cols
+        cur = await conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name='autonomous_email_sends'"
+        )
+        assert await cur.fetchone() is not None
+
+
+@pytest.mark.asyncio
+async def test_revert_removes_pristine_seed(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "seed.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await M30.up(conn)
+        # Mimic the 0032 Option-B seed: a pristine GRANTED standard cell.
+        await conn.execute(
+            "INSERT INTO capability_grants "
+            "(id, domain, verb, risk_class, state, granted_at, created_at, updated_at) "
+            "VALUES ('email:send:standard','email','send','standard','granted','t','t','t')"
+        )
+        await conn.commit()
+        await M33.up(conn)
+        await conn.commit()
+        cur = await conn.execute(
+            "SELECT id FROM capability_grants WHERE id='email:send:standard'"
+        )
+        assert await cur.fetchone() is None  # pristine seed removed → all-ASK
+
+
+@pytest.mark.asyncio
+async def test_revert_keeps_owner_touched_cell(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "seed2.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await M30.up(conn)
+        # The owner has acted on this cell (evidence present) → must NOT be removed.
+        await conn.execute(
+            "INSERT INTO capability_grants "
+            "(id, domain, verb, risk_class, state, successes, corrections, "
+            " granted_at, created_at, updated_at) "
+            "VALUES ('email:send:standard','email','send','standard','granted',3,1,'t','t','t')"
+        )
+        await conn.commit()
+        await M33.up(conn)
+        await conn.commit()
+        cur = await conn.execute(
+            "SELECT state FROM capability_grants WHERE id='email:send:standard'"
+        )
+        row = await cur.fetchone()
+        assert row is not None and row["state"] == "granted"
+
+
+@pytest.mark.asyncio
+async def test_down_drops_ledger(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "down.db")) as conn:
+        await M30.up(conn)
+        await M33.up(conn)
+        await M33.down(conn)
+        await conn.commit()
+        cur = await conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name='autonomous_email_sends'"
+        )
+        assert await cur.fetchone() is None

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -57,6 +57,7 @@ EXPECTED_TABLES = [
     "campaign_runs",
     "capability_grants",  # WS-8 PR-B: per-(domain,verb,risk_class) cells
     "pending_email_sends",  # WS-8 PR-C: email autonomy gate hold store
+    "autonomous_email_sends",  # WS-8 PR-D: autonomous-send ledger (visibility + flag + rate-limit)
 ]
 
 

--- a/tests/test_outreach/test_autonomous_send_ledger.py
+++ b/tests/test_outreach/test_autonomous_send_ledger.py
@@ -1,0 +1,148 @@
+"""WS-8 PR-D — the pipeline logs autonomous (GRANTED-cell) email sends to the
+``autonomous_email_sends`` ledger, and ONLY those (not held sends, not the
+owner-approved resume path)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from genesis.autonomy.approval import ApprovalManager
+from genesis.autonomy.email_gate import EmailAutonomyGate
+from genesis.autonomy.types import CellEvent
+from genesis.content.types import FormatTarget, FormattedContent
+from genesis.db.crud import autonomous_email_sends as aes
+from genesis.db.crud import capability_grants as cg
+from genesis.db.schema import create_all_tables
+from genesis.outreach.config import OutreachConfig, QuietHours
+from genesis.outreach.governance import GovernanceGate
+from genesis.outreach.pipeline import OutreachPipeline
+from genesis.outreach.types import OutreachCategory, OutreachRequest, OutreachStatus
+
+_TS = "2026-06-21T00:00:00"
+
+
+@pytest.fixture
+def config():
+    return OutreachConfig(
+        quiet_hours=QuietHours(start="22:00", end="07:00"),
+        channel_preferences={"default": "email"},
+        thresholds={"blocker": 0.0, "surplus": 0.0},
+        max_daily=50, surplus_daily=50, content_daily=50, notification_daily=50,
+        morning_report_time="07:00",
+        engagement_timeout_hours=24, engagement_poll_minutes=60,
+    )
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+@pytest.fixture
+def email_adapter():
+    a = AsyncMock()
+    a.send_message.return_value = "<msgid@example.com>"
+    return a
+
+
+def _pipeline(config, db, email_adapter):
+    formatter = MagicMock()
+    formatter.format.return_value = FormattedContent(
+        text="re: hello", target=FormatTarget.EMAIL,
+    )
+    pipeline = OutreachPipeline(
+        governance=GovernanceGate(config, db),
+        drafter=AsyncMock(),
+        formatter=formatter,
+        channels={"email": email_adapter},
+        db=db,
+        config=config,
+        recipients={"email": "fallback@example.com"},
+    )
+    pipeline.set_autonomy_gate(
+        EmailAutonomyGate(db=db, approval_manager=ApprovalManager(db=db), event_bus=None)
+    )
+    return pipeline
+
+
+async def _grant_standard(db):
+    for ev in (CellEvent.CLASSIFY, CellEvent.APPROVE):
+        await cg.apply_event(
+            db, domain="email", verb="send", risk_class="standard", event=ev, updated_at=_TS,
+        )
+
+
+async def _add_inbound(db, thread_id):
+    await db.execute(
+        "INSERT INTO email_thread_messages (thread_id, message_id, direction, received_at) "
+        "VALUES (?, ?, 'received', ?)",
+        (thread_id, f"m-{thread_id}", _TS),
+    )
+    await db.commit()
+
+
+def _req():
+    return OutreachRequest(
+        category=OutreachCategory.SURPLUS, topic="re: hello", context="body",
+        salience_score=0.9, signal_type="email_reply", channel="email",
+        validated_recipient="alice@example.com", thread_id="t1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_granted_send_is_logged_to_ledger(config, db, email_adapter):
+    await _grant_standard(db)
+    await _add_inbound(db, "t1")
+    pipeline = _pipeline(config, db, email_adapter)
+
+    result = await pipeline.submit_raw("re: hello", _req())
+
+    assert result.status == OutreachStatus.DELIVERED
+    sends = await aes.list_recent(db)
+    assert len(sends) == 1
+    assert sends[0]["recipient"] == "alice@example.com"
+    assert sends[0]["cell_risk_class"] == "standard"
+    assert sends[0]["thread_id"] == "t1"
+    # last_used_at bumped, successes NOT incremented (autonomous use != competence)
+    cell = await cg.get_cell(db, "email", "send", "standard")
+    assert cell["last_used_at"] is not None
+    assert cell["successes"] == 0
+
+
+@pytest.mark.asyncio
+async def test_held_send_is_not_logged(config, db, email_adapter):
+    # standard cell NOT granted → held → nothing delivered, nothing logged.
+    await _add_inbound(db, "t1")
+    pipeline = _pipeline(config, db, email_adapter)
+
+    result = await pipeline.submit_raw("re: hello", _req())
+
+    assert result.status == OutreachStatus.HELD
+    assert await aes.list_recent(db) == []
+    email_adapter.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resume_path_is_not_logged(config, db, email_adapter):
+    # deliver_approved (gate_cleared=True) = an owner-APPROVED hold resuming →
+    # NOT an autonomous send → must not be logged (P1-B exclusion).
+    await _grant_standard(db)
+    await _add_inbound(db, "t1")
+    pipeline = _pipeline(config, db, email_adapter)
+    pending = {
+        "category": "surplus", "message": "approved reply",
+        "validated_recipient": "alice@example.com", "thread_id": "t1",
+    }
+
+    result = await pipeline.deliver_approved(pending, subject="re: hello")
+
+    assert result.status == OutreachStatus.DELIVERED
+    email_adapter.send_message.assert_called_once()
+    assert await aes.list_recent(db) == []  # resume is not autonomous

--- a/tests/test_outreach/test_autonomous_send_ledger.py
+++ b/tests/test_outreach/test_autonomous_send_ledger.py
@@ -79,11 +79,12 @@ async def _grant_standard(db):
         )
 
 
-async def _add_inbound(db, thread_id):
+async def _add_inbound(db, thread_id, sender="alice@example.com"):
     await db.execute(
-        "INSERT INTO email_thread_messages (thread_id, message_id, direction, received_at) "
-        "VALUES (?, ?, 'received', ?)",
-        (thread_id, f"m-{thread_id}", _TS),
+        "INSERT INTO email_thread_messages "
+        "(thread_id, message_id, direction, sender, received_at) "
+        "VALUES (?, ?, 'received', ?, ?)",
+        (thread_id, f"m-{thread_id}", sender, _TS),
     )
     await db.commit()
 

--- a/tests/test_outreach/test_ws8_full_slice_e2e.py
+++ b/tests/test_outreach/test_ws8_full_slice_e2e.py
@@ -1,0 +1,164 @@
+"""WS-8 PR-D full-slice E2E — the headline earn/lose loop through REAL components
+(gate + pipeline + resolution watcher + promotion handler + flag), only the email
+adapter is faked.
+
+Narrative asserted end to end:
+  cold reply HOLDS (all-ASK) → owner approves N → cell earns competence →
+  becomes promotable → owner approves a promotion proposal → cell GRANTED →
+  a reply now sends AUTONOMOUSLY and is logged → owner flags it as bad →
+  the cell craters back to ASK (trust is easy to lose).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from genesis.autonomy.approval import ApprovalManager
+from genesis.autonomy.email_gate import EmailAutonomyGate
+from genesis.autonomy.email_gate_watcher import drain_pending_email_sends
+from genesis.autonomy.types import CellState
+from genesis.content.types import FormatTarget, FormattedContent
+from genesis.db.crud import autonomous_email_sends as aes
+from genesis.db.crud import capability_grants as cg
+from genesis.db.crud import pending_email_sends as pes
+from genesis.db.schema import create_all_tables
+from genesis.ego.cadence import EgoCadenceManager
+from genesis.ego.cell_promotion import handle_cell_promotion_resolution
+from genesis.outreach.config import OutreachConfig, QuietHours
+from genesis.outreach.governance import GovernanceGate
+from genesis.outreach.pipeline import OutreachPipeline
+from genesis.outreach.types import OutreachCategory, OutreachRequest, OutreachStatus
+
+_CELL = {"domain": "email", "verb": "send", "risk_class": "standard"}
+
+
+class _Rt:
+    """Minimal runtime double for the resolution watcher (reads _db + pipeline)."""
+
+    def __init__(self, db, pipeline):
+        self._db = db
+        self._outreach_pipeline = pipeline
+
+
+@pytest.fixture
+def config():
+    return OutreachConfig(
+        quiet_hours=QuietHours(start="22:00", end="07:00"),
+        channel_preferences={"default": "email"},
+        thresholds={"blocker": 0.0, "surplus": 0.0},
+        max_daily=999, surplus_daily=999, content_daily=999, notification_daily=999,
+        morning_report_time="07:00",
+        engagement_timeout_hours=24, engagement_poll_minutes=60,
+    )
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+def _pipeline(config, db, adapter):
+    formatter = MagicMock()
+    formatter.format.return_value = FormattedContent(text="re: hi", target=FormatTarget.EMAIL)
+    pipe = OutreachPipeline(
+        governance=GovernanceGate(config, db), drafter=AsyncMock(), formatter=formatter,
+        channels={"email": adapter}, db=db, config=config,
+        recipients={"email": "fallback@example.com"},
+    )
+    pipe.set_autonomy_gate(
+        EmailAutonomyGate(db=db, approval_manager=ApprovalManager(db=db), event_bus=None)
+    )
+    return pipe
+
+
+async def _add_inbound(db, thread, sender):
+    await db.execute(
+        "INSERT INTO email_thread_messages (thread_id, message_id, direction, sender, received_at) "
+        "VALUES (?, ?, 'received', ?, ?)",
+        (thread, f"m-{thread}", sender, "2026-06-21T00:00:00"),
+    )
+    await db.commit()
+
+
+def _reply(recipient="alice@example.com", thread="t1"):
+    return OutreachRequest(
+        category=OutreachCategory.SURPLUS, topic="re: hi", context="body",
+        salience_score=0.9, signal_type="email_reply", channel="email",
+        validated_recipient=recipient, thread_id=thread,
+    )
+
+
+async def _approve_all_held_and_drain(db, rt):
+    mgr = ApprovalManager(db=db)
+    for row in await pes.list_held(db):
+        await mgr.resolve(row["request_id"], status="approved")
+    return await drain_pending_email_sends(rt)
+
+
+@pytest.mark.asyncio
+async def test_full_earn_grant_send_flag_demote_loop(config, db):
+    adapter = AsyncMock()
+    adapter.send_message.return_value = "<m@x>"
+    pipe = _pipeline(config, db, adapter)
+    rt = _Rt(db, pipe)
+    await _add_inbound(db, "t1", "alice@example.com")  # known correspondent
+
+    # 1. COLD START (all-ASK): the very first autonomous reply HOLDS, not sent.
+    r = await pipe.submit_raw("re: hi", _reply())
+    assert r.status == OutreachStatus.HELD
+    adapter.send_message.assert_not_called()
+    # the gate created the cell at ASK on first sight (CLASSIFY), not GRANTED
+    assert (await cg.get_cell(db, **_CELL))["state"] == CellState.ASK.value
+
+    # 2. EARN: owner approves 5 held replies → 5 successes on the standard cell.
+    sent = await _approve_all_held_and_drain(db, rt)
+    assert sent == 1  # the one held above, now approved+delivered
+    for _ in range(4):
+        await pipe.submit_raw("re: hi", _reply())
+        await _approve_all_held_and_drain(db, rt)
+    cell = await cg.get_cell(db, **_CELL)
+    assert cell["successes"] == 5 and cell["state"] == CellState.ASK.value
+
+    # 3. PROMOTABLE: the cell now qualifies for an owner-approved promotion.
+    cands = await cg.detect_promotable_cells(db)
+    assert [c["id"] for c in cands] == ["email:send:standard"]
+
+    # 4. PROMOTE: build the real cadence proposal, owner approves it → GRANTED.
+    prop = EgoCadenceManager._build_cell_promotion_proposal(cands[0])
+    prop = {**prop, "id": "promo1", "expected_outputs": json.dumps(prop["expected_outputs"])}
+    assert await handle_cell_promotion_resolution(db, prop, "approved") is True
+    assert (await cg.get_cell(db, **_CELL))["state"] == CellState.GRANTED.value
+
+    # 5. AUTONOMOUS SEND: a reply now goes out WITHOUT holding, and is logged.
+    adapter.send_message.reset_mock()
+    r = await pipe.submit_raw("re: hi", _reply())
+    assert r.status == OutreachStatus.DELIVERED
+    adapter.send_message.assert_called_once()
+    log = await aes.list_recent(db)
+    assert len(log) == 1 and log[0]["recipient"] == "alice@example.com"
+    cell = await cg.get_cell(db, **_CELL)
+    assert cell["successes"] == 5  # autonomous use is NOT a success signal
+    assert cell["last_used_at"] is not None
+
+    # 6. FLAG: owner flags the autonomous send as bad (the dashboard route's
+    #    orchestration) → records a correction → the cell craters back to ASK.
+    now = datetime.now(UTC).isoformat()
+    flagged = await aes.mark_flagged(db, log[0]["id"], flagged_at=now)
+    assert flagged is True
+    state = await cg.record_correction(db, updated_at=now, **_CELL)
+    assert state == CellState.ASK
+    cell = await cg.get_cell(db, **_CELL)
+    assert cell["state"] == CellState.ASK.value
+    assert cell["weighted_corrections"] >= 1.0  # crater deepens re-earn
+
+    # 7. Re-flag is idempotent: no second demotion path is taken.
+    assert await aes.mark_flagged(db, log[0]["id"], flagged_at=now) is False


### PR DESCRIPTION
## WS-8 PR-D — the earn/lose autonomy loop + auto-revert (audit finding D5)

Completes WS-8. Building on PR-C's deterministic email gate (every send holds unless its capability cell is GRANTED), this adds the loop that lets a cell be **earned** and, critically, **lost** — and ships both halves together: an autonomous-send state never exists without a working revert path.

### What it does
- **Demotion (easy to lose):** any confirmed correction on a GRANTED cell immediately regresses it to ASK — deterministic, not posterior-gated. A consequence-weighted `weighted_corrections` accumulator (severity by risk class, gate-derived) governs how hard the cell is to re-earn.
- **Promotion (earned + approved):** recommend-only. Once a cell has enough approved successes (re-earn posterior ≥ 0.70, ≥ 5 approvals), Genesis proposes a `cell_promotion` ("may I send these on my own?"); only the owner approves. Wired into all 4 proposal-resolution entry points + excluded from the approved-proposal dispatch sweep, with a staleness re-check immediately before promoting.
- **Auto-revert net for GRANTED cells:** deterministic pre-send scope guards in the gate (recipient-match-thread + per-cell rate-limit over a new `autonomous_email_sends` ledger) — a trip holds the send AND demotes the cell. Plus an owner flag-as-bad → records a correction → demotes.
- **Visibility:** a read-only dashboard **Autonomy** tab — standing grants (what Genesis may do on its own) + the autonomous-send log, each row with a "Flag as bad" button. A per-send notification is built but **muted by default** (`email_send_notify` in the autonomy config) — the tab is the primary pull-based visibility path.
- **Staleness decay:** idle GRANTED cells lapse back to NOT_DETERMINED (a daily sweep) so autonomy can't entrench unused.
- **Default = all-ASK:** migration `0033` adds the columns + the ledger table and surgically reverts the prior `email:send:standard` seed, so nothing sends autonomously until it is earned + approved.

### Scope (v1)
In: deterministic scope guards + the owner flag (the auto-revert net). Fast-follow (not in this PR): autonomous content-harm ingestion (bounce/complaint detection, reply-sentiment), and a Telegram reply-to-flag path.

### Reviews + tests
- genesis-architect pass (GO-WITH-CHANGES) + a code-review pass (FIX-BEFORE-MERGE) — all findings folded in, including removing a NULL-sender bypass in the recipient-match guard.
- Full-slice E2E through the real gate / pipeline / resolution watcher / promotion handler / flag: cold reply holds → approve ×5 → promotable → promote → GRANTED → autonomous send logged → flag → craters back to ASK.
- Targeted suites green per phase; broad regression green (one pre-existing `cli_policy` local-env flake is unrelated). CI runs the full suite.

### Merge note
**Merge before deploying PR-C** — migration `0033` is what neutralizes the prior seed, so nothing sends autonomously until earned + approved. On merge, WS-8 (the last open work-stream of the 2026-06-13 audit) closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
