### PR TITLE
fix(guardian): wire watchdog escalations to Telegram (11569455)

### DIFF
--- a/src/genesis/guardian/watchdog.py
+++ b/src/genesis/guardian/watchdog.py
@@ -52,21 +52,55 @@ class GuardianWatchdog:
         self,
         remote,  # GuardianRemote — import avoided for loose coupling
         event_bus=None,
-        outreach_queue=None,
+        outreach_pipeline=None,  # OutreachPipeline — for user-facing alerts
     ) -> None:
         self._remote = remote
         self._event_bus = event_bus
-        self._outreach_queue = outreach_queue
+        self._outreach_pipeline = outreach_pipeline
         self._sentinel = None
         self._last_recovery_at: datetime | None = None
         self._last_reset_at: datetime | None = None
         self._consecutive_stuck: int = 0
+        self._recovery_failed_escalated: bool = False  # one alert per DOWN episode
         self._drift_count: int = 0
+        self._drift_escalated: bool = False  # one user alert per drift episode
         # Deployed-gateway staleness: the install-dir code can be current while
         # ~/.local/bin/guardian-gateway.sh lags (the bug that froze it ~2 months).
         self._gateway_drift_count: int = 0
         self._gateway_resync_attempted: bool = False
         self._gateway_escalated: bool = False
+
+    async def _alert_user(self, *, topic: str, context: str, source_id: str) -> None:
+        """Deliver a user-facing (Telegram) alert about a Guardian degradation.
+
+        Uses the outreach pipeline's ``submit_raw`` — the idiomatic urgent-infra
+        path (BLOCKER category → Telegram, governance skipped, built-in dedup),
+        the same one health alerts use. No-op when the pipeline isn't wired
+        (graceful degradation). Wrapped so an outreach failure NEVER breaks a
+        watchdog tick. Each call site passes a DISTINCT ``topic`` so the
+        pipeline's (signal_type, topic, category) dedup never cross-suppresses
+        one Guardian alert with another.
+        """
+        if not self._outreach_pipeline:
+            return
+        try:
+            from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+            await self._outreach_pipeline.submit_raw(
+                context,
+                OutreachRequest(
+                    category=OutreachCategory.BLOCKER,
+                    topic=topic,
+                    context=context,
+                    salience_score=1.0,
+                    signal_type="guardian_alert",
+                    source_id=source_id,
+                ),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to send Guardian alert (%s)", source_id, exc_info=True,
+            )
 
     def _in_cooldown(self) -> bool:
         if self._last_recovery_at is None:
@@ -104,6 +138,7 @@ class GuardianWatchdog:
 
         if result.status != ProbeStatus.DOWN:
             self._consecutive_stuck = 0
+            self._recovery_failed_escalated = False  # re-arm for the next episode
             return
 
         staleness = result.details.get("staleness_s", 0) if result.details else 0
@@ -135,16 +170,17 @@ class GuardianWatchdog:
                         "guardian.recovery.failed",
                         f"Guardian restart via SSH failed (stale {staleness:.0f}s)",
                     )
-                if self._outreach_queue:
-                    try:
-                        await self._outreach_queue.enqueue(
-                            f"Guardian is DOWN (heartbeat stale {staleness:.0f}s) "
-                            "and SSH restart failed. Manual intervention needed.",
-                            priority="high",
-                            source="guardian_watchdog",
-                        )
-                    except Exception:
-                        logger.warning("Failed to queue Guardian alert", exc_info=True)
+                if not self._recovery_failed_escalated:
+                    self._recovery_failed_escalated = True
+                    await self._alert_user(
+                        topic="Guardian is DOWN",
+                        context=(
+                            f"🚨 Guardian is DOWN (heartbeat stale "
+                            f"{staleness:.0f}s) and SSH restart failed. "
+                            "Manual intervention needed."
+                        ),
+                        source_id="guardian:recovery_failed",
+                    )
 
         # Step 2: Check if Guardian is stuck in confirmed_dead
         await self._check_stuck_state()
@@ -293,6 +329,7 @@ class GuardianWatchdog:
                 logger.info("Guardian code drift resolved (container=%s host=%s)",
                             container_hash, host_hash)
             self._drift_count = 0
+            self._drift_escalated = False  # re-arm the user alert for next episode
             return
 
         # Drift detected — host's deployed HEAD does NOT contain the container's
@@ -312,14 +349,22 @@ class GuardianWatchdog:
                     f"Guardian code version mismatch — container={container_hash} "
                     f"host={host_hash} (drifted {self._drift_count} ticks)",
                 )
-            if self._outreach_queue:
-                await self._outreach_queue.enqueue(
+
+        # User-facing alert: ONCE per drift episode (re-armed on resolution) —
+        # NOT every 3 ticks like the event-bus observability emit above.
+        if self._drift_count >= self.DRIFT_ALERT_THRESHOLD and \
+                not self._drift_escalated:
+            self._drift_escalated = True
+            await self._alert_user(
+                topic="Guardian code drift",
+                context=(
                     f"⚠️ Guardian code drift: container={container_hash} "
-                    f"host={host_hash}. Auto-redeploy may have failed. "
-                    "Check update logs or run install_guardian.sh --non-interactive on host.",
-                    priority="high",
-                    source="guardian_watchdog",
-                )
+                    f"host={host_hash}. Auto-redeploy may have failed. Check "
+                    "update logs or run install_guardian.sh --non-interactive "
+                    "on host."
+                ),
+                source_id="guardian:code_drift",
+            )
 
     async def _host_contains_commit(
         self, container_hash: str, host_hash: str,
@@ -440,11 +485,8 @@ class GuardianWatchdog:
                 )
             return
 
-        # Self-heal already attempted and it's STILL stale → escalate once via
-        # the event bus (ERROR surfaces in health/observability). NOTE: a
-        # user-facing outreach (Telegram) path for Guardian watchdog escalations
-        # is not yet wired — init builds the watchdog without an outreach_queue,
-        # the same gap as the code-drift escalation above. Tracked as a follow-up.
+        # Self-heal already attempted and it's STILL stale → escalate once per
+        # episode: the event bus (observability) AND a user-facing Telegram alert.
         if not self._gateway_escalated:
             self._gateway_escalated = True
             logger.error(
@@ -461,3 +503,12 @@ class GuardianWatchdog:
                     f"{host_gw_sha[:12]} vs expected {expected[:12]} @ "
                     f"{host_code_ver}). Manual check needed.",
                 )
+            await self._alert_user(
+                topic="Guardian gateway stale",
+                context=(
+                    f"Guardian deployed gateway is STILL stale after auto-resync "
+                    f"(sha {host_gw_sha[:12]} vs expected {expected[:12]} @ "
+                    f"{host_code_ver}). Manual intervention needed."
+                ),
+                source_id="guardian:gateway_stale",
+            )

--- a/src/genesis/runtime/init/guardian.py
+++ b/src/genesis/runtime/init/guardian.py
@@ -58,6 +58,10 @@ async def init_guardian_monitoring(rt) -> None:
     watchdog = GuardianWatchdog(
         remote,
         event_bus=rt._event_bus,
+        # Wire user-facing alerts (Telegram) for Guardian degradation. The
+        # outreach init step runs before guardian-monitoring init, so the
+        # pipeline is ready here; None-safe via getattr if it's ever absent.
+        outreach_pipeline=getattr(rt, "_outreach_pipeline", None),
     )
 
     if rt._awareness_loop:

--- a/tests/test_guardian/test_watchdog.py
+++ b/tests/test_guardian/test_watchdog.py
@@ -127,6 +127,35 @@ class TestEventEmission:
         args = event_bus.emit.call_args
         assert "recovery.failed" in args[0][2]
 
+    @pytest.mark.asyncio
+    async def test_recovery_failed_alerts_once_per_episode_and_rearms(self):
+        """Guardian DOWN + SSH restart fails → ONE user alert per DOWN episode
+        (even across repeated restart attempts), re-armed when Guardian recovers.
+        The most critical escalation: the last line of defense is down."""
+        outreach = AsyncMock()
+        r = AsyncMock()
+        r.restart.return_value = False
+        r.status.return_value = {"current_state": "healthy"}
+        wd = GuardianWatchdog(r, event_bus=AsyncMock(), outreach_pipeline=outreach)
+        wd._check_code_drift = AsyncMock()   # isolate from real git subprocess
+        wd._in_cooldown = lambda: False        # allow a restart attempt every tick
+        down = _make_probe_result(ProbeStatus.DOWN, staleness_s=600)
+        healthy = _make_probe_result(ProbeStatus.HEALTHY)
+
+        with patch("genesis.observability.health.probe_guardian", return_value=down):
+            for _ in range(3):                 # 3 down+fail ticks
+                await wd.check_and_recover()
+        outreach.submit_raw.assert_called_once()   # ONE alert for the episode
+        assert outreach.submit_raw.call_args.args[1].source_id == "guardian:recovery_failed"
+
+        with patch("genesis.observability.health.probe_guardian", return_value=healthy):
+            await wd.check_and_recover()           # recovers → re-arm
+        assert wd._recovery_failed_escalated is False
+
+        with patch("genesis.observability.health.probe_guardian", return_value=down):
+            await wd.check_and_recover()           # second episode → second alert
+        assert outreach.submit_raw.call_count == 2
+
 
 class TestStuckDetection:
     """Test container-side detection of Guardian stuck in confirmed_dead."""
@@ -223,7 +252,7 @@ def _gw_watchdog(sync_ok: bool = True):
     r.sync_gateway = AsyncMock(return_value={"ok": sync_ok})
     event_bus = AsyncMock()
     outreach = AsyncMock()
-    wd = GuardianWatchdog(r, event_bus=event_bus, outreach_queue=outreach)
+    wd = GuardianWatchdog(r, event_bus=event_bus, outreach_pipeline=outreach)
     wd._expected_gateway_sha = AsyncMock(return_value=_EXPECTED_GW_SHA)
     return wd, r, event_bus, outreach
 
@@ -280,19 +309,22 @@ class TestGatewayStaleness:
             await wd._check_gateway_staleness(vi)
         r.sync_gateway.assert_called_once()
         assert any("gateway_resync" in e for e in _emitted_events(eb))
-        outreach.enqueue.assert_not_called()  # not escalated yet
+        outreach.submit_raw.assert_not_called()  # not escalated yet
 
     @pytest.mark.asyncio
     async def test_still_stale_after_resync_escalates_once(self):
-        wd, r, eb, _ = _gw_watchdog()
+        wd, r, eb, outreach = _gw_watchdog()
         vi = {"gateway_sha": _STALE_GW_SHA, "code_version": "abc1234"}
         for _ in range(_THRESHOLD):
             await wd._check_gateway_staleness(vi)   # → one resync
-        await wd._check_gateway_staleness(vi)        # still stale → escalate (event bus)
+        await wd._check_gateway_staleness(vi)        # still stale → escalate
         await wd._check_gateway_staleness(vi)        # quiet — no second escalation
         stale_events = [e for e in _emitted_events(eb) if "gateway_stale" in e]
         assert len(stale_events) == 1               # escalated exactly once
         r.sync_gateway.assert_called_once()          # resync attempted exactly once
+        outreach.submit_raw.assert_called_once()     # ONE user alert per episode
+        req = outreach.submit_raw.call_args.args[1]
+        assert req.source_id == "guardian:gateway_stale"
 
     @pytest.mark.asyncio
     async def test_resolved_after_resync_resets_state(self):
@@ -404,7 +436,7 @@ def _drift_watchdog(deployed_commit: str):
     r.version = AsyncMock(return_value={"deployed_commit": deployed_commit})
     event_bus = AsyncMock()
     outreach = AsyncMock()
-    wd = GuardianWatchdog(r, event_bus=event_bus, outreach_queue=outreach)
+    wd = GuardianWatchdog(r, event_bus=event_bus, outreach_pipeline=outreach)
     return wd, r, event_bus, outreach
 
 
@@ -442,25 +474,30 @@ class TestCodeDrift:
             for _ in range(_THRESHOLD + 1):
                 await wd._check_code_drift_inner()
         assert wd._drift_count == 0
-        outreach.enqueue.assert_not_called()
+        outreach.submit_raw.assert_not_called()
         assert not any("code_drift" in e for e in _emitted_events(eb))
         wd._host_contains_commit.assert_awaited()  # the ancestry path ran
 
     @pytest.mark.asyncio
-    async def test_genuine_drift_alerts_at_threshold(self):
+    async def test_genuine_drift_alerts_once_per_episode(self):
         """Host genuinely missing the Guardian commit → quiet below threshold,
-        alerts exactly at the threshold tick (event bus + user-facing outreach)."""
+        then ONE user alert per episode — NOT every 3 ticks like the event-bus
+        emit. (The spam fix: ticking far past the threshold yields one Telegram.)"""
         wd, r, eb, outreach = _drift_watchdog(deployed_commit="0ld0ld0")
         wd._host_contains_commit = AsyncMock(return_value=False)
         with patch("genesis.guardian.watchdog.subprocess.run",
                    side_effect=_git_side_effect("a915a28")):
             for _ in range(_THRESHOLD - 1):
                 await wd._check_code_drift_inner()
-            outreach.enqueue.assert_not_called()   # below threshold: silent
-            await wd._check_code_drift_inner()       # tick == THRESHOLD
-        assert wd._drift_count == _THRESHOLD
-        assert any("code_drift" in e for e in _emitted_events(eb))
-        outreach.enqueue.assert_called_once()
+            outreach.submit_raw.assert_not_called()   # below threshold: silent
+            for _ in range(2 * _THRESHOLD):           # tick well past threshold
+                await wd._check_code_drift_inner()
+        assert wd._drift_count >= _THRESHOLD
+        assert any("code_drift" in e for e in _emitted_events(eb))  # bus re-emits
+        outreach.submit_raw.assert_called_once()       # user alerted exactly once
+        req = outreach.submit_raw.call_args.args[1]
+        assert req.source_id == "guardian:code_drift"
+        assert req.topic == "Guardian code drift"
 
     @pytest.mark.asyncio
     async def test_unresolvable_skips_no_alarm(self):
@@ -473,13 +510,13 @@ class TestCodeDrift:
             for _ in range(_THRESHOLD + 1):
                 await wd._check_code_drift_inner()
         assert wd._drift_count == 0
-        outreach.enqueue.assert_not_called()
+        outreach.submit_raw.assert_not_called()
         eb.emit.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_drift_then_resolved_resets(self):
-        """A genuine drift episode that later resolves (host catches up) resets
-        the counter — no 'stuck drifting' after recovery."""
+    async def test_drift_then_resolved_resets_and_rearms(self):
+        """A drift episode resolves (host catches up) → counter AND the user-alert
+        flag reset; a SECOND episode alerts again (no 'quiet forever')."""
         wd, r, eb, outreach = _drift_watchdog(deployed_commit="0ld0ld0")
         wd._host_contains_commit = AsyncMock(return_value=False)
         with patch("genesis.guardian.watchdog.subprocess.run",
@@ -487,9 +524,15 @@ class TestCodeDrift:
             for _ in range(_THRESHOLD):
                 await wd._check_code_drift_inner()
             assert wd._drift_count == _THRESHOLD
+            outreach.submit_raw.assert_called_once()   # episode 1: one alert
             wd._host_contains_commit = AsyncMock(return_value=True)  # host caught up
             await wd._check_code_drift_inner()
-        assert wd._drift_count == 0
+            assert wd._drift_count == 0
+            assert wd._drift_escalated is False         # re-armed
+            wd._host_contains_commit = AsyncMock(return_value=False)  # episode 2
+            for _ in range(_THRESHOLD):
+                await wd._check_code_drift_inner()
+        assert outreach.submit_raw.call_count == 2      # second episode re-alerts
 
     @pytest.mark.asyncio
     async def test_exit_128_full_chain_skips_no_alarm(self):
@@ -514,5 +557,40 @@ class TestCodeDrift:
             for _ in range(_THRESHOLD + 1):
                 await wd._check_code_drift_inner()
         assert wd._drift_count == 0
-        outreach.enqueue.assert_not_called()
+        outreach.submit_raw.assert_not_called()
         assert not any("code_drift" in e for e in _emitted_events(eb))
+
+
+class TestAlertUser:
+    """Direct coverage of the _alert_user delivery helper (shared by all three
+    escalation paths). Must reach the outreach pipeline, degrade gracefully when
+    unwired, and never propagate an outreach failure into a watchdog tick."""
+
+    @pytest.mark.asyncio
+    async def test_submits_raw_with_blocker_envelope(self):
+        from genesis.outreach.types import OutreachCategory
+        outreach = AsyncMock()
+        wd = GuardianWatchdog(AsyncMock(), event_bus=None, outreach_pipeline=outreach)
+        await wd._alert_user(
+            topic="Guardian code drift", context="msg body",
+            source_id="guardian:code_drift",
+        )
+        outreach.submit_raw.assert_awaited_once()
+        text, req = outreach.submit_raw.call_args.args
+        assert text == "msg body"
+        assert req.category == OutreachCategory.BLOCKER  # → Telegram, skips quiet hours
+        assert req.signal_type == "guardian_alert"
+        assert req.topic == "Guardian code drift"
+        assert req.source_id == "guardian:code_drift"
+
+    @pytest.mark.asyncio
+    async def test_no_pipeline_is_noop(self):
+        wd = GuardianWatchdog(AsyncMock(), event_bus=None, outreach_pipeline=None)
+        await wd._alert_user(topic="t", context="c", source_id="guardian:x")  # no raise
+
+    @pytest.mark.asyncio
+    async def test_outreach_failure_never_propagates(self):
+        outreach = AsyncMock()
+        outreach.submit_raw.side_effect = Exception("telegram down")
+        wd = GuardianWatchdog(AsyncMock(), event_bus=None, outreach_pipeline=outreach)
+        await wd._alert_user(topic="t", context="c", source_id="guardian:x")  # swallowed


### PR DESCRIPTION
## The gap (follow-up 11569455)
The Guardian watchdog was constructed with no outreach wiring (`init/guardian.py` passed only `remote` + `event_bus`), so its **three** user-facing escalations only ever hit the event bus, never the user:
1. **recovery-failed** — Guardian DOWN *and* the SSH restart failed (the last line of defense is down);
2. **code-drift** — the host is running stale Guardian code;
3. **gateway-staleness** — the deployed gateway script is frozen after a failed self-heal.

A genuine Guardian degradation went unnoticed unless someone watched the event stream. The pre-existing `self._outreach_queue.enqueue(msg, priority=…, source=…)` call was also dead *and* matched no real API.

## The fix
Inject the outreach pipeline (`rt._outreach_pipeline`, initialized before guardian init) and deliver via a shared `_alert_user(topic, context, source_id)` helper using `submit_raw(text, OutreachRequest(category=BLOCKER, signal_type="guardian_alert", source_id=…))` — the idiomatic urgent-infrastructure path that **delivers to Telegram immediately, skips the LLM drafter, and applies built-in dedup** (the same path the health alerts use). `_alert_user` is a no-op when the pipeline is unwired and `try/except`-wrapped so an outreach failure never breaks a watchdog tick.

**Cadence — one alert per episode**, re-armed on resolution, so a sustained problem pings once (not every ~15 min). Gateway already had `_gateway_escalated`; code-drift gains `_drift_escalated` and recovery-failed gains `_recovery_failed_escalated` (both reset when the condition clears). Each site uses a **distinct topic** so the pipeline's `(signal_type, topic, category)` dedup never cross-suppresses one Guardian alert with another.

**Why direct delivery, not the health-alert whitelist:** the health-alert list is built by a hardcoded probe pipeline that never reads the event bus, so guardian events can't become whitelist-able alerts. Direct delivery is the correct path.

## Tests (393 `test_guardian` green)
Once-per-episode + re-arm for all three sites (code-drift ticked past threshold → one alert; recovery DOWN×3 → one alert, recover→DOWN → second alert; gateway escalate-once), the recovery/gateway alert envelopes, and direct `_alert_user` coverage (real BLOCKER envelope, None-graceful no-op, failure-swallow). No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)