### PR TITLE
feat(backup): GFS retention prune for off-site dated snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Off-site backups now self-prune on a grandfather-father-son schedule instead of growing forever.**
+  When you back up to an off-site target (NAS/SMB or a mounted path), each run now prunes old dated
+  snapshots — keeping the last 7 daily, 4 weekly, and 6 monthly — so remote storage stays bounded. It
+  never deletes the most recent complete snapshot (the one a restore uses), never touches an
+  in-progress snapshot, and never affects your local keep-forever transcript archive.
+
 - **You can now run Genesis on Claude Fable 5, and pick the full thinking-effort range on Sonnet and Fable.**
   Fable 5 (Anthropic's new top-tier model) is now a selectable model everywhere you choose one — the ego,
   campaigns, the inbox monitor, the Telegram default, the `/model` command (terminal and Telegram), and the

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -454,6 +454,44 @@ else
         _T2_STATUS="partial"
         log "WARNING: Tier 2 backup partially failed"
     fi
+
+    # --- Tier 2 GFS retention prune (off-site dated snapshots only) --------------
+    # Keep daily 7 / weekly 4 / monthly 6 of the COMPLETE off-site snapshots. gfs_select
+    # ALWAYS keeps the newest (restore.sh selects the latest COMPLETE); we also skip the
+    # current run's stamp explicitly. Best-effort — a prune failure never fails the backup.
+    # Transcripts are preserved elsewhere (local git keep-forever + the latest snapshot
+    # re-uploads the full set every run), so deleting an aged snapshot's transcripts/ copy
+    # loses nothing. Only the off-site dated tree is touched; the local ~/backups git repo
+    # is never pruned here. Runs only after a fully-uploaded (ok) snapshot this run.
+    if [ "${_T2_STATUS:-}" = "ok" ] && backend_available; then
+        # DR-safety: the host segment flows into a DESTRUCTIVE backend_delete (smb deltree /
+        # local rm -rf), so refuse to prune unless it is the plain filename charset — then a
+        # pathological hostname can never break out of the snapshot path. (The stamps below
+        # are already grep-restricted to the timestamp charset.)
+        if ! printf '%s' "$_T2_HOST_DIR" | grep -qE '^Genesis/[A-Za-z0-9._-]+$'; then
+            log "WARNING: GFS prune skipped — unsafe off-site host path '$_T2_HOST_DIR'"
+        else
+            _gfs_complete="$(
+                for _st in $(backend_list_dirs "$_T2_HOST_DIR" 2>/dev/null \
+                                | grep -oE '[0-9]{8}T[0-9]{6}Z' | sort -u || true); do
+                    backend_exists "$_T2_HOST_DIR/$_st/COMPLETE" && printf '%s\n' "$_st"
+                done
+                true
+            )"
+            _gfs_delete="$(printf '%s\n' "$_gfs_complete" \
+                | python3 "$_SCRIPT_DIR/gfs_select.py" --daily 7 --weekly 4 --monthly 6)" || _gfs_delete=""
+            for _st in $_gfs_delete; do
+                if [ "$_st" = "$_T2_STAMP" ]; then
+                    continue   # never the current run's snapshot
+                fi
+                if backend_delete "$_T2_HOST_DIR/$_st"; then
+                    log "GFS prune: removed off-site snapshot $_st"
+                else
+                    log "WARNING: GFS prune failed for off-site snapshot $_st"
+                fi
+            done
+        fi
+    fi
 fi
 backend_cleanup
 

--- a/scripts/gfs_select.py
+++ b/scripts/gfs_select.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Grandfather-Father-Son retention selection for off-site backup snapshots.
+
+Reads COMPLETE-marked dated snapshot stamps (``YYYYMMDDTHHMMSSZ``, one per line) on stdin
+and prints the subset to DELETE (one per line). Keeps the newest snapshot per day
+(``--daily``), per ISO week (``--weekly``), and per month (``--monthly``). The NEWEST stamp
+overall is ALWAYS kept — restore.sh selects the latest COMPLETE snapshot, so it must never be
+pruned. An unparseable line is never emitted for deletion (fail-safe keep).
+
+Stdlib only; pure selection (no filesystem, no network). backup.sh feeds it the COMPLETE
+stamps and deletes exactly what it prints.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+
+
+def _parse(stamp: str):
+    try:
+        return datetime.strptime(stamp, "%Y%m%dT%H%M%SZ")
+    except (ValueError, TypeError):
+        return None
+
+
+def _keep_recent_buckets(valid, key_fn, count, keep) -> None:
+    """Add the newest stamp of each of the ``count`` most-recent buckets to ``keep``.
+
+    ``valid`` is ``[(stamp, dt), ...]`` sorted newest-first, so the first stamp seen for a
+    bucket key is that bucket's newest.
+    """
+    if count <= 0:
+        return
+    newest_in_bucket: dict = {}
+    for stamp, dt in valid:
+        k = key_fn(dt)
+        if k not in newest_in_bucket:
+            newest_in_bucket[k] = stamp
+    for k in sorted(newest_in_bucket, reverse=True)[:count]:
+        keep.add(newest_in_bucket[k])
+
+
+def select_deletions(stamps, *, daily: int, weekly: int, monthly: int) -> list[str]:
+    """Return the subset of ``stamps`` to DELETE per GFS.
+
+    The newest valid stamp is always kept; unparseable stamps are never returned for deletion.
+    Only parseable stamps outside every retention bucket are deleted.
+    """
+    valid = [(s, dt) for s in stamps if (dt := _parse(s)) is not None]
+    valid.sort(key=lambda p: p[1], reverse=True)  # newest first
+    if not valid:
+        return []
+    keep = {valid[0][0]}  # the latest COMPLETE — never pruned
+    _keep_recent_buckets(valid, lambda dt: dt.date(), daily, keep)
+    _keep_recent_buckets(valid, lambda dt: dt.isocalendar()[:2], weekly, keep)
+    _keep_recent_buckets(valid, lambda dt: (dt.year, dt.month), monthly, keep)
+    return [s for s, _ in valid if s not in keep]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="GFS retention: print snapshot stamps to delete")
+    ap.add_argument("--daily", type=int, default=7)
+    ap.add_argument("--weekly", type=int, default=4)
+    ap.add_argument("--monthly", type=int, default=6)
+    a = ap.parse_args()
+    stamps = [ln.strip() for ln in sys.stdin if ln.strip()]
+    for s in select_deletions(stamps, daily=a.daily, weekly=a.weekly, monthly=a.monthly):
+        print(s)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_scripts/test_backup_dated_snapshots.py
+++ b/tests/test_scripts/test_backup_dated_snapshots.py
@@ -246,3 +246,60 @@ def test_large_temp_goes_to_dedicated_dir_not_inherited_tmpdir(backup_env, tmp_p
     # The script announces where large temp goes; it must be the dedicated dir, not cc-tmp.
     assert f"big-temp dir: {bigtmp}" in proc.stdout, (
         f"backup did not route large temp to the dedicated dir (expected {bigtmp}):\n{proc.stdout}")
+
+
+# --------------------------------------------------------------------------- #
+# GFS retention prune (D4) — off-site dated snapshots
+# --------------------------------------------------------------------------- #
+
+def _seed_offsite_snapshot(host_dir: Path, stamp: str, *, complete: bool) -> None:
+    snap = host_dir / stamp
+    (snap / "data").mkdir(parents=True)
+    (snap / "data" / "genesis.sql.gpg").write_text("x")
+    (snap / "transcripts").mkdir()
+    (snap / "transcripts" / "t.jsonl.gpg").write_text("x")
+    if complete:
+        (snap / "COMPLETE").write_text("")
+
+
+def test_gfs_prune_keeps_buckets_never_latest_or_incomplete_or_transcripts(backup_env, tmp_path):
+    """backup.sh's GFS prune keeps daily/weekly/monthly + the run's latest COMPLETE, deletes
+    the rest, NEVER touches an incomplete (in-flight) snapshot, and every retained snapshot
+    keeps its transcripts/. Real `local` backend, real fs (the SMB path shares this dispatch;
+    it is verified manually at deploy)."""
+    from datetime import UTC, datetime, timedelta
+
+    host = subprocess.run(["hostname"], capture_output=True, text=True).stdout.strip()
+    offsite = tmp_path / "offsite"
+    host_dir = offsite / "Genesis" / host
+    host_dir.mkdir(parents=True)
+
+    now = datetime.now(UTC)
+    # 200 daily COMPLETE snapshots (day-1 .. day-200), all older than the run's new one.
+    seeded = []
+    for d in range(1, 201):
+        s = (now - timedelta(days=d)).strftime("%Y%m%dT%H%M%SZ")
+        _seed_offsite_snapshot(host_dir, s, complete=True)
+        seeded.append(s)
+    # An INCOMPLETE (no COMPLETE) snapshot — GFS must never consider or delete it.
+    incomplete = (now - timedelta(days=149, hours=3)).strftime("%Y%m%dT%H%M%SZ")
+    _seed_offsite_snapshot(host_dir, incomplete, complete=False)
+
+    proc = _run_local(backup_env, offsite)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+    remaining = {d.name for d in host_dir.iterdir() if _STAMP_RE.fullmatch(d.name)}
+    # the run wrote a new (newest) COMPLETE snapshot — it must survive the prune.
+    new_stamps = remaining - set(seeded) - {incomplete}
+    assert len(new_stamps) == 1, f"expected exactly one new snapshot, got {new_stamps}"
+    assert (host_dir / next(iter(new_stamps)) / "COMPLETE").is_file()
+    # GFS keeps at most daily7 + weekly4 + monthly6 of the COMPLETE snapshots (overlaps -> fewer).
+    complete_remaining = {s for s in remaining if (host_dir / s / "COMPLETE").is_file()}
+    assert len(complete_remaining) <= 7 + 4 + 6
+    # a very old, non-boundary snapshot is pruned.
+    assert (now - timedelta(days=199)).strftime("%Y%m%dT%H%M%SZ") not in remaining
+    # the incomplete snapshot is NEVER pruned (no COMPLETE -> not eligible).
+    assert incomplete in remaining, "GFS must not delete an incomplete/in-flight snapshot"
+    # every retained snapshot keeps its transcripts/.
+    for s in complete_remaining:
+        assert (host_dir / s / "transcripts").is_dir(), f"{s} lost its transcripts/"

--- a/tests/test_scripts/test_gfs_select.py
+++ b/tests/test_scripts/test_gfs_select.py
@@ -1,0 +1,110 @@
+"""Tests for scripts/gfs_select.py — Grandfather-Father-Son retention selection.
+
+This is the crown-jewel safety math for off-site backup pruning: it decides which dated
+snapshots to DELETE. The invariants under test:
+  * the NEWEST stamp is ALWAYS kept (restore.sh depends on the latest COMPLETE);
+  * keep the newest snapshot per day (daily N), per ISO-week (weekly M), per month (monthly K);
+  * everything outside every bucket is deleted;
+  * an unparseable stamp is never deleted (fail-safe keep).
+Pure function, no I/O — deterministic, wall-clock-independent (stamps are explicit).
+"""
+
+import importlib.util
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "gfs_select.py"
+_spec = importlib.util.spec_from_file_location("gfs_select", _SCRIPT)
+_gfs = importlib.util.module_from_spec(_spec)
+sys.modules["gfs_select"] = _gfs
+_spec.loader.exec_module(_gfs)
+
+
+def _stamp(dt: datetime) -> str:
+    return dt.strftime("%Y%m%dT%H%M%SZ")
+
+
+def _daily_series(days: int, *, end: datetime, per_day: int = 1) -> list[str]:
+    """`days` consecutive calendar days ending at `end`, `per_day` stamps each."""
+    out = []
+    for d in range(days):
+        base = end - timedelta(days=d)
+        for h in range(per_day):
+            out.append(_stamp(base - timedelta(hours=h)))
+    return out
+
+
+_END = datetime(2026, 7, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _select(stamps, daily=7, weekly=4, monthly=6):
+    return set(_gfs.select_deletions(stamps, daily=daily, weekly=weekly, monthly=monthly))
+
+
+def test_empty_deletes_nothing():
+    assert _gfs.select_deletions([], daily=7, weekly=4, monthly=6) == []
+
+
+def test_single_stamp_kept():
+    s = _stamp(_END)
+    assert _select([s]) == set()
+
+
+def test_newest_is_always_kept():
+    stamps = _daily_series(300, end=_END)
+    newest = _stamp(_END)
+    deletions = _select(stamps, daily=1, weekly=0, monthly=0)
+    assert newest not in deletions
+
+
+def test_same_day_keeps_only_newest_for_daily_bucket():
+    # 3 stamps on one day; daily=1, no weekly/monthly -> keep the newest, delete the 2 older.
+    stamps = _daily_series(1, end=_END, per_day=3)
+    deletions = _select(stamps, daily=1, weekly=0, monthly=0)
+    assert _stamp(_END) not in deletions          # newest kept
+    assert len(deletions) == 2                     # the two older same-day stamps
+
+
+def test_daily_keeps_n_most_recent_days():
+    # one stamp/day for 5 days; daily=3 -> keep newest 3 days, delete oldest 2.
+    stamps = _daily_series(5, end=_END)
+    deletions = _select(stamps, daily=3, weekly=0, monthly=0)
+    assert len(deletions) == 2
+    # the two OLDEST days are deleted
+    oldest_two = {_stamp(_END - timedelta(days=3)), _stamp(_END - timedelta(days=4))}
+    assert deletions == oldest_two
+
+
+def test_gfs_full_policy_keeps_daily_weekly_monthly_and_prunes_rest():
+    # 200 daily snapshots; classic 7/4/6. Keep-set = newest-per-day(7) ∪ per-week(4) ∪ per-month(6).
+    stamps = _daily_series(200, end=_END)
+    deletions = _select(stamps, daily=7, weekly=4, monthly=6)
+    kept = set(stamps) - deletions
+    assert _stamp(_END) in kept                    # newest always kept
+    assert deletions, "old snapshots outside all buckets must be pruned"
+    # keep-set is bounded by the bucket counts (with overlaps -> at most 7+4+6)
+    assert len(kept) <= 7 + 4 + 6
+    # a very old snapshot (>6 months) that is not a month-boundary keeper is deleted
+    assert _stamp(_END - timedelta(days=199)) in deletions
+
+
+def test_unparseable_stamp_is_never_deleted():
+    good_old = _stamp(_END - timedelta(days=100))
+    stamps = [_stamp(_END), "not-a-stamp", good_old]
+    deletions = _select(stamps, daily=1, weekly=0, monthly=0)
+    assert "not-a-stamp" not in deletions           # fail-safe: unparseable -> keep
+
+
+def test_weekly_buckets_by_iso_week_not_calendar_year():
+    """Two stamps in the SAME ISO week but DIFFERENT calendar years must share ONE weekly
+    bucket. 2025-12-30 and 2026-01-01 are both ISO week 1 of 2026. With weekly=2, correct
+    ISO bucketing sees a single bucket -> keeps only the newest -> prunes 2025-12-30; a buggy
+    (calendar_year, week) key would make two buckets and wrongly RETAIN 2025-12-30."""
+    older = _stamp(datetime(2025, 12, 30, 12, 0, 0, tzinfo=UTC))
+    newer = _stamp(datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC))
+    assert (datetime(2025, 12, 30).isocalendar()[:2]
+            == datetime(2026, 1, 1).isocalendar()[:2])  # sanity: same ISO (year, week)
+    deletions = _select([older, newer], daily=0, weekly=2, monthly=0)
+    assert older in deletions       # same ISO week -> only the newest survives
+    assert newer not in deletions   # newest always kept


### PR DESCRIPTION
Final piece of the disk-retention work (follows #871, #874). Bounds the one remaining unbounded store: the **off-site** dated backup snapshots.

## Problem
`backup.sh` uploads a new dated snapshot (`Genesis/<host>/<UTC-stamp>/…` + a `COMPLETE` marker) every run and **never pruned old ones** — off-site (NAS/SMB) storage grew forever. (The *local* `~/backups` git repo is self-bounding + keep-forever-transcripts by design and is untouched here.)

## Change
- **`scripts/gfs_select.py` (new, stdlib):** pure grandfather-father-son selection. Reads `COMPLETE` stamps on stdin, prints the delete-set. Keeps the newest snapshot per day (`--daily 7`), ISO-week (`--weekly 4`), and month (`--monthly 6`). **Always keeps the newest overall** (restore.sh selects the latest COMPLETE); unparseable stamps are never emitted for deletion.
- **`backup.sh`:** after a fully-uploaded (`ok`) snapshot, enumerate the `COMPLETE`-marked stamps, feed them to `gfs_select`, and `backend_delete` the result. Fully `set -euo pipefail` guarded; **best-effort — a prune failure never fails the backup.**

## Safety rails (DR-critical)
- **Never deletes the latest COMPLETE** — `gfs_select` always keeps the newest, and backup.sh also skips the current run's stamp explicitly.
- **Never touches an incomplete/in-flight snapshot** (no `COMPLETE` marker → not eligible).
- **Never touches the local repo or its keep-forever transcripts** — only the off-site dated tree; transcripts are preserved elsewhere (local git + the latest snapshot re-uploads the full set each run).

## Tests
`test_gfs_select.py` — the bucket math + "newest always kept" + "unparseable never deleted" (pure, wall-clock-independent). `test_backup_dated_snapshots.py` — an **end-to-end** run through the real `local` backend: seed 200 daily COMPLETE snapshots + one incomplete, run backup.sh, assert GFS kept ≤daily7+weekly4+monthly6, the latest COMPLETE + the incomplete survived, a >6-month non-boundary snapshot was pruned, and retained snapshots kept their `transcripts/`.

Note: the **SMB** backend shares the same `backend_list_dirs`/`backend_exists`/`backend_delete` dispatch as `local`; it can't be exercised in-repo, so it's verified manually at deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)