### PR TITLE
fix(hooks): block EnterWorktree relocation so sessions stay findable

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -243,6 +243,16 @@
                         "timeout": 2000
                     }
                 ]
+            },
+            {
+                "matcher": "EnterWorktree",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/worktree_cwd_guard.py --enter-worktree",
+                        "timeout": 2000
+                    }
+                ]
             }
         ],
         "Stop": [

--- a/.claude/skills/genesis-development/references/worktrees.md
+++ b/.claude/skills/genesis-development/references/worktrees.md
@@ -7,6 +7,18 @@ Multiple Claude Code sessions may work on this repo simultaneously. Rules:
 - **MANDATORY: Use git worktrees** for isolation when ANY other session might
   be active. Each session works in its own worktree off `main` via
   `.claude/worktrees/`. Never commit directly to `main` from a worktree.
+- **Create worktrees with `git worktree add` — NOT the `EnterWorktree` tool.**
+  `EnterWorktree` *relocates the live session* into the worktree: the harness
+  re-roots the transcript under a separate `…--claude-worktrees-<name>` project
+  slug and leaves only a `wt-<id>.jsonl` stub behind, so the conversation
+  disappears from `/resume` in the main repo (it looks "lost"). A PreToolUse
+  hook (`worktree_cwd_guard.py --enter-worktree`) hard-blocks it. To isolate
+  work while staying findable: `git worktree add .claude/worktrees/<name> -b
+  <scope>/<desc> origin/main`, then edit via the worktree's ABSOLUTE paths and
+  run tests with `PYTHONPATH=<worktree>/src pytest <files>` — your session stays
+  in the main repo and in `/resume`. For parallel isolated work, dispatch a
+  subagent (Agent tool, `isolation="worktree"`). If a worktree-ROOTED session is
+  genuinely wanted, the USER launches Claude Code from that directory.
 - **NEVER commit directly to `main` when another session is active.** Pre-commit
   hook warns on direct-to-main commits.
 - **NEVER use `git add .` or `git add -A`.** Always stage specific files by

--- a/scripts/hooks/worktree_cwd_guard.py
+++ b/scripts/hooks/worktree_cwd_guard.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
-"""PreToolUse hook: block worktree removal to protect active sessions.
+"""PreToolUse hook: worktree safety guard (removal protection + relocation block).
 
-Two modes:
+Three modes:
   1. Bash matcher (default) — intercepts `git worktree remove` commands.
   2. ExitWorktree matcher (--exit-worktree) — intercepts ExitWorktree tool
      with action "remove".
+  3. EnterWorktree matcher (--enter-worktree) — hard-blocks the EnterWorktree
+     tool, which would RELOCATE the session into a worktree and make the
+     conversation unfindable via /resume (see _handle_enter_worktree).
 
-In both modes:
+Removal modes (1 + 2):
   - If another process has its CWD inside the target worktree → hard block
     with PID list (cross-session safety).
   - If the current session's CWD IS the target → hard block (self-brick
@@ -18,6 +21,10 @@ In both modes:
 Incident 1: 2026-05-27 — Session bricked after deleting its own worktree.
 Incident 2: 2026-06-09 — Session B deleted worktree still used by Session A,
 turning A into a zombie.
+Incident 3: 2026-06-29 — EnterWorktree silently relocated a multi-day session
+into the `morning-report-nextsteps` worktree; its transcript moved to a
+separate Claude Code project slug, so /resume from the main repo no longer
+listed it (11 such `wt-*` relocation stubs had accumulated).
 
 Stdlib-only. Fail-open on parse errors.
 """
@@ -206,7 +213,71 @@ def _handle_exit_worktree(data: dict) -> int:
     return 2
 
 
+def _handle_enter_worktree(data: dict) -> int:
+    """Handle EnterWorktree tool — hard-block to keep sessions findable.
+
+    EnterWorktree re-roots the live session into a git worktree: the harness
+    mints a NEW session id whose transcript is written under a DIFFERENT Claude
+    Code project slug (``…<repo>--claude-worktrees-<name>/``), leaving only a
+    ``wt-<id>.jsonl`` pointer stub behind in the original project dir. The
+    conversation continues seamlessly on screen, but ``/resume`` launched from
+    the original directory no longer lists it — the session is, in effect, lost.
+
+    Worktree *isolation* never requires relocating the session, so block
+    unconditionally and redirect to non-relocating alternatives. Always returns
+    exit code 2 regardless of input (``name`` / ``path`` / empty).
+    """
+    target = "(auto-named worktree)"
+    if isinstance(data, dict):
+        target = data.get("name") or data.get("path") or target
+    print(
+        f"BLOCKED: EnterWorktree is disabled — entering '{target}' would "
+        "relocate this session into a worktree and make it unfindable.",
+        file=sys.stderr,
+    )
+    print(
+        "Why: the harness re-roots the session and writes its transcript under "
+        "a separate '<repo>--claude-worktrees-<name>' project dir, leaving only "
+        "a 'wt-<id>.jsonl' stub behind. /resume from the original directory will "
+        "no longer list this conversation.",
+        file=sys.stderr,
+    )
+    print("Keep the session findable — do this instead:", file=sys.stderr)
+    print(
+        "  - Isolated file changes: `git worktree add .claude/worktrees/<name> "
+        "-b <scope>/<desc> origin/main`, then edit via the worktree's ABSOLUTE "
+        "paths and test with `PYTHONPATH=<worktree>/src pytest <files>`. Your "
+        "session stays in the main repo and in /resume.",
+        file=sys.stderr,
+    )
+    print(
+        "  - Parallel isolated work: dispatch a subagent (Agent tool, "
+        'isolation="worktree") — the child runs in its own worktree; your '
+        "session is untouched.",
+        file=sys.stderr,
+    )
+    print(
+        "  - If a worktree-ROOTED session is genuinely wanted, the USER should "
+        "launch Claude Code from that directory, so it is findable there from "
+        "the start.",
+        file=sys.stderr,
+    )
+    return 2
+
+
 def main() -> int:
+    # EnterWorktree is hard-blocked UNCONDITIONALLY: it relocates the session
+    # regardless of arguments or input, so block before any parse that could
+    # otherwise fail-open (empty/missing/malformed CLAUDE_TOOL_INPUT) and let
+    # the relocation through. Input is parsed only to name the worktree in the
+    # message; failure to parse still blocks.
+    if "--enter-worktree" in sys.argv:
+        try:
+            data = json.loads(os.environ.get("CLAUDE_TOOL_INPUT") or "{}")
+        except (json.JSONDecodeError, ValueError):
+            data = {}
+        return _handle_enter_worktree(data)
+
     try:
         raw = os.environ.get("CLAUDE_TOOL_INPUT", "")
         if not raw:

--- a/tests/test_hooks/test_worktree_guard.py
+++ b/tests/test_hooks/test_worktree_guard.py
@@ -5,6 +5,7 @@ Tests the enhanced guard hook that:
 2. Blocks removal if the current session's CWD is the target (self-brick)
 3. Blocks ALL direct worktree removal (redirects to lifecycle manager)
 4. Handles ExitWorktree tool (--exit-worktree mode)
+5. Hard-blocks EnterWorktree relocation (--enter-worktree mode)
 
 Exit codes: 0 = allowed, 2 = blocked.
 """
@@ -222,6 +223,69 @@ class TestExitWorktree:
             finally:
                 proc.terminate()
                 proc.wait(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# EnterWorktree mode — relocation block (keeps sessions findable)
+# ---------------------------------------------------------------------------
+
+
+class TestEnterWorktree:
+    def test_enter_with_name_blocked(self, guard_cmd: str) -> None:
+        """EnterWorktree creating a named worktree is hard-blocked."""
+        result = _run_guard(
+            guard_cmd, {"name": "my-feature"}, extra_args="--enter-worktree",
+        )
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stderr
+        assert "my-feature" in result.stderr
+
+    def test_enter_with_path_blocked(self, guard_cmd: str) -> None:
+        """EnterWorktree switching into an existing worktree is hard-blocked."""
+        result = _run_guard(
+            guard_cmd,
+            {"path": ".claude/worktrees/existing"},
+            extra_args="--enter-worktree",
+        )
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stderr
+
+    def test_enter_empty_input_blocked(self, guard_cmd: str) -> None:
+        """EnterWorktree with no args (auto-named) is still hard-blocked."""
+        result = _run_guard(guard_cmd, {}, extra_args="--enter-worktree")
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stderr
+
+    def test_block_message_redirects_to_findable_pattern(
+        self, guard_cmd: str,
+    ) -> None:
+        """Message must point to the non-relocating alternative + /resume."""
+        result = _run_guard(
+            guard_cmd, {"name": "x"}, extra_args="--enter-worktree",
+        )
+        err = result.stderr.lower()
+        assert "git worktree add" in err
+        assert "/resume" in err
+
+    def test_enter_blocked_with_missing_env(self, guard_cmd: str) -> None:
+        """Hard block holds even when CLAUDE_TOOL_INPUT is unset (no fail-open)."""
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDE_TOOL_INPUT"}
+        result = subprocess.run(
+            f"{guard_cmd} --enter-worktree",
+            shell=True, env=env, capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stderr
+
+    def test_enter_blocked_with_malformed_env(self, guard_cmd: str) -> None:
+        """Hard block holds even when CLAUDE_TOOL_INPUT is not valid JSON."""
+        env = {**os.environ, "CLAUDE_TOOL_INPUT": "not-json"}
+        result = subprocess.run(
+            f"{guard_cmd} --enter-worktree",
+            shell=True, env=env, capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 2
+        assert "BLOCKED" in result.stderr
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Claude Code's native **`EnterWorktree`** tool re-roots a live session into a git
worktree. When it fires mid-conversation, the harness mints a **new session id**
whose transcript is written under a *different* project slug
(`…<repo>--claude-worktrees-<name>/`), leaving only a `wt-<id>.jsonl` pointer
stub in the original project directory.

The conversation continues seamlessly on screen, so it's invisible to the user —
but `/resume` launched from the main repo only lists the main slug, so the
relocated continuation never appears. The session effectively becomes
**unfindable** ("lost session"). Genesis's own worktree discipline ("MANDATORY:
use git worktrees") nudges the model to invoke `EnterWorktree`, so this happens
repeatedly and silently.

## Fix

Extend the existing PreToolUse guard `scripts/hooks/worktree_cwd_guard.py` with a
third mode, `--enter-worktree`, that **hard-blocks `EnterWorktree`** (exit 2) and
redirects to non-relocating isolation:

- `git worktree add .claude/worktrees/<name> -b <scope>/<desc> origin/main`, then
  edit via absolute paths and test with `PYTHONPATH=<worktree>/src` — the session
  stays in the main repo and in `/resume`.
- Dispatch a subagent (`Agent` tool, `isolation="worktree"`) for parallel work.
- If a worktree-rooted session is genuinely wanted, launch Claude Code from that
  directory so it's findable there from the start.

The block is **unconditional**: it fires before parsing tool input, so an empty,
missing, or malformed `CLAUDE_TOOL_INPUT` cannot bypass it.

## Changes

- `scripts/hooks/worktree_cwd_guard.py` — new `--enter-worktree` mode + relocation rationale.
- `.claude/settings.json` — wire the `EnterWorktree` PreToolUse matcher.
- `tests/test_hooks/test_worktree_guard.py` — `TestEnterWorktree` (name/path/empty/malformed-env/message). **22 pass.**
- `.claude/skills/genesis-development/references/worktrees.md` — clarify "use worktrees" = `git worktree add`, not the relocating tool.

## Verification

- `ruff check` clean; `.claude/settings.json` valid JSON.
- `pytest tests/test_hooks/test_worktree_guard.py` → 22 passed.
- Ran the exact wired launcher command end-to-end: `EnterWorktree` → exit 2 with
  guidance; empty/missing env → still exit 2; `ExitWorktree keep` → exit 0 (no
  regression to existing behavior).

## Regression marker

`wt-*.jsonl` relocation stubs in the project dir should stop accumulating. If a
new one appears after this lands, the matcher didn't catch the real trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
