### PR TITLE
fix(inbox): partial-failure auto-retry for stranded batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   repeatedly cancel and recreate that approval. Genesis now recognizes there's no new content and
   marks the note current in a single scan, so it settles instead of churning.
 
+- **Links that fail partway through an evaluation now retry themselves.** When only some of the
+  links in a note evaluate successfully and the rest fail (for example, a few get rate-limited),
+  the failed links used to sit untouched until you edited the note again. Genesis now
+  automatically re-attempts the stranded links on a later scan on its own — bounded so a link that
+  keeps failing eventually stops retrying rather than looping.
+
 - **Inbox evaluations no longer cram a whole batch of links into one giant pass — and stop
   re-evaluating links they've already covered.** When you drop many URLs into an inbox note,
   Genesis now evaluates them in small groups (≈5 at a time, configurable via

--- a/src/genesis/db/crud/inbox_items.py
+++ b/src/genesis/db/crud/inbox_items.py
@@ -484,6 +484,61 @@ async def get_retriable_failed_rows(
     return [dict(r) for r in await cursor.fetchall()]
 
 
+async def get_retriable_failure_files(
+    db: aiosqlite.Connection, *, max_retries: int = 3,
+) -> list[str]:
+    """Return file_paths that have a stranded retriable-failed batch to retry.
+
+    A file qualifies for partial-failure AUTO-RETRY when it has >=1 failed row
+    that is still retriable (``retry_count < max_retries`` and not
+    ``approval_invalidated:``) AND it has NO row currently ``pending`` or
+    ``processing`` (nothing in flight for it). Such files are otherwise stranded:
+    when only SOME batches of a drop fail, a completed sibling keeps the file's
+    hash in :func:`get_all_known`, so detection never re-surfaces the file and
+    the failed batch would only retry on the next user edit. The monitor uses
+    this to re-queue the failed batches independently of file-change detection.
+    Excludes approval-invalidated rows (those need a fresh approval, not a retry).
+    """
+    cursor = await db.execute(
+        """SELECT DISTINCT file_path FROM inbox_items
+           WHERE status = 'failed' AND retry_count < ?
+             AND (error_message IS NULL
+                  OR error_message NOT LIKE ? || '%')
+             AND file_path NOT IN (
+                 SELECT file_path FROM inbox_items
+                 WHERE status IN ('pending', 'processing')
+             )""",
+        (max_retries, APPROVAL_INVALIDATED_PREFIX),
+    )
+    return [row[0] for row in await cursor.fetchall()]
+
+
+async def mark_file_failures_abandoned(
+    db: aiosqlite.Connection, file_path: str, *, max_retries: int = 3,
+) -> int:
+    """Mark a file's retriable failed rows as approval-invalidated (abandoned).
+
+    Used when a retry candidate's failed content is no longer present in the
+    file (the user removed those URLs before the retry ran): the recomputed
+    delta is empty, so there is nothing to re-queue, but the retriable-failed
+    rows would otherwise keep the file a retry candidate forever. Flipping them
+    to the ``approval_invalidated:`` prefix excludes them from
+    :func:`get_retriable_failure_files` / :func:`get_retriable_failed_rows`.
+    Returns the number of rows updated.
+    """
+    cursor = await db.execute(
+        """UPDATE inbox_items
+           SET error_message = ? || 'content removed before retry'
+           WHERE file_path = ? AND status = 'failed' AND retry_count < ?
+             AND (error_message IS NULL
+                  OR error_message NOT LIKE ? || '%')""",
+        (APPROVAL_INVALIDATED_PREFIX, file_path, max_retries,
+         APPROVAL_INVALIDATED_PREFIX),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
 async def reuse_as_pending(
     db: aiosqlite.Connection,
     id: str,

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -318,7 +318,25 @@ class InboxMonitor:
             watch, resumed_paths,
         )
 
-        if not (new_files + modified_files) and not resume_items:
+        # Phase 2b: partial-failure retry candidates — files with a stranded
+        # retriable-failed batch and no in-flight row. They are NOT detected as
+        # new/modified (a completed sibling keeps their hash "known"), so surface
+        # them here and let _phase_create_records re-queue them independently of
+        # change detection. Exclude files already handled this scan.
+        detected = (
+            {str(p) for p in new_files}
+            | {str(p) for p in modified_files}
+            | set(resumed_paths)
+        )
+        retry_files = [
+            Path(fp)
+            for fp in await inbox_items.get_retriable_failure_files(
+                self._db, max_retries=self._config.max_retries,
+            )
+            if fp not in detected
+        ]
+
+        if not (new_files + modified_files + retry_files) and not resume_items:
             return CheckResult(
                 items_found=len(scan_folder(
                     watch, self._config.response_dir,
@@ -326,9 +344,9 @@ class InboxMonitor:
                 )),
             )
 
-        # Phase 3: Create/update DB records for changed files
-        pending_items = await self._phase_create_records(
-            new_files, modified_files, now, now_iso,
+        # Phase 3: Create/update DB records for changed + retry-candidate files
+        pending_items, items_retried = await self._phase_create_records(
+            new_files, modified_files, retry_files, now, now_iso,
         )
 
         # Phase 4: Batch and dispatch
@@ -343,6 +361,7 @@ class InboxMonitor:
             )),
             items_new=len(new_files),
             items_modified=len(modified_files),
+            items_retried=items_retried,
             batches_dispatched=batches_dispatched,
             errors=errors,
         )
@@ -700,13 +719,15 @@ class InboxMonitor:
         self,
         new_files: list[Path],
         modified_files: list[Path],
+        retry_files: list[Path],
         now: datetime,
         now_iso: str,
-    ) -> list[InboxItem]:
-        """Create/update DB rows for new and modified files.
+    ) -> tuple[list[InboxItem], int]:
+        """Create/update DB rows for new, modified, and retry-candidate files.
 
-        Returns ``pending_items`` — items queued for dispatch.
-        Resume items are NOT included (they're dispatched separately).
+        Returns ``(pending_items, retried_count)`` — items queued for dispatch,
+        and how many retry-candidate files were actually re-queued. Resume items
+        are NOT included (they're dispatched separately).
         """
         from genesis.db.crud import inbox_items
 
@@ -846,7 +867,58 @@ class InboxMonitor:
                 str(f), eval_content, h, now_iso, pending_items,
             )
 
-        return pending_items
+        # --- Partial-failure auto-retry (PR-2c) ---
+        # Re-queue stranded retriable-failed batches for files with no in-flight
+        # row. These aren't detected as new/modified (a completed sibling keeps
+        # the file's hash "known"), so we re-derive the delta and reuse the
+        # failed rows via _queue_drop. Cooldown-EXEMPT — a retry is failure
+        # recovery, not a re-eval on a user edit; bounded per row by retry_count
+        # (get_retriable_failed_rows excludes rows at the cap) plus the
+        # URL-failure storm guard below.
+        retried = 0
+        for f in retry_files:
+            try:
+                content = read_content(f)
+                h = compute_hash(f)
+            except (FileNotFoundError, PermissionError):
+                logger.warning("File vanished before retry read: %s", f)
+                continue
+            if not content.strip():
+                continue
+            url_fail_count = await inbox_items.count_url_failures(
+                self._db, str(f), since_hours=48,
+            )
+            if url_fail_count >= self._config.max_retries:
+                logger.warning(
+                    "Retry storm: %s has %d URL failures in 48h, skipping retry",
+                    f, url_fail_count,
+                )
+                continue
+            prev_content = await inbox_items.get_evaluated_content(
+                self._db, str(f),
+            )
+            delta = (
+                _compute_new_content(prev_content, content)
+                if prev_content else content
+            )
+            if not delta.strip():
+                # The failed batch's URLs are no longer in the file (removed) —
+                # nothing to retry. Abandon the stale failed rows so the file
+                # stops being a retry candidate forever.
+                logger.debug(
+                    "Retry candidate %s has no un-evaluated content; "
+                    "abandoning stale failed rows", f,
+                )
+                await inbox_items.mark_file_failures_abandoned(
+                    self._db, str(f), max_retries=self._config.max_retries,
+                )
+                continue
+            before = len(pending_items)
+            await self._queue_drop(str(f), delta, h, now_iso, pending_items)
+            if len(pending_items) > before:
+                retried += 1
+
+        return pending_items, retried
 
     async def _queue_drop(
         self,

--- a/src/genesis/inbox/types.py
+++ b/src/genesis/inbox/types.py
@@ -93,5 +93,6 @@ class CheckResult:
     items_found: int = 0
     items_new: int = 0
     items_modified: int = 0
+    items_retried: int = 0
     batches_dispatched: int = 0
     errors: list[str] = field(default_factory=list)

--- a/tests/test_inbox/test_crud_drop_batching.py
+++ b/tests/test_inbox/test_crud_drop_batching.py
@@ -222,6 +222,20 @@ async def _park(db, id, reqid, *, created_at="2026-06-30T00:00:01+00:00"):
     )
 
 
+# --- partial-failure auto-retry candidate selection (PR-2c) ---
+
+
+async def _failed(db, id, file_path, *, retry_count=0, error="rate limit",
+                  created_at="2026-06-30T00:00:01+00:00"):
+    await inbox_items.create(
+        db, id=id, file_path=file_path, content_hash="h", status="pending",
+        created_at=created_at,
+    )
+    await inbox_items.update_status(
+        db, id, status="failed", error_message=error, retry_count=retry_count,
+    )
+
+
 @pytest.mark.asyncio
 async def test_claim_for_dispatch_transitions_awaiting_to_dispatching(db):
     await _park(db, "a", "req-1")
@@ -308,3 +322,50 @@ async def test_expire_stuck_reaps_dispatching_not_awaiting(db):
     assert n == 1
     assert (await inbox_items.get_by_id(db, "disp"))["status"] == "failed"
     assert (await inbox_items.get_by_id(db, "await_row"))["status"] == "processing"
+
+
+@pytest.mark.asyncio
+async def test_get_retriable_failure_files_returns_stranded(db):
+    # A file with a completed batch + a retriable-failed batch, no in-flight row.
+    await inbox_items.create(
+        db, id="done", file_path="/inbox/A.md", content_hash="h",
+        status="completed", created_at="2026-06-30T00:00:01+00:00",
+    )
+    await _failed(db, "fail", "/inbox/A.md", created_at="2026-06-30T00:00:02+00:00")
+    files = await inbox_items.get_retriable_failure_files(db, max_retries=3)
+    assert files == ["/inbox/A.md"]
+
+
+@pytest.mark.asyncio
+async def test_get_retriable_failure_files_excludes_inflight(db):
+    # A retriable-failed row AND a pending row for the same file -> in flight,
+    # so NOT a retry candidate (a drop is already queued/processing).
+    await _failed(db, "fail", "/inbox/A.md")
+    await inbox_items.create(
+        db, id="pend", file_path="/inbox/A.md", content_hash="h",
+        status="pending", created_at="2026-06-30T00:00:02+00:00",
+    )
+    assert await inbox_items.get_retriable_failure_files(db, max_retries=3) == []
+
+
+@pytest.mark.asyncio
+async def test_get_retriable_failure_files_excludes_invalidated_and_exhausted(db):
+    # approval_invalidated failed row -> needs fresh approval, not a retry.
+    await _failed(db, "inv", "/inbox/A.md",
+                  error=f"{inbox_items.APPROVAL_INVALIDATED_PREFIX}gone")
+    # retry_count at the cap -> exhausted, not retriable.
+    await _failed(db, "exh", "/inbox/B.md", retry_count=3)
+    assert await inbox_items.get_retriable_failure_files(db, max_retries=3) == []
+
+
+@pytest.mark.asyncio
+async def test_mark_file_failures_abandoned_stops_candidacy(db):
+    # When a retry candidate's failed content is gone from the file, its stale
+    # failed rows are marked approval_invalidated so it stops being a candidate.
+    await _failed(db, "f1", "/inbox/A.md")
+    assert await inbox_items.get_retriable_failure_files(db, max_retries=3) == ["/inbox/A.md"]
+    n = await inbox_items.mark_file_failures_abandoned(db, "/inbox/A.md", max_retries=3)
+    assert n == 1
+    assert await inbox_items.get_retriable_failure_files(db, max_retries=3) == []
+    row = await inbox_items.get_by_id(db, "f1")
+    assert row["error_message"].startswith(inbox_items.APPROVAL_INVALIDATED_PREFIX)

--- a/tests/test_inbox/test_drop_dispatch.py
+++ b/tests/test_inbox/test_drop_dispatch.py
@@ -143,6 +143,132 @@ async def test_partial_batch_failure_baselines_only_successes(
     assert statuses == ["completed", "failed"]
 
 
+@pytest.mark.asyncio
+async def test_partial_failure_auto_retries_without_edit(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """A partially-failed drop's failed batch is auto-retried on a LATER scan
+    WITHOUT the user editing the file. A completed sibling keeps the file's hash
+    'known', so detection alone would never re-surface it (the stranding gap)."""
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, items_per_eval=3)
+    fp = inbox_dir / "Genesis.md"
+    fp.write_text(_urls(6))  # 6 URLs -> 2 batches
+    mock_invoker.run.side_effect = [_ok(), _err("rate limited")]
+    await mon.check_once()  # scan 1: batch1 ok, batch2 fails (stranded)
+    assert sorted(r["status"] for r in [dict(x) for x in await (await db.execute(
+        "SELECT status FROM inbox_items WHERE file_path=?", (str(fp),))).fetchall()]) == ["completed", "failed"]
+
+    # Scan 2: file UNCHANGED. The stranded batch2 must auto-retry and succeed.
+    mock_invoker.run.reset_mock()
+    mock_invoker.run.side_effect = None
+    mock_invoker.run.return_value = _ok()
+    r2 = await mon.check_once()
+    assert r2.items_new == 0
+    assert r2.items_modified == 0, "must NOT be re-detected via hash — it's a retry, not a modification"
+    assert r2.items_retried == 1
+    assert r2.batches_dispatched == 1, "the stranded batch2 was re-dispatched"
+    baseline = await inbox_items.get_evaluated_content(db, str(fp)) or ""
+    for i in range(6):
+        assert f"https://example.com/a{i}" in baseline, f"a{i} missing from baseline after retry"
+
+
+@pytest.mark.asyncio
+async def test_retry_is_cooldown_exempt(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """A partial-failure retry fires even within the evaluation cooldown window
+    — a retry is failure recovery, not a re-eval on a user edit, so the cooldown
+    (which throttles re-evals of edited files) must not defer it."""
+    cfg = InboxConfig(
+        watch_path=inbox_dir, items_per_eval=3, evaluation_cooldown_seconds=3600,
+    )
+    mon = InboxMonitor(
+        db=db, invoker=mock_invoker, session_manager=mock_session_manager,
+        config=cfg, writer=ResponseWriter(watch_path=inbox_dir, timezone="UTC"),
+        clock=_FakeClock(), prompt_dir=tmp_path,
+    )
+    fp = inbox_dir / "Genesis.md"
+    fp.write_text(_urls(6))
+    mock_invoker.run.side_effect = [_ok(), _err("rate limited")]
+    await mon.check_once()  # batch1 completes at clock T (within cooldown of T)
+
+    mock_invoker.run.reset_mock()
+    mock_invoker.run.side_effect = None
+    mock_invoker.run.return_value = _ok()
+    r2 = await mon.check_once()  # SAME clock -> still inside cooldown
+    assert r2.items_retried == 1, "retry must be cooldown-exempt"
+    assert r2.batches_dispatched == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_is_bounded_by_retry_count(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """A retry that KEEPS failing stops after retry_count hits the cap — the
+    load-bearing bound is retry_count (not the URL-failure guard, which here
+    never fires because the errors aren't 'partial_url_failure'). No infinite
+    retry loop, no row proliferation."""
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, items_per_eval=3)
+    max_r = mon._config.max_retries
+    fp = inbox_dir / "Genesis.md"
+    fp.write_text(_urls(6))  # 2 batches
+    # Scan 1: batch1 ok, batch2 fails (retry_count -> 1).
+    mock_invoker.run.side_effect = [_ok(), _err("rate limited")]
+    await mon.check_once()
+
+    # Every subsequent scan the retry keeps failing; it MUST stop at the cap.
+    mock_invoker.run.side_effect = None
+    mock_invoker.run.return_value = _err("still rate limited")
+    total_retries = 0
+    for _ in range(max_r + 5):  # far more scans than the cap
+        total_retries += (await mon.check_once()).items_retried
+    assert total_retries <= max_r, (
+        f"retried {total_retries}x, exceeds cap {max_r} — unbounded/proliferating"
+    )
+    # And it has stopped being a candidate (no further retries).
+    assert (await mon.check_once()).items_retried == 0
+    # No row proliferation: the file's row count stayed bounded (2 batches).
+    n = (await (await db.execute(
+        "SELECT COUNT(*) FROM inbox_items WHERE file_path=?", (str(fp),))).fetchone())[0]
+    assert n <= 4, f"row proliferation: {n} rows for a 2-batch file"
+
+
+@pytest.mark.asyncio
+async def test_retry_respects_url_failure_storm_guard(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """A file that persistently fails URL fetches (>= max_retries
+    partial_url_failure in 48h) is NOT retried — the storm guard applies on the
+    retry path just as on the new-files path."""
+    from datetime import UTC, datetime
+
+    from genesis.inbox.scanner import compute_hash
+
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, items_per_eval=3)
+    fp = inbox_dir / "Genesis.md"
+    fp.write_text(_urls(3))
+    h = compute_hash(fp)
+    recent = datetime.now(UTC).isoformat()  # count_url_failures windows on REAL now
+    # A completed row with the current hash keeps the file 'known' (undetected),
+    # so it reaches the retry path rather than the new-files path.
+    await inbox_items.create(
+        db, id="done", file_path=str(fp), content_hash=h, status="completed",
+        created_at=recent,
+    )
+    for i in range(3):  # 3 == max_retries -> storm
+        await inbox_items.create(
+            db, id=f"puf{i}", file_path=str(fp), content_hash=h,
+            status="pending", created_at=recent,
+        )
+        await inbox_items.update_status(
+            db, f"puf{i}", status="failed", error_message="partial_url_failure",
+        )
+    r = await mon.check_once()
+    assert r.items_modified == 0  # completed row keeps it known
+    assert r.items_retried == 0, "storm guard must skip a persistently URL-failing file"
+    assert mock_invoker.run.call_count == 0
+
+
 # ── One approval per drop (gate ON) ──────────────────────────────────────
 
 


### PR DESCRIPTION
## What

Final PR of the inbox series (PR-2c; follows #817 storm fix and #821 dispatch at-most-once). Auto-retries a batch that failed partway through a multi-batch evaluation.

**The gap:** when only SOME batches of a drop succeed and others fail (e.g. a rate-limit), the completed sibling keeps the file's whole-file hash in `get_all_known`, so the file is never re-detected as "modified" and the failed batch is stranded until the user next edits the note. `_queue_drop` (the only path that reuses failed rows) runs only from change detection, so partial failures never auto-retried. (A *total* failure already auto-retries — excluded from `get_all_known` → re-detected.)

## Changes

- **`get_retriable_failure_files`** (new CRUD): files with a retriable failed row (`retry_count < max`, not `approval_invalidated:`) **and no in-flight (`pending`/`processing`) row**.
- **`_check_once_inner`** computes retry candidates (minus files already detected this scan) and merges them into the early-return guard; **`_phase_create_records`** gains a retry loop that re-derives the delta and re-queues via the existing `_queue_drop` (row-reuse) machinery. New `CheckResult.items_retried`.
- If the failed batch's URLs were **removed** from the file (empty delta), **`mark_file_failures_abandoned`** flips the stale rows to `approval_invalidated:` so the file stops being a candidate.

## Design decisions

- **Cooldown-exempt.** A retry is failure recovery, not a re-eval on a user edit, so it fires the next scan (natural ~interval spacing) rather than waiting a full cooldown.
- **Bounded (no retry-storm), proven by test:** `retry_count` is the load-bearing bound (a stranded batch retries in lockstep at most `max_retries` times, then drops out — verified `test_retry_is_bounded_by_retry_count`, incl. no row proliferation); the no-in-flight guard prevents double-queue; the `count_url_failures` storm guard is applied on the retry path too (defense-in-depth).
- **Known tradeoff:** the retry loop and the modified-files loop share some plumbing (read → delta → `_queue_drop`). They're kept separate — different guards, cadence, and empty-delta handling — rather than refactoring the already-deployed modified loop; noted for a possible future dedup.

No schema change, no migration.

## Verification

- genesis-architect pre-review (storm guard + cooldown cadence + altitude — incorporated/adjudicated).
- TDD, red-first: 4 CRUD + 4 monitor tests (headline auto-retry-without-edit, cooldown-exempt, storm-guard, retry-count bound).
- Multi-agent review (logic/bounds, signature/cross-file, altitude/SQL): the one "infinite-loop" candidate was refuted empirically (bound test); no missed callers; `CheckResult` field insertion is named-arg-safe.
- Full inbox suite: **281 passed** (with #817); ruff clean.
- Live-schema E2E: candidate-select / in-flight-exclude / abandon all correct against a copy of the real DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)