### PR TITLE
fix(observability): malformed ambient config now visible, not silent

### DIFF
--- a/src/genesis/observability/ambient_health.py
+++ b/src/genesis/observability/ambient_health.py
@@ -39,31 +39,47 @@ class AmbientRemoteConfig:
     health_path: str = _DEFAULT_HEALTH_PATH
 
 
+class AmbientRemoteConfigError(Exception):
+    """Raised when ``~/.genesis/ambient_remote.yaml`` is present AND enabled but
+    malformed (unparseable, or missing ``host_ip``/``host_user``).
+
+    Distinct from absent/disabled (which return ``None``) so callers can surface a
+    VISIBLE "misconfigured" state — instead of a config typo silently looking
+    identical to "no ambient edge configured" and disabling monitoring unnoticed."""
+
+
 def load_ambient_remote_config() -> AmbientRemoteConfig | None:
-    """Load ``~/.genesis/ambient_remote.yaml``; return None if absent, disabled,
-    or invalid (monitor then no-ops). Never raises."""
+    """Load ``~/.genesis/ambient_remote.yaml``.
+
+    Returns ``None`` when the config is **absent** or **explicitly disabled**
+    (``enabled: false``) — both legitimate no-ops on installs without an ambient
+    edge. Raises :class:`AmbientRemoteConfigError` when the file is **present and
+    enabled but malformed** (unparseable, or missing ``host_ip``/``host_user``), so
+    a config typo surfaces visibly instead of silently looking like "not configured"."""
     if not _CONFIG_PATH.exists():
         return None
     try:
         import yaml
 
         data = yaml.safe_load(_CONFIG_PATH.read_text()) or {}
-        if not data.get("enabled", True):
-            return None
-        host_ip = data.get("host_ip")
-        host_user = data.get("host_user")
-        if not host_ip or not host_user:
-            logger.warning("ambient_remote.yaml missing host_ip/host_user — monitor disabled")
-            return None
-        return AmbientRemoteConfig(
-            host_ip=str(host_ip),
-            host_user=str(host_user),
-            ssh_key=str(data.get("ssh_key", _DEFAULT_KEY)),
-            health_path=str(data.get("health_path", _DEFAULT_HEALTH_PATH)),
-        )
-    except Exception:
-        logger.warning("Failed to load ambient_remote.yaml — monitor disabled", exc_info=True)
+    except Exception as exc:
+        raise AmbientRemoteConfigError(
+            f"ambient_remote.yaml could not be parsed: {exc}"
+        ) from exc
+    if not data.get("enabled", True):
         return None
+    host_ip = data.get("host_ip")
+    host_user = data.get("host_user")
+    if not host_ip or not host_user:
+        raise AmbientRemoteConfigError(
+            "ambient_remote.yaml is enabled but missing host_ip/host_user"
+        )
+    return AmbientRemoteConfig(
+        host_ip=str(host_ip),
+        host_user=str(host_user),
+        ssh_key=str(data.get("ssh_key", _DEFAULT_KEY)),
+        health_path=str(data.get("health_path", _DEFAULT_HEALTH_PATH)),
+    )
 
 
 async def read_edge_health(cfg: AmbientRemoteConfig) -> dict | None:

--- a/src/genesis/observability/health.py
+++ b/src/genesis/observability/health.py
@@ -645,13 +645,26 @@ async def probe_ambient_health(clock=None) -> ProbeResult | None:
     hammer the edge.
     """
     from genesis.observability.ambient_health import (
+        AmbientRemoteConfigError,
         evaluate_ambient_health,
         load_ambient_remote_config,
         read_edge_health,
     )
 
     _clock = clock or (lambda: datetime.now(UTC))
-    cfg = load_ambient_remote_config()
+    try:
+        cfg = load_ambient_remote_config()
+    except AmbientRemoteConfigError as exc:
+        # Present-but-malformed config: surface a VISIBLE degraded card with the
+        # reason, instead of silently looking like "no ambient edge configured".
+        return ProbeResult(
+            name="ambient",
+            status=ProbeStatus.DEGRADED,
+            latency_ms=0.0,
+            message=f"ambient_remote.yaml misconfigured: {exc}",
+            checked_at=_clock().isoformat(),
+            details={"verdict": "misconfigured"},
+        )
     if cfg is None:
         return None  # no ambient edge configured — observability no-op
 

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -500,12 +500,24 @@ class OutreachScheduler:
         """
         try:
             from genesis.observability.ambient_health import (
+                AmbientRemoteConfigError,
                 evaluate_ambient_health,
                 load_ambient_remote_config,
                 read_edge_health,
             )
 
-            cfg = load_ambient_remote_config()
+            try:
+                cfg = load_ambient_remote_config()
+            except AmbientRemoteConfigError as cfg_err:
+                # Present-but-malformed config: log loudly + record a clean run (the
+                # job itself didn't fail). The dashboard's degraded ambient card
+                # carries the detail; this avoids flapping a phantom job failure.
+                logger.error(
+                    "ambient_remote.yaml misconfigured — ambient health monitor disabled: %s",
+                    cfg_err,
+                )
+                await self._record_job_result("ambient_health")
+                return
             if cfg is None:
                 return  # no ambient edge on this install — silent no-op
 

--- a/tests/test_observability/test_ambient_health.py
+++ b/tests/test_observability/test_ambient_health.py
@@ -5,7 +5,15 @@ wiring are verified on-device (they need the edge + a running scheduler).
 """
 from datetime import UTC, datetime, timedelta
 
-from genesis.observability.ambient_health import evaluate_ambient_health
+import pytest
+
+from genesis.observability import ambient_health
+from genesis.observability.ambient_health import (
+    AmbientRemoteConfig,
+    AmbientRemoteConfigError,
+    evaluate_ambient_health,
+    load_ambient_remote_config,
+)
 
 NOW = datetime(2026, 6, 18, 12, 0, 0, tzinfo=UTC)
 
@@ -71,3 +79,54 @@ def test_diar_disabled_does_not_degrade():
     # If diarization is off, a False worker flag is irrelevant.
     snap = _snapshot(diar_enabled=False, diar_worker_alive=False)
     assert evaluate_ambient_health(snap, now=NOW).status == "ok"
+
+
+# --- load_ambient_remote_config: absent/disabled -> None; present-but-malformed -> raise ---
+
+
+def _point_config_at(tmp_path, monkeypatch, text):
+    cfg = tmp_path / "ambient_remote.yaml"
+    cfg.write_text(text)
+    monkeypatch.setattr(ambient_health, "_CONFIG_PATH", cfg)
+
+
+def test_load_absent_returns_none(tmp_path, monkeypatch):
+    # No config file -> legit no-op (install without an ambient edge).
+    monkeypatch.setattr(ambient_health, "_CONFIG_PATH", tmp_path / "absent.yaml")
+    assert load_ambient_remote_config() is None
+
+
+def test_load_disabled_returns_none(tmp_path, monkeypatch):
+    # enabled: false -> intentional disable, also a legit no-op (no raise).
+    _point_config_at(tmp_path, monkeypatch, "enabled: false\nhost_ip: x\nhost_user: y\n")
+    assert load_ambient_remote_config() is None
+
+
+def test_load_valid_returns_config(tmp_path, monkeypatch):
+    _point_config_at(tmp_path, monkeypatch, "host_ip: 192.0.2.9\nhost_user: edge\nenabled: true\n")
+    cfg = load_ambient_remote_config()
+    assert isinstance(cfg, AmbientRemoteConfig)
+    assert cfg.host_ip == "192.0.2.9"
+    assert cfg.host_user == "edge"
+
+
+def test_load_missing_host_user_raises(tmp_path, monkeypatch):
+    # Present + enabled but missing host_user -> misconfigured: MUST raise (visible),
+    # not silently return None and look identical to "not configured".
+    _point_config_at(tmp_path, monkeypatch, "host_ip: 192.0.2.9\nenabled: true\n")
+    with pytest.raises(AmbientRemoteConfigError):
+        load_ambient_remote_config()
+
+
+def test_load_missing_host_ip_raises(tmp_path, monkeypatch):
+    # The other branch of the `not host_ip or not host_user` guard.
+    _point_config_at(tmp_path, monkeypatch, "host_user: edge\nenabled: true\n")
+    with pytest.raises(AmbientRemoteConfigError):
+        load_ambient_remote_config()
+
+
+def test_load_unparseable_raises(tmp_path, monkeypatch):
+    # Broken YAML (unterminated flow sequence) -> raise, not silent None.
+    _point_config_at(tmp_path, monkeypatch, "host_ip: [1, 2\n")
+    with pytest.raises(AmbientRemoteConfigError):
+        load_ambient_remote_config()

--- a/tests/test_observability/test_health.py
+++ b/tests/test_observability/test_health.py
@@ -263,6 +263,23 @@ class TestProbeAmbientHealth:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_misconfigured_config_is_degraded_not_silent(self):
+        # Present-but-malformed config (loader raises) -> VISIBLE degraded card,
+        # NOT a silent None that looks identical to "not configured".
+        from genesis.observability.ambient_health import AmbientRemoteConfigError
+
+        with patch(
+            f"{self._MOD}.load_ambient_remote_config",
+            side_effect=AmbientRemoteConfigError("missing host_ip/host_user"),
+        ):
+            result = await probe_ambient_health(clock=FROZEN_CLOCK)
+        assert result is not None
+        assert result.name == "ambient"
+        assert result.status == ProbeStatus.DEGRADED
+        assert result.details["verdict"] == "misconfigured"
+        assert "misconfigured" in result.message
+
+    @pytest.mark.asyncio
     async def test_healthy(self):
         snap = {"ts": FROZEN_CLOCK().isoformat(), "diar_enabled": True, "diar_worker_alive": True}
         with (


### PR DESCRIPTION
## Problem
A present-but-malformed `~/.genesis/ambient_remote.yaml` (unparseable, or missing `host_ip`/`host_user`) used to return `None` from `load_ambient_remote_config()` — **identical to "no ambient edge configured."** So a config typo silently disabled BOTH the dashboard ambient probe (#735) **and** the Telegram down-alert monitor (#680/#685), with only a log warning nobody reads. (Found while verifying the dashboard relabel — *this* install's config is fine, but the silent-disable is a real footgun.)

## Fix
- `load_ambient_remote_config()` now **raises `AmbientRemoteConfigError`** when the file is present AND enabled but malformed. Absent / `enabled: false` still return `None` (legit no-ops, no raise).
- `probe_ambient_health` catches it → returns a **DEGRADED `ambient` card** (`details.verdict = "misconfigured"`) carrying the reason → visible on the dashboard.
- `_ambient_health_job` catches it → `logger.error(...)` (loud) + records a clean job run (no phantom job failure).

A misconfigured ambient monitor is now **visible** instead of invisible.

## Tests
- Loader: absent→None, `enabled:false`→None, valid→config, missing `host_ip`→raise, missing `host_user`→raise, unparseable YAML→raise.
- Probe: misconfigured→DEGRADED.
- `tests/test_observability/` green; ruff clean. Code-reviewed (2 findings fixed: doc-IP in a fixture, missing `host_ip`-branch test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)