### PR TITLE
fix(surplus): intake fence-stripping + bare-array findings + WING_AUDIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -397,6 +397,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   report (the dedicated morning-report pipeline is the sole source — its daily-briefing cycle now
   focuses on what you need today), and the pending-proposal guidance matches the real threshold.
 
+- **Background research findings reach your knowledge base again — instead of piling up as unreadable
+  JSON blobs.** Genesis's idle-time research (brainstorms, gap clustering, code and wing audits) sends its
+  findings through an intake step that splits them into individual knowledge entries. That step couldn't
+  read the output format models actually produce (code-fenced JSON, and the bare-array shape code audits
+  emit), so months of findings were stored as single raw JSON dumps — useless to search and recall. Intake
+  now parses these formats, skips empty result envelopes outright, and wing-audit results are split into
+  individual findings like the other research types. A new `scripts/cleanup_fenced_knowledge_units.py`
+  (dry-run by default) re-parses the previously mangled entries into proper knowledge units and removes
+  the junk ones.
+
 - **The dashboard's per-session memory row is clearer: "Claude Code Sessions", green when healthy.** The
   cryptic "CC" row that listed sessions as gray "cc-1 …" chips is now labeled **Claude Code Sessions**,
   renders each healthy session in green (amber ≥ 4 GB, red ≥ 6 GB), and shows a hover tooltip explaining

--- a/scripts/cleanup_fenced_knowledge_units.py
+++ b/scripts/cleanup_fenced_knowledge_units.py
@@ -51,14 +51,6 @@ from pathlib import Path
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 logger = logging.getLogger("cleanup_fenced_ku")
 
-_SELECT_SQL = """
-SELECT id, project_type, domain, source_doc, source_pipeline, body,
-       confidence, ingested_at, qdrant_id
-FROM knowledge_units
-WHERE source_doc LIKE 'intake:%' AND body LIKE '%```json%'
-ORDER BY ingested_at
-"""
-
 
 def _derive_task_type(title: str, multi_types: frozenset[str]) -> str:
     """Reverse the single_item title back to a task type for re-atomization.
@@ -84,7 +76,7 @@ async def main(execute: bool, limit: int | None) -> int:
     from genesis.memory.store import MemoryStore
     from genesis.surplus import intake
 
-    if not hasattr(intake, "_FENCE_RE"):
+    if not hasattr(intake, "FENCE_RE"):
         logger.error("intake.py fence fix is not present — refusing to run.")
         return 1
 
@@ -110,8 +102,7 @@ async def main(execute: bool, limit: int | None) -> int:
         logger.info("Deleted-row backup: %s", backup_path)
 
     try:
-        cursor = await db.execute(_SELECT_SQL)
-        rows = [dict(r) for r in await cursor.fetchall()]
+        rows = await knowledge_crud.select_fenced_intake_rows(db)
         if limit is not None:
             rows = rows[:limit]
         logger.info("Selected %d fence-polluted intake rows%s", len(rows),
@@ -131,7 +122,7 @@ async def main(execute: bool, limit: int | None) -> int:
             if not sep:
                 payload = row["body"]
                 title = ""
-            task_type = _derive_task_type(title, intake._MULTI_FINDING_TASK_TYPES)
+            task_type = _derive_task_type(title, intake.MULTI_FINDING_TASK_TYPES)
             findings, path = intake.atomize(payload, task_type)
 
             if path in ("json_findings", "json_single") and findings:

--- a/scripts/cleanup_fenced_knowledge_units.py
+++ b/scripts/cleanup_fenced_knowledge_units.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Re-parse fence-polluted knowledge units through the fixed intake atomizer.
+
+The 2026-07-03 context-layer audit found ~390 knowledge units whose body is a
+raw ```json-fenced findings payload stored verbatim: surplus/wing-audit output
+arrived fenced, the pre-fix atomizer could not parse it, and the whole envelope
+was stored as a single unit (fixed in src/genesis/surplus/intake.py).
+
+This one-off script:
+  1. Selects intake-provenance rows still carrying a fence
+     (``source_doc LIKE 'intake:%' AND body LIKE '%```json%'``). Non-intake
+     rows with legitimate inline JSON fences are deliberately OUT of scope —
+     verified 2026-07-03: 388 intake rows vs 3 legitimate manual/ingest docs.
+  2. Re-runs the FIXED atomizer over each fenced payload. Per-row outcome
+     (verified against the live population 2026-07-03):
+       - parses to findings/object → RECOVER as proper units;
+       - empty envelope → DELETE (nothing to store, audit decision D2);
+       - payload IS a fence but its JSON is malformed/truncated → DELETE (D2);
+       - prose that merely CONTAINS an inline fence → SKIP, keep the row —
+         that is legitimate single-item content, not pollution.
+  3. With --execute: ingests recovered findings as proper units (original
+     domain/project/confidence preserved; original unit id and ingested_at
+     carried as tags), then deletes the replaced/junk row everywhere it
+     lives: the memory-layer cascade FIRST via store.delete() (Qdrant point
+     + memory_metadata + memory_fts + links + pending_embeddings — ingest
+     wrote the fenced body to that layer too, so a knowledge_units-only
+     delete would leave it recallable via FTS), then knowledge_units +
+     knowledge_fts, then ingestion-manifest bookkeeping. If the cascade
+     fails, the row is KEPT so a re-run can retry it, and the script exits
+     nonzero. Every deleted row is first dumped verbatim to a JSONL backup
+     under ~/.genesis/output/ for manual salvage.
+  4. Default is DRY-RUN: reports what would happen, writes nothing.
+
+Idempotent: re-ingest upserts on (project, domain, concept), so a partially
+completed run can safely be re-run.
+
+Run from the repo root with the venv active:
+    python scripts/cleanup_fenced_knowledge_units.py            # dry-run
+    python scripts/cleanup_fenced_knowledge_units.py --execute
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger("cleanup_fenced_ku")
+
+_SELECT_SQL = """
+SELECT id, project_type, domain, source_doc, source_pipeline, body,
+       confidence, ingested_at, qdrant_id
+FROM knowledge_units
+WHERE source_doc LIKE 'intake:%' AND body LIKE '%```json%'
+ORDER BY ingested_at
+"""
+
+
+def _derive_task_type(title: str, multi_types: frozenset[str]) -> str:
+    """Reverse the single_item title back to a task type for re-atomization.
+
+    The polluted rows were stored via the single_item path, whose title is
+    ``task_type.replace("_", " ").title()``. Fall back to a known
+    multi-finding type — the type only gates the multi-parse path; every
+    selected row is a fenced JSON payload that needs that path.
+    """
+    derived = title.strip().lower().replace(" ", "_")
+    return derived if derived in multi_types else "anticipatory_research"
+
+
+async def main(execute: bool, limit: int | None) -> int:
+    import aiosqlite
+    from qdrant_client import QdrantClient
+
+    from genesis.db.crud import knowledge as knowledge_crud
+    from genesis.env import genesis_db_path, qdrant_url
+    from genesis.memory.embeddings import EmbeddingProvider
+    from genesis.memory.knowledge_ingest import ingest_knowledge_unit
+    from genesis.memory.linker import MemoryLinker
+    from genesis.memory.store import MemoryStore
+    from genesis.surplus import intake
+
+    if not hasattr(intake, "_FENCE_RE"):
+        logger.error("intake.py fence fix is not present — refusing to run.")
+        return 1
+
+    db = await aiosqlite.connect(str(genesis_db_path()))
+    db.row_factory = aiosqlite.Row
+    store = None
+    backup_fh = None
+    if execute:
+        from datetime import UTC, datetime
+
+        qdrant = QdrantClient(url=qdrant_url(), timeout=10)
+        store = MemoryStore(
+            embedding_provider=EmbeddingProvider(),
+            qdrant_client=qdrant,
+            db=db,
+            linker=MemoryLinker(qdrant_client=qdrant, db=db),
+        )
+        backup_dir = Path.home() / ".genesis" / "output"
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        backup_path = backup_dir / f"ku_cleanup_backup_{stamp}.jsonl"
+        backup_fh = open(backup_path, "w", encoding="utf-8")  # noqa: SIM115 — closed in finally with db
+        logger.info("Deleted-row backup: %s", backup_path)
+
+    try:
+        cursor = await db.execute(_SELECT_SQL)
+        rows = [dict(r) for r in await cursor.fetchall()]
+        if limit is not None:
+            rows = rows[:limit]
+        logger.info("Selected %d fence-polluted intake rows%s", len(rows),
+                    "" if execute else " (DRY-RUN — no writes)")
+
+        recovered_units = 0
+        rows_recovered = 0
+        rows_empty = 0
+        rows_junk = 0
+        rows_kept = 0
+        junk_ids: list[str] = []
+        kept_ids: list[str] = []
+        failed_ids: list[str] = []
+
+        for row in rows:
+            title, sep, payload = row["body"].partition("\n\n")
+            if not sep:
+                payload = row["body"]
+                title = ""
+            task_type = _derive_task_type(title, intake._MULTI_FINDING_TASK_TYPES)
+            findings, path = intake.atomize(payload, task_type)
+
+            if path in ("json_findings", "json_single") and findings:
+                rows_recovered += 1
+                recovered_units += len(findings)
+                action = f"recover {len(findings)} unit(s) via {path}"
+            elif path == "empty_findings":
+                rows_empty += 1
+                findings = []
+                action = "delete (empty findings envelope)"
+            elif payload.lstrip().startswith("```"):
+                # The payload IS a fence but its JSON is malformed/truncated —
+                # nothing recoverable behind it (D2: delete unparseable).
+                rows_junk += 1
+                junk_ids.append(row["id"])
+                findings = []
+                action = f"delete (malformed whole-fence payload — path={path})"
+            else:
+                # Prose that merely contains an inline fence — legitimate
+                # single-item content, not envelope pollution. Keep as-is.
+                rows_kept += 1
+                kept_ids.append(row["id"])
+                logger.info("%s [%s] %.60s → keep (prose with inline fence)",
+                            row["id"][:8], row["domain"], title or row["body"])
+                continue
+            logger.info("%s [%s] %.60s → %s", row["id"][:8], row["domain"],
+                        title or row["body"], action)
+
+            if not execute:
+                continue
+
+            authority = row["source_doc"].removeprefix("intake:")
+            for finding in findings:
+                await ingest_knowledge_unit(
+                    store=store,
+                    db=db,
+                    content=intake.kb_content_for_finding(finding),
+                    project=row["project_type"],
+                    domain=row["domain"],
+                    authority=authority,
+                    provenance={
+                        "source_doc": row["source_doc"],
+                        "source_pipeline": row["source_pipeline"] or "surplus",
+                    },
+                    memory_class="fact",
+                    confidence=row["confidence"],
+                    tags_json=json.dumps([
+                        row["domain"], row["project_type"], authority,
+                        f"refenced-from:{row['id']}",
+                        f"orig-ingested:{row['ingested_at']}",
+                    ]),
+                )
+
+            # Backup, then delete the polluted original. Order matters: the
+            # memory-layer cascade FIRST — store.delete() removes the Qdrant
+            # point and its memory_metadata / memory_fts / links /
+            # pending_embeddings rows. If the cascade fails, keep the
+            # knowledge_units row so the selector re-finds it on a re-run
+            # (deleting it first would strand the memory-layer copies with
+            # no retry path).
+            backup_fh.write(json.dumps(row) + "\n")
+            backup_fh.flush()
+            if row["qdrant_id"]:
+                try:
+                    await store.delete(row["qdrant_id"])
+                except Exception:
+                    logger.error(
+                        "store.delete failed for %s (%s) — row kept for re-run",
+                        row["id"], row["qdrant_id"], exc_info=True,
+                    )
+                    failed_ids.append(row["id"])
+                    continue
+            await knowledge_crud.delete(db, row["id"])
+            try:
+                from genesis.knowledge.manifest import ManifestManager
+
+                ManifestManager().remove_unit(row["id"])
+            except Exception:
+                logger.debug("Manifest cleanup skipped for %s", row["id"],
+                             exc_info=True)
+
+        logger.info(
+            "%s: %d rows → %d recovered rows (%d new units), "
+            "%d empty envelopes deleted, %d malformed-fence junk deleted, "
+            "%d prose rows kept",
+            "EXECUTED" if execute else "DRY-RUN", len(rows), rows_recovered,
+            recovered_units, rows_empty, rows_junk, rows_kept,
+        )
+        if junk_ids:
+            logger.info("Deleted-as-junk ids: %s", ", ".join(junk_ids))
+        if kept_ids:
+            logger.info("Kept prose ids: %s", ", ".join(kept_ids))
+        if failed_ids:
+            logger.error(
+                "%d row(s) failed the memory-layer cascade and were KEPT "
+                "for re-run: %s", len(failed_ids), ", ".join(failed_ids),
+            )
+            return 1
+        return 0
+    finally:
+        if backup_fh is not None:
+            backup_fh.close()
+        await db.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--execute", action="store_true",
+                        help="apply changes (default: dry-run report only)")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="process at most N rows (for a cautious first run)")
+    args = parser.parse_args()
+    sys.exit(asyncio.run(main(execute=args.execute, limit=args.limit)))

--- a/src/genesis/db/crud/knowledge.py
+++ b/src/genesis/db/crud/knowledge.py
@@ -356,6 +356,28 @@ async def list_by_domain(
     return result
 
 
+async def select_fenced_intake_rows(db: aiosqlite.Connection) -> list[dict]:
+    """Return intake-provenance units whose body still carries a ```json fence.
+
+    Selection for ``scripts/cleanup_fenced_knowledge_units.py`` (2026-07-03
+    context-layer audit): before the atomizer learned to unwrap fences,
+    surplus-intake output was stored verbatim as fenced envelopes. Scoped to
+    intake provenance so legitimate documents that merely contain inline JSON
+    fences are never selected. Ordered oldest-first so a resumed cleanup run
+    processes rows in a stable order.
+    """
+    rows = await db.execute_fetchall(
+        "SELECT id, project_type, domain, source_doc, source_pipeline, "
+        "body, confidence, ingested_at, qdrant_id "
+        "FROM knowledge_units "
+        "WHERE source_doc LIKE 'intake:%' AND body LIKE '%```json%' "
+        "ORDER BY ingested_at",
+    )
+    keys = ("id", "project_type", "domain", "source_doc", "source_pipeline",
+            "body", "confidence", "ingested_at", "qdrant_id")
+    return [dict(zip(keys, row, strict=True)) for row in rows]
+
+
 async def increment_retrieved_batch(
     db: aiosqlite.Connection,
     qdrant_ids: list[str],

--- a/src/genesis/surplus/executor.py
+++ b/src/genesis/surplus/executor.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from genesis.db.crud import observations
+from genesis.surplus.intake import _FENCE_RE
 from genesis.surplus.types import ExecutorResult, SurplusTask, TaskType
 
 if TYPE_CHECKING:
@@ -49,11 +50,8 @@ def _parse_search_queries(llm_output: str, max_queries: int = 5) -> list[str]:
     return queries
 
 
-# Matches ONLY a whole-message ```json fence (case-insensitive tag). `$` without
-# re.MULTILINE anchors to end-of-string, so combined with re.DOTALL the match
-# spans the entire message — inline fences (mid-text) and other-language blocks
-# (```python, bare ```) are deliberately NOT matched and pass through untouched.
-_FENCE_RE = re.compile(r"^\s*```(?i:json)\s*\n?(.*?)\n?\s*```\s*$", re.DOTALL)
+# _FENCE_RE (whole-message ```json fence matcher) is single-sourced in
+# intake.py — see the comment there for exact matching semantics.
 
 
 def _humanize_surplus_content(content: str) -> str:

--- a/src/genesis/surplus/executor.py
+++ b/src/genesis/surplus/executor.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from genesis.db.crud import observations
-from genesis.surplus.intake import _FENCE_RE
+from genesis.surplus.intake import FENCE_RE
 from genesis.surplus.types import ExecutorResult, SurplusTask, TaskType
 
 if TYPE_CHECKING:
@@ -50,7 +50,7 @@ def _parse_search_queries(llm_output: str, max_queries: int = 5) -> list[str]:
     return queries
 
 
-# _FENCE_RE (whole-message ```json fence matcher) is single-sourced in
+# FENCE_RE (whole-message ```json fence matcher) is single-sourced in
 # intake.py — see the comment there for exact matching semantics.
 
 
@@ -71,7 +71,7 @@ def _humanize_surplus_content(content: str) -> str:
     if not content:
         return content
     text = content.strip()
-    match = _FENCE_RE.match(text)
+    match = FENCE_RE.match(text)
     unwrapped = match.group(1).strip() if match else text
     try:
         data = json.loads(unwrapped)

--- a/src/genesis/surplus/intake.py
+++ b/src/genesis/surplus/intake.py
@@ -81,7 +81,7 @@ _TASK_TYPE_TO_SOURCE: dict[str, IntakeSource] = {
 }
 
 # Task types that typically produce multiple findings and should be atomized.
-_MULTI_FINDING_TASK_TYPES = frozenset({
+MULTI_FINDING_TASK_TYPES = frozenset({
     "anticipatory_research",
     "code_audit",
     "gap_clustering",
@@ -144,7 +144,7 @@ class IntakeStats:
 # spans the entire message — inline fences (mid-text) and other-language blocks
 # (```python, bare ```) are deliberately NOT matched and pass through untouched.
 # Single source of truth for the surplus package (executor.py imports it too).
-_FENCE_RE = re.compile(r"^\s*```(?i:json)\s*\n?(.*?)\n?\s*```\s*$", re.DOTALL)
+FENCE_RE = re.compile(r"^\s*```(?i:json)\s*\n?(.*?)\n?\s*```\s*$", re.DOTALL)
 
 
 def _finding_from_item(item: object, index: int, default_title: str) -> AtomicFinding | None:
@@ -197,7 +197,7 @@ def atomize(content: str, source_task_type: str) -> tuple[list[AtomicFinding], s
         return [], "empty"
 
     # Single-output task types skip atomization entirely.
-    if source_task_type not in _MULTI_FINDING_TASK_TYPES:
+    if source_task_type not in MULTI_FINDING_TASK_TYPES:
         return [AtomicFinding(
             title=source_task_type.replace("_", " ").title(),
             content=content.strip(),
@@ -207,7 +207,7 @@ def atomize(content: str, source_task_type: str) -> tuple[list[AtomicFinding], s
     # payload in a ```json fence despite instructions — unwrap a whole-message
     # fence first so the parse attempt sees bare JSON.
     json_text = content
-    fence_match = _FENCE_RE.match(content)
+    fence_match = FENCE_RE.match(content)
     if fence_match:
         json_text = fence_match.group(1)
     try:

--- a/src/genesis/surplus/intake.py
+++ b/src/genesis/surplus/intake.py
@@ -77,6 +77,7 @@ _TASK_TYPE_TO_SOURCE: dict[str, IntakeSource] = {
     "memory_audit": IntakeSource.ANTICIPATORY_RESEARCH,
     "procedure_audit": IntakeSource.ANTICIPATORY_RESEARCH,
     "prompt_effectiveness_review": IntakeSource.ANTICIPATORY_RESEARCH,
+    "wing_audit": IntakeSource.ANTICIPATORY_RESEARCH,
 }
 
 # Task types that typically produce multiple findings and should be atomized.
@@ -86,6 +87,7 @@ _MULTI_FINDING_TASK_TYPES = frozenset({
     "gap_clustering",
     "brainstorm_user",
     "brainstorm_self",
+    "wing_audit",
 })
 
 
@@ -124,7 +126,7 @@ class IntakeStats:
     """Observability counters for a single intake run."""
 
     source: str = ""
-    atomization_path: str = ""  # "json_findings", "json_single", "markdown_split", "single_item"
+    atomization_path: str = ""  # atomize() path — see its docstring for values
     findings_count: int = 0
     routed_knowledge: int = 0
     routed_observation: int = 0
@@ -137,14 +139,59 @@ class IntakeStats:
 # ── Atomization ──────────────────────────────────────────────────────────
 
 
+# Matches ONLY a whole-message ```json fence (case-insensitive tag). `$` without
+# re.MULTILINE anchors to end-of-string, so combined with re.DOTALL the match
+# spans the entire message — inline fences (mid-text) and other-language blocks
+# (```python, bare ```) are deliberately NOT matched and pass through untouched.
+# Single source of truth for the surplus package (executor.py imports it too).
+_FENCE_RE = re.compile(r"^\s*```(?i:json)\s*\n?(.*?)\n?\s*```\s*$", re.DOTALL)
+
+
+def _finding_from_item(item: object, index: int, default_title: str) -> AtomicFinding | None:
+    """Build a finding from one entry of a findings array.
+
+    Handles both the ``{"findings": [...]}`` envelope item shape
+    (title/content/sources/relevance) and bare-array shapes from task-specific
+    prompts (e.g. code_audit's ``{"file", "severity", "description", ...}``) —
+    unknown dict shapes keep a title from their identity keys and the full
+    item as pretty-printed JSON content. Scalars other than str are unusable.
+    """
+    if isinstance(item, dict):
+        title = str(item.get("title") or item.get("file") or item.get("name") or "").strip()
+        if not title:
+            title = f"{default_title} finding {index + 1}"
+        raw_content = item.get("content", "")
+        content = str(raw_content) if raw_content else json.dumps(item, indent=2)
+        # Model output is untrusted: sources may be null, a bare string, or a
+        # list of mixed types; relevance may be null. None of these may abort
+        # the parse (a raised TypeError here would degrade the WHOLE payload
+        # back to a raw single_item unit).
+        raw_sources = item.get("sources")
+        if isinstance(raw_sources, str):
+            raw_sources = [raw_sources]
+        elif not isinstance(raw_sources, list):
+            raw_sources = []
+        return AtomicFinding(
+            title=title[:200],
+            content=content,
+            sources=[str(s) for s in raw_sources if isinstance(s, str)],
+            relevance=str(item.get("relevance") or ""),
+        )
+    if isinstance(item, str):
+        return AtomicFinding(title=item[:200], content=item)
+    return None
+
+
 def atomize(content: str, source_task_type: str) -> tuple[list[AtomicFinding], str]:
     """Split content into atomic findings.
 
     Returns (findings, atomization_path) where path is one of:
-    - "json_findings": parsed JSON with findings array
-    - "json_single": valid JSON but no findings key
+    - "json_findings": parsed JSON findings — envelope or bare top-level array
+    - "json_single": valid JSON object but no findings key
+    - "empty_findings": findings envelope/array with nothing usable — store nothing
     - "markdown_split": split on markdown headings/numbered items
     - "single_item": treated as one finding (fallback or single-output type)
+    - "empty": blank input
     """
     if not content or not content.strip():
         return [], "empty"
@@ -156,29 +203,43 @@ def atomize(content: str, source_task_type: str) -> tuple[list[AtomicFinding], s
             content=content.strip(),
         )], "single_item"
 
-    # Attempt 1: Parse as JSON with findings array.
+    # Attempt 1: Parse as JSON with findings array. Models routinely wrap the
+    # payload in a ```json fence despite instructions — unwrap a whole-message
+    # fence first so the parse attempt sees bare JSON.
+    json_text = content
+    fence_match = _FENCE_RE.match(content)
+    if fence_match:
+        json_text = fence_match.group(1)
     try:
-        data = json.loads(content)
-        if isinstance(data, dict) and "findings" in data:
-            findings_raw = data["findings"]
-            if isinstance(findings_raw, list) and findings_raw:
-                findings = []
-                for item in findings_raw:
-                    if isinstance(item, dict):
-                        findings.append(AtomicFinding(
-                            title=str(item.get("title", ""))[:200],
-                            content=str(item.get("content", "")),
-                            sources=[str(s) for s in item.get("sources", [])
-                                     if isinstance(s, str)],
-                            relevance=str(item.get("relevance", "")),
-                        ))
-                    elif isinstance(item, str):
-                        findings.append(AtomicFinding(
-                            title=item[:200],
-                            content=item,
-                        ))
-                if findings:
-                    return findings, "json_findings"
+        data = json.loads(json_text)
+        items: list | None = None
+        if isinstance(data, dict) and isinstance(data.get("findings"), list):
+            items = data["findings"]
+        elif isinstance(data, list):
+            # Some task prompts (e.g. code_audit) request a bare top-level
+            # array of finding objects rather than a findings envelope.
+            items = data
+        if items is not None:
+            default_title = source_task_type.replace("_", " ").title()
+            # Flatten one level of accidental nesting ([[{...}, {...}]]) —
+            # otherwise list entries are unusable and the payload is dropped.
+            flat_items: list = []
+            for entry in items:
+                if isinstance(entry, list):
+                    flat_items.extend(entry)
+                else:
+                    flat_items.append(entry)
+            findings = []
+            for i, item in enumerate(flat_items):
+                finding = _finding_from_item(item, i, default_title)
+                if finding is not None:
+                    findings.append(finding)
+            if findings:
+                return findings, "json_findings"
+            # A findings envelope/array with nothing usable ([] or only
+            # unusable entry shapes) is a no-op result — never store the
+            # raw envelope as a single unit.
+            return [], "empty_findings"
         # Valid JSON but no findings key — treat as single item.
         if isinstance(data, dict):
             return [AtomicFinding(
@@ -512,6 +573,21 @@ async def run_intake(
     return stats
 
 
+def kb_content_for_finding(finding: AtomicFinding) -> str:
+    """Render a finding as the knowledge-base body text.
+
+    Shared by the runtime routing path and the offline cleanup script
+    (scripts/cleanup_fenced_knowledge_units.py) so the stored unit shape
+    stays single-sourced.
+    """
+    text = f"{finding.title}\n\n{finding.content}"
+    if finding.sources:
+        text += "\n\nSources: " + ", ".join(finding.sources)
+    if finding.relevance:
+        text += f"\n\nRelevance: {finding.relevance}"
+    return text
+
+
 async def _route_to_knowledge(
     scored: ScoredFinding,
     *,
@@ -546,17 +622,7 @@ async def _route_to_knowledge(
     # Determine domain from source.
     domain = _domain_for_source(scored.source, scored.source_task_type)
 
-    sources_str = ""
-    if scored.finding.sources:
-        sources_str = "\n\nSources: " + ", ".join(scored.finding.sources)
-
-    content_for_kb = (
-        f"{scored.finding.title}\n\n"
-        f"{scored.finding.content}"
-        f"{sources_str}"
-    )
-    if scored.finding.relevance:
-        content_for_kb += f"\n\nRelevance: {scored.finding.relevance}"
+    content_for_kb = kb_content_for_finding(scored.finding)
 
     await ingest_knowledge_unit(
         store=store,

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -1913,52 +1913,62 @@ class SurplusScheduler:
                     len(content.strip()), task.id[:8],
                 )
             else:
-                try:
-                    from genesis.surplus.intake import (
-                        run_intake,
-                        source_for_task_type,
-                    )
-                    source = source_for_task_type(str(task.task_type))
-                    intake_stats = await run_intake(
-                        content=content,
-                        source=source,
-                        source_task_type=str(task.task_type),
-                        generating_model=insight.get("generating_model", "unknown"),
-                        db=self._db,
-                    )
-                    logger.info(
-                        "Intake routed %d findings (k=%d, o=%d, d=%d) for task %s",
-                        intake_stats.findings_count,
-                        intake_stats.routed_knowledge,
-                        intake_stats.routed_observation,
-                        intake_stats.routed_discard,
-                        task.id[:8],
-                    )
-                    # Use a synthetic staging_id for tracking
+                if task.task_type == _TT.CODE_AUDIT:
+                    # Code-audit output is ingested per-finding by
+                    # FindingsBridge below, behind its confidence gate and
+                    # slop filter. Routing the raw findings array through
+                    # generic intake as well would double-ingest every
+                    # finding and bypass both gates. Synthetic staging_id
+                    # for tracking; the quality judge below still runs.
                     content_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
                     staging_id = f"{task.task_type.value}-{content_hash}"
-                except Exception:
-                    # Fallback: write to surplus_insights staging (old behavior)
-                    logger.warning(
-                        "Intake pipeline failed — falling back to surplus_insights staging",
-                        exc_info=True,
-                    )
-                    content_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
-                    staging_id = f"{task.task_type.value}-{content_hash}"
-                    now = self._clock()
-                    ttl = (now + timedelta(days=7)).isoformat()
-                    now_iso = now.isoformat()
-                    await surplus_crud.upsert(
-                        self._db,
-                        id=staging_id,
-                        content=content,
-                        source_task_type=str(task.task_type),
-                        generating_model=insight.get("generating_model", "unknown"),
-                        drive_alignment=task.drive_alignment,
-                        confidence=insight.get("confidence", 0.0),
-                        created_at=now_iso,
-                        ttl=ttl,
-                    )
+                else:
+                    try:
+                        from genesis.surplus.intake import (
+                            run_intake,
+                            source_for_task_type,
+                        )
+                        source = source_for_task_type(str(task.task_type))
+                        intake_stats = await run_intake(
+                            content=content,
+                            source=source,
+                            source_task_type=str(task.task_type),
+                            generating_model=insight.get("generating_model", "unknown"),
+                            db=self._db,
+                        )
+                        logger.info(
+                            "Intake routed %d findings (k=%d, o=%d, d=%d) for task %s",
+                            intake_stats.findings_count,
+                            intake_stats.routed_knowledge,
+                            intake_stats.routed_observation,
+                            intake_stats.routed_discard,
+                            task.id[:8],
+                        )
+                        # Use a synthetic staging_id for tracking
+                        content_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
+                        staging_id = f"{task.task_type.value}-{content_hash}"
+                    except Exception:
+                        # Fallback: write to surplus_insights staging (old behavior)
+                        logger.warning(
+                            "Intake pipeline failed — falling back to surplus_insights staging",
+                            exc_info=True,
+                        )
+                        content_hash = hashlib.sha256(content.encode()).hexdigest()[:16]
+                        staging_id = f"{task.task_type.value}-{content_hash}"
+                        now = self._clock()
+                        ttl = (now + timedelta(days=7)).isoformat()
+                        now_iso = now.isoformat()
+                        await surplus_crud.upsert(
+                            self._db,
+                            id=staging_id,
+                            content=content,
+                            source_task_type=str(task.task_type),
+                            generating_model=insight.get("generating_model", "unknown"),
+                            drive_alignment=task.drive_alignment,
+                            confidence=insight.get("confidence", 0.0),
+                            created_at=now_iso,
+                            ttl=ttl,
+                        )
 
                 # Measurement-only verified-correctness verdict. Runs whether
                 # intake succeeded or fell back (content is valid to judge either

--- a/tests/test_surplus/test_intake.py
+++ b/tests/test_surplus/test_intake.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 
 from genesis.surplus.intake import (
-    _MULTI_FINDING_TASK_TYPES,
+    MULTI_FINDING_TASK_TYPES,
     AtomicFinding,
     IntakeSource,
     atomize,
@@ -186,7 +186,7 @@ class TestBareArrayPayload:
 
 class TestWingAudit:
     def test_wing_audit_in_multi_finding_set(self):
-        assert "wing_audit" in _MULTI_FINDING_TASK_TYPES
+        assert "wing_audit" in MULTI_FINDING_TASK_TYPES
 
     def test_wing_audit_fenced_findings_atomized(self):
         findings, path = atomize(f"```json\n{_FINDINGS_JSON}\n```", "wing_audit")

--- a/tests/test_surplus/test_intake.py
+++ b/tests/test_surplus/test_intake.py
@@ -1,0 +1,225 @@
+"""Tests for the intelligence intake pipeline — atomization paths.
+
+Coverage added by the 2026-07-03 context-layer audit (PR-1): model output
+arrives wrapped in ```json fences that the bare json.loads() could not parse,
+WING_AUDIT was missing from the multi-finding set, and an empty findings
+envelope fell through to json_single storage — together these severed the
+surplus → knowledge pipeline and stored raw fenced envelopes as units.
+"""
+
+from __future__ import annotations
+
+import json
+
+from genesis.surplus.intake import (
+    _MULTI_FINDING_TASK_TYPES,
+    AtomicFinding,
+    IntakeSource,
+    atomize,
+    kb_content_for_finding,
+    source_for_task_type,
+)
+
+_FINDINGS_PAYLOAD = {
+    "findings": [
+        {"title": "A", "content": "alpha"},
+        {"title": "B", "content": "beta", "sources": ["s1"], "relevance": "rel"},
+    ]
+}
+_FINDINGS_JSON = json.dumps(_FINDINGS_PAYLOAD)
+
+
+class TestFenceUnwrapping:
+    def test_fenced_multi_finding_json(self):
+        findings, path = atomize(f"```json\n{_FINDINGS_JSON}\n```", "anticipatory_research")
+        assert path == "json_findings"
+        assert [f.title for f in findings] == ["A", "B"]
+        assert findings[1].sources == ["s1"]
+        assert findings[1].relevance == "rel"
+
+    def test_fence_tag_case_insensitive(self):
+        findings, path = atomize(f"```JSON\n{_FINDINGS_JSON}\n```", "anticipatory_research")
+        assert path == "json_findings"
+        assert len(findings) == 2
+
+    def test_fenced_single_object(self):
+        findings, path = atomize('```json\n{"title": "Solo", "note": "x"}\n```', "code_audit")
+        assert path == "json_single"
+        assert len(findings) == 1
+        assert findings[0].title == "Solo"
+        assert "```" not in findings[0].content
+
+    def test_unfenced_json_regression(self):
+        findings, path = atomize(_FINDINGS_JSON, "gap_clustering")
+        assert path == "json_findings"
+        assert len(findings) == 2
+
+    def test_inline_fence_not_unwrapped(self):
+        content = f"Preamble text.\n```json\n{_FINDINGS_JSON}\n```\nTrailing."
+        findings, path = atomize(content, "anticipatory_research")
+        # Not a whole-message fence — must NOT parse as findings JSON.
+        assert path == "single_item"
+        assert len(findings) == 1
+
+    def test_non_json_fence_untouched(self):
+        findings, path = atomize("```python\nprint('hi')\n```", "anticipatory_research")
+        assert path == "single_item"
+        assert findings[0].content == "```python\nprint('hi')\n```"
+
+
+class TestEmptyFindingsEnvelope:
+    def test_empty_envelope_stores_nothing(self):
+        findings, path = atomize('{"findings": []}', "anticipatory_research")
+        assert findings == []
+        assert path == "empty_findings"
+
+    def test_fenced_empty_envelope_stores_nothing(self):
+        findings, path = atomize('```json\n{"findings": []}\n```', "anticipatory_research")
+        assert findings == []
+        assert path == "empty_findings"
+
+    def test_empty_dict_entry_is_kept(self):
+        findings, path = atomize('{"findings": [42, null, {}]}', "anticipatory_research")
+        # {} yields a finding with empty title/content — kept (dict shape is
+        # usable); scalars are dropped. Only fully-unusable envelopes skip.
+        assert path == "json_findings"
+        assert len(findings) == 1
+
+    def test_scalar_only_envelope_stores_nothing(self):
+        findings, path = atomize('{"findings": [42, null]}', "anticipatory_research")
+        assert findings == []
+        assert path == "empty_findings"
+
+    def test_non_list_findings_falls_to_json_single(self):
+        findings, path = atomize('{"findings": "oops"}', "anticipatory_research")
+        assert path == "json_single"
+        assert len(findings) == 1
+
+
+class TestItemRobustness:
+    """Model output is untrusted — malformed fields must degrade per-item,
+    never abort the whole payload back to a raw single_item unit."""
+
+    def test_null_sources_does_not_degrade_payload(self):
+        payload = '{"findings": [{"title": "A", "content": "x", "sources": null}]}'
+        findings, path = atomize(payload, "anticipatory_research")
+        assert path == "json_findings"
+        assert findings[0].sources == []
+
+    def test_string_sources_wrapped_not_char_iterated(self):
+        payload = ('{"findings": [{"title": "A", "content": "x",'
+                   ' "sources": "http://example.test"}]}')
+        findings, path = atomize(payload, "anticipatory_research")
+        assert path == "json_findings"
+        assert findings[0].sources == ["http://example.test"]
+
+    def test_null_relevance_is_empty_string(self):
+        payload = '{"findings": [{"title": "A", "content": "x", "relevance": null}]}'
+        findings, path = atomize(payload, "anticipatory_research")
+        assert path == "json_findings"
+        assert findings[0].relevance == ""
+
+    def test_nested_list_flattened_one_level(self):
+        payload = '[[{"title": "A", "content": "x"}, {"title": "B", "content": "y"}]]'
+        findings, path = atomize(payload, "code_audit")
+        assert path == "json_findings"
+        assert [f.title for f in findings] == ["A", "B"]
+
+
+class TestFenceVariants:
+    def test_crlf_fence(self):
+        content = f"```json\r\n{_FINDINGS_JSON}\r\n```"
+        findings, path = atomize(content, "anticipatory_research")
+        assert path == "json_findings"
+        assert len(findings) == 2
+
+    def test_whitespace_padded_fence(self):
+        content = f"  ```json\n{_FINDINGS_JSON}\n```  \n"
+        findings, path = atomize(content, "anticipatory_research")
+        assert path == "json_findings"
+
+    def test_bare_fence_without_json_tag_not_unwrapped(self):
+        # Documented behavior: the unwrap requires the ```json tag; a bare
+        # fence stays opaque and falls through to single_item.
+        content = f"```\n{_FINDINGS_JSON}\n```"
+        findings, path = atomize(content, "anticipatory_research")
+        assert path == "single_item"
+
+
+class TestBareArrayPayload:
+    """code_audit-style prompts return a bare top-level array, not an envelope."""
+
+    _AUDIT_JSON = json.dumps([
+        {"file": "src/x.py", "line": 3, "severity": "high",
+         "description": "desc one", "confidence": 0.8},
+        {"file": "src/y.py", "line": None, "severity": "low",
+         "description": "desc two", "confidence": 0.6},
+    ])
+
+    def test_fenced_bare_array_atomized(self):
+        findings, path = atomize(f"```json\n{self._AUDIT_JSON}\n```", "code_audit")
+        assert path == "json_findings"
+        assert [f.title for f in findings] == ["src/x.py", "src/y.py"]
+        assert "desc one" in findings[0].content
+        assert "severity" in findings[0].content
+
+    def test_unfenced_bare_array_atomized(self):
+        findings, path = atomize(self._AUDIT_JSON, "code_audit")
+        assert path == "json_findings"
+        assert len(findings) == 2
+
+    def test_string_items_array(self):
+        findings, path = atomize('["insight one", "insight two"]', "brainstorm_self")
+        assert path == "json_findings"
+        assert [f.title for f in findings] == ["insight one", "insight two"]
+
+    def test_empty_array_stores_nothing(self):
+        findings, path = atomize("[]", "code_audit")
+        assert findings == []
+        assert path == "empty_findings"
+
+    def test_untitled_dict_gets_fallback_title(self):
+        findings, path = atomize('[{"description": "d"}]', "code_audit")
+        assert path == "json_findings"
+        assert findings[0].title == "Code Audit finding 1"
+
+
+class TestWingAudit:
+    def test_wing_audit_in_multi_finding_set(self):
+        assert "wing_audit" in _MULTI_FINDING_TASK_TYPES
+
+    def test_wing_audit_fenced_findings_atomized(self):
+        findings, path = atomize(f"```json\n{_FINDINGS_JSON}\n```", "wing_audit")
+        assert path == "json_findings"
+        assert len(findings) == 2
+
+    def test_wing_audit_source_mapping(self):
+        assert source_for_task_type("wing_audit") is IntakeSource.ANTICIPATORY_RESEARCH
+
+
+class TestExistingPaths:
+    def test_blank_content(self):
+        assert atomize("", "anticipatory_research") == ([], "empty")
+        assert atomize("   \n", "anticipatory_research") == ([], "empty")
+
+    def test_single_output_type_bypasses_parsing(self):
+        content = f"```json\n{_FINDINGS_JSON}\n```"
+        findings, path = atomize(content, "memory_audit")
+        assert path == "single_item"
+        assert findings[0].title == "Memory Audit"
+
+    def test_markdown_split_still_works(self):
+        content = "## First\nbody one\n## Second\nbody two"
+        findings, path = atomize(content, "anticipatory_research")
+        assert path == "markdown_split"
+        assert [f.title for f in findings] == ["First", "Second"]
+
+
+class TestKbContent:
+    def test_full_shape(self):
+        f = AtomicFinding(title="T", content="C", sources=["s1", "s2"], relevance="R")
+        assert kb_content_for_finding(f) == "T\n\nC\n\nSources: s1, s2\n\nRelevance: R"
+
+    def test_minimal_shape(self):
+        f = AtomicFinding(title="T", content="C")
+        assert kb_content_for_finding(f) == "T\n\nC"

--- a/tests/test_surplus/test_scheduler.py
+++ b/tests/test_surplus/test_scheduler.py
@@ -251,6 +251,36 @@ async def test_dispatch_judge_outage_stays_null(db):
     assert row["judge_detail"] is None
 
 
+async def test_code_audit_skips_generic_intake(db):
+    """CODE_AUDIT output is ingested per-finding by FindingsBridge (behind its
+    confidence gate and slop filter); the generic intake route must not
+    double-ingest the raw findings array or bypass those gates."""
+    from genesis.surplus.intake import IntakeStats
+
+    sched, compute = _make_scheduler(db, idle=True)
+    await sched._queue.enqueue(
+        TaskType.CODE_AUDIT, ComputeTier.FREE_API, 0.8, "curiosity",
+    )
+    intake_mock = AsyncMock(return_value=IntakeStats(findings_count=1))
+    with patch.object(
+        compute, "_ping_lmstudio", new_callable=AsyncMock, return_value=False,
+    ), patch(
+        "genesis.surplus.intake.run_intake", intake_mock,
+    ), patch(
+        "genesis.surplus.quality_judge.run_quality_judge",
+        new_callable=AsyncMock, return_value=(None, None, None),
+    ):
+        assert await sched.dispatch_once() is True
+    intake_mock.assert_not_awaited()
+    cur = await db.execute(
+        "SELECT status, result_staging_id FROM surplus_tasks "
+        "WHERE status='completed'"
+    )
+    row = await cur.fetchone()
+    assert row is not None
+    assert row["result_staging_id"]  # synthetic tracking id still recorded
+
+
 async def test_dispatch_non_insight_type_skips_judge(db):
     # An action / non-insight type must NOT invoke the judge (cost) and stays NULL.
     row, judge = await _dispatch_with_judge(


### PR DESCRIPTION
## Summary

Batch 1 PR-1 of the 2026-07-03 context-layer audit remediation. The surplus → knowledge pipeline was severed at intake: model output arrives wrapped in ```json fences that the bare `json.loads()` never parsed, code_audit emits bare top-level arrays no branch handled, and WING_AUDIT was missing from the multi-finding set — so months of findings were stored as raw fenced blobs (388 polluted knowledge units on this install).

- `atomize()` unwraps a whole-message ```json fence (regex single-sourced in intake.py, imported by executor.py), parses bare top-level arrays via a shared per-item extractor (identity-key title fallbacks, one-level nesting flatten), and treats empty/unusable envelopes as a no-op instead of storing the raw envelope.
- Per-item extraction is hardened against untrusted shapes (null/string `sources`, null `relevance`) so a malformed field degrades that item only, never the whole payload.
- `wing_audit` joins the multi-finding set + task-type→source map.
- **Scheduler**: CODE_AUDIT output no longer routes through generic intake — FindingsBridge owns per-finding ingestion behind its 0.7-confidence gate and slop filter; the generic route would double-ingest every finding and bypass both. The quality judge still runs.
- **New one-off script** `scripts/cleanup_fenced_knowledge_units.py` (dry-run default) re-parses the polluted rows: recover → proper units (provenance/confidence preserved, original id + timestamp as tags); malformed whole-fence junk → delete (D2); prose with incidental inline fences → keep. Deletes run the memory-layer cascade first via `store.delete()` (Qdrant point + memory_fts/metadata/links — a knowledge_units-only delete would leave bodies recallable via FTS), keep the row on cascade failure (re-runnable) with nonzero exit, and dump every deleted row to a JSONL backup first.

## Verification

- NEW `tests/test_surplus/test_intake.py` (31 tests — no coverage existed); RED-proven against unfixed code. Scheduler test pins the CODE_AUDIT intake skip. 101 tests green across test_intake/test_executor/test_scheduler.
- Script dry-run against the live DB: 388 rows → 369 recovered (1275 proper units), 5 malformed junk, 14 legit prose kept, 0 data loss. Executes post-merge (backup + 6h cron backups in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)