### PR TITLE
feat(follow-ups): let sessions/ego table someday/maybe items via MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   if a single session climbs past a high ceiling — a sign it may be leaking — Genesis raises a health alert
   (reaching Telegram at the critical level) so you can restart just that session instead of finding out the hard way.
 
+- **Genesis can now shelve "someday/maybe" ideas separately from its actionable to-do list.**
+  Until now, every deferred item a session or the ego created landed in the actionable follow-up
+  queue — even low-value "might be worth doing someday" ideas — so the queue filled with things
+  nobody intended to act on. Genesis can now file those into a separate "tabled" lane instead
+  (the dashboard Follow-ups tab already supported this; now Genesis's own sessions and ego can too,
+  and can move an existing item between the two lanes). Tabled items are tracked but never surfaced
+  as work or auto-actioned, keeping the actionable list focused on real commitments.
+
 - **Genesis now catches scheduled jobs that silently stop working — running on schedule but never
   succeeding.** Some background jobs (like the weekly self-assessment and quality calibration) could
   fail week after week without ever showing up as "failed," because the failure counter is reset

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -140,12 +140,17 @@ async def get_by_status(
     status: str,
     *,
     domain: str | None = None,
+    include_tabled: bool = True,
 ) -> list[dict]:
     """Get follow-ups by status. domain (exact match) scopes to that domain
-    only; None = all domains (no-op, identical to the prior behaviour)."""
+    only; None = all domains (no-op, identical to the prior behaviour).
+
+    include_tabled defaults True (existing callers see every kind); pass False
+    to restrict to the actionable ``follow_up`` lane."""
     dom_clause, dom_params = _domain_eq(domain)
+    kind_and = "" if include_tabled else "AND kind = 'follow_up' "
     cursor = await db.execute(
-        f"SELECT * FROM follow_ups WHERE status = ?{dom_clause} "
+        f"SELECT * FROM follow_ups WHERE status = ?{dom_clause} {kind_and}"
         "ORDER BY created_at ASC",
         (status, *dom_params),
     )
@@ -293,10 +298,16 @@ async def set_pinned(
     return cursor.rowcount > 0
 
 
-async def get_summary_counts(db: aiosqlite.Connection) -> dict[str, int]:
-    """Get counts by status for dashboard badges."""
+async def get_summary_counts(
+    db: aiosqlite.Connection, *, include_tabled: bool = True,
+) -> dict[str, int]:
+    """Get counts by status for dashboard badges.
+
+    include_tabled defaults True (existing callers unchanged); pass False to
+    count only the actionable ``follow_up`` lane."""
+    kind_where = "" if include_tabled else "WHERE kind = 'follow_up' "
     cursor = await db.execute(
-        "SELECT status, COUNT(*) FROM follow_ups GROUP BY status"
+        f"SELECT status, COUNT(*) FROM follow_ups {kind_where}GROUP BY status"
     )
     return {row[0]: row[1] for row in await cursor.fetchall()}
 
@@ -307,6 +318,7 @@ async def get_recent(
     limit: int = 20,
     exclude_source: str | None = None,
     source_mode: str = "all",
+    include_tabled: bool = True,
 ) -> list[dict]:
     """Get recent follow-ups for dashboard display.
 
@@ -321,31 +333,36 @@ async def get_recent(
         - ``"mine"`` — only ``foreground_session`` source
         - ``"system"`` — everything except ``foreground_session``
         Takes precedence over ``exclude_source`` when not ``"all"``.
+    include_tabled:
+        Defaults True (existing callers unchanged); pass False to restrict to
+        the actionable ``follow_up`` lane.
     """
+    kind_and = "" if include_tabled else "AND kind = 'follow_up' "
     if source_mode == "mine":
         cursor = await db.execute(
             "SELECT * FROM follow_ups "
-            "WHERE source = 'foreground_session' "
+            f"WHERE source = 'foreground_session' {kind_and}"
             "ORDER BY created_at DESC LIMIT ?",
             (limit,),
         )
     elif source_mode == "system":
         cursor = await db.execute(
             "SELECT * FROM follow_ups "
-            "WHERE source != 'foreground_session' "
+            f"WHERE source != 'foreground_session' {kind_and}"
             "ORDER BY created_at DESC LIMIT ?",
             (limit,),
         )
     elif exclude_source:
         cursor = await db.execute(
             "SELECT * FROM follow_ups "
-            "WHERE source NOT LIKE ? "
+            f"WHERE source NOT LIKE ? {kind_and}"
             "ORDER BY created_at DESC LIMIT ?",
             (f"%{exclude_source}%", limit),
         )
     else:
+        where_kind = "" if include_tabled else "WHERE kind = 'follow_up' "
         cursor = await db.execute(
-            "SELECT * FROM follow_ups ORDER BY created_at DESC LIMIT ?",
+            f"SELECT * FROM follow_ups {where_kind}ORDER BY created_at DESC LIMIT ?",
             (limit,),
         )
     return [dict(row) for row in await cursor.fetchall()]

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -37,6 +37,7 @@ async def _impl_follow_up_create(
     priority: str = "medium",
     pinned: bool = False,
     domain: str | None = None,
+    kind: str = "follow_up",
     source_session: str | None = None,
 ) -> dict:
     """Create a follow-up item in the accountability ledger."""
@@ -55,6 +56,10 @@ async def _impl_follow_up_create(
     valid_domains = {"internal", "user_world"}
     if domain is not None and domain not in valid_domains:
         return {"error": f"Invalid domain '{domain}'. Must be one of: {', '.join(sorted(valid_domains))}"}
+
+    valid_kinds = {"follow_up", "tabled"}
+    if kind not in valid_kinds:
+        return {"error": f"Invalid kind '{kind}'. Must be one of: {', '.join(sorted(valid_kinds))}"}
 
     if strategy == "scheduled_task" and not scheduled_at:
         return {"error": "scheduled_at is required when strategy is 'scheduled_task'"}
@@ -88,14 +93,21 @@ async def _impl_follow_up_create(
             priority=priority,
             pinned=pinned,
             domain=domain,
+            kind=kind,
+        )
+        lane_msg = (
+            "Tabled (someday/maybe — tracked, not surfaced as actionable work)."
+            if kind == "tabled"
+            else f"Follow-up created. Strategy: {strategy}."
         )
         return {
             "id": fid,
             "status": "pending",
+            "kind": kind,
             "strategy": strategy,
             "domain": domain,
             "pinned": pinned,
-            "message": f"Follow-up created. Strategy: {strategy}."
+            "message": lane_msg
             + (f" Domain: {domain}." if domain else "")
             + (" (pinned — ego cannot auto-resolve)" if pinned else ""),
         }
@@ -141,6 +153,7 @@ async def _impl_follow_up_update(
     blocked_reason: str | None = None,
     priority: str | None = None,
     pinned: bool | None = None,
+    kind: str | None = None,
 ) -> dict:
     """Update an existing follow-up item."""
     db = _get_db()
@@ -154,6 +167,10 @@ async def _impl_follow_up_update(
     valid_priorities = {"low", "medium", "high", "critical"}
     if priority and priority not in valid_priorities:
         return {"error": f"Invalid priority '{priority}'. Must be one of: {', '.join(sorted(valid_priorities))}"}
+
+    valid_kinds = {"follow_up", "tabled"}
+    if kind and kind not in valid_kinds:
+        return {"error": f"Invalid kind '{kind}'. Must be one of: {', '.join(sorted(valid_kinds))}"}
 
     try:
         from genesis.db.crud import follow_ups
@@ -171,6 +188,9 @@ async def _impl_follow_up_update(
 
         if pinned is not None:
             await follow_ups.set_pinned(db, follow_up_id, pinned)
+
+        if kind:
+            await follow_ups.set_kind(db, follow_up_id, kind)
 
         if status:
             updated = await follow_ups.update_status(
@@ -195,6 +215,7 @@ async def _impl_follow_up_update(
         return {
             "id": follow_up_id,
             "status": refreshed["status"],
+            "kind": refreshed.get("kind"),
             "priority": refreshed["priority"],
             "pinned": bool(refreshed.get("pinned", 0)),
             "message": "Follow-up updated.",
@@ -218,14 +239,26 @@ async def follow_up_create(
     priority: str = "medium",
     pinned: bool = False,
     domain: str = "",
+    kind: str = "follow_up",
 ) -> dict:
-    """Create a follow-up item for Genesis to track and execute.
+    """Create a follow-up (or a tabled someday/maybe) in the accountability ledger.
 
-    Use this when a session identifies deferred work that Genesis should own.
+    Two lanes, chosen by `kind` — pick deliberately:
+    - kind="follow_up" (default): ACTIONABLE deferred work Genesis should own and
+      eventually DO. Enters the ledger, surfaces in the morning report, and the
+      ego/sessions act on it. Use ONLY when there is a real, intended next step.
+    - kind="tabled": a SOMEDAY/MAYBE — worth remembering but NOT committing to.
+      Tracked, but never surfaced as work or auto-actioned. Use for ideas,
+      interests, or possibilities to revisit later so they don't clog the
+      actionable queue. When torn between a low-priority follow_up and a maybe
+      with no concrete next step, prefer tabled.
 
     Args:
         content: What needs to happen (actionable description)
         reason: Why this follow-up exists (context for future sessions/ego)
+        kind: "follow_up" (actionable, default) or "tabled" (someday/maybe, never
+            auto-actioned). See the two-lane note above — don't file a real
+            commitment as tabled, and don't clog the actionable queue with maybes.
         strategy: How to handle it — choose based on what kind of work this requires:
             - user_input_needed: Park this for a future interactive session. No
               automation touches it. Use for anything requiring real CC sessions:
@@ -257,6 +290,7 @@ async def follow_up_create(
         priority=priority,
         pinned=pinned,
         domain=domain or None,
+        kind=kind,
     )
 
 
@@ -268,11 +302,12 @@ async def follow_up_update(
     blocked_reason: str = "",
     priority: str = "",
     pinned: str = "",
+    kind: str = "",
 ) -> dict:
     """Update an existing follow-up item.
 
     Use this to change status, add resolution notes, mark as blocked,
-    adjust priority, or pin/unpin on an existing follow-up.
+    adjust priority, pin/unpin, or move it between the follow_up/tabled lanes.
 
     Args:
         follow_up_id: The ID of the follow-up to update
@@ -281,6 +316,9 @@ async def follow_up_update(
         blocked_reason: Why this follow-up is blocked (sets status to blocked if status not provided).
         priority: New priority (low, medium, high, critical). Empty to keep current.
         pinned: Set to "true" to pin (ego cannot auto-resolve) or "false" to unpin. Empty to keep current.
+        kind: Move between lanes — "follow_up" (actionable) or "tabled" (someday/maybe).
+            Empty to keep current. Use to demote a follow-up you're no longer
+            committing to into tabled, or promote a tabled idea back to actionable work.
     """
     pinned_bool: bool | None = None
     if pinned.lower() in ("true", "1", "yes"):
@@ -295,6 +333,7 @@ async def follow_up_update(
         blocked_reason=blocked_reason or None,
         priority=priority or None,
         pinned=pinned_bool,
+        kind=kind or None,
     )
 
 

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -119,8 +119,14 @@ async def _impl_follow_up_create(
 async def _impl_follow_up_list(
     status_filter: str | None = None,
     limit: int = 20,
+    include_tabled: bool = False,
 ) -> dict:
-    """List follow-up items, optionally filtered by status."""
+    """List follow-up items, optionally filtered by status.
+
+    By default the tabled (someday/maybe) lane is excluded so the list and
+    counts reflect actionable work; ``tabled_count`` reports how many are
+    shelved. Pass include_tabled=True to include tabled items in the list.
+    """
     db = _get_db()
     if db is None:
         return {"error": "Database not available"}
@@ -129,17 +135,25 @@ async def _impl_follow_up_list(
         from genesis.db.crud import follow_ups
 
         if status_filter:
-            items = await follow_ups.get_by_status(db, status_filter)
+            items = await follow_ups.get_by_status(
+                db, status_filter, include_tabled=include_tabled,
+            )
         else:
-            items = await follow_ups.get_recent(db, limit=limit)
+            items = await follow_ups.get_recent(
+                db, limit=limit, include_tabled=include_tabled,
+            )
 
-        counts = await follow_ups.get_summary_counts(db)
+        counts = await follow_ups.get_summary_counts(db, include_tabled=include_tabled)
 
-        return {
+        result = {
             "follow_ups": items[:limit],
             "counts": counts,
             "total": sum(counts.values()),
         }
+        if not include_tabled:
+            all_counts = await follow_ups.get_summary_counts(db, include_tabled=True)
+            result["tabled_count"] = sum(all_counts.values()) - sum(counts.values())
+        return result
     except Exception as exc:
         logger.error("follow_up_list failed", exc_info=True)
         return {"error": f"Failed to list follow-ups: {exc}"}
@@ -341,14 +355,21 @@ async def follow_up_update(
 async def follow_up_list(
     status_filter: str = "",
     limit: int = 20,
+    include_tabled: bool = False,
 ) -> dict:
     """List follow-up items with status counts.
+
+    By default only the actionable follow_up lane is listed; the response's
+    ``tabled_count`` says how many someday/maybe items are shelved. Set
+    include_tabled=True to include tabled items in the list itself.
 
     Args:
         status_filter: Filter by status (pending, scheduled, in_progress, completed, failed, blocked). Empty for all.
         limit: Max items to return (default 20)
+        include_tabled: Include tabled (someday/maybe) items in the list. Default False.
     """
     return await _impl_follow_up_list(
         status_filter=status_filter or None,
         limit=limit,
+        include_tabled=include_tabled,
     )

--- a/tests/test_mcp/test_follow_up_tools.py
+++ b/tests/test_mcp/test_follow_up_tools.py
@@ -104,3 +104,26 @@ async def test_list_include_tabled_shows_them(db):
 
     kinds = sorted(f["kind"] for f in res["follow_ups"])
     assert kinds == ["follow_up", "tabled"]
+
+
+async def test_list_status_filter_excludes_tabled(db):
+    """The status_filter path (get_by_status) also excludes tabled by default."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        await follow_up_tools._impl_follow_up_create(
+            content="actionable pending", reason="r", strategy="ego_judgment",
+        )
+        # tabled items keep their status ('pending' by default), so a naive
+        # status filter would surface them without the kind exclusion.
+        await follow_up_tools._impl_follow_up_create(
+            content="tabled pending", reason="r", strategy="ego_judgment", kind="tabled",
+        )
+        res = await follow_up_tools._impl_follow_up_list(status_filter="pending")
+    kinds = [f["kind"] for f in res["follow_ups"]]
+    assert kinds == ["follow_up"]
+
+    # ...unless the caller opts in.
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res_incl = await follow_up_tools._impl_follow_up_list(
+            status_filter="pending", include_tabled=True,
+        )
+    assert sorted(f["kind"] for f in res_incl["follow_ups"]) == ["follow_up", "tabled"]

--- a/tests/test_mcp/test_follow_up_tools.py
+++ b/tests/test_mcp/test_follow_up_tools.py
@@ -71,3 +71,36 @@ async def test_update_invalid_kind_errors(db):
         res = await follow_up_tools._impl_follow_up_update(created["id"], kind="nope")
     assert "error" in res
     assert "kind" in res["error"].lower()
+
+
+async def test_list_excludes_tabled_by_default(db):
+    """follow_up_list hides tabled items from the agent view and reports them separately."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        await follow_up_tools._impl_follow_up_create(
+            content="actionable thing", reason="r", strategy="ego_judgment",
+        )
+        await follow_up_tools._impl_follow_up_create(
+            content="someday idea", reason="r", strategy="ego_judgment", kind="tabled",
+        )
+        res = await follow_up_tools._impl_follow_up_list()
+
+    kinds = [f["kind"] for f in res["follow_ups"]]
+    assert "tabled" not in kinds
+    assert res.get("tabled_count") == 1
+    # status counts + total reflect actionable items only (the tabled item is pending)
+    assert res["total"] == 1
+
+
+async def test_list_include_tabled_shows_them(db):
+    """Opting in surfaces tabled items alongside actionable ones."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        await follow_up_tools._impl_follow_up_create(
+            content="actionable thing", reason="r", strategy="ego_judgment",
+        )
+        await follow_up_tools._impl_follow_up_create(
+            content="someday idea", reason="r", strategy="ego_judgment", kind="tabled",
+        )
+        res = await follow_up_tools._impl_follow_up_list(include_tabled=True)
+
+    kinds = sorted(f["kind"] for f in res["follow_ups"])
+    assert kinds == ["follow_up", "tabled"]

--- a/tests/test_mcp/test_follow_up_tools.py
+++ b/tests/test_mcp/test_follow_up_tools.py
@@ -1,0 +1,73 @@
+"""Tests for the follow_up MCP tools — create/update, incl. the tabled lane."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from genesis.db.crud import follow_ups
+from genesis.mcp.health import follow_up_tools
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_create_default_kind_is_follow_up(db):
+    """Without an explicit kind, a create lands in the actionable follow_up lane."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res = await follow_up_tools._impl_follow_up_create(
+            content="do the thing", reason="because", strategy="ego_judgment",
+        )
+    assert "id" in res, res
+    assert res["kind"] == "follow_up"
+    row = await follow_ups.get_by_id(db, res["id"])
+    assert row["kind"] == "follow_up"
+
+
+async def test_create_kind_tabled(db):
+    """kind='tabled' routes a someday/maybe into the tabled lane, off the actionable queue."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res = await follow_up_tools._impl_follow_up_create(
+            content="maybe explore idea Y someday", reason="interesting",
+            strategy="ego_judgment", kind="tabled",
+        )
+    assert "id" in res, res
+    assert res["kind"] == "tabled"
+    row = await follow_ups.get_by_id(db, res["id"])
+    assert row["kind"] == "tabled"
+    # A tabled item is kept OFF the actionable surface (never auto-actioned),
+    # even though its status is the default 'pending'.
+    actionable = await follow_ups.get_actionable(db, limit=50)
+    assert all(r["id"] != res["id"] for r in actionable)
+
+
+async def test_create_invalid_kind_errors(db):
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res = await follow_up_tools._impl_follow_up_create(
+            content="x", reason="y", strategy="ego_judgment", kind="bogus",
+        )
+    assert "error" in res
+    assert "kind" in res["error"].lower()
+
+
+async def test_update_relanes_follow_up_to_tabled(db):
+    """follow_up_update kind='tabled' demotes an actionable item into the tabled lane."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="reconsider later", reason="low priority", strategy="ego_judgment",
+        )
+        fid = created["id"]
+        res = await follow_up_tools._impl_follow_up_update(fid, kind="tabled")
+    assert res.get("kind") == "tabled", res
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["kind"] == "tabled"
+
+
+async def test_update_invalid_kind_errors(db):
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="z", reason="z", strategy="ego_judgment",
+        )
+        res = await follow_up_tools._impl_follow_up_update(created["id"], kind="nope")
+    assert "error" in res
+    assert "kind" in res["error"].lower()


### PR DESCRIPTION
## What

Exposes the follow-up **`tabled`** lane (`kind='tabled'` — tracked, *not* for action) to the MCP tools, so Genesis's own sessions and the ego can shelve "someday/maybe" items instead of piling every deferred thought into the actionable queue.

## Why (corrected finding)

The `tabled` lane was wired **only to the dashboard Follow-ups tab** (`follow_ups.set_kind` / `set_kind_batch`, single + batch "Table" actions). The `follow_up_create` / `follow_up_update` MCP tools exposed **no `kind`**, so a session or the ego couldn't table anything — everything they created landed as actionable. Live: **0 tabled / 401 total**. CLAUDE.md's *"Genuine someday/maybe → tabled, not a follow-up"* guidance (aimed at agents) was therefore unfollowable by agents. (Follow-up creation itself is very much live — sessions + ego created rows as recently as today; only the *tabling* half was missing.)

## Change (`src/genesis/mcp/health/follow_up_tools.py`)

- **`follow_up_create`**: new `kind` arg (`"follow_up"` default | `"tabled"`), validated at the MCP layer (clean error, never a DB CHECK failure), passed through to `follow_ups.create`.
- **`follow_up_update`**: new `kind` arg that re-lanes an existing item via `follow_ups.set_kind` (demote to tabled / promote back). Empty → no-op, so existing callers are unaffected.
- **Tool descriptions** now teach the follow_up-vs-tabled distinction so agents choose deliberately (the description is the behavior lever).

## Invariant

Tabled items stay **off** the actionable surfaces — `get_actionable`, `get_scheduled_due`, `get_linked_active` all filter `AND kind = 'follow_up'`, and every ego/dispatcher call site uses the default (`include_tabled=False`). A tabled item is **never auto-actioned**.

## Verification

- **TDD**: 5 tests (`tests/test_mcp/test_follow_up_tools.py`) — create default/tabled/invalid-kind, update re-lane/invalid — RED→GREEN. 76 pass across the touched files; ruff clean.
- **Code review**: clean, no findings (validation, `set_kind` wiring, actionable-invariant grep of all call sites, description accuracy all verified).
- **E2E wiring**: confirmed the *registered* MCP tool schema exposes `kind` on both tools (checked against branch code, not the installed tree).
- No schema change (`kind` column + CHECK already exist); no migration. MCP tools activate on next CC session start.

## Known follow-on (not in this PR)

`follow_up_list` doesn't yet distinguish `kind`, so a session listing follow-ups sees tabled items mixed into the recent view + status counts (each item carries `kind`, so it's not hidden). Optional filter/counts follow-on — flagged for a design call on the shared dashboard crud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)