### PR TITLE
feat(recon): extend active-model EOL detector to Google/Gemini

### DIFF
--- a/src/genesis/recon/model_intelligence.py
+++ b/src/genesis/recon/model_intelligence.py
@@ -35,12 +35,26 @@ _OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
 _AA_MODELS_URL = "https://artificialanalysis.ai/api/data/llms/models"
 _FREE_MODEL_CACHE_PATH = Path.home() / ".genesis" / "free_model_cache.json"
 
-# ── Active-model EOL detection (v1: Groq deprecations page) ────────────────
+# ── Active-model EOL detection (vendor deprecation pages: Groq + Gemini) ────
 _GROQ_DEPRECATIONS_URL = "https://console.groq.com/docs/deprecations"
 # A Groq deprecations table row is 3 pipe-separated cells. Rendered text may
 # carry surrounding pipes (`| model | date | repl |`, MCP-style markdown) or
 # not (`model| date| repl`, what genesis.web.fetch returns) — handle both.
 _DEP_DATE_RE = re.compile(r"(\d{1,2})/(\d{1,2})/(\d{2,4})")
+
+# Google's Gemini deprecations page. Same intent as Groq's, but a 4-column
+# table (`Model | Release | Shutdown | Repl`) with month-name dates
+# ("May 19, 2026"). Models without a dated shutdown carry "No shutdown date
+# announced" and must NOT fire. We fetch the HTML doc (rendered to markdown by
+# genesis.web.fetch) — NOT the `.md.txt` mirror, which is served as
+# `text/markdown` and rejected by the fetch content-type allowlist.
+_GEMINI_DEPRECATIONS_URL = "https://ai.google.dev/gemini-api/docs/deprecations"
+_GEMINI_DATE_RE = re.compile(r"\b([A-Z][a-z]{2,8})\s+(\d{1,2}),\s+(\d{4})\b")
+_MONTH_TO_NUM = {
+    m: i for i, m in enumerate(
+        ["January", "February", "March", "April", "May", "June", "July",
+         "August", "September", "October", "November", "December"], start=1)
+}
 
 
 def _parse_groq_deprecation_table(text: str) -> list[tuple[str, str, str]]:
@@ -79,38 +93,84 @@ def _parse_groq_deprecation_table(text: str) -> list[tuple[str, str, str]]:
     return rows
 
 
+def _parse_gemini_deprecation_table(text: str) -> list[tuple[str, str, str]]:
+    """Parse Google's Gemini deprecations markdown into rows of
+    ``(model_id, shutdown_date_iso, replacement)``.
+
+    The page is multi-section with 4-column tables
+    (``Model | Release date | Shutdown date | Recommended replacement``) and
+    month-name dates. Only rows whose *shutdown* column carries a real date
+    count — "No shutdown date announced", header, separator, and "Preview
+    models" rows are skipped. Robust to backticks / bold markers and to the
+    leading/trailing-pipe variation. Returns ``[]`` when nothing parses (the
+    caller logs a structure-changed warning).
+    """
+    rows: list[tuple[str, str, str]] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if "|" not in line:
+            continue
+        parts = [c.strip() for c in line.strip("|").split("|")]
+        if len(parts) != 4:
+            continue
+        model_cell, _release_cell, shutdown_cell, repl_cell = parts
+        date_m = _GEMINI_DATE_RE.search(shutdown_cell)
+        if not date_m:
+            continue  # "No shutdown date announced" / header / separator row
+        month_name, dd, yyyy = date_m.groups()
+        month = _MONTH_TO_NUM.get(month_name)
+        if month is None:
+            continue
+        dd_int = int(dd)
+        if not (1 <= dd_int <= 31):
+            continue
+        model_id = model_cell.strip("`* ").strip()
+        if not model_id or model_id.lower().startswith("model"):
+            continue  # header row ("**Model**")
+        shutdown_iso = f"{int(yyyy):04d}-{month:02d}-{dd_int:02d}"
+        replacement = repl_cell.strip("`* ").strip()
+        rows.append((model_id, shutdown_iso, replacement))
+    return rows
+
+
 def _eol_findings_from_rows(
     rows: list[tuple[str, str, str]], providers: dict, call_sites: dict,
+    *,
+    provider_type: str = "groq",
+    vendor: str = "groq",
+    source: str = "groq_deprecations_page",
 ) -> list[dict]:
-    """Match parsed deprecation rows against our ACTIVE Groq providers.
+    """Match parsed deprecation rows against our ACTIVE providers of one vendor.
 
     Emits an ``active_model_eol`` finding only for a model we actually use
-    (firehose guard: an unrelated Groq deprecation yields nothing), annotated
-    with blast radius — the call-site chains that depend on that provider.
+    (firehose guard: an unrelated deprecation yields nothing), annotated with
+    blast radius — the call-site chains that depend on that provider.
+    ``provider_type`` gates which of our providers a row can match (e.g.
+    ``"groq"`` rows never match a ``"google"`` provider and vice versa).
     """
     provider_chains: dict[str, list[str]] = defaultdict(list)
     for site_id, site in call_sites.items():
         for prov in site.chain:
             provider_chains[prov].append(site_id)
-    groq_models = {
+    active_models = {
         p.model_id: name
         for name, p in providers.items()
-        if p.enabled and p.provider_type == "groq"
+        if p.enabled and p.provider_type == provider_type
     }
     findings: list[dict] = []
     for model_id, shutdown_iso, replacement in rows:
-        name = groq_models.get(model_id)
+        name = active_models.get(model_id)
         if name is None:
             continue
         findings.append({
             "type": "active_model_eol",
             "model": model_id,
             "provider": name,
-            "vendor": "groq",
+            "vendor": vendor,
             "shutdown_date": shutdown_iso,
             "replacement": replacement,
             "blast_radius": sorted(set(provider_chains.get(name, []))),
-            "source": "groq_deprecations_page",
+            "source": source,
         })
     return findings
 
@@ -568,19 +628,21 @@ class ModelIntelligenceJob:
             return None
 
     async def _check_active_providers(self) -> list[dict]:
-        """Detect EOL of models WE ACTUALLY USE (v1: Groq deprecations page).
+        """Detect EOL of models WE ACTUALLY USE across vendors that publish a
+        structured deprecation page (Groq + Gemini/Google).
 
-        Loads the effective routing config to learn our active Groq models and
-        the chains that depend on each provider (blast radius), parses Groq's
-        structured deprecations table, and emits an ``active_model_eol``
-        finding ONLY for our active Groq models that appear with a shutdown
-        date.
+        Loads the effective routing config to learn our active models per
+        vendor and the chains that depend on each provider (blast radius),
+        parses each vendor's deprecation table, and emits an
+        ``active_model_eol`` finding ONLY for our active models that appear
+        with a real shutdown date.
 
-        Firehose-proof by construction: a deprecation for a Groq model we
-        don't use yields nothing; a fetch/parse failure yields nothing
-        (degrade gracefully, never crash the scan). Catalog ``/v1/models``
-        diff (all OpenAI-compatible vendors) and the Google changelog are a
-        documented follow-up, not silent gaps.
+        Firehose-proof by construction: a deprecation for a model we don't use
+        yields nothing; a fetch/parse failure yields nothing (degrade
+        gracefully, never crash the scan). Per vendor we only fetch when we
+        actually have an active provider of that type. Catalog ``/v1/models``
+        diff for the remaining OpenAI-compatible vendors is a documented
+        follow-up, not a silent gap.
         """
         try:
             from genesis.env import repo_root
@@ -596,25 +658,41 @@ class ModelIntelligenceJob:
             )
             return []
 
-        groq_count = sum(
-            1 for p in cfg.providers.values()
-            if p.enabled and p.provider_type == "groq"
-        )
-        if groq_count == 0:
-            return []
+        def _active(provider_type: str) -> int:
+            return sum(
+                1 for p in cfg.providers.values()
+                if p.enabled and p.provider_type == provider_type
+            )
 
-        rows = await self._fetch_groq_deprecations()
-        findings = _eol_findings_from_rows(rows, cfg.providers, cfg.call_sites)
+        findings: list[dict] = []
+
+        groq_count = _active("groq")
+        if groq_count:
+            rows = await self._fetch_groq_deprecations()
+            findings.extend(_eol_findings_from_rows(
+                rows, cfg.providers, cfg.call_sites,
+                provider_type="groq", vendor="groq",
+                source="groq_deprecations_page",
+            ))
+
+        google_count = _active("google")
+        if google_count:
+            grows = await self._fetch_gemini_deprecations()
+            findings.extend(_eol_findings_from_rows(
+                grows, cfg.providers, cfg.call_sites,
+                provider_type="google", vendor="google",
+                source="gemini_deprecations_page",
+            ))
 
         if findings:
             logger.warning(
-                "EOL check: %d active Groq model(s) deprecated: %s",
+                "EOL check: %d active model(s) deprecated: %s",
                 len(findings), [f["model"] for f in findings],
             )
         logger.info(
-            "EOL check: scanned Groq deprecations for %d active Groq model(s); "
-            "catalog-diff + non-Groq vendors deferred to follow-up",
-            groq_count,
+            "EOL check: scanned deprecations for %d Groq + %d Google active "
+            "model(s); catalog-diff + other vendors deferred to follow-up",
+            groq_count, google_count,
         )
         return findings
 
@@ -641,6 +719,35 @@ class ModelIntelligenceJob:
         if not rows:
             logger.warning(
                 "EOL check: Groq deprecations parse yielded 0 rows — page "
+                "structure may have changed (this is NOT 'no deprecations')",
+            )
+        return rows
+
+    async def _fetch_gemini_deprecations(self) -> list[tuple[str, str, str]]:
+        """Fetch + parse Google's Gemini deprecations page. Fails safe → [].
+
+        Uses ``genesis.web.fetch`` against the HTML doc (rendered to markdown).
+        The ``.md.txt`` mirror is served as ``text/markdown`` and rejected by
+        the fetch content-type allowlist, so we deliberately use the HTML URL.
+        """
+        try:
+            from genesis.web import fetch
+
+            result = await fetch(_GEMINI_DEPRECATIONS_URL, max_chars=40000)
+        except Exception:
+            logger.warning(
+                "EOL check: Gemini deprecations fetch raised", exc_info=True,
+            )
+            return []
+        if result.error or not result.text:
+            logger.warning(
+                "EOL check: Gemini deprecations page unavailable (%s)", result.error,
+            )
+            return []
+        rows = _parse_gemini_deprecation_table(result.text)
+        if not rows:
+            logger.warning(
+                "EOL check: Gemini deprecations parse yielded 0 rows — page "
                 "structure may have changed (this is NOT 'no deprecations')",
             )
         return rows

--- a/src/genesis/recon/model_intelligence.py
+++ b/src/genesis/recon/model_intelligence.py
@@ -50,11 +50,15 @@ _DEP_DATE_RE = re.compile(r"(\d{1,2})/(\d{1,2})/(\d{2,4})")
 # `text/markdown` and rejected by the fetch content-type allowlist.
 _GEMINI_DEPRECATIONS_URL = "https://ai.google.dev/gemini-api/docs/deprecations"
 _GEMINI_DATE_RE = re.compile(r"\b([A-Z][a-z]{2,8})\s+(\d{1,2}),\s+(\d{4})\b")
-_MONTH_TO_NUM = {
-    m: i for i, m in enumerate(
-        ["January", "February", "March", "April", "May", "June", "July",
-         "August", "September", "October", "November", "December"], start=1)
-}
+_MONTH_NAMES = [
+    "January", "February", "March", "April", "May", "June", "July",
+    "August", "September", "October", "November", "December",
+]
+# Full names + 3-letter abbreviations ("Jan", "Sep"), in case a rendered table
+# narrows the column. An unrecognised month after a date-shaped match is WARNED,
+# never silently dropped (a missed EOL is the dangerous failure mode).
+_MONTH_TO_NUM = {m: i for i, m in enumerate(_MONTH_NAMES, start=1)}
+_MONTH_TO_NUM.update({m[:3]: i for i, m in enumerate(_MONTH_NAMES, start=1)})
 
 
 def _parse_groq_deprecation_table(text: str) -> list[tuple[str, str, str]]:
@@ -120,6 +124,11 @@ def _parse_gemini_deprecation_table(text: str) -> list[tuple[str, str, str]]:
         month_name, dd, yyyy = date_m.groups()
         month = _MONTH_TO_NUM.get(month_name)
         if month is None:
+            logger.warning(
+                "EOL check: unrecognised month %r in Gemini shutdown cell %r — "
+                "row skipped (possible page-format change)",
+                month_name, shutdown_cell,
+            )
             continue
         dd_int = int(dd)
         if not (1 <= dd_int <= 31):
@@ -778,9 +787,15 @@ class ModelIntelligenceJob:
         )
         content = json.dumps({"title": title, **finding, "detected_at": now})
         # Stable dedup key — independent of detected_at / blast-radius churn.
+        # Includes vendor so two vendors deprecating the same model-id string on
+        # the same date don't suppress each other.
         dedup_key = hashlib.sha256(
             json.dumps(
-                {"model_id": model_id, "shutdown_date": shutdown_date},
+                {
+                    "model_id": model_id,
+                    "shutdown_date": shutdown_date,
+                    "vendor": finding.get("vendor", ""),
+                },
                 sort_keys=True,
             ).encode()
         ).hexdigest()

--- a/tests/test_recon/test_model_intelligence.py
+++ b/tests/test_recon/test_model_intelligence.py
@@ -423,6 +423,13 @@ class TestGeminiDeprecationParser:
         rows = _parse_gemini_deprecation_table(live)
         assert ("gemini-2.5-flash", "2026-10-16", "gemini-3.5-flash") in rows
 
+    def test_accepts_abbreviated_months(self) -> None:
+        # A narrowed column could abbreviate months — must NOT silently drop a
+        # real dated shutdown (the dangerous false-negative direction).
+        live = "`gemini-x`| Jan 5, 2026| Sep 30, 2027| `repl`\n"
+        rows = _parse_gemini_deprecation_table(live)
+        assert ("gemini-x", "2027-09-30", "repl") in rows
+
     def test_empty_or_garbage_returns_empty(self) -> None:
         assert _parse_gemini_deprecation_table("") == []
         assert _parse_gemini_deprecation_table("no tables here\njust text") == []
@@ -595,20 +602,44 @@ class TestActiveProvidersJob:
         assert google[0]["provider"] == "gemini-free"
 
     @pytest.mark.asyncio
-    async def test_check_active_providers_no_groq_short_circuits(self, db) -> None:
+    async def test_per_vendor_gating_google_only(self, db) -> None:
+        # google-only install: Gemini IS checked, Groq is never fetched.
         job = ModelIntelligenceJob(db=db)
         cfg = load_config_from_string(
             "providers:\n  g:\n    type: google\n    model: m\n    free: true\n"
             "call_sites:\n  s:\n    chain: [g]\n"
         )
-        mock_fetch = AsyncMock(return_value=[])
+        groq_fetch = AsyncMock(return_value=[])
+        gem_fetch = AsyncMock(return_value=[])
         with (
-            patch.object(job, "_fetch_groq_deprecations", mock_fetch),
+            patch.object(job, "_fetch_groq_deprecations", groq_fetch),
+            patch.object(job, "_fetch_gemini_deprecations", gem_fetch),
             patch("genesis.routing.config.load_config", return_value=cfg),
         ):
             findings = await job._check_active_providers()
         assert findings == []
-        mock_fetch.assert_not_called()  # no Groq providers → never fetches
+        groq_fetch.assert_not_called()  # no Groq providers → never fetches Groq
+        gem_fetch.assert_called_once()  # has Google provider → checks Gemini
+
+    @pytest.mark.asyncio
+    async def test_per_vendor_gating_groq_only(self, db) -> None:
+        # groq-only install: Groq IS checked, Gemini is never fetched.
+        job = ModelIntelligenceJob(db=db)
+        cfg = load_config_from_string(
+            "providers:\n  gq:\n    type: groq\n    model: m\n    free: true\n"
+            "call_sites:\n  s:\n    chain: [gq]\n"
+        )
+        groq_fetch = AsyncMock(return_value=[])
+        gem_fetch = AsyncMock(return_value=[])
+        with (
+            patch.object(job, "_fetch_groq_deprecations", groq_fetch),
+            patch.object(job, "_fetch_gemini_deprecations", gem_fetch),
+            patch("genesis.routing.config.load_config", return_value=cfg),
+        ):
+            findings = await job._check_active_providers()
+        assert findings == []
+        gem_fetch.assert_not_called()  # no Google providers → never fetches Gemini
+        groq_fetch.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_check_active_providers_config_failure_is_safe(self, db) -> None:

--- a/tests/test_recon/test_model_intelligence.py
+++ b/tests/test_recon/test_model_intelligence.py
@@ -11,6 +11,7 @@ import pytest
 from genesis.recon.model_intelligence import (
     ModelIntelligenceJob,
     _eol_findings_from_rows,
+    _parse_gemini_deprecation_table,
     _parse_groq_deprecation_table,
 )
 from genesis.routing.config import load_config_from_string
@@ -376,6 +377,60 @@ call_sites:
     chain: [groq-doomed, groq-free]
 """
 
+# Google's Gemini deprecations table: 4 columns, month-name dates, multi-section,
+# "No shutdown date announced" for undated models, a "Preview models" separator,
+# and a prose line. Only the two rows with a real dated shutdown must parse.
+_SAMPLE_GEMINI_TABLE = """\
+## Gemini 3 models
+| **Model** | **Release date** | **Shutdown date** | **Recommended replacement** |
+|---|---|---|---|
+| `gemini-3.5-flash` | May 19, 2026 | No shutdown date announced | |
+| `gemini-3.1-flash-lite` | May 7, 2026 | May 7, 2027 | |
+| Preview models ||||
+| `gemini-3-flash-preview` | December 17, 2025 | No shutdown date announced | `gemini-3.5-flash` |
+## Gemini 2.5 Flash models
+| `gemini-2.5-flash` | June 17, 2025 | October 16, 2026 | `gemini-3.5-flash` |
+Some prose | with a pipe but no date | here too | and here |
+"""
+
+
+class TestGeminiDeprecationParser:
+    """Pure parsing of Google's Gemini deprecations markdown table."""
+
+    def test_parses_dated_rows_only(self) -> None:
+        rows = _parse_gemini_deprecation_table(_SAMPLE_GEMINI_TABLE)
+        assert ("gemini-3.1-flash-lite", "2027-05-07", "") in rows
+        assert ("gemini-2.5-flash", "2026-10-16", "gemini-3.5-flash") in rows
+        assert len(rows) == 2
+
+    def test_skips_undated_models(self) -> None:
+        # "No shutdown date announced" models must NOT fire (the no-false-alarm
+        # case — exactly our current gemini-3-flash-preview situation).
+        models = [r[0] for r in _parse_gemini_deprecation_table(_SAMPLE_GEMINI_TABLE)]
+        assert "gemini-3.5-flash" not in models
+        assert "gemini-3-flash-preview" not in models
+
+    def test_skips_headers_separators_prose_and_preview_label(self) -> None:
+        models = [r[0] for r in _parse_gemini_deprecation_table(_SAMPLE_GEMINI_TABLE)]
+        assert "Model" not in models and "**Model**" not in models
+        assert all("---" not in m for m in models)
+        assert "Preview models" not in models
+        assert "Some prose" not in models
+
+    def test_no_surrounding_pipe_variant(self) -> None:
+        # genesis.web.fetch may render rows without surrounding pipes.
+        live = "`gemini-2.5-flash`| June 17, 2025| October 16, 2026| `gemini-3.5-flash`\n"
+        rows = _parse_gemini_deprecation_table(live)
+        assert ("gemini-2.5-flash", "2026-10-16", "gemini-3.5-flash") in rows
+
+    def test_empty_or_garbage_returns_empty(self) -> None:
+        assert _parse_gemini_deprecation_table("") == []
+        assert _parse_gemini_deprecation_table("no tables here\njust text") == []
+        assert _parse_gemini_deprecation_table(
+            "| **Model** | **Release date** | **Shutdown date** | **Replacement** |\n"
+            "|---|---|---|---|"
+        ) == []
+
 
 class TestGroqDeprecationParser:
     """Pure parsing of the Groq deprecations markdown table."""
@@ -466,10 +521,40 @@ class TestEOLMatcher:
         assert _eol_findings_from_rows(rows, cfg.providers, cfg.call_sites) == []
 
     def test_non_groq_model_ignored(self) -> None:
-        # vendor gate is groq — a google model string must not match
+        # default vendor gate is groq — a google model string must not match
         cfg = self._cfg()
         rows = [("gemini-3-flash-preview", "2026-06-01", "gemini-3.5-flash")]
         assert _eol_findings_from_rows(rows, cfg.providers, cfg.call_sites) == []
+
+    def test_fires_for_our_deprecated_gemini_model(self) -> None:
+        # The google vendor gate matches our active google provider and tags
+        # the finding with vendor/source + the right blast radius.
+        cfg = self._cfg()
+        rows = [("gemini-3-flash-preview", "2026-09-01", "gemini-3.5-flash")]
+        findings = _eol_findings_from_rows(
+            rows, cfg.providers, cfg.call_sites,
+            provider_type="google", vendor="google",
+            source="gemini_deprecations_page",
+        )
+        assert len(findings) == 1
+        f = findings[0]
+        assert f["model"] == "gemini-3-flash-preview"
+        assert f["provider"] == "gemini-free"
+        assert f["vendor"] == "google"
+        assert f["shutdown_date"] == "2026-09-01"
+        assert f["blast_radius"] == ["s_micro"]
+        assert f["source"] == "gemini_deprecations_page"
+
+    def test_google_gate_ignores_groq_model(self) -> None:
+        # symmetric to the groq gate: a groq model string must not match under
+        # the google gate (no cross-vendor false positives).
+        cfg = self._cfg()
+        rows = [("llama-3.3-70b-versatile", "2026-08-16", "x")]
+        assert _eol_findings_from_rows(
+            rows, cfg.providers, cfg.call_sites,
+            provider_type="google", vendor="google",
+            source="gemini_deprecations_page",
+        ) == []
 
 
 class TestActiveProvidersJob:
@@ -487,6 +572,27 @@ class TestActiveProvidersJob:
             findings = await job._check_active_providers()
         assert len(findings) == 1
         assert findings[0]["model"] == "moonshotai/kimi-k2-instruct-0905"
+
+    @pytest.mark.asyncio
+    async def test_check_active_providers_fires_gemini(self, db) -> None:
+        # The google vendor path runs independently of Groq and fires for an
+        # active gemini provider with a dated shutdown.
+        job = ModelIntelligenceJob(db=db)
+        cfg = load_config_from_string(_EOL_CONFIG_YAML)
+        gemini_rows = [("gemini-3-flash-preview", "2026-09-01", "gemini-3.5-flash")]
+        with (
+            patch.object(job, "_fetch_groq_deprecations", AsyncMock(return_value=[])),
+            patch.object(
+                job, "_fetch_gemini_deprecations",
+                AsyncMock(return_value=gemini_rows),
+            ),
+            patch("genesis.routing.config.load_config", return_value=cfg),
+        ):
+            findings = await job._check_active_providers()
+        google = [f for f in findings if f["vendor"] == "google"]
+        assert len(google) == 1
+        assert google[0]["model"] == "gemini-3-flash-preview"
+        assert google[0]["provider"] == "gemini-free"
 
     @pytest.mark.asyncio
     async def test_check_active_providers_no_groq_short_circuits(self, db) -> None:


### PR DESCRIPTION
WS3-A follow-on. The active-model EOL detector (#761) watched **only** Groq's deprecations page. This extends it to **Google/Gemini** — the highest-blast non-Groq vendor (`gemini-free` is chain[0] on ~27 call-sites).

## What
- **Generalize `_eol_findings_from_rows`** over `(provider_type, vendor, source)` — keyword defaults preserve the existing Groq behavior for all current callers/tests.
- **`_parse_gemini_deprecation_table`** — Gemini's table is 4 columns (`Model | Release | Shutdown | Replacement`) with month-name dates ("May 19, 2026"). Only rows with a *real dated shutdown* count; "No shutdown date announced", headers, separators, and "Preview models" rows are skipped. Accepts the no-surrounding-pipe render variant + 3-letter month abbreviations, and **warns (never silently drops)** on an unrecognised month — a missed EOL is the dangerous failure mode.
- **`_fetch_gemini_deprecations`** — fetches the **HTML doc** (`…/docs/deprecations`, rendered to markdown), *not* the `.md.txt` mirror, which `genesis.web.fetch` rejects as `text/markdown` (caught in live E2E).
- **`_check_active_providers`** now checks each vendor **independently** (removed the global `groq_count==0` short-circuit): a vendor's page is fetched only when we have an active provider of that type.
- Dedup key for `active_model_eol` now includes `vendor` (cross-vendor collision safety).

## Firehose-proof
Fires only for a model **we actually use** with a **real dated shutdown**. Our current `gemini-3-flash-preview` has *no* dated shutdown → correctly silent; it'll surface automatically the day Google dates a shutdown for whatever Gemini model we route to.

## Verification
- **Full wired-path LIVE E2E** (both real pages): Groq still flags `llama-3.3-70b-versatile`/Aug-16 (30 chains); Gemini correctly returns **0** findings (no dated shutdown for our model). Proves both paths fetch + parse + match end-to-end.
- 37 recon tests pass (10 new: parser, matcher, per-vendor gating, job path); ruff clean.
- Code-reviewed; 3 findings (silent-month-drop, dedup vendor, gating test gap) all fixed.

No DB migration (reuses the existing `observations` surfacing). Deploy = pull + restart; the weekly `model_intelligence` job picks it up.

Documented follow-up (unchanged): `/v1/models` catalog-diff for remaining OpenAI-compatible vendors; Mistral `archived` flag.
