### PR TITLE
chore(transcripts): local retention 180d + backups keep forever

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,7 @@
         "DISABLE_AUTOUPDATER": "1",
         "DISABLE_UPDATES": "1"
     },
-    "cleanupPeriodDays": 365,
+    "cleanupPeriodDays": 180,
     "hooks": {
         "SessionStart": [
             {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,7 @@
         "DISABLE_AUTOUPDATER": "1",
         "DISABLE_UPDATES": "1"
     },
+    "cleanupPeriodDays": 365,
     "hooks": {
         "SessionStart": [
             {

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -218,9 +218,18 @@ for collection in episodic_memory knowledge_base; do
 done
 
 # --- 3. CC session transcripts (encrypted — contain conversation PII) ---
+#
+# RETENTION POLICY — KEEP FOREVER BY DEFAULT. Backed-up transcripts are Genesis's
+# durable long-term conversational memory. The LOCAL store (~/.claude/projects)
+# expires on Claude Code's cleanupPeriodDays, but the BACKUP is the permanent
+# archive: transcripts/*.gpg accumulate here and are NEVER auto-pruned (the only
+# delete below is the pre-encryption plaintext staging, not the .gpg archive).
+# Any future retention work (GFS snapshot pruning, local-staging prune) MUST
+# EXEMPT transcripts/ — a user may opt into expiry, but the system must never
+# auto-expire transcripts the way the local store does.
 log "Backing up CC transcripts..."
 mkdir -p transcripts
-# Purge any pre-encryption plaintext transcripts.
+# Purge any pre-encryption plaintext transcripts (staging only — NOT the .gpg).
 find transcripts -maxdepth 1 -name '*.jsonl' -type f -delete 2>/dev/null || true
 if [ -d "$TRANSCRIPT_DIR" ]; then
     if ! $_ENCRYPT_READY; then


### PR DESCRIPTION
Two halves of one transcript-retention policy, since transcripts are Genesis's long-term conversational memory (the last-resort grep path + `cc_sessions` read the `.jsonl` files):

**1. Local — 180 days.** Sets `cleanupPeriodDays: 180` in the project `.claude/settings.json` (up from Claude Code's 30-day default). Project-level settings are honored by CC and ship with the repo, so it's an install-time default. Not retroactive — future cleanup passes only.

**2. Backups — keep forever (by default).** The encrypted 6h backup is the permanent archive: `transcripts/*.gpg` already accumulate locally and in every off-site snapshot, and are never auto-pruned. Adds an explicit policy note in `backup.sh §3` so the planned DR retention/prune work (GFS snapshot pruning + local-staging prune) must EXEMPT `transcripts/`. A user can opt into expiry, but the system never auto-expires backed-up transcripts the way the local store does.

Net effect: local disk stays modest (a half-year window for fast grep), while the full history is preserved durably in encrypted backups (on-box + off-site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)