### PR TITLE
fix(knowledge): re-ingest re-distills changed content via content-hash gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Re-ingesting a knowledge source with changed content now refreshes it instead of serving the stale
+  version.** Previously, once a file or URL was ingested, re-ingesting the same source was skipped on source
+  identity alone — so if the underlying content changed, the knowledge base kept serving the old distilled
+  version indefinitely. Re-ingestion now compares a content fingerprint and re-distills when the content has
+  actually changed (unchanged content is still skipped, and a now-unreachable source falls back to its
+  previously cached version).
+
 - **The dead-letter-queue alert no longer cries wolf on self-healing bursts.** A short burst of low-value
   retry items (e.g. memory-relevance grades, which are discarded within an hour by design) could push the queue
   past its alert threshold and fire a *critical* notification for something that clears itself minutes later.

--- a/src/genesis/knowledge/manifest.py
+++ b/src/genesis/knowledge/manifest.py
@@ -75,6 +75,19 @@ class ManifestManager:
         """Check if a source has already been ingested."""
         return self.source_hash(source) in self._load()
 
+    def has_unchanged_source(self, source: str, content_hash: str) -> bool:
+        """True iff the source is already ingested AND its stored ``content_hash``
+        matches (i.e. the content has NOT changed since the last ingest).
+
+        A source that is unknown, or a pre-existing entry with no stored
+        ``content_hash``, reads as *changed* (returns False) so it re-distills
+        exactly once and then stabilizes."""
+        entry = self._load().get(self.source_hash(source))
+        if entry is None:
+            return False
+        stored = entry.get("content_hash")
+        return stored is not None and stored == content_hash
+
     def save_extracted_text(self, source: str, text: str, source_type: str) -> Path:
         """Save extracted text to sources/ directory. Returns the file path."""
         self.ensure_dirs()
@@ -109,8 +122,16 @@ class ManifestManager:
         extracted_path: Path,
         original_path: Path | None = None,
         unit_ids: list[str] | None = None,
+        content_hash: str | None = None,
     ) -> None:
-        """Register a source in the manifest."""
+        """Register a source in the manifest.
+
+        ``content_hash`` (optional) fingerprints the extracted text so a later
+        re-ingest can tell whether the content CHANGED (re-distill) or is
+        unchanged (serve cache) via ``has_unchanged_source``. Additive JSON key —
+        entries written before this existed carry no ``content_hash`` and read as
+        *changed* the first time (re-distill once, then stabilize).
+        """
         manifest = self._load()
         h = self.source_hash(source)
         manifest[h] = {
@@ -119,6 +140,7 @@ class ManifestManager:
             "extracted_path": str(extracted_path),
             "original_path": str(original_path) if original_path else None,
             "unit_ids": unit_ids or [],
+            "content_hash": content_hash,
             "ingested_at": datetime.now(UTC).isoformat(),
         }
         self._save()
@@ -139,8 +161,9 @@ class ManifestManager:
         per-unit), but the manifest tracks whole sources. We pop ``unit_id`` from
         its owning entry's ``unit_ids``; when that removes the source's LAST live
         unit, we delete the entire entry — a *tombstone* — so a future re-ingest
-        is no longer blocked by the source-identity gate (``has_source``), which
-        would otherwise serve now-dead cached unit IDs forever.
+        is no longer short-circuited by the dedup gate (``has_unchanged_source``,
+        which keys on the manifest entry), which would otherwise serve now-dead
+        cached unit IDs forever.
 
         INVARIANT: only a transition-to-empty *via this method* tombstones an
         entry. A ``no_units_extracted`` source (``add_source`` with

--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import json
 import logging
 import typing
@@ -69,16 +70,10 @@ class KnowledgeOrchestrator:
         on_chunk_done: typing.Callable | None = None,
     ) -> IngestResult:
         """Ingest a single source (file path or URL) into the knowledge base."""
-        # 1. Check for duplicate
-        if self._manifest.has_source(source):
-            existing_ids = self._manifest.get_units_for_source(source)
-            return IngestResult(
-                source=source,
-                source_type="cached",
-                units_created=0,
-                unit_ids=existing_ids,
-                quality_flags=["duplicate_source"],
-            )
+        # NB: dedup is content-hash based and runs AFTER extraction (the
+        # "content-hash dedup gate" below). The old source-identity gate that lived
+        # here was removed so a re-ingest with CHANGED content re-distills instead
+        # of serving now-stale cached units.
 
         # 2. Find processor
         processor = self._registry.get_processor(source)
@@ -94,6 +89,22 @@ class KnowledgeOrchestrator:
         try:
             content = await processor.process(source)
         except Exception as exc:
+            # Regression guard for the content-hash gate move: every re-ingest now
+            # runs the processor BEFORE any dedup check. If a previously-cached
+            # source is now unreachable, serve its cached units instead of failing
+            # (strictly better than pre-move, which also served cache in this case).
+            if self._manifest.has_source(source):
+                logger.warning(
+                    "Re-ingest of %s failed extraction (%s) — serving cached units",
+                    source, exc,
+                )
+                return IngestResult(
+                    source=source,
+                    source_type="cached",
+                    units_created=0,
+                    unit_ids=self._manifest.get_units_for_source(source),
+                    quality_flags=["duplicate_source", "source_unreachable_served_cache"],
+                )
             return IngestResult(
                 source=source,
                 source_type="error",
@@ -107,6 +118,20 @@ class KnowledgeOrchestrator:
                 source_type=content.source_type,
                 units_created=0,
                 quality_flags=["empty_content"],
+            )
+
+        # Content-hash dedup gate (moved here from the top of the method). Now that
+        # the text is extracted, short-circuit ONLY if the content is unchanged;
+        # changed content falls through and re-distills. sha256[:32] mirrors the
+        # content-hash pattern in recon/web_monitoring.py.
+        content_hash = hashlib.sha256(content.text.encode()).hexdigest()[:32]
+        if self._manifest.has_unchanged_source(source, content_hash):
+            return IngestResult(
+                source=source,
+                source_type="cached",
+                units_created=0,
+                unit_ids=self._manifest.get_units_for_source(source),
+                quality_flags=["duplicate_source"],
             )
 
         # 3a. Injection-pattern scan (detect-and-flag, NEVER block; fail-open).
@@ -175,6 +200,7 @@ class KnowledgeOrchestrator:
                 source_type=content.source_type,
                 extracted_path=extracted_path,
                 original_path=original_path,
+                content_hash=content_hash,
             )
             # Still collect tree result if started
             tree_doc_id = await self._collect_tree_result(tree_task, source)
@@ -217,6 +243,7 @@ class KnowledgeOrchestrator:
             extracted_path=extracted_path,
             original_path=original_path,
             unit_ids=unit_ids,
+            content_hash=content_hash,
         )
 
         quality_flags = []

--- a/tests/test_knowledge/test_manifest.py
+++ b/tests/test_knowledge/test_manifest.py
@@ -101,3 +101,37 @@ def test_remove_unit_partial_removal_persists_across_reload(tmp_path: Path):
     assert mgr.remove_unit("u1") is True
     fresh = _mgr(tmp_path)
     assert fresh.get_units_for_source("doc.txt") == ["u2"]
+
+
+# ─── content-hash idempotency (gate move: re-ingest changed content) ──────────
+
+
+def test_add_source_persists_content_hash(tmp_path: Path):
+    """add_source stores an optional content_hash that survives a reload and
+    drives has_unchanged_source."""
+    mgr = _mgr(tmp_path)
+    mgr.add_source(
+        "doc.txt",
+        source_type="text",
+        extracted_path=mgr.sources_dir / f"{ManifestManager.source_hash('doc.txt')}.md",
+        unit_ids=["u1"],
+        content_hash="abc123",
+    )
+    fresh = _mgr(tmp_path)  # reload from disk
+    assert fresh.has_unchanged_source("doc.txt", "abc123") is True
+    assert fresh.has_unchanged_source("doc.txt", "different") is False
+
+
+def test_has_unchanged_source_unknown_source_is_false(tmp_path: Path):
+    """A never-ingested source is trivially 'changed' (needs ingest)."""
+    mgr = _mgr(tmp_path)
+    assert mgr.has_unchanged_source("never.txt", "abc") is False
+
+
+def test_has_unchanged_source_false_without_stored_hash(tmp_path: Path):
+    """A pre-existing entry with NO content_hash (legacy add_source) reads as
+    changed, so it re-distills exactly once and then stabilizes."""
+    mgr = _mgr(tmp_path)
+    _add(mgr, "doc.txt", ["u1"])  # legacy add: no content_hash persisted
+    assert mgr.has_source("doc.txt") is True
+    assert mgr.has_unchanged_source("doc.txt", "anyhash") is False

--- a/tests/test_knowledge/test_orchestrator.py
+++ b/tests/test_knowledge/test_orchestrator.py
@@ -248,3 +248,71 @@ async def test_ingest_scan_failure_is_fail_open(tmp_path: Path):
 
     assert result.units_created == 1
     assert not any("injection_patterns_detected" in f for f in result.quality_flags)
+
+
+# ─── content-hash idempotency: re-ingest changed vs unchanged content ─────────
+
+
+async def test_reingest_changed_content_redistills(tmp_path: Path):
+    """Re-ingesting the SAME source with CHANGED content re-runs distillation
+    instead of serving the stale cached units (the content-hash gate move)."""
+    units = [KnowledgeUnit(concept="Test", body="Test body", domain="test")]
+    orch = _make_orchestrator(tmp_path, mock_distill_result=units)
+    with patch("genesis.knowledge.orchestrator.KnowledgeOrchestrator._store_units",
+               new_callable=AsyncMock, return_value=["unit-1"]):
+        file = tmp_path / "doc.txt"
+        file.write_text("Original content worth distilling.")
+        r1 = await orch.ingest_source(str(file), project_type="test")
+        assert r1.units_created == 1
+
+        # Change the content — must NOT short-circuit as a duplicate now.
+        file.write_text("Completely different content, re-distill me please.")
+        r2 = await orch.ingest_source(str(file), project_type="test")
+        assert r2.units_created == 1
+        assert "duplicate_source" not in r2.quality_flags
+
+
+async def test_reingest_unchanged_content_serves_cache(tmp_path: Path):
+    """Re-ingesting identical content still short-circuits to the cached result
+    (dedup preserved through the gate move)."""
+    units = [KnowledgeUnit(concept="Test", body="Test body", domain="test")]
+    orch = _make_orchestrator(tmp_path, mock_distill_result=units)
+    with patch("genesis.knowledge.orchestrator.KnowledgeOrchestrator._store_units",
+               new_callable=AsyncMock, return_value=["unit-1"]):
+        file = tmp_path / "doc.txt"
+        file.write_text("Stable content.")
+        await orch.ingest_source(str(file), project_type="test")
+        r2 = await orch.ingest_source(str(file), project_type="test")
+        assert r2.units_created == 0
+        assert "duplicate_source" in r2.quality_flags
+
+
+async def test_reingest_unreachable_source_serves_cache(tmp_path: Path):
+    """With the source-string gate removed, a re-ingest runs the processor first;
+    if a previously-cached source is now unreachable, serve cached (not error)."""
+    units = [KnowledgeUnit(concept="Test", body="Test body", domain="test")]
+    orch = _make_orchestrator(tmp_path, mock_distill_result=units)
+    with patch("genesis.knowledge.orchestrator.KnowledgeOrchestrator._store_units",
+               new_callable=AsyncMock, return_value=["unit-1"]):
+        file = tmp_path / "doc.txt"
+        file.write_text("Cache me.")
+        r1 = await orch.ingest_source(str(file), project_type="test")
+        assert r1.units_created == 1
+
+        file.unlink()  # source now unreachable
+        r2 = await orch.ingest_source(str(file), project_type="test")
+        assert r2.error is None
+        assert r2.units_created == 0
+        assert r2.unit_ids == ["unit-1"]
+
+
+async def test_reingest_no_units_source_detects_unchanged(tmp_path: Path):
+    """The no-units path also persists content_hash, so an identical re-ingest of
+    a source that distilled to zero units is still detected as unchanged."""
+    orch = _make_orchestrator(tmp_path, mock_distill_result=[])
+    file = tmp_path / "notes.txt"
+    file.write_text("Content that yields no units.")
+    r1 = await orch.ingest_source(str(file), project_type="test")
+    assert "no_units_extracted" in r1.quality_flags
+    r2 = await orch.ingest_source(str(file), project_type="test")
+    assert "duplicate_source" in r2.quality_flags


### PR DESCRIPTION
## The bug
The knowledge-ingestion orchestrator deduped on **source string** at the top of `ingest_source`, so re-ingesting the same file/URL was skipped on identity alone. If the underlying content changed, the knowledge base kept serving the old distilled version indefinitely.

## The fix
Move the dedup gate to be **content-hash based**, after extraction: compute `sha256(text)[:32]` and short-circuit only when the content is unchanged (`has_unchanged_source`); changed content re-distills. Unchanged content is still served from cache, and a now-unreachable source falls back to its cached units instead of erroring. `content_hash` is an additive JSON manifest key (no migration), persisted at both `add_source` sites.

## Deliberately out of scope (→ follow-up)
The differential delete of disappeared/reworded units on a changed re-distill is **not** included — old units may linger. Knowledge-unit relationships are free-text concept strings (not id FKs), so lingering units orphan no references. Gated on re-ingest becoming a real pattern (live KB: ~5 sources, 0 re-ingests today).

## Verification
- Code review: all 6 correctness points verified (97%)
- 88 `test_knowledge` + 103 sibling tests green; `ruff` clean
- E2E through real `ingest_source` + on-disk manifest: new / unchanged→cached / changed→re-distill / unreachable→cache
- No migration; deploy = `git pull` + restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)