### PR TITLE
fix(guardian): gate code-drift detection to last deploy, not live HEAD

### DIFF
--- a/src/genesis/db/crud/update_history.py
+++ b/src/genesis/db/crud/update_history.py
@@ -1,0 +1,25 @@
+"""CRUD reader for the ``update_history`` ledger (Genesis self-update attempts).
+
+Writes are owned by ``scripts/update.sh`` (the deploy script records each run);
+this module provides read access through the CRUD layer so callers never issue
+raw SQL against ``genesis.db``.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def last_successful_deploy_commit(db: aiosqlite.Connection) -> str | None:
+    """Return ``new_commit`` of the most recent successful update, else None.
+
+    Ordered by ``datetime(started_at)`` so ISO timestamps with differing
+    timezone offsets compare by true instant rather than lexicographically.
+    """
+    cur = await db.execute(
+        "SELECT new_commit FROM update_history "
+        "WHERE status = 'success' AND new_commit IS NOT NULL "
+        "ORDER BY datetime(started_at) DESC LIMIT 1",
+    )
+    row = await cur.fetchone()
+    return str(row[0]).strip() if row and row[0] else None

--- a/src/genesis/guardian/watchdog.py
+++ b/src/genesis/guardian/watchdog.py
@@ -309,6 +309,13 @@ class GuardianWatchdog:
         if branch_result.returncode == 0 and branch_result.stdout.strip() not in ("main",):
             return
         if not container_hash:
+            # deploy_ref resolved but no Guardian-path commit is reachable from
+            # it — nothing to compare. Log so this silent-skip is observable
+            # (mirrors the no-baseline debug above) rather than going dark.
+            logger.debug(
+                "Guardian drift check: no Guardian-path commit reachable from "
+                "deploy_ref=%s — skipping", deploy_ref,
+            )
             return
 
         # Get host's deployed hash via SSH version command
@@ -452,7 +459,10 @@ class GuardianWatchdog:
                 cur = await db.execute(
                     "SELECT new_commit FROM update_history "
                     "WHERE status = 'success' AND new_commit IS NOT NULL "
-                    "ORDER BY started_at DESC LIMIT 1",
+                    # datetime() normalizes the ISO timestamp (incl. tz offset)
+                    # to UTC so mixed-offset rows order by true instant, not
+                    # lexicographically.
+                    "ORDER BY datetime(started_at) DESC LIMIT 1",
                 )
                 row = await cur.fetchone()
         except Exception:

--- a/src/genesis/guardian/watchdog.py
+++ b/src/genesis/guardian/watchdog.py
@@ -442,12 +442,15 @@ class GuardianWatchdog:
 
         Returns None when no successful update is recorded (no baseline → the
         caller skips, never false-alarms). Best-effort: any DB failure → None.
-        Function-level imports keep ``genesis.db`` off the host's import path
-        (this watchdog is container-side only — see guardian/DEPLOYMENT.md).
+        The SQL lives in ``genesis.db.crud.update_history`` (CRUD-layer reader);
+        all imports are function-level so ``genesis.db`` stays off the host's
+        import path (this watchdog is container-side only — see
+        guardian/DEPLOYMENT.md), with connection management kept here.
         """
         import aiosqlite
 
         from genesis.db.connection import BUSY_TIMEOUT_MS
+        from genesis.db.crud import update_history
         from genesis.env import genesis_db_path
 
         db_path = genesis_db_path()
@@ -456,18 +459,9 @@ class GuardianWatchdog:
         try:
             async with aiosqlite.connect(str(db_path)) as db:
                 await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
-                cur = await db.execute(
-                    "SELECT new_commit FROM update_history "
-                    "WHERE status = 'success' AND new_commit IS NOT NULL "
-                    # datetime() normalizes the ISO timestamp (incl. tz offset)
-                    # to UTC so mixed-offset rows order by true instant, not
-                    # lexicographically.
-                    "ORDER BY datetime(started_at) DESC LIMIT 1",
-                )
-                row = await cur.fetchone()
+                return await update_history.last_successful_deploy_commit(db)
         except Exception:
             return None
-        return str(row[0]).strip() if row and row[0] else None
 
     async def _expected_gateway_sha(self, code_version: str) -> str | None:
         """sha256 of the gateway script at the host's install-dir commit.

--- a/src/genesis/guardian/watchdog.py
+++ b/src/genesis/guardian/watchdog.py
@@ -268,14 +268,34 @@ class GuardianWatchdog:
         """Inner implementation of drift detection (may raise)."""
         import asyncio
 
-        # Get container's hash for Guardian-relevant paths (non-blocking)
+        # Reference point = the commit update.sh LAST SUCCESSFULLY DEPLOYED, not
+        # the container's live HEAD. The host Guardian is only redeployed by an
+        # update.sh run, while container `main` advances on every PR merge — so
+        # HEAD races ahead of the host between deploys and comparing against it
+        # false-alarms on benign lag. Measuring against the last deploy makes
+        # drift fire only when a redeploy was attempted but didn't take (a
+        # genuinely stale/frozen host), which is what this check exists to catch.
+        deploy_ref = await self._last_deployed_commit()
+        if deploy_ref is None:
+            # No successful update recorded → no deploy baseline. Skip rather
+            # than fall back to HEAD (which re-introduces the false alarm).
+            logger.debug(
+                "Guardian drift check: no successful update_history baseline "
+                "— skipping",
+            )
+            return
+
+        # Get container's hash for Guardian-relevant paths AS OF the last deploy
+        # (non-blocking).
         result = await asyncio.to_thread(
             subprocess.run,
             ["git", "-C", str(Path.home() / "genesis"),
-             "log", "-1", "--format=%h", "--"] + self._GUARDIAN_PATHS,
+             "log", "-1", "--format=%h", deploy_ref, "--"] + self._GUARDIAN_PATHS,
             capture_output=True, text=True, timeout=5,
         )
         if result.returncode != 0:
+            # deploy_ref unresolvable in the container's git (e.g. rewritten
+            # history) — skip, never false-alarm.
             return
         container_hash = result.stdout.strip()
 
@@ -403,6 +423,41 @@ class GuardianWatchdog:
         if result.returncode == 1:
             return False  # genuinely not contained → real drift
         return None       # 128 (unknown object — host ahead) / other → skip
+
+    async def _last_deployed_commit(self) -> str | None:
+        """Commit hash that update.sh LAST SUCCESSFULLY deployed.
+
+        This is the host Guardian's expected baseline: the host is only
+        redeployed by an update.sh run (which records the run in
+        ``update_history``), whereas the container's live HEAD advances on
+        every merge. Drift must be measured against this, not HEAD, or normal
+        between-deploy lag false-alarms.
+
+        Returns None when no successful update is recorded (no baseline → the
+        caller skips, never false-alarms). Best-effort: any DB failure → None.
+        Function-level imports keep ``genesis.db`` off the host's import path
+        (this watchdog is container-side only — see guardian/DEPLOYMENT.md).
+        """
+        import aiosqlite
+
+        from genesis.db.connection import BUSY_TIMEOUT_MS
+        from genesis.env import genesis_db_path
+
+        db_path = genesis_db_path()
+        if not db_path.exists():
+            return None
+        try:
+            async with aiosqlite.connect(str(db_path)) as db:
+                await db.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_MS}")
+                cur = await db.execute(
+                    "SELECT new_commit FROM update_history "
+                    "WHERE status = 'success' AND new_commit IS NOT NULL "
+                    "ORDER BY started_at DESC LIMIT 1",
+                )
+                row = await cur.fetchone()
+        except Exception:
+            return None
+        return str(row[0]).strip() if row and row[0] else None
 
     async def _expected_gateway_sha(self, code_version: str) -> str | None:
         """sha256 of the gateway script at the host's install-dir commit.

--- a/tests/test_guardian/test_watchdog.py
+++ b/tests/test_guardian/test_watchdog.py
@@ -611,6 +611,22 @@ class TestCodeDrift:
         outreach.submit_raw.assert_not_called()
         eb.emit.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_no_guardian_commit_reachable_skips(self):
+        """deploy_ref resolves but `git log` finds no Guardian-path commit at/
+        before it (exit 0, empty stdout) → skip before the SSH round-trip, no
+        alarm. Guards the empty-container_hash branch."""
+        wd, r, eb, outreach = _drift_watchdog(deployed_commit="0ld0ld0",
+                                              deploy_ref="dep10y0")
+        wd._host_contains_commit = AsyncMock(return_value=False)
+        with patch("genesis.guardian.watchdog.subprocess.run",
+                   side_effect=_git_side_effect("")):   # git log → empty
+            await wd._check_code_drift_inner()
+        assert wd._drift_count == 0
+        r.version.assert_not_called()
+        wd._host_contains_commit.assert_not_awaited()
+        outreach.submit_raw.assert_not_called()
+
 
 class TestLastDeployedCommit:
     """The deploy baseline read from update_history: the commit update.sh last
@@ -664,6 +680,21 @@ class TestLastDeployedCommit:
                             lambda: tmp_path / "nonexistent.db")
         wd = GuardianWatchdog(AsyncMock(), event_bus=None)
         assert await wd._last_deployed_commit() is None
+
+    @pytest.mark.asyncio
+    async def test_orders_by_true_instant_not_lexicographic(self, tmp_path, monkeypatch):
+        """Mixed timezone offsets must order by actual instant, not raw string.
+        Values chosen so lexicographic and true-instant order DIFFER: the row
+        whose string sorts higher ('...T20:00:00+05:00' = 15:00 UTC) is the
+        EARLIER instant, so it must NOT win over '...T16:00:00+00:00' (16:00 UTC)."""
+        db = tmp_path / "genesis.db"
+        self._seed_db(db, [
+            ("1", "WRONG_lexwin", "success", "2026-06-23T20:00:00+05:00"),   # 15:00 UTC
+            ("2", "RIGHT_instant", "success", "2026-06-23T16:00:00+00:00"),  # 16:00 UTC
+        ])
+        monkeypatch.setattr("genesis.env.genesis_db_path", lambda: db)
+        wd = GuardianWatchdog(AsyncMock(), event_bus=None)
+        assert await wd._last_deployed_commit() == "RIGHT_instant"
 
 
 class TestAlertUser:

--- a/tests/test_guardian/test_watchdog.py
+++ b/tests/test_guardian/test_watchdog.py
@@ -429,14 +429,18 @@ class TestHostContainsCommit:
             assert await wd._host_contains_commit("a915a28", "0a07272") is None
 
 
-def _drift_watchdog(deployed_commit: str):
+def _drift_watchdog(deployed_commit: str, deploy_ref: str | None = "dep10y0"):
     """Watchdog wired for code-drift tests: mock remote.version() → deployed_commit,
-    mock event_bus/outreach. `_host_contains_commit` is stubbed per-test."""
+    mock event_bus/outreach. `_last_deployed_commit` (the deploy baseline drift is
+    measured against) is stubbed to `deploy_ref` so the check runs without a DB;
+    pass deploy_ref=None to exercise the no-baseline skip. `_host_contains_commit`
+    is stubbed per-test."""
     r = AsyncMock()
     r.version = AsyncMock(return_value={"deployed_commit": deployed_commit})
     event_bus = AsyncMock()
     outreach = AsyncMock()
     wd = GuardianWatchdog(r, event_bus=event_bus, outreach_pipeline=outreach)
+    wd._last_deployed_commit = AsyncMock(return_value=deploy_ref)
     return wd, r, event_bus, outreach
 
 
@@ -559,6 +563,107 @@ class TestCodeDrift:
         assert wd._drift_count == 0
         outreach.submit_raw.assert_not_called()
         assert not any("code_drift" in e for e in _emitted_events(eb))
+
+    @pytest.mark.asyncio
+    async def test_reference_is_deploy_baseline_not_head(self):
+        """The container reference is the last DEPLOYED commit, not live HEAD:
+        the `git log` that derives the Guardian commit is scoped to the deploy
+        baseline. This is the fix for the per-commit false alarm — container
+        `main` races ahead of the host between update.sh runs, so HEAD is the
+        wrong reference."""
+        from unittest.mock import MagicMock
+        wd, r, eb, outreach = _drift_watchdog(deployed_commit="dep10y0",
+                                              deploy_ref="dep10y0")
+        wd._host_contains_commit = AsyncMock(return_value=True)
+        seen: dict = {}
+
+        def _se(cmd, **kw):
+            if "symbolic-ref" in cmd:
+                return MagicMock(returncode=0, stdout="main\n")
+            if "log" in cmd:
+                seen["log_cmd"] = cmd
+                return MagicMock(returncode=0, stdout="dep10y0\n")
+            return MagicMock(returncode=0, stdout="")
+
+        with patch("genesis.guardian.watchdog.subprocess.run", side_effect=_se):
+            await wd._check_code_drift_inner()
+        # git log was scoped to the deploy baseline (not implicit HEAD)
+        assert "dep10y0" in seen["log_cmd"]
+        assert wd._drift_count == 0
+        outreach.submit_raw.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_deploy_baseline_skips_no_alarm(self):
+        """No successful update recorded → no baseline → skip the whole check
+        (never fall back to live HEAD). version() is not even queried, so a host
+        that is legitimately behind because no deploy has run yet cannot
+        false-alarm — even ticking far past the threshold."""
+        wd, r, eb, outreach = _drift_watchdog(deployed_commit="0ld0ld0",
+                                              deploy_ref=None)
+        wd._host_contains_commit = AsyncMock(return_value=False)  # would alarm if reached
+        with patch("genesis.guardian.watchdog.subprocess.run",
+                   side_effect=_git_side_effect("a915a28")):
+            for _ in range(_THRESHOLD + 1):
+                await wd._check_code_drift_inner()
+        assert wd._drift_count == 0
+        r.version.assert_not_called()
+        wd._host_contains_commit.assert_not_awaited()
+        outreach.submit_raw.assert_not_called()
+        eb.emit.assert_not_called()
+
+
+class TestLastDeployedCommit:
+    """The deploy baseline read from update_history: the commit update.sh last
+    SUCCESSFULLY deployed. Drift is measured against this, not container HEAD."""
+
+    @staticmethod
+    def _seed_db(path, rows):
+        import sqlite3
+        con = sqlite3.connect(str(path))
+        con.execute(
+            "CREATE TABLE update_history (id TEXT PRIMARY KEY, old_tag TEXT, "
+            "new_tag TEXT, old_commit TEXT, new_commit TEXT, status TEXT, "
+            "rollback_tag TEXT, failure_reason TEXT, degraded_subsystems TEXT, "
+            "started_at TEXT, completed_at TEXT)",
+        )
+        con.executemany(
+            "INSERT INTO update_history (id, new_commit, status, started_at) "
+            "VALUES (?, ?, ?, ?)", rows,
+        )
+        con.commit()
+        con.close()
+
+    @pytest.mark.asyncio
+    async def test_returns_latest_success_new_commit(self, tmp_path, monkeypatch):
+        """Most recent status='success' row wins; a newer non-success row (e.g.
+        a failed deploy after) is correctly ignored."""
+        db = tmp_path / "genesis.db"
+        self._seed_db(db, [
+            ("1", "OLDcom", "success", "2026-06-23T01:00:00+00:00"),
+            ("2", "NEWcom", "success", "2026-06-23T14:00:00+00:00"),
+            ("3", "FAILcom", "failed", "2026-06-23T15:00:00+00:00"),
+        ])
+        monkeypatch.setattr("genesis.env.genesis_db_path", lambda: db)
+        wd = GuardianWatchdog(AsyncMock(), event_bus=None)
+        assert await wd._last_deployed_commit() == "NEWcom"
+
+    @pytest.mark.asyncio
+    async def test_no_success_rows_returns_none(self, tmp_path, monkeypatch):
+        db = tmp_path / "genesis.db"
+        self._seed_db(db, [
+            ("1", "Xcom", "failed", "2026-06-23T01:00:00+00:00"),
+            ("2", "Ycom", "rolled_back", "2026-06-23T02:00:00+00:00"),
+        ])
+        monkeypatch.setattr("genesis.env.genesis_db_path", lambda: db)
+        wd = GuardianWatchdog(AsyncMock(), event_bus=None)
+        assert await wd._last_deployed_commit() is None
+
+    @pytest.mark.asyncio
+    async def test_missing_db_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("genesis.env.genesis_db_path",
+                            lambda: tmp_path / "nonexistent.db")
+        wd = GuardianWatchdog(AsyncMock(), event_bus=None)
+        assert await wd._last_deployed_commit() is None
 
 
 class TestAlertUser:


### PR DESCRIPTION
## Problem

The container-side Guardian watchdog raises false **\"Guardian code drift\"** Telegram alerts:

```
level=ERROR genesis.guardian.watchdog "Guardian code drift detected for 3 ticks: container=<a> host=<b>"
```

## Root cause

`_check_code_drift_inner` compared the host's `deployed_commit` against the last Guardian-path commit reachable from the container's **live `HEAD`**. But the two move on different cadences:

- The **host Guardian** is only redeployed when `scripts/update.sh` runs (it archives HEAD and pushes a `redeploy` to the host *if* a Guardian-path changed). It is not on a timer.
- The container's **`main`** advances on **every PR merge**.

So `HEAD` races ahead of the host between deploys, and any Guardian-path commit landed in that window trips a false alarm ~15 min later (3 ticks) — even though the host is exactly where the last deploy put it. Comparing two commits alone can't distinguish *\"behind because no deploy ran yet\"* (benign) from *\"behind because a deploy failed/froze\"* (the #669/#670 case this check exists for).

## Fix

Measure drift against **what `update.sh` last successfully deployed**, not live `HEAD`:

- New `_last_deployed_commit()` reads the latest `status='success'` row's `new_commit` from `update_history` (the container's own deploy ledger). Function-level imports keep `genesis.db` off the host's import path (this module is container-side — see `guardian/DEPLOYMENT.md`).
- `container_hash` is now derived from that deploy baseline (`git log -1 --format=%h <deploy_ref> -- <GUARDIAN_PATHS>`).
- No baseline recorded → skip (never fall back to HEAD). `deploy_ref` unresolvable / no Guardian-path commit reachable → skip, with a debug log so it's observable.
- Everything downstream (ancestry check, drift counting, once-per-episode Telegram alert) is unchanged.

Result: benign between-deploy lag goes silent; a genuinely stale/frozen host (deploy attempted but not applied) **still alerts**.

Review follow-ups included: observable empty-skip log; `ORDER BY datetime(started_at)` so mixed timezone offsets order by true instant.

## Verification

- Targeted: `tests/test_guardian/` — **400 passed** (7 new/changed cases: deploy-baseline reference, no-baseline skip, empty-reachable skip, `_last_deployed_commit` success/none/missing-db, mixed-timezone ordering).
- End-to-end against live state:
  - host = latest successful deploy commit → **no alert** (false alarm gone).
  - host frozen at an older commit the deploy baseline contains → **still alerts** (signal preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)