### PR TITLE
docs: reframe code-intelligence around tool lanes + freshness

### DIFF
--- a/.claude/docs/code-intelligence-guide.md
+++ b/.claude/docs/code-intelligence-guide.md
@@ -45,11 +45,18 @@ Config: `.serena/project.yml`
 
 ## GitNexus (Knowledge Graph)
 
-Graph of ~41K nodes and ~66K edges. CLI: `gitnexus <command>`.
+Graph of ~32K nodes and ~51K edges (v1.6.8). CLI: `gitnexus <command>`.
 Index: `.gitnexus/lbug` (LadybugDB). Refresh: `gitnexus analyze`.
 
-**Best for:** impact analysis, execution flows, coupling, routes, tools,
-text search (`gitnexus query` — FTS fixed in 1.6.5 / @ladybugdb/core 0.16.1).
+**Snapshot-based — reindex when freshness matters.** The index reflects the
+commit it was built at; its auto-reindex fires on local commit, NOT on
+`git pull` of merged PRs, so it drifts after merges. Run `gitnexus analyze`
+before trusting `impact`/flows for a load-bearing decision; for live "who calls
+X" during active editing, Serena (LSP) is always current.
+
+**Best for:** impact analysis, execution flows, coupling, routes, tools.
+Text search (`gitnexus query`) needs the LadybugDB FTS extension (see Known
+Limitations).
 
 ### Graph Structure
 
@@ -151,9 +158,10 @@ gitnexus impact "Method:src/genesis/autonomy/dispatcher.py:TaskDispatcher.submit
 
 ### Known Limitations
 
-- **FTS/text search fixed.** LadybugDB/ladybug#430 resolved in
-  @ladybugdb/core 0.16.1 (shipped with GitNexus 1.6.5). `gitnexus query`
-  now works on Linux.
+- **FTS/text search depends on the LadybugDB extension.** When it isn't
+  pre-installed, `gitnexus analyze` logs "FTS extension unavailable; continuing
+  without FTS" and `gitnexus query` is degraded — it does NOT crash. Use
+  Serena/Grep for text/symbol search when FTS is off.
 - **Vector/embedding search not configured.** Requires `--embeddings`
   flag at analyze time + embedding provider.
 

--- a/.claude/docs/code-intelligence.md
+++ b/.claude/docs/code-intelligence.md
@@ -1,7 +1,10 @@
 # Code Intelligence — Decision Guide
 
-Four tool layers for code search and analysis, lightest to richest.
-Use the lightest layer that answers your question.
+Four tools for code search and analysis, each with a lane. Pick by the
+question, not a fixed hierarchy. One freshness rule cuts across all of them:
+**Serena is always live** (LSP — parses current files per query, never stale),
+while **CBM and GitNexus are indexed** and drift after you pull merged PRs —
+reindex before trusting them for anything load-bearing.
 
 ## Tool Layers
 
@@ -58,17 +61,23 @@ higher-confidence answers faster and catch things manual reads miss.
 
 ## Per-Tool Notes
 
-**Serena** — 1-2s LSP init on first call per session, then fast. Config:
-`.serena/project.yml`. Python-only (Pyright). Does not follow mock patterns
-in tests. Use Grep for non-Python files.
+**Serena** — **always live** (LSP via Pyright; parses current files per query,
+so it never goes stale — no index to rebuild). 1-2s init on first call per
+session, then fast. Config: `.serena/project.yml`. Python-only. Does not follow
+mock patterns in tests. Use Grep for non-Python files. Default for
+symbol/reference/impact questions.
 
 **codebase-memory-mcp** — Tree-sitter code graph, SQLite index (~48MB for
 Genesis). Supports 66 languages. 3D visualization at `localhost:9749`.
-Index rebuilds automatically on each commit (post-commit hook). If stale,
-run `index_repository` manually.
+Indexed (reindex on local commit); if stale, run `index_repository`.
 
-**GitNexus** — LadybugDB graph. All tools work including `query` (FTS
-fixed in 1.6.5). Auto-reindexes on commit + scheduled Mon/Thu 5am UTC.
+**GitNexus** — LadybugDB graph (v1.6.8). Snapshot-based: correct only when the
+index matches the working tree. Its reindex fires on local commit, **not** on
+`git pull` of merged PRs, so the index silently drifts after merges — a stale
+`impact` is confidently wrong exactly mid-change. **Reindex (`gitnexus analyze`)
+when you reach for it** for something load-bearing, and prefer Serena for live
+blast-radius. `query` (FTS) may be unavailable depending on the LadybugDB
+extension — it degrades gracefully (skips FTS, no crash).
 
 **Grep/Glob/Read** — Always available, zero overhead. Preferred for config
 files, markdown, YAML, JSON, shell scripts, SQL, and any non-code content.

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -85,23 +85,28 @@ changes: verify the notification actually arrives. Ask: "If the system
 restarts right now, will this actually work?" If you can't answer yes
 with evidence, you're not done.
 
-### Use GitNexus for Structural Code Intelligence
+### Code Intelligence — pick the right lane
 
-GitNexus provides graph-based code intelligence that Grep/Serena cannot:
-multi-hop call chains, blast radius, execution flows, coupling analysis.
+**Serena (Python LSP) is always live** — it parses current files per query, so
+it's the default for symbol/reference/impact questions ("who calls X", "what
+breaks if I change Z") and never goes stale. CBM gives the architecture/graph
+overview. GitNexus does what neither can — multi-hop blast radius, execution
+flows, route/tool maps, coupling/community analysis — but it is **snapshot-
+based**: its answers are only correct when the index matches the working tree,
+and it drifts after you pull merged PRs (its reindex fires on local commit, not
+on pull). So reach for GitNexus deliberately for its unique views, and run
+**`gitnexus analyze` first** when freshness matters; for live "who calls this"
+during active editing, prefer Serena. There is no "always run impact before
+every edit" mandate — that just gates work behind a tool that's stale-by-design.
 
-**Before editing:** `gitnexus impact <symbol>` — check blast radius.
-Use full UID if ambiguous (e.g., `Method:path/file.py:Class.method#N`).
-
-**Before committing:** `gitnexus detect-changes` — verify you haven't
-missed dependent symbols.
-
-**Understanding unfamiliar code:** `gitnexus context <symbol>` for 360°
-view, or browse processes via `gitnexus://repo/GENesis-AGI/processes`.
-
-**Custom questions:** `gitnexus cypher` for raw graph queries. Note:
-LadybugDB uses `CodeRelation` with a `type` property for edges, not
-Neo4j-style named edge labels.
+- **Blast radius / impact:** Serena `find_referencing_symbols` (live) for the
+  direct caller set; GitNexus `impact <symbol>` (reindex first) for multi-hop +
+  affected processes/risk. Use the full UID if ambiguous
+  (`Method:path/file.py:Class.method#N`).
+- **Unfamiliar code:** `gitnexus context <symbol>` or browse
+  `gitnexus://repo/GENesis-AGI/processes` (when fresh).
+- **Custom questions:** `gitnexus cypher` — LadybugDB uses `CodeRelation` with a
+  `type` property for edges, not Neo4j-style named edge labels.
 
 Full syntax, Cypher examples, and decision matrix:
 `.claude/docs/code-intelligence-guide.md`
@@ -141,7 +146,7 @@ thinking any of these, STOP — you are rationalizing a shortcut.
 | "I'll clean this up in the next commit" | Next commit never comes in autonomous sessions. Do it now or create a follow-up. |
 | "This file is too large to read fully" | Read the relevant section. Partial reads lead to partial understanding and wrong fixes. |
 | "The linter is happy, ship it" | Linters catch syntax, not logic. Clean lint with broken behavior is worse than a warning with correct behavior. |
-| "This change is low-risk, no impact analysis needed" | Your confidence is based on what you know. Impact analysis reveals what you don't. Run gitnexus impact. |
+| "This change is low-risk, no impact analysis needed" | Your confidence is based on what you know; checking callers reveals what you don't. Serena `find_referencing_symbols` is live — run it. For multi-hop blast radius, `gitnexus analyze` then `impact`. |
 | "I can skip the worktree, I'll be quick" | Concurrent session safety exists because "quick" commits have destroyed work before. Always worktree. |
 | "The error is transient, retry will fix it" | Diagnose first. Retrying a misdiagnosed error wastes tokens and masks root causes. |
 | "I'll add the follow-up later" | Follow-ups not created in-session are lost. Create it now while context is fresh. |
@@ -155,7 +160,7 @@ Use the right tool for how you're exploring:
 - **Architecture overview** — CBM `get_architecture(aspects=["overview"])`
 - **Finding symbols** — CBM `search_graph(name_pattern="...")` or Serena `find_symbol`
 - **Call tracing** — CBM `trace_path(function_name="...")` or Serena `find_referencing_symbols`
-- **Impact before changes** — GitNexus `impact(path="...")`
+- **Impact / blast radius** — Serena `find_referencing_symbols` (live caller set); GitNexus `impact` (reindex first) for multi-hop + affected processes
 - **Config/doc/non-code files** — Grep/Read directly
 
 Full decision matrix: `.claude/docs/code-intelligence.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,12 +71,14 @@ systemctl --user status genesis-server            # Verify server running
 
 ## Code Intelligence
 
-Four tool layers: (1) Grep/Glob/Read for text/configs, (2) Serena for
-Python LSP, (3) codebase-memory-mcp for code graph, (4) GitNexus for
-blast radius and impact analysis. Use GitNexus `impact` before editing
-symbols and `detect-changes` before committing. Use Serena or GitNexus
-for dependency questions, not manual file reads.
-Full decision matrix: `.claude/docs/code-intelligence.md`
+Pick the tool by the question (full matrix + freshness model:
+`.claude/docs/code-intelligence.md`): **Grep/Glob/Read** for text/configs;
+**Serena** (Python LSP) for symbols/references/rename — **always live**, the
+default for "who calls X / what breaks if I change Z"; **codebase-memory-mcp**
+for architecture/graph; **GitNexus** for deep blast-radius/flows/coupling —
+**snapshot-based, so `gitnexus analyze` first** when freshness matters (it
+drifts after pulling merged PRs). Prefer these over manual reads for dependency
+questions; none is a mandatory pre-edit gate.
 
 ## Skill Library
 


### PR DESCRIPTION
## Why

The code-intelligence guidance mandated running GitNexus `impact` before editing any symbol and `detect-changes` before committing. GitNexus is **snapshot-based** — its graph reflects the commit it was indexed at, and its auto-reindex fires on a local commit, *not* on `git pull` of merged PRs — so the index silently drifts after merges. That makes a hard pre-edit/pre-commit mandate gate work behind a tool that's stale-by-design, and a stale `impact` answer is confidently wrong exactly mid-change. Serena (LSP) has no such failure mode: it parses current files per query, so it's always live.

## What

Reframe the guidance around **lanes**, not a fixed hierarchy or a mandatory gate, across `CLAUDE.md`, the genesis-development skill, and both `code-intelligence*.md` docs:

- **Serena** (Python LSP) — always live; the default for symbol / reference / impact ("who calls X", "what breaks if I change Z").
- **codebase-memory-mcp** — architecture overview and call/graph tracing.
- **GitNexus** — deep blast-radius, multi-hop flows, route/tool maps, coupling/community analysis. Reach for it deliberately for those unique views, and **`gitnexus analyze` first** when freshness matters.
- **Grep/Glob/Read** — text, configs, docs, known paths.

Also corrects stale claims: the version, the on-commit-not-on-pull reindex behavior, and the FTS-extension caveat (text search degrades gracefully when the LadybugDB FTS extension isn't installed, rather than "fixed/works").

No behavior change — documentation and guidance only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)