### PR TITLE
feat(attention): PR3c-1 — A/B fire-set differ + config_version filter + l15 backfill

### DIFF
--- a/src/genesis/attention/consumers.py
+++ b/src/genesis/attention/consumers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import UTC, datetime
+from typing import Protocol, runtime_checkable
 
 import aiosqlite
 
@@ -17,6 +18,20 @@ from genesis.attention.types import AttentionEvent
 from genesis.db.crud import attention as attention_crud
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class ShadowConsumer(Protocol):
+    """Structural sink for the ``AttentionEvent``s ``run_shadow`` emits.
+
+    Buffer on ``add`` (sync), commit on ``flush`` (async, returns the count written).
+    ``ShadowStoreConsumer`` persists to genesis.db; an in-memory collector (the PR3c-1
+    differ) captures the full fire-set; a ``JSONLConsumer`` edge sink slots in later — all
+    satisfy this contract, so ``run_shadow`` need not know which concrete sink it holds."""
+
+    def add(self, ev: AttentionEvent) -> None: ...
+
+    async def flush(self) -> int: ...
 
 
 def _iso(epoch: float) -> str:

--- a/src/genesis/attention/differ.py
+++ b/src/genesis/attention/differ.py
@@ -65,9 +65,10 @@ class DiffResult:
     baseline_n: int
     candidate_n: int
     added: list[FireRecord]                            # fired in candidate, not baseline
-    removed: list[FireRecord]                          # fired in baseline, not candidate
-    activation_changed: list[tuple[int, str, str]]     # (key, baseline_act, candidate_act)
-    by_trigger_delta: dict[str, tuple[int, int, int]]  # name -> (baseline_n, candidate_n, delta)
+    removed: list[FireRecord]                           # fired in baseline, not candidate
+    activation_changed: list[tuple[int, str, str]]      # (key, baseline_act, candidate_act)
+    by_trigger_delta: dict[str, tuple[int, int, int]]   # name -> (baseline_n, candidate_n, delta)
+    by_suppressor_delta: dict[str, tuple[int, int, int]]  # name -> (baseline_n, candidate_n, delta)
     unresolvable: dict[str, int] = field(default_factory=dict)  # per side: rows skipped (empty utt_ids)
 
 
@@ -96,17 +97,21 @@ def diff_fire_sets(
         if b_by_key[k].activation != c_by_key[k].activation
     ]
 
-    b_trig = Counter(t for r in baseline for t in r.triggers)
-    c_trig = Counter(t for r in candidate for t in r.triggers)
-    by_trigger_delta = {
-        name: (b_trig[name], c_trig[name], c_trig[name] - b_trig[name])
-        for name in sorted(set(b_trig) | set(c_trig))
-    }
+    by_trigger_delta = _count_delta(baseline, candidate, lambda r: r.triggers)
+    by_suppressor_delta = _count_delta(baseline, candidate, lambda r: r.suppressors)
 
     return DiffResult(
         baseline_label, candidate_label, len(baseline), len(candidate),
-        added, removed, activation_changed, by_trigger_delta, unresolvable or {},
+        added, removed, activation_changed, by_trigger_delta, by_suppressor_delta,
+        unresolvable or {},
     )
+
+
+def _count_delta(baseline, candidate, extract) -> dict[str, tuple[int, int, int]]:
+    """Per-name (baseline_n, candidate_n, delta), each name counted once per record it's in."""
+    b = Counter(name for r in baseline for name in extract(r))
+    c = Counter(name for r in candidate for name in extract(r))
+    return {name: (b[name], c[name], c[name] - b[name]) for name in sorted(set(b) | set(c))}
 
 
 # ── mappers (persisted row / live event → FireRecord) ─────────────────────────────
@@ -214,6 +219,11 @@ def format_diff(d: DiffResult, *, sample: int = 12) -> str:
     for name, (b, c, delta) in sorted(d.by_trigger_delta.items(), key=lambda x: (-abs(x[1][2]), x[0])):
         sign = "+" if delta > 0 else ""
         lines.append(f"  {name:<22} {b:>5} -> {c:<5} ({sign}{delta})")
+    if d.by_suppressor_delta:
+        lines.append("\n--- by_suppressor delta (baseline -> candidate) ---")
+        for name, (b, c, delta) in sorted(d.by_suppressor_delta.items(), key=lambda x: (-abs(x[1][2]), x[0])):
+            sign = "+" if delta > 0 else ""
+            lines.append(f"  {name:<22} {b:>5} -> {c:<5} ({sign}{delta})")
     if d.activation_changed:
         lines.append(f"\n--- sample activation changes ({min(len(d.activation_changed), sample)} of {len(d.activation_changed)}) ---")
         for k, fr, to in d.activation_changed[:sample]:

--- a/src/genesis/attention/differ.py
+++ b/src/genesis/attention/differ.py
@@ -1,0 +1,269 @@
+"""A/B fire-set differ for the attention engine's shadow gate (offline calibration, PR3c-1).
+
+Diffs two config versions' FIRE-SETS over the SAME ambient snapshot — which utterances each
+config perked up on — so a taxonomy/weight change (e.g. PR3a's ``0.1.0-default`` →
+``0.2.0-taxonomy``) can be evaluated OBJECTIVELY (events added / removed / activation-changed
++ a per-trigger delta) instead of by eyeballing ``by_trigger`` counts.
+
+Each side is a list of ``FireRecord``s keyed by the TRIGGER utterance id (the window end).
+A side comes from ONE of two sources:
+
+  * **persisted rows** — ``attention_events`` for a ``config_version`` (how ``0.1.0-default``'s
+    326 already-run rows are read; its config no longer exists in code — PR3a overwrote it);
+  * **a live re-score** — ``run_shadow`` under the CURRENT config over the snapshot (how a
+    fresh config's fire-set is produced without persisting anything; ``ShadowReport`` discards
+    the full event list, so a ``_Collector`` captures it).
+
+Both sources read the SAME snapshot, so the utterance-id spaces align and the sets compare 1:1.
+"Fire-set" = every ``AttentionEvent`` emitted, i.e. HARD/SOFT perks AND SUPPRESSED vetoes
+(``evaluate`` emits suppressed events too) — so a soft→suppressed shift shows as an
+activation change, not a phantom add/remove.
+
+Value-free: derives refs + trigger NAMES + activation only — NEVER transcript text (firewall).
+A genesis-side ADAPTER (imports aiosqlite/runner) — NOT one of the six edge-portable core
+modules and NOT imported by ``attention/__init__``.
+
+    python -m genesis.attention.differ --baseline 0.1.0-default --rescore \\
+        --snapshot ~/.genesis/attention/snapshots/ambient_20260701T013412Z.db
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import aiosqlite
+
+from genesis.attention.config import AttentionConfig
+from genesis.attention.runner import load_runner_config, run_shadow
+from genesis.attention.types import AttentionEvent
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class FireRecord:
+    """One config's decision for a trigger utterance: activation + which names fired.
+
+    ``key`` = the trigger-utterance id (window end) — the join key across the two sides,
+    matching ``consumers._to_row``'s ``utt_ids[-1]`` row-id derivation."""
+
+    key: int
+    activation: str                 # "hard" / "soft" / "suppressed"
+    triggers: frozenset[str]        # trigger NAMES only (no weights, no text)
+    suppressors: frozenset[str]
+
+
+@dataclass
+class DiffResult:
+    baseline_label: str
+    candidate_label: str
+    baseline_n: int
+    candidate_n: int
+    added: list[FireRecord]                            # fired in candidate, not baseline
+    removed: list[FireRecord]                          # fired in baseline, not candidate
+    activation_changed: list[tuple[int, str, str]]     # (key, baseline_act, candidate_act)
+    by_trigger_delta: dict[str, tuple[int, int, int]]  # name -> (baseline_n, candidate_n, delta)
+    unresolvable: dict[str, int] = field(default_factory=dict)  # per side: rows skipped (empty utt_ids)
+
+
+def diff_fire_sets(
+    baseline: list[FireRecord],
+    candidate: list[FireRecord],
+    *,
+    baseline_label: str = "baseline",
+    candidate_label: str = "candidate",
+    unresolvable: dict[str, int] | None = None,
+) -> DiffResult:
+    """PURE set/dict diff of two fire-sets keyed by trigger-utt id. No IO, no LLM, no labels.
+
+    A key present on both sides with a different ``activation`` is an activation change (NOT
+    an add+remove). ``by_trigger_delta`` counts each trigger once per record it appears in
+    (mirroring the ``trigger_stats`` crud aggregate)."""
+    b_by_key = {r.key: r for r in baseline}
+    c_by_key = {r.key: r for r in candidate}
+    b_keys, c_keys = set(b_by_key), set(c_by_key)
+
+    added = [c_by_key[k] for k in sorted(c_keys - b_keys)]
+    removed = [b_by_key[k] for k in sorted(b_keys - c_keys)]
+    activation_changed = [
+        (k, b_by_key[k].activation, c_by_key[k].activation)
+        for k in sorted(b_keys & c_keys)
+        if b_by_key[k].activation != c_by_key[k].activation
+    ]
+
+    b_trig = Counter(t for r in baseline for t in r.triggers)
+    c_trig = Counter(t for r in candidate for t in r.triggers)
+    by_trigger_delta = {
+        name: (b_trig[name], c_trig[name], c_trig[name] - b_trig[name])
+        for name in sorted(set(b_trig) | set(c_trig))
+    }
+
+    return DiffResult(
+        baseline_label, candidate_label, len(baseline), len(candidate),
+        added, removed, activation_changed, by_trigger_delta, unresolvable or {},
+    )
+
+
+# ── mappers (persisted row / live event → FireRecord) ─────────────────────────────
+
+def _record_from_row(row: dict) -> FireRecord | None:
+    """Map a persisted ``attention_events`` row (JSON columns still strings) → FireRecord.
+
+    Returns None for a degenerate row whose ``window_ref`` has no ``utt_ids`` (the ``"x"``
+    fallback in ``consumers._to_row``) — the caller counts these as ``unresolvable``."""
+    wr = json.loads(row["window_ref"]) if row.get("window_ref") else {}
+    utt_ids = wr.get("utt_ids") or []
+    if not utt_ids:
+        return None
+    hits = json.loads(row["triggers_fired"]) if row.get("triggers_fired") else []
+    triggers = frozenset(h["name"] for h in hits if h.get("name"))
+    suppressors = frozenset(json.loads(row["suppressors"]) if row.get("suppressors") else [])
+    return FireRecord(int(utt_ids[-1]), row["activation"], triggers, suppressors)
+
+
+def _record_from_event(ev: AttentionEvent) -> FireRecord | None:
+    """Map a live ``AttentionEvent`` (rescore side) → FireRecord (None if no window)."""
+    utt_ids = ev.window_ref.utt_ids
+    if not utt_ids:
+        return None
+    return FireRecord(
+        int(utt_ids[-1]),
+        ev.activation.value,
+        frozenset(h.name for h in ev.triggers_fired),
+        frozenset(ev.suppressors),
+    )
+
+
+# ── IO adapters (persisted DB read / live re-score) ───────────────────────────────
+
+class _Collector:
+    """In-memory ``ShadowConsumer`` — captures the FULL fire-set ``ShadowReport`` discards.
+
+    Satisfies the ``ShadowConsumer`` Protocol (``add`` + async ``flush``). ``flush`` writes
+    nothing (returns 0 → ``ShadowReport.persisted == 0``); the differ reads ``self.events``."""
+
+    def __init__(self) -> None:
+        self.events: list[AttentionEvent] = []
+
+    def add(self, ev: AttentionEvent) -> None:
+        self.events.append(ev)
+
+    async def flush(self) -> int:
+        return 0
+
+
+async def load_from_db(db_path: str | Path, config_version: str) -> tuple[list[FireRecord], int]:
+    """Fire-set for a PERSISTED config_version, read from a READ-ONLY genesis.db connection.
+
+    Opens its own ``aiosqlite`` connection (``?mode=ro`` — the differ never writes) and sets
+    ``row_factory = aiosqlite.Row`` (the crud reads assume it). Returns (records, n_unresolvable)."""
+    from genesis.db.crud import attention as attention_crud
+
+    uri = f"file:{Path(db_path).expanduser()}?mode=ro"
+    conn = await aiosqlite.connect(uri, uri=True)
+    try:
+        conn.row_factory = aiosqlite.Row
+        rows = await attention_crud.load_fire_records(conn, config_version)
+    finally:
+        await conn.close()
+    return _map_records(_record_from_row, rows)
+
+
+async def rescore(snapshot_path: str | Path, config: AttentionConfig) -> tuple[list[FireRecord], int]:
+    """Fire-set from a LIVE re-score of the snapshot under ``config``. Returns (records, n_unresolvable).
+
+    Reuses ``run_shadow`` (blip-skip + evaluate) via an in-memory ``_Collector``; persists nothing."""
+    collector = _Collector()
+    await run_shadow(snapshot_path, config, consumer=collector)
+    return _map_records(_record_from_event, collector.events)
+
+
+def _map_records(mapper, items) -> tuple[list[FireRecord], int]:
+    """Apply ``mapper`` to each item; split into resolved records + a count of unresolvable ones."""
+    records: list[FireRecord] = []
+    unresolvable = 0
+    for item in items:
+        rec = mapper(item)
+        if rec is None:
+            unresolvable += 1
+        else:
+            records.append(rec)
+    return records, unresolvable
+
+
+# ── report ────────────────────────────────────────────────────────────────────────
+
+def format_diff(d: DiffResult, *, sample: int = 12) -> str:
+    """Human-readable diff (utt ids + trigger names + activations only — NEVER text)."""
+    lines = [
+        "\n=== ATTENTION A/B FIRE-SET DIFF ===",
+        f"baseline  [{d.baseline_label}]  fires={d.baseline_n}",
+        f"candidate [{d.candidate_label}]  fires={d.candidate_n}",
+        f"  added     (candidate only): {len(d.added)}",
+        f"  removed   (baseline only):  {len(d.removed)}",
+        f"  activation-changed (both):  {len(d.activation_changed)}",
+    ]
+    if d.unresolvable and any(d.unresolvable.values()):
+        lines.append(f"  unresolvable (empty utt_ids, skipped): {d.unresolvable}")
+    lines.append("\n--- by_trigger delta (baseline -> candidate, largest movers first) ---")
+    for name, (b, c, delta) in sorted(d.by_trigger_delta.items(), key=lambda x: (-abs(x[1][2]), x[0])):
+        sign = "+" if delta > 0 else ""
+        lines.append(f"  {name:<22} {b:>5} -> {c:<5} ({sign}{delta})")
+    if d.activation_changed:
+        lines.append(f"\n--- sample activation changes ({min(len(d.activation_changed), sample)} of {len(d.activation_changed)}) ---")
+        for k, fr, to in d.activation_changed[:sample]:
+            lines.append(f"  utt {k}: {fr} -> {to}")
+    for label, recs in (("added", d.added), ("removed", d.removed)):
+        if recs:
+            lines.append(f"\n--- sample {label} ({min(len(recs), sample)} of {len(recs)}) ---")
+            for r in recs[:sample]:
+                lines.append(f"  utt {r.key}: [{r.activation}] {sorted(r.triggers)}")
+    return "\n".join(lines)
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────────--
+
+async def _run(args) -> DiffResult:
+    from genesis.env import genesis_db_path
+
+    db_path = args.db or str(genesis_db_path())
+    baseline, b_unres = await load_from_db(db_path, args.baseline)
+    if args.candidate:
+        candidate, c_unres = await load_from_db(db_path, args.candidate)
+        cand_label = args.candidate
+    else:  # --rescore (the default when no --candidate)
+        cfg = load_runner_config(args.config)
+        candidate, c_unres = await rescore(args.snapshot, cfg)
+        cand_label = f"rescore:{cfg.version}"
+    return diff_fire_sets(
+        baseline, candidate,
+        baseline_label=args.baseline, candidate_label=cand_label,
+        unresolvable={args.baseline: b_unres, cand_label: c_unres},
+    )
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    ap = argparse.ArgumentParser(description="Attention A/B fire-set differ (offline calibration)")
+    ap.add_argument("--baseline", required=True,
+                    help="PERSISTED config_version for side A (e.g. 0.1.0-default)")
+    g = ap.add_mutually_exclusive_group()
+    g.add_argument("--candidate", help="PERSISTED config_version for side B")
+    g.add_argument("--rescore", action="store_true",
+                   help="side B = live re-score of --snapshot under the current config (default)")
+    ap.add_argument("--snapshot", help="snapshot .db for --rescore")
+    ap.add_argument("--config", help="attention_config.json for --rescore (default: overlay/built-in)")
+    ap.add_argument("--db", help="genesis.db path (default: genesis_db_path())")
+    args = ap.parse_args()
+    if not args.candidate and not args.snapshot:
+        ap.error("--rescore (default) requires --snapshot PATH")
+    print(format_diff(asyncio.run(_run(args))))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/genesis/attention/runner.py
+++ b/src/genesis/attention/runner.py
@@ -28,7 +28,7 @@ from genesis.attention.config import (
     default_config_dict,
     load_config,
 )
-from genesis.attention.consumers import ShadowStoreConsumer
+from genesis.attention.consumers import ShadowConsumer, ShadowStoreConsumer
 from genesis.attention.engine import evaluate
 from genesis.attention.snapshot import pull_snapshot
 from genesis.attention.sources import SnapshotSource
@@ -85,7 +85,7 @@ async def run_shadow(
     *,
     snapshot_id: str = "adhoc",
     sample_n: int = 25,
-    consumer: ShadowStoreConsumer | None = None,
+    consumer: ShadowConsumer | None = None,
     sampler: AttentionSampler | None = None,
 ) -> ShadowReport:
     src = SnapshotSource(snapshot_path)

--- a/src/genesis/dashboard/routes/attention.py
+++ b/src/genesis/dashboard/routes/attention.py
@@ -85,13 +85,14 @@ async def attention_list():
     trigger = request.args.get("trigger") or None
     is_user = request.args.get("is_user", "").lower() == "true"
     unlabeled = request.args.get("unlabeled", "").lower() == "true"
+    config_version = request.args.get("config_version") or None
     limit = max(1, min(request.args.get("limit", 200, type=int), 500))
     offset = max(0, request.args.get("offset", 0, type=int))
 
     try:
         rows = await attention_crud.list_events(
             rt.db, activation=activation, trigger=trigger, is_user=is_user,
-            unlabeled=unlabeled, limit=limit, offset=offset,
+            unlabeled=unlabeled, config_version=config_version, limit=limit, offset=offset,
         )
         events = [_event_summary(r) for r in rows]
         return jsonify({"events": events, "count": len(events)})
@@ -103,7 +104,11 @@ async def attention_list():
 @blueprint.route("/api/genesis/attention/stats")
 @_async_route
 async def attention_stats():
-    """Aggregate counts for the cockpit panel: labels, activation, per-trigger, suppressors."""
+    """Aggregate counts for the cockpit panel: labels, activation, per-trigger, suppressors.
+
+    ``config_version`` scopes the four count aggregates to one shadow-run config (so the
+    dominance bar doesn't mix versions once a 2nd config persists); ``config_versions`` is
+    always the FULL set (it populates the filter dropdown)."""
     if (resp := _auth_or_403()) is not None:
         return resp
     from genesis.db.crud import attention as attention_crud
@@ -113,12 +118,14 @@ async def attention_stats():
     if not rt.is_bootstrapped or rt.db is None:
         return jsonify({"error": "Not bootstrapped"}), 503
 
+    config_version = request.args.get("config_version") or None
     try:
         return jsonify({
-            "labels": await attention_crud.label_counts(rt.db),
-            "by_activation": await attention_crud.activation_stats(rt.db),
-            "by_trigger": await attention_crud.trigger_stats(rt.db),
-            "by_suppressor": await attention_crud.suppressor_stats(rt.db),
+            "labels": await attention_crud.label_counts(rt.db, config_version),
+            "by_activation": await attention_crud.activation_stats(rt.db, config_version),
+            "by_trigger": await attention_crud.trigger_stats(rt.db, config_version),
+            "by_suppressor": await attention_crud.suppressor_stats(rt.db, config_version),
+            "config_versions": await attention_crud.config_versions(rt.db),
         })
     except Exception:
         logger.exception("Attention stats failed")

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -239,7 +239,7 @@
         // ── Attention review tab state ──
         attentionEvents: [],
         attentionStats: null,
-        attentionFilters: { activation: "", trigger: "", is_user: false, unlabeled: true },
+        attentionFilters: { activation: "", trigger: "", is_user: false, unlabeled: true, config_version: "" },
         attentionRevealed: {},   // {event_id: [window rows] | "unavailable"}
         attentionLabeling: {},   // {event_id: true} while a label POST is in flight
 
@@ -1621,6 +1621,7 @@
           if (f.trigger) p.set("trigger", f.trigger);
           if (f.is_user) p.set("is_user", "true");
           if (f.unlabeled) p.set("unlabeled", "true");
+          if (f.config_version) p.set("config_version", f.config_version);
           return p.toString();
         },
         async fetchAttentionEvents() {
@@ -1631,7 +1632,9 @@
         },
         async fetchAttentionStats() {
           try {
-            const resp = await fetchApi("/api/genesis/attention/stats");
+            const cv = this.attentionFilters.config_version;
+            const qs = cv ? `?config_version=${encodeURIComponent(cv)}` : "";
+            const resp = await fetchApi(`/api/genesis/attention/stats${qs}`);
             if (resp && resp.ok) { this.attentionStats = await resp.json(); }
           } catch (e) { console.warn("Attention stats failed:", e); }
         },
@@ -10665,6 +10668,14 @@
           <option value="">All triggers</option>
           <template x-for="name in Object.keys($store.genesisDashboard.attentionStats?.by_trigger || {})" :key="name">
             <option :value="name" x-text="name"></option>
+          </template>
+        </select>
+        <!-- config_version: rescopes BOTH the list AND the stats panel (else the dominance bar mixes versions) -->
+        <select x-model="$store.genesisDashboard.attentionFilters.config_version" @change="$store.genesisDashboard.fetchAttentionEvents(); $store.genesisDashboard.fetchAttentionStats()"
+                style="padding: .4rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
+          <option value="">All versions</option>
+          <template x-for="v in ($store.genesisDashboard.attentionStats?.config_versions || [])" :key="v">
+            <option :value="v" x-text="v"></option>
           </template>
         </select>
         <label style="font-size:.8rem; display:flex; align-items:center; gap:.3rem;">

--- a/src/genesis/db/crud/attention.py
+++ b/src/genesis/db/crud/attention.py
@@ -12,6 +12,8 @@ the ``kind`` values and JSON keys).
 """
 from __future__ import annotations
 
+import json
+
 import aiosqlite
 
 # Column order — the offline runner's row tuples (ShadowStoreConsumer._to_row) MUST match.
@@ -72,6 +74,7 @@ async def list_events(
     is_user: bool = False,
     unlabeled: bool = False,
     session_id: str | None = None,
+    config_version: str | None = None,
     limit: int = 200,
     offset: int = 0,
 ) -> list[dict]:
@@ -80,12 +83,16 @@ async def list_events(
     ``trigger`` filters to events whose ``triggers_fired`` contains a hit with that exact
     ``name`` (via ``json_each``, not ``LIKE``). ``is_user=True`` additionally requires the
     ``is_user`` trigger — i.e. the *trigger utterance* (window end) had ``is_user=1``.
-    ``unlabeled=True`` restricts to ``acceptance_signal IS NULL`` (the review queue)."""
+    ``unlabeled=True`` restricts to ``acceptance_signal IS NULL`` (the review queue).
+    ``config_version`` scopes to one shadow-run config (the calibration A/B filter — PR3c-1)."""
     where: list[str] = []
     params: list = []
     if activation is not None:
         where.append("activation = ?")
         params.append(activation)
+    if config_version is not None:
+        where.append("config_version = ?")
+        params.append(config_version)
     if session_id is not None:
         where.append("session_id = ?")
         params.append(session_id)
@@ -139,39 +146,63 @@ async def update_acceptance_signal(
 
 
 # ── aggregates for the cockpit stats panel (all counts — never text) ──────────────
+#
+# Each aggregate accepts an optional ``config_version`` so the stats panel can scope to
+# ONE shadow-run config (PR3c-1's A/B filter) — otherwise, the moment a 2nd config_version
+# is persisted, the dominance bar would mix versions while the list filters correctly.
+# ``config_versions()`` itself stays UNFILTERED (the dropdown must list every version).
 
-async def activation_stats(db: aiosqlite.Connection) -> dict:
+def _cv_clause(config_version: str | None, *, alias: str = "") -> tuple[str, tuple]:
+    """WHERE fragment (leading space) + params for an optional config_version filter.
+
+    ``alias`` prefixes the column for the json_each aggregates (``ae.config_version``)."""
+    if config_version is None:
+        return "", ()
+    col = f"{alias}.config_version" if alias else "config_version"
+    return f" WHERE {col} = ?", (config_version,)
+
+
+async def activation_stats(db: aiosqlite.Connection, config_version: str | None = None) -> dict:
     """Per-activation event counts (hard / soft / suppressed) — the fire-rate breakdown."""
+    where, params = _cv_clause(config_version)
     cursor = await db.execute(
-        "SELECT activation, COUNT(*) AS n FROM attention_events GROUP BY activation"
+        f"SELECT activation, COUNT(*) AS n FROM attention_events{where} GROUP BY activation",  # noqa: S608
+        params,
     )
     return {r["activation"]: r["n"] for r in await cursor.fetchall()}
 
 
-async def trigger_stats(db: aiosqlite.Connection) -> dict:
+async def trigger_stats(db: aiosqlite.Connection, config_version: str | None = None) -> dict:
     """Per-trigger fire counts (the dominance bar) — exact name via json_each."""
+    where, params = _cv_clause(config_version, alias="ae")
     cursor = await db.execute(
         "SELECT json_extract(je.value, '$.name') AS name, COUNT(*) AS n "
-        "FROM attention_events ae, json_each(ae.triggers_fired) je "
-        "GROUP BY name ORDER BY n DESC"
+        f"FROM attention_events ae, json_each(ae.triggers_fired) je{where} "  # noqa: S608
+        "GROUP BY name ORDER BY n DESC",
+        params,
     )
     return {r["name"]: r["n"] for r in await cursor.fetchall()}
 
 
-async def suppressor_stats(db: aiosqlite.Connection) -> dict:
+async def suppressor_stats(db: aiosqlite.Connection, config_version: str | None = None) -> dict:
     """Per-suppressor hit counts (``suppressors`` is a JSON array of names)."""
+    where, params = _cv_clause(config_version, alias="ae")
     cursor = await db.execute(
         "SELECT je.value AS name, COUNT(*) AS n "
-        "FROM attention_events ae, json_each(ae.suppressors) je "
-        "GROUP BY name ORDER BY n DESC"
+        f"FROM attention_events ae, json_each(ae.suppressors) je{where} "  # noqa: S608
+        "GROUP BY name ORDER BY n DESC",
+        params,
     )
     return {r["name"]: r["n"] for r in await cursor.fetchall()}
 
 
-async def label_counts(db: aiosqlite.Connection) -> dict:
+async def label_counts(db: aiosqlite.Connection, config_version: str | None = None) -> dict:
     """total / labeled / unlabeled + a by-signal breakdown."""
+    where, params = _cv_clause(config_version)
     cursor = await db.execute(
-        "SELECT acceptance_signal, COUNT(*) AS n FROM attention_events GROUP BY acceptance_signal"
+        f"SELECT acceptance_signal, COUNT(*) AS n FROM attention_events{where} "  # noqa: S608
+        "GROUP BY acceptance_signal",
+        params,
     )
     by_signal: dict[str, int] = {}
     unlabeled = 0
@@ -189,3 +220,46 @@ async def label_counts(db: aiosqlite.Connection) -> dict:
         "unlabeled": unlabeled,
         "by_signal": by_signal,
     }
+
+
+async def config_versions(db: aiosqlite.Connection) -> list[str]:
+    """Every distinct ``config_version`` present (UNFILTERED — populates the A/B dropdown)."""
+    cursor = await db.execute(
+        "SELECT DISTINCT config_version FROM attention_events "
+        "WHERE config_version IS NOT NULL ORDER BY config_version"
+    )
+    return [r["config_version"] for r in await cursor.fetchall()]
+
+
+# ── calibration tooling (PR3c-1) ──────────────────────────────────────────────────
+
+async def load_fire_records(db: aiosqlite.Connection, config_version: str) -> list[dict]:
+    """Value-free rows for the A/B fire-set differ: every event of ONE config_version.
+
+    Returns raw dicts (``id``/``activation``/``triggers_fired``/``suppressors``/``window_ref``
+    with the JSON columns still strings) — the differ parses + maps them to fire-records.
+    ALL rows, UNPAGED (the differ needs the full set, not the 500-capped review page).
+    Assumes ``db.row_factory = aiosqlite.Row`` (the caller sets it — see differ.load_from_db)."""
+    cursor = await db.execute(
+        "SELECT id, activation, triggers_fired, suppressors, window_ref "
+        "FROM attention_events WHERE config_version = ? ORDER BY ts",
+        (config_version,),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def update_l15_verdict(
+    db: aiosqlite.Connection, event_id: str, verdict: dict | None,
+) -> bool:
+    """Backfill/refresh an event's L1.5 ``l15_verdict`` (a MACHINE field). Returns found.
+
+    UNCONDITIONAL (no ``acceptance_signal IS NULL`` guard) — unlike ``bulk_upsert_events``,
+    which guards the human label. ``l15_verdict`` carries no human input, so a later
+    ``--l15`` run may safely refresh it even on an already-LABELED row (the label/verdict
+    correlation workflow PR3c-2 needs). Stored floats-only (mirrors ``consumers._to_row``)."""
+    payload = json.dumps(verdict) if verdict is not None else None
+    cursor = await db.execute(
+        "UPDATE attention_events SET l15_verdict = ? WHERE id = ?", (payload, event_id)
+    )
+    await db.commit()
+    return cursor.rowcount > 0

--- a/tests/test_attention/test_differ.py
+++ b/tests/test_attention/test_differ.py
@@ -71,7 +71,16 @@ def test_by_trigger_delta_counts_per_record():
 def test_empty_sides():
     d = diff_fire_sets([], [])
     assert d.added == [] and d.removed == [] and d.by_trigger_delta == {}
+    assert d.by_suppressor_delta == {}
     assert d.baseline_n == 0 and d.candidate_n == 0
+
+
+def test_by_suppressor_delta():
+    base = [_fr(1, activation="soft", suppressors=())]
+    cand = [_fr(1, activation="suppressed", suppressors=("explicit_dismissal",))]
+    d = diff_fire_sets(base, cand)
+    assert d.by_suppressor_delta == {"explicit_dismissal": (0, 1, 1)}
+    assert d.activation_changed == [(1, "soft", "suppressed")]  # the suppression also shows as an activation change
 
 
 def test_added_and_removed_sorted_by_key():

--- a/tests/test_attention/test_differ.py
+++ b/tests/test_attention/test_differ.py
@@ -1,0 +1,226 @@
+"""differ: PURE A/B fire-set diff + row/event mappers + collector + load_from_db (temp RO DB).
+
+The rescore IO path (run_shadow + _Collector over a real snapshot) is covered by the
+mid-build real-corpus checkpoint / E2E, not a unit — here we unit its pure pieces
+(_record_from_event, _Collector) and diff logic."""
+import json
+
+import aiosqlite
+import pytest
+
+from genesis.attention.consumers import ShadowConsumer
+from genesis.attention.differ import (
+    FireRecord,
+    _Collector,
+    _record_from_event,
+    _record_from_row,
+    diff_fire_sets,
+    format_diff,
+    load_from_db,
+)
+from genesis.attention.types import (
+    Activation,
+    AttentionEvent,
+    TriggerHit,
+    TriggerKind,
+    WindowRef,
+)
+from genesis.db.crud import attention as crud
+from genesis.db.schema._tables import INDEXES, TABLES
+
+
+def _fr(key, activation="soft", triggers=("multi_speaker",), suppressors=()):
+    return FireRecord(key, activation, frozenset(triggers), frozenset(suppressors))
+
+
+# ── pure diff (the tested heart) ─────────────────────────────────────────────
+
+def test_identical_sets_no_diff():
+    a = [_fr(1), _fr(2, triggers=("question",))]
+    d = diff_fire_sets(a, list(a))
+    assert d.added == [] and d.removed == [] and d.activation_changed == []
+    assert all(delta == 0 for _, _, delta in d.by_trigger_delta.values())
+    assert d.baseline_n == 2 and d.candidate_n == 2
+
+
+def test_pure_add():
+    d = diff_fire_sets([_fr(1)], [_fr(1), _fr(2, triggers=("decision",))])
+    assert [r.key for r in d.added] == [2] and d.removed == []
+    assert d.by_trigger_delta["decision"] == (0, 1, 1)
+
+
+def test_pure_remove():
+    d = diff_fire_sets([_fr(1), _fr(2)], [_fr(1)])
+    assert [r.key for r in d.removed] == [2] and d.added == []
+
+
+def test_activation_change_is_not_add_remove():
+    d = diff_fire_sets([_fr(5, activation="soft")], [_fr(5, activation="suppressed")])
+    assert d.added == [] and d.removed == []
+    assert d.activation_changed == [(5, "soft", "suppressed")]
+
+
+def test_by_trigger_delta_counts_per_record():
+    base = [_fr(1, triggers=("multi_speaker", "question")), _fr(2, triggers=("multi_speaker",))]
+    cand = [_fr(1, triggers=("multi_speaker",))]  # utt2 dropped; utt1 lost 'question'
+    d = diff_fire_sets(base, cand)
+    assert d.by_trigger_delta["multi_speaker"] == (2, 1, -1)
+    assert d.by_trigger_delta["question"] == (1, 0, -1)
+
+
+def test_empty_sides():
+    d = diff_fire_sets([], [])
+    assert d.added == [] and d.removed == [] and d.by_trigger_delta == {}
+    assert d.baseline_n == 0 and d.candidate_n == 0
+
+
+def test_added_and_removed_sorted_by_key():
+    d = diff_fire_sets([_fr(8)], [_fr(9), _fr(3), _fr(7)])
+    assert [r.key for r in d.added] == [3, 7, 9]
+    assert [r.key for r in d.removed] == [8]
+
+
+def test_labels_and_unresolvable_passthrough():
+    d = diff_fire_sets(
+        [], [], baseline_label="0.1.0-default", candidate_label="rescore:0.2.0-taxonomy",
+        unresolvable={"0.1.0-default": 2},
+    )
+    assert d.baseline_label == "0.1.0-default"
+    assert d.candidate_label == "rescore:0.2.0-taxonomy"
+    assert d.unresolvable == {"0.1.0-default": 2}
+
+
+def test_format_diff_is_text_only_no_crash():
+    out = format_diff(diff_fire_sets([_fr(1)], [_fr(2, triggers=("decision",))]))
+    assert "FIRE-SET DIFF" in out and "decision" in out and "utt 2" in out
+
+
+# ── mappers ──────────────────────────────────────────────────────────────────
+
+def _row_dict(
+    utt_ids=(21051,),
+    activation="soft",
+    triggers=(("question", "soft", 0.3), ("multi_speaker", "soft", 0.4)),
+    suppressors=(),
+):
+    return {
+        "id": "x",
+        "activation": activation,
+        "triggers_fired": json.dumps([{"name": n, "kind": k, "contribution": c} for n, k, c in triggers]),
+        "suppressors": json.dumps(list(suppressors)),
+        "window_ref": json.dumps(
+            {"snapshot_id": "s", "session_id": "s1", "utt_ids": list(utt_ids), "ts_start": 0.0, "ts_end": 1.0}
+        ),
+    }
+
+
+def test_record_from_row_happy():
+    assert _record_from_row(_row_dict()) == FireRecord(
+        21051, "soft", frozenset({"question", "multi_speaker"}), frozenset()
+    )
+
+
+def test_record_from_row_keys_on_last_utt():
+    assert _record_from_row(_row_dict(utt_ids=(10, 20, 30))).key == 30
+
+
+def test_record_from_row_carries_suppressors():
+    r = _record_from_row(_row_dict(activation="suppressed", suppressors=("explicit_dismissal",)))
+    assert r.activation == "suppressed" and r.suppressors == frozenset({"explicit_dismissal"})
+
+
+def test_record_from_row_empty_utt_ids_none():
+    assert _record_from_row(_row_dict(utt_ids=())) is None
+
+
+def test_record_from_row_null_json_columns_safe():
+    assert _record_from_row(
+        {"id": "x", "activation": "soft", "window_ref": None, "triggers_fired": None, "suppressors": None}
+    ) is None
+
+
+def _event(utt_ids=(5,), activation=Activation.SOFT, triggers=("question",), suppressors=()):
+    return AttentionEvent(
+        activation=activation, score=0.6,
+        triggers_fired=tuple(TriggerHit(n, TriggerKind.SOFT, 0.3) for n in triggers),
+        suppressors=tuple(suppressors), session_id="s1",
+        window_ref=WindowRef("s1", tuple(utt_ids), 0.0, 1.0), ts=1.0, mode_state="unknown", clarity=0.9,
+    )
+
+
+def test_record_from_event_happy():
+    assert _record_from_event(_event(utt_ids=(5,), triggers=("question", "is_user"))) == FireRecord(
+        5, "soft", frozenset({"question", "is_user"}), frozenset()
+    )
+
+
+def test_record_from_event_no_window_none():
+    assert _record_from_event(_event(utt_ids=())) is None
+
+
+# ── collector satisfies the ShadowConsumer contract ──────────────────────────
+
+def test_collector_is_a_shadow_consumer():
+    assert isinstance(_Collector(), ShadowConsumer)
+
+
+@pytest.mark.asyncio
+async def test_collector_captures_events_and_flush_persists_nothing():
+    c = _Collector()
+    c.add(_event(utt_ids=(1,)))
+    c.add(_event(utt_ids=(2,)))
+    assert [e.window_ref.utt_ids[-1] for e in c.events] == [1, 2]
+    assert await c.flush() == 0  # differ reads c.events; nothing written to any DB
+
+
+# ── load_from_db (own read-only connection, version-scoped) ──────────────────
+
+async def _seed_db(path, rows):
+    conn = await aiosqlite.connect(path)
+    conn.row_factory = aiosqlite.Row
+    await conn.execute(TABLES["attention_events"])
+    for idx in INDEXES:
+        if "attention_events" in idx:
+            await conn.execute(idx)
+    await conn.commit()
+    await crud.bulk_upsert_events(conn, rows)
+    await conn.close()
+
+
+def _full_row(id_, config_version, *, utt_ids=(1, 2, 3), activation="soft",
+              triggers=(("multi_speaker", "soft", 0.4),)):
+    """A full attention_events tuple in COLUMNS order (bypasses _to_row so utt_ids can be empty)."""
+    triggers_json = json.dumps([{"name": n, "kind": k, "contribution": c} for n, k, c in triggers])
+    window_ref = json.dumps(
+        {"snapshot_id": "s", "session_id": "s1", "utt_ids": list(utt_ids), "ts_start": 0.0, "ts_end": 1.0}
+    )
+    return (
+        id_, "2026-07-01T00:00:00+00:00", "s1", activation, 0.6, triggers_json,
+        json.dumps([]), window_ref, "unknown", 0.9, None, None, "s", config_version,
+        "2026-07-01T00:00:00+00:00",
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_from_db_scopes_to_version_and_maps(tmp_path):
+    p = tmp_path / "g.db"
+    await _seed_db(p, [
+        _full_row("a", "0.1.0-default", utt_ids=(11,)),
+        _full_row("b", "0.1.0-default", utt_ids=(22,), triggers=(("question", "soft", 0.3),)),
+        _full_row("c", "0.2.0-taxonomy", utt_ids=(33,)),
+    ])
+    recs, unres = await load_from_db(p, "0.1.0-default")
+    assert unres == 0
+    assert {r.key for r in recs} == {11, 22}  # the 0.2.0 row is excluded
+    assert next(r for r in recs if r.key == 22).triggers == frozenset({"question"})
+
+
+@pytest.mark.asyncio
+async def test_load_from_db_counts_unresolvable_empty_utt_ids(tmp_path):
+    p = tmp_path / "g.db"
+    await _seed_db(p, [
+        _full_row("a", "0.1.0-default", utt_ids=(11,)),
+        _full_row("b", "0.1.0-default", utt_ids=()),  # empty utt_ids -> skipped + counted
+    ])
+    recs, unres = await load_from_db(p, "0.1.0-default")
+    assert {r.key for r in recs} == {11} and unres == 1

--- a/tests/test_dashboard/test_attention_api.py
+++ b/tests/test_dashboard/test_attention_api.py
@@ -107,6 +107,7 @@ def test_stats_aggregates(client):
         patch("genesis.db.crud.attention.activation_stats", new=AsyncMock(return_value={"soft": 2, "hard": 1})),
         patch("genesis.db.crud.attention.trigger_stats", new=AsyncMock(return_value={"multi_speaker": 2})),
         patch("genesis.db.crud.attention.suppressor_stats", new=AsyncMock(return_value={})),
+        patch("genesis.db.crud.attention.config_versions", new=AsyncMock(return_value=["0.1.0-default"])),
     ):
         MockRT.instance.return_value = _mock_rt()
         resp = client.get("/api/genesis/attention/stats")
@@ -114,6 +115,44 @@ def test_stats_aggregates(client):
     data = resp.get_json()
     assert data["labels"]["unlabeled"] == 2
     assert data["by_trigger"]["multi_speaker"] == 2
+    assert data["config_versions"] == ["0.1.0-default"]
+
+
+# ── config_version filter (PR3c-1) ─────────────────────────────────────────
+
+def test_list_threads_config_version(client):
+    le = AsyncMock(return_value=[])
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.list_events", new=le),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.get("/api/genesis/attention/list?config_version=0.2.0-taxonomy")
+    assert resp.status_code == 200
+    _, kwargs = le.call_args
+    assert kwargs["config_version"] == "0.2.0-taxonomy"
+
+
+def test_stats_scopes_aggregates_but_lists_all_versions(client):
+    """R4: the 4 count aggregates get the selected version; config_versions stays FULL (dropdown)."""
+    act = AsyncMock(return_value={"soft": 1})
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.label_counts",
+              new=AsyncMock(return_value={"total": 1, "labeled": 0, "unlabeled": 1, "by_signal": {}})),
+        patch("genesis.db.crud.attention.activation_stats", new=act),
+        patch("genesis.db.crud.attention.trigger_stats", new=AsyncMock(return_value={})),
+        patch("genesis.db.crud.attention.suppressor_stats", new=AsyncMock(return_value={})),
+        patch("genesis.db.crud.attention.config_versions",
+              new=AsyncMock(return_value=["0.1.0-default", "0.2.0-taxonomy"])),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.get("/api/genesis/attention/stats?config_version=0.1.0-default")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["config_versions"] == ["0.1.0-default", "0.2.0-taxonomy"]  # UNFILTERED
+    args, _ = act.call_args
+    assert args[1] == "0.1.0-default"                                      # aggregate scoped
 
 
 # ── reveal-text ───────────────────────────────────────────────────────────

--- a/tests/test_db/test_crud_attention.py
+++ b/tests/test_db/test_crud_attention.py
@@ -31,6 +31,7 @@ def _row(
     session_id="s1",
     snapshot_id="20260701T013412Z",
     utt_ids=(1, 2, 3),
+    config_version="0.1.0-default",
 ):
     """A full attention_events tuple in COLUMNS order."""
     triggers_json = json.dumps([{"name": nm, "kind": k, "contribution": c} for nm, k, c in triggers])
@@ -41,7 +42,7 @@ def _row(
     return (
         f"id-{n}", ts, session_id, activation, score, triggers_json,
         json.dumps(list(suppressors)), window_ref, "unknown", 0.9, None,
-        acceptance, snapshot_id, "0.1.0-default", "2026-07-01T00:00:00+00:00",
+        acceptance, snapshot_id, config_version, "2026-07-01T00:00:00+00:00",
     )
 
 
@@ -153,4 +154,81 @@ async def test_update_acceptance_signal_validation_and_missing(tmp_path):
 async def test_get_event_missing_returns_none(tmp_path):
     db = await _db(tmp_path / "g.db")
     assert await crud.get_event(db, "nope") is None
+    await db.close()
+
+
+# ── PR3c-1: config_version filter (list + all 4 aggregates), config_versions, backfill, differ read ──
+
+@pytest.mark.asyncio
+async def test_list_and_stats_scope_to_config_version(tmp_path):
+    """R4: the version filter must reach list AND every aggregate — else a 2nd version
+    persisting makes the stats panel show mixed counts while the list filters correctly."""
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [
+        _row(1, activation="soft", triggers=(("multi_speaker", "soft", 0.4),),
+             suppressors=("explicit_dismissal",), config_version="0.1.0-default"),
+        _row(2, activation="hard", triggers=(("ambient_name", "hard", 0.0),),
+             acceptance="should", config_version="0.1.0-default"),
+        _row(3, activation="soft", triggers=(("decision", "soft", 0.3),),
+             config_version="0.2.0-taxonomy"),
+    ])
+    # list
+    assert {e["id"] for e in await crud.list_events(db, config_version="0.1.0-default")} == {"id-1", "id-2"}
+    assert {e["id"] for e in await crud.list_events(db, config_version="0.2.0-taxonomy")} == {"id-3"}
+    # aggregates, scoped
+    assert await crud.activation_stats(db, "0.1.0-default") == {"soft": 1, "hard": 1}
+    assert await crud.activation_stats(db, "0.2.0-taxonomy") == {"soft": 1}
+    assert await crud.trigger_stats(db, "0.1.0-default") == {"multi_speaker": 1, "ambient_name": 1}
+    assert await crud.trigger_stats(db, "0.2.0-taxonomy") == {"decision": 1}
+    assert await crud.suppressor_stats(db, "0.1.0-default") == {"explicit_dismissal": 1}
+    assert await crud.suppressor_stats(db, "0.2.0-taxonomy") == {}
+    assert (await crud.label_counts(db, "0.1.0-default"))["labeled"] == 1
+    assert (await crud.label_counts(db, "0.2.0-taxonomy")) == {
+        "total": 1, "labeled": 0, "unlabeled": 1, "by_signal": {},
+    }
+    # unfiltered still aggregates across both versions (back-compat)
+    assert await crud.activation_stats(db) == {"soft": 2, "hard": 1}
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_config_versions_is_distinct_sorted_unfiltered(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [
+        _row(1, config_version="0.2.0-taxonomy"),
+        _row(2, config_version="0.1.0-default"),
+        _row(3, config_version="0.2.0-taxonomy"),
+    ])
+    assert await crud.config_versions(db) == ["0.1.0-default", "0.2.0-taxonomy"]
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_load_fire_records_returns_all_rows_for_version(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [
+        _row(1, utt_ids=(11,), config_version="0.1.0-default"),
+        _row(2, utt_ids=(22,), config_version="0.1.0-default"),
+        _row(3, utt_ids=(33,), config_version="0.2.0-taxonomy"),
+    ])
+    rows = await crud.load_fire_records(db, "0.1.0-default")
+    assert {r["id"] for r in rows} == {"id-1", "id-2"}          # version-scoped
+    assert all("triggers_fired" in r and "window_ref" in r for r in rows)  # JSON cols present (still strings)
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_update_l15_verdict_backfills_even_on_labeled_row(tmp_path):
+    """B3: l15_verdict is a MACHINE field — unconditional, unlike the label-guarded upsert."""
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [_row(1)])
+    await crud.update_acceptance_signal(db, "id-1", "should")  # LABEL the row
+    assert await crud.update_l15_verdict(db, "id-1", {"real": 0.8, "perk": 0.6}) is True
+    ev = await crud.get_event(db, "id-1")
+    assert json.loads(ev["l15_verdict"]) == {"real": 0.8, "perk": 0.6}
+    assert ev["acceptance_signal"] == "should"                 # label untouched
+    # None clears it; missing id returns False
+    assert await crud.update_l15_verdict(db, "id-1", None) is True
+    assert (await crud.get_event(db, "id-1"))["l15_verdict"] is None
+    assert await crud.update_l15_verdict(db, "missing", {"real": 1.0, "perk": 1.0}) is False
     await db.close()


### PR DESCRIPTION
## What

Label-free calibration tooling for the shadow attention engine (Track 1). Offline — **no runtime call site, no migration, no behavior change**. Unblocks clean per-version labeling and objective A/B comparison ahead of the retune (PR3c-2).

### 1. A/B fire-set differ (`attention/differ.py`)
Diffs two config versions' fire-sets over the **same** snapshot: events **added / removed / activation-changed** + `by_trigger` and `by_suppressor` deltas. Structure = a **pure** `diff_fire_sets` core + two IO adapters:
- **persisted** rows (read-only genesis.db), and
- a **live re-score** via `run_shadow` + an in-memory `_Collector` (`ShadowReport` keeps only counts + a sample, so the collector captures the full set).

Keyed on the trigger-utterance id; **value-free** (utt-ids + trigger names + activation only — never transcript text). CLI: `python -m genesis.attention.differ --baseline <ver> --rescore --snapshot <path>`.

### 2. `config_version` filter (crud + route + dashboard)
`config_version` scopes `list_events` **and all four stats aggregates** (so the dominance bar can't mix versions once a 2nd config persists); `config_versions()` stays unfiltered to populate the dropdown. A dashboard `<select>` rescopes both the list and the stats panel.

### 3. `update_l15_verdict` backfill crud
Unconditional `UPDATE … SET l15_verdict` — `l15_verdict` is a machine field, safe to refresh on already-labeled rows (unlike the label-guarded `bulk_upsert_events`). The verdict/label-correlation workflow PR3c-2 needs it.

### 4. `ShadowConsumer` Protocol (`consumers.py`)
Structural sink contract so `run_shadow` accepts the collector (and a future edge JSONL sink) without knowing the concrete type.

## Verification
- **140 targeted tests green** (differ pure + mappers + collector + `load_from_db`; crud version-filter across all 4 aggregates + `config_versions` + `load_fire_records` + `update_l15_verdict`; route threading).
- **Real-corpus differ E2E** reproduces the PR3a dilution finding: 326 → 352 fires, intent triggers appear (decision +82, unanswered_question +59), 100 marginal continuation fires dropped by decay — and surfaces the drop the eyeballed `by_trigger` missed.
- **Real-DB crud E2E** against the live 326-row store (read-only): filter, aggregates, `config_versions`, `load_fire_records` all correct.
- genesis-architect pre-review (2 blockers + R1/R2/R4/R5 folded in before coding) + code-reviewer (added `by_suppressor_delta`).
- Firewall + edge-portability preserved (`differ.py` is an adapter, not core; `test_edge_portability` green).

Browser-E2E of the tab `<select>` is post-deploy (editable install serves the main-tree template — the PR2/PR3a precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)