### PR TITLE
fix(guardian): drift watchdog tests containment, not equality

### DIFF
--- a/src/genesis/guardian/watchdog.py
+++ b/src/genesis/guardian/watchdog.py
@@ -272,15 +272,31 @@ class GuardianWatchdog:
         if not isinstance(host_hash, str) or host_hash == "unknown":
             return  # Host hasn't been redeployed yet (pre-feature) — skip
 
-        # Compare (short hashes — prefix match)
-        if container_hash.startswith(host_hash) or host_hash.startswith(container_hash):
+        # The host records `deployed_commit` as the full deploy HEAD, while
+        # `container_hash` is the LAST commit touching Guardian paths. A deploy
+        # batch with non-Guardian commits landing after the last Guardian-touching
+        # one leaves the two unequal even though HEAD *contains* the Guardian
+        # commit — so test containment (ancestry), not equality.
+        contains = await self._host_contains_commit(container_hash, host_hash)
+        if contains is None:
+            # Unresolvable (e.g. host ahead on a commit the container's git hasn't
+            # fetched) — never false-alarm. The self-referential deploy of THIS
+            # file is also covered: it drifts only until the host redeploys, which
+            # DRIFT_ALERT_THRESHOLD absorbs.
+            logger.debug(
+                "Guardian code drift check unresolvable (container=%s host=%s) "
+                "— skipping", container_hash, host_hash,
+            )
+            return
+        if contains:
             if self._drift_count > 0:
                 logger.info("Guardian code drift resolved (container=%s host=%s)",
                             container_hash, host_hash)
             self._drift_count = 0
             return
 
-        # Drift detected
+        # Drift detected — host's deployed HEAD does NOT contain the container's
+        # latest Guardian-path commit (genuine staleness).
         self._drift_count += 1
         if self._drift_count >= self.DRIFT_ALERT_THRESHOLD and \
                 self._drift_count % self.DRIFT_ALERT_THRESHOLD == 0:
@@ -304,6 +320,44 @@ class GuardianWatchdog:
                     priority="high",
                     source="guardian_watchdog",
                 )
+
+    async def _host_contains_commit(
+        self, container_hash: str, host_hash: str,
+    ) -> bool | None:
+        """Whether the host's deployed HEAD CONTAINS the container's latest
+        Guardian-path commit (i.e. the host Guardian is current).
+
+        Returns True when ``container_hash`` is an ancestor of (or equal to)
+        ``host_hash`` — the host's deployed code includes the container's latest
+        Guardian-relevant commit. Returns False on a genuine miss (real drift —
+        the host lacks that commit). Returns None when the relationship can't be
+        resolved (e.g. the host is ahead on a commit the container's git doesn't
+        have yet) — the caller then skips, never false-alarms. Mirrors
+        ``_expected_gateway_sha``'s None-on-unresolvable contract. Split out so
+        tests can stub it / exercise the exit-code mapping directly.
+
+        ``git merge-base --is-ancestor`` exits 0 (is ancestor), 1 (is not), or
+        128 (unknown object). The mapping is EXPLICIT on purpose: a naive
+        ``returncode == 0`` would fold 128 into False and re-introduce a false
+        alarm whenever the host is legitimately ahead. Argument order is
+        load-bearing: ``container_hash`` (the purported ancestor) FIRST.
+        """
+        import asyncio
+
+        try:
+            result = await asyncio.to_thread(
+                subprocess.run,
+                ["git", "-C", str(Path.home() / "genesis"),
+                 "merge-base", "--is-ancestor", container_hash, host_hash],
+                capture_output=True, timeout=5,
+            )
+        except Exception:
+            return None  # subprocess/timeout failure → unresolvable → skip
+        if result.returncode == 0:
+            return True   # container's Guardian commit is in the host's HEAD
+        if result.returncode == 1:
+            return False  # genuinely not contained → real drift
+        return None       # 128 (unknown object — host ahead) / other → skip
 
     async def _expected_gateway_sha(self, code_version: str) -> str | None:
         """sha256 of the gateway script at the host's install-dir commit.

--- a/tests/test_guardian/test_watchdog.py
+++ b/tests/test_guardian/test_watchdog.py
@@ -355,3 +355,164 @@ class TestExpectedGatewaySha:
         fake = MagicMock(returncode=0, stdout=b"")
         with patch("genesis.guardian.watchdog.subprocess.run", return_value=fake):
             assert await wd._expected_gateway_sha("abc1234") is None
+
+
+class TestHostContainsCommit:
+    """Direct coverage of the merge-base ancestry helper. The exit-code mapping
+    is load-bearing: a naive `returncode == 0` would fold 128 (host ahead) into
+    False and re-introduce a false alarm — the exact bug this fix removes."""
+
+    @pytest.mark.asyncio
+    async def test_ancestor_returns_true(self):
+        from unittest.mock import MagicMock
+        wd = GuardianWatchdog(AsyncMock(), event_bus=None)
+        with patch("genesis.guardian.watchdog.subprocess.run",
+                   return_value=MagicMock(returncode=0)):
+            assert await wd._host_contains_commit("a915a28", "0a07272") is True
+
+    @pytest.mark.asyncio
+    async def test_not_ancestor_returns_false(self):
+        from unittest.mock import MagicMock
+        wd = GuardianWatchdog(AsyncMock(), event_bus=None)
+        with patch("genesis.guardian.watchdog.subprocess.run",
+                   return_value=MagicMock(returncode=1)):
+            assert await wd._host_contains_commit("a915a28", "0ld0ld0") is False
+
+    @pytest.mark.asyncio
+    async def test_unknown_object_returns_none_not_false(self):
+        """exit 128 (host ahead — commit not in the container's git) MUST map to
+        None (skip), NOT False (which would false-alarm)."""
+        from unittest.mock import MagicMock
+        wd = GuardianWatchdog(AsyncMock(), event_bus=None)
+        with patch("genesis.guardian.watchdog.subprocess.run",
+                   return_value=MagicMock(returncode=128)):
+            assert await wd._host_contains_commit("a915a28", "ffffff0") is None
+
+    @pytest.mark.asyncio
+    async def test_subprocess_exception_returns_none(self):
+        """A slow/raising git (e.g. TimeoutExpired) skips, never false-alarms."""
+        wd = GuardianWatchdog(AsyncMock(), event_bus=None)
+        with patch("genesis.guardian.watchdog.subprocess.run",
+                   side_effect=TimeoutError("slow git")):
+            assert await wd._host_contains_commit("a915a28", "0a07272") is None
+
+
+def _drift_watchdog(deployed_commit: str):
+    """Watchdog wired for code-drift tests: mock remote.version() → deployed_commit,
+    mock event_bus/outreach. `_host_contains_commit` is stubbed per-test."""
+    r = AsyncMock()
+    r.version = AsyncMock(return_value={"deployed_commit": deployed_commit})
+    event_bus = AsyncMock()
+    outreach = AsyncMock()
+    wd = GuardianWatchdog(r, event_bus=event_bus, outreach_queue=outreach)
+    return wd, r, event_bus, outreach
+
+
+def _git_side_effect(container_hash: str):
+    """subprocess.run side_effect for the two git calls _check_code_drift_inner
+    makes before the (stubbed) ancestry check: git log → container_hash, and
+    symbolic-ref → 'main'."""
+    from unittest.mock import MagicMock
+
+    def _run(cmd, **kw):
+        if "symbolic-ref" in cmd:
+            return MagicMock(returncode=0, stdout="main\n")
+        if "log" in cmd:
+            return MagicMock(returncode=0, stdout=container_hash + "\n")
+        return MagicMock(returncode=0, stdout="")
+
+    return _run
+
+
+class TestCodeDrift:
+    """Drift = host's deployed HEAD does NOT CONTAIN the container's latest
+    Guardian-path commit. Equality was wrong: a deploy batch with non-Guardian
+    commits landing after the last Guardian-touching one leaves HEAD != that
+    commit even though HEAD contains it (the false positive this fix removes)."""
+
+    @pytest.mark.asyncio
+    async def test_host_contains_commit_no_drift(self):
+        """Regression: container's Guardian commit IS an ancestor of host HEAD
+        (later non-Guardian commits advanced HEAD) → host current → NO drift,
+        NO false Telegram alarm — even after many ticks."""
+        wd, r, eb, outreach = _drift_watchdog(deployed_commit="0a07272")
+        wd._host_contains_commit = AsyncMock(return_value=True)
+        with patch("genesis.guardian.watchdog.subprocess.run",
+                   side_effect=_git_side_effect("a915a28")):
+            for _ in range(_THRESHOLD + 1):
+                await wd._check_code_drift_inner()
+        assert wd._drift_count == 0
+        outreach.enqueue.assert_not_called()
+        assert not any("code_drift" in e for e in _emitted_events(eb))
+        wd._host_contains_commit.assert_awaited()  # the ancestry path ran
+
+    @pytest.mark.asyncio
+    async def test_genuine_drift_alerts_at_threshold(self):
+        """Host genuinely missing the Guardian commit → quiet below threshold,
+        alerts exactly at the threshold tick (event bus + user-facing outreach)."""
+        wd, r, eb, outreach = _drift_watchdog(deployed_commit="0ld0ld0")
+        wd._host_contains_commit = AsyncMock(return_value=False)
+        with patch("genesis.guardian.watchdog.subprocess.run",
+                   side_effect=_git_side_effect("a915a28")):
+            for _ in range(_THRESHOLD - 1):
+                await wd._check_code_drift_inner()
+            outreach.enqueue.assert_not_called()   # below threshold: silent
+            await wd._check_code_drift_inner()       # tick == THRESHOLD
+        assert wd._drift_count == _THRESHOLD
+        assert any("code_drift" in e for e in _emitted_events(eb))
+        outreach.enqueue.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_skips_no_alarm(self):
+        """Ancestry unresolvable (host ahead / git error) → skip every tick,
+        never alarm, drift_count untouched."""
+        wd, r, eb, outreach = _drift_watchdog(deployed_commit="ffffff0")
+        wd._host_contains_commit = AsyncMock(return_value=None)
+        with patch("genesis.guardian.watchdog.subprocess.run",
+                   side_effect=_git_side_effect("a915a28")):
+            for _ in range(_THRESHOLD + 1):
+                await wd._check_code_drift_inner()
+        assert wd._drift_count == 0
+        outreach.enqueue.assert_not_called()
+        eb.emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_drift_then_resolved_resets(self):
+        """A genuine drift episode that later resolves (host catches up) resets
+        the counter — no 'stuck drifting' after recovery."""
+        wd, r, eb, outreach = _drift_watchdog(deployed_commit="0ld0ld0")
+        wd._host_contains_commit = AsyncMock(return_value=False)
+        with patch("genesis.guardian.watchdog.subprocess.run",
+                   side_effect=_git_side_effect("a915a28")):
+            for _ in range(_THRESHOLD):
+                await wd._check_code_drift_inner()
+            assert wd._drift_count == _THRESHOLD
+            wd._host_contains_commit = AsyncMock(return_value=True)  # host caught up
+            await wd._check_code_drift_inner()
+        assert wd._drift_count == 0
+
+    @pytest.mark.asyncio
+    async def test_exit_128_full_chain_skips_no_alarm(self):
+        """End-to-end on the most dangerous path: the REAL _host_contains_commit
+        (not stubbed) with merge-base exit 128 (host ahead) must map through to a
+        skip, never a false alarm. Guards the 128->False misimplementation across
+        the whole chain (git 128 -> helper None -> drift check skips)."""
+        from unittest.mock import MagicMock
+        wd, r, eb, outreach = _drift_watchdog(deployed_commit="ffffff0")
+
+        def _side_effect(cmd, **kw):
+            if "symbolic-ref" in cmd:
+                return MagicMock(returncode=0, stdout="main\n")
+            if "log" in cmd:
+                return MagicMock(returncode=0, stdout="a915a28\n")
+            if "merge-base" in cmd:
+                return MagicMock(returncode=128)  # unknown object — host ahead
+            return MagicMock(returncode=0, stdout="")
+
+        with patch("genesis.guardian.watchdog.subprocess.run",
+                   side_effect=_side_effect):
+            for _ in range(_THRESHOLD + 1):
+                await wd._check_code_drift_inner()
+        assert wd._drift_count == 0
+        outreach.enqueue.assert_not_called()
+        assert not any("code_drift" in e for e in _emitted_events(eb))


### PR DESCRIPTION
## The bug
The Guardian code-drift watchdog (`_check_code_drift_inner`) detects when the host Guardian is running stale Guardian-relevant code. It compared:
- **container** = `git log -1 --format=%h -- <_GUARDIAN_PATHS>` — the last commit touching Guardian-relevant paths (`_GUARDIAN_PATHS` includes `src/genesis/db`, `src/genesis/observability`, etc.).
- **host** = `deployed_commit` — which the host records as the **full deploy HEAD**.

…using prefix-**equality**. When a deploy batch lands non-Guardian commits *after* the last Guardian-touching one — routine when several PRs merge per deploy — the two hashes differ **even though HEAD contains the Guardian commit**. Result: a false `ERROR` event **and a HIGH-priority user-facing "auto-redeploy may have failed" alarm, re-firing every 3 ticks**, while the host is actually current. (Observed live: a deploy where the last commit didn't touch Guardian paths.)

## The fix
Test **containment (ancestry)**, not equality — the host is current iff its deployed HEAD *contains* the container's latest Guardian-path commit. New `_host_contains_commit` helper runs `git merge-base --is-ancestor <container> <host>`, with the exit codes mapped **explicitly**: `0 → contained (current)`, `1 → genuine drift`, **anything else incl. `128` (host ahead / unresolvable) → skip**. A naive `returncode == 0` would fold `128` into "drift" and re-introduce the false alarm whenever the host is legitimately ahead — so the mapping mirrors the sibling `_expected_gateway_sha`'s skip-on-unresolvable contract. Exceptions/timeout also skip, never alarm. Genuine staleness still fires at the threshold.

`src/genesis/db` stays a Guardian-watched path (DB changes *are* Guardian-relevant) — the fix is the comparison logic, not the path set.

## Tests
First tests for `_check_code_drift` (it had none): direct helper exit-code mapping (`0/1/128/raise`), plus integration through `_check_code_drift_inner` — host-ahead-contains → no drift / no alarm (the regression), genuine stale → alert at threshold, unresolvable → skip, drift-then-resolved → reset, and an end-to-end `128 → skip` on the real helper. 33 tests green; ruff clean. Real-repo sanity confirms the exit semantics (`merge-base --is-ancestor` of the actual commits → 0 = contained). No migration.

Rejected the source-side alternative (host records last-Guardian-path-commit): it duplicates the path set into the host script and fails *open* on divergence — worse than this loud false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)