### PR TITLE
fix(memory): filter invalid + deprecated memories in the proactive recall hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Superseded memories no longer resurface in Genesis's automatic recall.** Before every prompt,
+  Genesis injects the most relevant memories into its working context. That fast-path recall wasn't
+  honoring a memory's expiry date — so a fact that had been explicitly replaced (an outdated network
+  note, stale career details, a deprecated index) could still surface, even though the main memory
+  system already filtered it out. The fast path now applies the same validity check across all of its
+  sources, matching the main retriever. Memories with no expiry (valid indefinitely) are never
+  affected, so nothing live is ever dropped.
+
 - **Completed background-task history no longer grows without bound.** Genesis's idle-time "surplus"
   task queue kept every finished task row forever — only never-started tasks were ever cleaned up — so
   the table crept upward over months of background work. Finished tasks (completed, failed, or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,13 +78,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
-- **Superseded memories no longer resurface in Genesis's automatic recall.** Before every prompt,
-  Genesis injects the most relevant memories into its working context. That fast-path recall wasn't
-  honoring a memory's expiry date — so a fact that had been explicitly replaced (an outdated network
-  note, stale career details, a deprecated index) could still surface, even though the main memory
-  system already filtered it out. The fast path now applies the same validity check across all of its
-  sources, matching the main retriever. Memories with no expiry (valid indefinitely) are never
-  affected, so nothing live is ever dropped.
+- **Superseded and expired memories no longer resurface in Genesis's automatic recall.** Before every
+  prompt, Genesis injects the most relevant memories into its working context. That fast-path recall
+  wasn't checking whether a memory had expired or been superseded (replaced by a newer, consolidated
+  version) — so an outdated network note, stale career details, an old build-progress snapshot, or a
+  duplicate the memory system had already merged away could still surface, even though the main memory
+  system filtered all of those out. The fast path now applies the same validity checks across all of
+  its sources, matching the main retriever. Memories that are current (no expiry, not superseded) are
+  never affected, so nothing live is ever dropped.
 
 - **Completed background-task history no longer grows without bound.** Genesis's idle-time "surplus"
   task queue kept every finished task row forever — only never-started tasks were ever cleaned up — so

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -406,10 +406,12 @@ def _search_fts5(
     LEFT JOIN with memory_metadata. NULL source_subsystem (user-sourced
     + legacy pre-1.5b rows) is preserved.
 
-    Also drops bitemporally-invalid rows (``invalid_at`` in the past), for
-    parity with the main retrieval path (``memory.crud.search_ranked``).
-    NULL ``invalid_at`` = "valid forever" and is always preserved, so the
-    filter can never over-drop live context.
+    Also drops bitemporally-invalid rows (``invalid_at`` in the past) and
+    superseded/deprecated rows (``deprecated = 1``), for parity with the main
+    retrieval path (``memory.crud.search_ranked``) and the hook's own Qdrant
+    path. NULL ``invalid_at`` = "valid forever" and NULL/0 ``deprecated`` =
+    "not deprecated" are always preserved, so the filter can never over-drop
+    live context.
 
     ``collection``: if provided, restrict to this collection
     (e.g. ``"episodic_memory"``). Default ``None`` searches all.
@@ -448,6 +450,8 @@ def _search_fts5(
                            NOT IN ({placeholders}))
                   AND (memory_metadata.invalid_at IS NULL
                        OR memory_metadata.invalid_at > ?)
+                  AND (memory_metadata.deprecated IS NULL
+                       OR memory_metadata.deprecated = 0)
                 ORDER BY rank
                 LIMIT ?
                 """,  # noqa: S608 -- placeholders bound separately

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -398,6 +398,7 @@ def _search_fts5(
     db_path: Path,
     keywords: list[str],
     collection: str | None = None,
+    now_iso: str | None = None,
 ) -> list[dict]:
     """Search memory_fts using FTS5 with OR-joined keywords.
 
@@ -405,11 +406,19 @@ def _search_fts5(
     LEFT JOIN with memory_metadata. NULL source_subsystem (user-sourced
     + legacy pre-1.5b rows) is preserved.
 
+    Also drops bitemporally-invalid rows (``invalid_at`` in the past), for
+    parity with the main retrieval path (``memory.crud.search_ranked``).
+    NULL ``invalid_at`` = "valid forever" and is always preserved, so the
+    filter can never over-drop live context.
+
     ``collection``: if provided, restrict to this collection
     (e.g. ``"episodic_memory"``). Default ``None`` searches all.
+    ``now_iso``: as-of instant for the invalid_at check; defaults to now.
     """
     if not keywords:
         return []
+    if now_iso is None:
+        now_iso = datetime.now(UTC).isoformat()
 
     fts_query = " OR ".join('"' + _escape_fts5(k) + '"' for k in keywords)
     placeholders = ",".join("?" * len(_PROACTIVE_EXCLUDED_SUBSYSTEMS))
@@ -437,11 +446,14 @@ def _search_fts5(
                   AND (memory_metadata.source_subsystem IS NULL
                        OR memory_metadata.source_subsystem
                            NOT IN ({placeholders}))
+                  AND (memory_metadata.invalid_at IS NULL
+                       OR memory_metadata.invalid_at > ?)
                 ORDER BY rank
                 LIMIT ?
                 """,  # noqa: S608 -- placeholders bound separately
                 (fts_query, *collection_params,
                  *_PROACTIVE_EXCLUDED_SUBSYSTEMS,
+                 now_iso,
                  _MAX_RESULTS * 2),
             )
             rows = [dict(row) for row in cursor.fetchall()]
@@ -457,6 +469,45 @@ def _search_fts5(
     except Exception as exc:
         print(f"FTS5 search error: {exc}", file=sys.stderr)
         return []
+
+
+def _expired_memory_ids(
+    db_path: Path,
+    ids: set[str],
+    now_iso: str | None = None,
+) -> set[str]:
+    """Return the subset of ``ids`` whose ``invalid_at`` is in the past.
+
+    Post-query bitemporal filter for the Qdrant union: vector + wing hits
+    enter the fused set without seeing ``memory_metadata.invalid_at`` (the
+    Qdrant payload doesn't carry it). Mirrors
+    ``memory.retrieval._expired_candidate_ids``.
+
+    NULL ``invalid_at`` = "valid forever" and is never returned. Ids with no
+    ``memory_metadata`` row (e.g. knowledge_base points) simply don't match,
+    so they're safely ignored. On any DB error this returns an empty set —
+    the safe direction: never drop context we can't positively prove expired.
+    """
+    if not ids:
+        return set()
+    if now_iso is None:
+        now_iso = datetime.now(UTC).isoformat()
+    placeholders = ",".join("?" * len(ids))
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=2)
+        try:
+            cursor = conn.execute(
+                f"SELECT memory_id FROM memory_metadata "  # noqa: S608 -- bound below
+                f"WHERE memory_id IN ({placeholders}) "
+                f"AND invalid_at IS NOT NULL AND invalid_at <= ?",
+                (*ids, now_iso),
+            )
+            return {row[0] for row in cursor.fetchall()}
+        finally:
+            conn.close()
+    except Exception as exc:
+        print(f"invalid_at filter error: {exc}", file=sys.stderr)
+        return set()
 
 
 _PROCEDURE_SURFACE_THRESHOLD = 0.7  # Cosine cutoff for PROVEN tiers (CORE/ADVISORY/LIBRARY).
@@ -1225,8 +1276,14 @@ async def _run(prompt: str, session_id: str = "") -> None:
     except Exception:
         pass  # Taxonomy module failure must not block hook
 
+    # As-of instant for bitemporal invalid_at filtering across FTS + Qdrant
+    # (parity with retrieval.py). Computed once so every path agrees.
+    now_iso = datetime.now(UTC).isoformat()
+
     # FTS5 search (synchronous, fast) — episodic only; KB comes via Qdrant
-    fts_results = _search_fts5(_DB_PATH, keywords, collection="episodic_memory")
+    fts_results = _search_fts5(
+        _DB_PATH, keywords, collection="episodic_memory", now_iso=now_iso,
+    )
 
     # Code index search (synchronous, fast) — structural code matches
     code_results = _search_code_index(_DB_PATH, keywords)
@@ -1264,6 +1321,16 @@ async def _run(prompt: str, session_id: str = "") -> None:
                 _search_qdrant(vector, collection="knowledge_base",
                                extra_filter=_knowledge_filter),
             )
+
+    # Bitemporal parity: drop memories past their invalid_at from the Qdrant
+    # union (episodic vector + wing). knowledge_base ids aren't episodic
+    # memory_metadata rows, so knowledge_results is intentionally not filtered.
+    _episodic_ids = {r["memory_id"] for r in vector_results}
+    _episodic_ids |= {r["memory_id"] for r in wing_results}
+    _expired = _expired_memory_ids(_DB_PATH, _episodic_ids, now_iso)
+    if _expired:
+        vector_results = [r for r in vector_results if r["memory_id"] not in _expired]
+        wing_results = [r for r in wing_results if r["memory_id"] not in _expired]
 
     fts_only_fallback = len(vector_results) == 0 and len(fts_results) > 0
 

--- a/tests/test_hooks/test_proactive_invalid_at.py
+++ b/tests/test_hooks/test_proactive_invalid_at.py
@@ -1,0 +1,205 @@
+"""The proactive memory hook must filter bitemporally-invalid memories.
+
+Parity with the main retrieval path (``memory/retrieval.py``): a memory whose
+``invalid_at`` is in the past has been superseded and must NOT be injected into
+the CC prompt context. The main path filters this two ways — in-SQL for the FTS
+query (``search_ranked``) and a post-query id filter for the Qdrant/calendar
+union (``_expired_candidate_ids``). The hook is a standalone reimplementation
+that historically filtered neither; these tests lock in both halves.
+
+NULL ``invalid_at`` = "valid forever" — never dropped. This is the safety
+property: a memory can only be excluded if it carries a concrete past
+timestamp, so the filter can never over-drop valid context.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+# Hook lives outside the package tree — add scripts/ to import path.
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import proactive_memory_hook as hook  # noqa: E402
+
+# A safely-past and safely-future ISO timestamp in the canonical T-sep+offset
+# format the modern writer emits (matches datetime.now(UTC).isoformat()).
+_PAST = "2020-01-01T00:00:00+00:00"
+_FUTURE = "2099-01-01T00:00:00+00:00"
+
+
+def _build_db(path: str) -> None:
+    """Create a temp DB mirroring the live memory_fts + memory_metadata shape.
+
+    Three episodic rows, all containing the FTS token ``row``:
+      - ``alive``   : NULL invalid_at   → valid forever
+      - ``future``  : invalid_at 2099   → still valid
+      - ``expired`` : invalid_at 2020   → past → must be dropped
+    """
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE memory_metadata (
+                memory_id        TEXT PRIMARY KEY,
+                created_at       TEXT NOT NULL,
+                collection       TEXT NOT NULL DEFAULT 'episodic_memory',
+                confidence       REAL,
+                embedding_status TEXT NOT NULL DEFAULT 'embedded',
+                memory_class     TEXT DEFAULT 'fact',
+                wing             TEXT,
+                room             TEXT,
+                valid_at         TEXT,
+                invalid_at       TEXT,
+                source_subsystem TEXT,
+                deprecated       INTEGER NOT NULL DEFAULT 0,
+                dream_cycle_run_id TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE VIRTUAL TABLE memory_fts USING fts5(
+                memory_id, content, source_type, tags, collection
+            )
+            """
+        )
+        rows = [
+            ("alive", None, "this row never expires"),
+            ("future", _FUTURE, "this row is valid until 2099"),
+            ("expired", _PAST, "this row expired long ago"),
+        ]
+        for mid, inv, content in rows:
+            conn.execute(
+                "INSERT INTO memory_metadata "
+                "(memory_id, created_at, invalid_at) VALUES (?, ?, ?)",
+                (mid, _PAST, inv),
+            )
+            conn.execute(
+                "INSERT INTO memory_fts "
+                "(memory_id, content, source_type, tags, collection) "
+                "VALUES (?, ?, 'memory', '', 'episodic_memory')",
+                (mid, content),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ── _search_fts5: in-SQL invalid_at filter (parity with search_ranked) ───────
+
+
+def test_search_fts5_drops_expired_by_default(tmp_path) -> None:
+    """Default now_iso drops the past-invalid row, keeps NULL + future."""
+    db = tmp_path / "t.db"
+    _build_db(str(db))
+    rows = hook._search_fts5(db, ["row"], collection="episodic_memory")
+    ids = {r["memory_id"] for r in rows}
+    assert ids == {"alive", "future"}
+    assert "expired" not in ids
+
+
+def test_search_fts5_null_invalid_at_always_kept(tmp_path) -> None:
+    """The NULL-safety property: a NULL invalid_at is never filtered."""
+    db = tmp_path / "t.db"
+    _build_db(str(db))
+    rows = hook._search_fts5(db, ["row"], collection="episodic_memory")
+    assert "alive" in {r["memory_id"] for r in rows}
+
+
+def test_search_fts5_explicit_past_as_of_keeps_expired(tmp_path) -> None:
+    """An explicit historical now_iso returns rows valid at that point.
+
+    Proves the parameter threads correctly (no silent hard-coded now).
+    """
+    db = tmp_path / "t.db"
+    _build_db(str(db))
+    rows = hook._search_fts5(
+        db, ["row"], collection="episodic_memory",
+        now_iso="2019-01-01T00:00:00+00:00",
+    )
+    ids = {r["memory_id"] for r in rows}
+    # At 2019, 'expired' (invalid 2020) was still valid.
+    assert ids == {"alive", "future", "expired"}
+
+
+def test_search_fts5_invalid_at_combines_with_subsystem(tmp_path) -> None:
+    """invalid_at + source_subsystem both apply on the same LEFT JOIN."""
+    db = tmp_path / "t.db"
+    _build_db(str(db))
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute(
+            "UPDATE memory_metadata SET source_subsystem='reflection' "
+            "WHERE memory_id='future'"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    rows = hook._search_fts5(db, ["row"], collection="episodic_memory")
+    ids = {r["memory_id"] for r in rows}
+    # alive: NULL/NULL → kept; future: reflection → excluded;
+    # expired: past invalid_at → excluded.
+    assert ids == {"alive"}
+
+
+# ── _expired_memory_ids: post-query filter for the Qdrant union ──────────────
+
+
+def test_expired_memory_ids_returns_only_past(tmp_path) -> None:
+    db = tmp_path / "t.db"
+    _build_db(str(db))
+    got = hook._expired_memory_ids(
+        db, {"alive", "future", "expired"},
+        now_iso=datetime.now(UTC).isoformat(),
+    )
+    assert got == {"expired"}
+
+
+def test_expired_memory_ids_empty_input(tmp_path) -> None:
+    db = tmp_path / "t.db"
+    _build_db(str(db))
+    assert hook._expired_memory_ids(db, set(), now_iso=_FUTURE) == set()
+
+
+def test_expired_memory_ids_ignores_unknown_ids(tmp_path) -> None:
+    """Ids absent from memory_metadata (e.g. knowledge_base points) never match."""
+    db = tmp_path / "t.db"
+    _build_db(str(db))
+    got = hook._expired_memory_ids(
+        db, {"nonexistent-kb-id", "alive"},
+        now_iso=datetime.now(UTC).isoformat(),
+    )
+    assert got == set()
+
+
+def test_expired_memory_ids_default_now(tmp_path) -> None:
+    """Default now_iso (None) drops the past-invalid row."""
+    db = tmp_path / "t.db"
+    _build_db(str(db))
+    got = hook._expired_memory_ids(db, {"alive", "future", "expired"})
+    assert got == {"expired"}
+
+
+def test_expired_memory_ids_boundary_future_kept(tmp_path) -> None:
+    """A row invalidated one hour from now is not yet expired."""
+    db = tmp_path / "t.db"
+    _build_db(str(db))
+    conn = sqlite3.connect(str(db))
+    try:
+        soon = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+        conn.execute(
+            "UPDATE memory_metadata SET invalid_at=? WHERE memory_id='alive'",
+            (soon,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    got = hook._expired_memory_ids(
+        db, {"alive", "expired"}, now_iso=datetime.now(UTC).isoformat(),
+    )
+    assert got == {"expired"}
+    assert "alive" not in got

--- a/tests/test_hooks/test_proactive_invalid_at.py
+++ b/tests/test_hooks/test_proactive_invalid_at.py
@@ -1,11 +1,12 @@
-"""The proactive memory hook must filter bitemporally-invalid memories.
+"""The proactive memory hook must filter invalid + deprecated memories.
 
-Parity with the main retrieval path (``memory/retrieval.py``): a memory whose
-``invalid_at`` is in the past has been superseded and must NOT be injected into
-the CC prompt context. The main path filters this two ways — in-SQL for the FTS
-query (``search_ranked``) and a post-query id filter for the Qdrant/calendar
-union (``_expired_candidate_ids``). The hook is a standalone reimplementation
-that historically filtered neither; these tests lock in both halves.
+Parity with the main retrieval path (``memory/retrieval.py`` / ``search_ranked``)
+and the hook's own Qdrant path: a memory whose ``invalid_at`` is in the past, or
+which has been superseded (``deprecated = 1``), must NOT be injected into the CC
+prompt context. The main path filters both; the hook's FTS path historically
+filtered neither. These tests lock in the in-SQL FTS filters plus the post-query
+``_expired_memory_ids`` id filter for the Qdrant union (which mirrors
+``_expired_candidate_ids``; the Qdrant search itself already drops deprecated).
 
 NULL ``invalid_at`` = "valid forever" — never dropped. This is the safety
 property: a memory can only be excluded if it carries a concrete past
@@ -144,6 +145,59 @@ def test_search_fts5_invalid_at_combines_with_subsystem(tmp_path) -> None:
     # alive: NULL/NULL → kept; future: reflection → excluded;
     # expired: past invalid_at → excluded.
     assert ids == {"alive"}
+
+
+# ── _search_fts5: deprecated (superseded) filter, parity with search_ranked ──
+
+
+def _insert_extra(db: str, memory_id: str, content: str, *, deprecated: int) -> None:
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute(
+            "INSERT INTO memory_metadata (memory_id, created_at, deprecated) "
+            "VALUES (?, ?, ?)",
+            (memory_id, _PAST, deprecated),
+        )
+        conn.execute(
+            "INSERT INTO memory_fts "
+            "(memory_id, content, source_type, tags, collection) "
+            "VALUES (?, ?, 'memory', '', 'episodic_memory')",
+            (memory_id, content),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_search_fts5_drops_deprecated(tmp_path) -> None:
+    """A deprecated=1 (superseded) row must not surface; valid rows stay."""
+    db = tmp_path / "t.db"
+    _build_db(str(db))
+    _insert_extra(str(db), "dep", "this row is a superseded duplicate", deprecated=1)
+    rows = hook._search_fts5(db, ["row"], collection="episodic_memory")
+    ids = {r["memory_id"] for r in rows}
+    assert "dep" not in ids
+    assert {"alive", "future"} <= ids  # non-deprecated valid rows untouched
+
+
+def test_search_fts5_keeps_deprecated_zero(tmp_path) -> None:
+    """deprecated=0 (the common case) is explicitly preserved."""
+    db = tmp_path / "t.db"
+    _build_db(str(db))
+    _insert_extra(str(db), "live", "this row is a live current fact", deprecated=0)
+    rows = hook._search_fts5(db, ["row"], collection="episodic_memory")
+    assert "live" in {r["memory_id"] for r in rows}
+
+
+def test_search_fts5_deprecated_and_invalid_at_both_apply(tmp_path) -> None:
+    """The deprecated and invalid_at filters compose on the same JOIN."""
+    db = tmp_path / "t.db"
+    _build_db(str(db))
+    _insert_extra(str(db), "dep", "this row is deprecated but unexpired", deprecated=1)
+    rows = hook._search_fts5(db, ["row"], collection="episodic_memory")
+    ids = {r["memory_id"] for r in rows}
+    # dep: deprecated → out; expired: past invalid_at → out; alive/future stay.
+    assert ids == {"alive", "future"}
 
 
 # ── _expired_memory_ids: post-query filter for the Qdrant union ──────────────


### PR DESCRIPTION
## Problem

The proactive memory hook (`scripts/proactive_memory_hook.py`) injects relevant memories into **every** prompt's context. It searches three ways — FTS5 (`_search_fts5`) + two Qdrant episodic searches (`vector_results`, `wing_results`) — fused by RRF. Its FTS path diverged from the main retrieval path (`memory/retrieval.py` / `db/crud/memory.py::search_ranked`) on **two** validity filters:

| Filter | Meaning | Leaked via FTS (live DB) | Already filtered by |
|---|---|---|---|
| `invalid_at` | bitemporally expired (superseded fact) | 8 memories | `search_ranked` (in-SQL) + `_expired_candidate_ids` (post-query) |
| `deprecated` | superseded/merged by consolidation | **2,596 memories** | `search_ranked` default **and** the hook's own Qdrant `must_not` |

So memories the system had explicitly retired — expired facts, and dream-cycle-consolidated duplicates (old build snapshots, superseded notes) — could still surface on the hottest path. The `deprecated` gap in particular silently undercut memory consolidation at the injection layer.

## Fix

Restore parity, mirroring the main path exactly:

- **`_search_fts5`** gains a `now_iso` param + two in-SQL clauses on the existing `LEFT JOIN memory_metadata`:
  - `AND (invalid_at IS NULL OR invalid_at > ?)`
  - `AND (deprecated IS NULL OR deprecated = 0)`
- **New `_expired_memory_ids(db_path, ids, now_iso)`** helper (mirrors `_expired_candidate_ids`) drops expired ids from the two episodic Qdrant result sets before fusion. `knowledge_base` results are intentionally not filtered (not episodic `memory_metadata` rows). The Qdrant search already excludes `deprecated`, so no change needed there.
- `now_iso` is computed once in `_run` so FTS and Qdrant agree on the as-of instant.

**Safety property:** the filters are NULL-safe — `invalid_at IS NULL` ("valid forever") and `deprecated IS NULL OR = 0` ("not deprecated") are always kept, and the JOIN's orphan-row NULLs are preserved. A memory can only be dropped if it carries a concrete past `invalid_at` or `deprecated=1`, so the filter **cannot over-drop live context**.

## Verification

- **53 tests green** (12 new in `tests/test_hooks/test_proactive_invalid_at.py`, 41 regression incl. the cross-process subsystem-list-sync guard); ruff clean.
- **E2E against a copy of the live DB**, old-vs-new, `_MAX_RESULTS` raised so the LIMIT can't mask the effect:
  - `reboot`: 76 → 75 — dropped exactly **1** expired row, all **75** valid-live kept.
  - `incident`: 272 → 251 — dropped exactly **21** deprecated rows, all **251** valid-live kept.
  - Every dropped row provably expired-or-deprecated; **zero** valid rows dropped.
- Full-hook orchestration smoke ran clean and the expired "Network topology reference" was absent from injected context.
- Two independent code reviews (both clean).

## Deploy

The hook is a `scripts/` per-prompt Claude Code hook — **no DB migration, no server restart**. Deploy = merge + `git pull`.

## Out of scope (tracked as follow-ups)

- `invalid_at` timestamp-format normalization — the DB has 3 formats (`T…+00:00`, 55 legacy space-naive, 1 `Z`); the raw string compare has a same-day latent edge shared by **both** retrieval paths (0 overlap with any currently-leaking memory). Tracking the shared root cause rather than fixing only the hook (which would make the paths disagree).
- Remove the dead `memory_proactive` MCP tool (0 internal callers, redundant with this hook; exposed surface → own review).
