### PR TITLE
feat(memory): locate self-retrieval MCP tool (Track 5.1)

### DIFF
--- a/src/genesis/env.py
+++ b/src/genesis/env.py
@@ -93,6 +93,30 @@ def genesis_db_path() -> Path:
     return repo_root() / "data" / "genesis.db"
 
 
+def genesis_home() -> Path:
+    """Resolve the Genesis runtime home (~/.genesis): output, sessions, config."""
+    value = os.environ.get("GENESIS_HOME")
+    return Path(value).expanduser() if value else Path.home() / ".genesis"
+
+
+def claude_home() -> Path:
+    """Resolve the Claude Code home (~/.claude): plans, skills, projects."""
+    value = os.environ.get("CLAUDE_HOME")
+    return Path(value).expanduser() if value else Path.home() / ".claude"
+
+
+def plans_dir() -> Path:
+    """Working plan/roadmap docs (~/.claude/plans)."""
+    value = os.environ.get("GENESIS_PLANS_DIR")
+    return Path(value).expanduser() if value else claude_home() / "plans"
+
+
+def output_dir() -> Path:
+    """Genesis report/spec/content output (~/.genesis/output)."""
+    value = os.environ.get("GENESIS_OUTPUT_DIR")
+    return Path(value).expanduser() if value else genesis_home() / "output"
+
+
 def cc_project_dir() -> str:
     """Claude Code project directory name, derived from repo root path.
 

--- a/src/genesis/mcp/memory/__init__.py
+++ b/src/genesis/mcp/memory/__init__.py
@@ -159,6 +159,7 @@ _documents_tools = importlib.import_module(".documents", __name__)  # noqa: F401
 _knowledge_tools = importlib.import_module(".knowledge", __name__)  # noqa: F401
 _observations_tools = importlib.import_module(".observations", __name__)  # noqa: F401
 _procedural_tools = importlib.import_module(".procedural", __name__)  # noqa: F401
+_locate_tools = importlib.import_module(".locate", __name__)  # noqa: F401
 
 
 # Backward-compatible patch points expected by tests and callers.

--- a/src/genesis/mcp/memory/locate.py
+++ b/src/genesis/mcp/memory/locate.py
@@ -1,0 +1,523 @@
+"""locate — deterministic self-retrieval over Genesis's known roots (Track 5.1).
+
+A Genesis-owned MCP tool that surfaces recently-changed files (by mtime) across
+known roots — plans, output, the repo, git worktrees — filtered by time window,
+file type, scope, name glob, and optional content match, ranked by recency.
+
+It exists because CC's Grep/Glob are flaky under the open-agents A/B bug; this is
+a deterministic alternative for "what changed recently / where is X?".
+
+STRICTLY READ-ONLY: only `os.scandir`/`stat`/`open`-for-read and `rg` (itself
+read-only) are used. Nothing here writes, creates, or deletes.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+from genesis import env
+
+from ..memory import mcp
+
+logger = logging.getLogger(__name__)
+
+# Suffixes treated as code/config for the file_type filter (yaml/json/toml count
+# as code/config; documented in the tool docstring).
+_CODE_EXTS = frozenset({
+    ".py", ".js", ".ts", ".tsx", ".jsx", ".go", ".rs", ".sh", ".bash", ".zsh",
+    ".sql", ".c", ".h", ".cpp", ".hpp", ".cc", ".java", ".rb", ".php", ".lua",
+    ".yaml", ".yml", ".toml", ".cfg", ".ini",
+})
+
+# Directory names whose entire subtree is skipped (build/dep/churn/binary noise).
+# "worktrees" prunes ~/genesis/.claude/worktrees/* under the `repo` scope — those
+# are reachable via the `worktrees` scope (git-discovered) instead.
+_PRUNE_DIRS = frozenset({
+    ".git", ".venv", "venv", "node_modules", "__pycache__", ".pytest_cache",
+    ".ruff_cache", ".mypy_cache", ".cache", "dist", "build", ".next", ".turbo",
+    "target", "worktrees", "worktree-trash", "background-sessions", "cc-tmp",
+    "embedding_cache", "qdrant_storage", "browser-profile", "camoufox-profile",
+    "paste-cache", "file-history", "backups", "downloads",
+})
+
+# Per-file glob skips (binary/churn artifacts not worth surfacing).
+_SKIP_FILE_GLOBS = ("*.db", "*.db-wal", "*.db-shm", "*.sqlite", "*.sqlite3", "*.lock")
+
+_MAX_CONTENT_BYTES = 1_048_576       # 1 MiB — matches `rg --max-filesize 1M`
+_BINARY_SNIFF_BYTES = 8192
+_MAX_FILES_SCANNED = 50_000          # pathological-walk backstop
+_CONTENT_POOL_CAP = 5_000            # most-recent N considered for content match
+_HARD_LIMIT = 200                    # absolute cap on returned results
+_SNIPPET_CHARS = 200
+_MAX_MATCHES_PER_FILE = 10
+_RG_CHUNK = 1_000                    # paths per rg invocation (ARG_MAX safety)
+
+_VALID_SCOPES = ("docs", "plans", "output", "repo", "worktrees", "all")
+_VALID_TYPES = ("any", "code", "noncode")
+
+
+# ── small helpers ─────────────────────────────────────────────────────────────
+
+
+def _have_rg() -> bool:
+    """True if ripgrep is on PATH. Monkeypatchable in tests."""
+    return shutil.which("rg") is not None
+
+
+def _parse_window(within: str) -> float | None:
+    """Parse a time-window token into seconds, or None for 'no limit'.
+
+    Accepts ``Nh`` (hours), ``Nd`` (days), bare ``N`` (days), and
+    ``0`` / ``""`` / ``all`` / ``any`` (no limit). Raises ValueError on garbage.
+    """
+    token = (within or "").strip().lower()
+    if token in ("", "0", "all", "any"):
+        return None
+    if token.endswith("h"):
+        seconds = float(token[:-1]) * 3600
+    elif token.endswith("d"):
+        seconds = float(token[:-1]) * 86400
+    else:
+        seconds = float(token) * 86400  # bare number = days; ValueError if non-numeric
+    if seconds < 0:
+        raise ValueError(f"negative time window: {within!r}")
+    return seconds
+
+
+def _humanize_age(mtime_epoch: float, now_epoch: float) -> str:
+    diff = max(0.0, now_epoch - mtime_epoch)
+    if diff < 60:
+        return "just now"
+    if diff < 3600:
+        return f"{int(diff // 60)}m ago"
+    if diff < 86400:
+        return f"{int(diff // 3600)}h ago"
+    return f"{int(diff // 86400)}d ago"
+
+
+def _display(p: Path) -> str:
+    s = str(p)
+    home = str(Path.home())
+    return "~" + s[len(home):] if s.startswith(home) else s
+
+
+def _list_worktrees(repo_root: Path) -> list[Path]:
+    """Worktree paths (excluding the main worktree) via git porcelain.
+
+    Catches worktrees at every location (siblings, nested under the repo, /tmp).
+    Returns [] on any error (not a git repo, git absent, timeout).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            capture_output=True, text=True, cwd=str(repo_root), timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+    paths: list[Path] = []
+    is_first = True
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            if is_first:
+                is_first = False  # first entry is the main worktree — skip
+            else:
+                paths.append(Path(line[len("worktree "):]))
+    return paths
+
+
+def _resolve_roots(scope: str) -> list[tuple[str, Path]]:
+    """Map a scope to (label, path) roots. Raises ValueError on unknown scope."""
+    plans = ("plans", env.plans_dir())
+    output = ("output", env.output_dir())
+    repo = ("repo", env.repo_root())
+    if scope == "plans":
+        return [plans]
+    if scope == "output":
+        return [output]
+    if scope == "docs":
+        return [plans, output]
+    if scope == "repo":
+        return [repo]
+    if scope == "worktrees":
+        return [(f"worktree:{p.name}", p) for p in _list_worktrees(env.repo_root())]
+    if scope == "all":
+        wts = [(f"worktree:{p.name}", p) for p in _list_worktrees(env.repo_root())]
+        return [plans, output, repo, *wts]
+    raise ValueError(f"unknown scope: {scope!r}")
+
+
+def _matches_skip_glob(name: str) -> bool:
+    return any(fnmatch.fnmatch(name, g) for g in _SKIP_FILE_GLOBS)
+
+
+# ── walk ──────────────────────────────────────────────────────────────────────
+
+
+def _walk(
+    label: str,
+    root: Path,
+    cutoff: float | None,
+    file_type: str,
+    name_glob: str,
+    scan_budget: list[int],
+) -> list[dict]:
+    """Return file records under ``root`` passing recency/type/glob filters.
+
+    Iterative, prune-aware, symlink-safe (never recurses into or lists symlinks).
+    ``scan_budget`` is a single-element list mutated as a shared scanned-file
+    counter / ceiling across roots.
+    """
+    records: list[dict] = []
+    name_pat = name_glob.lower() if name_glob else ""
+    stack: list[Path] = [root]
+    while stack:
+        d = stack.pop()
+        try:
+            with os.scandir(d) as it:
+                entries = list(it)
+        except (PermissionError, OSError):
+            continue
+        for e in entries:
+            if scan_budget[0] >= _MAX_FILES_SCANNED:
+                return records
+            try:
+                if e.is_dir(follow_symlinks=False):
+                    if e.name not in _PRUNE_DIRS:
+                        stack.append(Path(e.path))
+                    continue
+                if not e.is_file(follow_symlinks=False):
+                    continue  # symlinks, sockets, fifos — skip
+            except OSError:
+                continue
+            nm = e.name
+            if _matches_skip_glob(nm):
+                continue
+            scan_budget[0] += 1
+            if name_pat and not fnmatch.fnmatch(nm.lower(), name_pat):
+                continue
+            suffix = os.path.splitext(nm)[1].lower()
+            if file_type == "code" and suffix not in _CODE_EXTS:
+                continue
+            if file_type == "noncode" and suffix in _CODE_EXTS:
+                continue
+            try:
+                st = e.stat(follow_symlinks=False)
+            except OSError:
+                continue
+            if cutoff is not None and st.st_mtime < cutoff:
+                continue
+            records.append({
+                "path": Path(e.path),
+                "name": nm,
+                "scope": label,
+                "mtime": st.st_mtime,
+                "size": st.st_size,
+            })
+    return records
+
+
+# ── content match ─────────────────────────────────────────────────────────────
+
+
+def _is_text_and_small(path: Path) -> bool:
+    """True if the file is <= 1 MiB and not binary (no NUL in the first 8 KiB).
+
+    Applied to BOTH backends before matching: rg bypasses its own binary/size
+    filtering when files are passed as explicit path args (it only self-filters
+    during recursive traversal), so we must gate candidates ourselves.
+    """
+    try:
+        if path.stat().st_size > _MAX_CONTENT_BYTES:
+            return False
+        with path.open("rb") as fh:
+            head = fh.read(_BINARY_SNIFF_BYTES)
+    except OSError:
+        return False
+    return b"\x00" not in head
+
+
+def _content_match(records: list[dict], contains: str, regex: bool) -> tuple[list[dict], str | None]:
+    """Filter records to those whose content matches, attaching ``matches``.
+
+    Returns (records_with_matches, error). ``error`` set only on invalid regex.
+    Binary/oversize files are excluded up front (see ``_is_text_and_small``).
+    Tries rg first (fast); falls back to pure Python when rg is absent or
+    errors — identical result shape either way.
+    """
+    if regex:
+        try:
+            re.compile(contains)
+        except re.error as exc:
+            return [], f"invalid regex: {exc}"
+    eligible = [r for r in records if _is_text_and_small(r["path"])]
+    if _have_rg():
+        out = _content_match_rg(eligible, contains, regex)
+        if out is not None:
+            return out, None
+    return _content_match_python(eligible, contains, regex), None
+
+
+def _content_match_rg(records: list[dict], contains: str, regex: bool) -> list[dict] | None:
+    """rg-backed content match. Returns None to signal 'fall back to Python'."""
+    by_path = {str(r["path"]): r for r in records}
+    if not by_path:
+        return []
+    matches_by_path: dict[str, list[dict]] = {}
+    paths = list(by_path.keys())
+    base = ["rg", "--json", "--max-filesize", "1M"]
+    if not regex:
+        base.append("-F")
+    base += ["-e", contains, "--"]
+    for i in range(0, len(paths), _RG_CHUNK):
+        chunk = paths[i:i + _RG_CHUNK]
+        try:
+            proc = subprocess.run(base + chunk, capture_output=True, text=True, timeout=60)
+        except (subprocess.TimeoutExpired, OSError):
+            return None  # fall back entirely for a consistent result
+        if proc.returncode not in (0, 1):  # 0=matches, 1=no matches; >=2 = error
+            return None
+        for line in proc.stdout.splitlines():
+            if not line:
+                continue
+            try:
+                evt = json.loads(line)
+            except ValueError:
+                continue
+            if evt.get("type") != "match":
+                continue
+            data = evt.get("data", {})
+            p = data.get("path", {}).get("text")
+            if p is None:
+                continue
+            lst = matches_by_path.setdefault(p, [])
+            if len(lst) >= _MAX_MATCHES_PER_FILE:
+                continue
+            text = (data.get("lines", {}).get("text") or "").strip()[:_SNIPPET_CHARS]
+            lst.append({"line": data.get("line_number"), "text": text})
+    return [
+        {**rec, "matches": matches_by_path[p]}
+        for p, rec in by_path.items()
+        if p in matches_by_path
+    ]
+
+
+def _content_match_python(records: list[dict], contains: str, regex: bool) -> list[dict]:
+    """Pure-Python content match fallback (binary/oversize-guarded)."""
+    pattern = re.compile(contains) if regex else None
+    out: list[dict] = []
+    for rec in records:
+        path: Path = rec["path"]
+        try:
+            if path.stat().st_size > _MAX_CONTENT_BYTES:
+                continue
+            with path.open("rb") as fh:
+                head = fh.read(_BINARY_SNIFF_BYTES)
+            if b"\x00" in head:
+                continue
+            text = path.read_text(errors="replace")
+        except OSError:
+            continue
+        matches: list[dict] = []
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            hit = pattern.search(line) if pattern else (contains in line)
+            if hit:
+                matches.append({"line": lineno, "text": line.strip()[:_SNIPPET_CHARS]})
+                if len(matches) >= _MAX_MATCHES_PER_FILE:
+                    break
+        if matches:
+            out.append({**rec, "matches": matches})
+    return out
+
+
+# ── response assembly ─────────────────────────────────────────────────────────
+
+
+def _error_response(query: dict, error: str, *, roots=None, skipped=None, scanned=0) -> dict:
+    return {
+        "summary": f"locate error: {error}",
+        "query": query,
+        "count": 0,
+        "total_matched": 0,
+        "truncated": False,
+        "content_pool_capped": False,
+        "scan_truncated": False,
+        "scanned": scanned,
+        "roots": roots or [],
+        "skipped_roots": skipped or [],
+        "results": [],
+        "error": error,
+    }
+
+
+def _summarize(scope, within, file_type, contains, total, shown, truncated, skipped, capped, scan_truncated) -> str:
+    extra = []
+    if skipped:
+        extra.append(f"{len(skipped)} root(s) absent")
+    if capped:
+        extra.append(f"content pool capped at {_CONTENT_POOL_CAP}")
+    if scan_truncated:
+        extra.append(
+            f"scan hit the {_MAX_FILES_SCANNED}-file ceiling — results may be "
+            "incomplete (narrow scope or within)"
+        )
+    suffix = (" · " + " · ".join(extra)) if extra else ""
+    if total == 0:
+        return f"no files match in scope '{scope}' (within {within}, {file_type})" + suffix
+    head = f"{shown} of {total}" if truncated else f"{total}"
+    quals = [f"within {within}", file_type]
+    if contains:
+        quals.append(f"containing {contains!r}")
+    return f"{head} file(s) in '{scope}' ({', '.join(quals)})" + suffix
+
+
+async def _impl_locate(
+    scope: str = "docs",
+    within: str = "24h",
+    file_type: str = "any",
+    name: str = "",
+    contains: str = "",
+    regex: bool = False,
+    limit: int = 50,
+) -> dict:
+    now = time.time()
+    scope = (scope or "docs").strip().lower()
+    file_type = (file_type or "any").strip().lower()
+    query = {
+        "scope": scope, "within": within, "file_type": file_type,
+        "name": name, "contains": contains, "regex": regex, "limit": limit,
+    }
+
+    if scope not in _VALID_SCOPES:
+        return _error_response(query, f"unknown scope {scope!r}; valid: {', '.join(_VALID_SCOPES)}")
+    if file_type not in _VALID_TYPES:
+        return _error_response(query, f"unknown file_type {file_type!r}; valid: {', '.join(_VALID_TYPES)}")
+
+    try:
+        window_s = _parse_window(within)
+    except ValueError:
+        return _error_response(query, f"invalid 'within' value: {within!r}")
+    cutoff = (now - window_s) if window_s is not None else None
+
+    try:
+        roots = _resolve_roots(scope)
+    except ValueError as exc:
+        return _error_response(query, str(exc))
+
+    walked_roots: list[str] = []
+    skipped_roots: list[str] = []
+    scan_budget = [0]
+    records: list[dict] = []
+    for label, path in roots:
+        if not path.is_dir():
+            skipped_roots.append(_display(path))
+            continue
+        walked_roots.append(_display(path))
+        records.extend(_walk(label, path, cutoff, file_type, name, scan_budget))
+
+    scan_truncated = scan_budget[0] >= _MAX_FILES_SCANNED
+
+    capped = False
+    if contains:
+        if len(records) > _CONTENT_POOL_CAP:
+            records.sort(key=lambda r: (-r["mtime"], str(r["path"])))
+            records = records[:_CONTENT_POOL_CAP]
+            capped = True
+        records, error = _content_match(records, contains, regex)
+        if error:
+            return _error_response(
+                query, error, roots=walked_roots, skipped=skipped_roots, scanned=scan_budget[0],
+            )
+
+    records.sort(key=lambda r: (-r["mtime"], str(r["path"])))
+    total = len(records)
+    li = int(limit)
+    eff_limit = _HARD_LIMIT if li <= 0 else min(li, _HARD_LIMIT)  # 0/neg = all up to cap
+    top = records[:eff_limit]
+
+    results: list[dict] = []
+    for r in top:
+        item = {
+            "path": str(r["path"]),
+            "name": r["name"],
+            "scope": r["scope"],
+            "mtime": datetime.fromtimestamp(r["mtime"], tz=UTC).isoformat(timespec="seconds"),
+            "age": _humanize_age(r["mtime"], now),
+            "size": r["size"],
+        }
+        if "matches" in r:
+            item["matches"] = r["matches"]
+        results.append(item)
+
+    truncated = total > len(results)
+    return {
+        "summary": _summarize(
+            scope, within, file_type, contains, total, len(results),
+            truncated, skipped_roots, capped, scan_truncated,
+        ),
+        "query": query,
+        "count": len(results),
+        "total_matched": total,
+        "truncated": truncated,
+        "content_pool_capped": capped,
+        "scan_truncated": scan_truncated,
+        "scanned": scan_budget[0],
+        "roots": walked_roots,
+        "skipped_roots": skipped_roots,
+        "results": results,
+        "error": None,
+    }
+
+
+@mcp.tool()
+async def locate(
+    scope: str = "docs",
+    within: str = "24h",
+    file_type: str = "any",
+    name: str = "",
+    contains: str = "",
+    regex: bool = False,
+    limit: int = 50,
+) -> dict:
+    """Find recently-changed files across Genesis's known roots, ranked by recency.
+
+    Deterministic, read-only self-retrieval — use this (not Grep/Glob) to answer
+    "what working docs changed recently?" or "where is the file about X?".
+
+    Args:
+        scope: Which roots to search.
+            "docs" (default) = ~/.claude/plans + ~/.genesis/output (fast, the
+            working-docs case); "plans"; "output"; "repo" = the Genesis repo
+            (pruned of .git/.venv/node_modules/worktrees/…); "worktrees" = all
+            git worktrees; "all" = docs + repo + worktrees.
+        within: Time window: "12h", "24h" (default), "7d", "30d", a bare number
+            (days), or "0"/"all" for no time limit. Filters by file mtime.
+        file_type: "any" (default), "code" (.py/.js/.ts/.go/.yaml/.json-ish/…),
+            or "noncode" (.md/.txt/.pdf/… — the working-docs class).
+        name: Case-insensitive glob on the filename, e.g. "*roadmap*.md". Empty = all.
+        contains: Optional content match (only files passing the other filters are
+            opened). Empty = no content filtering.
+        regex: Treat ``contains`` as a regex (default: literal substring).
+        limit: Max results (default 50, hard cap 200; 0 or negative = all up to
+            the cap). Truncation is reported explicitly via count / total_matched
+            / truncated.
+
+    Returns a dict with: summary, query (echoed), count, total_matched, truncated,
+    content_pool_capped, scan_truncated (true if the walk hit its file ceiling, so
+    results may be incomplete), scanned, roots, skipped_roots, and results[] (path,
+    name, scope, mtime, age, size, and matches[] when ``contains`` is used), newest first.
+    """
+    return await _impl_locate(
+        scope=scope, within=within, file_type=file_type,
+        name=name, contains=contains, regex=regex, limit=limit,
+    )

--- a/tests/test_mcp/test_locate.py
+++ b/tests/test_mcp/test_locate.py
@@ -1,0 +1,285 @@
+"""Tests for the `locate` self-retrieval MCP tool (Track 5.1).
+
+Logic is tested against ``_impl_locate`` directly (fast, infra-free); one test
+asserts registration on the genesis-memory FastMCP server. Filesystem isolation
+via ``tmp_path`` + env-var overrides (the env.py helpers honor env vars).
+
+The rg-backed content path and its pure-Python fallback are asserted to produce
+identical results, so the suite passes whether or not ``rg`` is on PATH (CI-safe).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from genesis.mcp.memory.locate import _humanize_age, _impl_locate, _parse_window
+
+
+def _touch(p: Path, content: str = "", age_s: float = 0.0) -> Path:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+    if age_s:
+        t = time.time() - age_s
+        os.utime(p, (t, t))
+    return p
+
+
+def _names(result: dict) -> set[str]:
+    return {r["name"] for r in result["results"]}
+
+
+@pytest.fixture
+def roots(tmp_path, monkeypatch):
+    plans = tmp_path / "plans"
+    output = tmp_path / "output"
+    repo = tmp_path / "repo"
+    for d in (plans, output, repo):
+        d.mkdir()
+    monkeypatch.setenv("GENESIS_PLANS_DIR", str(plans))
+    monkeypatch.setenv("GENESIS_OUTPUT_DIR", str(output))
+    monkeypatch.setenv("GENESIS_REPO_ROOT", str(repo))
+    return {"plans": plans, "output": output, "repo": repo, "tmp": tmp_path}
+
+
+# ── window parsing ────────────────────────────────────────────────────────────
+
+
+def test_parse_window_units():
+    assert _parse_window("24h") == 24 * 3600
+    assert _parse_window("12h") == 12 * 3600
+    assert _parse_window("7d") == 7 * 86400
+    assert _parse_window("30d") == 30 * 86400
+    assert _parse_window("5") == 5 * 86400  # bare int = days
+
+
+def test_parse_window_no_limit():
+    for token in ("0", "", "all", "any"):
+        assert _parse_window(token) is None
+
+
+def test_parse_window_invalid_raises():
+    with pytest.raises(ValueError):
+        _parse_window("not-a-window")
+
+
+def test_parse_window_negative_raises():
+    with pytest.raises(ValueError):
+        _parse_window("-5d")
+
+
+# ── recency ───────────────────────────────────────────────────────────────────
+
+
+async def test_recency_window_boundary(roots):
+    _touch(roots["plans"] / "new.md", age_s=2 * 3600)
+    _touch(roots["plans"] / "mid.md", age_s=23 * 3600)
+    _touch(roots["plans"] / "old.md", age_s=30 * 3600)
+    r = await _impl_locate(scope="plans", within="24h")
+    assert _names(r) == {"new.md", "mid.md"}
+
+
+async def test_within_zero_no_filter(roots):
+    _touch(roots["plans"] / "old.md", age_s=30 * 3600)
+    r = await _impl_locate(scope="plans", within="0")
+    assert "old.md" in _names(r)
+
+
+# ── type / glob ───────────────────────────────────────────────────────────────
+
+
+async def test_file_type_filters(roots):
+    _touch(roots["plans"] / "a.py")
+    _touch(roots["plans"] / "b.md")
+    assert _names(await _impl_locate(scope="plans", within="0", file_type="code")) == {"a.py"}
+    assert _names(await _impl_locate(scope="plans", within="0", file_type="noncode")) == {"b.md"}
+    assert _names(await _impl_locate(scope="plans", within="0", file_type="any")) == {"a.py", "b.md"}
+
+
+async def test_name_glob_case_insensitive(roots):
+    _touch(roots["plans"] / "voice-roadmap.md")
+    _touch(roots["plans"] / "notes.md")
+    assert _names(await _impl_locate(scope="plans", within="0", name="*roadmap*")) == {"voice-roadmap.md"}
+    assert _names(await _impl_locate(scope="plans", within="0", name="*ROADMAP*.MD")) == {"voice-roadmap.md"}
+
+
+# ── scope mapping ─────────────────────────────────────────────────────────────
+
+
+async def test_scope_docs_maps_plans_and_output(roots):
+    _touch(roots["plans"] / "p.md")
+    _touch(roots["output"] / "o.md")
+    _touch(roots["repo"] / "r.md")
+    r = await _impl_locate(scope="docs", within="0")
+    assert _names(r) == {"p.md", "o.md"}
+    labels = {x["name"]: x["scope"] for x in r["results"]}
+    assert labels["p.md"] == "plans"
+    assert labels["o.md"] == "output"
+
+
+async def test_scope_repo_is_optin(roots):
+    _touch(roots["repo"] / "r.md")
+    assert "r.md" not in _names(await _impl_locate(scope="docs", within="0"))
+    rep = await _impl_locate(scope="repo", within="0")
+    assert "r.md" in _names(rep)
+    assert rep["results"][0]["scope"] == "repo"
+
+
+# ── pruning ───────────────────────────────────────────────────────────────────
+
+
+async def test_prune_dirs(roots):
+    repo = roots["repo"]
+    _touch(repo / "node_modules" / "x.md")
+    _touch(repo / ".git" / "y.md")
+    _touch(repo / ".claude" / "worktrees" / "wt" / "z.md")  # nested worktree -> pruned
+    _touch(repo / "keep.md")
+    r = await _impl_locate(scope="repo", within="0")
+    assert _names(r) == {"keep.md"}
+
+
+# ── content match (rg + fallback parity) ──────────────────────────────────────
+
+
+async def test_content_match_rg_present(roots):
+    _touch(roots["plans"] / "hit.md", content="alpha needle one\nbeta two\n")
+    _touch(roots["plans"] / "miss.md", content="nothing here\n")
+    r = await _impl_locate(scope="plans", within="0", contains="needle")
+    assert _names(r) == {"hit.md"}
+    matches = r["results"][0]["matches"]
+    assert matches and matches[0]["line"] == 1 and "needle" in matches[0]["text"]
+
+
+async def test_content_match_fallback_when_rg_absent(roots, monkeypatch):
+    monkeypatch.setattr("genesis.mcp.memory.locate._have_rg", lambda: False)
+    _touch(roots["plans"] / "hit.md", content="alpha needle one\nbeta two\n")
+    _touch(roots["plans"] / "miss.md", content="nothing here\n")
+    r = await _impl_locate(scope="plans", within="0", contains="needle")
+    assert _names(r) == {"hit.md"}
+    matches = r["results"][0]["matches"]
+    assert matches and matches[0]["line"] == 1 and "needle" in matches[0]["text"]
+
+
+async def test_content_invalid_regex(roots):
+    _touch(roots["plans"] / "f.md", content="x")
+    r = await _impl_locate(scope="plans", within="0", contains="(", regex=True)
+    assert r["error"]
+    assert r["results"] == []
+
+
+async def test_content_skips_binary_and_oversize(roots):
+    _touch(roots["plans"] / "big.md", content="needle " + ("x" * 2_000_000))  # > 1 MiB
+    (roots["plans"] / "bin.md").write_bytes(b"needle\x00\x01rest")
+    _touch(roots["plans"] / "ok.md", content="needle here\n")
+    r = await _impl_locate(scope="plans", within="0", contains="needle")
+    assert _names(r) == {"ok.md"}
+
+
+# ── truncation / ordering ─────────────────────────────────────────────────────
+
+
+async def test_truncation_signal(roots):
+    for i in range(60):
+        _touch(roots["plans"] / f"f{i:02d}.md", age_s=i)
+    r = await _impl_locate(scope="plans", within="0", limit=10)
+    assert r["count"] == 10
+    assert r["total_matched"] == 60
+    assert r["truncated"] is True
+    assert len(r["results"]) == 10
+
+
+async def test_scan_truncation_signal(roots, monkeypatch):
+    monkeypatch.setattr("genesis.mcp.memory.locate._MAX_FILES_SCANNED", 3)
+    for i in range(10):
+        _touch(roots["plans"] / f"f{i}.md")
+    r = await _impl_locate(scope="plans", within="0")
+    assert r["scan_truncated"] is True
+    assert "incomplete" in r["summary"].lower()
+
+
+async def test_no_scan_truncation_normally(roots):
+    _touch(roots["plans"] / "a.md")
+    r = await _impl_locate(scope="plans", within="0")
+    assert r["scan_truncated"] is False
+
+
+async def test_limit_zero_returns_all(roots):
+    for i in range(5):
+        _touch(roots["plans"] / f"f{i}.md")
+    r = await _impl_locate(scope="plans", within="0", limit=0)
+    assert r["count"] == 5
+    assert r["truncated"] is False
+
+
+async def test_ordering_recency_desc(roots):
+    _touch(roots["plans"] / "oldest.md", age_s=300)
+    _touch(roots["plans"] / "middle.md", age_s=200)
+    _touch(roots["plans"] / "newest.md", age_s=100)
+    r = await _impl_locate(scope="plans", within="0")
+    mtimes = [x["mtime"] for x in r["results"]]
+    assert mtimes == sorted(mtimes, reverse=True)
+    assert r["results"][0]["name"] == "newest.md"
+
+
+# ── empty / error / safety ────────────────────────────────────────────────────
+
+
+async def test_empty_no_match_is_clean(roots):
+    _touch(roots["plans"] / "a.md")
+    r = await _impl_locate(scope="plans", within="0", name="*nonexistent*")
+    assert r["count"] == 0
+    assert r["results"] == []
+    assert r["error"] is None
+    assert "no files" in r["summary"].lower()
+
+
+async def test_nonexistent_root_skipped_not_raised(roots, monkeypatch):
+    monkeypatch.setenv("GENESIS_OUTPUT_DIR", str(roots["tmp"] / "does_not_exist"))
+    _touch(roots["plans"] / "p.md")
+    r = await _impl_locate(scope="docs", within="0")
+    assert any("does_not_exist" in s for s in r["skipped_roots"])
+    assert "p.md" in _names(r)
+
+
+async def test_symlink_dir_not_followed(roots):
+    sub = roots["plans"] / "sub"
+    sub.mkdir()
+    _touch(sub / "real.md")
+    (sub / "loop").symlink_to(roots["plans"])  # back-reference; must not loop
+    r = await _impl_locate(scope="plans", within="0")
+    assert "real.md" in _names(r)
+
+
+async def test_permission_denied_dir_continues(roots):
+    if os.geteuid() == 0:
+        pytest.skip("running as root — chmod 000 is ineffective")
+    locked = roots["plans"] / "locked"
+    locked.mkdir()
+    _touch(locked / "hidden.md")
+    _touch(roots["plans"] / "visible.md")
+    os.chmod(locked, 0o000)
+    try:
+        r = await _impl_locate(scope="plans", within="0")
+        assert "visible.md" in _names(r)
+    finally:
+        os.chmod(locked, 0o755)
+
+
+# ── registration / helpers ────────────────────────────────────────────────────
+
+
+async def test_locate_registered_on_memory_server():
+    from genesis.mcp.memory_mcp import mcp
+
+    tools = await mcp.get_tools()
+    assert "locate" in tools
+
+
+def test_humanize_age():
+    now = time.time()
+    assert _humanize_age(now, now) == "just now"
+    assert _humanize_age(now - 7200, now) == "2h ago"
+    assert _humanize_age(now - 3 * 86400, now) == "3d ago"


### PR DESCRIPTION
## Summary

Adds `locate` — a deterministic, **read-only** MCP tool on the `genesis-memory` server
(`mcp__genesis-memory__locate`) that surfaces recently-changed files by mtime across known roots,
filtered by time window / file type / scope / name-glob / optional content match, ranked by recency.

It's a Genesis-owned alternative to Claude Code's `Grep`/`Glob` (unreliable under the open-agents A/B
issue) — a dependable way to answer "what changed recently / where is the doc about X?" instead of
falling back to reconstructing state from git.

## Behavior

- **Scopes:** `docs` (default = plans + output), `plans`, `output`, `repo`, `worktrees`, `all`.
  `repo` / `worktrees` / `all` are opt-in (heavier).
- **Filters:** `within` (e.g. `12h` / `24h` / `7d` / `0` = no limit), `file_type` (any/code/noncode),
  `name` (case-insensitive glob), `contains` (+ `regex`), `limit` (default 50, hard cap 200).
- **Output:** recency-ranked results with `mtime`, human `age`, size, scope label, and per-file
  content-match snippets. Honest truncation signals — `truncated`, `content_pool_capped`,
  `scan_truncated` — so coverage is never silently capped.

## Implementation

- Pure-Python `os.scandir` walk (symlink-safe, permission-tolerant) with directory pruning
  (`.git` / `.venv` / `node_modules` / build caches / nested worktrees / etc.).
- Content matching via `rg --json` with a pure-Python `re` fallback (identical result shape). Binary
  and oversize files are pre-filtered before either backend (ripgrep skips its own binary/size
  filtering when passed explicit path args, so the tool gates candidates itself).
- Worktrees discovered via `git worktree list --porcelain`.
- New `env.py` path helpers (`genesis_home` / `claude_home` / `plans_dir` / `output_dir`) following the
  existing env-override + default pattern.

## Testing

- 26 unit tests (`tests/test_mcp/test_locate.py`): recency boundaries, type/scope/glob filters,
  pruning, rg + fallback parity, binary/oversize skip, truncation signals, ordering, symlink and
  permission safety, MCP registration.
- Existing memory-MCP tests unaffected.
- E2E-verified against a live filesystem (default `docs` query returns in single-digit milliseconds;
  pruning keeps a full-repo scan fast).

## Notes

- Strictly read-only; no migration. New MCP tools become available to Claude Code on the next session.
- First slice of the self-retrieval track of the omnipresence layer.
