### PR TITLE
feat(observability): honest health surface — PSI/CPU status + per-CC-slot RSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **The dashboard's container-health badge now tells the truth about CPU and memory pressure.**
+  Previously the badge ignored CPU entirely (it was hardwired to "healthy") and judged memory only by a
+  raw usage figure that's inflated by reclaimable cache — so a busy or memory-throttling box could still
+  read all-green. It now factors in actual CPU utilization and PSI (pressure-stall) readings: it stays
+  green when the box is merely holding reclaimable cache, and only turns amber/red when CPU or memory is
+  genuinely stalling work, with a reason that says which.
+
 - **Genesis now catches scheduled jobs that silently stop working — running on schedule but never
   succeeding.** Some background jobs (like the weekly self-assessment and quality calibration) could
   fail week after week without ever showing up as "failed," because the failure counter is reset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   green when the box is merely holding reclaimable cache, and only turns amber/red when CPU or memory is
   genuinely stalling work, with a reason that says which.
 
+- **The dashboard now shows the memory each Claude Code session is using, and warns you if one balloons.**
+  Each concurrent session normally uses well under a gigabyte; the Container card now lists per-session RSS, and
+  if a single session climbs past a high ceiling — a sign it may be leaking — Genesis raises a health alert
+  (reaching Telegram at the critical level) so you can restart just that session instead of finding out the hard way.
+
 - **Genesis now catches scheduled jobs that silently stop working — running on schedule but never
   succeeding.** Some background jobs (like the weekly self-assessment and quality calibration) could
   fail week after week without ever showing up as "failed," because the failure counter is reset

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -134,6 +134,69 @@ async def _check_wal_health(db) -> None:
         logger.debug("Failed to create WAL health alert observation", exc_info=True)
 
 
+# Per-CC-slot RSS alerting. Same monotonic-since-boot caveat as WAL above: use a
+# key-existence check (a missing key means "never alerted"), NEVER a default of
+# 0.0 — on a host booted <cooldown ago, `now - 0.0` is small and would wrongly
+# suppress the first alert for a slot.
+_last_slot_alert_at: dict[str, float] = {}
+_SLOT_ALERT_COOLDOWN_S = 3600  # one alert per slot per hour
+
+
+async def _check_cc_slot_memory(db, slots: list[dict] | None = None) -> None:
+    """Alert when a single CC slot's RSS is abnormally high (a session leak).
+
+    Reads /proc (no DB dependency — runs even during a DB hiccup); only the
+    observation write needs `db`. WARN → priority 'high' (morning report); CRIT
+    → 'critical' (rides the critical-observations job to Telegram). Best-effort;
+    never raises into the tick. `slots` may be passed pre-collected (tests /
+    future sharing); otherwise it enumerates."""
+    try:
+        from genesis.observability.cc_slots import (
+            SLOT_RSS_CRIT_MB,
+            SLOT_RSS_WARN_MB,
+            enumerate_cc_slots,
+        )
+        if slots is None:
+            slots = enumerate_cc_slots()
+    except Exception:
+        logger.debug("cc_slot memory check: enumeration failed", exc_info=True)
+        return
+
+    now = time.monotonic()
+    for slot in slots:
+        rss = slot.get("rss_mb", 0.0)
+        if rss < SLOT_RSS_WARN_MB:
+            continue
+        key = str(slot.get("slot", "?"))
+        last = _last_slot_alert_at.get(key)
+        if last is not None and (now - last) < _SLOT_ALERT_COOLDOWN_S:
+            continue
+        if db is None:
+            continue  # can't write the observation now; retry next tick
+        priority = "critical" if rss >= SLOT_RSS_CRIT_MB else "high"
+        # Consumed only once we can actually write (after the db-None guard), and
+        # set before the await so a failed create still suppresses per-tick retries.
+        _last_slot_alert_at[key] = now
+        try:
+            await observations.create(
+                db,
+                id=str(uuid.uuid4()),
+                source="cc_slot_monitor",
+                type="infrastructure_alert",
+                content=(
+                    f"CC slot cc-{key} (pid {slot.get('pid')}) is using "
+                    f"{rss / 1024:.1f} GB RAM (warn {SLOT_RSS_WARN_MB // 1024} GB, "
+                    f"crit {SLOT_RSS_CRIT_MB // 1024} GB). A single Claude Code "
+                    f"session may be leaking — consider restarting slot cc-{key}."
+                ),
+                priority=priority,
+                created_at=datetime.now(UTC).isoformat(),
+            )
+            logger.warning("CC slot memory alert: cc-%s %.1f GB (%s)", key, rss / 1024, priority)
+        except Exception:
+            logger.debug("Failed to create cc_slot alert observation", exc_info=True)
+
+
 # Micro ticks are silent by default (counted for cascade, no LLM call).
 # LLM fires only when these critical operational signals are active.
 _MICRO_CRITICAL_SIGNALS = frozenset({"software_error_spike", "critical_failure"})
@@ -761,6 +824,11 @@ class AwarenessLoop:
                         self._resilience_state_machine.update_tmp_pressure(tmp_status)
                 except Exception:
                     logger.debug("tmp_pressure axis update failed", exc_info=True)
+
+            # Per-CC-slot RSS leak check — reads /proc (no DB dependency, so it
+            # still runs during a DB hiccup); the observation write is guarded on
+            # db inside the function. Surfaces a single ballooning CC session.
+            await _check_cc_slot_memory(self._db)
 
             # SQLite WAL checkpoint — prevent unbounded WAL growth from
             # external scripts or concurrent writers. PASSIVE is non-blocking.

--- a/src/genesis/dashboard/routes/resources.py
+++ b/src/genesis/dashboard/routes/resources.py
@@ -63,4 +63,12 @@ def system_resources():
     except OSError:
         result["disk"] = {"status": "unavailable"}
 
+    # Per-CC-slot RSS — leak/anomaly visibility (one row per Claude Code session)
+    try:
+        from genesis.observability.cc_slots import enumerate_cc_slots
+
+        result["cc_slots"] = enumerate_cc_slots()
+    except Exception:
+        result["cc_slots"] = []
+
     return jsonify(result)

--- a/src/genesis/dashboard/routes/resources.py
+++ b/src/genesis/dashboard/routes/resources.py
@@ -29,6 +29,7 @@ def system_resources():
     # Container memory — anon+kernel (non-reclaimable) for status decisions
     try:
         from genesis.autonomy.watchdog import get_container_anon_memory, get_container_memory
+        from genesis.observability.snapshots.infrastructure import _PSI_MEMORY_PATH, _read_psi
 
         anon_mem = get_container_anon_memory()
         total_mem = get_container_memory()
@@ -37,11 +38,12 @@ def system_resources():
             anon_pct = round(anon_kernel / limit * 100, 1)
             total_pct = round(total_mem[0] / limit * 100, 1) if total_mem and total_mem[1] > 0 else anon_pct
             result["memory"] = {
-                "status": "healthy" if anon_pct < 85 else ("degraded" if anon_pct < 95 else "critical"),
+                "status": "healthy" if anon_pct < 85 else ("degraded" if anon_pct < 95 else "down"),
                 "used_gb": round((total_mem[0] if total_mem else anon_kernel) / (1024**3), 1),
                 "total_gb": round(limit / (1024**3), 1),
                 "used_pct": total_pct,
                 "anon_pct": anon_pct,
+                "pressure": _read_psi(_PSI_MEMORY_PATH),
             }
         else:
             result["memory"] = {"status": "unavailable"}

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -3256,16 +3256,27 @@
         containerSemantic() {
           const mem = this.health.infrastructure?.container_memory;
           const disk = this.health.infrastructure?.disk;
-          const stateRank = { error: 3, degraded: 2, unknown: 1, healthy: 0 };
+          const cpu = this.health.infrastructure?.cpu;
+          // "down" is the memory block's worst status; rank it with "error".
+          const stateRank = { error: 3, down: 3, degraded: 2, unknown: 1, unavailable: 1, healthy: 0 };
 
-          // Memory assessment (primary — OOM kills)
+          // Memory assessment (primary — OOM kills). Status already folds in
+          // sustained memory PSI server-side; report PSI when it's the driver.
           let memState = "healthy", memReason = "container resources within safe limits";
+          const memPct = (mem?.anon_pct ?? mem?.used_pct);
+          const memFull60 = mem?.pressure?.full_avg60;
           if (!mem || ["unknown", "unavailable"].includes(mem.status)) {
             memState = "unknown"; memReason = "container memory data unavailable";
-          } else if ((mem.anon_pct ?? mem.used_pct) > 85 || mem.status === "down") {
-            memState = "error"; memReason = "memory in danger zone (" + (mem.anon_pct ?? mem.used_pct).toFixed(0) + "%)";
-          } else if ((mem.anon_pct ?? mem.used_pct) > 75 || mem.status === "degraded") {
-            memState = "degraded"; memReason = "memory usage elevated (" + (mem.anon_pct ?? mem.used_pct).toFixed(0) + "%)";
+          } else if (mem.status === "down" || memPct > 85) {
+            memState = "error";
+            memReason = (memFull60 >= 30)
+              ? "memory stalling work (PSI " + memFull60.toFixed(0) + "%)"
+              : "memory in danger zone (" + memPct.toFixed(0) + "%)";
+          } else if (mem.status === "degraded" || memPct > 75) {
+            memState = "degraded";
+            memReason = (memFull60 >= 10)
+              ? "memory pressure elevated (PSI " + memFull60.toFixed(0) + "%)"
+              : "memory usage elevated (" + memPct.toFixed(0) + "%)";
           }
 
           // Disk assessment (secondary — write failures)
@@ -3279,11 +3290,21 @@
             }
           }
 
-          // Worst-of-two — disk or memory, whichever is worse
-          if ((stateRank[diskState] || 0) > (stateRank[memState] || 0)) {
-            return { state: diskState, reason: diskReason };
+          // CPU assessment (utilization % from used_pct — NOT loadavg).
+          let cpuState = "healthy", cpuReason = "";
+          if (cpu && (cpu.status === "degraded" || cpu.status === "error")) {
+            cpuState = cpu.status;
+            const cpuFull60 = cpu.pressure?.full_avg60;
+            cpuReason = "CPU " + cpu.status + " (" + (cpu.used_pct ?? 0).toFixed(0) + "% used"
+              + ((cpuFull60 >= 1) ? ", stall " + cpuFull60.toFixed(0) + "%" : "") + ")";
           }
-          return { state: memState, reason: memReason };
+
+          // Worst-of — memory, disk, or CPU, whichever is worst.
+          let worst = { state: memState, reason: memReason };
+          for (const c of [{ state: diskState, reason: diskReason }, { state: cpuState, reason: cpuReason }]) {
+            if ((stateRank[c.state] || 0) > (stateRank[worst.state] || 0)) worst = c;
+          }
+          return worst;
         },
 
         awarenessSemantic() {

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -5196,6 +5196,19 @@
                         x-text="($store.genesisDashboard.health.infrastructure.disk.total_gb - $store.genesisDashboard.health.infrastructure.disk.free_gb).toFixed(0) + '/' + $store.genesisDashboard.health.infrastructure.disk.total_gb.toFixed(0) + ' GB'"></span>
                 </div>
               </template>
+              <!-- CC slots row (per-session RSS — leak detection) -->
+              <template x-if="($store.genesisDashboard.health.infrastructure?.cc_slots || []).length">
+                <div style="display:flex; align-items:flex-start; gap:0.5rem; font-size:0.8rem;">
+                  <span style="width:3.2rem; color:var(--color-text-secondary);">CC</span>
+                  <div style="flex:1; display:flex; flex-wrap:wrap; gap:0.35rem;">
+                    <template x-for="slot in $store.genesisDashboard.health.infrastructure.cc_slots" :key="slot.slot">
+                      <span style="font-size:0.7rem; padding:0.05rem 0.3rem; border-radius:3px; background:var(--color-background); white-space:nowrap;"
+                            :style="`color: ${slot.status === 'error' ? '#d9534f' : slot.status === 'degraded' ? '#f0ad4e' : 'var(--color-text-secondary)'}`"
+                            x-text="'cc-' + slot.slot + ' ' + (slot.rss_mb / 1024).toFixed(1) + 'G'"></span>
+                    </template>
+                  </div>
+                </div>
+              </template>
               <!-- Fallback when no data -->
               <template x-if="!$store.genesisDashboard.health.infrastructure?.container_memory?.used_pct && !$store.genesisDashboard.health.infrastructure?.cpu && !$store.genesisDashboard.health.infrastructure?.disk">
                 <span style="color: #666; font-size: 0.82rem;">no data</span>

--- a/src/genesis/observability/cc_slots.py
+++ b/src/genesis/observability/cc_slots.py
@@ -1,0 +1,102 @@
+"""Per-CC-slot memory (RSS) enumeration for leak/anomaly detection.
+
+Genesis runs concurrent Claude Code sessions ("slots"); each is a `claude`
+process carrying ``GENESIS_SLOT=<n>`` in its environ, normally ~0.7-1.0 GB RSS.
+A single session that balloons (a leak) is otherwise invisible — this surfaces
+per-slot RSS so it can be shown on the dashboard and alerted on. This is leak
+DETECTION, not OOM prevention (the container has ample headroom).
+
+Stdlib-only leaf module (no genesis imports → no import cycle). Uses same-uid
+/proc reads, which succeed despite yama ``ptrace_scope=1`` (that gates
+PTRACE_ATTACH, not the READ mode used for ``/proc/<pid>/environ``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_PROC = "/proc"
+
+# Thresholds on the main `claude` process RSS (MB). Normal is ~0.7-1.0 GB, so
+# 4 GB WARN is ~4x baseline. Tunable — revisit once a week of dashboard data
+# lands (a very large long-lived session can legitimately reach 2-3 GB).
+SLOT_RSS_WARN_MB = 4096
+SLOT_RSS_CRIT_MB = 6144
+
+
+def read_proc_rss_mb(pid: int) -> float | None:
+    """VmRSS of a pid in MB, or None if the pid is gone/unreadable."""
+    try:
+        with open(f"{_PROC}/{pid}/status") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return round(int(line.split()[1]) / 1024, 1)  # kB → MB
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+def _slot_label(pid: int) -> str | None:
+    """The GENESIS_SLOT value from a pid's environ, or None if absent/unreadable."""
+    try:
+        with open(f"{_PROC}/{pid}/environ", "rb") as f:
+            raw = f.read()
+    except OSError:
+        return None
+    for entry in raw.split(b"\x00"):
+        if entry.startswith(b"GENESIS_SLOT="):
+            val = entry.partition(b"=")[2].decode("utf-8", "replace").strip()
+            return val or None
+    return None
+
+
+def slot_status(rss_mb: float) -> str:
+    """Map a slot's RSS (MB) to a health status."""
+    if rss_mb >= SLOT_RSS_CRIT_MB:
+        return "error"
+    if rss_mb >= SLOT_RSS_WARN_MB:
+        return "degraded"
+    return "healthy"
+
+
+def enumerate_cc_slots() -> list[dict]:
+    """One row per CC slot: ``{slot, pid, rss_mb, status}``, sorted by slot.
+
+    Walks /proc for `claude` processes tagged with GENESIS_SLOT and reads each
+    one's VmRSS. If two `claude` processes somehow share a slot, the larger RSS
+    wins. Best-effort: returns [] on failure (logged at DEBUG so an empty list
+    caused by an error is distinguishable in the logs from a genuine no-slots
+    state — this is a visibility feature, so a silent hole would defeat it).
+    """
+    try:
+        pids = [int(n) for n in os.listdir(_PROC) if n.isdigit()]
+    except OSError:
+        logger.debug("cc_slots: cannot list /proc", exc_info=True)
+        return []
+
+    by_slot: dict[str, dict] = {}
+    for pid in pids:
+        try:
+            with open(f"{_PROC}/{pid}/comm") as f:
+                if f.read().strip() != "claude":
+                    continue
+        except OSError:
+            continue  # pid vanished or unreadable — normal, skip
+        label = _slot_label(pid)
+        if label is None:
+            continue
+        rss = read_proc_rss_mb(pid)
+        if rss is None:
+            continue
+        prev = by_slot.get(label)
+        if prev is None or rss > prev["rss_mb"]:
+            by_slot[label] = {"slot": label, "pid": pid, "rss_mb": rss, "status": slot_status(rss)}
+    # Numeric-aware sort so "10" follows "9" (labels are numeric strings today);
+    # any non-numeric label sorts last.
+    return sorted(
+        by_slot.values(),
+        key=lambda r: (0, int(r["slot"])) if r["slot"].isdigit() else (1, r["slot"]),
+    )

--- a/src/genesis/observability/snapshots/infrastructure.py
+++ b/src/genesis/observability/snapshots/infrastructure.py
@@ -77,17 +77,107 @@ def _read_mem_available() -> int | None:
     return None
 
 
+_PSI_CPU_PATH = "/sys/fs/cgroup/cpu.pressure"
+_PSI_MEMORY_PATH = "/sys/fs/cgroup/memory.pressure"
+
+
+def _read_psi(path: str) -> dict:
+    """Parse a cgroup PSI (pressure stall information) file into some/full avgs.
+
+    PSI is the honest "is contention actually HURTING" metric: `full.avgN` is
+    the % of wall-clock over the last N s during which *all* non-idle tasks were
+    stalled waiting on this resource. It distinguishes real pressure from benign
+    reclaim — e.g. a climbing memory.events 'high' count with memory.pressure
+    full.avg=0 is harmless page-cache reclaim, not a problem.
+
+    Returns {} if unavailable (kernel without CONFIG_PSI, missing file). Mirrors
+    genesis.guardian.health_signals.parse_psi_content; kept local to avoid
+    importing the host-side guardian module into the in-server snapshot path.
+    """
+    try:
+        out: dict[str, float] = {}
+        with open(path) as f:
+            for line in f:
+                parts = line.split()
+                if not parts or parts[0] not in ("some", "full"):
+                    continue
+                prefix = parts[0]
+                for part in parts[1:]:
+                    key, sep, val = part.partition("=")
+                    if sep and key in ("avg10", "avg60", "avg300"):
+                        try:
+                            out[f"{prefix}_{key}"] = float(val)
+                        except ValueError:
+                            continue
+        return out
+    except (OSError, ValueError):
+        return {}
+
+
+# Health-status ranking (higher = worse) for composing multiple signals.
+_STATUS_RANK = {"healthy": 0, "unknown": 1, "unavailable": 1, "degraded": 2, "down": 3, "error": 3}
+
+
+def _worse_status(a: str, b: str) -> str:
+    """Return the worse (higher-ranked) of two health statuses."""
+    return a if _STATUS_RANK.get(a, 0) >= _STATUS_RANK.get(b, 0) else b
+
+
+# Container memory PSI thresholds (full.avg60 %). Sustained memory stall is REAL
+# pressure even when anon% is moderate; benign cache reclaim reads ~0.
+_MEM_PSI_DEGRADED_PCT = 10.0
+_MEM_PSI_ERROR_PCT = 30.0
+
+
+def memory_status(anon_frac: float, pressure: dict) -> str:
+    """Container-memory health = worse of anon% (OOM guard, non-reclaimable) and
+    sustained memory PSI (catches reclaim that is actually stalling work).
+
+    anon_frac is a 0..1 fraction of the cgroup limit.
+    """
+    anon_status = "healthy" if anon_frac < 0.85 else ("degraded" if anon_frac < 0.95 else "down")
+    full60 = pressure.get("full_avg60", 0.0)
+    psi_status = (
+        "down" if full60 >= _MEM_PSI_ERROR_PCT
+        else ("degraded" if full60 >= _MEM_PSI_DEGRADED_PCT else "healthy")
+    )
+    return _worse_status(anon_status, psi_status)
+
+
+# CPU utilization % thresholds — plain used_pct (NOT loadavg; loadavg counts I/O
+# wait and misrepresents CPU). Only SUSTAINED high utilization degrades; the
+# normal box hum (~45%) stays healthy.
+_CPU_DEGRADED_PCT = 80.0
+_CPU_ERROR_PCT = 95.0
+
+
+def _cpu_status(used_pct: float | None) -> str:
+    """Map CPU utilization % → health status. None (baseline/no data) → healthy."""
+    if used_pct is None:
+        return "healthy"
+    if used_pct >= _CPU_ERROR_PCT:
+        return "error"
+    if used_pct >= _CPU_DEGRADED_PCT:
+        return "degraded"
+    return "healthy"
+
+
 # Module-level state for delta-based CPU reading (no blocking sleep)
 _last_cpu_reading: tuple[int, int, float] | None = None  # (idle, total, monotonic_time)
 
 
 def _collect_cpu_usage() -> dict:
-    """Read CPU usage from /proc/stat delta. No blocking sleep.
+    """Read CPU usage from /proc/stat delta + CPU pressure (PSI). No blocking sleep.
 
-    First call stores a baseline and returns None for used_pct.
-    Subsequent calls compute delta from the stored baseline.
+    First call stores a baseline and returns None for used_pct. Subsequent calls
+    compute the delta from the stored baseline. Status derives from used_pct
+    (plain CPU utilization %), NOT loadavg — loadavg counts I/O wait and
+    misrepresents CPU. cpu.pressure (PSI) is surfaced as the honest "is CPU
+    contention actually stalling work" signal.
     """
     global _last_cpu_reading  # noqa: PLW0603
+    pressure = _read_psi(_PSI_CPU_PATH)
+    count = os.cpu_count()
     try:
         with open("/proc/stat") as f:
             parts = f.readline().split()
@@ -98,7 +188,7 @@ def _collect_cpu_usage() -> dict:
 
         if _last_cpu_reading is None:
             _last_cpu_reading = (idle, total, now)
-            return {"status": "healthy", "used_pct": None, "count": os.cpu_count()}
+            return {"status": "healthy", "used_pct": None, "count": count, "pressure": pressure}
 
         prev_idle, prev_total, _prev_time = _last_cpu_reading
         _last_cpu_reading = (idle, total, now)
@@ -106,12 +196,12 @@ def _collect_cpu_usage() -> dict:
         delta_idle = idle - prev_idle
         delta_total = total - prev_total
         if delta_total == 0:
-            return {"status": "healthy", "used_pct": 0.0, "count": os.cpu_count()}
+            return {"status": "healthy", "used_pct": 0.0, "count": count, "pressure": pressure}
 
         used_pct = round((1.0 - delta_idle / delta_total) * 100, 1)
-        return {"status": "healthy", "used_pct": used_pct, "count": os.cpu_count()}
+        return {"status": _cpu_status(used_pct), "used_pct": used_pct, "count": count, "pressure": pressure}
     except (OSError, ValueError, IndexError):
-        return {"status": "unavailable", "used_pct": None, "count": os.cpu_count()}
+        return {"status": "unavailable", "used_pct": None, "count": count, "pressure": pressure}
 
 
 async def infrastructure(
@@ -222,16 +312,18 @@ async def infrastructure(
         if anon_mem and anon_mem[1] > 0:
             anon_kernel, limit = anon_mem
             anon_pct = anon_kernel / limit
-            # Status thresholds use anon+kernel (non-reclaimable).
-            # Total cgroup usage (memory.current) is shown for reference
-            # but not used for health decisions — it includes reclaimable
-            # page cache that inflates the metric.
+            mem_pressure = _read_psi(_PSI_MEMORY_PATH)
+            # Status = worse of anon% (OOM guard, non-reclaimable) and sustained
+            # memory PSI. Total cgroup usage (memory.current) is shown for
+            # reference but NOT used for health — it includes reclaimable page
+            # cache that inflates the metric, and whose reclaim is benign.
             mem_info: dict = {
-                "status": "healthy" if anon_pct < 0.85 else ("degraded" if anon_pct < 0.95 else "down"),
+                "status": memory_status(anon_pct, mem_pressure),
                 "current_gb": round((total_mem[0] if total_mem else anon_kernel) / (1024**3), 1),
                 "limit_gb": round(limit / (1024**3), 1),
                 "used_pct": round((total_mem[0] / limit * 100) if total_mem and total_mem[1] > 0 else anon_pct * 100, 1),
                 "anon_pct": round(anon_pct * 100, 1),
+                "pressure": mem_pressure,
             }
             # MemAvailable from /proc/meminfo — the kernel's estimate of
             # memory available for new allocations without swapping. This is

--- a/src/genesis/observability/snapshots/infrastructure.py
+++ b/src/genesis/observability/snapshots/infrastructure.py
@@ -298,6 +298,13 @@ async def infrastructure(
         infra["cc_tmp"] = {"status": "error", "error": str(exc)}
 
     try:
+        from genesis.observability.cc_slots import enumerate_cc_slots
+
+        infra["cc_slots"] = enumerate_cc_slots()
+    except Exception:
+        infra["cc_slots"] = []
+
+    try:
         from genesis.observability.service_status import probe_qdrant_collections
 
         infra["qdrant_collections"] = await probe_qdrant_collections()

--- a/tests/test_awareness/test_cc_slot_alert.py
+++ b/tests/test_awareness/test_cc_slot_alert.py
@@ -1,0 +1,92 @@
+"""Tests for _check_cc_slot_memory — the per-slot RSS Telegram/alert path (PR-2c).
+
+The alert rides the existing critical-observations job: a
+type="infrastructure_alert", priority="critical" observation → Telegram. We
+assert the observation is created with the right fields, the WARN/CRIT priority
+split, the per-slot cooldown, and the db-None / below-threshold no-ops.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from genesis.awareness import loop
+
+
+@pytest.fixture(autouse=True)
+def _reset_cooldown_and_mock_create(monkeypatch):
+    monkeypatch.setattr(loop, "_last_slot_alert_at", {})
+    create = AsyncMock()
+    monkeypatch.setattr(loop.observations, "create", create)
+    return create
+
+
+def _slot(label, rss_mb, pid=1234):
+    return {"slot": label, "pid": pid, "rss_mb": rss_mb, "status": "x"}
+
+
+@pytest.mark.asyncio
+async def test_crit_creates_critical_infrastructure_alert(_reset_cooldown_and_mock_create):
+    create = _reset_cooldown_and_mock_create
+    db = object()  # any non-None handle
+    await loop._check_cc_slot_memory(db, slots=[_slot("4", 6500)])
+    create.assert_awaited_once()
+    kwargs = create.await_args.kwargs
+    assert kwargs["type"] == "infrastructure_alert"
+    assert kwargs["priority"] == "critical"
+    assert kwargs["source"] == "cc_slot_monitor"
+    assert "cc-4" in kwargs["content"]
+
+
+@pytest.mark.asyncio
+async def test_warn_is_high_priority_not_critical(_reset_cooldown_and_mock_create):
+    create = _reset_cooldown_and_mock_create
+    await loop._check_cc_slot_memory(object(), slots=[_slot("2", 4500)])
+    create.assert_awaited_once()
+    assert create.await_args.kwargs["priority"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_below_warn_no_alert(_reset_cooldown_and_mock_create):
+    create = _reset_cooldown_and_mock_create
+    await loop._check_cc_slot_memory(object(), slots=[_slot("1", 950)])
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cooldown_suppresses_second_alert(_reset_cooldown_and_mock_create):
+    create = _reset_cooldown_and_mock_create
+    db = object()
+    await loop._check_cc_slot_memory(db, slots=[_slot("4", 6500)])
+    await loop._check_cc_slot_memory(db, slots=[_slot("4", 6600)])
+    # second call is within the 1h cooldown → still only one create
+    create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_distinct_slots_alert_independently(_reset_cooldown_and_mock_create):
+    create = _reset_cooldown_and_mock_create
+    await loop._check_cc_slot_memory(object(), slots=[_slot("4", 6500), _slot("5", 6700)])
+    assert create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_db_none_does_not_write_or_consume_cooldown(_reset_cooldown_and_mock_create):
+    create = _reset_cooldown_and_mock_create
+    # db None (e.g. DB down) → no write, and the cooldown is NOT consumed so a
+    # later tick with a live db still alerts.
+    await loop._check_cc_slot_memory(None, slots=[_slot("4", 6500)])
+    create.assert_not_awaited()
+    assert loop._last_slot_alert_at == {}
+    await loop._check_cc_slot_memory(object(), slots=[_slot("4", 6500)])
+    create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_failure_never_raises(_reset_cooldown_and_mock_create):
+    create = _reset_cooldown_and_mock_create
+    create.side_effect = RuntimeError("db locked")
+    # must not propagate into the tick
+    await loop._check_cc_slot_memory(object(), slots=[_slot("4", 6500)])

--- a/tests/test_observability/test_cc_slots.py
+++ b/tests/test_observability/test_cc_slots.py
@@ -1,0 +1,96 @@
+"""Tests for per-CC-slot RSS enumeration (PR-2c leak detection)."""
+
+from __future__ import annotations
+
+import os
+
+from genesis.observability import cc_slots
+from genesis.observability.cc_slots import (
+    SLOT_RSS_CRIT_MB,
+    SLOT_RSS_WARN_MB,
+    enumerate_cc_slots,
+    read_proc_rss_mb,
+    slot_status,
+)
+
+
+def _make_proc_entry(root, pid: int, comm: str, slot: str | None, rss_kb: int | None):
+    d = root / str(pid)
+    d.mkdir()
+    (d / "comm").write_text(comm + "\n")
+    if slot is not None:
+        (d / "environ").write_bytes(b"PATH=/usr/bin\x00GENESIS_SLOT=" + slot.encode() + b"\x00LANG=C\x00")
+    else:
+        (d / "environ").write_bytes(b"PATH=/usr/bin\x00LANG=C\x00")
+    if rss_kb is not None:
+        (d / "status").write_text(f"Name:\t{comm}\nVmPeak:\t{rss_kb + 100} kB\nVmRSS:\t{rss_kb} kB\n")
+
+
+class TestReadProcRssMb:
+    def test_reads_own_process(self):
+        # our own pid has a real VmRSS
+        rss = read_proc_rss_mb(os.getpid())
+        assert rss is not None and rss > 0
+
+    def test_missing_pid_returns_none(self):
+        assert read_proc_rss_mb(2_000_000_000) is None
+
+    def test_parses_kb_to_mb(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(cc_slots, "_PROC", str(tmp_path))
+        (tmp_path / "42").mkdir()
+        (tmp_path / "42" / "status").write_text("VmRSS:\t2048 kB\n")
+        assert read_proc_rss_mb(42) == 2.0
+
+
+class TestSlotStatus:
+    def test_thresholds(self):
+        assert slot_status(900) == "healthy"
+        assert slot_status(SLOT_RSS_WARN_MB - 1) == "healthy"
+        assert slot_status(SLOT_RSS_WARN_MB) == "degraded"
+        assert slot_status(SLOT_RSS_CRIT_MB - 1) == "degraded"
+        assert slot_status(SLOT_RSS_CRIT_MB) == "error"
+
+
+class TestEnumerateCcSlots:
+    def test_filters_and_labels(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(cc_slots, "_PROC", str(tmp_path))
+        _make_proc_entry(tmp_path, 1001, "claude", "3", 870_000)          # slot 3, healthy
+        _make_proc_entry(tmp_path, 1002, "node", "3", 120_000)            # not claude → skip
+        _make_proc_entry(tmp_path, 1003, "claude", None, 500_000)         # no GENESIS_SLOT → skip
+        _make_proc_entry(tmp_path, 1004, "claude", "7", 7 * 1024 * 1024)  # slot 7, CRIT (7 GB)
+        (tmp_path / "notapid").mkdir()  # non-numeric entry ignored
+
+        rows = enumerate_cc_slots()
+        slots = {r["slot"]: r for r in rows}
+        assert set(slots) == {"3", "7"}
+        assert slots["3"]["status"] == "healthy"
+        assert slots["3"]["rss_mb"] == round(870_000 / 1024, 1)
+        assert slots["3"]["pid"] == 1001
+        assert slots["7"]["status"] == "error"
+        # sorted by slot label
+        assert [r["slot"] for r in rows] == ["3", "7"]
+
+    def test_two_claude_sharing_a_slot_larger_rss_wins(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(cc_slots, "_PROC", str(tmp_path))
+        _make_proc_entry(tmp_path, 2001, "claude", "2", 500_000)
+        _make_proc_entry(tmp_path, 2002, "claude", "2", 900_000)
+        rows = enumerate_cc_slots()
+        assert len(rows) == 1
+        assert rows[0]["pid"] == 2002
+        assert rows[0]["rss_mb"] == round(900_000 / 1024, 1)
+
+    def test_numeric_slot_ordering(self, tmp_path, monkeypatch):
+        # "10" must follow "9", not sort lexicographically before it
+        monkeypatch.setattr(cc_slots, "_PROC", str(tmp_path))
+        _make_proc_entry(tmp_path, 3001, "claude", "9", 800_000)
+        _make_proc_entry(tmp_path, 3002, "claude", "10", 800_000)
+        _make_proc_entry(tmp_path, 3003, "claude", "2", 800_000)
+        assert [r["slot"] for r in enumerate_cc_slots()] == ["2", "9", "10"]
+
+    def test_empty_proc_returns_empty(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(cc_slots, "_PROC", str(tmp_path))
+        assert enumerate_cc_slots() == []
+
+    def test_missing_proc_dir_returns_empty_not_raise(self, monkeypatch):
+        monkeypatch.setattr(cc_slots, "_PROC", "/nonexistent/proc/path")
+        assert enumerate_cc_slots() == []

--- a/tests/test_observability/test_health_psi_cpu.py
+++ b/tests/test_observability/test_health_psi_cpu.py
@@ -1,0 +1,119 @@
+"""Tests for the PSI reader + CPU/memory health-status helpers.
+
+Covers PR-2b′ (health-surface honesty): CPU status derived from plain
+utilization % (not loadavg), and PSI (pressure stall information) surfaced as
+the honest "is contention actually hurting" signal, folded into memory status.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from genesis.observability.snapshots.infrastructure import (
+    _collect_cpu_usage,
+    _cpu_status,
+    _read_psi,
+    _worse_status,
+    memory_status,
+)
+
+# The `snapshots` package re-exports the `infrastructure` *function*, shadowing
+# the submodule name — grab the real module object for monkeypatching globals.
+infra = sys.modules["genesis.observability.snapshots.infrastructure"]
+
+_PSI_SAMPLE = (
+    "some avg10=6.72 avg60=8.89 avg300=10.68 total=123456\n"
+    "full avg10=0.95 avg60=1.10 avg300=1.22 total=65432\n"
+)
+
+
+class TestReadPsi:
+    def test_parses_some_and_full(self, tmp_path):
+        p = tmp_path / "cpu.pressure"
+        p.write_text(_PSI_SAMPLE)
+        out = _read_psi(str(p))
+        assert out["some_avg60"] == 8.89
+        assert out["full_avg10"] == 0.95
+        assert out["full_avg300"] == 1.22
+        # only avg10/60/300 kept — 'total' is dropped
+        assert not any(k.endswith("total") for k in out)
+        assert len(out) == 6
+
+    def test_missing_file_returns_empty(self):
+        assert _read_psi("/sys/fs/cgroup/definitely-not-a-real.pressure") == {}
+
+    def test_malformed_lines_are_skipped(self, tmp_path):
+        p = tmp_path / "bad.pressure"
+        p.write_text("garbage line\nsome avg10=notafloat avg60=2.0 total=5\n\n")
+        out = _read_psi(str(p))
+        # avg10 unparseable → skipped; avg60 parsed
+        assert out == {"some_avg60": 2.0}
+
+
+class TestCpuStatus:
+    def test_none_is_healthy(self):
+        # baseline / no-data must never alarm
+        assert _cpu_status(None) == "healthy"
+
+    def test_thresholds(self):
+        assert _cpu_status(0.0) == "healthy"
+        assert _cpu_status(45.0) == "healthy"  # the normal box hum
+        assert _cpu_status(79.9) == "healthy"
+        assert _cpu_status(80.0) == "degraded"
+        assert _cpu_status(94.9) == "degraded"
+        assert _cpu_status(95.0) == "error"
+        assert _cpu_status(100.0) == "error"
+
+
+class TestMemoryStatus:
+    def test_anon_only(self):
+        assert memory_status(0.36, {}) == "healthy"
+        assert memory_status(0.84, {}) == "healthy"
+        assert memory_status(0.85, {}) == "degraded"
+        assert memory_status(0.95, {}) == "down"
+
+    def test_psi_escalates_even_when_anon_is_low(self):
+        # benign reclaim (full60=0) stays healthy even at the live ~36% anon
+        assert memory_status(0.36, {"full_avg60": 0.0}) == "healthy"
+        # sustained stall is REAL pressure the anon metric alone would miss
+        assert memory_status(0.36, {"full_avg60": 10.0}) == "degraded"
+        assert memory_status(0.36, {"full_avg60": 30.0}) == "down"
+
+    def test_worse_of_the_two_axes_wins(self):
+        # anon degraded but PSI down → down
+        assert memory_status(0.90, {"full_avg60": 35.0}) == "down"
+
+
+class TestWorseStatus:
+    def test_ranking(self):
+        assert _worse_status("healthy", "down") == "down"
+        assert _worse_status("degraded", "healthy") == "degraded"
+        assert _worse_status("down", "degraded") == "down"
+        assert _worse_status("healthy", "healthy") == "healthy"
+
+
+class TestCollectCpuUsage:
+    def test_shape_and_pressure_present(self):
+        result = _collect_cpu_usage()
+        assert set(result) >= {"status", "used_pct", "count", "pressure"}
+        assert result["status"] in {"healthy", "degraded", "error", "unavailable"}
+        assert isinstance(result["pressure"], dict)
+
+    def test_baseline_first_call_is_healthy(self, monkeypatch):
+        # Reset module state → first call is the baseline (used_pct=None → healthy)
+        monkeypatch.setattr(infra, "_last_cpu_reading", None)
+        first = _collect_cpu_usage()
+        assert first["used_pct"] is None
+        assert first["status"] == "healthy"
+
+    def test_status_tracks_used_pct(self, monkeypatch):
+        # Force a high-utilization delta and assert the status reflects it.
+        monkeypatch.setattr(infra, "_last_cpu_reading", None)
+        _collect_cpu_usage()  # establish a baseline
+        # Rewrite the baseline so the next real /proc/stat delta looks ~100% busy:
+        # a large elapsed total with the same idle → 100% used → error.
+        idle, total, t = infra._last_cpu_reading
+        monkeypatch.setattr(infra, "_last_cpu_reading", (idle, total - 10_000_000, t))
+        result = _collect_cpu_usage()
+        assert result["used_pct"] is not None and result["used_pct"] >= 95.0
+        assert result["status"] == "error"


### PR DESCRIPTION
## Thread 2 — honest health surface (PSI/CPU) + per-CC-slot RSS

Makes the dashboard container-health badge tell the truth, and adds per-session
memory visibility with a leak alert. Two clean commits on one branch (they touch
overlapping files).

### Background
Investigation found the container has **no memory problem** — memory PSI = 0,
anon ~40%, ~21 GB OOM headroom; the climbing `memory.high` counter is benign
page-cache reclaim. So this is a small, additive honesty/visibility improvement,
**not** a fix, and it adds **no** auto-degrade behavior (per the no-auto-throttle
design principle).

### Commit 1 — health-surface honesty (`6a262f75`)
- `_collect_cpu_usage()` derives status from the existing `used_pct` (healthy
  <80 / degraded 80–95 / error >95) instead of hardcoding `"healthy"`. Not
  loadavg (loadavg counts I/O wait and misrepresents CPU).
- New `_read_psi()` reads `/sys/fs/cgroup/{cpu,memory}.pressure`; PSI surfaced on
  both blocks. `memory_status()` = worse of anon% (85/95) and sustained memory
  PSI (`full_avg60` >10% → degraded / >30% → down) — benign reclaim (PSI 0) never
  alarms.
- Dashboard `containerSemantic()`: CPU added as a 3rd worst-of dimension; memory
  reason reports PSI when it's the driver. `resources.py`: PSI surfaced; memory
  status `critical` → `down` (canonical vocabulary; the value was unconsumed).

### Commit 2 — per-CC-slot RSS + leak alert (`0711dd68`)
- New stdlib leaf `observability/cc_slots.py`: `enumerate_cc_slots()` walks
  `/proc` for `claude` processes tagged `GENESIS_SLOT` and reads VmRSS. Same-uid
  `/proc` reads (work despite `ptrace_scope=1`, which gates ATTACH not READ).
- Infra snapshot + `/api/genesis/resources` + the dashboard Container card show
  per-slot RSS.
- `awareness/loop.py::_check_cc_slot_memory` — WARN 4 GB / CRIT 6 GB on the main
  `claude` RSS (normal ~0.7–1 GB). Mirrors `_check_wal_health`; creates a
  `type=infrastructure_alert` observation that rides the existing
  critical-observations job → Telegram (CRIT) / morning report (WARN). Runs
  outside the DB block; per-slot 1 h cooldown with a key-existence check.

### Reviews
- genesis-architect (design): SHIP-WITH-CHANGES — placement outside the
  `db_available` block, key-existence cooldown, optional `slots=` seam,
  log-not-suppress — all folded in.
- code-reviewer (implementation, per commit): both P2s fixed (`critical`
  vocabulary; numeric slot sort).

### Verification
- Badge green live at 45% CPU / anon 41% / PSI 0 (honest — no cry-wolf).
- 5 live slots enumerated; a synthetic CRIT alert is selected by the exact
  `get_unsurfaced(critical)` query → Telegram (temp DB, no real alert fired).
- 417 observability + awareness tests green + 28 new; ruff clean; changed
  modules import clean.

### Deploy
Server-side — takes effect on the next `genesis-server` restart. Dashboard
template change: hard-refresh / `?cb=` to bust the browser cache.
