### PR TITLE
feat(learning): gate procedure surfacing by tier (Surfacing v2 PR-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Changed
 
+- **Genesis no longer auto-surfaces unproven draft procedures.** Procedures it
+  has learned but not yet proven are now recall-only — Genesis can look them up
+  on demand, but they're no longer injected into its context automatically on
+  every message. And the session-start procedure list is trimmed to only the
+  most-proven, always-on procedures, instead of a mix of mid-tier ones of
+  uncertain relevance picked before it even knows what the session is about.
+  Net effect: less noise, and the procedures that do surface have earned it.
+
 - **Procedures you actually use now earn their keep.** How often a learned
   procedure is recalled ("reads") now counts as a dampened usefulness signal:
   frequently-recalled procedures rank higher when surfaced, and can be promoted

--- a/docs/architecture/genesis-v3-procedure-activation.md
+++ b/docs/architecture/genesis-v3-procedure-activation.md
@@ -18,7 +18,7 @@ Reliability decreases as scope increases. Layers reinforce each other.
 - `scripts/procedure_advisor.py` — fires on every CC tool call
 - Reads YAML trigger cache (`config/procedure_triggers.yaml`)
 - Outputs JSON with `additionalContext` for matching procedures
-- Only L1-tier procedures with tool triggers
+- Only L1/L2-tier procedures with tool triggers (trigger cache built from both)
 - ~10ms overhead per non-matching call
 
 ### Layer 2: Skill-Embedded Procedures (active when skill invoked)
@@ -27,13 +27,34 @@ Reliability decreases as scope increases. Layers reinforce each other.
 - Auto-applied as MINOR changes at L2+ autonomy
 
 ### Layer 3: SessionStart Injection (active per session)
-- `scripts/genesis_session_context.py` section 2.5
-- Injects top-5 L3+ procedures, 200-word budget
+- `scripts/genesis_session_context.py` → `session_inject.load_active_procedures`
+- Injects CORE-tier (L1) procedures only, 200-word budget. **v2** narrowed this
+  from L3+: blind session-start injection runs before the session topic is
+  known, so it carries only the most-proven, topic-independent procedures.
 - Positioned after cognitive state, before MCP tools hint
 
 ### Layer 4: CLAUDE.md / STEERING.md Rule (advisory)
 - "Check procedures before multi-step tasks"
 - Weakest layer but broadest scope
+
+### Surfacing by tier (v2 re-gating)
+
+Beyond the activation layers, the **proactive memory hook**
+(`scripts/proactive_memory_hook.py` → `_search_procedures`) surfaces the single
+best embedding match on each user message. v2 gates surfacing so each tier is an
+*additive* channel — a higher tier gets everything the lower tiers do, plus one
+more surface:
+
+| Tier | recall (MCP) | proactive hook | tool advisor | session inject |
+|------|:---:|:---:|:---:|:---:|
+| L4 (DORMANT)  | ✓ |   |   |   |
+| L3 (LIBRARY)  | ✓ | ✓ |   |   |
+| L2 (ADVISORY) | ✓ | ✓ | ✓ |   |
+| L1 (CORE)     | ✓ | ✓ | ✓ | ✓ |
+
+So unproven L4 drafts are **recall-only** (never auto-injected), and only the
+proven L1 set is injected blindly at session start. (The L1–L4 labels are
+slated to become CORE/ADVISORY/LIBRARY/DORMANT in a follow-up rename.)
 
 ## Procedure Lifecycle
 

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -468,6 +468,9 @@ def _search_procedures(
     """Return (procedure_id, task_type, principle_snippet) if a procedure's
     principle embedding clears the cosine threshold, else None.
 
+    Only LIBRARY+ tiers (L1/L2/L3) are eligible for proactive surfacing; the
+    DORMANT tier (L4 — unproven drafts) is recall-only and never auto-injected.
+
     Best-effort: catches every failure mode and returns None so the parent
     hook (memory recall) is never blocked by this addition.
     """
@@ -485,6 +488,9 @@ def _search_procedures(
                 "FROM procedural_memory "
                 "WHERE deprecated = 0 AND quarantined = 0 "
                 "AND principle_embedding IS NOT NULL "
+                # v2: gate proactive surfacing to LIBRARY+ (L1/L2/L3) — DORMANT
+                # (L4) drafts are recall-only, never proactively auto-injected.
+                "AND activation_tier IN ('L1', 'L2', 'L3') "
                 "ORDER BY confidence DESC LIMIT 100"
             ).fetchall()
         finally:

--- a/src/genesis/learning/procedural/session_inject.py
+++ b/src/genesis/learning/procedural/session_inject.py
@@ -1,7 +1,12 @@
-"""SessionStart procedure injection — load relevant procedures for session context.
+"""SessionStart procedure injection — inject CORE-tier procedures.
 
-Queries the procedure store for L3+ tier procedures relevant to the current
-session context. Renders as compact markdown within a 200-word budget.
+Queries the procedure store for CORE-tier (L1) procedures — the most-proven,
+always-on set. Surfacing v2 narrowed this from L1/L2/L3 to CORE-only: blind
+session-start injection runs before the session topic is known, so it should
+carry only procedures proven enough to apply regardless of topic. Lower tiers
+surface contextually instead (the proactive hook on the first message, the
+tool advisor on tool use, and explicit recall). Renders as compact markdown
+within a 200-word budget.
 
 Called by genesis_session_context.py during the SessionStart hook.
 """
@@ -27,10 +32,10 @@ _MAX_WORDS = 200
 
 
 async def load_active_procedures(db_path: str | Path) -> str | None:
-    """Load relevant procedures for session context injection.
+    """Load CORE-tier procedures for session context injection.
 
-    Returns formatted markdown string, or None if no procedures found.
-    Budget: 200 words max, top 5 procedures.
+    Returns formatted markdown string, or None if no CORE procedures found.
+    Budget: 200 words max.
     """
     from genesis.db.connection import BUSY_TIMEOUT_MS
 
@@ -43,11 +48,14 @@ async def load_active_procedures(db_path: str | Path) -> str | None:
         return None
 
     try:
-        # Get L3+ procedures, ordered by confidence
+        # CORE-tier (L1) only — the always-on, most-proven set. v2 narrowed
+        # blind session-start injection from L1/L2/L3 to CORE so we don't
+        # inject mid-tier procedures of uncertain relevance before the session
+        # topic is known. Lower tiers surface contextually elsewhere.
         rows = await db.execute(
             """SELECT task_type, principle, steps, activation_tier, confidence
                FROM procedural_memory
-               WHERE activation_tier IN ('L1', 'L2', 'L3')
+               WHERE activation_tier = 'L1'
                  AND deprecated = 0 AND quarantined = 0
                ORDER BY confidence DESC
                LIMIT ?""",

--- a/src/genesis/mcp/memory/procedural.py
+++ b/src/genesis/mcp/memory/procedural.py
@@ -74,10 +74,12 @@ async def procedure_store(
     An MCP `procedure_store` call represents an *explicit teach* — the caller
     is asserting the procedure works. We seed it as already-confirmed
     (speculative=0) with one Laplace-equivalent success (success_count=1,
-    confidence=2/3), and place it at L3 so it is immediately recallable AND
-    eligible for SessionStart injection. Subsequent organic
-    successes/failures via `record_success`/`record_failure` continue to
-    update the row via Laplace smoothing.
+    confidence=2/3), and place it at L3 (LIBRARY) so it is immediately
+    recallable and eligible for proactive-hook surfacing. (Blind SessionStart
+    injection is CORE/L1-only as of Surfacing v2, so an explicit teach reaches
+    a session via the proactive hook on the first prompt, not at session start.)
+    Subsequent organic successes/failures via `record_success`/`record_failure`
+    continue to update the row via Laplace smoothing.
 
     Computes a principle embedding for the proactive procedure hook. If the
     embedding stack is unavailable, the procedure stores without it and the

--- a/tests/test_learning/test_proactive_hook_subprocess.py
+++ b/tests/test_learning/test_proactive_hook_subprocess.py
@@ -83,6 +83,7 @@ def seeded_db(tmp_path: Path):
             confidence REAL DEFAULT 0.9,
             deprecated INTEGER DEFAULT 0,
             quarantined INTEGER DEFAULT 0,
+            activation_tier TEXT DEFAULT 'L4',
             created_at TEXT DEFAULT (datetime('now'))
         )
     """)
@@ -93,9 +94,13 @@ def seeded_db(tmp_path: Path):
     assert vector is not None, "Embedding failed during test setup"
 
     proc_id = str(uuid.uuid4())
+    # activation_tier must be LIBRARY+ (L1/L2/L3): Surfacing v2 gates the
+    # proactive hook to those tiers, so a default-'L4' (DORMANT) procedure
+    # would be recall-only and never surfaced here. L3 is the eligibility floor.
     conn.execute(
-        "INSERT INTO procedural_memory (id, task_type, principle, principle_embedding, confidence) "
-        "VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO procedural_memory "
+        "(id, task_type, principle, principle_embedding, confidence, activation_tier) "
+        "VALUES (?, ?, ?, ?, ?, 'L3')",
         (proc_id, _TASK_TYPE, _PROCEDURE_PRINCIPLE, pack_embedding(vector), 0.92),
     )
     conn.commit()

--- a/tests/test_learning/test_proactive_procedure_tier.py
+++ b/tests/test_learning/test_proactive_procedure_tier.py
@@ -1,0 +1,102 @@
+"""Tests for proactive-hook procedure tier gating (Surfacing v2 PR-A).
+
+The UserPromptSubmit hook's `_search_procedures` previously surfaced the
+best cosine match across ALL tiers — including the large pool of unproven
+DORMANT (L4) drafts. v2 gates proactive surfacing to LIBRARY+ (L1/L2/L3),
+making DORMANT drafts recall-only (never auto-injected).
+
+`_search_procedures(db_path, prompt_vector)` takes the vector directly, so
+these are fast unit tests with seeded embeddings — no embedding backend.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from genesis.db.schema import create_all_tables
+from genesis.learning.procedural.embedding import pack_embedding
+
+# Load the hook script as a module (scripts/ is not a package). Pop the
+# CC-session guard first so the module's top-level `sys.exit(0)` never fires.
+_HOOK_PATH = Path(__file__).resolve().parent.parent.parent / "scripts" / "proactive_memory_hook.py"
+os.environ.pop("GENESIS_CC_SESSION", None)
+_spec = importlib.util.spec_from_file_location("proactive_memory_hook", _HOOK_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["proactive_memory_hook"] = _mod
+_spec.loader.exec_module(_mod)
+
+_search_procedures = _mod._search_procedures
+
+
+def _vec(*head: float) -> list[float]:
+    """A 1024-dim embedding: leading components then zero-pad (pack_embedding
+    requires EMBEDDING_DIM=1024). Cosine is determined by the head values."""
+    return list(head) + [0.0] * (1024 - len(head))
+
+
+_COLS = (
+    "id, task_type, principle, steps, tools_used, context_tags, "
+    "confidence, created_at, activation_tier, principle_embedding"
+)
+
+
+async def _seed(db_path, rows: list[dict]) -> None:
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await create_all_tables(conn)
+        for r in rows:
+            await conn.execute(
+                f"INSERT INTO procedural_memory ({_COLS}) "
+                "VALUES (?, ?, ?, '[]', '[]', '[]', ?, ?, ?, ?)",
+                (
+                    r["id"], r["task_type"], r["principle"], r["confidence"],
+                    "2026-01-01T00:00:00", r["activation_tier"],
+                    pack_embedding(r["embedding"]),
+                ),
+            )
+        await conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_dormant_excluded_even_at_best_cosine(tmp_path):
+    """A DORMANT (L4) row that is the BEST cosine match is still excluded;
+    the lower-scoring LIBRARY (L3) row is surfaced instead."""
+    db = tmp_path / "t.db"
+    await _seed(db, [
+        {"id": "d", "task_type": "dorm", "principle": "dormant", "confidence": 0.9,
+         "activation_tier": "L4", "embedding": _vec(1.0)},
+        {"id": "l", "task_type": "lib", "principle": "library", "confidence": 0.5,
+         "activation_tier": "L3", "embedding": _vec(0.8, 0.6)},
+    ])
+    result = _search_procedures(db, _vec(1.0))
+    assert result is not None
+    _proc_id, task_type, _principle = result
+    assert task_type == "lib"
+
+
+@pytest.mark.asyncio
+async def test_only_dormant_returns_none(tmp_path):
+    """When the only match is DORMANT, nothing is proactively surfaced."""
+    db = tmp_path / "t.db"
+    await _seed(db, [
+        {"id": "d", "task_type": "dorm", "principle": "p", "confidence": 0.9,
+         "activation_tier": "L4", "embedding": _vec(1.0)},
+    ])
+    assert _search_procedures(db, _vec(1.0)) is None
+
+
+@pytest.mark.asyncio
+async def test_library_tier_still_surfaced(tmp_path):
+    """Regression: LIBRARY+ tiers are NOT over-filtered — a clean match still surfaces."""
+    db = tmp_path / "t.db"
+    await _seed(db, [
+        {"id": "l", "task_type": "lib", "principle": "p", "confidence": 0.5,
+         "activation_tier": "L3", "embedding": _vec(1.0)},
+    ])
+    result = _search_procedures(db, _vec(1.0))
+    assert result is not None and result[1] == "lib"

--- a/tests/test_learning/test_session_inject.py
+++ b/tests/test_learning/test_session_inject.py
@@ -1,0 +1,77 @@
+"""Tests for SessionStart procedure injection tier gating (Surfacing v2 PR-A).
+
+`load_active_procedures` blindly injects procedures at session start, before
+the session topic is known. v2 narrows this to the CORE tier (L1) only — the
+most-proven always-on procedures — so session start stops injecting up to ~5
+mid-tier procedures of uncertain relevance.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.schema import create_all_tables
+from genesis.learning.procedural.session_inject import load_active_procedures
+
+_COLS = (
+    "id, task_type, principle, steps, tools_used, context_tags, "
+    "confidence, created_at, activation_tier, deprecated, quarantined"
+)
+
+
+async def _seed(db_path, rows: list[dict]) -> None:
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await create_all_tables(conn)
+        for r in rows:
+            await conn.execute(
+                f"INSERT INTO procedural_memory ({_COLS}) "
+                "VALUES (?, ?, ?, '[]', '[]', '[]', ?, ?, ?, ?, ?)",
+                (
+                    r["id"], r["task_type"], r["principle"],
+                    r.get("confidence", 0.8), "2026-01-01T00:00:00",
+                    r["activation_tier"], r.get("deprecated", 0),
+                    r.get("quarantined", 0),
+                ),
+            )
+        await conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_only_core_tier_injected(tmp_path):
+    """Only L1 (CORE) procedures are injected; L2/L3/L4 are excluded."""
+    db = tmp_path / "t.db"
+    await _seed(db, [
+        {"id": "c", "task_type": "core_proc", "principle": "core", "activation_tier": "L1"},
+        {"id": "a", "task_type": "adv_proc", "principle": "adv", "activation_tier": "L2"},
+        {"id": "l", "task_type": "lib_proc", "principle": "lib", "activation_tier": "L3"},
+        {"id": "d", "task_type": "dorm_proc", "principle": "dorm", "activation_tier": "L4"},
+    ])
+    out = await load_active_procedures(db)
+    assert out is not None
+    assert "core_proc" in out
+    assert "adv_proc" not in out
+    assert "lib_proc" not in out
+    assert "dorm_proc" not in out
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_no_core(tmp_path):
+    """With only mid/low-tier procedures, nothing is injected at session start."""
+    db = tmp_path / "t.db"
+    await _seed(db, [
+        {"id": "a", "task_type": "adv_proc", "principle": "p", "activation_tier": "L2"},
+        {"id": "l", "task_type": "lib_proc", "principle": "p", "activation_tier": "L3"},
+    ])
+    assert await load_active_procedures(db) is None
+
+
+@pytest.mark.asyncio
+async def test_excludes_deprecated_and_quarantined_core(tmp_path):
+    """A deprecated or quarantined CORE procedure is never injected."""
+    db = tmp_path / "t.db"
+    await _seed(db, [
+        {"id": "dep", "task_type": "dep_core", "principle": "p", "activation_tier": "L1", "deprecated": 1},
+        {"id": "q", "task_type": "q_core", "principle": "p", "activation_tier": "L1", "quarantined": 1},
+    ])
+    assert await load_active_procedures(db) is None


### PR DESCRIPTION
## What

Tightens two of the four procedure-surfacing paths so unproven *draft*
procedures stop being auto-injected into Claude Code context.

- **`session_inject`** — blind SessionStart injection narrowed from
  `L1/L2/L3` → **CORE (L1) only** (the most-proven, topic-independent
  procedures). Session start runs before the session topic is known, so it
  should carry only procedures that apply regardless of topic.
- **`proactive_memory_hook._search_procedures`** — gated to **LIBRARY+
  (L1/L2/L3)**; **DORMANT (L4)** drafts are now **recall-only**, never
  proactively surfaced.

Unchanged by design: `procedure_advisor` (already L1/L2) and `procedure_recall`
MCP (all tiers — recall-only is correct for DORMANT).

> Tier ranks are inverted: `L1` = top/most-proven, `L4` = unproven draft.
> The semantic rename `L1–L4 → CORE/ADVISORY/LIBRARY/DORMANT` is a separate
> follow-on PR (PR-B).

This makes surfacing **additive by tier**:

| Tier | recall | proactive hook | tool advisor | session inject |
|------|:---:|:---:|:---:|:---:|
| L4 (DORMANT)  | ✓ |   |   |   |
| L3 (LIBRARY)  | ✓ | ✓ |   |   |
| L2 (ADVISORY) | ✓ | ✓ | ✓ |   |
| L1 (CORE)     | ✓ | ✓ | ✓ | ✓ |

## Why

The proactive hook was tier-agnostic, so any of the ~344 unproven L4 drafts
could be auto-surfaced on a cosine match, and session start blindly injected up
to several mid-tier procedures of uncertain relevance before the topic was even
known. Net effect of this change: less noise, and the procedures that do surface
have earned it.

## Testing

- New unit tests: `test_session_inject.py` (CORE-only gate; none-when-no-core;
  deprecated/quarantined excluded) and `test_proactive_procedure_tier.py`
  (DORMANT excluded even at best cosine; only-DORMANT → None; LIBRARY+ still
  surfaces).
- Updated the proactive subprocess fixture — its minimal schema lacked an
  `activation_tier` column and seeded a default-L4 proc, which the new gate
  (correctly) excluded; now seeds L3.
- Broad subsystem sweep (`test_learning`, `test_hooks`, `test_scripts`,
  procedure MCP): **1123 passed, 3 skipped**.
- E2E vs the live DB: session-inject returns the single real CORE procedure;
  proactive candidate pool drops **408 → 64** (the 344 DORMANT drafts excluded).

## Docs

Architecture doc "surfacing by tier" table + Layer 3 update (and a fix to a
pre-existing Layer 1 inaccuracy: the tool advisor is built from L1+L2, not L1);
CHANGELOG entry; fixed a now-stale `procedure_store` docstring (newly-taught L3
procedures reach a session via the proactive hook, not blind session-start
injection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
