### PR TITLE
feat(autonomy): WS5 Stage 2 — Discord capability shadow-gate (observe-only, all 3 doors)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,19 @@ jobs:
           fi
           echo "Migration prefix check: CLEAN"
 
+  external-io-check:
+    # WS5 regression guard: no NEW ungated autonomous external-world egress
+    # (Discord REST/webhook, public social APIs) outside the reasoned allowlist.
+    # See scripts/check_external_io.py.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: External-I/O egress guard
+        run: python scripts/check_external_io.py
+
   test:
     runs-on: ubuntu-latest
     # CI is blocking — local full-suite runs are banned. See procedure

--- a/scripts/check_external_io.py
+++ b/scripts/check_external_io.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""WS5 external-I/O regression guard — no NEW ungated autonomous external egress.
+
+The whole point of WS5 autonomy-gating is that Genesis must not post to the outside
+world (Discord community, public webhooks, public social APIs) through an ungated,
+unobserved path. This grep-based guard is the CI/pre-commit backstop: any source file
+that references a Discord/webhook/public-social endpoint must be on the ALLOWLIST
+(each entry pinned to a known, capability-gated-or-shadowed egress door). A new door
+added anywhere else fails the check — forcing it through the capability gate (or an
+explicit, reasoned allowlist entry) instead of silently shipping a bypass.
+
+SCOPE (deliberately precise, not a generic ``.post(`` scan — there are ~dozens of
+legitimate compute/read POSTs: embeddings, search, TTS, crawl, IPC):
+  * HTTP egress to Discord (REST API + webhooks) and public-social APIs (Twitter/X,
+    Slack). You cannot POST to these without referencing their endpoint/webhook-env
+    string somewhere — that reference is what this guard flags.
+OUT OF SCOPE (documented, handled elsewhere):
+  * Browser-based publishing (e.g. Medium via Playwright) — a different egress
+    modality; a browser-egress guard lands with that channel's gating stage.
+  * Owner-private notification channels (email-to-owner, Telegram-to-owner) — the
+    owner IS the recipient; these are not external-world posting.
+
+Usage:  python scripts/check_external_io.py   (exit 0 = clean, 1 = violation)
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+SCAN_ROOT = Path("src/genesis")
+
+# Endpoint/webhook-env signatures for autonomous external-world HTTP egress.
+PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"discord\.com/api"),        # Discord REST API (send_reply)
+    re.compile(r"discordapp\.com/api"),     # legacy Discord API
+    re.compile(r"DISCORD_WEBHOOK"),         # Discord webhook env (adapter / outreach_poll)
+    re.compile(r"api\.twitter\.com"),       # Twitter/X (future public channel)
+    re.compile(r"slack\.com/api"),          # Slack API (future)
+    re.compile(r"hooks\.slack\.com"),       # Slack webhooks (future)
+]
+
+# Known egress doors. Each is capability-gate SHADOW-observed today (WS5 Discord
+# shadow-gate) and slated for enforcement in the enforce stage. Additions here MUST
+# carry an inline rationale AND route the send through the capability gate.
+ALLOWLIST: dict[str, str] = {
+    "src/genesis/mcp/discord_bot_mcp.py":
+        "external-io-ok: send_reply (Discord API); shadow-observed via observe_discord_send",
+    "src/genesis/mcp/outreach_mcp.py":
+        "external-io-ok: outreach_poll (Discord webhook); shadow-observed via observe_discord_send",
+    "src/genesis/runtime/init/outreach.py":
+        "external-io-ok: DiscordWebhookAdapter wiring (reads DISCORD_WEBHOOK_URL); "
+        "sends flow through pipeline._deliver, shadow-observed",
+}
+
+
+def scan(root: Path, allowlist: dict[str, str] | None = None) -> list[tuple[str, int, str]]:
+    """Return [(relpath, lineno, line)] for endpoint matches OUTSIDE the allowlist."""
+    allowed = set(allowlist if allowlist is not None else ALLOWLIST)
+    violations: list[tuple[str, int, str]] = []
+    for path in sorted(root.rglob("*.py")):
+        rel = path.as_posix()
+        if rel in allowed:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if any(p.search(line) for p in PATTERNS):
+                violations.append((rel, lineno, line.strip()))
+    return violations
+
+
+def main() -> int:
+    if not SCAN_ROOT.is_dir():
+        print(f"external-io guard: scan root {SCAN_ROOT} not found (run from repo root)")
+        return 1
+    violations = scan(SCAN_ROOT)
+    if not violations:
+        print("External-I/O guard: CLEAN (no ungated external-egress endpoints outside the allowlist)")
+        return 0
+    print("::error::New ungated external-world egress detected (WS5 autonomy-gating).")
+    print("Route the send through the capability gate, or add a reasoned ALLOWLIST entry.")
+    for rel, lineno, line in violations:
+        print(f"  {rel}:{lineno}: {line}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_external_io.py
+++ b/scripts/check_external_io.py
@@ -9,16 +9,22 @@ that references a Discord/webhook/public-social endpoint must be on the ALLOWLIS
 added anywhere else fails the check — forcing it through the capability gate (or an
 explicit, reasoned allowlist entry) instead of silently shipping a bypass.
 
-SCOPE (deliberately precise, not a generic ``.post(`` scan — there are ~dozens of
-legitimate compute/read POSTs: embeddings, search, TTS, crawl, IPC):
-  * HTTP egress to Discord (REST API + webhooks) and public-social APIs (Twitter/X,
-    Slack). You cannot POST to these without referencing their endpoint/webhook-env
-    string somewhere — that reference is what this guard flags.
-OUT OF SCOPE (documented, handled elsewhere):
-  * Browser-based publishing (e.g. Medium via Playwright) — a different egress
-    modality; a browser-egress guard lands with that channel's gating stage.
-  * Owner-private notification channels (email-to-owner, Telegram-to-owner) — the
-    owner IS the recipient; these are not external-world posting.
+WHAT IT FLAGS (deliberately precise — NOT a generic ``.post(`` scan; there are ~dozens
+of legitimate compute/read POSTs: embeddings, search, TTS, crawl, IPC):
+  * Any source file that REFERENCES a Discord REST/webhook or public-social (Twitter/X,
+    Slack) endpoint or webhook env var (see PATTERNS). A new external door cannot reach
+    these services without such a reference at its endpoint lookup, so it trips here.
+WHAT IT DOES NOT SEE (by design — this is a reference tripwire, not a taint analysis):
+  * A ``.post(pre_built_url)`` whose URL arrives as a variable with no literal endpoint
+    token on the call line — e.g. ``channels/discord_adapter.py`` posts to a webhook URL
+    it RECEIVES from ``runtime/init/outreach.py``. The guard covers that URL's ORIGIN
+    (the DISCORD_WEBHOOK reference in outreach.py, allow-listed) — which is exactly what
+    a new door must add — rather than the generic POST site itself.
+OUT OF SCOPE (handled elsewhere):
+  * Browser-based publishing (e.g. Medium via Playwright) — a different egress modality;
+    a browser-egress guard lands with that channel's gating stage.
+  * Owner-private notification channels (email-to-owner, Telegram-to-owner) — the owner
+    IS the recipient; these are not external-world posting.
 
 Usage:  python scripts/check_external_io.py   (exit 0 = clean, 1 = violation)
 """

--- a/scripts/genesis_mcp_server.py
+++ b/scripts/genesis_mcp_server.py
@@ -361,8 +361,10 @@ def _bootstrap_outreach(transport_kwargs: dict) -> None:
 def _bootstrap_discord_bot(transport_kwargs: dict) -> None:
     """Bootstrap and run the discord-bot MCP server.
 
-    Provides read/write Discord access via bot token for campaign
-    sessions. No DB connection needed — fully stateless.
+    Provides read/write Discord access via bot token for campaign sessions.
+    Opens a BEST-EFFORT genesis.db connection (WS5) so send_reply can record
+    capability-shadow observations — the server stays fully functional if the
+    DB is missing or fails to open (db=None => shadow is a no-op).
     """
     import os
 
@@ -373,8 +375,31 @@ def _bootstrap_discord_bot(transport_kwargs: dict) -> None:
         logger.error("DISCORD_BOT_TOKEN not set — discord-bot cannot start")
         return
 
-    init_discord_bot(bot_token=bot_token)
-    clear_mcp_crash("discord-bot")
+    @asynccontextmanager
+    async def _lifespan(server) -> AsyncIterator[None]:
+        from genesis.db.connection import get_db
+
+        # WS5 capability-shadow DB — opened ONCE for the server's lifetime (never
+        # per-call, to avoid a WAL-lock hang on the reply path). NON-fatal: the
+        # discord-bot's core job (send_reply) must work even with no shadow DB.
+        db = None
+        if _DEFAULT_DB.exists():
+            try:
+                db = await get_db(_DEFAULT_DB, foreign_keys=False)
+            except Exception:
+                logger.warning(
+                    "discord-bot: shadow DB open failed — continuing without shadow",
+                    exc_info=True,
+                )
+        init_discord_bot(bot_token=bot_token, db=db)
+        clear_mcp_crash("discord-bot")
+        try:
+            yield
+        finally:
+            if db is not None:
+                await db.close()
+
+    mcp._lifespan = _lifespan
     _run_mcp(mcp, transport_kwargs)
 
 

--- a/src/genesis/autonomy/shadow_gate.py
+++ b/src/genesis/autonomy/shadow_gate.py
@@ -16,6 +16,7 @@ Coverage (the three live Discord doors — enumerated, exhaustive):
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import uuid
 from datetime import UTC, datetime
@@ -46,8 +47,6 @@ async def observe_discord_send(
     if db is None:
         return False
     try:
-        from genesis.outreach.governance import content_hash
-
         cell = await cg.get_cell(db, _DOMAIN, verb, risk_class)
         # None => the cell has never been created => not_determined => would hold.
         state = cell["state"] if cell else None
@@ -66,7 +65,10 @@ async def observe_discord_send(
             would_hold=would_hold,
             target=target,
             content_preview=text[:_PREVIEW_MAX],
-            content_hash=content_hash(text),
+            # Hash the FULL content — a genuine fingerprint for dedup/analysis, distinct
+            # from the bounded content_preview (first N chars). NOT governance.content_hash,
+            # which truncates to 200 chars (would collide with the preview span).
+            content_hash=hashlib.sha256(text.encode()).hexdigest(),
         )
     except Exception:  # noqa: BLE001 — shadow is best-effort; NEVER break the real send
         logger.debug("capability shadow observe failed (best-effort)", exc_info=True)

--- a/src/genesis/autonomy/shadow_gate.py
+++ b/src/genesis/autonomy/shadow_gate.py
@@ -1,0 +1,73 @@
+"""WS5 Discord capability SHADOW-gate — observe-only.
+
+At each autonomous Discord egress door, record what a capability gate WOULD decide
+(hold vs allow) WITHOUT holding. The lookup is READ-ONLY (no ``apply_event`` /
+``ensure_cell`` — a not-yet-created cell simply reads as ``not_determined``), the
+record is BEST-EFFORT (any failure — a ``None`` db, a missing table, a locked DB — is
+swallowed at DEBUG), and the function NEVER raises, NEVER blocks, and NEVER mutates
+capability state. The real send always proceeds. This is the observation phase before
+the ENFORCE stage turns the gate on.
+
+Coverage (the three live Discord doors — enumerated, exhaustive):
+- ``deliver`` — ``outreach/pipeline._deliver`` (server process) -> discord webhook
+- ``poll``    — ``mcp/outreach_mcp.outreach_poll`` (outreach subprocess) -> webhook
+- ``reply``   — ``mcp/discord_bot_mcp.send_reply`` (discord-bot subprocess) -> API
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+
+from genesis.autonomy.types import CellState
+from genesis.db.crud import capability_grants as cg
+from genesis.db.crud import capability_shadow
+
+logger = logging.getLogger(__name__)
+
+_DOMAIN = "discord"
+_PREVIEW_MAX = 200
+
+
+async def observe_discord_send(
+    db,
+    *,
+    path: str,
+    verb: str,
+    risk_class: str,
+    target: str | None,
+    content: str | None,
+) -> bool:
+    """Record a Discord-send capability-shadow observation. Returns True iff a row was
+    written (False on a no-op/best-effort failure). Reads the (discord, verb,
+    risk_class) cell READ-ONLY: a GRANTED cell => ``would_allow``; anything else (incl.
+    a cell that doesn't exist yet) => ``would_hold``."""
+    if db is None:
+        return False
+    try:
+        from genesis.outreach.governance import content_hash
+
+        cell = await cg.get_cell(db, _DOMAIN, verb, risk_class)
+        # None => the cell has never been created => not_determined => would hold.
+        state = cell["state"] if cell else None
+        would_hold = state != CellState.GRANTED.value
+        text = content or ""
+        return await capability_shadow.record(
+            db,
+            id=str(uuid.uuid4()),
+            observed_at=datetime.now(UTC).isoformat(),
+            path=path,
+            channel=_DOMAIN,
+            cell_domain=_DOMAIN,
+            cell_verb=verb,
+            cell_risk_class=risk_class,
+            cell_state=state,
+            would_hold=would_hold,
+            target=target,
+            content_preview=text[:_PREVIEW_MAX],
+            content_hash=content_hash(text),
+        )
+    except Exception:  # noqa: BLE001 — shadow is best-effort; NEVER break the real send
+        logger.debug("capability shadow observe failed (best-effort)", exc_info=True)
+        return False

--- a/src/genesis/db/crud/capability_shadow.py
+++ b/src/genesis/db/crud/capability_shadow.py
@@ -1,0 +1,111 @@
+"""CRUD for capability_shadow_events — the WS5 Discord capability-gate SHADOW store.
+
+Observe-only: rows are gate DECISIONS + routing refs + a bounded content excerpt —
+NEVER a hold/approval. Written best-effort from THREE processes: the genesis-server
+(``outreach/pipeline._deliver``), the outreach MCP subprocess (``outreach_poll``),
+and the discord-bot MCP subprocess (``send_reply``) — all against the same
+``genesis.db`` (WAL + busy_timeout).
+
+Subprocess writers do NOT run migrations, so ``record()`` guards on table existence
+(cached per-process) and returns False if the table isn't there yet (the brief
+pre-migration window). It NEVER creates the table — migration 0044 is the sole schema
+authority, so there is no inline-DDL-vs-migration divergence surface.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+COLUMNS = (
+    "id", "observed_at", "path", "channel", "cell_domain", "cell_verb",
+    "cell_risk_class", "cell_state", "would_hold", "target", "content_preview",
+    "content_hash",
+)
+
+# Per-process cache: once the table is confirmed present we stop re-checking. Only the
+# TRUE result is cached — a missing table (pre-migration) is re-checked on every call so
+# a subprocess writer self-heals the moment the server migration lands.
+_table_verified = False
+
+
+async def _table_available(db: aiosqlite.Connection) -> bool:
+    global _table_verified
+    if _table_verified:
+        return True
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        "AND name='capability_shadow_events'"
+    )
+    exists = await cursor.fetchone() is not None
+    if exists:
+        _table_verified = True
+    return exists
+
+
+async def record(
+    db: aiosqlite.Connection,
+    *,
+    id: str,
+    observed_at: str,
+    path: str,
+    channel: str,
+    cell_domain: str,
+    cell_verb: str,
+    cell_risk_class: str,
+    cell_state: str | None,
+    would_hold: bool,
+    target: str | None,
+    content_preview: str | None,
+    content_hash: str | None,
+) -> bool:
+    """Insert one shadow observation. Returns False (no-op) if the table doesn't exist
+    yet (subprocess pre-migration window); never creates it."""
+    if not await _table_available(db):
+        return False
+    await db.execute(
+        "INSERT INTO capability_shadow_events "
+        "(id, observed_at, path, channel, cell_domain, cell_verb, cell_risk_class, "
+        "cell_state, would_hold, target, content_preview, content_hash) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            id, observed_at, path, channel, cell_domain, cell_verb, cell_risk_class,
+            cell_state, 1 if would_hold else 0, target, content_preview, content_hash,
+        ),
+    )
+    await db.commit()
+    return True
+
+
+async def count(db: aiosqlite.Connection) -> int:
+    cursor = await db.execute("SELECT COUNT(*) FROM capability_shadow_events")
+    row = await cursor.fetchone()
+    return row[0] if row else 0
+
+
+async def list_recent(
+    db: aiosqlite.Connection, *, limit: int = 100, offset: int = 0,
+) -> list[dict]:
+    """Recent shadow observations, newest first (for review). Assumes a Row factory."""
+    lim = max(1, min(int(limit), 500))
+    off = max(0, int(offset))
+    cursor = await db.execute(
+        "SELECT * FROM capability_shadow_events "
+        "ORDER BY observed_at DESC LIMIT ? OFFSET ?",
+        (lim, off),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def summary(db: aiosqlite.Connection) -> list[dict]:
+    """Per-door / per-cell volume + would_hold breakdown (COUNTS only — no content).
+
+    The observation deliverable: how much autonomous Discord traffic flows through each
+    door and how much a live gate would hold, so the ENFORCE stage can size the posture.
+    """
+    cursor = await db.execute(
+        "SELECT path, cell_domain, cell_verb, cell_risk_class, would_hold, "
+        "COUNT(*) AS n FROM capability_shadow_events "
+        "GROUP BY path, cell_domain, cell_verb, cell_risk_class, would_hold "
+        "ORDER BY n DESC"
+    )
+    return [dict(r) for r in await cursor.fetchall()]

--- a/src/genesis/db/migrations/0044_capability_shadow_events.py
+++ b/src/genesis/db/migrations/0044_capability_shadow_events.py
@@ -1,0 +1,55 @@
+"""Add capability_shadow_events — the WS5 Discord capability-gate SHADOW store.
+
+Observe-only: at each autonomous Discord egress door (the outreach pipeline
+``_deliver``, the ``outreach_poll`` webhook, and the discord-bot ``send_reply``
+API call) Genesis records what a capability gate WOULD decide (hold vs allow)
+WITHOUT actually holding. This gathers volume + pattern data before the ENFORCE
+stage turns the gate on; there is NO behavioural change to any send.
+
+Firewall/privacy: rows are gate DECISIONS + routing refs + a BOUNDED excerpt
+(<=200 chars of otherwise-public Discord content) + a hash over the FULL content.
+``content_preview`` and ``content_hash`` are NOT paired — the hash is over the
+full text, the preview is a truncated excerpt. Additive + idempotent; the canonical
+DDL is mirrored in ``db/schema/_tables.py`` for the fresh-DB path. Individual
+``db.execute()`` calls (never ``executescript``) so a concurrent
+``CREATE TABLE IF NOT EXISTS`` from a subprocess writer stays serialized under WAL.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS capability_shadow_events (
+            id               TEXT PRIMARY KEY,
+            observed_at      TEXT NOT NULL,      -- ISO8601 UTC — when the send was observed
+            path             TEXT NOT NULL,      -- egress door: deliver | poll | reply
+            channel          TEXT NOT NULL,      -- 'discord'
+            cell_domain      TEXT NOT NULL,      -- capability cell domain ('discord')
+            cell_verb        TEXT NOT NULL,      -- send | poll | reply
+            cell_risk_class  TEXT NOT NULL,      -- bulk | standard | identity
+            cell_state       TEXT,               -- capability_grants.state at observation; NULL => cell not yet created (not_determined)
+            would_hold       INTEGER NOT NULL,   -- 1 = a live gate WOULD hold this send; 0 = would allow (GRANTED cell)
+            target           TEXT,               -- routing target (webhook name / channel_id / recipient) — NOT content
+            content_preview  TEXT,               -- truncated excerpt (<=200 chars); NOT paired with content_hash
+            content_hash     TEXT                -- hash over the FULL content (analysis/dedup); != content_preview
+            -- SHADOW/OBSERVE-ONLY: gate DECISIONS + refs only. No hold/approval is
+            -- created here; the send always proceeds. Not read by any cognition job.
+        )
+        """
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_capability_shadow_events_observed_at "
+        "ON capability_shadow_events(observed_at)"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_capability_shadow_events_cell "
+        "ON capability_shadow_events(cell_domain, cell_verb, cell_risk_class)"
+    )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    await db.execute("DROP TABLE IF EXISTS capability_shadow_events")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -61,6 +61,24 @@ TABLES = {
             -- Not read by any cognition job (dream/ego/memory-synthesis).
         )
     """,
+    "capability_shadow_events": """
+        CREATE TABLE IF NOT EXISTS capability_shadow_events (
+            id               TEXT PRIMARY KEY,
+            observed_at      TEXT NOT NULL,      -- ISO8601 UTC — when the send was observed
+            path             TEXT NOT NULL,      -- egress door: deliver | poll | reply
+            channel          TEXT NOT NULL,      -- 'discord'
+            cell_domain      TEXT NOT NULL,      -- capability cell domain ('discord')
+            cell_verb        TEXT NOT NULL,      -- send | poll | reply
+            cell_risk_class  TEXT NOT NULL,      -- bulk | standard | identity
+            cell_state       TEXT,               -- capability_grants.state at observation; NULL => not_determined
+            would_hold       INTEGER NOT NULL,   -- 1 = a live gate WOULD hold this send; 0 = would allow (GRANTED)
+            target           TEXT,               -- routing target (webhook/channel_id/recipient) — NOT content
+            content_preview  TEXT,               -- truncated excerpt (<=200 chars); NOT paired with content_hash
+            content_hash     TEXT                -- hash over the FULL content; != content_preview
+            -- WS5 Discord capability-gate SHADOW store: gate DECISIONS + refs only.
+            -- Observe-only — no hold/approval is created here; the send always proceeds.
+        )
+    """,
     "observations": """
         CREATE TABLE IF NOT EXISTS observations (
             id               TEXT PRIMARY KEY,
@@ -1545,6 +1563,8 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_attention_events_session ON attention_events(session_id)",
     "CREATE INDEX IF NOT EXISTS idx_attention_events_ts ON attention_events(ts)",
     "CREATE INDEX IF NOT EXISTS idx_attention_events_unlabeled ON attention_events(acceptance_signal) WHERE acceptance_signal IS NULL",
+    "CREATE INDEX IF NOT EXISTS idx_capability_shadow_events_observed_at ON capability_shadow_events(observed_at)",
+    "CREATE INDEX IF NOT EXISTS idx_capability_shadow_events_cell ON capability_shadow_events(cell_domain, cell_verb, cell_risk_class)",
     "CREATE INDEX IF NOT EXISTS idx_procedural_task_type ON procedural_memory(task_type)",
     "CREATE INDEX IF NOT EXISTS idx_procedural_draft ON procedural_memory(draft)",
     "CREATE INDEX IF NOT EXISTS idx_procedural_activation_tier ON procedural_memory(activation_tier)",

--- a/src/genesis/mcp/discord_bot_mcp.py
+++ b/src/genesis/mcp/discord_bot_mcp.py
@@ -225,19 +225,6 @@ async def send_reply(
     except RuntimeError as exc:
         return json.dumps({"error": str(exc)})
 
-    # WS5 Discord capability SHADOW-gate: observe (never hold) this reply — record what
-    # a capability gate WOULD decide. Read-only + best-effort; _db is None if the shadow
-    # DB is unavailable. Wrapped so a shadow/import problem can NEVER break the reply.
-    try:
-        from genesis.autonomy.shadow_gate import observe_discord_send
-
-        await observe_discord_send(
-            _db, path="reply", verb="reply", risk_class="standard",
-            target=channel_id, content=content,
-        )
-    except Exception:  # noqa: BLE001 — the reply path must never fail on shadow
-        logger.debug("send_reply capability shadow observe failed", exc_info=True)
-
     chunks = _chunk_text(content)
     sent_ids: list[str] = []
 
@@ -275,6 +262,20 @@ async def send_reply(
 
             msg_data = resp.json()
             sent_ids.append(msg_data.get("id", ""))
+
+    # WS5 Discord capability SHADOW-gate: observe (never hold) this reply AFTER it is
+    # fully sent, so the reply is NEVER delayed by the shadow write. Best-effort; _db is
+    # None if the shadow DB is unavailable. Wrapped so a shadow/import problem can never
+    # break the reply.
+    try:
+        from genesis.autonomy.shadow_gate import observe_discord_send
+
+        await observe_discord_send(
+            _db, path="reply", verb="reply", risk_class="standard",
+            target=channel_id, content=content,
+        )
+    except Exception:  # noqa: BLE001 — the reply path must never fail on shadow
+        logger.debug("send_reply capability shadow observe failed", exc_info=True)
 
     result_text = (
         f"sent (id: {sent_ids[0]})"

--- a/src/genesis/mcp/discord_bot_mcp.py
+++ b/src/genesis/mcp/discord_bot_mcp.py
@@ -4,8 +4,10 @@ Provides fetch_messages, fetch_forum_threads, and send_reply tools via
 the Discord bot token. Loaded only by sessions that use the discord-bot MCP
 server (not by foreground, ego, reflection, or other session types).
 
-Stateless — no DB connection needed. Token injected at bootstrap via
-init_discord_bot().
+Token + an OPTIONAL best-effort genesis.db connection are injected at bootstrap
+via init_discord_bot(). The DB is used ONLY for WS5 capability-shadow recording
+(send_reply observes what a gate would decide, never holds); the server is fully
+functional without it (db=None => shadow is a no-op).
 """
 
 from __future__ import annotations
@@ -22,6 +24,10 @@ mcp = FastMCP("discord-bot")
 
 _bot_token: str | None = None
 
+# WS5: optional best-effort genesis.db connection for capability-shadow recording.
+# None => shadow is a no-op (the reply path is never gated on it).
+_db = None
+
 # GENesis Discord guild ID (public — visible in access.json)
 _GUILD_ID = "1486075405579583538"
 
@@ -32,11 +38,16 @@ _API = "https://discord.com/api/v10"
 _MAX_MESSAGE_LENGTH = 2000
 
 
-def init_discord_bot(*, bot_token: str) -> None:
-    """Wire the bot token for API calls."""
-    global _bot_token
+def init_discord_bot(*, bot_token: str, db=None) -> None:
+    """Wire the bot token for API calls, plus an OPTIONAL best-effort genesis.db
+    connection used only for WS5 capability-shadow recording (send_reply observes,
+    never holds). ``db=None`` keeps the server fully functional with shadow disabled."""
+    global _bot_token, _db
     _bot_token = bot_token
-    logger.info("Discord bot MCP wired (token=%s)", bool(bot_token))
+    _db = db
+    logger.info(
+        "Discord bot MCP wired (token=%s, shadow_db=%s)", bool(bot_token), bool(db),
+    )
 
 
 def _headers() -> dict[str, str]:
@@ -213,6 +224,19 @@ async def send_reply(
         headers = _headers()
     except RuntimeError as exc:
         return json.dumps({"error": str(exc)})
+
+    # WS5 Discord capability SHADOW-gate: observe (never hold) this reply — record what
+    # a capability gate WOULD decide. Read-only + best-effort; _db is None if the shadow
+    # DB is unavailable. Wrapped so a shadow/import problem can NEVER break the reply.
+    try:
+        from genesis.autonomy.shadow_gate import observe_discord_send
+
+        await observe_discord_send(
+            _db, path="reply", verb="reply", risk_class="standard",
+            target=channel_id, content=content,
+        )
+    except Exception:  # noqa: BLE001 — the reply path must never fail on shadow
+        logger.debug("send_reply capability shadow observe failed", exc_info=True)
 
     chunks = _chunk_text(content)
     sent_ids: list[str] = []

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -226,6 +226,15 @@ async def outreach_poll(
     question = gated[0].text
     answers = [g.text for g in gated[1:]]
 
+    # WS5 Discord capability SHADOW-gate: observe (never hold) this autonomous poll —
+    # record what a capability gate WOULD decide. Read-only + best-effort (guards a None
+    # _db in standalone mode); never blocks the post.
+    from genesis.autonomy.shadow_gate import observe_discord_send
+
+    await observe_discord_send(
+        _db, path="poll", verb="poll", risk_class="bulk", target=channel, content=question,
+    )
+
     url = f"{webhook_url}?wait=true"
     payload = {
         "poll": {

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -226,15 +226,6 @@ async def outreach_poll(
     question = gated[0].text
     answers = [g.text for g in gated[1:]]
 
-    # WS5 Discord capability SHADOW-gate: observe (never hold) this autonomous poll —
-    # record what a capability gate WOULD decide. Read-only + best-effort (guards a None
-    # _db in standalone mode); never blocks the post.
-    from genesis.autonomy.shadow_gate import observe_discord_send
-
-    await observe_discord_send(
-        _db, path="poll", verb="poll", risk_class="bulk", target=channel, content=question,
-    )
-
     url = f"{webhook_url}?wait=true"
     payload = {
         "poll": {
@@ -254,6 +245,16 @@ async def outreach_poll(
             data = resp.json()
             msg_id = data.get("id", "")
         logger.info("Discord poll created via %s (msg_id=%s)", channel, msg_id)
+
+        # WS5 Discord capability SHADOW-gate: observe (never hold) this poll AFTER it's
+        # posted, so the post is never delayed by the shadow write. Best-effort, read-
+        # only (guards a None _db in standalone mode).
+        from genesis.autonomy.shadow_gate import observe_discord_send
+
+        await observe_discord_send(
+            _db, path="poll", verb="poll", risk_class="bulk",
+            target=channel, content=question,
+        )
 
         # ── Record to outreach_history for dedup + campaign visibility ──
         if _db is not None:

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -248,13 +248,18 @@ async def outreach_poll(
 
         # WS5 Discord capability SHADOW-gate: observe (never hold) this poll AFTER it's
         # posted, so the post is never delayed by the shadow write. Best-effort, read-
-        # only (guards a None _db in standalone mode).
-        from genesis.autonomy.shadow_gate import observe_discord_send
+        # only (guards a None _db in standalone mode). The import + call are wrapped so a
+        # shadow/import failure can never flip an already-posted poll into an error return
+        # (which the caller could otherwise retry → double-post).
+        try:
+            from genesis.autonomy.shadow_gate import observe_discord_send
 
-        await observe_discord_send(
-            _db, path="poll", verb="poll", risk_class="bulk",
-            target=channel, content=question,
-        )
+            await observe_discord_send(
+                _db, path="poll", verb="poll", risk_class="bulk",
+                target=channel, content=question,
+            )
+        except Exception:  # noqa: BLE001 — shadow is best-effort; never break the poll
+            logger.debug("outreach_poll capability shadow observe failed", exc_info=True)
 
         # ── Record to outreach_history for dedup + campaign visibility ──
         if _db is not None:

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -592,12 +592,17 @@ class OutreachPipeline:
             # record). Records what a capability gate WOULD decide. Best-effort + read-
             # only; the gate_cleared resume path is below-the-gate → not observed.
             if channel == "discord" and not gate_cleared:
-                from genesis.autonomy.shadow_gate import observe_discord_send
+                # Import + call are wrapped so a shadow/import failure can never break the
+                # already-completed send (uniform with the poll/reply doors).
+                try:
+                    from genesis.autonomy.shadow_gate import observe_discord_send
 
-                await observe_discord_send(
-                    self._db, path="deliver", verb="send", risk_class="bulk",
-                    target=str(delivery_recipient), content=formatted.text,
-                )
+                    await observe_discord_send(
+                        self._db, path="deliver", verb="send", risk_class="bulk",
+                        target=str(delivery_recipient), content=formatted.text,
+                    )
+                except Exception:  # noqa: BLE001 — shadow is best-effort; never break the send
+                    logger.debug("deliver capability shadow observe failed", exc_info=True)
 
             # WS-8 PR-D: log autonomous (GRANTED-cell) email sends for owner
             # visibility (Activity tab), the flag-as-bad correction, and the

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -536,6 +536,18 @@ class OutreachPipeline:
             if egress.fixes_applied:
                 formatted = replace(formatted, text=egress.text)
 
+        # WS5 Discord capability SHADOW-gate: observe (never hold) autonomous Discord
+        # sends — record what a capability gate WOULD decide. Read-only + best-effort;
+        # never blocks the send. The gate_cleared resume path is below-the-gate, so it
+        # is not observed (mirrors the email gate's gate_cleared skip above).
+        if channel == "discord" and not gate_cleared:
+            from genesis.autonomy.shadow_gate import observe_discord_send
+
+            await observe_discord_send(
+                self._db, path="deliver", verb="send", risk_class="bulk",
+                target=str(delivery_recipient), content=formatted.text,
+            )
+
         try:
             delivery_id = await adapter.send_message(
                 delivery_recipient, formatted.text,

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -536,18 +536,6 @@ class OutreachPipeline:
             if egress.fixes_applied:
                 formatted = replace(formatted, text=egress.text)
 
-        # WS5 Discord capability SHADOW-gate: observe (never hold) autonomous Discord
-        # sends — record what a capability gate WOULD decide. Read-only + best-effort;
-        # never blocks the send. The gate_cleared resume path is below-the-gate, so it
-        # is not observed (mirrors the email gate's gate_cleared skip above).
-        if channel == "discord" and not gate_cleared:
-            from genesis.autonomy.shadow_gate import observe_discord_send
-
-            await observe_discord_send(
-                self._db, path="deliver", verb="send", risk_class="bulk",
-                target=str(delivery_recipient), content=formatted.text,
-            )
-
         try:
             delivery_id = await adapter.send_message(
                 delivery_recipient, formatted.text,
@@ -597,6 +585,19 @@ class OutreachPipeline:
                 content_hash=content_hash(request.context),
             )
             await outreach_crud.record_delivery(self._db, outreach_id, delivered_at=now)
+
+            # WS5 Discord capability SHADOW-gate: observe (never hold) autonomous Discord
+            # sends AFTER the post is already out, so the community-facing send is NEVER
+            # delayed by the shadow write (any WAL contention only defers the internal
+            # record). Records what a capability gate WOULD decide. Best-effort + read-
+            # only; the gate_cleared resume path is below-the-gate → not observed.
+            if channel == "discord" and not gate_cleared:
+                from genesis.autonomy.shadow_gate import observe_discord_send
+
+                await observe_discord_send(
+                    self._db, path="deliver", verb="send", risk_class="bulk",
+                    target=str(delivery_recipient), content=formatted.text,
+                )
 
             # WS-8 PR-D: log autonomous (GRANTED-cell) email sends for owner
             # visibility (Activity tab), the flag-as-bad correction, and the

--- a/tests/test_autonomy/test_shadow_gate.py
+++ b/tests/test_autonomy/test_shadow_gate.py
@@ -1,0 +1,126 @@
+"""autonomy.shadow_gate.observe_discord_send — observe-only Discord capability shadow.
+
+Verifies: would_hold reflects cell state (missing/ask => hold, granted => allow); a row
+is recorded; it is READ-ONLY (never creates/mutates the capability cell); and it is
+best-effort (None db / broken db never raise, never write)."""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.autonomy import shadow_gate
+from genesis.db.crud import capability_grants as cg
+from genesis.db.crud import capability_shadow
+from genesis.db.schema._tables import INDEXES, TABLES
+
+
+@pytest.fixture(autouse=True)
+def _reset_table_cache():
+    capability_shadow._table_verified = False
+    yield
+    capability_shadow._table_verified = False
+
+
+async def _db(path, *, grant=None):
+    conn = await aiosqlite.connect(path)
+    conn.row_factory = aiosqlite.Row
+    for table in ("capability_shadow_events", "capability_grants"):
+        await conn.execute(TABLES[table])
+    for idx in INDEXES:
+        if "capability_shadow_events" in idx:
+            await conn.execute(idx)
+    if grant is not None:  # (domain, verb, risk_class, state)
+        d, v, r, s = grant
+        await conn.execute(
+            "INSERT INTO capability_grants (id, domain, verb, risk_class, state) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (f"{d}:{v}:{r}", d, v, r, s),
+        )
+    await conn.commit()
+    return conn
+
+
+@pytest.mark.asyncio
+async def test_missing_cell_would_hold(tmp_path):
+    db = await _db(tmp_path / "g.db")  # no discord cell exists
+    ok = await shadow_gate.observe_discord_send(
+        db, path="deliver", verb="send", risk_class="bulk",
+        target="announcements", content="hi community",
+    )
+    assert ok is True
+    rows = await capability_shadow.list_recent(db)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["would_hold"] == 1 and r["cell_state"] is None
+    assert r["cell_domain"] == "discord" and r["cell_verb"] == "send"
+    assert r["cell_risk_class"] == "bulk" and r["path"] == "deliver"
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_ask_cell_would_hold(tmp_path):
+    db = await _db(tmp_path / "g.db", grant=("discord", "send", "bulk", "ask"))
+    await shadow_gate.observe_discord_send(
+        db, path="deliver", verb="send", risk_class="bulk", target="x", content="y",
+    )
+    r = (await capability_shadow.list_recent(db))[0]
+    assert r["would_hold"] == 1 and r["cell_state"] == "ask"
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_granted_cell_would_allow(tmp_path):
+    db = await _db(tmp_path / "g.db", grant=("discord", "reply", "standard", "granted"))
+    await shadow_gate.observe_discord_send(
+        db, path="reply", verb="reply", risk_class="standard",
+        target="123", content="thanks!",
+    )
+    r = (await capability_shadow.list_recent(db))[0]
+    assert r["would_hold"] == 0 and r["cell_state"] == "granted"
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_readonly_never_creates_or_mutates_cell(tmp_path):
+    db = await _db(tmp_path / "g.db")  # no discord cell
+    await shadow_gate.observe_discord_send(
+        db, path="poll", verb="poll", risk_class="bulk", target="a", content="b",
+    )
+    # The observation must NOT have created the capability cell (read-only shadow).
+    assert await cg.get_cell(db, "discord", "poll", "bulk") is None
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_content_preview_truncated_hash_over_full(tmp_path):
+    from genesis.outreach.governance import content_hash
+
+    db = await _db(tmp_path / "g.db")
+    long = "z" * 500
+    await shadow_gate.observe_discord_send(
+        db, path="deliver", verb="send", risk_class="bulk", target="t", content=long,
+    )
+    r = (await capability_shadow.list_recent(db))[0]
+    assert len(r["content_preview"]) == 200          # excerpt bounded
+    assert r["content_hash"] == content_hash(long)   # hash over FULL content, not the excerpt
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_none_db_is_noop(tmp_path):
+    # Never raises, never writes when the process has no DB connection.
+    assert await shadow_gate.observe_discord_send(
+        None, path="reply", verb="reply", risk_class="standard", target="t", content="c",
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_best_effort_swallows_db_error(tmp_path):
+    # A db with NO tables at all: get_cell raises OperationalError -> swallowed, no raise.
+    conn = await aiosqlite.connect(tmp_path / "empty.db")
+    conn.row_factory = aiosqlite.Row
+    assert await shadow_gate.observe_discord_send(
+        conn, path="deliver", verb="send", risk_class="bulk", target="t", content="c",
+    ) is False
+    await conn.close()

--- a/tests/test_autonomy/test_shadow_gate.py
+++ b/tests/test_autonomy/test_shadow_gate.py
@@ -93,17 +93,19 @@ async def test_readonly_never_creates_or_mutates_cell(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_content_preview_truncated_hash_over_full(tmp_path):
-    from genesis.outreach.governance import content_hash
+async def test_content_preview_bounded_hash_over_full_content(tmp_path):
+    import hashlib
 
     db = await _db(tmp_path / "g.db")
-    long = "z" * 500
+    long = "z" * 300 + "TAIL"  # content that differs BEYOND the 200-char preview span
     await shadow_gate.observe_discord_send(
         db, path="deliver", verb="send", risk_class="bulk", target="t", content=long,
     )
     r = (await capability_shadow.list_recent(db))[0]
-    assert len(r["content_preview"]) == 200          # excerpt bounded
-    assert r["content_hash"] == content_hash(long)   # hash over FULL content, not the excerpt
+    assert len(r["content_preview"]) == 200                                  # excerpt bounded
+    assert r["content_hash"] == hashlib.sha256(long.encode()).hexdigest()    # FULL content
+    # Genuinely full — NOT the first-200-chars span (which would collide with the preview).
+    assert r["content_hash"] != hashlib.sha256(long[:200].encode()).hexdigest()
     await db.close()
 
 

--- a/tests/test_db/test_crud_capability_shadow.py
+++ b/tests/test_db/test_crud_capability_shadow.py
@@ -1,0 +1,113 @@
+"""crud.capability_shadow: best-effort record with a table-existence guard + read helpers."""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import capability_shadow as crud
+from genesis.db.schema._tables import INDEXES, TABLES
+
+
+@pytest.fixture(autouse=True)
+def _reset_table_cache():
+    # The per-process existence cache would otherwise leak across tests (a test that
+    # creates the table would mark it verified for a later "no table" test).
+    crud._table_verified = False
+    yield
+    crud._table_verified = False
+
+
+async def _db(path, *, with_table=True):
+    conn = await aiosqlite.connect(path)
+    conn.row_factory = aiosqlite.Row
+    if with_table:
+        await conn.execute(TABLES["capability_shadow_events"])
+        for idx in INDEXES:
+            if "capability_shadow_events" in idx:
+                await conn.execute(idx)
+        await conn.commit()
+    return conn
+
+
+def _kw(n, *, path="deliver", verb="send", risk="bulk", state=None, would_hold=True):
+    return {
+        "id": f"sh-{n}",
+        "observed_at": f"2026-07-01T00:00:0{n}+00:00",
+        "path": path,
+        "channel": "discord",
+        "cell_domain": "discord",
+        "cell_verb": verb,
+        "cell_risk_class": risk,
+        "cell_state": state,
+        "would_hold": would_hold,
+        "target": "announcements",
+        "content_preview": "hello world",
+        "content_hash": f"h{n}",
+    }
+
+
+@pytest.mark.asyncio
+async def test_record_inserts_and_count(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    assert await crud.record(db, **_kw(1)) is True
+    assert await crud.count(db) == 1
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_record_noops_when_table_absent(tmp_path):
+    db = await _db(tmp_path / "g.db", with_table=False)
+    # Best-effort: the subprocess pre-migration window — skip, do NOT raise, do NOT create.
+    assert await crud.record(db, **_kw(1)) is False
+    # Table was NOT created as a side effect.
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='capability_shadow_events'"
+    )
+    assert await cur.fetchone() is None
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_record_self_heals_after_table_created(tmp_path):
+    db = await _db(tmp_path / "g.db", with_table=False)
+    assert await crud.record(db, **_kw(1)) is False  # missing -> skip (cache stays False)
+    # Server migration lands mid-life:
+    await db.execute(TABLES["capability_shadow_events"])
+    await db.commit()
+    assert await crud.record(db, **_kw(2)) is True  # now writes without a restart
+    assert await crud.count(db) == 1
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_would_hold_stored_as_int(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.record(db, **_kw(1, would_hold=True))
+    await crud.record(db, **_kw(2, would_hold=False))
+    rows = {r["id"]: r["would_hold"] for r in await crud.list_recent(db)}
+    assert rows == {"sh-1": 1, "sh-2": 0}
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_list_recent_newest_first(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.record(db, **_kw(1))
+    await crud.record(db, **_kw(3))
+    await crud.record(db, **_kw(2))
+    assert [r["id"] for r in await crud.list_recent(db)] == ["sh-3", "sh-2", "sh-1"]
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_summary_groups_by_door_and_verdict(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.record(db, **_kw(1, path="deliver", verb="send", risk="bulk", would_hold=True))
+    await crud.record(db, **_kw(2, path="deliver", verb="send", risk="bulk", would_hold=True))
+    await crud.record(db, **_kw(3, path="reply", verb="reply", risk="standard", would_hold=False))
+    rows = await crud.summary(db)
+    top = rows[0]
+    assert top["path"] == "deliver" and top["would_hold"] == 1 and top["n"] == 2
+    assert any(r["path"] == "reply" and r["would_hold"] == 0 and r["n"] == 1 for r in rows)
+    await db.close()

--- a/tests/test_db/test_migration_0044_capability_shadow_events.py
+++ b/tests/test_db/test_migration_0044_capability_shadow_events.py
@@ -1,0 +1,74 @@
+"""Migration 0044 — create capability_shadow_events (WS5 Discord gate SHADOW store).
+
+Verifies the table/columns/indexes, idempotency, and down().
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M44 = importlib.import_module("genesis.db.migrations.0044_capability_shadow_events")
+
+
+async def _columns(db: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await db.execute(f"PRAGMA table_info({table})")
+    return {row[1] for row in await cur.fetchall()}
+
+
+async def _indexes(db: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=?", (table,)
+    )
+    return {row[0] for row in await cur.fetchall()}
+
+
+async def _table_exists(db: aiosqlite.Connection, table: str) -> bool:
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    )
+    return await cur.fetchone() is not None
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        conn.row_factory = aiosqlite.Row
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_creates_table_with_expected_columns(db):
+    await M44.up(db)
+    cols = await _columns(db, "capability_shadow_events")
+    assert {
+        "id", "observed_at", "path", "channel", "cell_domain", "cell_verb",
+        "cell_risk_class", "cell_state", "would_hold", "target",
+        "content_preview", "content_hash",
+    } == cols  # exact column set — no full-content column leaks in
+
+
+@pytest.mark.asyncio
+async def test_creates_indexes(db):
+    await M44.up(db)
+    idx = await _indexes(db, "capability_shadow_events")
+    assert {
+        "idx_capability_shadow_events_observed_at",
+        "idx_capability_shadow_events_cell",
+    } <= idx
+
+
+@pytest.mark.asyncio
+async def test_idempotent_on_rerun(db):
+    await M44.up(db)
+    await M44.up(db)  # CREATE IF NOT EXISTS -> must not raise
+    assert await _table_exists(db, "capability_shadow_events")
+
+
+@pytest.mark.asyncio
+async def test_down_drops_table(db):
+    await M44.up(db)
+    await M44.down(db)
+    assert not await _table_exists(db, "capability_shadow_events")

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -59,6 +59,7 @@ EXPECTED_TABLES = [
     "capability_grants",  # WS-8 PR-B: per-(domain,verb,risk_class) cells
     "pending_email_sends",  # WS-8 PR-C: email autonomy gate hold store
     "autonomous_email_sends",  # WS-8 PR-D: autonomous-send ledger (visibility + flag + rate-limit)
+    "capability_shadow_events",  # WS5 Stage 2: Discord capability shadow-gate observations
 ]
 
 

--- a/tests/test_mcp/test_capability_shadow_wiring.py
+++ b/tests/test_mcp/test_capability_shadow_wiring.py
@@ -96,6 +96,20 @@ async def test_send_reply_records_shadow_and_still_sends(db):
         bot_mod._bot_token, bot_mod._db = old_token, old_db
 
 
+def test_init_discord_bot_wires_shadow_db():
+    # The bootstrap injects the shadow DB via init_discord_bot(db=...); confirm it lands.
+    from genesis.mcp.discord_bot_mcp import init_discord_bot
+
+    old_token, old_db = bot_mod._bot_token, bot_mod._db
+    sentinel = object()
+    try:
+        init_discord_bot(bot_token="tok", db=sentinel)
+        assert bot_mod._bot_token == "tok"
+        assert bot_mod._db is sentinel
+    finally:
+        bot_mod._bot_token, bot_mod._db = old_token, old_db
+
+
 @pytest.mark.asyncio
 async def test_send_reply_without_shadow_db_still_sends():
     # _db=None (shadow DB unavailable) => shadow is a no-op; the reply MUST still work.

--- a/tests/test_mcp/test_capability_shadow_wiring.py
+++ b/tests/test_mcp/test_capability_shadow_wiring.py
@@ -1,0 +1,112 @@
+"""PATH B/C wiring: outreach_poll and send_reply observe Discord sends (shadow) yet still post."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiosqlite
+import pytest
+
+import genesis.mcp.discord_bot_mcp as bot_mod
+import genesis.mcp.outreach_mcp as outreach_mod
+from genesis.db.crud import capability_shadow
+from genesis.db.schema import create_all_tables
+from genesis.mcp.discord_bot_mcp import mcp as bot_mcp
+from genesis.mcp.outreach_mcp import mcp as outreach_mcp
+
+
+@pytest.fixture(autouse=True)
+def _reset_table_cache():
+    capability_shadow._table_verified = False
+    yield
+    capability_shadow._table_verified = False
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+def _mock_httpx(msg_id):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"id": msg_id}
+    resp.raise_for_status = MagicMock()
+    client = AsyncMock()
+    client.post.return_value = resp
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+# ── PATH B: outreach_poll (webhook) ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_outreach_poll_records_shadow_and_still_posts(db):
+    old_db = outreach_mod._db
+    outreach_mod._db = db
+    try:
+        client = _mock_httpx("poll-1")
+        env = {"DISCORD_WEBHOOK_ANNOUNCEMENTS": "https://discord.com/api/webhooks/1/tok"}
+        with patch.dict("os.environ", env, clear=False), \
+             patch("genesis.mcp.outreach_mcp.httpx.AsyncClient", return_value=client):
+            tools = await outreach_mcp.get_tools()
+            result = await tools["outreach_poll"].fn(
+                channel="announcements", question="What next?", answers=["A", "B"],
+            )
+        assert json.loads(result)["status"] == "created"
+        client.post.assert_called_once()  # the poll still posted
+        rows = await capability_shadow.list_recent(db)
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["path"] == "poll" and r["cell_verb"] == "poll"
+        assert r["cell_risk_class"] == "bulk" and r["target"] == "announcements"
+        assert r["would_hold"] == 1
+    finally:
+        outreach_mod._db = old_db
+
+
+# ── PATH C: send_reply (Discord API) ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_reply_records_shadow_and_still_sends(db):
+    old_token, old_db = bot_mod._bot_token, bot_mod._db
+    bot_mod._bot_token, bot_mod._db = "test-token", db
+    try:
+        client = _mock_httpx("reply-1")
+        with patch("genesis.mcp.discord_bot_mcp.httpx.AsyncClient", return_value=client):
+            tools = await bot_mcp.get_tools()
+            result = await tools["send_reply"].fn(channel_id="789", content="thanks!")
+        assert json.loads(result)["status"] == "sent"
+        client.post.assert_called_once()  # the reply still sent
+        rows = await capability_shadow.list_recent(db)
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["path"] == "reply" and r["cell_verb"] == "reply"
+        assert r["cell_risk_class"] == "standard" and r["target"] == "789"
+        assert r["would_hold"] == 1
+    finally:
+        bot_mod._bot_token, bot_mod._db = old_token, old_db
+
+
+@pytest.mark.asyncio
+async def test_send_reply_without_shadow_db_still_sends():
+    # _db=None (shadow DB unavailable) => shadow is a no-op; the reply MUST still work.
+    old_token, old_db = bot_mod._bot_token, bot_mod._db
+    bot_mod._bot_token, bot_mod._db = "test-token", None
+    try:
+        client = _mock_httpx("reply-2")
+        with patch("genesis.mcp.discord_bot_mcp.httpx.AsyncClient", return_value=client):
+            tools = await bot_mcp.get_tools()
+            result = await tools["send_reply"].fn(channel_id="789", content="hi")
+        assert json.loads(result)["status"] == "sent"
+        client.post.assert_called_once()
+    finally:
+        bot_mod._bot_token, bot_mod._db = old_token, old_db

--- a/tests/test_outreach/test_pipeline_discord_shadow.py
+++ b/tests/test_outreach/test_pipeline_discord_shadow.py
@@ -1,0 +1,92 @@
+"""PATH A wiring: outreach pipeline._deliver observes Discord sends (shadow) yet still sends."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from genesis.content.types import FormatTarget, FormattedContent
+from genesis.db.crud import capability_shadow
+from genesis.db.schema import create_all_tables
+from genesis.outreach.config import OutreachConfig, QuietHours
+from genesis.outreach.governance import GovernanceGate
+from genesis.outreach.pipeline import OutreachPipeline
+from genesis.outreach.types import OutreachCategory, OutreachRequest, OutreachStatus
+
+
+@pytest.fixture(autouse=True)
+def _reset_table_cache():
+    capability_shadow._table_verified = False
+    yield
+    capability_shadow._table_verified = False
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+def _config():
+    return OutreachConfig(
+        quiet_hours=QuietHours(start="22:00", end="07:00"),
+        channel_preferences={"default": "discord"},
+        thresholds={"blocker": 0.0, "alert": 0.3, "surplus": 0.7, "digest": 0.0},
+        max_daily=5, surplus_daily=1, content_daily=3, notification_daily=10,
+        morning_report_time="07:00", engagement_timeout_hours=24, engagement_poll_minutes=60,
+    )
+
+
+def _pipeline(cfg, db, channel):
+    return OutreachPipeline(
+        governance=GovernanceGate(cfg, db), drafter=AsyncMock(), formatter=MagicMock(),
+        channels={"discord": channel}, db=db, config=cfg,
+        recipients={"discord": "announcements"},
+    )
+
+
+def _req(recipient="announcements"):
+    return OutreachRequest(
+        category=OutreachCategory.SURPLUS, topic="hi", context="ctx",
+        salience_score=0.9, signal_type="surplus_insight", channel="discord",
+        validated_recipient=recipient,
+    )
+
+
+@pytest.mark.asyncio
+async def test_deliver_discord_records_shadow_and_still_sends(db):
+    channel = AsyncMock()
+    channel.send_message.return_value = "disc-1"
+    pipeline = _pipeline(_config(), db, channel)
+    formatted = FormattedContent(text="hello discord community", target=FormatTarget.TELEGRAM)
+
+    result = await pipeline._deliver("oid-1", "discord", formatted, _req(), None)
+
+    assert result.status == OutreachStatus.DELIVERED
+    channel.send_message.assert_called_once()  # the real send still happened
+    rows = await capability_shadow.list_recent(db)
+    assert len(rows) == 1
+    r = rows[0]
+    assert r["path"] == "deliver" and r["cell_domain"] == "discord"
+    assert r["cell_verb"] == "send" and r["cell_risk_class"] == "bulk"
+    assert r["would_hold"] == 1  # no discord cell => not_determined => would hold
+    assert r["target"] == "announcements"
+
+
+@pytest.mark.asyncio
+async def test_deliver_gate_cleared_skips_shadow(db):
+    # The below-the-gate resume path (gate_cleared=True) must NOT be observed.
+    channel = AsyncMock()
+    channel.send_message.return_value = "disc-2"
+    pipeline = _pipeline(_config(), db, channel)
+    formatted = FormattedContent(text="resend", target=FormatTarget.TELEGRAM)
+
+    await pipeline._deliver("oid-2", "discord", formatted, _req("general"), None, gate_cleared=True)
+
+    channel.send_message.assert_called_once()
+    assert await capability_shadow.count(db) == 0

--- a/tests/test_scripts/test_check_external_io.py
+++ b/tests/test_scripts/test_check_external_io.py
@@ -1,0 +1,47 @@
+"""WS5 external-I/O regression guard (scripts/check_external_io.py)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "check_external_io", _REPO_ROOT / "scripts" / "check_external_io.py",
+)
+check = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check)
+
+
+def test_flags_planted_discord_egress(tmp_path):
+    f = tmp_path / "sneaky.py"
+    f.write_text('URL = "https://discord.com/api/v10/channels/1/messages"\n')
+    violations = check.scan(tmp_path)
+    assert [v[0] for v in violations] == [f.as_posix()]
+
+
+def test_flags_planted_webhook_env(tmp_path):
+    f = tmp_path / "hook.py"
+    f.write_text('key = os.environ["DISCORD_WEBHOOK_ANNOUNCEMENTS"]\n')
+    assert len(check.scan(tmp_path)) == 1
+
+
+def test_allowlisted_file_is_skipped(tmp_path):
+    f = tmp_path / "ok.py"
+    f.write_text('base = "https://discord.com/api/v10"\n')
+    assert check.scan(tmp_path, allowlist={f.as_posix()}) == []
+
+
+def test_no_false_positive_on_legit_compute_post(tmp_path):
+    # Legit compute/read egress (embeddings/search/etc.) must NOT trip the guard.
+    (tmp_path / "compute.py").write_text(
+        'r = await client.post("https://api.deepinfra.com/v1/embeddings", json=payload)\n'
+    )
+    assert check.scan(tmp_path) == []
+
+
+def test_real_tree_is_clean_under_allowlist(monkeypatch):
+    # The shipped ALLOWLIST must cover every current egress endpoint (fail-closed but
+    # currently-clean). This is the completeness invariant the CI step also enforces.
+    monkeypatch.chdir(_REPO_ROOT)
+    assert check.scan(check.SCAN_ROOT) == []


### PR DESCRIPTION
## WS5 Stage 2 — Discord capability SHADOW-gate (observe all 3 doors, hold nothing)

Autonomous Discord posting can currently reach the outside world through **three ungated
doors**. This PR installs an **observe-only** capability shadow-gate at every door: it
records what a capability gate *would* decide (hold vs allow) **without holding anything**
— gathering the volume/pattern data needed to choose the right enforcement posture, with
**zero behaviour change**.

> This **instruments** the doors; it does not **close** them. Enforcement (actual
> hold-for-approval) is a separate follow-on stage, informed by this shadow data.

### The three doors (exhaustively enumerated)
| Door | Path | Cell |
|---|---|---|
| A | `outreach/pipeline._deliver` → discord webhook (server process) | `discord:send:bulk` |
| B | `mcp/outreach_mcp.outreach_poll` → webhook (outreach subprocess) | `discord:poll:bulk` |
| C | `mcp/discord_bot_mcp.send_reply` → Discord API (discord-bot subprocess) | `discord:reply:standard` |

(`DiscordWebhookAdapter.send_poll` is dead — tests-only caller — so it is not instrumented; the CI guard backstops any revival.)

### Design
- **`autonomy/shadow_gate.observe_discord_send`** — **read-only** cell lookup (no
  `apply_event`/`ensure_cell`; a missing cell reads as `not_determined`), **best-effort**
  (swallows every failure at DEBUG), **never raises / never blocks / never mutates state**.
- Called **after the successful send** on all three doors, so the outbound post is never
  delayed — any DB contention only defers the internal record.
- **`db/crud/capability_shadow`** — best-effort `record()` with a cached table-existence
  guard. Migration `0044` is the *sole* DDL authority (no inline-DDL divergence); the
  subprocess writers (which don't run migrations) skip until the table exists, then
  self-heal.
- **discord-bot server** gains an *optional* best-effort `genesis.db` connection (opened
  once in its bootstrap lifespan, non-fatal) purely for shadow recording — it stays fully
  functional with no DB.
- **`content_preview`** is bounded (≤200 chars); **`content_hash`** is over the full
  content (a genuine fingerprint, distinct from the preview span). No full outbound
  content is stored.

### CI regression guard
`scripts/check_external_io.py` (new CI job) fails the build if any source file references
a Discord/webhook/public-social endpoint outside a reasoned allowlist — so a new ungated
door can't ship silently. Scoped precisely to external chat/webhook/social HTTP egress
(not a generic `.post(` scan); browser publish and owner-private channels are out of scope
by design.

### Verification
- **Architecture review** (pre-build): 2 blocker + 3 high findings, all resolved before coding.
- **Code review** (post-build): full-content hash fix, observe-moved-after-send, honest
  guard scope.
- **28 new + 52 regression tests green; lint clean; guard clean.**
- **End-to-end** against a copy of a migrated database (real migration runner + real code
  paths, incl. the discord-bot's own connection): all three doors record + still send;
  **0 capability cells created, 0 holds created, 0 approvals created**.

### Deploy notes
- Migration `0044` + door A go live on server restart; doors B/C (MCP subprocesses) apply
  on the next session — same pattern as the prior WS5 stage. No behaviour change
  (observe-only).
- Follow-on: the enforce stage (hold-for-approval + posture decision), informed by the
  `capability_shadow_events` volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
