### PR TITLE
fix(infra): bootstrap enables rendered systemd timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -407,6 +407,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   (dry-run by default) re-parses the previously mangled entries into proper knowledge units and removes
   the junk ones.
 
+- **Fresh installs and repairs now get scheduled housekeeping running without a manual step.** The
+  bootstrap script rendered Genesis's systemd timer units (watchdog health check, daily disk hygiene)
+  but never enabled them, so on a new machine — or after a repair re-render — the timers sat installed
+  yet dead until something else switched them on. Bootstrap now enables and starts the housekeeping
+  timers idempotently, right after the render pass; environments without systemd are unaffected. The
+  backup timer is deliberately left for you to enable after configuring backups (passphrase + verify
+  run), so it is not auto-started here.
+
 - **The dashboard's per-session memory row is clearer: "Claude Code Sessions", green when healthy.** The
   cryptic "CC" row that listed sessions as gray "cc-1 …" chips is now labeled **Claude Code Sessions**,
   renders each healthy session in green (amber ≥ 4 GB, red ≥ 6 GB), and shows a hover tooltip explaining

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -654,6 +654,25 @@ if [[ -d "$SYSTEMD_TEMPLATE_DIR" ]]; then
         systemctl --user daemon-reload 2>/dev/null || true
         echo "  systemd daemon reloaded"
     fi
+
+    # Enable + start every rendered timer (idempotent), EXCEPT timers that are a
+    # deliberate setup step. Without this a fresh install/repair leaves the
+    # housekeeping timers (watchdog, disk-hygiene) rendered but dead. The backup
+    # timer is intentionally skipped: it needs a passphrase + a verify run before
+    # it should fire (see the "Backups are NOT auto-enabled" note below and
+    # SETUP.md "Backups") — auto-enabling a 6h schedule here gives a false sense
+    # of safety while data is still local-only.
+    for template in "$SYSTEMD_TEMPLATE_DIR"/*.timer.template; do
+        [[ -f "$template" ]] || continue
+        timer_name=$(basename "$template" .template)
+        case "$timer_name" in
+            genesis-backup.timer) continue ;;  # deliberate setup step — see note below
+        esac
+        if [ -f "$SYSTEMD_USER_DIR/$timer_name" ]; then
+            systemctl --user enable --now "$timer_name" 2>/dev/null && \
+                echo "  + $timer_name enabled + started" || true
+        fi
+    done
 else
     echo "  Template directory $SYSTEMD_TEMPLATE_DIR not found — skipping"
 fi


### PR DESCRIPTION
## Summary

Batch 1 PR-6 of the 2026-07-03 context-layer audit remediation.

`scripts/bootstrap.sh` rendered systemd user unit templates but never enabled the rendered `*.timer` units, so a fresh install/repair left shipped timers (watchdog, disk-hygiene) dead until something else enabled them. After the render loop + daemon-reload, each rendered `*.timer` is now enabled idempotently (`systemctl --user enable --now`), mirroring the exact guard idiom install.sh already uses. The loop deliberately runs on every bootstrap (repair semantic: a timer can be rendered-but-disabled from a prior broken run). `*.service` units are intentionally untouched (started elsewhere by design).

## Testing
- `bash -n` clean; shellcheck delta is exactly one info-level SC2015 inherent to the mandated install.sh idiom. On this install, bootstrap re-run is a no-op (both timers already enabled) — verification by inspection + review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)