### PR TITLE
feat(recon): GitHub Discovery — curated proactive job (1B)

### DIFF
--- a/config/github_discovery_topics.yaml
+++ b/config/github_discovery_topics.yaml
@@ -1,0 +1,16 @@
+# Topics for autonomous GitHub Discovery — the user's domains.
+#
+# Each entry is one `gh search repos` query per run. Keep the list SHORT: each
+# topic is a single search call and the GitHub search API allows only 30
+# requests/minute. Install-specific or experimental topics go in
+# github_discovery_topics.local.yaml (gitignored), which is merged in on top.
+#
+# The discovery job scores results by momentum/activity/maturity and files only
+# the top few new high-signal repos to the recon triage queue for review.
+topics:
+  - "AI agent memory"
+  - "LLM agent framework"
+  - "agent harness orchestration"
+  - "retrieval augmented generation"
+  - "MCP server"
+  - "autonomous coding agent"

--- a/src/genesis/mcp/recon_mcp.py
+++ b/src/genesis/mcp/recon_mcp.py
@@ -407,3 +407,23 @@ async def recon_run_github_discovery(query: str, limit: int = 10) -> dict:
     if not repos:
         result["note"] = "no results — if unexpected, check gh auth / rate-limit (30/min) in logs"
     return result
+
+
+@mcp.tool()
+async def recon_run_github_discovery_job() -> dict:
+    """Run the curated GitHub Discovery JOB on-demand (files new repos → triage).
+
+    Normally runs weekly (Wednesday 6am). Searches the configured topics
+    (config/github_discovery_topics.yaml), scores candidates, and files the top
+    few NEW high-signal repos as recon findings to the TRIAGE queue (surfaced via
+    recon_findings job_type="github_discovery") — never the knowledge base.
+    Curated by design: narrow topics, a hard per-run cap, a score threshold, and
+    dedup vs the watchlist + already-filed findings. Returns a count summary.
+    """
+    if _db is None:
+        return {"error": "Database not initialized"}
+
+    from genesis.recon.github_discovery import GitHubDiscoveryJob
+
+    job = GitHubDiscoveryJob(db=_db, router=_router)
+    return await job.run()

--- a/src/genesis/recon/github_discovery.py
+++ b/src/genesis/recon/github_discovery.py
@@ -17,12 +17,16 @@ deterministic under test.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import math
+import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from pathlib import Path
 
+from genesis.db.crud import observations
 from genesis.recon.gh_cli import run_gh
 
 logger = logging.getLogger(__name__)
@@ -242,3 +246,152 @@ async def discover(
 
     ranked = sorted(best.values(), key=lambda c: c.score, reverse=True)
     return ranked[:total_cap] if total_cap else ranked
+
+
+# ── Curated proactive job (files survivors to the recon triage queue) ─────────
+
+_CONFIG_DIR = Path(__file__).resolve().parents[3] / "config"
+_TOPICS_FILE = "github_discovery_topics.yaml"
+# Curation knobs: file at most N high-signal repos per run, above a score floor.
+_FILE_SCORE_THRESHOLD = 0.55
+_MAX_FILE_PER_RUN = 5
+_DISCOVER_LIMIT_PER_QUERY = 10
+_DISCOVER_TOTAL_CAP = 30
+
+
+def _discovery_hash(full_name: str, score: float) -> str:
+    """Dedup key: repo + score TIER (0–10). A repo re-surfaces only if it climbs
+    a tier — not on every minor star drift, and (with unresolved_only) it can
+    re-surface after a prior finding is triaged or expires."""
+    bucket = int(score * 10)
+    return hashlib.sha256(f"gh_discovery:{full_name}:{bucket}".encode()).hexdigest()[:16]
+
+
+def _load_topics(path: Path) -> list[str]:
+    """Discovery topics: base YAML + optional gitignored ``.local.yaml`` overlay."""
+    if not path.exists():
+        return []
+    try:
+        import yaml
+
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+        topics = list(data.get("topics", []))
+        local = path.with_suffix(".local.yaml")
+        if local.exists():
+            with open(local) as f:
+                ldata = yaml.safe_load(f) or {}
+            for t in ldata.get("topics", []):
+                if t not in topics:
+                    topics.append(t)
+        return [str(t) for t in topics if t]
+    except Exception:
+        logger.error("Failed to load github_discovery topics from %s", path, exc_info=True)
+        return []
+
+
+def _format_finding(c: RepoCandidate) -> str:
+    """Human-readable triage finding — leads with full_name and shows WHY it
+    surfaced (the score breakdown)."""
+    return (
+        f"{c.full_name} — {c.stars}★ ({c.language or 'n/a'})\n"
+        f"score {c.score:.2f} (momentum {c.momentum:.2f} / activity {c.activity:.2f} / "
+        f"maturity {c.maturity:.2f})\n"
+        f"{c.description}\n"
+        f"created {c.created_at[:10]}, pushed {c.pushed_at[:10]}\n"
+        f"Source: {c.url}"
+    )
+
+
+class GitHubDiscoveryJob:
+    """Weekly curated discovery: search the user's topics, score, and file the
+    top few high-signal repos as recon findings for human triage.
+
+    Anti-firehose by construction: narrow topics, a hard per-run cap, a score
+    threshold, dedup vs the watchlist and already-filed findings, and filing
+    straight to the recon triage lane — never the knowledge base.
+    """
+
+    def __init__(
+        self, *, db, router: object | None = None, topics_path: Path | None = None
+    ) -> None:
+        self._db = db
+        self._router = router  # reserved for an optional LLM relevance pass
+        self._topics_path = topics_path
+
+    async def _probe_gh_auth(self) -> bool:
+        """True if gh is authenticated, so a silent 401 can't masquerade as
+        'no results'. ``gh api user`` requires auth and prints the login."""
+        return bool(await run_gh("gh", "api", "user", "--jq", ".login"))
+
+    def _resolve_topics(self) -> list[str]:
+        return _load_topics(self._topics_path or (_CONFIG_DIR / _TOPICS_FILE))
+
+    def _watchlist_names(self) -> set[str]:
+        """Repos already hand-tracked in the recon watchlist (skip — not 'new')."""
+        from genesis.recon.gatherer import ReconGatherer
+
+        return {
+            str(p.get("repo", "")).lower()
+            for p in ReconGatherer._load_watchlist()
+            if p.get("repo")
+        }
+
+    async def run(self) -> dict:
+        if not await self._probe_gh_auth():
+            logger.warning("github_discovery: gh not authenticated — skipping")
+            return {"filed": 0, "candidates": 0, "skipped": "gh not authenticated"}
+
+        topics = self._resolve_topics()
+        if not topics:
+            return {"filed": 0, "candidates": 0, "skipped": "no topics configured"}
+
+        candidates = await discover(
+            topics,
+            limit_per_query=_DISCOVER_LIMIT_PER_QUERY,
+            total_cap=_DISCOVER_TOTAL_CAP,
+        )
+        watchlist = self._watchlist_names()
+        now = datetime.now(UTC).isoformat()
+
+        # Curated cream only: drop watchlist repos and anything below the quality
+        # floor, then take the top N BY SCORE (candidates are already sorted desc).
+        # We file the not-yet-filed repos among THESE — we do NOT walk further down
+        # the pool to refill the cap, so once you've seen the top entrants the job
+        # goes quiet until better ones appear (anti-firehose).
+        eligible = [
+            c
+            for c in candidates
+            if c.score >= _FILE_SCORE_THRESHOLD and c.full_name.lower() not in watchlist
+        ][:_MAX_FILE_PER_RUN]
+
+        filed = 0
+        for cand in eligible:
+            content_hash = _discovery_hash(cand.full_name, cand.score)
+            # NEVER route discovery candidates through run_intake() — that path
+            # leads to the KB flood. File directly as a triageable recon finding.
+            # Permanent dedup (no unresolved_only): a repo seen at this score tier
+            # won't nag again even after you triage it; it re-surfaces only if it
+            # climbs a tier (new hash) or its finding TTL-expires.
+            if await observations.exists_by_hash(
+                self._db, source="recon", content_hash=content_hash
+            ):
+                continue
+            await observations.create(
+                self._db,
+                id=str(uuid.uuid4()),
+                source="recon",
+                type="finding",
+                category="github_discovery",
+                content=_format_finding(cand),
+                priority="low",  # surface in the triage queue, don't push-alert
+                created_at=now,
+                content_hash=content_hash,
+            )
+            filed += 1
+
+        logger.info(
+            "github_discovery: topics=%d candidates=%d filed=%d",
+            len(topics), len(candidates), filed,
+        )
+        return {"filed": filed, "candidates": len(candidates), "topics": len(topics)}

--- a/src/genesis/runtime/init/surplus.py
+++ b/src/genesis/runtime/init/surplus.py
@@ -134,6 +134,20 @@ async def init(rt: GenesisRuntime) -> None:
             logger.error("Unexpected error wiring SkillSecurityScanJob", exc_info=True)
             await _degraded(rt, "SkillSecurityScanJob")
 
+        try:
+            from genesis.recon.github_discovery import GitHubDiscoveryJob
+            gh_discovery_job = GitHubDiscoveryJob(
+                db=rt._db, router=getattr(rt, "_router", None),
+            )
+            rt._surplus_scheduler.set_github_discovery_job(gh_discovery_job)
+            logger.info("GitHubDiscoveryJob wired to surplus scheduler")
+        except (ImportError, AttributeError):
+            logger.error("Failed to wire GitHubDiscoveryJob", exc_info=True)
+            await _degraded(rt, "GitHubDiscoveryJob")
+        except Exception:
+            logger.error("Unexpected error wiring GitHubDiscoveryJob", exc_info=True)
+            await _degraded(rt, "GitHubDiscoveryJob")
+
         await rt._surplus_scheduler.start()
         logger.info("Genesis surplus scheduler started")
 

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -129,6 +129,7 @@ class SurplusScheduler:
         self._model_intelligence_job = None  # Set via set_model_intelligence_job()
         self._models_md_synthesis_job = None  # Set via set_models_md_synthesis_job()
         self._skill_security_scan_job = None  # Set via set_skill_security_scan_job()
+        self._github_discovery_job = None  # Set via set_github_discovery_job()
         self._extraction_store: MemoryStore | None = None
         self._extraction_router: Router | None = None
         self._follow_up_dispatcher = None  # Set via set_follow_up_dispatcher()
@@ -221,6 +222,10 @@ class SurplusScheduler:
     def set_skill_security_scan_job(self, job) -> None:
         """Set the SkillSecurityScanJob for the weekly skill-security scan."""
         self._skill_security_scan_job = job
+
+    def set_github_discovery_job(self, job) -> None:
+        """Set the GitHubDiscoveryJob for weekly curated repo discovery."""
+        self._github_discovery_job = job
 
     def set_extraction_deps(
         self,
@@ -323,6 +328,16 @@ class SurplusScheduler:
                 self.run_skill_security_scan,
                 CronTrigger(day_of_week="mon", hour=2, timezone=user_timezone()),
                 id="skill_security_scan",
+                max_instances=1,
+                misfire_grace_time=3600,
+            )
+        # GitHub Discovery: weekly Wednesday 6am — finds new repos in the user's
+        # domains and files the top few to the recon triage queue for review.
+        if self._github_discovery_job is not None:
+            self._scheduler.add_job(
+                self.run_github_discovery,
+                CronTrigger(day_of_week="wed", hour=6, timezone=user_timezone()),
+                id="github_discovery",
                 max_instances=1,
                 misfire_grace_time=3600,
             )
@@ -1109,6 +1124,45 @@ class SurplusScheduler:
             try:
                 from genesis.runtime import GenesisRuntime
                 GenesisRuntime.instance().record_job_failure("skill_security_scan", str(exc))
+            except Exception:
+                pass
+
+    async def run_github_discovery(self) -> None:
+        """Run weekly curated GitHub Discovery (new repos → recon triage queue)."""
+        if self._github_discovery_job is None:
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_failure(
+                    "github_discovery", "job not wired",
+                )
+            except Exception:
+                pass
+            return
+        try:
+            result = await self._github_discovery_job.run()
+            filed = result.get("filed", 0)
+            logger.info("GitHub Discovery: %d new repo(s) filed for triage", filed)
+            if self._event_bus:
+                await self._event_bus.emit(
+                    Subsystem.RECON, Severity.DEBUG,
+                    "heartbeat", "github_discovery completed",
+                )
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_success("github_discovery")
+            except Exception:
+                pass
+        except Exception as exc:
+            logger.exception("GitHub Discovery failed")
+            if self._event_bus:
+                await self._event_bus.emit(
+                    Subsystem.RECON, Severity.ERROR,
+                    "github_discovery.failed",
+                    "GitHub Discovery failed",
+                )
+            try:
+                from genesis.runtime import GenesisRuntime
+                GenesisRuntime.instance().record_job_failure("github_discovery", str(exc))
             except Exception:
                 pass
 

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -1129,6 +1129,13 @@ class SurplusScheduler:
 
     async def run_github_discovery(self) -> None:
         """Run weekly curated GitHub Discovery (new repos → recon triage queue)."""
+        try:
+            from genesis.runtime import GenesisRuntime
+            if GenesisRuntime.instance().paused:
+                logger.debug("GitHub Discovery skipped (Genesis paused)")
+                return
+        except Exception:
+            pass
         if self._github_discovery_job is None:
             try:
                 from genesis.runtime import GenesisRuntime

--- a/tests/test_recon/test_github_discovery_job.py
+++ b/tests/test_recon/test_github_discovery_job.py
@@ -1,0 +1,162 @@
+"""Tests for the scheduled, curated GitHubDiscoveryJob (files to triage queue)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from genesis.recon.github_discovery import (
+    GitHubDiscoveryJob,
+    RepoCandidate,
+    _discovery_hash,
+)
+
+
+def _cand(full_name: str, score: float) -> RepoCandidate:
+    return RepoCandidate(
+        full_name=full_name,
+        url=f"https://github.com/{full_name}",
+        stars=1000,
+        created_at="2025-01-01T00:00:00Z",
+        pushed_at="2026-06-20T00:00:00Z",
+        description="desc",
+        language="Python",
+        momentum=score,
+        activity=score,
+        maturity=score,
+        score=score,
+    )
+
+
+# ── dedup hash (P1-A) ────────────────────────────────────────────────────────
+
+
+def test_discovery_hash_is_score_bucketed_and_stable():
+    # Same repo, same score tier (0.6x) → same hash (no re-file on minor drift).
+    assert _discovery_hash("a/b", 0.66) == _discovery_hash("a/b", 0.64)
+    # Different score tier → different hash (re-surfaces if it climbs a tier).
+    assert _discovery_hash("a/b", 0.66) != _discovery_hash("a/b", 0.74)
+    # Different repo → different hash.
+    assert _discovery_hash("a/b", 0.5) != _discovery_hash("c/d", 0.5)
+
+
+# ── run() ────────────────────────────────────────────────────────────────────
+
+
+def _wire_job(monkeypatch, job, *, candidates, watchlist=None, seen=None):
+    """Stub the job's external deps for a deterministic run()."""
+    monkeypatch.setattr(job, "_probe_gh_auth", AsyncMock(return_value=True))
+    monkeypatch.setattr(job, "_resolve_topics", lambda: ["agents"])
+    monkeypatch.setattr(job, "_watchlist_names", lambda: set(watchlist or set()))
+    monkeypatch.setattr(
+        "genesis.recon.github_discovery.discover", AsyncMock(return_value=candidates)
+    )
+    seen = seen or set()
+
+    async def fake_exists(db, *, source, content_hash, unresolved_only=False):
+        return content_hash in seen
+
+    create = AsyncMock()
+    monkeypatch.setattr(
+        "genesis.recon.github_discovery.observations.exists_by_hash",
+        AsyncMock(side_effect=fake_exists),
+    )
+    monkeypatch.setattr(
+        "genesis.recon.github_discovery.observations.create", create
+    )
+    return create
+
+
+@pytest.mark.asyncio
+async def test_run_skips_when_gh_not_authenticated(monkeypatch):
+    job = GitHubDiscoveryJob(db=object())
+    monkeypatch.setattr(job, "_probe_gh_auth", AsyncMock(return_value=False))
+    result = await job.run()
+    assert result["filed"] == 0
+    assert result.get("skipped")
+
+
+@pytest.mark.asyncio
+async def test_run_files_top_survivors_capped(monkeypatch):
+    job = GitHubDiscoveryJob(db=object())
+    # 8 candidates 0.90..0.55, all above threshold → cap files only the top 5.
+    cands = [_cand(f"r/{i}", round(0.90 - i * 0.05, 2)) for i in range(8)]
+    create = _wire_job(monkeypatch, job, candidates=cands)
+    result = await job.run()
+    assert result["filed"] == 5
+    filed_names = [c.kwargs["content"].split(" —")[0] for c in create.await_args_list]
+    assert filed_names == ["r/0", "r/1", "r/2", "r/3", "r/4"]
+    # Files as a triageable recon finding (NOT the knowledge base).
+    kw = create.await_args_list[0].kwargs
+    assert kw["source"] == "recon"
+    assert kw["type"] == "finding"
+    assert kw["category"] == "github_discovery"
+
+
+@pytest.mark.asyncio
+async def test_run_drops_below_threshold(monkeypatch):
+    job = GitHubDiscoveryJob(db=object())
+    cands = [_cand("good/repo", 0.80), _cand("weak/repo", 0.30)]
+    create = _wire_job(monkeypatch, job, candidates=cands)
+    result = await job.run()
+    assert result["filed"] == 1
+    assert "good/repo" in create.await_args_list[0].kwargs["content"]
+
+
+@pytest.mark.asyncio
+async def test_run_dedups_already_filed(monkeypatch):
+    job = GitHubDiscoveryJob(db=object())
+    cands = [_cand("a/seen", 0.90), _cand("b/new", 0.80)]
+    create = _wire_job(
+        monkeypatch, job, candidates=cands, seen={_discovery_hash("a/seen", 0.90)}
+    )
+    result = await job.run()
+    assert result["filed"] == 1
+    assert "b/new" in create.await_args_list[0].kwargs["content"]
+
+
+@pytest.mark.asyncio
+async def test_run_rerun_dedups_top_n_does_not_walk_pool(monkeypatch):
+    """Re-running with the same pool files 0 — it must NOT dredge ranks 6-10 to
+    refill the cap once the top-N are already filed (the curation guarantee)."""
+    job = GitHubDiscoveryJob(db=object())
+    cands = [_cand(f"r/{i}", round(0.90 - i * 0.04, 2)) for i in range(12)]  # all >0.55
+    monkeypatch.setattr(job, "_probe_gh_auth", AsyncMock(return_value=True))
+    monkeypatch.setattr(job, "_resolve_topics", lambda: ["t"])
+    monkeypatch.setattr(job, "_watchlist_names", lambda: set())
+    monkeypatch.setattr(
+        "genesis.recon.github_discovery.discover", AsyncMock(return_value=cands)
+    )
+    seen: set[str] = set()
+
+    async def fake_exists(db, *, source, content_hash, unresolved_only=False):
+        return content_hash in seen
+
+    async def fake_create(db, **kw):
+        seen.add(kw["content_hash"])
+
+    monkeypatch.setattr(
+        "genesis.recon.github_discovery.observations.exists_by_hash",
+        AsyncMock(side_effect=fake_exists),
+    )
+    monkeypatch.setattr(
+        "genesis.recon.github_discovery.observations.create",
+        AsyncMock(side_effect=fake_create),
+    )
+    r1 = await job.run()
+    r2 = await job.run()
+    assert r1["filed"] == 5
+    assert r2["filed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_skips_watchlist_repos(monkeypatch):
+    job = GitHubDiscoveryJob(db=object())
+    cands = [_cand("known/repo", 0.95), _cand("fresh/repo", 0.80)]
+    create = _wire_job(
+        monkeypatch, job, candidates=cands, watchlist={"known/repo"}
+    )
+    result = await job.run()
+    assert result["filed"] == 1
+    assert "fresh/repo" in create.await_args_list[0].kwargs["content"]

--- a/tests/test_surplus/test_scheduler.py
+++ b/tests/test_surplus/test_scheduler.py
@@ -180,6 +180,21 @@ async def test_start_registers_skill_security_scan(db):
     await sched.stop()
 
 
+async def test_start_registers_github_discovery(db):
+    """A wired GitHubDiscoveryJob registers its weekly cron job on start().
+
+    Locks the scheduler wiring: start() resolves CronTrigger / user_timezone and
+    registers the job under id 'github_discovery'. A CronTrigger job does not
+    enqueue surplus tasks, so sibling pending_count assertions are unaffected.
+    """
+    sched, compute = _make_scheduler(db, idle=True)
+    sched.set_github_discovery_job(AsyncMock())
+    with patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False):
+        await sched.start()
+    assert sched._scheduler.get_job("github_discovery") is not None
+    await sched.stop()
+
+
 async def test_schedule_code_audit_noop_when_disabled(db):
     sched, compute = _make_scheduler(db, idle=True, enable_code_audits=False)
     # Direct call should be a no-op


### PR DESCRIPTION
## What

**1B — the curated proactive job**, building on the 1A foundation (#752). A weekly `GitHubDiscoveryJob` searches the user's domains, scores candidates with the 1A engine, and files the top few **new** high-signal repos as recon findings to the **triage queue** for review.

This completes the "inbox, inverted" design: Genesis now does the *finding* and surfaces a curated shortlist; the human review gate (recon triage) stays intact.

## Anti-firehose by construction

The old recon firehose flooded the KB (unscored → everything ingested). This job avoids that structurally:
- **Narrow topics** — `config/github_discovery_topics.yaml` (6 domains), with a gitignored `.local.yaml` overlay.
- **Hard per-run cap** (5) + **score threshold** (0.55) + **top-N snapshot** — files only the new repos among the top-5 by score; it does **not** walk down the pool to refill the cap, so once you've seen the top entrants it goes quiet.
- **Dedup** vs the watchlist and already-filed findings (score-tier hash → re-surfaces only when a repo climbs a tier).
- **Files to the recon triage lane** (`recon_findings(job_type="github_discovery")`), **never** the knowledge base (guarded with an explicit comment).

## Components

- `GitHubDiscoveryJob` (in `recon/github_discovery.py`) + `_discovery_hash` + topics loader + finding formatter.
- Scheduler wiring: slot + `set_github_discovery_job` + `run_github_discovery` wrapper (`record_job_success/failure`, **paused-state guard**) + `add_job(CronTrigger Wed 6am)`.
- `runtime/init/surplus.py` constructs the job (router passed for a future LLM-relevance pass).
- On-demand `recon_run_github_discovery_job()` MCP tool.

## Hardening (architect + code review)

- **gh auth probe** (`gh api user`) so a silent 401 can't masquerade as "no results".
- **Score-tier dedup hash** + permanent dedup (a *dismissed* repo doesn't nag back).
- **`record_job_success/failure`** in the wrapper (health dashboard + morning report visibility).
- **Paused-state guard** (code-review nit) — won't fire `gh`/write findings during a maintenance pause.

## A bug the E2E caught

The first E2E re-run filed 5 again instead of 0 — the filing loop was walking *down* the candidate pool to refill the cap (a slow-firehose that degrades quality over runs). Fixed to a top-N snapshot; re-run now correctly dedups to **0**. (Unit tests only ran once and missed it — added a re-run regression test.)

## Testing

- **147 scheduler + recon tests green**; ruff clean.
- **E2E vs live GitHub**: files 5 real on-topic repos (claude-mem, codegraph, opencode, …) to the triage queue, surfaced via the exact `recon_findings` query; re-run dedups to 0.

## Deploy / safety

- **No migration**, no new DB table. Takes effect on server restart (new scheduled job + MCP tool next CC session). Topics config ships in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
