### PR TITLE
feat(attention): PR3c-2a — label-scored precision calibration report

### DIFF
--- a/src/genesis/attention/calibrate.py
+++ b/src/genesis/attention/calibrate.py
@@ -1,0 +1,418 @@
+"""calibrate: OFFLINE precision-first calibration report for the attention shadow corpus.
+
+Genesis-side ADAPTER (imports ``genesis.db.crud`` + ``genesis.env`` + aiosqlite) — NOT one of
+the edge-portable core modules and NOT imported by ``genesis.attention.__init__``, so
+``tests/test_attention/test_edge_portability.py`` is unaffected.
+
+Turns the dashboard should/shouldn't labels on ``attention_events`` FIRES into per-trigger /
+per-activation PRECISION (+ 95% Wilson intervals + low-n flags), a soft-threshold sweep, a
+clarity-band split, and suppressor veto-correctness counts.
+
+PRECISION-FIRST: the store holds only windows that FIRED, so this measures false-positives
+(over-firing). True RECALL (moments the gate missed entirely) is out of scope — those windows
+were never emitted; measuring them needs a non-fire labeling surface (a deferred follow-on).
+
+Firewall: emits ONLY trigger names, activations, floats, utt-ids and counts — NEVER ambient
+transcript text (which lives+dies in ambient.db on the edge).
+
+CLI: ``python -m genesis.attention.calibrate --config-version 0.2.0-taxonomy [--db PATH]``.
+
+⚠ ``triggers_fired`` stores EVERY hit including ``contribution == 0.0`` ones (verified on live
+rows 2026-07-02: ``topic_continuation`` co-occurs on 206/352 fires at weight 0; hard triggers
+store ``contribution == 0.0``). So the row mapper SPLITS triggers into ``causal_soft``
+(``kind == soft`` and ``contribution > 0`` — actually drove the score), ``hard_triggers``
+(``kind == hard`` — the cause of a HARD fire), and ``inert_soft`` (``kind == soft`` and
+``contribution == 0`` — co-occurring, non-driving). Only causal triggers are scored; inert
+ones are reported separately so a zero-weight trigger can't earn a phantom precision.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+import aiosqlite
+
+from genesis.db.crud import attention as attention_crud
+from genesis.env import genesis_db_path
+
+_PERK = ("hard", "soft")  # activations that are a perk (vs "suppressed", a veto)
+LOW_N = 10                # a precision/rate figure below this n is flagged noisy
+
+
+# ── value objects ────────────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class LabeledFire:
+    """One labeled fire: the join of a persisted ``attention_events`` row + its human label.
+
+    ``causal_soft``/``hard_triggers``/``inert_soft`` split the stored ``triggers_fired`` by
+    (kind, contribution) so precision is only ever attributed to triggers that DROVE the fire.
+    """
+
+    key: int                      # window_ref.utt_ids[-1] (trigger utterance)
+    activation: str               # "hard" | "soft" | "suppressed"
+    score: float
+    clarity: float | None
+    signal: str                   # "should" | "shouldnt"  (skip excluded upstream)
+    causal_soft: frozenset[str]
+    hard_triggers: frozenset[str]
+    inert_soft: frozenset[str]
+    suppressors: frozenset[str]
+
+    @property
+    def causal(self) -> frozenset[str]:
+        """Triggers that caused this fire — soft with weight + hard summons. Never inert."""
+        return self.causal_soft | self.hard_triggers
+
+
+@dataclass(frozen=True)
+class PrecisionStat:
+    """should/shouldnt tally → precision + Wilson interval + low-n flag."""
+
+    should: int
+    shouldnt: int
+
+    @property
+    def n(self) -> int:
+        return self.should + self.shouldnt
+
+    @property
+    def precision(self) -> float | None:
+        return (self.should / self.n) if self.n else None
+
+    @property
+    def wilson(self) -> tuple[float, float] | None:
+        return wilson_interval(self.should, self.n)
+
+    @property
+    def low_n(self) -> bool:
+        return self.n < LOW_N
+
+
+@dataclass(frozen=True)
+class SuppressorStat:
+    """SUPPRESSED-event tally. ``n_miss`` = label ``should`` = the suppressor WRONGLY vetoed a
+    window Genesis should have perked on. ``n_correct_veto`` = label ``shouldnt`` = correct veto.
+    ``correct_veto_rate`` is the suppressor's PRECISION — reported only at n >= LOW_N (else noise)."""
+
+    n_miss: int
+    n_correct_veto: int
+
+    @property
+    def n(self) -> int:
+        return self.n_miss + self.n_correct_veto
+
+    @property
+    def correct_veto_rate(self) -> float | None:
+        return (self.n_correct_veto / self.n) if self.n >= LOW_N else None
+
+    @property
+    def low_n(self) -> bool:
+        return self.n < LOW_N
+
+
+@dataclass(frozen=True)
+class SweepPoint:
+    """One soft-threshold ``t``: precision over retained SOFT alone (the signal ``t`` controls)
+    and over hard+retained-soft (what actually ships), plus the fraction of good soft fires kept."""
+
+    t: float
+    soft: PrecisionStat            # over SOFT fires with score >= t
+    combined: PrecisionStat        # hard (always) + SOFT with score >= t
+    n_soft_retained: int
+    soft_recall_retained: float | None   # should-soft@>=t / should-soft-total (None if no should-soft)
+
+
+# ── pure statistics ──────────────────────────────────────────────────────────────────
+
+def wilson_interval(k: int, n: int, z: float = 1.96) -> tuple[float, float] | None:
+    """95% Wilson score interval for k successes in n trials. None when n == 0.
+
+    Wilson (not normal-approx) because n is small — a 2/2 must read as [0.34, 1.0], not "1.0"."""
+    if n <= 0:
+        return None
+    phat = k / n
+    denom = 1.0 + z * z / n
+    center = (phat + z * z / (2 * n)) / denom
+    margin = (z / denom) * math.sqrt(phat * (1 - phat) / n + z * z / (4 * n * n))
+    return (max(0.0, center - margin), min(1.0, center + margin))
+
+
+# ── row → LabeledFire ────────────────────────────────────────────────────────────────
+
+def labeled_from_row(row: dict) -> LabeledFire | None:
+    """Map a persisted (labeled) ``attention_events`` row → LabeledFire. None if no utt_ids.
+
+    Splits ``triggers_fired`` by (kind, contribution): hard → ``hard_triggers``; soft with
+    contribution > 0 → ``causal_soft``; soft with contribution == 0 → ``inert_soft``."""
+    wr = json.loads(row["window_ref"]) if row.get("window_ref") else {}
+    utt_ids = wr.get("utt_ids") or []
+    if not utt_ids:
+        return None
+    causal_soft: set[str] = set()
+    hard: set[str] = set()
+    inert: set[str] = set()
+    for h in (json.loads(row["triggers_fired"]) if row.get("triggers_fired") else []):
+        name = h.get("name")
+        if not name:
+            continue
+        if h.get("kind") == "hard":
+            hard.add(name)
+        elif float(h.get("contribution") or 0.0) > 0.0:
+            causal_soft.add(name)
+        else:
+            inert.add(name)
+    suppressors = frozenset(json.loads(row["suppressors"]) if row.get("suppressors") else [])
+    clarity = row.get("clarity")
+    return LabeledFire(
+        key=int(utt_ids[-1]),
+        activation=row["activation"],
+        score=float(row["score"]),
+        clarity=(None if clarity is None else float(clarity)),
+        signal=row["acceptance_signal"],
+        causal_soft=frozenset(causal_soft),
+        hard_triggers=frozenset(hard),
+        inert_soft=frozenset(inert),
+        suppressors=suppressors,
+    )
+
+
+# ── metrics (pure; operate on list[LabeledFire]) ─────────────────────────────────────
+
+def _perks(fires: list[LabeledFire]) -> list[LabeledFire]:
+    return [f for f in fires if f.activation in _PERK]
+
+
+def _tally(fires: list[LabeledFire], predicate) -> PrecisionStat:
+    should = sum(1 for f in fires if predicate(f) and f.signal == "should")
+    shouldnt = sum(1 for f in fires if predicate(f) and f.signal == "shouldnt")
+    return PrecisionStat(should, shouldnt)
+
+
+def overall_precision(fires: list[LabeledFire]) -> PrecisionStat:
+    """Precision over all HARD+SOFT (perk) fires."""
+    return _tally(_perks(fires), lambda f: True)
+
+
+def precision_by_activation(fires: list[LabeledFire]) -> dict[str, PrecisionStat]:
+    """Precision split by activation tier (hard vs soft)."""
+    return {act: _tally(fires, lambda f, a=act: f.activation == a) for act in _PERK}
+
+
+def precision_by_trigger(fires: list[LabeledFire]) -> dict[str, PrecisionStat]:
+    """Per-CAUSAL-trigger precision (soft-with-weight ∪ hard). Inert co-triggers are excluded —
+    see ``cooccurring_triggers``. A fire with k causal triggers counts toward all k (marginal
+    precision — the counts intentionally sum to more than the fire count)."""
+    perks = _perks(fires)
+    names = sorted({n for f in perks for n in f.causal})
+    return {name: _tally(perks, lambda f, nm=name: nm in f.causal) for name in names}
+
+
+def cooccurring_triggers(fires: list[LabeledFire]) -> dict[str, int]:
+    """Zero-weight soft triggers (contribution == 0) by how often they co-occur on a perk fire.
+    Visibility only — these drove NO fire, so they get no precision (e.g. ``topic_continuation``)."""
+    counts: dict[str, int] = {}
+    for f in _perks(fires):
+        for name in f.inert_soft:
+            counts[name] = counts.get(name, 0) + 1
+    return dict(sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])))
+
+
+def suppressor_stats(fires: list[LabeledFire]) -> dict[str, SuppressorStat]:
+    """Per-suppressor veto correctness over SUPPRESSED events (miss vs correct-veto counts)."""
+    suppressed = [f for f in fires if f.activation == "suppressed"]
+    names = sorted({n for f in suppressed for n in f.suppressors})
+    out: dict[str, SuppressorStat] = {}
+    for name in names:
+        miss = sum(1 for f in suppressed if name in f.suppressors and f.signal == "should")
+        veto = sum(1 for f in suppressed if name in f.suppressors and f.signal == "shouldnt")
+        out[name] = SuppressorStat(miss, veto)
+    return out
+
+
+# clarity bands tuned to the observed corpus (every stored fire has clarity >= ~0.6, because
+# the engine pre-multiplies relevance by clarity; a NULL band is guarded but empty in practice).
+DEFAULT_CLARITY_BANDS: tuple[tuple[float, float, str], ...] = (
+    (0.0, 0.7, "[0.0,0.7)"),
+    (0.7, 0.85, "[0.7,0.85)"),
+    (0.85, 1.0001, "[0.85,1.0]"),
+)
+
+
+def precision_by_clarity_band(
+    fires: list[LabeledFire], bands: tuple[tuple[float, float, str], ...] = DEFAULT_CLARITY_BANDS
+) -> dict[str, PrecisionStat]:
+    """Precision of perk fires bucketed by capture clarity — exposes garble-driven low precision.
+    NULL clarity → its own ``clarity=NULL`` bucket (never silently folded into the low band).
+    Bands are returned even when empty (n == 0, precision None) so coverage is explicit."""
+    perks = _perks(fires)
+    out: dict[str, PrecisionStat] = {}
+    null_fires = [f for f in perks if f.clarity is None]
+    if null_fires:
+        out["clarity=NULL"] = _tally(null_fires, lambda f: True)
+    for lo, hi, label in bands:
+        out[label] = _tally(
+            perks, lambda f, lo=lo, hi=hi: f.clarity is not None and lo <= f.clarity < hi
+        )
+    return out
+
+
+def threshold_sweep(fires: list[LabeledFire], ts_values: list[float]) -> list[SweepPoint]:
+    """Soft-threshold sweep. Raising ``t`` only ever DROPS soft fires (score is a fixed stored
+    REAL). Reports soft-only precision (what ``t`` governs), combined precision (hard + retained
+    soft = what ships), and the retained fraction of should-labeled soft fires (recall vs the
+    current soft fire-set — guarded to None when there are no should-labeled soft fires)."""
+    perks = _perks(fires)
+    hard = [f for f in perks if f.activation == "hard"]
+    soft = [f for f in perks if f.activation == "soft"]
+    should_soft_total = sum(1 for f in soft if f.signal == "should")
+    points: list[SweepPoint] = []
+    for t in ts_values:
+        retained = [f for f in soft if f.score >= t]
+        soft_stat = _tally(retained, lambda f: True)
+        combined_stat = _tally(retained + hard, lambda f: True)
+        kept_should = sum(1 for f in retained if f.signal == "should")
+        recall = (kept_should / should_soft_total) if should_soft_total else None
+        points.append(SweepPoint(t, soft_stat, combined_stat, len(retained), recall))
+    return points
+
+
+# ── report ───────────────────────────────────────────────────────────────────────────
+
+def _fmt_stat(s: PrecisionStat) -> str:
+    if s.n == 0:
+        return "   —   (n=0)"
+    lo, hi = s.wilson  # type: ignore[misc]
+    flag = " LOW" if s.low_n else ""
+    return f"{s.precision:5.2f} [{lo:.2f}-{hi:.2f}, n={s.n}{flag}]"
+
+
+def format_report(
+    fires: list[LabeledFire], counts: dict, *, config_version: str, unresolved: int = 0
+) -> str:
+    """Assemble the value-free text report. ``counts`` is ``crud.label_counts`` (total/labeled/
+    unlabeled/by_signal). Renders a labeling-quality header even at 0 labels."""
+    by_signal = counts.get("by_signal", {})
+    n_should = by_signal.get("should", 0)
+    n_shouldnt = by_signal.get("shouldnt", 0)
+    n_skip = by_signal.get("skip", 0)
+    labeled_judged = n_should + n_shouldnt
+    skip_rate = (n_skip / (labeled_judged + n_skip)) if (labeled_judged + n_skip) else 0.0
+
+    L: list[str] = []
+    L.append("\n=== ATTENTION CALIBRATION — PRECISION REPORT ===")
+    L.append(f"config_version: {config_version}")
+    L.append(
+        f"corpus: total={counts.get('total', 0)}  labeled={counts.get('labeled', 0)}  "
+        f"unlabeled={counts.get('unlabeled', 0)}  (unresolved rows skipped: {unresolved})"
+    )
+    L.append(
+        f"labels: should={n_should}  shouldnt={n_shouldnt}  skip={n_skip}  "
+        f"| base-rate should:shouldnt = {n_should}:{n_shouldnt}  | skip_rate={skip_rate:.2f}"
+    )
+    if skip_rate > 0.3:
+        L.append(
+            "  ⚠ skip_rate > 0.30 — corpus may be too garbled to calibrate from; "
+            "check the clarity distribution of skipped fires before trusting these numbers."
+        )
+    if labeled_judged == 0:
+        L.append("\n0 labeled (should/shouldnt) fires — nothing to score yet. Label a batch in the "
+                 "Attention tab (config_version filter) and re-run.\n")
+        return "\n".join(L)
+
+    L.append("\n-- overall precision (HARD+SOFT) --")
+    L.append(f"  {_fmt_stat(overall_precision(fires))}")
+
+    L.append("\n-- precision by activation --")
+    for act, stat in precision_by_activation(fires).items():
+        L.append(f"  {act:<10} {_fmt_stat(stat)}")
+
+    L.append("\n-- precision by CAUSAL trigger (soft-with-weight ∪ hard; sorted by n) --")
+    by_trig = precision_by_trigger(fires)
+    for name, stat in sorted(by_trig.items(), key=lambda kv: (-kv[1].n, kv[0])):
+        L.append(f"  {name:<20} {_fmt_stat(stat)}")
+
+    cooc = cooccurring_triggers(fires)
+    if cooc:
+        L.append("\n-- co-occurring INERT triggers (weight 0 — drove NO fire, not scored) --")
+        for name, c in cooc.items():
+            L.append(f"  {name:<20} co-occurs on {c} perk fire(s)")
+
+    L.append("\n-- precision by clarity band (exposes garble-driven fires) --")
+    for label, stat in precision_by_clarity_band(fires).items():
+        L.append(f"  {label:<14} {_fmt_stat(stat)}")
+
+    supp = suppressor_stats(fires)
+    if supp:
+        L.append("\n-- suppressor veto correctness (SUPPRESSED events) --")
+        for name, s in supp.items():
+            rate = f"  correct_veto_rate={s.correct_veto_rate:.2f}" if s.correct_veto_rate is not None else ""
+            flag = " LOW" if s.low_n else ""
+            L.append(f"  {name:<20} miss(should)={s.n_miss}  correct_veto(shouldnt)={s.n_correct_veto}  "
+                     f"n={s.n}{flag}{rate}")
+
+    L.append("\n-- soft-threshold sweep (soft-only precision = the signal t controls) --")
+    L.append(f"  {'t':>5}  {'soft_prec':>26}  {'combined_prec':>26}  {'n_soft':>7}  {'soft_recall':>11}")
+    for p in threshold_sweep(fires, [0.60, 0.65, 0.70, 0.75, 0.80]):
+        rec = f"{p.soft_recall_retained:.2f}" if p.soft_recall_retained is not None else "  —"
+        L.append(f"  {p.t:>5.2f}  {_fmt_stat(p.soft):>26}  {_fmt_stat(p.combined):>26}  "
+                 f"{p.n_soft_retained:>7}  {rec:>11}")
+    L.append("")
+    return "\n".join(L)
+
+
+# ── IO adapter (own read-only connection) ────────────────────────────────────────────
+
+async def load_labeled(
+    db_path: str | Path, config_version: str
+) -> tuple[list[LabeledFire], int, dict]:
+    """Load labeled (should/shouldnt) fires + label_counts for a config_version from a READ-ONLY
+    genesis.db connection. Returns (fires, n_unresolved, counts). Mirrors ``differ.load_from_db``."""
+    uri = f"file:{Path(db_path).expanduser()}?mode=ro"
+    conn = await aiosqlite.connect(uri, uri=True)
+    try:
+        conn.row_factory = aiosqlite.Row
+        rows = await attention_crud.load_labeled_fires(conn, config_version)
+        counts = await attention_crud.label_counts(conn, config_version)
+    finally:
+        await conn.close()
+    fires: list[LabeledFire] = []
+    unresolved = 0
+    for r in rows:
+        lf = labeled_from_row(dict(r))
+        if lf is None:
+            unresolved += 1
+        else:
+            fires.append(lf)
+    return fires, unresolved, counts
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────────────
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m genesis.attention.calibrate",
+        description="Offline precision-first calibration report over the attention shadow corpus.",
+    )
+    p.add_argument("--config-version", default="0.2.0-taxonomy",
+                   help="which shadow-run's labeled fires to score (default: 0.2.0-taxonomy)")
+    p.add_argument("--db", default=None, help="genesis.db path (default: env genesis_db_path())")
+    return p
+
+
+async def _run(args: argparse.Namespace) -> None:
+    db_path = args.db or str(genesis_db_path())
+    fires, unresolved, counts = await load_labeled(db_path, args.config_version)
+    print(format_report(fires, counts, config_version=args.config_version, unresolved=unresolved))
+
+
+def main(argv: list[str] | None = None) -> None:
+    asyncio.run(_run(_build_parser().parse_args(argv)))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/genesis/attention/calibrate.py
+++ b/src/genesis/attention/calibrate.py
@@ -148,10 +148,16 @@ def labeled_from_row(row: dict) -> LabeledFire | None:
     """Map a persisted (labeled) ``attention_events`` row → LabeledFire. None if no utt_ids.
 
     Splits ``triggers_fired`` by (kind, contribution): hard → ``hard_triggers``; soft with
-    contribution > 0 → ``causal_soft``; soft with contribution == 0 → ``inert_soft``."""
+    contribution > 0 → ``causal_soft``; soft with contribution == 0 → ``inert_soft``.
+
+    Total by contract: returns None (an "unresolvable" row, counted not raised) for a row missing
+    utt_ids OR any REQUIRED field (activation/score/acceptance_signal) — never a KeyError."""
+    activation = row.get("activation")
+    score = row.get("score")
+    signal = row.get("acceptance_signal")
     wr = json.loads(row["window_ref"]) if row.get("window_ref") else {}
     utt_ids = wr.get("utt_ids") or []
-    if not utt_ids:
+    if not utt_ids or activation is None or score is None or signal is None:
         return None
     causal_soft: set[str] = set()
     hard: set[str] = set()
@@ -170,10 +176,10 @@ def labeled_from_row(row: dict) -> LabeledFire | None:
     clarity = row.get("clarity")
     return LabeledFire(
         key=int(utt_ids[-1]),
-        activation=row["activation"],
-        score=float(row["score"]),
         clarity=(None if clarity is None else float(clarity)),
-        signal=row["acceptance_signal"],
+        activation=activation,
+        score=float(score),
+        signal=signal,
         causal_soft=frozenset(causal_soft),
         hard_triggers=frozenset(hard),
         inert_soft=frozenset(inert),
@@ -247,8 +253,9 @@ def precision_by_clarity_band(
     fires: list[LabeledFire], bands: tuple[tuple[float, float, str], ...] = DEFAULT_CLARITY_BANDS
 ) -> dict[str, PrecisionStat]:
     """Precision of perk fires bucketed by capture clarity — exposes garble-driven low precision.
-    NULL clarity → its own ``clarity=NULL`` bucket (never silently folded into the low band).
-    Bands are returned even when empty (n == 0, precision None) so coverage is explicit."""
+    The fixed ``bands`` are ALWAYS returned (even at n == 0, precision None) so coverage is explicit.
+    NULL clarity is never folded into the low band: it gets its own ``clarity=NULL`` bucket, which is
+    emitted ONLY when such rows exist — its presence is itself the signal that some rows lack clarity."""
     perks = _perks(fires)
     out: dict[str, PrecisionStat] = {}
     null_fires = [f for f in perks if f.clarity is None]

--- a/src/genesis/db/crud/attention.py
+++ b/src/genesis/db/crud/attention.py
@@ -248,6 +248,22 @@ async def load_fire_records(db: aiosqlite.Connection, config_version: str) -> li
     return [dict(r) for r in await cursor.fetchall()]
 
 
+async def load_labeled_fires(db: aiosqlite.Connection, config_version: str) -> list[dict]:
+    """Value-free rows for the LABEL-SCORED calibration report (PR3c-2a): every should/shouldnt
+    -labeled event of ONE config_version. Extends ``load_fire_records``'s columns with ``score``
+    + ``clarity`` + ``acceptance_signal`` (the label). ``skip`` and unlabeled rows are excluded
+    in SQL — they are not a usable judgment and must never reach the metrics. UNPAGED.
+    Assumes ``db.row_factory = aiosqlite.Row`` (the caller sets it — see calibrate.load_labeled)."""
+    cursor = await db.execute(
+        "SELECT id, activation, score, clarity, triggers_fired, suppressors, window_ref, "
+        "acceptance_signal FROM attention_events "
+        "WHERE config_version = ? AND acceptance_signal IS NOT NULL AND acceptance_signal != 'skip' "
+        "ORDER BY ts",
+        (config_version,),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
 async def update_l15_verdict(
     db: aiosqlite.Connection, event_id: str, verdict: dict | None,
 ) -> bool:

--- a/tests/test_attention/test_calibrate.py
+++ b/tests/test_attention/test_calibrate.py
@@ -120,6 +120,15 @@ def test_row_null_json_columns_safe():
     assert lf.causal_soft == frozenset() and lf.suppressors == frozenset()
 
 
+def test_row_missing_required_field_is_none_not_keyerror():
+    # a malformed row missing a REQUIRED field -> None (unresolvable), never a KeyError.
+    base = {"activation": "soft", "score": 0.6, "acceptance_signal": "should",
+            "window_ref": json.dumps({"utt_ids": [5]})}
+    assert labeled_from_row(base) is not None
+    for drop in ("activation", "score", "acceptance_signal"):
+        assert labeled_from_row({k: v for k, v in base.items() if k != drop}) is None
+
+
 # ── precision metrics ────────────────────────────────────────────────────────────────
 
 def test_overall_precision_excludes_suppressed():

--- a/tests/test_attention/test_calibrate.py
+++ b/tests/test_attention/test_calibrate.py
@@ -1,0 +1,298 @@
+"""calibrate (PR3c-2a): PURE precision metrics + row→LabeledFire mapper + Wilson + report,
+plus a seeded-DB ``load_labeled`` integration. The DB/LLM-free pure heart is what these exercise;
+the metric definitions are the load-bearing correctness surface (a subtly-wrong metric misleads
+weight tuning), so each is pinned including the architect-caught traps:
+  - zero-weight "ghost" triggers (topic_continuation @ contribution 0) must NOT earn precision,
+  - threshold sweep splits soft-only vs combined + guards the soft-recall zero-denominator,
+  - suppressor stats report raw counts (ratio only at n>=LOW_N),
+  - NULL clarity gets its own bucket.
+"""
+import json
+
+import aiosqlite
+import pytest
+
+from genesis.attention.calibrate import (
+    LOW_N,
+    LabeledFire,
+    PrecisionStat,
+    cooccurring_triggers,
+    format_report,
+    labeled_from_row,
+    load_labeled,
+    overall_precision,
+    precision_by_activation,
+    precision_by_clarity_band,
+    precision_by_trigger,
+    suppressor_stats,
+    threshold_sweep,
+    wilson_interval,
+)
+from genesis.db.crud import attention as crud
+from genesis.db.schema._tables import INDEXES, TABLES
+
+
+def _lf(key, signal="should", *, activation="soft", score=0.65, clarity=0.9,
+        causal=("multi_speaker",), hard=(), inert=(), suppressors=()):
+    return LabeledFire(
+        key=key, activation=activation, score=score, clarity=clarity, signal=signal,
+        causal_soft=frozenset(causal), hard_triggers=frozenset(hard),
+        inert_soft=frozenset(inert), suppressors=frozenset(suppressors),
+    )
+
+
+# ── wilson_interval ──────────────────────────────────────────────────────────────────
+
+def test_wilson_none_at_zero_n():
+    assert wilson_interval(0, 0) is None
+
+
+def test_wilson_perfect_small_n_is_not_1():
+    lo, hi = wilson_interval(2, 2)
+    assert hi == pytest.approx(1.0, abs=1e-9)
+    assert 0.2 < lo < 0.5           # 2/2 is NOT certainty — lower bound ~0.34
+
+
+def test_wilson_zero_successes():
+    lo, hi = wilson_interval(0, 2)
+    assert lo == pytest.approx(0.0, abs=1e-9)
+    assert 0.5 < hi < 0.8           # upper bound ~0.66
+
+
+def test_wilson_tightens_with_n():
+    _, hi_small = wilson_interval(8, 10)
+    _, hi_big = wilson_interval(80, 100)
+    assert hi_big < hi_small        # same ratio, more data -> tighter
+
+
+# ── PrecisionStat ────────────────────────────────────────────────────────────────────
+
+def test_precision_stat_props():
+    s = PrecisionStat(should=6, shouldnt=2)
+    assert s.n == 8 and s.precision == pytest.approx(0.75) and s.low_n is True
+    assert PrecisionStat(0, 0).precision is None and PrecisionStat(0, 0).wilson is None
+    assert PrecisionStat(15, 5).low_n is False
+
+
+# ── labeled_from_row (the causal/hard/inert split — the architect trap) ──────────────
+
+def _row(*, utt_ids=(21051,), activation="soft", score=0.65, clarity=0.9, signal="should",
+         triggers=(("question", "soft", 0.3), ("multi_speaker", "soft", 0.4)), suppressors=()):
+    return {
+        "id": "x", "activation": activation, "score": score, "clarity": clarity,
+        "acceptance_signal": signal,
+        "triggers_fired": json.dumps([{"name": n, "kind": k, "contribution": c} for n, k, c in triggers]),
+        "suppressors": json.dumps(list(suppressors)),
+        "window_ref": json.dumps({"utt_ids": list(utt_ids)}),
+    }
+
+
+def test_row_splits_causal_hard_inert():
+    # topic_continuation @ 0.0 (inert), ambient_name hard (contribution 0.0 but HARD), question causal
+    lf = labeled_from_row(_row(activation="hard", triggers=(
+        ("ambient_name", "hard", 0.0),
+        ("question", "soft", 0.3),
+        ("topic_continuation", "soft", 0.0),
+    )))
+    assert lf.hard_triggers == frozenset({"ambient_name"})
+    assert lf.causal_soft == frozenset({"question"})
+    assert lf.inert_soft == frozenset({"topic_continuation"})
+    assert lf.causal == frozenset({"ambient_name", "question"})   # inert NOT in causal
+
+
+def test_row_keys_on_last_utt_and_reads_score():
+    lf = labeled_from_row(_row(utt_ids=(10, 20, 30), score=0.72))
+    assert lf.key == 30 and lf.score == pytest.approx(0.72)
+
+
+def test_row_empty_utt_ids_none():
+    assert labeled_from_row(_row(utt_ids=())) is None
+
+
+def test_row_null_clarity_passthrough():
+    assert labeled_from_row(_row(clarity=None)).clarity is None
+
+
+def test_row_null_json_columns_safe():
+    lf = labeled_from_row({"activation": "soft", "score": 0.6, "clarity": 0.9,
+                           "acceptance_signal": "should", "window_ref": json.dumps({"utt_ids": [5]}),
+                           "triggers_fired": None, "suppressors": None})
+    assert lf.causal_soft == frozenset() and lf.suppressors == frozenset()
+
+
+# ── precision metrics ────────────────────────────────────────────────────────────────
+
+def test_overall_precision_excludes_suppressed():
+    fires = [_lf(1, "should"), _lf(2, "shouldnt"), _lf(3, "should", activation="suppressed")]
+    s = overall_precision(fires)
+    assert s.should == 1 and s.shouldnt == 1        # suppressed row not counted
+
+
+def test_precision_by_activation():
+    fires = [_lf(1, "should", activation="hard"), _lf(2, "shouldnt", activation="soft"),
+             _lf(3, "should", activation="soft")]
+    by = precision_by_activation(fires)
+    assert by["hard"].should == 1 and by["hard"].shouldnt == 0
+    assert by["soft"].should == 1 and by["soft"].shouldnt == 1
+
+
+def test_precision_by_trigger_uses_causal_only():
+    # topic_continuation is inert on both fires; it must NOT appear in precision_by_trigger.
+    fires = [
+        _lf(1, "should", causal=("multi_speaker", "question"), inert=("topic_continuation",)),
+        _lf(2, "shouldnt", causal=("multi_speaker",), inert=("topic_continuation",)),
+    ]
+    by = precision_by_trigger(fires)
+    assert "topic_continuation" not in by
+    assert by["multi_speaker"].should == 1 and by["multi_speaker"].shouldnt == 1
+    assert by["question"].should == 1 and by["question"].shouldnt == 0
+
+
+def test_cooccurring_triggers_counts_inert():
+    fires = [_lf(1, inert=("topic_continuation",)), _lf(2, inert=("topic_continuation",))]
+    assert cooccurring_triggers(fires) == {"topic_continuation": 2}
+
+
+def test_suppressor_stats_polarity_and_low_n():
+    # should = wrongly-vetoed MISS; shouldnt = correct veto. n<LOW_N -> rate None.
+    fires = [_lf(1, "should", activation="suppressed", suppressors=("mode_active_listen",)),
+             _lf(2, "shouldnt", activation="suppressed", suppressors=("mode_active_listen",))]
+    st = suppressor_stats(fires)["mode_active_listen"]
+    assert st.n_miss == 1 and st.n_correct_veto == 1 and st.n == 2
+    assert st.low_n is True and st.correct_veto_rate is None
+
+
+def test_suppressor_stats_rate_at_threshold():
+    fires = [_lf(i, "shouldnt", activation="suppressed", suppressors=("x",)) for i in range(LOW_N)]
+    st = suppressor_stats(fires)["x"]
+    assert st.n == LOW_N and st.correct_veto_rate == pytest.approx(1.0)
+
+
+# ── clarity bands ────────────────────────────────────────────────────────────────────
+
+def test_clarity_bands_bucket_and_null():
+    fires = [_lf(1, clarity=0.65), _lf(2, clarity=0.9), _lf(3, clarity=None), _lf(4, clarity=1.0)]
+    bands = precision_by_clarity_band(fires)
+    assert bands["[0.0,0.7)"].n == 1
+    assert bands["[0.85,1.0]"].n == 2           # 0.9 and 1.0 (top band closed)
+    assert bands["[0.7,0.85)"].n == 0           # empty band still reported, n=0
+    assert bands["clarity=NULL"].n == 1         # NULL gets its own bucket, not folded low
+
+
+# ── threshold sweep ──────────────────────────────────────────────────────────────────
+
+def test_threshold_sweep_monotone_and_soft_vs_combined():
+    fires = [
+        _lf(1, "should", activation="soft", score=0.62),
+        _lf(2, "shouldnt", activation="soft", score=0.70),
+        _lf(3, "should", activation="hard", score=0.0),   # hard: threshold-independent
+    ]
+    pts = {p.t: p for p in threshold_sweep(fires, [0.60, 0.65, 0.72])}
+    assert pts[0.60].n_soft_retained == 2
+    assert pts[0.65].n_soft_retained == 1        # 0.62 dropped
+    assert pts[0.72].n_soft_retained == 0        # both dropped -> soft precision None
+    assert pts[0.72].soft.precision is None
+    # combined always includes the hard should-fire
+    assert pts[0.72].combined.should == 1 and pts[0.72].combined.n == 1
+
+
+def test_threshold_sweep_score_equal_t_retained():
+    fires = [_lf(1, "should", activation="soft", score=0.70)]
+    assert threshold_sweep(fires, [0.70])[0].n_soft_retained == 1   # >= boundary
+
+
+def test_threshold_sweep_soft_recall_guarded():
+    # no should-labeled SOFT fires -> soft_recall_retained is None, never ZeroDivisionError
+    fires = [_lf(1, "shouldnt", activation="soft", score=0.8)]
+    assert threshold_sweep(fires, [0.6])[0].soft_recall_retained is None
+
+
+def test_threshold_sweep_soft_recall_fraction():
+    fires = [_lf(1, "should", activation="soft", score=0.62),
+             _lf(2, "should", activation="soft", score=0.80)]
+    pts = {p.t: p for p in threshold_sweep(fires, [0.6, 0.7])}
+    assert pts[0.6].soft_recall_retained == pytest.approx(1.0)
+    assert pts[0.7].soft_recall_retained == pytest.approx(0.5)      # only the 0.80 survives
+
+
+# ── report ───────────────────────────────────────────────────────────────────────────
+
+def _counts(should=0, shouldnt=0, skip=0, total=0):
+    by = {k: v for k, v in (("should", should), ("shouldnt", shouldnt), ("skip", skip)) if v}
+    labeled = should + shouldnt + skip
+    return {"total": total or labeled, "labeled": labeled,
+            "unlabeled": (total or labeled) - labeled, "by_signal": by}
+
+
+def test_report_zero_labels_graceful():
+    out = format_report([], _counts(total=352), config_version="0.2.0-taxonomy")
+    assert "0 labeled" in out and "0.2.0-taxonomy" in out
+
+
+def test_report_skip_rate_warning():
+    out = format_report([_lf(1, "should")], _counts(should=1, skip=9), config_version="v")
+    assert "skip_rate" in out and "⚠" in out           # 9/10 skipped -> warn
+
+
+def test_report_renders_metrics_and_no_transcript_text():
+    fires = [_lf(1, "should", causal=("multi_speaker",), inert=("topic_continuation",)),
+             _lf(2, "shouldnt", causal=("multi_speaker",))]
+    out = format_report(fires, _counts(should=1, shouldnt=1), config_version="v")
+    assert "multi_speaker" in out and "topic_continuation" in out   # names, not text
+    assert "co-occurring INERT" in out and "clarity band" in out and "threshold sweep" in out
+
+
+# ── load_labeled (seeded read-only DB integration) ──────────────────────────────────
+
+def _row_tuple(id_, config_version, *, activation="soft", score=0.65, clarity=0.9, signal=None,
+               triggers=(("multi_speaker", "soft", 0.4),), utt_ids=(1, 2, 3)):
+    """A full attention_events tuple in crud.COLUMNS order (bulk_upsert writes labels on insert)."""
+    triggers_json = json.dumps([{"name": n, "kind": k, "contribution": c} for n, k, c in triggers])
+    window_ref = json.dumps({"snapshot_id": "s", "session_id": "s1", "utt_ids": list(utt_ids),
+                             "ts_start": 0.0, "ts_end": 1.0})
+    ts = "2026-07-01T00:00:00+00:00"
+    return (id_, ts, "s1", activation, score, triggers_json, json.dumps([]), window_ref,
+            "unknown", clarity, None, signal, "s", config_version, ts)
+
+
+async def _seed(path, rows):
+    conn = await aiosqlite.connect(path)
+    conn.row_factory = aiosqlite.Row
+    await conn.execute(TABLES["attention_events"])
+    for idx in INDEXES:
+        if "attention_events" in idx:
+            await conn.execute(idx)
+    await conn.commit()
+    await crud.bulk_upsert_events(conn, rows)
+    await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_load_labeled_scopes_version_and_excludes_skip_unlabeled(tmp_path):
+    p = tmp_path / "g.db"
+    await _seed(p, [
+        _row_tuple("a", "0.2.0-taxonomy", signal="should", utt_ids=(11,)),
+        _row_tuple("b", "0.2.0-taxonomy", signal="shouldnt", utt_ids=(22,)),
+        _row_tuple("c", "0.2.0-taxonomy", signal="skip", utt_ids=(33,)),        # excluded
+        _row_tuple("d", "0.2.0-taxonomy", signal=None, utt_ids=(44,)),          # unlabeled excluded
+        _row_tuple("e", "0.1.0-default", signal="should", utt_ids=(55,)),       # other version
+    ])
+    fires, unresolved, counts = await load_labeled(p, "0.2.0-taxonomy")
+    assert {f.key for f in fires} == {11, 22}          # only labeled non-skip of THIS version
+    assert unresolved == 0
+    assert counts["by_signal"].get("skip") == 1 and counts["labeled"] == 3   # counts see skip too
+
+
+@pytest.mark.asyncio
+async def test_load_labeled_maps_causal_split_and_score(tmp_path):
+    p = tmp_path / "g.db"
+    await _seed(p, [
+        _row_tuple("a", "0.2.0-taxonomy", signal="should", score=0.71, utt_ids=(11,),
+                   triggers=(("question", "soft", 0.3), ("topic_continuation", "soft", 0.0),
+                             ("multi_speaker", "soft", 0.4))),
+    ])
+    fires, _, _ = await load_labeled(p, "0.2.0-taxonomy")
+    lf = fires[0]
+    assert lf.causal_soft == frozenset({"question", "multi_speaker"})
+    assert lf.inert_soft == frozenset({"topic_continuation"})
+    assert lf.score == pytest.approx(0.71) and lf.signal == "should"

--- a/tests/test_db/test_crud_attention.py
+++ b/tests/test_db/test_crud_attention.py
@@ -218,6 +218,24 @@ async def test_load_fire_records_returns_all_rows_for_version(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_load_labeled_fires_scopes_labeled_nonskip_with_score_and_signal(tmp_path):
+    """PR3c-2a: only should/shouldnt rows of ONE version, carrying score+clarity+acceptance_signal."""
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [
+        _row(1, utt_ids=(11,), acceptance="should", score=0.71, config_version="0.2.0-taxonomy"),
+        _row(2, utt_ids=(22,), acceptance="shouldnt", config_version="0.2.0-taxonomy"),
+        _row(3, utt_ids=(33,), acceptance="skip", config_version="0.2.0-taxonomy"),      # excluded
+        _row(4, utt_ids=(44,), acceptance=None, config_version="0.2.0-taxonomy"),        # excluded
+        _row(5, utt_ids=(55,), acceptance="should", config_version="0.1.0-default"),     # other version
+    ])
+    rows = await crud.load_labeled_fires(db, "0.2.0-taxonomy")
+    assert {r["id"] for r in rows} == {"id-1", "id-2"}                       # labeled non-skip, this version
+    r1 = next(r for r in rows if r["id"] == "id-1")
+    assert r1["acceptance_signal"] == "should" and r1["score"] == 0.71 and r1["clarity"] == 0.9
+    await db.close()
+
+
+@pytest.mark.asyncio
 async def test_update_l15_verdict_backfills_even_on_labeled_row(tmp_path):
     """B3: l15_verdict is a MACHINE field — unconditional, unlike the label-guarded upsert."""
     db = await _db(tmp_path / "g.db")


### PR DESCRIPTION
## What

Offline, **precision-first** calibration report over the attention shadow corpus — the tool that turns dashboard should/shouldn't labels on `attention_events` fires into tuning signal. Part of Track 1 (attention engine); follows PR3c-1 (A/B differ + version filter).

- **`src/genesis/attention/calibrate.py`** (NEW) — genesis-side adapter (not edge-core; not imported by `attention/__init__` → edge-portability test unaffected). Read-only CLI:
  `python -m genesis.attention.calibrate --config-version 0.2.0-taxonomy [--db PATH]`
- **`load_labeled_fires`** crud — labeled (should/shouldnt) rows of one `config_version` with `score`+`clarity`+`acceptance_signal`; skip + unlabeled excluded in SQL.

## Metrics
Per-trigger & per-activation precision, each with a **95% Wilson interval + low-n flag** (a 2/2 reads as `[0.34–1.0, n=2 LOW]`, not "1.0"); a **soft-threshold sweep** (soft-only precision + combined + retained-should, zero-denominator guarded); a **clarity-band split** (exposes garble-driven fires; NULL bucket handled); **suppressor veto-correctness** (raw counts, ratio only at n≥10); a label-quality header (base-rate + skip_rate warning).

## The load-bearing correctness guard
`triggers_fired` stores **every** hit including `contribution==0.0` — `topic_continuation` (weight 0) co-occurs on **206/352** fires; hard triggers store contribution 0. The row mapper splits triggers into **causal_soft** (`kind==soft` & `contribution>0`), **hard_triggers** (`kind==hard`), and **inert_soft** (weight-0 co-occurring). Only causal triggers are scored; inert ones are reported separately so a zero-weight trigger can **never** earn a phantom precision. Caught by a pre-build architect audit; verified on live rows.

## Scope
- **Precision-first**: the store holds only fired windows → measures over-firing (false positives). True recall (missed non-fires) is out of scope (deferred — needs a non-fire labeling surface).
- **No migration, no deploy** (offline tool). PR3c-2b (weight candidate search + suggested overlay) is gated on seeing this report's real numbers once a label batch exists.

## Firewall
Emits only trigger names, activations, floats, utt-ids, counts — never transcript text. `load_labeled_fires` selects no text column; read-only (`?mode=ro`).

## Verification
- 41 targeted tests (pure metrics incl. Wilson, causal/hard/inert split, threshold soft-only-vs-combined + zero-denom guard, suppressor polarity + low-n, clarity NULL bucket, total-mapper guard) + seeded-DB load + crud scoping; full attention suite (181) + edge-portability green; ruff clean.
- **E2E on real data**: ran read-only over prod (graceful "0 labeled" + real counts 352); built a fixture from the real 352 fires + a synthetic pilot-label batch → full report renders correctly (topic_continuation correctly excluded from precision + shown as inert; Wilson/low-n/clarity-bands/threshold-sweep all correct; firewall clean). Prod untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)