### PR TITLE
ci(deps): add pip-audit dependency-CVE gate + Actions dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Dependabot config — GitHub Actions version updates only.
+#
+# The pip ecosystem is intentionally NOT managed here: Genesis's runtime deps
+# carry deliberate security pins (litellm pinned <1.83 to dodge 1.82.x malware,
+# fastmcp <3 for API stability, transitive secure floors) that automatic
+# version-update PRs would fight. GitHub's Dependabot *security* alerts are
+# already enabled for the repo and cover the pip CVE side; the pip-audit CI job
+# gates the resolved tree per-PR. So dependabot only keeps the Actions current.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"  # weekly Mon 06:00 UTC — surface new CVEs even without repo activity
 
 permissions:
   contents: read
@@ -22,6 +24,42 @@ jobs:
         run: pip install ruff
       - name: Lint
         run: ruff check src/ tests/ scripts/
+
+  dependency-audit:
+    # Fail on any KNOWN-vulnerable dependency in the resolved runtime tree,
+    # except the triaged IDs below. A red run is a SIGNAL to bump the dep or
+    # add a triaged ignore — not a hard freeze (the ruleset has no required
+    # checks). Complements GitHub's already-enabled Dependabot security alerts.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install runtime deps + pip-audit
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pip-audit
+      - name: Audit dependencies for known CVEs
+        run: |
+          # Triaged --ignore-vuln IDs (rationale of record: pyproject.toml pins).
+          # A NEW / untriaged advisory is NOT in this list and so fails the job.
+          #   litellm 1.78.7 — every ID is a proxy-server / JWT / OIDC / UI vuln;
+          #     Genesis uses acompletion/completion_cost only (no proxy server),
+          #     so none are reachable. Pinned <1.83 also dodges 1.82.x malware.
+          #   diskcache 5.6.3 (CVE-2025-69872) — pickle-by-default RCE, no fixed
+          #     release. Genesis's only diskcache use (memory/embeddings.py) is a
+          #     JSON-only _SafeDisk subclass, so the vulnerable pickle path is unused.
+          pip-audit \
+            --ignore-vuln PYSEC-2026-390 \
+            --ignore-vuln PYSEC-2026-388 \
+            --ignore-vuln CVE-2026-35029 \
+            --ignore-vuln GHSA-69x8-hrgq-fjj8 \
+            --ignore-vuln CVE-2026-42271 \
+            --ignore-vuln CVE-2026-47102 \
+            --ignore-vuln CVE-2026-47101 \
+            --ignore-vuln CVE-2025-69872
 
   leak-detector:
     # Verify no user-specific content (IPs, timezones, personal paths, secrets)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -156,12 +156,20 @@ The guard:
 
 ### Dependency Security
 
-```bash
-# Check Python dependencies for known vulnerabilities
-pip-audit
+Python dependencies are declared in `pyproject.toml` (the sole dependency
+source — there is no `requirements.txt`). Known-CVE scanning runs automatically:
 
-# Review and update regularly
-pip install --upgrade -r requirements.txt
+- **CI** — the `dependency-audit` job in `.github/workflows/ci.yml` runs
+  `pip-audit` against the resolved runtime tree on every PR/push and weekly,
+  failing on any new (untriaged) advisory. Already-triaged, not-reachable
+  advisories are listed with rationale in that job.
+- **Dependabot** — GitHub's dependency-graph security alerts are enabled for
+  the repo, and `.github/dependabot.yml` keeps the GitHub Actions current.
+
+To scan locally:
+
+```bash
+pip install pip-audit && pip-audit
 ```
 
 ### Incident Response

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,9 @@ dependencies = [
     "apscheduler>=3.11,<4",
     "tzlocal>=5",  # transitive dep of apscheduler (ego/cadence uses the local-timezone path); declare so a clean/cached install can't drop it
     "python-telegram-bot>=21.0",
-    "litellm==1.78.7",  # pinned — 1.82.7/1.82.8 contain malware; CVE-2026-35030/35029 not exploitable
-                       # (Genesis uses acompletion/completion_cost only, no proxy server or OIDC)
+    "litellm==1.78.7",  # pinned — 1.82.7/1.82.8 contain malware. Its open advisories are all
+                       # proxy-server / JWT / OIDC / UI vulns (see the ci.yml dependency-audit
+                       # ignore-list); not reachable — Genesis uses acompletion/completion_cost only.
     "qdrant-client",
     "pyyaml",
     "httpx",
@@ -22,8 +23,9 @@ dependencies = [
     "flask>=3.0",
     "flask-sock>=0.7",
     "wsproto>=1.2",  # transitive dep of flask-sock; pin to prevent silent uninstall
-    "fastmcp>=2.0,<3.0",  # 3.x has breaking API changes; CVE-2026-32871/27124/2025-64340 not exploitable
-                         # (Genesis uses stdio transport only, no OpenAPI/OAuth/CLI features)
+    "fastmcp>=2.0,<3.0",  # <3 for API stability (3.x breaks the API). Genesis uses fastmcp stdio
+                         # transport only (no OpenAPIProvider/OAuthProxy), so its OpenAPI/OAuth CVEs
+                         # (CVE-2026-32871/27124/2025-64340, unfixed pre-3.2.0) are not reachable.
     "detect-secrets>=1.4",  # Phase 6 contribution sanitizer — REQUIRED floor. sanitize.py fails closed if missing.
     "pymupdf>=1.27",  # PDF text extraction for knowledge ingestion pipeline
     "scrapling>=0.4.7",  # Web fetching with TLS fingerprint impersonation


### PR DESCRIPTION
## What
Adds a `dependency-audit` CI job (`pip-audit` on the resolved runtime tree) + a github-actions-scoped `.github/dependabot.yml`, and fixes stale dependency docs. Second of two PRs from the WS-G dependency-audit work — #862 bumped aiohttp first, eliminating 11 CVEs.

## The job
- Runs on every PR/push + a weekly `schedule:`. Steps: `pip install -e .` (shipped runtime surface) → `pip-audit --ignore-vuln <8 triaged IDs>`.
- **Blocking = signal, not a hard freeze** (the ruleset has no required checks). A red run means "bump the dep or add a triaged ignore." Complements the already-enabled Dependabot security alerts.
- A NEW / untriaged advisory is not in the ignore-list and so fails the job.

## The 8 ignored IDs (all triaged, inline rationale in the job)
- **litellm ×7** (PYSEC-2026-390/388, CVE-2026-35029/42271/47102/47101, GHSA-69x8-hrgq-fjj8) — every one is a proxy-server / JWT / OIDC / UI vuln. Genesis uses `acompletion`/`completion_cost` only (no litellm proxy), so none are reachable.
- **diskcache ×1** (CVE-2025-69872) — pickle-by-default RCE, no upstream fix. Genesis's only diskcache use is a JSON-only `_SafeDisk` subclass (`memory/embeddings.py`), so the vulnerable pickle path is never exercised.

## dependabot.yml — github-actions only
The pip ecosystem is deliberately omitted: the runtime deps carry intentional security pins (litellm malware-dodge, fastmcp<3, transitive floors) that version-update PRs would fight, and GitHub's Dependabot *security* alerts (already enabled on the repo) cover the pip CVE side.

## Docs
- `SECURITY.md`: the "Dependency Security" section referenced a nonexistent `requirements.txt` — corrected to `pyproject.toml` + the new automated scanning.
- `pyproject.toml`: corrected the litellm (7 not-reachable proxy CVEs) and fastmcp (OpenAPI/OAuth CVEs, unfixed pre-3.2.0, not reachable via stdio-only usage) pin comments.

## Verification
`pip-audit --ignore-vuln <8>` → "No known vulnerabilities found, 8 ignored" (rc 0) on the current post-aiohttp-bump tree. YAML validated; no `github.event.*` in any `run:` block; code-reviewed (one finding — an inaccurate fastmcp comment — found and fixed).
