### PR TITLE
fix(inbox): follow-up dedup race + consume-failure visibility (dispatch safety, part 1)

### DIFF
--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -1134,20 +1134,39 @@ class InboxMonitor:
             )
         return "approved"
 
-    async def _consume_approval(self, request_id: str) -> None:
+    async def _consume_approval(self, request_id: str) -> bool:
         """Consume a resume drop's approval so the next drop cannot ride the
-        same (content-agnostic, stable-key) approval."""
+        same (content-agnostic, stable-key) approval.
+
+        Returns True if the approval was consumed (or there is no gate to
+        consume against), False if the consume failed or the approval was
+        already consumed. A failure is logged at WARNING (it was previously
+        swallowed at debug) because a non-consumed approval can be ridden by a
+        later inbox drop until the gate's 24h staleness window expires.
+
+        NOTE: the resume caller currently dispatches regardless of this result.
+        Acting on a False — skip-and-retry on transient failure, or fail-and-
+        re-detect when the approval is already consumed — requires the
+        at-most-once dispatch state machine tracked in follow-up 0b68d341.
+        """
         gate = getattr(self._autonomous_dispatcher, "approval_gate", None)
         consume = getattr(gate, "mark_consumed", None)
         if consume is None:
-            return
+            return True
         try:
-            await consume(request_id)
+            ok = bool(await consume(request_id))
         except Exception:
-            logger.debug(
-                "Failed to consume approval %s after resume", request_id,
-                exc_info=True,
+            logger.warning(
+                "Inbox resume: failed to consume approval %s — it may remain "
+                "rideable by a later drop until the 24h staleness window",
+                request_id, exc_info=True,
             )
+            return False
+        if not ok:
+            logger.warning(
+                "Inbox resume: approval %s was already consumed", request_id,
+            )
+        return ok
 
     async def _dispatch_one_batch(
         self, item, *, model, effort, system_prompt, now_iso, errors,
@@ -1528,6 +1547,7 @@ class InboxMonitor:
         Returns the number of follow-ups created.
         """
         import hashlib
+        import sqlite3
 
         from genesis.db.crud import follow_ups
         from genesis.inbox.recommendation import parse_recommendations
@@ -1574,18 +1594,33 @@ class InboxMonitor:
                 logger.debug("Skipping duplicate inbox follow-up: %s", title)
                 continue
 
-            await follow_ups.create(
-                self._db,
-                content=content,
-                source="inbox_evaluation",
-                reason=reason,
-                strategy=strategy,
-                priority=priority,
-                pinned=pinned,
-                # The evaluator already judges each item genesis-vs-user; reuse it.
-                domain="internal" if rec.classification == "genesis" else "user_world",
-                dedup_key=dedup_key,
-            )
+            try:
+                await follow_ups.create(
+                    self._db,
+                    content=content,
+                    source="inbox_evaluation",
+                    reason=reason,
+                    strategy=strategy,
+                    priority=priority,
+                    pinned=pinned,
+                    # The evaluator judges each item genesis-vs-user; reuse it.
+                    domain=(
+                        "internal" if rec.classification == "genesis"
+                        else "user_world"
+                    ),
+                    dedup_key=dedup_key,
+                )
+            except sqlite3.IntegrityError:
+                # Lost a race on the partial-unique dedup_key index — another
+                # writer created this exact recommendation between the
+                # exists check and the insert. Treat as deduped and KEEP
+                # processing the rest of this evaluation's recommendations
+                # (previously this propagated and aborted the loop, silently
+                # dropping every later recommendation in the same eval).
+                logger.debug(
+                    "Duplicate dedup_key race for inbox follow-up: %s", title,
+                )
+                continue
             created += 1
 
         return created

--- a/tests/test_inbox/test_drop_dispatch.py
+++ b/tests/test_inbox/test_drop_dispatch.py
@@ -321,6 +321,94 @@ async def test_follow_up_dedup_same_rec_created_once(
     assert len(rows) == 1, f"expected 1 deduped follow-up, got {len(rows)}"
 
 
+_TWO_RECS = """# Inbox Evaluation — test
+
+## https://a.com/x
+
+**Classification:** Genesis-relevant | **Decision:** Research
+
+### Recommendation
+
+```yaml
+action: ADAPT
+next_step: "do thing A"
+effort: Small
+scope: V4
+confidence: high
+architecture_impact: extends
+```
+
+## https://b.com/y
+
+**Classification:** Genesis-relevant | **Decision:** Research
+
+### Recommendation
+
+```yaml
+action: WATCH
+next_step: "do thing B"
+effort: Small
+scope: V5
+confidence: medium
+architecture_impact: extends
+```
+"""
+
+
+@pytest.mark.asyncio
+async def test_followup_integrity_error_does_not_abort_remaining_recs(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, monkeypatch,
+):
+    """If follow_ups.create raises IntegrityError (lost a dedup_key race) on one
+    recommendation, the loop must keep processing the REST of the evaluation's
+    recommendations — previously the exception aborted the whole loop."""
+    import sqlite3
+
+    from genesis.db.crud import follow_ups as fu
+
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
+    # Force the create() path (bypass the exists pre-check).
+    monkeypatch.setattr(fu, "exists_by_dedup_key", AsyncMock(return_value=False))
+    real_create = fu.create
+    calls = {"n": 0}
+
+    async def flaky_create(*a, **k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise sqlite3.IntegrityError(
+                "UNIQUE constraint failed: follow_ups.dedup_key"
+            )
+        return await real_create(*a, **k)
+
+    monkeypatch.setattr(fu, "create", flaky_create)
+
+    created = await mon._create_follow_ups_from_eval(
+        evaluation_text=_TWO_RECS, batch_id="b1",
+        source_files=[str(inbox_dir / "Genesis.md")],
+    )
+    assert calls["n"] == 2, "both recs attempted (loop not aborted by the first IntegrityError)"
+    assert created == 1, "first raised+caught, second created"
+
+
+@pytest.mark.asyncio
+async def test_consume_approval_returns_bool(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path):
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
+    # No dispatcher wired → nothing to consume → True (proceed).
+    assert await mon._consume_approval("req") is True
+    # mark_consumed returns False (already consumed) → False.
+    mon._autonomous_dispatcher = SimpleNamespace(
+        approval_gate=SimpleNamespace(mark_consumed=AsyncMock(return_value=False)),
+    )
+    assert await mon._consume_approval("req") is False
+    # mark_consumed raises (transient) → False (not swallowed silently).
+    mon._autonomous_dispatcher = SimpleNamespace(
+        approval_gate=SimpleNamespace(
+            mark_consumed=AsyncMock(side_effect=RuntimeError("db lock")),
+        ),
+    )
+    assert await mon._consume_approval("req") is False
+
+
 @pytest.mark.asyncio
 async def test_follow_up_dedup_key_persisted(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path):
     mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)


### PR DESCRIPTION
## Scope

The two cleanly-separable, low-risk items from the dispatch crash-safety cluster (follow-up `0b68d341`). The third item (#1, resume double-dispatch on crash) is intentionally **not** here — it needs an at-most-once dispatch state machine and is left in `0b68d341` to be done deliberately (with the storm/restart work).

## #3 — follow-up dedup IntegrityError no longer aborts the rec loop
`_create_follow_ups_from_eval` does a non-atomic check-then-insert against the partial-unique `dedup_key` index. A racing duplicate (another writer inserts the same key between the `exists` check and the insert) raised `sqlite3.IntegrityError`, which propagated and **silently aborted every remaining recommendation in that evaluation** (the outer try only logged "non-fatal"). Now the per-rec `create()` catches `IntegrityError` and `continue`s, so the rest of the evaluation's recommendations are still created.

## #2 — consume-failure visibility
`_consume_approval` swallowed all errors at debug and returned nothing. It now **returns bool** and logs a failed / already-consumed `mark_consumed` at **WARNING** (a non-consumed approval can be ridden by a later inbox drop until the gate's 24h staleness window). The resume caller still dispatches regardless — *acting* on the result (skip-and-retry on transient failure vs fail-and-re-detect when the approval was already consumed) requires the at-most-once dispatch state machine, so that part stays in `0b68d341` (#1) to avoid introducing a stranded-parked-drop state here.

## Tests
2 new (IntegrityError mid-loop doesn't abort remaining recs; `_consume_approval` returns True with no gate / False on already-consumed / False on raise). Full `tests/test_inbox` green (269).

🤖 Generated with [Claude Code](https://claude.com/claude-code)