### PR TITLE
fix(install): align container Claude Code to the pinned version on install/bootstrap/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Genesis now keeps your Claude Code CLI at the version it's tested against — automatically.**
+  Previously the installer only put Claude Code in place when it was *missing*, so if you already
+  had an older Claude Code, bumping the pinned version never actually upgraded you — you'd silently
+  keep running the old one. Now `install.sh`, `bootstrap.sh`, and `update.sh` all install *or* align
+  Claude Code to the pinned version on every run (matching it exactly, so an intentional rollback
+  also applies), with no manual step. It's non-fatal: if the update can't run (e.g. no permissions),
+  your update still completes and Claude Code is left as-is.
 - **A casual message can no longer be mistaken for a permanent "hard rule" — and your
   steering-rules file keeps its structure.** Genesis auto-adds a steering rule only when you
   actually give it a terse directive ("stop doing X", "never do Y"); an ordinary status update

--- a/docs/reference/cc-compatibility.md
+++ b/docs/reference/cc-compatibility.md
@@ -16,8 +16,16 @@
 ## Current CC Version
 
 **Installed:** Claude Code 2.1.173 on the **container** (upgraded 2026-06-11 from 2.1.170 — Fable 5 `[1m]` model-ID normalization fix + 2.1.172 long-conversation render perf). The **host VM** runs **2.1.87** — deliberately held there after the 2.1.90 Linux scrollback regression (see the 2.1.90 row below). 2.1.173 (the fullscreen-renderer scrollback fix) is the version the host is now being moved to via the unified updater. **Both** container and host install Claude Code **via npm-global** (`npm install -g @anthropic-ai/claude-code@<version>` — the container auto-detects its npm prefix, the host uses `sudo npm install -g`). There is no native-installer path.
-**Pin (single source of truth):** `CC_VERSION` in `scripts/lib/cc_version.sh`, sourced by `scripts/install.sh`, `scripts/host-setup.sh`, and `scripts/update.sh`. Bump it in one place; the next `update.sh` run syncs the host (see "Updating Claude Code" below).
-**Minimum required by Genesis:** intentionally **not enforced** at runtime (all current code works with 2.0+). A managed-settings `requiredMinimumVersion` floor (`/etc/claude-code/managed-settings.json`, Linux-only — never read from user/project `settings.json`) was evaluated and **deliberately rejected**: a hard floor removes the incident-recovery downgrade path the project has actually used (the 2.1.90→2.1.87 scrollback rollback) and can brick CC if the floor is written above the installed version. Drift is prevented instead by the npm pin + the unified `update-cc` updater + `DISABLE_AUTOUPDATER`/`DISABLE_UPDATES` (so CC never self-bumps).
+**Pin (single source of truth):** `CC_VERSION` in `scripts/lib/cc_version.sh`, which
+also exports the shared **`cc_ensure_local`** aligner. Sourced by `scripts/install.sh`,
+`scripts/host-setup.sh`, `scripts/bootstrap.sh`, and `scripts/update.sh`. Bump it in one
+place; the next `install.sh`/`bootstrap.sh`/`update.sh` run aligns the **container's**
+own Claude Code to the pin via `cc_ensure_local` (installs when absent AND upgrades/
+downgrades a drifted-but-present CC — the earlier scripts only installed when CC was
+*missing*, so a bumped pin never reached an already-installed container). `update.sh`
+additionally syncs the **host VM** via the guardian `update-cc` op (see "Updating Claude
+Code" below).
+**Minimum required by Genesis:** intentionally **not enforced** at runtime (all current code works with 2.0+). A managed-settings `requiredMinimumVersion` floor (`/etc/claude-code/managed-settings.json`, Linux-only — never read from user/project `settings.json`) was evaluated and **deliberately rejected**: a hard floor removes the incident-recovery downgrade path the project has actually used (the 2.1.90→2.1.87 scrollback rollback) and can brick CC if the floor is written above the installed version. Drift is prevented instead by the npm pin + `cc_ensure_local` (aligns the local CC to the pin on every install/bootstrap/update — exact-match, so a downgrade pin also applies) + the unified `update-cc` updater for the host + `DISABLE_AUTOUPDATER`/`DISABLE_UPDATES` (so CC never self-bumps).
 
 ---
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -271,6 +271,18 @@ else
     echo "  Node: $(node --version 2>/dev/null || echo 'not available') (needs >= 20)"
 fi
 
+# --- Claude Code version pin (install or align to the pinned version) ---
+# Node/npm are set up above. Align the local Claude Code to the repo pin so a
+# bump reaches the container via `bootstrap.sh` too (not just install.sh).
+# Non-fatal (`|| true`): `set -e` is active — a CC hiccup must not abort bootstrap.
+_cc_env="$SCRIPT_DIR/lib/cc_version.sh"
+if [ -f "$_cc_env" ]; then
+    echo "--- Aligning Claude Code to pinned version ---"
+    # shellcheck source=/dev/null
+    source "$_cc_env"
+    cc_ensure_local || true
+fi
+
 # bubblewrap (sandbox for codex exec — optional)
 if ! command -v bwrap &>/dev/null; then
     echo "  bubblewrap not found — installing..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1167,35 +1167,12 @@ fi
 source "$_cc_env"
 echo "  [12/$TOTAL_STEPS] Setting up Claude Code (v${CC_VERSION})..."
 
-if command -v claude &>/dev/null; then
-    cc_ver=$(claude --version 2>/dev/null || echo "unknown")
-    echo "    . Claude Code already installed ($cc_ver)"
-else
-    echo "    Installing Claude Code via npm..."
-    # Detect the npm prefix that PATH will actually resolve. The user may have
-    # a custom prefix (~/.npm-global) that shadows /usr/local. Install to
-    # whichever prefix `npm config get prefix` returns so `which claude` finds
-    # the new binary. See docs/reference/cc-compatibility.md.
-    _npm_prefix="$(npm config get prefix 2>/dev/null)"
-    if [ -n "$_npm_prefix" ] && [ "$_npm_prefix" != "/usr/local" ] && [ "$_npm_prefix" != "/usr" ]; then
-        # User-level prefix (e.g. ~/.npm-global) — no sudo needed
-        _npm_cmd="npm install -g @anthropic-ai/claude-code@${CC_VERSION}"
-        echo "    Using user npm prefix: $_npm_prefix"
-    else
-        # System prefix — use sudo + explicit /usr/local to avoid /usr/lib misrouting
-        _npm_cmd="npm install -g --prefix /usr/local @anthropic-ai/claude-code@${CC_VERSION}"
-        if [ "$(id -u)" != "0" ] && command -v sudo &>/dev/null; then
-            _npm_cmd="sudo npm install -g --prefix /usr/local @anthropic-ai/claude-code@${CC_VERSION}"
-        fi
-    fi
-    if timeout 300 $_npm_cmd; then
-        cc_ver=$(claude --version 2>/dev/null || echo "unknown")
-        echo "    + Claude Code installed ($cc_ver)"
-    else
-        echo "    WARNING: Claude Code installation failed"
-        echo "    Install manually: npm install -g @anthropic-ai/claude-code@${CC_VERSION}"
-        SETUP_WARNINGS=1
-    fi
+# Install OR align to the pin — cc_ensure_local (scripts/lib/cc_version.sh, sourced
+# above) installs when absent AND upgrades/downgrades a drifted-but-present CC to
+# the pin (the prior "already installed → skip" check never re-aligned drift).
+if ! cc_ensure_local; then
+    echo "    Install manually: npm install -g @anthropic-ai/claude-code@${CC_VERSION}"
+    SETUP_WARNINGS=1
 fi
 
 # Genesis wrapper — lets users type 'genesis' from anywhere inside the container

--- a/scripts/lib/cc_version.sh
+++ b/scripts/lib/cc_version.sh
@@ -62,12 +62,18 @@ cc_ensure_local() {
             return 0
         fi
         echo "--- Claude Code drift: ${current:-unknown} -> $pin (aligning) ---"
-        # Reinstall to the existing binary's OWN prefix so `which claude` updates.
+        # Reinstall to the existing binary's OWN prefix so `which claude` updates
+        # (npm config prefix can differ, which would install a 2nd copy and leave
+        # `which claude` stale). Assumes an npm-global install (Genesis has no
+        # native-installer path — see docs/reference/cc-compatibility.md); a
+        # non-npm launcher would be reinstalled to the wrong place, but the
+        # post-install verify below downgrades that to a non-fatal warning.
         prefix="$(dirname "$(dirname "$existing")")"   # /usr/local/bin/claude -> /usr/local
     else
         echo "  Claude Code not installed — installing pinned $pin"
-        prefix="$(npm config get prefix 2>/dev/null || echo /usr/local)"
-        [ "$prefix" = "/usr" ] && prefix="/usr/local"
+        prefix="$(npm config get prefix 2>/dev/null)"
+        [ -n "$prefix" ] || prefix="/usr/local"        # guard empty-but-rc-0 output
+        [ "$prefix" = "/usr" ] && prefix="/usr/local"  # avoid /usr/lib misrouting
     fi
 
     # Always pass --prefix explicitly (deterministic target). sudo only for

--- a/scripts/lib/cc_version.sh
+++ b/scripts/lib/cc_version.sh
@@ -1,12 +1,15 @@
 # shellcheck shell=bash
 # (sourced fragment, not an executable script — no shebang)
 #
-# Single source of truth for the Claude Code version Genesis installs/pins.
+# Single source of truth for the Claude Code version Genesis installs/pins,
+# PLUS the shared `cc_ensure_local` aligner that keeps the LOCAL machine's CC at
+# the pin.
 #
 # Sourced by scripts/install.sh (container), scripts/host-setup.sh (host VM),
-# and scripts/update.sh (which dispatches this pin to the host via the
-# guardian-gateway `update-cc` op). Bump CC_VERSION here in ONE place — the next
-# `update.sh` run syncs the host so container and host never drift.
+# scripts/bootstrap.sh, and scripts/update.sh. update.sh ALSO dispatches this pin
+# to the host VM via the guardian-gateway `update-cc` op. Bump CC_VERSION here in
+# ONE place — the next install/bootstrap/update run aligns the local CC, so the
+# container and host never drift.
 #
 # Governance model (see docs/reference/cc-compatibility.md): the npm pin below
 # + the unified `update-cc` updater + DISABLE_UPDATES in ~/.claude/settings.json.
@@ -15,3 +18,88 @@
 #
 # Honors an inherited CC_VERSION (e.g. `CC_VERSION=2.1.180 ./install.sh`).
 CC_VERSION="${CC_VERSION:-2.1.173}"
+
+
+# cc_ensure_local — install or align the LOCAL Claude Code CLI to $CC_VERSION.
+#
+# Idempotent, non-fatal, drift-healing. Container/local ONLY — the host VM's CC
+# is synced separately by update.sh via the guardian `update-cc` op. Callers
+# decide fatality: `cc_ensure_local || true` (update.sh/bootstrap.sh, where a
+# failure must never abort) or `cc_ensure_local || SETUP_WARNINGS=1` (install.sh).
+#
+# Behavior:
+#   - npm missing            -> warn + return 0 (nothing we can do; skip)
+#   - claude already at pin   -> return 0 (no-op)
+#   - claude present, drifted -> reinstall @pin to the SAME prefix the existing
+#                                binary resolves from (NOT `npm config get prefix`
+#                                — the two can differ, which would install beside
+#                                the live binary and leave `which claude` stale)
+#   - claude absent (fresh)   -> install @pin to `npm config get prefix`
+#                                (/usr remapped to /usr/local to avoid /usr/lib
+#                                misrouting — matches install.sh)
+#   - post-install: re-check `claude --version`; still != pin -> warn + return 1
+#
+# Exact-match to the pin (the pin may legitimately go DOWN for incident rollback;
+# `npm install @X.Y.Z` pins exactly X.Y.Z). NOTE `claude --version` prints
+# "2.1.173 (Claude Code)", so the version is field 1 (awk '{print $1}').
+cc_ensure_local() {
+    local pin="${CC_VERSION:-}"
+    if [ -z "$pin" ]; then
+        echo "  cc_ensure_local: CC_VERSION unset — skipping" >&2
+        return 0
+    fi
+    if ! command -v npm >/dev/null 2>&1; then
+        echo "  cc_ensure_local: npm not found — cannot manage Claude Code (skipping)" >&2
+        return 0
+    fi
+
+    local existing current prefix
+    existing="$(command -v claude 2>/dev/null || true)"
+    if [ -n "$existing" ]; then
+        current="$(claude --version 2>/dev/null | awk '{print $1}')"
+        if [ "$current" = "$pin" ]; then
+            echo "  Claude Code already at pin ($pin)"
+            return 0
+        fi
+        echo "--- Claude Code drift: ${current:-unknown} -> $pin (aligning) ---"
+        # Reinstall to the existing binary's OWN prefix so `which claude` updates.
+        prefix="$(dirname "$(dirname "$existing")")"   # /usr/local/bin/claude -> /usr/local
+    else
+        echo "  Claude Code not installed — installing pinned $pin"
+        prefix="$(npm config get prefix 2>/dev/null || echo /usr/local)"
+        [ "$prefix" = "/usr" ] && prefix="/usr/local"
+    fi
+
+    # Always pass --prefix explicitly (deterministic target). sudo only for
+    # system prefixes; user prefixes (~/.npm-global, nvm) are user-writable.
+    local -a npm_args
+    npm_args=(npm install -g --prefix "$prefix" "@anthropic-ai/claude-code@${pin}")
+    case "$prefix" in
+        /usr|/usr/local|/opt/*)
+            if [ "$(id -u)" != "0" ]; then
+                if command -v sudo >/dev/null 2>&1; then
+                    # PATH passthrough: npm is often nvm-managed + absent from
+                    # sudo's secure_path (matches host-setup.sh).
+                    npm_args=(sudo env "PATH=$PATH" "${npm_args[@]}")
+                else
+                    echo "  cc_ensure_local: sudo unavailable — cannot install to $prefix (skipping)" >&2
+                    return 0
+                fi
+            fi
+            ;;
+    esac
+
+    if ! timeout 300 "${npm_args[@]}"; then
+        echo "  WARNING: cc_ensure_local: npm install failed (non-fatal)" >&2
+        return 1
+    fi
+    hash -r 2>/dev/null || true   # drop bash's cached path to the old binary
+    local installed
+    installed="$(claude --version 2>/dev/null | awk '{print $1}')"
+    if [ "$installed" = "$pin" ]; then
+        echo "  + Claude Code now at pin ($pin)"
+        return 0
+    fi
+    echo "  WARNING: cc_ensure_local: install ran but 'claude --version' is ${installed:-unknown} (expected $pin) — possible npm-prefix/PATH mismatch" >&2
+    return 1
+}

--- a/scripts/spike_cc_ensure_local_test.sh
+++ b/scripts/spike_cc_ensure_local_test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Unit test for cc_ensure_local (scripts/lib/cc_version.sh).
+#
+# Stubs `npm` and `claude` in a curated-PATH sandbox (only these stubs + the
+# coreutils cc_ensure_local needs) so the real system CC is NEVER touched.
+# Verifies the branching + the "2.1.173 (Claude Code)" version parse.
+#
+# Scenarios:
+#   A. npm absent              -> skip, return 0, no install
+#   B. claude already at pin    -> no-op, return 0, no `npm install`
+#   C. claude present, drifted  -> `npm install --prefix <binprefix> @pin`, no sudo, return 0
+#   D. claude absent (fresh)    -> `npm install --prefix <cfgprefix> @pin`, return 0
+#   E. version parse            -> "2.1.170 (Claude Code)" recognized as drift, not pin
+#
+# All state isolated to ~/tmp throwaway dirs.
+set -u
+set -o pipefail
+
+PASS=0
+FAIL=0
+FAIL_DETAILS=()
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CC_ENV="$SCRIPT_DIR/lib/cc_version.sh"
+mkdir -p "$HOME/tmp"   # NEVER the default $TMPDIR (= CC's watchgod-policed cc-tmp)
+SANDBOX="$(mktemp -d -p "$HOME/tmp" cc_ensure_test.XXXXXX)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+PIN="$(bash -c "source '$CC_ENV'; echo \"\$CC_VERSION\"")"   # the pinned version
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); FAIL_DETAILS+=("$1"); echo "  FAIL: $1"; }
+
+# Build a fresh sandbox prefix with a curated bin dir (stubs + needed coreutils).
+new_prefix() {
+    local pfx="$SANDBOX/$1"
+    local bin="$pfx/bin"
+    mkdir -p "$bin"
+    local c
+    for c in awk dirname id timeout sudo bash; do
+        local real; real="$(command -v "$c" 2>/dev/null || true)"
+        [ -n "$real" ] && ln -sf "$real" "$bin/$c"
+    done
+    echo "$pfx"
+}
+
+# Write the npm stub. Logs `install` invocations to $CALLS; answers
+# `config get prefix` with $NPM_CFG_PREFIX; marks $INSTALLED_FLAG on install.
+write_npm_stub() {
+    local bin="$1/bin"
+    cat > "$bin/npm" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "config" ] && [ "${2:-}" = "get" ] && [ "${3:-}" = "prefix" ]; then
+    echo "${NPM_CFG_PREFIX:-/usr/local}"; exit 0
+fi
+case " $* " in *" install "*) echo "npm $*" >> "$CALLS"; : > "$INSTALLED_FLAG";; esac
+exit 0
+EOF
+    chmod +x "$bin/npm"
+}
+
+# Write the claude stub: reports $START_VER until $INSTALLED_FLAG appears, then $PIN.
+write_claude_stub() {
+    local bin="$1/bin"
+    cat > "$bin/claude" <<'EOF'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--version" ]; then
+    if [ -f "$INSTALLED_FLAG" ]; then echo "$PIN (Claude Code)"; else echo "$START_VER (Claude Code)"; fi
+fi
+EOF
+    chmod +x "$bin/claude"
+}
+
+# Run cc_ensure_local under the sandbox PATH; capture rc.
+run_ensure() {
+    local pfx="$1"
+    PATH="$pfx/bin" bash -c "source '$CC_ENV'; cc_ensure_local"
+}
+
+# ── A. npm absent → skip, rc 0, no install ────────────────────────────────
+{
+    pfx="$(new_prefix a)"; rm -f "$pfx/bin/npm"     # no npm stub → npm absent
+    export CALLS="$pfx/calls"; : > "$CALLS"; export INSTALLED_FLAG="$pfx/flag"
+    export PIN START_VER="0.0.0" NPM_CFG_PREFIX="$pfx"
+    write_claude_stub "$pfx"
+    if run_ensure "$pfx" >/dev/null 2>&1 && [ ! -s "$CALLS" ]; then
+        pass "A: npm absent → skip, no install"
+    else
+        fail "A: npm absent should skip cleanly (rc=$? calls=$(cat "$CALLS"))"
+    fi
+}
+
+# ── B. claude at pin → no-op, no `npm install` ────────────────────────────
+{
+    pfx="$(new_prefix b)"
+    export CALLS="$pfx/calls"; : > "$CALLS"; export INSTALLED_FLAG="$pfx/flag"; rm -f "$INSTALLED_FLAG"
+    export PIN START_VER="$PIN" NPM_CFG_PREFIX="$pfx"
+    write_npm_stub "$pfx"; write_claude_stub "$pfx"
+    if run_ensure "$pfx" >/dev/null 2>&1 && [ ! -s "$CALLS" ]; then
+        pass "B: at-pin → no-op, no install"
+    else
+        fail "B: at-pin should be a no-op (calls=$(cat "$CALLS"))"
+    fi
+}
+
+# ── C. drifted, user prefix → install --prefix <binprefix> @pin, no sudo ──
+{
+    pfx="$(new_prefix c)"
+    export CALLS="$pfx/calls"; : > "$CALLS"; export INSTALLED_FLAG="$pfx/flag"; rm -f "$INSTALLED_FLAG"
+    export PIN START_VER="2.1.170" NPM_CFG_PREFIX="$pfx"
+    write_npm_stub "$pfx"; write_claude_stub "$pfx"
+    if run_ensure "$pfx" >/dev/null 2>&1; then
+        line="$(cat "$CALLS")"
+        if grep -q -- "--prefix $pfx " <<<"$line" && grep -q -- "@anthropic-ai/claude-code@${PIN}" <<<"$line" && ! grep -q "sudo" <<<"$line"; then
+            pass "C: drift(user) → install --prefix $pfx @$PIN, no sudo"
+        else
+            fail "C: wrong npm invocation: $line"
+        fi
+    else
+        fail "C: drift(user) returned non-zero"
+    fi
+}
+
+# ── D. absent → install to configured prefix @pin ─────────────────────────
+# Asserts the fresh-install invocation. The return-0 post-install verify path is
+# already covered by C (drift → install → claude reports pin → rc 0); emulating
+# "npm materializes the binary" here would only re-test the harness, so rc is
+# ignored and we assert the npm command instead.
+{
+    pfx="$(new_prefix d)"; rm -f "$pfx/bin/claude"     # claude absent at decision time
+    export CALLS="$pfx/calls"; : > "$CALLS"; export INSTALLED_FLAG="$pfx/flag"; rm -f "$INSTALLED_FLAG"
+    export PIN START_VER="0.0.0" NPM_CFG_PREFIX="$pfx"
+    write_npm_stub "$pfx"
+    run_ensure "$pfx" >/dev/null 2>&1 || true          # rc ignored (no real binary appears)
+    line="$(cat "$CALLS")"
+    if grep -q -- "--prefix $pfx " <<<"$line" && grep -q -- "@anthropic-ai/claude-code@${PIN}" <<<"$line"; then
+        pass "D: absent → install --prefix $pfx @$PIN (from npm config prefix)"
+    else
+        fail "D: wrong/no npm invocation: $line"
+    fi
+}
+
+# ── E. version parse: "X (Claude Code)" drift is detected ─────────────────
+{
+    pfx="$(new_prefix e)"
+    export CALLS="$pfx/calls"; : > "$CALLS"; export INSTALLED_FLAG="$pfx/flag"; rm -f "$INSTALLED_FLAG"
+    export PIN START_VER="2.1.170" NPM_CFG_PREFIX="$pfx"
+    write_npm_stub "$pfx"; write_claude_stub "$pfx"
+    run_ensure "$pfx" >/dev/null 2>&1
+    if [ -s "$CALLS" ]; then
+        pass "E: '2.1.170 (Claude Code)' parsed as drift → install fired"
+    else
+        fail "E: version-suffix parse failed — drift not detected"
+    fi
+}
+
+echo ""
+echo "cc_ensure_local: $PASS passed, $FAIL failed"
+if [ "$FAIL" -ne 0 ]; then
+    printf '  - %s\n' "${FAIL_DETAILS[@]}"
+    exit 1
+fi

--- a/scripts/spike_cc_ensure_local_test.sh
+++ b/scripts/spike_cc_ensure_local_test.sh
@@ -37,7 +37,7 @@ new_prefix() {
     local bin="$pfx/bin"
     mkdir -p "$bin"
     local c
-    for c in awk dirname id timeout sudo bash; do
+    for c in awk dirname id timeout bash env; do   # NOT sudo — write_sudo_stub creates it fresh
         local real; real="$(command -v "$c" 2>/dev/null || true)"
         [ -n "$real" ] && ln -sf "$real" "$bin/$c"
     done
@@ -57,6 +57,18 @@ case " $* " in *" install "*) echo "npm $*" >> "$CALLS"; : > "$INSTALLED_FLAG";;
 exit 0
 EOF
     chmod +x "$bin/npm"
+}
+
+# Write a sudo stub that records the call then execs the rest (so the wrapped npm
+# stub still runs) — lets us assert the sudo-prepend on the system-prefix branch.
+write_sudo_stub() {
+    local bin="$1/bin"
+    cat > "$bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+echo "sudo $*" >> "$CALLS"
+exec "$@"
+EOF
+    chmod +x "$bin/sudo"
 }
 
 # Write the claude stub: reports $START_VER until $INSTALLED_FLAG appears, then $PIN.
@@ -151,6 +163,43 @@ run_ensure() {
         pass "E: '2.1.170 (Claude Code)' parsed as drift → install fired"
     else
         fail "E: version-suffix parse failed — drift not detected"
+    fi
+}
+
+# ── F. fresh, SYSTEM prefix → sudo env "PATH=..." prepended ───────────────
+{
+    pfx="$(new_prefix f)"; rm -f "$pfx/bin/claude"     # claude absent → fresh path
+    export CALLS="$pfx/calls"; : > "$CALLS"; export INSTALLED_FLAG="$pfx/flag"; rm -f "$INSTALLED_FLAG"
+    export PIN START_VER="0.0.0" NPM_CFG_PREFIX="/opt/cctest"   # matches /opt/* → sudo branch
+    write_npm_stub "$pfx"; write_sudo_stub "$pfx"
+    run_ensure "$pfx" >/dev/null 2>&1 || true
+    line="$(cat "$CALLS")"
+    if grep -q "^sudo " <<<"$line" && grep -q -- "--prefix /opt/cctest" <<<"$line" && grep -q -- "@anthropic-ai/claude-code@${PIN}" <<<"$line"; then
+        pass "F: system prefix → sudo env prepended, --prefix /opt/cctest @$PIN"
+    else
+        fail "F: sudo/system-prefix branch wrong: $line"
+    fi
+}
+
+# ── G. post-install verify fails (install didn't reach pin) → return 1 ─────
+{
+    pfx="$(new_prefix g)"
+    export CALLS="$pfx/calls"; : > "$CALLS"; export INSTALLED_FLAG="$pfx/flag"; rm -f "$INSTALLED_FLAG"
+    export PIN START_VER="2.1.170" NPM_CFG_PREFIX="$pfx"
+    # npm stub that logs install but does NOT flip the version (no INSTALLED_FLAG),
+    # so the post-install re-check still sees START_VER != pin.
+    cat > "$pfx/bin/npm" <<'EOF'
+#!/usr/bin/env bash
+[ "${1:-}" = "config" ] && { echo "${NPM_CFG_PREFIX:-/usr/local}"; exit 0; }
+case " $* " in *" install "*) echo "npm $*" >> "$CALLS";; esac
+exit 0
+EOF
+    chmod +x "$pfx/bin/npm"
+    write_claude_stub "$pfx"     # always reports START_VER (flag never set)
+    if run_ensure "$pfx" >/dev/null 2>&1; then
+        fail "G: expected non-zero return when install didn't reach pin"
+    else
+        pass "G: post-install mismatch → return 1 (non-fatal for callers)"
     fi
 }
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -911,6 +911,25 @@ print(cfg.get('host_user', 'ubuntu'))
     fi
 fi
 
+# ── Sync CONTAINER Claude Code to the pinned version ──────
+# The guardian block above syncs the HOST's CC. This aligns the CONTAINER's own
+# Claude Code (update.sh runs inside the container) so a pin bump reaches the
+# container with zero user action. UNCONDITIONAL — not gated on guardian config,
+# so guardian-less installs are covered too. Non-fatal (`|| true`): `set -e` is
+# active here (ERR trap already disarmed), and a CC install hiccup must never
+# abort an update after git-pull/migrations have run.
+_cc_env="$SCRIPT_DIR/lib/cc_version.sh"
+if [ -f "$_cc_env" ]; then
+    echo "--- Syncing container Claude Code to pin ---"
+    unset CC_VERSION            # repo pin must win over any inherited override
+    # shellcheck source=/dev/null
+    source "$_cc_env"
+    cc_ensure_local || true
+else
+    echo "  WARNING: $_cc_env missing — skipping container CC sync"
+fi
+echo ""
+
 # ── Clear update failure file on success ──────────────────
 if [ -f "$HOME/.genesis/last_update_failure.json" ]; then
     rm -f "$HOME/.genesis/last_update_failure.json"


### PR DESCRIPTION
## Summary

The pinned Claude Code version (`CC_VERSION` in `scripts/lib/cc_version.sh`) could silently fail to reach an install. Two gaps:

1. **`install.sh` and `host-setup.sh` only installed Claude Code when it was *absent*** — a present-but-stale CC was never upgraded, so bumping the pin never reached an already-installed machine.
2. **`update.sh` synced only the *host VM's* Claude Code** (via the guardian `update-cc` op) — nothing aligned the container's own CC (update.sh runs inside the container).
3. `bootstrap.sh` didn't handle the CC version at all.

Net effect: a machine could run an old Claude Code indefinitely despite the repo pin.

## Fix

- Add a shared **`cc_ensure_local`** to `scripts/lib/cc_version.sh` that installs *or* aligns the local Claude Code to the pin:
  - Exact-match to the pin (so an intentional **downgrade** for incident rollback also applies; `npm install @X.Y.Z` pins exactly).
  - On **upgrade**, reinstalls to the **existing binary's own prefix** (`dirname(dirname($(command -v claude)))`), not `npm config get prefix` — the two can differ, which would install a second copy and leave `which claude` stale.
  - System prefixes use `sudo env "PATH=$PATH" …`; user prefixes don't. Command built as a bash array (quoting-safe).
  - **Post-install re-verify** (`hash -r` + re-read `claude --version`); returns non-zero + warning if still off-pin.
  - Idempotent, **non-fatal**.
- Call it from `install.sh` (Step 12), `bootstrap.sh` (after Node), and `update.sh` (a new **unconditional** container-sync block after the guardian block, `|| true` — `set -e` is active, so a CC hiccup must never abort an update). The host CC still syncs via the guardian op.

## Testing

- `scripts/spike_cc_ensure_local_test.sh` — stubbed `npm`/`claude` in a curated-PATH sandbox (never touches the real system), **7/7**: npm-absent skip, at-pin no-op, drift(user-prefix) install, fresh install, version-suffix parse, **sudo/system-prefix branch**, **post-install verify-fail → return 1**.
- `shellcheck` clean; live idempotency no-op verified; each script's exact block sequence verified end-to-end against the real environment (no-op at pin).

## Docs

- `docs/reference/cc-compatibility.md` governance model updated; user-facing CHANGELOG entry under Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)