### PR TITLE
fix(cc): break cc.contingency <-> awareness.loop circular import

### DIFF
--- a/src/genesis/awareness/__init__.py
+++ b/src/genesis/awareness/__init__.py
@@ -1,15 +1,19 @@
-"""Genesis Awareness Loop — the system's heartbeat.
+"""Genesis Awareness package.
 
-Public API (import from genesis.awareness directly):
-- AwarenessLoop: Main loop class — periodic signal collection and depth-based ticking
-- JobRetryRegistry: Retry tracking for failed awareness jobs
-- SignalReading: Data class for individual signal measurements
-- Depth: Enum for tick depth levels (MICRO, LIGHT, DEEP, STRATEGIC)
-- TickResult: Result of a single awareness tick
+Public API:
+- AwarenessLoop: main heartbeat loop (periodic signal collection + depth ticks)
+- JobRetryRegistry: retry tracking for failed awareness jobs
+- Depth, SignalReading, TickResult: lightweight leaf types
+
+AwarenessLoop and JobRetryRegistry are exposed LAZILY (PEP 562 module __getattr__)
+so importing the leaf types — or any module that transitively touches this package
+(e.g. cc.contingency importing Depth) — does NOT eagerly load loop.py and its heavy
+async machinery. Eager-loading loop.py here previously created an import cycle
+(cc.contingency -> awareness.types -> this __init__ -> loop -> cc.contingency). For
+eager access, import from the submodules directly (genesis.awareness.loop /
+genesis.awareness.job_retry).
 """
 
-from genesis.awareness.job_retry import JobRetryRegistry
-from genesis.awareness.loop import AwarenessLoop
 from genesis.awareness.types import Depth, SignalReading, TickResult
 
 __all__ = [
@@ -19,3 +23,24 @@ __all__ = [
     "SignalReading",
     "TickResult",
 ]
+
+
+def __getattr__(name: str):
+    # PEP 562 lazy re-export — see the module docstring for the cycle rationale.
+    # Cache the resolved symbol back onto the module so later lookups are plain
+    # dict hits and __getattr__ is not re-entered.
+    if name == "AwarenessLoop":
+        from genesis.awareness.loop import AwarenessLoop
+
+        globals()[name] = AwarenessLoop
+        return AwarenessLoop
+    if name == "JobRetryRegistry":
+        from genesis.awareness.job_retry import JobRetryRegistry
+
+        globals()[name] = JobRetryRegistry
+        return JobRetryRegistry
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -28,7 +28,7 @@ from genesis.awareness.classifier import classify_depth
 from genesis.awareness.scorer import compute_scores, get_staleness_context
 from genesis.awareness.signals import SignalCollector, collect_all
 from genesis.awareness.types import Depth, TickResult
-from genesis.cc.contingency import RATE_LIMIT_DEFERRAL_TTL_S
+from genesis.cc.constants import RATE_LIMIT_DEFERRAL_TTL_S
 from genesis.db.crud import awareness_ticks, observations
 from genesis.observability.events import GenesisEventBus
 from genesis.observability.types import Severity, Subsystem

--- a/src/genesis/cc/constants.py
+++ b/src/genesis/cc/constants.py
@@ -1,0 +1,13 @@
+"""CC-layer shared constants.
+
+Home for CC-domain constants that must be referenced from OUTSIDE the cc package
+(e.g. genesis.awareness.loop) without importing cc.contingency — importing
+contingency from awareness created a package-level import cycle
+(cc.contingency <-> awareness.loop). Keep this a LEAF module: stdlib-only, no
+genesis imports.
+"""
+
+# How long deferred CC work persists before expiry. Matches the typical CC Max
+# rate-limit reset window. Referenced by cc.contingency, awareness.loop, and
+# cc.reflection_bridge._bridge.
+RATE_LIMIT_DEFERRAL_TTL_S = 14400  # 4 hours

--- a/src/genesis/cc/contingency.py
+++ b/src/genesis/cc/contingency.py
@@ -14,6 +14,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from genesis.awareness.types import Depth
+from genesis.cc.constants import RATE_LIMIT_DEFERRAL_TTL_S
 
 if TYPE_CHECKING:
     from genesis.resilience.deferred_work import DeferredWorkQueue
@@ -21,10 +22,6 @@ if TYPE_CHECKING:
     from genesis.routing.router import Router
 
 logger = logging.getLogger(__name__)
-
-# How long deferred items persist before expiry. Matches typical CC Max rate
-# limit reset window. Referenced from awareness/loop.py and reflection_bridge.py.
-RATE_LIMIT_DEFERRAL_TTL_S = 14400  # 4 hours
 
 # Depths that should be deferred (not routed to API) when CC is down.
 # Deep and Light reflections require Claude-quality reasoning — falling back

--- a/src/genesis/cc/reflection_bridge/_bridge.py
+++ b/src/genesis/cc/reflection_bridge/_bridge.py
@@ -19,7 +19,7 @@ from genesis.autonomy.autonomous_dispatch import AutonomousDispatchRequest
 from genesis.autonomy.dispatch_gate import check_dispatch_preconditions
 from genesis.autonomy.types import ActionClass, ApprovalDecision, AutonomyCategory
 from genesis.awareness.types import Depth
-from genesis.cc.contingency import RATE_LIMIT_DEFERRAL_TTL_S
+from genesis.cc.constants import RATE_LIMIT_DEFERRAL_TTL_S
 from genesis.cc.reflection_bridge._output import (
     route_deep_output,
     send_to_topic,

--- a/tests/test_cc/test_import_cycle.py
+++ b/tests/test_cc/test_import_cycle.py
@@ -1,0 +1,57 @@
+"""Regression guard: genesis.cc.contingency <-> genesis.awareness.loop import cycle.
+
+A layering inversion (awareness.loop importing a CC-domain constant from
+cc.contingency, combined with an eager awareness/__init__ that pulled in
+awareness.loop) once made ``import genesis.cc.contingency`` fail with an
+ImportError ("cannot import name 'RATE_LIMIT_DEFERRAL_TTL_S' from partially
+initialized module") under certain import orders. The full test suite masked it
+because an earlier test imported awareness.loop first.
+
+These tests import the modules in a FRESH interpreter so that sys.modules caching
+cannot hide a re-introduced cycle, and assert both import orders succeed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _import_in_fresh_process(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_import_contingency_first_no_cycle() -> None:
+    # This exact order used to raise the partially-initialized-module ImportError.
+    proc = _import_in_fresh_process(
+        "import genesis.cc.contingency; import genesis.awareness.loop"
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_import_awareness_loop_first_no_cycle() -> None:
+    proc = _import_in_fresh_process(
+        "import genesis.awareness.loop; import genesis.cc.contingency"
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_awareness_lazy_public_api_preserved() -> None:
+    # De-eagering awareness/__init__ (PEP 562 __getattr__) must not drop the
+    # documented package-level re-exports.
+    proc = _import_in_fresh_process(
+        "from genesis.awareness import "
+        "AwarenessLoop, Depth, JobRetryRegistry, SignalReading, TickResult"
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_rate_limit_ttl_constant_single_source() -> None:
+    from genesis.cc.constants import RATE_LIMIT_DEFERRAL_TTL_S as from_constants
+    from genesis.cc.contingency import RATE_LIMIT_DEFERRAL_TTL_S as from_contingency
+
+    assert from_constants == from_contingency == 14400


### PR DESCRIPTION
## What & why

A latent circular import between `genesis.cc.contingency` and `genesis.awareness.loop`. Importing `cc.contingency` first (e.g. running the `test_quota_exhausted_triggers_contingency` test in isolation) raised:

```
ImportError: cannot import name 'RATE_LIMIT_DEFERRAL_TTL_S' from partially initialized module 'genesis.cc.contingency'
```

It reproduces on clean `main` and is order-dependent — the full test suite masks it because an earlier test imports `awareness.loop` first. Found during unrelated merge verification.

### The cycle

- `cc/contingency.py` imports `Depth` from `awareness.types` (legitimate; used at module load).
- Touching the `awareness` package ran `awareness/__init__.py`, which **eagerly** imported `AwarenessLoop` from `awareness.loop`.
- `awareness/loop.py` imported `RATE_LIMIT_DEFERRAL_TTL_S` back from the still-initializing `cc.contingency` — a **layering inversion** (a low-level heartbeat reaching up into the CC dispatcher for a CC-domain constant).

## The fix (two independent break-points, both root-cause)

1. **Relocate the shared constant** to a new stdlib-only leaf `cc/constants.py`. `awareness.loop` and `cc.reflection_bridge._bridge` now import it from there instead of `cc.contingency`, removing the inverted `awareness -> cc` edge. `cc.contingency` re-imports the name, so its namespace (and any `from cc.contingency import RATE_LIMIT_DEFERRAL_TTL_S`) is unchanged.
2. **De-eager `awareness/__init__.py`** — `AwarenessLoop` / `JobRetryRegistry` are now exposed via a PEP 562 module-level `__getattr__` (lazy, cached). Importing the leaf types no longer drags in `loop.py`'s heavy async machinery. The documented public API (`from genesis.awareness import AwarenessLoop`) is preserved.

Constant value (14400) and all public behaviour are unchanged. No migration.

## Validation

- Fresh-process import probes: importing `cc.contingency` first now succeeds (was failing); `loop`-first OK; `from genesis.awareness import AwarenessLoop, Depth, JobRetryRegistry, SignalReading, TickResult` OK (lazy API preserved); `from genesis.awareness import loop, scorer` (submodule) OK under lazy init; unknown attribute still raises `AttributeError`; the constant is identical from both `cc.constants` and `cc.contingency`.
- `ruff` clean; `tests/test_cc/` + `tests/test_awareness/` = **598 passed, 2 skipped**. The previously-erroring `test_quota_exhausted_triggers_contingency` passes in isolation.
- Reviewed (automated code-reviewer): SHIP; the one nit raised (cache the lazily-resolved symbol per canonical PEP 562) is applied.

## Regression markers

If the fix is wrong, a fresh-process import of `cc.contingency` (or `awareness.loop`) would `ImportError` again, or `from genesis.awareness import AwarenessLoop` would stop resolving. Watch for either after deploy.
