### PR TITLE
feat(evo): human-gated reflection-prompt promotion (Evo PR-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Added
+
+- **Genesis can now propose improvements to how it reflects — and apply them only with your approval.**
+  The Evo loop measures variations of the deep-reflection prompt against a golden set
+  (with held-out re-validation), and when one is a confirmed improvement it files a
+  proposal on the dashboard. Approving it updates the live reflection prompt; the change
+  is fully reversible (one click rolls it back). Nothing is ever applied automatically —
+  Genesis recommends, you decide.
+
 ### Changed
 
 - **The dashboard Infrastructure card now labels the ambient-capture bridge as "Voice Bridge"** —

--- a/src/genesis/autonomy/classification.py
+++ b/src/genesis/autonomy/classification.py
@@ -288,6 +288,11 @@ ACTION_TYPE_DOMAIN_MAP: dict[str, ActionDomain] = {
     "payment": ActionDomain.FINANCIAL,
     "code_change": ActionDomain.SELF_MODIFY,
     "refactor": ActionDomain.SELF_MODIFY,
+    # Evo promotion rewrites Genesis's own deep-reflection prompt — a change to
+    # its cognition. SELF_MODIFY is hard-blocked from background dispatch
+    # (ACTION_DOMAIN_MIN_LEVEL = None), so an approved promotion can never be
+    # auto-run as a session; it is applied ONLY by its resolution handler.
+    "cognitive_variant_promotion": ActionDomain.SELF_MODIFY,
 }
 
 

--- a/src/genesis/dashboard/routes/comms.py
+++ b/src/genesis/dashboard/routes/comms.py
@@ -226,6 +226,14 @@ async def comms_resolve_proposal(proposal_id: str):
             await handle_cell_promotion_resolution(rt.db, prop, status)
         except Exception:
             logger.warning("cell promotion hook failed for %s", proposal_id)
+        try:
+            from genesis.ego.cognitive_variant import (
+                handle_cognitive_variant_resolution,
+            )
+
+            await handle_cognitive_variant_resolution(rt.db, prop, status)
+        except Exception:
+            logger.warning("cognitive-variant hook failed for %s", proposal_id)
 
     # Trigger delayed sweep on approval — same 5-min grace as Telegram,
     # so the user can revoke before dispatch fires.

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -368,6 +368,16 @@ async def ego_proposal_resolve(proposal_id: str):
             _logging.getLogger(__name__).warning(
                 "cell promotion hook failed for %s", proposal_id,
             )
+        try:
+            from genesis.ego.cognitive_variant import (
+                handle_cognitive_variant_resolution,
+            )
+
+            await handle_cognitive_variant_resolution(rt._db, prop, status)
+        except Exception:
+            _logging.getLogger(__name__).warning(
+                "cognitive-variant hook failed for %s", proposal_id,
+            )
 
     return jsonify({"ok": True, "id": proposal_id, "status": status})
 

--- a/src/genesis/ego/cognitive_variant.py
+++ b/src/genesis/ego/cognitive_variant.py
@@ -1,0 +1,163 @@
+"""Cognitive-variant promotion — the resolution hook fired when a
+``cognitive_variant_promotion`` proposal is resolved (Evo PR-B).
+
+The proposal carries a reflection-prompt winner that Evo measured against the
+canonical prompt (held-out validated, above the confidence floor). **Recommend-
+only:** the prompt is applied to the live deep-reflection overlay ONLY on the
+user's explicit approval, never autonomously — the user is the gate.
+
+Like ``autonomy_earnback`` / ``goal_status_change`` / ``cell_promotion``, a
+proposal can be resolved from four entry points (a Telegram reply, the
+``ego_proposal_resolve`` MCP tool, and two dashboard routes), so the apply logic
+lives here and every path calls it identically.
+
+The write goes through ``cognitive_ledger.record_file_modification`` so it
+captures a pre-image and is reversible via ``cognitive_modification_rollback``.
+The proposal is marked ``executed`` UNCONDITIONALLY after an approval (even if
+the write fails) so it never lingers ``approved`` — the dispatch sweep/briefs
+guards are defense-in-depth; this is the primary recommend-only guarantee.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+
+import aiosqlite
+
+from genesis.db.crud import ego as ego_crud
+
+logger = logging.getLogger(__name__)
+
+COGNITIVE_VARIANT_ACTION_TYPE = "cognitive_variant_promotion"
+
+# Minimum confidence to apply a promotion. Belt-and-suspenders: the promote path
+# (``promote_evo_winner``) already refuses to FILE below this, but the handler
+# re-checks so a sub-floor proposal that arrives by any other route is refused.
+_MIN_PROMOTE_CONFIDENCE = 0.75
+
+# The deep-reflection prompt file. Must match the name the reflection bridge
+# reads — ``_prompts._DEPTH_FILES[Depth.DEEP]`` (test_overlay_target_matches_
+# bridge_read guards against drift).
+_OVERLAY_FILENAME = "REFLECTION_DEEP.md"
+
+
+def _parse_expected_outputs(expected_outputs: object) -> dict:
+    """Decode a proposal's ``expected_outputs`` (stored as JSON) to a dict.
+    Returns ``{}`` on anything unparseable."""
+    data = expected_outputs
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except (ValueError, TypeError):
+            return {}
+    return data if isinstance(data, dict) else {}
+
+
+async def _mark_executed(db: aiosqlite.Connection, proposal: dict, response: str) -> None:
+    """Mark the proposal ``executed`` (best-effort) so it never lingers
+    ``approved``."""
+    with contextlib.suppress(Exception):
+        await ego_crud.execute_proposal(
+            db, proposal["id"], status="executed", user_response=response,
+        )
+
+
+async def handle_cognitive_variant_resolution(
+    db: aiosqlite.Connection,
+    proposal: dict,
+    status: object,
+) -> bool:
+    """Apply the reflection-prompt promotion side-effect of resolving *proposal*.
+
+    No-op unless *proposal* is a ``cognitive_variant_promotion`` proposal.
+    On rejection / any non-approved status: no-op (recommend-only — declining
+    changes nothing). On approval: validate the winner prompt + confidence floor,
+    write it to the live reflection overlay via the rollback-able cognitive
+    ledger, and mark the proposal ``executed``.
+
+    *status* may be a ``ProposalStatus`` enum or a plain string.
+    Returns True iff the overlay was written.
+    """
+    if proposal.get("action_type") != COGNITIVE_VARIANT_ACTION_TYPE:
+        return False
+
+    status_str = getattr(status, "value", status)
+    if status_str != "approved":
+        # Recommend-only: a declined / pending / failed proposal is left as-is.
+        return False
+
+    spec = _parse_expected_outputs(proposal.get("expected_outputs"))
+    full_prompt = spec.get("full_prompt")
+
+    # Validate before any write. An approved-but-unappliable proposal is marked
+    # executed (not left 'approved') so it doesn't clutter the board / get swept.
+    if not isinstance(full_prompt, str) or not full_prompt.strip():
+        logger.warning(
+            "cognitive_variant promotion %s refused: missing/empty full_prompt",
+            proposal.get("id"),
+        )
+        await _mark_executed(db, proposal, "promotion refused: missing prompt")
+        return False
+
+    try:
+        confidence = float(proposal.get("confidence") or 0.0)
+    except (TypeError, ValueError):
+        confidence = 0.0
+    if confidence < _MIN_PROMOTE_CONFIDENCE:
+        logger.warning(
+            "cognitive_variant promotion %s refused: confidence %.2f < floor %.2f",
+            proposal.get("id"), confidence, _MIN_PROMOTE_CONFIDENCE,
+        )
+        await _mark_executed(
+            db, proposal,
+            f"promotion refused: confidence {confidence:.2f} below floor",
+        )
+        return False
+
+    # Apply: write the winner to the live deep-reflection overlay via the ledger
+    # (captures a pre-image; reversible via cognitive_modification_rollback).
+    from genesis.cc.reflection_bridge._prompts import _reflection_override_dir
+    from genesis.learning import cognitive_ledger
+
+    overlay_path = _reflection_override_dir() / _OVERLAY_FILENAME
+    mod_id: str | None = None
+    ok = False
+    try:
+        mod_id = await cognitive_ledger.record_file_modification(
+            db,
+            actor="evo_promotion",
+            path=overlay_path,
+            new_content=full_prompt,
+            summary=f"Evo reflection-prompt promotion: {spec.get('approach', 'variant')}",
+            metadata={
+                "proposal_id": proposal.get("id"),
+                "approach": spec.get("approach"),
+                "evidence": spec.get("evidence"),
+            },
+        )
+        ok = True
+    except Exception:
+        logger.warning(
+            "cognitive_variant promotion %s: overlay write failed",
+            proposal.get("id"), exc_info=True,
+        )
+
+    # Mark executed UNCONDITIONALLY — even if the write failed. An approved
+    # proposal that stayed 'approved' could be grabbed by the dispatch sweep;
+    # the blocklist + SELF_MODIFY gate guard that, but this removes the risk at
+    # the source (mirrors goal_actions / cell_promotion).
+    await _mark_executed(
+        db, proposal,
+        f"reflection prompt promoted (mod {mod_id})" if ok
+        else "reflection prompt promotion failed (write error)",
+    )
+
+    if ok:
+        logger.info(
+            "Cognitive variant promoted: reflection overlay updated at %s "
+            "(mod=%s, user approved)",
+            overlay_path, mod_id,
+        )
+    return ok

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -564,6 +564,19 @@ class ProposalWorkflow:
                         "cell promotion hook failed for %s",
                         prop.get("id"), exc_info=True,
                     )
+                # Cognitive variant promotion (Evo PR-B): apply the reflection
+                # prompt winner to the overlay on approval.
+                try:
+                    from genesis.ego.cognitive_variant import (
+                        handle_cognitive_variant_resolution,
+                    )
+
+                    await handle_cognitive_variant_resolution(self._db, prop, status)
+                except Exception:
+                    logger.warning(
+                        "cognitive-variant hook failed for %s",
+                        prop.get("id"), exc_info=True,
+                    )
             else:
                 logger.warning(
                     "Proposal %s not updated (already resolved?)",

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -58,6 +58,19 @@ _DEFAULT_PROMPT_PATH = Path(__file__).resolve().parent.parent / "identity" / "EG
 _DEFAULT_CALL_SITE = "7_ego_cycle"
 _DEFAULT_FOCUS_SUMMARY_KEY = "ego_focus_summary"
 
+# Action_types that are applied + marked 'executed' by their resolution handler
+# at approval time and must NEVER be auto-dispatched as a background session.
+# Single source of truth for BOTH dispatch paths (the approved-sweep and the
+# execution-briefs path). cognitive_variant_promotion (Evo prompt promotion) is
+# also hard-blocked by the autonomy domain gate (SELF_MODIFY) — this is
+# defense-in-depth that holds even if that gate is absent or fails open.
+_NEVER_DISPATCH_ACTION_TYPES = (
+    "autonomy_earnback",
+    "goal_status_change",
+    "cell_promotion",
+    "cognitive_variant_promotion",
+)
+
 
 class CycleBlockedError(Exception):
     """Raised when the ego cycle is blocked by an approval gate.
@@ -1348,6 +1361,29 @@ class EgoSession:
             if not proposal_id or not prompt:
                 continue
 
+            # Never-dispatch guard (defense-in-depth, gate-independent): the
+            # approved-sweep path has an action_type blocklist; this path did
+            # not. Apply-at-approval action_types (resolved + marked 'executed'
+            # by their handler) must NEVER be auto-run as a session — this holds
+            # even if the autonomy gate below is absent or fails open. On a load
+            # failure we skip (conservative): we can't confirm it's safe.
+            try:
+                _brief_prop = await ego_crud.get_proposal(self._db, proposal_id)
+            except Exception:
+                logger.warning(
+                    "Execution brief %s: proposal load failed (blocklist check) — skipping",
+                    proposal_id, exc_info=True,
+                )
+                continue
+            if (_brief_prop is not None
+                    and _brief_prop.get("action_type") in _NEVER_DISPATCH_ACTION_TYPES):
+                logger.info(
+                    "Execution brief %s skipped — action_type %r is apply-at-approval "
+                    "(never dispatched as a session)",
+                    proposal_id, _brief_prop.get("action_type"),
+                )
+                continue
+
             # Append content firewall rules to ego-authored dispatch prompt.
             # The ego writes the brief prompt directly — this safety net
             # catches information that slips through the ego's own judgment.
@@ -1776,9 +1812,7 @@ class EgoSession:
             # (applied + marked executed) at approval time and must NEVER be
             # dispatched as a session. Defense-in-depth in case one is still
             # 'approved' here.
-            if prop.get("action_type") in (
-                "autonomy_earnback", "goal_status_change", "cell_promotion",
-            ):
+            if prop.get("action_type") in _NEVER_DISPATCH_ACTION_TYPES:
                 continue
             # Staleness guard — skip proposals approved more than 7 days ago.
             # Proposals go stale by clock only as a safety net; semantic

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -551,6 +551,15 @@ async def ego_proposal_resolve(
                     await handle_cell_promotion_resolution(db, prop, status)
                 except Exception:
                     logger.debug("cell promotion hook failed", exc_info=True)
+                # Cognitive variant promotion (Evo PR-B).
+                try:
+                    from genesis.ego.cognitive_variant import (
+                        handle_cognitive_variant_resolution,
+                    )
+
+                    await handle_cognitive_variant_resolution(db, prop, status)
+                except Exception:
+                    logger.debug("cognitive-variant hook failed", exc_info=True)
 
     resolved = sum(1 for v in results.values() if v in ("approved", "rejected"))
     return {

--- a/src/genesis/mcp/health/evo_run.py
+++ b/src/genesis/mcp/health/evo_run.py
@@ -83,7 +83,7 @@ def _resolve_canonical_base_prompt() -> str:
     resolved = _resolve_prompt_in_dir(Depth.DEEP, _DEFAULT_PROMPT_DIR)
     if resolved is not None:
         return resolved
-    return _FALLBACK_PROMPTS.get(Depth.DEEP, _FALLBACK_PROMPTS[Depth.DEEP])
+    return _FALLBACK_PROMPTS[Depth.DEEP]
 
 
 async def promote_evo_winner(

--- a/src/genesis/mcp/health/evo_run.py
+++ b/src/genesis/mcp/health/evo_run.py
@@ -141,6 +141,13 @@ async def promote_evo_winner(
         f"{result.candidates_evaluated} survivors at the Bonferroni alpha/N gate. "
         f"Judged via {judge_provider}; generated via {gen_provider}."
     )
+    if gen_provider == judge_provider:
+        # Self-scoring caveat (architect): same provider generates AND judges, so
+        # scores may be optimistic. Surface it so the user can discount.
+        rationale += (
+            f" CAVEAT: generator and judge share a provider ({gen_provider}) — "
+            "scores may be optimistic; a cross-provider re-run would strengthen this."
+        )
     execution_plan = (
         "On approval: writes this prompt to the deep-reflection overlay "
         "(~/.genesis/config/reflection/REFLECTION_DEEP.md) via the cognitive "

--- a/src/genesis/mcp/health/evo_run.py
+++ b/src/genesis/mcp/health/evo_run.py
@@ -1,13 +1,19 @@
 """evo_run MCP tool — run one Evo generation and recommend the winner.
 
-Generates N diverse variants of the current deep-reflection prompt, tests each
-vs the current prompt over the golden set (Bonferroni alpha/N gate + held-out
+Generates N diverse variants of the CANONICAL deep-reflection prompt, tests each
+vs that prompt over the golden set (Bonferroni alpha/N gate + held-out
 re-validation), and RETURNS the best confirmed variant as a recommendation.
 
-RECOMMEND-ONLY: it measures and recommends; it does NOT promote/apply anything
-(no overlay write, no proposal). ``autonomous_action`` is always False. The
-promotion path (a human-gated cognitive_variant_promotion proposal) is separate
-future work.
+RECOMMEND-ONLY: it measures and recommends; it NEVER mutates cognition itself.
+When ``propose`` is set (default), a confirmed winner is FILED as a human-gated
+``cognitive_variant_promotion`` proposal (dashboard-delivered) — nothing is
+applied until the user approves it, and approval writes the overlay reversibly.
+``autonomous_action`` is always False.
+
+Variants are built by appending a directive to the CANONICAL repo prompt (NOT
+the overlay), and the winner that gets filed is exactly that ``canonical +
+directive`` — so what is measured equals what is applied and repeated
+promotions never stack directives.
 """
 
 from __future__ import annotations
@@ -15,6 +21,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from genesis.ego.cognitive_variant import _MIN_PROMOTE_CONFIDENCE as _PROMOTE_FLOOR
 from genesis.mcp.health import mcp
 
 logger = logging.getLogger(__name__)
@@ -58,13 +65,111 @@ def _build_routers(gen_provider: str, judge_provider: str):
     return gen_router, judge_router, LLMJudgeScorer(router=judge_router)
 
 
-def _resolve_base_prompt() -> str:
-    """The current EFFECTIVE deep-reflection prompt (overlay-aware)."""
+def _resolve_canonical_base_prompt() -> str:
+    """The CANONICAL repo deep-reflection prompt, IGNORING the overlay.
+
+    Evo measures variants against this and the promoted overlay is written as
+    ``canonical + winning_directive`` — so measured == applied and repeated
+    promotions never stack directives. Using the overlay-aware resolver here
+    (``system_prompt_for_depth``) would re-read a prior promotion and compound.
+    """
     from genesis.awareness.types import Depth
     from genesis.cc.reflection_bridge._bridge import _DEFAULT_PROMPT_DIR
-    from genesis.cc.reflection_bridge._prompts import system_prompt_for_depth
+    from genesis.cc.reflection_bridge._prompts import (
+        _FALLBACK_PROMPTS,
+        _resolve_prompt_in_dir,
+    )
 
-    return system_prompt_for_depth(Depth.DEEP, _DEFAULT_PROMPT_DIR)
+    resolved = _resolve_prompt_in_dir(Depth.DEEP, _DEFAULT_PROMPT_DIR)
+    if resolved is not None:
+        return resolved
+    return _FALLBACK_PROMPTS.get(Depth.DEEP, _FALLBACK_PROMPTS[Depth.DEEP])
+
+
+async def promote_evo_winner(
+    db: object,
+    result,
+    *,
+    gen_provider: str,
+    judge_provider: str,
+) -> str | None:
+    """File a recommend-only ``cognitive_variant_promotion`` proposal for a
+    confirmed Evo winner. Returns the proposal id, or ``None`` if there is no
+    winner or its confidence is below the floor.
+
+    Stores the proposal in ``ego_proposals`` (dashboard-delivered + approvable);
+    nothing is applied until the user approves it. The 13KB winner prompt rides
+    in ``expected_outputs`` (NOT rendered in the digest); ``content`` carries a
+    human summary.
+    """
+    winner = result.winner
+    if winner is None:
+        return None
+
+    hwr = result.holdout_winrate or {}
+    holdout_p = hwr.get("p_value")
+    if holdout_p is None:
+        # No held-out p-value → can't establish confidence → don't file.
+        logger.info("evo promote: no held-out p_value — not filing")
+        return None
+    confidence = round(min(0.99, max(0.0, 1.0 - float(holdout_p))), 3)
+    if confidence < _PROMOTE_FLOOR:
+        logger.info(
+            "evo promote: winner confidence %.2f below floor %.2f — not filing",
+            confidence, _PROMOTE_FLOOR,
+        )
+        return None
+
+    t_mean = hwr.get("treatment_mean_score")
+    c_mean = hwr.get("control_mean_score")
+    effect = (
+        t_mean - c_mean
+        if isinstance(t_mean, int | float) and isinstance(c_mean, int | float)
+        else None
+    )
+
+    content = f"Promote reflection-prompt variant — {winner.description}"
+    rationale = (
+        f"Evo measured this directive against the canonical deep-reflection prompt "
+        f"and it survived held-out re-validation (disjoint={result.holdout_disjoint}, "
+        f"p={float(holdout_p):.4f}"
+        + (
+            f", held-out mean {t_mean:.3f} vs control {c_mean:.3f}, +{effect:.3f}"
+            if effect is not None else ""
+        )
+        + f"). It beat control as 1 of {result.survivors}/"
+        f"{result.candidates_evaluated} survivors at the Bonferroni alpha/N gate. "
+        f"Judged via {judge_provider}; generated via {gen_provider}."
+    )
+    execution_plan = (
+        "On approval: writes this prompt to the deep-reflection overlay "
+        "(~/.genesis/config/reflection/REFLECTION_DEEP.md) via the cognitive "
+        "ledger; reversible with cognitive_modification_rollback."
+    )
+    proposal = {
+        "action_type": "cognitive_variant_promotion",
+        "content": content,
+        "rationale": rationale,
+        "execution_plan": execution_plan,
+        "confidence": confidence,
+        "urgency": "normal",
+        "expected_outputs": {
+            "full_prompt": winner.system_prompt,
+            "approach": winner.description,
+            "evidence": rationale,
+        },
+    }
+
+    from genesis.ego.proposals import ProposalWorkflow
+
+    wf = ProposalWorkflow(db=db)
+    _batch_id, ids, _created = await wf.create_batch([proposal], ego_source="evo")
+    if not ids:
+        # create_batch dedup skipped it (an identical promotion is already pending).
+        logger.info("evo promote: proposal de-duplicated (identical one pending)")
+        return None
+    logger.info("evo promote: filed cognitive_variant_promotion proposal %s", ids[0])
+    return ids[0]
 
 
 async def _impl_evo_run(
@@ -76,6 +181,7 @@ async def _impl_evo_run(
     gen_provider: str = _DEFAULT_GEN_PROVIDER,
     judge_provider: str = _DEFAULT_JUDGE_PROVIDER,
     golden_set_path: str | None = None,
+    propose: bool = True,
 ) -> dict:
     if golden_set_path:
         gs = Path(golden_set_path)
@@ -94,7 +200,7 @@ async def _impl_evo_run(
 
     if not base_prompt:
         try:
-            base_prompt = _resolve_base_prompt()
+            base_prompt = _resolve_canonical_base_prompt()
         except Exception as exc:  # noqa: BLE001
             logger.warning("evo_run: could not resolve base prompt", exc_info=True)
             return {"status": "error", "message": f"base prompt unavailable: {exc}"}
@@ -154,6 +260,19 @@ async def _impl_evo_run(
         except Exception:  # noqa: BLE001 — persistence is non-fatal
             logger.warning("evo_run: summary persistence failed", exc_info=True)
 
+    # Auto-file the winner as a human-gated proposal (recommend-only): stores it
+    # in ego_proposals (dashboard-delivered + approvable). Nothing is applied
+    # until the user approves. Gated by `propose`, a confirmed winner, and the
+    # confidence floor (inside promote_evo_winner). Never crashes the tool.
+    proposal_id = None
+    if propose and db is not None and result.winner is not None:
+        try:
+            proposal_id = await promote_evo_winner(
+                db, result, gen_provider=gen_provider, judge_provider=judge_provider,
+            )
+        except Exception:  # noqa: BLE001 — filing is non-fatal to the measurement
+            logger.warning("evo_run: winner proposal filing failed", exc_info=True)
+
     w = result.winner
     return {
         "status": "ok",
@@ -175,11 +294,19 @@ async def _impl_evo_run(
         "per_candidate": result.per_candidate,
         "note": result.note,
         "persisted_run_id": persisted_run_id,
+        "proposal_id": proposal_id,
         "recommend_only": (
-            "Evo measured the variants and recommends the winner (if any). It does "
-            "NOT promote — apply manually by writing the prompt to "
-            "~/.genesis/config/reflection/REFLECTION_DEEP.md, or via the future "
-            "human-gated cognitive_variant_promotion proposal."
+            (
+                f"Filed cognitive_variant_promotion proposal {proposal_id} — "
+                "review and approve it on the dashboard Ego tab to apply (reversible). "
+                "Nothing is applied until you approve."
+            )
+            if proposal_id else
+            (
+                "Evo measured the variants and recommends the winner (if any). No "
+                "proposal was filed (no confirmed winner, propose=False, below the "
+                "confidence floor, or a duplicate is already pending)."
+            )
         ),
     }
 
@@ -193,21 +320,27 @@ async def evo_run(
     gen_provider: str = _DEFAULT_GEN_PROVIDER,
     judge_provider: str = _DEFAULT_JUDGE_PROVIDER,
     golden_set_path: str = "",
+    propose: bool = True,
 ) -> dict:
     """Evolve the deep-reflection prompt: generate N variants, A/B each vs the
-    current prompt, and recommend the best confirmed winner.
+    canonical prompt, recommend the best confirmed winner, and (by default) FILE
+    it as a human-gated proposal.
 
-    RECOMMEND-ONLY — measures + recommends, never promotes (autonomous_action
+    RECOMMEND-ONLY — measures, recommends, and on a confirmed winner files a
+    ``cognitive_variant_promotion`` proposal you approve on the dashboard to
+    apply (reversibly). It never mutates cognition itself (autonomous_action
     False). Bounded cost: <= n_variants*eval_limit + holdout_limit generations
     (x2 for judging), on free providers, on demand.
 
     Args:
-        base_prompt: prompt to evolve (default: the current effective deep
-            reflection prompt, overlay-aware).
+        base_prompt: prompt to evolve (default: the CANONICAL repo deep-reflection
+            prompt — NOT the overlay, so promotions never stack).
         n_variants: fan-out (capped 1..12).
         eval_limit / holdout_limit: golden cases for fan-out / held-out
             re-validation (disjoint slices).
         gen_provider / judge_provider: routing-config providers (default free).
+        propose: when True (default), a confirmed winner above the confidence
+            floor is filed as a proposal. Set False for pure measurement.
     """
     return await _impl_evo_run(
         base_prompt=base_prompt or None,
@@ -217,4 +350,5 @@ async def evo_run(
         gen_provider=gen_provider,
         judge_provider=judge_provider,
         golden_set_path=golden_set_path or None,
+        propose=propose,
     )

--- a/tests/ego/test_cognitive_variant.py
+++ b/tests/ego/test_cognitive_variant.py
@@ -126,6 +126,56 @@ async def test_missing_full_prompt_refused(db, overlay_dir):
     assert (await ego_crud.get_proposal(db, prop["id"]))["status"] == "executed"
 
 
+async def test_full_promote_approve_apply_rollback_e2e(db, overlay_dir, tmp_path):
+    """Decisive E2E (real functions, no mocks for the apply path): an Evo winner
+    is filed as a recommend-only proposal, the user approves it, the overlay is
+    written + goes live to the reflection bridge, and rollback reverts it."""
+    from genesis.experimentation.evo import EvoResult
+    from genesis.experimentation.types import CognitiveVariant
+    from genesis.learning import cognitive_ledger
+    from genesis.mcp.health.evo_run import promote_evo_winner
+
+    winner_prompt = "CANONICAL DEEP PROMPT\n\nbe more concise"
+    result = EvoResult(
+        winner=CognitiveVariant(
+            name="evo_v0", description="be more concise", system_prompt=winner_prompt,
+        ),
+        winner_winrate={"recommendation": "treatment_wins", "p_value": 0.002},
+        holdout_winrate={"recommendation": "treatment_wins", "p_value": 0.01,
+                         "treatment_mean_score": 0.82, "control_mean_score": 0.70},
+        candidates_evaluated=6, survivors=2, note="confirmed", holdout_disjoint=True,
+    )
+    overlay = overlay_dir / _OVERLAY_FILENAME
+
+    # 1. Evo files the winner — recommend-only: NOTHING is applied yet.
+    pid = await promote_evo_winner(
+        db, result, gen_provider="cc-haiku", judge_provider="groq-free",
+    )
+    assert pid is not None
+    assert not overlay.exists()
+
+    # 2. The user approves → the resolution site resolves to 'approved' then
+    #    runs the apply hook (mirrors all 4 wired resolution sites).
+    await ego_crud.resolve_proposal(db, pid, status="approved")
+    prop = await ego_crud.get_proposal(db, pid)
+    assert await handle_cognitive_variant_resolution(db, prop, "approved") is True
+    assert (await ego_crud.get_proposal(db, pid))["status"] == "executed"
+
+    # 3. The overlay is written AND live (the bridge reads it ahead of the repo).
+    assert overlay.read_text() == winner_prompt
+    empty_repo = tmp_path / "repo_identity"
+    empty_repo.mkdir()
+    assert system_prompt_for_depth(Depth.DEEP, empty_repo) == winner_prompt
+
+    # 4. Rollback reverts — overlay removed, no longer live.
+    rows = await cognitive_ledger.recent(db, limit=1, actor="evo_promotion")
+    assert rows, "ledger should have recorded the promotion"
+    res = await cognitive_ledger.rollback(db, rows[0]["id"])
+    assert res["ok"] is True
+    assert not overlay.exists()
+    assert system_prompt_for_depth(Depth.DEEP, empty_repo) != winner_prompt
+
+
 def test_handler_wired_into_all_resolution_paths():
     """Every proposal-resolution entry point MUST call the cognitive-variant
     apply hook, or an approval there silently no-ops (the prompt is never

--- a/tests/ego/test_cognitive_variant.py
+++ b/tests/ego/test_cognitive_variant.py
@@ -1,0 +1,172 @@
+"""Tests for cognitive_variant — the resolution hook that promotes an Evo-measured
+reflection-prompt winner to the live overlay (Evo PR-B).
+
+Recommend-only: the prompt is written ONLY on the user's explicit approval, via
+the rollback-able cognitive ledger. The handler marks the proposal 'executed'
+unconditionally (even if the write fails) so it never lingers 'approved' where
+the dispatch sweep could pick it up.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+import genesis
+from genesis.awareness.types import Depth
+from genesis.cc.reflection_bridge._prompts import system_prompt_for_depth
+from genesis.db.crud import ego as ego_crud
+from genesis.db.schema import create_all_tables
+from genesis.ego.cognitive_variant import (
+    _OVERLAY_FILENAME,
+    handle_cognitive_variant_resolution,
+)
+
+_WINNER = "# REFLECTION_DEEP (promoted)\n\nThink deeply. Be concise."
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+@pytest.fixture
+def overlay_dir(tmp_path, monkeypatch):
+    """Point the reflection overlay at a temp dir so tests never touch the real
+    ~/.genesis/config/reflection."""
+    monkeypatch.setenv("GENESIS_REFLECTION_PROMPT_DIR", str(tmp_path))
+    return tmp_path
+
+
+async def _make_proposal(
+    db, *, status="approved", action_type="cognitive_variant_promotion",
+    full_prompt=_WINNER, confidence=0.9, approach="more concise",
+):
+    pid = "cvp1"
+    outputs = {"full_prompt": full_prompt, "approach": approach, "evidence": "p=0.01"}
+    await ego_crud.create_proposal(
+        db, id=pid, action_type=action_type, content="promote reflection variant",
+        status="pending", created_at="2026-06-24T00:00:00+00:00",
+        confidence=confidence, expected_outputs=json.dumps(outputs),
+    )
+    await ego_crud.resolve_proposal(db, pid, status=status)
+    return await ego_crud.get_proposal(db, pid)
+
+
+async def test_approved_writes_overlay_and_executes(db, overlay_dir):
+    prop = await _make_proposal(db, status="approved")
+
+    ok = await handle_cognitive_variant_resolution(db, prop, "approved")
+
+    assert ok is True
+    # overlay written with the winner prompt
+    overlay = overlay_dir / _OVERLAY_FILENAME
+    assert overlay.read_text() == _WINNER
+    # proposal marked executed (never lingers 'approved')
+    assert (await ego_crud.get_proposal(db, prop["id"]))["status"] == "executed"
+
+
+async def test_overlay_target_matches_bridge_read(db, overlay_dir, tmp_path):
+    """The file we WRITE must be the file the reflection bridge READS — guards
+    against filename drift. After promotion, resolving DEEP returns the winner
+    (overlay is checked before the repo dir)."""
+    prop = await _make_proposal(db, status="approved")
+    await handle_cognitive_variant_resolution(db, prop, "approved")
+
+    empty_repo_dir = tmp_path / "repo_identity"
+    empty_repo_dir.mkdir()
+    assert system_prompt_for_depth(Depth.DEEP, empty_repo_dir) == _WINNER
+
+
+async def test_rejected_is_noop(db, overlay_dir):
+    prop = await _make_proposal(db, status="rejected")
+
+    ok = await handle_cognitive_variant_resolution(db, prop, "rejected")
+
+    assert ok is False
+    assert not (overlay_dir / _OVERLAY_FILENAME).exists()
+    # rejected proposals are left exactly as-is (recommend-only)
+    assert (await ego_crud.get_proposal(db, prop["id"]))["status"] == "rejected"
+
+
+async def test_non_cognitive_variant_is_noop(db, overlay_dir):
+    prop = await _make_proposal(db, status="approved", action_type="autonomy_earnback")
+
+    ok = await handle_cognitive_variant_resolution(db, prop, "approved")
+
+    assert ok is False
+    assert not (overlay_dir / _OVERLAY_FILENAME).exists()
+
+
+async def test_below_confidence_floor_refused(db, overlay_dir):
+    prop = await _make_proposal(db, status="approved", confidence=0.5)
+
+    ok = await handle_cognitive_variant_resolution(db, prop, "approved")
+
+    assert ok is False
+    assert not (overlay_dir / _OVERLAY_FILENAME).exists()
+    # marked executed so an unappliable approved proposal doesn't linger
+    assert (await ego_crud.get_proposal(db, prop["id"]))["status"] == "executed"
+
+
+async def test_missing_full_prompt_refused(db, overlay_dir):
+    prop = await _make_proposal(db, status="approved", full_prompt="   ")
+
+    ok = await handle_cognitive_variant_resolution(db, prop, "approved")
+
+    assert ok is False
+    assert not (overlay_dir / _OVERLAY_FILENAME).exists()
+    assert (await ego_crud.get_proposal(db, prop["id"]))["status"] == "executed"
+
+
+def test_handler_wired_into_all_resolution_paths():
+    """Every proposal-resolution entry point MUST call the cognitive-variant
+    apply hook, or an approval there silently no-ops (the prompt is never
+    promoted). Mirrors the cell_promotion / goal_status wiring guard."""
+    root = Path(genesis.__file__).parent
+    for path in [
+        root / "ego" / "proposals.py",
+        root / "mcp" / "health" / "ego_tools.py",
+        root / "dashboard" / "routes" / "ego.py",
+        root / "dashboard" / "routes" / "comms.py",
+    ]:
+        src = path.read_text()
+        assert "handle_cognitive_variant_resolution" in src, (
+            f"{path} is missing the cognitive-variant apply hook — "
+            "an approval there would silently no-op"
+        )
+
+
+def test_excluded_from_approved_proposal_sweep():
+    """The promotion action_type must be in session.py's never-dispatch set,
+    else an approved promotion could be auto-run as a session."""
+    root = Path(genesis.__file__).parent
+    src = (root / "ego" / "session.py").read_text()
+    assert '"cognitive_variant_promotion"' in src
+
+
+async def test_write_failure_still_marks_executed(db, overlay_dir, monkeypatch):
+    """The architect's fail-open backstop: if the overlay write raises, the
+    proposal must STILL be marked executed (returns False) — so it never lingers
+    'approved' for the dispatch sweep to grab."""
+    prop = await _make_proposal(db, status="approved")
+
+    async def _boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(
+        "genesis.learning.cognitive_ledger.record_file_modification", _boom,
+    )
+
+    ok = await handle_cognitive_variant_resolution(db, prop, "approved")
+
+    assert ok is False  # write failed
+    assert not (overlay_dir / _OVERLAY_FILENAME).exists()
+    assert (await ego_crud.get_proposal(db, prop["id"]))["status"] == "executed"

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -503,6 +503,18 @@ class TestProcessExecutionBriefs:
         prop = await ego_crud.get_proposal(db, "prop_cvp")
         assert prop["status"] == "approved"  # untouched by the dispatch path
 
+    async def test_cognitive_variant_not_dispatched_by_sweep(
+        self, ego_with_runner, mock_direct_runner, db,
+    ):
+        """The OTHER dispatch path — the approved-proposal sweep — must also skip
+        cognitive_variant_promotion (the blocklist fires before any spawn)."""
+        await self._insert_proposal(
+            db, "prop_cvp_sweep", action_type="cognitive_variant_promotion",
+        )
+        await ego_with_runner.sweep_approved_proposals()
+        mock_direct_runner.spawn.assert_not_called()
+        assert (await ego_crud.get_proposal(db, "prop_cvp_sweep"))["status"] == "approved"
+
 
 def test_never_dispatch_action_types_single_source_of_truth():
     """Both dispatch paths (sweep + execution-briefs) read this one tuple.

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -357,14 +357,15 @@ class TestProcessExecutionBriefs:
             direct_session_runner=mock_direct_runner,
         )
 
-    async def _insert_proposal(self, db, proposal_id, status="approved"):
+    async def _insert_proposal(self, db, proposal_id, status="approved",
+                               action_type="investigate"):
         """Insert a proposal into the DB for testing."""
         await db.execute(
             "INSERT INTO ego_proposals "
             "(id, action_type, action_category, content, rationale, "
             "confidence, urgency, status, created_at) "
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))",
-            (proposal_id, "investigate", "test", "test content",
+            (proposal_id, action_type, "test", "test content",
              "test rationale", 0.8, "normal", status),
         )
         await db.commit()
@@ -482,6 +483,37 @@ class TestProcessExecutionBriefs:
         await ego_with_runner._process_execution_briefs(briefs)
 
         mock_direct_runner.spawn.assert_not_called()
+
+    async def test_cognitive_variant_promotion_never_dispatched(
+        self, ego_with_runner, mock_direct_runner, db,
+    ):
+        """An approved cognitive_variant_promotion must NEVER be auto-dispatched
+        as a session via the execution-briefs path. This fixture has no autonomy
+        gate, so the assertion proves the explicit action_type blocklist (not the
+        gate) is the backstop — the fail-open path the architect flagged. The
+        proposal is applied only by its resolution handler at approval time."""
+        await self._insert_proposal(
+            db, "prop_cvp", action_type="cognitive_variant_promotion",
+        )
+
+        briefs = [{"proposal_id": "prop_cvp", "prompt": "apply winning prompt"}]
+        await ego_with_runner._process_execution_briefs(briefs)
+
+        mock_direct_runner.spawn.assert_not_called()
+        prop = await ego_crud.get_proposal(db, "prop_cvp")
+        assert prop["status"] == "approved"  # untouched by the dispatch path
+
+
+def test_never_dispatch_action_types_single_source_of_truth():
+    """Both dispatch paths (sweep + execution-briefs) read this one tuple.
+    cognitive_variant_promotion must be present (else an approved Evo promotion
+    could be auto-run as a session); the pre-existing apply-at-approval types
+    must remain (regression guard for the refactor to a shared constant)."""
+    from genesis.ego.session import _NEVER_DISPATCH_ACTION_TYPES
+
+    assert "cognitive_variant_promotion" in _NEVER_DISPATCH_ACTION_TYPES
+    for legacy in ("autonomy_earnback", "goal_status_change", "cell_promotion"):
+        assert legacy in _NEVER_DISPATCH_ACTION_TYPES
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_autonomy/test_classification.py
+++ b/tests/test_autonomy/test_classification.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-from genesis.autonomy.classification import ActionClassifier, classify_action
-from genesis.autonomy.types import ActionClass, ApprovalDecision
+from genesis.autonomy.classification import (
+    ActionClassifier,
+    classify_action,
+    classify_domain,
+)
+from genesis.autonomy.types import ActionClass, ActionDomain, ApprovalDecision
 
 # ---------------------------------------------------------------------------
 # TestActionClassifier
@@ -157,3 +161,28 @@ class TestClassifyAction:
 
     def test_unknown_action_reversible(self) -> None:
         assert classify_action("do some analysis") is ActionClass.REVERSIBLE
+
+
+# ---------------------------------------------------------------------------
+# TestClassifyDomain (action_type -> ActionDomain)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyDomain:
+    """Tests for classify_domain() — the action_type -> ActionDomain mapping
+    that the dispatch gate uses to enforce autonomy levels."""
+
+    def test_cognitive_variant_promotion_is_self_modify(self) -> None:
+        """A reflection-prompt promotion changes Genesis's own cognition, so it
+        must classify as SELF_MODIFY (hard-blocked from background dispatch) —
+        NOT fall through to the EXTERNAL_READ default (always allowed)."""
+        assert (
+            classify_domain("cognitive_variant_promotion")
+            is ActionDomain.SELF_MODIFY
+        )
+
+    def test_existing_code_change_self_modify(self) -> None:
+        assert classify_domain("code_change") is ActionDomain.SELF_MODIFY
+
+    def test_unknown_action_type_falls_to_external_read(self) -> None:
+        assert classify_domain("totally_unknown_xyz") is ActionDomain.EXTERNAL_READ

--- a/tests/test_autonomy/test_proposal_gate.py
+++ b/tests/test_autonomy/test_proposal_gate.py
@@ -67,6 +67,16 @@ class TestProposalDispatchGate:
         assert result.action_domain == ActionDomain.SELF_MODIFY
 
     @pytest.mark.asyncio
+    async def test_cognitive_variant_promotion_always_blocked(self) -> None:
+        """An approved Evo prompt-promotion must NEVER be auto-dispatched as a
+        session — even at max autonomy. It is SELF_MODIFY (always blocked); the
+        only path that applies it is its resolution handler at approval time."""
+        gate = _make_gate(current_level=4)
+        result = await gate.evaluate({"action_type": "cognitive_variant_promotion"})
+        assert not result.allowed
+        assert result.action_domain == ActionDomain.SELF_MODIFY
+
+    @pytest.mark.asyncio
     async def test_financial_blocked_below_l4(self) -> None:
         gate = _make_gate(current_level=3)
         result = await gate.evaluate({"action_type": "purchase"})

--- a/tests/test_experimentation/test_evo_run.py
+++ b/tests/test_experimentation/test_evo_run.py
@@ -158,3 +158,156 @@ def test_make_router_cc_provider_returns_cc_cli_router():
     r = _make_router("cc-haiku", None, None)
     assert isinstance(r, CCCliRouter)
     assert r._model == "haiku"
+
+
+# ---------------------------------------------------------------------------
+# Auto-file path (PR-B): promote_evo_winner + canonical base + propose gate
+# ---------------------------------------------------------------------------
+
+import aiosqlite  # noqa: E402
+import pytest  # noqa: E402
+
+from genesis.db.crud import ego as ego_crud  # noqa: E402
+from genesis.db.schema import create_all_tables  # noqa: E402
+
+
+@pytest.fixture
+async def cvdb():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+def _winner_result(*, holdout_p=0.01, t_mean=0.82, c_mean=0.70):
+    return EvoResult(
+        winner=CognitiveVariant(
+            name="evo_v0", description="be more concise",
+            system_prompt="CANONICAL\n\nbe more concise",
+        ),
+        winner_winrate={"recommendation": "treatment_wins", "p_value": 0.002,
+                        "treatment_mean_score": t_mean},
+        holdout_winrate={"recommendation": "treatment_wins", "p_value": holdout_p,
+                         "treatment_mean_score": t_mean, "control_mean_score": c_mean},
+        candidates_evaluated=6, survivors=2, note="confirmed", holdout_disjoint=True,
+    )
+
+
+async def test_promote_files_winner_proposal(cvdb):
+    from genesis.mcp.health.evo_run import promote_evo_winner
+
+    pid = await promote_evo_winner(
+        cvdb, _winner_result(), gen_provider="groq-free", judge_provider="groq-free",
+    )
+    assert pid is not None
+    prop = await ego_crud.get_proposal(cvdb, pid)
+    assert prop["action_type"] == "cognitive_variant_promotion"
+    assert prop["status"] == "pending"          # dashboard-visible, awaiting approval
+    assert float(prop["confidence"]) >= 0.75    # 1 - holdout_p = 0.99
+    outputs = json.loads(prop["expected_outputs"])
+    assert outputs["full_prompt"] == "CANONICAL\n\nbe more concise"
+    assert outputs["approach"] == "be more concise"
+
+
+async def test_promote_no_winner_files_nothing(cvdb):
+    from genesis.mcp.health.evo_run import promote_evo_winner
+
+    no_winner = EvoResult(
+        winner=None, winner_winrate=None, holdout_winrate=None,
+        candidates_evaluated=6, survivors=0, note="none",
+    )
+    pid = await promote_evo_winner(
+        cvdb, no_winner, gen_provider="g", judge_provider="j",
+    )
+    assert pid is None
+
+
+async def test_promote_below_floor_files_nothing(cvdb):
+    """A winner whose held-out p maps to confidence < 0.75 is NOT filed
+    (belt-and-suspenders to the held-out gate)."""
+    from genesis.mcp.health.evo_run import promote_evo_winner
+
+    pid = await promote_evo_winner(
+        cvdb, _winner_result(holdout_p=0.30),  # confidence 0.70
+        gen_provider="g", judge_provider="j",
+    )
+    assert pid is None
+
+
+async def test_promote_missing_holdout_p_files_nothing(cvdb):
+    from genesis.mcp.health.evo_run import promote_evo_winner
+
+    res = _winner_result()
+    res = EvoResult(
+        winner=res.winner, winner_winrate=res.winner_winrate,
+        holdout_winrate={"recommendation": "treatment_wins"},  # no p_value
+        candidates_evaluated=6, survivors=2, note="x", holdout_disjoint=True,
+    )
+    pid = await promote_evo_winner(cvdb, res, gen_provider="g", judge_provider="j")
+    assert pid is None
+
+
+def test_resolve_canonical_ignores_overlay(tmp_path, monkeypatch):
+    """The canonical base must read the REPO prompt, NOT the overlay — else
+    repeated promotions stack directives unboundedly."""
+    from genesis.mcp.health.evo_run import _resolve_canonical_base_prompt
+
+    overlay = tmp_path / "REFLECTION_DEEP.md"
+    overlay.write_text("OVERLAY_SENTINEL should never be the measurement base")
+    monkeypatch.setenv("GENESIS_REFLECTION_PROMPT_DIR", str(tmp_path))
+
+    base = _resolve_canonical_base_prompt()
+    assert "OVERLAY_SENTINEL" not in base
+    assert base.strip()  # the real repo prompt, non-empty
+
+
+async def test_evo_run_propose_false_skips_filing(cvdb, tmp_path, monkeypatch):
+    _stub_routers(monkeypatch)
+    _stub_variants(monkeypatch)
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    class _Svc:
+        _db = cvdb
+
+    monkeypatch.setattr(health_mcp_mod, "_service", _Svc(), raising=False)
+
+    async def fake_run_evo(**kw):
+        return _winner_result()
+
+    monkeypatch.setattr("genesis.experimentation.evo.run_evo", fake_run_evo)
+
+    from genesis.mcp.health.evo_run import _impl_evo_run
+
+    out = await _impl_evo_run(
+        base_prompt="BASE", golden_set_path=str(_golden(tmp_path)), propose=False,
+    )
+    assert out["status"] == "ok"
+    assert out["proposal_id"] is None
+    assert await ego_crud.list_proposals(cvdb, status="pending") == []
+
+
+async def test_evo_run_propose_true_files_winner(cvdb, tmp_path, monkeypatch):
+    _stub_routers(monkeypatch)
+    _stub_variants(monkeypatch)
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    class _Svc:
+        _db = cvdb
+
+    monkeypatch.setattr(health_mcp_mod, "_service", _Svc(), raising=False)
+
+    async def fake_run_evo(**kw):
+        return _winner_result()
+
+    monkeypatch.setattr("genesis.experimentation.evo.run_evo", fake_run_evo)
+
+    from genesis.mcp.health.evo_run import _impl_evo_run
+
+    out = await _impl_evo_run(
+        base_prompt="BASE", golden_set_path=str(_golden(tmp_path)), propose=True,
+    )
+    assert out["status"] == "ok"
+    assert out["proposal_id"] is not None
+    prop = await ego_crud.get_proposal(cvdb, out["proposal_id"])
+    assert prop["action_type"] == "cognitive_variant_promotion"

--- a/tests/test_experimentation/test_evo_run.py
+++ b/tests/test_experimentation/test_evo_run.py
@@ -210,6 +210,35 @@ async def test_promote_files_winner_proposal(cvdb):
     assert outputs["approach"] == "be more concise"
 
 
+async def test_promote_self_scoring_caveat(cvdb):
+    """Same gen+judge provider → the proposal rationale carries a self-scoring
+    caveat; cross-provider → it does not."""
+    from genesis.mcp.health.evo_run import promote_evo_winner
+
+    same = await promote_evo_winner(
+        cvdb, _winner_result(), gen_provider="groq-free", judge_provider="groq-free",
+    )
+    rat_same = (await ego_crud.get_proposal(cvdb, same))["rationale"]
+    assert "CAVEAT" in rat_same and "share a provider" in rat_same
+
+    # distinct winner so content-hash dedup doesn't skip the second proposal
+    cross_result = _winner_result()
+    cross_result = EvoResult(
+        winner=CognitiveVariant(
+            name="evo_v1", description="be deeper",
+            system_prompt="CANONICAL\n\nbe deeper",
+        ),
+        winner_winrate=cross_result.winner_winrate,
+        holdout_winrate=cross_result.holdout_winrate,
+        candidates_evaluated=6, survivors=2, note="x", holdout_disjoint=True,
+    )
+    cross = await promote_evo_winner(
+        cvdb, cross_result, gen_provider="groq-free", judge_provider="cc-haiku",
+    )
+    rat_cross = (await ego_crud.get_proposal(cvdb, cross))["rationale"]
+    assert "CAVEAT" not in rat_cross
+
+
 async def test_promote_no_winner_files_nothing(cvdb):
     from genesis.mcp.health.evo_run import promote_evo_winner
 


### PR DESCRIPTION
## Summary

Closes the Evo self-improvement loop: a measured reflection-prompt **winner** can now become an **approvable proposal** and, on the user's approval, be **applied to the live deep-reflection overlay — reversibly**. Builds on the Crucible foundation (#763) and the Evo measure-only loop (#769).

**Recommend-only / human-gated throughout.** Genesis recommends; the user decides. Nothing touches live cognition until a human approves a proposal, and any applied change is one rollback away from reverting.

## The loop

`evo_run` measures variants of the **canonical** deep-reflection prompt (Bonferroni α/N + disjoint held-out re-validation). When a winner is confirmed, it is **auto-filed** as a `cognitive_variant_promotion` proposal (dashboard-delivered). On approval, `handle_cognitive_variant_resolution` writes the winning prompt to the `~/.genesis/config/reflection/REFLECTION_DEEP.md` overlay via the rollback-able cognitive ledger.

## Recommend-only = 3 independent defense layers

1. **Apply-at-approval** — the resolution handler applies ONLY on `approved`, and marks the proposal `executed` **unconditionally** (even if the write fails), so it never lingers `approved` for the dispatch sweep to grab.
2. **Dispatch blocklist** — a single-source `_NEVER_DISPATCH_ACTION_TYPES` tuple guards **both** auto-dispatch paths in `ego/session.py` (the approved-sweep and the execution-briefs path, which previously had no action_type guard).
3. **Autonomy domain gate** — the action_type maps to `SELF_MODIFY` in `autonomy/classification.py` (hard-blocked from background dispatch). Without this it fell through to `EXTERNAL_READ` (always allowed) — the dispatch gate would have been a passthrough.

## Design decisions

- **Canonical base, not overlay** — variants are built against the canonical repo prompt and the filed winner is exactly `canonical + winning_directive`, so *what is measured equals what is applied* and repeated promotions never stack directives.
- **Dashboard-delivered** — the proposal is stored and approvable on the dashboard Ego tab (the apply hook is wired into all 4 resolution sites). A Telegram ping belongs with the deferred autonomous cadence.
- **0.75 confidence floor** (`1 − held-out p`), enforced at file time and re-checked in the handler.
- **Self-scoring caveat** — when generator and judge share a provider, the proposal rationale says so, so the user can discount optimistic scores.
- The 13KB winner prompt rides in `expected_outputs` (verified NOT rendered in the digest or the dashboard proposal API); `content`/`rationale` carry a human summary.

## Verification

- **genesis-architect review: recommend-only AIRTIGHT** — confirmed an approved promotion cannot reach session dispatch via any path, and the handler cannot write on a non-approved status.
- **Regression green**: autonomy 801 / ego 711 / experimentation 56 passed; ruff clean; all modules import.
- **End-to-end** (real functions, no apply-path mocks): winner → file → approve → overlay live → rollback reverts. Both no-dispatch paths proven behaviorally.
- **Real-provider E2E** (cc-haiku gen + judge): the pipeline produced real scores (mean ~0.73) and correctly filed nothing at small N where no winner is statistically confirmable.

## Known caveat (pre-existing, not introduced here)

The autonomy `_proposal_gate` is fail-open on exception in both dispatch paths. This is harmless for this action_type because the blocklist fires first, but it is a latent weakness for any future type relying solely on the gate. Out of scope for this PR.

## Deferred follow-on

Autonomous Evo→propose cadence (its own cost model + `CronTrigger`); weight-variant evolution; agentic experiment runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)