### PR TITLE
feat(dashboard): label ambient bridge "Voice Bridge" on infra card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Changed
+
+- **The dashboard Infrastructure card now labels the ambient-capture bridge as "Voice Bridge"** —
+  a clearer, user-facing name. It still only appears when a voice/ambient edge is configured.
+
 ### Fixed
 
 - **Updates no longer abort when a schema migration actually succeeded** — if the

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -3224,6 +3224,14 @@
           return "#666";
         },
 
+        // Display label for infrastructure probe keys: the internal dict key stays
+        // canonical (e.g. "ambient"); only the surfaced name is user-facing. The
+        // ambient-capture edge bridge is shown as "Voice Bridge" on the card.
+        infraLabel(name) {
+          const labels = { ambient: "Voice Bridge" };
+          return labels[name] || name;
+        },
+
         keyHealthColor(c) {
           // API-key health convention: green = configured + working,
           // yellow = key missing/unconfigured, red = present but NOT working
@@ -4389,19 +4397,19 @@
                   <div x-show="!['container_memory', 'disk', 'cpu'].includes(name)"
                        style="margin-bottom: 0.2rem; cursor: default;"
                        :title="probe.error
-                         ? name + ': ERROR — ' + probe.error
+                         ? $store.genesisDashboard.infraLabel(name) + ': ERROR — ' + probe.error
                          : probe.latency_ms != null
-                           ? name + ': ' + (probe.status || 'healthy') + ' (' + Math.round(probe.latency_ms) + 'ms)'
+                           ? $store.genesisDashboard.infraLabel(name) + ': ' + (probe.status || 'healthy') + ' (' + Math.round(probe.latency_ms) + 'ms)'
                            : probe.free_pct != null
-                             ? name + ': ' + probe.free_gb?.toFixed(1) + ' GB free (' + probe.free_pct?.toFixed(0) + '% of ' + probe.total_gb?.toFixed(0) + ' GB)'
+                             ? $store.genesisDashboard.infraLabel(name) + ': ' + probe.free_gb?.toFixed(1) + ' GB free (' + probe.free_pct?.toFixed(0) + '% of ' + probe.total_gb?.toFixed(0) + ' GB)'
                              : probe.total_points != null
-                               ? name + ': ' + probe.total_points + ' total points across ' + (probe.collections?.length || 0) + ' collections'
+                               ? $store.genesisDashboard.infraLabel(name) + ': ' + probe.total_points + ' total points across ' + (probe.collections?.length || 0) + ' collections'
                              : probe.cc_tier != null
-                               ? name + ': CC ' + probe.cc_tier + ' (' + probe.cc_used_mb + '/' + probe.cc_budget_mb + 'MB)' + (probe.sys_tier ? ', /tmp ' + probe.sys_tier + ' (' + probe.sys_used_pct + '%)' : '')
-                             : name + ': ' + (probe.status || 'unknown')">
+                               ? $store.genesisDashboard.infraLabel(name) + ': CC ' + probe.cc_tier + ' (' + probe.cc_used_mb + '/' + probe.cc_budget_mb + 'MB)' + (probe.sys_tier ? ', /tmp ' + probe.sys_tier + ' (' + probe.sys_used_pct + '%)' : '')
+                             : $store.genesisDashboard.infraLabel(name) + ': ' + (probe.status || 'unknown')">
                     <span class="status-dot"
                           :style="`background: ${$store.genesisDashboard.probeStatusColor(probe)}`"></span>
-                    <span x-text="name" style="font-size: 0.82rem"></span>
+                    <span x-text="$store.genesisDashboard.infraLabel(name)" style="font-size: 0.82rem"></span>
                     <template x-if="probe.wal_mb != null">
                       <span style="margin-left: 0.4rem; font-size: 0.72rem; opacity: 0.75;"
                             :title="'SQLite WAL sidecar size — green < 100MB, yellow ≥ 100MB, red ≥ 500MB'">


### PR DESCRIPTION
## What
The dashboard **Infrastructure** health card showed the ambient-capture edge bridge by its internal key **"ambient"**. This relabels it to a clearer user-facing **"Voice Bridge"**.

## How — presentation-only, zero blast radius
- New Alpine store method `infraLabel(name)` (`{ ambient: "Voice Bridge" }`, falls back to the raw key).
- Used by the infra-card visible label (`x-text`) and its hover `:title` tooltip.
- The internal `infra["ambient"]` dict key is **unchanged** — everything that reads it (the `health_status` MCP tool, `tests/test_observability/test_health.py`, the ambient-health alert job) is unaffected. No Python touched.

## Gate (already correct — no change)
The card only appears when a voice/ambient edge is configured: `probe_ambient_health()` returns `None` when `~/.genesis/ambient_remote.yaml` is absent, so `infra["ambient"]` is never set and the card is omitted on a no-voice install.

## Review / verification
- Code-reviewer pass: clean — syntax, completeness (the only two visible-label spots both use `infraLabel`), and null-safety verified.
- E2E (post-deploy): the infra card renders **"Voice Bridge"** for the ambient entry; no dashboard JS regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)