### PR TITLE
feat(deliberation): deliberate() 'the chorus' — model-panel verdict + dissent

### DIFF
--- a/src/genesis/deliberation/__init__.py
+++ b/src/genesis/deliberation/__init__.py
@@ -1,0 +1,9 @@
+"""Deliberation — "the chorus" (Track 4, omnipresence layer).
+
+`deliberate()` asks a panel of models and returns a synthesized verdict + the dissent.
+"""
+
+from genesis.deliberation.core import deliberate
+from genesis.deliberation.types import DeliberationResult, PerModel
+
+__all__ = ["DeliberationResult", "PerModel", "deliberate"]

--- a/src/genesis/deliberation/backends/__init__.py
+++ b/src/genesis/deliberation/backends/__init__.py
@@ -1,0 +1,16 @@
+"""Deliberation backends registry.
+
+v1 ships Fusion only. Fugu (`model: fugu`) and a Genesis-orchestrated panel land as new
+files registered here, with no change to `deliberate()` or existing backends.
+"""
+
+from __future__ import annotations
+
+from genesis.deliberation.backends.base import Backend
+from genesis.deliberation.backends.fusion import FusionBackend
+
+BACKENDS: dict[str, Backend] = {"fusion": FusionBackend()}
+
+
+def get_backend(name: str) -> Backend | None:
+    return BACKENDS.get(name)

--- a/src/genesis/deliberation/backends/__init__.py
+++ b/src/genesis/deliberation/backends/__init__.py
@@ -13,4 +13,5 @@ BACKENDS: dict[str, Backend] = {"fusion": FusionBackend()}
 
 
 def get_backend(name: str) -> Backend | None:
+    """Return the registered backend by name, or None if unknown."""
     return BACKENDS.get(name)

--- a/src/genesis/deliberation/backends/base.py
+++ b/src/genesis/deliberation/backends/base.py
@@ -1,0 +1,27 @@
+"""Backend protocol for `deliberate()`.
+
+A backend turns a question into a DeliberationResult. It owns ALL error handling
+and returns ``DeliberationResult(error=...)`` on failure — it does not raise. New
+backends (Fugu, a Genesis-orchestrated panel) are added as new files implementing
+this Protocol, with no change to the core or to existing backends.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from genesis.deliberation.types import DeliberationResult
+
+
+class Backend(Protocol):
+    name: str
+
+    async def run(
+        self,
+        question: str,
+        *,
+        context: str | None,
+        stakes: str,
+        timeout_s: float,
+        models: list[str] | None,
+    ) -> DeliberationResult: ...

--- a/src/genesis/deliberation/backends/base.py
+++ b/src/genesis/deliberation/backends/base.py
@@ -23,6 +23,7 @@ class Backend(Protocol):
         context: str | None,
         stakes: str,
         mode: str,
+        preset: str | None,
         timeout_s: float,
         models: list[str] | None,
     ) -> DeliberationResult: ...

--- a/src/genesis/deliberation/backends/base.py
+++ b/src/genesis/deliberation/backends/base.py
@@ -22,6 +22,7 @@ class Backend(Protocol):
         *,
         context: str | None,
         stakes: str,
+        mode: str,
         timeout_s: float,
         models: list[str] | None,
     ) -> DeliberationResult: ...

--- a/src/genesis/deliberation/backends/fusion.py
+++ b/src/genesis/deliberation/backends/fusion.py
@@ -1,21 +1,23 @@
 """Fusion backend — OpenRouter Fusion (a server-side panel-of-models + judge).
 
-Two modes, both probe-confirmed live (2026-06-24):
+Two modes × two presets, all probe-confirmed live (2026-06-24):
 
-- **synthesis** (default, fast ~47s, ~$0.16): the `openrouter/fusion` model-slug. A meta-model
-  synthesizes the panel into a prose verdict in ``message.content``. It IGNORES output-format
-  instructions, so we take its markdown as the ``answer`` (consensus/dissent stay empty — the
-  disagreement is woven into the prose).
-- **analysis** (deep ~170s, ~$0.12): a free, tool-capable orchestrator + the Fusion *server-tool*
-  (`tools:[{"type":"openrouter:fusion"}]`, `tool_choice:"required"`, passed via extra_body so litellm
-  doesn't drop the non-standard tool). The orchestrator runs the panel, then — because it IS a normal
-  instruct model that honors a system prompt — returns machine-structured JSON
-  {answer, consensus, dissent[], blind_spots[], confidence}.
+- **synthesis** (default, fast): the `openrouter/fusion` model-slug → a synthesized prose verdict in
+  ``message.content`` (the meta-model IGNORES output-format prompts, so we take its markdown as the
+  ``answer``; consensus/dissent stay empty). Default preset: **budget**.
+- **analysis** (deep): a free, tool-capable orchestrator + the Fusion *server-tool*
+  (`tools:[{"type":"openrouter:fusion"}]`, `tool_choice:"required"`, via extra_body) → the orchestrator
+  (a normal instruct model that honors a JSON system prompt) returns machine-structured
+  {answer, consensus, dissent[], blind_spots[], confidence}. Default preset: **strong**.
 
-We call litellm directly (not the Router) to own the request shape, cost, and error handling — a
-documented exception to route-everything, justified by deliberate()'s structured-synthesis value.
-An explicit ``max_tokens`` is REQUIRED (litellm's 65536 default trips an OpenRouter 402); cost is read
-from ``response.usage.cost`` (``litellm.completion_cost`` can't price these aggregator strings).
+Presets control the panel (who deliberates): **strong** → OpenRouter's `general-high` (strongest panel);
+**budget** → `general-budget` (mid-tier panel, cheaper). Passed via the fusion `plugins` entry
+(synthesis) or the server-tool `parameters` (analysis). Verified: budget → sonnet-3.5/gpt-4o/gemini-1.5.
+
+We call `litellm.acompletion` directly (a documented exception to routing via the Router) to own the
+request shape and read side data: an explicit ``max_tokens`` is REQUIRED (litellm's 65536 default trips
+an OpenRouter 402); cost is read from ``response.usage.cost`` (``litellm.completion_cost`` can't price
+these aggregator strings).
 """
 
 from __future__ import annotations
@@ -37,11 +39,19 @@ logger = logging.getLogger(__name__)
 _MODEL = "openrouter/openrouter/fusion"
 # analysis: a free, tool-capable orchestrator that calls the fusion server-tool and returns structured JSON.
 _ANALYSIS_ORCHESTRATOR = "openrouter/openai/gpt-oss-120b:free"
-_ANALYSIS_EXTRA = {"tools": [{"type": "openrouter:fusion"}], "tool_choice": "required"}
+
+# Our two presets → OpenRouter's curated panel+judge slugs.
+_PRESET_SLUG = {"strong": "general-high", "budget": "general-budget"}
+# Mode-aware default when the caller doesn't specify a preset.
+_DEFAULT_PRESET = {"synthesis": "budget", "analysis": "strong"}
 
 _MAX_TOKENS = 2000  # explicit — the 65536 default trips OpenRouter's "fewer max_tokens" 402.
-_DEFAULT_TIMEOUT_S = 240.0  # analysis (panel + judge + orchestrator) runs ~170s; synthesis ~47s.
+_DEFAULT_TIMEOUT_S = 240.0  # analysis (panel + judge + orchestrator) runs ~120-170s; synthesis ~47-110s.
 _ANSWER_CAP = 6000
+# deliberate() bypasses the Router, so it owns its own retry on TRANSIENT provider errors (frontier
+# panels 429 under load — observed on the strong/general-high preset). 4xx and timeouts are NOT retried.
+_MAX_ATTEMPTS = 3
+_BACKOFF_S = 3.0
 
 _SYNTHESIS_SYSTEM = (
     "You are a panel of independent expert models with a judge. Deliberate on the user's question "
@@ -70,6 +80,12 @@ def _openrouter_key() -> str | None:
     return None
 
 
+def _resolve_preset(preset: str | None, mode: str) -> tuple[str, str]:
+    """(preset_name, openrouter_slug). Falls back to the mode-aware default for unknown/None."""
+    name = preset if preset in _PRESET_SLUG else _DEFAULT_PRESET.get(mode, "budget")
+    return name, _PRESET_SLUG[name]
+
+
 class FusionBackend:
     """OpenRouter Fusion backend — `synthesis` (model-slug) and `analysis` (server-tool) modes."""
 
@@ -82,10 +98,11 @@ class FusionBackend:
         context: str | None = None,
         stakes: str = "normal",
         mode: str = "synthesis",
+        preset: str | None = None,
         timeout_s: float = _DEFAULT_TIMEOUT_S,
-        models: list[str] | None = None,  # noqa: ARG002 — Fusion's panel is server-side
+        models: list[str] | None = None,  # noqa: ARG002 — panel is set via preset, not a client list
     ) -> DeliberationResult:
-        """Deliberate via Fusion in the given mode. Returns a DeliberationResult; never raises."""
+        """Deliberate via Fusion in the given mode/preset. Returns a DeliberationResult; never raises."""
         key = _openrouter_key()
         if not key:
             return DeliberationResult(
@@ -93,14 +110,21 @@ class FusionBackend:
             )
         user = question if not context else f"{question}\n\nContext:\n{context}"
         high = _HIGH_SUFFIX if stakes == "high" else ""
+        preset_name, slug = _resolve_preset(preset, mode)
         if mode == "analysis":
+            extra = {
+                "tools": [{"type": "openrouter:fusion", "parameters": {"preset": slug}}],
+                "tool_choice": "required",
+            }
             return await _call(
-                _ANALYSIS_ORCHESTRATOR, _ANALYSIS_SYSTEM + high, user, key, timeout_s, _ANALYSIS_EXTRA, "analysis"
+                _ANALYSIS_ORCHESTRATOR, _ANALYSIS_SYSTEM + high, user, key, timeout_s, extra,
+                "analysis", preset_name,
             )
-        return await _call(_MODEL, _SYNTHESIS_SYSTEM + high, user, key, timeout_s, None, "synthesis")
+        extra = {"plugins": [{"id": "fusion", "preset": slug}]}
+        return await _call(_MODEL, _SYNTHESIS_SYSTEM + high, user, key, timeout_s, extra, "synthesis", preset_name)
 
 
-async def _call(model, system, user, key, timeout_s, extra_body, mode) -> DeliberationResult:
+async def _call(model, system, user, key, timeout_s, extra_body, mode, preset) -> DeliberationResult:
     messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
     kwargs = {
         "model": model,
@@ -114,31 +138,44 @@ async def _call(model, system, user, key, timeout_s, extra_body, mode) -> Delibe
     if extra_body:
         kwargs["extra_body"] = extra_body
     t0 = time.perf_counter()
-    try:
-        resp = await asyncio.wait_for(litellm.acompletion(**kwargs), timeout=timeout_s + 10)
-    except (TimeoutError, litellm.Timeout):
-        return DeliberationResult(
-            answer=None,
-            backend_used=f"fusion/{mode}",
-            latency_s=time.perf_counter() - t0,
-            error=f"fusion ({mode}) timed out after ~{timeout_s:.0f}s",
-        )
-    except Exception as exc:  # noqa: BLE001 — map ALL litellm errors to a graceful result
-        return _error_result(exc, time.perf_counter() - t0, mode)
-    return _normalize(resp, time.perf_counter() - t0, mode)
+    last_exc: Exception | None = None
+    for attempt in range(_MAX_ATTEMPTS):
+        try:
+            resp = await asyncio.wait_for(litellm.acompletion(**kwargs), timeout=timeout_s + 10)
+        except (TimeoutError, litellm.Timeout):
+            return DeliberationResult(
+                answer=None,
+                backend_used=f"fusion/{mode}",
+                preset_used=preset,
+                latency_s=time.perf_counter() - t0,
+                error=f"fusion ({mode}) timed out after ~{timeout_s:.0f}s",
+            )
+        except (litellm.RateLimitError, litellm.ServiceUnavailableError) as exc:
+            # transient — back off and retry (frontier panels 429 under load)
+            last_exc = exc
+            if attempt + 1 < _MAX_ATTEMPTS:
+                await asyncio.sleep(_BACKOFF_S * (attempt + 1))
+                continue
+            return _error_result(exc, time.perf_counter() - t0, mode, preset)
+        except Exception as exc:  # noqa: BLE001 — map ALL other litellm errors to a graceful result
+            return _error_result(exc, time.perf_counter() - t0, mode, preset)
+        else:
+            return _normalize(resp, time.perf_counter() - t0, mode, preset)
+    return _error_result(last_exc or RuntimeError("retries exhausted"), time.perf_counter() - t0, mode, preset)
 
 
-def _error_result(exc: Exception, latency: float, mode: str) -> DeliberationResult:
+def _error_result(exc: Exception, latency: float, mode: str, preset: str) -> DeliberationResult:
     status = getattr(exc, "status_code", None)
     return DeliberationResult(
         answer=None,
         backend_used=f"fusion/{mode}",
+        preset_used=preset,
         latency_s=latency,
         error=f"fusion ({mode}) call failed ({type(exc).__name__}, status={status}): {str(exc)[:300]}",
     )
 
 
-def _normalize(resp: object, latency: float, mode: str) -> DeliberationResult:
+def _normalize(resp: object, latency: float, mode: str, preset: str) -> DeliberationResult:
     content = _content(resp)
     parsed = _parse_content(content)
     cost, cost_known = _extract_cost(resp)
@@ -151,6 +188,7 @@ def _normalize(resp: object, latency: float, mode: str) -> DeliberationResult:
         confidence=parsed.get("confidence"),
         per_model=(),
         backend_used=f"fusion/{mode}",
+        preset_used=preset,
         latency_s=latency,
         cost_usd=cost,
         cost_known=cost_known,

--- a/src/genesis/deliberation/backends/fusion.py
+++ b/src/genesis/deliberation/backends/fusion.py
@@ -1,0 +1,197 @@
+"""Fusion backend — OpenRouter Fusion (a server-side panel-of-models + judge).
+
+A single OpenAI-compatible call to `openrouter/fusion` runs a panel of expert models
+in parallel (with web search) and a judge synthesizes the result. We call litellm
+directly (not through the Router) so we can read whatever the response carries and
+own cost/error handling — a deliberate, documented exception to the route-everything
+convention, justified because deliberate()'s value is the structured synthesis.
+
+Probe-confirmed (live, 2026-06-24): the bare model-slug returns a synthesized answer in
+``message.content`` (markdown by default; we system-prompt for JSON), NO side fields; an
+explicit ``max_tokens`` is REQUIRED (litellm's 65536 default trips an OpenRouter 402);
+the real cost is in ``response.usage.cost`` (``litellm.completion_cost`` can't price it);
+latency is ~80s.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import time
+
+import litellm
+
+from genesis.deliberation.types import DeliberationResult
+
+logger = logging.getLogger(__name__)
+
+# litellm model string = openrouter prefix + the `openrouter/fusion` model id (probe-confirmed;
+# the bare `openrouter/fusion` 502s).
+_MODEL = "openrouter/openrouter/fusion"
+_MAX_TOKENS = 2000  # explicit — the 65536 default trips OpenRouter's "fewer max_tokens" 402.
+_DEFAULT_TIMEOUT_S = 180.0  # panel + web search runs ~80s; leave generous headroom.
+_ANSWER_CAP = 6000
+
+_SYSTEM = (
+    "You are a panel of independent expert models with a judge. Deliberate on the user's "
+    "question with genuine rigor. Return ONLY a JSON object (no markdown fences, no prose "
+    "outside the JSON) with keys: "
+    '"answer" (string — the recommendation/verdict), '
+    '"consensus" (string — what the panel broadly agrees on), '
+    '"dissent" (array of strings — genuine minority or contrarian points; [] only if the panel '
+    "truly agrees), "
+    '"confidence" (number between 0 and 1). '
+    "Surface real disagreement — never manufacture false consensus, never suppress a minority view."
+)
+_HIGH_SUFFIX = (
+    " This is a HIGH-STAKES decision: weight dissent heavily and flag even a single-model objection."
+)
+
+
+def _openrouter_key() -> str | None:
+    for var in ("API_KEY_OPENROUTER", "OPENROUTER_API_KEY", "OPENROUTER_API_TOKEN"):
+        val = os.environ.get(var)
+        if val and val not in ("None", "NA", ""):
+            return val
+    return None
+
+
+class FusionBackend:
+    name = "fusion"
+
+    async def run(
+        self,
+        question: str,
+        *,
+        context: str | None = None,
+        stakes: str = "normal",
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+        models: list[str] | None = None,  # noqa: ARG002 — Fusion's panel is server-side (plugin-only)
+    ) -> DeliberationResult:
+        key = _openrouter_key()
+        if not key:
+            return DeliberationResult(
+                answer=None, error="OpenRouter API key not configured (API_KEY_OPENROUTER)"
+            )
+        system = _SYSTEM + (_HIGH_SUFFIX if stakes == "high" else "")
+        user = question if not context else f"{question}\n\nContext:\n{context}"
+        messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ]
+        t0 = time.perf_counter()
+        try:
+            resp = await asyncio.wait_for(
+                litellm.acompletion(
+                    model=_MODEL,
+                    messages=messages,
+                    api_key=key,
+                    max_tokens=_MAX_TOKENS,
+                    drop_params=True,
+                    num_retries=0,
+                    timeout=timeout_s,
+                ),
+                timeout=timeout_s + 10,
+            )
+        except TimeoutError:
+            return DeliberationResult(
+                answer=None,
+                latency_s=time.perf_counter() - t0,
+                error=f"fusion timed out after ~{timeout_s:.0f}s",
+            )
+        except Exception as exc:  # noqa: BLE001 — map ALL litellm errors to a graceful result
+            return _error_result(exc, time.perf_counter() - t0)
+        return _normalize(resp, time.perf_counter() - t0)
+
+
+def _error_result(exc: Exception, latency: float) -> DeliberationResult:
+    status = getattr(exc, "status_code", None)
+    return DeliberationResult(
+        answer=None,
+        latency_s=latency,
+        error=f"fusion call failed ({type(exc).__name__}, status={status}): {str(exc)[:300]}",
+    )
+
+
+def _normalize(resp: object, latency: float) -> DeliberationResult:
+    content = _content(resp)
+    parsed = _parse_content(content)
+    cost, cost_known = _extract_cost(resp)
+    answer = parsed.get("answer") or (content[:_ANSWER_CAP] if content else None)
+    return DeliberationResult(
+        answer=answer,
+        consensus=parsed.get("consensus"),
+        dissent=tuple(parsed.get("dissent") or ()),
+        confidence=parsed.get("confidence"),
+        per_model=(),
+        backend_used="fusion",
+        latency_s=latency,
+        cost_usd=cost,
+        cost_known=cost_known,
+        error=None if content else "fusion returned empty content",
+    )
+
+
+def _content(resp: object) -> str:
+    try:
+        return resp.choices[0].message.content or ""  # type: ignore[attr-defined]
+    except (AttributeError, IndexError, TypeError):
+        return ""
+
+
+def _parse_content(content: str) -> dict:
+    """Dual-path: structured JSON if Fusion complied with the system prompt, else {} so the
+    caller falls back to the raw content as ``answer`` (still a rich verdict)."""
+    if not content:
+        return {}
+    candidates = [content]
+    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", content, re.DOTALL)
+    if fenced:
+        candidates.append(fenced.group(1))
+    braced = re.search(r"\{.*\}", content, re.DOTALL)
+    if braced:
+        candidates.append(braced.group(0))
+    for cand in candidates:
+        try:
+            obj = json.loads(cand)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(obj, dict) and ("answer" in obj or "consensus" in obj):
+            return _coerce(obj)
+    return {}
+
+
+def _coerce(obj: dict) -> dict:
+    out: dict = {}
+    if isinstance(obj.get("answer"), str):
+        out["answer"] = obj["answer"]
+    if isinstance(obj.get("consensus"), str):
+        out["consensus"] = obj["consensus"]
+    dissent = obj.get("dissent")
+    if isinstance(dissent, list):
+        out["dissent"] = [str(x) for x in dissent if x]
+    elif isinstance(dissent, str) and dissent.strip():
+        out["dissent"] = [dissent.strip()]
+    conf = obj.get("confidence")
+    if isinstance(conf, (int, float)) and not isinstance(conf, bool):
+        out["confidence"] = max(0.0, min(1.0, float(conf)))
+    return out
+
+
+def _extract_cost(resp: object) -> tuple[float, bool]:
+    """Cost lives in response.usage.cost (probe-confirmed); litellm.completion_cost can't price fusion."""
+    usage = getattr(resp, "usage", None)
+    if usage is not None:
+        cost = getattr(usage, "cost", None)
+        if cost is None and isinstance(usage, dict):
+            cost = usage.get("cost")
+        if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+            return float(cost), True
+    hidden = getattr(resp, "_hidden_params", {}) or {}
+    rc = hidden.get("response_cost") if isinstance(hidden, dict) else None
+    if isinstance(rc, (int, float)) and not isinstance(rc, bool):
+        return float(rc), True
+    return 0.0, False

--- a/src/genesis/deliberation/backends/fusion.py
+++ b/src/genesis/deliberation/backends/fusion.py
@@ -113,7 +113,7 @@ async def _call(model, system, user, key, timeout_s, extra_body, mode) -> Delibe
     t0 = time.perf_counter()
     try:
         resp = await asyncio.wait_for(litellm.acompletion(**kwargs), timeout=timeout_s + 10)
-    except TimeoutError:
+    except (TimeoutError, litellm.Timeout):
         return DeliberationResult(
             answer=None,
             backend_used=f"fusion/{mode}",
@@ -168,7 +168,7 @@ def _parse_content(content: str) -> dict:
     if not content:
         return {}
     candidates = [content]
-    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", content, re.DOTALL)
+    fenced = re.search(r"```(?:json)?\s*(\{.*\})\s*```", content, re.DOTALL)
     if fenced:
         candidates.append(fenced.group(1))
     braced = re.search(r"\{.*\}", content, re.DOTALL)

--- a/src/genesis/deliberation/backends/fusion.py
+++ b/src/genesis/deliberation/backends/fusion.py
@@ -71,6 +71,8 @@ def _openrouter_key() -> str | None:
 
 
 class FusionBackend:
+    """OpenRouter Fusion backend — `synthesis` (model-slug) and `analysis` (server-tool) modes."""
+
     name = "fusion"
 
     async def run(
@@ -83,6 +85,7 @@ class FusionBackend:
         timeout_s: float = _DEFAULT_TIMEOUT_S,
         models: list[str] | None = None,  # noqa: ARG002 — Fusion's panel is server-side
     ) -> DeliberationResult:
+        """Deliberate via Fusion in the given mode. Returns a DeliberationResult; never raises."""
         key = _openrouter_key()
         if not key:
             return DeliberationResult(

--- a/src/genesis/deliberation/backends/fusion.py
+++ b/src/genesis/deliberation/backends/fusion.py
@@ -1,16 +1,21 @@
 """Fusion backend — OpenRouter Fusion (a server-side panel-of-models + judge).
 
-A single OpenAI-compatible call to `openrouter/fusion` runs a panel of expert models
-in parallel (with web search) and a judge synthesizes the result. We call litellm
-directly (not through the Router) so we can read whatever the response carries and
-own cost/error handling — a deliberate, documented exception to the route-everything
-convention, justified because deliberate()'s value is the structured synthesis.
+Two modes, both probe-confirmed live (2026-06-24):
 
-Probe-confirmed (live, 2026-06-24): the bare model-slug returns a synthesized answer in
-``message.content`` (markdown by default; we system-prompt for JSON), NO side fields; an
-explicit ``max_tokens`` is REQUIRED (litellm's 65536 default trips an OpenRouter 402);
-the real cost is in ``response.usage.cost`` (``litellm.completion_cost`` can't price it);
-latency is ~80s.
+- **synthesis** (default, fast ~47s, ~$0.16): the `openrouter/fusion` model-slug. A meta-model
+  synthesizes the panel into a prose verdict in ``message.content``. It IGNORES output-format
+  instructions, so we take its markdown as the ``answer`` (consensus/dissent stay empty — the
+  disagreement is woven into the prose).
+- **analysis** (deep ~170s, ~$0.12): a free, tool-capable orchestrator + the Fusion *server-tool*
+  (`tools:[{"type":"openrouter:fusion"}]`, `tool_choice:"required"`, passed via extra_body so litellm
+  doesn't drop the non-standard tool). The orchestrator runs the panel, then — because it IS a normal
+  instruct model that honors a system prompt — returns machine-structured JSON
+  {answer, consensus, dissent[], blind_spots[], confidence}.
+
+We call litellm directly (not the Router) to own the request shape, cost, and error handling — a
+documented exception to route-everything, justified by deliberate()'s structured-synthesis value.
+An explicit ``max_tokens`` is REQUIRED (litellm's 65536 default trips an OpenRouter 402); cost is read
+from ``response.usage.cost`` (``litellm.completion_cost`` can't price these aggregator strings).
 """
 
 from __future__ import annotations
@@ -28,23 +33,29 @@ from genesis.deliberation.types import DeliberationResult
 
 logger = logging.getLogger(__name__)
 
-# litellm model string = openrouter prefix + the `openrouter/fusion` model id (probe-confirmed;
-# the bare `openrouter/fusion` 502s).
+# synthesis: openrouter prefix + the `openrouter/fusion` model id (probe-confirmed; bare `openrouter/fusion` 502s).
 _MODEL = "openrouter/openrouter/fusion"
+# analysis: a free, tool-capable orchestrator that calls the fusion server-tool and returns structured JSON.
+_ANALYSIS_ORCHESTRATOR = "openrouter/openai/gpt-oss-120b:free"
+_ANALYSIS_EXTRA = {"tools": [{"type": "openrouter:fusion"}], "tool_choice": "required"}
+
 _MAX_TOKENS = 2000  # explicit — the 65536 default trips OpenRouter's "fewer max_tokens" 402.
-_DEFAULT_TIMEOUT_S = 180.0  # panel + web search runs ~80s; leave generous headroom.
+_DEFAULT_TIMEOUT_S = 240.0  # analysis (panel + judge + orchestrator) runs ~170s; synthesis ~47s.
 _ANSWER_CAP = 6000
 
-_SYSTEM = (
-    "You are a panel of independent expert models with a judge. Deliberate on the user's "
-    "question with genuine rigor. Return ONLY a JSON object (no markdown fences, no prose "
-    "outside the JSON) with keys: "
-    '"answer" (string — the recommendation/verdict), '
-    '"consensus" (string — what the panel broadly agrees on), '
-    '"dissent" (array of strings — genuine minority or contrarian points; [] only if the panel '
-    "truly agrees), "
-    '"confidence" (number between 0 and 1). '
-    "Surface real disagreement — never manufacture false consensus, never suppress a minority view."
+_SYNTHESIS_SYSTEM = (
+    "You are a panel of independent expert models with a judge. Deliberate on the user's question "
+    "with genuine rigor. If you can, return a JSON object with keys answer, consensus, dissent (array), "
+    "confidence (0..1); otherwise give a clear verdict that explicitly surfaces where the panel "
+    "disagrees. Never manufacture false consensus; never suppress a minority view."
+)
+_ANALYSIS_SYSTEM = (
+    "You have a fusion tool that convenes a panel of expert models and a judge. Call it, then return "
+    "ONLY a JSON object (no prose outside the JSON) with keys: "
+    '"answer" (string verdict), "consensus" (string — what the panel agreed on), '
+    '"dissent" (array of strings — genuine minority/contrarian points from the panel), '
+    '"blind_spots" (array of strings — what no panel model addressed), '
+    '"confidence" (number 0..1). Surface real disagreement; never invent false consensus.'
 )
 _HIGH_SUFFIX = (
     " This is a HIGH-STAKES decision: weight dissent heavily and flag even a single-model objection."
@@ -68,55 +79,63 @@ class FusionBackend:
         *,
         context: str | None = None,
         stakes: str = "normal",
+        mode: str = "synthesis",
         timeout_s: float = _DEFAULT_TIMEOUT_S,
-        models: list[str] | None = None,  # noqa: ARG002 — Fusion's panel is server-side (plugin-only)
+        models: list[str] | None = None,  # noqa: ARG002 — Fusion's panel is server-side
     ) -> DeliberationResult:
         key = _openrouter_key()
         if not key:
             return DeliberationResult(
                 answer=None, error="OpenRouter API key not configured (API_KEY_OPENROUTER)"
             )
-        system = _SYSTEM + (_HIGH_SUFFIX if stakes == "high" else "")
         user = question if not context else f"{question}\n\nContext:\n{context}"
-        messages = [
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ]
-        t0 = time.perf_counter()
-        try:
-            resp = await asyncio.wait_for(
-                litellm.acompletion(
-                    model=_MODEL,
-                    messages=messages,
-                    api_key=key,
-                    max_tokens=_MAX_TOKENS,
-                    drop_params=True,
-                    num_retries=0,
-                    timeout=timeout_s,
-                ),
-                timeout=timeout_s + 10,
+        high = _HIGH_SUFFIX if stakes == "high" else ""
+        if mode == "analysis":
+            return await _call(
+                _ANALYSIS_ORCHESTRATOR, _ANALYSIS_SYSTEM + high, user, key, timeout_s, _ANALYSIS_EXTRA, "analysis"
             )
-        except TimeoutError:
-            return DeliberationResult(
-                answer=None,
-                latency_s=time.perf_counter() - t0,
-                error=f"fusion timed out after ~{timeout_s:.0f}s",
-            )
-        except Exception as exc:  # noqa: BLE001 — map ALL litellm errors to a graceful result
-            return _error_result(exc, time.perf_counter() - t0)
-        return _normalize(resp, time.perf_counter() - t0)
+        return await _call(_MODEL, _SYNTHESIS_SYSTEM + high, user, key, timeout_s, None, "synthesis")
 
 
-def _error_result(exc: Exception, latency: float) -> DeliberationResult:
+async def _call(model, system, user, key, timeout_s, extra_body, mode) -> DeliberationResult:
+    messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
+    kwargs = {
+        "model": model,
+        "messages": messages,
+        "api_key": key,
+        "max_tokens": _MAX_TOKENS,
+        "drop_params": True,
+        "num_retries": 0,
+        "timeout": timeout_s,
+    }
+    if extra_body:
+        kwargs["extra_body"] = extra_body
+    t0 = time.perf_counter()
+    try:
+        resp = await asyncio.wait_for(litellm.acompletion(**kwargs), timeout=timeout_s + 10)
+    except TimeoutError:
+        return DeliberationResult(
+            answer=None,
+            backend_used=f"fusion/{mode}",
+            latency_s=time.perf_counter() - t0,
+            error=f"fusion ({mode}) timed out after ~{timeout_s:.0f}s",
+        )
+    except Exception as exc:  # noqa: BLE001 — map ALL litellm errors to a graceful result
+        return _error_result(exc, time.perf_counter() - t0, mode)
+    return _normalize(resp, time.perf_counter() - t0, mode)
+
+
+def _error_result(exc: Exception, latency: float, mode: str) -> DeliberationResult:
     status = getattr(exc, "status_code", None)
     return DeliberationResult(
         answer=None,
+        backend_used=f"fusion/{mode}",
         latency_s=latency,
-        error=f"fusion call failed ({type(exc).__name__}, status={status}): {str(exc)[:300]}",
+        error=f"fusion ({mode}) call failed ({type(exc).__name__}, status={status}): {str(exc)[:300]}",
     )
 
 
-def _normalize(resp: object, latency: float) -> DeliberationResult:
+def _normalize(resp: object, latency: float, mode: str) -> DeliberationResult:
     content = _content(resp)
     parsed = _parse_content(content)
     cost, cost_known = _extract_cost(resp)
@@ -125,13 +144,14 @@ def _normalize(resp: object, latency: float) -> DeliberationResult:
         answer=answer,
         consensus=parsed.get("consensus"),
         dissent=tuple(parsed.get("dissent") or ()),
+        blind_spots=tuple(parsed.get("blind_spots") or ()),
         confidence=parsed.get("confidence"),
         per_model=(),
-        backend_used="fusion",
+        backend_used=f"fusion/{mode}",
         latency_s=latency,
         cost_usd=cost,
         cost_known=cost_known,
-        error=None if content else "fusion returned empty content",
+        error=None if content else f"fusion ({mode}) returned empty content",
     )
 
 
@@ -143,8 +163,8 @@ def _content(resp: object) -> str:
 
 
 def _parse_content(content: str) -> dict:
-    """Dual-path: structured JSON if Fusion complied with the system prompt, else {} so the
-    caller falls back to the raw content as ``answer`` (still a rich verdict)."""
+    """Dual-path: structured JSON when the model emits it (analysis mode, or a compliant synthesis),
+    else {} so the caller uses the raw content as ``answer`` (synthesis prose)."""
     if not content:
         return {}
     candidates = [content]
@@ -170,11 +190,12 @@ def _coerce(obj: dict) -> dict:
         out["answer"] = obj["answer"]
     if isinstance(obj.get("consensus"), str):
         out["consensus"] = obj["consensus"]
-    dissent = obj.get("dissent")
-    if isinstance(dissent, list):
-        out["dissent"] = [str(x) for x in dissent if x]
-    elif isinstance(dissent, str) and dissent.strip():
-        out["dissent"] = [dissent.strip()]
+    for key in ("dissent", "blind_spots"):
+        val = obj.get(key)
+        if isinstance(val, list):
+            out[key] = [str(x) for x in val if x]
+        elif isinstance(val, str) and val.strip():
+            out[key] = [val.strip()]
     conf = obj.get("confidence")
     if isinstance(conf, (int, float)) and not isinstance(conf, bool):
         out["confidence"] = max(0.0, min(1.0, float(conf)))
@@ -182,7 +203,7 @@ def _coerce(obj: dict) -> dict:
 
 
 def _extract_cost(resp: object) -> tuple[float, bool]:
-    """Cost lives in response.usage.cost (probe-confirmed); litellm.completion_cost can't price fusion."""
+    """Cost is in response.usage.cost (probe-confirmed); litellm.completion_cost can't price fusion."""
     usage = getattr(resp, "usage", None)
     if usage is not None:
         cost = getattr(usage, "cost", None)

--- a/src/genesis/deliberation/core.py
+++ b/src/genesis/deliberation/core.py
@@ -1,0 +1,60 @@
+"""`deliberate()` — the chorus.
+
+Ask a panel of models (via a backend) and return a synthesized verdict PLUS the dissent.
+Opt-in, recursion-blocked, never-raises. For genuinely high-stakes / explicit decisions —
+not a default judgment path.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextvars import ContextVar
+
+from genesis.deliberation.backends import get_backend
+from genesis.deliberation.types import DeliberationResult, Stakes
+
+logger = logging.getLogger(__name__)
+
+# Blocks a deliberate-within-deliberate (e.g. a future orchestrated backend whose panel
+# member re-invokes the tool). ContextVar propagates through awaits and resets cleanly.
+_in_deliberate: ContextVar[bool] = ContextVar("genesis_in_deliberate", default=False)
+
+
+async def deliberate(
+    question: str,
+    *,
+    context: str | None = None,
+    stakes: Stakes = "normal",
+    backend: str = "fusion",
+    timeout_s: float = 180.0,
+    models: list[str] | None = None,
+) -> DeliberationResult:
+    """Run a question through a chorus of models and return verdict + dissent.
+
+    Never raises — every failure comes back as ``DeliberationResult(error=...)``.
+    PAID (Fusion) and recursion-blocked.
+    """
+    if not question or not question.strip():
+        return DeliberationResult(answer=None, backend_used=backend, error="question is required")
+    if _in_deliberate.get():
+        return DeliberationResult(
+            answer=None,
+            backend_used=backend,
+            error="deliberate() is recursion-blocked (already inside a deliberation)",
+        )
+    be = get_backend(backend)
+    if be is None:
+        return DeliberationResult(answer=None, backend_used=backend, error=f"unknown backend: {backend}")
+    if stakes not in ("normal", "high"):
+        stakes = "normal"
+
+    token = _in_deliberate.set(True)
+    try:
+        return await be.run(question, context=context, stakes=stakes, timeout_s=timeout_s, models=models)
+    except Exception as exc:  # noqa: BLE001 — last-resort envelope; backends are not supposed to raise
+        logger.exception("deliberate() backend %s raised", backend)
+        return DeliberationResult(
+            answer=None, backend_used=backend, error=f"deliberate failed: {type(exc).__name__}: {exc}"
+        )
+    finally:
+        _in_deliberate.reset(token)

--- a/src/genesis/deliberation/core.py
+++ b/src/genesis/deliberation/core.py
@@ -26,7 +26,8 @@ async def deliberate(
     context: str | None = None,
     stakes: Stakes = "normal",
     backend: str = "fusion",
-    timeout_s: float = 180.0,
+    mode: str = "synthesis",
+    timeout_s: float = 240.0,
     models: list[str] | None = None,
 ) -> DeliberationResult:
     """Run a question through a chorus of models and return verdict + dissent.
@@ -50,7 +51,9 @@ async def deliberate(
 
     token = _in_deliberate.set(True)
     try:
-        return await be.run(question, context=context, stakes=stakes, timeout_s=timeout_s, models=models)
+        return await be.run(
+            question, context=context, stakes=stakes, mode=mode, timeout_s=timeout_s, models=models
+        )
     except Exception as exc:  # noqa: BLE001 — last-resort envelope; backends are not supposed to raise
         logger.exception("deliberate() backend %s raised", backend)
         return DeliberationResult(

--- a/src/genesis/deliberation/core.py
+++ b/src/genesis/deliberation/core.py
@@ -27,6 +27,7 @@ async def deliberate(
     stakes: Stakes = "normal",
     backend: str = "fusion",
     mode: str = "synthesis",
+    preset: str | None = None,
     timeout_s: float = 240.0,
     models: list[str] | None = None,
 ) -> DeliberationResult:
@@ -52,7 +53,8 @@ async def deliberate(
     token = _in_deliberate.set(True)
     try:
         return await be.run(
-            question, context=context, stakes=stakes, mode=mode, timeout_s=timeout_s, models=models
+            question, context=context, stakes=stakes, mode=mode, preset=preset,
+            timeout_s=timeout_s, models=models,
         )
     except Exception as exc:  # noqa: BLE001 — last-resort envelope; backends are not supposed to raise
         logger.exception("deliberate() backend %s raised", backend)

--- a/src/genesis/deliberation/types.py
+++ b/src/genesis/deliberation/types.py
@@ -29,6 +29,7 @@ class DeliberationResult:
     answer: str | None
     consensus: str | None = None
     dissent: tuple[str, ...] = ()
+    blind_spots: tuple[str, ...] = ()
     confidence: float | None = None
     per_model: tuple[PerModel, ...] = ()
     backend_used: str = "fusion"

--- a/src/genesis/deliberation/types.py
+++ b/src/genesis/deliberation/types.py
@@ -33,6 +33,7 @@ class DeliberationResult:
     confidence: float | None = None
     per_model: tuple[PerModel, ...] = ()
     backend_used: str = "fusion"
+    preset_used: str | None = None
     latency_s: float | None = None
     cost_usd: float = 0.0
     cost_known: bool = False

--- a/src/genesis/deliberation/types.py
+++ b/src/genesis/deliberation/types.py
@@ -1,0 +1,42 @@
+"""Types for `deliberate()` — the chorus (Track 4, omnipresence layer)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+Stakes = Literal["normal", "high"]
+
+
+@dataclass(frozen=True)
+class PerModel:
+    """A single panel member's position, when the backend exposes it."""
+
+    model: str
+    answer: str | None = None
+    stance: str | None = None  # "agree" | "dissent" | None
+
+
+@dataclass(frozen=True)
+class DeliberationResult:
+    """The outcome of a `deliberate()` call.
+
+    Frozen + tuple-typed to match the routing/types.py convention. ``error`` is the
+    single failure channel — ``deliberate()`` never raises; on failure ``answer`` is
+    None and ``error`` is set.
+    """
+
+    answer: str | None
+    consensus: str | None = None
+    dissent: tuple[str, ...] = ()
+    confidence: float | None = None
+    per_model: tuple[PerModel, ...] = ()
+    backend_used: str = "fusion"
+    latency_s: float | None = None
+    cost_usd: float = 0.0
+    cost_known: bool = False
+    error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -62,6 +62,7 @@ from genesis.mcp.health import campaign_tools as _campaign_tools  # noqa: E402, 
 from genesis.mcp.health import codebase as _codebase  # noqa: E402
 from genesis.mcp.health import cognitive_ledger_tools as _cognitive_ledger_tools  # noqa: E402, F401
 from genesis.mcp.health import db_schema as _db_schema  # noqa: E402
+from genesis.mcp.health import deliberation_tools as _deliberation_tools  # noqa: E402
 from genesis.mcp.health import direct_session_tools as _direct_session_tools  # noqa: E402
 from genesis.mcp.health import ego_calibration as _ego_calibration  # noqa: E402, F401
 from genesis.mcp.health import ego_tools as _ego_tools  # noqa: E402
@@ -95,6 +96,7 @@ update_history = _update_history
 
 _impl_codebase_navigate = _codebase._impl_codebase_navigate
 _impl_db_schema = _db_schema._impl_db_schema
+_impl_deliberate = _deliberation_tools._impl_deliberate
 _impl_health_errors = _errors._impl_health_errors
 _impl_health_alerts = _errors._impl_health_alerts
 _impl_bootstrap_manifest = _manifest._impl_bootstrap_manifest

--- a/src/genesis/mcp/health/deliberation_tools.py
+++ b/src/genesis/mcp/health/deliberation_tools.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 async def _impl_deliberate(
-    question: str, context: str = "", stakes: str = "normal", mode: str = "synthesis"
+    question: str, context: str = "", stakes: str = "normal", mode: str = "synthesis", preset: str = ""
 ) -> dict:
     from genesis.deliberation import deliberate
 
@@ -24,7 +24,10 @@ async def _impl_deliberate(
         stakes = "normal"
     if mode not in ("synthesis", "analysis"):
         mode = "synthesis"
-    result = await deliberate(question, context=(context or None), stakes=stakes, mode=mode, backend="fusion")
+    preset_arg = preset if preset in ("strong", "budget") else None
+    result = await deliberate(
+        question, context=(context or None), stakes=stakes, mode=mode, preset=preset_arg, backend="fusion"
+    )
     return {
         "answer": result.answer,
         "consensus": result.consensus,
@@ -35,6 +38,7 @@ async def _impl_deliberate(
             {"model": pm.model, "answer": pm.answer, "stance": pm.stance} for pm in result.per_model
         ],
         "backend_used": result.backend_used,
+        "preset_used": result.preset_used,
         "latency_s": round(result.latency_s, 1) if result.latency_s is not None else None,
         "cost_usd": result.cost_usd,
         "cost_known": result.cost_known,
@@ -44,7 +48,7 @@ async def _impl_deliberate(
 
 @mcp.tool()
 async def deliberate(
-    question: str, context: str = "", stakes: str = "normal", mode: str = "synthesis"
+    question: str, context: str = "", stakes: str = "normal", mode: str = "synthesis", preset: str = ""
 ) -> dict:
     """Consult a chorus of models (a server-side panel + judge) for a verdict PLUS the dissent —
     for genuinely high-stakes or contested decisions.
@@ -56,10 +60,13 @@ async def deliberate(
       question: the decision or question to deliberate.
       context:  optional background to ground the panel.
       stakes:   "normal" (default) or "high" (weights dissent more heavily).
-      mode:     "synthesis" (default) = fast (~45-60s) prose verdict; "analysis" = deeper (~2-3min)
+      mode:     "synthesis" (default) = fast prose verdict; "analysis" = deeper (~2-3min)
                 machine-structured consensus + dissent[] + blind_spots[].
+      preset:   "" = mode default (synthesis→budget, analysis→strong); "strong" = general-high panel
+                (frontier models); "budget" = general-budget panel (mid-tier, cheaper/faster).
 
-    Returns {answer, consensus, dissent[], blind_spots[], confidence, per_model[], cost_usd,
-    cost_known, latency_s, error}. On failure, answer is null and error is set (never raises).
+    Returns {answer, consensus, dissent[], blind_spots[], confidence, per_model[], backend_used,
+    preset_used, cost_usd, cost_known, latency_s, error}. On failure, answer is null and error is set
+    (never raises).
     """
-    return await _impl_deliberate(question, context, stakes, mode)
+    return await _impl_deliberate(question, context, stakes, mode, preset)

--- a/src/genesis/mcp/health/deliberation_tools.py
+++ b/src/genesis/mcp/health/deliberation_tools.py
@@ -13,18 +13,23 @@ from genesis.mcp.health import mcp
 logger = logging.getLogger(__name__)
 
 
-async def _impl_deliberate(question: str, context: str = "", stakes: str = "normal") -> dict:
+async def _impl_deliberate(
+    question: str, context: str = "", stakes: str = "normal", mode: str = "synthesis"
+) -> dict:
     from genesis.deliberation import deliberate
 
     if not question or not question.strip():
         return {"error": "question is required"}
     if stakes not in ("normal", "high"):
         stakes = "normal"
-    result = await deliberate(question, context=(context or None), stakes=stakes, backend="fusion")
+    if mode not in ("synthesis", "analysis"):
+        mode = "synthesis"
+    result = await deliberate(question, context=(context or None), stakes=stakes, mode=mode, backend="fusion")
     return {
         "answer": result.answer,
         "consensus": result.consensus,
         "dissent": list(result.dissent),
+        "blind_spots": list(result.blind_spots),
         "confidence": result.confidence,
         "per_model": [
             {"model": pm.model, "answer": pm.answer, "stance": pm.stance} for pm in result.per_model
@@ -38,20 +43,23 @@ async def _impl_deliberate(question: str, context: str = "", stakes: str = "norm
 
 
 @mcp.tool()
-async def deliberate(question: str, context: str = "", stakes: str = "normal") -> dict:
-    """Consult a chorus of models (a server-side panel + judge) for a synthesized verdict PLUS
-    the dissent — for genuinely high-stakes or contested decisions.
+async def deliberate(
+    question: str, context: str = "", stakes: str = "normal", mode: str = "synthesis"
+) -> dict:
+    """Consult a chorus of models (a server-side panel + judge) for a verdict PLUS the dissent —
+    for genuinely high-stakes or contested decisions.
 
-    PAID + opt-in: routes to OpenRouter Fusion (non-free; a panel deliberates with web search,
-    ~60-90s). Use ONLY for high-stakes/explicit calls — never as a default judgment path.
-    Recursion-blocked.
+    PAID + opt-in: routes to OpenRouter Fusion (non-free). Use ONLY for high-stakes/explicit calls —
+    never as a default judgment path. Recursion-blocked.
 
     Args:
       question: the decision or question to deliberate.
       context:  optional background to ground the panel.
       stakes:   "normal" (default) or "high" (weights dissent more heavily).
+      mode:     "synthesis" (default) = fast (~45-60s) prose verdict; "analysis" = deeper (~2-3min)
+                machine-structured consensus + dissent[] + blind_spots[].
 
-    Returns {answer, consensus, dissent[], confidence, per_model[], cost_usd, cost_known,
-    latency_s, error}. On failure, answer is null and error is set (never raises).
+    Returns {answer, consensus, dissent[], blind_spots[], confidence, per_model[], cost_usd,
+    cost_known, latency_s, error}. On failure, answer is null and error is set (never raises).
     """
-    return await _impl_deliberate(question, context, stakes)
+    return await _impl_deliberate(question, context, stakes, mode)

--- a/src/genesis/mcp/health/deliberation_tools.py
+++ b/src/genesis/mcp/health/deliberation_tools.py
@@ -1,0 +1,57 @@
+"""MCP tool for `deliberate()` — "the chorus". On the genesis-health server.
+
+On-demand surface: lets a CC/chat session consult a panel of models for a high-stakes
+or contested decision and get back a synthesized verdict plus the explicit dissent.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+
+async def _impl_deliberate(question: str, context: str = "", stakes: str = "normal") -> dict:
+    from genesis.deliberation import deliberate
+
+    if not question or not question.strip():
+        return {"error": "question is required"}
+    if stakes not in ("normal", "high"):
+        stakes = "normal"
+    result = await deliberate(question, context=(context or None), stakes=stakes, backend="fusion")
+    return {
+        "answer": result.answer,
+        "consensus": result.consensus,
+        "dissent": list(result.dissent),
+        "confidence": result.confidence,
+        "per_model": [
+            {"model": pm.model, "answer": pm.answer, "stance": pm.stance} for pm in result.per_model
+        ],
+        "backend_used": result.backend_used,
+        "latency_s": round(result.latency_s, 1) if result.latency_s is not None else None,
+        "cost_usd": result.cost_usd,
+        "cost_known": result.cost_known,
+        "error": result.error,
+    }
+
+
+@mcp.tool()
+async def deliberate(question: str, context: str = "", stakes: str = "normal") -> dict:
+    """Consult a chorus of models (a server-side panel + judge) for a synthesized verdict PLUS
+    the dissent — for genuinely high-stakes or contested decisions.
+
+    PAID + opt-in: routes to OpenRouter Fusion (non-free; a panel deliberates with web search,
+    ~60-90s). Use ONLY for high-stakes/explicit calls — never as a default judgment path.
+    Recursion-blocked.
+
+    Args:
+      question: the decision or question to deliberate.
+      context:  optional background to ground the panel.
+      stakes:   "normal" (default) or "high" (weights dissent more heavily).
+
+    Returns {answer, consensus, dissent[], confidence, per_model[], cost_usd, cost_known,
+    latency_s, error}. On failure, answer is null and error is set (never raises).
+    """
+    return await _impl_deliberate(question, context, stakes)

--- a/tests/test_deliberation/test_deliberate.py
+++ b/tests/test_deliberation/test_deliberate.py
@@ -1,0 +1,232 @@
+"""Tests for deliberate() — the chorus. litellm is mocked; no live calls."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from genesis.deliberation import DeliberationResult, deliberate
+from genesis.deliberation.backends.fusion import (
+    FusionBackend,
+    _extract_cost,
+    _normalize,
+    _parse_content,
+)
+
+# ── fixtures: real-shaped litellm responses ──────────────────────────────────
+# PROSE = the actual probe output (2026-06-24): bare model-slug returns synthesized
+# MARKDOWN in message.content, no structured fields.
+PROSE = (
+    "# Recommendation: Cut now — but cut surgically\n\n"
+    "**B is a trap dressed up as ambition** and the math gives it away.\n"
+    "## When B is actually defensible\nOnly if PMF is strong and investors are already warm."
+)
+JSON_OK = (
+    '{"answer": "Cut now, surgically.", "consensus": "Time and runway beat headcount.", '
+    '"dissent": ["B is right if PMF is strong and a Series A investor is already warm."], '
+    '"confidence": 0.82}'
+)
+JSON_FENCED = "```json\n" + JSON_OK + "\n```"
+JSON_IN_PROSE = "Here is the panel's verdict.\n\n" + JSON_OK + "\n\nHope that helps."
+
+
+def _resp(content, cost=None):
+    """Mimic the litellm ModelResponse shape the backend reads."""
+    msg = SimpleNamespace(content=content)
+    usage = SimpleNamespace(cost=cost) if cost is not None else SimpleNamespace()
+    return SimpleNamespace(choices=[SimpleNamespace(message=msg)], usage=usage, _hidden_params={})
+
+
+# ── parser / normalizer ──────────────────────────────────────────────────────
+
+
+def test_parse_prose_returns_empty():
+    assert _parse_content(PROSE) == {}
+
+
+def test_parse_json():
+    p = _parse_content(JSON_OK)
+    assert p["answer"].startswith("Cut now")
+    assert p["consensus"]
+    assert p["dissent"] == ["B is right if PMF is strong and a Series A investor is already warm."]
+    assert p["confidence"] == 0.82
+
+
+def test_parse_fenced_json():
+    p = _parse_content(JSON_FENCED)
+    assert p["answer"].startswith("Cut now")
+    assert len(p["dissent"]) == 1
+
+
+def test_parse_json_embedded_in_prose():
+    p = _parse_content(JSON_IN_PROSE)
+    assert p.get("answer", "").startswith("Cut now")
+
+
+def test_confidence_clamped():
+    assert _parse_content('{"answer":"x","confidence":1.7}')["confidence"] == 1.0
+
+
+def test_dissent_string_coerced_to_list():
+    assert _parse_content('{"answer":"x","dissent":"single point"}')["dissent"] == ["single point"]
+
+
+def test_normalize_prose_uses_content_as_answer():
+    r = _normalize(_resp(PROSE, cost=0.3211), latency=80.0)
+    assert r.ok
+    assert r.answer.startswith("# Recommendation")
+    assert r.dissent == ()
+    assert r.cost_usd == 0.3211 and r.cost_known
+    assert r.latency_s == 80.0
+
+
+def test_normalize_json_structured():
+    r = _normalize(_resp(JSON_OK, cost=0.05), latency=70.0)
+    assert r.answer.startswith("Cut now")
+    assert r.consensus and len(r.dissent) == 1 and r.confidence == 0.82
+
+
+def test_normalize_empty_content_errors():
+    r = _normalize(_resp("", cost=0.01), latency=1.0)
+    assert not r.ok and "empty" in r.error
+
+
+def test_extract_cost_from_usage():
+    cost, known = _extract_cost(_resp("x", cost=0.42))
+    assert cost == 0.42 and known
+
+
+def test_extract_cost_unknown():
+    cost, known = _extract_cost(_resp("x"))
+    assert cost == 0.0 and not known
+
+
+# ── FusionBackend.run (litellm mocked) ───────────────────────────────────────
+
+
+async def test_fusion_happy(monkeypatch):
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+    with patch(
+        "genesis.deliberation.backends.fusion.litellm.acompletion",
+        new=AsyncMock(return_value=_resp(JSON_OK, cost=0.05)),
+    ) as m:
+        r = await FusionBackend().run("q", stakes="high")
+    assert r.ok and r.answer.startswith("Cut now")
+    assert r.cost_usd == 0.05 and r.cost_known and isinstance(r.latency_s, float)
+    kwargs = m.call_args.kwargs
+    assert "HIGH-STAKES" in kwargs["messages"][0]["content"]  # stakes strengthens system prompt
+    assert kwargs["max_tokens"] == 2000  # explicit max_tokens (the 402 guard)
+    assert kwargs["model"] == "openrouter/openrouter/fusion"
+
+
+async def test_fusion_no_key(monkeypatch):
+    for var in ("API_KEY_OPENROUTER", "OPENROUTER_API_KEY", "OPENROUTER_API_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    r = await FusionBackend().run("q")
+    assert not r.ok and "API key" in r.error
+
+
+async def test_fusion_error_graceful(monkeypatch):
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+    with patch(
+        "genesis.deliberation.backends.fusion.litellm.acompletion",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        r = await FusionBackend().run("q")
+    assert not r.ok and "fusion call failed" in r.error
+
+
+async def test_fusion_timeout_graceful(monkeypatch):
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+    with patch(
+        "genesis.deliberation.backends.fusion.litellm.acompletion",
+        new=AsyncMock(side_effect=TimeoutError()),
+    ):
+        r = await FusionBackend().run("q", timeout_s=1.0)
+    assert not r.ok and "timed out" in r.error
+
+
+# ── deliberate() core ────────────────────────────────────────────────────────
+
+
+async def test_empty_question():
+    r = await deliberate("   ")
+    assert not r.ok and "required" in r.error
+
+
+async def test_unknown_backend():
+    r = await deliberate("q", backend="nope")
+    assert not r.ok and "unknown backend" in r.error
+
+
+async def test_recursion_blocked(monkeypatch):
+    captured = {}
+
+    class Stub:
+        name = "stub"
+
+        async def run(self, q, **kw):
+            captured["inner"] = await deliberate("again", backend="stub")
+            return DeliberationResult(answer="outer")
+
+    monkeypatch.setattr("genesis.deliberation.core.get_backend", lambda n: Stub())
+    out = await deliberate("x", backend="stub")
+    assert out.answer == "outer"
+    assert "recursion-blocked" in captured["inner"].error
+
+
+async def test_recursion_resets_after_call(monkeypatch):
+    class Stub:
+        name = "stub"
+
+        async def run(self, q, **kw):
+            return DeliberationResult(answer="ok")
+
+    monkeypatch.setattr("genesis.deliberation.core.get_backend", lambda n: Stub())
+    await deliberate("x", backend="stub")
+    r2 = await deliberate("y", backend="stub")
+    assert r2.answer == "ok"
+
+
+async def test_backend_receives_stakes_and_context(monkeypatch):
+    seen = {}
+
+    class Stub:
+        name = "stub"
+
+        async def run(self, q, *, context, stakes, timeout_s, models):
+            seen.update(q=q, context=context, stakes=stakes)
+            return DeliberationResult(answer="ok")
+
+    monkeypatch.setattr("genesis.deliberation.core.get_backend", lambda n: Stub())
+    await deliberate("decide", context="bg", stakes="high", backend="stub")
+    assert seen == {"q": "decide", "context": "bg", "stakes": "high"}
+
+
+# ── MCP tool ─────────────────────────────────────────────────────────────────
+
+
+async def test_deliberate_tool_registered():
+    from genesis.mcp.health_mcp import mcp
+
+    tools = await mcp.get_tools()
+    assert "deliberate" in tools
+
+
+async def test_mcp_impl_graceful(monkeypatch):
+    import genesis.deliberation as dl
+
+    async def fake(q, **kw):
+        return DeliberationResult(
+            answer="A", consensus="C", dissent=("d1",), confidence=0.5,
+            cost_usd=0.1, cost_known=True, latency_s=70.0,
+        )
+
+    monkeypatch.setattr(dl, "deliberate", fake)
+    from genesis.mcp.health import deliberation_tools as dt
+
+    out = await dt._impl_deliberate("q")
+    assert out["answer"] == "A"
+    assert out["dissent"] == ["d1"]
+    assert out["cost_known"] is True
+    assert out["latency_s"] == 70.0

--- a/tests/test_deliberation/test_deliberate.py
+++ b/tests/test_deliberation/test_deliberate.py
@@ -28,6 +28,16 @@ JSON_OK = (
 )
 JSON_FENCED = "```json\n" + JSON_OK + "\n```"
 JSON_IN_PROSE = "Here is the panel's verdict.\n\n" + JSON_OK + "\n\nHope that helps."
+# ANALYSIS mode: the orchestrator returns clean structured JSON (real probe output, 2026-06-24).
+ANALYSIS_JSON = (
+    '{"answer": "Choose A — harden reliability; reserve ~20-30% for one high-impact feature.", '
+    '"consensus": "All three models agreed churn is the biggest risk, usually from reliability.", '
+    '"dissent": ["If churn is a missing-feature problem, one feature beats reliability.", '
+    '"A pure tech-debt quarter can unsettle investors and demotivate the team.", '
+    '"Not all debt causes churn; target paydown surgically."], '
+    '"blind_spots": ["Concrete churn-reason data.", "Runway/burn and fundraise timing."], '
+    '"confidence": 0.81}'
+)
 
 
 def _resp(content, cost=None):
@@ -71,23 +81,38 @@ def test_dissent_string_coerced_to_list():
     assert _parse_content('{"answer":"x","dissent":"single point"}')["dissent"] == ["single point"]
 
 
+def test_parse_blind_spots():
+    assert _parse_content('{"answer":"x","blind_spots":["b1","b2"]}')["blind_spots"] == ["b1", "b2"]
+
+
 def test_normalize_prose_uses_content_as_answer():
-    r = _normalize(_resp(PROSE, cost=0.3211), latency=80.0)
+    r = _normalize(_resp(PROSE, cost=0.3211), 80.0, "synthesis")
     assert r.ok
     assert r.answer.startswith("# Recommendation")
     assert r.dissent == ()
     assert r.cost_usd == 0.3211 and r.cost_known
     assert r.latency_s == 80.0
+    assert r.backend_used == "fusion/synthesis"
 
 
 def test_normalize_json_structured():
-    r = _normalize(_resp(JSON_OK, cost=0.05), latency=70.0)
+    r = _normalize(_resp(JSON_OK, cost=0.05), 70.0, "synthesis")
     assert r.answer.startswith("Cut now")
     assert r.consensus and len(r.dissent) == 1 and r.confidence == 0.82
 
 
+def test_normalize_analysis_structured():
+    r = _normalize(_resp(ANALYSIS_JSON, cost=0.12), 173.0, "analysis")
+    assert r.answer.startswith("Choose A")
+    assert len(r.dissent) == 3
+    assert len(r.blind_spots) == 2
+    assert r.confidence == 0.81
+    assert r.backend_used == "fusion/analysis"
+    assert r.cost_usd == 0.12 and r.cost_known
+
+
 def test_normalize_empty_content_errors():
-    r = _normalize(_resp("", cost=0.01), latency=1.0)
+    r = _normalize(_resp("", cost=0.01), 1.0, "synthesis")
     assert not r.ok and "empty" in r.error
 
 
@@ -119,6 +144,20 @@ async def test_fusion_happy(monkeypatch):
     assert kwargs["model"] == "openrouter/openrouter/fusion"
 
 
+async def test_fusion_analysis_mode_request(monkeypatch):
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+    with patch(
+        "genesis.deliberation.backends.fusion.litellm.acompletion",
+        new=AsyncMock(return_value=_resp(ANALYSIS_JSON, cost=0.12)),
+    ) as m:
+        r = await FusionBackend().run("q", mode="analysis")
+    assert r.ok and len(r.dissent) == 3 and r.backend_used == "fusion/analysis"
+    kwargs = m.call_args.kwargs
+    assert kwargs["model"] == "openrouter/openai/gpt-oss-120b:free"
+    assert kwargs["extra_body"]["tools"][0]["type"] == "openrouter:fusion"
+    assert kwargs["extra_body"]["tool_choice"] == "required"
+
+
 async def test_fusion_no_key(monkeypatch):
     for var in ("API_KEY_OPENROUTER", "OPENROUTER_API_KEY", "OPENROUTER_API_TOKEN"):
         monkeypatch.delenv(var, raising=False)
@@ -133,7 +172,7 @@ async def test_fusion_error_graceful(monkeypatch):
         new=AsyncMock(side_effect=RuntimeError("boom")),
     ):
         r = await FusionBackend().run("q")
-    assert not r.ok and "fusion call failed" in r.error
+    assert not r.ok and "call failed" in r.error
 
 
 async def test_fusion_timeout_graceful(monkeypatch):
@@ -194,13 +233,13 @@ async def test_backend_receives_stakes_and_context(monkeypatch):
     class Stub:
         name = "stub"
 
-        async def run(self, q, *, context, stakes, timeout_s, models):
-            seen.update(q=q, context=context, stakes=stakes)
+        async def run(self, q, *, context, stakes, mode, timeout_s, models):
+            seen.update(q=q, context=context, stakes=stakes, mode=mode)
             return DeliberationResult(answer="ok")
 
     monkeypatch.setattr("genesis.deliberation.core.get_backend", lambda n: Stub())
-    await deliberate("decide", context="bg", stakes="high", backend="stub")
-    assert seen == {"q": "decide", "context": "bg", "stakes": "high"}
+    await deliberate("decide", context="bg", stakes="high", mode="analysis", backend="stub")
+    assert seen == {"q": "decide", "context": "bg", "stakes": "high", "mode": "analysis"}
 
 
 # ── MCP tool ─────────────────────────────────────────────────────────────────

--- a/tests/test_deliberation/test_deliberate.py
+++ b/tests/test_deliberation/test_deliberate.py
@@ -11,6 +11,7 @@ from genesis.deliberation.backends.fusion import (
     _extract_cost,
     _normalize,
     _parse_content,
+    _resolve_preset,
 )
 
 # ── fixtures: real-shaped litellm responses ──────────────────────────────────
@@ -86,34 +87,43 @@ def test_parse_blind_spots():
 
 
 def test_normalize_prose_uses_content_as_answer():
-    r = _normalize(_resp(PROSE, cost=0.3211), 80.0, "synthesis")
+    r = _normalize(_resp(PROSE, cost=0.3211), 80.0, "synthesis", "budget")
     assert r.ok
     assert r.answer.startswith("# Recommendation")
     assert r.dissent == ()
     assert r.cost_usd == 0.3211 and r.cost_known
     assert r.latency_s == 80.0
-    assert r.backend_used == "fusion/synthesis"
+    assert r.backend_used == "fusion/synthesis" and r.preset_used == "budget"
 
 
 def test_normalize_json_structured():
-    r = _normalize(_resp(JSON_OK, cost=0.05), 70.0, "synthesis")
+    r = _normalize(_resp(JSON_OK, cost=0.05), 70.0, "synthesis", "budget")
     assert r.answer.startswith("Cut now")
     assert r.consensus and len(r.dissent) == 1 and r.confidence == 0.82
 
 
 def test_normalize_analysis_structured():
-    r = _normalize(_resp(ANALYSIS_JSON, cost=0.12), 173.0, "analysis")
+    r = _normalize(_resp(ANALYSIS_JSON, cost=0.12), 173.0, "analysis", "strong")
     assert r.answer.startswith("Choose A")
     assert len(r.dissent) == 3
     assert len(r.blind_spots) == 2
     assert r.confidence == 0.81
-    assert r.backend_used == "fusion/analysis"
+    assert r.backend_used == "fusion/analysis" and r.preset_used == "strong"
     assert r.cost_usd == 0.12 and r.cost_known
 
 
 def test_normalize_empty_content_errors():
-    r = _normalize(_resp("", cost=0.01), 1.0, "synthesis")
+    r = _normalize(_resp("", cost=0.01), 1.0, "synthesis", "budget")
     assert not r.ok and "empty" in r.error
+
+
+def test_resolve_preset_mapping_and_defaults():
+    assert _resolve_preset("strong", "synthesis") == ("strong", "general-high")
+    assert _resolve_preset("budget", "analysis") == ("budget", "general-budget")
+    # mode-aware defaults when preset is None/unknown
+    assert _resolve_preset(None, "synthesis") == ("budget", "general-budget")
+    assert _resolve_preset(None, "analysis") == ("strong", "general-high")
+    assert _resolve_preset("bogus", "analysis") == ("strong", "general-high")
 
 
 def test_extract_cost_from_usage():
@@ -138,10 +148,12 @@ async def test_fusion_happy(monkeypatch):
         r = await FusionBackend().run("q", stakes="high")
     assert r.ok and r.answer.startswith("Cut now")
     assert r.cost_usd == 0.05 and r.cost_known and isinstance(r.latency_s, float)
+    assert r.preset_used == "budget"  # synthesis default preset
     kwargs = m.call_args.kwargs
     assert "HIGH-STAKES" in kwargs["messages"][0]["content"]  # stakes strengthens system prompt
     assert kwargs["max_tokens"] == 2000  # explicit max_tokens (the 402 guard)
     assert kwargs["model"] == "openrouter/openrouter/fusion"
+    assert kwargs["extra_body"]["plugins"][0]["preset"] == "general-budget"
 
 
 async def test_fusion_analysis_mode_request(monkeypatch):
@@ -152,10 +164,23 @@ async def test_fusion_analysis_mode_request(monkeypatch):
     ) as m:
         r = await FusionBackend().run("q", mode="analysis")
     assert r.ok and len(r.dissent) == 3 and r.backend_used == "fusion/analysis"
+    assert r.preset_used == "strong"  # analysis default preset
     kwargs = m.call_args.kwargs
     assert kwargs["model"] == "openrouter/openai/gpt-oss-120b:free"
     assert kwargs["extra_body"]["tools"][0]["type"] == "openrouter:fusion"
+    assert kwargs["extra_body"]["tools"][0]["parameters"]["preset"] == "general-high"
     assert kwargs["extra_body"]["tool_choice"] == "required"
+
+
+async def test_fusion_preset_override(monkeypatch):
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+    with patch(
+        "genesis.deliberation.backends.fusion.litellm.acompletion",
+        new=AsyncMock(return_value=_resp(ANALYSIS_JSON, cost=0.12)),
+    ) as m:
+        r = await FusionBackend().run("q", mode="analysis", preset="budget")
+    assert r.preset_used == "budget"
+    assert m.call_args.kwargs["extra_body"]["tools"][0]["parameters"]["preset"] == "general-budget"
 
 
 async def test_fusion_no_key(monkeypatch):
@@ -196,6 +221,30 @@ async def test_fusion_litellm_timeout_graceful(monkeypatch):
     ):
         r = await FusionBackend().run("q", timeout_s=1.0)
     assert not r.ok and "timed out" in r.error
+
+
+async def test_fusion_retries_on_ratelimit(monkeypatch):
+    import litellm
+
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+    monkeypatch.setattr("genesis.deliberation.backends.fusion._BACKOFF_S", 0.0)
+    rle = litellm.RateLimitError(message="429", model="m", llm_provider="openrouter")
+    mock = AsyncMock(side_effect=[rle, rle, _resp(JSON_OK, cost=0.05)])  # fail twice, then succeed
+    with patch("genesis.deliberation.backends.fusion.litellm.acompletion", new=mock):
+        r = await FusionBackend().run("q")
+    assert r.ok and r.answer.startswith("Cut now")
+    assert mock.call_count == 3  # 1 + 2 retries
+
+
+async def test_fusion_ratelimit_exhausted(monkeypatch):
+    import litellm
+
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+    monkeypatch.setattr("genesis.deliberation.backends.fusion._BACKOFF_S", 0.0)
+    rle = litellm.RateLimitError(message="429", model="m", llm_provider="openrouter")
+    with patch("genesis.deliberation.backends.fusion.litellm.acompletion", new=AsyncMock(side_effect=rle)):
+        r = await FusionBackend().run("q")
+    assert not r.ok and "call failed" in r.error
 
 
 # ── deliberate() core ────────────────────────────────────────────────────────
@@ -246,13 +295,15 @@ async def test_backend_receives_stakes_and_context(monkeypatch):
     class Stub:
         name = "stub"
 
-        async def run(self, q, *, context, stakes, mode, timeout_s, models):
-            seen.update(q=q, context=context, stakes=stakes, mode=mode)
+        async def run(self, q, *, context, stakes, mode, preset, timeout_s, models):
+            seen.update(q=q, context=context, stakes=stakes, mode=mode, preset=preset)
             return DeliberationResult(answer="ok")
 
     monkeypatch.setattr("genesis.deliberation.core.get_backend", lambda n: Stub())
-    await deliberate("decide", context="bg", stakes="high", mode="analysis", backend="stub")
-    assert seen == {"q": "decide", "context": "bg", "stakes": "high", "mode": "analysis"}
+    await deliberate("decide", context="bg", stakes="high", mode="analysis", preset="budget", backend="stub")
+    assert seen == {
+        "q": "decide", "context": "bg", "stakes": "high", "mode": "analysis", "preset": "budget"
+    }
 
 
 # ── MCP tool ─────────────────────────────────────────────────────────────────

--- a/tests/test_deliberation/test_deliberate.py
+++ b/tests/test_deliberation/test_deliberate.py
@@ -185,6 +185,19 @@ async def test_fusion_timeout_graceful(monkeypatch):
     assert not r.ok and "timed out" in r.error
 
 
+async def test_fusion_litellm_timeout_graceful(monkeypatch):
+    import litellm
+
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+    exc = litellm.Timeout(message="slow", model="m", llm_provider="openrouter")
+    with patch(
+        "genesis.deliberation.backends.fusion.litellm.acompletion",
+        new=AsyncMock(side_effect=exc),
+    ):
+        r = await FusionBackend().run("q", timeout_s=1.0)
+    assert not r.ok and "timed out" in r.error
+
+
 # ── deliberate() core ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Adds `deliberate()` — "the chorus" — a cognitive primitive that consults a panel of models and returns
a synthesized verdict (and, in analysis mode, the explicit disagreement). Exposed as the on-demand
`mcp__genesis-health__deliberate` tool, for genuinely high-stakes or contested decisions where one
narrow model isn't enough. Opt-in, **paid** (OpenRouter Fusion), recursion-blocked, and never raises
(failures come back as `error`). Not wired into any production judgment path.

## Two modes

- **`synthesis`** (default): the `openrouter/fusion` model-slug — a server-side panel + judge produces
  a fast prose verdict (~45–110s); the disagreement is woven into the prose.
- **`analysis`**: a free, tool-capable orchestrator + the Fusion **server-tool** — returns
  **machine-structured** `{consensus, dissent[], blind_spots[], confidence}` (~3 min). Use when you
  need deep, separable disagreement.

## Design

- New package `src/genesis/deliberation/` (types, core, backends/) behind a `Backend` protocol, so
  additional backends drop in without touching existing code.
- The Fusion backend calls `litellm.acompletion` directly (a documented exception to routing through
  the Router) so it can own the request shape, read the real per-call cost from `response.usage.cost`
  (litellm can't price these aggregator model strings), and map every error to a graceful result.
- Explicit `max_tokens` (the provider's default trips a 402); the server-tool config is passed via
  `extra_body` so it isn't dropped; cost/latency captured per call. ContextVar recursion guard.

## Testing

- 26 unit tests (`tests/test_deliberation/`): both modes, the parser (structured JSON + prose fallback +
  fenced/embedded JSON), recursion guard, error/timeout handling, cost extraction, and MCP registration.
  litellm is mocked; real response captures are used as fixtures.
- Existing health-MCP tests unaffected. Both modes verified live end-to-end.

## Notes

- Self-contained — no `model_routing.yaml` / `model_profiles.yaml` changes (the model string is a
  constant; cost is read from the response).
- New MCP tools become available to Claude Code on the next session.
- First on-demand surface of the deliberation track; call-site consumers and additional backends are
  future work.
