### PR TITLE
fix(inbox): stop phantom re-detection storm (deterministic known-hash + delta-before-cooldown)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Inbox notes that change without adding anything new no longer get re-scanned over and over.**
+  Editing an inbox note in a way that changes its bytes but not its actual content — re-pasting a
+  link with different tracking/share parameters, reordering lines, tweaking whitespace — used to
+  leave the note looking "modified" on every scan, which (while a link approval was pending) could
+  repeatedly cancel and recreate that approval. Genesis now recognizes there's no new content and
+  marks the note current in a single scan, so it settles instead of churning.
+
 - **Inbox evaluations no longer cram a whole batch of links into one giant pass — and stop
   re-evaluating links they've already covered.** When you drop many URLs into an inbox note,
   Genesis now evaluates them in small groups (≈5 at a time, configurable via

--- a/src/genesis/db/crud/inbox_items.py
+++ b/src/genesis/db/crud/inbox_items.py
@@ -152,9 +152,17 @@ async def get_all_known(
     """
     from pathlib import Path
 
+    # ORDER BY created_at ASC, rowid ASC so the per-file dict-overwrite loop
+    # below deterministically keeps the NEWEST row's hash. A file has many rows
+    # (one per batch, plus reused rows), and `reuse_as_pending` resets created_at
+    # to now while KEEPING the old (low) rowid — so insertion/rowid order is NOT
+    # recency. Without this ORDER BY an arbitrary (stale) row's hash could win,
+    # so the file's current hash never matches "known" → phantom "modified"
+    # every scan (the detection storm).
     cursor = await db.execute(
         "SELECT file_path, content_hash, status, response_path, retry_count "
-        "FROM inbox_items WHERE status != 'failed'",
+        "FROM inbox_items WHERE status != 'failed' "
+        "ORDER BY created_at ASC, rowid ASC",
     )
     rows = await cursor.fetchall()
     result: dict[str, str] = {}
@@ -170,7 +178,8 @@ async def get_all_known(
     # Permanently failed items (exhausted retries) should also block reprocessing
     cursor2 = await db.execute(
         "SELECT file_path, content_hash FROM inbox_items "
-        "WHERE status = 'failed' AND retry_count >= ?",
+        "WHERE status = 'failed' AND retry_count >= ? "
+        "ORDER BY created_at ASC, rowid ASC",
         (max_retries,),
     )
     for row in await cursor2.fetchall():

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -777,28 +777,49 @@ class InboxMonitor:
                     created_at=now_iso,
                 )
                 continue
-            last_at = await inbox_items.get_last_completed_at(
+            # Compute the delta BEFORE the cooldown check. Cooldown must gate
+            # only GENUINELY-new content; an empty delta (file bytes changed but
+            # no new content vs the baseline — e.g. a re-pasted URL with
+            # different tracking params, or a whitespace/reorder edit) must
+            # ALWAYS advance the known hash, even inside the cooldown window, so
+            # the file is not re-detected as "modified" on every scan (the
+            # detection storm — a stale known hash never caught up because the
+            # cooldown branch used to `continue` before writing any row).
+            prev_content = await inbox_items.get_evaluated_content(
                 self._db, str(f),
             )
-            if last_at:
-                last_dt = parse_utc_iso(last_at)
-                if last_dt is None:
-                    logger.warning(
-                        "Cooldown check: unparseable last-eval timestamp "
-                        "%r for %s; proceeding with evaluation", last_at, f,
-                    )
-                elif now - last_dt < cooldown:
-                    # Defer WITHOUT consuming. Do NOT write a 'completed' row
-                    # here: that would advance the known content hash and the
-                    # modification would never be re-detected, stranding the
-                    # new content until the next edit. Skipping leaves the file
-                    # detectable, so the next check past the cooldown window
-                    # re-detects and evaluates it.
-                    logger.debug(
-                        "Cooldown: deferring %s (last eval %s ago)",
-                        f, now - last_dt,
-                    )
-                    continue
+            if prev_content:
+                delta = _compute_new_content(prev_content, content)
+                is_empty_delta = not delta.strip()
+                eval_content = delta
+            else:
+                is_empty_delta = False
+                eval_content = content
+            # Cooldown gates ONLY genuinely-new content (non-empty delta).
+            if not is_empty_delta:
+                last_at = await inbox_items.get_last_completed_at(
+                    self._db, str(f),
+                )
+                if last_at:
+                    last_dt = parse_utc_iso(last_at)
+                    if last_dt is None:
+                        logger.warning(
+                            "Cooldown check: unparseable last-eval timestamp "
+                            "%r for %s; proceeding with evaluation", last_at, f,
+                        )
+                    elif now - last_dt < cooldown:
+                        # Defer WITHOUT writing a row: the new content must stay
+                        # detectable so the next scan past the cooldown window
+                        # re-detects and evaluates it (do not strand it).
+                        logger.debug(
+                            "Cooldown: deferring %s (last eval %s ago)",
+                            f, now - last_dt,
+                        )
+                        continue
+            # Past the gate (or empty delta): supersede a stale pending drop so
+            # a fresh modification replaces an undispatched one — and an orphaned
+            # pending row from an interrupted scan is cleaned up (shared across
+            # both the empty-delta and new-content paths).
             existing = await inbox_items.get_by_file_path(self._db, str(f))
             if existing and existing["status"] == "pending":
                 await inbox_items.update_status(
@@ -806,28 +827,21 @@ class InboxMonitor:
                     status="failed",
                     error_message="superseded_by_modification",
                 )
-            prev_content = await inbox_items.get_evaluated_content(
-                self._db, str(f),
-            )
-            if prev_content:
-                delta = _compute_new_content(prev_content, content)
-                if not delta.strip():
-                    logger.debug(
-                        "No new content in modified file: %s", f,
-                    )
-                    await inbox_items.create(
-                        self._db,
-                        id=item_id,
-                        file_path=str(f),
-                        content_hash=h,
-                        status="completed",
-                        created_at=now_iso,
-                    )
-                    continue
-                eval_content = delta
-            else:
-                eval_content = content
-            # Segment the delta into per-batch rows under one drop.
+            if is_empty_delta:
+                # No new content vs the baseline: write a completing row to
+                # ADVANCE the known hash (no evaluation). This runs regardless
+                # of cooldown — it is the storm fix.
+                logger.debug("No new content in modified file: %s", f)
+                await inbox_items.create(
+                    self._db,
+                    id=item_id,
+                    file_path=str(f),
+                    content_hash=h,
+                    status="completed",
+                    created_at=now_iso,
+                )
+                continue
+            # Genuinely new content -> segment the delta into per-batch rows.
             await self._queue_drop(
                 str(f), eval_content, h, now_iso, pending_items,
             )

--- a/tests/test_inbox/test_crud.py
+++ b/tests/test_inbox/test_crud.py
@@ -82,6 +82,79 @@ async def test_get_all_known_excludes_failed(db):
 
 
 @pytest.mark.asyncio
+async def test_get_all_known_newest_created_at_wins(db):
+    """When a file has multiple non-failed rows, get_all_known must return the
+    NEWEST-created_at row's hash, not an arbitrary (insertion-order) one.
+
+    Regression (detection storm): a reused row resets created_at to now but
+    keeps its old (low) rowid, so rowid/insertion order != recency. Without a
+    deterministic ORDER BY, a stale row's hash could win -> the file's current
+    hash never matches 'known' -> phantom-modified every scan.
+    """
+    # Insert the NEWER-created_at row FIRST (lower rowid) to prove ORDER BY
+    # (recency), not insertion order, decides the winner.
+    await inbox_items.create(
+        db, id="new", file_path="/inbox/a.md", content_hash="NEWHASH",
+        status="completed", created_at="2026-03-10T20:00:00+00:00",
+    )
+    await inbox_items.create(
+        db, id="old", file_path="/inbox/a.md", content_hash="OLDHASH",
+        status="completed", created_at="2026-03-10T10:00:00+00:00",
+    )
+    known = await inbox_items.get_all_known(db)
+    assert known["/inbox/a.md"] == "NEWHASH"
+
+
+@pytest.mark.asyncio
+async def test_get_all_known_excludes_retriable_failed_keeps_completed(db):
+    """A retriable-failed row (retry_count < max) is excluded from 'known' so
+    the file stays re-detectable for retry — even when a completed sibling of
+    the same file exists (which supplies the known hash)."""
+    await inbox_items.create(
+        db, id="done", file_path="/inbox/a.md", content_hash="H",
+        status="completed", created_at="2026-03-10T10:00:00+00:00",
+    )
+    await inbox_items.create(
+        db, id="failed", file_path="/inbox/a.md", content_hash="H2",
+        status="pending", created_at="2026-03-10T20:00:00+00:00",
+    )
+    await inbox_items.update_status(db, "failed", status="failed", error_message="rate limit")
+    known = await inbox_items.get_all_known(db)
+    # Completed sibling supplies the hash; the retriable-failed newer row is excluded.
+    assert known["/inbox/a.md"] == "H"
+
+
+@pytest.mark.asyncio
+async def test_get_all_known_reused_row_wins_over_older_completed(db):
+    """The exact live storm trigger: reuse_as_pending re-arms a failed row —
+    resetting created_at to now but KEEPING its old (low) rowid — and re-points
+    it at the current drop's hash. get_all_known must return that re-armed row's
+    (current) hash, not an older completed sibling's, or the file's on-disk hash
+    never matches 'known' and it re-detects as modified every scan.
+    """
+    # The to-be-reused row is inserted FIRST -> low rowid. It will be re-armed
+    # to created_at=now (newest) while keeping that low rowid, so rowid order
+    # would pick the WRONG (older completed) row without the created_at ORDER BY.
+    await inbox_items.create(
+        db, id="reused", file_path="/inbox/a.md", content_hash="STALE",
+        status="pending", created_at="2026-01-01T00:00:00+00:00",
+    )
+    await inbox_items.update_status(db, "reused", status="failed", error_message="rate limit")
+    # Older completed sibling inserted SECOND -> higher rowid, older created_at.
+    await inbox_items.create(
+        db, id="done", file_path="/inbox/a.md", content_hash="OLDHASH",
+        status="completed", created_at="2026-03-10T10:00:00+00:00",
+    )
+    # Re-arm the failed row for the current drop: created_at=now (newest).
+    await inbox_items.reuse_as_pending(
+        db, "reused", drop_id="D", batch_items="new-url",
+        content_hash="CURRENT", created_at="2026-03-10T20:00:00+00:00",
+    )
+    known = await inbox_items.get_all_known(db)
+    assert known["/inbox/a.md"] == "CURRENT"
+
+
+@pytest.mark.asyncio
 async def test_update_status(db):
     await inbox_items.create(
         db, id="i1", file_path="/inbox/a.md",

--- a/tests/test_inbox/test_monitor.py
+++ b/tests/test_inbox/test_monitor.py
@@ -454,6 +454,56 @@ async def test_e2e_url_repaste_different_tracking_not_reevaluated(
     mock_invoker.run.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_phantom_modified_within_cooldown_advances_hash(
+    db, mock_invoker, mock_session_manager, inbox_dir, tmp_path,
+):
+    """A file modified within cooldown but with NO new content (empty delta)
+    must write a completing row that ADVANCES the known hash, so it is not
+    re-detected as modified on every subsequent scan.
+
+    Regression (detection storm): the cooldown branch used to `continue`
+    before the delta check, so an empty-delta phantom-modification never
+    advanced the hash and was re-detected every scan for hours.
+    """
+    clock = _FakeClock()
+    config = InboxConfig(
+        watch_path=inbox_dir, batch_size=5, evaluation_cooldown_seconds=3600,
+    )
+    writer = ResponseWriter(watch_path=inbox_dir, timezone="UTC")
+    mon = InboxMonitor(
+        db=db, invoker=mock_invoker, session_manager=mock_session_manager,
+        config=config, writer=writer, clock=clock, prompt_dir=tmp_path,
+    )
+    f = inbox_dir / "Genesis.md"
+    base = "https://www.linkedin.com/posts/foo-share-123-1G81/"
+
+    # First paste -> evaluated (baseline set).
+    f.write_text(base + "?utm_source=share&utm_medium=member_android")
+    assert (await mon.check_once()).batches_dispatched == 1
+    mock_invoker.run.reset_mock()
+
+    # WITHIN cooldown, re-paste the SAME post with different tracking params:
+    # hash changes (detected modified) but the delta is empty. Must NOT
+    # dispatch, but MUST advance the known hash.
+    clock.now = clock.now + timedelta(minutes=10)
+    f.write_text(base + "?utm_source=share&utm_medium=member_desktop")
+    r2 = await mon.check_once()
+    assert r2.items_modified == 1
+    assert r2.batches_dispatched == 0
+    mock_invoker.run.assert_not_called()
+
+    # Next scan, file UNCHANGED: must NOT be re-detected as modified — the
+    # empty-delta write advanced the known hash even though we were in cooldown.
+    clock.now = clock.now + timedelta(minutes=10)
+    r3 = await mon.check_once()
+    assert r3.items_modified == 0, (
+        "phantom-modified re-detected: the empty-delta write did not advance "
+        "the known hash within cooldown (storm)"
+    )
+    assert r3.batches_dispatched == 0
+
+
 # --- URL extraction tests ---
 
 


### PR DESCRIPTION
## What

Fixes the inbox **detection storm** (PR-2a of 3 — detection, then dispatch at-most-once, then partial-failure retry). Root cause proven via live diagnostics + DB forensics.

**Root cause:** `get_all_known()` returned a *stale* whole-file hash for a file during the window when no row carried the file's *current* hash — its query has no `ORDER BY` (arbitrary dict-overwrite winner among a file's many rows), and the cooldown-defer path wrote no row. So the "known" hash lagged the on-disk hash → the file was re-detected as "modified" on every scan. While an approval was pending, that repeatedly cancelled + recreated it (the storm).

## Changes

1. **`get_all_known` determinism** — `ORDER BY created_at ASC, rowid ASC` on both queries, so the newest row's hash wins the per-file overwrite deterministically. A file has many rows (one per batch, plus reused rows), and `reuse_as_pending` resets `created_at` to now while keeping the old (low) rowid, so insertion/rowid order is not recency.
2. **Delta before cooldown** — the modified-files loop computes the delta before the cooldown check. Cooldown now gates only genuinely-new content; on an **empty** delta (bytes changed but no new content vs the baseline — e.g. a re-pasted URL with different tracking params) it always writes a completing row to advance the known hash, so a phantom-modified settles in one scan. Stale-pending supersede is shared across both paths.

The cancel-on-detect amplifier is left untouched — it is downstream of detection and no longer fires spuriously once detection is correct.

No schema change, no migration.

## Verification

- genesis-architect reviewed pre-implementation (one tweak incorporated).
- TDD, red-first proven: the storm-kill test **fails on the old monitor**, passes on the fix.
- Multi-agent code review (9 angles + verify + sweep): no bugs; a data-loss candidate was refuted; one regression test added.
- Full inbox suite: **273 passed**; ruff clean.
- Live-DB E2E: fixed `get_all_known` is deterministic and returns the current hash against the real 306-row inbox note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)