### PR TITLE
fix(ego,routing): stop COO reactive-waste from provider-exhaustion storm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Genesis's COO (self-maintenance ego) no longer burns cognitive cycles reacting to model-provider
+  outages it can't fix.** When a provider chain runs out of options (e.g. a temporary DeepSeek outage),
+  the "all providers exhausted" alerts no longer wake the ego into a full high-effort reasoning cycle that
+  can only conclude "nothing I can do" — these were the large majority of its zero-outcome reactive cycles.
+  The outage still reaches the ego through its normal system-health context, so nothing is hidden; it just
+  stops paying to react to it. Relatedly, the cross-type procedure-dedup check now skips its judgment call
+  outright when that chain is down, instead of firing a doomed request that would raise yet another alert.
+
 - **The dashboard's system-health view stays responsive under load and no longer errors out when a single
   check hiccups.** Building the health snapshot used to run its systemd service checks (several `systemctl`
   calls) and a couple of file scans directly on the main event loop, so gathering health could briefly stall

--- a/src/genesis/learning/procedural/extractor.py
+++ b/src/genesis/learning/procedural/extractor.py
@@ -149,6 +149,25 @@ async def _cross_type_duplicate(
         nt=task_type, np=principle, ns=ns_txt, candidates="\n".join(lines),
     )
 
+    # Fail fast when the novelty-judge chain has NO available provider: a
+    # route_call now would just exhaust and emit an `all_exhausted` event that
+    # feeds the COO's reactive-cycle storm. Skip it and fail open to "novel" —
+    # the same outcome as a failed judgment (below), but without the doomed call.
+    # Precision-safe: worst case is a paraphrase duplicate stored, never a
+    # false-merge. Duck-typed (router may be a stub in tests) → any miss falls
+    # through to the normal call, which also fails open. See plan REACTIVE-WASTE (L2c).
+    _breakers = getattr(router, "breakers", None)
+    _cfg = getattr(router, "config", None)
+    if _breakers is not None and _cfg is not None:
+        _site = getattr(_cfg, "call_sites", {}).get(_NOVELTY_CALL_SITE)
+        _chain = getattr(_site, "chain", None)
+        if _chain and not _breakers.chain_has_available(_chain):
+            logger.debug(
+                "Cross-type dedup: all %s providers circuit-breaker-open — "
+                "skipping novelty judge, treating as novel", _NOVELTY_CALL_SITE,
+            )
+            return False, max_cross_sim
+
     try:
         result = await router.route_call(
             call_site_id=_NOVELTY_CALL_SITE,

--- a/src/genesis/routing/circuit_breaker.py
+++ b/src/genesis/routing/circuit_breaker.py
@@ -300,6 +300,17 @@ class CircuitBreakerRegistry:
             return False
         return self.get(name).is_available() and cfg.has_api_key
 
+    def chain_has_available(self, chain: list[str]) -> bool:
+        """True if ANY provider in ``chain`` can currently serve requests.
+
+        Reuses ``_provider_available`` (breaker not OPEN — CLOSED or HALF_OPEN —
+        AND a usable key). Callers use this to FAIL FAST when a whole chain is
+        circuit-breaker-open, instead of firing a doomed ``route_call`` that just
+        emits another ``all_exhausted`` event (and the reactive-cycle storm that
+        feeds off it). An empty or all-unknown chain returns False.
+        """
+        return any(self._provider_available(p) for p in chain)
+
     def uncovered_essential_sites(self) -> list[str]:
         """Essential cloud sites that currently have NO available provider
         (breaker not OPEN and key present).

--- a/src/genesis/runtime/init/ego.py
+++ b/src/genesis/runtime/init/ego.py
@@ -29,6 +29,19 @@ logger = logging.getLogger("genesis.runtime")
 _IDENTITY_DIR = Path(__file__).resolve().parents[2] / "identity"
 
 
+def _is_non_actionable_infra_event(subsystem: str, event_type: str) -> bool:
+    """True for routing/provider chain-exhaustion events the COO ego can't act on.
+
+    A provider outage / chain exhaustion is not reconfigurable by the ego, so a
+    reactive Opus/high cycle on it always no-ops — these drove ~92% of the COO's
+    zero-proposal reactive cycles. The condition still reaches the ego via
+    ProviderEscalation -> `provider_failure` observation (routing/escalation.py),
+    read in PROACTIVE context (genesis_context.py::_observations_section) — so the
+    gate drops the WASTE, not the signal. Module-level so it is unit-testable.
+    """
+    return subsystem in ("routing", "providers") and event_type == "all_exhausted"
+
+
 async def init(rt: GenesisRuntime) -> None:
     """Initialize both egos: user ego + genesis ego."""
     # Hard dependencies — skip if unavailable
@@ -375,6 +388,12 @@ async def init(rt: GenesisRuntime) -> None:
                     return
 
                 subsystem = str(getattr(event, "subsystem", ""))
+
+                # DOMAIN GATE: drop non-COO-actionable routing/provider exhaustion
+                # from the reactive path (still surfaced via ProviderEscalation ->
+                # proactive-context observation). See _is_non_actionable_infra_event.
+                if _is_non_actionable_infra_event(subsystem, event.event_type):
+                    return
 
                 event_dict = {
                     "type": event.event_type,

--- a/tests/ego/test_init.py
+++ b/tests/ego/test_init.py
@@ -193,3 +193,60 @@ class TestEgoInitWiring:
             call_kwargs = mock_cadence_cls.call_args[1]
             assert call_kwargs["idle_detector"] is None
             mock_cadence.start.assert_awaited_once()
+
+
+class TestReactiveDomainGate:
+    """L1: routing/provider chain-exhaustion is dropped from the COO reactive path."""
+
+    def test_routing_all_exhausted_is_filtered(self):
+        assert ego._is_non_actionable_infra_event("routing", "all_exhausted") is True
+
+    def test_providers_all_exhausted_is_filtered(self):
+        assert ego._is_non_actionable_infra_event("providers", "all_exhausted") is True
+
+    def test_other_routing_event_stays_actionable(self):
+        # A different routing ERROR (e.g. a future degradation alert) is not gated.
+        assert ego._is_non_actionable_infra_event("routing", "budget.exceeded") is False
+
+    def test_non_infra_subsystem_stays_actionable(self):
+        assert ego._is_non_actionable_infra_event("guardian", "all_exhausted") is False
+        assert ego._is_non_actionable_infra_event("memory", "corruption") is False
+
+    @pytest.mark.asyncio
+    async def test_wiring_gates_all_exhausted_but_forwards_other_routing(self):
+        """End-to-end through the subscriber closure: a routing all_exhausted
+        event is gated (no reactive push); a routing budget.exceeded event still
+        reaches the reactive path. Guards against a future refactor inverting it."""
+        rt = _make_runtime()
+        with (
+            patch("genesis.ego.config.load_ego_config") as mock_load,
+            patch("genesis.ego.session.EgoSession"),
+            patch("genesis.ego.cadence.EgoCadenceManager") as mock_cadence_cls,
+            patch("genesis.ego.compaction.CompactionEngine"),
+            patch("genesis.ego.context.EgoContextBuilder"),
+            patch("genesis.ego.proposals.ProposalWorkflow"),
+            patch("genesis.ego.dispatch.EgoDispatcher"),
+        ):
+            from genesis.ego.types import EgoConfig
+            mock_config = EgoConfig(enabled=True)
+            mock_load.return_value = mock_config
+            mock_cadence = AsyncMock()
+            mock_cadence.push_reactive_event = MagicMock()  # real method is sync
+            mock_cadence_cls.return_value = mock_cadence
+
+            await ego.init(rt)
+            callback = rt._event_bus.subscribe.call_args.args[0]
+
+            def _evt(subsystem, event_type):
+                e = MagicMock()
+                e.subsystem = subsystem
+                e.event_type = event_type
+                e.severity.name = "ERROR"
+                e.message = f"{event_type} from {subsystem}"
+                return e
+
+            await callback(_evt("routing", "all_exhausted"))
+            mock_cadence.push_reactive_event.assert_not_called()
+
+            await callback(_evt("routing", "budget.exceeded"))
+            mock_cadence.push_reactive_event.assert_called_once()

--- a/tests/test_learning/test_cross_type_novelty.py
+++ b/tests/test_learning/test_cross_type_novelty.py
@@ -117,3 +117,57 @@ async def test_deprecated_row_does_not_suppress(db):
         embedder=_embedder_returning(_vec(0)), router=router, new_steps=["s"],
     )
     assert is_novel is True  # deprecated dup excluded → stored
+
+
+def _router_38a_all_open() -> MagicMock:
+    """Router whose 38a novelty chain has NO available provider (all breakers open)."""
+    from types import SimpleNamespace
+
+    r = MagicMock()
+    r.route_call = AsyncMock(return_value=_Result(content="{}"))
+    r.breakers.chain_has_available = MagicMock(return_value=False)
+    r.config = SimpleNamespace(
+        call_sites={
+            "38a_procedure_novelty_llm": SimpleNamespace(
+                chain=["nvidia-nim-deepseek", "openrouter-deepseek-v4"],
+            ),
+        },
+    )
+    return r
+
+
+@pytest.mark.asyncio
+async def test_cross_type_fail_fast_when_chain_breaker_open(db):
+    """L2c: when the 38a chain has no available provider, skip the doomed
+    route_call (no all_exhausted storm) and fail open to 'novel'."""
+    await _seed(db, "reindex-gitnexus", _vec(0))
+    router = _router_38a_all_open()
+    is_novel, _max_sim, _vec_out, _fo = await _principle_is_novel(
+        db, task_type="reindex-code-intel", new_principle="reindex the code graph",
+        embedder=_embedder_returning(_vec(0)), router=router, new_steps=["s"],
+    )
+    assert is_novel is True  # fail-open to novel — never a false-merge
+    router.route_call.assert_not_awaited()  # the doomed 38a call was skipped
+    router.breakers.chain_has_available.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cross_type_proceeds_when_call_site_absent(db):
+    """L2c guard falls through to the normal route_call when the 38a call site
+    is absent from config (unknown/None chain must NOT skip)."""
+    from types import SimpleNamespace
+
+    await _seed(db, "reindex-gitnexus", _vec(0))
+    r = MagicMock()
+    r.route_call = AsyncMock(
+        return_value=_Result(content=json.dumps({"redundant_with": None})),
+    )
+    r.breakers.chain_has_available = MagicMock(return_value=False)  # would skip IF reached
+    r.config = SimpleNamespace(call_sites={})  # 38a not present -> _site is None
+    is_novel, _m, _v, _fo = await _principle_is_novel(
+        db, task_type="reindex-code-intel", new_principle="reindex the code graph",
+        embedder=_embedder_returning(_vec(0)), router=r, new_steps=["s"],
+    )
+    assert is_novel is True
+    r.route_call.assert_awaited_once()  # guard skipped -> normal call fired
+    r.breakers.chain_has_available.assert_not_called()  # short-circuit on _chain None

--- a/tests/test_routing/test_circuit_breaker.py
+++ b/tests/test_routing/test_circuit_breaker.py
@@ -647,3 +647,25 @@ def test_degradation_coverage_ollama_axis_independent_of_essential_map():
     for _ in range(3):
         reg.get("ol").record_failure(ErrorCategory.TRANSIENT)
     assert reg.compute_degradation_level() == DegradationLevel.LOCAL_COMPUTE_DOWN
+
+
+def test_chain_has_available_true_when_any_provider_closed():
+    reg = CircuitBreakerRegistry({"a": _provider("a"), "b": _provider("b")})
+    for _ in range(3):  # trip 'a' OPEN (default threshold trips on the 3rd)
+        reg.get("a").record_failure(ErrorCategory.TRANSIENT)
+    assert reg.get("a").state == ProviderState.OPEN
+    assert reg.chain_has_available(["a", "b"]) is True  # 'b' still CLOSED
+
+
+def test_chain_has_available_false_when_all_open():
+    reg = CircuitBreakerRegistry({"a": _provider("a"), "b": _provider("b")})
+    for name in ("a", "b"):
+        for _ in range(3):
+            reg.get(name).record_failure(ErrorCategory.TRANSIENT)
+    assert reg.chain_has_available(["a", "b"]) is False
+
+
+def test_chain_has_available_false_for_empty_or_unknown():
+    reg = CircuitBreakerRegistry({"a": _provider("a")})
+    assert reg.chain_has_available([]) is False
+    assert reg.chain_has_available(["nonexistent"]) is False


### PR DESCRIPTION
## Problem
The genesis (COO) self-maintenance ego ran ~94 reactive Opus/high cycles in 14 days, **~92% producing zero proposals**. It kept waking on routing `all_exhausted` ERROR events it fundamentally cannot act on (provider config is outside its domain), investigating, and concluding "nothing I can do" — on the order of $250/mo of wasted cognition.

## Root cause
The `judge` and `38a_procedure_novelty_llm` chains are **all-deepseek with no non-deepseek fallback**. When the deepseek providers' circuit breakers trip (they flap intermittently), every call exhausts and storms the event bus with `all_exhausted` (judge alone: ~398 in 3 days). Those ERROR events wake the COO's reactive path. Sibling chains are unaffected because they use non-deepseek providers.

## Fix (the high-value core; 2 of 4 investigated layers)
**L1 — domain-gate the reactive path** (`runtime/init/ego.py`): drop routing/provider `all_exhausted` from the COO reactive path via a new module-level `_is_non_actionable_infra_event(subsystem, event_type)`. **Nothing is hidden** — the condition still reaches the ego via `ProviderEscalation` → `provider_failure` observation, read in *proactive* context (`genesis_context._observations_section`). Only `all_exhausted` from routing/providers is gated; `budget.exceeded` and every other event still wakes the ego.

**L2c — fail-fast in the novelty judge** (`routing/circuit_breaker.py` + `learning/procedural/extractor.py`): new `CircuitBreakerRegistry.chain_has_available(chain)`; the cross-type dedup skips its `route_call` when the 38a chain has no available provider, failing open to "novel" (same outcome as a failed judgment, minus the doomed call that emits another `all_exhausted`). Precision-safe: worst case is a paraphrase duplicate stored, never a false-merge.

## Deferred (intentionally not here)
- **L2a** DLQ redispatch breaker-gate — the DLQ is currently empty (1h TTL clears items before the 6h redispatch cron); hygiene follow-up.
- **L3** a non-deepseek fallback for `judge`/`38a` — precision-constrained (0-false-merge validated on deepseek-v4); needs a fresh validation run + a model decision.

## Tests & verification
- 65 targeted tests green (9 new): the L1 predicate, an end-to-end test through the subscriber closure (all_exhausted gated / budget.exceeded forwarded), `chain_has_available` (any-open / all-open / empty), and the extractor fail-fast + fall-through paths. Existing tests unchanged — the guard is a no-op when providers are available.
- Code review (feature-dev:code-reviewer): SHIP-WITH-NITS; both coverage nits closed.
- E2E against the **live** routing config + durable breaker state: the predicate gates correctly, and `chain_has_available` returned "proceed" while the deepseek breakers were recovered (flapping, not dead) — confirming the fail-fast fires only during down-windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
