### PR TITLE
feat(eval): surface weekly cognitive-subsystem grades in morning report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Your morning report now shows Genesis's weekly cognitive-quality grades.** Each week
+  Genesis grades its own subsystems (memory, ego, procedural, awareness, reflection) A–F;
+  the morning report now surfaces them, so cognitive health is visible at a glance instead
+  of buried in a dashboard. Healthy grades compress to a single "nominal" line — it only
+  elaborates on a subsystem that's low.
+
 - **Genesis can now propose improvements to how it reflects — and apply them only with your approval.**
   The Evo loop measures variations of the deep-reflection prompt against a golden set
   (with held-out re-validation), and when one is a confirmed improvement it files a

--- a/src/genesis/identity/MORNING_REPORT.md
+++ b/src/genesis/identity/MORNING_REPORT.md
@@ -105,6 +105,12 @@ itself, evidence of a current problem.
 - Cost — restate the single `Spend:` line from the System Health data
   exactly as given (month-to-date spend against the cap). One line. Do not
   project, annualize, recompute, add a daily figure, or flag a spike.
+- Cognitive subsystem grades — the weekly cognitive-quality readout (memory,
+  ego, procedural, awareness, reflection), when provided. Mention a subsystem
+  ONLY if it is at D/F or dropped since last week; otherwise compress to
+  "cognitive subsystems nominal" or omit. Weekly cadence — do not repeat
+  unchanged grades in the daily report. This is a neutral readout, not an
+  alarm; do not lead the report with it.
 - Items requiring user decision — pending approvals, ego proposals, inbox items
 
 **Omit entirely:**

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -155,6 +155,16 @@ class MorningReportGenerator:
             logger.warning("Morning report: cognitive state unavailable", exc_info=True)
             await self._emit_warning("cognitive_state", "Cognitive state section unavailable")
 
+        # 3b. Cognitive subsystem quality grades (weekly J9 grades; neutral
+        # observability — the regression alarm is a separate deterministic path)
+        try:
+            eval_quality = await self._get_eval_quality_section()
+            if eval_quality:
+                sections.append(f"## Cognitive Subsystem Grades\n{eval_quality}")
+        except Exception:
+            logger.warning("Morning report: eval quality section unavailable", exc_info=True)
+            await self._emit_warning("eval_quality", "Cognitive subsystem grades section unavailable")
+
         # 4. Pending Items (user-actionable only)
         try:
             pending = await self._get_pending_items()
@@ -364,6 +374,37 @@ class MorningReportGenerator:
             aging_tag = " [AGING]" if _age_seconds(r["created_at"]) > 43200 else ""  # >12h
             entry_lines.append(f"- [{r['section']}]{aging_tag} {r['content'][:300]} ({age})")
         return header + "\n" + "\n".join(entry_lines)
+
+    async def _get_eval_quality_section(self) -> str | None:
+        """Weekly cognitive-subsystem quality grades (A–F) — neutral readout.
+
+        This is OBSERVABILITY, not an alarm channel: a grade *regression* is
+        surfaced separately and deterministically at aggregation time, not via
+        this LLM-narrated report. Returns None when no graded subsystem exists
+        (cold start / insufficient data) so the section is skipped entirely.
+        Subsystems with no letter grade (``cognitive_drift`` is dark by design;
+        sparse weeks grade to None) are omitted — never shown as a problem.
+        """
+        from genesis.db.crud import j9_eval
+
+        grades = await j9_eval.get_latest_subsystem_grades(self._db)
+        graded = [g for g in grades if g.get("grade")]
+        if not graded:
+            return None
+
+        lines = [
+            "Weekly cognitive-subsystem grades. Mention a subsystem ONLY if it "
+            "is at D/F or notably low; otherwise compress to 'cognitive "
+            "subsystems nominal'. Weekly cadence — do not repeat unchanged "
+            "grades in the daily report.",
+        ]
+        for g in sorted(graded, key=lambda x: x.get("subsystem", "")):
+            sub = g.get("subsystem", "?")
+            grade = g.get("grade", "?")
+            score = g.get("score")
+            score_txt = f" ({score:.0f})" if isinstance(score, (int, float)) else ""
+            lines.append(f"- {sub}: {grade}{score_txt}")
+        return "\n".join(lines)
 
     async def _get_pending_items(self) -> str:
         from genesis.db.crud import approval_requests as approval_crud

--- a/tests/test_outreach/test_morning_report.py
+++ b/tests/test_outreach/test_morning_report.py
@@ -266,3 +266,73 @@ async def test_no_event_bus_still_works(db, mock_health, mock_drafter):
     gen = MorningReportGenerator(mock_health, db, mock_drafter, event_bus=None)
     req = await gen.generate()
     assert req.category == OutreachCategory.DIGEST
+
+
+async def _insert_grade(db, subsystem, grade, score, period_end="2026-06-22T00:00:00Z"):
+    from genesis.db.crud import j9_eval
+
+    await j9_eval.insert_subsystem_grade(
+        db,
+        period_start="2026-06-15T00:00:00Z",
+        period_end=period_end,
+        period_type="weekly",
+        subsystem=subsystem,
+        grade=grade,
+        score=score,
+        factors={"f": 1.0},
+        sample_count=10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_eval_quality_section_surfaces_grades(db, mock_health, mock_drafter):
+    """Graded subsystems are surfaced with grade + score, sorted by name."""
+    await _insert_grade(db, "memory", "B", 82.0)
+    await _insert_grade(db, "ego", "D", 64.0)
+
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    out = await gen._get_eval_quality_section()
+
+    assert out is not None
+    assert "- ego: D (64)" in out
+    assert "- memory: B (82)" in out
+    # ego sorts before memory
+    assert out.index("ego:") < out.index("memory:")
+
+
+@pytest.mark.asyncio
+async def test_eval_quality_section_none_when_no_grades(db, mock_health, mock_drafter):
+    """No grades at all → section skipped entirely (returns None)."""
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    assert await gen._get_eval_quality_section() is None
+
+
+@pytest.mark.asyncio
+async def test_eval_quality_section_omits_ungraded(db, mock_health, mock_drafter):
+    """A None grade (cold-start / insufficient data) is omitted, never shown as
+    a problem; if it's the only row, the section is skipped. (cognitive_drift is
+    excluded at the schema level — the grades table CHECK-constrains subsystem to
+    the 5 graded subsystems, so the dark drift dimension never reaches here.)"""
+    await _insert_grade(db, "awareness", None, None)  # insufficient data → None
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    assert await gen._get_eval_quality_section() is None
+
+    # With one graded + one ungraded, only the graded one shows.
+    await _insert_grade(db, "memory", "A", 91.0)
+    out = await gen._get_eval_quality_section()
+    assert out is not None
+    assert "memory: A (91)" in out
+    assert "awareness" not in out
+
+
+@pytest.mark.asyncio
+async def test_eval_quality_section_appears_in_assembled_context(db, mock_health, mock_drafter):
+    """Wiring proof (Level-3 data-flow): when grades exist, the section reaches
+    the full assembled context that the LLM narrates."""
+    await _insert_grade(db, "memory", "B", 82.0)
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+
+    context = await gen._assemble_context()
+
+    assert "## Cognitive Subsystem Grades" in context
+    assert "memory: B (82)" in context


### PR DESCRIPTION
## What

J9 computes weekly per-subsystem quality grades (memory / ego / procedural / awareness / reflection) but nothing consumed them — render-only on the dashboard. This surfaces them in the daily morning report as a neutral **Cognitive Subsystem Grades** section.

## Why

The morning report is where the operator actually looks each day, so the grades belong there — cognitive health visible at a glance instead of buried in a dashboard. The section is **observability only**: it presents grades neutrally and self-compresses (the LLM narrator collapses stable grades to "cognitive subsystems nominal" and only elaborates on a low one). Any *alarm* on a regression is a separate deterministic path (follow-on PR), not this LLM-narrated report.

## Changes

- `outreach/morning_report.py`: new `_get_eval_quality_section()` reading `j9_eval.get_latest_subsystem_grades`, wired into `_assemble_context()`. Cold-start subsystems (grade `None`) are omitted; `cognitive_drift` is excluded at the schema level (the grades table CHECK-constrains subsystem to the 5 graded subsystems).
- `identity/MORNING_REPORT.md`: a guidance bullet aligned with the file's anti-telemetry / "compress to nominal" / "don't lead with it" philosophy.

## Testing

- 4 new tests (real in-memory sqlite, not mocked): surfaces grades, returns `None` when empty, omits ungraded/cold-start, and a wiring test proving the section reaches the assembled context.
- `ruff` clean; full existing morning-report suite green.