### PR TITLE
feat(observability): loop_closure_status — self-learning loop health funnel

### DIFF
--- a/src/genesis/db/crud/loop_closure.py
+++ b/src/genesis/db/crud/loop_closure.py
@@ -1,0 +1,179 @@
+"""Loop-closure funnel aggregations — READ-ONLY.
+
+Per-artifact "is the self-learning loop closed?" funnel —
+captured → surfaced/invoked → actuated → measured → leak — computed entirely
+from existing tables. No writes, no schema changes. Powers the
+``loop_closure_status`` MCP tool (the self-learning health surface, which
+subsumes ``self_improvement_status``).
+
+The point is honest accounting: a thing that is *captured* but never *acted on*
+or *measured* is a leak — work/learning that fell through the cracks. These
+queries count exactly that, per artifact, so the operator (and Genesis) can see
+where the loop is open.
+
+"Stale" thresholds are passed in by the caller (ISO cutoff) so these functions
+stay deterministic and unit-testable — no wall-clock inside the query layer.
+All ``created_at`` writers use ``datetime.now(UTC).isoformat()`` (fixed-width,
+same zone), so the lexicographic ``created_at < ?`` compare == chronological.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def _scalar(db: aiosqlite.Connection, sql: str, params: tuple = ()) -> int:
+    cur = await db.execute(sql, params)
+    row = await cur.fetchone()
+    return int(row[0]) if row and row[0] is not None else 0
+
+
+async def _group_counts(db: aiosqlite.Connection, sql: str) -> dict[str, int]:
+    cur = await db.execute(sql)
+    return {(r[0] or "∅"): r[1] for r in await cur.fetchall()}
+
+
+def _loop_label(total: int, *, flowing: int, leaked: int) -> str:
+    """Data-derived loop status (never hardcoded):
+
+    EMPTY   — nothing captured yet
+    OPEN    — captured but nothing is flowing through (acted on / measured)
+    PARTIAL — some flows, some leaks
+    CLOSED  — everything captured has flowed through, no leak
+    """
+    if total == 0:
+        return "EMPTY"
+    if flowing == 0:
+        return "OPEN"
+    return "PARTIAL" if leaked > 0 else "CLOSED"
+
+
+async def procedure_funnel(db: aiosqlite.Connection) -> dict:
+    """Procedures are outcome-graded, but ``procedural_memory`` has NO 'surfaced'
+    counter — ``invocation_count`` is the actuation signal (the procedure
+    actually fired). So we report ``invoked`` (not 'surfaced'); the leak is
+    captured-but-never-invoked (the golden-dormant that never gets to mature)."""
+    total = await _scalar(db, "SELECT COUNT(*) FROM procedural_memory")
+    invoked = await _scalar(
+        db, "SELECT COUNT(*) FROM procedural_memory WHERE invocation_count > 0"
+    )
+    measured = await _scalar(
+        db,
+        "SELECT COUNT(*) FROM procedural_memory WHERE success_count + failure_count > 0",
+    )
+    deprecated = await _scalar(
+        db, "SELECT COUNT(*) FROM procedural_memory WHERE deprecated = 1"
+    )
+    by_tier = await _group_counts(
+        db, "SELECT activation_tier, COUNT(*) FROM procedural_memory GROUP BY activation_tier"
+    )
+    leak_uninvoked = total - invoked
+    return {
+        "artifact": "procedure",
+        "captured": total,
+        "invoked": invoked,
+        "measured": measured,
+        "by_tier": by_tier,
+        "deprecated": deprecated,
+        "leak_uninvoked": leak_uninvoked,
+        "loop": _loop_label(total, flowing=invoked, leaked=leak_uninvoked),
+    }
+
+
+async def observation_funnel(db: aiosqlite.Connection, *, stale_before: str) -> dict:
+    """Observations: actuation signal = ``influenced_action``. Leak = unresolved,
+    un-actuated, and aged out."""
+    total = await _scalar(db, "SELECT COUNT(*) FROM observations")
+    surfaced = await _scalar(
+        db, "SELECT COUNT(*) FROM observations WHERE surfaced_count > 0"
+    )
+    actuated = await _scalar(
+        db, "SELECT COUNT(*) FROM observations WHERE influenced_action = 1"
+    )
+    resolved = await _scalar(db, "SELECT COUNT(*) FROM observations WHERE resolved = 1")
+    leak_stale = await _scalar(
+        db,
+        "SELECT COUNT(*) FROM observations "
+        "WHERE resolved = 0 AND influenced_action = 0 AND created_at < ?",
+        (stale_before,),
+    )
+    return {
+        "artifact": "observation",
+        "captured": total,
+        "surfaced": surfaced,
+        "actuated": actuated,
+        "resolved": resolved,
+        "leak_stale_unactuated": leak_stale,
+        "loop": _loop_label(total, flowing=actuated, leaked=leak_stale),
+    }
+
+
+async def reflection_funnel(db: aiosqlite.Connection) -> dict:
+    """Reflections: actuation signal = ``used_in_optimization``. Leak = generated
+    but never used to change anything."""
+    total = await _scalar(db, "SELECT COUNT(*) FROM reflection_corpus")
+    graded = await _scalar(
+        db, "SELECT COUNT(*) FROM reflection_corpus WHERE quality_label IS NOT NULL"
+    )
+    used = await _scalar(
+        db, "SELECT COUNT(*) FROM reflection_corpus WHERE used_in_optimization = 1"
+    )
+    leak_unused = total - used
+    return {
+        "artifact": "reflection",
+        "captured": total,
+        "graded": graded,
+        "actuated": used,
+        "leak_unused": leak_unused,
+        "loop": _loop_label(total, flowing=used, leaked=leak_unused),
+    }
+
+
+async def followup_funnel(db: aiosqlite.Connection, *, stale_before: str) -> dict:
+    """Follow-ups: actuated = past the queue (``scheduled``/``in_progress``/
+    ``completed``). Leak = ``pending`` past the stale cutoff (the graveyard)."""
+    by_status = await _group_counts(
+        db, "SELECT status, COUNT(*) FROM follow_ups GROUP BY status"
+    )
+    total = sum(by_status.values())
+    actuated = (
+        by_status.get("scheduled", 0)
+        + by_status.get("in_progress", 0)
+        + by_status.get("completed", 0)
+    )
+    pending_stale = await _scalar(
+        db,
+        "SELECT COUNT(*) FROM follow_ups WHERE status = 'pending' AND created_at < ?",
+        (stale_before,),
+    )
+    return {
+        "artifact": "follow_up",
+        "captured": total,
+        "by_status": by_status,
+        "actuated": actuated,
+        "leak_pending_stale": pending_stale,
+        "loop": _loop_label(total, flowing=actuated, leaked=pending_stale),
+    }
+
+
+async def proposal_funnel(db: aiosqlite.Connection, *, stale_before: str) -> dict:
+    """Ego proposals: actuated = sanctioned for action (``approved``/``executed``).
+    Leak = ``pending`` past the stale cutoff (approval never came)."""
+    by_status = await _group_counts(
+        db, "SELECT status, COUNT(*) FROM ego_proposals GROUP BY status"
+    )
+    total = sum(by_status.values())
+    actuated = by_status.get("approved", 0) + by_status.get("executed", 0)
+    pending_stale = await _scalar(
+        db,
+        "SELECT COUNT(*) FROM ego_proposals WHERE status = 'pending' AND created_at < ?",
+        (stale_before,),
+    )
+    return {
+        "artifact": "ego_proposal",
+        "captured": total,
+        "by_status": by_status,
+        "actuated": actuated,
+        "leak_pending_stale": pending_stale,
+        "loop": _loop_label(total, flowing=actuated, leaked=pending_stale),
+    }

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -73,10 +73,10 @@ from genesis.mcp.health import experiment_status as _experiment_status  # noqa: 
 from genesis.mcp.health import follow_up_tools as _follow_up_tools  # noqa: E402
 from genesis.mcp.health import inbox_digest as _inbox_digest  # noqa: E402
 from genesis.mcp.health import j9_eval as _j9_eval  # noqa: E402, F401
+from genesis.mcp.health import loop_closure_status  # noqa: E402, F401
 from genesis.mcp.health import manifest as _manifest  # noqa: E402
 from genesis.mcp.health import module_ops as _module_ops  # noqa: E402
 from genesis.mcp.health import provider as _provider  # noqa: E402
-from genesis.mcp.health import self_improvement_status  # noqa: E402, F401
 from genesis.mcp.health import session_control as _session_control  # noqa: E402
 from genesis.mcp.health import settings as _settings  # noqa: E402
 from genesis.mcp.health import status as _status  # noqa: E402

--- a/src/genesis/mcp/health/loop_closure_status.py
+++ b/src/genesis/mcp/health/loop_closure_status.py
@@ -1,0 +1,102 @@
+"""loop_closure_status MCP tool — the self-learning loop health surface.
+
+The umbrella "is the loop actually closed?" view. Two things in one read-only
+surface:
+
+1. A per-artifact **funnel** — captured → surfaced → actuated → measured → leak
+   — over the existing tables (procedures, observations, reflections,
+   follow-ups, ego proposals). It names each OPEN seam honestly: what's captured
+   but never acted on or measured. This is the assurance the operator asked for.
+2. The **Outcome Bus** section (tiers, per-domain T1 success, ego calibration) —
+   subsumes the former ``self_improvement_status`` tool, so there is ONE
+   self-learning-health surface instead of two overlapping ones.
+
+Read-only. Reuses existing CRUD; no new schema; does NOT change behaviour.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+# A discovered item still un-actuated after this long is counted as a leak
+# (the "work goes here to die" signal). 14d mirrors the morning report's
+# follow-up staleness rule.
+_STALE_DAYS = 14
+
+
+async def _impl_loop_closure_status() -> dict:
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    _service = health_mcp_mod._service
+    if _service is None or _service._db is None:
+        return {"status": "unavailable", "message": "DB not initialized"}
+
+    db = _service._db
+    from genesis.db.crud import loop_closure as lc
+    from genesis.mcp.health.self_improvement_status import (
+        _impl_self_improvement_status,
+    )
+
+    stale_before = (datetime.now(UTC) - timedelta(days=_STALE_DAYS)).isoformat()
+
+    funnel = [
+        await lc.procedure_funnel(db),
+        await lc.observation_funnel(db, stale_before=stale_before),
+        await lc.reflection_funnel(db),
+        await lc.followup_funnel(db, stale_before=stale_before),
+        await lc.proposal_funnel(db, stale_before=stale_before),
+    ]
+
+    # Honest leak report: name every open seam + non-zero leak.
+    open_seams: list[str] = []
+    for f in funnel:
+        if f.get("loop") == "OPEN" and f["captured"] > 0:
+            open_seams.append(
+                f"{f['artifact']}: {f['captured']} captured, nothing flowing "
+                "through (acted on / measured) — loop OPEN"
+            )
+        for key, val in f.items():
+            if key.startswith("leak_") and isinstance(val, int) and val > 0:
+                label = key.removeprefix("leak_").replace("_", " ")
+                open_seams.append(f"{f['artifact']}: {val} {label}")
+
+    # Subsumed: the Outcome Bus / calibration section (the "measured" layer for
+    # outcome-bearing decisions). Reused, not duplicated.
+    outcome_bus = await _impl_self_improvement_status()
+
+    return {
+        "status": "ok",
+        "funnel": funnel,
+        "open_seams": open_seams,
+        "outcome_bus": outcome_bus,
+        "skills_note": (
+            "Skills are file-based; their effectiveness signal (failure_reason) "
+            "is a stub → measured=OPEN. Closing that is LC2."
+        ),
+        "note": (
+            "Self-learning loop health. funnel = captured→surfaced→actuated→"
+            "measured per artifact; open_seams names what is leaking (captured "
+            "but never acted on / measured). Read-only — does NOT change "
+            f"behaviour. 'stale' = >{_STALE_DAYS}d un-actuated. Subsumes the "
+            "former self_improvement_status (now the outcome_bus section)."
+        ),
+    }
+
+
+@mcp.tool()
+async def loop_closure_status() -> dict:
+    """Is Genesis's self-learning loop actually closed, or is learning falling
+    through the cracks?
+
+    Per-artifact funnel — captured → surfaced → actuated → measured → leak —
+    across procedures, observations, reflections, follow-ups and ego proposals,
+    plus Outcome Bus health (signal tiers, per-domain success, ego calibration
+    ECE trend). ``open_seams`` names exactly what is captured but never acted on
+    or measured. Read-only; does NOT change behaviour.
+    """
+    return await _impl_loop_closure_status()

--- a/src/genesis/mcp/health/self_improvement_status.py
+++ b/src/genesis/mcp/health/self_improvement_status.py
@@ -1,9 +1,12 @@
-"""Self-improvement status MCP tool — soak observability for the Outcome Bus.
+"""Outcome Bus soak observability — internal helper.
 
-Read-only surface for watching the Phase-1 DARK soak of the self-improvement
-control plane. It answers two questions a human needs while the bus accrues:
-how much ground-truth has it captured (tier/coverage), and how is the ego's
-calibration trending?
+Provides ``_impl_self_improvement_status``, the Outcome Bus / ego-calibration
+readout. As of the LC0 consolidation this is **no longer a standalone MCP tool**:
+its content is surfaced as the ``outcome_bus`` section of ``loop_closure_status``
+(one self-learning-health surface instead of two). Read-only.
+
+It answers: how much ground-truth has the bus captured (tier/coverage), and how
+is the ego's calibration trending?
 
 It reads three existing CRUD surfaces directly — the Outcome Bus ledger
 (``outcome_events``) and the measure-only ego calibration snapshots — and does
@@ -15,12 +18,6 @@ Raw numbers; the human reading them applies judgement.
 """
 
 from __future__ import annotations
-
-import logging
-
-from genesis.mcp.health import mcp
-
-logger = logging.getLogger(__name__)
 
 
 async def _impl_self_improvement_status() -> dict:
@@ -94,18 +91,3 @@ async def _impl_self_improvement_status() -> dict:
             "6th source only after the soak (deferred follow-up)."
         ),
     }
-
-
-@mcp.tool()
-async def self_improvement_status() -> dict:
-    """What is the self-improvement Outcome Bus accumulating, and how is the ego's
-    confidence calibration trending?
-
-    Read-only soak instrument for the self-improvement control plane: bus
-    coverage by quality tier (T1 ground-truth > T2 rationale > T3 coverage) and
-    by signal_type, the per-domain T1 success picture (actual execution
-    outcomes, not user-approval proxies), and the ego Expected Calibration Error
-    (ECE) trend. DARK — reading this does NOT change Genesis's behaviour. No
-    ranking or scoring; raw data only.
-    """
-    return await _impl_self_improvement_status()

--- a/tests/test_db/test_loop_closure.py
+++ b/tests/test_db/test_loop_closure.py
@@ -1,0 +1,192 @@
+"""Unit tests for the loop-closure funnel aggregations (LC0).
+
+Verifies the per-artifact captured → invoked/surfaced → actuated → measured →
+leak accounting that powers ``loop_closure_status``. The funnel must (a) count
+the real columns, (b) derive the ``loop`` label from the data (never hardcode),
+and (c) correctly flag OPEN seams — captured-but-never-acted-on — which is the
+whole point of the assurance view. The MCP assembly + open_seams formatting are
+covered too.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from genesis.db.crud import loop_closure as lc
+
+pytestmark = pytest.mark.asyncio
+
+_OLD = "2020-01-01T00:00:00+00:00"   # before the stale cutoff
+_NEW = "2099-01-01T00:00:00+00:00"   # after the stale cutoff
+_STALE_BEFORE = "2024-01-01T00:00:00+00:00"
+
+
+async def _proc(db, pid, *, invocation=0, success=0, failure=0, tier="DORMANT", deprecated=0):
+    await db.execute(
+        "INSERT INTO procedural_memory "
+        "(id, task_type, principle, steps, tools_used, context_tags, created_at, "
+        " invocation_count, success_count, failure_count, activation_tier, deprecated) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+        (pid, "t", "p", "[]", "[]", "[]", _OLD, invocation, success, failure, tier, deprecated),
+    )
+
+
+async def _obs(db, oid, *, influenced=0, resolved=0, surfaced=0, created=_NEW):
+    await db.execute(
+        "INSERT INTO observations "
+        "(id, source, type, content, priority, created_at, influenced_action, resolved, surfaced_count) "
+        "VALUES (?,?,?,?,?,?,?,?,?)",
+        (oid, "s", "generic", "c", "medium", created, influenced, resolved, surfaced),
+    )
+
+
+async def _refl(db, rid, *, used=0, quality=None):
+    await db.execute(
+        "INSERT INTO reflection_corpus "
+        "(id, depth, prompt_text, response_text, created_at, used_in_optimization, quality_label) "
+        "VALUES (?,?,?,?,?,?,?)",
+        (rid, "light", "q", "a", _NEW, used, quality),
+    )
+
+
+async def _fu(db, fid, *, status, strategy="ego_judgment", created=_NEW):
+    await db.execute(
+        "INSERT INTO follow_ups (id, source, content, strategy, status, created_at) "
+        "VALUES (?,?,?,?,?,?)",
+        (fid, "session_retro", "do x", strategy, status, created),
+    )
+
+
+async def _prop(db, pid, *, status, created=_NEW):
+    await db.execute(
+        "INSERT INTO ego_proposals (id, action_type, content, status, created_at) "
+        "VALUES (?,?,?,?,?)",
+        (pid, "investigate", "do y", status, created),
+    )
+
+
+# ── procedures: invoked (not 'surfaced' — no such counter); leak = uninvoked ──
+
+async def test_procedure_funnel_counts_and_uninvoked_leak(db):
+    await _proc(db, "p1", invocation=5, success=3, tier="ADVISORY")  # invoked + measured
+    await _proc(db, "p2", invocation=0, tier="DORMANT")              # captured, never invoked
+    await _proc(db, "p3", invocation=0, tier="CORE", deprecated=1)
+    await db.commit()
+
+    f = await lc.procedure_funnel(db)
+    assert f["captured"] == 3
+    assert f["invoked"] == 1            # only p1
+    assert f["measured"] == 1          # only p1 has outcome counts
+    assert f["leak_uninvoked"] == 2    # p2 + p3 — the golden-dormant risk
+    assert f["deprecated"] == 1
+    assert f["by_tier"] == {"ADVISORY": 1, "DORMANT": 1, "CORE": 1}
+    assert f["loop"] == "PARTIAL"      # some invoked, some leaked — NOT hardcoded
+
+
+# ── observations: actuation = influenced_action ──────────────────────────────
+
+async def test_observation_funnel_open_when_none_actuated(db):
+    await _obs(db, "o1", influenced=0, resolved=0, created=_OLD)  # stale, un-actuated → leak
+    await _obs(db, "o2", influenced=0, resolved=0, created=_NEW)
+    await db.commit()
+
+    f = await lc.observation_funnel(db, stale_before=_STALE_BEFORE)
+    assert f["captured"] == 2
+    assert f["actuated"] == 0
+    assert f["leak_stale_unactuated"] == 1   # only o1 is past the cutoff
+    assert f["loop"] == "OPEN"
+
+
+async def test_observation_funnel_partial_with_leak(db):
+    await _obs(db, "o1", influenced=1, resolved=1)                # actuated
+    await _obs(db, "o2", influenced=0, resolved=0, created=_OLD)  # stale leak
+    await db.commit()
+    f = await lc.observation_funnel(db, stale_before=_STALE_BEFORE)
+    assert f["actuated"] == 1
+    assert f["leak_stale_unactuated"] == 1
+    assert f["loop"] == "PARTIAL"
+
+
+# ── reflections: actuation = used_in_optimization ────────────────────────────
+
+async def test_reflection_funnel_flags_unused(db):
+    await _refl(db, "r1", used=1, quality="good")
+    await _refl(db, "r2", used=0, quality="fair")
+    await _refl(db, "r3", used=0)               # ungraded too
+    await db.commit()
+
+    f = await lc.reflection_funnel(db)
+    assert f["captured"] == 3
+    assert f["graded"] == 2
+    assert f["actuated"] == 1
+    assert f["leak_unused"] == 2
+    assert f["loop"] == "PARTIAL"
+
+
+# ── follow-ups: actuated = scheduled/in_progress/completed; leak = stale pending ─
+
+async def test_followup_funnel_actuation_and_graveyard(db):
+    await _fu(db, "f1", status="scheduled")               # actuated
+    await _fu(db, "f2", status="completed")               # actuated
+    await _fu(db, "f5", status="in_progress")             # actuated (now counted)
+    await _fu(db, "f3", status="pending", created=_OLD)   # graveyard
+    await _fu(db, "f4", status="pending", created=_NEW)   # fresh pending (not yet a leak)
+    await db.commit()
+
+    f = await lc.followup_funnel(db, stale_before=_STALE_BEFORE)
+    assert f["captured"] == 5
+    assert f["actuated"] == 3
+    assert f["leak_pending_stale"] == 1   # only f3
+    assert f["by_status"]["pending"] == 2
+
+
+# ── ego proposals: actuated = approved/executed; leak = stale pending ─────────
+
+async def test_proposal_funnel(db):
+    await _prop(db, "g1", status="executed")
+    await _prop(db, "g2", status="approved")              # sanctioned → actuated
+    await _prop(db, "g3", status="pending", created=_OLD)
+    await db.commit()
+
+    f = await lc.proposal_funnel(db, stale_before=_STALE_BEFORE)
+    assert f["captured"] == 3
+    assert f["actuated"] == 2
+    assert f["leak_pending_stale"] == 1
+
+
+# ── empty DB: every funnel returns zeros + EMPTY label, no error ──────────────
+
+async def test_funnels_on_empty_db(db):
+    pf = await lc.procedure_funnel(db)
+    assert pf["captured"] == 0 and pf["loop"] == "EMPTY"
+    assert (await lc.observation_funnel(db, stale_before=_STALE_BEFORE))["loop"] == "EMPTY"
+    assert (await lc.reflection_funnel(db))["loop"] == "EMPTY"
+    assert (await lc.followup_funnel(db, stale_before=_STALE_BEFORE))["loop"] == "EMPTY"
+    assert (await lc.proposal_funnel(db, stale_before=_STALE_BEFORE))["loop"] == "EMPTY"
+
+
+# ── MCP assembly + open_seams formatting (W3) ────────────────────────────────
+
+async def test_impl_assembly_and_open_seams(db, monkeypatch):
+    import genesis.mcp.health_mcp as hm
+
+    monkeypatch.setattr(hm, "_service", SimpleNamespace(_db=db))
+
+    await _refl(db, "r1", used=0)        # reflection never used → OPEN seam
+    await _proc(db, "p1", invocation=0)  # uninvoked procedure → leak seam
+    await db.commit()
+
+    from genesis.mcp.health.loop_closure_status import _impl_loop_closure_status
+
+    res = await _impl_loop_closure_status()
+    assert res["status"] == "ok"
+    assert isinstance(res["funnel"], list) and len(res["funnel"]) == 5
+    assert "outcome_bus" in res
+
+    seams = res["open_seams"]
+    assert any("reflection" in s and "OPEN" in s for s in seams)
+    assert any("procedure" in s and "uninvoked" in s for s in seams)
+    # by_tier / by_status dicts must NEVER be rendered as a seam string
+    assert all("{" not in s and "[" not in s for s in seams)


### PR DESCRIPTION
## What

A new read-only `loop_closure_status` MCP tool that answers a question the existing observability couldn't: **is the self-learning loop actually closed, or is learning falling through the cracks?**

It reports a per-artifact funnel — **captured → surfaced/invoked → actuated → measured → leak** — across procedures, observations, reflections, follow-ups, and ego proposals, and names each *open seam*: what's captured but never acted on or measured. The `loop` status (`EMPTY`/`OPEN`/`PARTIAL`/`CLOSED`) is derived from the data, never hardcoded.

## Why

Genesis captures learning in many forms, but there was no single surface to see whether captured learning actually changes behaviour. This makes the gaps measurable — e.g. procedures that are stored but never invoked, or reflections generated but never used — so they can be prioritised by real leak size rather than guesswork.

## Consolidation, not proliferation

This **subsumes** the former `self_improvement_status` tool rather than competing with it: its Outcome Bus / ego-calibration readout becomes the `outcome_bus` section of the new tool, and the standalone registration is dropped (its `_impl` is kept and reused). Net result is one self-learning-health surface instead of two overlapping ones.

## Scope

- No new tables, no writes, no behaviour change — pure read-only reporting over existing CRUD.
- `db/crud/loop_closure.py` — funnel aggregations
- `mcp/health/loop_closure_status.py` — the umbrella tool
- `mcp/health/self_improvement_status.py` — tool registration removed; helper retained
- `tests/test_db/test_loop_closure.py` — funnel + MCP-assembly + open-seams coverage

## Verification

- `ruff check` clean
- 8/8 targeted tests pass (funnel counts, data-derived loop labels, empty-DB, MCP assembly, open-seams formatting)
- Live read-only run against a real database confirms the queries and labels work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)