### PR TITLE
feat(cc): gmodel — foreground launcher for roster models (Phase 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **You can now start an interactive Claude Code session on a different model with one command.**
+  `gmodel <name>` launches `claude` on the model you pick: a Claude tier (`gmodel opus`) runs on
+  your normal Max subscription, while a roster peer (`gmodel glm-5.2`) runs on that provider's
+  native endpoint and its own API key. Plain `claude` is untouched. `gmodel` on its own lists the
+  models and which have keys configured; `gmodel --print-env <name>` shows what it would do without
+  launching. Your Anthropic subscription is protected — the launcher never lets a stray API key
+  quietly switch you to per-token billing, and never sends your Anthropic key to a third-party
+  endpoint. (Switch models by relaunching; each session is pinned to one model.)
 - **You can now put a model through a "gauntlet" to prove it can actually drive Claude Code
   before you rely on it.** `genesis eval gauntlet --model <name>` has the model (native Claude,
   or a routed roster peer like GLM) fix real broken Python projects inside a live Claude Code

--- a/config/cc_roster.yaml
+++ b/config/cc_roster.yaml
@@ -12,6 +12,10 @@
 # only honors the resolved fields. failover_order: lower = tried first when the
 # active model rate-limits/exhausts (0 = primary; skipped as a failover peer is
 # not done — claude IS a valid peer when something else is active).
+#
+# Interactive use: `gmodel` (scripts/gmodel) launches a foreground `claude`
+# session on any model here — `gmodel glm-5.2` (peer), `gmodel opus` (native Max
+# tier), `gmodel` alone lists them. `gmodel --print-env <name>` previews the env.
 default: claude
 # Agentic gauntlet (genesis.eval.gauntlet) — validates that a roster member can
 # still drive Claude Code through a coding fix-loop. `genesis eval gauntlet run

--- a/scripts/genesis_session_context.py
+++ b/scripts/genesis_session_context.py
@@ -54,6 +54,27 @@ def _emit(text: str) -> None:
     sys.stdout.flush()
 
 
+def _routed_session_notice(model: str | None) -> str | None:
+    """Markdown NOTICE when this interactive session is routed to a roster peer.
+
+    ``model`` is ``GENESIS_ROSTER_MODEL`` (set only by ``scripts/gmodel`` for a
+    peer). CC's baked-in "You are powered by …" identity text still says Claude
+    when the endpoint is a peer, so the self-reported ``[model]`` header would be
+    wrong — this block surfaces the true model and steers the header. Returns
+    ``None`` (no block) for a native/plain session.
+    """
+    if not model:
+        return None
+    return (
+        f"## ⚠ Routed session — running on {model}\n\n"
+        f"This CLI session is routed to **{model}** (a non-Anthropic roster peer), "
+        "NOT native Claude. Claude Code's built-in identity text still says Claude "
+        f"— ignore it; the model answering you is **{model}**. Begin your status "
+        f"header with `[{model} / <effort>]` accordingly. Note: Genesis MCP tools "
+        "may be unavailable or limited on non-Anthropic endpoints."
+    )
+
+
 def _sync_genesis_hooks() -> None:
     """Self-heal Genesis git hooks at session start.
 
@@ -265,6 +286,15 @@ def main() -> None:
                     first = False
             except (OSError, ValueError):
                 pass  # Advisory only — never block session start
+
+        # Routed-session NOTICE (advisory): surfaces when `gmodel <peer>` launched
+        # this window on a non-Anthropic roster model (see _routed_session_notice).
+        _routed_notice = _routed_session_notice(os.environ.get("GENESIS_ROSTER_MODEL"))
+        if _routed_notice:
+            if not first:
+                _emit("\n\n---\n\n")
+            _emit(_routed_notice)
+            first = False
 
     # 2.5. Active procedures (advisory, silent failure is correct)
     try:

--- a/scripts/gmodel
+++ b/scripts/gmodel
@@ -138,14 +138,11 @@ def main(argv: list[str]) -> int:
         print("Run `gmodel` (no args) to list models; tiers: opus/sonnet/haiku.", file=sys.stderr)
         return 1
 
-    claude = shutil.which("claude")
-    if not claude:
-        print("gmodel: `claude` not found on PATH.", file=sys.stderr)
-        return 127
-
     env = _build_child_env(overrides, name)
 
     if print_env:
+        # Pure diagnostic — never launches, so it must NOT require `claude` on PATH
+        # (e.g. CI, or previewing before install).
         for k in (
             "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_MODEL",
             "ANTHROPIC_DEFAULT_OPUS_MODEL", "ANTHROPIC_API_KEY", "GENESIS_ROSTER_MODEL",
@@ -157,6 +154,11 @@ def main(argv: list[str]) -> int:
         target = overrides["anthropic_base_url"] if overrides else "native Claude (Max)"
         print(f"# would exec: claude {' '.join(tier_args + passthrough)}  → {target}")
         return 0
+
+    claude = shutil.which("claude")
+    if not claude:
+        print("gmodel: `claude` not found on PATH.", file=sys.stderr)
+        return 127
 
     if overrides:
         print(f"gmodel: launching claude on {name} ({overrides['anthropic_base_url']})", file=sys.stderr)

--- a/scripts/gmodel
+++ b/scripts/gmodel
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""gmodel — launch an interactive Claude Code session on a chosen model.
+
+    gmodel                 list the roster (models, default, key status)
+    gmodel <name>          launch `claude` on <name>
+    gmodel <name> …args    pass extra args straight through to `claude`
+    gmodel --print-env <n> show the env `claude` would get, then exit (no launch)
+
+<name> is either:
+  • a Claude tier — opus / sonnet / haiku — → native `claude --model <tier>` on
+    your Max subscription (OAuth); or
+  • a roster model from config/cc_roster.yaml — `claude` (a peer runs on that
+    provider's native Anthropic endpoint + its API key).
+
+Anthropic always runs on Max (native OAuth — `ANTHROPIC_API_KEY` is dropped so a
+stray key can't silently switch you to per-token billing). A session is pinned to
+one endpoint: to change model, relaunch. Plain `claude` is untouched (native Max).
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_VENV_PYTHON = _REPO_ROOT / ".venv" / "bin" / "python"
+
+# Re-exec under the Genesis venv so `import genesis` + yaml/dotenv resolve, no
+# matter how gmodel was invoked (symlink on PATH, bare python3, etc.).
+if _VENV_PYTHON.is_file() and Path(sys.executable).resolve() != _VENV_PYTHON.resolve():
+    os.execv(str(_VENV_PYTHON), [str(_VENV_PYTHON), str(Path(__file__).resolve()), *sys.argv[1:]])
+
+# Source checkout fallback (pip -e installs also satisfy the import directly).
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+# Load secrets.env into THIS process only so peer auth_env tokens (e.g.
+# ZHIPU_API_KEY) resolve for roster.overrides_for. The child's env is built
+# explicitly below — we never blanket-forward every secret, and ANTHROPIC_API_KEY
+# is always dropped from the child.
+_SECRETS = _REPO_ROOT / "secrets.env"
+if _SECRETS.is_file():
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(str(_SECRETS), override=False)
+    except ImportError:
+        pass
+
+from genesis.cc import roster  # noqa: E402
+
+#: Native Claude tiers — resolved to `claude --model <tier>` on Max, not the roster.
+_CLAUDE_TIERS = {"opus", "sonnet", "haiku", "default"}
+
+
+def _list_models() -> int:
+    r = roster.load_roster()
+    default = roster.active_model(r)
+    models = r.get("models") or {}
+    if not models:
+        print("No roster models configured (config/cc_roster.yaml).", file=sys.stderr)
+        return 1
+    print("Models (gmodel <name> to launch):\n")
+    print("  claude tiers:  opus  sonnet  haiku   (native Max, via --model)\n")
+    print("  roster:")
+    for name in models:
+        entry = roster.resolve(name, r)
+        tags = ["default"] if name == default else []
+        if entry and (entry.native_subscription or name == roster.CLAUDE):
+            tags.append("native Max")
+        else:
+            tags.append(entry.anthropic_base_url if entry and entry.anthropic_base_url else "no endpoint")
+            key_ok = bool(entry and entry.auth_env and os.environ.get(entry.auth_env))
+            tags.append("key ✓" if key_ok else f"key ✗ ({entry.auth_env if entry else '?'})")
+        print(f"    {name:<14} {'  ·  '.join(tags)}")
+    print(f"\nDefault: {default}. Plain `claude` always runs native Max.")
+    return 0
+
+
+def _resolve(name: str) -> tuple[dict, list[str]]:
+    """Return ``(routing_overrides, tier_passthrough_args)`` for ``name``.
+
+    Raises :class:`roster.RosterError` for an unknown, non-tier name.
+    """
+    r = roster.load_roster()
+    if roster.resolve(name, r) is None and name in _CLAUDE_TIERS:
+        # Native Claude tier: no routing, launch `claude --model <tier>` (Max).
+        return {}, ([] if name == "default" else ["--model", name])
+    return roster.overrides_for(name, r), []
+
+
+def _build_child_env(overrides: dict, name: str) -> dict[str, str]:
+    env = dict(os.environ)
+    # Avoid CC-in-CC nesting confusion when launched from inside a CC session
+    # (mirrors CCInvoker._build_env / experimentation.cc_router).
+    env.pop("CLAUDECODE", None)
+    env.pop("CLAUDE_CODE_ENTRYPOINT", None)
+    # ALWAYS drop the Anthropic API key:
+    #   native → forces the Max subscription (a stray ANTHROPIC_API_KEY silently
+    #            overrides OAuth and bills per token);
+    #   peer   → credential isolation (apply_routing_env drops it again anyway).
+    env.pop("ANTHROPIC_API_KEY", None)
+    roster.apply_routing_env(
+        env,
+        base_url=overrides.get("anthropic_base_url") if overrides else None,
+        auth_token=overrides.get("anthropic_auth_token") if overrides else None,
+        model_id=overrides.get("model_id_override") if overrides else None,
+    )
+    if overrides:
+        # Tell the SessionStart hook this window is on a peer — CC's self-reported
+        # model header would otherwise say "Claude". (Native → no flag, no notice.)
+        env["GENESIS_ROSTER_MODEL"] = name
+    else:
+        env.pop("GENESIS_ROSTER_MODEL", None)
+    return env
+
+
+def main(argv: list[str]) -> int:
+    if not argv or argv[0] in ("--list",):
+        return _list_models()
+    if argv[0] in ("-h", "--help"):
+        print(__doc__)
+        return 0
+
+    print_env = False
+    if argv[0] == "--print-env":
+        print_env = True
+        argv = argv[1:]
+        if not argv:
+            print("gmodel: --print-env needs a model name.", file=sys.stderr)
+            return 2
+
+    name, *passthrough = argv
+    try:
+        overrides, tier_args = _resolve(name)
+    except roster.RosterError as exc:
+        print(f"gmodel: {exc}", file=sys.stderr)
+        print("Run `gmodel` (no args) to list models; tiers: opus/sonnet/haiku.", file=sys.stderr)
+        return 1
+
+    claude = shutil.which("claude")
+    if not claude:
+        print("gmodel: `claude` not found on PATH.", file=sys.stderr)
+        return 127
+
+    env = _build_child_env(overrides, name)
+
+    if print_env:
+        for k in (
+            "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_MODEL",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL", "ANTHROPIC_API_KEY", "GENESIS_ROSTER_MODEL",
+        ):
+            if k == "ANTHROPIC_AUTH_TOKEN":
+                print(f"{k}={'<set>' if env.get(k) else '<unset>'}")
+            else:
+                print(f"{k}={env.get(k, '<unset>')}")
+        target = overrides["anthropic_base_url"] if overrides else "native Claude (Max)"
+        print(f"# would exec: claude {' '.join(tier_args + passthrough)}  → {target}")
+        return 0
+
+    if overrides:
+        print(f"gmodel: launching claude on {name} ({overrides['anthropic_base_url']})", file=sys.stderr)
+    else:
+        label = name if name in _CLAUDE_TIERS else "native Claude"
+        print(f"gmodel: launching {label} (Max)", file=sys.stderr)
+
+    os.execve(claude, [claude, *tier_args, *passthrough], env)
+    return 0  # unreachable (execve replaces the process)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -292,33 +292,17 @@ class CCInvoker:
             env.pop("GENESIS_PARENT_SPAN_ID", None)
         if inv and inv.stream_idle_timeout_ms is not None:
             env["CLAUDE_STREAM_IDLE_TIMEOUT_MS"] = str(inv.stream_idle_timeout_ms)
-        if inv and inv.anthropic_base_url:
-            env["ANTHROPIC_BASE_URL"] = inv.anthropic_base_url
-        else:
-            env.pop("ANTHROPIC_BASE_URL", None)
-        if inv and inv.anthropic_auth_token:
-            env["ANTHROPIC_AUTH_TOKEN"] = inv.anthropic_auth_token
-        else:
-            env.pop("ANTHROPIC_AUTH_TOKEN", None)
-        # Credential isolation (defense-in-depth): the inherited ANTHROPIC_API_KEY
-        # (from secrets.env) must NEVER travel to a non-Anthropic endpoint. Pop it
-        # whenever EITHER a third-party base_url OR auth_token is being injected —
-        # not just base_url — so an inconsistent field combination can't leak the
-        # Anthropic key. Native Claude (neither set) keeps it (Max subscription).
-        if inv and (inv.anthropic_base_url or inv.anthropic_auth_token):
-            env.pop("ANTHROPIC_API_KEY", None)
-        # Roster model selection via env (NOT --model — see _build_args). Set all
-        # default-model slots so CC's background/sub-calls use the roster model too.
-        _model_vars = (
-            "ANTHROPIC_MODEL", "ANTHROPIC_DEFAULT_OPUS_MODEL",
-            "ANTHROPIC_DEFAULT_SONNET_MODEL", "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+        # Roster routing (base_url / auth_token / model slots) + credential
+        # isolation. Shared with the foreground `gmodel` launcher via
+        # roster.apply_routing_env so the contract lives in ONE place. Native
+        # Claude (no override fields) → all routing vars popped, ANTHROPIC_API_KEY
+        # kept (Max subscription) — identical to the prior inline behavior.
+        roster.apply_routing_env(
+            env,
+            base_url=inv.anthropic_base_url if inv else None,
+            auth_token=inv.anthropic_auth_token if inv else None,
+            model_id=inv.model_id_override if inv else None,
         )
-        if inv and inv.model_id_override:
-            for _mv in _model_vars:
-                env[_mv] = inv.model_id_override
-        else:
-            for _mv in _model_vars:
-                env.pop(_mv, None)
         # Move CC's Bash sandbox off /tmp (512MB tmpfs) onto persistent disk.
         # CC reads CLAUDE_CODE_TMPDIR to choose where it creates
         # /claude-<uid>/<cwd>/<session-id>/ for each Bash invocation.

--- a/src/genesis/cc/roster.py
+++ b/src/genesis/cc/roster.py
@@ -35,6 +35,56 @@ _ROSTER_FILE = "cc_roster.yaml"
 #: The native-subscription default. Never carries routing overrides.
 CLAUDE = "claude"
 
+#: Env slots that select the model for a routed Claude Code subprocess. ALL are set
+#: (not just ANTHROPIC_MODEL) so CC's background/sub-agent calls also use the peer.
+_ROSTER_MODEL_ENV_VARS = (
+    "ANTHROPIC_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+)
+
+
+def apply_routing_env(
+    env: dict[str, str],
+    *,
+    base_url: str | None,
+    auth_token: str | None,
+    model_id: str | None,
+) -> dict[str, str]:
+    """Mutate ``env`` in place to route (or un-route) a Claude Code subprocess.
+
+    Shared by :class:`~genesis.cc.invoker.CCInvoker._build_env` and the foreground
+    ``scripts/gmodel`` launcher so the routing-env contract lives in ONE place.
+
+    - Set ``ANTHROPIC_BASE_URL`` / ``ANTHROPIC_AUTH_TOKEN`` / the four model slots
+      when the corresponding value is provided; **pop** them when it is ``None`` so
+      a reused environment can never leak stale routing.
+    - **Credential isolation:** pop ``ANTHROPIC_API_KEY`` whenever routing to a peer
+      (either ``base_url`` or ``auth_token`` present) so the Anthropic key never
+      travels to a third-party endpoint. Native Claude (neither set) keeps whatever
+      the caller's env had — the caller decides Max-vs-key for the native path.
+
+    Returns ``env`` for convenience.
+    """
+    if base_url:
+        env["ANTHROPIC_BASE_URL"] = base_url
+    else:
+        env.pop("ANTHROPIC_BASE_URL", None)
+    if auth_token:
+        env["ANTHROPIC_AUTH_TOKEN"] = auth_token
+    else:
+        env.pop("ANTHROPIC_AUTH_TOKEN", None)
+    if base_url or auth_token:
+        env.pop("ANTHROPIC_API_KEY", None)
+    if model_id:
+        for _var in _ROSTER_MODEL_ENV_VARS:
+            env[_var] = model_id
+    else:
+        for _var in _ROSTER_MODEL_ENV_VARS:
+            env.pop(_var, None)
+    return env
+
 
 class RosterError(RuntimeError):
     """Roster resolution failure (unknown model, misconfig, or missing auth)."""

--- a/tests/test_cc/test_gmodel.py
+++ b/tests/test_cc/test_gmodel.py
@@ -1,0 +1,74 @@
+"""Smoke tests for the foreground `gmodel` launcher (scripts/gmodel).
+
+Exercised via subprocess with `--print-env` (a no-launch diagnostic) so the tests
+never spawn a real `claude`. Uses the repo's real config/cc_roster.yaml; the peer
+key is supplied via env so no secrets.env is required (CI-safe).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GMODEL = _REPO_ROOT / "scripts" / "gmodel"
+
+
+def _run(args, extra_env=None):
+    env = {"PATH": "/usr/bin:/bin", "HOME": str(Path.home())}
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, str(_GMODEL), *args],
+        capture_output=True, text=True, env=env, timeout=60,
+    )
+
+
+@pytest.mark.skipif(not _GMODEL.is_file(), reason="gmodel launcher not present")
+def test_list_runs_and_shows_claude():
+    r = _run(["--list"])
+    assert r.returncode == 0, r.stderr
+    assert "claude" in r.stdout
+    assert "native Max" in r.stdout
+
+
+@pytest.mark.skipif(not _GMODEL.is_file(), reason="gmodel launcher not present")
+def test_unknown_model_errors():
+    r = _run(["--print-env", "no-such-model"])
+    assert r.returncode == 1
+    assert "unknown roster model" in r.stderr
+
+
+@pytest.mark.skipif(not _GMODEL.is_file(), reason="gmodel launcher not present")
+def test_native_claude_has_no_routing_and_drops_api_key():
+    # A stray ANTHROPIC_API_KEY must be dropped so native runs on Max, not API.
+    r = _run(["--print-env", "claude"], {"ANTHROPIC_API_KEY": "sk-stray"})
+    assert r.returncode == 0, r.stderr
+    assert "ANTHROPIC_API_KEY=<unset>" in r.stdout
+    assert "ANTHROPIC_BASE_URL=<unset>" in r.stdout
+    assert "GENESIS_ROSTER_MODEL=<unset>" in r.stdout
+
+
+@pytest.mark.skipif(not _GMODEL.is_file(), reason="gmodel launcher not present")
+def test_opus_tier_is_native_with_model_flag():
+    r = _run(["--print-env", "opus"], {"ANTHROPIC_API_KEY": "sk-stray"})
+    assert r.returncode == 0, r.stderr
+    assert "ANTHROPIC_API_KEY=<unset>" in r.stdout
+    assert "claude --model opus" in r.stdout
+
+
+@pytest.mark.skipif(not _GMODEL.is_file(), reason="gmodel launcher not present")
+def test_peer_routes_and_drops_api_key():
+    # Peer key via env (no secrets.env needed). Uses the repo roster's glm-5.2.
+    r = _run(
+        ["--print-env", "glm-5.2"],
+        {"ANTHROPIC_API_KEY": "sk-stray", "ZHIPU_API_KEY": "zk-test"},
+    )
+    assert r.returncode == 0, r.stderr
+    assert "ANTHROPIC_BASE_URL=https://open.bigmodel.cn/api/anthropic" in r.stdout
+    assert "ANTHROPIC_AUTH_TOKEN=<set>" in r.stdout
+    assert "ANTHROPIC_MODEL=glm-5.2" in r.stdout
+    assert "ANTHROPIC_API_KEY=<unset>" in r.stdout  # isolation
+    assert "GENESIS_ROSTER_MODEL=glm-5.2" in r.stdout

--- a/tests/test_cc/test_roster.py
+++ b/tests/test_cc/test_roster.py
@@ -188,3 +188,54 @@ def test_user_dir_overlay_controls_default(roster_dir, tmp_path):
 def test_non_dict_config_is_ignored(tmp_path):
     (tmp_path / "cc_roster.yaml").write_text("- just\n- a\n- list\n")
     assert R.load_roster(tmp_path) == {}  # no crash on malformed config
+
+
+# --- apply_routing_env: the shared invoker/gmodel routing-env contract ----------
+
+_MODEL_SLOTS = (
+    "ANTHROPIC_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+)
+
+
+def test_apply_routing_env_peer_sets_all_and_drops_api_key():
+    env = {"ANTHROPIC_API_KEY": "sk-anthropic", "PATH": "/x"}
+    out = R.apply_routing_env(
+        env,
+        base_url="https://open.bigmodel.cn/api/anthropic",
+        auth_token="zk-secret",
+        model_id="glm-5.2",
+    )
+    assert out is env  # mutates in place
+    assert env["ANTHROPIC_BASE_URL"] == "https://open.bigmodel.cn/api/anthropic"
+    assert env["ANTHROPIC_AUTH_TOKEN"] == "zk-secret"
+    assert all(env[s] == "glm-5.2" for s in _MODEL_SLOTS)
+    assert "ANTHROPIC_API_KEY" not in env  # credential isolation
+    assert env["PATH"] == "/x"  # unrelated vars untouched
+
+
+def test_apply_routing_env_native_pops_routing_keeps_api_key():
+    # Native Claude: no override fields → all routing popped, but the Anthropic key
+    # is preserved (the caller decides Max-vs-key for the native path).
+    env = {
+        "ANTHROPIC_API_KEY": "sk-anthropic",
+        "ANTHROPIC_BASE_URL": "stale",
+        "ANTHROPIC_AUTH_TOKEN": "stale",
+        "ANTHROPIC_MODEL": "stale",
+    }
+    R.apply_routing_env(env, base_url=None, auth_token=None, model_id=None)
+    assert "ANTHROPIC_BASE_URL" not in env
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+    assert all(s not in env for s in _MODEL_SLOTS)
+    assert env["ANTHROPIC_API_KEY"] == "sk-anthropic"  # kept for native
+
+
+def test_apply_routing_env_auth_token_only_still_drops_api_key():
+    # Defense-in-depth: an inconsistent combo (token but no base_url) must still
+    # drop the Anthropic key so it can't leak to a third-party endpoint.
+    env = {"ANTHROPIC_API_KEY": "sk-anthropic"}
+    R.apply_routing_env(env, base_url=None, auth_token="zk-secret", model_id=None)
+    assert "ANTHROPIC_API_KEY" not in env
+    assert env["ANTHROPIC_AUTH_TOKEN"] == "zk-secret"

--- a/tests/test_scripts/test_session_context_routed_notice.py
+++ b/tests/test_scripts/test_session_context_routed_notice.py
@@ -1,0 +1,28 @@
+"""Tests for the routed-session NOTICE in the SessionStart hook."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve().parent.parent.parent / "scripts" / "genesis_session_context.py"
+_spec = importlib.util.spec_from_file_location("genesis_session_context", _SCRIPT_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+_routed_session_notice = _mod._routed_session_notice
+
+
+def test_native_session_has_no_notice():
+    assert _routed_session_notice(None) is None
+    assert _routed_session_notice("") is None
+
+
+def test_peer_session_notice_names_the_model_and_steers_header():
+    block = _routed_session_notice("glm-5.2")
+    assert block is not None
+    assert "glm-5.2" in block
+    assert "NOT native Claude" in block
+    # Steers the header to the true model and warns about MCP limits.
+    assert "[glm-5.2 / <effort>]" in block
+    assert "MCP" in block


### PR DESCRIPTION
## Summary

Adds `gmodel`, a foreground launcher that starts an interactive Claude Code session on a chosen model — the interactive-terminal counterpart to the server-side model diversification already shipped.

- `gmodel opus` / `gmodel sonnet` / `gmodel haiku` → native `claude --model <tier>` on the **Max subscription** (OAuth).
- `gmodel glm-5.2` (or any roster peer) → `claude` pointed at that provider's **native Anthropic endpoint** + its own API key.
- `gmodel` (no args) → lists the roster and which peers have keys configured.
- `gmodel --print-env <name>` → shows the resolved child env **without launching** (no spend).
- Plain `claude` is completely untouched (native Max).

## Subscription safety

`ANTHROPIC_API_KEY` is dropped from the child env in **every** path:
- **native** → forces the Max subscription (a stray `ANTHROPIC_API_KEY` silently switches Claude Code to per-token API billing);
- **peer** → credential isolation (the Anthropic key never travels to a third-party endpoint).

## Implementation notes

- Routing-env logic is extracted from `CCInvoker._build_env` into `roster.apply_routing_env`, shared by the invoker and `gmodel` (behavior-neutral for the invoker — existing `_build_env` tests unchanged and green).
- A peer window is honest about its model: `gmodel` sets `GENESIS_ROSTER_MODEL`, and the SessionStart hook emits a **"⚠ Routed session"** notice (Claude Code's self-reported model header would otherwise say "Claude", since CC can't tell the endpoint changed).
- Switching model = relaunch; a session is pinned to one endpoint (cross-provider live-switch would break Max and is unsafe to resume anyway).

## Testing

- New: `apply_routing_env` (peer/native/isolation), `gmodel` smoke tests (list/unknown/native/tier/peer via `--print-env`), routed-notice helper.
- Affected-package sweep: 646 passed, 2 skipped (`tests/test_cc/`, `tests/test_scripts/`).
- E2E: `gmodel claude -p …` launched a real Max session (self-identified Opus 4.8); the routed notice fires with `GENESIS_ROSTER_MODEL` set and is absent without it.
- Live peer (GLM) session deferred to provider-balance recharge; routing env verified via `--print-env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)