### PR TITLE
fix(hooks): force-push guard matched -f as a substring, blocking valid branch pushes

### DIFF
--- a/scripts/bash_safety_hook.sh
+++ b/scripts/bash_safety_hook.sh
@@ -65,9 +65,6 @@ case "$CMD" in
     *"rm -rf /"*|*"rm -rf ~"*|*"rm -rf ."*|*"rm -rf .."*)
         echo "BLOCKED: rm -rf on broad paths is not allowed. Be specific or ask the user." >&2
         exit 2;;
-    *"git push"*"--force"*|*"git push"*"-f"*)
-        echo "BLOCKED: Force push not allowed. Use a PR." >&2
-        exit 2;;
     *"git reset --hard"*)
         echo "BLOCKED: git reset --hard destroys uncommitted work. Use git stash or ask the user." >&2
         exit 2;;
@@ -75,6 +72,18 @@ case "$CMD" in
         echo "BLOCKED: git clean removes untracked files permanently. Ask the user first." >&2
         exit 2;;
 esac
+
+# Force push — hard-block. MUST precede the soft "git push" warning below (which
+# exits 0). Match -f only as a FLAG token — a whitespace-delimited short-flag
+# cluster containing 'f' (so '-f', '-fv', '-uf' all count; 'f' is force-only
+# among push short flags). The leading start/space anchor is what keeps a branch
+# name that merely CONTAINS "-f" — e.g. "skill-funnel", "bug-fix" — from looking
+# like a force push. Also covers any --force* variant.
+if echo "$CMD" | grep -qE 'git push' \
+   && echo "$CMD" | grep -qE -- '(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)|--force'; then
+    echo "BLOCKED: Force push not allowed. Use a PR." >&2
+    exit 2
+fi
 
 # Push / PR protection — remind to get explicit user approval
 if echo "$CMD" | grep -qE "^git push|[;&|] *git push"; then

--- a/tests/test_scripts/test_bash_safety_hook.py
+++ b/tests/test_scripts/test_bash_safety_hook.py
@@ -63,6 +63,37 @@ def test_no_allowlist_still_blocks_destructive(cmd):
     assert _run(cmd).returncode == 2
 
 
+# --- Force-push detection: a FLAG token, not a branch-name substring ---
+
+@pytest.mark.parametrize("cmd", [
+    "git push -f origin main",
+    "git push --force origin main",
+    "git push origin main --force",
+    "git push --force-with-lease origin main",
+    "git push origin HEAD -f",
+    "git push -fv origin main",   # bundled short flags (force + verbose)
+    "git push -uf origin main",   # bundled (set-upstream + force)
+])
+def test_force_push_variants_blocked(cmd):
+    """Real force pushes (a standalone -f flag or any --force* variant) are
+    hard-blocked (exit 2)."""
+    assert _run(cmd).returncode == 2
+
+
+@pytest.mark.parametrize("cmd", [
+    "git push origin learning/lc2-honest-skill-funnel",  # '-f' inside 'skill-funnel'
+    "git push origin bug-fix",                            # '-f' inside 'bug-fix'
+    "git push origin feature/new-flow",                  # '-f' inside 'new-flow'
+    "git push origin HEAD",
+    "git push origin main",
+])
+def test_normal_push_with_dash_f_in_branch_not_blocked(cmd):
+    """A branch name that merely CONTAINS the literal '-f' must NOT be treated as
+    a force push. These clear the hard-block (the soft approval reminder still
+    fires on stderr, but exit code is 0)."""
+    assert _run(cmd).returncode == 0
+
+
 # --- Allowlist mode (steward) ---
 
 ALLOW = {"GENESIS_BASH_ALLOWLIST": "gh"}


### PR DESCRIPTION
## What

The Bash safety hook hard-blocked **any** `git push` whose command text contained the literal substring `-f` — via a `case` glob `*"git push"*"-f"*`. That substring appears in ordinary branch names (`skill-funnel`, `bug-fix`, `feature/new-flow`, …), so pushing such a branch failed with "Force push not allowed. Use a PR." even though it was a normal push.

## Fix

Replace the substring glob with a flag-boundary match. `-f` is treated as a force flag only when it is a whitespace-delimited short-flag *cluster* containing `f` (so `-f`, `-fv`, `-uf` all count), plus any `--force*` variant:

```sh
if echo "$CMD" | grep -qE 'git push' \
   && echo "$CMD" | grep -qE -- '(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)|--force'; then
    echo "BLOCKED: Force push not allowed. Use a PR." >&2
    exit 2
fi
```

The leading start/space anchor is what distinguishes a real flag from a branch name that merely contains `-f`. The block stays positioned before the soft `git push` approval reminder, so force pushes still hard-block (exit 2) before the exit-0 path.

This only changes detection **precision** — it never relaxes the guard. Every real force push still blocks.

## Tests

`tests/test_scripts/test_bash_safety_hook.py`, both directions:
- **Still blocks (exit 2):** `-f`, `--force`, `--force-with-lease`, trailing `-f`, and bundled `-fv` / `-uf`.
- **No longer blocks (exit 0):** branch names containing `-f` (`skill-funnel`, `bug-fix`, `feature/new-flow`), plus plain `origin main` / `origin HEAD`.

37/37 pass.

## Known limitation (pre-existing, not a regression)

The refspec force form `git push origin +main` is still not detected — it was not detected before this change either. A naive fix (matching a whitespace-prefixed `+`) would introduce a different false-positive (any `+token` in a chained command), so closing that gap needs its own scoped change and is left out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
