### PR TITLE
feat(learning): honest skill funnel in loop-closure status

### DIFF
--- a/src/genesis/db/crud/loop_closure.py
+++ b/src/genesis/db/crud/loop_closure.py
@@ -19,7 +19,15 @@ same zone), so the lexicographic ``created_at < ?`` compare == chronological.
 
 from __future__ import annotations
 
+import json
+
 import aiosqlite
+
+# Session statuses where a skill's outcome (success vs failure) is determinable,
+# so a success-rate is computable. 'active'/'checkpointed'/'expired' are not
+# terminal-for-outcome. Mirrors the success/failure model in
+# ``learning/skills/effectiveness.py`` (status == 'failed' vs everything else).
+_TERMINAL_SESSION_STATUS = ("completed", "failed")
 
 
 async def _scalar(db: aiosqlite.Connection, sql: str, params: tuple = ()) -> int:
@@ -98,6 +106,79 @@ async def procedure_funnel(db: aiosqlite.Connection) -> dict:
         "deprecated": deprecated,
         "leak_never_reached": leak_never_reached,
         "loop": _loop_label(total, flowing=reached, leaked=leak_never_reached),
+    }
+
+
+async def skill_funnel(db: aiosqlite.Connection) -> dict:
+    """Skills are file-based (``SKILL.md``) and — by deliberate design — **NOT
+    outcome-graded**: there is no skill equivalent of the procedure promoter
+    (skills have no per-invocation execution outcome). This funnel therefore
+    reports the HONEST state of the skill feedback signal rather than a fake
+    "closed" one. It is the LC2-honest observability slice; it writes nothing.
+
+    - ``captured``      — every skill in the library (``list_available_skills``).
+    - ``instrumented``  — library skills appearing in ≥1 ``cc_sessions.skill_tags``.
+      That tag is set today only for background sessions (task + reflection);
+      foreground sessions (the bulk of usage) tag nothing, so most skills are
+      uninstrumented.
+    - ``measured``      — instrumented skills with ≥1 **terminal-status**
+      (completed/failed) session, so a success-rate is computable. A skill used
+      only in *successful* sessions IS measured (rate = 1.0) — ``measured`` means
+      "outcome is knowable", NOT "has a failure".
+    - ``leak_uninstrumented`` — ``captured − instrumented``: skills with no usage
+      signal at all. This is the real, large leak — the missing afferent nerve
+      (foreground usage capture + a graded outcome source). Closing it is the
+      separately-documented **LC2-maturity** build, not this read-only slice.
+
+    Tags are matched by exact membership against the library, so a non-skill tag
+    (e.g. a reflection pseudo-label like ``strategic-reflection``, or a ``profile``
+    value like ``research`` that happens to collide with a skill name) does not
+    inflate ``instrumented`` unless it is genuinely a library skill in the list.
+    """
+    from genesis.learning.skills import wiring
+
+    library = set(wiring.list_available_skills())
+    captured = len(library)
+
+    cur = await db.execute(
+        "SELECT metadata, status FROM cc_sessions WHERE metadata LIKE '%skill_tags%'"
+    )
+    instrumented: set[str] = set()
+    measured: set[str] = set()
+    for raw, status in await cur.fetchall():
+        if not raw:
+            continue
+        try:
+            tags = json.loads(raw).get("skill_tags", [])
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            continue
+        if not isinstance(tags, list):
+            continue
+        hit = library.intersection(tags)
+        if not hit:
+            continue
+        instrumented |= hit
+        if status in _TERMINAL_SESSION_STATUS:
+            measured |= hit
+
+    leak_uninstrumented = captured - len(instrumented)
+    return {
+        "artifact": "skill",
+        "captured": captured,
+        "instrumented": len(instrumented),
+        "measured": len(measured),
+        "graded": False,  # skills are NOT outcome-graded (file-based, by design)
+        "leak_uninstrumented": leak_uninstrumented,
+        "loop": _loop_label(
+            captured, flowing=len(instrumented), leaked=leak_uninstrumented
+        ),
+        "note": (
+            "skills are file-based and NOT outcome-graded; instrumented = appears "
+            "in a session's skill_tags (only background sessions tag today), "
+            "measured = outcome computable (terminal-status session). "
+            "leak_uninstrumented = no usage signal at all (foreground usage "
+            "uncaptured + no graded outcome source) — closing it is LC2-maturity."
+        ),
     }
 
 

--- a/src/genesis/db/crud/loop_closure.py
+++ b/src/genesis/db/crud/loop_closure.py
@@ -23,10 +23,11 @@ import json
 
 import aiosqlite
 
-# Session statuses where a skill's outcome (success vs failure) is determinable,
-# so a success-rate is computable. 'active'/'checkpointed'/'expired' are not
-# terminal-for-outcome. Mirrors the success/failure model in
-# ``learning/skills/effectiveness.py`` (status == 'failed' vs everything else).
+# Session statuses where a skill's outcome is DETERMINABLE at all (so a
+# success-rate is computable) — the full terminal set, not just failures.
+# 'active'/'checkpointed'/'expired' are not terminal-for-outcome. NB:
+# ``learning/skills/effectiveness.py`` uses ``status == 'failed'`` as its
+# *failure* signal; here we use both terminals to mean "outcome is knowable".
 _TERMINAL_SESSION_STATUS = ("completed", "failed")
 
 
@@ -137,9 +138,18 @@ async def skill_funnel(db: aiosqlite.Connection) -> dict:
     """
     from genesis.learning.skills import wiring
 
+    # list_available_skills() is synchronous filesystem I/O (iterdir over 2 dirs).
+    # Acceptable on the loop here: the library is small (~30 entries), paths are
+    # local, and this tool is operator-invoked (no hot path). Would need
+    # run_in_executor only if the skills dir moved to slow/network storage.
     library = set(wiring.list_available_skills())
     captured = len(library)
 
+    # Unlike the sibling funnels (pure SQL-side COUNT via ``_scalar``), skill
+    # usage lives inside the ``metadata`` JSON blob, so we fetch the matching
+    # rows and intersect in Python. The ``LIKE`` bounds this to rows that carry
+    # skill_tags (background sessions only today) — a small set; no metadata
+    # index exists, but the scan stays cheap at this scale.
     cur = await db.execute(
         "SELECT metadata, status FROM cc_sessions WHERE metadata LIKE '%skill_tags%'"
     )

--- a/src/genesis/mcp/health/loop_closure_status.py
+++ b/src/genesis/mcp/health/loop_closure_status.py
@@ -4,9 +4,11 @@ The umbrella "is the loop actually closed?" view. Two things in one read-only
 surface:
 
 1. A per-artifact **funnel** — captured → surfaced → actuated → measured → leak
-   — over the existing tables (procedures, observations, reflections,
+   — over the existing tables (procedures, skills, observations, reflections,
    follow-ups, ego proposals). It names each OPEN seam honestly: what's captured
    but never acted on or measured. This is the assurance the operator asked for.
+   (Skills are file-based and NOT outcome-graded by design, so their funnel
+   reports the honest instrumentation gap rather than a graded outcome.)
 2. The **Outcome Bus** section (tiers, per-domain T1 success, ego calibration) —
    subsumes the former ``self_improvement_status`` tool, so there is ONE
    self-learning-health surface instead of two overlapping ones.
@@ -46,6 +48,7 @@ async def _impl_loop_closure_status() -> dict:
 
     funnel = [
         await lc.procedure_funnel(db),
+        await lc.skill_funnel(db),
         await lc.observation_funnel(db, stale_before=stale_before),
         await lc.reflection_funnel(db),
         await lc.followup_funnel(db, stale_before=stale_before),
@@ -74,10 +77,6 @@ async def _impl_loop_closure_status() -> dict:
         "funnel": funnel,
         "open_seams": open_seams,
         "outcome_bus": outcome_bus,
-        "skills_note": (
-            "Skills are file-based; their effectiveness signal (failure_reason) "
-            "is a stub → measured=OPEN. Closing that is LC2."
-        ),
         "note": (
             "Self-learning loop health. funnel = captured→surfaced→actuated→"
             "measured per artifact; open_seams names what is leaking (captured "
@@ -94,9 +93,9 @@ async def loop_closure_status() -> dict:
     through the cracks?
 
     Per-artifact funnel — captured → surfaced → actuated → measured → leak —
-    across procedures, observations, reflections, follow-ups and ego proposals,
-    plus Outcome Bus health (signal tiers, per-domain success, ego calibration
-    ECE trend). ``open_seams`` names exactly what is captured but never acted on
-    or measured. Read-only; does NOT change behaviour.
+    across procedures, skills, observations, reflections, follow-ups and ego
+    proposals, plus Outcome Bus health (signal tiers, per-domain success, ego
+    calibration ECE trend). ``open_seams`` names exactly what is captured but
+    never acted on or measured. Read-only; does NOT change behaviour.
     """
     return await _impl_loop_closure_status()

--- a/tests/test_db/test_loop_closure.py
+++ b/tests/test_db/test_loop_closure.py
@@ -10,6 +10,7 @@ covered too.
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -65,6 +66,28 @@ async def _prop(db, pid, *, status, created=_NEW):
         "VALUES (?,?,?,?,?)",
         (pid, "investigate", "do y", status, created),
     )
+
+
+async def _sess(db, sid, *, skill_tags, status="completed", session_type="background_task"):
+    """Insert a cc_sessions row whose metadata carries ``skill_tags`` (the only
+    skill-usage signal the funnel can read today)."""
+    meta = None if skill_tags is None else json.dumps({"skill_tags": list(skill_tags)})
+    await db.execute(
+        "INSERT INTO cc_sessions "
+        "(id, session_type, model, status, started_at, last_activity_at, metadata) "
+        "VALUES (?,?,?,?,?,?,?)",
+        (sid, session_type, "m", status, _NEW, _NEW, meta),
+    )
+
+
+# A fixed library so skill-funnel tests don't depend on the real on-disk skill set.
+_LIB = ["alpha", "beta", "gamma"]
+
+
+def _patch_library(monkeypatch, names=_LIB):
+    import genesis.learning.skills.wiring as wiring
+
+    monkeypatch.setattr(wiring, "list_available_skills", lambda: list(names))
 
 
 # ── procedures: captured → surfaced/invoked → measured; leak = never reached ──
@@ -204,6 +227,101 @@ async def test_proposal_funnel(db):
     assert f["leak_pending_stale"] == 1
 
 
+# ── skills: file-based, NOT outcome-graded; honest instrumentation funnel ─────
+
+async def test_skill_funnel_uninstrumented_is_leak(db, monkeypatch):
+    # No session tags any skill → every library skill is uninstrumented (the leak).
+    _patch_library(monkeypatch)
+    f = await lc.skill_funnel(db)
+    assert f["captured"] == 3
+    assert f["instrumented"] == 0
+    assert f["measured"] == 0
+    assert f["leak_uninstrumented"] == 3
+    assert f["graded"] is False
+    assert f["loop"] == "OPEN"            # nothing instrumented → loop open
+
+
+async def test_skill_funnel_instrumented_and_measured(db, monkeypatch):
+    _patch_library(monkeypatch)
+    await _sess(db, "s1", skill_tags=["alpha"], status="completed")  # measured
+    await _sess(db, "s2", skill_tags=["beta"], status="failed")      # measured (failed IS terminal)
+    await db.commit()
+    f = await lc.skill_funnel(db)
+    assert f["instrumented"] == 2          # alpha + beta
+    assert f["measured"] == 2              # both in terminal-status sessions
+    assert f["leak_uninstrumented"] == 1   # gamma untouched
+    assert f["loop"] == "PARTIAL"          # some flow, some leak
+
+
+async def test_skill_funnel_success_only_skill_is_measured(db, monkeypatch):
+    # Regression guard for the DISCARDED plan's design bug: a 100%-success skill
+    # (never failed) MUST still count as measured — 'measured' means outcome is
+    # knowable, NOT 'has a failure'.
+    _patch_library(monkeypatch)
+    await _sess(db, "s1", skill_tags=["alpha"], status="completed")
+    await _sess(db, "s2", skill_tags=["alpha"], status="completed")
+    await db.commit()
+    f = await lc.skill_funnel(db)
+    assert f["instrumented"] == 1
+    assert f["measured"] == 1              # alpha measured despite zero failures
+
+
+async def test_skill_funnel_non_terminal_is_instrumented_not_measured(db, monkeypatch):
+    # An 'active' (non-terminal) session tags a skill: usage signal exists
+    # (instrumented) but no determinable outcome yet (not measured).
+    _patch_library(monkeypatch)
+    await _sess(db, "s1", skill_tags=["alpha"], status="active")
+    await db.commit()
+    f = await lc.skill_funnel(db)
+    assert f["instrumented"] == 1
+    assert f["measured"] == 0
+    assert f["leak_uninstrumented"] == 2
+
+
+async def test_skill_funnel_non_library_tag_does_not_inflate(db, monkeypatch):
+    # A pseudo-label that is not a real library skill (e.g. a reflection depth
+    # label, or a 'profile' value) must NOT count as instrumented — exact
+    # membership against the library, not a loose substring.
+    _patch_library(monkeypatch)
+    await _sess(db, "s1", skill_tags=["strategic-reflection", "research"], status="completed")
+    await db.commit()
+    f = await lc.skill_funnel(db)
+    assert f["instrumented"] == 0
+    assert f["leak_uninstrumented"] == 3
+
+
+async def test_skill_funnel_ignores_malformed_metadata(db, monkeypatch):
+    # A row matching the LIKE filter but carrying invalid JSON must be skipped
+    # silently (fail-safe), not crash the funnel.
+    _patch_library(monkeypatch)
+    await db.execute(
+        "INSERT INTO cc_sessions "
+        "(id, session_type, model, status, started_at, last_activity_at, metadata) "
+        "VALUES (?,?,?,?,?,?,?)",
+        ("bad", "background_task", "m", "completed", _NEW, _NEW, '{"skill_tags": not json'),
+    )
+    await _sess(db, "ok", skill_tags=["alpha"], status="completed")
+    await db.commit()
+    f = await lc.skill_funnel(db)
+    assert f["instrumented"] == 1          # only the valid row counted; bad row skipped
+
+
+async def test_skill_funnel_exactly_one_leak_key(db, monkeypatch):
+    # open_seams iterates every leak_* key; the skill funnel must emit exactly one.
+    _patch_library(monkeypatch)
+    f = await lc.skill_funnel(db)
+    leak_keys = [k for k in f if k.startswith("leak_")]
+    assert leak_keys == ["leak_uninstrumented"]
+
+
+async def test_skill_funnel_empty_library(db, monkeypatch):
+    _patch_library(monkeypatch, names=[])
+    f = await lc.skill_funnel(db)
+    assert f["captured"] == 0
+    assert f["leak_uninstrumented"] == 0
+    assert f["loop"] == "EMPTY"
+
+
 # ── empty DB: every funnel returns zeros + EMPTY label, no error ──────────────
 
 async def test_funnels_on_empty_db(db):
@@ -221,23 +339,29 @@ async def test_impl_assembly_and_open_seams(db, monkeypatch):
     import genesis.mcp.health_mcp as hm
 
     monkeypatch.setattr(hm, "_service", SimpleNamespace(_db=db))
+    _patch_library(monkeypatch)          # deterministic skill funnel (3-skill library)
 
     # reflections actuate via observations → NOT a false OPEN on the dead column
     await _obs(db, "ro1", otype="micro_reflection", influenced=1)
     await _refl(db, "r1", used=0)        # raw transcript (context only)
     await _proc(db, "p1", invocation=0)  # never-reached procedure → leak seam
+    await _sess(db, "s1", skill_tags=["alpha"], status="completed")  # 1 skill instrumented
     await db.commit()
 
     from genesis.mcp.health.loop_closure_status import _impl_loop_closure_status
 
     res = await _impl_loop_closure_status()
     assert res["status"] == "ok"
-    assert isinstance(res["funnel"], list) and len(res["funnel"]) == 5
+    assert isinstance(res["funnel"], list) and len(res["funnel"]) == 6
+    assert any(f["artifact"] == "skill" for f in res["funnel"])
     assert "outcome_bus" in res
+    assert "skills_note" not in res       # the hardcoded stub note is gone
 
     seams = res["open_seams"]
     # the procedure leak still surfaces honestly (now: never reached)
     assert any("procedure" in s and "never reached" in s for s in seams)
+    # the skill instrumentation gap surfaces honestly (2 of 3 skills uninstrumented)
+    assert any("skill" in s and "uninstrumented" in s for s in seams)
     # reflections must NOT be flagged OPEN any more (dead-column false positive gone)
     assert not any("reflection" in s and "OPEN" in s for s in seams)
     # by_tier / by_status dicts must NEVER be rendered as a seam string


### PR DESCRIPTION
## What

Adds a real, read-only **skill funnel** to the `loop_closure_status` self-learning health surface, replacing a hardcoded placeholder note.

Previously the surface carried a static line claiming skills' effectiveness signal was "a stub → measured=OPEN." That both overstated the situation and pointed at an empty pipe. This replaces it with an honest per-artifact funnel that reports the *actual* instrumentation state of the skill library:

- **`captured`** — skills in the library (`list_available_skills()`).
- **`instrumented`** — library skills that appear in at least one session's `skill_tags`.
- **`measured`** — instrumented skills with a terminal-status (completed/failed) session, so a success-rate is computable. A skill used only in successful sessions counts as measured (measured = "outcome is knowable", not "has a failure").
- **`leak_uninstrumented`** — `captured − instrumented`: skills with no usage signal at all.

Skill tags are matched by exact membership against the library, so non-skill tags (e.g. reflection depth labels, profile values) do not inflate the counts.

## Why

Skills are file-based and, by design, not outcome-graded — there is no skill equivalent of the procedure promoter. The loop-closure surface should report that honestly rather than imply a broken grading pipeline. This makes the real gap visible (most skills currently have no usage signal) instead of hiding it behind a placeholder.

## Scope / safety

- **Read-only.** No writes, no schema change, no promotion path, no behaviour change.
- Follows the existing sibling-funnel conventions (`_loop_label`, a single `leak_` key so `open_seams` doesn't double-count).
- New `skill_funnel(db)` in `db/crud/loop_closure.py`; wired into the funnel list and the hardcoded note removed in `mcp/health/loop_closure_status.py`.

## Tests

19/19 in `tests/test_db/test_loop_closure.py` (10 existing + 9 new): uninstrumented → leak, instrumented + terminal → measured, a 100%-success skill counts as measured, non-skill tags don't inflate, malformed metadata is skipped safely, exactly one `leak_` key, and the full assembly renders the new artifact with no stale placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
