### PR TITLE
fix(autonomy): fail-closed dispatch gate + drop web_agent cost auto-deny (WS5 Stage 1)

### DIFF
--- a/src/genesis/autonomy/proposal_gate.py
+++ b/src/genesis/autonomy/proposal_gate.py
@@ -156,3 +156,85 @@ class ProposalDispatchGate:
                 highest = ProtectionLevel.SENSITIVE
 
         return highest if highest != ProtectionLevel.NORMAL else None
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed fallback (Stage-1 hardening)
+# ---------------------------------------------------------------------------
+# The dispatch gate is the last safety check before an already-user-approved
+# proposal runs autonomously in the background.  Previously, if the real gate
+# could not be built (init failure) or raised while evaluating, the caller
+# SILENTLY dispatched — a fail-OPEN hole.  These primitives give a
+# deterministic, dependency-free risk tier so a degraded gate fails CLOSED for
+# high-consequence domains while staying resilient (allow) for benign ones —
+# the latter avoids wedging the whole ego proposal cycle on a transient error.
+
+#: Domains that act on outside parties or on Genesis's own code/identity.  This
+#: is exactly the set whose ``ACTION_DOMAIN_MIN_LEVEL`` is >= 2 (or ``None``),
+#: i.e. the domains the real gate would block below the earned autonomy level.
+#: KEEP IN SYNC when adding an ``ActionDomain``: ``classify_domain``'s fallback
+#: is ``EXTERNAL_READ`` (benign), so an UNMAPPED action is ALLOWED under a
+#: degraded gate — any new external/self-modify domain MUST be added here.
+HIGH_RISK_DOMAINS: frozenset[ActionDomain] = frozenset({
+    ActionDomain.EXTERNAL_WRITE,
+    ActionDomain.REPRESENT_USER,
+    ActionDomain.FINANCIAL,
+    ActionDomain.SELF_MODIFY,
+})
+
+
+def is_high_risk_domain(domain: ActionDomain) -> bool:
+    """True if *domain* touches external parties or Genesis's own code/identity."""
+    return domain in HIGH_RISK_DOMAINS
+
+
+def gate_failure_is_blocking(proposal: dict) -> bool:
+    """Decide fail-closed (True) vs resilient-allow (False) when the dispatch
+    gate is unavailable or raised while evaluating *proposal*.
+
+    Re-derives the action domain from the proposal via the PURE
+    :func:`classify_domain` (no I/O).  Any error deriving it — including
+    ``classify_domain`` itself having been the failure — returns ``True``
+    (block): an undeterminable action is treated as high-risk.  Only
+    clearly-benign domains (OBSERVE / EXTERNAL_READ / INTERNAL_WRITE /
+    NOTIFY_USER) are allowed through, so a transient gate error can't wedge
+    routine (non-external) autonomy.
+    """
+    try:
+        domain = classify_domain(
+            proposal.get("action_type", ""),
+            proposal.get("execution_plan") or "",
+        )
+    except Exception:  # noqa: BLE001 — undeterminable domain => fail closed
+        return True
+    return is_high_risk_domain(domain)
+
+
+class DenyHighRiskSentinel:
+    """Fail-closed stand-in for :class:`ProposalDispatchGate`.
+
+    Installed by ``runtime/init`` when the real gate cannot be constructed, so
+    ``_proposal_dispatch_gate`` is NEVER left unset — which the ego would read
+    as "no gate" and dispatch every approved proposal ungated.  Blocks
+    HIGH_RISK_DOMAINS, allows benign domains.  Stateless; satisfies the same
+    ``evaluate(proposal) -> DispatchDecision`` contract the ego consumes.
+    """
+
+    async def evaluate(self, proposal: dict) -> DispatchDecision:
+        domain = classify_domain(
+            proposal.get("action_type", ""),
+            proposal.get("execution_plan") or "",
+        )
+        if is_high_risk_domain(domain):
+            return DispatchDecision(
+                allowed=False,
+                reason="degraded mode: real dispatch gate unavailable",
+                rule_id="deny_high_risk_sentinel",
+                action_domain=domain,
+            )
+        return DispatchDecision(
+            allowed=True,
+            reason="degraded mode: benign domain allowed",
+            rule_id="deny_high_risk_sentinel",
+            action_domain=domain,
+        )

--- a/src/genesis/autonomy/proposal_gate.py
+++ b/src/genesis/autonomy/proposal_gate.py
@@ -188,7 +188,7 @@ def is_high_risk_domain(domain: ActionDomain) -> bool:
     return domain in HIGH_RISK_DOMAINS
 
 
-def gate_failure_is_blocking(proposal: dict) -> bool:
+def gate_failure_is_blocking(proposal: dict | None) -> bool:
     """Decide fail-closed (True) vs resilient-allow (False) when the dispatch
     gate is unavailable or raised while evaluating *proposal*.
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1448,8 +1448,31 @@ class EgoSession:
                                 )
                             continue
                 except Exception:
+                    # Gate eval raised. Fail CLOSED for high-risk domains
+                    # (external / self-modify), stay resilient (allow) for benign
+                    # ones so a transient error can't wedge the ego cycle.
+                    from genesis.autonomy.proposal_gate import gate_failure_is_blocking
+
+                    if gate_failure_is_blocking(prop_row):
+                        logger.error(
+                            "Proposal gate failed for execution brief %s — "
+                            "BLOCKING dispatch (fail-closed, high-risk domain)",
+                            proposal_id,
+                            exc_info=True,
+                        )
+                        if self._event_bus:
+                            from genesis.observability.types import Severity, Subsystem
+                            await self._event_bus.emit(
+                                Subsystem.AUTONOMY,
+                                Severity.ERROR,
+                                "autonomy.dispatch_gate.fail_closed",
+                                "Gate eval error — execution brief blocked (fail-closed)",
+                                proposal_id=proposal_id,
+                            )
+                        continue
                     logger.error(
-                        "Proposal gate failed for execution brief %s — allowing dispatch",
+                        "Proposal gate failed for execution brief %s — allowing "
+                        "dispatch (resilient: benign domain)",
                         proposal_id,
                         exc_info=True,
                     )
@@ -1859,10 +1882,31 @@ class EgoSession:
                             )
                         continue
                 except Exception:
-                    # Gate failure is non-fatal — default to allowing dispatch
-                    # (fail-open, log the error for investigation)
+                    # Gate eval raised. Fail CLOSED for high-risk domains,
+                    # stay resilient (allow) for benign ones — same risk-tiered
+                    # policy as the execution-brief path above.
+                    from genesis.autonomy.proposal_gate import gate_failure_is_blocking
+
+                    if gate_failure_is_blocking(prop):
+                        logger.error(
+                            "Proposal gate evaluation failed for %s — BLOCKING "
+                            "dispatch (fail-closed, high-risk domain)",
+                            prop["id"],
+                            exc_info=True,
+                        )
+                        if self._event_bus:
+                            from genesis.observability.types import Severity, Subsystem
+                            await self._event_bus.emit(
+                                Subsystem.AUTONOMY,
+                                Severity.ERROR,
+                                "autonomy.dispatch_gate.fail_closed",
+                                "Gate eval error — proposal blocked (fail-closed)",
+                                proposal_id=prop["id"],
+                            )
+                        continue
                     logger.error(
-                        "Proposal gate evaluation failed for %s — allowing dispatch",
+                        "Proposal gate evaluation failed for %s — allowing "
+                        "dispatch (resilient: benign domain)",
                         prop["id"],
                         exc_info=True,
                     )

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1418,6 +1418,11 @@ class EgoSession:
             # autonomy level. Gate fires BEFORE the atomic claim so blocked
             # proposals stay 'approved' (ego-invisible).
             if self._proposal_gate is not None:
+                # Bind before the try so the except handler can't hit an
+                # UnboundLocalError (or read a stale prior-iteration value) if
+                # get_proposal() itself raises. None => unresolved => the except
+                # treats it as high-risk (fail-closed).
+                prop_row = None
                 try:
                     prop_row = await ego_crud.get_proposal(self._db, proposal_id)
                     if prop_row is None:
@@ -1453,7 +1458,7 @@ class EgoSession:
                     # ones so a transient error can't wedge the ego cycle.
                     from genesis.autonomy.proposal_gate import gate_failure_is_blocking
 
-                    if gate_failure_is_blocking(prop_row):
+                    if prop_row is None or gate_failure_is_blocking(prop_row):
                         logger.error(
                             "Proposal gate failed for execution brief %s — "
                             "BLOCKING dispatch (fail-closed, high-risk domain)",

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from genesis.autonomy.autonomous_dispatch import AutonomousDispatchRequest
+from genesis.autonomy.proposal_gate import gate_failure_is_blocking
 from genesis.cc.types import (
     CCInvocation,
     CCModel,
@@ -1456,8 +1457,6 @@ class EgoSession:
                     # Gate eval raised. Fail CLOSED for high-risk domains
                     # (external / self-modify), stay resilient (allow) for benign
                     # ones so a transient error can't wedge the ego cycle.
-                    from genesis.autonomy.proposal_gate import gate_failure_is_blocking
-
                     if prop_row is None or gate_failure_is_blocking(prop_row):
                         logger.error(
                             "Proposal gate failed for execution brief %s — "
@@ -1890,8 +1889,6 @@ class EgoSession:
                     # Gate eval raised. Fail CLOSED for high-risk domains,
                     # stay resilient (allow) for benign ones — same risk-tiered
                     # policy as the execution-brief path above.
-                    from genesis.autonomy.proposal_gate import gate_failure_is_blocking
-
                     if gate_failure_is_blocking(prop):
                         logger.error(
                             "Proposal gate evaluation failed for %s — BLOCKING "

--- a/src/genesis/mcp/health/web_tools.py
+++ b/src/genesis/mcp/health/web_tools.py
@@ -591,7 +591,13 @@ async def web_agent(
             if hasattr(status, "value"):
                 status = status.value
             if status == "EXCEEDED":
-                return {"error": "Daily budget exceeded. web_agent costs ~$0.015/step."}
+                # Design Principle 3: cost is OBSERVABILITY, never automatic
+                # control. Log the exceeded budget but PROCEED — the user
+                # decides tradeoffs; Genesis never auto-throttles itself.
+                logger.warning(
+                    "web_agent daily budget EXCEEDED — proceeding anyway "
+                    "(cost is observability, not a throttle; ~$0.015/step)",
+                )
     except Exception as exc:
         logger.debug("Budget check skipped: %s", exc)
 

--- a/src/genesis/runtime/init/autonomy.py
+++ b/src/genesis/runtime/init/autonomy.py
@@ -15,6 +15,16 @@ logger = logging.getLogger("genesis.runtime")
 async def init(rt: GenesisRuntime) -> None:
     """Initialize autonomy: protection, state machine, classification, verification."""
     try:
+        # Fail-CLOSED default: the proposal dispatch gate must NEVER be left
+        # unset. If the real gate can't be built below (missing DB/manager or a
+        # ctor error), the ego reads a None gate as "no gate" and dispatches
+        # every approved proposal UNGATED. Install a blocking sentinel FIRST so
+        # any later failure degrades to fail-closed; the real gate replaces it
+        # on success further down.
+        from genesis.autonomy.proposal_gate import DenyHighRiskSentinel
+
+        rt._proposal_dispatch_gate = DenyHighRiskSentinel()
+
         from genesis.autonomy.classification import ActionClassifier
         from genesis.autonomy.protection import ProtectedPathRegistry
         from genesis.autonomy.verification import TaskVerifier
@@ -189,7 +199,22 @@ async def init(rt: GenesisRuntime) -> None:
                 )
                 logger.info("Proposal dispatch gate initialized")
             except Exception:
-                logger.warning("Failed to initialize proposal dispatch gate", exc_info=True)
+                # Keep the fail-closed sentinel installed at the top of init()
+                # (do NOT clear it) and surface the degradation loudly.
+                logger.error(
+                    "Failed to initialize proposal dispatch gate — running on "
+                    "the fail-closed DenyHighRiskSentinel",
+                    exc_info=True,
+                )
+                if rt._event_bus is not None:
+                    from genesis.observability.types import Severity, Subsystem
+
+                    await rt._event_bus.emit(
+                        Subsystem.AUTONOMY,
+                        Severity.ERROR,
+                        "autonomy.gate_init_failed",
+                        "Proposal dispatch gate init failed; using fail-closed sentinel",
+                    )
 
         # Post-execution auditor — parses transcripts, feeds autonomy signals.
         # Wired into DirectSessionRunner in init/direct_session.py.
@@ -204,7 +229,20 @@ async def init(rt: GenesisRuntime) -> None:
                 )
                 logger.info("Post-execution auditor initialized")
             except Exception:
-                logger.warning("Failed to initialize post-execution auditor", exc_info=True)
+                # Auditor is observability, not a gate — no fail-closed here;
+                # just surface the degraded autonomy signal loudly.
+                logger.error(
+                    "Failed to initialize post-execution auditor", exc_info=True,
+                )
+                if rt._event_bus is not None:
+                    from genesis.observability.types import Severity, Subsystem
+
+                    await rt._event_bus.emit(
+                        Subsystem.AUTONOMY,
+                        Severity.WARNING,
+                        "autonomy.auditor_init_failed",
+                        "Post-execution auditor init failed (autonomy signals degraded)",
+                    )
 
         # Remediation registry — mechanical reflex layer for health probes
         try:

--- a/tests/test_autonomy/test_proposal_gate_sentinel.py
+++ b/tests/test_autonomy/test_proposal_gate_sentinel.py
@@ -1,0 +1,103 @@
+"""Fail-closed dispatch-gate fallback (Stage-1 autonomy-gate hardening).
+
+Covers the degraded-mode primitives that replace the previous silent
+fail-open when the real ``ProposalDispatchGate`` cannot be built (init
+failure) or raises while evaluating a proposal.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.autonomy.proposal_gate import (
+    HIGH_RISK_DOMAINS,
+    DenyHighRiskSentinel,
+    DispatchDecision,
+    gate_failure_is_blocking,
+    is_high_risk_domain,
+)
+from genesis.autonomy.types import ActionDomain
+
+# action_types drawn from ACTION_TYPE_DOMAIN_MAP (classification.py).
+_HIGH_RISK_ACTION_TYPES = [
+    "outreach", "email", "apply",          # REPRESENT_USER
+    "publish", "content", "post",          # EXTERNAL_WRITE
+    "purchase", "payment",                 # FINANCIAL
+    "code_change", "refactor",             # SELF_MODIFY
+    "cognitive_variant_promotion",         # SELF_MODIFY
+]
+_BENIGN_ACTION_TYPES = [
+    "investigate", "research", "analyze",  # EXTERNAL_READ
+    "diagnose", "monitor",                 # OBSERVE
+    "maintenance", "config", "optimize",   # INTERNAL_WRITE
+    "notification", "alert", "j9_regression",  # NOTIFY_USER
+]
+
+
+def test_high_risk_domains_is_the_external_and_self_modify_set():
+    expected = {
+        ActionDomain.EXTERNAL_WRITE,
+        ActionDomain.REPRESENT_USER,
+        ActionDomain.FINANCIAL,
+        ActionDomain.SELF_MODIFY,
+    }
+    assert set(HIGH_RISK_DOMAINS) == expected
+
+
+@pytest.mark.parametrize("domain", sorted(HIGH_RISK_DOMAINS, key=str))
+def test_is_high_risk_true(domain):
+    assert is_high_risk_domain(domain) is True
+
+
+@pytest.mark.parametrize("domain", [
+    ActionDomain.OBSERVE,
+    ActionDomain.EXTERNAL_READ,
+    ActionDomain.INTERNAL_WRITE,
+    ActionDomain.NOTIFY_USER,
+])
+def test_is_high_risk_false_for_benign(domain):
+    assert is_high_risk_domain(domain) is False
+
+
+@pytest.mark.parametrize("action_type", _HIGH_RISK_ACTION_TYPES)
+def test_gate_failure_blocks_high_risk(action_type):
+    assert gate_failure_is_blocking({"action_type": action_type}) is True
+
+
+@pytest.mark.parametrize("action_type", _BENIGN_ACTION_TYPES)
+def test_gate_failure_allows_benign(action_type):
+    assert gate_failure_is_blocking({"action_type": action_type}) is False
+
+
+def test_gate_failure_blocks_unmapped_type_with_high_risk_plan_hint():
+    # Unknown action_type, but the execution_plan mentions publishing ->
+    # classify_domain heuristic returns EXTERNAL_WRITE -> block.
+    prop = {"action_type": "mystery", "execution_plan": "publish the post to medium"}
+    assert gate_failure_is_blocking(prop) is True
+
+
+def test_gate_failure_allows_fully_unmapped():
+    # classify_domain's fallback is EXTERNAL_READ (benign) -> allow, so a
+    # transient gate error can't wedge routine (non-external) autonomy.
+    prop = {"action_type": "totally_unknown_type", "execution_plan": ""}
+    assert gate_failure_is_blocking(prop) is False
+
+
+def test_gate_failure_null_execution_plan_does_not_raise():
+    # execution_plan can be NULL in the DB -> None; helper must coerce to "".
+    prop = {"action_type": "outreach", "execution_plan": None}
+    assert gate_failure_is_blocking(prop) is True
+
+
+async def test_sentinel_blocks_high_risk_and_reports_domain():
+    decision = await DenyHighRiskSentinel().evaluate({"action_type": "publish"})
+    assert isinstance(decision, DispatchDecision)
+    assert decision.allowed is False
+    assert decision.action_domain == ActionDomain.EXTERNAL_WRITE
+    assert decision.rule_id  # non-empty so the block event carries a rule id
+
+
+async def test_sentinel_allows_benign_and_reports_domain():
+    decision = await DenyHighRiskSentinel().evaluate({"action_type": "investigate"})
+    assert decision.allowed is True
+    assert decision.action_domain == ActionDomain.EXTERNAL_READ

--- a/tests/test_autonomy/test_proposal_gate_sentinel.py
+++ b/tests/test_autonomy/test_proposal_gate_sentinel.py
@@ -89,6 +89,13 @@ def test_gate_failure_null_execution_plan_does_not_raise():
     assert gate_failure_is_blocking(prop) is True
 
 
+def test_gate_failure_blocks_on_undeterminable_proposal():
+    # A None / malformed proposal (e.g. get_proposal raised, leaving the row
+    # unresolved) is undeterminable -> classify raises -> fail CLOSED. Backs the
+    # `prop_row is None or ...` guard in _process_execution_briefs.
+    assert gate_failure_is_blocking(None) is True
+
+
 async def test_sentinel_blocks_high_risk_and_reports_domain():
     decision = await DenyHighRiskSentinel().evaluate({"action_type": "publish"})
     assert isinstance(decision, DispatchDecision)

--- a/tests/test_mcp/test_web_agent_budget.py
+++ b/tests/test_mcp/test_web_agent_budget.py
@@ -1,0 +1,53 @@
+"""web_agent must NOT auto-deny on an exceeded budget (Design Principle 3).
+
+Cost is observability, never automatic control. When the daily budget is
+EXCEEDED the tool logs a warning and PROCEEDS to the agent call instead of
+returning an error — verified here by asserting the adapter is reached.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+from genesis.mcp.health.web_tools import web_agent
+
+
+@asynccontextmanager
+async def _fake_db(*_a, **_k):
+    yield object()
+
+
+class _ExceededTracker:
+    def __init__(self, _db):
+        pass
+
+    async def check_budget(self):
+        return "EXCEEDED"
+
+
+class _AdapterReached:
+    """Adapter stub whose failure result proves control reached the agent call
+    rather than short-circuiting on the budget check."""
+
+    class _Result:
+        success = False
+        error = "ADAPTER_REACHED"
+        data = None
+
+    async def invoke(self, _payload):
+        return self._Result()
+
+
+async def test_web_agent_proceeds_when_budget_exceeded(monkeypatch):
+    monkeypatch.setenv("API_KEY_TINYFISH", "test-key")
+    with (
+        patch("genesis.db.connection.get_raw_db", _fake_db),
+        patch("genesis.routing.cost_tracker.CostTracker", _ExceededTracker),
+        patch("genesis.providers.tinyfish_agent.TinyFishAgentAdapter", _AdapterReached),
+    ):
+        result = await web_agent.fn(url="https://example.com", goal="do a thing")
+
+    # Reached the adapter (proceeded) — NOT the old budget short-circuit.
+    assert result["error"] == "ADAPTER_REACHED"
+    assert "budget" not in str(result).lower()

--- a/tests/test_runtime/test_autonomy_init_sentinel.py
+++ b/tests/test_runtime/test_autonomy_init_sentinel.py
@@ -1,0 +1,31 @@
+"""The autonomy init must NEVER leave the proposal dispatch gate unset.
+
+Previously, if the real ``ProposalDispatchGate`` could not be built, the
+attribute stayed unset and the ego wired it as ``None`` -> every approved
+proposal dispatched UNGATED (a silent fail-OPEN).  Stage-1 hardening installs
+a fail-closed ``DenyHighRiskSentinel`` by default, so any non-success path
+leaves a blocking gate.
+"""
+
+from __future__ import annotations
+
+import types
+
+from genesis.autonomy.proposal_gate import DenyHighRiskSentinel
+from genesis.runtime.init import autonomy as autonomy_init
+
+
+async def test_init_installs_fail_closed_sentinel_when_db_missing():
+    """With no DB the real gate is never built — the sentinel must remain."""
+    rt = types.SimpleNamespace(
+        _db=None,
+        _event_bus=None,
+        _cc_invoker=None,
+        _outreach_pipeline=None,
+        _awareness_loop=None,
+    )
+
+    await autonomy_init.init(rt)
+
+    # Never left unset (the ego reads a missing gate as "no gate" => bypass).
+    assert isinstance(rt._proposal_dispatch_gate, DenyHighRiskSentinel)


### PR DESCRIPTION
## What & why

Stage 1 of the WS5 autonomy-gating hardening. Closes two fail-OPEN holes in the proposal dispatch gate and removes a cost-based auto-deny that violated Design Principle 3 (cost is observability, never automatic control).

### Fail-closed dispatch gate (risk-tiered)

The dispatch gate is the last safety check before an already-approved ego proposal runs autonomously in the background. Two ways it could silently fail open:

- **Init failure → gate unset.** If `ProposalDispatchGate` couldn't be built, the runtime attribute stayed unset and the ego wired it as `None` → every approved proposal dispatched **ungated**. Now a fail-closed `DenyHighRiskSentinel` is installed as the default *before* the real gate is built, so any failure path leaves a blocking gate. Init errors are surfaced (`autonomy.gate_init_failed`, ERROR). The post-execution auditor is observability (not a gate) → visibility upgrade only, no deny.
- **Gate-eval exception → allow.** The two ego dispatch except-blocks previously fell through to ALLOW on a gate error. Now **risk-tiered**: BLOCK external-write / represent-user / financial / self-modify domains (fail-closed), stay resilient (allow) for benign domains so a transient error can't wedge the ego cycle. Shared, dependency-free helpers live in `autonomy/proposal_gate.py`.

### web_agent (Design Principle 3)

`web_agent`'s daily-budget-EXCEEDED check auto-denied the tool. Cost is observability, never control — it now logs a warning and proceeds.

## Testing

- New unit tests: sentinel + risk-tier helpers + `init()` installs the sentinel when the gate can't be built.
- Full changed-area regression green (autonomy, ego, runtime, web tools).
- Runtime E2E: a real `init()` installs the blocking sentinel; sentinel/helper decisions verified with real objects.
- architect-reviewed; code-reviewed (a fail-open `prop_row`-unbound bug in the except handler was caught and fixed).

## Scope

Stage 1 of 3. No migration. Deferred to later stages: the CI external-I/O guard (a raw-POST grep proved a weak proxy), and the actual gating of the direct discord/poll/medium/reply publish paths (which carries a live-behavior decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
