### PR TITLE
docs(voice-master): add Bash-unavailable overlay-resolution fallback

### DIFF
--- a/src/genesis/skills/voice-master/SKILL.md
+++ b/src/genesis/skills/voice-master/SKILL.md
@@ -78,7 +78,7 @@ version control).
   (index.md, social.md, professional.md, longform.md, …).
 - **Resolution** (full procedure in `references/overlay-loading.md` — follow it
   exactly; resolve the path with Bash, never shell-expand inside the Read tool):
-  1. Resolve `<overlay_root>` via Bash: `echo "${GENESIS_VOICE_OVERLAY:-$HOME/.claude/skills/voice-master}"`.
+  1. Resolve `<overlay_root>` via Bash: `echo "${GENESIS_VOICE_OVERLAY:-$HOME/.claude/skills/voice-master}"`. If executing Bash is unavailable, restricted, or timed out, immediately assume the fallback directory `~/.claude/skills/voice-master` silently and proceed without hanging or throwing errors.
   2. Read `<overlay_root>/voice-dimensions.md`. If missing, fall back to
      `references/voice-dimensions-TEMPLATE.md` AND emit the MANDATORY
      no-overlay warning (see overlay-loading.md) — output won't match the user.

--- a/src/genesis/skills/voice-master/references/overlay-loading.md
+++ b/src/genesis/skills/voice-master/references/overlay-loading.md
@@ -37,6 +37,9 @@ echo "${GENESIS_VOICE_OVERLAY:-$HOME/.claude/skills/voice-master}"
 ```
 
 Capture the output as `<overlay_root>` for the session. Strip any trailing slash.
+If Bash is unavailable, restricted, or times out, assume the default
+`~/.claude/skills/voice-master` and proceed without hanging — Step 2's
+no-overlay warning still fires if the overlay is genuinely absent.
 
 **Step 2 — Load voice-dimensions.** Read `<overlay_root>/voice-dimensions.md`
 (absolute path, no shell syntax).


### PR DESCRIPTION
## What & why

During overlay-root resolution, the voice-master skill runs a Bash `echo` to expand `${GENESIS_VOICE_OVERLAY:-$HOME/.claude/skills/voice-master}`. If Bash is unavailable, restricted, or times out, that step could hang. This adds an explicit fallback: assume the default `~/.claude/skills/voice-master` and proceed. Step 2's mandatory no-overlay warning still fires if the overlay is genuinely absent, so behaviour degrades gracefully instead of hanging.

The fallback is added to **both** the `SKILL.md` quick-reference and the authoritative `references/overlay-loading.md` procedure, so SKILL.md's "follow it exactly" pointer stays coherent.

Docs-only — no code or behaviour change beyond the documented fallback.
