### PR TITLE
feat(eval): J9 grade-regression gate — alert + human-gated proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis now tells you when its own cognitive quality regresses — and proposes a fix.**
+  When a subsystem's weekly grade drops to F or falls sharply from the week before, Genesis
+  sends you an alert and files a dashboard proposal to investigate (for example, running an
+  experiment on the affected subsystem). Nothing changes automatically — it's a heads-up plus
+  a recommendation you approve or dismiss.
+
 - **Genesis can now propose improvements to how it reflects — and apply them only with your approval.**
   The Evo loop measures variations of the deep-reflection prompt against a golden set
   (with held-out re-validation), and when one is a confirmed improvement it files a

--- a/src/genesis/autonomy/classification.py
+++ b/src/genesis/autonomy/classification.py
@@ -293,6 +293,11 @@ ACTION_TYPE_DOMAIN_MAP: dict[str, ActionDomain] = {
     # (ACTION_DOMAIN_MIN_LEVEL = None), so an approved promotion can never be
     # auto-run as a session; it is applied ONLY by its resolution handler.
     "cognitive_variant_promotion": ActionDomain.SELF_MODIFY,
+    # J-9 regression surfacing is INFORMATIONAL — it notifies the operator about
+    # a cognitive-quality regression and applies nothing. NOTIFY_USER + the
+    # _NEVER_DISPATCH_ACTION_TYPES blocklist mean an approved one is marked
+    # executed by its handler, never auto-run as a background session.
+    "j9_regression": ActionDomain.NOTIFY_USER,
 }
 
 

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -378,6 +378,16 @@ async def ego_proposal_resolve(proposal_id: str):
             _logging.getLogger(__name__).warning(
                 "cognitive-variant hook failed for %s", proposal_id,
             )
+        try:
+            from genesis.ego.j9_regression_actions import (
+                handle_j9_regression_resolution,
+            )
+
+            await handle_j9_regression_resolution(rt._db, prop, status)
+        except Exception:
+            _logging.getLogger(__name__).warning(
+                "j9 regression hook failed for %s", proposal_id,
+            )
 
     return jsonify({"ok": True, "id": proposal_id, "status": status})
 

--- a/src/genesis/ego/j9_regression_actions.py
+++ b/src/genesis/ego/j9_regression_actions.py
@@ -1,0 +1,66 @@
+"""J-9 regression proposal — the no-op apply hook fired on resolution.
+
+A ``j9_regression`` proposal is INFORMATIONAL (ActionDomain.NOTIFY_USER): J-9's
+weekly aggregation detected a cognitive-subsystem quality regression and surfaced
+it for the operator. It applies NOTHING. On approval the proposal is simply
+marked ``executed`` so it leaves the board and the approved-proposal sweep never
+tries to dispatch it as a session — belt-and-suspenders alongside the
+``_NEVER_DISPATCH_ACTION_TYPES`` blocklist and the NOTIFY_USER domain gate. On
+rejection / any other status: no-op.
+
+Like the other recommend-only handlers (``goal_status_change``,
+``cell_promotion``, ``cognitive_variant``), it is called identically from every
+proposal-resolution entry point so behaviour is path-independent.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import aiosqlite
+
+from genesis.db.crud import ego as ego_crud
+
+logger = logging.getLogger(__name__)
+
+J9_REGRESSION_ACTION_TYPE = "j9_regression"
+
+
+async def handle_j9_regression_resolution(
+    db: aiosqlite.Connection,
+    proposal: dict,
+    status: object,
+) -> bool:
+    """Mark an approved ``j9_regression`` proposal ``executed`` (no side-effect).
+
+    No-op unless *proposal* is a ``j9_regression`` proposal. On approval, mark it
+    executed so it does not linger as 'approved' (which would clutter the board
+    AND let the approved-sweep try to dispatch it as a session). On any other
+    status: no-op — declining an informational notice changes nothing.
+
+    *status* may be a ``ProposalStatus`` enum or a plain string.
+    Returns True iff the proposal was marked executed.
+    """
+    if proposal.get("action_type") != J9_REGRESSION_ACTION_TYPE:
+        return False
+
+    status_str = getattr(status, "value", status)
+    if status_str != "approved":
+        return False
+
+    # execute_proposal transitions approved → executed (it no-ops unless the
+    # proposal is currently 'approved' — which it is here, the resolution flow
+    # set it before firing this hook). Log rather than swallow on failure.
+    try:
+        return await ego_crud.execute_proposal(
+            db,
+            proposal["id"],
+            status="executed",
+            user_response="j9_regression acknowledged",
+        )
+    except Exception:
+        logger.warning(
+            "j9_regression: execute_proposal failed for %s",
+            proposal.get("id"), exc_info=True,
+        )
+        return False

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -577,6 +577,19 @@ class ProposalWorkflow:
                         "cognitive-variant hook failed for %s",
                         prop.get("id"), exc_info=True,
                     )
+                # J-9 regression (informational): mark executed on approval, no
+                # side-effect. Never dispatched (blocklist + NOTIFY_USER gate).
+                try:
+                    from genesis.ego.j9_regression_actions import (
+                        handle_j9_regression_resolution,
+                    )
+
+                    await handle_j9_regression_resolution(self._db, prop, status)
+                except Exception:
+                    logger.warning(
+                        "j9 regression hook failed for %s",
+                        prop.get("id"), exc_info=True,
+                    )
             else:
                 logger.warning(
                     "Proposal %s not updated (already resolved?)",

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -69,6 +69,9 @@ _NEVER_DISPATCH_ACTION_TYPES = (
     "goal_status_change",
     "cell_promotion",
     "cognitive_variant_promotion",
+    # j9_regression is informational (NOTIFY_USER); its handler marks it executed
+    # on approval. Blocklisted so it can never be dispatched as a session.
+    "j9_regression",
 )
 
 

--- a/src/genesis/eval/regression_alert.py
+++ b/src/genesis/eval/regression_alert.py
@@ -1,0 +1,186 @@
+"""J-9 subsystem-grade regression detection + human-gated surfacing.
+
+The MONITOR half of the self-improvement control plane. J-9 computes weekly
+per-subsystem quality grades (memory/ego/procedural/awareness/reflection) but
+nothing consumed them — render-only telemetry. This module gives those grades
+their first control path: a *regression* triggers (1) a deterministic BLOCKER
+alert to the operator and (2) a HUMAN-GATED ``j9_regression`` ego proposal.
+
+Neither auto-acts. The proposal is informational (NOTIFY_USER + never-dispatch):
+approving it merely acknowledges; the remedy — e.g. an Evo experiment on the
+regressed subsystem — is the user's call. No procedure/config is demoted or hidden
+by this code.
+
+Conservative while the grade baseline is young (~weeks): fires only on an
+ABSOLUTE FLOOR (grade F) or a ≥15-point week-over-week score DROP, and never on a
+cold-start week (grade None / insufficient data). Idempotent per
+(subsystem, period_end) via a deterministic proposal id, so a restart-triggered
+re-run of the weekly aggregation never double-files or double-alerts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+
+import aiosqlite
+
+from genesis.db.crud import ego as ego_crud
+from genesis.db.crud import j9_eval
+
+logger = logging.getLogger(__name__)
+
+# Must match j9_regression_actions.J9_REGRESSION_ACTION_TYPE (kept local to avoid
+# an eval→ego import; the handler module is the canonical owner).
+_J9_REGRESSION_ACTION_TYPE = "j9_regression"
+
+# Conservative thresholds for a young grade baseline. Absolute floor = F only (a
+# D at 5-6 samples can be measurement noise); delta = a ≥15-point week-over-week
+# score drop regardless of grade. Tunable down toward D once variance is known.
+_ABSOLUTE_FLOOR_GRADE = "F"
+_DELTA_DROP_POINTS = 15.0
+
+
+def _proposal_id(subsystem: str, period_end: str) -> str:
+    """Deterministic id from (subsystem, period_end) — the idempotency key."""
+    return hashlib.sha256(
+        f"{_J9_REGRESSION_ACTION_TYPE}:{subsystem}:{period_end}".encode(),
+    ).hexdigest()[:16]
+
+
+def _regression_reason(latest: dict, prior: dict | None) -> str | None:
+    """Return a human reason string if *latest* is a regression, else None.
+
+    Guards on ``grade is not None`` — a cold-start / insufficient-data week
+    (grade None) never alerts. Two triggers: absolute floor (grade F) or a
+    ≥15-point week-over-week score drop.
+    """
+    grade = latest.get("grade")
+    if not grade:  # None / "" → insufficient data, never alert
+        return None
+    score = latest.get("score")
+    if grade == _ABSOLUTE_FLOOR_GRADE:
+        score_txt = f" (score {score:.0f})" if isinstance(score, (int, float)) else ""
+        return f"grade {grade}{score_txt}"
+    prior_score = prior.get("score") if prior else None
+    if isinstance(score, (int, float)) and isinstance(prior_score, (int, float)):
+        drop = prior_score - score
+        if drop >= _DELTA_DROP_POINTS:
+            return (
+                f"score dropped {drop:.0f} pts week-over-week "
+                f"({prior_score:.0f}→{score:.0f}), grade {grade}"
+            )
+    return None
+
+
+async def check_and_alert_regressions(
+    db: aiosqlite.Connection,
+    outreach_pipeline: object | None = None,
+) -> list[dict]:
+    """Detect weekly subsystem-grade regressions and surface them (human-gated).
+
+    For each regressed subsystem: send a BLOCKER alert (if a pipeline is given)
+    and file an informational ``j9_regression`` proposal. Idempotent per
+    (subsystem, period_end) — the proposal's existence marks the period handled.
+    Returns the list of regressions handled (for logging/tests). Never raises into
+    the caller; per-subsystem failures are logged and skipped.
+    """
+    handled: list[dict] = []
+    try:
+        grades = await j9_eval.get_latest_subsystem_grades(db, period_type="weekly")
+    except Exception:
+        logger.warning("j9 regression check: failed to read grades", exc_info=True)
+        return handled
+
+    for latest in grades:
+        sub = latest.get("subsystem")
+        period_end = latest.get("period_end")
+        if not sub or not period_end:
+            continue
+
+        # Prior week for the delta check (limit=2 → [latest, prior]).
+        prior = None
+        try:
+            hist = await j9_eval.get_subsystem_grades(
+                db, subsystem=sub, period_type="weekly", limit=2,
+            )
+            if len(hist) >= 2:
+                prior = hist[1]
+        except Exception:
+            logger.warning(
+                "j9 regression check: history read failed for %s", sub, exc_info=True,
+            )
+
+        reason = _regression_reason(latest, prior)
+        if not reason:
+            continue
+
+        pid = _proposal_id(sub, period_end)
+        # Idempotency: the proposal's existence marks this (subsystem, period) as
+        # already handled — a restart re-run skips BOTH alert and proposal.
+        try:
+            if await ego_crud.get_proposal(db, pid):
+                continue
+        except Exception:
+            logger.warning(
+                "j9 regression check: existence check failed for %s", sub, exc_info=True,
+            )
+            continue
+
+        text = (
+            f"Cognitive subsystem regression — {sub}: {reason} "
+            f"(week ending {period_end[:10]}). Investigate the {sub} pipeline; "
+            f"candidate remedy: an Evo experiment on the {sub} config."
+        )
+
+        # 1. BLOCKER alert (best-effort; governance dedups within 168h).
+        if outreach_pipeline is not None:
+            try:
+                from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+                await outreach_pipeline.submit_raw(
+                    text,
+                    OutreachRequest(
+                        category=OutreachCategory.BLOCKER,
+                        topic=f"Eval regression: {sub}",
+                        context=text,
+                        salience_score=1.0,
+                        signal_type="j9_regression_alert",
+                        source_id=f"j9_regression:{sub}:{period_end[:10]}",
+                    ),
+                )
+            except Exception:
+                logger.warning("j9 regression alert failed for %s", sub, exc_info=True)
+
+        # 2. Human-gated informational proposal (durable idempotent marker).
+        try:
+            await ego_crud.create_proposal(
+                db,
+                id=pid,
+                action_type=_J9_REGRESSION_ACTION_TYPE,
+                content=text,
+                rationale=(
+                    "J-9 weekly eval flagged a cognitive-subsystem quality "
+                    "regression. Recommend-only: approving acknowledges it; no "
+                    "automated remediation runs."
+                ),
+                confidence=1.0,
+                urgency="high",
+                status="pending",
+                ego_source="j9_eval",
+            )
+        except Exception:
+            logger.warning(
+                "j9 regression proposal creation failed for %s", sub, exc_info=True,
+            )
+            continue
+
+        handled.append(
+            {"subsystem": sub, "period_end": period_end, "reason": reason, "proposal_id": pid},
+        )
+
+    if handled:
+        logger.info(
+            "J9 regression check: %d subsystem regression(s) surfaced", len(handled),
+        )
+    return handled

--- a/src/genesis/mcp/health/ego_tools.py
+++ b/src/genesis/mcp/health/ego_tools.py
@@ -560,6 +560,15 @@ async def ego_proposal_resolve(
                     await handle_cognitive_variant_resolution(db, prop, status)
                 except Exception:
                     logger.debug("cognitive-variant hook failed", exc_info=True)
+                # J-9 regression (informational): mark executed on approval.
+                try:
+                    from genesis.ego.j9_regression_actions import (
+                        handle_j9_regression_resolution,
+                    )
+
+                    await handle_j9_regression_resolution(db, prop, status)
+                except Exception:
+                    logger.debug("j9 regression hook failed", exc_info=True)
 
     resolved = sum(1 for v in results.values() if v in ("approved", "rejected"))
     return {

--- a/src/genesis/outreach/governance.py
+++ b/src/genesis/outreach/governance.py
@@ -47,6 +47,7 @@ _DEDUP_WINDOWS: dict[str, int] = {
     "mail_reply": 1,  # Email replies — short window to allow ack + full response
     "mail_follow_up": 24,  # Follow-up emails — one per day max per topic
     "discord_poll": 168,  # Discord polls — 7 days (matches default poll duration)
+    "j9_regression_alert": 168,  # Weekly eval regressions — one alert/week max
 }
 _DEFAULT_DEDUP_HOURS = 24
 

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -1002,6 +1002,24 @@ async def init(rt: GenesisRuntime) -> None:
                 results = await run_weekly_aggregation(rt._db)
                 dims_computed = len(results)
                 logger.info("J9 weekly aggregation: %d dimensions computed", dims_computed)
+                # Close the J-9 loop: a subsystem-grade regression becomes a
+                # control path — a BLOCKER alert + a human-gated proposal. Wrapped
+                # so a surfacing failure never fails the aggregation job.
+                try:
+                    from genesis.eval.regression_alert import (
+                        check_and_alert_regressions,
+                    )
+
+                    regressions = await check_and_alert_regressions(
+                        rt._db, getattr(rt, "_outreach_pipeline", None),
+                    )
+                    if regressions:
+                        logger.info(
+                            "J9 regression check surfaced %d regression(s)",
+                            len(regressions),
+                        )
+                except Exception:
+                    logger.warning("J9 regression check failed", exc_info=True)
                 rt.record_job_success("j9_eval_aggregation")
             except Exception as exc:
                 rt.record_job_failure("j9_eval_aggregation", str(exc))

--- a/tests/ego/test_j9_regression_actions.py
+++ b/tests/ego/test_j9_regression_actions.py
@@ -1,0 +1,77 @@
+"""Tests for the j9_regression resolution handler + its safety wiring.
+
+The handler is a no-op-on-approval (mark executed); the safety wiring (NOTIFY_USER
+domain + the never-dispatch blocklist) is what guarantees an approved j9_regression
+proposal can never be auto-dispatched as a background session.
+"""
+
+import aiosqlite
+import pytest
+
+from genesis.autonomy.classification import ACTION_TYPE_DOMAIN_MAP, classify_domain
+from genesis.autonomy.types import ActionDomain
+from genesis.db.crud import ego as ego_crud
+from genesis.db.schema import create_all_tables
+from genesis.ego.j9_regression_actions import handle_j9_regression_resolution
+from genesis.ego.session import _NEVER_DISPATCH_ACTION_TYPES
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+# ── Safety wiring (the two layers that prevent auto-dispatch) ────────────────
+
+def test_j9_regression_maps_to_notify_user():
+    assert ACTION_TYPE_DOMAIN_MAP["j9_regression"] == ActionDomain.NOTIFY_USER
+    # And the classifier resolves it (not falling through to EXTERNAL_READ).
+    assert classify_domain("j9_regression") == ActionDomain.NOTIFY_USER
+
+
+def test_j9_regression_blocklisted_from_dispatch():
+    assert "j9_regression" in _NEVER_DISPATCH_ACTION_TYPES
+
+
+# ── Handler behaviour ────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_handler_marks_executed_on_approval(db):
+    # The resolution flow sets a proposal to 'approved' BEFORE the hooks fire;
+    # execute_proposal only transitions an 'approved' proposal → 'executed'.
+    await ego_crud.create_proposal(
+        db, id="p1", action_type="j9_regression", content="regression x",
+        status="approved",
+    )
+    ok = await handle_j9_regression_resolution(
+        db, {"id": "p1", "action_type": "j9_regression"}, "approved",
+    )
+    assert ok is True
+    prop = await ego_crud.get_proposal(db, "p1")
+    assert prop["status"] == "executed"  # left the board; sweep can't dispatch it
+
+
+@pytest.mark.asyncio
+async def test_handler_noop_on_other_action_type(db):
+    ok = await handle_j9_regression_resolution(
+        db, {"id": "p2", "action_type": "goal_status_change"}, "approved",
+    )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_handler_noop_on_rejection(db):
+    await ego_crud.create_proposal(
+        db, id="p3", action_type="j9_regression", content="regression x",
+        status="pending",
+    )
+    ok = await handle_j9_regression_resolution(
+        db, {"id": "p3", "action_type": "j9_regression"}, "rejected",
+    )
+    assert ok is False
+    prop = await ego_crud.get_proposal(db, "p3")
+    assert prop["status"] == "pending"  # declining changes nothing

--- a/tests/test_eval/test_regression_alert.py
+++ b/tests/test_eval/test_regression_alert.py
@@ -1,0 +1,150 @@
+"""Tests for J-9 subsystem-grade regression detection + human-gated surfacing."""
+
+from unittest.mock import AsyncMock
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import ego as ego_crud
+from genesis.db.crud import j9_eval
+from genesis.db.schema import create_all_tables
+from genesis.eval.regression_alert import (
+    _proposal_id,
+    _regression_reason,
+    check_and_alert_regressions,
+)
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+async def _grade(db, subsystem, grade, score, period_end):
+    await j9_eval.insert_subsystem_grade(
+        db,
+        period_start="2026-06-08T00:00:00Z",
+        period_end=period_end,
+        period_type="weekly",
+        subsystem=subsystem,
+        grade=grade,
+        score=score,
+        factors={"f": 1.0},
+        sample_count=10,
+    )
+
+
+# ── _regression_reason (pure threshold logic) ────────────────────────────────
+
+def test_reason_none_grade_never_alerts():
+    """Cold-start / insufficient-data weeks (grade None) never alert."""
+    assert _regression_reason({"grade": None, "score": None}, None) is None
+
+
+def test_reason_healthy_grade_no_drop():
+    assert _regression_reason(
+        {"grade": "B", "score": 82.0}, {"grade": "B", "score": 83.0},
+    ) is None
+
+
+def test_reason_absolute_floor_f():
+    r = _regression_reason({"grade": "F", "score": 55.0}, None)
+    assert r is not None and "grade F" in r
+
+
+def test_reason_delta_drop_15plus():
+    r = _regression_reason(
+        {"grade": "C", "score": 70.0}, {"grade": "B", "score": 88.0},
+    )
+    assert r is not None and "dropped" in r
+
+
+def test_reason_small_drop_below_threshold():
+    # 10-pt drop is below the 15-pt threshold and grade is not F → no alert.
+    assert _regression_reason(
+        {"grade": "B", "score": 80.0}, {"grade": "A", "score": 90.0},
+    ) is None
+
+
+# ── check_and_alert_regressions (integration) ────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_f_grade_surfaces_alert_and_proposal(db):
+    await _grade(db, "memory", "F", 55.0, "2026-06-22T00:00:00Z")
+    pipeline = AsyncMock()
+
+    handled = await check_and_alert_regressions(db, pipeline)
+
+    assert len(handled) == 1
+    assert handled[0]["subsystem"] == "memory"
+    pipeline.submit_raw.assert_awaited_once()
+
+    pid = _proposal_id("memory", "2026-06-22T00:00:00Z")
+    prop = await ego_crud.get_proposal(db, pid)
+    assert prop is not None
+    assert prop["action_type"] == "j9_regression"
+    assert prop["status"] == "pending"  # human-gated; nothing auto-applied
+
+
+@pytest.mark.asyncio
+async def test_healthy_grades_no_surfacing(db):
+    await _grade(db, "memory", "A", 92.0, "2026-06-22T00:00:00Z")
+    await _grade(db, "ego", "B", 81.0, "2026-06-22T00:00:00Z")
+    pipeline = AsyncMock()
+
+    handled = await check_and_alert_regressions(db, pipeline)
+
+    assert handled == []
+    pipeline.submit_raw.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cold_start_none_grade_no_surfacing(db):
+    await _grade(db, "awareness", None, None, "2026-06-22T00:00:00Z")
+    pipeline = AsyncMock()
+
+    handled = await check_and_alert_regressions(db, pipeline)
+
+    assert handled == []
+    pipeline.submit_raw.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_idempotent_no_double_file_or_alert(db):
+    await _grade(db, "memory", "F", 55.0, "2026-06-22T00:00:00Z")
+    pipeline = AsyncMock()
+
+    first = await check_and_alert_regressions(db, pipeline)
+    second = await check_and_alert_regressions(db, pipeline)
+
+    assert len(first) == 1
+    assert second == []  # the proposal marks the period handled
+    pipeline.submit_raw.assert_awaited_once()  # exactly one alert, not two
+
+
+@pytest.mark.asyncio
+async def test_no_pipeline_still_files_proposal(db):
+    await _grade(db, "memory", "F", 55.0, "2026-06-22T00:00:00Z")
+
+    handled = await check_and_alert_regressions(db, None)
+
+    assert len(handled) == 1
+    pid = _proposal_id("memory", "2026-06-22T00:00:00Z")
+    assert await ego_crud.get_proposal(db, pid) is not None
+
+
+@pytest.mark.asyncio
+async def test_week_over_week_drop_surfaces(db):
+    # prior week B(85), this week C(68) → 17-pt drop ≥ 15
+    await _grade(db, "ego", "B", 85.0, "2026-06-15T00:00:00Z")
+    await _grade(db, "ego", "C", 68.0, "2026-06-22T00:00:00Z")
+    pipeline = AsyncMock()
+
+    handled = await check_and_alert_regressions(db, pipeline)
+
+    assert len(handled) == 1
+    assert "dropped" in handled[0]["reason"]


### PR DESCRIPTION
## What

Gives J9's weekly subsystem grades their first **control path**. After the weekly aggregation, a regression triggers (1) a deterministic **BLOCKER alert** to the operator and (2) a **human-gated `j9_regression` ego proposal** to investigate (candidate remedy: an Evo experiment on the affected subsystem).

## Why

J9 measured cognitive quality but acted on nothing. This closes the monitor→surface loop — connecting the monitor to the operator (and, via the proposal, to the existing Crucible/Evo improvement loop). Nothing is automated: the proposal applies nothing; approving it merely acknowledges.

## Regression criteria (conservative on a young baseline)

- Absolute floor: grade **F**.
- Week-over-week: a **≥15-point** score drop.
- Never fires on a cold-start week (grade `None`).
- Idempotent per `(subsystem, period_end)` via a deterministic proposal id — a restart-triggered re-run never double-files or double-alerts.

## Safety — the `j9_regression` proposal can never auto-dispatch

Three layers: (1) in `_NEVER_DISPATCH_ACTION_TYPES` — checked on **both** dispatch paths; (2) mapped to `ActionDomain.NOTIFY_USER` (not the permissive `EXTERNAL_READ` fallthrough); (3) its handler marks it `executed` on approval, so the approved-sweep never sees it.

## Changes

- New `eval/regression_alert.py` (detect + surface), `ego/j9_regression_actions.py` (no-op resolution handler).
- Hook in `runtime/init/learning.py` after `run_weekly_aggregation` (wrapped so a surfacing failure never fails the aggregation job).
- Wiring: `autonomy/classification.py` (domain map), `ego/session.py` (blocklist), `outreach/governance.py` (168h alert dedup), and the handler at all 3 resolution sites (the Telegram path tunnels through `proposals.py`).

## Testing

- 16 new tests (detection thresholds, idempotency, no-pipeline, handler, safety wiring) + 161 existing tests green.
- Safety property verified directly (blocklist gates both dispatch paths).
- E2E against a live-DB snapshot: real grades read, **0 false-fires** (cold-start correctly skipped), idempotent on re-run.