### PR TITLE
fix(inbox): URL-level batching, delta-correct resume, follow-up dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Inbox evaluations no longer cram a whole batch of links into one giant pass — and stop
+  re-evaluating links they've already covered.** When you drop many URLs into an inbox note,
+  Genesis now evaluates them in small groups (≈5 at a time, configurable via
+  `items_per_eval`), each producing its own `…-N.genesis.md` response file, instead of one
+  sprawling evaluation of everything at once. Crucially, once a link has been evaluated it is
+  not re-evaluated when you add new links to the same note — only the genuinely new links are
+  processed (previously an approved evaluation could re-chew the entire file). When the CLI
+  approval gate is on, you approve a drop once and all its groups run under that single
+  approval. Duplicate follow-up items from the same recommendation are now also prevented.
+
 - **Campaign results no longer sit uncaptured until the next scheduled tick.** Previously a
   campaign that ran every couple of days would finish its background session but not record
   the outcome (or cost, or notify you) until the *following* tick — so a finished run could

--- a/config/inbox_monitor.yaml
+++ b/config/inbox_monitor.yaml
@@ -7,6 +7,13 @@ inbox_monitor:
   # the source (e.g. Untitled.md → Untitled.genesis.md).
   response_dir: "_genesis"
   check_interval_seconds: 1800
+  # items_per_eval: how many items (URLs / prose blocks) go into ONE Claude
+  # evaluation. A file's NEW content is segmented into items and grouped into
+  # batches of this size, so a 16-URL drop becomes ~4 evals (each its own
+  # Genesis-N.genesis.md), not one mega-evaluation. Default 5.
+  items_per_eval: 5
+  # batch_size is LEGACY (files-per-cycle) and no longer governs eval grouping;
+  # items_per_eval replaces it. Kept for backward compatibility.
   batch_size: 1
   model: "sonnet"
   effort: "medium"

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -53,27 +53,48 @@ async def create(
     kind: str = "follow_up",
     domain: str | None = None,
     goal_id: str | None = None,
+    dedup_key: str | None = None,
     id: str | None = None,
 ) -> str:
     """Create a follow-up and return its ID.
 
-    kind:    'follow_up' (intended for action) or 'tabled' (tracked, not for action).
-    domain:  'internal' | 'user_world' | None (None = not yet classified).
-    goal_id: optional link to a unified goal (user_goals.id) for future promotion.
+    kind:     'follow_up' (intended for action) or 'tabled' (tracked, not for action).
+    domain:   'internal' | 'user_world' | None (None = not yet classified).
+    goal_id:  optional link to a unified goal (user_goals.id) for future promotion.
+    dedup_key: optional idempotency key. Callers that may re-run (e.g. inbox
+              re-evaluation) pass a stable hash so the same recommendation does
+              not create duplicate rows; a partial unique index backstops races.
     """
     fid = id or _new_id()
     await db.execute(
         """INSERT INTO follow_ups
            (id, source, source_session, content, reason, strategy,
             scheduled_at, status, priority, pinned, kind, domain, goal_id,
-            created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?)""",
+            dedup_key, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?)""",
         (fid, source, source_session, content, reason, strategy,
          _normalize_scheduled_at(scheduled_at), priority, int(pinned),
-         kind, domain, goal_id, _now_iso()),
+         kind, domain, goal_id, dedup_key, _now_iso()),
     )
     await db.commit()
     return fid
+
+
+async def exists_by_dedup_key(
+    db: aiosqlite.Connection, dedup_key: str,
+) -> bool:
+    """Return True if any follow-up already exists with *dedup_key*.
+
+    Dedup spans all statuses so a re-evaluation never recreates a follow-up the
+    user already completed/dismissed. NULL/empty keys never match.
+    """
+    if not dedup_key:
+        return False
+    cursor = await db.execute(
+        "SELECT 1 FROM follow_ups WHERE dedup_key = ? LIMIT 1",
+        (dedup_key,),
+    )
+    return await cursor.fetchone() is not None
 
 
 async def get_by_id(db: aiosqlite.Connection, id: str) -> dict | None:

--- a/src/genesis/db/crud/inbox_items.py
+++ b/src/genesis/db/crud/inbox_items.py
@@ -28,12 +28,16 @@ async def create(
     status: str = "pending",
     created_at: str,
     batch_id: str | None = None,
+    drop_id: str | None = None,
+    batch_items: str | None = None,
 ) -> str:
     await db.execute(
         """INSERT INTO inbox_items
-           (id, file_path, content_hash, status, batch_id, created_at)
-           VALUES (?, ?, ?, ?, ?, ?)""",
-        (id, file_path, content_hash, status, batch_id, created_at),
+           (id, file_path, content_hash, status, batch_id, created_at,
+            drop_id, batch_items)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        (id, file_path, content_hash, status, batch_id, created_at,
+         drop_id, batch_items),
     )
     await db.commit()
     return id
@@ -95,7 +99,7 @@ async def get_awaiting_approval(db: aiosqlite.Connection) -> list[dict]:
     """
     cursor = await db.execute(
         """SELECT id, file_path, content_hash, batch_id, error_message,
-                  created_at
+                  created_at, drop_id, batch_items
            FROM inbox_items
            WHERE status = 'processing'
              AND error_message LIKE ? || '%'
@@ -104,6 +108,64 @@ async def get_awaiting_approval(db: aiosqlite.Connection) -> list[dict]:
     )
     rows = await cursor.fetchall()
     return [dict(row) for row in rows]
+
+
+async def get_drop_rows(
+    db: aiosqlite.Connection, drop_id: str,
+) -> list[dict]:
+    """Return all inbox rows belonging to *drop_id*, oldest first.
+
+    Ordered by ``created_at, id`` so the batch order within a drop is stable
+    (sibling batches share the same detection ``created_at``; ``id`` breaks ties).
+    """
+    cursor = await db.execute(
+        "SELECT * FROM inbox_items WHERE drop_id = ? ORDER BY created_at, id",
+        (drop_id,),
+    )
+    return [dict(row) for row in await cursor.fetchall()]
+
+
+async def get_pending_drop_rows(
+    db: aiosqlite.Connection, drop_id: str,
+) -> list[dict]:
+    """Return the not-yet-completed rows of *drop_id* (pending or processing).
+
+    Used by the resume pass to fan out only the batches of a drop that still
+    need to run — completed batches (whose baseline already landed) are left
+    untouched, and failed batches are excluded (they retry via the delta path).
+    """
+    cursor = await db.execute(
+        "SELECT * FROM inbox_items WHERE drop_id = ? "
+        "AND status IN ('pending', 'processing') ORDER BY created_at, id",
+        (drop_id,),
+    )
+    return [dict(row) for row in await cursor.fetchall()]
+
+
+async def update_status_for_drop(
+    db: aiosqlite.Connection,
+    drop_id: str,
+    *,
+    status: str,
+    error_message: str | None = None,
+    processed_at: str | None = None,
+) -> int:
+    """Set status/error_message/processed_at on the live rows of a drop.
+
+    Targets only rows currently ``pending`` or ``processing`` (so completed
+    batches are never disturbed). Used to park a whole drop on one approval
+    (status='processing' + awaiting marker) or fail a whole drop on rejection.
+    Does NOT touch ``retry_count`` — callers manage retry semantics explicitly.
+    Returns the number of rows updated.
+    """
+    cursor = await db.execute(
+        """UPDATE inbox_items
+           SET status = ?, error_message = ?, processed_at = ?
+           WHERE drop_id = ? AND status IN ('pending', 'processing')""",
+        (status, error_message, processed_at, drop_id),
+    )
+    await db.commit()
+    return cursor.rowcount
 
 
 async def get_all_known(

--- a/src/genesis/db/crud/inbox_items.py
+++ b/src/genesis/db/crud/inbox_items.py
@@ -300,12 +300,18 @@ async def get_evaluated_content(
     Filters out NULL and empty-string values so callers can rely on a
     non-empty return meaning "real prior content exists."
     """
+    # Tie-break on processed_at then rowid: when a drop's batches complete in
+    # the SAME check cycle they share ``created_at``, and each batch merges its
+    # lines on top of the prior batch's baseline, so the LAST-completed batch
+    # (highest processed_at; highest rowid as final tiebreak since batches are
+    # created in order) holds the fullest cumulative baseline. Ordering by
+    # created_at alone returned an arbitrary partial baseline among ties.
     cursor = await db.execute(
         """SELECT evaluated_content FROM inbox_items
            WHERE file_path = ? AND status = 'completed'
              AND evaluated_content IS NOT NULL
              AND evaluated_content != ''
-           ORDER BY created_at DESC LIMIT 1""",
+           ORDER BY created_at DESC, processed_at DESC, rowid DESC LIMIT 1""",
         (file_path,),
     )
     row = await cursor.fetchone()
@@ -425,6 +431,54 @@ async def get_retriable_failed(
     )
     row = await cursor.fetchone()
     return dict(row) if row else None
+
+
+async def get_retriable_failed_rows(
+    db: aiosqlite.Connection, file_path: str, *, max_retries: int = 3,
+) -> list[dict]:
+    """Return ALL retriable failed rows for *file_path*, oldest first.
+
+    Like :func:`get_retriable_failed` but returns every retriable row, so the
+    monitor can reuse one per batch when a multi-batch drop is retried —
+    preventing duplicate-row accumulation while preserving each row's
+    ``retry_count`` (so the permanent-failure cap still applies). Excludes
+    approval-invalidated rows (those need fresh rows + fresh approvals).
+    """
+    cursor = await db.execute(
+        """SELECT * FROM inbox_items
+           WHERE file_path = ? AND status = 'failed' AND retry_count < ?
+             AND (error_message IS NULL
+                  OR error_message NOT LIKE ? || '%')
+           ORDER BY created_at ASC""",
+        (file_path, max_retries, APPROVAL_INVALIDATED_PREFIX),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def reuse_as_pending(
+    db: aiosqlite.Connection,
+    id: str,
+    *,
+    drop_id: str,
+    batch_items: str,
+    content_hash: str,
+) -> bool:
+    """Re-arm a retriable failed row as a fresh pending batch.
+
+    Preserves ``retry_count`` (the cap survives) but re-points the row at the
+    new drop, batch slice and content hash and clears the error. This is the
+    per-batch analogue of the old single-row reuse — it keeps retries from
+    piling up duplicate rows.
+    """
+    cursor = await db.execute(
+        """UPDATE inbox_items
+           SET status = 'pending', error_message = NULL,
+               drop_id = ?, batch_items = ?, content_hash = ?
+           WHERE id = ?""",
+        (drop_id, batch_items, content_hash, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
 
 
 async def query_pending(db: aiosqlite.Connection, *, limit: int = 50) -> list[dict]:

--- a/src/genesis/db/crud/inbox_items.py
+++ b/src/genesis/db/crud/inbox_items.py
@@ -110,38 +110,6 @@ async def get_awaiting_approval(db: aiosqlite.Connection) -> list[dict]:
     return [dict(row) for row in rows]
 
 
-async def get_drop_rows(
-    db: aiosqlite.Connection, drop_id: str,
-) -> list[dict]:
-    """Return all inbox rows belonging to *drop_id*, oldest first.
-
-    Ordered by ``created_at, id`` so the batch order within a drop is stable
-    (sibling batches share the same detection ``created_at``; ``id`` breaks ties).
-    """
-    cursor = await db.execute(
-        "SELECT * FROM inbox_items WHERE drop_id = ? ORDER BY created_at, id",
-        (drop_id,),
-    )
-    return [dict(row) for row in await cursor.fetchall()]
-
-
-async def get_pending_drop_rows(
-    db: aiosqlite.Connection, drop_id: str,
-) -> list[dict]:
-    """Return the not-yet-completed rows of *drop_id* (pending or processing).
-
-    Used by the resume pass to fan out only the batches of a drop that still
-    need to run — completed batches (whose baseline already landed) are left
-    untouched, and failed batches are excluded (they retry via the delta path).
-    """
-    cursor = await db.execute(
-        "SELECT * FROM inbox_items WHERE drop_id = ? "
-        "AND status IN ('pending', 'processing') ORDER BY created_at, id",
-        (drop_id,),
-    )
-    return [dict(row) for row in await cursor.fetchall()]
-
-
 async def update_status_for_drop(
     db: aiosqlite.Connection,
     drop_id: str,

--- a/src/genesis/db/migrations/0040_inbox_drop_batching.py
+++ b/src/genesis/db/migrations/0040_inbox_drop_batching.py
@@ -1,0 +1,57 @@
+"""Inbox URL-level batching: drop grouping + per-batch slice + follow-up dedup.
+
+Adds:
+- ``inbox_items.drop_id``    — groups the eval-batches carved from one file's
+  delta so one approval covers the whole drop and resume can fan out the
+  not-yet-completed batches.
+- ``inbox_items.batch_items`` — the exact item lines a batch owns, persisted so
+  resume re-dispatches the delta (not a full-file re-read) and survives restart.
+- ``follow_ups.dedup_key``   — idempotent re-evaluation guard so the same
+  recommendation does not pile duplicate follow-up rows.
+
+Plus a non-unique index on ``inbox_items.drop_id`` and a PARTIAL unique index on
+``follow_ups.dedup_key`` (partial so the many existing NULL-dedup_key rows do not
+collide).
+
+Fresh/test DBs get these from the canonical CREATE TABLE in
+``db/schema/_tables.py`` + ``_migrate_add_columns`` in ``db/schema/_migrations.py``;
+this numbered migration covers the existing-DB upgrade path via the runner.
+Idempotent: PRAGMA-guarded column adds + ``IF NOT EXISTS`` indexes. No commit —
+the runner owns the transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # inbox_items columns
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='inbox_items'"
+    )
+    if await cursor.fetchone():
+        col_cursor = await db.execute("PRAGMA table_info(inbox_items)")
+        cols = {row[1] for row in await col_cursor.fetchall()}
+        if "drop_id" not in cols:
+            await db.execute("ALTER TABLE inbox_items ADD COLUMN drop_id TEXT")
+        if "batch_items" not in cols:
+            await db.execute("ALTER TABLE inbox_items ADD COLUMN batch_items TEXT")
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_inbox_items_drop "
+            "ON inbox_items(drop_id)"
+        )
+
+    # follow_ups dedup_key + partial unique index
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='follow_ups'"
+    )
+    if await cursor.fetchone():
+        col_cursor = await db.execute("PRAGMA table_info(follow_ups)")
+        cols = {row[1] for row in await col_cursor.fetchall()}
+        if "dedup_key" not in cols:
+            await db.execute("ALTER TABLE follow_ups ADD COLUMN dedup_key TEXT")
+        await db.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_follow_ups_dedup "
+            "ON follow_ups(dedup_key) WHERE dedup_key IS NOT NULL"
+        )

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -77,6 +77,23 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE inbox_items ADD COLUMN evaluated_content TEXT",
         "inbox_items.evaluated_content")
 
+    # Inbox URL-level batching: drop_id groups the eval-batches carved from one
+    # file's delta; batch_items stores that batch's exact item lines so resume
+    # re-dispatches the delta (not a full-file re-read) and survives restart.
+    await _try_alter(db,
+        "ALTER TABLE inbox_items ADD COLUMN drop_id TEXT",
+        "inbox_items.drop_id")
+    await _try_alter(db,
+        "ALTER TABLE inbox_items ADD COLUMN batch_items TEXT",
+        "inbox_items.batch_items")
+
+    # Follow-up dedup: idempotent re-evaluation guard. dedup_key = hash of
+    # (source, normalized url/title, next_step) so re-evaluating the same URL
+    # does not pile duplicate follow-up rows.
+    await _try_alter(db,
+        "ALTER TABLE follow_ups ADD COLUMN dedup_key TEXT",
+        "follow_ups.dedup_key")
+
     # Phase 9: thread_id on cc_sessions (for forum topic multi-session)
     await _try_alter(db,
         "ALTER TABLE cc_sessions ADD COLUMN thread_id TEXT",

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -429,7 +429,9 @@ TABLES = {
             processed_at   TEXT,
             error_message  TEXT,
             retry_count    INTEGER NOT NULL DEFAULT 0,
-            evaluated_content TEXT
+            evaluated_content TEXT,
+            drop_id        TEXT,
+            batch_items    TEXT
         )
     """,
     "processed_emails": """
@@ -1108,7 +1110,8 @@ TABLES = {
             domain           TEXT CHECK (
                 domain IN ('internal', 'user_world')
             ),
-            goal_id          TEXT
+            goal_id          TEXT,
+            dedup_key        TEXT
         )
     """,
     "file_modifications": """
@@ -1581,6 +1584,7 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_inbox_items_status ON inbox_items(status)",
     "CREATE INDEX IF NOT EXISTS idx_inbox_items_file_path ON inbox_items(file_path)",
     "CREATE INDEX IF NOT EXISTS idx_inbox_items_batch_id ON inbox_items(batch_id)",
+    "CREATE INDEX IF NOT EXISTS idx_inbox_items_drop ON inbox_items(drop_id)",
     # processed emails
     "CREATE INDEX IF NOT EXISTS idx_processed_emails_status ON processed_emails(status)",
     "CREATE INDEX IF NOT EXISTS idx_processed_emails_message_id ON processed_emails(message_id)",
@@ -1698,6 +1702,7 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_follow_ups_scheduled ON follow_ups(scheduled_at)",
     "CREATE INDEX IF NOT EXISTS idx_follow_ups_source ON follow_ups(source)",
     "CREATE INDEX IF NOT EXISTS idx_follow_ups_linked_task ON follow_ups(linked_task_id)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_follow_ups_dedup ON follow_ups(dedup_key) WHERE dedup_key IS NOT NULL",
     # file modification audit trail
     "CREATE INDEX IF NOT EXISTS idx_file_mod_path ON file_modifications(file_path)",
     "CREATE INDEX IF NOT EXISTS idx_file_mod_session ON file_modifications(session_id)",

--- a/src/genesis/inbox/config.py
+++ b/src/genesis/inbox/config.py
@@ -52,6 +52,7 @@ def _parse(raw: dict) -> InboxConfig:
         response_dir=section.get("response_dir", "_genesis"),
         check_interval_seconds=int(section.get("check_interval_seconds", 1800)),
         batch_size=int(section.get("batch_size", 5)),
+        items_per_eval=int(section.get("items_per_eval", 5)),
         enabled=bool(section.get("enabled", True)),
         model=str(section.get("model", "sonnet")),
         effort=str(section.get("effort", "high")),

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -309,7 +309,7 @@ class InboxMonitor:
         now_iso = now.isoformat()
 
         # Phase 1: Resume approval-parked items
-        resume_items, resumed_ids, resumed_paths = await self._phase_resume(
+        resume_items, _resumed_ids, resumed_paths = await self._phase_resume(
             now, now_iso,
         )
 
@@ -333,7 +333,7 @@ class InboxMonitor:
 
         # Phase 4: Batch and dispatch
         batches_dispatched = await self._phase_dispatch_batches(
-            resume_items, pending_items, resumed_ids, now_iso, errors,
+            resume_items, pending_items, now_iso, errors,
         )
 
         return CheckResult(
@@ -900,7 +900,6 @@ class InboxMonitor:
         self,
         resume_items: list[InboxItem],
         pending_items: list[InboxItem],
-        resumed_ids: set[str],
         now_iso: str,
         errors: list[str],
     ) -> int:
@@ -931,19 +930,21 @@ class InboxMonitor:
 
         batches_dispatched = 0
 
-        # --- Resume drops: approval already resolved -> dispatch directly. ---
-        reqids_to_consume: set[str] = set()
+        # --- Resume drops: approval already resolved -> consume then dispatch. ---
         for _drop_id, items in self._group_by_drop(resume_items):
+            # Consume the drop's approval BEFORE dispatching so a restart
+            # mid-drop cannot leave an unconsumed approval that a later drop
+            # rides via the content-agnostic stable key. mark_consumed is
+            # idempotent; the parked rows still drive re-dispatch on restart.
+            reqid = items[0].approval_reqid if items else ""
+            if reqid:
+                await self._consume_approval(reqid)
             for item in items:
                 if await self._dispatch_one_batch(
                     item, model=model, effort=effort,
                     system_prompt=system_prompt, now_iso=now_iso, errors=errors,
                 ):
                     batches_dispatched += 1
-                if item.approval_reqid:
-                    reqids_to_consume.add(item.approval_reqid)
-        for reqid in reqids_to_consume:
-            await self._consume_approval(reqid)
 
         # --- New drops: ONE approval per drop, then dispatch each batch. ---
         for _drop_id, items in self._group_by_drop(pending_items):
@@ -995,17 +996,47 @@ class InboxMonitor:
         except Exception:
             logger.debug("Failed to record inbox prompt version", exc_info=True)
 
-    def _build_invocation(self, prompt: str, model, effort):
-        """Build a CCInvocation for an inbox evaluation."""
+    def _build_invocation(self, prompt: str, model, effort, system_prompt: str):
+        """Build a CCInvocation for an inbox evaluation.
+
+        ``system_prompt`` is passed in (loaded+hashed once per cycle in
+        ``_phase_dispatch_batches``) so the invocation's system prompt is the
+        SAME value used to build the approval request's message list.
+        """
         from genesis.cc.types import CCInvocation, background_session_dir
         mcp_path = SessionConfigBuilder().build_mcp_config("reflection")
         return CCInvocation(
             prompt=prompt, model=model, effort=effort,
-            system_prompt=self._load_system_prompt(),
+            system_prompt=system_prompt,
             timeout_s=self._config.timeout_s, skip_permissions=True,
             disallowed_tools=["Write", "Edit", "Agent", "NotebookEdit"],
             working_dir=background_session_dir(), mcp_config=mcp_path,
         )
+
+    async def _set_drop_status(
+        self, items, drop_id, *, status, error_message=None, processed_at=None,
+    ) -> None:
+        """Set status on all of a drop's live (pending/processing) rows.
+
+        Uses the atomic ``update_status_for_drop`` when a real ``drop_id`` is
+        present; falls back to per-row updates for legacy/solo rows (empty
+        drop_id) to avoid a drop_id='' UPDATE matching unrelated legacy rows.
+        Note: does not increment retry_count — callers that need the
+        permanent-fail cap update those rows explicitly.
+        """
+        from genesis.db.crud import inbox_items
+
+        if drop_id:
+            await inbox_items.update_status_for_drop(
+                self._db, drop_id, status=status,
+                error_message=error_message, processed_at=processed_at,
+            )
+        else:
+            for item in items:
+                await inbox_items.update_status(
+                    self._db, item.id, status=status,
+                    error_message=error_message, processed_at=processed_at,
+                )
 
     async def _acquire_drop_approval(
         self, items, *, model, effort, system_prompt, now_iso, errors,
@@ -1020,32 +1051,45 @@ class InboxMonitor:
         """
         from genesis.db.crud import inbox_items
 
+        drop_id = items[0].drop_id if items else ""
+
         # Claim the drop's rows for this cycle before the gate decision.
         batch_id = str(uuid.uuid4())
         for item in items:
             await inbox_items.set_batch(self._db, item.id, batch_id=batch_id)
-            await inbox_items.update_status(
-                self._db, item.id, status="processing",
-            )
+        await self._set_drop_status(items, drop_id, status="processing")
 
         if self._autonomous_dispatcher is None:
             return "approved"
 
         prompt = self._build_prompt(items)
-        invocation = self._build_invocation(prompt, model, effort)
-        decision = await self._autonomous_dispatcher.route(
-            AutonomousDispatchRequest(
-                subsystem="inbox", policy_id="inbox_evaluation",
-                action_label="inbox evaluation",
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": prompt},
-                ],
-                cli_invocation=invocation, api_call_site_id=None,
-                cli_fallback_allowed=True, approval_required_for_cli=True,
-                approval_key_stable=True, context=None,
-            ),
-        )
+        invocation = self._build_invocation(prompt, model, effort, system_prompt)
+        try:
+            decision = await self._autonomous_dispatcher.route(
+                AutonomousDispatchRequest(
+                    subsystem="inbox", policy_id="inbox_evaluation",
+                    action_label="inbox evaluation",
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": prompt},
+                    ],
+                    cli_invocation=invocation, api_call_site_id=None,
+                    cli_fallback_allowed=True, approval_required_for_cli=True,
+                    approval_key_stable=True, context=None,
+                ),
+            )
+        except Exception as exc:
+            # The gate raised (transient: network / DB lock / timeout). Fail the
+            # drop's rows (retriable — no permanent cap) so they don't sit stuck
+            # in 'processing' invisible to detection until expire_stuck fires.
+            err = f"Inbox approval gate error: {exc}"
+            logger.error(err, exc_info=True)
+            errors.append(err)
+            await self._set_drop_status(
+                items, drop_id, status="failed",
+                error_message=err, processed_at=now_iso,
+            )
+            return "failed"
         if decision.mode == "blocked":
             reason_lower = decision.reason.lower()
             is_pending = (
@@ -1062,12 +1106,13 @@ class InboxMonitor:
                     f"{inbox_items.AWAITING_APPROVAL_PREFIX}"
                     f"{decision.approval_request_id}"
                 )
-                for item in items:
-                    await inbox_items.update_status(
-                        self._db, item.id, status="processing",
-                        error_message=marker, processed_at=now_iso,
-                    )
+                await self._set_drop_status(
+                    items, drop_id, status="processing",
+                    error_message=marker, processed_at=now_iso,
+                )
                 return "parked"
+            # Hard rejection / CLI fallback disabled — do NOT retry this drop:
+            # set retry_count to the cap so get_all_known treats it permanent.
             err = f"CLI fallback blocked: {decision.reason}"
             errors.append(err)
             logger.warning(err)
@@ -1075,6 +1120,7 @@ class InboxMonitor:
                 await inbox_items.update_status(
                     self._db, item.id, status="failed",
                     error_message=err, processed_at=now_iso,
+                    retry_count=self._config.max_retries,
                 )
             return "rejected"
         if decision.mode == "api":
@@ -1120,7 +1166,7 @@ class InboxMonitor:
         batch_id = str(uuid.uuid4())
         await inbox_items.set_batch(self._db, item.id, batch_id=batch_id)
         prompt = self._build_prompt([item])
-        invocation = self._build_invocation(prompt, model, effort)
+        invocation = self._build_invocation(prompt, model, effort, system_prompt)
 
         session_id: str | None = None
         try:

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -19,9 +19,11 @@ from genesis.cc.session_config import SessionConfigBuilder
 from genesis.inbox.scanner import (
     compute_hash,
     detect_changes,
+    extract_urls,
     normalize_url_line,
     read_content,
     scan_folder,
+    segment_items,
 )
 from genesis.inbox.types import CheckResult, InboxConfig, InboxItem
 from genesis.security import ContentSanitizer, ContentSource
@@ -49,25 +51,9 @@ _FALLBACK_SYSTEM_PROMPT = (
     "Output readable markdown with per-item evaluation."
 )
 
-# URL extraction: matches https?://... and bare domain/path patterns like search.app/XYZ
-_URL_RE = re.compile(
-    r'(?:https?://[^\s<>\]\)]+)'
-    r'|'
-    r'(?:(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}/[^\s<>\]\)]+)',
-    re.IGNORECASE,
-)
-
-
-def _extract_urls(text: str) -> list[str]:
-    """Extract unique URLs from text, preserving order of first appearance."""
-    seen: set[str] = set()
-    urls: list[str] = []
-    for match in _URL_RE.finditer(text):
-        url = match.group(0).rstrip(".,;:!?)'\"")
-        if url not in seen:
-            seen.add(url)
-            urls.append(url)
-    return urls
+# URL extraction now lives in scanner.py (canonical). Kept as a module-level
+# alias because tests and call sites import ``_extract_urls`` from monitor.
+_extract_urls = extract_urls
 
 
 # Patterns indicating the evaluation GAVE UP on URLs (not just encountered errors).
@@ -517,16 +503,22 @@ class InboxMonitor:
                     processed_at=now_iso,
                 )
                 continue
-            # source_content = re-read at resume time, not original
-            # detection.  Safe: hash guard above ensures file is unchanged
-            # since it was parked for approval.
+            # Re-dispatch the EXACT delta this batch owns (persisted in
+            # batch_items at detection), NOT a full-file re-read — re-reading
+            # the whole file was the bug that made an approved eval re-chew
+            # every URL (Genesis-85). Legacy rows (pre-migration, no
+            # batch_items) fall back to the full re-read. The hash guard above
+            # ensures the file is unchanged since parking.
+            batch_text = str(row.get("batch_items") or "") or content
             resume_items.append(InboxItem(
                 id=row_id,
                 file_path=file_path,
-                content=content,
+                content=batch_text,
                 content_hash=stored_hash,
                 detected_at=str(row["created_at"]),
-                source_content=content,
+                source_content=batch_text,
+                drop_id=str(row.get("drop_id") or ""),
+                approval_reqid=request_id,
             ))
 
         resumed_ids: set[str] = {item.id for item in resume_items}
@@ -555,6 +547,23 @@ class InboxMonitor:
             modified_files = [
                 f for f in modified_files if str(f) not in resumed_paths
             ]
+        # STORM DIAGNOSTIC (read-only): the rate-limit-window "superseded by new
+        # inbox scan" churn re-detected an *unchanged* file as modified every
+        # scan, for reasons not yet reproduced. Log the known-vs-current hash
+        # and which row supplied the known hash so the next occurrence is
+        # diagnosable. No behaviour change — this only logs.
+        if modified_files:
+            for f in modified_files:
+                try:
+                    current = compute_hash(f)
+                except (FileNotFoundError, PermissionError):
+                    continue
+                known_hash = known.get(str(f), "<none>")
+                logger.info(
+                    "STORM_DIAG: %s detected modified — known_hash=%s "
+                    "current_hash=%s",
+                    f.name, str(known_hash)[:8], current[:8],
+                )
         return new_files, modified_files
 
     async def _phase_detect_changes(
@@ -739,50 +748,13 @@ class InboxMonitor:
                     created_at=now_iso,
                 )
                 continue
-            # Dedup: reuse existing retriable failed item instead of
-            # creating a duplicate row with retry_count=0.
-            existing_failed = await inbox_items.get_retriable_failed(
-                self._db, str(f), max_retries=self._config.max_retries,
+            # Segment the (full, for a new file) content into per-batch rows
+            # under one drop. Failed batches retry via the delta path next
+            # cycle (their lines stay un-baselined), so the old
+            # get_retriable_failed single-row reuse is no longer needed.
+            await self._queue_drop(
+                str(f), content, h, now_iso, pending_items,
             )
-            if existing_failed:
-                logger.info(
-                    "Reusing failed item %s for %s (retry_count=%d)",
-                    existing_failed["id"][:8], f,
-                    existing_failed["retry_count"],
-                )
-                await inbox_items.update_status(
-                    self._db, existing_failed["id"],
-                    status="pending",
-                    error_message=None,
-                )
-                # Update content_hash so the resume pass hash-check
-                # doesn't false-positive if this enters the approval gate.
-                if existing_failed["content_hash"] != h:
-                    await self._db.execute(
-                        "UPDATE inbox_items SET content_hash = ? WHERE id = ?",
-                        (h, existing_failed["id"]),
-                    )
-                    await self._db.commit()
-                pending_items.append(InboxItem(
-                    id=existing_failed["id"], file_path=str(f),
-                    content=content, content_hash=h, detected_at=now_iso,
-                    source_content=content,
-                ))
-                continue
-
-            await inbox_items.create(
-                self._db,
-                id=item_id,
-                file_path=str(f),
-                content_hash=h,
-                status="pending",
-                created_at=now_iso,
-            )
-            pending_items.append(InboxItem(
-                id=item_id, file_path=str(f), content=content,
-                content_hash=h, detected_at=now_iso,
-                source_content=content,
-            ))
 
         cooldown = timedelta(seconds=self._config.evaluation_cooldown_seconds)
 
@@ -855,21 +827,70 @@ class InboxMonitor:
                 eval_content = delta
             else:
                 eval_content = content
-            await inbox_items.create(
-                self._db,
-                id=item_id,
-                file_path=str(f),
-                content_hash=h,
-                status="pending",
-                created_at=now_iso,
+            # Segment the delta into per-batch rows under one drop.
+            await self._queue_drop(
+                str(f), eval_content, h, now_iso, pending_items,
             )
-            pending_items.append(InboxItem(
-                id=item_id, file_path=str(f), content=eval_content,
-                content_hash=h, detected_at=now_iso,
-                source_content=content,
-            ))
 
         return pending_items
+
+    async def _queue_drop(
+        self,
+        file_path: str,
+        eval_content: str,
+        content_hash: str,
+        now_iso: str,
+        pending_items: list[InboxItem],
+    ) -> None:
+        """Segment a file's delta into items, group into batches of
+        ``items_per_eval``, and create one pending row per batch under a shared
+        ``drop_id``. Appends one InboxItem per batch to ``pending_items``.
+
+        Each batch's lines are stored verbatim in ``batch_items`` so the resume
+        pass re-dispatches the exact delta (not a full-file re-read) and a
+        restart mid-drop can reconstruct the not-yet-completed batches.
+        """
+        from genesis.db.crud import inbox_items
+
+        items = segment_items(eval_content)
+        if not items:
+            return
+        size = max(1, self._config.items_per_eval)
+        batches = [items[i : i + size] for i in range(0, len(items), size)]
+        # Reuse retriable failed rows for this file (one per batch) so retries
+        # don't accumulate duplicate rows — the row's retry_count is preserved
+        # so the permanent-failure cap still applies. (A file is re-detected for
+        # retry when ALL its rows failed; partially-failed batches re-enter the
+        # delta on the next file edit.)
+        reusable = await inbox_items.get_retriable_failed_rows(
+            self._db, file_path, max_retries=self._config.max_retries,
+        )
+        drop_id = str(uuid.uuid4())
+        for idx, batch in enumerate(batches):
+            batch_text = "\n".join(it.text for it in batch)
+            if idx < len(reusable):
+                row_id = str(reusable[idx]["id"])
+                await inbox_items.reuse_as_pending(
+                    self._db, row_id, drop_id=drop_id,
+                    batch_items=batch_text, content_hash=content_hash,
+                )
+            else:
+                row_id = str(uuid.uuid4())
+                await inbox_items.create(
+                    self._db,
+                    id=row_id,
+                    file_path=file_path,
+                    content_hash=content_hash,
+                    status="pending",
+                    created_at=now_iso,
+                    drop_id=drop_id,
+                    batch_items=batch_text,
+                )
+            pending_items.append(InboxItem(
+                id=row_id, file_path=file_path, content=batch_text,
+                content_hash=content_hash, detected_at=now_iso,
+                source_content=batch_text, drop_id=drop_id,
+            ))
 
     # =================================================================
     # Phase 4: Batch and dispatch
@@ -883,468 +904,465 @@ class InboxMonitor:
         now_iso: str,
         errors: list[str],
     ) -> int:
-        """Build batches and dispatch to CC sessions.
+        """Dispatch evaluation batches to CC sessions.
+
+        Each row is one eval-batch (<= items_per_eval items) carved from a
+        file's delta; rows sharing a ``drop_id`` form one drop. Approval is
+        acquired ONCE per drop (a single ``route()`` call); on approval every
+        batch in the drop is dispatched directly as its own CC session, so a
+        16-URL file becomes ~4 small evals + 4 response files under a single
+        approval. Resume batches (their drop's approval already resolved) are
+        dispatched directly and their approval is consumed once per drop.
 
         Returns the number of batches successfully dispatched.
-        Appends errors to the ``errors`` list in-place.
         """
-        from genesis.cc.types import (
-            CCInvocation,
-            CCModel,
-            EffortLevel,
-            SessionType,
-            background_session_dir,
-        )
-        from genesis.db.crud import inbox_items, message_queue
+        from genesis.cc.types import CCModel, EffortLevel
+
+        try:
+            model = CCModel(self._config.model)
+        except ValueError:
+            model = CCModel.SONNET
+        try:
+            effort = EffortLevel(self._config.effort)
+        except ValueError:
+            effort = EffortLevel.MEDIUM
+        system_prompt = self._load_system_prompt()
+        await self._record_prompt_version(system_prompt)
 
         batches_dispatched = 0
-        batch_size = self._config.batch_size
+
+        # --- Resume drops: approval already resolved -> dispatch directly. ---
+        reqids_to_consume: set[str] = set()
+        for _drop_id, items in self._group_by_drop(resume_items):
+            for item in items:
+                if await self._dispatch_one_batch(
+                    item, model=model, effort=effort,
+                    system_prompt=system_prompt, now_iso=now_iso, errors=errors,
+                ):
+                    batches_dispatched += 1
+                if item.approval_reqid:
+                    reqids_to_consume.add(item.approval_reqid)
+        for reqid in reqids_to_consume:
+            await self._consume_approval(reqid)
+
+        # --- New drops: ONE approval per drop, then dispatch each batch. ---
+        for _drop_id, items in self._group_by_drop(pending_items):
+            outcome = await self._acquire_drop_approval(
+                items, model=model, effort=effort,
+                system_prompt=system_prompt, now_iso=now_iso, errors=errors,
+            )
+            if outcome != "approved":
+                continue
+            for item in items:
+                if await self._dispatch_one_batch(
+                    item, model=model, effort=effort,
+                    system_prompt=system_prompt, now_iso=now_iso, errors=errors,
+                ):
+                    batches_dispatched += 1
+
+        return batches_dispatched
+
+    @staticmethod
+    def _group_by_drop(
+        items: list[InboxItem],
+    ) -> list[tuple[str, list[InboxItem]]]:
+        """Group InboxItems by drop_id, preserving first-seen order.
+
+        Items with an empty drop_id (legacy/singleton rows) each form their own
+        one-item group keyed by their row id.
+        """
+        groups: dict[str, list[InboxItem]] = {}
+        order: list[str] = []
+        for item in items:
+            key = item.drop_id or f"_solo:{item.id}"
+            if key not in groups:
+                groups[key] = []
+                order.append(key)
+            groups[key].append(item)
+        return [(k, groups[k]) for k in order]
+
+    async def _record_prompt_version(self, system_prompt: str) -> None:
+        """Record the inbox prompt version once per monitor lifetime."""
+        if self._prompt_version_recorded or self._db is None:
+            return
+        try:
+            from genesis.db.crud.prompt_versions import record_version
+            await record_version(
+                self._db, prompt_hash=self._prompt_hash,
+                call_site="inbox_evaluate", content_preview=system_prompt[:200],
+            )
+            self._prompt_version_recorded = True
+        except Exception:
+            logger.debug("Failed to record inbox prompt version", exc_info=True)
+
+    def _build_invocation(self, prompt: str, model, effort):
+        """Build a CCInvocation for an inbox evaluation."""
+        from genesis.cc.types import CCInvocation, background_session_dir
         mcp_path = SessionConfigBuilder().build_mcp_config("reflection")
+        return CCInvocation(
+            prompt=prompt, model=model, effort=effort,
+            system_prompt=self._load_system_prompt(),
+            timeout_s=self._config.timeout_s, skip_permissions=True,
+            disallowed_tools=["Write", "Edit", "Agent", "NotebookEdit"],
+            working_dir=background_session_dir(), mcp_config=mcp_path,
+        )
 
-        # Resume items as singletons first, then new/modified in batches.
-        scheduled_batches: list[list[InboxItem]] = [
-            [item] for item in resume_items
-        ]
-        for i in range(0, len(pending_items), batch_size):
-            scheduled_batches.append(pending_items[i : i + batch_size])
+    async def _acquire_drop_approval(
+        self, items, *, model, effort, system_prompt, now_iso, errors,
+    ) -> str:
+        """Acquire ONE approval for a drop.
 
-        for batch in scheduled_batches:
-            batch_id = str(uuid.uuid4())
+        Returns ``"approved"``, ``"parked"``, ``"rejected"`` or ``"failed"``.
+        On park, all the drop's rows are set to processing + an awaiting marker.
+        On reject/failure, all rows are failed. When no dispatcher is wired (or
+        the gate is disabled, surfaced as cli_approved), returns ``"approved"``
+        so the gate-OFF direct path dispatches every batch.
+        """
+        from genesis.db.crud import inbox_items
 
-            for item in batch:
-                await inbox_items.set_batch(self._db, item.id, batch_id=batch_id)
-                if item.id not in resumed_ids:
-                    await inbox_items.update_status(
-                        self._db, item.id, status="processing",
-                    )
-
-            prompt = self._build_prompt(batch)
-            system_prompt = self._load_system_prompt()
-
-            # Record prompt version on first dispatch
-            if not self._prompt_version_recorded and self._db is not None:
-                try:
-                    from genesis.db.crud.prompt_versions import record_version
-                    await record_version(
-                        self._db,
-                        prompt_hash=self._prompt_hash,
-                        call_site="inbox_evaluate",
-                        content_preview=system_prompt[:200],
-                    )
-                    self._prompt_version_recorded = True
-                except Exception:
-                    logger.debug(
-                        "Failed to record inbox prompt version",
-                        exc_info=True,
-                    )
-
-            try:
-                model = CCModel(self._config.model)
-            except ValueError:
-                model = CCModel.SONNET
-
-            try:
-                effort = EffortLevel(self._config.effort)
-            except ValueError:
-                effort = EffortLevel.MEDIUM
-
-            invocation = CCInvocation(
-                prompt=prompt,
-                model=model,
-                effort=effort,
-                system_prompt=system_prompt,
-                timeout_s=self._config.timeout_s,
-                skip_permissions=True,
-                disallowed_tools=["Write", "Edit", "Agent", "NotebookEdit"],
-                working_dir=background_session_dir(),
-                mcp_config=mcp_path,
+        # Claim the drop's rows for this cycle before the gate decision.
+        batch_id = str(uuid.uuid4())
+        for item in items:
+            await inbox_items.set_batch(self._db, item.id, batch_id=batch_id)
+            await inbox_items.update_status(
+                self._db, item.id, status="processing",
             )
 
-            output = None
-            used_cli = True
-            session_id: str | None = None
-            if self._autonomous_dispatcher is not None:
-                decision = await self._autonomous_dispatcher.route(
-                    AutonomousDispatchRequest(
-                        subsystem="inbox",
-                        policy_id="inbox_evaluation",
-                        action_label="inbox evaluation",
-                        messages=[
-                            {"role": "system", "content": system_prompt},
-                            {"role": "user", "content": prompt},
-                        ],
-                        cli_invocation=invocation,
-                        api_call_site_id=None,
-                        cli_fallback_allowed=True,
-                        approval_required_for_cli=True,
-                        approval_key_stable=True,
-                        context=None,
-                    ),
-                )
-                if decision.mode == "blocked":
-                    err = f"CLI fallback blocked: {decision.reason}"
-                    reason_lower = decision.reason.lower()
-                    is_pending_approval = (
-                        decision.approval_request_id is not None
-                        and "reject" not in reason_lower
-                    )
-                    if is_pending_approval:
-                        logger.info(
-                            "Inbox batch %s parked awaiting approval %s",
-                            batch_id[:8], decision.approval_request_id,
-                        )
-                        marker = (
-                            f"{inbox_items.AWAITING_APPROVAL_PREFIX}"
-                            f"{decision.approval_request_id}"
-                        )
-                        for item in batch:
-                            await inbox_items.update_status(
-                                self._db, item.id, status="processing",
-                                error_message=marker, processed_at=now_iso,
-                            )
-                    else:
-                        errors.append(err)
-                        logger.warning(err)
-                        for item in batch:
-                            await inbox_items.update_status(
-                                self._db, item.id, status="failed",
-                                error_message=err, processed_at=now_iso,
-                            )
-                    continue
-                if decision.mode == "api":
-                    output = decision.output
-                    used_cli = False
+        if self._autonomous_dispatcher is None:
+            return "approved"
 
-            if output is None:
-                try:
-                    sess = await self._session_manager.create_background(
-                        session_type=SessionType.BACKGROUND_TASK,
-                        model=model,
-                        effort=effort,
-                        source_tag="inbox_evaluation",
-                    )
-                    session_id = sess["id"]
-                except Exception as exc:
-                    err = f"Session creation failed: {exc}"
-                    errors.append(err)
-                    logger.error(err, exc_info=True)
-                    for item in batch:
-                        await inbox_items.update_status(
-                            self._db, item.id, status="failed",
-                            error_message=err, processed_at=now_iso,
-                        )
-                    continue
-
-                try:
-                    output = await self._invoker.run(invocation)
-                except Exception as exc:
-                    err = f"CC invocation failed: {exc}"
-                    errors.append(err)
-                    logger.error(err, exc_info=True)
-                    await self._session_manager.fail(session_id, reason=err)
-                    for item in batch:
-                        await inbox_items.update_status(
-                            self._db, item.id, status="failed",
-                            error_message=err, processed_at=now_iso,
-                        )
-                    continue
-
-            if output.is_error:
-                err = f"CC error: {output.error_message}"
-                errors.append(err)
-                logger.error(err)
-                if used_cli and session_id is not None:
-                    await self._session_manager.fail(
-                        session_id, reason=output.error_message,
-                    )
-                for item in batch:
-                    await inbox_items.update_status(
-                        self._db, item.id, status="failed",
-                        error_message=err, processed_at=now_iso,
-                    )
-                continue
-
-            if not output.text or not output.text.strip():
-                err = "CC invocation returned empty evaluation text"
-                errors.append(err)
-                logger.error(
-                    "Inbox batch %s returned empty text — marking as "
-                    "failed (text_len=%d)",
-                    batch_id[:8], len(output.text or ""),
-                )
-                if used_cli and session_id is not None:
-                    await self._session_manager.fail(session_id, reason=err)
-                for item in batch:
-                    await inbox_items.update_status(
-                        self._db, item.id, status="failed",
-                        error_message=err, processed_at=now_iso,
-                    )
-                if self._event_bus:
-                    from genesis.observability.types import Severity, Subsystem
-                    await self._event_bus.emit(
-                        Subsystem.INBOX, Severity.ERROR,
-                        "evaluation.empty_output",
-                        f"Batch {batch_id[:8]} returned empty evaluation "
-                        f"text (used_cli={used_cli})",
-                        batch_id=batch_id, used_cli=used_cli,
-                    )
-                continue
-
-            if len(batch) == 1 and _is_acknowledged(output.text):
+        prompt = self._build_prompt(items)
+        invocation = self._build_invocation(prompt, model, effort)
+        decision = await self._autonomous_dispatcher.route(
+            AutonomousDispatchRequest(
+                subsystem="inbox", policy_id="inbox_evaluation",
+                action_label="inbox evaluation",
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": prompt},
+                ],
+                cli_invocation=invocation, api_call_site_id=None,
+                cli_fallback_allowed=True, approval_required_for_cli=True,
+                approval_key_stable=True, context=None,
+            ),
+        )
+        if decision.mode == "blocked":
+            reason_lower = decision.reason.lower()
+            is_pending = (
+                decision.approval_request_id is not None
+                and "reject" not in reason_lower
+            )
+            if is_pending:
+                drop_label = str(items[0].drop_id or items[0].id)[:8]
                 logger.info(
-                    "Item(s) classified as Acknowledged — no response file "
-                    "written (batch %s)",
-                    batch_id[:8],
+                    "Inbox drop %s parked awaiting approval %s",
+                    drop_label, decision.approval_request_id,
                 )
-                completed_at = self._clock().isoformat()
-                for item in batch:
-                    source = item.source_content or item.content
-                    prev = await inbox_items.get_evaluated_content(
-                        self._db, item.file_path,
-                    )
-                    full_content = _merge_evaluated_content(prev, source)
-                    # Diagnostic: detect file changes during evaluation
-                    try:
-                        current_content = read_content(Path(item.file_path))
-                    except (FileNotFoundError, PermissionError):
-                        current_content = None
-                    if current_content is not None and current_content != source:
-                        logger.warning(
-                            "BASELINE_GUARD: file changed during eval "
-                            "for %s (detection=%d chars, completion=%d "
-                            "chars, merge_baseline=%d chars)",
-                            item.file_path,
-                            len(source), len(current_content),
-                            len(full_content),
-                        )
-                        if self._event_bus:
-                            try:
-                                from genesis.observability.types import (
-                                    Severity,
-                                    Subsystem,
-                                )
-                                await self._event_bus.emit(
-                                    Subsystem.INBOX, Severity.WARNING,
-                                    "baseline_guard.file_changed",
-                                    f"File changed during evaluation: "
-                                    f"detection={len(source)}, "
-                                    f"completion={len(current_content)}",
-                                    file_path=item.file_path,
-                                )
-                            except Exception:
-                                logger.debug(
-                                    "BASELINE_GUARD event emit failed",
-                                    exc_info=True,
-                                )
+                marker = (
+                    f"{inbox_items.AWAITING_APPROVAL_PREFIX}"
+                    f"{decision.approval_request_id}"
+                )
+                for item in items:
                     await inbox_items.update_status(
-                        self._db, item.id, status="completed",
-                        processed_at=completed_at,
-                        evaluated_content=full_content,
+                        self._db, item.id, status="processing",
+                        error_message=marker, processed_at=now_iso,
                     )
-                if used_cli and session_id is not None:
-                    await self._session_manager.complete(session_id)
-
-                try:
-                    source_names = ", ".join(
-                        Path(item.file_path).name for item in batch
-                    )
-                    await message_queue.create(
-                        self._db,
-                        id=str(uuid.uuid4()),
-                        source="cc_background",
-                        target="cc_foreground",
-                        message_type="finding",
-                        content=(
-                            f"Inbox item acknowledged (no response needed): "
-                            f"{source_names}"
-                        ),
-                        created_at=completed_at,
-                        priority="low",
-                    )
-                except Exception:
-                    logger.exception("Failed to write message_queue entry")
-
-                if self._event_bus:
-                    from genesis.observability.types import Severity, Subsystem
-                    await self._event_bus.emit(
-                        Subsystem.INBOX, Severity.INFO,
-                        "check.acknowledged",
-                        f"Batch {batch_id[:8]} acknowledged ({len(batch)} items)",
-                        batch_id=batch_id, items=len(batch),
-                    )
-
-                batches_dispatched += 1
-                continue
-
-            # Coherence check: annotate low-quality evaluations
-            batch_content = "\n".join(item.content for item in batch)
-            if not _passes_coherence_check(output.text, batch_content):
-                logger.warning(
-                    "Inbox batch %s failed coherence check — annotating",
-                    batch_id[:8],
+                return "parked"
+            err = f"CLI fallback blocked: {decision.reason}"
+            errors.append(err)
+            logger.warning(err)
+            for item in items:
+                await inbox_items.update_status(
+                    self._db, item.id, status="failed",
+                    error_message=err, processed_at=now_iso,
                 )
-                output_text = (
-                    "\u26a0\ufe0f **Low-confidence evaluation** "
-                    "(failed structural coherence check)\n\n"
-                    + output.text
+            return "rejected"
+        if decision.mode == "api":
+            # Inbox sets api_call_site_id=None so the router never hits the API
+            # chain. If that invariant ever breaks, do NOT silently drop the
+            # batches — fall through to direct CLI dispatch.
+            logger.error(
+                "Inbox drop unexpectedly received an API decision "
+                "(api_call_site_id should be None) — dispatching via CLI",
+            )
+        return "approved"
+
+    async def _consume_approval(self, request_id: str) -> None:
+        """Consume a resume drop's approval so the next drop cannot ride the
+        same (content-agnostic, stable-key) approval."""
+        gate = getattr(self._autonomous_dispatcher, "approval_gate", None)
+        consume = getattr(gate, "mark_consumed", None)
+        if consume is None:
+            return
+        try:
+            await consume(request_id)
+        except Exception:
+            logger.debug(
+                "Failed to consume approval %s after resume", request_id,
+                exc_info=True,
+            )
+
+    async def _dispatch_one_batch(
+        self, item, *, model, effort, system_prompt, now_iso, errors,
+    ) -> bool:
+        """Run one eval-batch as its own CC session and post-process the result.
+
+        Approval is already cleared at the drop level, so this dispatches
+        directly (create_background + invoker.run). On success it merges ONLY
+        this batch's lines (``item.source_content``) into the file's
+        ``evaluated_content`` baseline, so a failed sibling batch's lines stay
+        un-baselined and resurface in the next delta for retry. Returns True iff
+        the batch produced a completed/acknowledged result.
+        """
+        from genesis.cc.types import SessionType
+        from genesis.db.crud import inbox_items, message_queue
+
+        batch_id = str(uuid.uuid4())
+        await inbox_items.set_batch(self._db, item.id, batch_id=batch_id)
+        prompt = self._build_prompt([item])
+        invocation = self._build_invocation(prompt, model, effort)
+
+        session_id: str | None = None
+        try:
+            sess = await self._session_manager.create_background(
+                session_type=SessionType.BACKGROUND_TASK,
+                model=model, effort=effort, source_tag="inbox_evaluation",
+            )
+            session_id = sess["id"]
+        except Exception as exc:
+            err = f"Session creation failed: {exc}"
+            errors.append(err)
+            logger.error(err, exc_info=True)
+            await inbox_items.update_status(
+                self._db, item.id, status="failed",
+                error_message=err, processed_at=now_iso,
+            )
+            return False
+
+        try:
+            output = await self._invoker.run(invocation)
+        except Exception as exc:
+            err = f"CC invocation failed: {exc}"
+            errors.append(err)
+            logger.error(err, exc_info=True)
+            await self._session_manager.fail(session_id, reason=err)
+            await inbox_items.update_status(
+                self._db, item.id, status="failed",
+                error_message=err, processed_at=now_iso,
+            )
+            return False
+
+        if output.is_error:
+            err = f"CC error: {output.error_message}"
+            errors.append(err)
+            logger.error(err)
+            if session_id is not None:
+                await self._session_manager.fail(
+                    session_id, reason=output.error_message,
                 )
-            else:
-                output_text = output.text
+            await inbox_items.update_status(
+                self._db, item.id, status="failed",
+                error_message=err, processed_at=now_iso,
+            )
+            return False
 
-            # Write response file
-            response_path = None
-            if self._writer:
-                try:
-                    response_path = await self._writer.write_response(
-                        batch_id=batch_id,
-                        source_files=[item.file_path for item in batch],
-                        evaluation_text=output_text,
-                        item_count=len(batch),
-                    )
-                except Exception as exc:
-                    err = f"Response write failed: {exc}"
-                    errors.append(err)
-                    logger.error(err)
-
-            # Create follow-ups from Recommendation blocks (non-fatal)
-            if output_text:
-                try:
-                    fu_count = await self._create_follow_ups_from_eval(
-                        evaluation_text=output_text,
-                        batch_id=batch_id,
-                        source_files=[item.file_path for item in batch],
-                    )
-                    if fu_count:
-                        logger.info(
-                            "Created %d follow-up(s) from inbox eval %s",
-                            fu_count, batch_id[:8],
-                        )
-                except Exception:
-                    logger.warning(
-                        "Follow-up creation from inbox eval failed (non-fatal)",
-                        exc_info=True,
-                    )
-
-            url_failures = _has_url_failures(output_text, batch_content)
-            if url_failures:
-                logger.warning(
-                    "URL failures detected in batch %s — marking as failed "
-                    "to enable retry (response file still written for user)",
-                    batch_id[:8],
-                )
-
-            completed_at = self._clock().isoformat()
-            for item in batch:
-                if url_failures:
-                    await inbox_items.mark_url_failure(
-                        self._db, item.id,
-                        response_path=str(response_path) if response_path else None,
-                        processed_at=completed_at,
-                    )
-                else:
-                    source = item.source_content or item.content
-                    prev = await inbox_items.get_evaluated_content(
-                        self._db, item.file_path,
-                    )
-                    full_content = _merge_evaluated_content(prev, source)
-                    # Diagnostic: detect file changes during evaluation
-                    try:
-                        current_content = read_content(
-                            Path(item.file_path),
-                        )
-                    except (FileNotFoundError, PermissionError):
-                        current_content = None
-                    if (current_content is not None
-                            and current_content != source):
-                        logger.warning(
-                            "BASELINE_GUARD: file changed during eval "
-                            "for %s (detection=%d chars, completion=%d "
-                            "chars, merge_baseline=%d chars)",
-                            item.file_path,
-                            len(source), len(current_content),
-                            len(full_content),
-                        )
-                        if self._event_bus:
-                            try:
-                                from genesis.observability.types import (
-                                    Severity,
-                                    Subsystem,
-                                )
-                                await self._event_bus.emit(
-                                    Subsystem.INBOX, Severity.WARNING,
-                                    "baseline_guard.file_changed",
-                                    f"File changed during evaluation: "
-                                    f"detection={len(source)}, "
-                                    f"completion={len(current_content)}",
-                                    file_path=item.file_path,
-                                )
-                            except Exception:
-                                logger.debug(
-                                    "BASELINE_GUARD event emit failed",
-                                    exc_info=True,
-                                )
-                    if response_path:
-                        await inbox_items.set_response_path(
-                            self._db, item.id,
-                            response_path=str(response_path),
-                            processed_at=completed_at,
-                            evaluated_content=full_content,
-                        )
-                    else:
-                        await inbox_items.update_status(
-                            self._db, item.id, status="completed",
-                            processed_at=completed_at,
-                            evaluated_content=full_content,
-                        )
-
-            if used_cli and session_id is not None:
-                await self._session_manager.complete(session_id)
-
-            try:
-                source_names = ", ".join(
-                    Path(item.file_path).name for item in batch
-                )
-                await message_queue.create(
-                    self._db,
-                    id=str(uuid.uuid4()),
-                    source="cc_background",
-                    target="cc_foreground",
-                    message_type="finding",
-                    content=(
-                        f"Inbox evaluation completed for {len(batch)} item(s): "
-                        f"{source_names}. "
-                        f"Response: {response_path or 'no file written'}"
-                    ),
-                    created_at=completed_at,
-                    priority="low",
-                )
-            except Exception:
-                logger.exception("Failed to write message_queue entry")
-
-            if self._triage_pipeline is not None:
-                from genesis.observability.types import Subsystem
-                from genesis.util.tasks import tracked_task
-
-                user_text = "\n".join(item.content for item in batch)
-                tracked_task(
-                    self._fire_triage(output, user_text),
-                    name="inbox-triage",
-                    event_bus=self._event_bus,
-                    subsystem=Subsystem.INBOX,
-                )
-
-            batches_dispatched += 1
-
+        if not output.text or not output.text.strip():
+            err = "CC invocation returned empty evaluation text"
+            errors.append(err)
+            logger.error(
+                "Inbox batch %s returned empty text — marking failed",
+                batch_id[:8],
+            )
+            if session_id is not None:
+                await self._session_manager.fail(session_id, reason=err)
+            await inbox_items.update_status(
+                self._db, item.id, status="failed",
+                error_message=err, processed_at=now_iso,
+            )
             if self._event_bus:
                 from genesis.observability.types import Severity, Subsystem
                 await self._event_bus.emit(
-                    Subsystem.INBOX, Severity.INFO,
-                    "check.complete",
-                    f"Batch {batch_id[:8]} evaluated ({len(batch)} items)",
-                    batch_id=batch_id, items=len(batch),
+                    Subsystem.INBOX, Severity.ERROR, "evaluation.empty_output",
+                    f"Batch {batch_id[:8]} returned empty evaluation text",
+                    batch_id=batch_id,
+                )
+            return False
+
+        completed_at = self._clock().isoformat()
+
+        # Acknowledged: pure-meta note, no response file.
+        if _is_acknowledged(output.text):
+            logger.info(
+                "Item classified as Acknowledged — no response file (batch %s)",
+                batch_id[:8],
+            )
+            await self._complete_batch_baseline(item, completed_at)
+            if session_id is not None:
+                await self._session_manager.complete(session_id)
+            await self._notify_batch(
+                message_queue, item, completed_at,
+                "Inbox item acknowledged (no response needed): "
+                f"{Path(item.file_path).name}",
+            )
+            if self._event_bus:
+                from genesis.observability.types import Severity, Subsystem
+                await self._event_bus.emit(
+                    Subsystem.INBOX, Severity.INFO, "check.acknowledged",
+                    f"Batch {batch_id[:8]} acknowledged", batch_id=batch_id,
+                )
+            return True
+
+        # Coherence annotation (non-blocking).
+        if not _passes_coherence_check(output.text, item.content):
+            logger.warning(
+                "Inbox batch %s failed coherence check — annotating",
+                batch_id[:8],
+            )
+            output_text = (
+                "⚠️ **Low-confidence evaluation** "
+                "(failed structural coherence check)\n\n" + output.text
+            )
+        else:
+            output_text = output.text
+
+        # Response file: one per batch -> numbered Genesis-N sibling
+        # (item_count=1 selects the sibling-naming path in the writer).
+        response_path = None
+        if self._writer:
+            try:
+                response_path = await self._writer.write_response(
+                    batch_id=batch_id, source_files=[item.file_path],
+                    evaluation_text=output_text, item_count=1,
+                )
+            except Exception as exc:
+                err = f"Response write failed: {exc}"
+                errors.append(err)
+                logger.error(err)
+
+        # Follow-ups (deduped per recommendation; non-fatal).
+        if output_text:
+            try:
+                fu_count = await self._create_follow_ups_from_eval(
+                    evaluation_text=output_text, batch_id=batch_id,
+                    source_files=[item.file_path],
+                )
+                if fu_count:
+                    logger.info(
+                        "Created %d follow-up(s) from inbox eval %s",
+                        fu_count, batch_id[:8],
+                    )
+            except Exception:
+                logger.warning(
+                    "Follow-up creation from inbox eval failed (non-fatal)",
+                    exc_info=True,
                 )
 
-        return batches_dispatched
+        # URL-fetch give-up -> mark failed (retry); do NOT baseline these lines.
+        if _has_url_failures(output_text, item.content):
+            logger.warning(
+                "URL failures in batch %s — marking failed to retry "
+                "(response kept)", batch_id[:8],
+            )
+            await inbox_items.mark_url_failure(
+                self._db, item.id,
+                response_path=str(response_path) if response_path else None,
+                processed_at=completed_at,
+            )
+            if session_id is not None:
+                await self._session_manager.complete(session_id)
+            return False
+
+        # Success: baseline ONLY this batch's lines.
+        await self._complete_batch_baseline(
+            item, completed_at, response_path=response_path,
+        )
+        if session_id is not None:
+            await self._session_manager.complete(session_id)
+        await self._notify_batch(
+            message_queue, item, completed_at,
+            f"Inbox evaluation completed: {Path(item.file_path).name}. "
+            f"Response: {response_path or 'no file written'}",
+        )
+        if self._triage_pipeline is not None:
+            from genesis.observability.types import Subsystem
+            from genesis.util.tasks import tracked_task
+            tracked_task(
+                self._fire_triage(output, item.content),
+                name="inbox-triage", event_bus=self._event_bus,
+                subsystem=Subsystem.INBOX,
+            )
+        if self._event_bus:
+            from genesis.observability.types import Severity, Subsystem
+            await self._event_bus.emit(
+                Subsystem.INBOX, Severity.INFO, "check.complete",
+                f"Batch {batch_id[:8]} evaluated", batch_id=batch_id,
+            )
+        return True
+
+    async def _complete_batch_baseline(
+        self, item, completed_at, *, response_path=None,
+    ) -> None:
+        """Mark a batch row completed, merging ONLY its lines into the baseline.
+
+        The per-batch merge is what makes partial-failure safe: a failed sibling
+        batch never contributes to ``evaluated_content``, so its lines reappear
+        in the next delta and retry, while completed batches stay evaluated.
+        """
+        from genesis.db.crud import inbox_items
+
+        source = item.source_content or item.content
+        prev = await inbox_items.get_evaluated_content(self._db, item.file_path)
+        full_content = _merge_evaluated_content(prev, source)
+        # Diagnostic: detect the source FILE changing during evaluation by
+        # comparing the drop's detection hash to the current file hash. (The
+        # whole file legitimately differs from a single batch's slice now, so
+        # the guard keys on the file hash, not a full-text equality check.)
+        try:
+            current_hash = compute_hash(Path(item.file_path))
+        except (FileNotFoundError, PermissionError):
+            current_hash = None
+        if current_hash is not None and current_hash != item.content_hash:
+            logger.warning(
+                "BASELINE_GUARD: file %s changed during eval "
+                "(detection_hash=%s current_hash=%s)",
+                item.file_path, item.content_hash[:8], current_hash[:8],
+            )
+            if self._event_bus:
+                try:
+                    from genesis.observability.types import Severity, Subsystem
+                    await self._event_bus.emit(
+                        Subsystem.INBOX, Severity.WARNING,
+                        "baseline_guard.file_changed",
+                        f"File changed during evaluation: {item.file_path}",
+                        file_path=item.file_path,
+                    )
+                except Exception:
+                    logger.debug(
+                        "BASELINE_GUARD event emit failed", exc_info=True,
+                    )
+        if response_path:
+            await inbox_items.set_response_path(
+                self._db, item.id, response_path=str(response_path),
+                processed_at=completed_at, evaluated_content=full_content,
+            )
+        else:
+            await inbox_items.update_status(
+                self._db, item.id, status="completed",
+                processed_at=completed_at, evaluated_content=full_content,
+            )
+
+    async def _notify_batch(
+        self, message_queue, item, completed_at, content: str,
+    ) -> None:
+        """Write a cc_background -> cc_foreground finding for a dispatched batch."""
+        try:
+            await message_queue.create(
+                self._db, id=str(uuid.uuid4()), source="cc_background",
+                target="cc_foreground", message_type="finding",
+                content=content, created_at=completed_at, priority="low",
+            )
+        except Exception:
+            logger.exception("Failed to write message_queue entry")
 
     def _build_prompt(self, items: list[InboxItem]) -> str:
         """Build the evaluation prompt from a batch of items.
@@ -1462,6 +1480,8 @@ class InboxMonitor:
 
         Returns the number of follow-ups created.
         """
+        import hashlib
+
         from genesis.db.crud import follow_ups
         from genesis.inbox.recommendation import parse_recommendations
 
@@ -1490,6 +1510,23 @@ class InboxMonitor:
                 f"Confidence: {rec.confidence}. Effort: {rec.effort}."
             )
 
+            # Dedup: skip if an identical recommendation already exists so that
+            # re-evaluating the same URL (or overlapping drops) never piles up
+            # duplicate follow-up rows. Key on the item's primary URL
+            # (tracking-normalized) or title + the next_step.
+            urls_in_title = extract_urls(title)
+            primary = (
+                normalize_url_line(urls_in_title[0])
+                if urls_in_title else title.strip().lower()
+            )
+            dedup_key = hashlib.sha256(
+                f"inbox_evaluation|{primary}|"
+                f"{(rec.next_step or '').strip().lower()}".encode()
+            ).hexdigest()
+            if await follow_ups.exists_by_dedup_key(self._db, dedup_key):
+                logger.debug("Skipping duplicate inbox follow-up: %s", title)
+                continue
+
             await follow_ups.create(
                 self._db,
                 content=content,
@@ -1500,6 +1537,7 @@ class InboxMonitor:
                 pinned=pinned,
                 # The evaluator already judges each item genesis-vs-user; reuse it.
                 domain="internal" if rec.classification == "genesis" else "user_world",
+                dedup_key=dedup_key,
             )
             created += 1
 

--- a/src/genesis/inbox/scanner.py
+++ b/src/genesis/inbox/scanner.py
@@ -4,10 +4,22 @@ from __future__ import annotations
 
 import hashlib
 import re
+from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 RESPONSE_SUFFIX = ".genesis.md"
+
+# URL extraction (canonical): matches https?://... and bare domain/path
+# patterns like ``search.app/XYZ``. Lives here (the stateless module) so both
+# the monitor and the segmenter share one definition; the monitor re-exports
+# ``extract_urls`` as ``_extract_urls`` for backward compatibility.
+_URL_RE = re.compile(
+    r"(?:https?://[^\s<>\]\)]+)"
+    r"|"
+    r"(?:(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}/[^\s<>\]\)]+)",
+    re.IGNORECASE,
+)
 
 # URL deduplication: strip volatile tracking/share params so the same article
 # re-pasted with different params (e.g. a LinkedIn share from android vs
@@ -152,3 +164,81 @@ def detect_changes(
         elif known_items[key] != current_hash:
             modified.append(f)
     return new, modified
+
+
+def extract_urls(text: str) -> list[str]:
+    """Extract unique URLs from *text*, preserving order of first appearance.
+
+    Trailing sentence punctuation is stripped. Matches both ``https?://`` URLs
+    and bare domain/path forms (e.g. ``search.app/XYZ``). Canonical home for
+    URL extraction; ``monitor._extract_urls`` re-exports this.
+    """
+    seen: set[str] = set()
+    urls: list[str] = []
+    for match in _URL_RE.finditer(text):
+        url = match.group(0).rstrip(".,;:!?)'\"")
+        if url not in seen:
+            seen.add(url)
+            urls.append(url)
+    return urls
+
+
+@dataclass(frozen=True)
+class Item:
+    """A single unit of inbox evaluation carved out of a file's delta.
+
+    ``kind`` is ``"url"`` for a line containing one or more URLs, or
+    ``"note"`` for a contiguous block of non-URL prose. ``text`` is the
+    original (un-normalized) content used for evaluation and for the
+    per-item baseline; ``urls`` lists every URL found in a ``"url"`` item.
+    """
+
+    text: str
+    kind: str
+    urls: list[str] = field(default_factory=list)
+
+
+def segment_items(delta_text: str) -> list[Item]:
+    """Split a file's delta into evaluation items.
+
+    Rules:
+    - A line containing >=1 URL becomes its own ``"url"`` item (a multi-URL
+      line stays one item; all its URLs are listed in ``Item.urls``).
+    - A contiguous run of non-URL, non-blank lines becomes one ``"note"`` item.
+    - Blank lines separate note blocks and are not items themselves.
+    - Within the delta, a URL line is de-duplicated by its tracking-normalized
+      form (the same article re-pasted with different share params → one item),
+      mirroring ``normalize_url_line`` used elsewhere for dedup.
+
+    Order of first appearance is preserved.
+    """
+    items: list[Item] = []
+    note_buf: list[str] = []
+    seen_urls: set[str] = set()
+
+    def _flush_note() -> None:
+        if note_buf:
+            text = "\n".join(note_buf).strip()
+            if text:
+                items.append(Item(text=text, kind="note"))
+            note_buf.clear()
+
+    for raw_line in delta_text.splitlines():
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if not stripped:
+            _flush_note()
+            continue
+        urls = extract_urls(stripped)
+        if urls:
+            # A URL line ends any pending prose block before it.
+            _flush_note()
+            norm = normalize_url_line(stripped)
+            if norm in seen_urls:
+                continue
+            seen_urls.add(norm)
+            items.append(Item(text=stripped, kind="url", urls=urls))
+        else:
+            note_buf.append(line)
+    _flush_note()
+    return items

--- a/src/genesis/inbox/types.py
+++ b/src/genesis/inbox/types.py
@@ -35,6 +35,11 @@ class InboxConfig:
     response_dir: str = "_genesis"
     check_interval_seconds: int = 1800
     batch_size: int = 5
+    # Max evaluation *items* (URLs / prose blocks) per CC call. A file's delta
+    # is segmented into items and grouped into batches of this size, so a
+    # 16-URL drop becomes ~4 evals instead of one mega-batch. ``batch_size``
+    # above is legacy (files-per-cycle) and no longer governs eval grouping.
+    items_per_eval: int = 5
     enabled: bool = True
     model: str = "sonnet"
     effort: str = "high"
@@ -55,15 +60,21 @@ class InboxItem:
     content_hash: str
     detected_at: str
     source_content: str = ""
-    """Full file content at detection time.
+    """The lines this item/batch owns, used both for the eval prompt and for
+    the per-batch baseline merge at completion.
 
-    For new files this equals ``content``.  For modified files
-    ``content`` holds only the delta while ``source_content``
-    preserves the complete file snapshot captured during Phase 3.
-    Used at completion to build a cumulative evaluated-content
-    baseline that survives mid-evaluation file changes (e.g. rclone
-    sync clearing the source while a CC session is running).
+    In the URL-level model an item is ONE eval-batch (<= items_per_eval
+    segmented items from a file's delta), so ``content`` and ``source_content``
+    are the same batch slice — merging ``source_content`` into the file
+    baseline marks exactly this batch's lines evaluated, leaving a failed
+    sibling batch's lines un-baselined for retry.
     """
+    drop_id: str = ""
+    """Groups the eval-batches carved from one file's delta. All batches of a
+    drop share one approval; empty for legacy/singleton rows."""
+    approval_reqid: str = ""
+    """For resume batches: the approval request id (from the awaiting marker)
+    so the drop's approval is consumed once after dispatch."""
 
 
 @dataclass(frozen=True)

--- a/tests/test_inbox/test_crud_drop_batching.py
+++ b/tests/test_inbox/test_crud_drop_batching.py
@@ -36,27 +36,6 @@ async def test_create_persists_drop_id_and_batch_items(db):
 
 
 @pytest.mark.asyncio
-async def test_get_drop_rows_returns_only_that_drop_ordered(db):
-    await _mk(db, id="a", drop_id="D1", created_at="2026-06-30T00:00:01+00:00")
-    await _mk(db, id="b", drop_id="D1", created_at="2026-06-30T00:00:02+00:00")
-    await _mk(db, id="c", drop_id="D2", created_at="2026-06-30T00:00:03+00:00")
-    rows = await inbox_items.get_drop_rows(db, "D1")
-    assert [r["id"] for r in rows] == ["a", "b"]
-
-
-@pytest.mark.asyncio
-async def test_get_pending_drop_rows_excludes_completed(db):
-    await _mk(db, id="a", drop_id="D1", status="completed",
-              created_at="2026-06-30T00:00:01+00:00")
-    await _mk(db, id="b", drop_id="D1", status="pending",
-              created_at="2026-06-30T00:00:02+00:00")
-    await _mk(db, id="c", drop_id="D1", status="processing",
-              created_at="2026-06-30T00:00:03+00:00")
-    rows = await inbox_items.get_pending_drop_rows(db, "D1")
-    assert sorted(r["id"] for r in rows) == ["b", "c"]
-
-
-@pytest.mark.asyncio
 async def test_update_status_for_drop_only_touches_pending_processing(db):
     await _mk(db, id="a", drop_id="D1", status="completed",
               created_at="2026-06-30T00:00:01+00:00")

--- a/tests/test_inbox/test_crud_drop_batching.py
+++ b/tests/test_inbox/test_crud_drop_batching.py
@@ -1,0 +1,99 @@
+"""CRUD tests for inbox drop-batching columns and follow-up dedup."""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import follow_ups, inbox_items
+from genesis.db.schema import create_all_tables
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+async def _mk(db, *, id, drop_id, status="pending", batch_items="x", created_at):
+    await inbox_items.create(
+        db, id=id, file_path="/inbox/Genesis.md", content_hash="h",
+        status=status, created_at=created_at, drop_id=drop_id,
+        batch_items=batch_items,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_persists_drop_id_and_batch_items(db):
+    await _mk(db, id="a", drop_id="D1", batch_items="line1\nline2",
+              created_at="2026-06-30T00:00:00+00:00")
+    row = await inbox_items.get_by_id(db, "a")
+    assert row["drop_id"] == "D1"
+    assert row["batch_items"] == "line1\nline2"
+
+
+@pytest.mark.asyncio
+async def test_get_drop_rows_returns_only_that_drop_ordered(db):
+    await _mk(db, id="a", drop_id="D1", created_at="2026-06-30T00:00:01+00:00")
+    await _mk(db, id="b", drop_id="D1", created_at="2026-06-30T00:00:02+00:00")
+    await _mk(db, id="c", drop_id="D2", created_at="2026-06-30T00:00:03+00:00")
+    rows = await inbox_items.get_drop_rows(db, "D1")
+    assert [r["id"] for r in rows] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_get_pending_drop_rows_excludes_completed(db):
+    await _mk(db, id="a", drop_id="D1", status="completed",
+              created_at="2026-06-30T00:00:01+00:00")
+    await _mk(db, id="b", drop_id="D1", status="pending",
+              created_at="2026-06-30T00:00:02+00:00")
+    await _mk(db, id="c", drop_id="D1", status="processing",
+              created_at="2026-06-30T00:00:03+00:00")
+    rows = await inbox_items.get_pending_drop_rows(db, "D1")
+    assert sorted(r["id"] for r in rows) == ["b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_update_status_for_drop_only_touches_pending_processing(db):
+    await _mk(db, id="a", drop_id="D1", status="completed",
+              created_at="2026-06-30T00:00:01+00:00")
+    await _mk(db, id="b", drop_id="D1", status="pending",
+              created_at="2026-06-30T00:00:02+00:00")
+    await _mk(db, id="c", drop_id="D1", status="processing",
+              created_at="2026-06-30T00:00:03+00:00")
+    n = await inbox_items.update_status_for_drop(
+        db, "D1", status="failed", error_message="superseded",
+        processed_at="2026-06-30T01:00:00+00:00",
+    )
+    assert n == 2
+    assert (await inbox_items.get_by_id(db, "a"))["status"] == "completed"
+    assert (await inbox_items.get_by_id(db, "b"))["status"] == "failed"
+    assert (await inbox_items.get_by_id(db, "c"))["status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_get_awaiting_approval_includes_drop_and_batch_items(db):
+    await _mk(db, id="a", drop_id="D1", status="processing",
+              batch_items="https://x.com/1", created_at="2026-06-30T00:00:01+00:00")
+    await inbox_items.update_status(
+        db, "a", status="processing",
+        error_message=f"{inbox_items.AWAITING_APPROVAL_PREFIX}req-123",
+    )
+    rows = await inbox_items.get_awaiting_approval(db)
+    assert len(rows) == 1
+    assert rows[0]["drop_id"] == "D1"
+    assert rows[0]["batch_items"] == "https://x.com/1"
+
+
+@pytest.mark.asyncio
+async def test_follow_up_dedup_key_create_and_exists(db):
+    assert await follow_ups.exists_by_dedup_key(db, "k1") is False
+    await follow_ups.create(
+        db, content="x", source="inbox_evaluation", strategy="ego_judgment",
+        dedup_key="k1",
+    )
+    assert await follow_ups.exists_by_dedup_key(db, "k1") is True
+    assert await follow_ups.exists_by_dedup_key(db, "k2") is False

--- a/tests/test_inbox/test_drop_dispatch.py
+++ b/tests/test_inbox/test_drop_dispatch.py
@@ -1,0 +1,310 @@
+"""Behavior tests for URL-level drop batching, per-batch baseline, one-approval-
+per-drop, delta-correct resume, and follow-up dedup wiring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import aiosqlite
+import pytest
+
+from genesis.autonomy.autonomous_dispatch import AutonomousDispatchDecision
+from genesis.cc.types import CCOutput
+from genesis.db.crud import follow_ups, inbox_items
+from genesis.db.schema import create_all_tables
+from genesis.inbox.monitor import InboxMonitor
+from genesis.inbox.types import InboxConfig
+from genesis.inbox.writer import ResponseWriter
+
+
+@dataclass
+class _FakeClock:
+    now: datetime = datetime(2026, 6, 30, 12, 0, 0, tzinfo=UTC)
+
+    def __call__(self):
+        return self.now
+
+
+def _ok(text: str = "# Inbox Evaluation\n\nlinkedin evaluation result body") -> CCOutput:
+    return CCOutput(
+        session_id="s", text=text, model_used="sonnet", cost_usd=0.01,
+        input_tokens=10, output_tokens=20, duration_ms=100, exit_code=0,
+    )
+
+
+def _err(msg: str = "boom") -> CCOutput:
+    return CCOutput(
+        session_id="", text="", model_used="sonnet", cost_usd=0.0,
+        input_tokens=0, output_tokens=0, duration_ms=10, exit_code=1,
+        is_error=True, error_message=msg,
+    )
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+@pytest.fixture
+def inbox_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "inbox"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def mock_invoker():
+    inv = AsyncMock()
+    inv.run = AsyncMock(return_value=_ok())
+    return inv
+
+
+@pytest.fixture
+def mock_session_manager():
+    sm = AsyncMock()
+    sm.create_background = AsyncMock(return_value={"id": "sess-1"})
+    sm.complete = AsyncMock()
+    sm.fail = AsyncMock()
+    return sm
+
+
+def _monitor(db, inbox_dir, invoker, sm, tmp_path, *, items_per_eval=3):
+    cfg = InboxConfig(
+        watch_path=inbox_dir, items_per_eval=items_per_eval,
+        evaluation_cooldown_seconds=0,
+    )
+    return InboxMonitor(
+        db=db, invoker=invoker, session_manager=sm, config=cfg,
+        writer=ResponseWriter(watch_path=inbox_dir, timezone="UTC"),
+        clock=_FakeClock(), prompt_dir=tmp_path,
+    )
+
+
+def _urls(n: int) -> str:
+    return "\n".join(f"https://example.com/a{i}" for i in range(n))
+
+
+# ── Batching (gate OFF / no dispatcher) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drop_splits_into_item_batches(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path):
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, items_per_eval=3)
+    (inbox_dir / "Genesis.md").write_text(_urls(7))  # 7 URLs / 3 -> 3 batches
+
+    result = await mon.check_once()
+
+    assert result.batches_dispatched == 3
+    assert mock_invoker.run.call_count == 3
+    # One drop, three completed batch rows.
+    rows = await inbox_items.get_by_file_path(db, str(inbox_dir / "Genesis.md"))
+    all_rows = [dict(r) for r in await (await db.execute(
+        "SELECT status, drop_id FROM inbox_items WHERE file_path LIKE '%Genesis.md'",
+    )).fetchall()]
+    assert len(all_rows) == 3
+    assert len({r["drop_id"] for r in all_rows}) == 1
+    assert all(r["status"] == "completed" for r in all_rows)
+    # Baseline contains all 7 URLs.
+    baseline = await inbox_items.get_evaluated_content(db, str(inbox_dir / "Genesis.md"))
+    for i in range(7):
+        assert f"https://example.com/a{i}" in baseline
+    # Three sibling response files.
+    genesis_files = list(inbox_dir.glob("Genesis-*.genesis.md"))
+    assert len(genesis_files) == 3
+    assert rows is not None
+
+
+@pytest.mark.asyncio
+async def test_partial_batch_failure_baselines_only_successes(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, items_per_eval=3)
+    # 6 URLs -> 2 batches; first succeeds, second errors.
+    mock_invoker.run.side_effect = [_ok(), _err("rate limited")]
+    (inbox_dir / "Genesis.md").write_text(_urls(6))
+
+    await mon.check_once()
+
+    baseline = await inbox_items.get_evaluated_content(db, str(inbox_dir / "Genesis.md")) or ""
+    # Batch 1 (a0..a2) baselined; batch 2 (a3..a5) NOT baselined -> retriable.
+    assert "https://example.com/a0" in baseline
+    assert "https://example.com/a5" not in baseline
+    statuses = sorted(r["status"] for r in [dict(x) for x in await (await db.execute(
+        "SELECT status FROM inbox_items WHERE file_path LIKE '%Genesis.md'",
+    )).fetchall()])
+    assert statuses == ["completed", "failed"]
+
+
+# ── One approval per drop (gate ON) ──────────────────────────────────────
+
+
+def _wired(*, decision, approval_by_id=None):
+    # NB: `is None` check, not `or {}` — an empty dict passed by the caller is
+    # falsy and must be kept (callers mutate it after wiring to flip approval).
+    if approval_by_id is None:
+        approval_by_id = {}
+
+    async def _find_site_pending(*, subsystem, policy_id):
+        return None
+
+    async def _get_by_id(request_id):
+        return approval_by_id.get(request_id)
+
+    gate = SimpleNamespace(
+        find_site_pending=_find_site_pending,
+        approval_manager=SimpleNamespace(
+            get_by_id=_get_by_id, cancel=AsyncMock(return_value=True),
+        ),
+        mark_consumed=AsyncMock(return_value=True),
+    )
+    d = SimpleNamespace()
+    d.route = AsyncMock(return_value=decision)
+    d.approval_gate = gate
+    return d
+
+
+@pytest.mark.asyncio
+async def test_one_approval_per_drop_then_resume_dispatches_all(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, items_per_eval=3)
+    approvals: dict[str, dict] = {}
+    disp = _wired(
+        decision=AutonomousDispatchDecision(
+            mode="blocked", reason="approval requested",
+            approval_request_id="req-1",
+        ),
+        approval_by_id=approvals,
+    )
+    mon._autonomous_dispatcher = disp
+    (inbox_dir / "Genesis.md").write_text(_urls(6))  # 6 URLs -> 1 drop, 2 batches
+
+    # Scan 1: ONE approval requested for the whole drop; both batches parked.
+    r1 = await mon.check_once()
+    assert disp.route.call_count == 1, "exactly one route() per drop"
+    assert r1.batches_dispatched == 0
+    assert mock_invoker.run.call_count == 0
+    parked = await inbox_items.get_awaiting_approval(db)
+    assert len(parked) == 2
+    assert {p["drop_id"] for p in parked} == {parked[0]["drop_id"]}  # same drop
+
+    # User approves -> scan 2 resume dispatches BOTH batches, consumes once.
+    approvals["req-1"] = {"status": "approved"}
+    await mon.check_once()
+    assert mock_invoker.run.call_count == 2, "both batches dispatched on resume"
+    assert disp.route.call_count == 1, "resume does NOT re-route"
+    disp.approval_gate.mark_consumed.assert_awaited_once_with("req-1")
+
+
+@pytest.mark.asyncio
+async def test_gate_off_dispatches_every_batch(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    # No dispatcher wired == gate OFF: every batch dispatches directly.
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, items_per_eval=2)
+    (inbox_dir / "Genesis.md").write_text(_urls(5))  # 5 URLs / 2 -> 3 batches
+    result = await mon.check_once()
+    assert result.batches_dispatched == 3
+    assert mock_invoker.run.call_count == 3
+
+
+# ── Resume uses the persisted batch delta, not a full-file re-read ────────
+
+
+@pytest.mark.asyncio
+async def test_resume_uses_persisted_batch_delta_not_full_file(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """The Genesis-85 fix: an approved resume evaluates ONLY the batch's
+    persisted lines, never a full re-read of the (much larger) file."""
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
+    f = inbox_dir / "Genesis.md"
+    f.write_text(_urls(20))  # big file
+    import hashlib
+    h = hashlib.sha256(
+        "\n".join(line.rstrip() for line in f.read_text().split("\n")).encode()
+    ).hexdigest()
+    # A parked batch that only owns 2 of the 20 URLs.
+    await inbox_items.create(
+        db, id="row-1", file_path=str(f), content_hash=h, status="processing",
+        created_at="2026-06-30T11:00:00+00:00", drop_id="D1",
+        batch_items="https://example.com/a18\nhttps://example.com/a19",
+    )
+    await inbox_items.update_status(
+        db, "row-1", status="processing",
+        error_message=f"{inbox_items.AWAITING_APPROVAL_PREFIX}req-9",
+    )
+    mon._autonomous_dispatcher = _wired(
+        decision=AutonomousDispatchDecision(mode="blocked", reason="pending", approval_request_id="req-9"),
+        approval_by_id={"req-9": {"status": "approved"}},
+    )
+
+    await mon.check_once()
+
+    assert mock_invoker.run.call_count == 1
+    prompt = mock_invoker.run.call_args.args[0].prompt
+    assert "https://example.com/a18" in prompt
+    assert "https://example.com/a19" in prompt
+    assert "https://example.com/a0" not in prompt  # NOT a full-file re-read
+
+
+# ── Follow-up dedup wiring ───────────────────────────────────────────────
+
+
+_REC_OUTPUT = """# Inbox Evaluation — test
+
+## https://example.com/a0
+
+**Classification:** Genesis-relevant | **Decision:** Research
+
+### Recommendation
+
+```yaml
+action: ADAPT
+next_step: "Wire a held-out regression gate into skill_evolution"
+effort: Medium
+scope: V4
+confidence: high
+architecture_impact: extends
+```
+"""
+
+
+@pytest.mark.asyncio
+async def test_follow_up_dedup_same_rec_created_once(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
+    mock_invoker.run.return_value = _ok(_REC_OUTPUT)
+    # Two different files producing the SAME recommendation.
+    (inbox_dir / "Genesis.md").write_text("https://example.com/a0")
+    (inbox_dir / "Other.md").write_text("https://example.com/a0")
+
+    await mon.check_once()
+
+    rows = [dict(r) for r in await (await db.execute(
+        "SELECT id FROM follow_ups WHERE source = 'inbox_evaluation'",
+    )).fetchall()]
+    assert len(rows) == 1, f"expected 1 deduped follow-up, got {len(rows)}"
+
+
+@pytest.mark.asyncio
+async def test_follow_up_dedup_key_persisted(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path):
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
+    mock_invoker.run.return_value = _ok(_REC_OUTPUT)
+    (inbox_dir / "Genesis.md").write_text("https://example.com/a0")
+    await mon.check_once()
+    row = [dict(r) for r in await (await db.execute(
+        "SELECT dedup_key FROM follow_ups WHERE source = 'inbox_evaluation'",
+    )).fetchall()]
+    assert len(row) == 1
+    assert row[0]["dedup_key"]  # non-null
+    assert await follow_ups.exists_by_dedup_key(db, row[0]["dedup_key"]) is True

--- a/tests/test_inbox/test_drop_dispatch.py
+++ b/tests/test_inbox/test_drop_dispatch.py
@@ -205,6 +205,31 @@ async def test_one_approval_per_drop_then_resume_dispatches_all(
 
 
 @pytest.mark.asyncio
+async def test_gate_error_fails_drop_not_stuck_processing(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """If the approval gate's route() raises (transient: net/DB/timeout), the
+    drop's rows are failed (retriable) — NOT left stuck in 'processing' where
+    they'd be invisible to detection until expire_stuck fires."""
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, items_per_eval=2)
+    disp = _wired(decision=AutonomousDispatchDecision(mode="blocked", reason="x"))
+    disp.route = AsyncMock(side_effect=RuntimeError("gate boom"))
+    mon._autonomous_dispatcher = disp
+    (inbox_dir / "Genesis.md").write_text(_urls(4))  # 2 batches
+
+    result = await mon.check_once()
+
+    rows = [dict(r) for r in await (await db.execute(
+        "SELECT status, retry_count FROM inbox_items WHERE file_path LIKE '%Genesis.md'",
+    )).fetchall()]
+    assert rows and all(r["status"] == "failed" for r in rows)
+    # Retriable (not permanently capped) — a transient gate error should retry.
+    assert all(r["retry_count"] < mon._config.max_retries for r in rows)
+    assert any("gate error" in e.lower() for e in result.errors)
+    assert mock_invoker.run.call_count == 0
+
+
+@pytest.mark.asyncio
 async def test_gate_off_dispatches_every_batch(
     db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
 ):

--- a/tests/test_inbox/test_inbox_digest.py
+++ b/tests/test_inbox/test_inbox_digest.py
@@ -38,7 +38,8 @@ async def db():
         pinned INTEGER DEFAULT 0,
         kind TEXT NOT NULL DEFAULT 'follow_up',
         domain TEXT,
-        goal_id TEXT
+        goal_id TEXT,
+        dedup_key TEXT
     )""")
     await conn.execute("""CREATE TABLE inbox_items (
         id TEXT PRIMARY KEY,
@@ -51,7 +52,9 @@ async def db():
         processed_at TEXT,
         error_message TEXT,
         retry_count INTEGER NOT NULL DEFAULT 0,
-        evaluated_content TEXT
+        evaluated_content TEXT,
+        drop_id TEXT,
+        batch_items TEXT
     )""")
     await conn.commit()
     yield conn

--- a/tests/test_inbox/test_monitor.py
+++ b/tests/test_inbox/test_monitor.py
@@ -163,13 +163,16 @@ async def test_already_processed_skipped(monitor, inbox_dir, mock_invoker):
 
 @pytest.mark.asyncio
 async def test_batching_multiple_batches(monitor, inbox_dir, mock_invoker, config):
-    # Create 12 files → should create 3 batches (batch_size=5)
+    # 12 separate files → 12 drops (a drop = ONE file's delta; there is no
+    # cross-file batching). Each single-line file segments to one item → one
+    # batch → one eval. (Within-file batching of ~items_per_eval is covered by
+    # test_drop_dispatch.py.)
     for i in range(12):
         (inbox_dir / f"item-{i:02d}.md").write_text(f"content {i}")
     result = await monitor.check_once()
     assert result.items_new == 12
-    assert result.batches_dispatched == 3
-    assert mock_invoker.run.call_count == 3
+    assert result.batches_dispatched == 12
+    assert mock_invoker.run.call_count == 12
 
 
 @pytest.mark.asyncio
@@ -965,15 +968,15 @@ async def test_dispatch_request_omits_volatile_context(
 
 
 @pytest.mark.asyncio
-async def test_resume_produces_stable_dispatch_across_scans(
+async def test_resume_does_not_reroute_across_scans(
     monitor, inbox_dir, mock_invoker,
 ):
-    """Two scans against the same unchanged pending-approval item must
-    produce dispatch requests with identical prompts, messages, and
-    contexts — the inputs to ``_approval_key``.  This is what guarantees
-    ApprovalManager dedup finds the existing pending request on scan 2
-    and skips the Telegram resend.  Regression guard for the whole
-    fix-it-now motivation: no new Telegram per scan."""
+    """A parked drop is dispatched DIRECTLY on resume — it does not re-enter
+    ``route()`` — so re-scanning a pending item never fires a duplicate
+    approval/Telegram. Regression guard for the whole fix-it-now motivation:
+    exactly ONE route() call across scans for the same content (the old design
+    re-routed every scan and depended on stable-key dedup to suppress the
+    duplicate; the new design simply doesn't re-route)."""
     captured: list[object] = []
 
     async def capture_route(request):
@@ -990,28 +993,24 @@ async def test_resume_produces_stable_dispatch_across_scans(
 
     (inbox_dir / "stable.md").write_text("some content to evaluate")
 
-    # First scan: row created, dispatched, parked
+    # First scan: row created, one approval requested, drop parked.
     await monitor.check_once()
-    # Second scan: resume pass picks up the same row, re-dispatches
+    # Second scan: resume pass dispatches the parked drop directly (no route()).
     await monitor.check_once()
 
-    assert len(captured) == 2, (
-        f"expected 2 dispatch calls, got {len(captured)}"
+    assert len(captured) == 1, (
+        f"expected 1 route() call (resume dispatches directly), "
+        f"got {len(captured)}"
     )
-    req1, req2 = captured[0], captured[1]
-
-    # The fields that feed _approval_key must be byte-identical between
-    # scans.  Any divergence would cause ApprovalManager._find_existing
-    # to miss the match and fire a fresh Telegram.
-    assert req1.subsystem == req2.subsystem
-    assert req1.policy_id == req2.policy_id
-    assert req1.action_label == req2.action_label
-    assert req1.messages == req2.messages
-    assert req1.cli_invocation.prompt == req2.cli_invocation.prompt
-    assert req1.cli_invocation.system_prompt == req2.cli_invocation.system_prompt
-    assert req1.cli_invocation.model == req2.cli_invocation.model
-    assert req1.cli_invocation.effort == req2.cli_invocation.effort
-    assert req1.context == req2.context  # both should be None or equal
+    req = captured[0]
+    # The single request carries the stable-key inputs + null context that keep
+    # the approval content-agnostic and dedupable.
+    assert req.subsystem == "inbox"
+    assert req.policy_id == "inbox_evaluation"
+    assert req.action_label == "inbox evaluation"
+    assert req.approval_key_stable is True
+    assert req.api_call_site_id is None
+    assert req.context is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_inbox/test_segmentation.py
+++ b/tests/test_inbox/test_segmentation.py
@@ -1,0 +1,99 @@
+"""Tests for inbox delta segmentation — splitting a file's delta into items.
+
+An "item" is the unit of evaluation: each URL line is its own item; a
+contiguous block of non-URL prose is a single "note" item. This is what lets
+the monitor evaluate ~5 items per CC call (instead of one mega-batch) and mark
+each item's lines as evaluated independently.
+"""
+
+from __future__ import annotations
+
+from genesis.inbox.scanner import Item, extract_urls, segment_items
+
+
+def test_each_url_line_is_its_own_item():
+    text = "https://a.com/x\nhttps://b.com/y\nhttps://c.com/z"
+    items = segment_items(text)
+    assert [i.kind for i in items] == ["url", "url", "url"]
+    assert [i.text for i in items] == [
+        "https://a.com/x",
+        "https://b.com/y",
+        "https://c.com/z",
+    ]
+
+
+def test_contiguous_prose_is_one_note():
+    text = "This is a note.\nSecond line of the note.\nThird line."
+    items = segment_items(text)
+    assert len(items) == 1
+    assert items[0].kind == "note"
+    assert "Second line" in items[0].text
+    assert items[0].urls == []
+
+
+def test_blank_line_separates_notes():
+    text = "First note block.\n\nSecond note block."
+    items = segment_items(text)
+    assert [i.kind for i in items] == ["note", "note"]
+    assert items[0].text == "First note block."
+    assert items[1].text == "Second note block."
+
+
+def test_url_breaks_prose_into_separate_items():
+    text = "Some prose here\nhttps://a.com/x\nmore prose"
+    items = segment_items(text)
+    assert [i.kind for i in items] == ["note", "url", "note"]
+    assert items[1].text == "https://a.com/x"
+
+
+def test_multiple_urls_on_one_line_is_one_item():
+    text = "https://a.com/x and https://b.com/y"
+    items = segment_items(text)
+    assert len(items) == 1
+    assert items[0].kind == "url"
+    assert len(items[0].urls) == 2
+
+
+def test_duplicate_normalized_url_deduped_within_delta():
+    # Same article re-pasted with different tracking params → one item.
+    text = (
+        "https://a.com/x?utm_source=android\n"
+        "https://a.com/x?utm_source=desktop"
+    )
+    items = segment_items(text)
+    assert len(items) == 1
+
+
+def test_empty_and_whitespace_yields_no_items():
+    assert segment_items("") == []
+    assert segment_items("\n\n   \n") == []
+
+
+def test_blank_lines_inside_prose_close_the_block():
+    # Real Genesis.md shape: URLs separated by blank lines, plus a prose block.
+    text = (
+        "https://venturebeat.com/a\n\n"
+        "# Heading of a pasted note\n"
+        "Body line one.\n"
+        "Body line two.\n\n"
+        "https://linkedin.com/posts/b"
+    )
+    items = segment_items(text)
+    assert [i.kind for i in items] == ["url", "note", "url"]
+    assert "Body line two." in items[1].text
+
+
+def test_extract_urls_matches_http_and_bare_domain():
+    urls = extract_urls("see https://x.com/a and search.app/XYZ here")
+    assert "https://x.com/a" in urls
+    assert "search.app/XYZ" in urls
+
+
+def test_extract_urls_strips_trailing_punctuation_and_dedups():
+    urls = extract_urls("https://x.com/a. https://x.com/a, https://y.com/b!")
+    assert urls == ["https://x.com/a", "https://y.com/b"]
+
+
+def test_item_is_frozen_dataclass():
+    item = Item(text="x", kind="note", urls=[])
+    assert item.text == "x"

--- a/tests/test_inbox/test_url_failures.py
+++ b/tests/test_inbox/test_url_failures.py
@@ -99,7 +99,9 @@ class TestMarkUrlFailure:
                     processed_at TEXT,
                     error_message TEXT,
                     retry_count INTEGER DEFAULT 0,
-                    evaluated_content TEXT
+                    evaluated_content TEXT,
+                    drop_id TEXT,
+                    batch_items TEXT
                 )
             """)
             await conn.commit()
@@ -215,7 +217,9 @@ class TestCountUrlFailures:
                     processed_at TEXT,
                     error_message TEXT,
                     retry_count INTEGER DEFAULT 0,
-                    evaluated_content TEXT
+                    evaluated_content TEXT,
+                    drop_id TEXT,
+                    batch_items TEXT
                 )
             """)
             await conn.commit()


### PR DESCRIPTION
## What & why

The inbox evaluates URLs dropped into a persistent note (delta vs a per-file `evaluated_content` baseline). Forensics on the live data found four defects — acute during a long rate-limit window but **structural**:

1. **"16 evals at once"** — dispatch batched by *file*, so a 16-URL note became one giant CC call.
2. **Re-evaluation of already-seen URLs** — the approval→resume path re-read the *whole file* and discarded the delta (an approved eval re-chewed every URL).
3. **Duplicate follow-ups** — `follow_ups.create` had zero dedup.
4. **Approval/detection "storm"** — *not fixed here* (root cause unproven); this PR ships read-only instrumentation and leaves the amplifier intact for a separate diagnosis track.

## What changed (PR-1)

- **Segment a file's delta into items** (`scanner.segment_items`: each URL line = 1 item; contiguous prose = 1 note), grouped into batches of **`items_per_eval`** (default 5), one `inbox_items` row per batch under a shared `drop_id`. A 16-URL drop → ~4 evals, each its own `Genesis-N.genesis.md`.
- **One approval per drop** (gate ON): a single `route()` per drop; on approval all batches dispatch directly; the approval is consumed once. Works gate ON and OFF.
- **Delta-correct resume**: parked batches re-dispatch from the persisted `batch_items` slice — never a full-file re-read.
- **Per-batch baseline**: each batch merges only its own lines, so a failed sibling batch's lines stay un-baselined and retry.
- **Follow-up dedup** via `dedup_key` (+ partial-unique index).
- **Gate-error safety**: a `route()` exception fails the drop's rows (retriable) instead of leaving them stuck `processing`.
- **Storm instrumentation** (`STORM_DIAG`, read-only) to root-cause the churn after deploy.

Schema: `inbox_items.drop_id`, `inbox_items.batch_items`, `follow_ups.dedup_key` (+ indexes), dual-written into the canonical DDL, the `create_all_tables` path, and numbered migration `0040`.

## Verification

- Tests: `tests/test_inbox` (261), `tests/test_db` (780, incl. migration-runner applying 0040), `tests/test_autonomy/test_executor` (302) — all green. 26 new tests prove the new behavior.
- `genesis-architect` review: 2 BLOCKER + 3 HIGH addressed; mediums deferred with rationale.
- E2E: migration 0040 applies + is idempotent on a copy of the live DB; the Genesis-84 scenario (16 URLs → 4 evals + 4 files; +1 URL → 1 eval seeing only the new URL); a live dry run against real inbox content (real 73-line note → 7 clean evals, 0 stuck rows, 0 errors).

## Deliberately deferred (tracked as follow-ups)

- **Approval storm** root-cause + fix (PR-2): observe via `STORM_DIAG` after deploy; the restart also clears a stale-process confound.
- **Partial-failure auto-retry**: a *partially* failed drop currently retries its failed batches on the next edit to that note (a *totally* failed drop auto-retries). Fixing auto-retry touches the same detection path as the storm, so it's bundled into PR-2.
- **Semantic follow-up dedup**: the `dedup_key` is deterministic (URL/title + next_step); a semantic layer was evaluated and deferred separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)