### PR TITLE
fix(inbox): baseline read order by processed_at (reuse breaks created_at sort)

### DIFF
--- a/src/genesis/db/crud/inbox_items.py
+++ b/src/genesis/db/crud/inbox_items.py
@@ -298,13 +298,17 @@ async def get_last_completed_at(
     Includes both normal evaluations (with response files) and Acknowledged
     items (no response file) so cooldown applies uniformly.
 
-    Orders by processed_at (completion time), not created_at, so a reused row
-    (which keeps its old created_at via reuse_as_pending) doesn't make the
-    cooldown read a stale completion time. See get_evaluated_content.
+    Orders by processed_at (completion time), not created_at, so a row that was
+    detected long ago but completed recently (e.g. parked for approval, then
+    approved) reports its true completion time. The ``processed_at IS NOT NULL``
+    guard excludes the meta completed rows (empty-file / no-new-content) that
+    are written without a processed_at — without it those NULLs (which sort last
+    under DESC) could leak as the return value when no real completion exists.
     """
     cursor = await db.execute(
         """SELECT processed_at FROM inbox_items
            WHERE file_path = ? AND status = 'completed'
+             AND processed_at IS NOT NULL
            ORDER BY processed_at DESC, created_at DESC LIMIT 1""",
         (file_path,),
     )
@@ -437,20 +441,29 @@ async def reuse_as_pending(
     drop_id: str,
     batch_items: str,
     content_hash: str,
+    created_at: str,
 ) -> bool:
     """Re-arm a retriable failed row as a fresh pending batch.
 
     Preserves ``retry_count`` (the cap survives) but re-points the row at the
-    new drop, batch slice and content hash and clears the error. This is the
-    per-batch analogue of the old single-row reuse — it keeps retries from
-    piling up duplicate rows.
+    new drop, batch slice and content hash, clears the error, and **resets
+    ``created_at`` to now** — the row represents a NEW evaluation attempt as of
+    now, so its created_at must reflect the re-arm time. This restores the
+    invariant "created_at = this row's current detection/arming time" that the
+    rest of the system relies on for created_at-ordered "latest row" reads
+    (get_by_file_path → supersede), recency windows (count_url_failures), and
+    expire_stuck_processing's age cutoff. Without this reset, a reused row kept
+    an ancient created_at and broke all of those (the baseline reads switched
+    to processed_at ordering for completion-keyed correctness; this fixes the
+    created_at-keyed consumers at the source).
     """
     cursor = await db.execute(
         """UPDATE inbox_items
            SET status = 'pending', error_message = NULL,
-               drop_id = ?, batch_items = ?, content_hash = ?
+               drop_id = ?, batch_items = ?, content_hash = ?,
+               created_at = ?
            WHERE id = ?""",
-        (drop_id, batch_items, content_hash, id),
+        (drop_id, batch_items, content_hash, created_at, id),
     )
     await db.commit()
     return cursor.rowcount > 0

--- a/src/genesis/db/crud/inbox_items.py
+++ b/src/genesis/db/crud/inbox_items.py
@@ -268,18 +268,21 @@ async def get_evaluated_content(
     Filters out NULL and empty-string values so callers can rely on a
     non-empty return meaning "real prior content exists."
     """
-    # Tie-break on processed_at then rowid: when a drop's batches complete in
-    # the SAME check cycle they share ``created_at``, and each batch merges its
-    # lines on top of the prior batch's baseline, so the LAST-completed batch
-    # (highest processed_at; highest rowid as final tiebreak since batches are
-    # created in order) holds the fullest cumulative baseline. Ordering by
-    # created_at alone returned an arbitrary partial baseline among ties.
+    # Order by processed_at (COMPLETION time), not created_at: the current
+    # baseline is the most-recently-COMPLETED row, and each completion merges
+    # its lines on top of the prior baseline. created_at is unreliable here
+    # because _queue_drop reuses retriable-failed rows (reuse_as_pending
+    # preserves their OLD created_at), so a freshly-completed reused row can
+    # have an ancient created_at — ordering by created_at would return a stale,
+    # partial baseline and cause re-evaluation. rowid is the final tiebreak for
+    # same-cycle batches that share processed_at (fake-clock tests; production
+    # completions are sequential so processed_at already differs).
     cursor = await db.execute(
         """SELECT evaluated_content FROM inbox_items
            WHERE file_path = ? AND status = 'completed'
              AND evaluated_content IS NOT NULL
              AND evaluated_content != ''
-           ORDER BY created_at DESC, processed_at DESC, rowid DESC LIMIT 1""",
+           ORDER BY processed_at DESC, created_at DESC, rowid DESC LIMIT 1""",
         (file_path,),
     )
     row = await cursor.fetchone()
@@ -294,11 +297,15 @@ async def get_last_completed_at(
     Used for cooldown checks — skip re-evaluation if too recent.
     Includes both normal evaluations (with response files) and Acknowledged
     items (no response file) so cooldown applies uniformly.
+
+    Orders by processed_at (completion time), not created_at, so a reused row
+    (which keeps its old created_at via reuse_as_pending) doesn't make the
+    cooldown read a stale completion time. See get_evaluated_content.
     """
     cursor = await db.execute(
         """SELECT processed_at FROM inbox_items
            WHERE file_path = ? AND status = 'completed'
-           ORDER BY created_at DESC LIMIT 1""",
+           ORDER BY processed_at DESC, created_at DESC LIMIT 1""",
         (file_path,),
     )
     row = await cursor.fetchone()

--- a/src/genesis/db/crud/inbox_items.py
+++ b/src/genesis/db/crud/inbox_items.py
@@ -481,6 +481,12 @@ async def get_recent_completed(
     """Return recently completed inbox items with response paths.
 
     Used by the inbox digest tool to show what was evaluated recently.
+
+    Windows and orders by processed_at (completion time), not created_at: a
+    reused retriable-failed row keeps its old created_at (reuse_as_pending), so
+    a freshly-completed reused eval would otherwise fall outside the day window
+    and disappear from the digest. Rows here always have a response_path, hence
+    a non-null processed_at. See get_evaluated_content.
     """
     cursor = await db.execute(
         """SELECT id, file_path, response_path, batch_id,
@@ -488,8 +494,8 @@ async def get_recent_completed(
            FROM inbox_items
            WHERE status = 'completed'
              AND response_path IS NOT NULL
-             AND created_at >= datetime('now', ? || ' days')
-           ORDER BY created_at DESC LIMIT ?""",
+             AND processed_at >= datetime('now', ? || ' days')
+           ORDER BY processed_at DESC LIMIT ?""",
         (f"-{days}", limit),
     )
     return [dict(row) for row in await cursor.fetchall()]

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -873,6 +873,7 @@ class InboxMonitor:
                 await inbox_items.reuse_as_pending(
                     self._db, row_id, drop_id=drop_id,
                     batch_items=batch_text, content_hash=content_hash,
+                    created_at=now_iso,
                 )
             else:
                 row_id = str(uuid.uuid4())

--- a/src/genesis/mcp/health/inbox_digest.py
+++ b/src/genesis/mcp/health/inbox_digest.py
@@ -131,10 +131,15 @@ def _format_digest(
         lines.append("| Date | Source | Response |")
         lines.append("|------|--------|----------|")
         for ev in evals:
-            created = ev.get("created_at", "")[:10]
+            # Show the COMPLETION date (processed_at) — get_recent_completed
+            # windows/orders by processed_at, and a reused row's created_at is
+            # its (recent) re-arm time but a long-parked row's created_at is its
+            # old detection time, so processed_at is the accurate "evaluated on"
+            # date. Fall back to created_at if processed_at is somehow absent.
+            date = (ev.get("processed_at") or ev.get("created_at") or "")[:10]
             source_file = Path(ev.get("file_path", "")).name
             response = Path(ev.get("response_path", "")).name if ev.get("response_path") else "—"
-            lines.append(f"| {created} | {source_file} | {response} |")
+            lines.append(f"| {date} | {source_file} | {response} |")
         lines.append("")
 
     if not pending and not resolved and not evals:

--- a/tests/test_inbox/test_crud_drop_batching.py
+++ b/tests/test_inbox/test_crud_drop_batching.py
@@ -126,3 +126,24 @@ async def test_get_last_completed_at_uses_processed_at(db):
                      processed_at="2026-06-30T16:00:00+00:00", content="x")
     last = await inbox_items.get_last_completed_at(db, _FP)
     assert last == "2026-06-30T17:39:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_get_recent_completed_windows_on_processed_at(db):
+    # A reused row keeps an ancient created_at but is COMPLETED now. The digest
+    # windows on the last N days; ordering/filtering by created_at would drop it.
+    from datetime import UTC, datetime
+    now = datetime.now(UTC).isoformat()
+    await inbox_items.create(
+        db, id="reused", file_path=_FP, content_hash="h", status="completed",
+        created_at="2026-03-18T00:00:00+00:00",
+    )
+    await inbox_items.set_response_path(
+        db, "reused", response_path="r-reused", processed_at=now,
+        evaluated_content="x",
+    )
+    recent = await inbox_items.get_recent_completed(db, days=7)
+    assert any(r["id"] == "reused" for r in recent), (
+        "a reused eval completed today must appear in the digest even though "
+        "its created_at is old"
+    )

--- a/tests/test_inbox/test_crud_drop_batching.py
+++ b/tests/test_inbox/test_crud_drop_batching.py
@@ -129,6 +129,64 @@ async def test_get_last_completed_at_uses_processed_at(db):
 
 
 @pytest.mark.asyncio
+async def test_reuse_as_pending_resets_created_at(db):
+    # Root-cause fix: re-arming a failed row resets created_at to now, so all
+    # created_at-ordered "latest row" / recency / expiry reads stay correct.
+    await inbox_items.create(
+        db, id="r", file_path=_FP, content_hash="h0", status="failed",
+        created_at="2026-03-18T00:00:00+00:00", drop_id="OLD",
+        batch_items="old",
+    )
+    await inbox_items.reuse_as_pending(
+        db, "r", drop_id="NEW", batch_items="new", content_hash="h1",
+        created_at="2026-06-30T18:00:00+00:00",
+    )
+    row = await inbox_items.get_by_id(db, "r")
+    assert row["status"] == "pending"
+    assert row["created_at"] == "2026-06-30T18:00:00+00:00"  # reset, not 03-18
+    assert row["drop_id"] == "NEW"
+    assert row["batch_items"] == "new"
+    assert row["content_hash"] == "h1"
+
+
+@pytest.mark.asyncio
+async def test_get_by_file_path_returns_rearmed_reused_row(db):
+    # The created_at-class fix proven end-to-end: get_by_file_path (still
+    # created_at-ordered, used for the supersede check) must return the freshly
+    # re-armed reused row, not an older completed row — because reuse reset
+    # created_at to now.
+    await _completed(db, id="done", created_at="2026-06-30T10:00:00+00:00",
+                     processed_at="2026-06-30T10:05:00+00:00", content="x")
+    await inbox_items.create(
+        db, id="reused", file_path=_FP, content_hash="h", status="failed",
+        created_at="2026-03-18T00:00:00+00:00",
+    )
+    await inbox_items.reuse_as_pending(
+        db, "reused", drop_id="D", batch_items="new", content_hash="h",
+        created_at="2026-06-30T18:00:00+00:00",
+    )
+    latest = await inbox_items.get_by_file_path(db, _FP)
+    assert latest["id"] == "reused", (
+        "the re-armed pending row (created_at=now) must be 'latest' so the "
+        "supersede check targets it, not a stale older completed row"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_last_completed_at_skips_null_processed_at_meta_rows(db):
+    # A real completion, plus a NEWER-created meta completed row (empty/no-delta
+    # path) that has NULL processed_at. Must return the real completion time.
+    await _completed(db, id="real", created_at="2026-06-30T10:00:00+00:00",
+                     processed_at="2026-06-30T10:05:00+00:00", content="x")
+    await inbox_items.create(
+        db, id="meta", file_path=_FP, content_hash="h", status="completed",
+        created_at="2026-06-30T12:00:00+00:00",  # NO processed_at
+    )
+    last = await inbox_items.get_last_completed_at(db, _FP)
+    assert last == "2026-06-30T10:05:00+00:00"
+
+
+@pytest.mark.asyncio
 async def test_get_recent_completed_windows_on_processed_at(db):
     # A reused row keeps an ancient created_at but is COMPLETED now. The digest
     # windows on the last N days; ordering/filtering by created_at would drop it.

--- a/tests/test_inbox/test_crud_drop_batching.py
+++ b/tests/test_inbox/test_crud_drop_batching.py
@@ -76,3 +76,53 @@ async def test_follow_up_dedup_key_create_and_exists(db):
     )
     assert await follow_ups.exists_by_dedup_key(db, "k1") is True
     assert await follow_ups.exists_by_dedup_key(db, "k2") is False
+
+
+# --- baseline read must key on completion time, not created_at ---
+# Regression: _queue_drop reuses retriable-failed rows via reuse_as_pending,
+# which preserves the reused row's OLD created_at. The current baseline is the
+# most-recently-COMPLETED row (max processed_at), so ordering the read by
+# created_at returned a stale row and dropped the just-evaluated lines →
+# re-evaluation on the next scan. (Observed live: a reused row created
+# 2026-03-18 but processed today held the full baseline, yet a row created
+# today/processed earlier won the created_at sort.)
+
+_FP = "/home/ubuntu/inbox/Genesis.md"
+
+
+async def _completed(db, *, id, created_at, processed_at, content):
+    await inbox_items.create(
+        db, id=id, file_path=_FP, content_hash="h",
+        status="completed", created_at=created_at,
+    )
+    await inbox_items.set_response_path(
+        db, id, response_path=f"r-{id}", processed_at=processed_at,
+        evaluated_content=content,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_evaluated_content_returns_latest_by_processed_at(db):
+    # Reused row: OLD created_at, LATEST processed_at, fullest baseline.
+    await _completed(db, id="reused", created_at="2026-03-18T00:00:00+00:00",
+                     processed_at="2026-06-30T17:39:00+00:00",
+                     content="urlA\nurlB")
+    # Competing row: NEWER created_at but EARLIER processed_at, less content.
+    await _completed(db, id="fresh", created_at="2026-06-30T14:00:00+00:00",
+                     processed_at="2026-06-30T16:00:00+00:00",
+                     content="urlA")
+    base = await inbox_items.get_evaluated_content(db, _FP)
+    assert "urlB" in base, (
+        "baseline must come from the latest-PROCESSED completed row "
+        "(reuse preserves old created_at, so created_at ordering is wrong)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_last_completed_at_uses_processed_at(db):
+    await _completed(db, id="reused", created_at="2026-03-18T00:00:00+00:00",
+                     processed_at="2026-06-30T17:39:00+00:00", content="x")
+    await _completed(db, id="fresh", created_at="2026-06-30T14:00:00+00:00",
+                     processed_at="2026-06-30T16:00:00+00:00", content="x")
+    last = await inbox_items.get_last_completed_at(db, _FP)
+    assert last == "2026-06-30T17:39:00+00:00"


### PR DESCRIPTION
## Live-caught regression in PR #810

While verifying PR #810 on the live system, the first real drop exposed a read-ordering bug:

`_queue_drop` reuses retriable-failed rows via `reuse_as_pending`, which **preserves the reused row's old `created_at`**. But `get_evaluated_content` (and `get_last_completed_at`) ordered by `created_at DESC`. So a freshly-completed *reused* row — which holds the correct, fullest cumulative baseline — could sort **below** an older completed row that merely has a newer `created_at`. The read then returned a **stale, partial baseline**, and the next scan **re-evaluated lines already done** (the exact behavior PR-1 fixes).

**Observed live:** a reused row `created 2026-03-18` but `processed` today held both newly-dropped URLs (`evlen 22271`); a `14:52`-created row (`evlen 21906`, missing one URL) won the `created_at` sort. The next scan would have re-evaluated the dropped URL.

## Fix

Order both baseline reads by **`processed_at DESC`** (completion time = the current baseline), with `created_at`/`rowid` as tiebreaks. Completion time is the correct key because the baseline is built at completion and reuse scrambles `created_at`.

- `get_evaluated_content`: `ORDER BY processed_at DESC, created_at DESC, rowid DESC`
- `get_last_completed_at`: `ORDER BY processed_at DESC, created_at DESC`

2 regression tests added (reused row with old `created_at` + latest `processed_at` must win). Full `tests/test_inbox` green (263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)