### PR TITLE
feat(attention): PR2 — dashboard Attention review/label tab (calibration cockpit)

### DIFF
--- a/src/genesis/attention/runner.py
+++ b/src/genesis/attention/runner.py
@@ -131,6 +131,16 @@ def print_report(r: ShadowReport) -> None:
         print(f"             text: {s['text'][:150]!r}")
 
 
+def _snapshot_id_from_path(path: Path) -> str:
+    """Canonical BARE snapshot_id from a snapshot filename.
+
+    ``pull_snapshot()`` names files ``ambient_{id}.db`` but stores the bare ``id`` in
+    ``attention_events.snapshot_id`` / ``window_ref``. So ``--snapshot`` must strip the
+    ``ambient_`` prefix to match — otherwise the dashboard reveal (which reconstructs
+    ``ambient_{snapshot_id}.db``) would look for ``ambient_ambient_...db`` and 410."""
+    return path.stem.removeprefix("ambient_")
+
+
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     ap = argparse.ArgumentParser(description="Attention engine offline shadow runner")
@@ -149,7 +159,7 @@ async def _run_cli(args) -> None:
     logger.info("config version=%s aliases=%s domain_kw=%d", cfg.version, cfg.aliases, len(cfg.domain_keywords))
     if args.snapshot:
         path = Path(args.snapshot).expanduser()
-        sid = path.stem
+        sid = _snapshot_id_from_path(path)
     else:
         sid, path = await pull_snapshot()
 

--- a/src/genesis/attention/sources.py
+++ b/src/genesis/attention/sources.py
@@ -9,11 +9,14 @@ import json
 import logging
 import re
 import sqlite3
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 
+import aiosqlite
+
 from genesis.attention.clarity import frac_below
+from genesis.attention.snapshot import _DEFAULT_DEST as _SNAPSHOTS_DIR
 from genesis.attention.types import AmbientUtterance
 
 logger = logging.getLogger(__name__)
@@ -74,6 +77,57 @@ def row_to_utterance(row: dict) -> AmbientUtterance | None:
         mode_state="unknown",  # ambient_transcripts carries no interaction-plane state
         source=row.get("source") or "",
     )
+
+
+async def resolve_window_text(
+    snapshot_id: str,
+    utt_ids: Sequence[int],
+    *,
+    snapshots_dir: str | Path | None = None,
+) -> list[dict] | None:
+    """Resolve a window's transcript text from the TRANSIENT snapshot, for the reveal UI.
+
+    Reads a transient read-only analysis snapshot — NOT genesis.db — so this raw SQL is
+    intentionally outside the "crud-layer only" rule (that rule guards genesis.db). The
+    firewall keeps transcript text off genesis.db; this returns it live to an authenticated
+    caller and persists nothing.
+
+    Returns the window's utterances (ts-ordered; ``is_trigger`` marks the last ``utt_id``,
+    the utterance the event fired on), or ``None`` if the snapshot file is gone (purged) —
+    the route turns ``None`` into a 410. A purged snapshot is permanent: that labeled event
+    becomes review-read-only. Do NOT add snapshot auto-purge without addressing this."""
+    base = Path(snapshots_dir).expanduser() if snapshots_dir else Path(_SNAPSHOTS_DIR).expanduser()
+    # pull_snapshot() writes ``ambient_{id}.db`` + stores the bare id; tolerate either form.
+    path = next(
+        (p for p in (base / f"ambient_{snapshot_id}.db", base / f"{snapshot_id}.db") if p.exists()),
+        None,
+    )
+    if path is None:
+        return None
+    ids = [int(i) for i in utt_ids]  # reject non-int; keep the IN() list parametrized
+    if not ids:
+        return []
+    trigger_id = ids[-1]
+    placeholders = ",".join("?" for _ in ids)
+    conn = await aiosqlite.connect(f"file:{path}?mode=ro", uri=True)
+    conn.row_factory = aiosqlite.Row
+    try:
+        cur = await conn.execute(
+            f"SELECT id, ts, text, speaker_label, is_user FROM ambient_transcripts "  # noqa: S608
+            f"WHERE id IN ({placeholders}) ORDER BY ts, id",
+            ids,
+        )
+        rows = await cur.fetchall()
+    finally:
+        await conn.close()
+    return [
+        {
+            "id": r["id"], "ts": r["ts"], "text": r["text"],
+            "speaker_label": r["speaker_label"], "is_user": r["is_user"],
+            "is_trigger": r["id"] == trigger_id,
+        }
+        for r in rows
+    ]
 
 
 class SnapshotSource:

--- a/src/genesis/dashboard/routes/__init__.py
+++ b/src/genesis/dashboard/routes/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from genesis.dashboard.routes import (
     activity,
+    attention,
     autonomy,
     backup,
     budget,
@@ -48,6 +49,7 @@ from genesis.dashboard.routes import (
 
 __all__ = [
     "activity",
+    "attention",
     "autonomy",
     "backup",
     "budget",

--- a/src/genesis/dashboard/routes/attention.py
+++ b/src/genesis/dashboard/routes/attention.py
@@ -1,0 +1,187 @@
+"""Attention-engine shadow-review routes — the PR2 calibration cockpit.
+
+Live, access-controlled view of ``attention_events`` (the offline shadow gate's decisions):
+list + per-trigger stats (value-free, refs only), an explicit reveal of the window's
+transcript text (resolved from the TRANSIENT snapshot, never genesis.db), and a
+should/shouldn't/skip label write-back that feeds PR3's retune.
+
+Security model (mirrors ``references.py``):
+- Every route is gated with ``is_authenticated()`` (a NO-OP when ``DASHBOARD_PASSWORD`` is
+  unset, enforced 403 when set) — the same deliberate, narrow exception to the dashboard's
+  "API routes bypass auth" default. ``reveal-text`` returns ambient household conversation
+  text, so it gets the same protection as references' secret reveal; the lockdown lever is
+  setting ``DASHBOARD_PASSWORD`` (which gates the whole UI). list/stats are value-free.
+- The firewall holds: list/stats never open a snapshot; only ``reveal-text`` reads the
+  transient snapshot, and it persists nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from flask import jsonify, request
+
+from genesis.dashboard._blueprint import _async_route, blueprint
+from genesis.dashboard.auth import is_authenticated
+
+logger = logging.getLogger(__name__)
+
+
+def _auth_or_403():
+    """Return a 403 response tuple if not authenticated, else None."""
+    if not is_authenticated():
+        return jsonify({"error": "authentication required"}), 403
+    return None
+
+
+def _loads(raw, default):
+    """Best-effort JSON parse for a stored column; ``default`` on empty/corrupt."""
+    if not raw:
+        return default
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return default
+
+
+def _event_summary(row: dict) -> dict:
+    """Value-free event dict (refs + features + label) with the JSON columns parsed.
+
+    ``window_ref`` carries ids + ts range (snapshot_id, utt_ids) — a reference, never text."""
+    return {
+        "id": row.get("id"),
+        "ts": row.get("ts"),
+        "session_id": row.get("session_id"),
+        "activation": row.get("activation"),
+        "score": row.get("score"),
+        "clarity": row.get("clarity"),
+        "mode_state": row.get("mode_state"),
+        "triggers_fired": _loads(row.get("triggers_fired"), []),
+        "suppressors": _loads(row.get("suppressors"), []),
+        "window_ref": _loads(row.get("window_ref"), {}),
+        "l15_verdict": _loads(row.get("l15_verdict"), None),
+        "acceptance_signal": row.get("acceptance_signal"),
+        "snapshot_id": row.get("snapshot_id"),
+        "config_version": row.get("config_version"),
+        "created_at": row.get("created_at"),
+    }
+
+
+@blueprint.route("/api/genesis/attention/list")
+@_async_route
+async def attention_list():
+    """List shadow events (newest first), filtered. Never returns transcript text."""
+    if (resp := _auth_or_403()) is not None:
+        return resp
+    from genesis.db.crud import attention as attention_crud
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"error": "Not bootstrapped"}), 503
+
+    activation = request.args.get("activation") or None
+    trigger = request.args.get("trigger") or None
+    is_user = request.args.get("is_user", "").lower() == "true"
+    unlabeled = request.args.get("unlabeled", "").lower() == "true"
+    limit = max(1, min(request.args.get("limit", 200, type=int), 500))
+    offset = max(0, request.args.get("offset", 0, type=int))
+
+    try:
+        rows = await attention_crud.list_events(
+            rt.db, activation=activation, trigger=trigger, is_user=is_user,
+            unlabeled=unlabeled, limit=limit, offset=offset,
+        )
+        events = [_event_summary(r) for r in rows]
+        return jsonify({"events": events, "count": len(events)})
+    except Exception:
+        logger.exception("Attention list failed")
+        return jsonify({"error": "Failed to list attention events"}), 500
+
+
+@blueprint.route("/api/genesis/attention/stats")
+@_async_route
+async def attention_stats():
+    """Aggregate counts for the cockpit panel: labels, activation, per-trigger, suppressors."""
+    if (resp := _auth_or_403()) is not None:
+        return resp
+    from genesis.db.crud import attention as attention_crud
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"error": "Not bootstrapped"}), 503
+
+    try:
+        return jsonify({
+            "labels": await attention_crud.label_counts(rt.db),
+            "by_activation": await attention_crud.activation_stats(rt.db),
+            "by_trigger": await attention_crud.trigger_stats(rt.db),
+            "by_suppressor": await attention_crud.suppressor_stats(rt.db),
+        })
+    except Exception:
+        logger.exception("Attention stats failed")
+        return jsonify({"error": "Failed to fetch attention stats"}), 500
+
+
+@blueprint.route("/api/genesis/attention/<event_id>/reveal-text", methods=["POST"])
+@_async_route
+async def attention_reveal_text(event_id: str):
+    """Reveal the window's transcript text from the transient snapshot. Auth-gated.
+
+    410 when the snapshot has been purged (the event is then review-read-only)."""
+    if (resp := _auth_or_403()) is not None:
+        return resp
+    from genesis.attention import sources
+    from genesis.db.crud import attention as attention_crud
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"error": "Not bootstrapped"}), 503
+
+    try:
+        row = await attention_crud.get_event(rt.db, event_id)
+        if row is None:
+            return jsonify({"error": "Event not found"}), 404
+        wr = _loads(row.get("window_ref"), {})
+        snapshot_id = wr.get("snapshot_id")
+        utt_ids = wr.get("utt_ids") or []
+        if not snapshot_id:
+            return jsonify({"error": "Event has no resolvable window_ref"}), 422
+        window = await sources.resolve_window_text(snapshot_id, utt_ids)
+        if window is None:
+            return jsonify({"error": "snapshot unavailable (purged)"}), 410
+        return jsonify({"id": event_id, "window": window})
+    except Exception:
+        logger.exception("Attention reveal-text failed")
+        return jsonify({"error": "Reveal failed"}), 500
+
+
+@blueprint.route("/api/genesis/attention/<event_id>/label", methods=["POST"])
+@_async_route
+async def attention_label(event_id: str):
+    """Write a should/shouldn't/skip review label. Returns the prior value (for X->Y)."""
+    if (resp := _auth_or_403()) is not None:
+        return resp
+    from genesis.db.crud import attention as attention_crud
+    from genesis.runtime import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if not rt.is_bootstrapped or rt.db is None:
+        return jsonify({"error": "Not bootstrapped"}), 503
+
+    data = request.get_json(silent=True) or {}
+    signal = data.get("acceptance_signal")
+    try:
+        found, prior = await attention_crud.update_acceptance_signal(rt.db, event_id, signal)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    except Exception:
+        logger.exception("Attention label failed")
+        return jsonify({"error": "Label failed"}), 500
+
+    if not found:
+        return jsonify({"error": "Event not found"}), 404
+    return jsonify({"status": "ok", "id": event_id, "acceptance_signal": signal, "prior": prior})

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -1641,7 +1641,9 @@
             if (resp && resp.ok) {
               this.attentionRevealed = { ...this.attentionRevealed, [id]: (await resp.json()).window || [] };
             } else if (resp && resp.status === 410) {
-              this.attentionRevealed = { ...this.attentionRevealed, [id]: "unavailable" };
+              this.attentionRevealed = { ...this.attentionRevealed, [id]: "snapshot no longer available — this event is review-read-only." };
+            } else {
+              this.attentionRevealed = { ...this.attentionRevealed, [id]: `reveal failed (${resp ? resp.status : "network error"})` };
             }
           } catch (e) { console.warn("Attention reveal failed:", e); }
         },
@@ -10710,8 +10712,8 @@
             <!-- Revealed window (from the transient snapshot) -->
             <template x-if="$store.genesisDashboard.attentionRevealed[ev.id] !== undefined">
               <div style="margin-top:.5rem; background:var(--color-panel); border-radius:4px; padding:.5rem .6rem;">
-                <template x-if="$store.genesisDashboard.attentionRevealed[ev.id] === 'unavailable'">
-                  <div style="font-size:.8em; color:var(--color-warning-text);">snapshot no longer available — this event is review-read-only.</div>
+                <template x-if="typeof $store.genesisDashboard.attentionRevealed[ev.id] === 'string'">
+                  <div style="font-size:.8em; color:var(--color-warning-text);" x-text="$store.genesisDashboard.attentionRevealed[ev.id]"></div>
                 </template>
                 <template x-if="Array.isArray($store.genesisDashboard.attentionRevealed[ev.id])">
                   <div style="display:flex; flex-direction:column; gap:.25rem;">

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -26,7 +26,7 @@
       Alpine.store("genesisDashboard", {
         // Tab state
         activeTab: "overview",
-        _tabInitialized: { overview: false, chat: false, internals: false, config: false, files: false, work: false, "follow-ups": false, observations: false, traces: false, autonomy: false, memory: false, knowledge: false, campaigns: false, references: false, backup: false },
+        _tabInitialized: { overview: false, chat: false, internals: false, config: false, files: false, work: false, "follow-ups": false, observations: false, traces: false, autonomy: false, memory: false, knowledge: false, campaigns: false, references: false, attention: false, backup: false },
         // ── Campaigns tab state ──
         campaignsList: [],
         campaignsMutating: {},
@@ -236,6 +236,12 @@
         referenceStats: null,
         referenceDetail: null,
         revealedValues: {},
+        // ── Attention review tab state ──
+        attentionEvents: [],
+        attentionStats: null,
+        attentionFilters: { activation: "", trigger: "", is_user: false, unlabeled: true },
+        attentionRevealed: {},   // {event_id: [window rows] | "unavailable"}
+        attentionLabeling: {},   // {event_id: true} while a label POST is in flight
 
         // ── Confirm modal state ──────────────────────────────────
         confirmModal: { show: false, title: '', message: '', _resolve: null },
@@ -452,7 +458,7 @@
 
         initTab() {
           const hash = location.hash.replace("#", "") || "overview";
-          const valid = ["overview", "chat", "internals", "config", "files", "work", "follow-ups", "observations", "traces", "autonomy", "memory", "knowledge", "campaigns", "references", "backup"];
+          const valid = ["overview", "chat", "internals", "config", "files", "work", "follow-ups", "observations", "traces", "autonomy", "memory", "knowledge", "campaigns", "references", "attention", "backup"];
           this.activeTab = valid.includes(hash) ? hash : "overview";
           window.addEventListener("hashchange", () => {
             const h = location.hash.replace("#", "");
@@ -540,6 +546,9 @@
               break;
             case "references":
               if (first) { this.fetchReferenceList(); this.fetchReferenceStats(); }
+              break;
+            case "attention":
+              if (first) { this.fetchAttentionEvents(); this.fetchAttentionStats(); }
               break;
             case "backup":
               if (first) { this.fetchBackupStatus(); this.fetchBackupConfig(); this.fetchUpdateStatus(); this.fetchUpdateProgress(); }
@@ -1602,6 +1611,70 @@
           if (sp === "reference_store") return "verified";
           if (sp === "extraction_job") return "auto-captured";
           return sp || "unknown";
+        },
+
+        // ── Attention review tab ─────────────────────────────────
+        _attentionQuery() {
+          const f = this.attentionFilters;
+          const p = new URLSearchParams();
+          if (f.activation) p.set("activation", f.activation);
+          if (f.trigger) p.set("trigger", f.trigger);
+          if (f.is_user) p.set("is_user", "true");
+          if (f.unlabeled) p.set("unlabeled", "true");
+          return p.toString();
+        },
+        async fetchAttentionEvents() {
+          try {
+            const resp = await fetchApi(`/api/genesis/attention/list?${this._attentionQuery()}`);
+            if (resp && resp.ok) { this.attentionEvents = (await resp.json()).events || []; }
+          } catch (e) { console.warn("Attention list failed:", e); }
+        },
+        async fetchAttentionStats() {
+          try {
+            const resp = await fetchApi("/api/genesis/attention/stats");
+            if (resp && resp.ok) { this.attentionStats = await resp.json(); }
+          } catch (e) { console.warn("Attention stats failed:", e); }
+        },
+        async revealAttentionText(id) {
+          try {
+            const resp = await fetchApi(`/api/genesis/attention/${encodeURIComponent(id)}/reveal-text`, { method: "POST" });
+            if (resp && resp.ok) {
+              this.attentionRevealed = { ...this.attentionRevealed, [id]: (await resp.json()).window || [] };
+            } else if (resp && resp.status === 410) {
+              this.attentionRevealed = { ...this.attentionRevealed, [id]: "unavailable" };
+            }
+          } catch (e) { console.warn("Attention reveal failed:", e); }
+        },
+        hideAttentionText(id) {
+          const copy = { ...this.attentionRevealed }; delete copy[id]; this.attentionRevealed = copy;
+        },
+        async labelAttentionEvent(id, signal) {
+          this.attentionLabeling = { ...this.attentionLabeling, [id]: true };
+          try {
+            const resp = await fetchApi(`/api/genesis/attention/${encodeURIComponent(id)}/label`, {
+              method: "POST", headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ acceptance_signal: signal }),
+            });
+            if (resp && resp.ok) {
+              const ev = this.attentionEvents.find(e => e.id === id);
+              if (ev) ev.acceptance_signal = signal;
+              if (this.attentionFilters.unlabeled) {
+                this.attentionEvents = this.attentionEvents.filter(e => e.id !== id);
+              }
+              this.hideAttentionText(id);
+              this.fetchAttentionStats();
+            }
+          } catch (e) { console.warn("Attention label failed:", e); }
+          finally { const m = { ...this.attentionLabeling }; delete m[id]; this.attentionLabeling = m; }
+        },
+        _attentionMaxTrigger() {
+          const t = this.attentionStats?.by_trigger || {};
+          return Math.max(1, ...Object.values(t));
+        },
+        _attnActivationColor(a) {
+          if (a === "hard") return "var(--color-primary)";
+          if (a === "suppressed") return "var(--color-text-secondary)";
+          return "var(--color-warning-text)";
         },
 
         // ── Knowledge upload methods ────────────────────────────
@@ -4534,6 +4607,8 @@
               @click="location.hash = 'campaigns'">Campaigns</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'references' }"
               @click="location.hash = 'references'">References</button>
+      <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'attention' }"
+              @click="location.hash = 'attention'">Attention</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'files' }"
               @click="location.hash = 'files'">Files</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'config' }"
@@ -10521,6 +10596,138 @@
           </div>
         </div>
       </template>
+      </div><!-- /panel-body padding -->
+    </div>
+
+    <!-- ═══════════════════════════════════════════════════════════
+         Panel: Attention Review [Tab: attention]
+         ═══════════════════════════════════════════════════════════ -->
+    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'attention'" style="overflow-y: auto; max-height: calc(100vh - 180px);">
+      <div class="panel-header">
+        <span class="material-symbols-outlined">hearing</span>
+        Attention Review
+      </div>
+      <div style="padding: 1rem;">
+
+      <div style="margin-bottom: 1rem; color: var(--color-text-secondary); font-size: .85em;">
+        Shadow decisions from the passive-listening attention gate — what it <em>would</em> have perked up on.
+        Nothing here speaks or acts. Reveal a window's transcript, then label it should / shouldn't / skip to
+        tune the gate. Transcript text is read live from the local snapshot; it is never stored here.
+      </div>
+
+      <!-- Stats -->
+      <div style="display: flex; gap: 1rem; margin-bottom: 1rem; flex-wrap: wrap;">
+        <div style="flex: 1; min-width: 90px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
+          <div style="font-size: 1.4rem; font-weight: 700;" x-text="$store.genesisDashboard.attentionStats?.labels?.total ?? '—'"></div>
+          <div style="font-size: .75rem; color: var(--color-text-secondary);">Events</div>
+        </div>
+        <div style="flex: 1; min-width: 90px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
+          <div style="font-size: 1.4rem; font-weight: 700; color: var(--color-primary);" x-text="$store.genesisDashboard.attentionStats?.labels?.labeled ?? 0"></div>
+          <div style="font-size: .75rem; color: var(--color-text-secondary);">Labeled</div>
+        </div>
+        <div style="flex: 1; min-width: 90px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
+          <div style="font-size: 1.4rem; font-weight: 700; color: var(--color-warning-text);" x-text="$store.genesisDashboard.attentionStats?.labels?.unlabeled ?? 0"></div>
+          <div style="font-size: .75rem; color: var(--color-text-secondary);">Unlabeled</div>
+        </div>
+      </div>
+
+      <!-- Per-trigger dominance bar -->
+      <template x-if="$store.genesisDashboard.attentionStats && Object.keys($store.genesisDashboard.attentionStats.by_trigger||{}).length">
+        <div style="margin-bottom: 1.25rem;">
+          <div style="font-size:.75rem; color:var(--color-text-secondary); margin-bottom:.35rem;">Trigger fire counts (dominance)</div>
+          <div style="display:flex; flex-direction:column; gap:.25rem;">
+            <template x-for="[name, n] in Object.entries($store.genesisDashboard.attentionStats.by_trigger)" :key="name">
+              <div style="display:flex; align-items:center; gap:.5rem;">
+                <span style="width:120px; font-size:.72rem; text-align:right; color:var(--color-text-secondary);" x-text="name"></span>
+                <div style="flex:1; background:var(--color-panel); border-radius:3px; overflow:hidden; height:14px;">
+                  <div :style="`height:100%; background:var(--color-primary); width:${Math.round(100*n/$store.genesisDashboard._attentionMaxTrigger())}%;`"></div>
+                </div>
+                <span style="width:38px; font-size:.72rem;" x-text="n"></span>
+              </div>
+            </template>
+          </div>
+        </div>
+      </template>
+
+      <!-- Filters -->
+      <div style="margin-bottom: 1rem; display: flex; gap: .5rem; flex-wrap: wrap; align-items:center;">
+        <select x-model="$store.genesisDashboard.attentionFilters.activation" @change="$store.genesisDashboard.fetchAttentionEvents()"
+                style="padding: .4rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
+          <option value="">All activations</option>
+          <option value="hard">hard</option>
+          <option value="soft">soft</option>
+          <option value="suppressed">suppressed</option>
+        </select>
+        <select x-model="$store.genesisDashboard.attentionFilters.trigger" @change="$store.genesisDashboard.fetchAttentionEvents()"
+                style="padding: .4rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
+          <option value="">All triggers</option>
+          <template x-for="name in Object.keys($store.genesisDashboard.attentionStats?.by_trigger || {})" :key="name">
+            <option :value="name" x-text="name"></option>
+          </template>
+        </select>
+        <label style="font-size:.8rem; display:flex; align-items:center; gap:.3rem;">
+          <input type="checkbox" x-model="$store.genesisDashboard.attentionFilters.is_user" @change="$store.genesisDashboard.fetchAttentionEvents()"> is_user
+        </label>
+        <label style="font-size:.8rem; display:flex; align-items:center; gap:.3rem;">
+          <input type="checkbox" x-model="$store.genesisDashboard.attentionFilters.unlabeled" @change="$store.genesisDashboard.fetchAttentionEvents()"> unlabeled only
+        </label>
+        <button @click="$store.genesisDashboard.fetchAttentionEvents(); $store.genesisDashboard.fetchAttentionStats()" class="btn-sm">Refresh</button>
+      </div>
+
+      <!-- Events -->
+      <template x-if="$store.genesisDashboard.attentionEvents.length === 0">
+        <p style="color: var(--color-text-secondary);">No attention events match. Populate with <code>python -m genesis.attention.runner --persist</code>.</p>
+      </template>
+      <div style="display:flex; flex-direction:column; gap:.5rem;">
+        <template x-for="ev in $store.genesisDashboard.attentionEvents" :key="ev.id">
+          <div style="background: var(--color-background); border: 1px solid var(--color-border); border-radius: 6px; padding: .6rem .75rem;">
+            <div style="display:flex; justify-content:space-between; align-items:center; gap:.5rem; flex-wrap:wrap;">
+              <div style="display:flex; align-items:center; gap:.4rem; flex-wrap:wrap;">
+                <span style="font-size:.6rem; padding:1px 6px; border-radius:3px; text-transform:uppercase; font-weight:700;"
+                      :style="`color:${$store.genesisDashboard._attnActivationColor(ev.activation)}; background:${$store.genesisDashboard._attnActivationColor(ev.activation)}22;`"
+                      x-text="ev.activation"></span>
+                <span style="font-size:.72rem; color:var(--color-text-secondary);" x-text="'score ' + (typeof ev.score === 'number' ? ev.score.toFixed(2) : ev.score)"></span>
+                <span style="font-size:.72rem; color:var(--color-text-secondary);" x-text="(ev.ts||'').substring(0,19).replace('T',' ')"></span>
+                <template x-for="t in (ev.triggers_fired||[])" :key="t.name">
+                  <span style="font-size:.6rem; padding:1px 5px; border-radius:3px; background:var(--color-panel);" x-text="t.name"></span>
+                </template>
+                <span x-show="ev.acceptance_signal" style="font-size:.6rem; padding:1px 6px; border-radius:3px; color:var(--color-primary); background:var(--color-primary)22;" x-text="ev.acceptance_signal"></span>
+              </div>
+              <div style="display:flex; gap:.3rem; align-items:center; flex-shrink:0;">
+                <button class="btn-sm" style="padding:.15rem .4rem;"
+                        @click="$store.genesisDashboard.attentionRevealed[ev.id] !== undefined ? $store.genesisDashboard.hideAttentionText(ev.id) : $store.genesisDashboard.revealAttentionText(ev.id)">
+                  <span class="material-symbols-outlined" style="font-size:1rem; vertical-align:middle;"
+                        x-text="$store.genesisDashboard.attentionRevealed[ev.id] !== undefined ? 'visibility_off' : 'visibility'"></span>
+                </button>
+                <button class="btn-sm" style="padding:.15rem .5rem;" :disabled="$store.genesisDashboard.attentionLabeling[ev.id]"
+                        @click="$store.genesisDashboard.labelAttentionEvent(ev.id, 'should')">should</button>
+                <button class="btn-sm" style="padding:.15rem .5rem;" :disabled="$store.genesisDashboard.attentionLabeling[ev.id]"
+                        @click="$store.genesisDashboard.labelAttentionEvent(ev.id, 'shouldnt')">shouldn't</button>
+                <button class="btn-sm" style="padding:.15rem .5rem; opacity:.7;" :disabled="$store.genesisDashboard.attentionLabeling[ev.id]"
+                        @click="$store.genesisDashboard.labelAttentionEvent(ev.id, 'skip')">skip</button>
+              </div>
+            </div>
+            <!-- Revealed window (from the transient snapshot) -->
+            <template x-if="$store.genesisDashboard.attentionRevealed[ev.id] !== undefined">
+              <div style="margin-top:.5rem; background:var(--color-panel); border-radius:4px; padding:.5rem .6rem;">
+                <template x-if="$store.genesisDashboard.attentionRevealed[ev.id] === 'unavailable'">
+                  <div style="font-size:.8em; color:var(--color-warning-text);">snapshot no longer available — this event is review-read-only.</div>
+                </template>
+                <template x-if="Array.isArray($store.genesisDashboard.attentionRevealed[ev.id])">
+                  <div style="display:flex; flex-direction:column; gap:.25rem;">
+                    <template x-for="u in $store.genesisDashboard.attentionRevealed[ev.id]" :key="u.id">
+                      <div :style="u.is_trigger ? 'font-size:.82em; font-weight:600; color:var(--color-text);' : 'font-size:.82em; color:var(--color-text-secondary);'">
+                        <span style="font-size:.7em; opacity:.7;" x-text="(u.speaker_label||'') + (u.is_user===1?' ·you':'') + '  '"></span>
+                        <span x-text="u.text"></span>
+                      </div>
+                    </template>
+                  </div>
+                </template>
+              </div>
+            </template>
+          </div>
+        </template>
+      </div>
       </div><!-- /panel-body padding -->
     </div>
 

--- a/src/genesis/db/crud/attention.py
+++ b/src/genesis/db/crud/attention.py
@@ -2,8 +2,13 @@
 
 Rows are attention DECISIONS + REFERENCES + labels ONLY (activation/score/
 triggers_fired/window_ref/clarity); NEVER ambient transcript text (firewall). The
-offline shadow runner is the only writer; a future dashboard tab (PR2) reads for the
-should/shouldn't review + offline calibration.
+offline shadow runner writes; the dashboard "Attention" tab (PR2) reads for the
+should/shouldn't review + offline calibration, and writes back ``acceptance_signal``.
+
+All reads assume ``db.row_factory = aiosqlite.Row`` (the runtime's ``rt.db`` sets it);
+they return plain dicts. Filter/aggregate queries key off ``json_each``/``json_extract``
+on the JSON columns (exact name match — NEVER a ``LIKE`` substring, which would false-match
+the ``kind`` values and JSON keys).
 """
 from __future__ import annotations
 
@@ -16,16 +21,30 @@ COLUMNS = (
     "snapshot_id", "config_version", "created_at",
 )
 
+# On a re-run over the same snapshot+config the row id collides. Refresh the derived
+# columns, but NEVER touch a human label (``acceptance_signal``) or the first-seen time
+# (``created_at``) — the WHERE guard below makes the whole UPDATE a no-op for labeled rows.
+_UPSERT_SET_COLS = tuple(c for c in COLUMNS if c not in ("id", "acceptance_signal", "created_at"))
+
+# The only valid review labels (mirrors the plan's should/shouldn't/skip).
+LABELS = ("should", "shouldnt", "skip")
+
 
 async def bulk_upsert_events(db: aiosqlite.Connection, rows: list[tuple]) -> int:
-    """Idempotent bulk INSERT OR REPLACE of shadow AttentionEvents. ``rows`` are tuples
-    in ``COLUMNS`` order. One transaction (executemany + commit); returns the count."""
+    """Idempotent, label-preserving bulk upsert of shadow AttentionEvents.
+
+    ``rows`` are tuples in ``COLUMNS`` order. Re-running the same snapshot+config collides
+    on the row id; we refresh the derived columns but preserve any human ``acceptance_signal``
+    label (and ``created_at``) via ``ON CONFLICT ... WHERE acceptance_signal IS NULL``. One
+    transaction; returns the count of rows submitted (matching prior behaviour)."""
     if not rows:
         return 0
     placeholders = ", ".join(["?"] * len(COLUMNS))
+    set_clause = ", ".join(f"{c}=excluded.{c}" for c in _UPSERT_SET_COLS)
     await db.executemany(
-        f"INSERT OR REPLACE INTO attention_events ({', '.join(COLUMNS)}) "  # noqa: S608
-        f"VALUES ({placeholders})",
+        f"INSERT INTO attention_events ({', '.join(COLUMNS)}) VALUES ({placeholders}) "  # noqa: S608
+        f"ON CONFLICT(id) DO UPDATE SET {set_clause} "
+        f"WHERE attention_events.acceptance_signal IS NULL",
         rows,
     )
     await db.commit()
@@ -36,3 +55,136 @@ async def count(db: aiosqlite.Connection) -> int:
     cursor = await db.execute("SELECT COUNT(*) AS n FROM attention_events")
     row = await cursor.fetchone()
     return row["n"] if row else 0
+
+
+async def get_event(db: aiosqlite.Connection, event_id: str) -> dict | None:
+    """One event row as a dict (refs + features + label — never transcript text), or None."""
+    cursor = await db.execute("SELECT * FROM attention_events WHERE id = ?", (event_id,))
+    row = await cursor.fetchone()
+    return dict(row) if row is not None else None
+
+
+async def list_events(
+    db: aiosqlite.Connection,
+    *,
+    activation: str | None = None,
+    trigger: str | None = None,
+    is_user: bool = False,
+    unlabeled: bool = False,
+    session_id: str | None = None,
+    limit: int = 200,
+    offset: int = 0,
+) -> list[dict]:
+    """List events (newest first), value-free (refs + features + label, NO text).
+
+    ``trigger`` filters to events whose ``triggers_fired`` contains a hit with that exact
+    ``name`` (via ``json_each``, not ``LIKE``). ``is_user=True`` additionally requires the
+    ``is_user`` trigger — i.e. the *trigger utterance* (window end) had ``is_user=1``.
+    ``unlabeled=True`` restricts to ``acceptance_signal IS NULL`` (the review queue)."""
+    where: list[str] = []
+    params: list = []
+    if activation is not None:
+        where.append("activation = ?")
+        params.append(activation)
+    if session_id is not None:
+        where.append("session_id = ?")
+        params.append(session_id)
+    if unlabeled:
+        where.append("acceptance_signal IS NULL")
+    # Exact name match on a triggers_fired[] element. EXISTS composes for AND without a
+    # DISTINCT-producing join, and lets trigger + is_user filter independently.
+    if trigger is not None:
+        where.append(
+            "EXISTS (SELECT 1 FROM json_each(triggers_fired) je "
+            "WHERE json_extract(je.value, '$.name') = ?)"
+        )
+        params.append(trigger)
+    if is_user:
+        where.append(
+            "EXISTS (SELECT 1 FROM json_each(triggers_fired) je "
+            "WHERE json_extract(je.value, '$.name') = 'is_user')"
+        )
+    where_sql = (" WHERE " + " AND ".join(where)) if where else ""
+    lim = max(1, min(int(limit), 500))
+    off = max(0, int(offset))
+    params.extend([lim, off])
+    cursor = await db.execute(
+        f"SELECT * FROM attention_events{where_sql} "  # noqa: S608
+        f"ORDER BY ts DESC LIMIT ? OFFSET ?",
+        params,
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def update_acceptance_signal(
+    db: aiosqlite.Connection, event_id: str, signal: str,
+) -> tuple[bool, str | None]:
+    """Write a review label. Returns ``(found, prior_signal)`` so the UI can show X->Y.
+
+    Raises ``ValueError`` for a signal outside ``LABELS`` (route maps it to 400)."""
+    if signal not in LABELS:
+        raise ValueError(f"invalid acceptance_signal {signal!r}; expected one of {LABELS}")
+    cursor = await db.execute(
+        "SELECT acceptance_signal FROM attention_events WHERE id = ?", (event_id,)
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return (False, None)
+    prior = row[0]
+    await db.execute(
+        "UPDATE attention_events SET acceptance_signal = ? WHERE id = ?", (signal, event_id)
+    )
+    await db.commit()
+    return (True, prior)
+
+
+# ── aggregates for the cockpit stats panel (all counts — never text) ──────────────
+
+async def activation_stats(db: aiosqlite.Connection) -> dict:
+    cursor = await db.execute(
+        "SELECT activation, COUNT(*) AS n FROM attention_events GROUP BY activation"
+    )
+    return {r["activation"]: r["n"] for r in await cursor.fetchall()}
+
+
+async def trigger_stats(db: aiosqlite.Connection) -> dict:
+    """Per-trigger fire counts (the dominance bar) — exact name via json_each."""
+    cursor = await db.execute(
+        "SELECT json_extract(je.value, '$.name') AS name, COUNT(*) AS n "
+        "FROM attention_events ae, json_each(ae.triggers_fired) je "
+        "GROUP BY name ORDER BY n DESC"
+    )
+    return {r["name"]: r["n"] for r in await cursor.fetchall()}
+
+
+async def suppressor_stats(db: aiosqlite.Connection) -> dict:
+    """Per-suppressor hit counts (``suppressors`` is a JSON array of names)."""
+    cursor = await db.execute(
+        "SELECT je.value AS name, COUNT(*) AS n "
+        "FROM attention_events ae, json_each(ae.suppressors) je "
+        "GROUP BY name ORDER BY n DESC"
+    )
+    return {r["name"]: r["n"] for r in await cursor.fetchall()}
+
+
+async def label_counts(db: aiosqlite.Connection) -> dict:
+    """total / labeled / unlabeled + a by-signal breakdown."""
+    cursor = await db.execute(
+        "SELECT acceptance_signal, COUNT(*) AS n FROM attention_events GROUP BY acceptance_signal"
+    )
+    by_signal: dict[str, int] = {}
+    unlabeled = 0
+    total = 0
+    for r in await cursor.fetchall():
+        n = r["n"]
+        total += n
+        if r["acceptance_signal"] is None:
+            unlabeled += n
+        else:
+            by_signal[r["acceptance_signal"]] = n
+    return {
+        "total": total,
+        "labeled": total - unlabeled,
+        "unlabeled": unlabeled,
+        "by_signal": by_signal,
+    }

--- a/src/genesis/db/crud/attention.py
+++ b/src/genesis/db/crud/attention.py
@@ -130,7 +130,7 @@ async def update_acceptance_signal(
     row = await cursor.fetchone()
     if row is None:
         return (False, None)
-    prior = row[0]
+    prior = row["acceptance_signal"]
     await db.execute(
         "UPDATE attention_events SET acceptance_signal = ? WHERE id = ?", (signal, event_id)
     )

--- a/tests/test_attention/test_consumers.py
+++ b/tests/test_attention/test_consumers.py
@@ -96,7 +96,36 @@ async def test_idempotent_reflush_same_snapshot_and_config(tmp_path):
         for ev in evs:
             c.add(ev)
         await c.flush()
-    assert _rows(db) == len(evs)  # INSERT OR REPLACE keyed on snapshot:config:utt
+    assert _rows(db) == len(evs)  # label-preserving upsert keyed on snapshot:config:utt
+
+
+@pytest.mark.asyncio
+async def test_reflush_preserves_human_label(tmp_path):
+    # B1 regression: persist -> a human labels a row -> re-run the SAME snapshot+config
+    # (the runner always writes acceptance_signal=NULL) must NOT clobber the label.
+    db = tmp_path / "g.db"
+    _make_db(db)
+    cfg = AttentionConfig.from_dict(default_config_dict())
+    evs = _run_events([_utt(1, 100.0, "what do you think?")], cfg)
+    assert evs
+
+    async def _persist():
+        c = ShadowStoreConsumer(db, snapshot_id="s", config_version=cfg.version)
+        for ev in evs:
+            c.add(ev)
+        await c.flush()
+
+    await _persist()
+    conn = sqlite3.connect(db)
+    conn.execute("UPDATE attention_events SET acceptance_signal = 'should'")
+    conn.commit()
+    conn.close()
+
+    await _persist()  # re-run over the same snapshot+config
+    conn = sqlite3.connect(db)
+    labels = [r[0] for r in conn.execute("SELECT acceptance_signal FROM attention_events")]
+    conn.close()
+    assert labels and all(v == "should" for v in labels)  # label survived the re-run
 
 
 @pytest.mark.asyncio

--- a/tests/test_attention/test_runner.py
+++ b/tests/test_attention/test_runner.py
@@ -1,12 +1,18 @@
 """Offline shadow runner: config resolution + run_shadow over a synthetic snapshot."""
 import json
 import sqlite3
+from pathlib import Path
 
 import pytest
 
 from genesis.attention import runner
 from genesis.attention.config import AttentionConfig, default_config_dict
-from genesis.attention.runner import ShadowReport, load_runner_config, run_shadow
+from genesis.attention.runner import (
+    ShadowReport,
+    _snapshot_id_from_path,
+    load_runner_config,
+    run_shadow,
+)
 
 
 def _meta(rms=0.2, ntok=20) -> str:
@@ -27,6 +33,13 @@ def _make_ambient(path, rows) -> None:
     )
     conn.commit()
     conn.close()
+
+
+def test_snapshot_id_from_path_strips_ambient_prefix():
+    # --snapshot must yield the BARE id so the dashboard reveal can reconstruct the file.
+    assert _snapshot_id_from_path(Path("/x/ambient_20260701T013412Z.db")) == "20260701T013412Z"
+    assert _snapshot_id_from_path(Path("/x/20260701T013412Z.db")) == "20260701T013412Z"
+    assert _snapshot_id_from_path(Path("/x/custom.db")) == "custom"
 
 
 def test_load_runner_config_from_explicit_file(tmp_path):

--- a/tests/test_attention/test_sources.py
+++ b/tests/test_attention/test_sources.py
@@ -1,7 +1,15 @@
-"""ambient_transcripts row -> AmbientUtterance mapping (pure, no DB)."""
+"""ambient_transcripts row -> AmbientUtterance mapping (pure, no DB) + snapshot text reveal."""
 import json
+import sqlite3
 
-from genesis.attention.sources import _parse_ts, _speaker_total, row_to_utterance
+import pytest
+
+from genesis.attention.sources import (
+    _parse_ts,
+    _speaker_total,
+    resolve_window_text,
+    row_to_utterance,
+)
 
 
 def _row(**over) -> dict:
@@ -52,3 +60,58 @@ def test_speaker_total_parse():
 
 def test_parse_ts_naive_assumed_utc_equals_explicit_utc():
     assert _parse_ts("2026-06-30T12:00:00") == _parse_ts("2026-06-30T12:00:00+00:00")
+
+
+# ── resolve_window_text: reveal transcript text from the transient snapshot ──────
+
+def _make_snapshot(dir_, snapshot_id, rows) -> None:
+    conn = sqlite3.connect(dir_ / f"ambient_{snapshot_id}.db")
+    conn.execute(
+        "CREATE TABLE ambient_transcripts (id INTEGER PRIMARY KEY, ts TEXT, text TEXT, "
+        "duration_s REAL, speaker_label TEXT, provenance TEXT, source TEXT, meta TEXT, "
+        "is_user INTEGER, speaker_name TEXT)"
+    )
+    conn.executemany(
+        "INSERT INTO ambient_transcripts (id, ts, text, speaker_label, is_user) "
+        "VALUES (?, ?, ?, ?, ?)", rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_resolve_window_text_orders_and_flags_trigger(tmp_path):
+    _make_snapshot(tmp_path, "20260701T013412Z", [
+        (10, "2026-07-01T00:00:02+00:00", "second", "w1:1/2", 0),
+        (11, "2026-07-01T00:00:01+00:00", "first", "w1:1/2", 1),
+        (12, "2026-07-01T00:00:03+00:00", "trigger utt", "w1:1/2", 0),
+    ])
+    win = await resolve_window_text("20260701T013412Z", [11, 10, 12], snapshots_dir=tmp_path)
+    assert [w["text"] for w in win] == ["first", "second", "trigger utt"]  # ts-ordered
+    assert [w["is_trigger"] for w in win] == [False, False, True]          # last utt_id
+    assert win[0]["is_user"] == 1 and win[0]["speaker_label"] == "w1:1/2"
+
+
+@pytest.mark.asyncio
+async def test_resolve_window_text_missing_snapshot_returns_none(tmp_path):
+    assert await resolve_window_text("gone", [1, 2], snapshots_dir=tmp_path) is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_window_text_bare_filename_form(tmp_path):
+    # tolerate a snapshot stored WITHOUT the ambient_ prefix
+    conn = sqlite3.connect(tmp_path / "bareid.db")
+    conn.execute("CREATE TABLE ambient_transcripts (id INTEGER PRIMARY KEY, ts TEXT, text TEXT, "
+                 "speaker_label TEXT, is_user INTEGER)")
+    conn.execute("INSERT INTO ambient_transcripts VALUES (1, '2026-07-01T00:00:00+00:00', 'x', 'w1', 1)")
+    conn.commit()
+    conn.close()
+    win = await resolve_window_text("bareid", [1], snapshots_dir=tmp_path)
+    assert win and win[0]["text"] == "x"
+
+
+@pytest.mark.asyncio
+async def test_resolve_window_text_rejects_non_int_ids(tmp_path):
+    _make_snapshot(tmp_path, "sid", [(1, "2026-07-01T00:00:00+00:00", "x", "w1", 1)])
+    with pytest.raises(ValueError):
+        await resolve_window_text("sid", ["1; DROP TABLE ambient_transcripts"], snapshots_dir=tmp_path)

--- a/tests/test_dashboard/test_attention_api.py
+++ b/tests/test_dashboard/test_attention_api.py
@@ -1,0 +1,204 @@
+"""Tests for the attention shadow-review dashboard routes.
+
+Critical invariants:
+- list / stats NEVER include transcript text (only reveal-text does, from the snapshot).
+- reveal-text is auth-gated; with DASHBOARD_PASSWORD set, no session -> 403.
+- reveal-text degrades to 410 when the snapshot is purged, 404 when the event is missing.
+- label validates the signal (bad -> 400) and 404s a missing event.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from genesis.dashboard.api import blueprint
+
+
+@pytest.fixture()
+def app():
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    app.config["TESTING"] = True
+    app.secret_key = "test-secret-key"
+    return app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _mock_rt(**kw):
+    rt = MagicMock()
+    rt.is_bootstrapped = True
+    rt.db = MagicMock()
+    for k, v in kw.items():
+        setattr(rt, k, v)
+    return rt
+
+
+def _evrow(**over):
+    row = {
+        "id": "20260701T013412Z:0.1.0-default:12",
+        "ts": "2026-07-01T00:00:03+00:00",
+        "session_id": "s12",
+        "activation": "soft",
+        "score": 0.62,
+        "clarity": 0.9,
+        "mode_state": "unknown",
+        "triggers_fired": json.dumps([{"name": "multi_speaker", "kind": "soft", "contribution": 0.4}]),
+        "suppressors": json.dumps([]),
+        "window_ref": json.dumps({
+            "snapshot_id": "20260701T013412Z", "session_id": "s12",
+            "utt_ids": [10, 11, 12], "ts_start": 1.0, "ts_end": 3.0,
+        }),
+        "l15_verdict": None,
+        "acceptance_signal": None,
+        "snapshot_id": "20260701T013412Z",
+        "config_version": "0.1.0-default",
+        "created_at": "2026-07-01T00:00:04+00:00",
+    }
+    row.update(over)
+    return row
+
+
+# ── list ──────────────────────────────────────────────────────────────────
+
+def test_list_returns_parsed_events_no_text(client):
+    le = AsyncMock(return_value=[_evrow()])
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.list_events", new=le),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.get("/api/genesis/attention/list?unlabeled=true&trigger=multi_speaker&is_user=true")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["count"] == 1
+    ev = data["events"][0]
+    assert ev["activation"] == "soft"
+    assert ev["triggers_fired"][0]["name"] == "multi_speaker"   # JSON parsed
+    assert ev["window_ref"]["utt_ids"] == [10, 11, 12]          # refs only
+    assert "text" not in json.dumps(ev)                          # no transcript text anywhere
+    # filters threaded through to the crud call
+    _, kwargs = le.call_args
+    assert kwargs["unlabeled"] is True and kwargs["trigger"] == "multi_speaker" and kwargs["is_user"] is True
+
+
+def test_list_503_when_not_bootstrapped(client):
+    with patch("genesis.runtime.GenesisRuntime") as MockRT:
+        MockRT.instance.return_value = _mock_rt(is_bootstrapped=False, db=None)
+        resp = client.get("/api/genesis/attention/list")
+    assert resp.status_code == 503
+
+
+# ── stats ─────────────────────────────────────────────────────────────────
+
+def test_stats_aggregates(client):
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.label_counts",
+              new=AsyncMock(return_value={"total": 3, "labeled": 1, "unlabeled": 2, "by_signal": {"should": 1}})),
+        patch("genesis.db.crud.attention.activation_stats", new=AsyncMock(return_value={"soft": 2, "hard": 1})),
+        patch("genesis.db.crud.attention.trigger_stats", new=AsyncMock(return_value={"multi_speaker": 2})),
+        patch("genesis.db.crud.attention.suppressor_stats", new=AsyncMock(return_value={})),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.get("/api/genesis/attention/stats")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["labels"]["unlabeled"] == 2
+    assert data["by_trigger"]["multi_speaker"] == 2
+
+
+# ── reveal-text ───────────────────────────────────────────────────────────
+
+def test_reveal_returns_window_text(client):
+    window = [{"id": 12, "ts": "2026-07-01T00:00:03+00:00", "text": "what do you think?",
+               "speaker_label": "w1:1/2", "is_user": 1, "is_trigger": True}]
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.get_event", new=AsyncMock(return_value=_evrow())),
+        patch("genesis.attention.sources.resolve_window_text", new=AsyncMock(return_value=window)),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/attention/evt-1/reveal-text")
+    assert resp.status_code == 200
+    assert resp.get_json()["window"][0]["text"] == "what do you think?"
+
+
+def test_reveal_410_when_snapshot_purged(client):
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.get_event", new=AsyncMock(return_value=_evrow())),
+        patch("genesis.attention.sources.resolve_window_text", new=AsyncMock(return_value=None)),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/attention/evt-1/reveal-text")
+    assert resp.status_code == 410
+
+
+def test_reveal_404_when_event_missing(client):
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.get_event", new=AsyncMock(return_value=None)),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/attention/evt-1/reveal-text")
+    assert resp.status_code == 404
+
+
+# ── label ─────────────────────────────────────────────────────────────────
+
+def test_label_ok_returns_prior(client):
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.update_acceptance_signal",
+              new=AsyncMock(return_value=(True, "should"))),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/attention/evt-1/label", json={"acceptance_signal": "shouldnt"})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {"status": "ok", "id": "evt-1", "acceptance_signal": "shouldnt", "prior": "should"}
+
+
+def test_label_400_on_invalid_signal(client):
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.update_acceptance_signal",
+              new=AsyncMock(side_effect=ValueError("invalid acceptance_signal 'maybe'"))),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/attention/evt-1/label", json={"acceptance_signal": "maybe"})
+    assert resp.status_code == 400
+
+
+def test_label_404_when_missing(client):
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.update_acceptance_signal",
+              new=AsyncMock(return_value=(False, None))),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/attention/evt-1/label", json={"acceptance_signal": "skip"})
+    assert resp.status_code == 404
+
+
+# ── auth gate (deliberate exception to the /api bypass, mirrors references) ──
+
+def test_list_403_when_password_set_no_session(client):
+    with patch("genesis.dashboard.auth.get_dashboard_password", return_value="secret"):
+        resp = client.get("/api/genesis/attention/list")
+    assert resp.status_code == 403
+
+
+def test_reveal_403_when_password_set_no_session(client):
+    with patch("genesis.dashboard.auth.get_dashboard_password", return_value="secret"):
+        resp = client.post("/api/genesis/attention/evt-1/reveal-text")
+    assert resp.status_code == 403

--- a/tests/test_db/test_crud_attention.py
+++ b/tests/test_db/test_crud_attention.py
@@ -1,0 +1,156 @@
+"""crud.attention: label-preserving upsert (B1), exact json_each filters (B2), aggregates, labeling."""
+import json
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import attention as crud
+from genesis.db.schema._tables import INDEXES, TABLES
+
+
+async def _db(path):
+    conn = await aiosqlite.connect(path)
+    conn.row_factory = aiosqlite.Row
+    await conn.execute(TABLES["attention_events"])
+    for idx in INDEXES:
+        if "attention_events" in idx:
+            await conn.execute(idx)
+    await conn.commit()
+    return conn
+
+
+def _row(
+    n,
+    *,
+    activation="soft",
+    score=0.6,
+    triggers=(("multi_speaker", "soft", 0.4),),
+    suppressors=(),
+    acceptance=None,
+    ts="2026-07-01T00:00:00+00:00",
+    session_id="s1",
+    snapshot_id="20260701T013412Z",
+    utt_ids=(1, 2, 3),
+):
+    """A full attention_events tuple in COLUMNS order."""
+    triggers_json = json.dumps([{"name": nm, "kind": k, "contribution": c} for nm, k, c in triggers])
+    window_ref = json.dumps({
+        "snapshot_id": snapshot_id, "session_id": session_id,
+        "utt_ids": list(utt_ids), "ts_start": 0.0, "ts_end": 1.0,
+    })
+    return (
+        f"id-{n}", ts, session_id, activation, score, triggers_json,
+        json.dumps(list(suppressors)), window_ref, "unknown", 0.9, None,
+        acceptance, snapshot_id, "0.1.0-default", "2026-07-01T00:00:00+00:00",
+    )
+
+
+@pytest.mark.asyncio
+async def test_bulk_upsert_preserves_label_on_reflush(tmp_path):
+    """B1: re-running the runner over a labeled snapshot must NOT clobber the label."""
+    db = await _db(tmp_path / "g.db")
+    assert await crud.bulk_upsert_events(db, [_row(1)]) == 1
+    ok, prior = await crud.update_acceptance_signal(db, "id-1", "should")
+    assert ok and prior is None
+    # re-persist the SAME id (same snapshot+config) with a changed derived column
+    await crud.bulk_upsert_events(db, [_row(1, score=0.99)])
+    ev = await crud.get_event(db, "id-1")
+    assert ev["acceptance_signal"] == "should"   # label PRESERVED
+    assert ev["score"] == 0.6                     # labeled row is FROZEN (runner can't mutate it)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_unlabeled_row_refreshes_on_reflush(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [_row(1, score=0.5)])
+    await crud.bulk_upsert_events(db, [_row(1, score=0.8)])
+    ev = await crud.get_event(db, "id-1")
+    assert ev["score"] == 0.8 and ev["acceptance_signal"] is None
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_list_filter_trigger_exact_not_like(tmp_path):
+    """B2: filtering trigger='soft' (a kind, not a name) must match nothing."""
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [
+        _row(1, triggers=(("multi_speaker", "soft", 0.4),)),
+        _row(2, triggers=(("question", "soft", 0.3), ("is_user", "soft", 0.1))),
+    ])
+    assert {e["id"] for e in await crud.list_events(db, trigger="multi_speaker")} == {"id-1"}
+    assert {e["id"] for e in await crud.list_events(db, trigger="question")} == {"id-2"}
+    assert await crud.list_events(db, trigger="soft") == []      # kind, not a name
+    assert await crud.list_events(db, trigger="contribution") == []  # JSON key, not a name
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_list_filter_is_user_and_activation_and_unlabeled(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [
+        _row(1, activation="soft", triggers=(("is_user", "soft", 0.1),)),
+        _row(2, activation="hard", triggers=(("ambient_name", "hard", 0.0),)),
+        _row(3, activation="soft", triggers=(("multi_speaker", "soft", 0.4),), acceptance="skip"),
+    ])
+    assert {e["id"] for e in await crud.list_events(db, is_user=True)} == {"id-1"}
+    assert {e["id"] for e in await crud.list_events(db, activation="hard")} == {"id-2"}
+    assert {e["id"] for e in await crud.list_events(db, unlabeled=True)} == {"id-1", "id-2"}
+    # combined trigger + is_user (AND semantics): id-1 has is_user, not multi_speaker
+    assert await crud.list_events(db, trigger="multi_speaker", is_user=True) == []
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_list_orders_desc_and_paginates(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [
+        _row(1, ts="2026-07-01T00:00:01+00:00"),
+        _row(2, ts="2026-07-01T00:00:03+00:00"),
+        _row(3, ts="2026-07-01T00:00:02+00:00"),
+    ])
+    ordered = [e["id"] for e in await crud.list_events(db)]
+    assert ordered == ["id-2", "id-3", "id-1"]           # newest first
+    assert [e["id"] for e in await crud.list_events(db, limit=1)] == ["id-2"]
+    assert [e["id"] for e in await crud.list_events(db, limit=1, offset=1)] == ["id-3"]
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_stats_aggregates(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [
+        _row(1, activation="soft", triggers=(("multi_speaker", "soft", 0.4), ("is_user", "soft", 0.1))),
+        _row(2, activation="soft", triggers=(("multi_speaker", "soft", 0.4),), suppressors=("explicit_dismissal",)),
+        _row(3, activation="hard", triggers=(("ambient_name", "hard", 0.0),), acceptance="should"),
+    ])
+    assert await crud.activation_stats(db) == {"soft": 2, "hard": 1}
+    trig = await crud.trigger_stats(db)
+    assert trig["multi_speaker"] == 2 and trig["is_user"] == 1 and trig["ambient_name"] == 1
+    assert list(trig)[0] == "multi_speaker"              # ORDER BY n DESC -> dominance first
+    assert await crud.suppressor_stats(db) == {"explicit_dismissal": 1}
+    lc = await crud.label_counts(db)
+    assert lc == {"total": 3, "labeled": 1, "unlabeled": 2, "by_signal": {"should": 1}}
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_update_acceptance_signal_validation_and_missing(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [_row(1)])
+    with pytest.raises(ValueError):
+        await crud.update_acceptance_signal(db, "id-1", "maybe")
+    assert await crud.update_acceptance_signal(db, "missing", "should") == (False, None)
+    # relabel returns the prior value
+    await crud.update_acceptance_signal(db, "id-1", "should")
+    ok, prior = await crud.update_acceptance_signal(db, "id-1", "shouldnt")
+    assert ok and prior == "should"
+    assert (await crud.get_event(db, "id-1"))["acceptance_signal"] == "shouldnt"
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_get_event_missing_returns_none(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    assert await crud.get_event(db, "nope") is None
+    await db.close()


### PR DESCRIPTION
## What

PR2 of the passive-listening **attention engine** (Track 1 of the omnipresence layer). PR1 (#820) shipped the deterministic L1 shadow gate that persists "would have perked up" decisions to `attention_events` (refs + features + labels only — **never transcript text**). This PR adds the **calibration cockpit**: an auth-gated dashboard "Attention" tab to review each shadow decision, reveal the window's transcript on demand, and label it **should / shouldn't / skip** — closing the calibration loop that PR3's retune consumes.

## Why

The shadow table had no way for a human to say whether a fire was *right*, so the gate couldn't be tuned. PR1's live run already showed `multi_speaker` fires on 321/326 windows (over-dominant); this tab surfaces that per-trigger dominance and turns the shadow corpus into **labeled** ground truth.

## Changes

- **`db/crud/attention.py`** — label-preserving `bulk_upsert_events` (`ON CONFLICT DO UPDATE … WHERE acceptance_signal IS NULL`, so re-running the runner never clobbers a human label); `list_events` (activation / trigger / is_user / unlabeled filters via `json_each` **exact-name** match, not `LIKE`); `get_event`; `update_acceptance_signal` (returns the prior value); aggregates (activation / trigger / suppressor / label counts).
- **`attention/sources.py`** — `resolve_window_text`: reveals a window's transcript from the **transient snapshot** (read-only, NOT genesis.db); parametrized `IN()` with `int()`-cast ids; `None` → 410 when the snapshot is purged.
- **`attention/runner.py`** — canonicalize `snapshot_id` for `--snapshot` (strip the `ambient_` prefix) so the dashboard reveal can reconstruct the file.
- **`dashboard/routes/attention.py`** (+ registration) — `list` / `stats` / `reveal-text` / `label`, mirroring `references.py` (auth gate, `GenesisRuntime` guard). list/stats are value-free; `reveal-text` is the only text path and persists nothing.
- **`dashboard/templates/genesis_dashboard.html`** — the Attention tab: stats bar + per-trigger dominance bar + filters + per-event reveal/label.

## Firewall

Transcript text is never written to genesis.db. `list`/`stats` never open a snapshot. `reveal-text` reads the transient snapshot live for the authenticated human and stores nothing. A firewall test asserts no transcript text reaches `attention_events`.

## Verification

- 128 targeted tests green (crud on real sqlite, resolver on a real snapshot, routes via a real Flask test client incl. the auth gate; existing References tests unbroken); ruff clean.
- `node --check` + render-check on the Alpine tab.
- genesis-architect pre-review (4 blockers folded in) + code-review (nits fixed).
- Live browser E2E + refs-only corpus population to follow post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)