### PR TITLE
chore(cc): bump pinned Claude Code 2.1.173 → 2.1.198

### DIFF
--- a/docs/reference/cc-compatibility.md
+++ b/docs/reference/cc-compatibility.md
@@ -9,13 +9,13 @@
 > through 8 evaluation lenses (see analyzer prompt for details). This document
 > is updated manually after each evaluation.
 >
-> Created: 2026-03-09 | Last updated: 2026-06-11
+> Created: 2026-03-09 | Last updated: 2026-07-01
 
 ---
 
 ## Current CC Version
 
-**Installed:** Claude Code 2.1.173 on the **container** (upgraded 2026-06-11 from 2.1.170 — Fable 5 `[1m]` model-ID normalization fix + 2.1.172 long-conversation render perf). The **host VM** runs **2.1.87** — deliberately held there after the 2.1.90 Linux scrollback regression (see the 2.1.90 row below). 2.1.173 (the fullscreen-renderer scrollback fix) is the version the host is now being moved to via the unified updater. **Both** container and host install Claude Code **via npm-global** (`npm install -g @anthropic-ai/claude-code@<version>` — the container auto-detects its npm prefix, the host uses `sudo npm install -g`). There is no native-installer path.
+**Pin:** Claude Code **2.1.198** (bumped 2026-07-01 from 2.1.173 — a 25-release delta that is overwhelmingly fixes + perf; Sonnet 5 becomes CC's default model at 2.1.197, and Claude-in-Chrome goes GA at 2.1.198). The **container** was on 2.1.173 (upgraded 2026-06-11 from 2.1.170); it and the **host VM** (previously held at 2.1.87 after the 2.1.90 Linux scrollback regression) both align to the pin on the next `scripts/update.sh` run — the container via `cc_ensure_local`, the host via the guardian `update-cc` op. The 2.1.198 range **retains and extends** the fullscreen-renderer scrollback fix that motivated the 2.1.173 pin (no scrollback regression in 2.1.174–2.1.198). **Both** container and host install Claude Code **via npm-global** (`npm install -g @anthropic-ai/claude-code@<version>` — the container auto-detects its npm prefix, the host uses `sudo npm install -g`). There is no native-installer path.
 **Pin (single source of truth):** `CC_VERSION` in `scripts/lib/cc_version.sh`, which
 also exports the shared **`cc_ensure_local`** aligner. Sourced by `scripts/install.sh`,
 `scripts/host-setup.sh`, `scripts/bootstrap.sh`, and `scripts/update.sh`. Bump it in one
@@ -48,7 +48,7 @@ installs `@anthropic-ai/claude-code@<version>` using the npm that owns the in-us
 baked `command -v claude` path), and verifies `claude --version` afterward.
 
 To move the host by hand:
-`ssh -i ~/.ssh/genesis_guardian_ed25519 <host_user>@<host_ip> "update-cc 2.1.173"`
+`ssh -i ~/.ssh/genesis_guardian_ed25519 <host_user>@<host_ip> "update-cc 2.1.198"`
 
 **Incident downgrade:** because there is no `requiredMinimumVersion` floor, the
 host (or container) can be rolled back to an older known-good version the same way
@@ -199,6 +199,9 @@ When a new CC version is released, run through this:
 | 2.1.170 | 2026-06-10 | **Claude Fable 5 (Mythos-class)** model access; fixed sessions not saving transcripts (and missing from `--resume`) when launched from a shell that inherited CC env vars | **Upgraded to this version.** Fable 5 → separate eval follow-up (background sessions pin `--model`, so no leak). Transcript fix benefits Genesis background sessions (inherited-env spawn path). |
 | 2.1.172 | 2026-06-11 | Nested sub-agents (5 levels); long-conversation render perf + idle CPU reduction; background-agent fixes (project settings cross-read, stale-version attach EAUTH); `[1M][1m]` doubled-suffix fix; mouse tracking disabled on limited Windows consoles | Additive/fixes — recon classified informational. Background-agent fixes benefit Genesis dispatch paths. |
 | 2.1.173 | 2026-06-11 | Fable 5 model IDs with `[1m]` suffix now normalized (1M context is default); Windows sandbox warning fix | **Upgraded to this version (container).** Settings had `"model": "claude-fable-5[1m]"` — normalization removes suffix-handling edge cases. |
+| 2.1.174–2.1.196 | 2026-07-01 | Range reviewed via changelog. Overwhelmingly fixes + perf: **hook** matcher fixes (comma-separated matchers never firing @191, hyphenated matchers substring-matching @195, symlinked `.claude/settings.json` @176, `.claude/rules/` via symlinks @198); **skills** fixes (nested `.claude/skills` load + closest-cwd-wins @178, frontmatter accepts kebab/snake/camelCase @186, hot-reload no longer re-sends full listing @176, duplicate autocomplete @181/@183); **MCP** fixes (untrusted-workspace `.mcp.json` no longer auto-spawned @196 [security], `headersHelper` re-auth on 401/403 @193, discovery/OAuth retries @191, false "server disconnected" for retired tools @186); **headless/`-p`** fixes (auth-stub tools no longer exposed in headless/SDK mode @183, `--resume "No conversation found"` @187, structured-output infinite re-calling @186/@187); **auto-mode** safety (destructive git + terraform/pulumi/cdk destroy blocked @183, `Agent(type)` deny rules enforced for named spawns @186, denial reasons in transcript @193); **perf/memory** (~37% less streaming CPU + reduced long-session terminal-cache growth @191, idle-session history loss fixed @181). Removed the `TeamCreate`/`TeamDelete` tools @178 and the `/agents` wizard @198 — grep-verified **not referenced** anywhere in Genesis (`src/`, `.claude/`, `scripts/`). | No Genesis-breaking changes. Perf + session-stability fixes directly benefit long CC sessions (the marathon-session heap/history-loss class). No code change required. |
+| 2.1.197 | 2026-07-01 | **Claude Sonnet 5** becomes CC's default model (native 1M-token context, promotional pricing) | Genesis pins explicit models everywhere it calls CC (`--model`, cc-sonnet/cc-haiku/opus), so the changed *default* does not auto-apply to any Genesis path. Sonnet 5 adoption → separate eval. |
+| 2.1.198 | 2026-07-01 | Claude in Chrome GA; background agents auto-commit/push/draft-PR on finishing code work; built-in Explore agent inherits the session model (capped at opus); subagents + context compaction inherit extended-thinking config; `/dataviz` skill; `Notification` hook fires for background-agent completion; broad fullscreen/background/hook fixes | **Pin bumped to this version (container + host via `scripts/update.sh`).** Fullscreen renderer (the reason for the 2.1.173 pin) preserved and improved — no scrollback regression across the range. |
 
 ---
 

--- a/scripts/host-setup.sh
+++ b/scripts/host-setup.sh
@@ -1133,7 +1133,7 @@ if [ "$_host_node_ok" = "0" ]; then
 fi
 
 # CC version pin — single source of truth: scripts/lib/cc_version.sh
-# (2.1.173 = scrollback fullscreen-renderer fix — see docs/reference/cc-compatibility.md)
+# (2.1.198 = current pin; retains the 2.1.173 fullscreen-renderer scrollback fix — see docs/reference/cc-compatibility.md)
 _cc_env="$_SCRIPT_DIR/lib/cc_version.sh"
 if [ ! -f "$_cc_env" ]; then
     echo "ERROR: missing CC version pin: $_cc_env" >&2

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1157,7 +1157,7 @@ echo ""
 #  Step 12 — Claude Code install + login
 # ══════════════════════════════════════════════════════════════
 # CC version pin — single source of truth: scripts/lib/cc_version.sh
-# (2.1.173 = scrollback fullscreen-renderer fix — see docs/reference/cc-compatibility.md)
+# (2.1.198 = current pin; retains the 2.1.173 fullscreen-renderer scrollback fix — see docs/reference/cc-compatibility.md)
 _cc_env="$SCRIPT_DIR/lib/cc_version.sh"
 if [ ! -f "$_cc_env" ]; then
     echo "ERROR: missing CC version pin: $_cc_env" >&2

--- a/scripts/lib/cc_version.sh
+++ b/scripts/lib/cc_version.sh
@@ -17,7 +17,7 @@
 # removes the incident-recovery downgrade path and can brick CC.
 #
 # Honors an inherited CC_VERSION (e.g. `CC_VERSION=2.1.180 ./install.sh`).
-CC_VERSION="${CC_VERSION:-2.1.173}"
+CC_VERSION="${CC_VERSION:-2.1.198}"
 
 
 # cc_ensure_local — install or align the LOCAL Claude Code CLI to $CC_VERSION.


### PR DESCRIPTION
## What

Moves the single-source-of-truth Claude Code version pin
(`scripts/lib/cc_version.sh`) from **2.1.173 → 2.1.198** (current npm
`latest`). `install.sh` / `bootstrap.sh` / `host-setup.sh` / `update.sh`
all read this pin, so the next `update.sh` run aligns **both** the container
(via `cc_ensure_local`) and the host VM (via the guardian `update-cc` op)
with no drift.

## Why

The 25-release delta (2.1.174–2.1.198) is overwhelmingly fixes + perf. Highlights relevant to this install:

- **Session stability / perf** (directly on our marathon-session pain): ~37% less streaming CPU + reduced long-session terminal-cache memory growth (@191); idle-session history loss fixed (@181).
- **Hooks:** comma-separated matchers never firing (@191), hyphenated-matcher substring bug (@195), symlinked settings / `.claude/rules` (@176/@198) — we are hook-heavy.
- **Skills:** nested `.claude/skills` load + closest-cwd-wins (@178), frontmatter case tolerance (@186), hot-reload fix (@176).
- **MCP:** untrusted-workspace `.mcp.json` no longer auto-spawned (@196, security), `headersHelper` re-auth + discovery/OAuth retries (@191/@193).
- **Headless `-p`** (CCCliRouter / Guardian diagnosis / Evo): auth-stub tools no longer exposed in headless/SDK mode (@183), `--resume` fix (@187), structured-output re-calling fix (@186/@187).
- **Auto-mode safety:** destructive git + terraform/pulumi/cdk destroy blocked (@183), `Agent(type)` deny enforced (@186).
- **2.1.197 — Sonnet 5** becomes CC's default model (1M context). Genesis pins explicit models on every CC call, so no path auto-adopts it.

The fullscreen-renderer scrollback fix that motivated the 2.1.173 pin is **preserved and extended** across the range — no scrollback regression.

## Safety checks

- Removed features in range (`TeamCreate`/`TeamDelete` tools @178, `/agents` wizard @198) — grep-verified **unreferenced** in `src/`, `.claude/`, `scripts/`.
- `bash -n` clean on all three scripts; pin resolves to `2.1.198`.
- `cc_ensure_local` unit test (`spike_cc_ensure_local_test.sh`) green — it sources the pin dynamically, so its install assertions now target 2.1.198 (7/7 pass).

## Deploy (after merge)

`scripts/update.sh` — aligns container + host to the pin, then E2E re-verify via CCInvoker per the compat-doc checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)