### PR TITLE
feat(recon): active-model EOL detector — flag deprecations of models we use

### DIFF
--- a/src/genesis/recon/model_intelligence.py
+++ b/src/genesis/recon/model_intelligence.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import re
+from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -32,6 +34,85 @@ logger = logging.getLogger(__name__)
 _OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
 _AA_MODELS_URL = "https://artificialanalysis.ai/api/data/llms/models"
 _FREE_MODEL_CACHE_PATH = Path.home() / ".genesis" / "free_model_cache.json"
+
+# ── Active-model EOL detection (v1: Groq deprecations page) ────────────────
+_GROQ_DEPRECATIONS_URL = "https://console.groq.com/docs/deprecations"
+# A Groq deprecations table row is 3 pipe-separated cells. Rendered text may
+# carry surrounding pipes (`| model | date | repl |`, MCP-style markdown) or
+# not (`model| date| repl`, what genesis.web.fetch returns) — handle both.
+_DEP_DATE_RE = re.compile(r"(\d{1,2})/(\d{1,2})/(\d{2,4})")
+
+
+def _parse_groq_deprecation_table(text: str) -> list[tuple[str, str, str]]:
+    """Parse Groq's deprecations markdown table into rows of
+    ``(model_id, shutdown_date_iso, replacement)``.
+
+    Only rows whose middle column carries a ``MM/DD/YY`` date count as
+    deprecation entries; header / separator / other rows are skipped. Robust
+    to missing backticks. Returns ``[]`` when nothing parses (the caller logs
+    a structure-changed warning).
+    """
+    rows: list[tuple[str, str, str]] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if "|" not in line:
+            continue
+        # Strip surrounding pipes (markdown style) then split into cells.
+        parts = [c.strip() for c in line.strip("|").split("|")]
+        if len(parts) != 3:
+            continue
+        model_cell, date_cell, repl_cell = parts
+        date_m = _DEP_DATE_RE.search(date_cell)
+        if not date_m:
+            continue  # header / separator / non-date row
+        model_id = model_cell.strip("` ").strip()
+        if not model_id or model_id.lower() == "deprecated model":
+            continue
+        mm, dd, yy = date_m.groups()
+        mm_int, dd_int = int(mm), int(dd)
+        if not (1 <= mm_int <= 12 and 1 <= dd_int <= 31):
+            continue  # not a real calendar date (e.g. a version number)
+        year = int(yy) + 2000 if int(yy) < 100 else int(yy)
+        shutdown_iso = f"{year:04d}-{mm_int:02d}-{dd_int:02d}"
+        replacement = repl_cell.replace("`", "").strip()
+        rows.append((model_id, shutdown_iso, replacement))
+    return rows
+
+
+def _eol_findings_from_rows(
+    rows: list[tuple[str, str, str]], providers: dict, call_sites: dict,
+) -> list[dict]:
+    """Match parsed deprecation rows against our ACTIVE Groq providers.
+
+    Emits an ``active_model_eol`` finding only for a model we actually use
+    (firehose guard: an unrelated Groq deprecation yields nothing), annotated
+    with blast radius — the call-site chains that depend on that provider.
+    """
+    provider_chains: dict[str, list[str]] = defaultdict(list)
+    for site_id, site in call_sites.items():
+        for prov in site.chain:
+            provider_chains[prov].append(site_id)
+    groq_models = {
+        p.model_id: name
+        for name, p in providers.items()
+        if p.enabled and p.provider_type == "groq"
+    }
+    findings: list[dict] = []
+    for model_id, shutdown_iso, replacement in rows:
+        name = groq_models.get(model_id)
+        if name is None:
+            continue
+        findings.append({
+            "type": "active_model_eol",
+            "model": model_id,
+            "provider": name,
+            "vendor": "groq",
+            "shutdown_date": shutdown_iso,
+            "replacement": replacement,
+            "blast_radius": sorted(set(provider_chains.get(name, []))),
+            "source": "groq_deprecations_page",
+        })
+    return findings
 
 
 class ModelIntelligenceJob:
@@ -73,7 +154,11 @@ class ModelIntelligenceJob:
         stale_findings = await self._check_staleness()
         findings.extend(stale_findings)
 
-        # 5. Store all findings
+        # 5. Active-provider EOL check (models WE USE being deprecated)
+        eol_findings = await self._check_active_providers()
+        findings.extend(eol_findings)
+
+        # 6. Store all findings
         for f in findings:
             await self._store_finding(f)
 
@@ -86,6 +171,7 @@ class ModelIntelligenceJob:
             "free_model_findings": len(free_findings),
             "aa_findings": len(aa_findings),
             "stale_findings": len(stale_findings),
+            "eol_findings": len(eol_findings),
             "findings": findings,
         }
 
@@ -384,6 +470,12 @@ class ModelIntelligenceJob:
         now = datetime.now(UTC).isoformat()
         finding_type = finding.get("type", "unknown")
 
+        # active_model_eol is a HIGH-priority, actionable alert — surface it as
+        # a recon observation, NOT via run_intake (curated model-intelligence
+        # findings route to the knowledge base, which would bury it).
+        if finding_type == "active_model_eol":
+            return await self._surface_eol_observation(finding, finding_id, now)
+
         title = f"Model intelligence: {finding_type}"
         if "model" in finding:
             title += f" — {finding['model']}"
@@ -474,3 +566,133 @@ class ModelIntelligenceJob:
         except Exception:
             logger.warning("Failed to create benchmark follow-up for %s", model_id, exc_info=True)
             return None
+
+    async def _check_active_providers(self) -> list[dict]:
+        """Detect EOL of models WE ACTUALLY USE (v1: Groq deprecations page).
+
+        Loads the effective routing config to learn our active Groq models and
+        the chains that depend on each provider (blast radius), parses Groq's
+        structured deprecations table, and emits an ``active_model_eol``
+        finding ONLY for our active Groq models that appear with a shutdown
+        date.
+
+        Firehose-proof by construction: a deprecation for a Groq model we
+        don't use yields nothing; a fetch/parse failure yields nothing
+        (degrade gracefully, never crash the scan). Catalog ``/v1/models``
+        diff (all OpenAI-compatible vendors) and the Google changelog are a
+        documented follow-up, not silent gaps.
+        """
+        try:
+            from genesis.env import repo_root
+            from genesis.routing.config import load_config
+
+            cfg = load_config(
+                repo_root() / "config" / "model_routing.yaml",
+                check_api_keys=False,
+            )
+        except Exception:
+            logger.warning(
+                "EOL check: could not load routing config — skipping", exc_info=True,
+            )
+            return []
+
+        groq_count = sum(
+            1 for p in cfg.providers.values()
+            if p.enabled and p.provider_type == "groq"
+        )
+        if groq_count == 0:
+            return []
+
+        rows = await self._fetch_groq_deprecations()
+        findings = _eol_findings_from_rows(rows, cfg.providers, cfg.call_sites)
+
+        if findings:
+            logger.warning(
+                "EOL check: %d active Groq model(s) deprecated: %s",
+                len(findings), [f["model"] for f in findings],
+            )
+        logger.info(
+            "EOL check: scanned Groq deprecations for %d active Groq model(s); "
+            "catalog-diff + non-Groq vendors deferred to follow-up",
+            groq_count,
+        )
+        return findings
+
+    async def _fetch_groq_deprecations(self) -> list[tuple[str, str, str]]:
+        """Fetch + parse Groq's deprecations page. Fails safe → [] on any error.
+
+        Uses ``genesis.web.fetch`` (rendered fetch with anti-bot/JS handling),
+        because the Groq docs page is JS-rendered and raw httpx would not see
+        the table.
+        """
+        try:
+            from genesis.web import fetch
+
+            result = await fetch(_GROQ_DEPRECATIONS_URL, max_chars=40000)
+        except Exception:
+            logger.warning("EOL check: Groq deprecations fetch raised", exc_info=True)
+            return []
+        if result.error or not result.text:
+            logger.warning(
+                "EOL check: Groq deprecations page unavailable (%s)", result.error,
+            )
+            return []
+        rows = _parse_groq_deprecation_table(result.text)
+        if not rows:
+            logger.warning(
+                "EOL check: Groq deprecations parse yielded 0 rows — page "
+                "structure may have changed (this is NOT 'no deprecations')",
+            )
+        return rows
+
+    async def _surface_eol_observation(
+        self, finding: dict, finding_id: str, now: str,
+    ) -> str:
+        """Surface an ``active_model_eol`` finding as a HIGH-priority recon
+        observation (``type='finding'``, ``category='active_model_eol'``).
+
+        Bypasses ``run_intake`` on purpose: curated MODEL_INTELLIGENCE findings
+        route to the knowledge base (``intake.route``), where an actionable EOL
+        alert would be buried. The dashboard recon tab and the ``recon_findings``
+        MCP tool read ``source='recon'`` / ``type='finding'`` observations.
+        Deduped on ``(model_id, shutdown_date)`` so the same EOL never re-fires
+        while unresolved (self-healing: re-alerts only after resolution).
+        """
+        import hashlib
+
+        from genesis.db.crud import observations
+
+        model_id = finding.get("model", "")
+        shutdown_date = finding.get("shutdown_date", "")
+        blast = finding.get("blast_radius", [])
+        title = (
+            f"Active model EOL: {model_id} (shutdown {shutdown_date}) — "
+            f"{len(blast)} chain(s) affected"
+        )
+        content = json.dumps({"title": title, **finding, "detected_at": now})
+        # Stable dedup key — independent of detected_at / blast-radius churn.
+        dedup_key = hashlib.sha256(
+            json.dumps(
+                {"model_id": model_id, "shutdown_date": shutdown_date},
+                sort_keys=True,
+            ).encode()
+        ).hexdigest()
+        try:
+            await observations.create(
+                self._db,
+                id=finding_id,
+                source="recon",
+                type="finding",
+                category="active_model_eol",
+                content=content,
+                priority="high",
+                created_at=now,
+                content_hash=dedup_key,
+                skip_if_duplicate=True,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to surface active_model_eol observation for %s",
+                model_id, exc_info=True,
+            )
+        return finding_id

--- a/tests/test_recon/test_model_intelligence.py
+++ b/tests/test_recon/test_model_intelligence.py
@@ -8,8 +8,28 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiosqlite
 import pytest
 
-from genesis.recon.model_intelligence import ModelIntelligenceJob
+from genesis.recon.model_intelligence import (
+    ModelIntelligenceJob,
+    _eol_findings_from_rows,
+    _parse_groq_deprecation_table,
+)
+from genesis.routing.config import load_config_from_string
 from genesis.routing.model_profiles import ModelProfileRegistry
+
+
+@pytest.fixture(autouse=True)
+def _stub_web_fetch():
+    """Stub genesis.web.fetch module-wide so run()-based tests never hit the
+    live Groq deprecations page. EOL tests override this by patching
+    _fetch_groq_deprecations directly or re-patching genesis.web.fetch locally.
+    """
+    from genesis.web.types import FetchResult
+
+    with patch(
+        "genesis.web.fetch",
+        AsyncMock(return_value=FetchResult(url="", text="", error="stubbed-in-tests")),
+    ):
+        yield
 
 
 @pytest.fixture()
@@ -311,3 +331,258 @@ class TestFindingStorage:
         count = (await cursor.fetchone())[0]
         assert count == result["total_findings"]
         assert count > 0
+
+
+# ── Active-provider EOL detection (Groq deprecations page) ─────────────────
+
+# A representative slice of Groq's real deprecations table (incl. header,
+# separator, single-digit date, multi-replacement cell, and a non-row line).
+_SAMPLE_GROQ_TABLE = """\
+## Deprecation History
+| Deprecated Model | Shutdown Date | Recommended Replacement Model ID |
+| --- | --- | --- |
+| `moonshotai/kimi-k2-instruct-0905` | 04/15/26 | `openai/gpt-oss-120b` |
+| `llama3-70b-8192` | 8/30/25 | `llama-3.3-70b-versatile` |
+| `mixtral-8x7b-32768` | 03/20/25 | `mistral-saba-24b`  `llama-3.3-70b-versatile` |
+Some prose line | with a pipe but not a table row
+"""
+
+# A config where one Groq provider (groq-doomed) uses a deprecated model and
+# another (groq-free) uses llama-3.3-70b-versatile — which appears in the table
+# ONLY as a replacement, so it must NOT fire (the no-false-alarm case).
+_EOL_CONFIG_YAML = """\
+providers:
+  groq-free:
+    type: groq
+    model: llama-3.3-70b-versatile
+    free: true
+    rpm_limit: 30
+  groq-doomed:
+    type: groq
+    model: moonshotai/kimi-k2-instruct-0905
+    free: true
+    rpm_limit: 30
+  gemini-free:
+    type: google
+    model: gemini-3-flash-preview
+    free: true
+    rpm_limit: 15
+call_sites:
+  s_micro:
+    chain: [groq-free, gemini-free]
+  s_report:
+    chain: [groq-doomed]
+  s_other:
+    chain: [groq-doomed, groq-free]
+"""
+
+
+class TestGroqDeprecationParser:
+    """Pure parsing of the Groq deprecations markdown table."""
+
+    def test_parses_real_format_rows(self) -> None:
+        rows = _parse_groq_deprecation_table(_SAMPLE_GROQ_TABLE)
+        assert ("moonshotai/kimi-k2-instruct-0905", "2026-04-15", "openai/gpt-oss-120b") in rows
+        # single-digit month/day normalized to ISO
+        assert ("llama3-70b-8192", "2025-08-30", "llama-3.3-70b-versatile") in rows
+        assert len(rows) == 3
+
+    def test_skips_header_separator_and_prose(self) -> None:
+        models = [r[0] for r in _parse_groq_deprecation_table(_SAMPLE_GROQ_TABLE)]
+        assert "Deprecated Model" not in models
+        assert all("---" not in m for m in models)
+
+    def test_multi_replacement_cell_kept_as_text(self) -> None:
+        rows = _parse_groq_deprecation_table(_SAMPLE_GROQ_TABLE)
+        mixtral = next(r for r in rows if r[0] == "mixtral-8x7b-32768")
+        assert "mistral-saba-24b" in mixtral[2]
+        assert "llama-3.3-70b-versatile" in mixtral[2]
+
+    def test_empty_or_garbage_returns_empty(self) -> None:
+        assert _parse_groq_deprecation_table("") == []
+        assert _parse_groq_deprecation_table("no tables here\njust text") == []
+        # header + separator only (no dated rows)
+        assert _parse_groq_deprecation_table(
+            "| Deprecated Model | Shutdown Date | Replacement |\n| --- | --- | --- |"
+        ) == []
+
+    def test_parses_live_no_leading_pipe_format(self) -> None:
+        # The format genesis.web.fetch ACTUALLY returns — cells separated by
+        # pipes with NO surrounding pipes (`model| date| repl`). Regression for
+        # the bug the live E2E caught; also the real llama-3.3-70b/Aug-16 row.
+        live = (
+            "### August 16, 2026\n"
+            "Deprecated Model| Shutdown Date| Recommended Replacement Model ID\n"
+            "---|---|---\n"
+            "`llama-3.1-8b-instant`| 08/16/26| `openai/gpt-oss-20b`\n"
+            "`llama-3.3-70b-versatile`| 08/16/26| `openai/gpt-oss-120b` or `qwen/qwen3.6-27b`\n"
+        )
+        rows = _parse_groq_deprecation_table(live)
+        assert ("llama-3.1-8b-instant", "2026-08-16", "openai/gpt-oss-20b") in rows
+        assert (
+            "llama-3.3-70b-versatile", "2026-08-16",
+            "openai/gpt-oss-120b or qwen/qwen3.6-27b",
+        ) in rows
+        assert len(rows) == 2
+
+    def test_rejects_non_calendar_dates(self) -> None:
+        # A version-number-like field (e.g. 13/45/26) in the middle column must
+        # not be parsed as a shutdown date.
+        assert _parse_groq_deprecation_table("`some/model`| 13/45/26| `repl`") == []
+
+
+class TestEOLMatcher:
+    """Matching parsed rows against our active Groq providers."""
+
+    def _cfg(self):
+        return load_config_from_string(_EOL_CONFIG_YAML)
+
+    def test_no_false_alarm_when_our_models_not_deprecated(self) -> None:
+        # The regression test for the whole episode: llama-3.3-70b-versatile is
+        # only a *replacement* in the table, so groq-free must NOT fire.
+        cfg = self._cfg()
+        rows = _parse_groq_deprecation_table(_SAMPLE_GROQ_TABLE)
+        findings = _eol_findings_from_rows(rows, cfg.providers, cfg.call_sites)
+        assert all(f["provider"] != "groq-free" for f in findings)
+
+    def test_fires_for_our_deprecated_model_with_blast_radius(self) -> None:
+        cfg = self._cfg()
+        rows = _parse_groq_deprecation_table(_SAMPLE_GROQ_TABLE)
+        findings = _eol_findings_from_rows(rows, cfg.providers, cfg.call_sites)
+        assert len(findings) == 1  # only groq-doomed's model is deprecated
+        f = findings[0]
+        assert f["type"] == "active_model_eol"
+        assert f["model"] == "moonshotai/kimi-k2-instruct-0905"
+        assert f["provider"] == "groq-doomed"
+        assert f["vendor"] == "groq"
+        assert f["shutdown_date"] == "2026-04-15"
+        assert f["replacement"] == "openai/gpt-oss-120b"
+        assert f["blast_radius"] == ["s_other", "s_report"]
+
+    def test_unrelated_deprecation_yields_nothing(self) -> None:
+        # firehose guard: a Groq deprecation for a model we don't use → []
+        cfg = self._cfg()
+        rows = [("some/model-we-dont-use", "2026-12-31", "repl")]
+        assert _eol_findings_from_rows(rows, cfg.providers, cfg.call_sites) == []
+
+    def test_non_groq_model_ignored(self) -> None:
+        # vendor gate is groq — a google model string must not match
+        cfg = self._cfg()
+        rows = [("gemini-3-flash-preview", "2026-06-01", "gemini-3.5-flash")]
+        assert _eol_findings_from_rows(rows, cfg.providers, cfg.call_sites) == []
+
+
+class TestActiveProvidersJob:
+    """The wired job method, surfacing, dedup, and run() integration."""
+
+    @pytest.mark.asyncio
+    async def test_check_active_providers_fires(self, db) -> None:
+        job = ModelIntelligenceJob(db=db)
+        rows = _parse_groq_deprecation_table(_SAMPLE_GROQ_TABLE)
+        cfg = load_config_from_string(_EOL_CONFIG_YAML)
+        with (
+            patch.object(job, "_fetch_groq_deprecations", AsyncMock(return_value=rows)),
+            patch("genesis.routing.config.load_config", return_value=cfg),
+        ):
+            findings = await job._check_active_providers()
+        assert len(findings) == 1
+        assert findings[0]["model"] == "moonshotai/kimi-k2-instruct-0905"
+
+    @pytest.mark.asyncio
+    async def test_check_active_providers_no_groq_short_circuits(self, db) -> None:
+        job = ModelIntelligenceJob(db=db)
+        cfg = load_config_from_string(
+            "providers:\n  g:\n    type: google\n    model: m\n    free: true\n"
+            "call_sites:\n  s:\n    chain: [g]\n"
+        )
+        mock_fetch = AsyncMock(return_value=[])
+        with (
+            patch.object(job, "_fetch_groq_deprecations", mock_fetch),
+            patch("genesis.routing.config.load_config", return_value=cfg),
+        ):
+            findings = await job._check_active_providers()
+        assert findings == []
+        mock_fetch.assert_not_called()  # no Groq providers → never fetches
+
+    @pytest.mark.asyncio
+    async def test_check_active_providers_config_failure_is_safe(self, db) -> None:
+        job = ModelIntelligenceJob(db=db)
+        with patch("genesis.routing.config.load_config", side_effect=OSError("boom")):
+            assert await job._check_active_providers() == []
+
+    @pytest.mark.asyncio
+    async def test_fetch_deprecations_failsafe_on_error(self, db) -> None:
+        from genesis.web.types import FetchResult
+
+        job = ModelIntelligenceJob(db=db)
+        with patch(
+            "genesis.web.fetch",
+            AsyncMock(return_value=FetchResult(url="u", text="", error="503")),
+        ):
+            assert await job._fetch_groq_deprecations() == []
+
+    @pytest.mark.asyncio
+    async def test_fetch_deprecations_failsafe_on_exception(self, db) -> None:
+        job = ModelIntelligenceJob(db=db)
+        with patch("genesis.web.fetch", AsyncMock(side_effect=RuntimeError("net"))):
+            assert await job._fetch_groq_deprecations() == []
+
+    @pytest.mark.asyncio
+    async def test_eol_surfaces_as_high_priority_finding_not_intake(self, db) -> None:
+        """active_model_eol → recon observation (type='finding',
+        category='active_model_eol', priority='high'), bypassing run_intake."""
+        job = ModelIntelligenceJob(db=db)
+        finding = {
+            "type": "active_model_eol", "model": "x/y", "provider": "p",
+            "vendor": "groq", "shutdown_date": "2026-08-16",
+            "replacement": "z", "blast_radius": ["s1", "s2"],
+            "source": "groq_deprecations_page",
+        }
+        await job._store_finding(finding)
+        cur = await db.execute(
+            "SELECT type, category, priority, content_hash FROM observations "
+            "WHERE category = 'active_model_eol'"
+        )
+        rows = [dict(r) for r in await cur.fetchall()]
+        assert len(rows) == 1
+        assert rows[0]["type"] == "finding"
+        assert rows[0]["priority"] == "high"
+        assert rows[0]["content_hash"]
+
+    @pytest.mark.asyncio
+    async def test_eol_observation_dedups_on_model_and_date(self, db) -> None:
+        job = ModelIntelligenceJob(db=db)
+        finding = {
+            "type": "active_model_eol", "model": "x/y",
+            "shutdown_date": "2026-08-16", "blast_radius": [],
+        }
+        await job._store_finding(finding)
+        await job._store_finding(finding)  # same (model, date) → deduped
+        cur = await db.execute(
+            "SELECT COUNT(*) FROM observations WHERE category = 'active_model_eol'"
+        )
+        assert (await cur.fetchone())[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_run_wires_eol_into_summary_and_storage(self, db, tmp_path) -> None:
+        """Built != wired: run() invokes the EOL check, counts it, stores it."""
+        job = ModelIntelligenceJob(db=db)
+        rows = _parse_groq_deprecation_table(_SAMPLE_GROQ_TABLE)
+        cfg = load_config_from_string(_EOL_CONFIG_YAML)
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock()
+        mock_client.get = AsyncMock(return_value=_mock_openrouter_response([]))
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("genesis.recon.model_intelligence._FREE_MODEL_CACHE_PATH",
+                  tmp_path / "free_cache.json"),
+            patch.object(job, "_fetch_groq_deprecations", AsyncMock(return_value=rows)),
+            patch("genesis.routing.config.load_config", return_value=cfg),
+        ):
+            result = await job.run()
+        assert result["eol_findings"] == 1
+        cur = await db.execute(
+            "SELECT COUNT(*) FROM observations WHERE category = 'active_model_eol'"
+        )
+        assert (await cur.fetchone())[0] == 1


### PR DESCRIPTION
Adds active-provider model-EOL detection to the wired weekly model-intelligence recon job, so a deprecation of a model **we actually use** surfaces as a high-priority alert instead of slipping by.

## What
- New `_check_active_providers()` (step 5 of `ModelIntelligenceJob.run()`): loads the routing config, parses Groq's deprecations page (via `genesis.web.fetch`), and emits an `active_model_eol` finding **only** for our active Groq models that appear with a dated shutdown — annotated with **blast radius** (the call-site chains that depend on that provider).
- Surfaces as a **high-priority recon observation** (`type=finding`, `category=active_model_eol`), deduped on a stable `(model_id, shutdown_date)` hash so the same EOL never re-fires while unresolved. Deliberately bypasses the intake → knowledge-base path (curated model-intelligence findings route to the KB, where an actionable alert would be buried).
- **Firehose-proof:** a deprecation for a model we don't use yields nothing; a fetch / parse / config failure yields nothing (degrades gracefully, never crashes the weekly scan).

## Scope
v1 covers Groq's structured deprecations page (our largest exposure). Catalog `/v1/models` diff (with a two-run blip guard) for all OpenAI-compatible vendors, plus the Google changelog, are a documented follow-up.

## Verification
- 27 unit tests — parser handles both pipe formats and rejects non-calendar dates; matcher firehose guard + blast radius; surfacing + stable dedup; `run()` wiring; fail-safe paths. Network is stubbed in `run()`-based tests.
- Live E2E: correctly flags the real `llama-3.3-70b-versatile` / `2026-08-16` Groq deprecation on `groq-free` with a 30-chain blast radius, and dedups on a second run.

No DB migration (reuses the `observations` table). Deploy = pull + restart.
