### PR TITLE
fix(contribution): block Tailscale CGNAT + IPv6 in the sanitizer floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           set -euo pipefail
           body=$(gh pr view ${{ github.event.pull_request.number }} --json body -q .body 2>/dev/null || echo "")
-          PATTERNS='10\.176\.[0-9]|192\.168\.50\.[0-9]|100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.|046056[0-9]{6}|moonandstar|zorror|assistant1'
+          PATTERNS='10\.176\.[0-9]|192\.168\.50\.[0-9]|100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.|fd7a:|046056[0-9]{6}|moonandstar|zorror|assistant1'
           if echo "$body" | grep -qE "$PATTERNS"; then
             echo "::error::PR description contains private infrastructure details"
             echo "$body" | grep -nE "$PATTERNS" || true

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -28,6 +28,12 @@ regex = '''100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}'''
 tags = ["infrastructure", "genesis"]
 
 [[rules]]
+id = "genesis-tailscale-ipv6"
+description = "Tailscale IPv6 ULA prefix (fd7a:)"
+regex = '''\bfd7a:'''
+tags = ["infrastructure", "genesis"]
+
+[[rules]]
 id = "genesis-aws-account-id"
 description = "AWS account ID near identifying keyword"
 regex = '''(?i)(account.?id|aws.?account)[\s=:"']+\d{12}'''
@@ -45,5 +51,6 @@ paths = [
     '''tests/''',
     '''\.github/workflows/''',
     '''src/genesis/contribution/sanitize\.py''',
+    '''scripts/hooks/commit-msg''',
     '''\.gitleaks\.toml''',
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Security
+
+- **The contribution sanitizer now blocks Tailscale addresses before they can reach the public
+  repo.** When you prepare a community contribution, the pre-push privacy scan now catches Tailscale
+  CGNAT and Tailscale IPv6 addresses, and flags the full private `10.176` subnet range (not just two
+  hard-coded addresses) — closing a gap where these install-specific addresses could otherwise slip
+  into a public PR. The commit-message guard gained the same IPv6 coverage.
+
 ### Added
 
 - **You can now start an interactive Claude Code session on a different model with one command.**

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -5,7 +5,7 @@
 # and private hostnames. Covers the gap that gitleaks (file-content only)
 # does not scan commit messages.
 
-PATTERNS='10\.176\.[0-9]|192\.168\.50\.[0-9]|100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.|046056[0-9]{6}|moonandstar|zorror|assistant1'
+PATTERNS='10\.176\.[0-9]|192\.168\.50\.[0-9]|100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.|fd7a:|046056[0-9]{6}|moonandstar|zorror|assistant1'
 
 if grep -qE "$PATTERNS" "$1"; then
     echo ""

--- a/src/genesis/contribution/sanitize.py
+++ b/src/genesis/contribution/sanitize.py
@@ -84,13 +84,14 @@ _PORTABILITY_PATTERNS: tuple[tuple[str, str], ...] = (
     (r"/home/ubuntu/agent-zero", "absolute path /home/ubuntu/agent-zero"),
     (r"/home/ubuntu/\.[A-Za-z]", "absolute path to user dotfile"),
     (r"-home-ubuntu-genesis", "CC project dir slug"),
-    (r"10\.176\.34\.199", "Ollama host IP"),
-    (r"10\.176\.34\.206", "container IP"),
+    (r"10\.176\.\d{1,3}\.\d{1,3}", "private 10.176 subnet IP"),
+    (r"100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}", "Tailscale CGNAT IP"),
     (r"192\.168\.50\.\d+", "private subnet IP"),
     (r"\bWingedGuardian/(Genesis|genesis-backups)\b", "private repo reference"),
     (r"\bAmerica/New_York\b", "hardcoded user timezone"),
     (r"\bfd42:e3ba\b", "container IPv6 prefix"),
     (r"\bfd4d:77b8\b", "host IPv6 prefix"),
+    (r"\bfd7a:", "Tailscale IPv6 prefix"),
     (r"\b5070ti\b", "hardware reference"),
 )
 

--- a/tests/test_contribution/test_sanitize.py
+++ b/tests/test_contribution/test_sanitize.py
@@ -500,3 +500,60 @@ def test_detect_secrets_positive_blocks(clean_diff, monkeypatch):
         r = sanitize.scan_diff(clean_diff)
     assert r.ok is False
     assert any(f.scanner == "detect-secrets" for f in r.blocking())
+
+
+def test_portability_cgnat_blocks():
+    """Tailscale CGNAT addresses (100.64-127.x.x) must be blocked pre-push."""
+    diff = (
+        "diff --git a/config.py b/config.py\n"
+        "--- a/config.py\n+++ b/config.py\n@@ -1 +1 @@\n"
+        "+NODE_URL = 'http://100.64.0.5:8080'\n"
+    )
+    r = sanitize.scan_diff(diff)
+    assert r.ok is False
+    assert any(f.kind == FindingKind.PORTABILITY for f in r.blocking())
+
+
+def test_portability_non_cgnat_100_allowed():
+    """A 100.x address OUTSIDE the CGNAT range (64-127) is a normal public IP
+    and must NOT be flagged (guards against an over-broad regex)."""
+    diff = (
+        "diff --git a/x.py b/x.py\n"
+        "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n+PUBLIC = '100.200.5.5'\n"
+    )
+    r = sanitize.scan_diff(diff)
+    assert r.ok is True
+
+
+def test_portability_tailscale_ipv6_blocks():
+    """Tailscale IPv6 (fd7a: ULA prefix) must be blocked pre-push."""
+    diff = (
+        "diff --git a/x.py b/x.py\n"
+        "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n+HOST6 = 'fd7a:115c:a1e0::1'\n"
+    )
+    r = sanitize.scan_diff(diff)
+    assert r.ok is False
+    assert any(f.kind == FindingKind.PORTABILITY for f in r.blocking())
+
+
+def test_portability_10_176_range_blocks():
+    """Any 10.176.x.x address (not just the two legacy literals) must block."""
+    diff = (
+        "diff --git a/x.py b/x.py\n"
+        "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n+HOST = '10.176.99.42'\n"
+    )
+    r = sanitize.scan_diff(diff)
+    assert r.ok is False
+    assert any(f.kind == FindingKind.PORTABILITY for f in r.blocking())
+
+
+def test_portability_fd7a_requires_colon_no_false_positive():
+    r"""`\bfd7a:` should match Tailscale IPv6 (fd7a:...) but NOT an unrelated
+    hex token that merely contains 'fd7a' without the trailing colon (e.g. a
+    commit hash), so the floor doesn't over-block legitimate content."""
+    diff = (
+        "diff --git a/x.py b/x.py\n"
+        "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n+HASH = 'fd7abeefcafe0123'\n"
+    )
+    r = sanitize.scan_diff(diff)
+    assert r.ok is True


### PR DESCRIPTION
## What

The public-repo contribution sanitizer's always-on portability floor missed two install-specific address classes — Tailscale CGNAT and the Tailscale IPv6 ULA prefix — so they could reach a public PR via the `genesis contribute` path. This closes the gap across every enforcement layer that already covers the CGNAT class:

- **Sanitizer floor** (`_check_portability`): added the CGNAT range and the Tailscale IPv6 prefix, and widened the private subnet match from two hard-coded addresses to the full range (deterministic, always-on).
- **gitleaks ruleset** (`.gitleaks.toml`): added the missing IPv6 rule (CGNAT was already present).
- **commit-message guard** and **CI PR-description scan**: added the IPv6 prefix (both already had CGNAT).
- Allowlisted the commit-msg pattern file so its own definitions don't self-match.

## Testing (TDD, red-first)

5 new tests in `test_sanitize.py`: CGNAT blocks, IPv6 blocks, the widened subnet range blocks, a public address outside the CGNAT range is NOT flagged (false-positive guard), and an IPv6-lookalike hex token without a colon is NOT flagged. Full file: **42 passing**, ruff clean. E2E-verified end to end: the floor blocks the real Tailscale address classes and passes clean diffs; the commit-message guard blocks and passes correctly.

## Scope notes

- The audit also suggested passing `--config` to the sanitizer's optional gitleaks layer. Intentionally **dropped**: reusing `.gitleaks.toml` inherits its global path-allowlist — correct for the repo's own at-rest scan, wrong trust boundary for untrusted contribution diffs. Filed as a follow-up (a rules-only diff-scan config).
- Separately filed follow-up: CI's `rg` portability scan doesn't scan committed source for private IPs at all (relies on the local gitleaks pre-commit hook) — a pre-existing defense-in-depth gap, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
