### PR TITLE
chore(dev): scrub private text from merged test docstring + add push/merge gates

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -195,6 +195,14 @@ Verify before any commit:
 - `git status --short` — check untracked files (should be staged or ignored)
 - Review level applied matches the adaptive protocol above
 - Staged files do not include secrets (`secrets.env`, `.env`, credentials)
+- **Private-data scan before every push (public repo).** Grep the ENTIRE diff
+  (`git diff origin/main...HEAD`) for private/identifying data — real names,
+  company/product names, emails, IPs, private career/project specifics, verbatim
+  user messages. Check ALL surfaces, not just prose: **source comments,
+  docstrings, and test fixtures/data** are the easy misses. Use a synthetic
+  stand-in in tests, never the real private artifact. (2026-07-01: a verbatim
+  private DM leaked via a test docstring + a code comment after the commit
+  message and PR body were already clean.)
 - GROUNDWORK-tagged code not accidentally deleted
 - New capabilities registered in `_capabilities.py` + bootstrap manifest
 - **Conventional commit prefixes**: `feat:`, `fix:`, `refactor:`, `docs:`,
@@ -221,6 +229,13 @@ Verify before any commit:
 5. **Override**: Append `# review-override` to the merge command to
    bypass the gate (e.g., `gh pr merge 123 --squash --admin  # review-override`).
    The override is logged. Use only when findings are intentionally accepted.
+6. **Read the PR's warning comments before merging — not just the hard gate.**
+   Beyond Codex, a structural-review bot posts under the repo-owner account
+   (`WingedGuardian`, review state COMMENTED) and emits **SOFT WARNINGs** (PII /
+   private-text / wording) that the hook does NOT block on and that a naive
+   `.comments` scan misses. Check BOTH `gh pr view N --json reviews,comments`
+   and `gh api repos/<owner>/<repo>/pulls/N/comments`, and address each soft
+   warning or consciously accept it. Never merge past an unread warning.
 
 ## Reference Router
 

--- a/tests/test_learning/test_classification.py
+++ b/tests/test_learning/test_classification.py
@@ -188,10 +188,10 @@ class TestOutcomeClassifier:
     async def test_prompt_scopes_goals_to_attempted_tasks(self):
         """IR-1b: a goal counts only if Genesis ATTEMPTED it this turn.
 
-        The 2026-06-30 incident: a Telegram status-update ("Autonomize is dead…
-        but we should continue… its never too late") was mislabeled
-        approach_failure because the classifier scored the user's external
-        statuses and forward-looking intent as failed goals, which fired the
+        The 2026-06-30 incident: a benign Telegram status-update (the user
+        reporting the state of their own external projects plus a forward-looking
+        intent) was mislabeled approach_failure because the classifier scored the
+        user's external statuses and forward-looking intent as failed goals, which fired the
         STEERING auto-write and a false autonomy correction. The prompt must
         scope "goal" to concrete tasks Genesis attempted, and treat status /
         forward-intent / clarifying-question turns as success. Behavioral proof


### PR DESCRIPTION
Fix-forward cleanup after the 2026-07-01 privacy incident.

## Scrub
The incident test in `test_classification.py` (merged in #826) quoted the **verbatim private Telegram DM** in its docstring — a real company name plus the user's career specifics. Replaced with a generic description; the test's assertions are unchanged (they check the prompt text, not the docstring).

## Standing gates (genesis-development skill)
Formalizes two checks so this doesn't recur:
- **Pre-push private-data scan** — grep the ENTIRE diff (comments, docstrings, **test fixtures**, not just prose) for private/identifying data before pushing to the public repo.
- **Pre-merge warning-comment check** — read the PR's warnings including the structural-review bot that posts under the repo-owner account (soft warnings the hard gate doesn't block on).

Docs + one test-docstring line; no runtime behavior change.