### PR TITLE
feat(attention): passive-listening attention engine v1 — deterministic L1 shadow gate (PR1)

### DIFF
--- a/src/genesis/attention/__init__.py
+++ b/src/genesis/attention/__init__.py
@@ -1,0 +1,17 @@
+"""Passive-listening attention engine (Track 1) — the deterministic L1 perk-up gate.
+
+v1 runs OFFLINE, Genesis-side, in SHADOW mode over pulled read-only ambient
+snapshots: it logs what it WOULD have perked up on (never speaks, never influences
+output). The engine CORE — ``types``, ``clarity``, ``config``, ``triggers``,
+``scorer``, ``engine`` — is a pure, genesis-dependency-free, event-``ts``-driven fold
+so a batch replay over a snapshot is byte-identical to a future live edge run and the
+core vendors to the edge voice repo unchanged (enforced by
+``tests/test_attention/test_edge_portability.py``). Adapters — ``sources``,
+``consumers``, ``snapshot``, ``runner`` — do all the I/O.
+
+Design: ``~/.genesis/output/specs/attention-engine-design.md`` (§3 architecture,
+§4 trigger taxonomy, §6 shadow mode, §11 the live-corpus eval).
+
+NOTE: keep this package ``__init__`` free of adapter imports — importing the core
+must never pull in ``genesis.db``/``genesis.routing``/etc. (see the edge-port test).
+"""

--- a/src/genesis/attention/clarity.py
+++ b/src/genesis/attention/clarity.py
@@ -1,0 +1,63 @@
+"""capture-clarity: a pure signal-richness prioritizer for the attention engine.
+
+Runtime copy of the edge-portable arithmetic that also lives in
+``scripts/ambient/garble_features.py`` (kept as a separate copy DELIBERATELY: the
+genesis package cannot import ``scripts/`` — no ``__init__`` — and this math is
+destined to be vendored to the edge voice repo unchanged; three deployment targets
+that cannot import one another, so ~25 lines of stable arithmetic legitimately lives
+in each). NO genesis imports, NO I/O.
+
+It scores capture-clarity / signal-richness — near-silence one-word blip -> ~0, a
+loud/long/confident passage -> ~1. Explicitly NOT accuracy and NOT relevance
+(``is_user`` stays orthogonal). The attention engine weights an utterance's soft-score
+contribution by its clarity (tolerate garbled text; don't require clean ASR) and drops
+``is_blip`` near-silence junk from the context window. Reference points baked into the
+constants are from the live corpus (2026-06-29, n=6074): rms p05~0.026 / p75~0.168 ·
+duration p75~3.85s · n_tokens p75~15 · frac_lt_1 p50~0.083.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+RMS_FLOOR = 0.02   # below ~ near-silence (corpus p05~0.026); the blip floor
+RMS_REF = 0.17     # "loud / clearly captured" reference (corpus p75~0.168)
+DUR_REF = 4.0      # seconds for a "full-length" utterance (corpus p75~3.85)
+NTOK_REF = 8.0     # tokens for a "content-rich" utterance
+
+
+def frac_below(values: Sequence[float], thr: float) -> float:
+    """Fraction of ``values`` strictly < ``thr``. Empty -> 0.0 (no evidence).
+
+    ``frac_below(ys_log_probs, -1.0)`` is the lead ASR-confidence statistic: real
+    speech sits ~0%, garble 12-20% (measured on the live corpus)."""
+    if not values:
+        return 0.0
+    return sum(1 for v in values if v < thr) / len(values)
+
+
+def _clamp01(x: float) -> float:
+    if x != x:  # NaN (the only value != itself) — corrupt meta -> worst-case
+        return 0.0
+    return 0.0 if x < 0.0 else (1.0 if x > 1.0 else x)
+
+
+def is_blip(rms: float, duration_s: float, n_tokens: int) -> bool:
+    """True for a near-silence throwaway (the ASR emitting a word or two from almost
+    no audio): ``rms`` below the near-silence floor AND sparse (sub-second OR <=2
+    tokens). Conservative physics gate — flags ~1.8% of the live corpus, the
+    unambiguous junk tail only. Needs no accuracy/relevance judgement, just loudness."""
+    return rms < RMS_FLOOR and (duration_s < 1.0 or n_tokens <= 2)
+
+
+def capture_clarity(
+    rms: float, duration_s: float, frac_lt_1: float, n_tokens: int,
+) -> float:
+    """Heuristic 0..1 capture-clarity score — equal-weight mean of four bounded
+    sub-scores (ASR confidence ``1-frac_lt_1``, loudness, length, token-richness).
+    Near-silence blips land near 0; loud/long/confident passages near 1. Edge-portable
+    plain arithmetic; NaN-safe (corrupt meta -> conservative low clarity)."""
+    confidence = 1.0 - _clamp01(frac_lt_1)
+    loudness = _clamp01((rms - RMS_FLOOR) / (RMS_REF - RMS_FLOOR))
+    length = _clamp01(duration_s / DUR_REF)
+    richness = _clamp01(n_tokens / NTOK_REF)
+    return (confidence + loudness + length + richness) / 4.0

--- a/src/genesis/attention/config.py
+++ b/src/genesis/attention/config.py
@@ -21,8 +21,8 @@ class StateModifiers:
     """The state dials that bend the threshold / shape the window (all in seconds
     or unitless multipliers; keyed off event-ts deltas, never wall-clock)."""
 
-    context_window_s: float = 8.0          # rolling context window (SAS §10-E)
-    context_cap_s: float = 12.0            # stale past this — drop from window
+    context_window_s: float = 8.0          # RESERVED (PR3): the SAS 8s active-signal window
+    context_cap_s: float = 12.0            # v1 window-eviction boundary — drop utterances older than this
     session_gap_s: float = 30.0            # silence gap that starts a NEW attention session
     session_stickiness_mult: float = 1.3   # in-session soft-score multiplier (stickiness)
     cooldown_s: float = 30.0               # refractory window after a perk

--- a/src/genesis/attention/config.py
+++ b/src/genesis/attention/config.py
@@ -1,0 +1,82 @@
+"""Genesis-owned attention config — the trigger banks, weights, and thresholds that
+parametrize the deterministic L1 gate. The taxonomy is DATA, not code: the same
+versioned JSON (``~/.genesis/config/attention_config.json``) loads identically here
+and, later, at the edge. Pure — stdlib only (json/re/pathlib), no genesis deps.
+
+``version`` enforces the calibration model (design §6): behaviour is FIXED within a
+deployed version; a re-tune ships a NEW version — never a live jittery threshold.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+_Bank = dict[str, tuple[re.Pattern, ...]]
+
+
+@dataclass(frozen=True)
+class StateModifiers:
+    """The state dials that bend the threshold / shape the window (all in seconds
+    or unitless multipliers; keyed off event-ts deltas, never wall-clock)."""
+
+    context_window_s: float = 8.0          # rolling context window (SAS §10-E)
+    context_cap_s: float = 12.0            # stale past this — drop from window
+    session_gap_s: float = 30.0            # silence gap that starts a NEW attention session
+    session_stickiness_mult: float = 1.3   # in-session soft-score multiplier (stickiness)
+    cooldown_s: float = 30.0               # refractory window after a perk
+    cooldown_raise: float = 0.2            # threshold ADD while in cooldown (anti-twitch)
+    unanswered_question_s: float = 5.0     # a "?" with no reply within this -> a soft signal
+
+
+@dataclass(frozen=True)
+class Thresholds:
+    soft_perk: float = 0.6         # effective soft-score >= this -> SOFT activation
+    l15_graduation: float = 0.4    # score >= this -> would graduate to L1.5 (stub in v1)
+
+
+@dataclass(frozen=True)
+class AttentionConfig:
+    version: str
+    aliases: tuple[str, ...]                 # Genesis's own names (ambient-name trigger)
+    domain_keywords: tuple[str, ...]         # the user's active projects/topics/tech
+    known_entities: tuple[str, ...]          # user_contacts names (+ aliases), flattened
+    lexical_patterns: _Bank                  # intent banks (question, help_seeking, ...)
+    emotional_patterns: _Bank                # frustration/excitement/confusion/urgency
+    suppressor_patterns: _Bank               # explicit_dismissal, sensitive_topics
+    weights: dict[str, float]                # soft-trigger name -> weight
+    state_modifiers: StateModifiers
+    thresholds: Thresholds
+    suppressors_enabled: tuple[str, ...]
+
+    @classmethod
+    def from_dict(cls, d: dict) -> AttentionConfig:
+        def compile_bank(bank: dict | None) -> _Bank:
+            return {
+                key: tuple(re.compile(p, re.IGNORECASE) for p in (pats or []))
+                for key, pats in (bank or {}).items()
+            }
+
+        def sub(kls, raw: dict | None):
+            raw = raw or {}
+            return kls(**{k: raw[k] for k in raw if k in kls.__dataclass_fields__})
+
+        return cls(
+            version=str(d.get("version", "0")),
+            aliases=tuple(d.get("aliases", [])),
+            domain_keywords=tuple(d.get("domain_keywords", [])),
+            known_entities=tuple(d.get("known_entities", [])),
+            lexical_patterns=compile_bank(d.get("lexical_patterns")),
+            emotional_patterns=compile_bank(d.get("emotional_patterns")),
+            suppressor_patterns=compile_bank(d.get("suppressor_patterns")),
+            weights={k: float(v) for k, v in (d.get("weights") or {}).items()},
+            state_modifiers=sub(StateModifiers, d.get("state_modifiers")),
+            thresholds=sub(Thresholds, d.get("thresholds")),
+            suppressors_enabled=tuple(d.get("suppressors_enabled", [])),
+        )
+
+
+def load_config(path: str | Path) -> AttentionConfig:
+    """Load + compile a versioned ``attention_config.json``."""
+    return AttentionConfig.from_dict(json.loads(Path(path).expanduser().read_text()))

--- a/src/genesis/attention/config.py
+++ b/src/genesis/attention/config.py
@@ -80,3 +80,65 @@ class AttentionConfig:
 def load_config(path: str | Path) -> AttentionConfig:
     """Load + compile a versioned ``attention_config.json``."""
     return AttentionConfig.from_dict(json.loads(Path(path).expanduser().read_text()))
+
+
+# ── default starter config (the ~/.genesis overlay overrides; used by the runner) ──
+DEFAULT_CONFIG_PATH = "~/.genesis/config/attention_config.json"
+
+
+def default_config_dict() -> dict:
+    """A complete generic STARTER config for the first shadow pass. ``domain_keywords``
+    is a coarse tech-talk starter; ``known_entities`` is empty (a generator fills it
+    from ``user_contacts`` later). ``emotional_patterns`` and the extra lexical banks
+    are present but only CONSUMED from PR3 onward — the PR1 trigger subset uses
+    question/help_seeking/multi_speaker/is_user/domain_keyword/known_entity +
+    ambient_name/explicit_invite + explicit_dismissal. All weights/thresholds are the
+    calibration surface the shadow review tunes."""
+    return {
+        "version": "0.1.0-default",
+        "aliases": ["genesis"],
+        "domain_keywords": [
+            "genesis", "routing", "memory", "embedding", "retrieval", "attention",
+            "ambient", "voice", "ego", "autonomy", "reflection", "dashboard",
+            "telegram", "qdrant", "sqlite", "migration", "outreach", "procedure",
+            "deliberate", "omnipresence", "pipeline", "deploy", "model", "prompt",
+            "agent", "worktree", "backup",
+        ],
+        "known_entities": [],
+        "lexical_patterns": {
+            "question": [
+                r"\b(how|what|why|when|where|who|which)\b.{0,40}\?",
+                r"\b(should|could|can|do|does|did|is|are|will|would)\s+(i|we|you|it|they)\b",
+            ],
+            "help_seeking": [
+                r"\bhow do i\b", r"\bi'?m stuck\b", r"\bcan'?t figure\b",
+                r"\bnot sure how\b", r"\bhelp me\b",
+            ],
+            "decision": [r"\bwe should\b", r"\blet'?s\b", r"\bi'?ll\b", r"\bwe need to\b"],
+            "task_reminder": [r"\bremind me\b", r"\blook up\b", r"\bfind out\b", r"\bdon'?t forget\b"],
+            "temporal_deadline": [r"\btomorrow\b", r"\bdeadline\b", r"\btonight\b", r"\bnext week\b"],
+            "quantity_money": [r"\$\s?\d", r"\bdollars?\b", r"\bbudget\b"],
+            "recall_cue": [r"\bwhat did we say\b", r"\bdidn'?t we\b", r"\bremember when\b"],
+            "dispute": [r"\bis it true\b", r"\bactually,? no\b", r"\bare you sure\b"],
+        },
+        "emotional_patterns": {
+            "frustration": [r"\bugh\b", r"\bso annoying\b", r"\bfrustrat", r"\bcan'?t stand\b"],
+            "excitement": [r"\bthis is huge\b", r"\bamazing\b", r"\bcan'?t wait\b", r"\bso cool\b"],
+            "confusion": [r"\bconfused\b", r"\bi don'?t (get|understand)\b", r"\bmakes no sense\b"],
+            "urgency": [r"\bhurry\b", r"\basap\b", r"\bright now\b", r"\burgent\b"],
+        },
+        "suppressor_patterns": {
+            "explicit_dismissal": [
+                r"\bnever mind\b", r"\bnot you\b", r"\bforget it\b",
+                r"\bjust between us\b", r"\bnone of your\b",
+            ],
+            "sensitive_topics": [],
+        },
+        "weights": {
+            "question": 0.30, "help_seeking": 0.35, "multi_speaker": 0.40,
+            "is_user": 0.10, "domain_keyword": 0.30, "known_entity": 0.25,
+        },
+        "state_modifiers": {},   # all StateModifiers defaults
+        "thresholds": {},        # all Thresholds defaults (soft_perk 0.6, l15_graduation 0.4)
+        "suppressors_enabled": ["explicit_dismissal"],
+    }

--- a/src/genesis/attention/consumers.py
+++ b/src/genesis/attention/consumers.py
@@ -81,10 +81,10 @@ class ShadowStoreConsumer:
         conn = sqlite3.connect(self.db_path, timeout=self.timeout_s)
         try:
             conn.execute("PRAGMA busy_timeout=30000")
-            conn.executemany(sql, self._rows)
-            conn.commit()
+            with conn:  # explicit txn: commit on success, ROLLBACK on any error (no partial batch)
+                conn.executemany(sql, self._rows)
         finally:
-            conn.close()
+            conn.close()  # __exit__ manages the txn, not the connection lifecycle
         n = len(self._rows)
         logger.info("persisted %d attention_events (snapshot=%s config=%s)",
                     n, self.snapshot_id, self.config_version)

--- a/src/genesis/attention/consumers.py
+++ b/src/genesis/attention/consumers.py
@@ -1,0 +1,92 @@
+"""Sink adapters for ``AttentionEvent``. ``ShadowStoreConsumer`` persists refs + derived
+features to genesis.db ``attention_events`` — NEVER transcript text (firewall). Events are
+buffered and flushed in ONE short transaction: the offline runner is a 2nd writer to the
+WAL DB while the server writes on its ticks, so ``timeout`` + ``busy_timeout`` + a single
+write window absorb lock contention. A ``JSONLConsumer`` (the edge sink) slots in beside
+this later (PR3).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from datetime import UTC, datetime
+
+from genesis.attention.types import AttentionEvent
+
+logger = logging.getLogger(__name__)
+
+_COLUMNS = (
+    "id", "ts", "session_id", "activation", "score", "triggers_fired", "suppressors",
+    "window_ref", "mode_state", "clarity", "l15_verdict", "acceptance_signal",
+    "snapshot_id", "config_version", "created_at",
+)
+
+
+def _iso(epoch: float) -> str:
+    return datetime.fromtimestamp(epoch, UTC).isoformat()
+
+
+class ShadowStoreConsumer:
+    """Buffer AttentionEvents; flush them to ``attention_events`` in one transaction.
+
+    Row id = ``snapshot_id:config_version:trigger_utt_id`` — idempotent per (snapshot,
+    config) so re-running the same snapshot yields identical rows, while a NEW
+    config_version writes NEW rows (never clobbers a labeled row's acceptance_signal).
+    """
+
+    def __init__(self, db_path, *, snapshot_id: str, config_version: str, timeout_s: float = 30.0):
+        self.db_path = str(db_path)
+        self.snapshot_id = snapshot_id
+        self.config_version = config_version
+        self.timeout_s = timeout_s
+        self._rows: list[tuple] = []
+        self._created_at = datetime.now(UTC).isoformat()
+
+    def add(self, ev: AttentionEvent) -> None:
+        self._rows.append(self._to_row(ev))
+
+    def _to_row(self, ev: AttentionEvent) -> tuple:
+        wr = ev.window_ref
+        trig_id = wr.utt_ids[-1] if wr.utt_ids else "x"
+        row_id = f"{self.snapshot_id}:{self.config_version}:{trig_id}"
+        triggers = json.dumps([  # names + kinds + weights only — NO transcript text
+            {"name": h.name, "kind": h.kind.value, "contribution": h.contribution}
+            for h in ev.triggers_fired
+        ])
+        window_ref = json.dumps({  # ids + ts range only — NO transcript text
+            "snapshot_id": self.snapshot_id,
+            "session_id": wr.session_id,
+            "utt_ids": list(wr.utt_ids),
+            "ts_start": wr.ts_start,
+            "ts_end": wr.ts_end,
+        })
+        return (
+            row_id, _iso(ev.ts), ev.session_id, ev.activation.value, ev.score,
+            triggers, json.dumps(list(ev.suppressors)), window_ref, ev.mode_state,
+            ev.clarity, json.dumps(ev.l15_verdict) if ev.l15_verdict is not None else None,
+            None,  # acceptance_signal — back-filled at review (PR2)
+            self.snapshot_id, self.config_version, self._created_at,
+        )
+
+    def flush(self) -> int:
+        """Write all buffered rows in one transaction; returns the count written."""
+        if not self._rows:
+            return 0
+        placeholders = ", ".join(["?"] * len(_COLUMNS))
+        sql = (  # columns/placeholders are constants, not user input
+            f"INSERT OR REPLACE INTO attention_events ({', '.join(_COLUMNS)}) "  # noqa: S608
+            f"VALUES ({placeholders})"
+        )
+        conn = sqlite3.connect(self.db_path, timeout=self.timeout_s)
+        try:
+            conn.execute("PRAGMA busy_timeout=30000")
+            conn.executemany(sql, self._rows)
+            conn.commit()
+        finally:
+            conn.close()
+        n = len(self._rows)
+        logger.info("persisted %d attention_events (snapshot=%s config=%s)",
+                    n, self.snapshot_id, self.config_version)
+        self._rows = []
+        return n

--- a/src/genesis/attention/consumers.py
+++ b/src/genesis/attention/consumers.py
@@ -1,26 +1,22 @@
 """Sink adapters for ``AttentionEvent``. ``ShadowStoreConsumer`` persists refs + derived
-features to genesis.db ``attention_events`` — NEVER transcript text (firewall). Events are
-buffered and flushed in ONE short transaction: the offline runner is a 2nd writer to the
-WAL DB while the server writes on its ticks, so ``timeout`` + ``busy_timeout`` + a single
-write window absorb lock contention. A ``JSONLConsumer`` (the edge sink) slots in beside
-this later (PR3).
+features to genesis.db ``attention_events`` via the crud layer (``genesis.db.crud.attention``)
+— NEVER transcript text (firewall). Events are buffered and written in ONE transaction: the
+offline runner is a 2nd writer to the WAL DB while the server writes on its ticks, so the
+connection's ``timeout`` + ``busy_timeout`` + a single write window absorb lock contention.
+A ``JSONLConsumer`` (the edge sink) slots in beside this later (PR3).
 """
 from __future__ import annotations
 
 import json
 import logging
-import sqlite3
 from datetime import UTC, datetime
 
+import aiosqlite
+
 from genesis.attention.types import AttentionEvent
+from genesis.db.crud import attention as attention_crud
 
 logger = logging.getLogger(__name__)
-
-_COLUMNS = (
-    "id", "ts", "session_id", "activation", "score", "triggers_fired", "suppressors",
-    "window_ref", "mode_state", "clarity", "l15_verdict", "acceptance_signal",
-    "snapshot_id", "config_version", "created_at",
-)
 
 
 def _iso(epoch: float) -> str:
@@ -28,7 +24,7 @@ def _iso(epoch: float) -> str:
 
 
 class ShadowStoreConsumer:
-    """Buffer AttentionEvents; flush them to ``attention_events`` in one transaction.
+    """Buffer AttentionEvents; flush them to ``attention_events`` (via crud) in one txn.
 
     Row id = ``snapshot_id:config_version:trigger_utt_id`` — idempotent per (snapshot,
     config) so re-running the same snapshot yields identical rows, while a NEW
@@ -47,6 +43,7 @@ class ShadowStoreConsumer:
         self._rows.append(self._to_row(ev))
 
     def _to_row(self, ev: AttentionEvent) -> tuple:
+        # Order MUST match genesis.db.crud.attention.COLUMNS.
         wr = ev.window_ref
         trig_id = wr.utt_ids[-1] if wr.utt_ids else "x"
         row_id = f"{self.snapshot_id}:{self.config_version}:{trig_id}"
@@ -69,23 +66,16 @@ class ShadowStoreConsumer:
             self.snapshot_id, self.config_version, self._created_at,
         )
 
-    def flush(self) -> int:
-        """Write all buffered rows in one transaction; returns the count written."""
+    async def flush(self) -> int:
+        """Write all buffered rows via the crud layer in one transaction; returns count."""
         if not self._rows:
             return 0
-        placeholders = ", ".join(["?"] * len(_COLUMNS))
-        sql = (  # columns/placeholders are constants, not user input
-            f"INSERT OR REPLACE INTO attention_events ({', '.join(_COLUMNS)}) "  # noqa: S608
-            f"VALUES ({placeholders})"
-        )
-        conn = sqlite3.connect(self.db_path, timeout=self.timeout_s)
+        conn = await aiosqlite.connect(self.db_path, timeout=self.timeout_s)
         try:
-            conn.execute("PRAGMA busy_timeout=30000")
-            with conn:  # explicit txn: commit on success, ROLLBACK on any error (no partial batch)
-                conn.executemany(sql, self._rows)
+            await conn.execute("PRAGMA busy_timeout=30000")
+            n = await attention_crud.bulk_upsert_events(conn, self._rows)
         finally:
-            conn.close()  # __exit__ manages the txn, not the connection lifecycle
-        n = len(self._rows)
+            await conn.close()
         logger.info("persisted %d attention_events (snapshot=%s config=%s)",
                     n, self.snapshot_id, self.config_version)
         self._rows = []

--- a/src/genesis/attention/engine.py
+++ b/src/genesis/attention/engine.py
@@ -1,0 +1,103 @@
+"""The pure attention-engine fold: ``evaluate(utt, state, config) -> (state, event?)``.
+
+Deterministic, event-``ts``-driven (NO wall-clock), NO I/O, NO genesis deps. Offline
+batch = ``reduce(evaluate, ts_ordered_utts, EngineState())``; the SAME core runs live at
+the edge later behind a different source/sink, no logic change. Enforced by
+``tests/test_attention/test_edge_portability.py``.
+"""
+from __future__ import annotations
+
+from genesis.attention.clarity import capture_clarity, is_blip
+from genesis.attention.config import AttentionConfig
+from genesis.attention.scorer import resolve_activation, soft_relevance
+from genesis.attention.triggers import HARD_TRIGGERS, SOFT_TRIGGERS, SUPPRESSORS
+from genesis.attention.types import (
+    Activation,
+    AmbientUtterance,
+    AttentionEvent,
+    EngineState,
+    WindowRef,
+)
+
+
+def _run(registry, utt, window, config, *, enabled=None):
+    hits = []
+    for name, fn in registry.items():
+        if enabled is not None and name not in enabled:
+            continue
+        hit = fn(utt, window, config)
+        if hit is not None:
+            hits.append(hit)
+    return hits
+
+
+def evaluate(
+    utt: AmbientUtterance, state: EngineState, config: AttentionConfig,
+) -> tuple[EngineState, AttentionEvent | None]:
+    """One fold step. Mutates ``state`` in place and returns ``(state, event | None)``."""
+    sm = config.state_modifiers
+    clarity = capture_clarity(utt.rms, utt.duration_s, utt.frac_lt_1, utt.n_tokens)
+
+    # near-silence junk: ignore entirely (never pollutes windows or timing).
+    if is_blip(utt.rms, utt.duration_s, utt.n_tokens):
+        return state, None
+
+    # ── sessionize (gap-based, a pure fold over ts) ──
+    new_session = state.last_utt_ts is None or (utt.ts - state.last_utt_ts) > sm.session_gap_s
+    if new_session:
+        state.session_id = f"s{utt.id}"
+        state.session_started_ts = utt.ts
+        state.window.clear()
+        # cooldown (last_perk_ts) intentionally persists across sessions (anti-twitch).
+
+    # ── context window (evict utterances older than the cap) ──
+    state.window.append(utt)
+    while state.window and (utt.ts - state.window[0].ts) > sm.context_cap_s:
+        state.window.popleft()
+    window = list(state.window)
+
+    # ── triggers ──
+    hard = _run(HARD_TRIGGERS, utt, window, config)
+    soft = _run(SOFT_TRIGGERS, utt, window, config)
+    supp = _run(SUPPRESSORS, utt, window, config, enabled=config.suppressors_enabled or None)
+
+    # ── score ──
+    relevance = soft_relevance(soft)
+    is_continuation = state.session_started_ts is not None and utt.ts != state.session_started_ts
+    effective = relevance * clarity
+    if is_continuation:
+        effective *= sm.session_stickiness_mult
+
+    in_cooldown = state.last_perk_ts is not None and (utt.ts - state.last_perk_ts) < sm.cooldown_s
+    threshold = config.thresholds.soft_perk + (sm.cooldown_raise if in_cooldown else 0.0)
+
+    activation = resolve_activation(
+        hard_hits=hard, suppressor_hits=supp, effective=effective, threshold=threshold,
+    )
+
+    state.last_utt_ts = utt.ts
+    if activation is None:
+        return state, None
+
+    # a real perk (not a suppressed veto) arms the cooldown.
+    if activation in (Activation.HARD, Activation.SOFT):
+        state.last_perk_ts = utt.ts
+
+    session_id = state.session_id or f"s{utt.id}"
+    event = AttentionEvent(
+        activation=activation,
+        score=round(effective, 4),
+        triggers_fired=tuple(hard + soft),
+        suppressors=tuple(h.name for h in supp),
+        session_id=session_id,
+        window_ref=WindowRef(
+            session_id=session_id,
+            utt_ids=tuple(w.id for w in window),
+            ts_start=window[0].ts,
+            ts_end=utt.ts,
+        ),
+        ts=utt.ts,
+        mode_state=utt.mode_state,
+        clarity=round(clarity, 4),
+    )
+    return state, event

--- a/src/genesis/attention/engine.py
+++ b/src/genesis/attention/engine.py
@@ -59,7 +59,9 @@ def evaluate(
     # ── triggers ──
     hard = _run(HARD_TRIGGERS, utt, window, config)
     soft = _run(SOFT_TRIGGERS, utt, window, config)
-    supp = _run(SUPPRESSORS, utt, window, config, enabled=config.suppressors_enabled or None)
+    # suppressors_enabled is an ALLOWLIST: empty tuple -> no suppressors run (NOT "all").
+    # Pass it straight through (no `or None`, which would misread [] as "run everything").
+    supp = _run(SUPPRESSORS, utt, window, config, enabled=config.suppressors_enabled)
 
     # ── score ──
     relevance = soft_relevance(soft)

--- a/src/genesis/attention/runner.py
+++ b/src/genesis/attention/runner.py
@@ -62,7 +62,7 @@ def load_runner_config(path: str | None) -> AttentionConfig:
     return AttentionConfig.from_dict(default_config_dict())
 
 
-def run_shadow(
+async def run_shadow(
     snapshot_path: str | Path,
     config: AttentionConfig,
     *,
@@ -95,7 +95,7 @@ def run_shadow(
         for s in ev.suppressors:
             by_supp[s] += 1
 
-    persisted = consumer.flush() if consumer is not None else 0
+    persisted = await consumer.flush() if consumer is not None else 0
     samples = []
     step = max(1, len(events) // sample_n) if events else 1
     for ev in events[::step][:sample_n]:
@@ -141,13 +141,17 @@ def main() -> None:
     ap.add_argument("--db", help="genesis.db path for --persist (default: genesis_db_path())")
     args = ap.parse_args()
 
+    asyncio.run(_run_cli(args))
+
+
+async def _run_cli(args) -> None:
     cfg = load_runner_config(args.config)
     logger.info("config version=%s aliases=%s domain_kw=%d", cfg.version, cfg.aliases, len(cfg.domain_keywords))
     if args.snapshot:
         path = Path(args.snapshot).expanduser()
         sid = path.stem
     else:
-        sid, path = asyncio.run(pull_snapshot())
+        sid, path = await pull_snapshot()
 
     consumer = None
     if args.persist:
@@ -155,7 +159,7 @@ def main() -> None:
         db_path = args.db or str(genesis_db_path())
         consumer = ShadowStoreConsumer(db_path, snapshot_id=sid, config_version=cfg.version)
         logger.info("persisting to %s", db_path)
-    report = run_shadow(path, cfg, snapshot_id=sid, sample_n=args.samples, consumer=consumer)
+    report = await run_shadow(path, cfg, snapshot_id=sid, sample_n=args.samples, consumer=consumer)
     print_report(report)
 
 

--- a/src/genesis/attention/runner.py
+++ b/src/genesis/attention/runner.py
@@ -26,6 +26,7 @@ from genesis.attention.config import (
     default_config_dict,
     load_config,
 )
+from genesis.attention.consumers import ShadowStoreConsumer
 from genesis.attention.engine import evaluate
 from genesis.attention.snapshot import pull_snapshot
 from genesis.attention.sources import SnapshotSource
@@ -44,6 +45,7 @@ class ShadowReport:
     by_trigger: dict = field(default_factory=dict)
     by_suppressor: dict = field(default_factory=dict)
     samples: list = field(default_factory=list)
+    persisted: int = 0
 
     @property
     def fire_rate(self) -> float:
@@ -61,7 +63,12 @@ def load_runner_config(path: str | None) -> AttentionConfig:
 
 
 def run_shadow(
-    snapshot_path: str | Path, config: AttentionConfig, *, snapshot_id: str = "adhoc", sample_n: int = 25,
+    snapshot_path: str | Path,
+    config: AttentionConfig,
+    *,
+    snapshot_id: str = "adhoc",
+    sample_n: int = 25,
+    consumer: ShadowStoreConsumer | None = None,
 ) -> ShadowReport:
     src = SnapshotSource(snapshot_path)
     state = EngineState()
@@ -80,12 +87,15 @@ def run_shadow(
         if ev is None:
             continue
         events.append(ev)
+        if consumer is not None:
+            consumer.add(ev)
         by_act[ev.activation.value] += 1
         for h in ev.triggers_fired:
             by_trig[h.name] += 1
         for s in ev.suppressors:
             by_supp[s] += 1
 
+    persisted = consumer.flush() if consumer is not None else 0
     samples = []
     step = max(1, len(events) // sample_n) if events else 1
     for ev in events[::step][:sample_n]:
@@ -102,14 +112,15 @@ def run_shadow(
         })
     return ShadowReport(
         snapshot_id, total, evaluated, len(events),
-        dict(by_act), dict(by_trig), dict(by_supp), samples,
+        dict(by_act), dict(by_trig), dict(by_supp), samples, persisted,
     )
 
 
 def print_report(r: ShadowReport) -> None:
     print(f"\n=== ATTENTION SHADOW — snapshot {r.snapshot_id} ===")
     print(f"rows={r.total_rows}  evaluated(non-blip)={r.evaluated}  "
-          f"blips_skipped={r.total_rows - r.evaluated}  events={r.events}  fire_rate={r.fire_rate:.1%}")
+          f"blips_skipped={r.total_rows - r.evaluated}  events={r.events}  "
+          f"fire_rate={r.fire_rate:.1%}  persisted={r.persisted}")
     print(f"by_activation: {r.by_activation}")
     print(f"by_trigger:    {dict(sorted(r.by_trigger.items(), key=lambda x: -x[1]))}")
     print(f"by_suppressor: {r.by_suppressor}")
@@ -126,6 +137,8 @@ def main() -> None:
     ap.add_argument("--snapshot", help="use an existing snapshot .db instead of pulling")
     ap.add_argument("--config", help="attention_config.json (default: ~/.genesis overlay or built-in)")
     ap.add_argument("--samples", type=int, default=25)
+    ap.add_argument("--persist", action="store_true", help="write events to attention_events")
+    ap.add_argument("--db", help="genesis.db path for --persist (default: genesis_db_path())")
     args = ap.parse_args()
 
     cfg = load_runner_config(args.config)
@@ -135,7 +148,14 @@ def main() -> None:
         sid = path.stem
     else:
         sid, path = asyncio.run(pull_snapshot())
-    report = run_shadow(path, cfg, snapshot_id=sid, sample_n=args.samples)
+
+    consumer = None
+    if args.persist:
+        from genesis.env import genesis_db_path
+        db_path = args.db or str(genesis_db_path())
+        consumer = ShadowStoreConsumer(db_path, snapshot_id=sid, config_version=cfg.version)
+        logger.info("persisting to %s", db_path)
+    report = run_shadow(path, cfg, snapshot_id=sid, sample_n=args.samples, consumer=consumer)
     print_report(report)
 
 

--- a/src/genesis/attention/runner.py
+++ b/src/genesis/attention/runner.py
@@ -1,0 +1,143 @@
+"""Offline shadow runner — pull an ambient snapshot, replay the L1 gate over it, report.
+
+v1 (spike): prints the fire-rate + activation/trigger breakdown + sample perked windows
+so we can eyeball whether the deterministic gate is sane BEFORE building the persistence
+layer. Persistence into ``attention_events`` is added after the spike checkpoint.
+
+Invoke (NOT an MCP tool — a direct CLI, per feedback_prefer_direct_over_mcp_tools):
+    python -m genesis.attention.runner [--snapshot PATH] [--config PATH] [--samples N]
+
+The transcript text shown in samples is read from the transient snapshot for OFFLINE
+eyeballing only; it is never persisted to genesis.db (firewall).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from genesis.attention.clarity import is_blip
+from genesis.attention.config import (
+    DEFAULT_CONFIG_PATH,
+    AttentionConfig,
+    default_config_dict,
+    load_config,
+)
+from genesis.attention.engine import evaluate
+from genesis.attention.snapshot import pull_snapshot
+from genesis.attention.sources import SnapshotSource
+from genesis.attention.types import AttentionEvent, EngineState
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ShadowReport:
+    snapshot_id: str
+    total_rows: int
+    evaluated: int  # non-blip
+    events: int
+    by_activation: dict = field(default_factory=dict)
+    by_trigger: dict = field(default_factory=dict)
+    by_suppressor: dict = field(default_factory=dict)
+    samples: list = field(default_factory=list)
+
+    @property
+    def fire_rate(self) -> float:
+        return self.events / self.evaluated if self.evaluated else 0.0
+
+
+def load_runner_config(path: str | None) -> AttentionConfig:
+    """--config path, else the ~/.genesis overlay, else the built-in starter default."""
+    if path:
+        return load_config(path)
+    overlay = Path(DEFAULT_CONFIG_PATH).expanduser()
+    if overlay.exists():
+        return load_config(overlay)
+    return AttentionConfig.from_dict(default_config_dict())
+
+
+def run_shadow(
+    snapshot_path: str | Path, config: AttentionConfig, *, snapshot_id: str = "adhoc", sample_n: int = 25,
+) -> ShadowReport:
+    src = SnapshotSource(snapshot_path)
+    state = EngineState()
+    utt_by_id: dict[int, object] = {}
+    total = evaluated = 0
+    events: list[AttentionEvent] = []
+    by_act, by_trig, by_supp = Counter(), Counter(), Counter()
+
+    for utt in src.iter_utterances():
+        total += 1
+        utt_by_id[utt.id] = utt
+        if is_blip(utt.rms, utt.duration_s, utt.n_tokens):
+            continue
+        evaluated += 1
+        state, ev = evaluate(utt, state, config)
+        if ev is None:
+            continue
+        events.append(ev)
+        by_act[ev.activation.value] += 1
+        for h in ev.triggers_fired:
+            by_trig[h.name] += 1
+        for s in ev.suppressors:
+            by_supp[s] += 1
+
+    samples = []
+    step = max(1, len(events) // sample_n) if events else 1
+    for ev in events[::step][:sample_n]:
+        trg = utt_by_id.get(ev.window_ref.utt_ids[-1])
+        samples.append({
+            "ts": ev.ts,
+            "activation": ev.activation.value,
+            "score": ev.score,
+            "clarity": ev.clarity,
+            "triggers": [h.name for h in ev.triggers_fired],
+            "suppressors": list(ev.suppressors),
+            "is_user": getattr(trg, "is_user", None),
+            "text": getattr(trg, "text", ""),
+        })
+    return ShadowReport(
+        snapshot_id, total, evaluated, len(events),
+        dict(by_act), dict(by_trig), dict(by_supp), samples,
+    )
+
+
+def print_report(r: ShadowReport) -> None:
+    print(f"\n=== ATTENTION SHADOW — snapshot {r.snapshot_id} ===")
+    print(f"rows={r.total_rows}  evaluated(non-blip)={r.evaluated}  "
+          f"blips_skipped={r.total_rows - r.evaluated}  events={r.events}  fire_rate={r.fire_rate:.1%}")
+    print(f"by_activation: {r.by_activation}")
+    print(f"by_trigger:    {dict(sorted(r.by_trigger.items(), key=lambda x: -x[1]))}")
+    print(f"by_suppressor: {r.by_suppressor}")
+    print(f"\n--- {len(r.samples)} sample events (text shown for OFFLINE eyeballing only) ---")
+    for s in r.samples:
+        print(f"[{s['activation']:>10}] score={s['score']:.3f} clarity={s['clarity']:.2f} "
+              f"u={s['is_user']} trig={s['triggers']} sup={s['suppressors']}")
+        print(f"             text: {s['text'][:150]!r}")
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    ap = argparse.ArgumentParser(description="Attention engine offline shadow runner")
+    ap.add_argument("--snapshot", help="use an existing snapshot .db instead of pulling")
+    ap.add_argument("--config", help="attention_config.json (default: ~/.genesis overlay or built-in)")
+    ap.add_argument("--samples", type=int, default=25)
+    args = ap.parse_args()
+
+    cfg = load_runner_config(args.config)
+    logger.info("config version=%s aliases=%s domain_kw=%d", cfg.version, cfg.aliases, len(cfg.domain_keywords))
+    if args.snapshot:
+        path = Path(args.snapshot).expanduser()
+        sid = path.stem
+    else:
+        sid, path = asyncio.run(pull_snapshot())
+    report = run_shadow(path, cfg, snapshot_id=sid, sample_n=args.samples)
+    print_report(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/genesis/attention/scorer.py
+++ b/src/genesis/attention/scorer.py
@@ -1,0 +1,41 @@
+"""Pure score composition + activation resolution (design §4). No genesis deps, no I/O.
+
+The dial is a single threshold (reply-everything <-> reply-nothing). Soft hits sum to a
+relevance, scaled by the utterance's capture-clarity (tolerate garble; weight it down,
+never drop it) and by in-session stickiness; state modifiers bend the threshold.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from genesis.attention.types import Activation, TriggerHit
+
+
+def soft_relevance(hits: Sequence[TriggerHit]) -> float:
+    """Sum of soft-hit weighted contributions."""
+    return sum(h.contribution for h in hits)
+
+
+def resolve_activation(
+    *,
+    hard_hits: Sequence[TriggerHit],
+    suppressor_hits: Sequence[TriggerHit],
+    effective: float,
+    threshold: float,
+) -> Activation | None:
+    """The gate verdict, or None if nothing would fire.
+
+    Precedence: a suppressor VETOES an otherwise-firing event -> SUPPRESSED, UNLESS an
+    explicit summons (``explicit_invite``) is present (only a summons beats a suppressor;
+    a bare name-mention does not). Otherwise: any hard trigger -> HARD; effective score
+    >= threshold -> SOFT. A suppressor with nothing to suppress emits no event.
+    """
+    has_summons = any(h.name == "explicit_invite" for h in hard_hits)
+    if suppressor_hits and not has_summons:
+        would_fire = bool(hard_hits) or effective >= threshold
+        return Activation.SUPPRESSED if would_fire else None
+    if hard_hits:
+        return Activation.HARD
+    if effective >= threshold:
+        return Activation.SOFT
+    return None

--- a/src/genesis/attention/snapshot.py
+++ b/src/genesis/attention/snapshot.py
@@ -1,0 +1,119 @@
+"""Pull a read-only snapshot of the edge ambient.db to a transient local file.
+
+NET-NEW (no reusable helper existed): adapts the SSH idiom from
+``observability.ambient_health`` (BatchMode / ConnectTimeout / orphan-kill) but runs a
+remote ``sqlite3.backup()`` (the edge has NO sqlite3 CLI -> remote python3) for a
+consistent copy, then ``scp``'s it back. Firewall: this transient file is the
+sanctioned offline read-only analysis snapshot — the raw transcript text lives ONLY
+here, NEVER in genesis.db.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import shlex
+from datetime import UTC, datetime
+from pathlib import Path
+
+from genesis.observability.ambient_health import (
+    AmbientRemoteConfig,
+    load_ambient_remote_config,
+)
+
+logger = logging.getLogger(__name__)
+
+# sqlite3.backup() over SSH streams the whole DB (tens of MB at ~1-5 MB/s on LAN) —
+# far slower than ambient_health's `cat`, so a dedicated, generous ceiling.
+_SNAPSHOT_SSH_TIMEOUT_S = 60.0
+_REMOTE_TMP = "~/.ambient_snap.db"
+_EDGE_DB = "~/ambient.db"
+_DEFAULT_DEST = "~/.genesis/attention/snapshots"
+
+
+class SnapshotError(Exception):
+    """Snapshot pull failed (edge unreachable / remote backup / scp / timeout)."""
+
+
+def _ssh_base(cfg: AmbientRemoteConfig) -> list[str]:
+    return [
+        "ssh", "-i", str(Path(cfg.ssh_key).expanduser()),
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", "ConnectTimeout=10",
+        "-o", "BatchMode=yes",
+        f"{cfg.host_user}@{cfg.host_ip}",
+    ]
+
+
+def _backup_py(edge_db: str, remote_tmp: str) -> str:
+    """Remote one-liner: consistent read-only backup of the edge DB to a temp file."""
+    return (
+        "import sqlite3,os;"
+        f"s=sqlite3.connect('file:'+os.path.expanduser({edge_db!r})+'?mode=ro',uri=True);"
+        f"d=sqlite3.connect(os.path.expanduser({remote_tmp!r}));"
+        "s.backup(d);d.close();s.close()"
+    )
+
+
+def _remote_backup_arg(edge_db: str, remote_tmp: str) -> str:
+    """The remote backup command as ONE shell-safe token. ssh joins trailing args with
+    spaces and re-parses them in the REMOTE shell, so the python one-liner's quotes and
+    parens MUST be shell-quoted or the remote bash chokes on '('."""
+    return f"python3 -c {shlex.quote(_backup_py(edge_db, remote_tmp))}"
+
+
+def _scp_cmd(cfg: AmbientRemoteConfig, remote_tmp: str, local: Path) -> list[str]:
+    return [
+        "scp", "-i", str(Path(cfg.ssh_key).expanduser()),
+        "-o", "StrictHostKeyChecking=accept-new",
+        "-o", "ConnectTimeout=10",
+        "-o", "BatchMode=yes",
+        f"{cfg.host_user}@{cfg.host_ip}:{remote_tmp}", str(local),
+    ]
+
+
+async def _run(cmd: list[str], timeout_s: float) -> None:
+    proc = await asyncio.create_subprocess_exec(
+        *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        _out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout_s + 5)
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
+        raise SnapshotError(f"{cmd[0]} timed out after {timeout_s}s") from None
+    if proc.returncode != 0:
+        raise SnapshotError(f"{cmd[0]} failed (rc={proc.returncode}): {err.decode().strip()[:300]}")
+
+
+async def pull_snapshot(
+    dest_dir: str | Path = _DEFAULT_DEST,
+    *,
+    cfg: AmbientRemoteConfig | None = None,
+    edge_db: str = _EDGE_DB,
+    remote_tmp: str = _REMOTE_TMP,
+    timeout_s: float = _SNAPSHOT_SSH_TIMEOUT_S,
+) -> tuple[str, Path]:
+    """Pull a consistent read-only snapshot of the edge ambient.db.
+
+    Returns ``(snapshot_id, local_path)``. Raises ``SnapshotError`` on any failure.
+    """
+    cfg = cfg or load_ambient_remote_config()
+    if cfg is None:
+        raise SnapshotError("ambient_remote.yaml absent or disabled — no edge configured")
+
+    dest = Path(dest_dir).expanduser()
+    dest.mkdir(parents=True, exist_ok=True)
+    snapshot_id = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    local = dest / f"ambient_{snapshot_id}.db"
+    base = _ssh_base(cfg)
+
+    await _run(base + [_remote_backup_arg(edge_db, remote_tmp)], timeout_s)
+    await _run(_scp_cmd(cfg, remote_tmp, local), timeout_s)
+    try:  # best-effort remote cleanup
+        await _run(base + ["rm", "-f", remote_tmp], 15.0)
+    except SnapshotError as exc:
+        logger.warning("snapshot remote cleanup failed (harmless): %s", exc)
+
+    logger.info("pulled ambient snapshot %s -> %s (%d bytes)", snapshot_id, local,
+                local.stat().st_size if local.exists() else -1)
+    return snapshot_id, local

--- a/src/genesis/attention/sources.py
+++ b/src/genesis/attention/sources.py
@@ -1,0 +1,98 @@
+"""Source adapters that feed ``AmbientUtterance`` into the engine. All I/O lives HERE,
+never in the pure core. ``SnapshotSource`` reads a transient read-only ambient.db
+snapshot; ``row_to_utterance`` is pure and unit-testable. A ``LiveBridgeSource`` (the
+future edge adapter emitting the same ``AmbientUtterance``) slots in beside this.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sqlite3
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+from genesis.attention.clarity import frac_below
+from genesis.attention.types import AmbientUtterance
+
+logger = logging.getLogger(__name__)
+
+_LABEL_TOTAL = re.compile(r"/(\d+)\s*$")  # speaker_label "wN:c/TOTAL" -> TOTAL
+
+
+def _parse_ts(ts) -> float | None:
+    """ISO8601 (UTC, naive-assumed-UTC) -> epoch seconds. None if unparseable."""
+    if not isinstance(ts, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(ts)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.timestamp()
+
+
+def _speaker_total(label) -> int | None:
+    if not label:
+        return None
+    m = _LABEL_TOTAL.search(str(label))
+    return int(m.group(1)) if m else None
+
+
+def row_to_utterance(row: dict) -> AmbientUtterance | None:
+    """Map an ``ambient_transcripts`` row (dict) -> ``AmbientUtterance``. Returns None
+    when the row has no usable timestamp. Robust to missing/corrupt ``meta``."""
+    ts = _parse_ts(row.get("ts"))
+    if ts is None:
+        return None
+    meta = {}
+    raw = row.get("meta")
+    if raw:
+        try:
+            meta = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            meta = {}
+    feats = meta.get("asr_feats") or {}
+    audio = meta.get("audio") or {}
+    ys = feats.get("ys_log_probs") or []
+    try:
+        n_tokens = int(feats.get("n_tokens") or 0)
+    except (TypeError, ValueError):
+        n_tokens = 0
+    return AmbientUtterance(
+        id=int(row["id"]),
+        ts=ts,
+        text=row.get("text") or "",
+        duration_s=float(row.get("duration_s") or 0.0),
+        is_user=row.get("is_user"),
+        speaker_total=_speaker_total(row.get("speaker_label")),
+        n_tokens=n_tokens,
+        frac_lt_1=frac_below(ys, -1.0),
+        rms=float(audio.get("rms") or 0.0),
+        mode_state="unknown",  # ambient_transcripts carries no interaction-plane state
+        source=row.get("source") or "",
+    )
+
+
+class SnapshotSource:
+    """Yield ts-ordered utterances from a read-only ambient.db snapshot file."""
+
+    def __init__(self, snapshot_path: str | Path):
+        self.path = Path(snapshot_path)
+
+    def iter_utterances(self) -> Iterator[AmbientUtterance]:
+        conn = sqlite3.connect(f"file:{self.path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        try:
+            cur = conn.execute(
+                "SELECT id, ts, text, duration_s, speaker_label, source, meta, is_user, "
+                "speaker_name FROM ambient_transcripts ORDER BY ts, id"
+            )
+            for r in cur:
+                utt = row_to_utterance(dict(r))
+                if utt is not None:
+                    yield utt
+        finally:
+            conn.close()

--- a/src/genesis/attention/triggers.py
+++ b/src/genesis/attention/triggers.py
@@ -1,0 +1,126 @@
+"""Pluggable, pure L1 triggers — the §4 taxonomy as DATA-parametrized predicates.
+
+Each trigger: ``(utt, window, config) -> TriggerHit | None``. Registries group them by
+kind (HARD precision-first / SOFT recall-first / SUPPRESSOR veto). The scorer composes
+the soft hits; the engine resolves activation. Pure — no genesis deps, no I/O.
+
+PR1 ships a high-signal subset; the remaining §4 triggers (emotional lexicon,
+unknown-speaker, unanswered-question, sensitive-topic, low-ASR-confidence, mode-state
+suppressors) land in PR3. Names here are the STABLE keys used in ``config.weights`` and
+in the shadow log's ``triggers_fired`` — do not rename casually.
+"""
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+
+from genesis.attention.config import AttentionConfig
+from genesis.attention.types import AmbientUtterance, TriggerHit, TriggerKind
+
+TriggerFn = Callable[[AmbientUtterance, Sequence[AmbientUtterance], AttentionConfig], "TriggerHit | None"]
+
+# An invite cue that, ALONGSIDE a Genesis alias, marks an explicit "ask Genesis".
+_INVITE_CUE = re.compile(r"\b(ask|tell|what (?:does|do|would|should)|let'?s ask|should we ask)\b", re.IGNORECASE)
+
+
+def _term_present(text: str, terms: Sequence[str]) -> bool:
+    """Whole-word, case-insensitive presence of ANY term (word-boundary match)."""
+    low = text.lower()
+    return any(re.search(rf"\b{re.escape(t.lower())}\b", low) for t in terms if t)
+
+
+def _bank_match(text: str, patterns: Sequence[re.Pattern]) -> bool:
+    return any(p.search(text) for p in patterns)
+
+
+def _w(config: AttentionConfig, name: str, default: float) -> float:
+    return config.weights.get(name, default)
+
+
+# ── HARD — precision-first, near-certain perk (still flows to the warrant stage) ──
+
+def hard_ambient_name(utt, window, config):
+    if config.aliases and _term_present(utt.text, config.aliases):
+        return TriggerHit("ambient_name", TriggerKind.HARD)
+    return None
+
+
+def hard_explicit_invite(utt, window, config):
+    # a Genesis alias AND an invite cue in the same utterance ("ask Genesis ...").
+    # This is the "explicit summons" that beats a suppressor (see scorer).
+    if config.aliases and _term_present(utt.text, config.aliases) and _INVITE_CUE.search(utt.text):
+        return TriggerHit("explicit_invite", TriggerKind.HARD)
+    return None
+
+
+# ── SOFT — recall-first, weighted (contribution = config weight) ──
+
+def soft_question(utt, window, config):
+    pats = config.lexical_patterns.get("question", ())
+    if (pats and _bank_match(utt.text, pats)) or "?" in utt.text:
+        return TriggerHit("question", TriggerKind.SOFT, _w(config, "question", 0.30))
+    return None
+
+
+def soft_help_seeking(utt, window, config):
+    pats = config.lexical_patterns.get("help_seeking", ())
+    if pats and _bank_match(utt.text, pats):
+        return TriggerHit("help_seeking", TriggerKind.SOFT, _w(config, "help_seeking", 0.35))
+    return None
+
+
+def soft_multi_speaker(utt, window, config):
+    # By-window speaker count only (speaker_label clusters are NOT comparable across
+    # windows). Multi-speaker RAISES confidence: less likely the user addressing
+    # Genesis directly -> more likely a real ambient conversation (§4).
+    if utt.speaker_total is not None and utt.speaker_total >= 2:
+        return TriggerHit("multi_speaker", TriggerKind.SOFT, _w(config, "multi_speaker", 0.40))
+    return None
+
+
+def soft_is_user(utt, window, config):
+    # WEAK on its own — the user may be talking directly to Genesis via STT right now.
+    if utt.is_user == 1:
+        return TriggerHit("is_user", TriggerKind.SOFT, _w(config, "is_user", 0.10))
+    return None
+
+
+def soft_domain_keyword(utt, window, config):
+    low = utt.text.lower()
+    if any(kw.lower() in low for kw in config.domain_keywords):
+        return TriggerHit("domain_keyword", TriggerKind.SOFT, _w(config, "domain_keyword", 0.30))
+    return None
+
+
+def soft_known_entity(utt, window, config):
+    if config.known_entities and _term_present(utt.text, config.known_entities):
+        return TriggerHit("known_entity", TriggerKind.SOFT, _w(config, "known_entity", 0.25))
+    return None
+
+
+# ── SUPPRESSOR — veto (overrides soft fires; only an explicit summons beats it) ──
+
+def suppress_explicit_dismissal(utt, window, config):
+    pats = config.suppressor_patterns.get("explicit_dismissal", ())
+    if pats and _bank_match(utt.text, pats):
+        return TriggerHit("explicit_dismissal", TriggerKind.SUPPRESSOR)
+    return None
+
+
+HARD_TRIGGERS: dict[str, TriggerFn] = {
+    "ambient_name": hard_ambient_name,
+    "explicit_invite": hard_explicit_invite,
+}
+
+SOFT_TRIGGERS: dict[str, TriggerFn] = {
+    "question": soft_question,
+    "help_seeking": soft_help_seeking,
+    "multi_speaker": soft_multi_speaker,
+    "is_user": soft_is_user,
+    "domain_keyword": soft_domain_keyword,
+    "known_entity": soft_known_entity,
+}
+
+SUPPRESSORS: dict[str, TriggerFn] = {
+    "explicit_dismissal": suppress_explicit_dismissal,
+}

--- a/src/genesis/attention/types.py
+++ b/src/genesis/attention/types.py
@@ -1,0 +1,105 @@
+"""Data types for the passive-listening attention engine (v1, shadow mode).
+
+Pure — NO genesis-runtime imports, NO I/O (enforced by the edge-port test). All
+time-state is keyed off the utterance ``ts`` (epoch seconds), never wall-clock, so an
+offline batch replay over a snapshot is byte-identical to a future live edge run.
+"""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class Activation(StrEnum):
+    """The gate's verdict for an utterance."""
+
+    HARD = "hard"              # near-certain perk (a precision-first trigger fired)
+    SOFT = "soft"              # weighted soft-score crossed the perk threshold
+    SUPPRESSED = "suppressed"  # a suppressor vetoed an otherwise-firing event
+
+
+class TriggerKind(StrEnum):
+    HARD = "hard"
+    SOFT = "soft"
+    SUPPRESSOR = "suppressor"
+
+
+@dataclass(frozen=True)
+class AmbientUtterance:
+    """One normalized, source-agnostic utterance the engine consumes.
+
+    Populated by an ADAPTER (``SnapshotSource`` offline; a ``LiveBridgeSource`` at
+    the edge later) — the pure core never opens ``ambient.db``. ``text`` is used only
+    by lexical triggers and lives in memory only; it is NEVER persisted (firewall).
+    """
+
+    id: int                     # source row id (used for window_ref — never text)
+    ts: float                   # epoch seconds, utterance END — the ONE clock
+    text: str                   # transcript; lexical-trigger input only, never stored
+    duration_s: float
+    is_user: int | None         # 1=user / 0=other / None=no verdict (conservative)
+    speaker_total: int | None   # # speakers in THIS utt's diar window (wN:c/TOTAL); None if unlabeled
+    n_tokens: int
+    frac_lt_1: float            # fraction of ys_log_probs < -1.0 (ASR-confidence stat)
+    rms: float
+    mode_state: str = "unknown"  # "unknown" offline; live interaction-plane booleans at the edge
+    source: str = ""            # connection/device id
+
+
+@dataclass(frozen=True)
+class TriggerHit:
+    """One fired trigger. ``contribution`` is its weighted add to the soft score
+    (0.0 for hard flags and suppressors — they act on activation, not the score)."""
+
+    name: str
+    kind: TriggerKind
+    contribution: float = 0.0
+
+
+@dataclass(frozen=True)
+class WindowRef:
+    """Reference to the ambient rows behind an event — IDs + ts range ONLY, never
+    text (the firewall: raw transcript lives only in the transient snapshot file).
+    ``snapshot_id`` is attached by the consumer at persist time, not the core."""
+
+    session_id: str
+    utt_ids: tuple[int, ...]
+    ts_start: float
+    ts_end: float
+
+
+@dataclass(frozen=True)
+class AttentionEvent:
+    """What the gate WOULD have perked up on. Snapshot-agnostic (the pure-core
+    output); the consumer stamps snapshot_id/config_version when persisting."""
+
+    activation: Activation
+    score: float
+    triggers_fired: tuple[TriggerHit, ...]
+    suppressors: tuple[str, ...]
+    session_id: str
+    window_ref: WindowRef
+    ts: float
+    mode_state: str
+    clarity: float                 # capture_clarity of the triggering utterance
+    l15_verdict: dict | None = None  # {real, perk} from L1.5 — always None in v1 (stub)
+
+
+@dataclass
+class EngineState:
+    """Rolling engine state, passed explicitly through the fold (NO module-level
+    state — cf. the awareness scorer anti-pattern). Mutated in place and returned;
+    serializable via ``dataclasses.asdict`` for the future edge runner.
+
+    ``window`` holds recent utterances within the context window (transient, text
+    included — in memory only). ``last_perk_ts`` drives the cooldown; it intentionally
+    persists across sessions (anti-twitch). (PR3 adds ``pending_questions`` for the
+    unanswered-question bounded-lookahead signal — out of the PR1 trigger subset.)
+    """
+
+    session_id: str | None = None
+    session_started_ts: float | None = None
+    last_utt_ts: float | None = None
+    last_perk_ts: float | None = None
+    window: deque = field(default_factory=deque)

--- a/src/genesis/dashboard/routes/vitals.py
+++ b/src/genesis/dashboard/routes/vitals.py
@@ -29,6 +29,7 @@ _TABLES_WITH_CREATED_AT = {
     "awareness_ticks", "pending_embeddings", "outreach_history",
     "surplus_tasks", "surplus_insights", "inbox_items",
     "session_bookmarks", "telegram_messages", "activity_log",
+    "attention_events",  # shadow store — rows_24h gives fire-rate visibility pre-PR2 tab
 }
 
 # Known MCP servers — shown even with zero activity so user sees full inventory.

--- a/src/genesis/db/crud/attention.py
+++ b/src/genesis/db/crud/attention.py
@@ -1,0 +1,38 @@
+"""CRUD for attention_events — the passive-listening attention engine's SHADOW store.
+
+Rows are attention DECISIONS + REFERENCES + labels ONLY (activation/score/
+triggers_fired/window_ref/clarity); NEVER ambient transcript text (firewall). The
+offline shadow runner is the only writer; a future dashboard tab (PR2) reads for the
+should/shouldn't review + offline calibration.
+"""
+from __future__ import annotations
+
+import aiosqlite
+
+# Column order — the offline runner's row tuples (ShadowStoreConsumer._to_row) MUST match.
+COLUMNS = (
+    "id", "ts", "session_id", "activation", "score", "triggers_fired", "suppressors",
+    "window_ref", "mode_state", "clarity", "l15_verdict", "acceptance_signal",
+    "snapshot_id", "config_version", "created_at",
+)
+
+
+async def bulk_upsert_events(db: aiosqlite.Connection, rows: list[tuple]) -> int:
+    """Idempotent bulk INSERT OR REPLACE of shadow AttentionEvents. ``rows`` are tuples
+    in ``COLUMNS`` order. One transaction (executemany + commit); returns the count."""
+    if not rows:
+        return 0
+    placeholders = ", ".join(["?"] * len(COLUMNS))
+    await db.executemany(
+        f"INSERT OR REPLACE INTO attention_events ({', '.join(COLUMNS)}) "  # noqa: S608
+        f"VALUES ({placeholders})",
+        rows,
+    )
+    await db.commit()
+    return len(rows)
+
+
+async def count(db: aiosqlite.Connection) -> int:
+    cursor = await db.execute("SELECT COUNT(*) AS n FROM attention_events")
+    row = await cursor.fetchone()
+    return row["n"] if row else 0

--- a/src/genesis/db/migrations/0042_attention_events.py
+++ b/src/genesis/db/migrations/0042_attention_events.py
@@ -1,0 +1,52 @@
+"""Add attention_events — the passive-listening attention engine's SHADOW store.
+
+Stores attention DECISIONS + REFERENCES + labels ONLY: activation/score/
+triggers_fired/window_ref/clarity never carry ambient transcript text. The raw text
+lives (and dies) in ambient.db on the edge; the offline shadow runner persists only
+salience metadata + a window_ref (ids + ts range) here, so no cognition job that
+scans this table can see conversation content. Feeds the shadow review + offline
+calibration (design §6/§9). Additive + idempotent; the canonical DDL is mirrored in
+db/schema/_tables.py for the fresh-DB path.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS attention_events (
+            id                TEXT PRIMARY KEY,
+            ts                TEXT NOT NULL,
+            session_id        TEXT NOT NULL,
+            activation        TEXT NOT NULL,
+            score             REAL NOT NULL,
+            triggers_fired    TEXT NOT NULL DEFAULT '[]',
+            suppressors       TEXT NOT NULL DEFAULT '[]',
+            window_ref        TEXT NOT NULL,
+            mode_state        TEXT,
+            clarity           REAL,
+            l15_verdict       TEXT,
+            acceptance_signal TEXT,
+            snapshot_id       TEXT,
+            config_version    TEXT,
+            created_at        TEXT NOT NULL
+        )
+        """
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_attention_events_session ON attention_events(session_id)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_attention_events_ts ON attention_events(ts)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_attention_events_unlabeled "
+        "ON attention_events(acceptance_signal) WHERE acceptance_signal IS NULL"
+    )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    await db.execute("DROP TABLE IF EXISTS attention_events")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -39,6 +39,28 @@ TABLES = {
             surfaced_count    INTEGER NOT NULL DEFAULT 0   -- contextual-hook surfacings (proactive hook / tool advisor); honest funnel signal, NOT read by promoter
         )
     """,
+    "attention_events": """
+        CREATE TABLE IF NOT EXISTS attention_events (
+            id                TEXT PRIMARY KEY,
+            ts                TEXT NOT NULL,               -- event ts (utterance end), ISO8601 UTC
+            session_id        TEXT NOT NULL,
+            activation        TEXT NOT NULL,               -- hard | soft | suppressed
+            score             REAL NOT NULL,
+            triggers_fired    TEXT NOT NULL DEFAULT '[]',  -- JSON [{name,kind,contribution}] — NO transcript text
+            suppressors       TEXT NOT NULL DEFAULT '[]',  -- JSON [name]
+            window_ref        TEXT NOT NULL,               -- JSON {snapshot_id,session_id,utt_ids,ts_start,ts_end} — REFS ONLY
+            mode_state        TEXT,
+            clarity           REAL,
+            l15_verdict       TEXT,                        -- JSON {real,perk}; NULL in v1 (L1.5 stubbed)
+            acceptance_signal TEXT,                        -- should|shouldnt|skip; back-filled at shadow review (PR2)
+            snapshot_id       TEXT,
+            config_version    TEXT,
+            created_at        TEXT NOT NULL
+            -- SHADOW/OFFLINE-ONLY firewall table: attention DECISIONS + REFERENCES only,
+            -- NEVER ambient transcript text (that lives+dies in ambient.db on the edge).
+            -- Not read by any cognition job (dream/ego/memory-synthesis).
+        )
+    """,
     "observations": """
         CREATE TABLE IF NOT EXISTS observations (
             id               TEXT PRIMARY KEY,
@@ -1515,6 +1537,9 @@ KNOWLEDGE_FTS5_DDL = """
 # ─── Indexes ──────────────────────────────────────────────────────────────────
 
 INDEXES = [
+    "CREATE INDEX IF NOT EXISTS idx_attention_events_session ON attention_events(session_id)",
+    "CREATE INDEX IF NOT EXISTS idx_attention_events_ts ON attention_events(ts)",
+    "CREATE INDEX IF NOT EXISTS idx_attention_events_unlabeled ON attention_events(acceptance_signal) WHERE acceptance_signal IS NULL",
     "CREATE INDEX IF NOT EXISTS idx_procedural_task_type ON procedural_memory(task_type)",
     "CREATE INDEX IF NOT EXISTS idx_procedural_draft ON procedural_memory(draft)",
     "CREATE INDEX IF NOT EXISTS idx_procedural_activation_tier ON procedural_memory(activation_tier)",

--- a/tests/test_attention/test_clarity.py
+++ b/tests/test_attention/test_clarity.py
@@ -1,0 +1,36 @@
+"""capture-clarity pure-function tests (runtime copy of the garble_features math)."""
+import math
+
+from genesis.attention.clarity import capture_clarity, frac_below, is_blip
+
+
+def test_frac_below():
+    assert frac_below([], -1.0) == 0.0
+    assert frac_below([-2.0, -0.5, -1.5, 0.0], -1.0) == 0.5  # two of four < -1.0
+
+
+def test_capture_clarity_loud_long_confident_is_max():
+    assert capture_clarity(rms=0.2, duration_s=5.0, frac_lt_1=0.0, n_tokens=20) == 1.0
+
+
+def test_capture_clarity_near_silence_blip_is_low():
+    lo = capture_clarity(rms=0.0, duration_s=0.3, frac_lt_1=0.9, n_tokens=1)
+    assert 0.0 <= lo <= 1.0
+    assert lo < 0.15
+
+
+def test_capture_clarity_monotonic_in_asr_confidence():
+    hi_conf = capture_clarity(0.1, 2.0, 0.0, 8)
+    lo_conf = capture_clarity(0.1, 2.0, 0.5, 8)
+    assert hi_conf > lo_conf  # more < -1.0 tokens -> lower clarity
+
+
+def test_capture_clarity_nan_safe():
+    v = capture_clarity(rms=float("nan"), duration_s=2.0, frac_lt_1=0.1, n_tokens=8)
+    assert 0.0 <= v <= 1.0 and not math.isnan(v)
+
+
+def test_is_blip():
+    assert is_blip(rms=0.01, duration_s=0.4, n_tokens=1) is True     # near-silence + short
+    assert is_blip(rms=0.01, duration_s=5.0, n_tokens=20) is False   # quiet but long + rich
+    assert is_blip(rms=0.2, duration_s=0.2, n_tokens=1) is False     # loud -> not a blip

--- a/tests/test_attention/test_config.py
+++ b/tests/test_attention/test_config.py
@@ -54,3 +54,14 @@ def test_load_config_reads_file(tmp_path):
     c = load_config(p)
     assert c.version == "1.0.0"
     assert c.suppressors_enabled == ("explicit_dismissal",)
+
+
+def test_default_config_dict_compiles():
+    from genesis.attention.config import default_config_dict
+
+    c = AttentionConfig.from_dict(default_config_dict())
+    assert c.aliases == ("genesis",)
+    assert "routing" in c.domain_keywords
+    assert c.thresholds.soft_perk == 0.6            # Thresholds default (empty dict -> defaults)
+    assert "explicit_dismissal" in c.suppressors_enabled
+    assert c.lexical_patterns["question"]           # compiled non-empty

--- a/tests/test_attention/test_config.py
+++ b/tests/test_attention/test_config.py
@@ -1,0 +1,56 @@
+"""attention_config.json parsing/compilation tests."""
+import json
+import re
+
+from genesis.attention.config import AttentionConfig, StateModifiers, Thresholds, load_config
+
+
+def _raw() -> dict:
+    return {
+        "version": "1.0.0",
+        "aliases": ["genesis", "gen"],
+        "domain_keywords": ["routing", "attention engine"],
+        "known_entities": ["Alice"],
+        "lexical_patterns": {"question": [r"\bhow do i\b", r"\?"]},
+        "emotional_patterns": {"frustration": [r"\bugh\b"]},
+        "suppressor_patterns": {"explicit_dismissal": [r"never mind", r"not you"]},
+        "weights": {"question": 0.3, "multi_speaker": 0.4},
+        "state_modifiers": {"cooldown_s": 45, "session_gap_s": 20},
+        "thresholds": {"soft_perk": 0.55},
+        "suppressors_enabled": ["explicit_dismissal"],
+    }
+
+
+def test_from_dict_parses_and_compiles_case_insensitive():
+    c = AttentionConfig.from_dict(_raw())
+    assert c.version == "1.0.0"
+    assert c.aliases == ("genesis", "gen")
+    pat = c.lexical_patterns["question"][0]
+    assert isinstance(pat, re.Pattern)
+    assert pat.search("HOW DO I do this")  # compiled with IGNORECASE
+    assert c.weights["question"] == 0.3
+    assert c.state_modifiers.cooldown_s == 45
+    assert c.state_modifiers.session_gap_s == 20
+    assert c.thresholds.soft_perk == 0.55
+
+
+def test_defaults_applied_for_missing_sections():
+    c = AttentionConfig.from_dict({"version": "x"})
+    assert c.aliases == ()
+    assert c.state_modifiers == StateModifiers()  # all defaults
+    assert c.thresholds == Thresholds()
+    assert c.lexical_patterns == {}
+    assert c.suppressors_enabled == ()
+
+
+def test_unknown_state_modifier_keys_ignored():
+    c = AttentionConfig.from_dict({"version": "x", "state_modifiers": {"bogus": 1, "cooldown_s": 10}})
+    assert c.state_modifiers.cooldown_s == 10  # known key applied, bogus dropped
+
+
+def test_load_config_reads_file(tmp_path):
+    p = tmp_path / "attention_config.json"
+    p.write_text(json.dumps(_raw()))
+    c = load_config(p)
+    assert c.version == "1.0.0"
+    assert c.suppressors_enabled == ("explicit_dismissal",)

--- a/tests/test_attention/test_consumers.py
+++ b/tests/test_attention/test_consumers.py
@@ -1,0 +1,107 @@
+"""ShadowStoreConsumer persistence + the refs-not-text firewall (E2E to a temp DB)."""
+import json
+import sqlite3
+
+from genesis.attention.config import AttentionConfig, default_config_dict
+from genesis.attention.consumers import ShadowStoreConsumer
+from genesis.attention.engine import evaluate
+from genesis.attention.types import AmbientUtterance, EngineState
+from genesis.db.schema._tables import INDEXES, TABLES
+
+
+def _make_db(path) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(TABLES["attention_events"])
+    for idx in INDEXES:
+        if "attention_events" in idx:
+            conn.execute(idx)
+    conn.commit()
+    conn.close()
+
+
+def _utt(id, ts, text, **kw) -> AmbientUtterance:
+    d = dict(duration_s=5.0, is_user=1, speaker_total=2, n_tokens=20,
+             frac_lt_1=0.0, rms=0.2, mode_state="unknown", source="t")
+    d.update(kw)
+    return AmbientUtterance(id=id, ts=ts, text=text, **d)
+
+
+def _run_events(utts, cfg):
+    state, evs = EngineState(), []
+    for u in utts:
+        state, ev = evaluate(u, state, cfg)
+        if ev is not None:
+            evs.append(ev)
+    return evs
+
+
+def test_persist_writes_rows_and_no_text_column(tmp_path):
+    db = tmp_path / "g.db"
+    _make_db(db)
+    cfg = AttentionConfig.from_dict(default_config_dict())
+    evs = _run_events([_utt(1, 100.0, "what do you think about it?")], cfg)
+    assert evs
+    c = ShadowStoreConsumer(db, snapshot_id="snapX", config_version=cfg.version)
+    for ev in evs:
+        c.add(ev)
+    assert c.flush() == len(evs)
+
+    conn = sqlite3.connect(db)
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(attention_events)")]
+    rows = conn.execute("SELECT window_ref, snapshot_id, config_version FROM attention_events").fetchall()
+    conn.close()
+    assert "text" not in cols                 # firewall: no transcript column at all
+    assert len(rows) == len(evs)
+    wr = json.loads(rows[0][0])
+    assert wr["utt_ids"] and wr["snapshot_id"] == "snapX"
+    assert rows[0][2] == cfg.version
+
+
+def test_firewall_no_transcript_text_persisted(tmp_path):
+    db = tmp_path / "g.db"
+    _make_db(db)
+    cfg = AttentionConfig.from_dict(default_config_dict())
+    secret = "zzsecretphrasezz"
+    evs = _run_events([_utt(1, 100.0, f"what do you think? {secret}")], cfg)
+    assert evs
+    c = ShadowStoreConsumer(db, snapshot_id="snapX", config_version=cfg.version)
+    for ev in evs:
+        c.add(ev)
+    c.flush()
+    conn = sqlite3.connect(db)
+    dump = " ".join(str(v) for row in conn.execute("SELECT * FROM attention_events") for v in row)
+    conn.close()
+    assert secret not in dump  # transcript text NEVER reaches genesis.db
+
+
+def test_idempotent_reflush_same_snapshot_and_config(tmp_path):
+    db = tmp_path / "g.db"
+    _make_db(db)
+    cfg = AttentionConfig.from_dict(default_config_dict())
+    evs = _run_events([_utt(1, 100.0, "what do you think?")], cfg)
+    for _ in range(2):  # re-running the same snapshot+config must not duplicate rows
+        c = ShadowStoreConsumer(db, snapshot_id="s", config_version=cfg.version)
+        for ev in evs:
+            c.add(ev)
+        c.flush()
+    conn = sqlite3.connect(db)
+    count = conn.execute("SELECT COUNT(*) FROM attention_events").fetchone()[0]
+    conn.close()
+    assert count == len(evs)  # INSERT OR REPLACE keyed on snapshot:config:utt
+
+
+def test_new_config_version_writes_new_rows(tmp_path):
+    db = tmp_path / "g.db"
+    _make_db(db)
+    utts = [_utt(1, 100.0, "what do you think?")]
+    for ver in ("v1", "v2"):
+        cfg = AttentionConfig.from_dict({**default_config_dict(), "version": ver})
+        evs = _run_events(utts, cfg)
+        c = ShadowStoreConsumer(db, snapshot_id="s", config_version=ver)
+        for ev in evs:
+            c.add(ev)
+        c.flush()
+    conn = sqlite3.connect(db)
+    count = conn.execute("SELECT COUNT(*) FROM attention_events").fetchone()[0]
+    conn.close()
+    assert count == 2  # different config_version -> distinct rows (labels preserved)

--- a/tests/test_attention/test_consumers.py
+++ b/tests/test_attention/test_consumers.py
@@ -1,6 +1,8 @@
-"""ShadowStoreConsumer persistence + the refs-not-text firewall (E2E to a temp DB)."""
+"""ShadowStoreConsumer persistence (via the crud layer) + the refs-not-text firewall."""
 import json
 import sqlite3
+
+import pytest
 
 from genesis.attention.config import AttentionConfig, default_config_dict
 from genesis.attention.consumers import ShadowStoreConsumer
@@ -35,7 +37,15 @@ def _run_events(utts, cfg):
     return evs
 
 
-def test_persist_writes_rows_and_no_text_column(tmp_path):
+def _rows(db) -> int:
+    conn = sqlite3.connect(db)
+    n = conn.execute("SELECT COUNT(*) FROM attention_events").fetchone()[0]
+    conn.close()
+    return n
+
+
+@pytest.mark.asyncio
+async def test_persist_writes_rows_and_no_text_column(tmp_path):
     db = tmp_path / "g.db"
     _make_db(db)
     cfg = AttentionConfig.from_dict(default_config_dict())
@@ -44,7 +54,7 @@ def test_persist_writes_rows_and_no_text_column(tmp_path):
     c = ShadowStoreConsumer(db, snapshot_id="snapX", config_version=cfg.version)
     for ev in evs:
         c.add(ev)
-    assert c.flush() == len(evs)
+    assert await c.flush() == len(evs)
 
     conn = sqlite3.connect(db)
     cols = [r[1] for r in conn.execute("PRAGMA table_info(attention_events)")]
@@ -57,7 +67,8 @@ def test_persist_writes_rows_and_no_text_column(tmp_path):
     assert rows[0][2] == cfg.version
 
 
-def test_firewall_no_transcript_text_persisted(tmp_path):
+@pytest.mark.asyncio
+async def test_firewall_no_transcript_text_persisted(tmp_path):
     db = tmp_path / "g.db"
     _make_db(db)
     cfg = AttentionConfig.from_dict(default_config_dict())
@@ -67,14 +78,15 @@ def test_firewall_no_transcript_text_persisted(tmp_path):
     c = ShadowStoreConsumer(db, snapshot_id="snapX", config_version=cfg.version)
     for ev in evs:
         c.add(ev)
-    c.flush()
+    await c.flush()
     conn = sqlite3.connect(db)
     dump = " ".join(str(v) for row in conn.execute("SELECT * FROM attention_events") for v in row)
     conn.close()
     assert secret not in dump  # transcript text NEVER reaches genesis.db
 
 
-def test_idempotent_reflush_same_snapshot_and_config(tmp_path):
+@pytest.mark.asyncio
+async def test_idempotent_reflush_same_snapshot_and_config(tmp_path):
     db = tmp_path / "g.db"
     _make_db(db)
     cfg = AttentionConfig.from_dict(default_config_dict())
@@ -83,14 +95,12 @@ def test_idempotent_reflush_same_snapshot_and_config(tmp_path):
         c = ShadowStoreConsumer(db, snapshot_id="s", config_version=cfg.version)
         for ev in evs:
             c.add(ev)
-        c.flush()
-    conn = sqlite3.connect(db)
-    count = conn.execute("SELECT COUNT(*) FROM attention_events").fetchone()[0]
-    conn.close()
-    assert count == len(evs)  # INSERT OR REPLACE keyed on snapshot:config:utt
+        await c.flush()
+    assert _rows(db) == len(evs)  # INSERT OR REPLACE keyed on snapshot:config:utt
 
 
-def test_new_config_version_writes_new_rows(tmp_path):
+@pytest.mark.asyncio
+async def test_new_config_version_writes_new_rows(tmp_path):
     db = tmp_path / "g.db"
     _make_db(db)
     utts = [_utt(1, 100.0, "what do you think?")]
@@ -100,8 +110,5 @@ def test_new_config_version_writes_new_rows(tmp_path):
         c = ShadowStoreConsumer(db, snapshot_id="s", config_version=ver)
         for ev in evs:
             c.add(ev)
-        c.flush()
-    conn = sqlite3.connect(db)
-    count = conn.execute("SELECT COUNT(*) FROM attention_events").fetchone()[0]
-    conn.close()
-    assert count == 2  # different config_version -> distinct rows (labels preserved)
+        await c.flush()
+    assert _rows(db) == 2  # different config_version -> distinct rows (labels preserved)

--- a/tests/test_attention/test_edge_portability.py
+++ b/tests/test_attention/test_edge_portability.py
@@ -1,0 +1,28 @@
+"""The engine core must be vendorable to the edge voice repo unchanged: importing it
+must NOT pull in any genesis-runtime dependency. Enforced in a clean subprocess (a
+full pytest run has already imported aiosqlite/genesis.db via other tests, so an
+in-process sys.modules check would false-pass)."""
+import os
+import subprocess
+import sys
+import textwrap
+
+
+def test_core_has_no_genesis_runtime_deps():
+    code = textwrap.dedent(
+        """
+        import sys
+        for m in ("genesis.attention.types", "genesis.attention.clarity",
+                  "genesis.attention.config", "genesis.attention.triggers",
+                  "genesis.attention.scorer", "genesis.attention.engine"):
+            __import__(m)
+        forbidden = [d for d in ("aiosqlite", "genesis.db", "genesis.routing",
+                                 "genesis.awareness", "genesis.memory", "genesis.observability")
+                     if d in sys.modules]
+        print(",".join(forbidden))
+        sys.exit(1 if forbidden else 0)
+        """
+    )
+    env = {**os.environ, "PYTHONPATH": os.pathsep.join(p for p in sys.path if p)}
+    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
+    assert r.returncode == 0, f"core imported forbidden dep(s): {r.stdout.strip()!r} err={r.stderr.strip()!r}"

--- a/tests/test_attention/test_engine.py
+++ b/tests/test_attention/test_engine.py
@@ -89,6 +89,14 @@ def test_lone_suppressor_emits_nothing():
     assert run([make_utt(1, 100.0, "never mind")], make_config()) == []
 
 
+def test_empty_suppressors_enabled_disables_all_suppressors():
+    # allowlist semantics: [] means NO suppressors run (regression: `or None` misread [] as "all").
+    cfg = make_config(suppressors_enabled=[])
+    ev = run([make_utt(1, 100.0, "what do you think? never mind", speaker_total=2)], cfg)
+    assert len(ev) == 1 and ev[0].activation == Activation.SOFT  # dismissal ignored -> soft fire stands
+    assert ev[0].suppressors == ()
+
+
 def test_blip_ignored_and_not_windowed():
     cfg = make_config()
     state = EngineState()
@@ -122,12 +130,12 @@ def test_cooldown_raises_threshold():
         state_modifiers={"cooldown_s": 30, "cooldown_raise": 0.3,
                          "session_stickiness_mult": 1.0, "session_gap_s": 300, "context_cap_s": 12},
     )
-    state = EngineState()
-    _, e1 = evaluate(make_utt(1, 100.0, "q?"), state, cfg)
+    state = EngineState()  # thread state explicitly (the fold contract), not via in-place mutation
+    state, e1 = evaluate(make_utt(1, 100.0, "q?"), state, cfg)
     assert e1.activation == Activation.SOFT                    # .5 >= .4
-    _, e2 = evaluate(make_utt(2, 105.0, "q?"), state, cfg)
+    state, e2 = evaluate(make_utt(2, 105.0, "q?"), state, cfg)
     assert e2 is None                                          # in cooldown -> bar .7, .5 < .7
-    _, e3 = evaluate(make_utt(3, 140.0, "q?"), state, cfg)
+    state, e3 = evaluate(make_utt(3, 140.0, "q?"), state, cfg)
     assert e3 is not None and e3.activation == Activation.SOFT  # 40s > cooldown -> fires again
 
 

--- a/tests/test_attention/test_engine.py
+++ b/tests/test_attention/test_engine.py
@@ -1,0 +1,139 @@
+"""Pure-fold engine tests: determinism, sessionization, window, cooldown, clarity
+weighting, suppressor precedence, blip handling."""
+from genesis.attention.config import AttentionConfig
+from genesis.attention.engine import evaluate
+from genesis.attention.types import Activation, AmbientUtterance, EngineState
+
+
+def make_config(**over) -> AttentionConfig:
+    raw = {
+        "version": "test",
+        "aliases": ["genesis"],
+        "domain_keywords": ["routing"],
+        "known_entities": ["Alice"],
+        "lexical_patterns": {"help_seeking": [r"\bi'?m stuck\b", r"\bhow do i\b"]},
+        "suppressor_patterns": {"explicit_dismissal": [r"never mind", r"not you", r"just between us"]},
+        "weights": {"question": 0.3, "help_seeking": 0.35, "multi_speaker": 0.4,
+                    "is_user": 0.1, "domain_keyword": 0.3, "known_entity": 0.25},
+        "state_modifiers": {"session_gap_s": 30, "cooldown_s": 30, "cooldown_raise": 0.2,
+                            "session_stickiness_mult": 1.3, "context_cap_s": 12, "context_window_s": 8},
+        "thresholds": {"soft_perk": 0.6, "l15_graduation": 0.4},
+        "suppressors_enabled": ["explicit_dismissal"],
+    }
+    raw.update(over)
+    return AttentionConfig.from_dict(raw)
+
+
+def make_utt(id, ts, text="", *, is_user=None, speaker_total=None, rms=0.2,
+             duration_s=5.0, frac_lt_1=0.0, n_tokens=20, mode_state="unknown") -> AmbientUtterance:
+    # defaults = clean / high-clarity so tests isolate the trigger + threshold logic.
+    return AmbientUtterance(
+        id=id, ts=ts, text=text, duration_s=duration_s, is_user=is_user,
+        speaker_total=speaker_total, n_tokens=n_tokens, frac_lt_1=frac_lt_1, rms=rms,
+        mode_state=mode_state, source="test",
+    )
+
+
+def run(utts, config):
+    state, events = EngineState(), []
+    for u in utts:
+        state, ev = evaluate(u, state, config)
+        if ev is not None:
+            events.append(ev)
+    return events
+
+
+def test_determinism_same_input_same_events():
+    cfg = make_config()
+    utts = [make_utt(1, 100.0, "hello there?"),
+            make_utt(2, 101.0, "we should decide?", speaker_total=2),
+            make_utt(3, 200.0, "routing question?")]
+    assert run(utts, cfg) == run(utts, cfg)
+
+
+def test_hard_ambient_name_activation():
+    ev = run([make_utt(1, 100.0, "hey genesis look at this")], make_config())
+    assert len(ev) == 1 and ev[0].activation == Activation.HARD
+    assert any(h.name == "ambient_name" for h in ev[0].triggers_fired)
+
+
+def test_soft_fires_over_threshold():
+    ev = run([make_utt(1, 100.0, "what do you think?", speaker_total=2)], make_config())
+    assert len(ev) == 1 and ev[0].activation == Activation.SOFT  # question .3 + multi .4 = .7 >= .6
+
+
+def test_soft_no_fire_below_threshold():
+    assert run([make_utt(1, 100.0, "what?")], make_config()) == []  # question .3 < .6
+
+
+def test_clarity_weighting_gates_garbled_but_passes_clean():
+    cfg = make_config()
+    garbled = make_utt(1, 100.0, "what?", speaker_total=2, rms=0.095, duration_s=2.0, frac_lt_1=0.5, n_tokens=4)
+    assert run([garbled], cfg) == []              # relevance .7 x clarity .5 = .35 < .6
+    clean = make_utt(1, 100.0, "what?", speaker_total=2)  # clarity ~1 -> .7 >= .6
+    assert len(run([clean], cfg)) == 1
+
+
+def test_suppressor_vetoes_soft_fire():
+    ev = run([make_utt(1, 100.0, "what do you think? never mind", speaker_total=2)], make_config())
+    assert len(ev) == 1 and ev[0].activation == Activation.SUPPRESSED
+    assert "explicit_dismissal" in ev[0].suppressors
+
+
+def test_explicit_invite_beats_suppressor():
+    ev = run([make_utt(1, 100.0, "ask genesis, never mind actually")], make_config())
+    assert len(ev) == 1 and ev[0].activation == Activation.HARD
+
+
+def test_lone_suppressor_emits_nothing():
+    assert run([make_utt(1, 100.0, "never mind")], make_config()) == []
+
+
+def test_blip_ignored_and_not_windowed():
+    cfg = make_config()
+    state = EngineState()
+    state, ev = evaluate(make_utt(1, 100.0, "hey genesis", rms=0.01, duration_s=0.3, n_tokens=1), state, cfg)
+    assert ev is None                 # blip short-circuits even with an alias
+    assert len(state.window) == 0     # never added to the window
+
+
+def test_new_session_on_gap_clears_window():
+    cfg = make_config()  # session_gap_s = 30
+    state = EngineState()
+    state, _ = evaluate(make_utt(1, 100.0, "routing talk", speaker_total=2), state, cfg)
+    assert state.session_id == "s1"
+    state, _ = evaluate(make_utt(2, 140.0, "different topic"), state, cfg)  # 40s gap
+    assert state.session_id == "s2" and len(state.window) == 1
+
+
+def test_window_evicts_beyond_cap():
+    cfg = make_config()  # context_cap_s = 12
+    state = EngineState()
+    for u in [make_utt(1, 100.0, "a"), make_utt(2, 105.0, "b"), make_utt(3, 116.0, "c")]:
+        state, _ = evaluate(u, state, cfg)
+    ids = [w.id for w in state.window]
+    assert 1 not in ids and 2 in ids and 3 in ids  # utt1 (16s old) evicted, utt2 (11s) kept
+
+
+def test_cooldown_raises_threshold():
+    cfg = make_config(
+        weights={"question": 0.5},
+        thresholds={"soft_perk": 0.4, "l15_graduation": 0.2},
+        state_modifiers={"cooldown_s": 30, "cooldown_raise": 0.3,
+                         "session_stickiness_mult": 1.0, "session_gap_s": 300, "context_cap_s": 12},
+    )
+    state = EngineState()
+    _, e1 = evaluate(make_utt(1, 100.0, "q?"), state, cfg)
+    assert e1.activation == Activation.SOFT                    # .5 >= .4
+    _, e2 = evaluate(make_utt(2, 105.0, "q?"), state, cfg)
+    assert e2 is None                                          # in cooldown -> bar .7, .5 < .7
+    _, e3 = evaluate(make_utt(3, 140.0, "q?"), state, cfg)
+    assert e3 is not None and e3.activation == Activation.SOFT  # 40s > cooldown -> fires again
+
+
+def test_event_carries_refs_not_text():
+    ev = run([make_utt(7, 100.0, "hey genesis secret plan")], make_config())[0]
+    # AttentionEvent must expose no raw transcript — window_ref is ids + ts only.
+    assert ev.window_ref.utt_ids == (7,)
+    assert not hasattr(ev, "text")
+    assert "secret plan" not in repr(ev.window_ref)

--- a/tests/test_attention/test_runner.py
+++ b/tests/test_attention/test_runner.py
@@ -1,0 +1,56 @@
+"""Offline shadow runner: config resolution + run_shadow over a synthetic snapshot."""
+import json
+import sqlite3
+
+import pytest
+
+from genesis.attention import runner
+from genesis.attention.config import AttentionConfig, default_config_dict
+from genesis.attention.runner import ShadowReport, load_runner_config, run_shadow
+
+
+def _meta(rms=0.2, ntok=20) -> str:
+    return json.dumps({"asr_feats": {"ys_log_probs": [-0.1] * ntok, "n_tokens": ntok},
+                       "audio": {"rms": rms}})
+
+
+def _make_ambient(path, rows) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE ambient_transcripts (id INTEGER PRIMARY KEY, ts TEXT, text TEXT, "
+        "duration_s REAL, speaker_label TEXT, provenance TEXT, source TEXT, meta TEXT, "
+        "is_user INTEGER, speaker_name TEXT)"
+    )
+    conn.executemany(
+        "INSERT INTO ambient_transcripts (id, ts, text, duration_s, speaker_label, meta, is_user) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)", rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_load_runner_config_from_explicit_file(tmp_path):
+    p = tmp_path / "cfg.json"
+    p.write_text(json.dumps({**default_config_dict(), "version": "custom-1"}))
+    assert load_runner_config(str(p)).version == "custom-1"
+
+
+def test_load_runner_config_falls_back_to_builtin(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner, "DEFAULT_CONFIG_PATH", str(tmp_path / "absent.json"))
+    assert load_runner_config(None).version == "0.1.0-default"
+
+
+@pytest.mark.asyncio
+async def test_run_shadow_over_snapshot(tmp_path):
+    snap = tmp_path / "ambient.db"
+    _make_ambient(snap, [
+        (1, "2026-06-30T12:00:00+00:00", "what do you think?", 5.0, "w1:1/2", _meta(), 1),
+        (2, "2026-06-30T12:05:00+00:00", "hello", 5.0, "w1:1/1", _meta(), None),
+    ])
+    cfg = AttentionConfig.from_dict(default_config_dict())
+    report = await run_shadow(snap, cfg, snapshot_id="t", sample_n=5)
+    assert isinstance(report, ShadowReport)
+    assert report.total_rows == 2
+    assert report.events >= 1            # the question+multi_speaker row fires
+    assert report.persisted == 0         # no consumer -> nothing persisted
+    assert 0.0 <= report.fire_rate <= 1.0

--- a/tests/test_attention/test_scorer.py
+++ b/tests/test_attention/test_scorer.py
@@ -1,0 +1,36 @@
+"""Direct unit tests for score composition + activation resolution."""
+from genesis.attention.scorer import resolve_activation, soft_relevance
+from genesis.attention.types import Activation, TriggerHit, TriggerKind
+
+
+def _h(name, contrib=0.0, kind=TriggerKind.SOFT) -> TriggerHit:
+    return TriggerHit(name, kind, contrib)
+
+
+def test_soft_relevance_sums_contributions():
+    assert soft_relevance([_h("a", 0.3), _h("b", 0.4)]) == 0.7
+    assert soft_relevance([]) == 0.0
+
+
+def test_resolve_none_below_threshold():
+    assert resolve_activation(hard_hits=[], suppressor_hits=[], effective=0.3, threshold=0.6) is None
+
+
+def test_resolve_soft_over_threshold():
+    assert resolve_activation(hard_hits=[], suppressor_hits=[], effective=0.7, threshold=0.6) == Activation.SOFT
+
+
+def test_resolve_hard_on_hard_hit():
+    hard = [_h("ambient_name", kind=TriggerKind.HARD)]
+    assert resolve_activation(hard_hits=hard, suppressor_hits=[], effective=0.0, threshold=0.6) == Activation.HARD
+
+
+def test_suppressor_precedence():
+    supp = [_h("explicit_dismissal", kind=TriggerKind.SUPPRESSOR)]
+    # a would-fire soft is vetoed -> SUPPRESSED
+    assert resolve_activation(hard_hits=[], suppressor_hits=supp, effective=0.7, threshold=0.6) == Activation.SUPPRESSED
+    # an explicit-invite summons beats the suppressor -> HARD
+    inv = [_h("explicit_invite", kind=TriggerKind.HARD)]
+    assert resolve_activation(hard_hits=inv, suppressor_hits=supp, effective=0.0, threshold=0.6) == Activation.HARD
+    # a lone suppressor with nothing to suppress -> no event
+    assert resolve_activation(hard_hits=[], suppressor_hits=supp, effective=0.1, threshold=0.6) is None

--- a/tests/test_attention/test_snapshot.py
+++ b/tests/test_attention/test_snapshot.py
@@ -1,0 +1,44 @@
+"""Snapshot puller command-builders (pure; the live SSH pull is verified in the spike)."""
+import shlex
+from pathlib import Path
+
+from genesis.attention.snapshot import (
+    _SNAPSHOT_SSH_TIMEOUT_S,
+    _backup_py,
+    _remote_backup_arg,
+    _scp_cmd,
+    _ssh_base,
+)
+from genesis.observability.ambient_health import AmbientRemoteConfig
+
+
+def _cfg() -> AmbientRemoteConfig:
+    return AmbientRemoteConfig(host_ip="10.0.0.1", host_user="edge", ssh_key="~/.ssh/id_ed25519")
+
+
+def test_ssh_base_has_batchmode_and_target():
+    b = _ssh_base(_cfg())
+    assert b[0] == "ssh" and "BatchMode=yes" in b and "edge@10.0.0.1" in b
+
+
+def test_backup_py_is_readonly_and_expands_home():
+    s = _backup_py("~/ambient.db", "~/.ambient_snap.db")
+    assert "mode=ro" in s and "expanduser('~/ambient.db')" in s and "backup(d)" in s
+
+
+def test_scp_cmd_pulls_remote_to_local():
+    c = _scp_cmd(_cfg(), "~/.ambient_snap.db", Path("/tmp/x.db"))
+    assert c[0] == "scp" and "edge@10.0.0.1:~/.ambient_snap.db" in c and "/tmp/x.db" in c
+
+
+def test_timeout_more_generous_than_health_cat():
+    assert _SNAPSHOT_SSH_TIMEOUT_S >= 30  # a DB-streaming backup needs more than cat's 10s
+
+
+def test_remote_backup_arg_is_single_shell_safe_token():
+    # regression: ssh re-parses the command in the remote shell; the python one-liner's
+    # parens/quotes must survive as ONE token (the '(' syntax-error bug).
+    arg = _remote_backup_arg("~/ambient.db", "~/.ambient_snap.db")
+    parts = shlex.split(arg)  # how the remote shell would split it
+    assert parts[0] == "python3" and parts[1] == "-c" and len(parts) == 3
+    assert parts[2] == _backup_py("~/ambient.db", "~/.ambient_snap.db")  # code intact, unsplit

--- a/tests/test_attention/test_snapshot.py
+++ b/tests/test_attention/test_snapshot.py
@@ -13,12 +13,12 @@ from genesis.observability.ambient_health import AmbientRemoteConfig
 
 
 def _cfg() -> AmbientRemoteConfig:
-    return AmbientRemoteConfig(host_ip="10.0.0.1", host_user="edge", ssh_key="~/.ssh/id_ed25519")
+    return AmbientRemoteConfig(host_ip="192.0.2.1", host_user="edge", ssh_key="~/.ssh/id_ed25519")
 
 
 def test_ssh_base_has_batchmode_and_target():
     b = _ssh_base(_cfg())
-    assert b[0] == "ssh" and "BatchMode=yes" in b and "edge@10.0.0.1" in b
+    assert b[0] == "ssh" and "BatchMode=yes" in b and "edge@192.0.2.1" in b
 
 
 def test_backup_py_is_readonly_and_expands_home():
@@ -28,7 +28,7 @@ def test_backup_py_is_readonly_and_expands_home():
 
 def test_scp_cmd_pulls_remote_to_local():
     c = _scp_cmd(_cfg(), "~/.ambient_snap.db", Path("/tmp/x.db"))
-    assert c[0] == "scp" and "edge@10.0.0.1:~/.ambient_snap.db" in c and "/tmp/x.db" in c
+    assert c[0] == "scp" and "edge@192.0.2.1:~/.ambient_snap.db" in c and "/tmp/x.db" in c
 
 
 def test_timeout_more_generous_than_health_cat():

--- a/tests/test_attention/test_sources.py
+++ b/tests/test_attention/test_sources.py
@@ -1,0 +1,54 @@
+"""ambient_transcripts row -> AmbientUtterance mapping (pure, no DB)."""
+import json
+
+from genesis.attention.sources import _parse_ts, _speaker_total, row_to_utterance
+
+
+def _row(**over) -> dict:
+    row = {
+        "id": 42, "ts": "2026-06-30T12:00:00+00:00", "text": "hey genesis",
+        "duration_s": 2.5, "speaker_label": "w7:2/3", "source": "dev1",
+        "is_user": 1, "speaker_name": "user",
+        "meta": json.dumps({
+            "asr_feats": {"ys_log_probs": [-0.2, -1.5, -2.0, -0.1], "n_tokens": 4},
+            "audio": {"rms": 0.15},
+        }),
+    }
+    row.update(over)
+    return row
+
+
+def test_row_to_utterance_full():
+    u = row_to_utterance(_row())
+    assert u.id == 42 and u.is_user == 1
+    assert u.speaker_total == 3       # "w7:2/3" -> 3
+    assert u.n_tokens == 4
+    assert u.rms == 0.15
+    assert u.frac_lt_1 == 0.5         # two of four ys_log_probs < -1.0
+    assert u.mode_state == "unknown"  # ambient carries no interaction-plane state
+
+
+def test_row_missing_meta_and_label():
+    u = row_to_utterance(_row(meta=None, speaker_label=None, is_user=None))
+    assert u.speaker_total is None and u.n_tokens == 0 and u.frac_lt_1 == 0.0 and u.rms == 0.0
+
+
+def test_row_bad_ts_returns_none():
+    assert row_to_utterance(_row(ts="not-a-date")) is None
+    assert row_to_utterance(_row(ts=None)) is None
+
+
+def test_row_corrupt_meta_tolerated():
+    u = row_to_utterance(_row(meta="{not valid json"))
+    assert u is not None and u.n_tokens == 0 and u.rms == 0.0
+
+
+def test_speaker_total_parse():
+    assert _speaker_total("w500:2/5") == 5
+    assert _speaker_total("w1:1/1") == 1
+    assert _speaker_total(None) is None
+    assert _speaker_total("weird") is None
+
+
+def test_parse_ts_naive_assumed_utc_equals_explicit_utc():
+    assert _parse_ts("2026-06-30T12:00:00") == _parse_ts("2026-06-30T12:00:00+00:00")

--- a/tests/test_attention/test_triggers.py
+++ b/tests/test_attention/test_triggers.py
@@ -1,0 +1,57 @@
+"""Direct unit tests for the pluggable L1 triggers."""
+from genesis.attention.config import AttentionConfig, default_config_dict
+from genesis.attention.triggers import (
+    _term_present,
+    hard_ambient_name,
+    hard_explicit_invite,
+    soft_domain_keyword,
+    soft_multi_speaker,
+    soft_question,
+    suppress_explicit_dismissal,
+)
+from genesis.attention.types import AmbientUtterance, TriggerKind
+
+CFG = AttentionConfig.from_dict(default_config_dict())
+
+
+def _u(text, **kw) -> AmbientUtterance:
+    d = dict(id=1, ts=0.0, duration_s=1.0, is_user=None, speaker_total=None,
+             n_tokens=5, frac_lt_1=0.0, rms=0.1)
+    d.update(kw)
+    return AmbientUtterance(text=text, **d)
+
+
+def test_term_present_word_boundary():
+    assert _term_present("hey genesis there", ["genesis"])
+    assert not _term_present("regenesis rules", ["genesis"])  # substring, not a whole word
+
+
+def test_ambient_name_fires_on_alias():
+    hit = hard_ambient_name(_u("ask genesis"), [], CFG)
+    assert hit and hit.name == "ambient_name" and hit.kind == TriggerKind.HARD
+
+
+def test_explicit_invite_needs_alias_and_cue():
+    assert hard_explicit_invite(_u("what does genesis think"), [], CFG)
+    assert hard_explicit_invite(_u("genesis is cool"), [], CFG) is None  # alias, no invite cue
+
+
+def test_question_fires_on_qmark():
+    assert soft_question(_u("really?"), [], CFG)
+    assert soft_question(_u("a flat statement"), [], CFG) is None
+
+
+def test_multi_speaker_needs_two():
+    assert soft_multi_speaker(_u("x", speaker_total=2), [], CFG)
+    assert soft_multi_speaker(_u("x", speaker_total=1), [], CFG) is None
+    assert soft_multi_speaker(_u("x", speaker_total=None), [], CFG) is None
+
+
+def test_domain_keyword_substring():
+    assert soft_domain_keyword(_u("about the routing layer"), [], CFG)  # 'routing' is a default kw
+    assert soft_domain_keyword(_u("blah blah okay"), [], CFG) is None
+
+
+def test_suppressor_dismissal():
+    assert suppress_explicit_dismissal(_u("never mind"), [], CFG)
+    assert suppress_explicit_dismissal(_u("carry on then"), [], CFG) is None

--- a/tests/test_db/test_migration_0042_attention_events.py
+++ b/tests/test_db/test_migration_0042_attention_events.py
@@ -1,0 +1,74 @@
+"""Migration 0042 — create attention_events (the attention-engine SHADOW store).
+
+Stores attention decisions + references + labels only; NEVER ambient transcript text
+(firewall). Verifies the table/columns/indexes, idempotency, and down().
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M42 = importlib.import_module("genesis.db.migrations.0042_attention_events")
+
+
+async def _columns(db: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await db.execute(f"PRAGMA table_info({table})")
+    return {row[1] for row in await cur.fetchall()}
+
+
+async def _indexes(db: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=?", (table,)
+    )
+    return {row[0] for row in await cur.fetchall()}
+
+
+async def _table_exists(db: aiosqlite.Connection, table: str) -> bool:
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    )
+    return await cur.fetchone() is not None
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_creates_table_with_expected_columns_and_no_text(db):
+    await M42.up(db)
+    cols = await _columns(db, "attention_events")
+    assert {
+        "id", "ts", "session_id", "activation", "score", "triggers_fired",
+        "suppressors", "window_ref", "mode_state", "clarity", "l15_verdict",
+        "acceptance_signal", "snapshot_id", "config_version", "created_at",
+    } <= cols
+    assert "text" not in cols  # firewall: no transcript column exists at all
+
+
+@pytest.mark.asyncio
+async def test_creates_indexes(db):
+    await M42.up(db)
+    idx = await _indexes(db, "attention_events")
+    assert {"idx_attention_events_session", "idx_attention_events_ts",
+            "idx_attention_events_unlabeled"} <= idx
+
+
+@pytest.mark.asyncio
+async def test_idempotent_on_rerun(db):
+    await M42.up(db)
+    await M42.up(db)  # CREATE IF NOT EXISTS -> must not raise
+    assert await _table_exists(db, "attention_events")
+
+
+@pytest.mark.asyncio
+async def test_down_drops_table(db):
+    await M42.up(db)
+    await M42.down(db)
+    assert not await _table_exists(db, "attention_events")

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -22,6 +22,7 @@ EXPECTED_TABLES = [
     "cost_events",
     "budgets",
     "awareness_ticks",
+    "attention_events",
     "depth_thresholds",
     "dead_letter",
     "surplus_tasks",


### PR DESCRIPTION
## Summary

First slice (PR1) of the **passive-listening attention engine** (omnipresence Track 1): a deterministic **L1 "perk-up" pre-gate** that runs over ambient room-conversation transcripts and decides whether to *raise attention* — strictly below any decision to speak. **Shadow-only**: it logs what it *would* have perked up on; it never speaks or influences output.

## Architecture

- **Runs Genesis-side, offline, in batch over pulled read-only ambient snapshots** — no edge deploy. v1 is shadow-only, so the real-time/edge rationale doesn't apply; this yields a *re-runnable* calibration corpus (re-score a frozen snapshot under new weights) with zero production risk. The real-time edge port is deferred until the gate is calibrated.
- **Pure, edge-portable core** (`types`, `clarity`, `config`, `triggers`, `scorer`, `engine`): a deterministic, event-`ts`-driven fold `evaluate(utt, state, config) -> (state', event?)` with **zero genesis-runtime dependencies** (enforced by a subprocess test), so the same core later vendors to the edge unchanged.
- **Adapters** (`sources`, `snapshot`, `consumers`, `runner`) hold all I/O.
- **Deterministic-L1 only** for this slice; the cheap-LLM (L1.5) salience seam is stubbed.

## What's in this PR

- `src/genesis/attention/` — the engine core + adapters + `python -m genesis.attention.runner` (offline shadow runner).
- Migration **0042** `attention_events` (+ canonical DDL in `_tables.py`) — the shadow store.
- Dashboard vitals row-count for the new table.

## Firewall

Ambient transcript **text never enters genesis.db**. `attention_events` stores attention *decisions* + *references* + labels only (activation, score, `triggers_fired` names/weights, a `window_ref` of ids + ts range, clarity). Raw text lives only in the transient snapshot file. Enforced by a test and verified end-to-end (a text-leak scan across every persisted column found none).

## Testing / verification

- 45 tests: engine determinism, window/session/cooldown, clarity gating, suppressor precedence, adapters, persistence, migration up/idempotent/down, the refs-not-text firewall, and a subprocess edge-portability guard.
- End-to-end verified on a live snapshot: pull → parse → engine → persist, deterministic (re-run = identical output), firewall clean.

## Deferred (follow-up PRs)

- **PR2**: dashboard review tab + should/shouldn't labeling — the calibration loop.
- **PR3**: the full trigger taxonomy, the L1.5 salience seam, an offline retune helper, and the edge `LiveBridgeSource` stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
