### PR TITLE
feat(infra): automatic disk hygiene — scheduled worktree reaping + cache reclamation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis now keeps its own disk clean automatically, so it won't quietly fill up and stall.**
+  A daily hygiene job reaps git worktrees whose branches have already merged (moving them to a
+  7-day recovery trash bin, never deleting work in progress) and clears regenerable caches that
+  otherwise creep up over time. If the disk still climbs toward full, Genesis clears the heavier
+  reindexable caches automatically at 90% — before the disk hits 100% and disrupts the server,
+  its write-ahead log, or backups. Previously the worktree cleanup existed but was never
+  scheduled, so it never actually ran.
+
 - **The dashboard now has a Campaigns tab where you can see and control your autonomous campaigns.**
   Each campaign shows its status, schedule (with next fire time), model/effort, today's spend
   against its daily cap, completed runs vs. attempts, and whether a session is currently in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,9 @@ systemctl --user list-units 'genesis-*' --all    # All units
 
 Other units: `genesis-bridge.service` (Telegram relay, on-demand),
 `genesis-tmp-watchgod.service` (/tmp protection), `genesis-watchdog.timer`
-(health check). MCP servers are CC child processes (not systemd) — code
-changes take effect on next CC session start.
+(health check), `genesis-disk-hygiene.timer` (daily worktree reaping + cache
+reclaim; see `scripts/disk_hygiene.sh`). MCP servers are CC child processes
+(not systemd) — code changes take effect on next CC session start.
 
 ## Common Commands
 

--- a/scripts/disk_hygiene.sh
+++ b/scripts/disk_hygiene.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# genesis-disk-hygiene — daily disk grooming entrypoint.
+#
+# Run by the genesis-disk-hygiene.timer systemd unit (also runnable by hand).
+# Two steps, both best-effort (one failing must not skip the other):
+#   1. Reap merged/inactive git worktrees  → scripts/worktree_lifecycle.py
+#      (trash-bin with 7-day recovery; frees space when trash purges)
+#   2. Reclaim regenerable caches          → scripts/disk_reclaim.py
+#      (cheap tier always; medium/reindex tier only when disk >= 90%)
+#
+# Note: run under a hardened systemd sandbox (NoNewPrivileges, ProtectSystem=
+# strict), so disk_reclaim's --system (/var, sudo) path is intentionally NOT
+# passed here — it would no-op anyway. /var reclaim is the reactive path's job.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+VENV_PY="$REPO_DIR/.venv/bin/python"
+if [ ! -x "$VENV_PY" ]; then
+    VENV_PY="$(command -v python3 || true)"
+fi
+if [ -z "$VENV_PY" ]; then
+    echo "disk_hygiene: no python interpreter found" >&2
+    exit 1
+fi
+
+echo "=== genesis-disk-hygiene $(date -u +%FT%TZ) ==="
+
+echo "--- worktree reaping ---"
+"$VENV_PY" "$REPO_DIR/scripts/worktree_lifecycle.py" || echo "worktree_lifecycle exited $?"
+
+echo "--- cache reclamation ---"
+"$VENV_PY" "$REPO_DIR/scripts/disk_reclaim.py" --apply --if-above 90 || echo "disk_reclaim exited $?"
+
+echo "=== genesis-disk-hygiene done ==="

--- a/scripts/disk_reclaim.py
+++ b/scripts/disk_reclaim.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Regenerable-cache reclamation — frees disk by clearing caches that rebuild.
+
+Companion to ``worktree_lifecycle.py`` (which reaps merged worktrees). This
+handles the OTHER disk accumulators: regenerable caches and stale output.
+
+Three tiers, cleared in order until the disk is comfortable:
+
+  CHEAP   — always cleared on ``--apply``. Rebuild is free/near-free
+            (package-manager download caches).
+  MEDIUM  — cleared only when disk usage >= ``--if-above`` PCT. Rebuild is
+            expensive (a CBM / GitNexus reindex), so we only pay it under
+            genuine pressure.
+  SYSTEM  — best-effort, needs sudo + write access to /var. Silently skipped
+            when unavailable (e.g. inside the hardened systemd service, which
+            runs with NoNewPrivileges + ProtectSystem=strict).
+
+NEVER touches: the git repo tree, .venv, data/, config/, secrets, browser
+profiles (they hold logins), ~/tau3-bench, embedding_cache (re-embedding costs
+API calls), or any user file. Every target is matched against a strict
+allowlist and re-validated at delete time.
+
+Usage:
+    disk_reclaim.py                         # dry-run (report only) — default
+    disk_reclaim.py --apply                 # clear CHEAP tier
+    disk_reclaim.py --apply --if-above 90   # also clear MEDIUM tier if >= 90%
+
+Note: ~/.genesis/output is intentionally NOT touched — those are generated
+deliverables (not regenerable cache), managed by the user, not this tool.
+
+Designed to run:
+  - Daily via genesis-disk-hygiene.timer (HOME-scoped, hardened, no sudo)
+  - Reactively via the remediation registry at >= 90% (full privileges)
+
+Stdlib-only (no genesis imports) so it runs even when the server is unhealthy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+HOME = Path.home()
+LOG_DIR = HOME / ".genesis" / "logs"
+MOUNT = "/"
+
+# Paths that must NEVER be inside a reclaim target, even by accident. A target
+# is rejected if it equals or contains (is an ancestor of) any of these.
+_PROTECTED = {
+    HOME,
+    HOME / "genesis",
+    HOME / "genesis" / ".venv",
+    HOME / "genesis" / "data",
+    HOME / "genesis" / "src",
+    HOME / "genesis" / ".git",
+    HOME / ".genesis",
+    HOME / ".genesis" / "camoufox-profile",
+    HOME / ".genesis" / "browser-profile",
+    HOME / ".genesis" / "embedding_cache",
+    HOME / "tau3-bench",
+    HOME / ".ssh",
+    Path("/"),
+}
+
+
+@dataclass(frozen=True)
+class CacheTarget:
+    """A directory whose entire contents are safe to delete (it regenerates)."""
+
+    description: str
+    path: Path
+    tier: str  # "cheap" | "medium"
+
+
+# Directories cleared wholesale (they are pure regenerable caches). Each is
+# removed with shutil.rmtree; the owning tool recreates it on next use.
+_CACHE_TARGETS: list[CacheTarget] = [
+    CacheTarget("npm content cache", HOME / ".npm" / "_cacache", "cheap"),
+    CacheTarget("npm logs", HOME / ".npm" / "_logs", "cheap"),
+    CacheTarget("uv download cache", HOME / ".cache" / "uv", "cheap"),
+    CacheTarget("pip cache", HOME / ".cache" / "pip", "cheap"),
+    CacheTarget("codebase-memory-mcp index (forces reindex)",
+                HOME / ".cache" / "codebase-memory-mcp", "medium"),
+    CacheTarget("code-graph cache (forces reindex)",
+                HOME / ".cache" / "code-graph", "medium"),
+    CacheTarget("GitNexus index (forces reanalyze)",
+                HOME / "genesis" / ".gitnexus", "medium"),
+]
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
+
+
+def _log(msg: str) -> None:
+    ts = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S")
+    line = f"{ts} {msg}"
+    print(line, flush=True)
+    try:
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        with (LOG_DIR / "disk_reclaim.log").open("a") as fh:
+            fh.write(line + "\n")
+    except OSError:
+        pass
+
+
+def _fmt_bytes(n: int) -> str:
+    if n < 1024:
+        return f"{n} B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f} KB"
+    if n < 1024 * 1024 * 1024:
+        return f"{n / (1024 * 1024):.1f} MB"
+    return f"{n / (1024 * 1024 * 1024):.2f} GB"
+
+
+def _disk_pct(mount: str = MOUNT) -> float:
+    """Return percent used of the filesystem holding *mount*.
+
+    Uses statvfs f_bavail (space available to non-root) so this MATCHES
+    ``genesis.observability.health.probe_disk`` and ``df`` Use%. This alignment
+    is load-bearing: the reactive ``--if-above`` gate must fire at the same
+    threshold the remediation ``probe_disk`` critical uses, or the medium-tier
+    purge would no-op exactly when remediation triggered it. (shutil.disk_usage
+    counts reserved blocks as free, under-reporting usage by ~5%.)
+    """
+    st = os.statvfs(mount)
+    total = st.f_blocks * st.f_frsize
+    free = st.f_bavail * st.f_frsize
+    used = total - free
+    return (used / total * 100) if total > 0 else 0.0
+
+
+def _dir_size(path: Path) -> int:
+    """Sum of file sizes under *path* (no symlink following)."""
+    total = 0
+    for root, _dirs, files in os.walk(path, followlinks=False):
+        for name in files:
+            fp = Path(root) / name
+            try:
+                if not fp.is_symlink():
+                    total += fp.stat().st_size
+            except OSError:
+                continue
+    return total
+
+
+def _is_safe_target(path: Path) -> bool:
+    """True only if *path* is safe to rmtree.
+
+    Rejects symlinks, non-existent paths, and anything that equals or is an
+    ancestor of a PROTECTED path (deleting it would nuke protected data).
+    A target may live *under* a protected dir (e.g. ~/.genesis/output), but it
+    must not BE or CONTAIN one.
+    """
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    if path.is_symlink():
+        _log(f"REFUSE {path}: is a symlink")
+        return False
+    for prot in _PROTECTED:
+        try:
+            prot_r = prot.resolve()
+        except OSError:
+            continue
+        if resolved == prot_r:
+            _log(f"REFUSE {path}: equals protected path {prot}")
+            return False
+        # target must not be an ancestor of a protected path
+        if prot_r != resolved and prot_r.is_relative_to(resolved):
+            _log(f"REFUSE {path}: contains protected path {prot}")
+            return False
+    return True
+
+
+# ─── Reclaim operations ──────────────────────────────────────────────────
+
+
+def _clear_cache(target: CacheTarget, *, apply: bool) -> int:
+    """Remove a cache directory. Returns bytes actually reclaimed.
+
+    Resilient to per-file permission errors (e.g. stray root-owned entries left
+    by a past ``sudo npm``): deletes everything it can, skips what it can't, and
+    reports the *actual* delta rather than assuming the whole tree was removed.
+    Package caches tolerate partial deletion — a cache miss just triggers a
+    redownload / rebuild.
+    """
+    path = target.path
+    if not path.exists():
+        return 0
+    if not _is_safe_target(path):
+        return 0
+    size = _dir_size(path)
+    if size == 0:
+        return 0
+    if not apply:
+        _log(f"WOULD CLEAR [{target.tier}] {target.description}: "
+             f"{_fmt_bytes(size)} ({path})")
+        return size
+
+    skipped: list[str] = []
+
+    def _onexc(_func, failed_path, exc):
+        # Called by rmtree for each entry it cannot remove; record + continue.
+        skipped.append(str(failed_path))
+
+    # Python 3.12 uses onexc; keep onerror as a fallback for older interpreters.
+    try:
+        shutil.rmtree(path, onexc=_onexc)  # type: ignore[call-arg]
+    except TypeError:
+        def _onerror(_func, failed_path, _exc_info):
+            skipped.append(str(failed_path))
+        shutil.rmtree(path, onerror=_onerror)
+
+    remaining = _dir_size(path) if path.exists() else 0
+    reclaimed = max(size - remaining, 0)
+    if skipped:
+        _log(f"CLEARED [{target.tier}] {target.description}: "
+             f"{_fmt_bytes(reclaimed)} reclaimed, {len(skipped)} entries skipped "
+             f"(permission) ({path})")
+    else:
+        _log(f"CLEARED [{target.tier}] {target.description}: "
+             f"{_fmt_bytes(reclaimed)} ({path})")
+    return reclaimed
+
+
+def _system_clean(*, apply: bool) -> int:
+    """Best-effort /var reclaim via sudo. Skipped silently if unavailable.
+
+    Returns bytes reclaimed (measured via disk delta, approximate).
+    """
+    # Only attempt if passwordless sudo is available (fails fast, no prompt).
+    try:
+        probe = subprocess.run(
+            ["sudo", "-n", "true"], capture_output=True, timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return 0
+    if probe.returncode != 0:
+        _log("SKIP system tier: no passwordless sudo (expected in hardened service)")
+        return 0
+
+    before = shutil.disk_usage(MOUNT).free
+    cmds = [
+        ["sudo", "-n", "apt-get", "clean"],
+        ["sudo", "-n", "journalctl", "--vacuum-size=100M"],
+    ]
+    for cmd in cmds:
+        if not apply:
+            _log(f"WOULD RUN: {' '.join(cmd)}")
+            continue
+        try:
+            subprocess.run(cmd, capture_output=True, timeout=60)
+            _log(f"RAN: {' '.join(cmd)}")
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            _log(f"ERROR running {' '.join(cmd)}: {exc}")
+    if not apply:
+        return 0
+    reclaimed = shutil.disk_usage(MOUNT).free - before
+    return max(reclaimed, 0)
+
+
+# ─── Main ────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Regenerable-cache reclamation")
+    parser.add_argument("--apply", action="store_true",
+                        help="Actually delete (default is dry-run)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Report only (default; overrides --apply)")
+    parser.add_argument("--if-above", type=float, default=101.0, metavar="PCT",
+                        help="Also clear MEDIUM tier when disk usage >= PCT "
+                             "(default 101 = never)")
+    parser.add_argument("--fail-above", type=float, default=101.0, metavar="PCT",
+                        help="Exit non-zero if usage is still >= PCT after "
+                             "applying (signals 'cleaned but still critical' to "
+                             "the remediation registry so it escalates)")
+    parser.add_argument("--system", action="store_true",
+                        help="Also attempt best-effort /var clean via sudo")
+    args = parser.parse_args()
+
+    apply = args.apply and not args.dry_run
+    pct = _disk_pct()
+    include_medium = pct >= args.if_above
+
+    _log(f"Disk reclaim starting (usage={pct:.1f}%, mode={'APPLY' if apply else 'DRY-RUN'}, "
+         f"medium_tier={'ON' if include_medium else 'OFF'} @>={args.if_above})")
+
+    total = 0
+    for target in _CACHE_TARGETS:
+        if target.tier == "medium" and not include_medium:
+            if target.path.exists():
+                _log(f"HOLD [medium] {target.description}: disk {pct:.1f}% "
+                     f"< {args.if_above}% threshold ({target.path})")
+            continue
+        total += _clear_cache(target, apply=apply)
+
+    if args.system:
+        total += _system_clean(apply=apply)
+
+    verb = "Reclaimed" if apply else "Reclaimable"
+    new_pct = _disk_pct()
+    _log(f"Disk reclaim complete: {verb} {_fmt_bytes(total)} "
+         f"(disk {pct:.1f}% -> {new_pct:.1f}%)")
+
+    # Signal "cleaned but still critical" so the remediation registry escalates.
+    if apply and new_pct >= args.fail_above:
+        _log(f"STILL CRITICAL: disk {new_pct:.1f}% >= {args.fail_above}% after "
+             f"reclaim — escalating (exit 2)")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1099,6 +1099,11 @@ if [ -f "$SYSTEMD_USER_DIR/genesis-watchdog.timer" ]; then
         echo "    + genesis-watchdog.timer enabled + started" || true
 fi
 
+if [ -f "$SYSTEMD_USER_DIR/genesis-disk-hygiene.timer" ]; then
+    systemctl --user enable --now genesis-disk-hygiene.timer 2>/dev/null && \
+        echo "    + genesis-disk-hygiene.timer enabled + started" || true
+fi
+
 # Enable AND start tmp watchgod (OS-level temp protection)
 WATCHGOD_SRC="$REPO_DIR/config/genesis-tmp-watchgod.service"
 if [ -f "$WATCHGOD_SRC" ]; then

--- a/scripts/systemd/genesis-disk-hygiene.service.template
+++ b/scripts/systemd/genesis-disk-hygiene.service.template
@@ -1,0 +1,22 @@
+[Unit]
+Description=Genesis Disk Hygiene — reap merged worktrees + reclaim regenerable caches
+After=genesis-server.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=__REPO_DIR__
+ExecStart=/bin/bash __REPO_DIR__/scripts/disk_hygiene.sh
+# Reaping ~dozens of worktrees (gh/git calls each) + a multi-GB rmtree can run
+# well past the 90s default TimeoutStartSec, which would SIGTERM mid-trash-move.
+TimeoutStartSec=1200
+# `gh` (squash-merge detection) + `git` may live in /usr/bin, CC_BIN_DIR, or
+# npm-global — list all so the reaper doesn't silently fall back to git-only.
+Environment=PATH=__VENV__/bin:__CC_BIN_DIR__:__HOME__/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
+StandardOutput=journal
+StandardError=journal
+# Home-scoped: reaper trashes under ~/.genesis, reclaim clears ~/.cache & ~/.npm.
+# No sudo needed here (disk_reclaim's --system /var path is intentionally not
+# invoked by the daily wrapper — that is the reactive path's job).
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=%h

--- a/scripts/systemd/genesis-disk-hygiene.timer.template
+++ b/scripts/systemd/genesis-disk-hygiene.timer.template
@@ -1,0 +1,11 @@
+[Unit]
+Description=Genesis Disk Hygiene — daily schedule
+
+[Timer]
+OnCalendar=*-*-* 04:00:00
+Persistent=true
+AccuracySec=1h
+RandomizedDelaySec=600
+
+[Install]
+WantedBy=timers.target

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -405,6 +405,7 @@ if [ "$MODE" != "guardian-only" ] && [ "$HAS_GENESIS" = true ]; then
 
         # Stop all Genesis services (timer first, then service, to prevent restart)
         for unit in genesis-watchdog.timer genesis-watchdog.service \
+                    genesis-disk-hygiene.timer genesis-disk-hygiene.service \
                     genesis-server.service genesis-bridge.service \
                     qdrant.service; do
             safe_disable_service "$unit"

--- a/scripts/worktree_lifecycle.py
+++ b/scripts/worktree_lifecycle.py
@@ -15,8 +15,8 @@ Usage:
     worktree_lifecycle.py --list-trash       # Show trash contents with age
     worktree_lifecycle.py --recover <name>   # Recover a trashed worktree
 
-Designed for daily cron:
-    0 4 * * * .venv/bin/python scripts/worktree_lifecycle.py
+Run daily by the genesis-disk-hygiene.timer systemd unit (via
+scripts/disk_hygiene.sh, alongside disk_reclaim.py). Also runnable by hand.
 
 Stdlib-only (no genesis package imports). Uses gh CLI for PR status.
 """

--- a/src/genesis/autonomy/remediation.py
+++ b/src/genesis/autonomy/remediation.py
@@ -14,7 +14,9 @@ Design:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
+import sys
 import time
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
@@ -42,6 +44,7 @@ class RemediationAction:
     reversible: bool = True
     cooldown_s: int = 300    # Min seconds between runs
     max_attempts: int = 3    # Max consecutive attempts before giving up
+    timeout_s: int = 30      # Max seconds for the command (see _run_command)
 
 
 @dataclass
@@ -287,7 +290,7 @@ class RemediationRegistry:
                 env=systemctl_env(),
             )
             stdout, stderr = await asyncio.wait_for(
-                proc.communicate(), timeout=30,
+                proc.communicate(), timeout=action.timeout_s,
             )
             if proc.returncode == 0:
                 logger.info("Remediation %s completed (rc=0)", action.name)
@@ -300,8 +303,15 @@ class RemediationRegistry:
             )
             return False
         except TimeoutError:
+            # Kill the hung child AND reap it so it can't leak a zombie / an
+            # unclosed subprocess transport after we give up.
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            with contextlib.suppress(Exception):
+                await proc.wait()
             logger.error(
-                "Remediation %s timed out after 30s", action.name, exc_info=True,
+                "Remediation %s timed out after %ds",
+                action.name, action.timeout_s, exc_info=True,
             )
             return False
         except FileNotFoundError:
@@ -344,6 +354,25 @@ def _extract_status(probe: Any) -> ProbeStatus:
 # Default remediation actions
 # ---------------------------------------------------------------------------
 
+
+def _disk_reclaim_command() -> list[str]:
+    """Build the reactive disk-reclaim command (absolute, venv-python).
+
+    Runs from the genesis-server context (has passwordless sudo), so --system
+    also clears /var (apt/journald). ``--if-above 90`` gates the reindex-heavy
+    MEDIUM tier; the CHEAP tier (regenerable package caches) always clears.
+    ``--fail-above 90`` makes the script exit non-zero if the disk is still
+    critical afterwards, so the registry escalates via max_attempts.
+    """
+    from genesis.env import repo_root
+
+    script = repo_root() / "scripts" / "disk_reclaim.py"
+    return [
+        sys.executable, str(script),
+        "--apply", "--if-above", "90", "--fail-above", "90", "--system",
+    ]
+
+
 DEFAULT_REMEDIATIONS: list[RemediationAction] = [
     RemediationAction(
         name="qdrant_restart",
@@ -378,12 +407,24 @@ DEFAULT_REMEDIATIONS: list[RemediationAction] = [
     RemediationAction(
         name="disk_cleanup",
         probe_name="disk",
-        condition="Root filesystem usage exceeds 90%",
-        command=["sudo", "journalctl", "--vacuum-size=100M"],
-        governance_level=3,
+        condition=(
+            "Disk DEGRADED (>=85%): clear regenerable caches + /var. "
+            "At >=90% also clears reindex-heavy caches (CBM/GitNexus). "
+            "Escalates if still >=90% after cleanup."
+        ),
+        # L2 auto-run: deletes ONLY regenerable caches (package caches,
+        # reindexable graph caches) + journald/apt vacuum. Self-gated by
+        # --if-above so the expensive tier only clears under real pressure.
+        command=_disk_reclaim_command(),
+        governance_level=2,
         reversible=True,
-        cooldown_s=86400,
+        # Short cooldown + low attempts so a genuinely-stuck disk (caches can't
+        # relieve it) escalates to a critical alert in ~30-60min, not ~18h —
+        # well before it can climb to 100%. Re-runs are cheap (caches already
+        # cleared → fast no-op).
+        cooldown_s=1800,    # 30min
         max_attempts=2,
+        timeout_s=300,      # multi-GB rmtree legitimately exceeds the 30s default
     ),
     RemediationAction(
         name="stale_browser_alert",

--- a/src/genesis/observability/health.py
+++ b/src/genesis/observability/health.py
@@ -242,7 +242,7 @@ async def probe_scheduler(
 async def probe_disk(
     mount_path: str = "/",
     *,
-    warn_pct: float = 80.0,
+    warn_pct: float = 85.0,
     critical_pct: float = 90.0,
     clock=None,
 ) -> ProbeResult:

--- a/tests/test_autonomy/test_remediation.py
+++ b/tests/test_autonomy/test_remediation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -104,6 +104,17 @@ class TestRegistration:
         assert "awareness_restart" in names
         assert "ollama_alert" in names
         assert "disk_cleanup" in names
+
+    def test_default_timeout_s(self):
+        # New per-action timeout defaults to 30s (no behavior change for others).
+        assert _l2_action().timeout_s == 30
+
+    def test_disk_cleanup_is_autorun_reclaim(self):
+        disk = [a for a in DEFAULT_REMEDIATIONS if a.name == "disk_cleanup"][0]
+        assert disk.governance_level == 2          # auto-run (regenerable only)
+        assert disk.timeout_s == 300               # multi-GB rmtree needs > 30s
+        assert any("disk_reclaim.py" in part for part in disk.command)
+        assert "--if-above" in disk.command and "--fail-above" in disk.command
 
 
 # ---------------------------------------------------------------------------
@@ -277,10 +288,12 @@ class TestCommandFailures:
         reg.register(_l2_action())
         mock_proc = AsyncMock()
         mock_proc.communicate = AsyncMock(side_effect=TimeoutError)
+        mock_proc.kill = MagicMock()  # real asyncio Process.kill() is synchronous
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
             outcomes = await reg.check_and_remediate({"qdrant": _down_probe()})
         assert outcomes[0].executed
         assert outcomes[0].success is False
+        mock_proc.kill.assert_called_once()  # hung child is killed on timeout
 
     @pytest.mark.asyncio
     async def test_command_not_found(self):

--- a/tests/test_observability/test_health.py
+++ b/tests/test_observability/test_health.py
@@ -124,6 +124,13 @@ class TestProbeDisk:
         assert result.details["pct_used"] == 50.0
 
     @pytest.mark.asyncio
+    async def test_healthy_below_warn(self):
+        # 82% used — below the 85% warn threshold (was DEGRADED under old 80%)
+        with patch("os.statvfs", return_value=_fake_statvfs(1000000, 180000)):
+            result = await probe_disk(clock=FROZEN_CLOCK)
+        assert result.status == ProbeStatus.HEALTHY
+
+    @pytest.mark.asyncio
     async def test_degraded_at_warn(self):
         # 85% used
         with patch("os.statvfs", return_value=_fake_statvfs(1000000, 150000)):

--- a/tests/test_scripts/test_disk_reclaim.py
+++ b/tests/test_scripts/test_disk_reclaim.py
@@ -1,0 +1,148 @@
+"""Tests for scripts/disk_reclaim.py — regenerable-cache reclamation.
+
+Focus: the safety allowlist (a bug here could delete real data), resilient
+partial deletion, MEDIUM-tier gating, and the --fail-above exit contract that
+the remediation registry relies on to escalate a stuck disk.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Load the script as a module (it's not a package — use importlib). It must be
+# registered in sys.modules BEFORE exec so its frozen @dataclass can resolve
+# its own module namespace.
+_SCRIPT_PATH = Path(__file__).resolve().parent.parent.parent / "scripts" / "disk_reclaim.py"
+_spec = importlib.util.spec_from_file_location("disk_reclaim", _SCRIPT_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["disk_reclaim"] = _mod
+_spec.loader.exec_module(_mod)
+
+CacheTarget = _mod.CacheTarget
+
+
+# ─── Safety allowlist ────────────────────────────────────────────────────
+
+class TestIsSafeTarget:
+    def test_rejects_home(self):
+        assert _mod._is_safe_target(_mod.HOME) is False
+
+    def test_rejects_repo(self):
+        assert _mod._is_safe_target(_mod.HOME / "genesis") is False
+
+    def test_rejects_venv_and_data(self):
+        assert _mod._is_safe_target(_mod.HOME / "genesis" / ".venv") is False
+        assert _mod._is_safe_target(_mod.HOME / "genesis" / "data") is False
+
+    def test_rejects_filesystem_root(self):
+        assert _mod._is_safe_target(Path("/")) is False
+
+    def test_rejects_symlink(self, tmp_path):
+        real = tmp_path / "real"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
+        assert _mod._is_safe_target(link) is False
+
+    def test_rejects_ancestor_of_protected(self, tmp_path):
+        # A target that CONTAINS a protected path must be refused.
+        protected = tmp_path / "cache" / "keepme"
+        protected.mkdir(parents=True)
+        with patch.object(_mod, "_PROTECTED", {protected}):
+            assert _mod._is_safe_target(tmp_path / "cache") is False
+
+    def test_accepts_plain_cache_dir(self, tmp_path):
+        cache = tmp_path / "somecache"
+        cache.mkdir()
+        assert _mod._is_safe_target(cache) is True
+
+
+# ─── Cache clearing ──────────────────────────────────────────────────────
+
+def _make_cache(tmp_path: Path, name: str = "c", tier: str = "cheap") -> CacheTarget:
+    d = tmp_path / name
+    d.mkdir()
+    (d / "a.bin").write_bytes(b"x" * 1000)
+    (d / "sub").mkdir()
+    (d / "sub" / "b.bin").write_bytes(b"y" * 2000)
+    return CacheTarget(f"test {name}", d, tier)
+
+
+class TestClearCache:
+    def test_dry_run_reports_but_keeps(self, tmp_path):
+        target = _make_cache(tmp_path)
+        n = _mod._clear_cache(target, apply=False)
+        assert n == 3000
+        assert target.path.exists()  # untouched
+
+    def test_apply_removes_and_reports(self, tmp_path):
+        target = _make_cache(tmp_path)
+        n = _mod._clear_cache(target, apply=True)
+        assert n == 3000
+        assert not target.path.exists()
+
+    def test_missing_dir_is_noop(self, tmp_path):
+        target = CacheTarget("missing", tmp_path / "nope", "cheap")
+        assert _mod._clear_cache(target, apply=True) == 0
+
+    def test_resilient_to_permission_error(self, tmp_path):
+        # A read-only subdir blocks unlinking its file; clear must reclaim what
+        # it can and report the rest as skipped rather than aborting.
+        target = _make_cache(tmp_path, "locked")
+        locked = target.path / "sub"
+        locked.chmod(0o500)  # r-x: cannot remove b.bin inside
+        try:
+            reclaimed = _mod._clear_cache(target, apply=True)
+            # The top-level a.bin (1000 B) is reclaimable; the locked file isn't.
+            assert reclaimed >= 1000
+            assert reclaimed < 3000
+        finally:
+            locked.chmod(0o700)  # restore so tmp cleanup works
+
+
+# ─── main(): gating + exit contract ──────────────────────────────────────
+
+class TestMain:
+    def _run(self, argv, disk_pct):
+        with patch.object(_mod.sys, "argv", ["disk_reclaim.py", *argv]), \
+             patch.object(_mod, "_disk_pct", return_value=disk_pct):
+            return _mod.main()
+
+    def test_medium_held_below_threshold(self, tmp_path):
+        cheap = _make_cache(tmp_path, "cheap1", "cheap")
+        medium = _make_cache(tmp_path, "med1", "medium")
+        with patch.object(_mod, "_CACHE_TARGETS", [cheap, medium]):
+            self._run(["--apply", "--if-above", "90"], disk_pct=80.0)
+        assert not cheap.path.exists()     # cheap always cleared
+        assert medium.path.exists()        # medium held below 90
+
+    def test_medium_cleared_above_threshold(self, tmp_path):
+        cheap = _make_cache(tmp_path, "cheap2", "cheap")
+        medium = _make_cache(tmp_path, "med2", "medium")
+        with patch.object(_mod, "_CACHE_TARGETS", [cheap, medium]):
+            self._run(["--apply", "--if-above", "90"], disk_pct=92.0)
+        assert not cheap.path.exists()
+        assert not medium.path.exists()    # medium cleared at/above 90
+
+    def test_dry_run_deletes_nothing(self, tmp_path):
+        cheap = _make_cache(tmp_path, "cheap3", "cheap")
+        with patch.object(_mod, "_CACHE_TARGETS", [cheap]):
+            self._run(["--dry-run", "--if-above", "0"], disk_pct=95.0)
+        assert cheap.path.exists()
+
+    def test_fail_above_returns_2_when_still_critical(self, tmp_path):
+        with patch.object(_mod, "_CACHE_TARGETS", []):
+            rc = self._run(["--apply", "--fail-above", "90"], disk_pct=93.0)
+        assert rc == 2
+
+    def test_fail_above_returns_0_when_recovered(self, tmp_path):
+        with patch.object(_mod, "_CACHE_TARGETS", []):
+            rc = self._run(["--apply", "--fail-above", "90"], disk_pct=70.0)
+        assert rc == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Why

The container root filesystem could fill to 100% and stall Genesis — disrupting
the server, its SQLite WAL, and backups. The root cause: a worktree-cleanup
script existed but was **never scheduled by any installer**, so merged git
worktrees (and regenerable caches) accumulated unbounded until the disk filled.

## What this does

**Automatic disk hygiene**, wired to run on its own:

- **New `genesis-disk-hygiene` systemd timer** (daily) that runs the existing
  worktree reaper plus a new cache-reclamation step. Installer-enabled from
  templates, so every install gets it — the piece that was missing before.
- **`scripts/disk_reclaim.py`** — clears only *regenerable* caches on a strict
  allowlist: package caches (npm/uv/pip) every run; heavier reindexable caches
  (code-graph indexes) only when the disk is genuinely under pressure (≥90%).
  Never touches the repo, virtualenv, data, config, secrets, browser profiles,
  or generated output.
- **Pre-100% safety net** — the health system now clears regenerable caches
  automatically at 90% (before the disk fills) and raises the warning threshold
  to 85% for earlier visibility.

Merged worktrees are moved to a 7-day recovery trash bin, never hard-deleted;
in-progress and unmerged work is always skipped.

## Verification

- Ran end-to-end under the real (sandboxed) service: reaped merged worktrees
  (correctly skipping active/recent/unmerged), reclaimed cache space, exited
  cleanly.
- New unit tests for the reclaim allowlist, threshold gating, and the health
  probe; existing suites pass; lint clean.
