### PR TITLE
feat(ego,outreach,learning): domain-scope follow-up consumers (PR3)

### DIFF
--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -25,6 +25,20 @@ def _normalize_scheduled_at(iso_str: str | None) -> str | None:
     return dt.isoformat()
 
 
+def _domain_eq(domain: str | None) -> tuple[str, list[str]]:
+    """Build an exact-match domain WHERE fragment for the reader queries.
+
+    Returns ``("", [])`` when ``domain`` is None (no-op — the caller behaves
+    byte-identically to before), else ``(" AND domain = ?", [domain])``. Exact
+    match only: when a domain is given, NULL-domain rows are excluded. This
+    mirrors the cockpit's ``_build_filter_where`` exact-match semantics — it is
+    deliberately NOT a second NULL-handling idiom (no "domain OR NULL" union).
+    """
+    if domain is None:
+        return "", []
+    return " AND domain = ?", [domain]
+
+
 async def create(
     db: aiosqlite.Connection,
     *,
@@ -74,11 +88,13 @@ async def get_pending(
     source: str | None = None,
     strategy: str | None = None,
     include_tabled: bool = False,
+    domain: str | None = None,
 ) -> list[dict]:
-    """Get pending follow-ups, optionally filtered by source/strategy.
+    """Get pending follow-ups, optionally filtered by source/strategy/domain.
 
     Tabled follow-ups (kind='tabled') are excluded unless include_tabled=True —
     tabled items are tracked but never dispatched or surfaced as action.
+    domain (exact match) scopes to that domain only; None = all domains (no-op).
     """
     query = "SELECT * FROM follow_ups WHERE status = 'pending'"
     params: list[str] = []
@@ -90,6 +106,9 @@ async def get_pending(
     if strategy is not None:
         query += " AND strategy = ?"
         params.append(strategy)
+    dom_clause, dom_params = _domain_eq(domain)
+    query += dom_clause
+    params.extend(dom_params)
     query += " ORDER BY created_at ASC"
     cursor = await db.execute(query, params)
     return [dict(row) for row in await cursor.fetchall()]
@@ -98,31 +117,41 @@ async def get_pending(
 async def get_by_status(
     db: aiosqlite.Connection,
     status: str,
+    *,
+    domain: str | None = None,
 ) -> list[dict]:
+    """Get follow-ups by status. domain (exact match) scopes to that domain
+    only; None = all domains (no-op, identical to the prior behaviour)."""
+    dom_clause, dom_params = _domain_eq(domain)
     cursor = await db.execute(
-        "SELECT * FROM follow_ups WHERE status = ? ORDER BY created_at ASC",
-        (status,),
+        f"SELECT * FROM follow_ups WHERE status = ?{dom_clause} "
+        "ORDER BY created_at ASC",
+        (status, *dom_params),
     )
     return [dict(row) for row in await cursor.fetchall()]
 
 
 async def get_actionable(
     db: aiosqlite.Connection, *, limit: int = 50, include_tabled: bool = False,
+    domain: str | None = None,
 ) -> list[dict]:
     """Get follow-ups needing attention: pending, failed, blocked.
 
     Tabled follow-ups are excluded unless include_tabled=True. Capped at `limit`
-    to prevent unbounded growth from flooding contexts.
+    to prevent unbounded growth from flooding contexts. domain (exact match)
+    scopes to that domain only — applied in SQL BEFORE the LIMIT, so the cap
+    samples within the scoped domain (None = all domains, identical to before).
     """
     kind_clause = "" if include_tabled else "AND kind = 'follow_up' "
+    dom_clause, dom_params = _domain_eq(domain)
     cursor = await db.execute(
         "SELECT * FROM follow_ups WHERE status IN ('pending', 'failed', 'blocked') "
-        f"{kind_clause}"
+        f"{kind_clause}{dom_clause} "
         "ORDER BY CASE priority "
         "  WHEN 'critical' THEN 0 WHEN 'high' THEN 1 "
         "  WHEN 'medium' THEN 2 ELSE 3 END, created_at ASC "
         "LIMIT ?",
-        (limit,),
+        (*dom_params, limit),
     )
     return [dict(row) for row in await cursor.fetchall()]
 
@@ -379,14 +408,21 @@ async def get_recently_completed(
     *,
     hours: int = 24,
     limit: int = 5,
+    domain: str | None = None,
 ) -> list[dict]:
-    """Get follow-ups completed within the given time window."""
+    """Get follow-ups completed within the given time window.
+
+    domain (exact match) scopes to that domain only and is applied in SQL
+    BEFORE the LIMIT (so the cap samples within the scoped domain — a Python
+    post-filter would be wrong here). None = all domains (no-op).
+    """
+    dom_clause, dom_params = _domain_eq(domain)
     cursor = await db.execute(
         "SELECT content, resolution_notes FROM follow_ups "
         "WHERE status = 'completed' "
-        "AND completed_at >= datetime('now', ? || ' hours') "
+        f"AND completed_at >= datetime('now', ? || ' hours'){dom_clause} "
         "ORDER BY completed_at DESC LIMIT ?",
-        (f"-{hours}", limit),
+        (f"-{hours}", *dom_params, limit),
     )
     return [dict(row) for row in await cursor.fetchall()]
 

--- a/src/genesis/ego/user_context.py
+++ b/src/genesis/ego/user_context.py
@@ -685,7 +685,11 @@ class UserEgoContextBuilder:
             cursor = await self._db.execute(
                 "SELECT COUNT(*), MIN(created_at) FROM follow_ups "
                 "WHERE status = 'pending' "
-                "AND strategy = 'user_input_needed'"
+                "AND strategy = 'user_input_needed' "
+                # Strict user_world: only items genuinely awaiting the USER's
+                # input (excludes internal-dev backlog parked under this strategy
+                # and any tabled rows).
+                "AND domain = 'user_world' AND kind = 'follow_up'"
             )
             row = await cursor.fetchone()
             if row and row[0] > 0:
@@ -849,7 +853,14 @@ class UserEgoContextBuilder:
         try:
             from genesis.db.crud import follow_ups as follow_up_crud
 
-            actionable = await follow_up_crud.get_actionable(self._db)
+            # Strict user_world: the user (CEO) ego tracks the user's world only.
+            # Scoping in SQL (before get_actionable's LIMIT) is what actually
+            # surfaces the genuine user items — they're recent, so unscoped they
+            # rank past the cap and never appear. Pinned/high-priority internal
+            # items intentionally re-home to the cockpit, not the user ego.
+            actionable = await follow_up_crud.get_actionable(
+                self._db, domain="user_world",
+            )
         except Exception:
             logger.error("Failed to query follow-ups", exc_info=True)
             lines.append("*Could not query follow-ups.*\n")

--- a/src/genesis/learning/signals/user_goal_staleness.py
+++ b/src/genesis/learning/signals/user_goal_staleness.py
@@ -71,6 +71,12 @@ class UserGoalStalenessCollector:
                 "SELECT created_at FROM follow_ups "
                 "WHERE strategy = 'user_input_needed' "
                 "AND status IN ('pending', 'blocked') "
+                # Strict user_world so this measures genuine USER-goal staleness,
+                # not internal-dev backlog parked under user_input_needed. NOTE:
+                # this signal feeds the Light-reflection scorer, so scoping it
+                # (correctly) lowers its value and softens Light-reflection
+                # cadence — an intended de-biasing, not a side effect.
+                "AND domain = 'user_world' AND kind = 'follow_up' "
                 "ORDER BY created_at ASC LIMIT 1"
             )
             row = await cursor.fetchone()

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -428,9 +428,11 @@ class MorningReportGenerator:
 
         lines = []
 
-        # User-input-needed items
+        # User-input-needed items. Strict user_world throughout: the morning
+        # report is the USER's brief — internal-dev items (incl. internal
+        # failed/blocked) belong to the genesis ego / health, not here.
         user_items = await follow_ups.get_pending(
-            self._db, strategy="user_input_needed",
+            self._db, strategy="user_input_needed", domain="user_world",
         )
         if user_items:
             lines.append("**Needs your input:**")
@@ -438,8 +440,8 @@ class MorningReportGenerator:
                 lines.append(f"- {fu['content'][:200]}")
 
         # Blocked/failed items
-        blocked = await follow_ups.get_by_status(self._db, "failed")
-        blocked += await follow_ups.get_by_status(self._db, "blocked")
+        blocked = await follow_ups.get_by_status(self._db, "failed", domain="user_world")
+        blocked += await follow_ups.get_by_status(self._db, "blocked", domain="user_world")
         if blocked:
             lines.append("**Blocked/failed:**")
             for fu in blocked[:5]:
@@ -448,7 +450,7 @@ class MorningReportGenerator:
 
         # Recently completed (last 24h)
         completed = await follow_ups.get_recently_completed(
-            self._db, hours=24, limit=5,
+            self._db, hours=24, limit=5, domain="user_world",
         )
         if completed:
             lines.append("**Completed (24h):**")

--- a/tests/ego/test_user_context.py
+++ b/tests/ego/test_user_context.py
@@ -803,11 +803,22 @@ class TestUserEgoContextBuilder:
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             ("f1", "recon", "finding", "finding", "Interesting article", "medium", 0, old_date),
         )
+        # A genuine user_world item — counts toward "Awaiting user input".
         await db.execute(
             "INSERT INTO follow_ups "
-            "(id, source, content, strategy, status, priority, created_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            ("fu1", "ego", "Review draft", "user_input_needed", "pending", "high", old_date),
+            "(id, source, content, strategy, status, priority, domain, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("fu1", "ego", "Review draft", "user_input_needed", "pending",
+             "high", "user_world", old_date),
+        )
+        # An internal item under the SAME strategy must NOT inflate the user
+        # backlog — PR3 scopes the "Awaiting user input" counter to user_world.
+        await db.execute(
+            "INSERT INTO follow_ups "
+            "(id, source, content, strategy, status, priority, domain, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("fu2", "foreground_session", "Fix internal bug", "user_input_needed",
+             "pending", "high", "internal", old_date),
         )
         builder = UserEgoContextBuilder(
             db=db, health_data=mock_health_data, capabilities=capabilities,
@@ -817,6 +828,7 @@ class TestUserEgoContextBuilder:
         assert "**Inbox**: 2 pending" in result
         assert "6d ago" in result
         assert "**Recon findings**: 1 pending" in result
+        # Only the user_world item is counted (internal fu2 excluded).
         assert "**Awaiting user input**: 1 pending" in result
 
     @pytest.mark.asyncio

--- a/tests/test_db/test_follow_ups.py
+++ b/tests/test_db/test_follow_ups.py
@@ -305,3 +305,18 @@ async def test_get_recently_completed_domain_exact_match(db):
     assert scoped == ["uw done"]  # internal excluded (NB: result has no domain col)
     unscoped = {r["content"] for r in await follow_ups.get_recently_completed(db)}
     assert unscoped == {"int done", "uw done"}  # backward-compat no-op
+
+
+async def test_get_actionable_domain_excludes_pinned_internal(db):
+    """A PINNED internal row is still excluded by domain='user_world'. Locks the
+    PR3 decision that pinned/high-priority cross-domain items re-home to the
+    cockpit, NOT the user (CEO) ego."""
+    uw = await follow_ups.create(
+        db, **{**_BASE, "content": "user item"}, domain="user_world",
+    )
+    pinned_internal = await follow_ups.create(
+        db, **{**_BASE, "content": "pinned internal"}, domain="internal", pinned=True,
+    )
+    ids = {r["id"] for r in await follow_ups.get_actionable(db, domain="user_world")}
+    assert ids == {uw}
+    assert pinned_internal not in ids

--- a/tests/test_db/test_follow_ups.py
+++ b/tests/test_db/test_follow_ups.py
@@ -236,3 +236,72 @@ async def test_update_status_batch_rejects_invalid_status(db):
     fid = await follow_ups.create(db, **_BASE)
     with pytest.raises(ValueError):
         await follow_ups.update_status_batch(db, [fid], "cancelled")
+
+
+# ─── PR3: exact-match domain scoping on the reader queries ───────────────────
+# Each reader gains an optional exact-match `domain`. Two guarantees per reader:
+#   (1) domain="user_world" returns ONLY user_world rows (NULL excluded);
+#   (2) domain=None (or omitted) returns IDENTICAL rows to before — the
+#       load-bearing backward-compat claim for every untouched caller.
+
+
+async def _seed_pending_domains(db):
+    """One pending follow-up per domain. Returns {domain_key: id}."""
+    return {
+        "internal": await follow_ups.create(
+            db, **{**_BASE, "content": "internal item"}, domain="internal",
+        ),
+        "user_world": await follow_ups.create(
+            db, **{**_BASE, "content": "user item"}, domain="user_world",
+        ),
+        "null": await follow_ups.create(
+            db, **{**_BASE, "content": "unclassified item"},
+        ),
+    }
+
+
+async def test_get_pending_domain_exact_match(db):
+    ids = await _seed_pending_domains(db)
+    scoped = {r["id"] for r in await follow_ups.get_pending(db, domain="user_world")}
+    assert scoped == {ids["user_world"]}  # NULL + internal excluded
+
+
+async def test_get_pending_domain_none_is_noop(db):
+    ids = await _seed_pending_domains(db)
+    explicit_none = {r["id"] for r in await follow_ups.get_pending(db, domain=None)}
+    unscoped = {r["id"] for r in await follow_ups.get_pending(db)}
+    assert explicit_none == unscoped == set(ids.values())
+
+
+async def test_get_by_status_domain_exact_match(db):
+    ids = await _seed_pending_domains(db)
+    scoped = {
+        r["id"] for r in await follow_ups.get_by_status(db, "pending", domain="user_world")
+    }
+    assert scoped == {ids["user_world"]}
+    unscoped = {r["id"] for r in await follow_ups.get_by_status(db, "pending")}
+    assert unscoped == set(ids.values())  # backward-compat no-op
+
+
+async def test_get_actionable_domain_exact_match(db):
+    ids = await _seed_pending_domains(db)
+    scoped = {r["id"] for r in await follow_ups.get_actionable(db, domain="user_world")}
+    assert scoped == {ids["user_world"]}
+    unscoped = {r["id"] for r in await follow_ups.get_actionable(db)}
+    assert unscoped == set(ids.values())  # backward-compat no-op
+
+
+async def test_get_recently_completed_domain_exact_match(db):
+    int_id = await follow_ups.create(
+        db, **{**_BASE, "content": "int done"}, domain="internal",
+    )
+    uw_id = await follow_ups.create(
+        db, **{**_BASE, "content": "uw done"}, domain="user_world",
+    )
+    await follow_ups.update_status(db, int_id, "completed")
+    await follow_ups.update_status(db, uw_id, "completed")
+
+    scoped = [r["content"] for r in await follow_ups.get_recently_completed(db, domain="user_world")]
+    assert scoped == ["uw done"]  # internal excluded (NB: result has no domain col)
+    unscoped = {r["content"] for r in await follow_ups.get_recently_completed(db)}
+    assert unscoped == {"int done", "uw done"}  # backward-compat no-op

--- a/tests/test_db/test_follow_ups.py
+++ b/tests/test_db/test_follow_ups.py
@@ -298,13 +298,15 @@ async def test_get_recently_completed_domain_exact_match(db):
     uw_id = await follow_ups.create(
         db, **{**_BASE, "content": "uw done"}, domain="user_world",
     )
+    null_id = await follow_ups.create(db, **{**_BASE, "content": "null done"})
     await follow_ups.update_status(db, int_id, "completed")
     await follow_ups.update_status(db, uw_id, "completed")
+    await follow_ups.update_status(db, null_id, "completed")
 
     scoped = [r["content"] for r in await follow_ups.get_recently_completed(db, domain="user_world")]
-    assert scoped == ["uw done"]  # internal excluded (NB: result has no domain col)
+    assert scoped == ["uw done"]  # internal + NULL excluded (NB: result has no domain col)
     unscoped = {r["content"] for r in await follow_ups.get_recently_completed(db)}
-    assert unscoped == {"int done", "uw done"}  # backward-compat no-op
+    assert unscoped == {"int done", "uw done", "null done"}  # NULL survives unscoped no-op
 
 
 async def test_get_actionable_domain_excludes_pinned_internal(db):

--- a/tests/test_learning/test_user_goal_staleness.py
+++ b/tests/test_learning/test_user_goal_staleness.py
@@ -1,0 +1,48 @@
+"""Tests for UserGoalStalenessCollector follow-up scoping (PR3).
+
+The signal must measure genuine USER-goal staleness — i.e. only follow-ups in
+the user_world domain — not internal-dev backlog parked under the
+`user_input_needed` strategy. This is the change that (correctly) de-skews the
+signal from ~0.97 and, as a downstream effect, softens Light-reflection cadence.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from genesis.db.crud import follow_ups
+from genesis.learning.signals.user_goal_staleness import UserGoalStalenessCollector
+
+
+async def _make(db, *, domain, age_days, now):
+    fid = await follow_ups.create(
+        db, source="t", content=f"{domain} item",
+        strategy="user_input_needed", domain=domain,
+    )
+    await db.execute(
+        "UPDATE follow_ups SET created_at = ? WHERE id = ?",
+        ((now - timedelta(days=age_days)).isoformat(), fid),
+    )
+    await db.commit()
+    return fid
+
+
+async def test_check_follow_ups_scoped_to_user_world(db):
+    now = datetime(2026, 6, 22, tzinfo=UTC)
+    collector = UserGoalStalenessCollector(db)
+
+    # An ancient INTERNAL user_input_needed item is ignored entirely — pre-scoping
+    # this single 60-day row pinned the signal at 1.0.
+    await _make(db, domain="internal", age_days=60, now=now)
+    assert await collector._check_follow_ups(now) == 0.0
+
+    # A recent user_world item makes the signal reflect ITS (low) age — proving
+    # the 60-day internal row did NOT leak in (else it would read 1.0).
+    uw_id = await _make(db, domain="user_world", age_days=1, now=now)
+    assert await collector._check_follow_ups(now) < 1.0
+
+    # And an OLD user_world item DOES drive it to 1.0 (user_world is counted).
+    await db.execute(
+        "UPDATE follow_ups SET created_at = ? WHERE id = ?",
+        ((now - timedelta(days=60)).isoformat(), uw_id),
+    )
+    await db.commit()
+    assert await collector._check_follow_ups(now) == 1.0


### PR DESCRIPTION
Third piece of the follow-up subsystem redesign (after #741 schema foundation and #746 the cockpit). Scopes the user-facing follow-up consumers to the user's domain so they surface the user's items instead of Genesis's internal-engineering backlog. **No migration** — the `domain` column already exists (#741).

## Why
Every consumer read `follow_ups` domain-blind. Because `user_input_needed` is effectively a junk-drawer strategy (the dominant pending class), the user ego, the morning report, and the `user_goal_staleness` signal were dominated by internal-dev backlog. Two concrete effects, both verified against live data:
- **Genuine user items were invisible.** `get_actionable` caps at the top 50 by `(priority, created_at)`; the real user-world items are recent, so they rank past the cap and never reach the user ego at all.
- **The staleness signal was mis-measuring.** Named/rendered as *user*-goal staleness, it counted internal items too — pinning it near the top of its range off internal backlog.

## What
- **CRUD (commit 1):** an optional exact-match `domain` param on `get_pending` / `get_by_status` / `get_actionable` / `get_recently_completed` (via a small `_domain_eq` helper). When set, scopes in SQL *before* the LIMIT; `domain=None` is a byte-identical no-op, so every other caller is untouched. Cockpit-consistent exact-match — deliberately not a second NULL-handling idiom.
- **Consumers (commit 2):** the user ego's open-threads section, the "awaiting user input" counter, the `user_goal_staleness` signal, and the morning report are scoped to the user's domain (signal + counter also exclude tabled rows). The genesis ego is **deferred** — its existing strategy/source post-filter already rejects the relevant rows, so scoping it is a near-no-op.

## Deliberate trade-offs (accepted)
- **Pinned / high-priority cross-domain items re-home to the cockpit.** Strict scoping drops them from the user (CEO) ego — by design: they're internal/COO-domain work, fully visible in the cockpit (#746). Nothing is lost, just correctly homed.
- **The signal change softens Light-reflection cadence.** The signal feeds the Light-reflection scorer, so correcting its value (a de-biasing) reduces how often Light reflections fire. Intended.

## Testing
- ~200 targeted tests green; ruff clean. New tests cover the domain filter, the `domain=None` backward-compat no-op per reader, the signal scoping, the ego-level internal-exclusion, and the pinned-cross-domain re-homing.
- **E2E against a consistent copy of the live DB, running this branch's code:** the unscoped top-50 contains zero user-world items (the burial), while the scoped query returns exactly the genuine user items; the counter and signal de-skew as expected. The full live verification (ego cycle, reflection cadence, morning report on the running server) is post-deploy.

CHANGELOG: no entry here — consistent with #741/#746; a consolidated redesign entry belongs at the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)