### PR TITLE
feat(learning): track procedure surfaced_count for honest self-learning funnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   ever presenting it as settled guidance. Blind session-start injection still stays
   limited to the most-proven, always-on procedures. Genesis also now repairs
   procedures that were missing their embedding, so they stop being silently
-  invisible to this relevance matching.
+  invisible to this relevance matching. Genesis also now counts each time a
+  procedure is surfaced into context this way, so its own self-learning health
+  check reports learned procedures honestly as *reaching* its attention rather
+  than falsely flagging them as lost — and this surfacing count is kept strictly
+  separate from the signals that promote a procedure, so merely showing a draft
+  can never inflate its standing.
 
 - **Procedures you actually use now earn their keep.** How often a learned
   procedure is recalled ("reads") now counts as a dampened usefulness signal:

--- a/docs/architecture/genesis-v3-procedure-activation.md
+++ b/docs/architecture/genesis-v3-procedure-activation.md
@@ -109,6 +109,19 @@ The one-time migration `0035_backfill_procedure_invocation_count` seeds
 `invocation_count` from historical `procedure_invoked` events in `eval_events`
 so the signal doesn't start at zero.
 
+**Surfacing vs. invocation — two distinct counters.** `invocation_count` (above)
+tracks *explicit recall* via `procedure_recall` — the read-signal that feeds
+`effective_confidence` and tier promotion. Passive *contextual surfacing* — the
+proactive memory hook injecting a relevant procedure on a prompt, or the
+PreToolUse advisor on a tool call — is tracked separately on **`surfaced_count`**
+(migration `0039`). `surfaced_count` is HONEST funnel observability ONLY: it is
+deliberately **never** read by the promoter or `effective_confidence`, so passive
+exposure can never promote an unproven draft. The loop-closure funnel
+(`db/crud/loop_closure.py::procedure_funnel`) reports
+`captured → surfaced → invoked → measured`, so a draft that the proactive hook
+surfaces but that is never explicitly recalled reads honestly as *reached*, not
+as a leak.
+
 > **Limitation:** reads are a *proxy* for usefulness, not proof a procedure
 > worked. The discount, the ≥1-real-success gate for ADVISORY, and the FailureDetector
 > are the counterweights. A real recall-path outcome signal remains future work.

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -959,6 +959,29 @@ def _record_activity(db_path: Path, latency_ms: float, success: bool) -> None:
         pass  # Never block user prompt
 
 
+def _record_procedure_surfaced(db_path: Path, proc_id: str) -> None:
+    """Bump a procedure's ``surfaced_count`` after surfacing it into context.
+
+    HONEST funnel observability ONLY — deliberately bumps ``surfaced_count`` and
+    NOT ``invocation_count``, so passive surfacing never feeds the promoter
+    (which reads ``invocation_count``) and cannot promote an unproven draft.
+    Fire-and-forget: best-effort, never blocks the user prompt.
+    """
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=1)
+        try:
+            conn.execute(
+                "UPDATE procedural_memory "
+                "SET surfaced_count = surfaced_count + 1 WHERE id = ?",
+                (proc_id,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception:
+        pass  # Never block user prompt
+
+
 def _record_detail(
     fts_count: int,
     vector_count: int,
@@ -1280,11 +1303,13 @@ async def _run(prompt: str, session_id: str = "") -> None:
     # Procedure surfacing — reuses the already-computed prompt embedding
     # so there's no extra cloud call. Top-1 only, per-tier cosine bar. Wrapped
     # in a broad try/except so a bad procedure read can't crash the memory hook.
+    _surfaced_proc_id: str | None = None
     if vector:
         try:
             proc = _search_procedures(_DB_PATH, vector)
             if proc is not None:
                 proc_id, task_type, principle, tier = proc
+                _surfaced_proc_id = proc_id
                 # DORMANT drafts are unproven (0 invocations, conf 0.0): label
                 # them so the model treats them as a hint, not authoritative.
                 label = (
@@ -1313,6 +1338,10 @@ async def _run(prompt: str, session_id: str = "") -> None:
 
     had_results = fused_count > 0
     _record_activity(_DB_PATH, total_ms, success=had_results)
+    # Honest funnel signal: count that we surfaced this procedure into context
+    # (NOT an invocation — does not feed promotion). Fire-and-forget after flush.
+    if _surfaced_proc_id is not None:
+        _record_procedure_surfaced(_DB_PATH, _surfaced_proc_id)
     _record_detail(
         fts_count=len(fts_results),
         vector_count=len(vector_results),

--- a/scripts/procedure_advisor.py
+++ b/scripts/procedure_advisor.py
@@ -66,8 +66,8 @@ def _record_procedures_surfaced(proc_ids: list[str]) -> None:
             conn.commit()
         finally:
             conn.close()
-    except Exception:
-        pass  # Never disrupt the tool call
+    except Exception as exc:  # Never disrupt the tool call — but leave a trace.
+        print(f"procedure_advisor: surfaced_count update skipped: {exc}", file=sys.stderr)
 
 
 def _match_context(tool_input_str: str, context_patterns: list[str]) -> bool:

--- a/scripts/procedure_advisor.py
+++ b/scripts/procedure_advisor.py
@@ -40,6 +40,36 @@ def _load_triggers() -> list[dict]:
         return []
 
 
+def _record_procedures_surfaced(proc_ids: list[str]) -> None:
+    """Bump ``surfaced_count`` for advisor-surfaced procedures (honest funnel).
+
+    Called ONLY on a match, AFTER the advisory is emitted. Bumps
+    ``surfaced_count`` and NOT ``invocation_count`` — passive advisory surfacing
+    must not feed the promoter (which reads ``invocation_count``) or promote an
+    unproven draft. Imports are local so the no-match hot path stays lean.
+    Fire-and-forget: never disrupts the tool call.
+    """
+    if not proc_ids:
+        return
+    try:
+        import importlib
+        import sqlite3
+        db_path = importlib.import_module("genesis.env").genesis_db_path()
+        placeholders = ",".join("?" for _ in proc_ids)
+        conn = sqlite3.connect(str(db_path), timeout=1)
+        try:
+            conn.execute(
+                f"UPDATE procedural_memory "
+                f"SET surfaced_count = surfaced_count + 1 WHERE id IN ({placeholders})",
+                proc_ids,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception:
+        pass  # Never disrupt the tool call
+
+
 def _match_context(tool_input_str: str, context_patterns: list[str]) -> bool:
     """Check if any context pattern matches the tool input."""
     lower = tool_input_str.lower()
@@ -148,6 +178,11 @@ def main() -> int:
     json.dump(output, sys.stdout)
     with __import__("contextlib").suppress(BrokenPipeError):
         sys.stdout.flush()
+    # Honest funnel signal: count advisory surfacing (NOT an invocation — does
+    # not feed promotion). After the advisory is already delivered.
+    _record_procedures_surfaced(
+        [t.get("procedure_id") for t in matched if t.get("procedure_id")]
+    )
     return 0
 
 

--- a/src/genesis/db/crud/loop_closure.py
+++ b/src/genesis/db/crud/loop_closure.py
@@ -88,8 +88,11 @@ async def procedure_funnel(db: aiosqlite.Connection) -> dict:
     return {
         "artifact": "procedure",
         "captured": total,
-        "surfaced": surfaced,
-        "invoked": invoked,
+        # NOTE: surfaced and invoked OVERLAP (a procedure can be both). Do not
+        # sum them — use ``reached`` (the de-duped union) for total reach.
+        "surfaced": surfaced,   # surfaced_count > 0 (contextual hooks)
+        "invoked": invoked,     # invocation_count > 0 (explicit procedure_recall)
+        "reached": reached,     # surfaced OR invoked, de-duped — the flow signal
         "measured": measured,
         "by_tier": by_tier,
         "deprecated": deprecated,

--- a/src/genesis/db/crud/loop_closure.py
+++ b/src/genesis/db/crud/loop_closure.py
@@ -49,13 +49,30 @@ def _loop_label(total: int, *, flowing: int, leaked: int) -> str:
 
 
 async def procedure_funnel(db: aiosqlite.Connection) -> dict:
-    """Procedures are outcome-graded, but ``procedural_memory`` has NO 'surfaced'
-    counter — ``invocation_count`` is the actuation signal (the procedure
-    actually fired). So we report ``invoked`` (not 'surfaced'); the leak is
-    captured-but-never-invoked (the golden-dormant that never gets to mature)."""
+    """Procedures are outcome-graded. ``procedural_memory`` now carries TWO
+    distinct usage counters:
+
+    - ``surfaced_count`` — a contextual hook put the procedure into a model's
+      context (the proactive memory hook on a prompt, or the PreToolUse advisor
+      on a tool call). Passive exposure. NOT read by the promoter.
+    - ``invocation_count`` — the procedure was explicitly recalled/fired via the
+      ``procedure_recall`` MCP tool. Active actuation; the promoter's read-signal.
+
+    So the honest funnel is captured → **surfaced → invoked** → measured. A
+    procedure that has been neither surfaced nor invoked has never reached a
+    model at all — that is the real leak (golden-dormant that never gets to
+    mature). ``reached`` (surfaced OR invoked) is the loop's "flowing" signal."""
     total = await _scalar(db, "SELECT COUNT(*) FROM procedural_memory")
+    surfaced = await _scalar(
+        db, "SELECT COUNT(*) FROM procedural_memory WHERE surfaced_count > 0"
+    )
     invoked = await _scalar(
         db, "SELECT COUNT(*) FROM procedural_memory WHERE invocation_count > 0"
+    )
+    reached = await _scalar(
+        db,
+        "SELECT COUNT(*) FROM procedural_memory "
+        "WHERE surfaced_count > 0 OR invocation_count > 0",
     )
     measured = await _scalar(
         db,
@@ -67,16 +84,17 @@ async def procedure_funnel(db: aiosqlite.Connection) -> dict:
     by_tier = await _group_counts(
         db, "SELECT activation_tier, COUNT(*) FROM procedural_memory GROUP BY activation_tier"
     )
-    leak_uninvoked = total - invoked
+    leak_never_reached = total - reached
     return {
         "artifact": "procedure",
         "captured": total,
+        "surfaced": surfaced,
         "invoked": invoked,
         "measured": measured,
         "by_tier": by_tier,
         "deprecated": deprecated,
-        "leak_uninvoked": leak_uninvoked,
-        "loop": _loop_label(total, flowing=invoked, leaked=leak_uninvoked),
+        "leak_never_reached": leak_never_reached,
+        "loop": _loop_label(total, flowing=reached, leaked=leak_never_reached),
     }
 
 

--- a/src/genesis/db/migrations/0039_procedural_surfaced_count.py
+++ b/src/genesis/db/migrations/0039_procedural_surfaced_count.py
@@ -1,0 +1,35 @@
+"""Add surfaced_count column to procedural_memory.
+
+``surfaced_count`` tracks how many times a procedure was *surfaced* into a
+model's context by a contextual hook (the proactive memory hook on a prompt, or
+the PreToolUse procedure advisor on a tool call) — distinct from
+``invocation_count`` (explicit recall via the ``procedure_recall`` MCP tool).
+
+This is an HONEST funnel-observability counter ONLY. It is deliberately NOT read
+by the promoter (``learning/procedural/promoter.py`` reads ``invocation_count``
+alone), so passive surfacing can never promote an unproven DORMANT draft. Default
+0; existing rows backfill via the column DEFAULT.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # Table may not exist if migrations run on a fresh DB before schema init.
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='procedural_memory'"
+    )
+    if not await cursor.fetchone():
+        return
+
+    # Only add column if it doesn't already exist (fresh DBs get it from the
+    # canonical CREATE TABLE in db/schema/_tables.py).
+    col_cursor = await db.execute("PRAGMA table_info(procedural_memory)")
+    cols = {row[1] for row in await col_cursor.fetchall()}
+    if "surfaced_count" not in cols:
+        await db.execute(
+            "ALTER TABLE procedural_memory "
+            "ADD COLUMN surfaced_count INTEGER NOT NULL DEFAULT 0"
+        )

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1096,6 +1096,15 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE procedural_memory ADD COLUMN principle_embedding BLOB",
         "procedural_memory.principle_embedding")
 
+    # C-honest: contextual-surfacing counter (proactive hook / tool advisor).
+    # Honest loop-closure funnel observability ONLY — NOT read by the promoter
+    # (which reads invocation_count), so passive surfacing can never promote an
+    # unproven draft. Existing rows backfill via DEFAULT 0. Numbered migration
+    # 0039 also adds this; both are idempotent (_try_alter suppresses dup-column).
+    await _try_alter(db,
+        "ALTER TABLE procedural_memory ADD COLUMN surfaced_count INTEGER NOT NULL DEFAULT 0",
+        "procedural_memory.surfaced_count")
+
     # Rebuild cognitive_state table if CHECK constraint lacks resilience_degradation.
     # SQLite can't ALTER CHECK constraints — requires table rebuild.
     await _migrate_cognitive_state_check(db)

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -35,7 +35,8 @@ TABLES = {
             tool_trigger      TEXT,                        -- JSON array of tool names for CORE matching
             source            TEXT,                        -- JSON: {type, session_id?, observation_id?, triage_outcome?}
             promotion_history TEXT,                        -- JSON array: [{from_tier, to_tier, at, reason}]
-            principle_embedding BLOB                       -- qwen3-embedding(1024 float32) of `principle`, little-endian; read by proactive procedure hook
+            principle_embedding BLOB,                      -- qwen3-embedding(1024 float32) of `principle`, little-endian; read by proactive procedure hook
+            surfaced_count    INTEGER NOT NULL DEFAULT 0   -- contextual-hook surfacings (proactive hook / tool advisor); honest funnel signal, NOT read by promoter
         )
     """,
     "observations": """

--- a/tests/test_db/test_loop_closure.py
+++ b/tests/test_db/test_loop_closure.py
@@ -74,17 +74,19 @@ async def test_procedure_funnel_counts_surfaced_invoked_and_leak(db):
     await _proc(db, "p2", surfaced=4, tier="DORMANT")               # surfaced only (NOT invoked)
     await _proc(db, "p3", invocation=0, tier="DORMANT")            # never reached — the real leak
     await _proc(db, "p4", invocation=0, tier="CORE", deprecated=1)  # never reached + deprecated
+    await _proc(db, "p5", surfaced=2, invocation=1, tier="LIBRARY")  # BOTH — must not double-count
     await db.commit()
 
     f = await lc.procedure_funnel(db)
-    assert f["captured"] == 4
-    assert f["surfaced"] == 1          # only p2 (surfaced_count > 0)
-    assert f["invoked"] == 1           # only p1 (invocation_count > 0)
+    assert f["captured"] == 5
+    assert f["surfaced"] == 2          # p2 + p5 (surfaced_count > 0)
+    assert f["invoked"] == 2           # p1 + p5 (invocation_count > 0)
+    assert f["reached"] == 3           # p1 + p2 + p5 — de-duped union (NOT surfaced+invoked=4)
     assert f["measured"] == 1          # only p1 has outcome counts
     assert f["leak_never_reached"] == 2  # p3 + p4 — neither surfaced nor invoked
     assert f["deprecated"] == 1
-    assert f["by_tier"] == {"ADVISORY": 1, "DORMANT": 2, "CORE": 1}
-    assert f["loop"] == "PARTIAL"      # p1 invoked + p2 surfaced flow; p3/p4 leak
+    assert f["by_tier"] == {"ADVISORY": 1, "DORMANT": 2, "CORE": 1, "LIBRARY": 1}
+    assert f["loop"] == "PARTIAL"      # p1/p2/p5 flow; p3/p4 leak
 
 
 async def test_procedure_surfaced_only_flips_loop_open_to_partial(db):

--- a/tests/test_db/test_loop_closure.py
+++ b/tests/test_db/test_loop_closure.py
@@ -23,13 +23,13 @@ _NEW = "2099-01-01T00:00:00+00:00"   # after the stale cutoff
 _STALE_BEFORE = "2024-01-01T00:00:00+00:00"
 
 
-async def _proc(db, pid, *, invocation=0, success=0, failure=0, tier="DORMANT", deprecated=0):
+async def _proc(db, pid, *, surfaced=0, invocation=0, success=0, failure=0, tier="DORMANT", deprecated=0):
     await db.execute(
         "INSERT INTO procedural_memory "
         "(id, task_type, principle, steps, tools_used, context_tags, created_at, "
-        " invocation_count, success_count, failure_count, activation_tier, deprecated) "
-        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
-        (pid, "t", "p", "[]", "[]", "[]", _OLD, invocation, success, failure, tier, deprecated),
+        " surfaced_count, invocation_count, success_count, failure_count, activation_tier, deprecated) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        (pid, "t", "p", "[]", "[]", "[]", _OLD, surfaced, invocation, success, failure, tier, deprecated),
     )
 
 
@@ -67,22 +67,50 @@ async def _prop(db, pid, *, status, created=_NEW):
     )
 
 
-# ── procedures: invoked (not 'surfaced' — no such counter); leak = uninvoked ──
+# ── procedures: captured → surfaced/invoked → measured; leak = never reached ──
 
-async def test_procedure_funnel_counts_and_uninvoked_leak(db):
+async def test_procedure_funnel_counts_surfaced_invoked_and_leak(db):
     await _proc(db, "p1", invocation=5, success=3, tier="ADVISORY")  # invoked + measured
-    await _proc(db, "p2", invocation=0, tier="DORMANT")              # captured, never invoked
-    await _proc(db, "p3", invocation=0, tier="CORE", deprecated=1)
+    await _proc(db, "p2", surfaced=4, tier="DORMANT")               # surfaced only (NOT invoked)
+    await _proc(db, "p3", invocation=0, tier="DORMANT")            # never reached — the real leak
+    await _proc(db, "p4", invocation=0, tier="CORE", deprecated=1)  # never reached + deprecated
     await db.commit()
 
     f = await lc.procedure_funnel(db)
-    assert f["captured"] == 3
-    assert f["invoked"] == 1            # only p1
+    assert f["captured"] == 4
+    assert f["surfaced"] == 1          # only p2 (surfaced_count > 0)
+    assert f["invoked"] == 1           # only p1 (invocation_count > 0)
     assert f["measured"] == 1          # only p1 has outcome counts
-    assert f["leak_uninvoked"] == 2    # p2 + p3 — the golden-dormant risk
+    assert f["leak_never_reached"] == 2  # p3 + p4 — neither surfaced nor invoked
     assert f["deprecated"] == 1
-    assert f["by_tier"] == {"ADVISORY": 1, "DORMANT": 1, "CORE": 1}
-    assert f["loop"] == "PARTIAL"      # some invoked, some leaked — NOT hardcoded
+    assert f["by_tier"] == {"ADVISORY": 1, "DORMANT": 2, "CORE": 1}
+    assert f["loop"] == "PARTIAL"      # p1 invoked + p2 surfaced flow; p3/p4 leak
+
+
+async def test_procedure_surfaced_only_flips_loop_open_to_partial(db):
+    # The C-honest fix: a DORMANT draft that the proactive hook surfaces (but is
+    # never explicitly invoked) now counts as 'reached' — the loop is no longer
+    # falsely OPEN just because invocation_count stayed 0.
+    await _proc(db, "p1", surfaced=2, invocation=0, tier="DORMANT")
+    await db.commit()
+
+    f = await lc.procedure_funnel(db)
+    assert f["surfaced"] == 1
+    assert f["invoked"] == 0
+    assert f["leak_never_reached"] == 0
+    assert f["loop"] == "CLOSED"       # the one procedure reached context; nothing leaks
+
+
+async def test_procedure_funnel_only_one_leak_key(db):
+    # open_seams iterates every ``leak_*`` key; the procedure funnel must emit
+    # exactly one so a single dark procedure isn't double-counted as a seam.
+    await _proc(db, "p1", invocation=0, tier="DORMANT")
+    await db.commit()
+
+    f = await lc.procedure_funnel(db)
+    leak_keys = [k for k in f if k.startswith("leak_")]
+    assert leak_keys == ["leak_never_reached"]
+    assert f["loop"] == "OPEN"         # nothing surfaced or invoked yet
 
 
 # ── observations: actuation = influenced_action ──────────────────────────────
@@ -195,7 +223,7 @@ async def test_impl_assembly_and_open_seams(db, monkeypatch):
     # reflections actuate via observations → NOT a false OPEN on the dead column
     await _obs(db, "ro1", otype="micro_reflection", influenced=1)
     await _refl(db, "r1", used=0)        # raw transcript (context only)
-    await _proc(db, "p1", invocation=0)  # uninvoked procedure → leak seam
+    await _proc(db, "p1", invocation=0)  # never-reached procedure → leak seam
     await db.commit()
 
     from genesis.mcp.health.loop_closure_status import _impl_loop_closure_status
@@ -206,8 +234,8 @@ async def test_impl_assembly_and_open_seams(db, monkeypatch):
     assert "outcome_bus" in res
 
     seams = res["open_seams"]
-    # the procedure leak still surfaces honestly
-    assert any("procedure" in s and "uninvoked" in s for s in seams)
+    # the procedure leak still surfaces honestly (now: never reached)
+    assert any("procedure" in s and "never reached" in s for s in seams)
     # reflections must NOT be flagged OPEN any more (dead-column false positive gone)
     assert not any("reflection" in s and "OPEN" in s for s in seams)
     # by_tier / by_status dicts must NEVER be rendered as a seam string

--- a/tests/test_learning/test_proactive_procedure_tier.py
+++ b/tests/test_learning/test_proactive_procedure_tier.py
@@ -144,3 +144,64 @@ async def test_deprecated_and_quarantined_never_surface(tmp_path):
             )
         await conn.commit()
     assert _search_procedures(db, _QUERY) is None
+
+
+# ── C-honest: surfaced_count bump (honest funnel signal, promotion-inert) ─────
+
+_record_procedure_surfaced = _mod._record_procedure_surfaced
+
+
+async def _seed_one(db_path, pid="p", *, invocation=0):
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await create_all_tables(conn)
+        await conn.execute(
+            "INSERT INTO procedural_memory "
+            "(id, task_type, principle, steps, tools_used, context_tags, created_at, "
+            " invocation_count, activation_tier) "
+            "VALUES (?, 't', 'p', '[]', '[]', '[]', '2026-01-01T00:00:00', ?, 'DORMANT')",
+            (pid, invocation),
+        )
+        await conn.commit()
+
+
+async def _read_counts(db_path, pid):
+    async with aiosqlite.connect(str(db_path)) as conn:
+        cur = await conn.execute(
+            "SELECT surfaced_count, invocation_count FROM procedural_memory WHERE id = ?",
+            (pid,),
+        )
+        return await cur.fetchone()
+
+
+@pytest.mark.asyncio
+async def test_record_procedure_surfaced_bumps_and_is_idempotent(tmp_path):
+    db = tmp_path / "t.db"
+    await _seed_one(db, "p")
+    _record_procedure_surfaced(db, "p")
+    assert (await _read_counts(db, "p"))[0] == 1
+    _record_procedure_surfaced(db, "p")          # second surface
+    assert (await _read_counts(db, "p"))[0] == 2
+
+
+@pytest.mark.asyncio
+async def test_record_procedure_surfaced_does_not_touch_invocation(tmp_path):
+    """Promotion-safety: surfacing must NOT feed invocation_count (the promoter's
+    read-signal), or an unproven draft would promote on passive surfacing."""
+    db = tmp_path / "t.db"
+    await _seed_one(db, "p", invocation=0)
+    _record_procedure_surfaced(db, "p")
+    surfaced, invocation = await _read_counts(db, "p")
+    assert surfaced == 1 and invocation == 0
+
+
+@pytest.mark.asyncio
+async def test_record_procedure_surfaced_missing_id_is_noop(tmp_path):
+    db = tmp_path / "t.db"
+    await _seed_one(db, "p")
+    _record_procedure_surfaced(db, "does-not-exist")   # must not raise
+    assert (await _read_counts(db, "p"))[0] == 0
+
+
+def test_record_procedure_surfaced_bad_path_fails_open(tmp_path):
+    # A missing/locked DB must never raise out of the hook.
+    _record_procedure_surfaced(tmp_path / "nope.db", "p")

--- a/tests/test_learning/test_procedure_advisor_surfaced.py
+++ b/tests/test_learning/test_procedure_advisor_surfaced.py
@@ -1,0 +1,87 @@
+"""C-honest: the PreToolUse procedure advisor bumps ``surfaced_count`` on a
+match — honest funnel observability, deliberately NOT ``invocation_count`` (so
+advisory surfacing can never feed the promoter / promote an unproven draft).
+
+``_record_procedures_surfaced`` resolves the DB path via ``genesis.env`` (proven
+to work in hook runtime), so we monkeypatch that to a tmp DB.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from genesis.db.schema import create_all_tables
+
+# Load the advisor script as a module (scripts/ is not a package).
+_ADVISOR_PATH = Path(__file__).resolve().parent.parent.parent / "scripts" / "procedure_advisor.py"
+_spec = importlib.util.spec_from_file_location("procedure_advisor", _ADVISOR_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["procedure_advisor"] = _mod
+_spec.loader.exec_module(_mod)
+
+_record_procedures_surfaced = _mod._record_procedures_surfaced
+
+
+async def _seed(db_path, ids):
+    async with aiosqlite.connect(str(db_path)) as conn:
+        await create_all_tables(conn)
+        for pid in ids:
+            await conn.execute(
+                "INSERT INTO procedural_memory "
+                "(id, task_type, principle, steps, tools_used, context_tags, created_at, "
+                " activation_tier) "
+                "VALUES (?, 't', 'p', '[]', '[]', '[]', '2026-01-01T00:00:00', 'CORE')",
+                (pid,),
+            )
+        await conn.commit()
+
+
+async def _counts(db_path, pid):
+    async with aiosqlite.connect(str(db_path)) as conn:
+        cur = await conn.execute(
+            "SELECT surfaced_count, invocation_count FROM procedural_memory WHERE id = ?",
+            (pid,),
+        )
+        return await cur.fetchone()
+
+
+@pytest.fixture
+def _db(tmp_path, monkeypatch):
+    db = tmp_path / "t.db"
+    env = importlib.import_module("genesis.env")
+    monkeypatch.setattr(env, "genesis_db_path", lambda: db)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_advisor_bumps_all_matched_ids(_db):
+    await _seed(_db, ["a", "b"])
+    _record_procedures_surfaced(["a", "b"])
+    assert (await _counts(_db, "a"))[0] == 1
+    assert (await _counts(_db, "b"))[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_advisor_does_not_touch_invocation(_db):
+    await _seed(_db, ["a"])
+    _record_procedures_surfaced(["a"])
+    surfaced, invocation = await _counts(_db, "a")
+    assert surfaced == 1 and invocation == 0
+
+
+@pytest.mark.asyncio
+async def test_advisor_missing_id_tolerated(_db):
+    await _seed(_db, ["a"])
+    _record_procedures_surfaced(["a", "ghost"])   # 'ghost' absent — must not raise
+    assert (await _counts(_db, "a"))[0] == 1
+
+
+def test_advisor_empty_list_is_noop(_db):
+    # No DB access at all when there are no matches.
+    _record_procedures_surfaced([])

--- a/tests/test_learning/test_procedure_advisor_surfaced.py
+++ b/tests/test_learning/test_procedure_advisor_surfaced.py
@@ -85,3 +85,48 @@ async def test_advisor_missing_id_tolerated(_db):
 def test_advisor_empty_list_is_noop(_db):
     # No DB access at all when there are no matches.
     _record_procedures_surfaced([])
+
+
+# ── main()-level wiring: bump fires only on match; triggers w/o id are skipped ─
+
+@pytest.mark.asyncio
+async def test_advisor_main_bumps_only_matched_with_id(_db, monkeypatch, capsys):
+    import io
+    await _seed(_db, ["pa", "pz"])   # pa matches; pz is unrelated
+
+    # Crafted cache: one matching trigger WITH an id, one matching trigger
+    # WITHOUT an id (must be skipped from the bump, not crash), and pz absent.
+    triggers = [
+        {"tool": ["Bash"], "context_patterns": ["pip.*-e"], "procedure_id": "pa",
+         "task_type": "t", "principle": "p", "steps": [], "confidence": 0.9},
+        {"tool": ["Bash"], "context_patterns": ["pip.*-e"],
+         "task_type": "t", "principle": "p", "steps": [], "confidence": 0.9},
+    ]
+    monkeypatch.setattr(_mod, "_load_triggers", lambda: triggers)
+    stdin = io.StringIO('{"tool_name": "Bash", "tool_input": {"command": "pip install -e ."}}')
+    monkeypatch.setattr("sys.stdin", stdin)
+
+    rc = _mod.main()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "PROCEDURE" in out          # the advisory was emitted
+
+    assert (await _counts(_db, "pa"))[0] == 1   # matched + had id → bumped
+    assert (await _counts(_db, "pz"))[0] == 0   # never matched → untouched
+
+
+@pytest.mark.asyncio
+async def test_advisor_main_no_match_does_not_write(_db, monkeypatch):
+    import io
+    await _seed(_db, ["pa"])
+    triggers = [
+        {"tool": ["Bash"], "context_patterns": ["pip.*-e"], "procedure_id": "pa",
+         "task_type": "t", "principle": "p", "steps": [], "confidence": 0.9},
+    ]
+    monkeypatch.setattr(_mod, "_load_triggers", lambda: triggers)
+    # A Bash command that does NOT match the pattern → no advisory, no bump.
+    stdin = io.StringIO('{"tool_name": "Bash", "tool_input": {"command": "ls -la"}}')
+    monkeypatch.setattr("sys.stdin", stdin)
+
+    assert _mod.main() == 0
+    assert (await _counts(_db, "pa"))[0] == 0


### PR DESCRIPTION
## Problem

Genesis surfaces a learned procedure into context two ways without an explicit recall: the proactive memory hook (on a prompt) and the PreToolUse advisor (on a tool call). Neither was tracked. Only an explicit `procedure_recall` writes `invocation_count`, so the self-learning health funnel (`loop_closure_status`) couldn't see contextual surfacing at all — procedures that *were* reaching the model read as a leak ("captured but nothing flowing — loop OPEN"), even when they were being shown every relevant turn.

## Change

- Add a `surfaced_count` column to `procedural_memory` (migration `0039` + canonical schema; retrofits existing installs).
- Both contextual hooks bump it via a fire-and-forget write **after** the advisory/injection is delivered, so there's no added latency on the user prompt or tool call.
- `procedure_funnel` now reports `captured → surfaced → invoked → reached → measured`, where `reached` is the de-duped union (surfaced **or** invoked). A procedure that has neither been surfaced nor invoked is the real leak (`leak_never_reached`).

## Safety: surfacing never promotes

`surfaced_count` is observability **only**. The procedure promoter reads `invocation_count` exclusively, so passively showing an unproven draft can never inflate its standing or promote it a tier. The two writers bump `surfaced_count` alone — never `invocation_count` or `confidence`. This boundary is asserted directly in tests and was verified end-to-end against production-shaped data (a surface bump moved `surfaced_count 0→1` while `invocation_count` stayed `0`).

## Testing

- New + updated unit tests cover: the funnel's surfaced/invoked/reached/leak math and overlap de-dup; the promotion-inert property in both hooks; idempotent re-surface; missing-id no-op; fail-open on a bad DB; and an end-to-end advisor `main()` run (bump only on a match, only for triggers carrying a procedure id).
- Migration retrofit + idempotency verified directly (existing table without the column → added; re-apply is a no-op; bare DB guarded).
- Full `test_db` + `test_learning` suites green; ruff clean.

## Scope

Contextual surfacing only (proactive hook + tool advisor). Blind session-start injection of always-on procedures is intentionally excluded. Explicit `procedure_recall` continues to be tracked as `invoked`.