### PR TITLE
fix(knowledge): tombstone manifest entry on unit delete (unblock re-ingest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Deleting a knowledge item no longer blocks you from re-adding its source.** When you deleted
+  a knowledge unit from the dashboard, Genesis removed it from the search index but still remembered
+  having ingested its source — so re-adding that same file or URL was silently skipped and nothing
+  came back. Now deleting a source's last remaining unit clears that record, and re-ingesting the
+  source works normally again.
 - **`update.sh` no longer hangs if the health watchdog restarts the server mid-update.**
   During an update Genesis stops its server to swap in new code and migrate the database. The
   background health watchdog could see it "down" and restart it right then — and the revived

--- a/src/genesis/dashboard/routes/knowledge.py
+++ b/src/genesis/dashboard/routes/knowledge.py
@@ -145,10 +145,23 @@ async def knowledge_delete(unit_id: str):
             except Exception:
                 logger.warning("Failed to delete Qdrant point %s", qdrant_id)
 
+        # Drop the unit from the ingestion manifest so a fully-deleted source is
+        # not permanently blocked from re-ingest by the source-identity gate.
+        # Best-effort: the unit is already physically gone; manifest bookkeeping
+        # must never fail the delete.
+        manifest_removed = False
+        try:
+            from genesis.knowledge.manifest import ManifestManager
+
+            manifest_removed = ManifestManager().remove_unit(unit_id)
+        except Exception:
+            logger.warning("Failed to update manifest after deleting unit %s", unit_id)
+
         return jsonify({
             "status": "ok",
             "sqlite_deleted": True,
             "qdrant_deleted": qdrant_deleted,
+            "manifest_removed": manifest_removed,
         })
     except Exception:
         logger.exception("Knowledge delete failed")

--- a/src/genesis/knowledge/manifest.py
+++ b/src/genesis/knowledge/manifest.py
@@ -132,6 +132,44 @@ class ManifestManager:
             manifest[h]["unit_ids"] = existing + unit_ids
             self._save()
 
+    def remove_unit(self, unit_id: str) -> bool:
+        """Drop a knowledge ``unit_id`` from whichever source entry owns it.
+
+        Knowledge units are deleted one at a time (the dashboard DELETE route is
+        per-unit), but the manifest tracks whole sources. We pop ``unit_id`` from
+        its owning entry's ``unit_ids``; when that removes the source's LAST live
+        unit, we delete the entire entry — a *tombstone* — so a future re-ingest
+        is no longer blocked by the source-identity gate (``has_source``), which
+        would otherwise serve now-dead cached unit IDs forever.
+
+        INVARIANT: only a transition-to-empty *via this method* tombstones an
+        entry. A ``no_units_extracted`` source (``add_source`` with
+        ``unit_ids=[]``) already has an empty list, contains no ``unit_id`` to
+        match, and is therefore left untouched.
+
+        The entry is removed even if it carries a ``pageindex_doc_id`` — keeping
+        it would keep ``has_source`` True and re-block ingest, and the tree index
+        is rebuilt (and its on-disk cache overwritten, keyed by ``source_hash``)
+        on re-ingest. Physical artifacts (extracted text, originals) are left in
+        place; re-ingest overwrites them and unlinking only adds failure modes.
+
+        Returns True if a matching entry was found and mutated, else False
+        (idempotent: a repeat delete of the same ``unit_id`` is a no-op).
+        """
+        manifest = self._load()
+        for h, entry in list(manifest.items()):  # snapshot: we may del during loop
+            unit_ids = entry.get("unit_ids", [])
+            if unit_id not in unit_ids:
+                continue
+            remaining = [u for u in unit_ids if u != unit_id]
+            if remaining:
+                entry["unit_ids"] = remaining
+            else:
+                del manifest[h]  # last live unit gone → tombstone the source
+            self._save()
+            return True
+        return False
+
     def get_units_for_source(self, source: str) -> list[str]:
         """Get all knowledge unit IDs produced from a source."""
         manifest = self._load()

--- a/tests/test_knowledge/test_manifest.py
+++ b/tests/test_knowledge/test_manifest.py
@@ -1,0 +1,103 @@
+"""Tests for the knowledge ingestion manifest (source→units provenance).
+
+Focus: `remove_unit` — the unit-granular tombstone that keeps the manifest's
+source-identity gate (`has_source`) honest when knowledge units are deleted.
+"""
+
+from pathlib import Path
+
+from genesis.knowledge.manifest import ManifestManager
+
+
+def _mgr(tmp_path: Path) -> ManifestManager:
+    return ManifestManager(root=tmp_path / "knowledge")
+
+
+def _add(mgr: ManifestManager, source: str, unit_ids: list[str]) -> None:
+    mgr.add_source(
+        source,
+        source_type="text",
+        extracted_path=mgr.sources_dir / f"{ManifestManager.source_hash(source)}.md",
+        unit_ids=unit_ids,
+    )
+
+
+def test_remove_unit_from_multi_unit_source_keeps_entry(tmp_path: Path):
+    """Removing one unit of a multi-unit source leaves the source registered."""
+    mgr = _mgr(tmp_path)
+    _add(mgr, "doc.txt", ["u1", "u2", "u3"])
+    assert mgr.remove_unit("u2") is True
+    assert mgr.has_source("doc.txt") is True
+    assert mgr.get_units_for_source("doc.txt") == ["u1", "u3"]
+
+
+def test_remove_last_unit_tombstones_source(tmp_path: Path):
+    """Removing the last live unit deletes the entry so re-ingest is unblocked."""
+    mgr = _mgr(tmp_path)
+    _add(mgr, "doc.txt", ["only"])
+    assert mgr.remove_unit("only") is True
+    assert mgr.has_source("doc.txt") is False
+
+
+def test_remove_all_units_sequentially_tombstones(tmp_path: Path):
+    """The entry survives until the LAST unit is removed, then tombstones."""
+    mgr = _mgr(tmp_path)
+    _add(mgr, "doc.txt", ["u1", "u2"])
+    assert mgr.remove_unit("u1") is True
+    assert mgr.has_source("doc.txt") is True
+    assert mgr.remove_unit("u2") is True
+    assert mgr.has_source("doc.txt") is False
+
+
+def test_remove_unit_not_found_returns_false(tmp_path: Path):
+    """A unit_id belonging to no entry is a no-op returning False."""
+    mgr = _mgr(tmp_path)
+    _add(mgr, "doc.txt", ["u1"])
+    assert mgr.remove_unit("nope") is False
+    assert mgr.get_units_for_source("doc.txt") == ["u1"]
+
+
+def test_remove_unit_idempotent(tmp_path: Path):
+    """A second delete of the same unit_id is a harmless no-op (False)."""
+    mgr = _mgr(tmp_path)
+    _add(mgr, "doc.txt", ["u1", "u2"])
+    assert mgr.remove_unit("u1") is True
+    assert mgr.remove_unit("u1") is False
+    assert mgr.get_units_for_source("doc.txt") == ["u2"]
+
+
+def test_remove_unit_leaves_no_units_extracted_entry_untouched(tmp_path: Path):
+    """A legitimately-empty `no_units_extracted` entry is never matched/tombstoned."""
+    mgr = _mgr(tmp_path)
+    _add(mgr, "empty.txt", [])  # add_source(..., unit_ids=None) writes []
+    assert mgr.has_source("empty.txt") is True
+    assert mgr.remove_unit("whatever") is False
+    assert mgr.has_source("empty.txt") is True
+
+
+def test_remove_unit_only_affects_matching_source(tmp_path: Path):
+    """Removal is scoped to the source that owns the unit_id."""
+    mgr = _mgr(tmp_path)
+    _add(mgr, "a.txt", ["a1", "a2"])
+    _add(mgr, "b.txt", ["b1"])
+    assert mgr.remove_unit("a1") is True
+    assert mgr.get_units_for_source("a.txt") == ["a2"]
+    assert mgr.get_units_for_source("b.txt") == ["b1"]
+
+
+def test_remove_unit_persists_across_reload(tmp_path: Path):
+    """The tombstone must be written to disk, not just the in-memory cache."""
+    mgr = _mgr(tmp_path)
+    _add(mgr, "doc.txt", ["u1"])
+    assert mgr.remove_unit("u1") is True
+    fresh = _mgr(tmp_path)  # new instance → reads manifest.json from disk
+    assert fresh.has_source("doc.txt") is False
+
+
+def test_remove_unit_partial_removal_persists_across_reload(tmp_path: Path):
+    """A non-tombstoning removal also persists the shortened unit_ids to disk."""
+    mgr = _mgr(tmp_path)
+    _add(mgr, "doc.txt", ["u1", "u2"])
+    assert mgr.remove_unit("u1") is True
+    fresh = _mgr(tmp_path)
+    assert fresh.get_units_for_source("doc.txt") == ["u2"]

--- a/tests/test_knowledge/test_orchestrator.py
+++ b/tests/test_knowledge/test_orchestrator.py
@@ -76,6 +76,30 @@ async def test_ingest_duplicate_detection(tmp_path: Path):
         assert "duplicate_source" in r2.quality_flags
 
 
+async def test_reingest_after_full_unit_delete(tmp_path: Path):
+    """After all of a source's units are removed from the manifest (the
+    tombstone path), a re-ingest runs the full pipeline again rather than
+    returning the now-dead cached result."""
+    units = [KnowledgeUnit(concept="Test", body="Test body", domain="test")]
+    orch = _make_orchestrator(tmp_path, mock_distill_result=units)
+
+    with patch("genesis.knowledge.orchestrator.KnowledgeOrchestrator._store_units",
+               new_callable=AsyncMock, return_value=["unit-1"]):
+        file = tmp_path / "doc.txt"
+        file.write_text("Some meaningful content here.")
+
+        r1 = await orch.ingest_source(str(file), project_type="test")
+        assert r1.units_created == 1
+
+        # Simulate the dashboard deleting the source's only unit.
+        assert orch._manifest.remove_unit("unit-1") is True
+
+        # Re-ingest must NOT short-circuit as a duplicate now.
+        r2 = await orch.ingest_source(str(file), project_type="test")
+        assert r2.units_created == 1
+        assert "duplicate_source" not in r2.quality_flags
+
+
 async def test_ingest_no_units_extracted(tmp_path: Path):
     """Distillation producing zero units flags appropriately."""
     orch = _make_orchestrator(tmp_path, mock_distill_result=[])


### PR DESCRIPTION
## Problem

The knowledge-ingestion **manifest** (`knowledge/manifest.py`, an on-disk JSON keyed by source, one source → many `unit_ids`) is a source-identity cache. The dashboard DELETE route removed a knowledge unit from SQLite + Qdrant but **never touched the manifest**. So once a source's *last* unit was deleted, the manifest entry survived → `has_source()` kept returning True → re-ingest of that file/URL was permanently skipped (serving now-dead cached unit IDs). Deleting then re-adding a knowledge source silently returned nothing.

## Fix

- New `ManifestManager.remove_unit(unit_id) -> bool` — **unit-granular** (matching the per-unit DELETE route): pops the id from its owning source entry and **tombstones the whole entry only when its last live unit is removed**, so re-ingest is unblocked. Idempotent; leaves legitimately-empty `no_units_extracted` entries untouched; leaves physical artifacts in place (re-ingest overwrites them).
- Wired into the DELETE route as a **best-effort** call after the physical delete (a manifest hiccup can never fail an already-successful delete); adds a `manifest_removed` field to the response.

No DB migration (JSON manifest).

## Testing

- 9 new `remove_unit` unit tests (tombstone-on-empty, multi-unit keep, idempotency, no-units-untouched, cross-reload disk persistence) + 1 orchestrator-level re-ingest-after-delete test. **21/21 green** in `test_knowledge/`; ruff clean.
- Reviewed inline (code-reviewer). The one flagged concern — a stale in-process manifest cache — was verified **not applicable**: `_get_orchestrator()` builds a fresh `ManifestManager` per ingest, so the tombstone is seen on the very next ingest without a restart.
- Mechanism E2E covered by tests; the live HTTP-DELETE → re-ingest E2E runs at deploy.

## Scope note

Content-hash idempotency (re-ingesting a *changed* source) is a separate, larger change and is **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)