### PR TITLE
feat(learning): C2b — multi-playbook builder, grounding, cross-type dedup, flag-only chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   engineering patterns, one-off events, broad workflows; those belong in skills/CLAUDE.md). The
   result is a smaller, higher-signal procedure store.
 
+- **Genesis now learns several distinct playbooks from one session, and stops storing duplicates.**
+  A session that accomplished several different things now yields a separate playbook for each
+  (instead of one muddled procedure), and a genuinely reusable sub-step can be captured on its own.
+  At the same time, before saving a new procedure Genesis checks whether it already knows
+  essentially the same one — even if it would be filed under a different name — and skips the
+  duplicate. Together these keep the procedure store both more complete and less cluttered.
+
 ### Fixed
 
 - **Inbox evaluations no longer cram a whole batch of links into one giant pass — and stop

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -487,6 +487,15 @@ call_sites:
     default_paid: true
     description: Judge + store procedures from struggle detection and extraction
       pipeline candidates
+  38a_procedure_novelty_llm:
+    chain:
+    - nvidia-nim-deepseek
+    - openrouter-deepseek-v4
+    default_paid: true
+    description: Cross-task_type procedure dedup judgment (is a new procedure
+      redundant with existing ones). S-tier only — precision is the safety
+      property (validated 0 false-merges on deepseek-v4); fires per novel
+      procedure, low volume.
   40_ego_focus_selection:
     chain:
     - groq-free

--- a/src/genesis/db/crud/procedural.py
+++ b/src/genesis/db/crud/procedural.py
@@ -182,7 +182,14 @@ async def list_by_task_type(
     person_id: str | None = None,
     limit: int = 50,
 ) -> list[dict]:
-    sql = "SELECT * FROM procedural_memory WHERE task_type = ?"
+    # Exclude deprecated/quarantined rows: the dominant caller is the procedure
+    # novelty/dedup gate, which must NOT let a deprecated procedure suppress a new
+    # one. (matcher.find_best_match already skips them in Python, so this is a
+    # consistent no-op there.)
+    sql = (
+        "SELECT * FROM procedural_memory "
+        "WHERE task_type = ? AND deprecated = 0 AND quarantined = 0"
+    )
     params: list = [task_type]
     if person_id is not None:
         sql += " AND person_id = ?"

--- a/src/genesis/learning/procedural/embedding.py
+++ b/src/genesis/learning/procedural/embedding.py
@@ -11,11 +11,51 @@ cosine across all procedures crosses the activation threshold.
 
 from __future__ import annotations
 
+import logging
 import math
 import struct
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from genesis.memory.embeddings import EmbeddingProvider
+
+logger = logging.getLogger(__name__)
 
 # qwen3-embedding output dimensionality. Matches genesis.memory.embeddings.
 EMBEDDING_DIM = 1024
+
+# ── Shared novelty-gate state ──────────────────────────────────────────────────
+# Both procedure-extraction paths (learning/procedural/extractor.py and judge.py)
+# share ONE embedder singleton and ONE fail-open rate-limiter, so they don't each
+# spin up a provider or independently flood the table during an embedding outage.
+_EMBEDDING_PROVIDER: EmbeddingProvider | None = None
+
+# Fail-open rate limiter: when the embedder is unavailable the novelty gate can't
+# check, so it defaults to "novel". This per-task_type cooldown caps stores to one
+# per window to prevent table flooding during extended outages. Keyed by task_type
+# → time.monotonic() of the last fail-open store. SHARED across both paths.
+FAIL_OPEN_COOLDOWN_SECS = 3600  # 1 hour
+_fail_open_timestamps: dict[str, float] = {}
+
+
+def get_embedding_provider() -> EmbeddingProvider | None:
+    """Lazy shared singleton embedder for the procedure novelty gate. Returns
+    None if no embedding backend is configured (callers fall open and store
+    without novelty filtering, rate-limited via _fail_open_timestamps).
+    """
+    global _EMBEDDING_PROVIDER
+    if _EMBEDDING_PROVIDER is None:
+        try:
+            from genesis.memory.embeddings import EmbeddingProvider
+
+            _EMBEDDING_PROVIDER = EmbeddingProvider()
+        except Exception:
+            logger.warning(
+                "EmbeddingProvider unavailable; procedure novelty gate disabled",
+                exc_info=True,
+            )
+            return None
+    return _EMBEDDING_PROVIDER
 
 
 def pack_embedding(vector: list[float]) -> bytes:

--- a/src/genesis/learning/procedural/extractor.py
+++ b/src/genesis/learning/procedural/extractor.py
@@ -26,10 +26,17 @@ from __future__ import annotations
 
 import json
 import logging
-import math
+import re
 import time
 from typing import TYPE_CHECKING, Any, Protocol
 
+from genesis.learning.procedural.embedding import (
+    FAIL_OPEN_COOLDOWN_SECS,
+    _fail_open_timestamps,
+    cosine_similarity,
+    get_embedding_provider,
+    unpack_embedding,
+)
 from genesis.learning.procedural.operations import store_procedure
 
 if TYPE_CHECKING:
@@ -45,43 +52,121 @@ logger = logging.getLogger(__name__)
 # after 30 days of extraction data.
 NOVELTY_THRESHOLD = 0.85
 
-# Fail-open rate limiter: when the embedder is unavailable, at most one
-# procedure per task_type per cooldown window is stored without novelty
-# filtering.  Prevents table flooding during extended embedding outages.
-_FAIL_OPEN_COOLDOWN_SECS = 3600  # 1 hour
-_fail_open_timestamps: dict[str, float] = {}
+# ── Cross-type novelty (LLM dedup) ─────────────────────────────────────────
+# The same-task_type cosine gate (NOVELTY_THRESHOLD) cannot catch a paraphrase
+# stored under a DIFFERENT slug. After the same-type gate passes, scan ALL active
+# procedures by stored-embedding cosine, prefilter the nearest, and ask ONE LLM
+# "is the new procedure redundant with any of these?". Precision-first (the dedup
+# spike found 0 false-merges on S-tier); fail-open (any error → treat as novel).
+_NOVELTY_CALL_SITE = "38a_procedure_novelty_llm"
+CROSS_TYPE_PREFILTER = 0.62   # cosine floor for candidates (spike found dups @0.66)
+CROSS_TYPE_TOPK = 10          # cap candidates sent to the LLM (bounds cost)
+_JSON_BLOCK_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
 
-_EMBEDDING_PROVIDER: EmbeddingProvider | None = None
+_CROSS_TYPE_DEDUP_PROMPT = """\
+You are deduplicating an AI agent's PROCEDURE store. A NEW procedure was just built. Decide whether it is REDUNDANT with any EXISTING procedure listed below.
+
+REDUNDANT = the same goal achieved with essentially the same commands; OR the new one is a paraphrase of an existing one; OR an existing one FULLY CONTAINS the new one (a superset) so the new one adds nothing on its own.
+DISTINCT (keep the new one) = a different goal, different tools/commands, OR each is independently useful in its own distinct situation (even within the same domain). A genuinely reusable sub-step that stands on its own is DISTINCT from a parent that contains it. When unsure, answer DISTINCT.
+
+NEW procedure:
+  task_type: {nt}
+  principle: {np}
+  steps: {ns}
+
+EXISTING procedures:
+{candidates}
+
+Return ONLY this JSON in backticks:
+```json
+{{"redundant_with": <number of the existing procedure it duplicates, or null>, "reason": "<one line>"}}
+```"""
 
 
-def _get_embedding_provider() -> EmbeddingProvider | None:
-    """Lazy module-level singleton. Returns None if no embedding backend is
-    configured (extractor falls open and stores without novelty filtering).
+def _row_get(row: object, key: str) -> object:
+    return row.get(key) if isinstance(row, dict) else row[key]
+
+
+async def _cross_type_duplicate(
+    db: aiosqlite.Connection,
+    *,
+    task_type: str,
+    principle: str,
+    new_steps: list[str] | None,
+    new_emb: list[float] | None,
+    router: object | None,
+) -> tuple[bool, float]:
+    """Best-effort cross-task_type dedup. Returns (is_duplicate, max_cross_sim).
+
+    Fail-open: no router, no embedding, or any error → (False, …) so storage is
+    never blocked by a dedup failure. Precision over recall — when unsure, store.
     """
-    global _EMBEDDING_PROVIDER
-    if _EMBEDDING_PROVIDER is None:
+    if router is None or new_emb is None:
+        return False, 0.0
+    try:
+        from genesis.db.crud.procedural import list_active
+
+        active = await list_active(db, limit=500)
+    except Exception:
+        logger.warning(
+            "Cross-type dedup: list_active failed; treating as novel", exc_info=True,
+        )
+        return False, 0.0
+
+    scored: list[tuple[float, object]] = []
+    for row in active:
+        if _row_get(row, "task_type") == task_type:
+            continue  # same-type already handled by the cosine gate
+        vec = unpack_embedding(_row_get(row, "principle_embedding"))
+        if vec is None:
+            continue  # no stored embedding → skip (cross-type is best-effort)
+        sim = cosine_similarity(new_emb, vec)
+        if sim >= CROSS_TYPE_PREFILTER:
+            scored.append((sim, row))
+    if not scored:
+        return False, 0.0
+    scored.sort(key=lambda x: x[0], reverse=True)
+    top = scored[:CROSS_TYPE_TOPK]
+    max_cross_sim = top[0][0]
+
+    lines = []
+    for i, (_sim, row) in enumerate(top, 1):
         try:
-            from genesis.memory.embeddings import EmbeddingProvider
-
-            _EMBEDDING_PROVIDER = EmbeddingProvider()
+            steps = json.loads(_row_get(row, "steps")) if _row_get(row, "steps") else []
         except Exception:
-            logger.warning(
-                "EmbeddingProvider unavailable; procedure novelty gate disabled",
-                exc_info=True,
+            steps = []
+        steps_txt = " | ".join(str(s)[:160] for s in (steps or [])[:6])
+        lines.append(
+            f"  [{i}] task_type: {_row_get(row, 'task_type')}\n"
+            f"      principle: {_row_get(row, 'principle') or ''}\n"
+            f"      steps: {steps_txt}"
+        )
+    ns_txt = " | ".join(str(s)[:160] for s in (new_steps or [])[:6])
+    prompt = _CROSS_TYPE_DEDUP_PROMPT.format(
+        nt=task_type, np=principle, ns=ns_txt, candidates="\n".join(lines),
+    )
+
+    try:
+        result = await router.route_call(
+            call_site_id=_NOVELTY_CALL_SITE,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        if not getattr(result, "success", False):
+            return False, max_cross_sim
+        match = _JSON_BLOCK_RE.search(result.content or "")
+        data = json.loads(match.group(1) if match else (result.content or ""))
+        rw = data.get("redundant_with")
+        if isinstance(rw, int) and 1 <= rw <= len(top):
+            dup = top[rw - 1][1]
+            logger.info(
+                "Cross-type duplicate: new '%s' ~ existing '%s' (cosine=%.3f): %s",
+                task_type, _row_get(dup, "task_type"), top[rw - 1][0],
+                data.get("reason", ""),
             )
-            return None
-    return _EMBEDDING_PROVIDER
-
-
-def _cosine_similarity(a: list[float], b: list[float]) -> float:
-    if len(a) != len(b):
-        return 0.0
-    dot = sum(x * y for x, y in zip(a, b, strict=True))
-    na = math.sqrt(sum(x * x for x in a))
-    nb = math.sqrt(sum(y * y for y in b))
-    if na == 0.0 or nb == 0.0:
-        return 0.0
-    return dot / (na * nb)
+            return True, max_cross_sim
+    except Exception:
+        logger.warning("Cross-type dedup LLM failed; treating as novel", exc_info=True)
+    return False, max_cross_sim
 
 
 async def _principle_is_novel(
@@ -90,12 +175,20 @@ async def _principle_is_novel(
     task_type: str,
     new_principle: str,
     embedder: EmbeddingProvider | None,
+    router: object | None = None,
+    new_steps: list[str] | None = None,
 ) -> tuple[bool, float, list[float] | None, bool]:
     """Return (is_novel, max_similarity_seen, new_principle_vector, fell_open).
 
-    ``fell_open`` is True when the novelty gate could not perform a real
-    check (embedder unavailable, lookup failed, etc.) and defaulted to
-    "novel".  Callers use this to apply the fail-open rate limiter.
+    Two layers: (1) same-task_type cosine gate (BLOB-first — uses each row's
+    stored embedding, falling back to a live embed only when the BLOB is NULL);
+    (2) when ``router`` is supplied, a cross-task_type LLM dedup that catches a
+    paraphrase stored under a different slug (the same-type gate's blind spot).
+
+    ``fell_open`` is True when the gate could not perform a real check (embedder
+    unavailable, lookup failed) and defaulted to "novel". Callers use it to apply
+    the fail-open rate limiter. The cross-type layer is best-effort and never
+    sets ``fell_open`` (a dedup-LLM failure just stores, it isn't an outage).
     """
     if embedder is None:
         return True, 0.0, None, True
@@ -119,28 +212,45 @@ async def _principle_is_novel(
         )
         return True, 0.0, None, True
 
-    if not existing:
-        return True, 0.0, new_emb, False
-
+    # ── Layer 1: same-task_type cosine gate (BLOB-first) ──
+    max_sim = 0.0
     try:
-        max_sim = 0.0
         for row in existing:
-            existing_principle = (
-                row.get("principle") if isinstance(row, dict) else row["principle"]
-            )
+            existing_principle = _row_get(row, "principle")
             if not existing_principle:
                 continue
-            existing_emb = await embedder.embed(existing_principle)
-            sim = _cosine_similarity(new_emb, existing_emb)
+            existing_emb = unpack_embedding(_row_get(row, "principle_embedding"))
+            if existing_emb is None:
+                try:
+                    existing_emb = await embedder.embed(existing_principle)
+                except Exception:
+                    continue  # skip this row, keep checking the rest
+            sim = cosine_similarity(new_emb, existing_emb)
             if sim > max_sim:
                 max_sim = sim
-        return max_sim < NOVELTY_THRESHOLD, max_sim, new_emb, False
     except Exception:
         logger.warning(
             "Embedding/cosine failed in novelty gate; allowing storage",
             exc_info=True,
         )
-        return True, 0.0, new_emb, True
+        return True, max_sim, new_emb, True
+
+    if max_sim >= NOVELTY_THRESHOLD:
+        return False, max_sim, new_emb, False
+
+    # ── Layer 2: cross-task_type LLM dedup (best-effort, fail-open) ──
+    is_dup, cross_sim = await _cross_type_duplicate(
+        db,
+        task_type=task_type,
+        principle=new_principle,
+        new_steps=new_steps,
+        new_emb=new_emb,
+        router=router,
+    )
+    seen = max(max_sim, cross_sim)
+    if is_dup:
+        return False, seen, new_emb, False
+    return True, seen, new_emb, False
 
 # 38_procedure_extraction — extracts reusable procedures from interaction outcomes.
 # Currently in the learning-pipeline-only path (partially wired per _call_site_meta.py).
@@ -281,12 +391,14 @@ async def extract_procedure(
     # ── Same-type novelty gate ───────────────────────────────────────────
     # Skip if a near-duplicate principle already exists for this task_type.
     # Fail-open when embeddings are unavailable (rate-limited below).
-    embedder = embedding_provider if embedding_provider is not None else _get_embedding_provider()
+    embedder = embedding_provider if embedding_provider is not None else get_embedding_provider()
     is_novel, max_sim, principle_vec, fell_open = await _principle_is_novel(
         db,
         task_type=data["task_type"],
         new_principle=data["principle"],
         embedder=embedder,
+        router=router,
+        new_steps=data["steps"],
     )
     if not is_novel:
         logger.info(
@@ -301,7 +413,7 @@ async def extract_procedure(
     if fell_open:
         now = time.monotonic()
         task_type_key = data["task_type"]
-        if task_type_key in _fail_open_timestamps and now - _fail_open_timestamps[task_type_key] < _FAIL_OPEN_COOLDOWN_SECS:
+        if task_type_key in _fail_open_timestamps and now - _fail_open_timestamps[task_type_key] < FAIL_OPEN_COOLDOWN_SECS:
             logger.warning(
                 "Fail-open rate limited for %s: cooldown active",
                 task_type_key,
@@ -329,7 +441,7 @@ async def extract_procedure(
             ):
                 try:
                     ov_emb = await embedder.embed(ov["principle"])
-                    sim = _cosine_similarity(principle_vec, ov_emb)
+                    sim = cosine_similarity(principle_vec, ov_emb)
                     if sim >= NOVELTY_THRESHOLD:
                         logger.info(
                             "Cross-type duplicate: '%s' vs existing '%s' "

--- a/src/genesis/learning/procedural/extractor.py
+++ b/src/genesis/learning/procedural/extractor.py
@@ -142,6 +142,9 @@ async def _cross_type_duplicate(
             f"      steps: {steps_txt}"
         )
     ns_txt = " | ".join(str(s)[:160] for s in (new_steps or [])[:6])
+    # str.format() does NOT re-scan substituted VALUES, so brace literals in
+    # principle/steps/candidates (e.g. shell `{src,tests}` or `${VAR}`) are safe —
+    # only the template's own {fields} are interpolated. (Verified; do not "fix".)
     prompt = _CROSS_TYPE_DEDUP_PROMPT.format(
         nt=task_type, np=principle, ns=ns_txt, candidates="\n".join(lines),
     )

--- a/src/genesis/learning/procedural/grounding.py
+++ b/src/genesis/learning/procedural/grounding.py
@@ -1,0 +1,71 @@
+"""Grounding score for built procedures — OBSERVABILITY, never a drop gate.
+
+A procedure built from a session's action spine should quote the REAL
+commands / paths / flags Genesis ran. ``grounding_score`` measures what
+fraction of a procedure's distinctive step-tokens actually appear in the
+*grounding haystack* (the uncapped record of executed tool inputs, from
+``struggle_detector.build_spine_and_haystack``). A low score means the steps
+quote commands that were never run — i.e. fabricated or merely discussed.
+
+By design this is WARNING-ONLY (user decision 2026-06-30): the builder logs +
+records a low score but ALWAYS stores the procedure. Every "drop" observed in
+the C2b spikes was a FALSE NEGATIVE (a real procedure scored 0% only because
+the earlier tokenizer treated a backtick-wrapped command as one atomic token),
+and zero true hallucinations were seen. So grounding informs; it never controls.
+
+Tokenizer (deterministically validated, ~/tmp/prc_grounding_proof.py): the 3
+previously-dropped real procedures re-score 97-100%; fabricated/discussed-only
+commands stay near 0%; templated procedures stay high after placeholder
+normalization.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Placeholders are normalized away before matching so a templated step
+# (e.g. ``gh api repos/<owner>/<repo>``) still grounds against the concrete
+# command Genesis ran (``gh api repos/WingedGuardian/Genesis``).
+_PLACEHOLDER = re.compile(
+    r"<[^>]+>|\$\{?\w+\}?|\bYYYY[-/]?MM[-/]?DD\b|\bv?\d+\.\dbXX\b|\bXX+\b"
+)
+
+# Distinctive command-ish tokens: long/short flags, paths (~ or /), and dotted
+# identifiers (binaries.subcommands, file.ext, dotted ids). Extracted from the
+# whole step text INCLUDING inside backtick spans (handled separately below).
+_TECH = re.compile(r"--?[A-Za-z][\w-]{2,}|[/~][\w./\-]{3,}|\b\w[\w-]*\.[\w./-]{2,}")
+
+# Split backtick-span contents on shell metacharacters + commas + quotes, so a
+# wrapped command yields its individual binaries/flags/paths as tokens.
+_BACKTICK_SPLIT = re.compile(r"[\s|&;<>()\"',]+")
+
+
+def _step_tokens(step: str, *, normalize: bool = True) -> set[str]:
+    """Distinctive command/path tokens from one step string."""
+    s = _PLACEHOLDER.sub(" ", step) if normalize else step
+    toks: set[str] = set(_TECH.findall(s))
+    for span in re.findall(r"`([^`]+)`", s):
+        for w in _BACKTICK_SPLIT.split(span):
+            if len(w) >= 4 and re.search(r"[A-Za-z]", w) and not w.startswith("<"):
+                toks.add(w)
+    return toks
+
+
+def grounding_score(steps: list[str], haystack: str) -> float:
+    """Fraction of a procedure's distinctive step-tokens present in the haystack.
+
+    Returns 1.0 (treated as "cannot assess — do not warn") when the haystack is
+    empty OR the steps yield no distinctive tokens. Otherwise returns
+    ``hits / total`` in [0, 1]. This function NEVER decides storage — callers
+    log/record the value for observability only.
+    """
+    if not haystack:
+        return 1.0
+    toks: set[str] = set()
+    for step in steps or []:
+        if isinstance(step, str):
+            toks |= _step_tokens(step)
+    if not toks:
+        return 1.0
+    hits = sum(1 for t in toks if t in haystack)
+    return hits / len(toks)

--- a/src/genesis/learning/procedural/judge.py
+++ b/src/genesis/learning/procedural/judge.py
@@ -1,8 +1,14 @@
-"""Procedure Judge — validates candidates from Stream 1 (struggle) and Stream 2 (extraction).
+"""Procedure Judge — builds reusable PLAYBOOKS from struggle-detected sessions.
 
-Import discipline: this module is imported from memory/procedure_extraction.py
-(memory → learning direction). All memory/ imports must stay deferred inside
-function bodies to avoid a circular import cycle (memory ↔ learning).
+Single entry point: ``judge_multi_procedure()`` takes a USER-BLIND action spine
+(tool actions only) + a grounding haystack (the uncapped record of executed tool
+inputs) and returns 0..N topic-segmented procedures. The legacy per-candidate
+chunk judge was removed in C2b — the chunk path is now flag-only (a session-level
+signal), and this whole-session builder is the single judge.
+
+Import discipline: this module is imported from memory/* (memory → learning
+direction). All memory/ imports stay deferred inside function bodies to avoid a
+circular import cycle (memory ↔ learning).
 """
 
 from __future__ import annotations
@@ -12,40 +18,35 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from pathlib import Path
+from genesis.learning.procedural.embedding import (
+    FAIL_OPEN_COOLDOWN_SECS,
+    _fail_open_timestamps,
+    get_embedding_provider,
+)
 
+if TYPE_CHECKING:
     import aiosqlite
 
 logger = logging.getLogger(__name__)
 
 _CALL_SITE = "38_procedure_extraction"
 
-# Timeout for Judge LLM calls. Shared by both Stream 1 and Stream 2
-# callers (extraction_job.py and procedure_extraction.py).
-JUDGE_TIMEOUT_SECS = 60.0
+# Outer guard for the whole-session builder (extraction_job caller). NOT a single
+# call: the builder makes up to ~15 sequential LLM calls (1 build + 1 retry, then
+# per stored procedure a scoping check + a cross-type dedup check). Realistic
+# ceiling ~150s; 300s gives >2x margin while still bounding a pathological hang.
+# Each individual LLM call is separately timeout-guarded by the router — this only
+# catches the case where the whole build wedges.
+JUDGE_TIMEOUT_SECS = 300.0
+
+# Grounding is OBSERVABILITY-ONLY (user decision 2026-06-30): below this fraction
+# of step-tokens present in the execution record, log a warning + record the
+# score — but ALWAYS store. Grounding is never a drop gate. See grounding.py.
+_GROUNDING_WARN_THRESHOLD = 0.25
 
 _JSON_BLOCK_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
 
 # ── Prompts ──────────────────────────────────────────────────────────────────
-
-# A procedure is a concrete, replayable PLAYBOOK — `steps` carries the real
-# commands/paths/flags, `principle` is the specific problem solved (NOT a
-# "what this teaches" essay), `scenario` is the exact replay trigger.
-_JSON_SCHEMA_EXAMPLE = """\
-```json
-{
-  "worth_storing": true,
-  "reason": "why this is a concrete replayable playbook (or why not)",
-  "task_type": "descriptive-kebab-slug",
-  "scenario": "When <exact trigger condition for replaying this>",
-  "principle": "<the specific hard problem this solves, one line>",
-  "steps": ["<concrete step with the REAL command / path / flag used>", "..."],
-  "tools_used": ["tool1", "tool2"],
-  "context_tags": ["domain1", "domain2"],
-  "tool_trigger": ["Bash", "Read"]
-}
-```"""
 
 # Shared definition + skip criteria. A procedure is a step-by-step PLAYBOOK for a
 # specific hard-to-replicate scenario — NOT a directive, best-practice, pattern,
@@ -67,91 +68,127 @@ _PROCEDURE_DEF = (
     "skill, the knowledge base, or CLAUDE.md — not the procedure store.\n\n"
 )
 
+# Multi-procedure builder framing (C2b). The spine is USER-BLIND — only Genesis's
+# own tool actions — so the builder cannot mistake the user's request for a
+# procedure. Validated against the prod chain + S-tier (~/tmp/prc_c2b_prodspike.py).
+_MULTI_PROCEDURE_INTRO = (
+    "You are reconstructing reusable PROCEDURES from what an AI coding agent (Genesis) DID "
+    "in a session. The action spine below contains ONLY Genesis's own tool actions "
+    "(commands + outcomes) — NOT the user's messages. A procedure is about what GENESIS "
+    "does, never about what the user said or asked.\n\n"
+)
 
-def _build_struggle_prompt(spine_text: str, score: float) -> str:
-    """Build struggle judge prompt. Uses concatenation instead of str.format()
-    to avoid KeyError on { } in transcript content (JSON tool args, etc.)."""
+_MULTI_SEGMENTATION = (
+    "A session may contain ZERO, ONE, or SEVERAL procedures. Segment BY TOPIC / GOAL:\n"
+    "- Each distinct goal accomplished via a concrete replayable playbook = one procedure "
+    "(e.g. \"publish a post to Medium\").\n"
+    "- ALSO emit a SEPARATE procedure for a sub-sequence that is INDEPENDENTLY REUSABLE in a "
+    "DIFFERENT task (set is_subprocedure_of to the parent task_type) — captured specifically "
+    "(exact tool/selectors/commands). Do this ONLY when the sub-sequence would genuinely be "
+    "replayed on its own in other contexts; do NOT split every step into its own procedure.\n"
+    "- Do NOT fragment one continuous flow into many tiny procedures, and skip a 'procedure' "
+    "that is just a single trivial command. MOST sessions contain no replayable playbook — "
+    "return an empty list.\n\n"
+    "ONE-OFF TEST (critical): a real procedure must be REPLAYABLE with DIFFERENT inputs the "
+    "next time the scenario recurs. If the steps only make sense for THIS session's specific "
+    "data — hardcoded row/record/follow-up IDs, one-time resolution notes, a specific list of "
+    "items that will not recur — it is a one-off cleanup, NOT a playbook: do NOT emit it. If a "
+    "candidate mixes a generic investigation with one-off actions tied to specific IDs, skip "
+    "it. Ask: \"next month, in a NEW situation, could Genesis replay these exact steps?\" If "
+    "no, skip.\n\n"
+    "EVERY step must quote an EXACT command/path/flag that appears verbatim in the spine — "
+    "never paraphrase or invent. For credentials / PII: never embed actual secrets — reference "
+    "the reference store instead (e.g. \"use the medium.com login from the reference store\").\n\n"
+)
+
+_MULTI_SCHEMA_EXAMPLE = """\
+```json
+{"procedures": [{"task_type": "kebab-slug", "scenario": "When <trigger>", "principle": "<specific problem solved, one line>", "steps": ["<concrete step with the REAL command/path/flag>"], "tools_used": ["..."], "context_tags": ["..."], "tool_trigger": ["Bash"], "is_subprocedure_of": "<parent task_type or null>"}]}
+```"""
+
+
+def _build_multi_struggle_prompt(spine_text: str, score: float) -> str:
+    """Build the multi-procedure builder prompt. Uses concatenation (NOT
+    str.format) so { } in transcript content can't raise KeyError."""
     return (
-        "Reconstruct a reusable PROCEDURE from this session's action spine "
-        "(tool calls with their arguments + outcomes).\n\n"
+        _MULTI_PROCEDURE_INTRO
         + _PROCEDURE_DEF
+        + _MULTI_SEGMENTATION
         + "## Action Spine\n"
         + spine_text + "\n\n"
         "## Struggle Score: " + f"{score:.2f}" + "\n\n"
-        "Return JSON in backticks:\n\n"
-        + _JSON_SCHEMA_EXAMPLE
+        "Return ONLY this JSON in backticks (the list may be empty):\n\n"
+        + _MULTI_SCHEMA_EXAMPLE
     )
 
 
-def _build_extraction_prompt(
-    content: str, scenario: str, entities: str, chunk_context: str,
-) -> str:
-    """Build extraction-flag judge prompt. Uses concatenation to avoid
-    KeyError on { } in transcript content."""
-    return (
-        "A procedure candidate was flagged during transcript extraction. "
-        "Reconstruct it as a concrete playbook from the surrounding context.\n\n"
-        + _PROCEDURE_DEF
-        + "## Candidate\n"
-        "Content: " + content + "\n"
-        "Scenario: " + scenario + "\n"
-        "Entities: " + entities + "\n\n"
-        "## Surrounding Context\n"
-        + chunk_context[:3000] + "\n\n"
-        "Return JSON in backticks:\n\n"
-        + _JSON_SCHEMA_EXAMPLE
-    )
+# ── Parsing ──────────────────────────────────────────────────────────────────
 
-
-# ── Helpers ──────────────────────────────────────────────────────────────────
-
-def _parse_judge_response(text: str) -> dict | None:
-    """Extract JSON from Judge LLM response. Returns None on parse failure."""
+def _coerce_json(text: object) -> object | None:
+    """Extract a JSON value from an LLM response (handles ```json fences).
+    Returns the parsed object, or None on any parse failure."""
+    if not isinstance(text, str):
+        return None
     match = _JSON_BLOCK_RE.search(text)
-    if match:
-        text = match.group(1)
+    raw = match.group(1) if match else text
     try:
-        data = json.loads(text)
+        return json.loads(raw)
     except (json.JSONDecodeError, TypeError):
-        logger.warning("Judge returned unparseable response")
         return None
 
+
+def _parse_judge_response(text: str) -> dict | None:
+    """Validate a SINGLE judged-procedure dict. Returns None on parse failure,
+    worth_storing=false, or a missing required field. (Retained as the documented
+    single-item contract; exercised directly by the parsing tests.)"""
+    data = _coerce_json(text)
+    if data is None:
+        logger.warning("Judge returned unparseable response")
+        return None
     if not isinstance(data, dict):
         return None
     if not data.get("worth_storing"):
         logger.info("Judge rejected candidate: %s", data.get("reason", "no reason"))
         return None
-
-    # Validate required fields
     for field in ("task_type", "principle", "steps"):
         if not data.get(field):
             logger.warning("Judge response missing required field: %s", field)
             return None
-
     return data
 
 
-_EMBEDDING_PROVIDER = None
+def _parse_judge_response_list(text: str) -> list[dict] | None:
+    """Parse the multi-procedure builder response.
 
-# Fail-open rate limiter: at most one procedure per task_type per cooldown
-# when the embedder is unavailable. Prevents table flooding during outages.
-_FAIL_OPEN_COOLDOWN_SECS = 3600  # 1 hour
-_fail_open_timestamps: dict[str, float] = {}
-
-
-def _get_embedder():
-    """Lazy singleton embedder for novelty check. Returns None if unavailable."""
-    global _EMBEDDING_PROVIDER
-    if _EMBEDDING_PROVIDER is None:
+    Returns ``None`` when the envelope is unparseable (caller may retry once),
+    ``[]`` when it parses but yields no valid procedure, or the list of valid
+    procedure dicts (each must carry task_type/principle/steps). Per-item
+    validation is defensive — one malformed item never discards the rest.
+    """
+    data = _coerce_json(text)
+    if data is None:
+        return None  # unparseable → signal retry
+    if isinstance(data, dict):
+        procs = data.get("procedures")
+    elif isinstance(data, list):
+        procs = data
+    else:
+        procs = None
+    if not isinstance(procs, list):
+        return []
+    valid: list[dict] = []
+    for item in procs:
         try:
-            from genesis.memory.embeddings import EmbeddingProvider
-
-            _EMBEDDING_PROVIDER = EmbeddingProvider()
+            if isinstance(item, dict) and all(
+                item.get(f) for f in ("task_type", "principle", "steps")
+            ):
+                valid.append(item)
         except Exception:
-            logger.warning("EmbeddingProvider unavailable for Judge novelty check")
-            return None
-    return _EMBEDDING_PROVIDER
+            continue  # never let one bad item sink the batch
+    return valid
 
+
+# ── Storage ──────────────────────────────────────────────────────────────────
 
 async def _store_judged_procedure(
     db: aiosqlite.Connection,
@@ -160,11 +197,11 @@ async def _store_judged_procedure(
     *,
     source_type: str,
     source_session_id: str | None = None,
+    grounding_score: float | None = None,
 ) -> str | None:
-    """Run the scoping + novelty checks, then store via store_procedure_checked.
-
-    Returns procedure ID on success, None on skip/duplicate/directive.
-    """
+    """Run the scoping + (same-type + cross-type) novelty checks, then store via
+    store_procedure_checked. Returns procedure ID on success, None on
+    skip/duplicate/directive."""
     from genesis.learning.procedural.extractor import _principle_is_novel
     from genesis.learning.procedural.operations import store_procedure_checked
     from genesis.learning.procedural.scoping import is_behavioral_directive
@@ -194,19 +231,21 @@ async def _store_judged_procedure(
     ):
         return None
 
-    # Cosine novelty check
-    embedder = _get_embedder()
+    # Novelty: same-task_type cosine gate + cross-task_type LLM dedup (router-gated).
+    embedder = get_embedding_provider()
     is_novel, max_sim, principle_vec, fell_open = await _principle_is_novel(
         db, task_type=task_type, new_principle=principle, embedder=embedder,
+        router=router, new_steps=steps,
     )
 
-    # Fail-open rate limiter: when the novelty gate couldn't check
-    # (embedder down), allow at most one per task_type per cooldown window.
+    # Fail-open rate limiter: when the novelty gate couldn't check (embedder down),
+    # allow at most one per task_type per cooldown window. Shared across both
+    # extraction paths via embedding._fail_open_timestamps.
     if fell_open:
         import time
 
         last = _fail_open_timestamps.get(task_type, 0.0)
-        if time.monotonic() - last < _FAIL_OPEN_COOLDOWN_SECS:
+        if time.monotonic() - last < FAIL_OPEN_COOLDOWN_SECS:
             logger.info(
                 "Judge: rate-limited fail-open store for %s (cooldown active)",
                 task_type,
@@ -231,10 +270,14 @@ async def _store_judged_procedure(
         except Exception:
             logger.warning("Failed to pack principle embedding", exc_info=True)
 
-    # Store via checked path (handles task_type dedup, upsert, explicit-teach guard)
-    source = {"type": source_type}
+    # Store via checked path (handles task_type dedup, upsert, explicit-teach guard).
+    # grounding_score is recorded for observability (warning-only gate); the JSON
+    # source blob is queryable via json_extract(source, '$.grounding_score').
+    source: dict = {"type": source_type}
     if source_session_id:
         source["session_id"] = source_session_id
+    if grounding_score is not None:
+        source["grounding_score"] = round(grounding_score, 3)
 
     result = await store_procedure_checked(
         db,
@@ -264,91 +307,104 @@ async def _store_judged_procedure(
     return result.procedure_id
 
 
-# ── Public entry points ──────────────────────────────────────────────────────
+# ── Public entry point ─────────────────────────────────────────────────────────
 
-async def judge_struggle_procedure(
+async def _call_and_parse_list(router: object, prompt: str) -> list[dict]:
+    """Call the builder LLM and parse a procedure list, retrying ONCE on an
+    unparseable envelope. Returns [] on call failure or persistent unparse."""
+    for attempt in (1, 2):
+        try:
+            result = await router.route_call(
+                call_site_id=_CALL_SITE,
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except Exception:
+            logger.warning(
+                "Judge LLM call failed for multi-procedure (attempt %d)", attempt,
+                exc_info=True,
+            )
+            return []
+        if not result.success:
+            logger.warning(
+                "Judge LLM call unsuccessful (attempt %d): %s", attempt, result.error,
+            )
+            return []
+        parsed = _parse_judge_response_list(result.content)
+        if parsed is not None:
+            return parsed
+        logger.warning(
+            "Judge multi-procedure response unparseable (attempt %d of 2)", attempt,
+        )
+    return []
+
+
+async def judge_multi_procedure(
     db: aiosqlite.Connection,
     spine: list[dict],
+    haystack: str,
     score: float,
-    transcript_path: Path,
     router,
     *,
     source_session_id: str | None = None,
-) -> str | None:
-    """Judge a struggle-flagged session for procedure extraction.
+    max_new: int | None = None,
+) -> list[str]:
+    """Build 0..N topic-segmented procedures from a struggle-detected session.
 
-    Called by Stream 1 after score_struggle() >= threshold.
-    Returns procedure ID on success, None on rejection.
+    ``spine`` is rendered USER-BLIND (tool actions only); ``haystack`` is the
+    uncapped execution record used for grounding. Each built procedure is grounded
+    (warning-only — never dropped), scoping-gated, novelty-checked, and stored.
+    Returns the list of stored procedure IDs (capped at ``max_new`` when given).
     """
+    from genesis.learning.procedural.grounding import grounding_score
     from genesis.learning.procedural.struggle_detector import format_spine_for_judge
 
     spine_text = format_spine_for_judge(spine)
+    prompt = _build_multi_struggle_prompt(spine_text, score)
 
-    prompt = _build_struggle_prompt(spine_text, score)
+    procedures = await _call_and_parse_list(router, prompt)
+    if not procedures:
+        return []
 
-    try:
-        result = await router.route_call(
-            call_site_id=_CALL_SITE,
-            messages=[{"role": "user", "content": prompt}],
+    stored: list[str] = []
+    for data in procedures:
+        if max_new is not None and len(stored) >= max_new:
+            logger.info(
+                "Multi-procedure builder hit per-session cap (%d); %d more not stored",
+                max_new, len(procedures) - len(stored),
+            )
+            break
+
+        steps = data.get("steps", [])
+        if isinstance(steps, str):
+            steps = [steps]
+
+        # Grounding: WARNING-ONLY observability. Low score → log + record, store anyway.
+        try:
+            gscore = grounding_score(steps, haystack)
+        except Exception:
+            gscore = 1.0
+        if gscore < _GROUNDING_WARN_THRESHOLD:
+            logger.warning(
+                "Procedure '%s' weakly grounded (%.0f%% of step tokens in the "
+                "execution record) — storing anyway (grounding is observability only)",
+                data.get("task_type"), gscore * 100,
+            )
+
+        # Sub-procedure linkage → context_tags tag (no schema change).
+        parent = data.get("is_subprocedure_of")
+        if parent and str(parent).strip().lower() not in ("", "null", "none"):
+            tags = data.get("context_tags") or []
+            if isinstance(tags, str):
+                tags = [tags]
+            data["context_tags"] = [*tags, f"subprocedure_of:{parent}"]
+
+        proc_id = await _store_judged_procedure(
+            db, data, router,
+            source_type="struggle_extraction",
+            source_session_id=source_session_id,
+            grounding_score=gscore,
         )
-    except Exception:
-        logger.warning("Judge LLM call failed for struggle procedure", exc_info=True)
-        return None
+        if proc_id:
+            stored.append(proc_id)
 
-    if not result.success:
-        logger.warning("Judge LLM call unsuccessful: %s", result.error)
-        return None
-
-    data = _parse_judge_response(result.content)
-    if data is None:
-        return None
-
-    return await _store_judged_procedure(
-        db, data, router,
-        source_type="struggle_extraction",
-        source_session_id=source_session_id,
-    )
-
-
-async def judge_extraction_candidate(
-    db: aiosqlite.Connection,
-    candidate: dict,
-    chunk_context: str,
-    router,
-    *,
-    source_session_id: str | None = None,
-) -> str | None:
-    """Judge a Stream 2 procedure candidate.
-
-    Called by procedure_extraction.py for each procedure_candidate extraction.
-    Returns procedure ID on success, None on rejection.
-    """
-    prompt = _build_extraction_prompt(
-        content=candidate.get("principle", ""),
-        scenario=candidate.get("scenario", ""),
-        entities=", ".join(candidate.get("tools_used", [])),
-        chunk_context=chunk_context,
-    )
-
-    try:
-        result = await router.route_call(
-            call_site_id=_CALL_SITE,
-            messages=[{"role": "user", "content": prompt}],
-        )
-    except Exception:
-        logger.warning("Judge LLM call failed for extraction candidate", exc_info=True)
-        return None
-
-    if not result.success:
-        logger.warning("Judge LLM call unsuccessful: %s", result.error)
-        return None
-
-    data = _parse_judge_response(result.content)
-    if data is None:
-        return None
-
-    return await _store_judged_procedure(
-        db, data, router,
-        source_type="extraction_pipeline",
-        source_session_id=source_session_id,
-    )
+    return stored

--- a/src/genesis/learning/procedural/judge.py
+++ b/src/genesis/learning/procedural/judge.py
@@ -244,8 +244,13 @@ async def _store_judged_procedure(
     if fell_open:
         import time
 
-        last = _fail_open_timestamps.get(task_type, 0.0)
-        if time.monotonic() - last < FAIL_OPEN_COOLDOWN_SECS:
+        # Only rate-limit if a fail-open store for this task_type ACTUALLY happened
+        # before. A 0.0 default would wrongly rate-limit the FIRST store whenever
+        # time.monotonic() (uptime-based on Linux) < cooldown — i.e. on a freshly
+        # booted host (the failure mode CI's fresh runners hit). Matches the
+        # membership-guarded check in extractor._fail_open.
+        last = _fail_open_timestamps.get(task_type)
+        if last is not None and time.monotonic() - last < FAIL_OPEN_COOLDOWN_SECS:
             logger.info(
                 "Judge: rate-limited fail-open store for %s (cooldown active)",
                 task_type,

--- a/src/genesis/learning/procedural/judge.py
+++ b/src/genesis/learning/procedural/judge.py
@@ -366,11 +366,11 @@ async def judge_multi_procedure(
         return []
 
     stored: list[str] = []
-    for data in procedures:
+    for idx, data in enumerate(procedures):
         if max_new is not None and len(stored) >= max_new:
             logger.info(
-                "Multi-procedure builder hit per-session cap (%d); %d more not stored",
-                max_new, len(procedures) - len(stored),
+                "Multi-procedure builder hit per-session cap (%d); %d candidate(s) "
+                "not evaluated", max_new, len(procedures) - idx,
             )
             break
 

--- a/src/genesis/learning/procedural/struggle_detector.py
+++ b/src/genesis/learning/procedural/struggle_detector.py
@@ -73,8 +73,16 @@ def _summarize_args(tool_name: str, tool_input: object) -> str:
     return args_text[:cap]
 
 
-def build_action_spine(transcript_path: Path) -> list[dict]:
-    """Parse JSONL into a compact action spine.
+def build_spine_and_haystack(transcript_path: Path) -> tuple[list[dict], str]:
+    """Parse JSONL into a compact action spine AND a grounding haystack.
+
+    The haystack is the newline-joined, UNCAPPED ``json.dumps`` of every
+    tool_use's input — the record of what Genesis actually RAN. The grounding
+    gate matches a built procedure's step command-tokens against it (a command
+    that was truly executed appears here; a fabricated or merely-discussed one
+    does not). Distinct from the spine's per-tool-capped ``args_summary``.
+
+    Parse JSONL into a compact action spine.
 
     Each entry: {
         "turn": int,            # sequential turn number
@@ -89,6 +97,7 @@ def build_action_spine(transcript_path: Path) -> list[dict]:
     that read_transcript_messages() intentionally strips.
     """
     spine: list[dict] = []
+    haystack_parts: list[str] = []  # uncapped tool inputs → grounding record
     pending_tools: dict[str, dict] = {}  # tool_use_id → spine entry (awaiting result)
     turn = 0
 
@@ -133,6 +142,14 @@ def build_action_spine(transcript_path: Path) -> list[dict]:
                         turn += 1
                         tool_name = block.get("name", "unknown")
                         tool_input = block.get("input", {})
+
+                        # Grounding record: the FULL command/args Genesis ran,
+                        # uncapped (the spine's args_summary is per-tool capped).
+                        # ExitPlanMode is plan prose, not an action — exclude it.
+                        if tool_name != "ExitPlanMode":
+                            haystack_parts.append(
+                                json.dumps(tool_input, ensure_ascii=False, default=str)
+                            )
 
                         args_summary = _summarize_args(tool_name, tool_input)
 
@@ -190,7 +207,15 @@ def build_action_spine(transcript_path: Path) -> list[dict]:
         entry["outcome"] = "error"
         entry["error_text"] = "no result received (session may have crashed)"
 
-    return spine
+    return spine, "\n".join(haystack_parts)
+
+
+def build_action_spine(transcript_path: Path) -> list[dict]:
+    """Back-compat thin wrapper: returns the action spine only (drops the
+    haystack). Retained so existing callers (score_struggle and its tests) keep
+    their ``list[dict]`` contract; the builder path uses build_spine_and_haystack.
+    """
+    return build_spine_and_haystack(transcript_path)[0]
 
 
 def score_struggle(spine: list[dict]) -> float:
@@ -279,24 +304,28 @@ def score_struggle(spine: list[dict]) -> float:
 
 
 def format_spine_for_judge(spine: list[dict]) -> str:
-    """Format action spine as compact text for the Judge LLM.
+    """Format the action spine as compact text for the Judge LLM — TOOL ACTIONS
+    ONLY (user turns are dropped).
+
+    A procedure is about what GENESIS DID, never what the user said. Dropping
+    user turns was the single biggest noise cut in the C2b builder spike: it
+    stops the builder reconstructing "procedures" from the user's requests or
+    corrections. (score_struggle still sees user corrections — it reads the full
+    spine from build_action_spine, not this formatted view.)
 
     Output:
     [T=1] TOOL: Bash {"command": "ssh root@..."} -> OK
     [T=2] TOOL: Read {"file_path": "/home..."} -> ERR: not found
-    [T=5] USER: "that didn't work, try again"
     """
     lines: list[str] = []
     for entry in spine:
+        if entry["type"] != "tool":
+            continue
         turn = entry["turn"]
-        if entry["type"] == "tool":
-            outcome = "OK" if entry["outcome"] == "ok" else f"ERR: {entry['error_text'][:300]}"
-            lines.append(
-                f"[T={turn}] TOOL: {entry['tool']} {entry['args_summary']} -> {outcome}"
-            )
-        elif entry["type"] == "user":
-            text = entry["args_summary"][:160]
-            lines.append(f'[T={turn}] USER: "{text}"')
+        outcome = "OK" if entry["outcome"] == "ok" else f"ERR: {entry['error_text'][:300]}"
+        lines.append(
+            f"[T={turn}] TOOL: {entry['tool']} {entry['args_summary']} -> {outcome}"
+        )
     text = "\n".join(lines)
     if len(text) > _MAX_SPINE_CHARS:
         text = "...[earlier turns truncated]...\n" + text[-_MAX_SPINE_CHARS:]

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -12,6 +12,7 @@ Extraction scope:
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
@@ -487,10 +488,17 @@ async def run_extraction_cycle(
                         len(stored_ids),
                     )
             except TimeoutError:
+                # The build was cancelled mid-flight; discard any half-written
+                # store so a partial transaction can't block the shared connection.
+                # (Completed per-procedure stores already auto-committed.)
+                with contextlib.suppress(Exception):
+                    await db.rollback()
                 logger.warning(
                     "Procedure builder timed out for session %s", session_id,
                 )
             except Exception:
+                with contextlib.suppress(Exception):
+                    await db.rollback()
                 logger.warning(
                     "Procedure builder failed for session %s",
                     session_id, exc_info=True,

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -104,7 +104,7 @@ async def run_extraction_cycle(
     start_line_override: int | None = None,
     session_filter: set[str] | None = None,
     max_extractions_per_session: int = 30,
-    max_procedures_per_session: int = 3,
+    max_procedures_per_session: int = 7,
 ) -> dict:
     """Run one extraction cycle across all eligible sessions.
 
@@ -175,6 +175,7 @@ async def run_extraction_cycle(
         # streams). Without this, a single session can flood the store with
         # hundreds of conf≈0 candidates that never get validated.
         session_procs = 0
+        session_candidates: list[dict] = []  # flag-only chunk signal (C2b)
 
         for chunk in chunks:
             chunk_start = chunk[0].line_number
@@ -242,31 +243,25 @@ async def run_extraction_cycle(
                     session_id, chunk_start, chunk_end, exc_info=True,
                 )
 
-            # Stream 2: procedure candidate extraction (same pattern as
-            # references). Only in normal mode — procedure candidates are
-            # a new extraction type flagged by the SLM, routed to the Judge
-            # LLM for validation. Each Judge call is timeout-guarded.
-            if not reference_only_mode and session_procs < max_procedures_per_session:
+            # Stream 2: procedure candidate flagging (C2b — flag-only). The SLM
+            # flags procedure_candidate extractions; we classify them and
+            # ACCUMULATE them as a session-level signal. No Judge call and no
+            # storage here — the whole-session builder (Stream 1) does the
+            # reconstruction. This fixes the prior priority inversion, where the
+            # chunk path could exhaust the per-session cap before the
+            # higher-fidelity struggle builder ran.
+            if not reference_only_mode:
                 try:
                     from genesis.memory.procedure_extraction import (
                         extract_procedures_from_chunk,
                     )
 
-                    proc_count = await extract_procedures_from_chunk(
-                        result.extractions,
-                        db=db,
-                        router=router,
-                        source_session_id=cc_session_id,
-                        chunk_context=format_chunk_for_extraction(chunk),
-                        max_new=max_procedures_per_session - session_procs,
-                    )
-                    session_procs += proc_count
-                    summary["procedures_extracted"] = (
-                        summary.get("procedures_extracted", 0) + proc_count
+                    session_candidates.extend(
+                        extract_procedures_from_chunk(result.extractions)
                     )
                 except Exception:
                     logger.warning(
-                        "Procedure extraction failed on session %s chunk %d-%d",
+                        "Procedure candidate flagging failed on session %s chunk %d-%d",
                         session_id, chunk_start, chunk_end, exc_info=True,
                     )
 
@@ -437,51 +432,67 @@ async def run_extraction_cycle(
                     keywords=all_keywords, topic=latest_topic,
                 )
 
-            # Stream 1: struggle detection (runs once per session, after all
-            # chunks). Parses the full JSONL into an action spine, scores
-            # struggle heuristics, and routes to Judge if above threshold.
+            # Stream 1: the whole-session procedure BUILDER (runs once per
+            # session, after all chunks). Parses the full JSONL into a user-blind
+            # action spine + a grounding haystack, scores struggle, and runs the
+            # multi-procedure builder when EITHER the struggle score crosses the
+            # threshold OR the chunk path flagged candidates. Returns 0..N
+            # topic-segmented playbooks.
             try:
                 import asyncio
 
                 from genesis.learning.procedural.struggle_detector import (
                     STRUGGLE_THRESHOLD,
-                    build_action_spine,
+                    build_spine_and_haystack,
                     score_struggle,
                 )
 
-                spine = build_action_spine(transcript_path)
+                spine, haystack = build_spine_and_haystack(transcript_path)
                 struggle_score = score_struggle(spine)
+                struggle_triggered = struggle_score >= STRUGGLE_THRESHOLD
                 if (
-                    struggle_score >= STRUGGLE_THRESHOLD
+                    (struggle_triggered or session_candidates)
                     and session_procs < max_procedures_per_session
                 ):
                     from genesis.learning.procedural.judge import (
                         JUDGE_TIMEOUT_SECS,
-                        judge_struggle_procedure,
+                        judge_multi_procedure,
                     )
 
-                    proc_id = await asyncio.wait_for(
-                        judge_struggle_procedure(
-                            db, spine, struggle_score, transcript_path, router,
+                    stored_ids = await asyncio.wait_for(
+                        judge_multi_procedure(
+                            db, spine, haystack, struggle_score, router,
                             source_session_id=cc_session_id,
+                            max_new=max_procedures_per_session - session_procs,
                         ),
                         timeout=JUDGE_TIMEOUT_SECS,
                     )
-                    if proc_id:
+                    session_procs += len(stored_ids)
+                    if stored_ids:
                         summary["struggle_procedures"] = (
-                            summary.get("struggle_procedures", 0) + 1
+                            summary.get("struggle_procedures", 0) + len(stored_ids)
+                        )
+                    # Measure SLM over-flagging: the builder fired on chunk
+                    # candidates alone, with no struggle signal.
+                    if session_candidates and not struggle_triggered:
+                        logger.info(
+                            "Procedure builder fired on candidates-only for %s "
+                            "(%d candidates, score=%.2f): stored=%d",
+                            session_id, len(session_candidates), struggle_score,
+                            len(stored_ids),
                         )
                     logger.info(
-                        "Struggle detection for %s: score=%.2f, stored=%s",
-                        session_id, struggle_score, proc_id is not None,
+                        "Procedure builder for %s: score=%.2f, candidates=%d, stored=%d",
+                        session_id, struggle_score, len(session_candidates),
+                        len(stored_ids),
                     )
             except TimeoutError:
                 logger.warning(
-                    "Struggle judge timed out for session %s", session_id,
+                    "Procedure builder timed out for session %s", session_id,
                 )
             except Exception:
                 logger.warning(
-                    "Struggle detection failed for session %s",
+                    "Procedure builder failed for session %s",
                     session_id, exc_info=True,
                 )
 

--- a/src/genesis/memory/procedure_extraction.py
+++ b/src/genesis/memory/procedure_extraction.py
@@ -1,36 +1,25 @@
-"""Stream 2: Procedure candidate post-processor.
+"""Stream 2: Procedure candidate classifier (flag-only).
 
 Runs over each chunk's extraction output (alongside reference_extraction.py).
-Classifies procedure_candidate extractions and routes them to the Judge LLM
-for validation and storage.
+Classifies ``procedure_candidate`` extractions into lightweight candidate dicts.
 
-Pattern: mirrors reference_extraction.py — zero extra LLM calls for
-classification, paid LLM call only when the Judge is invoked.
+C2b: this path no longer calls the Judge per candidate. The classified candidates
+are returned as a SESSION-LEVEL SIGNAL — their presence tells the whole-session
+struggle builder (``learning/procedural/judge.judge_multi_procedure``) to run even
+when the struggle score is below threshold. Procedure CONTENT is reconstructed by
+that builder from the action spine, not stored here. Pure, zero-LLM classification.
 """
 
 from __future__ import annotations
 
-import asyncio
-import logging
-from typing import TYPE_CHECKING
-
 from genesis.memory.extraction import Extraction
-
-if TYPE_CHECKING:
-    import aiosqlite
-
-logger = logging.getLogger(__name__)
-
-# Timeout for Judge LLM calls. Must match judge.JUDGE_TIMEOUT_SECS.
-# Kept as local constant to avoid top-level memory → learning import.
-_JUDGE_TIMEOUT_SECS = 60.0
 
 
 def classify_as_procedure(extraction: Extraction) -> dict | None:
     """Classify an extraction as a procedure candidate.
 
     Returns a dict with scenario/principle/tools or None if not a candidate.
-    Pure classifier — no LLM calls. The heavy lifting is done by the Judge.
+    Pure classifier — no LLM calls. The heavy lifting is done by the builder.
     """
     if extraction.extraction_type != "procedure_candidate":
         return None
@@ -46,52 +35,16 @@ def classify_as_procedure(extraction: Extraction) -> dict | None:
     }
 
 
-async def extract_procedures_from_chunk(
-    extractions: list[Extraction],
-    *,
-    db: aiosqlite.Connection,
-    router,
-    source_session_id: str | None = None,
-    chunk_context: str = "",
-    max_new: int | None = None,
-) -> int:
-    """Run classifier over chunk extractions, route candidates to Judge.
+def extract_procedures_from_chunk(extractions: list[Extraction]) -> list[dict]:
+    """Classify chunk extractions into procedure candidates (flag-only signal).
 
-    Returns count of procedures stored. Each Judge call is individually
-    timeout-guarded to prevent a single hung LLM from blocking the
-    entire extraction loop. ``max_new`` caps how many procedures this call may
-    store (the caller's remaining per-session budget); once reached, no further
-    candidates are judged.
+    Returns the list of candidate dicts (possibly empty). Stores nothing and
+    makes no LLM calls — the caller accumulates candidates across chunks and uses
+    their existence to trigger the whole-session builder.
     """
-    # Deferred import — memory → learning direction
-    from genesis.learning.procedural.judge import judge_extraction_candidate
-
-    count = 0
+    candidates: list[dict] = []
     for ext in extractions:
-        if max_new is not None and count >= max_new:
-            break
         candidate = classify_as_procedure(ext)
-        if candidate is None:
-            continue
-
-        try:
-            result = await asyncio.wait_for(
-                judge_extraction_candidate(
-                    db, candidate, chunk_context, router,
-                    source_session_id=source_session_id,
-                ),
-                timeout=_JUDGE_TIMEOUT_SECS,
-            )
-            if result is not None:
-                count += 1
-        except TimeoutError:
-            logger.warning(
-                "Judge timed out on procedure candidate (session %s)",
-                source_session_id,
-            )
-        except Exception:
-            logger.warning(
-                "Judge failed on procedure candidate", exc_info=True,
-            )
-
-    return count
+        if candidate is not None:
+            candidates.append(candidate)
+    return candidates

--- a/tests/test_learning/test_cross_type_novelty.py
+++ b/tests/test_learning/test_cross_type_novelty.py
@@ -1,0 +1,119 @@
+"""Tests for the C2b cross-task_type novelty gate (extractor._principle_is_novel).
+
+Covers: a cross-type paraphrase is caught via the LLM dedup; a distinct one is
+kept; the same-type compare reads STORED embedding BLOBs (no re-embed); and
+deprecated rows never suppress a new procedure (list_by_task_type / list_active
+both exclude them).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.db.crud import procedural
+from genesis.learning.procedural import embedding as embedding_mod
+from genesis.learning.procedural.embedding import EMBEDDING_DIM, pack_embedding
+from genesis.learning.procedural.extractor import _principle_is_novel
+from genesis.learning.procedural.operations import store_procedure
+
+
+@dataclass
+class _Result:
+    success: bool = True
+    content: str = ""
+    error: str | None = None
+
+
+def _vec(i: int) -> list[float]:
+    v = [0.0] * EMBEDDING_DIM
+    v[i] = 1.0
+    return v
+
+
+def _embedder_returning(vec: list[float]) -> MagicMock:
+    e = MagicMock()
+    e.embed = AsyncMock(return_value=list(vec))
+    return e
+
+
+def _router_38a(redundant_with) -> MagicMock:
+    r = MagicMock()
+    r.route_call = AsyncMock(
+        return_value=_Result(content=json.dumps({"redundant_with": redundant_with})),
+    )
+    return r
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    embedding_mod._EMBEDDING_PROVIDER = None
+    embedding_mod._fail_open_timestamps.clear()
+    yield
+    embedding_mod._fail_open_timestamps.clear()
+
+
+async def _seed(db, task_type, vec, *, deprecated=0):
+    pid = await store_procedure(
+        db, task_type=task_type, principle=f"{task_type} principle",
+        steps=["s"], tools_used=["Bash"], context_tags=["c"],
+        principle_embedding=pack_embedding(vec),
+    )
+    if deprecated:
+        await procedural.update(db, pid, deprecated=1)
+    return pid
+
+
+@pytest.mark.asyncio
+async def test_cross_type_duplicate_caught(db):
+    await _seed(db, "reindex-gitnexus", _vec(0))
+    # New procedure under a DIFFERENT slug, near-identical embedding.
+    router = _router_38a(1)  # LLM: redundant with candidate #1
+    is_novel, _max_sim, _vec_out, fell_open = await _principle_is_novel(
+        db, task_type="reindex-code-intel", new_principle="reindex the code graph",
+        embedder=_embedder_returning(_vec(0)), router=router, new_steps=["s"],
+    )
+    assert is_novel is False
+    assert fell_open is False
+    router.route_call.assert_awaited_once()  # the 38a dedup call fired
+
+
+@pytest.mark.asyncio
+async def test_cross_type_distinct_kept(db):
+    await _seed(db, "reindex-gitnexus", _vec(0))
+    router = _router_38a(None)  # LLM: not redundant
+    is_novel, _max_sim, _vec_out, _fo = await _principle_is_novel(
+        db, task_type="restart-server", new_principle="restart the server cleanly",
+        embedder=_embedder_returning(_vec(0)), router=router, new_steps=["s"],
+    )
+    assert is_novel is True
+
+
+@pytest.mark.asyncio
+async def test_same_type_uses_stored_blob_no_reembed(db):
+    """Existing same-type rows are compared via their stored BLOB — the embedder
+    is called only once (for the NEW principle), not per existing row."""
+    await _seed(db, "task-a", _vec(0))
+    embedder = _embedder_returning(_vec(5))  # orthogonal → passes same-type gate
+    is_novel, _max_sim, _v, _fo = await _principle_is_novel(
+        db, task_type="task-a", new_principle="a different a-principle",
+        embedder=embedder, router=None, new_steps=["s"],
+    )
+    assert is_novel is True
+    embedder.embed.assert_awaited_once()  # only the new principle was embedded
+
+
+@pytest.mark.asyncio
+async def test_deprecated_row_does_not_suppress(db):
+    """A deprecated near-duplicate (same task_type, identical embedding) must NOT
+    block a new procedure — list_by_task_type/list_active exclude deprecated."""
+    await _seed(db, "task-a", _vec(0), deprecated=1)
+    router = _router_38a(None)
+    is_novel, _max_sim, _v, _fo = await _principle_is_novel(
+        db, task_type="task-a", new_principle="same idea, fresh row",
+        embedder=_embedder_returning(_vec(0)), router=router, new_steps=["s"],
+    )
+    assert is_novel is True  # deprecated dup excluded → stored

--- a/tests/test_learning/test_extractor.py
+++ b/tests/test_learning/test_extractor.py
@@ -8,10 +8,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from genesis.learning.procedural import extractor as extractor_mod
+from genesis.learning.procedural import embedding as embedding_mod
+from genesis.learning.procedural.embedding import cosine_similarity
 from genesis.learning.procedural.extractor import (
     NOVELTY_THRESHOLD,
-    _cosine_similarity,
     extract_procedure,
 )
 from genesis.learning.procedural.operations import store_procedure
@@ -19,12 +19,13 @@ from genesis.learning.procedural.operations import store_procedure
 
 @pytest.fixture(autouse=True)
 def _reset_module_state():
-    """Reset module-level singletons between tests so state can't leak."""
-    extractor_mod._EMBEDDING_PROVIDER = None
-    extractor_mod._fail_open_timestamps.clear()
+    """Reset the SHARED procedure-novelty singletons (now in embedding.py)
+    between tests so state can't leak."""
+    embedding_mod._EMBEDDING_PROVIDER = None
+    embedding_mod._fail_open_timestamps.clear()
     yield
-    extractor_mod._EMBEDDING_PROVIDER = None
-    extractor_mod._fail_open_timestamps.clear()
+    embedding_mod._EMBEDDING_PROVIDER = None
+    embedding_mod._fail_open_timestamps.clear()
 
 
 @dataclass
@@ -76,12 +77,12 @@ def _valid_payload(task_type: str = "deploy-service", principle: str = "always v
 
 
 def test_cosine_similarity_basic():
-    assert _cosine_similarity([1.0, 0.0], [1.0, 0.0]) == pytest.approx(1.0)
-    assert _cosine_similarity([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+    assert cosine_similarity([1.0, 0.0], [1.0, 0.0]) == pytest.approx(1.0)
+    assert cosine_similarity([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
     # Length mismatch returns 0 (defensive)
-    assert _cosine_similarity([1.0], [1.0, 0.0]) == 0.0
+    assert cosine_similarity([1.0], [1.0, 0.0]) == 0.0
     # Zero vector returns 0
-    assert _cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
+    assert cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
 
 
 @pytest.mark.asyncio
@@ -200,7 +201,7 @@ async def test_extract_fails_open_when_embedder_is_none(db):
         router=router,
         embedding_provider=None,
     )
-    # With embedder=None, _get_embedding_provider() is consulted. In test
+    # With embedder=None, embedding.get_embedding_provider() is consulted. In test
     # environments without an embedding backend it returns None and we
     # fail-open. The procedure should store.
     # (Note: if a backend IS available in the test env, this test would still

--- a/tests/test_learning/test_grounding.py
+++ b/tests/test_learning/test_grounding.py
@@ -1,0 +1,68 @@
+"""Tests for the procedure grounding score (observability-only gate).
+
+Grounding measures what fraction of a built procedure's distinctive step-tokens
+(commands / flags / paths) appear in the execution haystack. It NEVER drops a
+procedure — these tests pin the tokenizer behavior the C2b spike validated
+(real commands ground high; fabricated/discussed-only ones ground low; empty or
+untokenizable cases fail open to 1.0).
+"""
+
+from __future__ import annotations
+
+from genesis.learning.procedural.grounding import grounding_score
+
+
+def test_empty_haystack_is_one():
+    # Cannot assess → 1.0 (never warns, never drops).
+    assert grounding_score(["run gh api repos/x/y"], "") == 1.0
+
+
+def test_no_distinctive_tokens_is_one():
+    # Prose with no command/flag/path tokens → cannot assess → 1.0.
+    assert grounding_score(["do the thing carefully"], "some haystack text") == 1.0
+    assert grounding_score([], "anything") == 1.0
+
+
+def test_real_command_grounds_high():
+    haystack = '{"command": "gh api repos/WingedGuardian/Genesis --jq .name"}'
+    score = grounding_score(
+        ["Run `gh api repos/WingedGuardian/Genesis --jq .name` to read the repo"],
+        haystack,
+    )
+    assert score >= 0.75
+
+
+def test_fabricated_command_grounds_low():
+    haystack = '{"command": "gh api repos/WingedGuardian/Genesis"}'
+    score = grounding_score(
+        ["Run `frobnicate --quux /nonsense/path/here` to fix it"],
+        haystack,
+    )
+    assert score < 0.25
+
+
+def test_placeholder_normalization_grounds_templated_step():
+    # A templated step should ground against the concrete command that ran.
+    haystack = '{"command": "gh api repos/WingedGuardian/Genesis/code-scanning"}'
+    score = grounding_score(
+        ["gh api repos/<owner>/<repo>/code-scanning"],
+        haystack,
+    )
+    assert score >= 0.5
+
+
+def test_flags_and_paths_extracted_from_plain_text():
+    haystack = "systemctl --user restart genesis-server /home/ubuntu/genesis/data"
+    score = grounding_score(
+        ["systemctl --user restart the unit, data at /home/ubuntu/genesis/data"],
+        haystack,
+    )
+    assert score >= 0.5
+
+
+def test_backtick_command_tokenized_not_atomic():
+    # Regression for the tokenizer bug: a backtick-wrapped command must yield its
+    # individual tokens, not one atomic never-matching blob.
+    haystack = "ruff check . && pytest tests/test_x.py -q"
+    score = grounding_score(["`ruff check .` then `pytest tests/test_x.py -q`"], haystack)
+    assert score >= 0.75

--- a/tests/test_learning/test_judge_multi.py
+++ b/tests/test_learning/test_judge_multi.py
@@ -1,0 +1,150 @@
+"""Tests for the C2b multi-procedure builder (judge_multi_procedure).
+
+Covers: empty result, real store with grounding recorded, retry on an
+unparseable envelope, the per-session max_new cap, sub-procedure tagging, and the
+warning-only grounding gate (a weakly-grounded procedure still stores).
+
+The novelty embedder is forced to None (get_embedding_provider patched) so these
+tests are deterministic and offline — storage then goes through the fail-open
+path, exercising the builder's loop/store wiring without a real embedding backend.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.db.crud import procedural
+from genesis.learning.procedural import embedding as embedding_mod
+from genesis.learning.procedural.judge import judge_multi_procedure
+
+_SPINE = [{
+    "turn": 1, "type": "tool", "tool": "Bash",
+    "args_summary": '{"command": "echo hi"}', "outcome": "ok", "error_text": "",
+}]
+_SCOPING_TASK = '{"procedure_type": "task_procedure"}'
+
+
+@dataclass
+class _Result:
+    success: bool = True
+    content: str = ""
+    error: str | None = None
+
+
+def _router_seq(*results: _Result) -> MagicMock:
+    r = MagicMock()
+    r.route_call = AsyncMock(side_effect=list(results))
+    return r
+
+
+def _builder_json(procedures: list[dict]) -> str:
+    return "```json\n" + json.dumps({"procedures": procedures}) + "\n```"
+
+
+def _proc(task_type="cut-release", principle="ship the release", steps=None, **extra):
+    p = {
+        "task_type": task_type,
+        "principle": principle,
+        "steps": steps or ["run `echo hi`"],
+        "tools_used": ["Bash"],
+        "context_tags": ["release"],
+    }
+    p.update(extra)
+    return p
+
+
+@pytest.fixture(autouse=True)
+def _no_embedder(monkeypatch):
+    """Force the novelty embedder to None → deterministic fail-open store path."""
+    embedding_mod._EMBEDDING_PROVIDER = None
+    embedding_mod._fail_open_timestamps.clear()
+    monkeypatch.setattr(
+        "genesis.learning.procedural.judge.get_embedding_provider", lambda: None,
+    )
+    yield
+    embedding_mod._fail_open_timestamps.clear()
+
+
+@pytest.mark.asyncio
+async def test_builder_empty_response_returns_empty(db):
+    router = _router_seq(_Result(content=_builder_json([])))
+    assert await judge_multi_procedure(db, _SPINE, "", 0.5, router) == []
+
+
+@pytest.mark.asyncio
+async def test_builder_stores_real_procedure_and_records_grounding(db):
+    router = _router_seq(
+        _Result(content=_builder_json([_proc()])),  # builder
+        _Result(content=_SCOPING_TASK),             # scoping verdict
+    )
+    haystack = '{"command": "echo hi"}'  # grounds the step
+    stored = await judge_multi_procedure(db, _SPINE, haystack, 0.5, router)
+    assert len(stored) == 1
+
+    row = await procedural.find_by_task_type(db, "cut-release")
+    assert row is not None
+    assert row["draft"] == 1 and row["activation_tier"] == "DORMANT"
+    source = json.loads(row["source"])
+    assert source["type"] == "struggle_extraction"
+    assert "grounding_score" in source and source["grounding_score"] >= 0.5
+
+
+@pytest.mark.asyncio
+async def test_builder_retries_on_unparseable_envelope(db):
+    router = _router_seq(
+        _Result(content="not json — total garbage"),  # attempt 1 → unparseable
+        _Result(content=_builder_json([_proc()])),     # attempt 2 → valid (retry)
+        _Result(content=_SCOPING_TASK),                 # scoping
+    )
+    stored = await judge_multi_procedure(db, _SPINE, '{"command": "echo hi"}', 0.5, router)
+    assert len(stored) == 1
+
+
+@pytest.mark.asyncio
+async def test_builder_respects_max_new(db):
+    procs = [_proc(task_type=f"task-{i}") for i in range(3)]
+    router = _router_seq(
+        _Result(content=_builder_json(procs)),  # builder returns 3
+        _Result(content=_SCOPING_TASK),          # scoping for the 1 we keep
+    )
+    stored = await judge_multi_procedure(
+        db, _SPINE, '{"command": "echo hi"}', 0.5, router, max_new=1,
+    )
+    assert len(stored) == 1
+
+
+@pytest.mark.asyncio
+async def test_builder_tags_subprocedure(db):
+    proc = _proc(task_type="solve-captcha", is_subprocedure_of="publish-medium-post")
+    router = _router_seq(
+        _Result(content=_builder_json([proc])),
+        _Result(content=_SCOPING_TASK),
+    )
+    stored = await judge_multi_procedure(db, _SPINE, '{"command": "echo hi"}', 0.5, router)
+    assert len(stored) == 1
+
+    row = await procedural.find_by_task_type(db, "solve-captcha")
+    tags = json.loads(row["context_tags"])
+    assert "subprocedure_of:publish-medium-post" in tags
+
+
+@pytest.mark.asyncio
+async def test_builder_low_grounding_still_stores(db):
+    """Grounding is warning-only: a weakly-grounded procedure is STILL stored,
+    and its low score is recorded for observability."""
+    proc = _proc(task_type="weak-ground", steps=["run `frobnicate --xyz /a/b/c`"])
+    router = _router_seq(
+        _Result(content=_builder_json([proc])),
+        _Result(content=_SCOPING_TASK),
+    )
+    haystack = '{"command": "totally unrelated execution record"}'
+    stored = await judge_multi_procedure(db, _SPINE, haystack, 0.5, router)
+    assert len(stored) == 1  # stored despite low grounding
+
+    row = await procedural.find_by_task_type(db, "weak-ground")
+    source = json.loads(row["source"])
+    assert source["grounding_score"] < 0.25

--- a/tests/test_learning/test_procedure_extraction.py
+++ b/tests/test_learning/test_procedure_extraction.py
@@ -157,6 +157,59 @@ class TestBuildActionSpine:
         spine = build_action_spine(Path("/nonexistent/path.jsonl"))
         assert spine == []
 
+    def test_build_spine_and_haystack_returns_both(self):
+        """C2b: spine keeps user turns (for score_struggle); the grounding
+        haystack carries the uncapped tool inputs and excludes user text."""
+        from genesis.learning.procedural.struggle_detector import build_spine_and_haystack
+
+        path = self._write_jsonl([
+            self._tool_use_entry("Bash", {"command": "gh api repos/WingedGuardian/Genesis"}, "t1"),
+            self._tool_result_entry("t1", "ok"),
+            self._user_text_entry("try again"),
+        ])
+        spine, haystack = build_spine_and_haystack(path)
+        assert any(e["type"] == "user" for e in spine)
+        assert any(e["type"] == "tool" for e in spine)
+        assert "gh api repos/WingedGuardian/Genesis" in haystack
+        assert "try again" not in haystack  # user text never grounds a procedure
+
+    def test_haystack_excludes_exitplanmode(self):
+        from genesis.learning.procedural.struggle_detector import build_spine_and_haystack
+
+        path = self._write_jsonl([
+            self._tool_use_entry("ExitPlanMode", {"plan": "SECRET_PLAN_TEXT"}, "t1"),
+            self._tool_use_entry("Bash", {"command": "echo hi"}, "t2"),
+            self._tool_result_entry("t2", "hi"),
+        ])
+        _spine, haystack = build_spine_and_haystack(path)
+        assert "SECRET_PLAN_TEXT" not in haystack  # plan prose, not an action
+        assert "echo hi" in haystack
+
+    def test_haystack_is_uncapped_vs_capped_spine(self):
+        """The grounding haystack keeps the FULL command even when the spine's
+        args_summary is per-tool capped (Bash → 800)."""
+        from genesis.learning.procedural.struggle_detector import build_spine_and_haystack
+
+        long_cmd = "echo " + "A" * 1500 + "_TAIL_MARKER"
+        path = self._write_jsonl([
+            self._tool_use_entry("Bash", {"command": long_cmd}, "t1"),
+            self._tool_result_entry("t1", "ok"),
+        ])
+        spine, haystack = build_spine_and_haystack(path)
+        assert "_TAIL_MARKER" not in spine[0]["args_summary"]  # spine capped
+        assert "_TAIL_MARKER" in haystack  # haystack uncapped
+
+    def test_build_action_spine_wrapper_matches_first_half(self):
+        from genesis.learning.procedural.struggle_detector import (
+            build_action_spine,
+            build_spine_and_haystack,
+        )
+        path = self._write_jsonl([
+            self._tool_use_entry("Bash", {"command": "ls"}, "t1"),
+            self._tool_result_entry("t1", "ok"),
+        ])
+        assert build_action_spine(path) == build_spine_and_haystack(path)[0]
+
 
 class TestScoreStruggle:
     """Tests for struggle scoring heuristics."""
@@ -246,7 +299,9 @@ class TestFormatSpineForJudge:
         text = format_spine_for_judge(spine)
         assert "-> ERR: File not found" in text
 
-    def test_formats_user_entry(self):
+    def test_drops_user_entry(self):
+        """C2b user-blind view: user turns are dropped (a procedure is about what
+        Genesis DID, never what the user said)."""
         from genesis.learning.procedural.struggle_detector import format_spine_for_judge
 
         spine = [{
@@ -254,7 +309,22 @@ class TestFormatSpineForJudge:
             "args_summary": "try again", "outcome": "ok", "error_text": "",
         }]
         text = format_spine_for_judge(spine)
-        assert '[T=3] USER: "try again"' in text
+        assert text == ""  # only user turns → empty
+        assert "USER" not in text
+
+    def test_keeps_tool_drops_interleaved_user(self):
+        """Tool entries are kept; an interleaved user turn is omitted."""
+        from genesis.learning.procedural.struggle_detector import format_spine_for_judge
+
+        spine = [
+            {"turn": 1, "type": "tool", "tool": "Bash",
+             "args_summary": '{"command": "ls"}', "outcome": "ok", "error_text": ""},
+            {"turn": 2, "type": "user", "tool": None,
+             "args_summary": "try again", "outcome": "ok", "error_text": ""},
+        ]
+        text = format_spine_for_judge(spine)
+        assert "[T=1] TOOL: Bash" in text
+        assert "USER" not in text and "try again" not in text
 
 
 # ── Judge response parsing ──────────────────────────────────────────────────
@@ -554,38 +624,29 @@ def _proc_candidate_extraction() -> Extraction:
     )
 
 
-async def test_extract_procedures_respects_max_new(db, monkeypatch):
-    """max_new caps how many candidates are stored (and judged) per call."""
+def test_extract_procedures_from_chunk_returns_candidates():
+    """Flag-only (C2b): the chunk path CLASSIFIES candidates and returns them as
+    a list — no Judge call, no storage. Their existence is a session-level signal
+    that triggers the whole-session builder."""
     from genesis.memory import procedure_extraction as pe
 
-    calls = []
-
-    async def _fake_judge(db, candidate, ctx, router, *, source_session_id=None):
-        calls.append(candidate)
-        return f"stored-{len(calls)}"
-
-    monkeypatch.setattr(
-        "genesis.learning.procedural.judge.judge_extraction_candidate", _fake_judge,
-    )
     exts = [_proc_candidate_extraction() for _ in range(5)]
-    count = await pe.extract_procedures_from_chunk(exts, db=db, router=None, max_new=3)
-    assert count == 3
-    assert len(calls) == 3  # Judge not called once the cap is hit
+    candidates = pe.extract_procedures_from_chunk(exts)
+    assert isinstance(candidates, list)
+    assert len(candidates) == 5
+    assert all("scenario" in c and "principle" in c for c in candidates)
 
 
-async def test_extract_procedures_no_cap_when_max_new_none(db, monkeypatch):
-    """Without a cap, behavior is unchanged (all valid candidates judged)."""
+def test_extract_procedures_from_chunk_filters_non_candidates():
+    """Non-procedure extractions are filtered out of the candidate list."""
     from genesis.memory import procedure_extraction as pe
 
-    async def _fake_judge(db, candidate, ctx, router, *, source_session_id=None):
-        return "stored"
-
-    monkeypatch.setattr(
-        "genesis.learning.procedural.judge.judge_extraction_candidate", _fake_judge,
-    )
-    exts = [_proc_candidate_extraction() for _ in range(5)]
-    count = await pe.extract_procedures_from_chunk(exts, db=db, router=None)
-    assert count == 5
+    exts = [
+        _proc_candidate_extraction(),
+        Extraction(content="x" * 60, extraction_type="entity", confidence=0.9, scenario="s"),
+    ]
+    candidates = pe.extract_procedures_from_chunk(exts)
+    assert len(candidates) == 1
 
 
 class TestSummarizeArgs:

--- a/tests/test_learning/test_scoping.py
+++ b/tests/test_learning/test_scoping.py
@@ -9,16 +9,12 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from genesis.learning.procedural.extractor import extract_procedure
-from genesis.learning.procedural.judge import (
-    judge_extraction_candidate,
-    judge_struggle_procedure,
-)
+from genesis.learning.procedural.judge import judge_multi_procedure
 from genesis.learning.procedural.scoping import (
     PROCEDURE_TYPE_DIRECTIVE,
     PROCEDURE_TYPE_TASK,
@@ -188,45 +184,25 @@ async def test_extract_procedure_keeps_real_procedure(db):
 
 
 @pytest.mark.asyncio
-async def test_judge_struggle_suppresses_directive(db):
-    """Judge path (struggle stream): a directive verdict blocks storage."""
-    judge_json = (
-        '```json\n{"worth_storing": true, "task_type": "confidence-gate", '
+async def test_builder_suppresses_directive(db):
+    """The multi-procedure builder: a directive verdict blocks that procedure.
+
+    The scoping gate fires inside _store_judged_procedure (shared by every built
+    procedure) BEFORE the novelty/embedder path, so this is deterministic without
+    an embedder. Covers the C2b single judge entry point.
+    """
+    builder_json = (
+        '```json\n{"procedures": [{"task_type": "confidence-gate", '
         '"principle": "always state confidence", "steps": ["1"], '
-        '"tools_used": ["Bash"], "context_tags": ["meta"]}\n```'
+        '"tools_used": ["Bash"], "context_tags": ["meta"]}]}\n```'
     )
     router = _router_seq(
-        _Result(content=judge_json),                                    # judge
+        _Result(content=builder_json),                                  # builder
         _Result(content='{"procedure_type": "behavioral_directive"}'),  # scoping
     )
     spine = [{
         "turn": 1, "type": "tool", "tool": "Bash",
         "args_summary": "x", "outcome": "ok", "error_text": "",
     }]
-    result = await judge_struggle_procedure(db, spine, 0.5, Path("/tmp/x.jsonl"), router)
-    assert result is None  # suppressed as a behavioral directive
-
-
-@pytest.mark.asyncio
-async def test_judge_extraction_candidate_suppresses_directive(db):
-    """Judge path (extraction-candidate stream): a directive verdict blocks storage.
-
-    Covers the second judge entry point so the router threading through
-    _store_judged_procedure is caught by a dedicated test, not only structurally.
-    """
-    judge_json = (
-        '```json\n{"worth_storing": true, "task_type": "pre-plan-confidence", '
-        '"principle": "investigate before planning", "steps": ["1"], '
-        '"tools_used": ["Bash"], "context_tags": ["meta"]}\n```'
-    )
-    router = _router_seq(
-        _Result(content=judge_json),                                    # judge
-        _Result(content='{"procedure_type": "behavioral_directive"}'),  # scoping
-    )
-    candidate = {
-        "principle": "investigate before planning",
-        "scenario": "before planning",
-        "tools_used": ["Bash"],
-    }
-    result = await judge_extraction_candidate(db, candidate, "chunk context", router)
-    assert result is None  # suppressed as a behavioral directive
+    stored = await judge_multi_procedure(db, spine, "", 0.5, router)
+    assert stored == []  # suppressed as a behavioral directive

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -146,8 +146,10 @@ def test_load_full_yaml(monkeypatch):
     # 2026-05-29: 48 → 49 after dream_cycle_entity_check added (Sprint 2).
     # 2026-06-06: 49 → 51 after dream_cycle_synthesis_challenge + dream_cycle_entity_challenge (immune system PR).
     # 2026-06-20: 51 → 52 after crag_grade added (W-CRAG selective corrective retrieval, PR #711).
-    assert len(cfg.call_sites) == 52
+    # 2026-06-30: 52 → 53 after 38a_procedure_novelty_llm added (C2b cross-type procedure dedup).
+    assert len(cfg.call_sites) == 53
     assert "crag_grade" in cfg.call_sites  # W-CRAG runtime grader (2026-06-20)
+    assert "38a_procedure_novelty_llm" in cfg.call_sites  # C2b cross-type dedup (2026-06-30)
     assert "models_md_synthesis" not in cfg.call_sites  # removed 2026-05-24
     assert "2_triage" not in cfg.call_sites  # removed 2026-05-10
     assert "7_task_retrospective" not in cfg.call_sites  # removed 2026-05-10 (duplicate; live one is 43_task_retrospective)


### PR DESCRIPTION
## Context

Stacked follow-up to C2a (#806). C2a fixed the *shape* of learned procedures (concrete playbooks, not essays) and widened the spine arg-caps. C2b fixes the rest of why the procedure store fills with low-value near-duplicates: it makes the builder produce **0..N topic-segmented playbooks from a user-blind view**, keeps only what the agent actually **ran** (observability-only grounding), and stops minting **duplicates** — including ones filed under a different name.

## What changed

- **`struggle_detector`** — `build_spine_and_haystack()` returns the action spine **plus** an uncapped "grounding haystack" (the real executed tool inputs). `format_spine_for_judge()` is now **user-blind** (tool actions only) — the biggest noise cut. `build_action_spine()` kept as a thin wrapper.
- **`grounding.py`** (new) — `grounding_score()` measures how much of a built procedure's commands actually appear in the execution record. **Observability-only: it logs a warning but never drops a procedure.**
- **`judge.judge_multi_procedure()`** — single entry point; builds 0..N topic-segmented playbooks in one pass, per-item parse + one retry, sub-procedure → `context_tags` tag. Replaces the old single-procedure struggle judge and the per-candidate chunk judge.
- **`procedure_extraction`** — flag-only: classifies chunk candidates as a session-level signal (no per-chunk LLM/store). Fixes a priority inversion where the chunk path could exhaust the per-session cap before the higher-fidelity whole-session builder ran.
- **`extraction_job`** — runs the builder once after the chunk loop when the struggle score crosses threshold **or** candidates were flagged; correct cap accounting; per-session cap 3→7.
- **`extractor._principle_is_novel`** — adds **cross-task_type** dedup: stored-embedding cosine prefilter → top-N → one LLM "is this redundant?" check (new routing call-site). Same-type compare is now BLOB-first. Fail-open throughout.
- **`embedding.py`** — shared embedder singleton + cross-path fail-open rate limiter (was duplicated).
- **`crud.list_by_task_type`** — excludes deprecated/quarantined rows (dedup correctness).

Server-side (extraction job) — takes effect on deploy/restart.

## Verification

- Targeted suites green (learning, extraction-job, db, routing) + new tests for grounding, the multi-procedure builder, cross-type novelty, and haystack emission. Lint clean.
- Code-reviewed (one flagged item verified a false positive and documented; two minor items fixed: accurate cap log, rollback-on-timeout).
- **E2E on a copy of the live DB with a real model + live embedder**: real transcripts produced grounded, topic-segmented playbooks (incl. a tagged sub-procedure), most sessions correctly produced nothing, the per-session cap held, and a second pass deduplicated against the first (2 stored → 0).