### PR TITLE
feat(learning): surface golden-dormant procedures + fix reflection loop measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,13 +47,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Changed
 
-- **Genesis no longer auto-surfaces unproven draft procedures.** Procedures it
-  has learned but not yet proven are now recall-only — Genesis can look them up
-  on demand, but they're no longer injected into its context automatically on
-  every message. And the session-start procedure list is trimmed to only the
-  most-proven, always-on procedures, instead of a mix of mid-tier ones of
-  uncertain relevance picked before it even knows what the session is about.
-  Net effect: less noise, and the procedures that do surface have earned it.
+- **Genesis surfaces its learned procedures by relevance — now including unproven
+  drafts, carefully.** A procedure Genesis has learned but not yet validated can be
+  surfaced when it's a strong match for what you're doing, but only on a higher
+  relevance bar than proven procedures and clearly flagged as an *unproven draft —
+  suggestion, not authoritative*. This lets a genuinely useful draft help (and earn
+  its way to proven status through use) instead of sitting unused forever, without
+  ever presenting it as settled guidance. Blind session-start injection still stays
+  limited to the most-proven, always-on procedures. Genesis also now repairs
+  procedures that were missing their embedding, so they stop being silently
+  invisible to this relevance matching.
 
 - **Procedures you actually use now earn their keep.** How often a learned
   procedure is recalled ("reads") now counts as a dampened usefulness signal:

--- a/docs/architecture/genesis-v3-procedure-activation.md
+++ b/docs/architecture/genesis-v3-procedure-activation.md
@@ -41,21 +41,26 @@ Reliability decreases as scope increases. Layers reinforce each other.
 
 Beyond the activation layers, the **proactive memory hook**
 (`scripts/proactive_memory_hook.py` → `_search_procedures`) surfaces the single
-best embedding match on each user message. v2 gates surfacing so each tier is an
-*additive* channel — a higher tier gets everything the lower tiers do, plus one
-more surface:
+best embedding match on each user message. Surfacing is gated so each *higher*
+channel is reserved for *more-proven* tiers:
 
 | Tier | recall (MCP) | proactive hook | tool advisor | session inject |
 |------|:---:|:---:|:---:|:---:|
-| DORMANT  | ✓ |   |   |   |
+| DORMANT  | ✓ | ✓ (strict bar) |   |   |
 | LIBRARY  | ✓ | ✓ |   |   |
 | ADVISORY | ✓ | ✓ | ✓ |   |
 | CORE     | ✓ | ✓ | ✓ | ✓ |
 
-So unproven DORMANT drafts are **recall-only** (never auto-injected), and only the
-proven CORE set is injected blindly at session start. The tiers are ranked
-CORE > ADVISORY > LIBRARY > DORMANT (CORE = most-proven; see `_TIER_RANK` in
-`promoter.py`).
+DORMANT drafts **are** eligible for the proactive hook, but each row is gated
+against its own tier's cosine bar: DORMANT (unproven, conf 0.0) must clear a
+**stricter** cutoff (`_DORMANT_SURFACE_THRESHOLD`, 0.78) than proven tiers
+(`_PROCEDURE_SURFACE_THRESHOLD`, 0.70), and a surfaced DORMANT row is framed to
+the model as an *unproven draft — suggestion, not authoritative*. This breaks the
+golden-dormant lockout (a draft that is never surfaced is never used, so never
+promoted out of DORMANT) while keeping false-positive risk bounded. The tool
+advisor and blind session-start inject remain proven-only (LIBRARY+/CORE). The
+tiers are ranked CORE > ADVISORY > LIBRARY > DORMANT (CORE = most-proven; see
+`_TIER_RANK` in `promoter.py`).
 
 ## Procedure Lifecycle
 

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -500,7 +500,13 @@ def _search_procedures(
                 # All tiers eligible — including DORMANT drafts. The per-row tier
                 # threshold below (not the SQL) is what gates unproven drafts;
                 # surfacing them is how they escape the golden-dormant lockout.
-                "ORDER BY confidence DESC LIMIT 100"
+                # NB: DORMANT drafts have confidence 0.0, so they sort LAST under
+                # "confidence DESC" — a tight LIMIT would starve the exact rows
+                # we want to unlock. The bound is generous (procedures are sparse
+                # by design); the real selector is cosine, computed below over the
+                # whole fetched set. Revisit with a vector index if the pool nears
+                # this bound.
+                "ORDER BY confidence DESC LIMIT 1000"
             ).fetchall()
         finally:
             conn.close()

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -456,21 +456,29 @@ def _search_fts5(
         return []
 
 
-_PROCEDURE_SURFACE_THRESHOLD = 0.7  # Cosine threshold for the procedure hook.
+_PROCEDURE_SURFACE_THRESHOLD = 0.7  # Cosine cutoff for PROVEN tiers (CORE/ADVISORY/LIBRARY).
 # "Recommend a procedure" carries higher risk of being a false positive than
 # "recommend a memory" (procedures are workflow assertions), so use a stricter
 # cosine cutoff. Top-1 only: most prompts have no relevant procedure.
+_DORMANT_SURFACE_THRESHOLD = 0.78  # Stricter bar for UNPROVEN drafts (DORMANT).
+# DORMANT procedures (0 invocations, confidence 0.0) are eligible for surfacing —
+# that's how golden-dormant drafts escape the never-seen → never-used → never-
+# promoted lockout — but they must clear a HIGHER relevance bar than proven tiers
+# before being auto-injected, and the caller frames them as unproven suggestions.
 
 
 def _search_procedures(
     db_path: Path, prompt_vector: list[float],
-) -> tuple[str, str, str] | None:
-    """Return (procedure_id, task_type, principle_snippet) if a procedure's
-    principle embedding clears the cosine threshold, else None.
+) -> tuple[str, str, str, str] | None:
+    """Return (procedure_id, task_type, principle_snippet, activation_tier) if a
+    procedure's principle embedding clears its tier-dependent cosine threshold,
+    else None.
 
-    Only LIBRARY+ tiers (CORE/ADVISORY/LIBRARY) are eligible for proactive
-    surfacing; the DORMANT tier (unproven drafts) is recall-only and never
-    auto-injected.
+    ALL non-deprecated, non-quarantined, embedded procedures are eligible —
+    including DORMANT drafts. Each row is gated against its OWN tier threshold
+    (DORMANT must clear the stricter ``_DORMANT_SURFACE_THRESHOLD``), then the
+    highest-similarity row that cleared its bar wins — so a high-similarity-but-
+    rejected DORMANT never shadows a proven LIBRARY match just below it.
 
     Best-effort: catches every failure mode and returns None so the parent
     hook (memory recall) is never blocked by this addition.
@@ -485,32 +493,39 @@ def _search_procedures(
         try:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(
-                "SELECT id, task_type, principle, principle_embedding "
+                "SELECT id, task_type, principle, principle_embedding, activation_tier "
                 "FROM procedural_memory "
                 "WHERE deprecated = 0 AND quarantined = 0 "
                 "AND principle_embedding IS NOT NULL "
-                # v2: gate proactive surfacing to LIBRARY+ (CORE/ADVISORY/
-                # LIBRARY) — DORMANT drafts are recall-only, never proactively
-                # auto-injected.
-                "AND activation_tier IN ('CORE', 'ADVISORY', 'LIBRARY') "
+                # All tiers eligible — including DORMANT drafts. The per-row tier
+                # threshold below (not the SQL) is what gates unproven drafts;
+                # surfacing them is how they escape the golden-dormant lockout.
                 "ORDER BY confidence DESC LIMIT 100"
             ).fetchall()
         finally:
             conn.close()
 
-        best: tuple[float, str, str, str] | None = None
+        best: tuple[float, str, str, str, str] | None = None
         for row in rows:
             existing_vec = unpack_embedding(row["principle_embedding"])
             if existing_vec is None:
                 continue
             sim = cosine_similarity(prompt_vector, existing_vec)
+            tier = row["activation_tier"] or "DORMANT"
+            threshold = (
+                _DORMANT_SURFACE_THRESHOLD
+                if tier == "DORMANT"
+                else _PROCEDURE_SURFACE_THRESHOLD
+            )
+            if sim < threshold:
+                continue  # row failed its OWN tier's bar — never let it win
             if best is None or sim > best[0]:
-                best = (sim, row["id"], row["task_type"] or "", row["principle"] or "")
+                best = (sim, row["id"], row["task_type"] or "", row["principle"] or "", tier)
 
-        if best is None or best[0] < _PROCEDURE_SURFACE_THRESHOLD:
+        if best is None:
             return None
-        _sim, proc_id, task_type, principle = best
-        return proc_id, task_type, principle[:200]
+        _sim, proc_id, task_type, principle, tier = best
+        return proc_id, task_type, principle[:200], tier
     except Exception:
         return None  # Never block the memory hook
 
@@ -1257,14 +1272,21 @@ async def _run(prompt: str, session_id: str = "") -> None:
             sys.stdout.flush()
 
     # Procedure surfacing — reuses the already-computed prompt embedding
-    # so there's no extra cloud call. Top-1 only, cosine >= 0.7. Wrapped in
-    # a broad try/except so a bad procedure read can't crash the memory hook.
+    # so there's no extra cloud call. Top-1 only, per-tier cosine bar. Wrapped
+    # in a broad try/except so a bad procedure read can't crash the memory hook.
     if vector:
         try:
             proc = _search_procedures(_DB_PATH, vector)
             if proc is not None:
-                proc_id, task_type, principle = proc
-                tag = f"Procedure | {task_type} | id:{proc_id[:8]}" if task_type else f"Procedure | id:{proc_id[:8]}"
+                proc_id, task_type, principle, tier = proc
+                # DORMANT drafts are unproven (0 invocations, conf 0.0): label
+                # them so the model treats them as a hint, not authoritative.
+                label = (
+                    "Procedure (unproven draft — suggestion, not authoritative)"
+                    if tier == "DORMANT"
+                    else "Procedure"
+                )
+                tag = f"{label} | {task_type} | id:{proc_id[:8]}" if task_type else f"{label} | id:{proc_id[:8]}"
                 print(f"[{tag}] {principle}")
                 sys.stdout.flush()
         except Exception as proc_exc:

--- a/src/genesis/db/crud/loop_closure.py
+++ b/src/genesis/db/crud/loop_closure.py
@@ -108,24 +108,68 @@ async def observation_funnel(db: aiosqlite.Connection, *, stale_before: str) -> 
     }
 
 
+# Reflection-OUTPUT observation types — the actuation-bearing reflection
+# artifacts. EXPLICIT allow-list, deliberately NOT a ``LIKE '%reflection%'``:
+# that would wrongly pull in ``quarantined_reflection`` (gatekept failures, not
+# actuation). ``learning`` is excluded too — it is shared with the learning
+# pipeline (``learning/pipeline.py``), so it isn't reflection-exclusive.
+_REFLECTION_OBS_TYPES = (
+    "light_reflection",
+    "micro_reflection",
+    "reflection_output",
+    "reflection_summary",
+    "reflection_observation",
+)
+
+
 async def reflection_funnel(db: aiosqlite.Connection) -> dict:
-    """Reflections: actuation signal = ``used_in_optimization``. Leak = generated
-    but never used to change anything."""
-    total = await _scalar(db, "SELECT COUNT(*) FROM reflection_corpus")
-    graded = await _scalar(
-        db, "SELECT COUNT(*) FROM reflection_corpus WHERE quality_label IS NOT NULL"
+    """Reflections actuate as OBSERVATIONS, not via ``reflection_corpus``.
+
+    ``reflection_corpus`` is the raw reflection-LLM transcript log; its
+    ``used_in_optimization`` column was reserved for a prompt-optimization
+    pipeline that was never built (zero writers in the codebase) — so a 0 there
+    is NOT a leak, it's an unbuilt arc. The real actuation flows through the
+    reflection-output observations (``_REFLECTION_OBS_TYPES``), measured by
+    ``influenced_action``.
+
+    This is a focused SUBSET view of rows already counted in
+    ``observation_funnel`` (they live in both), so it intentionally emits **no**
+    ``leak_`` key — the staleness/leak of those rows is owned by
+    ``observation_funnel`` and must not be double-counted in the umbrella's
+    open-seams. ``leaked`` here is internal to the loop label only.
+    """
+    placeholders = ",".join("?" for _ in _REFLECTION_OBS_TYPES)
+    captured = await _scalar(
+        db,
+        f"SELECT COUNT(*) FROM observations WHERE type IN ({placeholders})",
+        _REFLECTION_OBS_TYPES,
     )
-    used = await _scalar(
-        db, "SELECT COUNT(*) FROM reflection_corpus WHERE used_in_optimization = 1"
+    actuated = await _scalar(
+        db,
+        f"SELECT COUNT(*) FROM observations "
+        f"WHERE type IN ({placeholders}) AND influenced_action = 1",
+        _REFLECTION_OBS_TYPES,
     )
-    leak_unused = total - used
+    # Raw transcript capture log — context only, NOT the actuation signal.
+    corpus_captured = await _scalar(db, "SELECT COUNT(*) FROM reflection_corpus")
+    corpus_parsed = await _scalar(
+        db, "SELECT COUNT(*) FROM reflection_corpus WHERE parsed_ok = 1"
+    )
+    leaked = captured - actuated  # loop-label math only; never exposed as leak_
     return {
         "artifact": "reflection",
-        "captured": total,
-        "graded": graded,
-        "actuated": used,
-        "leak_unused": leak_unused,
-        "loop": _loop_label(total, flowing=used, leaked=leak_unused),
+        "captured": captured,
+        "actuated": actuated,
+        "corpus_captured": corpus_captured,
+        "corpus_parsed": corpus_parsed,
+        "optimization_pipeline": "not_built",
+        "loop": _loop_label(captured, flowing=actuated, leaked=leaked),
+        "note": (
+            "actuation measured via reflection-output observations (subset of "
+            "observation_funnel — not additive); reflection_corpus."
+            "used_in_optimization is reserved for an unbuilt optimization "
+            "pipeline, not a leak"
+        ),
     }
 
 

--- a/src/genesis/learning/procedural/promoter.py
+++ b/src/genesis/learning/procedural/promoter.py
@@ -204,3 +204,88 @@ async def promote_and_demote(db: aiosqlite.Connection) -> dict:
     if any(v > 0 for v in result.values()):
         logger.info("Promotion results: %s", result)
     return result
+
+
+# Bound per run: backfilling re-embeds via the network, so cap how many
+# missing-embedding rows we repair per hourly pass (the steady-state count is 0).
+_EMBED_BACKFILL_LIMIT = 10
+
+
+async def backfill_missing_embeddings(
+    db: aiosqlite.Connection, *, limit: int = _EMBED_BACKFILL_LIMIT
+) -> int:
+    """Re-embed active procedures whose ``principle_embedding`` is NULL.
+
+    Both create paths embed at store time, but the embed is best-effort — a
+    transient backend outage (or a pre-embedding legacy row) leaves the column
+    NULL, and a NULL-embedding procedure is invisible to the relevance-gated
+    proactive hook (never surfaced → never invoked → never promoted). This
+    self-healing pass repairs those rows so they rejoin the surfacing pool.
+
+    Network embeds are done FIRST (outside any write), then the quick UPDATEs are
+    applied — so the embedding round-trips never interleave with held DB state on
+    the shared connection. Fail-open: an embedder outage aborts the run cleanly
+    (retried next hour); a per-row failure is logged and skipped. Returns the
+    number of rows repaired.
+    """
+    try:
+        cur = await db.execute(
+            "SELECT id, principle FROM procedural_memory "
+            "WHERE principle_embedding IS NULL AND deprecated = 0 AND quarantined = 0 "
+            "AND principle IS NOT NULL AND principle != '' "
+            "ORDER BY created_at DESC LIMIT ?",
+            (limit,),
+        )
+        rows = await cur.fetchall()
+    except Exception:
+        logger.warning("Embedding backfill: query failed", exc_info=True)
+        return 0
+
+    if not rows:
+        return 0
+
+    try:
+        from genesis.learning.procedural.embedding import pack_embedding
+        from genesis.memory.embeddings import (
+            EmbeddingProvider,
+            EmbeddingUnavailableError,
+        )
+
+        provider = EmbeddingProvider()
+    except Exception:
+        logger.warning("Embedding backfill: provider unavailable — skipping run")
+        return 0
+
+    # Phase 1 — embed (network). Gather blobs without touching the DB so the
+    # round-trips don't interleave with held state on the shared connection.
+    pending: list[tuple[str, bytes]] = []
+    for row in rows:
+        pid, principle = row[0], row[1]
+        try:
+            blob = pack_embedding(await provider.embed(principle))
+        except EmbeddingUnavailableError:
+            # Backend outage — stop now, retry the whole batch next hour.
+            logger.warning("Embedding backfill: embedder unavailable, aborting run")
+            break
+        except Exception:
+            # Bad vector dim / pack error for this row — skip it, keep going.
+            logger.warning(
+                "Embedding backfill: failed to embed %s; skipping", pid, exc_info=True
+            )
+            continue
+        pending.append((pid, blob))
+
+    # Phase 2 — quick writes.
+    repaired = 0
+    for pid, blob in pending:
+        try:
+            if await procedural.update(db, pid, principle_embedding=blob):
+                repaired += 1
+        except Exception:
+            logger.warning(
+                "Embedding backfill: failed to write %s; skipping", pid, exc_info=True
+            )
+
+    if repaired:
+        logger.info("Embedding backfill: repaired %d procedure embedding(s)", repaired)
+    return repaired

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -509,6 +509,17 @@ async def init(rt: GenesisRuntime) -> None:
             except Exception as exc:
                 rt.record_job_failure("procedure_promotion", str(exc))
                 logger.exception("Procedure promotion failed")
+            # Self-healing embedding backfill — independent of promotion so a
+            # backfill failure never fails the promotion job. Repairs procedures
+            # whose principle_embedding is NULL (transient embed failure at
+            # create) so they rejoin the proactive-surfacing pool.
+            try:
+                from genesis.learning.procedural.promoter import (
+                    backfill_missing_embeddings,
+                )
+                await backfill_missing_embeddings(rt._db)
+            except Exception:
+                logger.exception("Procedure embedding backfill failed")
 
         # CronTrigger instead of IntervalTrigger: IntervalTrigger resets its
         # countdown on every server restart, so under frequent restarts the job

--- a/tests/test_db/test_loop_closure.py
+++ b/tests/test_db/test_loop_closure.py
@@ -33,12 +33,12 @@ async def _proc(db, pid, *, invocation=0, success=0, failure=0, tier="DORMANT", 
     )
 
 
-async def _obs(db, oid, *, influenced=0, resolved=0, surfaced=0, created=_NEW):
+async def _obs(db, oid, *, otype="generic", influenced=0, resolved=0, surfaced=0, created=_NEW):
     await db.execute(
         "INSERT INTO observations "
         "(id, source, type, content, priority, created_at, influenced_action, resolved, surfaced_count) "
         "VALUES (?,?,?,?,?,?,?,?,?)",
-        (oid, "s", "generic", "c", "medium", created, influenced, resolved, surfaced),
+        (oid, "s", otype, "c", "medium", created, influenced, resolved, surfaced),
     )
 
 
@@ -109,20 +109,38 @@ async def test_observation_funnel_partial_with_leak(db):
     assert f["loop"] == "PARTIAL"
 
 
-# ── reflections: actuation = used_in_optimization ────────────────────────────
+# ── reflections: actuation measured via reflection-output observations ────────
 
-async def test_reflection_funnel_flags_unused(db):
-    await _refl(db, "r1", used=1, quality="good")
-    await _refl(db, "r2", used=0, quality="fair")
-    await _refl(db, "r3", used=0)               # ungraded too
+async def test_reflection_funnel_measures_observation_actuation(db):
+    # reflection-output observations carry the actuation signal
+    await _obs(db, "ro1", otype="micro_reflection", influenced=1)    # actuated
+    await _obs(db, "ro2", otype="reflection_summary", influenced=0)  # not actuated
+    await _obs(db, "ro3", otype="light_reflection", influenced=1)    # actuated
+    # quarantined_reflection is a gatekept failure → must NOT be counted
+    await _obs(db, "qr1", otype="quarantined_reflection", influenced=0)
+    # a non-reflection observation → must NOT be counted
+    await _obs(db, "g1", otype="generic", influenced=0)
+    # raw corpus transcripts: context only; used_in_optimization is a dead column
+    await _refl(db, "c1", used=0)
     await db.commit()
 
     f = await lc.reflection_funnel(db)
-    assert f["captured"] == 3
-    assert f["graded"] == 2
-    assert f["actuated"] == 1
-    assert f["leak_unused"] == 2
-    assert f["loop"] == "PARTIAL"
+    assert f["captured"] == 3            # ro1/ro2/ro3 only (not qr1, not g1)
+    assert f["actuated"] == 2            # ro1 + ro3
+    assert f["corpus_captured"] == 1     # transcript log, context only
+    assert f["optimization_pipeline"] == "not_built"
+    # emits NO leak_ key — those rows' staleness is owned by observation_funnel
+    assert not any(k.startswith("leak_") for k in f)
+    assert f["loop"] == "PARTIAL"        # some actuate, some don't — NOT OPEN
+
+
+async def test_reflection_funnel_open_only_when_no_actuation(db):
+    # genuinely OPEN (real, not a dead-column artifact) when nothing influenced
+    await _obs(db, "ro1", otype="reflection_observation", influenced=0)
+    await db.commit()
+    f = await lc.reflection_funnel(db)
+    assert f["captured"] == 1 and f["actuated"] == 0
+    assert f["loop"] == "OPEN"
 
 
 # ── follow-ups: actuated = scheduled/in_progress/completed; leak = stale pending ─
@@ -174,7 +192,9 @@ async def test_impl_assembly_and_open_seams(db, monkeypatch):
 
     monkeypatch.setattr(hm, "_service", SimpleNamespace(_db=db))
 
-    await _refl(db, "r1", used=0)        # reflection never used → OPEN seam
+    # reflections actuate via observations → NOT a false OPEN on the dead column
+    await _obs(db, "ro1", otype="micro_reflection", influenced=1)
+    await _refl(db, "r1", used=0)        # raw transcript (context only)
     await _proc(db, "p1", invocation=0)  # uninvoked procedure → leak seam
     await db.commit()
 
@@ -186,7 +206,9 @@ async def test_impl_assembly_and_open_seams(db, monkeypatch):
     assert "outcome_bus" in res
 
     seams = res["open_seams"]
-    assert any("reflection" in s and "OPEN" in s for s in seams)
+    # the procedure leak still surfaces honestly
     assert any("procedure" in s and "uninvoked" in s for s in seams)
+    # reflections must NOT be flagged OPEN any more (dead-column false positive gone)
+    assert not any("reflection" in s and "OPEN" in s for s in seams)
     # by_tier / by_status dicts must NEVER be rendered as a seam string
     assert all("{" not in s and "[" not in s for s in seams)

--- a/tests/test_learning/test_embedding_backfill.py
+++ b/tests/test_learning/test_embedding_backfill.py
@@ -1,0 +1,84 @@
+"""Tests for promoter.backfill_missing_embeddings (LC1-B).
+
+Procedures whose ``principle_embedding`` is NULL (a transient embed failure at
+create time, or a legacy row) are invisible to the relevance-gated proactive
+hook. The hourly backfill re-embeds them so they rejoin the surfacing pool. The
+embedder is faked here — these are deterministic unit tests, no network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.db.crud import procedural
+from genesis.learning.procedural import promoter
+from genesis.learning.procedural.embedding import EMBEDDING_DIM, unpack_embedding
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeProvider:
+    def __init__(self, *, fail: bool = False) -> None:
+        self._fail = fail
+
+    async def embed(self, text: str) -> list[float]:
+        if self._fail:
+            from genesis.memory.embeddings import EmbeddingUnavailableError
+
+            raise EmbeddingUnavailableError("backends down")
+        return [0.1] * EMBEDDING_DIM
+
+
+def _patch_provider(monkeypatch, *, fail: bool = False) -> None:
+    monkeypatch.setattr(
+        "genesis.memory.embeddings.EmbeddingProvider",
+        lambda *a, **k: _FakeProvider(fail=fail),
+    )
+
+
+async def _mk(db, pid, *, embed=None, tier="LIBRARY", deprecated=0, quarantined=0):
+    await db.execute(
+        "INSERT INTO procedural_memory "
+        "(id, task_type, principle, steps, tools_used, context_tags, created_at, "
+        " activation_tier, principle_embedding, deprecated, quarantined) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+        (pid, "t", "do x", "[]", "[]", "[]", "2026-01-01T00:00:00",
+         tier, embed, deprecated, quarantined),
+    )
+
+
+async def test_backfill_repairs_null_embeddings(db, monkeypatch):
+    _patch_provider(monkeypatch)
+    await _mk(db, "p1", embed=None)                        # NULL → repaired
+    await _mk(db, "p2", embed=b"x" * (EMBEDDING_DIM * 4))  # already embedded → untouched
+    await db.commit()
+
+    assert await promoter.backfill_missing_embeddings(db) == 1
+    row = await procedural.get_by_id(db, "p1")
+    assert row["principle_embedding"] is not None
+    assert unpack_embedding(row["principle_embedding"]) is not None
+
+
+async def test_backfill_skips_deprecated_and_quarantined(db, monkeypatch):
+    _patch_provider(monkeypatch)
+    await _mk(db, "dep", embed=None, deprecated=1)
+    await _mk(db, "quar", embed=None, quarantined=1)
+    await db.commit()
+    assert await promoter.backfill_missing_embeddings(db) == 0
+
+
+async def test_backfill_fail_open_on_embedder_outage(db, monkeypatch):
+    _patch_provider(monkeypatch, fail=True)
+    await _mk(db, "p1", embed=None)
+    await db.commit()
+    # Outage → 0 repaired, no exception raised, row stays NULL (retried next run).
+    assert await promoter.backfill_missing_embeddings(db) == 0
+    row = await procedural.get_by_id(db, "p1")
+    assert row["principle_embedding"] is None
+
+
+async def test_backfill_noop_when_all_embedded(db, monkeypatch):
+    _patch_provider(monkeypatch)
+    await _mk(db, "p1", embed=b"x" * (EMBEDDING_DIM * 4))
+    await db.commit()
+    assert await promoter.backfill_missing_embeddings(db) == 0

--- a/tests/test_learning/test_proactive_hook_subprocess.py
+++ b/tests/test_learning/test_proactive_hook_subprocess.py
@@ -94,9 +94,10 @@ def seeded_db(tmp_path: Path):
     assert vector is not None, "Embedding failed during test setup"
 
     proc_id = str(uuid.uuid4())
-    # activation_tier must be LIBRARY+ (CORE/ADVISORY/LIBRARY): Surfacing v2
-    # gates the proactive hook to those tiers, so a default-'DORMANT' procedure
-    # would be recall-only and never surfaced here. LIBRARY is the eligibility floor.
+    # Seed at LIBRARY for a deterministic proven-tier match. Since LC1-A, DORMANT
+    # drafts are ALSO eligible to surface (at a stricter cosine bar + 'unproven
+    # draft' framing); LIBRARY keeps this E2E assertion on the proven path so the
+    # exact `[Procedure |` prefix is expected (DORMANT carries a draft-note prefix).
     conn.execute(
         "INSERT INTO procedural_memory "
         "(id, task_type, principle, principle_embedding, confidence, activation_tier) "

--- a/tests/test_learning/test_proactive_procedure_tier.py
+++ b/tests/test_learning/test_proactive_procedure_tier.py
@@ -1,17 +1,25 @@
-"""Tests for proactive-hook procedure tier gating (Surfacing v2 PR-A).
+"""Tests for proactive-hook procedure tier gating (LC1-A: golden-dormant unlock).
 
-The UserPromptSubmit hook's `_search_procedures` previously surfaced the
-best cosine match across ALL tiers — including the large pool of unproven
-DORMANT drafts. v2 gates proactive surfacing to LIBRARY+ (CORE/ADVISORY/
-LIBRARY), making DORMANT drafts recall-only (never auto-injected).
+History: "Surfacing v2" (PR-A) gated proactive surfacing to LIBRARY+ and made
+DORMANT drafts recall-only — which locked golden-dormant drafts out forever
+(never surfaced → never invoked → never promoted). LC1-A reverses that with a
+SAFER rule: ALL tiers are eligible, but each row is gated against its OWN tier
+threshold — DORMANT (unproven) must clear a STRICTER cosine bar
+(`_DORMANT_SURFACE_THRESHOLD`, 0.78) than proven tiers
+(`_PROCEDURE_SURFACE_THRESHOLD`, 0.70) — and the caller frames a surfaced
+DORMANT row as an unproven suggestion. The highest-similarity row that clears
+its own bar wins, so a high-cosine-but-rejected DORMANT never shadows a proven
+LIBRARY match just below it.
 
 `_search_procedures(db_path, prompt_vector)` takes the vector directly, so
-these are fast unit tests with seeded embeddings — no embedding backend.
+these are fast unit tests with seeded embeddings — no embedding backend. It
+returns a 4-tuple `(proc_id, task_type, principle_snippet, activation_tier)`.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import math
 import os
 import sys
 from pathlib import Path
@@ -34,11 +42,14 @@ _spec.loader.exec_module(_mod)
 _search_procedures = _mod._search_procedures
 
 
-def _vec(*head: float) -> list[float]:
-    """A 1024-dim embedding: leading components then zero-pad (pack_embedding
-    requires EMBEDDING_DIM=1024). Cosine is determined by the head values."""
-    return list(head) + [0.0] * (1024 - len(head))
+def _unit(cos: float) -> list[float]:
+    """A 1024-dim UNIT vector whose cosine with ``_unit(1.0)`` (== [1,0,0,…]) is
+    exactly ``cos``: components [cos, sqrt(1-cos^2), 0, …]."""
+    rest = math.sqrt(max(0.0, 1.0 - cos * cos))
+    return [cos, rest] + [0.0] * (1024 - 2)
 
+
+_QUERY = _unit(1.0)  # cosine(_QUERY, _unit(c)) == c
 
 _COLS = (
     "id, task_type, principle, steps, tools_used, context_tags, "
@@ -63,40 +74,73 @@ async def _seed(db_path, rows: list[dict]) -> None:
 
 
 @pytest.mark.asyncio
-async def test_dormant_excluded_even_at_best_cosine(tmp_path):
-    """A DORMANT row that is the BEST cosine match is still excluded;
-    the lower-scoring LIBRARY row is surfaced instead."""
+async def test_dormant_surfaced_when_it_clears_the_strict_bar(tmp_path):
+    """LC1-A: a DORMANT draft that clears the stricter 0.78 bar IS surfaced,
+    and the returned 4-tuple carries its tier so the caller can frame it."""
     db = tmp_path / "t.db"
     await _seed(db, [
-        {"id": "d", "task_type": "dorm", "principle": "dormant", "confidence": 0.9,
-         "activation_tier": "DORMANT", "embedding": _vec(1.0)},
-        {"id": "l", "task_type": "lib", "principle": "library", "confidence": 0.5,
-         "activation_tier": "LIBRARY", "embedding": _vec(0.8, 0.6)},
+        {"id": "d", "task_type": "dorm", "principle": "p", "confidence": 0.0,
+         "activation_tier": "DORMANT", "embedding": _unit(0.9)},
     ])
-    result = _search_procedures(db, _vec(1.0))
+    result = _search_procedures(db, _QUERY)
     assert result is not None
-    _proc_id, task_type, _principle = result
-    assert task_type == "lib"
+    proc_id, task_type, _principle, tier = result
+    assert task_type == "dorm" and tier == "DORMANT"
 
 
 @pytest.mark.asyncio
-async def test_only_dormant_returns_none(tmp_path):
-    """When the only match is DORMANT, nothing is proactively surfaced."""
+async def test_dormant_below_strict_bar_does_not_shadow_library(tmp_path):
+    """The key safety property: a DORMANT with HIGHER cosine but below its own
+    0.78 bar must NOT shadow a proven LIBRARY row that clears the 0.70 bar."""
+    db = tmp_path / "t.db"
+    await _seed(db, [
+        # cosine 0.75: best overall, but below the DORMANT bar (0.78) → rejected
+        {"id": "d", "task_type": "dorm", "principle": "p", "confidence": 0.9,
+         "activation_tier": "DORMANT", "embedding": _unit(0.75)},
+        # cosine 0.72: clears the LIBRARY bar (0.70) → should win
+        {"id": "l", "task_type": "lib", "principle": "p", "confidence": 0.5,
+         "activation_tier": "LIBRARY", "embedding": _unit(0.72)},
+    ])
+    result = _search_procedures(db, _QUERY)
+    assert result is not None
+    assert result[1] == "lib" and result[3] == "LIBRARY"
+
+
+@pytest.mark.asyncio
+async def test_only_dormant_below_bar_returns_none(tmp_path):
+    """A DORMANT below the strict bar with no other candidate → nothing surfaces."""
     db = tmp_path / "t.db"
     await _seed(db, [
         {"id": "d", "task_type": "dorm", "principle": "p", "confidence": 0.9,
-         "activation_tier": "DORMANT", "embedding": _vec(1.0)},
+         "activation_tier": "DORMANT", "embedding": _unit(0.75)},  # < 0.78
     ])
-    assert _search_procedures(db, _vec(1.0)) is None
+    assert _search_procedures(db, _QUERY) is None
 
 
 @pytest.mark.asyncio
 async def test_library_tier_still_surfaced(tmp_path):
-    """Regression: LIBRARY+ tiers are NOT over-filtered — a clean match still surfaces."""
+    """Regression: proven LIBRARY+ tiers still surface on a clean match."""
     db = tmp_path / "t.db"
     await _seed(db, [
         {"id": "l", "task_type": "lib", "principle": "p", "confidence": 0.5,
-         "activation_tier": "LIBRARY", "embedding": _vec(1.0)},
+         "activation_tier": "LIBRARY", "embedding": _unit(1.0)},
     ])
-    result = _search_procedures(db, _vec(1.0))
-    assert result is not None and result[1] == "lib"
+    result = _search_procedures(db, _QUERY)
+    assert result is not None and result[1] == "lib" and result[3] == "LIBRARY"
+
+
+@pytest.mark.asyncio
+async def test_deprecated_and_quarantined_never_surface(tmp_path):
+    """Correctness filters still apply — only DORMANT *exclusion* was lifted."""
+    db = tmp_path / "t.db"
+    async with aiosqlite.connect(str(db)) as conn:
+        await create_all_tables(conn)
+        for pid, tier, dep, quar in [("dep", "LIBRARY", 1, 0), ("quar", "CORE", 0, 1)]:
+            await conn.execute(
+                f"INSERT INTO procedural_memory ({_COLS}, deprecated, quarantined) "
+                "VALUES (?, ?, ?, '[]', '[]', '[]', ?, ?, ?, ?, ?, ?)",
+                (pid, "t", "p", 0.9, "2026-01-01T00:00:00", tier,
+                 pack_embedding(_unit(1.0)), dep, quar),
+            )
+        await conn.commit()
+    assert _search_procedures(db, _QUERY) is None


### PR DESCRIPTION
## What & why

Three fixes to how Genesis surfaces its learned procedures and reports its own learning-loop health.

### Surface golden-dormant procedures (instead of locking them out)
The proactive hook excluded unproven (DORMANT) procedure drafts from surfacing entirely, which created a dead end: a draft that is never surfaced is never used, so it never earns the successes that would promote it — it sits unused forever. Now all tiers are eligible, but each row is gated against its own tier's relevance bar: an unproven draft must clear a **stricter** cosine cutoff (0.78 vs 0.70) and is surfaced with explicit framing (*unproven draft — suggestion, not authoritative*). The highest-similarity row that clears its own bar wins, so a high-cosine-but-rejected draft never shadows a proven match just below it.

### Self-heal missing procedure embeddings
Both procedure-creation paths embed the principle at store time, but the embed is best-effort — a transient backend outage leaves the embedding NULL, and a NULL-embedding procedure is invisible to the relevance-gated hook. The hourly promoter now re-embeds those rows (bounded, embed-first/write-second, fail-open), so they rejoin the surfacing pool.

### Measure the reflection loop via observations
The loop-closure health view reported reflections as a permanently open loop because it read `reflection_corpus.used_in_optimization` — a column with no writers (its optimization-pipeline consumer was never built). Reflections actually actuate as observations (`influenced_action`). The funnel now measures that, with the unbuilt optimization pipeline labelled as reserved rather than counted as a leak. It is a focused subset view of the observation funnel and emits no leak key, so those rows are not double-counted.

## Verification
- New/updated unit tests: per-tier surfacing logic (incl. shadow-prevention + deprecated/quarantined filters), embedding backfill (repair / skip deprecated+quarantined / fail-open on outage), and the reflection funnel (allow-list excludes gatekept and shared observation types; emits no leak key).
- Targeted suite green; ruff clean.
- Reflection funnel verified against a live database: reports PARTIAL with the correct actuation counts (previously a false "open").

## Notes
- Reflection "actuated" uses the same definition as the observation funnel (an output later surfaced into a context render) — a deliberately loose proxy; the view reports PARTIAL, not closed.
- Recording a signal when a procedure is *surfaced* (as distinct from explicitly recalled) is intentionally left to a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)