### PR TITLE
fix(autonomy): defer watchdog restarts during a deploy + bound the seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **`update.sh` no longer hangs if the health watchdog restarts the server mid-update.**
+  During an update Genesis stops its server to swap in new code and migrate the database. The
+  background health watchdog could see it "down" and restart it right then — and the revived
+  server's database lock deadlocked the update's procedure-seeding step, leaving the whole update
+  stuck for as long as ~30 minutes with no error. The watchdog now defers restarts while an update
+  is in progress, and the seeding step is time-bounded so a contended database fails fast instead of
+  hanging silently.
 - **Genesis now keeps your Claude Code CLI at the version it's tested against — automatically.**
   Previously the installer only put Claude Code in place when it was *missing*, so if you already
   had an older Claude Code, bumping the pinned version never actually upgraded you — you'd silently

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -417,7 +417,11 @@ echo "--- Seeding baseline procedures ---"
 # Non-fatal, but surface a failure instead of swallowing it (a silent miss would
 # leave advisory surfacing untracked with no signal). Capture, then check for the
 # success line rather than relying on the exit code through the pipe.
-SEED_OUT="$("$VENV_DIR/bin/python" "$GENESIS_ROOT/scripts/seed_procedures.py" 2>&1)" || true
+# Defense-in-depth (incident IR-2): bound the seed with `timeout 300`. Seeding
+# normally finishes in seconds; if the DB write lock is ever contended (a mid-
+# deploy server revival deadlocked it, hanging bootstrap ~30 min silently), fail
+# FAST at 5 min — the `|| true` keeps it non-fatal and the WARNING below fires.
+SEED_OUT="$(timeout 300 "$VENV_DIR/bin/python" "$GENESIS_ROOT/scripts/seed_procedures.py" 2>&1)" || true
 echo "$SEED_OUT" | tail -2
 if ! echo "$SEED_OUT" | grep -q "Seeded .* procedures"; then
     echo "  WARNING: baseline procedure seeding did not complete — advisor surfacing tracking may be degraded."

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -509,6 +509,12 @@ with open(sys.argv[11], 'w') as f:
   "$(date -Iseconds)" \
   "$HOME/.genesis/last_update_failure.json"
 
+    # Clear the in-progress signal files (mirrors the success-path cleanup) so a
+    # leftover entry can't suppress the watchdog's deploy-restart guard after a
+    # rollback. The server is back up (above); once this invocation exits its PID
+    # dies anyway, but removing the files closes the PID-reuse window proactively.
+    rm -f "$STATE_FILE" "$HOME/.genesis/update_in_progress.pid"
+
     echo ""
     echo "  ──────────────────────────────────────"
     echo "  Rolled back: $OLD_TAG ($OLD_COMMIT) on $ORIGINAL_BRANCH"
@@ -626,6 +632,9 @@ if [[ "$OLD_COMMIT" == "$NEW_COMMIT" ]]; then
             systemctl --user start "$svc.service" 2>/dev/null || true
         fi
     done
+    # Nothing changed and no --post-merge continuation follows, so clear the
+    # in-progress signals (like the success path) — a leftover must never linger.
+    rm -f "$STATE_FILE" "$HOME/.genesis/update_in_progress.pid"
     echo ""
     echo "  Nothing to do."
     exit 0

--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -30,6 +30,7 @@ import yaml
 
 from genesis.autonomy.types import WatchdogAction
 from genesis.env import secrets_path as default_secrets_path
+from genesis.env import update_in_progress
 from genesis.util.systemd import systemctl_env
 
 if TYPE_CHECKING:
@@ -200,6 +201,19 @@ class WatchdogChecker:
 
     def _restart_if_allowed(self, state: dict, *, reason: str) -> WatchdogAction:
         """Shared restart logic: backoff → validation → restart or skip."""
+        # Defer restarts while a deploy is running. update.sh intentionally stops
+        # genesis-server for its merge/bootstrap/migrate window; a watchdog revival
+        # there takes the DB write lock and deadlocks bootstrap's seed (incident
+        # IR-2). Return SKIP (not NOTIFY/BACKOFF) BEFORE _record_failure so the
+        # deploy window never trips backoff or the max-restart counter. Note: this
+        # trusts every deploy phase to either self-bound or not deadlock (the seed,
+        # the one proven hang, is separately timeout-bounded in bootstrap.sh).
+        if update_in_progress():
+            logger.info(
+                "Deploy in progress — deferring %s restart until it completes", reason,
+            )
+            return WatchdogAction.SKIP
+
         if state["consecutive_failures"] >= self._max_restarts:
             logger.error(
                 "Max restart attempts (%d) reached — refusing to restart. Manual intervention needed.",

--- a/src/genesis/env.py
+++ b/src/genesis/env.py
@@ -11,8 +11,10 @@ Configuration precedence (highest to lowest):
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
@@ -97,6 +99,99 @@ def genesis_home() -> Path:
     """Resolve the Genesis runtime home (~/.genesis): output, sessions, config."""
     value = os.environ.get("GENESIS_HOME")
     return Path(value).expanduser() if value else Path.home() / ".genesis"
+
+
+# A real deploy completes in minutes (update.sh's health-check phase caps at
+# ~3 min). A state file whose start is older than this cutoff is a crashed or
+# abandoned deploy, not a live one — treating it as stale bounds the (rare)
+# PID-reuse window in which a leftover state file could otherwise suppress the
+# watchdog's restart guard indefinitely.
+_UPDATE_STALE_AFTER_S = 4 * 3600  # 4 hours
+
+
+def _deploy_state_is_recent(state: dict) -> bool:
+    """False if update_state.json's ``started_at`` is older than the stale cutoff.
+
+    Absent/unparseable timestamp → True (fall back to PID liveness alone; never
+    let a formatting quirk be the thing that suppresses the watchdog).
+    """
+    started_at = state.get("started_at")
+    if not started_at:
+        return True
+    try:
+        started = datetime.fromisoformat(started_at)
+    except (ValueError, TypeError):
+        return True
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=UTC)
+    return (datetime.now(UTC) - started).total_seconds() < _UPDATE_STALE_AFTER_S
+
+
+def update_in_progress() -> bool:
+    """True while a Genesis self-update (deploy) is actively running.
+
+    Read by the autonomy watchdog to DEFER restarting genesis-server during a
+    deploy. ``update.sh`` intentionally stops the server for its
+    merge/bootstrap/migrate window; a mid-deploy revival takes the DB write lock
+    and deadlocks bootstrap's procedure seed (incident IR-2). Two independent
+    deploy signals are honored — either one alive → in progress:
+
+    * ``~/.genesis/update_in_progress.pid`` — a bare-integer PID written by the
+      dashboard-orchestrated update path (``dashboard/routes/updates.py``).
+      Present ONLY for dashboard-triggered updates; a CLI ``./scripts/update.sh``
+      run never writes it.
+    * ``~/.genesis/update_state.json`` — ``{phase, pid, started_at, ...}`` written
+      per-phase by ``update.sh::_write_state`` (the CLI path; the incident path).
+      Counts only while ``phase != "done"`` (``done`` is written immediately
+      before the file is removed) and ``started_at`` is recent.
+
+    A signal counts only if its PID is > 1 (an ``AsyncMock().pid`` is 1) AND
+    still alive (``os.kill(pid, 0)``). Any dead / absent / corrupt / ``done`` /
+    expired signal is treated as "no deploy", so a stale file can never
+    permanently disable the watchdog. This check is defensive by contract: it
+    NEVER raises into the caller (the watchdog restart path).
+    """
+    try:
+        home = genesis_home()
+
+        # Dashboard path: bare-int PID file (dashboard-only; absent for CLI runs).
+        pid_file = home / "update_in_progress.pid"
+        if pid_file.exists():
+            try:
+                pid = int(pid_file.read_text().strip())
+                if pid > 1:
+                    os.kill(pid, 0)
+                    return True
+            except (ProcessLookupError, ValueError, OSError):
+                pass  # dead / invalid PID — not an active deploy
+
+        # CLI path: update.sh state file with phase + owning PID + start time.
+        state_file = home / "update_state.json"
+        if state_file.exists():
+            try:
+                state = json.loads(state_file.read_text())
+            except (json.JSONDecodeError, OSError, ValueError, UnicodeDecodeError):
+                state = None
+            if (
+                isinstance(state, dict)
+                and state.get("phase") != "done"
+                and _deploy_state_is_recent(state)
+            ):
+                pid = state.get("pid")
+                if isinstance(pid, int) and pid > 1:
+                    try:
+                        os.kill(pid, 0)
+                        return True
+                    except (ProcessLookupError, OSError):
+                        pass  # owning process gone — stale state file
+
+        return False
+    except Exception:  # never raise into the watchdog loop — fail open to "no deploy"
+        logger.warning(
+            "update_in_progress() check failed — assuming no deploy in progress",
+            exc_info=True,
+        )
+        return False
 
 
 def claude_home() -> Path:

--- a/src/genesis/learning/signals/genesis_version.py
+++ b/src/genesis/learning/signals/genesis_version.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
@@ -24,6 +23,7 @@ import aiosqlite
 import yaml
 
 from genesis.awareness.types import SignalReading
+from genesis.env import update_in_progress
 
 if TYPE_CHECKING:
     pass
@@ -548,22 +548,16 @@ class GenesisVersionCollector:
         if not _FAILURE_FILE.exists():
             return
 
-        # Gate: if the update orchestrator is still running (multi-tier),
-        # defer the alarm. Tier 1 may fail and write this file, but Tier 2
-        # may succeed — don't fire a false alarm mid-orchestration.
-        _ORCHESTRATOR_PID_FILE = Path.home() / ".genesis" / "update_in_progress.pid"
-        if _ORCHESTRATOR_PID_FILE.exists():
-            try:
-                pid = int(_ORCHESTRATOR_PID_FILE.read_text().strip())
-                if pid > 1:
-                    os.kill(pid, 0)  # Check if alive (signal 0 = existence check)
-                    logger.debug(
-                        "Update failure file present but orchestrator still running "
-                        "(pid=%d) — deferring observation", pid,
-                    )
-                    return
-            except (ProcessLookupError, ValueError, OSError):
-                pass  # PID dead or invalid — orchestrator finished, proceed
+        # Gate: if a deploy is still in progress — a dashboard-orchestrated
+        # multi-tier run OR a CLI `update.sh` run — defer the alarm. A later tier
+        # may succeed, and a failure file written mid-deploy is expected transient
+        # noise, not a settled failure. (Shared with the watchdog's restart guard.)
+        if update_in_progress():
+            logger.debug(
+                "Update failure file present but a deploy is still in progress "
+                "— deferring observation",
+            )
+            return
 
         try:
             data = json.loads(_FAILURE_FILE.read_text())

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -30,6 +30,16 @@ def _mock_bridge_active():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _no_deploy_in_progress():
+    """Default every watchdog test to 'no deploy running' so the restart gate is
+    deterministic regardless of a real ~/.genesis/update_state.json on the host.
+    The IR-2 deploy-guard tests override this to True.
+    """
+    with patch("genesis.autonomy.watchdog.update_in_progress", return_value=False):
+        yield
+
+
 @pytest.fixture()
 def fresh_status(tmp_path: Path) -> Path:
     """Write a fresh status.json and return the path."""
@@ -76,6 +86,46 @@ def _make_checker(
         state_file=str(tmp_path / "watchdog_state.json"),
         stabilization_s=kwargs.get("stabilization_s", 600),
     )
+
+
+class TestDeployInProgress:
+    """IR-2: the watchdog must DEFER restarts while a deploy is running.
+
+    A mid-deploy revival takes the DB write lock and deadlocks bootstrap's
+    procedure seed. update.sh stops genesis-server on purpose during the
+    merge/bootstrap/migrate window; the guard keeps it down until the deploy ends.
+    """
+
+    def test_stale_status_defers_when_deploy_in_progress(
+        self, tmp_path: Path, stale_status: Path
+    ):
+        # A stale status normally RESTARTs (see TestStale); during a deploy → SKIP.
+        checker = _make_checker(tmp_path, stale_status)
+        with patch("genesis.autonomy.watchdog.update_in_progress", return_value=True):
+            assert checker.check() is WatchdogAction.SKIP
+
+    def test_deploy_guard_does_not_trip_failure_counter(
+        self, tmp_path: Path, stale_status: Path
+    ):
+        # SKIP returns BEFORE _record_failure, so the backoff / max-restart
+        # counter is never burned during a deploy window.
+        checker = _make_checker(tmp_path, stale_status)
+        state_file = tmp_path / "watchdog_state.json"
+        state_file.write_text(json.dumps({
+            "consecutive_failures": 2, "next_attempt_after": None, "last_reason": "x",
+        }))
+        with patch("genesis.autonomy.watchdog.update_in_progress", return_value=True):
+            checker.check()
+        state = json.loads(state_file.read_text())
+        assert state["consecutive_failures"] == 2  # unchanged — guard skipped the failure path
+
+    def test_restarts_normally_when_no_deploy(
+        self, tmp_path: Path, stale_status: Path
+    ):
+        # Sanity: with the (default) no-deploy state, stale still RESTARTs — the
+        # guard adds zero behavior change outside a deploy window.
+        checker = _make_checker(tmp_path, stale_status)
+        assert checker.check() is WatchdogAction.RESTART
 
 
 class TestHealthy:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,146 @@
+"""Tests for genesis.env deploy-state helpers.
+
+Covers ``update_in_progress()`` — the shared signal the autonomy watchdog uses
+to DEFER restarting genesis-server during a deploy (incident IR-2). The contract
+is fail-open: any dead / absent / corrupt / expired signal → False, and the
+helper must NEVER raise into its caller (the watchdog restart path).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from genesis.env import update_in_progress
+
+
+@pytest.fixture()
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point genesis_home() at an isolated tmp dir (via the GENESIS_HOME env)."""
+    monkeypatch.setenv("GENESIS_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _write_state(
+    home: Path,
+    *,
+    phase: str = "bootstrap",
+    pid: int | None = None,
+    started_at: str | None = None,
+) -> None:
+    """Write an update_state.json like update.sh::_write_state does."""
+    if pid is None:
+        pid = os.getpid()  # a real, alive, > 1 pid
+    if started_at is None:
+        started_at = datetime.now(UTC).isoformat()
+    (home / "update_state.json").write_text(
+        json.dumps(
+            {
+                "phase": phase,
+                "pid": pid,
+                "started_at": started_at,
+                "rollback_tag": "pre-update-x",
+                "timestamp": started_at,
+            }
+        )
+    )
+
+
+def _kill_dead(_pid: int, _sig: int) -> None:
+    """Stand-in for os.kill on a dead pid."""
+    raise ProcessLookupError
+
+
+class TestStateJsonPath:
+    """The CLI path — update.sh writes update_state.json (the incident path)."""
+
+    def test_false_when_nothing_present(self, home: Path):
+        assert update_in_progress() is False
+
+    def test_true_for_live_pid_mid_bootstrap(self, home: Path):
+        _write_state(home, phase="bootstrap", pid=os.getpid())
+        assert update_in_progress() is True
+
+    def test_false_when_phase_done(self, home: Path):
+        # "done" is written just before the file is removed — not in progress.
+        _write_state(home, phase="done", pid=os.getpid())
+        assert update_in_progress() is False
+
+    def test_false_for_dead_pid(self, home: Path, monkeypatch: pytest.MonkeyPatch):
+        _write_state(home, pid=os.getpid())
+        monkeypatch.setattr(os, "kill", _kill_dead)
+        assert update_in_progress() is False
+
+    def test_false_for_pid_le_1(self, home: Path):
+        # An AsyncMock().pid is 1 in py3.12 — must never count as a live deploy.
+        _write_state(home, pid=1)
+        assert update_in_progress() is False
+
+    def test_false_for_stale_started_at(self, home: Path):
+        old = (datetime.now(UTC) - timedelta(hours=5)).isoformat()
+        _write_state(home, pid=os.getpid(), started_at=old)
+        assert update_in_progress() is False
+
+    def test_true_when_started_at_missing(self, home: Path):
+        # No timestamp → fall back to pid liveness alone.
+        (home / "update_state.json").write_text(
+            json.dumps({"phase": "bootstrap", "pid": os.getpid()})
+        )
+        assert update_in_progress() is True
+
+    def test_true_for_naive_started_at(self, home: Path):
+        # A naive (tz-less) timestamp is treated as UTC by the recency check,
+        # so a fresh naive start still counts as in-progress (never wrongly stale).
+        naive = datetime.now(UTC).replace(tzinfo=None).isoformat()  # no offset
+        _write_state(home, pid=os.getpid(), started_at=naive)
+        assert update_in_progress() is True
+
+    def test_false_for_corrupt_json(self, home: Path):
+        (home / "update_state.json").write_text("{not valid json")
+        assert update_in_progress() is False
+
+
+class TestPidFilePath:
+    """The dashboard path — updates.py writes a bare-int update_in_progress.pid."""
+
+    def test_true_for_live_pid_file(self, home: Path):
+        (home / "update_in_progress.pid").write_text(str(os.getpid()))
+        assert update_in_progress() is True
+
+    def test_false_for_dead_pid_file(self, home: Path, monkeypatch: pytest.MonkeyPatch):
+        (home / "update_in_progress.pid").write_text(str(os.getpid()))
+        monkeypatch.setattr(os, "kill", _kill_dead)
+        assert update_in_progress() is False
+
+    def test_false_for_pid_le_1(self, home: Path):
+        (home / "update_in_progress.pid").write_text("1")
+        assert update_in_progress() is False
+
+    def test_false_for_garbage_pid_file(self, home: Path):
+        (home / "update_in_progress.pid").write_text("not-a-pid")
+        assert update_in_progress() is False
+
+
+def test_never_raises_fails_open_to_false(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """An unexpected error type must fail open to False, never propagate."""
+    _write_state(home, pid=os.getpid())
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("disk on fire")
+
+    # read_text isn't in any inner except tuple — only the outer catch saves us.
+    monkeypatch.setattr(Path, "read_text", _boom)
+    assert update_in_progress() is False
+
+
+def test_pid_file_takes_precedence_but_either_signal_counts(home: Path):
+    """Both signals present → still True (dashboard path checked first)."""
+    (home / "update_in_progress.pid").write_text(str(os.getpid()))
+    _write_state(home, phase="done", pid=1)  # JSON path alone would be False
+    assert update_in_progress() is True

--- a/tests/test_learning/test_genesis_version_collector.py
+++ b/tests/test_learning/test_genesis_version_collector.py
@@ -285,6 +285,24 @@ class TestFailureArchive:
         self.fake_failure = fake_failure
         self.fake_archive_dir = fake_archive_dir
 
+    @pytest.mark.asyncio
+    async def test_check_failure_file_defers_during_deploy(self, collector, db) -> None:
+        """IR-2 wiring: with a deploy in progress, a present failure file is NOT
+        consumed — the observation defers (shared genesis.env.update_in_progress).
+        """
+        self.fake_failure.write_text('{"timestamp": "2026-07-01T00:00:00Z"}')
+        with patch(
+            "genesis.learning.signals.genesis_version.update_in_progress",
+            return_value=True,
+        ):
+            await collector._check_failure_file()
+        # Deferred: the live failure file is left in place (not archived/consumed)...
+        assert self.fake_failure.exists()
+        # ...and no observation row was written.
+        cursor = await db.execute("SELECT COUNT(*) FROM observations")
+        (count,) = await cursor.fetchone()
+        assert count == 0
+
     def test_archive_creates_timestamped_file(self) -> None:
         self.fake_failure.write_text('{"timestamp": "2026-04-10T12:00:00Z"}')
         GenesisVersionCollector._archive_failure_file()


### PR DESCRIPTION
## What & why

`update.sh` intentionally stops `genesis-server` for its merge/bootstrap/migrate window. The `genesis-watchdog` timer (fires every 60s) could see the server "down" during that window and restart it — and the revived server's DB write lock deadlocked `bootstrap.sh`'s procedure seed (`seed_procedures.py`, an aiosqlite worker thread), hanging the whole update silently for ~30 minutes. `update.sh` already disarms systemd's `Restart=on-failure`, but was blind to the watchdog — a second, independent revival path.

## The fix

**1. New shared signal — `genesis.env.update_in_progress()`**
Reads both deploy signals under `~/.genesis/`: the CLI path's `update_state.json` (`{phase, pid, started_at, …}`, written per-phase by `update.sh::_write_state`) and the dashboard path's bare-int `update_in_progress.pid`. Returns `True` only while an owning `pid > 1` is alive (`os.kill(pid, 0)`) **and**, for the state file, `phase != "done"` **and** `started_at` is within a 4h cutoff. Everything else — dead / absent / corrupt / expired / `pid <= 1` — is `False`, and the whole body is wrapped so it **never raises into the watchdog** (fail-open to "no deploy"). The 4h cutoff bounds the rare PID-reuse window in which a leftover state file could otherwise suppress the watchdog.

**2. Watchdog guard** — `autonomy/watchdog.py::_restart_if_allowed()` returns `WatchdogAction.SKIP` when a deploy is in progress, *before* `_record_failure`, so a deploy window never trips backoff or the max-restart counter. This function is the sole producer of `WatchdogAction.RESTART`, so all three restart paths are covered by the one guard.

**3. Defense-in-depth** — `bootstrap.sh` wraps the procedure seed in `timeout 300` (keeps the existing `|| true`; a contended DB now fails fast at 5 min with the existing WARNING instead of hanging silently).

**4. Cleanup symmetry** — `update.sh::_do_rollback` and the "already up to date" early exit now clear the in-progress signal files, mirroring the success-path cleanup. The merge-conflict `exit 2` path deliberately keeps `update_state.json` (the `--post-merge` continuation reads it for the rollback tag); that path is already watchdog-safe because its PID dies on exit.

**5. DRY** — `learning/signals/genesis_version.py::_check_failure_file()` now reuses `update_in_progress()` instead of an inline orchestrator-PID read, so the update-failure alarm also defers during CLI updates (not just dashboard-orchestrated ones). Removed the now-unused `import os`.

## Validation

- `ruff` clean; `bash -n` clean on both scripts.
- New `tests/test_env.py` (15 cases: both signal paths, `phase=done`, dead/`<=1` PID, stale/naive `started_at`, corrupt JSON, never-raises). Watchdog deploy-guard tests (defers a stale-server restart; does not trip the failure counter; restarts normally with no deploy). A `genesis_version` defer test. **98 targeted tests pass**; import-cycle regression stays green.
- **E2E with the real `WatchdogChecker` + real `update_in_progress()`** (side-effect-free — `check()` only decides): a 20-min-stale server that would normally RESTART is **deferred (SKIP)** while a realistic `phase=bootstrap` deploy signal is present, and RESTARTs again on `phase=done` / a dead PID. `bootstrap`'s `timeout 300` was verified to fail fast and emit the WARNING on a simulated deadlock.

## Regression markers

- If the watchdog ever stops restarting a genuinely-down server: suspect a stale `update_state.json` / `update_in_progress.pid` whose PID was recycled to a live process — remove it (auto-cleared by the next bootstrap; the 4h cutoff bounds the window).
- A deploy must complete without the watchdog reviving the server mid-run — the "Restarting … via systemctl" line must NOT appear in the watchdog journal during the stop-window.

## Deploy note

This fix must be deployed with the watchdog timer paused (`systemctl --user stop genesis-watchdog.timer`) for its *own* update.sh run, then restarted — because the old (unguarded) watchdog is still live during the deploy that installs the guard. After it lands, future deploys are self-protected.
