### PR TITLE
chore(ci): block committed binary/data artifacts in leak-detector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,30 @@ jobs:
           fi
           echo "Email scan: CLEAN"
 
+      - name: Binary/data artifact scan
+        run: |
+          set -euo pipefail
+          # Voiceprints, audio, databases, and models match NONE of the text
+          # scans above, so a `git add -f` past .gitignore would commit one
+          # unnoticed. Block any TRACKED artifact of these types (uses the git
+          # index, so untracked local data is ignored).
+          data_globs=(
+            '*.wav' '*.flac' '*.pcm' '*.mp3' '*.m4a' '*.ogg' '*.opus'
+            '*.db' '*.db-wal' '*.db-shm' '*.sqlite' '*.sqlite3'
+            '*.onnx'
+            '*speaker_registry*.json' 'ambient_enroll_*.json'
+          )
+          # Allowlist: ':(exclude)path' entries for confirmed-legit files.
+          data_allow=()
+          hits=$(git ls-files -z -- "${data_globs[@]}" "${data_allow[@]}" 2>/dev/null \
+                 | tr '\0' '\n' || true)
+          if [[ -n "$hits" ]]; then
+            echo "::error::Binary/data artifacts must never be committed (voiceprints, audio, databases, models):"
+            printf '%s\n' "$hits"
+            exit 1
+          fi
+          echo "Binary/data artifact scan: CLEAN"
+
       - name: PR description scan
         if: github.event_name == 'pull_request'
         env:


### PR DESCRIPTION
## Why
The `leak-detector` job already scans for secrets (detect-secrets), user-specific
content, and personal emails — all **text**. A voiceprint registry, audio file, or
`.db` matches none of those patterns, so a `git add -f` past `.gitignore` could commit
one into this public repo unnoticed. That's the risk class introduced once speaker-ID
gained online voiceprint enrollment.

## What
One DRY step added to the existing `leak-detector` job — **no new job, no gitleaks**
(detect-secrets already covers secret scanning; this fills the only real gap):

- **Binary/data artifact scan** — block any *tracked* audio / database / voiceprint /
  model artifact (`*.wav`, `*.db*`, `*.onnx`, `*speaker_registry*.json`, …). It reads
  the git index, so untracked local data is ignored, and supports a documented
  `:(exclude)path` allowlist for legitimate exceptions.

Mirrors the equivalent guard in the voice repo, adapted to this repo's existing
leak-detector rather than duplicated.

## Verification (run locally)
- Clean tree → step passes (no tracked artifacts today).
- Planted `.db` → surfaces and fails the step.
- `bash -n` on the step OK; full workflow YAML valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
