### PR TITLE
feat(learning): extract procedures as concrete playbooks, not essays (PR-C2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   schedule "jitter" (randomized fire times so ticks aren't perfectly periodic). Until now the
   only way to see or steer a campaign was through Genesis directly.
 
+### Changed
+
+- **The procedures Genesis learns are now concrete, replayable playbooks instead of vague
+  summaries.** Previously every learned procedure was written as a "what this teaches: …"
+  summary, and the learner only saw a heavily-truncated view of what happened (each tool's
+  arguments cut to 80 characters), so the real commands, paths, and flags were lost. Now the
+  learner reconstructs the actual step-by-step playbook — with the real commands used — for a
+  specific recurring scenario, and skips things that aren't procedures (general best-practices,
+  engineering patterns, one-off events, broad workflows; those belong in skills/CLAUDE.md). The
+  result is a smaller, higher-signal procedure store.
+
 ### Fixed
 
 - **Campaign results no longer sit uncaptured until the next scheduled tick.** Previously a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,11 @@ Applies to both CC sessions and Genesis autonomy decisions.
 
 ## Memory System — Layer Model
 
+**Two memory systems:** a **fact, decision, or plan** to store for later →
+*Genesis memory* (`memory_store` MCP, system-wide). Something that must **affect
+behavior during the conversation** → *CC file memory* (`~/.claude/.../memory/`,
+foreground-only). Unsure → ask.
+
 Genesis memory operates in 4 layers. Each has a role — use the lightest layer
 that answers your question before escalating.
 

--- a/src/genesis/learning/procedural/judge.py
+++ b/src/genesis/learning/procedural/judge.py
@@ -29,33 +29,55 @@ _JSON_BLOCK_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
 
 # ── Prompts ──────────────────────────────────────────────────────────────────
 
+# A procedure is a concrete, replayable PLAYBOOK — `steps` carries the real
+# commands/paths/flags, `principle` is the specific problem solved (NOT a
+# "what this teaches" essay), `scenario` is the exact replay trigger.
 _JSON_SCHEMA_EXAMPLE = """\
 ```json
 {
   "worth_storing": true,
-  "reason": "why this is worth storing",
+  "reason": "why this is a concrete replayable playbook (or why not)",
   "task_type": "descriptive-kebab-slug",
-  "scenario": "When to use: <trigger condition>",
-  "principle": "What this teaches: <summary>",
-  "steps": ["1. ...", "2. ..."],
+  "scenario": "When <exact trigger condition for replaying this>",
+  "principle": "<the specific hard problem this solves, one line>",
+  "steps": ["<concrete step with the REAL command / path / flag used>", "..."],
   "tools_used": ["tool1", "tool2"],
   "context_tags": ["domain1", "domain2"],
   "tool_trigger": ["Bash", "Read"]
 }
 ```"""
 
+# Shared definition + skip criteria. A procedure is a step-by-step PLAYBOOK for a
+# specific hard-to-replicate scenario — NOT a directive, best-practice, pattern,
+# generic workflow, one-off, or essay. (Validated 2026-06-30 builder spike: this
+# framing yields grounded playbooks instead of "what this teaches" summaries.)
+_PROCEDURE_DEF = (
+    "A PROCEDURE is a specific, step-by-step PLAYBOOK for a specific, hard-to-replicate "
+    'scenario — concrete "do exactly this, then this" actions WITH THE REAL '
+    "commands / paths / flags used, capturing how a particular challenge was solved so it "
+    "can be REPLAYED the next time the SAME scenario occurs.\n"
+    "Write `steps` using ONLY commands/paths/values that actually appear in the material "
+    "below — never invent commands. `principle` is the specific problem solved (one line), "
+    "NOT a 'what this teaches' summary.\n\n"
+    "Set worth_storing=false (with a reason) if it is instead: a behavioral DIRECTIVE / "
+    "working habit (confidence, due diligence, planning, when to ask); a generic "
+    "BEST-PRACTICE or reminder; an engineering PATTERN or dev-TECHNIQUE (e.g. TDD, "
+    "decouple-for-testing); a generic dev/debug/deploy/audit WORKFLOW; a ONE-OFF "
+    "non-recurring event; or there is no concrete solution to replay. Those belong in a "
+    "skill, the knowledge base, or CLAUDE.md — not the procedure store.\n\n"
+)
+
 
 def _build_struggle_prompt(spine_text: str, score: float) -> str:
     """Build struggle judge prompt. Uses concatenation instead of str.format()
     to avoid KeyError on { } in transcript content (JSON tool args, etc.)."""
     return (
-        "Given this session's tool call history, extract a reusable procedure.\n\n"
-        "## Action Spine\n"
+        "Reconstruct a reusable PROCEDURE from this session's action spine "
+        "(tool calls with their arguments + outcomes).\n\n"
+        + _PROCEDURE_DEF
+        + "## Action Spine\n"
         + spine_text + "\n\n"
         "## Struggle Score: " + f"{score:.2f}" + "\n\n"
-        "Write a procedure that would prevent this struggle next time.\n"
-        "If this does NOT contain a genuinely reusable procedure, set "
-        "worth_storing to false.\n\n"
         "Return JSON in backticks:\n\n"
         + _JSON_SCHEMA_EXAMPLE
     )
@@ -67,15 +89,15 @@ def _build_extraction_prompt(
     """Build extraction-flag judge prompt. Uses concatenation to avoid
     KeyError on { } in transcript content."""
     return (
-        "A procedure candidate was flagged during transcript extraction.\n\n"
-        "## Candidate\n"
+        "A procedure candidate was flagged during transcript extraction. "
+        "Reconstruct it as a concrete playbook from the surrounding context.\n\n"
+        + _PROCEDURE_DEF
+        + "## Candidate\n"
         "Content: " + content + "\n"
         "Scenario: " + scenario + "\n"
         "Entities: " + entities + "\n\n"
         "## Surrounding Context\n"
         + chunk_context[:3000] + "\n\n"
-        "Evaluate: is this a genuinely reusable procedure worth storing?\n"
-        "If not, set worth_storing to false with a reason.\n\n"
         "Return JSON in backticks:\n\n"
         + _JSON_SCHEMA_EXAMPLE
     )

--- a/src/genesis/learning/procedural/struggle_detector.py
+++ b/src/genesis/learning/procedural/struggle_detector.py
@@ -29,6 +29,49 @@ _WEIGHTS = {
     "length_with_errors": 0.10,
 }
 
+# Per-tool-type argument caps for the action spine. The builder needs the REAL
+# commands/paths to reconstruct a replayable playbook, so action tools keep
+# generous args (Edit truncated symmetrically to preserve both old+new), plan
+# text (ExitPlanMode) is dropped (not an action), and unknown/MCP tools get a
+# moderate cap. (Replaces a flat 80-char truncation that destroyed every command
+# — verified 2026-06-30 to be the reason the builder wrote essays, not playbooks.)
+_ARG_CAPS = {
+    "Bash": 800, "Edit": 800, "Write": 800, "Read": 800, "NotebookEdit": 800,
+    "Grep": 400, "Glob": 300,
+    # ExitPlanMode is handled by an early return in _summarize_args (plan prose,
+    # not an action); kept here as defense if that early return is ever removed.
+    "ExitPlanMode": 0,
+}
+_MCP_ARG_CAP = 400
+_DEFAULT_ARG_CAP = 300
+
+# Cap on the formatted spine handed to the judge, to keep even pathological
+# sessions (thousands of tool calls) safely inside the model context window
+# (~25k tokens; lead judge window is 131k). When exceeded, keep the END — a
+# struggle's resolution is usually in the final turns.
+_MAX_SPINE_CHARS = 100_000
+
+
+def _summarize_args(tool_name: str, tool_input: object) -> str:
+    """Compact but faithful arg summary for the spine. Preserves real
+    commands/paths up to a per-tool cap; symmetric for Edit (keep old+new)."""
+    if tool_name == "ExitPlanMode":
+        return ""  # plan prose, not an action
+    if isinstance(tool_input, dict):
+        if tool_name == "Edit" and "old_string" in tool_input:
+            return json.dumps({
+                "file_path": tool_input.get("file_path", ""),
+                "old": str(tool_input.get("old_string", ""))[:400],
+                "new": str(tool_input.get("new_string", ""))[:400],
+            }, ensure_ascii=False)
+        args_text = json.dumps(tool_input, ensure_ascii=False)
+    else:
+        args_text = str(tool_input)
+    cap = _ARG_CAPS.get(
+        tool_name, _MCP_ARG_CAP if tool_name.startswith("mcp__") else _DEFAULT_ARG_CAP
+    )
+    return args_text[:cap]
+
 
 def build_action_spine(transcript_path: Path) -> list[dict]:
     """Parse JSONL into a compact action spine.
@@ -91,12 +134,7 @@ def build_action_spine(transcript_path: Path) -> list[dict]:
                         tool_name = block.get("name", "unknown")
                         tool_input = block.get("input", {})
 
-                        # Compact args summary
-                        if isinstance(tool_input, dict):
-                            args_text = json.dumps(tool_input, ensure_ascii=False)
-                        else:
-                            args_text = str(tool_input)
-                        args_summary = args_text[:80]
+                        args_summary = _summarize_args(tool_name, tool_input)
 
                         spine_entry = {
                             "turn": turn,
@@ -126,7 +164,7 @@ def build_action_spine(transcript_path: Path) -> list[dict]:
                             entry_ref = pending_tools.pop(tool_id)
                             if is_error:
                                 entry_ref["outcome"] = "error"
-                                entry_ref["error_text"] = str(result_content)[:200]
+                                entry_ref["error_text"] = str(result_content)[:400]
 
                     elif block_type == "text" and msg_type == "user":
                         text = block.get("text", "")
@@ -252,11 +290,14 @@ def format_spine_for_judge(spine: list[dict]) -> str:
     for entry in spine:
         turn = entry["turn"]
         if entry["type"] == "tool":
-            outcome = "OK" if entry["outcome"] == "ok" else f"ERR: {entry['error_text'][:60]}"
+            outcome = "OK" if entry["outcome"] == "ok" else f"ERR: {entry['error_text'][:300]}"
             lines.append(
                 f"[T={turn}] TOOL: {entry['tool']} {entry['args_summary']} -> {outcome}"
             )
         elif entry["type"] == "user":
-            text = entry["args_summary"][:80]
+            text = entry["args_summary"][:160]
             lines.append(f'[T={turn}] USER: "{text}"')
-    return "\n".join(lines)
+    text = "\n".join(lines)
+    if len(text) > _MAX_SPINE_CHARS:
+        text = "...[earlier turns truncated]...\n" + text[-_MAX_SPINE_CHARS:]
+    return text

--- a/tests/test_learning/test_procedure_extraction.py
+++ b/tests/test_learning/test_procedure_extraction.py
@@ -586,3 +586,56 @@ async def test_extract_procedures_no_cap_when_max_new_none(db, monkeypatch):
     exts = [_proc_candidate_extraction() for _ in range(5)]
     count = await pe.extract_procedures_from_chunk(exts, db=db, router=None)
     assert count == 5
+
+
+class TestSummarizeArgs:
+    """Per-tool-type arg caps for the action spine (C2a builder fix). Replaces
+    the old flat 80-char truncation that destroyed real commands."""
+
+    def test_bash_keeps_full_command(self):
+        from genesis.learning.procedural.struggle_detector import _summarize_args
+        cmd = ("openssl s_client -connect api.openai.com:443 -showcerts 2>/dev/null "
+               "| grep -A3 'subject\\|issuer'")
+        out = _summarize_args("Bash", {"command": cmd})
+        # Old 80-char cap would have cut at "...openai.com:443 -showc"; now intact.
+        assert "grep -A3" in out
+
+    def test_exitplanmode_dropped(self):
+        from genesis.learning.procedural.struggle_detector import _summarize_args
+        assert _summarize_args("ExitPlanMode", {"plan": "x" * 500}) == ""
+
+    def test_edit_symmetric_keeps_old_and_new(self):
+        from genesis.learning.procedural.struggle_detector import _summarize_args
+        out = _summarize_args(
+            "Edit", {"file_path": "/x.py", "old_string": "A" * 1000, "new_string": "B" * 1000},
+        )
+        d = json.loads(out)
+        assert d["file_path"] == "/x.py"
+        assert len(d["old"]) == 400 and len(d["new"]) == 400  # both ends preserved
+
+    def test_mcp_tool_moderate_cap(self):
+        from genesis.learning.procedural.struggle_detector import _summarize_args
+        out = _summarize_args("mcp__genesis_health__foo", {"q": "z" * 1000})
+        assert len(out) == 400
+
+    def test_unknown_tool_default_cap(self):
+        from genesis.learning.procedural.struggle_detector import _summarize_args
+        out = _summarize_args("SomeNewTool", {"q": "z" * 1000})
+        assert len(out) == 300
+
+
+def test_format_spine_caps_pathological_size():
+    """A huge spine is truncated to fit the judge context, keeping the END."""
+    from genesis.learning.procedural.struggle_detector import (
+        _MAX_SPINE_CHARS,
+        format_spine_for_judge,
+    )
+    spine = [{"turn": i, "type": "tool", "tool": "Bash",
+              "args_summary": "x" * 500, "outcome": "ok", "error_text": ""}
+             for i in range(2000)]
+    spine.append({"turn": 9999, "type": "tool", "tool": "Bash",
+                  "args_summary": "THE_FINAL_FIX_COMMAND", "outcome": "ok", "error_text": ""})
+    out = format_spine_for_judge(spine)
+    assert len(out) <= _MAX_SPINE_CHARS + 64
+    assert "earlier turns truncated" in out
+    assert "THE_FINAL_FIX_COMMAND" in out  # resolution (end) preserved


### PR DESCRIPTION
## Why
The procedure store had become ~94% low-value: every learned procedure was written as a `"what this teaches: <summary>"` essay, and the learner only saw a heavily-truncated view of what happened — `build_action_spine` cut **every tool argument to 80 chars**, so the real commands/paths/flags needed to reconstruct a replayable playbook were lost. Result: vague summaries, not procedures.

## What
Fix the **builder** (not add a downstream gate):
- **`judge.py`** — rewrite the output schema + struggle/extraction prompts to demand a concrete, replayable **PLAYBOOK** (real commands in `steps`; `principle` = the specific problem solved, not an essay) and to **skip non-procedures** (behavioral directives, best-practices, engineering patterns/dev-techniques, generic workflows, one-offs — those belong in skills/CLAUDE.md).
- **`struggle_detector.py`** — replace the flat 80-char truncation with **per-tool-type arg caps** (`_summarize_args`: Bash/Edit/Write/Read 800, Edit symmetric old+new, ExitPlanMode dropped, MCP 400) so the builder sees real commands; widen `error_text` 200→400 + the judge formatter; add a 100k-char spine guard so pathological sessions stay inside the model context window.

## Validation
Run on real recent transcripts with the S-tier model (deepseek-v4-pro): produced **grounded playbooks** (55–100% of step commands appear verbatim in the spine — paraphrase/templating, not hallucination) and **correctly skipped** generic workflows, one-offs, and generic reviews. 46 unit tests pass; lint clean; code-reviewer verdict SHIP with 0 P1.

## Notes
- Server-side (the extraction job in `genesis-server`) — takes effect on deploy/restart.
- Part of a larger procedure-store program: a one-time cleanup of the existing low-value entries and a periodic reversible backstop are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)