### PR TITLE
feat(attention): PR3b — L1.5 attention_salience sampler seam (gated, non-Groq)

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -684,6 +684,21 @@ call_sites:
     description: "Voice channel conversation \u2014 low-latency free-tier chain\
       \ for HA voice assistant. Groq first for speed (~1s), Gemini/Mistral\
       \ as fallbacks."
+  attention_salience:
+    chain:
+    - mistral-small-free
+    - nvidia-nim-deepseek
+    never_pays: true
+    retry_profile: user_facing
+    description: >-
+      Attention engine L1.5 salience gate (offline shadow tool, opt-in via the runner's
+      --l15 flag): scores a graduated ~8s ambient window into {real, perk} floats. PRIVACY
+      \u2014 this sends the window's household transcript text to an external free LLM; only the
+      float verdict is persisted (never the text). Provider bake-off 2026-07-01 over real
+      garbled windows: mistral-small-latest (100% clean JSON, ~0.8s) primary + nvidia-nim
+      deepseek-v4-pro (100% clean, different vendor) fallback; both free, so never_pays
+      keeps a valid chain. NON-Groq deliberately \u2014 Groq's 8B is EOL 2026-08-16 and its
+      gpt-oss-20b replacement breaks strict JSON.
 retry:
   # max_total_s: aggregate wall-clock ceiling (seconds) across a single
   # route_call's retries x chain length. A safety net against pathological

--- a/src/genesis/attention/runner.py
+++ b/src/genesis/attention/runner.py
@@ -16,13 +16,15 @@ import argparse
 import asyncio
 import logging
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from genesis.attention.clarity import is_blip
 from genesis.attention.config import (
     DEFAULT_CONFIG_PATH,
     AttentionConfig,
+    Thresholds,
     default_config_dict,
     load_config,
 )
@@ -30,7 +32,10 @@ from genesis.attention.consumers import ShadowStoreConsumer
 from genesis.attention.engine import evaluate
 from genesis.attention.snapshot import pull_snapshot
 from genesis.attention.sources import SnapshotSource
-from genesis.attention.types import AttentionEvent, EngineState
+from genesis.attention.types import Activation, AttentionEvent, EngineState
+
+if TYPE_CHECKING:
+    from genesis.attention.sampler import AttentionSampler
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +67,18 @@ def load_runner_config(path: str | None) -> AttentionConfig:
     return AttentionConfig.from_dict(default_config_dict())
 
 
+def _graduates_to_l15(ev: AttentionEvent, thresholds: Thresholds) -> bool:
+    """Whether an event should be scored by L1.5. Gate on ACTIVATION, not raw ``ev.score``:
+    a bare-HARD fire has ``score == 0.0`` (no soft co-trigger) yet is the MOST certain
+    perk-up, and SUPPRESSED events are vetoes not worth an LLM call. So HARD always
+    graduates; SOFT graduates above the ``l15_graduation`` cost-floor; SUPPRESSED never."""
+    if ev.activation == Activation.HARD:
+        return True
+    if ev.activation == Activation.SOFT:
+        return ev.score >= thresholds.l15_graduation
+    return False
+
+
 async def run_shadow(
     snapshot_path: str | Path,
     config: AttentionConfig,
@@ -69,6 +86,7 @@ async def run_shadow(
     snapshot_id: str = "adhoc",
     sample_n: int = 25,
     consumer: ShadowStoreConsumer | None = None,
+    sampler: AttentionSampler | None = None,
 ) -> ShadowReport:
     src = SnapshotSource(snapshot_path)
     state = EngineState()
@@ -86,6 +104,13 @@ async def run_shadow(
         state, ev = evaluate(utt, state, config)
         if ev is None:
             continue
+        # L1.5 (opt-in): score the fire's window via a cheap LLM and attach the
+        # {real, perk} verdict BEFORE the event is buffered/persisted. state.window is a
+        # fire-time snapshot (immutable utterances; last element is this trigger utt);
+        # its text goes to the LLM in memory only — never to genesis.db (firewall).
+        if sampler is not None and _graduates_to_l15(ev, config.thresholds):
+            verdict = await sampler.sample(list(state.window), config)
+            ev = replace(ev, l15_verdict=verdict)
         events.append(ev)
         if consumer is not None:
             consumer.add(ev)
@@ -108,6 +133,7 @@ async def run_shadow(
             "triggers": [h.name for h in ev.triggers_fired],
             "suppressors": list(ev.suppressors),
             "is_user": getattr(trg, "is_user", None),
+            "l15": ev.l15_verdict,   # {real, perk} when --l15 ran, else None
             "text": getattr(trg, "text", ""),
         })
     return ShadowReport(
@@ -126,8 +152,9 @@ def print_report(r: ShadowReport) -> None:
     print(f"by_suppressor: {r.by_suppressor}")
     print(f"\n--- {len(r.samples)} sample events (text shown for OFFLINE eyeballing only) ---")
     for s in r.samples:
+        l15 = f" l15={s['l15']}" if s.get("l15") is not None else ""
         print(f"[{s['activation']:>10}] score={s['score']:.3f} clarity={s['clarity']:.2f} "
-              f"u={s['is_user']} trig={s['triggers']} sup={s['suppressors']}")
+              f"u={s['is_user']} trig={s['triggers']} sup={s['suppressors']}{l15}")
         print(f"             text: {s['text'][:150]!r}")
 
 
@@ -148,6 +175,12 @@ def main() -> None:
     ap.add_argument("--config", help="attention_config.json (default: ~/.genesis overlay or built-in)")
     ap.add_argument("--samples", type=int, default=25)
     ap.add_argument("--persist", action="store_true", help="write events to attention_events")
+    ap.add_argument(
+        "--l15", action="store_true",
+        help="score graduated (HARD + above-floor SOFT) windows via the L1.5 "
+             "'attention_salience' LLM call-site. PRIVACY: this SENDS the window's ambient "
+             "transcript text to an external free LLM provider. Off by default.",
+    )
     ap.add_argument("--db", help="genesis.db path for --persist (default: genesis_db_path())")
     args = ap.parse_args()
 
@@ -169,7 +202,22 @@ async def _run_cli(args) -> None:
         db_path = args.db or str(genesis_db_path())
         consumer = ShadowStoreConsumer(db_path, snapshot_id=sid, config_version=cfg.version)
         logger.info("persisting to %s", db_path)
-    report = await run_shadow(path, cfg, snapshot_id=sid, sample_n=args.samples, consumer=consumer)
+
+    sampler = None
+    if args.l15:
+        from genesis.attention.sampler import CALL_SITE, AttentionSampler
+        from genesis.routing.standalone import _build_standalone_router
+        router = _build_standalone_router()
+        if router is None:
+            logger.error("--l15: could not build a router (missing config/secrets); running WITHOUT L1.5")
+        else:
+            sampler = AttentionSampler(router)
+            logger.info("L1.5 ENABLED: scoring graduated windows via '%s' — sends window "
+                        "transcript text to an external LLM (egress).", CALL_SITE)
+
+    report = await run_shadow(
+        path, cfg, snapshot_id=sid, sample_n=args.samples, consumer=consumer, sampler=sampler,
+    )
     print_report(report)
 
 

--- a/src/genesis/attention/sampler.py
+++ b/src/genesis/attention/sampler.py
@@ -1,0 +1,134 @@
+"""L1.5 salience sampler — a Genesis-side adapter that asks a cheap FREE LLM to judge a
+graduated attention window: is it coherent real speech (``real``), and is it worth a
+proactive assistant's attention (``perk``)?
+
+This is the ONLY attention module that makes an LLM call, so it lives OUTSIDE the pure
+edge-portable core: it is NOT one of the 6 guarded modules (types/config/triggers/
+scorer/engine/clarity) and is NEVER imported from ``attention/__init__`` — importing the
+core must stay ``genesis.routing``-free (see ``tests/test_attention/test_edge_portability.py``).
+
+Two invariants:
+- **Fail-closed.** Every failure path (route failure, malformed/garbled JSON, missing
+  key, non-finite value, any exception) returns ``None``. The shadow run never crashes;
+  the verdict simply stays absent (``AttentionEvent.l15_verdict is None``).
+- **Firewall.** The window transcript TEXT is sent to the LLM in memory only. The stored
+  verdict is floats-only (``{real, perk}``); the consumer persists no text (``consumers``).
+
+Router is INJECTED (``_Router`` Protocol, mirroring ``ego/focus.py``) so the sampler is
+unit-testable with a fake and pulls no heavy router import into this module.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import math
+import re
+from typing import Any, Protocol
+
+from genesis.attention.config import AttentionConfig
+from genesis.attention.types import AmbientUtterance
+
+logger = logging.getLogger(__name__)
+
+# The router call-site (defined in config/model_routing.yaml). Free-only, cross-vendor
+# fallback, non-Groq — see the plan's PR3b bake-off.
+CALL_SITE = "attention_salience"
+
+# ```json ... ``` (or a bare ``` ... ```) fenced block — models love to wrap JSON in one.
+_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL)
+
+
+class _Router(Protocol):
+    """The slice of ``genesis.routing.Router`` the sampler needs (mirrors the injected
+    ``_Router`` in ``ego/focus.py:35``). Injecting a Protocol keeps this module free of a
+    hard ``Router`` import and makes ``sample`` testable with a fake."""
+
+    async def route_call(
+        self, call_site_id: str, messages: list[dict[str, Any]], **kwargs: Any
+    ) -> Any: ...
+
+
+class AttentionSampler:
+    """Scores a graduated attention window via the L1.5 ``attention_salience`` call-site."""
+
+    def __init__(self, router: _Router) -> None:
+        self._router = router
+
+    async def sample(
+        self, window: list[AmbientUtterance], config: AttentionConfig
+    ) -> dict | None:
+        """Return ``{"real": float, "perk": float}`` in ``[0, 1]``, or ``None`` on ANY failure.
+
+        ``window`` is a FIRE-TIME SNAPSHOT of the recent in-context utterances (frozen,
+        immutable ``AmbientUtterance``; the last element is the triggering utt). Its
+        ``.text`` is sent to the LLM in memory only — never persisted (the consumer stores
+        the returned floats, no text). ``config`` is accepted for parity/future prompt
+        shaping; the current prompt needs only the window.
+        """
+        if not window:
+            return None
+        messages = [{"role": "user", "content": _build_prompt(window)}]
+        try:
+            result = await self._router.route_call(CALL_SITE, messages)
+        except Exception:  # any router/transport fault -> no verdict, never crash the run
+            logger.warning("L1.5 sample: route_call raised", exc_info=True)
+            return None
+        if not getattr(result, "success", False):
+            return None
+        return _parse_verdict(getattr(result, "content", None))
+
+
+def _build_prompt(window: list[AmbientUtterance]) -> str:
+    """A strict-JSON scoring prompt over the ~8s context window (the last line is the
+    trigger). Speaker labels give the model turn-taking context; §11 of the design bible
+    found the CONTEXT WINDOW (not the bare utterance) is what makes the judgment tractable."""
+    lines = []
+    for u in window:
+        who = "user" if u.is_user == 1 else ("other" if u.is_user == 0 else "?")
+        lines.append(f"[{who}] {u.text}")
+    transcript = "\n".join(lines)
+    return (
+        "You judge a short snippet of ambient household speech, auto-transcribed and "
+        "possibly garbled. Score two things, each a float from 0.0 to 1.0:\n"
+        "- real: is this COHERENT real speech (not ASR noise or hallucination)? "
+        "1.0 = clearly real, 0.0 = garble.\n"
+        "- perk: is this worth a proactive assistant's attention — a question, task, "
+        "decision, or problem? 1.0 = clearly salient, 0.0 = idle chatter.\n\n"
+        f"Conversation window (the LAST line is the trigger):\n{transcript}\n\n"
+        'Reply with ONLY a JSON object, no prose: {"real": <float>, "perk": <float>}'
+    )
+
+
+def _parse_verdict(content: str | None) -> dict | None:
+    """Fail-closed parse of a ``{real, perk}`` object from model output.
+
+    Strip a code fence -> take the first ``{...}`` span -> ``json.loads`` -> require BOTH
+    keys, coerce to float, reject non-finite (NaN/inf), clamp to ``[0, 1]``. Any miss ->
+    ``None`` (never raises)."""
+    if not content:
+        return None
+    text = content.strip()
+    fenced = _FENCE_RE.search(text)
+    if fenced:
+        text = fenced.group(1).strip()
+    start, end = text.find("{"), text.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        return None
+    try:
+        obj = json.loads(text[start : end + 1])
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+    verdict: dict[str, float] = {}
+    for key in ("real", "perk"):
+        if key not in obj:
+            return None
+        try:
+            value = float(obj[key])
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(value):  # rejects NaN / inf that json.loads happily parses
+            return None
+        verdict[key] = min(1.0, max(0.0, value))
+    return verdict

--- a/src/genesis/attention/sampler.py
+++ b/src/genesis/attention/sampler.py
@@ -99,23 +99,43 @@ def _build_prompt(window: list[AmbientUtterance]) -> str:
     )
 
 
+def _first_json_object(text: str) -> str | None:
+    """The first brace-balanced ``{...}`` span. A bare ``find``/``rfind`` mis-slices two
+    plausible model outputs — an object followed by prose that contains a ``}``, and an
+    object with a nested value — so we scan brace depth instead. (Braces inside string
+    values aren't tracked; irrelevant for a numeric ``{real, perk}`` object, and a miscount
+    just fails to parse — fail-closed.)"""
+    start = text.find("{")
+    if start == -1:
+        return None
+    depth = 0
+    for i in range(start, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return None
+
+
 def _parse_verdict(content: str | None) -> dict | None:
     """Fail-closed parse of a ``{real, perk}`` object from model output.
 
-    Strip a code fence -> take the first ``{...}`` span -> ``json.loads`` -> require BOTH
-    keys, coerce to float, reject non-finite (NaN/inf), clamp to ``[0, 1]``. Any miss ->
-    ``None`` (never raises)."""
+    Strip a code fence -> take the first brace-balanced ``{...}`` -> ``json.loads`` ->
+    require BOTH keys, reject booleans (``bool`` subclasses ``int``), coerce to float,
+    reject non-finite (NaN/inf), clamp to ``[0, 1]``. Any miss -> ``None`` (never raises)."""
     if not content:
         return None
     text = content.strip()
     fenced = _FENCE_RE.search(text)
     if fenced:
         text = fenced.group(1).strip()
-    start, end = text.find("{"), text.rfind("}")
-    if start == -1 or end == -1 or end < start:
+    span = _first_json_object(text)
+    if span is None:
         return None
     try:
-        obj = json.loads(text[start : end + 1])
+        obj = json.loads(span)
     except (json.JSONDecodeError, ValueError):
         return None
     if not isinstance(obj, dict):
@@ -124,8 +144,11 @@ def _parse_verdict(content: str | None) -> dict | None:
     for key in ("real", "perk"):
         if key not in obj:
             return None
+        raw = obj[key]
+        if isinstance(raw, bool):  # bool subclasses int; float(True)==1.0 would slip past
+            return None
         try:
-            value = float(obj[key])
+            value = float(raw)
         except (TypeError, ValueError):
             return None
         if not math.isfinite(value):  # rejects NaN / inf that json.loads happily parses

--- a/src/genesis/routing/standalone.py
+++ b/src/genesis/routing/standalone.py
@@ -12,9 +12,12 @@ rt._router is already set, create_standalone_router() is a no-op.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from genesis.routing.types import BudgetStatus
+
+if TYPE_CHECKING:
+    from genesis.routing.router import Router
 
 logger = logging.getLogger(__name__)
 
@@ -43,19 +46,19 @@ class NullCostTracker:
         pass
 
 
-def create_standalone_router() -> None:
-    """Bootstrap a lightweight router on the GenesisRuntime singleton.
+def _build_standalone_router() -> Router | None:
+    """Construct a lightweight, DB-free ``Router`` with real provider access.
 
-    Safe to call multiple times -- skips if a router is already set.
-    Loads secrets and routing config from disk, constructs a Router
-    with real provider access but no DB-dependent components.
+    Loads secrets + routing config from disk and wires a Router with no
+    DB-dependent components (read-only breakers, null cost tracker, no event
+    bus / dead-letter). Returns the ``Router``, or ``None`` if construction
+    fails (missing config/secrets) — never raises.
+
+    Touches NO global state. Callers wanting the process-wide singleton use
+    ``create_standalone_router()``; callers that just need a router instance
+    (e.g. the offline attention runner's ``--l15`` path) call this directly and
+    own the returned object.
     """
-    from genesis.runtime._core import GenesisRuntime
-
-    rt = GenesisRuntime.instance()
-    if rt._router is not None:
-        return
-
     try:
         from dotenv import load_dotenv
 
@@ -83,7 +86,7 @@ def create_standalone_router() -> None:
         degradation = DegradationTracker(resilience_state=None)
         cost_tracker = NullCostTracker()
 
-        router = Router(
+        return Router(
             config=config,
             breakers=breakers,
             cost_tracker=cost_tracker,
@@ -92,12 +95,29 @@ def create_standalone_router() -> None:
             event_bus=None,
             dead_letter=None,
         )
-        rt._router = router
-        logger.info("Standalone router bootstrapped for MCP server")
-
     except Exception:
         logger.warning(
-            "Failed to bootstrap standalone router -- "
-            "LLM-dependent MCP tools will be unavailable",
+            "Failed to build standalone router -- "
+            "LLM-dependent tools will be unavailable",
             exc_info=True,
         )
+        return None
+
+
+def create_standalone_router() -> None:
+    """Bootstrap a lightweight router on the GenesisRuntime singleton.
+
+    Safe to call multiple times -- skips if a router is already set. Delegates
+    construction to ``_build_standalone_router()`` and assigns the result to the
+    singleton; on build failure the singleton's ``_router`` stays ``None``.
+    """
+    from genesis.runtime._core import GenesisRuntime
+
+    rt = GenesisRuntime.instance()
+    if rt._router is not None:
+        return
+
+    router = _build_standalone_router()
+    if router is not None:
+        rt._router = router
+        logger.info("Standalone router bootstrapped for MCP server")

--- a/tests/test_attention/test_runner.py
+++ b/tests/test_attention/test_runner.py
@@ -9,10 +9,12 @@ from genesis.attention import runner
 from genesis.attention.config import AttentionConfig, default_config_dict
 from genesis.attention.runner import (
     ShadowReport,
+    _graduates_to_l15,
     _snapshot_id_from_path,
     load_runner_config,
     run_shadow,
 )
+from genesis.attention.types import Activation, AmbientUtterance, AttentionEvent, WindowRef
 
 
 def _meta(rms=0.2, ntok=20) -> str:
@@ -67,3 +69,65 @@ async def test_run_shadow_over_snapshot(tmp_path):
     assert report.events >= 1            # the question+multi_speaker row fires
     assert report.persisted == 0         # no consumer -> nothing persisted
     assert 0.0 <= report.fire_rate <= 1.0
+
+
+# ── PR3b: L1.5 seam (activation-gated graduation + verdict attach) ──
+
+def _ev(activation, score) -> AttentionEvent:
+    return AttentionEvent(
+        activation=activation, score=score, triggers_fired=(), suppressors=(),
+        session_id="s1", window_ref=WindowRef("s1", (1,), 0.0, 1.0),
+        ts=1.0, mode_state="unknown", clarity=1.0,
+    )
+
+
+def test_graduates_to_l15_gates_on_activation():
+    th = AttentionConfig.from_dict(default_config_dict()).thresholds   # l15_graduation = 0.4
+    assert _graduates_to_l15(_ev(Activation.HARD, 0.0), th) is True         # bare-HARD (score 0) graduates
+    assert _graduates_to_l15(_ev(Activation.SOFT, 0.7), th) is True         # SOFT above the floor
+    assert _graduates_to_l15(_ev(Activation.SUPPRESSED, 0.9), th) is False  # a veto -> never spend a call
+
+
+def test_graduates_to_l15_soft_cost_floor():
+    # A raised floor lets L1.5 skip weak SOFT fires (a cost knob); HARD is unaffected.
+    th = AttentionConfig.from_dict({**default_config_dict(), "thresholds": {"l15_graduation": 0.8}}).thresholds
+    assert _graduates_to_l15(_ev(Activation.SOFT, 0.6), th) is False        # below the raised floor
+    assert _graduates_to_l15(_ev(Activation.SOFT, 0.9), th) is True
+    assert _graduates_to_l15(_ev(Activation.HARD, 0.0), th) is True         # floor never gates HARD
+
+
+class _FakeSampler:
+    def __init__(self, verdict):
+        self.verdict = verdict
+        self.windows: list = []
+
+    async def sample(self, window, config):
+        self.windows.append(window)
+        return self.verdict
+
+
+@pytest.mark.asyncio
+async def test_run_shadow_l15_attaches_verdict(tmp_path):
+    snap = tmp_path / "ambient.db"
+    _make_ambient(snap, [
+        (1, "2026-06-30T12:00:00+00:00", "what do you think?", 5.0, "w1:1/2", _meta(), 1),
+    ])
+    cfg = AttentionConfig.from_dict(default_config_dict())
+    fake = _FakeSampler({"real": 0.9, "perk": 0.4})
+    report = await run_shadow(snap, cfg, snapshot_id="t", sampler=fake)
+    assert report.events >= 1
+    assert fake.windows                                                   # sampler was invoked
+    assert all(isinstance(u, AmbientUtterance) for u in fake.windows[0])  # window = live utterances
+    assert report.samples[0]["l15"] == {"real": 0.9, "perk": 0.4}         # verdict rode onto the event
+
+
+@pytest.mark.asyncio
+async def test_run_shadow_without_sampler_leaves_verdict_none(tmp_path):
+    snap = tmp_path / "ambient.db"
+    _make_ambient(snap, [
+        (1, "2026-06-30T12:00:00+00:00", "what do you think?", 5.0, "w1:1/2", _meta(), 1),
+    ])
+    cfg = AttentionConfig.from_dict(default_config_dict())
+    report = await run_shadow(snap, cfg, snapshot_id="t")                 # default: no sampler
+    assert report.events >= 1
+    assert report.samples[0]["l15"] is None

--- a/tests/test_attention/test_sampler.py
+++ b/tests/test_attention/test_sampler.py
@@ -61,6 +61,21 @@ def test_parse_non_numeric_returns_none():
     assert _parse_verdict('{"real": "high", "perk": 0.3}') is None
 
 
+def test_parse_boolean_values_return_none():
+    # bool subclasses int -> float(True)==1.0 would sneak a false verdict past the parser.
+    assert _parse_verdict('{"real": true, "perk": false}') is None
+
+
+def test_parse_object_then_prose_with_brace():
+    # brace-depth scan must stop at the object's close, not extend to a later stray "}".
+    assert _parse_verdict('{"real": 0.8, "perk": 0.3} (all set})') == {"real": 0.8, "perk": 0.3}
+
+
+def test_parse_object_with_nested_extra_field():
+    # a nested extra field must not break extraction; real/perk still read, extra ignored.
+    assert _parse_verdict('{"real": 0.8, "perk": 0.3, "meta": {"k": 1}}') == {"real": 0.8, "perk": 0.3}
+
+
 def test_parse_non_dict_json_returns_none():
     assert _parse_verdict('[0.8, 0.3]') is None
 

--- a/tests/test_attention/test_sampler.py
+++ b/tests/test_attention/test_sampler.py
@@ -1,0 +1,142 @@
+"""L1.5 sampler: fail-closed verdict parsing + injected-router integration.
+
+The sampler is the ONLY attention module that calls an LLM. It must never raise (a
+failing sample just leaves ``l15_verdict`` absent) and must send NO junk downstream —
+so the parser is fail-closed and every router failure mode collapses to ``None``.
+"""
+from dataclasses import dataclass
+
+import pytest
+
+from genesis.attention.config import AttentionConfig, default_config_dict
+from genesis.attention.sampler import AttentionSampler, _build_prompt, _parse_verdict
+from genesis.attention.types import AmbientUtterance
+
+CFG = AttentionConfig.from_dict(default_config_dict())
+
+
+def _u(text, is_user=None, **kw) -> AmbientUtterance:
+    d = dict(id=1, ts=0.0, duration_s=1.0, is_user=is_user, speaker_total=None,
+             n_tokens=5, frac_lt_1=0.0, rms=0.1)
+    d.update(kw)
+    return AmbientUtterance(text=text, **d)
+
+
+# ── _parse_verdict: fail-closed float extraction ──
+
+def test_parse_happy():
+    assert _parse_verdict('{"real": 0.8, "perk": 0.3}') == {"real": 0.8, "perk": 0.3}
+
+
+def test_parse_fenced_json_block():
+    assert _parse_verdict('```json\n{"real": 0.9, "perk": 0.1}\n```') == {"real": 0.9, "perk": 0.1}
+
+
+def test_parse_prose_wrapped_object():
+    assert _parse_verdict('Sure! {"real": 0.5, "perk": 0.5} hope that helps') == {"real": 0.5, "perk": 0.5}
+
+
+def test_parse_clamps_out_of_range_to_unit_interval():
+    assert _parse_verdict('{"real": 1.5, "perk": -0.2}') == {"real": 1.0, "perk": 0.0}
+
+
+def test_parse_integer_values_coerce_to_float():
+    assert _parse_verdict('{"real": 1, "perk": 0}') == {"real": 1.0, "perk": 0.0}
+
+
+def test_parse_malformed_json_returns_none():
+    assert _parse_verdict('{real: 0.8, perk: 0.3') is None
+
+
+def test_parse_missing_key_returns_none():
+    assert _parse_verdict('{"real": 0.8}') is None
+
+
+def test_parse_nan_returns_none():
+    # json.loads accepts a bare NaN token; the finite-check must reject it (fail-closed).
+    assert _parse_verdict('{"real": NaN, "perk": 0.3}') is None
+
+
+def test_parse_non_numeric_returns_none():
+    assert _parse_verdict('{"real": "high", "perk": 0.3}') is None
+
+
+def test_parse_non_dict_json_returns_none():
+    assert _parse_verdict('[0.8, 0.3]') is None
+
+
+def test_parse_no_object_returns_none():
+    assert _parse_verdict("real 0.8 perk 0.3") is None
+
+
+def test_parse_empty_or_none_returns_none():
+    assert _parse_verdict("") is None
+    assert _parse_verdict(None) is None
+
+
+# ── _build_prompt: window text + speaker labels reach the model ──
+
+def test_prompt_carries_window_text_and_speaker_labels():
+    p = _build_prompt([_u("did we ship it?", is_user=1), _u("not yet", is_user=0)])
+    assert "did we ship it?" in p and "not yet" in p
+    assert "[user]" in p and "[other]" in p
+    assert "real" in p and "perk" in p          # asks for BOTH scores
+
+
+def test_prompt_unknown_speaker_label():
+    p = _build_prompt([_u("mumble", is_user=None)])
+    assert "[?]" in p
+
+
+# ── AttentionSampler.sample: injected fake router ──
+
+@dataclass
+class _Result:
+    success: bool
+    content: str | None
+
+
+class _FakeRouter:
+    def __init__(self, *, content=None, success=True, raises=False):
+        self._content = content
+        self._success = success
+        self._raises = raises
+        self.calls: list = []
+
+    async def route_call(self, call_site_id, messages, **kwargs):
+        self.calls.append((call_site_id, messages))
+        if self._raises:
+            raise RuntimeError("boom")
+        return _Result(self._success, self._content)
+
+
+@pytest.mark.asyncio
+async def test_sample_happy_hits_attention_salience_call_site():
+    r = _FakeRouter(content='{"real": 0.7, "perk": 0.6}')
+    out = await AttentionSampler(r).sample([_u("what's the plan?", is_user=1)], CFG)
+    assert out == {"real": 0.7, "perk": 0.6}
+    assert r.calls and r.calls[0][0] == "attention_salience"
+
+
+@pytest.mark.asyncio
+async def test_sample_route_failure_returns_none():
+    assert await AttentionSampler(_FakeRouter(success=False, content=None)).sample(
+        [_u("hi", is_user=1)], CFG) is None
+
+
+@pytest.mark.asyncio
+async def test_sample_router_exception_never_propagates():
+    assert await AttentionSampler(_FakeRouter(raises=True)).sample([_u("hi", is_user=1)], CFG) is None
+
+
+@pytest.mark.asyncio
+async def test_sample_empty_window_skips_router_call():
+    r = _FakeRouter(content='{"real": 1, "perk": 1}')
+    assert await AttentionSampler(r).sample([], CFG) is None
+    assert r.calls == []            # no wasted egress on an empty window
+
+
+@pytest.mark.asyncio
+async def test_sample_malformed_content_returns_none():
+    assert await AttentionSampler(_FakeRouter(content="not json at all")).sample(
+        [_u("hi", is_user=1)], CFG) is None

--- a/tests/test_attention/test_sampler.py
+++ b/tests/test_attention/test_sampler.py
@@ -155,3 +155,21 @@ async def test_sample_empty_window_skips_router_call():
 async def test_sample_malformed_content_returns_none():
     assert await AttentionSampler(_FakeRouter(content="not json at all")).sample(
         [_u("hi", is_user=1)], CFG) is None
+
+
+def test_attention_salience_call_site_is_configured():
+    """The sampler's call-site must exist in the real routing config: free-only (so
+    never_pays keeps a valid chain) and non-Groq (the L1.5 chain deliberately avoids
+    Groq's EOL 8B / JSON-breaking gpt-oss-20b). Picked by the 2026-07-01 bake-off."""
+    from genesis.attention.sampler import CALL_SITE
+    from genesis.env import repo_root
+    from genesis.routing.config import load_config
+
+    cfg = load_config(repo_root() / "config" / "model_routing.yaml", check_api_keys=False)
+    assert CALL_SITE in cfg.call_sites
+    site = cfg.call_sites[CALL_SITE]
+    assert site.never_pays is True
+    assert site.chain
+    for provider in site.chain:
+        assert cfg.providers[provider].is_free            # never_pays needs a free chain
+        assert cfg.providers[provider].provider_type != "groq"  # non-Groq by design

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -147,9 +147,11 @@ def test_load_full_yaml(monkeypatch):
     # 2026-06-06: 49 → 51 after dream_cycle_synthesis_challenge + dream_cycle_entity_challenge (immune system PR).
     # 2026-06-20: 51 → 52 after crag_grade added (W-CRAG selective corrective retrieval, PR #711).
     # 2026-06-30: 52 → 53 after 38a_procedure_novelty_llm added (C2b cross-type procedure dedup).
-    assert len(cfg.call_sites) == 53
+    # 2026-07-01: 53 → 54 after attention_salience added (PR3b L1.5 salience gate).
+    assert len(cfg.call_sites) == 54
     assert "crag_grade" in cfg.call_sites  # W-CRAG runtime grader (2026-06-20)
     assert "38a_procedure_novelty_llm" in cfg.call_sites  # C2b cross-type dedup (2026-06-30)
+    assert "attention_salience" in cfg.call_sites  # PR3b L1.5 salience gate (2026-07-01)
     assert "models_md_synthesis" not in cfg.call_sites  # removed 2026-05-24
     assert "2_triage" not in cfg.call_sites  # removed 2026-05-10
     assert "7_task_retrospective" not in cfg.call_sites  # removed 2026-05-10 (duplicate; live one is 43_task_retrospective)

--- a/tests/test_routing/test_standalone.py
+++ b/tests/test_routing/test_standalone.py
@@ -76,3 +76,31 @@ class TestCreateStandaloneRouterFailure:
 
         assert rt._router is None  # failed gracefully
         GenesisRuntime.reset()
+
+
+class TestBuildStandaloneRouter:
+    async def test_returns_router_without_touching_singleton(self):
+        """The helper returns a Router and must NOT mutate the GenesisRuntime singleton
+        (the offline runner's --l15 path uses it directly, not via the singleton)."""
+        from genesis.routing.router import Router
+        from genesis.routing.standalone import _build_standalone_router
+        from genesis.runtime._core import GenesisRuntime
+
+        GenesisRuntime.reset()
+        rt = GenesisRuntime.instance()
+        assert rt._router is None
+
+        router = _build_standalone_router()
+
+        assert isinstance(router, Router)
+        assert rt._router is None  # helper left the singleton untouched
+        GenesisRuntime.reset()
+
+    async def test_returns_none_on_build_failure(self):
+        """Missing config -> None (never raises), same graceful failure as the public fn."""
+        from unittest.mock import patch
+
+        from genesis.routing.standalone import _build_standalone_router
+
+        with patch("genesis.env.repo_root", return_value="/nonexistent"):
+            assert _build_standalone_router() is None


### PR DESCRIPTION
## What

Completes the attention engine's **L1.5 tier**: for a graduated attention window, a cheap FREE LLM scores `{real, perk}` (coherent-real-speech gate + salience) and the verdict rides onto the `AttentionEvent`. Offline shadow tooling, **OFF by default** — opt-in via the runner's `--l15` flag. No runtime call site (offline CLI), so **no deploy/restart**.

## Design

- **`attention/sampler.py`** (NEW) — genesis-side adapter with an injected `_Router` Protocol (mirrors `ego/focus.py`). Strict-JSON prompt over the in-memory window; a **fail-closed parser** (fence strip → brace-depth object scan → require both keys, reject bools/NaN/inf, clamp `[0,1]`; any miss → `None`, never raises). NOT a core module, NOT imported by `attention/__init__` → edge-portability firewall intact.
- **`routing/standalone.py`** — extracted `_build_standalone_router() -> Router | None` (no `GenesisRuntime` singleton mutation) so the CLI gets a DB-free real-provider router; `create_standalone_router()` delegates to it (public behaviour unchanged).
- **`attention/runner.py`** — `run_shadow` gains a `sampler` param + `--l15` flag. A pure `_graduates_to_l15(ev, thresholds)` gate: **HARD always; SOFT above the `l15_graduation` cost-floor; SUPPRESSED never**. In-loop `await sampler.sample(...)` → `dataclasses.replace(ev, l15_verdict=v)` before persist. Default path (`sampler=None`) is byte-identical.
- **`config/model_routing.yaml`** — `attention_salience` call-site: `chain: [mistral-small-free → nvidia-nim-deepseek]`, `never_pays: true`, `retry_profile: user_facing`.

## Firewall

Window transcript text goes to the LLM **in memory only**; the persisted verdict is **floats only** (`{real, perk}`) — verified on a DB copy that no transcript text lands in any column.

## Provider bake-off (non-Groq)

Groq is excluded deliberately (its 8B is EOL 2026-08-16; the `gpt-oss-20b` replacement breaks strict JSON). A live bake-off over real garbled windows picked **mistral-small-latest** (100% clean JSON, ~0.8s, full discrimination range) primary + **nvidia-nim deepseek-v4-pro** (100% clean, different vendor) fallback. Others failed hard (gemini daily quota, openrouter rate-limits, mistral-large more limited, nvidia-kimi emitted non-JSON garbage — the fail-closed parser correctly returned `None`).

## Review

- **genesis-architect** pre-review caught 3 blockers, all fixed: (B1) the graduation gate was backwards — a score threshold excluded every bare-HARD fire (`score=0`) and admitted vetoed SUPPRESSED events → switched to the activation gate; (B2) singleton mutation → the extracted builder; (B3) labeled-row verdict backfill gap → scoped to PR3c-1 (fresh/unlabeled writes work, which is all PR3b needs).
- **code-reviewer** caught 2 fail-closed gaps: bool coercion (`float(True)==1.0`) and brace mis-slicing → fixed with a bool guard + brace-depth scan.

## Verification

- ruff clean; targeted tests green (sampler fail-closed parser, injected fake router, `_graduates_to_l15` all branches, standalone extraction, config-integration + call-site count).
- **E2E on a genesis.db copy**: real CLI `--l15 --persist` over a synthetic snapshot → HARD+SOFT got float verdicts, SUPPRESSED skipped, firewall clean, both config versions coexist, production DB untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)