### PR TITLE
feat(observability): surface silently-stale scheduled jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis now catches scheduled jobs that silently stop working — running on schedule but never
+  succeeding.** Some background jobs (like the weekly self-assessment and quality calibration) could
+  fail week after week without ever showing up as "failed," because the failure counter is reset
+  every time the server restarts. Genesis now watches the gap between a job's last run and its last
+  success: if a job has been running-but-not-succeeding for more than about a week, it raises a health
+  alert that reaches your daily report and the dashboard, and the job-health view now shows a
+  `days_since_success` figure and a `stale` flag for every job.
 - **You can now start an interactive Claude Code session on a different model with one command.**
   `gmodel <name>` launches `claude` on the model you pick: a Claude tier (`gmodel opus`) runs on
   your normal Max subscription, while a roster peer (`gmodel glm-5.2`) runs on that provider's

--- a/src/genesis/db/crud/job_health.py
+++ b/src/genesis/db/crud/job_health.py
@@ -1,0 +1,33 @@
+"""Read-side queries for the ``job_health`` table.
+
+Writes live in :mod:`genesis.runtime._job_health` (record_job_success /
+_failure / clear_stale_job_failures). This module holds the observability
+READ queries consumed by the health MCP + dashboard.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def get_stale_jobs(
+    db: aiosqlite.Connection, *, threshold_days: float
+) -> list[dict]:
+    """Jobs that have RUN more than ``threshold_days`` since they last SUCCEEDED.
+
+    Returns ``{job_name, last_success, gap_days}`` rows, widest gap first. The
+    ``last_run − last_success`` gap survives the per-restart ``consecutive_failures``
+    reset (``clear_stale_job_failures`` never touches ``last_run``/``last_success``),
+    so it is the honest "running but not succeeding" signal — one a healthy job
+    reads as 0 (a successful run writes both columns together).
+    """
+    cursor = await db.execute(
+        "SELECT job_name, last_success, "
+        "julianday(last_run) - julianday(last_success) AS gap_days "
+        "FROM job_health "
+        "WHERE last_run IS NOT NULL AND last_success IS NOT NULL "
+        "AND julianday(last_run) - julianday(last_success) > ? "
+        "ORDER BY gap_days DESC",
+        (threshold_days,),
+    )
+    return [dict(r) for r in await cursor.fetchall()]

--- a/src/genesis/mcp/health/constants.py
+++ b/src/genesis/mcp/health/constants.py
@@ -1,0 +1,19 @@
+"""Leaf constants for the health MCP package.
+
+Kept dependency-free (imports nothing from ``genesis.mcp.health.*``) so both
+``errors.py`` and ``manifest.py`` can share values without an import cycle —
+the package ``__init__`` imports both of those modules. Same pattern as
+``genesis/cc/constants.py`` (introduced to break the cc↔awareness cycle).
+"""
+
+from __future__ import annotations
+
+# A scheduled job whose ``last_run`` is more than this many days ahead of its
+# ``last_success`` has been running-but-not-succeeding long enough to be
+# "silently stale" — surfaced as a ``job_stale:`` health alert and as the
+# ``stale`` flag on the job_health MCP output. Keyed on the last_run−last_success
+# gap (which ``clear_stale_job_failures`` never touches), so it survives the
+# per-restart failure-counter reset that otherwise hides these failures.
+# >~1 weekly cadence: catches a job that has missed a weekly run, ignores a
+# single transient daily failure.
+JOB_STALE_GAP_DAYS = 6.0

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -550,27 +550,20 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
     # cadence — no per-job schedule lookup needed.
     if _service and _service._db:
         try:
-            cursor = await _service._db.execute(
-                "SELECT job_name, last_success, "
-                "julianday(last_run) - julianday(last_success) AS gap_days "
-                "FROM job_health "
-                "WHERE last_run IS NOT NULL AND last_success IS NOT NULL "
-                "AND julianday(last_run) - julianday(last_success) > ? "
-                "ORDER BY gap_days DESC",
-                (JOB_STALE_GAP_DAYS,),
-            )
-            for row in await cursor.fetchall():
-                job_name = row[0] if isinstance(row, tuple) else row["job_name"]
-                last_success = row[1] if isinstance(row, tuple) else row["last_success"]
-                gap_days = row[2] if isinstance(row, tuple) else row["gap_days"]
-                alert_id = f"job_stale:{job_name}"
+            from genesis.db.crud import job_health as job_health_crud
+
+            for row in await job_health_crud.get_stale_jobs(
+                _service._db, threshold_days=JOB_STALE_GAP_DAYS
+            ):
+                alert_id = f"job_stale:{row['job_name']}"
                 alerts.append({
                     "id": alert_id,
                     "severity": "WARNING",
                     "message": (
-                        f"Scheduled job '{job_name}' has run since but not succeeded "
-                        f"in {gap_days:.0f} days (last success {str(last_success)[:10]}) — "
-                        f"silently failing (its failure counter resets on restart)"
+                        f"Scheduled job '{row['job_name']}' has run since but not "
+                        f"succeeded in {row['gap_days']:.0f} days (last success "
+                        f"{str(row['last_success'])[:10]}) — silently failing "
+                        f"(its failure counter resets on restart)"
                     ),
                 })
                 current_ids.add(alert_id)

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -7,6 +7,7 @@ import logging
 from datetime import UTC, datetime
 
 from genesis.mcp.health import mcp  # noqa: E402
+from genesis.mcp.health.constants import JOB_STALE_GAP_DAYS
 
 logger = logging.getLogger(__name__)
 
@@ -536,6 +537,49 @@ async def _impl_health_alerts(active_only: bool = True) -> list[dict]:
                     "message": f"Job {job_name} is quarantined (max retries exhausted, auto-unquarantine in ≤24h)",
                 })
                 current_ids.add(alert_id)
+
+    # ── Silently-stale jobs ──────────────────────────────────────────
+    # A job whose last_run is well ahead of last_success is firing on
+    # schedule but never completing. consecutive_failures MISSES this:
+    # clear_stale_job_failures resets it to 0 on every server restart, and
+    # an infrequent (weekly/monthly) job can't reach the failure threshold
+    # between restarts anyway. The last_run − last_success gap survives
+    # restarts (clear_stale never touches those two fields), so it is the
+    # honest "running but not succeeding" signal. The gap only grows when a
+    # job runs without succeeding, so a healthy job reads 0 regardless of
+    # cadence — no per-job schedule lookup needed.
+    if _service and _service._db:
+        try:
+            cursor = await _service._db.execute(
+                "SELECT job_name, last_success, "
+                "julianday(last_run) - julianday(last_success) AS gap_days "
+                "FROM job_health "
+                "WHERE last_run IS NOT NULL AND last_success IS NOT NULL "
+                "AND julianday(last_run) - julianday(last_success) > ? "
+                "ORDER BY gap_days DESC",
+                (JOB_STALE_GAP_DAYS,),
+            )
+            for row in await cursor.fetchall():
+                job_name = row[0] if isinstance(row, tuple) else row["job_name"]
+                last_success = row[1] if isinstance(row, tuple) else row["last_success"]
+                gap_days = row[2] if isinstance(row, tuple) else row["gap_days"]
+                alert_id = f"job_stale:{job_name}"
+                alerts.append({
+                    "id": alert_id,
+                    "severity": "WARNING",
+                    "message": (
+                        f"Scheduled job '{job_name}' has run since but not succeeded "
+                        f"in {gap_days:.0f} days (last success {str(last_success)[:10]}) — "
+                        f"silently failing (its failure counter resets on restart)"
+                    ),
+                })
+                current_ids.add(alert_id)
+        except Exception:
+            # job_health is a core table that always exists — a failure here is
+            # a real operational fault, not an expected-absent-table case, so
+            # ERROR (unlike the credit-exhaustion block, which queries the
+            # optionally-absent activity_log).
+            logger.error("Silently-stale job alert check failed", exc_info=True)
 
     # ── Genesis update available ─────────────────────────────────────
     if _service and _service._db:

--- a/src/genesis/mcp/health/manifest.py
+++ b/src/genesis/mcp/health/manifest.py
@@ -10,12 +10,56 @@ import aiosqlite
 
 from genesis.db.connection import BUSY_TIMEOUT_MS
 from genesis.mcp.health import mcp  # noqa: E402
+from genesis.mcp.health.constants import JOB_STALE_GAP_DAYS
 
 logger = logging.getLogger(__name__)
 
 # Module-level DB path so tests can monkeypatch it without touching
 # ``Path.home()``. Matches the pattern used in ``update_history.py``.
 _DB_PATH = Path.home() / "genesis" / "data" / "genesis.db"
+
+def _parse_ts_utc(raw: str) -> datetime:
+    """Parse an ISO timestamp, coercing to timezone-aware UTC.
+
+    job_health timestamps are written as ``datetime.now(UTC).isoformat()``
+    (offset-aware), but coerce naive strings to UTC too so a mixed naive/aware
+    pair can still be subtracted without raising ``TypeError``.
+    """
+    dt = datetime.fromisoformat(raw)
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+
+
+def _annotate_staleness(jobs: dict) -> dict:
+    """Return a copy of ``jobs`` with derived ``days_since_success`` + ``stale``.
+
+    ``days_since_success`` = the ``last_run − last_success`` gap in days — how
+    long a job has been firing without completing. ``stale`` = that gap exceeds
+    the alert threshold. Keying on this gap (rather than ``consecutive_failures``)
+    surfaces silent failures that ``clear_stale_job_failures`` would otherwise
+    hide by resetting the failure counter on every restart.
+
+    Non-mutating: the runtime return path hands back ``rt.job_health`` by
+    reference, so each entry is shallow-copied before the derived keys are added.
+    """
+    annotated: dict[str, dict] = {}
+    for name, info in jobs.items():
+        entry = dict(info)
+        gap: float | None = None
+        last_run = info.get("last_run")
+        last_ok = info.get("last_success")
+        if last_run and last_ok:
+            try:
+                gap = round(
+                    (_parse_ts_utc(last_run) - _parse_ts_utc(last_ok)).total_seconds()
+                    / 86400,
+                    1,
+                )
+            except (ValueError, TypeError):
+                gap = None
+        entry["days_since_success"] = gap
+        entry["stale"] = gap is not None and gap > JOB_STALE_GAP_DAYS
+        annotated[name] = entry
+    return annotated
 
 
 async def _impl_bootstrap_manifest() -> dict:
@@ -145,7 +189,7 @@ async def _impl_job_health() -> dict:
         rt = GenesisRuntime.instance()
         if rt.job_health:
             return {
-                "jobs": rt.job_health,
+                "jobs": _annotate_staleness(rt.job_health),
                 "note": None,
                 "source": "runtime",
             }
@@ -182,7 +226,7 @@ async def _impl_job_health() -> dict:
                     "last_error": row[4],
                     "consecutive_failures": row[5],
                 }
-            return {"jobs": jobs, "note": None, "source": "sqlite"}
+            return {"jobs": _annotate_staleness(jobs), "note": None, "source": "sqlite"}
     except (aiosqlite.Error, OSError):
         # aiosqlite.Error covers DB-level failures (corrupt file, busy
         # timeout, schema mismatch). OSError covers filesystem issues

--- a/tests/test_mcp/test_health_constants.py
+++ b/tests/test_mcp/test_health_constants.py
@@ -1,0 +1,10 @@
+"""Guards for health MCP constants."""
+
+from __future__ import annotations
+
+
+def test_job_stale_gap_days_is_positive_float():
+    from genesis.mcp.health.constants import JOB_STALE_GAP_DAYS
+
+    assert isinstance(JOB_STALE_GAP_DAYS, float)
+    assert JOB_STALE_GAP_DAYS > 0

--- a/tests/test_mcp/test_job_staleness.py
+++ b/tests/test_mcp/test_job_staleness.py
@@ -1,0 +1,180 @@
+"""Tests for silent-job-staleness surfacing.
+
+Two surfaces:
+  - ``_impl_health_alerts`` emits a ``job_stale:<name>`` WARNING when a job's
+    ``last_run`` is more than the threshold ahead of its ``last_success``
+    (running but not succeeding). Exercised against a REAL in-memory SQLite DB
+    so the ``julianday`` gap math + WHERE threshold are tested, not mocked away.
+  - ``_annotate_staleness`` (job_health MCP output) adds ``days_since_success``
+    and ``stale`` per job without mutating the source dict.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiosqlite
+import pytest
+
+# Fixed timestamps so the last_run − last_success gap is deterministic
+# (julianday works on the stored strings, not on "now").
+_RUN = "2026-06-28T00:00:00+00:00"
+_OK_STALE = "2026-06-14T00:00:00+00:00"   # 14.0 days before _RUN  → alerts
+_OK_RECENT = "2026-06-25T00:00:00+00:00"  # 3.0 days before _RUN   → below threshold
+_OK_HEALTHY = _RUN                          # 0.0 days               → healthy
+
+
+async def _make_service_with_jobs(rows):
+    """Build a mock HealthDataService backed by a real in-memory job_health DB.
+
+    ``rows`` = list of (job_name, last_run, last_success). Only the columns the
+    staleness query touches are created; other alert blocks that query missing
+    tables fail gracefully inside their own try/except.
+    """
+    db = await aiosqlite.connect(":memory:")
+    # Match production: get_db() sets row_factory=aiosqlite.Row, so rows are
+    # Row objects (name-based access), never plain tuples. Exercise that path.
+    db.row_factory = aiosqlite.Row
+    await db.execute(
+        "CREATE TABLE job_health ("
+        "job_name TEXT PRIMARY KEY, last_run TEXT, last_success TEXT, "
+        "last_failure TEXT, last_error TEXT, consecutive_failures INTEGER DEFAULT 0)"
+    )
+    await db.executemany(
+        "INSERT INTO job_health (job_name, last_run, last_success) VALUES (?, ?, ?)",
+        rows,
+    )
+    await db.commit()
+
+    svc = MagicMock()
+    svc._db = db
+    svc.snapshot = AsyncMock(return_value={
+        "call_sites": {}, "infrastructure": {}, "cc_sessions": {},
+        "queues": {}, "awareness": {}, "services": {},
+    })
+    return svc
+
+
+async def _run_alerts(svc):
+    with patch("genesis.mcp.health_mcp._service", svc), \
+         patch("genesis.mcp.health_mcp._activity_tracker", None), \
+         patch("genesis.mcp.health_mcp._job_retry_registry", None), \
+         patch("genesis.mcp.health_mcp._alert_history", {}):
+        from genesis.mcp.health.errors import _impl_health_alerts
+        return await _impl_health_alerts(active_only=True)
+
+
+@pytest.mark.asyncio
+async def test_stale_job_alerts():
+    """A job running-but-not-succeeding past the threshold emits one WARNING."""
+    svc = await _make_service_with_jobs([("weekly_assessment", _RUN, _OK_STALE)])
+    try:
+        alerts = await _run_alerts(svc)
+    finally:
+        await svc._db.close()
+
+    stale = [a for a in alerts if a.get("id", "").startswith("job_stale:")]
+    assert len(stale) == 1
+    a = stale[0]
+    assert a["id"] == "job_stale:weekly_assessment"
+    assert a["severity"] == "WARNING"
+    assert "weekly_assessment" in a["message"]
+    assert "14" in a["message"]          # gap days
+    assert "2026-06-14" in a["message"]  # last success date
+
+
+@pytest.mark.asyncio
+async def test_healthy_and_recent_jobs_do_not_alert():
+    """gap==0 (healthy) and gap<threshold (single recent miss) stay silent."""
+    svc = await _make_service_with_jobs([
+        ("healthy_job", _RUN, _OK_HEALTHY),   # gap 0
+        ("recent_miss", _RUN, _OK_RECENT),    # gap 3 < 6.0
+    ])
+    try:
+        alerts = await _run_alerts(svc)
+    finally:
+        await svc._db.close()
+
+    stale = [a for a in alerts if a.get("id", "").startswith("job_stale:")]
+    assert stale == []
+
+
+@pytest.mark.asyncio
+async def test_never_succeeded_job_is_not_flagged_here():
+    """A job with last_success NULL is excluded (liveness signal's domain)."""
+    svc = await _make_service_with_jobs([("never_ok", _RUN, None)])
+    try:
+        alerts = await _run_alerts(svc)
+    finally:
+        await svc._db.close()
+
+    stale = [a for a in alerts if a.get("id", "").startswith("job_stale:")]
+    assert stale == []
+
+
+@pytest.mark.asyncio
+async def test_multiple_stale_jobs_sorted_worst_first():
+    """Every stale job gets its own alert; query orders by widest gap first."""
+    svc = await _make_service_with_jobs([
+        ("weekly_calibration", _RUN, "2026-06-20T00:00:00+00:00"),  # 8 days
+        ("weekly_assessment", _RUN, _OK_STALE),                     # 14 days
+    ])
+    try:
+        alerts = await _run_alerts(svc)
+    finally:
+        await svc._db.close()
+
+    stale = [a for a in alerts if a.get("id", "").startswith("job_stale:")]
+    ids = [a["id"] for a in stale]
+    assert ids == ["job_stale:weekly_assessment", "job_stale:weekly_calibration"]
+
+
+# ── _annotate_staleness (job_health MCP output field) ────────────────────────
+
+def test_annotate_staleness_computes_gap_and_flag():
+    from genesis.mcp.health.manifest import _annotate_staleness
+
+    out = _annotate_staleness({
+        "stale_job": {"last_run": _RUN, "last_success": _OK_STALE, "consecutive_failures": 0},
+        "healthy_job": {"last_run": _RUN, "last_success": _OK_HEALTHY},
+    })
+    assert out["stale_job"]["days_since_success"] == 14.0
+    assert out["stale_job"]["stale"] is True
+    assert out["healthy_job"]["days_since_success"] == 0.0
+    assert out["healthy_job"]["stale"] is False
+    # existing fields preserved
+    assert out["stale_job"]["consecutive_failures"] == 0
+
+
+def test_annotate_staleness_handles_missing_and_bad_timestamps():
+    from genesis.mcp.health.manifest import _annotate_staleness
+
+    out = _annotate_staleness({
+        "no_success": {"last_run": _RUN, "last_success": None},
+        "no_run": {"last_run": None, "last_success": _OK_STALE},
+        "garbage": {"last_run": "not-a-date", "last_success": _OK_STALE},
+    })
+    for name in ("no_success", "no_run", "garbage"):
+        assert out[name]["days_since_success"] is None
+        assert out[name]["stale"] is False
+
+
+def test_annotate_staleness_handles_mixed_tz_awareness():
+    """A naive last_run vs an aware last_success must not silently become None."""
+    from genesis.mcp.health.manifest import _annotate_staleness
+
+    out = _annotate_staleness({
+        # last_run naive, last_success offset-aware — both UTC in Genesis
+        "mixed": {"last_run": "2026-06-28T00:00:00", "last_success": _OK_STALE},
+    })
+    assert out["mixed"]["days_since_success"] == 14.0
+    assert out["mixed"]["stale"] is True
+
+
+def test_annotate_staleness_does_not_mutate_source():
+    from genesis.mcp.health.manifest import _annotate_staleness
+
+    source = {"j": {"last_run": _RUN, "last_success": _OK_STALE}}
+    _annotate_staleness(source)
+    assert "days_since_success" not in source["j"]
+    assert "stale" not in source["j"]

--- a/tests/test_mcp/test_job_staleness.py
+++ b/tests/test_mcp/test_job_staleness.py
@@ -129,6 +129,37 @@ async def test_multiple_stale_jobs_sorted_worst_first():
     assert ids == ["job_stale:weekly_assessment", "job_stale:weekly_calibration"]
 
 
+# ── get_stale_jobs crud (the raw query behind the alert) ─────────────────────
+
+@pytest.mark.asyncio
+async def test_get_stale_jobs_crud():
+    """The crud read returns only jobs past the threshold, widest gap first."""
+    from genesis.db.crud import job_health
+
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute(
+        "CREATE TABLE job_health (job_name TEXT PRIMARY KEY, last_run TEXT, last_success TEXT)"
+    )
+    await db.executemany(
+        "INSERT INTO job_health (job_name, last_run, last_success) VALUES (?, ?, ?)",
+        [
+            ("stale_a", _RUN, _OK_STALE),        # gap 14
+            ("stale_b", _RUN, "2026-06-20T00:00:00+00:00"),  # gap 8
+            ("healthy", _RUN, _OK_HEALTHY),      # gap 0
+            ("recent", _RUN, _OK_RECENT),        # gap 3 (< 6.0)
+        ],
+    )
+    await db.commit()
+    try:
+        rows = await job_health.get_stale_jobs(db, threshold_days=6.0)
+    finally:
+        await db.close()
+
+    assert [r["job_name"] for r in rows] == ["stale_a", "stale_b"]  # widest gap first
+    assert rows[0]["gap_days"] == 14.0
+
+
 # ── _annotate_staleness (job_health MCP output field) ────────────────────────
 
 def test_annotate_staleness_computes_gap_and_flag():


### PR DESCRIPTION
## What & why

Scheduled jobs that run on schedule but silently never succeed were invisible. The weekly self-assessment and quality-calibration jobs failed on several recent Sundays — they returned empty Claude Code output (root cause: the shared Claude Code subscription hit its usage cap for ~2 days; investigated separately, not a per-provider 429) — but nothing surfaced because:

- `clear_stale_job_failures` resets `consecutive_failures` to 0 and clears `last_failure` on **every server restart** (no age check) — the ~10 restarts over two days erased each recorded failure.
- The awareness `JobHealthCollector` only alerts on `consecutive_failures >= 2`, which an infrequent (weekly) job cannot reach between restarts.

The failures were real (`job_health.total_failures > 0`) but the current-state fields kept getting wiped, so nothing surfaced.

## The fix

Surface staleness where job health is actually observed, keyed on the **`last_run − last_success` gap** — which `clear_stale_job_failures` never touches (so it survives restarts) and which is cadence-independent (a healthy job has gap 0, because a successful run writes both fields together):

- `_impl_health_alerts` emits a `job_stale:<name>` **WARNING** for any job whose gap exceeds ~1 weekly cadence. This flows automatically into the daily report, the `health_alerts` MCP tool, and the dashboard.
- `_impl_job_health` adds `days_since_success` + a `stale` flag per job (non-mutating — the runtime path returns `job_health` by reference).
- The shared threshold lives in a dependency-free `health/constants.py` leaf to avoid an import cycle (the package `__init__` imports both modules).

Deliberately does **not** modify `clear_stale_job_failures` (the gap signal is robust to it) or the awareness signal-collector path (which is dormant post-bootstrap — dropped by the learning-init collector swap and unweighted in scoring).

## Verification

- Architect + code-reviewer: all findings addressed (log level, shared-constant leaf, test/prod `row_factory` parity, mixed-tz normalization).
- 8 new tests (real `julianday` gap query against an in-memory DB + the annotate helper incl. mixed tz-awareness) + 424 existing tests green; ruff clean; no import cycle (fresh-process probes).
- E2E against the live DB: flags exactly the two stale weeklies (14d / 7d), healthy jobs `0.0 / False` — no false positives.

Note: the *underlying* cause (why the weekly cognitive jobs hit rate limits) is a separate, deeper follow-on — this PR makes the silent failure **visible**, it does not fix the rate-limiting.

