### PR TITLE
fix(tests): kill shared-fixture contaminant + feat(recon): operationalize skill-security scan

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -350,6 +350,26 @@ fi
 if command -v serena &>/dev/null; then
     echo "  Serena: $(serena --version 2>/dev/null || echo 'installed')"
 fi
+
+# SkillSpector (NVIDIA — skill-security scanner; external dep, not vendored).
+# The scheduled skill-security scan resolves the binary from this stable path.
+SKILLSPECTOR_DIR="$HOME/.genesis/deps/skillspector"
+if [[ ! -x "$SKILLSPECTOR_DIR/.venv/bin/skillspector" ]]; then
+    echo "  SkillSpector not found — installing..."
+    mkdir -p "$HOME/.genesis/deps"
+    if [[ ! -d "$SKILLSPECTOR_DIR/.git" ]]; then
+        git clone --depth 1 https://github.com/NVIDIA/SkillSpector.git "$SKILLSPECTOR_DIR" 2>/dev/null \
+            || echo "  WARNING: SkillSpector clone failed (skill-security scan will no-op until installed)"
+    fi
+    if [[ -d "$SKILLSPECTOR_DIR" ]]; then
+        "$PYTHON_BIN" -m venv "$SKILLSPECTOR_DIR/.venv" 2>/dev/null \
+            && "$SKILLSPECTOR_DIR/.venv/bin/pip" install -q "$SKILLSPECTOR_DIR" 2>/dev/null \
+            || echo "  WARNING: SkillSpector install failed (non-critical)"
+    fi
+fi
+if [[ -x "$SKILLSPECTOR_DIR/.venv/bin/skillspector" ]]; then
+    echo "  SkillSpector: installed at $SKILLSPECTOR_DIR/.venv/bin/skillspector"
+fi
 echo
 
 # --- Python venv ---
@@ -367,6 +387,13 @@ if ! "$VENV_DIR/bin/python" -c "from genesis.runtime import GenesisRuntime" 2>/d
     echo "  Re-run: $VENV_DIR/bin/pip install -e $GENESIS_ROOT --verbose"
     exit 1
 fi
+echo
+
+# --- Skill-security trusted baseline ---
+# Bless the currently-installed skills so the scheduled scan files findings only
+# for NEW/untrusted skills (a raw scan flags ~every capable skill as CRITICAL).
+echo "--- Seeding skill-security trusted allowlist ---"
+"$VENV_DIR/bin/python" -m genesis.security.skill_scan --seed-trusted 2>&1 | tail -1 || true
 echo
 
 # --- Secrets ---

--- a/src/genesis/mcp/recon_mcp.py
+++ b/src/genesis/mcp/recon_mcp.py
@@ -350,3 +350,22 @@ async def recon_run_model_intelligence() -> dict:
         db=_db, profile_registry=profile_registry, surplus_queue=_surplus_queue,
     )
     return await job.run()
+
+
+@mcp.tool()
+async def recon_run_skill_scan() -> dict:
+    """Run the skill-security scan on-demand (NVIDIA SkillSpector → recon findings).
+
+    Normally runs weekly (Monday 2am). Scans installed skills and files findings
+    for UNTRUSTED skills only — trusted-source skills (first-party + the
+    --seed-trusted allowlist) are scanned but kept out of recon to avoid noise.
+    Requires SkillSpector installed (see scripts/bootstrap.sh); returns a
+    {"skipped": ...} summary if the binary is missing.
+    """
+    if _db is None:
+        return {"error": "Database not initialized"}
+
+    from genesis.recon.skill_security_scan_job import SkillSecurityScanJob
+
+    job = SkillSecurityScanJob(db=_db)
+    return await job.run()

--- a/src/genesis/recon/skill_security_scan_job.py
+++ b/src/genesis/recon/skill_security_scan_job.py
@@ -30,6 +30,11 @@ logger = logging.getLogger(__name__)
 # Stable install path the bootstrap uses (see scripts/bootstrap.sh).
 _INSTALL_BIN = Path.home() / ".genesis" / "deps" / "skillspector" / ".venv" / "bin" / "skillspector"
 
+# Single source of truth for the file-it threshold: passed to scan_and_store
+# (which decides what reaches the DB) AND used to count the summary, so the
+# reported total can never disagree with what was actually stored.
+_MIN_SCORE = 1
+
 
 def _known_install_bin() -> str | None:
     return str(_INSTALL_BIN) if _INSTALL_BIN.is_file() else None
@@ -69,9 +74,10 @@ class SkillSecurityScanJob:
             return run_skillspector(skill_dir, skillspector_bin=binary, no_llm=True)
 
         results = await scan_and_store(
-            self._db, skill_dirs, scanner=scanner, storer=store_finding, trusted=trusted
+            self._db, skill_dirs, scanner=scanner, storer=store_finding,
+            trusted=trusted, min_score=_MIN_SCORE,
         )
-        filed = sum(1 for r in results if r.score >= 1 and not trusted(Path(r.source)))
+        filed = sum(1 for r in results if r.score >= _MIN_SCORE and not trusted(Path(r.source)))
         logger.info(
             "Skill-security scan: %d skills scanned, %d untrusted findings filed",
             len(results),

--- a/src/genesis/recon/skill_security_scan_job.py
+++ b/src/genesis/recon/skill_security_scan_job.py
@@ -1,0 +1,80 @@
+"""Scheduled skill-security scan recon job.
+
+Wraps the skill_scan logic as a SurplusScheduler job (mirrors
+``ModelIntelligenceJob``): resolve the SkillSpector binary, scan installed
+skills, file findings for UNTRUSTED skills only, and report a summary. If
+SkillSpector isn't installed it skips gracefully (never crashes the scheduler).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+
+from genesis.security.skill_scan import (
+    _default_roots,
+    _default_trusted_file,
+    _load_trusted_names,
+    _repo_skill_roots,
+    discover_skill_dirs,
+    is_trusted,
+    run_skillspector,
+    scan_and_store,
+    store_finding,
+)
+
+logger = logging.getLogger(__name__)
+
+# Stable install path the bootstrap uses (see scripts/bootstrap.sh).
+_INSTALL_BIN = Path.home() / ".genesis" / "deps" / "skillspector" / ".venv" / "bin" / "skillspector"
+
+
+def _known_install_bin() -> str | None:
+    return str(_INSTALL_BIN) if _INSTALL_BIN.is_file() else None
+
+
+class SkillSecurityScanJob:
+    """Weekly scan of installed skills via NVIDIA SkillSpector → recon findings."""
+
+    def __init__(self, *, db: object, skillspector_bin: str | None = None) -> None:
+        self._db = db
+        self._bin = skillspector_bin
+
+    def _resolve_bin(self) -> str | None:
+        """Explicit bin → SKILLSPECTOR_BIN env → bootstrap install path → PATH."""
+        return (
+            self._bin
+            or os.environ.get("SKILLSPECTOR_BIN")
+            or _known_install_bin()
+            or shutil.which("skillspector")
+        )
+
+    async def run(self) -> dict:
+        binary = self._resolve_bin()
+        if not binary:
+            logger.warning("SkillSpector binary not found — skipping skill-security scan")
+            return {"total_findings": 0, "skills_scanned": 0, "skipped": "skillspector not installed"}
+
+        roots = _default_roots()
+        skill_dirs = discover_skill_dirs(roots)
+        trusted_names = _load_trusted_names(_default_trusted_file())
+        trusted_roots = _repo_skill_roots()
+
+        def trusted(skill_dir: Path) -> bool:
+            return is_trusted(skill_dir, trusted_names=trusted_names, trusted_roots=trusted_roots)
+
+        def scanner(skill_dir: Path) -> dict | None:
+            return run_skillspector(skill_dir, skillspector_bin=binary, no_llm=True)
+
+        results = await scan_and_store(
+            self._db, skill_dirs, scanner=scanner, storer=store_finding, trusted=trusted
+        )
+        filed = sum(1 for r in results if r.score >= 1 and not trusted(Path(r.source)))
+        logger.info(
+            "Skill-security scan: %d skills scanned, %d untrusted findings filed",
+            len(results),
+            filed,
+        )
+        return {"total_findings": filed, "skills_scanned": len(results)}

--- a/src/genesis/runtime/init/surplus.py
+++ b/src/genesis/runtime/init/surplus.py
@@ -122,6 +122,18 @@ async def init(rt: GenesisRuntime) -> None:
             logger.error("Unexpected error wiring ModelsMdSynthesisJob", exc_info=True)
             await _degraded(rt, "ModelsMdSynthesisJob")
 
+        try:
+            from genesis.recon.skill_security_scan_job import SkillSecurityScanJob
+            skill_scan_job = SkillSecurityScanJob(db=rt._db)
+            rt._surplus_scheduler.set_skill_security_scan_job(skill_scan_job)
+            logger.info("SkillSecurityScanJob wired to surplus scheduler")
+        except (ImportError, AttributeError):
+            logger.error("Failed to wire SkillSecurityScanJob", exc_info=True)
+            await _degraded(rt, "SkillSecurityScanJob")
+        except Exception:
+            logger.error("Unexpected error wiring SkillSecurityScanJob", exc_info=True)
+            await _degraded(rt, "SkillSecurityScanJob")
+
         await rt._surplus_scheduler.start()
         logger.info("Genesis surplus scheduler started")
 

--- a/src/genesis/security/skill_scan.py
+++ b/src/genesis/security/skill_scan.py
@@ -9,9 +9,10 @@ its JSON report, and stores ranked findings as recon observations
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Awaitable, Callable, Iterable
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -181,14 +182,22 @@ async def scan_and_store(
     skills are scanned (for visibility) but kept out of recon to avoid swamping it
     with expected CRITICALs. A failed/timed-out scan (scanner returns None) is
     skipped, not fatal.
+
+    Each result's ``source`` is stamped with the actual scanned ``skill_dir`` (not
+    SkillSpector's self-reported ``skill.source``, which may be a URL/blank), so a
+    caller re-deriving filed/trusted counts via ``trusted(Path(r.source))`` agrees
+    with the filing decision made here. The scanner is a *blocking* subprocess, so
+    it is offloaded to a worker thread — callers run on the scheduler event loop.
     """
     results: list[ScanResult] = []
     for raw_dir in skill_dirs:
         skill_dir = Path(raw_dir)
-        report = scanner(skill_dir)
+        report = await asyncio.to_thread(scanner, skill_dir)
         if report is None:
             continue
-        result = parse_report(report)
+        # Stamp the authoritative provenance (the dir we scanned) over whatever
+        # SkillSpector reported, so trust/location consumers can't disagree.
+        result = replace(parse_report(report), source=str(skill_dir))
         results.append(result)
         if result.score >= min_score and not (trusted and trusted(skill_dir)):
             await storer(db, report_to_finding(result))
@@ -383,7 +392,11 @@ def main(argv: list[str] | None = None) -> int:
         names = sorted({d.name for d in skill_dirs})
         trusted_file.parent.mkdir(parents=True, exist_ok=True)
         trusted_file.write_text(
-            "# Trusted skill names — scanned but NOT filed to recon.\n" + "\n".join(names) + "\n"
+            "# Trusted skill names — scanned but NOT filed to recon.\n"
+            "# Seeded from the skills installed at this moment. Skills installed\n"
+            "# LATER are untrusted and will surface as recon findings until you\n"
+            "# re-bless them: python -m genesis.security.skill_scan --seed-trusted\n"
+            + "\n".join(names) + "\n"
         )
         print(f"Seeded {len(names)} trusted skill names -> {trusted_file}")
         return 0

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -128,6 +128,7 @@ class SurplusScheduler:
         self._recon_gatherer: ReconGatherer | None = None
         self._model_intelligence_job = None  # Set via set_model_intelligence_job()
         self._models_md_synthesis_job = None  # Set via set_models_md_synthesis_job()
+        self._skill_security_scan_job = None  # Set via set_skill_security_scan_job()
         self._extraction_store: MemoryStore | None = None
         self._extraction_router: Router | None = None
         self._follow_up_dispatcher = None  # Set via set_follow_up_dispatcher()
@@ -216,6 +217,10 @@ class SurplusScheduler:
     def set_models_md_synthesis_job(self, job) -> None:
         """Set the ModelsMdSynthesisJob for weekly models.md updates."""
         self._models_md_synthesis_job = job
+
+    def set_skill_security_scan_job(self, job) -> None:
+        """Set the SkillSecurityScanJob for the weekly skill-security scan."""
+        self._skill_security_scan_job = job
 
     def set_extraction_deps(
         self,
@@ -309,6 +314,15 @@ class SurplusScheduler:
                 self.run_models_md_synthesis,
                 CronTrigger(day_of_week="sun", hour=10, timezone=user_timezone()),
                 id="models_md_synthesis",
+                max_instances=1,
+                misfire_grace_time=3600,
+            )
+        # Skill-security scan: weekly Monday 2am — audits installed skills via SkillSpector.
+        if self._skill_security_scan_job is not None:
+            self._scheduler.add_job(
+                self.run_skill_security_scan,
+                CronTrigger(day_of_week="mon", hour=2, timezone=user_timezone()),
+                id="skill_security_scan",
                 max_instances=1,
                 misfire_grace_time=3600,
             )
@@ -1043,6 +1057,45 @@ class SurplusScheduler:
             try:
                 from genesis.runtime import GenesisRuntime
                 GenesisRuntime.instance().record_job_failure("model_intelligence", str(exc))
+            except Exception:
+                pass
+
+    async def run_skill_security_scan(self) -> None:
+        """Run the weekly skill-security scan (SkillSpector → recon findings)."""
+        if self._skill_security_scan_job is None:
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_failure(
+                    "skill_security_scan", "job not wired",
+                )
+            except Exception:
+                pass
+            return
+        try:
+            result = await self._skill_security_scan_job.run()
+            total = result.get("total_findings", 0)
+            logger.info("Skill-security scan: %d untrusted findings", total)
+            if self._event_bus:
+                await self._event_bus.emit(
+                    Subsystem.RECON, Severity.DEBUG,
+                    "heartbeat", "skill_security_scan completed",
+                )
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_success("skill_security_scan")
+            except Exception:
+                pass
+        except Exception as exc:
+            logger.exception("Skill-security scan failed")
+            if self._event_bus:
+                await self._event_bus.emit(
+                    Subsystem.RECON, Severity.ERROR,
+                    "skill_security_scan.failed",
+                    "Skill-security scan failed",
+                )
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_failure("skill_security_scan", str(exc))
             except Exception:
                 pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,47 @@ async def db():
     await wrapped.close()
 
 
+@pytest.fixture(autouse=True)
+def _guard_db_crud_not_mocked():
+    """Pin the test that leaks a Mock onto a real ``genesis.db.crud`` function.
+
+    A bare ``obs_crud.create = AsyncMock()`` — assigning a mock to a real module
+    attribute *without* ``monkeypatch``/``patch`` — is never restored. It then
+    silently poisons the shared ``db`` fixture for the rest of the session:
+    inserts return a truthy Mock but write nothing, so a distant victim test
+    reads 0 rows and fails mysteriously (cost us a multi-session hunt). This
+    guard makes the leak fail at the *offending* test instead.
+
+    Scoped to ``observations`` (the proven hotspot + highest-traffic crud
+    module). Autouse fixtures tear down *after* explicitly-requested fixtures,
+    so a legitimate ``monkeypatch.setattr(obs_crud, …)`` is already restored
+    when this check runs — no false positives. Cost: one ``isinstance`` sweep
+    of one small module's namespace per test.
+
+    Caveat: a *session*/*module*-scoped fixture that patches ``obs_crud`` and is
+    still active during a later function-scoped test's teardown would trip this
+    guard (no such fixture exists today). Use function scope, or set the mock on
+    a local object, if you ever need one.
+    """
+    from unittest.mock import Mock
+
+    import genesis.db.crud.observations as obs_crud
+
+    yield
+    leaked = sorted(
+        name
+        for name, obj in vars(obs_crud).items()
+        if not name.startswith("__") and isinstance(obj, Mock)
+    )
+    if leaked:
+        raise AssertionError(
+            "Test leaked unittest.mock object(s) onto real module "
+            f"genesis.db.crud.observations: {leaked}. Use monkeypatch.setattr "
+            "or `with patch(...)` so the patch is restored, or set the mock on a "
+            "local mock object — never assign to the real module attribute."
+        )
+
+
 @pytest.fixture
 async def empty_db():
     """In-memory SQLite database with tables but no seed data."""

--- a/tests/test_autonomy/test_autonomous_dispatch.py
+++ b/tests/test_autonomy/test_autonomous_dispatch.py
@@ -364,7 +364,13 @@ async def test_dispatch_router_records_dead_letter_when_api_only(approval_gate):
     assert kwargs.get("suppress_dead_letter") is False
 
 
-def test_load_autonomous_cli_policy_from_yaml(tmp_path: Path):
+def test_load_autonomous_cli_policy_from_yaml(tmp_path: Path, monkeypatch):
+    # Isolate the user-config overlay dir. merge_local_overlay() resolves
+    # ``~/.genesis/config/<stem>.local.yaml`` user-dir-first, so on any live
+    # install a real autonomous_cli_policy.local.yaml deep-merges over this
+    # test's tmp file and inverts the asserted values. Point the overlay dir at
+    # tmp_path (no overlay there) so the loader sees only what we wrote.
+    monkeypatch.setattr("genesis._config_overlay._user_config_dir", lambda: tmp_path)
     path = tmp_path / "autonomous_cli_policy.yaml"
     path.write_text(
         "autonomous_cli_fallback_enabled: false\n"

--- a/tests/test_recon/test_skill_security_scan_job.py
+++ b/tests/test_recon/test_skill_security_scan_job.py
@@ -1,0 +1,56 @@
+"""Tests for the scheduled skill-security scan recon job."""
+
+from __future__ import annotations
+
+from genesis.recon.skill_security_scan_job import SkillSecurityScanJob
+
+
+def test_resolve_bin_prefers_explicit_then_env(monkeypatch):
+    monkeypatch.setenv("SKILLSPECTOR_BIN", "/from/env/skillspector")
+    # Explicit bin wins over env.
+    assert SkillSecurityScanJob(db=None, skillspector_bin="/explicit/ss")._resolve_bin() == "/explicit/ss"
+    # Env wins when no explicit bin.
+    assert SkillSecurityScanJob(db=None)._resolve_bin() == "/from/env/skillspector"
+
+
+def test_resolve_bin_returns_none_when_nothing_found(monkeypatch):
+    monkeypatch.delenv("SKILLSPECTOR_BIN", raising=False)
+    import genesis.recon.skill_security_scan_job as mod
+
+    monkeypatch.setattr(mod.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(mod, "_known_install_bin", lambda: None)
+    assert SkillSecurityScanJob(db=None)._resolve_bin() is None
+
+
+async def test_run_skips_gracefully_when_binary_missing(monkeypatch):
+    job = SkillSecurityScanJob(db=None)
+    monkeypatch.setattr(job, "_resolve_bin", lambda: None)
+    result = await job.run()
+    # Missing scanner must NOT crash the scheduler — it returns a clean no-op summary.
+    assert result["total_findings"] == 0
+    assert result.get("skipped")
+
+
+async def test_run_delegates_and_summarizes(monkeypatch):
+    """run() resolves the binary, scans, and reports the untrusted-filed count."""
+    import genesis.recon.skill_security_scan_job as mod
+    from genesis.security.skill_scan import ScanResult
+
+    job = SkillSecurityScanJob(db=object(), skillspector_bin="/x/ss")
+    monkeypatch.setattr(mod, "discover_skill_dirs", lambda _roots: ["/x/bad", "/x/ok"])
+    monkeypatch.setattr(mod, "_load_trusted_names", lambda _p: {"ok"})
+    monkeypatch.setattr(mod, "_repo_skill_roots", lambda: [])
+
+    async def fake_scan_and_store(db, dirs, *, scanner, storer, trusted, **kw):
+        # Mimic the real shape: one untrusted finding, one trusted (skipped).
+        return [
+            ScanResult(name="bad", source="/x/bad", score=100, severity="CRITICAL", recommendation="x"),
+            ScanResult(name="ok", source="/x/ok", score=100, severity="CRITICAL", recommendation="x"),
+        ]
+
+    monkeypatch.setattr(mod, "scan_and_store", fake_scan_and_store)
+    monkeypatch.setattr(mod, "is_trusted", lambda d, **kw: d.name == "ok")
+
+    result = await job.run()
+    assert result["skills_scanned"] == 2
+    assert result["total_findings"] == 1  # only the untrusted "bad" counts

--- a/tests/test_recon/test_skill_security_scan_job.py
+++ b/tests/test_recon/test_skill_security_scan_job.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from genesis.recon.skill_security_scan_job import SkillSecurityScanJob
 
 
@@ -22,6 +24,7 @@ def test_resolve_bin_returns_none_when_nothing_found(monkeypatch):
     assert SkillSecurityScanJob(db=None)._resolve_bin() is None
 
 
+@pytest.mark.asyncio
 async def test_run_skips_gracefully_when_binary_missing(monkeypatch):
     job = SkillSecurityScanJob(db=None)
     monkeypatch.setattr(job, "_resolve_bin", lambda: None)
@@ -31,6 +34,7 @@ async def test_run_skips_gracefully_when_binary_missing(monkeypatch):
     assert result.get("skipped")
 
 
+@pytest.mark.asyncio
 async def test_run_delegates_and_summarizes(monkeypatch):
     """run() resolves the binary, scans, and reports the untrusted-filed count."""
     import genesis.recon.skill_security_scan_job as mod

--- a/tests/test_resilience/test_outreach_recovery.py
+++ b/tests/test_resilience/test_outreach_recovery.py
@@ -87,13 +87,16 @@ async def test_failed_retry_resets_to_pending(worker):
 @pytest.mark.asyncio
 async def test_exhausted_creates_observation(worker):
     """After max retries, item is discarded and observation created."""
+    from unittest.mock import patch
+
     item = _make_item(attempts=_MAX_RETRIES)
 
-    # Mock the observation create
-    import genesis.db.crud.observations as obs_crud
-    obs_crud.create = AsyncMock()
-
-    await worker._exhaust(item)
+    # Mock the observation create. Context-managed so the patch is RESTORED —
+    # a bare ``obs_crud.create = AsyncMock()`` leaks process-wide and turns
+    # every later real insert into a silent no-op, poisoning the shared ``db``
+    # fixture for the rest of the suite (returns an id but writes nothing).
+    with patch("genesis.db.crud.observations.create", new_callable=AsyncMock):
+        await worker._exhaust(item)
 
     worker._queue.mark_discarded.assert_awaited_once()
     assert "exhausted" in worker._queue.mark_discarded.call_args[0][1].lower()

--- a/tests/test_surplus/test_scheduler.py
+++ b/tests/test_surplus/test_scheduler.py
@@ -141,6 +141,22 @@ async def test_start_without_code_audits(db):
     await sched.stop()
 
 
+async def test_start_registers_skill_security_scan(db):
+    """A wired SkillSecurityScanJob registers its weekly cron job on start().
+
+    Locks the scheduler wiring end-to-end: proves start() resolves CronTrigger /
+    user_timezone in scope and registers the job under id 'skill_security_scan'.
+    A CronTrigger job does not enqueue surplus tasks, so the pending_count
+    assertions in the sibling start tests are unaffected.
+    """
+    sched, compute = _make_scheduler(db, idle=True)
+    sched.set_skill_security_scan_job(AsyncMock())
+    with patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False):
+        await sched.start()
+    assert sched._scheduler.get_job("skill_security_scan") is not None
+    await sched.stop()
+
+
 async def test_schedule_code_audit_noop_when_disabled(db):
     sched, compute = _make_scheduler(db, idle=True, enable_code_audits=False)
     # Direct call should be a no-op


### PR DESCRIPTION
## Summary

Two related pieces of work:

1. **Fix a latent test-suite contaminant** that silently poisoned the shared `db` fixture (it forced an earlier PR's storage test to go deterministic and cost a multi-session hunt).
2. **Operationalize the merged skill-security scan** (NVIDIA SkillSpector → recon findings) so it actually runs in production — it was code-complete but deploy-pending.

A third item — a **GitHub Discovery** recon engine — was scoped this round (design written to the internal spec doc) and is deliberately **not** in this PR; it's tracked as a follow-up.

## Task 1 — test contaminant + guard

Root cause: `tests/test_resilience/test_outreach_recovery.py` did `obs_crud.create = AsyncMock()` as a bare module-attribute assignment, never restored. It leaked process-wide — every later real insert returned a truthy Mock but wrote nothing, so a distant victim read 0 rows on its own connection and failed mysteriously (only in the full suite).

- Restore the patch via `with patch(...)` (matches the file's sibling tests).
- Add an **autouse conftest guard** that fails the *offending* test at teardown when it leaks a `unittest.mock` onto the real `genesis.db.crud.observations` module — so this class fails loudly at the source, not in a baffled victim downstream.

Verified RED→GREEN (12 failed → 123 passed on the minimal repro; the guard pins the leaker by name) and **0 false-positives across 4,464 tests**, including dirs that legitimately monkeypatch the guarded attribute (autouse teardown ordering restores those first).

Also fixes an unrelated, environment-specific test-isolation gap found along the way: `test_load_autonomous_cli_policy_from_yaml` didn't isolate the user-config `.local.yaml` overlay, so it failed on any live install (CI was green — no overlay there). Now pins the overlay dir to `tmp_path`.

## Task 2 — operationalize the skill-security scan

Wires the merged `genesis.security.skill_scan` for production, mirroring `ModelIntelligenceJob`:

- **`SkillSecurityScanJob`** (`recon/skill_security_scan_job.py`): resolves the binary (explicit → `SKILLSPECTOR_BIN` → install path → `PATH`), scans installed skills, files findings for **untrusted** skills only, and no-ops cleanly when the binary is absent.
- **SurplusScheduler**: `set_skill_security_scan_job` + `run_skill_security_scan` wrapper + a weekly `CronTrigger` (Mon 2am — never `IntervalTrigger`, which resets on restart). Wired in `runtime/init/surplus.py`.
- **`recon_run_skill_scan()`** MCP tool for on-demand runs (auto-exposed, like `recon_run_model_intelligence`).
- **`bootstrap.sh`**: installs NVIDIA SkillSpector to a stable path + a one-time `--seed-trusted` to bless the current install.

### Review fixes (also fix the Phase-A CLI, since `scan_and_store` is shared)
- The blocking SkillSpector subprocess now runs via `asyncio.to_thread`, so the weekly sweep can't stall the scheduler event loop.
- Each result's `source` is stamped with the actual scanned dir (not SkillSpector's self-reported field), so re-derived filed/trusted counts can't disagree with what was actually filed.

## Verification

- **Unit/integration**: job tests, Phase-A scan tests, and a new `test_surplus` test that locks job registration on `start()` (Level-4 wiring) — all green.
- **E2E against real SkillSpector v2.2.3**: `Discovered 97 skills; scanned 96 (1 timed out, skipped gracefully); filed 59 untrusted, 29 trusted-source skipped.` The CRITICAL/100 scorers are all first-party skills, correctly trust-skipped — confirming the "scan all, file untrusted only" design keeps the recon lane clean. Real JSON output parses correctly; `source` is the dir path.
- Reviewed by two independent agents; findings addressed.

## Notes / follow-ups (filed separately)
- GitHub Discovery recon engine (scoped, build next).
- Promote 4 private helpers in `skill_scan.py` to public (cross-package import smell).
- Add a `recon` capability-manifest entry for CC-session discoverability.
- Very large skills (e.g. tool-bundle skills) hit the 120s timeout and are skipped — safe today, a coverage gap worth future tuning.
