### PR TITLE
fix(memory): evidence-gate dream-cycle auto-merge + survivor fix

### DIFF
--- a/src/genesis/memory/dream_entity_scan.py
+++ b/src/genesis/memory/dream_entity_scan.py
@@ -13,6 +13,7 @@ Contradictions create ``contradicts`` or ``succeeded_by`` links in the graph.
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -59,17 +60,21 @@ async def run_entity_resolution(
     """
     from genesis.memory.entity_resolution import (
         AUTO_MERGE_THRESHOLD,
+        EVIDENCE_THRESHOLD,
         LLM_CHECK_FLOOR,
         MAX_ENTITY_CHECKS_PER_RUN,
         check_semantic_overlap,
+        compute_evidence_strength,
         find_dedup_candidates,
         log_resolution,
+        pick_duplicate_survivor,
     )
     from genesis.qdrant import collections as qdrant_ops
 
     report: dict[str, Any] = {
         "candidates_found": 0,
         "auto_merged": 0,
+        "low_evidence_skipped": 0,
         "llm_checked": 0,
         "llm_merged": 0,
         "contradictions": 0,
@@ -184,7 +189,41 @@ async def run_entity_resolution(
                     survivor_id, deprecated_id = point_b["id"], point_a["id"]
 
                 if score >= AUTO_MERGE_THRESHOLD:
-                    # Auto-merge: deprecate older, keep newer
+                    # Evidence gate (spec ③): high cosine alone is not enough.
+                    # A near-floor merge whose corroborating signals (temporal
+                    # distance, confidence, load-bearing) are jointly weak is
+                    # flagged for review instead of being silently deprecated.
+                    strength, evidence = compute_evidence_strength(
+                        payload_a, payload_b, score,
+                    )
+                    if strength < EVIDENCE_THRESHOLD:
+                        await log_resolution(
+                            db,
+                            run_id=run_id,
+                            action="flagged",
+                            memory_id_a=point_a["id"],
+                            memory_id_b=point_b["id"],
+                            content_a=content_a,
+                            content_b=content_b,
+                            cosine_score=score,
+                            llm_verdict="low_evidence",
+                            llm_reasoning=json.dumps({
+                                "reason": "low_evidence_auto_merge",
+                                "strength": round(strength, 4),
+                                "threshold": EVIDENCE_THRESHOLD,
+                                "signals": evidence,
+                            }),
+                        )
+                        report["low_evidence_skipped"] += 1
+                        continue
+
+                    # Confirmed duplicate: keep the load-bearing memory as
+                    # survivor (not merely the newer one — survivor fix).
+                    survivor_id, deprecated_id = pick_duplicate_survivor(
+                        point_a["id"], payload_a, dt_a,
+                        point_b["id"], payload_b, dt_b,
+                    )
+                    # Auto-merge: deprecate the non-survivor, keep the survivor
                     try:
                         await _deprecate_memory(
                             qdrant, db, deprecated_id,
@@ -269,6 +308,12 @@ async def run_entity_resolution(
                             )
                             continue
 
+                        # Confirmed duplicate: keep the load-bearing memory as
+                        # survivor (consistent with the auto-merge path).
+                        survivor_id, deprecated_id = pick_duplicate_survivor(
+                            point_a["id"], payload_a, dt_a,
+                            point_b["id"], payload_b, dt_b,
+                        )
                         try:
                             await _deprecate_memory(
                                 qdrant, db, deprecated_id,
@@ -303,14 +348,17 @@ async def run_entity_resolution(
                         if ts_a != ts_b:
                             link_type = "succeeded_by"
 
+                        # Resolve link direction BEFORE the try so the error
+                        # handler below can never hit an unbound name if the
+                        # import or create() raises.
+                        # Older → newer for succeeded_by; either direction for contradicts
+                        if link_type == "succeeded_by":
+                            src, tgt = deprecated_id, survivor_id
+                        else:
+                            src, tgt = point_a["id"], point_b["id"]
+
                         try:
                             from genesis.db.crud import memory_links
-
-                            # Older → newer for succeeded_by; either direction for contradicts
-                            if link_type == "succeeded_by":
-                                src, tgt = deprecated_id, survivor_id
-                            else:
-                                src, tgt = point_a["id"], point_b["id"]
 
                             await memory_links.create(
                                 db,
@@ -368,10 +416,12 @@ async def run_entity_resolution(
             pass
 
     logger.info(
-        "Entity resolution: %d candidates, %d auto-merged, %d LLM-checked "
+        "Entity resolution: %d candidates, %d auto-merged, "
+        "%d low-evidence-flagged, %d LLM-checked "
         "(%d merged, %d contradictions, %d distinct), %d errors",
         report["candidates_found"],
         report["auto_merged"],
+        report["low_evidence_skipped"],
         report["llm_checked"],
         report["llm_merged"],
         report["contradictions"],

--- a/src/genesis/memory/entity_resolution.py
+++ b/src/genesis/memory/entity_resolution.py
@@ -34,6 +34,14 @@ LLM_CHECK_FLOOR: float = 0.85
 MAX_ENTITY_CHECKS_PER_RUN: int = 50
 CALL_SITE_ID: str = "dream_cycle_entity_check"
 
+# Evidence gate for auto-merge (spec ③). A ≥0.95-cosine pair auto-merges only
+# when its multi-signal evidence strength clears this floor; below it, the pair
+# is flagged for review instead of being silently deprecated. Calibrated
+# against 1727 historical auto-merges: at 0.30 the gate blocks ~5% of merges,
+# entirely within the 0.95–0.96 suspect band, and never blocks a ≥0.98
+# near-identical pair (see PR for the calibration replay).
+EVIDENCE_THRESHOLD: float = 0.30
+
 _ALIAS_PATH = Path(
     os.environ.get(
         "GENESIS_ENTITY_ALIASES",
@@ -199,6 +207,110 @@ def _find_dedup_candidates_sync(
             candidates.append((point, point_b, hit["score"]))
 
     return candidates
+
+
+# ── Evidence Gate (spec ③) ───────────────────────────────────────────────
+
+
+def _parse_created_at(payload: dict) -> datetime | None:
+    """Parse a payload's ``created_at`` ISO timestamp; None on absence/garbage."""
+    ts = payload.get("created_at")
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts)
+    except (ValueError, TypeError):
+        return None
+    return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt
+
+
+def compute_evidence_strength(
+    payload_a: dict,
+    payload_b: dict,
+    cosine: float,
+) -> tuple[float, dict[str, Any]]:
+    """Multi-signal evidence score in ``[0, 1]`` for an auto-merge candidate.
+
+    Higher = safer to auto-merge. The auto-merge gate flags (not merges) a
+    pair whose strength is below :data:`EVIDENCE_THRESHOLD`.
+
+    Coincident-weakness design (calibrated against 1727 historical merges):
+    cosine is the dominant term so near-identical text keeps a strong floor and
+    always clears the gate regardless of the other signals. Temporal closeness
+    and confidence are *capped* modifiers — neither can block on its own; only
+    coincident weakness (e.g. floor cosine AND far apart) drops below the gate.
+    The load-bearing factor is an intentional bar-raiser (a heavily-retrieved
+    memory needs more corroboration before deprecation), not a "weakness".
+    Absent payload fields resolve to neutral and never block on their own (so
+    sparse payloads keep merging as before).
+
+    Returns ``(strength, signals)`` where ``signals`` is an audit-friendly
+    breakdown (cosine, temporal distance in days, mean confidence, max
+    retrieved_count).
+    """
+    def clamp01(x: float) -> float:
+        return max(0.0, min(1.0, x))
+
+    conf_a = payload_a.get("confidence")
+    conf_b = payload_b.get("confidence")
+    conf_a = 0.5 if conf_a is None else conf_a
+    conf_b = 0.5 if conf_b is None else conf_b
+    conf_mean = (conf_a + conf_b) / 2.0
+
+    rc_max = max(payload_a.get("retrieved_count") or 0,
+                 payload_b.get("retrieved_count") or 0)
+
+    dt_a = _parse_created_at(payload_a)
+    dt_b = _parse_created_at(payload_b)
+    if dt_a is not None and dt_b is not None:
+        dt_days: float | None = abs((dt_a - dt_b).total_seconds()) / 86400.0
+        s_temporal = clamp01(1.0 - dt_days / 30.0)  # 0d→1, 30d→0
+    else:
+        dt_days = None
+        s_temporal = 0.7  # unknown timestamps → mildly supportive (neutral)
+
+    s_cos = clamp01((cosine - 0.95) / 0.045)   # 0.95→0, 0.995→1 (dominant)
+    s_conf = clamp01((conf_mean - 0.5) / 0.4)  # 0.5(default)→0, 0.9→1
+    s_load = 1.0 if rc_max < 5 else 0.5        # heavily-retrieved → raise the bar
+
+    strength = clamp01(
+        0.45 * s_cos + 0.25 * s_temporal + 0.15 * s_conf + 0.15 * s_load
+    )
+    signals = {
+        "cosine": round(cosine, 4),
+        "dt_days": round(dt_days, 2) if dt_days is not None else None,
+        "conf_mean": round(conf_mean, 3),
+        "retrieved_count_max": rc_max,
+    }
+    return strength, signals
+
+
+def pick_duplicate_survivor(
+    id_a: str,
+    payload_a: dict,
+    dt_a: datetime,
+    id_b: str,
+    payload_b: dict,
+    dt_b: datetime,
+) -> tuple[str, str]:
+    """Pick ``(survivor_id, deprecated_id)`` for a CONFIRMED-DUPLICATE pair.
+
+    Prefers the more-retrieved (load-bearing) memory as survivor even when it is
+    the older one — duplicates carry ~identical content, so we keep the
+    established memory rather than deprecating one that is actively used. Ties
+    break to the newer memory (prior behavior).
+
+    For duplicate paths only (auto_merge / llm_merge). The contradiction /
+    succeeded_by path keeps temporal survivorship (newer supersedes older) and
+    must NOT be routed through here.
+    """
+    rc_a = payload_a.get("retrieved_count") or 0
+    rc_b = payload_b.get("retrieved_count") or 0
+    if rc_a > rc_b:
+        return id_a, id_b
+    if rc_b > rc_a:
+        return id_b, id_a
+    return (id_a, id_b) if dt_a >= dt_b else (id_b, id_a)
 
 
 # ── Semantic Overlap Checker ─────────────────────────────────────────────

--- a/tests/test_memory/test_dream_entity_scan.py
+++ b/tests/test_memory/test_dream_entity_scan.py
@@ -1,0 +1,117 @@
+"""Integration tests for the evidence-gated auto-merge (spec ③).
+
+Exercises ``run_entity_resolution`` end-to-end with a controlled candidate pair
+and a real in-memory audit DB, mocking only Qdrant I/O. Proves the Level-4
+done-condition: a low-evidence pair that previously auto-merged is now FLAGGED
+(not deprecated); strong pairs still merge; the survivor is the load-bearing
+memory.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.memory import dream_entity_scan
+
+NOW = datetime(2026, 6, 23, tzinfo=UTC)
+
+
+def _point(pid, *, confidence, retrieved_count, created_at):
+    return {
+        "id": pid,
+        "payload": {
+            "content": f"memory content for {pid}",
+            "confidence": confidence,
+            "retrieved_count": retrieved_count,
+            "created_at": created_at.isoformat(),
+            "wing": "memory",
+            "room": "test",
+        },
+    }
+
+
+async def _run(db, point_a, point_b, score, monkeypatch):
+    monkeypatch.setattr(
+        "genesis.qdrant.collections.batch_retrieve_vectors",
+        MagicMock(return_value={point_a["id"]: [0.1] * 8,
+                                point_b["id"]: [0.1] * 8}),
+    )
+    monkeypatch.setattr(
+        "genesis.qdrant.collections.update_payload", MagicMock(),
+    )
+    # graph-cache invalidation is incidental to this test
+    monkeypatch.setattr(
+        "genesis.memory.graph.invalidate_graph_cache", MagicMock(),
+        raising=False,
+    )
+
+    async def fake_find(*_a, **_k):
+        return [(point_a, point_b, score)]
+
+    monkeypatch.setattr(
+        "genesis.memory.entity_resolution.find_dedup_candidates", fake_find,
+    )
+
+    buckets = {("memory", "test"): [point_a, point_b]}
+    return await dream_entity_scan.run_entity_resolution(
+        qdrant=MagicMock(), db=db, router=AsyncMock(), store=MagicMock(),
+        run_id="test-run", dry_run=False, buckets=buckets,
+    )
+
+
+async def _audit_rows(db):
+    cur = await db.execute(
+        "SELECT action, llm_verdict, survivor_id FROM entity_resolution_audit"
+    )
+    return [dict(r) for r in await cur.fetchall()]
+
+
+@pytest.mark.asyncio
+async def test_low_evidence_pair_flagged_not_merged(db, monkeypatch):
+    """Floor cosine + far apart + default confidence: previously an auto-merge,
+    now flagged for review with no deprecation."""
+    far = NOW - timedelta(days=40)
+    a = _point("a", confidence=0.5, retrieved_count=0, created_at=NOW)
+    b = _point("b", confidence=0.5, retrieved_count=0, created_at=far)
+
+    report = await _run(db, a, b, 0.95, monkeypatch)
+
+    assert report["auto_merged"] == 0
+    assert report["low_evidence_skipped"] == 1
+    rows = await _audit_rows(db)
+    assert len(rows) == 1
+    assert rows[0]["action"] == "flagged"
+    assert rows[0]["llm_verdict"] == "low_evidence"
+
+
+@pytest.mark.asyncio
+async def test_strong_pair_still_auto_merges(db, monkeypatch):
+    """Near-identical, close-in-time, confident pair still auto-merges."""
+    a = _point("a", confidence=0.8, retrieved_count=0, created_at=NOW)
+    b = _point("b", confidence=0.8, retrieved_count=0, created_at=NOW)
+
+    report = await _run(db, a, b, 0.99, monkeypatch)
+
+    assert report["auto_merged"] == 1
+    assert report["low_evidence_skipped"] == 0
+    rows = await _audit_rows(db)
+    assert rows[0]["action"] == "auto_merge"
+
+
+@pytest.mark.asyncio
+async def test_survivor_is_the_load_bearing_memory(db, monkeypatch):
+    """On a strong merge, the more-retrieved memory survives even if older
+    (the survivor fix) — instead of the prior newest-wins behavior."""
+    older = NOW - timedelta(days=1)
+    a = _point("a", confidence=0.8, retrieved_count=9, created_at=older)
+    b = _point("b", confidence=0.8, retrieved_count=0, created_at=NOW)
+
+    report = await _run(db, a, b, 0.99, monkeypatch)
+
+    assert report["auto_merged"] == 1
+    rows = await _audit_rows(db)
+    assert rows[0]["action"] == "auto_merge"
+    assert rows[0]["survivor_id"] == "a"  # older but load-bearing survives

--- a/tests/test_memory/test_entity_resolution.py
+++ b/tests/test_memory/test_entity_resolution.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from genesis.memory.entity_resolution import (
+    EVIDENCE_THRESHOLD,
     check_semantic_overlap,
+    compute_evidence_strength,
     find_dedup_candidates,
     log_resolution,
     normalize_content,
+    pick_duplicate_survivor,
 )
 
 # --- normalize_content ---
@@ -203,3 +207,117 @@ async def test_log_resolution(db):
     assert row["memory_id_b"] == "mem-b"
     assert row["cosine_score"] == 0.97
     assert row["survivor_id"] == "mem-b"
+
+
+# --- compute_evidence_strength (spec ③: evidence-gated auto-merge) ---
+#
+# Strength in [0,1]; the auto-merge gate blocks when strength <
+# EVIDENCE_THRESHOLD. Design invariants (calibrated vs 1727 historical merges):
+#   - near-identical text (high cosine) is structurally merge-safe
+#   - no SINGLE weak signal can block; only coincident weakness does
+#   - absent payload fields never block on their own (no regression)
+
+_NOW = datetime(2026, 6, 23, tzinfo=UTC)
+
+
+def _payload(*, confidence=None, retrieved_count=None, created_at=_NOW, content="x"):
+    p = {"content": content}
+    if confidence is not None:
+        p["confidence"] = confidence
+    if retrieved_count is not None:
+        p["retrieved_count"] = retrieved_count
+    if created_at is not None:
+        p["created_at"] = created_at.isoformat()
+    return p
+
+
+def test_evidence_strong_signals_merge():
+    """High cosine + close in time + good confidence => clears the gate."""
+    a = _payload(confidence=0.8, retrieved_count=0, created_at=_NOW)
+    b = _payload(confidence=0.8, retrieved_count=0, created_at=_NOW)
+    strength, signals = compute_evidence_strength(a, b, 0.99)
+    assert strength >= EVIDENCE_THRESHOLD
+    assert signals["cosine"] == 0.99
+
+
+def test_evidence_coincident_weakness_blocks():
+    """Floor cosine + far apart + default confidence => below threshold."""
+    far = _NOW - timedelta(days=40)
+    a = _payload(confidence=0.5, retrieved_count=0, created_at=_NOW)
+    b = _payload(confidence=0.5, retrieved_count=0, created_at=far)
+    strength, _ = compute_evidence_strength(a, b, 0.95)
+    assert strength < EVIDENCE_THRESHOLD
+
+
+def test_evidence_high_cosine_bypass():
+    """Near-identical text always clears the gate, even when every other
+    signal is weak (far apart + low conf + load-bearing). This is the key
+    structural property: cosine alone keeps a strong floor."""
+    far = _NOW - timedelta(days=40)
+    a = _payload(confidence=0.5, retrieved_count=10, created_at=_NOW)
+    b = _payload(confidence=0.5, retrieved_count=10, created_at=far)
+    strength, _ = compute_evidence_strength(a, b, 0.99)
+    assert strength >= EVIDENCE_THRESHOLD
+
+
+def test_evidence_single_weak_signal_does_not_block():
+    """Floor cosine but everything else strong => still merges. A single
+    weak dimension must not block (only coincident weakness does)."""
+    a = _payload(confidence=0.85, retrieved_count=0, created_at=_NOW)
+    b = _payload(confidence=0.85, retrieved_count=0, created_at=_NOW)
+    strength, _ = compute_evidence_strength(a, b, 0.95)
+    assert strength >= EVIDENCE_THRESHOLD
+
+
+def test_evidence_high_cosine_bypass_survives_load_penalty():
+    """The high-cosine bypass must hold even when the load-bearing penalty
+    applies (rc>=5) AND temporal/confidence are worst-case. Locks the
+    invariant that near-identical text always clears the gate."""
+    far = _NOW - timedelta(days=60)
+    a = _payload(confidence=0.5, retrieved_count=50, created_at=_NOW)
+    b = _payload(confidence=0.5, retrieved_count=50, created_at=far)
+    strength, _ = compute_evidence_strength(a, b, 0.98)
+    assert strength >= EVIDENCE_THRESHOLD
+
+
+def test_evidence_absent_fields_do_not_block():
+    """Missing confidence/retrieved_count/created_at must not, on their own,
+    push a mid-band merge below threshold (no regression on sparse payloads)."""
+    a = {"content": "x"}  # no confidence, retrieved_count, created_at
+    b = {"content": "y"}
+    strength, signals = compute_evidence_strength(a, b, 0.96)
+    assert strength >= EVIDENCE_THRESHOLD
+    assert signals["dt_days"] is None  # unknown temporal
+
+
+def test_evidence_garbage_timestamp_is_defensive():
+    """A malformed created_at must not raise — treated as unknown temporal."""
+    a = {"content": "x", "created_at": "not-a-timestamp"}
+    b = {"content": "y", "created_at": "also-bad"}
+    strength, signals = compute_evidence_strength(a, b, 0.96)
+    assert 0.0 <= strength <= 1.0
+    assert signals["dt_days"] is None
+
+
+# --- pick_duplicate_survivor (spec ③: survivor fix) ---
+
+
+def test_survivor_prefers_more_retrieved_even_if_older():
+    """The load-bearing memory survives even when it is the OLDER one
+    (the live-data bug: we were deprecating the more-retrieved memory)."""
+    older = _NOW - timedelta(days=5)
+    a = _payload(retrieved_count=5, created_at=older)   # older, load-bearing
+    b = _payload(retrieved_count=0, created_at=_NOW)    # newer, unused
+    survivor, deprecated = pick_duplicate_survivor("id_a", a, older, "id_b", b, _NOW)
+    assert survivor == "id_a"
+    assert deprecated == "id_b"
+
+
+def test_survivor_tie_breaks_to_newer():
+    """Equal retrieved_count => newest survives (prior behavior preserved)."""
+    older = _NOW - timedelta(days=5)
+    a = _payload(retrieved_count=3, created_at=older)
+    b = _payload(retrieved_count=3, created_at=_NOW)
+    survivor, deprecated = pick_duplicate_survivor("id_a", a, older, "id_b", b, _NOW)
+    assert survivor == "id_b"
+    assert deprecated == "id_a"


### PR DESCRIPTION
## Problem

The dream-cycle entity-resolution phase auto-merges near-duplicate episodic
memories whenever cosine ≥ 0.95 — **on cosine alone, with no corroboration**.
The LLM path (0.85–0.95) is already double-gated by an adversarial second
opinion, so the auto-merge branch is the only place a memory is permanently
deprecated on a single number.

A replay over **1,749 historical auto-merges** (audit → live Qdrant payloads)
showed this is not hypothetical: real false-merges happen at 0.95–0.96 cosine —
different PR numbers ("Merged PR #260" vs "#480"), plan-vs-implementation facts
("Planned LLM reranking" vs "Default rerank=True"), and distinct queries merged
on shared boilerplate. A false-merge permanently deprecates a distinct memory
and corrupts episodic retrieval.

## Change

**1. Evidence gate (auto-merge branch only).** `compute_evidence_strength`
combines four signals — cosine (dominant) + temporal closeness + confidence +
a load-bearing bar-raiser — into a `[0,1]` score. Below `EVIDENCE_THRESHOLD`
(0.30) the pair is logged as a `flagged` audit row (`low_evidence`) for review
instead of being deprecated. Coincident-weakness design: near-identical text
(high cosine) always clears the gate; no single weak signal can block. The LLM
path is untouched. **No migration** — reuses the existing `flagged` action.

**2. Survivor fix.** For confirmed duplicates (auto_merge + llm_merge),
`pick_duplicate_survivor` keeps the more-retrieved (load-bearing) memory as
survivor instead of always-newest. Live data showed a `retrieved_count=5`
memory being deprecated in favor of a `retrieved_count=0` one. The
contradiction / `succeeded_by` path intentionally keeps temporal survivorship.

**3. Drive-by safety fix.** The pre-existing `contradicts` link handler bound
`src`/`tgt` inside the `try`; an import/create failure would hit the `except`
with an `UnboundLocalError` and crash the whole resolution phase. Direction is
now resolved before the `try`.

## Calibration (how the threshold was chosen)

The `EVIDENCE_THRESHOLD` and signal weights were calibrated by replaying the
scorer over all 1,749 historical merges, not guessed. At **0.30** the gate:

- blocks **~5%** of historical merges, **all within the 0.95–0.96 suspect band**;
- **never** blocks a ≥0.98 near-identical pair (0 of 353);
- the blocked rows skew to genuine false-merges (different PR numbers,
  plan-vs-impl, distinct sessions far apart in time).

This is a conservative correction: a missed merge is recoverable on the next
weekly run; a false-merge is not.

## Verification

- **TDD**: 9 unit tests (evidence scorer invariants + survivor) + 3 integration
  tests exercising the full `run_entity_resolution` path against a real
  in-memory audit DB. 60 targeted memory/dream tests green, `ruff` clean.
- **E2E on real data**: replayed the *shipped* `compute_evidence_strength` over
  1,727 real merges — 0 raises, 5.0% blocked (matches calibration), 0 high-cosine
  blocked.
- **Review**: genesis-architect (design) + two code-review passes (first
  found+fixed a critical pre-existing `UnboundLocalError`; second on the final
  commit is clean, no findings). External-model second opinion (Codex / OpenCode)
  was quota-blocked at review time — merge relies on CI + the Claude-family
  passes per the review-quota policy.

## Deferred (tracked, not in this PR)

- `succeeded_by` link direction is unreliable when one memory lacks a timestamp
  (`ts_a != ts_b` on `"" vs real`) — pre-existing, in the contradiction path.
- Survivor-aware behavior in the contradiction path (out of scope; duplicates
  only here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
