### PR TITLE
feat(cc): real-time silent-cap detection + DLQ alert honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Genesis now notices when its Claude Code subscription hits its usage cap — instead of quietly going dark.**
+  A capped Anthropic subscription makes `claude -p` return *empty* output with no error, which Genesis used to
+  record as a successful (but blank) run — so its background thinking (ego cycles, reflections, weekly reviews)
+  could silently produce nothing for days without anyone noticing. Genesis now watches for a run of empty
+  results on calls that should have produced output and, when it sees one, sends a single critical alert
+  ("CC subscription likely capped — degraded until the limit resets") so you know to check. It's detection only:
+  it never changes how a call runs, and it stays quiet during normal idle periods.
+
 - **The Genesis Voice add-on's attention surface now shows the judge's reasoning — and lets you review it.**
   For the optional passive-listening add-on, the buried "Attention" tab is now a top-level **Genesis Voice →
   Judgment** review. Each moment the attention gate noticed is scored by a lightweight LLM judge that says
@@ -111,6 +119,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   duplicate. Together these keep the procedure store both more complete and less cluttered.
 
 ### Fixed
+
+- **The dead-letter-queue alert no longer cries wolf on self-healing bursts.** A short burst of low-value
+  retry items (e.g. memory-relevance grades, which are discarded within an hour by design) could push the queue
+  past its alert threshold and fire a *critical* notification for something that clears itself minutes later.
+  The alert now counts only items that are genuinely stuck — pending past their designed self-heal window — so a
+  transient burst stays quiet while a real, un-draining backlog still alerts. The dashboard still shows the full
+  raw count.
 
 - **The dashboard now reports each ego's cycle health separately.** Genesis runs two egos (a user-facing
   one and its own), and both recorded their proactive-cycle health under a single shared key — so on the

--- a/src/genesis/autonomy/decomposer.py
+++ b/src/genesis/autonomy/decomposer.py
@@ -204,6 +204,7 @@ class TaskDecomposer:
 
         invocation = CCInvocation(
             prompt=prompt,
+            expect_output=True,  # silent-cap detection (decomposition needs a step list)
             model=CCModel.SONNET,
             effort=EffortLevel.HIGH,
             timeout_s=300,

--- a/src/genesis/autonomy/executor/research.py
+++ b/src/genesis/autonomy/executor/research.py
@@ -123,6 +123,7 @@ class DeepResearcherImpl:
 
         invocation = CCInvocation(
             prompt=prompt,
+            expect_output=True,  # silent-cap detection (research needs output)
             model=CCModel.SONNET,
             effort=EffortLevel.HIGH,
             system_prompt=None,  # Uses default SOUL.md identity

--- a/src/genesis/autonomy/executor/review.py
+++ b/src/genesis/autonomy/executor/review.py
@@ -177,6 +177,7 @@ class TaskReviewer:
 
         invocation = CCInvocation(
             prompt=prompt,
+            expect_output=True,  # silent-cap detection (plan review needs output)
             model=CCModel.OPUS,
             effort=EffortLevel.HIGH,
             timeout_s=600,
@@ -479,6 +480,7 @@ class TaskReviewer:
 
             invocation = CCInvocation(
                 prompt=prompt,
+                expect_output=True,  # silent-cap detection (adversarial review output)
                 model=CCModel.SONNET,
                 effort=EffortLevel.HIGH,
                 skip_permissions=True,

--- a/src/genesis/autonomy/executor/step_dispatcher.py
+++ b/src/genesis/autonomy/executor/step_dispatcher.py
@@ -177,6 +177,7 @@ class StepDispatcher:
 
         invocation = CCInvocation(
             prompt=prompt,
+            expect_output=True,  # silent-cap detection (step needs a result)
             model=CCModel.SONNET,
             effort=effort,
             timeout_s=step_type.default_timeout_s,

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -225,9 +225,7 @@ async def _check_cc_cap_detection(db) -> None:
     global _last_cap_alert_at
     if db is None:
         return
-    now = time.monotonic()
-    if _last_cap_alert_at is not None and now - _last_cap_alert_at < _CAP_ALERT_COOLDOWN_S:
-        return
+    # Query first (always) so we can BOTH alert on a run AND resolve on recovery.
     try:
         cutoff = (datetime.now(UTC) - timedelta(minutes=_CAP_EMPTY_WINDOW_MIN)).isoformat()
         cur = await db.execute(
@@ -241,12 +239,40 @@ async def _check_cc_cap_detection(db) -> None:
     except Exception:
         logger.debug("cc_cap detection: query failed", exc_info=True)
         return
+
     if count < _CAP_EMPTY_THRESHOLD:
+        # Recovery: clear any outstanding cap alert so it doesn't linger for its
+        # 3-day TTL after the cap lifts, and reset the cooldown on a genuine
+        # resolve so a fresh cap re-alerts immediately (mirrors the DLQ path).
+        try:
+            resolved = await observations.resolve_by_source_and_type(
+                db,
+                source="cc_cap_monitor",
+                type="infrastructure_alert",
+                resolved_at=datetime.now(UTC).isoformat(),
+                resolution_notes=(
+                    f"auto-resolved: {count} empty cognitive completions in the last "
+                    f"{_CAP_EMPTY_WINDOW_MIN} min (< {_CAP_EMPTY_THRESHOLD})"
+                ),
+            )
+            if resolved:
+                _last_cap_alert_at = None
+        except Exception:
+            logger.debug("cc_cap detection: resolve failed", exc_info=True)
+        return
+
+    now = time.monotonic()
+    if _last_cap_alert_at is not None and now - _last_cap_alert_at < _CAP_ALERT_COOLDOWN_S:
         return
     # Set the cooldown BEFORE the write so a failed create still suppresses retries.
     _last_cap_alert_at = now
     try:
-        await observations.create(
+        # DB-backed dedup: a stable content_hash + skip_if_duplicate means a cap
+        # persisting for hours produces ONE unresolved alert, not one per hour
+        # (the same discipline as the DLQ accumulation alert). It clears via the
+        # resolve path above and re-alerts on a fresh cap.
+        content_hash = hashlib.sha256(b"cc_cap_alert").hexdigest()
+        created = await observations.create(
             db,
             id=str(uuid.uuid4()),
             source="cc_cap_monitor",
@@ -260,7 +286,11 @@ async def _check_cc_cap_detection(db) -> None:
             ),
             priority="critical",
             created_at=datetime.now(UTC).isoformat(),
+            content_hash=content_hash,
+            skip_if_duplicate=True,
         )
+        if created is None:
+            return  # an unresolved cap alert already exists — don't duplicate
         logger.warning(
             "CC cap detection alert: %d empty cognitive completions in %d min",
             count, _CAP_EMPTY_WINDOW_MIN,

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -225,7 +225,10 @@ async def _check_cc_cap_detection(db) -> None:
     global _last_cap_alert_at
     if db is None:
         return
-    # Query first (always) so we can BOTH alert on a run AND resolve on recovery.
+    # ONE best-effort guard around the whole thing: this runs on every tick, so any
+    # failure (a DB hiccup, an unexpected row shape) must skip the check, never break
+    # the tick. Query first (always) so we can BOTH alert on a run AND resolve on
+    # recovery.
     try:
         cutoff = (datetime.now(UTC) - timedelta(minutes=_CAP_EMPTY_WINDOW_MIN)).isoformat()
         cur = await db.execute(
@@ -236,15 +239,11 @@ async def _check_cc_cap_detection(db) -> None:
         )
         row = await cur.fetchone()
         count = row[0] if row else 0
-    except Exception:
-        logger.debug("cc_cap detection: query failed", exc_info=True)
-        return
 
-    if count < _CAP_EMPTY_THRESHOLD:
-        # Recovery: clear any outstanding cap alert so it doesn't linger for its
-        # 3-day TTL after the cap lifts, and reset the cooldown on a genuine
-        # resolve so a fresh cap re-alerts immediately (mirrors the DLQ path).
-        try:
+        if count < _CAP_EMPTY_THRESHOLD:
+            # Recovery: clear any outstanding cap alert so it doesn't linger for its
+            # 3-day TTL after the cap lifts, and reset the cooldown on a genuine
+            # resolve so a fresh cap re-alerts immediately (mirrors the DLQ path).
             resolved = await observations.resolve_by_source_and_type(
                 db,
                 source="cc_cap_monitor",
@@ -257,20 +256,17 @@ async def _check_cc_cap_detection(db) -> None:
             )
             if resolved:
                 _last_cap_alert_at = None
-        except Exception:
-            logger.debug("cc_cap detection: resolve failed", exc_info=True)
-        return
+            return
 
-    now = time.monotonic()
-    if _last_cap_alert_at is not None and now - _last_cap_alert_at < _CAP_ALERT_COOLDOWN_S:
-        return
-    # Set the cooldown BEFORE the write so a failed create still suppresses retries.
-    _last_cap_alert_at = now
-    try:
+        now = time.monotonic()
+        if _last_cap_alert_at is not None and now - _last_cap_alert_at < _CAP_ALERT_COOLDOWN_S:
+            return
+        # Set the cooldown BEFORE the write so a failed create still suppresses retries.
+        _last_cap_alert_at = now
         # DB-backed dedup: a stable content_hash + skip_if_duplicate means a cap
-        # persisting for hours produces ONE unresolved alert, not one per hour
-        # (the same discipline as the DLQ accumulation alert). It clears via the
-        # resolve path above and re-alerts on a fresh cap.
+        # persisting for hours produces ONE unresolved alert, not one per hour (the
+        # same discipline as the DLQ accumulation alert). It clears via the resolve
+        # path above and re-alerts on a fresh cap.
         content_hash = hashlib.sha256(b"cc_cap_alert").hexdigest()
         created = await observations.create(
             db,
@@ -296,7 +292,7 @@ async def _check_cc_cap_detection(db) -> None:
             count, _CAP_EMPTY_WINDOW_MIN,
         )
     except Exception:
-        logger.debug("Failed to create cc_cap alert observation", exc_info=True)
+        logger.debug("cc_cap detection failed — skipping this tick", exc_info=True)
 
 
 # Micro ticks are silent by default (counted for cascade, no LLM call).

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -231,14 +231,9 @@ async def _check_cc_cap_detection(db) -> None:
     # recovery.
     try:
         cutoff = (datetime.now(UTC) - timedelta(minutes=_CAP_EMPTY_WINDOW_MIN)).isoformat()
-        cur = await db.execute(
-            "SELECT COUNT(*) FROM observations "
-            "WHERE type = 'cc_cap_empty_event' AND source = 'cc_cap_monitor' "
-            "AND created_at > ? AND resolved = 0",
-            (cutoff,),
+        count = await observations.count_recent_unresolved_by_type_and_source(
+            db, type="cc_cap_empty_event", source="cc_cap_monitor", since=cutoff,
         )
-        row = await cur.fetchone()
-        count = row[0] if row else 0
 
         if count < _CAP_EMPTY_THRESHOLD:
             # Recovery: clear any outstanding cap alert so it doesn't linger for its

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -16,7 +16,7 @@ import json
 import logging
 import time
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 import aiosqlite
@@ -195,6 +195,78 @@ async def _check_cc_slot_memory(db, slots: list[dict] | None = None) -> None:
             logger.warning("CC slot memory alert: cc-%s %.1f GB (%s)", key, rss / 1024, priority)
         except Exception:
             logger.debug("Failed to create cc_slot alert observation", exc_info=True)
+
+
+# CC silent-cap detection. A capped Anthropic subscription makes `claude -p`
+# return empty output (no text, no error, no rate-limit signal) on OUTPUT-EXPECTING
+# cognitive invocations — it reads as a successful completion, so nothing alerts
+# (this happened for ~2 days in late June). The invoker records one
+# `cc_cap_empty_event` observation per such empty (opt-in via
+# CCInvocation.expect_output; see runtime/init/cc_relay._on_cc_empty_output). This
+# check aggregates a run of them into a single critical alert. Same monotonic-
+# since-boot caveat as WAL/slot: None = "never alerted", never 0.0.
+_CAP_EMPTY_WINDOW_MIN = 60          # look back this many minutes for empties
+_CAP_EMPTY_THRESHOLD = 3           # ≥ this many empties in the window → alert
+_CAP_ALERT_COOLDOWN_S = 3600       # one alert per hour max
+_last_cap_alert_at: float | None = None
+
+
+async def _check_cc_cap_detection(db) -> None:
+    """Alert when output-expecting cognitive CC invocations return empty in a run.
+
+    Counts recent `cc_cap_empty_event` observations (written by the invoker's
+    empty-output callback) and raises ONE critical infrastructure_alert when
+    ``>=_CAP_EMPTY_THRESHOLD`` land inside ``_CAP_EMPTY_WINDOW_MIN`` — the silent-
+    cap signature. Rides the critical-observations job to Telegram. Detection only;
+    the invoker never altered control flow to produce these. Best-effort; never
+    raises into the tick. The cooldown + the window rolling forward mean a
+    persisting cap re-alerts at most hourly (correct), and a transient blip that
+    ages out of the window stops re-firing."""
+    global _last_cap_alert_at
+    if db is None:
+        return
+    now = time.monotonic()
+    if _last_cap_alert_at is not None and now - _last_cap_alert_at < _CAP_ALERT_COOLDOWN_S:
+        return
+    try:
+        cutoff = (datetime.now(UTC) - timedelta(minutes=_CAP_EMPTY_WINDOW_MIN)).isoformat()
+        cur = await db.execute(
+            "SELECT COUNT(*) FROM observations "
+            "WHERE type = 'cc_cap_empty_event' AND source = 'cc_cap_monitor' "
+            "AND created_at > ? AND resolved = 0",
+            (cutoff,),
+        )
+        row = await cur.fetchone()
+        count = row[0] if row else 0
+    except Exception:
+        logger.debug("cc_cap detection: query failed", exc_info=True)
+        return
+    if count < _CAP_EMPTY_THRESHOLD:
+        return
+    # Set the cooldown BEFORE the write so a failed create still suppresses retries.
+    _last_cap_alert_at = now
+    try:
+        await observations.create(
+            db,
+            id=str(uuid.uuid4()),
+            source="cc_cap_monitor",
+            type="infrastructure_alert",
+            content=(
+                f"CC subscription likely capped: {count} output-expecting cognitive "
+                f"sessions returned EMPTY in the last {_CAP_EMPTY_WINDOW_MIN} min "
+                f"(no text, no error, no rate-limit signal — the silent-cap signature). "
+                f"CC cognitive work (ego, reflections, weekly jobs) is degraded until "
+                f"the Anthropic usage limit resets."
+            ),
+            priority="critical",
+            created_at=datetime.now(UTC).isoformat(),
+        )
+        logger.warning(
+            "CC cap detection alert: %d empty cognitive completions in %d min",
+            count, _CAP_EMPTY_WINDOW_MIN,
+        )
+    except Exception:
+        logger.debug("Failed to create cc_cap alert observation", exc_info=True)
 
 
 # Micro ticks are silent by default (counted for cascade, no LLM call).
@@ -829,6 +901,11 @@ class AwarenessLoop:
             # still runs during a DB hiccup); the observation write is guarded on
             # db inside the function. Surfaces a single ballooning CC session.
             await _check_cc_slot_memory(self._db)
+
+            # CC silent-cap detection — counts recent empty-output cognitive
+            # completions (recorded by the invoker) and alerts on a run. Guarded
+            # on db internally; a query failure no-ops (never breaks the tick).
+            await _check_cc_cap_detection(self._db)
 
             # SQLite WAL checkpoint — prevent unbounded WAL growth from
             # external scripts or concurrent writers. PASSIVE is non-blocking.

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -164,6 +164,9 @@ class CCInvoker:
         on_model_downgrade: (
             Callable[[str, str, str], Awaitable[None]] | None
         ) = None,
+        on_cc_empty_output: (
+            Callable[[CCInvocation, CCOutput], Awaitable[None]] | None
+        ) = None,
         protected_paths: object | None = None,
     ):
         self._claude_path = claude_path
@@ -175,6 +178,7 @@ class CCInvoker:
         self._active_procs: dict[str, asyncio.subprocess.Process] = {}
         self._on_cc_status_change = on_cc_status_change
         self._on_model_downgrade = on_model_downgrade
+        self._on_cc_empty_output = on_cc_empty_output
         self._last_was_error = False
         self._status_lock = asyncio.Lock()
         self._protected_paths = protected_paths
@@ -210,6 +214,28 @@ class CCInvoker:
             )
         except Exception:
             logger.warning("Model downgrade callback failed", exc_info=True)
+
+    async def _fire_empty_output_callback(
+        self, invocation: CCInvocation, output: CCOutput,
+    ) -> None:
+        """Notify the runtime when an output-EXPECTING invocation returns empty.
+
+        The silent-cap signature: an Anthropic-subscription cap makes ``claude -p``
+        return 0-token, no-text output with ``is_error=False`` and no
+        ``rate_limit_event`` — which every success path reads as a completed run.
+        Only invocations that opt in via ``expect_output`` (output-producing
+        cognitive call sites) are considered; the caller has already confirmed the
+        output is genuinely empty and non-error before calling this. This is
+        DETECTION only — it never raises and never alters control flow (the empty
+        output is still returned to the caller exactly as before). Never raises;
+        mirrors ``_fire_downgrade_callback``.
+        """
+        if self._on_cc_empty_output is None:
+            return
+        try:
+            await self._on_cc_empty_output(invocation, output)
+        except Exception:
+            logger.warning("CC empty-output callback failed", exc_info=True)
 
     def _build_args(self, inv: CCInvocation) -> list[str]:
         args = [self._claude_path, "-p"]
@@ -610,6 +636,10 @@ class CCInvoker:
         if self._last_was_error:
             await self._notify_status_change(None)
         await self._fire_downgrade_callback(output)
+        # Silent-cap detection: a non-error, non-rate-limited return that reached
+        # here with empty text (returncode==0 above rules out rate-limit text).
+        if invocation.expect_output and not output.is_error and not output.text.strip():
+            await self._fire_empty_output_callback(invocation, output)
         return output
 
     async def run_streaming(
@@ -858,6 +888,10 @@ class CCInvoker:
             if self._last_was_error:
                 await self._notify_status_change(None)
             await self._fire_downgrade_callback(output)
+            # Silent-cap detection: reaching here means is_error=False AND no
+            # rate_limit_event (both handled above) — empty text is the signal.
+            if invocation.expect_output and not output.is_error and not output.text.strip():
+                await self._fire_empty_output_callback(invocation, output)
             return output
 
         # No result event — treat collected text as response (success path)
@@ -876,6 +910,15 @@ class CCInvoker:
             via_proxy=bool(invocation.anthropic_base_url),
         )
         await self._fire_downgrade_callback(output)
+        # Silent-cap detection (no-result path): also guard on rate_limit_event,
+        # since the rate-limit branch above runs only inside the result_data block.
+        if (
+            invocation.expect_output
+            and not output.is_error
+            and not output.text.strip()
+            and "rate_limit_event" not in event_types
+        ):
+            await self._fire_empty_output_callback(invocation, output)
         return output
 
     @staticmethod

--- a/src/genesis/cc/reflection_bridge/_bridge.py
+++ b/src/genesis/cc/reflection_bridge/_bridge.py
@@ -273,6 +273,7 @@ class CCReflectionBridge:
             mcp_path = None
         invocation = CCInvocation(
             prompt=prompt,
+            expect_output=True,  # silent-cap detection (reflection always emits text)
             model=model,
             effort=effort,
             timeout_s=_DEPTH_TIMEOUT_S.get(depth, 300),
@@ -535,6 +536,7 @@ class CCReflectionBridge:
 
         invocation = CCInvocation(
             prompt=prompt,
+            expect_output=True,  # silent-cap detection (weekly assessment output)
             model=CCModel.SONNET,
             effort=EffortLevel.HIGH,
             system_prompt=load_prompt_file("SELF_ASSESSMENT.md", self._prompt_dir),
@@ -611,6 +613,7 @@ class CCReflectionBridge:
 
         invocation = CCInvocation(
             prompt=prompt,
+            expect_output=True,  # silent-cap detection (quality calibration output)
             model=CCModel.SONNET,
             effort=EffortLevel.HIGH,
             system_prompt=load_prompt_file("QUALITY_CALIBRATION.md", self._prompt_dir),

--- a/src/genesis/cc/types.py
+++ b/src/genesis/cc/types.py
@@ -165,6 +165,15 @@ class CCInvocation:
     # opt in (foreground conversation, background DirectSession) are routed; every
     # other CC call site stays Claude-native until a dedicated activation pass.
     roster_eligible: bool = False
+    # Silent-cap detection opt-in. When True, the invoker fires its
+    # on_cc_empty_output callback if this invocation returns genuinely-empty
+    # output (no text, no error, no rate_limit_event) — the signature of a
+    # silent Anthropic-subscription cap that otherwise reads as a "successful"
+    # empty completion. Default False = zero behavior change; only output-
+    # producing COGNITIVE call sites (ego, reflection, weekly jobs, sentinel,
+    # autonomy executors, mail judge) opt in. NEVER changes control flow —
+    # detection/alerting only, never a raise or failover.
+    expect_output: bool = False
     # cc-loop-01: opaque per-session key for the invoker's proc registry, so an
     # interrupt (e.g. Telegram /stop) targets THIS session's subprocess and not
     # a concurrent background one. None → keyed by pid (never cross-fired).

--- a/src/genesis/db/crud/dead_letter.py
+++ b/src/genesis/db/crud/dead_letter.py
@@ -81,6 +81,21 @@ async def count_pending(
     return int(row[0])
 
 
+async def list_pending_type_age(db: aiosqlite.Connection) -> list[tuple[str, str]]:
+    """Return ``(operation_type, created_at)`` for every pending item.
+
+    Lightweight companion to :func:`count_pending` — omits the (potentially
+    large) payload so a caller can apply per-operation-type age policy (e.g. the
+    stuck-vs-self-healing split used for the DLQ-accumulation alert) without
+    pulling full rows. Pending counts are bounded (~hundreds), same as the set
+    ``expire_old`` already iterates.
+    """
+    cursor = await db.execute(
+        "SELECT operation_type, created_at FROM dead_letter WHERE status = 'pending'"
+    )
+    return [(row[0], row[1]) for row in await cursor.fetchall()]
+
+
 async def delete(db: aiosqlite.Connection, id: str) -> bool:
     cursor = await db.execute("DELETE FROM dead_letter WHERE id = ?", (id,))
     await db.commit()

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -728,3 +728,24 @@ async def count_unresolved_by_types(
     )
     row = rows[0] if rows else None
     return row[0] if row else 0
+
+
+async def count_recent_unresolved_by_type_and_source(
+    db: aiosqlite.Connection,
+    *,
+    type: str,
+    source: str,
+    since: str,
+) -> int:
+    """Count unresolved observations of a type+source created after ``since`` (ISO).
+
+    Used by the awareness silent-cap detector to count recent
+    ``cc_cap_empty_event`` telemetry rows without embedding raw SQL in the loop.
+    """
+    rows = await db.execute_fetchall(
+        "SELECT COUNT(*) FROM observations "
+        "WHERE type = ? AND source = ? AND created_at > ? AND resolved = 0",
+        (type, source, since),
+    )
+    row = rows[0] if rows else None
+    return row[0] if row else 0

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -65,6 +65,10 @@ INTERNAL_OBS_TYPES: frozenset[str] = frozenset({
     "interpretation_correction",
     "scope_clarification",
     "feedback_rule",
+    # CC silent-cap detection — per-empty telemetry rows. Internal: only the
+    # aggregate infrastructure_alert (raised by the awareness cap detector when
+    # a run of these accumulates) surfaces to the user.
+    "cc_cap_empty_event",
 })
 
 # Default TTL for types not explicitly listed. Any new type that appears without
@@ -88,6 +92,7 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     "process_reaper_kill": timedelta(days=3),
     "operational_alert": timedelta(days=3),
     "infrastructure_alert": timedelta(days=3),
+    "cc_cap_empty_event": timedelta(days=3),
     "strategic_reflection": timedelta(days=3),
     # ── 1-day (transient) ──────────────────────────────────────────────
     "light_escalation_resolved": timedelta(days=1),

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -290,6 +290,7 @@ class EgoSession:
         # Build invocation — ephemeral (no resume)
         invocation = CCInvocation(
             prompt=user_prompt,
+            expect_output=True,  # silent-cap detection (cognitive, always emits text)
             model=model,
             effort=effort,
             resume_session_id=None,
@@ -1062,6 +1063,7 @@ class EgoSession:
         try:
             invocation = CCInvocation(
                 prompt=prompt,
+                expect_output=True,  # silent-cap detection (realist gate needs verdict text)
                 model=CCModel.OPUS,
                 effort=EffortLevel.MEDIUM,
                 skip_permissions=True,

--- a/src/genesis/mail/monitor.py
+++ b/src/genesis/mail/monitor.py
@@ -479,6 +479,7 @@ class MailMonitor:
             )
             invocation = CCInvocation(
                 prompt=prompt,
+                expect_output=True,  # silent-cap detection (judge silently no-ops on empty)
                 model=self._config.model,
                 effort=self._config.effort,
                 system_prompt=system_prompt,

--- a/src/genesis/observability/snapshots/queues.py
+++ b/src/genesis/observability/snapshots/queues.py
@@ -80,10 +80,12 @@ async def _alert_dead_letter_accumulation(db: aiosqlite.Connection | None, count
             source="dead_letter_monitor",
             type="infrastructure_alert",
             content=(
-                f"Dead letter queue has {count} pending items (threshold: "
-                f"{_DEAD_LETTER_ALERT_THRESHOLD}). Likely cause: provider "
-                f"chain exhaustion or circuit breaker stuck open. "
-                f"Check circuit breaker state and provider health."
+                f"Dead letter queue has {count} STUCK items — pending past their "
+                f"self-heal TTL (threshold: {_DEAD_LETTER_ALERT_THRESHOLD}). Short-"
+                f"TTL self-healing bursts (e.g. chain_exhausted:judge) are excluded, "
+                f"so this is a genuine backlog: the replay/expire drainer is failing "
+                f"or a provider chain is exhausted. Check circuit breaker state, "
+                f"provider health, and the dead_letter_replay surplus task."
             ),
             priority="critical",
             created_at=datetime.now(UTC).isoformat(),
@@ -164,14 +166,19 @@ async def queues(
     dead = None
     if dead_letter:
         try:
+            # Raw total for the snapshot/dashboard (honest count of everything
+            # pending), but ALERT on the genuinely-STUCK subset only: a fresh
+            # burst of short-TTL self-healing items (e.g. chain_exhausted:judge,
+            # 1h) drains itself and must not cry wolf on the critical alert.
             dead = await dead_letter.get_pending_count()
-            # Alert when dead letters accumulate; resolve the alert when the
-            # queue drains. Without the resolve, the observation pipeline is
-            # write-only and stale "DLQ at N" alerts linger until TTL.
-            if dead is not None and dead >= _DEAD_LETTER_ALERT_THRESHOLD:
-                await _alert_dead_letter_accumulation(db, dead)
-            elif dead is not None:
-                await _resolve_dead_letter_alerts(db, dead)
+            stuck = await dead_letter.get_stuck_count()
+            # Alert when STUCK items accumulate; resolve when they clear. Without
+            # the resolve, the observation pipeline is write-only and stale
+            # "DLQ at N" alerts linger until TTL.
+            if stuck >= _DEAD_LETTER_ALERT_THRESHOLD:
+                await _alert_dead_letter_accumulation(db, stuck)
+            else:
+                await _resolve_dead_letter_alerts(db, stuck)
         except Exception:
             errors.append("dead_letters: query failed")
             logger.error("Failed to query dead letter queue", exc_info=True)

--- a/src/genesis/routing/dead_letter.py
+++ b/src/genesis/routing/dead_letter.py
@@ -265,3 +265,43 @@ class DeadLetterQueue:
     async def get_pending_count(self, *, target_provider: str | None = None) -> int:
         """Count pending items, optionally filtered by provider."""
         return await dl_crud.count_pending(self.db, target_provider=target_provider)
+
+    def _short_ttl_hours_for(self, operation_type: str) -> int | None:
+        """The short self-heal TTL (hours) for an op_type, or None if it has none.
+
+        Longest-prefix match against :attr:`_OPERATION_TTL_HOURS` — the SAME map
+        ``expire_old`` uses. ``None`` means the type carries no short TTL, so for
+        stuck-counting it is countable immediately (the 72h ``expire_old`` default
+        is deliberately NOT treated as a short window here).
+        """
+        for pattern, hours in self._OPERATION_TTL_HOURS.items():
+            if operation_type.startswith(pattern):
+                return hours
+        return None
+
+    async def get_stuck_count(self) -> int:
+        """Count pending items that are GENUINELY STUCK (for alerting).
+
+        A pending item counts iff it is NOT a short-TTL self-healing type still
+        inside its window: an item whose operation_type has a short TTL in
+        ``_OPERATION_TTL_HOURS`` counts only once it is OLDER than that TTL (past
+        its designed self-heal window ⇒ the drainer is failing to clear it); an
+        item with no short-TTL entry counts immediately (unchanged from the raw
+        pending count — the 72h default is NOT applied as a gate, so long-lived
+        types never regress). This stops a fresh burst of short-TTL, self-healing
+        items (e.g. a ``chain_exhausted:judge`` batch, 1h TTL) from crying wolf on
+        the critical DLQ-accumulation alert, while a genuine accumulation — or an
+        aged, un-drained backlog — still trips it.
+        """
+        rows = await dl_crud.list_pending_type_age(self.db)
+        now = self._clock()
+        stuck = 0
+        for op_type, created_at in rows:
+            ttl_hours = self._short_ttl_hours_for(op_type or "")
+            if ttl_hours is None:
+                stuck += 1  # no short TTL → genuinely stuck from the moment pending
+                continue
+            cutoff = (now - timedelta(hours=ttl_hours)).isoformat()
+            if (created_at or "") < cutoff:
+                stuck += 1  # short-TTL type past its self-heal window → stuck
+        return stuck

--- a/src/genesis/runtime/init/cc_relay.py
+++ b/src/genesis/runtime/init/cc_relay.py
@@ -77,9 +77,48 @@ async def init(rt: GenesisRuntime) -> None:
                 except Exception:
                     logger.error("Failed to create model downgrade observation", exc_info=True)
 
+        async def _on_cc_empty_output(invocation, output) -> None:
+            """Record a silent-empty CC completion (the silent-cap signature).
+
+            Fired by the invoker ONLY for output-EXPECTING cognitive invocations
+            that returned genuinely-empty output (no text, no error, no
+            rate_limit_event) — the shape a silent Anthropic-subscription cap
+            takes when it otherwise reads as a successful completion. Writes
+            durable, queryable telemetry (``cc_cap_empty_event``, low priority,
+            internal); the awareness cap detector aggregates a run of these into
+            one critical infrastructure_alert. Detection only — never alters CC
+            control flow. Never raises.
+            """
+            if rt._db is None:
+                return
+            try:
+                import json
+                import uuid
+                from datetime import UTC, datetime
+
+                from genesis.db.crud import observations
+                content = json.dumps({
+                    "model": str(invocation.model),
+                    "effort": str(invocation.effort),
+                    "output_tokens": output.output_tokens,
+                    "session_id": output.session_id,
+                })
+                await observations.create(
+                    rt._db,
+                    id=str(uuid.uuid4()),
+                    source="cc_cap_monitor",
+                    type="cc_cap_empty_event",
+                    content=content,
+                    priority="low",
+                    created_at=datetime.now(UTC).isoformat(),
+                )
+            except Exception:
+                logger.warning("Failed to record cc_cap empty event", exc_info=True)
+
         rt._cc_invoker = CCInvoker(
             on_cc_status_change=_on_cc_status_change,
             on_model_downgrade=_on_model_downgrade,
+            on_cc_empty_output=_on_cc_empty_output,
         )
 
         # CC fallback recovery safety probe — clears a stale account-wide fallback

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -1059,6 +1059,7 @@ class SentinelDispatcher:
 
             invocation = CCInvocation(
                 prompt=full_prompt,
+                expect_output=True,  # silent-cap detection (structured diagnosis expected)
                 model=CCModel.OPUS,
                 effort=EffortLevel.HIGH,
                 timeout_s=3600,

--- a/tests/test_awareness/test_cc_cap_detection.py
+++ b/tests/test_awareness/test_cc_cap_detection.py
@@ -27,25 +27,21 @@ def _mocks(monkeypatch):
     return create, resolve
 
 
-class _FakeCursor:
-    def __init__(self, count: int):
-        self._count = count
-
-    async def fetchone(self):
-        return (self._count,)
-
-
 class _FakeDB:
-    """Minimal async db whose COUNT(*) query returns a controllable value."""
+    """Minimal async db whose COUNT(*) fetch returns a controllable value.
+
+    The detector counts via observations.count_recent_unresolved_by_type_and_source,
+    which uses execute_fetchall — so that's what the fake implements.
+    """
 
     def __init__(self, count: int, *, raise_on_execute: bool = False):
         self._count = count
         self._raise = raise_on_execute
 
-    async def execute(self, *args, **kwargs):
+    async def execute_fetchall(self, *args, **kwargs):
         if self._raise:
             raise RuntimeError("db error")
-        return _FakeCursor(self._count)
+        return [(self._count,)]
 
     async def commit(self):
         pass

--- a/tests/test_awareness/test_cc_cap_detection.py
+++ b/tests/test_awareness/test_cc_cap_detection.py
@@ -18,11 +18,13 @@ from genesis.awareness import loop
 
 
 @pytest.fixture(autouse=True)
-def _reset_cooldown_and_mock_create(monkeypatch):
+def _mocks(monkeypatch):
     monkeypatch.setattr(loop, "_last_cap_alert_at", None)
-    create = AsyncMock()
+    create = AsyncMock()          # returns a truthy handle by default (not a dup)
+    resolve = AsyncMock(return_value=0)
     monkeypatch.setattr(loop.observations, "create", create)
-    return create
+    monkeypatch.setattr(loop.observations, "resolve_by_source_and_type", resolve)
+    return create, resolve
 
 
 class _FakeCursor:
@@ -45,29 +47,44 @@ class _FakeDB:
             raise RuntimeError("db error")
         return _FakeCursor(self._count)
 
+    async def commit(self):
+        pass
+
 
 @pytest.mark.asyncio
-async def test_run_of_empties_creates_critical_alert(_reset_cooldown_and_mock_create):
-    create = _reset_cooldown_and_mock_create
+async def test_run_of_empties_creates_critical_alert(_mocks):
+    create, _ = _mocks
     await loop._check_cc_cap_detection(_FakeDB(3))
     create.assert_awaited_once()
     kwargs = create.await_args.kwargs
     assert kwargs["type"] == "infrastructure_alert"
     assert kwargs["priority"] == "critical"
     assert kwargs["source"] == "cc_cap_monitor"
+    assert kwargs["skip_if_duplicate"] is True  # DB-backed dedup, one row per cap
+    assert kwargs.get("content_hash")
     assert "capped" in kwargs["content"].lower()
 
 
 @pytest.mark.asyncio
-async def test_below_threshold_no_alert(_reset_cooldown_and_mock_create):
-    create = _reset_cooldown_and_mock_create
+async def test_below_threshold_resolves_not_alerts(_mocks):
+    create, resolve = _mocks
     await loop._check_cc_cap_detection(_FakeDB(loop._CAP_EMPTY_THRESHOLD - 1))
     create.assert_not_awaited()
+    resolve.assert_awaited_once()  # recovery path clears any outstanding alert
 
 
 @pytest.mark.asyncio
-async def test_cooldown_suppresses_second_alert(_reset_cooldown_and_mock_create):
-    create = _reset_cooldown_and_mock_create
+async def test_recovery_resets_cooldown(_mocks):
+    create, resolve = _mocks
+    resolve.return_value = 1  # an outstanding alert was actually resolved
+    loop._last_cap_alert_at = 123.0
+    await loop._check_cc_cap_detection(_FakeDB(0))
+    assert loop._last_cap_alert_at is None  # reset so a fresh cap re-alerts now
+
+
+@pytest.mark.asyncio
+async def test_cooldown_suppresses_second_alert(_mocks):
+    create, _ = _mocks
     db = _FakeDB(5)
     await loop._check_cc_cap_detection(db)
     await loop._check_cc_cap_detection(db)
@@ -75,8 +92,16 @@ async def test_cooldown_suppresses_second_alert(_reset_cooldown_and_mock_create)
 
 
 @pytest.mark.asyncio
-async def test_db_none_does_not_write_or_consume_cooldown(_reset_cooldown_and_mock_create):
-    create = _reset_cooldown_and_mock_create
+async def test_duplicate_alert_returns_none_no_log(_mocks):
+    create, _ = _mocks
+    create.return_value = None  # skip_if_duplicate → an unresolved alert exists
+    await loop._check_cc_cap_detection(_FakeDB(4))
+    create.assert_awaited_once()  # attempted, but the row already existed (no dup)
+
+
+@pytest.mark.asyncio
+async def test_db_none_does_not_write_or_consume_cooldown(_mocks):
+    create, _ = _mocks
     await loop._check_cc_cap_detection(None)
     create.assert_not_awaited()
     assert loop._last_cap_alert_at is None  # cooldown not consumed
@@ -85,15 +110,15 @@ async def test_db_none_does_not_write_or_consume_cooldown(_reset_cooldown_and_mo
 
 
 @pytest.mark.asyncio
-async def test_query_failure_never_raises_and_no_alert(_reset_cooldown_and_mock_create):
-    create = _reset_cooldown_and_mock_create
+async def test_query_failure_never_raises_and_no_alert(_mocks):
+    create, _ = _mocks
     await loop._check_cc_cap_detection(_FakeDB(3, raise_on_execute=True))
     create.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_create_failure_never_raises(_reset_cooldown_and_mock_create):
-    create = _reset_cooldown_and_mock_create
+async def test_create_failure_never_raises(_mocks):
+    create, _ = _mocks
     create.side_effect = RuntimeError("db locked")
     # must not propagate into the tick
     await loop._check_cc_cap_detection(_FakeDB(3))

--- a/tests/test_awareness/test_cc_cap_detection.py
+++ b/tests/test_awareness/test_cc_cap_detection.py
@@ -1,0 +1,99 @@
+"""Tests for _check_cc_cap_detection — the silent-CC-cap alert path.
+
+The detector counts recent `cc_cap_empty_event` observations (written by the
+invoker's empty-output callback) and raises ONE critical infrastructure_alert
+when a run of them lands in the window — the signal that an Anthropic-subscription
+cap is making output-expecting cognitive invocations return empty. We assert the
+threshold, the alert fields, the cooldown, and the db-None / query-failure /
+create-failure no-ops (never breaks the tick).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from genesis.awareness import loop
+
+
+@pytest.fixture(autouse=True)
+def _reset_cooldown_and_mock_create(monkeypatch):
+    monkeypatch.setattr(loop, "_last_cap_alert_at", None)
+    create = AsyncMock()
+    monkeypatch.setattr(loop.observations, "create", create)
+    return create
+
+
+class _FakeCursor:
+    def __init__(self, count: int):
+        self._count = count
+
+    async def fetchone(self):
+        return (self._count,)
+
+
+class _FakeDB:
+    """Minimal async db whose COUNT(*) query returns a controllable value."""
+
+    def __init__(self, count: int, *, raise_on_execute: bool = False):
+        self._count = count
+        self._raise = raise_on_execute
+
+    async def execute(self, *args, **kwargs):
+        if self._raise:
+            raise RuntimeError("db error")
+        return _FakeCursor(self._count)
+
+
+@pytest.mark.asyncio
+async def test_run_of_empties_creates_critical_alert(_reset_cooldown_and_mock_create):
+    create = _reset_cooldown_and_mock_create
+    await loop._check_cc_cap_detection(_FakeDB(3))
+    create.assert_awaited_once()
+    kwargs = create.await_args.kwargs
+    assert kwargs["type"] == "infrastructure_alert"
+    assert kwargs["priority"] == "critical"
+    assert kwargs["source"] == "cc_cap_monitor"
+    assert "capped" in kwargs["content"].lower()
+
+
+@pytest.mark.asyncio
+async def test_below_threshold_no_alert(_reset_cooldown_and_mock_create):
+    create = _reset_cooldown_and_mock_create
+    await loop._check_cc_cap_detection(_FakeDB(loop._CAP_EMPTY_THRESHOLD - 1))
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cooldown_suppresses_second_alert(_reset_cooldown_and_mock_create):
+    create = _reset_cooldown_and_mock_create
+    db = _FakeDB(5)
+    await loop._check_cc_cap_detection(db)
+    await loop._check_cc_cap_detection(db)
+    create.assert_awaited_once()  # second within the 1h cooldown → still one
+
+
+@pytest.mark.asyncio
+async def test_db_none_does_not_write_or_consume_cooldown(_reset_cooldown_and_mock_create):
+    create = _reset_cooldown_and_mock_create
+    await loop._check_cc_cap_detection(None)
+    create.assert_not_awaited()
+    assert loop._last_cap_alert_at is None  # cooldown not consumed
+    await loop._check_cc_cap_detection(_FakeDB(3))
+    create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_query_failure_never_raises_and_no_alert(_reset_cooldown_and_mock_create):
+    create = _reset_cooldown_and_mock_create
+    await loop._check_cc_cap_detection(_FakeDB(3, raise_on_execute=True))
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_failure_never_raises(_reset_cooldown_and_mock_create):
+    create = _reset_cooldown_and_mock_create
+    create.side_effect = RuntimeError("db locked")
+    # must not propagate into the tick
+    await loop._check_cc_cap_detection(_FakeDB(3))

--- a/tests/test_cc/test_invoker_empty_output.py
+++ b/tests/test_cc/test_invoker_empty_output.py
@@ -1,0 +1,90 @@
+"""Tests for the silent-cap empty-output callback (on_cc_empty_output).
+
+The invoker fires on_cc_empty_output ONLY when an invocation opted in via
+expect_output=True returns genuinely-empty output (no text, no error). It must
+NOT fire for the default (expect_output=False) or for a non-empty result. The
+callback never alters control flow — the (empty) output is still returned.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from genesis.cc.invoker import CCInvoker
+from genesis.cc.types import CCInvocation
+
+
+def _result_line(*, result_text: str, is_error: bool = False) -> str:
+    return json.dumps(
+        {
+            "type": "result",
+            "subtype": "success",
+            "is_error": is_error,
+            "result": result_text,
+            "session_id": "sess-empty-1",
+            "total_cost_usd": 0.0,
+            "duration_ms": 10,
+            "usage": {"input_tokens": 5, "output_tokens": 0},
+            "modelUsage": {"claude-sonnet-4-6": {"outputTokens": 0}},
+        }
+    )
+
+
+def _mock_proc(stdout: str):
+    proc = AsyncMock()
+    proc.communicate = AsyncMock(return_value=(stdout.encode(), b""))
+    proc.returncode = 0
+    return proc
+
+
+@pytest.mark.asyncio
+async def test_empty_output_fires_callback_when_expected():
+    cb = AsyncMock()
+    invoker = CCInvoker(claude_path="/usr/bin/claude", on_cc_empty_output=cb)
+    with patch("asyncio.create_subprocess_exec", return_value=_mock_proc(_result_line(result_text=""))):
+        output = await invoker.run(CCInvocation(prompt="hi", expect_output=True))
+    cb.assert_awaited_once()
+    # callback receives (invocation, output); output is the (empty) result, still returned
+    inv_arg, out_arg = cb.await_args.args
+    assert inv_arg.expect_output is True
+    assert out_arg.text == ""
+    assert output.text == ""  # control flow unchanged — empty output still returned
+
+
+@pytest.mark.asyncio
+async def test_empty_output_no_callback_when_not_expected():
+    cb = AsyncMock()
+    invoker = CCInvoker(claude_path="/usr/bin/claude", on_cc_empty_output=cb)
+    with patch("asyncio.create_subprocess_exec", return_value=_mock_proc(_result_line(result_text=""))):
+        await invoker.run(CCInvocation(prompt="hi"))  # expect_output defaults False
+    cb.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_nonempty_output_no_callback():
+    cb = AsyncMock()
+    invoker = CCInvoker(claude_path="/usr/bin/claude", on_cc_empty_output=cb)
+    with patch("asyncio.create_subprocess_exec", return_value=_mock_proc(_result_line(result_text="Done."))):
+        output = await invoker.run(CCInvocation(prompt="hi", expect_output=True))
+    cb.assert_not_awaited()
+    assert output.text == "Done."
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_output_counts_as_empty():
+    cb = AsyncMock()
+    invoker = CCInvoker(claude_path="/usr/bin/claude", on_cc_empty_output=cb)
+    with patch("asyncio.create_subprocess_exec", return_value=_mock_proc(_result_line(result_text="  \n\t "))):
+        await invoker.run(CCInvocation(prompt="hi", expect_output=True))
+    cb.assert_awaited_once()  # not .strip() → whitespace-only is empty
+
+
+@pytest.mark.asyncio
+async def test_callback_failure_never_breaks_the_call():
+    cb = AsyncMock(side_effect=RuntimeError("sink down"))
+    invoker = CCInvoker(claude_path="/usr/bin/claude", on_cc_empty_output=cb)
+    with patch("asyncio.create_subprocess_exec", return_value=_mock_proc(_result_line(result_text=""))):
+        output = await invoker.run(CCInvocation(prompt="hi", expect_output=True))
+    # callback raised, but run() still returns the output
+    assert output.text == ""

--- a/tests/test_observability/test_queues_dead_letter.py
+++ b/tests/test_observability/test_queues_dead_letter.py
@@ -118,20 +118,42 @@ async def test_resolve_then_respike_realerts(db):
     assert await _total_infra(db) == 2
 
 
+class _DLQ:
+    """Fake DeadLetterQueue: raw pending total + genuinely-stuck subset.
+
+    ``stuck`` defaults to ``n`` (all pending are stuck) so a genuine backlog still
+    alerts; pass a smaller ``stuck`` to model a self-healing burst (high raw total,
+    few/zero stuck) that must NOT cry wolf.
+    """
+
+    def __init__(self, n: int, stuck: int | None = None) -> None:
+        self._n = n
+        self._stuck = n if stuck is None else stuck
+
+    async def get_pending_count(self) -> int:
+        return self._n
+
+    async def get_stuck_count(self) -> int:
+        return self._stuck
+
+
 @pytest.mark.asyncio
 async def test_queues_end_to_end_spike_then_drain(db):
-    """queues() alerts on spike and resolves on drain — the full snapshot path."""
-
-    class _DLQ:
-        def __init__(self, n: int) -> None:
-            self._n = n
-
-        async def get_pending_count(self) -> int:
-            return self._n
-
+    """queues() alerts on a genuine (stuck) spike and resolves on drain."""
     q._last_dead_letter_alert_at = 0.0
-    await q.queues(db, None, _DLQ(200), None)  # spike >= threshold
+    await q.queues(db, None, _DLQ(200), None)  # 200 stuck >= threshold
     assert await _unresolved_infra(db) == 1
 
     await q.queues(db, None, _DLQ(0), None)  # drained < threshold
     assert await _unresolved_infra(db) == 0
+
+
+@pytest.mark.asyncio
+async def test_queues_high_pending_low_stuck_does_not_alert(db):
+    """The cry-wolf fix: a big raw pending total that is all self-healing (0 stuck,
+    e.g. a fresh chain_exhausted:judge burst) must NOT alert — but the snapshot
+    still reports the honest raw total."""
+    q._last_dead_letter_alert_at = 0.0
+    result = await q.queues(db, None, _DLQ(200, stuck=0), None)
+    assert await _unresolved_infra(db) == 0        # no cry-wolf
+    assert result["dead_letters"] == 200           # raw total stays honest

--- a/tests/test_routing/test_dead_letter_stuck_count.py
+++ b/tests/test_routing/test_dead_letter_stuck_count.py
@@ -1,0 +1,75 @@
+"""Tests for DeadLetterQueue.get_stuck_count — the DLQ cry-wolf fix.
+
+The critical DLQ-accumulation alert must count only GENUINELY-STUCK items: a
+short-TTL self-healing type (e.g. chain_exhausted:judge, 1h) counts only once it
+is OLDER than its TTL; a type with no short TTL counts immediately (no regression).
+A fresh short-TTL burst -> not counted (no cry-wolf); aged-past-TTL or a genuine
+accumulation -> counted. The raw get_pending_count stays the full total.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from genesis.routing.dead_letter import DeadLetterQueue
+
+_NOW = datetime(2026, 3, 4, 12, 0, 0, tzinfo=UTC)
+
+
+def _at(hours_ago: float):
+    from datetime import timedelta
+    t = _NOW - timedelta(hours=hours_ago)
+    return lambda: t
+
+
+@pytest.mark.asyncio
+async def test_fresh_judge_burst_is_not_stuck(db):
+    """The exact incident: a fresh chain_exhausted:judge burst must not count."""
+    fresh = DeadLetterQueue(db, clock=lambda: _NOW)
+    for i in range(5):
+        await fresh.enqueue("chain_exhausted:judge", "{}", "all", f"exhausted {i}")
+    now_q = DeadLetterQueue(db, clock=lambda: _NOW)
+    assert await now_q.get_pending_count() == 5   # raw total unchanged
+    assert await now_q.get_stuck_count() == 0     # within the 1h self-heal window
+
+
+@pytest.mark.asyncio
+async def test_aged_short_ttl_is_stuck(db):
+    """A judge item older than its 1h TTL is genuinely stuck (drainer failing)."""
+    old = DeadLetterQueue(db, clock=_at(2))  # 2h ago > 1h judge TTL
+    await old.enqueue("chain_exhausted:judge", "{}", "all", "exhausted")
+    assert await DeadLetterQueue(db, clock=lambda: _NOW).get_stuck_count() == 1
+
+
+@pytest.mark.asyncio
+async def test_non_short_ttl_counts_immediately(db):
+    """A type with no short-TTL entry counts immediately (unchanged behavior)."""
+    fresh = DeadLetterQueue(db, clock=lambda: _NOW)
+    await fresh.enqueue("llm_call", "{}", "anthropic", "err")
+    assert await DeadLetterQueue(db, clock=lambda: _NOW).get_stuck_count() == 1
+
+
+@pytest.mark.asyncio
+async def test_chain_exhausted_six_hour_window(db):
+    """chain_exhausted:<other> (6h TTL): not stuck at 2h, stuck at 7h."""
+    two_h = DeadLetterQueue(db, clock=_at(2))
+    await two_h.enqueue("chain_exhausted:other", "{}", "all", "err")
+    assert await DeadLetterQueue(db, clock=lambda: _NOW).get_stuck_count() == 0
+
+    seven_h = DeadLetterQueue(db, clock=_at(7))
+    await seven_h.enqueue("chain_exhausted:other", "{}", "all", "err")
+    assert await DeadLetterQueue(db, clock=lambda: _NOW).get_stuck_count() == 1
+
+
+@pytest.mark.asyncio
+async def test_mixed_population(db):
+    """Full mix: 3 stuck (aged judge, aged chain, fresh llm_call) of 5 pending."""
+    await DeadLetterQueue(db, clock=_at(2)).enqueue("chain_exhausted:judge", "{}", "all", "e")   # stuck
+    await DeadLetterQueue(db, clock=lambda: _NOW).enqueue("chain_exhausted:judge", "{}", "all", "e")  # fresh
+    await DeadLetterQueue(db, clock=_at(2)).enqueue("chain_exhausted:other", "{}", "all", "e")   # within 6h
+    await DeadLetterQueue(db, clock=_at(7)).enqueue("chain_exhausted:other", "{}", "all", "e")   # stuck
+    await DeadLetterQueue(db, clock=lambda: _NOW).enqueue("llm_call", "{}", "x", "e")            # stuck (no short TTL)
+
+    q = DeadLetterQueue(db, clock=lambda: _NOW)
+    assert await q.get_pending_count() == 5
+    assert await q.get_stuck_count() == 3


### PR DESCRIPTION
## What & why

In late June a capped Anthropic **Max** subscription made `claude -p` return **silent empty output** (0 tokens, no error, no `rate_limit_event`) on Genesis's cognitive calls. Those blank runs recorded as *successes*, so ego cycles / reflections / weekly jobs produced nothing for ~2 days and **nothing alerted**. This PR makes that visible in real time, and fixes a related cry-wolf on the dead-letter alert.

Scope was set with the user to **detection + alert only** (real-time, invoker-level) + the DLQ threshold honesty fix. Failover of ego/reflection to a peer (and provisioning `ZHIPU_API_KEY` to re-arm the currently-inert CC roster) are **deferred** to the ego-quality spike — verified during planning that those sites have no failover loop and the roster has no authenticable peer today.

## Item 1 — real-time silent-cap detection (no raise, no failover, no control-flow change)

- **`CCInvocation.expect_output: bool = False`** (opt-in). The invoker fires a new injected `on_cc_empty_output` callback at the success returns when `expect_output and not output.text.strip() and not output.is_error` (+ `rate_limit_event` guard on the streaming no-result path). It never raises and never changes the returned output (mirrors `_fire_downgrade_callback`).
- **`cc_relay._on_cc_empty_output`** records each as a low-priority **internal** `cc_cap_empty_event` observation (mirrors `_on_model_downgrade`; 3-day TTL; no migration).
- **`awareness/loop._check_cc_cap_detection`** counts unresolved events in the last 60 min; **≥3 → one critical `infrastructure_alert`** (`cc_cap_monitor`) that rides the existing critical-observations job to Telegram. DB-backed dedup (`content_hash` + `skip_if_duplicate`) so a multi-hour cap yields **one** alert, and it **auto-resolves** on recovery (+ resets the cooldown). **Alert-only** — deliberately does *not* touch `CCStatus`/backoff (that would suppress the very signal + oscillate).
- **12 output-producing cognitive sites** opt in (ego ×2, reflection ×3, sentinel, decomposer, plan/adversarial review, step dispatcher, research, mail judge). Excludes foreground/streaming, direct sessions, the liveness probe, checkpoint resume, gauntlet, and the inbox monitor (already fails-on-empty).

**Calibration:** verified against real `cc_sessions` that `output_tokens=0` is *normal* for foreground/inbox (accounting gap) but the invoker sees the true empty output; and that a row-counting `cc_sessions` detector can't beat ~48h latency (normal cognitive-success gaps reach ~31h; the June cap was a 114h drought) — hence the invoker hook.

**Honest limits (documented in code):** fires only while cognitive work is *attempted* (a cap that also halts dispatch is a blind spot — a ~48h drought backstop is possible future work); targets the *silent* case only (`is_error=False`) — classified errors are already visible.

## Item 2 — DLQ alert counts genuinely-stuck items, not self-healing bursts

The critical DLQ-accumulation alert counted *all* pending equally, so a 7-min burst of ~63 `chain_exhausted:judge` grades (1h TTL, "worthless after minutes") fired a **critical** Telegram alert though it self-heals. New `DeadLetterQueue.get_stuck_count()` counts an item only if it's **not** a short-TTL self-healing type still inside its window (reusing `_OPERATION_TTL_HOURS`); types without a short TTL count immediately (no long-TTL regression). Raw total still shows on the dashboard/snapshot (`get_pending_count` unchanged).

## Verification

- **genesis-architect**: SHIP-WITH-CHANGES — all folded in (observations sink not cc_session metadata; alert-only; `not text.strip()` discriminant; the 12-site opt-in set).
- **code-reviewer**: SHIP-WITH-NITS — the one real finding (cap-alert write-spam under a persisting cap) fixed with dedup + resolve; one pre-existing DLQ boot-caveat tracked as a follow-up.
- **Tests**: `test_invoker_empty_output`, `test_cc_cap_detection`, `test_dead_letter_stuck_count`, updated `test_queues_dead_letter`. Regression: full `test_cc` (639p), `test_awareness`, `test_routing`, observation-TTL — all green. ruff clean on the full diff.
- **E2E** (real schema + live data): detector creates the critical alert → it surfaces via the exact `get_unsurfaced(critical)` Telegram query → raw events stay internal → dedup holds → recovery resolves; and `get_stuck_count` on live data correctly split 39 pending into 36 stuck (aged past 1h) / 3 fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
