### PR TITLE
feat(recon): GitHub Discovery — ranking engine + on-demand tool (1A foundation)

### DIFF
--- a/src/genesis/mcp/recon_mcp.py
+++ b/src/genesis/mcp/recon_mcp.py
@@ -369,3 +369,41 @@ async def recon_run_skill_scan() -> dict:
 
     job = SkillSecurityScanJob(db=_db)
     return await job.run()
+
+
+@mcp.tool()
+async def recon_run_github_discovery(query: str, limit: int = 10) -> dict:
+    """Discover GitHub repos for a topic, ranked by momentum/activity/maturity.
+
+    On-demand foreground tool — searches GitHub (newest+most-starred pool),
+    scores each repo on three axes, and returns the top `limit` ranked
+    candidates. Files NOTHING (read-only). The composite `score` plus its
+    momentum/activity/maturity breakdown are returned so a fast-growing
+    lower-star repo can visibly outrank a stale high-star one.
+
+    momentum = stars-per-day-since-creation (log-damped); activity = push
+    recency; maturity = repo age. Forks and archived repos are excluded.
+    """
+    from genesis.recon.github_discovery import search_repos
+
+    candidates = await search_repos(query, limit=limit)
+    repos = [
+        {
+            "full_name": c.full_name,
+            "url": c.url,
+            "stars": c.stars,
+            "language": c.language,
+            "description": (c.description or "")[:200],
+            "created_at": c.created_at,
+            "pushed_at": c.pushed_at,
+            "score": round(c.score, 4),
+            "momentum": round(c.momentum, 4),
+            "activity": round(c.activity, 4),
+            "maturity": round(c.maturity, 4),
+        }
+        for c in candidates
+    ]
+    result = {"query": query, "count": len(repos), "repos": repos}
+    if not repos:
+        result["note"] = "no results — if unexpected, check gh auth / rate-limit (30/min) in logs"
+    return result

--- a/src/genesis/recon/gatherer.py
+++ b/src/genesis/recon/gatherer.py
@@ -19,7 +19,6 @@ logger = logging.getLogger(__name__)
 
 _CONFIG_DIR = Path(__file__).resolve().parents[3] / "config"
 _WATCHLIST_PATH = _CONFIG_DIR / "recon_watchlist.yaml"
-_GH_TIMEOUT = 15  # seconds — network calls are slower than local git
 _RELEASES_PER_PROJECT = 2
 _MAX_BODY_CHARS = 1000
 
@@ -355,7 +354,7 @@ class ReconGatherer:
         subprocess/timeout/kill handling); kept as a method so existing call
         sites and tests that patch ``ReconGatherer._run_gh`` are unaffected.
         """
-        return await run_gh(*args, timeout=_GH_TIMEOUT)
+        return await run_gh(*args)
 
     @staticmethod
     def _load_watchlist() -> list[dict]:

--- a/src/genesis/recon/gatherer.py
+++ b/src/genesis/recon/gatherer.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import hashlib
 import json
 import logging
@@ -15,6 +13,7 @@ from pathlib import Path
 import aiosqlite
 
 from genesis.db.crud import observations
+from genesis.recon.gh_cli import run_gh
 
 logger = logging.getLogger(__name__)
 
@@ -350,35 +349,13 @@ class ReconGatherer:
         return None
 
     async def _run_gh(self, *args: str) -> str:
-        """Run gh CLI command with timeout. Returns stdout or empty on failure."""
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                *args,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(), timeout=_GH_TIMEOUT
-            )
-            if proc.returncode != 0:
-                logger.warning(
-                    "gh command failed (rc=%d): %s — %s",
-                    proc.returncode,
-                    " ".join(args),
-                    stderr.decode("utf-8", errors="replace")[:200],
-                )
-                return ""
-            return stdout.decode("utf-8", errors="replace").strip()
-        except TimeoutError:
-            logger.warning("gh command timed out: %s", " ".join(args))
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
-            with contextlib.suppress(ChildProcessError):
-                await proc.wait()
-            return ""
-        except OSError:
-            logger.warning("gh command failed to start: %s", " ".join(args), exc_info=True)
-            return ""
+        """Run gh CLI command with timeout. Returns stdout or empty on failure.
+
+        Delegates to the shared ``gh_cli.run_gh`` (single source of truth for the
+        subprocess/timeout/kill handling); kept as a method so existing call
+        sites and tests that patch ``ReconGatherer._run_gh`` are unaffected.
+        """
+        return await run_gh(*args, timeout=_GH_TIMEOUT)
 
     @staticmethod
     def _load_watchlist() -> list[dict]:

--- a/src/genesis/recon/gh_cli.py
+++ b/src/genesis/recon/gh_cli.py
@@ -25,6 +25,7 @@ async def run_gh(*args: str, timeout: int | float = _DEFAULT_TIMEOUT) -> str:
     an empty string so callers can treat "no data" uniformly. On timeout the
     child process is killed and reaped to avoid leaks.
     """
+    proc: asyncio.subprocess.Process | None = None
     try:
         proc = await asyncio.create_subprocess_exec(
             *args,
@@ -43,10 +44,11 @@ async def run_gh(*args: str, timeout: int | float = _DEFAULT_TIMEOUT) -> str:
         return stdout.decode("utf-8", errors="replace").strip()
     except TimeoutError:
         logger.warning("gh command timed out: %s", " ".join(args))
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
-        with contextlib.suppress(ChildProcessError):
-            await proc.wait()
+        if proc is not None:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            with contextlib.suppress(ProcessLookupError):
+                await proc.wait()
         return ""
     except OSError:
         logger.warning("gh command failed to start: %s", " ".join(args), exc_info=True)

--- a/src/genesis/recon/gh_cli.py
+++ b/src/genesis/recon/gh_cli.py
@@ -1,0 +1,53 @@
+"""Shared `gh` CLI runner for recon jobs.
+
+Single source of truth for invoking the GitHub CLI via subprocess with a
+timeout and uniform failure handling (the process-kill sequence on timeout is
+easy to get subtly wrong, so it lives here rather than being copy-pasted).
+Both ``ReconGatherer`` and ``github_discovery`` use this.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Network calls are slower than local git — generous default ceiling.
+_DEFAULT_TIMEOUT = 15
+
+
+async def run_gh(*args: str, timeout: int | float = _DEFAULT_TIMEOUT) -> str:
+    """Run a ``gh`` command with a timeout. Returns stdout, or "" on any failure.
+
+    Failure (non-zero exit, timeout, or spawn error) is logged and collapsed to
+    an empty string so callers can treat "no data" uniformly. On timeout the
+    child process is killed and reaped to avoid leaks.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        if proc.returncode != 0:
+            logger.warning(
+                "gh command failed (rc=%s): %s — %s",
+                proc.returncode,
+                " ".join(args),
+                stderr.decode("utf-8", errors="replace")[:200],
+            )
+            return ""
+        return stdout.decode("utf-8", errors="replace").strip()
+    except TimeoutError:
+        logger.warning("gh command timed out: %s", " ".join(args))
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        with contextlib.suppress(ChildProcessError):
+            await proc.wait()
+        return ""
+    except OSError:
+        logger.warning("gh command failed to start: %s", " ".join(args), exc_info=True)
+        return ""

--- a/src/genesis/recon/github_discovery.py
+++ b/src/genesis/recon/github_discovery.py
@@ -1,0 +1,236 @@
+"""GitHub Discovery — proactively find new repos in the user's domains.
+
+Ranking engine (this module) + an on-demand MCP tool. A scheduled job that
+files curated findings is layered on top separately. The engine searches via
+the gh CLI, scores each repo on three axes, and returns a ranked shortlist:
+
+  momentum  — stars-per-day-since-creation (a first-sight growth proxy; no
+              star history needed), log-damped, denominator floored so a
+              one-day-old hype repo can't dominate.
+  activity  — recency of the last push (exponential decay): alive vs abandoned.
+  maturity  — repo age (saturating): penalizes brand-new/unproven repos.
+
+Scoring functions are pure and take an explicit ``now`` so they're
+deterministic under test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from genesis.recon.gh_cli import run_gh
+
+logger = logging.getLogger(__name__)
+
+# gh search returns at most 100/page. Fetch the full page and score locally so
+# the momentum metric isn't defeated by gh's stars-ordered top-`limit` slice.
+_GH_SEARCH_PAGE = 100
+_GH_FIELDS = "fullName,url,stargazersCount,createdAt,pushedAt,description,language,isArchived"
+# GitHub search API allows 30 req/min → ≥2s between topic queries.
+_QUERY_SPACING_S = 2.0
+
+# ── Scoring tunables (eyeballed at the foundation checkpoint, easy to adjust) ──
+_MOMENTUM_AGE_FLOOR_DAYS = 30.0   # don't reward 1-day-old stars-per-day spikes
+_MOMENTUM_SATURATION = 50.0       # stars/day at which momentum ≈ 1.0
+_ACTIVITY_TAU_DAYS = 45.0         # push-recency decay constant
+_MATURITY_TAU_DAYS = 180.0        # age-maturity rise constant
+
+
+@dataclass(frozen=True)
+class ScoreWeights:
+    """Weights for the composite score. Sum need not be 1 (kept ≈1 here)."""
+
+    momentum: float = 0.4
+    activity: float = 0.3
+    maturity: float = 0.3
+
+
+# Default mirrors the inbox tool-scoring rubric (momentum 40 / activity 30 /
+# maturity 30). The architect flagged push-recency as the noisiest signal; if
+# the checkpoint shows activity misleading, shift toward .5/.2/.3.
+DEFAULT_WEIGHTS = ScoreWeights()
+
+
+@dataclass(frozen=True)
+class RepoCandidate:
+    """A scored GitHub repo discovered for the user's review."""
+
+    full_name: str
+    url: str
+    stars: int
+    created_at: str
+    pushed_at: str
+    description: str
+    language: str
+    momentum: float
+    activity: float
+    maturity: float
+    score: float
+
+
+def _clamp01(x: float) -> float:
+    return max(0.0, min(1.0, x))
+
+
+def _days_between(iso: str | None, now: datetime) -> float | None:
+    """Fractional days between an ISO timestamp and ``now``. None if unparsable."""
+    if not iso:
+        return None
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        return (now - dt).total_seconds() / 86400.0
+    except (ValueError, TypeError):
+        return None
+
+
+def score_momentum(stars: int, created_at: str | None, now: datetime) -> float:
+    """Stars-per-day-since-creation, log-damped. Floor the age so very young
+    repos aren't rewarded for a high transient rate."""
+    age = _days_between(created_at, now)
+    if age is None:
+        return 0.0
+    denom = max(age, _MOMENTUM_AGE_FLOOR_DAYS)
+    rate = max(stars, 0) / denom
+    return _clamp01(math.log10(rate + 1.0) / math.log10(_MOMENTUM_SATURATION + 1.0))
+
+
+def score_activity(pushed_at: str | None, now: datetime) -> float:
+    """Exponential decay on days-since-last-push. Unknown push date → 0."""
+    days = _days_between(pushed_at, now)
+    if days is None:
+        return 0.0
+    return _clamp01(math.exp(-max(days, 0.0) / _ACTIVITY_TAU_DAYS))
+
+
+def score_maturity(created_at: str | None, now: datetime) -> float:
+    """Saturating rise with age: brand-new repos score low (unproven)."""
+    age = _days_between(created_at, now)
+    if age is None:
+        return 0.0
+    return _clamp01(1.0 - math.exp(-max(age, 0.0) / _MATURITY_TAU_DAYS))
+
+
+def score_candidate(
+    repo: dict, now: datetime, weights: ScoreWeights = DEFAULT_WEIGHTS
+) -> RepoCandidate:
+    """Score a single ``gh search repos --json`` item into a RepoCandidate.
+
+    Tolerant of missing keys (gh omits null descriptions/languages).
+    """
+    full_name = str(repo.get("fullName") or repo.get("full_name") or "")
+    url = str(repo.get("url") or "")
+    stars = int(repo.get("stargazersCount") or repo.get("stars") or 0)
+    created = str(repo.get("createdAt") or repo.get("created_at") or "")
+    pushed = str(repo.get("pushedAt") or repo.get("pushed_at") or "")
+    description = str(repo.get("description") or "")
+    language = str(repo.get("language") or "")
+
+    momentum = score_momentum(stars, created, now)
+    activity = score_activity(pushed, now)
+    maturity = score_maturity(created, now)
+    # Keep full precision so `score` is exactly the weighted sum of the stored
+    # components (display rounding happens at the MCP-tool boundary).
+    score = _clamp01(
+        weights.momentum * momentum
+        + weights.activity * activity
+        + weights.maturity * maturity
+    )
+    return RepoCandidate(
+        full_name=full_name,
+        url=url,
+        stars=stars,
+        created_at=created,
+        pushed_at=pushed,
+        description=description,
+        language=language,
+        momentum=momentum,
+        activity=activity,
+        maturity=maturity,
+        score=score,
+    )
+
+
+# ── Search & discovery ───────────────────────────────────────────────────────
+
+
+async def search_repos(
+    query: str,
+    *,
+    limit: int = 10,
+    now: datetime | None = None,
+    weights: ScoreWeights = DEFAULT_WEIGHTS,
+) -> list[RepoCandidate]:
+    """Search GitHub for repos matching ``query``, scored and ranked desc.
+
+    Fetches a wide page from gh and scores locally (so a high-momentum,
+    lower-star repo isn't pre-filtered away), excludes forks and archived
+    repos, then returns the top ``limit`` by composite score. Returns [] on any
+    gh failure or malformed output (callers treat that as "no results").
+    """
+    now = now or datetime.now(UTC)
+    full_query = query if "fork:" in query else f"{query} fork:false"
+
+    raw = await run_gh(
+        "gh", "search", "repos", full_query,
+        "--sort", "stars",
+        "--limit", str(_GH_SEARCH_PAGE),
+        "--json", _GH_FIELDS,
+    )
+    if not raw:
+        return []
+    try:
+        items = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("github_discovery: malformed gh JSON for query %r", query)
+        return []
+    if not isinstance(items, list):
+        return []
+
+    candidates = [
+        score_candidate(r, now, weights)
+        for r in items
+        if isinstance(r, dict) and not r.get("isArchived")
+    ]
+    candidates.sort(key=lambda c: c.score, reverse=True)
+    logger.info(
+        "github_discovery: query=%r fetched=%d ranked=%d returned=%d",
+        query, len(items), len(candidates), min(limit, len(candidates)),
+    )
+    return candidates[:limit]
+
+
+async def discover(
+    queries: list[str],
+    *,
+    limit_per_query: int = 10,
+    total_cap: int | None = None,
+    now: datetime | None = None,
+    weights: ScoreWeights = DEFAULT_WEIGHTS,
+    spacing_s: float = _QUERY_SPACING_S,
+) -> list[RepoCandidate]:
+    """Run several topic searches, dedupe by repo (keep highest score), rank.
+
+    Spaces calls by ``spacing_s`` to respect GitHub's 30 req/min search limit.
+    """
+    now = now or datetime.now(UTC)
+    best: dict[str, RepoCandidate] = {}
+
+    for i, query in enumerate(queries):
+        if i > 0 and spacing_s:
+            await asyncio.sleep(spacing_s)
+        for cand in await search_repos(
+            query, limit=limit_per_query, now=now, weights=weights
+        ):
+            if not cand.full_name:
+                continue
+            prev = best.get(cand.full_name)
+            if prev is None or cand.score > prev.score:
+                best[cand.full_name] = cand
+
+    ranked = sorted(best.values(), key=lambda c: c.score, reverse=True)
+    return ranked[:total_cap] if total_cap else ranked

--- a/src/genesis/recon/github_discovery.py
+++ b/src/genesis/recon/github_discovery.py
@@ -34,11 +34,18 @@ _GH_FIELDS = "fullName,url,stargazersCount,createdAt,pushedAt,description,langua
 # GitHub search API allows 30 req/min → ≥2s between topic queries.
 _QUERY_SPACING_S = 2.0
 
-# ── Scoring tunables (eyeballed at the foundation checkpoint, easy to adjust) ──
+# ── Scoring tunables — "balanced" calibration (recalibrated at the checkpoint
+# against real shortlists so no axis saturates and a young riser and an
+# established leader can both surface). All easy to adjust. ──
 _MOMENTUM_AGE_FLOOR_DAYS = 30.0   # don't reward 1-day-old stars-per-day spikes
-_MOMENTUM_SATURATION = 50.0       # stars/day at which momentum ≈ 1.0
-_ACTIVITY_TAU_DAYS = 45.0         # push-recency decay constant
-_MATURITY_TAU_DAYS = 180.0        # age-maturity rise constant
+# stars/day at which momentum ≈ 1.0. Set high so hot repos (mem0 ~54/day,
+# deer-flow ~178/day) stay distinguishable instead of all pegging at 1.0.
+_MOMENTUM_SATURATION = 250.0
+_ACTIVITY_TAU_DAYS = 45.0         # push-recency decay constant (liveness)
+# Maturity is a SOFT ramp, not an age reward: rises linearly to 1.0 by this many
+# days, then plateaus — so it penalizes only brand-new/unproven repos and does
+# NOT keep rewarding a 3-year-old repo over a healthy 6-month-old one.
+_MATURITY_PLATEAU_DAYS = 120.0
 
 
 @dataclass(frozen=True)
@@ -108,11 +115,12 @@ def score_activity(pushed_at: str | None, now: datetime) -> float:
 
 
 def score_maturity(created_at: str | None, now: datetime) -> float:
-    """Saturating rise with age: brand-new repos score low (unproven)."""
+    """Soft linear ramp with age, plateauing at 1.0: brand-new repos score low
+    (unproven), but age past the plateau is not further rewarded."""
     age = _days_between(created_at, now)
     if age is None:
         return 0.0
-    return _clamp01(1.0 - math.exp(-max(age, 0.0) / _MATURITY_TAU_DAYS))
+    return _clamp01(max(age, 0.0) / _MATURITY_PLATEAU_DAYS)
 
 
 def score_candidate(

--- a/tests/test_recon/test_gh_cli.py
+++ b/tests/test_recon/test_gh_cli.py
@@ -1,0 +1,67 @@
+"""Tests for the shared gh CLI runner (genesis.recon.gh_cli)."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from genesis.recon.gh_cli import run_gh
+
+
+def _mock_subprocess(stdout: str, returncode: int = 0):
+    """Build a fake asyncio.create_subprocess_exec returning given stdout/rc."""
+
+    async def create_subprocess(*args, **kwargs):
+        proc = AsyncMock()
+        proc.returncode = returncode
+        proc.communicate = AsyncMock(return_value=(stdout.encode(), b""))
+        return proc
+
+    return create_subprocess
+
+
+@pytest.mark.asyncio
+async def test_success_returns_stripped_stdout():
+    with patch("asyncio.create_subprocess_exec", side_effect=_mock_subprocess('  ["ok"]  ')):
+        result = await run_gh("gh", "api", "test")
+    assert result == '["ok"]'
+
+
+@pytest.mark.asyncio
+async def test_nonzero_exit_returns_empty():
+    with patch("asyncio.create_subprocess_exec", side_effect=_mock_subprocess("boom", returncode=1)):
+        result = await run_gh("gh", "api", "test")
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_timeout_returns_empty_and_kills_process():
+    captured: dict = {}
+
+    async def slow_subprocess(*args, **kwargs):
+        proc = AsyncMock()
+        proc.returncode = 0
+
+        async def slow_communicate():
+            await asyncio.sleep(100)
+            return b"", b""
+
+        proc.communicate = slow_communicate
+        captured["proc"] = proc
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=slow_subprocess):
+        result = await run_gh("gh", "api", "test", timeout=0.05)
+
+    assert result == ""
+    captured["proc"].kill.assert_called_once()
+    captured["proc"].wait.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_os_error_returns_empty():
+    with patch("asyncio.create_subprocess_exec", side_effect=OSError("gh not found")):
+        result = await run_gh("gh", "api", "test")
+    assert result == ""

--- a/tests/test_recon/test_github_discovery.py
+++ b/tests/test_recon/test_github_discovery.py
@@ -50,6 +50,15 @@ def test_momentum_handles_missing_date():
     assert score_momentum(1000, "", _NOW) == 0.0
 
 
+def test_momentum_discriminates_among_hot_repos_no_saturation():
+    # Balanced calibration: popular repos must NOT all peg at 1.0 — momentum has
+    # to separate a fast grower from a faster one across the realistic range.
+    hot = score_momentum(10000, _iso(100), _NOW)     # ~100 stars/day
+    hotter = score_momentum(20000, _iso(100), _NOW)  # ~200 stars/day
+    assert hot < hotter
+    assert hot < 1.0 and hotter < 1.0
+
+
 # ── score_activity ───────────────────────────────────────────────────────────
 
 

--- a/tests/test_recon/test_github_discovery.py
+++ b/tests/test_recon/test_github_discovery.py
@@ -1,0 +1,214 @@
+"""Tests for the GitHub Discovery ranking engine."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from genesis.recon.github_discovery import (
+    DEFAULT_WEIGHTS,
+    RepoCandidate,
+    discover,
+    score_activity,
+    score_candidate,
+    score_maturity,
+    score_momentum,
+    search_repos,
+)
+
+_NOW = datetime(2026, 6, 22, tzinfo=UTC)
+
+
+def _iso(days_ago: int) -> str:
+    """ISO timestamp `days_ago` before _NOW, with a Z suffix like gh returns."""
+    from datetime import timedelta
+
+    return (_NOW - timedelta(days=days_ago)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ── score_momentum ───────────────────────────────────────────────────────────
+
+
+def test_momentum_young_fast_beats_old_slow():
+    young = score_momentum(3000, _iso(60), _NOW)   # 50 stars/day
+    old = score_momentum(3000, _iso(1500), _NOW)   # 2 stars/day
+    assert young > old
+    assert 0.0 <= old <= young <= 1.0
+
+
+def test_momentum_floors_denominator_so_one_day_hype_does_not_max_out():
+    # A 1-day-old repo should NOT score near-1 just because stars/age is huge:
+    # denominator is floored at 30 days.
+    hype = score_momentum(300, _iso(1), _NOW)
+    assert hype < 0.9
+
+
+def test_momentum_handles_missing_date():
+    assert score_momentum(1000, "", _NOW) == 0.0
+
+
+# ── score_activity ───────────────────────────────────────────────────────────
+
+
+def test_activity_recent_beats_stale():
+    recent = score_activity(_iso(1), _NOW)
+    stale = score_activity(_iso(150), _NOW)
+    assert recent > stale
+    assert 0.0 <= stale <= recent <= 1.0
+
+
+def test_activity_pushed_today_is_near_one():
+    assert score_activity(_iso(0), _NOW) > 0.95
+
+
+def test_activity_handles_missing_date():
+    assert score_activity(None, _NOW) == 0.0
+
+
+# ── score_maturity ───────────────────────────────────────────────────────────
+
+
+def test_maturity_proven_beats_brand_new():
+    mature = score_maturity(_iso(730), _NOW)   # 2 years
+    brand_new = score_maturity(_iso(10), _NOW)  # 10 days
+    assert mature > brand_new
+    assert 0.0 <= brand_new <= mature <= 1.0
+
+
+def test_maturity_brand_new_is_low():
+    assert score_maturity(_iso(5), _NOW) < 0.1
+
+
+# ── score_candidate ──────────────────────────────────────────────────────────
+
+
+def _repo(full_name, stars, created_days, pushed_days):
+    return {
+        "fullName": full_name,
+        "url": f"https://github.com/{full_name}",
+        "stargazersCount": stars,
+        "createdAt": _iso(created_days),
+        "pushedAt": _iso(pushed_days),
+        "description": "a repo",
+        "language": "Python",
+    }
+
+
+def test_score_candidate_returns_populated_dataclass():
+    cand = score_candidate(_repo("a/b", 1200, 400, 3), _NOW)
+    assert isinstance(cand, RepoCandidate)
+    assert cand.full_name == "a/b"
+    assert cand.url == "https://github.com/a/b"
+    assert cand.stars == 1200
+    assert cand.language == "Python"
+    assert 0.0 <= cand.score <= 1.0
+    # Composite equals the weighted sum of the three components.
+    expected = (
+        DEFAULT_WEIGHTS.momentum * cand.momentum
+        + DEFAULT_WEIGHTS.activity * cand.activity
+        + DEFAULT_WEIGHTS.maturity * cand.maturity
+    )
+    assert cand.score == pytest.approx(expected)
+
+
+def test_score_candidate_strong_outranks_weak():
+    strong = score_candidate(_repo("x/strong", 3000, 90, 2), _NOW)   # young-ish, active, traction
+    stale = score_candidate(_repo("y/stale", 3000, 1500, 500), _NOW)  # old, abandoned
+    assert strong.score > stale.score
+
+
+def test_score_candidate_survives_missing_fields():
+    cand = score_candidate({"fullName": "only/name"}, _NOW)
+    assert cand.full_name == "only/name"
+    assert cand.stars == 0
+    assert 0.0 <= cand.score <= 1.0
+
+
+# ── search_repos ─────────────────────────────────────────────────────────────
+
+
+def _gh_json(*repos: dict) -> str:
+    return json.dumps(list(repos))
+
+
+@pytest.mark.asyncio
+async def test_search_repos_parses_scores_and_sorts_desc():
+    raw = _gh_json(
+        _repo("slow/old", 3000, 1500, 500),    # should rank last
+        _repo("fast/young", 3000, 90, 2),       # should rank first
+    )
+    with patch("genesis.recon.github_discovery.run_gh", AsyncMock(return_value=raw)):
+        results = await search_repos("agent memory", limit=10, now=_NOW)
+    assert [c.full_name for c in results] == ["fast/young", "slow/old"]
+    assert all(isinstance(c, RepoCandidate) for c in results)
+
+
+@pytest.mark.asyncio
+async def test_search_repos_fetches_wide_then_cuts_to_limit():
+    # P1-C: must fetch the API page cap (100) from gh, NOT `limit`, so scoring
+    # selects from the full pool rather than a stars-biased top-`limit` slice.
+    raw = _gh_json(*[_repo(f"r/{i}", 100 * i, 200, 5) for i in range(1, 6)])
+    mock = AsyncMock(return_value=raw)
+    with patch("genesis.recon.github_discovery.run_gh", mock):
+        results = await search_repos("mcp", limit=2, now=_NOW)
+    assert len(results) == 2  # cut to limit locally
+    called_args = mock.call_args.args
+    assert "100" in called_args  # fetched wide
+    assert "2" not in called_args  # did NOT pass limit to gh
+
+
+@pytest.mark.asyncio
+async def test_search_repos_excludes_forks_in_query():
+    mock = AsyncMock(return_value="[]")
+    with patch("genesis.recon.github_discovery.run_gh", mock):
+        await search_repos("rag", now=_NOW)
+    query_arg = next(a for a in mock.call_args.args if "rag" in a)
+    assert "fork:false" in query_arg
+
+
+@pytest.mark.asyncio
+async def test_search_repos_filters_archived():
+    archived = _repo("dead/archived", 5000, 400, 3)
+    archived["isArchived"] = True
+    raw = _gh_json(archived, _repo("live/repo", 800, 200, 1))
+    with patch("genesis.recon.github_discovery.run_gh", AsyncMock(return_value=raw)):
+        results = await search_repos("harness", now=_NOW)
+    assert [c.full_name for c in results] == ["live/repo"]
+
+
+@pytest.mark.asyncio
+async def test_search_repos_handles_empty_and_malformed():
+    for bad in ("", "not json", '{"not": "a list"}'):
+        with patch("genesis.recon.github_discovery.run_gh", AsyncMock(return_value=bad)):
+            assert await search_repos("x", now=_NOW) == []
+
+
+# ── discover (multi-topic) ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_discover_dedupes_across_queries_keeping_best_score():
+    # Same repo appears in two topic searches; keep one entry (highest score).
+    q1 = _gh_json(_repo("dup/repo", 1000, 300, 5), _repo("a/one", 500, 300, 5))
+    q2 = _gh_json(_repo("dup/repo", 1000, 300, 5), _repo("b/two", 700, 300, 5))
+    with patch("genesis.recon.github_discovery.run_gh", AsyncMock(side_effect=[q1, q2])), \
+            patch("genesis.recon.github_discovery.asyncio.sleep", AsyncMock()):
+        results = await discover(["agents", "memory"], limit_per_query=10, now=_NOW)
+    names = [c.full_name for c in results]
+    assert names.count("dup/repo") == 1
+    assert set(names) == {"dup/repo", "a/one", "b/two"}
+
+
+@pytest.mark.asyncio
+async def test_discover_applies_total_cap_and_spaces_calls():
+    raw = _gh_json(_repo("a/1", 900, 300, 5), _repo("b/2", 800, 300, 5))
+    sleep_mock = AsyncMock()
+    with patch("genesis.recon.github_discovery.run_gh", AsyncMock(return_value=raw)), \
+            patch("genesis.recon.github_discovery.asyncio.sleep", sleep_mock):
+        results = await discover(["q1", "q2"], total_cap=3, now=_NOW)
+    assert len(results) <= 3
+    # Spacing between the 2 queries → exactly one inter-call sleep.
+    assert sleep_mock.await_count == 1


### PR DESCRIPTION
## What

The **1A foundation** of GitHub Discovery: a curated repo-discovery ranking engine + an on-demand MCP tool. Genesis can now search GitHub in the user's domains and return a *scored, ranked* shortlist — the groundwork for proactive "here are rising repos worth a look" discovery.

Framing: **GitHub Discovery = the inbox, inverted.** Today the user manually finds repos and drops them in for evaluation; this lets Genesis do the *finding* and present a curated shortlist, with the human review gate kept intact.

## Why this is the read-only foundation (no firehose)

The old recon lane floods the knowledge base because it routes findings through `run_intake` **without a router** → everything defaults to 0.5 confidence → clears the `>=0.4` KB threshold → nothing is ever discarded. This PR deliberately ships only the **read-only** half: the engine + an on-demand tool that **files nothing**. The scheduled job that files curated survivors to the recon **triage queue** (never the KB), with dedup-hash + gh-auth-probe hardening, is the follow-up **1B** PR.

## What's in this PR

- **`recon/gh_cli.py`** (new) — shared `run_gh(*args, timeout=15)`, extracted from `ReconGatherer._run_gh` so the subprocess/timeout/kill handling has a single owner (the gatherer now delegates; behavior unchanged).
- **`recon/github_discovery.py`** (new) — ranking engine:
  - `momentum` (stars-per-day-since-creation, log-damped, age-floored) · `activity` (push-recency decay) · `maturity` (soft age ramp). Pure functions, inject `now` for determinism. "Balanced" calibration (ceiling/plateau tuned against real shortlists so no axis saturates).
  - `search_repos` fetches the gh API page cap and scores **locally** (so a high-momentum lower-star repo isn't pre-filtered by gh's stars order), excludes forks + archived.
  - `discover` runs multiple topics, dedupes (keep best score), spaces calls for the 30 req/min search limit.
- **`recon_run_github_discovery(query, limit)`** MCP tool — returns the ranked shortlist **with the momentum/activity/maturity breakdown** so a fast-growing lower-star repo visibly outranks a stale high-star one. Files nothing.

## Testing

- **27 targeted tests** (engine + gh_cli); **58 recon tests green** (gatherer unaffected by the extraction); ruff clean.
- **Live E2E against real GitHub** verified end-to-end — the balanced ranking surfaced a genuinely on-topic, recent, high-traction agent-harness repo at the top (confirmed real via the API, not a parse artifact).

## Review

- **genesis-architect** design review *before* implementation — fetch-wide-then-score, gh_cli extraction, fork/archived/age-instability fixes incorporated.
- **code-reviewer** implementation review — fixed the timeout-handler unbound-name/wrong-suppressor (P1) and the duplicate timeout constant (P2). Codex quota-exhausted until ~mid-July; can re-run before merge if it recovers.

## Scope / safety

- No migration, no new DB table, no capabilities registration (MCP tools auto-expose).
- The curated **proactive scheduled job** (1B) is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
