### PR TITLE
refactor(learning): rename procedure `speculative` column to `draft`

### DIFF
--- a/docs/architecture/genesis-v3-autonomous-behavior-design.md
+++ b/docs/architecture/genesis-v3-autonomous-behavior-design.md
@@ -1884,12 +1884,12 @@ down should absolutely be re-attempted when the service is back up.
 
 Procedure selection balances performance and novelty: ~90% of the time, use the highest-confidence procedure for the task type. ~10% of the time, deliberately try a novel (lower-confidence, higher-novelty) procedure and log the comparison. This explore-exploit ratio ensures the system doesn't stop discovering better approaches for tasks it already handles adequately.
 
-**Speculative tagging for new procedures:** Pattern 3 (speculative vs. grounded claims) applies to procedures, not just observations. A procedure extracted from a single successful task execution is speculative — it worked once, but is it generalizable?
+**Draft tagging for new procedures:** The idea behind Pattern 3 (speculative vs. grounded claims) applies to procedures too — though a procedure's unproven flag is named `draft`, not `speculative`, to keep the two concepts distinct (a procedure isn't *speculating about* anything; it's an untested draft). A procedure extracted from a single successful task execution is a draft — it worked once, but is it generalizable?
 
-- New procedures start with `speculative: true`, `success_count: 1`
+- New procedures start with `draft: true`, `success_count: 1`
 - Confirmed after `success_count >= 3` across different task contexts (not 3 successes on the same task — 3 successes in different situations)
-- Speculative procedures are available for use but do NOT override confirmed procedures for the same task type
-- Speculative procedures that fail 3 times before reaching confirmation are archived, not
+- Draft procedures are available for use but do NOT override confirmed procedures for the same task type
+- Draft procedures that fail 3 times before reaching confirmation are archived, not
   deleted (the failure data is valuable). Archived procedures remain accessible for
   re-evaluation — if conditions change (new tools available, service restored, different
   context), the LLM can re-consider an archived procedure. Archived ≠ forbidden.

--- a/docs/architecture/genesis-v3-procedure-activation.md
+++ b/docs/architecture/genesis-v3-procedure-activation.md
@@ -61,13 +61,13 @@ CORE > ADVISORY > LIBRARY > DORMANT (CORE = most-proven; see `_TIER_RANK` in
 
 ```
 Auto-extracted (triage / extractor pipeline):
-  → DORMANT (speculative=1, success_count=0, conf=0.0, advisory only)
-  → LIBRARY (3+ successes, conf >= 0.65, speculative=0)
+  → DORMANT (draft=1, success_count=0, conf=0.0, advisory only)
+  → LIBRARY (3+ successes, conf >= 0.65, draft=0)
   → ADVISORY (5+ successes, conf >= 0.75, embedded in skills)
   → CORE (8+ successes, conf >= 0.85, tool trigger set)
 
 Explicit user teach (procedure_store MCP tool):
-  → LIBRARY (speculative=0, success_count=1, conf=2/3) — recallable and
+  → LIBRARY (draft=0, success_count=1, conf=2/3) — recallable and
        eligible for proactive-hook surfacing from the moment it is stored.
        Earns further promotion to ADVISORY/CORE organically via record_success.
 ```
@@ -96,9 +96,9 @@ treated as a *dampened* positive signal:
   by `effective_confidence` (read-heavy procedures surface first; ties keep
   relevance order). Isolated to the recall path — `find_relevant`'s global
   behavior is unchanged (it has 6 callers, incl. autonomy outcome-attribution).
-- **De-speculation:** a draft (`speculative=1`) graduates to validated
-  (`speculative=0`) on its first *real* success with no failures — closing the
-  prior gap where nothing ever cleared the flag. Reads alone do not de-speculate.
+- **Draft clearing:** a draft (`draft=1`) graduates to validated
+  (`draft=0`) on its first *real* success with no failures — closing the
+  prior gap where nothing ever cleared the flag. Reads alone do not clear the draft flag.
 
 The one-time migration `0035_backfill_procedure_invocation_count` seeds
 `invocation_count` from historical `procedure_invoked` events in `eval_events`
@@ -114,7 +114,7 @@ Demotion is **evidence-driven only** — never metric drift:
 
 > **Eval note:** the J-9 system composite's procedure-confidence signal and the
 > procedure dimension's `mean_confidence` average **validated** procedures
-> (speculative=0) only. Speculative candidates start at conf≈0 and would measure
+> (draft=0) only. Draft candidates start at conf≈0 and would measure
 > extraction *volume*, not knowledge *quality* (`total_procedures` still counts
 > the whole store, consistent with `tier_distribution`).
 
@@ -131,8 +131,8 @@ promoter runs.
 1. **Triage / extraction pipeline** — extracts procedures from
    APPROACH_FAILURE and WORKAROUND_SUCCESS outcomes via LLM (call site 34),
    plus the per-session extraction + struggle streams. Defaults to DORMANT /
-   speculative=1 — the LLM hypothesis must earn trust through real
-   organic successes before promotion. **Capped at 3 new speculative
+   draft=1 — the LLM hypothesis must earn trust through real
+   organic successes before promotion. **Capped at 3 new draft
    procedures per session** (`max_procedures_per_session`, shared across the
    extraction and struggle streams) so a single session cannot flood the store.
    **Scoping gate:** before storage, an LLM classifies each extracted procedure as a
@@ -143,7 +143,7 @@ promoter runs.
    real procedure is never suppressed (`scoping.py`).
 2. **MCP tool** — `procedure_store` for explicit user teaching. Treated
    as one Laplace-equivalent confirmed success — seeds at LIBRARY with
-   speculative=0, success_count=1, confidence=2/3. The caller asserting
+   draft=0, success_count=1, confidence=2/3. The caller asserting
    "this procedure works" is the evidence; the system trusts that
    assertion enough to make the procedure immediately recallable and
    eligible for proactive-hook surfacing.

--- a/scripts/seed_procedures.py
+++ b/scripts/seed_procedures.py
@@ -47,7 +47,7 @@ SEED_PROCEDURES = [
         "context_tags": ["youtube", "video", "transcript", "ssl", "content-fetch"],
         "activation_tier": "CORE",
         "tool_trigger": ["WebFetch"],
-        "speculative": 0,
+        "draft": 0,
         "success_count": 5,
         "confidence": 0.86,  # (5+1)/(5+0+2) = 0.857
     },
@@ -64,7 +64,7 @@ SEED_PROCEDURES = [
         "context_tags": ["youtube", "transcript", "workaround", "fallback"],
         "activation_tier": "LIBRARY",
         "tool_trigger": None,
-        "speculative": 0,
+        "draft": 0,
         "success_count": 2,
         "confidence": 0.75,  # (2+1)/(2+0+2) = 0.75
     },
@@ -81,7 +81,7 @@ SEED_PROCEDURES = [
         "context_tags": ["pip.*-e", "pip.*--editable"],
         "activation_tier": "CORE",
         "tool_trigger": ["Bash"],
-        "speculative": 0,
+        "draft": 0,
         "success_count": 8,
         "confidence": 0.90,  # (8+1)/(8+0+2) = 0.90
     },
@@ -98,7 +98,7 @@ SEED_PROCEDURES = [
         "context_tags": ["os.killpg", "os.kill(", "killpg(", "mock_proc.pid", "pgid"],
         "activation_tier": "CORE",
         "tool_trigger": ["Write", "Edit"],
-        "speculative": 0,
+        "draft": 0,
         "success_count": 5,
         "confidence": 0.86,
     },
@@ -116,7 +116,7 @@ SEED_PROCEDURES = [
         "context_tags": ["git", "worktree", "concurrent", "safety", "commit"],
         "activation_tier": "LIBRARY",
         "tool_trigger": None,
-        "speculative": 0,
+        "draft": 0,
         "success_count": 10,
         "confidence": 0.92,
     },
@@ -135,7 +135,7 @@ SEED_PROCEDURES = [
         "context_tags": ["tmp", "filesystem", "disk", "safety", "tmpdir", "watchgod"],
         "activation_tier": "LIBRARY",
         "tool_trigger": None,
-        "speculative": 0,
+        "draft": 0,
         "success_count": 3,
         "confidence": 0.90,
     },
@@ -148,13 +148,13 @@ SEED_PROCEDURES = [
             "Call out what you don't know — lead with unknowns",
             "State falsifiability criteria: 'This would be DISPROVEN if [observation]'",
             "Include regression markers: what to watch for if the fix is wrong",
-            "No speculative changes without diagnosis confirmation",
+            "No draft changes without diagnosis confirmation",
         ],
         "tools_used": ["Write", "Edit"],
         "context_tags": ["planning", "decision", "confidence", "framework", "analysis"],
         "activation_tier": "LIBRARY",
         "tool_trigger": None,
-        "speculative": 0,
+        "draft": 0,
         "success_count": 4,
         "confidence": 0.83,
     },
@@ -177,7 +177,7 @@ async def main(db_path: Path) -> None:
         await db.execute(
             """INSERT INTO procedural_memory
                (id, task_type, principle, steps, tools_used, context_tags,
-                activation_tier, tool_trigger, speculative, success_count,
+                activation_tier, tool_trigger, draft, success_count,
                 confidence, created_at)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
                ON CONFLICT(id) DO UPDATE SET
@@ -187,7 +187,7 @@ async def main(db_path: Path) -> None:
                  context_tags = excluded.context_tags,
                  activation_tier = excluded.activation_tier,
                  tool_trigger = excluded.tool_trigger,
-                 speculative = excluded.speculative""",
+                 draft = excluded.draft""",
             (
                 proc_id,
                 proc["task_type"],
@@ -197,7 +197,7 @@ async def main(db_path: Path) -> None:
                 json.dumps(proc["context_tags"]),
                 proc["activation_tier"],
                 json.dumps(proc["tool_trigger"]) if proc["tool_trigger"] else None,
-                proc["speculative"],
+                proc["draft"],
                 proc["success_count"],
                 proc["confidence"],
             ),

--- a/src/genesis/autonomy/executor/trace.py
+++ b/src/genesis/autonomy/executor/trace.py
@@ -459,7 +459,7 @@ class ExecutionTracer:
             tools_used=proc_data["tools_used"],
             context_tags=proc_data["context_tags"],
             activation_tier="LIBRARY",
-            speculative=1,
+            draft=1,
             confidence=0.5,
             principle_embedding=principle_blob,
         )

--- a/src/genesis/db/crud/procedural.py
+++ b/src/genesis/db/crud/procedural.py
@@ -20,7 +20,7 @@ async def create(
     created_at: str,
     scenario: str | None = None,
     person_id: str | None = None,
-    speculative: int = 1,
+    draft: int = 1,
     attempted_workarounds: list | None = None,
     version: int = 1,
     activation_tier: str = "DORMANT",
@@ -36,14 +36,14 @@ async def create(
     await db.execute(
         """INSERT INTO procedural_memory
            (id, person_id, task_type, principle, scenario, steps, tools_used,
-            context_tags, speculative, attempted_workarounds, version, created_at,
+            context_tags, draft, attempted_workarounds, version, created_at,
             activation_tier, tool_trigger, success_count, confidence,
             source, promotion_history, principle_embedding,
             extraction_context, first_mover)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (id, person_id, task_type, principle, scenario,
          json.dumps(steps), json.dumps(tools_used),
-         json.dumps(context_tags), speculative,
+         json.dumps(context_tags), draft,
          json.dumps(attempted_workarounds) if attempted_workarounds else None,
          version, created_at, activation_tier,
          json.dumps(tool_trigger) if tool_trigger else None,
@@ -65,7 +65,7 @@ async def upsert(
     context_tags: list[str],
     created_at: str,
     person_id: str | None = None,
-    speculative: int = 1,
+    draft: int = 1,
     attempted_workarounds: list | None = None,
     version: int = 1,
     activation_tier: str = "DORMANT",
@@ -80,13 +80,13 @@ async def upsert(
     Mirrors `create()`'s `success_count` / `confidence` plumbing so that
     callers building idempotent seed/teach paths (e.g., batch seed scripts,
     future explicit-teach upserters) can't accidentally land rows with the
-    invisible-to-recall (speculative=0, success_count=0, confidence=0.0)
+    invisible-to-recall (draft=0, success_count=0, confidence=0.0)
     profile that bit `procedure_store` before this fix.
     """
     await db.execute(
         """INSERT INTO procedural_memory
            (id, person_id, task_type, principle, steps, tools_used, context_tags,
-            speculative, attempted_workarounds, version, created_at,
+            draft, attempted_workarounds, version, created_at,
             activation_tier, tool_trigger, success_count, confidence,
             source, promotion_history)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -94,7 +94,7 @@ async def upsert(
              person_id = excluded.person_id,
              task_type = excluded.task_type, principle = excluded.principle,
              steps = excluded.steps, tools_used = excluded.tools_used,
-             context_tags = excluded.context_tags, speculative = excluded.speculative,
+             context_tags = excluded.context_tags, draft = excluded.draft,
              attempted_workarounds = excluded.attempted_workarounds,
              version = excluded.version,
              activation_tier = excluded.activation_tier,
@@ -104,7 +104,7 @@ async def upsert(
              source = COALESCE(procedural_memory.source, excluded.source),
              promotion_history = COALESCE(procedural_memory.promotion_history, excluded.promotion_history)""",
         (id, person_id, task_type, principle, json.dumps(steps), json.dumps(tools_used),
-         json.dumps(context_tags), speculative,
+         json.dumps(context_tags), draft,
          json.dumps(attempted_workarounds) if attempted_workarounds else None,
          version, created_at, activation_tier,
          json.dumps(tool_trigger) if tool_trigger else None,

--- a/src/genesis/db/migrations/0037_rename_procedure_speculative_to_draft.py
+++ b/src/genesis/db/migrations/0037_rename_procedure_speculative_to_draft.py
@@ -1,0 +1,60 @@
+"""Rename ``procedural_memory.speculative`` -> ``draft``.
+
+A procedure's unproven state lived in a column named ``speculative`` — but a
+procedure isn't *speculating about* anything (the word Genesis reserves for
+observations and hypothesis-claims); it is an untested **draft** destined for
+real use. This renames ONLY the procedural_memory column so the vocabulary says
+what it means. ``observations.speculative`` and ``speculative_claims.speculative``
+are a genuinely different concept and are intentionally left as-is.
+
+Pure column rename — no value rewrite. ``ALTER TABLE … RENAME COLUMN`` preserves
+every row's data; SQLite auto-updates the column reference inside the existing
+index, and we additionally rename the index *identifier*
+(``idx_procedural_speculative`` -> ``idx_procedural_draft``) so it reads cleanly.
+
+Idempotent: if the column is already ``draft`` (or ``speculative`` is gone), the
+guard returns early, so applying twice — or against a fresh DB already born with
+``draft`` from ``_tables.py`` — is a no-op. The code rename (CRUD params, query
+literals, dict-key reads) ships in the same PR, so new rows are written against
+``draft`` from the moment this lands.
+
+Rollback path: revert the PR and apply a symmetric reverse rename; this file has
+no ``down()`` (matches the migration-set norm).
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # The runner applies migrations against a bare DB in its own unit tests,
+    # where base tables (created by `create_all_tables` in production) are
+    # absent. Skip cleanly rather than fail the apply-all sequence. (Mirrors
+    # 0035 / 0036.)
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='procedural_memory'"
+    )
+    if not await cursor.fetchone():
+        return
+
+    # Idempotency: skip if the rename already happened (column is ``draft``) or
+    # there is nothing to rename (``speculative`` absent). Makes a re-run — or a
+    # run against a fresh DB born with ``draft`` — a clean no-op.
+    cursor = await db.execute("PRAGMA table_info(procedural_memory)")
+    columns = {row[1] for row in await cursor.fetchall()}
+    if "draft" in columns or "speculative" not in columns:
+        return
+
+    # Rename the column (row data is preserved verbatim).
+    await db.execute(
+        "ALTER TABLE procedural_memory RENAME COLUMN speculative TO draft"
+    )
+
+    # Rename the index identifier to match. SQLite already repointed the old
+    # index at the renamed column, so this is purely for a clean name.
+    await db.execute("DROP INDEX IF EXISTS idx_procedural_speculative")
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_procedural_draft "
+        "ON procedural_memory(draft)"
+    )

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -26,7 +26,7 @@ TABLES = {
             deprecated        INTEGER NOT NULL DEFAULT 0,
             deprecated_reason TEXT,
             superseded_by     TEXT,                -- FK to procedural_memory.id
-            speculative       INTEGER NOT NULL DEFAULT 1,
+            draft             INTEGER NOT NULL DEFAULT 1,  -- untested draft (was: speculative)
             invocation_count  INTEGER NOT NULL DEFAULT 0,
             attempted_workarounds TEXT,            -- JSON: array of {description, outcome, conditions}
             version           INTEGER NOT NULL DEFAULT 1,
@@ -1503,7 +1503,7 @@ KNOWLEDGE_FTS5_DDL = """
 
 INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_procedural_task_type ON procedural_memory(task_type)",
-    "CREATE INDEX IF NOT EXISTS idx_procedural_speculative ON procedural_memory(speculative)",
+    "CREATE INDEX IF NOT EXISTS idx_procedural_draft ON procedural_memory(draft)",
     "CREATE INDEX IF NOT EXISTS idx_procedural_activation_tier ON procedural_memory(activation_tier)",
     "CREATE INDEX IF NOT EXISTS idx_observations_source ON observations(source)",
     "CREATE INDEX IF NOT EXISTS idx_observations_type ON observations(type)",

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -362,12 +362,12 @@ async def _compute_system_composite(
     obs_influenced = row["influenced"] if row else 0
     obs_influence_pct = round(obs_influenced / obs_total, 4) if obs_total else None
 
-    # Procedure mean confidence — VALIDATED procedures only. Speculative
+    # Procedure mean confidence — VALIDATED procedures only. Draft
     # candidates (extracted at confidence ≈ 0, never invoked) measure extraction
     # volume, not knowledge quality; including them tanked this composite signal.
     cursor = await db.execute(
         "SELECT AVG(confidence) as avg_conf FROM procedural_memory "
-        "WHERE deprecated = 0 AND speculative = 0",
+        "WHERE deprecated = 0 AND draft = 0",
     )
     row = await cursor.fetchone()
     proc_mean_conf = round(row["avg_conf"], 4) if row and row["avg_conf"] else None
@@ -535,10 +535,10 @@ async def _compute_procedural_effectiveness(
 
     # Overall procedure stats. total counts the whole store (consistent with
     # tier_distribution below); mean_confidence averages VALIDATED procedures
-    # only (speculative candidates start at ≈0 and would mask real quality).
+    # only (draft candidates start at ≈0 and would mask real quality).
     cursor = await db.execute(
         """SELECT COUNT(*) as total,
-                  AVG(CASE WHEN speculative = 0 THEN confidence END) as avg_conf
+                  AVG(CASE WHEN draft = 0 THEN confidence END) as avg_conf
         FROM procedural_memory WHERE deprecated = 0""",
     )
     row = await cursor.fetchone()

--- a/src/genesis/learning/procedural/extractor.py
+++ b/src/genesis/learning/procedural/extractor.py
@@ -3,7 +3,7 @@
 When the triage pipeline classifies an interaction as APPROACH_FAILURE,
 WORKAROUND_SUCCESS, or (on autonomous channels) SUCCESS, this module extracts
 a reusable procedure and stores it. New procedures start at LIBRARY with
-speculative=1 and confidence=0.5 — immediately recallable and eligible for
+draft=1 and confidence=0.5 — immediately recallable and eligible for
 proactive surfacing (but not blind session-start injection, which is CORE-only).
 
 Quality gate: the extraction prompt includes criteria for the LLM to
@@ -269,7 +269,7 @@ async def extract_procedure(
         from genesis.db.crud.procedural import find_by_task_type
 
         existing = await find_by_task_type(db, data["task_type"])
-        if existing and existing.get("speculative") == 0:
+        if existing and existing.get("draft") == 0:
             logger.info(
                 "Skipped extraction for %s: explicit-teach %s exists",
                 data["task_type"], existing["id"],
@@ -323,7 +323,7 @@ async def extract_procedure(
         for ov in overlapping:
             if (
                 ov.get("confidence", 0) >= 0.5
-                and ov.get("speculative") == 0
+                and ov.get("draft") == 0
                 and principle_vec is not None
                 and embedder is not None
             ):
@@ -406,7 +406,7 @@ async def extract_procedure(
             context_tags=data["context_tags"],
             tool_trigger=data.get("tool_trigger"),
             activation_tier="LIBRARY",
-            speculative=1,
+            draft=1,
             confidence=gate_result.adjusted_confidence,
             source={"type": "auto_extracted", "triage_outcome": outcome},
             principle_embedding=principle_blob,

--- a/src/genesis/learning/procedural/judge.py
+++ b/src/genesis/learning/procedural/judge.py
@@ -224,7 +224,7 @@ async def _store_judged_procedure(
         context_tags=context_tags,
         tool_trigger=tool_trigger,
         activation_tier="DORMANT",
-        speculative=1,
+        draft=1,
         success_count=0,
         confidence=0.0,
         source=source,

--- a/src/genesis/learning/procedural/operations.py
+++ b/src/genesis/learning/procedural/operations.py
@@ -56,7 +56,7 @@ async def store_procedure(
     scenario: str | None = None,
     activation_tier: str = "DORMANT",
     tool_trigger: list[str] | None = None,
-    speculative: int = 1,
+    draft: int = 1,
     success_count: int = 0,
     confidence: float = 0.0,
     source: dict | None = None,
@@ -66,10 +66,10 @@ async def store_procedure(
 ) -> str:
     """Create a new procedure and return its ID.
 
-    Defaults match the extractor path (speculative=1, success_count=0,
+    Defaults match the extractor path (draft=1, success_count=0,
     confidence=0.0). Callers that represent explicit confirmations — e.g.,
     user-driven `procedure_store` MCP writes — should pass non-default
-    values to seed the procedure as already-trusted (speculative=0,
+    values to seed the procedure as already-trusted (draft=0,
     success_count>=1, confidence via Laplace).
 
     `principle_embedding` is the packed BLOB returned by
@@ -95,7 +95,7 @@ async def store_procedure(
         created_at=now,
         activation_tier=activation_tier,
         tool_trigger=tool_trigger,
-        speculative=speculative,
+        draft=draft,
         success_count=success_count,
         confidence=confidence,
         source=json.dumps(source) if source else None,
@@ -117,7 +117,7 @@ async def store_procedure_checked(
     scenario: str | None = None,
     activation_tier: str = "LIBRARY",
     tool_trigger: list[str] | None = None,
-    speculative: int = 0,
+    draft: int = 0,
     success_count: int = 1,
     confidence: float = 2 / 3,
     source: dict | None = None,
@@ -125,7 +125,7 @@ async def store_procedure_checked(
 ) -> StoreResult:
     """Store a procedure with conflict detection.
 
-    Defaults match the explicit-teach path (speculative=0, success_count=1).
+    Defaults match the explicit-teach path (draft=0, success_count=1).
 
     Conflict resolution:
     - Exact task_type match, incoming is auto-extracted but existing is
@@ -138,7 +138,7 @@ async def store_procedure_checked(
 
     if existing:
         # Auto-extracted should never overwrite explicit-teach
-        if speculative == 1 and existing.get("speculative") == 0:
+        if draft == 1 and existing.get("draft") == 0:
             logger.info(
                 "Skipped auto-extracted procedure for %s: explicit-teach %s exists",
                 task_type, existing["id"],
@@ -191,7 +191,7 @@ async def store_procedure_checked(
         context_tags=context_tags,
         activation_tier=activation_tier,
         tool_trigger=tool_trigger,
-        speculative=speculative,
+        draft=draft,
         success_count=success_count,
         confidence=confidence,
         source=source,

--- a/src/genesis/learning/procedural/promoter.py
+++ b/src/genesis/learning/procedural/promoter.py
@@ -109,7 +109,7 @@ async def promote_and_demote(db: aiosqlite.Connection) -> dict:
     promotions = 0
     demotions = 0
     quarantined = 0
-    despeculated = 0
+    drafts_cleared = 0
 
     for row in rows:
         current_tier = row.get("activation_tier", "DORMANT")
@@ -131,13 +131,13 @@ async def promote_and_demote(db: aiosqlite.Connection) -> dict:
             logger.info("Quarantined procedure %s (conf=%.2f)", row["task_type"], row["confidence"])
             continue
 
-        # De-speculation: a draft graduates to validated once it has >=1 real
-        # success and no failures (reads alone do NOT de-speculate). Closes the
-        # gap where nothing ever cleared speculative=1.
-        if row["speculative"] and row["success_count"] >= 1 and row["failure_count"] == 0:
-            await procedural.update(db, proc_id, speculative=0)
-            despeculated += 1
-            logger.info("De-speculated procedure %s (success=%d)", row["task_type"], row["success_count"])
+        # Draft clearing: a draft graduates to validated once it has >=1 real
+        # success and no failures (reads alone do NOT clear the draft flag).
+        # Closes the gap where nothing ever cleared draft=1.
+        if row["draft"] and row["success_count"] >= 1 and row["failure_count"] == 0:
+            await procedural.update(db, proc_id, draft=0)
+            drafts_cleared += 1
+            logger.info("Cleared draft on procedure %s (success=%d)", row["task_type"], row["success_count"])
 
         # Compute target tier. Failure evidence (`_check_demotion`) takes
         # precedence over BOTH real-metric and read-driven promotion: a
@@ -199,7 +199,7 @@ async def promote_and_demote(db: aiosqlite.Connection) -> dict:
         "promotions": promotions,
         "demotions": demotions,
         "quarantined": quarantined,
-        "despeculated": despeculated,
+        "drafts_cleared": drafts_cleared,
     }
     if any(v > 0 for v in result.values()):
         logger.info("Promotion results: %s", result)

--- a/src/genesis/mcp/memory/procedural.py
+++ b/src/genesis/mcp/memory/procedural.py
@@ -73,7 +73,7 @@ async def procedure_store(
 
     An MCP `procedure_store` call represents an *explicit teach* — the caller
     is asserting the procedure works. We seed it as already-confirmed
-    (speculative=0) with one Laplace-equivalent success (success_count=1,
+    (draft=0) with one Laplace-equivalent success (success_count=1,
     confidence=2/3), and place it at LIBRARY so it is immediately
     recallable and eligible for proactive-hook surfacing. (Blind SessionStart
     injection is CORE-only as of Surfacing v2, so an explicit teach reaches
@@ -86,7 +86,7 @@ async def procedure_store(
     hook skips that row.
 
     The auto-extraction path (`learning.procedural.extractor`) keeps its
-    speculative=1 / success_count=0 / confidence=0.0 / DORMANT defaults — those
+    draft=1 / success_count=0 / confidence=0.0 / DORMANT defaults — those
     procedures are LLM-hypothesized and must earn trust.
     """
     memory_mod = _memory_mod()
@@ -106,7 +106,7 @@ async def procedure_store(
         context_tags=context_tags,
         tool_trigger=tool_trigger,
         activation_tier="LIBRARY",
-        speculative=0,
+        draft=0,
         success_count=1,
         confidence=2 / 3,
         source={"type": "explicit_teach"},

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -171,7 +171,7 @@ async def run_extraction_cycle(
         all_keywords: set[str] = set()
         latest_topic = ""
         session_extraction_count = 0
-        # Per-session cap on NEW speculative procedures (extraction + struggle
+        # Per-session cap on NEW draft procedures (extraction + struggle
         # streams). Without this, a single session can flood the store with
         # hundreds of conf≈0 candidates that never get validated.
         session_procs = 0

--- a/tests/test_autonomy/test_executor/test_trace.py
+++ b/tests/test_autonomy/test_executor/test_trace.py
@@ -171,7 +171,7 @@ class TestRetrospective:
         assert call_kwargs.kwargs["task_type"] == "api-endpoint-creation"
         assert call_kwargs.kwargs["activation_tier"] == "LIBRARY"
         assert call_kwargs.kwargs["confidence"] == 0.5
-        assert call_kwargs.kwargs["speculative"] == 1
+        assert call_kwargs.kwargs["draft"] == 1
         assert "proc-new-123" in trace.procedural_extractions
 
     async def test_retrospective_skipped_without_router(self) -> None:

--- a/tests/test_db/test_migration_0037_rename_speculative_to_draft.py
+++ b/tests/test_db/test_migration_0037_rename_speculative_to_draft.py
@@ -1,0 +1,139 @@
+"""Migration 0037 — rename ``procedural_memory.speculative`` -> ``draft``.
+
+A procedure's unproven state is not "speculative" (the word Genesis reserves
+for observations and hypothesis-claims); it is an untested *draft*. This
+migration renames ONLY the procedural_memory column. ``observations.speculative``
+and ``speculative_claims.speculative`` are a different concept and stay.
+
+The test builds the *pre-migration* schema explicitly (a raw table carrying a
+``speculative`` column) so it exercises the real ``ALTER TABLE … RENAME COLUMN``
+regardless of the current ``_tables.py`` DDL — a migration must keep working on
+databases born under the old schema forever.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M37 = importlib.import_module(
+    "genesis.db.migrations.0037_rename_procedure_speculative_to_draft"
+)
+
+
+async def _columns(db: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await db.execute(f"PRAGMA table_info({table})")
+    return {row[1] for row in await cur.fetchall()}
+
+
+async def _indexes(db: aiosqlite.Connection) -> set[str]:
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='index'"
+    )
+    return {row[0] for row in await cur.fetchall()}
+
+
+async def _build_pre_state(conn: aiosqlite.Connection) -> None:
+    """Construct the schema as it existed *before* 0037: procedural_memory
+    with a ``speculative`` column + its index, plus the two sibling tables
+    that must be left untouched."""
+    await conn.execute(
+        """
+        CREATE TABLE procedural_memory (
+            id           TEXT PRIMARY KEY,
+            task_type    TEXT NOT NULL,
+            speculative  INTEGER NOT NULL DEFAULT 1,
+            confidence   REAL NOT NULL DEFAULT 0.0,
+            deprecated   INTEGER NOT NULL DEFAULT 0
+        )
+        """
+    )
+    await conn.execute(
+        "CREATE INDEX idx_procedural_speculative "
+        "ON procedural_memory(speculative)"
+    )
+    # Sibling tables that legitimately keep their own ``speculative`` column.
+    await conn.execute(
+        "CREATE TABLE observations (id TEXT PRIMARY KEY, "
+        "speculative INTEGER NOT NULL DEFAULT 0)"
+    )
+    await conn.execute(
+        "CREATE TABLE speculative_claims (id TEXT PRIMARY KEY, "
+        "speculative INTEGER NOT NULL DEFAULT 1)"
+    )
+    await conn.commit()
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await _build_pre_state(conn)
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_renames_column_preserving_values(db):
+    await db.execute(
+        "INSERT INTO procedural_memory (id, task_type, speculative, confidence) "
+        "VALUES ('draftp', 'td', 1, 0.5), ('validp', 'tv', 0, 0.9)"
+    )
+    await db.commit()
+
+    await M37.up(db)
+
+    cols = await _columns(db, "procedural_memory")
+    assert "draft" in cols
+    assert "speculative" not in cols
+
+    # Values survive the rename, mapped onto the new column name.
+    cur = await db.execute(
+        "SELECT draft, confidence FROM procedural_memory ORDER BY id"
+    )
+    rows = await cur.fetchall()
+    assert (rows[0]["draft"], rows[0]["confidence"]) == (1, 0.5)   # draftp
+    assert (rows[1]["draft"], rows[1]["confidence"]) == (0, 0.9)   # validp
+
+
+@pytest.mark.asyncio
+async def test_index_renamed(db):
+    await M37.up(db)
+    idx = await _indexes(db)
+    assert "idx_procedural_speculative" not in idx
+    assert "idx_procedural_draft" in idx
+    # The new index actually covers the new column.
+    cur = await db.execute("PRAGMA index_info(idx_procedural_draft)")
+    covered = {row[2] for row in await cur.fetchall()}
+    assert covered == {"draft"}
+
+
+@pytest.mark.asyncio
+async def test_leaves_observations_and_claims_untouched(db):
+    await M37.up(db)
+    assert "speculative" in await _columns(db, "observations")
+    assert "draft" not in await _columns(db, "observations")
+    assert "speculative" in await _columns(db, "speculative_claims")
+    assert "draft" not in await _columns(db, "speculative_claims")
+
+
+@pytest.mark.asyncio
+async def test_idempotent_on_already_renamed(db):
+    await M37.up(db)
+    # Second application: column already named ``draft`` -> clean no-op.
+    await M37.up(db)
+    cols = await _columns(db, "procedural_memory")
+    assert "draft" in cols
+    assert "speculative" not in cols
+
+
+@pytest.mark.asyncio
+async def test_skips_when_base_table_absent(tmp_path):
+    """The runner applies migrations against a bare DB (no base tables); 0037
+    must skip cleanly rather than fail on a missing table."""
+    async with aiosqlite.connect(str(tmp_path / "bare.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute("CREATE TABLE schema_migrations (version TEXT)")
+        await conn.commit()
+        await M37.up(conn)  # must not raise (no such table: procedural_memory)

--- a/tests/test_db/test_procedural.py
+++ b/tests/test_db/test_procedural.py
@@ -28,13 +28,13 @@ async def test_create_with_initial_counts(db):
     """Verify success_count and confidence kwargs are persisted on create."""
     await procedural.create(
         db, id="p_seed", success_count=1, confidence=2 / 3,
-        speculative=0, activation_tier="LIBRARY", **_COMMON,
+        draft=0, activation_tier="LIBRARY", **_COMMON,
     )
     row = await procedural.get_by_id(db, "p_seed")
     assert row is not None
     assert row["success_count"] == 1
     assert abs(row["confidence"] - 2 / 3) < 1e-9
-    assert row["speculative"] == 0
+    assert row["draft"] == 0
     assert row["activation_tier"] == "LIBRARY"
 
 

--- a/tests/test_ego/test_capability_aggregator.py
+++ b/tests/test_ego/test_capability_aggregator.py
@@ -58,7 +58,7 @@ async def db(tmp_path):
             CREATE TABLE procedural_memory (
                 id TEXT PRIMARY KEY, task_type TEXT NOT NULL,
                 confidence REAL DEFAULT 0.0, deprecated INTEGER DEFAULT 0,
-                quarantined INTEGER DEFAULT 0, speculative INTEGER DEFAULT 1,
+                quarantined INTEGER DEFAULT 0, draft INTEGER DEFAULT 1,
                 success_count INTEGER DEFAULT 0, failure_count INTEGER DEFAULT 0,
                 invocation_count INTEGER DEFAULT 0,
                 activation_tier TEXT DEFAULT 'DORMANT',

--- a/tests/test_eval/test_j9_procedure_confidence.py
+++ b/tests/test_eval/test_j9_procedure_confidence.py
@@ -1,9 +1,9 @@
-"""Procedure-confidence signals must exclude speculative (unvalidated) procedures.
+"""Procedure-confidence signals must exclude draft (unvalidated) procedures.
 
-A flood of speculative L4 procedures (confidence ≈ 0, never invoked) dragged the
+A flood of draft L4 procedures (confidence ≈ 0, never invoked) dragged the
 system composite down ~0.10 — a volume artifact, not a quality regression. The
 composite's `procedure_mean_confidence` and the procedure dimension's
-`mean_confidence` must measure VALIDATED procedures (speculative=0) only, while
+`mean_confidence` must measure VALIDATED procedures (draft=0) only, while
 `total_procedures` still counts the whole store (consistent with tier_distribution).
 """
 
@@ -20,23 +20,23 @@ _SINCE = "2000-01-01T00:00:00Z"
 _UNTIL = "2099-01-01T00:00:00Z"
 
 
-async def _seed_proc(db, pid, confidence, *, speculative, deprecated=0):
+async def _seed_proc(db, pid, confidence, *, draft, deprecated=0):
     await db.execute(
         "INSERT INTO procedural_memory "
         "(id, task_type, principle, steps, tools_used, context_tags, "
-        " confidence, speculative, deprecated, created_at) "
+        " confidence, draft, deprecated, created_at) "
         "VALUES (?, 'task', 'p', '[]', '[]', '[]', ?, ?, ?, '2026-06-01T00:00:00Z')",
-        (pid, confidence, speculative, deprecated),
+        (pid, confidence, draft, deprecated),
     )
     await db.commit()
 
 
-async def test_procedural_mean_confidence_excludes_speculative(db):
-    # 3 validated @0.8 + 3 speculative @0.0. Naive AVG would be 0.4.
+async def test_procedural_mean_confidence_excludes_draft(db):
+    # 3 validated @0.8 + 3 draft @0.0. Naive AVG would be 0.4.
     for i in range(3):
-        await _seed_proc(db, f"val-{i}", 0.8, speculative=0)
+        await _seed_proc(db, f"val-{i}", 0.8, draft=0)
     for i in range(3):
-        await _seed_proc(db, f"spec-{i}", 0.0, speculative=1)
+        await _seed_proc(db, f"spec-{i}", 0.0, draft=1)
 
     metrics, _ = await _compute_procedural_effectiveness(db, _SINCE, _UNTIL)
     assert metrics["mean_confidence"] == pytest.approx(0.8, abs=1e-3)
@@ -44,21 +44,21 @@ async def test_procedural_mean_confidence_excludes_speculative(db):
     assert metrics["total_procedures"] == 6
 
 
-async def test_system_composite_procedure_signal_excludes_speculative(db):
+async def test_system_composite_procedure_signal_excludes_draft(db):
     for i in range(3):
-        await _seed_proc(db, f"val-{i}", 0.8, speculative=0)
+        await _seed_proc(db, f"val-{i}", 0.8, draft=0)
     for i in range(3):
-        await _seed_proc(db, f"spec-{i}", 0.0, speculative=1)
+        await _seed_proc(db, f"spec-{i}", 0.0, draft=1)
 
     metrics, _ = await _compute_system_composite(db, _SINCE, _UNTIL)
     assert metrics["procedure_mean_confidence"] == pytest.approx(0.8, abs=1e-3)
 
 
-async def test_all_speculative_yields_null_mean_not_zero(db):
-    # With only speculative rows, the validated-mean is undefined → None (not 0),
+async def test_all_draft_yields_null_mean_not_zero(db):
+    # With only draft rows, the validated-mean is undefined → None (not 0),
     # so the composite drops the signal rather than reporting a false 0.0.
     for i in range(3):
-        await _seed_proc(db, f"spec-{i}", 0.0, speculative=1)
+        await _seed_proc(db, f"spec-{i}", 0.0, draft=1)
 
     proc, _ = await _compute_procedural_effectiveness(db, _SINCE, _UNTIL)
     assert proc["mean_confidence"] is None
@@ -69,9 +69,9 @@ async def test_all_speculative_yields_null_mean_not_zero(db):
 
 
 async def test_deprecated_still_excluded(db):
-    # Regression guard: deprecated rows remain excluded regardless of speculative.
-    await _seed_proc(db, "val", 0.8, speculative=0)
-    await _seed_proc(db, "dep", 0.9, speculative=0, deprecated=1)
+    # Regression guard: deprecated rows remain excluded regardless of draft.
+    await _seed_proc(db, "val", 0.8, draft=0)
+    await _seed_proc(db, "dep", 0.9, draft=0, deprecated=1)
     metrics, _ = await _compute_procedural_effectiveness(db, _SINCE, _UNTIL)
     assert metrics["mean_confidence"] == pytest.approx(0.8, abs=1e-3)
     assert metrics["total_procedures"] == 1

--- a/tests/test_learning/test_extractor.py
+++ b/tests/test_learning/test_extractor.py
@@ -271,7 +271,7 @@ async def test_cross_type_duplicate_blocked(db):
         steps=["run yt-dlp"],
         tools_used=["Bash"],
         context_tags=["youtube", "video", "transcript"],
-        speculative=0,
+        draft=0,
         confidence=0.7,
     )
 
@@ -308,7 +308,7 @@ async def test_cross_type_check_allows_different_principles(db):
         steps=["run yt-dlp"],
         tools_used=["Bash"],
         context_tags=["youtube", "video", "transcript"],
-        speculative=0,
+        draft=0,
         confidence=0.7,
     )
 
@@ -352,14 +352,14 @@ async def test_auto_extracted_starts_at_l3_with_baseline_confidence(db):
     assert proc_id is not None
 
     cursor = await db.execute(
-        "SELECT activation_tier, confidence, speculative FROM procedural_memory WHERE id = ?",
+        "SELECT activation_tier, confidence, draft FROM procedural_memory WHERE id = ?",
         (proc_id,),
     )
     rows = await cursor.fetchall()
     assert len(rows) == 1
     assert rows[0][0] == "LIBRARY"
     assert rows[0][1] == pytest.approx(0.5)
-    assert rows[0][2] == 1  # still marked speculative (provenance only)
+    assert rows[0][2] == 1  # still marked draft (provenance only)
 
 
 # ─── FM5: Fail-open rate limiter ────────────────────────────────────────────

--- a/tests/test_learning/test_procedural.py
+++ b/tests/test_learning/test_procedural.py
@@ -299,17 +299,17 @@ async def test_store_procedure_explicit_teach_defaults(db):
         tools_used=["browser_navigate", "browser_fill", "browser_click"],
         context_tags=["discourse", "forum", "registration"],
         activation_tier="LIBRARY",
-        speculative=0,
+        draft=0,
         success_count=1,
         confidence=2 / 3,
     )
     cursor = await db.execute(
-        "SELECT speculative, success_count, confidence, activation_tier "
+        "SELECT draft, success_count, confidence, activation_tier "
         "FROM procedural_memory WHERE id = ?",
         (pid,),
     )
     row = await cursor.fetchone()
-    assert row[0] == 0  # speculative
+    assert row[0] == 0  # draft
     assert row[1] == 1  # success_count
     assert abs(row[2] - 2 / 3) < 1e-9  # Laplace for 1 success
     assert row[3] == "LIBRARY"  # activation_tier
@@ -320,7 +320,7 @@ async def test_find_relevant_surfaces_explicit_teach(db):
     """An explicit-teach procedure must be visible to procedure_recall.
 
     Regression test for the bug where procedure_store wrote
-    speculative=1, confidence=0.0 — making the procedure invisible to
+    draft=1, confidence=0.0 — making the procedure invisible to
     find_relevant's confidence>=0.3 filter.
     """
     await store_procedure(
@@ -331,7 +331,7 @@ async def test_find_relevant_surfaces_explicit_teach(db):
         tools_used=["browser_navigate"],
         context_tags=["discourse", "forum", "registration"],
         activation_tier="LIBRARY",
-        speculative=0,
+        draft=0,
         success_count=1,
         confidence=2 / 3,
     )
@@ -341,11 +341,11 @@ async def test_find_relevant_surfaces_explicit_teach(db):
 
 
 @pytest.mark.asyncio
-async def test_find_relevant_still_hides_speculative_extractor_writes(db):
-    """Auto-extracted procedures (speculative=1, confidence=0.0) stay hidden.
+async def test_find_relevant_still_hides_draft_extractor_writes(db):
+    """Auto-extracted procedures (draft=1, confidence=0.0) stay hidden.
 
     Protects the extractor pipeline from regression — only explicit-teach
-    writes should bypass the speculative quarantine.
+    writes should bypass the draft quarantine.
     """
     await store_procedure(
         db,
@@ -354,7 +354,7 @@ async def test_find_relevant_still_hides_speculative_extractor_writes(db):
         steps=["maybe-do-this"],
         tools_used=["Bash"],
         context_tags=["extracted", "hypothesis"],
-        # extractor defaults: speculative=1, success_count=0, confidence=0.0
+        # extractor defaults: draft=1, success_count=0, confidence=0.0
     )
     matches = await find_relevant(db, ["extracted", "hypothesis"], limit=3)
     assert all(m.task_type != "auto-extracted-task" for m in matches)
@@ -369,7 +369,7 @@ async def test_store_checked_exact_match_upserts(db):
     proc_id = await store_procedure(
         db, task_type="deploy-safety", principle="original",
         steps=["step-a"], tools_used=["Bash"], context_tags=["deploy"],
-        speculative=0, success_count=3, confidence=0.8,
+        draft=0, success_count=3, confidence=0.8,
     )
     result = await store_procedure_checked(
         db, task_type="deploy-safety", principle="updated principle",
@@ -394,12 +394,12 @@ async def test_store_checked_auto_skips_explicit(db):
     proc_id = await store_procedure(
         db, task_type="manual-task", principle="human taught",
         steps=["do-this"], tools_used=["Bash"], context_tags=["manual"],
-        speculative=0, success_count=1, confidence=2 / 3,
+        draft=0, success_count=1, confidence=2 / 3,
     )
     result = await store_procedure_checked(
         db, task_type="manual-task", principle="auto extracted",
         steps=["maybe-this"], tools_used=["Bash"],
-        context_tags=["manual"], speculative=1, confidence=0.0,
+        context_tags=["manual"], draft=1, confidence=0.0,
     )
     assert result.action == "skipped"
     assert proc_id in result.conflicting_ids
@@ -416,7 +416,7 @@ async def test_store_checked_context_overlap_warns(db):
         db, task_type="youtube-fetch", principle="fetch youtube",
         steps=["s1"], tools_used=["WebFetch"],
         context_tags=["youtube", "video", "transcript"],
-        speculative=0, success_count=1, confidence=2 / 3,
+        draft=0, success_count=1, confidence=2 / 3,
     )
     # Jaccard: 3/4 = 0.75 >= 0.7 threshold
     result = await store_procedure_checked(
@@ -507,7 +507,7 @@ async def test_promoter_records_promotion_history(db):
     proc_id = await store_procedure(
         db, task_type="promotable", principle="test",
         steps=["s1"], tools_used=["Bash"], context_tags=["test"],
-        speculative=0, success_count=5, confidence=0.78,
+        draft=0, success_count=5, confidence=0.78,
         activation_tier="DORMANT",
     )
     # Mock regenerate to avoid clobbering the filesystem trigger cache

--- a/tests/test_learning/test_promoter.py
+++ b/tests/test_learning/test_promoter.py
@@ -132,7 +132,7 @@ def test_compute_tier_core_with_drift_stays_at_core():
 
 
 def test_compute_tier_draft_procedure_can_promote_to_library():
-    """Speculative procedures can promote to LIBRARY if they meet thresholds."""
+    """Draft procedures can promote to LIBRARY if they meet thresholds."""
     row = {
         "success_count": 5, "confidence": 0.7, "draft": 1,
         "tool_trigger": None, "activation_tier": "DORMANT",
@@ -313,7 +313,7 @@ async def test_reads_promote_draft_to_library_but_stay_draft(db):
     )
     row = await cursor.fetchone()
     assert row[0] == "LIBRARY"
-    assert row[1] == 1  # still draft — reads don't de-speculate
+    assert row[1] == 1  # still draft — reads don't clear the draft flag
 
 
 @pytest.mark.asyncio
@@ -364,9 +364,9 @@ async def test_reads_never_promote_to_core(db):
 
 
 @pytest.mark.asyncio
-async def test_despeculate_on_real_success(db):
+async def test_draft_cleared_on_real_success(db):
     """A draft procedure with ≥1 real success and no failures graduates
-    to validated (draft=0) — closing the de-speculation gap."""
+    to validated (draft=0) — closing the draft-clearing gap."""
     await _insert(
         db, id="grad-1", task_type="t",
         success_count=1, failure_count=0, confidence=2 / 3,
@@ -406,8 +406,8 @@ async def test_reads_do_not_promote_a_failing_procedure(db):
 
 
 @pytest.mark.asyncio
-async def test_despeculate_blocked_by_failure(db):
-    """A failure blocks de-speculation even with real successes."""
+async def test_draft_clearing_blocked_by_failure(db):
+    """A failure blocks draft clearing even with real successes."""
     await _insert(
         db, id="grad-fail", task_type="t",
         success_count=2, failure_count=1, confidence=0.6,

--- a/tests/test_learning/test_promoter.py
+++ b/tests/test_learning/test_promoter.py
@@ -35,7 +35,7 @@ def _isolate_trigger_cache_path(tmp_path, monkeypatch):
 async def _insert(db, *, id: str, task_type: str, **fields) -> None:
     """Insert a procedural_memory row with explicit field overrides.
 
-    Defaults to a fresh DORMANT speculative procedure unless overridden.
+    Defaults to a fresh DORMANT draft procedure unless overridden.
     """
     defaults = dict(
         person_id=None,
@@ -46,7 +46,7 @@ async def _insert(db, *, id: str, task_type: str, **fields) -> None:
         success_count=0,
         failure_count=0,
         confidence=0.0,
-        speculative=1,
+        draft=1,
         activation_tier="DORMANT",
         tool_trigger=None,
         failure_modes=None,
@@ -72,7 +72,7 @@ async def _insert(db, *, id: str, task_type: str, **fields) -> None:
 
 def test_compute_tier_promotes_to_library():
     row = {
-        "success_count": 3, "confidence": 0.65, "speculative": 0,
+        "success_count": 3, "confidence": 0.65, "draft": 0,
         "tool_trigger": None, "activation_tier": "DORMANT",
     }
     assert _compute_tier(row) == "LIBRARY"
@@ -80,7 +80,7 @@ def test_compute_tier_promotes_to_library():
 
 def test_compute_tier_promotes_to_advisory():
     row = {
-        "success_count": 5, "confidence": 0.78, "speculative": 0,
+        "success_count": 5, "confidence": 0.78, "draft": 0,
         "tool_trigger": None, "activation_tier": "DORMANT",
     }
     assert _compute_tier(row) == "ADVISORY"
@@ -88,7 +88,7 @@ def test_compute_tier_promotes_to_advisory():
 
 def test_compute_tier_promotes_to_core_with_trigger():
     row = {
-        "success_count": 8, "confidence": 0.86, "speculative": 0,
+        "success_count": 8, "confidence": 0.86, "draft": 0,
         "tool_trigger": ["Bash"], "activation_tier": "DORMANT",
     }
     assert _compute_tier(row) == "CORE"
@@ -97,7 +97,7 @@ def test_compute_tier_promotes_to_core_with_trigger():
 def test_compute_tier_no_core_without_trigger():
     """CORE requires tool_trigger; without it, fall back to ADVISORY."""
     row = {
-        "success_count": 8, "confidence": 0.86, "speculative": 0,
+        "success_count": 8, "confidence": 0.86, "draft": 0,
         "tool_trigger": None, "activation_tier": "DORMANT",
     }
     assert _compute_tier(row) == "ADVISORY"
@@ -110,7 +110,7 @@ def test_compute_tier_explicit_teach_stays_at_library():
     through to DORMANT — it preserves the explicitly-stored tier.
     """
     row = {
-        "success_count": 1, "confidence": 2 / 3, "speculative": 0,
+        "success_count": 1, "confidence": 2 / 3, "draft": 0,
         "tool_trigger": None, "activation_tier": "LIBRARY",
     }
     assert _compute_tier(row) == "LIBRARY"
@@ -124,20 +124,20 @@ def test_compute_tier_core_with_drift_stays_at_core():
     or quarantine can demote — never tier drift.
     """
     row = {
-        "success_count": 9, "confidence": 0.83, "speculative": 0,
+        "success_count": 9, "confidence": 0.83, "draft": 0,
         "tool_trigger": ["Bash"], "activation_tier": "CORE",
     }
     # CORE fails (conf<0.85), ADVISORY matches (s>=5, conf>=0.75) — but we hold CORE.
     assert _compute_tier(row) == "CORE"
 
 
-def test_compute_tier_speculative_procedure_can_promote_to_library():
+def test_compute_tier_draft_procedure_can_promote_to_library():
     """Speculative procedures can promote to LIBRARY if they meet thresholds."""
     row = {
-        "success_count": 5, "confidence": 0.7, "speculative": 1,
+        "success_count": 5, "confidence": 0.7, "draft": 1,
         "tool_trigger": None, "activation_tier": "DORMANT",
     }
-    # speculative flag is provenance metadata, not a promotion gate.
+    # draft flag is provenance metadata, not a promotion gate.
     assert _compute_tier(row) == "LIBRARY"
 
 
@@ -172,7 +172,7 @@ async def test_promote_and_demote_does_not_demote_explicit_teach(db):
     await _insert(
         db, id="explicit-1", task_type="user-teach",
         success_count=1, failure_count=0, confidence=2 / 3,
-        speculative=0, activation_tier="LIBRARY",
+        draft=0, activation_tier="LIBRARY",
     )
     result = await promote_and_demote(db)
     assert result["demotions"] == 0
@@ -191,7 +191,7 @@ async def test_promote_and_demote_promotes_on_thresholds(db):
     await _insert(
         db, id="earned-1", task_type="t",
         success_count=5, failure_count=0, confidence=0.78,
-        speculative=0, activation_tier="DORMANT",
+        draft=0, activation_tier="DORMANT",
     )
     result = await promote_and_demote(db)
     assert result["promotions"] == 1
@@ -210,7 +210,7 @@ async def test_promote_and_demote_demotes_on_failure_evidence(db):
     await _insert(
         db, id="failing-1", task_type="t",
         success_count=1, failure_count=4, confidence=0.4,
-        speculative=0, activation_tier="LIBRARY",
+        draft=0, activation_tier="LIBRARY",
         failure_modes=json.dumps([
             {"description": "timeout", "conditions": "timeout",
              "times_hit": 3, "transient": False},
@@ -233,7 +233,7 @@ async def test_promote_and_demote_quarantines_low_confidence(db):
     await _insert(
         db, id="bad-1", task_type="t",
         success_count=1, failure_count=10, confidence=0.15,
-        speculative=0, activation_tier="LIBRARY",
+        draft=0, activation_tier="LIBRARY",
     )
     result = await promote_and_demote(db)
     assert result["quarantined"] == 1
@@ -252,7 +252,7 @@ async def test_promote_and_demote_does_not_metric_demote_core(db):
     await _insert(
         db, id="drifty-1", task_type="t",
         success_count=9, failure_count=2, confidence=0.83,
-        speculative=0, activation_tier="CORE",
+        draft=0, activation_tier="CORE",
         tool_trigger=json.dumps(["Bash"]),
     )
     result = await promote_and_demote(db)
@@ -297,23 +297,23 @@ def test_read_eligible_tier_below_threshold_is_dormant():
 
 
 @pytest.mark.asyncio
-async def test_reads_promote_speculative_to_library_but_stay_speculative(db):
+async def test_reads_promote_draft_to_library_but_stay_draft(db):
     """A heavily-read draft (no real success) promotes to LIBRARY on effective
-    metrics, but stays speculative (de-spec needs a real success)."""
+    metrics, but stays draft (de-spec needs a real success)."""
     await _insert(
         db, id="read-draft", task_type="t",
         success_count=0, failure_count=0, confidence=0.5,
-        speculative=1, activation_tier="DORMANT", invocation_count=15,  # eff_success=3
+        draft=1, activation_tier="DORMANT", invocation_count=15,  # eff_success=3
     )
     result = await promote_and_demote(db)
     assert result["promotions"] == 1
     cursor = await db.execute(
-        "SELECT activation_tier, speculative FROM procedural_memory WHERE id = ?",
+        "SELECT activation_tier, draft FROM procedural_memory WHERE id = ?",
         ("read-draft",),
     )
     row = await cursor.fetchone()
     assert row[0] == "LIBRARY"
-    assert row[1] == 1  # still speculative — reads don't de-speculate
+    assert row[1] == 1  # still draft — reads don't de-speculate
 
 
 @pytest.mark.asyncio
@@ -322,7 +322,7 @@ async def test_reads_without_real_success_do_not_reach_advisory(db):
     await _insert(
         db, id="read-only", task_type="t",
         success_count=0, failure_count=0, confidence=0.5,
-        speculative=1, activation_tier="LIBRARY", invocation_count=25,  # eff_success=5
+        draft=1, activation_tier="LIBRARY", invocation_count=25,  # eff_success=5
     )
     await promote_and_demote(db)
     cursor = await db.execute(
@@ -337,7 +337,7 @@ async def test_reads_plus_real_success_promote_to_advisory(db):
     await _insert(
         db, id="read-proven", task_type="t",
         success_count=1, failure_count=0, confidence=2 / 3,
-        speculative=0, activation_tier="LIBRARY", invocation_count=20,  # eff_success=5
+        draft=0, activation_tier="LIBRARY", invocation_count=20,  # eff_success=5
     )
     result = await promote_and_demote(db)
     assert result["promotions"] == 1
@@ -353,7 +353,7 @@ async def test_reads_never_promote_to_core(db):
     await _insert(
         db, id="read-heavy", task_type="t",
         success_count=0, failure_count=0, confidence=0.5,
-        speculative=0, activation_tier="ADVISORY", invocation_count=200,
+        draft=0, activation_tier="ADVISORY", invocation_count=200,
         tool_trigger=json.dumps(["Bash"]),
     )
     await promote_and_demote(db)
@@ -365,17 +365,17 @@ async def test_reads_never_promote_to_core(db):
 
 @pytest.mark.asyncio
 async def test_despeculate_on_real_success(db):
-    """A speculative procedure with ≥1 real success and no failures graduates
-    to validated (speculative=0) — closing the de-speculation gap."""
+    """A draft procedure with ≥1 real success and no failures graduates
+    to validated (draft=0) — closing the de-speculation gap."""
     await _insert(
         db, id="grad-1", task_type="t",
         success_count=1, failure_count=0, confidence=2 / 3,
-        speculative=1, activation_tier="LIBRARY",
+        draft=1, activation_tier="LIBRARY",
     )
     result = await promote_and_demote(db)
-    assert result["despeculated"] == 1
+    assert result["drafts_cleared"] == 1
     cursor = await db.execute(
-        "SELECT speculative FROM procedural_memory WHERE id = ?", ("grad-1",),
+        "SELECT draft FROM procedural_memory WHERE id = ?", ("grad-1",),
     )
     assert (await cursor.fetchone())[0] == 0
 
@@ -392,7 +392,7 @@ async def test_reads_do_not_promote_a_failing_procedure(db):
     await _insert(
         db, id="failing-read", task_type="t",
         success_count=1, failure_count=4, confidence=0.333,
-        speculative=0, activation_tier="DORMANT", invocation_count=40,  # eff_success=9
+        draft=0, activation_tier="DORMANT", invocation_count=40,  # eff_success=9
         failure_modes=json.dumps([
             {"description": "x", "conditions": "x", "times_hit": 3},
         ]),
@@ -411,11 +411,11 @@ async def test_despeculate_blocked_by_failure(db):
     await _insert(
         db, id="grad-fail", task_type="t",
         success_count=2, failure_count=1, confidence=0.6,
-        speculative=1, activation_tier="LIBRARY",
+        draft=1, activation_tier="LIBRARY",
     )
     result = await promote_and_demote(db)
-    assert result["despeculated"] == 0
+    assert result["drafts_cleared"] == 0
     cursor = await db.execute(
-        "SELECT speculative FROM procedural_memory WHERE id = ?", ("grad-fail",),
+        "SELECT draft FROM procedural_memory WHERE id = ?", ("grad-fail",),
     )
     assert (await cursor.fetchone())[0] == 1

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -63,7 +63,7 @@ async def test_procedure_recall_registered():
 async def test_procedure_store_recall_roundtrip():
     """End-to-end regression test for the procedure_store→procedure_recall bug.
 
-    Pre-fix: procedure_store wrote speculative=1, success_count=0,
+    Pre-fix: procedure_store wrote draft=1, success_count=0,
     confidence=0.0 → find_relevant filtered it out → procedure_recall
     returned []. This test stores a procedure and verifies it comes back.
     """
@@ -95,12 +95,12 @@ async def test_procedure_store_recall_roundtrip():
 
             # Verify the row landed with explicit-teach defaults.
             cursor = await real_db.execute(
-                "SELECT speculative, success_count, confidence, activation_tier "
+                "SELECT draft, success_count, confidence, activation_tier "
                 "FROM procedural_memory WHERE id = ?",
                 (pid,),
             )
             row = await cursor.fetchone()
-            assert row[0] == 0  # speculative
+            assert row[0] == 0  # draft
             assert row[1] == 1  # success_count
             assert abs(row[2] - 2 / 3) < 1e-9  # Laplace
             assert row[3] == "LIBRARY"  # activation_tier

--- a/tests/test_mcp/test_procedure_recall_ranking.py
+++ b/tests/test_mcp/test_procedure_recall_ranking.py
@@ -45,7 +45,7 @@ async def test_find_relevant_carries_invocation_count(db):
         db, id="m1", task_type="t", principle="p", steps=["s"],
         tools_used=[], context_tags=["alpha"],
         created_at="2026-01-01T00:00:00",
-        confidence=0.6, speculative=0, activation_tier="LIBRARY",
+        confidence=0.6, draft=0, activation_tier="LIBRARY",
     )
     await procedural.record_invocation(db, "m1")
     matches = await find_relevant(db, ["alpha"], min_confidence=0.3, limit=5)


### PR DESCRIPTION
## What

Renames the `procedural_memory.speculative` column to `draft` — and every coupled Python identifier — in **procedure context only**. A procedure's unproven state isn't "speculative" (the term Genesis reserves for observations and hypothesis-claims); it's an untested **draft** destined for real use.

`observations.speculative` and `speculative_claims.speculative` are a genuinely different concept and are **intentionally left unchanged** (user-confirmed vocabulary divergence).

This is the `speculative→draft` half (PR-C) of the procedure-vocabulary cleanup. Tier rename (CORE/ADVISORY/LIBRARY/DORMANT) shipped earlier; a dashboard procedures viewer (PR-D) follows.

## How

`SELECT *` couples the returned row-dict key to the column name, so the column rename **forces** renaming every `row["speculative"]` read and `speculative=` kwarg in lockstep — a miss is a loud `KeyError`/`OperationalError`, never silent.

- **Migration `0037`** — `ALTER TABLE … RENAME COLUMN` + index rename (`idx_procedural_speculative` → `idx_procedural_draft`). Pure rename, no value rewrite; idempotent (skips if already `draft` or base table absent); leaves the sibling tables untouched.
- Renamed across CRUD, extractor, judge, promoter, executor trace, the J9 VALIDATED filter (`draft = 0`), the seed script, and the `procedure_store` MCP tool.
- Internal counter `despeculated` → `drafts_cleared`; architecture docs updated.

## Verification

- **TDD migration test** (5 cases): rename + data preservation, index rename, leaves observations/claims alone, idempotent re-run, base-table-absent skip.
- **Targeted procedure surface**: 234 pass. **Broad regression** (`test_learning/eval/db/mcp`): **1873 passed, 3 skipped**. `ruff` clean.
- **E2E on a real 437-procedure DB copy** applied via the migration runner: `draft` distribution `{0:33, 1:404}` preserved exactly, index renamed, observations/`speculative_claims` columns untouched, idempotent, recorded in `schema_migrations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)