### PR TITLE
fix(inbox): abandon partial-failure retry candidates that can never be retried

### DIFF
--- a/src/genesis/db/crud/inbox_items.py
+++ b/src/genesis/db/crud/inbox_items.py
@@ -515,24 +515,25 @@ async def get_retriable_failure_files(
 
 async def mark_file_failures_abandoned(
     db: aiosqlite.Connection, file_path: str, *, max_retries: int = 3,
+    reason: str = "content removed before retry",
 ) -> int:
     """Mark a file's retriable failed rows as approval-invalidated (abandoned).
 
-    Used when a retry candidate's failed content is no longer present in the
-    file (the user removed those URLs before the retry ran): the recomputed
-    delta is empty, so there is nothing to re-queue, but the retriable-failed
-    rows would otherwise keep the file a retry candidate forever. Flipping them
-    to the ``approval_invalidated:`` prefix excludes them from
-    :func:`get_retriable_failure_files` / :func:`get_retriable_failed_rows`.
-    Returns the number of rows updated.
+    Used when a retry candidate can never be retried again — either its failed
+    content was removed from the file (empty delta; the default ``reason``), or
+    the source file itself was deleted (``reason="source file deleted"``). The
+    retriable-failed rows would otherwise keep the file a retry candidate
+    forever; flipping them to the ``approval_invalidated:<reason>`` prefix
+    excludes them from :func:`get_retriable_failure_files` /
+    :func:`get_retriable_failed_rows`. Returns the number of rows updated.
     """
     cursor = await db.execute(
         """UPDATE inbox_items
-           SET error_message = ? || 'content removed before retry'
+           SET error_message = ? || ?
            WHERE file_path = ? AND status = 'failed' AND retry_count < ?
              AND (error_message IS NULL
                   OR error_message NOT LIKE ? || '%')""",
-        (APPROVAL_INVALIDATED_PREFIX, file_path, max_retries,
+        (APPROVAL_INVALIDATED_PREFIX, reason, file_path, max_retries,
          APPROVAL_INVALIDATED_PREFIX),
     )
     await db.commit()

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -880,10 +880,35 @@ class InboxMonitor:
             try:
                 content = read_content(f)
                 h = compute_hash(f)
-            except (FileNotFoundError, PermissionError):
-                logger.warning("File vanished before retry read: %s", f)
+            except FileNotFoundError:
+                # The source file was deleted since it failed — its stranded
+                # retriable-failed rows can never be re-evaluated. Abandon them
+                # so the file stops being a retry candidate; otherwise it recurs
+                # (and re-logs) every scan forever. (If the file is ever
+                # re-created it is detected as new and evaluated fresh.)
+                logger.info(
+                    "Retry candidate %s no longer exists; abandoning its "
+                    "stale failed rows", f,
+                )
+                await inbox_items.mark_file_failures_abandoned(
+                    self._db, str(f), max_retries=self._config.max_retries,
+                    reason="source file deleted",
+                )
+                continue
+            except PermissionError:
+                # Possibly transient (e.g. locked mid-write) — skip WITHOUT
+                # abandoning; a later scan's read may succeed.
+                logger.warning(
+                    "Permission error reading retry candidate %s; skipping", f,
+                )
                 continue
             if not content.strip():
+                # Empty source file — nothing to ever retry; abandon so it stops
+                # being a candidate (same terminal state as a deleted file).
+                await inbox_items.mark_file_failures_abandoned(
+                    self._db, str(f), max_retries=self._config.max_retries,
+                    reason="source file is empty",
+                )
                 continue
             url_fail_count = await inbox_items.count_url_failures(
                 self._db, str(f), since_hours=48,

--- a/tests/test_inbox/test_drop_dispatch.py
+++ b/tests/test_inbox/test_drop_dispatch.py
@@ -269,6 +269,72 @@ async def test_retry_respects_url_failure_storm_guard(
     assert mock_invoker.run.call_count == 0
 
 
+@pytest.mark.asyncio
+async def test_retry_candidate_vanished_file_is_abandoned(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """A retry candidate whose SOURCE FILE was deleted is abandoned — its
+    stranded failed rows are flipped to approval_invalidated so it stops being a
+    candidate (no 'File vanished before retry read' every scan, forever)."""
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, items_per_eval=3)
+    gone = inbox_dir / "Deleted.md"  # never created on disk
+    # A retriable-failed row for a file that does not exist -> pure retry
+    # candidate (not detected as new/modified, since it isn't on disk).
+    await inbox_items.create(
+        db, id="f1", file_path=str(gone), content_hash="h", status="pending",
+        created_at="2026-06-30T00:00:01+00:00",
+    )
+    await inbox_items.update_status(db, "f1", status="failed", error_message="rate limited")
+    assert await inbox_items.get_retriable_failure_files(db, max_retries=3) == [str(gone)]
+
+    await mon.check_once()  # retry loop hits FileNotFoundError -> abandons it
+
+    assert await inbox_items.get_retriable_failure_files(db, max_retries=3) == [], (
+        "a vanished-file candidate must be abandoned, not recur every scan"
+    )
+    row = await inbox_items.get_by_id(db, "f1")
+    # The reason flows through end-to-end (distinct from the empty-delta case).
+    assert row["error_message"] == (
+        f"{inbox_items.APPROVAL_INVALIDATED_PREFIX}source file deleted"
+    )
+    assert mock_invoker.run.call_count == 0  # nothing dispatched (file is gone)
+
+
+@pytest.mark.asyncio
+async def test_retry_candidate_empty_file_is_abandoned(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """A retry candidate whose file exists but is now EMPTY is abandoned too —
+    another terminal state (no content to ever retry), same as a deleted file."""
+    from genesis.inbox.scanner import compute_hash
+
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, items_per_eval=3)
+    empty = inbox_dir / "Emptied.md"
+    empty.write_text("")
+    h = compute_hash(empty)
+    # A completed row with the current (empty) hash keeps the file 'known', so it
+    # reaches the RETRY path (not re-detected as new/modified).
+    await inbox_items.create(
+        db, id="done", file_path=str(empty), content_hash=h, status="completed",
+        created_at="2026-06-30T00:00:01+00:00",
+    )
+    await inbox_items.create(
+        db, id="f1", file_path=str(empty), content_hash="oldh", status="pending",
+        created_at="2026-06-30T00:00:02+00:00",
+    )
+    await inbox_items.update_status(db, "f1", status="failed", error_message="rate limited")
+    assert await inbox_items.get_retriable_failure_files(db, max_retries=3) == [str(empty)]
+
+    await mon.check_once()
+
+    assert await inbox_items.get_retriable_failure_files(db, max_retries=3) == []
+    row = await inbox_items.get_by_id(db, "f1")
+    assert row["error_message"] == (
+        f"{inbox_items.APPROVAL_INVALIDATED_PREFIX}source file is empty"
+    )
+    assert mock_invoker.run.call_count == 0
+
+
 # ── One approval per drop (gate ON) ──────────────────────────────────────
 
 


### PR DESCRIPTION
## What

Follow-on to the inbox series (after #817/#821/#824). PR-2c's partial-failure retry loop selects candidates from the DB (files with a retriable `failed` row + no in-flight row). Two **terminal** states left a candidate recurring **every scan forever** — a `WARNING` + wasted query/read each ~30-min scan:

- **source file DELETED** → the read raised `FileNotFoundError` → warn + skip.
- **source file EMPTIED** → `content.strip()` empty → skip.

Observed live post-#824 deploy for two deleted notes (`Untitled.md`, `Verify claims & research.md`) — 27 stranded failed rows re-logging every scan.

## Change

Both terminal states now **abandon** the file's stranded retriable-failed rows via `mark_file_failures_abandoned` (`reason="source file deleted"` / `"source file is empty"`), flipping them to `approval_invalidated:` so the file drops out of `get_retriable_failure_files` — stopping the recurrence. This mirrors the existing empty-delta ("content removed before retry") abandon. `mark_file_failures_abandoned` gains a `reason` kwarg (default unchanged) so all three sites store an accurate reason.

`PermissionError` is deliberately **not** abandoned (possibly transient — a later scan's read may succeed; keep warn + skip). If an abandoned note is ever re-created it's detected as new and evaluated fresh (abandoned rows are excluded from `get_all_known`).

Internal log-noise/hygiene fix — no user-visible behavior change, **no CHANGELOG**. No schema, no migration.

## Verification

- TDD, red-first: `test_retry_candidate_vanished_file_is_abandoned` (proven red — the file stayed a candidate) + `test_retry_candidate_empty_file_is_abandoned`.
- Multi-agent review (line-by-line/SQL + behavior/edges): SQL param order verified; single existing caller confirmed; the empty-file gap the review surfaced is **fixed here** (broader-class completion); the storm-guard skip is correctly left alone (it's a *temporary* 48h guard, not a terminal state).
- Full inbox suite: **290 passed**; ruff clean.
- Live-DB E2E: the two real stale candidates (27 rows) are abandoned and drop out of the retry set against a copy of production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)