### PR TITLE
fix(inbox): dispatch at-most-once via row-state claim (no duplicate eval on crash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   approval gate is on, you approve a drop once and all its groups run under that single
   approval. Duplicate follow-up items from the same recommendation are now also prevented.
 
+- **An approved inbox evaluation that gets interrupted mid-run can no longer be evaluated
+  twice.** If the server restarted (or crashed) in the narrow window right after you approved a
+  link evaluation but before it finished, the next scan could re-run the same evaluation and
+  write a duplicate `…-N.genesis.md` file. Genesis now claims each evaluation the moment it
+  starts, so an interrupted one is recovered and retried rather than run a second time.
+
 - **Campaign results no longer sit uncaptured until the next scheduled tick.** Previously a
   campaign that ran every couple of days would finish its background session but not record
   the outcome (or cost, or notify you) until the *following* tick — so a finished run could

--- a/src/genesis/db/crud/inbox_items.py
+++ b/src/genesis/db/crud/inbox_items.py
@@ -18,6 +18,17 @@ AWAITING_APPROVAL_PREFIX = "awaiting_approval:"
 # invalidated-failed rows with still-awaiting rows.
 APPROVAL_INVALIDATED_PREFIX = "approval_invalidated:"
 
+# Prefix marking a row that has been CLAIMED for an in-flight dispatch (the CC
+# call is about to run / is running).  The resume pass flips a parked row from
+# ``awaiting_approval:`` to ``dispatching:`` via ``claim_for_dispatch`` BEFORE
+# the CC call — this is the at-most-once dispatch authority.  Deliberately a
+# distinct prefix so a claimed row is NOT re-found by ``get_awaiting_approval``
+# (which matches ``awaiting_approval:%``) yet IS reaped by
+# ``expire_stuck_processing`` (which excludes only ``awaiting_approval:%``) —
+# so a crash mid-dispatch cannot re-resume, and a stranded claim is recovered
+# into the retry path.
+DISPATCHING_PREFIX = "dispatching:"
+
 
 async def create(
     db: aiosqlite.Connection,
@@ -108,6 +119,36 @@ async def get_awaiting_approval(db: aiosqlite.Connection) -> list[dict]:
     )
     rows = await cursor.fetchall()
     return [dict(row) for row in rows]
+
+
+async def claim_for_dispatch(
+    db: aiosqlite.Connection, id: str, *, reqid: str,
+) -> bool:
+    """Atomically claim a parked row for an in-flight dispatch (at-most-once).
+
+    Transitions ``error_message`` from ``awaiting_approval:<reqid>`` to
+    ``dispatching:<reqid>`` (status stays ``processing``), but ONLY for the row
+    still parked on exactly this approval. Returns True iff this call won the
+    claim (``rowcount == 1``).
+
+    This is the dispatch at-most-once gate. A row already claimed (``dispatching:``
+    — e.g. by a prior scan whose CC call is still running, or a concurrent scan),
+    already completed/failed, or parked on a different approval, does NOT match
+    and returns False, so the caller skips it. Because the claimed row is now
+    ``dispatching:`` it is invisible to :func:`get_awaiting_approval`, so a crash
+    between the claim and completion cannot re-resume and duplicate the dispatch;
+    :func:`expire_stuck_processing` reaps a stranded ``dispatching:`` row after
+    its timeout, returning it to the retry path.
+    """
+    cursor = await db.execute(
+        """UPDATE inbox_items
+           SET error_message = ? || ?
+           WHERE id = ? AND status = 'processing'
+             AND error_message = ? || ?""",
+        (DISPATCHING_PREFIX, reqid, id, AWAITING_APPROVAL_PREFIX, reqid),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
 
 
 async def update_status_for_drop(
@@ -261,7 +302,7 @@ async def set_response_path(
     cursor = await db.execute(
         """UPDATE inbox_items
            SET response_path = ?, processed_at = ?, status = 'completed',
-               evaluated_content = ?
+               evaluated_content = ?, error_message = NULL
            WHERE id = ?""",
         (response_path, processed_at, evaluated_content, id),
     )

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -931,6 +931,7 @@ class InboxMonitor:
         Returns the number of batches successfully dispatched.
         """
         from genesis.cc.types import CCModel, EffortLevel
+        from genesis.db.crud import inbox_items
 
         try:
             model = CCModel(self._config.model)
@@ -945,16 +946,32 @@ class InboxMonitor:
 
         batches_dispatched = 0
 
-        # --- Resume drops: approval already resolved -> consume then dispatch. ---
+        # --- Resume drops: claim (at-most-once) -> consume -> dispatch. ---
         for _drop_id, items in self._group_by_drop(resume_items):
-            # Consume the drop's approval BEFORE dispatching so a restart
-            # mid-drop cannot leave an unconsumed approval that a later drop
-            # rides via the content-agnostic stable key. mark_consumed is
-            # idempotent; the parked rows still drive re-dispatch on restart.
-            reqid = items[0].approval_reqid if items else ""
+            # CLAIM each batch row out of the awaiting-approval parked state
+            # BEFORE the CC call. The claim (awaiting_approval: -> dispatching:)
+            # is the at-most-once authority: a row already claimed (a prior scan
+            # still dispatching, or a concurrent scan) or no longer parked loses
+            # the claim and is skipped. A crash between the claim and completion
+            # therefore cannot duplicate the dispatch — the claimed row is
+            # 'dispatching:' (invisible to get_awaiting_approval), and a stranded
+            # one is reaped by expire_stuck_processing back into the retry path.
+            claimed = [
+                item for item in items
+                if await inbox_items.claim_for_dispatch(
+                    self._db, item.id, reqid=item.approval_reqid,
+                )
+            ]
+            if not claimed:
+                continue
+            # Consume the drop's approval (best-effort). The row-state claim above
+            # is the real gate, so a consume failure neither strands the drop nor
+            # bypasses at-most-once; it only leaves the content-agnostic approval
+            # rideable until the gate's 24h staleness window (WARNING-logged).
+            reqid = claimed[0].approval_reqid
             if reqid:
                 await self._consume_approval(reqid)
-            for item in items:
+            for item in claimed:
                 if await self._dispatch_one_batch(
                     item, model=model, effort=effort,
                     system_prompt=system_prompt, now_iso=now_iso, errors=errors,

--- a/tests/test_inbox/test_crud_drop_batching.py
+++ b/tests/test_inbox/test_crud_drop_batching.py
@@ -205,3 +205,106 @@ async def test_get_recent_completed_windows_on_processed_at(db):
         "a reused eval completed today must appear in the digest even though "
         "its created_at is old"
     )
+
+
+# --- claim_for_dispatch: at-most-once dispatch authority (PR-2b) ---
+
+
+async def _park(db, id, reqid, *, created_at="2026-06-30T00:00:01+00:00"):
+    """Create a row parked on an approval (processing + awaiting marker)."""
+    await inbox_items.create(
+        db, id=id, file_path=_FP, content_hash="h", status="processing",
+        created_at=created_at, drop_id="D", batch_items="url",
+    )
+    await inbox_items.update_status(
+        db, id, status="processing",
+        error_message=f"{inbox_items.AWAITING_APPROVAL_PREFIX}{reqid}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_claim_for_dispatch_transitions_awaiting_to_dispatching(db):
+    await _park(db, "a", "req-1")
+    won = await inbox_items.claim_for_dispatch(db, "a", reqid="req-1")
+    assert won is True
+    row = await inbox_items.get_by_id(db, "a")
+    assert row["status"] == "processing"
+    assert row["error_message"] == f"{inbox_items.DISPATCHING_PREFIX}req-1"
+
+
+@pytest.mark.asyncio
+async def test_claim_for_dispatch_is_single_winner(db):
+    await _park(db, "a", "req-1")
+    assert await inbox_items.claim_for_dispatch(db, "a", reqid="req-1") is True
+    # A second claim (e.g. a re-resume after a crash, or a concurrent scan)
+    # loses — the row is already 'dispatching:', not awaiting.
+    assert await inbox_items.claim_for_dispatch(db, "a", reqid="req-1") is False
+
+
+@pytest.mark.asyncio
+async def test_claim_for_dispatch_rejects_wrong_reqid_and_nonparked(db):
+    await _park(db, "a", "req-1")
+    # Wrong approval id -> not this row's parked approval -> no claim.
+    assert await inbox_items.claim_for_dispatch(db, "a", reqid="req-OTHER") is False
+    # A plain pending row (never parked on an approval) -> no claim.
+    await _mk(db, id="b", drop_id="D2", status="pending",
+              created_at="2026-06-30T00:00:02+00:00")
+    assert await inbox_items.claim_for_dispatch(db, "b", reqid="req-1") is False
+    # A completed row -> no claim.
+    await _mk(db, id="c", drop_id="D3", status="completed",
+              created_at="2026-06-30T00:00:03+00:00")
+    assert await inbox_items.claim_for_dispatch(db, "c", reqid="req-1") is False
+
+
+@pytest.mark.asyncio
+async def test_get_awaiting_approval_excludes_claimed_dispatching(db):
+    await _park(db, "a", "req-1")
+    assert len(await inbox_items.get_awaiting_approval(db)) == 1
+    await inbox_items.claim_for_dispatch(db, "a", reqid="req-1")
+    # Once claimed, the row is 'dispatching:' -> get_awaiting_approval no longer
+    # returns it, so a crash before completion cannot re-resume + re-dispatch it.
+    assert await inbox_items.get_awaiting_approval(db) == []
+
+
+@pytest.mark.asyncio
+async def test_completion_clears_inflight_marker(db):
+    # A completed row must NOT retain its in-flight dispatching:/awaiting:
+    # marker in error_message — it would surface as internal dispatch state on a
+    # finished item (e.g. in the dashboard).
+    await _park(db, "a", "req-1")
+    await inbox_items.claim_for_dispatch(db, "a", reqid="req-1")
+    await inbox_items.set_response_path(
+        db, "a", response_path="r", processed_at="2026-06-30T01:00:00+00:00",
+        evaluated_content="x",
+    )
+    row = await inbox_items.get_by_id(db, "a")
+    assert row["status"] == "completed"
+    assert row["error_message"] is None
+
+
+@pytest.mark.asyncio
+async def test_expire_stuck_reaps_dispatching_not_awaiting(db):
+    # A claimed row whose CC call crashed sits in 'dispatching:'. It must be
+    # reaped (back to retriable failed) after the timeout so the drop retries;
+    # an 'awaiting:' row must NOT be reaped (it waits for the user arbitrarily).
+    old = "2026-01-01T00:00:00+00:00"  # far past the 2h cutoff
+    await inbox_items.create(
+        db, id="disp", file_path="/inbox/A.md", content_hash="h",
+        status="processing", created_at=old,
+    )
+    await inbox_items.update_status(
+        db, "disp", status="processing",
+        error_message=f"{inbox_items.DISPATCHING_PREFIX}req-1",
+    )
+    await inbox_items.create(
+        db, id="await_row", file_path="/inbox/B.md", content_hash="h",
+        status="processing", created_at=old,
+    )
+    await inbox_items.update_status(
+        db, "await_row", status="processing",
+        error_message=f"{inbox_items.AWAITING_APPROVAL_PREFIX}req-2",
+    )
+    n = await inbox_items.expire_stuck_processing(db)
+    assert n == 1
+    assert (await inbox_items.get_by_id(db, "disp"))["status"] == "failed"
+    assert (await inbox_items.get_by_id(db, "await_row"))["status"] == "processing"

--- a/tests/test_inbox/test_drop_dispatch.py
+++ b/tests/test_inbox/test_drop_dispatch.py
@@ -205,6 +205,56 @@ async def test_one_approval_per_drop_then_resume_dispatches_all(
 
 
 @pytest.mark.asyncio
+async def test_resume_claim_prevents_double_dispatch_on_crash(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, monkeypatch,
+):
+    """A crash between dispatch and completion must NOT duplicate the eval.
+
+    The resume pass claims each row (awaiting_approval: -> dispatching:) BEFORE
+    the CC call, so a re-run (restart) finds the rows already 'dispatching:'
+    (excluded from get_awaiting_approval) and does not re-dispatch them. Without
+    the claim, the rows stay 'awaiting_approval:' and the next scan re-resumes
+    and re-dispatches -> duplicate eval + duplicate Genesis-N file.
+    """
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, items_per_eval=3)
+    approvals: dict[str, dict] = {}
+    disp = _wired(
+        decision=AutonomousDispatchDecision(
+            mode="blocked", reason="approval requested",
+            approval_request_id="req-1",
+        ),
+        approval_by_id=approvals,
+    )
+    mon._autonomous_dispatcher = disp
+    (inbox_dir / "Genesis.md").write_text(_urls(6))  # 6 URLs -> 1 drop, 2 batches
+
+    await mon.check_once()  # scan 1: parked awaiting approval
+    assert len(await inbox_items.get_awaiting_approval(db)) == 2
+
+    # Simulate a crash AFTER dispatch but BEFORE completion: the resume loop
+    # claims the row first, then calls _dispatch_one_batch — stub it so the row
+    # is never marked completed (as if the process died mid-eval).
+    dispatch_calls: list[str] = []
+
+    async def _crash_dispatch(item, **kw):
+        dispatch_calls.append(item.id)
+        return True  # "dispatched" but leaves the row in its claimed state
+
+    monkeypatch.setattr(mon, "_dispatch_one_batch", _crash_dispatch)
+
+    approvals["req-1"] = {"status": "approved"}
+    await mon.check_once()  # scan 2: claim + (crashed) dispatch
+    assert len(dispatch_calls) == 2, "both batches dispatched once on resume"
+    # Claimed rows are 'dispatching:' now -> no longer awaiting.
+    assert await inbox_items.get_awaiting_approval(db) == []
+
+    await mon.check_once()  # scan 3: restart — must NOT re-dispatch the claimed rows
+    assert len(dispatch_calls) == 2, (
+        "claimed rows were re-dispatched after a crash (double dispatch)"
+    )
+
+
+@pytest.mark.asyncio
 async def test_gate_error_fails_drop_not_stuck_processing(
     db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
 ):


### PR DESCRIPTION
## What

Makes inbox dispatch **at-most-once** (PR-2b of 3 — follows #817 detection storm; PR-2c partial-failure retry next). Fixes a restart/crash double-dispatch edge found reviewing the batching rework.

**Root cause:** the resume pass consumed the approval *gate* then dispatched, but never moved the row out of its `awaiting_approval:` parked state until completion. A crash between consume and completion left the row re-findable by `get_awaiting_approval`, so the next scan re-resumed and re-dispatched it — duplicate eval + duplicate `…-N.genesis.md`. The consume return value was also ignored, so a failed `mark_consumed` left an unconsumed content-agnostic approval a later drop could ride.

## Changes

- **`claim_for_dispatch(id, reqid)`** — an atomic CAS that flips a parked row `awaiting_approval:<reqid>` → `dispatching:<reqid>` (a new marker prefix), returning whether this call won the claim. The **row state is now the at-most-once authority**.
- **Resume loop** claims each row *before* the CC call, skips losers, then consumes (best-effort) and dispatches only claimed rows.
- A claimed (`dispatching:`) row is invisible to `get_awaiting_approval` (so a crash can't re-resume it) but **is** reaped by `expire_stuck_processing` after its timeout — recovered into the retry path. New-drop dispatch is unchanged (already crash-safe).
- Consume is now best-effort: a failure neither strands the drop nor bypasses at-most-once; it only leaves the approval rideable until the gate's 24h staleness window (WARNING-logged).
- **Cleanup (review-driven):** completion now clears the in-flight marker from `error_message`, so a finished item no longer shows internal dispatch state.

No schema change, no migration.

## Verification

- TDD, red-first proven: the double-dispatch test fails without the claim; the marker-clear test fails without the clear.
- Multi-agent code review (line-by-line + SQL, removed-behavior, cross-file + altitude): no correctness bugs; two LOW cosmetic findings fixed at root (marker clear).
- Full inbox suite: **280 passed** (with #817 present); ruff clean.
- Live-schema E2E: awaiting → claim (single-winner) → invisible-to-resume → reap → retriable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)