### PR TITLE
fix(cc): isolate background session CC sandbox from cc-tmp

### DIFF
--- a/scripts/disk_hygiene.sh
+++ b/scripts/disk_hygiene.sh
@@ -33,4 +33,16 @@ echo "--- worktree reaping ---"
 echo "--- cache reclamation ---"
 "$VENV_PY" "$REPO_DIR/scripts/disk_reclaim.py" --apply --if-above 90 || echo "disk_reclaim exited $?"
 
+# Reap orphaned per-session background-CC sandboxes (~/tmp/bg-cc-sessions/<id>).
+# direct_session._run_session removes these in a finally on normal completion;
+# this catches orphans left when a session is hard-SIGKILLed (skips finally).
+# 24h is well past any live session: the Genesis-controlled max timeout is
+# 7200s/2h (CCInvocation.timeout_s); DirectSessionRequest defaults to 3600s/1h.
+echo "--- background CC sandbox reaping ---"
+BG_CC_SANDBOX_DIR="$HOME/tmp/bg-cc-sessions"
+if [ -d "$BG_CC_SANDBOX_DIR" ]; then
+    find "$BG_CC_SANDBOX_DIR" -mindepth 1 -maxdepth 1 -type d -mmin +1440 \
+        -exec rm -rf {} + 2>/dev/null || echo "bg-cc-sandbox reap exited $?"
+fi
+
 echo "=== genesis-disk-hygiene done ==="

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -23,9 +23,11 @@ import asyncio
 import contextlib
 import json
 import logging
+import shutil
 import sys
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from genesis.cc import roster
@@ -48,6 +50,36 @@ if TYPE_CHECKING:
     from genesis.cc.session_manager import SessionManager
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Per-session CC Bash-sandbox isolation (background dispatch sessions)
+# ---------------------------------------------------------------------------
+# By default a background session's CC Bash sandbox (CLAUDE_CODE_TMPDIR) lives in
+# the shared, watchgod-policed ~/.genesis/cc-tmp. Giving each session its OWN
+# sandbox under ~/tmp (OFF cc-tmp) means (a) its scratch can't be clipped by
+# tmp_watchgod's RED nuclear-cleanup mid-run, and (b) it stops contributing to
+# cc-tmp pressure that could trip cleanup of foreground CLI sessions. Mirrors the
+# gauntlet (eval/gauntlet.py). This overrides CLAUDE_CODE_TMPDIR — the CC-specific
+# per-invocation sandbox var — NOT the shell TMPDIR, which the `tmp_filesystem_limit`
+# procedure correctly says never to override globally. (It does NOT prevent a
+# "kill": background sessions are asyncio subprocesses, not tmux sessions, so
+# watchgod's tmux-kill can't reach them anyway — do not claim otherwise.)
+_BG_CC_TMP_ROOT = Path.home() / "tmp" / "bg-cc-sessions"
+
+
+def _bg_session_root(session_id: str) -> Path:
+    """Per-session root dir for a background CC session's isolated sandbox."""
+    return _BG_CC_TMP_ROOT / session_id
+
+
+def _bg_session_sandbox(session_id: str) -> str:
+    """Return this session's CLAUDE_CODE_TMPDIR path (off cc-tmp).
+
+    Pure — the caller (_run_session) creates the directory just before the
+    session runs, so building an invocation has no filesystem side effect.
+    """
+    return str(_bg_session_root(session_id) / "cc-sandbox")
 
 
 # ---------------------------------------------------------------------------
@@ -666,7 +698,16 @@ class DirectSessionRunner:
 
         try:
             async with self._semaphore:
-                invocation = self._build_invocation(request)
+                invocation = self._build_invocation(request, session_id)
+                # Create this session's isolated CC sandbox (off cc-tmp) just
+                # before the run; removed in the finally below. The guard is
+                # intentional: if claude_code_tmpdir is unset (tests, or any
+                # future non-isolated path), CC falls back to the shared cc-tmp
+                # (the old behaviour) rather than this crashing.
+                if invocation.claude_code_tmpdir:
+                    Path(invocation.claude_code_tmpdir).mkdir(
+                        parents=True, exist_ok=True,
+                    )
                 output: CCOutput = await self._invoker.run_streaming(
                     invocation, on_event=on_event,
                 )
@@ -789,6 +830,12 @@ class DirectSessionRunner:
                 session_id[:8], elapsed, exc,
             )
             raise
+
+        finally:
+            # Remove this session's isolated CC sandbox (created off cc-tmp just
+            # before the run above). Best-effort; the disk-hygiene reaper catches
+            # any orphans left by a hard SIGKILL that skips this finally.
+            shutil.rmtree(_bg_session_root(session_id), ignore_errors=True)
 
     async def _record_proposal_outcome(
         self,
@@ -938,7 +985,9 @@ class DirectSessionRunner:
         except Exception:
             logger.debug("Failed to send dispatch debrief", exc_info=True)
 
-    def _build_invocation(self, request: DirectSessionRequest) -> CCInvocation:
+    def _build_invocation(
+        self, request: DirectSessionRequest, session_id: str,
+    ) -> CCInvocation:
         system_prompt = request.system_prompt
         if system_prompt is None:
             # Use the surplus config's system prompt (which loads SOUL.md)
@@ -1031,6 +1080,7 @@ class DirectSessionRunner:
             skip_permissions=True,
             disallowed_tools=disallowed,
             working_dir=background_session_dir(),
+            claude_code_tmpdir=_bg_session_sandbox(session_id),
             mcp_config=mcp_config,
             bash_allowlist=_PROFILE_BASH_ALLOWLIST.get(request.profile, ()),
             roster_eligible=roster_eligible,
@@ -1070,8 +1120,6 @@ class DirectSessionRunner:
         # .replace("/", "-") leaves the dot and yields a wrong path.
         transcript_path = ""
         if result.cc_session_id:
-            from pathlib import Path
-
             project_key = cc_project_key(background_session_dir())
             transcript_path = str(
                 Path.home() / ".claude" / "projects"

--- a/tests/test_cc/test_direct_session.py
+++ b/tests/test_cc/test_direct_session.py
@@ -200,7 +200,7 @@ class TestBackgroundFallbackRecovery:
             invoker=invoker, session_manager=sm, config_builder=AsyncMock(),
             runtime=SimpleNamespace(_db=db),
         )
-        runner._build_invocation = lambda _req: CCInvocation(prompt="x")
+        runner._build_invocation = lambda _req, _sid: CCInvocation(prompt="x")
         sess = await sm.create_background(
             session_type=SessionType.BACKGROUND_TASK,
             model=CCModel.SONNET, effort=EffortLevel.MEDIUM,
@@ -233,3 +233,56 @@ class TestBackgroundFallbackRecovery:
         # succeeds but must NOT clear the glm fallback (Claude is ~always up).
         state = await self._run(db, tmp_path, monkeypatch, home="glm-5.2", roster_model="claude")
         assert state.is_fallback is True
+
+
+@pytest.mark.asyncio
+async def test_run_session_isolates_and_cleans_sandbox(db, tmp_path, monkeypatch):
+    """E2E lifecycle: _run_session creates the per-session CC sandbox OFF the
+    watchgod-policed cc-tmp BEFORE invoking CC, and removes it in the finally
+    afterward. The stub run_streaming asserts the dir exists at invocation time,
+    proving the mkdir-before-run ordering; the post-return check proves cleanup.
+    """
+    from pathlib import Path
+    from types import SimpleNamespace
+
+    from genesis.cc.direct_session import _bg_session_root, _bg_session_sandbox
+    from genesis.cc.types import CCInvocation, CCModel, CCOutput, EffortLevel, SessionType
+
+    monkeypatch.setenv("GENESIS_HOME", str(tmp_path))
+    captured: dict = {}
+
+    async def _check_sandbox_live(inv, on_event=None):
+        # Called by _run_session — the sandbox must already exist here.
+        p = Path(inv.claude_code_tmpdir)
+        captured["existed_at_run"] = p.exists()
+        captured["path"] = str(p)
+        return CCOutput(
+            session_id="cc-bg", text="done", model_used="sonnet",
+            cost_usd=0.0, input_tokens=1, output_tokens=1, duration_ms=1,
+            exit_code=0, is_error=False, roster_model=None,
+        )
+
+    sm = SessionManager(db=db, invoker=AsyncMock(), day_boundary_hour=0)
+    invoker = AsyncMock()
+    invoker.run_streaming = _check_sandbox_live
+    runner = DirectSessionRunner(
+        invoker=invoker, session_manager=sm, config_builder=AsyncMock(),
+        runtime=SimpleNamespace(_db=db),
+    )
+    # Mirror the real _build_invocation: wire the per-session sandbox tmpdir.
+    runner._build_invocation = lambda _req, sid: CCInvocation(
+        prompt="x", claude_code_tmpdir=_bg_session_sandbox(sid),
+    )
+    sess = await sm.create_background(
+        session_type=SessionType.BACKGROUND_TASK,
+        model=CCModel.SONNET, effort=EffortLevel.MEDIUM,
+    )
+    result = await runner._run_session(DirectSessionRequest(prompt="t"), sess["id"])
+
+    assert result.success is True
+    # mkdir ran before the CC invocation, in a dir OFF cc-tmp
+    assert captured["existed_at_run"] is True
+    assert ".genesis/cc-tmp" not in captured["path"]
+    assert "bg-cc-sessions" in captured["path"]
+    # finally cleanup removed the whole per-session tree
+    assert not _bg_session_root(sess["id"]).exists()

--- a/tests/test_cc/test_direct_session_profiles.py
+++ b/tests/test_cc/test_direct_session_profiles.py
@@ -10,12 +10,15 @@ from unittest.mock import MagicMock
 import pytest
 
 from genesis.cc.direct_session import (
+    _BG_CC_TMP_ROOT,
     _PROFILE_ADDENDA,
     PROFILES,
     VALID_PROFILES,
     DirectSessionRequest,
     DirectSessionRunner,
     ProfileOverlayContext,
+    _bg_session_root,
+    _bg_session_sandbox,
     _build_profile_addendum,
 )
 from genesis.cc.types import CCModel
@@ -255,7 +258,7 @@ def test_interact_profile_upgrades_model_to_opus():
     """Interact sessions must always use Opus regardless of requested model."""
     runner = _make_runner()
     req = DirectSessionRequest(prompt="test", profile="interact", model=CCModel.SONNET)
-    inv = runner._build_invocation(req)
+    inv = runner._build_invocation(req, "test-session")
     assert inv.model == CCModel.OPUS
 
 
@@ -263,7 +266,7 @@ def test_interact_profile_keeps_opus_when_already_opus():
     """Opus request + interact should stay Opus (idempotent)."""
     runner = _make_runner()
     req = DirectSessionRequest(prompt="test", profile="interact", model=CCModel.OPUS)
-    inv = runner._build_invocation(req)
+    inv = runner._build_invocation(req, "test-session")
     assert inv.model == CCModel.OPUS
 
 
@@ -271,7 +274,7 @@ def test_research_profile_does_not_upgrade_model():
     """Non-interact profiles must NOT override the requested model."""
     runner = _make_runner()
     req = DirectSessionRequest(prompt="test", profile="research", model=CCModel.SONNET)
-    inv = runner._build_invocation(req)
+    inv = runner._build_invocation(req, "test-session")
     assert inv.model == CCModel.SONNET
 
 
@@ -279,7 +282,7 @@ def test_observe_profile_does_not_upgrade_model():
     """Observe profile must NOT override the requested model."""
     runner = _make_runner()
     req = DirectSessionRequest(prompt="test", profile="observe", model=CCModel.HAIKU)
-    inv = runner._build_invocation(req)
+    inv = runner._build_invocation(req, "test-session")
     assert inv.model == CCModel.HAIKU
 
 
@@ -310,7 +313,7 @@ def test_roster_model_routes_to_peer(monkeypatch):
     monkeypatch.setenv("ZHIPU_TEST_KEY", "sk-secret")
     runner = _make_runner()
     req = DirectSessionRequest(prompt="t", profile="observe", roster_model="glm-5.2")
-    inv = runner._build_invocation(req)
+    inv = runner._build_invocation(req, "test-session")
     assert inv.model_id_override == "glm-5.2"
     assert inv.anthropic_base_url == "https://open.bigmodel.cn/api/anthropic"
     assert inv.anthropic_auth_token == "sk-secret"
@@ -322,7 +325,7 @@ def test_roster_model_claude_pins_native(monkeypatch):
     _patch_roster(monkeypatch)
     runner = _make_runner()
     req = DirectSessionRequest(prompt="t", profile="observe", roster_model="claude")
-    inv = runner._build_invocation(req)
+    inv = runner._build_invocation(req, "test-session")
     assert inv.model_id_override is None
     assert inv.anthropic_base_url is None
     # native pin → NOT eligible so the chokepoint can't re-select the global default.
@@ -333,7 +336,7 @@ def test_no_roster_model_uses_chokepoint_default(monkeypatch):
     _patch_roster(monkeypatch)
     runner = _make_runner()
     req = DirectSessionRequest(prompt="t", profile="observe")  # no roster_model
-    inv = runner._build_invocation(req)
+    inv = runner._build_invocation(req, "test-session")
     assert inv.roster_eligible is True  # chokepoint selects at invoke time
     assert inv.model_id_override is None
 
@@ -343,7 +346,7 @@ def test_unknown_roster_model_fails_loud(monkeypatch):
     runner = _make_runner()
     req = DirectSessionRequest(prompt="t", profile="observe", roster_model="nope")
     with pytest.raises(roster.RosterError):
-        runner._build_invocation(req)
+        runner._build_invocation(req, "test-session")
 
 
 def test_keyless_roster_model_fails_loud(monkeypatch):
@@ -352,7 +355,7 @@ def test_keyless_roster_model_fails_loud(monkeypatch):
     runner = _make_runner()
     req = DirectSessionRequest(prompt="t", profile="observe", roster_model="glm-5.2")
     with pytest.raises(roster.RosterError):
-        runner._build_invocation(req)
+        runner._build_invocation(req, "test-session")
 
 
 # --- Mail profile: perimeter session restrictions ---
@@ -420,7 +423,7 @@ def test_mail_addendum_does_not_include_mission_injection():
 def test_mail_profile_does_not_upgrade_model():
     runner = _make_runner()
     req = DirectSessionRequest(prompt="test", profile="mail", model=CCModel.SONNET)
-    inv = runner._build_invocation(req)
+    inv = runner._build_invocation(req, "test-session")
     assert inv.model == CCModel.SONNET
 
 
@@ -465,7 +468,7 @@ def test_steward_addendum_has_mission():
 def test_steward_does_not_upgrade_model():
     runner = _make_runner()
     req = DirectSessionRequest(prompt="test", profile="steward", model=CCModel.SONNET)
-    inv = runner._build_invocation(req)
+    inv = runner._build_invocation(req, "test-session")
     assert inv.model == CCModel.SONNET
 
 
@@ -474,14 +477,14 @@ def test_steward_does_not_upgrade_model():
 def test_steward_invocation_sets_gh_bash_allowlist():
     runner = _make_runner()
     req = DirectSessionRequest(prompt="test", profile="steward", model=CCModel.SONNET)
-    inv = runner._build_invocation(req)
+    inv = runner._build_invocation(req, "test-session")
     assert inv.bash_allowlist == ("gh",)
 
 
 def test_non_steward_invocation_has_empty_bash_allowlist():
     runner = _make_runner()
     req = DirectSessionRequest(prompt="test", profile="research", model=CCModel.SONNET)
-    inv = runner._build_invocation(req)
+    inv = runner._build_invocation(req, "test-session")
     assert inv.bash_allowlist == ()
 
 
@@ -590,7 +593,7 @@ def test_overlay_profile_flows_through_build_invocation(overlay_ctx, monkeypatch
     monkeypatch.setattr(ds, "VALID_PROFILES", ds.VALID_PROFILES | {"ztest-profile"})
     runner = _make_runner()
     req = DirectSessionRequest(prompt="t", profile="ztest-profile", model=CCModel.SONNET)
-    inv = runner._build_invocation(req)
+    inv = runner._build_invocation(req, "test-session")
     assert inv.bash_allowlist == (ds._VENV_PYTHON,)
     runner._config_builder.build_mcp_config.assert_called_with(profile="campaign")
 
@@ -650,3 +653,41 @@ def test_load_profile_overlays_noop_when_absent(monkeypatch):
     before = set(ds.PROFILES)
     ds._load_profile_overlays()
     assert set(ds.PROFILES) == before
+
+
+# --- Per-session CC sandbox isolation (background dispatch) ---
+
+def test_bg_session_sandbox_is_off_cc_tmp():
+    """A session's sandbox lives under ~/tmp/bg-cc-sessions, NOT the
+    watchgod-policed ~/.genesis/cc-tmp."""
+    path = _bg_session_sandbox("sess-abc")
+    assert path.endswith("/bg-cc-sessions/sess-abc/cc-sandbox")
+    assert str(_BG_CC_TMP_ROOT) in path
+    assert ".genesis/cc-tmp" not in path
+
+
+def test_bg_session_sandbox_distinct_per_session():
+    """Two sessions get distinct sandbox dirs (no cross-session collision)."""
+    assert _bg_session_sandbox("sess-a") != _bg_session_sandbox("sess-b")
+    assert _bg_session_root("sess-a") != _bg_session_root("sess-b")
+
+
+def test_bg_session_sandbox_is_pure_no_mkdir():
+    """Deriving the path must NOT create the dir (side-effect belongs to
+    _run_session, so building an invocation is pure)."""
+    sid = "sess-pure-check-xyz"
+    root = _bg_session_root(sid)
+    assert not root.exists()
+    _bg_session_sandbox(sid)
+    assert not root.exists()
+
+
+def test_build_invocation_sets_isolated_tmpdir():
+    """_build_invocation wires the per-session sandbox into the CCInvocation,
+    off cc-tmp — the actual seam the fix depends on."""
+    runner = _make_runner()
+    req = DirectSessionRequest(prompt="t", profile="research", model=CCModel.SONNET)
+    inv = runner._build_invocation(req, "sess-xyz")
+    assert inv.claude_code_tmpdir == _bg_session_sandbox("sess-xyz")
+    assert "bg-cc-sessions/sess-xyz" in (inv.claude_code_tmpdir or "")
+    assert ".genesis/cc-tmp" not in (inv.claude_code_tmpdir or "")


### PR DESCRIPTION
## What
Give each background dispatch CC session its own Bash sandbox (`CLAUDE_CODE_TMPDIR`) under `~/tmp/bg-cc-sessions/<session_id>` instead of the shared, watchgod-policed `~/.genesis/cc-tmp`. Reuses the existing per-invocation `CCInvocation.claude_code_tmpdir` seam (the same one `eval/gauntlet.py` already uses).

## Why
Background sessions shared one CC sandbox under cc-tmp. Isolating it removes two effects:
- At cc-tmp RED pressure, `tmp_watchgod.sh`'s nuclear cleanup deletes cc-tmp session dirs — which could clip a background session's Bash scratch mid-run.
- Background sessions contributed to cc-tmp pressure that can trigger cleanup of foreground CLI (`cc-*` tmux) sessions.

**Scope, honestly:** this is NOT a "prevent kill" change — background sessions are asyncio subprocesses, not tmux sessions, so watchgod's tmux-kill can't reach them regardless. It's scratch-file protection + pressure reduction, i.e. defense-in-depth (cc-tmp is rarely pressured in practice).

## How
- `_build_invocation` takes `session_id` and sets `claude_code_tmpdir` per session (pure path helper).
- `_run_session` mkdirs the sandbox just before the run and `shutil.rmtree`s the per-session tree in a `finally`.
- `working_dir` (transcript-path derivation) and the shell `TMPDIR` are untouched — only `CLAUDE_CODE_TMPDIR`, the CC-specific per-invocation var.
- `disk_hygiene.sh` gains a 24h orphan reaper for sessions hard-SIGKILLed before the `finally`.

## Tradeoff
Sandboxes move onto `~/tmp` (persistent, not watchgod-budgeted) → a small disk-fill exposure, bounded by `Semaphore(2)` concurrency + finally-cleanup + the 24h reaper + the light bg-session workload.

## Tests
88 targeted tests pass (`tests/test_cc/test_direct_session*.py`), including a new async E2E lifecycle test asserting the sandbox exists at CC-invocation time (mkdir-before-run) and is removed after (finally-cleanup), off cc-tmp. Ruff clean.

Internal robustness fix — no CHANGELOG entry (not user-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)