### PR TITLE
chore: bump bundled GitNexus pin 1.6.4 → 1.6.8

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -315,16 +315,16 @@ if command -v codebase-memory-mcp &>/dev/null; then
 fi
 
 # GitNexus (blast radius, impact analysis, execution flows)
-# Exact pin to 1.6.4 — only ship versions we've actually verified.
-# Bumping to 1.6.5+ or 1.7+ is an explicit decision in a follow-up PR
-# (1.7 prereleases had FTS read-blocking issues that need re-verification).
+# Exact pin to 1.6.8 — only ship versions we've actually verified. 1.6.8 (stable):
+# `analyze` works; FTS degrades gracefully when the extension is absent. The prior
+# 1.6.4-rc line crashed `analyze` silently. Re-verify before bumping further.
 if _node_version_ok; then
     if ! command -v gitnexus &>/dev/null; then
         echo "  GitNexus not found — installing..."
-        npm install -g gitnexus@1.6.4 2>/dev/null || echo "  WARNING: GitNexus install failed (non-critical)"
+        npm install -g gitnexus@1.6.8 2>/dev/null || echo "  WARNING: GitNexus install failed (non-critical)"
     else
         echo "  GitNexus: ensuring pin..."
-        npm install -g gitnexus@1.6.4 2>/dev/null || echo "  WARNING: GitNexus upgrade failed (non-critical)"
+        npm install -g gitnexus@1.6.8 2>/dev/null || echo "  WARNING: GitNexus upgrade failed (non-critical)"
     fi
     if command -v gitnexus &>/dev/null; then
         echo "  GitNexus: $(gitnexus --version 2>/dev/null)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -613,18 +613,18 @@ curl -fsSL https://raw.githubusercontent.com/DeusData/codebase-memory-mcp/main/i
     || echo "    NOTE: codebase-memory-mcp unavailable (optional)"
 
 if _node_version_ok; then
-    # Exact pin to 1.6.4 — only ship versions we've actually verified.
-    # Bumping to 1.6.5+ or 1.7+ is an explicit decision in a follow-up
-    # PR (1.7 prereleases had FTS read-blocking issues that need
-    # re-verification).
+    # Exact pin to 1.6.8 — only ship versions we've actually verified. 1.6.8
+    # (stable): `analyze` works; text search (FTS) degrades gracefully when the
+    # LadybugDB extension is absent. The prior 1.6.4-rc line crashed `analyze`
+    # silently. Re-verify before bumping further.
     if ! command -v gitnexus &>/dev/null; then
-        npm install -g gitnexus@1.6.4 2>/dev/null \
+        npm install -g gitnexus@1.6.8 2>/dev/null \
             && echo "    + GitNexus installed ($(gitnexus --version 2>/dev/null))" \
             || echo "    NOTE: GitNexus unavailable (optional)"
     else
-        npm install -g gitnexus@1.6.4 2>/dev/null \
+        npm install -g gitnexus@1.6.8 2>/dev/null \
             && echo "    + GitNexus pin enforced ($(gitnexus --version 2>/dev/null))" \
-            || echo "    NOTE: GitNexus pin enforcement skipped (already at 1.6.4 or failed)"
+            || echo "    NOTE: GitNexus pin enforcement skipped (already at 1.6.8 or failed)"
     fi
 fi
 


### PR DESCRIPTION
## Why

`install.sh` / `bootstrap.sh` pin GitNexus at **1.6.4** — a release candidate whose `analyze` crashes silently (exits 1 with no error, even under `DEBUG=*`), so fresh installs get a code-intelligence tool that can't build its index. The existing pin comment explicitly deferred a bump to "a follow-up PR" once a newer version was verified.

## What

Bump the pin to **1.6.8** (stable) in both scripts, and update the comment to record the verification.

**Verified on this install:** `gitnexus analyze` indexes cleanly (≈31.7K nodes / 51K edges in ~100s); text search (FTS) degrades gracefully with a logged warning when the LadybugDB FTS extension isn't installed, rather than crashing. 1.6.8 also ships a project-local runner and assorted tool improvements over the old rc.

Version-pin only — no logic change. `bash -n` clean on both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)