### PR TITLE
fix(dashboard): de-dupe follow-ups UI, hide-done filter, sort fixes

### DIFF
--- a/src/genesis/dashboard/routes/follow_ups.py
+++ b/src/genesis/dashboard/routes/follow_ups.py
@@ -14,57 +14,6 @@ from genesis.dashboard._blueprint import _async_route, blueprint
 logger = logging.getLogger(__name__)
 
 
-@blueprint.route("/api/genesis/follow-ups")
-@_async_route
-async def follow_up_list():
-    """Return follow-ups with optional status filter.
-
-    Query params:
-        status – filter by status (default: all)
-        limit – max results (default 30)
-    """
-    from genesis.db.crud import follow_ups
-    from genesis.runtime import GenesisRuntime
-
-    rt = GenesisRuntime.instance()
-    if not rt.is_bootstrapped or rt.db is None:
-        return jsonify({"follow_ups": [], "counts": {}})
-
-    status_filter = request.args.get("status", "").strip() or None
-    source_filter = request.args.get("source", "").strip() or None
-    source_mode = request.args.get("source_mode", "all").strip()
-    limit = min(request.args.get("limit", 30, type=int), 200)
-
-    # Backward compat: source=user maps to source_mode=mine
-    if source_filter == "user" and source_mode == "all":
-        source_mode = "mine"
-
-    try:
-        if status_filter:
-            items = await follow_ups.get_by_status(rt.db, status_filter)
-            # Apply source_mode filter post-query for status-filtered results
-            if source_mode == "mine":
-                items = [i for i in items if i.get("source") == "foreground_session"]
-            elif source_mode == "system":
-                items = [i for i in items if i.get("source") != "foreground_session"]
-            items = items[:limit]
-        else:
-            items = await follow_ups.get_recent(
-                rt.db, limit=limit, source_mode=source_mode,
-            )
-
-        counts = await follow_ups.get_summary_counts(rt.db)
-    except Exception:
-        logger.error("Failed to list follow-ups", exc_info=True)
-        return jsonify({"follow_ups": [], "counts": {}})
-
-    return jsonify({
-        "follow_ups": items,
-        "counts": counts,
-        "total": sum(counts.values()),
-    })
-
-
 @blueprint.route("/api/genesis/follow-ups/summary")
 @_async_route
 async def follow_up_summary():
@@ -91,6 +40,8 @@ async def follow_up_summary():
 _COCKPIT_STATUSES = (
     "pending", "scheduled", "in_progress", "completed", "failed", "blocked",
 )
+# Terminal states hidden by the cockpit's default "hide done" view.
+_DONE_STATUSES = ["completed", "failed"]
 _BATCH_ACTIONS = ("done", "delete", "tabled", "follow_up")
 
 
@@ -100,7 +51,11 @@ async def follow_up_cockpit():
     """Paginated/sorted/filtered follow-up list for the cockpit tab.
 
     Query params: kind (follow_up|tabled|all), domain (internal|user_world|
-    __null__), status, source, search, sort, page, page_size.
+    __null__), status, source, search, sort, page, page_size, hide_done.
+
+    ``hide_done`` (default "1") excludes terminal states (completed/failed) so
+    the default view is actionable work; it is ignored when an explicit
+    ``status`` filter is supplied. Pass hide_done=0 to show everything.
     """
     from genesis.db.crud import follow_ups
     from genesis.runtime import GenesisRuntime
@@ -118,18 +73,20 @@ async def follow_up_cockpit():
     source = request.args.get("source", "").strip() or None
     search = request.args.get("search", "").strip() or None
     sort = request.args.get("sort", "priority").strip() or "priority"
+    hide_done = request.args.get("hide_done", "1").strip() not in ("0", "false", "")
+    status_exclude = _DONE_STATUSES if hide_done else None
     page = max(1, request.args.get("page", 1, type=int))
     page_size = min(max(request.args.get("page_size", 50, type=int), 1), 200)
 
     try:
         items = await follow_ups.query_page(
             rt.db, kind=kind, domain=domain, status=status, source=source,
-            search=search, sort=sort, offset=(page - 1) * page_size,
-            limit=page_size,
+            search=search, status_exclude=status_exclude, sort=sort,
+            offset=(page - 1) * page_size, limit=page_size,
         )
         total = await follow_ups.count_filtered(
             rt.db, kind=kind, domain=domain, status=status, source=source,
-            search=search,
+            search=search, status_exclude=status_exclude,
         )
     except Exception:
         logger.error("Failed to query follow-up cockpit", exc_info=True)

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -175,11 +175,6 @@
         sessionsList: [],
         sessionsView: 'active',    // 'active' or 'history'
         sessionsExpanded: null,
-        followUpsList: [],
-        followUpsView: 'active',   // 'active' or 'all'
-        followUpsSourceMode: 'all', // 'all' | 'mine' | 'system'
-        followUpsCounts: {},
-        followUpsExpanded: null,
 
         // ── Comms state (on Chat tab) ────────────────────────────
         commsOutreach: [],
@@ -299,7 +294,6 @@
         _jobHealthInterval: null,
         _tasksInterval: null,
         _workSessionsInterval: null,
-        _followUpsInterval: null,
         _observationsInterval: null,
         _cockpitInterval: null,
         _commsInterval: null,
@@ -324,6 +318,7 @@
         cockpitPageSize: 50,
         cockpitFilters: { kind: 'follow_up', domain: '', status: '', source: '', search: '' },
         cockpitSort: 'priority',
+        cockpitHideDone: true,   // default: hide completed/failed (actionable view)
         cockpitAvailableFilters: { sources: [], statuses: [] },
         cockpitExpanded: null,
         cockpitBatchIds: {},
@@ -351,7 +346,7 @@
           internals: ["_awarenessInterval", "_routingInterval", "_jobHealthInterval", "_activityInterval", "_sessionsInterval"],
           config:    [],
           files:     [],
-          work:      ["_tasksInterval", "_workSessionsInterval", "_followUpsInterval"],
+          work:      ["_tasksInterval", "_workSessionsInterval"],
           observations: ["_observationsInterval"],
           "follow-ups": ["_cockpitInterval"],
           traces:    ["_tracesInterval"],
@@ -417,10 +412,9 @@
               if (first) { this.fetchFiles(); }
               break;
             case "work":
-              if (first) { this.fetchTasks(); this.fetchWorkSessions(); this.fetchFollowUps(); }
+              if (first) { this.fetchTasks(); this.fetchWorkSessions(); }
               this._tasksInterval = setInterval(() => this.fetchTasks(), 5000);
               this._workSessionsInterval = setInterval(() => this.fetchWorkSessions(), 10000);
-              this._followUpsInterval = setInterval(() => this.fetchFollowUps(), 15000);
               break;
             case "observations":
               if (first) { this.fetchObservations(); this.fetchObservationsSummary(); this.fetchObservationsFilters(); }
@@ -931,18 +925,6 @@
             }
           } catch (e) { console.warn("Work sessions fetch failed:", e); }
         },
-        async fetchFollowUps() {
-          try {
-            const sm = this.followUpsSourceMode;
-            const url = `/api/genesis/follow-ups?limit=50${sm !== 'all' ? '&source_mode=' + sm : ''}`;
-            const resp = await fetchApi(url);
-            if (resp && resp.ok) {
-              const data = await resp.json();
-              this.followUpsList = data.follow_ups || [];
-              this.followUpsCounts = data.counts || {};
-            }
-          } catch (e) { console.warn("Follow-ups fetch failed:", e); }
-        },
 
         // ── Observations tab fetches ─────────────────────────────
         async fetchObservations() {
@@ -1049,6 +1031,7 @@
             if (f.source) params.set("source", f.source);
             if (f.search) params.set("search", f.search);
             params.set("sort", this.cockpitSort);
+            params.set("hide_done", this.cockpitHideDone ? "1" : "0");
             params.set("page", String(this.cockpitPage));
             params.set("page_size", String(this.cockpitPageSize));
             const resp = await fetchApi(`/api/genesis/follow-ups/cockpit?${params}`);
@@ -8864,110 +8847,6 @@
       </div>
     </div>
 
-    <!-- Work: Follow-ups -->
-    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'work'">
-      <div class="panel-header">
-        <span class="material-symbols-outlined">follow_the_signs</span>
-        Follow-ups
-        <span class="panel-status" x-show="$store.genesisDashboard.followUpsCounts.pending > 0">
-          <span style="background:#ce93d8; width:6px; height:6px; border-radius:50%; display:inline-block;"></span>
-          <span x-text="$store.genesisDashboard.followUpsCounts.pending + ' pending'"></span>
-        </span>
-      </div>
-      <div class="panel-body">
-        <!-- Active / All toggle -->
-        <div style="display:flex; gap:0.25rem; margin-bottom:0.75rem;">
-          <button style="font-size:0.72rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer; transition:all 0.15s;"
-                  :style="$store.genesisDashboard.followUpsView === 'active' ? 'background:#4caf5033; border:1px solid #4caf50; color:#4caf50; font-weight:600;' : 'background:transparent; border:1px solid #666; color:#aaa;'"
-                  @click="$store.genesisDashboard.followUpsView = 'active'">Active</button>
-          <button style="font-size:0.72rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer; transition:all 0.15s;"
-                  :style="$store.genesisDashboard.followUpsView === 'all' ? 'background:#2196F333; border:1px solid #2196F3; color:#2196F3; font-weight:600;' : 'background:transparent; border:1px solid #666; color:#aaa;'"
-                  @click="$store.genesisDashboard.followUpsView = 'all'">All</button>
-          <!-- Source filter -->
-          <span style="border-left:1px solid #555; margin:0 0.25rem;"></span>
-          <button style="font-size:0.72rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer; transition:all 0.15s;"
-                  :style="$store.genesisDashboard.followUpsSourceMode === 'all' ? 'background:#9c27b033; border:1px solid #9c27b0; color:#9c27b0; font-weight:600;' : 'background:transparent; border:1px solid #666; color:#aaa;'"
-                  @click="$store.genesisDashboard.followUpsSourceMode = 'all'; $store.genesisDashboard.fetchFollowUps()">All Sources</button>
-          <button style="font-size:0.72rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer; transition:all 0.15s;"
-                  :style="$store.genesisDashboard.followUpsSourceMode === 'mine' ? 'background:#ff980033; border:1px solid #ff9800; color:#ff9800; font-weight:600;' : 'background:transparent; border:1px solid #666; color:#aaa;'"
-                  @click="$store.genesisDashboard.followUpsSourceMode = 'mine'; $store.genesisDashboard.fetchFollowUps()">Mine</button>
-          <button style="font-size:0.72rem; padding:0.2rem 0.6rem; border-radius:3px; cursor:pointer; transition:all 0.15s;"
-                  :style="$store.genesisDashboard.followUpsSourceMode === 'system' ? 'background:#00bcd433; border:1px solid #00bcd4; color:#00bcd4; font-weight:600;' : 'background:transparent; border:1px solid #666; color:#aaa;'"
-                  @click="$store.genesisDashboard.followUpsSourceMode = 'system'; $store.genesisDashboard.fetchFollowUps()">System</button>
-        </div>
-        <template x-if="$store.genesisDashboard.followUpsList.filter(f => {
-          if ($store.genesisDashboard.followUpsView === 'active') return ['pending','in_progress','blocked'].includes(f.status);
-          return true;
-        }).length === 0">
-          <div style="padding:1.5rem; text-align:center; color:var(--color-text-secondary); font-size:0.75rem;">
-            No follow-ups found.
-          </div>
-        </template>
-        <div class="activity-feed">
-          <template x-for="item in $store.genesisDashboard.followUpsList.filter(f => {
-            if ($store.genesisDashboard.followUpsView === 'active') return ['pending','in_progress','blocked'].includes(f.status);
-            return true;
-          })" :key="item.id">
-            <div>
-              <div class="activity-row" style="cursor:pointer; display:flex; align-items:center; gap:0.5rem;"
-                   @click="$store.genesisDashboard.followUpsExpanded = $store.genesisDashboard.followUpsExpanded === item.id ? null : item.id">
-                <!-- Status badge -->
-                <span style="font-size:0.65rem; padding:0.1rem 0.4rem; border-radius:3px; font-weight:600; text-transform:uppercase; flex-shrink:0;"
-                      :style="{
-                        'pending':     'background:rgba(158,158,158,0.15); color:#9e9e9e;',
-                        'in_progress': 'background:rgba(33,150,243,0.15); color:#2196F3;',
-                        'blocked':     'background:rgba(255,167,38,0.15); color:#ffa726;',
-                        'completed':   'background:rgba(102,187,106,0.15); color:#66bb6a;',
-                        'cancelled':   'background:rgba(158,158,158,0.15); color:#9e9e9e;',
-                      }[item.status] || 'background:rgba(158,158,158,0.15); color:#9e9e9e;'"
-                      x-text="item.status"></span>
-                <!-- Priority badge -->
-                <template x-if="item.priority && item.priority !== 'medium'">
-                  <span style="font-size:0.6rem; padding:0.08rem 0.3rem; border-radius:3px; flex-shrink:0;"
-                        :style="item.priority === 'high' || item.priority === 'critical' ? 'background:rgba(239,154,154,0.15); color:#ef9a9a;' : 'background:rgba(158,158,158,0.1); color:#9e9e9e;'"
-                        x-text="item.priority"></span>
-                </template>
-                <!-- Description -->
-                <span style="flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-size:0.73rem;"
-                      x-text="item.content || item.id"></span>
-                <!-- Timestamp -->
-                <span style="color:var(--color-text-secondary); font-size:0.65rem; flex-shrink:0;"
-                      x-text="$store.genesisDashboard.formatTime(item.created_at)"></span>
-                <!-- Expand arrow -->
-                <span class="material-symbols-outlined" style="font-size:0.9rem; color:var(--color-text-secondary); transition:transform 0.15s;"
-                      :style="$store.genesisDashboard.followUpsExpanded === item.id ? 'transform:rotate(90deg)' : ''">chevron_right</span>
-              </div>
-              <!-- Expanded detail -->
-              <template x-if="$store.genesisDashboard.followUpsExpanded === item.id">
-                <div style="padding:0.5rem 0.75rem; background:rgba(0,0,0,0.15); border-radius:4px; margin:0.25rem 0 0.5rem 0; font-size:0.72rem;">
-                  <div style="margin-bottom:0.4rem; line-height:1.5;" x-text="item.content"></div>
-                  <template x-if="item.reason">
-                    <div style="margin-bottom:0.3rem; color:var(--color-text-secondary); font-size:0.7rem;">
-                      <strong>Reason:</strong> <span x-text="item.reason"></span>
-                    </div>
-                  </template>
-                  <div style="display:flex; gap:0.5rem; font-size:0.65rem; color:var(--color-text-secondary);">
-                    <span x-text="'Strategy: ' + (item.strategy || 'unknown')"></span>
-                    <span x-text="'Source: ' + (item.source || 'unknown')"></span>
-                  </div>
-                  <template x-if="item.resolution_notes">
-                    <div style="margin-top:0.3rem; padding:0.2rem 0.4rem; background:rgba(0,0,0,0.2); border-radius:3px; font-size:0.65rem; color:var(--color-text-secondary);">
-                      <strong>Resolution:</strong> <span x-text="item.resolution_notes"></span>
-                    </div>
-                  </template>
-                  <template x-if="item.blocked_reason">
-                    <div style="margin-top:0.3rem; padding:0.2rem 0.4rem; background:rgba(255,167,38,0.08); border-radius:3px; border:1px solid rgba(255,167,38,0.15); font-size:0.65rem;">
-                      <strong style="color:#ffa726;">Blocked:</strong> <span x-text="item.blocked_reason"></span>
-                    </div>
-                  </template>
-                </div>
-              </template>
-            </div>
-          </template>
-        </div>
-      </div>
-    </div>
-
     <!-- ═══════════════════════════════════════════════════════════
          Panel: Observations [Tab: observations]
          ═══════════════════════════════════════════════════════════ -->
@@ -9214,6 +9093,17 @@
             <option value="status">Sort: Status</option>
             <option value="source">Sort: Source</option>
           </select>
+
+          <!-- Hide done toggle: excludes completed/failed (ignored when a
+               specific status is selected). On by default → actionable view. -->
+          <label style="display:inline-flex; align-items:center; gap:0.3rem; font-size:0.68rem; color:var(--color-text-secondary); cursor:pointer; user-select:none;"
+                 :title="$store.genesisDashboard.cockpitFilters.status ? 'Showing the selected status — hide-done does not apply' : 'Hide completed and failed follow-ups'">
+            <input type="checkbox"
+                   :checked="$store.genesisDashboard.cockpitHideDone"
+                   :disabled="!!$store.genesisDashboard.cockpitFilters.status"
+                   @change="$store.genesisDashboard.cockpitHideDone = $event.target.checked; $store.genesisDashboard.cockpitApplyFilter()">
+            Hide done
+          </label>
 
           <input type="text" placeholder="Search content/reason… (Enter)"
                  :value="$store.genesisDashboard.cockpitFilters.search"

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -440,15 +440,26 @@ _VALID_STATUS = {
 }
 
 # Allowlisted sort keys → ORDER BY fragment (never interpolate caller input).
+# Every fragment floats pinned rows to the top (pinned is a "keep visible"
+# flag, honored regardless of the chosen sort). The status sort ranks by
+# actionability — active work first, terminal states last — not alphabetically
+# (plain ``status ASC`` buried pending/blocked items under completed ones).
 _SORT_MAP: dict[str, str] = {
     "priority": (
+        "pinned DESC, "
         "CASE priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 "
         "WHEN 'medium' THEN 2 ELSE 3 END, created_at DESC"
     ),
-    "created_desc": "created_at DESC",
-    "created_asc": "created_at ASC",
-    "status": "status ASC, created_at DESC",
-    "source": "source ASC, created_at DESC",
+    "created_desc": "pinned DESC, created_at DESC",
+    "created_asc": "pinned DESC, created_at ASC",
+    "status": (
+        "pinned DESC, "
+        "CASE status WHEN 'in_progress' THEN 0 WHEN 'blocked' THEN 1 "
+        "WHEN 'pending' THEN 2 WHEN 'scheduled' THEN 3 "
+        "WHEN 'failed' THEN 4 WHEN 'completed' THEN 5 ELSE 6 END, "
+        "created_at DESC"
+    ),
+    "source": "pinned DESC, source ASC, created_at DESC",
 }
 
 
@@ -574,12 +585,15 @@ def _build_filter_where(
     status: str | None,
     source: str | None,
     search: str | None,
+    status_exclude: list[str] | None = None,
 ) -> tuple[str, list]:
     """Build a parameterized WHERE clause shared by query_page/count_filtered.
 
     Only static column/clause text is assembled here; every caller value is
     bound via a ``?`` placeholder. ``domain='__null__'`` matches unclassified
-    rows (domain IS NULL).
+    rows (domain IS NULL). ``status_exclude`` hides terminal states (e.g.
+    completed/failed) and is ignored when an explicit ``status`` is requested
+    — filtering *to* a status and excluding it are mutually exclusive intents.
     """
     clauses: list[str] = []
     params: list = []
@@ -595,6 +609,10 @@ def _build_filter_where(
     if status is not None:
         clauses.append("status = ?")
         params.append(status)
+    elif status_exclude:
+        placeholders = ",".join("?" for _ in status_exclude)
+        clauses.append(f"status NOT IN ({placeholders})")
+        params.extend(status_exclude)
     if source is not None:
         clauses.append("source = ?")
         params.append(source)
@@ -614,10 +632,12 @@ async def count_filtered(
     status: str | None = None,
     source: str | None = None,
     search: str | None = None,
+    status_exclude: list[str] | None = None,
 ) -> int:
     """Count follow-ups matching the cockpit filters."""
     where, params = _build_filter_where(
         kind=kind, domain=domain, status=status, source=source, search=search,
+        status_exclude=status_exclude,
     )
     cursor = await db.execute(f"SELECT COUNT(*) FROM follow_ups{where}", params)
     row = await cursor.fetchone()
@@ -632,6 +652,7 @@ async def query_page(
     status: str | None = None,
     source: str | None = None,
     search: str | None = None,
+    status_exclude: list[str] | None = None,
     sort: str = "priority",
     offset: int = 0,
     limit: int = 50,
@@ -640,9 +661,11 @@ async def query_page(
 
     ``sort`` is allowlisted (see ``_SORT_MAP``); unknown values fall back to
     priority. ``domain='__null__'`` matches rows with no domain set.
+    ``status_exclude`` hides terminal states (ignored when ``status`` is set).
     """
     where, params = _build_filter_where(
         kind=kind, domain=domain, status=status, source=source, search=search,
+        status_exclude=status_exclude,
     )
     order = _SORT_MAP.get(sort, _SORT_MAP["priority"])
     limit = max(1, min(limit, 200))

--- a/tests/test_dashboard/test_follow_ups_cockpit_api.py
+++ b/tests/test_dashboard/test_follow_ups_cockpit_api.py
@@ -75,6 +75,47 @@ def test_cockpit_empty_200_when_not_bootstrapped(client):
     assert resp.get_json()["items"] == []
 
 
+def test_cockpit_hide_done_default_excludes_terminal(client):
+    """Default view (no hide_done param) excludes completed/failed."""
+    qp = AsyncMock(return_value=[])
+    cf = AsyncMock(return_value=0)
+    with (
+        patch(_RT) as MockRT,
+        patch(f"{_CRUD}.query_page", new=qp),
+        patch(f"{_CRUD}.count_filtered", new=cf),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        client.get("/api/genesis/follow-ups/cockpit?kind=follow_up")
+    assert qp.call_args.kwargs["status_exclude"] == ["completed", "failed"]
+    assert cf.call_args.kwargs["status_exclude"] == ["completed", "failed"]
+
+
+def test_cockpit_hide_done_off_includes_all(client):
+    """hide_done=0 passes status_exclude=None (show everything)."""
+    qp = AsyncMock(return_value=[])
+    with (
+        patch(_RT) as MockRT,
+        patch(f"{_CRUD}.query_page", new=qp),
+        patch(f"{_CRUD}.count_filtered", new=AsyncMock(return_value=0)),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        client.get("/api/genesis/follow-ups/cockpit?hide_done=0")
+    assert qp.call_args.kwargs["status_exclude"] is None
+
+
+def test_cockpit_explicit_status_still_passes_through(client):
+    """An explicit status filter is forwarded; exclusion is handled CRUD-side."""
+    qp = AsyncMock(return_value=[])
+    with (
+        patch(_RT) as MockRT,
+        patch(f"{_CRUD}.query_page", new=qp),
+        patch(f"{_CRUD}.count_filtered", new=AsyncMock(return_value=0)),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        client.get("/api/genesis/follow-ups/cockpit?status=completed")
+    assert qp.call_args.kwargs["status"] == "completed"
+
+
 def test_cockpit_passes_null_domain_sentinel(client):
     qp = AsyncMock(return_value=[])
     with (

--- a/tests/test_db/test_follow_ups.py
+++ b/tests/test_db/test_follow_ups.py
@@ -322,3 +322,61 @@ async def test_get_actionable_domain_excludes_pinned_internal(db):
     ids = {r["id"] for r in await follow_ups.get_actionable(db, domain="user_world")}
     assert ids == {uw}
     assert pinned_internal not in ids
+
+
+# ─── Cockpit: status exclusion + pin-first / actionability sort ──────────────
+
+
+async def test_query_page_status_exclude_hides_terminal(db):
+    """status_exclude drops the listed statuses (the cockpit 'hide done')."""
+    keep = await follow_ups.create(db, **{**_BASE, "content": "still open"})
+    done = await follow_ups.create(db, **{**_BASE, "content": "finished"})
+    await follow_ups.update_status(db, done, status="completed")
+
+    rows = await follow_ups.query_page(db, status_exclude=["completed", "failed"])
+    ids = {r["id"] for r in rows}
+    assert keep in ids and done not in ids
+    assert await follow_ups.count_filtered(
+        db, status_exclude=["completed", "failed"]
+    ) == 1
+
+
+async def test_query_page_explicit_status_overrides_exclude(db):
+    """An explicit status filter wins over status_exclude (mutually exclusive)."""
+    done = await follow_ups.create(db, **{**_BASE, "content": "finished"})
+    await follow_ups.update_status(db, done, status="completed")
+
+    rows = await follow_ups.query_page(
+        db, status="completed", status_exclude=["completed"],
+    )
+    assert {r["id"] for r in rows} == {done}
+
+
+async def test_query_page_pinned_floats_to_top(db):
+    """Pinned rows sort first regardless of the chosen sort key."""
+    pinned_old = await follow_ups.create(db, **{**_BASE, "content": "pinned old"})
+    await follow_ups.create(db, **{**_BASE, "content": "newer unpinned"})
+    # Make the pinned row OLDER so a plain recency/priority sort would bury it.
+    await db.execute(
+        "UPDATE follow_ups SET pinned = 1, "
+        "created_at = '2025-01-01T00:00:00+00:00' WHERE id = ?",
+        (pinned_old,),
+    )
+    await db.commit()
+
+    for sort in ("priority", "created_desc", "status", "source"):
+        rows = await follow_ups.query_page(db, sort=sort)
+        assert rows[0]["id"] == pinned_old, f"pinned not first under sort={sort}"
+
+
+async def test_query_page_status_sort_ranks_by_actionability(db):
+    """Status sort surfaces active work before terminal states (not A→Z)."""
+    done = await follow_ups.create(db, **{**_BASE, "content": "done"})
+    active = await follow_ups.create(db, **{**_BASE, "content": "active"})
+    await follow_ups.update_status(db, done, status="completed")
+    await follow_ups.update_status(db, active, status="in_progress")
+
+    order = [r["id"] for r in await follow_ups.query_page(db, sort="status")]
+    # Alphabetical 'completed' < 'in_progress' would invert this — the rank CASE
+    # must put in_progress first.
+    assert order.index(active) < order.index(done)


### PR DESCRIPTION
## Problem
The Follow-ups area had three issues:
1. **Duplicate UI** — the standalone Follow-ups cockpit tab (#746) duplicated the older Work-tab follow-ups panel.
2. **Can't hide completed** — the cockpit had no way to exclude completed/failed; they swamped every view (the status filter was positive-match only).
3. **Sort bugs** — pinned rows never floated to the top under any sort, and the "Status" sort ordered alphabetically (`completed→pending`), burying actionable items.

## Changes
- Remove the Work-tab follow-ups panel + its orphaned Alpine JS (state, interval, `fetchFollowUps`) and the now-uncalled `GET /api/genesis/follow-ups` list route (verified zero callers; `/summary`, `/filters`, `/cockpit`, `/<id>/*` remain). The cockpit is a strict superset.
- **Hide done**: new `status_exclude` through `_build_filter_where`/`query_page`/`count_filtered`; the cockpit route reads `hide_done` (default on) → excludes `completed`/`failed`, ignored when an explicit `status` is chosen. Adds a "Hide done" toggle (disabled while a specific status is selected).
- **Sort**: every `_SORT_MAP` fragment now floats pinned rows first; the `status` sort ranks by actionability (active work first) instead of alphabetically.

## Tests
`tests/test_db/test_follow_ups.py` (status_exclude exclusion + explicit-status override, pin-first across sorts, actionability ranking) and `tests/test_dashboard/test_follow_ups_cockpit_api.py` (hide_done → status_exclude wiring). 55 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)