### PR TITLE
fix(outreach): stop the self-send follow-up email spam loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   even though nothing had actually regressed. The score now reflects only validated
   procedures. Genesis also caps how many drafts a single session can create, so the
   procedure store stops accumulating dead weight.
+- **Genesis no longer floods its own approvals with follow-up emails addressed to itself.**
+  A follow-up drafted in a background session could lose its thread (and therefore its
+  recipient) on the way to the outreach queue, then fall back to Genesis's own email address.
+  The capability gate correctly held each one for approval, but because the queue kept
+  retrying, a new held "email to myself" piled up every few minutes. Genesis now keeps the
+  thread recipient with the queued message, never sends an email to its own address, and
+  treats a held or undeliverable message as resolved instead of retrying it forever. A
+  message that can never be delivered is now dropped after a day rather than looping.
 - **Updates no longer abort when a schema migration actually succeeded** — if the
   database was busy during an update (for example a background task writing at the same
   time), a migration could commit successfully yet still surface a transient "database

--- a/src/genesis/autonomy/email_gate_watcher.py
+++ b/src/genesis/autonomy/email_gate_watcher.py
@@ -99,8 +99,12 @@ async def drain_pending_email_sends(rt: object) -> int:
                 # The pipeline terminally SKIPPED this approved send (self-
                 # addressed / no recipient). It is not deliverable and not an
                 # error — mark the hold rejected so it can't busy-loop every
-                # cycle. No correction (the skip is a guard, not owner intent).
+                # cycle, and consume the approval so it doesn't linger as a ghost
+                # approved/unconsumed row. No correction (a guard, not owner intent).
                 if await pes.mark_rejected(db, row["id"], rejected_at=now):
+                    await approval_crud.mark_consumed(
+                        db, row["request_id"], consumed_at=now,
+                    )
                     resolved += 1
                 logger.warning(
                     "Held email %s skipped by pipeline (IGNORED) — marked terminal",

--- a/src/genesis/autonomy/email_gate_watcher.py
+++ b/src/genesis/autonomy/email_gate_watcher.py
@@ -95,6 +95,17 @@ async def drain_pending_email_sends(rt: object) -> int:
                     "Resolved held email %s → sent to %s",
                     row["id"], row["validated_recipient"],
                 )
+            elif result.status == OutreachStatus.IGNORED:
+                # The pipeline terminally SKIPPED this approved send (self-
+                # addressed / no recipient). It is not deliverable and not an
+                # error — mark the hold rejected so it can't busy-loop every
+                # cycle. No correction (the skip is a guard, not owner intent).
+                if await pes.mark_rejected(db, row["id"], rejected_at=now):
+                    resolved += 1
+                logger.warning(
+                    "Held email %s skipped by pipeline (IGNORED) — marked terminal",
+                    row["id"],
+                )
             else:
                 logger.warning(
                     "Held email %s delivery failed (%s) — retry next cycle",

--- a/src/genesis/channels/email_adapter.py
+++ b/src/genesis/channels/email_adapter.py
@@ -39,6 +39,13 @@ class EmailAdapter(ChannelAdapter):
         self._from_address = from_address
         self._from_name = from_name
 
+    @property
+    def from_address(self) -> str:
+        """The configured sender address — the pipeline's self-send guard
+        compares delivery recipients against this to suppress emails the agent
+        would otherwise address to itself."""
+        return self._from_address
+
     async def start(self) -> None:
         """No-op — SMTP is stateless per-send."""
 

--- a/src/genesis/db/crud/pending_outreach.py
+++ b/src/genesis/db/crud/pending_outreach.py
@@ -18,17 +18,27 @@ async def enqueue(
     channel: str = "telegram",
     urgency: str = "low",
     deliver_after: str | None = None,
+    thread_id: str | None = None,
+    validated_recipient: str | None = None,
 ) -> str:
-    """Queue a message for bridge delivery. Returns the pending ID."""
+    """Queue a message for bridge delivery. Returns the pending ID.
+
+    ``thread_id`` / ``validated_recipient`` carry the resolved email thread and
+    recipient through the queue so the genesis-server drain can rebuild a
+    properly-routed request — without them a queued email defaulted to the
+    agent's own address (a self-send loop).
+    """
     from datetime import UTC, datetime
 
     pending_id = str(uuid.uuid4())
     now = datetime.now(UTC).isoformat()
     await db.execute(
         """INSERT INTO pending_outreach
-           (id, message, category, channel, urgency, deliver_after, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?)""",
-        (pending_id, message, category, channel, urgency, deliver_after, now),
+           (id, message, category, channel, urgency, deliver_after, created_at,
+            thread_id, validated_recipient)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (pending_id, message, category, channel, urgency, deliver_after, now,
+         thread_id, validated_recipient),
     )
     await db.commit()
     return pending_id
@@ -74,15 +84,17 @@ async def ensure_table(db: aiosqlite.Connection) -> None:
     """
     await db.execute("""
         CREATE TABLE IF NOT EXISTS pending_outreach (
-            id              TEXT PRIMARY KEY,
-            message         TEXT NOT NULL,
-            category        TEXT NOT NULL,
-            channel         TEXT NOT NULL DEFAULT 'telegram',
-            urgency         TEXT NOT NULL DEFAULT 'low',
-            deliver_after   TEXT,
-            created_at      TEXT NOT NULL,
-            delivered       INTEGER NOT NULL DEFAULT 0,
-            delivered_at    TEXT
+            id                  TEXT PRIMARY KEY,
+            message             TEXT NOT NULL,
+            category            TEXT NOT NULL,
+            channel             TEXT NOT NULL DEFAULT 'telegram',
+            urgency             TEXT NOT NULL DEFAULT 'low',
+            deliver_after       TEXT,
+            created_at          TEXT NOT NULL,
+            delivered           INTEGER NOT NULL DEFAULT 0,
+            delivered_at        TEXT,
+            thread_id           TEXT,
+            validated_recipient TEXT
         )
     """)
     await db.commit()

--- a/src/genesis/db/migrations/0038_pending_outreach_thread_recipient.py
+++ b/src/genesis/db/migrations/0038_pending_outreach_thread_recipient.py
@@ -1,0 +1,36 @@
+"""Add ``thread_id`` + ``validated_recipient`` to ``pending_outreach``.
+
+Subprocess (``pipeline=None``) ``outreach_send`` calls fall back to enqueueing
+into ``pending_outreach``; the fallback dropped the thread id and resolved
+recipient, so a queued email follow-up arrived recipient-less and the
+genesis-server drain defaulted it to the agent's own address — a self-send spam
+loop. Carrying both columns lets the drain reconstruct a properly-routed
+``OutreachRequest`` (recipient + reply-vs-cold classification).
+
+Additive, nullable, no backfill (old rows are telegram queue entries or the
+now-cleared self-send rows). Idempotent via ``PRAGMA table_info``. Self-contained
+per migration convention — no genesis imports.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name='pending_outreach'"
+    )
+    if not await cursor.fetchone():
+        return  # bare DB (runner unit tests) — nothing to alter
+
+    col_cursor = await db.execute("PRAGMA table_info(pending_outreach)")
+    cols = {row[1] for row in await col_cursor.fetchall()}
+
+    if "thread_id" not in cols:
+        await db.execute("ALTER TABLE pending_outreach ADD COLUMN thread_id TEXT")
+    if "validated_recipient" not in cols:
+        await db.execute(
+            "ALTER TABLE pending_outreach ADD COLUMN validated_recipient TEXT"
+        )

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -198,15 +198,17 @@ TABLES = {
     """,
     "pending_outreach": """
         CREATE TABLE IF NOT EXISTS pending_outreach (
-            id              TEXT PRIMARY KEY,
-            message         TEXT NOT NULL,
-            category        TEXT NOT NULL,
-            channel         TEXT NOT NULL DEFAULT 'telegram',
-            urgency         TEXT NOT NULL DEFAULT 'low',
-            deliver_after   TEXT,
-            created_at      TEXT NOT NULL,
-            delivered       INTEGER NOT NULL DEFAULT 0,
-            delivered_at    TEXT
+            id                  TEXT PRIMARY KEY,
+            message             TEXT NOT NULL,
+            category            TEXT NOT NULL,
+            channel             TEXT NOT NULL DEFAULT 'telegram',
+            urgency             TEXT NOT NULL DEFAULT 'low',
+            deliver_after       TEXT,
+            created_at          TEXT NOT NULL,
+            delivered           INTEGER NOT NULL DEFAULT 0,
+            delivered_at        TEXT,
+            thread_id           TEXT,
+            validated_recipient TEXT
         )
     """,
     "brainstorm_log": """

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -79,7 +79,9 @@ async def outreach_send(
             logger.warning("Thread %s not found for recipient lookup", thread_id)
     elif channel == "email" and not thread_id:
         logger.warning(
-            "outreach_send email without thread_id — no recipient resolved"
+            "outreach_send email without thread_id — recipient will come from "
+            "OUTREACH_RECIPIENT_EMAIL if configured, else the send is dropped "
+            "(IGNORED) by the pipeline self-send guard"
         )
 
     if not _pipeline:

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -62,6 +62,26 @@ async def outreach_send(
     The thread_id maps to a registered email thread whose recipient is
     used for delivery.
     """
+    # Resolve the per-thread recipient for email sends BEFORE the
+    # pipeline/fallback split — so a QUEUED follow-up (pipeline=None subprocess)
+    # carries its thread recipient through pending_outreach instead of arriving
+    # recipient-less and self-sending to the agent's own address on drain.
+    validated_recipient: str | None = None
+    if thread_id and channel == "email" and _db is not None:
+        from genesis.db.crud import email_threads
+        thread = await email_threads.get_thread(_db, thread_id)
+        if thread:
+            validated_recipient = thread.get("recipient")
+            logger.info(
+                "Thread %s resolved recipient: %s", thread_id, validated_recipient,
+            )
+        else:
+            logger.warning("Thread %s not found for recipient lookup", thread_id)
+    elif channel == "email" and not thread_id:
+        logger.warning(
+            "outreach_send email without thread_id — no recipient resolved"
+        )
+
     if not _pipeline:
         # Validate category before enqueuing (same check the pipeline path does)
         from genesis.outreach.types import OutreachCategory
@@ -86,6 +106,8 @@ async def outreach_send(
                 channel=channel,
                 urgency=urgency,
                 deliver_after=preferred_timing,
+                thread_id=thread_id,
+                validated_recipient=validated_recipient,
             )
             return json.dumps({
                 "status": "queued",
@@ -104,24 +126,7 @@ async def outreach_send(
     except ValueError:
         return f"Error: invalid category '{category}'"
 
-    # Resolve per-thread recipient for email sends
-    validated_recipient: str | None = None
-    if channel == "email" and not thread_id:
-        logger.warning(
-            "outreach_send email without thread_id — using pipeline default recipient"
-        )
-    if thread_id and channel == "email" and _db is not None:
-        from genesis.db.crud import email_threads
-        thread = await email_threads.get_thread(_db, thread_id)
-        if thread:
-            validated_recipient = thread.get("recipient")
-            logger.info(
-                "Thread %s resolved recipient: %s",
-                thread_id, validated_recipient,
-            )
-        else:
-            logger.warning("Thread %s not found for recipient lookup", thread_id)
-
+    # validated_recipient was resolved above (shared with the fallback path).
     req = OutreachRequest(
         category=cat,
         topic=message[:100],

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -377,6 +377,37 @@ class OutreachPipeline:
     ) -> OutreachResult:
         adapter = self._channels.get(channel)
         recipient = request.validated_recipient or self._recipients.get(channel, "")
+
+        # Email self-send / no-recipient terminal skip (WS-8 spam-loop fix). A
+        # send to the agent's OWN address, or an email with no resolved
+        # recipient, is never valid outreach — drop it terminally (IGNORED)
+        # here, BEFORE the no-recipient defer below (which would retry-loop in
+        # the deferred-work queue) and BEFORE the gate below (which would HELD
+        # it and flood approvals). Fires regardless of gate_cleared: an approved
+        # self-send must still never be sent.
+        if channel == "email":
+            self_addr = getattr(self._channels.get("email"), "from_address", None)
+            if not recipient:
+                logger.warning(
+                    "Outreach %s: email has no resolved recipient — "
+                    "skipping (IGNORED)", outreach_id,
+                )
+                return OutreachResult(
+                    outreach_id=outreach_id, status=OutreachStatus.IGNORED,
+                    channel=channel, message_content=formatted.text,
+                    error="no recipient resolved",
+                )
+            if self_addr and recipient == self_addr:
+                logger.warning(
+                    "Outreach %s: email recipient is the agent's own address "
+                    "(%s) — skipping self-send (IGNORED)", outreach_id, recipient,
+                )
+                return OutreachResult(
+                    outreach_id=outreach_id, status=OutreachStatus.IGNORED,
+                    channel=channel, message_content=formatted.text,
+                    error="self-addressed email suppressed",
+                )
+
         if not adapter or not recipient:
             logger.warning("No adapter/recipient for channel %s — deferring", channel)
             await self._defer(

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -193,6 +193,7 @@ class OutreachPipeline:
                 channel="",
                 message_content="",
                 governance_result=gov,
+                error=gov.reason,  # surface the reason so retry logs aren't blank
             )
 
         if request.category == OutreachCategory.SURPLUS and self._fresh_eyes:

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -605,7 +605,13 @@ class OutreachScheduler:
                     created_at = row.get("created_at")
                     if created_at:
                         try:
-                            age = datetime.now(UTC) - datetime.fromisoformat(created_at)
+                            parsed = datetime.fromisoformat(created_at)
+                            if parsed.tzinfo is None:
+                                # A naive timestamp must not silently bypass the
+                                # cap (subtracting naive from aware raises) — treat
+                                # it as UTC, which is how created_at is written.
+                                parsed = parsed.replace(tzinfo=UTC)
+                            age = datetime.now(UTC) - parsed
                         except (ValueError, TypeError):
                             age = None
                         if age is not None and age > timedelta(hours=24):

--- a/src/genesis/outreach/scheduler.py
+++ b/src/genesis/outreach/scheduler.py
@@ -587,7 +587,7 @@ class OutreachScheduler:
         if self._is_paused():
             return
         try:
-            from datetime import UTC, datetime
+            from datetime import UTC, datetime, timedelta
 
             from genesis.db.crud import pending_outreach
 
@@ -599,6 +599,27 @@ class OutreachScheduler:
 
             for row in rows:
                 try:
+                    # Retry-age cap: a row that never reaches a terminal status
+                    # (e.g. a recipient-less email perpetually rejected) must not
+                    # churn forever — that loop locked the DB. Drop it after 24h.
+                    created_at = row.get("created_at")
+                    if created_at:
+                        try:
+                            age = datetime.now(UTC) - datetime.fromisoformat(created_at)
+                        except (ValueError, TypeError):
+                            age = None
+                        if age is not None and age > timedelta(hours=24):
+                            await pending_outreach.mark_delivered(
+                                self._db, row["id"],
+                                delivered_at=datetime.now(UTC).isoformat(),
+                            )
+                            logger.warning(
+                                "Pending outreach %s aged out (%.1fh, never "
+                                "delivered) — dropping",
+                                row["id"], age.total_seconds() / 3600,
+                            )
+                            continue
+
                     # Validate category — map known non-enum values, fall
                     # back to DIGEST (not ALERT) for truly unknown ones.
                     _CATEGORY_ALIASES = {
@@ -629,23 +650,32 @@ class OutreachScheduler:
                         salience_score=0.7,
                         signal_type="pending_queue",
                         channel=channel,
+                        thread_id=row.get("thread_id"),
+                        validated_recipient=row.get("validated_recipient"),
                     )
                     if row.get("urgency") == "high":
                         result = await self._pipeline.submit_urgent(req)
                     else:
                         result = await self._pipeline.submit(req)
 
-                    # Only mark delivered on actual success
+                    # Terminal dispositions stop the retry. DELIVERED/ENGAGED =
+                    # sent; HELD = handed off to the gate's approval queue (the
+                    # watcher owns its lifecycle — re-submitting just re-holds);
+                    # IGNORED = the pipeline deliberately dropped it (self-send /
+                    # no recipient). Anything else (REJECTED via quiet_hours,
+                    # FAILED) is transient and retried next cycle.
                     if result.status in (
                         OutreachStatus.DELIVERED,
                         OutreachStatus.ENGAGED,
+                        OutreachStatus.HELD,
+                        OutreachStatus.IGNORED,
                     ):
                         delivered_at = datetime.now(UTC).isoformat()
                         await pending_outreach.mark_delivered(
                             self._db, row["id"], delivered_at=delivered_at,
                         )
                         logger.info(
-                            "Drained pending outreach %s: %s",
+                            "Drained pending outreach %s: %s (terminal)",
                             row["id"], result.status.value,
                         )
                     else:

--- a/src/genesis/runtime/init/outreach.py
+++ b/src/genesis/runtime/init/outreach.py
@@ -64,8 +64,12 @@ async def init(rt: GenesisRuntime) -> None:
                 password=gmail_pass,
                 from_address=gmail_addr,
             )
-            if "email" not in recipients:
-                recipients["email"] = gmail_addr
+            # NOTE: do NOT default recipients["email"] to the agent's own
+            # address. A recipient-less email used to fall back to gmail_addr →
+            # the pipeline self-addressed it → the WS-8 gate HELD it → a self-send
+            # spam loop. Email recipients now come only from the thread (replies)
+            # or an explicit OUTREACH_RECIPIENT_EMAIL; a send with no recipient is
+            # terminally skipped in _deliver (IGNORED).
             logger.info("Email channel adapter registered (from: %s)", gmail_addr)
 
         # Wire Discord webhook adapter if webhook URL exists

--- a/tests/test_autonomy/test_email_gate_watcher.py
+++ b/tests/test_autonomy/test_email_gate_watcher.py
@@ -155,4 +155,6 @@ async def test_approved_but_pipeline_ignores_is_terminal(db):
     assert await drain_pending_email_sends(_FakeRt(db, pipe)) == 1
     assert pipe.calls == [("p1", "hi")]  # attempted (deliver_approved called)
     assert (await pes.get_by_id(db, "p1"))["status"] == "rejected"  # terminal
-    assert (await ac.get_by_id(db, rid))["consumed_at"] is None  # not a real send
+    # The approval lifecycle is closed (consumed) so it doesn't linger as a
+    # ghost approved/unconsumed row in operator views.
+    assert (await ac.get_by_id(db, rid))["consumed_at"] is not None

--- a/tests/test_autonomy/test_email_gate_watcher.py
+++ b/tests/test_autonomy/test_email_gate_watcher.py
@@ -141,3 +141,18 @@ async def test_approved_but_delivery_fails_stays_held(db):
     assert pipe.calls == [("p1", "hi")]  # attempted
     assert (await pes.get_by_id(db, "p1"))["status"] == "held"  # retry next cycle
     assert (await ac.get_by_id(db, rid))["consumed_at"] is None  # not consumed
+
+
+@pytest.mark.asyncio
+async def test_approved_but_pipeline_ignores_is_terminal(db):
+    """If the pipeline terminally skips an approved send (IGNORED — e.g. a
+    self-addressed hold the new guard drops), the watcher must mark it rejected,
+    NOT leave it held to busy-loop every cycle."""
+    rid = await _approval(db, status="approved")
+    await _hold(db, pid="p1", rid=rid)
+    pipe = _FakePipeline(OutreachStatus.IGNORED)
+
+    assert await drain_pending_email_sends(_FakeRt(db, pipe)) == 1
+    assert pipe.calls == [("p1", "hi")]  # attempted (deliver_approved called)
+    assert (await pes.get_by_id(db, "p1"))["status"] == "rejected"  # terminal
+    assert (await ac.get_by_id(db, rid))["consumed_at"] is None  # not a real send

--- a/tests/test_db/test_migration_0038_pending_outreach_thread_recipient.py
+++ b/tests/test_db/test_migration_0038_pending_outreach_thread_recipient.py
@@ -1,0 +1,103 @@
+"""Migration 0038 — add ``thread_id`` + ``validated_recipient`` to pending_outreach.
+
+A subprocess (``pipeline=None``) ``outreach_send`` falls back to enqueueing into
+``pending_outreach``; before this the fallback dropped both the thread id and the
+resolved recipient, so a queued email follow-up arrived recipient-less and the
+drain defaulted it to the agent's own address (a self-send spam loop). These two
+nullable columns let the drain reconstruct a properly-routed request.
+
+The test builds the *pre-migration* schema explicitly (no new columns) so it
+exercises the real ``ALTER TABLE … ADD COLUMN`` regardless of current DDL.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M38 = importlib.import_module(
+    "genesis.db.migrations.0038_pending_outreach_thread_recipient"
+)
+
+
+async def _columns(db: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await db.execute(f"PRAGMA table_info({table})")
+    return {row[1] for row in await cur.fetchall()}
+
+
+async def _build_pre_state(conn: aiosqlite.Connection) -> None:
+    """pending_outreach as it existed *before* 0038 — no thread_id /
+    validated_recipient columns."""
+    await conn.execute(
+        """
+        CREATE TABLE pending_outreach (
+            id              TEXT PRIMARY KEY,
+            message         TEXT NOT NULL,
+            category        TEXT NOT NULL,
+            channel         TEXT NOT NULL DEFAULT 'telegram',
+            urgency         TEXT NOT NULL DEFAULT 'low',
+            deliver_after   TEXT,
+            created_at      TEXT NOT NULL,
+            delivered       INTEGER NOT NULL DEFAULT 0,
+            delivered_at    TEXT
+        )
+        """
+    )
+    await conn.commit()
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await _build_pre_state(conn)
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_adds_both_columns(db):
+    await M38.up(db)
+    cols = await _columns(db, "pending_outreach")
+    assert "thread_id" in cols
+    assert "validated_recipient" in cols
+
+
+@pytest.mark.asyncio
+async def test_preserves_existing_rows(db):
+    await db.execute(
+        "INSERT INTO pending_outreach (id, message, category, created_at) "
+        "VALUES ('r1', 'hello', 'notification', '2026-06-24T00:00:00+00:00')"
+    )
+    await db.commit()
+
+    await M38.up(db)
+
+    cur = await db.execute(
+        "SELECT message, thread_id, validated_recipient FROM pending_outreach "
+        "WHERE id='r1'"
+    )
+    row = await cur.fetchone()
+    assert row["message"] == "hello"
+    assert row["thread_id"] is None          # new column, no backfill
+    assert row["validated_recipient"] is None
+
+
+@pytest.mark.asyncio
+async def test_idempotent_on_rerun(db):
+    await M38.up(db)
+    await M38.up(db)  # must not raise "duplicate column name"
+    cols = await _columns(db, "pending_outreach")
+    assert {"thread_id", "validated_recipient"} <= cols
+
+
+@pytest.mark.asyncio
+async def test_skips_when_base_table_absent(tmp_path):
+    """The runner applies migrations against a bare DB; 0038 must skip cleanly
+    rather than fail on a missing table."""
+    async with aiosqlite.connect(str(tmp_path / "bare.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute("CREATE TABLE schema_migrations (version TEXT)")
+        await conn.commit()
+        await M38.up(conn)  # must not raise (no such table: pending_outreach)

--- a/tests/test_db/test_pending_outreach.py
+++ b/tests/test_db/test_pending_outreach.py
@@ -1,0 +1,57 @@
+"""CRUD tests for pending_outreach — thread_id / validated_recipient round-trip.
+
+The subprocess fallback path (``outreach_send`` with ``pipeline=None``) enqueues
+here. It must persist the resolved thread + recipient so the genesis-server
+drain can rebuild a properly-routed request instead of defaulting a recipient-
+less email to the agent's own address.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import pending_outreach
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await pending_outreach.ensure_table(conn)
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_ensure_table_includes_new_columns(db):
+    cur = await db.execute("PRAGMA table_info(pending_outreach)")
+    cols = {row[1] for row in await cur.fetchall()}
+    assert "thread_id" in cols
+    assert "validated_recipient" in cols
+
+
+@pytest.mark.asyncio
+async def test_enqueue_persists_thread_and_recipient(db):
+    await pending_outreach.enqueue(
+        db,
+        message="follow up",
+        category="notification",
+        channel="email",
+        thread_id="thread-123",
+        validated_recipient="real@prospect.com",
+    )
+    rows = await pending_outreach.drain(db, now="2999-01-01T00:00:00+00:00")
+    assert len(rows) == 1
+    assert rows[0]["thread_id"] == "thread-123"
+    assert rows[0]["validated_recipient"] == "real@prospect.com"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_defaults_to_none(db):
+    await pending_outreach.enqueue(
+        db, message="m", category="notification", channel="telegram",
+    )
+    rows = await pending_outreach.drain(db, now="2999-01-01T00:00:00+00:00")
+    assert len(rows) == 1
+    assert rows[0]["thread_id"] is None
+    assert rows[0]["validated_recipient"] is None

--- a/tests/test_mcp/test_outreach_mcp.py
+++ b/tests/test_mcp/test_outreach_mcp.py
@@ -235,3 +235,55 @@ async def test_send_standalone_valid_category():
     finally:
         mcp_mod._pipeline = old_pipeline
         mcp_mod._db = old_db
+
+
+@pytest.mark.asyncio
+async def test_send_standalone_email_resolves_and_enqueues_thread_recipient():
+    """Fallback (pipeline=None) MUST resolve the thread's recipient and carry
+    both thread_id + validated_recipient into enqueue — otherwise the queued
+    email is recipient-less and the drain self-sends to the agent's own address.
+    """
+    old_pipeline, old_db = mcp_mod._pipeline, mcp_mod._db
+    enq = AsyncMock(return_value="pending-xyz")
+    try:
+        mcp_mod._pipeline = None
+        mcp_mod._db = AsyncMock()
+        with patch("genesis.db.crud.pending_outreach.ensure_table", new_callable=AsyncMock), \
+             patch("genesis.db.crud.pending_outreach.enqueue", enq), \
+             patch("genesis.db.crud.email_threads.get_thread", new_callable=AsyncMock,
+                   return_value={"recipient": "real@prospect.com"}):
+            tools = await mcp.get_tools()
+            result = await tools["outreach_send"].fn(
+                message="following up", category="notification", channel="email",
+                thread_id="t1",
+            )
+        assert json.loads(result)["status"] == "queued"
+        kwargs = enq.call_args.kwargs
+        assert kwargs["thread_id"] == "t1"
+        assert kwargs["validated_recipient"] == "real@prospect.com"
+    finally:
+        mcp_mod._pipeline = old_pipeline
+        mcp_mod._db = old_db
+
+
+@pytest.mark.asyncio
+async def test_send_standalone_email_without_thread_enqueues_no_recipient():
+    """A queued email with no thread_id carries validated_recipient=None so the
+    drain's self-send guard drops it (never silently self-sends)."""
+    old_pipeline, old_db = mcp_mod._pipeline, mcp_mod._db
+    enq = AsyncMock(return_value="pending-none")
+    try:
+        mcp_mod._pipeline = None
+        mcp_mod._db = AsyncMock()
+        with patch("genesis.db.crud.pending_outreach.ensure_table", new_callable=AsyncMock), \
+             patch("genesis.db.crud.pending_outreach.enqueue", enq):
+            tools = await mcp.get_tools()
+            await tools["outreach_send"].fn(
+                message="orphan", category="notification", channel="email",
+            )
+        kwargs = enq.call_args.kwargs
+        assert kwargs["thread_id"] is None
+        assert kwargs["validated_recipient"] is None
+    finally:
+        mcp_mod._pipeline = old_pipeline
+        mcp_mod._db = old_db

--- a/tests/test_outreach/test_pipeline.py
+++ b/tests/test_outreach/test_pipeline.py
@@ -506,7 +506,7 @@ async def test_email_to_own_address_is_ignored_not_held(
 ):
     """A send to the agent's own address is terminally IGNORED — never HELD
     (approval flood) or DEFERred (retry loop)."""
-    self_addr = "genesisagiagent@gmail.com"
+    self_addr = "genesis@example.com"
     adapter = _email_adapter(self_addr)
     gate = AsyncMock()
     pipeline = OutreachPipeline(
@@ -534,7 +534,7 @@ async def test_email_without_recipient_is_ignored_not_deferred(
 ):
     """A recipient-less email is terminally IGNORED, NOT FAILED/deferred — a
     deferred no-recipient email would just loop in the deferred-work queue."""
-    adapter = _email_adapter("genesisagiagent@gmail.com")
+    adapter = _email_adapter("genesis@example.com")
     pipeline = OutreachPipeline(
         governance=GovernanceGate(config, db),
         drafter=mock_drafter, formatter=mock_formatter,
@@ -558,7 +558,7 @@ async def test_self_send_skipped_on_gate_cleared_resume(
 ):
     """The self-guard fires even on the gate_cleared resume path
     (deliver_approved) — an approved self-send must still never be sent."""
-    self_addr = "genesisagiagent@gmail.com"
+    self_addr = "genesis@example.com"
     adapter = _email_adapter(self_addr)
     pipeline = OutreachPipeline(
         governance=GovernanceGate(config, db),

--- a/tests/test_outreach/test_pipeline.py
+++ b/tests/test_outreach/test_pipeline.py
@@ -477,3 +477,103 @@ async def test_submit_to_email_quarantines_secret_end_to_end(config, db, mock_dr
     assert result.status == OutreachStatus.FAILED
     assert "quarantine" in (result.error or "").lower()
     email_adapter.send_message.assert_not_called()
+
+
+# ── self-send / recipient-less terminal guards at the _deliver chokepoint ──
+
+
+def _email_adapter(from_address):
+    from genesis.channels.email_adapter import EmailAdapter
+    a = EmailAdapter(
+        smtp_host="smtp.invalid", smtp_port=465, username="u",
+        password="p", from_address=from_address,
+    )
+    a.send_message = AsyncMock(return_value="<id@x>")
+    return a
+
+
+def test_email_adapter_exposes_from_address():
+    assert _email_adapter("me@self.com").from_address == "me@self.com"
+
+
+@pytest.mark.asyncio
+async def test_email_to_own_address_is_ignored_not_held(
+    config, db, mock_drafter, mock_formatter
+):
+    """A send to the agent's own address is terminally IGNORED — never HELD
+    (approval flood) or DEFERred (retry loop)."""
+    self_addr = "genesisagiagent@gmail.com"
+    adapter = _email_adapter(self_addr)
+    gate = AsyncMock()
+    pipeline = OutreachPipeline(
+        governance=GovernanceGate(config, db),
+        drafter=mock_drafter, formatter=mock_formatter,
+        channels={"email": adapter}, db=db, config=config,
+        recipients={"email": self_addr},  # the misconfigured self default
+    )
+    pipeline._autonomy_gate = gate
+    request = OutreachRequest(
+        category=OutreachCategory.NOTIFICATION, topic="hi", context="body",
+        salience_score=0.5, signal_type="x", channel="email",
+    )
+
+    result = await pipeline.submit_raw("body", request)
+
+    assert result.status == OutreachStatus.IGNORED
+    gate.check.assert_not_called()             # never reached the gate (no hold)
+    adapter.send_message.assert_not_called()   # never sent
+
+
+@pytest.mark.asyncio
+async def test_email_without_recipient_is_ignored_not_deferred(
+    config, db, mock_drafter, mock_formatter
+):
+    """A recipient-less email is terminally IGNORED, NOT FAILED/deferred — a
+    deferred no-recipient email would just loop in the deferred-work queue."""
+    adapter = _email_adapter("genesisagiagent@gmail.com")
+    pipeline = OutreachPipeline(
+        governance=GovernanceGate(config, db),
+        drafter=mock_drafter, formatter=mock_formatter,
+        channels={"email": adapter}, db=db, config=config,
+        recipients={},  # no email default -> recipient resolves to ""
+    )
+    request = OutreachRequest(
+        category=OutreachCategory.NOTIFICATION, topic="hi", context="body",
+        salience_score=0.5, signal_type="x", channel="email",
+    )
+
+    result = await pipeline.submit_raw("body", request)
+
+    assert result.status == OutreachStatus.IGNORED
+    adapter.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_self_send_skipped_on_gate_cleared_resume(
+    config, db, mock_drafter, mock_formatter
+):
+    """The self-guard fires even on the gate_cleared resume path
+    (deliver_approved) — an approved self-send must still never be sent."""
+    self_addr = "genesisagiagent@gmail.com"
+    adapter = _email_adapter(self_addr)
+    pipeline = OutreachPipeline(
+        governance=GovernanceGate(config, db),
+        drafter=mock_drafter, formatter=mock_formatter,
+        channels={"email": adapter}, db=db, config=config,
+        recipients={"email": self_addr},
+    )
+    request = OutreachRequest(
+        category=OutreachCategory.NOTIFICATION, topic="t", context="c",
+        salience_score=0.5, signal_type="x", channel="email",
+        validated_recipient=self_addr,
+    )
+    formatted = FormattedContent(
+        text="hi", target=FormatTarget.EMAIL, truncated=False, original_length=2,
+    )
+
+    result = await pipeline._deliver(
+        "oid", "email", formatted, request, None, gate_cleared=True,
+    )
+
+    assert result.status == OutreachStatus.IGNORED
+    adapter.send_message.assert_not_called()

--- a/tests/test_outreach/test_pipeline.py
+++ b/tests/test_outreach/test_pipeline.py
@@ -121,6 +121,10 @@ async def test_submit_governance_denied(config, db, mock_drafter, mock_formatter
     result = await pipeline.submit(req)
     assert result.status == OutreachStatus.REJECTED
     mock_channel.send_message.assert_not_called()
+    # The denial reason must reach result.error so the drain's "will retry"
+    # log is diagnosable (was blank: "not delivered (rejected: )").
+    assert result.error
+    assert result.error == result.governance_result.reason
 
 
 @pytest.mark.asyncio

--- a/tests/test_outreach/test_scheduler.py
+++ b/tests/test_outreach/test_scheduler.py
@@ -202,3 +202,109 @@ async def test_health_check_single_alert_still_batches(config, db):
     batched_text = pipeline.submit_raw.call_args[0][0]
     assert "/tmp at 3% free" in batched_text
     assert "1 critical alert(s)" in batched_text
+
+
+# ── _drain_pending_job: terminal handling + thread routing + age cap ────────
+
+
+def _drain_pipeline(status):
+    pipeline = AsyncMock()
+    result = OutreachResult(
+        outreach_id="o", status=status, channel="email", message_content="",
+    )
+    pipeline.submit = AsyncMock(return_value=result)
+    pipeline.submit_urgent = AsyncMock(return_value=result)
+    return pipeline
+
+
+async def _remaining(db):
+    """Rows still eligible for the next drain (delivered=0)."""
+    from genesis.db.crud import pending_outreach
+    return await pending_outreach.drain(db, now="2999-01-01T00:00:00+00:00")
+
+
+@pytest.mark.asyncio
+async def test_drain_reconstructs_request_with_thread_and_recipient(config, db):
+    """A queued email row must rebuild an OutreachRequest carrying its thread_id
+    + validated_recipient — so _deliver routes to the real recipient, not self."""
+    from genesis.db.crud import pending_outreach
+    await pending_outreach.enqueue(
+        db, message="follow up", category="notification", channel="email",
+        thread_id="t1", validated_recipient="real@prospect.com",
+    )
+    pipeline = _drain_pipeline(OutreachStatus.DELIVERED)
+    scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
+
+    await scheduler._drain_pending_job()
+
+    pipeline.submit.assert_called_once()
+    req = pipeline.submit.call_args[0][0]
+    assert req.thread_id == "t1"
+    assert req.validated_recipient == "real@prospect.com"
+
+
+@pytest.mark.asyncio
+async def test_drain_held_is_terminal_not_retried(config, db):
+    """HELD = handed off to the gate's approval queue; the queue row is done.
+    Re-submitting every cycle is exactly the spam multiplier we are killing."""
+    from genesis.db.crud import pending_outreach
+    await pending_outreach.enqueue(
+        db, message="x", category="notification", channel="email",
+    )
+    pipeline = _drain_pipeline(OutreachStatus.HELD)
+    scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
+
+    await scheduler._drain_pending_job()
+
+    assert await _remaining(db) == []  # marked delivered, not retried
+
+
+@pytest.mark.asyncio
+async def test_drain_ignored_is_terminal(config, db):
+    from genesis.db.crud import pending_outreach
+    await pending_outreach.enqueue(
+        db, message="x", category="notification", channel="email",
+    )
+    pipeline = _drain_pipeline(OutreachStatus.IGNORED)
+    scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
+
+    await scheduler._drain_pending_job()
+
+    assert await _remaining(db) == []
+
+
+@pytest.mark.asyncio
+async def test_drain_rejected_is_retried(config, db):
+    """A transient governance rejection (e.g. quiet_hours) stays queued."""
+    from genesis.db.crud import pending_outreach
+    await pending_outreach.enqueue(
+        db, message="x", category="notification", channel="telegram",
+    )
+    pipeline = _drain_pipeline(OutreachStatus.REJECTED)
+    scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
+
+    await scheduler._drain_pending_job()
+
+    assert len(await _remaining(db)) == 1  # still pending for next cycle
+
+
+@pytest.mark.asyncio
+async def test_drain_ages_out_perpetually_stuck_row(config, db):
+    """A row that never reaches a terminal status must be dropped after 24h
+    instead of looping forever (the churn that locked the DB)."""
+    from datetime import UTC, datetime, timedelta
+    old = (datetime.now(UTC) - timedelta(hours=25)).isoformat()
+    await db.execute(
+        "INSERT INTO pending_outreach (id, message, category, channel, urgency, "
+        "created_at, delivered) VALUES ('old1', 'x', 'notification', 'telegram', "
+        "'low', ?, 0)",
+        (old,),
+    )
+    await db.commit()
+    pipeline = _drain_pipeline(OutreachStatus.REJECTED)
+    scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
+
+    await scheduler._drain_pending_job()
+
+    pipeline.submit.assert_not_called()  # aged out BEFORE re-submitting
+    assert await _remaining(db) == []    # dropped

--- a/tests/test_outreach/test_scheduler.py
+++ b/tests/test_outreach/test_scheduler.py
@@ -308,3 +308,28 @@ async def test_drain_ages_out_perpetually_stuck_row(config, db):
 
     pipeline.submit.assert_not_called()  # aged out BEFORE re-submitting
     assert await _remaining(db) == []    # dropped
+
+
+@pytest.mark.asyncio
+async def test_drain_ages_out_naive_timestamp_row(config, db):
+    """A created_at WITHOUT a tz offset must still age out — a naive timestamp
+    must not silently bypass the cap (and loop forever)."""
+    from datetime import UTC, datetime, timedelta
+    old_naive = (
+        (datetime.now(UTC) - timedelta(hours=25)).replace(tzinfo=None).isoformat()
+    )
+    assert "+00:00" not in old_naive  # genuinely naive
+    await db.execute(
+        "INSERT INTO pending_outreach (id, message, category, channel, urgency, "
+        "created_at, delivered) VALUES ('oldnaive', 'x', 'notification', "
+        "'telegram', 'low', ?, 0)",
+        (old_naive,),
+    )
+    await db.commit()
+    pipeline = _drain_pipeline(OutreachStatus.REJECTED)
+    scheduler = OutreachScheduler(pipeline, AsyncMock(), AsyncMock(), config, db)
+
+    await scheduler._drain_pending_job()
+
+    pipeline.submit.assert_not_called()
+    assert await _remaining(db) == []


### PR DESCRIPTION
## Problem

Background follow-up sessions were flooding the approvals tab with held "cold email to the agent's own address" messages — a new one every ~5 minutes. All were correctly **held** at the WS-8 capability gate (none ever sent), but the queue kept regenerating them, and the churn periodically locked the DB (it broke a recent deploy twice).

## Root cause — a 4-layer self-send loop

1. **Origin:** follow-up/reply sessions run as subprocesses where the outreach MCP has `pipeline=None`. `outreach_send(thread_id, channel="email")` fell back to `pending_outreach.enqueue()`, which **dropped the `thread_id` and recipient** (no such columns) — even though the tool's docstring says `thread_id` routes the recipient.
2. **Default-to-self:** on drain, `_deliver` resolved `recipient = validated_recipient or recipients["email"]`, and `recipients["email"]` defaulted to the agent's **own** address.
3. **No self-guard:** the email gate classified the self-send (`email/send/identity`, ASK) → **HELD** → wrote `pending_email_sends` + a pending approval.
4. **Multiplier:** the drain only marked the queue row delivered on `DELIVERED`/`ENGAGED`; **HELD and REJECTED both retried forever** → a new held self-email every cycle.

## The fix (defense-in-depth)

- **Origin** — Migration `0038` adds nullable `thread_id` + `validated_recipient` to `pending_outreach`; `enqueue()`/`ensure_table()`/canonical schema carry them; the `outreach_send` fallback resolves the thread recipient (hoisted above the pipeline/fallback split) and enqueues both.
- **Chokepoint** — `_deliver` drops an email addressed to the agent's own `from_address`, or with no resolved recipient, as terminal `IGNORED` — **before** the gate (which would HOLD it) and **before** the no-recipient defer (which would retry-loop). Fires on the approved-resume path too. The self-address default is removed; email recipients now come from the thread or `OUTREACH_RECIPIENT_EMAIL`.
- **Multiplier** — the drain treats `HELD` (handed to the approval queue) and `IGNORED` as terminal, and drops any row stuck >24h.
- **Watcher** — an approved hold the pipeline terminally skips is marked rejected + consumed (no busy-loop, no ghost approval).
- **Observability** — governance denial reasons now surface in the result (retry logs were blank).

## Testing

- TDD throughout (every behavioral change watched fail first). New tests across migration, CRUD, MCP fallback, scheduler drain, pipeline guard, and watcher.
- Full consolidated regression green; lint clean on all changed files.
- **Code review** (agent): confirmed correctness on 10 checklist items; 1 P1 + 2 P2 found and all fixed + tested.
- **E2E on a copy of the live DB:** the real migration runner applied only `0038` (no failures), recorded it, preserved data, idempotent re-run — and a round-trip enqueue/drain routed to the real recipient, not self.

The 83 held self-emails + their approvals were already cleared from the live DB (approvals cancelled to preserve the tamper-evident audit chain; the rest hard-deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
