### PR TITLE
feat(guardian): host storage-pool monitoring with tiered alerts + disk-status verb

### DIFF
--- a/config/guardian.yaml
+++ b/config/guardian.yaml
@@ -63,6 +63,20 @@ snapshots:
   # safety net). Empty string disables. NOT applied to manual snapshots.
   expiry: "2w"
 
+# Host storage-pool monitoring (LVM-thin data% + metadata% + VG headroom).
+# Tiered guardian alerts with hysteresis; metadata alerts earlier than data
+# (metadata-full forces an offline thin_check/repair). This is the warning that
+# was missing when the thin pool silently filled to 100%.
+storage_pool:
+  enabled: true
+  data_warn_pct: 75
+  data_high_pct: 85
+  data_crit_pct: 92
+  metadata_warn_pct: 60
+  metadata_high_pct: 70
+  metadata_crit_pct: 80
+  realert_hours: 6
+
 recovery:
   verification_delay_s: 30
   max_escalations: 3

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -14,6 +14,8 @@
 #   update-cc <ver> — install a pinned Claude Code version (validated semver)
 #   update-node <N> — install a pinned Node.js major via NodeSource (validated)
 #   test-approval   — E2E test the keyword-reply approval gate (no recovery)
+#   disk-status     — read-only storage-pool + snapshot JSON (Genesis's window
+#                     into host capacity: lvs data%/metadata%, VG free, snapshots)
 #   ping            — liveness check
 #
 # SSH authorized_keys entry (replace CONTAINER_IP with the container's
@@ -448,6 +450,20 @@ PYEOF
         GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
         GUARDIAN_SECRETS="$INSTALL_DIR/secrets.env" \
             timeout 130 "$VENV_PY" -m genesis.guardian --test-approval
+        ;;
+    disk-status)
+        # Read-only: print storage-pool + snapshot JSON. Genesis's programmatic
+        # window into host capacity (thin-pool data%/metadata%, VG free extents,
+        # guardian snapshot list). No mutation, no secrets needed.
+        INSTALL_DIR="${HOME}/.local/share/genesis-guardian"
+        VENV_PY="$INSTALL_DIR/.venv/bin/python"
+        if [ ! -x "$VENV_PY" ]; then
+            echo '{"ok": false, "action": "disk-status", "error": "guardian venv not found"}' >&2
+            exit 1
+        fi
+        PYTHONPATH="$INSTALL_DIR/src" \
+        GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
+            timeout 30 "$VENV_PY" -m genesis.guardian --disk-status
         ;;
     sync-gateway)
         # Recovery: redeploy the gateway script from the (already-pulled) install

--- a/src/genesis/guardian/__main__.py
+++ b/src/genesis/guardian/__main__.py
@@ -5,6 +5,7 @@ Usage:
     python -m genesis.guardian --test        # test alert channels
     python -m genesis.guardian --check-only  # one-shot health check (no recovery)
     python -m genesis.guardian --test-approval  # E2E test the keyword-reply gate
+    python -m genesis.guardian --disk-status  # print storage-pool JSON (read-only)
 """
 
 from __future__ import annotations
@@ -29,6 +30,10 @@ def main() -> None:
 
     if "--test-approval" in sys.argv:
         asyncio.run(_test_approval())
+        return
+
+    if "--disk-status" in sys.argv:
+        asyncio.run(_disk_status())
         return
 
     asyncio.run(run_check())
@@ -105,6 +110,38 @@ async def _test_approval() -> None:
             print(f"  Read keyword: {kw}")
             return
     print("  Timeout — no APPROVE/DENY reply read within ~120s")
+
+
+async def _disk_status() -> None:
+    """Print storage-pool + snapshot status as JSON (read-only).
+
+    Genesis's programmatic window into host capacity — consumed by the
+    `disk-status` gateway verb. Reuses the same measurement the guardian alerts
+    on, so the container sees exactly what the guardian sees.
+    """
+    import dataclasses
+    import json
+
+    from genesis.guardian.config import load_config
+    from genesis.guardian.pool import measure_storage_pool, worst_tier
+    from genesis.guardian.snapshots import SnapshotManager
+
+    config = load_config()
+    status = await measure_storage_pool(config)
+    tier = worst_tier(status, config.storage_pool) if status.detected else "unknown"
+
+    snap_mgr = SnapshotManager(config)
+    snapshots = [
+        {"name": name, "created_at": created.isoformat() if created else None}
+        for name, created in await snap_mgr._list_snapshots_with_meta()
+    ]
+
+    print(json.dumps({
+        "ok": True,
+        "pool": dataclasses.asdict(status),
+        "tier": tier,
+        "snapshots": snapshots,
+    }))
 
 
 async def _check_only() -> None:

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -35,6 +35,13 @@ from genesis.guardian.diagnosis import DiagnosisEngine
 from genesis.guardian.diagnosis_writer import write_diagnosis_result
 from genesis.guardian.dialogue import DialogueStatus, build_request, send_dialogue
 from genesis.guardian.health_signals import collect_all_signals
+from genesis.guardian.pool import (
+    TIER_CRIT,
+    TIER_OK,
+    decide_alert,
+    measure_storage_pool,
+    worst_tier,
+)
 from genesis.guardian.recovery import RecoveryEngine
 from genesis.guardian.snapshots import SnapshotManager
 from genesis.guardian.state_machine import (
@@ -205,6 +212,9 @@ async def run_check(config: GuardianConfig | None = None) -> None:
         # enforce expiry + prune stale snapshots (the incident: prune only ran
         # in HEALTHY, so it never fired while the pool silently filled).
         await _maintain_snapshots(config, snapshots)
+        # Storage-pool monitoring runs every cycle regardless of state — a
+        # filling thin pool is the exact silent failure that caused the outage.
+        await _check_storage_pool_and_alert(config, dispatcher)
         # Heartbeat means "Guardian process is alive and watching" —
         # NOT "Genesis container is healthy". Any successful check cycle
         # (regardless of resulting state) should refresh liveness. A
@@ -357,6 +367,95 @@ async def _maintain_snapshots(
 
     prune_marker.parent.mkdir(parents=True, exist_ok=True)
     prune_marker.write_text(datetime.now(UTC).isoformat())
+
+
+_POOL_TIER_SEVERITY = {
+    "warn": AlertSeverity.WARNING,
+    "high": AlertSeverity.WARNING,
+    "crit": AlertSeverity.CRITICAL,
+}
+
+
+async def _check_storage_pool_and_alert(
+    config: GuardianConfig,
+    dispatcher: AlertDispatcher,
+) -> None:
+    """Measure the host storage pool and emit tiered alerts with hysteresis.
+
+    State (last-alerted tier + timestamp) persists in the guardian state dir so
+    the hysteresis survives across the guardian's stateless per-tick invocations.
+    Alerts go through the guardian's own dispatcher (host Telegram channel),
+    which survives a read-only/dead container — exactly when this matters most.
+    """
+    cfg = config.storage_pool
+    if not cfg.enabled:
+        return
+
+    try:
+        status = await measure_storage_pool(config)
+    except Exception:
+        logger.warning("storage-pool measurement failed", exc_info=True)
+        return
+    if not status.detected:
+        logger.debug("storage-pool not measurable: %s", status.detail)
+        return
+
+    tier = worst_tier(status, cfg)
+
+    state_file = config.state_path / "pool_alert_state.json"
+    last_tier = TIER_OK
+    last_alert_at: datetime | None = None
+    if state_file.exists():
+        try:
+            data = json.loads(state_file.read_text())
+            last_tier = data.get("tier", TIER_OK)
+            raw_at = data.get("last_alert_at")
+            last_alert_at = datetime.fromisoformat(raw_at) if raw_at else None
+        except (ValueError, OSError):
+            pass
+
+    now = datetime.now(UTC)
+    decision = decide_alert(tier, last_tier, last_alert_at, now, cfg.realert_hours)
+
+    if decision.should_alert:
+        if decision.is_resolution:
+            severity = AlertSeverity.INFO
+            title = "Storage pool recovered"
+        else:
+            severity = _POOL_TIER_SEVERITY.get(tier, AlertSeverity.WARNING)
+            title = f"Storage pool {tier.upper()}"
+        parts = []
+        if status.data_pct is not None:
+            parts.append(f"data {status.data_pct:.0f}%")
+        if status.metadata_pct is not None:
+            parts.append(f"metadata {status.metadata_pct:.0f}%")
+        if status.vg_free_bytes is not None:
+            parts.append(f"VG free {status.vg_free_bytes / 1024**3:.1f}G")
+        if status.pool_used_pct is not None:
+            parts.append(f"pool used {status.pool_used_pct:.0f}%")
+        body = f"{decision.reason}. " + ", ".join(parts)
+        if tier == TIER_CRIT:
+            body += (
+                "\nThin pool near exhaustion — add VG space or free allocation "
+                "before it forces the container read-only."
+            )
+        try:
+            await dispatcher.send(Alert(severity=severity, title=title, body=body))
+        except Exception:
+            logger.warning("failed to send storage-pool alert", exc_info=True)
+
+    # Persist tier every cycle (even without an alert) so a later rise from a
+    # silently-decreased tier re-alerts correctly. Only advance the alert
+    # timestamp when we actually alerted.
+    new_alert_at = now if decision.should_alert else last_alert_at
+    try:
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(json.dumps({
+            "tier": tier,
+            "last_alert_at": new_alert_at.isoformat() if new_alert_at else None,
+        }))
+    except OSError:
+        logger.warning("failed to persist pool alert state", exc_info=True)
 
 
 async def _handle_confirming(

--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -132,6 +132,29 @@ class RecoveryConfig:
 
 
 @dataclass
+class StoragePoolConfig:
+    """Host storage-pool monitoring thresholds (LVM-thin data + metadata).
+
+    The incident that motivated this: the LVM thin pool filled to 100% with no
+    warning. Metadata exhaustion is worse than data exhaustion (it forces an
+    offline thin_check/repair), so metadata alerts at LOWER percentages.
+    """
+
+    enabled: bool = True
+    # Data-allocation tiers (percent of thin-pool data space used).
+    data_warn_pct: float = 75.0
+    data_high_pct: float = 85.0
+    data_crit_pct: float = 92.0
+    # Metadata tiers — alert earlier; metadata-full is nastier to recover.
+    metadata_warn_pct: float = 60.0
+    metadata_high_pct: float = 70.0
+    metadata_crit_pct: float = 80.0
+    # Re-alert cadence while a tier is sustained (avoids per-tick spam but keeps
+    # a live problem visible). Tier *increases* always alert immediately.
+    realert_hours: float = 6.0
+
+
+@dataclass
 class GuardianConfig:
     """Top-level Guardian configuration."""
 
@@ -155,6 +178,7 @@ class GuardianConfig:
     briefing: BriefingConfig = field(default_factory=BriefingConfig)
     snapshots: SnapshotConfig = field(default_factory=SnapshotConfig)
     recovery: RecoveryConfig = field(default_factory=RecoveryConfig)
+    storage_pool: StoragePoolConfig = field(default_factory=StoragePoolConfig)
 
     @property
     def health_url(self) -> str:
@@ -320,6 +344,7 @@ def load_config(path: Path | None = None) -> GuardianConfig:
         briefing=_build_sub(BriefingConfig, raw, "briefing"),
         snapshots=_build_sub(SnapshotConfig, raw, "snapshots"),
         recovery=_build_sub(RecoveryConfig, raw, "recovery"),
+        storage_pool=_build_sub(StoragePoolConfig, raw, "storage_pool"),
     )
 
     return _env_override(config)

--- a/src/genesis/guardian/pool.py
+++ b/src/genesis/guardian/pool.py
@@ -1,0 +1,243 @@
+"""Host storage-pool monitoring — HOST-SIDE.
+
+Backstops the thin-pool-exhaustion incident: `df` on the incus storage-pool
+mountpath is blind to LVM-thin *allocation*, so a pool can fill to 100%
+(forcing the container rootfs read-only) with no warning. This module measures
+true pool allocation — LVM-thin data% and metadata% via `lvs`, plus VG free
+headroom — and drives tiered guardian alerts with hysteresis.
+
+Design:
+- Measurement (:func:`measure_storage_pool`) is defensive: any failure yields
+  ``detected=False`` so we never raise a false alarm on a probe error.
+- Tier + alert-decision logic is pure and fully unit-tested (:func:`worst_tier`,
+  :func:`decide_alert`) — the subprocess glue is kept thin around it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+
+from genesis.guardian._subprocess import run_subprocess as _run_subprocess
+from genesis.guardian.config import GuardianConfig, StoragePoolConfig
+
+logger = logging.getLogger(__name__)
+
+TIER_OK = "ok"
+TIER_WARN = "warn"
+TIER_HIGH = "high"
+TIER_CRIT = "crit"
+_TIER_RANK = {TIER_OK: 0, TIER_WARN: 1, TIER_HIGH: 2, TIER_CRIT: 3}
+
+
+@dataclass(frozen=True)
+class StoragePoolStatus:
+    """A point-in-time measurement of the host storage pool.
+
+    ``detected=False`` means measurement failed (pool not LVM, incus/lvs
+    unavailable, parse error) — callers must treat it as "no signal", never as
+    "healthy", and must not alert on it.
+    """
+
+    detected: bool
+    data_pct: float | None = None
+    metadata_pct: float | None = None
+    vg_free_bytes: int | None = None
+    pool_used_pct: float | None = None
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class AlertDecision:
+    """Outcome of the hysteresis evaluation for one measurement."""
+
+    should_alert: bool
+    tier: str
+    reason: str
+    is_resolution: bool = False
+
+
+def _tier_for(pct: float | None, warn: float, high: float, crit: float) -> str:
+    if pct is None:
+        return TIER_OK
+    if pct >= crit:
+        return TIER_CRIT
+    if pct >= high:
+        return TIER_HIGH
+    if pct >= warn:
+        return TIER_WARN
+    return TIER_OK
+
+
+def worst_tier(status: StoragePoolStatus, cfg: StoragePoolConfig) -> str:
+    """Highest tier across data% and metadata% (metadata alerts earlier)."""
+    data = _tier_for(
+        status.data_pct, cfg.data_warn_pct, cfg.data_high_pct, cfg.data_crit_pct,
+    )
+    meta = _tier_for(
+        status.metadata_pct,
+        cfg.metadata_warn_pct, cfg.metadata_high_pct, cfg.metadata_crit_pct,
+    )
+    return data if _TIER_RANK[data] >= _TIER_RANK[meta] else meta
+
+
+def parse_lvs_data_metadata(stdout: str) -> tuple[float | None, float | None]:
+    """Parse ``lvs --noheadings -o data_percent,metadata_percent``.
+
+    Output is one line like ``  75.00  12.34`` (percentages). Returns
+    ``(data_pct, metadata_pct)``; either element is None if absent/unparseable.
+    """
+    lines = [ln for ln in stdout.strip().splitlines() if ln.strip()]
+    if not lines:
+        return None, None
+    parts = lines[0].split()
+
+    def _f(idx: int) -> float | None:
+        if idx >= len(parts):
+            return None
+        try:
+            return float(parts[idx])
+        except ValueError:
+            return None
+
+    return _f(0), _f(1)
+
+
+def decide_alert(
+    current_tier: str,
+    last_tier: str,
+    last_alert_at: datetime | None,
+    now: datetime,
+    realert_hours: float,
+) -> AlertDecision:
+    """Hysteresis policy for pool alerts.
+
+    - Tier **increase** → alert immediately.
+    - Return to ``ok`` from a raised tier → one resolution notice.
+    - **Sustained** non-ok tier → re-alert once every ``realert_hours``.
+    - Tier decrease that is still non-ok → no alert (avoid noise), but the
+      caller still records the new (lower) tier so a later rise re-alerts.
+    """
+    cur = _TIER_RANK[current_tier]
+    last = _TIER_RANK.get(last_tier, 0)
+
+    if cur > last:
+        return AlertDecision(True, current_tier, f"tier rose {last_tier}→{current_tier}")
+    if cur == 0 and last > 0:
+        return AlertDecision(
+            True, current_tier, f"pool recovered ({last_tier}→ok)", is_resolution=True,
+        )
+    if cur > 0 and cur == last:
+        if last_alert_at is None:
+            return AlertDecision(True, current_tier, "sustained (no prior alert time)")
+        hours = (now - last_alert_at).total_seconds() / 3600.0
+        if hours >= realert_hours:
+            return AlertDecision(
+                True, current_tier, f"sustained {current_tier} for {hours:.1f}h",
+            )
+    return AlertDecision(False, current_tier, "no change")
+
+
+async def _detect_pool_name(config: GuardianConfig) -> str | None:
+    rc, out, _ = await _run_subprocess(
+        "incus", "config", "device", "get", config.container_name, "root", "pool",
+        timeout=10.0,
+    )
+    return out.strip() if rc == 0 and out.strip() else None
+
+
+async def _lvm_source(pool_name: str) -> str | None:
+    """Return the LVM ``vg/thinpool`` backing an incus pool, or None if not LVM."""
+    rc, out, _ = await _run_subprocess(
+        "incus", "storage", "show", pool_name, timeout=10.0,
+    )
+    if rc != 0:
+        return None
+    # incus storage show emits YAML; the driver + source lines identify LVM.
+    driver = None
+    source = None
+    for line in out.splitlines():
+        s = line.strip()
+        if s.startswith("driver:"):
+            driver = s.split(":", 1)[1].strip()
+        elif s.startswith("source:"):
+            source = s.split(":", 1)[1].strip()
+    if driver != "lvm" or not source:
+        return None
+    # source is the VG name; the thin pool LV is conventionally the pool name.
+    return source
+
+
+async def measure_storage_pool(config: GuardianConfig) -> StoragePoolStatus:
+    """Measure the host storage pool. Defensive: failure → detected=False."""
+    pool_name = await _detect_pool_name(config)
+    if not pool_name:
+        return StoragePoolStatus(detected=False, detail="pool name undetected")
+
+    # Backend-agnostic used% via incus storage info (best-effort).
+    pool_used_pct: float | None = None
+    rc, out, _ = await _run_subprocess(
+        "incus", "storage", "info", pool_name, "--format", "json", timeout=10.0,
+    )
+    if rc == 0:
+        try:
+            info = json.loads(out)
+            space = info.get("space") or info.get("resources", {}).get("space", {})
+            used, total = space.get("used"), space.get("total")
+            if isinstance(used, (int, float)) and total:
+                pool_used_pct = 100.0 * used / total
+        except (json.JSONDecodeError, TypeError, AttributeError, ZeroDivisionError):
+            pass
+
+    vg = await _lvm_source(pool_name)
+    if not vg:
+        # Non-LVM backend — pool_used_pct (if any) is the only signal.
+        return StoragePoolStatus(
+            detected=pool_used_pct is not None,
+            pool_used_pct=pool_used_pct,
+            detail=f"non-lvm pool {pool_name}",
+        )
+
+    # LVM-thin: data% + metadata% via lvs (needs passwordless sudo on host).
+    # Select ONLY thin-pool LVs — a bare `lvs <vg>` lists every LV in the VG
+    # (regular LVs report blank percents), so we must filter to segtype
+    # thin-pool to read the pool's own data%/metadata%.
+    vg_name = vg.split("/")[0]
+    rc, out, err = await _run_subprocess(
+        "sudo", "-n", "lvs", "--noheadings", "--nosuffix",
+        "-S", "segtype=thin-pool",
+        "-o", "data_percent,metadata_percent", vg_name,
+        timeout=10.0,
+    )
+    if rc != 0:
+        logger.warning("lvs failed for %s: %s", vg_name, err)
+        return StoragePoolStatus(
+            detected=pool_used_pct is not None,
+            pool_used_pct=pool_used_pct,
+            detail=f"lvs failed: {err[:120]}",
+        )
+    data_pct, metadata_pct = parse_lvs_data_metadata(out)
+
+    # VG free bytes (headroom for autoextend — 0 free = autoextend can't fire).
+    vg_free_bytes: int | None = None
+    rc, out, _ = await _run_subprocess(
+        "sudo", "-n", "vgs", "--noheadings", "--nosuffix", "--units", "b",
+        "-o", "vg_free", vg_name,
+        timeout=10.0,
+    )
+    if rc == 0 and out.strip():
+        try:
+            vg_free_bytes = int(float(out.strip().split()[0]))
+        except (ValueError, IndexError):
+            vg_free_bytes = None
+
+    return StoragePoolStatus(
+        detected=True,
+        data_pct=data_pct,
+        metadata_pct=metadata_pct,
+        vg_free_bytes=vg_free_bytes,
+        pool_used_pct=pool_used_pct,
+        detail=f"lvm {vg} data={data_pct} meta={metadata_pct}",
+    )

--- a/tests/test_guardian/test_check.py
+++ b/tests/test_guardian/test_check.py
@@ -9,6 +9,7 @@ import pytest
 
 from genesis.guardian.check import (
     _build_dispatcher,
+    _check_storage_pool_and_alert,
     _execute_recovery_with_approval,
     _handle_cc_resolved,
     _handle_confirmed_dead,
@@ -20,6 +21,7 @@ from genesis.guardian.check import (
 from genesis.guardian.config import GuardianConfig
 from genesis.guardian.diagnosis import DiagnosisEngine, DiagnosisResult, RecoveryAction
 from genesis.guardian.health_signals import HealthSnapshot, PauseState, SignalResult
+from genesis.guardian.pool import StoragePoolStatus
 from genesis.guardian.state_machine import ConfirmationStateMachine, GuardianState
 
 
@@ -149,6 +151,58 @@ class TestMaintainSnapshots:
 
         await _maintain_snapshots(config, snapshots)
         assert (config.state_path / ".last_prune").exists()
+
+
+class TestStoragePoolAlert:
+
+    @pytest.mark.asyncio
+    async def test_crit_alerts_and_persists_state(self, config: GuardianConfig) -> None:
+        dispatcher = MagicMock()
+        dispatcher.send = AsyncMock(return_value=True)
+        status = StoragePoolStatus(detected=True, data_pct=95.0, metadata_pct=30.0)
+
+        with patch("genesis.guardian.check.measure_storage_pool",
+                   AsyncMock(return_value=status)):
+            await _check_storage_pool_and_alert(config, dispatcher)
+
+        dispatcher.send.assert_called_once()
+        alert = dispatcher.send.call_args.args[0]
+        assert alert.severity.value == "critical"
+        assert (config.state_path / "pool_alert_state.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_sustained_tier_does_not_double_alert(self, config: GuardianConfig) -> None:
+        dispatcher = MagicMock()
+        dispatcher.send = AsyncMock(return_value=True)
+        status = StoragePoolStatus(detected=True, data_pct=95.0)
+
+        with patch("genesis.guardian.check.measure_storage_pool",
+                   AsyncMock(return_value=status)):
+            await _check_storage_pool_and_alert(config, dispatcher)  # first: alerts
+            await _check_storage_pool_and_alert(config, dispatcher)  # same tier, within interval
+        # Only the first tick alerts; the second is suppressed by hysteresis.
+        assert dispatcher.send.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_undetected_pool_never_alerts(self, config: GuardianConfig) -> None:
+        dispatcher = MagicMock()
+        dispatcher.send = AsyncMock(return_value=True)
+        status = StoragePoolStatus(detected=False, detail="not lvm")
+
+        with patch("genesis.guardian.check.measure_storage_pool",
+                   AsyncMock(return_value=status)):
+            await _check_storage_pool_and_alert(config, dispatcher)
+        dispatcher.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_disabled_short_circuits(self, config: GuardianConfig) -> None:
+        config.storage_pool.enabled = False
+        dispatcher = MagicMock()
+        dispatcher.send = AsyncMock(return_value=True)
+        called = MagicMock()
+        with patch("genesis.guardian.check.measure_storage_pool", called):
+            await _check_storage_pool_and_alert(config, dispatcher)
+        called.assert_not_called()
 
 
 class TestRunCheck:

--- a/tests/test_guardian/test_pool.py
+++ b/tests/test_guardian/test_pool.py
@@ -1,0 +1,95 @@
+"""Tests for host storage-pool monitoring (pure logic)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from genesis.guardian.config import StoragePoolConfig
+from genesis.guardian.pool import (
+    TIER_CRIT,
+    TIER_HIGH,
+    TIER_OK,
+    TIER_WARN,
+    StoragePoolStatus,
+    decide_alert,
+    parse_lvs_data_metadata,
+    worst_tier,
+)
+
+
+def _status(data=None, meta=None) -> StoragePoolStatus:
+    return StoragePoolStatus(detected=True, data_pct=data, metadata_pct=meta)
+
+
+class TestWorstTier:
+    cfg = StoragePoolConfig()
+
+    def test_ok_when_both_low(self):
+        assert worst_tier(_status(50, 40), self.cfg) == TIER_OK
+
+    def test_data_tiers(self):
+        assert worst_tier(_status(76, 0), self.cfg) == TIER_WARN
+        assert worst_tier(_status(86, 0), self.cfg) == TIER_HIGH
+        assert worst_tier(_status(93, 0), self.cfg) == TIER_CRIT
+
+    def test_metadata_alerts_earlier_than_data(self):
+        # metadata 72% is HIGH (>=70) while the same 72% data is only WARN.
+        assert worst_tier(_status(0, 72), self.cfg) == TIER_HIGH
+        assert worst_tier(_status(72, 0), self.cfg) == TIER_OK  # 72 < data_warn 75
+
+    def test_worst_of_the_two_wins(self):
+        # data WARN (76) + metadata CRIT (81) → CRIT
+        assert worst_tier(_status(76, 81), self.cfg) == TIER_CRIT
+
+    def test_none_percents_are_ok(self):
+        assert worst_tier(_status(None, None), self.cfg) == TIER_OK
+
+
+class TestParseLvs:
+    def test_parses_data_and_metadata(self):
+        assert parse_lvs_data_metadata("  75.00  12.34\n") == (75.0, 12.34)
+
+    def test_handles_single_column(self):
+        assert parse_lvs_data_metadata("  88.5\n") == (88.5, None)
+
+    def test_empty(self):
+        assert parse_lvs_data_metadata("") == (None, None)
+        assert parse_lvs_data_metadata("\n\n") == (None, None)
+
+    def test_garbage_is_none(self):
+        assert parse_lvs_data_metadata("  n/a  x\n") == (None, None)
+
+
+class TestDecideAlert:
+    now = datetime(2026, 7, 3, 12, 0, tzinfo=UTC)
+
+    def test_tier_increase_alerts(self):
+        d = decide_alert(TIER_WARN, TIER_OK, None, self.now, 6.0)
+        assert d.should_alert and not d.is_resolution
+
+    def test_jump_multiple_tiers_alerts(self):
+        d = decide_alert(TIER_CRIT, TIER_OK, None, self.now, 6.0)
+        assert d.should_alert and d.tier == TIER_CRIT
+
+    def test_recovery_to_ok_sends_resolution(self):
+        d = decide_alert(TIER_OK, TIER_HIGH, self.now - timedelta(hours=1), self.now, 6.0)
+        assert d.should_alert and d.is_resolution
+
+    def test_ok_to_ok_silent(self):
+        assert not decide_alert(TIER_OK, TIER_OK, None, self.now, 6.0).should_alert
+
+    def test_sustained_realerts_after_interval(self):
+        last = self.now - timedelta(hours=7)
+        assert decide_alert(TIER_HIGH, TIER_HIGH, last, self.now, 6.0).should_alert
+
+    def test_sustained_silent_within_interval(self):
+        last = self.now - timedelta(hours=2)
+        assert not decide_alert(TIER_HIGH, TIER_HIGH, last, self.now, 6.0).should_alert
+
+    def test_tier_decrease_still_nonok_is_silent(self):
+        # crit → high (still bad) does not spam; caller records new tier.
+        assert not decide_alert(TIER_HIGH, TIER_CRIT, self.now, self.now, 6.0).should_alert
+
+    def test_sustained_with_no_prior_time_alerts(self):
+        # Defensive: missing last_alert_at shouldn't suppress a live problem.
+        assert decide_alert(TIER_WARN, TIER_WARN, None, self.now, 6.0).should_alert


### PR DESCRIPTION
## Problem

The thin-pool-exhaustion outage happened silently: nothing warned that the host storage pool was filling. The Guardian's only pool check ran `df` on the pool mountpath, which on an LVM-thin backend is blind to thin-pool **allocation** — so a pool can reach 100% (forcing the container root filesystem read-only) with no signal.

## Changes

- **`pool.py`** — `measure_storage_pool()` reads true LVM-thin `data_percent` / `metadata_percent` via `lvs -S segtype=thin-pool` plus VG free extents (headroom for autoextend; 0 free = autoextend silently can't fire). Defensive: any failure yields `detected=False` so a probe error never raises a false alarm.
- **Pure, unit-tested policy**: `worst_tier()` (metadata alerts at lower percentages than data — metadata-full forces an offline `thin_check`/repair) and `decide_alert()` hysteresis (alert on tier rise, re-alert on a sustained tier every `realert_hours`, one resolution notice on recovery).
- **`_check_storage_pool_and_alert()`** runs every check cycle in **all** Guardian states and dispatches through the Guardian's own host Telegram channel — which survives a read-only or dead container, exactly when this matters.
- **`StoragePoolConfig`** thresholds (data 75/85/92, metadata 60/70/80, re-alert 6h) + `guardian.yaml` section.
- **`disk-status` gateway verb** + `python -m genesis.guardian --disk-status`: read-only JSON window into host capacity (data%/metadata%, VG free, snapshot list with timestamps), reusing the exact measurement the Guardian alerts on.

## Testing

- `pytest tests/test_guardian/` — 431 passing.
- `test_pool.py` covers tier boundaries, metadata-earlier-than-data, `lvs` parsing, and the full hysteresis decision table.
- Check-level tests cover alert dispatch, hysteresis persistence across ticks, undetected-pool safety, and the disabled short-circuit.
- End-to-end verified the `ok → warn → crit → sustained-suppressed → resolved` state machine drives the correct alert severities and persisted state.

Note: live `lvs`/`incus storage info` against the host is verified post-deploy via the new `disk-status` verb (can't reach host incus from inside the container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)