### PR TITLE
feat(ego): optional Outcome Bus capability feed behind a default-OFF flag

### DIFF
--- a/config/ego.yaml
+++ b/config/ego.yaml
@@ -46,3 +46,11 @@ failure_backoff_minutes: 60  # pause after N consecutive failures
 # so it can self-correct (informational only, never a mechanical rescale).
 # Live — takes effect next cycle. Set false to turn off instantly.
 calibration_injection_enabled: true
+
+# LC3-B go-live gate (default OFF): fold Outcome Bus tier-1 execution ground
+# truth (source='surplus') into the capability map as a 6th source. While false,
+# the capability map is unchanged (original 5 sources). capability_map is
+# display-only, so enabling this only adjusts the self-performance numbers the
+# ego sees in its context — no control-flow gate keys off it. Live — takes
+# effect next capability-map refresh.
+outcome_bus_capability_feed: false

--- a/config/ego.yaml
+++ b/config/ego.yaml
@@ -52,5 +52,7 @@ calibration_injection_enabled: true
 # the capability map is unchanged (original 5 sources). capability_map is
 # display-only, so enabling this only adjusts the self-performance numbers the
 # ego sees in its context — no control-flow gate keys off it. Live — takes
-# effect next capability-map refresh.
+# effect at the next capability-map refresh (9:15/21:15), no restart needed.
+# NOTE: settings_update marks the whole ego domain "restart required"; that is
+# not true for THIS field — the refresh job re-reads the config each run.
 outcome_bus_capability_feed: false

--- a/src/genesis/db/crud/outcome_events.py
+++ b/src/genesis/db/crud/outcome_events.py
@@ -148,6 +148,7 @@ async def aggregate_by_domain(
     *,
     days: int | None = 30,
     tier: int | None = None,
+    source: str | None = None,
 ) -> list[dict]:
     """Per-domain outcome rollup.
 
@@ -155,7 +156,10 @@ async def aggregate_by_domain(
     all-time rollup (so the per-domain breakdown reconciles with the lifetime
     ``count_by_tier``/``count_by_signal_type`` totals). ``tier`` optionally
     restricts to one signal tier (e.g. tier=1 for the ground-truth view that
-    downstream quality scoring should weight highest).
+    downstream quality scoring should weight highest). ``source`` optionally
+    restricts to a single producer (e.g. ``source='surplus'``) so a consumer can
+    fold in one clean domain without double-counting producers it already
+    aggregates by other means.
     """
     sql = """
         SELECT domain,
@@ -175,6 +179,9 @@ async def aggregate_by_domain(
     if tier is not None:
         clauses.append("signal_tier = ?")
         params.append(tier)
+    if source is not None:
+        clauses.append("source = ?")
+        params.append(source)
     if clauses:
         sql += " WHERE " + " AND ".join(clauses)
     sql += " GROUP BY domain ORDER BY n DESC"

--- a/src/genesis/ego/capability_aggregator.py
+++ b/src/genesis/ego/capability_aggregator.py
@@ -126,13 +126,23 @@ async def compute_capability_map(db: aiosqlite.Connection) -> list[dict]:
     # unchanged. Scoped to source='surplus' — the only clean-new tier-1 domain.
     # ego_proposals + cc_sessions tier-1 rows are ALREADY sources #2/#5, so an
     # all-source read would double-count them; the source filter prevents that.
+    # Config read and the DB read are in SEPARATE try blocks so a config failure
+    # (which keeps the flag OFF) is not misdiagnosed as "outcome_events missing".
+    outcome_bus_enabled = False
     try:
         from genesis.ego.config import load_ego_config
 
         cfg = load_ego_config()
         # Default OFF: enable ONLY on an explicit True (a YAML null / missing key
         # / falsey value all keep it off, so it can't be silently enabled).
-        if getattr(cfg, "outcome_bus_capability_feed", False) is True:
+        outcome_bus_enabled = (
+            getattr(cfg, "outcome_bus_capability_feed", False) is True
+        )
+    except Exception:
+        logger.debug("Capability aggregation: ego config unreadable; outcome bus OFF")
+
+    if outcome_bus_enabled:
+        try:
             from genesis.db.crud import outcome_events as oe_crud
 
             rows = await oe_crud.aggregate_by_domain(
@@ -153,8 +163,8 @@ async def compute_capability_map(db: aiosqlite.Connection) -> list[dict]:
                     continue
                 acc = domains.setdefault(domain, _DomainAccumulator(domain))
                 acc.add_signal("outcomes", rate, n)
-    except Exception:
-        logger.debug("Capability aggregation: outcome_events unavailable")
+        except Exception:
+            logger.debug("Capability aggregation: outcome_events unavailable")
 
     # Compute composite scores
     results = []

--- a/src/genesis/ego/capability_aggregator.py
+++ b/src/genesis/ego/capability_aggregator.py
@@ -1,7 +1,10 @@
 """Capability aggregator — builds the ego's self-model from multiple data sources.
 
 Queries intervention journal, ego proposals, autonomy state, procedural
-memory, and CC sessions to compute per-domain confidence scores.
+memory, and CC sessions to compute per-domain confidence scores. An optional
+6th source — Outcome Bus tier-1 execution ground truth (``source='surplus'``) —
+is folded in only when the ``outcome_bus_capability_feed`` ego flag is enabled
+(default OFF, the LC3-B go-live gate).
 """
 
 from __future__ import annotations
@@ -14,10 +17,13 @@ logger = logging.getLogger(__name__)
 
 
 async def compute_capability_map(db: aiosqlite.Connection) -> list[dict]:
-    """Aggregate data from 5 sources into domain-level capability scores.
+    """Aggregate data from up to 6 sources into domain-level capability scores.
 
     Returns a list of dicts: {domain, confidence, sample_size, trend, evidence}.
-    Each source is queried independently — failures are logged and skipped.
+    Each source is queried independently — failures are logged and skipped. The
+    6th source (Outcome Bus tier-1 ground truth) is gated behind the
+    ``outcome_bus_capability_feed`` ego flag (default OFF); while disabled the
+    output is identical to the original 5-source computation.
     """
     domains: dict[str, _DomainAccumulator] = {}
 
@@ -113,6 +119,42 @@ async def compute_capability_map(db: aiosqlite.Connection) -> list[dict]:
             acc.add_signal("sessions", rate, total)
     except Exception:
         logger.debug("Capability aggregation: cc_sessions unavailable")
+
+    # 6. Outcome Bus — tier-1 execution ground truth per domain (LC3-B go-live).
+    # Gated behind the default-OFF ``outcome_bus_capability_feed`` flag: until an
+    # operator flips it this adds NO signal, so the 5-source output above is
+    # unchanged. Scoped to source='surplus' — the only clean-new tier-1 domain.
+    # ego_proposals + cc_sessions tier-1 rows are ALREADY sources #2/#5, so an
+    # all-source read would double-count them; the source filter prevents that.
+    try:
+        from genesis.ego.config import load_ego_config
+
+        cfg = load_ego_config()
+        # Default OFF: enable ONLY on an explicit True (a YAML null / missing key
+        # / falsey value all keep it off, so it can't be silently enabled).
+        if getattr(cfg, "outcome_bus_capability_feed", False) is True:
+            from genesis.db.crud import outcome_events as oe_crud
+
+            rows = await oe_crud.aggregate_by_domain(
+                db, tier=1, source="surplus", days=30
+            )
+            for row in rows:
+                n = row.get("n") or 0
+                # Noise gate — mirrors cc_sessions' HAVING total >= 3.
+                if n < 3:
+                    continue
+                positive = row.get("positive") or 0
+                # rate = positive / n is provably in [0, 1]; passing an
+                # out-of-range value would make inverse_confidence_weight raise
+                # and silently degrade the WHOLE domain to an arithmetic mean.
+                rate = positive / n
+                domain = row.get("domain")
+                if not domain:
+                    continue
+                acc = domains.setdefault(domain, _DomainAccumulator(domain))
+                acc.add_signal("outcomes", rate, n)
+    except Exception:
+        logger.debug("Capability aggregation: outcome_events unavailable")
 
     # Compute composite scores
     results = []

--- a/src/genesis/ego/config.py
+++ b/src/genesis/ego/config.py
@@ -149,4 +149,8 @@ def validate_ego_config(changes: dict) -> list[str]:
         changes["calibration_injection_enabled"], bool
     ):
         errors.append("calibration_injection_enabled must be a boolean")
+    if "outcome_bus_capability_feed" in changes and not isinstance(
+        changes["outcome_bus_capability_feed"], bool
+    ):
+        errors.append("outcome_bus_capability_feed must be a boolean")
     return errors

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -149,5 +149,12 @@ class EgoConfig:
     # self-correct (informational, never a mechanical rescale). Live-read each
     # cycle; default ON. Genesis ego only for now.
     calibration_injection_enabled: bool = True
+    # LC3-B go-live gate: fold Outcome Bus tier-1 execution ground truth
+    # (source='surplus') into the capability map as a 6th aggregator source.
+    # Default OFF — until an operator flips this, the capability map is computed
+    # from the original 5 sources and behaviour is unchanged. capability_map is
+    # display-only (rendered into ego-context sections, no code gate), so even ON
+    # only nudges the numbers the ego sees about itself. Live-read each refresh.
+    outcome_bus_capability_feed: bool = False
 
 

--- a/tests/ego/test_config.py
+++ b/tests/ego/test_config.py
@@ -112,6 +112,22 @@ class TestValidateEgoConfig:
         errors = validate_ego_config({"proposal_expiry_minutes": 240})
         assert errors == []  # unknown key, ignored
 
+    def test_outcome_bus_capability_feed_rejects_non_bool(self):
+        for bad in ("yes", 1, 0, None):
+            errors = validate_ego_config({"outcome_bus_capability_feed": bad})
+            assert len(errors) == 1
+            assert "outcome_bus_capability_feed must be a boolean" in errors[0]
+
+    def test_outcome_bus_capability_feed_accepts_bool(self):
+        assert validate_ego_config({"outcome_bus_capability_feed": True}) == []
+        assert validate_ego_config({"outcome_bus_capability_feed": False}) == []
+
+    def test_calibration_injection_enabled_rejects_non_bool(self):
+        # Sibling bool validator — equally untested before this PR.
+        errors = validate_ego_config({"calibration_injection_enabled": "on"})
+        assert len(errors) == 1
+        assert "calibration_injection_enabled must be a boolean" in errors[0]
+
     def test_multiple_errors(self):
         errors = validate_ego_config({
             "cadence_minutes": -1,

--- a/tests/ego/test_realist.py
+++ b/tests/ego/test_realist.py
@@ -273,9 +273,17 @@ class TestTabledProposalBoard:
 
 class TestCapabilityMapFix:
     @pytest.mark.asyncio
-    async def test_withdrawn_excluded_from_denominator(self, db):
+    async def test_withdrawn_excluded_from_denominator(self, db, monkeypatch):
         """Withdrawn/tabled proposals don't inflate failure rate."""
         from genesis.ego.capability_aggregator import compute_capability_map
+        from genesis.ego.types import EgoConfig
+
+        # Hermetic: pin the Outcome Bus 6th-source flag OFF so this test never
+        # reads a live ego.local.yaml that has it enabled.
+        monkeypatch.setattr(
+            "genesis.ego.config.load_ego_config",
+            lambda *a, **k: EgoConfig(outcome_bus_capability_feed=False),
+        )
 
         # Create proposals: 1 approved, 1 rejected, 3 withdrawn
         await ego_crud.create_proposal(

--- a/tests/test_db/test_outcome_events.py
+++ b/tests/test_db/test_outcome_events.py
@@ -227,6 +227,38 @@ class TestAggregates:
         assert d["n"] == 1
 
     @pytest.mark.asyncio
+    async def test_aggregate_source_filter(self, db):
+        # source= restricts the rollup to one producer so a consumer can fold in
+        # a single clean domain (surplus) without double-counting producers it
+        # already aggregates elsewhere (ego/cc_sessions).
+        await oe.record(
+            db, source="surplus", ref_type="task", ref_id="s1",
+            signal_type="execution_outcome", signal_tier=1, domain="code_audit",
+            polarity="positive", value=1.0,
+        )
+        await oe.record(
+            db, source="surplus", ref_type="task", ref_id="s2",
+            signal_type="execution_outcome", signal_tier=1, domain="code_audit",
+            polarity="negative", value=0.0,
+        )
+        await oe.record(
+            db, source="ego", ref_type="proposal", ref_id="e1",
+            signal_type="execution_outcome", signal_tier=1, domain="code_audit",
+            polarity="positive", value=1.0,
+        )
+        # Unfiltered: both producers contribute to the same domain.
+        unfiltered = await oe.aggregate_by_domain(db, tier=1)
+        assert next(a for a in unfiltered if a["domain"] == "code_audit")["n"] == 3
+        # source='surplus' sees only the two surplus rows.
+        surplus = await oe.aggregate_by_domain(db, tier=1, source="surplus")
+        srow = next(a for a in surplus if a["domain"] == "code_audit")
+        assert srow["n"] == 2
+        assert srow["positive"] == 1
+        assert srow["negative"] == 1
+        # An unknown source yields nothing — no accidental all-source fallthrough.
+        assert await oe.aggregate_by_domain(db, tier=1, source="nope") == []
+
+    @pytest.mark.asyncio
     async def test_count_by_tier(self, db):
         # Two T1, one T3 — tier cannot be derived from signal_type alone, so
         # this needs its own GROUP BY (the soak instrument relies on it).

--- a/tests/test_ego/test_capability_aggregator.py
+++ b/tests/test_ego/test_capability_aggregator.py
@@ -76,8 +76,44 @@ async def db(tmp_path):
                 completed_at TEXT, metadata TEXT
             )
         """)
+        # outcome_events (6th source — tier-1 ground truth, surplus-scoped)
+        await conn.execute("""
+            CREATE TABLE outcome_events (
+                id TEXT PRIMARY KEY, source TEXT NOT NULL,
+                ref_type TEXT NOT NULL, ref_id TEXT NOT NULL, domain TEXT,
+                signal_type TEXT NOT NULL,
+                signal_class TEXT NOT NULL DEFAULT 'implicit',
+                signal_tier INTEGER NOT NULL,
+                polarity TEXT, value REAL, stated_confidence REAL,
+                prediction_error REAL, reason TEXT, reason_text TEXT,
+                metadata TEXT, harvested_from TEXT,
+                occurred_at TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                UNIQUE (source, ref_type, ref_id, signal_type)
+            )
+        """)
         await conn.commit()
         yield conn
+
+
+async def _add_surplus_outcomes(db, domain, *, positive, negative):
+    """Seed N tier-1 surplus execution-outcome rows for a domain (recent)."""
+    from datetime import UTC, datetime
+    now = datetime.now(UTC).isoformat()
+    i = 0
+    for pol, count in (("positive", positive), ("negative", negative)):
+        for _ in range(count):
+            await db.execute(
+                "INSERT INTO outcome_events "
+                "(id, source, ref_type, ref_id, domain, signal_type, "
+                " signal_tier, polarity, value, occurred_at) "
+                "VALUES (?, 'surplus', 'task', ?, ?, 'execution_outcome', "
+                " 1, ?, ?, ?)",
+                (f"oe-{domain}-{i}", f"t-{domain}-{i}", domain, pol,
+                 1.0 if pol == "positive" else 0.0, now),
+            )
+            i += 1
+    await db.commit()
 
 
 class TestComputeCapabilityMap:
@@ -175,3 +211,96 @@ class TestComputeCapabilityMap:
         assert len(results) == 2
         assert results[0]["domain"] == "high_domain"
         assert results[1]["domain"] == "low_domain"
+
+
+class TestOutcomeBusSource:
+    """The 6th source (Outcome Bus tier-1) is gated behind the default-OFF
+    ``outcome_bus_capability_feed`` ego flag. OFF = behaviour-neutral; ON folds
+    surplus-scoped ground truth in. ``load_ego_config`` is patched so the tests
+    are hermetic regardless of the machine's ego.yaml."""
+
+    def _patch_flag(self, monkeypatch, enabled):
+        from genesis.ego.types import EgoConfig
+        monkeypatch.setattr(
+            "genesis.ego.config.load_ego_config",
+            lambda *a, **k: EgoConfig(outcome_bus_capability_feed=enabled),
+        )
+
+    @pytest.mark.asyncio
+    async def test_flag_off_no_surplus_signal(self, db, monkeypatch):
+        """Default OFF: surplus rows exist but contribute nothing."""
+        self._patch_flag(monkeypatch, False)
+        await _add_surplus_outcomes(db, "code_audit", positive=7, negative=1)
+
+        results = await compute_capability_map(db)
+        # surplus-only domain must NOT appear, and no 'outcomes:' evidence anywhere.
+        assert not any(r["domain"] == "code_audit" for r in results)
+        assert not any("outcomes:" in r.get("evidence", "") for r in results)
+
+    @pytest.mark.asyncio
+    async def test_flag_off_output_identical_to_baseline(self, db, monkeypatch):
+        """OFF output is byte-identical to the no-surplus baseline — proves the
+        6th source is truly inert when disabled."""
+        await db.execute(
+            "INSERT INTO autonomy_state (id, category, total_successes, "
+            "total_corrections) VALUES ('a1', 'outreach', 8, 2)"
+        )
+        await db.commit()
+
+        self._patch_flag(monkeypatch, False)
+        baseline = await compute_capability_map(db)
+        # Now add surplus rows; with the flag OFF the result must not change.
+        await _add_surplus_outcomes(db, "code_audit", positive=7, negative=1)
+        after = await compute_capability_map(db)
+        assert after == baseline
+
+    @pytest.mark.asyncio
+    async def test_flag_on_adds_surplus_domain(self, db, monkeypatch):
+        """ON: a surplus-only domain appears with 'outcomes:' evidence and the
+        correct success rate (7/8 = 87.5%)."""
+        self._patch_flag(monkeypatch, True)
+        await _add_surplus_outcomes(db, "code_audit", positive=7, negative=1)
+
+        results = await compute_capability_map(db)
+        ca = next((r for r in results if r["domain"] == "code_audit"), None)
+        assert ca is not None
+        assert "outcomes:" in ca["evidence"]
+        # Single source → composite == the surplus rate 7/8 = 0.875.
+        assert abs(ca["confidence"] - 0.875) < 0.01
+        assert ca["sample_size"] == 8
+
+    @pytest.mark.asyncio
+    async def test_flag_on_noise_gate_skips_thin_domains(self, db, monkeypatch):
+        """ON: a domain with n < 3 surplus rows is skipped (mirrors the
+        cc_sessions HAVING total >= 3 gate)."""
+        self._patch_flag(monkeypatch, True)
+        await _add_surplus_outcomes(db, "thin", positive=2, negative=0)   # n=2
+        await _add_surplus_outcomes(db, "thick", positive=3, negative=0)  # n=3
+
+        results = await compute_capability_map(db)
+        assert not any(r["domain"] == "thin" for r in results)
+        assert any(r["domain"] == "thick" for r in results)
+
+    @pytest.mark.asyncio
+    async def test_flag_on_combines_with_existing_source(self, db, monkeypatch):
+        """ON: when a domain has BOTH a non-surplus source and surplus rows, the
+        composite reflects both signals (evidence carries both tags)."""
+        from datetime import UTC, datetime
+        now = datetime.now(UTC).isoformat()
+        # 10 'investigate' proposals, 5 approved → proposals signal 50%.
+        for i in range(10):
+            status = "approved" if i < 5 else "rejected"
+            await db.execute(
+                "INSERT INTO ego_proposals (id, action_type, content, status, "
+                "created_at) VALUES (?, 'investigate', 'test', ?, ?)",
+                (f"p{i}", status, now),
+            )
+        await db.commit()
+        self._patch_flag(monkeypatch, True)
+        await _add_surplus_outcomes(db, "investigate", positive=8, negative=0)
+
+        results = await compute_capability_map(db)
+        inv = next((r for r in results if r["domain"] == "investigate"), None)
+        assert inv is not None
+        assert "proposals:" in inv["evidence"]
+        assert "outcomes:" in inv["evidence"]


### PR DESCRIPTION
## What

Adds an optional sixth source to the ego's capability map — tier-1 execution
ground truth from the Outcome Bus (`outcome_events`, `source='surplus'`) — behind
a new config flag `outcome_bus_capability_feed` that is **OFF by default**.

While the flag is off (the default), the capability map is computed exactly as
before from its five existing sources, so behaviour is unchanged. When an
operator enables it, recent per-domain execution success rates are folded into
the ego's self-model. The capability map is display-only — it shapes the
performance summary the ego sees about itself in its own context; no control
flow keys off it.

## Why

The Outcome Bus already records real tier-1 execution outcomes, but nothing
consumed them yet. This wires the first, safest consumer behind an explicit
toggle, so the connection can be enabled deliberately rather than implicitly.

## Details

- `EgoConfig.outcome_bus_capability_feed: bool = False` (+ `config/ego.yaml`
  entry and a bool validator) — live-read each capability-map refresh.
- `aggregate_by_domain(..., source=)` — a new optional, backward-compatible
  filter so the consumer reads a single producer's domains and never
  double-counts producers the aggregator already includes by other means.
- The sixth source applies a sample-size floor (n >= 3) consistent with the
  existing session source, and contributes a success rate in [0, 1].

## Tests

New unit tests for the source filter and for the aggregator in both flag states
(off = output identical to the five-source baseline; on = the new domains appear
with correct rates, the noise gate holds, and it composes with existing
sources). Full targeted ego/db suites pass.