### PR TITLE
fix(reflection): self-heal weekly jobs (daily fire, ≤1 success/week via idempotency)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   having ingested its source — so re-adding that same file or URL was silently skipped and nothing
   came back. Now deleting a source's last remaining unit clears that record, and re-ingesting the
   source works normally again.
+
+- **The weekly self-assessment and quality-calibration jobs now recover on their own instead of
+  going dark for weeks.** Previously each ran only once a week, so if that one run failed — for
+  example when the shared Claude Code subscription was capped and returned empty output — the next
+  attempt wasn't until the following week, and a multi-day outage could leave them stale for 2–3
+  weeks. They now run daily but still complete at most once per week (an idempotency check skips the
+  rest of the week once one run succeeds), so a failed day is simply retried the next day until it
+  succeeds. Side effect: the successful run now normally lands early in the week rather than on Sunday.
+
 - **`update.sh` no longer hangs if the health watchdog restarts the server mid-update.**
   During an update Genesis stops its server to swap in new code and migrate the database. The
   background health watchdog could see it "down" and restart it right then — and the revived

--- a/src/genesis/reflection/scheduler.py
+++ b/src/genesis/reflection/scheduler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -16,14 +16,22 @@ logger = logging.getLogger(__name__)
 
 
 class ReflectionScheduler:
-    """Owns APScheduler for weekly reflection jobs.
+    """Owns APScheduler for the weekly reflection jobs.
 
-    - Weekly self-assessment: Sunday 10:00 (user-configured timezone)
-    - Weekly quality calibration: Sunday 12:00 (user-configured timezone)
-    - Learning regression check runs after quality calibration completes
+    Both jobs FIRE DAILY (at the configured hours) but the
+    ``_already_ran_this_week`` idempotency gate holds each to ≤1 SUCCESSFUL run
+    per Monday-anchored week — so a day that fails (e.g. the shared Claude Code
+    subscription is capped and returns empty output) is retried the next day
+    instead of leaving a ≥7-day gap. Effective cadence: one success per week,
+    normally landing on the week's first fire (Monday).
 
-    Timezone is resolved via ``genesis.env.user_timezone()`` which checks
-    USER_TIMEZONE env → genesis.yaml timezone → UTC fallback.
+    - Self-assessment: daily @ ``assessment_hour`` (default 10)
+    - Quality calibration: daily @ ``calibration_hour`` (default 12)
+    - Learning regression check runs after a SUCCESSFUL quality calibration
+
+    ``assessment_day`` is retained for back-compat but no longer pins the fire
+    day. Timezone is resolved via ``genesis.env.user_timezone()`` (USER_TIMEZONE
+    env → genesis.yaml timezone → UTC fallback).
     """
 
     def __init__(
@@ -69,13 +77,19 @@ class ReflectionScheduler:
 
         self._scheduler = AsyncIOScheduler()
 
+        # Fire DAILY (at the configured hour) rather than only on one weekday,
+        # and let the _already_ran_this_week() idempotency gate hold it to ≤1
+        # SUCCESSFUL run per week. This self-heals: if the run fails on its
+        # normal day (e.g. the shared Claude Code subscription is capped and
+        # returns empty output), it retries the next day — and the next —
+        # until one success lands that week, instead of leaving a ≥7-day gap.
+        # Effective cadence: one success per Monday-anchored week (normally the
+        # week's first fire); later days that week no-op via the gate.
+        # (`_assessment_day` is retained for config/back-compat but no longer
+        # pins the fire day — the idempotency week anchor governs cadence.)
         self._scheduler.add_job(
             self._run_assessment,
-            CronTrigger(
-                day_of_week=self._assessment_day,
-                hour=self._assessment_hour,
-                timezone=tz,
-            ),
+            CronTrigger(hour=self._assessment_hour, timezone=tz),
             id="weekly_self_assessment",
             max_instances=1,
             misfire_grace_time=None,
@@ -83,11 +97,7 @@ class ReflectionScheduler:
 
         self._scheduler.add_job(
             self._run_calibration,
-            CronTrigger(
-                day_of_week=self._assessment_day,
-                hour=self._calibration_hour,
-                timezone=tz,
-            ),
+            CronTrigger(hour=self._calibration_hour, timezone=tz),
             id="weekly_quality_calibration",
             max_instances=1,
             misfire_grace_time=None,
@@ -95,9 +105,9 @@ class ReflectionScheduler:
 
         self._scheduler.start()
         logger.info(
-            "Reflection scheduler started (assessment=%s@%02d, calibration=%s@%02d, tz=%s)",
-            self._assessment_day, self._assessment_hour,
-            self._assessment_day, self._calibration_hour, tz_name,
+            "Reflection scheduler started (daily fire, ≤1 success/week via idempotency; "
+            "assessment@%02d, calibration@%02d, tz=%s)",
+            self._assessment_hour, self._calibration_hour, tz_name,
         )
 
     async def stop(self) -> None:
@@ -173,23 +183,22 @@ class ReflectionScheduler:
             result = await self._bridge.run_quality_calibration(self._db)
             if result.success:
                 logger.info("Quality calibration completed")
-            else:
-                logger.warning("Quality calibration failed: %s", result.reason)
-
-            # Run regression check after calibration
-            if self._stability:
-                regression = await self._stability.check_regression(self._db)
-                if regression:
-                    await self._stability.emit_regression_signal(self._db)
-                    logger.warning("Learning regression detected after calibration")
-                else:
-                    # Resolve-on-recovery: clear any standing regression alarm
-                    # once effectiveness recovers, so it doesn't persist stale.
-                    await self._stability.resolve_regression_if_standing(self._db)
-
-            if result.success:
+                # Regression check only after a SUCCESSFUL calibration — a failed
+                # run produces no new effectiveness data to regress against, and
+                # with daily firing an outage week would otherwise re-run this
+                # check (and possibly re-emit the signal) every day.
+                if self._stability:
+                    regression = await self._stability.check_regression(self._db)
+                    if regression:
+                        await self._stability.emit_regression_signal(self._db)
+                        logger.warning("Learning regression detected after calibration")
+                    else:
+                        # Resolve-on-recovery: clear any standing regression alarm
+                        # once effectiveness recovers, so it doesn't persist stale.
+                        await self._stability.resolve_regression_if_standing(self._db)
                 await self._record_job_result("weekly_calibration")
             else:
+                logger.warning("Quality calibration failed: %s", result.reason)
                 await self._record_job_result("weekly_calibration", error=result.reason or "unknown")
         except Exception as exc:
             logger.exception("Quality calibration error")
@@ -206,13 +215,18 @@ class ReflectionScheduler:
         The observation is written only on a *successful* run (a failure writes
         nothing), so its presence is a last-success signal and a failed run
         stays retriable.
+
+        The reflection jobs fire DAILY (see ``start``); this gate is what holds
+        that to ≤1 successful run per Monday-anchored week. Once a week's run
+        succeeds, later days no-op here; if the run fails, the window stays
+        empty so the next day's fire retries — that is the self-heal.
         """
         from genesis.db.crud import observations
 
         # Get start of current week (Monday 00:00)
         now = datetime.now(UTC)
         monday = now.replace(hour=0, minute=0, second=0, microsecond=0)
-        monday -= __import__("datetime").timedelta(days=now.weekday())
+        monday -= timedelta(days=now.weekday())
         monday_iso = monday.isoformat()
 
         for obs_type in obs_types:

--- a/tests/test_reflection/test_scheduler.py
+++ b/tests/test_reflection/test_scheduler.py
@@ -60,6 +60,24 @@ class TestSchedulerLifecycle:
         assert not scheduler.is_running
 
     @pytest.mark.asyncio
+    async def test_jobs_fire_daily_for_self_heal(self, scheduler):
+        # Both reflection jobs must fire EVERY day (day_of_week unrestricted) so
+        # the _already_ran_this_week idempotency gate — not the cron day —
+        # governs cadence. This is the self-heal: a day that fails on empty CC
+        # output retries the next day instead of leaving a ≥7-day gap.
+        await scheduler.start()
+        try:
+            for job_id in ("weekly_self_assessment", "weekly_quality_calibration"):
+                job = scheduler._scheduler.get_job(job_id)
+                assert job is not None, f"{job_id} not registered"
+                dow = next(
+                    f for f in job.trigger.fields if f.name == "day_of_week"
+                )
+                assert str(dow) == "*", f"{job_id} still pinned to one weekday: {dow}"
+        finally:
+            await scheduler.stop()
+
+    @pytest.mark.asyncio
     async def test_not_running_before_start(self, scheduler):
         assert not scheduler.is_running
 
@@ -140,6 +158,20 @@ class TestCalibrationJob:
     async def test_no_regression_no_signal(self, scheduler, mock_stability, db):
         mock_stability.check_regression.return_value = False
         await scheduler._run_calibration()
+        mock_stability.emit_regression_signal.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_regression_check_on_failed_calibration(
+        self, scheduler, mock_bridge, mock_stability, db,
+    ):
+        # A failed calibration produces no new baseline — the regression check
+        # (and any signal) must be skipped, so daily retries during a CC outage
+        # don't re-run/re-emit it every day.
+        mock_bridge.run_quality_calibration.return_value = ReflectionResult(
+            success=False, reason="empty output",
+        )
+        await scheduler._run_calibration()
+        mock_stability.check_regression.assert_not_called()
         mock_stability.emit_regression_signal.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What & why

The weekly self-assessment and quality-calibration jobs fired **once a week** (Sunday, `misfire_grace_time=None`), so a single failed run meant the next attempt was a full week later. Root cause of the recent failures: the shared Claude Code Max subscription hit its **usage cap** → `claude -p` returned **empty output** → the reflection parsed to nothing → recorded a failure. During a multi-day cap (late June) the jobs stayed broken for ~2–3 weeks.

## The fix — self-heal via daily fire + idempotency

Both jobs now fire **daily** (dropped `day_of_week`; kept the hour), and the **existing `_already_ran_this_week()` idempotency gate** holds each to **≤1 *successful* run per Monday-anchored week**. A day that fails leaves the idempotency window empty, so the next day retries — until one success lands that week. This recovers from *any* transient cause (a usage cap, a throttle, a one-off), not just the specific June outage.

**Behavior note:** the effective run-day shifts from **Sunday → the week's first fire (Monday)**; retries fill in later in the week after a failure. Monday-morning "review last week" is a natural fit, and it moves the job off the Sunday window where the cap landed. (Easy to pin back to Sunday via the idempotency anchor if preferred.)

## From review (architect + code-reviewer)
- **Guard the calibration regression check behind `result.success`** — a failed calibration has no new baseline, and daily firing would otherwise re-run it (and possibly re-emit the signal) every day during an outage.
- Replaced an obscure `__import__("datetime").timedelta` with a proper top-level `timedelta` import (the gate is load-bearing).
- Corrected the class docstring (said "Sunday"; now daily/Monday-anchored).
- Verified the idempotency gate is correct: `observations.query` sorts `created_at DESC`, so `limit=1` returns the newest row (a reviewer flagged a possible oldest-first bug — refuted).

## Verification
- 25 unit tests green (added: daily-fire assertion, failed-calibration-skips-regression). ruff clean.
- E2E: the trigger fires on consecutive days (07-01 → 07-02 → 07-03); a stuck 14-day-old state **runs** (self-heal); a this-week success **skips** (≤1/week).

## Deploy note
If deployed mid-week after a healthy prior run, expect **one** extra invocation on the first fire of the new regime (the prior Sunday run falls outside the new Monday-anchored window). One-time, ~$0.30, and moot for the currently-stuck jobs.

## Not in this PR (deliberately)
- **Live failover to a roster model (GLM-5.2) when capped** — needs cap *detection* first (the cap returns silent-empty, treated as success); a separate careful follow-on.
- **Reducing ego CC-subscription consumption** (~$88/wk Opus — the real driver of hitting the cap) — a separate analysis + proposal.
