### PR TITLE
feat(recon): editable tracked-repo watchlist + unify loaders

### DIFF
--- a/src/genesis/dashboard/routes/recon.py
+++ b/src/genesis/dashboard/routes/recon.py
@@ -1,12 +1,16 @@
-"""Recon findings and code audit routes."""
+"""Recon findings, code audit, and watchlist routes."""
 
 from __future__ import annotations
 
 import json
+import logging
 
 from flask import jsonify, request
 
 from genesis.dashboard._blueprint import _async_route, blueprint
+from genesis.dashboard.auth import is_authenticated
+
+logger = logging.getLogger(__name__)
 
 
 @blueprint.route("/api/genesis/recon/findings")
@@ -46,3 +50,54 @@ async def recon_findings():
         results.append(finding)
 
     return jsonify(results)
+
+
+# ── Tracked-repo watchlist (recon) ────────────────────────────────────
+# The list (base + install overlay) is non-sensitive and readable; mutations
+# write the gitignored overlay and are gated behind dashboard auth (a no-op
+# when no password is configured). The recon MCP tool stays read-only by
+# design, so the editor is the only write surface.
+
+@blueprint.route("/api/genesis/recon/watchlist")
+def recon_watchlist_list():
+    """Annotated watchlist entries (base + overlay, with source/disabled)."""
+    from genesis.recon import watchlist
+    try:
+        return jsonify({"entries": watchlist.list_entries()})
+    except Exception:
+        logger.error("Failed to list watchlist", exc_info=True)
+        return jsonify({"entries": []})
+
+
+@blueprint.route("/api/genesis/recon/watchlist", methods=["POST"])
+def recon_watchlist_add():
+    """Add an install-specific tracked repo to the overlay."""
+    if not is_authenticated():
+        return jsonify({"error": "authentication required"}), 401
+    from genesis.recon import watchlist
+    result = watchlist.add_repo(request.get_json(silent=True) or {})
+    return (jsonify(result), 422) if "error" in result else jsonify(result)
+
+
+@blueprint.route("/api/genesis/recon/watchlist/disable", methods=["POST"])
+def recon_watchlist_disable():
+    """Disable/re-enable a BASE watchlist entry (tombstone in the overlay)."""
+    if not is_authenticated():
+        return jsonify({"error": "authentication required"}), 401
+    from genesis.recon import watchlist
+    data = request.get_json(silent=True) or {}
+    repo = str(data.get("repo") or "").strip()
+    result = watchlist.set_base_disabled(repo, bool(data.get("disabled", True)))
+    return (jsonify(result), 422) if "error" in result else jsonify(result)
+
+
+@blueprint.route("/api/genesis/recon/watchlist", methods=["DELETE"])
+def recon_watchlist_remove():
+    """Remove an install-added repo from the overlay (base entries: disable)."""
+    if not is_authenticated():
+        return jsonify({"error": "authentication required"}), 401
+    from genesis.recon import watchlist
+    data = request.get_json(silent=True) or {}
+    repo = str(data.get("repo") or "").strip()
+    result = watchlist.remove_overlay_repo(repo)
+    return (jsonify(result), 422) if "error" in result else jsonify(result)

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -220,6 +220,11 @@
         knowledgeUploads: [],
         knowledgeTaxonomy: { project_types: [], domains: [] },
         _uploadPollInterval: null,
+        // Tracked GitHub repositories (recon watchlist)
+        watchlistEntries: [],
+        watchlistForm: { name: '', repo: '', track: 'releases,commits', priority: 'medium', notes: '' },
+        watchlistMsg: null,
+        watchlistSaving: false,
 
         // ── References tab state ──────────────────────────────────
         referenceByKind: {},
@@ -442,7 +447,7 @@
               if (first) { this.fetchMemoryRecent(); this.fetchMemoryStats(); }
               break;
             case "knowledge":
-              if (first) { this.fetchKnowledgeRecent(); this.fetchKnowledgeStats(); this.fetchKnowledgeUploads(); this.fetchKnowledgeTaxonomy(); }
+              if (first) { this.fetchKnowledgeRecent(); this.fetchKnowledgeStats(); this.fetchKnowledgeUploads(); this.fetchKnowledgeTaxonomy(); this.fetchWatchlist(); }
               // Resume polling if any uploads are processing
               if (this.knowledgeUploads.some(u => u.status === "processing")) { this._startUploadPolling(); }
               break;
@@ -1357,6 +1362,59 @@
             const resp = await fetchApi("/api/genesis/knowledge/stats");
             if (resp && resp.ok) { this.knowledgeStats = await resp.json(); }
           } catch (e) { console.warn("Knowledge stats failed:", e); }
+        },
+        // ── Tracked repositories (recon watchlist) ──────────────────
+        async fetchWatchlist() {
+          try {
+            const resp = await fetchApi("/api/genesis/recon/watchlist");
+            if (resp && resp.ok) { this.watchlistEntries = (await resp.json()).entries || []; }
+          } catch (e) { console.warn("Watchlist fetch failed:", e); }
+        },
+        async addWatchlistRepo() {
+          this.watchlistSaving = true; this.watchlistMsg = null;
+          try {
+            const f = this.watchlistForm;
+            const body = {
+              name: f.name, repo: f.repo, priority: f.priority,
+              track: f.track.split(',').map(t => t.trim()).filter(Boolean),
+            };
+            if (f.notes) body.notes = f.notes;
+            const resp = await fetchApi("/api/genesis/recon/watchlist", {
+              method: "POST", headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(body),
+            });
+            const data = resp ? await resp.json() : null;
+            if (resp && resp.ok) {
+              this.watchlistMsg = { ok: true, text: "Added " + data.repo };
+              f.name = ''; f.repo = ''; f.notes = '';
+              this.fetchWatchlist();
+            } else {
+              this.watchlistMsg = { ok: false, text: (data && (data.error || (data.details || []).join('; '))) || "Add failed" };
+            }
+          } catch (e) {
+            this.watchlistMsg = { ok: false, text: String(e) };
+          } finally { this.watchlistSaving = false; }
+        },
+        async toggleWatchlistRepo(repo, disabled) {
+          try {
+            const resp = await fetchApi("/api/genesis/recon/watchlist/disable", {
+              method: "POST", headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ repo, disabled }),
+            });
+            if (resp && resp.ok) { this.fetchWatchlist(); }
+            else { const d = resp ? await resp.json() : null; this.watchlistMsg = { ok: false, text: (d && d.error) || "Update failed" }; }
+          } catch (e) { this.watchlistMsg = { ok: false, text: String(e) }; }
+        },
+        async removeWatchlistRepo(repo) {
+          if (!await this.showConfirm("Remove repository", "Remove " + repo + " from tracked repositories?")) return;
+          try {
+            const resp = await fetchApi("/api/genesis/recon/watchlist", {
+              method: "DELETE", headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ repo }),
+            });
+            if (resp && resp.ok) { this.fetchWatchlist(); }
+            else { const d = resp ? await resp.json() : null; this.watchlistMsg = { ok: false, text: (d && d.error) || "Remove failed" }; }
+          } catch (e) { this.watchlistMsg = { ok: false, text: String(e) }; }
         },
         async searchKnowledge() {
           if (!this.knowledgeQuery.trim()) return;
@@ -9768,6 +9826,75 @@
         Knowledge Base
       </div>
       <div style="padding: 1rem;">
+
+      <!-- ── Tracked GitHub Repositories (recon watchlist) ───── -->
+      <div style="margin-bottom: 1.5rem;">
+        <div style="display:flex; align-items:center; gap:0.4rem; margin-bottom:0.4rem;">
+          <span class="material-symbols-outlined" style="font-size:1.1rem;">visibility</span>
+          <strong>Tracked GitHub Repositories</strong>
+          <span style="font-size:0.72rem; color:var(--color-text-secondary);"
+                x-text="'(' + $store.genesisDashboard.watchlistEntries.length + ')'"></span>
+        </div>
+        <div style="font-size:0.74rem; color:var(--color-text-secondary); margin-bottom:0.6rem;">
+          Repos Genesis monitors for releases, commits, and issues. Base entries ship with
+          Genesis (lock icon — can be disabled); add install-specific repos below.
+        </div>
+        <div style="display:flex; flex-direction:column; gap:0.3rem; margin-bottom:0.6rem;">
+          <template x-for="e in $store.genesisDashboard.watchlistEntries" :key="e.repo">
+            <div style="display:flex; align-items:center; gap:0.5rem; padding:0.35rem 0.5rem; border-radius:4px; background:rgba(0,0,0,0.15);"
+                 :style="e.disabled ? 'opacity:0.5;' : ''">
+              <span class="material-symbols-outlined" style="font-size:0.85rem; color:var(--color-text-secondary);"
+                    x-text="e.source === 'base' ? 'lock' : 'person'"
+                    :title="e.source === 'base' ? 'Base entry (ships with Genesis)' : 'Install-added'"></span>
+              <a :href="'https://github.com/' + e.repo" target="_blank" rel="noopener"
+                 style="font-family:monospace; font-size:0.78rem; color:#64b5f6; text-decoration:none;" x-text="e.repo"></a>
+              <span style="font-size:0.62rem; padding:0.05rem 0.3rem; border-radius:3px; background:rgba(255,255,255,0.08); color:var(--color-text-secondary);" x-text="e.priority"></span>
+              <span style="font-size:0.66rem; color:var(--color-text-secondary); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; flex:1;" x-text="(e.track || []).join(', ')"></span>
+              <template x-if="e.source === 'base'">
+                <button style="font-size:0.62rem; padding:0.1rem 0.45rem; border-radius:3px; cursor:pointer; border:1px solid #555; background:transparent;"
+                        :style="e.disabled ? 'color:#81c784; border-color:#81c784;' : 'color:#aaa;'"
+                        @click="$store.genesisDashboard.toggleWatchlistRepo(e.repo, !e.disabled)"
+                        x-text="e.disabled ? 'Enable' : 'Disable'"></button>
+              </template>
+              <template x-if="e.source === 'overlay'">
+                <button style="font-size:0.62rem; padding:0.1rem 0.45rem; border-radius:3px; cursor:pointer; border:1px solid rgba(239,83,80,0.4); background:transparent; color:#ef9a9a;"
+                        @click="$store.genesisDashboard.removeWatchlistRepo(e.repo)">Remove</button>
+              </template>
+            </div>
+          </template>
+          <template x-if="$store.genesisDashboard.watchlistEntries.length === 0">
+            <div style="font-size:0.74rem; color:var(--color-text-secondary); padding:0.5rem;">No tracked repositories loaded.</div>
+          </template>
+        </div>
+        <details style="font-size:0.78rem;">
+          <summary style="cursor:pointer; color:var(--color-text-secondary);">+ Add a repository</summary>
+          <div style="display:flex; flex-direction:column; gap:0.4rem; margin-top:0.5rem; max-width:480px;">
+            <input type="text" x-model="$store.genesisDashboard.watchlistForm.name" placeholder="Name (e.g. Cool Project)"
+                   style="font-size:0.78rem; padding:0.3rem 0.4rem; border-radius:4px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);">
+            <input type="text" x-model="$store.genesisDashboard.watchlistForm.repo" placeholder="owner/repo (not a URL)"
+                   style="font-size:0.78rem; padding:0.3rem 0.4rem; border-radius:4px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary); font-family:monospace;">
+            <input type="text" x-model="$store.genesisDashboard.watchlistForm.track" placeholder="track: releases,commits,issues,discussions,stars"
+                   style="font-size:0.78rem; padding:0.3rem 0.4rem; border-radius:4px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);">
+            <select x-model="$store.genesisDashboard.watchlistForm.priority"
+                    style="font-size:0.78rem; padding:0.3rem 0.4rem; border-radius:4px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);">
+              <option value="high">Priority: high</option>
+              <option value="medium">Priority: medium</option>
+              <option value="low">Priority: low</option>
+            </select>
+            <input type="text" x-model="$store.genesisDashboard.watchlistForm.notes" placeholder="Notes (optional) — why track this?"
+                   style="font-size:0.78rem; padding:0.3rem 0.4rem; border-radius:4px; background:rgba(0,0,0,0.2); border:1px solid #555; color:var(--color-text-primary);">
+            <div style="display:flex; gap:0.6rem; align-items:center;">
+              <button @click="$store.genesisDashboard.addWatchlistRepo()"
+                      :disabled="$store.genesisDashboard.watchlistSaving"
+                      style="font-size:0.78rem; padding:0.3rem 0.8rem; border-radius:4px; cursor:pointer; background:rgba(33,150,243,0.15); color:#64b5f6; border:1px solid rgba(33,150,243,0.4);"
+                      x-text="$store.genesisDashboard.watchlistSaving ? 'Adding…' : 'Add repository'"></button>
+              <span x-show="$store.genesisDashboard.watchlistMsg"
+                    :style="$store.genesisDashboard.watchlistMsg?.ok ? 'color:#81c784; font-size:0.76rem;' : 'color:#ef9a9a; font-size:0.76rem;'"
+                    x-text="$store.genesisDashboard.watchlistMsg?.text"></span>
+            </div>
+          </div>
+        </details>
+      </div>
 
       <!-- ── Upload Zone ─────────────────────────────────────── -->
       <div style="margin-bottom: 1.5rem;">

--- a/src/genesis/mcp/recon_mcp.py
+++ b/src/genesis/mcp/recon_mcp.py
@@ -24,9 +24,6 @@ mcp = FastMCP("genesis-recon")
 _REPO_CONFIG_DIR = Path(__file__).resolve().parents[3] / "config"
 _USER_CONFIG_DIR = Path.home() / ".genesis" / "config"
 
-# Watchlist is read-only (curated by developer), always from repo
-_WATCHLIST_PATH = _REPO_CONFIG_DIR / "recon_watchlist.yaml"
-
 # Schedules and sources are user-modifiable — prefer user override
 _REPO_SCHEDULES = _REPO_CONFIG_DIR / "recon_schedules.yaml"
 _REPO_SOURCES = _REPO_CONFIG_DIR / "recon_sources.yaml"
@@ -64,12 +61,15 @@ def init_recon_mcp(
 
 
 def _load_watchlist() -> list[dict]:
-    """Load the hardcoded project watchlist from config/recon_watchlist.yaml."""
-    if not _WATCHLIST_PATH.exists():
-        return []
-    with open(_WATCHLIST_PATH) as f:
-        data = yaml.safe_load(f)
-    return data.get("projects", []) if data else []
+    """Active watchlist (base minus user-disabled + install overlay).
+
+    Delegates to the shared ``recon.watchlist`` store so the recon_config MCP
+    view reflects overlay edits made via the dashboard (previously this read
+    base-only, so those edits were invisible here). Read-only by design —
+    recon targets must not be self-modifiable from an autonomous loop.
+    """
+    from genesis.recon import watchlist
+    return watchlist.active_entries()
 
 
 def _load_schedules() -> dict[str, dict]:

--- a/src/genesis/recon/gatherer.py
+++ b/src/genesis/recon/gatherer.py
@@ -8,7 +8,6 @@ import logging
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from pathlib import Path
 
 import aiosqlite
 
@@ -17,8 +16,6 @@ from genesis.recon.gh_cli import run_gh
 
 logger = logging.getLogger(__name__)
 
-_CONFIG_DIR = Path(__file__).resolve().parents[3] / "config"
-_WATCHLIST_PATH = _CONFIG_DIR / "recon_watchlist.yaml"
 _RELEASES_PER_PROJECT = 2
 _MAX_BODY_CHARS = 1000
 
@@ -358,36 +355,12 @@ class ReconGatherer:
 
     @staticmethod
     def _load_watchlist() -> list[dict]:
-        """Load project watchlist with local overlay support.
+        """Active watchlist: base minus user-disabled, plus the install overlay.
 
-        Base: ``config/recon_watchlist.yaml`` (committed, project-level)
-        Overlay: ``config/recon_watchlist.local.yaml`` (gitignored, install-level)
-
-        Projects from the local overlay are appended to the base list.
+        Delegates to the shared ``recon.watchlist`` store so the gatherer, the
+        recon MCP view, and the dashboard editor all agree on one
+        merged-and-tombstoned list (the loaders used to diverge — the MCP read
+        base-only, so overlay edits were invisible there).
         """
-        if not _WATCHLIST_PATH.exists():
-            return []
-        try:
-            import yaml
-
-            with open(_WATCHLIST_PATH) as f:
-                data = yaml.safe_load(f) or {}
-            projects = list(data.get("projects", []))
-
-            # Merge install-specific overlay (gitignored)
-            local_path = _WATCHLIST_PATH.with_suffix(".local.yaml")
-            if local_path.exists():
-                with open(local_path) as f:
-                    local_data = yaml.safe_load(f) or {}
-                local_projects = local_data.get("projects", [])
-                # Deduplicate by repo name
-                existing_repos = {p.get("repo") for p in projects}
-                for lp in local_projects:
-                    if lp.get("repo") not in existing_repos:
-                        projects.append(lp)
-                        existing_repos.add(lp.get("repo"))
-
-            return projects
-        except Exception:
-            logger.error("Failed to load watchlist", exc_info=True)
-            return []
+        from genesis.recon import watchlist
+        return watchlist.active_entries()

--- a/src/genesis/recon/watchlist.py
+++ b/src/genesis/recon/watchlist.py
@@ -48,10 +48,12 @@ def _load_yaml(path: Path) -> dict:
 
 
 def load_base() -> list[dict]:
+    """Return the committed base project list (``recon_watchlist.yaml``)."""
     return list(_load_yaml(WATCHLIST_PATH).get("projects") or [])
 
 
 def load_overlay() -> dict:
+    """Return the gitignored overlay (install-added ``projects`` + ``disabled`` tombstones)."""
     data = _load_yaml(LOCAL_PATH)
     return {
         "projects": list(data.get("projects") or []),

--- a/src/genesis/recon/watchlist.py
+++ b/src/genesis/recon/watchlist.py
@@ -1,0 +1,206 @@
+"""Recon watchlist — single source of truth for the tracked-repo list.
+
+Two layers:
+  - Base   (``config/recon_watchlist.yaml``)        committed, project-level.
+  - Overlay (``config/recon_watchlist.local.yaml``)  gitignored, install-level.
+
+The overlay both ADDS install-specific repos (``projects``) and TOMBSTONES base
+repos the user disabled (``disabled``). ``active_entries()`` is what the recon
+gatherer / discovery / MCP consume; ``list_entries()`` is the annotated view for
+the dashboard editor. Writes only ever touch the overlay — the committed base is
+never modified, so ``git pull`` stays clean.
+
+Editing is dashboard-only: the recon MCP tool stays read-only by design, so an
+autonomous loop cannot rewrite its own recon targets.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import tempfile
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_DIR = Path(__file__).resolve().parents[3] / "config"
+WATCHLIST_PATH = _CONFIG_DIR / "recon_watchlist.yaml"
+LOCAL_PATH = _CONFIG_DIR / "recon_watchlist.local.yaml"
+
+_VALID_TRACK = {"releases", "commits", "issues", "discussions", "stars"}
+_VALID_PRIORITY = {"high", "medium", "low"}
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+# ── loading ───────────────────────────────────────────────────────────
+
+def _load_yaml(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        import yaml
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
+    except Exception:
+        logger.error("Failed to read watchlist file %s", path, exc_info=True)
+        return {}
+
+
+def load_base() -> list[dict]:
+    return list(_load_yaml(WATCHLIST_PATH).get("projects") or [])
+
+
+def load_overlay() -> dict:
+    data = _load_yaml(LOCAL_PATH)
+    return {
+        "projects": list(data.get("projects") or []),
+        "disabled": list(data.get("disabled") or []),
+    }
+
+
+def active_entries() -> list[dict]:
+    """The repos recon should actually watch: base minus tombstoned, plus
+    install-added — deduped by repo. Consumed by the gatherer / discovery / MCP.
+    """
+    overlay = load_overlay()
+    disabled = set(overlay["disabled"])
+    result = [dict(p) for p in load_base() if p.get("repo") not in disabled]
+    seen = {p.get("repo") for p in result}
+    for op in overlay["projects"]:
+        repo = op.get("repo")
+        if repo and repo not in seen and repo not in disabled:
+            result.append(dict(op))
+            seen.add(repo)
+    return result
+
+
+def list_entries() -> list[dict]:
+    """Annotated view for the dashboard editor: every entry with its ``source``
+    (base|overlay) and ``disabled`` flag. Base entries are always listed (so a
+    disabled one can be re-enabled); install-added entries are listed once.
+    """
+    overlay = load_overlay()
+    disabled = set(overlay["disabled"])
+    out: list[dict] = []
+    seen: set[str] = set()
+    for p in load_base():
+        repo = p.get("repo")
+        out.append({**p, "source": "base", "disabled": repo in disabled})
+        seen.add(repo)
+    for op in overlay["projects"]:
+        repo = op.get("repo")
+        if repo and repo not in seen:
+            out.append({**op, "source": "overlay", "disabled": False})
+            seen.add(repo)
+    return out
+
+
+# ── validation ────────────────────────────────────────────────────────
+
+def validate_entry(entry: dict) -> tuple[dict | None, str | None]:
+    """Validate/normalize an add request. Returns (cleaned_entry, error)."""
+    if not isinstance(entry, dict):
+        return None, "entry must be an object"
+    name = str(entry.get("name") or "").strip()
+    repo = str(entry.get("repo") or "").strip()
+    track = entry.get("track") or []
+    priority = str(entry.get("priority") or "medium").strip().lower()
+    notes = str(entry.get("notes") or "").strip()
+    urls = entry.get("urls") or []
+
+    if not name:
+        return None, "name is required"
+    if not _REPO_RE.match(repo):
+        return None, "repo must be in owner/repo form (not a URL)"
+    if not isinstance(track, list) or not track:
+        return None, "track must be a non-empty list"
+    bad_track = [t for t in track if t not in _VALID_TRACK]
+    if bad_track:
+        return None, f"invalid track values {bad_track}; allowed {sorted(_VALID_TRACK)}"
+    if priority not in _VALID_PRIORITY:
+        return None, f"priority must be one of {sorted(_VALID_PRIORITY)}"
+    if not isinstance(urls, list) or any(
+        not isinstance(u, str) or not u.startswith("https://") for u in urls
+    ):
+        return None, "urls must be a list of https:// strings"
+
+    cleaned: dict = {"name": name, "repo": repo, "track": list(track),
+                     "priority": priority}
+    if notes:
+        cleaned["notes"] = notes
+    if urls:
+        cleaned["urls"] = list(urls)
+    return cleaned, None
+
+
+# ── writes (overlay only) ─────────────────────────────────────────────
+
+def _write_overlay(overlay: dict) -> None:
+    """Atomically write the overlay (tmp + replace). Drops empty sections."""
+    import yaml
+    out: dict = {}
+    if overlay.get("projects"):
+        out["projects"] = overlay["projects"]
+    if overlay.get("disabled"):
+        out["disabled"] = overlay["disabled"]
+
+    LOCAL_PATH.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        dir=str(LOCAL_PATH.parent), prefix=".recon_watchlist.", suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write("# Install-specific recon watchlist overlay (gitignored).\n")
+            f.write("# 'projects' add tracked repos; 'disabled' tombstones base "
+                    "repos.\n")
+            f.write("# Managed by the dashboard → Knowledge → Tracked Repositories.\n")
+            if out:
+                yaml.safe_dump(out, f, sort_keys=False, default_flow_style=False)
+        os.replace(tmp, LOCAL_PATH)
+    except BaseException:
+        Path(tmp).unlink(missing_ok=True)
+        raise
+
+
+def add_repo(entry: dict) -> dict:
+    """Add an install-specific tracked repo to the overlay."""
+    cleaned, err = validate_entry(entry)
+    if err:
+        return {"error": err}
+    repo = cleaned["repo"]
+    existing = {p.get("repo") for p in load_base()}
+    overlay = load_overlay()
+    existing |= {p.get("repo") for p in overlay["projects"]}
+    if repo in existing:
+        return {"error": f"{repo} is already tracked"}
+    overlay["projects"].append(cleaned)
+    _write_overlay(overlay)
+    return {"ok": True, "repo": repo}
+
+
+def set_base_disabled(repo: str, disabled: bool) -> dict:
+    """Tombstone (disable) or re-enable a BASE watchlist entry via the overlay."""
+    if repo not in {p.get("repo") for p in load_base()}:
+        return {"error": f"{repo} is not a base watchlist entry"}
+    overlay = load_overlay()
+    dis = overlay["disabled"]
+    if disabled and repo not in dis:
+        dis.append(repo)
+    elif not disabled and repo in dis:
+        dis.remove(repo)
+    _write_overlay(overlay)
+    return {"ok": True, "repo": repo, "disabled": bool(disabled)}
+
+
+def remove_overlay_repo(repo: str) -> dict:
+    """Delete an install-added repo from the overlay. Base repos can only be
+    disabled (use ``set_base_disabled``), never deleted here."""
+    overlay = load_overlay()
+    kept = [p for p in overlay["projects"] if p.get("repo") != repo]
+    if len(kept) == len(overlay["projects"]):
+        return {"error": f"{repo} is not an install-added entry "
+                         "(base entries can only be disabled)"}
+    overlay["projects"] = kept
+    _write_overlay(overlay)
+    return {"ok": True, "repo": repo}

--- a/tests/test_dashboard/test_recon_watchlist_api.py
+++ b/tests/test_dashboard/test_recon_watchlist_api.py
@@ -1,0 +1,113 @@
+"""Tests for the dashboard recon-watchlist routes (list/add/disable/remove).
+
+The store functions are mocked — these cover routing, the auth gate on
+mutations, and error→422 mapping.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from genesis.dashboard.api import blueprint
+
+_WL = "genesis.recon.watchlist"
+_AUTH = "genesis.dashboard.routes.recon.is_authenticated"
+
+
+@pytest.fixture()
+def client():
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    app.config["TESTING"] = True
+    app.secret_key = "test-secret-key"
+    return app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def _authed():
+    with patch(_AUTH, return_value=True):
+        yield
+
+
+def test_list_returns_entries(client):
+    entries = [{"repo": "a/b", "source": "base", "disabled": False}]
+    with patch(f"{_WL}.list_entries", return_value=entries):
+        resp = client.get("/api/genesis/recon/watchlist")
+    assert resp.status_code == 200
+    assert resp.get_json()["entries"] == entries
+
+
+def test_list_survives_store_error(client):
+    with patch(f"{_WL}.list_entries", side_effect=RuntimeError("boom")):
+        resp = client.get("/api/genesis/recon/watchlist")
+    assert resp.status_code == 200 and resp.get_json()["entries"] == []
+
+
+def test_add_success(client):
+    with patch(f"{_WL}.add_repo", return_value={"ok": True, "repo": "a/b"}) as add:
+        resp = client.post("/api/genesis/recon/watchlist",
+                           json={"name": "X", "repo": "a/b",
+                                 "track": ["releases"], "priority": "low"})
+    assert resp.status_code == 200 and resp.get_json()["ok"] is True
+    assert add.call_args.args[0]["repo"] == "a/b"
+
+
+def test_add_validation_error_maps_422(client):
+    with patch(f"{_WL}.add_repo", return_value={"error": "bad"}):
+        resp = client.post("/api/genesis/recon/watchlist", json={"repo": "bad"})
+    assert resp.status_code == 422
+
+
+def test_disable_success(client):
+    with patch(f"{_WL}.set_base_disabled",
+               return_value={"ok": True, "repo": "a/b", "disabled": True}) as fn:
+        resp = client.post("/api/genesis/recon/watchlist/disable",
+                           json={"repo": "a/b", "disabled": True})
+    assert resp.status_code == 200
+    assert fn.call_args.args == ("a/b", True)
+
+
+def test_remove_success(client):
+    with patch(f"{_WL}.remove_overlay_repo",
+               return_value={"ok": True, "repo": "a/b"}) as fn:
+        resp = client.delete("/api/genesis/recon/watchlist", json={"repo": "a/b"})
+    assert resp.status_code == 200
+    assert fn.call_args.args == ("a/b",)
+
+
+def test_remove_base_error_maps_422(client):
+    with patch(f"{_WL}.remove_overlay_repo", return_value={"error": "base only"}):
+        resp = client.delete("/api/genesis/recon/watchlist", json={"repo": "x/y"})
+    assert resp.status_code == 422
+
+
+# ── auth gate on mutations ────────────────────────────────────────────
+@pytest.mark.parametrize("method,path", [
+    ("post", "/api/genesis/recon/watchlist"),
+    ("post", "/api/genesis/recon/watchlist/disable"),
+    ("delete", "/api/genesis/recon/watchlist"),
+])
+def test_mutations_require_auth(client, method, path):
+    with (
+        patch(_AUTH, return_value=False),
+        patch(f"{_WL}.add_repo") as add,
+        patch(f"{_WL}.set_base_disabled") as dis,
+        patch(f"{_WL}.remove_overlay_repo") as rem,
+    ):
+        resp = getattr(client, method)(path, json={"repo": "a/b"})
+    assert resp.status_code == 401
+    add.assert_not_called()
+    dis.assert_not_called()
+    rem.assert_not_called()
+
+
+def test_list_does_not_require_auth(client):
+    with (
+        patch(_AUTH, return_value=False),
+        patch(f"{_WL}.list_entries", return_value=[]),
+    ):
+        resp = client.get("/api/genesis/recon/watchlist")
+    assert resp.status_code == 200

--- a/tests/test_mcp/test_recon_sources.py
+++ b/tests/test_mcp/test_recon_sources.py
@@ -16,13 +16,17 @@ def source_files(tmp_path, monkeypatch):
     monkeypatch.setattr(recon_mcp, "_REPO_SOURCES", sources_path)
     monkeypatch.setattr(recon_mcp, "_USER_CONFIG_DIR", tmp_path)
 
+    # The watchlist now loads via the shared recon.watchlist store, so point
+    # its paths (not the removed recon_mcp._WATCHLIST_PATH) at the temp file.
+    from genesis.recon import watchlist as _watchlist
     watchlist_path = tmp_path / "recon_watchlist.yaml"
     watchlist_path.write_text(yaml.safe_dump({
         "projects": [
             {"name": "TestProject", "repo": "test/repo", "track": ["releases"], "priority": "high"},
         ]
     }))
-    monkeypatch.setattr(recon_mcp, "_WATCHLIST_PATH", watchlist_path)
+    monkeypatch.setattr(_watchlist, "WATCHLIST_PATH", watchlist_path)
+    monkeypatch.setattr(_watchlist, "LOCAL_PATH", tmp_path / "recon_watchlist.local.yaml")
     return sources_path
 
 

--- a/tests/test_recon/test_recon_gatherer.py
+++ b/tests/test_recon/test_recon_gatherer.py
@@ -1,32 +1,35 @@
-"""Tests for ReconGatherer watchlist path and release fetching."""
+"""Tests for the recon watchlist path resolution.
+
+The watchlist path now lives in the shared ``recon.watchlist`` store (the
+gatherer/MCP loaders delegate to it), so the path checks point there.
+"""
 
 from __future__ import annotations
 
-from genesis.recon.gatherer import _CONFIG_DIR, _WATCHLIST_PATH
+from genesis.recon.watchlist import WATCHLIST_PATH
 
 
 class TestWatchlistPath:
     """Verify the watchlist path resolves correctly."""
 
     def test_config_dir_points_to_project_root(self) -> None:
-        """_CONFIG_DIR should be <project_root>/config, not src/config."""
-        assert _CONFIG_DIR.name == "config"
+        """The watchlist lives in <project_root>/config, not src/config."""
+        config_dir = WATCHLIST_PATH.parent
+        assert config_dir.name == "config"
         # The parent of config/ should contain src/ (i.e., it's the project root)
-        assert (_CONFIG_DIR.parent / "src").is_dir(), (
-            f"_CONFIG_DIR parent {_CONFIG_DIR.parent} does not look like project root"
+        assert (config_dir.parent / "src").is_dir(), (
+            f"config dir parent {config_dir.parent} does not look like project root"
         )
 
     def test_watchlist_path_exists(self) -> None:
         """The watchlist YAML file should exist on disk."""
-        assert _WATCHLIST_PATH.exists(), (
-            f"Watchlist not found at {_WATCHLIST_PATH}"
-        )
+        assert WATCHLIST_PATH.exists(), f"Watchlist not found at {WATCHLIST_PATH}"
 
     def test_watchlist_is_yaml(self) -> None:
         """Watchlist file should be valid YAML with a 'projects' key."""
         import yaml
 
-        with open(_WATCHLIST_PATH) as f:
+        with open(WATCHLIST_PATH) as f:
             data = yaml.safe_load(f)
 
         assert isinstance(data, dict)

--- a/tests/test_recon/test_watchlist.py
+++ b/tests/test_recon/test_watchlist.py
@@ -1,0 +1,120 @@
+"""Tests for the shared recon watchlist store (base + overlay + tombstones)."""
+
+import pytest
+import yaml
+
+from genesis.recon import watchlist
+
+
+@pytest.fixture
+def wl(tmp_path, monkeypatch):
+    """Point the store at temp base/overlay files with a 2-entry base list."""
+    base = tmp_path / "recon_watchlist.yaml"
+    base.write_text(yaml.safe_dump({"projects": [
+        {"name": "Claude Code", "repo": "anthropics/claude-code",
+         "track": ["releases"], "priority": "high"},
+        {"name": "OpenClaw", "repo": "openclaw/openclaw",
+         "track": ["commits"], "priority": "medium"},
+    ]}))
+    monkeypatch.setattr(watchlist, "WATCHLIST_PATH", base)
+    monkeypatch.setattr(watchlist, "LOCAL_PATH",
+                        tmp_path / "recon_watchlist.local.yaml")
+    return watchlist
+
+
+def _repos(entries):
+    return [e["repo"] for e in entries]
+
+
+def test_active_entries_base_only(wl):
+    assert _repos(wl.active_entries()) == [
+        "anthropics/claude-code", "openclaw/openclaw"]
+
+
+def test_add_repo_appends_and_persists(wl):
+    r = wl.add_repo({"name": "Foo", "repo": "acme/foo",
+                     "track": ["releases", "stars"], "priority": "low"})
+    assert r == {"ok": True, "repo": "acme/foo"}
+    assert "acme/foo" in _repos(wl.active_entries())
+    assert wl.LOCAL_PATH.exists()           # overlay written
+    # Survives a re-read (atomic write produced valid YAML).
+    assert "acme/foo" in _repos(wl.active_entries())
+
+
+def test_add_repo_dedup_against_base_and_overlay(wl):
+    assert "error" in wl.add_repo({"name": "x", "repo": "openclaw/openclaw",
+                                   "track": ["commits"], "priority": "low"})
+    wl.add_repo({"name": "Foo", "repo": "acme/foo",
+                 "track": ["releases"], "priority": "low"})
+    assert "error" in wl.add_repo({"name": "y", "repo": "acme/foo",
+                                   "track": ["releases"], "priority": "low"})
+
+
+@pytest.mark.parametrize("entry", [
+    {"name": "", "repo": "a/b", "track": ["commits"], "priority": "low"},
+    {"name": "x", "repo": "not-a-repo", "track": ["commits"], "priority": "low"},
+    {"name": "x", "repo": "https://github.com/a/b", "track": ["commits"], "priority": "low"},
+    {"name": "x", "repo": "a/b", "track": [], "priority": "low"},
+    {"name": "x", "repo": "a/b", "track": ["bogus"], "priority": "low"},
+    {"name": "x", "repo": "a/b", "track": ["commits"], "priority": "urgent"},
+    {"name": "x", "repo": "a/b", "track": ["commits"], "priority": "low",
+     "urls": ["http://insecure"]},
+])
+def test_add_repo_validation_rejects(wl, entry):
+    assert "error" in wl.add_repo(entry)
+
+
+def test_disable_base_tombstones_and_reenable(wl):
+    r = wl.set_base_disabled("openclaw/openclaw", True)
+    assert r["disabled"] is True
+    assert "openclaw/openclaw" not in _repos(wl.active_entries())
+    # Still visible in the editor view, flagged disabled.
+    le = {e["repo"]: e for e in wl.list_entries()}
+    assert le["openclaw/openclaw"]["disabled"] is True
+    assert le["openclaw/openclaw"]["source"] == "base"
+    # Re-enable restores it.
+    wl.set_base_disabled("openclaw/openclaw", False)
+    assert "openclaw/openclaw" in _repos(wl.active_entries())
+
+
+def test_disable_rejects_non_base(wl):
+    wl.add_repo({"name": "Foo", "repo": "acme/foo",
+                 "track": ["releases"], "priority": "low"})
+    assert "error" in wl.set_base_disabled("acme/foo", True)
+
+
+def test_remove_overlay_repo(wl):
+    wl.add_repo({"name": "Foo", "repo": "acme/foo",
+                 "track": ["releases"], "priority": "low"})
+    assert wl.remove_overlay_repo("acme/foo")["ok"] is True
+    assert "acme/foo" not in _repos(wl.active_entries())
+
+
+def test_remove_rejects_base_entry(wl):
+    # Base entries can only be disabled, never deleted via the overlay.
+    assert "error" in wl.remove_overlay_repo("openclaw/openclaw")
+
+
+def test_list_entries_marks_source(wl):
+    wl.add_repo({"name": "Foo", "repo": "acme/foo",
+                 "track": ["releases"], "priority": "low"})
+    src = {e["repo"]: e["source"] for e in wl.list_entries()}
+    assert src["anthropics/claude-code"] == "base"
+    assert src["acme/foo"] == "overlay"
+
+
+# ── loader unification (the bug this PR closes) ───────────────────────
+
+
+def test_gatherer_loader_sees_overlay(wl):
+    from genesis.recon.gatherer import ReconGatherer
+    wl.add_repo({"name": "Foo", "repo": "acme/foo",
+                 "track": ["releases"], "priority": "low"})
+    assert "acme/foo" in _repos(ReconGatherer._load_watchlist())
+
+
+def test_mcp_loader_respects_tombstone(wl):
+    from genesis.mcp.recon_mcp import _load_watchlist
+    wl.set_base_disabled("openclaw/openclaw", True)
+    # Previously the MCP loader read base-only and would still show this.
+    assert "openclaw/openclaw" not in _repos(_load_watchlist())


### PR DESCRIPTION
## Problem
The recon **watchlist** (the tracked GitHub repos Genesis monitors — Claude Code, OpenClaw, etc.) was immutable and only visible read-only under the Config tab. The user expected to see/modify it on the **Knowledge tab** and couldn't.

Separately, the two watchlist loaders had **diverged**: the recon MCP read the base file only, so any overlay edit was invisible to the `recon_config` view.

## What it does
- **New `src/genesis/recon/watchlist.py`** — single source of truth. Base (committed `config/recon_watchlist.yaml`) + gitignored `.local` overlay that ADDS install repos (`projects`) and TOMBSTONES base repos (`disabled`). `active_entries()` (base − disabled + overlay) is what the gatherer/discovery/MCP consume; `list_entries()` is the annotated editor view. Writes touch the overlay only (atomic tmp+replace), with validation (`owner/repo` regex, track subset, priority, https urls) and dedup.
- **Full edit (incl. base)**: base entries can be **disabled/re-enabled** (tombstone), install-added repos **removed**. The committed base is never modified, so `git pull` stays clean.
- **Loader unification (bug fix)**: `ReconGatherer._load_watchlist` and `recon_mcp._load_watchlist` now both delegate to `watchlist.active_entries()`, so the gatherer, the MCP `recon_config` view, and GitHub Discovery all agree on one merged-and-tombstoned list. Removes now-dead path constants.
- **Routes** (`routes/recon.py`): GET list (open, non-sensitive) + POST add / POST disable / DELETE remove, each gated behind `is_authenticated()` (a no-op when no dashboard password is set). The recon **MCP watchlist stays read-only by design** — the dashboard is the only write surface, so an autonomous loop can't rewrite its own recon targets.
- **UI**: a "Tracked Repositories" panel on the Knowledge tab — base entries (lock icon) with Enable/Disable, install-added entries with Remove, and an add form.

## Tests
- Store: base/overlay merge, tombstone exclusion + re-enable, dedup, validation matrix, atomic persist round-trip, source annotation.
- Loader delegation: gatherer now sees overlay adds; MCP loader now respects tombstones (the bug this closes).
- Routes: auth gate on all mutations, list stays open, error→422 mapping.
82 recon tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)