### PR TITLE
feat(follow-ups): cockpit dashboard tab — PR2 (manage/drain the backlog)

### DIFF
--- a/src/genesis/dashboard/routes/follow_ups.py
+++ b/src/genesis/dashboard/routes/follow_ups.py
@@ -293,7 +293,7 @@ async def follow_up_batch():
     ids = data.get("ids", [])
     notes = data.get("notes") or None
 
-    if not ids or action not in _BATCH_ACTIONS:
+    if not isinstance(ids, list) or not ids or action not in _BATCH_ACTIONS:
         return jsonify({"ok": False, "error": "Invalid action or empty ids"}), 400
     if len(ids) > 200:
         return jsonify({"ok": False, "error": "Too many ids (max 200)"}), 400

--- a/src/genesis/dashboard/routes/follow_ups.py
+++ b/src/genesis/dashboard/routes/follow_ups.py
@@ -298,13 +298,17 @@ async def follow_up_batch():
     if len(ids) > 200:
         return jsonify({"ok": False, "error": "Too many ids (max 200)"}), 400
 
-    if action == "done":
-        count = await follow_ups.update_status_batch(
-            rt.db, ids, "completed", resolution_notes=notes,
-        )
-    elif action == "delete":
-        count = await follow_ups.delete_batch(rt.db, ids)
-    else:  # "tabled" | "follow_up"
-        count = await follow_ups.set_kind_batch(rt.db, ids, action)
+    try:
+        if action == "done":
+            count = await follow_ups.update_status_batch(
+                rt.db, ids, "completed", resolution_notes=notes,
+            )
+        elif action == "delete":
+            count = await follow_ups.delete_batch(rt.db, ids)
+        else:  # "tabled" | "follow_up"
+            count = await follow_ups.set_kind_batch(rt.db, ids, action)
+    except Exception:
+        logger.error("Batch follow-up action %r failed", action, exc_info=True)
+        return jsonify({"ok": False, "error": "Batch action failed"}), 503
 
     return jsonify({"ok": True, "count": count})

--- a/src/genesis/dashboard/routes/follow_ups.py
+++ b/src/genesis/dashboard/routes/follow_ups.py
@@ -82,3 +82,229 @@ async def follow_up_summary():
     except Exception:
         logger.error("Failed to get follow-up summary", exc_info=True)
         return jsonify({"counts": {}, "total": 0})
+
+
+# ── Cockpit: the dedicated "Follow-ups" management tab ──────────────────
+# Read routes return an empty 200 when not bootstrapped (panel renders empty);
+# mutation routes return (…, 503) so the UI can surface a real failure.
+
+_COCKPIT_STATUSES = (
+    "pending", "scheduled", "in_progress", "completed", "failed", "blocked",
+)
+_BATCH_ACTIONS = ("done", "delete", "tabled", "follow_up")
+
+
+@blueprint.route("/api/genesis/follow-ups/cockpit")
+@_async_route
+async def follow_up_cockpit():
+    """Paginated/sorted/filtered follow-up list for the cockpit tab.
+
+    Query params: kind (follow_up|tabled|all), domain (internal|user_world|
+    __null__), status, source, search, sort, page, page_size.
+    """
+    from genesis.db.crud import follow_ups
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    empty = {"items": [], "total": 0, "page": 1, "page_size": 50}
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify(empty)
+
+    kind = request.args.get("kind", "").strip() or None
+    if kind == "all":
+        kind = None
+    domain = request.args.get("domain", "").strip() or None
+    status = request.args.get("status", "").strip() or None
+    source = request.args.get("source", "").strip() or None
+    search = request.args.get("search", "").strip() or None
+    sort = request.args.get("sort", "priority").strip() or "priority"
+    page = max(1, request.args.get("page", 1, type=int))
+    page_size = min(max(request.args.get("page_size", 50, type=int), 1), 200)
+
+    try:
+        items = await follow_ups.query_page(
+            rt.db, kind=kind, domain=domain, status=status, source=source,
+            search=search, sort=sort, offset=(page - 1) * page_size,
+            limit=page_size,
+        )
+        total = await follow_ups.count_filtered(
+            rt.db, kind=kind, domain=domain, status=status, source=source,
+            search=search,
+        )
+    except Exception:
+        logger.error("Failed to query follow-up cockpit", exc_info=True)
+        return jsonify(empty)
+
+    return jsonify({
+        "items": items, "total": total, "page": page, "page_size": page_size,
+    })
+
+
+@blueprint.route("/api/genesis/follow-ups/filters")
+@_async_route
+async def follow_up_filters():
+    """Distinct sources (dynamic) + the fixed status set, for cockpit dropdowns."""
+    from genesis.db.crud import follow_ups
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"sources": [], "statuses": list(_COCKPIT_STATUSES)})
+
+    try:
+        sources = await follow_ups.get_distinct_sources(rt.db)
+    except Exception:
+        logger.error("Failed to load follow-up filters", exc_info=True)
+        sources = []
+    return jsonify({"sources": sources, "statuses": list(_COCKPIT_STATUSES)})
+
+
+@blueprint.route("/api/genesis/follow-ups/<fid>/done", methods=["POST"])
+@_async_route
+async def follow_up_done(fid: str):
+    """Mark a follow-up Done (soft — status=completed, row kept)."""
+    from genesis.db.crud import follow_ups
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"ok": False, "error": "Not bootstrapped"}), 503
+
+    notes = (request.get_json(silent=True) or {}).get("notes") or None
+    ok = await follow_ups.update_status(
+        rt.db, fid, "completed", resolution_notes=notes,
+    )
+    if not ok:
+        return jsonify({"ok": False, "error": "Not found"}), 404
+    return jsonify({"ok": True})
+
+
+@blueprint.route("/api/genesis/follow-ups/<fid>/delete", methods=["POST"])
+@_async_route
+async def follow_up_delete(fid: str):
+    """Permanently delete a follow-up (UI gates this behind a confirm)."""
+    from genesis.db.crud import follow_ups
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"ok": False, "error": "Not bootstrapped"}), 503
+
+    ok = await follow_ups.delete(rt.db, fid)
+    if not ok:
+        return jsonify({"ok": False, "error": "Not found"}), 404
+    return jsonify({"ok": True})
+
+
+@blueprint.route("/api/genesis/follow-ups/<fid>/pin", methods=["POST"])
+@_async_route
+async def follow_up_pin(fid: str):
+    """Pin/unpin a follow-up."""
+    from genesis.db.crud import follow_ups
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"ok": False, "error": "Not bootstrapped"}), 503
+
+    pinned = bool((request.get_json(silent=True) or {}).get("pinned"))
+    ok = await follow_ups.set_pinned(rt.db, fid, pinned)
+    if not ok:
+        return jsonify({"ok": False, "error": "Not found"}), 404
+    return jsonify({"ok": True, "pinned": pinned})
+
+
+@blueprint.route("/api/genesis/follow-ups/<fid>/priority", methods=["POST"])
+@_async_route
+async def follow_up_priority(fid: str):
+    """Change a follow-up's priority."""
+    from genesis.db.crud import follow_ups
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"ok": False, "error": "Not bootstrapped"}), 503
+
+    priority = (request.get_json(silent=True) or {}).get("priority", "")
+    try:
+        ok = await follow_ups.set_priority(rt.db, fid, priority)
+    except ValueError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
+    if not ok:
+        return jsonify({"ok": False, "error": "Not found"}), 404
+    return jsonify({"ok": True, "priority": priority})
+
+
+@blueprint.route("/api/genesis/follow-ups/<fid>/kind", methods=["POST"])
+@_async_route
+async def follow_up_kind(fid: str):
+    """Move a follow-up between the follow_up and tabled lanes."""
+    from genesis.db.crud import follow_ups
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"ok": False, "error": "Not bootstrapped"}), 503
+
+    kind = (request.get_json(silent=True) or {}).get("kind", "")
+    try:
+        ok = await follow_ups.set_kind(rt.db, fid, kind)
+    except ValueError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
+    if not ok:
+        return jsonify({"ok": False, "error": "Not found"}), 404
+    return jsonify({"ok": True, "kind": kind})
+
+
+@blueprint.route("/api/genesis/follow-ups/<fid>/domain", methods=["POST"])
+@_async_route
+async def follow_up_domain(fid: str):
+    """Override a follow-up's domain (or clear it with an empty value)."""
+    from genesis.db.crud import follow_ups
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"ok": False, "error": "Not bootstrapped"}), 503
+
+    domain = (request.get_json(silent=True) or {}).get("domain") or None
+    try:
+        ok = await follow_ups.set_domain(rt.db, fid, domain)
+    except ValueError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
+    if not ok:
+        return jsonify({"ok": False, "error": "Not found"}), 404
+    return jsonify({"ok": True, "domain": domain})
+
+
+@blueprint.route("/api/genesis/follow-ups/batch", methods=["POST"])
+@_async_route
+async def follow_up_batch():
+    """Batch action over a selection (max 200): done/delete/tabled/follow_up."""
+    from genesis.db.crud import follow_ups
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"ok": False, "error": "Not bootstrapped"}), 503
+
+    data = request.get_json(silent=True) or {}
+    action = data.get("action")
+    ids = data.get("ids", [])
+    notes = data.get("notes") or None
+
+    if not ids or action not in _BATCH_ACTIONS:
+        return jsonify({"ok": False, "error": "Invalid action or empty ids"}), 400
+    if len(ids) > 200:
+        return jsonify({"ok": False, "error": "Too many ids (max 200)"}), 400
+
+    if action == "done":
+        count = await follow_ups.update_status_batch(
+            rt.db, ids, "completed", resolution_notes=notes,
+        )
+    elif action == "delete":
+        count = await follow_ups.delete_batch(rt.db, ids)
+    else:  # "tabled" | "follow_up"
+        count = await follow_ups.set_kind_batch(rt.db, ids, action)
+
+    return jsonify({"ok": True, "count": count})

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -9171,6 +9171,7 @@
         <!-- Filter bar -->
         <div style="display:flex; gap:0.25rem; margin-bottom:0.75rem; flex-wrap:wrap; align-items:center;">
           <select style="font-size:0.68rem; padding:0.2rem 0.3rem; border-radius:3px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);"
+                  :value="$store.genesisDashboard.cockpitFilters.domain"
                   @change="$store.genesisDashboard.cockpitFilters.domain = $event.target.value; $store.genesisDashboard.cockpitApplyFilter()">
             <option value="">All domains</option>
             <option value="internal">Internal</option>
@@ -9179,6 +9180,7 @@
           </select>
 
           <select style="font-size:0.68rem; padding:0.2rem 0.3rem; border-radius:3px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);"
+                  :value="$store.genesisDashboard.cockpitFilters.status"
                   @change="$store.genesisDashboard.cockpitFilters.status = $event.target.value; $store.genesisDashboard.cockpitApplyFilter()">
             <option value="">All statuses</option>
             <template x-for="s in $store.genesisDashboard.cockpitAvailableFilters.statuses" :key="s">
@@ -9187,6 +9189,7 @@
           </select>
 
           <select style="font-size:0.68rem; padding:0.2rem 0.3rem; border-radius:3px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);"
+                  :value="$store.genesisDashboard.cockpitFilters.source"
                   @change="$store.genesisDashboard.cockpitFilters.source = $event.target.value; $store.genesisDashboard.cockpitApplyFilter()">
             <option value="">All sources</option>
             <template x-for="s in $store.genesisDashboard.cockpitAvailableFilters.sources" :key="s">
@@ -9195,6 +9198,7 @@
           </select>
 
           <select style="font-size:0.68rem; padding:0.2rem 0.3rem; border-radius:3px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);"
+                  :value="$store.genesisDashboard.cockpitSort"
                   @change="$store.genesisDashboard.cockpitSort = $event.target.value; $store.genesisDashboard.cockpitApplyFilter()">
             <option value="priority">Sort: Priority</option>
             <option value="created_desc">Sort: Newest</option>
@@ -9204,6 +9208,7 @@
           </select>
 
           <input type="text" placeholder="Search content/reason… (Enter)"
+                 :value="$store.genesisDashboard.cockpitFilters.search"
                  @keydown.enter="$store.genesisDashboard.cockpitFilters.search = $event.target.value; $store.genesisDashboard.cockpitApplyFilter()"
                  style="font-size:0.68rem; padding:0.2rem 0.4rem; border-radius:3px; min-width:160px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);">
 

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -26,7 +26,7 @@
       Alpine.store("genesisDashboard", {
         // Tab state
         activeTab: "overview",
-        _tabInitialized: { overview: false, chat: false, internals: false, config: false, files: false, work: false, observations: false, traces: false, autonomy: false, memory: false, knowledge: false, backup: false },
+        _tabInitialized: { overview: false, chat: false, internals: false, config: false, files: false, work: false, "follow-ups": false, observations: false, traces: false, autonomy: false, memory: false, knowledge: false, backup: false },
 
         // State
         health: {},
@@ -301,6 +301,7 @@
         _workSessionsInterval: null,
         _followUpsInterval: null,
         _observationsInterval: null,
+        _cockpitInterval: null,
         _commsInterval: null,
         _tracesInterval: null,
 
@@ -315,6 +316,18 @@
         observationsResolving: {},
         observationsMarkingRead: {},
         observationsBatchIds: {},
+
+        // Follow-ups cockpit tab state
+        cockpitList: [],
+        cockpitTotal: 0,
+        cockpitPage: 1,
+        cockpitPageSize: 50,
+        cockpitFilters: { kind: 'follow_up', domain: '', status: '', source: '', search: '' },
+        cockpitSort: 'priority',
+        cockpitAvailableFilters: { sources: [], statuses: [] },
+        cockpitExpanded: null,
+        cockpitBatchIds: {},
+        cockpitMutating: {},
 
         // Traces tab state
         tracesList: [],
@@ -340,6 +353,7 @@
           files:     [],
           work:      ["_tasksInterval", "_workSessionsInterval", "_followUpsInterval"],
           observations: ["_observationsInterval"],
+          "follow-ups": ["_cockpitInterval"],
           traces:    ["_tracesInterval"],
           autonomy:  ["_autonomyInterval"],
           memory:    [],
@@ -349,7 +363,7 @@
 
         initTab() {
           const hash = location.hash.replace("#", "") || "overview";
-          const valid = ["overview", "chat", "internals", "config", "files", "work", "observations", "traces", "autonomy", "memory", "knowledge", "references", "backup"];
+          const valid = ["overview", "chat", "internals", "config", "files", "work", "follow-ups", "observations", "traces", "autonomy", "memory", "knowledge", "references", "backup"];
           this.activeTab = valid.includes(hash) ? hash : "overview";
           window.addEventListener("hashchange", () => {
             const h = location.hash.replace("#", "");
@@ -411,6 +425,10 @@
             case "observations":
               if (first) { this.fetchObservations(); this.fetchObservationsSummary(); this.fetchObservationsFilters(); }
               this._observationsInterval = setInterval(() => { this.fetchObservations(); this.fetchObservationsSummary(); }, 30000);
+              break;
+            case "follow-ups":
+              if (first) { this.fetchCockpit(); this.fetchCockpitFilters(); }
+              this._cockpitInterval = setInterval(() => this.fetchCockpit(), 30000);
               break;
             case "traces":
               if (first) { this.fetchSpansRecent(); }
@@ -1018,6 +1036,96 @@
         },
         get observationsBatchCount() {
           return Object.keys(this.observationsBatchIds).filter(k => this.observationsBatchIds[k]).length;
+        },
+
+        // ── Follow-ups cockpit tab ───────────────────────────────
+        async fetchCockpit() {
+          try {
+            const f = this.cockpitFilters;
+            const params = new URLSearchParams();
+            if (f.kind) params.set("kind", f.kind);
+            if (f.domain) params.set("domain", f.domain);
+            if (f.status) params.set("status", f.status);
+            if (f.source) params.set("source", f.source);
+            if (f.search) params.set("search", f.search);
+            params.set("sort", this.cockpitSort);
+            params.set("page", String(this.cockpitPage));
+            params.set("page_size", String(this.cockpitPageSize));
+            const resp = await fetchApi(`/api/genesis/follow-ups/cockpit?${params}`);
+            if (resp && resp.ok) {
+              const data = await resp.json();
+              this.cockpitList = data.items || [];
+              this.cockpitTotal = data.total || 0;
+            }
+          } catch (e) { console.warn("Cockpit fetch failed:", e); }
+        },
+        async fetchCockpitFilters() {
+          try {
+            const resp = await fetchApi("/api/genesis/follow-ups/filters");
+            if (resp && resp.ok) { this.cockpitAvailableFilters = await resp.json(); }
+          } catch (e) { console.warn("Cockpit filters fetch failed:", e); }
+        },
+        cockpitApplyFilter() {
+          this.cockpitPage = 1;   // reset paging whenever a filter changes
+          this.fetchCockpit();
+        },
+        get cockpitTotalPages() {
+          return Math.max(1, Math.ceil(this.cockpitTotal / this.cockpitPageSize));
+        },
+        cockpitPrevPage() {
+          if (this.cockpitPage > 1) { this.cockpitPage--; this.fetchCockpit(); }
+        },
+        cockpitNextPage() {
+          if (this.cockpitPage < this.cockpitTotalPages) { this.cockpitPage++; this.fetchCockpit(); }
+        },
+        async _cockpitMutate(id, path, body) {
+          this.cockpitMutating = { ...this.cockpitMutating, [id]: true };
+          try {
+            const resp = await fetchApi(`/api/genesis/follow-ups/${id}${path}`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(body || {}),
+            });
+            if (resp && resp.ok) { await this.fetchCockpit(); return true; }
+          } catch (e) { console.warn("Cockpit mutate failed:", e); }
+          finally { const { [id]: _, ...rest } = this.cockpitMutating; this.cockpitMutating = rest; }
+          return false;
+        },
+        cockpitDone(id) { return this._cockpitMutate(id, '/done', {}); },
+        cockpitPin(id, pinned) { return this._cockpitMutate(id, '/pin', { pinned }); },
+        cockpitSetPriority(id, priority) { return this._cockpitMutate(id, '/priority', { priority }); },
+        cockpitMoveKind(id, kind) { return this._cockpitMutate(id, '/kind', { kind }); },
+        cockpitSetDomain(id, d) {
+          const domain = (d === '__clear__') ? '' : d;
+          return this._cockpitMutate(id, '/domain', { domain });
+        },
+        cockpitDelete(id) {
+          if (!confirm('Delete this follow-up forever? This cannot be undone.')) return;
+          return this._cockpitMutate(id, '/delete', {});
+        },
+        async cockpitBatch(action) {
+          const ids = Object.keys(this.cockpitBatchIds).filter(k => this.cockpitBatchIds[k]);
+          if (!ids.length) return;
+          if (action === 'delete' && !confirm(`Delete ${ids.length} follow-up(s) forever? This cannot be undone.`)) return;
+          try {
+            const resp = await fetchApi("/api/genesis/follow-ups/batch", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ action, ids }),
+            });
+            if (resp && resp.ok) { this.cockpitBatchIds = {}; await this.fetchCockpit(); }
+          } catch (e) { console.warn("Cockpit batch failed:", e); }
+        },
+        toggleCockpitBatch(id) {
+          if (this.cockpitBatchIds[id]) {
+            const { [id]: _, ...rest } = this.cockpitBatchIds;
+            this.cockpitBatchIds = rest;
+          } else {
+            this.cockpitBatchIds = { ...this.cockpitBatchIds, [id]: true };
+          }
+        },
+        get cockpitBatchCount() {
+          return Object.keys(this.cockpitBatchIds).filter(k => this.cockpitBatchIds[k]).length;
         },
 
         // ── Traces tab (trace waterfall) ─────────────────────────
@@ -4191,6 +4299,8 @@
               @click="location.hash = 'chat'">Chat</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'work' }"
               @click="location.hash = 'work'">Work</button>
+      <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'follow-ups' }"
+              @click="location.hash = 'follow-ups'">Follow-ups</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'observations' }"
               @click="location.hash = 'observations'">Observations
         <span x-show="$store.genesisDashboard.observationsCounts.total_unsurfaced > 0"
@@ -9032,6 +9142,221 @@
         <div x-show="$store.genesisDashboard.observationsHasMore"
              style="text-align:center; padding:0.5rem; font-size:0.65rem; color:var(--color-text-secondary);">
           Showing first 50 results. Use filters to narrow down.
+        </div>
+      </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════════════════════
+         Panel: Follow-ups cockpit [Tab: follow-ups]
+         ═══════════════════════════════════════════════════════════ -->
+    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'follow-ups'">
+      <div class="panel-header">
+        <span class="material-symbols-outlined">checklist</span>
+        Follow-ups
+        <span class="panel-status" x-show="$store.genesisDashboard.cockpitTotal > 0">
+          <span x-text="$store.genesisDashboard.cockpitTotal + ' shown'"></span>
+        </span>
+      </div>
+      <div class="panel-body">
+        <!-- Tier toggle: follow_up | tabled | all -->
+        <div style="display:flex; gap:0.25rem; margin-bottom:0.6rem; align-items:center; flex-wrap:wrap;">
+          <template x-for="tier in [{k:'follow_up',l:'Follow-ups'},{k:'tabled',l:'Tabled'},{k:'',l:'All'}]" :key="tier.l">
+            <button style="font-size:0.7rem; padding:0.2rem 0.7rem; border-radius:3px; cursor:pointer; border:1px solid #555;"
+                    :style="$store.genesisDashboard.cockpitFilters.kind === tier.k ? 'background:rgba(33,150,243,0.18); color:#2196F3; border-color:rgba(33,150,243,0.4); font-weight:600;' : 'background:transparent; color:var(--color-text-secondary);'"
+                    @click="$store.genesisDashboard.cockpitFilters.kind = tier.k; $store.genesisDashboard.cockpitApplyFilter()"
+                    x-text="tier.l"></button>
+          </template>
+        </div>
+
+        <!-- Filter bar -->
+        <div style="display:flex; gap:0.25rem; margin-bottom:0.75rem; flex-wrap:wrap; align-items:center;">
+          <select style="font-size:0.68rem; padding:0.2rem 0.3rem; border-radius:3px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);"
+                  @change="$store.genesisDashboard.cockpitFilters.domain = $event.target.value; $store.genesisDashboard.cockpitApplyFilter()">
+            <option value="">All domains</option>
+            <option value="internal">Internal</option>
+            <option value="user_world">User world</option>
+            <option value="__null__">Unclassified</option>
+          </select>
+
+          <select style="font-size:0.68rem; padding:0.2rem 0.3rem; border-radius:3px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);"
+                  @change="$store.genesisDashboard.cockpitFilters.status = $event.target.value; $store.genesisDashboard.cockpitApplyFilter()">
+            <option value="">All statuses</option>
+            <template x-for="s in $store.genesisDashboard.cockpitAvailableFilters.statuses" :key="s">
+              <option :value="s" x-text="s"></option>
+            </template>
+          </select>
+
+          <select style="font-size:0.68rem; padding:0.2rem 0.3rem; border-radius:3px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);"
+                  @change="$store.genesisDashboard.cockpitFilters.source = $event.target.value; $store.genesisDashboard.cockpitApplyFilter()">
+            <option value="">All sources</option>
+            <template x-for="s in $store.genesisDashboard.cockpitAvailableFilters.sources" :key="s">
+              <option :value="s" x-text="s"></option>
+            </template>
+          </select>
+
+          <select style="font-size:0.68rem; padding:0.2rem 0.3rem; border-radius:3px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);"
+                  @change="$store.genesisDashboard.cockpitSort = $event.target.value; $store.genesisDashboard.cockpitApplyFilter()">
+            <option value="priority">Sort: Priority</option>
+            <option value="created_desc">Sort: Newest</option>
+            <option value="created_asc">Sort: Oldest</option>
+            <option value="status">Sort: Status</option>
+            <option value="source">Sort: Source</option>
+          </select>
+
+          <input type="text" placeholder="Search content/reason… (Enter)"
+                 @keydown.enter="$store.genesisDashboard.cockpitFilters.search = $event.target.value; $store.genesisDashboard.cockpitApplyFilter()"
+                 style="font-size:0.68rem; padding:0.2rem 0.4rem; border-radius:3px; min-width:160px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);">
+
+          <!-- Batch actions -->
+          <template x-if="$store.genesisDashboard.cockpitBatchCount > 0">
+            <div style="margin-left:auto; display:flex; gap:0.25rem; align-items:center;">
+              <span style="font-size:0.62rem; color:var(--color-text-secondary);" x-text="$store.genesisDashboard.cockpitBatchCount + ' selected'"></span>
+              <button style="font-size:0.65rem; padding:0.15rem 0.5rem; border-radius:3px; cursor:pointer; background:rgba(102,187,106,0.1); color:#66bb6a; border:1px solid rgba(102,187,106,0.2);"
+                      @click="$store.genesisDashboard.cockpitBatch('done')">Done</button>
+              <button style="font-size:0.65rem; padding:0.15rem 0.5rem; border-radius:3px; cursor:pointer; background:rgba(149,117,205,0.12); color:#9575cd; border:1px solid rgba(149,117,205,0.25);"
+                      @click="$store.genesisDashboard.cockpitBatch('tabled')">Table</button>
+              <button style="font-size:0.65rem; padding:0.15rem 0.5rem; border-radius:3px; cursor:pointer; background:rgba(33,150,243,0.1); color:#2196F3; border:1px solid rgba(33,150,243,0.2);"
+                      @click="$store.genesisDashboard.cockpitBatch('follow_up')">Un-table</button>
+              <button style="font-size:0.65rem; padding:0.15rem 0.5rem; border-radius:3px; cursor:pointer; background:rgba(244,67,54,0.1); color:#ef5350; border:1px solid rgba(244,67,54,0.25);"
+                      @click="$store.genesisDashboard.cockpitBatch('delete')">Delete</button>
+            </div>
+          </template>
+        </div>
+
+        <!-- Empty state -->
+        <template x-if="$store.genesisDashboard.cockpitList.length === 0">
+          <div style="padding:1.5rem; text-align:center; color:var(--color-text-secondary); font-size:0.75rem;">
+            No follow-ups match these filters.
+          </div>
+        </template>
+
+        <!-- Follow-up list -->
+        <div class="activity-feed">
+          <template x-for="item in $store.genesisDashboard.cockpitList" :key="item.id">
+            <div>
+              <div class="activity-row" style="cursor:pointer; display:flex; align-items:center; gap:0.5rem;"
+                   @click="$store.genesisDashboard.cockpitExpanded = $store.genesisDashboard.cockpitExpanded === item.id ? null : item.id">
+                <!-- Batch checkbox -->
+                <input type="checkbox" @click.stop
+                       :checked="!!$store.genesisDashboard.cockpitBatchIds[item.id]"
+                       @change="$store.genesisDashboard.toggleCockpitBatch(item.id)"
+                       style="width:12px; height:12px; cursor:pointer; flex-shrink:0;">
+                <!-- Pinned -->
+                <span x-show="item.pinned" title="Pinned" style="color:#ffd54f; font-size:0.8rem; flex-shrink:0;">★</span>
+                <!-- Priority badge -->
+                <span style="font-size:0.6rem; padding:0.1rem 0.35rem; border-radius:3px; font-weight:600; text-transform:uppercase; flex-shrink:0; min-width:3rem; text-align:center;"
+                      :style="{
+                        critical: 'background:rgba(244,67,54,0.15); color:#f44336',
+                        high: 'background:rgba(255,152,0,0.15); color:#ff9800',
+                        medium: 'background:rgba(255,193,7,0.15); color:#ffc107',
+                        low: 'background:rgba(158,158,158,0.15); color:#9e9e9e'
+                      }[item.priority] || ''"
+                      x-text="item.priority"></span>
+                <!-- Status badge -->
+                <span style="font-size:0.55rem; padding:0.1rem 0.3rem; border-radius:3px; font-weight:600; text-transform:uppercase; flex-shrink:0;"
+                      :style="{
+                        pending:     'background:rgba(158,158,158,0.15); color:#9e9e9e',
+                        scheduled:   'background:rgba(149,117,205,0.15); color:#9575cd',
+                        in_progress: 'background:rgba(33,150,243,0.15); color:#2196F3',
+                        blocked:     'background:rgba(255,167,38,0.15); color:#ffa726',
+                        completed:   'background:rgba(102,187,106,0.15); color:#66bb6a',
+                        failed:      'background:rgba(244,67,54,0.15); color:#ef5350'
+                      }[item.status] || 'background:rgba(158,158,158,0.15); color:#9e9e9e'"
+                      x-text="item.status"></span>
+                <!-- Tabled chip -->
+                <span x-show="item.kind === 'tabled'" title="Tabled (someday/maybe)"
+                      style="font-size:0.52rem; padding:0.1rem 0.3rem; border-radius:3px; font-weight:600; text-transform:uppercase; flex-shrink:0; background:rgba(149,117,205,0.12); color:#9575cd;">tabled</span>
+                <!-- Domain chip -->
+                <span style="font-size:0.52rem; padding:0.1rem 0.3rem; border-radius:3px; flex-shrink:0; letter-spacing:0.02em;"
+                      :style="{
+                        internal:   'background:rgba(100,181,246,0.13); color:#64b5f6',
+                        user_world: 'background:rgba(129,199,132,0.13); color:#81c784'
+                      }[item.domain] || 'background:rgba(158,158,158,0.1); color:#9e9e9e'"
+                      x-text="item.domain || 'unclassified'"></span>
+                <!-- Content preview -->
+                <span style="flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-size:0.72rem;"
+                      x-text="item.content || item.id"></span>
+                <!-- Timestamp (date+time — rows can be weeks old) -->
+                <span style="color:var(--color-text-secondary); font-size:0.63rem; flex-shrink:0;"
+                      x-text="$store.genesisDashboard.formatDateTime(item.created_at)"></span>
+                <!-- Expand arrow -->
+                <span class="material-symbols-outlined" style="font-size:0.9rem; color:var(--color-text-secondary); transition:transform 0.15s;"
+                      :style="$store.genesisDashboard.cockpitExpanded === item.id ? 'transform:rotate(90deg)' : ''">chevron_right</span>
+              </div>
+
+              <!-- Expanded detail -->
+              <template x-if="$store.genesisDashboard.cockpitExpanded === item.id">
+                <div style="padding:0.5rem 0.75rem; background:rgba(0,0,0,0.15); border-radius:4px; margin:0.25rem 0 0.5rem 1.5rem; font-size:0.72rem;">
+                  <div style="margin-bottom:0.4rem; line-height:1.5; white-space:pre-wrap; word-break:break-word;" x-text="item.content"></div>
+                  <template x-if="item.reason">
+                    <div style="margin-bottom:0.3rem; color:var(--color-text-secondary); font-size:0.68rem;">
+                      <strong>Reason:</strong> <span x-text="item.reason"></span>
+                    </div>
+                  </template>
+                  <div style="display:flex; gap:0.5rem; font-size:0.62rem; color:var(--color-text-secondary); flex-wrap:wrap; margin-bottom:0.4rem;">
+                    <span x-text="'Strategy: ' + (item.strategy || 'unknown')"></span>
+                    <span x-text="'Source: ' + (item.source || 'unknown')"></span>
+                    <span x-text="'Created: ' + $store.genesisDashboard.formatDateTime(item.created_at)"></span>
+                  </div>
+                  <template x-if="item.resolution_notes">
+                    <div style="margin-top:0.3rem; padding:0.25rem 0.5rem; background:rgba(102,187,106,0.08); border-radius:3px; font-size:0.65rem;">
+                      <strong style="color:#66bb6a;">Resolution:</strong> <span x-text="item.resolution_notes"></span>
+                    </div>
+                  </template>
+                  <template x-if="item.blocked_reason">
+                    <div style="margin-top:0.3rem; padding:0.25rem 0.5rem; background:rgba(255,167,38,0.08); border-radius:3px; border:1px solid rgba(255,167,38,0.15); font-size:0.65rem;">
+                      <strong style="color:#ffa726;">Blocked:</strong> <span x-text="item.blocked_reason"></span>
+                    </div>
+                  </template>
+                  <!-- Actions -->
+                  <div style="display:flex; gap:0.3rem; margin-top:0.5rem; align-items:center; flex-wrap:wrap;"
+                       :style="$store.genesisDashboard.cockpitMutating[item.id] ? 'opacity:0.5; pointer-events:none;' : ''">
+                    <button @click.stop="$store.genesisDashboard.cockpitDone(item.id)"
+                            x-show="item.status !== 'completed'"
+                            style="font-size:0.65rem; padding:0.15rem 0.5rem; border-radius:3px; cursor:pointer; background:rgba(102,187,106,0.1); color:#66bb6a; border:1px solid rgba(102,187,106,0.2);">Done</button>
+                    <button @click.stop="$store.genesisDashboard.cockpitPin(item.id, !item.pinned)"
+                            style="font-size:0.65rem; padding:0.15rem 0.5rem; border-radius:3px; cursor:pointer; background:rgba(255,213,79,0.1); color:#ffd54f; border:1px solid rgba(255,213,79,0.2);"
+                            x-text="item.pinned ? 'Unpin' : 'Pin'"></button>
+                    <select @click.stop
+                            @change.stop="if($event.target.value){ $store.genesisDashboard.cockpitSetPriority(item.id, $event.target.value); $event.target.selectedIndex=0; }"
+                            style="font-size:0.63rem; padding:0.15rem 0.3rem; border-radius:3px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);">
+                      <option value="">Priority…</option>
+                      <option value="critical">Critical</option>
+                      <option value="high">High</option>
+                      <option value="medium">Medium</option>
+                      <option value="low">Low</option>
+                    </select>
+                    <button x-show="item.kind !== 'tabled'" @click.stop="$store.genesisDashboard.cockpitMoveKind(item.id, 'tabled')"
+                            style="font-size:0.65rem; padding:0.15rem 0.5rem; border-radius:3px; cursor:pointer; background:rgba(149,117,205,0.1); color:#9575cd; border:1px solid rgba(149,117,205,0.25);">→ Tabled</button>
+                    <button x-show="item.kind === 'tabled'" @click.stop="$store.genesisDashboard.cockpitMoveKind(item.id, 'follow_up')"
+                            style="font-size:0.65rem; padding:0.15rem 0.5rem; border-radius:3px; cursor:pointer; background:rgba(33,150,243,0.1); color:#2196F3; border:1px solid rgba(33,150,243,0.2);">→ Follow-up</button>
+                    <select @click.stop
+                            @change.stop="$store.genesisDashboard.cockpitSetDomain(item.id, $event.target.value); $event.target.selectedIndex=0;"
+                            style="font-size:0.63rem; padding:0.15rem 0.3rem; border-radius:3px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);">
+                      <option value="">Domain…</option>
+                      <option value="internal">Internal</option>
+                      <option value="user_world">User world</option>
+                      <option value="__clear__">Clear</option>
+                    </select>
+                    <button @click.stop="$store.genesisDashboard.cockpitDelete(item.id)"
+                            style="font-size:0.65rem; padding:0.15rem 0.5rem; border-radius:3px; cursor:pointer; background:rgba(244,67,54,0.1); color:#ef5350; border:1px solid rgba(244,67,54,0.25); margin-left:auto;">Delete</button>
+                  </div>
+                </div>
+              </template>
+            </div>
+          </template>
+        </div>
+
+        <!-- Pagination -->
+        <div x-show="$store.genesisDashboard.cockpitTotal > 0"
+             style="display:flex; gap:0.5rem; align-items:center; justify-content:center; padding:0.6rem; font-size:0.68rem; color:var(--color-text-secondary);">
+          <button @click="$store.genesisDashboard.cockpitPrevPage()" :disabled="$store.genesisDashboard.cockpitPage <= 1"
+                  style="font-size:0.65rem; padding:0.15rem 0.6rem; border-radius:3px; cursor:pointer; background:rgba(33,150,243,0.1); color:#2196F3; border:1px solid rgba(33,150,243,0.2);"
+                  :style="$store.genesisDashboard.cockpitPage <= 1 ? 'opacity:0.4; cursor:default;' : ''">Prev</button>
+          <span x-text="'Page ' + $store.genesisDashboard.cockpitPage + ' of ' + $store.genesisDashboard.cockpitTotalPages + ' · ' + $store.genesisDashboard.cockpitTotal + ' items'"></span>
+          <button @click="$store.genesisDashboard.cockpitNextPage()" :disabled="$store.genesisDashboard.cockpitPage >= $store.genesisDashboard.cockpitTotalPages"
+                  style="font-size:0.65rem; padding:0.15rem 0.6rem; border-radius:3px; cursor:pointer; background:rgba(33,150,243,0.1); color:#2196F3; border:1px solid rgba(33,150,243,0.2);"
+                  :style="$store.genesisDashboard.cockpitPage >= $store.genesisDashboard.cockpitTotalPages ? 'opacity:0.4; cursor:default;' : ''">Next</button>
         </div>
       </div>
     </div>

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -399,6 +399,9 @@ async def get_recently_completed(
 _VALID_KIND = {"follow_up", "tabled"}
 _VALID_DOMAIN = {"internal", "user_world"}
 _VALID_PRIORITY = {"low", "medium", "high", "critical"}
+_VALID_STATUS = {
+    "pending", "scheduled", "in_progress", "completed", "failed", "blocked",
+}
 
 # Allowlisted sort keys → ORDER BY fragment (never interpolate caller input).
 _SORT_MAP: dict[str, str] = {
@@ -497,6 +500,10 @@ async def update_status_batch(
 
     Mirrors update_status: stamps completed_at on terminal states.
     """
+    if status not in _VALID_STATUS:
+        raise ValueError(
+            f"invalid status {status!r}; must be one of {sorted(_VALID_STATUS)}"
+        )
     if not ids:
         return 0
     parts = ["status = ?"]

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -398,6 +398,7 @@ async def get_recently_completed(
 
 _VALID_KIND = {"follow_up", "tabled"}
 _VALID_DOMAIN = {"internal", "user_world"}
+_VALID_PRIORITY = {"low", "medium", "high", "critical"}
 
 # Allowlisted sort keys → ORDER BY fragment (never interpolate caller input).
 _SORT_MAP: dict[str, str] = {
@@ -441,6 +442,78 @@ async def set_domain(db: aiosqlite.Connection, id: str, domain: str | None) -> b
     )
     await db.commit()
     return cursor.rowcount > 0
+
+
+async def set_priority(db: aiosqlite.Connection, id: str, priority: str) -> bool:
+    """Set a follow-up's priority (validated against the schema CHECK set)."""
+    if priority not in _VALID_PRIORITY:
+        raise ValueError(
+            f"invalid priority {priority!r}; must be one of {sorted(_VALID_PRIORITY)}"
+        )
+    cursor = await db.execute(
+        "UPDATE follow_ups SET priority = ? WHERE id = ?", (priority, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+# Batch mutations — single-statement WHERE id IN (...) so a multi-row cockpit
+# action is one transaction (no silent partial failure on a 200-id selection).
+async def delete_batch(db: aiosqlite.Connection, ids: list[str]) -> int:
+    """Permanently delete multiple follow-ups in one statement. Returns count."""
+    if not ids:
+        return 0
+    placeholders = ",".join("?" for _ in ids)
+    cursor = await db.execute(
+        f"DELETE FROM follow_ups WHERE id IN ({placeholders})", ids,
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
+async def set_kind_batch(db: aiosqlite.Connection, ids: list[str], kind: str) -> int:
+    """Move multiple follow-ups between lanes in one statement. Returns count."""
+    if kind not in _VALID_KIND:
+        raise ValueError(f"invalid kind {kind!r}; must be one of {sorted(_VALID_KIND)}")
+    if not ids:
+        return 0
+    placeholders = ",".join("?" for _ in ids)
+    cursor = await db.execute(
+        f"UPDATE follow_ups SET kind = ? WHERE id IN ({placeholders})",
+        [kind, *ids],
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
+async def update_status_batch(
+    db: aiosqlite.Connection,
+    ids: list[str],
+    status: str,
+    *,
+    resolution_notes: str | None = None,
+) -> int:
+    """Update status for multiple follow-ups in one statement. Returns count.
+
+    Mirrors update_status: stamps completed_at on terminal states.
+    """
+    if not ids:
+        return 0
+    parts = ["status = ?"]
+    params: list[str | None] = [status]
+    if status in ("completed", "failed"):
+        parts.append("completed_at = ?")
+        params.append(_now_iso())
+    if resolution_notes is not None:
+        parts.append("resolution_notes = ?")
+        params.append(resolution_notes)
+    placeholders = ",".join("?" for _ in ids)
+    cursor = await db.execute(
+        f"UPDATE follow_ups SET {', '.join(parts)} WHERE id IN ({placeholders})",
+        [*params, *ids],
+    )
+    await db.commit()
+    return cursor.rowcount
 
 
 async def get_distinct_sources(db: aiosqlite.Connection) -> list[str]:

--- a/tests/test_dashboard/test_follow_ups_cockpit_api.py
+++ b/tests/test_dashboard/test_follow_ups_cockpit_api.py
@@ -1,0 +1,244 @@
+"""Tests for the dashboard follow-up cockpit routes (PR2).
+
+Covers param handling, the soft/hard mutations, the batch dispatch, and the
+503/404/400 guards. Runtime + CRUD layer are mocked (no real DB) — mirrors the
+test_references_api.py pattern.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from genesis.dashboard.api import blueprint
+
+_CRUD = "genesis.db.crud.follow_ups"
+_RT = "genesis.runtime.GenesisRuntime"
+
+
+@pytest.fixture()
+def app():
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    app.config["TESTING"] = True
+    app.secret_key = "test-secret-key"
+    return app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _mock_rt(is_bootstrapped=True, has_db=True):
+    rt = MagicMock()
+    rt.is_bootstrapped = is_bootstrapped
+    rt.db = MagicMock() if has_db else None
+    return rt
+
+
+def _row(**over):
+    row = {
+        "id": "fu-1", "content": "do the thing", "reason": "because",
+        "status": "pending", "priority": "medium", "kind": "follow_up",
+        "domain": None, "source": "foreground_session",
+        "strategy": "ego_judgment", "created_at": "2026-06-01T00:00:00Z",
+        "pinned": 0,
+    }
+    row.update(over)
+    return row
+
+
+# ── cockpit list ──────────────────────────────────────────────────────
+def test_cockpit_returns_items_and_total(client):
+    with (
+        patch(_RT) as MockRT,
+        patch(f"{_CRUD}.query_page", new=AsyncMock(return_value=[_row()])),
+        patch(f"{_CRUD}.count_filtered", new=AsyncMock(return_value=1)),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.get(
+            "/api/genesis/follow-ups/cockpit?kind=follow_up&page=1&page_size=50"
+        )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["total"] == 1 and data["page"] == 1 and len(data["items"]) == 1
+
+
+def test_cockpit_empty_200_when_not_bootstrapped(client):
+    with patch(_RT) as MockRT:
+        MockRT.instance.return_value = _mock_rt(is_bootstrapped=False, has_db=False)
+        resp = client.get("/api/genesis/follow-ups/cockpit")
+    assert resp.status_code == 200
+    assert resp.get_json()["items"] == []
+
+
+def test_cockpit_passes_null_domain_sentinel(client):
+    qp = AsyncMock(return_value=[])
+    with (
+        patch(_RT) as MockRT,
+        patch(f"{_CRUD}.query_page", new=qp),
+        patch(f"{_CRUD}.count_filtered", new=AsyncMock(return_value=0)),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        client.get("/api/genesis/follow-ups/cockpit?domain=__null__")
+    assert qp.await_args.kwargs["domain"] == "__null__"
+
+
+def test_cockpit_all_tier_clears_kind_filter(client):
+    qp = AsyncMock(return_value=[])
+    with (
+        patch(_RT) as MockRT,
+        patch(f"{_CRUD}.query_page", new=qp),
+        patch(f"{_CRUD}.count_filtered", new=AsyncMock(return_value=0)),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        client.get("/api/genesis/follow-ups/cockpit?kind=all")
+    assert qp.await_args.kwargs["kind"] is None
+
+
+# ── filters ───────────────────────────────────────────────────────────
+def test_filters_returns_sources_and_statuses(client):
+    with (
+        patch(_RT) as MockRT,
+        patch(f"{_CRUD}.get_distinct_sources", new=AsyncMock(return_value=["ego_cycle"])),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.get("/api/genesis/follow-ups/filters")
+    data = resp.get_json()
+    assert data["sources"] == ["ego_cycle"]
+    assert "pending" in data["statuses"] and "completed" in data["statuses"]
+
+
+# ── single mutations ──────────────────────────────────────────────────
+def test_done_marks_completed(client):
+    us = AsyncMock(return_value=True)
+    with patch(_RT) as MockRT, patch(f"{_CRUD}.update_status", new=us):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/follow-ups/fu-1/done", json={"notes": "x"})
+    assert resp.status_code == 200 and resp.get_json()["ok"] is True
+    assert us.await_args.args[1:] == ("fu-1", "completed")
+
+
+def test_done_404_when_missing(client):
+    with (
+        patch(_RT) as MockRT,
+        patch(f"{_CRUD}.update_status", new=AsyncMock(return_value=False)),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/follow-ups/nope/done", json={})
+    assert resp.status_code == 404
+
+
+def test_done_503_when_not_bootstrapped(client):
+    with patch(_RT) as MockRT:
+        MockRT.instance.return_value = _mock_rt(is_bootstrapped=False, has_db=False)
+        resp = client.post("/api/genesis/follow-ups/fu-1/done", json={})
+    assert resp.status_code == 503
+
+
+def test_delete_ok(client):
+    with patch(_RT) as MockRT, patch(f"{_CRUD}.delete", new=AsyncMock(return_value=True)):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/follow-ups/fu-1/delete", json={})
+    assert resp.status_code == 200
+
+
+def test_pin_passes_bool(client):
+    sp = AsyncMock(return_value=True)
+    with patch(_RT) as MockRT, patch(f"{_CRUD}.set_pinned", new=sp):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/follow-ups/fu-1/pin", json={"pinned": True})
+    assert resp.status_code == 200 and resp.get_json()["pinned"] is True
+    assert sp.await_args.args[2] is True
+
+
+def test_priority_400_on_invalid(client):
+    with (
+        patch(_RT) as MockRT,
+        patch(f"{_CRUD}.set_priority", new=AsyncMock(side_effect=ValueError("bad"))),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post(
+            "/api/genesis/follow-ups/fu-1/priority", json={"priority": "urgent"}
+        )
+    assert resp.status_code == 400
+
+
+def test_kind_ok(client):
+    with patch(_RT) as MockRT, patch(f"{_CRUD}.set_kind", new=AsyncMock(return_value=True)):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/follow-ups/fu-1/kind", json={"kind": "tabled"})
+    assert resp.status_code == 200 and resp.get_json()["kind"] == "tabled"
+
+
+def test_domain_clear_passes_none(client):
+    sd = AsyncMock(return_value=True)
+    with patch(_RT) as MockRT, patch(f"{_CRUD}.set_domain", new=sd):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/follow-ups/fu-1/domain", json={"domain": ""})
+    assert resp.status_code == 200
+    assert sd.await_args.args[2] is None  # empty string -> None (clear)
+
+
+# ── batch ─────────────────────────────────────────────────────────────
+def test_batch_done(client):
+    usb = AsyncMock(return_value=3)
+    with patch(_RT) as MockRT, patch(f"{_CRUD}.update_status_batch", new=usb):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post(
+            "/api/genesis/follow-ups/batch",
+            json={"action": "done", "ids": ["a", "b", "c"]},
+        )
+    assert resp.status_code == 200 and resp.get_json()["count"] == 3
+
+
+def test_batch_tabled_routes_to_set_kind_batch(client):
+    skb = AsyncMock(return_value=2)
+    with patch(_RT) as MockRT, patch(f"{_CRUD}.set_kind_batch", new=skb):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post(
+            "/api/genesis/follow-ups/batch",
+            json={"action": "tabled", "ids": ["a", "b"]},
+        )
+    assert resp.status_code == 200
+    assert skb.await_args.args[2] == "tabled"
+
+
+def test_batch_400_on_bad_action(client):
+    with patch(_RT) as MockRT:
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post(
+            "/api/genesis/follow-ups/batch", json={"action": "nuke", "ids": ["a"]}
+        )
+    assert resp.status_code == 400
+
+
+def test_batch_400_on_non_list_ids(client):
+    with patch(_RT) as MockRT:
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post(
+            "/api/genesis/follow-ups/batch", json={"action": "done", "ids": "abc"}
+        )
+    assert resp.status_code == 400
+
+
+def test_batch_400_on_too_many_ids(client):
+    with patch(_RT) as MockRT:
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post(
+            "/api/genesis/follow-ups/batch",
+            json={"action": "delete", "ids": [str(i) for i in range(201)]},
+        )
+    assert resp.status_code == 400
+
+
+def test_batch_503_when_not_bootstrapped(client):
+    with patch(_RT) as MockRT:
+        MockRT.instance.return_value = _mock_rt(is_bootstrapped=False, has_db=False)
+        resp = client.post(
+            "/api/genesis/follow-ups/batch", json={"action": "done", "ids": ["a"]}
+        )
+    assert resp.status_code == 503

--- a/tests/test_db/test_follow_ups.py
+++ b/tests/test_db/test_follow_ups.py
@@ -230,3 +230,9 @@ async def test_update_status_batch_stamps_completed_at(db):
         assert row["status"] == "completed"
         assert row["completed_at"] is not None
         assert row["resolution_notes"] == "bulk done"
+
+
+async def test_update_status_batch_rejects_invalid_status(db):
+    fid = await follow_ups.create(db, **_BASE)
+    with pytest.raises(ValueError):
+        await follow_ups.update_status_batch(db, [fid], "cancelled")

--- a/tests/test_db/test_follow_ups.py
+++ b/tests/test_db/test_follow_ups.py
@@ -180,3 +180,53 @@ async def test_query_page_rejects_nothing_on_bad_sort(db):
     await follow_ups.create(db, **_BASE)
     rows = await follow_ups.query_page(db, sort="; DROP TABLE follow_ups; --")
     assert len(rows) == 1
+
+
+async def test_set_priority_updates(db):
+    fid = await follow_ups.create(db, **_BASE)
+    assert await follow_ups.set_priority(db, fid, "critical")
+    assert (await follow_ups.get_by_id(db, fid))["priority"] == "critical"
+
+
+async def test_set_priority_rejects_invalid(db):
+    fid = await follow_ups.create(db, **_BASE)
+    with pytest.raises(ValueError):
+        await follow_ups.set_priority(db, fid, "urgent")
+
+
+async def test_set_priority_unknown_id_returns_false(db):
+    assert await follow_ups.set_priority(db, "nope", "high") is False
+
+
+async def test_delete_batch_removes_all(db):
+    ids = [await follow_ups.create(db, **_BASE) for _ in range(3)]
+    assert await follow_ups.delete_batch(db, ids) == 3
+    for fid in ids:
+        assert await follow_ups.get_by_id(db, fid) is None
+    # Empty selection is a no-op, not an error.
+    assert await follow_ups.delete_batch(db, []) == 0
+
+
+async def test_set_kind_batch_moves_lane(db):
+    ids = [await follow_ups.create(db, **_BASE) for _ in range(2)]
+    assert await follow_ups.set_kind_batch(db, ids, "tabled") == 2
+    for fid in ids:
+        assert (await follow_ups.get_by_id(db, fid))["kind"] == "tabled"
+
+
+async def test_set_kind_batch_rejects_invalid(db):
+    fid = await follow_ups.create(db, **_BASE)
+    with pytest.raises(ValueError):
+        await follow_ups.set_kind_batch(db, [fid], "bogus")
+
+
+async def test_update_status_batch_stamps_completed_at(db):
+    ids = [await follow_ups.create(db, **_BASE) for _ in range(2)]
+    assert await follow_ups.update_status_batch(
+        db, ids, "completed", resolution_notes="bulk done"
+    ) == 2
+    for fid in ids:
+        row = await follow_ups.get_by_id(db, fid)
+        assert row["status"] == "completed"
+        assert row["completed_at"] is not None
+        assert row["resolution_notes"] == "bulk done"


### PR DESCRIPTION
## Follow-ups cockpit — PR2 of the follow-up subsystem redesign

A dedicated **Follow-ups** dashboard tab so the backlog can actually be drained: server-side filter/search/sort/paginate the full table, flip items between the follow-up and tabled lanes, override a misclassified domain, edit priority/pin, mark Done, or delete — individually or in batches.

PR1 (#741) landed the schema foundation (`kind`/`domain`/`goal_id` + the cockpit data layer). **This PR adds no migration** — it builds on that live schema.

### What's in it

**Data layer** (`db/crud/follow_ups.py`)
- `set_priority` (the one cockpit mutator PR1 didn't add) — validated against the `priority` CHECK set.
- Atomic batch helpers `delete_batch` / `set_kind_batch` / `update_status_batch` — single-statement `WHERE id IN (...)` so a multi-row action is one transaction (no silent partial failure on a large selection). `update_status_batch` validates status and stamps `completed_at` on terminal states, mirroring `update_status`.

**Routes** (`dashboard/routes/follow_ups.py`)
- `GET  /api/genesis/follow-ups/cockpit` — paginated/sorted/filtered list.
- `GET  /api/genesis/follow-ups/filters` — distinct sources + the fixed status set.
- `POST /api/genesis/follow-ups/<id>/{done,delete,pin,priority,kind,domain}`.
- `POST /api/genesis/follow-ups/batch` — done/delete/tabled/follow_up (max 200).
- Reads return an empty 200 when unbootstrapped; mutations return 503/404/400; the batch dispatch is exception-guarded.

**UI** (`templates/genesis_dashboard.html`)
- A `Follow-ups | Tabled | All` tier toggle (default = follow-ups; tabled is a deliberate click-away).
- Domain / Status / Source / Sort filters + keyword search + true page-N-of-M pagination.
- Per-row actions in the expanded detail: **Done/Dismiss** (soft — status→completed, row kept) is primary; **Delete forever** is secondary and gated behind a JS confirm; plus Pin, Priority, Move-lane, and Domain-override.
- Batch actions over a checkbox selection. Row body mirrors the existing read-only Work-tab follow-ups panel; filter/batch/pagination chrome mirrors the Observations tab. The existing Work-tab panel is untouched (additive).

### Design notes
- **Soft-primary, confirm-gated hard delete.** "Done" keeps the row (consistent with the redesign's never-amnesiac ethos); permanent deletion is deliberate and confirmed.
- The dashboard's `/api/*` surface is unauthenticated by design (auth gates the web UI only); the destructive endpoint is accepted on the trusted-LAN dashboard and gated behind a confirm in the UI.

### Verification
- 23 CRUD unit tests (new `set_priority` + batch + status-validation cases) — green; ruff clean.
- Pre-implementation architecture review + code review; findings addressed (batch error handling, status validation, filter↔store sync).
- Template JS validated as a module; panel tags balanced.
- **Full real-browser E2E will run post-deploy** (the UI can only be exercised against a server running this code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
