### PR TITLE
fix(dashboard): honest memory GB label — stop pairing 47% with cache-inflated 32/36 GB

### DIFF
--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -5153,7 +5153,8 @@
                          :style="(() => { const p = $store.genesisDashboard.health.infrastructure.container_memory.anon_pct ?? $store.genesisDashboard.health.infrastructure.container_memory.used_pct ?? 0; return 'width:' + p + '%; background:' + (p > 85 ? '#d9534f' : p > 75 ? '#f0ad4e' : '#4caf50'); })()"></div>
                   </div>
                   <span style="font-size:0.7rem; color:var(--color-text-secondary); white-space:nowrap;"
-                        x-text="$store.genesisDashboard.health.infrastructure.container_memory.current_gb?.toFixed(0) + '/' + $store.genesisDashboard.health.infrastructure.container_memory.limit_gb?.toFixed(0) + ' GB'"></span>
+                        :title="(() => { const cm = $store.genesisDashboard.health.infrastructure.container_memory; const avail = cm.available_gb != null ? cm.available_gb.toFixed(0) + ' GB available. ' : ''; return avail + 'Shows non-reclaimable memory (anon+kernel), matching the %. cgroup memory.current is ' + (cm.current_gb ?? 0).toFixed(0) + ' GB including reclaimable page cache, which is not counted here.'; })()"
+                        x-text="(() => { const cm = $store.genesisDashboard.health.infrastructure.container_memory; const used = (cm.anon_gb != null && cm.kernel_gb != null) ? (cm.anon_gb + cm.kernel_gb) : cm.current_gb; return (used ?? 0).toFixed(0) + '/' + (cm.limit_gb ?? 0).toFixed(0) + ' GB'; })()"></span>
                 </div>
               </template>
               <!-- CPU row -->


### PR DESCRIPTION
## Problem
The dashboard health widget showed **Memory 47%** next to **32/36 GB** — a contradiction (32/36 ≈ 89%).

They measured different things:
- **47%** = `anon_pct` = non-reclaimable memory (anon + kernel) ÷ limit — the honest OOM signal.
- **32/36 GB** = cgroup `memory.current` ÷ `memory.max` — **includes ~16 GB of reclaimable page cache**.

`#855` (honest health surface) correctly switched the **percentage and bar** to `anon_pct`, but left the **GB label** at `genesis_dashboard.html:5156` still reading `current_gb` — so the honest % ended up paired with the cache-inflated absolute. (Before #855 they agreed at ~87%; the fix updated one half.)

It was never a real memory problem — the container had ~20 GB genuinely available; the extra "used" was reclaimable cache the kernel drops on demand.

## Fix
Show honest non-reclaimable used GB (`anon_gb + kernel_gb`, which matches `anon_pct`) instead of `current_gb`, with a tooltip noting GB available and that `memory.current` includes reclaimable cache. Falls back to `current_gb` if the breakdown is unavailable. One-line template change; the snapshot already exposes every field used.

## Verification
`anon_gb+kernel_gb` ≈ 16 GB → **"16/36 GB" next to 47%** (consistent). Node-checked both the normal and fallback expressions; confirmed all fields (`anon_gb`, `kernel_gb`, `current_gb`, `limit_gb`, `available_gb`) are set by the infrastructure snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)