### PR TITLE
feat(cc): surface model-fallback state on the dashboard and CLI

### DIFF
--- a/scripts/genesis_session_context.py
+++ b/scripts/genesis_session_context.py
@@ -232,6 +232,40 @@ def main() -> None:
             except (OSError, ValueError):
                 pass  # Never block session start
 
+        # Fallback NOTICE (advisory): Genesis's server-side ConversationLoop is
+        # currently running on a roster peer (e.g. GLM) because the home model
+        # (Claude) is rate-limited/exhausted account-wide. This interactive CLI
+        # session runs on CC-native pinned Claude and does NOT fail over itself
+        # (failover is server-side, a different process) — so the [model] header
+        # stays honest and we surface the server's degraded condition here as a
+        # separate block. Read the cross-process state file directly (import-free,
+        # fail-open), mirroring the status.json read above.
+        # Writer: src/genesis/cc/fallback_state.py.
+        _fallback_file = Path.home() / ".genesis" / "cc_fallback_state.json"
+        if _fallback_file.exists():
+            try:
+                import json as _json_fb
+                fb = _json_fb.loads(_fallback_file.read_text())
+                if isinstance(fb, dict) and fb.get("is_fallback"):
+                    peer = fb.get("fallback") or "a roster peer"
+                    home = fb.get("original") or "Claude"
+                    reason = (fb.get("reason") or "unknown").replace("_", " ")
+                    since = str(fb.get("since") or "")
+                    since_disp = (since.replace("T", " ")[:16] + " UTC") if since else "unknown"
+                    if not first:
+                        _emit("\n\n---\n\n")
+                    _emit(
+                        "## ⚠ Genesis Fallback Active\n\n"
+                        f"Genesis's server-side conversation is running on **{peer}** "
+                        f"because **{home}** is unavailable (reason: {reason}; since "
+                        f"{since_disp}). This is account-wide. *Your* interactive session "
+                        "here still runs on native Claude — this notice reflects the "
+                        "Genesis server's state, not this CLI session."
+                    )
+                    first = False
+            except (OSError, ValueError):
+                pass  # Advisory only — never block session start
+
     # 2.5. Active procedures (advisory, silent failure is correct)
     try:
         from genesis.learning.procedural.session_inject import load_active_procedures

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -937,45 +937,27 @@ class ConversationLoop:
             return None
 
     async def _maybe_clear_fallback(self, session: dict) -> None:
-        """On a successful HOME-model turn, clear any prior fallback — the account-
-        wide flag AND this session's sticky peer session — and fire one recovery
-        ALERT. Reached only when the home invocation actually succeeded (= genuine
-        recovery; failover returns early and never falls through to here)."""
+        """On a successful HOME-model turn, clear any prior fallback — this session's
+        sticky peer session (foreground-specific) AND the account-wide flag (via the
+        shared helper, which fires one recovery ALERT). Reached only when the home
+        invocation actually succeeded (= genuine recovery; failover returns early and
+        never falls through to here)."""
         try:
-            from genesis.cc import fallback_state
             if self._session_fallback_session(session) is not None:
                 await self._merge_session_metadata(
                     session["id"], {"fallback_session": None},
                 )
-            if fallback_state.clear():
-                await self._fire_fallback_alert(
-                    topic="cc_fallback_recovery",
-                    context=(
-                        "<b>CC recovered</b>\n\nThe home model is back — replies are "
-                        "running on it again."
-                    ),
-                )
+            from genesis.cc.fallback_recovery import note_home_recovery
+            await note_home_recovery()
         except Exception:
             logger.warning("fallback recovery handling failed", exc_info=True)
 
     async def _fire_fallback_alert(self, *, topic: str, context: str) -> None:
-        """Fire-and-forget ALERT via the outreach pipeline (never crash the turn).
-        ConversationLoop holds no outreach ref, so reach it via the runtime
-        singleton — mirrors the idle-detector access pattern in handle_message."""
-        try:
-            from genesis.runtime import GenesisRuntime
-            pipeline = getattr(GenesisRuntime.instance(), "_outreach_pipeline", None)
-            if pipeline is None:
-                return
-            from genesis.outreach.types import OutreachCategory, OutreachRequest
-            await pipeline.submit(OutreachRequest(
-                category=OutreachCategory.ALERT,
-                topic=topic,
-                context=context,
-                salience_score=0.9,
-            ))
-        except Exception:
-            logger.debug("fallback ALERT dispatch failed", exc_info=True)
+        """Fire-and-forget CC-fallback ALERT (never crash the turn). Delegates to the
+        shared module helper — same impl used for the switch alert here and for
+        background/probe recovery in genesis.cc.fallback_recovery."""
+        from genesis.cc.fallback_recovery import fire_fallback_alert
+        await fire_fallback_alert(topic=topic, context=context)
 
     async def _recover_stale_resume(
         self,

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -690,6 +690,20 @@ class DirectSessionRunner:
             # Persist result in session metadata (merge, don't overwrite)
             await self._store_result(session_id, request, result)
 
+            # Turn-independent fallback recovery: a successful run on the HOME model
+            # proves it's back (no foreground conversation turn needed). "Home" is the
+            # rate-limited model recorded at failover (state.original) — which may be a
+            # roster PEER when the configured default is non-Claude, NOT necessarily
+            # native Claude. A success on any OTHER model (incl. an intentional native
+            # pin while a peer is the down home) must NOT clear the fallback.
+            if result.success:
+                from genesis.cc import fallback_state
+                from genesis.cc.fallback_recovery import note_home_recovery
+
+                st = fallback_state.read()
+                if st.is_fallback and result.roster_model == (st.original or roster.CLAUDE):
+                    await note_home_recovery()
+
             # Feed outcome back to ego proposal if this was a proposal dispatch
             await self._record_proposal_outcome(request, result)
 

--- a/src/genesis/cc/fallback_recovery.py
+++ b/src/genesis/cc/fallback_recovery.py
@@ -1,0 +1,76 @@
+"""Account-wide CC fallback recovery — shared across every home-success path.
+
+When Claude is rate-limited account-wide, conversation turns fail over to a
+roster peer and ``fallback_state`` records the degraded condition. Recovery
+(Claude is back) CANNOT be inferred from the resilience state machine or the CC
+budget tracker — both track Genesis's *self-imposed* throttle (session-spawn
+rate) and latched invoker errors, NOT Anthropic's real rate-limit state. The
+only proof the home model is back is a home-model call that actually succeeds.
+
+So every home-model success funnels through :func:`note_home_recovery`:
+- foreground conversation turns (``conversation._maybe_clear_fallback``),
+- background DirectSession runs (``direct_session`` success path),
+- the slow safety probe for a totally-idle system
+  (``resilience.cc_fallback_probe``).
+
+All functions here are fire-and-forget and never raise — they sit on success
+paths that must not be broken by recovery bookkeeping.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def fire_fallback_alert(*, topic: str, context: str) -> None:
+    """Fire-and-forget CC-fallback ALERT via the outreach pipeline.
+
+    Reaches the pipeline through the runtime singleton (call sites here hold no
+    outreach ref). No-ops cleanly when the runtime/pipeline is absent (tests,
+    early startup). Never raises.
+    """
+    try:
+        from genesis.runtime import GenesisRuntime
+
+        pipeline = getattr(GenesisRuntime.instance(), "_outreach_pipeline", None)
+        if pipeline is None:
+            return
+        from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+        await pipeline.submit(OutreachRequest(
+            category=OutreachCategory.ALERT,
+            topic=topic,
+            context=context,
+            salience_score=0.9,
+        ))
+    except Exception:
+        logger.debug("fallback ALERT dispatch failed", exc_info=True)
+
+
+async def note_home_recovery() -> bool:
+    """Clear account-wide fallback after a confirmed home-model success.
+
+    Idempotent: ``fallback_state.clear()`` only transitions active→inactive once,
+    so the recovery ALERT fires exactly once per outage no matter how many home
+    successes race in. Returns True only on that transition. Never raises.
+
+    Note: this clears only the ACCOUNT-WIDE flag. The per-conversation sticky peer
+    session (``cc_sessions.metadata.fallback_session``) is foreground-specific and
+    is cleared by ``conversation._maybe_clear_fallback`` around this call.
+    """
+    try:
+        from genesis.cc import fallback_state
+
+        if fallback_state.clear():
+            await fire_fallback_alert(
+                topic="cc_fallback_recovery",
+                context=(
+                    "<b>CC recovered</b>\n\nThe home model is back — replies are "
+                    "running on it again."
+                ),
+            )
+            return True
+    except Exception:
+        logger.warning("fallback recovery handling failed", exc_info=True)
+    return False

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -4544,6 +4544,15 @@
               @click="location.hash = 'backup'">Backup & Updates</button>
     </nav>
 
+    <!-- CC model-fallback banner (page-top, full-width, visible on every tab):
+         the server-side conversation is failed over to a roster peer because the
+         home model (Claude) is rate-limited account-wide. Placed here (block flow,
+         outside the flex-row .panel) so it renders as a slim top bar, not a column. -->
+    <template x-if="$store.genesisDashboard.health.cc_sessions?.fallback?.is_fallback">
+      <div style="background: #f0ad4e; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center;"
+           x-text="'⚠ Running on ' + ($store.genesisDashboard.health.cc_sessions.fallback.fallback || 'a roster peer') + ' — Claude ' + ($store.genesisDashboard.health.cc_sessions.fallback.reason || 'unavailable').replace(/_/g, ' ') + ' since ' + (($store.genesisDashboard.health.cc_sessions.fallback.since || '').replace('T', ' ').slice(0, 16) || 'unknown')"></div>
+    </template>
+
     <!-- Panel 1: System Health [Tab: overview] -->
     <div class="panel" x-show="$store.genesisDashboard.activeTab === 'overview'">
       <div class="panel-header">
@@ -4570,11 +4579,6 @@
         <div style="background: #f0ad4e; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center;">
           Genesis is paused — background processing suspended. Use the pause button or /pause off in Telegram to resume.
         </div>
-      </template>
-      <!-- CC model-fallback banner: conversation failover to a roster peer (Claude unavailable) -->
-      <template x-if="$store.genesisDashboard.health.cc_sessions?.fallback?.is_fallback">
-        <div style="background: #f0ad4e; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center;"
-             x-text="'⚠ Running on ' + ($store.genesisDashboard.health.cc_sessions.fallback.fallback || 'a roster peer') + ' — Claude ' + ($store.genesisDashboard.health.cc_sessions.fallback.reason || 'unavailable').replace(/_/g, ' ') + ' since ' + (($store.genesisDashboard.health.cc_sessions.fallback.since || '').replace('T', ' ').slice(0, 16) || 'unknown')"></div>
       </template>
       <!-- Resilience degradation banner -->
       <template x-if="$store.genesisDashboard.health.resilience?.level && $store.genesisDashboard.health.resilience.level !== 'L0' && $store.genesisDashboard.health.resilience.level !== 'not configured'">

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -3072,8 +3072,15 @@
           const cc = this.health.cc_sessions;
           if (!cc) return { state: "unknown", reason: "CC session data unavailable" };
           const rt = cc.realtime_status;
+          // A hard contingency outage (UNAVAILABLE, never auto-reconciled) outranks
+          // fallback: don't paint a red outage yellow if is_fallback is stale.
           if (rt === "UNAVAILABLE") {
             return { state: "error", reason: "CC is unavailable — contingency mode active" };
+          }
+          // Fallback is more specific than the rate-limit that triggered it, so it
+          // takes precedence over the RATE_LIMITED/THROTTLED branch below.
+          if (cc.fallback?.is_fallback) {
+            return { state: "fallback", reason: `running on ${cc.fallback.fallback || 'a roster peer'} (Claude ${(cc.fallback.reason || 'unavailable').replace(/_/g, ' ')})` };
           }
           if (rt === "RATE_LIMITED" || rt === "THROTTLED") {
             return { state: "degraded", reason: `CC is ${rt.toLowerCase().replace('_', '-')}` };
@@ -4564,6 +4571,11 @@
           Genesis is paused — background processing suspended. Use the pause button or /pause off in Telegram to resume.
         </div>
       </template>
+      <!-- CC model-fallback banner: conversation failover to a roster peer (Claude unavailable) -->
+      <template x-if="$store.genesisDashboard.health.cc_sessions?.fallback?.is_fallback">
+        <div style="background: #f0ad4e; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center;"
+             x-text="'⚠ Running on ' + ($store.genesisDashboard.health.cc_sessions.fallback.fallback || 'a roster peer') + ' — Claude ' + ($store.genesisDashboard.health.cc_sessions.fallback.reason || 'unavailable').replace(/_/g, ' ') + ' since ' + (($store.genesisDashboard.health.cc_sessions.fallback.since || '').replace('T', ' ').slice(0, 16) || 'unknown')"></div>
+      </template>
       <!-- Resilience degradation banner -->
       <template x-if="$store.genesisDashboard.health.resilience?.level && $store.genesisDashboard.health.resilience.level !== 'L0' && $store.genesisDashboard.health.resilience.level !== 'not configured'">
         <div :style="`background: ${['L3', 'L4', 'L5', 'error'].includes($store.genesisDashboard.health.resilience.level) ? '#d9534f' : '#f0ad4e'}; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center; overflow-wrap: break-word; white-space: normal; line-height: 1.3;`"
@@ -4677,6 +4689,10 @@
             <template x-if="($store.genesisDashboard.health.cc_sessions?.failed_24h || 0) > 0">
               <div class="health-card-detail" style="color: #d9534f; font-weight: 600;"
                    x-text="$store.genesisDashboard.health.cc_sessions.failed_24h + ' failed (24h)'"></div>
+            </template>
+            <template x-if="$store.genesisDashboard.health.cc_sessions?.fallback?.is_fallback">
+              <div class="health-card-detail" style="color: #f0ad4e; font-weight: 600;"
+                   x-text="'on ' + ($store.genesisDashboard.health.cc_sessions.fallback.fallback || 'roster peer') + ' since ' + (($store.genesisDashboard.health.cc_sessions.fallback.since || '').replace('T', ' ').slice(0, 16) || 'unknown')"></div>
             </template>
             <div class="health-card-reason" x-text="$store.genesisDashboard.ccSemantic().reason"></div>
           </div>

--- a/src/genesis/observability/snapshots/cc_sessions.py
+++ b/src/genesis/observability/snapshots/cc_sessions.py
@@ -15,13 +15,40 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _fallback_snapshot() -> dict:
+    """Account-wide CC fallback state for the dashboard CC card. Never raises.
+
+    Reads the cross-process record written by the conversation-failover path
+    (``genesis/cc/fallback_state.py``). Cheap (one small file read, no DB) and
+    safe on the snapshot hot path — any error degrades to "not in fallback".
+    """
+    try:
+        from genesis.cc.fallback_state import read as read_fallback_state
+
+        st = read_fallback_state()
+        return {
+            "is_fallback": st.is_fallback,
+            "original": st.original,
+            "fallback": st.fallback,
+            "reason": st.reason,
+            "since": st.since,
+        }
+    except Exception:
+        logger.debug("fallback_state read failed", exc_info=True)
+        return {"is_fallback": False, "original": "", "fallback": "", "reason": "", "since": ""}
+
+
 async def cc_sessions(
     db: aiosqlite.Connection | None,
     cc_budget: CCBudgetTracker | None,
     state_machine: ResilienceStateMachine | None,
 ) -> dict:
     if not db:
-        return {"foreground": {"status": "unknown"}, "background": {"status": "unknown"}}
+        return {
+            "foreground": {"status": "unknown"},
+            "background": {"status": "unknown"},
+            "fallback": _fallback_snapshot(),
+        }
 
     try:
         cursor = await db.execute(
@@ -175,4 +202,5 @@ async def cc_sessions(
         "total_tokens_today": total_tokens_today,
         "rate_limited_24h": rate_limited_24h,
         "realtime_status": cc_realtime_status,
+        "fallback": _fallback_snapshot(),
     }

--- a/src/genesis/resilience/cc_fallback_probe.py
+++ b/src/genesis/resilience/cc_fallback_probe.py
@@ -40,6 +40,7 @@ class CCFallbackProbeWorker:
         self._task: asyncio.Task | None = None
 
     def start(self) -> None:
+        """Start the probe loop (idempotent — no-op if a task is already running)."""
         if self._task is None or self._task.done():
             self._task = asyncio.create_task(self._loop())
             logger.info(
@@ -47,6 +48,7 @@ class CCFallbackProbeWorker:
             )
 
     async def stop(self) -> None:
+        """Cancel the probe loop and wait for it to unwind (idempotent)."""
         if self._task is not None:
             self._task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/src/genesis/resilience/cc_fallback_probe.py
+++ b/src/genesis/resilience/cc_fallback_probe.py
@@ -1,0 +1,113 @@
+"""Safety-net probe for total-idle CC fallback recovery.
+
+While CC is in account-wide fallback (Claude rate-limited, running on a roster
+peer), recovery is normally detected by the next successful HOME-model call —
+a foreground turn or any background DirectSession (see
+``genesis.cc.fallback_recovery``). But a *totally* idle system makes no home
+calls at all, so the dashboard banner + CLI notice could assert a stale
+fallback after Claude has actually recovered.
+
+This worker closes that gap: on a slow cadence, and ONLY while in fallback, it
+makes one minimal native-Claude call. Success ⇒ Claude is back ⇒ clear the flag
+(via the shared ``note_home_recovery``). This is the *only* way to detect
+Anthropic-side recovery without traffic — the resilience state machine and CC
+budget tracker track Genesis's self-imposed throttle, not Anthropic availability.
+
+The cadence is deliberately slow (30 min): real turns/background sessions clear
+fallback far sooner in an active system, so this is purely the idle backstop. A
+probe during an outage just fails fast with a rate-limit error (cheap); it only
+costs a real (minimal) Claude call on the cycle where recovery is detected.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Slow backstop: foreground/background success clears fallback much faster in an
+# active system; this only matters when nothing else is talking to the home model.
+_PROBE_INTERVAL_S = 1800  # 30 minutes
+
+
+class CCFallbackProbeWorker:
+    """Periodically probes the home model while in fallback; clears on recovery."""
+
+    def __init__(self, *, invoker, interval_s: int = _PROBE_INTERVAL_S) -> None:
+        self._invoker = invoker
+        self._interval_s = interval_s
+        self._task: asyncio.Task | None = None
+
+    def start(self) -> None:
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._loop())
+            logger.info(
+                "CC fallback probe worker started (interval=%ds)", self._interval_s,
+            )
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+            logger.info("CC fallback probe worker stopped")
+
+    async def _loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(self._interval_s)
+                await self._probe_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning("CC fallback probe iteration failed", exc_info=True)
+
+    async def _probe_once(self) -> None:
+        """One probe cycle: no-op unless in fallback; minimal HOME-model call; clear
+        on OK. The home model is whatever was rate-limited (``state.original``) —
+        which may be a roster PEER when the configured default is non-Claude, NOT
+        necessarily native Claude. Probing the wrong model would falsely clear a
+        peer outage (Claude is ~always up)."""
+        from genesis.cc import fallback_state, roster
+
+        state = fallback_state.read()
+        if not state.is_fallback:
+            return  # only probe while degraded — zero cost in the normal state
+
+        from genesis.cc.exceptions import CCQuotaExhaustedError, CCRateLimitError
+        from genesis.cc.types import CCInvocation, CCModel, EffortLevel
+
+        home = state.original or roster.CLAUDE
+        try:
+            # {} for native Claude; the peer's endpoint+token otherwise. Pre-stamped
+            # so the invoker routes to the HOME model; roster_eligible=False keeps the
+            # chokepoint from re-selecting the global default over it.
+            overrides = roster.overrides_for(home)
+        except roster.RosterError:
+            logger.warning("CC fallback probe: cannot resolve home model %r", home)
+            return
+
+        # Minimal call: bare (no system prompt / MCP), cheapest effort.
+        inv = CCInvocation(
+            prompt="ping",
+            model=CCModel.SONNET,
+            effort=EffortLevel.LOW,
+            bare=True,
+            roster_eligible=False,
+            **overrides,
+        )
+        try:
+            output = await self._invoker.run(inv)
+        except (CCRateLimitError, CCQuotaExhaustedError):
+            logger.info("CC fallback probe: home model %r still rate-limited", home)
+            return
+
+        if output is not None and not output.is_error:
+            from genesis.cc.fallback_recovery import note_home_recovery
+
+            if await note_home_recovery():
+                logger.info(
+                    "CC fallback probe: home model %r recovered — fallback cleared", home,
+                )

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -178,6 +178,7 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
         self._router: Router | None = None
         self._reflection_engine: object | None = None
         self._cc_invoker: AgentProvider | None = None
+        self._cc_fallback_probe_worker: object | None = None
         self._session_manager: SessionManager | None = None
         self._checkpoint_manager: CheckpointManager | None = None
         self._cc_reflection_bridge: CCReflectionBridge | None = None
@@ -510,6 +511,7 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
             ("learning_scheduler", self._learning_scheduler),
             ("campaign_runner", self._campaign_runner),
             ("awareness_loop", self._awareness_loop),
+            ("cc_fallback_probe", self._cc_fallback_probe_worker),
         ]:
             if component is None:
                 continue

--- a/src/genesis/runtime/init/cc_relay.py
+++ b/src/genesis/runtime/init/cc_relay.py
@@ -81,6 +81,18 @@ async def init(rt: GenesisRuntime) -> None:
             on_cc_status_change=_on_cc_status_change,
             on_model_downgrade=_on_model_downgrade,
         )
+
+        # CC fallback recovery safety probe — clears a stale account-wide fallback
+        # flag during total idle (no foreground/background home calls to detect
+        # Anthropic recovery on their own). Slow cadence; no-op unless in fallback.
+        try:
+            from genesis.resilience.cc_fallback_probe import CCFallbackProbeWorker
+
+            rt._cc_fallback_probe_worker = CCFallbackProbeWorker(invoker=rt._cc_invoker)
+            rt._cc_fallback_probe_worker.start()
+        except Exception:
+            logger.warning("Failed to start CC fallback probe worker", exc_info=True)
+
         rt._session_manager = SessionManager(
             db=rt._db,
             invoker=rt._cc_invoker,

--- a/tests/test_cc/test_conversation_failover.py
+++ b/tests/test_cc/test_conversation_failover.py
@@ -178,17 +178,21 @@ async def test_streaming_failover_when_nothing_streamed(loop, invoker):
 
 
 @pytest.mark.asyncio
-async def test_recovery_clears_state_and_alerts(loop, invoker):
+async def test_recovery_clears_state_and_alerts(loop, invoker, monkeypatch):
     # Pre-existing fallback → a successful HOME turn clears it + fires recovery ALERT.
+    # Recovery now routes through the shared helper (foreground/background/probe all
+    # share genesis.cc.fallback_recovery), so assert on that module function.
     fallback_state.enter("claude", "glm-5.2", "rate_limit")
     assert fallback_state.read().is_fallback is True
+    fired = AsyncMock()
+    monkeypatch.setattr("genesis.cc.fallback_recovery.fire_fallback_alert", fired)
     invoker.run = AsyncMock(return_value=_output(
         text="home reply", roster_model="claude", session_id="cc-home",
     ))
     result = await loop.handle_message("hi", user_id="u1", channel=ChannelType.TERMINAL)
     assert "home reply" in result
     assert fallback_state.read().is_fallback is False
-    loop._fire_fallback_alert.assert_awaited()  # recovery ALERT
+    fired.assert_awaited()  # recovery ALERT via shared helper
 
 
 @pytest.mark.asyncio

--- a/tests/test_cc/test_direct_session.py
+++ b/tests/test_cc/test_direct_session.py
@@ -169,3 +169,63 @@ class TestSpawnRecordsSkillSignal:
 
         report = await SkillEffectivenessAnalyzer().analyze(db, "research")
         assert report.usage_count == 0  # profile match must not count as skill usage
+
+
+class TestBackgroundFallbackRecovery:
+    """A successful background run clears account-wide CC fallback only when it ran
+    on the HOME model (the rate-limited one recorded at failover, state.original) —
+    which may be a roster PEER when the default is non-Claude. A success on any
+    OTHER model must NOT clear. GENESIS_HOME is redirected so the real state file is
+    untouched."""
+
+    async def _run(self, db, tmp_path, monkeypatch, *, home: str, roster_model: str):
+        from types import SimpleNamespace
+
+        from genesis.cc import fallback_state
+        from genesis.cc.types import CCInvocation, CCModel, CCOutput, EffortLevel, SessionType
+
+        monkeypatch.setenv("GENESIS_HOME", str(tmp_path))
+        fallback_state.clear()
+        peer = "glm-5.2" if home == "claude" else "claude"
+        fallback_state.enter(home, peer, "rate_limit")  # original=home
+
+        sm = SessionManager(db=db, invoker=AsyncMock(), day_boundary_hour=0)
+        invoker = AsyncMock()
+        invoker.run_streaming = AsyncMock(return_value=CCOutput(
+            session_id="cc-bg", text="done", model_used=roster_model or "claude",
+            cost_usd=0.0, input_tokens=1, output_tokens=1, duration_ms=1, exit_code=0,
+            is_error=False, roster_model=roster_model,
+        ))
+        runner = DirectSessionRunner(
+            invoker=invoker, session_manager=sm, config_builder=AsyncMock(),
+            runtime=SimpleNamespace(_db=db),
+        )
+        runner._build_invocation = lambda _req: CCInvocation(prompt="x")
+        sess = await sm.create_background(
+            session_type=SessionType.BACKGROUND_TASK,
+            model=CCModel.SONNET, effort=EffortLevel.MEDIUM,
+        )
+        result = await runner._run_session(DirectSessionRequest(prompt="t"), sess["id"])
+        assert result.success is True
+        state = fallback_state.read()
+        fallback_state.clear()
+        return state
+
+    async def test_home_claude_success_clears(self, db, tmp_path, monkeypatch):
+        state = await self._run(db, tmp_path, monkeypatch, home="claude", roster_model="claude")
+        assert state.is_fallback is False  # home (claude) success → cleared
+
+    async def test_peer_success_with_claude_home_does_not_clear(self, db, tmp_path, monkeypatch):
+        state = await self._run(db, tmp_path, monkeypatch, home="claude", roster_model="glm-5.2")
+        assert state.is_fallback is True  # glm run doesn't prove claude back
+
+    async def test_home_peer_success_clears(self, db, tmp_path, monkeypatch):
+        # default=peer: home is glm-5.2; a successful glm run is the recovery signal.
+        state = await self._run(db, tmp_path, monkeypatch, home="glm-5.2", roster_model="glm-5.2")
+        assert state.is_fallback is False
+
+    async def test_native_claude_success_with_peer_home_does_not_clear(self, db, tmp_path, monkeypatch):
+        # The bug case: home is glm-5.2 (down); an intentional native-Claude run
+        # succeeds but must NOT clear the glm fallback (Claude is ~always up).
+        state = await self._run(db, tmp_path, monkeypatch, home="glm-5.2", roster_model="claude")
+        assert state.is_fallback is True

--- a/tests/test_cc/test_direct_session.py
+++ b/tests/test_cc/test_direct_session.py
@@ -211,19 +211,23 @@ class TestBackgroundFallbackRecovery:
         fallback_state.clear()
         return state
 
+    @pytest.mark.asyncio
     async def test_home_claude_success_clears(self, db, tmp_path, monkeypatch):
         state = await self._run(db, tmp_path, monkeypatch, home="claude", roster_model="claude")
         assert state.is_fallback is False  # home (claude) success → cleared
 
+    @pytest.mark.asyncio
     async def test_peer_success_with_claude_home_does_not_clear(self, db, tmp_path, monkeypatch):
         state = await self._run(db, tmp_path, monkeypatch, home="claude", roster_model="glm-5.2")
         assert state.is_fallback is True  # glm run doesn't prove claude back
 
+    @pytest.mark.asyncio
     async def test_home_peer_success_clears(self, db, tmp_path, monkeypatch):
         # default=peer: home is glm-5.2; a successful glm run is the recovery signal.
         state = await self._run(db, tmp_path, monkeypatch, home="glm-5.2", roster_model="glm-5.2")
         assert state.is_fallback is False
 
+    @pytest.mark.asyncio
     async def test_native_claude_success_with_peer_home_does_not_clear(self, db, tmp_path, monkeypatch):
         # The bug case: home is glm-5.2 (down); an intentional native-Claude run
         # succeeds but must NOT clear the glm fallback (Claude is ~always up).

--- a/tests/test_cc/test_fallback_recovery.py
+++ b/tests/test_cc/test_fallback_recovery.py
@@ -1,0 +1,105 @@
+"""Turn-independent CC fallback recovery — note_home_recovery + the safety probe.
+
+GENESIS_HOME is redirected to a temp dir (autouse fixture) so these never touch
+the real ~/.genesis/cc_fallback_state.json the live server reads.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from genesis.cc import fallback_state
+from genesis.cc.exceptions import CCRateLimitError
+from genesis.cc.fallback_recovery import note_home_recovery
+from genesis.cc.types import CCOutput
+from genesis.resilience.cc_fallback_probe import CCFallbackProbeWorker
+
+
+def _output(*, is_error: bool = False, roster_model: str = "claude") -> CCOutput:
+    return CCOutput(
+        session_id="probe-1", text="pong", model_used="claude", cost_usd=0.0,
+        input_tokens=1, output_tokens=1, duration_ms=1, exit_code=0 if not is_error else 1,
+        is_error=is_error, roster_model=roster_model,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("GENESIS_HOME", str(tmp_path))
+    fallback_state.clear()
+    yield
+    fallback_state.clear()
+
+
+class TestNoteHomeRecovery:
+    @pytest.mark.asyncio
+    async def test_clears_active_and_returns_true(self):
+        fallback_state.enter("claude", "glm-5.2", "rate_limit")
+        assert await note_home_recovery() is True
+        assert fallback_state.read().is_fallback is False
+
+    @pytest.mark.asyncio
+    async def test_noop_when_inactive(self):
+        assert await note_home_recovery() is False
+
+    @pytest.mark.asyncio
+    async def test_idempotent_second_call(self):
+        fallback_state.enter("claude", "glm-5.2", "rate_limit")
+        assert await note_home_recovery() is True
+        assert await note_home_recovery() is False  # already cleared → fires once
+
+
+class TestProbeWorker:
+    @pytest.fixture
+    def _stub_overrides(self, monkeypatch):
+        """Record overrides_for() calls and return {} (no real config/keys needed)."""
+        from genesis.cc import roster
+
+        calls: list[str] = []
+        monkeypatch.setattr(roster, "overrides_for", lambda name, *a, **k: calls.append(name) or {})
+        return calls
+
+    @pytest.mark.asyncio
+    async def test_noop_when_not_in_fallback(self, _stub_overrides):
+        invoker = AsyncMock()
+        invoker.run = AsyncMock()
+        await CCFallbackProbeWorker(invoker=invoker)._probe_once()
+        invoker.run.assert_not_awaited()  # zero cost in the healthy state
+        assert _stub_overrides == []  # never resolved a model when healthy
+
+    @pytest.mark.asyncio
+    async def test_clears_on_home_success(self, _stub_overrides):
+        fallback_state.enter("claude", "glm-5.2", "rate_limit")
+        invoker = AsyncMock()
+        invoker.run = AsyncMock(return_value=_output())
+        await CCFallbackProbeWorker(invoker=invoker)._probe_once()
+        invoker.run.assert_awaited_once()
+        assert fallback_state.read().is_fallback is False
+
+    @pytest.mark.asyncio
+    async def test_probes_the_actual_home_model_not_native_claude(self, _stub_overrides):
+        # default=peer: home is glm-5.2. The probe MUST resolve overrides for glm-5.2
+        # (the down model), not hardcode native Claude — else it would falsely clear.
+        fallback_state.enter("glm-5.2", "claude", "rate_limit")
+        invoker = AsyncMock()
+        invoker.run = AsyncMock(return_value=_output(roster_model="glm-5.2"))
+        await CCFallbackProbeWorker(invoker=invoker)._probe_once()
+        assert _stub_overrides == ["glm-5.2"]  # probed the HOME model
+        assert fallback_state.read().is_fallback is False
+
+    @pytest.mark.asyncio
+    async def test_stays_in_fallback_on_rate_limit(self, _stub_overrides):
+        fallback_state.enter("claude", "glm-5.2", "rate_limit")
+        invoker = AsyncMock()
+        invoker.run = AsyncMock(side_effect=CCRateLimitError("still down"))
+        await CCFallbackProbeWorker(invoker=invoker)._probe_once()
+        assert fallback_state.read().is_fallback is True  # not cleared
+
+    @pytest.mark.asyncio
+    async def test_stays_in_fallback_on_error_output(self, _stub_overrides):
+        fallback_state.enter("claude", "glm-5.2", "rate_limit")
+        invoker = AsyncMock()
+        invoker.run = AsyncMock(return_value=_output(is_error=True))
+        await CCFallbackProbeWorker(invoker=invoker)._probe_once()
+        assert fallback_state.read().is_fallback is True

--- a/tests/test_health_data.py
+++ b/tests/test_health_data.py
@@ -178,6 +178,50 @@ class TestCCSessions:
         # 2 background_reflection + 1 background_task = 3 background
         assert snap["cc_sessions"]["background"]["active"] == 3
 
+    @pytest.mark.asyncio
+    async def test_cc_sessions_fallback_active_and_cleared(self, db, tmp_path, monkeypatch):
+        """The snapshot exposes account-wide CC fallback state for the dashboard.
+
+        GENESIS_HOME is redirected to a temp dir so this never touches the real
+        ~/.genesis/cc_fallback_state.json (the live server reads it).
+        """
+        from genesis.cc import fallback_state
+
+        monkeypatch.setenv("GENESIS_HOME", str(tmp_path))
+        fallback_state.clear()  # clean slate in the temp home
+
+        svc = HealthDataService(db=db)
+        snap = await svc.snapshot()
+        assert snap["cc_sessions"]["fallback"]["is_fallback"] is False
+
+        fallback_state.enter("claude", "glm-5.2", "rate_limit")
+        snap2 = await svc.snapshot()
+        fb = snap2["cc_sessions"]["fallback"]
+        assert fb["is_fallback"] is True
+        assert fb["fallback"] == "glm-5.2"
+        assert fb["original"] == "claude"
+        assert fb["reason"] == "rate_limit"
+        assert fb["since"]  # non-empty ISO timestamp
+
+        fallback_state.clear()
+        snap3 = await svc.snapshot()
+        assert snap3["cc_sessions"]["fallback"]["is_fallback"] is False
+
+    @pytest.mark.asyncio
+    async def test_cc_sessions_fallback_present_without_db(self, tmp_path, monkeypatch):
+        """The no-db early return still carries the fallback key (shape consistency)."""
+        from genesis.cc import fallback_state
+        from genesis.observability.snapshots.cc_sessions import cc_sessions as cc_snapshot
+
+        monkeypatch.setenv("GENESIS_HOME", str(tmp_path))
+        fallback_state.enter("claude", "glm-5.2", "rate_limit")
+        try:
+            snap = await cc_snapshot(None, None, None)
+            assert snap["fallback"]["is_fallback"] is True
+            assert snap["fallback"]["fallback"] == "glm-5.2"
+        finally:
+            fallback_state.clear()
+
 
 class TestInfrastructure:
     @pytest.mark.asyncio


### PR DESCRIPTION
## What

When Claude is rate-limited account-wide and Genesis fails the conversation over to a roster peer (e.g. GLM), that degraded condition is now **visible** instead of silent:

- **Dashboard** — a slim page-top banner (`⚠ Running on <peer> — Claude <reason> since <time>`), and the CC Sessions card goes to a `fallback` state with a badge naming the active peer and since-time. Driven by a new `fallback` field on the CC sessions health snapshot (no new route).
- **Interactive CLI session start** — an advisory "Genesis Fallback Active" notice. The `[model]` header stays honest: interactive sessions run on native Claude and don't fail over; the notice reflects the *server's* state.

## Recovery is now turn-independent

Previously the fallback flag only cleared on a successful foreground turn, so the indicators could go stale during idle. Now it clears on **any** successful home-model call — foreground turns and background sessions — plus a slow safety probe for a totally idle system. Recovery is anchored on the actual rate-limited home model, so a success on a different model never clears it prematurely.

## Notes

- Honest precedence: a hard `UNAVAILABLE` (contingency) outranks the fallback indicator, so a real outage is never shown as a softer "fallback".
- Internal-facing surfaces only (dashboard + CLI session context).

## Verification

- Targeted unit tests for the snapshot field, the shared recovery helper, the background-session clear, and the safety probe.
- Session-start hook exercised end-to-end (notice shows when active, absent when cleared).
- Dashboard rendering verified in a real browser: active → top banner + degraded card with badge; cleared → hidden, card back to healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)