### PR TITLE
feat(ambient): capture-clarity prioritizer for ambient STT signal-richness

### DIFF
--- a/scripts/ambient/garble_features.py
+++ b/scripts/ambient/garble_features.py
@@ -1,0 +1,256 @@
+"""Pure feature functions for ambient STT analysis — NO I/O, NO LLM, NO genesis
+imports, so they're unit-testable in isolation and port to the edge as plain
+arithmetic.
+
+The headline (and only wired-toward) deliverable is **capture-clarity**
+(``capture_clarity`` / ``is_blip``, bottom of file): a signal-richness prioritizer
+for the future attention engine — see the note above those functions.
+
+> History: this module began as the maths for a "filter out hallucinated garble"
+> approach. That framing was **corrected by user ground truth (2026-06-29): the
+> ambient stream is ALL real household audio, just mis-transcribed** — there is no
+> "fake garble"/TV class to filter. The garble-detection helpers below
+> (``dict_coverage``, ``gate_metrics``, ``best_threshold``, ``stratified_sample``)
+> are retained as general, tested utilities, but the *deliverable* is the
+> capture-clarity score. See [[project_ambient_stt_garble]].
+"""
+from __future__ import annotations
+
+import random
+import re
+from collections.abc import Callable, Hashable, Sequence
+from typing import Any
+
+# Token = a whitespace chunk reduced to its lowercase alphabetic core. Keeps an
+# internal apostrophe ("don't") so contractions can be matched against vocab.
+_WORD_RE = re.compile(r"[a-z]+(?:'[a-z]+)?")
+
+
+# ── confidence statistics over per-token ys_log_probs ────────────────────────
+
+def frac_below(values: Sequence[float], thr: float) -> float:
+    """Fraction of values strictly < ``thr``. Empty → 0.0 (no evidence).
+
+    ``frac_below(ys_log_probs, -1.0)`` is the lead garble statistic: real speech
+    sits ~0%, garble 12-20% (measured on the live corpus 2026-06-29).
+    """
+    if not values:
+        return 0.0
+    return sum(1 for v in values if v < thr) / len(values)
+
+
+def mean_or(values: Sequence[float], *, default: float) -> float:
+    """Mean, or ``default`` when empty (no div-by-zero)."""
+    return sum(values) / len(values) if values else default
+
+
+def min_or(values: Sequence[float], *, default: float) -> float:
+    """Min, or ``default`` when empty."""
+    return min(values) if values else default
+
+
+# ── lexical signals over the transcript text ─────────────────────────────────
+
+def _word_tokens(text: str) -> list[str]:
+    """Lowercase alphabetic word-cores from free text (drops digits/punctuation)."""
+    return _WORD_RE.findall((text or "").lower())
+
+
+def dict_coverage(text: str, vocab: set[str]) -> float:
+    """Fraction of word-tokens present in ``vocab`` (real-English coverage).
+
+    Catches class-(a) garble like "INSTITUAL"/"DOLLIONS"/"COMFENCE" which are
+    fluent-looking but not real words. No word-tokens at all → 0.0 (no evidence
+    it is real speech). ``vocab`` is injected so this stays pure/testable; the
+    CLI builds the real vocab from nltk ``words`` + a casual-speech allowlist.
+    """
+    toks = _word_tokens(text)
+    if not toks:
+        return 0.0
+    covered = sum(1 for t in toks if t in vocab or t.split("'", 1)[0] in vocab)
+    return covered / len(toks)
+
+
+def repetition_ratio(tokens: Sequence[str]) -> float:
+    """1 - unique/total over tokens (0.0 for <2 tokens). ASR loops repeat tokens."""
+    n = len(tokens)
+    if n < 2:
+        return 0.0
+    return 1.0 - len(set(tokens)) / n
+
+
+def max_repeat_run(tokens: Sequence[str]) -> int:
+    """Longest run of consecutive identical tokens (0 for empty, 1 for all-distinct)."""
+    best = run = 0
+    prev = object()
+    for t in tokens:
+        run = run + 1 if t == prev else 1
+        best = max(best, run)
+        prev = t
+    return best
+
+
+# ── deterministic, proportional stratified sample (the judge set) ────────────
+
+def stratified_sample(
+    items: Sequence[Any],
+    *,
+    key_fn: Callable[[Any], Hashable],
+    n: int,
+    seed: int,
+) -> list[Any]:
+    """Pick ``n`` items spread proportionally across strata (largest-remainder),
+    deterministically given ``seed``. ``n >= len(items)`` returns all items.
+
+    Used to bound how many real household fragments leave to the external judge
+    while keeping every (is_user × confidence × length) cell represented.
+    """
+    items = list(items)
+    if n >= len(items):
+        return items
+
+    strata: dict[Hashable, list[Any]] = {}
+    for it in items:
+        strata.setdefault(key_fn(it), []).append(it)
+
+    total = len(items)
+    # Largest-remainder allocation so the picks sum to exactly n.
+    raw = {k: n * len(v) / total for k, v in strata.items()}
+    alloc = {k: int(v) for k, v in raw.items()}
+    short = n - sum(alloc.values())
+    # Distribute the remaining slots to the largest fractional remainders;
+    # ties break by stratum key order for determinism.
+    order = sorted(strata.keys(), key=lambda k: (-(raw[k] - alloc[k]), _sortable(k)))
+    for k in order[:short]:
+        alloc[k] += 1
+
+    rng = random.Random(seed)
+    out: list[Any] = []
+    for k in sorted(strata.keys(), key=_sortable):
+        bucket = strata[k]
+        take = min(alloc.get(k, 0), len(bucket))
+        out.extend(rng.sample(bucket, take))
+    return out
+
+
+def _sortable(k: Hashable) -> str:
+    """Stable string key for deterministic ordering of heterogeneous stratum keys."""
+    return repr(k)
+
+
+# ── the tradeoff metric every curve is computed from ─────────────────────────
+
+def gate_metrics(labels: Sequence[str], keep: Sequence[bool]) -> dict[str, Any]:
+    """Score a keep/drop decision against real|garble ground truth.
+
+    Non-{real,garble} labels (e.g. ``abstain``) are excluded from both
+    denominators. Returns garble-killed (recall on garble) and real-dropped
+    (the cost) plus raw counts. Empty denominators → 0.0, never a div-by-zero.
+    """
+    real_total = real_dropped = garble_total = garble_killed = 0
+    for lab, k in zip(labels, keep, strict=False):
+        if lab == "real":
+            real_total += 1
+            if not k:
+                real_dropped += 1
+        elif lab == "garble":
+            garble_total += 1
+            if not k:
+                garble_killed += 1
+    return {
+        "real_total": real_total,
+        "garble_total": garble_total,
+        "real_dropped_n": real_dropped,
+        "garble_killed_n": garble_killed,
+        "real_dropped": (real_dropped / real_total) if real_total else 0.0,
+        "garble_killed": (garble_killed / garble_total) if garble_total else 0.0,
+    }
+
+
+# ── greedy threshold search (depth-1; the building block of the stump) ────────
+
+def _keep_mask(scores: Sequence[float], thr: float, direction: str) -> list[bool]:
+    """direction='drop_high' → drop (keep=False) rows with score >= thr."""
+    if direction == "drop_high":
+        return [s < thr for s in scores]
+    if direction == "drop_low":
+        return [s > thr for s in scores]
+    raise ValueError(f"unknown direction {direction!r}")
+
+
+def best_threshold(
+    scores: Sequence[float],
+    labels: Sequence[str],
+    *,
+    max_real_dropped: float,
+    direction: str = "drop_high",
+) -> dict[str, Any] | None:
+    """Best single threshold on ``scores`` maximizing garble-killed subject to
+    real-dropped ≤ ``max_real_dropped``. Returns the winning metrics (with the
+    chosen ``threshold``/``direction``), or ``None`` if no split kills any garble
+    within budget. Candidate thresholds sit just above each observed score so a
+    ``>=`` drop is exact.
+    """
+    uniq = sorted(set(scores))
+    # Candidate cut points: above the max (drop nothing) and just above each value.
+    eps = 1e-9
+    candidates = [uniq[-1] + 1.0] + [v + eps for v in uniq]
+    best: dict[str, Any] | None = None
+    for thr in candidates:
+        m = gate_metrics(labels, _keep_mask(scores, thr, direction))
+        if m["real_dropped"] > max_real_dropped + 1e-12:
+            continue
+        if best is None or m["garble_killed"] > best["garble_killed"]:
+            best = {**m, "threshold": thr, "direction": direction}
+    if best is None or best["garble_killed"] == 0.0:
+        return best if best and best["garble_killed"] > 0.0 else None
+    return best
+
+
+# ── capture-clarity: a heuristic signal-richness prioritizer ─────────────────
+# NOT an accuracy measure and NOT a relevance measure. It orders utterances from
+# near-silence one-word blips → loud, long, confident passages — "how clearly was
+# this captured," which is all the stored data can honestly support. The original
+# "filter out hallucinated garble" framing was WRONG (user ground truth 2026-06-29:
+# the stream is ALL real household audio, just mis-transcribed); a dict-coverage
+# accuracy proxy came out flat (~0.90 everywhere — single mis-heard real words score
+# 1.0), and the raw audio isn't stored, so transcription ACCURACY is unverifiable.
+# What survives is this clarity ordering, validated by human eyeball.
+# Reference points from the live corpus (2026-06-29, n=6074): rms p05≈0.026 /
+# p75≈0.168 · duration p75≈3.85s · n_tokens p75≈15 · frac_lt_1 p50≈0.083.
+
+RMS_FLOOR = 0.02      # below ≈ near-silence (corpus p05≈0.026); the blip floor
+RMS_REF = 0.17        # "loud / clearly captured" reference (corpus p75≈0.168)
+DUR_REF = 4.0         # seconds for a "full-length" utterance (corpus p75≈3.85)
+NTOK_REF = 8.0        # tokens for a "content-rich" utterance
+
+
+def _clamp01(x: float) -> float:
+    if x != x:  # NaN (the only value not equal to itself) — corrupt meta → worst-case
+        return 0.0
+    return 0.0 if x < 0.0 else (1.0 if x > 1.0 else x)
+
+
+def is_blip(rms: float, duration_s: float, n_tokens: int) -> bool:
+    """True for a near-silence throwaway — the ASR emitting a word or two from
+    almost no audio. Pure physics: ``rms`` below the near-silence floor AND sparse
+    (sub-second OR ≤2 tokens). Deliberately conservative — flags ~1.8% of the live
+    corpus, the unambiguous junk tail only. The one rock-solid signal here: it needs
+    no accuracy or relevance judgement, just loudness."""
+    return rms < RMS_FLOOR and (duration_s < 1.0 or n_tokens <= 2)
+
+
+def capture_clarity(
+    rms: float, duration_s: float, frac_lt_1: float, n_tokens: int,
+) -> float:
+    """Heuristic 0..1 capture-clarity score (see the module note: clarity, NOT
+    accuracy, NOT relevance — relevance is ``is_user``, kept orthogonal). Equal-
+    weight mean of four bounded sub-scores, so there's no false precision on weights
+    (a consumer may reweight): ASR confidence (``1-frac_lt_1``), loudness, length,
+    token-richness. Near-silence blips land near 0; loud/long/confident passages near
+    1. Edge-portable — plain arithmetic, no population statistics."""
+    confidence = 1.0 - _clamp01(frac_lt_1)
+    loudness = _clamp01((rms - RMS_FLOOR) / (RMS_REF - RMS_FLOOR))
+    length = _clamp01(duration_s / DUR_REF)
+    richness = _clamp01(n_tokens / NTOK_REF)
+    return (confidence + loudness + length + richness) / 4.0

--- a/tests/test_scripts/test_ambient_garble.py
+++ b/tests/test_scripts/test_ambient_garble.py
@@ -1,0 +1,223 @@
+"""Unit tests for the ambient garble-analysis pure feature/metric functions.
+
+These cover the genuinely-custom, correctness-critical logic the gate decision
+rests on: the per-token confidence statistic, dict-coverage, repetition, the
+deterministic stratified sample we send to the (paid-attention) LLM judge, the
+tradeoff metric every curve is computed from, and the greedy stump that becomes
+the edge gate. All pure — no I/O, no LLM, no genesis imports — so they pin the
+maths independent of the snapshot/judge plumbing.
+"""
+import sys
+from pathlib import Path
+
+# Import the script module the way tests/test_hooks/* import scripts (sys.path).
+_AMBIENT = Path(__file__).resolve().parents[2] / "scripts" / "ambient"
+sys.path.insert(0, str(_AMBIENT))
+
+import garble_features as gf  # noqa: E402
+
+# ── frac_below: the lead confidence statistic frac(ys_log_probs < thr) ──
+
+def test_frac_below_basic():
+    assert gf.frac_below([-0.2, -0.3, -0.1], -1.0) == 0.0
+    assert gf.frac_below([-2.0, -0.1], -1.0) == 0.5
+    assert gf.frac_below([-2.0, -1.5, -3.0], -1.0) == 1.0
+
+
+def test_frac_below_empty_is_zero():
+    # No tokens → no evidence of garble (capture-side already dropped empties).
+    assert gf.frac_below([], -1.0) == 0.0
+
+
+def test_frac_below_boundary_is_strict_less_than():
+    # exactly == thr must NOT count (strict <), matching the plan's frac(<-1).
+    assert gf.frac_below([-1.0, -1.0], -1.0) == 0.0
+
+
+def test_mean_or_and_min_or_handle_empty():
+    assert gf.mean_or([-1.0, -3.0], default=0.0) == -2.0
+    assert gf.mean_or([], default=0.0) == 0.0
+    assert gf.min_or([-0.2, -2.0], default=0.0) == -2.0
+    assert gf.min_or([], default=0.0) == 0.0
+
+
+# ── dict_coverage: fraction of word-tokens that are real English ──
+
+def test_dict_coverage_all_real():
+    vocab = {"hey", "turn", "off", "the", "light"}
+    assert gf.dict_coverage("hey turn off the light", vocab) == 1.0
+
+
+def test_dict_coverage_garble_words_uncovered():
+    # "DOLLIONS"/"COMFENCE" are ASR inventions → only "the" is covered.
+    vocab = {"the", "buy", "under"}
+    cov = gf.dict_coverage("AND BUY COMFENCE UNDER DOLLIONS the", vocab)
+    # tokens: and(no) buy(yes) comfence(no) under(yes) dollions(no) the(yes) -> 3/6
+    assert abs(cov - 0.5) < 1e-9
+
+
+def test_dict_coverage_strips_punctuation_and_casefolds():
+    vocab = {"hey", "off"}
+    assert gf.dict_coverage("Hey, OFF!", vocab) == 1.0
+
+
+def test_dict_coverage_no_word_tokens_is_zero():
+    # punctuation/digits only → no evidence it's real speech.
+    assert gf.dict_coverage("?? 123 --", {"hey"}) == 0.0
+
+
+# ── repetition: ASR loops emit repeated tokens ──
+
+def test_repetition_ratio():
+    assert gf.repetition_ratio(["a", "a", "a"]) == (1.0 - 1.0 / 3.0)
+    assert gf.repetition_ratio(["a", "b", "c"]) == 0.0
+    assert gf.repetition_ratio([]) == 0.0
+    assert gf.repetition_ratio(["a"]) == 0.0
+
+
+def test_max_repeat_run():
+    assert gf.max_repeat_run(["a", "a", "b", "a"]) == 2
+    assert gf.max_repeat_run(["a", "b", "c"]) == 1
+    assert gf.max_repeat_run([]) == 0
+
+
+# ── stratified_sample: the deterministic, proportional judge sample ──
+
+def test_stratified_sample_is_deterministic():
+    items = [{"id": i, "g": i % 3} for i in range(60)]
+    a = gf.stratified_sample(items, key_fn=lambda x: x["g"], n=12, seed=7)
+    b = gf.stratified_sample(items, key_fn=lambda x: x["g"], n=12, seed=7)
+    assert [x["id"] for x in a] == [x["id"] for x in b]
+    assert len(a) == 12
+
+
+def test_stratified_sample_respects_strata_proportions():
+    # two equal strata of 10; n=4 → exactly 2 per stratum (largest-remainder).
+    items = [{"id": i, "g": "A"} for i in range(10)] + [{"id": 100 + i, "g": "B"} for i in range(10)]
+    out = gf.stratified_sample(items, key_fn=lambda x: x["g"], n=4, seed=1)
+    counts = {}
+    for x in out:
+        counts[x["g"]] = counts.get(x["g"], 0) + 1
+    assert counts == {"A": 2, "B": 2}
+
+
+def test_stratified_sample_n_ge_population_returns_all():
+    items = [{"id": i, "g": i % 2} for i in range(8)]
+    out = gf.stratified_sample(items, key_fn=lambda x: x["g"], n=100, seed=3)
+    assert sorted(x["id"] for x in out) == list(range(8))
+
+
+# ── gate_metrics: the tradeoff measurement every curve depends on ──
+
+def test_gate_metrics_perfect_gate():
+    labels = ["real", "garble", "garble", "real"]
+    keep = [True, False, False, True]
+    m = gf.gate_metrics(labels, keep)
+    assert m["garble_killed"] == 1.0
+    assert m["real_dropped"] == 0.0
+    assert m["real_total"] == 2 and m["garble_total"] == 2
+
+
+def test_gate_metrics_drops_some_real():
+    labels = ["real", "real", "garble", "garble"]
+    keep = [True, False, False, False]  # killed both garble but dropped 1 real
+    m = gf.gate_metrics(labels, keep)
+    assert m["garble_killed"] == 1.0
+    assert m["real_dropped"] == 0.5
+
+
+def test_gate_metrics_ignores_abstain_and_other_labels():
+    labels = ["real", "garble", "abstain", "real"]
+    keep = [True, False, True, True]
+    m = gf.gate_metrics(labels, keep)
+    # abstain row excluded from both denominators
+    assert m["real_total"] == 2 and m["garble_total"] == 1
+    assert m["garble_killed"] == 1.0 and m["real_dropped"] == 0.0
+
+
+def test_gate_metrics_empty_denominators_are_zero_not_div0():
+    m = gf.gate_metrics(["real", "real"], [True, True])
+    assert m["garble_total"] == 0
+    assert m["garble_killed"] == 0.0  # no garble to kill → 0, not a ZeroDivisionError
+
+
+# ── best_threshold: depth-1 split honouring the real-dropped budget ──
+
+def test_best_threshold_picks_max_garble_kill_within_budget():
+    # scores: higher frac(<-1) = more garble. drop rows with score >= thr.
+    scores = [0.0, 0.0, 0.3, 0.4, 0.5]
+    labels = ["real", "real", "garble", "garble", "garble"]
+    # budget 0 real-dropped → thr must sit above the real rows (0.0) and at/below 0.3
+    res = gf.best_threshold(scores, labels, max_real_dropped=0.0, direction="drop_high")
+    assert res is not None
+    assert res["garble_killed"] == 1.0
+    assert res["real_dropped"] == 0.0
+
+
+def test_best_threshold_returns_none_when_budget_impossible_without_real_loss():
+    # real and garble fully overlap at the same score → can't kill garble w/o dropping real
+    scores = [0.5, 0.5]
+    labels = ["real", "garble"]
+    res = gf.best_threshold(scores, labels, max_real_dropped=0.0, direction="drop_high")
+    # killing the garble (score 0.5) also drops the real (score 0.5) → over budget → no valid split
+    assert res is None or res["garble_killed"] == 0.0
+
+
+# ── is_blip: the rock-solid near-silence physics gate ────────────────────────
+
+def test_is_blip_flags_near_silence_short():
+    # rms≈0.01 (below the 0.02 floor) + short/one-word → throwaway blip
+    assert gf.is_blip(rms=0.01, duration_s=0.5, n_tokens=1) is True
+    assert gf.is_blip(rms=0.008, duration_s=2.0, n_tokens=1) is True  # near-silent + 1 token
+
+
+def test_is_blip_false_for_loud_or_rich():
+    assert gf.is_blip(rms=0.20, duration_s=20.0, n_tokens=30) is False
+    # quiet but long AND wordy → NOT a blip (only near-silence + short/sparse qualifies)
+    assert gf.is_blip(rms=0.01, duration_s=5.0, n_tokens=10) is False
+
+
+def test_is_blip_floor_is_strict():
+    # exactly at the floor is not below it → not a blip
+    assert gf.is_blip(rms=gf.RMS_FLOOR, duration_s=0.5, n_tokens=1) is False
+
+
+# ── capture_clarity: heuristic 0..1 prioritizer (NOT an accuracy claim) ───────
+
+def test_capture_clarity_extremes():
+    hi = gf.capture_clarity(rms=0.25, duration_s=22.0, frac_lt_1=0.0, n_tokens=30)
+    lo = gf.capture_clarity(rms=0.005, duration_s=0.5, frac_lt_1=1.0, n_tokens=1)
+    assert hi > 0.9
+    assert lo < 0.1
+    assert hi > lo
+
+
+def test_capture_clarity_bounded_0_1():
+    for args in [(0.0, 0.0, 1.0, 0), (999.0, 999.0, -5.0, 999), (0.17, 4.0, 0.0, 8)]:
+        c = gf.capture_clarity(*args)
+        assert 0.0 <= c <= 1.0
+
+
+def test_capture_clarity_handles_nan_meta():
+    # corrupt meta (NaN rms/duration) must NOT yield a NaN score — stays in [0,1].
+    nan = float("nan")
+    c = gf.capture_clarity(rms=nan, duration_s=nan, frac_lt_1=0.0, n_tokens=6)
+    assert c == c  # not NaN
+    assert 0.0 <= c <= 1.0
+
+
+def test_capture_clarity_monotonic_in_each_signal():
+    base = dict(rms=0.1, duration_s=2.0, frac_lt_1=0.3, n_tokens=6)
+    # louder → clearer
+    assert gf.capture_clarity(**{**base, "rms": 0.18}) > gf.capture_clarity(**{**base, "rms": 0.04})
+    # more ASR-confident (lower frac_lt_1) → clearer
+    assert gf.capture_clarity(**{**base, "frac_lt_1": 0.0}) > gf.capture_clarity(**{**base, "frac_lt_1": 0.8})
+    # longer → clearer
+    assert gf.capture_clarity(**{**base, "duration_s": 6.0}) > gf.capture_clarity(**{**base, "duration_s": 0.6})
+    # more tokens → clearer
+    assert gf.capture_clarity(**{**base, "n_tokens": 20}) > gf.capture_clarity(**{**base, "n_tokens": 1})
+
+
+def test_capture_clarity_blip_scores_low():
+    # a near-silence blip should land near the bottom of the scale
+    assert gf.capture_clarity(rms=0.01, duration_s=0.5, frac_lt_1=1.0, n_tokens=1) < 0.15


### PR DESCRIPTION
## What

A pure, edge-portable scorer for the ambient transcript stream, intended for a future passive-listening attention layer to prioritize what's worth attending to:

- `capture_clarity(rms, duration_s, frac_lt_1, n_tokens) -> 0..1` — equal-weight mean of four bounded sub-scores (ASR token-confidence, loudness, length, token-richness). No false precision on weights; a consumer may reweight.
- `is_blip(rms, duration_s, n_tokens) -> bool` — flags near-silence throwaways (the recognizer emitting a word or two from almost no audio) by pure physics; conservative (~1.8% of the corpus).

Pure functions: no I/O, no LLM, no package imports — unit-testable in isolation and portable to the edge as plain arithmetic.

## Why it scores *clarity*, not *accuracy*

This started as a "filter out hallucinated garble" effort and was corrected by ground-truth review: the ambient stream is essentially **all real speech, just imperfectly transcribed** — there is no large "fake"/background-media class to filter. Transcription *accuracy* turns out to be **unverifiable from the stored data** (raw audio isn't retained, and a dictionary-coverage accuracy proxy came out flat ~0.90 because single mis-heard real words still score as real words).

What the data *does* support is a **capture-clarity / signal-richness** ordering — near-silence one-word blips at the bottom, loud/long/confident passages at the top. That's what this ships. It is explicitly **not** an accuracy measure and **not** a relevance measure (speaker attribution stays an orthogonal dimension).

## Validation (calibration-free, n≈6074)

- Clarity distribution p10/50/90 = 0.31 / 0.69 / 0.97; blips flagged = 1.8%.
- Orthogonal to speaker attribution (top-clarity quartile is only ~41% user) — clarity ≠ "it's the user."
- Thresholds documented from the live corpus distribution.

## Tests / review

27 unit tests (TDD), ruff clean. Code-reviewed; a NaN-on-corrupt-meta robustness bug was caught and fixed (`_clamp01` now guards NaN → worst-case, keeping the `0..1` contract on a 24/7 stream).

## Status

**Unwired building block** — the attention layer that will consume it doesn't exist yet. Merging this lands a tested utility ahead of its consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)