### PR TITLE
feat(feedback): verified-correctness signal for surplus background tasks

### DIFF
--- a/src/genesis/db/crud/outcome_events.py
+++ b/src/genesis/db/crud/outcome_events.py
@@ -163,11 +163,14 @@ async def aggregate_by_domain(
 
     Note on surplus "hollow" tasks: an insight task that ran but produced nothing
     useful emits TWO tier-1 rows — a positive EXECUTION_OUTCOME ("it ran") and a
-    negative VERIFICATION_FAILED ("output was useless") — so it shows up here as
-    ``n=2, positive=1, negative=1, avg_value≈0.5`` by design. A useful task is
-    ``n=1, avg_value=1.0``; a hard failure is ``n=1, avg_value=0.0``. Read
-    ``avg_value`` (or ``positive``/``negative``), not ``positive/n``, to rank
-    domain quality — the latter understates useful tasks relative to hollow ones.
+    negative VERIFICATION_FAILED ("output was useless") — so it contributes ``n=2``
+    (one positive, one negative) to its domain. For the ``source='surplus'`` feed,
+    every ``value`` is 0.0/1.0 and aligned with ``polarity``, so ``avg_value`` and
+    ``positive/n`` are IDENTICAL here; both already fold in the hollow penalty.
+    Ordering still holds — a domain of U useful / H hollow / F failed scores
+    ``(U+H)/(U+2H+F)``, i.e. all-useful=1.0 > hollow-mixed > all-failed=0.0. The
+    n=2 weighting makes a hollow task count as ~1/3 effective credit, not 1/2; a
+    consumer that needs exact per-task semantics must dedup by ``ref_id``.
     """
     sql = """
         SELECT domain,

--- a/src/genesis/db/crud/outcome_events.py
+++ b/src/genesis/db/crud/outcome_events.py
@@ -160,6 +160,14 @@ async def aggregate_by_domain(
     restricts to a single producer (e.g. ``source='surplus'``) so a consumer can
     fold in one clean domain without double-counting producers it already
     aggregates by other means.
+
+    Note on surplus "hollow" tasks: an insight task that ran but produced nothing
+    useful emits TWO tier-1 rows — a positive EXECUTION_OUTCOME ("it ran") and a
+    negative VERIFICATION_FAILED ("output was useless") — so it shows up here as
+    ``n=2, positive=1, negative=1, avg_value≈0.5`` by design. A useful task is
+    ``n=1, avg_value=1.0``; a hard failure is ``n=1, avg_value=0.0``. Read
+    ``avg_value`` (or ``positive``/``negative``), not ``positive/n``, to rank
+    domain quality — the latter understates useful tasks relative to hollow ones.
     """
     sql = """
         SELECT domain,

--- a/src/genesis/db/crud/surplus_tasks.py
+++ b/src/genesis/db/crud/surplus_tasks.py
@@ -73,11 +73,12 @@ async def mark_completed(
     *,
     completed_at: str,
     result_staging_id: str | None = None,
+    outcome_quality: str | None = None,
 ) -> bool:
     cursor = await db.execute(
         "UPDATE surplus_tasks SET status = 'completed', completed_at = ?, "
-        "result_staging_id = ? WHERE id = ?",
-        (completed_at, result_staging_id, id),
+        "result_staging_id = ?, outcome_quality = ? WHERE id = ?",
+        (completed_at, result_staging_id, outcome_quality, id),
     )
     await db.commit()
     return cursor.rowcount > 0

--- a/src/genesis/db/migrations/0041_surplus_outcome_quality.py
+++ b/src/genesis/db/migrations/0041_surplus_outcome_quality.py
@@ -1,0 +1,46 @@
+"""Add outcome_quality column to surplus_tasks (verified-correctness verdict).
+
+``outcome_quality`` records whether an insight-producing surplus task's output
+was actually *useful* — not just whether it *ran*. A terminal ``status`` of
+``completed`` only means "the work ran to completion"; it says nothing about
+whether the produced insight survived the intake quality gate. This column
+captures that second axis so the Outcome Bus carries discriminative negatives.
+
+Values (set only for ``surplus.types.INSIGHT_PRODUCING_TASK_TYPES``):
+  - ``useful`` : intake routed >=1 finding to knowledge/observations.
+  - ``hollow`` : intake ran but routed everything to discard (ran, produced
+                 nothing of value) -> harvested as a VERIFICATION_FAILED negative.
+  - ``NULL``   : action task, legacy row, intake infra-failure, or empty/
+                 too-short output. NULL keeps the existing positive-only
+                 behaviour (no retroactive flip; the harvester treats NULL like
+                 a plain completion).
+
+Additive and backward-compatible: existing rows backfill to NULL. The harvester
+(feedback/harvest.py) keeps emitting the EXECUTION_OUTCOME positive for every
+completed task unchanged, and only ADDS a VERIFICATION_FAILED row when
+``outcome_quality = 'hollow'``.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # Table may not exist if migrations run on a fresh DB before schema init.
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='surplus_tasks'"
+    )
+    if not await cursor.fetchone():
+        return
+
+    # Only add column if it doesn't already exist (fresh DBs get it from the
+    # canonical CREATE TABLE in db/schema/_tables.py).
+    col_cursor = await db.execute("PRAGMA table_info(surplus_tasks)")
+    cols = {row[1] for row in await col_cursor.fetchall()}
+    if "outcome_quality" not in cols:
+        await db.execute(
+            "ALTER TABLE surplus_tasks "
+            "ADD COLUMN outcome_quality TEXT "
+            "CHECK (outcome_quality IN ('useful', 'hollow'))"
+        )

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -344,7 +344,13 @@ TABLES = {
             result_staging_id TEXT,
             failure_reason    TEXT,
             attempt_count     INTEGER NOT NULL DEFAULT 0,
-            not_before        TEXT
+            not_before        TEXT,
+            -- Verified-correctness verdict for insight-producing tasks (see
+            -- surplus.types.INSIGHT_PRODUCING_TASK_TYPES). 'useful' = intake
+            -- routed >=1 finding to knowledge/observation; 'hollow' = intake
+            -- ran but routed everything to discard. NULL = action task, legacy
+            -- row, intake-failure, or empty/too-short output (not penalized).
+            outcome_quality   TEXT CHECK (outcome_quality IN ('useful', 'hollow'))
         )
     """,
     "drive_weights": """

--- a/src/genesis/ego/capability_aggregator.py
+++ b/src/genesis/ego/capability_aggregator.py
@@ -157,6 +157,11 @@ async def compute_capability_map(db: aiosqlite.Connection) -> list[dict]:
                 # rate = positive / n is provably in [0, 1]; passing an
                 # out-of-range value would make inverse_confidence_weight raise
                 # and silently degrade the WHOLE domain to an arithmetic mean.
+                # NB (LC3-B go-live tuning): a surplus "hollow" task contributes
+                # two rows (pos EXECUTION_OUTCOME + neg VERIFICATION_FAILED), so it
+                # inflates ``n`` by 2 and counts as ~1/3 effective credit here, not
+                # 1/2. Discrimination is correct (useful > hollow > failed); revisit
+                # the exact hollow weight / per-task dedup when enabling this feed.
                 rate = positive / n
                 domain = row.get("domain")
                 if not domain:

--- a/src/genesis/feedback/harvest.py
+++ b/src/genesis/feedback/harvest.py
@@ -51,6 +51,11 @@ BACKFILL_MARKER = "outcome_backfill_done"
 # idempotent on the (source, ref_type, ref_id, signal_type) unique key, so
 # already-harvested rows are INSERT-OR-IGNORE no-ops (read I/O, no WAL write).
 # v2 (2026-06-29): added the surplus_tasks source.
+# NO bump for the surplus verified-correctness signal (2026-06-30): the new
+# VERIFICATION_FAILED rows only exist for tasks completed AFTER deploy (legacy
+# rows have NULL outcome_quality and so can never be hollow). There is nothing
+# historical to re-backfill, and new hollow tasks are picked up by the normal
+# incremental window — a forced full re-backfill would be pure wasted I/O.
 BACKFILL_VERSION = 2
 
 # Markers update_proposal_outcome appends to ego_proposals.user_response.
@@ -322,6 +327,14 @@ class OutcomeHarvester:
         ``completed``/``failed`` is a real "did the work run to completion"
         signal. ``cutoff`` (ISO) limits to recent rows; ``None`` = all history.
 
+        Two orthogonal signals per task: EXECUTION_OUTCOME ("did the work run")
+        and — for insight-producing types whose output was hollow — an additional
+        VERIFICATION_FAILED ("was the output useful"). A hollow task therefore
+        yields BOTH a positive (it ran) and a negative (it produced nothing),
+        netting ~0.5 in ``aggregate_by_domain`` — below a useful task (1.0) and
+        above a hard failure (0.0). See ``surplus.types.INSIGHT_PRODUCING_TASK_TYPES``
+        and ``surplus_tasks.outcome_quality``.
+
         Maintainer notes (deliberate asymmetries):
         - ``cancelled`` (and non-terminal pending/running) tasks are NOT
           recorded — a cancel is a lifecycle event, not an execution outcome.
@@ -339,7 +352,7 @@ class OutcomeHarvester:
         """
         sql = (
             "SELECT id, task_type, status, failure_reason, completed_at, "
-            "       created_at "
+            "       created_at, outcome_quality "
             "FROM surplus_tasks WHERE status IN ('completed', 'failed')"
         )
         params: list = []
@@ -370,6 +383,33 @@ class OutcomeHarvester:
             )
             if eid:
                 inserted += 1
+
+            # Verified-correctness (second, orthogonal axis). EXECUTION_OUTCOME
+            # above answers "did it run"; this answers "was the output useful".
+            # A completed insight task whose intake routed EVERYTHING to discard
+            # is hollow — it ran but produced nothing of value — so it earns an
+            # ADDITIONAL tier-1 negative. Because VERIFICATION_FAILED is a
+            # distinct signal_type, it coexists with the positive EXECUTION_OUTCOME
+            # on the same (source, ref_type, ref_id) under the unique key; the two
+            # never dup-suppress each other across incremental re-harvests.
+            # NULL outcome_quality (action tasks, legacy rows, intake failures,
+            # empty/too-short output) adds nothing here — positive-only, unchanged.
+            if completed and r["outcome_quality"] == "hollow":
+                veid = await record_outcome(
+                    self._db,
+                    source="surplus",
+                    ref_type="task",
+                    ref_id=r["id"],
+                    domain=r["task_type"],
+                    signal_type=SignalType.VERIFICATION_FAILED,
+                    polarity="negative",
+                    value=0.0,
+                    reason_text="intake routed all findings to discard (hollow)",
+                    occurred_at=r["completed_at"] or r["created_at"],
+                    harvested_from="surplus_tasks",
+                )
+                if veid:
+                    inserted += 1
         return inserted
 
     # -- helper ------------------------------------------------------------- #

--- a/src/genesis/surplus/queue.py
+++ b/src/genesis/surplus/queue.py
@@ -74,11 +74,17 @@ class SurplusQueue:
             self._db, task_id, started_at=self._clock().isoformat(),
         )
 
-    async def mark_completed(self, task_id: str, staging_id: str | None = None) -> None:
+    async def mark_completed(
+        self,
+        task_id: str,
+        staging_id: str | None = None,
+        outcome_quality: str | None = None,
+    ) -> None:
         await surplus_tasks.mark_completed(
             self._db, task_id,
             completed_at=self._clock().isoformat(),
             result_staging_id=staging_id,
+            outcome_quality=outcome_quality,
         )
 
     async def mark_failed(self, task_id: str, reason: str) -> None:

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -1595,6 +1595,7 @@ class SurplusScheduler:
         logger.info("Dispatching surplus task %s (%s)", task.id, task.task_type)
         await self._queue.mark_running(task.id)
 
+        from genesis.surplus.types import INSIGHT_PRODUCING_TASK_TYPES
         from genesis.surplus.types import TaskType as _TT
 
         executor = self._executor
@@ -1669,6 +1670,11 @@ class SurplusScheduler:
 
         # 6. Route through intake pipeline (atomize → score → route to knowledge)
         staging_id = None
+        # Verified-correctness verdict (insight-producing types only). Stays NULL
+        # for action tasks, intake failures, and empty/too-short output — all
+        # ambiguous or not-a-quality-signal, so they keep the positive-only
+        # behaviour. Only set to 'useful'/'hollow' once intake has actually run.
+        outcome_quality: str | None = None
         if result.insights:
             insight = result.insights[0]
             content = result.content or ""
@@ -1700,6 +1706,17 @@ class SurplusScheduler:
                         intake_stats.routed_discard,
                         task.id[:8],
                     )
+                    # Verified-correctness verdict: for insight-producing types,
+                    # intake having routed nothing to knowledge/observations means
+                    # the work ran but produced nothing of value (hollow). This is
+                    # the only path that sets the verdict — empty/too-short output
+                    # and intake failures stay NULL on purpose (see above).
+                    if task.task_type in INSIGHT_PRODUCING_TASK_TYPES:
+                        kept = (
+                            intake_stats.routed_knowledge
+                            + intake_stats.routed_observation
+                        )
+                        outcome_quality = "useful" if kept > 0 else "hollow"
                     # Use a synthetic staging_id for tracking
                     content_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
                     staging_id = f"{task.task_type.value}-{content_hash}"
@@ -1726,7 +1743,9 @@ class SurplusScheduler:
                         ttl=ttl,
                     )
 
-        await self._queue.mark_completed(task.id, staging_id=staging_id)
+        await self._queue.mark_completed(
+            task.id, staging_id=staging_id, outcome_quality=outcome_quality,
+        )
 
         # Pipeline chaining — enqueue next step if this was a pipeline task.
         # Note: if a step returns NOMINAL (empty content), chaining still

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -24,7 +24,7 @@ from genesis.surplus.compute_availability import ComputeAvailability
 from genesis.surplus.executor import StubExecutor
 from genesis.surplus.idle_detector import IdleDetector
 from genesis.surplus.queue import SurplusQueue
-from genesis.surplus.types import SurplusExecutor
+from genesis.surplus.types import INSIGHT_PRODUCING_TASK_TYPES, SurplusExecutor
 
 if TYPE_CHECKING:
     from genesis.memory.store import MemoryStore
@@ -1595,7 +1595,6 @@ class SurplusScheduler:
         logger.info("Dispatching surplus task %s (%s)", task.id, task.task_type)
         await self._queue.mark_running(task.id)
 
-        from genesis.surplus.types import INSIGHT_PRODUCING_TASK_TYPES
         from genesis.surplus.types import TaskType as _TT
 
         executor = self._executor

--- a/src/genesis/surplus/types.py
+++ b/src/genesis/surplus/types.py
@@ -43,6 +43,43 @@ class TaskType(StrEnum):
     FRESH_SESSION_TEST = "fresh_session_test"
 
 
+# Task types whose *success* means "produced a useful insight that belongs in the
+# knowledge base", as opposed to "an action ran to completion". Only these are
+# eligible for the verified-correctness verdict (``outcome_quality``): when one of
+# them completes but the intake pipeline routes ALL of its findings to discard
+# (nothing reached knowledge or observations), the work was hollow — it ran but
+# produced nothing of value — and the Outcome Bus records a VERIFICATION_FAILED
+# negative alongside the usual EXECUTION_OUTCOME positive.
+#
+# Deliberately EXCLUDED (would manufacture false negatives):
+#   - Action tasks (CODE_INDEX, MODEL_EVAL, DISK_CLEANUP, DB_MAINTENANCE,
+#     DEAD_LETTER_REPLAY, BACKUP_VERIFICATION, J9_EVAL_BATCH, FRESH_SESSION_TEST):
+#     success = the action ran; they don't target the KB, so all-discard is normal.
+#   - Pipeline intermediates (RESEARCH_QUERY_GEN, PROMPT_REVIEW_CATALOG,
+#     PROMPT_REVIEW_SAMPLE): their output feeds the *next* pipeline step, not the
+#     KB, so intake legitimately discards it. Only the pipeline *terminals*
+#     (ANTICIPATORY_RESEARCH, PROMPT_EFFECTIVENESS_REVIEW) produce KB-bound insight.
+#   - Monitoring/probe types (INFRASTRUCTURE_MONITOR, CC_MEMORY_STALENESS): a
+#     "nothing noteworthy / all healthy" pass is the EXPECTED good outcome, and
+#     their status content isn't durable knowledge — all-discard isn't a failure.
+#   - BOOKMARK_ENRICHMENT: uses a dedicated executor whose intake routing is not
+#     yet validated (no live volume). Excluded NULL-on-uncertainty (matches the
+#     codebase's conservative-classification norm); add once its routing is proven.
+INSIGHT_PRODUCING_TASK_TYPES: frozenset[TaskType] = frozenset({
+    TaskType.BRAINSTORM_USER,
+    TaskType.BRAINSTORM_SELF,
+    TaskType.META_BRAINSTORM,
+    TaskType.MEMORY_AUDIT,
+    TaskType.PROCEDURE_AUDIT,
+    TaskType.GAP_CLUSTERING,
+    TaskType.SELF_UNBLOCK,
+    TaskType.ANTICIPATORY_RESEARCH,
+    TaskType.PROMPT_EFFECTIVENESS_REVIEW,
+    TaskType.CODE_AUDIT,
+    TaskType.WING_AUDIT,
+})
+
+
 class ComputeTier(StrEnum):
     LOCAL_30B = "local_30b"
     FREE_API = "free_api"

--- a/tests/feedback/test_harvest.py
+++ b/tests/feedback/test_harvest.py
@@ -80,16 +80,17 @@ async def _add_outreach(
 
 async def _add_surplus(
     db, *, tid, status, task_type="code_audit", failure_reason=None,
-    completed_at=None, created_at=None,
+    completed_at=None, created_at=None, outcome_quality=None,
 ):
     created_at = created_at or _recent(hours=2)
     completed_at = completed_at if completed_at is not None else _recent(hours=1)
     await db.execute(
         "INSERT INTO surplus_tasks "
         "(id, task_type, compute_tier, priority, drive_alignment, status, "
-        " failure_reason, created_at, completed_at) "
-        "VALUES (?, ?, 'local', 0.5, 'curiosity', ?, ?, ?, ?)",
-        (tid, task_type, status, failure_reason, created_at, completed_at),
+        " failure_reason, created_at, completed_at, outcome_quality) "
+        "VALUES (?, ?, 'local', 0.5, 'curiosity', ?, ?, ?, ?, ?)",
+        (tid, task_type, status, failure_reason, created_at, completed_at,
+         outcome_quality),
     )
     await db.commit()
 
@@ -306,6 +307,84 @@ class TestHarvestSurplusTasks:
         assert await oe.count(db) == 0
         await OutcomeHarvester(db).run_backfill()
         assert await oe.count(db) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Surplus verified-correctness (#4 — the second, orthogonal axis)
+# --------------------------------------------------------------------------- #
+class TestSurplusVerifiedCorrectness:
+    @pytest.mark.asyncio
+    async def test_hollow_emits_positive_AND_verification_failed(self, db):
+        # A completed insight task whose output was hollow gets BOTH the usual
+        # EXECUTION_OUTCOME positive ("it ran") and an additional, discriminative
+        # VERIFICATION_FAILED negative ("output was useless").
+        await _add_surplus(
+            db, tid="h1", status="completed", task_type="brainstorm_self",
+            outcome_quality="hollow",
+        )
+        await OutcomeHarvester(db).run_backfill()
+
+        assert await oe.count_by_signal_type(db) == {
+            "execution_outcome": 1, "verification_failed": 1,
+        }
+        rows = await oe.recent(db, limit=10)
+        vf = next(r for r in rows if r["signal_type"] == "verification_failed")
+        assert vf["signal_tier"] == 1
+        assert vf["polarity"] == "negative"
+        assert vf["value"] == 0.0
+        assert vf["domain"] == "brainstorm_self"
+        assert vf["source"] == "surplus"
+        assert vf["harvested_from"] == "surplus_tasks"
+        assert vf["stated_confidence"] is None  # excluded from calibration
+        eo = next(r for r in rows if r["signal_type"] == "execution_outcome")
+        assert eo["polarity"] == "positive" and eo["value"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_useful_is_positive_only(self, db):
+        await _add_surplus(
+            db, tid="u1", status="completed", task_type="brainstorm_self",
+            outcome_quality="useful",
+        )
+        await OutcomeHarvester(db).run_backfill()
+        assert await oe.count_by_signal_type(db) == {"execution_outcome": 1}
+
+    @pytest.mark.asyncio
+    async def test_legacy_null_is_positive_only(self, db):
+        # Legacy / action / intake-failure / empty rows (NULL outcome_quality)
+        # keep the original positive-only behaviour — no retroactive negatives.
+        await _add_surplus(
+            db, tid="l1", status="completed", task_type="code_audit",
+            outcome_quality=None,
+        )
+        await OutcomeHarvester(db).run_backfill()
+        assert await oe.count_by_signal_type(db) == {"execution_outcome": 1}
+
+    @pytest.mark.asyncio
+    async def test_failed_hollow_does_not_double_emit(self, db):
+        # Defensive: outcome_quality is only ever set on completed rows, but a
+        # (failed, hollow) row must NOT add a verification_failed — a failure is
+        # already the negative; verification applies to COMPLETED work only.
+        await _add_surplus(
+            db, tid="f1", status="failed", task_type="code_audit",
+            outcome_quality="hollow", failure_reason="boom",
+        )
+        await OutcomeHarvester(db).run_backfill()
+        assert await oe.count_by_signal_type(db) == {"execution_outcome": 1}
+
+    @pytest.mark.asyncio
+    async def test_hollow_idempotent_across_reruns(self, db):
+        # The two signals coexist under the (source, ref_type, ref_id, signal_type)
+        # unique key and neither dup-suppresses the other on incremental re-scan.
+        await _add_surplus(
+            db, tid="h2", status="completed", task_type="code_audit",
+            outcome_quality="hollow",
+        )
+        await OutcomeHarvester(db).run()
+        await OutcomeHarvester(db).run()  # re-scan same window
+        assert await oe.count(db) == 2
+        assert await oe.count_by_signal_type(db) == {
+            "execution_outcome": 1, "verification_failed": 1,
+        }
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_db/test_migration_0041_surplus_outcome_quality.py
+++ b/tests/test_db/test_migration_0041_surplus_outcome_quality.py
@@ -1,0 +1,129 @@
+"""Migration 0041 — add ``outcome_quality`` to surplus_tasks.
+
+Records the verified-correctness verdict for insight-producing surplus tasks
+('useful' / 'hollow' / NULL). The test builds the *pre-migration* schema
+explicitly (no outcome_quality column) so it exercises the real
+``ALTER TABLE … ADD COLUMN`` regardless of current DDL.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M41 = importlib.import_module(
+    "genesis.db.migrations.0041_surplus_outcome_quality"
+)
+
+
+async def _columns(db: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await db.execute(f"PRAGMA table_info({table})")
+    return {row[1] for row in await cur.fetchall()}
+
+
+async def _build_pre_state(conn: aiosqlite.Connection) -> None:
+    """surplus_tasks as it existed *before* 0041 — no outcome_quality column."""
+    await conn.execute(
+        """
+        CREATE TABLE surplus_tasks (
+            id                TEXT PRIMARY KEY,
+            task_type         TEXT NOT NULL,
+            compute_tier      TEXT NOT NULL,
+            priority          REAL NOT NULL DEFAULT 0.5,
+            drive_alignment   TEXT NOT NULL,
+            status            TEXT NOT NULL DEFAULT 'pending',
+            payload           TEXT,
+            created_at        TEXT NOT NULL,
+            started_at        TEXT,
+            completed_at      TEXT,
+            result_staging_id TEXT,
+            failure_reason    TEXT,
+            attempt_count     INTEGER NOT NULL DEFAULT 0,
+            not_before        TEXT
+        )
+        """
+    )
+    await conn.commit()
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await _build_pre_state(conn)
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_adds_column(db):
+    assert "outcome_quality" not in await _columns(db, "surplus_tasks")
+    await M41.up(db)
+    assert "outcome_quality" in await _columns(db, "surplus_tasks")
+
+
+@pytest.mark.asyncio
+async def test_preserves_existing_rows_with_null(db):
+    await db.execute(
+        "INSERT INTO surplus_tasks "
+        "(id, task_type, compute_tier, drive_alignment, status, created_at) "
+        "VALUES ('t1', 'code_audit', 'local', 'competence', 'completed', "
+        "'2026-06-24T00:00:00+00:00')"
+    )
+    await db.commit()
+
+    await M41.up(db)
+
+    cur = await db.execute(
+        "SELECT task_type, outcome_quality FROM surplus_tasks WHERE id='t1'"
+    )
+    row = await cur.fetchone()
+    assert row["task_type"] == "code_audit"
+    assert row["outcome_quality"] is None  # new column, no backfill
+
+
+@pytest.mark.asyncio
+async def test_check_constraint_allows_valid_and_null(db):
+    await M41.up(db)
+    for verdict in ("useful", "hollow", None):
+        await db.execute(
+            "INSERT INTO surplus_tasks "
+            "(id, task_type, compute_tier, drive_alignment, status, created_at, "
+            " outcome_quality) "
+            "VALUES (?, 'brainstorm_self', 'local', 'curiosity', 'completed', "
+            "'2026-06-24T00:00:00+00:00', ?)",
+            (f"ok-{verdict}", verdict),
+        )
+    await db.commit()  # no IntegrityError
+
+
+@pytest.mark.asyncio
+async def test_check_constraint_rejects_invalid(db):
+    await M41.up(db)
+    with pytest.raises(aiosqlite.IntegrityError):
+        await db.execute(
+            "INSERT INTO surplus_tasks "
+            "(id, task_type, compute_tier, drive_alignment, status, created_at, "
+            " outcome_quality) "
+            "VALUES ('bad', 'brainstorm_self', 'local', 'curiosity', 'completed', "
+            "'2026-06-24T00:00:00+00:00', 'garbage')"
+        )
+
+
+@pytest.mark.asyncio
+async def test_idempotent_on_rerun(db):
+    await M41.up(db)
+    await M41.up(db)  # must not raise "duplicate column name"
+    assert "outcome_quality" in await _columns(db, "surplus_tasks")
+
+
+@pytest.mark.asyncio
+async def test_skips_when_base_table_absent(tmp_path):
+    """The runner applies migrations against a bare DB; 0041 must skip cleanly
+    rather than fail on a missing table."""
+    async with aiosqlite.connect(str(tmp_path / "bare.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute("CREATE TABLE schema_migrations (version TEXT)")
+        await conn.commit()
+        await M41.up(conn)  # must not raise (no such table: surplus_tasks)

--- a/tests/test_db/test_surplus_tasks.py
+++ b/tests/test_db/test_surplus_tasks.py
@@ -98,6 +98,25 @@ async def test_mark_completed(db):
     assert row["status"] == "completed"
     assert row["completed_at"] == "2026-03-04T00:02:00Z"
     assert row["result_staging_id"] == "rs-1"
+    # Backward-compatible default: no verdict passed → NULL.
+    assert row["outcome_quality"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("verdict", ["useful", "hollow"])
+async def test_mark_completed_records_outcome_quality(db, verdict):
+    await surplus_tasks.create(
+        db, id="st-q", task_type="brainstorm_self", compute_tier="slm",
+        priority=0.5, drive_alignment="curiosity", created_at="2026-03-04T00:00:00Z",
+    )
+    ok = await surplus_tasks.mark_completed(
+        db, "st-q", completed_at="2026-03-04T00:02:00Z",
+        result_staging_id="rs-q", outcome_quality=verdict,
+    )
+    assert ok is True
+    row = await surplus_tasks.get_by_id(db, "st-q")
+    assert row["status"] == "completed"
+    assert row["outcome_quality"] == verdict
 
 
 @pytest.mark.asyncio

--- a/tests/test_surplus/test_scheduler.py
+++ b/tests/test_surplus/test_scheduler.py
@@ -123,6 +123,106 @@ async def test_dispatch_handles_executor_error(db):
     assert await queue.pending_count() == 0
 
 
+# --------------------------------------------------------------------------- #
+# Verified-correctness verdict (#4 — producer side)
+# --------------------------------------------------------------------------- #
+async def _completed_verdict(db) -> str | None:
+    cur = await db.execute(
+        "SELECT outcome_quality FROM surplus_tasks WHERE status='completed'"
+    )
+    row = await cur.fetchone()
+    return row[0]
+
+
+async def _dispatch_with_intake(db, task_type, intake_stats):
+    """Dispatch one task of ``task_type`` through the stub executor with
+    ``run_intake`` patched to return ``intake_stats``; return its verdict."""
+    sched, compute = _make_scheduler(db, idle=True)
+    await sched._queue.enqueue(task_type, ComputeTier.FREE_API, 0.8, "curiosity")
+    with patch.object(
+        compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False,
+    ), patch(
+        "genesis.surplus.intake.run_intake",
+        new_callable=AsyncMock, return_value=intake_stats,
+    ):
+        assert await sched.dispatch_once() is True
+    return await _completed_verdict(db)
+
+
+async def test_dispatch_records_hollow_when_intake_all_discard(db):
+    from genesis.surplus.intake import IntakeStats
+
+    hollow = IntakeStats(
+        findings_count=2, routed_knowledge=0, routed_observation=0, routed_discard=2,
+    )
+    assert await _dispatch_with_intake(db, TaskType.BRAINSTORM_USER, hollow) == "hollow"
+
+
+async def test_dispatch_records_useful_when_intake_routes(db):
+    from genesis.surplus.intake import IntakeStats
+
+    useful = IntakeStats(
+        findings_count=2, routed_knowledge=1, routed_observation=0, routed_discard=1,
+    )
+    assert await _dispatch_with_intake(db, TaskType.BRAINSTORM_USER, useful) == "useful"
+
+
+async def test_dispatch_useful_via_observation_only(db):
+    # routed_observation alone (no knowledge) still counts as useful.
+    from genesis.surplus.intake import IntakeStats
+
+    obs = IntakeStats(
+        findings_count=1, routed_knowledge=0, routed_observation=1, routed_discard=0,
+    )
+    assert await _dispatch_with_intake(db, TaskType.WING_AUDIT, obs) == "useful"
+
+
+async def test_dispatch_non_insight_type_stays_null(db):
+    # An action / non-insight type must NOT get a verdict even if intake discards
+    # everything — all-discard is normal for tasks that don't target the KB.
+    from genesis.surplus.intake import IntakeStats
+
+    hollow = IntakeStats(
+        findings_count=2, routed_knowledge=0, routed_observation=0, routed_discard=2,
+    )
+    assert await _dispatch_with_intake(db, TaskType.CODE_INDEX, hollow) is None
+
+
+async def test_dispatch_pipeline_intermediate_stays_null(db):
+    # Pipeline-intermediate output feeds the next step, not the KB; excluded.
+    from genesis.surplus.intake import IntakeStats
+
+    hollow = IntakeStats(
+        findings_count=1, routed_knowledge=0, routed_observation=0, routed_discard=1,
+    )
+    assert await _dispatch_with_intake(db, TaskType.RESEARCH_QUERY_GEN, hollow) is None
+
+
+async def test_dispatch_empty_insights_stays_null(db):
+    # NOMINAL / clean-pass (executor returns no insights) is NOT hollow — a
+    # monitoring/scan type reporting "nothing noteworthy" is a valid success.
+    from genesis.surplus.types import ExecutorResult
+
+    sched, compute = _make_scheduler(db, idle=True)
+    await sched._queue.enqueue(
+        TaskType.BRAINSTORM_SELF, ComputeTier.FREE_API, 0.8, "curiosity",
+    )
+
+    async def _nominal(task):
+        return ExecutorResult(
+            success=True,
+            content="All clear — nothing noteworthy to capture in this pass today.",
+            insights=[],
+        )
+
+    sched._executor.execute = _nominal
+    with patch.object(
+        compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False,
+    ):
+        await sched.dispatch_once()
+    assert await _completed_verdict(db) is None
+
+
 async def test_brainstorm_check_schedules_sessions(db):
     sched, compute = _make_scheduler(db, idle=True)
     with patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False):


### PR DESCRIPTION
## What

Background (\"surplus\") tasks feed the Outcome Bus, but a terminal `status='completed'` only proves the work **ran** — not that its output was **useful**. That left the surplus signal ~99.6% positive and non-discriminative.

This adds a second, orthogonal axis: for insight-producing task types, record whether the intake pipeline actually kept any of the task's output, and surface a discriminative negative when it didn't.

## How

- **`surplus_tasks.outcome_quality`** (`'useful'` | `'hollow'` | `NULL`), with migration `0041`. Set at task completion, reusing the existing intake quality verdict — no new model call:
  - `hollow` = intake ran but routed **everything** to discard (the task ran yet produced nothing of value)
  - `useful` = intake kept at least one finding (knowledge or observation)
  - `NULL` = action tasks, legacy rows, intake failures, and empty/too-short output (ambiguous or not a quality signal — left untouched)
- **Only insight-producing task types are eligible** (`INSIGHT_PRODUCING_TASK_TYPES`). Action tasks, pipeline *intermediate* steps (their output feeds the next step, not the knowledge base), and monitoring/probe types (a \"nothing noteworthy\" pass is a valid success) are deliberately excluded to avoid false negatives.
- **The harvester change is purely additive.** The existing `EXECUTION_OUTCOME` positive is unchanged for every completed task; a `hollow` completion *additionally* emits a tier-1 `VERIFICATION_FAILED`. The two are distinct signal types, so they coexist and remain idempotent across re-harvests. In per-domain rollups: useful = 1.0 > hollow ≈ 0.5 > hard failure = 0.0.

## Verification

- 92 targeted tests (harvester emit, per-branch scheduler verdict, CRUD, migration) + lint clean.
- End-to-end check on a realistic dataset: verdict at completion → harvest → tier-1 negatives → per-domain aggregation, with legacy rows keeping their original positive-only behaviour (no retroactive changes) and re-harvests adding no duplicates.

## Notes

- No backfill-version bump: only tasks completed after deploy can be `hollow`, so there is nothing historical to re-process.
- The capability-map consumer that reads these aggregates remains behind its existing default-off flag; a code comment marks the exact-weighting decision to revisit when that feed is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)