### PR TITLE
refactor(security): promote 4 skill_scan helpers to public API

### DIFF
--- a/src/genesis/recon/skill_security_scan_job.py
+++ b/src/genesis/recon/skill_security_scan_job.py
@@ -14,12 +14,12 @@ import shutil
 from pathlib import Path
 
 from genesis.security.skill_scan import (
-    _default_roots,
-    _default_trusted_file,
-    _load_trusted_names,
-    _repo_skill_roots,
+    default_roots,
+    default_trusted_file,
     discover_skill_dirs,
     is_trusted,
+    load_trusted_names,
+    repo_skill_roots,
     run_skillspector,
     scan_and_store,
     store_finding,
@@ -62,10 +62,10 @@ class SkillSecurityScanJob:
             logger.warning("SkillSpector binary not found — skipping skill-security scan")
             return {"total_findings": 0, "skills_scanned": 0, "skipped": "skillspector not installed"}
 
-        roots = _default_roots()
+        roots = default_roots()
         skill_dirs = discover_skill_dirs(roots)
-        trusted_names = _load_trusted_names(_default_trusted_file())
-        trusted_roots = _repo_skill_roots()
+        trusted_names = load_trusted_names(default_trusted_file())
+        trusted_roots = repo_skill_roots()
 
         def trusted(skill_dir: Path) -> bool:
             return is_trusted(skill_dir, trusted_names=trusted_names, trusted_roots=trusted_roots)

--- a/src/genesis/security/skill_scan.py
+++ b/src/genesis/security/skill_scan.py
@@ -313,7 +313,7 @@ async def store_finding(db: object, finding: dict) -> str | None:
     return finding_id
 
 
-def _repo_skill_roots() -> list[Path]:
+def repo_skill_roots() -> list[Path]:
     """First-party (in-repo) skill roots — trusted by default."""
     try:
         import genesis
@@ -324,21 +324,21 @@ def _repo_skill_roots() -> list[Path]:
         return []
 
 
-def _default_roots() -> list[Path]:
+def default_roots() -> list[Path]:
     """Default skill roots to sweep (some live outside the repo)."""
     return [
         Path.home() / ".claude" / "skills",
         Path.home() / ".genesis" / "skill-library",
-        *_repo_skill_roots(),
+        *repo_skill_roots(),
     ]
 
 
-def _default_trusted_file() -> Path:
+def default_trusted_file() -> Path:
     """Allowlist of trusted skill names (one per line); blessed via --seed-trusted."""
     return Path.home() / ".genesis" / "config" / "skill_scan_trusted.txt"
 
 
-def _load_trusted_names(path: Path) -> set[str]:
+def load_trusted_names(path: Path) -> set[str]:
     if not path.is_file():
         return set()
     return {
@@ -370,7 +370,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--no-store", action="store_true", help="Scan + print only; do not write recon findings.")
     parser.add_argument(
         "--trusted-file", default=None,
-        help=f"Allowlist of trusted skill names (default: {_default_trusted_file()}).",
+        help=f"Allowlist of trusted skill names (default: {default_trusted_file()}).",
     )
     parser.add_argument(
         "--seed-trusted", action="store_true",
@@ -382,11 +382,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    roots = [Path(r) for r in args.roots] if args.roots else _default_roots()
+    roots = [Path(r) for r in args.roots] if args.roots else default_roots()
     skill_dirs = discover_skill_dirs(roots)
     print(f"Discovered {len(skill_dirs)} skills across {len(roots)} roots.")
 
-    trusted_file = Path(args.trusted_file) if args.trusted_file else _default_trusted_file()
+    trusted_file = Path(args.trusted_file) if args.trusted_file else default_trusted_file()
 
     if args.seed_trusted:
         names = sorted({d.name for d in skill_dirs})
@@ -401,8 +401,8 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Seeded {len(names)} trusted skill names -> {trusted_file}")
         return 0
 
-    trusted_names = set() if args.no_trust else _load_trusted_names(trusted_file)
-    trusted_roots = [] if args.no_trust else _repo_skill_roots()
+    trusted_names = set() if args.no_trust else load_trusted_names(trusted_file)
+    trusted_roots = [] if args.no_trust else repo_skill_roots()
 
     def trusted(skill_dir: Path) -> bool:
         return is_trusted(skill_dir, trusted_names=trusted_names, trusted_roots=trusted_roots)

--- a/src/genesis/security/skill_scan.py
+++ b/src/genesis/security/skill_scan.py
@@ -339,6 +339,8 @@ def default_trusted_file() -> Path:
 
 
 def load_trusted_names(path: Path) -> set[str]:
+    """Return the set of trusted skill names from *path* (one per line, ``#``
+    comments and blanks ignored), or an empty set if the file does not exist."""
     if not path.is_file():
         return set()
     return {

--- a/tests/test_recon/test_skill_security_scan_job.py
+++ b/tests/test_recon/test_skill_security_scan_job.py
@@ -42,8 +42,8 @@ async def test_run_delegates_and_summarizes(monkeypatch):
 
     job = SkillSecurityScanJob(db=object(), skillspector_bin="/x/ss")
     monkeypatch.setattr(mod, "discover_skill_dirs", lambda _roots: ["/x/bad", "/x/ok"])
-    monkeypatch.setattr(mod, "_load_trusted_names", lambda _p: {"ok"})
-    monkeypatch.setattr(mod, "_repo_skill_roots", lambda: [])
+    monkeypatch.setattr(mod, "load_trusted_names", lambda _p: {"ok"})
+    monkeypatch.setattr(mod, "repo_skill_roots", lambda: [])
 
     async def fake_scan_and_store(db, dirs, *, scanner, storer, trusted, **kw):
         # Mimic the real shape: one untrusted finding, one trusted (skipped).


### PR DESCRIPTION
Follow-up to #745 review (MEDIUM-1). `recon/skill_security_scan_job.py` imports `default_roots`, `default_trusted_file`, `load_trusted_names`, `repo_skill_roots` from `genesis.security.skill_scan` across a package boundary — the underscore-private prefix was a cross-package coupling smell. Drops the underscore and updates all refs (the skill_scan CLI `main()`, the recon job, and its tests).

Pure rename, no behavior change. Tests green (test_security + test_recon, 16 passed), ruff clean.