### PR TITLE
fix(surplus): correct gap_clustering and wing_audit judge-expected strings

### DIFF
--- a/src/genesis/surplus/quality_judge.py
+++ b/src/genesis/surplus/quality_judge.py
@@ -81,10 +81,17 @@ _JUDGE_EXPECTED: dict[TaskType, str] = {
         "and references actual procedures or patterns."
     ),
     TaskType.GAP_CLUSTERING: (
-        "A clustered analysis of knowledge or capability gaps — coherent themes "
-        "grouped from underlying signals, each described specifically. Good output "
-        "is a structured set of real, distinguishable gap clusters, not a flat "
-        "generic list."
+        # Matches the executor's actual task (executor.py GAP_CLUSTERING prompt:
+        # "cluster recent unresolved observations into themes ... recurring
+        # patterns that suggest systemic issues"). An earlier draft graded against
+        # "knowledge/capability gaps", which false-hollowed correct systemic-issue
+        # theme clusterings — corrected 2026-07-01 from the calibration probe.
+        "A clustered analysis that groups recent unresolved observations into "
+        "recurring themes — patterns that suggest systemic issues rather than "
+        "one-off events. Good output is a structured set of real, distinguishable "
+        "themes (e.g. 'Theme 1: ...'), each named and supported with specific "
+        "evidence from the observations. A flat list of individual signals, or a "
+        "single one-off diagnostic that does not cluster, is not good output."
     ),
     TaskType.SELF_UNBLOCK: (
         "Concrete steps or a diagnosis to unblock a stuck goal or task. Good output "

--- a/src/genesis/surplus/quality_judge.py
+++ b/src/genesis/surplus/quality_judge.py
@@ -89,9 +89,10 @@ _JUDGE_EXPECTED: dict[TaskType, str] = {
         "A clustered analysis that groups recent unresolved observations into "
         "recurring themes — patterns that suggest systemic issues rather than "
         "one-off events. Good output is a structured set of real, distinguishable "
-        "themes (e.g. 'Theme 1: ...'), each named and supported with specific "
-        "evidence from the observations. A flat list of individual signals, or a "
-        "single one-off diagnostic that does not cluster, is not good output."
+        "named themes, each grouping several related observations and supported "
+        "with specific evidence (regardless of prose or JSON format). A flat list "
+        "of individual signals, or a single one-off diagnostic that does not "
+        "cluster, is not good output."
     ),
     TaskType.SELF_UNBLOCK: (
         "Concrete steps or a diagnosis to unblock a stuck goal or task. Good output "

--- a/src/genesis/surplus/quality_judge.py
+++ b/src/genesis/surplus/quality_judge.py
@@ -114,9 +114,20 @@ _JUDGE_EXPECTED: dict[TaskType, str] = {
         "found'). Good output is concrete and technically grounded, not vague."
     ),
     TaskType.WING_AUDIT: (
-        "A memory-taxonomy hygiene finding about wings/rooms — miscategorization, "
-        "sparse or overloaded domains, or structural improvements. Good output "
-        "names specific wings/rooms and concrete issues."
+        # Matches the executor's actual task (executor.py WING_AUDIT prompt:
+        # "identify clusters of related [currently-uncategorized] memories that
+        # should be reclassified into a more specific wing/room"). An earlier
+        # draft graded against auditing the EXISTING taxonomy for "miscategorization
+        # / sparse-or-overloaded domains", which would false-hollow correct
+        # reclassification proposals — corrected 2026-07-01 (same class of mismatch
+        # as GAP_CLUSTERING; caught by the broader-class scan, not empirically —
+        # WING_AUDIT has no completed tasks to grade).
+        "A finding that groups currently-uncategorized memories into clusters and "
+        "proposes a specific wing/room for each, naming the member memories and a "
+        "rationale for why the grouping improves retrieval. Good output is a "
+        "conservative, well-supported reclassification proposal (memories that "
+        "clearly belong together); a reasoned 'nothing clearly clusters' conclusion "
+        "is also valid. A vague comment that proposes no concrete grouping is not."
     ),
 }
 


### PR DESCRIPTION
The surplus quality judge grades each completed background insight task's output against a per-task-type description of what a good output looks like. Two of those descriptions did not match what the tasks actually produce, so correct outputs were being scored as low-quality:

- **gap_clustering** clusters recent unresolved observations into recurring themes that suggest systemic issues, but was graded against "knowledge or capability gaps" — so correct systemic-issue theme clusterings were failed on relevance.
- **wing_audit** proposes reclassifying currently-uncategorized memories into specific wings/rooms, but was graded against "auditing the existing taxonomy for miscategorization / sparse-or-overloaded domains" — so correct reclassification proposals would be failed.

Both descriptions are rewritten to match each task's actual prompt. The judge stays measurement-only — it never gates anything or changes intake routing; only the grading target for these two task types is corrected. No logic or threshold changes. The other nine task-type descriptions were checked and already match their tasks.

**Verification:** re-grading a real gap_clustering sample with the corrected description recovers 5 false-negative "hollow" verdicts with zero regressions (genuine non-clustering outputs stay hollow); synthetic wing_audit controls discriminate correctly. `ruff` clean; targeted tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)