### PR TITLE
fix(dashboard): knowledge delete used nonexistent rt.qdrant_client (500 on every delete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,11 +78,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
-- **Deleting a knowledge item no longer blocks you from re-adding its source.** When you deleted
-  a knowledge unit from the dashboard, Genesis removed it from the search index but still remembered
-  having ingested its source — so re-adding that same file or URL was silently skipped and nothing
-  came back. Now deleting a source's last remaining unit clears that record, and re-ingesting the
-  source works normally again.
+- **Deleting a knowledge item from the dashboard now works end to end.** Previously the delete
+  button returned a server error, and behind the scenes the item was only half-removed — dropped
+  from search but with its stored embedding left behind and its source still marked as already
+  ingested, so re-adding that same file or URL was silently skipped and nothing came back. Deletes
+  now complete cleanly (search entry and embedding both removed), and once a source's last item is
+  deleted, re-ingesting that file or URL works again.
 
 - **The weekly self-assessment and quality-calibration jobs now recover on their own instead of
   going dark for weeks.** Previously each ran only once a week, so if that one run failed — for

--- a/src/genesis/dashboard/routes/knowledge.py
+++ b/src/genesis/dashboard/routes/knowledge.py
@@ -131,13 +131,16 @@ async def knowledge_delete(unit_id: str):
         if not deleted:
             return jsonify({"error": "Unit not found"}), 404
 
-        # Also delete from Qdrant if we have a reference
+        # Also delete from Qdrant. The client lives on the memory store, not on
+        # the runtime directly — rt.qdrant_client never existed (bug since #83,
+        # sibling of the dream_cycle rt.qdrant→store.qdrant_client fix in #385).
         qdrant_deleted = False
-        if qdrant_id and rt.qdrant_client:
+        store = getattr(rt, "memory_store", None)
+        if qdrant_id and store is not None:
             try:
                 from qdrant_client.models import PointIdsList
 
-                rt.qdrant_client.delete(
+                store.qdrant_client.delete(
                     collection_name="knowledge_base",
                     points_selector=PointIdsList(points=[qdrant_id]),
                 )

--- a/tests/test_dashboard/test_knowledge_api.py
+++ b/tests/test_dashboard/test_knowledge_api.py
@@ -1,0 +1,127 @@
+"""Tests for the dashboard knowledge-browser DELETE route.
+
+Regression focus: the DELETE route must remove the Qdrant vector via
+``rt.memory_store.qdrant_client`` — NOT the non-existent ``rt.qdrant_client``
+(a bug present since #83 that made every delete 500) — and must then drop the
+unit from the ingestion manifest (tombstone) so a fully-deleted source can be
+re-ingested.
+
+These tests use a faithful ``SimpleNamespace`` runtime stand-in rather than a
+bare ``MagicMock``: a MagicMock would auto-vivify ``rt.qdrant_client`` and
+silently hide the bug. SimpleNamespace raises ``AttributeError`` on attributes
+the real ``GenesisRuntime`` lacks, exactly as production does.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from genesis.dashboard.api import blueprint
+
+
+@pytest.fixture()
+def app():
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    app.config["TESTING"] = True
+    app.secret_key = "test-secret-key"
+    return app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+_SENTINEL = object()
+
+
+def _fake_rt(*, memory_store=_SENTINEL, is_bootstrapped=True, db=_SENTINEL):
+    """A faithful runtime stand-in that genuinely lacks ``qdrant_client``."""
+    if memory_store is _SENTINEL:
+        memory_store = MagicMock()  # .qdrant_client.delete is an auto-mock
+    if db is _SENTINEL:
+        db = MagicMock()
+    return SimpleNamespace(
+        is_bootstrapped=is_bootstrapped, db=db, memory_store=memory_store
+    )
+
+
+@patch("genesis.knowledge.manifest.ManifestManager")
+@patch("genesis.db.crud.knowledge.delete", new_callable=AsyncMock)
+@patch("genesis.db.crud.knowledge.get", new_callable=AsyncMock)
+@patch("genesis.runtime.GenesisRuntime")
+def test_delete_removes_qdrant_via_memory_store_and_tombstones(
+    MockRT, mock_get, mock_delete, MockManifest, client
+):
+    """Happy path: SQLite + Qdrant (via memory_store) + manifest all handled."""
+    rt = _fake_rt()
+    MockRT.instance.return_value = rt
+    mock_get.return_value = {"id": "u-1", "qdrant_id": "qid-1"}
+    mock_delete.return_value = True
+    MockManifest.return_value.remove_unit.return_value = True
+
+    resp = client.delete("/api/genesis/knowledge/u-1")
+
+    assert resp.status_code == 200  # buggy rt.qdrant_client code 500s here
+    body = resp.get_json()
+    assert body["sqlite_deleted"] is True
+    assert body["qdrant_deleted"] is True
+    assert body["manifest_removed"] is True
+    # Qdrant deletion routed through the memory store's client + right collection.
+    rt.memory_store.qdrant_client.delete.assert_called_once()
+    _, kwargs = rt.memory_store.qdrant_client.delete.call_args
+    assert kwargs["collection_name"] == "knowledge_base"
+    # The RIGHT vector is deleted (the crux of the original bug).
+    assert list(kwargs["points_selector"].points) == ["qid-1"]
+    MockManifest.return_value.remove_unit.assert_called_once_with("u-1")
+
+
+@patch("genesis.knowledge.manifest.ManifestManager")
+@patch("genesis.db.crud.knowledge.delete", new_callable=AsyncMock)
+@patch("genesis.db.crud.knowledge.get", new_callable=AsyncMock)
+@patch("genesis.runtime.GenesisRuntime")
+def test_delete_ok_when_memory_store_absent(
+    MockRT, mock_get, mock_delete, MockManifest, client
+):
+    """No memory store → Qdrant delete is skipped gracefully (no 500); the
+    manifest tombstone still runs."""
+    MockRT.instance.return_value = _fake_rt(memory_store=None)
+    mock_get.return_value = {"id": "u-1", "qdrant_id": "qid-1"}
+    mock_delete.return_value = True
+    MockManifest.return_value.remove_unit.return_value = True
+
+    resp = client.delete("/api/genesis/knowledge/u-1")
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["qdrant_deleted"] is False
+    assert body["manifest_removed"] is True
+
+
+@patch("genesis.knowledge.manifest.ManifestManager")
+@patch("genesis.db.crud.knowledge.delete", new_callable=AsyncMock)
+@patch("genesis.db.crud.knowledge.get", new_callable=AsyncMock)
+@patch("genesis.runtime.GenesisRuntime")
+def test_delete_404_when_unit_missing(
+    MockRT, mock_get, mock_delete, MockManifest, client
+):
+    MockRT.instance.return_value = _fake_rt()
+    mock_get.return_value = None
+    mock_delete.return_value = False  # nothing deleted
+
+    resp = client.delete("/api/genesis/knowledge/missing")
+
+    assert resp.status_code == 404
+    MockManifest.return_value.remove_unit.assert_not_called()
+
+
+@patch("genesis.runtime.GenesisRuntime")
+def test_delete_503_when_not_bootstrapped(MockRT, client):
+    MockRT.instance.return_value = _fake_rt(is_bootstrapped=False, db=None)
+    resp = client.delete("/api/genesis/knowledge/u-1")
+    assert resp.status_code == 503


### PR DESCRIPTION
## Problem

The dashboard knowledge DELETE route (`knowledge_delete`) referenced `rt.qdrant_client`, which `GenesisRuntime` has **never had** (bug since #83, `a0c0099f`). Every dashboard knowledge delete:
1. deleted the SQLite row (runs first), then
2. **crashed** at the Qdrant step with `AttributeError: 'GenesisRuntime' object has no attribute 'qdrant_client'` → **HTTP 500**,
3. orphaning the embedding, and
4. **never reaching the manifest tombstone** — so #846's re-ingest-after-delete fix could never actually run.

Confirmed live via traceback during the #846 deploy E2E. Enumerated: this was the *only* `rt.qdrant_client` reference left; the sibling `rt.qdrant→store.qdrant_client` bug in dream_cycle was already fixed in #385.

## Fix

Route the Qdrant deletion through the memory store's client: `store = getattr(rt, "memory_store", None)` then `store.qdrant_client.delete(...)`, guarded so a missing store degrades gracefully (skip Qdrant, no 500) instead of crashing. `rt.memory_store` is a property returning the `MemoryStore` whose `.qdrant_client` is the live client — mirrors `references.py:250` and the #385 pattern. The manifest tombstone (from #846) now actually runs.

## Tests

First tests of this route (`tests/test_dashboard/test_knowledge_api.py`). Key detail: they use a faithful `SimpleNamespace` fake runtime, **not** a `MagicMock` — a MagicMock would auto-vivify `rt.qdrant_client` and hide the bug. Against the old code these tests fail with the exact production `AttributeError`; against the fix they pass. Cases: happy path (200 + Qdrant `.delete` on the `knowledge_base` collection with the correct point id + manifest `remove_unit` called), `memory_store=None` (200, Qdrant skipped, tombstone still runs), 404 (missing unit), 503 (not bootstrapped). Full `test_dashboard` + `test_knowledge` suites green; ruff clean. No DB migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)