### PR TITLE
feat(dashboard): top-level Genesis Voice section (optional add-on)

### DIFF
--- a/src/genesis/dashboard/routes/__init__.py
+++ b/src/genesis/dashboard/routes/__init__.py
@@ -44,6 +44,7 @@ from genesis.dashboard.routes import (
     ui_data,
     updates,
     vitals,
+    voice,
     work,
 )
 
@@ -89,5 +90,6 @@ __all__ = [
     "ui_data",
     "updates",
     "vitals",
+    "voice",
     "work",
 ]

--- a/src/genesis/dashboard/routes/voice.py
+++ b/src/genesis/dashboard/routes/voice.py
@@ -1,0 +1,55 @@
+"""Genesis Voice — the optional voice-infrastructure dashboard section.
+
+Serves the ``/genesis/voice`` page (a top-level nav peer of Dashboard / Event Log /
+Error Log / Neural Monitor) and a tiny enablement probe that drives the nav link's
+visibility. Voice is an OPTIONAL add-on: on a stock clone with no
+``~/.genesis/ambient_remote.yaml`` the page 404s and the nav link stays hidden, so
+non-voice installs never see voice surfaces.
+
+The page's sub-tabs (Calibration / Bridge / STT / S2S) are all in the served template;
+the Bridge tab reuses the existing ``/api/genesis/health`` ``infrastructure.ambient``
+block, so no heavy voice-specific endpoint is added here.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from flask import abort, jsonify, send_from_directory
+
+from genesis.dashboard._blueprint import blueprint
+
+TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
+
+
+def _voice_configured() -> bool:
+    """True when this install has the optional ambient/voice add-on configured.
+
+    Present-but-malformed ``ambient_remote.yaml`` counts as configured (the Bridge tab
+    surfaces the degraded reason); only a wholly-absent config means "no voice add-on".
+    Reads the local YAML only — never the SSH edge probe — so it is cheap to call per page.
+    """
+    from genesis.observability.ambient_health import (
+        AmbientRemoteConfigError,
+        load_ambient_remote_config,
+    )
+
+    try:
+        return load_ambient_remote_config() is not None
+    except AmbientRemoteConfigError:
+        return True
+
+
+@blueprint.route("/genesis/voice")
+def voice_page():
+    """Serve the Genesis Voice page. 404 when the optional voice add-on isn't configured
+    (a web-UI page → also auth-gated by the blueprint before_request hook)."""
+    if not _voice_configured():
+        abort(404)
+    return send_from_directory(str(TEMPLATE_DIR), "genesis_voice.html")
+
+
+@blueprint.route("/api/genesis/voice/enabled")
+def voice_enabled():
+    """Whether the optional voice add-on is configured — drives nav-link visibility.
+    Non-sensitive boolean; open like the rest of the ``/api`` surface."""
+    return jsonify({"enabled": _voice_configured()})

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -26,7 +26,7 @@
       Alpine.store("genesisDashboard", {
         // Tab state
         activeTab: "overview",
-        _tabInitialized: { overview: false, chat: false, internals: false, config: false, files: false, work: false, "follow-ups": false, observations: false, traces: false, autonomy: false, memory: false, knowledge: false, campaigns: false, references: false, attention: false, backup: false },
+        _tabInitialized: { overview: false, chat: false, internals: false, config: false, files: false, work: false, "follow-ups": false, observations: false, traces: false, autonomy: false, memory: false, knowledge: false, campaigns: false, references: false, backup: false },
         // ── Campaigns tab state ──
         campaignsList: [],
         campaignsMutating: {},
@@ -236,14 +236,6 @@
         referenceStats: null,
         referenceDetail: null,
         revealedValues: {},
-        // ── Attention review tab state ──
-        attentionEvents: [],
-        attentionStats: null,
-        attentionFilters: { activation: "", trigger: "", is_user: false, unlabeled: true, config_version: "" },
-        _attentionVersionDefaulted: false,   // one-time guard: default the filter to newest version once
-        _attentionEventsGen: 0,   // request generation — discard a stale events response superseded by a newer fetch
-        attentionRevealed: {},   // {event_id: [window rows] | "unavailable"}
-        attentionLabeling: {},   // {event_id: true} while a label POST is in flight
 
         // ── Confirm modal state ──────────────────────────────────
         confirmModal: { show: false, title: '', message: '', _resolve: null },
@@ -460,7 +452,7 @@
 
         initTab() {
           const hash = location.hash.replace("#", "") || "overview";
-          const valid = ["overview", "chat", "internals", "config", "files", "work", "follow-ups", "observations", "traces", "autonomy", "memory", "knowledge", "campaigns", "references", "attention", "backup"];
+          const valid = ["overview", "chat", "internals", "config", "files", "work", "follow-ups", "observations", "traces", "autonomy", "memory", "knowledge", "campaigns", "references", "backup"];
           this.activeTab = valid.includes(hash) ? hash : "overview";
           window.addEventListener("hashchange", () => {
             const h = location.hash.replace("#", "");
@@ -548,9 +540,6 @@
               break;
             case "references":
               if (first) { this.fetchReferenceList(); this.fetchReferenceStats(); }
-              break;
-            case "attention":
-              if (first) { this.fetchAttentionEvents(); this.fetchAttentionStats(); }
               break;
             case "backup":
               if (first) { this.fetchBackupStatus(); this.fetchBackupConfig(); this.fetchUpdateStatus(); this.fetchUpdateProgress(); }
@@ -1615,96 +1604,6 @@
           return sp || "unknown";
         },
 
-        // ── Attention review tab ─────────────────────────────────
-        _attentionQuery() {
-          const f = this.attentionFilters;
-          const p = new URLSearchParams();
-          if (f.activation) p.set("activation", f.activation);
-          if (f.trigger) p.set("trigger", f.trigger);
-          if (f.is_user) p.set("is_user", "true");
-          if (f.unlabeled) p.set("unlabeled", "true");
-          if (f.config_version) p.set("config_version", f.config_version);
-          return p.toString();
-        },
-        async fetchAttentionEvents() {
-          // Stamp each request; only apply the response if it's still the latest. On tab-init the
-          // one-time version default fires a second (scoped) fetch while the first (unscoped, all-versions)
-          // fetch may still be in flight — without this guard a late unscoped response could clobber the
-          // scoped list and re-introduce the version duplicates.
-          const gen = ++this._attentionEventsGen;
-          try {
-            const resp = await fetchApi(`/api/genesis/attention/list?${this._attentionQuery()}`);
-            if (resp && resp.ok) {
-              const data = await resp.json();
-              if (gen === this._attentionEventsGen) this.attentionEvents = data.events || [];
-            }
-          } catch (e) { console.warn("Attention list failed:", e); }
-        },
-        async fetchAttentionStats() {
-          try {
-            const cv = this.attentionFilters.config_version;
-            const qs = cv ? `?config_version=${encodeURIComponent(cv)}` : "";
-            const resp = await fetchApi(`/api/genesis/attention/stats${qs}`);
-            if (resp && resp.ok) {
-              this.attentionStats = await resp.json();
-              // ONE-TIME default to the NEWEST config version so windows that fired under multiple
-              // versions don't render as duplicates — labeling should target one clean version.
-              // config_versions is ascending, so the last entry is newest (future-proof for 0.2.1+).
-              // Guarded by _attentionVersionDefaulted so a later manual "All versions" selection sticks
-              // (else this would snap the filter back to newest on every empty-version stats fetch).
-              const versions = this.attentionStats?.config_versions || [];
-              if (!cv && !this._attentionVersionDefaulted && versions.length) {
-                this._attentionVersionDefaulted = true;
-                this.attentionFilters.config_version = versions[versions.length - 1];
-                this.fetchAttentionEvents();
-                this.fetchAttentionStats();
-              }
-            }
-          } catch (e) { console.warn("Attention stats failed:", e); }
-        },
-        async revealAttentionText(id) {
-          try {
-            const resp = await fetchApi(`/api/genesis/attention/${encodeURIComponent(id)}/reveal-text`, { method: "POST" });
-            if (resp && resp.ok) {
-              this.attentionRevealed = { ...this.attentionRevealed, [id]: (await resp.json()).window || [] };
-            } else if (resp && resp.status === 410) {
-              this.attentionRevealed = { ...this.attentionRevealed, [id]: "snapshot no longer available — this event is review-read-only." };
-            } else {
-              this.attentionRevealed = { ...this.attentionRevealed, [id]: `reveal failed (${resp ? resp.status : "network error"})` };
-            }
-          } catch (e) { console.warn("Attention reveal failed:", e); }
-        },
-        hideAttentionText(id) {
-          const copy = { ...this.attentionRevealed }; delete copy[id]; this.attentionRevealed = copy;
-        },
-        async labelAttentionEvent(id, signal) {
-          this.attentionLabeling = { ...this.attentionLabeling, [id]: true };
-          try {
-            const resp = await fetchApi(`/api/genesis/attention/${encodeURIComponent(id)}/label`, {
-              method: "POST", headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ acceptance_signal: signal }),
-            });
-            if (resp && resp.ok) {
-              const ev = this.attentionEvents.find(e => e.id === id);
-              if (ev) ev.acceptance_signal = signal;
-              if (this.attentionFilters.unlabeled) {
-                this.attentionEvents = this.attentionEvents.filter(e => e.id !== id);
-              }
-              this.hideAttentionText(id);
-              this.fetchAttentionStats();
-            }
-          } catch (e) { console.warn("Attention label failed:", e); }
-          finally { const m = { ...this.attentionLabeling }; delete m[id]; this.attentionLabeling = m; }
-        },
-        _attentionMaxTrigger() {
-          const t = this.attentionStats?.by_trigger || {};
-          return Math.max(1, ...Object.values(t));
-        },
-        _attnActivationColor(a) {
-          if (a === "hard") return "var(--color-primary)";
-          if (a === "suppressed") return "var(--color-text-secondary)";
-          return "var(--color-warning-text)";
-        },
 
         // ── Knowledge upload methods ────────────────────────────
         async handleKnowledgeFileDrop(event) {
@@ -4540,6 +4439,7 @@
       border-radius: 3px;
     }
   </style>
+  <script src="/js/voice-nav.js"></script>
 </head>
 
 <body class="dark-mode" x-data x-init="$store.genesisDashboard.onOpen()"
@@ -4554,6 +4454,7 @@
       <a href="/genesis/logs">Event Log</a>
       <a href="/genesis/errors">Error Log</a>
       <a href="/genesis/monitor">Neural Monitor</a>
+    <a href="/genesis/voice" data-voice-nav style="display:none">Genesis Voice</a>
     </nav>
 
     <!-- Error banner -->
@@ -4636,8 +4537,6 @@
               @click="location.hash = 'campaigns'">Campaigns</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'references' }"
               @click="location.hash = 'references'">References</button>
-      <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'attention' }"
-              @click="location.hash = 'attention'">Attention</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'files' }"
               @click="location.hash = 'files'">Files</button>
       <button :class="{ 'active-tab': $store.genesisDashboard.activeTab === 'config' }"
@@ -10628,149 +10527,6 @@
       </div><!-- /panel-body padding -->
     </div>
 
-    <!-- ═══════════════════════════════════════════════════════════
-         Panel: Attention Review [Tab: attention]
-         ═══════════════════════════════════════════════════════════ -->
-    <div class="panel" x-show="$store.genesisDashboard.activeTab === 'attention'" style="overflow-y: auto; max-height: calc(100vh - 180px);">
-      <div class="panel-header">
-        <span class="material-symbols-outlined">hearing</span>
-        Attention Review
-      </div>
-      <div style="padding: 1rem;">
-
-      <div style="margin-bottom: 1rem; color: var(--color-text-secondary); font-size: .85em;">
-        Moments the passive-listening attention gate <em>would</em> have noticed. Nothing here speaks or acts.
-        <strong style="color:var(--color-text);">For each one, ask: should Genesis have PAID ATTENTION here —
-        was it worth being aware of / remembering?</strong> This is about <em>attention</em>, not about
-        interrupting you (whether to actually speak is a separate, later decision). Reveal the transcript, then
-        label — <strong>Worth noticing</strong> = yes, attend · <strong>Not worth it</strong> = noise, not
-        worth a glance · <strong>Skip</strong> = can't tell (garbled). Transcript text is read live from the
-        local snapshot; it is never stored here.
-      </div>
-
-      <!-- Stats -->
-      <div style="display: flex; gap: 1rem; margin-bottom: 1rem; flex-wrap: wrap;">
-        <div style="flex: 1; min-width: 90px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
-          <div style="font-size: 1.4rem; font-weight: 700;" x-text="$store.genesisDashboard.attentionStats?.labels?.total ?? '—'"></div>
-          <div style="font-size: .75rem; color: var(--color-text-secondary);">Events</div>
-        </div>
-        <div style="flex: 1; min-width: 90px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
-          <div style="font-size: 1.4rem; font-weight: 700; color: var(--color-primary);" x-text="$store.genesisDashboard.attentionStats?.labels?.labeled ?? 0"></div>
-          <div style="font-size: .75rem; color: var(--color-text-secondary);">Labeled</div>
-        </div>
-        <div style="flex: 1; min-width: 90px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
-          <div style="font-size: 1.4rem; font-weight: 700; color: var(--color-warning-text);" x-text="$store.genesisDashboard.attentionStats?.labels?.unlabeled ?? 0"></div>
-          <div style="font-size: .75rem; color: var(--color-text-secondary);">Unlabeled</div>
-        </div>
-      </div>
-
-      <!-- Per-trigger dominance bar -->
-      <template x-if="$store.genesisDashboard.attentionStats && Object.keys($store.genesisDashboard.attentionStats.by_trigger||{}).length">
-        <div style="margin-bottom: 1.25rem;">
-          <div style="font-size:.75rem; color:var(--color-text-secondary); margin-bottom:.35rem;">Trigger fire counts (dominance)</div>
-          <div style="display:flex; flex-direction:column; gap:.25rem;">
-            <template x-for="[name, n] in Object.entries($store.genesisDashboard.attentionStats.by_trigger)" :key="name">
-              <div style="display:flex; align-items:center; gap:.5rem;">
-                <span style="width:120px; font-size:.72rem; text-align:right; color:var(--color-text-secondary);" x-text="name"></span>
-                <div style="flex:1; background:var(--color-panel); border-radius:3px; overflow:hidden; height:14px;">
-                  <div :style="`height:100%; background:var(--color-primary); width:${Math.round(100*n/$store.genesisDashboard._attentionMaxTrigger())}%;`"></div>
-                </div>
-                <span style="width:38px; font-size:.72rem;" x-text="n"></span>
-              </div>
-            </template>
-          </div>
-        </div>
-      </template>
-
-      <!-- Filters -->
-      <div style="margin-bottom: 1rem; display: flex; gap: .5rem; flex-wrap: wrap; align-items:center;">
-        <select x-model="$store.genesisDashboard.attentionFilters.activation" @change="$store.genesisDashboard.fetchAttentionEvents()"
-                style="padding: .4rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
-          <option value="">All activations</option>
-          <option value="hard">hard</option>
-          <option value="soft">soft</option>
-          <option value="suppressed">suppressed</option>
-        </select>
-        <select x-model="$store.genesisDashboard.attentionFilters.trigger" @change="$store.genesisDashboard.fetchAttentionEvents()"
-                style="padding: .4rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
-          <option value="">All triggers</option>
-          <template x-for="name in Object.keys($store.genesisDashboard.attentionStats?.by_trigger || {})" :key="name">
-            <option :value="name" x-text="name"></option>
-          </template>
-        </select>
-        <!-- config_version: rescopes BOTH the list AND the stats panel (else the dominance bar mixes versions) -->
-        <select x-model="$store.genesisDashboard.attentionFilters.config_version" @change="$store.genesisDashboard.fetchAttentionEvents(); $store.genesisDashboard.fetchAttentionStats()"
-                style="padding: .4rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
-          <option value="">All versions</option>
-          <template x-for="v in ($store.genesisDashboard.attentionStats?.config_versions || [])" :key="v">
-            <option :value="v" x-text="v"></option>
-          </template>
-        </select>
-        <label style="font-size:.8rem; display:flex; align-items:center; gap:.3rem;">
-          <input type="checkbox" x-model="$store.genesisDashboard.attentionFilters.is_user" @change="$store.genesisDashboard.fetchAttentionEvents()"> is_user
-        </label>
-        <label style="font-size:.8rem; display:flex; align-items:center; gap:.3rem;">
-          <input type="checkbox" x-model="$store.genesisDashboard.attentionFilters.unlabeled" @change="$store.genesisDashboard.fetchAttentionEvents()"> unlabeled only
-        </label>
-        <button @click="$store.genesisDashboard.fetchAttentionEvents(); $store.genesisDashboard.fetchAttentionStats()" class="btn-sm">Refresh</button>
-      </div>
-
-      <!-- Events -->
-      <template x-if="$store.genesisDashboard.attentionEvents.length === 0">
-        <p style="color: var(--color-text-secondary);">No attention events match. Populate with <code>python -m genesis.attention.runner --persist</code>.</p>
-      </template>
-      <div style="display:flex; flex-direction:column; gap:.5rem;">
-        <template x-for="ev in $store.genesisDashboard.attentionEvents" :key="ev.id">
-          <div style="background: var(--color-background); border: 1px solid var(--color-border); border-radius: 6px; padding: .6rem .75rem;">
-            <div style="display:flex; justify-content:space-between; align-items:center; gap:.5rem; flex-wrap:wrap;">
-              <div style="display:flex; align-items:center; gap:.4rem; flex-wrap:wrap;">
-                <span style="font-size:.6rem; padding:1px 6px; border-radius:3px; text-transform:uppercase; font-weight:700;"
-                      :style="`color:${$store.genesisDashboard._attnActivationColor(ev.activation)}; background:${$store.genesisDashboard._attnActivationColor(ev.activation)}22;`"
-                      x-text="ev.activation"></span>
-                <span style="font-size:.72rem; color:var(--color-text-secondary);" x-text="'score ' + (typeof ev.score === 'number' ? ev.score.toFixed(2) : ev.score)"></span>
-                <span style="font-size:.72rem; color:var(--color-text-secondary);" x-text="(ev.ts||'').substring(0,19).replace('T',' ')"></span>
-                <template x-for="t in (ev.triggers_fired||[])" :key="t.name">
-                  <span style="font-size:.6rem; padding:1px 5px; border-radius:3px; background:var(--color-panel);" x-text="t.name"></span>
-                </template>
-                <span x-show="ev.acceptance_signal" style="font-size:.6rem; padding:1px 6px; border-radius:3px; color:var(--color-primary); background:var(--color-primary)22;" x-text="({should:'noticed',shouldnt:'ignored',skip:'skipped'})[ev.acceptance_signal] || ev.acceptance_signal"></span>
-              </div>
-              <div style="display:flex; gap:.3rem; align-items:center; flex-shrink:0;">
-                <button class="btn-sm" style="padding:.15rem .4rem;"
-                        @click="$store.genesisDashboard.attentionRevealed[ev.id] !== undefined ? $store.genesisDashboard.hideAttentionText(ev.id) : $store.genesisDashboard.revealAttentionText(ev.id)">
-                  <span class="material-symbols-outlined" style="font-size:1rem; vertical-align:middle;"
-                        x-text="$store.genesisDashboard.attentionRevealed[ev.id] !== undefined ? 'visibility_off' : 'visibility'"></span>
-                </button>
-                <button class="btn-sm" style="padding:.15rem .5rem;" title="Genesis should have paid attention here (worth being aware of / remembering)" :disabled="$store.genesisDashboard.attentionLabeling[ev.id] === true"
-                        @click="$store.genesisDashboard.labelAttentionEvent(ev.id, 'should')">Worth noticing</button>
-                <button class="btn-sm" style="padding:.15rem .5rem;" title="Noise — not worth a glance" :disabled="$store.genesisDashboard.attentionLabeling[ev.id] === true"
-                        @click="$store.genesisDashboard.labelAttentionEvent(ev.id, 'shouldnt')">Not worth it</button>
-                <button class="btn-sm" style="padding:.15rem .5rem; opacity:.7;" title="Can't tell — too garbled to judge" :disabled="$store.genesisDashboard.attentionLabeling[ev.id] === true"
-                        @click="$store.genesisDashboard.labelAttentionEvent(ev.id, 'skip')">Skip</button>
-              </div>
-            </div>
-            <!-- Revealed window (from the transient snapshot) -->
-            <template x-if="$store.genesisDashboard.attentionRevealed[ev.id] !== undefined">
-              <div style="margin-top:.5rem; background:var(--color-panel); border-radius:4px; padding:.5rem .6rem;">
-                <template x-if="typeof $store.genesisDashboard.attentionRevealed[ev.id] === 'string'">
-                  <div style="font-size:.8em; color:var(--color-warning-text);" x-text="$store.genesisDashboard.attentionRevealed[ev.id]"></div>
-                </template>
-                <template x-if="Array.isArray($store.genesisDashboard.attentionRevealed[ev.id])">
-                  <div style="display:flex; flex-direction:column; gap:.25rem;">
-                    <template x-for="u in $store.genesisDashboard.attentionRevealed[ev.id]" :key="u.id">
-                      <div :style="u.is_trigger ? 'font-size:.82em; font-weight:600; color:var(--color-text);' : 'font-size:.82em; color:var(--color-text-secondary);'">
-                        <span style="font-size:.7em; opacity:.7;" x-text="(u.speaker_label||'') + (u.is_user===1?' ·you':'') + '  '"></span>
-                        <span x-text="u.text"></span>
-                      </div>
-                    </template>
-                  </div>
-                </template>
-              </div>
-            </template>
-          </div>
-        </template>
-      </div>
-      </div><!-- /panel-body padding -->
-    </div>
 
     <!-- ═══════════════════════════════════════════════════════════
          Panel: Backup & Updates [Tab: backup]

--- a/src/genesis/dashboard/templates/genesis_errors.html
+++ b/src/genesis/dashboard/templates/genesis_errors.html
@@ -570,6 +570,7 @@
       .group-header span:nth-child(7) { display: none; }
     }
   </style>
+  <script src="/js/voice-nav.js"></script>
 </head>
 
 <body>
@@ -581,6 +582,7 @@
       <a href="/genesis/logs">Event Log</a>
       <a href="/genesis/errors" class="active">Error Log</a>
       <a href="/genesis/monitor">Neural Monitor</a>
+    <a href="/genesis/voice" data-voice-nav style="display:none">Genesis Voice</a>
     </nav>
 
     <!-- Error banner -->

--- a/src/genesis/dashboard/templates/genesis_logs.html
+++ b/src/genesis/dashboard/templates/genesis_logs.html
@@ -528,6 +528,7 @@
       .event-table-header span:nth-child(4) { display: none; }
     }
   </style>
+  <script src="/js/voice-nav.js"></script>
 </head>
 
 <body>
@@ -539,6 +540,7 @@
       <a href="/genesis/logs" class="active">Event Log</a>
       <a href="/genesis/errors">Error Log</a>
       <a href="/genesis/monitor">Neural Monitor</a>
+    <a href="/genesis/voice" data-voice-nav style="display:none">Genesis Voice</a>
     </nav>
 
     <!-- Error banner -->

--- a/src/genesis/dashboard/templates/genesis_voice.html
+++ b/src/genesis/dashboard/templates/genesis_voice.html
@@ -1,0 +1,379 @@
+<!DOCTYPE html>
+<html lang="en" style="background-color:#131313;color:#fff;">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="color-scheme" content="dark">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <title>Genesis Voice</title>
+  <link rel="icon" type="image/svg+xml" href="/public/favicon.svg">
+  <link rel="stylesheet" href="/index.css">
+  <link rel="stylesheet" href="/css/buttons.css">
+  <link rel="stylesheet" href="/vendor/google/google-icons.css">
+  <script type="module" src="/js/initFw.js"></script>
+
+  <script type="module">
+    import { fetchApi } from "/js/api.js";
+
+    document.addEventListener("alpine:init", () => {
+      Alpine.store("genesisVoice", {
+        // ── sub-tab state ──
+        voiceTab: "calibration",
+
+        // ── Bridge (ambient edge) — reuses /api/genesis/health infrastructure.ambient ──
+        bridge: null,
+        bridgeError: null,
+        bridgeLoading: true,
+        async fetchBridge() {
+          this.bridgeLoading = true;
+          try {
+            const resp = await fetchApi("/api/genesis/health");
+            if (resp && resp.ok) {
+              const data = await resp.json();
+              this.bridge = (data.infrastructure || {}).ambient || null;
+              this.bridgeError = this.bridge ? null : "no ambient bridge in the health snapshot (edge not reporting)";
+            } else { this.bridgeError = `health fetch failed (${resp ? resp.status : "network error"})`; }
+          } catch (e) { this.bridgeError = String(e); }
+          finally { this.bridgeLoading = false; }
+        },
+        _bridgeColor(status) {
+          const s = (status || "").toLowerCase();
+          if (s === "healthy" || s === "ok") return "var(--color-primary)";
+          if (s === "degraded") return "var(--color-warning-text)";
+          if (s === "down" || s === "error") return "#ef4444";
+          return "var(--color-text-secondary)";
+        },
+        bridgeExtras() {
+          const b = this.bridge || {};
+          return Object.entries(b).filter(([k]) => !["status","latency_ms","message"].includes(k));
+        },
+
+        setTab(t) { this.voiceTab = t; if (t === "bridge") this.fetchBridge(); },
+        onOpen() { this.fetchAttentionEvents(); this.fetchAttentionStats(); this.fetchBridge(); },
+
+        // ── Attention review tab ─────────────────────────────────
+        _attentionQuery() {
+          const f = this.attentionFilters;
+          const p = new URLSearchParams();
+          if (f.activation) p.set("activation", f.activation);
+          if (f.trigger) p.set("trigger", f.trigger);
+          if (f.is_user) p.set("is_user", "true");
+          if (f.unlabeled) p.set("unlabeled", "true");
+          if (f.config_version) p.set("config_version", f.config_version);
+          return p.toString();
+        },
+        async fetchAttentionEvents() {
+          // Stamp each request; only apply the response if it's still the latest. On tab-init the
+          // one-time version default fires a second (scoped) fetch while the first (unscoped, all-versions)
+          // fetch may still be in flight — without this guard a late unscoped response could clobber the
+          // scoped list and re-introduce the version duplicates.
+          const gen = ++this._attentionEventsGen;
+          try {
+            const resp = await fetchApi(`/api/genesis/attention/list?${this._attentionQuery()}`);
+            if (resp && resp.ok) {
+              const data = await resp.json();
+              if (gen === this._attentionEventsGen) this.attentionEvents = data.events || [];
+            }
+          } catch (e) { console.warn("Attention list failed:", e); }
+        },
+        async fetchAttentionStats() {
+          try {
+            const cv = this.attentionFilters.config_version;
+            const qs = cv ? `?config_version=${encodeURIComponent(cv)}` : "";
+            const resp = await fetchApi(`/api/genesis/attention/stats${qs}`);
+            if (resp && resp.ok) {
+              this.attentionStats = await resp.json();
+              // ONE-TIME default to the NEWEST config version so windows that fired under multiple
+              // versions don't render as duplicates — labeling should target one clean version.
+              // config_versions is ascending, so the last entry is newest (future-proof for 0.2.1+).
+              // Guarded by _attentionVersionDefaulted so a later manual "All versions" selection sticks
+              // (else this would snap the filter back to newest on every empty-version stats fetch).
+              const versions = this.attentionStats?.config_versions || [];
+              if (!cv && !this._attentionVersionDefaulted && versions.length) {
+                this._attentionVersionDefaulted = true;
+                this.attentionFilters.config_version = versions[versions.length - 1];
+                this.fetchAttentionEvents();
+                this.fetchAttentionStats();
+              }
+            }
+          } catch (e) { console.warn("Attention stats failed:", e); }
+        },
+        async revealAttentionText(id) {
+          try {
+            const resp = await fetchApi(`/api/genesis/attention/${encodeURIComponent(id)}/reveal-text`, { method: "POST" });
+            if (resp && resp.ok) {
+              this.attentionRevealed = { ...this.attentionRevealed, [id]: (await resp.json()).window || [] };
+            } else if (resp && resp.status === 410) {
+              this.attentionRevealed = { ...this.attentionRevealed, [id]: "snapshot no longer available — this event is review-read-only." };
+            } else {
+              this.attentionRevealed = { ...this.attentionRevealed, [id]: `reveal failed (${resp ? resp.status : "network error"})` };
+            }
+          } catch (e) { console.warn("Attention reveal failed:", e); }
+        },
+        hideAttentionText(id) {
+          const copy = { ...this.attentionRevealed }; delete copy[id]; this.attentionRevealed = copy;
+        },
+        async labelAttentionEvent(id, signal) {
+          this.attentionLabeling = { ...this.attentionLabeling, [id]: true };
+          try {
+            const resp = await fetchApi(`/api/genesis/attention/${encodeURIComponent(id)}/label`, {
+              method: "POST", headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ acceptance_signal: signal }),
+            });
+            if (resp && resp.ok) {
+              const ev = this.attentionEvents.find(e => e.id === id);
+              if (ev) ev.acceptance_signal = signal;
+              if (this.attentionFilters.unlabeled) {
+                this.attentionEvents = this.attentionEvents.filter(e => e.id !== id);
+              }
+              this.hideAttentionText(id);
+              this.fetchAttentionStats();
+            }
+          } catch (e) { console.warn("Attention label failed:", e); }
+          finally { const m = { ...this.attentionLabeling }; delete m[id]; this.attentionLabeling = m; }
+        },
+        _attentionMaxTrigger() {
+          const t = this.attentionStats?.by_trigger || {};
+          return Math.max(1, ...Object.values(t));
+        },
+        _attnActivationColor(a) {
+          if (a === "hard") return "var(--color-primary)";
+          if (a === "suppressed") return "var(--color-text-secondary)";
+          return "var(--color-warning-text)";
+        },
+      });
+    });
+  </script>
+
+  <style>
+    .voice-wrap { max-width: 1150px; margin: 0 auto; padding: 0 1rem 2rem; }
+    .voice-tabs { display:flex; gap:.15rem; border-bottom:1px solid var(--color-border); margin:.25rem 0 1rem; flex-wrap:wrap; }
+    .voice-tabs button { background:transparent; border:none; color:var(--color-text-secondary); padding:.5rem 1rem; cursor:pointer; border-bottom:2px solid transparent; font-size:.9rem; }
+    .voice-tabs button.active { color:var(--color-text); border-bottom-color:var(--color-primary); font-weight:600; }
+    .voice-stat { flex:1; min-width:120px; background:var(--color-background); border-radius:6px; padding:.75rem; text-align:center; }
+  </style>
+</head>
+
+<body class="dark-mode" x-data x-init="$store.genesisVoice.onOpen()">
+  <nav class="genesis-nav">
+    <a href="/genesis">Dashboard</a>
+    <a href="/genesis/logs">Event Log</a>
+    <a href="/genesis/errors">Error Log</a>
+    <a href="/genesis/monitor">Neural Monitor</a>
+    <a href="/genesis/voice" class="active">Genesis Voice</a>
+  </nav>
+
+  <div class="voice-wrap">
+    <h1 style="font-size:1.25rem; display:flex; align-items:center; gap:.5rem; margin:1rem 0 .25rem;">
+      <span class="material-symbols-outlined">graphic_eq</span> Genesis Voice
+    </h1>
+    <div style="color:var(--color-text-secondary); font-size:.85em; margin-bottom:.75rem;">
+      The optional passive-listening / voice add-on. Surfaces here are offline observability + calibration — nothing here speaks or acts.
+    </div>
+
+    <nav class="voice-tabs">
+      <button :class="{ active: $store.genesisVoice.voiceTab === 'calibration' }" @click="$store.genesisVoice.setTab('calibration')">Calibration</button>
+      <button :class="{ active: $store.genesisVoice.voiceTab === 'bridge' }" @click="$store.genesisVoice.setTab('bridge')">Bridge</button>
+      <button :class="{ active: $store.genesisVoice.voiceTab === 'stt' }" @click="$store.genesisVoice.setTab('stt')">STT quality</button>
+      <button :class="{ active: $store.genesisVoice.voiceTab === 's2s' }" @click="$store.genesisVoice.setTab('s2s')">S2S sessions</button>
+    </nav>
+
+    <!-- ═══ Calibration (the attention review tab, relocated) ═══ -->
+    <div class="panel" x-show="$store.genesisVoice.voiceTab === 'calibration'" style="overflow-y: auto; max-height: calc(100vh - 180px);">
+      <div class="panel-header">
+        <span class="material-symbols-outlined">hearing</span>
+        Calibration
+      </div>
+      <div style="padding: 1rem;">
+
+      <div style="margin-bottom: 1rem; color: var(--color-text-secondary); font-size: .85em;">
+        Moments the passive-listening attention gate <em>would</em> have noticed. Nothing here speaks or acts.
+        <strong style="color:var(--color-text);">For each one, ask: should Genesis have PAID ATTENTION here —
+        was it worth being aware of / remembering?</strong> This is about <em>attention</em>, not about
+        interrupting you (whether to actually speak is a separate, later decision). Reveal the transcript, then
+        label — <strong>Worth noticing</strong> = yes, attend · <strong>Not worth it</strong> = noise, not
+        worth a glance · <strong>Skip</strong> = can't tell (garbled). Transcript text is read live from the
+        local snapshot; it is never stored here.
+      </div>
+
+      <!-- Stats -->
+      <div style="display: flex; gap: 1rem; margin-bottom: 1rem; flex-wrap: wrap;">
+        <div style="flex: 1; min-width: 90px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
+          <div style="font-size: 1.4rem; font-weight: 700;" x-text="$store.genesisVoice.attentionStats?.labels?.total ?? '—'"></div>
+          <div style="font-size: .75rem; color: var(--color-text-secondary);">Events</div>
+        </div>
+        <div style="flex: 1; min-width: 90px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
+          <div style="font-size: 1.4rem; font-weight: 700; color: var(--color-primary);" x-text="$store.genesisVoice.attentionStats?.labels?.labeled ?? 0"></div>
+          <div style="font-size: .75rem; color: var(--color-text-secondary);">Labeled</div>
+        </div>
+        <div style="flex: 1; min-width: 90px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
+          <div style="font-size: 1.4rem; font-weight: 700; color: var(--color-warning-text);" x-text="$store.genesisVoice.attentionStats?.labels?.unlabeled ?? 0"></div>
+          <div style="font-size: .75rem; color: var(--color-text-secondary);">Unlabeled</div>
+        </div>
+      </div>
+
+      <!-- Per-trigger dominance bar -->
+      <template x-if="$store.genesisVoice.attentionStats && Object.keys($store.genesisVoice.attentionStats.by_trigger||{}).length">
+        <div style="margin-bottom: 1.25rem;">
+          <div style="font-size:.75rem; color:var(--color-text-secondary); margin-bottom:.35rem;">Trigger fire counts (dominance)</div>
+          <div style="display:flex; flex-direction:column; gap:.25rem;">
+            <template x-for="[name, n] in Object.entries($store.genesisVoice.attentionStats.by_trigger)" :key="name">
+              <div style="display:flex; align-items:center; gap:.5rem;">
+                <span style="width:120px; font-size:.72rem; text-align:right; color:var(--color-text-secondary);" x-text="name"></span>
+                <div style="flex:1; background:var(--color-panel); border-radius:3px; overflow:hidden; height:14px;">
+                  <div :style="`height:100%; background:var(--color-primary); width:${Math.round(100*n/$store.genesisVoice._attentionMaxTrigger())}%;`"></div>
+                </div>
+                <span style="width:38px; font-size:.72rem;" x-text="n"></span>
+              </div>
+            </template>
+          </div>
+        </div>
+      </template>
+
+      <!-- Filters -->
+      <div style="margin-bottom: 1rem; display: flex; gap: .5rem; flex-wrap: wrap; align-items:center;">
+        <select x-model="$store.genesisVoice.attentionFilters.activation" @change="$store.genesisVoice.fetchAttentionEvents()"
+                style="padding: .4rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
+          <option value="">All activations</option>
+          <option value="hard">hard</option>
+          <option value="soft">soft</option>
+          <option value="suppressed">suppressed</option>
+        </select>
+        <select x-model="$store.genesisVoice.attentionFilters.trigger" @change="$store.genesisVoice.fetchAttentionEvents()"
+                style="padding: .4rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
+          <option value="">All triggers</option>
+          <template x-for="name in Object.keys($store.genesisVoice.attentionStats?.by_trigger || {})" :key="name">
+            <option :value="name" x-text="name"></option>
+          </template>
+        </select>
+        <!-- config_version: rescopes BOTH the list AND the stats panel (else the dominance bar mixes versions) -->
+        <select x-model="$store.genesisVoice.attentionFilters.config_version" @change="$store.genesisVoice.fetchAttentionEvents(); $store.genesisVoice.fetchAttentionStats()"
+                style="padding: .4rem; background: var(--color-background); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 4px;">
+          <option value="">All versions</option>
+          <template x-for="v in ($store.genesisVoice.attentionStats?.config_versions || [])" :key="v">
+            <option :value="v" x-text="v"></option>
+          </template>
+        </select>
+        <label style="font-size:.8rem; display:flex; align-items:center; gap:.3rem;">
+          <input type="checkbox" x-model="$store.genesisVoice.attentionFilters.is_user" @change="$store.genesisVoice.fetchAttentionEvents()"> is_user
+        </label>
+        <label style="font-size:.8rem; display:flex; align-items:center; gap:.3rem;">
+          <input type="checkbox" x-model="$store.genesisVoice.attentionFilters.unlabeled" @change="$store.genesisVoice.fetchAttentionEvents()"> unlabeled only
+        </label>
+        <button @click="$store.genesisVoice.fetchAttentionEvents(); $store.genesisVoice.fetchAttentionStats()" class="btn-sm">Refresh</button>
+      </div>
+
+      <!-- Events -->
+      <template x-if="$store.genesisVoice.attentionEvents.length === 0">
+        <p style="color: var(--color-text-secondary);">No attention events match. Populate with <code>python -m genesis.attention.runner --persist</code>.</p>
+      </template>
+      <div style="display:flex; flex-direction:column; gap:.5rem;">
+        <template x-for="ev in $store.genesisVoice.attentionEvents" :key="ev.id">
+          <div style="background: var(--color-background); border: 1px solid var(--color-border); border-radius: 6px; padding: .6rem .75rem;">
+            <div style="display:flex; justify-content:space-between; align-items:center; gap:.5rem; flex-wrap:wrap;">
+              <div style="display:flex; align-items:center; gap:.4rem; flex-wrap:wrap;">
+                <span style="font-size:.6rem; padding:1px 6px; border-radius:3px; text-transform:uppercase; font-weight:700;"
+                      :style="`color:${$store.genesisVoice._attnActivationColor(ev.activation)}; background:${$store.genesisVoice._attnActivationColor(ev.activation)}22;`"
+                      x-text="ev.activation"></span>
+                <span style="font-size:.72rem; color:var(--color-text-secondary);" x-text="'score ' + (typeof ev.score === 'number' ? ev.score.toFixed(2) : ev.score)"></span>
+                <span style="font-size:.72rem; color:var(--color-text-secondary);" x-text="(ev.ts||'').substring(0,19).replace('T',' ')"></span>
+                <template x-for="t in (ev.triggers_fired||[])" :key="t.name">
+                  <span style="font-size:.6rem; padding:1px 5px; border-radius:3px; background:var(--color-panel);" x-text="t.name"></span>
+                </template>
+                <span x-show="ev.acceptance_signal" style="font-size:.6rem; padding:1px 6px; border-radius:3px; color:var(--color-primary); background:var(--color-primary)22;" x-text="({should:'noticed',shouldnt:'ignored',skip:'skipped'})[ev.acceptance_signal] || ev.acceptance_signal"></span>
+              </div>
+              <div style="display:flex; gap:.3rem; align-items:center; flex-shrink:0;">
+                <button class="btn-sm" style="padding:.15rem .4rem;"
+                        @click="$store.genesisVoice.attentionRevealed[ev.id] !== undefined ? $store.genesisVoice.hideAttentionText(ev.id) : $store.genesisVoice.revealAttentionText(ev.id)">
+                  <span class="material-symbols-outlined" style="font-size:1rem; vertical-align:middle;"
+                        x-text="$store.genesisVoice.attentionRevealed[ev.id] !== undefined ? 'visibility_off' : 'visibility'"></span>
+                </button>
+                <button class="btn-sm" style="padding:.15rem .5rem;" title="Genesis should have paid attention here (worth being aware of / remembering)" :disabled="$store.genesisVoice.attentionLabeling[ev.id] === true"
+                        @click="$store.genesisVoice.labelAttentionEvent(ev.id, 'should')">Worth noticing</button>
+                <button class="btn-sm" style="padding:.15rem .5rem;" title="Noise — not worth a glance" :disabled="$store.genesisVoice.attentionLabeling[ev.id] === true"
+                        @click="$store.genesisVoice.labelAttentionEvent(ev.id, 'shouldnt')">Not worth it</button>
+                <button class="btn-sm" style="padding:.15rem .5rem; opacity:.7;" title="Can't tell — too garbled to judge" :disabled="$store.genesisVoice.attentionLabeling[ev.id] === true"
+                        @click="$store.genesisVoice.labelAttentionEvent(ev.id, 'skip')">Skip</button>
+              </div>
+            </div>
+            <!-- Revealed window (from the transient snapshot) -->
+            <template x-if="$store.genesisVoice.attentionRevealed[ev.id] !== undefined">
+              <div style="margin-top:.5rem; background:var(--color-panel); border-radius:4px; padding:.5rem .6rem;">
+                <template x-if="typeof $store.genesisVoice.attentionRevealed[ev.id] === 'string'">
+                  <div style="font-size:.8em; color:var(--color-warning-text);" x-text="$store.genesisVoice.attentionRevealed[ev.id]"></div>
+                </template>
+                <template x-if="Array.isArray($store.genesisVoice.attentionRevealed[ev.id])">
+                  <div style="display:flex; flex-direction:column; gap:.25rem;">
+                    <template x-for="u in $store.genesisVoice.attentionRevealed[ev.id]" :key="u.id">
+                      <div :style="u.is_trigger ? 'font-size:.82em; font-weight:600; color:var(--color-text);' : 'font-size:.82em; color:var(--color-text-secondary);'">
+                        <span style="font-size:.7em; opacity:.7;" x-text="(u.speaker_label||'') + (u.is_user===1?' ·you':'') + '  '"></span>
+                        <span x-text="u.text"></span>
+                      </div>
+                    </template>
+                  </div>
+                </template>
+              </div>
+            </template>
+          </div>
+        </template>
+      </div>
+      </div><!-- /panel-body padding -->
+    </div>
+
+    <!-- ═══ Bridge ═══ -->
+    <div class="panel" x-show="$store.genesisVoice.voiceTab === 'bridge'">
+      <div class="panel-header"><span class="material-symbols-outlined">sensors</span> Ambient Bridge</div>
+      <div style="padding:1rem;">
+        <div style="color:var(--color-text-secondary); font-size:.85em; margin-bottom:1rem;">
+          Live health of the edge ambient-capture bridge (from the <code>infrastructure.ambient</code> probe). An absent bridge is not a fault.
+        </div>
+        <template x-if="$store.genesisVoice.bridgeLoading && !$store.genesisVoice.bridge">
+          <p style="color:var(--color-text-secondary);">Loading bridge status…</p>
+        </template>
+        <template x-if="$store.genesisVoice.bridge">
+          <div>
+            <div style="display:flex; gap:1rem; flex-wrap:wrap; margin-bottom:1rem;">
+              <div class="voice-stat">
+                <div style="font-size:1.3rem; font-weight:700; text-transform:uppercase;" :style="`color:${$store.genesisVoice._bridgeColor($store.genesisVoice.bridge.status)}`" x-text="$store.genesisVoice.bridge.status || 'unknown'"></div>
+                <div style="font-size:.75rem; color:var(--color-text-secondary);">Status</div>
+              </div>
+              <div class="voice-stat" x-show="$store.genesisVoice.bridge.latency_ms != null">
+                <div style="font-size:1.3rem; font-weight:700;" x-text="Math.round($store.genesisVoice.bridge.latency_ms) + ' ms'"></div>
+                <div style="font-size:.75rem; color:var(--color-text-secondary);">Probe latency</div>
+              </div>
+            </div>
+            <div x-show="$store.genesisVoice.bridge.message" style="color:var(--color-text-secondary); margin-bottom:1rem;" x-text="$store.genesisVoice.bridge.message"></div>
+            <template x-if="$store.genesisVoice.bridgeExtras().length">
+              <div style="display:flex; flex-direction:column; gap:.25rem; font-size:.8rem;">
+                <template x-for="[k,v] in $store.genesisVoice.bridgeExtras()" :key="k">
+                  <div style="display:flex; gap:.5rem;"><span style="min-width:160px; color:var(--color-text-secondary);" x-text="k"></span><span x-text="typeof v === 'object' ? JSON.stringify(v) : v"></span></div>
+                </template>
+              </div>
+            </template>
+          </div>
+        </template>
+        <template x-if="$store.genesisVoice.bridgeError && !$store.genesisVoice.bridge">
+          <p style="color:var(--color-warning-text);" x-text="$store.genesisVoice.bridgeError"></p>
+        </template>
+        <button class="btn-sm" style="margin-top:1rem;" @click="$store.genesisVoice.fetchBridge()">Refresh</button>
+      </div>
+    </div>
+
+    <!-- ═══ STT placeholder ═══ -->
+    <div class="panel" x-show="$store.genesisVoice.voiceTab === 'stt'">
+      <div class="panel-header"><span class="material-symbols-outlined">graphic_eq</span> STT quality</div>
+      <div style="padding:1rem; color:var(--color-text-secondary);">
+        <p><strong style="color:var(--color-text);">Coming soon.</strong> Will surface ambient STT quality — garble rate, capture clarity, low-confidence-token fraction and word-coverage — from the shadow instrumentation, to track how much of the stream is usable speech vs. ASR hallucination.</p>
+      </div>
+    </div>
+
+    <!-- ═══ S2S placeholder ═══ -->
+    <div class="panel" x-show="$store.genesisVoice.voiceTab === 's2s'">
+      <div class="panel-header"><span class="material-symbols-outlined">forum</span> S2S sessions</div>
+      <div style="padding:1rem; color:var(--color-text-secondary);">
+        <p><strong style="color:var(--color-text);">Coming soon.</strong> Will surface live speech-to-speech session status per satellite — active sessions, connection age, last-turn timestamps — for the realtime voice pipeline (the "mouth").</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/genesis/dashboard/templates/genesis_voice.html
+++ b/src/genesis/dashboard/templates/genesis_voice.html
@@ -20,6 +20,16 @@
         // ── sub-tab state ──
         voiceTab: "calibration",
 
+        // ── Calibration (attention review) state — must be declared so the ported methods/panel
+        //    have reactive keys to read on first load (before any fetch returns) ──
+        attentionEvents: [],
+        attentionStats: null,
+        attentionFilters: { activation: "", trigger: "", is_user: false, unlabeled: true, config_version: "" },
+        _attentionVersionDefaulted: false,   // one-time guard: default the filter to newest version once
+        _attentionEventsGen: 0,   // request generation — discard a stale events response superseded by a newer fetch
+        attentionRevealed: {},   // {event_id: [window rows] | "unavailable"}
+        attentionLabeling: {},   // {event_id: true} while a label POST is in flight
+
         // ── Bridge (ambient edge) — reuses /api/genesis/health infrastructure.ambient ──
         bridge: null,
         bridgeError: null,

--- a/src/genesis/dashboard/templates/neural_monitor.html
+++ b/src/genesis/dashboard/templates/neural_monitor.html
@@ -374,6 +374,7 @@ body {
     .monitor-grid { grid-template-columns: 1fr; }
 }
 </style>
+  <script src="/js/voice-nav.js"></script>
 </head>
 <body>
 
@@ -382,6 +383,7 @@ body {
     <a href="/genesis/logs">Event Log</a>
     <a href="/genesis/errors">Error Log</a>
     <a href="/genesis/monitor" class="active">Neural Monitor</a>
+    <a href="/genesis/voice" data-voice-nav style="display:none">Genesis Voice</a>
 </nav>
 
 <div class="header">
@@ -652,6 +654,17 @@ function updateSidePanel(data) {
             const ccColor = ccTier === 'green' ? 'color:#4ade80' : ccTier === 'orange' ? 'color:#ffe600' : ccTier === 'red' ? 'color:#ef4444' : 'color:#888';
             svcEl.appendChild(sectionRow('CC Tmp', ccTmp.cc_used_mb + 'MB / ' + ccTmp.cc_budget_mb + 'MB', ccColor));
         }
+
+        // Voice Bridge — the OPTIONAL ambient add-on. Present in the health snapshot only when
+        // configured (an absent ambient edge is omitted, not a fault), so this row self-hides otherwise.
+        const ambient = (data.infrastructure || {}).ambient;
+        if (ambient && ambient.status !== undefined) {
+            const aStatus = String(ambient.status);
+            const aColor = /healthy|ok/i.test(aStatus) ? 'color:#4ade80'
+                : /degraded/i.test(aStatus) ? 'color:#ffe600' : 'color:#ef4444';
+            const aDetail = aStatus + (ambient.latency_ms != null ? ' (' + Math.round(ambient.latency_ms) + 'ms)' : '');
+            svcEl.appendChild(sectionRow('Voice Bridge', aDetail, aColor + ';font-weight:600'));
+        }
     }
 
     // Infrastructure
@@ -661,6 +674,7 @@ function updateSidePanel(data) {
         infraEl.replaceChildren();
         for (const [name, info] of Object.entries(infra)) {
             if (name === 'cc_tmp') continue;
+            if (name === 'ambient') continue;  // shown as "Voice Bridge" in Services (above)
             const row = el('div', 'section-row');
             const labelSpan = el('span', 'label');
             const dot = el('span', 'status-dot ' + infraStatusClass(info));

--- a/src/genesis/dashboard/webui/js/voice-nav.js
+++ b/src/genesis/dashboard/webui/js/voice-nav.js
@@ -1,0 +1,15 @@
+// voice-nav.js — reveal the optional "Genesis Voice" top-nav link only when the voice add-on
+// is configured on this install. The link ships HIDDEN (display:none, [data-voice-nav]) on every
+// page that renders the genesis-nav, so a stock clone with no ~/.genesis/ambient_remote.yaml never
+// shows a voice surface. Plain fetch (no module import) so it also runs on the vanilla Neural Monitor page.
+(async () => {
+  try {
+    const resp = await fetch("/api/genesis/voice/enabled", { credentials: "same-origin" });
+    if (!resp.ok) return;
+    const data = await resp.json();
+    if (!data || !data.enabled) return;
+    document.querySelectorAll("[data-voice-nav]").forEach((el) => { el.style.display = ""; });
+  } catch (_) {
+    // add-on absent / endpoint unreachable → leave the link hidden.
+  }
+})();

--- a/tests/test_dashboard/test_voice_api.py
+++ b/tests/test_dashboard/test_voice_api.py
@@ -1,0 +1,65 @@
+"""Genesis Voice routes — the OPTIONAL-addon gate.
+
+Invariant: a stock install with no ~/.genesis/ambient_remote.yaml must see NOTHING voice —
+the enable probe returns false and the page 404s. A present (even malformed) config → enabled.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from genesis.dashboard.api import blueprint
+
+
+@pytest.fixture()
+def client():
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    app.config["TESTING"] = True
+    app.secret_key = "test-secret-key"
+    return app.test_client()
+
+
+_CFG = "genesis.observability.ambient_health.load_ambient_remote_config"
+
+
+# ── /api/genesis/voice/enabled ─────────────────────────────────────────────
+
+def test_enabled_true_when_config_present(client):
+    with patch(_CFG, return_value=object()):
+        resp = client.get("/api/genesis/voice/enabled")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"enabled": True}
+
+
+def test_enabled_false_when_no_config(client):
+    with patch(_CFG, return_value=None):
+        resp = client.get("/api/genesis/voice/enabled")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"enabled": False}
+
+
+def test_enabled_true_when_config_malformed(client):
+    from genesis.observability.ambient_health import AmbientRemoteConfigError
+
+    with patch(_CFG, side_effect=AmbientRemoteConfigError("bad yaml")):
+        resp = client.get("/api/genesis/voice/enabled")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"enabled": True}  # present-but-broken is still a voice install
+
+
+# ── /genesis/voice page (optional-addon 404) ───────────────────────────────
+
+def test_page_404_when_not_configured(client):
+    with patch(_CFG, return_value=None):
+        resp = client.get("/genesis/voice")
+    assert resp.status_code == 404
+
+
+def test_page_served_when_configured(client):
+    with patch(_CFG, return_value=object()):
+        resp = client.get("/genesis/voice")
+    assert resp.status_code == 200
+    assert b"Genesis Voice" in resp.data  # the served template


### PR DESCRIPTION
## What
Promotes the Attention **calibration** tab out of the dashboard's secondary tab strip into a new **top-level** server-routed page **`/genesis/voice`** (peer of Dashboard / Event Log / Error Log / Neural Monitor), built to hold all voice-infrastructure surfaces. PR-2 of the labeling/voice work (PR-1 = #851, the labeling-mechanics fixes).

## Changes
- **NEW `routes/voice.py`** — `/genesis/voice` (404 when the optional add-on isn't configured) + `/api/genesis/voice/enabled`. `_voice_configured()` = `load_ambient_remote_config() is not None` (malformed-but-present → configured). On the dashboard blueprint → page is auth-gated, bool probe is open.
- **NEW `genesis_voice.html`** — Alpine page (mirrors the dashboard bootstrap) with a sub-tab strip: **Calibration** (the Attention tab ported verbatim, incl. PR-1's reframed labeling + newest-version default + race guard), **Bridge** (live ambient health from `/api/genesis/health` `infrastructure.ambient`), **STT** / **S2S** placeholders.
- **Removed** the Attention tab from `genesis_dashboard.html` (nav button, panel, store state + 8 methods, tab-init hooks) — verified **zero dangling references**; the unrelated "warning-strip" `attention` feature untouched.
- **Optional-addon self-hide:** NEW `webui/js/voice-nav.js` reveals a hidden `[data-voice-nav]` link only when `enabled` is true; the hidden link + script added to all 4 nav pages. A stock clone with no `~/.genesis/ambient_remote.yaml` shows **nothing** voice (page 404s, link hidden, no Neural-Monitor row).
- **Neural Monitor:** a labelled **Voice Bridge** row in Services (self-hiding when `infrastructure.ambient` absent); dropped the raw `ambient` row from the generic infra loop (no double render).

## Verification
- Unit: `test_voice_api.py` (enabled true/false/malformed; page 404 vs served). `node --check` on every edited JS block. ruff clean.
- **Code review** (genesis code-reviewer): confirmed removal cleanliness, the self-hide invariant on all 4 surfaces, voice-nav fail-closed, auth, firewall unchanged, no double-render — and **caught a real bug** (the port dropped the Calibration store's state keys → load-time TypeError), now **fixed** (keys declared).
- **Browser-E2E is post-deploy** — the new Python route needs a `genesis-server` restart to register; will verify the page loads, sub-tabs switch, Calibration works (no dupes, reframed labels), Bridge shows live status, dashboard no longer has Attention, nav link gated, Neural Monitor Voice Bridge row.

## Note
No migration; no attention-logic or firewall change (pure UI relocation + optional-addon gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)