### PR TITLE
fix(surplus): age-cap terminal task rows + reap two async leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Completed background-task history no longer grows without bound.** Genesis's idle-time "surplus"
+  task queue kept every finished task row forever — only never-started tasks were ever cleaned up — so
+  the table crept upward over months of background work. Finished tasks (completed, failed, or
+  cancelled) are now aged out after 30 days, while any task still referenced by an open follow-up is
+  kept until that follow-up resolves.
+
 - **Deleting a knowledge item from the dashboard now works end to end.** Previously the delete
   button returned a server error, and behind the scenes the item was only half-removed — dropped
   from search but with its stored embedding left behind and its source still marked as already

--- a/src/genesis/db/crud/surplus_tasks.py
+++ b/src/genesis/db/crud/surplus_tasks.py
@@ -188,6 +188,35 @@ async def drain_expired(db: aiosqlite.Connection, *, before: str) -> int:
     return cursor.rowcount
 
 
+async def delete_terminal_before(db: aiosqlite.Connection, *, before: str) -> int:
+    """Delete terminal (completed/failed/cancelled) tasks older than *before*.
+
+    ``drain_expired`` only removes ``pending`` rows, so terminal rows accumulate
+    forever. This age-caps them. Age is taken from ``completed_at`` when present,
+    else ``started_at``, else ``created_at`` — a ``failed`` row never gets a
+    ``completed_at``, so the COALESCE fallback ages it by when it last ran.
+
+    Rows still referenced by a NON-terminal follow-up (``linked_task_id``) are
+    preserved so ``follow_ups.dispatcher`` can still resolve them; a terminal
+    follow-up (completed/failed) no longer protects its linked task. The
+    ``linked_task_id IS NOT NULL`` filter keeps NULLs out of the ``NOT IN`` set
+    (a NULL there would make the whole predicate false and delete nothing).
+    """
+    cursor = await db.execute(
+        "DELETE FROM surplus_tasks "
+        "WHERE status IN ('completed', 'failed', 'cancelled') "
+        "AND COALESCE(completed_at, started_at, created_at) < ? "
+        "AND id NOT IN ("
+        "    SELECT linked_task_id FROM follow_ups "
+        "    WHERE linked_task_id IS NOT NULL "
+        "    AND status NOT IN ('completed', 'failed')"
+        ")",
+        (before,),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
 async def count_pending(db: aiosqlite.Connection) -> int:
     cursor = await db.execute(
         "SELECT COUNT(*) FROM surplus_tasks WHERE status = 'pending'",

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -31,13 +31,17 @@ def init_outreach_mcp(*, pipeline, engagement, config, db, activity_tracker=None
 
     # Ensure pending_outreach table exists for standalone fallback
     if db is not None and pipeline is None:
-        import asyncio
         import contextlib
 
         from genesis.db.crud.pending_outreach import ensure_table
+        from genesis.util.tasks import tracked_task
 
+        # Requires a running loop; suppress if we're called outside one
+        # (standalone fallback). tracked_task surfaces a failed ensure_table()
+        # via its error callback instead of letting it vanish, and avoids the
+        # old get_event_loop() spawning an orphan-loop task that never runs.
         with contextlib.suppress(RuntimeError):
-            asyncio.get_event_loop().create_task(ensure_table(db))
+            tracked_task(ensure_table(db), name="outreach-ensure-pending-table", logger=logger)
 
     if activity_tracker is not None:
         from genesis.observability.mcp_middleware import InstrumentationMiddleware

--- a/src/genesis/surplus/code_audit.py
+++ b/src/genesis/surplus/code_audit.py
@@ -76,6 +76,10 @@ class CodebaseContextGatherer:
             return stdout.decode("utf-8", errors="replace").strip()
         except TimeoutError:
             logger.warning("Subprocess timed out: %s", " ".join(args))
+            # Reap the timed-out child so it isn't left running past our timeout.
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+                await proc.wait()
             return ""
         except OSError:
             logger.warning("Subprocess failed: %s", " ".join(args), exc_info=True)

--- a/src/genesis/surplus/queue.py
+++ b/src/genesis/surplus/queue.py
@@ -98,6 +98,20 @@ class SurplusQueue:
         cutoff = self._clock() - timedelta(hours=max_age_hours)
         return await surplus_tasks.drain_expired(self._db, before=cutoff.isoformat())
 
+    async def reap_terminal(self, *, older_than_days: int = 30) -> int:
+        """Delete terminal (completed/failed/cancelled) tasks older than *older_than_days*.
+
+        ``drain_expired`` only removes ``pending`` rows, so terminal rows would
+        otherwise accumulate forever. Retention defaults to 30 days — far above
+        the largest scheduler cooldown (``analytical_hours``=24h) and the
+        pending-drain window (``task_expiry_hours``=72h), so neither
+        ``last_completed_at`` cooldown checks nor open follow-up links are ever
+        disturbed. Rows referenced by a non-terminal follow-up are preserved by
+        the CRUD layer.
+        """
+        cutoff = self._clock() - timedelta(days=older_than_days)
+        return await surplus_tasks.delete_terminal_before(self._db, before=cutoff.isoformat())
+
     async def recover_stuck(self, *, older_than_hours: int = 2, max_retries: int = 3) -> tuple[int, int]:
         """Recover tasks stuck in 'running' state."""
         return await surplus_tasks.recover_stuck_with_retries(

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -78,6 +78,7 @@ class SurplusScheduler:
         dispatch_interval_minutes: int = 5,
         brainstorm_check_hours: int = 12,
         task_expiry_hours: int = 72,
+        terminal_retention_days: int = 30,
         code_audit_hours: int = 12,
         code_index_hours: int = 4,
         recon_gather_hours: int = 84,
@@ -104,6 +105,7 @@ class SurplusScheduler:
         self._dispatch_interval = dispatch_interval_minutes
         self._brainstorm_interval = brainstorm_check_hours
         self._task_expiry_hours = task_expiry_hours
+        self._terminal_retention_days = terminal_retention_days
         self._code_audit_hours = code_audit_hours
         self._code_index_hours = code_index_hours
         self._recon_gather_hours = recon_gather_hours
@@ -1590,8 +1592,12 @@ class SurplusScheduler:
         # 0. Recover tasks stuck in 'running' state (crashed mid-execution)
         await self._queue.recover_stuck()
 
-        # 1. Drain expired tasks
+        # 1. Drain expired pending tasks
         await self._queue.drain_expired(max_age_hours=self._task_expiry_hours)
+
+        # 1b. Age-cap terminal rows (completed/failed/cancelled) so they don't
+        # accumulate forever — drain_expired only touches pending.
+        await self._queue.reap_terminal(older_than_days=self._terminal_retention_days)
 
         # 2. Check idle
         if not self._idle_detector.is_idle():

--- a/tests/test_db/test_surplus_tasks.py
+++ b/tests/test_db/test_surplus_tasks.py
@@ -187,6 +187,109 @@ async def test_delete(db):
     assert await surplus_tasks.delete(db, "st-1") is False
 
 
+# ---------------------------------------------------------------------------
+# delete_terminal_before — terminal-row age-cap reaper (WS-F / F7)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reap_terminal_deletes_old_completed_keeps_recent(db):
+    """Old completed rows are reaped; completed rows newer than the cutoff stay."""
+    await surplus_tasks.create(
+        db, id="old", task_type="brainstorm", compute_tier="slm",
+        priority=0.5, drive_alignment="curiosity", created_at="2026-01-01T00:00:00+00:00",
+    )
+    await surplus_tasks.mark_completed(db, "old", completed_at="2026-01-01T01:00:00+00:00")
+    await surplus_tasks.create(
+        db, id="recent", task_type="brainstorm", compute_tier="slm",
+        priority=0.5, drive_alignment="curiosity", created_at="2026-06-01T00:00:00+00:00",
+    )
+    await surplus_tasks.mark_completed(db, "recent", completed_at="2026-06-01T01:00:00+00:00")
+
+    reaped = await surplus_tasks.delete_terminal_before(db, before="2026-03-01T00:00:00+00:00")
+
+    assert reaped == 1
+    assert await surplus_tasks.get_by_id(db, "old") is None
+    assert await surplus_tasks.get_by_id(db, "recent") is not None
+
+
+@pytest.mark.asyncio
+async def test_reap_terminal_keeps_pending_and_running(db):
+    """Non-terminal rows are never reaped, regardless of age."""
+    await surplus_tasks.create(
+        db, id="old-pending", task_type="brainstorm", compute_tier="slm",
+        priority=0.5, drive_alignment="curiosity", created_at="2026-01-01T00:00:00+00:00",
+    )
+    await surplus_tasks.create(
+        db, id="old-running", task_type="brainstorm", compute_tier="slm",
+        priority=0.5, drive_alignment="curiosity", created_at="2026-01-01T00:00:00+00:00",
+    )
+    await surplus_tasks.mark_running(db, "old-running", started_at="2026-01-01T00:30:00+00:00")
+
+    reaped = await surplus_tasks.delete_terminal_before(db, before="2026-03-01T00:00:00+00:00")
+
+    assert reaped == 0
+    assert await surplus_tasks.get_by_id(db, "old-pending") is not None
+    assert await surplus_tasks.get_by_id(db, "old-running") is not None
+
+
+@pytest.mark.asyncio
+async def test_reap_terminal_ages_failed_and_cancelled_by_fallback(db):
+    """Failed rows (no completed_at) age by started_at/created_at; cancelled reaped too."""
+    await surplus_tasks.create(
+        db, id="old-failed", task_type="brainstorm", compute_tier="slm",
+        priority=0.5, drive_alignment="curiosity", created_at="2026-01-01T00:00:00+00:00",
+    )
+    await surplus_tasks.mark_running(db, "old-failed", started_at="2026-01-01T00:30:00+00:00")
+    await surplus_tasks.mark_failed(db, "old-failed", failure_reason="boom")
+    await surplus_tasks.create(
+        db, id="old-cancelled", task_type="brainstorm", compute_tier="slm",
+        priority=0.5, drive_alignment="curiosity", created_at="2026-01-01T00:00:00+00:00",
+    )
+    await db.execute(
+        "UPDATE surplus_tasks SET status = 'cancelled' WHERE id = ?", ("old-cancelled",),
+    )
+    await db.commit()
+
+    reaped = await surplus_tasks.delete_terminal_before(db, before="2026-03-01T00:00:00+00:00")
+
+    assert reaped == 2
+    assert await surplus_tasks.get_by_id(db, "old-failed") is None
+    assert await surplus_tasks.get_by_id(db, "old-cancelled") is None
+
+
+@pytest.mark.asyncio
+async def test_reap_terminal_skips_rows_linked_to_open_followup(db):
+    """A terminal row referenced by a NON-terminal follow-up is kept; a terminal
+    follow-up does not protect it."""
+    from genesis.db.crud import follow_ups
+
+    # completed task referenced by an OPEN (scheduled) follow-up -> keep
+    await surplus_tasks.create(
+        db, id="linked-open", task_type="brainstorm", compute_tier="slm",
+        priority=0.5, drive_alignment="curiosity", created_at="2026-01-01T00:00:00+00:00",
+    )
+    await surplus_tasks.mark_completed(db, "linked-open", completed_at="2026-01-01T01:00:00+00:00")
+    fu_open = await follow_ups.create(db, content="c", source="test", strategy="surplus_task")
+    await follow_ups.link_task(db, fu_open, "linked-open")  # -> status 'scheduled'
+
+    # completed task referenced only by a COMPLETED follow-up -> reap
+    await surplus_tasks.create(
+        db, id="linked-closed", task_type="brainstorm", compute_tier="slm",
+        priority=0.5, drive_alignment="curiosity", created_at="2026-01-01T00:00:00+00:00",
+    )
+    await surplus_tasks.mark_completed(db, "linked-closed", completed_at="2026-01-01T01:00:00+00:00")
+    fu_closed = await follow_ups.create(db, content="c", source="test", strategy="surplus_task")
+    await follow_ups.link_task(db, fu_closed, "linked-closed")
+    await follow_ups.update_status(db, fu_closed, "completed")
+
+    reaped = await surplus_tasks.delete_terminal_before(db, before="2026-03-01T00:00:00+00:00")
+
+    assert reaped == 1
+    assert await surplus_tasks.get_by_id(db, "linked-open") is not None
+    assert await surplus_tasks.get_by_id(db, "linked-closed") is None
+
+
 @pytest.mark.asyncio
 async def test_consecutive_failures(db):
     """Counts consecutive failed tasks, stopping at first non-failed."""

--- a/tests/test_mcp/test_outreach_mcp.py
+++ b/tests/test_mcp/test_outreach_mcp.py
@@ -287,3 +287,29 @@ async def test_send_standalone_email_without_thread_enqueues_no_recipient():
     finally:
         mcp_mod._pipeline = old_pipeline
         mcp_mod._db = old_db
+
+
+@pytest.mark.asyncio
+async def test_init_schedules_ensure_table_via_tracked_task():
+    """Standalone fallback (pipeline=None, db set) schedules ensure_table via
+    tracked_task — not a bare get_event_loop().create_task that swallows errors
+    and can spawn an orphan-loop task."""
+    old_pipeline, old_db = mcp_mod._pipeline, mcp_mod._db
+    scheduled: list[dict] = []
+
+    def _capture(coro, **kwargs):
+        scheduled.append(kwargs)
+        coro.close()  # avoid 'coroutine was never awaited' warning
+        return MagicMock()
+
+    try:
+        with patch("genesis.util.tasks.tracked_task", side_effect=_capture), \
+             patch("genesis.db.crud.pending_outreach.ensure_table", new_callable=AsyncMock):
+            mcp_mod.init_outreach_mcp(
+                pipeline=None, engagement=None, config=None, db=AsyncMock(),
+            )
+        assert scheduled, "ensure_table was not scheduled via tracked_task"
+        assert scheduled[0].get("name") == "outreach-ensure-pending-table"
+    finally:
+        mcp_mod._pipeline = old_pipeline
+        mcp_mod._db = old_db

--- a/tests/test_surplus/test_code_audit.py
+++ b/tests/test_surplus/test_code_audit.py
@@ -35,6 +35,28 @@ def _make_task(task_type: TaskType = TaskType.CODE_AUDIT) -> SurplusTask:
 
 
 @pytest.mark.asyncio
+async def test_run_cmd_kills_process_on_timeout():
+    """On subprocess timeout, the child is killed and reaped (not left running)."""
+    db = AsyncMock()
+    gatherer = CodebaseContextGatherer(db, repo_root="/tmp/fake")
+
+    proc = MagicMock()
+    proc.communicate = AsyncMock(side_effect=TimeoutError)
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+
+    with patch(
+        "genesis.surplus.code_audit.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=proc),
+    ):
+        result = await gatherer._run_cmd("git", "log")
+
+    assert result == ""
+    proc.kill.assert_called_once()
+    proc.wait.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_gatherer_assembles_context():
     """Gatherer runs subprocess commands and assembles sections."""
     db = AsyncMock()

--- a/tests/test_surplus/test_queue.py
+++ b/tests/test_surplus/test_queue.py
@@ -85,6 +85,29 @@ async def test_drain_expired_removes_old_tasks(db, queue):
     assert removed == 1
 
 
+async def test_reap_terminal_removes_old_terminal_keeps_recent(db, queue):
+    """reap_terminal deletes completed rows older than retention; recent ones stay."""
+    base = datetime(2026, 3, 4, 12, 0, 0, tzinfo=UTC)  # queue's fixed clock
+    old = (base - timedelta(days=40)).isoformat()
+    await surplus_tasks.create(
+        db, id="old-done", task_type="brainstorm_self", compute_tier="free_api",
+        priority=0.5, drive_alignment="curiosity", created_at=old,
+    )
+    await surplus_tasks.mark_completed(db, "old-done", completed_at=old)
+    recent = (base - timedelta(hours=1)).isoformat()
+    await surplus_tasks.create(
+        db, id="recent-done", task_type="brainstorm_self", compute_tier="free_api",
+        priority=0.5, drive_alignment="curiosity", created_at=recent,
+    )
+    await surplus_tasks.mark_completed(db, "recent-done", completed_at=recent)
+
+    reaped = await queue.reap_terminal(older_than_days=30)
+
+    assert reaped == 1
+    assert await surplus_tasks.get_by_id(db, "old-done") is None
+    assert await surplus_tasks.get_by_id(db, "recent-done") is not None
+
+
 async def test_pending_count(queue):
     await queue.enqueue(TaskType.BRAINSTORM_SELF, ComputeTier.FREE_API, 0.5, "curiosity")
     await queue.enqueue(TaskType.BRAINSTORM_USER, ComputeTier.FREE_API, 0.3, "curiosity")

--- a/tests/test_surplus/test_scheduler.py
+++ b/tests/test_surplus/test_scheduler.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from genesis.db.crud import surplus_tasks
 from genesis.surplus.compute_availability import ComputeAvailability
 from genesis.surplus.executor import StubExecutor
 from genesis.surplus.idle_detector import IdleDetector
@@ -64,6 +65,20 @@ async def test_dispatch_skips_when_queue_empty(db):
     with patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False):
         result = await sched.dispatch_once()
     assert result is False
+
+
+async def test_dispatch_reaps_old_terminal_rows(db):
+    """dispatch_once age-caps terminal rows (runs before the idle short-circuit)."""
+    sched, compute = _make_scheduler(db, idle=False)  # not idle → returns early after reap
+    old = (datetime.now(UTC) - timedelta(days=40)).isoformat()
+    await surplus_tasks.create(
+        db, id="ancient", task_type="brainstorm_self", compute_tier="free_api",
+        priority=0.5, drive_alignment="curiosity", created_at=old,
+    )
+    await surplus_tasks.mark_completed(db, "ancient", completed_at=old)
+    with patch.object(compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False):
+        await sched.dispatch_once()
+    assert await surplus_tasks.get_by_id(db, "ancient") is None
 
 
 async def test_dispatch_processes_task(db):


### PR DESCRIPTION
## WS-F — queue hygiene (audit 2026-07-02)

Three independent, low-risk fixes from the read-only audit. No DB migration.

### F7 — surplus terminal-row reaper (the main change)
`drain_expired` only ever deleted `pending` rows, so finished tasks accumulated forever. On the live DB that's **3,798 completed + 107 failed = 3,905 terminal rows** and climbing.

- New `surplus_tasks.delete_terminal_before(before)` — deletes `completed`/`failed`/`cancelled` rows aged by `COALESCE(completed_at, started_at, created_at)` (a `failed` row never gets a `completed_at`).
- `SurplusQueue.reap_terminal(older_than_days=30)` wrapper; wired into `scheduler.dispatch_once` (new `terminal_retention_days=30` ctor param) right after `drain_expired`.
- **30-day retention** sits far above every scheduler cooldown (max 24h) and the pending-drain window (72h), so `last_completed_at` cooldown checks are never disturbed.
- Rows still referenced by a **non-terminal follow-up** (`linked_task_id`) are preserved so `follow_ups.dispatcher` can still resolve them. The `linked_task_id IS NOT NULL` filter keeps NULLs out of the `NOT IN` set (avoids the classic footgun).

### F10.2 — outreach_mcp orphan-task on init
`init_outreach_mcp`'s standalone fallback used `asyncio.get_event_loop().create_task(ensure_table(db))`, which can spin up an orphan loop and swallows errors. Now `tracked_task(...)` (RuntimeError suppressed in the no-loop path), so a failed `ensure_table` surfaces via the error callback.

### F10.3 — code_audit leaked subprocess on timeout
`_run_cmd` returned on `TimeoutError` while leaving the child running. Now `proc.kill()` + `await proc.wait()` (guarded by `ProcessLookupError`), mirroring `guardian/_subprocess`.

### Dropped: F9 (not a bug)
The audit's F9 (`staleness_policy "drain"→"ttl"` in `outreach/pipeline.py`) was investigated and **dropped as a false positive**. `outreach_delivery` items are owned end-to-end by `OutreachRecoveryWorker`, which marks them terminal itself; `drain` deliberately keeps `expire_by_policy` from age-deleting them (WS-6 / AUTO-RECOV-01). Flipping to `ttl` would re-break that.

## Verification
- **TDD** — 8 new tests (4 crud reaper incl. the follow-up-link exclusion, 1 queue wrapper, 1 scheduler dispatch, 1 code_audit kill-on-timeout, 1 outreach init). 84 pass across the 5 touched test files; ruff clean.
- **Code review** — clean, no findings (NULL/`NOT IN` guard, ISO-timestamp comparison, cooldown headroom, `blocked` treated as open, `proc` binding all verified).
- **E2E dry-run on the live DB** (read-only): the exact reaper query is valid SQL and would reap **3,181** stale rows (→ ~724 remaining); **0** rows wrongly protected or reaped by the exclusion; newest `completed_at` per task type is all *today*, so no cooldown check is endangered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)