### PR TITLE
fix: autonomy context-ceiling gate + Guardian SSH key hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   and several denial-of-service vectors). Genesis uses it only as a client for outbound calls, so
   real-world exposure was limited, but the newer version removes the advisories outright.
 
+- **The autonomy gate now honors each action category's context ceiling before auto-dispatching a
+  background action.** When deciding whether a background action may run, the gate compared the
+  required level against the raw *earned* level — so a category that had earned a high level could
+  clear a bar it shouldn't in a more restricted context, most notably letting a financial action pass
+  its level check. It now uses the ceiling-clamped effective level, so background auto-dispatch of
+  higher-risk categories (e.g. financial) is refused regardless of earned level. Your explicit
+  approval was, and still is, required for these actions — this closes a defense-in-depth gap behind
+  that approval.
+
+- **The Genesis→host control SSH key is now bound to the container's source address and denied an
+  interactive terminal.** The key that lets the container drive recovery on the host is installed with
+  a `from=` source-IP restriction and `no-pty`, so a copied key can't be used from another machine on
+  your LAN and can't request a shell. Re-running the Guardian installer upgrades an existing key in
+  place; if the source address can't be confirmed it keeps the terminal restriction and safely skips
+  the address lock (verified by the installer's own connectivity test) rather than risk locking
+  Guardian out.
+
 ### Added
 
 - **Off-site backups now self-prune on a grandfather-father-son schedule instead of growing forever.**

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -16,8 +16,9 @@
 #   test-approval   — E2E test the keyword-reply approval gate (no recovery)
 #   ping            — liveness check
 #
-# SSH authorized_keys entry (replace CONTAINER_IP with your container's IP):
-#   command="~/.local/bin/guardian-gateway.sh",from="CONTAINER_IP" ssh-ed25519 ...
+# SSH authorized_keys entry (replace CONTAINER_IP with the container's
+# host-facing source IP — install_guardian.sh derives and installs this):
+#   from="CONTAINER_IP",command="~/.local/bin/guardian-gateway.sh",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-ed25519 ...
 #
 # This gives Genesis a fixed allowlist of operations on the host. Nothing else.
 

--- a/scripts/install_guardian.sh
+++ b/scripts/install_guardian.sh
@@ -595,18 +595,24 @@ REMOTECONF
     SSH_TEST=$(_guardian_ssh_test)
     if echo "$SSH_TEST" | grep -q '"ok": true'; then
         echo "  SSH bidirectional link verified${GUARD_FROM_IP:+ (source-restricted to ${GUARD_FROM_IP})}"
-    elif [ -n "${GUARD_FROM_IP:-}" ]; then
-        # A wrong from= restriction would silently lock Guardian out of the host.
-        # Never let that persist: drop from= (keep no-pty + the other options)
-        # and re-test. Guardian keeps working; the LAN source-restriction just
-        # isn't applied until the correct source IP is determined.
-        echo "  SSH test failed with from=\"${GUARD_FROM_IP}\" — retrying without from= (keeping no-pty)..."
-        sed -i '/genesis-guardian-control/d' "$HOME/.ssh/authorized_keys"
-        echo "${GUARD_BASE_OPTS} ${PUBKEY}" >> "$HOME/.ssh/authorized_keys"
-        chmod 600 "$HOME/.ssh/authorized_keys"
+    elif grep -F "$PUBKEY_BLOB" "$HOME/.ssh/authorized_keys" 2>/dev/null | grep -q 'from='; then
+        # The guardian key carries a from= restriction and the link is down — the
+        # restriction likely doesn't match the source IP the host observes (wrong
+        # derivation, or the container's address changed since the key was
+        # written). A wrong from= silently locks Guardian out, so drop it (keeping
+        # no-pty + the other options) and re-test. Keyed on the PRESENCE of from=
+        # (not on whether we wrote it this run), so a stale from= also self-heals
+        # on a plain re-run. Remove by key material (grep -vF on the blob), not
+        # the comment, so it works regardless of the key's comment field.
+        echo "  SSH test failed while a from= restriction is set on the guardian key — dropping from= (keeping no-pty) and retrying..."
+        _ak="$HOME/.ssh/authorized_keys"; _tmp="${_ak}.tmp.$$"
+        grep -vF "$PUBKEY_BLOB" "$_ak" > "$_tmp" 2>/dev/null || true
+        echo "${GUARD_BASE_OPTS} ${PUBKEY}" >> "$_tmp"
+        mv "$_tmp" "$_ak"
+        chmod 600 "$_ak"
         SSH_TEST=$(_guardian_ssh_test)
         if echo "$SSH_TEST" | grep -q '"ok": true'; then
-            echo "  SSH link verified WITHOUT from= — the derived source IP (${GUARD_FROM_IP}) is not what the host observes."
+            echo "  SSH link verified WITHOUT from= — the source-IP restriction did not match what the host observes."
             echo "  Guardian works; the LAN key-theft restriction is NOT enforced. To enable it, add"
             echo "  from=\"<container's host-facing source IP>\" to the guardian key in ~/.ssh/authorized_keys."
         else

--- a/scripts/install_guardian.sh
+++ b/scripts/install_guardian.sh
@@ -538,18 +538,39 @@ if [ -z "$PUBKEY" ]; then
 else
     # Install command-restricted authorized_keys entry (idempotent by key material)
     PUBKEY_BLOB=$(echo "$PUBKEY" | awk '{print $2}')
-    if grep -qF "$PUBKEY_BLOB" "$HOME/.ssh/authorized_keys" 2>/dev/null; then
-        echo "  Authorized key already installed (key matches)"
+    GUARD_FROM_IP=""
+    GUARD_BASE_OPTS="command=\"$HOME/.local/bin/guardian-gateway.sh\",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty"
+    # Treat the key as installed only if it is present AND hardened (no-pty is
+    # the marker for this installer version's options). A key present without
+    # no-pty is an older, under-hardened entry — re-install to upgrade it.
+    if grep -F "$PUBKEY_BLOB" "$HOME/.ssh/authorized_keys" 2>/dev/null | grep -q 'no-pty'; then
+        echo "  Authorized key already installed and hardened"
     else
-        # Remove stale entry (same comment, different key) if present
+        # Remove any existing control entry (stale key OR older un-hardened one)
         if grep -q "genesis-guardian-control" "$HOME/.ssh/authorized_keys" 2>/dev/null; then
             sed -i '/genesis-guardian-control/d' "$HOME/.ssh/authorized_keys"
-            echo "  Removed stale guardian key (container rebuilt)"
+            echo "  Removed prior guardian key entry (re-installing hardened)"
         fi
         mkdir -p "$HOME/.ssh" && chmod 700 "$HOME/.ssh"
-        echo "command=\"$HOME/.local/bin/guardian-gateway.sh\",no-port-forwarding,no-X11-forwarding,no-agent-forwarding ${PUBKEY}" >> "$HOME/.ssh/authorized_keys"
+        # Harden beyond the ForceCommand:
+        #   no-pty  — the gateway is a non-interactive JSON contract, never a shell.
+        #   from="" — bind the key to the container's source IP so a stolen key
+        #             can't be used from any other LAN host. Derive that IP from
+        #             the container's ACTUAL egress route to the host, NOT
+        #             `incus list -c4` (which can return the tailscale address the
+        #             host never sees). If it can't be derived, install without
+        #             from= (no-pty still applies) rather than guess and risk a
+        #             lockout; a wrong from= is caught + rolled back by the
+        #             connectivity test below.
+        GUARD_FROM_IP=$(incus exec "$CONTAINER_NAME" -- ip -4 route get "${TS_IP:-}" 2>/dev/null | grep -oP 'src \K\S+' | head -1 || true)
+        if [ -n "$GUARD_FROM_IP" ]; then
+            echo "from=\"${GUARD_FROM_IP}\",${GUARD_BASE_OPTS} ${PUBKEY}" >> "$HOME/.ssh/authorized_keys"
+        else
+            echo "  NOTE: could not derive container source IP — installing without from= (no-pty still applied)"
+            echo "${GUARD_BASE_OPTS} ${PUBKEY}" >> "$HOME/.ssh/authorized_keys"
+        fi
         chmod 600 "$HOME/.ssh/authorized_keys"
-        echo "  Installed command-restricted SSH key for Genesis→Guardian control"
+        echo "  Installed hardened command-restricted SSH key for Genesis→Guardian control"
     fi
 
     # Write connection config into container for Genesis to read
@@ -567,18 +588,42 @@ REMOTECONF
 
     # Verify SSH connectivity: container → host
     echo "  Testing SSH connectivity (container → host)..."
-    CONTAINER_IP=$(incus list "$CONTAINER_NAME" -f csv -c 4 2>/dev/null | grep -oP '[\d.]+' | head -1)
-    SSH_TEST=$(incus exec "$CONTAINER_NAME" -- su - "$CONTAINER_USER" -c \
-        "ssh -i ${GUARDIAN_KEY} -o StrictHostKeyChecking=no -o ConnectTimeout=5 ${HOST_USER}@${HOST_IP} ping 2>&1" || echo "FAILED")
+    _guardian_ssh_test() {
+        incus exec "$CONTAINER_NAME" -- su - "$CONTAINER_USER" -c \
+            "ssh -i ${GUARDIAN_KEY} -o StrictHostKeyChecking=no -o ConnectTimeout=5 ${HOST_USER}@${HOST_IP} ping 2>&1" || echo "FAILED"
+    }
+    SSH_TEST=$(_guardian_ssh_test)
     if echo "$SSH_TEST" | grep -q '"ok": true'; then
-        echo "  SSH bidirectional link verified"
+        echo "  SSH bidirectional link verified${GUARD_FROM_IP:+ (source-restricted to ${GUARD_FROM_IP})}"
+    elif [ -n "${GUARD_FROM_IP:-}" ]; then
+        # A wrong from= restriction would silently lock Guardian out of the host.
+        # Never let that persist: drop from= (keep no-pty + the other options)
+        # and re-test. Guardian keeps working; the LAN source-restriction just
+        # isn't applied until the correct source IP is determined.
+        echo "  SSH test failed with from=\"${GUARD_FROM_IP}\" — retrying without from= (keeping no-pty)..."
+        sed -i '/genesis-guardian-control/d' "$HOME/.ssh/authorized_keys"
+        echo "${GUARD_BASE_OPTS} ${PUBKEY}" >> "$HOME/.ssh/authorized_keys"
+        chmod 600 "$HOME/.ssh/authorized_keys"
+        SSH_TEST=$(_guardian_ssh_test)
+        if echo "$SSH_TEST" | grep -q '"ok": true'; then
+            echo "  SSH link verified WITHOUT from= — the derived source IP (${GUARD_FROM_IP}) is not what the host observes."
+            echo "  Guardian works; the LAN key-theft restriction is NOT enforced. To enable it, add"
+            echo "  from=\"<container's host-facing source IP>\" to the guardian key in ~/.ssh/authorized_keys."
+        else
+            echo ""
+            echo "  WARNING: SSH test still failing after dropping from=. Guardian bidirectional monitoring may not work."
+            echo "  Error: $SSH_TEST"
+            echo "  To fix manually, add this to ~/.ssh/authorized_keys on the host:"
+            echo "    ${GUARD_BASE_OPTS} ${PUBKEY}"
+            echo ""
+        fi
     else
         echo ""
         echo "  WARNING: SSH test failed. Guardian bidirectional monitoring may not work."
         echo "  Error: $SSH_TEST"
         echo ""
         echo "  To fix manually, add this to ~/.ssh/authorized_keys on the host:"
-        echo "    command=\"\$HOME/.local/bin/guardian-gateway.sh\",no-port-forwarding,no-X11-forwarding,no-agent-forwarding ${PUBKEY}"
+        echo "    ${GUARD_BASE_OPTS} ${PUBKEY}"
         echo ""
     fi
 fi

--- a/src/genesis/autonomy/audit.py
+++ b/src/genesis/autonomy/audit.py
@@ -150,6 +150,16 @@ class PostExecutionAuditor:
                             continue
                         if block.get("type") != "tool_use":
                             continue
+                        # LIMITATION: this only sees file mutations made via the
+                        # Write/Edit tools, so a session that changes files via
+                        # Bash (sed -i, redirects, cp/mv) is invisible to the
+                        # protected-path audit below. Currently safe: every
+                        # background profile blocks Bash+Edit except `steward`,
+                        # whose Bash is hard-locked to the `gh` binary by
+                        # scripts/bash_safety_hook.sh (no redirect/pipe/chain),
+                        # so it cannot write files. REVISIT if any profile or
+                        # overlay grants file-writing Bash (see follow-up:
+                        # add Bash file-target coverage to _parse_transcript).
                         if block.get("name") not in ("Write", "Edit"):
                             continue
                         fp = block.get("input", {}).get("file_path", "")

--- a/src/genesis/autonomy/proposal_gate.py
+++ b/src/genesis/autonomy/proposal_gate.py
@@ -82,11 +82,17 @@ class ProposalDispatchGate:
                 action_domain=domain,
             )
 
-        # 3. Get current autonomy level for background cognitive
-        state = await self._autonomy_manager.get_state(
+        # 3. Get the ceiling-clamped effective autonomy level for background
+        # cognitive. Use effective_level (not the raw earned current_level): an
+        # earned level above the context ceiling (e.g. background_cognitive can
+        # sit at L4 while its context ceiling is L3) must NOT satisfy a domain
+        # min-level check — otherwise a FINANCIAL proposal (min L4) would pass on
+        # a raw L4 read. effective_level() returns 0 when no state row exists;
+        # treat that as baseline L1 (preserves the prior fresh-install default).
+        effective = await self._autonomy_manager.effective_level(
             AutonomyCategory.BACKGROUND_COGNITIVE.value
         )
-        current_level = state.current_level if state else 1
+        current_level = effective if effective > 0 else 1
 
         # 4. Check minimum level for domain
         if current_level < min_level:

--- a/tests/test_autonomy/test_proposal_gate.py
+++ b/tests/test_autonomy/test_proposal_gate.py
@@ -18,6 +18,12 @@ def _make_gate(current_level: int = 2) -> ProposalDispatchGate:
     mock_state = MagicMock()
     mock_state.current_level = current_level
     mgr.get_state = AsyncMock(return_value=mock_state)
+    # The gate gates on the ceiling-clamped *effective* level, not the raw
+    # earned level. Mock effective_level to mirror current_level so these unit
+    # tests exercise the gate's threshold comparison; the ceiling-clamp itself
+    # is covered by test_financial_uses_effective_not_raw_level below and by
+    # the AutonomyManager.effective_level tests.
+    mgr.effective_level = AsyncMock(return_value=current_level)
 
     engine = RuleEngine()
 
@@ -84,10 +90,34 @@ class TestProposalDispatchGate:
         assert "L4" in result.reason
 
     @pytest.mark.asyncio
-    async def test_financial_allowed_at_l4(self) -> None:
+    async def test_financial_allowed_when_effective_meets_min(self) -> None:
+        # Pure gate-threshold check: given an effective level of 4, FINANCIAL
+        # (min L4) passes. In production background_cognitive is ceiling-capped
+        # at L3 so this state is unreachable there — the clamp is exercised by
+        # test_financial_uses_effective_not_raw_level.
         gate = _make_gate(current_level=4)
         result = await gate.evaluate({"action_type": "purchase"})
         assert result.allowed
+
+    @pytest.mark.asyncio
+    async def test_financial_uses_effective_not_raw_level(self) -> None:
+        """The gate must read the ceiling-clamped effective level, not the raw
+        earned level. background_cognitive can earn L4 while its context ceiling
+        is L3, so a FINANCIAL proposal (min L4) must be BLOCKED at effective L3
+        — even though the raw current_level is 4."""
+        mgr = MagicMock(spec=AutonomyManager)
+        raw_state = MagicMock()
+        raw_state.current_level = 4  # earned above the L3 ceiling
+        mgr.get_state = AsyncMock(return_value=raw_state)
+        mgr.effective_level = AsyncMock(return_value=3)  # ceiling-clamped
+        gate = ProposalDispatchGate(autonomy_manager=mgr, rule_engine=RuleEngine())
+
+        result = await gate.evaluate({"action_type": "purchase"})
+
+        assert not result.allowed
+        assert "L4" in result.reason
+        # Prove the gate consulted the clamped level, not the raw one.
+        mgr.effective_level.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_unknown_action_type_defaults_to_external_read(self) -> None:
@@ -126,9 +156,12 @@ class TestProposalDispatchGate:
 
     @pytest.mark.asyncio
     async def test_no_state_defaults_to_l1(self) -> None:
-        """If AutonomyManager returns no state, default to L1."""
+        """With no autonomy state, effective_level() returns 0; the gate treats
+        that as baseline L1 so benign L1 domains still pass (fresh-install
+        behavior preserved)."""
         mgr = MagicMock(spec=AutonomyManager)
         mgr.get_state = AsyncMock(return_value=None)
+        mgr.effective_level = AsyncMock(return_value=0)  # no state row
         gate = ProposalDispatchGate(
             autonomy_manager=mgr,
             rule_engine=RuleEngine(),


### PR DESCRIPTION
## Summary

Two security-posture fixes surfaced by an architecture audit, plus a documented limitation marker.

### Autonomy gate honors the context ceiling (`proposal_gate`)
The background-dispatch gate compared an action's required autonomy level against the raw *earned* level for the background-cognitive category. An earned level can legitimately sit above a context's ceiling (the ceiling is a per-context clamp, not a cap on earning), so a category that had earned L4 could clear a check it shouldn't in the more restricted background context — most visibly letting a FINANCIAL action (which requires L4) pass the gate's level check even though background cognition is capped at L3. The gate now uses the ceiling-clamped effective level. Only autonomous FINANCIAL background dispatch is newly refused; every other domain is unaffected. Explicit user approval was, and remains, required for these actions, so this closes a defense-in-depth gap behind that approval.

### Guardian→host control SSH key hardening (`install_guardian.sh`)
The installer wrote the container→host control key without the `from=` source-IP restriction and `no-pty` that its own gateway header documents, so a stolen key was usable from any host on the LAN and could request a PTY. The key is now installed with `no-pty` and a `from=` bound to the container's actual host-facing source address (derived from its egress route, not from a listing that can return an unrelated address). A source address that doesn't match is caught by the installer's own connectivity test and rolled back to a working, `no-pty`-only entry, so the restriction can never lock Guardian out of the host. Re-running the installer upgrades an older un-hardened key in place and self-heals a stale restriction.

### Post-exec audit limitation marker (`audit.py`)
The post-execution auditor's protected-path scan reads Write/Edit tool calls only, so it cannot see file changes made via Bash. This is currently safe (no background session profile can write files via Bash), so rather than add a partial heuristic, a comment documents the bound and the condition under which it must be revisited.

## Testing
- New and existing autonomy gate tests pass; the full autonomy package suite is green.
- An end-to-end check with a real autonomy manager confirms the ceiling clamp blocks a background financial action while leaving lower-risk domains untouched.
- Installer changes validated with shellcheck and a logic harness covering source-address derivation, idempotent re-run, and the rollback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
