### PR TITLE
docs(audit): enumerate-not-spotcheck protocol into agents + skill

### DIFF
--- a/.claude/agents/genesis-architect.md
+++ b/.claude/agents/genesis-architect.md
@@ -38,6 +38,31 @@ V3 = conservative. Flag anything that looks like:
 - Bare `except Exception` without specific catches first
 - Missing `exc_info=True` on error-path logging
 
+## Auditing Existing Capabilities (enumerate, don't spot-check)
+
+Before you affirm an implementer's claim that Genesis "lacks X", "needs to add X",
+or is "weaker than <external system> at X" — verify by ENUMERATION, not a
+spot-check. Auditing a symbol is not auditing the stack.
+
+1. **Enumerate** the subsystem's full module inventory before concluding anything
+   is absent.
+2. **Trace the call graph BOTH directions** — mechanisms often live in the
+   wrapper/caller layer, not the symbol first landed on (CRAG lives in the MCP
+   recall wrapper, not `retrieval.py`; the reranker is applied by the caller).
+3. **Grep by CONCEPT** with several synonyms, not one symbol.
+4. **Verify built/enabled/disabled against RUNTIME state** (env gates, server
+   logs) — code presence ≠ enabled; code absence in one file ≠ absent from the
+   system.
+5. For **multi-path** systems build a coverage matrix (N entry points × M
+   mechanisms) — hot auto-fired paths often carry a thinner stack than the deep
+   path: a gradient, not an absence.
+6. **Confidence is capped by enumeration completeness.** A negative from a
+   positive search is not evidence of absence.
+
+This exists because a 2026-06-30 competitive audit wrongly claimed Genesis lacked
+CRAG, scope-before-rank, and a live reranker — all three had already shipped.
+Full protocol: procedure `codebase_audit` / CC memory `audit-enumerate-not-spotcheck`.
+
 ## Review Output Format
 
 For each concern:

--- a/.claude/agents/genesis-codebase-mapper.md
+++ b/.claude/agents/genesis-codebase-mapper.md
@@ -78,3 +78,12 @@ You are a codebase mapping agent. Your job is to produce a comprehensive, accura
 - **Distinguish IS from SHOULD BE.** Report the codebase as it exists.
 - **Flag large files** (>600 LOC) as split candidates.
 - **Cross-reference** CLAUDE.md and ARCHITECTURE.md against findings — note discrepancies.
+- **Absence claims require ENUMERATION, not spot-checks.** Never report a
+  capability "missing" from a single failed search — a negative from a positive
+  search is not evidence of absence. Enumerate the subsystem's full module
+  inventory, trace the call graph both directions (mechanisms often live in the
+  wrapper/caller layer, not the first symbol you find), grep by concept with
+  several synonyms, and verify enabled/disabled against runtime state (env gates,
+  logs). State confidence as capped by enumeration completeness. (Full protocol:
+  procedure `codebase_audit` / CC memory `audit-enumerate-not-spotcheck`;
+  motivated by a 2026-06-30 audit that missed CRAG and the live reranker.)

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -165,6 +165,31 @@ Use the right tool for how you're exploring:
 
 Full decision matrix: `.claude/docs/code-intelligence.md`
 
+### Auditing Existing Capabilities — enumerate, don't spot-check
+
+Before claiming Genesis "lacks X", "needs to add X", or is "weaker than
+<external system> at X" — or before any competitive/architecture comparison —
+verify by ENUMERATION, not a spot-check. **Auditing a symbol is not auditing the
+stack**, and a negative from a positive search is not evidence of absence:
+
+1. Enumerate the subsystem's full module inventory before concluding anything is absent.
+2. Trace the call graph BOTH directions — mechanisms often live in the
+   wrapper/caller layer, not the first symbol (CRAG lives in the MCP recall
+   wrapper, not `retrieval.py`; the reranker is applied by the caller).
+3. Grep by CONCEPT with several synonyms, not one symbol.
+4. Verify built/enabled/disabled against RUNTIME state (env gates, server logs),
+   not code presence.
+5. Multi-path systems → coverage matrix (N entry points × M mechanisms); hot
+   auto-fired paths often carry a thinner stack than the deep path — a gradient,
+   not an absence.
+6. Confidence is capped by enumeration completeness.
+
+A 2026-06-30 competitive audit wrongly claimed Genesis lacked CRAG,
+scope-before-rank, and a live reranker — all three had already shipped. Full
+protocol: procedure `codebase_audit` / CC memory `audit-enumerate-not-spotcheck`.
+For "does Genesis already have X", consult the capability map
+(`references/codebase-map.md`) FIRST.
+
 ## Adaptive Review Protocol
 
 Choose the review level proportional to the change:


### PR DESCRIPTION
## What

Bakes the **"absence claims require enumeration, not spot-checks"** audit
protocol into the three places an audit or capability comparison begins:

- `genesis-architect` — a new *Auditing Existing Capabilities* section for
  capability-existence checks during reviews.
- `genesis-codebase-mapper` — an absence-claim rule (audit the stack, not the
  symbol; a negative from a positive search is not evidence of absence).
- `genesis-development` skill — a callout in the Code Discovery section.

Canonical source stays single: procedure `codebase_audit` + the CC-side
`audit-enumerate-not-spotcheck` memory. The three edits are concise pointers, so
there is one place to maintain.

## Why

A recent competitive audit (RedPlanetHQ CORE differential) claimed Genesis
lacked CRAG, scope-before-rank, and a live reranker. A re-audit **by
enumeration** refuted 6 of 7 claims — all three mechanisms had already shipped
(CRAG merged ten days before the analysis; the Voyage reranker was live). The
root cause was auditing a *symbol* rather than the *stack*, and proving a
negative from a failed positive search. This protocol prevents the recurrence.

## Scope

Docs-only, no runtime effect. Not a CHANGELOG entry (internal process doc).