### PR TITLE
fix(skills): catalog recursion + nudge scorer repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Skill suggestions now actually fire — and nested skill packs show up in the catalog.** The
+  prompt-time skill nudge scored matches against the length of your prompt, so on any wordy prompt a
+  genuine match was diluted below the firing threshold and suggestions near-never appeared; a single
+  clear name-or-keyword match is now enough. Suggestions also no longer get crowded out by the process
+  (TDD/brainstorming) nudges — each kind keeps its own slots — and library-skill suggestions now tell
+  you exactly what to do (`Read <path>/SKILL.md`) instead of pointing at a command that can't load
+  them. The catalog builder now looks inside container directories (skill packs like `gitnexus/` or
+  plugin repos in the skill library), indexing the real skills inside instead of one useless entry for
+  the folder. And a stale catalog can no longer cut the nudge off entirely: regeneration now runs in
+  the background while the current prompt uses the existing catalog.
+
 - **The dashboard's per-session memory row is clearer: "Claude Code Sessions", green when healthy.** The
   cryptic "CC" row that listed sessions as gray "cc-1 …" chips is now labeled **Claude Code Sessions**,
   renders each healthy session in green (amber ≥ 4 GB, red ≥ 6 GB), and shows a hover tooltip explaining

--- a/scripts/generate_skill_catalog.py
+++ b/scripts/generate_skill_catalog.py
@@ -41,7 +41,7 @@ def _extract_skill_info(skill_dir: Path) -> dict | None:
                 continue
 
     # Fallback: use directory name
-    return {"name": skill_dir.name, "description": ""}
+    return {"name": skill_dir.name, "description": "", "keywords": []}
 
 
 def _parse_frontmatter(content: str, fallback_name: str = "") -> dict:
@@ -102,22 +102,65 @@ def _parse_frontmatter(content: str, fallback_name: str = "") -> dict:
     return {"name": name, "description": description, "keywords": keywords}
 
 
-def _scan_tier(tier_dir: Path, tier_num: int, repo_root: Path | None) -> list[dict]:
-    """Scan a single tier directory for skills."""
+# A directory without its own SKILL.md may be a container of real skills
+# (e.g. gitnexus/<skill>/SKILL.md, or a plugin repo laid out as
+# <plugin>/skills/<skill>/SKILL.md). These fixed-depth globs detect that.
+_NESTED_SKILL_GLOBS = ("*/SKILL.md", "skills/*/SKILL.md", "*/skills/*/SKILL.md")
+# Recursion cap: tier dir = depth 0; deepest known layout is
+# skill-library/<vendor>/<plugin>/skills/<skill>/SKILL.md (depth 3).
+_MAX_SCAN_DEPTH = 3
+
+
+def _has_own_skill_md(entry: Path) -> bool:
+    """True if the directory is itself a skill (has a SKILL.md marker)."""
+    return (entry / "SKILL.md").exists() or (entry / "skill.md").exists()
+
+
+def _has_nested_skills(entry: Path) -> bool:
+    """True if the directory contains skills nested below it."""
+    return any(
+        next(entry.glob(pattern), None) is not None
+        for pattern in _NESTED_SKILL_GLOBS
+    )
+
+
+def _scan_tier(
+    tier_dir: Path,
+    tier_num: int,
+    repo_root: Path | None,
+    _depth: int = 0,
+) -> list[dict]:
+    """Scan a single tier directory for skills, recursing into containers.
+
+    A child directory with its own SKILL.md is indexed as a skill. A child
+    without one that holds nested SKILL.md files is a container — recurse
+    and index the real skills instead of emitting a phantom entry for the
+    container itself. Inside containers, directories with neither marker
+    (plugin repos carry hooks/, scripts/, docs/) are skipped; at the top
+    level they keep the name-only fallback entry.
+    """
     results: list[dict] = []
     if not tier_dir.is_dir():
         return results
 
     for entry in sorted(tier_dir.iterdir()):
-        if entry.is_dir() and not entry.name.startswith("."):
-            info = _extract_skill_info(entry)
-            if info:
-                info["tier"] = tier_num
-                if repo_root and entry.is_relative_to(repo_root):
-                    info["path"] = str(entry.relative_to(repo_root))
-                else:
-                    info["path"] = str(entry)
-                results.append(info)
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        if not _has_own_skill_md(entry):
+            if _depth < _MAX_SCAN_DEPTH and _has_nested_skills(entry):
+                results.extend(_scan_tier(entry, tier_num, repo_root, _depth + 1))
+                continue
+            if _depth > 0:
+                # Support dir inside a container (hooks/, scripts/, …).
+                continue
+        info = _extract_skill_info(entry)
+        if info:
+            info["tier"] = tier_num
+            if repo_root and entry.is_relative_to(repo_root):
+                info["path"] = str(entry.relative_to(repo_root))
+            else:
+                info["path"] = str(entry)
+            results.append(info)
     return results
 
 
@@ -146,7 +189,12 @@ def main() -> None:
     catalog = generate_catalog()
 
     CATALOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    CATALOG_PATH.write_text(json.dumps(catalog, indent=2), encoding="utf-8")
+    # Atomic write: the injection hook reads this file on every prompt and
+    # regeneration now runs detached in the background — a reader must never
+    # see a half-written catalog.
+    tmp_path = CATALOG_PATH.with_suffix(".json.tmp")
+    tmp_path.write_text(json.dumps(catalog, indent=2), encoding="utf-8")
+    tmp_path.replace(CATALOG_PATH)
 
     total = len(catalog["tier1"]) + len(catalog["tier2"])
     print(

--- a/scripts/hooks/skill_injection_hook.py
+++ b/scripts/hooks/skill_injection_hook.py
@@ -20,13 +20,15 @@ from pathlib import Path
 CATALOG_PATH = Path.home() / ".genesis" / "skill_catalog.json"
 _CATALOG_MAX_AGE_S = 3600  # Regenerate catalog if older than 1h
 
-# Minimum confidence threshold — even 1-2 keyword matches should surface
-# the skill. With 10 prompt keywords, a single keyword match = 0.1 (name)
-# or 0.05 (desc). Threshold of 0.1 means 1 name/keyword match suffices.
-_MIN_CONFIDENCE = 0.1
-# Total nudge budget per prompt (process + catalog combined).
-# If process nudges consume slots, catalog gets fewer.
-_MAX_TOTAL_NUDGES = 2
+# Minimum raw match score — a single name or explicit-keyword hit scores
+# 2 points and is enough to surface the skill. A lone description hit
+# (1 point) is not. Raw points, NOT normalized by prompt keyword count:
+# normalization made keyword-rich prompts dilute genuine hits below the
+# threshold, so catalog nudges near-never fired.
+_MIN_SCORE = 2
+# Catalog nudge budget per prompt. Process (superpowers) nudges have their
+# own separate budget and never compete for these slots.
+_MAX_CATALOG_NUDGES = 2
 
 # --- Process Discipline Detection ---
 # Superpowers skills aren't in the Genesis catalog but need nudges
@@ -57,24 +59,32 @@ _EXCLUDE_KEYWORDS = {
 
 
 def _ensure_catalog_fresh() -> None:
-    """Regenerate the skill catalog if it's missing or stale (>1h old)."""
+    """Spawn a detached catalog regeneration if it's missing or stale (>1h).
+
+    Regeneration is out-of-band: the spawn is fire-and-forget and the
+    current prompt uses the stale catalog, so the hook's 500ms timeout can
+    never kill nudge output while waiting on the generator. The refreshed
+    catalog serves the next prompt.
+    """
     try:
         if CATALOG_PATH.exists():
             import time
             age = time.time() - CATALOG_PATH.stat().st_mtime
             if age < _CATALOG_MAX_AGE_S:
                 return
-        # Locate and run the generator
+        # Locate the generator and spawn it detached
         gen_script = Path(__file__).resolve().parents[1] / "generate_skill_catalog.py"
         if gen_script.exists():
             import subprocess
-            subprocess.run(
+            subprocess.Popen(
                 [sys.executable, str(gen_script)],
-                capture_output=True, timeout=5,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
             )
     except Exception as exc:
         # Never block prompt, but emit diagnostics
-        print(f"Catalog refresh failed: {exc}", file=sys.stderr)
+        print(f"Catalog refresh spawn failed: {exc}", file=sys.stderr)
 
 
 def _load_catalog() -> dict:
@@ -117,7 +127,12 @@ def _save_session_nudge(session_id: str, skill_name: str) -> None:
 
 
 def _score_skill(skill: dict, keywords: list[str]) -> float:
-    """Score a skill against prompt keywords. Returns 0.0-1.0."""
+    """Score a skill against prompt keywords. Returns raw match points.
+
+    Name and explicit-keyword hits score 2 points each, description hits 1.
+    Deliberately NOT normalized by prompt keyword count — a long prompt
+    must not dilute a genuine hit below the firing threshold.
+    """
     if not keywords:
         return 0.0
 
@@ -135,8 +150,7 @@ def _score_skill(skill: dict, keywords: list[str]) -> float:
         elif kw_lower in desc_lower:
             matches += 1
 
-    max_score = 2 * len(keywords)
-    return min(matches / max_score, 1.0) if max_score > 0 else 0.0
+    return float(matches)
 
 
 def _extract_keywords(prompt: str) -> list[str]:
@@ -244,20 +258,25 @@ def main() -> None:
             if name in already_nudged:
                 continue
             score = _score_skill(skill, keywords)
-            if score >= _MIN_CONFIDENCE:
+            if score >= _MIN_SCORE:
                 candidates.append((score, skill))
 
         candidates.sort(key=lambda x: x[0], reverse=True)
 
-        # Dynamic budget: total nudges (process + catalog) capped at _MAX_TOTAL_NUDGES
-        catalog_budget = max(0, _MAX_TOTAL_NUDGES - len(process_nudges))
-        for _score, skill in candidates[:catalog_budget]:
+        # Catalog budget is independent of process nudges — process nudges
+        # keep their own slots and never crowd out skill suggestions.
+        for _score, skill in candidates[:_MAX_CATALOG_NUDGES]:
             name = skill.get("name", "")
             tier = skill.get("tier", "?")
             desc = skill.get("description", "")
 
             if tier == 1:
                 print(f"[Skill] The '{name}' skill is relevant here. {desc[:80]}")
+            elif skill.get("path"):
+                print(
+                    f"[Skill] The '{name}' skill matches this task. "
+                    f"Read {skill['path']}/SKILL.md. {desc[:60]}"
+                )
             else:
                 print(
                     f"[Skill] The '{name}' skill matches this task. "

--- a/tests/test_hooks/test_skill_injection.py
+++ b/tests/test_hooks/test_skill_injection.py
@@ -1,7 +1,11 @@
 """Tests for skill injection hook logic."""
 from __future__ import annotations
 
+import io
+import json
+import os
 import sys
+import time
 from pathlib import Path
 
 # Add scripts dirs to path for import
@@ -97,3 +101,207 @@ def test_catalog_parse_folded_scalar():
     assert "refactoring" in info["description"]
     # Should be joined into a single string, not contain ">"
     assert info["description"] != ">"
+
+
+# --- Raw-point scoring (threshold repair) ---
+
+
+def test_score_skill_raw_points_keyword_hit():
+    """A single explicit-keyword hit scores 2 raw points."""
+    from skill_injection_hook import _MIN_SCORE, _score_skill
+
+    skill = {"name": "stealth-browser", "description": "", "keywords": ["selenium"]}
+    assert _score_skill(skill, ["selenium"]) == 2.0
+    assert _score_skill(skill, ["selenium"]) >= _MIN_SCORE
+
+
+def test_score_skill_raw_points_desc_hit_below_threshold():
+    """A lone description hit (1 point) stays below the firing threshold."""
+    from skill_injection_hook import _MIN_SCORE, _score_skill
+
+    skill = {"name": "forecasting", "description": "predict future trends", "keywords": []}
+    score = _score_skill(skill, ["trends"])
+    assert score == 1.0
+    assert score < _MIN_SCORE
+
+
+def test_score_skill_not_diluted_by_long_prompt():
+    """Raw scoring: many unrelated prompt keywords must not dilute one hit.
+
+    The old score/(2*n_keywords) normalization made a single keyword hit in
+    a 12-keyword prompt score 2/24 < 0.1 — so keyword-rich prompts near-never
+    fired a nudge.
+    """
+    from skill_injection_hook import _MIN_SCORE, _score_skill
+
+    skill = {"name": "stealth-browser", "description": "", "keywords": ["selenium"]}
+    keywords = ["selenium"] + [f"filler{i}" for i in range(11)]
+    score = _score_skill(skill, keywords)
+    assert score == 2.0
+    assert score >= _MIN_SCORE
+
+
+# --- main() end-to-end behavior (stdin -> nudge output) ---
+
+# 12 significant keywords, exactly one ("selenium") matching the skill below.
+_LONG_SELENIUM_PROMPT = (
+    "selenium grid nodes keep dropping sessions during long "
+    "overnight batch runs tonight"
+)
+
+_TIER2_SKILL = {
+    "name": "stealth-browser",
+    "description": "Browser automation with anti-detection",
+    "keywords": ["selenium"],
+    "tier": 2,
+    "path": "src/genesis/skills/stealth-browser",
+}
+
+
+def _write_catalog(path: Path, tier1: list | None = None, tier2: list | None = None) -> None:
+    path.write_text(json.dumps({"tier1": tier1 or [], "tier2": tier2 or []}))
+
+
+def _run_main(monkeypatch, capsys, catalog_file: Path, prompt: str) -> str:
+    """Drive hook main() with a synthetic catalog and prompt; return stdout."""
+    import skill_injection_hook as hook
+
+    monkeypatch.setattr(hook, "CATALOG_PATH", catalog_file)
+    # Empty session_id -> session-nudge persistence is a no-op (no ~ writes).
+    payload = {"prompt": prompt, "session_id": ""}
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    hook.main()
+    return capsys.readouterr().out
+
+
+def test_main_single_keyword_hit_fires_on_long_prompt(tmp_path, monkeypatch, capsys):
+    """One keyword hit in a 12-keyword prompt emits a [Skill] nudge."""
+    catalog_file = tmp_path / "skill_catalog.json"
+    _write_catalog(catalog_file, tier2=[_TIER2_SKILL])
+
+    out = _run_main(monkeypatch, capsys, catalog_file, _LONG_SELENIUM_PROMPT)
+    assert "[Skill]" in out
+    assert "stealth-browser" in out
+
+
+def test_main_desc_only_hit_does_not_fire(tmp_path, monkeypatch, capsys):
+    """A lone description match (1 point) emits no [Skill] nudge."""
+    catalog_file = tmp_path / "skill_catalog.json"
+    skill = {
+        "name": "forecasting",
+        "description": "predict future trends",
+        "keywords": [],
+        "tier": 2,
+        "path": "src/genesis/skills/forecasting",
+    }
+    _write_catalog(catalog_file, tier2=[skill])
+
+    out = _run_main(
+        monkeypatch, capsys, catalog_file, "market trends overnight tonight"
+    )
+    assert "[Skill]" not in out
+
+
+def test_main_catalog_nudges_not_crowded_out_by_process_nudges(
+    tmp_path, monkeypatch, capsys
+):
+    """Process nudges keep their own budget; catalog nudges still fire.
+
+    Old behavior: 2 process nudges consumed the whole shared budget, so the
+    catalog nudge was silently dropped.
+    """
+    catalog_file = tmp_path / "skill_catalog.json"
+    _write_catalog(catalog_file, tier2=[_TIER2_SKILL])
+
+    # "implement"/"build"/"feature"/"endpoint" trigger BOTH process nudges;
+    # "selenium" matches the catalog skill.
+    prompt = "implement and build the new feature endpoint with selenium"
+    out = _run_main(monkeypatch, capsys, catalog_file, prompt)
+
+    assert out.count("[Process]") == 2
+    assert "[Skill]" in out
+    assert "stealth-browser" in out
+
+
+def test_main_tier2_nudge_says_read_skill_md(tmp_path, monkeypatch, capsys):
+    """Tier-2 nudges give a real invocation instruction: Read <path>/SKILL.md."""
+    catalog_file = tmp_path / "skill_catalog.json"
+    _write_catalog(catalog_file, tier2=[_TIER2_SKILL])
+
+    out = _run_main(monkeypatch, capsys, catalog_file, _LONG_SELENIUM_PROMPT)
+    assert "Read src/genesis/skills/stealth-browser/SKILL.md" in out
+    assert "/skill stealth-browser" not in out
+
+
+def test_main_tier1_nudge_text_unchanged(tmp_path, monkeypatch, capsys):
+    """Tier-1 skills keep the 'is relevant here' phrasing (no Read line)."""
+    catalog_file = tmp_path / "skill_catalog.json"
+    skill = {
+        "name": "stealth-browser",
+        "description": "Browser automation",
+        "keywords": ["selenium"],
+        "tier": 1,
+        "path": ".claude/skills/stealth-browser",
+    }
+    _write_catalog(catalog_file, tier1=[skill])
+
+    out = _run_main(monkeypatch, capsys, catalog_file, _LONG_SELENIUM_PROMPT)
+    assert "is relevant here" in out
+    assert "SKILL.md" not in out
+
+
+def test_stale_catalog_regen_detached_and_stale_catalog_still_used(
+    tmp_path, monkeypatch, capsys
+):
+    """Stale catalog: regen is spawned detached; the stale copy still serves.
+
+    The 500ms hook timeout must never kill nudge output while a regeneration
+    runs, so the spawn is fire-and-forget (Popen + start_new_session) and the
+    current prompt reads the stale file.
+    """
+    import subprocess
+
+    import skill_injection_hook as hook
+
+    catalog_file = tmp_path / "skill_catalog.json"
+    _write_catalog(catalog_file, tier2=[_TIER2_SKILL])
+    stale = time.time() - (hook._CATALOG_MAX_AGE_S + 600)
+    os.utime(catalog_file, (stale, stale))
+
+    popen_calls: list[dict] = []
+
+    def fake_popen(*args, **kwargs):
+        popen_calls.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    out = _run_main(monkeypatch, capsys, catalog_file, _LONG_SELENIUM_PROMPT)
+
+    # Nudge came from the stale catalog — no blocking on regeneration.
+    assert "[Skill]" in out
+    assert popen_calls, "stale catalog should spawn a detached regeneration"
+    kwargs = popen_calls[0]
+    assert kwargs.get("start_new_session") is True
+    assert kwargs.get("stdout") == subprocess.DEVNULL
+    assert kwargs.get("stderr") == subprocess.DEVNULL
+
+
+def test_fresh_catalog_spawns_no_regen(tmp_path, monkeypatch, capsys):
+    """A fresh catalog must not spawn the generator at all."""
+    import subprocess
+
+    popen_calls: list[dict] = []
+
+    def fake_popen(*args, **kwargs):
+        popen_calls.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    catalog_file = tmp_path / "skill_catalog.json"
+    _write_catalog(catalog_file, tier2=[_TIER2_SKILL])  # mtime = now
+
+    out = _run_main(monkeypatch, capsys, catalog_file, _LONG_SELENIUM_PROMPT)
+    assert "[Skill]" in out
+    assert not popen_calls

--- a/tests/test_scripts/test_generate_skill_catalog.py
+++ b/tests/test_scripts/test_generate_skill_catalog.py
@@ -1,0 +1,157 @@
+"""Tests for scripts/generate_skill_catalog.py — container recursion + entry shape.
+
+The invariants under test:
+  * a directory whose children hold SKILL.md files (gitnexus-style
+    ``container/<skill>/SKILL.md``, or plugin-repo style
+    ``vendor/<plugin>/skills/<skill>/SKILL.md``) is a CONTAINER — the nested
+    real skills are indexed and NO phantom entry is emitted for the container;
+  * inside a container, support dirs (hooks/, scripts/) are skipped, never
+    indexed as phantom skills;
+  * every catalog entry always carries a ``keywords`` key — the no-SKILL.md
+    fallback emits ``"keywords": []`` rather than omitting the key.
+
+All fixtures are synthetic tmp_path trees — no dependence on the live repo
+or ~/.genesis state.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# Load the stdlib script as a module (not a package — use importlib).
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "generate_skill_catalog.py"
+)
+_spec = importlib.util.spec_from_file_location("generate_skill_catalog", _SCRIPT_PATH)
+_gen = importlib.util.module_from_spec(_spec)
+sys.modules["generate_skill_catalog"] = _gen
+_spec.loader.exec_module(_gen)
+
+
+def _mk_skill(skill_dir: Path, name: str, description: str = "does things") -> None:
+    """Create a skill dir with a minimal SKILL.md."""
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n# {name}\n"
+    )
+
+
+def _names(results: list[dict]) -> set[str]:
+    return {r["name"] for r in results}
+
+
+def test_scan_tier_indexes_direct_skills(tmp_path):
+    _mk_skill(tmp_path / "alpha", "alpha")
+    _mk_skill(tmp_path / "beta", "beta")
+
+    results = _gen._scan_tier(tmp_path, 2, None)
+
+    assert _names(results) == {"alpha", "beta"}
+    for entry in results:
+        assert entry["tier"] == 2
+        assert entry["path"].startswith(str(tmp_path))
+
+
+def test_scan_tier_recurses_into_container(tmp_path):
+    """gitnexus-style: container/<skill>/SKILL.md — no phantom container entry."""
+    container = tmp_path / "gitnexus"
+    _mk_skill(container / "gitnexus-cli", "gitnexus-cli")
+    _mk_skill(container / "gitnexus-debugging", "gitnexus-debugging")
+
+    results = _gen._scan_tier(tmp_path, 1, None)
+
+    assert _names(results) == {"gitnexus-cli", "gitnexus-debugging"}
+    assert "gitnexus" not in _names(results)
+    # Paths point at the real skill dirs, not the container
+    paths = {r["path"] for r in results}
+    assert str(container / "gitnexus-cli") in paths
+
+
+def test_scan_tier_recurses_plugin_repo_layout(tmp_path):
+    """vendor/<plugin>/skills/<skill>/SKILL.md is indexed; support dirs skipped."""
+    plugin = tmp_path / "aws" / "aws-serverless"
+    _mk_skill(plugin / "skills" / "api-gateway", "api-gateway")
+    _mk_skill(plugin / "skills" / "aws-lambda", "aws-lambda")
+    # Support dirs inside the plugin repo must not become phantom entries
+    (plugin / "hooks").mkdir(parents=True)
+    (plugin / "hooks" / "hook.sh").write_text("#!/bin/sh\n")
+    (plugin / "scripts").mkdir()
+
+    results = _gen._scan_tier(tmp_path, 2, None)
+
+    assert _names(results) == {"api-gateway", "aws-lambda"}
+    for phantom in ("aws", "aws-serverless", "skills", "hooks", "scripts"):
+        assert phantom not in _names(results)
+
+
+def test_scan_tier_container_readme_does_not_shadow_nested_skills(tmp_path):
+    """A container with README.md but no SKILL.md still recurses."""
+    container = tmp_path / "toolkit"
+    _mk_skill(container / "inner-skill", "inner-skill")
+    (container / "README.md").write_text(
+        "---\nname: toolkit\ndescription: container readme\n---\n"
+    )
+
+    results = _gen._scan_tier(tmp_path, 2, None)
+
+    assert _names(results) == {"inner-skill"}
+
+
+def test_scan_tier_fallback_entry_has_empty_keywords_list(tmp_path):
+    """Top-level dir with no markdown at all: fallback entry, keywords == []."""
+    lonely = tmp_path / "lonely"
+    lonely.mkdir()
+    (lonely / "notes.txt").write_text("not a skill file")
+
+    results = _gen._scan_tier(tmp_path, 2, None)
+
+    assert len(results) == 1
+    entry = results[0]
+    assert entry["name"] == "lonely"
+    assert entry["description"] == ""
+    assert entry["keywords"] == []
+
+
+def test_scan_tier_every_entry_has_keywords_key(tmp_path):
+    """Catalog shape: the keywords key is always present, whatever the source."""
+    _mk_skill(tmp_path / "real-skill", "real-skill")
+    container = tmp_path / "container"
+    _mk_skill(container / "nested-skill", "nested-skill")
+    (tmp_path / "bare").mkdir()
+
+    results = _gen._scan_tier(tmp_path, 2, None)
+
+    assert _names(results) == {"real-skill", "nested-skill", "bare"}
+    for entry in results:
+        assert "keywords" in entry, f"missing keywords key: {entry['name']}"
+        assert isinstance(entry["keywords"], list)
+
+
+def test_scan_tier_skips_hidden_dirs(tmp_path):
+    """Hidden dirs (.claude-plugin, .git) are skipped at every level."""
+    _mk_skill(tmp_path / ".hidden" / "sneaky", "sneaky")
+    container = tmp_path / "vendor"
+    _mk_skill(container / "plug" / "skills" / "real", "real")
+    hidden_in_container = container / ".claude-plugin"
+    hidden_in_container.mkdir(parents=True)
+    (hidden_in_container / "plugin.json").write_text("{}")
+
+    results = _gen._scan_tier(tmp_path, 2, None)
+
+    assert _names(results) == {"real"}
+
+
+def test_scan_tier_relative_paths_under_repo_root(tmp_path):
+    """Nested skill paths are repo-relative when under repo_root."""
+    repo = tmp_path / "repo"
+    tier = repo / ".claude" / "skills"
+    _mk_skill(tier / "gitnexus" / "gitnexus-cli", "gitnexus-cli")
+
+    results = _gen._scan_tier(tier, 1, repo)
+
+    assert len(results) == 1
+    assert results[0]["path"] == str(
+        Path(".claude") / "skills" / "gitnexus" / "gitnexus-cli"
+    )


### PR DESCRIPTION
## Summary

Batch 1 PR-2 of the 2026-07-03 context-layer audit remediation.

- **Catalog generator**: recurses into container directories (skill packs like `gitnexus/`, plugin repos with `*/skills/*/SKILL.md`) and indexes the real skills inside instead of emitting a phantom entry for the folder; the no-SKILL.md fallback entry now always carries `"keywords": []`. Catalog writes are atomic (tmp + rename) so the hook can never read a half-written file.
- **Injection hook**: threshold now fires on raw match points (a single clear name/keyword hit is enough) instead of a prompt-length-diluted ratio that near-never fired; catalog nudges no longer compete with superpowers process nudges for the same 2 slots (separate budgets); tier-2 nudge text is a real instruction (`Read <path>/SKILL.md`); stale-catalog regeneration runs detached out-of-band so the 500ms hook budget can't kill nudge output.

Post-merge on this install: regenerate `~/.genesis/skill_catalog.json` and verify nested entries + a live nudge.

## Testing
- `tests/test_hooks/test_skill_injection.py` extended (threshold, slot separation, tier-2 text) + NEW `tests/test_scripts/test_generate_skill_catalog.py` (recursion, phantom elimination, keywords shape). RED-proven against unfixed sources; 27 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)