### PR TITLE
feat(routing): prefer free NIM deepseek-v4-pro on the deepseek-pro chains

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -348,6 +348,8 @@ call_sites:
     cc_model: Sonnet
   17_executor_review:
     chain:
+    - nvidia-nim-deepseek
+    - openrouter-deepseek-v4-flash
     - openrouter-deepseek-v4
     - openrouter-qwen36plus
     default_paid: true
@@ -361,6 +363,7 @@ call_sites:
   20_adversarial_counterargument:
     chain:
     - openrouter-gpt55
+    - nvidia-nim-deepseek
     - openrouter-deepseek-v4
     - openrouter-qwen36plus
     default_paid: true
@@ -477,6 +480,8 @@ call_sites:
     description: Synthesize research results into concise summaries
   38_procedure_extraction:
     chain:
+    - nvidia-nim-deepseek
+    - openrouter-deepseek-v4-flash
     - openrouter-deepseek-v4
     - groq-free
     - mistral-large-free
@@ -491,6 +496,8 @@ call_sites:
     description: "Unified cognitive loop focus selector — picks ego attention direction from pending signals"
   43_task_retrospective:
     chain:
+    - nvidia-nim-deepseek
+    - openrouter-deepseek-v4-flash
     - openrouter-deepseek-v4
     - mistral-large-free
     - gemini-free
@@ -498,6 +505,8 @@ call_sites:
     description: Post-execution retrospective learning extraction
   44_task_premortem:
     chain:
+    - nvidia-nim-deepseek
+    - openrouter-deepseek-v4-flash
     - openrouter-deepseek-v4
     - mistral-large-free
     - gemini-free
@@ -646,6 +655,7 @@ call_sites:
       \ grader is slow/down) and sheds under REDUCED degradation."
   judge:
     chain:
+    - nvidia-nim-deepseek
     - openrouter-deepseek-v4
     - openrouter-deepseek-v4-flash
     default_paid: true
@@ -653,7 +663,7 @@ call_sites:
     dispatch: api
     description: "LLM-as-judge primitive \u2014 grades outputs against versioned\
       \ rubrics for the eval harness (and, in later phases, CRAG retrieval).\
-      \ Same-family fallback (v4 then v4-flash) for resilience; model_used\
+      \ Free NIM v4-pro first, then paid v4-pro, then v4-flash for resilience; model_used\
       \ is logged per judgment for calibration traceability."
   voice_conversation:
     chain:

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -155,8 +155,11 @@ def test_load_full_yaml(monkeypatch):
     assert cfg.call_sites["5_deep_reflection"].default_paid is True
     assert cfg.call_sites["36_code_auditor"].never_pays is False
     assert cfg.call_sites["37_infrastructure_monitor"].default_paid is True
-    # judge: LLM-as-judge eval primitive — same-family fallback, paid-by-default
-    assert cfg.call_sites["judge"].chain == ["openrouter-deepseek-v4", "openrouter-deepseek-v4-flash"]
+    # judge: LLM-as-judge eval primitive — free NIM v4-pro first, then paid v4-pro,
+    # then v4-flash; paid-by-default
+    assert cfg.call_sites["judge"].chain == [
+        "nvidia-nim-deepseek", "openrouter-deepseek-v4", "openrouter-deepseek-v4-flash"
+    ]
     assert cfg.call_sites["judge"].default_paid is True
     assert cfg.call_sites["judge"].dispatch == "api"
 


### PR DESCRIPTION
Right-sizes the DeepSeek routing: the same `deepseek-v4-pro` model is available both paid (`openrouter-deepseek-v4`) and **free via NVIDIA NIM** (`nvidia-nim-deepseek`, same model, credit-capped). This prefers the free copy where it makes sense, with paid as the reliable backstop.

## What
The 6 call-sites that used paid `deepseek-v4-pro` now lead with free `nvidia-nim-deepseek`:
- **`judge`** (eval backbone): `nvidia-nim-deepseek` → `openrouter-deepseek-v4` → `…-flash` — keeps both S-tier options ahead of the A-tier flash.
- **`17_executor_review` / `38_procedure_extraction` / `43_task_retrospective` / `44_task_premortem`**: `nvidia-nim-deepseek` → `…-flash` (tier A, ~4.4× cheaper) → `openrouter-deepseek-v4` → existing free fallbacks.
- **`20_adversarial_counterargument`**: `gpt55` primary unchanged; `nvidia-nim-deepseek` inserted ahead of paid pro (no flash — adversarial wants S).

## Net
Free S-tier while NIM has credits → graceful fallback to flash/paid on exhaustion (breaker-bounded). All existing free fallbacks preserved.

## Caveat (watch post-deploy)
NIM is shared + credit-capped; high-volume `judge` will drain it, after which these chains fall back to paid (today's behavior). Watch: NIM exhaustion rate, starvation of the chains that already depend on NIM (`surplus_brainstorm` / `skill_refiner` / dream-cycle), and DLQ growth. One-line-per-chain reversible.

## Test
302 routing tests pass; live `nvidia-nim-deepseek` smoke-test (responds, ~2.2s); router E2E confirms each site routes to its expected first provider. No DB migration. Deploy = pull + restart.
