### PR TITLE
refactor(cc): generic community-responder profile + campaign-privacy contract

### DIFF
--- a/.claude/skills/content-publish/SKILL.md
+++ b/.claude/skills/content-publish/SKILL.md
@@ -184,9 +184,10 @@ Store the outcome in memory:
 - `memory_store` with tags: `["content", "published", "medium"]`
 - Content: topic, URL, date, any engagement data later
 
-Append to the Discord campaign showcase pool so the next campaign tick
-can reference this article:
-- File: `~/.genesis/campaigns/discord-engagement/showcase-pool.md`
+If running under a campaign, append to that campaign's showcase pool so the next
+campaign tick can reference this article (skip this step otherwise):
+- File: `~/.genesis/campaigns/<your-campaign-slug>/showcase-pool.md`
+  (substitute the running campaign's own slug)
 - Append under `## Published Medium Articles` with today's date, title,
   and a 2-3 line summary of the article's argument/angle
 - The campaign session uses this as safe public content to share

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -275,3 +275,10 @@ Standard open-source workflow: PRs go directly to the public repo.
 - **No sensitive data in commits** — voice data, research profiles, IPs,
   and secrets must never enter the repo. User data lives in overlays
   outside the repo (e.g., `~/.claude/skills/*/`, `~/.genesis/`).
+- **Individual campaigns are user data, not infrastructure** — a campaign's
+  name/prompt/targets/cadence live only in the `campaigns` DB table and the
+  private backups repo; never hardcode them into tracked source. Unlike modules
+  (which ship defaults under `config/modules/*.yaml`), campaigns ship ZERO
+  defaults (no `config/campaigns/`). Only campaign infrastructure ships. Express
+  reusable session types as generic roles (e.g. the `community-responder`
+  profile), not names coupled to a live campaign. See `src/genesis/campaigns/__init__.py`.

--- a/src/genesis/campaigns/__init__.py
+++ b/src/genesis/campaigns/__init__.py
@@ -1,1 +1,23 @@
-"""Campaign subsystem — persistent, scheduled, LLM-driven operations."""
+"""Campaign subsystem — persistent, scheduled, LLM-driven operations.
+
+Public/private contract (enshrined; do not violate):
+
+    Campaign INFRASTRUCTURE ships in the public repo — this package (runner,
+    control, models, prechecks), the ``campaigns`` table schema,
+    ``db/crud/campaigns.py``, and ``mcp/health/campaign_tools.py``.
+
+    Individual CAMPAIGNS are USER DATA, never infrastructure. A campaign's
+    name, strategy doc, cadence, session profile, and state live only in the
+    ``campaigns`` DB table (created by the user at runtime) and are backed up to
+    the user's PRIVATE backups repo. They MUST NEVER enter the public repo.
+
+    Unlike modules — which ship built-in defaults under ``config/modules/*.yaml``
+    — campaigns ship ZERO defaults. There is no ``config/campaigns/`` directory;
+    a fresh install starts with an empty campaigns table.
+
+    Therefore: never hardcode a specific campaign's name, prompt, target, or
+    schedule into tracked source (code, docstrings, examples, comments). If a
+    session type is genuinely reusable, express it as a GENERIC role (e.g. the
+    ``community-responder`` DirectSession profile), not one named after a live
+    campaign.
+"""

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -172,12 +172,12 @@ PROFILES: dict[str, list[str]] = {
         [t for t in _UNIVERSAL_DISALLOW if t != "Bash"]
         + _NO_BROWSER_INTERACTION + _NO_FILE_WRITE
     ),
-    # ── Discord monitor profile ─────────────────────────────────
-    # Reads Discord channels and responds via bot token API.
-    # MCP config loads discord-bot + health + outreach (no memory server).
-    # Belt-and-suspenders: block memory writes at tool level too, in case
-    # MCP config generation fails and falls back to full config.
-    "discord-monitor": (
+    # ── Community responder profile ─────────────────────────────
+    # Reactive community responder: reads a community's channels and replies
+    # via the discord-bot MCP server. MCP config loads discord-bot + health +
+    # outreach (no memory server). Belt-and-suspenders: block memory writes at
+    # tool level too, in case MCP config generation fails and falls back to full.
+    "community-responder": (
         _UNIVERSAL_DISALLOW + _NO_BROWSER_INTERACTION
         + _NO_MEMORY_WRITES + _NO_FOLLOW_UPS
     ),
@@ -261,17 +261,17 @@ action you take on an external PR.
 
 {_MISSION_INJECTION}
 """,
-    "discord-monitor": f"""
+    "community-responder": f"""
 
-## Session Profile: discord-monitor
+## Session Profile: community-responder
 
 You have: discord-bot MCP tools (fetch_messages, fetch_forum_threads, send_reply), outreach_send, web tools.
 You do NOT have: Edit, Bash, NotebookEdit, browser tools, memory tools.
 Your final message IS your deliverable.
 
-You are a reactive community responder. Read Discord channels and respond
-to unanswered messages using send_reply. Do NOT post proactive content —
-that is the discord-engagement campaign's job.
+You are a reactive community responder. Read the community's channels and respond
+to unanswered messages using send_reply. Do NOT post proactive content — proactive
+posting is a separate campaign's job, not this profile's.
 
 {_MISSION_INJECTION}
 """,
@@ -297,7 +297,7 @@ _PROFILE_SKILLS: dict[str, list[str]] = {
     "observe": [],
     "campaign": ["voice-master"],
     "steward": ["voice-master"],
-    "discord-monitor": ["genesis-voice"],
+    "community-responder": ["genesis-voice"],
     "mail": ["genesis-voice"],
 }
 
@@ -318,7 +318,7 @@ _PROFILE_TO_MCP: dict[str, str] = {
     "interact": "sentinel",
     "campaign": "campaign",
     "steward": "campaign",  # health + memory + outreach (for notify)
-    "discord-monitor": "discord-monitor",
+    "community-responder": "community-responder",
     "mail": "mail",
 }
 

--- a/src/genesis/cc/session_config.py
+++ b/src/genesis/cc/session_config.py
@@ -35,7 +35,7 @@ _MCP_PROFILES: dict[str, list[str]] = {
     "user_reflection": ["genesis-memory"],  # User ego: memory only, no health tools
     "sentinel": ["genesis-health", "genesis-memory", "genesis-outreach"],
     "campaign": ["genesis-health", "genesis-memory", "genesis-outreach"],
-    "discord-monitor": ["genesis-health", "genesis-outreach", "discord-bot"],
+    "community-responder": ["genesis-health", "genesis-outreach", "discord-bot"],
     "interop": ["genesis-health", "genesis-memory"],
     "mail": ["genesis-outreach"],  # Perimeter: outreach only, no memory/health
 }

--- a/src/genesis/mcp/discord_bot_mcp.py
+++ b/src/genesis/mcp/discord_bot_mcp.py
@@ -1,8 +1,8 @@
 """Standalone Discord bot MCP server — read-only message access + reply.
 
 Provides fetch_messages, fetch_forum_threads, and send_reply tools via
-the Discord bot token. Scoped to discord-monitor campaign sessions only
-(not loaded by foreground, ego, reflection, or other session types).
+the Discord bot token. Loaded only by sessions that use the discord-bot MCP
+server (not by foreground, ego, reflection, or other session types).
 
 Stateless — no DB connection needed. Token injected at bootstrap via
 init_discord_bot().

--- a/src/genesis/mcp/health/campaign_tools.py
+++ b/src/genesis/mcp/health/campaign_tools.py
@@ -76,6 +76,18 @@ async def _impl_campaign_create(
     initial_state: dict | None = None,
 ) -> dict:
     """Create and activate a new campaign."""
+    # Validate the session profile against the live registry BEFORE persisting.
+    # An unknown profile would pass here but raise ValueError at DirectSession
+    # init on every tick — a silent campaign outage. Mirrors user_job_tools.py /
+    # direct_session_tools.py.
+    from genesis.cc.direct_session import VALID_PROFILES
+
+    if profile not in VALID_PROFILES:
+        return {
+            "error": f"Invalid profile '{profile}'. "
+            f"Must be one of: {', '.join(sorted(VALID_PROFILES))}"
+        }
+
     db = _db
     own_db = False
     if db is None:
@@ -324,7 +336,7 @@ async def campaign_create(
     """Create and activate a new campaign.
 
     Args:
-        name: Unique slug (e.g., 'discord-engagement').
+        name: Unique slug (e.g., 'weekly-digest').
         strategy_doc_path: Path to the strategy markdown file.
         cron_cadence: Cron expression for tick schedule.
         model: LLM model for session ticks (sonnet/opus/haiku).

--- a/src/genesis/mcp/health/user_job_tools.py
+++ b/src/genesis/mcp/health/user_job_tools.py
@@ -51,10 +51,9 @@ async def user_job_create(
     if _scheduler is None:
         return {"error": "User job scheduler not initialized"}
 
-    # Validate inputs before persisting. Use the live profile registry (incl.
-    # campaign/steward/mail/discord-monitor + any install-local overlay
-    # profiles) rather than a stale hardcoded subset — matches
-    # direct_session_tools.py.
+    # Validate inputs before persisting. Use the live profile registry
+    # (VALID_PROFILES, incl. any install-local overlay profiles) rather than a
+    # stale hardcoded subset — matches direct_session_tools.py.
     from genesis.cc.direct_session import VALID_PROFILES
 
     _VALID_MODELS = {"sonnet", "opus", "haiku"}

--- a/tests/test_campaigns/test_crud.py
+++ b/tests/test_campaigns/test_crud.py
@@ -25,12 +25,12 @@ async def test_get_campaign_by_name(db):
     await crud.create_campaign(
         db,
         id="c2",
-        name="discord-engagement",
+        name="weekly-digest",
         strategy_doc_path="/tmp/strat.md",
         cron_cadence="0 */8 * * *",
         created_at="2026-06-07T00:00:00Z",
     )
-    row = await crud.get_campaign_by_name(db, "discord-engagement")
+    row = await crud.get_campaign_by_name(db, "weekly-digest")
     assert row is not None
     assert row["id"] == "c2"
     assert row["status"] == "active"

--- a/tests/test_mcp/test_campaign_tools.py
+++ b/tests/test_mcp/test_campaign_tools.py
@@ -205,6 +205,65 @@ class TestRunnerAbsent:
             ct_mod._runner = old_runner
 
 
+class TestCampaignCreateValidation:
+    """campaign_create must validate `profile` against VALID_PROFILES before persisting
+    (mirrors user_job_tools / direct_session_tools). Guards against a bogus profile that
+    would silently fail every tick at DirectSession init."""
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_invalid_profile(self, _test_db):
+        """An unknown profile is rejected and NOTHING is persisted."""
+        old_db, old_runner = ct_mod._db, ct_mod._runner
+        try:
+            ct_mod._db = _test_db
+            ct_mod._runner = None
+            result = await ct_mod._impl_campaign_create(
+                name="bogus-profile-campaign",
+                strategy_doc_path="/tmp/s.md",
+                cron_cadence="0 */8 * * *",
+                profile="not-a-real-profile",
+            )
+            assert "error" in result
+            assert "Invalid profile" in result["error"]
+            cursor = await _test_db.execute(
+                "SELECT COUNT(*) AS n FROM campaigns WHERE name = ?",
+                ("bogus-profile-campaign",),
+            )
+            row = await cursor.fetchone()
+            assert row["n"] == 0
+        finally:
+            ct_mod._db = old_db
+            ct_mod._runner = old_runner
+
+    @pytest.mark.asyncio
+    async def test_create_accepts_valid_profile(self, _test_db):
+        """A valid profile passes validation and flows through to creation."""
+        from unittest.mock import AsyncMock
+
+        old_db, old_runner = ct_mod._db, ct_mod._runner
+        try:
+            ct_mod._db = _test_db
+            ct_mod._runner = None
+            with patch(
+                "genesis.db.crud.campaigns.get_campaign_by_name",
+                new=AsyncMock(return_value=None),
+            ), patch(
+                "genesis.db.crud.campaigns.create_campaign", new=AsyncMock(),
+            ) as mock_create:
+                result = await ct_mod._impl_campaign_create(
+                    name="valid-profile-campaign",
+                    strategy_doc_path="/tmp/s.md",
+                    cron_cadence="0 */8 * * *",
+                    profile="community-responder",
+                )
+            assert "error" not in result
+            mock_create.assert_awaited_once()
+            assert mock_create.call_args.kwargs["session_profile"] == "community-responder"
+        finally:
+            ct_mod._db = old_db
+            ct_mod._runner = old_runner
+
+
 class TestWiredDbPath:
     """When _db is wired (e.g., via init_campaign_tools), _get_db is not called."""
 

--- a/tests/test_mcp/test_discord_bot_mcp.py
+++ b/tests/test_mcp/test_discord_bot_mcp.py
@@ -241,19 +241,22 @@ async def test_send_reply_auto_chunks():
 # ── Profile tests ───────────────────────────────────────────────────────
 
 
-def test_discord_monitor_profile_exists():
-    """discord-monitor should be a valid session profile."""
+def test_community_responder_profile_exists():
+    """community-responder should be a valid session profile (renamed from discord-monitor)."""
     from genesis.cc.direct_session import VALID_PROFILES
 
-    assert "discord-monitor" in VALID_PROFILES
+    assert "community-responder" in VALID_PROFILES
+    # The old campaign-coupled name must be fully gone from tracked source.
+    assert "discord-monitor" not in VALID_PROFILES
 
 
-def test_discord_monitor_mcp_profile_exists():
-    """discord-monitor should have an MCP profile with discord-bot server."""
+def test_community_responder_mcp_profile_exists():
+    """community-responder should have an MCP profile with the discord-bot server."""
     from genesis.cc.session_config import _MCP_PROFILES
 
-    assert "discord-monitor" in _MCP_PROFILES
-    servers = _MCP_PROFILES["discord-monitor"]
+    assert "community-responder" in _MCP_PROFILES
+    assert "discord-monitor" not in _MCP_PROFILES
+    servers = _MCP_PROFILES["community-responder"]
     assert "discord-bot" in servers
     assert "genesis-health" in servers
     assert "genesis-outreach" in servers


### PR DESCRIPTION
## What & why

Renames the `discord-monitor` DirectSession profile to the generic role name
`community-responder` and keeps its tool scope + MCP server set identical. The
profile is a generic *reactive community-responder* role, so it belongs in
tracked infrastructure under a generic name rather than one coupled to a
specific deployment's campaign.

Alongside the rename, this enshrines the campaign public/private contract and
removes tracked-source references to specific campaigns.

## Changes

- **Rename** `discord-monitor` → `community-responder` across the profile
  registries (`PROFILES`, `_PROFILE_ADDENDA`, `_PROFILE_SKILLS`,
  `_PROFILE_TO_MCP`, `_MCP_PROFILES`). The tool disallow set and MCP server list
  are byte-identical to the prior definition — **no change in access scope**.
- **Enshrine the contract** (`campaigns/__init__.py` + the genesis-development
  skill): individual campaigns are DB-only user data with **zero shipped
  defaults** (unlike modules, which ship defaults under `config/modules/*.yaml`);
  only campaign *infrastructure* ships. Never hardcode a campaign's
  name/prompt/target/schedule into tracked source.
- **Validate `campaign_create`** against the live profile registry (mirrors the
  existing checks in `user_job_tools` / `direct_session_tools`), so an unknown
  profile is rejected at creation instead of failing silently at session init.
- **Genericize** the profile prompt, docstrings, comments, and examples that
  referenced specific campaigns.

## Tests / verification

- Renamed profile tests + a new `campaign_create` validation test.
- 147 targeted tests green; ruff clean.
- E2E: profile fully rewired, `build_mcp_config` yields the intended scoped
  server set, and the tool disallow set is unchanged.

## Deploy note

An install with an existing campaign whose `session_profile` still references the
old profile name should repoint it with a one-row `UPDATE` (not a schema
migration); that data update is not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
