### PR TITLE
fix(observability): health snapshot — offload blocking I/O, isolate section failures, coalesce callers (WS-D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The dashboard's system-health view stays responsive under load and no longer errors out when a single
+  check hiccups.** Building the health snapshot used to run its systemd service checks (several `systemctl`
+  calls) and a couple of file scans directly on the main event loop, so gathering health could briefly stall
+  other work; and if any one sub-check raised an unexpected error, the entire health request failed. Those
+  checks now run off the main loop, and a failure in one section degrades just that section to an error state
+  while the rest of the health view loads normally. Overlapping health requests now also share a single
+  computation instead of each recomputing from scratch.
+
 - **Uploading a large or malformed PDF to the Knowledge tab no longer freezes — or crashes — Genesis.**
   PDF text extraction used to run directly on the main event loop, so a big document could stall the whole
   server for seconds (health checks, background thinking, other requests all waited), and a corrupt or

--- a/src/genesis/observability/health_data.py
+++ b/src/genesis/observability/health_data.py
@@ -102,21 +102,39 @@ class HealthDataService:
         instead of each triggering a full recompute. The returned dict is
         READ-ONLY by contract (every caller reads via ``.get()``), so it is shared
         among coalesced callers without a defensive copy.
+
+        The shared task is awaited through ``asyncio.shield`` so one caller's
+        cancellation — e.g. the dashboard route's 15s ``_async_route`` timeout —
+        cannot cancel the in-flight snapshot out from under the other coalesced
+        callers (who catch ``Exception``, not ``CancelledError``). ``_inflight``
+        is released by the task's own done-callback, not a caller's ``finally``,
+        so it survives the cancelling caller unwinding first; the ``.done()`` guard
+        makes correctness independent of when that callback runs.
         """
         inflight = self._inflight
         if inflight is not None and not inflight.done():
-            return await inflight
+            return await asyncio.shield(inflight)
         # No await between the done() check and the assignment below → race-free
         # on the single-threaded loop.
         task = asyncio.create_task(self._compute_snapshot())
         self._inflight = task
-        try:
-            return await task
-        finally:
-            # Clear only if still ours: a later caller may have installed a fresh
-            # task after ours finished, and we must not clobber it.
-            if self._inflight is task:
-                self._inflight = None
+        task.add_done_callback(self._release_inflight)
+        return await asyncio.shield(task)
+
+    def _release_inflight(self, task: asyncio.Task) -> None:
+        """Done-callback: drop the in-flight handle when the compute finishes.
+
+        Runs on the loop (scheduled via ``call_soon``). Clears only if the handle
+        is still ours, and retrieves any exception so a fully-orphaned failed
+        compute (every awaiter cancelled before completion) does not emit a
+        "Task exception was never retrieved" warning.
+        """
+        if self._inflight is task:
+            self._inflight = None
+        if not task.cancelled():
+            exc = task.exception()
+            if exc is not None:
+                logger.debug("Orphaned health snapshot compute failed", exc_info=exc)
 
     async def _compute_snapshot(self) -> dict:
         """Build the full system health state as a dict (uncoalesced)."""

--- a/src/genesis/observability/health_data.py
+++ b/src/genesis/observability/health_data.py
@@ -34,6 +34,25 @@ logger = logging.getLogger(__name__)
 CC_JSONL_DIR = str(Path.home() / ".claude" / "projects" / cc_project_dir())
 
 
+def _or_error(result: object) -> object:
+    """Isolate a failed gather section.
+
+    With ``return_exceptions=True`` a raising sub-snapshot lands in the results
+    list as an exception instead of aborting the whole snapshot. Convert a normal
+    ``Exception`` into a ``{"status": "error"}`` section (every consumer reads
+    sections defensively via ``.get()``), but re-raise a ``BaseException`` such as
+    ``CancelledError`` so cooperative cancellation is never swallowed. Applied
+    uniformly to every result so no un-serializable exception object leaks into
+    the snapshot dict.
+    """
+    if isinstance(result, Exception):
+        logger.warning("Health snapshot section failed", exc_info=result)
+        return {"status": "error", "error": str(result)}
+    if isinstance(result, BaseException):
+        raise result
+    return result
+
+
 class HealthDataService:
     """Aggregates all health sources into a single snapshot dict.
 
@@ -71,9 +90,36 @@ class HealthDataService:
         self._activity_tracker = activity_tracker
         self._provider_health = provider_health_checker
         self._event_bus = event_bus
+        # Single-flight: concurrent snapshot() callers coalesce onto one compute.
+        self._inflight: asyncio.Task | None = None
 
     async def snapshot(self) -> dict:
-        """Return full system health state as a dict."""
+        """Return full system health state, coalescing concurrent callers.
+
+        The snapshot is expensive (systemd subprocesses + DB + network). Callers
+        that overlap — the two ego-context builders on an awareness tick, the
+        sentinel dispatcher, the morning report — share ONE in-flight computation
+        instead of each triggering a full recompute. The returned dict is
+        READ-ONLY by contract (every caller reads via ``.get()``), so it is shared
+        among coalesced callers without a defensive copy.
+        """
+        inflight = self._inflight
+        if inflight is not None and not inflight.done():
+            return await inflight
+        # No await between the done() check and the assignment below → race-free
+        # on the single-threaded loop.
+        task = asyncio.create_task(self._compute_snapshot())
+        self._inflight = task
+        try:
+            return await task
+        finally:
+            # Clear only if still ours: a later caller may have installed a fresh
+            # task after ours finished, and we must not clobber it.
+            if self._inflight is task:
+                self._inflight = None
+
+    async def _compute_snapshot(self) -> dict:
+        """Build the full system health state as a dict (uncoalesced)."""
         from genesis.observability.snapshots import (
             api_key_health,
             awareness,
@@ -89,7 +135,7 @@ class HealthDataService:
             proactive_memory_metrics,
             provider_activity,
             queues,
-            services,
+            services_async,
             surplus_status,
         )
 
@@ -111,11 +157,7 @@ class HealthDataService:
         # instead of the sum: aiosqlite serializes DB queries on the single
         # connection (safe), while network-bound calls (memory_health/Qdrant,
         # mcp_status) overlap with them and each other.
-        (
-            r_call_sites, r_cc_sessions, r_infrastructure, r_queues, r_surplus,
-            r_cost, r_awareness, r_outreach, r_mcp, r_provider_activity,
-            r_memory_health, r_eval_staleness, r_vcr,
-        ) = await asyncio.gather(
+        results = await asyncio.gather(
             call_sites(
                 self._db, self._routing_config, self._breakers,
                 probe_results=probe_results, state_machine=self._state_machine,
@@ -134,7 +176,25 @@ class HealthDataService:
             memory_health(self._db),
             eval_staleness(self._db),
             self._vcr_snapshot(),
+            # Offloaded so NO blocking I/O runs on the event loop. services_async
+            # threads only the systemctl subprocesses (the sentinel read stays
+            # on-loop, atomic); the two file-reading snapshots go to a worker
+            # thread whole. Concurrent with the DB/network calls above → ≈0 added
+            # wall-clock vs. the old serial post-gather calls.
+            services_async(),
+            asyncio.to_thread(conversation_activity),
+            asyncio.to_thread(proactive_memory_metrics),
+            return_exceptions=True,
         )
+        # Isolate any failed section uniformly: one raising sub-snapshot degrades
+        # to {"status": "error"} instead of taking down the whole snapshot.
+        results = [_or_error(r) for r in results]
+        (
+            r_call_sites, r_cc_sessions, r_infrastructure, r_queues, r_surplus,
+            r_cost, r_awareness, r_outreach, r_mcp, r_provider_activity,
+            r_memory_health, r_eval_staleness, r_vcr,
+            r_services, r_conversation, r_proactive,
+        ) = results
 
         return {
             "timestamp": now,
@@ -147,12 +207,12 @@ class HealthDataService:
             "cost": r_cost,
             "awareness": r_awareness,
             "outreach_stats": r_outreach,
-            "services": services(),
+            "services": r_services,
             "api_keys": api_key_health(self._routing_config, breakers=self._breakers),
             "mcp_servers": r_mcp,
-            "conversation": conversation_activity(),
+            "conversation": r_conversation,
             "provider_activity": r_provider_activity,
-            "proactive_memory": proactive_memory_metrics(),
+            "proactive_memory": r_proactive,
             "memory_health": r_memory_health,
             "provider_health": self._serialize_provider_health(),
             "eval_staleness": r_eval_staleness,

--- a/src/genesis/observability/snapshots/__init__.py
+++ b/src/genesis/observability/snapshots/__init__.py
@@ -23,7 +23,7 @@ from genesis.observability.snapshots.outreach import outreach_stats
 from genesis.observability.snapshots.proactive_memory import proactive_memory_metrics
 from genesis.observability.snapshots.provider_activity import provider_activity
 from genesis.observability.snapshots.queues import queues
-from genesis.observability.snapshots.services import mcp_status, services
+from genesis.observability.snapshots.services import mcp_status, services, services_async
 from genesis.observability.snapshots.surplus import surplus_status
 
 __all__ = [
@@ -44,6 +44,7 @@ __all__ = [
     "resilience_state",
     "resilience_state_detail",
     "services",
+    "services_async",
     "surplus_status",
     "validate_api_keys",
 ]

--- a/src/genesis/observability/snapshots/services.py
+++ b/src/genesis/observability/snapshots/services.py
@@ -14,16 +14,33 @@ logger = logging.getLogger(__name__)
 _MCP_CRASH_DIR = Path.home() / ".genesis" / "mcp_crashes"
 
 
-def services() -> dict:
-    """Collect systemd service states, watchdog health, and host framework."""
+def _collect_service_status_safe() -> dict:
+    """Subprocess-heavy systemd/watchdog collection — safe to run in a worker thread.
+
+    This is the ONLY loop-blocking part of the services snapshot (up to ~7
+    ``systemctl`` subprocesses @ 5s each). It touches no shared event-loop state,
+    so ``services_async()`` offloads it via ``asyncio.to_thread``.
+    """
     try:
         from genesis.observability.service_status import collect_service_status
 
-        result = collect_service_status()
+        return collect_service_status()
     except Exception:
         logger.warning("Failed to collect service status", exc_info=True)
-        result = {"status": "unknown"}
+        return {"status": "unknown"}
 
+
+def _finish_services(result: dict) -> dict:
+    """Augment a base service-status dict with host framework + sentinel state.
+
+    MUST run on the event loop. It reads the live ``sentinel.state``, which the
+    sentinel dispatcher mutates in place, field-by-field, on the loop; single-
+    threaded execution (no ``await`` mid-read) is what makes that read atomic.
+    Do NOT offload this to a worker thread — that would open a torn-read window
+    (e.g. a fresh ``current_state`` paired with a stale ``last_heartbeat_at``).
+    Host-framework ``detect()`` is near-free (empty detector registry, 30s cache),
+    so it stays here too rather than warranting its own offload.
+    """
     # Host framework detection (USB mode)
     try:
         status = _get_registry().detect()
@@ -100,6 +117,26 @@ def services() -> dict:
         result["sentinel"] = _sentinel_unavailable()
 
     return result
+
+
+def services() -> dict:
+    """Collect systemd service states, watchdog health, and host framework.
+
+    Synchronous composition — kept for the standalone/MCP path and direct tests.
+    On the event loop, prefer ``services_async()`` (offloads the subprocess work).
+    """
+    return _finish_services(_collect_service_status_safe())
+
+
+async def services_async() -> dict:
+    """Event-loop-safe services snapshot.
+
+    Offloads ONLY the subprocess-heavy collection to a worker thread, then
+    assembles host framework + sentinel on the loop (the sentinel read must stay
+    loop-atomic — see ``_finish_services``).
+    """
+    base = await _aio.to_thread(_collect_service_status_safe)
+    return _finish_services(base)
 
 
 def _sentinel_unavailable() -> dict:

--- a/tests/test_observability/test_health_snapshot_offload.py
+++ b/tests/test_observability/test_health_snapshot_offload.py
@@ -1,0 +1,148 @@
+"""WS-D — health snapshot: offload blocking I/O, gather failure isolation, single-flight.
+
+Three behaviours:
+1. F4 — the subprocess-heavy `collect_service_status()` runs OFF the event-loop
+   thread (via `services_async()`), while the sentinel assembly stays on-loop.
+2. F10 — one failing sub-snapshot is isolated to a `{"status": "error"}` section
+   instead of taking down the whole snapshot.
+3. Coalescer — concurrent `snapshot()` callers share ONE in-flight computation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import AsyncMock
+
+from genesis.observability.health_data import HealthDataService
+
+
+def _mock_db():
+    """Fake aiosqlite connection whose queries return empty result sets."""
+    db = AsyncMock()
+
+    async def _execute(sql, params=None):
+        cursor = AsyncMock()
+        cursor.fetchone = AsyncMock(return_value=None)
+        cursor.fetchall = AsyncMock(return_value=[])
+        return cursor
+
+    db.execute = AsyncMock(side_effect=_execute)
+    return db
+
+
+# ---------------------------------------------------------------------------
+# F4 — offload the subprocess-heavy collection, keep sentinel read on the loop
+# ---------------------------------------------------------------------------
+
+def test_services_async_offloads_collection_to_worker_thread(monkeypatch):
+    """`collect_service_status()` must run in a worker thread, not on the loop."""
+    from genesis.observability.snapshots.services import services_async
+
+    loop_thread = threading.get_ident()
+    recorded: dict[str, int] = {}
+
+    def fake_collect():
+        recorded["thread"] = threading.get_ident()
+        return {"bridge": {"active_state": "active"}}
+
+    # _collect_service_status_safe imports collect_service_status at call time.
+    monkeypatch.setattr(
+        "genesis.observability.service_status.collect_service_status", fake_collect
+    )
+
+    result = asyncio.run(services_async())
+
+    assert recorded.get("thread") is not None, "collect_service_status was never called"
+    assert recorded["thread"] != loop_thread, "collection ran on the event-loop thread"
+    # The on-loop assembly (host framework + sentinel) must still be present.
+    assert "host_framework" in result
+    assert "sentinel" in result
+
+
+def test_services_sync_and_async_agree_on_shape(monkeypatch):
+    """The sync `services()` and async `services_async()` produce the same keys."""
+    from genesis.observability.snapshots.services import services, services_async
+
+    def fake_collect():
+        return {"bridge": {"active_state": "active"}}
+
+    monkeypatch.setattr(
+        "genesis.observability.service_status.collect_service_status", fake_collect
+    )
+
+    sync_result = services()
+    async_result = asyncio.run(services_async())
+    assert set(sync_result) == set(async_result)
+
+
+# ---------------------------------------------------------------------------
+# F10 — a failing sub-snapshot is isolated, not fatal
+# ---------------------------------------------------------------------------
+
+def test_failing_section_is_isolated_not_fatal(monkeypatch):
+    """One raising sub-snapshot degrades that section; the rest survive."""
+    async def boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    # call_sites is imported inside _compute_snapshot from the snapshots package,
+    # so patch it on that package namespace.
+    monkeypatch.setattr("genesis.observability.snapshots.call_sites", boom)
+
+    svc = HealthDataService(db=_mock_db())
+    snap = asyncio.run(svc.snapshot())
+
+    assert snap["call_sites"]["status"] == "error"
+    assert "boom" in snap["call_sites"]["error"]
+    # Every other section is still present and did not inherit the failure.
+    for key in ("cc_sessions", "queues", "cost", "services", "conversation", "proactive_memory"):
+        assert key in snap, f"section {key} missing after an isolated failure"
+    assert snap["cc_sessions"].get("status") != "error"
+
+
+# ---------------------------------------------------------------------------
+# Coalescer — concurrent callers share one in-flight computation
+# ---------------------------------------------------------------------------
+
+def test_concurrent_snapshots_coalesce_to_single_compute():
+    """Two overlapping snapshot() calls trigger _compute_snapshot exactly once."""
+    svc = HealthDataService(db=_mock_db())
+
+    call_count = 0
+
+    async def counting_compute():
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0.05)  # hold the in-flight window open for the 2nd caller
+        return {"marker": call_count}
+
+    svc._compute_snapshot = counting_compute
+
+    async def _run():
+        return await asyncio.gather(svc.snapshot(), svc.snapshot())
+
+    r1, r2 = asyncio.run(_run())
+
+    assert call_count == 1, f"expected a single coalesced compute, got {call_count}"
+    assert r1 is r2, "coalesced callers should receive the same shared result object"
+
+
+def test_inflight_cleared_after_completion():
+    """After a snapshot completes, the in-flight handle is cleared for the next call."""
+    svc = HealthDataService(db=_mock_db())
+
+    calls = 0
+
+    async def counting_compute():
+        nonlocal calls
+        calls += 1
+        return {"n": calls}
+
+    svc._compute_snapshot = counting_compute
+
+    asyncio.run(svc.snapshot())
+    asyncio.run(svc.snapshot())
+
+    # Sequential (non-overlapping) calls must each recompute — no stale coalescing.
+    assert calls == 2
+    assert svc._inflight is None

--- a/tests/test_observability/test_health_snapshot_offload.py
+++ b/tests/test_observability/test_health_snapshot_offload.py
@@ -14,6 +14,8 @@ import asyncio
 import threading
 from unittest.mock import AsyncMock
 
+import pytest
+
 from genesis.observability.health_data import HealthDataService
 
 
@@ -127,8 +129,8 @@ def test_concurrent_snapshots_coalesce_to_single_compute():
     assert r1 is r2, "coalesced callers should receive the same shared result object"
 
 
-def test_inflight_cleared_after_completion():
-    """After a snapshot completes, the in-flight handle is cleared for the next call."""
+def test_completed_snapshot_is_not_reused():
+    """A completed in-flight handle must not coalesce — sequential calls recompute."""
     svc = HealthDataService(db=_mock_db())
 
     calls = 0
@@ -145,4 +147,43 @@ def test_inflight_cleared_after_completion():
 
     # Sequential (non-overlapping) calls must each recompute — no stale coalescing.
     assert calls == 2
-    assert svc._inflight is None
+    # The handle is never left pointing at a live task (cleared by done-callback;
+    # the .done() guard makes a lingering completed handle harmless regardless).
+    assert svc._inflight is None or svc._inflight.done()
+
+
+def test_caller_cancellation_does_not_abort_coalesced_siblings():
+    """One caller's cancellation must NOT cancel the shared compute for siblings.
+
+    Regression for the unshielded-task bug: the dashboard route's 15s timeout
+    cancels its snapshot() future; without asyncio.shield that would cancel the
+    in-flight computation for the sentinel/ego callers coalescing on it.
+    """
+    svc = HealthDataService(db=_mock_db())
+    started = asyncio.Event()
+    release = asyncio.Event()
+    completed = False
+
+    async def slow_compute():
+        nonlocal completed
+        started.set()
+        await release.wait()  # held in-flight until we allow completion
+        completed = True
+        return {"ok": True}
+
+    svc._compute_snapshot = slow_compute
+
+    async def _run():
+        a = asyncio.create_task(svc.snapshot())   # owner
+        await started.wait()                       # compute is now in-flight
+        b = asyncio.create_task(svc.snapshot())    # coalesces onto the same task
+        await asyncio.sleep(0)                      # let b reach its await
+        a.cancel()                                 # simulate the dashboard 15s timeout
+        with pytest.raises(asyncio.CancelledError):
+            await a
+        release.set()                              # allow the shared compute to finish
+        return await b                             # sibling must still get the result
+
+    result_b = asyncio.run(_run())
+    assert completed is True, "shared compute was cancelled by the other caller"
+    assert result_b == {"ok": True}, "coalesced sibling did not receive the result"


### PR DESCRIPTION
## WS-D — health-snapshot correctness (F4 + F10 + single-flight)

`HealthDataService.snapshot()` ran three synchronous I/O calls **on the event loop** while building the return dict, and its `asyncio.gather` had no failure isolation. Under load this stalled the loop, and a single unguarded sub-snapshot raise 500-ed the whole health route.

Two files: `observability/health_data.py` + a small extract-refactor of `observability/snapshots/services.py`. No migration.

### What changed
- **F4 — no blocking I/O on the loop.** Fold the blocking work into the existing gather via `asyncio.to_thread`: `conversation_activity()` + `proactive_memory_metrics()` (pure file I/O) offload whole; `services()` is split so only `collect_service_status()` (the ~7 `systemctl` subprocesses) is threaded, while the **sentinel read stays on-loop** — `sentinel.state` is mutated in place field-by-field on the loop, so offloading it would open a torn-read window. Host-framework `detect()` is near-free (empty registry) so it stays on-loop too. All three run concurrently with the DB/network sub-calls → ≈0 added wall-clock vs. the old serial post-gather calls.
- **F10 — gather failure isolation.** `return_exceptions=True` + a uniform `_or_error()` map: a raising sub-snapshot (e.g. `call_sites`, which has no internal guard) degrades to a `{"status": "error"}` section instead of taking down the whole snapshot; `CancelledError`/`BaseException` still propagate (never swallowed).
- **Single-flight coalescer.** Concurrent callers that share the runtime singleton (both ego-context builders on an awareness tick, sentinel dispatch, morning report) coalesce onto one in-flight compute. The shared task is awaited through **`asyncio.shield()`** so one caller's cancellation (e.g. the dashboard route's 15s `_async_route` timeout) can't abort the computation for the others; `_inflight` is released via the task's done-callback. Callers are read-only, so the shared dict needs no copy.

### Review + verification
- **Code review caught a Critical** (unshielded shared task → cross-caller cancellation cascade) — fixed with `asyncio.shield()` + done-callback lifecycle, plus a regression test proving a cancelled caller can't abort its coalesced siblings.
- **Tests (TDD):** new `test_health_snapshot_offload.py` (offload-off-thread, gather isolation, coalescing, cancellation-isolation) + existing guards green (`test_snapshot_includes_services_key`, `test_all_none_produces_valid_snapshot`, `test_services_snapshot.py`, `test_health_cache.py`). Full `test_observability/` (290) + ego/sentinel/morning-report consumer suites (236) pass.
- **E2E (real code path):** a warm snapshot runs in **57ms with a 14ms max event-loop gap** (loop not blocked), returns the full section set with real systemd/sentinel data, and concurrent callers coalesce without error. Live `/health` is 8–11ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)