### PR TITLE
feat(learning): reads as a procedure usage signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Changed
 
+- **Procedures you actually use now earn their keep.** How often a learned
+  procedure is recalled ("reads") now counts as a dampened usefulness signal:
+  frequently-recalled procedures rank higher when surfaced, and can be promoted
+  to higher activation tiers (reads alone can reach passive surfacing; the
+  proactive advisory tier still requires a real success). A procedure also now
+  graduates from speculative to validated on its first real success — previously
+  nothing ever cleared that flag.
 - **The dashboard Infrastructure card now labels the ambient-capture bridge as "Voice Bridge"** —
   a clearer, user-facing name. It still only appears when a voice/ambient edge is configured.
 

--- a/docs/architecture/genesis-v3-procedure-activation.md
+++ b/docs/architecture/genesis-v3-procedure-activation.md
@@ -50,6 +50,42 @@ Explicit user teach (procedure_store MCP tool):
        Earns further promotion to L2/L1 organically via record_success.
 ```
 
+### Reads as a usage signal (effective confidence)
+
+Recorded outcomes are sparse — `record_success`/`record_failure` only fire from
+the autonomy executor's task retrospective, never from the dominant
+`procedure_recall` path. So a procedure can be recalled (read) dozens of times
+yet never earn confidence. To stop that, a **read** (a deliberate
+`procedure_recall` that surfaces a procedure, tracked on `invocation_count`) is
+treated as a *dampened* positive signal:
+
+- `effective_confidence(success, failure, invocation_count)` folds reads in as
+  fractional successes: every `READ_CONFIDENCE_DISCOUNT` (=5) reads count as one
+  effective success, with recorded failures as the counterweight.
+- **Stored `confidence` stays real Laplace** (success/failure only). Effective
+  confidence is *derived* and used ONLY for (a) recall ranking and (b) tier
+  promotion — so the j9 metric, quarantine, and demotion stay honest.
+- **Hybrid promotion guard:** reads alone may promote to **L3** (passive
+  surfacing); **L2** (advisory-eligible) requires ≥1 *real* success; **L1**
+  (always-on) is never reachable from reads. Promotion is additive — the target
+  tier is the higher of the real-metric and read-eligible tiers (`_compute_tier`
+  vs `_read_eligible_tier`), still promote-only.
+- **Recall ranking:** `procedure_recall` widens the candidate pool then re-ranks
+  by `effective_confidence` (read-heavy procedures surface first; ties keep
+  relevance order). Isolated to the recall path — `find_relevant`'s global
+  behavior is unchanged (it has 6 callers, incl. autonomy outcome-attribution).
+- **De-speculation:** a draft (`speculative=1`) graduates to validated
+  (`speculative=0`) on its first *real* success with no failures — closing the
+  prior gap where nothing ever cleared the flag. Reads alone do not de-speculate.
+
+The one-time migration `0035_backfill_procedure_invocation_count` seeds
+`invocation_count` from historical `procedure_invoked` events in `eval_events`
+so the signal doesn't start at zero.
+
+> **Limitation:** reads are a *proxy* for usefulness, not proof a procedure
+> worked. The discount, the ≥1-real-success gate for L2, and the FailureDetector
+> are the counterweights. A real recall-path outcome signal remains future work.
+
 Demotion is **evidence-driven only** — never metric drift:
 - 3+ failure-mode hits AND failure_count >= success_count + 3 → tier - 1
 - confidence < 0.3 AND total samples >= 3 → quarantine (excluded everywhere)

--- a/src/genesis/db/crud/procedural.py
+++ b/src/genesis/db/crud/procedural.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 
 import aiosqlite
 
@@ -239,6 +240,22 @@ async def update(db: aiosqlite.Connection, id: str, **fields) -> bool:
     values = list(fields.values()) + [id]
     cursor = await db.execute(
         f"UPDATE procedural_memory SET {set_clause} WHERE id = ?", values
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def record_invocation(db: aiosqlite.Connection, id: str) -> bool:
+    """Count a procedure read: a model recalled it (surfaced into context).
+
+    Atomically bumps ``invocation_count`` and stamps ``last_used``. This is the
+    top-of-funnel usage signal — distinct from ``record_success``/``record_failure``
+    (outcomes). Returns True if the procedure exists.
+    """
+    cursor = await db.execute(
+        "UPDATE procedural_memory "
+        "SET invocation_count = invocation_count + 1, last_used = ? WHERE id = ?",
+        (datetime.now(UTC).isoformat(), id),
     )
     await db.commit()
     return cursor.rowcount > 0

--- a/src/genesis/db/migrations/0035_backfill_procedure_invocation_count.py
+++ b/src/genesis/db/migrations/0035_backfill_procedure_invocation_count.py
@@ -1,0 +1,41 @@
+"""Backfill procedural_memory.invocation_count from procedure_invoked history.
+
+The reads signal (a deliberate procedure_recall) is now tracked on the
+``invocation_count`` column, but the column was dead until it was wired — the
+historical reads live only as ``procedure_invoked`` events in ``eval_events``.
+This one-time migration seeds the column from that history so the read signal
+(used for recall ranking + tier promotion) doesn't start at zero.
+
+Authoritative SET (not increment): at migration time the column is 0 and the
+events are the historical record, so ``count`` is correct. Going forward the
+column and events grow in lockstep (both written in ``procedure_recall``). The
+versioned runner applies this exactly once.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # Fresh installs may not have eval_events yet — nothing to backfill.
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='eval_events'"
+    )
+    if not await cursor.fetchone():
+        return
+
+    await db.execute(
+        """
+        UPDATE procedural_memory
+        SET invocation_count = (
+            SELECT COUNT(*) FROM eval_events e
+            WHERE e.event_type = 'procedure_invoked'
+              AND e.subject_id = procedural_memory.id
+        )
+        WHERE id IN (
+            SELECT DISTINCT subject_id FROM eval_events
+            WHERE event_type = 'procedure_invoked' AND subject_id IS NOT NULL
+        )
+        """
+    )

--- a/src/genesis/db/migrations/0035_backfill_procedure_invocation_count.py
+++ b/src/genesis/db/migrations/0035_backfill_procedure_invocation_count.py
@@ -18,11 +18,17 @@ import aiosqlite
 
 
 async def up(db: aiosqlite.Connection) -> None:
-    # Fresh installs may not have eval_events yet — nothing to backfill.
+    # Both tables must be present. In production `create_all_tables` (which
+    # creates the base `procedural_memory` table) runs before the migration
+    # runner, so this guard passes and the backfill runs. The runner's own unit
+    # tests apply migrations against a bare DB where base tables are absent —
+    # there is simply nothing to backfill, so skip cleanly. (Mirrors 0013.)
     cursor = await db.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='eval_events'"
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        "AND name IN ('eval_events', 'procedural_memory')"
     )
-    if not await cursor.fetchone():
+    tables = {row[0] for row in await cursor.fetchall()}
+    if not {"eval_events", "procedural_memory"} <= tables:
         return
 
     await db.execute(

--- a/src/genesis/learning/procedural/matcher.py
+++ b/src/genesis/learning/procedural/matcher.py
@@ -28,6 +28,7 @@ def _row_to_match(row: dict) -> ProcedureMatch:
         tool_trigger=tool_trigger,
         steps=steps,
         principle=row.get("principle"),
+        invocation_count=row.get("invocation_count", 0) or 0,
     )
 
 

--- a/src/genesis/learning/procedural/operations.py
+++ b/src/genesis/learning/procedural/operations.py
@@ -14,6 +14,26 @@ from genesis.db.crud import procedural
 
 logger = logging.getLogger(__name__)
 
+# Reads-as-signal: a deliberate procedure_recall ("read") is a soft positive
+# signal. Every READ_CONFIDENCE_DISCOUNT reads count as one *effective* success.
+# Recorded failures are the counterweight. This derived value is used ONLY for
+# ranking + tier decisions — the stored `confidence` column stays real Laplace
+# (success/failure only), so the j9 metric, quarantine, and demotion stay honest.
+READ_CONFIDENCE_DISCOUNT = 5
+
+
+def effective_confidence(
+    success_count: int, failure_count: int, invocation_count: int
+) -> float:
+    """Laplace-smoothed confidence that folds reads in as fractional successes.
+
+    ``eff_success = success_count + invocation_count // READ_CONFIDENCE_DISCOUNT``;
+    returns ``(eff_success + 1) / (eff_success + failure_count + 2)``. With zero
+    reads this is identical to the real Laplace confidence.
+    """
+    eff_success = success_count + invocation_count // READ_CONFIDENCE_DISCOUNT
+    return (eff_success + 1) / (eff_success + failure_count + 2)
+
 
 @dataclass
 class StoreResult:

--- a/src/genesis/learning/procedural/promoter.py
+++ b/src/genesis/learning/procedural/promoter.py
@@ -139,25 +139,29 @@ async def promote_and_demote(db: aiosqlite.Connection) -> dict:
             despeculated += 1
             logger.info("De-speculated procedure %s (success=%d)", row["task_type"], row["success_count"])
 
-        # Compute target tier: the higher of real-metric promotion and
-        # read-driven (effective-metric) promotion. Reads can only *raise* the
-        # target; quarantine/demotion below stay on real metrics.
+        # Compute target tier. Failure evidence (`_check_demotion`) takes
+        # precedence over BOTH real-metric and read-driven promotion: a
+        # failing procedure must never be promoted — least of all by soft read
+        # signal. Otherwise the target is the higher of real-metric and
+        # read-driven (effective-metric) promotion (reads can only *raise* it).
         real_target = _compute_tier(row)
-        reads = row.get("invocation_count") or 0
-        eff_success = row["success_count"] + reads // READ_CONFIDENCE_DISCOUNT
-        eff_conf = effective_confidence(row["success_count"], row["failure_count"], reads)
-        read_target = _read_eligible_tier(eff_success, eff_conf, row["success_count"])
-        target_tier = (
-            real_target
-            if _TIER_RANK[real_target] >= _TIER_RANK[read_target]
-            else read_target
-        )
-
-        # Check for demotion
         if _check_demotion(row):
+            target_tier = real_target  # promote-only on real metrics; held for failing rows
             current_rank = _TIER_RANK.get(current_tier, 1)
             if current_rank > 1:
                 target_tier = _RANK_TIER[current_rank - 1]
+        else:
+            reads = row.get("invocation_count") or 0
+            eff_success = row["success_count"] + reads // READ_CONFIDENCE_DISCOUNT
+            eff_conf = effective_confidence(
+                row["success_count"], row["failure_count"], reads
+            )
+            read_target = _read_eligible_tier(eff_success, eff_conf, row["success_count"])
+            target_tier = (
+                real_target
+                if _TIER_RANK[real_target] >= _TIER_RANK[read_target]
+                else read_target
+            )
 
         if target_tier != current_tier:
             target_rank = _TIER_RANK.get(target_tier, 1)

--- a/src/genesis/learning/procedural/promoter.py
+++ b/src/genesis/learning/procedural/promoter.py
@@ -30,12 +30,33 @@ from datetime import UTC, datetime
 import aiosqlite
 
 from genesis.db.crud import procedural
+from genesis.learning.procedural.operations import (
+    READ_CONFIDENCE_DISCOUNT,
+    effective_confidence,
+)
 from genesis.learning.procedural.trigger_cache import regenerate
 
 logger = logging.getLogger(__name__)
 
 _TIER_RANK = {"L1": 4, "L2": 3, "L3": 2, "L4": 1}
 _RANK_TIER = {4: "L1", 3: "L2", 2: "L3", 1: "L4"}
+
+
+def _read_eligible_tier(eff_success: int, eff_conf: float, real_success: int) -> str:
+    """Tier a procedure qualifies for from *effective* (read-inclusive) metrics.
+
+    Hybrid guard (reads are a dampened signal, not proof of success):
+      - L3 (passive surfacing): reads alone may qualify.
+      - L2 (advisory-eligible): requires >= 1 *real* success.
+      - L1 (always-on): never reachable from reads.
+
+    Mirrors `_compute_tier`'s real-metric thresholds, minus the L1 branch.
+    """
+    if eff_success >= 5 and eff_conf >= 0.75 and real_success >= 1:
+        return "L2"
+    if eff_success >= 3 and eff_conf >= 0.65:
+        return "L3"
+    return "L4"
 
 
 def _compute_tier(row: dict) -> str:
@@ -88,12 +109,14 @@ async def promote_and_demote(db: aiosqlite.Connection) -> dict:
     promotions = 0
     demotions = 0
     quarantined = 0
+    despeculated = 0
 
     for row in rows:
         current_tier = row.get("activation_tier", "L4")
         proc_id = row["id"]
 
-        # Quarantine check
+        # Quarantine check — uses REAL stored confidence + real counts (reads
+        # never mask a genuinely-failing procedure).
         if row["confidence"] < 0.3 and row["success_count"] + row["failure_count"] >= 3:
             history = json.loads(row.get("promotion_history") or "[]")
             history.append({
@@ -108,8 +131,27 @@ async def promote_and_demote(db: aiosqlite.Connection) -> dict:
             logger.info("Quarantined procedure %s (conf=%.2f)", row["task_type"], row["confidence"])
             continue
 
-        # Compute target tier
-        target_tier = _compute_tier(row)
+        # De-speculation: a draft graduates to validated once it has >=1 real
+        # success and no failures (reads alone do NOT de-speculate). Closes the
+        # gap where nothing ever cleared speculative=1.
+        if row["speculative"] and row["success_count"] >= 1 and row["failure_count"] == 0:
+            await procedural.update(db, proc_id, speculative=0)
+            despeculated += 1
+            logger.info("De-speculated procedure %s (success=%d)", row["task_type"], row["success_count"])
+
+        # Compute target tier: the higher of real-metric promotion and
+        # read-driven (effective-metric) promotion. Reads can only *raise* the
+        # target; quarantine/demotion below stay on real metrics.
+        real_target = _compute_tier(row)
+        reads = row.get("invocation_count") or 0
+        eff_success = row["success_count"] + reads // READ_CONFIDENCE_DISCOUNT
+        eff_conf = effective_confidence(row["success_count"], row["failure_count"], reads)
+        read_target = _read_eligible_tier(eff_success, eff_conf, row["success_count"])
+        target_tier = (
+            real_target
+            if _TIER_RANK[real_target] >= _TIER_RANK[read_target]
+            else read_target
+        )
 
         # Check for demotion
         if _check_demotion(row):
@@ -149,7 +191,12 @@ async def promote_and_demote(db: aiosqlite.Connection) -> dict:
         except Exception:
             logger.error("Failed to regenerate trigger cache after promotion", exc_info=True)
 
-    result = {"promotions": promotions, "demotions": demotions, "quarantined": quarantined}
+    result = {
+        "promotions": promotions,
+        "demotions": demotions,
+        "quarantined": quarantined,
+        "despeculated": despeculated,
+    }
     if any(v > 0 for v in result.values()):
         logger.info("Promotion results: %s", result)
     return result

--- a/src/genesis/learning/types.py
+++ b/src/genesis/learning/types.py
@@ -124,6 +124,7 @@ class ProcedureMatch:
     tool_trigger: list[str] | None = None
     steps: list[str] | None = None
     principle: str | None = None
+    invocation_count: int = 0
 
 
 @dataclass(frozen=True)

--- a/src/genesis/mcp/memory/procedural.py
+++ b/src/genesis/mcp/memory/procedural.py
@@ -125,13 +125,18 @@ async def procedure_recall(
         if len(results) >= 3:
             break
 
-    # J-9 eval: log procedure invocations for learning effectiveness tracking
+    # Count the read (usage signal) + log the J-9 invocation event. Returning a
+    # procedure means the model recalled it and it is surfaced into context.
     if results:
+        from genesis.db.crud import procedural
         from genesis.eval.j9_hooks import emit_procedure_invoked
         for r in results:
+            pid = r.get("procedure_id", "")
+            if pid:
+                await procedural.record_invocation(memory_mod._db, pid)
             await emit_procedure_invoked(
                 memory_mod._db,
-                procedure_id=r.get("procedure_id", ""),
+                procedure_id=pid,
                 confidence=r.get("confidence", 0.0),
                 matched_tags=tags[:10] if tags else [],
             )

--- a/src/genesis/mcp/memory/procedural.py
+++ b/src/genesis/mcp/memory/procedural.py
@@ -159,8 +159,11 @@ async def procedure_recall(
         from genesis.eval.j9_hooks import emit_procedure_invoked
         for r in results:
             pid = r.get("procedure_id", "")
-            if pid:
-                await procedural.record_invocation(memory_mod._db, pid)
+            if not pid:
+                continue
+            # Keep the read counter and the J-9 event in lockstep — both gated
+            # on a real procedure_id so neither records an orphan.
+            await procedural.record_invocation(memory_mod._db, pid)
             await emit_procedure_invoked(
                 memory_mod._db,
                 procedure_id=pid,

--- a/src/genesis/mcp/memory/procedural.py
+++ b/src/genesis/mcp/memory/procedural.py
@@ -18,6 +18,27 @@ def _memory_mod():
     return memory_mod
 
 
+def _rank_by_effective_confidence(results: list[dict]) -> list[dict]:
+    """Re-rank recall results so deliberately-read procedures surface first.
+
+    Reads count as fractional successes via ``effective_confidence``; a stable
+    sort preserves ``find_relevant``'s relevance order on ties. Isolated to the
+    recall path — ``find_relevant`` itself is unchanged (6 callers, incl.
+    autonomy outcome-attribution).
+    """
+    from genesis.learning.procedural.operations import effective_confidence
+
+    return sorted(
+        results,
+        key=lambda r: effective_confidence(
+            r.get("success_count", 0) or 0,
+            r.get("failure_count", 0) or 0,
+            r.get("invocation_count", 0) or 0,
+        ),
+        reverse=True,
+    )
+
+
 async def _embed_principle_for_hook(principle: str) -> bytes | None:
     """Best-effort: compute principle embedding for the proactive procedure
     hook. Returns None on any failure — the hook simply skips rows without
@@ -110,20 +131,26 @@ async def procedure_recall(
     memory_mod._require_init()
     assert memory_mod._db is not None
 
-    results = []
+    results: list[dict] = []
+    seen: set[str] = set()
 
     if context_tags:
         match = await find_best_match(memory_mod._db, task_description, context_tags)
         if match:
             results.append(_asdict(match))
+            seen.add(match.procedure_id)
 
     tags = context_tags or task_description.lower().replace("-", " ").split()
-    relevant = await find_relevant(memory_mod._db, tags, limit=3)
+    # Widen the candidate pool, then re-rank by reads (effective confidence) and
+    # cap — so a proven-useful procedure can surface, not just get reordered
+    # within an already-relevance-capped top 3.
+    relevant = await find_relevant(memory_mod._db, tags, limit=10)
     for m in relevant:
-        if not any(r.get("procedure_id") == m.procedure_id for r in results):
+        if m.procedure_id not in seen:
             results.append(_asdict(m))
-        if len(results) >= 3:
-            break
+            seen.add(m.procedure_id)
+
+    results = _rank_by_effective_confidence(results)[:3]
 
     # Count the read (usage signal) + log the J-9 invocation event. Returning a
     # procedure means the model recalled it and it is surfaced into context.

--- a/tests/test_db/test_migration_0035_backfill_invocation.py
+++ b/tests/test_db/test_migration_0035_backfill_invocation.py
@@ -1,0 +1,91 @@
+"""Migration 0035 — backfill procedural_memory.invocation_count from history.
+
+The reads signal lives in eval_events (procedure_invoked) for procedures
+recalled before the invocation_count column was wired. This one-time migration
+seeds the column from that history so the read signal doesn't start at zero.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import procedural
+
+M35 = importlib.import_module(
+    "genesis.db.migrations.0035_backfill_procedure_invocation_count"
+)
+
+_PROC = dict(
+    principle="p", steps=["s"], tools_used=[], context_tags=[],
+    created_at="2026-01-01T00:00:00",
+)
+
+
+async def _add_invoked_events(db, subject_id: str, n: int) -> None:
+    for i in range(n):
+        await db.execute(
+            "INSERT INTO eval_events "
+            "(id, timestamp, dimension, event_type, subject_id, metrics_json, created_at) "
+            "VALUES (?, ?, 'procedure', 'procedure_invoked', ?, '{}', ?)",
+            (f"{subject_id}-ev{i}", "2026-01-01T00:00:00", subject_id, "2026-01-01T00:00:00"),
+        )
+    await db.commit()
+
+
+@pytest.fixture
+async def db(tmp_path):
+    from genesis.db.schema import create_all_tables
+
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await create_all_tables(conn)
+        await conn.commit()
+        yield conn
+
+
+async def _ic(db, pid: str) -> int:
+    cur = await db.execute(
+        "SELECT invocation_count FROM procedural_memory WHERE id = ?", (pid,)
+    )
+    return (await cur.fetchone())[0]
+
+
+@pytest.mark.asyncio
+async def test_backfill_sets_count_from_events(db):
+    await procedural.create(db, id="p-read", task_type="a", **_PROC)
+    await procedural.create(db, id="p-many", task_type="b", **_PROC)
+    await procedural.create(db, id="p-none", task_type="c", **_PROC)
+    await _add_invoked_events(db, "p-read", 3)
+    await _add_invoked_events(db, "p-many", 5)
+    # A non-invoked event must not be counted.
+    await db.execute(
+        "INSERT INTO eval_events (id, timestamp, dimension, event_type, subject_id, "
+        "metrics_json, created_at) VALUES "
+        "('o1','2026-01-01T00:00:00','procedure','procedure_outcome','p-read','{}','2026-01-01T00:00:00')"
+    )
+    await db.commit()
+
+    await M35.up(db)
+
+    assert await _ic(db, "p-read") == 3
+    assert await _ic(db, "p-many") == 5
+    assert await _ic(db, "p-none") == 0  # untouched
+
+
+@pytest.mark.asyncio
+async def test_backfill_is_deterministic_on_rerun(db):
+    await procedural.create(db, id="p1", task_type="a", **_PROC)
+    await _add_invoked_events(db, "p1", 4)
+    await M35.up(db)
+    await M35.up(db)  # re-run = SET from events, same result
+    assert await _ic(db, "p1") == 4
+
+
+@pytest.mark.asyncio
+async def test_backfill_ignores_orphan_events(db):
+    # An event whose subject_id matches no procedure must not crash.
+    await _add_invoked_events(db, "ghost", 2)
+    await M35.up(db)  # no row to update; must complete cleanly

--- a/tests/test_db/test_migration_0035_backfill_invocation.py
+++ b/tests/test_db/test_migration_0035_backfill_invocation.py
@@ -89,3 +89,19 @@ async def test_backfill_ignores_orphan_events(db):
     # An event whose subject_id matches no procedure must not crash.
     await _add_invoked_events(db, "ghost", 2)
     await M35.up(db)  # no row to update; must complete cleanly
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_when_base_tables_absent(tmp_path):
+    """The migration runner applies migrations against a bare DB (no base
+    tables). 0035 must skip cleanly rather than fail on a missing table —
+    otherwise it breaks the runner's apply-all sequence for every migration."""
+    async with aiosqlite.connect(str(tmp_path / "bare.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        # Simulate the runner state where 0002 created eval_events but the base
+        # procedural_memory table does not exist yet.
+        await conn.execute(
+            "CREATE TABLE eval_events (id TEXT, event_type TEXT, subject_id TEXT)"
+        )
+        await conn.commit()
+        await M35.up(conn)  # must not raise (no such table: procedural_memory)

--- a/tests/test_db/test_procedural.py
+++ b/tests/test_db/test_procedural.py
@@ -112,3 +112,25 @@ async def test_list_by_task_type_filters_by_person_id(db):
     rows = await procedural.list_by_task_type(db, "deploy", person_id="alice")
     assert len(rows) == 1
     assert rows[0]["id"] == "ppid3"
+
+
+# ── record_invocation: count reads (procedure recalled = surfaced to model) ──
+
+
+async def test_record_invocation_increments_and_stamps(db):
+    await procedural.create(db, id="p_read", **_COMMON)
+    row = await procedural.get_by_id(db, "p_read")
+    assert row["invocation_count"] == 0
+    assert row["last_used"] is None
+
+    assert await procedural.record_invocation(db, "p_read") is True
+    row = await procedural.get_by_id(db, "p_read")
+    assert row["invocation_count"] == 1
+    assert row["last_used"] is not None
+
+    await procedural.record_invocation(db, "p_read")
+    assert (await procedural.get_by_id(db, "p_read"))["invocation_count"] == 2
+
+
+async def test_record_invocation_unknown_id_is_noop(db):
+    assert await procedural.record_invocation(db, "nope") is False

--- a/tests/test_learning/test_effective_confidence.py
+++ b/tests/test_learning/test_effective_confidence.py
@@ -1,0 +1,44 @@
+"""Tests for effective_confidence — reads as a dampened (fractional-success) signal.
+
+A *read* (deliberate procedure_recall) is a soft positive signal. It counts as a
+fractional success via READ_CONFIDENCE_DISCOUNT reads == 1 effective success, with
+recorded failures as the counterweight. Stored `confidence` stays real Laplace;
+this derived value is used ONLY for ranking + tier decisions.
+"""
+
+from __future__ import annotations
+
+from genesis.learning.procedural.operations import (
+    READ_CONFIDENCE_DISCOUNT,
+    effective_confidence,
+)
+
+
+def test_no_reads_equals_plain_laplace():
+    # 0/0 → 1/2; 1 success → 2/3 — identical to the real Laplace formula.
+    assert effective_confidence(0, 0, 0) == 0.5
+    assert abs(effective_confidence(1, 0, 0) - 2 / 3) < 1e-9
+
+
+def test_discount_threshold_no_partial_credit():
+    # Fewer than DISCOUNT reads earns zero effective success (integer floor).
+    assert effective_confidence(0, 0, READ_CONFIDENCE_DISCOUNT - 1) == 0.5
+
+
+def test_reads_add_fractional_success():
+    # DISCOUNT reads == 1 effective success → same as one real success.
+    assert abs(effective_confidence(0, 0, READ_CONFIDENCE_DISCOUNT) - 2 / 3) < 1e-9
+    # 31 reads at discount 5 → 6 effective successes → (6+1)/(6+0+2) = 7/8.
+    assert abs(effective_confidence(0, 0, 31) - 7 / 8) < 1e-9
+
+
+def test_failures_are_the_counterweight():
+    # No reads, 3 failures → (0+1)/(0+3+2) = 0.2.
+    assert abs(effective_confidence(0, 3, 0) - 0.2) < 1e-9
+    # 20 reads (4 eff successes) vs 3 failures → (4+1)/(4+3+2) = 5/9.
+    assert abs(effective_confidence(0, 3, 20) - 5 / 9) < 1e-9
+
+
+def test_real_successes_and_reads_compound():
+    # 2 real + 17 reads (3 eff) → 5 eff successes → (5+1)/(5+0+2) = 6/7.
+    assert abs(effective_confidence(2, 0, 17) - 6 / 7) < 1e-9

--- a/tests/test_learning/test_promoter.py
+++ b/tests/test_learning/test_promoter.py
@@ -10,6 +10,7 @@ from genesis.learning.procedural import trigger_cache
 from genesis.learning.procedural.promoter import (
     _check_demotion,
     _compute_tier,
+    _read_eligible_tier,
     promote_and_demote,
 )
 
@@ -262,3 +263,134 @@ async def test_promote_and_demote_does_not_metric_demote_l1(db):
     )
     row = await cursor.fetchone()
     assert row[0] == "L1"
+
+
+# ─── reads-as-signal: _read_eligible_tier (hybrid, dampened) ──────────────────
+
+
+def test_read_eligible_tier_l3_on_reads_alone():
+    """Effective metrics from reads alone qualify for L3 (passive surfacing)."""
+    # eff_success=3, eff_conf=(3+1)/(3+0+2)=0.8 ≥ 0.65
+    assert _read_eligible_tier(3, 0.8, 0) == "L3"
+
+
+def test_read_eligible_tier_l2_requires_real_success():
+    """L2 (the advisory-eligible tier) needs ≥1 *real* success — reads alone
+    can't reach it."""
+    # eff metrics qualify for L2 but real_success=0 → capped at L3.
+    assert _read_eligible_tier(5, 0.78, 0) == "L3"
+    # same effective metrics, but with one real success → L2.
+    assert _read_eligible_tier(5, 0.78, 1) == "L2"
+
+
+def test_read_eligible_tier_never_l1():
+    """Reads can never buy L1 (always-on), no matter how high the effective
+    metrics, even with a real success."""
+    assert _read_eligible_tier(50, 0.99, 5) == "L2"
+
+
+def test_read_eligible_tier_below_threshold_is_l4():
+    assert _read_eligible_tier(2, 0.6, 0) == "L4"
+
+
+# ─── reads-as-signal: promote_and_demote integration ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reads_promote_speculative_to_l3_but_stay_speculative(db):
+    """A heavily-read draft (no real success) promotes to L3 on effective
+    metrics, but stays speculative (de-spec needs a real success)."""
+    await _insert(
+        db, id="read-draft", task_type="t",
+        success_count=0, failure_count=0, confidence=0.5,
+        speculative=1, activation_tier="L4", invocation_count=15,  # eff_success=3
+    )
+    result = await promote_and_demote(db)
+    assert result["promotions"] == 1
+    cursor = await db.execute(
+        "SELECT activation_tier, speculative FROM procedural_memory WHERE id = ?",
+        ("read-draft",),
+    )
+    row = await cursor.fetchone()
+    assert row[0] == "L3"
+    assert row[1] == 1  # still speculative — reads don't de-speculate
+
+
+@pytest.mark.asyncio
+async def test_reads_without_real_success_do_not_reach_l2(db):
+    """Effective metrics alone (no real success) cannot push past L3."""
+    await _insert(
+        db, id="read-only", task_type="t",
+        success_count=0, failure_count=0, confidence=0.5,
+        speculative=1, activation_tier="L3", invocation_count=25,  # eff_success=5
+    )
+    await promote_and_demote(db)
+    cursor = await db.execute(
+        "SELECT activation_tier FROM procedural_memory WHERE id = ?", ("read-only",),
+    )
+    assert (await cursor.fetchone())[0] == "L3"
+
+
+@pytest.mark.asyncio
+async def test_reads_plus_real_success_promote_to_l2(db):
+    """Reads + ≥1 real success promote to L2."""
+    await _insert(
+        db, id="read-proven", task_type="t",
+        success_count=1, failure_count=0, confidence=2 / 3,
+        speculative=0, activation_tier="L3", invocation_count=20,  # eff_success=5
+    )
+    result = await promote_and_demote(db)
+    assert result["promotions"] == 1
+    cursor = await db.execute(
+        "SELECT activation_tier FROM procedural_memory WHERE id = ?", ("read-proven",),
+    )
+    assert (await cursor.fetchone())[0] == "L2"
+
+
+@pytest.mark.asyncio
+async def test_reads_never_promote_to_l1(db):
+    """No volume of reads lifts a procedure to L1 (always-on)."""
+    await _insert(
+        db, id="read-heavy", task_type="t",
+        success_count=0, failure_count=0, confidence=0.5,
+        speculative=0, activation_tier="L2", invocation_count=200,
+        tool_trigger=json.dumps(["Bash"]),
+    )
+    await promote_and_demote(db)
+    cursor = await db.execute(
+        "SELECT activation_tier FROM procedural_memory WHERE id = ?", ("read-heavy",),
+    )
+    assert (await cursor.fetchone())[0] == "L2"
+
+
+@pytest.mark.asyncio
+async def test_despeculate_on_real_success(db):
+    """A speculative procedure with ≥1 real success and no failures graduates
+    to validated (speculative=0) — closing the de-speculation gap."""
+    await _insert(
+        db, id="grad-1", task_type="t",
+        success_count=1, failure_count=0, confidence=2 / 3,
+        speculative=1, activation_tier="L3",
+    )
+    result = await promote_and_demote(db)
+    assert result["despeculated"] == 1
+    cursor = await db.execute(
+        "SELECT speculative FROM procedural_memory WHERE id = ?", ("grad-1",),
+    )
+    assert (await cursor.fetchone())[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_despeculate_blocked_by_failure(db):
+    """A failure blocks de-speculation even with real successes."""
+    await _insert(
+        db, id="grad-fail", task_type="t",
+        success_count=2, failure_count=1, confidence=0.6,
+        speculative=1, activation_tier="L3",
+    )
+    result = await promote_and_demote(db)
+    assert result["despeculated"] == 0
+    cursor = await db.execute(
+        "SELECT speculative FROM procedural_memory WHERE id = ?", ("grad-fail",),
+    )
+    assert (await cursor.fetchone())[0] == 1

--- a/tests/test_learning/test_promoter.py
+++ b/tests/test_learning/test_promoter.py
@@ -381,6 +381,31 @@ async def test_despeculate_on_real_success(db):
 
 
 @pytest.mark.asyncio
+async def test_reads_do_not_promote_a_failing_procedure(db):
+    """A procedure in a failure state (trips _check_demotion) must NOT be
+    read-promoted, even with enough reads to otherwise qualify. Reads are a
+    soft signal; recorded failures are the hard counterweight.
+
+    Sits in the 0.3–0.5 confidence band so it escapes the quarantine guard and
+    actually reaches the promote/demote block.
+    """
+    await _insert(
+        db, id="failing-read", task_type="t",
+        success_count=1, failure_count=4, confidence=0.333,
+        speculative=0, activation_tier="L4", invocation_count=40,  # eff_success=9
+        failure_modes=json.dumps([
+            {"description": "x", "conditions": "x", "times_hit": 3},
+        ]),
+    )
+    result = await promote_and_demote(db)
+    assert result["promotions"] == 0
+    cursor = await db.execute(
+        "SELECT activation_tier FROM procedural_memory WHERE id = ?", ("failing-read",),
+    )
+    assert (await cursor.fetchone())[0] == "L4"  # reads can't promote a failing proc
+
+
+@pytest.mark.asyncio
 async def test_despeculate_blocked_by_failure(db):
     """A failure blocks de-speculation even with real successes."""
     await _insert(

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -121,6 +121,46 @@ async def test_procedure_store_recall_roundtrip():
             mod._retriever = old_retriever
 
 
+async def test_procedure_recall_counts_reads():
+    """Recalling a procedure (surfacing it to the model) bumps invocation_count
+    — the top-of-funnel usage signal that was previously never recorded."""
+    import aiosqlite
+
+    import genesis.mcp.memory_mcp as mod
+
+    async with aiosqlite.connect(":memory:") as real_db:
+        real_db.row_factory = aiosqlite.Row
+        from genesis.db.schema import create_all_tables
+        await create_all_tables(real_db)
+        await real_db.commit()
+
+        old_store, old_db, old_retriever = mod._store, mod._db, mod._retriever
+        try:
+            mod._store, mod._db, mod._retriever = MagicMock(), real_db, MagicMock()
+            tools = await _get_tools()
+            pid = await tools["procedure_store"].fn(
+                task_type="discourse-forum-registration",
+                principle="Browser is required; the raw API returns fake success.",
+                steps=["navigate", "fill", "submit", "verify"],
+                tools_used=["browser_navigate"],
+                context_tags=["discourse", "forum", "registration", "browser"],
+            )
+
+            async def invocations() -> int:
+                cur = await real_db.execute(
+                    "SELECT invocation_count FROM procedural_memory WHERE id = ?", (pid,))
+                return (await cur.fetchone())[0]
+
+            assert await invocations() == 0
+            await tools["procedure_recall"].fn(
+                task_description="register on discourse forum",
+                context_tags=["discourse", "forum", "registration"],
+            )
+            assert await invocations() >= 1   # read counted
+        finally:
+            mod._store, mod._db, mod._retriever = old_store, old_db, old_retriever
+
+
 # ─── End-to-end knowledge_ingest test ────────────────────────────────────────
 
 

--- a/tests/test_mcp/test_procedure_recall_ranking.py
+++ b/tests/test_mcp/test_procedure_recall_ranking.py
@@ -1,0 +1,54 @@
+"""procedure_recall re-ranks surfaced procedures by reads (effective confidence).
+
+Read-ranking is isolated to the recall path — `find_relevant`'s global behavior
+is unchanged (it has 6 callers incl. autonomy outcome-attribution).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.db.crud import procedural
+from genesis.learning.procedural.matcher import find_relevant
+from genesis.mcp.memory.procedural import _rank_by_effective_confidence
+
+
+def test_rank_orders_read_heavy_first():
+    results = [
+        # eff_conf = 2/3
+        {"procedure_id": "low-read", "success_count": 1, "failure_count": 0,
+         "invocation_count": 0},
+        # 30 reads → 6 eff successes → eff_conf = 7/8
+        {"procedure_id": "high-read", "success_count": 0, "failure_count": 0,
+         "invocation_count": 30},
+    ]
+    ranked = _rank_by_effective_confidence(results)
+    assert [r["procedure_id"] for r in ranked] == ["high-read", "low-read"]
+
+
+def test_rank_preserves_relevance_order_on_ties():
+    # Equal effective confidence → keep find_relevant's input (relevance) order.
+    results = [
+        {"procedure_id": "a", "success_count": 1, "failure_count": 0,
+         "invocation_count": 0},
+        {"procedure_id": "b", "success_count": 1, "failure_count": 0,
+         "invocation_count": 0},
+    ]
+    ranked = _rank_by_effective_confidence(results)
+    assert [r["procedure_id"] for r in ranked] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_find_relevant_carries_invocation_count(db):
+    """ProcedureMatch surfaces invocation_count so recall can rank on it."""
+    await procedural.create(
+        db, id="m1", task_type="t", principle="p", steps=["s"],
+        tools_used=[], context_tags=["alpha"],
+        created_at="2026-01-01T00:00:00",
+        confidence=0.6, speculative=0, activation_tier="L3",
+    )
+    await procedural.record_invocation(db, "m1")
+    matches = await find_relevant(db, ["alpha"], min_confidence=0.3, limit=5)
+    assert matches
+    assert matches[0].procedure_id == "m1"
+    assert matches[0].invocation_count == 1


### PR DESCRIPTION
## Problem

Genesis's procedural memory has a catch-22: `record_success`/`record_failure` are wired **only** into the autonomy executor's task retrospective (`executor/trace.py`), never into the dominant `procedure_recall` path. There are **zero `procedure_outcome` events ever** — so a procedure can be deliberately recalled dozens of times yet never earn confidence, and **nothing ever cleared `speculative=1`**. Procedures freeze at their seed confidence forever.

## What this does

Treats a **read** (a deliberate `procedure_recall` that surfaces a procedure, counted on `invocation_count`) as a *dampened* usefulness signal — the only usage signal that exists on the recall path.

- **`effective_confidence(success, failure, invocation_count)`** — folds reads in as fractional successes (5 reads = 1 effective success), failures as counterweight. **Stored `confidence` stays real Laplace** (success/failure only) — the j9 metric, quarantine, and demotion keep honest values. Effective confidence is *derived*, used only for ranking + tier decisions.
- **Recall ranking** — `procedure_recall` widens its candidate pool then re-ranks by `effective_confidence` (read-heavy procedures surface first; ties keep relevance order). **Isolated to the recall path** — `find_relevant`'s global behaviour is unchanged (it has 6 callers incl. autonomy outcome-attribution; changing it could mis-attribute outcomes).
- **Hybrid tier promotion** (additive) — `target = max(real-metric tier, read-eligible tier)`. Reads alone may reach the passive tier (L3); the advisory tier (L2) requires ≥1 **real** success; the always-on tier (L1) is **never** reachable from reads. Failure evidence (`_check_demotion`) pre-empts all promotion — a failing procedure is never promoted, least of all by soft read signal.
- **De-speculation** — a draft graduates to validated on its first **real** success with no failures (closing the gap where nothing ever cleared the flag). Reads alone don't de-speculate.
- **Backfill migration `0035`** — one-time, idempotent SET of `invocation_count` from historical `procedure_invoked` events so the signal doesn't start at zero.

This is the **incremental core**. A planned **second pass** (Surfacing v2) will retire the blind SessionStart injection in favour of the context-aware paths and rename the confusingly-inverted `L1–L4` tiers to semantic names — deferred until this signal is proven live.

## Verification

- **TDD** throughout; targeted suites green. Full blast-radius sweep (learning + MCP + DB + eval + autonomy): **all green** (the sweep caught a migration-runner regression — 0035 missing a base-table guard — now fixed and regression-tested).
- **Code review** (2 findings, both fixed): failure-evidence now pre-empts read-promotion; `emit_procedure_invoked` shares `record_invocation`'s guard.
- **E2E on a live-DB snapshot** (read-only to prod): backfill + promote yields 3 correct read-driven promotions; `linkedin-post-evaluation` (31 reads, 0 real successes) honestly stays speculative/passive; no tier bought past the guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)