### PR TITLE
docs(autonomy): codify egress-gating contract + GROUNDWORK the CI-blind distribute() path

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -307,3 +307,8 @@ Standard open-source workflow: PRs go directly to the public repo.
   defaults (no `config/campaigns/`). Only campaign infrastructure ships. Express
   reusable session types as generic roles (e.g. the `community-responder`
   profile), not names coupled to a live campaign. See `src/genesis/campaigns/__init__.py`.
+- **External egress is gated; owner-facing egress is not** — any autonomous send to the
+  outside world (Discord, Medium, Twitter/X, Slack, `DistributionManager.distribute`) MUST
+  route through the capability shadow-gate (`autonomy/shadow_gate`) before the enforce stage;
+  the `scripts/check_external_io.py` CI guard backstops new endpoints. Delivery TO the owner
+  (Telegram/voice/email-to-owner) is NEVER gated. Full contract in `autonomy/shadow_gate.py`.

--- a/src/genesis/autonomy/shadow_gate.py
+++ b/src/genesis/autonomy/shadow_gate.py
@@ -1,12 +1,28 @@
-"""WS5 Discord capability SHADOW-gate — observe-only.
+"""WS5 capability SHADOW-gate — observe-only (Discord doors today).
 
-At each autonomous Discord egress door, record what a capability gate WOULD decide
+At each autonomous external egress door, record what a capability gate WOULD decide
 (hold vs allow) WITHOUT holding. The lookup is READ-ONLY (no ``apply_event`` /
 ``ensure_cell`` — a not-yet-created cell simply reads as ``not_determined``), the
 record is BEST-EFFORT (any failure — a ``None`` db, a missing table, a locked DB — is
 swallowed at DEBUG), and the function NEVER raises, NEVER blocks, and NEVER mutates
 capability state. The real send always proceeds. This is the observation phase before
 the ENFORCE stage turns the gate on.
+
+EGRESS-GATING CONTRACT — read before wiring ANY new outbound channel:
+- **Owner-facing channels are NEVER gated.** Delivery TO the owner — Telegram-to-owner,
+  voice/TTS, email-to-owner — is not external-world posting (the owner IS the recipient);
+  gating it only obstructs the user. There is no gate on these today; keep it that way.
+- **Every autonomous EXTERNAL/public egress MUST be gated** — shadow-observed here now,
+  enforced later. Live external egress today: email (ENFORCES via ``autonomy.email_gate``)
+  and Discord (SHADOW-observed at the 3 doors below). Any FUTURE public channel — Medium,
+  Twitter/X, Slack, autonomous ``distribution.DistributionManager.distribute`` publishing —
+  MUST route its send through this shadow-gate before the enforce stage. Do not ship an
+  unobserved external door.
+- **CI backstop:** ``scripts/check_external_io.py`` fails the build on a new Discord/webhook/
+  public-social endpoint outside its allowlist and documents the same owner-vs-external rule
+  (its lines 24-27). It CANNOT see browser/Composio egress or a ``distribute()`` call with no
+  literal endpoint token — those carry a ``# GROUNDWORK(autonomous-distribution)`` marker at
+  the call sites (``distribution/manager.py``, ``modules/content_pipeline/module.py``) instead.
 
 Coverage (the three live Discord doors — enumerated, exhaustive):
 - ``deliver`` — ``outreach/pipeline._deliver`` (server process) -> discord webhook

--- a/src/genesis/distribution/manager.py
+++ b/src/genesis/distribution/manager.py
@@ -55,6 +55,12 @@ class DistributionManager:
         Returns:
             List of PostResult, one per platform attempted.
         """
+        # GROUNDWORK(autonomous-distribution): the server-side autonomous publish path.
+        # Dormant today (no prod caller; the distributor registry is empty and Medium/
+        # browser publishing runs from foreground CC sessions). When this goes live, EACH
+        # external platform send below MUST first route through the capability shadow-gate
+        # (autonomy/shadow_gate) — then the enforce stage — per the egress-gating contract.
+        # check_external_io.py cannot see this door (no literal endpoint token on the call).
         results: list[PostResult] = []
 
         for platform in platforms:

--- a/src/genesis/modules/content_pipeline/module.py
+++ b/src/genesis/modules/content_pipeline/module.py
@@ -131,6 +131,11 @@ class ContentPipelineModule:
         handles DB record-keeping; platform adapters are registered at
         publish time by the calling session.
         """
+        # GROUNDWORK(autonomous-distribution): when server-side autonomous publishing is
+        # turned on here (registering platform distributors + calling manager.distribute()),
+        # each EXTERNAL send MUST route through the capability shadow-gate (autonomy/
+        # shadow_gate) before the enforce stage. Public targets (medium/discord in
+        # _platform_targets) are gated; owner-facing targets (telegram/voice) are NOT.
         manager = DistributionManager(db=db)
         logger.info("Distribution manager initialized (platforms registered per-session)")
         return manager


### PR DESCRIPTION
## What
Codifies the egress-gating contract in code (docs + GROUNDWORK markers) so a future session wiring a new outbound channel can't ship it ungated.

## Why
Owner-facing channels (Telegram, voice, email-to-owner) are intentionally **never** gated; every autonomous **external/public** egress must route through the capability shadow-gate (shadow now, enforce later). Today that rule lives only in tribal knowledge + the `scripts/check_external_io.py` CI guard — which structurally can't see browser/Composio egress or a `DistributionManager.distribute()` call with no literal endpoint token. This closes that documentation gap.

## Changes (docs/comments only — no behavior change)
- `autonomy/shadow_gate.py`: module docstring now states the full egress-gating contract + cross-references the CI guard.
- `distribution/manager.py` + `modules/content_pipeline/module.py`: `# GROUNDWORK(autonomous-distribution)` markers at the two spots a dev would wire server-side autonomous publishing — the paths the CI guard cannot catch.
- `genesis-development` skill: one bullet pointing devs at the contract.

Deferred to the PR that actually adds the next external channel: renaming `observe_discord_send` → `observe_external_send` + generalizing its signature (speculative today, and can't be safely auto-renamed — the 3 doors use function-local imports the LSP under-resolves).

## Verification
- Reviewer verified every factual claim against code
- `ruff` clean; `scripts/check_external_io.py` clean; 7 shadow-gate tests green
- No runtime change → no restart needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)