### PR TITLE
fix(db,scheduler): migration false-failure reconciliation + decouple GitNexus CLAUDE.md strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Fixed
+
+- **Updates no longer abort when a schema migration actually succeeded** — if the
+  database was busy during an update (for example a background task writing at the same
+  time), a migration could commit successfully yet still surface a transient "database
+  is locked" error, which made the update roll the code back while the database had
+  already moved forward. Updates now confirm whether the migration was truly applied
+  before treating it as a failure, and give migrations more room to wait out a busy
+  database.
+
 ## [v3.0b16] - 2026-06-21
 
 ### Added

--- a/src/genesis/db/connection.py
+++ b/src/genesis/db/connection.py
@@ -26,6 +26,14 @@ DEFAULT_DB_PATH = genesis_db_path()
 
 BUSY_TIMEOUT_MS = 5000
 
+# Schema migrations run rarely (deploy / server startup) but must win the write
+# lock even when other processes (concurrent CC-session MCP servers) are writing.
+# A generous timeout lets the migration's BEGIN IMMEDIATE and its COMMIT-time
+# autocheckpoint wait out that contention instead of failing with
+# "database is locked". The runner reconciles against schema_migrations either
+# way, but this keeps the common case quiet.
+MIGRATION_BUSY_TIMEOUT_MS = 60000
+
 
 class SerializedConnection:
     """Proxy that serializes all DB operations through an asyncio.Lock.

--- a/src/genesis/db/migrations/__main__.py
+++ b/src/genesis/db/migrations/__main__.py
@@ -28,11 +28,11 @@ async def _run(args: argparse.Namespace) -> int:
         print(f"Database not found: {db_path}", file=sys.stderr)
         return 1
 
-    from genesis.db.connection import BUSY_TIMEOUT_MS
+    from genesis.db.connection import MIGRATION_BUSY_TIMEOUT_MS
 
     async with aiosqlite.connect(str(db_path)) as db:
         await db.execute("PRAGMA journal_mode=WAL")
-        await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+        await db.execute(f"PRAGMA busy_timeout={MIGRATION_BUSY_TIMEOUT_MS}")
         runner = MigrationRunner(db)
 
         if args.status:

--- a/src/genesis/db/migrations/runner.py
+++ b/src/genesis/db/migrations/runner.py
@@ -291,17 +291,49 @@ class MigrationRunner:
 
             except Exception as exc:
                 duration_ms = int((time.monotonic() - t0) * 1000)
-                # Rollback the failed migration's changes via explicit SQL.
-                # Log rollback failures at ERROR — DB state is unknown if
-                # rollback fails.
+                # Roll back FIRST. A WAL COMMIT can return SQLITE_BUSY from a
+                # post-commit autocheckpoint AFTER the commit frame is durably
+                # written, so this error does NOT prove the migration failed.
+                # ROLLBACK is a harmless no-op ("no transaction is active") when
+                # the commit already landed, and undoes a genuinely open
+                # transaction otherwise — either way schema_migrations then holds
+                # the TRUE durable state.
                 try:
                     await self._db.execute("ROLLBACK")
                 except Exception as rb_exc:
-                    logger.error(
-                        "Rollback FAILED after migration %s error — "
-                        "database state is unknown: %s",
-                        name, rb_exc, exc_info=True,
+                    logger.debug(
+                        "ROLLBACK after migration %s error (expected when the "
+                        "commit already landed): %s", name, rb_exc,
                     )
+
+                # Reconcile against the source of truth: is the migration durably
+                # recorded? If so, the COMMIT-time error was post-commit noise —
+                # treat it as applied instead of reporting a false failure (which
+                # previously rolled back the code and left new-schema + old-code).
+                applied = False
+                try:
+                    cur = await self._db.execute(
+                        "SELECT 1 FROM schema_migrations WHERE id = ?", (mid,)
+                    )
+                    applied = await cur.fetchone() is not None
+                except Exception:
+                    logger.error(
+                        "Reconciliation read failed after migration %s error — "
+                        "treating as failed", name, exc_info=True,
+                    )
+                    applied = False
+
+                if applied:
+                    logger.warning(
+                        "Migration %s raised %r but is durably recorded in "
+                        "schema_migrations — treating as applied (likely a "
+                        "post-commit WAL autocheckpoint SQLITE_BUSY).",
+                        name, exc,
+                    )
+                    results.append(MigrationResult(
+                        id=mid, name=name, success=True, duration_ms=duration_ms,
+                    ))
+                    continue  # proceed to the next migration
 
                 results.append(MigrationResult(
                     id=mid, name=name, success=False,

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -331,6 +331,17 @@ class SurplusScheduler:
             max_instances=1,
             misfire_grace_time=3600,
         )
+        # GitNexus CLAUDE.md strip: hourly. Decoupled from the reindex job above —
+        # out-of-band reindexes (GitNexus's own staleness `analyze`) also re-inject
+        # the block but never run that job's post-strip, so without this the block
+        # would persist in CLAUDE.md until the next Mon/Thu reindex.
+        self._scheduler.add_job(
+            self.run_gitnexus_strip,
+            CronTrigger(minute=0, timezone=user_timezone()),
+            id="gitnexus_strip",
+            max_instances=1,
+            misfire_grace_time=300,
+        )
         # Wing audit: twice-weekly memory taxonomy review (Tue & Fri 2am local).
         # Moved off Sunday to avoid dream cycle congestion.
         self._scheduler.add_job(
@@ -463,6 +474,8 @@ class SurplusScheduler:
             await self.schedule_model_eval()
         if self._analytical_hours > 0:
             await self.schedule_analytical()
+        # Clean any GitNexus block an out-of-band reindex left in CLAUDE.md.
+        await self.run_gitnexus_strip()
         logger.info(
             "Surplus scheduler started (dispatch=%dm, brainstorm=%dh)",
             self._dispatch_interval, self._brainstorm_interval,
@@ -1282,6 +1295,28 @@ class SurplusScheduler:
                 GenesisRuntime.instance().record_job_failure(
                     "gitnexus_reindex", str(exc),
                 )
+
+    async def run_gitnexus_strip(self) -> None:
+        """Strip GitNexus's auto-injected block from CLAUDE.md (hourly + on startup).
+
+        ``gitnexus analyze`` re-injects the block into CLAUDE.md on EVERY reindex,
+        including the out-of-band staleness reindex run by GitNexus's own MCP
+        server — which never triggers ``run_gitnexus_reindex``'s post-strip. This
+        decoupled job keeps CLAUDE.md clean regardless of what reindexed; AGENTS.md
+        intentionally keeps the block (read by cross-tool agents). Idempotent no-op
+        when the block is absent.
+        """
+        from genesis.runtime import GenesisRuntime
+
+        try:
+            if _strip_gitnexus_block(Path.home() / "genesis" / "CLAUDE.md"):
+                logger.info("Stripped GitNexus block from CLAUDE.md (kept in AGENTS.md)")
+            with contextlib.suppress(Exception):
+                GenesisRuntime.instance().record_job_success("gitnexus_strip")
+        except Exception as exc:
+            logger.warning("GitNexus strip failed", exc_info=True)
+            with contextlib.suppress(Exception):
+                GenesisRuntime.instance().record_job_failure("gitnexus_strip", str(exc))
 
     async def run_memory_extraction(self) -> None:
         """Run periodic memory extraction from session transcripts."""

--- a/tests/test_db/test_migrations_runner.py
+++ b/tests/test_db/test_migrations_runner.py
@@ -476,3 +476,57 @@ class TestSerializedConnectionCompat:
             # Re-run is a no-op (idempotence holds through the wrapper)
             second = await runner.run_pending()
             assert second == []
+
+
+class TestFalseFailureReconciliation:
+    """A WAL COMMIT can return SQLITE_BUSY from a post-commit autocheckpoint
+    AFTER the commit frame is durably written (concurrent readers blocking the
+    checkpoint). The runner must reconcile against schema_migrations and treat
+    such a migration as APPLIED — not report a false failure that rolls back the
+    deploy code. Regression for the 2026-06-22 deploy incident (migration 0034)."""
+
+    @pytest.mark.asyncio
+    async def test_commit_busy_after_commit_is_treated_as_applied(self, db, caplog) -> None:
+        import logging
+        from sqlite3 import OperationalError
+
+        class _CommitThenRaise:
+            """First execute('COMMIT') commits for real, then raises SQLITE_BUSY."""
+
+            def __init__(self, real):
+                self._real = real
+                self._tripped = False
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def execute(self, sql, *args, **kwargs):
+                if not self._tripped and sql.strip().upper().startswith("COMMIT"):
+                    self._tripped = True
+
+                    async def _commit_then_raise():
+                        await self._real.execute("COMMIT")
+                        raise OperationalError("database is locked")
+
+                    return _commit_then_raise()
+                return self._real.execute(sql, *args, **kwargs)
+
+        runner = MigrationRunner(_CommitThenRaise(db))
+        with caplog.at_level(logging.WARNING, logger="genesis.db.migrations.runner"):
+            results = await runner.run_pending()
+
+        # The reconciliation path MUST have fired — otherwise this test would pass
+        # even if the wrapper never tripped or reconciliation were removed.
+        assert any(
+            "treating as applied" in rec.getMessage() for rec in caplog.records
+        ), "reconciliation warning not emitted — busy-after-commit path not exercised"
+
+        # The first migration's COMMIT raised SQLITE_BUSY *after* committing;
+        # reconciliation must report it applied rather than a false failure.
+        failed = [(r.name, r.error) for r in results if not r.success]
+        assert not failed, f"committed-but-busy must reconcile to applied: {failed}"
+
+        applied = await runner.get_applied()
+        assert "0001" in applied, "migration durably recorded"
+        # Idempotent: re-run is a no-op.
+        assert await runner.run_pending() == []

--- a/tests/test_surplus/test_scheduler.py
+++ b/tests/test_surplus/test_scheduler.py
@@ -31,6 +31,27 @@ def _make_scheduler(db, *, idle=True, lmstudio_up=False, enable_code_audits=Fals
     ), compute
 
 
+async def test_run_gitnexus_strip_cleans_claude_md(db, tmp_path, monkeypatch):
+    """run_gitnexus_strip removes the GitNexus block from CLAUDE.md, not AGENTS.md."""
+    from pathlib import Path as _P
+
+    sched, _ = _make_scheduler(db)  # build before patching Path.home
+
+    genesis_dir = tmp_path / "genesis"
+    genesis_dir.mkdir()
+    block = "<!-- gitnexus:start -->\n# GitNexus\nidx\n<!-- gitnexus:end -->\n"
+    (genesis_dir / "CLAUDE.md").write_text("# Real instructions\n\n" + block)
+    (genesis_dir / "AGENTS.md").write_text("# Agents\n\n" + block)
+
+    monkeypatch.setattr(_P, "home", lambda: tmp_path)
+    await sched.run_gitnexus_strip()
+
+    claude = (genesis_dir / "CLAUDE.md").read_text()
+    assert "gitnexus:start" not in claude, "block stripped from CLAUDE.md"
+    assert "# Real instructions" in claude, "real content preserved"
+    assert "gitnexus:start" in (genesis_dir / "AGENTS.md").read_text(), "AGENTS.md kept"
+
+
 async def test_dispatch_skips_when_not_idle(db):
     sched, compute = _make_scheduler(db, idle=False)
     with patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False):
@@ -112,7 +133,8 @@ async def test_brainstorm_check_schedules_sessions(db):
 
 async def test_start_and_stop(db):
     sched, compute = _make_scheduler(db, idle=True, enable_code_audits=True)
-    with patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False):
+    with patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False), \
+         patch.object(sched, "run_gitnexus_strip", new_callable=AsyncMock):
         await sched.start()
     assert sched._scheduler.running is True
     # Verify jobs were registered
@@ -129,7 +151,8 @@ async def test_start_and_stop(db):
 
 async def test_start_without_code_audits(db):
     sched, compute = _make_scheduler(db, idle=True, enable_code_audits=False)
-    with patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False):
+    with patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False), \
+         patch.object(sched, "run_gitnexus_strip", new_callable=AsyncMock):
         await sched.start()
     assert sched._scheduler.running is True
     # Code audit job should NOT be registered


### PR DESCRIPTION
## Two robustness fixes surfaced while deploying the follow-up schema (PR #741)

### 1. Migration false-failure reconciliation (deploy-critical)

Deploying migration `0034` failed with `database is locked` **yet the migration had
actually committed** — in WAL mode a `COMMIT` can return `SQLITE_BUSY` from a
post-commit autocheckpoint *after* the commit frame is durably written, when
concurrent writers hold the WAL. The runner treated that as a failure, so the update
rolled the **code** back while the **DB** advanced (new-schema + old-code). Server
startup has the same exposure — it raises and fails init on a "failed" migration.

**Fix:** in `run_pending()`'s error path, roll back first (a no-op if the commit
already landed; undoes a genuinely-open transaction), then reconcile against
`schema_migrations`. If the migration is durably recorded it committed → treat it as
applied; only a genuinely-absent row is a real failure. Mechanism-agnostic, the happy
path is unchanged, and it fixes both callers (deploy + server startup). Migrations
also get a dedicated 60s busy-timeout (the app stays at 5s) so the lock and the
COMMIT-checkpoint can wait out contention. A regression test reproduces the exact
incident and asserts the reconciliation path actually fired.

### 2. Decouple the GitNexus CLAUDE.md strip

The strip that keeps GitNexus's auto-injected block out of `CLAUDE.md` only ran after
the scheduled Mon/Thu reindex, so out-of-band reindexes (GitNexus's own staleness
`analyze`) re-injected the block and it persisted for days. Added an hourly job plus
a one-shot strip on scheduler startup, reusing the existing idempotent strip
(`AGENTS.md` intentionally keeps its block).

### Verification

- The reproduction test fails on the old runner and passes on the new one
  (committed-but-busy → reconciled to applied; a genuine failure still rolls back).
  Full `test_db/` + `test_surplus/` suites green (904 tests).
- The migration entrypoint `--status` / `--dry-run` run clean against a real database
  with the new timeout. **No new migration in this PR**, so deploying it is a no-op on
  the migration step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
