### PR TITLE
feat(security,learning): skill-security scan + skill-evolution provenance (inbox Phase A)

### DIFF
--- a/src/genesis/learning/skills/applicator.py
+++ b/src/genesis/learning/skills/applicator.py
@@ -28,6 +28,22 @@ class SkillApplicator:
         self._autonomy_level = autonomy_level
         self._validator = SkillValidator()
 
+    @staticmethod
+    def _build_modification_metadata(proposal: SkillProposal) -> dict:
+        """Metadata recorded with a skill mutation in the cognitive-mod ledger.
+
+        Captures *why* the skill changed — the triggering signals
+        (failure_patterns_addressed + the SkillReport-derived provenance trace) —
+        not just the diff, so a degrading edit can be understood and rolled back.
+        """
+        return {
+            "skill_name": proposal.skill_name,
+            "change_size": proposal.change_size.value,
+            "confidence": proposal.confidence,
+            "failure_patterns_addressed": proposal.failure_patterns_addressed,
+            "provenance_trace": proposal.provenance_trace,
+        }
+
     async def apply(
         self,
         proposal: SkillProposal,
@@ -79,11 +95,7 @@ class SkillApplicator:
                 path=path,
                 new_content=proposal.proposed_content,
                 summary=f"MINOR auto-apply: {proposal.rationale[:200]}",
-                metadata={
-                    "skill_name": proposal.skill_name,
-                    "change_size": proposal.change_size.value,
-                    "confidence": proposal.confidence,
-                },
+                metadata=self._build_modification_metadata(proposal),
             )
 
             # Log observation (include validation warnings if any)

--- a/src/genesis/learning/skills/refiner.py
+++ b/src/genesis/learning/skills/refiner.py
@@ -51,7 +51,31 @@ class SkillRefiner:
             logger.exception("Skill refiner LLM call failed")
             return None
 
-        return self._parse_response(report.skill_name, result.content)
+        return self._parse_response(
+            report.skill_name,
+            result.content,
+            provenance_trace=self._build_provenance(report),
+        )
+
+    @staticmethod
+    def _build_provenance(report: SkillReport) -> str:
+        """Summarize the SkillReport signals that triggered this refinement.
+
+        Recorded with the mutation so the cognitive-mod ledger captures *why*
+        the skill changed, not just the diff.
+        """
+        parts = [
+            f"usage={report.usage_count}",
+            f"success_rate={report.success_rate:.0%}",
+            f"trend={report.trend.value}",
+        ]
+        if report.baseline_success_rate is not None:
+            parts.append(f"baseline={report.baseline_success_rate:.0%}")
+        if report.failure_patterns:
+            parts.append(f"failure_patterns={', '.join(report.failure_patterns)}")
+        if report.sessions_since_last_refined:
+            parts.append(f"sessions_since_refined={report.sessions_since_last_refined}")
+        return "; ".join(parts)
 
     def _build_prompt(self, report: SkillReport, current_content: str) -> str:
         lines = len(current_content.splitlines())
@@ -101,7 +125,9 @@ class SkillRefiner:
             f'"failure_patterns_addressed": ["..."]}}'
         )
 
-    def _parse_response(self, skill_name: str, text: str) -> SkillProposal | None:
+    def _parse_response(
+        self, skill_name: str, text: str, *, provenance_trace: str | None = None
+    ) -> SkillProposal | None:
         try:
             match = re.search(r"```(?:json)?\s*(.*?)```", text, re.DOTALL)
             raw = match.group(1) if match else text
@@ -127,4 +153,5 @@ class SkillRefiner:
             change_size=change_size,
             confidence=float(data.get("confidence", 0.7)),
             failure_patterns_addressed=data.get("failure_patterns_addressed", []),
+            provenance_trace=provenance_trace,
         )

--- a/src/genesis/learning/skills/types.py
+++ b/src/genesis/learning/skills/types.py
@@ -47,6 +47,9 @@ class SkillProposal:
     change_size: ChangeSize
     confidence: float = 0.7
     failure_patterns_addressed: list[str] = field(default_factory=list)
+    # Why this refinement was triggered (SkillReport signals: trend, usage,
+    # success rate, failure patterns). Recorded in the cognitive-mod ledger.
+    provenance_trace: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/genesis/security/skill_scan.py
+++ b/src/genesis/security/skill_scan.py
@@ -69,6 +69,20 @@ def parse_report(report: dict) -> ScanResult:
     )
 
 
+def _format_location(loc: object) -> str:
+    """Render a SkillSpector issue location as 'file:line'.
+
+    SkillSpector emits ``location`` as either a string ("file:line") or a dict
+    ({"file", "start_line", "end_line"}); normalize both to a clean string so a
+    raw dict repr never leaks into a human-facing finding.
+    """
+    if isinstance(loc, dict):
+        file = loc.get("file") or ""
+        line = loc.get("start_line")
+        return f"{file}:{line}" if file and line is not None else (file or "")
+    return str(loc or "")
+
+
 def report_to_finding(result: ScanResult) -> dict:
     """Build a recon finding payload (title/summary/priority/source_url/job_type).
 
@@ -86,7 +100,7 @@ def report_to_finding(result: ScanResult) -> dict:
         for issue in result.issues[:10]:
             cat = issue.get("category", "?")
             sev = issue.get("severity", "?")
-            loc = issue.get("location", "")
+            loc = _format_location(issue.get("location"))
             lines.append(f"  - [{sev}] {cat}{f' @ {loc}' if loc else ''}")
     else:
         lines.append("No issues detected.")
@@ -163,10 +177,12 @@ def run_skillspector(
 ) -> dict | None:
     """Run ``skillspector scan <dir> -f json`` and return the parsed report.
 
-    Returns None on timeout, non-zero exit, or unreadable output — one bad/huge
+    Returns None on timeout, exec error, or unreadable output — one bad/huge
     skill (e.g. a skill bundling thousands of files) is logged and skipped, never
-    fatal to the sweep. SkillSpector must be installed separately; pass
-    ``skillspector_bin`` or have it on PATH.
+    fatal to the sweep. A NON-ZERO exit is NOT treated as failure: SkillSpector
+    signals risk level via the exit code (CRITICAL -> rc=1), so the parsed JSON
+    is trusted whenever it parses. SkillSpector must be installed separately;
+    pass ``skillspector_bin`` or have it on PATH.
     """
     import json
     import os
@@ -193,6 +209,10 @@ def run_skillspector(
         proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s)
     except subprocess.TimeoutExpired:
         logger.warning("skillspector scan timed out for %s (%ss)", skill_dir, timeout_s)
+        _safe_unlink(out_path)
+        return None
+    except OSError as exc:
+        logger.warning("skillspector could not be executed for %s: %s", skill_dir, exc)
         _safe_unlink(out_path)
         return None
 

--- a/src/genesis/security/skill_scan.py
+++ b/src/genesis/security/skill_scan.py
@@ -132,11 +132,37 @@ def discover_skill_dirs(roots: Iterable[Path]) -> list[Path]:
     return found
 
 
+def is_trusted(
+    skill_dir: Path,
+    *,
+    trusted_names: set[str],
+    trusted_roots: Iterable[Path],
+) -> bool:
+    """Whether a skill is trusted (name allowlisted OR under a trusted root).
+
+    Trusted skills are still scanned, but their findings are NOT filed to recon:
+    a curated, capable skill (gstack, first-party Genesis) legitimately trips
+    SkillSpector's excessive-agency / dangerous-code patterns, so filing them all
+    would swamp the recon lane. The signal is in untrusted / unknown skills.
+    """
+    skill_dir = Path(skill_dir).resolve()
+    if skill_dir.name in trusted_names:
+        return True
+    for root in trusted_roots:
+        try:
+            skill_dir.relative_to(Path(root).resolve())
+            return True
+        except (ValueError, OSError):
+            continue
+    return False
+
+
 # A scanner takes a skill dir and returns a SkillSpector JSON report, or None on
 # failure/timeout. A storer persists one finding payload. Both are injected so
 # the orchestration is testable without a live subprocess or DB.
 ScannerFn = Callable[[Path], "dict | None"]
 StorerFn = Callable[[object, dict], Awaitable[None]]
+TrustedFn = Callable[[Path], bool]
 
 
 async def scan_and_store(
@@ -146,21 +172,25 @@ async def scan_and_store(
     scanner: ScannerFn,
     storer: StorerFn,
     min_score: int = 1,
+    trusted: TrustedFn | None = None,
 ) -> list[ScanResult]:
     """Scan each skill dir, parse the report, and file a recon finding.
 
-    Every successfully-scanned skill is returned; only those at/above
-    ``min_score`` are filed to recon (keeps clean skills from swamping the lane).
-    A failed/timed-out scan (scanner returns None) is skipped, not fatal.
+    Every successfully-scanned skill is returned; a finding is filed only when the
+    skill scores at/above ``min_score`` AND is not ``trusted`` — trusted-source
+    skills are scanned (for visibility) but kept out of recon to avoid swamping it
+    with expected CRITICALs. A failed/timed-out scan (scanner returns None) is
+    skipped, not fatal.
     """
     results: list[ScanResult] = []
-    for skill_dir in skill_dirs:
-        report = scanner(Path(skill_dir))
+    for raw_dir in skill_dirs:
+        skill_dir = Path(raw_dir)
+        report = scanner(skill_dir)
         if report is None:
             continue
         result = parse_report(report)
         results.append(result)
-        if result.score >= min_score:
+        if result.score >= min_score and not (trusted and trusted(skill_dir)):
             await storer(db, report_to_finding(result))
     return results
 
@@ -274,29 +304,54 @@ async def store_finding(db: object, finding: dict) -> str | None:
     return finding_id
 
 
-def _default_roots() -> list[Path]:
-    """Default skill roots to sweep (some live outside the repo)."""
-    roots = [
-        Path.home() / ".claude" / "skills",
-        Path.home() / ".genesis" / "skill-library",
-    ]
+def _repo_skill_roots() -> list[Path]:
+    """First-party (in-repo) skill roots — trusted by default."""
     try:
         import genesis
 
         repo = Path(genesis.__file__).resolve().parents[2]
-        roots += [repo / ".claude" / "skills", repo / "src" / "genesis" / "skills"]
+        return [repo / ".claude" / "skills", repo / "src" / "genesis" / "skills"]
     except Exception:  # pragma: no cover - best-effort repo-root resolution
-        pass
-    return roots
+        return []
+
+
+def _default_roots() -> list[Path]:
+    """Default skill roots to sweep (some live outside the repo)."""
+    return [
+        Path.home() / ".claude" / "skills",
+        Path.home() / ".genesis" / "skill-library",
+        *_repo_skill_roots(),
+    ]
+
+
+def _default_trusted_file() -> Path:
+    """Allowlist of trusted skill names (one per line); blessed via --seed-trusted."""
+    return Path.home() / ".genesis" / "config" / "skill_scan_trusted.txt"
+
+
+def _load_trusted_names(path: Path) -> set[str]:
+    if not path.is_file():
+        return set()
+    return {
+        line.strip()
+        for line in path.read_text().splitlines()
+        if line.strip() and not line.startswith("#")
+    }
 
 
 def main(argv: list[str] | None = None) -> int:
-    """CLI: scan installed skills with SkillSpector and file recon findings."""
+    """CLI: scan installed skills with SkillSpector.
+
+    Files recon findings for UNTRUSTED skills only — trusted-source skills
+    (first-party repo + the ``--trusted-file`` allowlist) are scanned for
+    visibility but kept out of recon, since curated capable skills legitimately
+    score CRITICAL and would otherwise swamp the lane.
+    """
     import argparse
     import asyncio
 
     parser = argparse.ArgumentParser(
-        description="Scan installed skills with NVIDIA SkillSpector → recon findings.",
+        description="Scan installed skills with NVIDIA SkillSpector → recon findings (untrusted only).",
     )
     parser.add_argument("--roots", nargs="*", help="Skill root dirs (default: standard skill locations).")
     parser.add_argument("--skillspector-bin", default=None, help="Path to the skillspector binary.")
@@ -304,11 +359,40 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--min-score", type=int, default=1, help="Only file findings at/above this score.")
     parser.add_argument("--llm", action="store_true", help="Enable SkillSpector's LLM stage (default: static-only).")
     parser.add_argument("--no-store", action="store_true", help="Scan + print only; do not write recon findings.")
+    parser.add_argument(
+        "--trusted-file", default=None,
+        help=f"Allowlist of trusted skill names (default: {_default_trusted_file()}).",
+    )
+    parser.add_argument(
+        "--seed-trusted", action="store_true",
+        help="Write the currently-discovered skill names to the trusted allowlist and exit.",
+    )
+    parser.add_argument(
+        "--no-trust", action="store_true",
+        help="Disable trust filtering — file EVERY skill (the noisy mode).",
+    )
     args = parser.parse_args(argv)
 
     roots = [Path(r) for r in args.roots] if args.roots else _default_roots()
     skill_dirs = discover_skill_dirs(roots)
     print(f"Discovered {len(skill_dirs)} skills across {len(roots)} roots.")
+
+    trusted_file = Path(args.trusted_file) if args.trusted_file else _default_trusted_file()
+
+    if args.seed_trusted:
+        names = sorted({d.name for d in skill_dirs})
+        trusted_file.parent.mkdir(parents=True, exist_ok=True)
+        trusted_file.write_text(
+            "# Trusted skill names — scanned but NOT filed to recon.\n" + "\n".join(names) + "\n"
+        )
+        print(f"Seeded {len(names)} trusted skill names -> {trusted_file}")
+        return 0
+
+    trusted_names = set() if args.no_trust else _load_trusted_names(trusted_file)
+    trusted_roots = [] if args.no_trust else _repo_skill_roots()
+
+    def trusted(skill_dir: Path) -> bool:
+        return is_trusted(skill_dir, trusted_names=trusted_names, trusted_roots=trusted_roots)
 
     def scanner(skill_dir: Path) -> dict | None:
         return run_skillspector(
@@ -318,14 +402,18 @@ def main(argv: list[str] | None = None) -> int:
             no_llm=not args.llm,
         )
 
+    async def _run(storer: StorerFn, db: object) -> list[ScanResult]:
+        return await scan_and_store(
+            db, skill_dirs, scanner=scanner, storer=storer,
+            min_score=args.min_score, trusted=trusted,
+        )
+
     async def _go() -> int:
         if args.no_store:
             async def _noop(_db: object, _finding: dict) -> None:
                 return None
 
-            results = await scan_and_store(
-                None, skill_dirs, scanner=scanner, storer=_noop, min_score=args.min_score
-            )
+            results = await _run(_noop, None)
         else:
             import aiosqlite
 
@@ -333,14 +421,17 @@ def main(argv: list[str] | None = None) -> int:
 
             async with aiosqlite.connect(str(genesis_db_path())) as db:
                 await db.execute("PRAGMA busy_timeout=5000")
-                results = await scan_and_store(
-                    db, skill_dirs, scanner=scanner, storer=store_finding, min_score=args.min_score
-                )
+                results = await _run(store_finding, db)
 
-        filed = sum(1 for r in results if r.score >= args.min_score)
-        print(f"Scanned {len(results)} skills; filed {filed} findings (min_score={args.min_score}).\n")
+        filed = sum(1 for r in results if r.score >= args.min_score and not trusted(Path(r.source)))
+        skipped = sum(1 for r in results if trusted(Path(r.source)))
+        print(
+            f"Scanned {len(results)} skills; filed {filed} untrusted finding(s); "
+            f"{skipped} trusted-source skipped (min_score={args.min_score}).\n"
+        )
         for r in sorted(results, key=lambda r: r.score, reverse=True):
-            print(f"  {r.score:3d}/100  {r.severity:8s}  {r.name}  ({len(r.issues)} issues)")
+            mark = "trust" if trusted(Path(r.source)) else "FILE "
+            print(f"  [{mark}] {r.score:3d}/100  {r.severity:8s}  {r.name}  ({len(r.issues)} issues)")
         return 0
 
     return asyncio.run(_go())

--- a/src/genesis/security/skill_scan.py
+++ b/src/genesis/security/skill_scan.py
@@ -1,0 +1,330 @@
+"""Wrap NVIDIA SkillSpector to scan installed skills and file findings to recon.
+
+SkillSpector (https://github.com/NVIDIA/SkillSpector) is an external dependency,
+installed separately (it is not vendored). This module shells out to it, parses
+its JSON report, and stores ranked findings as recon observations
+(source='recon', type='finding', category='skill-security') so they surface via
+`recon_findings(job_type="skill-security")` and the dashboard.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+JOB_TYPE = "skill-security"
+
+# SkillSpector severity label → recon finding priority.
+_SEVERITY_PRIORITY = {
+    "CRITICAL": "high",
+    "HIGH": "high",
+    "MEDIUM": "medium",
+    "LOW": "low",
+}
+
+
+def severity_to_priority(severity: str) -> str:
+    """Map a SkillSpector severity label to a recon finding priority.
+
+    Unknown/blank severities default to "low" so a malformed report never
+    escalates noise into the high-priority recon lane.
+    """
+    return _SEVERITY_PRIORITY.get((severity or "").strip().upper(), "low")
+
+
+@dataclass(frozen=True)
+class ScanResult:
+    """The fields we care about from a SkillSpector JSON report."""
+
+    name: str
+    source: str
+    score: int
+    severity: str
+    recommendation: str
+    issues: list[dict] = field(default_factory=list)
+    has_executable_scripts: bool = False
+
+
+def parse_report(report: dict) -> ScanResult:
+    """Parse a SkillSpector JSON report into a ScanResult.
+
+    Tolerant of missing fields — a partial report yields a low/zero result
+    rather than raising, so one odd skill never aborts a full sweep.
+    """
+    skill = report.get("skill") or {}
+    risk = report.get("risk_assessment") or {}
+    meta = report.get("metadata") or {}
+    return ScanResult(
+        name=skill.get("name") or "unknown",
+        source=skill.get("source") or "",
+        score=int(risk.get("score") or 0),
+        severity=(risk.get("severity") or "LOW").upper(),
+        recommendation=risk.get("recommendation") or "",
+        issues=list(report.get("issues") or []),
+        has_executable_scripts=bool(meta.get("has_executable_scripts", False)),
+    )
+
+
+def report_to_finding(result: ScanResult) -> dict:
+    """Build a recon finding payload (title/summary/priority/source_url/job_type).
+
+    Title leads with the skill name + score so the recon lane is scannable;
+    summary names the top issues (capped) so triage is actionable at a glance.
+    """
+    priority = severity_to_priority(result.severity)
+    title = f"Skill '{result.name}': {result.severity} risk ({result.score}/100)"
+
+    lines: list[str] = []
+    if result.recommendation:
+        lines.append(f"Recommendation: {result.recommendation}")
+    if result.issues:
+        lines.append(f"{len(result.issues)} issue(s):")
+        for issue in result.issues[:10]:
+            cat = issue.get("category", "?")
+            sev = issue.get("severity", "?")
+            loc = issue.get("location", "")
+            lines.append(f"  - [{sev}] {cat}{f' @ {loc}' if loc else ''}")
+    else:
+        lines.append("No issues detected.")
+
+    return {
+        "title": title,
+        "summary": "\n".join(lines),
+        "priority": priority,
+        "job_type": JOB_TYPE,
+        "source_url": result.source or None,
+    }
+
+
+def discover_skill_dirs(roots: Iterable[Path]) -> list[Path]:
+    """Return immediate subdirectories of each root that contain a SKILL.md.
+
+    Non-existent roots are skipped. Discovery is one level deep on purpose: we
+    point SkillSpector at the skill directory (it recurses internally), so we
+    avoid mistaking a skill's bundled sub-tree for separate skills.
+    """
+    found: list[Path] = []
+    for root in roots:
+        root = Path(root)
+        if not root.is_dir():
+            continue
+        for child in sorted(root.iterdir()):
+            if child.is_dir() and (child / "SKILL.md").is_file():
+                found.append(child)
+    return found
+
+
+# A scanner takes a skill dir and returns a SkillSpector JSON report, or None on
+# failure/timeout. A storer persists one finding payload. Both are injected so
+# the orchestration is testable without a live subprocess or DB.
+ScannerFn = Callable[[Path], "dict | None"]
+StorerFn = Callable[[object, dict], Awaitable[None]]
+
+
+async def scan_and_store(
+    db: object,
+    skill_dirs: Iterable[Path],
+    *,
+    scanner: ScannerFn,
+    storer: StorerFn,
+    min_score: int = 1,
+) -> list[ScanResult]:
+    """Scan each skill dir, parse the report, and file a recon finding.
+
+    Every successfully-scanned skill is returned; only those at/above
+    ``min_score`` are filed to recon (keeps clean skills from swamping the lane).
+    A failed/timed-out scan (scanner returns None) is skipped, not fatal.
+    """
+    results: list[ScanResult] = []
+    for skill_dir in skill_dirs:
+        report = scanner(Path(skill_dir))
+        if report is None:
+            continue
+        result = parse_report(report)
+        results.append(result)
+        if result.score >= min_score:
+            await storer(db, report_to_finding(result))
+    return results
+
+
+# --- I/O integration (verified end-to-end, not unit-tested: real subprocess + DB) ---
+
+
+def run_skillspector(
+    skill_dir: Path,
+    *,
+    skillspector_bin: str | None = None,
+    timeout_s: int = 120,
+    no_llm: bool = True,
+) -> dict | None:
+    """Run ``skillspector scan <dir> -f json`` and return the parsed report.
+
+    Returns None on timeout, non-zero exit, or unreadable output — one bad/huge
+    skill (e.g. a skill bundling thousands of files) is logged and skipped, never
+    fatal to the sweep. SkillSpector must be installed separately; pass
+    ``skillspector_bin`` or have it on PATH.
+    """
+    import json
+    import os
+    import shutil
+    import subprocess
+    import tempfile
+
+    binary = skillspector_bin or shutil.which("skillspector")
+    if not binary:
+        raise FileNotFoundError(
+            "skillspector not found on PATH. Install NVIDIA/SkillSpector "
+            "(github.com/NVIDIA/SkillSpector) and pass skillspector_bin= or add it to PATH."
+        )
+
+    tmpdir = os.path.expanduser("~/tmp")
+    os.makedirs(tmpdir, exist_ok=True)
+    fd, out_path = tempfile.mkstemp(suffix=".json", dir=tmpdir)
+    os.close(fd)
+    cmd = [binary, "scan", str(skill_dir), "-f", "json", "-o", out_path]
+    if no_llm:
+        cmd.append("--no-llm")
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        logger.warning("skillspector scan timed out for %s (%ss)", skill_dir, timeout_s)
+        _safe_unlink(out_path)
+        return None
+
+    # SkillSpector exits NON-ZERO to signal risk level (e.g. a CRITICAL skill →
+    # rc=1), not failure — it still writes a valid report. So trust the JSON
+    # whenever it parses; treat only missing/invalid output as a real failure.
+    # (Gating on returncode here would silently drop the highest-risk skills.)
+    try:
+        with open(out_path) as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "skillspector produced no usable report for %s (rc=%s): %s | %s",
+            skill_dir, proc.returncode, exc, (proc.stderr or "")[:200],
+        )
+        return None
+    finally:
+        _safe_unlink(out_path)
+
+
+def _safe_unlink(path: str) -> None:
+    import contextlib
+    import os
+
+    with contextlib.suppress(OSError):
+        os.unlink(path)
+
+
+async def store_finding(db: object, finding: dict) -> str | None:
+    """Persist one finding as a recon observation (source='recon', type='finding').
+
+    Mirrors ``recon_store_finding``'s storage contract so findings surface via
+    ``recon_findings(job_type="skill-security")``. Dedupes on content hash, so
+    re-scanning an unchanged skill does not pile up duplicate findings.
+    """
+    import uuid
+    from datetime import UTC, datetime
+
+    from genesis.db.crud import observations as obs_crud
+
+    content = finding["title"]
+    if finding.get("summary"):
+        content += f"\n\n{finding['summary']}"
+    if finding.get("source_url"):
+        content += f"\n\nSource: {finding['source_url']}"
+
+    finding_id = await obs_crud.create(
+        db,  # type: ignore[arg-type]
+        id=str(uuid.uuid4()),
+        source="recon",
+        type="finding",
+        category=finding["job_type"],
+        content=content,
+        priority=finding["priority"],
+        created_at=datetime.now(UTC).isoformat(),
+        skip_if_duplicate=True,
+    )
+    await db.commit()  # type: ignore[attr-defined]
+    return finding_id
+
+
+def _default_roots() -> list[Path]:
+    """Default skill roots to sweep (some live outside the repo)."""
+    roots = [
+        Path.home() / ".claude" / "skills",
+        Path.home() / ".genesis" / "skill-library",
+    ]
+    try:
+        import genesis
+
+        repo = Path(genesis.__file__).resolve().parents[2]
+        roots += [repo / ".claude" / "skills", repo / "src" / "genesis" / "skills"]
+    except Exception:  # pragma: no cover - best-effort repo-root resolution
+        pass
+    return roots
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: scan installed skills with SkillSpector and file recon findings."""
+    import argparse
+    import asyncio
+
+    parser = argparse.ArgumentParser(
+        description="Scan installed skills with NVIDIA SkillSpector → recon findings.",
+    )
+    parser.add_argument("--roots", nargs="*", help="Skill root dirs (default: standard skill locations).")
+    parser.add_argument("--skillspector-bin", default=None, help="Path to the skillspector binary.")
+    parser.add_argument("--timeout", type=int, default=120, help="Per-skill scan timeout (seconds).")
+    parser.add_argument("--min-score", type=int, default=1, help="Only file findings at/above this score.")
+    parser.add_argument("--llm", action="store_true", help="Enable SkillSpector's LLM stage (default: static-only).")
+    parser.add_argument("--no-store", action="store_true", help="Scan + print only; do not write recon findings.")
+    args = parser.parse_args(argv)
+
+    roots = [Path(r) for r in args.roots] if args.roots else _default_roots()
+    skill_dirs = discover_skill_dirs(roots)
+    print(f"Discovered {len(skill_dirs)} skills across {len(roots)} roots.")
+
+    def scanner(skill_dir: Path) -> dict | None:
+        return run_skillspector(
+            skill_dir,
+            skillspector_bin=args.skillspector_bin,
+            timeout_s=args.timeout,
+            no_llm=not args.llm,
+        )
+
+    async def _go() -> int:
+        if args.no_store:
+            async def _noop(_db: object, _finding: dict) -> None:
+                return None
+
+            results = await scan_and_store(
+                None, skill_dirs, scanner=scanner, storer=_noop, min_score=args.min_score
+            )
+        else:
+            import aiosqlite
+
+            from genesis.env import genesis_db_path
+
+            async with aiosqlite.connect(str(genesis_db_path())) as db:
+                await db.execute("PRAGMA busy_timeout=5000")
+                results = await scan_and_store(
+                    db, skill_dirs, scanner=scanner, storer=store_finding, min_score=args.min_score
+                )
+
+        filed = sum(1 for r in results if r.score >= args.min_score)
+        print(f"Scanned {len(results)} skills; filed {filed} findings (min_score={args.min_score}).\n")
+        for r in sorted(results, key=lambda r: r.score, reverse=True):
+            print(f"  {r.score:3d}/100  {r.severity:8s}  {r.name}  ({len(r.issues)} issues)")
+        return 0
+
+    return asyncio.run(_go())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_learning/test_skill_provenance.py
+++ b/tests/test_learning/test_skill_provenance.py
@@ -1,0 +1,87 @@
+"""ACE-style provenance for skill_evolution: every mutation records *why*.
+
+The cognitive_file_modifications ledger previously stored only
+{skill_name, change_size, confidence}, dropping the triggering signals
+(failure patterns + the SkillReport trend/usage that prompted the refinement).
+"""
+
+from __future__ import annotations
+
+from genesis.learning.skills.applicator import SkillApplicator
+from genesis.learning.skills.refiner import SkillRefiner
+from genesis.learning.skills.types import (
+    ChangeSize,
+    SkillProposal,
+    SkillReport,
+    SkillTrend,
+)
+
+
+def _declining_report() -> SkillReport:
+    return SkillReport(
+        skill_name="demo",
+        usage_count=12,
+        success_count=6,
+        failure_count=6,
+        success_rate=0.5,
+        baseline_success_rate=0.8,
+        failure_patterns=["timeout", "truncation"],
+        trend=SkillTrend.DECLINING,
+    )
+
+
+def test_skill_proposal_provenance_defaults_to_none():
+    proposal = SkillProposal(
+        skill_name="s",
+        proposed_content="c",
+        rationale="r",
+        change_size=ChangeSize.MINOR,
+    )
+    assert proposal.provenance_trace is None
+
+
+def test_build_provenance_summarizes_the_trigger_signals():
+    trace = SkillRefiner()._build_provenance(_declining_report())
+    # The trace must capture *why* this skill was picked for refinement.
+    assert "declining" in trace.lower()
+    assert "timeout" in trace
+    assert "12" in trace  # usage count
+    assert "50" in trace or "0.5" in trace  # success rate
+
+
+def test_parse_response_attaches_provenance_when_supplied():
+    text = (
+        '{"proposed_content": "x", "rationale": "y", "change_size": "minor", '
+        '"confidence": 0.9, "failure_patterns_addressed": ["timeout"]}'
+    )
+    proposal = SkillRefiner()._parse_response(
+        "demo", text, provenance_trace="usage=12 trend=declining"
+    )
+    assert proposal is not None
+    assert proposal.provenance_trace == "usage=12 trend=declining"
+
+
+def test_parse_response_provenance_is_optional_backward_compatible():
+    # Existing callers pass only (skill_name, text) — must still work.
+    text = '{"proposed_content": "x", "rationale": "y", "change_size": "minor"}'
+    proposal = SkillRefiner()._parse_response("demo", text)
+    assert proposal is not None
+    assert proposal.provenance_trace is None
+
+
+def test_modification_metadata_includes_provenance_and_failure_patterns():
+    proposal = SkillProposal(
+        skill_name="s",
+        proposed_content="c",
+        rationale="r",
+        change_size=ChangeSize.MINOR,
+        confidence=0.8,
+        failure_patterns_addressed=["timeout"],
+        provenance_trace="usage=12 trend=declining",
+    )
+    metadata = SkillApplicator._build_modification_metadata(proposal)
+    assert metadata["skill_name"] == "s"
+    assert metadata["change_size"] == "minor"
+    assert metadata["confidence"] == 0.8
+    assert metadata["provenance_trace"] == "usage=12 trend=declining"
+    assert metadata["failure_patterns_addressed"] == ["timeout"]

--- a/tests/test_security/test_skill_scan.py
+++ b/tests/test_security/test_skill_scan.py
@@ -92,6 +92,28 @@ def test_report_to_finding_builds_recon_finding():
     assert "DO NOT INSTALL" in finding["summary"]
 
 
+def test_report_to_finding_handles_dict_location():
+    # SkillSpector emits `location` as either a string ("file:line") or a dict
+    # ({"file","start_line","end_line"}); the summary must render a clean
+    # "file:line", never a raw dict repr.
+    result = parse_report(
+        {
+            "skill": {"name": "x"},
+            "risk_assessment": {"score": 25, "severity": "MEDIUM", "recommendation": "CAUTION"},
+            "issues": [
+                {
+                    "category": "Memory Poisoning",
+                    "severity": "HIGH",
+                    "location": {"file": "SKILL.md", "start_line": 288, "end_line": None},
+                }
+            ],
+        }
+    )
+    finding = report_to_finding(result)
+    assert "SKILL.md:288" in finding["summary"]
+    assert "{" not in finding["summary"]  # no raw dict repr leaked into the text
+
+
 def test_report_to_finding_safe_skill_is_low_priority():
     safe = parse_report(
         {

--- a/tests/test_security/test_skill_scan.py
+++ b/tests/test_security/test_skill_scan.py
@@ -234,22 +234,32 @@ async def test_scan_and_store_skips_failed_scans():
     assert results == []
 
 
-async def test_store_finding_persists_recon_observation_row(db):
-    """A stored finding lands as a recon observation row (source/type/category).
+async def test_store_finding_uses_recon_finding_contract():
+    """store_finding persists via observations.create with the recon-finding shape
+    (source/type/category/priority) so findings surface through recon_findings.
 
-    Verified by direct SQL rather than ``observations.query`` so the assertion is
-    immune to a leaked mock of that helper elsewhere in the full suite — it checks
-    the actual persisted row.
+    Asserts store_finding's translation contract deterministically by mocking the
+    CRUD layer — no shared DB fixture, so it can't be poisoned by suite-wide
+    connection state. The real DB round-trip is covered separately by
+    observations.create's own tests and the live-DB scan E2E.
     """
-    finding = report_to_finding(parse_report(SAMPLE_REPORT))
-    finding_id = await store_finding(db, finding)
-    assert finding_id
+    from unittest.mock import AsyncMock, patch
 
-    cursor = await db.execute(
-        "SELECT content, priority FROM observations "
-        "WHERE source = 'recon' AND type = 'finding' AND category = 'skill-security'"
-    )
-    rows = await cursor.fetchall()
-    assert len(rows) == 1
-    assert "demo-skill" in rows[0]["content"]
-    assert rows[0]["priority"] == "high"
+    finding = report_to_finding(parse_report(SAMPLE_REPORT))
+    fake_db = AsyncMock()
+    with patch(
+        "genesis.db.crud.observations.create", new_callable=AsyncMock, return_value="fid-1"
+    ) as mock_create:
+        finding_id = await store_finding(fake_db, finding)
+
+    assert finding_id == "fid-1"
+    mock_create.assert_awaited_once()
+    kwargs = mock_create.call_args.kwargs
+    assert kwargs["source"] == "recon"
+    assert kwargs["type"] == "finding"
+    assert kwargs["category"] == "skill-security"
+    assert kwargs["priority"] == "high"
+    assert kwargs["skip_if_duplicate"] is True
+    assert "demo-skill" in kwargs["content"]
+    assert "DO NOT INSTALL" in kwargs["content"]  # summary folded into content
+    fake_db.commit.assert_awaited_once()

--- a/tests/test_security/test_skill_scan.py
+++ b/tests/test_security/test_skill_scan.py
@@ -234,17 +234,22 @@ async def test_scan_and_store_skips_failed_scans():
     assert results == []
 
 
-async def test_store_finding_persists_queryable_recon_finding(db):
-    """A stored finding is retrievable via the same query recon_findings uses."""
-    from genesis.db.crud import observations as obs_crud
+async def test_store_finding_persists_recon_observation_row(db):
+    """A stored finding lands as a recon observation row (source/type/category).
 
+    Verified by direct SQL rather than ``observations.query`` so the assertion is
+    immune to a leaked mock of that helper elsewhere in the full suite — it checks
+    the actual persisted row.
+    """
     finding = report_to_finding(parse_report(SAMPLE_REPORT))
     finding_id = await store_finding(db, finding)
     assert finding_id
 
-    rows = await obs_crud.query(
-        db, source="recon", type="finding", category="skill-security", limit=10
+    cursor = await db.execute(
+        "SELECT content, priority FROM observations "
+        "WHERE source = 'recon' AND type = 'finding' AND category = 'skill-security'"
     )
+    rows = await cursor.fetchall()
     assert len(rows) == 1
     assert "demo-skill" in rows[0]["content"]
     assert rows[0]["priority"] == "high"

--- a/tests/test_security/test_skill_scan.py
+++ b/tests/test_security/test_skill_scan.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from genesis.security.skill_scan import (
     ScanResult,
     discover_skill_dirs,
+    is_trusted,
     parse_report,
     report_to_finding,
     scan_and_store,
@@ -172,6 +173,50 @@ async def test_scan_and_store_files_findings_above_threshold():
     assert len(stored) == 1
     assert stored[0]["title"].startswith("Skill 'bad'")
     assert stored[0]["priority"] == "high"
+
+
+def test_is_trusted_by_root_or_name(tmp_path):
+    repo_skills = tmp_path / "repo" / ".claude" / "skills"
+    (repo_skills / "first-party").mkdir(parents=True)
+    ext = tmp_path / "ext"
+    (ext / "blessed").mkdir(parents=True)
+    (ext / "unknown").mkdir(parents=True)
+
+    # Under a trusted root -> trusted (first-party).
+    assert is_trusted(repo_skills / "first-party", trusted_names=set(), trusted_roots=[repo_skills]) is True
+    # Name on the allowlist -> trusted, regardless of root.
+    assert is_trusted(ext / "blessed", trusted_names={"blessed"}, trusted_roots=[repo_skills]) is True
+    # Neither -> untrusted.
+    assert is_trusted(ext / "unknown", trusted_names={"blessed"}, trusted_roots=[repo_skills]) is False
+
+
+async def test_scan_and_store_skips_filing_trusted_sources():
+    stored: list[dict] = []
+
+    def fake_scanner(skill_dir: Path) -> dict:
+        # Everything scores CRITICAL (the real-world false-positive case).
+        return {
+            "skill": {"name": skill_dir.name, "source": str(skill_dir)},
+            "risk_assessment": {"score": 100, "severity": "CRITICAL", "recommendation": "DO NOT INSTALL"},
+            "issues": [{"category": "Excessive Agency", "severity": "CRITICAL"}],
+        }
+
+    async def fake_storer(db: object, finding: dict) -> None:
+        stored.append(finding)
+
+    results = await scan_and_store(
+        None,
+        [Path("/x/trusted-skill"), Path("/x/unknown-skill")],
+        scanner=fake_scanner,
+        storer=fake_storer,
+        min_score=1,
+        trusted=lambda d: d.name == "trusted-skill",
+    )
+
+    # Both are scanned + returned, but only the untrusted one is filed to recon.
+    assert sorted(r.name for r in results) == ["trusted-skill", "unknown-skill"]
+    assert len(stored) == 1
+    assert stored[0]["title"].startswith("Skill 'unknown-skill'")
 
 
 async def test_scan_and_store_skips_failed_scans():

--- a/tests/test_security/test_skill_scan.py
+++ b/tests/test_security/test_skill_scan.py
@@ -1,0 +1,183 @@
+"""Tests for the SkillSpector wrapper (skill-security scan → recon findings)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from genesis.security.skill_scan import (
+    ScanResult,
+    discover_skill_dirs,
+    parse_report,
+    report_to_finding,
+    scan_and_store,
+    severity_to_priority,
+    store_finding,
+)
+
+# A representative SkillSpector JSON report (the contract: skill / risk_assessment /
+# components / issues / metadata), modeled on a real `skillspector scan -f json` output.
+SAMPLE_REPORT = {
+    "skill": {
+        "name": "demo-skill",
+        "source": "/skills/demo-skill",
+        "scanned_at": "2026-06-21T00:00:00Z",
+    },
+    "risk_assessment": {"score": 78, "severity": "HIGH", "recommendation": "DO NOT INSTALL"},
+    "components": [
+        {"path": "scripts/sync.py", "type": "python", "lines": 87, "executable": True, "size_bytes": 2000},
+    ],
+    "issues": [
+        {
+            "id": "E2",
+            "category": "Data Exfiltration",
+            "pattern": "Env Variable Harvesting",
+            "severity": "HIGH",
+            "confidence": 0.94,
+            "location": "scripts/sync.py:23",
+            "finding": "for key, val in os.environ.items(): ...",
+            "explanation": "Collects env vars and sends them externally.",
+        },
+    ],
+    "metadata": {
+        "has_executable_scripts": True,
+        "skillspector_version": "2.0.0",
+        "llm_requested": False,
+        "llm_available": False,
+    },
+}
+
+
+def test_severity_to_priority_maps_severities_to_recon_priorities():
+    assert severity_to_priority("CRITICAL") == "high"
+    assert severity_to_priority("HIGH") == "high"
+    assert severity_to_priority("MEDIUM") == "medium"
+    assert severity_to_priority("LOW") == "low"
+    # Unknown / missing severities default to low rather than crashing.
+    assert severity_to_priority("") == "low"
+    assert severity_to_priority("bogus") == "low"
+
+
+def test_parse_report_extracts_core_fields():
+    result = parse_report(SAMPLE_REPORT)
+    assert isinstance(result, ScanResult)
+    assert result.name == "demo-skill"
+    assert result.score == 78
+    assert result.severity == "HIGH"
+    assert result.recommendation == "DO NOT INSTALL"
+    assert result.has_executable_scripts is True
+    assert len(result.issues) == 1
+    assert result.issues[0]["category"] == "Data Exfiltration"
+    assert result.issues[0]["location"] == "scripts/sync.py:23"
+
+
+def test_parse_report_tolerates_missing_fields():
+    # A minimal/odd report must not crash — score defaults to 0, issues to [].
+    result = parse_report({"skill": {"name": "bare"}})
+    assert result.name == "bare"
+    assert result.score == 0
+    assert result.severity == "LOW"
+    assert result.issues == []
+    assert result.has_executable_scripts is False
+
+
+def test_report_to_finding_builds_recon_finding():
+    result = parse_report(SAMPLE_REPORT)
+    finding = report_to_finding(result)
+    assert finding["job_type"] == "skill-security"
+    assert finding["priority"] == "high"
+    assert "demo-skill" in finding["title"]
+    assert "78" in finding["title"]  # score surfaced in the title
+    # Summary names the top issue category so triage is actionable at a glance.
+    assert "Data Exfiltration" in finding["summary"]
+    assert "DO NOT INSTALL" in finding["summary"]
+
+
+def test_report_to_finding_safe_skill_is_low_priority():
+    safe = parse_report(
+        {
+            "skill": {"name": "safe-skill"},
+            "risk_assessment": {"score": 5, "severity": "LOW", "recommendation": "SAFE"},
+            "issues": [],
+        }
+    )
+    finding = report_to_finding(safe)
+    assert finding["priority"] == "low"
+    assert "safe-skill" in finding["title"]
+
+
+def test_discover_skill_dirs_finds_skill_md_subdirs(tmp_path):
+    (tmp_path / "skA").mkdir()
+    (tmp_path / "skA" / "SKILL.md").write_text("a")
+    (tmp_path / "skB").mkdir()
+    (tmp_path / "skB" / "SKILL.md").write_text("b")
+    (tmp_path / "not-a-skill").mkdir()  # no SKILL.md → excluded
+
+    found = discover_skill_dirs([tmp_path, tmp_path / "does-not-exist"])
+
+    names = sorted(p.name for p in found)
+    assert names == ["skA", "skB"]
+
+
+async def test_scan_and_store_files_findings_above_threshold():
+    stored: list[dict] = []
+
+    def fake_scanner(skill_dir: Path) -> dict:
+        if skill_dir.name == "bad":
+            return {
+                "skill": {"name": "bad", "source": str(skill_dir)},
+                "risk_assessment": {"score": 78, "severity": "HIGH", "recommendation": "DO NOT INSTALL"},
+                "issues": [{"category": "Data Exfiltration", "severity": "HIGH"}],
+            }
+        return {
+            "skill": {"name": "good", "source": str(skill_dir)},
+            "risk_assessment": {"score": 0, "severity": "LOW", "recommendation": "SAFE"},
+            "issues": [],
+        }
+
+    async def fake_storer(db: object, finding: dict) -> None:
+        stored.append(finding)
+
+    results = await scan_and_store(
+        None,
+        [Path("/x/bad"), Path("/x/good")],
+        scanner=fake_scanner,
+        storer=fake_storer,
+        min_score=21,
+    )
+
+    # Both scanned + parsed; only the above-threshold one is filed to recon.
+    assert sorted(r.name for r in results) == ["bad", "good"]
+    assert len(stored) == 1
+    assert stored[0]["title"].startswith("Skill 'bad'")
+    assert stored[0]["priority"] == "high"
+
+
+async def test_scan_and_store_skips_failed_scans():
+    async def fake_storer(db: object, finding: dict) -> None:
+        raise AssertionError("must not store when the scan fails")
+
+    results = await scan_and_store(
+        None,
+        [Path("/x/timed-out")],
+        scanner=lambda d: None,  # None == scan failed/timed out
+        storer=fake_storer,
+        min_score=0,
+    )
+
+    assert results == []
+
+
+async def test_store_finding_persists_queryable_recon_finding(db):
+    """A stored finding is retrievable via the same query recon_findings uses."""
+    from genesis.db.crud import observations as obs_crud
+
+    finding = report_to_finding(parse_report(SAMPLE_REPORT))
+    finding_id = await store_finding(db, finding)
+    assert finding_id
+
+    rows = await obs_crud.query(
+        db, source="recon", type="finding", category="skill-security", limit=10
+    )
+    assert len(rows) == 1
+    assert "demo-skill" in rows[0]["content"]
+    assert rows[0]["priority"] == "high"


### PR DESCRIPTION
## Phase A — two cheap wins from the 2026-06 inbox/harness batch

### 1. Skill-security scan (`src/genesis/security/skill_scan.py`)
Wrap NVIDIA SkillSpector to audit installed skills and file findings as recon
observations (`source=recon`, `type=finding`, `category=skill-security`),
surfaced via `recon_findings(job_type="skill-security")` + the dashboard.

- **Trusted-source allowlist (Option C):** a raw scan flags ~68 CRITICAL — nearly
  every curated, capable skill (gstack suite, Genesis's own) trips SkillSpector's
  excessive-agency / dangerous-code patterns by design. So we scan everything for
  visibility but **file findings only for untrusted/unknown skills.** First-party
  repo roots auto-trusted; `--seed-trusted` blesses the current install;
  `--no-trust` restores the file-everything mode.
- SkillSpector exits **non-zero to signal risk, not failure** — the wrapper trusts
  the JSON whenever it parses (else it would silently drop the highest-risk skills).
- Per-skill timeout + graceful skip for outliers (a skill can bundle thousands of
  files); issue `location` normalized (str or dict); `skip_if_duplicate` so
  re-scans don't pile up.
- **SkillSpector is an external dependency** (not vendored): deploy needs it
  installed + a one-time `--seed-trusted` run.

### 2. Skill-evolution provenance (`src/genesis/learning/skills/*`)
Record *why* a skill mutation happened: an optional `provenance_trace` on
`SkillProposal`, derived from the `SkillReport` (trend / usage / success rate /
failure patterns), is written (with `failure_patterns_addressed`) into the
`cognitive_file_modifications` ledger metadata. No migration (JSON metadata);
the optional `_parse_response` kwarg leaves existing callers unaffected.

### Verification
148 targeted tests · ruff clean · E2E: full 97-skill sweep, live-store →
`recon_findings` → cleanup against the canonical DB, trust-filter ON → filed 0 /
`--no-trust` → all filed.

**Review note:** Codex was quota-exhausted and the code-reviewer subagent hit
repeated 529s, so this carries a rigorous self-review (which already caught + fixed
an rc-handling bug that would have dropped every CRITICAL skill, plus the
false-positive flood). Please run the PR-stage review before merge.

### Follow-ups (not in this PR)
- Recurring recon job for the skill scan.
- Baseline-and-diff drift detection (flag only new/changed skills).
