### PR TITLE
fix(ego): restart-safe ego_cycle boot first-fire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Genesis's background egos now keep their thinking rhythm across a restart instead of going quiet.**
+  The two egos run proactive cycles on an adaptive schedule that stretches out when things are idle. That
+  schedule was re-armed from scratch on every restart, so an install that restarts often (deploys, recovery)
+  could keep pushing the next cycle further out — in the worst case starving an ego for up to its full
+  backed-off interval. Each ego now anchors its first post-restart cycle to when it last actually ran: an
+  overdue ego runs shortly after startup, while an up-to-date one simply keeps its cadence.
+
 - **Re-ingesting a knowledge source with changed content now refreshes it instead of serving the stale
   version.** Previously, once a file or URL was ingested, re-ingesting the same source was skipped on source
   identity alone — so if the underlying content changed, the knowledge base kept serving the old distilled

--- a/src/genesis/db/crud/job_health.py
+++ b/src/genesis/db/crud/job_health.py
@@ -31,3 +31,20 @@ async def get_stale_jobs(
         (threshold_days,),
     )
     return [dict(r) for r in await cursor.fetchall()]
+
+
+async def get_job_last_success(
+    db: aiosqlite.Connection, job_name: str
+) -> str | None:
+    """Return the ISO ``last_success`` timestamp for ``job_name`` (or None).
+
+    Used by the ego cadence to anchor its restart-safe boot first-fire to the
+    last time this ego actually cycled (see
+    ``EgoCadenceManager._compute_boot_first_fire``).
+    """
+    cursor = await db.execute(
+        "SELECT last_success FROM job_health WHERE job_name = ?",
+        (job_name,),
+    )
+    row = await cursor.fetchone()
+    return row[0] if row else None

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -134,12 +134,24 @@ class EgoCadenceManager:
 
     async def start(self) -> None:
         """Register APScheduler jobs and start."""
+        # Restart-safe boot first-fire: anchor to this ego's own persisted
+        # job_health.last_success so a restart cannot starve the proactive
+        # cycle by a full (backed-off, up to 72h) interval — the documented
+        # IntervalTrigger-resets-on-restart trap. None => fresh install =>
+        # OMIT next_run_time (never pass None — APScheduler treats an explicit
+        # next_run_time=None as a PAUSED job).
+        boot_first_fire = await self._compute_boot_first_fire()
+        ego_cycle_kwargs: dict[str, object] = {
+            "id": "ego_cycle",
+            "max_instances": 1,
+            "misfire_grace_time": 300,
+        }
+        if boot_first_fire is not None:
+            ego_cycle_kwargs["next_run_time"] = boot_first_fire
         self._scheduler.add_job(
             self._on_tick,
             IntervalTrigger(minutes=self._current_interval),
-            id="ego_cycle",
-            max_instances=1,
-            misfire_grace_time=300,
+            **ego_cycle_kwargs,
         )
         if self._config.morning_report_enabled:
             tz = user_timezone()
@@ -1026,6 +1038,56 @@ class EgoCadenceManager:
                 return max_mins
 
         return self._config.max_interval_minutes
+
+    async def _compute_boot_first_fire(self) -> datetime | None:
+        """Restart-safe first-fire time for the ``ego_cycle`` job.
+
+        The proactive cadence uses an ``IntervalTrigger`` whose interval adapts
+        (base → up to 72h) and RESETS to base on every restart, and APScheduler
+        counts the interval from scheduler start with no ``next_run_time``. On a
+        restart-heavy install this defers — and keeps re-deferring — the first
+        proactive fire by a full backed-off interval (the documented
+        IntervalTrigger-resets-on-restart trap).
+
+        Anchor the boot first-fire to this ego's OWN ``job_health.last_success``
+        (per-ego since #863; persisted and reloaded across restarts). Mirrors the
+        ``memory_extraction`` boot-pin from #863: fire ~soon after boot when the
+        ego is overdue, otherwise wait out only the remaining base interval so a
+        restart does not re-run the expensive cycle prematurely.
+
+        Returns the datetime for ``add_job(next_run_time=...)``, or ``None`` when
+        there is no prior successful cycle (fresh install / no row / read error)
+        so ``start()`` OMITS the kwarg and keeps APScheduler's default
+        trigger-computed first fire. ``None`` must never be passed to
+        ``add_job`` — an explicit ``next_run_time=None`` marks the job PAUSED.
+        """
+        try:
+            cursor = await self._db.execute(
+                "SELECT last_success FROM job_health WHERE job_name = ?",
+                (self._session._source_tag,),
+            )
+            row = await cursor.fetchone()
+        except Exception:
+            logger.debug(
+                "Boot first-fire: job_health read failed; using default timing",
+                exc_info=True,
+            )
+            return None
+
+        if not row or not row[0]:
+            return None
+        try:
+            last_success = datetime.fromisoformat(row[0])
+        except (ValueError, TypeError):
+            return None
+        if last_success.tzinfo is None:
+            last_success = last_success.replace(tzinfo=UTC)
+
+        now = datetime.now(UTC)
+        base = timedelta(minutes=self._config.cadence_minutes)
+        # ~60s boot-pin mirrors #863's memory_extraction restart-safe schedule.
+        boot_pin = now + timedelta(seconds=60)
+        return max(boot_pin, last_success + base)
 
     async def _update_interval(self, *, had_proposals: bool) -> None:
         """Adjust cycle interval based on productivity and user recency.

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -134,9 +134,15 @@ class EgoCadenceManager:
 
     async def start(self) -> None:
         """Register APScheduler jobs and start."""
-        # Restart-safe boot first-fire: anchor to this ego's own persisted
+        # NOTE: this job intentionally keeps IntervalTrigger despite the
+        # ">1h intervals should use CronTrigger" convention (CLAUDE.md Traps) —
+        # the ego's interval is variable/adaptive (base → up to 72h) and a
+        # wall-clock CronTrigger can't express a changing interval. The
+        # restart-safe boot first-fire below is the mitigation for the reset trap.
+        #
+        # Boot first-fire: anchor to this ego's own persisted
         # job_health.last_success so a restart cannot starve the proactive
-        # cycle by a full (backed-off, up to 72h) interval — the documented
+        # cycle by a full (backed-off) interval — the documented
         # IntervalTrigger-resets-on-restart trap. None => fresh install =>
         # OMIT next_run_time (never pass None — APScheduler treats an explicit
         # next_run_time=None as a PAUSED job).
@@ -1062,11 +1068,11 @@ class EgoCadenceManager:
         ``add_job`` — an explicit ``next_run_time=None`` marks the job PAUSED.
         """
         try:
-            cursor = await self._db.execute(
-                "SELECT last_success FROM job_health WHERE job_name = ?",
-                (self._session._source_tag,),
+            from genesis.db.crud import job_health as job_health_crud
+
+            last_success_iso = await job_health_crud.get_job_last_success(
+                self._db, self._session._source_tag,
             )
-            row = await cursor.fetchone()
         except Exception:
             logger.debug(
                 "Boot first-fire: job_health read failed; using default timing",
@@ -1074,10 +1080,10 @@ class EgoCadenceManager:
             )
             return None
 
-        if not row or not row[0]:
+        if not last_success_iso:
             return None
         try:
-            last_success = datetime.fromisoformat(row[0])
+            last_success = datetime.fromisoformat(last_success_iso)
         except (ValueError, TypeError):
             return None
         if last_success.tzinfo is None:

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -130,6 +130,112 @@ class TestCadenceLifecycle:
 
 
 # ---------------------------------------------------------------------------
+# Restart-safe boot first-fire (B1): anchor ego_cycle to job_health.last_success
+# ---------------------------------------------------------------------------
+
+_JOB_HEALTH_DDL = """
+    CREATE TABLE IF NOT EXISTS job_health (
+        job_name         TEXT PRIMARY KEY,
+        last_run         TEXT,
+        last_success     TEXT,
+        last_failure     TEXT,
+        last_error       TEXT,
+        consecutive_failures INTEGER NOT NULL DEFAULT 0,
+        total_runs       INTEGER NOT NULL DEFAULT 0,
+        total_successes  INTEGER NOT NULL DEFAULT 0,
+        total_failures   INTEGER NOT NULL DEFAULT 0,
+        updated_at       TEXT NOT NULL
+    )
+"""
+
+
+async def _seed_last_success(conn, job_name: str, last_success: datetime) -> None:
+    """Create job_health (not in TABLES) and seed one ego's last_success row."""
+    await conn.execute(_JOB_HEALTH_DDL)
+    iso = last_success.isoformat()
+    await conn.execute(
+        "INSERT INTO job_health "
+        "(job_name, last_run, last_success, consecutive_failures, "
+        " total_runs, total_successes, total_failures, updated_at) "
+        "VALUES (?, ?, ?, 0, 1, 1, 0, ?)",
+        (job_name, iso, iso, iso),
+    )
+    await conn.commit()
+
+
+class TestBootFirstFire:
+    """The ego_cycle boot first-fire is anchored to this ego's OWN persisted
+    job_health.last_success so a restart cannot starve the proactive cycle
+    (the IntervalTrigger-resets-on-restart trap)."""
+
+    async def test_overdue_fires_soon(self, cadence, mock_session, db):
+        mock_session._source_tag = "user_ego_cycle"
+        await _seed_last_success(
+            db, "user_ego_cycle", datetime.now(UTC) - timedelta(days=5),
+        )
+        first_fire = await cadence._compute_boot_first_fire()
+        assert first_fire is not None
+        delta = (first_fire - datetime.now(UTC)).total_seconds()
+        # overdue by >> base → ~60s boot-pin, not a full base interval away
+        assert 0 < delta <= 120
+
+    async def test_recent_waits_remaining_base(self, cadence, mock_session, db):
+        mock_session._source_tag = "user_ego_cycle"
+        last = datetime.now(UTC) - timedelta(minutes=10)  # base=60 → +50m ahead
+        await _seed_last_success(db, "user_ego_cycle", last)
+        first_fire = await cadence._compute_boot_first_fire()
+        expected = last + timedelta(minutes=60)  # config.cadence_minutes == 60
+        assert abs((first_fire - expected).total_seconds()) < 2
+
+    async def test_no_row_returns_none(self, cadence, mock_session, db):
+        mock_session._source_tag = "genesis_ego_cycle"
+        await db.execute(_JOB_HEALTH_DDL)  # table exists, no row for this ego
+        await db.commit()
+        assert await cadence._compute_boot_first_fire() is None
+
+    async def test_missing_table_returns_none(self, cadence, mock_session):
+        # job_health never created → read raises → swallowed → None (fresh path)
+        mock_session._source_tag = "genesis_ego_cycle"
+        assert await cadence._compute_boot_first_fire() is None
+
+    async def test_per_ego_isolation(self, cadence, mock_session, db):
+        # only the genesis row exists; the user ego must NOT read it
+        await _seed_last_success(
+            db, "genesis_ego_cycle", datetime.now(UTC) - timedelta(days=5),
+        )
+        mock_session._source_tag = "user_ego_cycle"
+        assert await cadence._compute_boot_first_fire() is None
+
+    async def test_start_pins_next_run_time_when_overdue(
+        self, cadence, mock_session, db,
+    ):
+        mock_session._source_tag = "user_ego_cycle"
+        await _seed_last_success(
+            db, "user_ego_cycle", datetime.now(UTC) - timedelta(days=5),
+        )
+        await cadence.start()
+        try:
+            job = cadence._scheduler.get_job("ego_cycle")
+            assert job is not None and job.next_run_time is not None
+            delta = (job.next_run_time - datetime.now(UTC)).total_seconds()
+            assert 0 < delta <= 120
+        finally:
+            await cadence.stop()
+
+    async def test_start_fresh_install_not_paused(self, cadence, mock_session):
+        # No job_health row → next_run_time OMITTED → trigger computes it
+        # (now + base). Must NOT be paused: an explicit None would pause it.
+        mock_session._source_tag = "genesis_ego_cycle"
+        await cadence.start()
+        try:
+            job = cadence._scheduler.get_job("ego_cycle")
+            assert job is not None
+            assert job.next_run_time is not None  # not paused
+        finally:
+            await cadence.stop()
+
+
+# ---------------------------------------------------------------------------
 # Heartbeat — dedicated fixed-interval liveness pulse (decoupled from _on_tick)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

The ego's proactive cadence (`EgoCadenceManager`) armed its `ego_cycle` job with `IntervalTrigger(minutes=self._current_interval)` and no `next_run_time`. APScheduler's `IntervalTrigger` counts from scheduler start, so the first proactive fire was `boot + interval` and reset on every restart. Because the interval adapts upward when things are idle (base → up to 72h), an install that restarts more often than the current interval could keep deferring the proactive cycle — the same IntervalTrigger-resets-on-restart trap #863 fixed for `memory_extraction`.

## Fix

Anchor the boot first-fire to this ego's own persisted `job_health.last_success` (per-ego since #863):

- `_compute_boot_first_fire()` returns `max(now + 60s, last_success + base_cadence)` — an overdue ego fires shortly after boot; an up-to-date one waits only the remaining base interval, so a restart doesn't re-run the expensive cycle prematurely.
- `start()` passes `next_run_time` only when non-`None`; a fresh install (no prior run) omits it and keeps APScheduler's default timing. It never passes `next_run_time=None`, which APScheduler treats as a *paused* job.

The ego interval is variable/adaptive, so unlike `memory_extraction` it keeps `IntervalTrigger` (a wall-clock `CronTrigger` can't express a changing interval) — only the boot arming changes. No new persistence: it reuses the per-ego `job_health` row. The after-cycle reschedule is unchanged, so this affects only the first fire after a restart. On a fresh install (or before the per-ego row exists) it degrades to the previous default timing.

## Testing

- 7 targeted tests in `tests/ego/test_cadence.py`: overdue → boot-pin, recent → remaining base, no-row / missing-table → safe fallback, per-ego isolation, `start()` pins `next_run_time` when overdue, fresh install not paused.
- `tests/ego/test_cadence.py` passes (81/81); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)