### PR TITLE
feat(feedback): harvest surplus_tasks into the Outcome Bus as tier-1 ground truth

### DIFF
--- a/src/genesis/feedback/harvest.py
+++ b/src/genesis/feedback/harvest.py
@@ -24,6 +24,11 @@ Source authority (no double-counting):
 
 Each source read is wrapped independently (``_safe``) so one bad source can never
 abort the others.
+
+Note: this module is a read-only ETL pipeline — its per-source ``SELECT``s are
+intentional raw SQL (dynamic, filtered reads that don't map to a standard crud
+API), NOT a crud-layer violation. The only write path is ``record_outcome`` via
+``genesis.feedback.bus``; the authoritative source tables are never mutated.
 """
 
 from __future__ import annotations

--- a/src/genesis/feedback/harvest.py
+++ b/src/genesis/feedback/harvest.py
@@ -39,6 +39,14 @@ from genesis.feedback.bus import SignalType, record_outcome
 logger = logging.getLogger(__name__)
 
 BACKFILL_MARKER = "outcome_backfill_done"
+# Bumped whenever a NEW harvest source is added AFTER installs have already set
+# the marker — forces a one-time re-backfill so the new source's history lands.
+# The stored value is "v{N}:{iso}"; a bare ISO (no "v" prefix) is the legacy v1
+# stamp (proposals + outreach only). Re-running is safe: every source is
+# idempotent on the (source, ref_type, ref_id, signal_type) unique key, so
+# already-harvested rows are INSERT-OR-IGNORE no-ops (read I/O, no WAL write).
+# v2 (2026-06-29): added the surplus_tasks source.
+BACKFILL_VERSION = 2
 
 # Markers update_proposal_outcome appends to ego_proposals.user_response.
 # Two forms exist: "<session_id>|completed:<summary>" and a bare
@@ -82,6 +90,27 @@ def _parse_execution_suffix(user_response: str | None) -> tuple[str, float, str]
     return None
 
 
+def _marker_version(value: str | None) -> int:
+    """Parse the backfill schema-version from a stored marker value.
+
+    The current stamp is ``"v{N}:{iso}"``; a bare ISO timestamp (no ``v``
+    prefix) is the legacy v1 stamp. ISO dates start with ``"2"``, so there is no
+    ambiguity with the ``"v"`` prefix. ``None`` (never backfilled) → 0 so the
+    guard runs the first backfill.
+    """
+    if not value:
+        return 0
+    if value.startswith("v") and ":" in value:
+        try:
+            n = int(value.split(":", 1)[0][1:])
+        except ValueError:
+            return 1
+        # Clamp malformed sub-v1 values (e.g. a hand-edited "v0:"/"v-1:") to the
+        # legacy fallback so a corrupt marker re-runs once, not forever.
+        return n if n >= 1 else 1
+    return 1  # legacy bare-ISO stamp = v1
+
+
 class OutcomeHarvester:
     """Idempotently folds existing outcome signals into ``outcome_events``."""
 
@@ -96,6 +125,7 @@ class OutcomeHarvester:
         return {
             "proposals": await self._safe(self._harvest_proposals, cutoff),
             "outreach": await self._safe(self._harvest_outreach, cutoff),
+            "surplus": await self._safe(self._harvest_surplus_tasks, cutoff),
         }
 
     async def run_backfill(self) -> dict:
@@ -107,14 +137,20 @@ class OutcomeHarvester:
         rows. A clean run over genuinely-empty tables (0 rows, no error) DOES
         set the marker — there is nothing to backfill.
         """
-        if await ego_crud.get_state(self._db, BACKFILL_MARKER):
+        stored = await ego_crud.get_state(self._db, BACKFILL_MARKER)
+        if stored and _marker_version(stored) >= BACKFILL_VERSION:
             return {"skipped": True}
 
         failures = 0
         counts: dict[str, int] = {}
+        # NB: surplus goes in THIS loop (which increments ``failures`` on error),
+        # NOT via ``_safe`` — ``_safe`` swallows the exception, which would let
+        # the marker be set despite a surplus failure and permanently lose its
+        # history. The marker is set ONLY when failures == 0 (see below).
         for name, fn in (
             ("proposals", self._harvest_proposals),
             ("outreach", self._harvest_outreach),
+            ("surplus", self._harvest_surplus_tasks),
         ):
             try:
                 counts[name] = await fn(None)
@@ -126,7 +162,9 @@ class OutcomeHarvester:
         result = {"skipped": False, **counts}
         if failures == 0:
             await ego_crud.set_state(
-                self._db, key=BACKFILL_MARKER, value=datetime.now(UTC).isoformat()
+                self._db,
+                key=BACKFILL_MARKER,
+                value=f"v{BACKFILL_VERSION}:{datetime.now(UTC).isoformat()}",
             )
             logger.info("Outcome backfill complete: %s", result)
         else:
@@ -266,6 +304,64 @@ class OutcomeHarvester:
                 polarity=polarity,
                 value=value,
                 reason_text=r["user_response"],
+            )
+            if eid:
+                inserted += 1
+        return inserted
+
+    async def _harvest_surplus_tasks(self, cutoff: str | None) -> int:
+        """surplus_tasks → execution_outcome (T1 ground truth).
+
+        Background autonomous work (reapers, audits, indexing, …) is the richest
+        execution-outcome silo Genesis has: a terminal ``status`` of
+        ``completed``/``failed`` is a real "did the work run to completion"
+        signal. ``cutoff`` (ISO) limits to recent rows; ``None`` = all history.
+
+        Maintainer notes (deliberate asymmetries):
+        - ``cancelled`` (and non-terminal pending/running) tasks are NOT
+          recorded — a cancel is a lifecycle event, not an execution outcome.
+          Unlike tabled/withdrawn proposals (which get LIFECYCLE_* rows), surplus
+          has no lifecycle signal type and a cancel carries no quality info.
+        - ``stated_confidence`` is left NULL: surplus tasks carry no
+          pre-execution confidence, so they are CORRECTLY excluded from
+          ``calibration_pairs`` (which requires a non-NULL confidence). Do NOT
+          add a synthetic value to "fill" it.
+        - ``domain`` = ``task_type``. ``aggregate_by_domain`` groups by ``domain``
+          across all sources, so a surplus ``task_type`` shares that namespace
+          with ego ``action_type``; no collision exists today, and any future
+          one is read-only observability noise (``calibration_pairs`` is
+          source-filtered, so ego calibration never mixes in surplus rows).
+        """
+        sql = (
+            "SELECT id, task_type, status, failure_reason, completed_at, "
+            "       created_at "
+            "FROM surplus_tasks WHERE status IN ('completed', 'failed')"
+        )
+        params: list = []
+        if cutoff is not None:
+            sql += " AND COALESCE(completed_at, created_at) >= ?"
+            params.append(cutoff)
+
+        cur = await self._db.execute(sql, params)
+        rows = await cur.fetchall()
+        cols = [d[0] for d in cur.description]
+
+        inserted = 0
+        for raw in rows:
+            r = dict(zip(cols, raw, strict=False))
+            completed = r["status"] == "completed"
+            eid = await record_outcome(
+                self._db,
+                source="surplus",
+                ref_type="task",
+                ref_id=r["id"],
+                domain=r["task_type"],
+                signal_type=SignalType.EXECUTION_OUTCOME,
+                polarity="positive" if completed else "negative",
+                value=1.0 if completed else 0.0,
+                reason_text=None if completed else r["failure_reason"],
+                occurred_at=r["completed_at"] or r["created_at"],
+                harvested_from="surplus_tasks",
             )
             if eid:
                 inserted += 1

--- a/tests/feedback/test_harvest.py
+++ b/tests/feedback/test_harvest.py
@@ -11,7 +11,9 @@ from genesis.db.crud import ego as ego_crud
 from genesis.db.crud import outcome_events as oe
 from genesis.feedback.harvest import (
     BACKFILL_MARKER,
+    BACKFILL_VERSION,
     OutcomeHarvester,
+    _marker_version,
     _parse_execution_suffix,
 )
 
@@ -72,6 +74,22 @@ async def _add_outreach(
         "VALUES (?, 'sig', 'topic', ?, 0.5, 'telegram', 'msg', ?, ?, ?, ?, ?)",
         (oid, category, engagement_outcome, user_response, prediction_error,
          delivered_at, _recent(hours=2)),
+    )
+    await db.commit()
+
+
+async def _add_surplus(
+    db, *, tid, status, task_type="code_audit", failure_reason=None,
+    completed_at=None, created_at=None,
+):
+    created_at = created_at or _recent(hours=2)
+    completed_at = completed_at if completed_at is not None else _recent(hours=1)
+    await db.execute(
+        "INSERT INTO surplus_tasks "
+        "(id, task_type, compute_tier, priority, drive_alignment, status, "
+        " failure_reason, created_at, completed_at) "
+        "VALUES (?, ?, 'local', 0.5, 'curiosity', ?, ?, ?, ?)",
+        (tid, task_type, status, failure_reason, created_at, completed_at),
     )
     await db.commit()
 
@@ -223,6 +241,128 @@ class TestHarvestOutreach:
         await _add_outreach(db, oid="real", engagement_outcome="useful")
         await OutcomeHarvester(db).run_backfill()
         assert await oe.count(db) == 1  # only the real one
+
+
+# --------------------------------------------------------------------------- #
+# Surplus-task harvest (LC3-A — the tier-1 execution-outcome producer)
+# --------------------------------------------------------------------------- #
+class TestHarvestSurplusTasks:
+    @pytest.mark.asyncio
+    async def test_completed_is_t1_positive(self, db):
+        await _add_surplus(db, tid="s1", status="completed", task_type="code_audit")
+        await OutcomeHarvester(db).run_backfill()
+        row = (await oe.recent(db, limit=1))[0]
+        assert row["signal_type"] == "execution_outcome"
+        assert row["signal_tier"] == 1
+        assert row["polarity"] == "positive"
+        assert row["value"] == 1.0
+        assert row["domain"] == "code_audit"
+        assert row["source"] == "surplus"
+        assert row["harvested_from"] == "surplus_tasks"
+        assert row["reason_text"] is None
+        # surplus tasks carry no pre-execution confidence → excluded from calibration
+        assert row["stated_confidence"] is None
+
+    @pytest.mark.asyncio
+    async def test_failed_is_t1_negative_with_reason(self, db):
+        # completed_at=None exercises the COALESCE(completed_at, created_at) path.
+        await _add_surplus(
+            db, tid="s2", status="failed", task_type="infrastructure_monitor",
+            failure_reason="probe timed out", completed_at=None,
+        )
+        await OutcomeHarvester(db).run_backfill()
+        row = (await oe.recent(db, limit=1))[0]
+        assert row["signal_type"] == "execution_outcome"
+        assert row["signal_tier"] == 1
+        assert row["polarity"] == "negative"
+        assert row["value"] == 0.0
+        assert row["reason_text"] == "probe timed out"
+        assert row["domain"] == "infrastructure_monitor"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", ["pending", "running", "cancelled"])
+    async def test_non_terminal_is_skipped(self, db, status):
+        # A cancel/in-flight task is not an execution outcome — no row.
+        await _add_surplus(db, tid=f"s-{status}", status=status)
+        await OutcomeHarvester(db).run_backfill()
+        assert await oe.count(db) == 0
+
+    @pytest.mark.asyncio
+    async def test_idempotent_on_unique_key(self, db):
+        await _add_surplus(db, tid="s3", status="completed")
+        await OutcomeHarvester(db).run()
+        await OutcomeHarvester(db).run()  # re-scan same window
+        assert await oe.count(db) == 1  # unique key dedupes
+
+    @pytest.mark.asyncio
+    async def test_incremental_window_excludes_old_but_backfill_includes(self, db):
+        await _add_surplus(
+            db, tid="s-old", status="completed",
+            created_at="2026-05-01T00:00:00+00:00",
+            completed_at="2026-05-01T00:00:00+00:00",
+        )
+        run_result = await OutcomeHarvester(db).run(window_days=2)
+        assert run_result["surplus"] == 0
+        assert await oe.count(db) == 0
+        await OutcomeHarvester(db).run_backfill()
+        assert await oe.count(db) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Versioned backfill marker (LC3-A — re-backfill when a new source is added)
+# --------------------------------------------------------------------------- #
+class TestVersionedBackfillMarker:
+    def test_marker_version_parsing(self):
+        assert _marker_version(None) == 0
+        assert _marker_version("") == 0
+        assert _marker_version("2026-06-25T12:45:02+00:00") == 1  # legacy bare ISO
+        assert _marker_version("v2:2026-06-29T00:00:00+00:00") == 2
+        assert _marker_version("v3:2026-07-01T00:00:00+00:00") == 3
+        assert _marker_version("vX:garbage") == 1  # unparseable → legacy fallback
+        assert _marker_version("v0:x") == 1         # sub-v1 clamps to legacy (no loop)
+        assert _marker_version("v-1:x") == 1
+
+    @pytest.mark.asyncio
+    async def test_legacy_marker_triggers_rerun_and_restamps(self, db):
+        # Pre-LC3-A install: marker present as a bare ISO (v1), so the new
+        # surplus source was never backfilled. The version bump must re-run it.
+        await ego_crud.set_state(
+            db, key=BACKFILL_MARKER, value="2026-06-25T12:45:02+00:00",
+        )
+        await _add_surplus(
+            db, tid="hist", status="completed",
+            created_at="2026-05-01T00:00:00+00:00",
+            completed_at="2026-05-01T00:00:00+00:00",
+        )
+        result = await OutcomeHarvester(db).run_backfill()
+        assert result["skipped"] is False        # v1 < BACKFILL_VERSION → re-run
+        assert result["surplus"] == 1             # historical surplus now harvested
+        stored = await ego_crud.get_state(db, BACKFILL_MARKER)
+        assert _marker_version(stored) == BACKFILL_VERSION  # re-stamped, not bare ISO
+        assert stored.startswith(f"v{BACKFILL_VERSION}:")
+
+    @pytest.mark.asyncio
+    async def test_current_version_marker_skips(self, db):
+        await ego_crud.set_state(
+            db, key=BACKFILL_MARKER,
+            value=f"v{BACKFILL_VERSION}:2026-06-29T00:00:00+00:00",
+        )
+        await _add_surplus(db, tid="s", status="completed")
+        result = await OutcomeHarvester(db).run_backfill()
+        assert result == {"skipped": True}
+        assert await oe.count(db) == 0  # already current → no work, no rows
+
+    @pytest.mark.asyncio
+    async def test_marker_not_set_when_surplus_source_fails(self, db):
+        # Parallel to the outreach reliability guard: a surplus failure must NOT
+        # lock the gate (else its 2k+ historical rows are lost forever). surplus
+        # is in the failures-counting loop, NOT wrapped in _safe.
+        await _add_surplus(db, tid="s", status="completed")
+        await db.execute("DROP TABLE surplus_tasks")
+        await db.commit()
+        result = await OutcomeHarvester(db).run_backfill()
+        assert result.get("incomplete") is True
+        assert await ego_crud.get_state(db, BACKFILL_MARKER) is None  # NOT locked
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

The Outcome Bus ledger held only tier-3 *coverage* signals — **zero tier-1 execution ground truth** — because only `ego_proposals` and `outreach_history` were harvested into it, and both are currently low-yield. This adds the richest unharvested execution-outcome source, **`surplus_tasks`** (Genesis's background autonomous work queue), as a tier-1 producer, so the self-improvement signal actually accrues real ground truth.

## Changes

- **New `_harvest_surplus_tasks` source** in `feedback/harvest.py`, mirroring the existing harvesters: a terminal `surplus_tasks` status of `completed` → `EXECUTION_OUTCOME` (positive, value 1.0); `failed` → negative (value 0.0) carrying `failure_reason`. `domain = task_type`, `source = "surplus"`, `ref_id = id`. Registered in both `run()` (incremental window) and `run_backfill()` (one-shot history).
- **Versioned backfill marker.** The one-shot backfill is guarded by a single `ego_state` marker. Adding a source after that marker is set would otherwise never backfill the new source's history. The marker now carries a schema version (`v{N}:{iso}`; a legacy bare-ISO value is treated as v1), so a version bump re-runs the backfill exactly once on existing installs. Re-running is safe — every source is idempotent on the `(source, ref_type, ref_id, signal_type)` unique key, so already-harvested rows are `INSERT OR IGNORE` no-ops.

## Behaviour

**Behaviour-neutral — the bus stays read-only/"dark".** `calibration_pairs` is source-filtered (ego only) and `surplus` rows carry a NULL stated-confidence, so they never enter ego calibration; `aggregate_by_domain` is read-only observability. No cognitive path consumes the new rows. This is purely producer-side: it makes the ledger honest, it does not change any decision.

## Tests

`tests/feedback/test_harvest.py` — new `TestHarvestSurplusTasks` (completed→T1 positive, failed→T1 negative + reason, non-terminal/cancelled skipped, idempotent on the unique key, incremental-window vs backfill) and `TestVersionedBackfillMarker` (version parsing incl. malformed-value clamping, legacy marker triggers a one-time re-backfill and re-stamps, current-version skips, and a reliability guard that a surplus failure must not lock the backfill gate). Full `tests/feedback/` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
