### PR TITLE
feat(deliberation): custom chorus panels + raw-SSE Fusion backend

### DIFF
--- a/src/genesis/deliberation/backends/fusion.py
+++ b/src/genesis/deliberation/backends/fusion.py
@@ -10,14 +10,21 @@ Two modes × two presets, all probe-confirmed live (2026-06-24):
   (a normal instruct model that honors a JSON system prompt) returns machine-structured
   {answer, consensus, dissent[], blind_spots[], confidence}. Default preset: **strong**.
 
-Presets control the panel (who deliberates): **strong** → OpenRouter's `general-high` (strongest panel);
-**budget** → `general-budget` (mid-tier panel, cheaper). Passed via the fusion `plugins` entry
-(synthesis) or the server-tool `parameters` (analysis). Verified: budget → sonnet-3.5/gpt-4o/gemini-1.5.
+Presets control the panel (who deliberates) — explicit, custom-defined model lists (see _PRESET_PANELS):
+**strong** = a frontier panel (opus/gpt/gemini-pro/grok/deepseek/kimi) judged by gpt; **budget** = a
+mid-tier panel (deepseek/gpt-mini/grok/qwen/kimi/gemini-flash) judged by sonnet (cheaper/faster). Passed
+as `analysis_models` (panel) + `model` (judge) via the fusion `plugins` entry (synthesis) or the
+server-tool `parameters` (analysis). Edit _PRESET_PANELS to recompose the chorus.
 
-We call `litellm.acompletion` directly (a documented exception to routing via the Router) to own the
-request shape and read side data: an explicit ``max_tokens`` is REQUIRED (litellm's 65536 default trips
-an OpenRouter 402); cost is read from ``response.usage.cost`` (``litellm.completion_cost`` can't price
-these aggregator strings).
+We POST the OpenRouter chat-completions endpoint over a raw streaming ``httpx`` connection (NOT via
+litellm / the Router) so we own the request shape AND can read the streamed ``usage.cost``. We must
+STREAM: Fusion convenes a server-side panel that can run for minutes, and OpenRouter pads that wait with
+SSE keep-alive comments (lines starting ``:``) that break a non-streaming ``.json()`` parse (observed:
+"Unable to get json response" on a 6-model panel). litellm's streaming path survives the padding but
+STRIPS the provider ``cost`` from its Usage object and hides OpenRouter's generation id, so neither
+litellm path can report cost — hence the direct SSE read. An explicit ``max_tokens`` is REQUIRED
+(OpenRouter's large default trips a "fewer max_tokens" 402); cost comes from the final ``usage.cost``
+SSE chunk — the only place these dynamic-priced aggregator calls expose it.
 """
 
 from __future__ import annotations
@@ -29,29 +36,55 @@ import os
 import re
 import time
 
-import litellm
+import httpx
 
 from genesis.deliberation.types import DeliberationResult
 
 logger = logging.getLogger(__name__)
 
-# synthesis: openrouter prefix + the `openrouter/fusion` model id (probe-confirmed; bare `openrouter/fusion` 502s).
-_MODEL = "openrouter/openrouter/fusion"
+_OR_ENDPOINT = "https://openrouter.ai/api/v1/chat/completions"
+# synthesis: the `openrouter/fusion` model-slug — the meta-model itself (raw OpenRouter id, probe-confirmed).
+_MODEL = "openrouter/fusion"
 # analysis: a free, tool-capable orchestrator that calls the fusion server-tool and returns structured JSON.
-_ANALYSIS_ORCHESTRATOR = "openrouter/openai/gpt-oss-120b:free"
+_ANALYSIS_ORCHESTRATOR = "openai/gpt-oss-120b:free"
 
-# Our two presets → OpenRouter's curated panel+judge slugs.
-_PRESET_SLUG = {"strong": "general-high", "budget": "general-budget"}
-# Mode-aware default when the caller doesn't specify a preset.
+# Explicit chorus panels (`analysis_models`) + judge (`model`) per preset. EDIT THESE to change the
+# chorus. `~…-latest` ids float to the newest version. Panel/judge models need NOT support tools.
+_PRESET_PANELS: dict[str, dict] = {
+    "strong": {
+        "analysis_models": [
+            "~anthropic/claude-opus-latest",
+            "~openai/gpt-latest",
+            "~google/gemini-pro-latest",
+            "x-ai/grok-4.3",
+            "deepseek/deepseek-v4-pro",
+            "~moonshotai/kimi-latest",
+        ],
+        "model": "~openai/gpt-latest",  # judge
+    },
+    "budget": {
+        "analysis_models": [
+            "deepseek/deepseek-v4-pro",
+            "~openai/gpt-mini-latest",
+            "x-ai/grok-4.3",
+            "qwen/qwen3-235b-a22b-thinking-2507",
+            "~moonshotai/kimi-latest",
+            "~google/gemini-flash-latest",
+        ],
+        "model": "~anthropic/claude-sonnet-latest",  # judge
+    },
+}
+# synthesis defaults to budget; analysis is ALWAYS strong (pinned in _resolve_preset).
 _DEFAULT_PRESET = {"synthesis": "budget", "analysis": "strong"}
 
 _MAX_TOKENS = 2000  # explicit — the 65536 default trips OpenRouter's "fewer max_tokens" 402.
 _DEFAULT_TIMEOUT_S = 240.0  # analysis (panel + judge + orchestrator) runs ~120-170s; synthesis ~47-110s.
 _ANSWER_CAP = 6000
-# deliberate() bypasses the Router, so it owns its own retry on TRANSIENT provider errors (frontier
-# panels 429 under load — observed on the strong/general-high preset). 4xx and timeouts are NOT retried.
+# deliberate() owns its own retry on TRANSIENT errors (frontier panels 429 under load — observed on the
+# strong preset). Retried: 429/5xx + transport errors. NOT retried: other 4xx and timeouts.
 _MAX_ATTEMPTS = 3
 _BACKOFF_S = 3.0
+_RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
 
 _SYNTHESIS_SYSTEM = (
     "You are a panel of independent expert models with a judge. Deliberate on the user's question "
@@ -80,10 +113,20 @@ def _openrouter_key() -> str | None:
     return None
 
 
-def _resolve_preset(preset: str | None, mode: str) -> tuple[str, str]:
-    """(preset_name, openrouter_slug). Falls back to the mode-aware default for unknown/None."""
-    name = preset if preset in _PRESET_SLUG else _DEFAULT_PRESET.get(mode, "budget")
-    return name, _PRESET_SLUG[name]
+def _resolve_preset(preset: str | None, mode: str) -> tuple[str, dict]:
+    """(preset_name, panel_config). Analysis is ALWAYS strong; synthesis defaults to budget."""
+    if mode == "analysis":
+        return "strong", _PRESET_PANELS["strong"]
+    name = preset if preset in _PRESET_PANELS else _DEFAULT_PRESET.get(mode, "budget")
+    return name, _PRESET_PANELS[name]
+
+
+def _resolve_stakes(stakes: str | None, mode: str, preset_name: str) -> str:
+    """Auto-couple stakes when not explicitly given: analysis→high, synthesis strong→high, budget→normal.
+    An explicit "normal"/"high" always wins."""
+    if stakes in ("normal", "high"):
+        return stakes
+    return "high" if (mode == "analysis" or preset_name == "strong") else "normal"
 
 
 class FusionBackend:
@@ -96,7 +139,7 @@ class FusionBackend:
         question: str,
         *,
         context: str | None = None,
-        stakes: str = "normal",
+        stakes: str | None = None,
         mode: str = "synthesis",
         preset: str | None = None,
         timeout_s: float = _DEFAULT_TIMEOUT_S,
@@ -109,40 +152,40 @@ class FusionBackend:
                 answer=None, error="OpenRouter API key not configured (API_KEY_OPENROUTER)"
             )
         user = question if not context else f"{question}\n\nContext:\n{context}"
-        high = _HIGH_SUFFIX if stakes == "high" else ""
-        preset_name, slug = _resolve_preset(preset, mode)
+        preset_name, panel = _resolve_preset(preset, mode)
+        high = _HIGH_SUFFIX if _resolve_stakes(stakes, mode, preset_name) == "high" else ""
+        fusion_cfg = {"analysis_models": panel["analysis_models"], "model": panel["model"]}
         if mode == "analysis":
             extra = {
-                "tools": [{"type": "openrouter:fusion", "parameters": {"preset": slug}}],
+                "tools": [{"type": "openrouter:fusion", "parameters": fusion_cfg}],
                 "tool_choice": "required",
             }
             return await _call(
                 _ANALYSIS_ORCHESTRATOR, _ANALYSIS_SYSTEM + high, user, key, timeout_s, extra,
                 "analysis", preset_name,
             )
-        extra = {"plugins": [{"id": "fusion", "preset": slug}]}
+        extra = {"plugins": [{"id": "fusion", **fusion_cfg}]}
         return await _call(_MODEL, _SYNTHESIS_SYSTEM + high, user, key, timeout_s, extra, "synthesis", preset_name)
 
 
 async def _call(model, system, user, key, timeout_s, extra_body, mode, preset) -> DeliberationResult:
-    messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
-    kwargs = {
+    body = {
         "model": model,
-        "messages": messages,
-        "api_key": key,
+        "messages": [{"role": "system", "content": system}, {"role": "user", "content": user}],
         "max_tokens": _MAX_TOKENS,
-        "drop_params": True,
-        "num_retries": 0,
-        "timeout": timeout_s,
+        "stream": True,
+        "stream_options": {"include_usage": True},  # final SSE chunk carries usage.cost
     }
     if extra_body:
-        kwargs["extra_body"] = extra_body
+        body.update(extra_body)
     t0 = time.perf_counter()
     last_exc: Exception | None = None
     for attempt in range(_MAX_ATTEMPTS):
         try:
-            resp = await asyncio.wait_for(litellm.acompletion(**kwargs), timeout=timeout_s + 10)
-        except (TimeoutError, litellm.Timeout):
+            content, cost, stream_err = await asyncio.wait_for(
+                _consume_stream(body, key, timeout_s), timeout=timeout_s + 10
+            )
+        except (TimeoutError, httpx.TimeoutException):
             return DeliberationResult(
                 answer=None,
                 backend_used=f"fusion/{mode}",
@@ -150,22 +193,88 @@ async def _call(model, system, user, key, timeout_s, extra_body, mode, preset) -
                 latency_s=time.perf_counter() - t0,
                 error=f"fusion ({mode}) timed out after ~{timeout_s:.0f}s",
             )
-        except (litellm.RateLimitError, litellm.ServiceUnavailableError) as exc:
-            # transient — back off and retry (frontier panels 429 under load)
+        except httpx.HTTPStatusError as exc:
+            last_exc = exc
+            if exc.response.status_code in _RETRYABLE_STATUS and attempt + 1 < _MAX_ATTEMPTS:
+                await asyncio.sleep(_BACKOFF_S * (attempt + 1))
+                continue
+            return _error_result(exc, time.perf_counter() - t0, mode, preset)
+        except httpx.TransportError as exc:
+            # connection reset / read error mid-panel — transient, retry
             last_exc = exc
             if attempt + 1 < _MAX_ATTEMPTS:
                 await asyncio.sleep(_BACKOFF_S * (attempt + 1))
                 continue
             return _error_result(exc, time.perf_counter() - t0, mode, preset)
-        except Exception as exc:  # noqa: BLE001 — map ALL other litellm errors to a graceful result
+        except Exception as exc:  # noqa: BLE001 — any other error → graceful result, never raise
             return _error_result(exc, time.perf_counter() - t0, mode, preset)
         else:
-            return _normalize(resp, time.perf_counter() - t0, mode, preset)
+            if not content and attempt + 1 < _MAX_ATTEMPTS:
+                # transient empty / in-stream panel error from a flaky panel — one more shot
+                last_exc = RuntimeError(stream_err or "empty stream")
+                await asyncio.sleep(_BACKOFF_S * (attempt + 1))
+                continue
+            return _normalize(content, cost, stream_err, time.perf_counter() - t0, mode, preset)
     return _error_result(last_exc or RuntimeError("retries exhausted"), time.perf_counter() - t0, mode, preset)
 
 
+async def _consume_stream(body: dict, key: str, timeout_s: float) -> tuple[str, float | None, str | None]:
+    """Raw streaming POST → buffer the SSE lines, then parse content + final usage.cost + any error.
+
+    Wrapped in asyncio.wait_for by the caller. Raises httpx errors (status / transport / timeout) for the
+    caller's retry map; ``raise_for_status`` turns a 4xx/5xx into ``httpx.HTTPStatusError``.
+    """
+    headers = {"Authorization": f"Bearer {key}"}  # httpx sets Content-Type from json=
+    timeout = httpx.Timeout(timeout_s, connect=30.0)
+    async with (
+        httpx.AsyncClient(timeout=timeout) as client,
+        client.stream("POST", _OR_ENDPOINT, json=body, headers=headers) as resp,
+    ):
+        if resp.status_code >= 400:
+            await resp.aread()  # read the error body so HTTPStatusError carries a message
+            resp.raise_for_status()
+        lines = [line async for line in resp.aiter_lines()]
+    return _parse_sse(lines)
+
+
+def _parse_sse(lines: list[str]) -> tuple[str, float | None, str | None]:
+    """Parse OpenRouter SSE lines: skip ``:`` keep-alive comments, assemble ``delta.content``, read the
+    final ``usage.cost``, and capture any in-stream ``error`` message (OpenRouter reports mid-stream
+    panel failures as an ``error`` object on a 200 response). Tolerant of malformed / partial lines."""
+    parts: list[str] = []
+    cost: float | None = None
+    error: str | None = None
+    for line in lines:
+        if not line or line.startswith(":"):
+            continue
+        if not line.startswith("data:"):
+            continue
+        data = line[5:].strip()
+        if data == "[DONE]":
+            break
+        try:
+            obj = json.loads(data)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(obj, dict):
+            continue
+        for ch in obj.get("choices") or []:
+            piece = (ch.get("delta") or {}).get("content") if isinstance(ch, dict) else None
+            if piece:
+                parts.append(piece)
+        usage = obj.get("usage")
+        if isinstance(usage, dict):
+            c = usage.get("cost")
+            if isinstance(c, (int, float)) and not isinstance(c, bool):
+                cost = float(c)
+        err = obj.get("error")
+        if err:
+            error = err.get("message") if isinstance(err, dict) else str(err)
+    return "".join(parts), cost, error
+
+
 def _error_result(exc: Exception, latency: float, mode: str, preset: str) -> DeliberationResult:
-    status = getattr(exc, "status_code", None)
+    status = getattr(getattr(exc, "response", None), "status_code", None) or getattr(exc, "status_code", None)
     return DeliberationResult(
         answer=None,
         backend_used=f"fusion/{mode}",
@@ -175,11 +284,21 @@ def _error_result(exc: Exception, latency: float, mode: str, preset: str) -> Del
     )
 
 
-def _normalize(resp: object, latency: float, mode: str, preset: str) -> DeliberationResult:
-    content = _content(resp)
+def _normalize(
+    content: str, cost: float | None, error: str | None, latency: float, mode: str, preset: str
+) -> DeliberationResult:
     parsed = _parse_content(content)
-    cost, cost_known = _extract_cost(resp)
+    cost_known = isinstance(cost, (int, float)) and not isinstance(cost, bool)
     answer = parsed.get("answer") or (content[:_ANSWER_CAP] if content else None)
+    err = None
+    if not content:  # surface the real in-stream reason when we got nothing back
+        err = f"fusion ({mode}) returned no content"
+        if error:
+            err += f": {error[:200]}"
+    elif error:
+        # content arrived AND a late in-stream error — the verdict is usable but may be partial;
+        # don't false-fail a complete answer, but don't drop the signal either (log it).
+        logger.warning("fusion (%s) delivered content with a trailing in-stream error: %s", mode, error[:200])
     return DeliberationResult(
         answer=answer,
         consensus=parsed.get("consensus"),
@@ -190,17 +309,10 @@ def _normalize(resp: object, latency: float, mode: str, preset: str) -> Delibera
         backend_used=f"fusion/{mode}",
         preset_used=preset,
         latency_s=latency,
-        cost_usd=cost,
+        cost_usd=float(cost) if cost_known else 0.0,
         cost_known=cost_known,
-        error=None if content else f"fusion ({mode}) returned empty content",
+        error=err,
     )
-
-
-def _content(resp: object) -> str:
-    try:
-        return resp.choices[0].message.content or ""  # type: ignore[attr-defined]
-    except (AttributeError, IndexError, TypeError):
-        return ""
 
 
 def _parse_content(content: str) -> dict:
@@ -241,19 +353,3 @@ def _coerce(obj: dict) -> dict:
     if isinstance(conf, (int, float)) and not isinstance(conf, bool):
         out["confidence"] = max(0.0, min(1.0, float(conf)))
     return out
-
-
-def _extract_cost(resp: object) -> tuple[float, bool]:
-    """Cost is in response.usage.cost (probe-confirmed); litellm.completion_cost can't price fusion."""
-    usage = getattr(resp, "usage", None)
-    if usage is not None:
-        cost = getattr(usage, "cost", None)
-        if cost is None and isinstance(usage, dict):
-            cost = usage.get("cost")
-        if isinstance(cost, (int, float)) and not isinstance(cost, bool):
-            return float(cost), True
-    hidden = getattr(resp, "_hidden_params", {}) or {}
-    rc = hidden.get("response_cost") if isinstance(hidden, dict) else None
-    if isinstance(rc, (int, float)) and not isinstance(rc, bool):
-        return float(rc), True
-    return 0.0, False

--- a/src/genesis/deliberation/core.py
+++ b/src/genesis/deliberation/core.py
@@ -11,7 +11,7 @@ import logging
 from contextvars import ContextVar
 
 from genesis.deliberation.backends import get_backend
-from genesis.deliberation.types import DeliberationResult, Stakes
+from genesis.deliberation.types import DeliberationResult
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ async def deliberate(
     question: str,
     *,
     context: str | None = None,
-    stakes: Stakes = "normal",
+    stakes: str | None = None,
     backend: str = "fusion",
     mode: str = "synthesis",
     preset: str | None = None,
@@ -32,6 +32,12 @@ async def deliberate(
     models: list[str] | None = None,
 ) -> DeliberationResult:
     """Run a question through a chorus of models and return verdict + dissent.
+
+    ``mode`` ``"synthesis"`` (fast prose) | ``"analysis"`` (structured consensus/dissent).
+    ``preset`` ``"strong"`` (frontier panel) | ``"budget"`` (mid-tier); mode-aware default
+    (synthesis→budget, analysis→strong, which is always forced strong). ``stakes`` left as
+    ``None`` auto-couples to high for analysis or the strong preset, else normal — pass an
+    explicit ``"normal"``/``"high"`` to override.
 
     Never raises — every failure comes back as ``DeliberationResult(error=...)``.
     PAID (Fusion) and recursion-blocked.
@@ -47,8 +53,8 @@ async def deliberate(
     be = get_backend(backend)
     if be is None:
         return DeliberationResult(answer=None, backend_used=backend, error=f"unknown backend: {backend}")
-    if stakes not in ("normal", "high"):
-        stakes = "normal"
+    # stakes left as-is (incl. None / unknown): the backend auto-couples it from mode+preset
+    # when not an explicit "normal"/"high". See FusionBackend._resolve_stakes.
 
     token = _in_deliberate.set(True)
     try:

--- a/src/genesis/mcp/health/deliberation_tools.py
+++ b/src/genesis/mcp/health/deliberation_tools.py
@@ -14,19 +14,19 @@ logger = logging.getLogger(__name__)
 
 
 async def _impl_deliberate(
-    question: str, context: str = "", stakes: str = "normal", mode: str = "synthesis", preset: str = ""
+    question: str, context: str = "", stakes: str = "", mode: str = "synthesis", preset: str = ""
 ) -> dict:
     from genesis.deliberation import deliberate
 
     if not question or not question.strip():
         return {"error": "question is required"}
-    if stakes not in ("normal", "high"):
-        stakes = "normal"
+    # "" / unknown → None so the backend auto-couples stakes from mode+preset.
+    stakes_arg = stakes if stakes in ("normal", "high") else None
     if mode not in ("synthesis", "analysis"):
         mode = "synthesis"
     preset_arg = preset if preset in ("strong", "budget") else None
     result = await deliberate(
-        question, context=(context or None), stakes=stakes, mode=mode, preset=preset_arg, backend="fusion"
+        question, context=(context or None), stakes=stakes_arg, mode=mode, preset=preset_arg, backend="fusion"
     )
     return {
         "answer": result.answer,
@@ -48,9 +48,9 @@ async def _impl_deliberate(
 
 @mcp.tool()
 async def deliberate(
-    question: str, context: str = "", stakes: str = "normal", mode: str = "synthesis", preset: str = ""
+    question: str, context: str = "", stakes: str = "", mode: str = "synthesis", preset: str = ""
 ) -> dict:
-    """Consult a chorus of models (a server-side panel + judge) for a verdict PLUS the dissent —
+    """Consult a chorus of models (a custom panel + judge) for a verdict PLUS the dissent —
     for genuinely high-stakes or contested decisions.
 
     PAID + opt-in: routes to OpenRouter Fusion (non-free). Use ONLY for high-stakes/explicit calls —
@@ -59,11 +59,13 @@ async def deliberate(
     Args:
       question: the decision or question to deliberate.
       context:  optional background to ground the panel.
-      stakes:   "normal" (default) or "high" (weights dissent more heavily).
+      stakes:   "" (default) auto-couples — high for analysis or the strong preset, else normal.
+                Pass "normal"/"high" to override (high weights dissent more heavily).
       mode:     "synthesis" (default) = fast prose verdict; "analysis" = deeper (~2-3min)
-                machine-structured consensus + dissent[] + blind_spots[].
-      preset:   "" = mode default (synthesis→budget, analysis→strong); "strong" = general-high panel
-                (frontier models); "budget" = general-budget panel (mid-tier, cheaper/faster).
+                machine-structured consensus + dissent[] + blind_spots[] (always the strong panel).
+      preset:   "" = mode default (synthesis→budget, analysis→strong); "strong" = frontier panel
+                (opus/gpt/gemini/grok/deepseek/kimi, gpt judge); "budget" = mid-tier panel
+                (deepseek/gpt-mini/grok/qwen/kimi/gemini-flash, sonnet judge — cheaper/faster).
 
     Returns {answer, consensus, dissent[], blind_spots[], confidence, per_model[], backend_used,
     preset_used, cost_usd, cost_known, latency_s, error}. On failure, answer is null and error is set

--- a/tests/test_deliberation/test_deliberate.py
+++ b/tests/test_deliberation/test_deliberate.py
@@ -1,22 +1,25 @@
-"""Tests for deliberate() — the chorus. litellm is mocked; no live calls."""
+"""Tests for deliberate() — the chorus. The HTTP layer (_consume_stream) is mocked; no live calls."""
 
 from __future__ import annotations
 
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
+
+import httpx
 
 from genesis.deliberation import DeliberationResult, deliberate
 from genesis.deliberation.backends.fusion import (
+    _PRESET_PANELS,
     FusionBackend,
-    _extract_cost,
     _normalize,
     _parse_content,
+    _parse_sse,
     _resolve_preset,
+    _resolve_stakes,
 )
 
-# ── fixtures: real-shaped litellm responses ──────────────────────────────────
-# PROSE = the actual probe output (2026-06-24): bare model-slug returns synthesized
-# MARKDOWN in message.content, no structured fields.
+# ── fixtures: real-shaped content ────────────────────────────────────────────
+# PROSE = the actual probe output (2026-06-24): the fusion model-slug returns synthesized
+# MARKDOWN, no structured fields.
 PROSE = (
     "# Recommendation: Cut now — but cut surgically\n\n"
     "**B is a trap dressed up as ambition** and the math gives it away.\n"
@@ -41,11 +44,59 @@ ANALYSIS_JSON = (
 )
 
 
-def _resp(content, cost=None):
-    """Mimic the litellm ModelResponse shape the backend reads."""
-    msg = SimpleNamespace(content=content)
-    usage = SimpleNamespace(cost=cost) if cost is not None else SimpleNamespace()
-    return SimpleNamespace(choices=[SimpleNamespace(message=msg)], usage=usage, _hidden_params={})
+def _http_error(status: int) -> httpx.HTTPStatusError:
+    req = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+    resp = httpx.Response(status, request=req)
+    return httpx.HTTPStatusError(f"status {status}", request=req, response=resp)
+
+
+# ── SSE parser ───────────────────────────────────────────────────────────────
+
+
+def test_parse_sse_assembles_content_and_cost():
+    lines = [
+        ": OPENROUTER PROCESSING",  # keep-alive comment
+        "",
+        'data: {"choices":[{"delta":{"content":"Hello "}}]}',
+        'data: {"choices":[{"delta":{"content":"world"}}]}',
+        'data: {"choices":[],"usage":{"prompt_tokens":10,"cost":0.1839}}',
+        "data: [DONE]",
+    ]
+    content, cost, err = _parse_sse(lines)
+    assert content == "Hello world"
+    assert cost == 0.1839
+    assert err is None
+
+
+def test_parse_sse_skips_comments_and_malformed():
+    lines = [": keep-alive", "", "data: not-json", 'data: {"choices":[{"delta":{"content":"ok"}}]}']
+    content, cost, _ = _parse_sse(lines)
+    assert content == "ok" and cost is None
+
+
+def test_parse_sse_stops_at_done():
+    lines = [
+        'data: {"choices":[{"delta":{"content":"keep"}}]}',
+        "data: [DONE]",
+        'data: {"choices":[{"delta":{"content":"DROP"}}]}',
+    ]
+    content, _, _ = _parse_sse(lines)
+    assert content == "keep"
+
+
+def test_parse_sse_cost_bool_rejected():
+    content, cost, _ = _parse_sse(['data: {"choices":[],"usage":{"cost":true}}'])
+    assert content == "" and cost is None
+
+
+def test_parse_sse_captures_in_stream_error():
+    lines = [
+        ": OPENROUTER PROCESSING",
+        'data: {"choices":[],"error":{"code":502,"message":"panel upstream failed"}}',
+    ]
+    content, cost, err = _parse_sse(lines)
+    assert content == "" and cost is None
+    assert err == "panel upstream failed"
 
 
 # ── parser / normalizer ──────────────────────────────────────────────────────
@@ -87,7 +138,7 @@ def test_parse_blind_spots():
 
 
 def test_normalize_prose_uses_content_as_answer():
-    r = _normalize(_resp(PROSE, cost=0.3211), 80.0, "synthesis", "budget")
+    r = _normalize(PROSE, 0.3211, None, 80.0, "synthesis", "budget")
     assert r.ok
     assert r.answer.startswith("# Recommendation")
     assert r.dissent == ()
@@ -97,13 +148,13 @@ def test_normalize_prose_uses_content_as_answer():
 
 
 def test_normalize_json_structured():
-    r = _normalize(_resp(JSON_OK, cost=0.05), 70.0, "synthesis", "budget")
+    r = _normalize(JSON_OK, 0.05, None, 70.0, "synthesis", "budget")
     assert r.answer.startswith("Cut now")
     assert r.consensus and len(r.dissent) == 1 and r.confidence == 0.82
 
 
 def test_normalize_analysis_structured():
-    r = _normalize(_resp(ANALYSIS_JSON, cost=0.12), 173.0, "analysis", "strong")
+    r = _normalize(ANALYSIS_JSON, 0.12, None, 173.0, "analysis", "strong")
     assert r.answer.startswith("Choose A")
     assert len(r.dissent) == 3
     assert len(r.blind_spots) == 2
@@ -112,75 +163,125 @@ def test_normalize_analysis_structured():
     assert r.cost_usd == 0.12 and r.cost_known
 
 
+def test_normalize_cost_unknown():
+    r = _normalize(PROSE, None, None, 80.0, "synthesis", "budget")
+    assert r.ok and r.cost_usd == 0.0 and not r.cost_known
+
+
 def test_normalize_empty_content_errors():
-    r = _normalize(_resp("", cost=0.01), 1.0, "synthesis", "budget")
-    assert not r.ok and "empty" in r.error
+    r = _normalize("", 0.01, None, 1.0, "synthesis", "budget")
+    assert not r.ok and "no content" in r.error
 
 
-def test_resolve_preset_mapping_and_defaults():
-    assert _resolve_preset("strong", "synthesis") == ("strong", "general-high")
-    assert _resolve_preset("budget", "analysis") == ("budget", "general-budget")
-    # mode-aware defaults when preset is None/unknown
-    assert _resolve_preset(None, "synthesis") == ("budget", "general-budget")
-    assert _resolve_preset(None, "analysis") == ("strong", "general-high")
-    assert _resolve_preset("bogus", "analysis") == ("strong", "general-high")
+def test_normalize_empty_surfaces_stream_error():
+    r = _normalize("", None, "panel exploded", 1.0, "analysis", "strong")
+    assert not r.ok and "no content" in r.error and "panel exploded" in r.error
 
 
-def test_extract_cost_from_usage():
-    cost, known = _extract_cost(_resp("x", cost=0.42))
-    assert cost == 0.42 and known
+def test_normalize_content_with_trailing_error_stays_ok():
+    # a complete/usable verdict alongside a late in-stream error is NOT false-failed (error is logged)
+    r = _normalize("a real verdict", 0.1, "late panel error", 50.0, "synthesis", "strong")
+    assert r.ok and r.answer == "a real verdict"
 
 
-def test_extract_cost_unknown():
-    cost, known = _extract_cost(_resp("x"))
-    assert cost == 0.0 and not known
+def test_resolve_preset_returns_panels_and_defaults():
+    # explicit synthesis presets pick the matching custom panel
+    assert _resolve_preset("strong", "synthesis") == ("strong", _PRESET_PANELS["strong"])
+    assert _resolve_preset("budget", "synthesis") == ("budget", _PRESET_PANELS["budget"])
+    # synthesis defaults to budget when preset is None/unknown
+    assert _resolve_preset(None, "synthesis") == ("budget", _PRESET_PANELS["budget"])
+    assert _resolve_preset("bogus", "synthesis") == ("budget", _PRESET_PANELS["budget"])
+    # analysis is ALWAYS strong, ignoring any requested preset
+    assert _resolve_preset(None, "analysis") == ("strong", _PRESET_PANELS["strong"])
+    assert _resolve_preset("budget", "analysis") == ("strong", _PRESET_PANELS["strong"])
 
 
-# ── FusionBackend.run (litellm mocked) ───────────────────────────────────────
+def test_resolve_stakes_auto_couples():
+    # an explicit normal/high always wins
+    assert _resolve_stakes("normal", "analysis", "strong") == "normal"
+    assert _resolve_stakes("high", "synthesis", "budget") == "high"
+    # auto-couple when stakes is None/unknown: analysis→high, synthesis strong→high, budget→normal
+    assert _resolve_stakes(None, "analysis", "strong") == "high"
+    assert _resolve_stakes(None, "synthesis", "strong") == "high"
+    assert _resolve_stakes(None, "synthesis", "budget") == "normal"
+    assert _resolve_stakes("", "synthesis", "budget") == "normal"
+    assert _resolve_stakes("garbage", "synthesis", "strong") == "high"
+
+
+# ── FusionBackend.run (HTTP layer mocked) ────────────────────────────────────
+# Patch _consume_stream → (content, cost); assert the request body shape + error mapping.
+_STREAM = "genesis.deliberation.backends.fusion._consume_stream"
 
 
 async def test_fusion_happy(monkeypatch):
     monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
-    with patch(
-        "genesis.deliberation.backends.fusion.litellm.acompletion",
-        new=AsyncMock(return_value=_resp(JSON_OK, cost=0.05)),
-    ) as m:
+    with patch(_STREAM, new=AsyncMock(return_value=(JSON_OK, 0.05, None))) as m:
         r = await FusionBackend().run("q", stakes="high")
     assert r.ok and r.answer.startswith("Cut now")
     assert r.cost_usd == 0.05 and r.cost_known and isinstance(r.latency_s, float)
     assert r.preset_used == "budget"  # synthesis default preset
-    kwargs = m.call_args.kwargs
-    assert "HIGH-STAKES" in kwargs["messages"][0]["content"]  # stakes strengthens system prompt
-    assert kwargs["max_tokens"] == 2000  # explicit max_tokens (the 402 guard)
-    assert kwargs["model"] == "openrouter/openrouter/fusion"
-    assert kwargs["extra_body"]["plugins"][0]["preset"] == "general-budget"
+    body = m.call_args.args[0]
+    assert "HIGH-STAKES" in body["messages"][0]["content"]  # stakes strengthens system prompt
+    assert body["max_tokens"] == 2000  # explicit max_tokens (the 402 guard)
+    assert body["stream"] is True and body["stream_options"] == {"include_usage": True}
+    assert body["model"] == "openrouter/fusion"
+    plugin = body["plugins"][0]
+    assert plugin["id"] == "fusion"  # synthesis default preset → budget panel
+    assert plugin["analysis_models"] == _PRESET_PANELS["budget"]["analysis_models"]
+    assert plugin["model"] == _PRESET_PANELS["budget"]["model"]
 
 
 async def test_fusion_analysis_mode_request(monkeypatch):
     monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
-    with patch(
-        "genesis.deliberation.backends.fusion.litellm.acompletion",
-        new=AsyncMock(return_value=_resp(ANALYSIS_JSON, cost=0.12)),
-    ) as m:
+    with patch(_STREAM, new=AsyncMock(return_value=(ANALYSIS_JSON, 0.12, None))) as m:
         r = await FusionBackend().run("q", mode="analysis")
     assert r.ok and len(r.dissent) == 3 and r.backend_used == "fusion/analysis"
     assert r.preset_used == "strong"  # analysis default preset
-    kwargs = m.call_args.kwargs
-    assert kwargs["model"] == "openrouter/openai/gpt-oss-120b:free"
-    assert kwargs["extra_body"]["tools"][0]["type"] == "openrouter:fusion"
-    assert kwargs["extra_body"]["tools"][0]["parameters"]["preset"] == "general-high"
-    assert kwargs["extra_body"]["tool_choice"] == "required"
+    body = m.call_args.args[0]
+    assert body["model"] == "openai/gpt-oss-120b:free"
+    assert body["tools"][0]["type"] == "openrouter:fusion"
+    params = body["tools"][0]["parameters"]  # analysis default preset → strong panel
+    assert params["analysis_models"] == _PRESET_PANELS["strong"]["analysis_models"]
+    assert params["model"] == _PRESET_PANELS["strong"]["model"]
+    assert body["tool_choice"] == "required"
 
 
-async def test_fusion_preset_override(monkeypatch):
+async def test_fusion_analysis_always_strong(monkeypatch):
+    """analysis pins the strong panel even when budget is requested."""
     monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
-    with patch(
-        "genesis.deliberation.backends.fusion.litellm.acompletion",
-        new=AsyncMock(return_value=_resp(ANALYSIS_JSON, cost=0.12)),
-    ) as m:
+    with patch(_STREAM, new=AsyncMock(return_value=(ANALYSIS_JSON, 0.12, None))) as m:
         r = await FusionBackend().run("q", mode="analysis", preset="budget")
-    assert r.preset_used == "budget"
-    assert m.call_args.kwargs["extra_body"]["tools"][0]["parameters"]["preset"] == "general-budget"
+    assert r.preset_used == "strong"
+    params = m.call_args.args[0]["tools"][0]["parameters"]
+    assert params["analysis_models"] == _PRESET_PANELS["strong"]["analysis_models"]
+    assert params["model"] == _PRESET_PANELS["strong"]["model"]
+
+
+async def test_fusion_synthesis_preset_override(monkeypatch):
+    """synthesis honors an explicit strong preset → the frontier panel."""
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+    with patch(_STREAM, new=AsyncMock(return_value=(JSON_OK, 0.05, None))) as m:
+        r = await FusionBackend().run("q", preset="strong")
+    assert r.preset_used == "strong"
+    plugin = m.call_args.args[0]["plugins"][0]
+    assert plugin["analysis_models"] == _PRESET_PANELS["strong"]["analysis_models"]
+    assert plugin["model"] == _PRESET_PANELS["strong"]["model"]
+
+
+async def test_fusion_stakes_auto_couples(monkeypatch):
+    """Default stakes (None) auto-couples to the system prompt: budget synthesis stays normal,
+    strong synthesis and analysis go high; an explicit value overrides."""
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+
+    async def _system_prompt(**kw):
+        with patch(_STREAM, new=AsyncMock(return_value=(JSON_OK, 0.05, None))) as m:
+            await FusionBackend().run("q", **kw)
+        return m.call_args.args[0]["messages"][0]["content"]
+
+    assert "HIGH-STAKES" not in await _system_prompt()  # synthesis + budget default → normal
+    assert "HIGH-STAKES" in await _system_prompt(preset="strong")  # synthesis + strong → high
+    assert "HIGH-STAKES" in await _system_prompt(mode="analysis")  # analysis → high
+    assert "HIGH-STAKES" not in await _system_prompt(mode="analysis", stakes="normal")  # override
 
 
 async def test_fusion_no_key(monkeypatch):
@@ -192,59 +293,76 @@ async def test_fusion_no_key(monkeypatch):
 
 async def test_fusion_error_graceful(monkeypatch):
     monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
-    with patch(
-        "genesis.deliberation.backends.fusion.litellm.acompletion",
-        new=AsyncMock(side_effect=RuntimeError("boom")),
-    ):
+    with patch(_STREAM, new=AsyncMock(side_effect=RuntimeError("boom"))):
         r = await FusionBackend().run("q")
     assert not r.ok and "call failed" in r.error
 
 
 async def test_fusion_timeout_graceful(monkeypatch):
     monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
-    with patch(
-        "genesis.deliberation.backends.fusion.litellm.acompletion",
-        new=AsyncMock(side_effect=TimeoutError()),
-    ):
+    with patch(_STREAM, new=AsyncMock(side_effect=httpx.ReadTimeout("slow"))):
         r = await FusionBackend().run("q", timeout_s=1.0)
     assert not r.ok and "timed out" in r.error
 
 
-async def test_fusion_litellm_timeout_graceful(monkeypatch):
-    import litellm
-
+async def test_fusion_http_400_no_retry(monkeypatch):
     monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
-    exc = litellm.Timeout(message="slow", model="m", llm_provider="openrouter")
-    with patch(
-        "genesis.deliberation.backends.fusion.litellm.acompletion",
-        new=AsyncMock(side_effect=exc),
-    ):
-        r = await FusionBackend().run("q", timeout_s=1.0)
-    assert not r.ok and "timed out" in r.error
+    mock = AsyncMock(side_effect=_http_error(400))
+    with patch(_STREAM, new=mock):
+        r = await FusionBackend().run("q")
+    assert not r.ok and "call failed" in r.error and "status=400" in r.error
+    assert mock.call_count == 1  # 4xx is not retried
 
 
-async def test_fusion_retries_on_ratelimit(monkeypatch):
-    import litellm
-
+async def test_fusion_http_429_retries(monkeypatch):
     monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
     monkeypatch.setattr("genesis.deliberation.backends.fusion._BACKOFF_S", 0.0)
-    rle = litellm.RateLimitError(message="429", model="m", llm_provider="openrouter")
-    mock = AsyncMock(side_effect=[rle, rle, _resp(JSON_OK, cost=0.05)])  # fail twice, then succeed
-    with patch("genesis.deliberation.backends.fusion.litellm.acompletion", new=mock):
+    mock = AsyncMock(side_effect=[_http_error(429), _http_error(429), (JSON_OK, 0.05, None)])
+    with patch(_STREAM, new=mock):
         r = await FusionBackend().run("q")
     assert r.ok and r.answer.startswith("Cut now")
     assert mock.call_count == 3  # 1 + 2 retries
 
 
-async def test_fusion_ratelimit_exhausted(monkeypatch):
-    import litellm
-
+async def test_fusion_transport_error_retries(monkeypatch):
     monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
     monkeypatch.setattr("genesis.deliberation.backends.fusion._BACKOFF_S", 0.0)
-    rle = litellm.RateLimitError(message="429", model="m", llm_provider="openrouter")
-    with patch("genesis.deliberation.backends.fusion.litellm.acompletion", new=AsyncMock(side_effect=rle)):
+    mock = AsyncMock(side_effect=[httpx.ConnectError("reset"), (JSON_OK, 0.05, None)])
+    with patch(_STREAM, new=mock):
         r = await FusionBackend().run("q")
-    assert not r.ok and "call failed" in r.error
+    assert r.ok and mock.call_count == 2
+
+
+async def test_fusion_retries_on_empty_stream(monkeypatch):
+    """A transient empty / in-stream-error result gets one more shot, then succeeds."""
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+    monkeypatch.setattr("genesis.deliberation.backends.fusion._BACKOFF_S", 0.0)
+    mock = AsyncMock(side_effect=[("", None, "panel hiccup"), (JSON_OK, 0.05, None)])
+    with patch(_STREAM, new=mock):
+        r = await FusionBackend().run("q")
+    assert r.ok and r.answer.startswith("Cut now")
+    assert mock.call_count == 2
+
+
+async def test_fusion_empty_stream_surfaces_error(monkeypatch):
+    """An empty stream that never recovers surfaces the real in-stream error, not a generic message."""
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+    monkeypatch.setattr("genesis.deliberation.backends.fusion._BACKOFF_S", 0.0)
+    mock = AsyncMock(return_value=("", None, "panel exploded"))
+    with patch(_STREAM, new=mock):
+        r = await FusionBackend().run("q")
+    assert not r.ok and "no content" in r.error and "panel exploded" in r.error
+    assert mock.call_count == 3  # empty retried to exhaustion
+
+
+async def test_fusion_http_429_exhausted(monkeypatch):
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+    monkeypatch.setattr("genesis.deliberation.backends.fusion._BACKOFF_S", 0.0)
+    mock = AsyncMock(side_effect=_http_error(429))
+    with patch(_STREAM, new=mock):
+        r = await FusionBackend().run("q")
+    assert not r.ok and "call failed" in r.error and "status=429" in r.error
+    assert mock.call_count == 3  # exhausts all attempts
 
 
 # ── deliberate() core ────────────────────────────────────────────────────────
@@ -306,6 +424,22 @@ async def test_backend_receives_stakes_and_context(monkeypatch):
     }
 
 
+async def test_deliberate_default_stakes_is_none(monkeypatch):
+    """Unspecified stakes reaches the backend as None so it can auto-couple."""
+    seen = {}
+
+    class Stub:
+        name = "stub"
+
+        async def run(self, q, *, context, stakes, mode, preset, timeout_s, models):
+            seen["stakes"] = stakes
+            return DeliberationResult(answer="ok")
+
+    monkeypatch.setattr("genesis.deliberation.core.get_backend", lambda n: Stub())
+    await deliberate("q", backend="stub")
+    assert seen["stakes"] is None
+
+
 # ── MCP tool ─────────────────────────────────────────────────────────────────
 
 
@@ -333,3 +467,23 @@ async def test_mcp_impl_graceful(monkeypatch):
     assert out["dissent"] == ["d1"]
     assert out["cost_known"] is True
     assert out["latency_s"] == 70.0
+
+
+async def test_mcp_impl_stakes_passthrough(monkeypatch):
+    """The tool's "" default and unknown values pass None (auto-couple); normal/high pass through."""
+    seen = {}
+    import genesis.deliberation as dl
+
+    async def fake(q, **kw):
+        seen["stakes"] = kw.get("stakes")
+        return DeliberationResult(answer="A")
+
+    monkeypatch.setattr(dl, "deliberate", fake)
+    from genesis.mcp.health import deliberation_tools as dt
+
+    await dt._impl_deliberate("q")  # "" default → None
+    assert seen["stakes"] is None
+    await dt._impl_deliberate("q", stakes="high")
+    assert seen["stakes"] == "high"
+    await dt._impl_deliberate("q", stakes="garbage")  # unknown → None
+    assert seen["stakes"] is None


### PR DESCRIPTION
Follow-on to #772. Lets `deliberate()` run **explicit, custom-defined model panels** instead of OpenRouter's preset slugs, and rewrites the Fusion call so per-call **cost survives**.

## Custom panels (`_PRESET_PANELS`)
- **strong** — opus / gpt / gemini-pro / grok-4.3 / deepseek-v4-pro / kimi (`~…-latest` floats to newest), judged by gpt.
- **budget** — deepseek-v4-pro / gpt-mini / grok-4.3 / qwen3-235b-thinking / kimi / gemini-flash, judged by sonnet (cheaper/faster).
- `analysis` is **always** the strong panel; `synthesis` defaults to budget. Edit `_PRESET_PANELS` to recompose the chorus.
- `stakes` now **auto-couples** — `high` for analysis or the strong preset, else `normal` — unless an explicit `normal`/`high` is given. The MCP tool's `""` default and unknown values pass `None` so the backend couples.

## Backend rewrite: litellm → raw streaming `httpx`
The 6-model panels exposed two dead ends in litellm:
- its **non-streaming** path breaks on OpenRouter's SSE keep-alive padding for long panels (`Unable to get json response`);
- its **streaming** path strips the provider `usage.cost` and hides the OpenRouter generation id (so the `/generation` cost endpoint is unreachable).

So the backend now POSTs the chat-completions endpoint over a raw streaming `httpx` connection and parses the SSE itself — recovering content + `usage.cost` + any in-stream `error`. Custom retry: `429`/`5xx` + transport errors + a transient empty-stream retry; other `4xx` and timeouts don't retry. Never raises; a late in-stream error alongside usable content is logged, not false-failed.

## Verified live (all `cost_known=True`)
| setting | result | cost |
|---|---|---|
| synthesis-budget | ok, full prose verdict | $0.187 |
| analysis (strong) | ok, dissent=3 + blind_spots=6, conf 0.78 | $0.389 |
| synthesis-strong | ok, frontier prose verdict | $0.502 |

All 14 panel/judge model IDs confirmed present in the live OpenRouter catalog.

## Tests
44 deliberation tests (SSE parse, panels, stakes coupling, retry/error mapping, empty-stream retry) + 28 health-MCP regression — green. ruff clean. Code-reviewed (one finding addressed: surface, not drop, a trailing in-stream error).