### PR TITLE
feat(follow-ups): kind/domain/goal_id schema foundation (PR1)

### DIFF
--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -896,6 +896,7 @@ class CCSessionExecutor:
                 source="task_executor",
                 strategy="ego_judgment",
                 reason=content,
+                domain="internal",
             )
         except Exception:
             logger.exception("Failed to create challenge follow-up")

--- a/src/genesis/autonomy/executor/trace.py
+++ b/src/genesis/autonomy/executor/trace.py
@@ -643,6 +643,7 @@ class ExecutionTracer:
                 strategy="ego_judgment",
                 reason="Retrospective learning extraction failed — needs investigation",
                 priority="medium",
+                domain="internal",
             )
         except Exception:
             # Last resort — at least the log warning above was emitted

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -36,18 +36,27 @@ async def create(
     scheduled_at: str | None = None,
     priority: str = "medium",
     pinned: bool = False,
+    kind: str = "follow_up",
+    domain: str | None = None,
+    goal_id: str | None = None,
     id: str | None = None,
 ) -> str:
-    """Create a follow-up and return its ID."""
+    """Create a follow-up and return its ID.
+
+    kind:    'follow_up' (intended for action) or 'tabled' (tracked, not for action).
+    domain:  'internal' | 'user_world' | None (None = not yet classified).
+    goal_id: optional link to a unified goal (user_goals.id) for future promotion.
+    """
     fid = id or _new_id()
     await db.execute(
         """INSERT INTO follow_ups
            (id, source, source_session, content, reason, strategy,
-            scheduled_at, status, priority, pinned, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)""",
+            scheduled_at, status, priority, pinned, kind, domain, goal_id,
+            created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?)""",
         (fid, source, source_session, content, reason, strategy,
          _normalize_scheduled_at(scheduled_at), priority, int(pinned),
-         _now_iso()),
+         kind, domain, goal_id, _now_iso()),
     )
     await db.commit()
     return fid
@@ -64,10 +73,17 @@ async def get_pending(
     *,
     source: str | None = None,
     strategy: str | None = None,
+    include_tabled: bool = False,
 ) -> list[dict]:
-    """Get pending follow-ups, optionally filtered by source/strategy."""
+    """Get pending follow-ups, optionally filtered by source/strategy.
+
+    Tabled follow-ups (kind='tabled') are excluded unless include_tabled=True —
+    tabled items are tracked but never dispatched or surfaced as action.
+    """
     query = "SELECT * FROM follow_ups WHERE status = 'pending'"
     params: list[str] = []
+    if not include_tabled:
+        query += " AND kind = 'follow_up'"
     if source is not None:
         query += " AND source = ?"
         params.append(source)
@@ -90,13 +106,18 @@ async def get_by_status(
     return [dict(row) for row in await cursor.fetchall()]
 
 
-async def get_actionable(db: aiosqlite.Connection, *, limit: int = 50) -> list[dict]:
+async def get_actionable(
+    db: aiosqlite.Connection, *, limit: int = 50, include_tabled: bool = False,
+) -> list[dict]:
     """Get follow-ups needing attention: pending, failed, blocked.
 
-    Capped at `limit` to prevent unbounded growth from flooding contexts.
+    Tabled follow-ups are excluded unless include_tabled=True. Capped at `limit`
+    to prevent unbounded growth from flooding contexts.
     """
+    kind_clause = "" if include_tabled else "AND kind = 'follow_up' "
     cursor = await db.execute(
         "SELECT * FROM follow_ups WHERE status IN ('pending', 'failed', 'blocked') "
+        f"{kind_clause}"
         "ORDER BY CASE priority "
         "  WHEN 'critical' THEN 0 WHEN 'high' THEN 1 "
         "  WHEN 'medium' THEN 2 ELSE 3 END, created_at ASC "
@@ -106,11 +127,18 @@ async def get_actionable(db: aiosqlite.Connection, *, limit: int = 50) -> list[d
     return [dict(row) for row in await cursor.fetchall()]
 
 
-async def get_scheduled_due(db: aiosqlite.Connection) -> list[dict]:
-    """Get scheduled follow-ups whose time has arrived."""
+async def get_scheduled_due(
+    db: aiosqlite.Connection, *, include_tabled: bool = False,
+) -> list[dict]:
+    """Get scheduled follow-ups whose time has arrived.
+
+    Tabled follow-ups are excluded unless include_tabled=True.
+    """
+    kind_clause = "" if include_tabled else "AND kind = 'follow_up' "
     cursor = await db.execute(
         "SELECT * FROM follow_ups "
         "WHERE strategy = 'scheduled_task' AND status = 'pending' "
+        f"{kind_clause}"
         "AND scheduled_at IS NOT NULL "
         "AND datetime(scheduled_at) <= datetime('now') "
         "ORDER BY scheduled_at ASC",
@@ -118,12 +146,19 @@ async def get_scheduled_due(db: aiosqlite.Connection) -> list[dict]:
     return [dict(row) for row in await cursor.fetchall()]
 
 
-async def get_linked_active(db: aiosqlite.Connection) -> list[dict]:
-    """Get follow-ups linked to surplus tasks that are in flight."""
+async def get_linked_active(
+    db: aiosqlite.Connection, *, include_tabled: bool = False,
+) -> list[dict]:
+    """Get follow-ups linked to surplus tasks that are in flight.
+
+    Tabled follow-ups are excluded unless include_tabled=True.
+    """
+    kind_clause = "" if include_tabled else "AND kind = 'follow_up' "
     cursor = await db.execute(
         "SELECT * FROM follow_ups "
         "WHERE linked_task_id IS NOT NULL "
         "AND status IN ('scheduled', 'in_progress') "
+        f"{kind_clause}"
         "ORDER BY created_at ASC",
     )
     return [dict(row) for row in await cursor.fetchall()]
@@ -273,10 +308,16 @@ async def get_by_source(
     status: str | None = None,
     days: int | None = None,
     limit: int = 50,
+    include_tabled: bool = False,
 ) -> list[dict]:
-    """Get follow-ups by source, optionally filtered by status and recency."""
+    """Get follow-ups by source, optionally filtered by status and recency.
+
+    Tabled follow-ups are excluded unless include_tabled=True.
+    """
     query = "SELECT * FROM follow_ups WHERE source = ?"
     params: list[str | int] = [source]
+    if not include_tabled:
+        query += " AND kind = 'follow_up'"
     if status:
         query += " AND status = ?"
         params.append(status)
@@ -346,5 +387,152 @@ async def get_recently_completed(
         "AND completed_at >= datetime('now', ? || ' hours') "
         "ORDER BY completed_at DESC LIMIT ?",
         (f"-{hours}", limit),
+    )
+    return [dict(row) for row in await cursor.fetchall()]
+
+
+# ---------------------------------------------------------------------------
+# Cockpit support — mutations + paginated/filtered query (consumed by the
+# dashboard Follow-ups tab). Pure data layer; kept here alongside the table.
+# ---------------------------------------------------------------------------
+
+_VALID_KIND = {"follow_up", "tabled"}
+_VALID_DOMAIN = {"internal", "user_world"}
+
+# Allowlisted sort keys → ORDER BY fragment (never interpolate caller input).
+_SORT_MAP: dict[str, str] = {
+    "priority": (
+        "CASE priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 "
+        "WHEN 'medium' THEN 2 ELSE 3 END, created_at DESC"
+    ),
+    "created_desc": "created_at DESC",
+    "created_asc": "created_at ASC",
+    "status": "status ASC, created_at DESC",
+    "source": "source ASC, created_at DESC",
+}
+
+
+async def delete(db: aiosqlite.Connection, id: str) -> bool:
+    """Permanently delete a follow-up. Returns True if a row was removed."""
+    cursor = await db.execute("DELETE FROM follow_ups WHERE id = ?", (id,))
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def set_kind(db: aiosqlite.Connection, id: str, kind: str) -> bool:
+    """Move a follow-up between the 'follow_up' and 'tabled' lanes."""
+    if kind not in _VALID_KIND:
+        raise ValueError(f"invalid kind {kind!r}; must be one of {sorted(_VALID_KIND)}")
+    cursor = await db.execute(
+        "UPDATE follow_ups SET kind = ? WHERE id = ?", (kind, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def set_domain(db: aiosqlite.Connection, id: str, domain: str | None) -> bool:
+    """Set/override a follow-up's domain (or clear it with None)."""
+    if domain is not None and domain not in _VALID_DOMAIN:
+        raise ValueError(
+            f"invalid domain {domain!r}; must be one of {sorted(_VALID_DOMAIN)} or None"
+        )
+    cursor = await db.execute(
+        "UPDATE follow_ups SET domain = ? WHERE id = ?", (domain, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def get_distinct_sources(db: aiosqlite.Connection) -> list[str]:
+    """Distinct source values present, for cockpit filter dropdowns."""
+    cursor = await db.execute(
+        "SELECT DISTINCT source FROM follow_ups ORDER BY source"
+    )
+    return [row[0] for row in await cursor.fetchall()]
+
+
+def _build_filter_where(
+    *,
+    kind: str | None,
+    domain: str | None,
+    status: str | None,
+    source: str | None,
+    search: str | None,
+) -> tuple[str, list]:
+    """Build a parameterized WHERE clause shared by query_page/count_filtered.
+
+    Only static column/clause text is assembled here; every caller value is
+    bound via a ``?`` placeholder. ``domain='__null__'`` matches unclassified
+    rows (domain IS NULL).
+    """
+    clauses: list[str] = []
+    params: list = []
+    if kind is not None:
+        clauses.append("kind = ?")
+        params.append(kind)
+    if domain is not None:
+        if domain == "__null__":
+            clauses.append("domain IS NULL")
+        else:
+            clauses.append("domain = ?")
+            params.append(domain)
+    if status is not None:
+        clauses.append("status = ?")
+        params.append(status)
+    if source is not None:
+        clauses.append("source = ?")
+        params.append(source)
+    if search:
+        clauses.append("(content LIKE ? OR reason LIKE ?)")
+        like = f"%{search}%"
+        params.extend([like, like])
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    return where, params
+
+
+async def count_filtered(
+    db: aiosqlite.Connection,
+    *,
+    kind: str | None = None,
+    domain: str | None = None,
+    status: str | None = None,
+    source: str | None = None,
+    search: str | None = None,
+) -> int:
+    """Count follow-ups matching the cockpit filters."""
+    where, params = _build_filter_where(
+        kind=kind, domain=domain, status=status, source=source, search=search,
+    )
+    cursor = await db.execute(f"SELECT COUNT(*) FROM follow_ups{where}", params)
+    row = await cursor.fetchone()
+    return row[0] if row else 0
+
+
+async def query_page(
+    db: aiosqlite.Connection,
+    *,
+    kind: str | None = None,
+    domain: str | None = None,
+    status: str | None = None,
+    source: str | None = None,
+    search: str | None = None,
+    sort: str = "priority",
+    offset: int = 0,
+    limit: int = 50,
+) -> list[dict]:
+    """Paginated/sorted/filtered follow-up query for the cockpit.
+
+    ``sort`` is allowlisted (see ``_SORT_MAP``); unknown values fall back to
+    priority. ``domain='__null__'`` matches rows with no domain set.
+    """
+    where, params = _build_filter_where(
+        kind=kind, domain=domain, status=status, source=source, search=search,
+    )
+    order = _SORT_MAP.get(sort, _SORT_MAP["priority"])
+    limit = max(1, min(limit, 200))
+    offset = max(0, offset)
+    cursor = await db.execute(
+        f"SELECT * FROM follow_ups{where} ORDER BY {order} LIMIT ? OFFSET ?",
+        [*params, limit, offset],
     )
     return [dict(row) for row in await cursor.fetchall()]

--- a/src/genesis/db/migrations/0034_follow_up_kind_domain_goal.py
+++ b/src/genesis/db/migrations/0034_follow_up_kind_domain_goal.py
@@ -1,0 +1,107 @@
+"""Add kind / domain / goal_id columns to follow_ups (four-axis foundation).
+
+Adds the orthogonal axes the overloaded ``strategy`` enum was missing:
+  - ``kind``    : ``follow_up`` | ``tabled``  (tabled = tracked-but-not-for-action)
+  - ``domain``  : ``internal`` | ``user_world`` (Genesis-COO vs user-CEO
+                  jurisdiction; nullable — NULL means "not yet classified")
+  - ``goal_id`` : link target for future follow-up -> goal promotion (nullable)
+
+``strategy`` and the surplus dispatcher are untouched; these axes are additive.
+
+``kind`` backfills to ``follow_up`` automatically via the column DEFAULT.
+
+``domain`` backfill is conservative / NULL-on-uncertainty:
+  * ``recon_pipeline`` source -> internal (model benchmarking; single producer)
+  * ``inbox_evaluation`` -> the evaluator's own per-item judgment, recovered from
+    the ``[ACTION]`` tag stored in ``content``: ADAPT/WATCH/IGNORE (genesis vocab)
+    -> internal; EXPLORE/BOOKMARK (user vocab) -> user_world; ADOPT (ambiguous,
+    both vocabs) -> NULL
+  * else an internal-keyword hit on ``content+reason`` -> internal
+  * otherwise leave NULL — never guess ``user_world``. A wrong domain would hide
+    a row from the ego that needs it once consumers are domain-scoped; NULL keeps
+    it visible to both egos transitionally and reclassifiable in the cockpit.
+
+Self-contained: a migration is a frozen artifact and must NOT import
+``genesis.ego`` (the live classifier evolves independently). The keyword set is
+copied here intentionally — a snapshot as of migration 0034.
+"""
+
+from __future__ import annotations
+
+import re
+
+import aiosqlite
+
+# Frozen snapshot of genesis.ego.domain_classifier.GENESIS_INTERNAL_KEYWORDS.
+_INTERNAL_KEYWORDS = frozenset({
+    "surplus", "dream cycle", "dream_cycle", "genesis runtime",
+    "routing config", "circuit breaker", "guardian", "sentinel", "qdrant",
+    "awareness loop", "health check", "dead letter", "model_routing",
+    "worktree", "genesis-development", "dashboard fix", "ego cycle",
+    "model eval", "surplus_task", "provider fallback", "watchdog",
+    "systemd", "genesis server", "eval batch", "j9 eval",
+    "runtime init", "embedding chain", "embedding fallback",
+})
+
+# Inbox evaluator's own per-item judgment, recovered from the [ACTION] tag.
+# Genesis vocab -> internal; user vocab -> user_world. ADOPT is in BOTH vocabs
+# (case is lost once stored uppercase in content) so it stays uncertain -> NULL.
+_INBOX_INTERNAL_ACTIONS = {"ADAPT", "WATCH", "IGNORE"}
+_INBOX_USER_ACTIONS = {"EXPLORE", "BOOKMARK"}
+_ACTION_RE = re.compile(r"^\[([A-Z_]+)\]")
+
+
+def _classify_domain(source: str, content: str | None, reason: str | None) -> str | None:
+    """Return 'internal' | 'user_world' | None for an existing row."""
+    if source == "recon_pipeline":
+        return "internal"
+    if source == "inbox_evaluation":
+        m = _ACTION_RE.match(content or "")
+        act = m.group(1) if m else None
+        if act in _INBOX_INTERNAL_ACTIONS:
+            return "internal"
+        if act in _INBOX_USER_ACTIONS:
+            return "user_world"
+        # ADOPT / unparseable -> fall through to the keyword check
+    text = f"{content or ''} {reason or ''}".lower()
+    if any(kw in text for kw in _INTERNAL_KEYWORDS):
+        return "internal"
+    return None
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='follow_ups'"
+    )
+    if not await cursor.fetchone():
+        return
+
+    col_cursor = await db.execute("PRAGMA table_info(follow_ups)")
+    cols = {row[1] for row in await col_cursor.fetchall()}
+
+    if "kind" not in cols:
+        await db.execute(
+            "ALTER TABLE follow_ups ADD COLUMN kind TEXT NOT NULL "
+            "DEFAULT 'follow_up' CHECK (kind IN ('follow_up', 'tabled'))"
+        )
+    if "domain" not in cols:
+        await db.execute(
+            "ALTER TABLE follow_ups ADD COLUMN domain TEXT "
+            "CHECK (domain IN ('internal', 'user_world'))"
+        )
+    if "goal_id" not in cols:
+        await db.execute("ALTER TABLE follow_ups ADD COLUMN goal_id TEXT")
+
+    # Backfill domain (NULL-on-uncertainty) for rows not yet classified.
+    cur = await db.execute(
+        "SELECT id, source, content, reason FROM follow_ups WHERE domain IS NULL"
+    )
+    updates: list[tuple[str, str]] = []
+    for row in await cur.fetchall():
+        dom = _classify_domain(row[1], row[2], row[3])
+        if dom is not None:
+            updates.append((dom, row[0]))
+    if updates:
+        await db.executemany(
+            "UPDATE follow_ups SET domain = ? WHERE id = ?", updates
+        )

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1098,7 +1098,14 @@ TABLES = {
             escalated_to     TEXT,
             verified_at      TEXT,
             verification_notes TEXT,
-            pinned           INTEGER NOT NULL DEFAULT 0
+            pinned           INTEGER NOT NULL DEFAULT 0,
+            kind             TEXT NOT NULL DEFAULT 'follow_up' CHECK (
+                kind IN ('follow_up', 'tabled')
+            ),
+            domain           TEXT CHECK (
+                domain IN ('internal', 'user_world')
+            ),
+            goal_id          TEXT
         )
     """,
     "file_modifications": """

--- a/src/genesis/ego/domain_classifier.py
+++ b/src/genesis/ego/domain_classifier.py
@@ -1,0 +1,49 @@
+"""Shared domain classification for the internal / user_world spine.
+
+Two jurisdictions:
+  - ``internal``   — Genesis's own system work (the Genesis-COO ego's domain:
+    runtime, routing, memory, health, dev work).
+  - ``user_world`` — the user's life, career, content, and interests (the
+    user-CEO ego's domain).
+
+The keyword set positively detects ``internal`` ONLY. There is deliberately no
+positive ``user_world`` detector: Genesis runs its own marketing/outreach
+campaign, so terms like "outreach", "marketing", "discord", or "github" collide
+with the user's career/content vocabulary and would produce false ``user_world``
+tags. Two entry points reflect this asymmetry:
+
+  - :func:`is_genesis_internal` — binary (internal-keyword present or not). Used
+    where a definite genesis/non-genesis split is required (e.g. annotating
+    conversation transcripts for the user ego).
+  - :func:`classify_domain` — ``'internal'`` on a keyword hit, else ``None``.
+    Never guesses ``user_world``; callers store ``None`` as "not yet classified"
+    rather than a wrong guess.
+"""
+
+from __future__ import annotations
+
+# Keywords indicating a session/item is about Genesis internals (not user-world).
+GENESIS_INTERNAL_KEYWORDS = frozenset({
+    "surplus", "dream cycle", "dream_cycle", "genesis runtime",
+    "routing config", "circuit breaker", "guardian", "sentinel", "qdrant",
+    "awareness loop", "health check", "dead letter", "model_routing",
+    "worktree", "genesis-development", "dashboard fix", "ego cycle",
+    "model eval", "surplus_task", "provider fallback", "watchdog",
+    "systemd", "genesis server", "eval batch", "j9 eval",
+    "runtime init", "embedding chain", "embedding fallback",
+})
+
+
+def is_genesis_internal(text: str) -> bool:
+    """True if *text* contains a Genesis-internal keyword."""
+    lowered = (text or "").lower()
+    return any(kw in lowered for kw in GENESIS_INTERNAL_KEYWORDS)
+
+
+def classify_domain(text: str) -> str | None:
+    """Classify *text* into the domain spine.
+
+    Returns ``'internal'`` on an internal-keyword hit, otherwise ``None``
+    (uncertain — never guesses ``'user_world'``).
+    """
+    return "internal" if is_genesis_internal(text) else None

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import aiosqlite
 
+from genesis.ego.domain_classifier import is_genesis_internal as _is_genesis_internal
 from genesis.ego.types import NEUTRAL_STATUS
 
 logger = logging.getLogger(__name__)
@@ -35,24 +36,9 @@ _USER_WORLD_CATEGORIES = frozenset({
     "marketing", "outreach", "networking",
 })
 
-# Keywords indicating a session is about Genesis internals (not user-world).
-# Used to annotate conversation transcripts so the user ego knows which
-# sessions fall under the Genesis ego's jurisdiction.
-_GENESIS_INTERNAL_KEYWORDS = frozenset({
-    "surplus", "dream cycle", "dream_cycle", "genesis runtime",
-    "routing config", "circuit breaker", "guardian", "sentinel", "qdrant",
-    "awareness loop", "health check", "dead letter", "model_routing",
-    "worktree", "genesis-development", "dashboard fix", "ego cycle",
-    "model eval", "surplus_task", "provider fallback", "watchdog",
-    "systemd", "genesis server", "eval batch", "j9 eval",
-    "runtime init", "embedding chain", "embedding fallback",
-})
-
-
-def _is_genesis_internal(topic: str) -> bool:
-    """Check if a session topic is about Genesis internals."""
-    topic_lower = topic.lower()
-    return any(kw in topic_lower for kw in _GENESIS_INTERNAL_KEYWORDS)
+# Genesis-internal keyword detection now lives in genesis.ego.domain_classifier
+# (shared with follow-up domain classification); imported above as
+# _is_genesis_internal.
 
 
 class UserEgoContextBuilder:

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -1498,6 +1498,8 @@ class InboxMonitor:
                 strategy=strategy,
                 priority=priority,
                 pinned=pinned,
+                # The evaluator already judges each item genesis-vs-user; reuse it.
+                domain="internal" if rec.classification == "genesis" else "user_world",
             )
             created += 1
 

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -36,6 +36,7 @@ async def _impl_follow_up_create(
     scheduled_at: str | None = None,
     priority: str = "medium",
     pinned: bool = False,
+    domain: str | None = None,
     source_session: str | None = None,
 ) -> dict:
     """Create a follow-up item in the accountability ledger."""
@@ -51,6 +52,10 @@ async def _impl_follow_up_create(
     if priority not in valid_priorities:
         return {"error": f"Invalid priority '{priority}'. Must be one of: {', '.join(sorted(valid_priorities))}"}
 
+    valid_domains = {"internal", "user_world"}
+    if domain is not None and domain not in valid_domains:
+        return {"error": f"Invalid domain '{domain}'. Must be one of: {', '.join(sorted(valid_domains))}"}
+
     if strategy == "scheduled_task" and not scheduled_at:
         return {"error": "scheduled_at is required when strategy is 'scheduled_task'"}
 
@@ -58,12 +63,19 @@ async def _impl_follow_up_create(
         import os
 
         from genesis.db.crud import follow_ups
+        from genesis.ego.domain_classifier import classify_domain
 
         # Detect dispatched session context for proper source attribution
         if os.environ.get("GENESIS_CC_SESSION") == "1":
             source = "ego_dispatch"
         else:
             source = "foreground_session"
+
+        # The session declares domain when it knows; otherwise fall back to the
+        # internal-only classifier (returns 'internal' on a keyword hit, else
+        # None → stored NULL, never a user_world guess).
+        if domain is None:
+            domain = classify_domain(f"{content} {reason}")
 
         fid = await follow_ups.create(
             db,
@@ -75,13 +87,16 @@ async def _impl_follow_up_create(
             scheduled_at=scheduled_at,
             priority=priority,
             pinned=pinned,
+            domain=domain,
         )
         return {
             "id": fid,
             "status": "pending",
             "strategy": strategy,
+            "domain": domain,
             "pinned": pinned,
             "message": f"Follow-up created. Strategy: {strategy}."
+            + (f" Domain: {domain}." if domain else "")
             + (" (pinned — ego cannot auto-resolve)" if pinned else ""),
         }
     except Exception as exc:
@@ -202,6 +217,7 @@ async def follow_up_create(
     scheduled_at: str = "",
     priority: str = "medium",
     pinned: bool = False,
+    domain: str = "",
 ) -> dict:
     """Create a follow-up item for Genesis to track and execute.
 
@@ -228,6 +244,10 @@ async def follow_up_create(
         pinned: If true, ego can see this follow-up but cannot auto-resolve it.
             Only the user can close a pinned follow-up. Use for items you want
             to track personally.
+        domain: Whose world this belongs to — "internal" (Genesis's own system
+            work: runtime, routing, memory, health, dev) or "user_world" (the
+            user's life, career, content, interests). Leave empty to let Genesis
+            classify (it only auto-detects internal; otherwise leaves it unset).
     """
     return await _impl_follow_up_create(
         content,
@@ -236,6 +256,7 @@ async def follow_up_create(
         scheduled_at=scheduled_at or None,
         priority=priority,
         pinned=pinned,
+        domain=domain or None,
     )
 
 

--- a/src/genesis/recon/model_intelligence.py
+++ b/src/genesis/recon/model_intelligence.py
@@ -467,6 +467,7 @@ class ModelIntelligenceJob:
                 strategy="surplus_task",
                 reason=json.dumps(payload),
                 priority="medium",
+                domain="internal",
             )
             logger.info("Created benchmark follow-up %s for %s", fid[:8], model_id)
             return fid

--- a/tests/ego/test_context_separation.py
+++ b/tests/ego/test_context_separation.py
@@ -286,7 +286,8 @@ _EXTRA_TABLES_DDL = [
         linked_task_id TEXT, priority TEXT NOT NULL DEFAULT 'medium',
         created_at TEXT NOT NULL, completed_at TEXT,
         resolution_notes TEXT, blocked_reason TEXT,
-        escalated_to TEXT
+        escalated_to TEXT,
+        kind TEXT NOT NULL DEFAULT 'follow_up', domain TEXT, goal_id TEXT
     )""",
     """CREATE TABLE user_model_cache (
         id TEXT PRIMARY KEY DEFAULT 'current', person_id TEXT,

--- a/tests/ego/test_genesis_context.py
+++ b/tests/ego/test_genesis_context.py
@@ -124,7 +124,10 @@ async def db():
                 completed_at     TEXT,
                 resolution_notes TEXT,
                 blocked_reason   TEXT,
-                escalated_to     TEXT
+                escalated_to     TEXT,
+                kind             TEXT NOT NULL DEFAULT 'follow_up',
+                domain           TEXT,
+                goal_id          TEXT
             )
         """)
         yield conn

--- a/tests/ego/test_user_context.py
+++ b/tests/ego/test_user_context.py
@@ -158,7 +158,10 @@ async def db():
                 completed_at     TEXT,
                 resolution_notes TEXT,
                 blocked_reason   TEXT,
-                escalated_to     TEXT
+                escalated_to     TEXT,
+                kind             TEXT NOT NULL DEFAULT 'follow_up',
+                domain           TEXT,
+                goal_id          TEXT
             )
         """)
         yield conn

--- a/tests/test_db/test_follow_ups.py
+++ b/tests/test_db/test_follow_ups.py
@@ -1,4 +1,6 @@
-"""Tests for follow_ups CRUD — retention cleanup."""
+"""Tests for follow_ups CRUD — retention cleanup + four-axis foundation."""
+
+import pytest
 
 from genesis.db.crud import follow_ups
 
@@ -79,3 +81,102 @@ async def test_purge_failed_old(db):
 
     count = await follow_ups.purge_completed(db)
     assert count == 1
+
+
+# ─── Four-axis foundation: kind / domain / goal_id ───────────────────────────
+
+
+async def test_create_with_kind_and_domain(db):
+    """create() persists kind, domain, and goal_id."""
+    fid = await follow_ups.create(
+        db, **_BASE, kind="tabled", domain="internal", goal_id="g1",
+    )
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["kind"] == "tabled"
+    assert row["domain"] == "internal"
+    assert row["goal_id"] == "g1"
+
+
+async def test_create_defaults(db):
+    """Defaults: kind='follow_up', domain NULL, goal_id NULL."""
+    fid = await follow_ups.create(db, **_BASE)
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["kind"] == "follow_up"
+    assert row["domain"] is None
+    assert row["goal_id"] is None
+
+
+async def test_get_actionable_excludes_tabled(db):
+    """Tabled follow-ups never appear in the actionable feed unless opted in."""
+    fu = await follow_ups.create(db, **_BASE)
+    tabled = await follow_ups.create(db, **_BASE, kind="tabled")
+
+    ids = {r["id"] for r in await follow_ups.get_actionable(db)}
+    assert fu in ids
+    assert tabled not in ids
+
+    ids_all = {r["id"] for r in await follow_ups.get_actionable(db, include_tabled=True)}
+    assert tabled in ids_all
+
+
+async def test_get_pending_excludes_tabled(db):
+    """The dispatcher/pending feeds also exclude tabled by default."""
+    tabled = await follow_ups.create(db, **_BASE, kind="tabled")
+    ids = {r["id"] for r in await follow_ups.get_pending(db)}
+    assert tabled not in ids
+
+
+async def test_set_kind_moves_lane(db):
+    fid = await follow_ups.create(db, **_BASE)
+    assert await follow_ups.set_kind(db, fid, "tabled")
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["kind"] == "tabled"
+
+
+async def test_set_kind_rejects_invalid(db):
+    fid = await follow_ups.create(db, **_BASE)
+    with pytest.raises(ValueError):
+        await follow_ups.set_kind(db, fid, "bogus")
+
+
+async def test_set_domain_and_clear(db):
+    fid = await follow_ups.create(db, **_BASE)
+    assert await follow_ups.set_domain(db, fid, "user_world")
+    assert (await follow_ups.get_by_id(db, fid))["domain"] == "user_world"
+    assert await follow_ups.set_domain(db, fid, None)
+    assert (await follow_ups.get_by_id(db, fid))["domain"] is None
+
+
+async def test_delete_removes_row(db):
+    fid = await follow_ups.create(db, **_BASE)
+    assert await follow_ups.delete(db, fid)
+    assert await follow_ups.get_by_id(db, fid) is None
+
+
+async def test_query_page_filters_search_and_null_domain(db):
+    await follow_ups.create(
+        db, **{**_BASE, "content": "alpha internal item"}, domain="internal",
+    )
+    await follow_ups.create(
+        db, **{**_BASE, "content": "beta user item"}, domain="user_world",
+    )
+    await follow_ups.create(db, **{**_BASE, "content": "gamma unclassified"})
+
+    internal = await follow_ups.query_page(db, domain="internal")
+    assert internal and all(r["domain"] == "internal" for r in internal)
+
+    hits = await follow_ups.query_page(db, search="alpha")
+    assert len(hits) == 1 and "alpha" in hits[0]["content"]
+
+    nulls = await follow_ups.query_page(db, domain="__null__")
+    assert nulls and all(r["domain"] is None for r in nulls)
+
+    total = await follow_ups.count_filtered(db)
+    assert total == 3
+
+
+async def test_query_page_rejects_nothing_on_bad_sort(db):
+    """Unknown sort falls back to priority instead of raising/injecting."""
+    await follow_ups.create(db, **_BASE)
+    rows = await follow_ups.query_page(db, sort="; DROP TABLE follow_ups; --")
+    assert len(rows) == 1

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -270,6 +270,22 @@ async def test_budgets_rejects_invalid_budget_type(db):
         )
 
 
+async def test_follow_ups_rejects_invalid_kind(db):
+    with pytest.raises(sqlite3.IntegrityError):
+        await db.execute(
+            "INSERT INTO follow_ups (id, source, content, strategy, created_at, kind) "
+            "VALUES ('t', 's', 'c', 'ego_judgment', '2026-01-01T00:00:00', 'INVALID')"
+        )
+
+
+async def test_follow_ups_rejects_invalid_domain(db):
+    with pytest.raises(sqlite3.IntegrityError):
+        await db.execute(
+            "INSERT INTO follow_ups (id, source, content, strategy, created_at, domain) "
+            "VALUES ('t', 's', 'c', 'ego_judgment', '2026-01-01T00:00:00', 'INVALID')"
+        )
+
+
 # ─── NOT NULL constraints ────────────────────────────────────────────────────
 
 

--- a/tests/test_inbox/test_inbox_digest.py
+++ b/tests/test_inbox/test_inbox_digest.py
@@ -35,7 +35,10 @@ async def db():
         escalated_to TEXT,
         verified_at TEXT,
         verification_notes TEXT,
-        pinned INTEGER DEFAULT 0
+        pinned INTEGER DEFAULT 0,
+        kind TEXT NOT NULL DEFAULT 'follow_up',
+        domain TEXT,
+        goal_id TEXT
     )""")
     await conn.execute("""CREATE TABLE inbox_items (
         id TEXT PRIMARY KEY,


### PR DESCRIPTION
## PR1 of the follow-up system redesign — schema foundation

The `follow_ups` table had become a graveyard because one overloaded `strategy`
enum fused *who executes* and *when* into a single field, leaving the long tail
with no path to action or closure. The redesign decomposes that into orthogonal
axes; this PR lands the **schema foundation** for two of them plus a goal link.
It is strictly **additive** — `strategy` and the surplus dispatcher are untouched.

### New columns (migration `0034`)
- **`kind`** — `follow_up` | `tabled`. Tabled = tracked but never dispatched or
  surfaced as action (the honest someday/maybe lane, reached by judgment).
- **`domain`** — `internal` | `user_world` (nullable). Genesis-COO vs user-CEO
  jurisdiction. NULL = not yet classified.
- **`goal_id`** — link target for a future follow-up → goal promotion.

`kind` backfills to `follow_up` via the column default. `domain` backfill is
**NULL-on-uncertainty**: a correct-by-construction source (model-benchmarking) →
`internal`; inbox items reuse the evaluator's own per-item genesis/user judgment;
an internal-keyword hit → `internal`; otherwise left NULL (never a `user_world`
guess — a wrong domain would hide a row from the ego that needs it, whereas NULL
stays visible to both and is reclassifiable later).

### Other changes
- Extract a shared `domain_classifier` (internal-only detector; returns
  `internal` or `None`, never guesses `user_world`).
- `crud.create()` gains `kind`/`domain`/`goal_id`; the action/pending readers
  gain `include_tabled=False`, so a tabled item can never be dispatched or
  surfaced once tabling exists.
- Data-layer functions for the upcoming management UI (delete / set_kind /
  set_domain / paginated filtered query / counts / distinct sources).
- The follow-up MCP tool and the four producers now set `domain`.

### Not in scope (follow-on PRs)
- The dashboard management cockpit (PR2).
- Scoping existing ego/report/signal consumers by `domain` (PR3 — behavior change).

### Verification
- Migration applied to a copy of the live DB: all three columns present,
  `kind` = `follow_up` across the board, domain split internal/user_world/NULL =
  184 / 4 / 180, and re-running is a no-op (idempotent).
- `ruff` clean; targeted suites green (schema CHECK constraints, CRUD round-trips
  + tabled exclusion + filtered query, dispatcher, ego context, inbox digest).
- Fixed four test fixtures that hand-rolled a partial `follow_ups` schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
