### PR TITLE
feat(learning): scope behavioral directives out of the procedure store (dedup PR-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   is fully reversible (one click rolls it back). Nothing is ever applied automatically —
   Genesis recommends, you decide.
 
+- **Genesis stops cluttering its procedure store with general working-style rules.** When it
+  learns a "procedure" from a work session, it now tells a reusable *task procedure* (how a
+  specific tool or system works) apart from a *behavioral directive* (a general habit like
+  "double-check before acting" — which belongs in its standing instructions, not the procedure
+  store). Directives are no longer stored, removing the most common source of near-duplicate
+  procedures. The check errs toward keeping, so genuine procedures are never dropped.
+
 ### Changed
 
 - **Genesis no longer auto-surfaces unproven draft procedures.** Procedures it

--- a/docs/architecture/genesis-v3-procedure-activation.md
+++ b/docs/architecture/genesis-v3-procedure-activation.md
@@ -134,6 +134,12 @@ promoter runs.
    organic successes before promotion. **Capped at 3 new speculative
    procedures per session** (`max_procedures_per_session`, shared across the
    extraction and struggle streams) so a single session cannot flood the store.
+   **Scoping gate:** before storage, an LLM classifies each extracted procedure as a
+   reusable *task procedure* (how a specific external system works) vs a general
+   *behavioral directive* (working-style rules — confidence, due diligence, planning
+   cadence — that belong in CLAUDE.md). Directives are not stored, removing the dominant
+   near-duplicate source. The gate **fails open** (keeps) on any classifier error, so a
+   real procedure is never suppressed (`scoping.py`).
 2. **MCP tool** — `procedure_store` for explicit user teaching. Treated
    as one Laplace-equivalent confirmed success — seeds at L3 with
    speculative=0, success_count=1, confidence=2/3. The caller asserting
@@ -150,6 +156,7 @@ promoter runs.
 | File | Purpose |
 |------|---------|
 | `src/genesis/learning/procedural/extractor.py` | LLM procedure extraction |
+| `src/genesis/learning/procedural/scoping.py` | Scoping gate: keep behavioral directives out of the store |
 | `src/genesis/learning/procedural/trigger_cache.py` | YAML cache generation |
 | `src/genesis/learning/procedural/session_inject.py` | SessionStart injection |
 | `src/genesis/learning/procedural/promoter.py` | Tier promotion/demotion |

--- a/src/genesis/learning/procedural/extractor.py
+++ b/src/genesis/learning/procedural/extractor.py
@@ -250,6 +250,20 @@ async def extract_procedure(
         logger.warning("Procedure extraction: missing required fields in %s", list(data.keys()))
         return None
 
+    # Scoping gate: behavioral DIRECTIVES (general working-style rules) belong in
+    # CLAUDE.md, not the procedure store, and are the dominant near-duplicate source.
+    # Fails open to "keep" on any classifier error — never suppress a real procedure.
+    from genesis.learning.procedural.scoping import is_behavioral_directive
+
+    if await is_behavioral_directive(
+        router, task_type=data["task_type"], principle=data["principle"], steps=data["steps"],
+    ):
+        logger.info(
+            "Extraction: skipping behavioral directive %s (belongs in CLAUDE.md)",
+            data["task_type"],
+        )
+        return None
+
     # Skip if an explicit-teach procedure already covers this task_type
     try:
         from genesis.db.crud.procedural import find_by_task_type

--- a/src/genesis/learning/procedural/judge.py
+++ b/src/genesis/learning/procedural/judge.py
@@ -134,16 +134,18 @@ def _get_embedder():
 async def _store_judged_procedure(
     db: aiosqlite.Connection,
     data: dict,
+    router: object,
     *,
     source_type: str,
     source_session_id: str | None = None,
 ) -> str | None:
-    """Run novelty check, then store via store_procedure_checked.
+    """Run the scoping + novelty checks, then store via store_procedure_checked.
 
-    Returns procedure ID on success, None on skip/duplicate.
+    Returns procedure ID on success, None on skip/duplicate/directive.
     """
     from genesis.learning.procedural.extractor import _principle_is_novel
     from genesis.learning.procedural.operations import store_procedure_checked
+    from genesis.learning.procedural.scoping import is_behavioral_directive
 
     task_type = data["task_type"]
     principle = data["principle"]
@@ -160,6 +162,15 @@ async def _store_judged_procedure(
         tools_used = [tools_used]
     if isinstance(context_tags, str):
         context_tags = [context_tags]
+
+    # Scoping gate: behavioral DIRECTIVES (general working-style rules — confidence,
+    # due diligence, planning cadence) belong in CLAUDE.md, not the procedure store,
+    # and are the dominant near-duplicate source. Fails open to "keep" on any
+    # classifier error — never suppress a real procedure.
+    if await is_behavioral_directive(
+        router, task_type=task_type, principle=principle, steps=steps,
+    ):
+        return None
 
     # Cosine novelty check
     embedder = _get_embedder()
@@ -271,7 +282,7 @@ async def judge_struggle_procedure(
         return None
 
     return await _store_judged_procedure(
-        db, data,
+        db, data, router,
         source_type="struggle_extraction",
         source_session_id=source_session_id,
     )
@@ -315,7 +326,7 @@ async def judge_extraction_candidate(
         return None
 
     return await _store_judged_procedure(
-        db, data,
+        db, data, router,
         source_type="extraction_pipeline",
         source_session_id=source_session_id,
     )

--- a/src/genesis/learning/procedural/scoping.py
+++ b/src/genesis/learning/procedural/scoping.py
@@ -97,47 +97,56 @@ async def is_behavioral_directive(
     """Return True iff this extracted procedure is really a behavioral directive
     (and should be kept OUT of the procedure store).
 
-    Fails OPEN (returns False = keep) on any error, unsuccessful call, or
+    Fails OPEN (returns False = keep) on ANY error, unsuccessful call, or
     unparseable / unknown classification — never suppress a real procedure on a
-    flaky classifier.
+    flaky classifier. The whole body is wrapped so that no exception can reach
+    the caller (where it would be treated as a failed extraction and drop the
+    procedure — i.e. fail CLOSED, the opposite of what we want).
     """
-    prompt = _CLASSIFIER_PROMPT.format(
-        task_type=task_type,
-        principle=(principle or "")[:600],
-        steps=json.dumps(steps or [])[:800],
-    )
     try:
-        result = await router.route_call(
-            call_site_id=_CALL_SITE,
-            messages=[{"role": "user", "content": prompt}],
+        prompt = _CLASSIFIER_PROMPT.format(
+            task_type=task_type,
+            principle=(principle or "")[:600],
+            steps=json.dumps(steps or [])[:800],
         )
+        try:
+            result = await router.route_call(
+                call_site_id=_CALL_SITE,
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except Exception:
+            logger.warning(
+                "procedure scoping: classifier call failed for %s; keeping",
+                task_type, exc_info=True,
+            )
+            return False
+
+        if not getattr(result, "success", False):
+            logger.warning(
+                "procedure scoping: classifier unsuccessful for %s (%s); keeping",
+                task_type, getattr(result, "error", None),
+            )
+            return False
+
+        ptype = _parse_procedure_type(getattr(result, "content", None))
+        if ptype is None:
+            logger.warning(
+                "procedure scoping: unparseable classification for %s; keeping",
+                task_type,
+            )
+            return False
+
+        is_directive = ptype == PROCEDURE_TYPE_DIRECTIVE
+        if is_directive:
+            logger.info(
+                "procedure scoping: %s classified as behavioral_directive "
+                "(belongs in CLAUDE.md) — not stored",
+                task_type,
+            )
+        return is_directive
     except Exception:
         logger.warning(
-            "procedure scoping: classifier call failed for %s; keeping",
-            task_type, exc_info=True,
+            "procedure scoping: unexpected error for %s; keeping", task_type,
+            exc_info=True,
         )
         return False
-
-    if not getattr(result, "success", False):
-        logger.warning(
-            "procedure scoping: classifier unsuccessful for %s (%s); keeping",
-            task_type, getattr(result, "error", None),
-        )
-        return False
-
-    ptype = _parse_procedure_type(getattr(result, "content", None))
-    if ptype is None:
-        logger.warning(
-            "procedure scoping: unparseable classification for %s; keeping",
-            task_type,
-        )
-        return False
-
-    is_directive = ptype == PROCEDURE_TYPE_DIRECTIVE
-    if is_directive:
-        logger.info(
-            "procedure scoping: %s classified as behavioral_directive "
-            "(belongs in CLAUDE.md) — not stored",
-            task_type,
-        )
-    return is_directive

--- a/src/genesis/learning/procedural/scoping.py
+++ b/src/genesis/learning/procedural/scoping.py
@@ -1,0 +1,143 @@
+"""Procedure scoping gate — keep behavioral DIRECTIVES out of the procedure store.
+
+The procedure store is for reusable TASK procedures: how a *specific external
+technical system* works (IMAP consumers, Docker layer caching, MCP wiring, an
+OAuth flow…). Behavioral DIRECTIVES — how the agent should work *in general*
+(state confidence, do due diligence, investigate before planning, when to ask
+the user) — belong in the standing instructions (CLAUDE.md), NOT here. The
+agent re-derives the same directive from almost every session, so directives are
+the dominant source of near-duplicate procedures (e.g. ~40 paraphrases of
+"do honest confidence + due diligence before planning").
+
+This module classifies an already-extracted procedure and reports whether it is
+really a behavioral directive. The classifier is one router LLM call using the
+same call site as extraction (``38_procedure_extraction``).
+
+**Safety contract (validated 2026-06-24 on a 40-item hand-labeled, held-out
+sample — 100% directive recall / 0% procedure false-positive):** the classifier
+ERRS TOWARD ``task_procedure``. A directive slipping through is harmless (a low
+-value procedure, no worse than today). Suppressing a real procedure is NOT — it
+loses institutional memory. Therefore every failure mode here (call error,
+unsuccessful result, unparseable output, unknown label) FAILS OPEN to "keep".
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Reuse the extraction call site so dedup-classifier cost is attributed with the
+# rest of the procedure-extraction spend (no new routing config / test churn).
+_CALL_SITE = "38_procedure_extraction"
+
+PROCEDURE_TYPE_TASK = "task_procedure"
+PROCEDURE_TYPE_DIRECTIVE = "behavioral_directive"
+
+_JSON_BLOCK_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
+
+# The validated v3 discriminator. Judge by WHAT THE LESSON IS ABOUT (the agent's
+# general working process vs a specific external technical system), not by how
+# the principle is phrased, and err toward task_procedure when unsure.
+_CLASSIFIER_PROMPT = """You are reviewing a "procedure" an AI coding agent extracted from its own work session, deciding whether it belongs in the agent's PROCEDURE STORE or is really a standing behavioral rule.
+
+Decide by WHAT THE LESSON IS ABOUT, not by how the principle is phrased ("always/never/before" wording is NOT decisive):
+
+"behavioral_directive" — a lesson about the agent's OWN general working process that applies to ANY task regardless of the technology involved: stating confidence levels, doing due diligence, investigating before planning, verifying assumptions, when to use plan mode / ExitPlanMode / AskUserQuestion, when to ask the user, planning and communication cadence. These describe a universal working HABIT and belong in the agent's standing instructions (CLAUDE.md) — EVEN WHEN they mention meta-tools like ExitPlanMode or AskUserQuestion, because those are incidental to the habit, not its subject.
+
+"task_procedure" — a lesson about operating a SPECIFIC external technical system, tool, library, service, or codebase mechanic: e.g. IMAP inbox consumers, MCP server wiring, Docker layer caching, ripgrep flags, PYTHONPATH, a database, an OAuth flow, a video/transcript API, a specific file or component. Its steps are concrete actions on that system, reusable for that KIND of technical task.
+
+Decisive test: strip away any "always/before/never" framing and ask — is the core lesson about HOW THE AGENT SHOULD WORK IN GENERAL (confidence, diligence, planning, asking) or about HOW A SPECIFIC TECHNICAL SYSTEM WORKS? The former is behavioral_directive; the latter is task_procedure. When genuinely unsure, choose task_procedure (NEVER suppress a real procedure).
+
+Procedure under review:
+  task_type: {task_type}
+  principle: {principle}
+  steps: {steps}
+
+Respond with ONLY this JSON in backticks:
+```json
+{{"procedure_type": "task_procedure" or "behavioral_directive", "reason": "<one short sentence>"}}
+```"""
+
+
+def _parse_procedure_type(text: str | None) -> str | None:
+    """Extract ``procedure_type`` from the classifier response. Returns None on
+    any parse failure (caller fails open to keep)."""
+    if not text:
+        return None
+    match = _JSON_BLOCK_RE.search(text)
+    raw = match.group(1) if match else text
+    ptype: str | None = None
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            ptype = data.get("procedure_type")
+    except (json.JSONDecodeError, TypeError):
+        # Lenient fallback: the label may appear in prose.
+        low = text.lower()
+        if PROCEDURE_TYPE_DIRECTIVE in low and PROCEDURE_TYPE_TASK not in low:
+            ptype = PROCEDURE_TYPE_DIRECTIVE
+        elif PROCEDURE_TYPE_TASK in low:
+            ptype = PROCEDURE_TYPE_TASK
+    if ptype not in (PROCEDURE_TYPE_TASK, PROCEDURE_TYPE_DIRECTIVE):
+        return None
+    return ptype
+
+
+async def is_behavioral_directive(
+    router: Any,
+    *,
+    task_type: str,
+    principle: str,
+    steps: list | None,
+) -> bool:
+    """Return True iff this extracted procedure is really a behavioral directive
+    (and should be kept OUT of the procedure store).
+
+    Fails OPEN (returns False = keep) on any error, unsuccessful call, or
+    unparseable / unknown classification — never suppress a real procedure on a
+    flaky classifier.
+    """
+    prompt = _CLASSIFIER_PROMPT.format(
+        task_type=task_type,
+        principle=(principle or "")[:600],
+        steps=json.dumps(steps or [])[:800],
+    )
+    try:
+        result = await router.route_call(
+            call_site_id=_CALL_SITE,
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except Exception:
+        logger.warning(
+            "procedure scoping: classifier call failed for %s; keeping",
+            task_type, exc_info=True,
+        )
+        return False
+
+    if not getattr(result, "success", False):
+        logger.warning(
+            "procedure scoping: classifier unsuccessful for %s (%s); keeping",
+            task_type, getattr(result, "error", None),
+        )
+        return False
+
+    ptype = _parse_procedure_type(getattr(result, "content", None))
+    if ptype is None:
+        logger.warning(
+            "procedure scoping: unparseable classification for %s; keeping",
+            task_type,
+        )
+        return False
+
+    is_directive = ptype == PROCEDURE_TYPE_DIRECTIVE
+    if is_directive:
+        logger.info(
+            "procedure scoping: %s classified as behavioral_directive "
+            "(belongs in CLAUDE.md) — not stored",
+            task_type,
+        )
+    return is_directive

--- a/tests/test_learning/test_extractor.py
+++ b/tests/test_learning/test_extractor.py
@@ -34,10 +34,21 @@ class _FakeRouterResult:
 
 
 def _router_returning(payload: dict) -> MagicMock:
+    """Router mock: the first route_call returns the extraction payload; any
+    subsequent call (the scoping classifier) returns a task_procedure verdict so
+    real procedures pass the scoping gate by an explicit verdict, not via the
+    fail-open path."""
     router = MagicMock()
-    router.route_call = AsyncMock(
-        return_value=_FakeRouterResult(success=True, content=json.dumps(payload))
-    )
+    pending = [_FakeRouterResult(success=True, content=json.dumps(payload))]
+
+    def _call(*_args, **_kwargs):
+        if pending:
+            return pending.pop(0)
+        return _FakeRouterResult(
+            success=True, content='{"procedure_type": "task_procedure"}',
+        )
+
+    router.route_call = AsyncMock(side_effect=_call)
     return router
 
 

--- a/tests/test_learning/test_scoping.py
+++ b/tests/test_learning/test_scoping.py
@@ -1,0 +1,196 @@
+"""Tests for the procedure scoping gate — behavioral-directive classifier.
+
+The gate keeps behavioral DIRECTIVES (general working-style rules) out of the
+procedure store. Its safety contract is FAIL-OPEN: any classifier failure must
+default to "keep" so a real procedure is never silently suppressed.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.learning.procedural.extractor import extract_procedure
+from genesis.learning.procedural.judge import judge_struggle_procedure
+from genesis.learning.procedural.scoping import (
+    PROCEDURE_TYPE_DIRECTIVE,
+    PROCEDURE_TYPE_TASK,
+    _parse_procedure_type,
+    is_behavioral_directive,
+)
+
+
+@dataclass
+class _Result:
+    success: bool = True
+    content: str = ""
+    error: str | None = None
+
+
+def _router(content: str, *, success: bool = True) -> MagicMock:
+    r = MagicMock()
+    r.route_call = AsyncMock(return_value=_Result(success=success, content=content))
+    return r
+
+
+def _router_seq(*results: _Result) -> MagicMock:
+    r = MagicMock()
+    r.route_call = AsyncMock(side_effect=list(results))
+    return r
+
+
+def _embedder() -> MagicMock:
+    emb = MagicMock()
+    emb.embed = AsyncMock(return_value=[1.0, 0.0, 0.0])
+    return emb
+
+
+# ── _parse_procedure_type ────────────────────────────────────────────────────
+
+def test_parse_backticked_directive():
+    out = _parse_procedure_type('```json\n{"procedure_type": "behavioral_directive"}\n```')
+    assert out == PROCEDURE_TYPE_DIRECTIVE
+
+
+def test_parse_raw_task_procedure():
+    out = _parse_procedure_type('{"procedure_type": "task_procedure", "reason": "docker"}')
+    assert out == PROCEDURE_TYPE_TASK
+
+
+def test_parse_lenient_substring_when_not_json():
+    # Model prose without valid JSON — fall back to substring detection.
+    assert _parse_procedure_type("Verdict: behavioral_directive — it's a habit.") == PROCEDURE_TYPE_DIRECTIVE
+
+
+def test_parse_returns_none_on_garbage():
+    assert _parse_procedure_type("no label anywhere") is None
+    assert _parse_procedure_type("") is None
+    assert _parse_procedure_type(None) is None
+
+
+def test_parse_returns_none_on_unknown_value():
+    # Unknown label must not be treated as a directive (fail open to keep).
+    assert _parse_procedure_type('{"procedure_type": "something_else"}') is None
+
+
+# ── is_behavioral_directive ──────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_directive_is_detected():
+    r = _router('```json\n{"procedure_type": "behavioral_directive"}\n```')
+    out = await is_behavioral_directive(
+        r, task_type="honest-confidence-gate", principle="always state confidence", steps=[],
+    )
+    assert out is True
+
+
+@pytest.mark.asyncio
+async def test_real_procedure_is_kept():
+    r = _router('```json\n{"procedure_type": "task_procedure"}\n```')
+    out = await is_behavioral_directive(
+        r, task_type="docker-cache-bust", principle="rm the COPY layer", steps=["docker build"],
+    )
+    assert out is False
+
+
+@pytest.mark.asyncio
+async def test_fail_open_on_call_exception():
+    r = MagicMock()
+    r.route_call = AsyncMock(side_effect=RuntimeError("router down"))
+    out = await is_behavioral_directive(r, task_type="x", principle="p", steps=["s"])
+    assert out is False  # keep
+
+
+@pytest.mark.asyncio
+async def test_fail_open_on_unsuccessful_result():
+    r = _router("", success=False)
+    out = await is_behavioral_directive(r, task_type="x", principle="p", steps=["s"])
+    assert out is False  # keep
+
+
+@pytest.mark.asyncio
+async def test_fail_open_on_unparseable_content():
+    r = _router("<html>Error 500</html>")
+    out = await is_behavioral_directive(r, task_type="x", principle="p", steps=["s"])
+    assert out is False  # keep
+
+
+@pytest.mark.asyncio
+async def test_uses_extraction_call_site():
+    r = _router('{"procedure_type": "task_procedure"}')
+    await is_behavioral_directive(r, task_type="x", principle="p", steps=["s"])
+    _, kwargs = r.route_call.call_args
+    assert kwargs["call_site_id"] == "38_procedure_extraction"
+
+
+# ── Integration: directive is actually suppressed at each storage path ────────
+
+def _valid_payload() -> dict:
+    return {
+        "task_type": "honest-confidence-gate",
+        "principle": "always state confidence before planning",
+        "steps": ["assess", "state confidence"],
+        "tools_used": ["Bash"],
+        "context_tags": ["meta"],
+        "tool_trigger": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_extract_procedure_suppresses_directive(db):
+    """Path 3 (extract_procedure): a directive verdict blocks storage."""
+    router = _router_seq(
+        _Result(content=json.dumps(_valid_payload())),          # extraction
+        _Result(content='{"procedure_type": "behavioral_directive"}'),  # scoping
+    )
+    proc_id = await extract_procedure(
+        db, summary_text="discussed confidence", outcome="success",
+        router=router, embedding_provider=_embedder(),
+    )
+    assert proc_id is None  # suppressed as a behavioral directive
+
+
+@pytest.mark.asyncio
+async def test_extract_procedure_keeps_real_procedure(db):
+    """Path 3 control: a task_procedure verdict stores normally."""
+    payload = {
+        "task_type": "docker-layer-cache-bust",
+        "principle": "rebuild with no-cache when COPY layer is stale",
+        "steps": ["docker build --no-cache"],
+        "tools_used": ["Bash"],
+        "context_tags": ["docker"],
+        "tool_trigger": None,
+    }
+    router = _router_seq(
+        _Result(content=json.dumps(payload)),
+        _Result(content='{"procedure_type": "task_procedure"}'),
+    )
+    proc_id = await extract_procedure(
+        db, summary_text="busted a docker cache", outcome="success",
+        router=router, embedding_provider=_embedder(),
+    )
+    assert proc_id is not None
+
+
+@pytest.mark.asyncio
+async def test_judge_struggle_suppresses_directive(db):
+    """Judge path (struggle stream): a directive verdict blocks storage."""
+    judge_json = (
+        '```json\n{"worth_storing": true, "task_type": "confidence-gate", '
+        '"principle": "always state confidence", "steps": ["1"], '
+        '"tools_used": ["Bash"], "context_tags": ["meta"]}\n```'
+    )
+    router = _router_seq(
+        _Result(content=judge_json),                                    # judge
+        _Result(content='{"procedure_type": "behavioral_directive"}'),  # scoping
+    )
+    spine = [{
+        "turn": 1, "type": "tool", "tool": "Bash",
+        "args_summary": "x", "outcome": "ok", "error_text": "",
+    }]
+    result = await judge_struggle_procedure(db, spine, 0.5, Path("/tmp/x.jsonl"), router)
+    assert result is None  # suppressed as a behavioral directive

--- a/tests/test_learning/test_scoping.py
+++ b/tests/test_learning/test_scoping.py
@@ -15,7 +15,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from genesis.learning.procedural.extractor import extract_procedure
-from genesis.learning.procedural.judge import judge_struggle_procedure
+from genesis.learning.procedural.judge import (
+    judge_extraction_candidate,
+    judge_struggle_procedure,
+)
 from genesis.learning.procedural.scoping import (
     PROCEDURE_TYPE_DIRECTIVE,
     PROCEDURE_TYPE_TASK,
@@ -75,6 +78,14 @@ def test_parse_returns_none_on_garbage():
 def test_parse_returns_none_on_unknown_value():
     # Unknown label must not be treated as a directive (fail open to keep).
     assert _parse_procedure_type('{"procedure_type": "something_else"}') is None
+
+
+def test_parse_lenient_both_present_falls_to_task():
+    # Both labels in non-JSON prose — must NOT suppress; falls to task_procedure (keep).
+    out = _parse_procedure_type(
+        "This is a task_procedure but has some behavioral_directive qualities too."
+    )
+    assert out == PROCEDURE_TYPE_TASK
 
 
 # ── is_behavioral_directive ──────────────────────────────────────────────────
@@ -193,4 +204,29 @@ async def test_judge_struggle_suppresses_directive(db):
         "args_summary": "x", "outcome": "ok", "error_text": "",
     }]
     result = await judge_struggle_procedure(db, spine, 0.5, Path("/tmp/x.jsonl"), router)
+    assert result is None  # suppressed as a behavioral directive
+
+
+@pytest.mark.asyncio
+async def test_judge_extraction_candidate_suppresses_directive(db):
+    """Judge path (extraction-candidate stream): a directive verdict blocks storage.
+
+    Covers the second judge entry point so the router threading through
+    _store_judged_procedure is caught by a dedicated test, not only structurally.
+    """
+    judge_json = (
+        '```json\n{"worth_storing": true, "task_type": "pre-plan-confidence", '
+        '"principle": "investigate before planning", "steps": ["1"], '
+        '"tools_used": ["Bash"], "context_tags": ["meta"]}\n```'
+    )
+    router = _router_seq(
+        _Result(content=judge_json),                                    # judge
+        _Result(content='{"procedure_type": "behavioral_directive"}'),  # scoping
+    )
+    candidate = {
+        "principle": "investigate before planning",
+        "scenario": "before planning",
+        "tools_used": ["Bash"],
+    }
+    result = await judge_extraction_candidate(db, candidate, "chunk context", router)
     assert result is None  # suppressed as a behavioral directive


### PR DESCRIPTION
## What

Adds a **scoping gate** that keeps behavioral *directives* out of the procedure store. The procedure store is for reusable **task procedures** (how a specific external technical system works — Docker, IMAP, MCP wiring). Behavioral **directives** (general working-style rules — "do due diligence before planning", "state confidence") belong in `CLAUDE.md`. Because the agent re-derives the same directive from almost every session, directives are the **dominant source of near-duplicate procedures** (a live snapshot had ~40 paraphrases of one "honest confidence + due diligence" lesson).

This is **PR-A (Layer 1)** of a 3-part dedup/consolidation effort: A) stop directives entering (this PR), B) cross-type dedup detection, C) one-time reversible consolidation of existing dups.

## How

`learning/procedural/scoping.py::is_behavioral_directive()` makes one LLM classification call (reusing the `38_procedure_extraction` call site) and reports whether an extracted procedure is really a directive. It is gated at the two storage convergence points, covering all three storage paths:

- `judge.py::_store_judged_procedure` — both judge streams (`judge_struggle_procedure`, `judge_extraction_candidate`)
- `extractor.py::extract_procedure` — the third path

## Safety contract: FAIL-OPEN

A real procedure must **never** be silently suppressed by a classifier hiccup. Every failure mode (router exception, unsuccessful result, unparseable/unknown classification) — and the whole function body — defaults to **keep**. The worst realistic failure is a directive slipping through (harmless), never a deleted procedure.

## Validation

- **Classifier** — 100% directive recall / **0% procedure false-positives** on a 40-item hand-labeled, held-out sample (incl. 14 technical procedures not used to tune the prompt).
- **E2E against the live model** — the wired gate suppressed 3 real directives and **kept** 3 real procedures, including two that an earlier prompt iteration misclassified.
- **Tests** — new `test_scoping.py` (unit fail-open coverage + integration tests for all 3 paths); existing extractor tests made explicit; full `learning/` subsystem green.

## Docs

CHANGELOG (user-facing) + `genesis-v3-procedure-activation.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)