### PR TITLE
fix(knowledge): ingest async correctness — crash/hang-safe PDF pool + unstranded uploads + no orphan tree tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Uploading a large or malformed PDF to the Knowledge tab no longer freezes — or crashes — Genesis.**
+  PDF text extraction used to run directly on the main event loop, so a big document could stall the whole
+  server for seconds (health checks, background thinking, other requests all waited), and a corrupt or
+  hostile PDF could take the process down entirely. Extraction now runs in an isolated worker process with a
+  time limit: a large PDF no longer blocks anything else, and a PDF that crashes or hangs the parser fails
+  just that one ingest — the rest of Genesis keeps running. Uploads that hit a transient database hiccup are
+  now marked "failed" (and can be retried) instead of getting stuck showing "processing" forever.
+
 - **The dead-letter-queue alert no longer cries wolf on self-healing bursts.** A short burst of low-value
   retry items (e.g. memory-relevance grades, which are discarded within an hour by design) could push the queue
   past its alert threshold and fire a *critical* notification for something that clears itself minutes later.

--- a/src/genesis/dashboard/routes/knowledge_upload.py
+++ b/src/genesis/dashboard/routes/knowledge_upload.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import mimetypes
 import re
@@ -137,18 +136,26 @@ async def knowledge_ingest_upload():
             return jsonify({"error": "Upload not found"}), 404
         return jsonify({"error": f"Upload in '{upload['status']}' state, expected 'uploaded'"}), 409
 
-    # Fire-and-forget: _async_route already runs us on the main event loop,
-    # so create_task schedules directly without an extra cross-thread hop.
+    # Fire-and-forget: _async_route already runs us on the main event loop, so
+    # create_task schedules directly without an extra cross-thread hop. Use
+    # tracked_task so any failure that escapes run_ingest's own handling (e.g.
+    # an unexpected error before its inner try) is logged with context instead
+    # of being silently swallowed by a bare create_task.
     from genesis.knowledge.ingest_upload import run_ingest
+    from genesis.util.tasks import tracked_task
 
-    asyncio.create_task(run_ingest(
-        upload_id,
-        project_type=project_type,
-        domain=domain,
-        purpose=purpose_list,
-        context=context,
-        mode=mode,
-    ))
+    tracked_task(
+        run_ingest(
+            upload_id,
+            project_type=project_type,
+            domain=domain,
+            purpose=purpose_list,
+            context=context,
+            mode=mode,
+        ),
+        name=f"ingest-{upload_id}",
+        logger=logger,
+    )
 
     return jsonify({
         "upload_id": upload_id,

--- a/src/genesis/knowledge/_pdf_worker.py
+++ b/src/genesis/knowledge/_pdf_worker.py
@@ -1,0 +1,44 @@
+"""Synchronous PDF text extraction — runs inside a ProcessPoolExecutor worker.
+
+This module is deliberately tiny and free of any ``genesis`` runtime imports so
+that a ``spawn``-context worker re-importing it (to unpickle the target function)
+pulls in nothing heavy. ``pymupdf`` is imported lazily inside the function, in
+the child process, where it is safe to run one document at a time.
+
+See ``genesis.knowledge.pdf_extract`` for the async wrapper and the rationale
+(PyMuPDF is not thread-safe and can natively crash/hang on adversarial PDFs).
+"""
+
+from __future__ import annotations
+
+
+def _warmup() -> bool:
+    """Trivial task to force a pool worker to spawn (keeps worker imports to
+    this tiny module only). See ``pdf_extract._make_pool``."""
+    return True
+
+
+def extract_pdf_text_sync(path: str) -> tuple[str, list[str], int]:
+    """Extract text from a PDF file.
+
+    Returns ``(full_text, sections, page_count)``. Semantics are preserved
+    exactly from the original inline ``PDFProcessor`` implementation:
+
+    - only pages whose *stripped* text is non-empty are collected;
+    - ``page_count`` is the number of NON-BLANK pages (NOT ``len(doc)``);
+    - ``sections`` is the list of per-page non-blank texts.
+    """
+    import pymupdf
+
+    doc = pymupdf.open(path)
+    try:
+        pages: list[str] = []
+        for page in doc:
+            text = page.get_text()
+            if text.strip():
+                pages.append(text.strip())
+    finally:
+        doc.close()
+
+    full_text = "\n\n".join(pages)
+    return full_text, pages, len(pages)

--- a/src/genesis/knowledge/ingest_upload.py
+++ b/src/genesis/knowledge/ingest_upload.py
@@ -48,8 +48,26 @@ async def run_ingest(
         logger.error("DB not available for ingest upload %s", upload_id)
         return
 
-    # Fetch upload record to get file_path
-    upload = await knowledge_uploads.get(rt.db, upload_id)
+    # Fetch upload record to get file_path. A transient DB error here (e.g. a
+    # locked DB) previously propagated above the try/except below and stranded
+    # the row in 'processing' until the next server restart (recovery only runs
+    # at startup). Mark the row 'failed' instead so the dashboard reflects it
+    # and the file can be retried.
+    try:
+        upload = await knowledge_uploads.get(rt.db, upload_id)
+    except Exception as exc:
+        logger.exception("Failed to load upload %s — marking failed", upload_id)
+        try:
+            await knowledge_uploads.update_status(
+                rt.db, upload_id,
+                status="failed",
+                error_message=f"Upload lookup failed: {exc}",
+            )
+        except Exception:
+            logger.exception(
+                "Failed to mark upload %s failed after lookup error", upload_id
+            )
+        return
     if upload is None:
         logger.error("Upload %s not found in DB", upload_id)
         return

--- a/src/genesis/knowledge/orchestrator.py
+++ b/src/genesis/knowledge/orchestrator.py
@@ -150,24 +150,37 @@ class KnowledgeOrchestrator:
                 name=f"tree-index-{Path(source).name}",
             )
 
-        # 4. Save extracted text to disk
-        extracted_path = self._manifest.save_extracted_text(
-            source, content.text, content.source_type
-        )
+        # 4-6. Save extracted text + optional original, then distill. If any of
+        # these fail, cancel the in-flight tree-index task first so a failed
+        # ingest can't leak an orphaned PageIndex upload (which polls for up to
+        # 300s), then re-raise. (The storage step below has its own cancel.)
+        try:
+            # 4. Save extracted text to disk
+            extracted_path = self._manifest.save_extracted_text(
+                source, content.text, content.source_type
+            )
 
-        # 5. Optionally save original
-        original_path = None
-        source_path = Path(source)
-        if source_path.exists():
-            original_path = self._manifest.save_original(source, source_path)
+            # 5. Optionally save original
+            original_path = None
+            source_path = Path(source)
+            if source_path.exists():
+                original_path = self._manifest.save_original(source, source_path)
 
-        # 6. Distill
-        units = await self._distillation.distill(
-            content, project_type=project_type, domain=domain,
-            user_context=user_context,
-            on_chunk_done=on_chunk_done,
-            content_source=content_source,
-        )
+            # 6. Distill
+            units = await self._distillation.distill(
+                content, project_type=project_type, domain=domain,
+                user_context=user_context,
+                on_chunk_done=on_chunk_done,
+                content_source=content_source,
+            )
+        except Exception:
+            if tree_task is not None:
+                tree_task.cancel()
+                # CancelledError is a BaseException, so suppress(Exception)
+                # alone would let it escape and mask the real error.
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await tree_task
+            raise
 
         if not units:
             self._manifest.add_source(
@@ -201,7 +214,9 @@ class KnowledgeOrchestrator:
             # Cancel tree task to avoid orphaned upload
             if tree_task is not None:
                 tree_task.cancel()
-                with contextlib.suppress(Exception):
+                # CancelledError is a BaseException, so suppress(Exception)
+                # alone would let it escape and mask the real error.
+                with contextlib.suppress(asyncio.CancelledError, Exception):
                     await tree_task
             return IngestResult(
                 source=source,

--- a/src/genesis/knowledge/pdf_extract.py
+++ b/src/genesis/knowledge/pdf_extract.py
@@ -26,6 +26,7 @@ artifacts there to be reaped. Revisit if a future CPython changes this.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import multiprocessing
 from concurrent.futures import ProcessPoolExecutor
@@ -65,7 +66,15 @@ def _make_pool() -> ProcessPoolExecutor:
     """
     ctx = multiprocessing.get_context("spawn")
     pool = ProcessPoolExecutor(max_workers=1, mp_context=ctx)
-    pool.submit(_warmup).result(timeout=_START_TIMEOUT_S)
+    try:
+        pool.submit(_warmup).result(timeout=_START_TIMEOUT_S)
+    except Exception:
+        # A failed warmup (spawn stall, resource exhaustion) must not leak the
+        # executor or any worker the OS did manage to start.
+        _kill_workers(pool)
+        with contextlib.suppress(Exception):
+            pool.shutdown(wait=False, cancel_futures=True)
+        raise
     return pool
 
 
@@ -87,8 +96,15 @@ async def extract_pdf_text(path: str) -> tuple[str, list[str], int]:
     recreated on the next call). Callers treat this as a failed ingest; the
     server is unaffected.
     """
-    pool = await _get_pool()
     loop = asyncio.get_running_loop()
+    try:
+        pool = await _get_pool()
+    except Exception as exc:
+        # Pool creation failed (worker spawn stall, resource exhaustion).
+        # _make_pool has already cleaned up its own partial pool; surface a
+        # clean domain error so callers (e.g. resume_review) degrade gracefully.
+        logger.error("PDF extraction pool unavailable: %s", exc)
+        raise PDFExtractionError("PDF extraction pool unavailable") from exc
     try:
         return await asyncio.wait_for(
             loop.run_in_executor(pool, extract_pdf_text_sync, path),

--- a/src/genesis/knowledge/pdf_extract.py
+++ b/src/genesis/knowledge/pdf_extract.py
@@ -1,0 +1,163 @@
+"""Async PDF text extraction via a crash/hang-isolated process pool.
+
+PyMuPDF is not thread-safe and can natively crash (segfault) or hang on
+malformed/adversarial PDFs. Genesis ingests UNTRUSTED PDFs (dashboard uploads,
+web-fetched sources via ``knowledge_ingest_source``), so extraction runs in a
+dedicated single-worker, ``spawn``-context ``ProcessPoolExecutor``:
+
+- a crash surfaces as ``BrokenProcessPool`` (recoverable) instead of taking
+  down the genesis-server event loop;
+- a hang is bounded by ``PDF_EXTRACT_TIMEOUT_S`` and the wedged worker is
+  SIGKILLed (``Future.cancel()`` is a no-op once a worker is running, so a
+  caller-side timeout alone would leak the worker);
+- both cases raise ``PDFExtractionError`` and lazily recreate the pool.
+
+With ``max_workers=1`` a crash also fails any PDF concurrently queued behind the
+offending one (they share the single worker) — an accepted tradeoff given the
+low ingest volume; each failed caller simply retries on a fresh pool.
+
+Temp/IPC note: a ``spawn`` ProcessPoolExecutor on Linux/CPython 3.12 keeps its
+IPC in ``/dev/shm`` (POSIX ``sem.mp-*``) plus anonymous fd pipes — it writes
+NOTHING under ``$TMPDIR`` (verified empirically). So despite genesis-server's
+``TMPDIR=~/.genesis/cc-tmp`` (which the tmp-watchgod sweeps), the pool has no
+artifacts there to be reaped. Revisit if a future CPython changes this.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import multiprocessing
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
+
+from genesis.knowledge._pdf_worker import _warmup, extract_pdf_text_sync
+
+logger = logging.getLogger(__name__)
+
+# Bound a pathological/hung parse. Legitimate PDF *text* extraction (not
+# rendering) completes in well under a minute even for very large documents;
+# 300s gives generous headroom while ensuring a single wedged/adversarial PDF
+# cannot jam the max_workers=1 pipeline indefinitely. This is the subprocess
+# exception to the "no speculative timeouts" rule (genesis-development timeout
+# policy): the pool is the ONLY recovery mechanism for a hung native call, and
+# a hang here blocks every subsequent ingest.
+PDF_EXTRACT_TIMEOUT_S = 300.0
+
+# Worker spawn should be near-instant; bound it so a broken environment fails
+# pool creation loudly instead of hanging.
+_START_TIMEOUT_S = 30.0
+
+_pool: ProcessPoolExecutor | None = None
+_lock = asyncio.Lock()
+
+
+class PDFExtractionError(RuntimeError):
+    """PDF extraction crashed, hung, or otherwise failed in the worker pool."""
+
+
+def _make_pool() -> ProcessPoolExecutor:
+    """Create a spawn-context single-worker pool and force the worker to start.
+
+    Blocking (spawn) — call via ``asyncio.to_thread``. Forcing the worker to
+    spawn now pre-pays the spawn latency and surfaces a broken environment at
+    creation time rather than mid-ingest.
+    """
+    ctx = multiprocessing.get_context("spawn")
+    pool = ProcessPoolExecutor(max_workers=1, mp_context=ctx)
+    pool.submit(_warmup).result(timeout=_START_TIMEOUT_S)
+    return pool
+
+
+async def _get_pool() -> ProcessPoolExecutor:
+    global _pool
+    if _pool is not None:
+        return _pool
+    async with _lock:
+        if _pool is None:
+            _pool = await asyncio.to_thread(_make_pool)
+        return _pool
+
+
+async def extract_pdf_text(path: str) -> tuple[str, list[str], int]:
+    """Extract ``(full_text, sections, page_count)`` from a PDF, off the loop.
+
+    Raises ``PDFExtractionError`` if the worker crashes or the parse exceeds
+    ``PDF_EXTRACT_TIMEOUT_S`` (the wedged worker is killed and the pool
+    recreated on the next call). Callers treat this as a failed ingest; the
+    server is unaffected.
+    """
+    pool = await _get_pool()
+    loop = asyncio.get_running_loop()
+    try:
+        return await asyncio.wait_for(
+            loop.run_in_executor(pool, extract_pdf_text_sync, path),
+            timeout=PDF_EXTRACT_TIMEOUT_S,
+        )
+    except TimeoutError as exc:
+        logger.error(
+            "PDF extraction timed out after %.0fs — killing worker: %s",
+            PDF_EXTRACT_TIMEOUT_S, path,
+        )
+        await _kill_and_recreate(pool)
+        raise PDFExtractionError(
+            f"PDF extraction timed out after {PDF_EXTRACT_TIMEOUT_S:.0f}s"
+        ) from exc
+    except BrokenProcessPool as exc:
+        logger.error("PDF worker crashed while extracting %s", path)
+        await _kill_and_recreate(pool)
+        raise PDFExtractionError("PDF parser crashed") from exc
+
+
+async def _kill_and_recreate(broken: ProcessPoolExecutor) -> None:
+    """Hard-kill the pool's worker(s) and drop the pool (compare-and-swap).
+
+    ``pool.shutdown()`` alone can block on a wedged native call, so SIGKILL the
+    worker processes directly (mirroring guardian/_subprocess.py), then let
+    ``_get_pool`` lazily recreate. Only the caller that observed *this* broken
+    instance replaces it, so a concurrent failure can't discard a fresh pool.
+    """
+    global _pool
+    async with _lock:
+        if _pool is not broken:
+            return  # already replaced by another caller
+        _kill_workers(broken)
+        try:
+            broken.shutdown(wait=False, cancel_futures=True)
+        except Exception:
+            logger.debug("PDF pool shutdown(wait=False) failed", exc_info=True)
+        _pool = None
+
+
+def _kill_workers(pool: ProcessPoolExecutor) -> None:
+    """SIGKILL the pool's worker process(es). Guards against signalling pid 0/1."""
+    for proc in list(getattr(pool, "_processes", {}).values()):
+        pid = getattr(proc, "pid", None)
+        if pid and pid > 1:  # never signal pid 0/1 (would hit the process group)
+            try:
+                proc.kill()
+            except Exception:
+                logger.debug("Failed to kill PDF worker %s", pid, exc_info=True)
+
+
+async def shutdown_pdf_pool(timeout: float = 10.0) -> None:
+    """Tear down the PDF pool on runtime shutdown (bounded; kills if it stalls)."""
+    global _pool
+    async with _lock:
+        pool, _pool = _pool, None
+    if pool is None:
+        return
+
+    def _close() -> None:
+        try:
+            pool.shutdown(wait=True, cancel_futures=True)
+        except Exception:
+            logger.debug("PDF pool graceful shutdown failed", exc_info=True)
+
+    try:
+        await asyncio.wait_for(asyncio.to_thread(_close), timeout=timeout)
+    except TimeoutError:
+        logger.warning(
+            "PDF pool shutdown stalled after %.0fs — killing workers", timeout
+        )
+        _kill_workers(pool)

--- a/src/genesis/knowledge/processors/audio.py
+++ b/src/genesis/knowledge/processors/audio.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -22,7 +23,8 @@ class AudioProcessor:
         if not path.exists():
             raise FileNotFoundError(f"Audio file not found: {source}")
 
-        audio_bytes = path.read_bytes()
+        # Offload the blocking read off the event loop.
+        audio_bytes = await asyncio.to_thread(path.read_bytes)
         text = await transcribe(audio_bytes)
 
         if not text:

--- a/src/genesis/knowledge/processors/pdf.py
+++ b/src/genesis/knowledge/processors/pdf.py
@@ -14,30 +14,22 @@ class PDFProcessor:
     """Extract text from PDF files using PyMuPDF."""
 
     async def process(self, source: str, **kwargs: object) -> ProcessedContent:
-        import pymupdf
+        from genesis.knowledge.pdf_extract import extract_pdf_text
 
         path = Path(source)
         if not path.exists():
             raise FileNotFoundError(f"PDF file not found: {source}")
 
-        doc = pymupdf.open(str(path))
-        pages: list[str] = []
-        sections: list[str] = []
-
-        for page in doc:
-            text = page.get_text()
-            if text.strip():
-                pages.append(text.strip())
-                sections.append(text.strip())
-
-        full_text = "\n\n".join(pages)
-        doc.close()
+        # PyMuPDF is not thread-safe and can natively crash/hang on adversarial
+        # PDFs; extraction runs in a crash/hang-isolated process pool off the
+        # event loop. Raises PDFExtractionError on crash/timeout (caller degrades).
+        full_text, sections, page_count = await extract_pdf_text(str(path))
 
         return ProcessedContent(
             text=full_text,
             metadata={
                 "filename": path.name,
-                "page_count": len(pages),
+                "page_count": page_count,
                 "size_bytes": path.stat().st_size,
             },
             source_type="pdf",

--- a/src/genesis/knowledge/processors/text.py
+++ b/src/genesis/knowledge/processors/text.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -20,7 +21,10 @@ class TextProcessor:
         if not path.exists():
             raise FileNotFoundError(f"Text file not found: {source}")
 
-        text = path.read_text(encoding="utf-8", errors="replace")
+        # Offload the blocking read off the event loop (large files stall it).
+        text = await asyncio.to_thread(
+            path.read_text, encoding="utf-8", errors="replace"
+        )
         return ProcessedContent(
             text=text.strip(),
             metadata={

--- a/src/genesis/mcp/memory/knowledge.py
+++ b/src/genesis/mcp/memory/knowledge.py
@@ -838,13 +838,18 @@ async def resume_review(
     source_path = Path(resume_source)
     if source_path.exists():
         if source_path.suffix.lower() == ".pdf":
-            import pymupdf
-
-            doc = pymupdf.open(str(source_path))
-            resume_text = "\n\n".join(
-                page.get_text().strip() for page in doc if page.get_text().strip()
+            # Extract via the crash/hang-isolated pool (PyMuPDF is not
+            # thread-safe and can crash on adversarial PDFs). Return a
+            # structured error rather than throwing through the MCP boundary.
+            from genesis.knowledge.pdf_extract import (
+                PDFExtractionError,
+                extract_pdf_text,
             )
-            doc.close()
+
+            try:
+                resume_text, _sections, _pages = await extract_pdf_text(str(source_path))
+            except PDFExtractionError as exc:
+                return {"error": f"Resume PDF could not be parsed: {exc}"}
         else:
             resume_text = source_path.read_text(encoding="utf-8", errors="replace")
 

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -540,6 +540,14 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
                 except Exception:
                     logger.debug("Reranker close failed", exc_info=True)
 
+        try:
+            from genesis.knowledge.pdf_extract import shutdown_pdf_pool
+
+            await shutdown_pdf_pool()
+            logger.info("PDF extraction pool shut down")
+        except Exception:
+            logger.exception("Failed to shut down PDF extraction pool")
+
         if self._event_bus is not None:
             try:
                 await self._event_bus.stop()

--- a/tests/test_knowledge/test_ingest_upload.py
+++ b/tests/test_knowledge/test_ingest_upload.py
@@ -113,6 +113,36 @@ async def test_run_ingest_missing_upload(db):
         await run_ingest("nonexistent", project_type="pro")
 
 
+async def test_run_ingest_marks_failed_on_lookup_error(db, upload_id):
+    """A transient DB error reading the upload row must mark it failed, not strand it.
+
+    F3 regression: the early ``knowledge_uploads.get()`` sat ABOVE the try/except,
+    so a locked-DB ``OperationalError`` propagated out of ``run_ingest`` and left
+    the row stuck in 'processing' until the next server restart (recovery only runs
+    at startup). The fix wraps the lookup and marks the row 'failed' instead.
+    """
+    import sqlite3
+
+    from genesis.knowledge.ingest_upload import run_ingest
+
+    mock_rt = MagicMock()
+    mock_rt.db = db
+
+    async def raising_get(conn, uid):
+        raise sqlite3.OperationalError("database is locked")
+
+    with (
+        patch("genesis.runtime.GenesisRuntime.instance", return_value=mock_rt),
+        patch("genesis.db.crud.knowledge_uploads.get", new=raising_get),
+    ):
+        # Must NOT raise — the failure must be handled and recorded on the row.
+        await run_ingest(upload_id, project_type="pro", domain="test")
+
+    row = await knowledge_uploads.get(db, upload_id)
+    assert row["status"] == "failed"
+    assert "lookup" in (row["error_message"] or "").lower()
+
+
 # ─── injection-defense: store-as-is (no-LLM) path ──────────────────────────
 
 

--- a/tests/test_knowledge/test_orchestrator.py
+++ b/tests/test_knowledge/test_orchestrator.py
@@ -248,3 +248,64 @@ async def test_ingest_scan_failure_is_fail_open(tmp_path: Path):
 
     assert result.units_created == 1
     assert not any("injection_patterns_detected" in f for f in result.quality_flags)
+
+
+# ─── tree-index orphan-task safety (F10.1) ─────────────────────────────────
+
+
+async def test_distill_failure_cancels_orphan_tree_task(tmp_path: Path, monkeypatch):
+    """A distill() failure must cancel the in-flight tree-index task, not orphan it.
+
+    F10.1: the PageIndex upload task was cancelled only on the storage-failure
+    path. A ``distill()`` raise propagated out of ``ingest_source`` while the
+    task was still running (a leaked upload+poll for up to 300s). The fix
+    cancels+awaits the task on any failure before re-raising.
+    """
+    import asyncio
+
+    import pytest
+
+    from genesis.knowledge.processors.base import ProcessedContent
+
+    # Source must live under $HOME to pass the path-traversal guard.
+    monkeypatch.setattr("genesis.knowledge.orchestrator.Path.home", lambda: tmp_path)
+    pdf = tmp_path / "big.pdf"
+    pdf.write_bytes(b"%PDF-1.4 fake")
+
+    orch = _make_orchestrator(tmp_path)
+    orch._tree_index = MagicMock()        # enables should_tree_index
+    orch._tree_index_threshold = 1
+
+    proc = MagicMock()
+    proc.process = AsyncMock(return_value=ProcessedContent(
+        text="lots of extracted content", source_type="pdf",
+        metadata={"page_count": 30}, source_path=str(pdf),
+    ))
+    orch._registry.get_processor = MagicMock(return_value=proc)
+
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def fake_tree_source(source):
+        started.set()
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    orch._tree_index_source = fake_tree_source
+
+    async def failing_distill(*args, **kwargs):
+        # Wait until the tree task is actually running, THEN fail — so the test
+        # exercises the "task in flight when distill raises" race deterministically.
+        await started.wait()
+        raise RuntimeError("distill boom")
+
+    orch._distillation.distill = failing_distill
+
+    with pytest.raises(RuntimeError, match="distill boom"):
+        await orch.ingest_source(str(pdf), project_type="test")
+
+    assert started.is_set(), "tree-index task should have started"
+    assert cancelled.is_set(), "tree-index task must be cancelled, not orphaned"

--- a/tests/test_knowledge/test_pdf_extract.py
+++ b/tests/test_knowledge/test_pdf_extract.py
@@ -118,6 +118,41 @@ async def test_hang_is_killed_and_pool_dropped(tmp_path, monkeypatch):
     assert pe._pool is None, "wedged pool must be dropped for recreation"
 
 
+async def test_large_pdf_does_not_block_event_loop(tmp_path):
+    """The whole point of F1: a big PDF must extract WITHOUT stalling the loop."""
+    import asyncio
+
+    import pymupdf
+
+    from genesis.knowledge.processors.pdf import PDFProcessor
+
+    big = tmp_path / "big.pdf"
+    doc = pymupdf.open()
+    for i in range(200):
+        page = doc.new_page()
+        page.insert_text((72, 72), f"Page {i} " + ("lorem ipsum dolor sit amet " * 40))
+    doc.save(str(big))
+    doc.close()
+
+    ticks = 0
+    stop = False
+
+    async def heartbeat():
+        nonlocal ticks
+        while not stop:
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    hb = asyncio.create_task(heartbeat())
+    result = await PDFProcessor().process(str(big))
+    stop = True
+    await hb
+
+    assert result.metadata["page_count"] == 200
+    # With on-loop parsing this would be ~0; the offload keeps the loop live.
+    assert ticks > 5, f"event loop appears to have stalled (only {ticks} heartbeats)"
+
+
 async def test_shutdown_then_reextract(tmp_path):
     """shutdown_pdf_pool tears the pool down; a later call lazily recreates it."""
     import genesis.knowledge.pdf_extract as pe

--- a/tests/test_knowledge/test_pdf_extract.py
+++ b/tests/test_knowledge/test_pdf_extract.py
@@ -153,6 +153,50 @@ async def test_large_pdf_does_not_block_event_loop(tmp_path):
     assert ticks > 5, f"event loop appears to have stalled (only {ticks} heartbeats)"
 
 
+async def test_pool_creation_failure_raises_pdf_error(monkeypatch):
+    """A failed pool creation must surface as PDFExtractionError, not a bare error.
+
+    resume_review only catches PDFExtractionError; a raw TimeoutError from a
+    stalled worker spawn would otherwise escape through the MCP boundary.
+    """
+    import genesis.knowledge.pdf_extract as pe
+
+    def _boom() -> object:
+        raise TimeoutError("worker spawn stalled")
+
+    monkeypatch.setattr(pe, "_make_pool", _boom)
+
+    with pytest.raises(pe.PDFExtractionError):
+        await pe.extract_pdf_text("/nonexistent/file.pdf")
+    assert pe._pool is None  # nothing left half-created
+
+
+def test_make_pool_shuts_down_on_warmup_failure(monkeypatch):
+    """If the warmup probe fails, _make_pool must not leak the executor."""
+    import genesis.knowledge.pdf_extract as pe
+
+    shutdown_called = {"v": False}
+
+    class _FakeFuture:
+        def result(self, timeout=None):
+            raise TimeoutError("warmup stalled")
+
+    class _FakePool:
+        _processes: dict = {}
+
+        def submit(self, *a, **k):
+            return _FakeFuture()
+
+        def shutdown(self, wait=True, cancel_futures=False):
+            shutdown_called["v"] = True
+
+    monkeypatch.setattr(pe, "ProcessPoolExecutor", lambda *a, **k: _FakePool())
+
+    with pytest.raises(TimeoutError):
+        pe._make_pool()
+    assert shutdown_called["v"], "a failed pool creation must shut the executor down"
+
+
 async def test_shutdown_then_reextract(tmp_path):
     """shutdown_pdf_pool tears the pool down; a later call lazily recreates it."""
     import genesis.knowledge.pdf_extract as pe

--- a/tests/test_knowledge/test_pdf_extract.py
+++ b/tests/test_knowledge/test_pdf_extract.py
@@ -1,0 +1,133 @@
+"""Tests for the crash/hang-isolated PDF extraction process pool (pdf_extract).
+
+These tests spin up a REAL spawn-context ProcessPoolExecutor (not mocked) so
+they exercise the actual crash-recovery, shutdown, and IPC-temp behaviour.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import time
+from pathlib import Path
+
+import pytest
+
+
+def _make_pdf(tmp_path: Path, text: str = "Hello from PDF", name: str = "doc.pdf") -> Path:
+    import pymupdf
+
+    p = tmp_path / name
+    doc = pymupdf.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), text)
+    doc.save(str(p))
+    doc.close()
+    return p
+
+
+def _sleep_worker(path: str) -> tuple[str, list[str], int]:
+    """Top-level (picklable) worker that hangs — used to test hang isolation.
+
+    Importable by the spawn pool worker via its qualified name.
+    """
+    import time as _t
+
+    _t.sleep(30)
+    return ("", [], 0)
+
+
+@pytest.fixture(autouse=True)
+async def _reset_pool():
+    """Start each test with a torn-down pool and clean up after."""
+    import genesis.knowledge.pdf_extract as pe
+
+    await pe.shutdown_pdf_pool()
+    yield
+    await pe.shutdown_pdf_pool()
+
+
+async def test_extract_returns_text(tmp_path):
+    import genesis.knowledge.pdf_extract as pe
+
+    pdf = _make_pdf(tmp_path)
+    full_text, sections, page_count = await pe.extract_pdf_text(str(pdf))
+
+    assert "Hello from PDF" in full_text
+    assert page_count == 1  # count of NON-blank pages (parity with old inline impl)
+    assert sections == [full_text]  # single non-blank page → its text
+
+
+async def test_concurrent_extractions_all_succeed(tmp_path):
+    """Concurrent callers share the single-worker pool (serialized) and all succeed."""
+    import asyncio
+
+    import genesis.knowledge.pdf_extract as pe
+
+    pdfs = [_make_pdf(tmp_path, f"Doc number {i}", name=f"d{i}.pdf") for i in range(4)]
+
+    results = await asyncio.gather(*(pe.extract_pdf_text(str(p)) for p in pdfs))
+    assert len(results) == 4
+    for i, (text, _sections, page_count) in enumerate(results):
+        assert f"Doc number {i}" in text
+        assert page_count == 1
+
+
+async def test_crash_recovery(tmp_path):
+    """A killed worker → PDFExtractionError on the in-flight call, then self-heal."""
+    import genesis.knowledge.pdf_extract as pe
+
+    pdf = _make_pdf(tmp_path)
+    text, _, _ = await pe.extract_pdf_text(str(pdf))  # prime the pool
+    assert "Hello" in text
+
+    # Kill the worker process out from under the pool.
+    procs = list(pe._pool._processes.values())
+    assert procs, "expected a live worker process"
+    for p in procs:
+        assert p.pid and p.pid > 1  # never signal pid 0/1 (would hit the process group)
+        os.kill(p.pid, signal.SIGKILL)
+    # Let the OS reap it so the next submit sees a broken pool.
+    for _ in range(50):
+        if any(not p.is_alive() for p in procs):
+            break
+        time.sleep(0.05)
+
+    with pytest.raises(pe.PDFExtractionError):
+        await pe.extract_pdf_text(str(pdf))
+
+    # Pool must recreate itself on the next call.
+    text2, _, _ = await pe.extract_pdf_text(str(pdf))
+    assert "Hello" in text2
+
+
+async def test_hang_is_killed_and_pool_dropped(tmp_path, monkeypatch):
+    """A worker that hangs past the timeout is killed; the pool is dropped."""
+    import genesis.knowledge.pdf_extract as pe
+
+    monkeypatch.setattr(pe, "extract_pdf_text_sync", _sleep_worker)
+    monkeypatch.setattr(pe, "PDF_EXTRACT_TIMEOUT_S", 1.0)
+
+    pdf = _make_pdf(tmp_path)
+    t0 = time.monotonic()
+    with pytest.raises(pe.PDFExtractionError):
+        await pe.extract_pdf_text(str(pdf))
+    elapsed = time.monotonic() - t0
+
+    assert elapsed < 15, "should time out at ~1s, not wait the full 30s hang"
+    assert pe._pool is None, "wedged pool must be dropped for recreation"
+
+
+async def test_shutdown_then_reextract(tmp_path):
+    """shutdown_pdf_pool tears the pool down; a later call lazily recreates it."""
+    import genesis.knowledge.pdf_extract as pe
+
+    pdf = _make_pdf(tmp_path)
+    await pe.extract_pdf_text(str(pdf))
+    assert pe._pool is not None
+
+    await pe.shutdown_pdf_pool()
+    assert pe._pool is None
+
+    text, _, _ = await pe.extract_pdf_text(str(pdf))
+    assert "Hello" in text


### PR DESCRIPTION
## WS-B — Knowledge-ingest async correctness

Fixes three correctness/reliability defects from the 2026-07-02 audit. One PR, no DB migration.

### F1 — PDF parsing no longer blocks (or can crash) the event loop
PyMuPDF is **not thread-safe** and can natively **crash or hang** on malformed/adversarial input. Genesis ingests untrusted PDFs (dashboard uploads, web-fetched sources), and extraction ran synchronously on the main event loop — a large PDF froze the whole server, and a corrupt/hostile one could take the process down.

Extraction now runs in a dedicated single-worker, **`spawn`-context `ProcessPoolExecutor`**:
- a crash → `BrokenProcessPool` → recover (server survives);
- a hang → bounded by a timeout that **SIGKILLs** the wedged worker (`Future.cancel()` is a no-op once a worker is running);
- both raise `PDFExtractionError` and lazily recreate the pool via **compare-and-swap** (a concurrent failure can't discard a fresh pool);
- a **bounded shutdown hook** is registered in `GenesisRuntime.shutdown()`.

Both runtime pymupdf sites (the PDF processor and the resume-review MCP tool) route through the pool; the resume tool returns a structured `{"error": ...}` instead of throwing through the MCP boundary. `text`/`audio` processors offload their blocking reads via `asyncio.to_thread`. PDF metadata semantics (`page_count` = non-blank pages) are preserved exactly.

An architect pass hardened this design before implementation (hang isolation, lifecycle, CAS, resume-review error handling). One flagged risk — multiprocessing IPC artifacts landing under `$TMPDIR` (which a temp watchdog sweeps) — was **empirically disproven** on this platform (a spawn pool keeps its IPC in `/dev/shm`, writes nothing under `$TMPDIR`), so that hardening was dropped as unnecessary.

### F3 — uploads no longer strand in "processing"
The early `knowledge_uploads.get()` in the ingest worker sat above the try/except, so a transient locked-DB read propagated out and left the row stuck in `processing` until the next restart (recovery only runs at startup). It's now wrapped to mark the row `failed` (retryable). The dashboard route dispatches ingestion via `tracked_task` so any escape is logged, not silently swallowed.

### F10.1 — no more orphaned PageIndex uploads
A `distill()`/save failure left the in-flight tree-index task running (a leaked upload+poll up to 300s). It's now cancelled+awaited before re-raising. This also fixed a **pre-existing latent bug**: the cancel path used `suppress(Exception)`, which misses `CancelledError` (a `BaseException`), so a cancel could mask the real error.

### Verification
- Full knowledge suite + dashboard/runtime tests green locally.
- The pool tests exercise a **real** spawn pool: a SIGKILL'd worker recovers, a 30s-hung worker is killed at ~1s, a 200-page PDF extracts while the event loop keeps ticking, and pool-creation failure surfaces cleanly (no leak).
- Code-reviewed; the one Critical finding (unwrapped pool-creation failure → MCP-boundary leak + orphaned executor) was fixed and covered by new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
