### PR TITLE
feat(inbox): tool/product scoring rubric in inbox evaluation (spec 7b)

### DIFF
--- a/src/genesis/identity/INBOX_EVALUATE.md
+++ b/src/genesis/identity/INBOX_EVALUATE.md
@@ -343,6 +343,27 @@ assign a scope tag, and produce the Recommendation YAML block (see output format
 in Step 5). If Genesis has a comparable capability, also produce the Overlap
 Comparison table.
 
+### Tool/Product Scoring Rubric (for concrete external tools, products, libraries, repos)
+
+When a Genesis-relevant item IS a specific external tool/product/library/repo
+(not an abstract idea or pattern), also score its **traction** on three axes.
+These complement — they don't replace — the fit-focused scoring axes above
+(capability gap, replacement risk, integration cost, lock-in risk):
+
+- **Momentum (40%)** — is it growing? Star/adoption trend, release frequency,
+  contributor growth. A fast-rising newcomer can outweigh a larger but stagnant
+  incumbent — don't anchor on raw size alone.
+- **Activity (30%)** — is it alive? Recency of commits/releases, issue response,
+  maintenance signals. Penalize abandoned/stale projects regardless of past size.
+- **Maturity (30%)** — is it proven? Age, release stability, production usage,
+  documentation depth. Penalize brand-new/unproven, but don't over-reward age alone.
+
+Judge each axis **high / medium / low** from whatever signals the source provides
+— you won't always have exact metrics; reason from what's available. For such
+items, add the optional `tool_momentum` / `tool_activity` / `tool_maturity` fields
+to the Recommendation YAML (see Step 5). Omit them for abstract ideas, patterns,
+or non-tool items.
+
 ### User Evaluation Framework
 
 For user-relevant items, read and apply the full evaluation framework from:
@@ -496,6 +517,10 @@ effort: Small              # Trivial | Small | Medium | Large
 scope: V4                  # V4 (current) | V5 (next) | Future | Never
 confidence: high           # low | medium | high
 architecture_impact: extends  # validates | extends | challenges | irrelevant
+# Optional — ONLY for concrete external tools/products/repos (see Step 3 rubric):
+tool_momentum: high        # high | medium | low — growth/adoption trend
+tool_activity: high        # high | medium | low — maintenance/recency
+tool_maturity: medium      # high | medium | low — proven/stable/age
 ```
 
 For **User-relevant** items, use this YAML block:

--- a/src/genesis/inbox/recommendation.py
+++ b/src/genesis/inbox/recommendation.py
@@ -46,6 +46,11 @@ class Recommendation:
     # User-relevant fields
     timeline: str | None = None
     relevance: str | None = None
+    # Tool/product traction rubric (for Genesis-relevant external tools/repos;
+    # qualitative high|medium|low — the inbox eval has no live metrics)
+    tool_momentum: str | None = None
+    tool_activity: str | None = None
+    tool_maturity: str | None = None
     # Context
     item_title: str = ""
     classification: str = ""  # "genesis" or "user"
@@ -159,6 +164,18 @@ def parse_recommendations(evaluation_text: str) -> list[Recommendation]:
             relevance=(
                 str(data["relevance"]).strip()
                 if "relevance" in data else None
+            ),
+            tool_momentum=(
+                str(data["tool_momentum"]).strip()
+                if "tool_momentum" in data else None
+            ),
+            tool_activity=(
+                str(data["tool_activity"]).strip()
+                if "tool_activity" in data else None
+            ),
+            tool_maturity=(
+                str(data["tool_maturity"]).strip()
+                if "tool_maturity" in data else None
             ),
             item_title=title,
             classification=classification,

--- a/tests/test_inbox/test_recommendation.py
+++ b/tests/test_inbox/test_recommendation.py
@@ -45,6 +45,26 @@ architecture_impact: extends
 Some analysis here.
 """
 
+GENESIS_WITH_TOOL_SCORES = """\
+## 1. Some Agent Framework
+
+**Classification:** Genesis-relevant
+
+### Recommendation
+
+```yaml
+action: WATCH
+next_step: "Track release cadence and revisit in Q3"
+effort: Small
+scope: V5
+confidence: medium
+architecture_impact: extends
+tool_momentum: high
+tool_activity: high
+tool_maturity: low
+```
+"""
+
 USER_SINGLE = """\
 ---
 date: 2026-06-06
@@ -265,6 +285,21 @@ class TestParseRecommendations:
         assert r.classification == "genesis"
         assert r.item_title == "Evo — Autoresearch Loop for Codebase Optimization"
         assert r.is_actionable is True
+
+    def test_parses_tool_scoring_fields(self):
+        recs = parse_recommendations(GENESIS_WITH_TOOL_SCORES)
+        assert len(recs) == 1
+        r = recs[0]
+        assert r.tool_momentum == "high"
+        assert r.tool_activity == "high"
+        assert r.tool_maturity == "low"
+
+    def test_tool_scoring_fields_default_none_when_absent(self):
+        # Backward compatible: existing recommendations without the rubric.
+        r = parse_recommendations(GENESIS_SINGLE)[0]
+        assert r.tool_momentum is None
+        assert r.tool_activity is None
+        assert r.tool_maturity is None
 
     def test_user_single(self):
         recs = parse_recommendations(USER_SINGLE)


### PR DESCRIPTION
## What

Adds a **Tool/Product Scoring Rubric** (momentum / activity / maturity) to the inbox evaluation — the other half of spec item ⑦. (⑦a, the recon-side momentum, was absorbed into the GitHub Discovery engine in #752/#754; this is ⑦b, the inbox side.)

When a Genesis-relevant inbox item IS a concrete external tool/product/library/repo, the evaluator now also scores its **traction**:
- **Momentum (40%)** — growth/adoption trend (a fast riser can outweigh a stagnant incumbent)
- **Activity (30%)** — maintenance/recency (penalize abandoned)
- **Maturity (30%)** — proven/stable/age (penalize unproven, don't over-reward age)

These **complement** the existing fit-focused scoring axes (capability gap, replacement risk, integration cost, lock-in risk) — they don't replace them.

## Qualitative, not numeric

Unlike the GitHub Discovery recon engine (which scores from live `gh` metrics), the inbox eval has no live data — so the rubric is **qualitative** (`high | medium | low`), judged from whatever signals the dropped source provides. Same conceptual rubric, different surface.

## Changes

- `INBOX_EVALUATE.md` (system prompt): a "Tool/Product Scoring Rubric" subsection under the Genesis Evaluation Framework + the three optional fields documented in the Step 5 Recommendation YAML.
- `inbox/recommendation.py`: `tool_momentum` / `tool_activity` / `tool_maturity` (`str | None = None`) on the `Recommendation` dataclass + defensive parser extraction. **Backward compatible** — absent fields default to `None`.

## Testing / review

- **238 inbox tests green**; ruff clean. New tests cover present-and-parsed + absent-defaults-None. Field names verified consistent across prompt, parser, and YAML example.
- code-reviewer: **READY** (no issues).

## Deploy / safety

- No migration. Prompt change takes effect on the next inbox evaluation after deploy; the parser is forward-compatible immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
