### PR TITLE
fix(routing): WS2b rebalance — drop expired trinity, GA gemini-3.5-flash, resolve profile drift

### DIFF
--- a/config/model_profiles.yaml
+++ b/config/model_profiles.yaml
@@ -492,7 +492,7 @@ profiles:
   minimax-m2.7:
     display_name: "MiniMax M2.7"
     provider: minimax
-    api_id: "minimax/minimax-m2.7"
+    api_id: "MiniMax-M2.7"
     intelligence_tier: A
     reasoning: B
     instruction_following: A

--- a/config/model_profiles.yaml
+++ b/config/model_profiles.yaml
@@ -124,10 +124,10 @@ profiles:
     last_reviewed: "2026-03-14"
     review_source: manual
 
-  gemini-3-flash:
-    display_name: "Gemini 3 Flash"
+  gemini-3.5-flash:
+    display_name: "Gemini 3.5 Flash"
     provider: google
-    api_id: "google/gemini-3-flash"
+    api_id: "google/gemini-3.5-flash"
     intelligence_tier: B
     reasoning: B
     instruction_following: A

--- a/config/model_profiles.yaml
+++ b/config/model_profiles.yaml
@@ -32,10 +32,10 @@ profiles:
     last_reviewed: "2026-03-14"
     review_source: manual
 
-  kimi-k2.5:
-    display_name: "Kimi K2.5"
+  kimi-k2.6:
+    display_name: "Kimi K2.6"
     provider: moonshot
-    api_id: "moonshotai/kimi-k2.5"
+    api_id: "moonshotai/kimi-k2.6"
     intelligence_tier: A
     reasoning: A
     instruction_following: A
@@ -63,10 +63,10 @@ profiles:
     last_reviewed: "2026-03-14"
     review_source: manual
 
-  glm-5:
-    display_name: "GLM-5"
+  glm-5.1:
+    display_name: "GLM-5.1"
     provider: zenmux
-    api_id: "z-ai/glm-5-turbo"
+    api_id: "z-ai/glm-5.1"
     intelligence_tier: S
     reasoning: S
     instruction_following: A
@@ -489,10 +489,10 @@ profiles:
     last_reviewed: "2026-03-14"
     review_source: manual
 
-  minimax-m2.5:
-    display_name: "MiniMax M2.5"
+  minimax-m2.7:
+    display_name: "MiniMax M2.7"
     provider: minimax
-    api_id: "minimax/minimax-m2.5"
+    api_id: "minimax/minimax-m2.7"
     intelligence_tier: A
     reasoning: B
     instruction_following: A
@@ -1014,10 +1014,10 @@ profiles:
     last_reviewed: "2026-04-14"
     review_source: manual
 
-  gemma-4-27b:
-    display_name: "Gemma 4 27B Dense"
+  gemma-4-31b:
+    display_name: "Gemma 4 31B Dense"
     provider: google
-    api_id: "google/gemma-4-27b-it:free"
+    api_id: "google/gemma-4-31b-it:free"
     intelligence_tier: B
     reasoning: B
     instruction_following: B
@@ -1045,10 +1045,10 @@ profiles:
     last_reviewed: "2026-04-14"
     review_source: manual
 
-  qwen3-coder-480b:
+  qwen3-coder:
     display_name: "Qwen3-Coder 480B"
     provider: alibaba
-    api_id: "qwen/qwen3-coder-480b-a35b:free"
+    api_id: "qwen/qwen3-coder:free"
     intelligence_tier: B
     reasoning: B
     instruction_following: B
@@ -1103,4 +1103,89 @@ profiles:
       provider: openrouter
       limits: "OpenRouter free tier (1,000 RPD with $10 balance)"
     last_reviewed: "2026-04-14"
+    review_source: manual
+
+  # --- Point-version profiles added to resolve dangling routing references.
+  # Metadata carried from the named sibling (point bump → ~same list price/tier);
+  # re-review if any of these becomes a heavily-used primary. ---
+  gpt-5.5:  # carried from gpt-5.4
+    display_name: "GPT-5.5"
+    provider: openai
+    api_id: "openai/gpt-5.5"
+    intelligence_tier: S
+    reasoning: S
+    instruction_following: A
+    anti_sycophancy: B
+    context_window: 1048576
+    cost_tier: moderate
+    cost_per_mtok_in: 2.50
+    cost_per_mtok_out: 12.00
+    latency: moderate
+    strengths:
+      - computer use and agentic work
+      - multi-step tool calling efficiency
+      - factuality (reduced false claims)
+    weaknesses:
+      - creative writing (less distinctive voice)
+      - cost for bulk background work
+    best_for: [deep_reflection, task_execution, code_work, adversarial_counterargument]
+    avoid_for: [surplus_brainstorm, micro_reflection]
+    free_tier:
+      available: false
+    last_reviewed: "2026-03-14"
+    review_source: manual
+
+  qwen-3.6-plus:  # carried from qwen-3.5-plus
+    display_name: "Qwen 3.6 Plus"
+    provider: alibaba
+    api_id: "qwen/qwen3.6-plus"
+    intelligence_tier: A
+    reasoning: A
+    instruction_following: A
+    anti_sycophancy: B
+    context_window: 131072
+    cost_tier: cheap
+    cost_per_mtok_in: 0.40
+    cost_per_mtok_out: 2.40
+    latency: moderate
+    strengths:
+      - agent benchmarks (top agentic task completion)
+      - value (strong reasoning at low cost)
+      - structured output (reliable JSON)
+    weaknesses:
+      - English nuance (occasional awkward phrasing)
+      - creative tasks (functional but uninspired)
+    best_for: [task_retrospective, outcome_classification, structured_extraction]
+    avoid_for: [foreground_conversation, creative_writing]
+    free_tier:
+      available: false
+    last_reviewed: "2026-03-14"
+    review_source: manual
+
+  nvidia-nim-kimi-k2.6:  # carried from kimi-k2.6 (NIM free variant)
+    display_name: "Kimi K2.6 (NIM)"
+    provider: nvidia_nim
+    api_id: "moonshotai/kimi-k2.6"
+    intelligence_tier: A
+    reasoning: A
+    instruction_following: A
+    anti_sycophancy: B
+    context_window: 2097152
+    cost_tier: free
+    cost_per_mtok_in: 0.0
+    cost_per_mtok_out: 0.0
+    latency: moderate
+    strengths:
+      - free NIM access to Kimi K2.6
+      - long-context summarization (2M tokens)
+    weaknesses:
+      - rate limited (40 RPM, 5000 credits, shared NIM pool)
+      - single-thread speed slower than Flash
+    best_for: [research_synthesis, long_context_work, fallback_reasoning]
+    avoid_for: [micro_reflection, math_heavy, high_throughput]
+    free_tier:
+      available: true
+      credits: 5000
+      rpm_limit: 40
+    last_reviewed: "2026-03-14"
     review_source: manual

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -53,11 +53,20 @@ providers:
         reasoning_effort: low
   gemini-free:
     type: google
-    model: gemini-3-flash-preview
-    profile: gemini-3-flash
+    # GA stable (was gemini-3-flash-preview; gemini-3.5-flash is Google's own
+    # recommended replacement for that preview — escape preview deprecation churn).
+    model: gemini-3.5-flash
+    profile: gemini-3.5-flash
     free: true
     rpm_limit: 15
     open_duration_s: 120
+    # gemini-3.5-flash reasons by default (~70-90 thinking tokens even on trivial
+    # prompts → empty content at tight max_tokens + free-tier TPM bloat). This is
+    # the fast-flash lane (fact extraction, tagging, surplus brainstorm), so
+    # suppress thinking. reasoning_effort=disable → Gemini thinkingBudget=0
+    # (verified live 2026-06-23: content correct, 0 reasoning tokens at mt=20).
+    params:
+      reasoning_effort: disable
   openrouter-free:
     type: openrouter
     model: qwen/qwen-2.5-72b-instruct

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -231,14 +231,6 @@ providers:
     free: false
     rpm_limit: 20
     open_duration_s: 120
-  openrouter-trinity-free:
-    type: openrouter
-    model: arcee-ai/trinity-large-preview:free
-    profile: trinity-large-preview
-    free: true
-    # 400B MoE (13B active). Free until 2026-04-22. Benchmark before expiry.
-    rpm_limit: 20
-    open_duration_s: 120
   lmstudio-30b:
     type: lmstudio
     model: mistral-small-3.2-24b-instruct-2506
@@ -260,7 +252,6 @@ call_sites:
     # paid fallback. Healthy OpenRouter-free models first; NIM last (shared
     # 40 RPM pool, currently flaky).
     - openrouter-gemma4
-    - openrouter-trinity-free
     - nvidia-nim-kimi
     - nvidia-nim-deepseek
     retry_profile: background
@@ -409,7 +400,6 @@ call_sites:
     - gemini-free
     - mistral-large-free
     - openrouter-gemma4
-    - openrouter-trinity-free
     retry_profile: background
   # Adversarial challenge of entity "duplicate" verdicts. Flipped pairing:
   # DeepSeek challenges Kimi's entity judgments.

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -127,7 +127,8 @@ def test_load_full_yaml(monkeypatch):
     # nvidia-nim-deepseek + nvidia-nim-kimi added 2026-05-25)
     # 2026-06-23: 28 → 29 after groq-oss-120b added (free reasoning option,
     # not yet wired into any chain).
-    assert len(cfg.providers) == 29
+    # 2026-06-23 (WS2b): 29 → 28 after removing expired openrouter-trinity-free.
+    assert len(cfg.providers) == 28
     assert "lmstudio-30b" not in cfg.providers
     assert "github-o3mini" not in cfg.providers
     assert "openrouter-deepseek-r1" not in cfg.providers  # removed from config


### PR DESCRIPTION
WS2b routing rebalance — the **safe, mechanical hygiene** subset (quality/cost-neutral). The user-decision items (paid-primary demotions, backstop relief wiring) are deliberately **out of scope** and left for explicit sign-off per the quality-over-cost tenet.

## What
**1. Remove expired `openrouter-trinity-free`** — `arcee-ai/trinity-large-preview:free`'s free window ended 2026-04-22; it was only a last-resort fallback in `3_micro_reflection` and `dream_cycle_entity_check` (behind 7-8 other free providers) and its profile was never defined. Drop the provider + both chain tails.

**2. Pin `gemini-free` off the preview to GA `gemini-3.5-flash`** — was routed to `gemini-3-flash-preview`. `gemini-3.5-flash` is Google's own recommended GA replacement for that preview (verified live against the Gemini deprecations page), so we escape preview-deprecation churn. It's a fast-flash workhorse lane (chain[0] on 8 call-sites: fact extraction, tagging, surplus brainstorm, light reflection, skill refiner, research synthesis, intelligence intake, outreach), but **gemini-3.5-flash reasons by default** (~70-90 thinking tokens even on trivial prompts → empty `content` at tight `max_tokens` + free-tier TPM bloat), so we suppress thinking via `params: {reasoning_effort: disable}` (→ Gemini `thinkingBudget=0`), reusing the #757 per-provider param plumbing exactly like gpt-oss.

**3. Resolve 9 dangling profile references** — chains referenced bumped model point-versions (kimi-k2.6, glm-5.1, minimax-m2.7, gemma-4-31b, qwen3-coder, qwen-3.6-plus, gpt-5.5, nvidia-nim-kimi-k2.6) whose `model_profiles.yaml` entries were never updated, so the matcher/recon/cost layers had no metadata for them. Rename the 5 orphaned sibling profiles to the referenced names (api_id matched to the real provider `model:`) and add 3 point-version copies with carried-from-sibling provenance.

## Verification
- `load_config` parses (28 providers, 52 call-sites); **zero dangling profile references** after the change (set-diff of referenced vs defined).
- **Live E2E through `LiteLLMDelegate`**: `gemini-free` → `gemini-3.5-flash` with reasoning disabled returns correct content and **0 reasoning tokens at `max_tokens=20`** (would be empty `content` without the suppression).
- `tests/test_routing/` 302 pass (provider-count assertion updated 29→28); ruff clean.
- Code-reviewed; one finding (minimax-m2.7 api_id casing) fixed.

## Not in this PR (user-decision, deferred)
Relieving the 4-RPM `mistral-large-free` backstop (wire dormant `groq-oss-120b`), the paid-primary sites (`8_ego_compaction`, `36_code_auditor`), and `11_user_model_synthesis`'s 32k primary — all quality-vs-cost calls per the no-auto-downgrade tenet.

No DB migration. Deploy = pull + restart.
