### PR TITLE
fix(dashboard): clearer per-session memory row — "Claude Code Sessions", green when healthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,11 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The dashboard's per-session memory row is clearer: "Claude Code Sessions", green when healthy.** The
+  cryptic "CC" row that listed sessions as gray "cc-1 …" chips is now labeled **Claude Code Sessions**,
+  renders each healthy session in green (amber ≥ 4 GB, red ≥ 6 GB), and shows a hover tooltip explaining
+  it's per-session memory for leak detection — so "gray" no longer reads as inactive/unknown.
+
 - **The dashboard's system-health view stays responsive under load and no longer errors out when a single
   check hiccups.** Building the health snapshot used to run its systemd service checks (several `systemctl`
   calls) and a couple of file scans directly on the main event loop, so gathering health could briefly stall

--- a/src/genesis/dashboard/templates/genesis_dashboard.html
+++ b/src/genesis/dashboard/templates/genesis_dashboard.html
@@ -5197,15 +5197,17 @@
                         x-text="($store.genesisDashboard.health.infrastructure.disk.total_gb - $store.genesisDashboard.health.infrastructure.disk.free_gb).toFixed(0) + '/' + $store.genesisDashboard.health.infrastructure.disk.total_gb.toFixed(0) + ' GB'"></span>
                 </div>
               </template>
-              <!-- CC slots row (per-session RSS — leak detection) -->
+              <!-- Claude Code sessions row (per-session RSS — leak detection) -->
               <template x-if="($store.genesisDashboard.health.infrastructure?.cc_slots || []).length">
-                <div style="display:flex; align-items:flex-start; gap:0.5rem; font-size:0.8rem;">
-                  <span style="width:3.2rem; color:var(--color-text-secondary);">CC</span>
-                  <div style="flex:1; display:flex; flex-wrap:wrap; gap:0.35rem;">
+                <div style="display:flex; flex-direction:column; gap:0.3rem; font-size:0.8rem;">
+                  <span style="color:var(--color-text-secondary);"
+                        title="Memory (RSS) used by each concurrent Claude Code worker session — leak detection. Green = healthy, amber ≥ 4 GB, red ≥ 6 GB.">Claude Code Sessions</span>
+                  <div style="display:flex; flex-wrap:wrap; gap:0.35rem;">
                     <template x-for="slot in $store.genesisDashboard.health.infrastructure.cc_slots" :key="slot.slot">
                       <span style="font-size:0.7rem; padding:0.05rem 0.3rem; border-radius:3px; background:var(--color-background); white-space:nowrap;"
-                            :style="`color: ${slot.status === 'error' ? '#d9534f' : slot.status === 'degraded' ? '#f0ad4e' : 'var(--color-text-secondary)'}`"
-                            x-text="'cc-' + slot.slot + ' ' + (slot.rss_mb / 1024).toFixed(1) + 'G'"></span>
+                            :style="`color: ${slot.status === 'error' ? '#d9534f' : slot.status === 'degraded' ? '#f0ad4e' : '#4caf50'}`"
+                            :title="'Session ' + slot.slot + ' (pid ' + slot.pid + '): ' + (slot.rss_mb / 1024).toFixed(2) + ' GB RSS'"
+                            x-text="'#' + slot.slot + ' ' + (slot.rss_mb / 1024).toFixed(1) + 'G'"></span>
                     </template>
                   </div>
                 </div>


### PR DESCRIPTION
The infrastructure health card's per-session RSS row (added in #855) was labeled **"CC"** with **gray** `cc-N` chips. Gray reads as inactive/unknown, and "CC" is opaque — a user asked what it even was and why it looked gray.

**Change (display-only; `cc_slots` data + thresholds unchanged):**
- Rename the row **"CC" → "Claude Code Sessions"** (stacked label so the full name fits the compact card).
- Color **healthy sessions green** (`#4caf50`, matching the CPU/Disk rows) — amber ≥ 4 GB, red ≥ 6 GB unchanged.
- Chips **`cc-N` → `#N`**, plus hover tooltips (row purpose on the label; per-session pid + GB on each chip).

Verified the template still parses (jinja2). One file, +8/−6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)