### PR TITLE
feat(attention): auditable L1.5 verdict v2 (category + reason) + labeled-row backfill

### DIFF
--- a/src/genesis/attention/consumers.py
+++ b/src/genesis/attention/consumers.py
@@ -82,16 +82,45 @@ class ShadowStoreConsumer:
         )
 
     async def flush(self) -> int:
-        """Write all buffered rows via the crud layer in one transaction; returns count."""
+        """Write all buffered rows via the crud layer; returns the upserted count.
+
+        Two passes on one connection: (1) the label-preserving upsert; (2) an unconditional
+        backfill of ``l15_verdict`` for buffered rows that carry one. Pass 2 exists because
+        pass 1's ``WHERE acceptance_signal IS NULL`` guard FREEZES a labeled row's derived
+        columns — so on a re-run WITH ``--l15``, a verdict would never reach an already-labeled
+        row without it (and those are exactly the human∩judge rows the review needs). Only
+        NON-None verdicts are backfilled, so a plain (no ``--l15``) re-run never nulls a stored
+        verdict.
+
+        The two passes COMMIT SEPARATELY (each crud call commits), so this is not one atomic
+        transaction. That is acceptable here: this is an offline, single-writer, manually-run
+        tool, and BOTH passes are idempotent — if pass 2 fails after pass 1 commits, the rows
+        are simply back in their pre-``--l15`` state (present, no verdict) and the next ``--l15``
+        run re-attaches verdicts. A failure re-raises (surfacing in the runner) after a scoped
+        log; ``self._rows`` is only cleared on success, so a caller may safely retry ``flush``."""
         if not self._rows:
             return 0
+        id_idx = attention_crud.COLUMNS.index("id")
+        verdict_idx = attention_crud.COLUMNS.index("l15_verdict")
+        verdict_rows = [
+            (r[id_idx], r[verdict_idx]) for r in self._rows if r[verdict_idx] is not None
+        ]
+        n = 0
         conn = await aiosqlite.connect(self.db_path, timeout=self.timeout_s)
         try:
             await conn.execute("PRAGMA busy_timeout=30000")
             n = await attention_crud.bulk_upsert_events(conn, self._rows)
+            if verdict_rows:
+                await attention_crud.bulk_update_l15_verdicts(conn, verdict_rows)
+        except Exception:
+            logger.exception(
+                "attention flush failed (snapshot=%s config=%s, upserted≈%d, verdicts=%d)",
+                self.snapshot_id, self.config_version, n, len(verdict_rows),
+            )
+            raise
         finally:
             await conn.close()
-        logger.info("persisted %d attention_events (snapshot=%s config=%s)",
-                    n, self.snapshot_id, self.config_version)
+        logger.info("persisted %d attention_events (snapshot=%s config=%s, verdicts=%d)",
+                    n, self.snapshot_id, self.config_version, len(verdict_rows))
         self._rows = []
         return n

--- a/src/genesis/attention/sampler.py
+++ b/src/genesis/attention/sampler.py
@@ -10,9 +10,17 @@ core must stay ``genesis.routing``-free (see ``tests/test_attention/test_edge_po
 Two invariants:
 - **Fail-closed.** Every failure path (route failure, malformed/garbled JSON, missing
   key, non-finite value, any exception) returns ``None``. The shadow run never crashes;
-  the verdict simply stays absent (``AttentionEvent.l15_verdict is None``).
-- **Firewall.** The window transcript TEXT is sent to the LLM in memory only. The stored
-  verdict is floats-only (``{real, perk}``); the consumer persists no text (``consumers``).
+  the verdict simply stays absent (``AttentionEvent.l15_verdict is None``). ``real``/``perk``
+  are HARD-required; the v2 ``category``/``reason`` fields are best-effort (a missing or junk
+  category/reason never fails the parse, so an old ``{real, perk}`` response still parses).
+- **Firewall (v2 — softened 2026-07-02 with explicit user approval).** The window transcript
+  TEXT is sent to the LLM in memory only and is NEVER persisted. The stored verdict is the
+  judge's OWN output — floats ``{real, perk}`` + a ``category`` enum + a short ``reason`` the
+  prompt instructs to be a CHARACTERIZATION, not a verbatim quote. The reason is a judgment
+  artifact (Genesis-side, private DB), a deliberate small relaxation of the prior floats-only
+  rule so verdicts are auditable; the consumer still persists no raw transcript text.
+``sample()`` also stamps ``prompt_version`` (comparability across prompt iterations) and the
+serving ``model`` when the router reports it (the chain may fall back off the primary).
 
 Router is INJECTED (``_Router`` Protocol, mirroring ``ego/focus.py``) so the sampler is
 unit-testable with a fake and pulls no heavy router import into this module.
@@ -33,6 +41,18 @@ logger = logging.getLogger(__name__)
 # The router call-site (defined in config/model_routing.yaml). Free-only, cross-vendor
 # fallback, non-Groq — see the plan's PR3b bake-off.
 CALL_SITE = "attention_salience"
+
+# Stamped into every verdict so a later prompt iteration's verdicts are comparable/filterable
+# against these (the analog of a config_version for the judge prompt). Bump on prompt change.
+PROMPT_VERSION = "v2"
+
+# The category buckets the judge picks from; anything else the model returns collapses to
+# "other" (never fails the parse). "other" is the fallback bucket, not offered in the prompt.
+_CATEGORIES = frozenset({"question", "task", "decision", "problem", "chatter", "garble"})
+
+# A hard cap on the stored reason (defence-in-depth on the firewall-soften: a short
+# characterization, never a transcript dump). The prompt asks for <=140 chars; we cap at 200.
+_REASON_CAP = 200
 
 # ```json ... ``` (or a bare ``` ... ```) fenced block — models love to wrap JSON in one.
 _FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL)
@@ -57,13 +77,18 @@ class AttentionSampler:
     async def sample(
         self, window: list[AmbientUtterance], config: AttentionConfig
     ) -> dict | None:
-        """Return ``{"real": float, "perk": float}`` in ``[0, 1]``, or ``None`` on ANY failure.
+        """Return the judge verdict dict, or ``None`` on ANY failure.
+
+        On success the dict has ``real``/``perk`` floats in ``[0, 1]`` (always), a
+        ``category`` enum + short ``reason`` (best-effort — present when the model supplies
+        them), plus provenance this method stamps: ``prompt_version`` (always) and ``model``
+        (when the router reports the serving model).
 
         ``window`` is a FIRE-TIME SNAPSHOT of the recent in-context utterances (frozen,
         immutable ``AmbientUtterance``; the last element is the triggering utt). Its
         ``.text`` is sent to the LLM in memory only — never persisted (the consumer stores
-        the returned floats, no text). ``config`` is accepted for parity/future prompt
-        shaping; the current prompt needs only the window.
+        the returned verdict, no raw transcript). ``config`` is accepted for parity/future
+        prompt shaping; the current prompt needs only the window.
         """
         if not window:
             return None
@@ -75,7 +100,14 @@ class AttentionSampler:
             return None
         if not getattr(result, "success", False):
             return None
-        return _parse_verdict(getattr(result, "content", None))
+        verdict = _parse_verdict(getattr(result, "content", None))
+        if verdict is None:
+            return None
+        verdict["prompt_version"] = PROMPT_VERSION
+        model_id = getattr(result, "model_id", None)
+        if model_id:  # RoutingResult.model_id — records WHICH chain model actually judged
+            verdict["model"] = model_id
+        return verdict
 
 
 def _build_prompt(window: list[AmbientUtterance]) -> str:
@@ -89,30 +121,48 @@ def _build_prompt(window: list[AmbientUtterance]) -> str:
     transcript = "\n".join(lines)
     return (
         "You judge a short snippet of ambient household speech, auto-transcribed and "
-        "possibly garbled. Score two things, each a float from 0.0 to 1.0:\n"
-        "- real: is this COHERENT real speech (not ASR noise or hallucination)? "
-        "1.0 = clearly real, 0.0 = garble.\n"
-        "- perk: is this worth a proactive assistant's attention — a question, task, "
-        "decision, or problem? 1.0 = clearly salient, 0.0 = idle chatter.\n\n"
+        "possibly garbled. Return a strict JSON object with four fields:\n"
+        "- real: float 0.0-1.0 — is this COHERENT real speech (not ASR noise or "
+        "hallucination)? 1.0 = clearly real, 0.0 = garble.\n"
+        "- perk: float 0.0-1.0 — is this worth a proactive assistant's attention (a "
+        "question, task, decision, or problem)? 1.0 = clearly salient, 0.0 = idle chatter.\n"
+        "- category: exactly one word from: question, task, decision, problem, chatter, garble.\n"
+        "- reason: ONE short sentence (<=140 chars) explaining the scores IN GENERAL TERMS. "
+        "Do NOT quote or repeat the transcript verbatim — characterize it (e.g. 'a scheduling "
+        "question', not the words spoken).\n\n"
         f"Conversation window (the LAST line is the trigger):\n{transcript}\n\n"
-        'Reply with ONLY a JSON object, no prose: {"real": <float>, "perk": <float>}'
+        "Reply with ONLY the JSON object, no prose: "
+        '{"real": <float>, "perk": <float>, "category": "<one word>", "reason": "<sentence>"}'
     )
 
 
 def _first_json_object(text: str) -> str | None:
     """The first brace-balanced ``{...}`` span. A bare ``find``/``rfind`` mis-slices two
     plausible model outputs — an object followed by prose that contains a ``}``, and an
-    object with a nested value — so we scan brace depth instead. (Braces inside string
-    values aren't tracked; irrelevant for a numeric ``{real, perk}`` object, and a miscount
-    just fails to parse — fail-closed.)"""
+    object with a nested value — so we scan brace depth instead. The scan is STRING-AWARE:
+    braces inside a JSON string value are skipped (so a ``}`` in the free-text v2 ``reason``
+    doesn't prematurely close the object). A miscount still just fails to parse — fail-closed."""
     start = text.find("{")
     if start == -1:
         return None
     depth = 0
+    in_string = False
+    escaped = False
     for i in range(start, len(text)):
-        if text[i] == "{":
+        ch = text[i]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
             depth += 1
-        elif text[i] == "}":
+        elif ch == "}":
             depth -= 1
             if depth == 0:
                 return text[start : i + 1]
@@ -120,11 +170,14 @@ def _first_json_object(text: str) -> str | None:
 
 
 def _parse_verdict(content: str | None) -> dict | None:
-    """Fail-closed parse of a ``{real, perk}`` object from model output.
+    """Fail-closed parse of a v2 ``{real, perk, category, reason}`` object from model output.
 
-    Strip a code fence -> take the first brace-balanced ``{...}`` -> ``json.loads`` ->
-    require BOTH keys, reject booleans (``bool`` subclasses ``int``), coerce to float,
-    reject non-finite (NaN/inf), clamp to ``[0, 1]``. Any miss -> ``None`` (never raises)."""
+    Strip a code fence -> take the first brace-balanced ``{...}`` -> ``json.loads``. ``real``
+    and ``perk`` are HARD-required: reject booleans (``bool`` subclasses ``int``), coerce to
+    float, reject non-finite (NaN/inf), clamp to ``[0, 1]``; any miss -> ``None`` (never
+    raises). ``category`` and ``reason`` are BEST-EFFORT and additive — a missing/junk one is
+    simply omitted, so an old ``{real, perk}`` response (or a model that ignores the v2 fields)
+    still parses cleanly with no invented keys."""
     if not content:
         return None
     text = content.strip()
@@ -140,7 +193,7 @@ def _parse_verdict(content: str | None) -> dict | None:
         return None
     if not isinstance(obj, dict):
         return None
-    verdict: dict[str, float] = {}
+    verdict: dict[str, Any] = {}
     for key in ("real", "perk"):
         if key not in obj:
             return None
@@ -154,4 +207,19 @@ def _parse_verdict(content: str | None) -> dict | None:
         if not math.isfinite(value):  # rejects NaN / inf that json.loads happily parses
             return None
         verdict[key] = min(1.0, max(0.0, value))
+    # category (best-effort): a known bucket passes through lowercased; anything the model
+    # returns that isn't in the enum collapses to "other"; an absent category is not invented.
+    if "category" in obj:
+        cat = obj["category"]
+        verdict["category"] = (
+            cat.strip().lower()
+            if isinstance(cat, str) and cat.strip().lower() in _CATEGORIES
+            else "other"
+        )
+    # reason (best-effort): only a non-empty string, stripped and hard-capped; else omitted.
+    reason = obj.get("reason")
+    if isinstance(reason, str):
+        reason = reason.strip()[:_REASON_CAP]
+        if reason:
+            verdict["reason"] = reason
     return verdict

--- a/src/genesis/db/crud/attention.py
+++ b/src/genesis/db/crud/attention.py
@@ -272,10 +272,35 @@ async def update_l15_verdict(
     UNCONDITIONAL (no ``acceptance_signal IS NULL`` guard) — unlike ``bulk_upsert_events``,
     which guards the human label. ``l15_verdict`` carries no human input, so a later
     ``--l15`` run may safely refresh it even on an already-LABELED row (the label/verdict
-    correlation workflow PR3c-2 needs). Stored floats-only (mirrors ``consumers._to_row``)."""
+    correlation workflow PR3c-2 needs). Stored as the judge's own JSON verdict (mirrors
+    ``consumers._to_row``) — never raw transcript text (firewall)."""
     payload = json.dumps(verdict) if verdict is not None else None
     cursor = await db.execute(
         "UPDATE attention_events SET l15_verdict = ? WHERE id = ?", (payload, event_id)
     )
     await db.commit()
     return cursor.rowcount > 0
+
+
+async def bulk_update_l15_verdicts(
+    db: aiosqlite.Connection, rows: list[tuple[str, str]]
+) -> int:
+    """Unconditionally set ``l15_verdict`` for each ``(event_id, verdict_json)`` pair; returns
+    the count submitted.
+
+    The bulk sibling of ``update_l15_verdict`` for the shadow runner's backfill: ``l15_verdict``
+    is a MACHINE field, so — unlike ``bulk_upsert_events``, whose ``WHERE acceptance_signal IS
+    NULL`` guard FREEZES a labeled row's derived columns — this writes even on LABELED rows.
+    That is exactly what a later ``--l15`` run needs: the verdict must attach to the same rows
+    the human already labeled, or the human∩judge agreement view reads the judge as "missing"
+    on precisely the rows under review. Callers pass already-serialized JSON (mirrors
+    ``ShadowStoreConsumer``, which ``json.dumps`` once) and filter out None verdicts themselves
+    (a no-verdict re-run must not null a stored one). One ``executemany`` in the caller's txn."""
+    if not rows:
+        return 0
+    await db.executemany(
+        "UPDATE attention_events SET l15_verdict = ? WHERE id = ?",
+        [(verdict_json, event_id) for event_id, verdict_json in rows],
+    )
+    await db.commit()
+    return len(rows)

--- a/tests/test_attention/test_consumers.py
+++ b/tests/test_attention/test_consumers.py
@@ -129,6 +129,73 @@ async def test_reflush_preserves_human_label(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_flush_backfills_l15_verdict_onto_labeled_row(tmp_path):
+    # PR3d: a re-run WITH --l15 must attach the judge verdict even to a row the human already
+    # labeled. bulk_upsert's label guard FREEZES derived cols on a labeled row, so the verdict
+    # (a machine field) has to land via a second, unconditional pass — else the human∩judge
+    # agreement view would read the judge as "missing" on exactly the rows we care about.
+    from dataclasses import replace
+    db = tmp_path / "g.db"
+    _make_db(db)
+    cfg = AttentionConfig.from_dict(default_config_dict())
+    evs = _run_events([_utt(1, 100.0, "what do you think?")], cfg)
+    assert evs
+
+    c = ShadowStoreConsumer(db, snapshot_id="s", config_version=cfg.version)
+    for ev in evs:
+        c.add(ev)                                    # first persist: no verdict yet
+    await c.flush()
+    conn = sqlite3.connect(db)
+    conn.execute("UPDATE attention_events SET acceptance_signal = 'should'")   # human labels it
+    conn.commit()
+    conn.close()
+
+    c2 = ShadowStoreConsumer(db, snapshot_id="s", config_version=cfg.version)
+    for ev in evs:
+        c2.add(replace(ev, l15_verdict={"real": 0.9, "perk": 0.8, "category": "question"}))
+    await c2.flush()                                 # re-run WITH a verdict
+
+    conn = sqlite3.connect(db)
+    rows = conn.execute("SELECT acceptance_signal, l15_verdict FROM attention_events").fetchall()
+    conn.close()
+    assert rows
+    for label, verdict in rows:
+        assert label == "should"                     # human label preserved
+        assert verdict is not None and json.loads(verdict)["category"] == "question"  # verdict landed
+
+
+@pytest.mark.asyncio
+async def test_flush_without_verdict_does_not_null_a_labeled_rows_verdict(tmp_path):
+    # A plain re-run (no --l15) carries l15_verdict=None; it must NOT wipe a verdict a prior
+    # --l15 run wrote. The backfill pass only writes NON-None verdicts, and the label freezes
+    # the upsert — so the earlier verdict survives.
+    from dataclasses import replace
+    db = tmp_path / "g.db"
+    _make_db(db)
+    cfg = AttentionConfig.from_dict(default_config_dict())
+    evs = _run_events([_utt(1, 100.0, "what do you think?")], cfg)
+
+    c = ShadowStoreConsumer(db, snapshot_id="s", config_version=cfg.version)
+    for ev in evs:
+        c.add(replace(ev, l15_verdict={"real": 0.5, "perk": 0.5}))
+    await c.flush()
+    conn = sqlite3.connect(db)
+    conn.execute("UPDATE attention_events SET acceptance_signal = 'should'")
+    conn.commit()
+    conn.close()
+
+    c2 = ShadowStoreConsumer(db, snapshot_id="s", config_version=cfg.version)
+    for ev in evs:
+        c2.add(ev)                                   # l15_verdict is None on this re-run
+    await c2.flush()
+
+    conn = sqlite3.connect(db)
+    verdicts = [r[0] for r in conn.execute("SELECT l15_verdict FROM attention_events")]
+    conn.close()
+    assert verdicts and all(v is not None for v in verdicts)   # prior verdict survived
+
+
+@pytest.mark.asyncio
 async def test_new_config_version_writes_new_rows(tmp_path):
     db = tmp_path / "g.db"
     _make_db(db)

--- a/tests/test_attention/test_sampler.py
+++ b/tests/test_attention/test_sampler.py
@@ -89,6 +89,66 @@ def test_parse_empty_or_none_returns_none():
     assert _parse_verdict(None) is None
 
 
+# ── verdict v2: category + reason are additive + best-effort (real/perk stay required) ──
+
+def test_parse_v2_full_verdict():
+    out = _parse_verdict(
+        '{"real": 0.8, "perk": 0.9, "category": "question", "reason": "they asked whether to ship"}'
+    )
+    assert out == {"real": 0.8, "perk": 0.9, "category": "question",
+                   "reason": "they asked whether to ship"}
+
+
+def test_parse_old_format_invents_no_v2_keys():
+    # a bare {real, perk} (model ignored the v2 fields) parses cleanly with NO invented
+    # category/reason — backward compatible, and the parser never fabricates a category.
+    assert _parse_verdict('{"real": 0.8, "perk": 0.3}') == {"real": 0.8, "perk": 0.3}
+
+
+def test_parse_unknown_category_coerces_to_other():
+    out = _parse_verdict('{"real": 0.5, "perk": 0.5, "category": "banana"}')
+    assert out["category"] == "other"
+
+
+def test_parse_category_normalized_to_lowercase():
+    out = _parse_verdict('{"real": 0.5, "perk": 0.5, "category": "Question"}')
+    assert out["category"] == "question"
+
+
+def test_parse_non_string_category_coerces_to_other():
+    out = _parse_verdict('{"real": 0.5, "perk": 0.5, "category": 7}')
+    assert out["category"] == "other"
+
+
+def test_parse_reason_stripped_and_hard_capped():
+    out = _parse_verdict('{"real": 0.5, "perk": 0.5, "reason": "  ' + "x" * 400 + '  "}')
+    assert out["reason"] == "x" * 200          # whitespace-stripped, hard-capped to 200 chars
+
+
+def test_parse_blank_reason_omitted():
+    out = _parse_verdict('{"real": 0.5, "perk": 0.5, "reason": "   "}')
+    assert "reason" not in out and out["real"] == 0.5
+
+
+def test_parse_non_string_reason_omitted():
+    out = _parse_verdict('{"real": 0.5, "perk": 0.5, "reason": {"x": 1}}')
+    assert "reason" not in out
+
+
+def test_parse_missing_real_still_none_with_v2_fields_present():
+    # real/perk remain HARD-required even when category/reason are supplied.
+    assert _parse_verdict('{"perk": 0.5, "category": "task", "reason": "do X"}') is None
+
+
+def test_parse_reason_containing_brace_is_not_truncated():
+    # v2 reason is FREE TEXT; a stray "}" (or "{") inside it must NOT prematurely close the
+    # brace-balanced scan (the pre-v2 scanner ignored string context — fine when all fields
+    # were numeric, a silent verdict-loss regression now that reason is prose).
+    out = _parse_verdict('{"real": 0.8, "perk": 0.3, "category": "task", "reason": "fix the }close} bug"}')
+    assert out["real"] == 0.8 and out["category"] == "task"
+    assert out["reason"] == "fix the }close} bug"
+
+
 # ── _build_prompt: window text + speaker labels reach the model ──
 
 def test_prompt_carries_window_text_and_speaker_labels():
@@ -103,33 +163,50 @@ def test_prompt_unknown_speaker_label():
     assert "[?]" in p
 
 
+def test_prompt_lists_category_enum_and_reason_field():
+    p = _build_prompt([_u("can you book it?", is_user=1)])
+    for cat in ("question", "task", "decision", "problem", "chatter", "garble"):
+        assert cat in p
+    assert "category" in p and "reason" in p
+
+
+def test_prompt_reason_instructs_no_verbatim_quote():
+    # firewall-soften safety: the reason is a CHARACTERIZATION, not a transcript quote —
+    # the prompt must tell the model not to quote the window text back.
+    p = _build_prompt([_u("hi", is_user=1)]).lower()
+    assert "quote" in p or "verbatim" in p
+
+
 # ── AttentionSampler.sample: injected fake router ──
 
 @dataclass
 class _Result:
     success: bool
     content: str | None
+    model_id: str | None = None       # RoutingResult carries the serving model (may fall back)
 
 
 class _FakeRouter:
-    def __init__(self, *, content=None, success=True, raises=False):
+    def __init__(self, *, content=None, success=True, raises=False, model_id=None):
         self._content = content
         self._success = success
         self._raises = raises
+        self._model_id = model_id
         self.calls: list = []
 
     async def route_call(self, call_site_id, messages, **kwargs):
         self.calls.append((call_site_id, messages))
         if self._raises:
             raise RuntimeError("boom")
-        return _Result(self._success, self._content)
+        return _Result(self._success, self._content, self._model_id)
 
 
 @pytest.mark.asyncio
 async def test_sample_happy_hits_attention_salience_call_site():
     r = _FakeRouter(content='{"real": 0.7, "perk": 0.6}')
     out = await AttentionSampler(r).sample([_u("what's the plan?", is_user=1)], CFG)
-    assert out == {"real": 0.7, "perk": 0.6}
+    assert out["real"] == 0.7 and out["perk"] == 0.6
+    assert out["prompt_version"] == "v2"        # sample() stamps the prompt version
     assert r.calls and r.calls[0][0] == "attention_salience"
 
 
@@ -155,6 +232,29 @@ async def test_sample_empty_window_skips_router_call():
 async def test_sample_malformed_content_returns_none():
     assert await AttentionSampler(_FakeRouter(content="not json at all")).sample(
         [_u("hi", is_user=1)], CFG) is None
+
+
+@pytest.mark.asyncio
+async def test_sample_stamps_prompt_version_and_preserves_v2_fields():
+    r = _FakeRouter(content='{"real": 0.7, "perk": 0.6, "category": "question", "reason": "asked a q"}')
+    out = await AttentionSampler(r).sample([_u("what's the plan?", is_user=1)], CFG)
+    assert out["prompt_version"] == "v2"
+    assert out["category"] == "question" and out["reason"] == "asked a q"
+    assert out["real"] == 0.7 and out["perk"] == 0.6
+
+
+@pytest.mark.asyncio
+async def test_sample_stamps_model_when_router_reports_it():
+    r = _FakeRouter(content='{"real": 1, "perk": 1}', model_id="mistral-small-latest")
+    out = await AttentionSampler(r).sample([_u("hi", is_user=1)], CFG)
+    assert out["model"] == "mistral-small-latest"
+
+
+@pytest.mark.asyncio
+async def test_sample_omits_model_when_router_reports_none():
+    r = _FakeRouter(content='{"real": 1, "perk": 1}')     # RoutingResult.model_id is None
+    out = await AttentionSampler(r).sample([_u("hi", is_user=1)], CFG)
+    assert "model" not in out
 
 
 def test_attention_salience_call_site_is_configured():

--- a/tests/test_db/test_crud_attention.py
+++ b/tests/test_db/test_crud_attention.py
@@ -250,3 +250,29 @@ async def test_update_l15_verdict_backfills_even_on_labeled_row(tmp_path):
     assert (await crud.get_event(db, "id-1"))["l15_verdict"] is None
     assert await crud.update_l15_verdict(db, "missing", {"real": 1.0, "perk": 1.0}) is False
     await db.close()
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_l15_verdicts_writes_even_on_labeled_rows(tmp_path):
+    """The shadow runner's backfill path: attach verdicts to MANY rows in one pass, including
+    already-LABELED rows (which bulk_upsert's label guard freezes). Verdict is a machine field."""
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [_row(1), _row(2)])
+    await crud.update_acceptance_signal(db, "id-1", "should")   # LABEL id-1 (frozen to upsert)
+    v1 = json.dumps({"real": 0.8, "perk": 0.6, "category": "question"})
+    v2 = json.dumps({"real": 0.2, "perk": 0.1, "category": "garble"})
+    n = await crud.bulk_update_l15_verdicts(db, [("id-1", v1), ("id-2", v2)])
+    assert n == 2
+    e1 = await crud.get_event(db, "id-1")
+    assert json.loads(e1["l15_verdict"])["category"] == "question"   # verdict landed on labeled row
+    assert e1["acceptance_signal"] == "should"                       # label untouched
+    e2 = await crud.get_event(db, "id-2")
+    assert json.loads(e2["l15_verdict"])["real"] == 0.2
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_l15_verdicts_empty_is_noop(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    assert await crud.bulk_update_l15_verdicts(db, []) == 0
+    await db.close()


### PR DESCRIPTION
## Why

The L1.5 attention **judge** (offline shadow LLM that scores whether a moment is worth attention) returned two bare floats `{real, perk}` — as unauditable as the human binary labels we retired. This is the methodology reframe: the perk-up decision is an **LLM judgment**, so humans should **review the judge's reasoning** and iterate the **prompt**, not label fires to tune trigger weights. To review a verdict, you have to be able to *see it*.

## What

**Verdict v2** (`sampler.py`): the judge now returns `{real, perk, category, reason}`.
- `category` ∈ {question, task, decision, problem, chatter, garble}; anything else → `other`.
- `reason` is ONE short sentence the prompt instructs to be a **characterization, not a verbatim quote**.
- `real`/`perk` stay HARD-required + fail-closed; `category`/`reason` are best-effort and additive, so an old `{real, perk}` response still parses with no invented keys.
- `_first_json_object` is now **string-aware** — a stray `}` inside the free-text `reason` no longer prematurely closes the JSON scan (a silent verdict-loss the numeric-only scanner couldn't hit).
- `sample()` stamps `prompt_version` (comparability across prompt iterations) and the serving `model` when the router reports it.

**Firewall note:** the `reason` sentence is a judge *characterization* stored in the private DB — a deliberate, small, **explicitly-approved** relaxation of the prior floats-only rule, made so verdicts are auditable. No raw transcript text reaches the DB.

**Backfill fix** (`consumers.py` + new `crud.bulk_update_l15_verdicts`): `bulk_upsert_events`' `WHERE acceptance_signal IS NULL` guard **freezes a labeled row's derived columns**, so a `--l15` re-run would never attach a verdict to an already-labeled row — exactly the human∩judge rows a review needs. `flush()` now does a second, unconditional pass to backfill verdicts (None-verdict runs skipped, so a plain re-run never nulls a stored verdict).

## Tests

201 passed. New: v2 parse (happy / category coercion / reason cap / omit / **brace-in-reason**), old-format compat, prompt enum + no-quote instruction, `sample()` stamping, crud bulk-update on labeled rows, flush backfill onto a labeled row + no-null-on-plain-rerun.

This is a shadow-only path (no runtime consumer); the judge is still opt-in via the runner's `--l15` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)