### PR TITLE
docs+identity: worktree pytest note + reframe MORNING_REPORT prohibitions

### DIFF
--- a/.claude/skills/genesis-development/references/worktrees.md
+++ b/.claude/skills/genesis-development/references/worktrees.md
@@ -27,6 +27,25 @@ Multiple Claude Code sessions may work on this repo simultaneously. Rules:
   file in the diff belongs to your work. If you see files you didn't modify,
   STOP and investigate.
 
+## Testing code in a worktree
+
+`tests/conftest.py` pins `sys.path[0]` to the worktree's own `src`, so `pytest`
+run from a worktree always tests THAT worktree's code — you don't need
+`PYTHONPATH`, and setting it will NOT redirect pytest (the guard shadows the
+editable install and any env path). Consequence: to prove a new regression test
+actually fails on the unfixed code, you can't point pytest at old code via the
+environment — revert the source in place instead:
+
+```bash
+git stash push -- path/to/file.py        # restore the unfixed code
+pytest tests/.../test_x.py -k new_test    # expect RED
+git stash pop                             # restore the fix
+```
+
+A standalone `python -c "import genesis; print(genesis.__file__)"` DOES honor
+`PYTHONPATH`/the editable install, so it can misleadingly show main's path while
+pytest is using the worktree's. Trust the stash check, not the env var.
+
 ## Push/Merge Enforcement
 
 `git_push_guard.py` (PreToolUse hook) blocks:

--- a/src/genesis/identity/MORNING_REPORT.md
+++ b/src/genesis/identity/MORNING_REPORT.md
@@ -11,27 +11,29 @@ briefing from a senior advisor — not a system health dashboard.
 The user's day should start with: "here's what we worked on, here's what
 I thought of while you were away, here's what needs your attention."
 
-## ABSOLUTE PROHIBITIONS
+## Format Requirements
 
-These are hard rules. Violating ANY of them makes the report unusable.
-The LLM generating this report has historically violated all of these
-despite being told not to. BE DIFFERENT. FOLLOW THESE RULES.
+This is a structured briefing an operator scans in seconds, not a chat
+message. Each rule below keeps it scannable and fast to read.
 
-- **NO greetings** — no "Good morning!", "Hey there!", "Hi!", or ANY
-  opening address. Not even subtle ones like "Here's today's briefing."
-- **NO sign-offs** — no "Let me know!", "What would you like to dive
-  into?", "Happy to discuss!", or ANY closing address.
-- **NO excessive emoji** — a single alert icon (e.g. for urgent items)
-  is fine. Do NOT decorate every section header with emoji.
-- **NO rhetorical questions** — do not ask the user anything.
-- **NO conversational filler** — no "Here's what's going on", "Let's
-  take a look", "pulse of the system", or similar padding.
-- **NO quoting cognitive state entries verbatim** — these are Genesis's
-  internal context, not action items. At most: "Genesis is tracking N
-  internal context items."
+- **No greetings** — open on content, not an address ("Good morning!",
+  "Hey there!", "Hi!", or even "Here's today's briefing"). The operator
+  already knows what this is.
+- **No sign-offs** — end on the last fact, with no closing address ("Let me
+  know!", "What would you like to dive into?", "Happy to discuss!"). It's a
+  briefing, not a message awaiting a reply.
+- **Minimal emoji** — a single alert icon for a genuinely urgent item is
+  fine; section headers carry no decoration.
+- **No rhetorical questions** — the report states; it does not ask the
+  operator anything.
+- **No conversational filler** — every line carries information ("Here's
+  what's going on", "Let's take a look", "pulse of the system" add nothing).
+- **No verbatim cognitive-state entries** — these are Genesis's internal
+  context, not action items; summarize as "Genesis is tracking N internal
+  context items."
 
-Start directly with the first section header. End with the last bullet.
-Nothing before the first header. Nothing after the last bullet.
+Begin with the first section header and end with the last bullet — nothing
+framing the report before or after.
 
 ## Voice
 


### PR DESCRIPTION
Two small, low-risk hygiene changes.

**1. `docs(worktrees)` — pytest import pinning + falsification note.**
`tests/conftest.py` pins `sys.path[0]` to the worktree's own `src`, so `pytest` run from a worktree always tests that worktree's code — `PYTHONPATH` does not redirect it. Documents the consequence in the worktrees reference: to prove a regression test fails on the *unfixed* code, revert the source in place (`git stash`), not via the environment.

**2. `refactor(identity)` — reframe MORNING_REPORT "ABSOLUTE PROHIBITIONS".**
An Opus 4.8 compatibility audit flagged that section's output-suppression / gag-clause framing ("Violating ANY of them makes the report unusable… BE DIFFERENT. FOLLOW THESE RULES") as borderline injection-shape language — the only identity file with this pattern. Renamed to "Format Requirements" with the operational *why* leading; every constraint is preserved in effect, only the suppressive wrapper changes. Resolves two pending follow-ups from that audit.

Docs/prompt only — no runtime code paths changed. `tests/test_outreach/test_morning_report.py` passes; a content check confirms all six constraints and concrete examples survive the rewrite.