### PR TITLE
feat(crucible): foundation — experiment_run tool + reflection-prompt overlay

### DIFF
--- a/src/genesis/cc/reflection_bridge/_prompts.py
+++ b/src/genesis/cc/reflection_bridge/_prompts.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import uuid as _uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -573,20 +574,56 @@ _FALLBACK_PROMPTS = {
 }
 
 
-def system_prompt_for_depth(depth: Depth, prompt_dir: Path) -> str:
-    """Load the system prompt for a given depth, with model-specific variant support."""
+def _resolve_prompt_in_dir(depth: Depth, prompt_dir: Path) -> str | None:
+    """Resolve a depth's prompt within one dir — model-specific variant
+    (e.g. ``REFLECTION_DEEP_SONNET.md``) then the base file. None if neither
+    exists or the dir can't be read."""
     filename = _PROMPT_FILES.get(depth)
-    if filename:
+    if not filename:
+        return None
+    try:
         model = _DEPTH_MODEL.get(depth)
         if model:
             stem = filename.rsplit(".", 1)[0]
-            model_file = f"{stem}_{model.value.upper()}.md"
-            model_path = prompt_dir / model_file
+            model_path = prompt_dir / f"{stem}_{model.value.upper()}.md"
             if model_path.exists():
                 return model_path.read_text()
         path = prompt_dir / filename
         if path.exists():
             return path.read_text()
+    except OSError:
+        logger.debug("reflection prompt read failed in %s", prompt_dir, exc_info=True)
+    return None
+
+
+def _reflection_override_dir() -> Path:
+    """User overlay dir for reflection prompts (``~/.genesis/config/reflection``).
+
+    A writable, out-of-git-tree target for hand-overriding the reflection prompt
+    (and the future Evo promotion path). Env-overridable via
+    ``GENESIS_REFLECTION_PROMPT_DIR`` for tests / explicit control.
+    """
+    value = os.environ.get("GENESIS_REFLECTION_PROMPT_DIR")
+    if value:
+        return Path(value).expanduser()
+    from genesis.env import genesis_home
+
+    return genesis_home() / "config" / "reflection"
+
+
+def system_prompt_for_depth(depth: Depth, prompt_dir: Path) -> str:
+    """Load the depth's reflection system prompt.
+
+    Resolution order, first hit wins: (1) the user overlay
+    (``~/.genesis/config/reflection``; env ``GENESIS_REFLECTION_PROMPT_DIR``),
+    (2) the repo ``prompt_dir``, (3) the hardcoded fallback. Within each dir the
+    model-specific variant beats the base file. No overlay file → behavior is
+    identical to using ``prompt_dir`` alone.
+    """
+    for prompt_source in (_reflection_override_dir(), prompt_dir):
+        resolved = _resolve_prompt_in_dir(depth, prompt_source)
+        if resolved is not None:
+            return resolved
     return _FALLBACK_PROMPTS.get(depth, _FALLBACK_PROMPTS[Depth.DEEP])
 
 

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -66,6 +66,7 @@ from genesis.mcp.health import direct_session_tools as _direct_session_tools  # 
 from genesis.mcp.health import ego_calibration as _ego_calibration  # noqa: E402, F401
 from genesis.mcp.health import ego_tools as _ego_tools  # noqa: E402
 from genesis.mcp.health import errors as _errors  # noqa: E402
+from genesis.mcp.health import experiment_run as _experiment_run  # noqa: E402, F401
 from genesis.mcp.health import experiment_status as _experiment_status  # noqa: E402, F401
 from genesis.mcp.health import follow_up_tools as _follow_up_tools  # noqa: E402
 from genesis.mcp.health import inbox_digest as _inbox_digest  # noqa: E402

--- a/src/genesis/mcp/health/experiment_run.py
+++ b/src/genesis/mcp/health/experiment_run.py
@@ -1,0 +1,157 @@
+"""experiment_run MCP tool — Crucible's "run" button.
+
+The action surface the experimentation harness ("Crucible") was missing: it
+runs a control-vs-treatment **reflection-prompt** A/B over the calibrated golden
+set via ``run_reflection_experiment``, **persists** the result to ``eval_runs``
+(trigger='experiment'), and returns the win-rate verdict.
+
+Recommend-only: this MEASURES a prompt variant and records the result — it
+NEVER promotes one. ``autonomous_action`` is always False; a human acts on the
+recommendation. Surfaced afterward via ``experiment_status``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+# Default judge is a healthy free provider, NOT the runner module's stale
+# ``nvidia-nim-deepseek`` default (which is frequently down); both are
+# caller-overridable.
+_DEFAULT_GEN_PROVIDER = "groq-free"
+_DEFAULT_JUDGE_PROVIDER = "groq-free"
+
+
+async def _impl_experiment_run(
+    *,
+    experiment_name: str,
+    control_prompt: str,
+    treatment_prompt: str,
+    control_name: str = "control",
+    treatment_name: str = "treatment",
+    golden_set_path: str | None = None,
+    limit: int | None = None,
+    gen_provider: str = _DEFAULT_GEN_PROVIDER,
+    judge_provider: str = _DEFAULT_JUDGE_PROVIDER,
+) -> dict:
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    _service = getattr(health_mcp_mod, "_service", None)
+    if _service is None or getattr(_service, "_db", None) is None:
+        return {"status": "unavailable", "message": "DB not initialized"}
+    db = _service._db
+
+    if golden_set_path:
+        gs_path = Path(golden_set_path)
+    else:
+        from genesis.eval.reflection_golden_set import DEFAULT_OUTPUT
+
+        gs_path = DEFAULT_OUTPUT
+    if not gs_path.exists():
+        return {
+            "status": "error",
+            "message": (
+                f"golden set not found: {gs_path}. Generate it with: "
+                "python -m genesis.eval.reflection_golden_set --count 150"
+            ),
+        }
+
+    from genesis.experimentation import runner as _runner
+    from genesis.experimentation.types import CognitiveVariant
+
+    control = CognitiveVariant(
+        name=control_name, description="control arm", system_prompt=control_prompt,
+    )
+    treatment = CognitiveVariant(
+        name=treatment_name, description="treatment arm", system_prompt=treatment_prompt,
+    )
+
+    try:
+        result = await _runner.run_reflection_experiment(
+            experiment_name=experiment_name,
+            control=control,
+            treatment=treatment,
+            golden_set_path=gs_path,
+            gen_provider=gen_provider,
+            judge_provider=judge_provider,
+            limit=limit,
+            db=db,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface failure, never crash the tool
+        logger.warning("experiment_run %s failed", experiment_name, exc_info=True)
+        return {"status": "error", "message": f"{type(exc).__name__}: {exc}"}
+
+    wr = result.winrate or {}
+    return {
+        "status": "ok",
+        "autonomous_action": False,
+        "experiment": experiment_name,
+        "recommendation": wr.get("recommendation"),
+        "significant": wr.get("significant"),
+        "winrate": wr,
+        "n_cases": result.n_cases,
+        "errors": result.errors,
+        "control": {
+            "variant": result.control.variant_name,
+            "mean_score": result.control.mean_score,
+            "n_pass": result.control.n_pass,
+        },
+        "treatment": {
+            "variant": result.treatment.variant_name,
+            "mean_score": result.treatment.mean_score,
+            "n_pass": result.treatment.n_pass,
+        },
+        "persisted": True,
+        "gen_provider": gen_provider,
+        "judge_provider": judge_provider,
+        "note": (
+            "Recommend-only: this MEASURES a reflection-prompt A/B and persists "
+            "it to eval_runs (surfaced by experiment_status). It NEVER promotes "
+            "a variant. recommendation ∈ {treatment_wins, control_wins, "
+            "no_difference, insufficient_data}."
+        ),
+    }
+
+
+@mcp.tool()
+async def experiment_run(
+    experiment_name: str,
+    control_prompt: str,
+    treatment_prompt: str,
+    control_name: str = "control",
+    treatment_name: str = "treatment",
+    golden_set_path: str = "",
+    limit: int = 0,
+    gen_provider: str = _DEFAULT_GEN_PROVIDER,
+    judge_provider: str = _DEFAULT_JUDGE_PROVIDER,
+) -> dict:
+    """Run a reflection-prompt A/B (control vs treatment) and persist the result.
+
+    Generates a fresh reflection per golden-set case for each prompt, judges
+    both with the ``reflection_quality`` rubric, computes a paired win-rate
+    (McNemar exact), and writes the result to ``eval_runs`` (trigger='experiment').
+    RECOMMEND-ONLY — nothing is promoted; ``autonomous_action`` is always False.
+
+    Args:
+        experiment_name: Label stored with the result.
+        control_prompt / treatment_prompt: the two reflection system prompts.
+        golden_set_path: JSONL golden set (default: the reflection golden set).
+        limit: cap golden cases (0 = all) — use a small N for a cheap smoke run.
+        gen_provider / judge_provider: routing-config provider names (default a
+            free provider; override to whatever is currently healthy).
+    """
+    return await _impl_experiment_run(
+        experiment_name=experiment_name,
+        control_prompt=control_prompt,
+        treatment_prompt=treatment_prompt,
+        control_name=control_name,
+        treatment_name=treatment_name,
+        golden_set_path=golden_set_path or None,
+        limit=limit or None,
+        gen_provider=gen_provider,
+        judge_provider=judge_provider,
+    )

--- a/tests/test_cc/test_reflection_prompt_override.py
+++ b/tests/test_cc/test_reflection_prompt_override.py
@@ -1,0 +1,67 @@
+"""Reflection-prompt user-overlay: ``system_prompt_for_depth`` checks a
+``~/.genesis/config/reflection/`` overlay (env-overridable via
+``GENESIS_REFLECTION_PROMPT_DIR``) BEFORE the repo default ``prompt_dir``.
+
+This gives a writable, out-of-git-tree target for hand-overriding the
+reflection prompt (and the future Evo promotion path). No overlay file → behavior
+is identical to before.
+"""
+
+from genesis.awareness.types import Depth
+from genesis.cc.reflection_bridge._prompts import system_prompt_for_depth
+
+
+def _base_dir(tmp_path):
+    base = tmp_path / "identity"
+    base.mkdir()
+    (base / "REFLECTION_DEEP.md").write_text("BASE deep prompt")
+    return base
+
+
+def test_override_dir_takes_precedence(tmp_path, monkeypatch):
+    base = _base_dir(tmp_path)
+    override = tmp_path / "override"
+    override.mkdir()
+    (override / "REFLECTION_DEEP.md").write_text("OVERRIDE deep prompt")
+    monkeypatch.setenv("GENESIS_REFLECTION_PROMPT_DIR", str(override))
+
+    assert system_prompt_for_depth(Depth.DEEP, base) == "OVERRIDE deep prompt"
+
+
+def test_override_model_specific_wins(tmp_path, monkeypatch):
+    base = _base_dir(tmp_path)
+    override = tmp_path / "override"
+    override.mkdir()
+    (override / "REFLECTION_DEEP.md").write_text("OVERRIDE base")
+    # DEEP maps to the SONNET model variant.
+    (override / "REFLECTION_DEEP_SONNET.md").write_text("OVERRIDE sonnet")
+    monkeypatch.setenv("GENESIS_REFLECTION_PROMPT_DIR", str(override))
+
+    assert system_prompt_for_depth(Depth.DEEP, base) == "OVERRIDE sonnet"
+
+
+def test_no_override_file_falls_back_to_prompt_dir(tmp_path, monkeypatch):
+    base = _base_dir(tmp_path)
+    override = tmp_path / "override"
+    override.mkdir()  # exists but empty → no override file
+    monkeypatch.setenv("GENESIS_REFLECTION_PROMPT_DIR", str(override))
+
+    assert system_prompt_for_depth(Depth.DEEP, base) == "BASE deep prompt"
+
+
+def test_missing_override_dir_uses_prompt_dir(tmp_path, monkeypatch):
+    base = _base_dir(tmp_path)
+    monkeypatch.setenv(
+        "GENESIS_REFLECTION_PROMPT_DIR", str(tmp_path / "does_not_exist"),
+    )
+
+    assert system_prompt_for_depth(Depth.DEEP, base) == "BASE deep prompt"
+
+
+def test_env_unset_does_not_crash(tmp_path, monkeypatch):
+    base = _base_dir(tmp_path)
+    monkeypatch.delenv("GENESIS_REFLECTION_PROMPT_DIR", raising=False)
+    # Default overlay (~/.genesis/config/reflection) has no file on a fresh box,
+    # so it falls through to the repo prompt_dir — and never raises.
+    out = system_prompt_for_depth(Depth.DEEP, base)
+    assert isinstance(out, str) and out

--- a/tests/test_experimentation/test_experiment_run.py
+++ b/tests/test_experimentation/test_experiment_run.py
@@ -1,0 +1,110 @@
+"""Test the experiment_run MCP tool — Crucible's "run" button.
+
+Hermetic: the LLM A/B (`run_reflection_experiment`) is mocked, so these tests
+exercise the tool's wiring (param→variant mapping, persistence pass-through,
+verdict shaping, and the unavailable/missing-golden-set guards) without any
+live model calls.
+"""
+
+from genesis.experimentation.types import ArmResult, ExperimentResult
+
+
+def _fake_result(name="run_test"):
+    return ExperimentResult(
+        experiment_name=name,
+        control=ArmResult(
+            variant_name="ctrl", case_scores=[0.6] * 6, case_results=[True] * 6,
+            n_pass=6, mean_score=0.6,
+        ),
+        treatment=ArmResult(
+            variant_name="trt", case_scores=[0.9] * 6, case_results=[True] * 6,
+            n_pass=6, mean_score=0.9,
+        ),
+        winrate={"recommendation": "treatment_wins", "significant": True, "p_value": 0.03},
+        n_cases=6,
+        errors=0,
+        metadata={},
+    )
+
+
+async def test_experiment_run_returns_verdict_and_persists(eval_db, tmp_path, monkeypatch):
+    gs = tmp_path / "g.jsonl"
+    gs.write_text(
+        '{"id":"c1","actual":"x","user_passed":true,'
+        '"scorer_config":{"session_context":"ctx","rubric_name":"reflection_quality"}}\n'
+    )
+
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    class _Svc:
+        _db = eval_db
+
+    monkeypatch.setattr(health_mcp_mod, "_service", _Svc(), raising=False)
+
+    captured = {}
+
+    async def fake_run(**kwargs):
+        captured.update(kwargs)
+        return _fake_result()
+
+    monkeypatch.setattr(
+        "genesis.experimentation.runner.run_reflection_experiment", fake_run,
+    )
+
+    from genesis.mcp.health.experiment_run import _impl_experiment_run
+
+    out = await _impl_experiment_run(
+        experiment_name="run_test",
+        control_prompt="You are Genesis. Reflect. Output JSON.",
+        treatment_prompt="You are Genesis. Reflect carefully. Output JSON.",
+        golden_set_path=str(gs),
+        limit=6,
+    )
+
+    assert out["status"] == "ok"
+    assert out["autonomous_action"] is False
+    assert out["recommendation"] == "treatment_wins"
+    assert out["significant"] is True
+    assert out["control"]["mean_score"] == 0.6
+    assert out["treatment"]["mean_score"] == 0.9
+    assert out["n_cases"] == 6
+    assert out["persisted"] is True
+    # db threaded through so the run persists; prompts mapped onto variants
+    assert captured["db"] is eval_db
+    assert captured["control"].system_prompt.startswith("You are Genesis")
+    assert captured["treatment"].system_prompt.startswith("You are Genesis")
+    # provider defaults thread through (catches a runner signature rename that
+    # would otherwise silently fall back to the stale module default judge)
+    assert captured["gen_provider"] == "groq-free"
+    assert captured["judge_provider"] == "groq-free"
+
+
+async def test_experiment_run_missing_golden_set(eval_db, monkeypatch):
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    class _Svc:
+        _db = eval_db
+
+    monkeypatch.setattr(health_mcp_mod, "_service", _Svc(), raising=False)
+    from genesis.mcp.health.experiment_run import _impl_experiment_run
+
+    out = await _impl_experiment_run(
+        experiment_name="x",
+        control_prompt="a",
+        treatment_prompt="b",
+        golden_set_path="/nonexistent/path.jsonl",
+    )
+    assert out["status"] == "error"
+    assert "golden set" in out["message"].lower()
+
+
+async def test_experiment_run_unavailable_without_db(monkeypatch):
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    monkeypatch.setattr(health_mcp_mod, "_service", None, raising=False)
+    from genesis.mcp.health.experiment_run import _impl_experiment_run
+
+    out = await _impl_experiment_run(
+        experiment_name="x", control_prompt="a", treatment_prompt="b",
+    )
+    assert out["status"] == "unavailable"


### PR DESCRIPTION
## Context

The cognitive A/B experimentation harness ("Crucible", formerly "Phase 7",
`src/genesis/experimentation/`) was **built but unrun**: 197 tests, deployed,
yet **0 real experiments** (`eval_runs WHERE trigger='experiment'` = 0). It was
deliberately a *measurement library with no action surface* — (1) no way to
**run** an experiment, and (2) no clean **apply** target (the live deep-reflection
prompt is a markdown file in the git tree, with no settings/overlay knob).

This PR builds the **foundation** for the self-improvement loop ("Evo", next):
make Crucible runnable, and give it a clean writable knob to promote into. It
does **not** build Evo or any promotion path — recommend-only throughout.

## What

**1. `experiment_run` MCP tool** (`mcp/health/experiment_run.py`) — the run
button. Wires `run_reflection_experiment` so a control-vs-treatment
reflection-prompt A/B can be run + persisted to `eval_runs` (trigger=experiment),
then surfaced by the existing read-only `experiment_status`. Mirrors that tool's
service/DB pattern. **Recommend-only** (`autonomous_action: False`) — measures
and records, never promotes. Defaults gen/judge to a healthy free provider
(`groq-free`), caller-overridable (the runner module's stale `nvidia-nim-deepseek`
judge default is frequently down).

**2. Reflection-prompt overlay** (`cc/reflection_bridge/_prompts.py`) —
`system_prompt_for_depth` now checks a `~/.genesis/config/reflection/` overlay
(env `GENESIS_REFLECTION_PROMPT_DIR`) **before** the repo `prompt_dir`, then the
hardcoded fallback. A writable, out-of-git-tree target for hand-overriding the
reflection prompt (and the future Evo promotion), consistent with Genesis's
CAPS/overlay philosophy. **No overlay file → behavior identical to before** (a
live cognitive path — verified by the regression suite + a reviewer trace).

No migration. No new tables.

## Verification

- **Tests:** hermetic — `experiment_run` (param→variant mapping, db persistence
  pass-through, provider threading, missing-golden-set + no-db guards) +
  reflection-overlay precedence/fallback. 89 targeted tests green, ruff clean.
- **Live E2E:** a real `groq-free` A/B over the actual golden set ran the full
  pipeline (gen → judge → McNemar win-rate) and **persisted 2 `experiment`
  rows**; the overlay returned the override when set and the real 13.5KB repo
  prompt when not. *Honest note:* 6 of 8 case-evals errored under `groq-free`
  free-tier **rate-limiting** on rapid calls (not a code bug — some cases scored
  and persisted correctly; the hermetic tests cover the logic). It's a provider
  signal for **Evo's** fan-out/cost design next session; the tool exposes
  `judge_provider` to swap in a sturdier model.
- **Review:** feature-dev code-reviewer — clean (no P1; one P2 on test
  provider-assertions, fixed). Codex / OpenCode / OpenRouter all quota-blocked at
  review time, so the external second opinion relies on CI + the Claude pass.

## Next (not in this PR)

**Evo** — the loop on top: fan-out N reflection-prompt variants → gate at α/N +
held-out re-validation → surface the winner as a `cognitive_variant_promotion`
approval proposal that applies to the overlay this PR adds. Designed +
architect-reviewed; built next session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
