### PR TITLE
fix(deps): raise aiohttp floor to >=3.14.1 (fixes 11 CVEs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   hard-coded addresses) — closing a gap where these install-specific addresses could otherwise slip
   into a public PR. The commit-message guard gained the same IPv6 coverage.
 
+- **The HTTP client Genesis uses for outbound requests is upgraded to clear 11 security advisories.**
+  `aiohttp` — the library behind health checks, provider pings, and market/price-data fetches — now
+  requires 3.14.1 or newer, which fixes 11 published CVEs (including a cookie-leak-on-redirect issue
+  and several denial-of-service vectors). Genesis uses it only as a client for outbound calls, so
+  real-world exposure was limited, but the newer version removes the advisories outright.
+
 ### Added
 
 - **The dashboard's container-health badge now tells the truth about CPU and memory pressure.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ version = "3.0.0b16"
 requires-python = ">=3.12"
 dependencies = [
     "aiosqlite",
-    "aiohttp<3.14",  # 3.14 adds required stream_writer kwarg to ClientResponse; aioresponses 0.7.8 doesn't pass it
+    "aiohttp>=3.14.1",  # security floor — 3.14.1 fixes 11 advisories (cookie leak on redirect, several DoS,
+                       # multipart header injection). Genesis is client-only; the aioresponses/ClientResponse
+                       # stream_writer-kwarg mismatch is absorbed by the tests/test_observability/conftest.py shim.
     "apscheduler>=3.11,<4",
     "tzlocal>=5",  # transitive dep of apscheduler (ego/cadence uses the local-timezone path); declare so a clean/cached install can't drop it
     "python-telegram-bot>=21.0",

--- a/tests/test_observability/conftest.py
+++ b/tests/test_observability/conftest.py
@@ -11,11 +11,16 @@ from aioresponses import aioresponses
 def _patch_client_response_init():
     """Patch ClientResponse.__init__ to accept stream_writer / writer kwargs.
 
-    Older aioresponses (<0.7.7) constructs ClientResponse without the
-    ``stream_writer`` (aiohttp >=3.10) or ``writer`` (aiohttp >=3.12) kwarg
-    that newer aiohttp versions require.  This shim silently absorbs
-    whichever variant the library passes and supplies a MagicMock default
-    when it is missing so the mock response can be created.
+    aioresponses (through its latest release, 0.7.9) constructs ClientResponse
+    without the ``stream_writer`` (aiohttp >=3.10) / ``writer`` (aiohttp >=3.12)
+    keyword-only arg that current aiohttp requires — so a bare ``aioresponses``
+    mock raises ``TypeError: ClientResponse.__init__() missing ... 'stream_writer'``
+    under aiohttp >=3.14.  This shim silently absorbs whichever variant the
+    library passes and supplies a MagicMock default when it is missing, so the
+    mock response can be created.  It is what lets the runtime dep stay on
+    aiohttp >=3.14.1 (which fixes 11 advisories) while still mocking with
+    aioresponses in tests — do not remove it until aioresponses ships native
+    aiohttp 3.14 support.
     """
     original_init = aiohttp.ClientResponse.__init__
 


### PR DESCRIPTION
## What
Raise the `aiohttp` floor from `<3.14` to `>=3.14.1`, closing 11 published CVEs in the HTTP client library Genesis uses for outbound requests.

## Why
A `pip-audit` run against the installed dependency tree flagged 11 aiohttp advisories — all fixed in 3.14.0/3.14.1 (cookie-leak on cross-origin redirect, several DoS vectors, multipart header injection). The prior `aiohttp<3.14` pin existed **only** because `aioresponses` (the test HTTP mock) can't construct `aiohttp.ClientResponse` on aiohttp ≥3.14 — it omits the now-required `stream_writer` kwarg. But `tests/test_observability/conftest.py` already carries a shim that absorbs that mismatch, so the pin was unnecessary and lifting it costs nothing.

## Scope / safety
- Genesis uses aiohttp **client-only** across 9 modules (simple `ClientSession(timeout=)` + `session.get()`). No `aiohttp.web` server, no `CookieJar`, no `MultipartWriter`, no `DigestAuth`, no per-request `cookies=`, no direct `ClientResponse` construction — so none of 3.14's breaking changes apply, and the two cookie CVEs are not reachable.
- `pyproject.toml` is the sole dependency source; nothing else caps aiohttp.

## Verification
- Isolated venv resolves cleanly to aiohttp 3.14.1 / aioresponses 0.7.9; `pip check` clean.
- **190 aiohttp-touching tests pass** on 3.14.1 (including `test_health.py`, which exercises the shim fixture).
- ruff clean; code-reviewed with no findings.

First of two PRs from the WS-G dependency-audit work; the pip-audit CI job follows separately.
