### PR TITLE
fix(reflection): recognise drift-week runs in calibration idempotency guard

### DIFF
--- a/src/genesis/reflection/scheduler.py
+++ b/src/genesis/reflection/scheduler.py
@@ -166,7 +166,7 @@ class ReflectionScheduler:
         except Exception:
             pass
         try:
-            if await self._already_ran_this_week("quality_calibration"):
+            if await self._already_ran_this_week("quality_calibration", "quality_drift"):
                 logger.info("Quality calibration already ran this week — skipping")
                 return
 
@@ -195,8 +195,18 @@ class ReflectionScheduler:
             logger.exception("Quality calibration error")
             await self._record_job_result("weekly_calibration", error=str(exc))
 
-    async def _already_ran_this_week(self, obs_type: str) -> bool:
-        """Check if an observation of this type exists from the current week."""
+    async def _already_ran_this_week(self, *obs_types: str) -> bool:
+        """Check if an observation of any of these types exists from this week.
+
+        Accepts multiple types because one logical run can land under more than
+        one observation type: quality calibration writes ``quality_calibration``
+        on a clean week but ``quality_drift`` on a drift week (see
+        ``output_router.route_calibration``). The guard must recognise either —
+        otherwise a drift week looks like "never ran" and the run could repeat.
+        The observation is written only on a *successful* run (a failure writes
+        nothing), so its presence is a last-success signal and a failed run
+        stays retriable.
+        """
         from genesis.db.crud import observations
 
         # Get start of current week (Monday 00:00)
@@ -205,8 +215,9 @@ class ReflectionScheduler:
         monday -= __import__("datetime").timedelta(days=now.weekday())
         monday_iso = monday.isoformat()
 
-        recent = await observations.query(self._db, type=obs_type, limit=1)
-        if not recent:
-            return False
+        for obs_type in obs_types:
+            recent = await observations.query(self._db, type=obs_type, limit=1)
+            if recent and recent[0].get("created_at", "") >= monday_iso:
+                return True
 
-        return recent[0].get("created_at", "") >= monday_iso
+        return False

--- a/tests/test_reflection/test_scheduler.py
+++ b/tests/test_reflection/test_scheduler.py
@@ -156,6 +156,36 @@ class TestCalibrationJob:
         mock_bridge.run_quality_calibration.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_skips_if_drift_ran_this_week(self, scheduler, mock_bridge, db):
+        # Drift weeks write a `quality_drift` observation (not `quality_calibration`).
+        # The guard must still recognise this week's run and skip — otherwise the
+        # expensive calibration repeats on every re-trigger during a drift week.
+        now = datetime.now(UTC).isoformat()
+        await db.execute(
+            "INSERT INTO observations (id, source, type, content, priority, created_at) "
+            "VALUES ('d1', 'quality_calibration', 'quality_drift', '{}', 'high', ?)",
+            (now,),
+        )
+        await db.commit()
+
+        await scheduler._run_calibration()
+        mock_bridge.run_quality_calibration.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_runs_if_only_old_drift(self, scheduler, mock_bridge, db):
+        # A drift observation from last week must NOT suppress this week's run.
+        old = (datetime.now(UTC) - timedelta(days=8)).isoformat()
+        await db.execute(
+            "INSERT INTO observations (id, source, type, content, priority, created_at) "
+            "VALUES ('d1', 'quality_calibration', 'quality_drift', '{}', 'high', ?)",
+            (old,),
+        )
+        await db.commit()
+
+        await scheduler._run_calibration()
+        mock_bridge.run_quality_calibration.assert_called_once_with(db)
+
+    @pytest.mark.asyncio
     async def test_no_stability_monitor(self, db, mock_bridge):
         sched = ReflectionScheduler(
             bridge=mock_bridge,
@@ -183,6 +213,50 @@ class TestIdempotency:
         await db.commit()
         result = await scheduler._already_ran_this_week("self_assessment")
         assert result
+
+    @pytest.mark.asyncio
+    async def test_drift_type_counts_as_calibration_run(self, scheduler, db):
+        # The calibration guard passes both types; a this-week drift row counts.
+        now = datetime.now(UTC).isoformat()
+        await db.execute(
+            "INSERT INTO observations (id, source, type, content, priority, created_at) "
+            "VALUES ('d1', 'quality_calibration', 'quality_drift', '{}', 'high', ?)",
+            (now,),
+        )
+        await db.commit()
+        result = await scheduler._already_ran_this_week(
+            "quality_calibration", "quality_drift",
+        )
+        assert result
+
+    @pytest.mark.asyncio
+    async def test_clean_type_counts_as_calibration_run(self, scheduler, db):
+        now = datetime.now(UTC).isoformat()
+        await db.execute(
+            "INSERT INTO observations (id, source, type, content, priority, created_at) "
+            "VALUES ('c1', 'quality_calibration', 'quality_calibration', '{}', 'medium', ?)",
+            (now,),
+        )
+        await db.commit()
+        result = await scheduler._already_ran_this_week(
+            "quality_calibration", "quality_drift",
+        )
+        assert result
+
+    @pytest.mark.asyncio
+    async def test_multi_type_all_old_means_not_ran(self, scheduler, db):
+        old = (datetime.now(UTC) - timedelta(days=8)).isoformat()
+        for oid, otype in (("c1", "quality_calibration"), ("d1", "quality_drift")):
+            await db.execute(
+                "INSERT INTO observations (id, source, type, content, priority, created_at) "
+                "VALUES (?, 'quality_calibration', ?, '{}', 'medium', ?)",
+                (oid, otype, old),
+            )
+        await db.commit()
+        result = await scheduler._already_ran_this_week(
+            "quality_calibration", "quality_drift",
+        )
+        assert not result
 
 
 class TestRuntimeBootstrap:


### PR DESCRIPTION
## Problem

The weekly quality-calibration job guards re-runs with
`_already_ran_this_week("quality_calibration")`. But `route_calibration`
writes the observation as type **`quality_drift`** when drift is detected
(`reflection/output_router.py`). On a drift week the guard never matched that
type, so the run looked like "never ran" and could repeat on any same-week
re-trigger.

## Fix

Widen `_already_ran_this_week` to accept multiple observation types and have
the calibration job pass both `quality_calibration` and `quality_drift`. The
`self_assessment` call site is unchanged (single positional arg).

The observation is kept as the idempotency signal rather than
`job_health.last_run`: the observation is written **only on a successful run**
(failures write nothing, so they stay retriable), whereas `last_run` is recorded
on failure too and would block legitimate same-week retries.

## Scope / honesty

This is a **defensive / latent-correctness** fix. Under the current wiring —
in-memory APScheduler jobstore (missed runs are not caught up across restart),
a once-weekly cron, and the reflection jobs not registered with the retry
registry — nothing re-enters the job within a week, so the guard does not trip
today. The change keeps it correct for any future re-trigger path (a persistent
jobstore, a manual trigger, or retry registration).

## Tests

`tests/test_reflection/test_scheduler.py`:
- drift-week skip (verified to fail without the fix),
- old-drift re-run,
- multi-type helper matrix (drift recognised / clean recognised / both-old → not ran).

All reflection tests pass; ruff clean. A data-flow check additionally drove the
real `route_calibration` writer through the real guard end to end.