### PR TITLE
fix(dashboard): count LLM totals from activity_log, not cost_events

### DIFF
--- a/src/genesis/dashboard/routes/vitals.py
+++ b/src/genesis/dashboard/routes/vitals.py
@@ -468,21 +468,31 @@ async def _build_llm_section(rt, routing_ctx: dict) -> dict:
             providers_list.sort(key=lambda p: (-p["calls_24h"], p["name"]))
             section["providers"] = providers_list
 
-            # Totals
+            # Totals — call counts come from activity_log (EVERY LLM call is
+            # logged there, including free-tier providers that emit no
+            # cost_events row); dollar cost comes from cost_events. Counting
+            # calls from cost_events undercounted by ~75% because free calls
+            # are gated out of cost_events (router writes only when cost > 0).
             cursor = await rt.db.execute(
                 "SELECT "
                 "  COUNT(*) FILTER (WHERE created_at >= datetime('now', '-1 hour')), "
-                "  COUNT(*) FILTER (WHERE created_at >= datetime('now', '-24 hours')), "
+                "  COUNT(*) FILTER (WHERE created_at >= datetime('now', '-24 hours')) "
+                "FROM activity_log WHERE provider LIKE 'llm.%'"
+            )
+            calls_row = await cursor.fetchone()
+            cursor = await rt.db.execute(
+                "SELECT "
                 "  COALESCE(SUM(cost_usd) FILTER (WHERE created_at >= datetime('now', '-1 hour')), 0), "
                 "  COALESCE(SUM(cost_usd) FILTER (WHERE created_at >= datetime('now', '-24 hours')), 0) "
                 "FROM cost_events"
             )
-            row = await cursor.fetchone()
-            if row:
-                section["totals"] = {
-                    "calls_1h": row[0], "calls_24h": row[1],
-                    "cost_1h": round(row[2], 4), "cost_24h": round(row[3], 4),
-                }
+            cost_row = await cursor.fetchone()
+            section["totals"] = {
+                "calls_1h": calls_row[0] if calls_row else 0,
+                "calls_24h": calls_row[1] if calls_row else 0,
+                "cost_1h": round(cost_row[0], 4) if cost_row else 0.0,
+                "cost_24h": round(cost_row[1], 4) if cost_row else 0.0,
+            }
 
             # Sessions
             cursor = await rt.db.execute(

--- a/tests/test_dashboard/test_vitals_llm_totals.py
+++ b/tests/test_dashboard/test_vitals_llm_totals.py
@@ -1,0 +1,67 @@
+"""Regression test for the Internals-tab LLM totals undercount.
+
+`_build_llm_section` totals previously counted calls from `cost_events`, which
+omits free-tier providers (the router writes a cost_events row only when cost is
+non-zero/unknown). That undercounted total LLM calls by ~75%. The totals call
+count must come from `activity_log` (where every call is logged); only the
+dollar cost comes from `cost_events`.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from genesis.dashboard.routes.vitals import _build_llm_section
+
+
+async def _seed(db):
+    # 5 free-tier calls (no cost_events) + 2 paid calls (with cost_events).
+    for _ in range(5):
+        await db.execute(
+            "INSERT INTO activity_log (provider, latency_ms, success, created_at) "
+            "VALUES ('llm.groq-free', 120, 1, datetime('now'))"
+        )
+    for _ in range(2):
+        await db.execute(
+            "INSERT INTO activity_log (provider, latency_ms, success, created_at) "
+            "VALUES ('llm.openrouter-deepseek-v4', 300, 1, datetime('now'))"
+        )
+    # A non-LLM row that must NOT be counted in LLM totals.
+    await db.execute(
+        "INSERT INTO activity_log (provider, latency_ms, success, created_at) "
+        "VALUES ('qdrant.search', 8, 1, datetime('now'))"
+    )
+    # cost_events only for the paid provider (free calls emit none).
+    for i in range(2):
+        await db.execute(
+            "INSERT INTO cost_events (id, event_type, provider, cost_usd, "
+            "cost_known, created_at) VALUES (?, 'llm_call', "
+            "'openrouter-deepseek-v4', 0.2, 1, datetime('now'))",
+            (f"ce-{i}",),
+        )
+    await db.commit()
+
+
+async def test_totals_count_calls_from_activity_log_not_cost_events(db):
+    await _seed(db)
+    rt = SimpleNamespace(db=db, circuit_breakers=None)
+    routing_ctx = {"providers": {}, "call_site_assignments": {}, "profiles": {}}
+
+    section = await _build_llm_section(rt, routing_ctx)
+    totals = section["totals"]
+
+    # 7 LLM calls in activity_log (5 free + 2 paid); the qdrant row excluded.
+    # Counting from cost_events would have yielded 2 — the bug.
+    assert totals["calls_24h"] == 7
+    assert totals["calls_1h"] == 7
+    # Dollar cost still sourced from cost_events: 2 × $0.2.
+    assert totals["cost_24h"] == 0.4
+
+
+async def test_totals_zero_when_no_activity(db):
+    rt = SimpleNamespace(db=db, circuit_breakers=None)
+    section = await _build_llm_section(
+        rt, {"providers": {}, "call_site_assignments": {}, "profiles": {}}
+    )
+    assert section["totals"]["calls_24h"] == 0
+    assert section["totals"]["cost_24h"] == 0.0


### PR DESCRIPTION
## Problem
The Internals tab's LLM **totals** (calls/1h, calls/24h) read from `cost_events`, but the router writes a `cost_events` row only when cost is non-zero/unknown — so every **free-tier** call was invisible in the totals. Live data: **615** LLM calls in `activity_log` vs **141** `cost_events` rows in 24h — a ~75% undercount, which made the tab "look broken."

## Change
Count `calls_1h`/`calls_24h` from `activity_log WHERE provider LIKE 'llm.%'`; keep the dollar cost (`cost_1h`/`cost_24h`) sourced from `cost_events`. Per-provider rows already used `activity_log` and were correct — only the totals query was wrong.

## Not changed (verified, not bugs)
- Per-provider cards correctly show no per-call cost for free providers (guarded on `cost_24h > 0`); the near-zero **total** cost is accurate (mostly free tiers).
- `is_free` flags left as-is — whether `glm51`/`deepseek-v4-flash` are truly free is a real-world pricing decision, not a code bug.

## Tests
`tests/test_dashboard/test_vitals_llm_totals.py` — real-DB regression test proving totals count from `activity_log` (7) not `cost_events` (would be 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)