### PR TITLE
feat(surplus): grade autonomous insight tasks with an LLM quality judge

### DIFF
--- a/src/genesis/db/crud/surplus_tasks.py
+++ b/src/genesis/db/crud/surplus_tasks.py
@@ -74,11 +74,15 @@ async def mark_completed(
     completed_at: str,
     result_staging_id: str | None = None,
     outcome_quality: str | None = None,
+    judge_score: float | None = None,
+    judge_detail: str | None = None,
 ) -> bool:
     cursor = await db.execute(
         "UPDATE surplus_tasks SET status = 'completed', completed_at = ?, "
-        "result_staging_id = ?, outcome_quality = ? WHERE id = ?",
-        (completed_at, result_staging_id, outcome_quality, id),
+        "result_staging_id = ?, outcome_quality = ?, judge_score = ?, "
+        "judge_detail = ? WHERE id = ?",
+        (completed_at, result_staging_id, outcome_quality, judge_score,
+         judge_detail, id),
     )
     await db.commit()
     return cursor.rowcount > 0

--- a/src/genesis/db/migrations/0043_surplus_judge_score.py
+++ b/src/genesis/db/migrations/0043_surplus_judge_score.py
@@ -1,0 +1,44 @@
+"""Add judge_score + judge_detail columns to surplus_tasks (quality judge).
+
+The ``outcome_quality`` verdict on insight-producing surplus tasks is now set by
+a measurement-only LLM quality judge (``surplus.quality_judge``) rather than the
+old intake-routing heuristic (which was structurally unreachable — curated
+surplus sources skip scoring and route at a fixed 0.6 confidence, so intake
+never discarded everything, so 'hollow' could never fire). ``outcome_quality``
+keeps its meaning at the *bus* level — ``useful`` / ``hollow`` / NULL — but now
+means "judge passed / judge failed / no verdict" instead of
+"intake kept something / intake discarded everything / n-a".
+
+This migration adds the two continuous, human-readable columns behind that
+binary verdict, for calibration and display (they are NOT read by the Outcome
+Bus harvester, which only branches on ``outcome_quality``):
+
+  - ``judge_score``  REAL : the judge's [0, 1] quality score.
+  - ``judge_detail`` TEXT : the judge's JSON detail (rubric, model, rationale).
+
+Additive and backward-compatible: existing rows backfill to NULL. Fresh DBs get
+both columns from the canonical CREATE TABLE in db/schema/_tables.py.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # Table may not exist if migrations run on a fresh DB before schema init.
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='surplus_tasks'"
+    )
+    if not await cursor.fetchone():
+        return
+
+    # Only add columns that don't already exist (fresh DBs get them from the
+    # canonical CREATE TABLE; re-runs must be idempotent).
+    col_cursor = await db.execute("PRAGMA table_info(surplus_tasks)")
+    cols = {row[1] for row in await col_cursor.fetchall()}
+
+    if "judge_score" not in cols:
+        await db.execute("ALTER TABLE surplus_tasks ADD COLUMN judge_score REAL")
+    if "judge_detail" not in cols:
+        await db.execute("ALTER TABLE surplus_tasks ADD COLUMN judge_detail TEXT")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -368,11 +368,16 @@ TABLES = {
             attempt_count     INTEGER NOT NULL DEFAULT 0,
             not_before        TEXT,
             -- Verified-correctness verdict for insight-producing tasks (see
-            -- surplus.types.INSIGHT_PRODUCING_TASK_TYPES). 'useful' = intake
-            -- routed >=1 finding to knowledge/observation; 'hollow' = intake
-            -- ran but routed everything to discard. NULL = action task, legacy
-            -- row, intake-failure, or empty/too-short output (not penalized).
-            outcome_quality   TEXT CHECK (outcome_quality IN ('useful', 'hollow'))
+            -- surplus.types.INSIGHT_PRODUCING_TASK_TYPES), set by the
+            -- measurement-only quality judge (surplus.quality_judge). 'useful' =
+            -- judge passed the output; 'hollow' = judge failed it (harvested as a
+            -- VERIFICATION_FAILED negative). NULL = action task, legacy row,
+            -- unknown type, judge outage, or empty/too-short output (not penalized).
+            outcome_quality   TEXT CHECK (outcome_quality IN ('useful', 'hollow')),
+            -- Continuous [0,1] quality score + JSON rationale from the judge, for
+            -- calibration/display (NOT read by the Outcome Bus harvester).
+            judge_score       REAL,
+            judge_detail      TEXT
         )
     """,
     "drive_weights": """

--- a/src/genesis/feedback/harvest.py
+++ b/src/genesis/feedback/harvest.py
@@ -386,14 +386,15 @@ class OutcomeHarvester:
 
             # Verified-correctness (second, orthogonal axis). EXECUTION_OUTCOME
             # above answers "did it run"; this answers "was the output useful".
-            # A completed insight task whose intake routed EVERYTHING to discard
-            # is hollow — it ran but produced nothing of value — so it earns an
-            # ADDITIONAL tier-1 negative. Because VERIFICATION_FAILED is a
-            # distinct signal_type, it coexists with the positive EXECUTION_OUTCOME
-            # on the same (source, ref_type, ref_id) under the unique key; the two
-            # never dup-suppress each other across incremental re-harvests.
-            # NULL outcome_quality (action tasks, legacy rows, intake failures,
-            # empty/too-short output) adds nothing here — positive-only, unchanged.
+            # A completed insight task whose output the measurement-only quality
+            # judge FAILED (score below the output_quality threshold) is hollow —
+            # it ran but produced nothing of value — so it earns an ADDITIONAL
+            # tier-1 negative. Because VERIFICATION_FAILED is a distinct
+            # signal_type, it coexists with the positive EXECUTION_OUTCOME on the
+            # same (source, ref_type, ref_id) under the unique key; the two never
+            # dup-suppress each other across incremental re-harvests. NULL
+            # outcome_quality (action tasks, legacy rows, judge outages, unknown
+            # types, empty/too-short output) adds nothing — positive-only, unchanged.
             if completed and r["outcome_quality"] == "hollow":
                 veid = await record_outcome(
                     self._db,
@@ -404,7 +405,7 @@ class OutcomeHarvester:
                     signal_type=SignalType.VERIFICATION_FAILED,
                     polarity="negative",
                     value=0.0,
-                    reason_text="intake routed all findings to discard (hollow)",
+                    reason_text="quality judge scored output below threshold (hollow)",
                     occurred_at=r["completed_at"] or r["created_at"],
                     harvested_from="surplus_tasks",
                 )

--- a/src/genesis/runtime/init/surplus.py
+++ b/src/genesis/runtime/init/surplus.py
@@ -148,6 +148,16 @@ async def init(rt: GenesisRuntime) -> None:
             logger.error("Unexpected error wiring GitHubDiscoveryJob", exc_info=True)
             await _degraded(rt, "GitHubDiscoveryJob")
 
+        # Measurement-only quality judge (surplus.quality_judge) grades insight
+        # outputs so the Outcome Bus gains a two-sided signal. Wired BEFORE start()
+        # so the router is guaranteed present before any dispatch could run (the
+        # dispatch loop is interval-triggered, never zero-delay, but wiring first
+        # removes the ordering dependency). If no router exists the judge records
+        # NULL verdicts (no-op).
+        if rt._router is not None:
+            rt._surplus_scheduler.set_judge_router(rt._router)
+            logger.info("Surplus quality judge router wired")
+
         await rt._surplus_scheduler.start()
         logger.info("Genesis surplus scheduler started")
 

--- a/src/genesis/surplus/quality_judge.py
+++ b/src/genesis/surplus/quality_judge.py
@@ -1,0 +1,203 @@
+"""Measurement-only quality judge for autonomous surplus insight tasks.
+
+Closes the surplus half of the self-learning loop's *measure* layer. Background
+insight tasks (brainstorms, audits, research) previously recorded only "did it
+run to completion" — a signal that is ~99.6% positive and therefore carries no
+discriminative information about whether the autonomous work was actually *good*.
+(The prior intake-based verdict was structurally unreachable: curated surplus
+sources skip LLM scoring and route at a fixed 0.6 confidence, so intake never
+discarded everything, so a 'hollow' verdict could never fire.)
+
+This module grades the FULL insight output with the existing eval LLM-judge
+(:class:`genesis.eval.scorers.OutputQualityScorer` + the ``output_quality``
+rubric) and maps the verdict onto the ``surplus_tasks.outcome_quality`` column
+that the Outcome Bus harvester already understands::
+
+    pass (score >= rubric threshold)  -> 'useful'
+    fail (score <  rubric threshold)  -> 'hollow'   (harvested as VERIFICATION_FAILED)
+    judge unavailable / unknown type  -> None        (no verdict; positive-only)
+
+**Measurement-only.** This does NOT change intake routing or gate anything. A
+curated source is still trusted for storage; the judge only *observes* quality so
+the bus gains a real two-sided signal. Design note: an earlier ``output_quality``
+*gate* in the ego pipeline was removed as "fragile under judge-provider outages",
+so this is deliberately never a gate — any judge outage yields a NULL verdict for
+that task (exactly like an intake failure), never a false negative.
+
+:func:`run_quality_judge` NEVER raises: a judge problem must not fail a surplus
+task that otherwise completed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from genesis.surplus.types import TaskType
+
+if TYPE_CHECKING:
+    from genesis.routing.router import Router
+
+logger = logging.getLogger(__name__)
+
+# Per-task-type description of what a GOOD output looks like — the ``expected``
+# the judge grades ``actual`` against. The Step 0 de-risk probe showed a GENERIC
+# expected prompt inflates the fail rate (it graded a structured model record as
+# "not a prose insight"), so each type gets a tailored intent string describing
+# its legitimate output shape. Only the 11 INSIGHT_PRODUCING_TASK_TYPES appear
+# here; any other task type -> no verdict (None).
+#
+# CALIBRATION NOTE: these strings are ~75%-confidence first drafts. LC3-B go-live
+# (consuming this signal to *change behaviour* via the capability aggregator)
+# stays gated on ``calibration_by_domain(source='surplus', tier=1)`` over >=30
+# graded tasks matching human intuition — validate/tune these before any flag
+# flip. Keep the keys in lockstep with surplus.types.INSIGHT_PRODUCING_TASK_TYPES.
+_JUDGE_EXPECTED: dict[TaskType, str] = {
+    TaskType.BRAINSTORM_USER: (
+        "A brainstormed idea or suggestion relevant to the user's goals, projects, "
+        "or stated interests. Good output is a specific, actionable, on-topic idea "
+        "(or small set of ideas) with enough substance to act on — not vague "
+        "platitudes or generic advice."
+    ),
+    TaskType.BRAINSTORM_SELF: (
+        "A self-improvement idea for the Genesis system itself — a concrete "
+        "capability, workflow, or architectural improvement. Good output is "
+        "specific and grounded in how Genesis actually works, not generic filler."
+    ),
+    TaskType.META_BRAINSTORM: (
+        "An insight about Genesis's own ideation process — how to generate better "
+        "ideas or steer its own cognition. Good output is a concrete, reasoned "
+        "observation, not a restatement of the prompt."
+    ),
+    TaskType.MEMORY_AUDIT: (
+        "A finding from auditing the memory system: a specific gap, inconsistency, "
+        "duplication, or health issue (or a well-supported 'healthy' conclusion). "
+        "Good output names concrete items or patterns, not vague generalities."
+    ),
+    TaskType.PROCEDURE_AUDIT: (
+        "A finding from auditing stored procedures: a specific stale, duplicate, "
+        "missing, or low-quality procedure with reasoning. Good output is concrete "
+        "and references actual procedures or patterns."
+    ),
+    TaskType.GAP_CLUSTERING: (
+        "A clustered analysis of knowledge or capability gaps — coherent themes "
+        "grouped from underlying signals, each described specifically. Good output "
+        "is a structured set of real, distinguishable gap clusters, not a flat "
+        "generic list."
+    ),
+    TaskType.SELF_UNBLOCK: (
+        "Concrete steps or a diagnosis to unblock a stuck goal or task. Good output "
+        "identifies the actual blocker and proposes specific, actionable next steps."
+    ),
+    TaskType.ANTICIPATORY_RESEARCH: (
+        "A research finding on a topic likely to become relevant, synthesized from "
+        "sources. Good output is substantive, on-topic, and informative — a real "
+        "finding or synthesis, not a raw data dump, a list of search queries, or an "
+        "off-topic tangent."
+    ),
+    TaskType.PROMPT_EFFECTIVENESS_REVIEW: (
+        "An assessment of how effective a prompt or call-site is, with specific "
+        "observations and improvement recommendations. Good output is a concrete, "
+        "evidence-based review, not a generic 'looks fine'."
+    ),
+    TaskType.CODE_AUDIT: (
+        "A code-quality, security, or architecture finding with specifics — the "
+        "file/area, the issue, and why it matters (or a well-supported 'no issues "
+        "found'). Good output is concrete and technically grounded, not vague."
+    ),
+    TaskType.WING_AUDIT: (
+        "A memory-taxonomy hygiene finding about wings/rooms — miscategorization, "
+        "sparse or overloaded domains, or structural improvements. Good output "
+        "names specific wings/rooms and concrete issues."
+    ),
+}
+
+
+async def run_quality_judge(
+    content: str,
+    task_type: TaskType | str,
+    router: Router | None,
+) -> tuple[str | None, float | None, str | None]:
+    """Grade a completed surplus insight's output; return the verdict.
+
+    Returns ``(outcome_quality, judge_score, judge_detail)`` where:
+
+    - ``outcome_quality`` is ``'useful'`` (judge passed), ``'hollow'`` (judge
+      failed → harvested as a VERIFICATION_FAILED negative), or ``None`` (no
+      verdict: missing router, unknown/non-insight task type, or judge outage).
+      Only ``'hollow'`` becomes a bus negative; ``None`` stays positive-only.
+    - ``judge_score`` is the continuous quality score in ``[0, 1]`` (for
+      calibration/display; NOT read by the harvester), or ``None``.
+    - ``judge_detail`` is the judge's JSON detail (rationale etc.), or ``None``.
+
+    NEVER raises. Every failure path yields ``(None, None, None)`` so a judge
+    problem cannot fail an otherwise-completed surplus task.
+    """
+    if router is None:
+        # No router wired (degraded init) — cannot judge; positive-only.
+        return None, None, None
+
+    # StrEnum: accept either the enum member or its string value. An unknown
+    # value (or a non-insight type absent from _JUDGE_EXPECTED) -> no verdict.
+    try:
+        tt = TaskType(task_type)
+    except ValueError:
+        return None, None, None
+
+    expected = _JUDGE_EXPECTED.get(tt)
+    if expected is None:
+        return None, None, None
+
+    try:
+        from genesis.eval.scorers import OutputQualityScorer
+
+        scorer = OutputQualityScorer(router=router)
+        passed, score, detail = await scorer.score_async(
+            actual=content,
+            expected=expected,
+            config={"rubric_name": "output_quality"},
+        )
+    except Exception:
+        # Judge infra failure — treat exactly like an intake failure: NULL.
+        logger.warning(
+            "surplus quality judge raised for task_type=%s — recording NULL verdict",
+            tt.value,
+            exc_info=True,
+        )
+        return None, None, None
+
+    # OUTAGE GUARD (critical): score_async signals judge-call and parse failures
+    # by returning passed=False with an ``"error"`` key in the detail JSON (see
+    # eval.scorers.LLMJudgeScorer.score_async — _JUDGE_CALL_FAIL / _JUDGE_PARSE_FAIL).
+    # Without this guard a provider outage would write 'hollow' for EVERY task — a
+    # false-negative flood that would poison the Outcome Bus. Match on the presence
+    # of the "error" key (not specific sentinel strings) so new error kinds stay
+    # covered. Any "error" key => no verdict (NULL).
+    try:
+        parsed = json.loads(detail) if detail else {}
+    except (json.JSONDecodeError, ValueError):
+        parsed = {}
+    # Only a dict can carry the judge's "error" sentinel. Normalize any non-dict
+    # JSON (a list/scalar — not a shape score_async produces today, but guard
+    # against a future error format silently bypassing this check) to {} so the
+    # membership test below is meaningful; absent an error dict, the passed/score
+    # verdict stands (they are score_async's authoritative signal).
+    if not isinstance(parsed, dict):
+        parsed = {}
+    if "error" in parsed:
+        logger.info(
+            "surplus quality judge unavailable (%s) for task_type=%s — NULL verdict",
+            parsed.get("error"),
+            tt.value,
+        )
+        return None, None, None
+
+    outcome_quality = "useful" if passed else "hollow"
+    logger.info(
+        "surplus quality judge: task_type=%s score=%.3f verdict=%s",
+        tt.value,
+        score,
+        outcome_quality,
+    )
+    return outcome_quality, score, detail

--- a/src/genesis/surplus/queue.py
+++ b/src/genesis/surplus/queue.py
@@ -79,12 +79,16 @@ class SurplusQueue:
         task_id: str,
         staging_id: str | None = None,
         outcome_quality: str | None = None,
+        judge_score: float | None = None,
+        judge_detail: str | None = None,
     ) -> None:
         await surplus_tasks.mark_completed(
             self._db, task_id,
             completed_at=self._clock().isoformat(),
             result_staging_id=staging_id,
             outcome_quality=outcome_quality,
+            judge_score=judge_score,
+            judge_detail=judge_detail,
         )
 
     async def mark_failed(self, task_id: str, reason: str) -> None:

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -132,6 +132,10 @@ class SurplusScheduler:
         self._github_discovery_job = None  # Set via set_github_discovery_job()
         self._extraction_store: MemoryStore | None = None
         self._extraction_router: Router | None = None
+        # Router for the measurement-only surplus quality judge (set via
+        # set_judge_router). Independent of extraction deps so the judge is
+        # available whenever a router exists; None => judge records NULL verdicts.
+        self._judge_router: Router | None = None
         self._follow_up_dispatcher = None  # Set via set_follow_up_dispatcher()
         self._topic_manager = None
         self._scheduler = AsyncIOScheduler()
@@ -236,6 +240,16 @@ class SurplusScheduler:
         """Set dependencies for the memory extraction job."""
         self._extraction_store = store
         self._extraction_router = router
+
+    def set_judge_router(self, router: Router) -> None:
+        """Wire the router used by the measurement-only surplus quality judge
+        (surplus.quality_judge).
+
+        Kept separate from set_extraction_deps so the judge is available whenever
+        a router exists, even if memory extraction was not wired. If never set
+        (degraded init with no router), the judge records NULL verdicts.
+        """
+        self._judge_router = router
 
     def set_follow_up_dispatcher(self, dispatcher) -> None:
         """Set the follow-up dispatcher for accountability tracking.
@@ -1669,11 +1683,16 @@ class SurplusScheduler:
 
         # 6. Route through intake pipeline (atomize → score → route to knowledge)
         staging_id = None
-        # Verified-correctness verdict (insight-producing types only). Stays NULL
-        # for action tasks, intake failures, and empty/too-short output — all
-        # ambiguous or not-a-quality-signal, so they keep the positive-only
-        # behaviour. Only set to 'useful'/'hollow' once intake has actually run.
+        # Verified-correctness verdict (insight-producing types only), produced by
+        # the measurement-only quality judge (surplus.quality_judge). Stays NULL for
+        # action tasks, empty/too-short output, unknown types, and judge outages —
+        # all ambiguous or not-a-quality-signal — so they keep the positive-only
+        # behaviour. 'useful' = judge passed the output; 'hollow' = judge failed it
+        # (harvested as a VERIFICATION_FAILED negative). judge_score/judge_detail
+        # persist the continuous score + rationale for calibration/display.
         outcome_quality: str | None = None
+        judge_score: float | None = None
+        judge_detail: str | None = None
         if result.insights:
             insight = result.insights[0]
             content = result.content or ""
@@ -1705,17 +1724,6 @@ class SurplusScheduler:
                         intake_stats.routed_discard,
                         task.id[:8],
                     )
-                    # Verified-correctness verdict: for insight-producing types,
-                    # intake having routed nothing to knowledge/observations means
-                    # the work ran but produced nothing of value (hollow). This is
-                    # the only path that sets the verdict — empty/too-short output
-                    # and intake failures stay NULL on purpose (see above).
-                    if task.task_type in INSIGHT_PRODUCING_TASK_TYPES:
-                        kept = (
-                            intake_stats.routed_knowledge
-                            + intake_stats.routed_observation
-                        )
-                        outcome_quality = "useful" if kept > 0 else "hollow"
                     # Use a synthetic staging_id for tracking
                     content_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
                     staging_id = f"{task.task_type.value}-{content_hash}"
@@ -1742,8 +1750,24 @@ class SurplusScheduler:
                         ttl=ttl,
                     )
 
+                # Measurement-only verified-correctness verdict. Runs whether
+                # intake succeeded or fell back (content is valid to judge either
+                # way); insight-producing types only. Grades the FULL output with
+                # the eval LLM-judge — decoupled from intake routing (curated
+                # sources stay trusted for storage; the judge only measures quality
+                # so the Outcome Bus gains a real two-sided signal). NEVER raises;
+                # a judge outage yields a NULL verdict, never a false 'hollow'.
+                if task.task_type in INSIGHT_PRODUCING_TASK_TYPES:
+                    from genesis.surplus.quality_judge import run_quality_judge
+                    outcome_quality, judge_score, judge_detail = (
+                        await run_quality_judge(
+                            content, task.task_type, self._judge_router,
+                        )
+                    )
+
         await self._queue.mark_completed(
             task.id, staging_id=staging_id, outcome_quality=outcome_quality,
+            judge_score=judge_score, judge_detail=judge_detail,
         )
 
         # Pipeline chaining — enqueue next step if this was a pipeline task.

--- a/src/genesis/surplus/types.py
+++ b/src/genesis/surplus/types.py
@@ -46,12 +46,18 @@ class TaskType(StrEnum):
 # Task types whose *success* means "produced a useful insight that belongs in the
 # knowledge base", as opposed to "an action ran to completion". Only these are
 # eligible for the verified-correctness verdict (``outcome_quality``): when one of
-# them completes but the intake pipeline routes ALL of its findings to discard
-# (nothing reached knowledge or observations), the work was hollow — it ran but
-# produced nothing of value — and the Outcome Bus records a VERIFICATION_FAILED
-# negative alongside the usual EXECUTION_OUTCOME positive.
+# them completes, its FULL output is graded by the measurement-only LLM quality
+# judge (surplus.quality_judge). 'useful' = the judge passed the output; 'hollow'
+# = the judge scored it below the output_quality threshold (it ran but produced
+# nothing of value) — and the Outcome Bus records a VERIFICATION_FAILED negative
+# alongside the usual EXECUTION_OUTCOME positive. NULL = a judge outage, a
+# non-insight type, or empty/too-short output (positive-only, not penalized).
+# (The judge REPLACED an earlier intake-routing heuristic — 'hollow' = intake
+# discarded every finding — which was structurally unreachable: curated surplus
+# sources skip scoring and route at a fixed 0.6 confidence, so intake never
+# discarded everything, so 'hollow' could never fire.)
 #
-# Deliberately EXCLUDED (would manufacture false negatives):
+# Deliberately EXCLUDED (would manufacture false negatives / are not KB-bound):
 #   - Action tasks (CODE_INDEX, MODEL_EVAL, DISK_CLEANUP, DB_MAINTENANCE,
 #     DEAD_LETTER_REPLAY, BACKUP_VERIFICATION, J9_EVAL_BATCH, FRESH_SESSION_TEST):
 #     success = the action ran; they don't target the KB, so all-discard is normal.

--- a/tests/test_db/test_migration_0043.py
+++ b/tests/test_db/test_migration_0043.py
@@ -1,0 +1,97 @@
+"""Migration 0043 — judge_score + judge_detail columns on surplus_tasks."""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+_MIG = "genesis.db.migrations.0043_surplus_judge_score"
+
+# Pre-0043 surplus_tasks: has outcome_quality (from 0041) but no judge columns.
+_OLD_DDL = """
+    CREATE TABLE surplus_tasks (
+        id                TEXT PRIMARY KEY,
+        task_type         TEXT NOT NULL,
+        compute_tier      TEXT NOT NULL,
+        priority          REAL NOT NULL DEFAULT 0.5,
+        drive_alignment   TEXT NOT NULL,
+        status            TEXT NOT NULL DEFAULT 'pending',
+        payload           TEXT,
+        created_at        TEXT NOT NULL,
+        started_at        TEXT,
+        completed_at      TEXT,
+        result_staging_id TEXT,
+        failure_reason    TEXT,
+        attempt_count     INTEGER NOT NULL DEFAULT 0,
+        not_before        TEXT,
+        outcome_quality   TEXT CHECK (outcome_quality IN ('useful', 'hollow'))
+    )
+"""
+
+
+async def _cols(conn: aiosqlite.Connection) -> set[str]:
+    cur = await conn.execute("PRAGMA table_info(surplus_tasks)")
+    return {r[1] for r in await cur.fetchall()}
+
+
+@pytest.mark.asyncio
+async def test_adds_judge_columns(tmp_path) -> None:
+    db = tmp_path / "m.db"
+    async with aiosqlite.connect(str(db)) as conn:
+        await conn.execute(_OLD_DDL)
+        await conn.commit()
+        mod = importlib.import_module(_MIG)
+        await mod.up(conn)
+        await conn.commit()
+        cols = await _cols(conn)
+        assert "judge_score" in cols
+        assert "judge_detail" in cols
+
+
+@pytest.mark.asyncio
+async def test_idempotent(tmp_path) -> None:
+    """Running up() twice must not raise (duplicate-column) or drop data."""
+    db = tmp_path / "m.db"
+    async with aiosqlite.connect(str(db)) as conn:
+        await conn.execute(_OLD_DDL)
+        await conn.commit()
+        mod = importlib.import_module(_MIG)
+        await mod.up(conn)
+        await mod.up(conn)
+        await conn.commit()
+        assert {"judge_score", "judge_detail"} <= await _cols(conn)
+
+
+@pytest.mark.asyncio
+async def test_missing_table_is_noop(tmp_path) -> None:
+    db = tmp_path / "empty.db"
+    async with aiosqlite.connect(str(db)) as conn:
+        mod = importlib.import_module(_MIG)
+        await mod.up(conn)  # no surplus_tasks table → safe no-op
+        await conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_columns_accept_judge_values(tmp_path) -> None:
+    db = tmp_path / "m.db"
+    async with aiosqlite.connect(str(db)) as conn:
+        await conn.execute(_OLD_DDL)
+        await conn.commit()
+        mod = importlib.import_module(_MIG)
+        await mod.up(conn)
+        await conn.execute(
+            "INSERT INTO surplus_tasks "
+            "(id, task_type, compute_tier, drive_alignment, created_at, status, "
+            " outcome_quality, judge_score, judge_detail) "
+            "VALUES ('t1','brainstorm_user','free_api','curiosity','2026-01-01',"
+            "'completed','hollow', 0.3, '{\"judge_score\": 0.3}')"
+        )
+        await conn.commit()
+        cur = await conn.execute(
+            "SELECT judge_score, judge_detail FROM surplus_tasks WHERE id='t1'"
+        )
+        row = await cur.fetchone()
+        assert row[0] == 0.3
+        assert "0.3" in row[1]

--- a/tests/test_surplus/test_quality_judge.py
+++ b/tests/test_surplus/test_quality_judge.py
@@ -1,0 +1,124 @@
+"""Tests for the measurement-only surplus quality judge (surplus.quality_judge).
+
+The judge grades a completed insight's FULL output with the eval LLM-judge and
+maps the verdict onto ``outcome_quality`` (useful/hollow/NULL). These tests pin
+the mapping and — critically — the OUTAGE GUARD: a judge-provider failure returns
+``passed=False`` with an ``"error"`` key, which must become a NULL verdict, never
+a false ``hollow`` (which would flood the Outcome Bus with fake negatives).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genesis.surplus.quality_judge import _JUDGE_EXPECTED, run_quality_judge
+from genesis.surplus.types import INSIGHT_PRODUCING_TASK_TYPES, TaskType
+
+pytestmark = pytest.mark.asyncio
+
+
+def _patch_scorer(passed: bool, score: float, detail: str):
+    """Patch OutputQualityScorer so score_async returns a fixed verdict."""
+    scorer = MagicMock()
+    scorer.score_async = AsyncMock(return_value=(passed, score, detail))
+    cls = MagicMock(return_value=scorer)
+    return patch("genesis.eval.scorers.OutputQualityScorer", cls)
+
+
+async def test_expected_keys_exactly_cover_insight_types():
+    # Invariant guard: every insight-producing type has an expected string and
+    # there are no extras. If someone adds a type to INSIGHT_PRODUCING_TASK_TYPES
+    # without an expected string, that type would silently get NULL verdicts.
+    assert set(_JUDGE_EXPECTED) == set(INSIGHT_PRODUCING_TASK_TYPES)
+
+
+async def test_pass_maps_to_useful():
+    detail = json.dumps({"judge_score": 0.82, "rationale": "solid, on-topic"})
+    with _patch_scorer(True, 0.82, detail):
+        oq, score, d = await run_quality_judge(
+            "a substantive real insight body ...", TaskType.BRAINSTORM_USER, object(),
+        )
+    assert oq == "useful"
+    assert score == 0.82
+    assert d == detail
+
+
+async def test_fail_maps_to_hollow():
+    detail = json.dumps({"judge_score": 0.30, "rationale": "vague filler"})
+    with _patch_scorer(False, 0.30, detail):
+        oq, score, d = await run_quality_judge(
+            "weak body", TaskType.CODE_AUDIT, object(),
+        )
+    assert oq == "hollow"
+    assert score == 0.30
+    assert d == detail
+
+
+async def test_call_fail_error_key_maps_to_null():
+    # Provider outage: score_async returns passed=False + an "error" key. This
+    # MUST become NULL, not hollow (otherwise an outage floods false negatives).
+    detail = json.dumps({"error": "judge_call_fail", "error_message": "boom"})
+    with _patch_scorer(False, 0.0, detail):
+        oq, score, d = await run_quality_judge(
+            "body", TaskType.BRAINSTORM_USER, object(),
+        )
+    assert (oq, score, d) == (None, None, None)
+
+
+async def test_parse_fail_error_key_maps_to_null():
+    detail = json.dumps({"error": "judge_parse_fail", "error_message": "bad json"})
+    with _patch_scorer(False, 0.0, detail):
+        oq, _, _ = await run_quality_judge("body", TaskType.WING_AUDIT, object())
+    assert oq is None
+
+
+async def test_scorer_raises_maps_to_null():
+    scorer = MagicMock()
+    scorer.score_async = AsyncMock(side_effect=RuntimeError("kaboom"))
+    with patch(
+        "genesis.eval.scorers.OutputQualityScorer", MagicMock(return_value=scorer),
+    ):
+        oq, score, d = await run_quality_judge(
+            "body", TaskType.BRAINSTORM_USER, object(),
+        )
+    assert (oq, score, d) == (None, None, None)
+
+
+async def test_no_router_returns_null_without_constructing_scorer():
+    with patch("genesis.eval.scorers.OutputQualityScorer") as cls:
+        oq, score, d = await run_quality_judge(
+            "body", TaskType.BRAINSTORM_USER, None,
+        )
+    assert (oq, score, d) == (None, None, None)
+    cls.assert_not_called()
+
+
+async def test_non_insight_type_returns_null_without_constructing_scorer():
+    # A type absent from _JUDGE_EXPECTED (e.g. an action/index type) short-circuits
+    # BEFORE the judge call — no LLM cost, no verdict.
+    with patch("genesis.eval.scorers.OutputQualityScorer") as cls:
+        oq, _, _ = await run_quality_judge("body", TaskType.CODE_INDEX, object())
+    assert oq is None
+    cls.assert_not_called()
+
+
+async def test_accepts_string_task_type():
+    # StrEnum: callers may pass the raw value; it must resolve to the enum.
+    detail = json.dumps({"judge_score": 0.9})
+    with _patch_scorer(True, 0.9, detail):
+        oq, _, _ = await run_quality_judge("body", "brainstorm_user", object())
+    assert oq == "useful"
+
+
+async def test_unparseable_detail_without_error_key_still_useful():
+    # Defensive: if the judge returns a real pass but detail isn't JSON we can
+    # parse, absence of an "error" key means it is NOT an outage → keep the verdict.
+    with _patch_scorer(True, 0.75, "not-json-detail"):
+        oq, score, _ = await run_quality_judge(
+            "body", TaskType.ANTICIPATORY_RESEARCH, object(),
+        )
+    assert oq == "useful"
+    assert score == 0.75

--- a/tests/test_surplus/test_scheduler.py
+++ b/tests/test_surplus/test_scheduler.py
@@ -124,7 +124,7 @@ async def test_dispatch_handles_executor_error(db):
 
 
 # --------------------------------------------------------------------------- #
-# Verified-correctness verdict (#4 — producer side)
+# Verified-correctness verdict (measurement-only quality judge — producer side)
 # --------------------------------------------------------------------------- #
 async def _completed_verdict(db) -> str | None:
     cur = await db.execute(
@@ -134,68 +134,110 @@ async def _completed_verdict(db) -> str | None:
     return row[0]
 
 
-async def _dispatch_with_intake(db, task_type, intake_stats):
-    """Dispatch one task of ``task_type`` through the stub executor with
-    ``run_intake`` patched to return ``intake_stats``; return its verdict."""
+async def _dispatch_with_judge(db, task_type, judge_return):
+    """Dispatch one ``task_type`` through the stub executor with the quality
+    judge patched to return ``judge_return``.
+
+    Intake is stubbed benign — the verdict no longer depends on intake routing
+    (it comes from the judge). Returns ``(completed_row, judge_mock)`` so callers
+    can assert the persisted columns AND whether the judge was invoked at all.
+    """
+    from genesis.surplus.intake import IntakeStats
+
     sched, compute = _make_scheduler(db, idle=True)
     await sched._queue.enqueue(task_type, ComputeTier.FREE_API, 0.8, "curiosity")
+    benign = IntakeStats(
+        findings_count=1, routed_knowledge=1, routed_observation=0, routed_discard=0,
+    )
+    judge = AsyncMock(return_value=judge_return)
     with patch.object(
         compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False,
     ), patch(
         "genesis.surplus.intake.run_intake",
-        new_callable=AsyncMock, return_value=intake_stats,
+        new_callable=AsyncMock, return_value=benign,
+    ), patch(
+        "genesis.surplus.quality_judge.run_quality_judge", judge,
     ):
         assert await sched.dispatch_once() is True
-    return await _completed_verdict(db)
-
-
-async def test_dispatch_records_hollow_when_intake_all_discard(db):
-    from genesis.surplus.intake import IntakeStats
-
-    hollow = IntakeStats(
-        findings_count=2, routed_knowledge=0, routed_observation=0, routed_discard=2,
+    cur = await db.execute(
+        "SELECT outcome_quality, judge_score, judge_detail "
+        "FROM surplus_tasks WHERE status='completed'"
     )
-    assert await _dispatch_with_intake(db, TaskType.BRAINSTORM_USER, hollow) == "hollow"
+    return await cur.fetchone(), judge
 
 
-async def test_dispatch_records_useful_when_intake_routes(db):
-    from genesis.surplus.intake import IntakeStats
-
-    useful = IntakeStats(
-        findings_count=2, routed_knowledge=1, routed_observation=0, routed_discard=1,
+async def test_dispatch_records_useful_when_judge_passes(db):
+    detail = '{"judge_score": 0.82, "rationale": "solid"}'
+    row, judge = await _dispatch_with_judge(
+        db, TaskType.BRAINSTORM_USER, ("useful", 0.82, detail),
     )
-    assert await _dispatch_with_intake(db, TaskType.BRAINSTORM_USER, useful) == "useful"
+    assert row["outcome_quality"] == "useful"
+    assert row["judge_score"] == 0.82
+    assert row["judge_detail"] == detail
+    judge.assert_awaited_once()
 
 
-async def test_dispatch_useful_via_observation_only(db):
-    # routed_observation alone (no knowledge) still counts as useful.
-    from genesis.surplus.intake import IntakeStats
-
-    obs = IntakeStats(
-        findings_count=1, routed_knowledge=0, routed_observation=1, routed_discard=0,
+async def test_dispatch_records_hollow_when_judge_fails(db):
+    row, _ = await _dispatch_with_judge(
+        db, TaskType.CODE_AUDIT, ("hollow", 0.30, '{"judge_score": 0.30}'),
     )
-    assert await _dispatch_with_intake(db, TaskType.WING_AUDIT, obs) == "useful"
+    assert row["outcome_quality"] == "hollow"
+    assert row["judge_score"] == 0.30
 
 
-async def test_dispatch_non_insight_type_stays_null(db):
-    # An action / non-insight type must NOT get a verdict even if intake discards
-    # everything — all-discard is normal for tasks that don't target the KB.
-    from genesis.surplus.intake import IntakeStats
-
-    hollow = IntakeStats(
-        findings_count=2, routed_knowledge=0, routed_observation=0, routed_discard=2,
+async def test_dispatch_judge_outage_stays_null(db):
+    # Judge unavailable → (None, None, None) → positive-only, no false hollow.
+    row, _ = await _dispatch_with_judge(
+        db, TaskType.WING_AUDIT, (None, None, None),
     )
-    assert await _dispatch_with_intake(db, TaskType.CODE_INDEX, hollow) is None
+    assert row["outcome_quality"] is None
+    assert row["judge_score"] is None
+    assert row["judge_detail"] is None
 
 
-async def test_dispatch_pipeline_intermediate_stays_null(db):
+async def test_dispatch_non_insight_type_skips_judge(db):
+    # An action / non-insight type must NOT invoke the judge (cost) and stays NULL.
+    row, judge = await _dispatch_with_judge(
+        db, TaskType.CODE_INDEX, ("hollow", 0.1, "{}"),
+    )
+    assert row["outcome_quality"] is None
+    judge.assert_not_awaited()
+
+
+async def test_dispatch_pipeline_intermediate_skips_judge(db):
     # Pipeline-intermediate output feeds the next step, not the KB; excluded.
-    from genesis.surplus.intake import IntakeStats
-
-    hollow = IntakeStats(
-        findings_count=1, routed_knowledge=0, routed_observation=0, routed_discard=1,
+    row, judge = await _dispatch_with_judge(
+        db, TaskType.RESEARCH_QUERY_GEN, ("hollow", 0.1, "{}"),
     )
-    assert await _dispatch_with_intake(db, TaskType.RESEARCH_QUERY_GEN, hollow) is None
+    assert row["outcome_quality"] is None
+    judge.assert_not_awaited()
+
+
+async def test_dispatch_short_content_skips_judge(db):
+    # Output shorter than the 50-char quality gate must NOT invoke the judge —
+    # the verdict stays NULL (too little to grade), never hollow.
+    from genesis.surplus.types import ExecutorResult
+
+    sched, compute = _make_scheduler(db, idle=True)
+    await sched._queue.enqueue(
+        TaskType.BRAINSTORM_USER, ComputeTier.FREE_API, 0.8, "curiosity",
+    )
+
+    async def _short(task):
+        return ExecutorResult(
+            success=True,
+            content="too short",
+            insights=[{"generating_model": "x"}],
+        )
+
+    sched._executor.execute = _short
+    judge = AsyncMock(return_value=("hollow", 0.1, "{}"))
+    with patch.object(
+        compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False,
+    ), patch("genesis.surplus.quality_judge.run_quality_judge", judge):
+        await sched.dispatch_once()
+    judge.assert_not_awaited()
+    assert await _completed_verdict(db) is None
 
 
 async def test_dispatch_empty_insights_stays_null(db):


### PR DESCRIPTION
## What

Background "surplus" tasks (brainstorms, audits, anticipatory research) run
autonomously and feed insights into the knowledge base. Until now the system
only recorded whether such a task *ran to completion* — a signal that is almost
always positive and says nothing about whether the produced insight was any good.

This adds a measurement-only quality judge that grades each completed insight
task's output using the existing evaluation LLM-judge (the `output_quality`
rubric) and records the verdict per task:

- **useful** — the judge passed the output
- **hollow** — the judge scored it below threshold
- **null** — no verdict (judge unavailable, non-insight task, or too-short output)

A `hollow` verdict surfaces as a verification-failed signal alongside the usual
execution-outcome, giving the system a genuine two-sided quality signal about its
own autonomous work instead of a near-constant "it ran" positive.

## Design

- **Measurement-only.** The judge does not change how insights are stored or
  routed — it only observes quality. Trusted sources stay trusted.
- **Outage-safe.** A judge-provider failure yields a null verdict, never a false
  negative, so an outage can't flood the signal with fake failures.
- **Never fails the task.** The judge runs after completion and never raises; a
  judge problem cannot fail a task that otherwise completed.

## Changes

- New `surplus/quality_judge.py` with per-task-type grading intent for the 11
  insight-producing task types.
- New `judge_score` / `judge_detail` columns on `surplus_tasks` (migration 0043)
  storing the continuous score + rationale for later calibration and display.
- Insight-task completion grades the full output and records the verdict; the
  harvester's verification-failed path is now reachable for the first time.

## Verification

- Unit tests for the judge (verdict mapping, the outage guard, task-type gating,
  the short-content skip), the migration (idempotent, additive), and the
  scheduler wiring.
- End-to-end with the real judge: two-sided on real and control content, the
  verdict persists, and the harvester emits the expected outcome signals
  (idempotent across re-runs).

## Notes

The per-task-type grading prompts are a first pass, and the signal is not yet
used to drive any behaviour — that stays behind a default-off switch pending
per-domain calibration.
