### PR TITLE
fix(attention): enable label buttons — strict-boolean :disabled binding

### DIFF
--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -10701,11 +10701,11 @@
                   <span class="material-symbols-outlined" style="font-size:1rem; vertical-align:middle;"
                         x-text="$store.genesisDashboard.attentionRevealed[ev.id] !== undefined ? 'visibility_off' : 'visibility'"></span>
                 </button>
-                <button class="btn-sm" style="padding:.15rem .5rem;" :disabled="$store.genesisDashboard.attentionLabeling[ev.id]"
+                <button class="btn-sm" style="padding:.15rem .5rem;" :disabled="$store.genesisDashboard.attentionLabeling[ev.id] === true"
                         @click="$store.genesisDashboard.labelAttentionEvent(ev.id, 'should')">should</button>
-                <button class="btn-sm" style="padding:.15rem .5rem;" :disabled="$store.genesisDashboard.attentionLabeling[ev.id]"
+                <button class="btn-sm" style="padding:.15rem .5rem;" :disabled="$store.genesisDashboard.attentionLabeling[ev.id] === true"
                         @click="$store.genesisDashboard.labelAttentionEvent(ev.id, 'shouldnt')">shouldn't</button>
-                <button class="btn-sm" style="padding:.15rem .5rem; opacity:.7;" :disabled="$store.genesisDashboard.attentionLabeling[ev.id]"
+                <button class="btn-sm" style="padding:.15rem .5rem; opacity:.7;" :disabled="$store.genesisDashboard.attentionLabeling[ev.id] === true"
                         @click="$store.genesisDashboard.labelAttentionEvent(ev.id, 'skip')">skip</button>
               </div>
             </div>


### PR DESCRIPTION
## What

Follow-up to #829 (Attention review tab). **Live browser E2E** revealed the should/shouldn't/skip label buttons rendered permanently **disabled**.

## Root cause

In this Alpine build, `:disabled="$store...attentionLabeling[ev.id]"` where the key is unset evaluates to `undefined`, which Alpine treats as truthy for the boolean `disabled` attribute (renders `disabled="disabled"`). Coercing to a strict boolean fixes it:

```
:disabled="$store.genesisDashboard.attentionLabeling[ev.id] === true"
```

The `attentionLabeling` map only ever stores `true` (while a label POST is in flight), so `=== true` is exact.

## Verification (live)

Swapped the fixed template onto the running dashboard and confirmed via the browser: all label buttons **enabled at rest**, disable during the in-flight request, and labels persist to `attention_events` (verified 2 rows written via real clicks). Reveal + list + stats + the per-trigger dominance bar all render correctly. Template-only change (no restart/migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)