### PR TITLE
feat(dashboard): attention Judgment review — L1.5 verdict + reasoning + reviewer note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **The Genesis Voice add-on's attention surface now shows the judge's reasoning — and lets you review it.**
+  For the optional passive-listening add-on, the buried "Attention" tab is now a top-level **Genesis Voice →
+  Judgment** review. Each moment the attention gate noticed is scored by a lightweight LLM judge that says
+  whether it was real speech, whether it was worth attention, and — new — a one-word category and a short
+  reason. You review the judge (worth noticing / not worth it / skip) and can jot your own *why*; your notes
+  inform the judge's prompt, not any hidden weights. It stays offline observability — nothing here speaks or
+  acts, and it's hidden entirely when the voice add-on isn't installed.
+
 - **The dashboard's container-health badge now tells the truth about CPU and memory pressure.**
   Previously the badge ignored CPU entirely (it was hardwired to "healthy") and judged memory only by a
   raw usage figure that's inflated by reclaimable cache — so a busy or memory-throttling box could still

--- a/src/genesis/dashboard/routes/attention.py
+++ b/src/genesis/dashboard/routes/attention.py
@@ -62,6 +62,7 @@ def _event_summary(row: dict) -> dict:
         "window_ref": _loads(row.get("window_ref"), {}),
         "l15_verdict": _loads(row.get("l15_verdict"), None),
         "acceptance_signal": row.get("acceptance_signal"),
+        "acceptance_note": row.get("acceptance_note"),
         "snapshot_id": row.get("snapshot_id"),
         "config_version": row.get("config_version"),
         "created_at": row.get("created_at"),
@@ -169,7 +170,12 @@ async def attention_reveal_text(event_id: str):
 @blueprint.route("/api/genesis/attention/<event_id>/label", methods=["POST"])
 @_async_route
 async def attention_label(event_id: str):
-    """Write a should/shouldn't/skip review label. Returns the prior value (for X->Y)."""
+    """Write a should/shouldn't/skip review label, plus the reviewer's optional WHY note.
+
+    The perk decision is an LLM judgment, so the review captures the human's REASONING, not
+    just a binary — an ``acceptance_note`` (when present in the body) is stored beside the
+    label. Omit it to leave any existing note untouched (crud sentinel); send ``""``/null to
+    clear. Returns the prior signal (for X->Y)."""
     if (resp := _auth_or_403()) is not None:
         return resp
     from genesis.db.crud import attention as attention_crud
@@ -181,8 +187,19 @@ async def attention_label(event_id: str):
 
     data = request.get_json(silent=True) or {}
     signal = data.get("acceptance_signal")
+    note_kwargs = {}
+    stored_note = None
+    if "acceptance_note" in data:  # present (incl. null/"") => set it; absent => preserve
+        raw = data.get("acceptance_note")
+        if raw is not None and not isinstance(raw, str):
+            # reject junk types (a number/array) rather than silently CLEARING the note
+            return jsonify({"error": "acceptance_note must be a string or null"}), 400
+        stored_note = raw.strip()[:500] or None if isinstance(raw, str) else None
+        note_kwargs["note"] = stored_note
     try:
-        found, prior = await attention_crud.update_acceptance_signal(rt.db, event_id, signal)
+        found, prior = await attention_crud.update_acceptance_signal(
+            rt.db, event_id, signal, **note_kwargs
+        )
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
     except Exception:
@@ -191,4 +208,7 @@ async def attention_label(event_id: str):
 
     if not found:
         return jsonify({"error": "Event not found"}), 404
-    return jsonify({"status": "ok", "id": event_id, "acceptance_signal": signal, "prior": prior})
+    body = {"status": "ok", "id": event_id, "acceptance_signal": signal, "prior": prior}
+    if "acceptance_note" in data:  # echo only what we actually wrote (else UI keeps its note)
+        body["acceptance_note"] = stored_note
+    return jsonify(body)

--- a/src/genesis/dashboard/templates/genesis_voice.html
+++ b/src/genesis/dashboard/templates/genesis_voice.html
@@ -18,10 +18,10 @@
     document.addEventListener("alpine:init", () => {
       Alpine.store("genesisVoice", {
         // ── sub-tab state ──
-        voiceTab: "calibration",
+        voiceTab: "judgment",
 
-        // ── Calibration (attention review) state — must be declared so the ported methods/panel
-        //    have reactive keys to read on first load (before any fetch returns) ──
+        // ── Judgment (L1.5 review) state — must be declared so the methods/panel have reactive
+        //    keys to read on first load (before any fetch returns) ──
         attentionEvents: [],
         attentionStats: null,
         attentionFilters: { activation: "", trigger: "", is_user: false, unlabeled: true, config_version: "" },
@@ -29,6 +29,7 @@
         _attentionEventsGen: 0,   // request generation — discard a stale events response superseded by a newer fetch
         attentionRevealed: {},   // {event_id: [window rows] | "unavailable"}
         attentionLabeling: {},   // {event_id: true} while a label POST is in flight
+        attentionNotes: {},      // {event_id: draft note text} — the reviewer's WHY, sent with the label
 
         // ── Bridge (ambient edge) — reuses /api/genesis/health infrastructure.ambient ──
         bridge: null,
@@ -126,13 +127,21 @@
         async labelAttentionEvent(id, signal) {
           this.attentionLabeling = { ...this.attentionLabeling, [id]: true };
           try {
+            const note = (this.attentionNotes[id] || "").trim();
+            const body = { acceptance_signal: signal };
+            if (note) body.acceptance_note = note;   // omit when empty → crud preserves any prior note
             const resp = await fetchApi(`/api/genesis/attention/${encodeURIComponent(id)}/label`, {
               method: "POST", headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ acceptance_signal: signal }),
+              body: JSON.stringify(body),
             });
             if (resp && resp.ok) {
+              const data = await resp.json().catch(() => ({}));
               const ev = this.attentionEvents.find(e => e.id === id);
-              if (ev) ev.acceptance_signal = signal;
+              if (ev) {
+                ev.acceptance_signal = signal;
+                if ("acceptance_note" in data) ev.acceptance_note = data.acceptance_note;
+              }
+              const nm = { ...this.attentionNotes }; delete nm[id]; this.attentionNotes = nm;  // clear draft
               if (this.attentionFilters.unlabeled) {
                 this.attentionEvents = this.attentionEvents.filter(e => e.id !== id);
               }
@@ -150,6 +159,35 @@
           if (a === "hard") return "var(--color-primary)";
           if (a === "suppressed") return "var(--color-text-secondary)";
           return "var(--color-warning-text)";
+        },
+        // ── judge-verdict glances (client-side, over the SHOWN events only — honest "of shown",
+        //    never an optimization target; the perk decision is the judge's, not a fitted metric) ──
+        _verdictCategoryColor(cat) {
+          return ({ question:"#60a5fa", task:"#34d399", decision:"#a78bfa", problem:"#f87171",
+                    chatter:"#9ca3af", garble:"#6b7280", other:"#9ca3af" })[cat] || "#9ca3af";
+        },
+        judgedShown() { return this.attentionEvents.filter(e => e.l15_verdict).length; },
+        categorySplitShown() {
+          const h = {};
+          for (const e of this.attentionEvents) {
+            const c = e.l15_verdict && e.l15_verdict.category;
+            if (c) h[c] = (h[c] || 0) + 1;
+          }
+          return Object.entries(h).sort((a, b) => b[1] - a[1]);
+        },
+        _mean(a) { return a.length ? a.reduce((x, y) => x + y, 0) / a.length : null; },
+        agreementShown() {
+          // Of shown rows with BOTH your label and a judge verdict: the judge's mean `perk` split
+          // by your verdict. A GLANCE — does the judge's salience track your worth/not-worth? Not
+          // an accuracy score, no threshold; the two can legitimately diverge (your reason ≠ content).
+          const g = { should: [], shouldnt: [] };
+          for (const e of this.attentionEvents) {
+            if (!e.l15_verdict || typeof e.l15_verdict.perk !== "number") continue;
+            if (e.acceptance_signal === "should") g.should.push(e.l15_verdict.perk);
+            else if (e.acceptance_signal === "shouldnt") g.shouldnt.push(e.l15_verdict.perk);
+          }
+          return { should: this._mean(g.should), shouldnt: this._mean(g.shouldnt),
+                   n: { should: g.should.length, shouldnt: g.shouldnt.length } };
         },
       });
     });
@@ -178,49 +216,87 @@
       <span class="material-symbols-outlined">graphic_eq</span> Genesis Voice
     </h1>
     <div style="color:var(--color-text-secondary); font-size:.85em; margin-bottom:.75rem;">
-      The optional passive-listening / voice add-on. Surfaces here are offline observability + calibration — nothing here speaks or acts.
+      The optional passive-listening / voice add-on. Surfaces here are offline observability — nothing here speaks or acts.
     </div>
 
     <nav class="voice-tabs">
-      <button :class="{ active: $store.genesisVoice.voiceTab === 'calibration' }" @click="$store.genesisVoice.setTab('calibration')">Calibration</button>
+      <button :class="{ active: $store.genesisVoice.voiceTab === 'judgment' }" @click="$store.genesisVoice.setTab('judgment')">Judgment</button>
       <button :class="{ active: $store.genesisVoice.voiceTab === 'bridge' }" @click="$store.genesisVoice.setTab('bridge')">Bridge</button>
       <button :class="{ active: $store.genesisVoice.voiceTab === 'stt' }" @click="$store.genesisVoice.setTab('stt')">STT quality</button>
       <button :class="{ active: $store.genesisVoice.voiceTab === 's2s' }" @click="$store.genesisVoice.setTab('s2s')">S2S sessions</button>
     </nav>
 
-    <!-- ═══ Calibration (the attention review tab, relocated) ═══ -->
-    <div class="panel" x-show="$store.genesisVoice.voiceTab === 'calibration'" style="overflow-y: auto; max-height: calc(100vh - 180px);">
+    <!-- ═══ Judgment (L1.5 review) ═══ -->
+    <div class="panel" x-show="$store.genesisVoice.voiceTab === 'judgment'" style="overflow-y: auto; max-height: calc(100vh - 180px);">
       <div class="panel-header">
-        <span class="material-symbols-outlined">hearing</span>
-        Calibration
+        <span class="material-symbols-outlined">gavel</span>
+        Judgment
       </div>
       <div style="padding: 1rem;">
 
       <div style="margin-bottom: 1rem; color: var(--color-text-secondary); font-size: .85em;">
-        Moments the passive-listening attention gate <em>would</em> have noticed. Nothing here speaks or acts.
-        <strong style="color:var(--color-text);">For each one, ask: should Genesis have PAID ATTENTION here —
-        was it worth being aware of / remembering?</strong> This is about <em>attention</em>, not about
-        interrupting you (whether to actually speak is a separate, later decision). Reveal the transcript, then
-        label — <strong>Worth noticing</strong> = yes, attend · <strong>Not worth it</strong> = noise, not
-        worth a glance · <strong>Skip</strong> = can't tell (garbled). Transcript text is read live from the
-        local snapshot; it is never stored here.
+        For each moment the gate noticed, the <strong style="color:var(--color-text);">L1.5 judge</strong>
+        (a cheap LLM) scored whether it was real speech and worth attention, and <em>why</em>. Whether to
+        perk up is an LLM <em>judgment</em> — not something we tune from labels — so your role here is to
+        <strong style="color:var(--color-text);">review the judge</strong>: reveal the transcript, see the
+        verdict + reasoning, and record your own take and, most usefully, <em>why</em>. Your reviews inform
+        the judge's <strong>prompt</strong>, never the trigger weights. This is about <em>attention</em>
+        (worth being aware of / remembering), not interrupting — <strong>Worth noticing</strong> = attend ·
+        <strong>Not worth it</strong> = noise · <strong>Skip</strong> = can't tell (garbled). A "not worth it"
+        is not a verdict on the trigger — you may decline for reasons of your own; the <em>note</em> is where
+        that reasoning lives. Transcript text is read live from the local snapshot; it is never stored here.
       </div>
 
-      <!-- Stats -->
+      <!-- Stats: version-wide counts (backend) + judged-of-shown (client) -->
       <div style="display: flex; gap: 1rem; margin-bottom: 1rem; flex-wrap: wrap;">
-        <div style="flex: 1; min-width: 90px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
+        <div style="flex: 1; min-width: 80px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
           <div style="font-size: 1.4rem; font-weight: 700;" x-text="$store.genesisVoice.attentionStats?.labels?.total ?? '—'"></div>
           <div style="font-size: .75rem; color: var(--color-text-secondary);">Events</div>
         </div>
-        <div style="flex: 1; min-width: 90px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
+        <div style="flex: 1; min-width: 80px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
           <div style="font-size: 1.4rem; font-weight: 700; color: var(--color-primary);" x-text="$store.genesisVoice.attentionStats?.labels?.labeled ?? 0"></div>
-          <div style="font-size: .75rem; color: var(--color-text-secondary);">Labeled</div>
+          <div style="font-size: .75rem; color: var(--color-text-secondary);">Reviewed</div>
         </div>
-        <div style="flex: 1; min-width: 90px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
+        <div style="flex: 1; min-width: 80px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
           <div style="font-size: 1.4rem; font-weight: 700; color: var(--color-warning-text);" x-text="$store.genesisVoice.attentionStats?.labels?.unlabeled ?? 0"></div>
-          <div style="font-size: .75rem; color: var(--color-text-secondary);">Unlabeled</div>
+          <div style="font-size: .75rem; color: var(--color-text-secondary);">Unreviewed</div>
+        </div>
+        <div style="flex: 1; min-width: 80px; background: var(--color-background); border-radius: 6px; padding: .75rem; text-align: center;">
+          <div style="font-size: 1.4rem; font-weight: 700;" x-text="$store.genesisVoice.judgedShown()"></div>
+          <div style="font-size: .75rem; color: var(--color-text-secondary);">Judged (shown)</div>
         </div>
       </div>
+
+      <!-- Judge glances (client-side, over the SHOWN events; appear only when there are verdicts) -->
+      <template x-if="$store.genesisVoice.judgedShown() > 0">
+        <div style="display:flex; gap:1rem; margin-bottom:1.25rem; flex-wrap:wrap; align-items:flex-start;">
+          <div style="flex:1; min-width:220px;">
+            <div style="font-size:.72rem; color:var(--color-text-secondary); margin-bottom:.35rem;">Judge category split (of shown)</div>
+            <div style="display:flex; flex-wrap:wrap; gap:.3rem;">
+              <template x-for="[cat, n] in $store.genesisVoice.categorySplitShown()" :key="cat">
+                <span style="font-size:.7rem; padding:2px 7px; border-radius:10px; font-weight:600;"
+                      :style="`color:${$store.genesisVoice._verdictCategoryColor(cat)}; background:${$store.genesisVoice._verdictCategoryColor(cat)}22;`"
+                      x-text="cat + ' · ' + n"></span>
+              </template>
+            </div>
+          </div>
+          <template x-if="$store.genesisVoice.agreementShown().n.should + $store.genesisVoice.agreementShown().n.shouldnt > 0">
+            <div style="flex:1; min-width:220px;">
+              <div style="font-size:.72rem; color:var(--color-text-secondary); margin-bottom:.35rem;" title="A glance, not an accuracy score — the judge's salience can legitimately diverge from your call.">
+                Judge mean perk by your call (of shown, reviewed + judged)
+              </div>
+              <div style="font-size:.78rem; display:flex; flex-direction:column; gap:.15rem;">
+                <div><span style="color:var(--color-primary);">Worth noticing</span>:
+                  <span x-text="$store.genesisVoice.agreementShown().should != null ? $store.genesisVoice.agreementShown().should.toFixed(2) : '—'"></span>
+                  <span style="color:var(--color-text-secondary);" x-text="'(n=' + $store.genesisVoice.agreementShown().n.should + ')'"></span></div>
+                <div><span style="color:var(--color-warning-text);">Not worth it</span>:
+                  <span x-text="$store.genesisVoice.agreementShown().shouldnt != null ? $store.genesisVoice.agreementShown().shouldnt.toFixed(2) : '—'"></span>
+                  <span style="color:var(--color-text-secondary);" x-text="'(n=' + $store.genesisVoice.agreementShown().n.shouldnt + ')'"></span></div>
+              </div>
+            </div>
+          </template>
+        </div>
+      </template>
 
       <!-- Per-trigger dominance bar -->
       <template x-if="$store.genesisVoice.attentionStats && Object.keys($store.genesisVoice.attentionStats.by_trigger||{}).length">
@@ -293,19 +369,31 @@
                 <span x-show="ev.acceptance_signal" style="font-size:.6rem; padding:1px 6px; border-radius:3px; color:var(--color-primary); background:var(--color-primary)22;" x-text="({should:'noticed',shouldnt:'ignored',skip:'skipped'})[ev.acceptance_signal] || ev.acceptance_signal"></span>
               </div>
               <div style="display:flex; gap:.3rem; align-items:center; flex-shrink:0;">
-                <button class="btn-sm" style="padding:.15rem .4rem;"
+                <button class="btn-sm" style="padding:.15rem .4rem;" title="Reveal / hide the window transcript (read live from the local snapshot, never stored)"
                         @click="$store.genesisVoice.attentionRevealed[ev.id] !== undefined ? $store.genesisVoice.hideAttentionText(ev.id) : $store.genesisVoice.revealAttentionText(ev.id)">
                   <span class="material-symbols-outlined" style="font-size:1rem; vertical-align:middle;"
                         x-text="$store.genesisVoice.attentionRevealed[ev.id] !== undefined ? 'visibility_off' : 'visibility'"></span>
                 </button>
-                <button class="btn-sm" style="padding:.15rem .5rem;" title="Genesis should have paid attention here (worth being aware of / remembering)" :disabled="$store.genesisVoice.attentionLabeling[ev.id] === true"
-                        @click="$store.genesisVoice.labelAttentionEvent(ev.id, 'should')">Worth noticing</button>
-                <button class="btn-sm" style="padding:.15rem .5rem;" title="Noise — not worth a glance" :disabled="$store.genesisVoice.attentionLabeling[ev.id] === true"
-                        @click="$store.genesisVoice.labelAttentionEvent(ev.id, 'shouldnt')">Not worth it</button>
-                <button class="btn-sm" style="padding:.15rem .5rem; opacity:.7;" title="Can't tell — too garbled to judge" :disabled="$store.genesisVoice.attentionLabeling[ev.id] === true"
-                        @click="$store.genesisVoice.labelAttentionEvent(ev.id, 'skip')">Skip</button>
               </div>
             </div>
+
+            <!-- Judge verdict (L1.5) -->
+            <template x-if="ev.l15_verdict">
+              <div style="margin-top:.5rem; display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; font-size:.75rem;">
+                <span style="padding:1px 8px; border-radius:10px; font-weight:700; text-transform:capitalize;"
+                      :style="`color:${$store.genesisVoice._verdictCategoryColor(ev.l15_verdict.category||'other')}; background:${$store.genesisVoice._verdictCategoryColor(ev.l15_verdict.category||'other')}22;`"
+                      x-text="ev.l15_verdict.category || 'other'"></span>
+                <span style="color:var(--color-text-secondary);" x-text="'real ' + (typeof ev.l15_verdict.real==='number' ? ev.l15_verdict.real.toFixed(2) : '—') + ' · perk ' + (typeof ev.l15_verdict.perk==='number' ? ev.l15_verdict.perk.toFixed(2) : '—')"></span>
+                <span x-show="ev.l15_verdict.reason" style="color:var(--color-text); font-style:italic;" x-text="'“' + (ev.l15_verdict.reason||'') + '”'"></span>
+                <span x-show="ev.l15_verdict.model" style="color:var(--color-text-secondary); opacity:.55; font-size:.68rem;" x-text="ev.l15_verdict.model"></span>
+              </div>
+            </template>
+            <template x-if="!ev.l15_verdict">
+              <div style="margin-top:.5rem; font-size:.72rem; color:var(--color-text-secondary); opacity:.7;">
+                judge: not yet scored — run <code>python -m genesis.attention.runner --l15 --persist</code>
+              </div>
+            </template>
+
             <!-- Revealed window (from the transient snapshot) -->
             <template x-if="$store.genesisVoice.attentionRevealed[ev.id] !== undefined">
               <div style="margin-top:.5rem; background:var(--color-panel); border-radius:4px; padding:.5rem .6rem;">
@@ -322,6 +410,25 @@
                     </template>
                   </div>
                 </template>
+              </div>
+            </template>
+
+            <!-- Your review: your WHY (the note) + your verdict -->
+            <div style="margin-top:.5rem; display:flex; gap:.4rem; align-items:center; flex-wrap:wrap;">
+              <input type="text" maxlength="500" placeholder="why? — your reasoning (optional, the most useful part)"
+                     x-model="$store.genesisVoice.attentionNotes[ev.id]"
+                     style="flex:1; min-width:200px; padding:.3rem .5rem; font-size:.78rem; background:var(--color-panel); border:1px solid var(--color-border); color:var(--color-text); border-radius:4px;">
+              <button class="btn-sm" style="padding:.15rem .5rem;" title="Worth being aware of / remembering" :disabled="$store.genesisVoice.attentionLabeling[ev.id] === true"
+                      @click="$store.genesisVoice.labelAttentionEvent(ev.id, 'should')">Worth noticing</button>
+              <button class="btn-sm" style="padding:.15rem .5rem;" title="Noise — not worth a glance" :disabled="$store.genesisVoice.attentionLabeling[ev.id] === true"
+                      @click="$store.genesisVoice.labelAttentionEvent(ev.id, 'shouldnt')">Not worth it</button>
+              <button class="btn-sm" style="padding:.15rem .5rem; opacity:.7;" title="Can't tell — too garbled to judge" :disabled="$store.genesisVoice.attentionLabeling[ev.id] === true"
+                      @click="$store.genesisVoice.labelAttentionEvent(ev.id, 'skip')">Skip</button>
+            </div>
+            <!-- Previously stored note (survives across reviews) -->
+            <template x-if="ev.acceptance_note">
+              <div style="margin-top:.35rem; font-size:.72rem; color:var(--color-text-secondary);">
+                <span style="opacity:.7;">your note:</span> <span x-text="ev.acceptance_note"></span>
               </div>
             </template>
           </div>

--- a/src/genesis/db/crud/attention.py
+++ b/src/genesis/db/crud/attention.py
@@ -123,10 +123,18 @@ async def list_events(
     return [dict(r) for r in await cursor.fetchall()]
 
 
+_NOTE_UNSET = object()  # sentinel: distinguishes "note not provided" from "note set to None (clear)"
+
+
 async def update_acceptance_signal(
-    db: aiosqlite.Connection, event_id: str, signal: str,
+    db: aiosqlite.Connection, event_id: str, signal: str, note=_NOTE_UNSET,
 ) -> tuple[bool, str | None]:
-    """Write a review label. Returns ``(found, prior_signal)`` so the UI can show X->Y.
+    """Write a review label (+ an optional reviewer note). Returns ``(found, prior_signal)``
+    so the UI can show X->Y.
+
+    ``note`` is the reviewer's own one-line WHY — the reasoning that the perk decision is an
+    LLM judgment makes the point of the review (PR3d). It is SENTINEL-defaulted: omitted →
+    the existing note is preserved; passed (a string, or ``None`` to clear) → it is written.
 
     Raises ``ValueError`` for a signal outside ``LABELS`` (route maps it to 400)."""
     if signal not in LABELS:
@@ -138,9 +146,15 @@ async def update_acceptance_signal(
     if row is None:
         return (False, None)
     prior = row["acceptance_signal"]
-    await db.execute(
-        "UPDATE attention_events SET acceptance_signal = ? WHERE id = ?", (signal, event_id)
-    )
+    if note is _NOTE_UNSET:
+        await db.execute(
+            "UPDATE attention_events SET acceptance_signal = ? WHERE id = ?", (signal, event_id)
+        )
+    else:
+        await db.execute(
+            "UPDATE attention_events SET acceptance_signal = ?, acceptance_note = ? WHERE id = ?",
+            (signal, note, event_id),
+        )
     await db.commit()
     return (True, prior)
 

--- a/src/genesis/db/migrations/0045_attention_acceptance_note.py
+++ b/src/genesis/db/migrations/0045_attention_acceptance_note.py
@@ -1,0 +1,28 @@
+"""Add ``attention_events.acceptance_note`` — the reviewer's optional one-line WHY.
+
+The attention shadow-review shifts from *labeling to tune trigger weights* (retired: the
+perk decision is an LLM judgment, not a tunable gate) to *reviewing the L1.5 judge*. The
+reviewer's REASONING — why a moment was or wasn't worth attention — is the point of that
+review, so a labeled row can now carry a short free-text note beside its should/shouldnt/skip.
+
+The runner NEVER writes this column (it is deliberately kept out of ``crud.attention.COLUMNS``,
+so the label-preserving upsert can't touch it — human input protected by construction, like
+``acceptance_signal``). Fresh/test DBs get it from the canonical CREATE TABLE in
+``db/schema/_tables.py``; this numbered migration covers the existing-DB upgrade path.
+Idempotent: PRAGMA-guarded ADD COLUMN. No commit — the runner owns the transaction.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='attention_events'"
+    )
+    if await cursor.fetchone():
+        col_cursor = await db.execute("PRAGMA table_info(attention_events)")
+        cols = {row[1] for row in await col_cursor.fetchall()}
+        if "acceptance_note" not in cols:
+            await db.execute("ALTER TABLE attention_events ADD COLUMN acceptance_note TEXT")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -51,8 +51,9 @@ TABLES = {
             window_ref        TEXT NOT NULL,               -- JSON {snapshot_id,session_id,utt_ids,ts_start,ts_end} — REFS ONLY
             mode_state        TEXT,
             clarity           REAL,
-            l15_verdict       TEXT,                        -- JSON {real,perk}; NULL in v1 (L1.5 stubbed)
+            l15_verdict       TEXT,                        -- JSON {real,perk,category,reason,...}; the judge's verdict (PR3d)
             acceptance_signal TEXT,                        -- should|shouldnt|skip; back-filled at shadow review (PR2)
+            acceptance_note   TEXT,                        -- reviewer's optional one-line WHY (PR3d); their reasoning, not the judge's
             snapshot_id       TEXT,
             config_version    TEXT,
             created_at        TEXT NOT NULL

--- a/tests/test_dashboard/test_attention_api.py
+++ b/tests/test_dashboard/test_attention_api.py
@@ -58,6 +58,7 @@ def _evrow(**over):
         }),
         "l15_verdict": None,
         "acceptance_signal": None,
+        "acceptance_note": None,
         "snapshot_id": "20260701T013412Z",
         "config_version": "0.1.0-default",
         "created_at": "2026-07-01T00:00:04+00:00",
@@ -205,6 +206,82 @@ def test_label_ok_returns_prior(client):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data == {"status": "ok", "id": "evt-1", "acceptance_signal": "shouldnt", "prior": "should"}
+
+
+def test_label_forwards_stripped_note_to_crud(client):
+    upd = AsyncMock(return_value=(True, None))
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.update_acceptance_signal", new=upd),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/attention/evt-1/label",
+                           json={"acceptance_signal": "shouldnt", "acceptance_note": "  self-answerable  "})
+    assert resp.status_code == 200
+    _, kwargs = upd.call_args
+    assert kwargs.get("note") == "self-answerable"                  # stripped before store
+    assert resp.get_json()["acceptance_note"] == "self-answerable"  # echoed back
+
+
+def test_label_without_note_omits_note_kwarg(client):
+    # No note in the body → the crud call omits `note` (sentinel) so an existing note survives.
+    upd = AsyncMock(return_value=(True, None))
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.update_acceptance_signal", new=upd),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/attention/evt-1/label", json={"acceptance_signal": "should"})
+    assert resp.status_code == 200
+    _, kwargs = upd.call_args
+    assert "note" not in kwargs
+
+
+def test_label_rejects_non_string_note(client):
+    # A non-string, non-null acceptance_note (e.g. a number) must 400, not silently clear the note.
+    upd = AsyncMock(return_value=(True, None))
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.update_acceptance_signal", new=upd),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/attention/evt-1/label",
+                           json={"acceptance_signal": "should", "acceptance_note": 42})
+    assert resp.status_code == 400
+    assert upd.call_count == 0  # never reached the crud layer
+
+
+def test_label_null_note_clears(client):
+    # Explicit null note → crud receives note=None (clear).
+    upd = AsyncMock(return_value=(True, None))
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.update_acceptance_signal", new=upd),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.post("/api/genesis/attention/evt-1/label",
+                           json={"acceptance_signal": "should", "acceptance_note": None})
+    assert resp.status_code == 200
+    _, kwargs = upd.call_args
+    assert kwargs.get("note") is None and "note" in kwargs
+
+
+def test_list_surfaces_verdict_and_note(client):
+    row = _evrow(
+        l15_verdict=json.dumps({"real": 0.9, "perk": 0.8, "category": "question",
+                                "reason": "a scheduling question", "prompt_version": "v2"}),
+        acceptance_note="declined — I was mid-task",
+    )
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.db.crud.attention.list_events", new=AsyncMock(return_value=[row])),
+    ):
+        MockRT.instance.return_value = _mock_rt()
+        resp = client.get("/api/genesis/attention/list")
+    ev = resp.get_json()["events"][0]
+    assert ev["l15_verdict"]["category"] == "question"
+    assert ev["l15_verdict"]["reason"] == "a scheduling question"
+    assert ev["acceptance_note"] == "declined — I was mid-task"
 
 
 def test_label_400_on_invalid_signal(client):

--- a/tests/test_db/test_crud_attention.py
+++ b/tests/test_db/test_crud_attention.py
@@ -276,3 +276,39 @@ async def test_bulk_update_l15_verdicts_empty_is_noop(tmp_path):
     db = await _db(tmp_path / "g.db")
     assert await crud.bulk_update_l15_verdicts(db, []) == 0
     await db.close()
+
+
+@pytest.mark.asyncio
+async def test_label_with_note_persists_reviewer_reasoning(tmp_path):
+    """PR3d: the reviewer's WHY is the point of the review loop — a label can carry a note."""
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [_row(1)])
+    ok, prior = await crud.update_acceptance_signal(
+        db, "id-1", "shouldnt", note="trivial + self-answerable; didn't want interrupting"
+    )
+    assert ok and prior is None
+    ev = await crud.get_event(db, "id-1")
+    assert ev["acceptance_signal"] == "shouldnt"
+    assert ev["acceptance_note"] == "trivial + self-answerable; didn't want interrupting"
+
+
+@pytest.mark.asyncio
+async def test_relabel_without_note_leaves_existing_note_untouched(tmp_path):
+    """Omitting the note (sentinel) must PRESERVE a prior note — only an explicit value changes it."""
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [_row(1)])
+    await crud.update_acceptance_signal(db, "id-1", "should", note="original reasoning")
+    await crud.update_acceptance_signal(db, "id-1", "shouldnt")          # no note arg
+    ev = await crud.get_event(db, "id-1")
+    assert ev["acceptance_signal"] == "shouldnt"
+    assert ev["acceptance_note"] == "original reasoning"                 # preserved
+
+
+@pytest.mark.asyncio
+async def test_label_note_can_be_explicitly_cleared(tmp_path):
+    db = await _db(tmp_path / "g.db")
+    await crud.bulk_upsert_events(db, [_row(1)])
+    await crud.update_acceptance_signal(db, "id-1", "should", note="x")
+    await crud.update_acceptance_signal(db, "id-1", "should", note=None)  # explicit clear
+    assert (await crud.get_event(db, "id-1"))["acceptance_note"] is None
+    await db.close()

--- a/tests/test_db/test_migration_0045_attention_acceptance_note.py
+++ b/tests/test_db/test_migration_0045_attention_acceptance_note.py
@@ -1,0 +1,58 @@
+"""Migration 0045 — add attention_events.acceptance_note (reviewer's optional WHY).
+
+Verifies the column is added to a pre-existing table, the add is idempotent (fresh DBs
+already have it from _tables.py), and a missing table is a safe no-op.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M45 = importlib.import_module("genesis.db.migrations.0045_attention_acceptance_note")
+
+# A minimal PRE-0045 attention_events (no acceptance_note) — the existing-DB upgrade path.
+_OLD_DDL = """
+    CREATE TABLE attention_events (
+        id TEXT PRIMARY KEY, ts TEXT NOT NULL, session_id TEXT NOT NULL,
+        activation TEXT NOT NULL, score REAL NOT NULL, triggers_fired TEXT NOT NULL DEFAULT '[]',
+        suppressors TEXT NOT NULL DEFAULT '[]', window_ref TEXT NOT NULL, mode_state TEXT,
+        clarity REAL, l15_verdict TEXT, acceptance_signal TEXT, snapshot_id TEXT,
+        config_version TEXT, created_at TEXT NOT NULL
+    )
+"""
+
+
+async def _columns(db: aiosqlite.Connection) -> set[str]:
+    cur = await db.execute("PRAGMA table_info(attention_events)")
+    return {row[1] for row in await cur.fetchall()}
+
+
+@pytest.mark.asyncio
+async def test_up_adds_note_column_to_existing_table(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_OLD_DDL)
+        assert "acceptance_note" not in await _columns(db)
+        await M45.up(db)
+        assert "acceptance_note" in await _columns(db)
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_OLD_DDL)
+        await M45.up(db)
+        await M45.up(db)  # second run must NOT raise "duplicate column"
+        assert "acceptance_note" in await _columns(db)
+
+
+@pytest.mark.asyncio
+async def test_up_noop_when_table_absent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M45.up(db)  # no attention_events table — must be a safe no-op
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='attention_events'"
+        )
+        assert await cur.fetchone() is None


### PR DESCRIPTION
## Why

Companion to #860. The attention sub-tab was "Calibration" — label fires so we could tune trigger weights. That's retired: the perk-up decision is an **LLM judgment**, not a tunable gate. This reframes the tab into **Judgment**: your job is to *review the L1.5 judge* — see its verdict + reasoning, record your own take, and (most usefully) **why**. Reviews inform the judge's **prompt**, never the weights.

## What

**Backend**
- New column `attention_events.acceptance_note` — the reviewer's free-text WHY (migration `0045`, PRAGMA-guarded/idempotent, + `_tables.py` DDL). Deliberately kept **out of** crud `COLUMNS` so the offline runner can never write it — human input protected by construction, like `acceptance_signal`.
- `update_acceptance_signal(..., note=<sentinel>)`: omit → prior note preserved; pass a string → set; pass `null` → clear.
- `/label` route accepts + strips/caps (500) `acceptance_note`, **rejects non-string/non-null with 400** (no silent clear), and echoes what it wrote. `_event_summary` now surfaces `l15_verdict` (already parsed) + `acceptance_note`.

**Frontend (`genesis_voice.html`)**
- Each event shows the judge's verdict: **category** chip, **real/perk**, the **reason** sentence, and which model judged. Un-judged rows prompt to run `--l15`.
- A **note input** beside the verdict buttons captures the reviewer's reasoning (sent with the label; empty → omitted so a prior note survives); the stored note is shown back.
- Header reframed to the review framing (attention ≠ interruption; a "not worth it" is not a verdict on the trigger — your reasoning lives in the note).
- Lightweight **client-side glances over the shown events only**: judged count, judge category split, and judge mean-perk by your call — explicitly a glance, never an optimization target.

## Tests

98 passed (crud note persist/preserve/clear; route note-forwarding + 400-on-junk + verdict/note in payload; migration `0045` add/idempotent/absent-table). Code-review-caught fixes folded in (reject non-string note; fixture fidelity).

**Independent of #860** — displays whatever verdict JSON exists (2-field or v2). Both compose at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)