### PR TITLE
feat(attention): PR3a — complete the §4 trigger taxonomy (deterministic)

### DIFF
--- a/src/genesis/attention/config.py
+++ b/src/genesis/attention/config.py
@@ -144,10 +144,10 @@ def default_config_dict() -> dict:
             "is_user": 0.10, "domain_keyword": 0.30, "known_entity": 0.25,
             # PR3a — §4 taxonomy completion (SEED weights; PR3c re-tunes against labels).
             # multi_speaker stays 0.40 — DILUTED by these new signals, NOT down-weighted here.
-            # topic_continuation=0.0: the dry-run over the live snapshot showed it fires on ~78% of
-            # windows (non-discriminative) and stacked with multi_speaker + stickiness to DOUBLE the
-            # fire-rate on garble (11.8% vs 6.2%). NEUTRALIZED (still recorded in triggers_fired for
-            # the shadow log) pending a labelled PR3c re-tune. See quiet-frolicking-hearth.md.
+            # topic_continuation=0.0: a shadow dry-run over the live snapshot showed it fires on ~78%
+            # of windows (non-discriminative) and stacked with multi_speaker + stickiness to DOUBLE the
+            # fire-rate on garble (11.8% vs 6.2%). NEUTRALIZED (still recorded in triggers_fired for the
+            # shadow log) pending a labelled re-tune against acceptance signals.
             "decision": 0.30, "task_reminder": 0.35, "temporal_deadline": 0.25,
             "quantity_money": 0.25, "recall_cue": 0.35, "dispute": 0.30,
             "emotional": 0.20, "topic_continuation": 0.0, "lexical_repetition": 0.20,

--- a/src/genesis/attention/config.py
+++ b/src/genesis/attention/config.py
@@ -100,7 +100,7 @@ def default_config_dict() -> dict:
     are REGISTERED but OFF by default (not in ``suppressors_enabled``). All weights/
     thresholds are the calibration surface the shadow review tunes."""
     return {
-        "version": "0.1.0-default",
+        "version": "0.2.0-taxonomy",
         "aliases": ["genesis"],
         "domain_keywords": [
             "genesis", "routing", "memory", "embedding", "retrieval", "attention",
@@ -144,9 +144,13 @@ def default_config_dict() -> dict:
             "is_user": 0.10, "domain_keyword": 0.30, "known_entity": 0.25,
             # PR3a — §4 taxonomy completion (SEED weights; PR3c re-tunes against labels).
             # multi_speaker stays 0.40 — DILUTED by these new signals, NOT down-weighted here.
+            # topic_continuation=0.0: the dry-run over the live snapshot showed it fires on ~78% of
+            # windows (non-discriminative) and stacked with multi_speaker + stickiness to DOUBLE the
+            # fire-rate on garble (11.8% vs 6.2%). NEUTRALIZED (still recorded in triggers_fired for
+            # the shadow log) pending a labelled PR3c re-tune. See quiet-frolicking-hearth.md.
             "decision": 0.30, "task_reminder": 0.35, "temporal_deadline": 0.25,
             "quantity_money": 0.25, "recall_cue": 0.35, "dispute": 0.30,
-            "emotional": 0.20, "topic_continuation": 0.15, "lexical_repetition": 0.20,
+            "emotional": 0.20, "topic_continuation": 0.0, "lexical_repetition": 0.20,
             "unanswered_question": 0.30,
         },
         "state_modifiers": {},   # all StateModifiers defaults

--- a/src/genesis/attention/config.py
+++ b/src/genesis/attention/config.py
@@ -28,6 +28,11 @@ class StateModifiers:
     cooldown_s: float = 30.0               # refractory window after a perk
     cooldown_raise: float = 0.2            # threshold ADD while in cooldown (anti-twitch)
     unanswered_question_s: float = 5.0     # a "?" with no reply within this -> a soft signal
+    # ── PR3a: decay + suppressor dials ──
+    decay_window_s: float = 30.0           # in-session stickiness fully decays to the floor by this off-topic gap (§9: 5-30s)
+    decay_floor_mult: float = 1.0          # stickiness decays TOWARD this — removes the bonus, never a below-baseline penalty
+    low_asr_frac_lt_1: float = 0.35        # frac_lt_1 >= this -> low_asr_confidence suppressor (OFF by default; capture_clarity already dampens by 1-frac_lt_1)
+    lexical_repetition_min_tokens: int = 3  # a "repeat" needs >= this many shared CONTENT tokens (guards stopword noise)
 
 
 @dataclass(frozen=True)
@@ -89,11 +94,11 @@ DEFAULT_CONFIG_PATH = "~/.genesis/config/attention_config.json"
 def default_config_dict() -> dict:
     """A complete generic STARTER config for the first shadow pass. ``domain_keywords``
     is a coarse tech-talk starter; ``known_entities`` is empty (a generator fills it
-    from ``user_contacts`` later). ``emotional_patterns`` and the extra lexical banks
-    are present but only CONSUMED from PR3 onward — the PR1 trigger subset uses
-    question/help_seeking/multi_speaker/is_user/domain_keyword/known_entity +
-    ambient_name/explicit_invite + explicit_dismissal. All weights/thresholds are the
-    calibration surface the shadow review tunes."""
+    from ``user_contacts`` later). PR3a wires the full §4 soft taxonomy (all lexical +
+    emotional banks) + conversational-dynamics; ``sensitive_topics`` ships empty (inert
+    until a config author fills it) and the ``low_asr_confidence`` / ``mode_*`` suppressors
+    are REGISTERED but OFF by default (not in ``suppressors_enabled``). All weights/
+    thresholds are the calibration surface the shadow review tunes."""
     return {
         "version": "0.1.0-default",
         "aliases": ["genesis"],
@@ -137,8 +142,16 @@ def default_config_dict() -> dict:
         "weights": {
             "question": 0.30, "help_seeking": 0.35, "multi_speaker": 0.40,
             "is_user": 0.10, "domain_keyword": 0.30, "known_entity": 0.25,
+            # PR3a — §4 taxonomy completion (SEED weights; PR3c re-tunes against labels).
+            # multi_speaker stays 0.40 — DILUTED by these new signals, NOT down-weighted here.
+            "decision": 0.30, "task_reminder": 0.35, "temporal_deadline": 0.25,
+            "quantity_money": 0.25, "recall_cue": 0.35, "dispute": 0.30,
+            "emotional": 0.20, "topic_continuation": 0.15, "lexical_repetition": 0.20,
+            "unanswered_question": 0.30,
         },
         "state_modifiers": {},   # all StateModifiers defaults
         "thresholds": {},        # all Thresholds defaults (soft_perk 0.6, l15_graduation 0.4)
-        "suppressors_enabled": ["explicit_dismissal"],
+        # low_asr_confidence + mode_* are registered but deliberately NOT enabled by default
+        # (double-count with capture_clarity / inert offline). sensitive_topic is on but empty.
+        "suppressors_enabled": ["explicit_dismissal", "sensitive_topic"],
     }

--- a/src/genesis/attention/engine.py
+++ b/src/genesis/attention/engine.py
@@ -9,8 +9,13 @@ from __future__ import annotations
 
 from genesis.attention.clarity import capture_clarity, is_blip
 from genesis.attention.config import AttentionConfig
-from genesis.attention.scorer import resolve_activation, soft_relevance
-from genesis.attention.triggers import HARD_TRIGGERS, SOFT_TRIGGERS, SUPPRESSORS
+from genesis.attention.scorer import resolve_activation, soft_relevance, stickiness_multiplier
+from genesis.attention.triggers import (
+    HARD_TRIGGERS,
+    SOFT_TRIGGERS,
+    SUPPRESSORS,
+    unanswered_question_update,
+)
 from genesis.attention.types import (
     Activation,
     AmbientUtterance,
@@ -48,6 +53,8 @@ def evaluate(
         state.session_id = f"s{utt.id}"
         state.session_started_ts = utt.ts
         state.window.clear()
+        state.pending_questions = []      # cross-session questions are stale
+        state.last_relevance_ts = None    # reset the decay clock (cooldown below persists)
         # cooldown (last_perk_ts) intentionally persists across sessions (anti-twitch).
 
     # ── context window (evict utterances older than the cap) ──
@@ -59,16 +66,27 @@ def evaluate(
     # ── triggers ──
     hard = _run(HARD_TRIGGERS, utt, window, config)
     soft = _run(SOFT_TRIGGERS, utt, window, config)
+    # unanswered-question look-ahead is engine-emitted (it needs state) and also advances
+    # the pending-question queue for future utterances.
+    uq_hit = unanswered_question_update(state, utt, config)
+    if uq_hit is not None:
+        soft.append(uq_hit)
     # suppressors_enabled is an ALLOWLIST: empty tuple -> no suppressors run (NOT "all").
     # Pass it straight through (no `or None`, which would misread [] as "run everything").
     supp = _run(SUPPRESSORS, utt, window, config, enabled=config.suppressors_enabled)
 
     # ── score ──
     relevance = soft_relevance(soft)
-    is_continuation = state.session_started_ts is not None and utt.ts != state.session_started_ts
     effective = relevance * clarity
-    if is_continuation:
-        effective *= sm.session_stickiness_mult
+    # in-session stickiness that DECAYS as the conversation drifts off-topic (§4). off_topic_s
+    # = seconds since the last utt that carried ANY relevance; None on the first relevant utt of
+    # a session -> floor (no bonus), matching the pre-PR3a first-utt behaviour without a crash.
+    off_topic_s = (utt.ts - state.last_relevance_ts) if state.last_relevance_ts is not None else None
+    effective *= stickiness_multiplier(
+        sm.session_stickiness_mult, off_topic_s, sm.decay_window_s, sm.decay_floor_mult,
+    )
+    if relevance > 0.0:
+        state.last_relevance_ts = utt.ts   # advance the decay clock on an on-topic utt
 
     in_cooldown = state.last_perk_ts is not None and (utt.ts - state.last_perk_ts) < sm.cooldown_s
     threshold = config.thresholds.soft_perk + (sm.cooldown_raise if in_cooldown else 0.0)

--- a/src/genesis/attention/scorer.py
+++ b/src/genesis/attention/scorer.py
@@ -16,6 +16,26 @@ def soft_relevance(hits: Sequence[TriggerHit]) -> float:
     return sum(h.contribution for h in hits)
 
 
+def stickiness_multiplier(
+    base: float, off_topic_s: float | None, decay_window_s: float, floor: float = 1.0,
+) -> float:
+    """In-session stickiness that DECAYS as the conversation drifts off-topic (§4/§9).
+
+    ``off_topic_s`` = ``utt.ts - last_relevance_ts`` (seconds since the last utterance
+    that carried ANY soft relevance). Returns ``base`` when fully on-topic (0s) and
+    linearly decays toward ``floor``, reaching ``floor`` at ``decay_window_s``; clamped —
+    it removes the bonus, never penalizes below ``floor``.
+
+    ``off_topic_s is None`` (first utt of a session — no prior relevant utt yet) or a
+    non-positive ``decay_window_s`` -> ``floor`` (no bonus, no crash). Returning ``floor``
+    on the first utt matches the pre-PR3a "first-utt gets no stickiness" behaviour.
+    """
+    if off_topic_s is None or decay_window_s <= 0.0:
+        return floor
+    frac = min(max(off_topic_s, 0.0) / decay_window_s, 1.0)
+    return base - (base - floor) * frac
+
+
 def resolve_activation(
     *,
     hard_hits: Sequence[TriggerHit],

--- a/src/genesis/attention/scorer.py
+++ b/src/genesis/attention/scorer.py
@@ -33,7 +33,9 @@ def stickiness_multiplier(
     if off_topic_s is None or decay_window_s <= 0.0:
         return floor
     frac = min(max(off_topic_s, 0.0) / decay_window_s, 1.0)
-    return base - (base - floor) * frac
+    # clamp to floor: decay removes the bonus, never dips below floor — and guards a
+    # misconfig where base < floor (plus any float undershoot at frac == 1.0).
+    return max(floor, base - (base - floor) * frac)
 
 
 def resolve_activation(

--- a/src/genesis/attention/triggers.py
+++ b/src/genesis/attention/triggers.py
@@ -183,6 +183,11 @@ def _is_question(utt, config) -> bool:
     return bool((pats and _bank_match(utt.text, pats)) or "?" in utt.text)
 
 
+# Fail-safe against a pathological question-burst (stale entries drain within
+# ``unanswered_question_s``; a session reset also clears the queue) — bounds the state.
+_MAX_PENDING_QUESTIONS = 64
+
+
 def unanswered_question_update(state: EngineState, utt, config):
     """Forward-only unanswered-question look-ahead (§4 conversational dynamics). Engine-
     called (it needs state — NOT a registry trigger). ONE pass, no mutate-during-iterate:
@@ -202,7 +207,7 @@ def unanswered_question_update(state: EngineState, utt, config):
         (qid, qts) for (qid, qts) in state.pending_questions
         if qid not in emitted and qid not in answered
     ]
-    if _is_question(utt, config):
+    if _is_question(utt, config) and len(state.pending_questions) < _MAX_PENDING_QUESTIONS:
         state.pending_questions.append((utt.id, utt.ts))
     if emitted:
         return TriggerHit("unanswered_question", TriggerKind.SOFT, _w(config, "unanswered_question", 0.30))

--- a/src/genesis/attention/triggers.py
+++ b/src/genesis/attention/triggers.py
@@ -4,10 +4,13 @@ Each trigger: ``(utt, window, config) -> TriggerHit | None``. Registries group t
 kind (HARD precision-first / SOFT recall-first / SUPPRESSOR veto). The scorer composes
 the soft hits; the engine resolves activation. Pure — no genesis deps, no I/O.
 
-PR1 ships a high-signal subset; the remaining §4 triggers (emotional lexicon,
-unknown-speaker, unanswered-question, sensitive-topic, low-ASR-confidence, mode-state
-suppressors) land in PR3. Names here are the STABLE keys used in ``config.weights`` and
-in the shadow log's ``triggers_fired`` — do not rename casually.
+PR3a completes the §4 taxonomy (emotional lexicon, conversational-dynamics, sensitive-
+topic / low-ASR-confidence / mode-state suppressors). ``unanswered_question`` is
+engine-emitted (it needs state — see ``unanswered_question_update``, NOT a registry
+trigger); ``unknown_speaker`` is DEFERRED (no resolved per-speaker identity —
+``speaker_name`` is a diarization label dropped upstream; §5 has no voiceprint link).
+Names here are the STABLE keys used in ``config.weights`` and the shadow log's
+``triggers_fired`` — do not rename casually.
 """
 from __future__ import annotations
 
@@ -15,7 +18,7 @@ import re
 from collections.abc import Callable, Sequence
 
 from genesis.attention.config import AttentionConfig
-from genesis.attention.types import AmbientUtterance, TriggerHit, TriggerKind
+from genesis.attention.types import AmbientUtterance, EngineState, TriggerHit, TriggerKind
 
 TriggerFn = Callable[[AmbientUtterance, Sequence[AmbientUtterance], AttentionConfig], "TriggerHit | None"]
 
@@ -98,12 +101,162 @@ def soft_known_entity(utt, window, config):
     return None
 
 
+# ── SOFT (PR3a) — the rest of the §4 taxonomy ──
+
+def _soft_bank(utt, config, name, default):
+    """A soft trigger that fires on a ``lexical_patterns`` bank match (the common shape)."""
+    pats = config.lexical_patterns.get(name, ())
+    if pats and _bank_match(utt.text, pats):
+        return TriggerHit(name, TriggerKind.SOFT, _w(config, name, default))
+    return None
+
+
+def soft_decision(utt, window, config):
+    return _soft_bank(utt, config, "decision", 0.30)
+
+
+def soft_task_reminder(utt, window, config):
+    return _soft_bank(utt, config, "task_reminder", 0.35)
+
+
+def soft_temporal_deadline(utt, window, config):
+    return _soft_bank(utt, config, "temporal_deadline", 0.25)
+
+
+def soft_quantity_money(utt, window, config):
+    return _soft_bank(utt, config, "quantity_money", 0.25)
+
+
+def soft_recall_cue(utt, window, config):
+    return _soft_bank(utt, config, "recall_cue", 0.35)
+
+
+def soft_dispute(utt, window, config):
+    return _soft_bank(utt, config, "dispute", 0.30)
+
+
+def soft_emotional(utt, window, config):
+    # ONE trigger for the whole emotional lexicon (frustration/excitement/confusion/
+    # urgency) — a text proxy for prosody (§4). Fires once if ANY emotional bank matches.
+    for pats in config.emotional_patterns.values():
+        if pats and _bank_match(utt.text, pats):
+            return TriggerHit("emotional", TriggerKind.SOFT, _w(config, "emotional", 0.20))
+    return None
+
+
+def soft_topic_continuation(utt, window, config):
+    # a follow-on within an active attention window (§4 conversational dynamics): more than
+    # this one utt still in the context window => an ongoing exchange. Pure over ``window``.
+    if len(window) > 1:
+        return TriggerHit("topic_continuation", TriggerKind.SOFT, _w(config, "topic_continuation", 0.15))
+    return None
+
+
+_STOPWORDS = frozenset({
+    "the", "a", "an", "of", "to", "and", "or", "is", "are", "was", "were", "be", "been",
+    "do", "did", "i", "you", "we", "it", "that", "this", "in", "on", "at", "for", "with",
+    "have", "has", "had", "not", "no", "so", "but", "if", "then", "he", "she", "they",
+    "them", "my", "your", "our",
+})
+
+
+def _content_tokens(text: str) -> set[str]:
+    return {t for t in re.findall(r"[a-z0-9']+", text.lower()) if t not in _STOPWORDS}
+
+
+def soft_lexical_repetition(utt, window, config):
+    # an unresolved repeat within the window (§4): this utt shares >= min_tokens CONTENT
+    # tokens (stopwords excluded) with an earlier window utt. Pure over ``window``.
+    min_t = config.state_modifiers.lexical_repetition_min_tokens
+    cur = _content_tokens(utt.text)
+    if len(cur) < min_t:
+        return None
+    for prev in window[:-1]:          # window[-1] is the current utt (already appended by the engine)
+        if len(cur & _content_tokens(prev.text)) >= min_t:
+            return TriggerHit("lexical_repetition", TriggerKind.SOFT, _w(config, "lexical_repetition", 0.20))
+    return None
+
+
+def _is_question(utt, config) -> bool:
+    """``soft_question``'s predicate, reused by the unanswered-question look-ahead."""
+    pats = config.lexical_patterns.get("question", ())
+    return bool((pats and _bank_match(utt.text, pats)) or "?" in utt.text)
+
+
+def unanswered_question_update(state: EngineState, utt, config):
+    """Forward-only unanswered-question look-ahead (§4 conversational dynamics). Engine-
+    called (it needs state — NOT a registry trigger). ONE pass, no mutate-during-iterate:
+    a pending "?" older than ``unanswered_question_s`` EMITS an ``unanswered_question`` soft
+    hit; a pending "?" that a later substantive non-question utt answered within the window
+    is DROPPED; then this utt is enqueued if it is itself a question. Mutates
+    ``state.pending_questions`` in place; returns the emit ``TriggerHit | None``.
+    """
+    sm = config.state_modifiers
+    emitted, answered = set(), set()
+    for (qid, qts) in state.pending_questions:
+        if utt.ts - qts > sm.unanswered_question_s:
+            emitted.add(qid)
+        elif utt.id != qid and utt.n_tokens >= 1 and not _is_question(utt, config):
+            answered.add(qid)
+    state.pending_questions = [
+        (qid, qts) for (qid, qts) in state.pending_questions
+        if qid not in emitted and qid not in answered
+    ]
+    if _is_question(utt, config):
+        state.pending_questions.append((utt.id, utt.ts))
+    if emitted:
+        return TriggerHit("unanswered_question", TriggerKind.SOFT, _w(config, "unanswered_question", 0.30))
+    return None
+
+
 # ── SUPPRESSOR — veto (overrides soft fires; only an explicit summons beats it) ──
 
 def suppress_explicit_dismissal(utt, window, config):
     pats = config.suppressor_patterns.get("explicit_dismissal", ())
     if pats and _bank_match(utt.text, pats):
         return TriggerHit("explicit_dismissal", TriggerKind.SUPPRESSOR)
+    return None
+
+
+# ── SUPPRESSOR (PR3a) — sensitive_topic (on, empty bank) + edge-only vetoes (OFF by default) ──
+
+def suppress_sensitive_topic(utt, window, config):
+    pats = config.suppressor_patterns.get("sensitive_topics", ())   # existing bank key is plural
+    if pats and _bank_match(utt.text, pats):
+        return TriggerHit("sensitive_topic", TriggerKind.SUPPRESSOR)
+    return None
+
+
+def suppress_low_asr_confidence(utt, window, config):
+    # A hard veto reserved for the catastrophic-ASR tail; OFF by default — capture_clarity
+    # already dampens the score by (1 - frac_lt_1), so enabling this DOUBLE-COUNTS. It's an
+    # edge-only opt-in for when even a high-relevance window is too garbled to trust.
+    if utt.frac_lt_1 >= config.state_modifiers.low_asr_frac_lt_1:
+        return TriggerHit("low_asr_confidence", TriggerKind.SUPPRESSOR)
+    return None
+
+
+def _mode_active(utt, mode: str) -> bool:
+    return mode in utt.mode_state.split()
+
+
+def suppress_mode_active_listen(utt, window, config):
+    # capture-only Listen Mode ON -> passive must not perk. Inert offline (mode_state="unknown").
+    if _mode_active(utt, "listen_active"):
+        return TriggerHit("mode_active_listen", TriggerKind.SUPPRESSOR)
+    return None
+
+
+def suppress_mode_active_s2s(utt, window, config):
+    # a wake-word S2S turn is in progress -> passive stays quiet.
+    if _mode_active(utt, "s2s_active"):
+        return TriggerHit("mode_active_s2s", TriggerKind.SUPPRESSOR)
+    return None
+
+
+def suppress_mode_global_mute(utt, window, config):
+    if _mode_active(utt, "global_mute"):
+        return TriggerHit("mode_global_mute", TriggerKind.SUPPRESSOR)
     return None
 
 
@@ -119,8 +272,24 @@ SOFT_TRIGGERS: dict[str, TriggerFn] = {
     "is_user": soft_is_user,
     "domain_keyword": soft_domain_keyword,
     "known_entity": soft_known_entity,
+    # ── PR3a: §4 taxonomy completion (unanswered_question is engine-emitted, not here) ──
+    "decision": soft_decision,
+    "task_reminder": soft_task_reminder,
+    "temporal_deadline": soft_temporal_deadline,
+    "quantity_money": soft_quantity_money,
+    "recall_cue": soft_recall_cue,
+    "dispute": soft_dispute,
+    "emotional": soft_emotional,
+    "topic_continuation": soft_topic_continuation,
+    "lexical_repetition": soft_lexical_repetition,
 }
 
 SUPPRESSORS: dict[str, TriggerFn] = {
     "explicit_dismissal": suppress_explicit_dismissal,
+    # PR3a — registered; only explicit_dismissal + sensitive_topic are ENABLED by default.
+    "sensitive_topic": suppress_sensitive_topic,
+    "low_asr_confidence": suppress_low_asr_confidence,
+    "mode_active_listen": suppress_mode_active_listen,
+    "mode_active_s2s": suppress_mode_active_s2s,
+    "mode_global_mute": suppress_mode_global_mute,
 }

--- a/src/genesis/attention/types.py
+++ b/src/genesis/attention/types.py
@@ -43,7 +43,7 @@ class AmbientUtterance:
     n_tokens: int
     frac_lt_1: float            # fraction of ys_log_probs < -1.0 (ASR-confidence stat)
     rms: float
-    mode_state: str = "unknown"  # "unknown" offline; live interaction-plane booleans at the edge
+    mode_state: str = "unknown"  # edge: space-separated active modes ("listen_active s2s_active global_mute"); "unknown" offline. Suppressors test `<mode> in mode_state.split()`.
     source: str = ""            # connection/device id
 
 
@@ -89,13 +89,19 @@ class AttentionEvent:
 @dataclass
 class EngineState:
     """Rolling engine state, passed explicitly through the fold (NO module-level
-    state — cf. the awareness scorer anti-pattern). Mutated in place and returned;
-    serializable via ``dataclasses.asdict`` for the future edge runner.
+    state — cf. the awareness scorer anti-pattern). Mutated in place and returned.
 
     ``window`` holds recent utterances within the context window (transient, text
-    included — in memory only). ``last_perk_ts`` drives the cooldown; it intentionally
-    persists across sessions (anti-twitch). (PR3 adds ``pending_questions`` for the
-    unanswered-question bounded-lookahead signal — out of the PR1 trigger subset.)
+    included — in memory only, NEVER persisted). ``last_perk_ts`` drives the cooldown;
+    it intentionally persists across sessions (anti-twitch). ``pending_questions`` +
+    ``last_relevance_ts`` (PR3a) carry the unanswered-question look-ahead and the decay
+    clock; both reset per session (unlike ``last_perk_ts``).
+
+    Serialization (for a future edge checkpoint): primitive fields round-trip via
+    ``dataclasses.asdict``, but ``window`` is in-memory only (a ``deque`` is returned
+    as-is, not recursed) and ``pending_questions`` tuples become lists on reload — so an
+    edge checkpoint needs a custom ``serialize()``/``deserialize()`` pair (deferred to the
+    edge runner PR), NOT a bare ``asdict``.
     """
 
     session_id: str | None = None
@@ -103,3 +109,6 @@ class EngineState:
     last_utt_ts: float | None = None
     last_perk_ts: float | None = None
     window: deque = field(default_factory=deque)
+    # ── PR3a: forward-only look-ahead + decay clock (both reset per session) ──
+    pending_questions: list[tuple[int, float]] = field(default_factory=list)  # (utt_id, ts) of un-replied "?"
+    last_relevance_ts: float | None = None   # ts of the last utt carrying ANY soft relevance (the decay clock)

--- a/src/genesis/db/crud/attention.py
+++ b/src/genesis/db/crud/attention.py
@@ -141,6 +141,7 @@ async def update_acceptance_signal(
 # ── aggregates for the cockpit stats panel (all counts — never text) ──────────────
 
 async def activation_stats(db: aiosqlite.Connection) -> dict:
+    """Per-activation event counts (hard / soft / suppressed) — the fire-rate breakdown."""
     cursor = await db.execute(
         "SELECT activation, COUNT(*) AS n FROM attention_events GROUP BY activation"
     )

--- a/tests/test_attention/test_config.py
+++ b/tests/test_attention/test_config.py
@@ -2,7 +2,13 @@
 import json
 import re
 
-from genesis.attention.config import AttentionConfig, StateModifiers, Thresholds, load_config
+from genesis.attention.config import (
+    AttentionConfig,
+    StateModifiers,
+    Thresholds,
+    default_config_dict,
+    load_config,
+)
 
 
 def _raw() -> dict:
@@ -65,3 +71,31 @@ def test_default_config_dict_compiles():
     assert c.thresholds.soft_perk == 0.6            # Thresholds default (empty dict -> defaults)
     assert "explicit_dismissal" in c.suppressors_enabled
     assert c.lexical_patterns["question"]           # compiled non-empty
+
+
+# ── PR3a ──
+
+def test_new_state_modifier_defaults():
+    sm = StateModifiers()
+    assert sm.decay_window_s == 30.0
+    assert sm.decay_floor_mult == 1.0
+    assert sm.low_asr_frac_lt_1 == 0.35
+    assert sm.lexical_repetition_min_tokens == 3
+
+
+def test_default_config_has_all_pr3a_weights():
+    w = default_config_dict()["weights"]
+    for name in ("decision", "task_reminder", "temporal_deadline", "quantity_money",
+                 "recall_cue", "dispute", "emotional", "topic_continuation",
+                 "lexical_repetition", "unanswered_question"):
+        assert isinstance(w[name], float), name
+    assert w["multi_speaker"] == 0.40  # unchanged — diluted, not down-weighted
+
+
+def test_default_suppressors_enabled_excludes_low_asr_and_mode():
+    # the double-count / inert-offline suppressors are REGISTERED but OFF by default.
+    enabled = default_config_dict()["suppressors_enabled"]
+    assert "explicit_dismissal" in enabled
+    assert "sensitive_topic" in enabled           # on, but its bank ships empty (inert)
+    for off in ("low_asr_confidence", "mode_active_listen", "mode_active_s2s", "mode_global_mute"):
+        assert off not in enabled, off

--- a/tests/test_attention/test_engine.py
+++ b/tests/test_attention/test_engine.py
@@ -134,7 +134,7 @@ def test_cooldown_raises_threshold():
     state, e1 = evaluate(make_utt(1, 100.0, "q?"), state, cfg)
     assert e1.activation == Activation.SOFT                    # .5 >= .4
     state, e2 = evaluate(make_utt(2, 105.0, "q?"), state, cfg)
-    assert e2 is None                                          # in cooldown -> bar .7, .5 < .7
+    assert e2 is None                                          # cooldown bar .7; .5 + topic_continuation .15 = .65 < .7
     state, e3 = evaluate(make_utt(3, 140.0, "q?"), state, cfg)
     assert e3 is not None and e3.activation == Activation.SOFT  # 40s > cooldown -> fires again
 
@@ -145,3 +145,84 @@ def test_event_carries_refs_not_text():
     assert ev.window_ref.utt_ids == (7,)
     assert not hasattr(ev, "text")
     assert "secret plan" not in repr(ev.window_ref)
+
+
+# ── PR3a: decay, dilution, new suppressors, look-ahead, determinism ──
+
+def test_new_triggers_dilute_multi_speaker():
+    cfg = make_config(
+        weights={"multi_speaker": 0.4, "question": 0.3, "decision": 0.3},
+        lexical_patterns={"question": [r"\?"], "decision": [r"\bwe should\b"]},
+    )
+    # a bare multi-speaker window no longer clears the 0.6 bar on its own (0.40 < 0.60)
+    assert run([make_utt(1, 100.0, "some chatter", speaker_total=2)], cfg) == []
+    # multi-speaker + real intent does (0.40 + 0.30 + 0.30 = 1.00)
+    rich = run([make_utt(1, 100.0, "we should ship?", speaker_total=2)], cfg)
+    assert len(rich) == 1 and rich[0].activation == Activation.SOFT
+
+
+def test_decay_reduces_stickiness_over_off_topic_gap():
+    cfg = make_config(
+        weights={"question": 0.5, "topic_continuation": 0.15},
+        lexical_patterns={"question": [r"\?"]},
+        thresholds={"soft_perk": 0.6, "l15_graduation": 0.4},
+        # unanswered_question pushed out of range so decay is ISOLATED from that bonus
+        # (a lingering "?" would otherwise add +unanswered_question to the far case and mask decay).
+        state_modifiers={"session_gap_s": 300, "cooldown_s": 0, "session_stickiness_mult": 1.3,
+                         "decay_window_s": 30, "decay_floor_mult": 1.0, "context_cap_s": 300,
+                         "unanswered_question_s": 100000},
+    )
+    near = run([make_utt(1, 100.0, "q?"), make_utt(2, 101.0, "q?")], cfg)   # 1s gap: near-full stickiness
+    far = run([make_utt(1, 100.0, "q?"), make_utt(2, 128.0, "q?")], cfg)    # 28s gap: decayed toward 1.0
+    assert near[-1].score > far[-1].score
+
+
+def test_last_relevance_ts_advances_only_on_relevant():
+    cfg = make_config(weights={"question": 0.5}, lexical_patterns={"question": [r"\?"]})
+    state = EngineState()
+    state, _ = evaluate(make_utt(1, 100.0, "nothing here"), state, cfg)   # no trigger, window len 1
+    assert state.last_relevance_ts is None                                # clock NOT advanced
+    state, _ = evaluate(make_utt(2, 101.0, "q?"), state, cfg)             # question fires
+    assert state.last_relevance_ts == 101.0                               # advanced on the relevant utt
+
+
+def test_low_asr_suppressor_off_by_default_on_by_config():
+    garbled = make_utt(1, 100.0, "what do you think?", speaker_total=2,
+                       frac_lt_1=0.5, rms=0.2, duration_s=5.0, n_tokens=20)
+    off = run([garbled], make_config(suppressors_enabled=["explicit_dismissal"]))
+    assert off and all(e.activation != Activation.SUPPRESSED for e in off)   # clarity dampens, no veto
+    on = run([garbled], make_config(suppressors_enabled=["explicit_dismissal", "low_asr_confidence"]))
+    assert len(on) == 1 and on[0].activation == Activation.SUPPRESSED         # frac_lt_1 0.5 >= 0.35
+
+
+def test_mode_suppressor_inert_offline_but_vetoes_when_active():
+    cfg = make_config(suppressors_enabled=["explicit_dismissal", "mode_active_listen"])
+    # offline default mode_state="unknown" -> inert -> the soft fire stands
+    assert run([make_utt(1, 100.0, "what do you think?", speaker_total=2)], cfg)[0].activation == Activation.SOFT
+    # edge mode set -> veto
+    active = make_utt(1, 100.0, "what do you think?", speaker_total=2, mode_state="listen_active")
+    assert run([active], cfg)[0].activation == Activation.SUPPRESSED
+
+
+def test_unanswered_question_fires_in_fold():
+    cfg = make_config(
+        weights={"unanswered_question": 0.7},
+        lexical_patterns={"question": [r"\?"]},
+        state_modifiers={"unanswered_question_s": 5, "session_gap_s": 300, "cooldown_s": 0,
+                         "session_stickiness_mult": 1.0, "context_cap_s": 300},
+        thresholds={"soft_perk": 0.6, "l15_graduation": 0.4},
+    )
+    ev = run([make_utt(1, 100.0, "did it work?"), make_utt(2, 108.0, "yeah anyway")], cfg)  # 8s > 5s
+    assert any(h.name == "unanswered_question" for e in ev for h in e.triggers_fired)
+
+
+def test_determinism_with_pending_and_decay():
+    cfg = make_config(
+        weights={"question": 0.5, "decision": 0.3, "unanswered_question": 0.4, "topic_continuation": 0.15},
+        lexical_patterns={"question": [r"\?"], "decision": [r"\bwe should\b"]},
+        state_modifiers={"session_gap_s": 300, "cooldown_s": 30, "session_stickiness_mult": 1.3,
+                         "decay_window_s": 30, "context_cap_s": 300},
+    )
+    utts = [make_utt(1, 100.0, "should we go?"), make_utt(2, 103.0, "we should decide", speaker_total=2),
+            make_utt(3, 110.0, "hmm not sure"), make_utt(4, 118.0, "we should go?")]
+    assert run(utts, cfg) == run(utts, cfg)

--- a/tests/test_attention/test_runner.py
+++ b/tests/test_attention/test_runner.py
@@ -50,7 +50,7 @@ def test_load_runner_config_from_explicit_file(tmp_path):
 
 def test_load_runner_config_falls_back_to_builtin(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "DEFAULT_CONFIG_PATH", str(tmp_path / "absent.json"))
-    assert load_runner_config(None).version == "0.1.0-default"
+    assert load_runner_config(None).version == "0.2.0-taxonomy"
 
 
 @pytest.mark.asyncio

--- a/tests/test_attention/test_scorer.py
+++ b/tests/test_attention/test_scorer.py
@@ -59,3 +59,9 @@ def test_stickiness_none_off_topic_is_floor():
 
 def test_stickiness_zero_window_safe():
     assert stickiness_multiplier(1.3, 5.0, 0.0) == 1.0   # no div-by-zero
+
+
+def test_stickiness_never_below_floor_when_misconfigured():
+    # base < floor (decay_floor_mult > session_stickiness_mult) must NOT dip below floor
+    assert stickiness_multiplier(0.8, 0.0, 30.0, floor=1.0) == 1.0
+    assert stickiness_multiplier(0.8, 15.0, 30.0, floor=1.0) == 1.0

--- a/tests/test_attention/test_scorer.py
+++ b/tests/test_attention/test_scorer.py
@@ -1,5 +1,5 @@
 """Direct unit tests for score composition + activation resolution."""
-from genesis.attention.scorer import resolve_activation, soft_relevance
+from genesis.attention.scorer import resolve_activation, soft_relevance, stickiness_multiplier
 from genesis.attention.types import Activation, TriggerHit, TriggerKind
 
 
@@ -34,3 +34,28 @@ def test_suppressor_precedence():
     assert resolve_activation(hard_hits=inv, suppressor_hits=supp, effective=0.0, threshold=0.6) == Activation.HARD
     # a lone suppressor with nothing to suppress -> no event
     assert resolve_activation(hard_hits=[], suppressor_hits=supp, effective=0.1, threshold=0.6) is None
+
+
+# ── PR3a: decay ──
+
+def test_stickiness_full_when_on_topic():
+    assert stickiness_multiplier(1.3, 0.0, 30.0) == 1.3
+
+
+def test_stickiness_half_decay():
+    # 15s off-topic of a 30s window -> halfway from 1.3 to 1.0 = 1.15
+    assert round(stickiness_multiplier(1.3, 15.0, 30.0), 4) == 1.15
+
+
+def test_stickiness_floors_at_window_and_beyond():
+    assert stickiness_multiplier(1.3, 30.0, 30.0) == 1.0
+    assert stickiness_multiplier(1.3, 100.0, 30.0) == 1.0   # clamped, never below floor
+
+
+def test_stickiness_none_off_topic_is_floor():
+    # first utt of a session (no prior relevant utt) -> no bonus AND no crash (BLOCKER-1)
+    assert stickiness_multiplier(1.3, None, 30.0) == 1.0
+
+
+def test_stickiness_zero_window_safe():
+    assert stickiness_multiplier(1.3, 5.0, 0.0) == 1.0   # no div-by-zero

--- a/tests/test_attention/test_triggers.py
+++ b/tests/test_attention/test_triggers.py
@@ -172,3 +172,10 @@ def test_unanswered_question_dropped_when_answered_in_window():
 
 def test_unknown_speaker_not_registered():
     assert "unknown_speaker" not in SOFT_TRIGGERS              # deferred: no resolved identity field
+
+
+def test_pending_questions_is_bounded():
+    st = EngineState()
+    for i in range(80):                                        # a pathological question-burst
+        unanswered_question_update(st, _u("q?", id=i, ts=100.0 + i * 0.01), CFG)
+    assert len(st.pending_questions) <= 64                     # capped, does not grow unbounded

--- a/tests/test_attention/test_triggers.py
+++ b/tests/test_attention/test_triggers.py
@@ -1,15 +1,31 @@
 """Direct unit tests for the pluggable L1 triggers."""
 from genesis.attention.config import AttentionConfig, default_config_dict
 from genesis.attention.triggers import (
+    SOFT_TRIGGERS,
     _term_present,
     hard_ambient_name,
     hard_explicit_invite,
+    soft_decision,
+    soft_dispute,
     soft_domain_keyword,
+    soft_emotional,
+    soft_lexical_repetition,
     soft_multi_speaker,
+    soft_quantity_money,
     soft_question,
+    soft_recall_cue,
+    soft_task_reminder,
+    soft_temporal_deadline,
+    soft_topic_continuation,
     suppress_explicit_dismissal,
+    suppress_low_asr_confidence,
+    suppress_mode_active_listen,
+    suppress_mode_active_s2s,
+    suppress_mode_global_mute,
+    suppress_sensitive_topic,
+    unanswered_question_update,
 )
-from genesis.attention.types import AmbientUtterance, TriggerKind
+from genesis.attention.types import AmbientUtterance, EngineState, TriggerKind
 
 CFG = AttentionConfig.from_dict(default_config_dict())
 
@@ -55,3 +71,104 @@ def test_domain_keyword_substring():
 def test_suppressor_dismissal():
     assert suppress_explicit_dismissal(_u("never mind"), [], CFG)
     assert suppress_explicit_dismissal(_u("carry on then"), [], CFG) is None
+
+
+# ── PR3a: new soft triggers ──
+
+def test_lexical_bank_triggers_fire_on_default_banks():
+    assert soft_decision(_u("we should ship it"), [], CFG).name == "decision"
+    assert soft_task_reminder(_u("remind me to call"), [], CFG).name == "task_reminder"
+    assert soft_temporal_deadline(_u("it's due tomorrow"), [], CFG).name == "temporal_deadline"
+    assert soft_quantity_money(_u("that's $50"), [], CFG).name == "quantity_money"
+    assert soft_recall_cue(_u("what did we say about it"), [], CFG).name == "recall_cue"
+    assert soft_dispute(_u("are you sure about that"), [], CFG).name == "dispute"
+
+
+def test_lexical_bank_triggers_silent_on_plain_text():
+    for fn in (soft_decision, soft_task_reminder, soft_temporal_deadline,
+               soft_quantity_money, soft_recall_cue, soft_dispute):
+        assert fn(_u("the weather is nice"), [], CFG) is None
+
+
+def test_emotional_fires_on_any_bank():
+    for text in ("ugh this again", "this is amazing", "i'm so confused", "hurry up"):
+        hit = soft_emotional(_u(text), [], CFG)
+        assert hit is not None and hit.name == "emotional", text
+    assert soft_emotional(_u("a neutral sentence"), [], CFG) is None
+
+
+def test_emotional_is_single_hit_when_two_banks_match():
+    hit = soft_emotional(_u("amazing but i'm confused"), [], CFG)  # excitement + confusion
+    assert hit is not None and hit.name == "emotional"            # still exactly one hit
+
+
+def test_topic_continuation_needs_multi_utt_window():
+    cur = _u("continuing on")
+    assert soft_topic_continuation(cur, [cur], CFG) is None                       # only this utt
+    assert soft_topic_continuation(cur, [_u("earlier"), cur], CFG).name == "topic_continuation"
+
+
+def test_lexical_repetition_fires_on_shared_content_tokens():
+    prev = _u("the migration keeps failing on startup")
+    cur = _u("migration failing again on startup")   # shared: migration, failing, startup (>=3)
+    assert soft_lexical_repetition(cur, [prev, cur], CFG).name == "lexical_repetition"
+
+
+def test_lexical_repetition_ignores_distinct_content():
+    prev = _u("the routing layer is broken")
+    cur = _u("the memory cache is slow")             # 3 content tokens, zero overlap with prev
+    assert soft_lexical_repetition(cur, [prev, cur], CFG) is None
+
+
+def test_lexical_repetition_ignores_too_short():
+    cur = _u("routing")                              # 1 content token < min 3
+    assert soft_lexical_repetition(cur, [_u("routing here"), cur], CFG) is None
+
+
+# ── PR3a: new suppressors ──
+
+def test_sensitive_topic_inert_when_bank_empty():
+    assert suppress_sensitive_topic(_u("anything at all"), [], CFG) is None       # default bank is []
+
+
+def test_sensitive_topic_fires_when_bank_filled():
+    cfg = AttentionConfig.from_dict({**default_config_dict(),
+                                     "suppressor_patterns": {"sensitive_topics": [r"\bsalary\b"]}})
+    assert suppress_sensitive_topic(_u("my salary is"), [], cfg).name == "sensitive_topic"
+
+
+def test_low_asr_confidence_threshold():
+    assert suppress_low_asr_confidence(_u("x", frac_lt_1=0.5), [], CFG).name == "low_asr_confidence"
+    assert suppress_low_asr_confidence(_u("x", frac_lt_1=0.1), [], CFG) is None
+    assert suppress_low_asr_confidence(_u("x", frac_lt_1=0.35), [], CFG) is not None  # boundary (>=)
+
+
+def test_mode_suppressors_inert_offline_but_fire_on_mode():
+    assert suppress_mode_active_listen(_u("x"), [], CFG) is None                   # mode_state="unknown"
+    assert suppress_mode_active_listen(_u("x", mode_state="listen_active"), [], CFG).name == "mode_active_listen"
+    assert suppress_mode_active_s2s(_u("x", mode_state="s2s_active"), [], CFG).name == "mode_active_s2s"
+    assert suppress_mode_global_mute(_u("x", mode_state="global_mute"), [], CFG).name == "mode_global_mute"
+    # a mixed multi-mode string still matches by token
+    assert suppress_mode_global_mute(_u("x", mode_state="listen_active global_mute"), [], CFG) is not None
+
+
+# ── PR3a: unanswered-question look-ahead + deferral lock ──
+
+def test_unanswered_question_emits_after_window_and_enqueues():
+    st = EngineState()
+    assert unanswered_question_update(st, _u("what time is it?", id=1, ts=100.0), CFG) is None
+    assert st.pending_questions == [(1, 100.0)]                # enqueued, nothing stale yet
+    hit = unanswered_question_update(st, _u("mm", id=2, ts=106.0), CFG)   # 6s > 5s window
+    assert hit is not None and hit.name == "unanswered_question"
+    assert st.pending_questions == []                          # emitted -> dropped
+
+
+def test_unanswered_question_dropped_when_answered_in_window():
+    st = EngineState()
+    unanswered_question_update(st, _u("where are we?", id=1, ts=100.0), CFG)
+    hit = unanswered_question_update(st, _u("we are on step three", id=2, ts=102.0), CFG)
+    assert hit is None and st.pending_questions == []          # substantive reply within 5s answers it
+
+
+def test_unknown_speaker_not_registered():
+    assert "unknown_speaker" not in SOFT_TRIGGERS              # deferred: no resolved identity field


### PR DESCRIPTION
## What

PR3a of the attention engine (Track 1 omnipresence): completes the deterministic **§4 trigger taxonomy** in the pure L1 core. Follows PR1 (shadow gate, #820) and PR2 (calibration cockpit, #829).

**Pure-core only — no migration, no LLM, no runtime call site** (v1 is an offline CLI). Edge-portability preserved (`test_edge_portability.py` holds — zero new genesis-runtime imports in the core).

### Triggers added
- 9 soft: `decision` / `task_reminder` / `temporal_deadline` / `quantity_money` / `recall_cue` / `dispute` (wire existing config banks) + `emotional` (one trigger, any of the 4 banks) + `topic_continuation` + `lexical_repetition` (pure over the window)
- `unanswered_question`: engine-emitted forward-only look-ahead (`pending_questions` state, single-pass filter, bounded)
- **decay**: `stickiness_multiplier` linearly decays the in-session stickiness bonus toward the floor over `decay_window_s` (None-safe on the first utt of a session)
- suppressors: `sensitive_topic` (on, empty bank) + `low_asr_confidence` + `mode_*` — **registered but OFF by default** (`low_asr` would double-count `capture_clarity`'s `1-frac_lt_1`; `mode_*` inert offline, live at the edge via `mode_state` tokens)
- `unknown_speaker` **deferred** — no resolved per-speaker identity field (`speaker_name` is a diarization label, dropped upstream)

### Calibration (the honest part)
A dry-run over the live snapshot (5299 non-blip utts) caught the seed weights **over-firing** — fire-rate 6.2% → 11.8%, with `topic_continuation` firing on ~78% of windows and stacking with `multi_speaker` + stickiness to push content-free garble over the bar. Fix: **neutralized `topic_continuation` (weight 0.0** — still recorded in `triggers_fired` for the shadow log). Fire-rate returns to ~baseline (6.6%) with an **intent-driven** firing mix (question/decision/unanswered_question/domain/recall). Finer `multi_speaker`/`is_user` tuning is deferred to the **labelled PR3c re-tune** (0/326 events labelled today). Config version bumped `0.1.0-default → 0.2.0-taxonomy` so a persist writes NEW rows and never clobbers PR2's labelled corpus.

## Review
- genesis-architect pre-review (2 blockers fixed pre-code: stickiness None-guard; dropped a redundant `recent_texts` deque).
- code-reviewer pass (no blockers; 2 defensive one-liners folded in: clamp stickiness to floor; bound `pending_questions`).
- 94 tests green in `tests/test_attention/` (incl. edge-portability); ruff clean.

## Not in this PR
PR3b (L1.5 `attention_salience` sampler seam, gated/off; non-Groq provider bake-off) and PR3c (offline re-tune helper against labels) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)