### PR TITLE
fix(dashboard): move system banners to page-top (slim bars, every tab)

### DIFF
--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -4544,13 +4544,41 @@
               @click="location.hash = 'backup'">Backup & Updates</button>
     </nav>
 
-    <!-- CC model-fallback banner (page-top, full-width, visible on every tab):
-         the server-side conversation is failed over to a roster peer because the
-         home model (Claude) is rate-limited account-wide. Placed here (block flow,
-         outside the flex-row .panel) so it renders as a slim top bar, not a column. -->
+    <!-- Global system banners (page-top, full-width block flow, visible on every
+         tab). Kept OUTSIDE the flex-row .panel so each renders as a slim top bar,
+         not a stretched column, and so these global conditions surface on all tabs. -->
+    <!-- Stale data warning -->
+    <template x-if="$store.genesisDashboard.healthStale">
+      <div style="background: #d9534f; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center;">
+        Health data stale — API unreachable. Data shown may be outdated.
+      </div>
+    </template>
+    <!-- Genesis paused banner -->
+    <template x-if="$store.genesisDashboard.pauseState.paused">
+      <div style="background: #f0ad4e; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center;">
+        Genesis is paused — background processing suspended. Use the pause button or /pause off in Telegram to resume.
+      </div>
+    </template>
+    <!-- CC model-fallback banner: the server-side conversation is failed over to a
+         roster peer because the home model (Claude) is rate-limited account-wide. -->
     <template x-if="$store.genesisDashboard.health.cc_sessions?.fallback?.is_fallback">
       <div style="background: #f0ad4e; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center;"
            x-text="'⚠ Running on ' + ($store.genesisDashboard.health.cc_sessions.fallback.fallback || 'a roster peer') + ' — Claude ' + ($store.genesisDashboard.health.cc_sessions.fallback.reason || 'unavailable').replace(/_/g, ' ') + ' since ' + (($store.genesisDashboard.health.cc_sessions.fallback.since || '').replace('T', ' ').slice(0, 16) || 'unknown')"></div>
+    </template>
+    <!-- Resilience degradation banner -->
+    <template x-if="$store.genesisDashboard.health.resilience?.level && $store.genesisDashboard.health.resilience.level !== 'L0' && $store.genesisDashboard.health.resilience.level !== 'not configured'">
+      <div :style="`background: ${['L3', 'L4', 'L5', 'error'].includes($store.genesisDashboard.health.resilience.level) ? '#d9534f' : '#f0ad4e'}; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center; overflow-wrap: break-word; white-space: normal; line-height: 1.3;`"
+           x-text="'Resilience: ' + $store.genesisDashboard.health.resilience.level + ' — ' + ($store.genesisDashboard.health.resilience.summary || 'system is operating in degraded mode')">
+      </div>
+    </template>
+    <!-- Provider alert banners (credit exhaustion, missing critical keys) -->
+    <template x-for="alert in ($store.genesisDashboard.health.api_keys?.alerts || []).filter(a => a.severity === 'critical')" :key="'prov-crit-' + alert.provider_type">
+      <div style="background: rgba(217,83,79,0.15); border: 1px solid #d9534f; border-radius: 6px; padding: 0.5rem 1rem; margin: 0.25rem 0.5rem; font-size: 0.82rem; font-weight: 600; color: #d9534f; text-align: center;"
+           x-text="alert.message"></div>
+    </template>
+    <template x-for="alert in ($store.genesisDashboard.health.api_keys?.alerts || []).filter(a => a.severity === 'warning')" :key="'prov-warn-' + alert.provider_type">
+      <div style="background: rgba(240,173,78,0.15); border: 1px solid #f0ad4e; border-radius: 6px; padding: 0.5rem 1rem; margin: 0.25rem 0.5rem; font-size: 0.82rem; font-weight: 600; color: #f0ad4e; text-align: center;"
+           x-text="alert.message"></div>
     </template>
 
     <!-- Panel 1: System Health [Tab: overview] -->
@@ -4568,33 +4596,6 @@
             : $store.genesisDashboard.overallHealthSemantic().state"></span>
         </span>
       </div>
-      <!-- Stale data warning -->
-      <template x-if="$store.genesisDashboard.healthStale">
-        <div style="background: #d9534f; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center;">
-          Health data stale — API unreachable. Data shown may be outdated.
-        </div>
-      </template>
-      <!-- Genesis paused banner -->
-      <template x-if="$store.genesisDashboard.pauseState.paused">
-        <div style="background: #f0ad4e; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center;">
-          Genesis is paused — background processing suspended. Use the pause button or /pause off in Telegram to resume.
-        </div>
-      </template>
-      <!-- Resilience degradation banner -->
-      <template x-if="$store.genesisDashboard.health.resilience?.level && $store.genesisDashboard.health.resilience.level !== 'L0' && $store.genesisDashboard.health.resilience.level !== 'not configured'">
-        <div :style="`background: ${['L3', 'L4', 'L5', 'error'].includes($store.genesisDashboard.health.resilience.level) ? '#d9534f' : '#f0ad4e'}; color: white; padding: 0.5rem 1rem; font-size: 0.85rem; font-weight: 600; text-align: center; overflow-wrap: break-word; white-space: normal; line-height: 1.3;`"
-             x-text="'Resilience: ' + $store.genesisDashboard.health.resilience.level + ' — ' + ($store.genesisDashboard.health.resilience.summary || 'system is operating in degraded mode')">
-        </div>
-      </template>
-      <!-- Provider alert banners (credit exhaustion, missing critical keys) -->
-      <template x-for="alert in ($store.genesisDashboard.health.api_keys?.alerts || []).filter(a => a.severity === 'critical')" :key="'prov-crit-' + alert.provider_type">
-        <div style="background: rgba(217,83,79,0.15); border: 1px solid #d9534f; border-radius: 6px; padding: 0.5rem 1rem; margin: 0.25rem 0.5rem; font-size: 0.82rem; font-weight: 600; color: #d9534f; text-align: center;"
-             x-text="alert.message"></div>
-      </template>
-      <template x-for="alert in ($store.genesisDashboard.health.api_keys?.alerts || []).filter(a => a.severity === 'warning')" :key="'prov-warn-' + alert.provider_type">
-        <div style="background: rgba(240,173,78,0.15); border: 1px solid #f0ad4e; border-radius: 6px; padding: 0.5rem 1rem; margin: 0.25rem 0.5rem; font-size: 0.82rem; font-weight: 600; color: #f0ad4e; text-align: center;"
-             x-text="alert.message"></div>
-      </template>
       <div class="panel-body">
         <template x-if="$store.genesisDashboard.panelStatusDetail('health')">
           <div class="panel-status-detail" x-text="$store.genesisDashboard.panelStatusDetail('health')"></div>


### PR DESCRIPTION
## What

The dashboard's stale-data, paused, resilience-degradation, and provider-alert banners lived **inside** the System Health panel. That panel is a flex-row container, so an active banner rendered as a stretched full-height **column** wedged between the panel title and the cards — and the banners only showed on the Overview tab.

This moves all of them to the **page-top block container** (joining the CC model-fallback banner added in #811), so each renders as a **slim full-width bar** and stays visible on **every tab** — which is what you want for global conditions (API unreachable, Genesis paused, resilience degraded, provider credit/key alerts).

Pure relocation: the banner conditions, styles, and bindings are unchanged.

## Verification

Rendered in a real browser with fallback + resilience + provider-critical + provider-warning all active simultaneously: all banners stack as slim full-width bars (~32px tall) above the panel, and remain visible after switching to a non-overview tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)