### PR TITLE
feat(experimentation): Evo loop core + CC-CLI provider (recommend-only)

### DIFF
--- a/src/genesis/experimentation/cc_router.py
+++ b/src/genesis/experimentation/cc_router.py
@@ -1,0 +1,117 @@
+"""CC-CLI router — run the experiment harness's generation/judging through the
+``claude`` CLI (the Claude Code subscription) instead of a litellm API provider.
+
+Why: the offline harness routes via litellm, but OpenRouter (which fronts the
+Claude providers) is out of credits and the direct Anthropic API is off-limits.
+The ``claude`` CLI uses the subscription and is the live path Genesis already
+uses for deep reflection — so it's both available and representative.
+
+Drop-in: ``route_call(call_site_id, messages) -> StandaloneRoutingResult`` — the
+same shape ``StandaloneLiteLLMRouter`` returns, so it works as both the
+generation router and the judge's router (``LLMJudgeScorer(router=...)``).
+Single-completion only (``-p``); no tools, no session resume.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+
+from genesis.experimentation.standalone_router import StandaloneRoutingResult
+
+logger = logging.getLogger(__name__)
+
+_VALID_MODELS = {"haiku", "sonnet", "opus"}
+
+
+class CCCliRouter:
+    """Invoke ``claude -p`` per call as a single-shot completion provider."""
+
+    def __init__(self, model: str = "haiku", *, timeout_s: float = 180.0):
+        m = model.lower().removeprefix("cc-")
+        if m not in _VALID_MODELS:
+            raise ValueError(f"CCCliRouter model must be one of {_VALID_MODELS}, got {model!r}")
+        self._model = m
+        self._timeout_s = timeout_s
+
+    async def route_call(
+        self, call_site_id: str, messages: list[dict], **_kwargs,
+    ) -> StandaloneRoutingResult:
+        # **_kwargs: tolerate API-shaped args (temperature, etc.) the judge/harness
+        # may pass — the CLI doesn't take them.
+        system = "\n\n".join(m["content"] for m in messages if m.get("role") == "system").strip()
+        user = "\n\n".join(m["content"] for m in messages if m.get("role") == "user").strip() or " "
+
+        args = [
+            "claude", "-p",
+            "--model", self._model,
+            "--output-format", "text",
+            "--dangerously-skip-permissions",  # non-interactive, no permission prompts
+            # Force a PURE single-turn completion: with tools enabled, claude -p
+            # goes agentic (explores logs/files) instead of reflecting on the
+            # given text — slow + off-task. Disable the built-in tools.
+            "--disallowedTools",
+            "Bash,Read,Write,Edit,MultiEdit,Glob,Grep,LS,WebFetch,WebSearch,Task,"
+            "TodoWrite,NotebookEdit,NotebookRead,ExitPlanMode",
+            "--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}',  # no MCP tools
+            # Suppress SessionStart/UserPromptSubmit hooks (gstack/genesis inject
+            # skill-lists + preambles that contaminate a bare completion).
+            "--settings", '{"hooks":{}}',
+        ]
+        if system:
+            # Replace (not append) — the variant's system prompt IS the system.
+            args += ["--system-prompt", system]
+
+        env = dict(os.environ)
+        # Avoid CC-in-CC nesting confusion (mirrors CCInvoker._build_env).
+        env.pop("CLAUDECODE", None)
+        env.pop("CLAUDE_CODE_ENTRYPOINT", None)
+        # Mark as a Genesis-dispatched session so the SessionStart hooks skip
+        # identity/context injection — we want a clean completion on the given
+        # text, not Genesis's project context bleeding into the reflection.
+        env["GENESIS_CC_SESSION"] = "1"
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+            out, err = await asyncio.wait_for(
+                proc.communicate(input=user.encode()), timeout=self._timeout_s,
+            )
+        except TimeoutError:
+            logger.warning("cc-cli %s timed out after %ss", self._model, self._timeout_s)
+            # Reap the orphaned claude process (else it keeps running + holds a
+            # subscription slot). Mirrors CCInvoker's timeout handling.
+            with contextlib.suppress(ProcessLookupError, OSError):
+                proc.kill()
+            with contextlib.suppress(Exception):
+                await proc.wait()
+            return StandaloneRoutingResult(
+                success=False, content=None, model_id=self._model,
+                provider_used="cc-cli", error="timeout",
+            )
+        except Exception as exc:  # noqa: BLE001 — subprocess spawn failure → failed result
+            logger.warning("cc-cli %s invocation failed", self._model, exc_info=True)
+            return StandaloneRoutingResult(
+                success=False, content=None, model_id=self._model,
+                provider_used="cc-cli", error=str(exc),
+            )
+
+        content = out.decode(errors="replace").strip()
+        ok = proc.returncode == 0 and bool(content)
+        return StandaloneRoutingResult(
+            success=ok,
+            content=content if ok else None,
+            model_id=self._model,
+            provider_used="cc-cli",
+            error=None if ok else (err.decode(errors="replace")[:300] or f"exit {proc.returncode}"),
+        )
+
+    async def close(self) -> None:  # interface parity with StandaloneLiteLLMRouter
+        return None

--- a/src/genesis/experimentation/evo.py
+++ b/src/genesis/experimentation/evo.py
@@ -1,0 +1,310 @@
+"""Evo — the evolution loop on top of Crucible (recommend-only, measure-only).
+
+Fans out N reflection-PROMPT variants, tests each independently vs a shared
+control via ``run_reflection_experiment``, keeps only those that beat control at
+a **Bonferroni-corrected** threshold (alpha / N), picks the best survivor, then
+**re-validates it on a disjoint held-out golden slice** before declaring a
+winner. The held-out pass + the corrected threshold are the winner's-curse /
+multiple-comparison defenses — they reduce, not eliminate, the inflated
+false-positive rate of "pick the best of N". This is acceptable because Evo is
+**recommend-only**: it surfaces a recommendation; a human gates any promotion.
+It NEVER mutates cognition.
+
+Cost is bounded deterministically by fan-out: at most
+``len(candidates) * eval_limit + holdout_limit`` reflection generations (×2 for
+judging), on free providers, on demand. (USD accounting is a later refinement —
+``run_reflection_experiment`` does not surface per-call cost today.)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from genesis.eval.calibration import _load_golden_set
+from genesis.experimentation.types import CognitiveVariant
+
+logger = logging.getLogger(__name__)
+
+_TMP_DIR = os.path.expanduser("~/tmp")
+
+
+@dataclass(frozen=True)
+class EvoConfig:
+    eval_limit: int = 30          # golden cases per fan-out experiment (M)
+    holdout_limit: int = 20       # disjoint cases for winner re-validation
+    alpha: float = 0.05           # family-wise target; per-test gate = alpha / N
+    gen_provider: str = "groq-free"
+    judge_provider: str = "groq-free"
+
+
+@dataclass(frozen=True)
+class EvoResult:
+    winner: CognitiveVariant | None
+    winner_winrate: dict[str, Any] | None
+    holdout_winrate: dict[str, Any] | None
+    candidates_evaluated: int
+    survivors: int
+    note: str
+    holdout_disjoint: bool = True  # False when the golden set was too small to hold out
+    per_candidate: list[dict[str, Any]] = field(default_factory=list)
+
+
+# Fixed mutation directives appended to the base prompt to form variants.
+# DIRECTIVE-APPEND (not full LLM rewrite): deterministic, no generation LLM call,
+# and zero truncation risk on the large (~13KB) base prompt — the exact pattern
+# the Crucible foundation E2E proved (control + an appended steering directive).
+# A multi-generation Evo may later LLM-propose novel directives.
+_VARIATION_DIRECTIVES = (
+    "For this reflection, be more concise and direct; cut filler.",
+    "For this reflection, push for deeper, non-obvious patterns rather than surface restatement.",
+    "For this reflection, add explicit step-by-step structure to the analysis.",
+    "For this reflection, prioritize — surface the single most important thing first, plainly.",
+    "For this reflection, be more skeptical: challenge assumptions and hunt for contradictions.",
+    "For this reflection, favor concrete, actionable observations over abstract ones.",
+)
+
+
+def build_directive_variants(base_prompt: str, n: int) -> list[CognitiveVariant]:
+    """Build up to ``n`` variants by appending a fixed mutation directive to the
+    base prompt. Deterministic — NO LLM call, no truncation risk. Each variant is
+    ``base_prompt`` + one directive (capped at the number of directives)."""
+    variants: list[CognitiveVariant] = []
+    for i in range(min(max(0, n), len(_VARIATION_DIRECTIVES))):
+        directive = _VARIATION_DIRECTIVES[i]
+        variants.append(CognitiveVariant(
+            name=f"evo_v{i}",
+            description=directive,
+            system_prompt=f"{base_prompt}\n\n{directive}",
+        ))
+    return variants
+
+
+def _write_slice(cases: list[dict], suffix: str) -> Path:
+    os.makedirs(_TMP_DIR, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=f"_{suffix}.jsonl", dir=_TMP_DIR, delete=False,
+    ) as fh:
+        for case in cases:
+            fh.write(json.dumps(case) + "\n")
+        return Path(fh.name)
+
+
+def _split_golden_set(
+    path: Path, eval_limit: int, holdout_limit: int,
+) -> tuple[Path, Path, bool]:
+    """Split the golden set into a fan-out slice (first ``eval_limit``) and a
+    held-out slice (the next ``holdout_limit``). Returns ``(eval_path,
+    holdout_path, disjoint)`` — ``disjoint`` is False when the golden set was too
+    small to hold out and the held-out slice reuses the eval tail (degraded
+    winner's-curse defense; surfaced to the caller, not hidden)."""
+    cases = _load_golden_set(path)
+    if not cases:
+        raise ValueError(f"golden set {path} has no cases")
+    eval_cases = cases[:eval_limit]
+    holdout_cases = cases[eval_limit:eval_limit + holdout_limit]
+    disjoint = bool(holdout_cases)
+    if not holdout_cases:
+        logger.warning(
+            "evo: golden set %s too small for a disjoint held-out slice "
+            "(have %d, eval_limit=%d) — re-validating on the eval tail (NOT disjoint)",
+            path, len(cases), eval_limit,
+        )
+        holdout_cases = eval_cases[-max(1, holdout_limit):]
+    return (
+        _write_slice(eval_cases, "eval"),
+        _write_slice(holdout_cases, "holdout"),
+        disjoint,
+    )
+
+
+def _passes_gate(winrate: dict, threshold: float) -> bool:
+    p = winrate.get("p_value")
+    return (
+        winrate.get("recommendation") == "treatment_wins"
+        and p is not None
+        and p <= threshold
+    )
+
+
+async def run_evo(
+    *,
+    base: CognitiveVariant,
+    candidates: list[CognitiveVariant],
+    golden_set_path: Path,
+    config: EvoConfig | None = None,
+    gen_router: object | None = None,
+    judge: object | None = None,
+) -> EvoResult:
+    """Run one Evo generation over prompt ``candidates`` vs ``base``.
+
+    Recommend-only: returns the best variant that beats control at alpha/N AND
+    survives held-out re-validation, or ``winner=None``. Mutates nothing.
+    """
+    if config is None:
+        config = EvoConfig()
+    n = len(candidates)
+    if n == 0:
+        return EvoResult(
+            winner=None, winner_winrate=None, holdout_winrate=None,
+            candidates_evaluated=0, survivors=0, note="no candidates",
+        )
+
+    from genesis.experimentation import runner as _runner
+
+    eval_path, holdout_path, holdout_disjoint = _split_golden_set(
+        golden_set_path, config.eval_limit, config.holdout_limit,
+    )
+    threshold = config.alpha / n  # Bonferroni
+    survivors: list[tuple[CognitiveVariant, Any]] = []
+    per_candidate: list[dict[str, Any]] = []
+    try:
+        for cand in candidates:
+            try:
+                res = await _runner.run_reflection_experiment(
+                    experiment_name=f"evo:{cand.name}",
+                    control=base,
+                    treatment=cand,
+                    golden_set_path=eval_path,
+                    gen_provider=config.gen_provider,
+                    judge_provider=config.judge_provider,
+                    limit=config.eval_limit,
+                    gen_router=gen_router,
+                    judge=judge,
+                )
+            except Exception:  # noqa: BLE001 — one bad variant must not abort the run
+                logger.warning("evo: variant %s failed", cand.name, exc_info=True)
+                per_candidate.append({"variant": cand.name, "error": True})
+                continue
+            wr = res.winrate or {}
+            survived = _passes_gate(wr, threshold)
+            per_candidate.append({
+                "variant": cand.name,
+                "recommendation": wr.get("recommendation"),
+                "p_value": wr.get("p_value"),
+                "mean_score": res.treatment.mean_score,
+                "survived_gate": survived,
+            })
+            if survived:
+                survivors.append((cand, res))
+
+        if not survivors:
+            return EvoResult(
+                winner=None, winner_winrate=None, holdout_winrate=None,
+                candidates_evaluated=n, survivors=0,
+                note=f"no variant beat control at alpha/N={threshold:.4f}",
+                holdout_disjoint=holdout_disjoint,
+                per_candidate=per_candidate,
+            )
+
+        best_cand, best_res = max(survivors, key=lambda cr: cr[1].treatment.mean_score)
+
+        # Winner's-curse defense: re-validate the best on the disjoint held-out slice.
+        try:
+            hold = await _runner.run_reflection_experiment(
+                experiment_name=f"evo:holdout:{best_cand.name}",
+                control=base,
+                treatment=best_cand,
+                golden_set_path=holdout_path,
+                gen_provider=config.gen_provider,
+                judge_provider=config.judge_provider,
+                limit=config.holdout_limit,
+                gen_router=gen_router,
+                judge=judge,
+            )
+            hwr = hold.winrate or {}
+        except Exception:  # noqa: BLE001
+            logger.warning("evo: held-out re-validation failed", exc_info=True)
+            hwr = {}
+
+        # Held-out re-validation is a SINGLE comparison → gate on the uncorrected
+        # alpha explicitly (not the baked-in `significant`, which is also α=0.05
+        # but would silently diverge if the fan-out's α/N is read as the bar).
+        hp = hwr.get("p_value")
+        confirmed = (
+            hwr.get("recommendation") == "treatment_wins"
+            and hp is not None
+            and hp <= config.alpha
+        )
+        winner = best_cand if confirmed else None
+        note = (
+            f"winner {best_cand.name} confirmed on held-out slice"
+            if confirmed
+            else f"best survivor {best_cand.name} did NOT survive held-out re-validation"
+        )
+        if confirmed and not holdout_disjoint:
+            note += " (WARNING: held-out slice was NOT disjoint — golden set too small)"
+        return EvoResult(
+            winner=winner,
+            winner_winrate=best_res.winrate,
+            holdout_winrate=hwr,
+            candidates_evaluated=n,
+            survivors=len(survivors),
+            note=note,
+            holdout_disjoint=holdout_disjoint,
+            per_candidate=per_candidate,
+        )
+    finally:
+        for p in (eval_path, holdout_path):
+            with contextlib.suppress(OSError):
+                p.unlink()
+
+
+async def persist_evo_summary(
+    db: object,
+    result: EvoResult,
+    *,
+    gen_provider: str,
+    judge_provider: str,
+    label: str,
+) -> str:
+    """Write ONE ``eval_runs`` summary row for an Evo run (history/audit).
+
+    Reuses ``trigger=EXPERIMENT`` (no enum/migration change) with a
+    ``kind='evo_summary'`` metadata marker + an ``evo:reflection:`` dataset, so
+    ``experiment_status`` surfaces it under ``evo_runs`` without polluting the
+    2-arm experiments list. Run-level summary only (winner + survivors +
+    per-candidate scores) — NOT the N+1 fan-out rows.
+    """
+    import uuid as _uuid
+
+    from genesis.eval.db import insert_run
+    from genesis.eval.types import EvalRunSummary, EvalTrigger, TaskCategory
+
+    run_id = _uuid.uuid4().hex
+    w = result.winner
+    winner_mean = (result.winner_winrate or {}).get("treatment_mean_score") or 0.0
+    await insert_run(db, EvalRunSummary(
+        run_id=run_id,
+        model_id=judge_provider,
+        model_profile="evo_summary",
+        dataset=f"evo:reflection:{label}",
+        trigger=EvalTrigger.EXPERIMENT,
+        task_category=TaskCategory.REASONING,
+        total_cases=result.candidates_evaluated,
+        passed_cases=result.survivors,
+        failed_cases=max(0, result.candidates_evaluated - result.survivors),
+        aggregate_score=winner_mean,
+        metadata={
+            "kind": "evo_summary",
+            "winner": (w.name if w else None),
+            "winner_approach": (w.description if w else None),
+            "survivors": result.survivors,
+            "candidates_evaluated": result.candidates_evaluated,
+            "holdout_disjoint": result.holdout_disjoint,
+            "winner_winrate": result.winner_winrate,
+            "holdout_winrate": result.holdout_winrate,
+            "per_candidate": result.per_candidate,
+            "note": result.note,
+            "gen_provider": gen_provider,
+            "judge_provider": judge_provider,
+        },
+        results=[],
+    ))
+    return run_id

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -66,6 +66,7 @@ from genesis.mcp.health import direct_session_tools as _direct_session_tools  # 
 from genesis.mcp.health import ego_calibration as _ego_calibration  # noqa: E402, F401
 from genesis.mcp.health import ego_tools as _ego_tools  # noqa: E402
 from genesis.mcp.health import errors as _errors  # noqa: E402
+from genesis.mcp.health import evo_run as _evo_run  # noqa: E402, F401
 from genesis.mcp.health import experiment_run as _experiment_run  # noqa: E402, F401
 from genesis.mcp.health import experiment_status as _experiment_status  # noqa: E402, F401
 from genesis.mcp.health import follow_up_tools as _follow_up_tools  # noqa: E402

--- a/src/genesis/mcp/health/evo_run.py
+++ b/src/genesis/mcp/health/evo_run.py
@@ -1,0 +1,220 @@
+"""evo_run MCP tool — run one Evo generation and recommend the winner.
+
+Generates N diverse variants of the current deep-reflection prompt, tests each
+vs the current prompt over the golden set (Bonferroni alpha/N gate + held-out
+re-validation), and RETURNS the best confirmed variant as a recommendation.
+
+RECOMMEND-ONLY: it measures and recommends; it does NOT promote/apply anything
+(no overlay write, no proposal). ``autonomous_action`` is always False. The
+promotion path (a human-gated cognitive_variant_promotion proposal) is separate
+future work.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_GEN_PROVIDER = "groq-free"
+_DEFAULT_JUDGE_PROVIDER = "groq-free"
+
+
+def _make_router(provider: str, config, delegate):
+    """A ``cc-haiku``/``cc-sonnet`` provider → CC-CLI (subscription); otherwise a
+    litellm provider from model_routing.yaml."""
+    if provider.startswith("cc-"):
+        from genesis.experimentation.cc_router import CCCliRouter
+
+        return CCCliRouter(provider)
+    from genesis.experimentation.standalone_router import StandaloneLiteLLMRouter
+
+    return StandaloneLiteLLMRouter(provider, config=config, delegate=delegate)
+
+
+def _build_routers(gen_provider: str, judge_provider: str):
+    """Build (gen_router, judge_router, judge). Isolated so tests can stub it.
+
+    Supports CC-CLI providers (`cc-haiku`/`cc-sonnet`) for when the litellm
+    Claude providers (OpenRouter) are unavailable.
+    """
+    from genesis.eval.scorers import LLMJudgeScorer
+
+    config = delegate = None
+    # litellm config/delegate only needed if a non-CC provider is used
+    if not (gen_provider.startswith("cc-") and judge_provider.startswith("cc-")):
+        from genesis.experimentation.standalone_router import _default_config_path
+        from genesis.routing.config import load_config
+        from genesis.routing.litellm_delegate import LiteLLMDelegate
+
+        config = load_config(_default_config_path())
+        delegate = LiteLLMDelegate(config)
+
+    gen_router = _make_router(gen_provider, config, delegate)
+    judge_router = _make_router(judge_provider, config, delegate)
+    return gen_router, judge_router, LLMJudgeScorer(router=judge_router)
+
+
+def _resolve_base_prompt() -> str:
+    """The current EFFECTIVE deep-reflection prompt (overlay-aware)."""
+    from genesis.awareness.types import Depth
+    from genesis.cc.reflection_bridge._bridge import _DEFAULT_PROMPT_DIR
+    from genesis.cc.reflection_bridge._prompts import system_prompt_for_depth
+
+    return system_prompt_for_depth(Depth.DEEP, _DEFAULT_PROMPT_DIR)
+
+
+async def _impl_evo_run(
+    *,
+    base_prompt: str | None = None,
+    n_variants: int = 6,
+    eval_limit: int = 30,
+    holdout_limit: int = 20,
+    gen_provider: str = _DEFAULT_GEN_PROVIDER,
+    judge_provider: str = _DEFAULT_JUDGE_PROVIDER,
+    golden_set_path: str | None = None,
+) -> dict:
+    if golden_set_path:
+        gs = Path(golden_set_path)
+    else:
+        from genesis.eval.reflection_golden_set import DEFAULT_OUTPUT
+
+        gs = DEFAULT_OUTPUT
+    if not gs.exists():
+        return {
+            "status": "error",
+            "message": (
+                f"golden set not found: {gs}. Generate it with: "
+                "python -m genesis.eval.reflection_golden_set --count 150"
+            ),
+        }
+
+    if not base_prompt:
+        try:
+            base_prompt = _resolve_base_prompt()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("evo_run: could not resolve base prompt", exc_info=True)
+            return {"status": "error", "message": f"base prompt unavailable: {exc}"}
+
+    n_variants = max(1, min(n_variants, 12))  # hard fan-out cap (cost bound)
+
+    from genesis.experimentation import evo as _evo
+    from genesis.experimentation.types import CognitiveVariant
+
+    # Deterministic directive-append — no generation LLM call, no truncation.
+    candidates = _evo.build_directive_variants(base_prompt, n_variants)
+    if not candidates:
+        return {"status": "error", "message": "no variants to evaluate (n_variants must be >= 1)"}
+
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    _service = getattr(health_mcp_mod, "_service", None)
+    db = getattr(_service, "_db", None) if _service is not None else None
+
+    gen_router, judge_router, judge = _build_routers(gen_provider, judge_provider)
+    try:
+        base = CognitiveVariant(
+            name="current", description="current effective deep-reflection prompt",
+            system_prompt=base_prompt,
+        )
+        result = await _evo.run_evo(
+            base=base,
+            candidates=candidates,
+            golden_set_path=gs,
+            config=_evo.EvoConfig(
+                eval_limit=eval_limit, holdout_limit=holdout_limit,
+                gen_provider=gen_provider, judge_provider=judge_provider,
+            ),
+            gen_router=gen_router,
+            judge=judge,
+        )
+    except Exception as exc:  # noqa: BLE001 — never crash the tool
+        logger.warning("evo_run failed", exc_info=True)
+        return {"status": "error", "message": f"{type(exc).__name__}: {exc}"}
+    finally:
+        import contextlib
+
+        for r in (gen_router, judge_router):
+            with contextlib.suppress(Exception):
+                await r.close()
+
+    # Best-effort one-row summary for history (recommend-only — no cognition write).
+    persisted_run_id = None
+    if db is not None:
+        import uuid as _uuid
+
+        try:
+            persisted_run_id = await _evo.persist_evo_summary(
+                db, result, gen_provider=gen_provider, judge_provider=judge_provider,
+                label=_uuid.uuid4().hex[:8],
+            )
+        except Exception:  # noqa: BLE001 — persistence is non-fatal
+            logger.warning("evo_run: summary persistence failed", exc_info=True)
+
+    w = result.winner
+    return {
+        "status": "ok",
+        "autonomous_action": False,
+        "winner": (
+            {
+                "name": w.name,
+                "approach": w.description,
+                "prompt_preview": w.system_prompt[:300],
+                "full_prompt": w.system_prompt,
+            }
+            if w else None
+        ),
+        "winner_winrate": result.winner_winrate,
+        "holdout_winrate": result.holdout_winrate,
+        "candidates_evaluated": result.candidates_evaluated,
+        "survivors": result.survivors,
+        "holdout_disjoint": result.holdout_disjoint,
+        "per_candidate": result.per_candidate,
+        "note": result.note,
+        "persisted_run_id": persisted_run_id,
+        "recommend_only": (
+            "Evo measured the variants and recommends the winner (if any). It does "
+            "NOT promote — apply manually by writing the prompt to "
+            "~/.genesis/config/reflection/REFLECTION_DEEP.md, or via the future "
+            "human-gated cognitive_variant_promotion proposal."
+        ),
+    }
+
+
+@mcp.tool()
+async def evo_run(
+    base_prompt: str = "",
+    n_variants: int = 6,
+    eval_limit: int = 30,
+    holdout_limit: int = 20,
+    gen_provider: str = _DEFAULT_GEN_PROVIDER,
+    judge_provider: str = _DEFAULT_JUDGE_PROVIDER,
+    golden_set_path: str = "",
+) -> dict:
+    """Evolve the deep-reflection prompt: generate N variants, A/B each vs the
+    current prompt, and recommend the best confirmed winner.
+
+    RECOMMEND-ONLY — measures + recommends, never promotes (autonomous_action
+    False). Bounded cost: <= n_variants*eval_limit + holdout_limit generations
+    (x2 for judging), on free providers, on demand.
+
+    Args:
+        base_prompt: prompt to evolve (default: the current effective deep
+            reflection prompt, overlay-aware).
+        n_variants: fan-out (capped 1..12).
+        eval_limit / holdout_limit: golden cases for fan-out / held-out
+            re-validation (disjoint slices).
+        gen_provider / judge_provider: routing-config providers (default free).
+    """
+    return await _impl_evo_run(
+        base_prompt=base_prompt or None,
+        n_variants=n_variants,
+        eval_limit=eval_limit,
+        holdout_limit=holdout_limit,
+        gen_provider=gen_provider,
+        judge_provider=judge_provider,
+        golden_set_path=golden_set_path or None,
+    )

--- a/src/genesis/mcp/health/experiment_status.py
+++ b/src/genesis/mcp/health/experiment_status.py
@@ -43,8 +43,23 @@ async def _impl_experiment_status(limit: int = 10) -> dict:
     by_id = {r["id"]: r for r in rows}
 
     experiments = []
+    evo_runs = []
     for r in rows:
         meta = _meta(r)
+        if meta.get("kind") == "evo_summary":
+            # Evo loop run summary (one row per run) — surfaced separately.
+            if len(evo_runs) < limit:
+                evo_runs.append({
+                    "evo_run": r.get("dataset"),  # "evo:reflection:<id>"
+                    "created_at": r.get("created_at"),
+                    "winner": meta.get("winner"),
+                    "winner_approach": meta.get("winner_approach"),
+                    "survivors": meta.get("survivors"),
+                    "candidates_evaluated": meta.get("candidates_evaluated"),
+                    "holdout_disjoint": meta.get("holdout_disjoint"),
+                    "note": meta.get("note"),
+                })
+            continue
         if meta.get("arm") != "treatment":
             continue  # the treatment row carries the comparison + win-rate
         control = by_id.get(r.get("comparison_run_id")) or {}
@@ -75,6 +90,7 @@ async def _impl_experiment_status(limit: int = 10) -> dict:
         "status": "ok",
         "autonomous_action": False,
         "experiments": experiments,
+        "evo_runs": evo_runs,
         "note": (
             "Recommend-only: the harness NEVER promotes a variant. Act on a "
             "recommendation manually — settings_update for flag knobs, "

--- a/tests/test_experimentation/test_cc_router.py
+++ b/tests/test_experimentation/test_cc_router.py
@@ -1,0 +1,107 @@
+"""Hermetic tests for CCCliRouter — the claude-CLI completion provider.
+
+The subprocess is mocked, so these exercise arg-shaping, result mapping, and
+the failure/kwargs paths without spawning `claude`.
+"""
+
+import asyncio
+
+import pytest
+
+from genesis.experimentation.cc_router import CCCliRouter
+
+
+class _FakeProc:
+    def __init__(self, out=b"OUT", err=b"", rc=0):
+        self._out = out
+        self._err = err
+        self.returncode = rc
+
+    async def communicate(self, input=None):
+        return self._out, self._err
+
+
+def test_model_normalization_and_validation():
+    assert CCCliRouter("cc-haiku")._model == "haiku"
+    assert CCCliRouter("cc-sonnet")._model == "sonnet"
+    assert CCCliRouter("HAIKU")._model == "haiku"
+    with pytest.raises(ValueError):
+        CCCliRouter("gpt-4")
+
+
+async def test_route_call_success(monkeypatch):
+    captured = {}
+
+    async def fake_exec(*args, **kw):
+        captured["args"] = args
+        return _FakeProc(out=b'```json\n{"observations":["x"]}\n```')
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    r = CCCliRouter("cc-haiku")
+    # temperature kwarg must be tolerated (judge/harness pass API-shaped args)
+    res = await r.route_call(
+        "gen",
+        [{"role": "system", "content": "SYS"}, {"role": "user", "content": "USR"}],
+        temperature=0.3,
+    )
+    assert res.success is True
+    assert "observations" in res.content
+    assert res.provider_used == "cc-cli"
+    assert res.model_id == "haiku"
+    # claude CLI invoked with the right shape
+    args = captured["args"]
+    assert args[0] == "claude" and "-p" in args
+    assert "--model" in args and "haiku" in args
+    assert "--system-prompt" in args  # system message → --system-prompt
+
+
+async def test_route_call_failure_nonzero_exit(monkeypatch):
+    async def fake_exec(*a, **k):
+        return _FakeProc(out=b"", err=b"kaboom", rc=1)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    res = await CCCliRouter("haiku").route_call("gen", [{"role": "user", "content": "U"}])
+    assert res.success is False
+    assert res.content is None
+    assert res.error
+
+
+async def test_route_call_subprocess_raises(monkeypatch):
+    async def boom(*a, **k):
+        raise OSError("no claude binary")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", boom)
+
+    res = await CCCliRouter("haiku").route_call("gen", [{"role": "user", "content": "U"}])
+    assert res.success is False
+    assert "no claude binary" in (res.error or "")
+
+
+async def test_route_call_timeout_kills_subprocess(monkeypatch):
+    killed = {"v": False}
+
+    class _HangProc:
+        returncode = None
+
+        async def communicate(self, input=None):
+            await asyncio.sleep(10)  # exceed the tiny timeout
+
+        def kill(self):
+            killed["v"] = True
+
+        async def wait(self):
+            self.returncode = -9
+
+    async def fake_exec(*a, **k):
+        return _HangProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    res = await CCCliRouter("haiku", timeout_s=0.05).route_call(
+        "gen", [{"role": "user", "content": "U"}],
+    )
+    assert res.success is False
+    assert res.error == "timeout"
+    assert killed["v"] is True  # the orphaned claude proc was reaped

--- a/tests/test_experimentation/test_evo.py
+++ b/tests/test_experimentation/test_evo.py
@@ -1,0 +1,177 @@
+"""Tests for the Evo orchestration core (recommend-only, measure-only).
+
+Hermetic: `run_reflection_experiment` is mocked to return controlled win-rates
+per candidate, so these exercise the gating / selection / held-out-revalidation
+logic (the winner's-curse defense) without live model calls.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from genesis.experimentation.evo import EvoConfig, run_evo
+from genesis.experimentation.types import ArmResult, CognitiveVariant, ExperimentResult
+
+
+def _golden(tmp_path: Path, n: int = 8) -> Path:
+    p = tmp_path / "golden.jsonl"
+    lines = [
+        json.dumps({
+            "id": f"c{i}", "actual": "x", "user_passed": True,
+            "scorer_config": {"session_context": "ctx", "rubric_name": "reflection_quality"},
+        })
+        for i in range(n)
+    ]
+    p.write_text("\n".join(lines) + "\n")
+    return p
+
+
+def _result(treatment_name, *, rec, p_value, mean_score, significant=True):
+    return ExperimentResult(
+        experiment_name="x",
+        control=ArmResult(variant_name="base", case_scores=[0.5], case_results=[True], n_pass=1, mean_score=0.5),
+        treatment=ArmResult(variant_name=treatment_name, case_scores=[mean_score], case_results=[True], n_pass=1, mean_score=mean_score),
+        winrate={"recommendation": rec, "p_value": p_value, "significant": significant},
+        n_cases=4,
+        errors=0,
+        metadata={},
+    )
+
+
+def _base():
+    return CognitiveVariant(name="base", system_prompt="BASE")
+
+
+def _cands(*names):
+    return [CognitiveVariant(name=n, system_prompt=f"VARIANT {n}") for n in names]
+
+
+@pytest.fixture
+def patch_run(monkeypatch):
+    """Patch run_reflection_experiment with a dict: treatment_name -> ExperimentResult.
+
+    Distinguishes the held-out re-validation pass by experiment_name prefix
+    ('evo:holdout:') so a test can make a candidate win the fan-out but fail
+    (or pass) the held-out slice.
+    """
+    table: dict = {}
+
+    async def fake(**kwargs):
+        name = kwargs["treatment"].name
+        key = ("holdout:" + name) if kwargs["experiment_name"].startswith("evo:holdout:") else name
+        return table[key]
+
+    monkeypatch.setattr("genesis.experimentation.runner.run_reflection_experiment", fake)
+    return table
+
+
+async def test_only_bonferroni_significant_treatment_wins_survive(tmp_path, patch_run):
+    # 4 candidates → Bonferroni threshold = 0.05/4 = 0.0125
+    base = _base()
+    cands = _cands("a", "b", "c", "d")
+    patch_run["a"] = _result("a", rec="treatment_wins", p_value=0.01, mean_score=0.7)   # survives
+    patch_run["b"] = _result("b", rec="treatment_wins", p_value=0.03, mean_score=0.9)   # p>0.0125 → out
+    patch_run["c"] = _result("c", rec="control_wins", p_value=0.001, mean_score=0.2)    # wrong dir → out
+    patch_run["d"] = _result("d", rec="no_difference", p_value=0.5, mean_score=0.6)     # out
+    # 'a' is the only survivor; held-out confirms it
+    patch_run["holdout:a"] = _result("a", rec="treatment_wins", p_value=0.01, mean_score=0.72)
+
+    out = await run_evo(base=base, candidates=cands, golden_set_path=_golden(tmp_path),
+                        config=EvoConfig(eval_limit=4, holdout_limit=4))
+    assert out.candidates_evaluated == 4
+    assert out.survivors == 1
+    assert out.winner is not None and out.winner.name == "a"
+
+
+async def test_best_survivor_by_mean_score_then_holdout_confirms(tmp_path, patch_run):
+    base = _base()
+    cands = _cands("a", "b")
+    # both survive the gate; b has higher mean_score → chosen
+    patch_run["a"] = _result("a", rec="treatment_wins", p_value=0.001, mean_score=0.7)
+    patch_run["b"] = _result("b", rec="treatment_wins", p_value=0.001, mean_score=0.85)
+    patch_run["holdout:b"] = _result("b", rec="treatment_wins", p_value=0.005, mean_score=0.83)
+
+    out = await run_evo(base=base, candidates=cands, golden_set_path=_golden(tmp_path),
+                        config=EvoConfig(eval_limit=4, holdout_limit=4))
+    assert out.winner is not None and out.winner.name == "b"
+
+
+async def test_winner_rejected_when_holdout_fails(tmp_path, patch_run):
+    """Winner's-curse defense: a fan-out winner that does NOT survive the
+    held-out re-validation is rejected (winner=None)."""
+    base = _base()
+    cands = _cands("a")
+    patch_run["a"] = _result("a", rec="treatment_wins", p_value=0.001, mean_score=0.9)
+    patch_run["holdout:a"] = _result("a", rec="no_difference", p_value=0.4, mean_score=0.55, significant=False)
+
+    out = await run_evo(base=base, candidates=cands, golden_set_path=_golden(tmp_path),
+                        config=EvoConfig(eval_limit=4, holdout_limit=4))
+    assert out.survivors == 1
+    assert out.winner is None  # held-out did not confirm
+
+
+async def test_no_survivors_returns_no_winner(tmp_path, patch_run):
+    base = _base()
+    cands = _cands("a", "b")
+    patch_run["a"] = _result("a", rec="no_difference", p_value=0.6, mean_score=0.5)
+    patch_run["b"] = _result("b", rec="control_wins", p_value=0.01, mean_score=0.3)
+
+    out = await run_evo(base=base, candidates=cands, golden_set_path=_golden(tmp_path),
+                        config=EvoConfig(eval_limit=4, holdout_limit=4))
+    assert out.survivors == 0
+    assert out.winner is None
+
+
+async def test_empty_candidates_is_safe(tmp_path, patch_run):
+    out = await run_evo(base=_base(), candidates=[], golden_set_path=_golden(tmp_path),
+                        config=EvoConfig(eval_limit=4, holdout_limit=4))
+    assert out.winner is None
+    assert out.candidates_evaluated == 0
+
+
+# --- build_directive_variants (deterministic directive-append) ---
+
+
+def test_build_directive_variants_appends_directives():
+    from genesis.experimentation.evo import build_directive_variants
+
+    out = build_directive_variants("BASE PROMPT", 3)
+    assert len(out) == 3
+    assert all(v.name == f"evo_v{i}" for i, v in enumerate(out))
+    # each variant = base + a distinct directive (no truncation, deterministic)
+    assert all(v.system_prompt.startswith("BASE PROMPT\n\n") for v in out)
+    assert len({v.system_prompt for v in out}) == 3  # distinct directives
+    assert all(v.description for v in out)
+
+
+def test_build_directive_variants_caps_at_directive_count():
+    from genesis.experimentation.evo import build_directive_variants
+
+    out = build_directive_variants("BASE", 99)
+    assert len(out) == 6  # capped at the number of fixed directives
+    out0 = build_directive_variants("BASE", 0)
+    assert out0 == []
+
+
+async def test_holdout_disjoint_false_on_small_golden_set(tmp_path, patch_run):
+    # golden set of 4, eval_limit=4 → nothing left to hold out → not disjoint
+    base = _base()
+    cands = _cands("a")
+    patch_run["a"] = _result("a", rec="treatment_wins", p_value=0.001, mean_score=0.9)
+    patch_run["holdout:a"] = _result("a", rec="treatment_wins", p_value=0.01, mean_score=0.9)
+
+    out = await run_evo(base=base, candidates=cands, golden_set_path=_golden(tmp_path, n=4),
+                        config=EvoConfig(eval_limit=4, holdout_limit=4))
+    assert out.holdout_disjoint is False  # surfaced, not hidden
+
+
+async def test_holdout_disjoint_true_on_large_golden_set(tmp_path, patch_run):
+    base = _base()
+    cands = _cands("a")
+    patch_run["a"] = _result("a", rec="treatment_wins", p_value=0.001, mean_score=0.9)
+    patch_run["holdout:a"] = _result("a", rec="treatment_wins", p_value=0.01, mean_score=0.9)
+
+    out = await run_evo(base=base, candidates=cands, golden_set_path=_golden(tmp_path, n=8),
+                        config=EvoConfig(eval_limit=4, holdout_limit=4))
+    assert out.holdout_disjoint is True

--- a/tests/test_experimentation/test_evo_run.py
+++ b/tests/test_experimentation/test_evo_run.py
@@ -1,0 +1,160 @@
+"""Hermetic tests for the evo_run MCP tool (recommend-only wiring).
+
+The live router build + run_evo are stubbed; variant building is deterministic.
+These exercise the tool's wiring, verdict mapping, and summary persistence with
+no model calls.
+"""
+
+import json
+
+from genesis.experimentation.evo import EvoResult
+from genesis.experimentation.types import CognitiveVariant
+
+
+class _DummyRouter:
+    async def close(self):
+        pass
+
+
+def _golden(tmp_path):
+    p = tmp_path / "g.jsonl"
+    p.write_text(json.dumps({
+        "id": "c0", "actual": "x", "user_passed": True,
+        "scorer_config": {"session_context": "ctx", "rubric_name": "reflection_quality"},
+    }) + "\n")
+    return p
+
+
+def _stub_routers(monkeypatch):
+    monkeypatch.setattr(
+        "genesis.mcp.health.evo_run._build_routers",
+        lambda g, j: (_DummyRouter(), _DummyRouter(), object()),
+    )
+
+
+def _stub_variants(monkeypatch, n=3):
+    monkeypatch.setattr(
+        "genesis.experimentation.evo.build_directive_variants",
+        lambda base, count: [
+            CognitiveVariant(name=f"evo_v{i}", system_prompt=f"{base} :: d{i}")
+            for i in range(min(count, n))
+        ],
+    )
+
+
+async def test_evo_run_recommends_winner(tmp_path, monkeypatch):
+    _stub_routers(monkeypatch)
+    _stub_variants(monkeypatch)
+
+    winner = CognitiveVariant(name="evo_v1", description="more concise", system_prompt="WINNER PROMPT TEXT")
+
+    async def fake_run_evo(*, base, candidates, golden_set_path, config, gen_router, judge):
+        return EvoResult(
+            winner=winner,
+            winner_winrate={"recommendation": "treatment_wins", "p_value": 0.001},
+            holdout_winrate={"recommendation": "treatment_wins", "p_value": 0.01},
+            candidates_evaluated=len(candidates), survivors=2, note="confirmed",
+            holdout_disjoint=True,
+        )
+
+    monkeypatch.setattr("genesis.experimentation.evo.run_evo", fake_run_evo)
+
+    from genesis.mcp.health.evo_run import _impl_evo_run
+
+    out = await _impl_evo_run(
+        base_prompt="BASE", n_variants=3, golden_set_path=str(_golden(tmp_path)),
+        eval_limit=2, holdout_limit=2,
+    )
+    assert out["status"] == "ok"
+    assert out["autonomous_action"] is False
+    assert out["winner"]["name"] == "evo_v1"
+    assert out["winner"]["full_prompt"] == "WINNER PROMPT TEXT"
+    assert out["winner"]["approach"] == "more concise"
+    assert out["survivors"] == 2
+    assert out["holdout_disjoint"] is True
+    assert out["persisted_run_id"] is None  # no _service db in this test
+
+
+async def test_evo_run_persists_summary(eval_db, tmp_path, monkeypatch):
+    _stub_routers(monkeypatch)
+    _stub_variants(monkeypatch)
+
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    class _Svc:
+        _db = eval_db
+
+    monkeypatch.setattr(health_mcp_mod, "_service", _Svc(), raising=False)
+
+    async def fake_run_evo(*, base, candidates, golden_set_path, config, gen_router, judge):
+        return EvoResult(
+            winner=CognitiveVariant(name="evo_v0", system_prompt="W"),
+            winner_winrate={"recommendation": "treatment_wins", "treatment_mean_score": 0.8},
+            holdout_winrate={"recommendation": "treatment_wins"},
+            candidates_evaluated=3, survivors=1, note="ok", holdout_disjoint=True,
+        )
+
+    monkeypatch.setattr("genesis.experimentation.evo.run_evo", fake_run_evo)
+
+    from genesis.mcp.health.evo_run import _impl_evo_run
+
+    out = await _impl_evo_run(base_prompt="BASE", golden_set_path=str(_golden(tmp_path)))
+    assert out["status"] == "ok"
+    assert out["persisted_run_id"] is not None
+
+    # one evo_summary row written, surfaced by experiment_status under evo_runs
+    from genesis.mcp.health.experiment_status import _impl_experiment_status
+
+    status = await _impl_experiment_status()
+    assert len(status["evo_runs"]) == 1
+    assert status["evo_runs"][0]["winner"] == "evo_v0"
+    assert status["evo_runs"][0]["survivors"] == 1
+
+
+async def test_evo_run_no_winner(tmp_path, monkeypatch):
+    _stub_routers(monkeypatch)
+    _stub_variants(monkeypatch, n=1)
+
+    async def fake_run_evo(**kw):
+        return EvoResult(
+            winner=None, winner_winrate=None, holdout_winrate=None,
+            candidates_evaluated=1, survivors=0, note="no variant beat control",
+        )
+
+    monkeypatch.setattr("genesis.experimentation.evo.run_evo", fake_run_evo)
+
+    from genesis.mcp.health.evo_run import _impl_evo_run
+
+    out = await _impl_evo_run(base_prompt="BASE", golden_set_path=str(_golden(tmp_path)))
+    assert out["status"] == "ok"
+    assert out["winner"] is None
+    assert out["survivors"] == 0
+
+
+async def test_evo_run_missing_golden_set():
+    from genesis.mcp.health.evo_run import _impl_evo_run
+
+    out = await _impl_evo_run(base_prompt="BASE", golden_set_path="/nonexistent.jsonl")
+    assert out["status"] == "error"
+    assert "golden set" in out["message"].lower()
+
+
+async def test_evo_run_no_variants_built(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "genesis.experimentation.evo.build_directive_variants", lambda base, count: [],
+    )
+
+    from genesis.mcp.health.evo_run import _impl_evo_run
+
+    out = await _impl_evo_run(base_prompt="BASE", golden_set_path=str(_golden(tmp_path)))
+    assert out["status"] == "error"
+    assert "no variants" in out["message"].lower()
+
+
+def test_make_router_cc_provider_returns_cc_cli_router():
+    from genesis.experimentation.cc_router import CCCliRouter
+    from genesis.mcp.health.evo_run import _make_router
+
+    r = _make_router("cc-haiku", None, None)
+    assert isinstance(r, CCCliRouter)
+    assert r._model == "haiku"


### PR DESCRIPTION
## Context

On top of the merged Crucible foundation (#763 — the `experiment_run` run button +
the `~/.genesis/config/reflection/` prompt overlay). This adds **Evo**, the
evolution loop: generate N variants of the reflection prompt, A/B each against
the current prompt, and **recommend** the best. **Recommend-only, measure-only** —
it surfaces a recommendation and mutates nothing. The promotion/apply path (the
sensitive piece) is a separate, architect-gated PR-B, not here.

## What

- **`experimentation/evo.py`**
  - `build_directive_variants(base, n)` — variants by **directive-append** (`base +
    a fixed mutation directive`): deterministic, no generation LLM call, no
    truncation on the large prompt. The pattern the foundation E2E proved.
  - `run_evo(...)` — fan-out: A/B each variant vs control via the foundation's
    `run_reflection_experiment`; keep those beating control at **Bonferroni α/N**;
    pick the best survivor; **re-validate on a DISJOINT held-out golden slice**
    (gated `p ≤ α`; `holdout_disjoint` surfaced when the set is too small).
  - `persist_evo_summary(...)` — one `eval_runs` row per run (`kind=evo_summary`).
- **`experimentation/cc_router.py` — `CCCliRouter`**: runs gen/judge through the
  `claude` CLI (the CC subscription) when the litellm Claude providers (OpenRouter)
  are dry. Single-shot `claude -p` with tools, MCP, and hooks **disabled** for a
  clean completion; the timeout branch reaps the subprocess. Drop-in
  `StandaloneRoutingResult`.
- **`evo_run` MCP tool**: evolve the current effective deep-reflection prompt
  (overlay-aware), recommend the winner, persist the summary (surfaced by
  `experiment_status.evo_runs`). Providers `cc-haiku`/`cc-sonnet` route to the CLI.
  `autonomous_action=False`. **No promotion/apply.**

No migration, no new table (reuses `eval_runs`).

## Verification

- **Tests:** 16 hermetic for the new code (α/N gating, best-survivor selection,
  held-out rejection, directive variants, summary persistence + surfacing, the
  cc-router success/failure/timeout-kill paths, provider wiring). 76 experimentation
  tests green, ruff clean.
- **Real-score E2E (live, via CC CLI `cc-haiku`):** generation produces real
  reflections; the judge returns **real scores (0.74, 0.79)**; the full `evo_run`
  path persists + surfaces the summary; recommend-only holds. This is what the
  rate-limited/dry litellm providers couldn't demonstrate.
- **Reviews:** three code-review passes, clean after fixes — incl. a **P1** the
  reviewer caught: the CC-CLI timeout branch leaked the `claude` subprocess (now
  killed + awaited, with a test).

## Honest caveats

- **CC CLI is ~55s/call**, so a real *winner-finding* run (10+ cases for power) is
  ~30 min — an on-demand/background self-improvement op, not a hot path. The E2E
  proved *real scoring*; finding a statistical winner needs more cases + time.
- Making `claude -p` a clean completion required disabling tools/MCP/hooks (it
  otherwise goes agentic and echoes hook preambles). The Anthropic API is **not**
  used (per policy); OpenRouter is currently out of credits.

## Next (not in this PR)

**PR-B — the promotion path** (architect-review-first + a security E2E): a
human-gated `cognitive_variant_promotion` proposal that writes the winner to the
reflection overlay on approval. Wiring already verified on current code (4
resolution + 2 security sites; exactly 2 auto-dispatch paths to block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
